### PR TITLE
drivers: sensor: adi: adxl345: Unit tests for conversion function

### DIFF
--- a/drivers/sensor/adi/adxl345/CMakeLists.txt
+++ b/drivers/sensor/adi/adxl345/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 zephyr_library()
 
-zephyr_library_sources(adxl345.c)
+zephyr_library_sources(adxl345.c adxl345_convert.c)
 zephyr_library_sources_ifdef(CONFIG_ADXL345_TRIGGER adxl345_trigger.c)
 zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API adxl345_rtio.c adxl345_decoder.c)
 zephyr_library_sources_ifdef(CONFIG_ADXL345_STREAM adxl345_stream.c adxl345_decoder.c)

--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -18,6 +18,8 @@
 
 LOG_MODULE_REGISTER(ADXL345, CONFIG_SENSOR_LOG_LEVEL);
 
+extern void adxl345_accel_convert(struct sensor_value *val, int16_t sample, uint8_t selected_range);
+
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 static bool adxl345_bus_is_ready_i2c(const union adxl345_bus *bus)
 {
@@ -374,23 +376,6 @@ int adxl345_read_sample(const struct device *dev,
 	return 0;
 }
 
-static void adxl345_accel_convert(struct sensor_value *val, int16_t sample,
-				  uint8_t selected_range)
-{
-	const int32_t sensitivity[] = {
-		[ADXL345_RANGE_2G] = INT32_C(SENSOR_G / 256),
-		[ADXL345_RANGE_4G] = INT32_C(SENSOR_G / 128),
-		[ADXL345_RANGE_8G] = INT32_C(SENSOR_G / 64),
-		[ADXL345_RANGE_16G] = INT32_C(SENSOR_G / 32),
-	};
-
-	if (sample & BIT(9)) {
-		sample |= ADXL345_COMPLEMENT;
-	}
-
-	val->val1 = (sample * sensitivity[selected_range]) / 1000000;
-	val->val2 = (sample * sensitivity[selected_range]) % 1000000;
-}
 
 static int adxl345_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/dt-bindings/sensor/adxl345.h>
 
+#include "adxl345_features.h"
 #ifdef CONFIG_ADXL345_STREAM
 #include <zephyr/rtio/rtio.h>
 #endif /* CONFIG_ADXL345_STREAM */
@@ -51,16 +52,11 @@
 
 #define ADXL345_PART_ID            0xe5
 
-#define ADXL345_RANGE_2G           0x0
-#define ADXL345_RANGE_4G           0x1
-#define ADXL345_RANGE_8G           0x2
-#define ADXL345_RANGE_16G          0x3
 #define ADXL345_RATE_25HZ          0x8
 #define ADXL345_ENABLE_MEASURE_BIT (1 << 3)
 #define ADXL345_FIFO_STREAM_MODE   (1 << 7)
 #define ADXL345_FIFO_COUNT_MASK    0x3f
 #define ADXL345_COMPLEMENT_MASK(x) GENMASK(15, (x))
-#define ADXL345_COMPLEMENT         0xfc00
 
 #define ADXL345_MAX_FIFO_SIZE      32
 

--- a/drivers/sensor/adi/adxl345/adxl345_convert.c
+++ b/drivers/sensor/adi/adxl345/adxl345_convert.c
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+
+#include <zephyr/drivers/sensor.h>
+
+#include "adxl345_features.h"
+
+void adxl345_accel_convert(struct sensor_value *val, int16_t sample, uint8_t selected_range)
+{
+	const int32_t sensitivity[] = {
+		[ADXL345_RANGE_2G] = INT32_C(SENSOR_G / 256),
+		[ADXL345_RANGE_4G] = INT32_C(SENSOR_G / 128),
+		[ADXL345_RANGE_8G] = INT32_C(SENSOR_G / 64),
+		[ADXL345_RANGE_16G] = INT32_C(SENSOR_G / 32),
+	};
+
+	if (sample & BIT(9)) {
+		sample |= ADXL345_COMPLEMENT;
+	}
+
+	val->val1 = (sample * sensitivity[selected_range]) / 1000000;
+	val->val2 = (sample * sensitivity[selected_range]) % 1000000;
+}

--- a/drivers/sensor/adi/adxl345/adxl345_features.h
+++ b/drivers/sensor/adi/adxl345/adxl345_features.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_FEATURES_H_
+#define ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_FEATURES_H_
+
+#define ADXL345_RANGE_2G  0x0
+#define ADXL345_RANGE_4G  0x1
+#define ADXL345_RANGE_8G  0x2
+#define ADXL345_RANGE_16G 0x3
+
+#define ADXL345_COMPLEMENT 0xfc00
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_FEATURES_H_ */

--- a/tests/drivers/sensor/adxl345/CMakeLists.txt
+++ b/tests/drivers/sensor/adxl345/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Set minimum CMake version
+cmake_minimum_required(VERSION 3.20.0)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(test_adxl345_accel_convert)
+
+target_sources(testbinary
+    PRIVATE
+        src/main.c
+        $ENV{ZEPHYR_BASE}/drivers/sensor/adi/adxl345/adxl345_convert.c
+)
+
+# make sure we include prepared sensor.h and have access to adxl345_features.h
+target_include_directories(testbinary
+    BEFORE
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        $ENV{ZEPHYR_BASE}/drivers/sensor/adi/adxl345
+)

--- a/tests/drivers/sensor/adxl345/include/zephyr/drivers/sensor.h
+++ b/tests/drivers/sensor/adxl345/include/zephyr/drivers/sensor.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_STRIPPED_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_STRIPPED_
+
+#include <stdint.h>
+#include <zephyr/sys/util_macro.h>
+
+#ifndef SENSOR_G
+#define SENSOR_G 9806650LL
+#endif
+
+/* Define struct sensor_value here to avoid including include/zepyhr/drivers/sensor.h */
+struct sensor_value {
+	/** Integer part of the value. */
+	int32_t val1;
+	/** Fractional part of the value (in one-millionth parts). */
+	int32_t val2;
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_STRIPPED_ */

--- a/tests/drivers/sensor/adxl345/prj.conf
+++ b/tests/drivers/sensor/adxl345/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/sensor/adxl345/src/main.c
+++ b/tests/drivers/sensor/adxl345/src/main.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+/*
+ * Include the stripped sensor.h from the include directory of the test folder!
+ * The directory /zephyr/tests/drivers/sensor/adxl345 is injected in CMakeLists.txt
+ */
+#include <zephyr/drivers/sensor.h>
+
+#include "adxl345_features.h"
+
+extern void adxl345_accel_convert(struct sensor_value *val, int16_t sample, uint8_t selected_range);
+
+ZTEST(adxl345_accel_convert, test_convert_10bit_right_justified_2g_mode)
+{
+	struct sensor_value data[3] = {0};
+	int16_t samples[3] = {0, 100, -100};
+
+	/* Convert and check x-axis. */
+	adxl345_accel_convert(&data[0], samples[0], ADXL345_RANGE_2G);
+	zassert_equal(data[0].val1, 0, "expected 0, was %d", data[0].val1);
+	zassert_equal(data[0].val2, 0, "expected 0, was %d", data[0].val2);
+
+	/* Convert and check y-axis. */
+	adxl345_accel_convert(&data[1], samples[1], ADXL345_RANGE_2G);
+	zassert_equal(data[1].val1, 3, "expected 3, was %d", data[1].val1);
+	zassert_equal(data[1].val2, 830700, "expected 830700, was %d", data[1].val2);
+
+	/* Convert and check z-axis. */
+	adxl345_accel_convert(&data[2], samples[2], ADXL345_RANGE_2G);
+	zassert_equal(data[2].val1, -3, "expected -3, was %d", data[2].val1);
+	zassert_equal(data[2].val2, -830700, "expected -830700, was %d", data[2].val2);
+}
+
+ZTEST(adxl345_accel_convert, test_convert_10bit_right_justified_4g_mode)
+{
+	struct sensor_value data[3] = {0};
+	int16_t samples[3] = {0, 100, -100};
+
+	/* Convert and check x-axis. */
+	adxl345_accel_convert(&data[0], samples[0], ADXL345_RANGE_4G);
+	zassert_equal(data[0].val1, 0, "expected 0, was %d", data[0].val1);
+	zassert_equal(data[0].val2, 0, "expected 0, was %d", data[0].val2);
+
+	/* Convert and check y-axis. */
+	adxl345_accel_convert(&data[1], samples[1], ADXL345_RANGE_4G);
+	zassert_equal(data[1].val1, 7, "expected 7, was %d", data[1].val1);
+	zassert_equal(data[1].val2, 661400, "expected 661400, was %d", data[1].val2);
+
+	/* Convert and check z-axis. */
+	adxl345_accel_convert(&data[2], samples[2], ADXL345_RANGE_4G);
+	zassert_equal(data[2].val1, -7, "expected -7, was %d", data[2].val1);
+	zassert_equal(data[2].val2, -661400, "expected -661400, was %d", data[2].val2);
+}
+
+ZTEST_SUITE(adxl345_accel_convert, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/sensor/adxl345/testcase.yaml
+++ b/tests/drivers/sensor/adxl345/testcase.yaml
@@ -1,0 +1,9 @@
+tests:
+  drivers.sensor.adxl345:
+    tags:
+      - drivers
+      - sensor
+    type: unit
+    extra_args:
+      # add -g to allow debugging in vscode
+      - EXTRA_CPPFLAGS="-g"


### PR DESCRIPTION
This PR adds two unit tests with the required mocks to test the conversion function in the adxl345 for right justified data, in 2G and 4G mode.

To run this test invoke twister from zephyr root:
"twister -T zephyr/drivers/sensor/adi/adxl345/"