### PR TITLE
tests: build_all: display: Update test cases to behave as intended

### DIFF
--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
@@ -19,7 +19,6 @@ supported:
   - uart
   - dma
   - i2c
-  - display
   - spi
   - flash
 vendor: bflb

--- a/tests/drivers/build_all/display/testcase.yaml
+++ b/tests/drivers/build_all/display/testcase.yaml
@@ -3,19 +3,13 @@ common:
   tags:
     - drivers
     - display
-  depends_on: display
 
 tests:
   drivers.display.build.default:
     integration_platforms:
       - native_sim
       - native_sim/native/64
-
-  drivers.display.build.rk055hdmipi4ma0:
-    platform_allow:
-      - mimxrt1170_evk/mimxrt1176/cm7
-    extra_args:
-      - SHIELD=rk055hdmipi4ma0
+    depends_on: display
 
   drivers.display.build.bflb_dbi:
     platform_allow:


### PR DESCRIPTION
Following discussion in https://github.com/zephyrproject-rtos/zephyr/pull/99549#discussion_r2631615093
and looking at the commit: https://github.com/zephyrproject-rtos/zephyr/commit/23871f6ecba7e8f630788197f0cf754da625ed21, that indicates the mixrt case is only an example

do this: 

- move depends on to only apply to default case
- remove 'example' case
- remove unnecessary display tag on ai_m62_12f_kit