### PR TITLE
cyw920829 low power management related fixes

### DIFF
--- a/drivers/rtc/rtc_infineon.c
+++ b/drivers/rtc/rtc_infineon.c
@@ -169,7 +169,7 @@ static int ifx_cat1_rtc_init(const struct device *dev)
 		}
 
 #ifdef CONFIG_PM
-		rslt = Cy_SysPm_RegisterCallback(&_ifx_cat1_rtc_pm_cb)
+		rslt = Cy_SysPm_RegisterCallback(&_ifx_cat1_rtc_pm_cb);
 #endif /* CONFIG_PM */
 
 		if (rslt == CY_RSLT_SUCCESS) {

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -59,10 +59,11 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	uint32_t delta_ticks =
 		((uint64_t)(lptimer_value - last_lptimer_value) * CONFIG_SYS_CLOCK_TICKS_PER_SEC) /
 		LPTIMER_FREQ;
-	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 	last_lptimer_value += (delta_ticks * LPTIMER_FREQ) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 
 	k_spin_unlock(&lock, key);
+
+	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)


### PR DESCRIPTION
-  driver: timer: cyw20829 sys_clock_announce moved outside of spinlock context
-  driver: rtc: compilation error fixed