### PR TITLE
arch posix: cleanup NATIVE_APPLICATION support remnants

### DIFF
--- a/arch/posix/core/CMakeLists.txt
+++ b/arch/posix/core/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_compile_definitions(NO_POSIX_CHEATS)
 zephyr_library_sources(
   cpuhalt.c
   fatal.c

--- a/boards/native/common/sdl/CMakeLists.txt
+++ b/boards/native/common/sdl/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 zephyr_library()
 
-zephyr_library_compile_definitions(NO_POSIX_CHEATS)
-
 find_package(PkgConfig REQUIRED)
 pkg_search_module(SDL2 REQUIRED sdl2)
 

--- a/boards/native/native_sim/CMakeLists.txt
+++ b/boards/native/native_sim/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 zephyr_library()
 
-zephyr_library_compile_definitions(NO_POSIX_CHEATS)
-
 zephyr_library_sources(
   cmdline.c
   cpu_wait.c

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -114,13 +114,11 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE uart_handlers.c)
 # zephyr-keep-sorted-stop
 
 if(CONFIG_UART_NATIVE_PTY)
-  zephyr_library_compile_definitions(NO_POSIX_CHEATS)
   zephyr_library_sources(uart_native_pty.c)
   target_sources(native_simulator INTERFACE uart_native_pty_bottom.c)
 endif()
 
 if(CONFIG_UART_NATIVE_TTY)
-  zephyr_library_compile_definitions(NO_POSIX_CHEATS)
   zephyr_library_sources(uart_native_tty.c)
   target_sources(native_simulator INTERFACE uart_native_tty_bottom.c)
 endif()

--- a/soc/native/inf_clock/CMakeLists.txt
+++ b/soc/native/inf_clock/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 zephyr_library()
 
-zephyr_library_compile_definitions(NO_POSIX_CHEATS)
-
 zephyr_library_sources(
   soc.c
   native_tasks.c


### PR DESCRIPTION
NO_POSIX_CHEATS was a macro used to avoid including the content of a header (`posix_cheats.h`) which allowed building applications in the POSIX architecture without the native simulator, avoiding collisions between some embedded symbols and those from the host C library.

Support for this way of building, and this header and macro were removed in e150ffb92c83a52f88f467e625028952f9574a74, but these users were forgotten. This was harmless, but let's just clean it up now.
