### PR TITLE
linker: section_tags: remove deprecated STM32 CCM section tags

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -54,6 +54,12 @@ Clock Control
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
 
+STM32
+=====
+
+* The attribute macros ``__ccm_data_section``, ``__ccm_data_section`` and ``__ccm_data_section``
+  retained in Zephyr 4.4 for backwards compatibility have been removed. (:github:`101255`)
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth

--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -43,14 +43,6 @@
 #define __imx_boot_dcd_section Z_GENERIC_SECTION(_IMX_BOOT_DCD_SECTION_NAME)
 #define __imx_boot_container_section Z_GENERIC_SECTION(_IMX_BOOT_CONTAINER_SECTION_NAME)
 #define __stm32_backup_sram_section Z_GENERIC_SECTION(_STM32_BACKUP_SRAM_SECTION_NAME)
-
-/*
- * Deprecated aliases, provided for backwards compatibility.
- * These aliases will be removed in Zephyr v4.5.
- */
-#define __ccm_data_section __dtcm_data_section __DEPRECATED_MACRO
-#define __ccm_bss_section __dtcm_bss_section __DEPRECATED_MACRO
-#define __ccm_noinit_section __dtcm_noinit_section __DEPRECATED_MACRO
 #endif /* CONFIG_ARM */
 
 #if defined(CONFIG_NOCACHE_MEMORY)


### PR DESCRIPTION
The ST-specific CCM mechanism was replaced by DTCM in Zephyr release v4.4. Remove backwards compatibility macros as part of this release, as planned and documented in the v4.4 migration guide and on the macros themselves - c.f. #100590
