### PR TITLE
kernel: thread monitor - Assert reusing TCB in use

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -873,6 +873,28 @@ static inline void init_thread_usage(struct k_thread *thread)
 #endif /* CONFIG_SCHED_THREAD_USAGE */
 }
 
+static inline void check_if_tid_is_reused(struct k_thread *new_thread)
+{
+#ifdef CONFIG_THREAD_MONITOR
+#ifdef CONFIG_ASSERT
+	k_spinlock_key_t key = k_spin_lock(&z_thread_monitor_lock);
+	bool reused = false;
+
+	/* Check if the thread is already in the list */
+	for (struct k_thread *t = _kernel.threads; t; t = t->next_thread) {
+		if (t == new_thread) {
+			reused = true;
+			break;
+		}
+	}
+
+	k_spin_unlock(&z_thread_monitor_lock, key);
+
+	__ASSERT(!reused, "thread %p is already in the running list", new_thread);
+#endif
+#endif
+}
+
 /*
  * The provided stack_size value is presumed to be either the result of
  * K_THREAD_STACK_SIZEOF(stack), or the size value passed to the instance
@@ -887,6 +909,8 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	char *stack_ptr;
 
 	Z_ASSERT_VALID_PRIO(prio, entry);
+
+	check_if_tid_is_reused(new_thread);
 
 	thread_abort_cleanup_check_reuse(new_thread);
 	init_thread_obj_core(new_thread);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -873,6 +873,30 @@ static inline void init_thread_usage(struct k_thread *thread)
 #endif /* CONFIG_SCHED_THREAD_USAGE */
 }
 
+/* Assert the thread wasn't already linked into the monitor list. */
+static inline void assert_thread_not_reused(struct k_thread *new_thread)
+{
+#ifdef CONFIG_THREAD_MONITOR
+#ifdef CONFIG_ASSERT
+	k_spinlock_key_t key = k_spin_lock(&z_thread_monitor_lock);
+	bool reused = false;
+
+	/* Check if the thread is already in the list */
+	for (struct k_thread *t = _kernel.threads; t; t = t->next_thread) {
+		if (t == new_thread) {
+			reused = true;
+			break;
+		}
+	}
+
+	k_spin_unlock(&z_thread_monitor_lock, key);
+
+	__ASSERT(!reused, "thread %p is already in the running list", new_thread);
+#endif /* CONFIG_ASSERT */
+#endif /* CONFIG_THREAD_MONITOR */
+	ARG_UNUSED(new_thread);
+}
+
 /*
  * The provided stack_size value is presumed to be either the result of
  * K_THREAD_STACK_SIZEOF(stack), or the size value passed to the instance
@@ -887,6 +911,8 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	char *stack_ptr;
 
 	Z_ASSERT_VALID_PRIO(prio, entry);
+
+	assert_thread_not_reused(new_thread);
 
 	thread_abort_cleanup_check_reuse(new_thread);
 	init_thread_obj_core(new_thread);

--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -14,8 +14,11 @@ static ZTEST_DMEM int case_type;
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static K_THREAD_STACK_DEFINE(test_stack, STACK_SIZE);
+static K_THREAD_STACK_DEFINE(reuse_stack1, STACK_SIZE);
+static K_THREAD_STACK_DEFINE(reuse_stack2, STACK_SIZE);
 static struct k_thread tdata;
 static struct k_thread test_tdata;
+static struct k_thread reuse_tdata;
 
 /* identifiers for each negative test scenario */
 enum {
@@ -32,12 +35,19 @@ enum {
 	THREAD_PRIORITY_GET_NULL,
 	THREAD_WAKEUP_NULL,
 	THREAD_CREATE_SUPERVISOR,
-	THREAD_CREATE_ESSENTIAL
+	THREAD_CREATE_ESSENTIAL,
+	THREAD_REUSE_ACTIVE_THREAD_ID
 } neg_case;
 
 static void test_thread(void *p1, void *p2, void *p3)
 {
 	/* intentionally empty target thread */
+}
+
+static void long_running_thread(void *p1, void *p2, void *p3)
+{
+	/* Sleep for a long time to keep thread active */
+	k_sleep(K_FOREVER);
 }
 
 static void tThread_entry_negative(void *p1, void *p2, void *p3)
@@ -148,6 +158,19 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 			test_thread, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
 			K_USER | K_ESSENTIAL, K_NO_WAIT);
+		break;
+	case THREAD_REUSE_ACTIVE_THREAD_ID:
+		ztest_set_fault_valid(true);
+		if (k_is_user_context()) {
+			perm = perm | K_USER;
+		}
+		/* Create first thread that will run for a while */
+		k_thread_create(&reuse_tdata, reuse_stack1, STACK_SIZE, long_running_thread, NULL,
+				NULL, NULL, K_PRIO_PREEMPT(THREAD_TEST_PRIORITY + 1), perm,
+				K_NO_WAIT);
+		/* Try to reuse the same thread structure while it's still active */
+		k_thread_create(&reuse_tdata, reuse_stack2, STACK_SIZE, test_thread, NULL, NULL,
+				NULL, K_PRIO_PREEMPT(THREAD_TEST_PRIORITY), perm, K_NO_WAIT);
 		break;
 	default:
 		TC_PRINT("should not be here!\n");
