### PR TITLE
dts: intel_ish: Remove unnecessary #interrupt-cells from /soc node

### DIFF
--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -77,7 +77,6 @@
 	soc: soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		#interrupt-cells = <3>;
 		compatible = "simple-bus";
 		interrupt-parent = <&intc>;
 		interrupts = <6 IRQ_TYPE_FIXED_LEVEL_HIGH 1


### PR DESCRIPTION
The /soc node is a simple-bus node and not an interrupt provider. Leaving the #interrupt-cells property produces misleading Device Tree build warnings:
        _Warning (interrupt_provider): /soc: '#interrupt-cells' found, but node is
        not an interrupt provider <stdout>:  Warning (interrupt_map): Failed
        prerequisite 'interrupt_provider'._