### PR TITLE
dts: renesas: ra: Fix adc compatible for ra6-cm4

### DIFF
--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -371,7 +371,7 @@
 		};
 
 		adc1: adc@4005c200 {
-			compatible = "renesas,ra-adc";
+			compatible = "renesas,ra-adc12";
 			interrupts = <39 1>;
 			interrupt-names = "scanend";
 			unit = <1>;


### PR DESCRIPTION
The `renesas,ra-adc` compatible was replaced by `renesas,ra-adc12`, at #95710 but one ADC devicetree node was not updated accordingly.

This commit updates the missing node to use the correct `renesas,ra-adc12` compatible.