### PR TITLE
drivers: dts: ti: fix typo in "Texas Instruments" company name

### DIFF
--- a/drivers/serial/Kconfig.stellaris
+++ b/drivers/serial/Kconfig.stellaris
@@ -9,7 +9,7 @@ menuconfig UART_STELLARIS
 	help
 	  This option enables the Stellaris serial driver.
 	  This specific driver can be used for the serial hardware
-	  available at the Texas Instrument LM3S6965 board.
+	  available at the Texas Instruments LM3S6965 board.
 
 if UART_STELLARIS
 

--- a/dts/bindings/adc/ti,ads1013.yaml
+++ b/dts/bindings/adc/ti,ads1013.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1013 I2C ADC
+description: Texas Instruments ADS1013 I2C ADC
 
 compatible: "ti,ads1013"
 

--- a/dts/bindings/adc/ti,ads1014.yaml
+++ b/dts/bindings/adc/ti,ads1014.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1014 I2C ADC
+description: Texas Instruments ADS1014 I2C ADC
 
 compatible: "ti,ads1014"
 

--- a/dts/bindings/adc/ti,ads1015.yaml
+++ b/dts/bindings/adc/ti,ads1015.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1015 I2C ADC
+description: Texas Instruments ADS1015 I2C ADC
 
 compatible: "ti,ads1015"
 

--- a/dts/bindings/adc/ti,ads1112.yaml
+++ b/dts/bindings/adc/ti,ads1112.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1112 I2C ADC
+description: Texas Instruments ADS1112 I2C ADC
 
 compatible: "ti,ads1112"
 

--- a/dts/bindings/adc/ti,ads1113.yaml
+++ b/dts/bindings/adc/ti,ads1113.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1113 I2C ADC
+description: Texas Instruments ADS1113 I2C ADC
 
 compatible: "ti,ads1113"
 

--- a/dts/bindings/adc/ti,ads1114.yaml
+++ b/dts/bindings/adc/ti,ads1114.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1114 I2C ADC
+description: Texas Instruments ADS1114 I2C ADC
 
 compatible: "ti,ads1114"
 

--- a/dts/bindings/adc/ti,ads1115.yaml
+++ b/dts/bindings/adc/ti,ads1115.yaml
@@ -1,4 +1,4 @@
-description: Texas Instrument ADS1115 I2C ADC
+description: Texas Instruments ADS1115 I2C ADC
 
 compatible: "ti,ads1115"
 

--- a/dts/bindings/adc/ti,ads1119.yaml
+++ b/dts/bindings/adc/ti,ads1119.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Innoseis
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 4 channels I2C ADC
+description: Texas Instruments 4 channels I2C ADC
 
 compatible: "ti,ads1119"
 

--- a/dts/bindings/adc/ti,ads114s06.yaml
+++ b/dts/bindings/adc/ti,ads114s06.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 6 channels 16 bit SPI ADC
+description: Texas Instruments 6 channels 16 bit SPI ADC
 
 compatible: "ti,ads114s06"
 

--- a/dts/bindings/adc/ti,ads114s08.yaml
+++ b/dts/bindings/adc/ti,ads114s08.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 SILA Embedded Solutions GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 12 channels 16 bit SPI ADC
+description: Texas Instruments 12 channels 16 bit SPI ADC
 
 compatible: "ti,ads114s08"
 

--- a/dts/bindings/adc/ti,ads124s06.yaml
+++ b/dts/bindings/adc/ti,ads124s06.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 6 channels 24 bit SPI ADC
+description: Texas Instruments 6 channels 24 bit SPI ADC
 
 compatible: "ti,ads124s06"
 

--- a/dts/bindings/adc/ti,ads124s08.yaml
+++ b/dts/bindings/adc/ti,ads124s08.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 12 channels 24 bit SPI ADC
+description: Texas Instruments 12 channels 24 bit SPI ADC
 
 compatible: "ti,ads124s08"
 

--- a/dts/bindings/adc/ti,ads131m02.yaml
+++ b/dts/bindings/adc/ti,ads131m02.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Linumiz
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument 2 channels SPI ADC
+description: Texas Instruments 2 channels SPI ADC
 
 compatible: "ti,ads131m02"
 

--- a/dts/bindings/adc/ti,ads7052.yaml
+++ b/dts/bindings/adc/ti,ads7052.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instrument Single Channel SPI ADC
+description: Texas Instruments Single Channel SPI ADC
 
 compatible: "ti,ads7052"
 


### PR DESCRIPTION
`s/Texas Instrument/Texas Instruments/g`