### PR TITLE
include: tracing: add missing k_thread_heap_assign tracing hook

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -85,6 +85,13 @@
 #define sys_port_trace_k_thread_user_mode_enter()
 
 /**
+ * @brief Called when a resource pool is assigned to a thread
+ * @param thread Thread object
+ * @param heap Heap object
+ */
+#define sys_port_trace_k_thread_heap_assign(thread, heap)
+
+/**
  * @brief Called when entering a k_thread_join
  * @param thread Thread object
  * @param timeout Timeout period


### PR DESCRIPTION
Add sys_port_trace_k_thread_heap_assign macro which was defined in all backend implementations but missing from the main tracing.h header.

This macro traces when a resource pool is assigned to a thread via k_thread_heap_assign().