### PR TITLE
drivers: counter: stm32: fix rtc subsecond register read

### DIFF
--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -413,25 +413,29 @@ tick_t rtc_stm32_read(const struct device *dev)
 	uint32_t rtc_date, rtc_time;
 	tick_t ticks;
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
-	uint32_t rtc_subseconds;
+	uint32_t rtc_subsecond;
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 	ARG_UNUSED(dev);
 
-	/* Read time and date registers. Make sure value of the previous register
-	 * hasn't been changed while reading the next one.
-	 */
 	do {
+		/* read date, time and subseconds and relaunch if a day increment occurred
+		 * while doing so as it will result in an erroneous result otherwise
+		 */
 		rtc_date = LL_RTC_DATE_Get(RTC);
-
-#ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
 		do {
+			/* read time and subseconds and relaunch if a second increment occurred
+			 * while doing so as it will result in an erroneous result otherwise
+			 */
 			rtc_time = LL_RTC_TIME_Get(RTC);
-			rtc_subseconds = LL_RTC_TIME_GetSubSecond(RTC);
+#if CONFIG_COUNTER_RTC_STM32_SUBSECONDS
+			do {
+				/* read subseconds and relaunch if a second increment occurred
+				 * while doing so as it will result in an erroneous result otherwise
+				 */
+				rtc_subsecond = LL_RTC_TIME_GetSubSecond(RTC);
+			} while (rtc_subsecond != LL_RTC_TIME_GetSubSecond(RTC));
+#endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 		} while (rtc_time != LL_RTC_TIME_Get(RTC));
-#else /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
-		rtc_time = LL_RTC_TIME_Get(RTC);
-#endif
-
 	} while (rtc_date != LL_RTC_DATE_Get(RTC));
 
 	/* Convert calendar datetime to UNIX timestamp */
@@ -460,7 +464,7 @@ tick_t rtc_stm32_read(const struct device *dev)
 	 * down starting from the sync prescaler value. Add already counted
 	 * ticks.
 	 */
-	ticks += RTC_SYNCPRE - rtc_subseconds;
+	ticks += RTC_SYNCPRE - rtc_subsecond;
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 
 	return ticks;

--- a/drivers/rtc/rtc_stm32.c
+++ b/drivers/rtc/rtc_stm32.c
@@ -649,9 +649,14 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 			/* read time and subseconds and relaunch if a second increment occurred
 			 * while doing so as it will result in an erroneous result otherwise
 			 */
-			rtc_time      = LL_RTC_TIME_Get(RTC);
+			rtc_time = LL_RTC_TIME_Get(RTC);
 #if HW_SUBSECOND_SUPPORT
-			rtc_subsecond = LL_RTC_TIME_GetSubSecond(RTC);
+			do {
+				/* read subseconds and relaunch if a second increment occurred
+				 * while doing so as it will result in an erroneous result otherwise
+				 */
+				rtc_subsecond = LL_RTC_TIME_GetSubSecond(RTC);
+			} while (rtc_subsecond != LL_RTC_TIME_GetSubSecond(RTC));
 #endif /* HW_SUBSECOND_SUPPORT */
 		} while (rtc_time != LL_RTC_TIME_Get(RTC));
 	} while (rtc_date != LL_RTC_DATE_Get(RTC));


### PR DESCRIPTION
The return value of `rtc_stm32_read` and `rtc_stm32_get_time` may be inconsistent due to an erroneous read of the RTC subsecond register.

According to the reference manual:

> When the BYPSHAD control bit is set in the RTC_CR register [...] the value of one of the registers may be incorrect if an RTCCLK edge occurs during the read operation.

The subsecond register can be affected by this and must be read until two reads are identical.

This can be exposed by catching values in the past:

```
while (true) {
    volatile tick_t a = rtc_stm32_read(dev);
    volatile tick_t b = rtc_stm32_read(dev);
    if (b < a) {
        // erroneous read here
    }
}
```

I have changed both places where the subseconds register is read.