### PR TITLE
soc/ite: it8xxx2: Add SOC_IT8XXX2_RAM_CODE_NOINLINE option

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -245,6 +245,15 @@ config SOC_IT8XXX2_ZEPHYR_IN_RAM
 	help
 	  Place zephyr handling code in ILM. This can significantly improve performance.
 
+config SOC_IT8XXX2_RAM_CODE_NOINLINE
+	bool "Force RAM code functions to be non-inlined"
+	depends on LTO
+	help
+	  When enabled, functions marked with __soc_ram_code will use the 'noinline'
+	  attribute to ensure they are not inlined by the compiler.
+	  This guarantees the function body stays in the RAM code section rather
+	  than being merged into callers.
+
 config SOC_IT8XXX2_SHA256_HW_ACCELERATE
 	bool "HW SHA256 calculation"
 	help

--- a/soc/ite/ec/it8xxx2/ilm.h
+++ b/soc/ite/ec/it8xxx2/ilm.h
@@ -7,8 +7,11 @@
 #include <stdbool.h>
 
 /* Places code in the section that gets mapped into ILM */
+#ifdef CONFIG_SOC_IT8XXX2_RAM_CODE_NOINLINE
+#define __soc_ram_code __attribute__((noinline)) __attribute__((section(".__ram_code")))
+#else
 #define __soc_ram_code __attribute__((section(".__ram_code")))
-
+#endif
 
 #ifndef _ASMLANGUAGE
 bool it8xxx2_is_ilm_configured(void);


### PR DESCRIPTION
Add the SOC_IT8XXX2_RAM_CODE_NOINLINE Kconfig option to prevent functions marked with __soc_ram_code from being inlined when LTO is enabled.

This ensures RAM code functions remain in the RAM section instead of being merged into callers by the compiler.