### PR TITLE
drivers/i2c: it8xxx2: Add I2C_ENHANCE_RAM_CODE for critical functions

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -59,6 +59,12 @@ config I2C_CQ_MODE_MAX_PAYLOAD_SIZE
 	  This is the command queue mode payload size which size
 	  up to 2k bytes.
 
+config I2C_CODE_IN_RAM
+	bool "Ram code functions"
+	help
+	  Place critical functions into RAM section to ensure they run with
+	  minimal latency.
+
 endif # I2C_ITE_ENHANCE
 
 if I2C_TARGET

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -14,6 +14,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 #include <errno.h>
+#include <ilm.h>
 #include <soc.h>
 #include <soc_dt.h>
 #include <zephyr/sys/util.h>
@@ -22,6 +23,12 @@
 LOG_MODULE_REGISTER(i2c_ite_enhance, CONFIG_I2C_LOG_LEVEL);
 #include "i2c_bitbang.h"
 #include "i2c-priv.h"
+
+#ifdef CONFIG_I2C_CODE_IN_RAM
+#define IT8XXX2_I2C_CODE_IN_RAM __soc_ram_code
+#else
+#define IT8XXX2_I2C_CODE_IN_RAM
+#endif
 
 /* Start smbus session from idle state */
 #define I2C_MSG_START    BIT(5)
@@ -233,6 +240,7 @@ enum enhanced_i2c_target_status {
 };
 #endif
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_parsing_return_value(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -254,6 +262,7 @@ static int i2c_parsing_return_value(const struct device *dev)
 	}
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_get_line_levels(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -271,6 +280,7 @@ static int i2c_get_line_levels(const struct device *dev)
 	return pin_sts;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_is_busy(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -279,6 +289,7 @@ static int i2c_is_busy(const struct device *dev)
 	return (IT8XXX2_I2C_STR(base) & E_HOSTA_BB);
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_bus_not_available(const struct device *dev)
 {
 	if (i2c_is_busy(dev) ||
@@ -289,6 +300,7 @@ static int i2c_bus_not_available(const struct device *dev)
 	return 0;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void i2c_reset(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -299,6 +311,7 @@ static void i2c_reset(const struct device *dev)
 }
 
 /* Set clock frequency for i2c port D, E , or F */
+IT8XXX2_I2C_CODE_IN_RAM
 static void i2c_enhanced_port_set_frequency(const struct device *dev,
 					    int freq_hz)
 {
@@ -401,6 +414,7 @@ static int i2c_enhance_get_config(const struct device *dev, uint32_t *dev_config
 	return 0;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int enhanced_i2c_error(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -423,6 +437,7 @@ static int enhanced_i2c_error(const struct device *dev)
 	return data->err;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void enhanced_i2c_start(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -441,6 +456,7 @@ static void enhanced_i2c_start(const struct device *dev)
 	IT8XXX2_I2C_CTR1(base) = IT8XXX2_I2C_MDL_EN;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void i2c_pio_trans_data(const struct device *dev,
 			       enum enhanced_i2c_transfer_direct direct,
 			       uint16_t trans_data, int first_byte)
@@ -476,6 +492,7 @@ static void i2c_pio_trans_data(const struct device *dev,
 	}
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int enhanced_i2c_tran_read(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -539,6 +556,7 @@ static int enhanced_i2c_tran_read(const struct device *dev)
 	return 1;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int enhanced_i2c_tran_write(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -580,6 +598,7 @@ static int enhanced_i2c_tran_write(const struct device *dev)
 	return 1;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_transaction(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -624,6 +643,7 @@ static int i2c_transaction(const struct device *dev)
 	return 0;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_enhance_pio_transfer(const struct device *dev,
 				    struct i2c_msg *msgs)
 {
@@ -713,6 +733,7 @@ static void enhanced_i2c_set_cmd_addr_regs(const struct device *dev)
 	IT8XXX2_I2C_CMD_ADDL(base) = dlm_base & 0xff;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void enhanced_i2c_cq_write(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -731,6 +752,7 @@ static void enhanced_i2c_cq_write(const struct device *dev)
 	}
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void enhanced_i2c_cq_read(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -747,6 +769,7 @@ static void enhanced_i2c_cq_read(const struct device *dev)
 	i2c_cq_pckt->cmd_h = num_bit_10_3;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void enhanced_i2c_cq_write_to_read(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -773,6 +796,7 @@ static void enhanced_i2c_cq_write_to_read(const struct device *dev)
 	i2c_cq_pckt->wdata[i] = num_bit_10_3;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int enhanced_i2c_cq_isr(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -807,6 +831,7 @@ static int enhanced_i2c_cq_isr(const struct device *dev)
 	return 0;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int enhanced_i2c_cmd_queue_trans(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -850,6 +875,7 @@ static int enhanced_i2c_cmd_queue_trans(const struct device *dev)
 	return 1;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_enhance_cq_transfer(const struct device *dev,
 				   struct i2c_msg *msgs)
 {
@@ -884,6 +910,7 @@ static int i2c_enhance_cq_transfer(const struct device *dev,
 	return data->err;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static bool cq_mode_allowed(const struct device *dev, struct i2c_msg *msgs)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -952,6 +979,7 @@ static bool cq_mode_allowed(const struct device *dev, struct i2c_msg *msgs)
 }
 #endif /* CONFIG_I2C_IT8XXX2_CQ_MODE */
 
+IT8XXX2_I2C_CODE_IN_RAM
 static int i2c_enhance_transfer(const struct device *dev,
 				struct i2c_msg *msgs,
 				uint8_t num_msgs, uint16_t addr)
@@ -1015,6 +1043,7 @@ done:
 
 #ifdef CONFIG_I2C_TARGET
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+IT8XXX2_I2C_CODE_IN_RAM
 static void target_i2c_isr_dma(const struct device *dev,
 			       uint8_t interrupt_status)
 {
@@ -1080,6 +1109,7 @@ static void target_i2c_isr_dma(const struct device *dev,
 }
 #endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void target_i2c_isr_pio(const struct device *dev, uint8_t interrupt_status,
 			       uint8_t target_status)
 {
@@ -1142,6 +1172,7 @@ static void target_i2c_isr_pio(const struct device *dev, uint8_t interrupt_statu
 	IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 }
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void target_i2c_isr(const struct device *dev)
 {
 	const struct i2c_enhance_config *config = dev->config;
@@ -1175,6 +1206,7 @@ static void target_i2c_isr(const struct device *dev)
 }
 #endif
 
+IT8XXX2_I2C_CODE_IN_RAM
 static void i2c_enhance_isr(void *arg)
 {
 	struct device *dev = (struct device *)arg;


### PR DESCRIPTION
Introduce the I2C_ENHANCE_RAM_CODE option to place selected critical functions into the RAM code section.
This allows latency-sensitive I2C paths to execute from RAM when required, while keeping the default behavior unchanged.

NOTE1: Enable I2C_ENHANCE_RAM_CODE on it81202bx: RAM size +2272B.
NOTE2: With kernel in RAM, enabling I2C_ENHANCE_RAM_CODE saves ~558ms  over 1,000 transfers (W/R/W2R), tested on it81202bx.