### PR TITLE
doc: build: use dt_freq_m in example

### DIFF
--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -362,7 +362,7 @@ child device on an existing bus node, do something like this:
 
 		/* Configure other SPI device properties as needed.
 		 * Find your device's DT binding for details. */
-		spi-max-frequency = <4000000>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 	};
    };
 


### PR DESCRIPTION
Example dts should use dt_freq_m instead of lots of zeros.