### PR TITLE
Tpm pwm mode support

### DIFF
--- a/dts/bindings/pwm/nxp,kinetis-tpm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-tpm.yaml
@@ -31,6 +31,17 @@ properties:
       - 128
     description: Input clock prescaler
 
+  pwm-mode:
+    type: int
+    enum:
+      - 0
+      - 1
+    description: |
+      TPM PWM operation mode
+        0 - Edge aligned PWM (kTPM_EdgeAlignedPwm)
+        1 - Center aligned PWM (kTPM_CenterAlignedPwm)
+      Default is edge aligned PWM if not specified.
+
   "#pwm-cells":
     const: 3
 

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxw71_2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxw71_2.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2026 NXP
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,11 @@
 	aliases {
 		pwm-test = &tpm0;
 	};
+};
+
+/* Add node label for twister test case drivers.pwm.tpm.center */
+pwm_test_center: &tpm0 {
+	status = "okay";
 };
 
 /* To test this sample, check the wave from PTA21(J1-8). */
@@ -24,4 +29,5 @@
 	status = "okay";
 	pinctrl-0 = <&tpm0_default>;
 	pinctrl-names = "default";
+	pwm-mode = <1>;
 };

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -159,3 +159,14 @@ tests:
       - s32k5xxcvb/s32k566/m7
       - s32k5xxcvb/s32k566/r52
     depends_on: pwm
+  drivers.pwm.tpm.center:
+    tags:
+      - drivers
+      - pwm
+      - userspace
+    extra_args:
+      - platform:frdm_mcxw71/mcxw716c:DTC_OVERLAY_FILE="boards/frdm_mcxw71_2.overlay"
+    platform_allow:
+      - frdm_mcxw71
+    filter: dt_nodelabel_enabled("pwm_test_center") and CONFIG_DT_HAS_NXP_KINETIS_TPM_ENABLED
+    depends_on: pwm

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -171,6 +171,10 @@ ZTEST_USER(pwm_loopback, test_capture_timeout)
 		err = pwm_capture_cycles(in.dev, in.pwm,
 					 PWM_CAPTURE_TYPE_PERIOD, &period,
 					 &pulse, K_MSEC(1000));
+		if (err == -ENOTSUP) {
+			TC_PRINT("capture type not supported\n");
+			ztest_test_skip();
+		}
 	}
 
 	zassert_equal(err, -EAGAIN, "pwm capture did not timeout (err %d)",
@@ -246,9 +250,14 @@ ZTEST(pwm_loopback, test_continuous_capture)
 					    PWM_CAPTURE_MODE_CONTINUOUS |
 					    PWM_CAPTURE_TYPE_PERIOD,
 					    continuous_capture_callback, &data);
-		zassert_equal(err, 0, "failed to configure pwm input (err %d)",
-			      err);
-		data.pulse_capture = false;
+		if (err == -ENOTSUP) {
+			TC_PRINT("capture type not supported\n");
+			ztest_test_skip();
+		} else {
+			zassert_equal(err, 0, "failed to configure pwm input (err %d)",
+					err);
+			data.pulse_capture = false;
+		}
 	}
 
 	err = pwm_enable_capture(in.dev, in.pwm);
@@ -308,9 +317,14 @@ ZTEST(pwm_loopback, test_capture_busy)
 		flags = PWM_CAPTURE_MODE_SINGLE | PWM_CAPTURE_TYPE_PERIOD;
 		err = pwm_configure_capture(in.dev, in.pwm, in.flags | flags,
 					    continuous_capture_callback, &data);
-		zassert_equal(err, 0, "failed to configure pwm input (err %d)",
-			      err);
-		data.pulse_capture = false;
+		if (err == -ENOTSUP) {
+			TC_PRINT("capture type not supported\n");
+			ztest_test_skip();
+		} else {
+			zassert_equal(err, 0, "failed to configure pwm input (err %d)",
+					err);
+			data.pulse_capture = false;
+		}
 	}
 
 	err = pwm_enable_capture(in.dev, in.pwm);


### PR DESCRIPTION
1. Fix bugs
    1. Do not set up pwm for all channels when specific channel is provided.
    2. Do not use interrupt setting to judge whether channel is active, because it may be disabled in IRQ
3. PWM center align mode support
4. Update pwm_loopback test case when capture mode is not support