### PR TITLE
drivers: usb: Adjust log level

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -342,7 +342,7 @@ int udc_ep_enable_internal(const struct device *dev,
 	}
 
 	if (cfg->stat.enabled) {
-		LOG_ERR("ep 0x%02x already enabled", cfg->addr);
+		LOG_WRN("ep 0x%02x already enabled", cfg->addr);
 		return -EALREADY;
 	}
 
@@ -403,7 +403,7 @@ int udc_ep_disable_internal(const struct device *dev, const uint8_t ep)
 	}
 
 	if (!cfg->stat.enabled) {
-		LOG_ERR("ep 0x%02x already disabled", cfg->addr);
+		LOG_WRN("ep 0x%02x already disabled", cfg->addr);
 		return -EALREADY;
 	}
 
@@ -599,7 +599,7 @@ int udc_ep_dequeue(const struct device *dev, const uint8_t ep)
 	}
 
 	if (cfg->stat.enabled || cfg->stat.halted) {
-		LOG_INF("ep 0x%02x is not halted|disabled", cfg->addr);
+		LOG_DBG("ep 0x%02x is not halted|disabled", cfg->addr);
 	}
 
 	if (UDC_COMMON_LOG_LEVEL == LOG_LEVEL_DBG) {
@@ -630,7 +630,7 @@ struct net_buf *udc_ep_buf_alloc(const struct device *dev,
 
 	buf = net_buf_alloc_len(&udc_ep_pool, size, K_NO_WAIT);
 	if (!buf) {
-		LOG_ERR("Failed to allocate net_buf %zd, ep 0x%02x", size, ep);
+		LOG_WRN("Failed to allocate net_buf %zd, ep 0x%02x", size, ep);
 		goto ep_alloc_error;
 	}
 
@@ -981,7 +981,7 @@ void udc_ctrl_update_stage(const struct device *dev,
 		uint16_t length  = udc_data_stage_length(buf);
 
 		if (data->stage != CTRL_PIPE_STAGE_SETUP) {
-			LOG_INF("Sequence %u not completed", data->stage);
+			LOG_DBG("Sequence %u not completed", data->stage);
 
 			if (data->stage == CTRL_PIPE_STAGE_DATA_OUT) {
 				/*
@@ -990,7 +990,7 @@ void udc_ctrl_update_stage(const struct device *dev,
 				 * packet must be removed here because it will
 				 * never reach the stack.
 				 */
-				LOG_INF("Drop setup packet (%p)", (void *)data->setup);
+				LOG_DBG("Drop setup packet (%p)", (void *)data->setup);
 				net_buf_unref(data->setup);
 			}
 
@@ -1049,7 +1049,7 @@ void udc_ctrl_update_stage(const struct device *dev,
 				next_stage = CTRL_PIPE_STAGE_ERROR;
 			}
 		} else {
-			LOG_ERR("Cannot determine the next stage");
+			LOG_WRN("Cannot determine the next stage");
 			next_stage = CTRL_PIPE_STAGE_ERROR;
 		}
 
@@ -1083,7 +1083,7 @@ void udc_ctrl_update_stage(const struct device *dev,
 			LOG_DBG("s-status");
 			next_stage = CTRL_PIPE_STAGE_SETUP;
 		} else {
-			LOG_ERR("Cannot determine the next stage");
+			LOG_WRN("Cannot determine the next stage");
 			next_stage = CTRL_PIPE_STAGE_ERROR;
 		}
 	}

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -392,7 +392,7 @@ static void ev_usbreset_handler(void)
 {
 	m_bus_suspend = false;
 
-	LOG_INF("Reset");
+	LOG_DBG("Reset");
 	udc_submit_event(udc_nrf_dev, UDC_EVT_RESET, 0);
 }
 
@@ -620,7 +620,7 @@ static void usbd_dmareq_process(void)
 		__ASSERT_NO_MSG(nrfx_is_in_ram(payload_buf));
 
 		if (received > payload_len) {
-			LOG_ERR("buffer too small: r: %u, l: %u", received, payload_len);
+			LOG_WRN("buffer too small: r: %u, l: %u", received, payload_len);
 		} else {
 			payload_len = received;
 		}
@@ -1235,7 +1235,7 @@ static void udc_event_xfer_in(const struct device *dev, const uint8_t ep)
 
 	buf = udc_buf_get(ep_cfg);
 	if (buf == NULL) {
-		LOG_ERR("ep 0x%02x queue is empty", ep);
+		LOG_WRN("ep 0x%02x queue is empty", ep);
 		__ASSERT_NO_MSG(false);
 		return;
 	}
@@ -1290,7 +1290,7 @@ static void udc_event_xfer_out(const struct device *dev, const uint8_t ep)
 	ep_cfg = udc_get_ep_cfg(dev, ep);
 	buf = udc_buf_get(ep_cfg);
 	if (buf == NULL) {
-		LOG_ERR("ep 0x%02x ok, queue is empty", ep);
+		LOG_WRN("ep 0x%02x ok, queue is empty", ep);
 		return;
 	}
 
@@ -1463,20 +1463,20 @@ static void udc_nrf_thread_handler(const struct device *dev)
 	evt = k_event_clear(&drv_evt, UINT32_MAX);
 
 	if (evt & BIT(UDC_NRF_EVT_SUSPEND)) {
-		LOG_INF("SUSPEND state detected");
+		LOG_DBG("SUSPEND state detected");
 		nrf_usbd_legacy_suspend();
 		udc_set_suspended(dev, true);
 		udc_submit_event(dev, UDC_EVT_SUSPEND, 0);
 	}
 
 	if (evt & BIT(UDC_NRF_EVT_RESUME)) {
-		LOG_INF("RESUMING from suspend");
+		LOG_DBG("RESUMING from suspend");
 		udc_set_suspended(dev, false);
 		udc_submit_event(dev, UDC_EVT_RESUME, 0);
 	}
 
 	if (evt & BIT(UDC_NRF_EVT_WUREQ)) {
-		LOG_INF("Remote wakeup initiated");
+		LOG_DBG("Remote wakeup initiated");
 		udc_set_suspended(dev, false);
 		udc_submit_event(dev, UDC_EVT_RESUME, 0);
 	}
@@ -1554,7 +1554,7 @@ static void udc_nrf_power_handler(nrfx_power_usb_evt_t pwr_evt)
 		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_REMOVED, 0);
 		break;
 	default:
-		LOG_ERR("Unknown power event %d", pwr_evt);
+		LOG_WRN("Unknown power event %d", pwr_evt);
 	}
 }
 
