### PR TITLE
include: adc: add doxygen docs for device-specific ADC API extensions

### DIFF
--- a/dts/bindings/iio/afe/voltage-divider.yaml
+++ b/dts/bindings/iio/afe/voltage-divider.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2019, Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+title: Voltage Divider
+
 description: |
     Description for a voltage divider, with optional ability to measure
     resistance of the upper leg.

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -31,6 +31,11 @@ extern "C" {
  * @version 1.0.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup adc_interface_ext Device-specific ADC API extensions
+ *
+ * @{
+ * @}
  */
 
 /** @brief ADC channel gain factors. */

--- a/include/zephyr/drivers/adc/ads131m02.h
+++ b/include/zephyr/drivers/adc/ads131m02.h
@@ -4,45 +4,107 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended API of ADS131M02 ADC
+ * @ingroup ads131m02_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_ADS131M02_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_ADS131M02_H_
 
 #include <zephyr/device.h>
 
+/**
+ * @brief Texas Instruments 2 channels SPI ADC
+ * @defgroup ads131m02_interface ADS131M02
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief ADS131M02 ADC mode.
+ */
 enum ads131m02_adc_mode {
-	ADS131M02_CONTINUOUS_MODE,	/* Continuous conversion mode */
-	ADS131M02_GLOBAL_CHOP_MODE	/* Global chop mode */
+	ADS131M02_CONTINUOUS_MODE,	/**< Continuous conversion mode */
+	ADS131M02_GLOBAL_CHOP_MODE	/**< Global-chop mode */
 };
 
+/**
+ * @brief ADS131M02 power mode.
+ */
 enum ads131m02_adc_power_mode {
-	ADS131M02_VLP,	/* Very Low Power */
-	ADS131M02_LP,	/* Low Power */
-	ADS131M02_HR	/* High Resolution */
+	ADS131M02_VLP,	/**< Very Low Power */
+	ADS131M02_LP,	/**< Low Power */
+	ADS131M02_HR	/**< High Resolution */
 };
 
+/**
+ * @brief ADS131M02 global-chop delay.
+ *
+ * Delay inserted after the chopping switches toggle in global-chop mode to allow for external input
+ * circuitry settling.
+ */
 enum ads131m02_gc_delay {
+	/** 2 sample delay */
 	ADS131M02_GC_DELAY_2,
+	/** 4 sample delay */
 	ADS131M02_GC_DELAY_4,
+	/** 8 sample delay */
 	ADS131M02_GC_DELAY_8,
+	/** 16 sample delay */
 	ADS131M02_GC_DELAY_16,
+	/** 32 sample delay */
 	ADS131M02_GC_DELAY_32,
+	/** 64 sample delay */
 	ADS131M02_GC_DELAY_64,
+	/** 128 sample delay */
 	ADS131M02_GC_DELAY_128,
+	/** 256 sample delay */
 	ADS131M02_GC_DELAY_256,
+	/** 512 sample delay */
 	ADS131M02_GC_DELAY_512,
+	/** 1024 sample delay */
 	ADS131M02_GC_DELAY_1024,
+	/** 2048 sample delay */
 	ADS131M02_GC_DELAY_2048,
+	/** 4096 sample delay */
 	ADS131M02_GC_DELAY_4096,
+	/** 8192 sample delay */
 	ADS131M02_GC_DELAY_8192,
+	/** 16384 sample delay */
 	ADS131M02_GC_DELAY_16384,
+	/** 32768 sample delay */
 	ADS131M02_GC_DELAY_32768,
+	/** 65536 sample delay */
 	ADS131M02_GC_DELAY_65536
 };
 
+/**
+ * @brief Set the ADC mode of an ADS131M02 ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mode ADC mode to set.
+ * @param gc_delay Global chop delay to set (if @p mode is @ref ADS131M02_GLOBAL_CHOP_MODE).
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads131m02_set_adc_mode(const struct device *dev, enum ads131m02_adc_mode mode,
 			   enum ads131m02_gc_delay gc_delay);
 
+/**
+ * @brief Set the power mode of an ADS131M02 ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mode Power mode to set.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads131m02_set_power_mode(const struct device *dev,
 			     enum ads131m02_adc_power_mode mode);
+
+/** @} */
 
 #endif

--- a/include/zephyr/drivers/adc/ads1x4s0x.h
+++ b/include/zephyr/drivers/adc/ads1x4s0x.h
@@ -4,32 +4,123 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended API of ADS1x4s0x ADC
+ * @ingroup ads1x4s0x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_ADS1X4S0X_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_ADS1X4S0X_H_
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 
+/**
+ * @brief Texas Instruments ADS1x4s0x
+ * @defgroup ads1x4s0x_interface ADS1x4s0x
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Configure a GPIO pin of an ADS1x4s0x ADC as an output.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number.
+ * @param initial_value Initial value of the pin.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_set_output(const struct device *dev, uint8_t pin, bool initial_value);
 
+/**
+ * @brief Configure a GPIO pin of an ADS1x4s0x ADC as an input.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_set_input(const struct device *dev, uint8_t pin);
 
+/**
+ * @brief Deconfigure a GPIO pin of an ADS1x4s0x ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_deconfigure(const struct device *dev, uint8_t pin);
 
+/**
+ * @brief Set the value of a GPIO pin of an ADS1x4s0x ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number.
+ * @param value Value to set.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_set_pin_value(const struct device *dev, uint8_t pin,
 				bool value);
 
+/**
+ * @brief Get the value of a GPIO pin of an ADS1x4s0x ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number.
+ * @param value Pointer to where the value will be stored.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_get_pin_value(const struct device *dev, uint8_t pin,
 				bool *value);
 
+/**
+ * @brief Get the value of the GPIO port of an ADS1x4s0x ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param value Pointer to where the port value will be stored.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_port_get_raw(const struct device *dev,
 			       gpio_port_value_t *value);
 
+/**
+ * @brief Set the value of the GPIO port of an ADS1x4s0x ADC with a mask.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mask Mask of pins to change.
+ * @param value Value to set.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_port_set_masked_raw(const struct device *dev,
 				      gpio_port_pins_t mask,
 				      gpio_port_value_t value);
 
+/**
+ * @brief Toggle bits of the GPIO port of an ADS1x4s0x ADC.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pins Mask of pins to toggle.
+ *
+ * @retval 0 success.
+ * @retval -errno negative errno on failure.
+ */
 int ads1x4s0x_gpio_port_toggle_bits(const struct device *dev,
 				   gpio_port_pins_t pins);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_ADS1X4S0X_H_ */

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -4,21 +4,50 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended ADC API of Current Sense Amplifier
+ * @ingroup adc_current_sense_amplifier_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_AMPLIFIER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_AMPLIFIER_H_
 
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/gpio.h>
 
+/**
+ * @brief Current Sense Amplifier
+ * @defgroup adc_current_sense_amplifier_interface Current Sense Amplifier
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Current sense amplifier DT struct.
+ *
+ * This stores information about a current sense amplifier obtained from Devicetree.
+ *
+ * @see CURRENT_SENSE_AMPLIFIER_DT_SPEC_GET
+ */
 struct current_sense_amplifier_dt_spec {
+	/** ADC channel info */
 	struct adc_dt_spec port;
+	/** GPIO to enable the amplifier */
 	struct gpio_dt_spec power_gpio;
+	/** Sense resistor value in milliohms */
 	uint32_t sense_milli_ohms;
+	/** Sense amplifier gain multiplier */
 	uint16_t sense_gain_mult;
+	/** Sense amplifier gain divider */
 	uint16_t sense_gain_div;
+	/** Noise threshold */
 	uint16_t noise_threshold;
+	/** Voltage at zero current in millivolts */
 	int16_t zero_current_voltage_mv;
+	/** Gain range */
 	enum adc_gain gain_extended_range;
+	/** Enable calibration */
 	bool enable_calibration;
 };
 
@@ -46,7 +75,7 @@ struct current_sense_amplifier_dt_spec {
 	}
 
 /**
- * @brief Calculates the actual amperage from the measured voltage
+ * @brief Calculates the actual amperage from a measured voltage
  *
  * @param[in] spec current sensor specification from Devicetree.
  * @param[in,out] v_to_i Pointer to the measured voltage in millivolts on input, and the
@@ -69,7 +98,7 @@ current_sense_amplifier_scale_dt(const struct current_sense_amplifier_dt_spec *s
 }
 
 /**
- * @brief Calculates the actual amperage from the measured voltage
+ * @brief Calculates the actual amperage from a measured voltage
  *
  * @param spec Current sensor specification from Devicetree.
  * @param microvolts Measured voltage in microvolts.
@@ -93,5 +122,7 @@ current_sense_amplifier_scale_ua_dt(const struct current_sense_amplifier_dt_spec
 	/* Perform final divisions */
 	return scaled / spec->sense_gain_mult / spec->sense_milli_ohms;
 }
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_AMPLIFIER_H_ */

