### PR TITLE
drivers: spi: stm32: add RTIO-DMA support

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -26,6 +26,8 @@ config SPI_STM32_DMA
 	help
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.
+	  This can be used with the SPI_RTIO config to have SPI
+	  transactions using DMA + RTIO
 
 config SPI_STM32_ERRATA_BUSY
 	bool

--- a/tests/drivers/spi/spi_loopback/overlay-stm32-spi-rtio-dma.conf
+++ b/tests/drivers/spi/spi_loopback/overlay-stm32-spi-rtio-dma.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SPI_RTIO=y
+CONFIG_SPI_STM32_DMA=y
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -142,6 +142,29 @@ tests:
       - stm32u083c_dk
     integration_platforms:
       - stm32h573i_dk
+  drivers.spi.stm32_spi_rtio_dma.loopback:
+    extra_args: EXTRA_CONF_FILE="overlay-stm32-spi-rtio-dma.conf"
+    platform_allow:
+      - b_u585i_iot02a
+      - nucleo_c071rb
+      - nucleo_f207zg
+      - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_f767zi
+      - nucleo_g474re
+      - nucleo_h743zi
+      - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
+      - nucleo_l152re
+      - nucleo_wba55cg
+      - nucleo_wb55rg
+      - nucleo_wl55jc
+      - stm32h573i_dk
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
+    integration_platforms:
+      - stm32h573i_dk
   drivers.spi.gd32_spi_interrupt.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-gd32-spi-interrupt.conf"
     platform_allow:


### PR DESCRIPTION
This PR adds the support of RTIO SPI transactions using DMA, it also adds a test case for the loopback test.

Tested on our test bench using `H7` and `non-H7` SPI compatible boards
