### PR TITLE
firmware: scmi: lock all pm states in interrupt flow

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -115,6 +115,13 @@ static int scmi_send_message_polling(struct scmi_protocol *proto,
 	int ret;
 	int status;
 
+	/* wait for channel to be free */
+	ret = k_mutex_lock(&proto->tx->lock, K_NO_WAIT);
+	if (ret < 0) {
+		LOG_ERR("failed to acquire chan lock");
+		return -EBUSY;
+	}
+
 	/*
 	 * SCMI communication interrupt is enabled by default during setup_chan
 	 * to support interrupt-driven communication. When using polling mode
@@ -151,6 +158,8 @@ cleanup:
 	if (status >= 0) {
 		scmi_interrupt_enable(proto->tx, true);
 	}
+
+	k_mutex_unlock(&proto->tx->lock);
 
 	return ret;
 }


### PR DESCRIPTION
Prevent system from entering low power modes during SCMI message transmission to avoid channel conflicts.

When PM is enabled, the system may enter idle mode while waiting for SCMI reply. If the idle transition itself requires SCMI communication, it causes concurrent channel access and corrupts the channel state.

Lock all PM states before sending SCMI messages and unlock after completion to ensure exclusive channel access during the entire transaction.

This issue only affects interrupt-driven SCMI communication. Polling mode is not affected as it already disables interrupts.