### PR TITLE
openocd: espressif: enable thread awareness and update configurations

### DIFF
--- a/boards/01space/esp32c3_042_oled/support/openocd.cfg
+++ b/boards/01space/esp32c3_042_oled/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/adafruit/feather_esp32s2/support/openocd.cfg
+++ b/boards/adafruit/feather_esp32s2/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/adafruit/feather_esp32s3/support/openocd.cfg
+++ b/boards/adafruit/feather_esp32s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/adafruit/feather_esp32s3_tft/support/openocd.cfg
+++ b/boards/adafruit/feather_esp32s3_tft/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/adafruit/feather_esp32s3_tft_reverse/support/openocd.cfg
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/adafruit/qt_py_esp32s3/support/openocd.cfg
+++ b/boards/adafruit/qt_py_esp32s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/aithinker/esp32_cam/support/openocd.cfg
+++ b/boards/aithinker/esp32_cam/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/alientek/dnesp32s3b/support/openocd.cfg
+++ b/boards/alientek/dnesp32s3b/support/openocd.cfg
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Joel Guittet
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -3,7 +3,7 @@
 board_set_flasher_ifnset(esp32)
 board_set_debugger_ifnset(openocd)
 
-board_runner_args(openocd  --no-halt --no-targets --no-load)
+board_runner_args(openocd  --no-halt --no-targets --no-load --target-handle _TARGETNAME_0)
 board_runner_args(openocd  --gdb-init "set remote hardware-watchpoint-limit 2")
 
 board_runner_args(openocd  --gdb-init "maintenance flush register-cache")

--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -3,7 +3,7 @@
 board_set_flasher_ifnset(esp32)
 board_set_debugger_ifnset(openocd)
 
-board_runner_args(openocd  --no-init --no-halt --no-targets --no-load)
+board_runner_args(openocd  --no-halt --no-targets --no-load)
 board_runner_args(openocd  --gdb-init "set remote hardware-watchpoint-limit 2")
 
 board_runner_args(openocd  --gdb-init "maintenance flush register-cache")

--- a/boards/dptechnics/walter/support/openocd.cfg
+++ b/boards/dptechnics/walter/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/espressif/common/openocd-debugging.rst
+++ b/boards/espressif/common/openocd-debugging.rst
@@ -2,34 +2,50 @@
 
 .. espressif-openocd-debugging
 
-OpenOCD
-=======
+OpenOCD Debugging
+=================
 
-As with much custom hardware, the ESP32 modules require patches to
-OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD for ESP32`_.
+Espressif chips require a custom OpenOCD build with ESP32-specific patches.
+Download the latest release from `OpenOCD for ESP32`_.
 
-The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
-``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
-parameter when building.
+For detailed JTAG setup instructions, see `JTAG debugging for ESP32`_.
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32`_.
+Zephyr Thread Awareness
+-----------------------
 
-Here is an example for building the :zephyr:code-sample:`hello_world` application.
+OpenOCD supports Zephyr RTOS thread awareness, allowing GDB to:
 
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: <board>
-   :goals: build flash
-   :gen-args: -DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>
+- List all threads with ``info threads``
+- Display thread names, priorities, and states
+- Switch between thread contexts
+- Show backtraces for any thread
 
-You can debug an application in the usual way. Here is an example for the :zephyr:code-sample:`hello_world` application.
+**Requirements:**
+
+- `OpenOCD ESP32 v0.12.0-esp32-20251215`_ or later
+- Build with ``CONFIG_DEBUG_THREAD_INFO=y``
+
+**Example:**
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: <board>
    :goals: debug
+   :gen-args: -DCONFIG_DEBUG_THREAD_INFO=y -DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>
+
+Using a Custom OpenOCD
+----------------------
+
+The Zephyr SDK includes a bundled OpenOCD, but it may not have ESP32 support.
+To use the Espressif OpenOCD, specify the path when building:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: <board>
+   :goals: debug
+   :gen-args: -DOPENOCD=/path/to/openocd -DOPENOCD_DEFAULT_PATH=/path/to/openocd/scripts
 
 
 .. _`OpenOCD for ESP32`: https://github.com/espressif/openocd-esp32/releases
+.. _`OpenOCD ESP32 v0.12.0-esp32-20251215`: https://github.com/espressif/openocd-esp32/releases/tag/v0.12.0-esp32-20251215
 .. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html

--- a/boards/espressif/esp32_devkitc/support/openocd.cfg
+++ b/boards/espressif/esp32_devkitc/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/espressif/esp32_ethernet_kit/support/openocd.cfg
+++ b/boards/espressif/esp32_ethernet_kit/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/espressif/esp32c3_devkitc/support/openocd.cfg
+++ b/boards/espressif/esp32c3_devkitc/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/espressif/esp32c3_devkitm/support/openocd.cfg
+++ b/boards/espressif/esp32c3_devkitm/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/espressif/esp32c3_rust/support/openocd.cfg
+++ b/boards/espressif/esp32c3_rust/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/espressif/esp32c6_devkitc/support/openocd.cfg
+++ b/boards/espressif/esp32c6_devkitc/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32C6 has built-in JTAG interface over USB port in pins GPIO13/GPIO12 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32c6-builtin.cfg]

