### PR TITLE
Sctimer pwm capture

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -13,12 +13,17 @@
 #include <fsl_clock.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
-
+#ifdef CONFIG_PWM_CAPTURE
+#include <zephyr/irq.h>
+#include <fsl_inputmux.h>
+#endif
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(pwm_mcux_sctimer, CONFIG_PWM_LOG_LEVEL);
 
 #define CHANNEL_COUNT FSL_FEATURE_SCT_NUMBER_OF_OUTPUTS
+
+#define CAPTURE_CHANNEL_COUNT FSL_FEATURE_SCT_NUMBER_OF_MATCH_CAPTURE
 
 /* Constant identifying that no event number has been set */
 #define EVENT_NOT_SET FSL_FEATURE_SCT_NUMBER_OF_EVENTS
@@ -29,13 +34,44 @@ struct pwm_mcux_sctimer_config {
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+#ifdef CONFIG_PWM_CAPTURE
+	const uint32_t *input_channels;
+	const uint32_t *inputmux_connections;
+	uint8_t input_channel_count;
+	void (*irq_config_func)(const struct device *dev);
+#endif /* CONFIG_PWM_CAPTURE */
 };
+
+#ifdef CONFIG_PWM_CAPTURE
+struct pwm_mcux_sctimer_capture_data {
+	pwm_capture_callback_handler_t callback;
+	void *user_data;
+	uint32_t overflow_count;
+	uint32_t first_capture_event;
+	uint32_t second_capture_event;
+	uint32_t first_limit_count;
+	uint32_t second_limit_count;
+	uint32_t first_capture_value;
+	uint32_t second_capture_value;
+
+	bool continuous : 1;
+	bool overflowed : 1;
+	bool pulse_capture : 1;
+	bool capture_ready : 1;
+	bool channel_used: 1;
+	bool first_edge_captured : 1;
+};
+#endif /* CONFIG_PWM_CAPTURE */
 
 struct pwm_mcux_sctimer_data {
 	uint32_t event_number[CHANNEL_COUNT];
 	sctimer_pwm_signal_param_t channel[CHANNEL_COUNT];
 	uint32_t match_period;
 	uint32_t configured_chan;
+#ifdef CONFIG_PWM_CAPTURE
+	uint32_t match_event;
+	struct pwm_mcux_sctimer_capture_data capture_data[CAPTURE_CHANNEL_COUNT];
+#endif /* CONFIG_PWM_CAPTURE */
 };
 
 /* Helper to setup channel that has not previously been configured for PWM */
@@ -56,7 +92,6 @@ static int mcux_sctimer_new_channel(const struct device *dev,
 	}
 
 	pwm_freq = (clock_freq / config->prescale) / period_cycles;
