### PR TITLE
Add I2C driver support for PIC32CX SG family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -14,6 +14,13 @@
 		};
 	};
 
+	sercom6_i2c_default: sercom6_i2c_default {
+		group1 {
+			pinmux = <PD9D_SERCOM6_PAD0>,
+				 <PD8D_SERCOM6_PAD1>;
+		};
+	};
+
 	tcc0_pwm_default: tcc0_pwm_default {
 		group1 {
 			pinmux = <PC21F_TCC0_WO5>;

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cx_sg/pic32cx_sg41/pic32cx1025sg41128.dtsi>
 #include "pic32cx_sg41_cult-pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -208,5 +209,17 @@
 };
 
 &dmac {
+	status = "okay";
+};
+
+&sercom6 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom6_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 10 0x10>, <&dmac 11 0x11>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -14,6 +14,7 @@ supported:
   - dma
   - flash
   - gpio
+  - i2c
   - pinctrl
   - pwm
   - rtc

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -14,6 +14,13 @@
 		};
 	};
 
+	sercom6_i2c_default: sercom6_i2c_default {
+		group1 {
+			pinmux = <PD9D_SERCOM6_PAD0>,
+				 <PD8D_SERCOM6_PAD1>;
+		};
+	};
+
 	tcc0_pwm_default: tcc0_pwm_default {
 		group1 {
 			pinmux = <PC21F_TCC0_WO5>;

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cx_sg/pic32cx_sg61/pic32cx1025sg61128.dtsi>
 #include "pic32cx_sg61_cult-pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -202,5 +203,17 @@
 };
 
 &dmac {
+	status = "okay";
+};
+
+&sercom6 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom6_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 10 0x10>, <&dmac 11 0x11>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -14,6 +14,7 @@ supported:
   - dma
   - flash
   - gpio
+  - i2c
   - pinctrl
   - pwm
   - rtc

--- a/tests/drivers/i2c/i2c_async/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/i2c/i2c_async/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sercom6 {
+	eeprom0: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_async/testcase.yaml
+++ b/tests/drivers/i2c/i2c_async/testcase.yaml
@@ -7,3 +7,4 @@ tests:
   drivers.i2c.i2c_async:
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg41_cult

--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 5dd7bc0858d29b405891ad8d6b3e911b4003ebca
+      revision: dbbff4a054d5888c3e8a27096335197a1a8186ca
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
This PR adds I2C driver support for the PIC32CX SG family of devices and board support for PIC32CX SG41 and SG61 Curiosity Ultra boards.