### PR TITLE
include: led_strip: add doxygen docs for device-specific LED strip API extensions

### DIFF
--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -22,6 +22,11 @@
  * @defgroup led_strip_interface LED Strip
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup led_strip_interface_ext Device-specific LED Strip API extensions
+ * @{
+ * @}
+ *
  */
 
 #include <errno.h>

--- a/include/zephyr/drivers/led_strip/tlc5971.h
+++ b/include/zephyr/drivers/led_strip/tlc5971.h
@@ -4,8 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended LED Strip API of TLC5971 LED strip controller
+ * @ingroup tlc5971_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_LED_STRIP_TLC5971_H_
 #define ZEPHYR_INCLUDE_DRIVERS_LED_STRIP_TLC5971_H_
+
+/**
+ * @brief Texas Instruments TLC5971 (and compatible) LED strip controllers
+ * @defgroup tlc5971_interface TLC5971
+ * @ingroup led_strip_interface_ext
+ * @{
+ */
+
+#include <zephyr/drivers/led_strip.h>
 
 /**
  * @brief Maximum value for global brightness control, i.e 100% brightness
@@ -13,15 +28,24 @@
 #define TLC5971_GLOBAL_BRIGHTNESS_CONTROL_MAX 127
 
 /**
- * @brief Set the global brightness control levels for the tlc5971 strip.
+ * @brief Set the global brightness control (BC) levels of a TLC5971 strip.
  *
- * change will take effect on next update of the led strip
+ * The TLC5971 has a 7-bit global brightness control (BC) for each color group (Red, Green, Blue).
+ * This function allows setting these values.
+ *
+ * The brightness value of each channel of @p pixel (r, g, b) maps to the corresponding global
+ * brightness control register (BCR, BCG, BCB) and must be lower than or equal to
+ * @ref TLC5971_GLOBAL_BRIGHTNESS_CONTROL_MAX.
+ *
+ * The change takes effect on the next update of the LED strip.
  *
  * @param dev LED strip device
- * @param pixel global brightness values for RGB channels
-
+ * @param pixel Global brightness values for RGB channels
+ *
  * @return 0 on success, negative on error
  */
 int tlc5971_set_global_brightness(const struct device *dev, struct led_rgb pixel);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_LED_STRIP_TLC5971_H_ */


### PR DESCRIPTION
Adds doxygen documentation for the extended API of the TLC5971 driver.

https://builds.zephyrproject.io/zephyr/pr/101284/docs/doxygen/html/group__led__strip__interface__ext.html
https://builds.zephyrproject.io/zephyr/pr/101284/api-coverage/zephyr/drivers/led_strip/index.html