### PR TITLE
drivers: stepper: include enable and microstep pins in common config

### DIFF
--- a/drivers/stepper/adi_tmc/tmc22xx/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx/tmc22xx.c
@@ -15,9 +15,6 @@ LOG_MODULE_REGISTER(tmc22xx, CONFIG_STEPPER_LOG_LEVEL);
 
 struct tmc22xx_config {
 	struct step_dir_stepper_common_config common;
-	const struct gpio_dt_spec enable_pin;
-	struct gpio_dt_spec m0_pin;
-	struct gpio_dt_spec m1_pin;
 	enum stepper_drv_micro_step_resolution *msx_resolutions;
 };
 
@@ -32,7 +29,7 @@ static int tmc22xx_enable(const struct device *dev)
 	const struct tmc22xx_config *config = dev->config;
 
 	LOG_DBG("Enabling Stepper motor controller %s", dev->name);
-	return gpio_pin_set_dt(&config->enable_pin, 1);
+	return gpio_pin_set_dt(&config->common.en_pin, 1);
 }
 
 static int tmc22xx_disable(const struct device *dev)
@@ -40,7 +37,7 @@ static int tmc22xx_disable(const struct device *dev)
 	const struct tmc22xx_config *config = dev->config;
 
 	LOG_DBG("Disabling Stepper motor controller %s", dev->name);
