### PR TITLE
net: mqtt: Allow to force native TLS on MQTT socket

### DIFF
--- a/doc/connectivity/networking/api/mqtt.rst
+++ b/doc/connectivity/networking/api/mqtt.rst
@@ -150,6 +150,7 @@ additional configuration information:
    tls_config->sec_tag_list = m_sec_tags;
    tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);
    tls_config->hostname = MQTT_BROKER_HOSTNAME;
+   tls_config->set_native_tls = true;
 
 In this sample code, the ``m_sec_tags`` array holds a list of tags, referencing TLS
 credentials that the MQTT library should use for authentication. We do not specify
@@ -161,6 +162,9 @@ the ``peer_verify`` field.
 Note, that TLS credentials referenced by the ``m_sec_tags`` array must be
 registered in the system first. For more information on how to do that, refer
 to :ref:`secure sockets documentation <secure_sockets_interface>`.
+
+Finally, ``set_native_tls`` can be optionally set to enable native TLS support
+instead of offloading TLS operations to an offloaded socket.
 
 An example of how to use TLS with MQTT is also present in
 :zephyr:code-sample:`mqtt-publisher` sample application.

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -768,6 +768,9 @@ struct mqtt_sec_config {
 
 	/** Indicates the preference for copying certificates to the heap. */
 	int cert_nocopy;
+
+	/** Set socket to use native TLS (used with socket offloading). */
+	bool set_native_tls;
 };
 
 /** @brief MQTT transport type. */

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -32,6 +32,18 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 
 	NET_DBG("Created socket %d", client->transport.tls.sock);
 
+	if (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD_DISPATCHER) && tls_config->set_native_tls) {
+		int tls_native = 1;
+
+		ret = zsock_setsockopt(client->transport.tls.sock, ZSOCK_SOL_TLS,
+				       ZSOCK_TLS_NATIVE, &tls_native,
+				       sizeof(tls_native));
+		if (ret < 0) {
+			NET_ERR("Failed to set native TLS (%d)", -errno);
+			goto error;
+		}
+	}
+
 	if (client->transport.if_name != NULL) {
 		struct net_ifreq ifname = { 0 };
 


### PR DESCRIPTION
Add a parameter to MQTT TLS configuration that allows to force native TLS on a socket if offload dispatcher is used. This allows for MQTT to use native TLS implementation with an offloaded TCP socket.