### PR TITLE
boards: doc: Update information regarding memory sizes for stm32g474r…

### DIFF
--- a/boards/st/nucleo_g474re/doc/index.rst
+++ b/boards/st/nucleo_g474re/doc/index.rst
@@ -51,8 +51,8 @@ The STM32G474RE SoC provides the following hardware IPs:
 - Up to 86 fast I/Os, most 5 V-tolerant
 - Memories
 
-  - Up to 128 KB single bank Flash, proprietary code readout protection
-  - Up to 22 KB of SRAM including 16 KB with hardware parity check
+  - Up to 512 KB single bank Flash, proprietary code readout protection
+  - Up to 128 KB of SRAM including 32 KB with hardware parity check
 
 - Rich analog peripherals (independent supply)
 


### PR DESCRIPTION
…e MCU

According to STM's website:
https://www.st.com/en/microcontrollers-microprocessors/stm32g474re.html

the stm32g474re has larger FLASH and SRAM sizes than stated in the Zephyr's documentation.