### PR TITLE
am243x_evm/am2434/r50_0: configure timer clock source

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -25,6 +25,7 @@
 	aliases {
 		led0 = &ld26;
 		adc0 = &main_adc0;
+		system-timer = &main_timer8;
 	};
 
 	leds: leds {

--- a/soc/ti/k3/am6x/common/ctrl_partitions.c
+++ b/soc/ti/k3/am6x/common/ctrl_partitions.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/arch/common/sys_io.h>
@@ -22,8 +23,14 @@
 #elif defined CONFIG_SOC_AM6234_M4 | defined CONFIG_SOC_AM6232_M4
 #define WKUP_PADCFG_BASE (0x4080000)
 #elif defined CONFIG_SOC_AM2434_R5F0_0
-#define MCU_PADCFG_BASE  (0x4080000)
-#define MAIN_PADCFG_BASE (0xf0000)
+#define DT_TIMER_INST                                                                              \
+	((DT_REG_ADDR(DT_ALIAS(system_timer)) - DT_REG_ADDR(DT_NODELABEL(main_timer0))) / 0x10000)
+#define MCU_PADCFG_BASE            (0x4080000)
+#define MAIN_PADCFG_BASE           (0xf0000)
+#define MAIN_MMR_BASE              (0x43000000)
+#define MAIN_MMR_TIMER_CLKSEL_PART CTRL_PARTITION(MAIN_MMR_BASE, 2)
+#define MAIN_MMR_TIMER_CLKSEL_VAL  (0x0) /* HFOSC0_CLKOUT */
+#define MAIN_MMR_TIMER_CLKSEL      (MAIN_MMR_BASE + 0x81B0 + (DT_TIMER_INST * 4))
 #endif
 
 static const uintptr_t ctrl_partitions[] = {
@@ -41,16 +48,39 @@ static const uintptr_t ctrl_partitions[] = {
 #endif
 };
 
+void k3_write_mmr(uint32_t value, mm_reg_t base_addr)
+{
+#ifdef DEVICE_MMIO_IS_IN_RAM
+	device_map(&base_addr, base_addr, sizeof(base_addr), K_MEM_CACHE_NONE);
+#endif
+
+	sys_write32(value, base_addr);
+}
+
+void k3_unlock_partition(mm_reg_t base_addr)
+{
+	k3_write_mmr(KICK0_UNLOCK_VAL, base_addr + KICK0_OFFSET);
+	k3_write_mmr(KICK1_UNLOCK_VAL, base_addr + KICK1_OFFSET);
+}
+
+void k3_lock_partition(mm_reg_t base_addr)
+{
+	k3_write_mmr(KICK_LOCK_VAL, base_addr + KICK0_OFFSET);
+	k3_write_mmr(KICK_LOCK_VAL, base_addr + KICK1_OFFSET);
+}
+
 void k3_unlock_all_ctrl_partitions(void)
 {
 	ARRAY_FOR_EACH(ctrl_partitions, i) {
-		mm_reg_t base_addr = ctrl_partitions[i];
-
-#ifdef DEVICE_MMIO_IS_IN_RAM
-		device_map(&base_addr, base_addr, sizeof(base_addr), K_MEM_CACHE_NONE);
-#endif
-
-		sys_write32(KICK0_UNLOCK_VAL, base_addr + KICK0_OFFSET);
-		sys_write32(KICK1_UNLOCK_VAL, base_addr + KICK1_OFFSET);
+		k3_unlock_partition(ctrl_partitions[i]);
 	}
+
+/* Currently setting clock parent is not possible via standard clock control API,
+ * hence do this for now
+ */
+#ifdef MAIN_MMR_TIMER_CLKSEL
+	k3_unlock_partition(MAIN_MMR_TIMER_CLKSEL_PART);
+	k3_write_mmr(MAIN_MMR_TIMER_CLKSEL_VAL, MAIN_MMR_TIMER_CLKSEL);
+	k3_lock_partition(MAIN_MMR_TIMER_CLKSEL_PART);
+#endif
 }


### PR DESCRIPTION
Write the protected MMR region during early init to select the correct clock source for the specified timer. To get the correct offset, recognize the timer currently in use via the DT alias system-timer. Then we do some soc-specific calculations to configure this source. This can be removed once there are clock control APIs to set parent sources in place.