### PR TITLE
drivers: firmware: tisci: Add secure path support

### DIFF
--- a/drivers/firmware/tisci/tisci.c
+++ b/drivers/firmware/tisci/tisci.c
@@ -31,6 +31,7 @@ struct tisci_config {
 	uint32_t host_id;
 	int max_msg_size;
 	int max_rx_timeout_ms;
+	bool is_secure;
 };
 
 /**
@@ -1595,6 +1596,7 @@ static int tisci_init(const struct device *dev)
 		.host_id = DT_INST_PROP(_n, ti_host_id),                                           \
 		.max_msg_size = MAILBOX_MBOX_SIZE,                                                 \
 		.max_rx_timeout_ms = 10000,                                                        \
+		.is_secure = DT_INST_PROP_OR(_n, ti_is_secure, false),                             \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(_n, tisci_init, NULL, &tisci_data_##_n, &tisci_config_##_n,          \
 			      PRE_KERNEL_1, CONFIG_TISCI_INIT_PRIORITY, NULL);

--- a/drivers/firmware/tisci/tisci.c
+++ b/drivers/firmware/tisci/tisci.c
@@ -139,12 +139,26 @@ static int tisci_get_response(const struct device *dev, struct tisci_xfer *xfer)
 		return -EINVAL;
 	}
 
+	if (config->is_secure) {
+		/* In secure mode, response includes 4-byte secure header */
+		xfer->rx_message.size += sizeof(struct tisci_secure_msg_hdr);
+	}
+
 	if (data->rx_message.size < xfer->rx_message.size) {
-		LOG_ERR("rx_message.size [ %d ] < xfer->rx_message.size\n", data->rx_message.size);
+		LOG_ERR("rx_message.size [ %zu ] < xfer->rx_message.size [ %zu ]\n",
+			data->rx_message.size, xfer->rx_message.size);
 		return -EINVAL;
 	}
 
-	memcpy(xfer->rx_message.buf, data->rx_message.buf, xfer->rx_message.size);
+	if (config->is_secure) {
+		xfer->rx_message.size -= sizeof(struct tisci_secure_msg_hdr);
+		/* Skip secure header and copy tisci_msg_hdr + payload */
+		memcpy(xfer->rx_message.buf,
+		       (uint8_t *)data->rx_message.buf + sizeof(struct tisci_secure_msg_hdr),
+		       xfer->rx_message.size);
+	} else {
+		memcpy(xfer->rx_message.buf, data->rx_message.buf, xfer->rx_message.size);
+	}
 	hdr = (struct tisci_msg_hdr *)xfer->rx_message.buf;
 
 	/* Sanity check for message response */
