### PR TITLE
SC-OBC module V1: DTS Cleanup

### DIFF
--- a/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
+++ b/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <arm/xilinx/versal_rpu.dtsi>
+#include <freq.h>
 
 / {
 	model = "SC-OBC Module V1 Versal Cortex-R5F";
@@ -21,10 +22,10 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	clock-frequency = <100000000>;
+	clock-frequency = <DT_FREQ_M(100)>;
 };
 
 &ttc0 {
 	status = "okay";
-	clock-frequency = <150000000>;
+	clock-frequency = <DT_FREQ_M(150)>;
 };

--- a/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
+++ b/boards/sc/scobc_v1/scobc_v1_versal_rpu.dts
@@ -24,12 +24,6 @@
 	clock-frequency = <100000000>;
 };
 
-&uart0 {
-	status = "okay";
-	current-speed = <115200>;
-	clock-frequency = <100000000>;
-};
-
 &ttc0 {
 	status = "okay";
 	clock-frequency = <150000000>;


### PR DESCRIPTION
Two commits to clean up the dts file for SC-OBC module V1.

- removing unused uart0 for rpu.
- useing `DT_FREQ_M()`.

pointed out by #98183.