### PR TITLE
posix: mutex: annotate intentional unreachable code for Coverity

### DIFF
--- a/lib/posix/options/mutex.c
+++ b/lib/posix/options/mutex.c
@@ -148,6 +148,7 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 			do {
 				(void)k_sleep(K_FOREVER);
 			} while (true);
+			/* [coverity: unreachable] */
 			CODE_UNREACHABLE;
 			break;
 		case PTHREAD_MUTEX_RECURSIVE:


### PR DESCRIPTION
Coverity reports structurally dead code in the POSIX mutex implementation. The code path is intentionally unreachable and uses CODE_UNREACHABLE macro.

Annotate the statement to silence the false positive while keeping the existing logic unchanged.

Fixes #99981