@@ -159,17 +173,48 @@ static int tisci_get_response(const struct device *dev, struct tisci_xfer *xfer)
 
 static int tisci_do_xfer(const struct device *dev, struct tisci_xfer *xfer)
 {
-	if (!dev) {
+	if (!dev || !xfer) {
 		return -EINVAL;
 	}
 
+	struct tisci_data *data = dev->data;
 	const struct tisci_config *config = dev->config;
 	struct mbox_msg *msg = &xfer->tx_message;
 	int ret;
 
+	/* Stack buffer for secure messaging (max 60 bytes total) */
+	uint8_t secure_buf[MAILBOX_MBOX_SIZE];
+	struct mbox_msg secure_msg;
+
+	if (config->is_secure) {
+		struct tisci_secure_msg_hdr secure_hdr;
+
+		/* Verify message fits with secure header (already checked in max_msg_size) */
+		if (msg->size + sizeof(struct tisci_secure_msg_hdr) > MAILBOX_MBOX_SIZE) {
+			LOG_ERR("Message too large for secure mailbox (%zu + %zu > %d)\n",
+				msg->size, sizeof(struct tisci_secure_msg_hdr), MAILBOX_MBOX_SIZE);
+			k_sem_give(&data->data_sem);
+			return -EMSGSIZE;
+		}
+
+		/* Prepare secure header */
+		secure_hdr.checksum = 0;
+		secure_hdr.reserved = 0;
+
+		/* Copy header and message into secure buffer */
+		memcpy(secure_buf, &secure_hdr, sizeof(struct tisci_secure_msg_hdr));
+		memcpy(secure_buf + sizeof(struct tisci_secure_msg_hdr), msg->data, msg->size);
+
+		/* Use temporary message structure to avoid modifying original */
+		secure_msg.data = secure_buf;
+		secure_msg.size = msg->size + sizeof(struct tisci_secure_msg_hdr);
+		msg = &secure_msg;
+	}
+
 	ret = mbox_send_dt(&config->mbox_tx, msg);
 	if (ret < 0) {
-		LOG_ERR("Could not send (%d)\n", ret);
+		LOG_ERR("Could not send on %s path\n",
+			config->is_secure ? "secure" : "non-secure");
 		return ret;
 	}
 

--- a/drivers/firmware/tisci/tisci.h
+++ b/drivers/firmware/tisci/tisci.h
@@ -21,24 +21,21 @@
 #define __packed __attribute__((__packed__))
 #endif
 
+/* Core System Messages */
 #define TISCI_MSG_ENABLE_WDT            0x0000
 #define TISCI_MSG_WAKE_RESET            0x0001
 #define TISCI_MSG_VERSION               0x0002
 #define TISCI_MSG_WAKE_REASON           0x0003
 #define TISCI_MSG_GOODBYE               0x0004
 #define TISCI_MSG_SYS_RESET             0x0005
-#define TISCI_MSG_BOARD_CONFIG          0x000b
+#define TISCI_MSG_BOOT_NOTIFICATION     0x000a /* Secure */
+#define TISCI_MSG_BOARD_CONFIG          0x000b /* Secure */
 #define TISCI_MSG_BOARD_CONFIG_RM       0x000c
-#define TISCI_MSG_BOARD_CONFIG_SECURITY 0x000d
+#define TISCI_MSG_BOARD_CONFIG_SECURITY 0x000d /* Secure */
 #define TISCI_MSG_BOARD_CONFIG_PM       0x000e
 #define TISCI_MSG_QUERY_MSMC            0x0020
 
-/* Device requests */
-#define TISCI_MSG_SET_DEVICE_STATE  0x0200
-#define TISCI_MSG_GET_DEVICE_STATE  0x0201
-#define TISCI_MSG_SET_DEVICE_RESETS 0x0202
-
-/* Clock requests */
+/* Clock Management */
 #define TISCI_MSG_SET_CLOCK_STATE       0x0100
 #define TISCI_MSG_GET_CLOCK_STATE       0x0101
 #define TISCI_MSG_SET_CLOCK_PARENT      0x0102
@@ -47,6 +44,77 @@
 #define TISCI_MSG_SET_CLOCK_FREQ        0x010c
 #define TISCI_MSG_QUERY_CLOCK_FREQ      0x010d
 #define TISCI_MSG_GET_CLOCK_FREQ        0x010e
+
+/* Device Management */
+#define TISCI_MSG_SET_DEVICE_STATE  0x0200
+#define TISCI_MSG_GET_DEVICE_STATE  0x0201
+#define TISCI_MSG_SET_DEVICE_RESETS 0x0202
+
+/* Low Power Mode Messages */
+#define TISCI_MSG_ENTER_SLEEP 0x0301 /* Secure */
+
+/* Resource Management Requests */
+/* RM TISCI message to set an IRQ between a peripheral and host processor */
+#define TISCI_MSG_RM_IRQ_SET         0x1000
+/* RM TISCI message to release a configured IRQ */
+#define TISCI_MSG_RM_IRQ_RELEASE     0x1001
+
+/* Ring Accelerator */
+#define TISCI_MSG_RM_RING_CFG 0x1110
+
+/* UDMAP Transmit Channels */
+#define TISCI_MSG_RM_UDMAP_TX_ALLOC  0x1200
+#define TISCI_MSG_RM_UDMAP_TX_FREE   0x1201
+#define TISCI_MSG_RM_UDMAP_TX_CH_CFG 0x1205
+
+/* UDMAP Receive Channels */
+#define TISCI_MSG_RM_UDMAP_RX_ALLOC  0x1210
+#define TISCI_MSG_RM_UDMAP_RX_FREE   0x1211
+#define TISCI_MSG_RM_UDMAP_RX_CH_CFG 0x1215
+
+/* UDMAP Flow Configuration */
+#define TISCI_MSG_RM_UDMAP_FLOW_CFG             0x1220
+#define TISCI_MSG_RM_UDMAP_OPT_FLOW_CFG         0x1221
+#define TISCI_MSG_RM_UDMAP_FLOW_SIZE_THRESH_CFG 0x1231
+
+/* PSI-L Pairing */
+#define TISCI_MSG_RM_PSIL_PAIR   0x1280
+#define TISCI_MSG_RM_PSIL_UNPAIR 0x1281
+
+/* RM TISCI message to request a resource range assignment for a host */
+#define TISCI_MSG_GET_RESOURCE_RANGE 0x1500
+
+/* Security Messages */
+/* Firewall Configuration */
+#define TISCI_MSG_FWL_SET          0x9000
+#define TISCI_MSG_FWL_GET          0x9001
+#define TISCI_MSG_FWL_CHANGE_OWNER 0x9002
+#define TISCI_MSG_OPEN_DEBUG_FWLS  0x900c /* Secure */
+
+/* Cryptographic Key Management (DKEK) */
+#define TISCI_MSG_SA2UL_SET_DKEK     0x9003 /* Secure */
+#define TISCI_MSG_SA2UL_RELEASE_DKEK 0x9004 /* Secure */
+#define TISCI_MSG_SA2UL_GET_DKEK     0x9029 /* Secure */
+
+/* OTP (One-Time Programmable) Memory */
+#define TISCI_MSG_READ_OTP_MMR               0x9022 /* Secure */
+#define TISCI_MSG_WRITE_OTP_ROW              0x9023 /* Secure */
+#define TISCI_MSG_LOCK_OTP_ROW               0x9024 /* Secure */
+#define TISCI_MSG_SOFT_LOCK_OTP_WRITE_GLOBAL 0x9025 /* Secure */
+#define TISCI_MSG_GET_OTP_ROW_LOCK_STATUS    0x9026 /* Secure */
+
+/* Security Handover and Key Writing */
+#define TISCI_MSG_SEC_HANDOVER       0x9030 /* Secure */
+#define TISCI_MSG_KEY_WRITER         0x9031 /* Secure */
+#define TISCI_MSG_WRITE_SWREV        0x9032 /* Secure */
+#define TISCI_MSG_READ_SWREV         0x9033 /* Secure */
+#define TISCI_MSG_READ_KEYCNT_KEYREV 0x9034 /* Secure */
+#define TISCI_MSG_WRITE_KEYREV       0x9035 /* Secure */
+
+/* Cryptographic Key Management (DSMEK) */
+#define TISCI_MSG_SA2UL_GET_DSMEK     0x9036 /* Secure */
+#define TISCI_MSG_SA2UL_SET_DSMEK     0x9037 /* Secure */
+#define TISCI_MSG_SA2UL_RELEASE_DSMEK 0x9038 /* Secure */
 
 /* Processor Control Messages */
 #define TISCI_MSG_PROC_REQUEST          0xc000
@@ -57,37 +125,6 @@
 #define TISCI_MSG_PROC_AUTH_BOOT_IMAGE  0xc120
 #define TISCI_MSG_GET_PROC_BOOT_STATUS  0xc400
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS 0xc401
-
-/* Resource Management Requests */
-/* RM TISCI message to request a resource range assignment for a host */
-#define TISCI_MSG_GET_RESOURCE_RANGE 0x1500
-/* RM TISCI message to set an IRQ between a peripheral and host processor */
-#define TISCI_MSG_RM_IRQ_SET         (0x1000U)
-/* RM TISCI message to release a configured IRQ */
-#define TISCI_MSG_RM_IRQ_RELEASE     (0x1001U)
-
-/* NAVSS resource management */
-/* Ringacc requests */
-#define TISCI_MSG_RM_RING_CFG 0x1110
-
-/* PSI-L requests */
-#define TISCI_MSG_RM_PSIL_PAIR   0x1280
-#define TISCI_MSG_RM_PSIL_UNPAIR 0x1281
-
-#define TISCI_MSG_RM_UDMAP_TX_ALLOC     0x1200
-#define TISCI_MSG_RM_UDMAP_TX_FREE      0x1201
-#define TISCI_MSG_RM_UDMAP_RX_ALLOC     0x1210
-#define TISCI_MSG_RM_UDMAP_RX_FREE      0x1211
-#define TISCI_MSG_RM_UDMAP_FLOW_CFG     0x1220
-#define TISCI_MSG_RM_UDMAP_OPT_FLOW_CFG 0x1221
-
-#define TISCI_MSG_RM_UDMAP_TX_CH_CFG            0x1205
-#define TISCI_MSG_RM_UDMAP_RX_CH_CFG            0x1215
-#define TISCI_MSG_RM_UDMAP_FLOW_SIZE_THRESH_CFG 0x1231
-
-#define TISCI_MSG_FWL_SET          0x9000
-#define TISCI_MSG_FWL_GET          0x9001
-#define TISCI_MSG_FWL_CHANGE_OWNER 0x9002
 
 /**
  * @struct rx_msg

--- a/dts/bindings/firmware/ti,k2g-sci.yaml
+++ b/dts/bindings/firmware/ti,k2g-sci.yaml
@@ -16,6 +16,10 @@ properties:
     required: true
     description: Host ID for processor
 
+  ti,is-secure:
+    type: boolean
+    description: Indicates if the host is a secure entity
+
   mboxes:
     description: phandle to the MBOX controller (TX and RX are required)
     required: true


### PR DESCRIPTION
**Summary**
Add support for secure TISCI communication paths to enable usage of secure threads for communication.

**Changes:**
- Add is_secure flag to tisci_config for secure/non-secure path selection
- Implement tisci_msg_requires_secure_path() to identify messages requiring secure path
- Add secure header wrapping for outbound messages on secure path
- Add secure header parsing for inbound messages on secure path
- Improve error handling with proper semaphore cleanup in error paths
- Add ti,is-secure device tree property to indicate secure host entities

**Testing**
Change the host-id and thread ids in the core specific dt file and run the /tests/drivers/tisci