### PR TITLE
fs: zms: Add zms_mount_force()

### DIFF
--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -106,6 +106,10 @@ Mounting the storage system starts by getting the flash parameters, checking tha
 properties are correct (sector_size, sector_count ...) then calling the zms_init function to
 make the storage ready.
 
+By default, :c:func:`zms_mount` returns an error if the partition cannot be mounted.
+For recovery-oriented use cases, :c:func:`zms_mount_force` can be used to automatically
+wipe and reinitialize the partition when the first mount attempt fails.
+
 To mount the filesystem the following elements in the :c:struct:`zms_fs` structure must be initialized:
 
 .. code-block:: c
@@ -396,6 +400,8 @@ Version 1
 - Versioning of ZMS (to handle future evolutions)
 - Supports large ``write-block-size`` (only for platforms that need it)
 - Supports multiple ATE formats to satisfy the requirements of different applications
+- Supports forced mount recovery via :c:func:`zms_mount_force` (automatic partition wipe
+  and reinitialization on mount failure)
 
 Future features
 ===============
@@ -410,8 +416,6 @@ Future features
 - Add the possibility to retrieve the wear out value of the device based on the cycle count value
 - Add a recovery function that can recover a storage partition if something went wrong
 - Add a library/application to allow migration from NVS entries to ZMS entries
