### PR TITLE
twister, west: testcase extra_conf_files arg to EXTRA_CONF_FILE

### DIFF
--- a/samples/boards/nordic/clock_control/prj.conf
+++ b/samples/boards/nordic/clock_control/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -52,6 +52,7 @@ class TwisterConfigParser:
         "type": {"type": "str", "default": "integration"},
         "extra_args": {"type": "list"},
         "extra_configs": {"type": "list"},
+        "conf_files": {"type": "list", "default": []},
         "extra_conf_files": {"type": "list", "default": []},
         "extra_overlay_confs": {"type": "list", "default": []},
         "extra_dtc_overlay_files": {"type": "list", "default": []},
@@ -204,16 +205,21 @@ class TwisterConfigParser:
             else:
                 d[k] = v
 
-        # Compile conf files in to a single list. The order to apply them is:
-        #  (1) CONF_FILEs extracted from common['extra_args']
-        #  (2) common['extra_conf_files']
-        #  (3) CONF_FILES extracted from scenarios[name]['extra_args']
-        #  (4) scenarios[name]['extra_conf_files']
+        # Compile extra conf files intended for EXTRA_CONF_FILE into a single list.
+        # The order to apply them is:
+        #  (1) common['extra_conf_files']
+        #  (2) scenarios[name]['extra_conf_files']
         d["extra_conf_files"] = \
-            extracted_common.get("CONF_FILE", []) + \
             self.common.get("extra_conf_files", []) + \
-            extracted_testsuite.get("CONF_FILE", []) + \
             self.scenarios[name].get("extra_conf_files", [])
+
+        # Compile conf files intended for CONF_FILE into a single list.
+        # The order to apply them is:
+        #  (1) CONF_FILEs extracted from common['extra_args']
+        #  (2) CONF_FILES extracted from scenarios[name]['extra_args']
+        d["conf_files"] = \
+            extracted_common.get("CONF_FILE", []) + \
+            extracted_testsuite.get("CONF_FILE", [])
 
         # Repeat the above for overlay confs and DTC overlay files
         d["extra_overlay_confs"] = \

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1661,7 +1661,7 @@ class ProjectBuilder(FilterBuilder):
         sys.stdout.flush()
 
     @staticmethod
