### PR TITLE
drivers: timer: Fix radio timer issue on STM32WB07/STM32WB05

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -951,5 +951,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    entropy_stm32_rng_init,
 		    PM_DEVICE_DT_INST_GET(0),
 		    &entropy_stm32_rng_data, &entropy_stm32_rng_config,
-		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
+		    STM32_TRNG_INIT_LEVEL, CONFIG_ENTROPY_INIT_PRIORITY,
 		    &entropy_stm32_rng_api);

--- a/drivers/entropy/entropy_stm32.h
+++ b/drivers/entropy/entropy_stm32.h
@@ -18,10 +18,18 @@
 #if IRQLESS_TRNG
 #define DT_DRV_COMPAT st_stm32_rng_noirq
 #define TRNG_GENERATION_DELAY	K_NSEC(DT_INST_PROP_OR(0, generation_delay_ns, 0))
+
+/* In IRQ-less hardware, the system workqueue is used to poll the TRNG
+ * during driver initialization. Since the workqueue service is not available
+ * in PRE_KERNEL_1/PRE_KERNEL_2, the init routine must run at POST_KERNEL.
+ */
+#define STM32_TRNG_INIT_LEVEL POST_KERNEL
+
 #else /* !IRQLESS_TRNG */
 #define DT_DRV_COMPAT st_stm32_rng
 #define IRQN		DT_INST_IRQN(0)
 #define IRQ_PRIO	DT_INST_IRQ(0, priority)
+#define STM32_TRNG_INIT_LEVEL PRE_KERNEL_1
 #endif /* IRQLESS_TRNG */
 
 /* Cross-series LL compatibility wrappers */

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -45,6 +45,7 @@ static const uint32_t calibration_data_freq1 = 0x0028F5C2;
 uint32_t blue_unit_conversion(uint32_t time, uint32_t period_freq, uint32_t thr);
 
 static uint64_t announced_cycles;
+static uint32_t last_cpu_wakeup_time;
 
 static void radio_timer_error_isr(void *args)
 {
@@ -69,7 +70,16 @@ static void radio_timer_cpu_wkup_isr(void *args)
 
 	ARG_UNUSED(args);
 
-	HAL_RADIO_TIMER_TimeoutCallback();
+	last_cpu_wakeup_time = LL_RADIO_TIMER_GetAbsoluteTime(WAKEUP);
+
+	/* Clear the interrupt */
+	LL_RADIO_TIMER_ClearFlag_CPUWakeup(WAKEUP);
+
+	/* Read back the register to ensure that the previous
+	 * write operation is completed.
+	 */
+	LL_RADIO_TIMER_IsActiveFlag_CPUWakeup(WAKEUP);
+
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		diff_cycles = HAL_RADIO_TIMER_GetCurrentSysTime() - announced_cycles;
 		dticks = (int32_t)k_cyc_to_ticks_near64(diff_cycles);
@@ -85,7 +95,17 @@ static void radio_timer_txrx_wkup_isr(void *args)
 {
 	ARG_UNUSED(args);
 
-	HAL_RADIO_TIMER_WakeUpCallback();
+	/* The callback body will be properly implemented in the future
+	 * while providing PM support for WB06/WB07.
+	 */
+
+	/* Clear the interrupt */
+	LL_RADIO_TIMER_ClearFlag_BLEWakeup(WAKEUP);
+
+	/* Read back the register to ensure that the previous
+	 * write operation is completed.
+	 */
+	LL_RADIO_TIMER_IsActiveFlag_BLEWakeup(WAKEUP);
 }
 #endif /* CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB07XX */
 
@@ -99,6 +119,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t current_time, delay;
+		uint32_t key;
 
 		ticks = MAX(1, ticks);
 		delay = blue_unit_conversion(k_ticks_to_cyc_near32(ticks), calibration_data_freq1,
@@ -108,9 +129,20 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		} else {
 			delay = MAX(MIN_ALLOWED_DELAY, delay);
 		}
-		current_time = LL_RADIO_TIMER_GetAbsoluteTime(WAKEUP);
+		key = irq_lock();
+
+		/* Due to a hardware limitation, the radio timer wake-up time
+		 * must not be updated until at least 16 Machine Time Units
+		 * have elapsed since the interrupt was triggered; otherwise,
+		 * the next wake-up will only occur after the timer wraps around.
+		 */
+		do {
+			current_time = LL_RADIO_TIMER_GetAbsoluteTime(WAKEUP);
+		} while ((current_time - last_cpu_wakeup_time) < 16U);
+
 		LL_RADIO_TIMER_SetCPUWakeupTime(WAKEUP, current_time + delay + TIMER_ROUNDING);
 		LL_RADIO_TIMER_EnableCPUWakeupTimer(WAKEUP);
+		irq_unlock(key);
 	}
 }
 

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(radio_timer_driver);
 BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_NODELABEL(clk_lsi), disabled),
 	     "LSI is not supported yet");
 
-#if (defined(CONFIG_SOC_STM32WB06XX) || defined(CONFIG_SOC_STM32WB06XX)) && defined(CONFIG_PM)
+#if (defined(CONFIG_SOC_STM32WB06XX) || defined(CONFIG_SOC_STM32WB07XX)) && defined(CONFIG_PM)
 #error "PM is not supported yet for WB06/WB07"
 #endif /* (CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB06XX) && CONFIG_PM */
 

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ec0fe4a09a5bbf0e482ab1f4bd42d66131c64369
+      revision: e05bb4707857ecf4344c29a9407aaa4227407546
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- Change the initialization priority in `entropy_stm32.c` when there is a `IRQLESS_TRNG` SoC.  According to the documentation, kernel services should not be used during device configuration with PRE_KERNEL_1.
In "entropy_stm32_rng_init", there is "start_pool_filling" which calls
"k_work_schedule". Moreover, "k_work_schedule" requires system timer which
is initialized within PRE_KERNEL_2. Therefore, the SoC gets stuck.

- Due to the hardware limitation, the time between the CPU wake-up IRQ fire
(IRQ 23) and the next call of LL_RADIO_TIMER_SetCPUWakeupTime should not
be less than 16 MTU (Machine Time Unit), i.e. approximately 30us.
otherwise, the next CPU wake-up doesn't happen unless the timer wraps.

- Lock IRQs while sys_clock_set_timeout is being executed.

Supplementary PR[#337](https://github.com/zephyrproject-rtos/hal_stm32/pull/337)