### PR TITLE
tracing: systemview: fix assertion fail on first thread switch

### DIFF
--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -33,6 +33,10 @@ void sys_trace_k_thread_switched_in(void)
 {
 	struct k_thread *thread;
 
+	if (k_is_pre_kernel()) {
+		return;
+	}
+
 	thread = k_current_get();
 
 	if (z_is_idle_thread_object(thread)) {


### PR DESCRIPTION
Segger Systemview calls` k_current_get() ` in `sys_trace_k_thread_switched_in()`. 
During early boot, this hook is triggered while `k_is_pre_kernel()` is true.

This triggers an assertion failure when CONFIG_ASSERT is enabled.

This patch adds a guard to ignore the thread switch event if it is called pre-kernel.