### PR TITLE
include: Bluetooth: Host: add doxygen docs for GAP timer macros

### DIFF
--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -36,30 +36,52 @@ extern "C" {
  */
 
 /**
- * @name Defined GAP timers
+ * @name Defined GAP timers.
+ * As per Bluetooth Core Specification 6.2, Vol 3, Part C, Appendix A.
  * @{
  */
-#define BT_GAP_SCAN_FAST_INTERVAL_MIN           0x0030  /* 30 ms    */
-#define BT_GAP_SCAN_FAST_INTERVAL               0x0060  /* 60 ms    */
-#define BT_GAP_SCAN_FAST_WINDOW                 0x0030  /* 30 ms    */
-#define BT_GAP_SCAN_SLOW_INTERVAL_1             0x0800  /* 1.28 s   */
-#define BT_GAP_SCAN_SLOW_WINDOW_1               0x0012  /* 11.25 ms */
-#define BT_GAP_SCAN_SLOW_INTERVAL_2             0x1000  /* 2.56 s   */
-#define BT_GAP_SCAN_SLOW_WINDOW_2               0x0012  /* 11.25 ms */
-#define BT_GAP_ADV_FAST_INT_MIN_1               0x0030  /* 30 ms    */
-#define BT_GAP_ADV_FAST_INT_MAX_1               0x0060  /* 60 ms    */
-#define BT_GAP_ADV_FAST_INT_MIN_2               0x00a0  /* 100 ms   */
-#define BT_GAP_ADV_FAST_INT_MAX_2               0x00f0  /* 150 ms   */
-#define BT_GAP_ADV_SLOW_INT_MIN                 0x0640  /* 1 s      */
-#define BT_GAP_ADV_SLOW_INT_MAX                 0x0780  /* 1.2 s    */
-#define BT_GAP_PER_ADV_FAST_INT_MIN_1           0x0018  /* 30 ms    */
-#define BT_GAP_PER_ADV_FAST_INT_MAX_1           0x0030  /* 60 ms    */
-#define BT_GAP_PER_ADV_FAST_INT_MIN_2           0x0050  /* 100 ms   */
-#define BT_GAP_PER_ADV_FAST_INT_MAX_2           0x0078  /* 150 ms   */
-#define BT_GAP_PER_ADV_SLOW_INT_MIN             0x0320  /* 1 s      */
-#define BT_GAP_PER_ADV_SLOW_INT_MAX             0x03C0  /* 1.2 s    */
-#define BT_GAP_INIT_CONN_INT_MIN                0x0018  /* 30 ms    */
-#define BT_GAP_INIT_CONN_INT_MAX                0x0028  /* 50 ms    */
+/** Recommended minimum scan interval for fast scanning. 30 ms. */
+#define BT_GAP_SCAN_FAST_INTERVAL_MIN           0x0030
+/** Recommended maximum scan interval for fast scanning. 60 ms. */
+#define BT_GAP_SCAN_FAST_INTERVAL               0x0060
+/** Recommended scan window for fast scanning. 30 ms. */
+#define BT_GAP_SCAN_FAST_WINDOW                 0x0030
+/** Recommended scan interval for slow scanning (mode 1). 1.28 s. */
+#define BT_GAP_SCAN_SLOW_INTERVAL_1             0x0800
+/** Recommended scan window for slow scanning (mode 1). 11.25 ms. */
+#define BT_GAP_SCAN_SLOW_WINDOW_1               0x0012
+/** Recommended scan interval for slow scanning (mode 2). 2.56 s. */
+#define BT_GAP_SCAN_SLOW_INTERVAL_2             0x1000
+/** Recommended scan window for slow scanning (mode 2). 11.25 ms. */
+#define BT_GAP_SCAN_SLOW_WINDOW_2               0x0012
+/** Recommended minimum advertising interval for fast advertising (mode 1). 30 ms. */
+#define BT_GAP_ADV_FAST_INT_MIN_1               0x0030
+/** Recommended maximum advertising interval for fast advertising (mode 1). 60 ms. */
+#define BT_GAP_ADV_FAST_INT_MAX_1               0x0060
+/** Recommended minimum advertising interval for fast advertising (mode 2). 100 ms. */
+#define BT_GAP_ADV_FAST_INT_MIN_2               0x00a0
+/** Recommended maximum advertising interval for fast advertising (mode 2). 150 ms. */
+#define BT_GAP_ADV_FAST_INT_MAX_2               0x00f0
+/** Recommended minimum advertising interval for slow advertising. 1 s. */
+#define BT_GAP_ADV_SLOW_INT_MIN                 0x0640
+/** Recommended maximum advertising interval for slow advertising. 1.2 s. */
+#define BT_GAP_ADV_SLOW_INT_MAX                 0x0780
+/** Recommended minimum periodic advertising interval for fast advertising (mode 1). 30 ms. */
+#define BT_GAP_PER_ADV_FAST_INT_MIN_1           0x0018
+/** Recommended maximum periodic advertising interval for fast advertising (mode 1). 60 ms. */
+#define BT_GAP_PER_ADV_FAST_INT_MAX_1           0x0030
+/** Recommended minimum periodic advertising interval for fast advertising (mode 2). 100 ms. */
+#define BT_GAP_PER_ADV_FAST_INT_MIN_2           0x0050
+/** Recommended maximum periodic advertising interval for fast advertising (mode 2). 150 ms. */
+#define BT_GAP_PER_ADV_FAST_INT_MAX_2           0x0078
+/** Recommended minimum periodic advertising interval for slow advertising. 1 s. */
+#define BT_GAP_PER_ADV_SLOW_INT_MIN             0x0320
+/** Recommended maximum periodic advertising interval for slow advertising. 1.2 s. */
+#define BT_GAP_PER_ADV_SLOW_INT_MAX             0x03C0
+/** Recommended minimum initial connection interval. 30 ms. */
+#define BT_GAP_INIT_CONN_INT_MIN                0x0018
+/** Recommended maximum initial connection interval. 50 ms. */
+#define BT_GAP_INIT_CONN_INT_MAX                0x0028
 /**
  * @}
  */


### PR DESCRIPTION
This adds proper doxygen documentation for the GAP timers macros.

https://builds.zephyrproject.io/zephyr/pr/101299/docs/doxygen/html/gap_8h.html#define-members-1