### PR TITLE
drivers: gpio: emul: validate pins in single-pin APIs and  mask in port APIs

### DIFF
--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -333,10 +333,21 @@ int gpio_emul_input_set_masked(const struct device *port, gpio_port_pins_t mask,
 			      gpio_port_value_t values)
 {
 	struct gpio_emul_data *drv_data = (struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
 	gpio_port_pins_t prev_input_values;
 	gpio_port_pins_t input_values;
 	k_spinlock_key_t key;
 	int rv;
+
+	if (mask == 0) {
+		return 0;
+	}
+
+	if ((config->common.port_pin_mask & mask) == 0) {
+		LOG_ERR("Pin not supported port_pin_mask=%x mask=%x", config->common.port_pin_mask,
+			mask);
+		return -EINVAL;
+	}
 
 	key = k_spin_lock(&drv_data->lock);
 	prev_input_values = drv_data->input_vals;
@@ -473,6 +484,12 @@ static int gpio_emul_pin_get_config(const struct device *port, gpio_pin_t pin,
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
+
+	if ((config->common.port_pin_mask & BIT(pin)) == 0) {
+		return -EINVAL;
+	}
+
 	k_spinlock_key_t key;
 
 	key = k_spin_lock(&drv_data->lock);
@@ -522,8 +539,12 @@ static int gpio_emul_port_set_masked_raw(const struct device *port,
 	gpio_port_pins_t input_mask;
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
+
 	k_spinlock_key_t key;
 	int rv;
+
+	mask &= config->common.port_pin_mask;
 
 	key = k_spin_lock(&drv_data->lock);
 	output_mask = get_output_pins(port);
@@ -556,11 +577,15 @@ static int gpio_emul_port_set_bits_raw(const struct device *port,
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
+
 	k_spinlock_key_t key;
 	gpio_port_pins_t prev_input_values;
 	gpio_port_pins_t input_values;
 	gpio_port_pins_t input_mask;
 	int rv;
+
+	pins &= config->common.port_pin_mask;
 
 	key = k_spin_lock(&drv_data->lock);
 	pins &= get_output_pins(port);
@@ -584,11 +609,15 @@ static int gpio_emul_port_clear_bits_raw(const struct device *port,
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
+
 	k_spinlock_key_t key;
 	gpio_port_pins_t prev_input_values;
 	gpio_port_pins_t input_values;
 	gpio_port_pins_t input_mask;
 	int rv;
+
+	pins &= config->common.port_pin_mask;
 
 	key = k_spin_lock(&drv_data->lock);
 	pins &= get_output_pins(port);
@@ -610,8 +639,12 @@ static int gpio_emul_port_toggle_bits(const struct device *port, gpio_port_pins_
 {
 	struct gpio_emul_data *drv_data =
 		(struct gpio_emul_data *)port->data;
+	const struct gpio_emul_config *config = (const struct gpio_emul_config *)port->config;
+
 	k_spinlock_key_t key;
 	int rv;
+
+	pins &= config->common.port_pin_mask;
 
 	key = k_spin_lock(&drv_data->lock);
 	drv_data->output_vals ^= (pins & get_output_pins(port));


### PR DESCRIPTION
Add input validation to single-pin GPIO APIs (e.g., gpio_pin_configure) and emulator-specific helpers to return -EINVAL for invalid pins. This ensures tests correctly fail when targeting non-existent pins.

For standard port-wide APIs (e.g., gpio_port_set_bits_raw), align behavior with hardware drivers by masking out invalid pins instead of returning an error. This mimics hardware behavior where writing to unimplemented bits is ignored, and ensures compatibility with generic tests that use full 32-bit masks (e.g., 0xFFFFFFFF).