### PR TITLE
libc/picolibc: Implement fdopen in terms of zvfs APIs

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -354,6 +354,18 @@ ssize_t zvfs_read(int fd, void *buf, size_t sz, const size_t *from_offset);
  */
 ssize_t zvfs_write(int fd, const void *buf, size_t sz, const size_t *from_offset);
 
+/**
+ * @brief Set I/O position of file.
+ *
+ * @param fd File descriptor index
+ * @param offset New file I/O position
+ * @param whence Offset relative to 0 - offset is absolute.
+ * 1 - offset is relative to current. 2 - offset is relative to end.
+ *
+ * @return New position or (off_t) -1 with errno set on failure.
+ */
+off_t zvfs_lseek(int fd, off_t offset, int whence);
+
 #ifdef CONFIG_ZVFS_DEFAULT_FILE_VMETHODS
 int zvfs_ioctl_vmeth(void *obj, unsigned int request, va_list args);
 int zvfs_close_vmeth(void *obj);

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_library_sources(
   locks.c
   stdio.c
   )
+zephyr_library_sources_ifdef(CONFIG_ZVFS_FDTABLE fdopen.c)
 zephyr_include_directories(include)
 
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,prohibit_lto>)

--- a/lib/libc/picolibc/fdopen.c
+++ b/lib/libc/picolibc/fdopen.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2025, Keith Packard <keithp@keithp.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio-bufio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <zephyr/sys/fdtable.h>
+
+/* not exported by picolibc */
+int
+__stdio_flags(const char *mode, int *optr);
+
+static ssize_t
+_read(int fd, void *buf, size_t sz)
+{
+	return zvfs_read(fd, buf, sz, NULL);
+}
+
+static ssize_t
+_write(int fd, const void *buf, size_t sz)
+{
+	return zvfs_write(fd, buf, sz, NULL);
+}
+
+FILE *
+fdopen(int fd, const char *mode)
+{
+	int stdio_flags;
+	int open_flags;
+	struct __file_bufio *bf;
+	char *buf;
+
+	stdio_flags = __stdio_flags(mode, &open_flags);
+	if (stdio_flags == 0) {
+		return NULL;
+	}
+
+	/* Allocate file structure and necessary buffers */
+	bf = calloc(1, sizeof(struct __file_bufio) + BUFSIZ);
+
+	if (bf == NULL) {
+		return NULL;
+	}
+
+	buf = (char *) (bf + 1);
+
+	*bf = (struct __file_bufio)
+		FDEV_SETUP_BUFIO(fd, buf, BUFSIZ,
+				 _read,
+				 _write,
+				 zvfs_lseek,
+				 zvfs_close,
+				 stdio_flags, __BFALL);
+
+	if (open_flags & O_APPEND) {
+		(void) fseeko(&(bf->xfile.cfile.file), 0, SEEK_END);
+	}
+
+	return &(bf->xfile.cfile.file);
+}

--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -435,17 +435,25 @@ FILE *zvfs_fdopen(int fd, const char *mode)
 		return NULL;
 	}
 
+#ifdef CONFIG_PICOLIBC
+	return fdopen(fd, mode);
+#else
 	return (FILE *)&fdtable[fd];
+#endif
 }
 
 int zvfs_fileno(FILE *file)
 {
+#ifdef CONFIG_PICOLIBC
+	return fileno(file);
+#else
 	if (!IS_ARRAY_ELEMENT(fdtable, file)) {
 		errno = EBADF;
 		return -1;
 	}
 
 	return (struct fd_entry *)file - fdtable;
+#endif
 }
 
 int zvfs_fstat(int fd, struct zvfs_stat *buf)

--- a/lib/posix/options/device_io.c
+++ b/lib/posix/options/device_io.c
@@ -13,10 +13,6 @@
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/sys/select.h>
 
-/* prototypes for external, not-yet-public, functions in fdtable.c or fs.c */
-FILE *zvfs_fdopen(int fd, const char *mode);
-int zvfs_fileno(FILE *file);
-
 static struct fd_op_vtable posix_op_vtable = {
 	.read = zvfs_read_vmeth,
 	.write = zvfs_write_vmeth,
@@ -52,6 +48,11 @@ int close(int fd)
 FUNC_ALIAS(close, _close, int);
 #endif
 
+#ifndef CONFIG_PICOLIBC
+/* prototypes for external, not-yet-public, functions in fdtable.c or fs.c */
+FILE *zvfs_fdopen(int fd, const char *mode);
+int zvfs_fileno(FILE *file);
+
 FILE *fdopen(int fd, const char *mode)
 {
 	return zvfs_fdopen(fd, mode);
@@ -61,6 +62,7 @@ int fileno(FILE *file)
 {
 	return zvfs_fileno(file);
 }
+#endif
 
 static int posix_mode_to_zephyr(int mf)
 {


### PR DESCRIPTION
Use picolibc 'bufio' interfaces to provide a non-POSIX implementation of fdopen. This depends upon CONFIG_ZVFS_FDTABLE as that provides an fd abstraction on top of regular zephyr APIs.

Use this API to provide zvfs_fdopen and zvfs_fileno.