### PR TITLE
Xtensa ace bug

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1068,7 +1068,9 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 	k_spinlock_key_t key;
 
 	src_l2_table = (uint32_t *)PTE_PPN_GET(l1_table[l1_pos]);
-
+	if (!src_l2_table) {
+		return;
+	}
 	key = k_spin_lock(&xtensa_counter_lock);
 	if (l2_page_tables_counter[l2_table_to_counter_pos(src_l2_table)] == 1) {
 		/* Only one user of L2 table, no need to duplicate. */
@@ -1077,6 +1079,7 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 	}
 
 	l2_table = dup_l2_table(src_l2_table, action);
+	__ASSERT(l2_table, "dup_l2_table() failed");
 
 	/* The page table is using kernel ASID because we don't
 	 * user thread manipulate it.


### PR DESCRIPTION
Ensure `dup_l2_table_if_needed()` safely handles cases where the
source L2 page table pointer is NULL and where `dup_l2_table()`
may fail due to allocation failure. Previously, dereferencing
`src_l2_table` without a NULL check could lead to a fault, and no
check was present for the return value of `dup_l2_table()`. This
change avoids dereferencing NULL and returns early when duplication
fails, with a kernel assert in debug builds to catch failures during
development/testing.

Fixes: #101339