--- a/boards/espressif/esp32h2_devkitm/support/openocd.cfg
+++ b/boards/espressif/esp32h2_devkitm/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32H2 has built-in JTAG interface over USB port in pins GPIO26/GPIO27 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32h2-builtin.cfg]

--- a/boards/espressif/esp32s2_devkitc/support/openocd.cfg
+++ b/boards/espressif/esp32s2_devkitc/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/ftdi/esp32s2_kaluga_v1.cfg]
 source [find target/esp32s2.cfg]

--- a/boards/espressif/esp32s2_saola/support/openocd.cfg
+++ b/boards/espressif/esp32s2_saola/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/ftdi/esp32s2_kaluga_v1.cfg]
 source [find target/esp32s2.cfg]

--- a/boards/espressif/esp32s3_devkitc/support/openocd.cfg
+++ b/boards/espressif/esp32s3_devkitc/support/openocd.cfg
@@ -1,7 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
-# Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]
-# Source the ESP32-S3 configuration file
 source [find target/esp32s3.cfg]

--- a/boards/espressif/esp32s3_eye/support/openocd.cfg
+++ b/boards/espressif/esp32s3_eye/support/openocd.cfg
@@ -1,7 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
-# Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]
-# Source the ESP32-S3 configuration file
 source [find target/esp32s3.cfg]

--- a/boards/espressif/esp8684_devkitm/support/openocd.cfg
+++ b/boards/espressif/esp8684_devkitm/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # Use external JTAG interface, such as ESP-Prog
 source [find interface/ftdi/esp32_devkitj_v1.cfg]

--- a/boards/espressif/esp_wrover_kit/support/openocd.cfg
+++ b/boards/espressif/esp_wrover_kit/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/franzininho/esp32s2_franzininho/support/openocd.cfg
+++ b/boards/franzininho/esp32s2_franzininho/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/ftdi/esp32s2_kaluga_v1.cfg]
 source [find target/esp32s2.cfg]

--- a/boards/heltec/heltec_wireless_stick_lite_v3/support/openocd.cfg
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/heltec/heltec_wireless_tracker/support/openocd.cfg
+++ b/boards/heltec/heltec_wireless_tracker/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/kincony/kincony_kc868_a32/support/openocd.cfg
+++ b/boards/kincony/kincony_kc868_a32/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/lilygo/tdongle_s3/support/openocd.cfg
+++ b/boards/lilygo/tdongle_s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/lilygo/ttgo_lora32/support/openocd.cfg
+++ b/boards/lilygo/ttgo_lora32/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/lilygo/ttgo_t7v1_5/support/openocd.cfg
+++ b/boards/lilygo/ttgo_t7v1_5/support/openocd.cfg
@@ -1,4 +1,5 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/lilygo/ttgo_t8c3/support/openocd.cfg
+++ b/boards/lilygo/ttgo_t8c3/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/lilygo/ttgo_t8s3/support/openocd.cfg
+++ b/boards/lilygo/ttgo_t8s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/lilygo/ttgo_tbeam/support/openocd.cfg
+++ b/boards/lilygo/ttgo_tbeam/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/lilygo/ttgo_toiplus/support/openocd.cfg
+++ b/boards/lilygo/ttgo_toiplus/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/lilygo/twatch_s3/support/openocd.cfg
+++ b/boards/lilygo/twatch_s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/luatos/esp32c3_luatos_core/support/openocd.cfg
+++ b/boards/luatos/esp32c3_luatos_core/support/openocd.cfg
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/luatos/esp32s3_luatos_core/support/openocd.cfg
+++ b/boards/luatos/esp32s3_luatos_core/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/m5stack/m5stack_core2/support/openocd.cfg
+++ b/boards/m5stack/m5stack_core2/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/m5stack/m5stack_cores3/support/openocd.cfg
+++ b/boards/m5stack/m5stack_cores3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/m5stack/m5stack_fire/support/openocd.cfg
+++ b/boards/m5stack/m5stack_fire/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/m5stack/m5stack_nanoc6/support/openocd.cfg
+++ b/boards/m5stack/m5stack_nanoc6/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32C6 has built-in JTAG interface over USB port in pins GPIO13/GPIO12 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32c6-builtin.cfg]

--- a/boards/m5stack/m5stickc_plus/support/openocd.cfg
+++ b/boards/m5stack/m5stickc_plus/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/m5stack/stamp_c3/support/openocd.cfg
+++ b/boards/m5stack/stamp_c3/support/openocd.cfg
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/olimex/olimex_esp32_evb/support/openocd.cfg
+++ b/boards/olimex/olimex_esp32_evb/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/others/doit_esp32_devkit_v1/support/openocd.cfg
+++ b/boards/others/doit_esp32_devkit_v1/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/others/esp32c3_lckfb/support/openocd.cfg
+++ b/boards/others/esp32c3_lckfb/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/others/esp32c3_supermini/support/openocd.cfg
+++ b/boards/others/esp32c3_supermini/support/openocd.cfg
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Arrel Neumiller
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/others/icev_wireless/support/openocd.cfg
+++ b/boards/others/icev_wireless/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/pcbcupid/glyph_c6/support/openocd.cfg
+++ b/boards/pcbcupid/glyph_c6/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32C6 has built-in JTAG interface over USB port in pins GPIO13/GPIO12 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32c6-builtin.cfg]

