### PR TITLE
samples: infineon: add missing copyright headers to overlay files

### DIFF
--- a/samples/drivers/flash_shell/boards/cy8cproto_062_4343w.overlay
+++ b/samples/drivers/flash_shell/boards/cy8cproto_062_4343w.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/samples/drivers/flash_shell/boards/cy8cproto_063_ble.overlay
+++ b/samples/drivers/flash_shell/boards/cy8cproto_063_ble.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/samples/drivers/uart/async_api/boards/cy8cproto_062_4343w.overlay
+++ b/samples/drivers/uart/async_api/boards/cy8cproto_062_4343w.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &dma0 {
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/samples/drivers/uart/async_api/boards/cy8cproto_063_ble.overlay
+++ b/samples/drivers/uart/async_api/boards/cy8cproto_063_ble.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &dma0 {
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/samples/subsys/nvs/boards/cy8cproto_062_4343w.overlay
+++ b/samples/subsys/nvs/boards/cy8cproto_062_4343w.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/samples/subsys/nvs/boards/cy8cproto_063_ble.overlay
+++ b/samples/subsys/nvs/boards/cy8cproto_063_ble.overlay
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;


### PR DESCRIPTION
Add SPDX-License-Identifier and copyright headers to Infineon board overlay files in flash_shell, uart async_api, and nvs samples for cy8cproto_062_4343w and cy8cproto_063_ble boards.