### PR TITLE
github: Add copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# GitHub Copilot Instructions
+
+This project follows the coding and contribution guidelines outlined in the [Zephyr Project Documentation](https://docs.zephyrproject.org/latest/). GitHub Copilot should follow these principles when providing suggestions for code completion and reviews:
+
+## Coding Style and Guidelines
+- Adhere to the coding style defined in the [Coding Guidelines](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html).
+  - Ensure code is formatted to meet these style requirements.
+  - Prefer functions and constructs defined in the guidelines.
+
+## Contribution Guidelines
+- Follow the contribution process described in the [Contribution Guide](https://docs.zephyrproject.org/latest/contribute/index.html).
+  - Maintain consistency with existing code.
+  - Require commits to follow the format specified in the guidelines.
+
+## Key Practices for Copilot
+- Prefer idiomatic Zephyr APIs and patterns where applicable.
+- Use documentation examples as the default reference for common tasks.
+- Avoid recommendations that diverge from the principles outlined in the Zephyr documentation.
+
+For detailed standards, contributors are expected to review the latest version of the Zephyr Project documentation linked above.


### PR DESCRIPTION
Add the copilot-instructions.md that Github Copilot will use when performing e.g. code review, as defined by https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review

The content of the file is generated by https://github.com/copilot based on a few inputs, and can be modified/extended as we want.

The purpose of adding the file is to improve the quality and process of using Github Copilot for reviews, and help catch more "trivial" issues and help users to more easily follow the contribution and coding guidelines.