### PR TITLE
tests: Bluetooth: tester: Fix Central Address Resolution chr. read

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -619,6 +619,12 @@ struct btp_gap_periodic_biginfo_ev {
 	uint8_t encryption;
 } __packed;
 
+#define BTP_GAP_EV_PEER_CAR_RECEIVED 0x98
+struct btp_gap_peer_car_status_ev {
+	bt_addr_le_t address;
+	uint8_t car;
+} __packed;
+
 struct bt_le_per_adv_param;
 struct bt_le_per_adv_sync_param;
 struct bt_le_adv_param;


### PR DESCRIPTION
Addressing PTS v8.11.1b6 updates for PTS test cases:
GAP/CONN/DCON/BV-04-C
GAP/CONN/DCON/BV-05-C

Required  AutoPTS Changes https://github.com/auto-pts/auto-pts/pull/1660

CAR characteristic read process was incomplete, CAR status was not actually stored.

Added a new BTP_GAP_EV_PEER_CAR_RECEIVED to tester. This is to prevent disconnect events before IUT successfully reads CAR from central.

Updated start_directed_advertising() so that if the central has no CAR support we must not send directed advertisements. IUT might enter another connectable mode according to specification, thus IUT starts sending connectable undirected advertisements with resovable address.