### PR TITLE
Bluetooth: Mesh: Let vendor models receive messages with SIG opcodes

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -445,6 +445,12 @@ Bluetooth Audio
   :c:func:`bt_bap_broadcast_assistant_read_recv_state` to read the existing receive states, if any,
   prior to performing any operations. (:github:`91587`)
 
+Bluetooth Mesh
+==============
+
+* :kconfig:option:`CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE` has been deprecated. Enabling it no
+  longer has any effect on message handling performance.
+
 Networking
 **********
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -77,6 +77,7 @@ Deprecated APIs and options
       :c:func:`bt_mesh_input_numeric` instead.
     * The callback :c:member:`output_number` in :c:struct:`bt_mesh_prov` structure was deprecated.
       Applications should use :c:member:`output_numeric` callback instead.
+    * The :kconfig:option:`CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE` option has been deprecated.
 
   * Host
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -785,11 +785,12 @@ config BT_MESH_ACCESS_LAYER_MSG
 	  might wear out persistent memory.
 
 config BT_MESH_MODEL_VND_MSG_CID_FORCE
-	bool "Force vendor model to use the corresponding CID field message"
-	default y
+	bool "Force vendor model to use opcodes with matching CID [DEPRECATED]"
+	default n
+	select DEPRECATED
 	help
-	  This option forces vendor model to use messages for the
-	  corresponding CID field.
+	  This option forces vendor models to only use opcodes with a CID field
+	  matching the models CID. It is deprecated and should no longer be used.
 
 config BT_MESH_MODEL_EXTENSIONS
 	bool "Support for Model extensions"

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1413,12 +1413,6 @@ static const struct bt_mesh_model_op *find_op(const struct bt_mesh_elem *elem,
 
 		const struct bt_mesh_model_op *op;
 
-		if (IS_ENABLED(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE) &&
-		     cid != UINT32_MAX &&
-		     cid != models[i].vnd.company) {
-			continue;
-		}
-
 		*model = &models[i];
 
 		for (op = (*model)->op; op->func; op++) {

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -990,7 +990,6 @@ const struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_
 	}
 }
 
-#if defined(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE)
 static int bt_mesh_vnd_mod_msg_cid_check(const struct bt_mesh_model *mod)
 {
 	uint16_t cid;
@@ -1012,7 +1011,6 @@ static int bt_mesh_vnd_mod_msg_cid_check(const struct bt_mesh_model *mod)
 
 	return 0;
 }
-#endif
 
 static void mod_init(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		     bool vnd, bool primary, void *user_data)

--- a/tests/bsim/bluetooth/mesh/tests_scripts/access/access_vnd_rcv_sig_msg.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/access/access_vnd_rcv_sig_msg.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# This test checks that vendor models are able to receive messages using
+# SIG-defined opcodes, which is needed for vendor models to communicate
+# with SIG models.
+#
+# Test scenario:
+# Device 2 has a vendor model that defines a handler for a specific 1-byte (SIG)
+# opcode.
+# Device 1 sends a message using the 1-byte (SIG) opcode to device 2.
+# The vendor model on device 2 receives the message.
+
+RunTest mesh_access_vnd_rcv_sig_msg \
+	access_tx_transmit_sig_msg_to_vnd access_rx_transmit_sig_msg_to_vnd


### PR DESCRIPTION
This fixes a limitation where the stack assumed that vendor models could
not specify handlers for SIG-defined (1- or 2-byte) opcodes. This
assumption does not exist in the specification. In fact, the
specification expects this very use-case to be possible, in MeshPRT 1.1,
section 3.8.3:

> To exchange messages with a Bluetooth SIG adopted model, a Vendor Model
> shall use the Access message defined for the Bluetooth SIG model.

In addition, it includes a commit to add a BSIM test to check this
behvior, a commit to fix a compile warning when not forcing CID to match
between model and opcode handlers, and a commit to deprecate the forced CID
match (and related optimization) option and disable it by default. See individual commit messages
for details.