### PR TITLE
drivers: ethernet: dwmac: Fix Kconfig for stm32h7

### DIFF
--- a/drivers/ethernet/Kconfig.dwmac
+++ b/drivers/ethernet/Kconfig.dwmac
@@ -3,12 +3,11 @@
 # Copyright (c) 2021 BayLibre SAS
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig ETH_DWMAC
-	bool "Synopsys DesignWare MAC driver"
-	default y
+menu "Synopsys DesignWare MAC driver"
+
+config ETH_DWMAC
+	bool
 	depends on NET_BUF_FIXED_DATA_SIZE
-	depends on (SOC_SERIES_STM32H7X && !ETH_STM32_HAL) || MMU
-	depends on DT_HAS_SNPS_DESIGNWARE_ETHERNET_ENABLED
 	help
 	  This is a driver for the Synopsys DesignWare MAC, also referred to
 	  as "DesignWare Cores Ethernet Quality-of-Service". Hardware versions
@@ -25,19 +24,30 @@ menuconfig ETH_DWMAC
 	  - VLAN support
 	  - various hardware offloads (when available)
 
-if ETH_DWMAC
-
 config ETH_DWMAC_STM32H7X
-	bool
+	bool "Synopsys DesignWare MAC driver for STM32H7 series"
+	depends on !ETH_STM32_HAL
 	depends on SOC_SERIES_STM32H7X
+	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
+	select ETH_DWMAC
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select PINCTRL
 	default y
+	help
+	  This enables the Synopsys DesignWare MAC driver on STM32H7 series
+	  SoCs.
 
 config ETH_DWMAC_MMU
-	bool
+	bool "Synopsys DesignWare MAC driver for MMU based platforms"
 	depends on MMU
+	depends on DT_HAS_SNPS_DESIGNWARE_ETHERNET_ENABLED
+	select ETH_DWMAC
 	default y
+	help
+	  This enables the Synopsys DesignWare MAC driver on MMU based
+	  platforms.
+
+if ETH_DWMAC
 
 config DWMAC_NB_TX_DESCS
 	int "Number of entries in the transmit descriptor ring"
@@ -67,3 +77,5 @@ config DWMAC_NB_RX_DESCS
 	  dropped packets.
 
 endif # ETH_DWMAC
+
+endmenu

--- a/tests/drivers/build_all/ethernet/boards/qemu_cortex_a9.overlay
+++ b/tests/drivers/build_all/ethernet/boards/qemu_cortex_a9.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 The Zephyr Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		eth0: ethernet@40000000 {
+			compatible = "snps,designware-ethernet";
+			reg = <0x40000000 0x2000>;
+			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			local-mac-address = [00 11 22 33 44 55];
+		};
+	};
+};

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -23,3 +23,12 @@ tests:
       - CONFIG_ETH_STM32_MULTICAST_FILTER=y
     platform_allow:
       - stm32h573i_dk
+
+  net.ethernet.build.stm32_dwmac:
+    extra_configs:
+      - CONFIG_ETH_STM32_HAL=n
+      - CONFIG_MDIO_ST_STM32_HAL=n
+      - CONFIG_ETH_DWMAC_STM32H7X=y
+      - CONFIG_ETH_PHY_DRIVER=n
+    platform_allow:
+      - stm32h735g_disco


### PR DESCRIPTION
The DWMAC driver was no longer selectable for STM32H7 series because of `CONFIG_ETH_DWMAC`'s dependency on `DT_HAS_SNPS_DESIGNWARE_ETHERNET_MMU_ENABLED`, which is only used for MMU based platforms.

This PR restructures the Kconfig to have user-selectable options for the platform-specific DWMAC drivers and select the common DWMAC driver accordingly. This way platform-specific dependencies can be tracked on these options, simplifying the logic.

Additionally, the DWMAC driver has been included in the Ethernet build-all test suite to improve pipeline coverage and help prevent future regressions.