### PR TITLE
west.yml: Replace native_posix by native_sim in tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -394,7 +394,7 @@ manifest:
       revision: ac80c3bf2b88deec86d129654fbde09761582342
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
-      revision: 9b07780aca6fb21f82a241ba386ad9b379809337
+      revision: 9164bd18dcd88ff9d9ef98279501fc1093571017
       path: modules/lib/zcbor
   # zephyr-keep-sorted-stop
 


### PR DESCRIPTION
Repalce the native_posix by native_sim in tests and reformat platform list to allow twister to correct recognize the platforms.

Fixes #101300