@@ -1591,7 +1591,7 @@ static int udc_nrf_ep_dequeue(const struct device *dev,
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	} else {
-		LOG_INF("ep 0x%02x queue is empty", cfg->addr);
+		LOG_DBG("ep 0x%02x queue is empty", cfg->addr);
 	}
 
 	udc_ep_set_busy(cfg, false);
@@ -1779,14 +1779,14 @@ static int udc_nrf_init(const struct device *dev)
 	nrfx_power_usbevt_init(&cfg->evt);
 
 	nrfx_power_usbevt_enable();
-	LOG_INF("Initialized");
+	LOG_DBG("Initialized");
 
 	return 0;
 }
 
 static int udc_nrf_shutdown(const struct device *dev)
 {
-	LOG_INF("shutdown");
+	LOG_DBG("shutdown");
 
 	nrfx_power_usbevt_disable();
 	nrfx_power_usbevt_uninit();
@@ -1799,7 +1799,7 @@ static int udc_nrf_driver_init(const struct device *dev)
 	struct udc_data *data = dev->data;
 	int err;
 
-	LOG_INF("Preinit");
+	LOG_DBG("Preinit");
 	udc_nrf_dev = dev;
 	k_mutex_init(&data->mutex);
 	k_thread_create(&drv_stack_data, drv_stack,

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -328,14 +328,14 @@ int usbd_uac2_send(const struct device *dev, uint8_t terminal,
 		/* This shouldn't really happen because netbuf should be large
 		 * enough, but if it does all we loose is just single packet.
 		 */
-		LOG_ERR("No netbuf for send");
+		LOG_WRN("No netbuf for send");
 		atomic_clear_bit(queued_bits, as_idx);
 		return -ENOMEM;
 	}
 
 	ret = usbd_ep_enqueue(cfg->c_data, buf);
 	if (ret) {
-		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
+		LOG_WRN("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		atomic_clear_bit(queued_bits, as_idx);
 	}
@@ -378,14 +378,14 @@ static void schedule_iso_out_read(struct usbd_class_data *const c_data,
 	/* Prepare transfer to read audio OUT data from host */
 	data_buf = ctx->ops->get_recv_buf(dev, terminal, mps, ctx->user_data);
 	if (!data_buf) {
-		LOG_ERR_RATELIMIT("No data buffer for terminal %d", terminal);
+		LOG_WRN_RATELIMIT("No data buffer for terminal %d", terminal);
 		atomic_clear_bit(queued_bits, as_idx);
 		return;
 	}
 
 	buf = uac2_buf_alloc(ep, data_buf, mps);
 	if (!buf) {
-		LOG_ERR("No netbuf for read");
+		LOG_WRN("No netbuf for read");
 		/* Netbuf pool should be large enough, but if for some reason
 		 * we are out of netbuf, there's nothing better to do than to
 		 * pass the buffer back to application.
@@ -398,7 +398,7 @@ static void schedule_iso_out_read(struct usbd_class_data *const c_data,
 
 	ret = usbd_ep_enqueue(c_data, buf);
 	if (ret) {
-		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
+		LOG_WRN("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		ctx->ops->data_recv_cb(dev, terminal,
 				       data_buf, 0, ctx->user_data);
@@ -422,7 +422,7 @@ static void write_explicit_feedback(struct usbd_class_data *const c_data,
 
 	buf = net_buf_alloc(&uac2_pool, K_NO_WAIT);
 	if (!buf) {
-		LOG_ERR("No buf for feedback");
+		LOG_WRN("No buf for feedback");
 		return;
 	}
 
@@ -439,7 +439,7 @@ static void write_explicit_feedback(struct usbd_class_data *const c_data,
 
 	ret = usbd_ep_enqueue(c_data, buf);
 	if (ret) {
-		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
+		LOG_WRN("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 	} else {
 		if (ctx->fb_queued & BIT(as_idx)) {
@@ -803,11 +803,9 @@ static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *bu
 	bi = udc_get_buf_info(buf);
 	if (err) {
 		if (err == -ECONNABORTED) {
-			LOG_WRN("request ep 0x%02x, len %u cancelled",
-				bi->ep, buf->len);
+			LOG_DBG("request ep 0x%02x, len %u cancelled", bi->ep, buf->len);
 		} else {
-			LOG_ERR("request ep 0x%02x, len %u failed",
-				bi->ep, buf->len);
+			LOG_WRN("request ep 0x%02x, len %u failed", bi->ep, buf->len);
 		}
 	}
 


### PR DESCRIPTION
- Change all LOG_INF to LOG_DBG
- Change most LOG_ERR to LOG_WRN

- Viewpoint for making this change: Drivers should never have LOG_INF, they should just operate silently. If a fault is not breaking the application it should throw a warning and not an error. Error during setup is a clear LOG_ERR though.

Disclaimer: I do not know the inner workings of the USB drivers, so there might be some places where I've set the wrong level. The general idea is to limit the amount of logs from the drivers and reserver LOG_ERRs for actual breaking faults that should be caught in CI