### PR TITLE
drivers: eth: nxp: Fix DSA default MAC address allocation.

### DIFF
--- a/doc/connectivity/networking/dsa.rst
+++ b/doc/connectivity/networking/dsa.rst
@@ -83,7 +83,7 @@ of i.MX NETC.
                    .phy_mode = NETC_PHY_MODE(port),                                            \
            };                                                                                  \
            struct dsa_port_config dsa_##n##_##port##_config = {                                \
-                   .use_random_mac_addr = DT_NODE_HAS_PROP(port, zephyr_random_mac_address),   \
+                   .use_random_mac_addr = DT_PROP(port, zephyr_random_mac_address),            \
                    .mac_addr = DT_PROP_OR(port, local_mac_address, {0}),                       \
                    .port_idx = DT_REG_ADDR(port),                                              \
                    .phy_dev = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port, phy_handle)),             \

--- a/drivers/ethernet/nxp_imx_netc/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/dsa_nxp_imx_netc.c
@@ -123,7 +123,7 @@ static struct dsa_api dsa_netc_api = {
 		.phy_mode = NETC_PHY_MODE(port),                                            \
 	};                                                                                  \
 	struct dsa_port_config dsa_##n##_##port##_config = {                                \
-		.use_random_mac_addr = DT_NODE_HAS_PROP(port, zephyr_random_mac_address),   \
+		.use_random_mac_addr = DT_PROP(port, zephyr_random_mac_address),            \
 		.mac_addr = DT_PROP_OR(port, local_mac_address, {0}),                       \
 		.port_idx = DT_REG_ADDR(port),                                              \
 		.phy_dev = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port, phy_handle)),             \


### PR DESCRIPTION
NXP DSA drivers fails to disable random MAC address allocation  by adding "/delete-property/" tag in front of "random-mac-address" field. This cause issue when we want to assign a specified MAC address to the board.

Also update the corresponding doc.

Fixes #101236 