-    def cmake_assemble_args(extra_args, handler, extra_conf_files, extra_overlay_confs,
+    def cmake_assemble_args(extra_args, handler, conf_files, extra_conf_files, extra_overlay_confs,
                             extra_dtc_overlay_files, cmake_extra_args,
                             build_dir):
         # Retain quotes around config options
@@ -1673,8 +1673,11 @@ class ProjectBuilder(FilterBuilder):
         if handler.ready:
             args.extend(handler.args)
 
+        if conf_files:
+            args.append(f"CONF_FILE=\"{';'.join(conf_files)}\"")
+
         if extra_conf_files:
-            args.append(f"CONF_FILE=\"{';'.join(extra_conf_files)}\"")
+            args.append(f"EXTRA_CONF_FILE=\"{';'.join(extra_conf_files)}\"")
 
         if extra_dtc_overlay_files:
             args.append(f"DTC_OVERLAY_FILE=\"{';'.join(extra_dtc_overlay_files)}\"")
@@ -1721,6 +1724,7 @@ class ProjectBuilder(FilterBuilder):
         args = self.cmake_assemble_args(
             args,
             self.instance.handler,
+            self.testsuite.conf_files,
             self.testsuite.extra_conf_files,
             self.testsuite.extra_overlay_confs,
             self.testsuite.extra_dtc_overlay_files,

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -25,6 +25,7 @@ from twisterlib.harness import Pytest
 from twisterlib.runner import CMake, ExecutionCounter, FilterBuilder, ProjectBuilder, TwisterRunner
 from twisterlib.statuses import TwisterStatus
 
+# pylint: disable=no-name-in-module
 from . import ZEPHYR_BASE
 
 
@@ -103,6 +104,7 @@ def test_projectbuilder_cmake_assemble_args_single(m):
         ["basearg1", "CONFIG_t=\"test\"", "SNIPPET_t=\"test\""],
         handler,
         ["a.conf;b.conf", "c.conf"],
+        ["d.conf;e.conf", "f.conf"],
         ["extra_overlay.conf"],
         ["x.overlay;y.overlay", "z.overlay"],
         ["cmake1=foo", "cmake2=bar"],
@@ -113,6 +115,7 @@ def test_projectbuilder_cmake_assemble_args_single(m):
         "-Dbasearg1", "-DSNIPPET_t=test",
         "-Dhandler_arg1", "-Dhandler_arg2",
         "-DCONF_FILE=a.conf;b.conf;c.conf",
+        "-DEXTRA_CONF_FILE=d.conf;e.conf;f.conf",
         "-DDTC_OVERLAY_FILE=x.overlay;y.overlay;z.overlay",
         "-DOVERLAY_CONFIG=extra_overlay.conf "
         "/builddir/twister/testsuite_extra.conf",
@@ -2158,6 +2161,7 @@ def test_projectbuilder_report_out(
 def test_projectbuilder_cmake_assemble_args():
     extra_args = ['CONFIG_FOO=y', 'DUMMY_EXTRA="yes"']
     handler = mock.Mock(ready=True, args=['dummy_handler'])
+    conf_files = ['file1.conf', 'file2.conf']
     extra_conf_files = ['extrafile1.conf', 'extrafile2.conf']
     extra_overlay_confs = ['extra_overlay_conf']
     extra_dtc_overlay_files = ['overlay1.dtc', 'overlay2.dtc']
@@ -2166,6 +2170,7 @@ def test_projectbuilder_cmake_assemble_args():
 
     with mock.patch('os.path.exists', return_value=True):
         results = ProjectBuilder.cmake_assemble_args(extra_args, handler,
+                                                     conf_files,
                                                      extra_conf_files,
                                                      extra_overlay_confs,
                                                      extra_dtc_overlay_files,
@@ -2178,7 +2183,8 @@ def test_projectbuilder_cmake_assemble_args():
         '-DCMAKE2=n',
         '-DDUMMY_EXTRA=yes',
         '-Ddummy_handler',
-        '-DCONF_FILE=extrafile1.conf;extrafile2.conf',
+        '-DCONF_FILE=file1.conf;file2.conf',
+        '-DEXTRA_CONF_FILE=extrafile1.conf;extrafile2.conf',
         '-DDTC_OVERLAY_FILE=overlay1.dtc;overlay2.dtc',
         f'-DOVERLAY_CONFIG=extra_overlay_conf ' \
         f'{os.path.join("build", "dir", "twister", "testsuite_extra.conf")}'
@@ -2196,9 +2202,10 @@ def test_projectbuilder_cmake():
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
     pb.build_dir = 'build_dir'
     pb.testsuite.extra_args = ['some', 'args']
-    pb.testsuite.extra_conf_files = ['some', 'files1']
-    pb.testsuite.extra_overlay_confs = ['some', 'files2']
-    pb.testsuite.extra_dtc_overlay_files = ['some', 'files3']
+    pb.testsuite.conf_files = ['some', 'files1']
+    pb.testsuite.extra_conf_files = ['some', 'files2']
+    pb.testsuite.extra_overlay_confs = ['some', 'files3']
+    pb.testsuite.extra_dtc_overlay_files = ['some', 'files4']
     pb.options.extra_args = ['other', 'args']
     pb.cmake_assemble_args = mock.Mock(return_value=['dummy'])
     cmake_res_mock = mock.Mock()
@@ -2210,6 +2217,7 @@ def test_projectbuilder_cmake():
     pb.cmake_assemble_args.assert_called_once_with(
         pb.testsuite.extra_args,
         pb.instance.handler,
+        pb.testsuite.conf_files,
         pb.testsuite.extra_conf_files,
         pb.testsuite.extra_overlay_confs,
         pb.testsuite.extra_dtc_overlay_files,

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -15,6 +15,7 @@ import scl
 from twisterlib.error import ConfigurationError
 from twisterlib.testplan import TwisterConfigParser
 
+# pylint: disable=no-name-in-module
 from . import ZEPHYR_BASE
 
 
@@ -75,7 +76,10 @@ def test_testsuite_config_files():
 
     # Check that all conf files have been assembled in the correct order
     assert ";".join(scenario["extra_conf_files"]) == \
-        "conf1;conf2;conf3;conf4;conf5;conf6;conf7;conf8"
+        "conf3;conf4;conf7;conf8"
+
+    assert ";".join(scenario["conf_files"]) == \
+        "conf1;conf2;conf5;conf6"
 
     # Check that all DTC overlay files have been assembled in the correct order
     assert ";".join(scenario["extra_dtc_overlay_files"]) == \

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -418,7 +418,7 @@ class Build(Forceable):
         if found_test_metadata:
             args = []
             if extra_conf_files:
-                args.append(f"CONF_FILE=\"{';'.join(extra_conf_files)}\"")
+                args.append(f"EXTRA_CONF_FILE=\"{';'.join(extra_conf_files)}\"")
 
             if extra_dtc_overlay_files:
                 args.append(f"DTC_OVERLAY_FILE=\"{';'.join(extra_dtc_overlay_files)}\"")

--- a/tests/drivers/build_all/modem/prj.conf
+++ b/tests/drivers/build_all/modem/prj.conf
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
The extra_conf_files arg in testcase.yaml was being improperly assigned to the CONF_FILE CMake arg, which caused
configuration_files.cmake to ignore soc and board Kconfig overlays. Change to use EXTRA_CONF_FILE CMake arg.

Fixes #101226 