### PR TITLE
Bluetooth: Host: Add L2CAP chan send warning

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -1046,6 +1046,12 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  @note Buffer ownership is transferred to the stack in case of success, in
  *  case of an error the caller retains the ownership of the buffer.
  *
+ *  @warning If the buffer's pool has a destroy callback defined, that callback
+ *  may be invoked from the ISR context when the HCI driver releases the buffer.
+ *  Thus, the destroy callback must not call any synchronization primitives
+ *  that are unsafe in the ISR context, i. e. blocking calls or locking the
+ *  scheduler.
+ *
  *  @param chan The channel to send the data to. See @ref bt_l2cap_chan_connect
  *              for more details.
  *  @param buf Buffer containing the data.


### PR DESCRIPTION
Adds a warning to `bt_l2cap_chan_send` that the user must not pass buffers to this function whose pool has implemented a destroy callback (net_buf_pool::destroy) that uses synchronization primitives. This is due to the HCI driver interface not having defined rules for where a buffer may be freed, leading to the possibility of the callback being called from the ISR. This warning can be removed at a later point if the HCI driver interface is redesigned to not pass the net_bufs directly.