### PR TITLE
scripts: check_compliance: read text files as UTF-8 on Windows

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2404,11 +2404,6 @@ class KeepSorted(ComplianceTest):
         return -1
 
     def check_file(self, file, fp):
-        mime_type = magic.from_file(os.fspath(file), mime=True)
-
-        if not mime_type.startswith("text/"):
-            return
-
         block_data = ""
         in_block = False
 
@@ -2462,7 +2457,16 @@ class KeepSorted(ComplianceTest):
 
     def run(self):
         for file in get_files(filter="d"):
-            with open(file) as fp:
+            file_path = GIT_TOP / file
+
+            mime_type = magic.from_file(os.fspath(file_path), mime=True)
+            if not mime_type.startswith("text/"):
+                continue
+
+            # Text in the Zephyr tree is UTF-8. On Windows, the default text
+            # encoding depends on the active code page (e.g. GBK), which can
+            # break local runs with UnicodeDecodeError.
+            with open(file_path, encoding="utf-8", errors="surrogateescape") as fp:
                 self.check_file(file, fp)
 
 


### PR DESCRIPTION
KeepSorted can fail on Windows when the active code page is not UTF-8 (e.g. GBK), because text files in the Zephyr tree are UTF-8. Detect file type via libmagic and only process text/* files, avoiding attempts to decode binary content. Open text files via GIT_TOP / <path> with encoding="utf-8" (and errors="surrogateescape") to prevent UnicodeDecodeError during local compliance runs without changing the KeepSorted sorting rules.