### PR TITLE
soc: st: stm32: handle debug power mode in common code for WBA series

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -80,6 +80,9 @@ static int st_stm32_common_config(void)
 	LL_DBGMCU_EnableDebugInStopMode();
 #elif defined(CONFIG_SOC_SERIES_STM32WB0X)
 	LL_PWR_EnableDEEPSTOP2();
+#elif defined(CONFIG_SOC_SERIES_STM32WBAX)
+	LL_DBGMCU_EnableDBGStopMode();
+	LL_DBGMCU_EnableDBGStandbyMode();
 #elif defined(CONFIG_SOC_SERIES_STM32MP13X)
 	LL_DBGMCU_EnableDebugInLowPowerMode();
 #else /* all other parts */
@@ -100,6 +103,9 @@ static int st_stm32_common_config(void)
 	LL_DBGMCU_DisableDebugInStopMode();
 #elif defined(CONFIG_SOC_SERIES_STM32WB0X)
 	LL_PWR_DisableDEEPSTOP2();
+#elif defined(CONFIG_SOC_SERIES_STM32WBAX)
+	LL_DBGMCU_DisableDBGStopMode();
+	LL_DBGMCU_DisableDBGStandbyMode();
 #elif defined(CONFIG_SOC_SERIES_STM32MP13X)
 	LL_DBGMCU_DisableDebugInLowPowerMode();
 #else /* all other parts */

--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -245,11 +245,8 @@ void stm32_power_init(void)
 	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_PWR);
 
 #ifdef CONFIG_DEBUG
-	LL_DBGMCU_EnableDBGStandbyMode();
 	LL_DBGMCU_APB7_GRP1_FreezePeriph(LL_DBGMCU_APB7_GRP1_RTC_STOP);
 	LL_DBGMCU_APB7_GRP1_FreezePeriph(LL_DBGMCU_APB7_GRP1_LPTIM1_STOP);
-#else
-	LL_DBGMCU_DisableDBGStandbyMode();
 #endif
 
 	/* Enable SRAM full retention */


### PR DESCRIPTION
Perform call to `LL_DBGMCU_{Dis,En}ableDBGStandbyMode()` for STM32WBA series in the common code, as done with other series. While at it, also add missing call to `LL_DBGMCU_{Dis,En}ableDBGStopMode()`.

This does change the dependency from `CONFIG_DEBUG` to `CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP` but the latter is `default y if CONFIG_DEBUG` so this should not bring any behavior change(?)