### PR TITLE
drivers: display: co5300: Fix pitch calculation in write function

### DIFF
--- a/drivers/display/display_co5300.c
+++ b/drivers/display/display_co5300.c
@@ -154,7 +154,7 @@ static int co5300_write(const struct device *dev,
 	uint16_t end_pos;
 	uint8_t cmd_params[4];
 	struct mipi_dsi_msg msg = {0};
-	uint32_t total_bytes_sent = 0U;
+	uint16_t line_each_sent = 0U;
 	int bytes_written = 0;
 	const uint8_t *src;
 	uint32_t tx_size = 0U;
@@ -247,10 +247,9 @@ static int co5300_write(const struct device *dev,
 
 		/* Advance source pointer and decrement remaining */
 		if (local_desc.pitch > local_desc.width) {
-			total_bytes_sent += bytes_written;
-			src += bytes_written + total_bytes_sent /
-				(local_desc.width * data->bytes_per_pixel) *
-				((local_desc.pitch - local_desc.width) * data->bytes_per_pixel);
+			line_each_sent = bytes_written / (local_desc.width * data->bytes_per_pixel);
+			src += line_each_sent * local_desc.pitch * data->bytes_per_pixel;
+			src += bytes_written % (local_desc.width * data->bytes_per_pixel);
 		} else {
 			src += bytes_written;
 		}


### PR DESCRIPTION
The previous implementation incorrectly calculated the source pointer advancement when pitch differs from width. The calculation was using `total_bytes_sent` which accumulated across iterations, leading to incorrect pointer arithmetic.

Replace `total_bytes_sent` with `line_each_sent` to track lines written per iteration. Simplify the pointer advancement by:
- Calculating complete lines written from bytes_written
- Advancing by full pitch-sized lines
- Adding any remaining partial line bytes

This fixes the source pointer calculation when the buffer pitch is greater than the display width.