### PR TITLE
drivers: can: mcan: add timestamp counter support

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1469,6 +1469,23 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	/*
+	 * Enable the internal timestamp counter by default. SoC-specific driver frontends can
+	 * overwrite this if configured for using a SoC-specific, external timestamp counter.
+	 */
+	reg = FIELD_PREP(CAN_MCAN_TSCC_TCP, config->timestamp_prescaler - 1U) |
+		FIELD_PREP(CAN_MCAN_TSCC_TSS, 1U);
+#else /* CONFIG_CAN_RX_TIMESTAMP */
+	/* Disable timestamp counter */
+	reg = 0U;
+#endif /* !CONFIG_CAN_RX_TIMESTAMP */
+
+	err = can_mcan_write_reg(dev, CAN_MCAN_TSCC, reg);
+	if (err != 0) {
+		return err;
+	}
+
 	err = can_mcan_read_reg(dev, CAN_MCAN_TEST, &reg);
 	if (err != 0) {
 		return err;

--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -24,3 +24,28 @@ properties:
       Rx Buffers	    0-64 elements / 0-1152 words
       Tx Event FIFO	  0-32 elements / 0-64 words
       Tx Buffers	    0-32 elements / 0-576 words
+
+  bosch,timestamp-counter-prescaler:
+    type: int
+    enum:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+    default: 1
+    description: |
+      Configures the internal timestamp counter time unit in multiples of CAN bit times. Valid range
+      is 1 to 16. The default value is a prescaler of 1, such that the time unit equals one CAN bit
+      time.

--- a/dts/bindings/can/nxp,lpc-mcan.yaml
+++ b/dts/bindings/can/nxp,lpc-mcan.yaml
@@ -16,3 +16,15 @@ properties:
 
   clocks:
     required: true
+
+  use-external-timestamp-counter:
+    type: boolean
+    description: |
+      Use external 16-bit timestamp counter clocked by the CPUCLK.
+
+  external-timestamp-counter-prescaler:
+    type: int
+    default: 1
+    description: |
+      Configure the prescaler for the external timestamp counter. Valid range is 1 to 2048. Default
+      is 1, corresponding to the ETSCC register reset value.

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1238,6 +1238,9 @@ struct can_mcan_config {
 	uint16_t mram_offsets[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	size_t mram_size;
 	const void *custom;
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	uint8_t timestamp_prescaler;
+#endif /* CONFIG_CAN_RX_TIMESTAMP */
 };
 
 /**
@@ -1298,6 +1301,8 @@ struct can_mcan_config {
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
 		.custom = _custom,                                                                 \
+		COND_CODE_1(IS_ENABLED(CONFIG_CAN_RX_TIMESTAMP),                                   \
+		(.timestamp_prescaler = DT_PROP(node_id, bosch_timestamp_counter_prescaler),), ()) \
 	}
 #else /* CONFIG_CAN_FD_MODE */
 #define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops, _cbs)                                       \
@@ -1309,6 +1314,8 @@ struct can_mcan_config {
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
 		.custom = _custom,                                                                 \
+		COND_CODE_1(IS_ENABLED(CONFIG_CAN_RX_TIMESTAMP),                                   \
+		(.timestamp_prescaler = DT_PROP(node_id, bosch_timestamp_counter_prescaler),), ()) \
 	}
 #endif /* !CONFIG_CAN_FD_MODE */
 


### PR DESCRIPTION
- Add support for configuring and enabling the internal timestamp counter of the Bosch M_CAN IP core. Frontend drivers can overwrite this configuration for using a SoC-specific, external timestamp counter.
- Enable support for configuring and enabling the external timestamp counter of the NXP LPC MCAN.
