### PR TITLE
Cleanup a few unnecessary headers includes

### DIFF
--- a/samples/drivers/ipm/ipm_esp32/src/procpu_shell.c
+++ b/samples/drivers/ipm/ipm_esp32/src/procpu_shell.c
@@ -9,11 +9,6 @@
 #include <stdlib.h>
 
 #include <zephyr/device.h>
-#include <zephyr/drivers/regulator.h>
-#include <zephyr/drivers/watchdog.h>
-#include <zephyr/dt-bindings/gpio/nordic-npm6001-gpio.h>
-#include <zephyr/dt-bindings/regulator/npm6001.h>
-#include <zephyr/posix/unistd.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 

--- a/samples/shields/npm6001_ek/src/main.c
+++ b/samples/shields/npm6001_ek/src/main.c
@@ -11,10 +11,8 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/dt-bindings/gpio/nordic-npm6001-gpio.h>
 #include <zephyr/dt-bindings/regulator/npm6001.h>
-#include <zephyr/posix/unistd.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
-
 #include <zephyr/sys/sys_getopt.h>
 
 struct regulators_map {

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -12,12 +12,6 @@
 #include <zephyr/drivers/uart.h>
 #include <ctype.h>
 
-#ifdef CONFIG_NATIVE_LIBC
-#include <unistd.h>
-#else
-#include <zephyr/posix/unistd.h>
-#endif
-
 LOG_MODULE_REGISTER(app);
 
 extern void foo(void);


### PR DESCRIPTION
To use the shell one does not need anymore to pull unistd.h, if one uses sys_getopt, we need to include sys/sys_getopt.h.

For `samples/drivers/ipm/ipm_esp32/src/procpu_shell.c`, it seems all headers had just been copied from another sample even though none of the ones removed are used.