--- a/include/zephyr/drivers/adc/current_sense_shunt.h
+++ b/include/zephyr/drivers/adc/current_sense_shunt.h
@@ -4,13 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended ADC API of Current Sense Shunt
+ * @ingroup adc_current_sense_shunt_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_SHUNT_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_SHUNT_H_
 
 #include <zephyr/drivers/adc.h>
 
+/**
+ * @brief Current Sense Shunt
+ * @defgroup adc_current_sense_shunt_interface Current Sense Shunt
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Current sense shunt DT struct.
+ *
+ * This stores information about a current sense shunt obtained from Devicetree.
+ *
+ * @see CURRENT_SENSE_SHUNT_DT_SPEC_GET
+ */
 struct current_sense_shunt_dt_spec {
+	/** ADC channel info */
 	const struct adc_dt_spec port;
+	/** Shunt resistor value in micro-ohms */
 	uint32_t shunt_micro_ohms;
 };
 
@@ -31,7 +53,7 @@ struct current_sense_shunt_dt_spec {
 	}
 
 /**
- * @brief Calculates the actual amperage from the measured voltage
+ * @brief Calculates the actual amperage from a measured voltage
  *
  * @param[in] spec current sensor specification from Devicetree.
  * @param[in,out] v_to_i Pointer to the measured voltage in millivolts on input, and the
@@ -48,5 +70,7 @@ static inline void current_sense_shunt_scale_dt(const struct current_sense_shunt
 
 	*v_to_i = (int32_t)tmp;
 }
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_SHUNT_H_ */

