### PR TITLE
boards: shields: nxp_m2_wifi_bt remove oob-gpios

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_1xk_wifi_bt.overlay
@@ -32,7 +32,6 @@
 &m2_wifi_sdio {
 	nxp_wifi {
 		compatible = "nxp,wifi";
-		oob-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 		wakeup-gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};


### PR DESCRIPTION
Remove oob-gpios property from nxp_m2_1xk_wifi_bt.overlay. There is no binding for this property at bindings/wifi/nxp,wifi.yaml. Therefore, builds using this shield will fail.