### PR TITLE
lib: cbprintf: fix printing high-bit characters

### DIFF
--- a/lib/os/cbprintf.c
+++ b/lib/os/cbprintf.c
@@ -46,7 +46,7 @@ static int str_out(int c,
 		*(scp->dp++) = c;
 	}
 
-	return c;
+	return (int) (unsigned char) c;
 }
 
 int fprintfcb(FILE *stream, const char *format, ...)

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -93,6 +93,8 @@
 #define PKG_ALIGN_OFFSET (size_t)0
 #endif
 
+static const char *utf8_str = "\xF0\x9F\xAA\x81";
+
 /* We can't determine at build-time whether int is 64-bit, so assume
  * it is.  If not the values are truncated at build time, and the str
  * pointers will be updated during test initialization.
@@ -1131,6 +1133,12 @@ ZTEST(prf, test_libc_substs)
 	zassert_equal(rc, 20, "rc %d", rc);
 	zassert_equal(lbuf[7], full_flag);
 	zassert_equal(strncmp("000000", lbuf, rc), 0);
+
+	memset(lbuf, full_flag, sizeof(lbuf));
+	rc = snprintfcb(lbuf, len, "%s", utf8_str);
+	zassert_equal(rc, strlen(utf8_str));
+	zassert_equal(lbuf[rc + 1], full_flag);
+	zassert_equal(strncmp(utf8_str, lbuf, rc), 0);
 
 	rc = cbprintf(out_counter, &count, "%020d", 1);
 	zassert_equal(rc, 20, "rc %d", rc);


### PR DESCRIPTION
The `cbprintf_cb` callback function taken by `cbvprintf()` may return a negative number to indicate an I/O error; in the success case, it is supposed to return the (positive) input. The `str_out()` implementation can never error (it just copies the input to a buffer), but it always returns its literal input. When called with a signed character with its MSB set (e.g., UTF-8-encoded text), the integer value is sign-extended, and the function returns a negative number. This is interpreted as an error by `outs()` (in `cbprintf_complete.c`), and so printing concludes after a single character.

For example, prior to this change, the assertion in this snippet fails:

```c
char buf[16];
int len = snprintfcb(buf, sizeof(buf), "\xED\xA0\xBD\xED\xB1\x8D");
assert(len == 6);
```

This can be seen when compiling with `CONFIG_CBPRINTF_LIBC_SUBSTS=y` and `CONFIG_CBPRINTF_NANO=n`, as covered by these unit tests:

```sh
west build --pristine --board unit_testing/unit_testing tests/unit/cbprintf/ --test-item utilities.prf.m32v101
# or
west build --pristine --board unit_testing/unit_testing tests/unit/cbprintf/ --test-item utilities.prf.m64v101
```

Then try:

```sh
./build/testbinary
```

...without and with the change to `lib/os/cbprintf.c`.