### PR TITLE
toolchain: iar: fix some potential issues for the IAR build tool

### DIFF
--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -160,3 +160,10 @@ endforeach()
 foreach(F ${IAR_ASM_FLAGS})
   list(APPEND TOOLCHAIN_C_FLAGS $<$<COMPILE_LANGUAGE:ASM>:${F}>)
 endforeach()
+
+# --------------------------------------------------------------------
+# Disable GCC-specific runtime library detection for IAR
+# --------------------------------------------------------------------
+function(compiler_set_linker_properties)
+  message(STATUS "Skipping GCC-specific runtime lib detection for IAR toolchain")
+endfunction()

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -247,6 +247,17 @@
 #endif
 
 /**
+ * @def TOOLCHAIN_WARNING_ALWAYS_INLINE
+ * @brief Toolchain-specific warning for inline functions.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ALWAYS_INLINE
+#define TOOLCHAIN_WARNING_ALWAYS_INLINE
+#endif
+
+/**
  * @def TOOLCHAIN_WARNING_CAST_QUAL
  * @brief Toolchain-specific warning for pointer casts removing a type qualifier.
  *

--- a/include/zephyr/toolchain/iar.h
+++ b/include/zephyr/toolchain/iar.h
@@ -132,6 +132,18 @@
 
 #define TOOLCHAIN_WARNING_UNUSED_FUNCTION Pe001
 
+/**
+ * @def TOOLCHAIN_WARNING_ALWAYS_INLINE
+ * @brief Toolchain-specific warning for inline functions.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_ALWAYS_INLINE
+#define TOOLCHAIN_WARNING_ALWAYS_INLINE Go004
+#define IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+#endif
+
 #ifdef __ICCARM__
 #include "iar/iccarm.h"
 #endif

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -57,6 +57,9 @@
 #define TRAILING_ZEROS u32_count_trailing_zeros
 #endif /* CONFIG_64BIT */
 
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE void z_priq_simple_init(sys_dlist_t *pq)
 {
 	sys_dlist_init(pq);
@@ -345,5 +348,8 @@ static ALWAYS_INLINE struct k_thread *z_priq_mq_best(struct _priq_mq *pq)
 
 	return NULL;
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_PRIORITY_Q_H_ */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -45,6 +45,9 @@ BUILD_ASSERT(CONFIG_NUM_COOP_PRIORITIES >= CONFIG_NUM_METAIRQ_PRIORITIES,
 	     "CONFIG_NUM_METAIRQ_PRIORITIES as Meta IRQs are just a special class of cooperative "
 	     "threads.");
 
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE void *thread_runq(struct k_thread *thread)
 {
 #ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
@@ -129,6 +132,9 @@ static ALWAYS_INLINE void dequeue_thread(struct k_thread *thread)
 		runq_remove(thread);
 	}
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 /* Called out of z_swap() when CONFIG_SMP.  The current thread can
  * never live in the run queue until we are inexorably on the context
@@ -173,6 +179,9 @@ static void update_metairq_preempt(struct k_thread *thread)
 #endif /* CONFIG_NUM_METAIRQ_PRIORITIES > 0 */
 }
 
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE struct k_thread *next_up(void)
 {
 #ifdef CONFIG_SMP
@@ -264,6 +273,9 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 	return thread;
 #endif /* CONFIG_SMP */
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 void move_current_to_end_of_prio_q(void)
 {
@@ -272,6 +284,9 @@ void move_current_to_end_of_prio_q(void)
 	update_cache(1);
 }
 
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE void update_cache(int preempt_ok)
 {
 #ifndef CONFIG_SMP
@@ -299,6 +314,9 @@ static ALWAYS_INLINE void update_cache(int preempt_ok)
 	_current_cpu->swap_ok = preempt_ok;
 #endif /* CONFIG_SMP */
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 static struct _cpu *thread_active_elsewhere(struct k_thread *thread)
 {
@@ -401,6 +419,9 @@ static ALWAYS_INLINE void z_metairq_preempted_clear(struct k_thread *thread)
  * (aborting _current will not return, obviously), which may be after
  * a context switch.
  */
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 					bool terminate)
 {
@@ -455,6 +476,9 @@ static ALWAYS_INLINE void z_thread_halt(struct k_thread *thread, k_spinlock_key_
 	 * re-take the lock!
 	 */
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 
 void z_impl_k_thread_suspend(k_tid_t thread)
@@ -537,6 +561,9 @@ static void unready_thread(struct k_thread *thread)
 }
 
 /* _sched_spinlock must be held */
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
 	unready_thread(thread);
@@ -549,6 +576,9 @@ static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 		_priq_wait_add(&wait_q->waitq, thread);
 	}
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 static void add_thread_timeout(struct k_thread *thread, k_timeout_t timeout)
 {
@@ -670,6 +700,9 @@ void z_unpend_thread(struct k_thread *thread)
 /* Priority set utility that does no rescheduling, it just changes the
  * run queue state, returning true if a reschedule is needed later.
  */
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 bool z_thread_prio_set(struct k_thread *thread, int prio)
 {
 	bool need_sched = 0;
@@ -725,6 +758,9 @@ bool z_thread_prio_set(struct k_thread *thread, int prio)
 
 	return need_sched;
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 static inline bool resched(uint32_t key)
 {
@@ -1264,6 +1300,9 @@ extern void thread_abort_hook(struct k_thread *thread);
  * @param thread Identify the thread to halt
  * @param new_state New thread state (_THREAD_DEAD or _THREAD_SUSPENDED)
  */
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state)
 {
 	bool dummify = false;
@@ -1356,6 +1395,9 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 		clear_halting(thread);
 	}
 }
+#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
+TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
+#endif
 
 void z_thread_abort(struct k_thread *thread)
 {

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -149,7 +149,7 @@ const size_t _kernel_thread_info_offsets[] = {
 };
 
 extern const size_t __attribute__((alias("_kernel_thread_info_offsets")))
-		_kernel_openocd_offsets;
+		_kernel_openocd_offsets[ARRAY_SIZE(_kernel_thread_info_offsets)];
 
 __attribute__((used, section(".dbg_thread_info")))
 const size_t _kernel_thread_info_num_offsets = ARRAY_SIZE(_kernel_thread_info_offsets);

--- a/subsys/testsuite/include/zephyr/test_asm_inline_other.h
+++ b/subsys/testsuite/include/zephyr/test_asm_inline_other.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TEST_ASM_INLINE_OTHER_H_
+#define ZEPHYR_TEST_ASM_INLINE_OTHER_H_
+
+/* Stub for non-GNUC toolchains (e.g. IAR) used in benchmark tests.
+ * These macros are only required by timestamp.h during kernel tests.
+ * We provide a no-op implementation so that tests can build.
+ */
+
+static inline void timestamp_serialize(void) { }
+
+#endif /* ZEPHYR_TEST_ASM_INLINE_OTHER_H_ */

--- a/subsys/testsuite/include/zephyr/test_toolchain.h
+++ b/subsys/testsuite/include/zephyr/test_toolchain.h
@@ -13,6 +13,8 @@
 #include <zephyr/test_toolchain/llvm.h>
 #elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <zephyr/test_toolchain/gcc.h>
+#elif defined(__IAR_SYSTEMS_ICC__)
+#include <zephyr/test_toolchain/iar.h>
 #endif
 
 /**

--- a/subsys/testsuite/include/zephyr/test_toolchain/iar.h
+++ b/subsys/testsuite/include/zephyr/test_toolchain/iar.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_IAR_H_
+#define ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_IAR_H_
+
+#ifndef ZEPHYR_TESTSUITE_INCLUDE_TEST_TOOLCHAIN_H_
+#error "Please do not include test toolchain-specific headers directly, \
+use <zephyr/test_toolchain.h> instead"
+#endif
+
+#define TOOLCHAIN_WARNING_PRAGMAS            Pe161
+#define TOOLCHAIN_WARNING_INFINITE_RECURSION Pe2440
+
+#endif


### PR DESCRIPTION
This PR introduces fixes for potential issues that could cause build errors or warnings, or result in failed kernel test suites, when using the IAR build tool.