### PR TITLE
doc: nxp: add link to Board Support Status

### DIFF
--- a/boards/nxp/common/board-footer.rst.inc
+++ b/boards/nxp/common/board-footer.rst.inc
@@ -1,10 +1,14 @@
 Support Resources for Zephyr
 ============================
+- `NXP Board Support Status`_
 - `NXP Zephyr Downstream Software Development Kit`_
 - `MCUXpresso for VS Code`_, `wiki`_ documentation and `Zephyr lab guides`_
 - `NXP Zephyr Knowledge Hub`_
 - `NXP’s Zephyr landing page`_  (including training resources)
 - `NXP Support Community forum for Zephyr`_
+
+.. _NXP Board Support Status:
+   https://github.com/nxp-zephyr/nxp-zsdk/blob/main/doc/releases/Board-Support-Status.md
 
 .. _NXP Zephyr Downstream Software Development Kit:
    https://github.com/nxp-zephyr/nxp-zsdk


### PR DESCRIPTION
Adds to common footer for all NXP board doc pages.