### PR TITLE
soc: intel_adsp/ace40: disable spin validation on simulator

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace40
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace40
@@ -35,4 +35,11 @@ config XTENSA_MMU_NUM_L2_TABLES
 config XTENSA_MMU_USE_DEFAULT_MAPPINGS
 	default n
 
+# xt-clang seems to generate some memory access patterns which
+# result in the simulator accessing incorrect memory or
+# messing with cached TLB entries when spinlock validation
+# is enabled. So disable this to avoid this issue.
+config SPIN_VALIDATE
+	default n if INTEL_ADSP_SIM
+
 endif


### PR DESCRIPTION
xt-clang seems to generate some memory access patterns which result in the simulator accessing incorrect memory and/or messing with cached TLB entries when spinlock validation is enabled. Not exactly sure what's going on here due to the core of the simulator is built on top of pre-built binaries provided by the toolchain without any sources so debugging would be nearly impossible. But at least we have an easy workaround by disabling spin lock validation.

Fixes #100885