### PR TITLE
modules: hal_nordic: nrfx: Move defines to header file

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -36,75 +36,75 @@ zephyr_include_directories(.)
 include(${BSP_DIR}/zephyr/nrfx.cmake OPTIONAL)
 
 # Define MDK defines globally
-zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51X       NRF51)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAA       NRF51422_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAB       NRF51422_XXAB)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAC       NRF51422_XXAC)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52805            NRF52805_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810            NRF52810_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52811            NRF52811_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52820            NRF52820_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832            NRF52832_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF52833 NRF52833_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840            NRF52840_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP NRF5340_XXAA_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET NRF5340_XXAA_NETWORK)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUAPP     NRF54H20_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51X       NRF51)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAA       NRF51422_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAB       NRF51422_XXAB)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAC       NRF51422_XXAC)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52805            NRF52805_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52810            NRF52810_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52811            NRF52811_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52820            NRF52820_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52832            NRF52832_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF52833 NRF52833_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF52840            NRF52840_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP NRF5340_XXAA_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET NRF5340_XXAA_NETWORK)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUAPP     NRF54H20_XXAA
                                                                 NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPURAD     NRF54H20_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPURAD     NRF54H20_XXAA
                                                                 NRF_RADIOCORE)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
                                                                 NRF_PPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
                                                                 NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA
                                                                 DEVELOP_IN_NRF54L15)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUAPP     NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUAPP     NRF_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUFLPR    NRF_FLPR)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA
                                                                 DEVELOP_IN_NRF54L15)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUAPP     NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15 NRF54L15_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA     NRF54LM20A_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A NRF54LM20A_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9120             NRF9120_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9160             NRF9160_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUAPP     NRF_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUFLPR    NRF_FLPR)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15 NRF54L15_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP NRF_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_CPUFLPR    NRF_FLPR)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA     NRF54LM20A_ENGA_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP NRF_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR NRF_FLPR)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A NRF54LM20A_ENGA_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A_CPUAPP NRF_APPLICATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF9120             NRF9120_XXAA)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF9160             NRF9160_XXAA)
 
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUAPP NRF9230_ENGB_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUAPP NRF9230_ENGB_XXAA
                                                                 NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPURAD NRF9230_ENGB_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPURAD NRF9230_ENGB_XXAA
                                                                 NRF_RADIOCORE)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUPPR NRF9230_ENGB_XXAA
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUPPR NRF9230_ENGB_XXAA
                                                                 NRF_PPR)
 
-zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_LOCK
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_LOCK
                                  ENABLE_APPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_USER_HANDLING
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_USER_HANDLING
                                  ENABLE_APPROTECT_USER_HANDLING
                                  ENABLE_AUTHENTICATED_APPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
                                  ENABLE_SECURE_APPROTECT
                                  ENABLE_SECUREAPPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_AUTHENTICATED_SECUREAPPROTECT)
 zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
                                  ENABLE_TRACE)
 
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUAPP
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUAPP
                                  NRF_SKIP_FICR_NS_COPY_TO_RAM)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF91X
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF91X
                                  NRF_SKIP_FICR_NS_COPY_TO_RAM)
 
 # Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
-zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
-zephyr_compile_definitions_ifdef(CONFIG_LOG_BACKEND_SWO ENABLE_SWO)
+zephyr_library_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
+zephyr_library_compile_definitions_ifdef(CONFIG_LOG_BACKEND_SWO ENABLE_SWO)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_NRF51X  ${MDK_DIR}/system_nrf51.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_NRF52805       ${MDK_DIR}/system_nrf52805.c)
@@ -222,13 +222,13 @@ if(CONFIG_SOC_NRF54L_CPUAPP_COMMON)
   # is using hfpll as CPU clock source (true for all existing devices).
   dt_prop(clock_frequency PATH "/clocks/hfpll" PROPERTY "clock-frequency")
   math(EXPR clock_frequency_mhz "${clock_frequency} / 1000000")
-  zephyr_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
+  zephyr_library_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
 endif()
 
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SKIP_CLOCK_CONFIG NRF_SKIP_CLOCK_CONFIGURATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF NRF_DISABLE_FICR_TRIMCNF)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE NRF_SKIP_GLITCHDETECTOR_DISABLE)
-zephyr_compile_definitions_ifndef(CONFIG_SOC_NRF54L_ANOMALY_56_WORKAROUND NRF54L_CONFIGURATION_56_ENABLE=0)
+zephyr_library_compile_definitions_ifdef(CONFIG_NRF_SKIP_CLOCK_CONFIG NRF_SKIP_CLOCK_CONFIGURATION)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF NRF_DISABLE_FICR_TRIMCNF)
+zephyr_library_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE NRF_SKIP_GLITCHDETECTOR_DISABLE)
+zephyr_library_compile_definitions_ifndef(CONFIG_SOC_NRF54L_ANOMALY_56_WORKAROUND NRF54L_CONFIGURATION_56_ENABLE=0)
 
 if(CONFIG_SOC_SERIES_NRF54HX AND CONFIG_NRFX_GPPI_V1)
   zephyr_library_sources(${HELPERS_DIR}/internal/nrfx_gppiv1_ipct.c)

