### PR TITLE
posix: pthread: use non-zero size for pthread stack min

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -54,8 +54,8 @@ extern "C" {
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT {0}
 
-/* The minimum allowable stack size */
-#define PTHREAD_STACK_MIN K_KERNEL_STACK_LEN(0)
+/* The minimum allowable stack size (sufficient space to perform a context switch) */
+#define PTHREAD_STACK_MIN CONFIG_IDLE_STACK_SIZE
 
 /**
  * @brief Declare a condition variable as initialized


### PR DESCRIPTION
Fix Coverity CIDs 316801 and 434530 (comparing an unsigned value to zero).

Fixes #99971
Fixes #99977