-
 	if (pwm_freq == 0) {
 		LOG_ERR("Could not set up pwm_freq=%d", pwm_freq);
 		return -EINVAL;
@@ -72,6 +107,12 @@ static int mcux_sctimer_new_channel(const struct device *dev,
 		LOG_ERR("Could not set up pwm");
 		return -ENOTSUP;
 	}
+#ifdef CONFIG_PWM_CAPTURE
+	/* All channel share same period, so we can use one of pwm period
+	 * as capture period.
+	 */
+	data->match_event = data->event_number[channel];
+#endif /* CONFIG_PWM_CAPTURE */
 
 	SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
 	data->configured_chan++;
@@ -244,6 +285,379 @@ static int mcux_sctimer_pwm_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
+
+#ifdef CONFIG_PWM_CAPTURE
+static void mcux_sctimer_get_edge_events(bool inverted, bool pulse_capture,
+				sctimer_event_t *first_edge, sctimer_event_t *second_edge)
+{
+	if (inverted) {
+		*first_edge = kSCTIMER_InputFallEvent;
+		*second_edge = pulse_capture ? kSCTIMER_InputRiseEvent : kSCTIMER_InputFallEvent;
+	} else {
+		*first_edge = kSCTIMER_InputRiseEvent;
+		*second_edge = pulse_capture ? kSCTIMER_InputFallEvent : kSCTIMER_InputRiseEvent;
+	}
+}
+
+static int mcux_sctimer_setup_capture_events(const struct device *dev, uint32_t channel,
+				sctimer_event_t first_edge_event,
+				sctimer_event_t second_edge_event,
+				uint32_t *first_capture_event,
+				uint32_t *second_capture_event)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	uint32_t capture_reg;
+
+	/* Create first edge capture event */
+	if (SCTIMER_CreateAndScheduleEvent(config->base, first_edge_event,
+			0, channel, kSCTIMER_Counter_U,
+			first_capture_event) != kStatus_Success) {
+		LOG_ERR("Failed to create first edge event");
+		return -ENOTSUP;
+	}
+
+	/* Setup capture action for first edge */
+	if (SCTIMER_SetupCaptureAction(config->base, kSCTIMER_Counter_U,
+			&capture_reg, *first_capture_event) != kStatus_Success) {
+		LOG_ERR("Failed to setup first edge capture");
+		return -ENOTSUP;
+	}
+
+	/* Create second edge capture event */
+	if (SCTIMER_CreateAndScheduleEvent(config->base, second_edge_event,
+			0, channel, kSCTIMER_Counter_U,
+			second_capture_event) != kStatus_Success) {
+		LOG_ERR("Failed to create second edge event");
+		return -ENOTSUP;
+	}
+
+	/* Setup capture action for second edge */
+	if (SCTIMER_SetupCaptureAction(config->base, kSCTIMER_Counter_U,
+			&capture_reg, *second_capture_event) != kStatus_Success) {
+		LOG_ERR("Failed to setup second edge capture");
+		return -ENOTSUP;
+	}
+
+	if (data->match_event == EVENT_NOT_SET) {
+		/* Create limit event for overflow detection */
+		if (SCTIMER_CreateAndScheduleEvent(config->base, kSCTIMER_MatchEventOnly,
+				0xFFFF, 0, kSCTIMER_Counter_U,
+				&data->match_event) != kStatus_Success) {
+			LOG_ERR("Failed to create limit event");
+			return -ENOTSUP;
+		}
+		/* Setup counter limit action */
+		SCTIMER_SetupCounterLimitAction(config->base, kSCTIMER_Counter_U,
+			data->match_event);
+	}
+
+	return 0;
+}
+
+static int mcux_sctimer_configure_capture(const struct device *dev,
+					uint32_t channel, pwm_flags_t flags,
+					pwm_capture_callback_handler_t cb,
+					void *user_data)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	bool inverted = (flags & PWM_POLARITY_INVERTED) != 0;
+	bool pulse_capture = (flags & PWM_CAPTURE_TYPE_PERIOD) == 0;
+	uint32_t first_capture_event = EVENT_NOT_SET;
+	uint32_t second_capture_event = EVENT_NOT_SET;
+	sctimer_event_t first_edge_event;
+	sctimer_event_t second_edge_event;
+	int ret;
+
+	if (channel >= CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("invalid channel %d", channel);
+		return -EINVAL;
+	}
+
+	if (!(flags & PWM_CAPTURE_TYPE_MASK)) {
+		LOG_ERR("No capture type specified");
+		return -EINVAL;
+	}
+
+	if ((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_BOTH) {
+		LOG_ERR("Cannot capture both period and pulse width");
+		return -ENOTSUP;
+	}
+
+	if (data->capture_data[channel].channel_used) {
+		LOG_ERR("pwm capture in progress");
+		return -EBUSY;
+	}
+
+	mcux_sctimer_get_edge_events(inverted, pulse_capture, &first_edge_event,
+		&second_edge_event);
+
+	data->capture_data[channel].callback = cb;
+	data->capture_data[channel].user_data = user_data;
+	data->capture_data[channel].continuous =
+		(flags & PWM_CAPTURE_MODE_MASK) == PWM_CAPTURE_MODE_CONTINUOUS;
+	data->capture_data[channel].pulse_capture = pulse_capture;
+	data->capture_data[channel].first_edge_captured = false;
+
+	/* If capture is already configured, return success */
+	if (data->capture_data[channel].first_capture_event == EVENT_NOT_SET &&
+		data->capture_data[channel].second_capture_event == EVENT_NOT_SET) {
+		ret = mcux_sctimer_setup_capture_events(dev, channel, first_edge_event,
+				second_edge_event, &first_capture_event, &second_capture_event);
+		if (ret != 0) {
+			return ret;
+		}
+		/* Store capture configuration */
+		data->capture_data[channel].first_capture_event = first_capture_event;
+		data->capture_data[channel].second_capture_event = second_capture_event;
+	} else {
+		/* Capture already configured, update capture events */
+		config->base->EV[data->capture_data[channel].first_capture_event].CTRL &=
+			~(SCT_EV_CTRL_IOCOND_MASK | SCT_EV_CTRL_IOSEL_MASK);
+		config->base->EV[data->capture_data[channel].first_capture_event].CTRL |=
+			first_edge_event | SCT_EV_CTRL_IOSEL(channel);
+
+		config->base->EV[data->capture_data[channel].second_capture_event].CTRL &=
+			~(SCT_EV_CTRL_IOCOND_MASK | SCT_EV_CTRL_IOSEL_MASK);
+		config->base->EV[data->capture_data[channel].second_capture_event].CTRL |=
+			second_edge_event | SCT_EV_CTRL_IOSEL(channel);
+	}
+
+	return 0;
+}
+
+static int mcux_sctimer_enable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	uint32_t status_flags;
+
+	if (channel >= CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("invalid channel %d", channel);
+		return -EINVAL;
+	}
+
+	if (!data->capture_data[channel].callback) {
+		LOG_ERR("PWM capture not configured");
+		return -EINVAL;
+	}
+
+	if (data->capture_data[channel].channel_used) {
+		LOG_ERR("pwm capture channel in progress");
+		return -EBUSY;
+	}
+
+	/* Reset capture state */
+	data->capture_data[channel].channel_used = true;
+
+	/* The flag is set when match events happen even if interrupt is disabled.
+	 * Clear status before enabling interrupt.
+	 */
+	status_flags = SCTIMER_GetStatusFlags(config->base);
+	SCTIMER_ClearStatusFlags(config->base, status_flags);
+
+	/* Enable interrupts for capture events and limit */
+	SCTIMER_EnableInterrupts(config->base,
+		(1 << data->capture_data[channel].first_capture_event) |
+		(1 << data->capture_data[channel].second_capture_event) |
+		(1 << data->match_event));
+
+	return 0;
+}
+
+static int mcux_sctimer_disable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+
+	if (channel >= CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("invalid channel %d", channel);
+		return -EINVAL;
+	}
+
+	/* Disable interrupts */
+	if (data->capture_data[channel].channel_used) {
+		data->capture_data[channel].channel_used = false;
+		SCTIMER_DisableInterrupts(config->base,
+			(1 << data->capture_data[channel].first_capture_event) |
+			(1 << data->capture_data[channel].second_capture_event) |
+			(1 << data->match_event));
+	}
+
+	/* Stop timer */
+	SCTIMER_StopTimer(config->base, kSCTIMER_Counter_U);
+
+	return 0;
+}
+
+static int mcux_sctimer_calc_ticks(uint32_t period, uint32_t first_limit, uint32_t second_limit,
+				   uint32_t first_capture, uint32_t second_capture,
+				   uint32_t *result)
+{
+	uint32_t ticks;
+	uint32_t overflow_ticks;
+
+	/* Calculate overflow ticks */
+	if (u32_mul_overflow(second_limit - first_limit, period, &overflow_ticks)) {
+		return -ERANGE;
+	}
+
+	/* Add capture difference */
+	if (second_capture >= first_capture) {
+		if (u32_add_overflow(overflow_ticks, second_capture - first_capture, &ticks)) {
+			return -ERANGE;
+		}
+	} else {
+		/* Handle counter wrap */
+		if (u32_add_overflow(overflow_ticks, period - first_capture + second_capture,
+				     &ticks)) {
+			return -ERANGE;
+		}
+	}
+
+	*result = ticks;
+
+	return 0;
+}
+
+static void mcux_sctimer_capture_first_edge(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+
+	data->capture_data[channel].first_capture_value =
+		SCTIMER_GetCaptureValue(config->base, kSCTIMER_Counter_U,
+			data->capture_data[channel].first_capture_event);
+	data->capture_data[channel].first_limit_count =
+		data->capture_data[channel].overflow_count;
+	data->capture_data[channel].first_edge_captured = true;
+}
+
+static void mcux_sctimer_capture_second_edge(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+
+	data->capture_data[channel].second_capture_value =
+		SCTIMER_GetCaptureValue(config->base, kSCTIMER_Counter_U,
+			data->capture_data[channel].second_capture_event);
+	data->capture_data[channel].second_limit_count =
+		data->capture_data[channel].overflow_count;
+	data->capture_data[channel].capture_ready = true;
+	data->capture_data[channel].first_edge_captured = false;
+}
+
+static void prepare_next_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+
+	data->capture_data[channel].capture_ready = false;
+	data->capture_data[channel].overflowed = false;
+	data->capture_data[channel].overflow_count = 0;
+
+	/* Clear first capture setting */
+	data->capture_data[channel].first_limit_count = 0;
+	data->capture_data[channel].first_capture_value = 0;
+
+	if (data->capture_data[channel].continuous) {
+		if (!data->capture_data[channel].pulse_capture) {
+			/* For period capture, current first edge is start of next period */
+			data->capture_data[channel].first_capture_value =
+				data->capture_data[channel].second_capture_value;
+			data->capture_data[channel].first_limit_count =
+				data->capture_data[channel].second_limit_count;
+			data->capture_data[channel].first_edge_captured = true;
+		} else {
+			/* No actions required. */
+		}
+	} else {
+		/* Single capture mode: Disable interrupts */
+		SCTIMER_DisableInterrupts(config->base,
+			(1 << data->capture_data[channel].first_capture_event) |
+			(1 << data->capture_data[channel].second_capture_event) |
+			(1 << data->match_event));
+	}
+
+	/* Clear second capture setting */
+	data->capture_data[channel].second_limit_count = 0;
+	data->capture_data[channel].second_capture_value = 0;
+}
+
+static void mcux_sctimer_process_channel_events(const struct device *dev, uint32_t channel,
+				uint32_t status_flags)
+{
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	uint32_t ticks = 0;
+	int err;
+
+	/* Handle limit/overflow interrupt */
+	if (status_flags & (1 << data->match_event)) {
+		data->capture_data[channel].overflowed |= u32_add_overflow(1,
+			data->capture_data[channel].overflow_count,
+			&data->capture_data[channel].overflow_count);
+	}
+
+	/* Handle first edge capture */
+	if (status_flags & (1 << data->capture_data[channel].first_capture_event)) {
+		if (!data->capture_data[channel].first_edge_captured) {
+			mcux_sctimer_capture_first_edge(dev, channel);
+			return;
+		}
+	}
+
+	/* Handle second edge capture */
+	if (status_flags & (1 << data->capture_data[channel].second_capture_event)) {
+		if (data->capture_data[channel].first_edge_captured) {
+			mcux_sctimer_capture_second_edge(dev, channel);
+		}
+	}
+
+	/* Process capture if ready */
+	if (data->capture_data[channel].capture_ready) {
+
+		err = mcux_sctimer_calc_ticks(data->match_period,
+				data->capture_data[channel].first_limit_count,
+				data->capture_data[channel].second_limit_count,
+				data->capture_data[channel].first_capture_value,
+				data->capture_data[channel].second_capture_value,
+				&ticks);
+
+		if (!data->capture_data[channel].callback) {
+			return;
+		}
+
+		if (data->capture_data[channel].pulse_capture) {
+			data->capture_data[channel].callback(dev, channel,
+				0, ticks, err, data->capture_data[channel].user_data);
+		} else {
+			data->capture_data[channel].callback(dev, channel,
+				ticks, 0, err, data->capture_data[channel].user_data);
+		}
+
+		prepare_next_capture(dev, channel);
+	}
+}
+
+static void mcux_sctimer_isr(const struct device *dev)
+{
+	const struct pwm_mcux_sctimer_config *config = dev->config;
+	struct pwm_mcux_sctimer_data *data = dev->data;
+	uint32_t status_flags;
+
+	status_flags = SCTIMER_GetStatusFlags(config->base);
+	SCTIMER_ClearStatusFlags(config->base, status_flags);
+
+	for (uint32_t channel = 0; channel < CAPTURE_CHANNEL_COUNT; channel++) {
+		if (!data->capture_data[channel].channel_used) {
+			continue;
+		}
+		mcux_sctimer_process_channel_events(dev, channel, status_flags);
+	}
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
 static int mcux_sctimer_pwm_init(const struct device *dev)
 {
 	const struct pwm_mcux_sctimer_config *config = dev->config;
@@ -277,26 +691,74 @@ static int mcux_sctimer_pwm_init(const struct device *dev)
 	data->match_period = 0;
 	data->configured_chan = 0;
 
+#ifdef CONFIG_PWM_CAPTURE
+	/* set inputmux connections */
+	INPUTMUX_Init(INPUTMUX);
+	for (i = 0; i < config->input_channel_count; i++) {
+		INPUTMUX_AttachSignal(INPUTMUX, config->input_channels[i],
+			config->inputmux_connections[i]);
+	}
+	/* Initialize capture data */
+	data->match_event = EVENT_NOT_SET;
+	for (i = 0; i < CAPTURE_CHANNEL_COUNT; i++) {
+		/* Reset capture state */
+		memset(&data->capture_data[i], 0, sizeof(struct pwm_mcux_sctimer_capture_data));
+		data->capture_data[i].first_capture_event = EVENT_NOT_SET;
+		data->capture_data[i].second_capture_event = EVENT_NOT_SET;
+	}
+	/* Configure IRQ */
+	config->irq_config_func(dev);
+#endif /* CONFIG_PWM_CAPTURE */
+
 	return 0;
 }
 
 static DEVICE_API(pwm, pwm_mcux_sctimer_driver_api) = {
 	.set_cycles = mcux_sctimer_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_sctimer_pwm_get_cycles_per_sec,
+#ifdef CONFIG_PWM_CAPTURE
+	.configure_capture = mcux_sctimer_configure_capture,
+	.enable_capture = mcux_sctimer_enable_capture,
+	.disable_capture = mcux_sctimer_disable_capture,
+#endif
 };
+
+#define SCTIMER_DECLARE_CFG(n, CAPTURE_INIT) \
+	static const struct pwm_mcux_sctimer_config pwm_mcux_sctimer_config_##n = { \
+		.base = (SCT_Type *)DT_INST_REG_ADDR(n),				\
+		.prescale = DT_INST_PROP(n, prescaler),					\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		CAPTURE_INIT								\
+	}
+
+#ifdef CONFIG_PWM_CAPTURE
+#define SCTIMER_CONFIG_FUNC(n) \
+static void mcux_sctimer_config_func_##n(const struct device *dev) \
+{ \
+	IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), \
+		    mcux_sctimer_isr, DEVICE_DT_INST_GET(n), 0); \
+	irq_enable(DT_INST_IRQN(n)); \
+}
+#define SCTIMER_CFG_CAPTURE_INIT(n) \
+	.input_channels = (const uint32_t[]) DT_INST_PROP(n, input_channels), \
+	.inputmux_connections = (const uint32_t[]) DT_INST_PROP(n, inputmux_connections), \
+	.input_channel_count = DT_INST_PROP_LEN(n, input_channels), \
+	.irq_config_func = mcux_sctimer_config_func_##n
+#define SCTIMER_INIT_CFG(n)	SCTIMER_DECLARE_CFG(n, SCTIMER_CFG_CAPTURE_INIT(n))
+#else /* !CONFIG_PWM_CAPTURE */
+#define SCTIMER_CONFIG_FUNC(n)
+#define SCTIMER_CFG_CAPTURE_INIT
+#define SCTIMER_INIT_CFG(n)	SCTIMER_DECLARE_CFG(n, SCTIMER_CFG_CAPTURE_INIT)
+#endif /* !CONFIG_PWM_CAPTURE */
 
 #define PWM_MCUX_SCTIMER_DEVICE_INIT_MCUX(n)						\
 	PINCTRL_DT_INST_DEFINE(n);							\
 	static struct pwm_mcux_sctimer_data pwm_mcux_sctimer_data_##n;			\
 											\