--- a/boards/rakwireless/rak3112/support/openocd.cfg
+++ b/boards/rakwireless/rak3112/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/seeed/xiao_esp32c3/support/openocd.cfg
+++ b/boards/seeed/xiao_esp32c3/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/esp_usb_jtag.cfg]
 

--- a/boards/seeed/xiao_esp32c6/support/openocd.cfg
+++ b/boards/seeed/xiao_esp32c6/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32C6 has built-in JTAG interface over USB port in pins GPIO13/GPIO12 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32c6-builtin.cfg]

--- a/boards/seeed/xiao_esp32s3/support/openocd.cfg
+++ b/boards/seeed/xiao_esp32s3/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/vcc-gnd/yd_esp32/support/openocd.cfg
+++ b/boards/vcc-gnd/yd_esp32/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/boards/waveshare/esp32s3_geek/support/openocd.cfg
+++ b/boards/waveshare/esp32s3_geek/support/openocd.cfg
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Joel Guittet
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/waveshare/esp32s3_matrix/support/openocd.cfg
+++ b/boards/waveshare/esp32s3_matrix/support/openocd.cfg
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Joel Guittet
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/support/openocd.cfg
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/support/openocd.cfg
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Joel Guittet
 # SPDX-License-Identifier: Apache-2.0
 
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/we/orthosie1ev/support/openocd.cfg
+++ b/boards/we/orthosie1ev/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/weact/esp32c3_mini/support/openocd.cfg
+++ b/boards/weact/esp32c3_mini/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 # ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
 # Uncomment the line below to enable USB debugging.

--- a/boards/weact/esp32c6_mini/support/openocd.cfg
+++ b/boards/weact/esp32c6_mini/support/openocd.cfg
@@ -1,4 +1,4 @@
 # ESP32C6 has built-in JTAG interface over USB port in pins GPIO13/GPIO12 (D-/D+).
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find board/esp32c6-builtin.cfg]

--- a/boards/weact/esp32s3_mini/support/openocd.cfg
+++ b/boards/weact/esp32s3_mini/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/weact/weact_esp32s3_b/support/openocd.cfg
+++ b/boards/weact/weact_esp32s3_b/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 # Source the JTAG interface configuration file
 source [find interface/esp_usb_jtag.cfg]

--- a/boards/wemos/esp32s2_lolin_mini/support/openocd.cfg
+++ b/boards/wemos/esp32s2_lolin_mini/support/openocd.cfg
@@ -1,4 +1,4 @@
-set ESP_RTOS none
+set ESP_RTOS Zephyr
 
 source [find interface/ftdi/esp32s2_kaluga_v1.cfg]
 source [find target/esp32s2.cfg]

--- a/boards/wemos/lolin32_lite/support/openocd.cfg
+++ b/boards/wemos/lolin32_lite/support/openocd.cfg
@@ -1,5 +1,5 @@
-set ESP_RTOS none
-set ESP32_ONLYCPU 1
+set ESP_RTOS Zephyr
+set ESP_ONLYCPU 1
 
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 source [find target/esp32.cfg]

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -86,12 +86,16 @@ const size_t _kernel_thread_info_offsets[] = {
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread,
 						callee_saved.thread_status),
 #elif defined(CONFIG_XTENSA)
-	/* Xtensa does not store stack pointers inside thread objects.
-	 * The registers are saved in thread stack where there is
-	 * no fixed location for this to work. So mark this as
-	 * unimplemented to avoid the #warning below.
-	 */
+/* Xtensa does not store stack pointers inside thread objects.
+ * The registers are saved in thread stack where there is
+ * no fixed location for this to work. It needs arch_switch in
+ * order to work on Xtensa.
+ */
+#ifdef CONFIG_USE_SWITCH
+	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread, switch_handle),
+#else
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
+#endif
 #elif defined(CONFIG_RX)
 	/* RX doesn't store *anything* inside thread objects yet */
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,


### PR DESCRIPTION
1. Remove --no-init from openocd runner args to fix debugserver on boards with built-in USB JTAG
2. Set correct target handle (_TARGETNAME_0) for ESP32 OpenOCD RTOS support
3. Enable ESP_RTOS Zephyr on all ESP32 boards for thread-aware debugging
4. Add _ESP_SMP_TARGET 0 for dual-core boards (ESP32, ESP32-S3) to workaround OpenOCD SMP issue
5. Document thread awareness requirements (OpenOCD v0.12.0-esp32-20251215+, CONFIG_DEBUG_THREAD_INFO=y)

Fixes #96102
Fixes #62791