### PR TITLE
dts/arm/st: Add cryp to STM32H753

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -275,3 +275,7 @@ zephyr_udc0: &usbotg_fs {
 &iwdg1 {
 	status = "okay";
 };
+
+&cryp {
+	status = "okay";
+};

--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -9,5 +9,14 @@
 / {
 	soc {
 		compatible = "st,stm32h753", "st,stm32h7", "simple-bus";
+
+		cryp: cryp@48021000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x48021000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -15,6 +15,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h757.dtsi
+++ b/dts/arm/st/h7/stm32h757.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/tests/crypto/crypto_aes/src/main.c
+++ b/tests/crypto/crypto_aes/src/main.c
@@ -14,6 +14,8 @@
 #define CRYPTO_DRV_NAME CONFIG_CRYPTO_MBEDTLS_SHIM_DRV_NAME
 #elif CONFIG_CRYPTO_ESP32_AES
 #define CRYPTO_DEV_COMPAT espressif_esp32_aes
+#elif CONFIG_CRYPTO_STM32
+#define CRYPTO_DEV_COMPAT st_stm32_cryp
 #else
 #error "You need to enable one crypto device"
 #endif

--- a/tests/crypto/crypto_aes/testcase.yaml
+++ b/tests/crypto/crypto_aes/testcase.yaml
@@ -14,4 +14,5 @@ tests:
       - esp32c3_devkitc
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
+      - nucleo_h753zi
     tags: crypto


### PR DESCRIPTION
STM32H753 has a cryp block like the STM32H755, but it is missing from the stm32h753.dtsi file.

Adds an entry to stm32h753.dtsi essentially copied from H755.

Untested, but confirmed that the reg address, reg size, AHB clock enable number, interrupt number match the H753 datasheet.