### PR TITLE
subsys/mgmt: Declare PROCESSOR_NAME for native_sim

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
@@ -184,6 +184,22 @@ extern "C" {
 #define PROCESSOR_NAME "sparc"
 #endif
 
+#if defined(CONFIG_ARCH_POSIX)
+#if defined(PROCESSOR_NAME)
+#error "Processor name already selected; compile-time check should be removed."
+#endif
+
+#if defined(__x86_64__)
+#define PROCESSOR_NAME "x86_64"
+#elif defined(__i386__)
+#define PROCESSOR_NAME "x86"
+#elif defined(__aarch64__)
+#define PROCESSOR_NAME "aarch64"
+#elif defined(__arm__)
+#define PROCESSOR_NAME "arm"
+#endif
+#endif
+
 #ifndef PROCESSOR_NAME
 #warning "Processor type could not be determined"
 #define PROCESSOR_NAME "unknown"


### PR DESCRIPTION
I don't think this value can be elegantly selected in Kconfig like it is for actual boards, so falling back to selecting it by compiler definitions should be required.

This was intentionally put outside of the regular #elif block because it follows a different pattern and this block should be removed if in the future the CONFIG_architecture can properly be selected by the Kconfig/Cmake system somehow.