### PR TITLE
MAINTAINERS.yml: add lucien-nxp(myself) as nxp platforms collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3591,6 +3591,7 @@ NXP Platforms (MCU):
     - mmahadevan108
   collaborators:
     - butok
+    - lucien-nxp
   files:
     - boards/nxp/mimxrt*/
     - boards/nxp/frdm*/


### PR DESCRIPTION
Over the past year, I was mainly responsible for enabling the RT700/RT1180/MCXE series of NXP on the Zephyr platform. I am quite familiar with the NXP platforms of the community, and I am also very willing to participate in the review work of PR related to NXP MCU platforms.

[Historical PR](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+is%3Aclosed+platform%3A+NXP+)
