### PR TITLE
samples: openthread: add esp platforms to the border_router (eth)

### DIFF
--- a/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.overlay
@@ -34,6 +34,35 @@
 	pinctrl-names = "default";
 };
 
+&spim2_default {
+	group1 {
+		pinmux = <SPIM2_MISO_GPIO2>,
+			 <SPIM2_SCLK_GPIO6>,
+			 <SPIM2_CSEL_GPIO10>;
+	};
+
+	group2 {
+		pinmux = <SPIM2_MOSI_GPIO7>;
+		output-low;
+	};
+};
+
+&spi2 {
+	pinctrl-0 = <&spim2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eth_w5500: eth-w5500@0 {
+		compatible = "wiznet,w5500";
+		status = "okay";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(20)>;
+		int-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		zephyr,random-mac-address;
+	};
+};
+
 &psram0 {
 	size = <DT_SIZE_M(2)>;
 };

--- a/samples/net/openthread/border_router/overlay-ot-rcp-host-eth-esp.conf
+++ b/samples/net/openthread/border_router/overlay-ot-rcp-host-eth-esp.conf
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+
+CONFIG_ESP_SPIRAM=y
+CONFIG_ESP_SPIRAM_BSS_RELOC_LIBS_AND_OBJS="libopenthread-ftd.a libopenthread-cli-ftd.a"
+
+# Generic network options
+CONFIG_SPI=y
+CONFIG_ETH_DRIVER=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_L2_ETHERNET_MGMT=y
+
+CONFIG_NET_CONFIG_AUTO_INIT=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+CONFIG_NET_CONFIG_SETTINGS=y
+
+# lib & os
+CONFIG_EVENTS=y
+
+# CPP library
+CONFIG_CPP=y
+
+# Use NVS as settings backend
+CONFIG_NVS=y
+
+# Shell
+CONFIG_SHELL_ARGC_MAX=26
+CONFIG_SHELL_CMD_BUFF_SIZE=512
+CONFIG_SHELL_STACK_SIZE=5120
+
+# Network shell
+CONFIG_NET_SHELL=y
+CONFIG_SHELL=y
+CONFIG_SHELL_GETOPT=y
+CONFIG_SHELL_TAB=y
+CONFIG_SHELL_TAB_AUTOCOMPLETION=y
+
+# Enable Openthread RCP host interface
+CONFIG_IEEE802154=n
+CONFIG_HDLC_RCP_IF=y
+CONFIG_OPENTHREAD_MANUAL_START=y
+CONFIG_OPENTHREAD_RCP_RESTORATION_MAX_COUNT=10
+
+# Border Router mDNS host name and service base name
+CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_VENDOR_NAME="Espressif Systems"
+CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_BASE_SERVICE_NAME="ESP-BorderRouter"
+
+# As per Thread v1.2.0 Conformance, a Thread Border Router MUST be able to hold a Multicast Listener
+# Table in memory with at least 75 entries.
+# 75 entries for conformance, 10 extra for other purposes, if any.
+CONFIG_NET_MAX_MCAST_ROUTES=85
+CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=85
+
+# Network diagnostics
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_NAME="Espressif Systems"
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_MODEL="ESP-BR"
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_SW_VERSION="v1.0.0"

--- a/samples/net/openthread/border_router/sample.yaml
+++ b/samples/net/openthread/border_router/sample.yaml
@@ -25,3 +25,16 @@ tests:
     platform_allow:
       - esp32s3_devkitc/esp32s3/procpu
       - esp_threadbr/esp32s3/procpu
+  sample.net.openthread.border_router.esp_rcp_host_eth.esp_devkits:
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ot-rcp-host-eth-esp.conf"
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu
+  sample.net.openthread.border_router.esp_rcp_host_eth.esp_threadbr:
+    build_only: true
+    extra_args:
+      - SHIELD="esp_threadbr_ethernet"
+      - EXTRA_CONF_FILE="overlay-ot-rcp-host-eth-esp.conf"
+    platform_allow:
+      - esp_threadbr/esp32s3/procpu


### PR DESCRIPTION
Add the following esp platforms to the openthread border_router sample (eth) using rcp with hdlc trhough uart:
- esp32s3_devkitc/esp32s3/procpu
- esp_threadbr/esp32s3/procpu