### PR TITLE
xtensa: mmu: add assertions and system halting point if there are not enough free L2 tables to be allocated

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -968,8 +968,14 @@ static uint32_t *dup_l2_table(uint32_t *src_l2_table, enum dup_action action)
 	uint32_t *l2_table;
 
 	l2_table = alloc_l2_table();
+
+	/* Duplicating L2 tables is a must-have and must-success operation.
+	 * If we are running out of free L2 tables to be allocated, we cannot
+	 * continue.
+	 */
+	__ASSERT_NO_MSG(l2_table != NULL);
 	if (l2_table == NULL) {
-		return NULL;
+		arch_system_halt(K_ERR_KERNEL_PANIC);
 	}
 
 	switch (action) {

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -407,6 +407,15 @@ static void map_memory_range(const uint32_t start, const uint32_t end,
 			__ASSERT(l2_table != NULL,
 				 "There is no l2 page table available to map 0x%08x\n", page);
 
+			if (l2_table == NULL) {
+				/* This function is called during boot. If this cannot
+				 * properly map all predefined memory regions, it is very
+				 * unlikely for anything to run correctly. So forcibly
+				 * halt the system in case assertion has been turned off.
+				 */
+				arch_system_halt(K_ERR_KERNEL_PANIC);
+			}
+
 			init_page_table(l2_table, L2_PAGE_TABLE_NUM_ENTRIES, PTE_L2_ILLEGAL);
 
 			xtensa_kernel_ptables[l1_pos] =


### PR DESCRIPTION
This adds some assertions when there are not enough free L2 page tables to be allocated. And adds system halting point after these assertions in case assertion is disabled via kconfigs.

Also adds debug logging on page table pool usage during de-/allocation so that there are some visual clues on whether there are enough tables in the pool.

Fixes #101339 