### PR TITLE
stm32l562e_dk: tests: drivers: fix regresssion in flash&psa tests drivers and add support for mcuboot 

### DIFF
--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,display = &st7789v;
 	};
@@ -49,9 +50,24 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* 2KB at the end of 512KB flash is set for storage */
-		storage_partition: partition@7f800 {
-			reg = <0x0007f800 DT_SIZE_K(2)>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(48)>;
+		};
+
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000c000 DT_SIZE_K(228)>;
+		};
+
+		slot1_partition: partition@45000 {
+			label = "image-1";
+			reg = <0x00045000 DT_SIZE_K(230)>;
+		};
+
+		storage_partition: partition@7e800 {
+			label = "storage";
+			reg = <0x0007e800 DT_SIZE_K(6)>;
 		};
 	};
 };

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -34,6 +34,7 @@ tests:
       - stm32h573i_dk
       - stm32h573i_dk/stm32h573xx/ext_flash_app
       - stm32h750b_dk/stm32h750xx/ext_flash_app
+      - stm32l562e_dk
       - stm32u083c_dk
       - stm32wba65i_dk1
       - sam_e54_xpro

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -70,6 +70,7 @@ tests:
       - nucleo_wba65ri
       - nucleo_wl55jc
       - stm32f3_disco
+      - stm32l562e_dk
       - stm32u083c_dk
       - stm32wba65i_dk1
     integration_platforms:

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -14,6 +14,7 @@ common:
     - nucleo_wl55jc
     - stm32f3_disco
     - stm32h573i_dk
+    - stm32l562e_dk
     - stm32u083c_dk
     - stm32wba65i_dk1
   timeout: 600
@@ -47,6 +48,7 @@ tests:
       - nucleo_wba65ri
       - nucleo_wl55jc
       - stm32f3_disco
+      - stm32l562e_dk
       - stm32u083c_dk
       - stm32wba65i_dk1
     integration_platforms:


### PR DESCRIPTION
This pull request introduces the following changes:

- Add stm32l562e_dk board as an allowed platform for executing tests in CI.
- Add support swap using offset logic 

These changes are necessary to:

- Enable MCUboot tests on the stm32l562e_dk board.
- Fix issues detected in common flash and PSA test drivers related to slot size alignment.