### PR TITLE
counter: mcux_lptmr: Fix prescaler/glitch filter configuration

### DIFF
--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -542,7 +542,7 @@
 			clocks = <&scmi_clk IMX95_CLK_LPTMR2>;
 			clock-frequency = <DT_FREQ_K(32)>;
 			clk-source = <2>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			resolution = <32>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -289,7 +289,7 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <58 0>;
 			clock-frequency = <DT_FREQ_K(128)>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <16>;
 		};

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -204,7 +204,7 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <29 0>;
 			clock-frequency = <DT_FREQ_K(128)>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <16>;
 		};

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -296,7 +296,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -507,7 +507,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -449,7 +449,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxa5x_common.dtsi
@@ -508,7 +508,7 @@
 		reg = <0xab000 0x1000>;
 		interrupts = <55 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
 	};

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -197,7 +197,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -555,7 +555,7 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <58 0>;
 			clock-frequency = <1000>;
-			prescale-glitch-filter = <0>;
+			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <16>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -983,7 +983,7 @@
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
 	};
@@ -993,7 +993,7 @@
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
 	};

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1087,7 +1087,7 @@
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
 	};
@@ -1097,7 +1097,7 @@
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
 	};

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -336,7 +336,7 @@
 		interrupts = <34 0>;
 		clock-frequency = <32768>;
 		clk-source = <2>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		resolution = <32>;
 		status = "disabled";
 	};
@@ -347,7 +347,7 @@
 		interrupts = <35 0>;
 		clock-frequency = <32768>;
 		clk-source = <2>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		resolution = <32>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -925,7 +925,7 @@
 		reg = <0x4300000 0x1000>;
 		interrupts = <18 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";
@@ -936,7 +936,7 @@
 		reg = <0x24d0000 0x1000>;
 		interrupts = <67 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";
@@ -947,7 +947,7 @@
 		reg = <0x2cd0000 0x1000>;
 		interrupts = <150 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescale-glitch-filter = <0>;
+		prescale-glitch-filter-bypass;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -52,21 +52,29 @@ properties:
     required: true
     description: Represents the width of the counter in bits.
 
+  prescale-glitch-filter-bypass:
+    type: boolean
+    description: |
+      Controls the clocking of Counter (CNR). If false, the output of the prescaler
+      or glitch filter clocks CNR. If true, the selected prescaler clock in Time
+      Counter mode, or the selected input source in Pulse Counter mode, directly
+      clocks CNR.
+
   prescale-glitch-filter:
     type: int
     default: 0
-    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     description: |
-      When in prescaler mode, if prescale-glitch-filter is 0, the prescaler
-        is bypassed, the selected prescaler clock increments Counter (CNR) on every
-        clock cycle. Otherwise the counter is incremented every
-        2 ^ [prescaler-glitch-filter] clock cycles.
-      When in pulse mode, if prescale-glitch-filter is 0, the glitch filter
-        is bypassed, the selected input source increments the value of Counter(CNR)
-        every time it asserts. Otherwise the counter is incremented every
-        2 ^ [prescaler-glitch-filter] rising edges detected by the pin configured
-        from the input-pin value.
-      Note, that the pulse mode cannot be 2 ^ 16.
+      Configures the size of the prescaler in Time Counter mode and the width of the
+      glitch filter in Pulse Counter mode.
+
+      Note: If ``prescale-glitch-filter-bypass`` is set, this property is ignored.
+      When in prescaler mode, prescaler divides the prescaler clock by
+        2^(prescaler-glitch-filter + 1)
+      When in pulse mode, prescale-glitch-filter = 0 is not supported for glitch
+        filtering. To request no filtering, set ``prescale-glitch-filter-bypass``.
+        If prescale-glitch-filter is greater than 0, glitch filter recognizes change
+        on input pin after 2^prescale-glitch-filter rising clock edges.
 
   timer-mode-sel:
     type: int


### PR DESCRIPTION
and frequency calculation

- Change prescale-glitch-filter-bypass from boolean to int enum [0, 1] to align with hardware register representation
- Fix prescaler division calculation in time counter mode to use 2^(value + 1) instead of 2^value
- Fix glitch filter calculation in pulse counter mode to use 2^value
- Introduce MCUX_LPTMR_EFFECTIVE_FREQ macro to correctly calculate counter frequency based on mode and bypass settings
- Remove incorrect prescaler_glitch offset calculation that added timer_mode_sel - 1
- Update prescale-glitch-filter enum range from [0-16] to [0-15] as pulse mode cannot support value 16
- Improve BUILD_ASSERT error message for prescale-glitch-filter range
- Update devicetree binding documentation to clarify prescaler and glitch filter behavior

This fixes incorrect counter frequency reporting and ensures the prescaler/glitch filter values are correctly mapped to hardware register settings according to the NXP LPTMR reference manual.