-- Add the possibility to force formatting the storage partition to the ZMS format if something
-  went wrong when mounting the storage.
 
 ZMS and other storage systems in Zephyr
 =======================================

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -103,6 +103,21 @@ typedef uint32_t zms_id_t;
 int zms_mount(struct zms_fs *fs);
 
 /**
+ * @brief Mount a ZMS file system onto the device specified in `fs`, wiping the partition if
+ * mounting fails the first time.
+ *
+ * @param fs Pointer to the file system.
+ *
+ * @retval 0 on success.
+ * @retval -ENOTSUP if the detected file system is not ZMS.
+ * @retval -EPROTONOSUPPORT if the ZMS version is not supported.
+ * @retval -EINVAL if `fs` is NULL or any of the flash parameters or the sector layout is invalid.
+ * @retval -ENXIO if there is a device error.
+ * @retval -EIO if there is a memory read/write error.
+ */
+int zms_mount_force(struct zms_fs *fs);
+
+/**
  * @brief Clear the ZMS file system from device. The ZMS file system must be re-mounted after this
  * operation.
  *

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -92,6 +92,12 @@ config SETTINGS_ZMS_LL_CACHE_SIZE
 	help
 	  Number of entries in Settings ZMS linked list cache.
 
+config SETTINGS_ZMS_FORCE_MOUNT
+	bool "ZMS force mount"
+	help
+	  Enable forcing of ZMS storage mount, wiping partition if necessary to recover from
+	  corrupted data.
+
 endif # SETTINGS_ZMS
 
 config SETTINGS_FCB

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -682,7 +682,11 @@ static int settings_zms_backend_init(struct settings_zms *cf)
 		return -ENODEV;
 	}
 
+#ifdef CONFIG_SETTINGS_ZMS_FORCE_MOUNT
+	rc = zms_mount_force(&cf->cf_zms);
+#else
 	rc = zms_mount(&cf->cf_zms);
+#endif
 	if (rc) {
 		return rc;
 	}

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -1318,3 +1318,78 @@ ZTEST_F(zms, test_zms_free_space_5sectors)
 	zassert_equal(free_space_total, zms_calc_free_space(&fixture->fs),
 		      "total free space did not match sum of gc'd sectors");
 }
+
+/*
+ * Test mounting recovery using zms_mount_force().
+ * Verifies that corrupted ZMS partition triggers mount failure when using zms_mount(),
+ * but auto-recovery when using zms_mount_force().
+ */
+ZTEST_F(zms, test_zms_mount_force)
+{
+	int err;
+	struct zms_ate close_ate;
+	struct zms_ate empty_ate;
+	uint32_t test_data = 0xDEADBEEFU;
+	ssize_t len;
+
+	/* Construct valid ZMS ATEs with UNSUPPORTED VERSION (version=2).
+	 * This will cause zms_init to detect ZMS magic but fail with -EPROTONOSUPPORT.
+	 */
+
+	/* Create close_ate with version=2, magic=0x42, format=0 */
+	memset(&close_ate, 0, sizeof(close_ate));
+	close_ate.id = ZMS_HEAD_ID;
+	close_ate.len = 0;
+	close_ate.cycle_cnt = 1;
+	close_ate.offset = 2 * sizeof(struct zms_ate); /* Points to close ATE location */
+	close_ate.metadata = FIELD_PREP(ZMS_VERSION_MASK, 2) |  /* Unsupported version */
+			     FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) |
+			     FIELD_PREP(ZMS_ATE_FORMAT_MASK, ZMS_DEFAULT_ATE_FORMAT);
+	close_ate.crc8 = crc8_ccitt(0xff,
+				    (uint8_t *)&close_ate + SIZEOF_FIELD(struct zms_ate, crc8),
+				    sizeof(struct zms_ate) - SIZEOF_FIELD(struct zms_ate, crc8));
+
+	/* Create empty_ate with version=2 */
+	memset(&empty_ate, 0, sizeof(empty_ate));
+	empty_ate.id = ZMS_HEAD_ID;
+	empty_ate.len = 0xffff;  /* Empty ATE marker */
+	empty_ate.cycle_cnt = 1;
+	empty_ate.metadata = FIELD_PREP(ZMS_VERSION_MASK, 2) |  /* Unsupported version */
+			     FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) |
+			     FIELD_PREP(ZMS_ATE_FORMAT_MASK, ZMS_DEFAULT_ATE_FORMAT);
+	empty_ate.crc8 = crc8_ccitt(0xff,
+				    (uint8_t *)&empty_ate + SIZEOF_FIELD(struct zms_ate, crc8),
+				    sizeof(struct zms_ate) - SIZEOF_FIELD(struct zms_ate, crc8));
+
+	/* Erase sector 0 before writing corrupted ATEs */
+	err = flash_erase(fixture->fs.flash_device, fixture->fs.offset, fixture->fs.sector_size);
+	zassert_true(err == 0, "flash_erase failed: %d", err);
+
+	/* Write corrupted ATEs to sector 0 */
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset + fixture->fs.sector_size - sizeof(struct zms_ate),
+			  &empty_ate, sizeof(empty_ate));
+	zassert_true(err == 0, "flash_write empty_ate failed: %d", err);
+
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset + fixture->fs.sector_size - 2 * sizeof(struct zms_ate),
+			  &close_ate, sizeof(close_ate));
+	zassert_true(err == 0, "flash_write close_ate failed: %d", err);
+
+	/* Test 1: Mount using zms_mount() - should FAIL with -EPROTONOSUPPORT */
+	err = zms_mount(&fixture->fs);
+	zassert_equal(err, -EPROTONOSUPPORT,
+		      "zms_mount should fail with -EPROTONOSUPPORT, got: %d", err);
+
+	/* Test 2: Mount with zms_mount_force - should SUCCEED (auto-wipe and recover) */
+	err = zms_mount_force(&fixture->fs);
+	zassert_true(err == 0, "zms_mount_force should succeed: %d", err);
+
+	/* Verify that the filesystem is functional after auto-wipe */
+	len = zms_write(&fixture->fs, 1, &test_data, sizeof(test_data));
+	zassert_equal(len, sizeof(test_data), "zms_write after recovery failed: %d", len);
+
+	len = zms_read(&fixture->fs, 1, &test_data, sizeof(test_data));
+	zassert_equal(len, sizeof(test_data), "zms_read after recovery failed: %d", len);
+	zassert_equal(test_data, 0xDEADBEEF, "read data mismatch after recovery");
+}


### PR DESCRIPTION
Add a `wipe_on_failure` parameter to zms_mount() that automatically wipes and reinitializes the partition if the initial mount fails.

A corresponding Kconfig option `SETTINGS_ZMS_WIPE_ON_MOUNT_FAILURE` is added to the settings subsystem to enable this feature when using ZMS as the storage backend.

Relates to #100948 