### PR TITLE
drivers: sdhc: stm32: skip semaphore wait on HAL error

### DIFF
--- a/drivers/sdhc/sdhc_stm32.c
+++ b/drivers/sdhc/sdhc_stm32.c
@@ -334,6 +334,12 @@ static int sdhc_stm32_rw_extended(const struct device *dev, struct sdhc_command 
 	}
 
 	if (!IS_ENABLED(CONFIG_SDHC_STM32_POLLING_SUPPORT)) {
+		/* Only wait on semaphore if HAL function succeeded */
+		if (res != HAL_OK) {
+			k_free(dev_data->sdio_dma_buf);
+			return -EIO;
+		}
+
 		/* Wait for whole transfer to complete */
 		if (k_sem_take(&dev_data->device_sync_sem, K_MSEC(CONFIG_SD_CMD_TIMEOUT)) != 0) {
 			k_free(dev_data->sdio_dma_buf);


### PR DESCRIPTION
When HAL_SDIO_WriteExtended_DMA or HAL_SDIO_ReadExtended_DMA returns an error, interrupts are not enabled so the semaphore would never be given, and it will always timeout.

Some drivers expect certain functions to fail during normal operation. For example, WHD calls whd_kso_enable during sleep/wakeup cycles which can fail. This would waste 200ms (CONFIG_SD_CMD_TIMEOUT default) on every such failure.

For reference, the logic of `HAL_SDIO_WriteExtended_DMA` and `HAL_SDIO_ReadExtended_DMA` looks like this:

  ```c
  HAL_StatusTypeDef HAL_SDIO_WriteExtended_DMA(...) {
      if (params == NULL)
          return HAL_ERROR;              // No ISR enabled

      if (state != READY)
          return HAL_BUSY;               // No ISR enabled

      // ... setup DMA, configure DPSM ...

      errorstate = SDMMC_SDIO_CmdReadWriteExtended(...);
      if (errorstate != HAL_SDIO_ERROR_NONE) {
          hsdio->ErrorCode |= errorstate;
          if (errorstate != (ADDR_OUT_OF_RANGE | ILLEGAL_CMD | COM_CRC_FAILED | GENERAL_UNKNOWN_ERR)) {
              // cleanup
              return HAL_ERROR;          // No ISR enabled
          }
      }

      // Enable interrupts - only reached if no early return
      __HAL_SDIO_ENABLE_IT(hsdio, (DCRCFAIL | DTIMEOUT | TXUNDERR | DATAEND));

      return HAL_OK;
  }
```