--- a/include/zephyr/drivers/adc/lmp90xxx.h
+++ b/include/zephyr/drivers/adc/lmp90xxx.h
@@ -4,39 +4,142 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended API of LMP90xxx ADC
+ * @ingroup lmp90xxx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 
-/* LMP90xxx supports GPIO D0..D6 */
+/**
+ * @brief Texas Instruments LMP90xxx Analog Front End (AFE)
+ * @defgroup lmp90xxx_interface LMP90xxx
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Maximum pin number supported by LMP90xxx
+ *
+ * LMP90xxx supports GPIO D0..D6
+ */
 #define LMP90XXX_GPIO_MAX 6
 
+/**
+ * @brief Configure a GPIO pin of an LMP90xxx as an output.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number. The value must be between 0 and LMP90XXX_GPIO_MAX.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_set_output(const struct device *dev, uint8_t pin);
 
+/**
+ * @brief Configure a GPIO pin of an LMP90xxx as an input.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number. The value must be between 0 and LMP90XXX_GPIO_MAX.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_set_input(const struct device *dev, uint8_t pin);
 
+/**
+ * @brief Set the value of a GPIO pin of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number. The value must be between 0 and LMP90XXX_GPIO_MAX.
+ * @param value Value to set.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_set_pin_value(const struct device *dev, uint8_t pin,
 				bool value);
 
+/**
+ * @brief Get the value of a GPIO pin of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pin Pin number. The value must be between 0 and LMP90XXX_GPIO_MAX.
+ * @param value Pointer to where the value will be stored.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_get_pin_value(const struct device *dev, uint8_t pin,
 				bool *value);
 
+/**
+ * @brief Get the value of the GPIO port of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param value Pointer to where the port value will be stored.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_port_get_raw(const struct device *dev,
 			       gpio_port_value_t *value);
 
+/**
+ * @brief Set the value of the GPIO port of an LMP90xxx with a mask.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param mask Mask of pins to change.
+ * @param value Value to set.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_port_set_masked_raw(const struct device *dev,
 				      gpio_port_pins_t mask,
 				      gpio_port_value_t value);
 
+/**
+ * @brief Set bits of the GPIO port of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pins Mask of pins to set.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_port_set_bits_raw(const struct device *dev,
 				    gpio_port_pins_t pins);
 
+/**
+ * @brief Clear bits of the GPIO port of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pins Mask of pins to clear.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_port_clear_bits_raw(const struct device *dev,
 				      gpio_port_pins_t pins);
 
+/**
+ * @brief Toggle bits of the GPIO port of an LMP90xxx.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param pins Mask of pins to toggle.
+ *
+ * @retval 0 on success.
+ * @retval -EIO or other negative errno if communication failed.
+ */
 int lmp90xxx_gpio_port_toggle_bits(const struct device *dev,
 				   gpio_port_pins_t pins);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_ */

--- a/include/zephyr/drivers/adc/voltage_divider.h
+++ b/include/zephyr/drivers/adc/voltage_divider.h
@@ -4,14 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended API of Voltage Divider
+ * @ingroup adc_voltage_divider_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_
 
 #include <zephyr/drivers/adc.h>
 
+/**
+ * @brief Voltage Divider
+ * @defgroup adc_voltage_divider_interface Voltage Divider
+ * @ingroup adc_interface_ext
+ * @{
+ */
+
+/**
+ * @brief Voltage divider DT struct.
+ *
+ * This stores information about a voltage divider obtained from Devicetree.
+ *
+ * @see VOLTAGE_DIVIDER_DT_SPEC_GET
+ */
 struct voltage_divider_dt_spec {
+	/** ADC channel info */
 	const struct adc_dt_spec port;
+	/** Full resistance in ohms */
 	uint32_t full_ohms;
+	/** Output resistance in ohms */
 	uint32_t output_ohms;
 };
 
@@ -33,7 +56,7 @@ struct voltage_divider_dt_spec {
 	}
 
 /**
- * @brief Calculates the actual voltage from the measured voltage
+ * @brief Calculates the actual voltage from a measured voltage
  *
  * @param[in] spec voltage divider specification from Devicetree.
  * @param[in,out] v_to_v Pointer to the measured voltage on input, and the
@@ -55,5 +78,7 @@ static inline int voltage_divider_scale_dt(const struct voltage_divider_dt_spec 
 
 	return 0;
 }
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_ */


### PR DESCRIPTION
Add doxygen docs for a bunch of adc drivers device-specific API:

- ads1x4s0x
- ads131m02
- lmp90xxx
- voltage_divider
- current_sense_amplifier
- current_sense_shunt

https://builds.zephyrproject.io/zephyr/pr/101260/docs/doxygen/html/group__adc__interface__ext.html
https://builds.zephyrproject.io/zephyr/pr/101260/api-coverage/zephyr/drivers/adc/index.html