### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -326,7 +326,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 234c66e66ee39c0f836a57ba805245534be332f2
+      revision: 9ac72969f281491d677e669d053281fc2d538ed4
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  9ac72969f281491d677e669d053281fc2d538ed4

Brings following Zephyr relevant fixes:

  - 9ac72969 boot: bootutil: loader: Fix bootstrap copying in swap move mode
  - 3f69203f bootutil: ed25519 psa: Merge bootutil_verify_sig and bootutil_verify
  - 7f354916 bootutil: Remove bootutil_verify_img
  - 7cec4af1 bootutil: Replace bootutil_verify_img with bootutil_verify_sig
  - 4a57d03d boot: zephyr: socs: stm32h7s3xx: Add support for ext_flash_app variant
  - a21fd276 bootutil: Small logging improvements
  - 0acc9806 bootutil: boot_read_enc_key now returns boolean
  - 553be8b0 readme: Update for next dev release
  - eecc3f7d Release v2.3.0

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.