-	return gpio_pin_set_dt(&config->enable_pin, 0);
+	return gpio_pin_set_dt(&config->common.en_pin, 0);
 }
 
 static int tmc22xx_set_micro_step_res(const struct device *dev,
@@ -50,7 +47,7 @@ static int tmc22xx_set_micro_step_res(const struct device *dev,
 	const struct tmc22xx_config *config = dev->config;
 	int ret;
 
-	if ((config->m0_pin.port == NULL) || (config->m1_pin.port == NULL)) {
+	if ((config->common.m0_pin.port == NULL) || (config->common.m1_pin.port == NULL)) {
 		LOG_ERR("%s: Failed to set microstep resolution: microstep pins are not defined "
 			"(error: %d)",
 			dev->name, -ENOTSUP);
@@ -62,13 +59,13 @@ static int tmc22xx_set_micro_step_res(const struct device *dev,
 			continue;
 		}
 
-		ret = gpio_pin_set_dt(&config->m0_pin, i & 0x01);
+		ret = gpio_pin_set_dt(&config->common.m0_pin, i & 0x01);
 		if (ret < 0) {
 			LOG_ERR("Failed to set MS1 pin: %d", ret);
 			return ret;
 		}
 
-		ret = gpio_pin_set_dt(&config->m1_pin, (i & 0x02) >> 1);
+		ret = gpio_pin_set_dt(&config->common.m1_pin, (i & 0x02) >> 1);
 		if (ret < 0) {
 			LOG_ERR("Failed to set MS2 pin: %d", ret);
 			return ret;
@@ -97,23 +94,23 @@ static int tmc22xx_stepper_configure_msx_pins(const struct device *dev)
 	const struct tmc22xx_config *config = dev->config;
 	int ret;
 
-	if (!gpio_is_ready_dt(&config->m0_pin)) {
+	if (!gpio_is_ready_dt(&config->common.m0_pin)) {
 		LOG_ERR("MS1 pin not ready");
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(&config->m0_pin, GPIO_OUTPUT);
+	ret = gpio_pin_configure_dt(&config->common.m0_pin, GPIO_OUTPUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure ms1 pin");
 		return ret;
 	}
 
-	if (!gpio_is_ready_dt(&config->m1_pin)) {
+	if (!gpio_is_ready_dt(&config->common.m1_pin)) {
 		LOG_ERR("MS2 pin not ready");
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(&config->m1_pin, GPIO_OUTPUT);
+	ret = gpio_pin_configure_dt(&config->common.m1_pin, GPIO_OUTPUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure ms2 pin");
 		return ret;
@@ -128,18 +125,18 @@ static int tmc22xx_stepper_init(const struct device *dev)
 	struct tmc22xx_data *data = dev->data;
 	int ret;
 
-	if (!gpio_is_ready_dt(&config->enable_pin)) {
+	if (!gpio_is_ready_dt(&config->common.en_pin)) {
 		LOG_ERR("GPIO pins are not ready");
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(&config->enable_pin, GPIO_OUTPUT);
+	ret = gpio_pin_configure_dt(&config->common.en_pin, GPIO_OUTPUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure enable pin: %d", ret);
 		return ret;
 	}
 
-	if ((config->m0_pin.port != NULL) && (config->m1_pin.port != NULL)) {
+	if ((config->common.m0_pin.port != NULL) && (config->common.m1_pin.port != NULL)) {
 		ret = tmc22xx_stepper_configure_msx_pins(dev);
 		if (ret < 0) {
 			LOG_ERR("Failed to configure MSX pins: %d", ret);
@@ -166,10 +163,7 @@ static DEVICE_API(stepper_drv, tmc22xx_stepper_api) = {
 #define TMC22XX_STEPPER_DEFINE(inst, msx_table)                                                    \
 	static const struct tmc22xx_config tmc22xx_config_##inst = {                               \
 		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst),                       \
-		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, en_gpios),	                           \
 		.msx_resolutions = msx_table,                                                      \
-		.m0_pin = GPIO_DT_SPEC_INST_GET_OR(inst, m0_gpios, {0}),                           \
-		.m1_pin = GPIO_DT_SPEC_INST_GET_OR(inst, m1_gpios, {0}),                           \
 	};                                                                                         \
 	static struct tmc22xx_data tmc22xx_data_##inst = {                                         \
 		.resolution = DT_INST_PROP(inst, micro_step_res),                                  \

--- a/drivers/stepper/step_dir/include/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/include/step_dir_stepper_common.h
@@ -21,6 +21,9 @@
  * This structure **must** be placed first in the driver's config structure.
  */
 struct step_dir_stepper_common_config {
+	struct gpio_dt_spec en_pin;
+	struct gpio_dt_spec m0_pin;
+	struct gpio_dt_spec m1_pin;
 	uint32_t step_width_ns;
 	bool dual_edge;
 };
@@ -34,6 +37,9 @@ struct step_dir_stepper_common_config {
  */
 #define STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id)                                            \
 	{                                                                                          \
+		.en_pin = GPIO_DT_SPEC_GET_OR(node_id, en_gpios, {0}),                             \
+		.m0_pin = GPIO_DT_SPEC_GET_OR(node_id, m0_gpios, {0}),                             \
+		.m1_pin = GPIO_DT_SPEC_GET_OR(node_id, m1_gpios, {0}),                             \
 		.dual_edge = DT_PROP_OR(node_id, dual_edge_step, false),                           \
 		.step_width_ns = DT_PROP(node_id, step_width_ns),                                  \
 	}


### PR DESCRIPTION
# Summary

Fixes #101079

This PR moves the init code for en-gpios, m0-gpios and m1-gpios to common init instead of initialize them individually in the driver.

@jilaypandya please let me know if this is the right change you are expecting and appreciate some feedback if not.

Edited: Add the test results

# Test Results

This is the tests results I ran with west twister -T tests/drivers/stepper -v

```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-2586-g3f8adc40fda3
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /home/hong/Documents/GitHubRepos/zephyr-workspace/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/8 native_sim/native/64      drivers.stepper.stepper_drv.drv84xx                PASSED (native 0.005s <host>)
INFO    - 2/8 native_sim/native/64      drivers.stepper.stepper_drv.allegro_a4979          PASSED (native 0.005s <host>)
INFO    - 3/8 native_sim/native/64      drivers.stepper.stepper_api.h_bridge_stepper_work_q PASSED (native 0.009s <host>)
INFO    - 4/8 native_sim/native/64      drivers.stepper.stepper_api.gpio_step_dir          PASSED (native 0.005s <host>)
INFO    - 5/8 native_sim/native/64      drivers.stepper.stepper_api.h_bridge_stepper       PASSED (native 0.007s <host>)
INFO    - 6/8 native_sim/native         drivers.stepper.shell                              PASSED (native 0.007s <host>)
INFO    - 7/8 native_sim/native/64      drivers.stepper.stepper_drv.adi_tmc2209            PASSED (native 0.004s <host>)
INFO    - 8/8 native_sim/native/64      drivers.stepper.stepper_api.gpio_step_dir_work_q   PASSED (native 0.006s <host>)

INFO    - 8 test scenarios (8 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 8 of 8 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 6.43 seconds.
INFO    - 64 of 64 executed test cases passed (100.00%) on 2 out of total 1306 platforms (0.15%).
INFO    - 8 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/hong/Documents/GitHubRepos/zephyr-workspace/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/hong/Documents/GitHubRepos/zephyr-workspace/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/hong/Documents/GitHubRepos/zephyr-workspace/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```