-	static const struct pwm_mcux_sctimer_config pwm_mcux_sctimer_config_##n = {	\
-		.base = (SCT_Type *)DT_INST_REG_ADDR(n),				\
-		.prescale = DT_INST_PROP(n, prescaler),					\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
-	};										\
-											\
+	SCTIMER_CONFIG_FUNC(n)								\
+	SCTIMER_INIT_CFG(n);	\
 	DEVICE_DT_INST_DEFINE(n,							\
 			      mcux_sctimer_pwm_init,					\
 			      NULL,							\

--- a/dts/bindings/pwm/nxp,sctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,sctimer-pwm.yaml
@@ -22,6 +22,23 @@ properties:
       - 64
       - 128
 
+  input-channels:
+    type: array
+    description: |
+      Array of SCTimer input channel numbers that are configured for capture.
+      Each element represents an input channel (0-7 for most NXP SoCs).
+      Example: <0 1 2> configures IN0, IN1, and IN2.
+
+  inputmux-connections:
+    type: array
+    description: |
+      Array of INPUTMUX connection types for each input channel.
+      Each element corresponds to the input channel at the same index in input-channels.
+      Values map to device-specific inputmux_connection_t enum values from
+      fsl_inputmux_connections.h, take LPC55S36 as example:
+      - 0: kINPUTMUX_SctGpioInAToSct0 (GPIO to SCT input A)
+      - 1: kINPUTMUX_SctGpioInBToSct0 (GPIO to SCT input B)
+
   "#pwm-cells":
     const: 3
 

--- a/tests/drivers/pwm/pwm_loopback/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/lpcxpresso55s36.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-test = &sc_timer;
+	};
+};
+
+&pinctrl {
+	pinmux_pwm0: pinmux_pwm0 {
+		group0 {
+			pinmux = <SCT0_OUT0_PIO1_4>;
+			slew-rate = "standard";
+		};
+
+		group1 {
+			pinmux = <SCT0_IN1_PIO0_13>;
+			slew-rate = "standard";
+		};
+	};
+};
+
+/* To test this sample, connect
+ * J10-5 ---> J10-3
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&sc_timer 0 0 PWM_POLARITY_NORMAL>, /* PIO1_4 J10 pin 5 */
+		       <&sc_timer 1 0 PWM_POLARITY_NORMAL>; /* PIO0_13 J10 pin 3 */
+	};
+};
+
+&sc_timer {
+	status = "okay";
+	pinctrl-0 = <&pinmux_pwm0>;
+	pinctrl-names = "default";
+	prescaler = <1>;
+	input-channels = <1>;
+	inputmux-connections = <0>;
+};


### PR DESCRIPTION
1.Add mcux_sctimer_pwm_update_polarity() function to properly reconfigure PWM output polarity when duty cycle is updated

2.Add input-channels and inputmux-connections properties to the
    nxp,sctimer-pwm device tree binding to support SCTimer input
    capture configuration.

3.Implement PWM input capture functionality for the NXP SCTimer
    driver with support for pulse width and period measurement
    in single-shot and continuous modes

4.Enable test on lpcxpresso55s36