--- a/modules/hal_nordic/nrfx/nrfx_kconfig.h
+++ b/modules/hal_nordic/nrfx/nrfx_kconfig.h
@@ -14,6 +14,168 @@
  * supported by nrfx (see the corresponding nrfx_config_*.h files).
  */
 
+#if defined(CONFIG_SOC_SERIES_NRF51X) && !defined(NRF51)
+#define NRF51
+#endif
+#if defined(CONFIG_SOC_NRF51822_QFAA) && !defined(NRF51422_XXAA)
+#define NRF51422_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF51822_QFAB) && !defined(NRF51422_XXAB)
+#define NRF51422_XXAB
+#endif
+#if defined(CONFIG_SOC_NRF51822_QFAC) && !defined(NRF51422_XXAC)
+#define NRF51422_XXAC
+#endif
+#if defined(CONFIG_SOC_NRF52805) && !defined(NRF52805_XXAA)
+#define NRF52805_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF52810) && !defined(NRF52810_XXAA)
+#define NRF52810_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF52811) && !defined(NRF52811_XXAA)
+#define NRF52811_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF52820) && !defined(NRF52820_XXAA)
+#define NRF52820_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF52832) && !defined(NRF52832_XXAA)
+#define NRF52832_XXAA
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF52833) && !defined(NRF52833_XXAA)
+#define NRF52833_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF52840) && !defined(NRF52840_XXAA)
+#define NRF52840_XXAA
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP) && !defined(NRF5340_XXAA_APPLICATION)
+#define NRF5340_XXAA_APPLICATION
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET) && !defined(NRF5340_XXAA_NETWORK)
+#define NRF5340_XXAA_NETWORK
+#endif
+#if defined(CONFIG_SOC_NRF54H20_CPUAPP) && !defined(NRF54H20_XXAA)
+#define NRF54H20_XXAA
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF54H20_CPURAD) && !defined(NRF54H20_XXAA)
+#define NRF54H20_XXAA
+#define NRF_RADIOCORE
+#endif
+#if defined(CONFIG_SOC_NRF54H20_CPUPPR) && !defined(NRF54H20_XXAA)
+#define NRF54H20_XXAA
+#define NRF_PPR
+#endif
+#if defined(CONFIG_SOC_NRF54H20_CPUFLPR) && !defined(NRF54H20_XXAA)
+#define NRF54H20_XXAA
+#define NRF_FLPR
+#endif
+#if defined(CONFIG_SOC_NRF54L05) && !defined(NRF54L05_XXAA)
+#define NRF54L05_XXAA
+#define DEVELOP_IN_NRF54L15
+#endif
+#if defined(CONFIG_SOC_NRF54L05_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF54L05_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+#if defined(CONFIG_SOC_NRF54L10) && !defined(NRF54L10_XXAA)
+#define NRF54L10_XXAA
+#define DEVELOP_IN_NRF54L15
+#endif
+#if defined(CONFIG_SOC_NRF54L10_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF54L10_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54L15) && !defined(NRF54L15_XXAA)
+#define NRF54L15_XXAA
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF54L15_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA) && !defined(NRF54LM20A_ENGA_XXAA)
+#define NRF54LM20A_ENGA_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LM20A) && !defined(NRF54LM20A_ENGA_XXAA)
+#define NRF54LM20A_ENGA_XXAA
+#endif
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LM20A_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF9120) && !defined(NRF9120_XXAA)
+#define NRF9120_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF9160) && !defined(NRF9160_XXAA)
+#define NRF9160_XXAA
+#endif
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPUAPP) && !defined(NRF9230_ENGB_XXAA)
+#define NRF9230_ENGB_XXAA
+#define NRF_APPLICATION
+#endif
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPURAD) && !defined(NRF9230_ENGB_XXAA)
+#define NRF9230_ENGB_XXAA
+#define NRF_RADIOCORE
+#endif
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPUPPR) && !defined(NRF9230_ENGB_XXAA)
+#define NRF9230_ENGB_XXAA
+#define NRF_PPR
+#endif
+#if defined(CONFIG_NRF_APPROTECT_LOCK) && !defined(CONFIG_NRF_APPROTECT_LOCK)
+#define ENABLE_APPROTECT
+#endif
+#if defined(CONFIG_NRF_APPROTECT_USER_HANDLING) && !defined(CONFIG_NRF_APPROTECT_USER_HANDLING)
+#define ENABLE_APPROTECT_USER_HANDLING
+#define ENABLE_AUTHENTICATED_APPROTECT
+#endif
+#if defined(CONFIG_NRF_SECURE_APPROTECT_LOCK) && !defined(CONFIG_NRF_SECURE_APPROTECT_LOCK)
+#define ENABLE_SECURE_APPROTECT
+#define ENABLE_SECUREAPPROTECT
+#endif
+#if defined(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING) && \
+	!defined(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING)
+#define ENABLE_SECURE_APPROTECT_USER_HANDLING
+#define ENABLE_AUTHENTICATED_SECUREAPPROTECT
+#endif
+#if defined(CONFIG_NRF_TRACE_PORT) && !defined(CONFIG_NRF_TRACE_PORT)
+#define ENABLE_TRACE
+#endif
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && !defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define NRF_SKIP_FICR_NS_COPY_TO_RAM
+#endif
+#if defined(CONFIG_SOC_SERIES_NRF91X) && !defined(CONFIG_SOC_SERIES_NRF91X)
+#define NRF_SKIP_FICR_NS_COPY_TO_RAM
+#endif
+#if defined(CONFIG_ARM_NONSECURE_FIRMWARE) && !defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_TRUSTZONE_NONSECURE
+#endif
+#if defined(CONFIG_LOG_BACKEND_SWO) && !defined(ENABLE_SWO)
+#define ENABLE_SWO
+#endif
+#if defined(CONFIG_NRF_SKIP_CLOCK_CONFIG) && !defined(NRF_SKIP_CLOCK_CONFIGURATION)
+#define NRF_SKIP_CLOCK_CONFIGURATION
+#endif
+#if defined(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF) && !defined(NRF_DISABLE_FICR_TRIMCNF)
+#define NRF_DISABLE_FICR_TRIMCNF
+#endif
+#if defined(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE) && \
+	!defined(NRF_SKIP_GLITCHDETECTOR_DISABLE)
+#define NRF_SKIP_GLITCHDETECTOR_DISABLE
+#endif
+#if !defined(zephyr_library_compile_definitions_ifndef) && !defined(NRF54L_CONFIGURATION_56_ENABLE)
+#define NRF54L_CONFIGURATION_56_ENABLE 0
+#endif
+
 #ifdef CONFIG_NRFX_ADC
 #define NRFX_ADC_ENABLED 1
 #endif
