### PR TITLE
doc: releases: Fix heading underline in migration guide 4.4

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -260,7 +260,7 @@ USB
 .. zephyr-keep-sorted-stop
 
 Video
-===
+=====
 
 * CONFIG_VIDEO_OV7670 is now gone and replaced by CONFIG_VIDEO_OV767X.  This allows supporting both the OV7670 and 0V7675.
 


### PR DESCRIPTION
Fix the Video section heading underline to use the correct number of equal signs to match the heading length.