### PR TITLE
samples: drivers: display: Fix nonsense alignment default

### DIFF
--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -9,7 +9,8 @@ source "Kconfig.zephyr"
 
 config SAMPLE_BUFFER_ADDR_ALIGN
 	int "The display buffer address alignment"
-	default 1
+	default 8 if 64BIT
+	default 4
 
 config SAMPLE_PITCH_ALIGN
 	int "The update area pitch alignment"


### PR DESCRIPTION
A alignment of 1 is also called 'unaligned'.
This default causes exceptions on CPUs that use different paths/instructions for unaligned and aligned access (like a lot of RISCV) and compile to expect a aligned buffer out of the allocate.
Use a sane default that doesnt guarantee a store/access exception.