### PR TITLE
soc: nxp: unify DISABLE_WDOG condition

### DIFF
--- a/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
@@ -18,4 +18,4 @@ zephyr_linker_sources_ifdef(CONFIG_MCXE_FLASH_CONFIG
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched
 # if this Kconfig is set
-zephyr_compile_definitions_ifdef(CONFIG_WDOG_ENABLE_AT_BOOT DISABLE_WDOG=0)
+zephyr_compile_definitions_ifndef(CONFIG_WDT_DISABLE_AT_BOOT DISABLE_WDOG=0)


### PR DESCRIPTION
Aligh the macro to determine DISABLE_WDOG definition for nxp devices.