@@ -340,6 +502,7 @@
 #define NRF52_ERRATA_58_ENABLE_WORKAROUND 1
 #endif
 
+#if !defined(CONFIG_SOC_SERIES_BSIM_NRFXX) && defined(CONFIG_SOC_FAMILY_NORDIC_NRF)
 #define NRFX_SPIM_DT_HAS_RX_DELAY(node) DT_PROP(node, rx_delay_supported) +
 
 #ifndef NRFX_SPIM_EXTENDED_ENABLED
@@ -347,6 +510,7 @@
 #define NRFX_SPIM_EXTENDED_ENABLED 1
 #endif
 #endif
+#endif /* !defined(CONFIG_SOC_SERIES_BSIM_NRFXX) */
 
 #ifdef CONFIG_NRFX_SPIS
 #define NRFX_SPIS_ENABLED 1
@@ -462,6 +626,7 @@
 	CONFIG_NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE
 #endif
 
+#if !defined(CONFIG_SOC_SERIES_BSIM_NRFXX) && defined(CONFIG_SOC_FAMILY_NORDIC_NRF)
 /* If local or global DPPIC peripherals are used, provide the following macro
  * definitions required by the interconnect/ipct layer:
  * - NRFX_IPCTx_PUB_CONFIG_ALLOWED_CHANNELS_MASK_BY_INST_NUM(inst_num)
@@ -480,6 +645,8 @@
 		(NRFX_CONFIG_MASK_DT(node_id, owned_channels)), \
 		(COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, nordic_nrf_ipct_local), \
 			(BIT_MASK(DT_PROP(node_id, channels))), (0))))
+
+#endif /* !defined(CONFIG_SOC_SERIES_BSIM_NRFXX) */
 
 #if defined(NRF_APPLICATION)
 #define NRFX_CONFIG_IPCT_LOCAL_NODE DT_NODELABEL(cpuapp_ipct)

--- a/west.yml
+++ b/west.yml
@@ -344,7 +344,9 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 0f0c43748111c65800c6920f1c0690676423a351
+      revision: pull/11/head
+      remote: babblesim
+      repo-path: ext_nRF_hw_models
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 9f09f0785f9fc716514d8956a2a446021697400c


### PR DESCRIPTION
Moves defines to a header file to keep the locally defined to files that need them which are in or use files in the HAL rather than globally applying them to every file