### PR TITLE
net: websocket: Remove unnecessary includes

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -22,12 +22,7 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
-#if defined(CONFIG_POSIX_API)
-#include <zephyr/posix/unistd.h>
-#include <zephyr/posix/sys/socket.h>
-#else
 #include <zephyr/net/socket.h>
-#endif
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/websocket.h>
 


### PR DESCRIPTION
Since d45cd6716bbab3a805e3a5fd461934f0dcdc13e5 this code does not use types defined in the POSIX_API and therefore we do not need to work around header include issues.