@@ -289,6 +312,22 @@ ZTEST_USER(thread_error_case, test_thread_create_stack_overflow)
 }
 
 /**
+ * @brief Test that k_thread_create() asserts if a thread pointer is
+ *        reused, while the thread pointer is in use
+ *
+ * Verifies that thread pointer that is passed to thread create is
+ * not the only which is already created and in use
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see k_thread_create()
+ */
+ZTEST_USER(thread_error_case, test_thread_reuse_active_thread_id)
+{
+	create_negative_test_thread(THREAD_REUSE_ACTIVE_THREAD_ID);
+}
+
+/**
  * @brief Test that k_thread_suspend() rejects a NULL thread pointer
  *
  * Verifies that passing a NULL pointer to k_thread_suspend() triggers
@@ -402,7 +441,8 @@ ZTEST_USER(thread_error_case, test_thread_create_essential)
 /* Grant the test thread access to all shared kernel objects. */
 void *thread_grant_setup(void)
 {
-	k_thread_access_grant(k_current_get(), &tdata, &tstack, &test_tdata, &test_stack);
+	k_thread_access_grant(k_current_get(), &tdata, &tstack, &test_tdata, &test_stack,
+			      &reuse_tdata, &reuse_stack1, &reuse_stack2);
 
 	return NULL;
 }

--- a/tests/kernel/threads/thread_error_case/src/main.c
+++ b/tests/kernel/threads/thread_error_case/src/main.c
@@ -14,8 +14,11 @@ static ZTEST_DMEM int case_type;
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 static K_THREAD_STACK_DEFINE(test_stack, STACK_SIZE);
+static K_THREAD_STACK_DEFINE(reuse_stack1, STACK_SIZE);
+static K_THREAD_STACK_DEFINE(reuse_stack2, STACK_SIZE);
 static struct k_thread tdata;
 static struct k_thread test_tdata;
+static struct k_thread reuse_tdata;
 
 /* identifiers for each negative test scenario */
 enum {
@@ -32,12 +35,19 @@ enum {
 	THREAD_PRIORITY_GET_NULL,
 	THREAD_WAKEUP_NULL,
 	THREAD_CREATE_SUPERVISOR,
-	THREAD_CREATE_ESSENTIAL
+	THREAD_CREATE_ESSENTIAL,
+	THREAD_REUSE_ACTIVE_THREAD_ID
 } neg_case;
 
 static void test_thread(void *p1, void *p2, void *p3)
 {
 	/* intentionally empty target thread */
+}
+
+static void long_running_thread(void *p1, void *p2, void *p3)
+{
+	/* Sleep for a long time to keep thread active */
+	k_sleep(K_FOREVER);
 }
 
 static void tThread_entry_negative(void *p1, void *p2, void *p3)
@@ -148,6 +158,16 @@ static void tThread_entry_negative(void *p1, void *p2, void *p3)
 			test_thread, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(THREAD_TEST_PRIORITY),
 			K_USER | K_ESSENTIAL, K_NO_WAIT);
+		break;
+	case THREAD_REUSE_ACTIVE_THREAD_ID:
+		ztest_set_fault_valid(true);
+		/* Create first thread that will run for a while */
+		k_thread_create(&reuse_tdata, reuse_stack1, STACK_SIZE, long_running_thread, NULL,
+				NULL, NULL, K_PRIO_PREEMPT(THREAD_TEST_PRIORITY + 1), perm,
+				K_NO_WAIT);
+		/* Try to reuse the same thread structure while it's still active */
+		k_thread_create(&reuse_tdata, reuse_stack2, STACK_SIZE, test_thread, NULL, NULL,
+				NULL, K_PRIO_PREEMPT(THREAD_TEST_PRIORITY), perm, K_NO_WAIT);
 		break;
 	default:
 		TC_PRINT("should not be here!\n");
@@ -380,6 +400,38 @@ ZTEST_USER(thread_error_case, test_thread_create_null_stack)
 ZTEST_USER(thread_error_case, test_thread_create_stack_size_overflow)
 {
 	create_negative_test_thread(THREAD_CREATE_STACK_SIZE_OVERFLOW);
+}
+
+/**
+ * @brief Verify that k_thread_create() asserts if a thread pointer is
+ *        reused while the thread pointer is in use.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @details
+ * A thread structure must not be reused for a new thread while the
+ * thread it currently backs is still active, so this must be detected
+ * instead of silently corrupting the running thread's state.
+ *
+ * This test runs in kernel mode, a worker thread arms the ztest
+ * fatal-error hook and then makes the offending call. The call must
+ * not return -- reaching the code after it fails the test -- so a pass
+ * means the error really was caught.
+ *
+ * Test steps:
+ * - Spawn a worker thread and arm the ztest fatal-error hook.
+ * - Create a first thread that keeps running, then try to reuse its thread
+ *   structure to create a second thread from the same worker thread.
+ * - Join the worker thread.
+ *
+ * Expected result:
+ * - The call raises the expected fatal error and never returns.
+ *
+ * @see k_thread_create()
+ */
+ZTEST(thread_error_case, test_thread_reuse_active_thread_id)
+{
+	create_negative_test_thread(THREAD_REUSE_ACTIVE_THREAD_ID);
 }
 
 /**


### PR DESCRIPTION
Add a check in thread monitor to assert if a TCB is reused while it is still present in the kernel thread list.
This prevents undefined behavior due to TID reuse before proper cleanup.

tests: Add test for thread tcb reuse