### PR TITLE
samples: mgmt: mcumgr: smp_svr: Fix shell-mgmt Kconfig conflict

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/shell-mgmt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/shell-mgmt.conf
@@ -4,3 +4,6 @@ CONFIG_CRC=y
 CONFIG_SHELL=y
 CONFIG_SHELL_BACKEND_DUMMY=y
 CONFIG_MCUMGR_GRP_SHELL=y
+
+# Disable serial backend to prevent conflict with MCUmgr serial Kconfig fragment
+CONFIG_SHELL_BACKEND_SERIAL=n


### PR DESCRIPTION
Disables the shell serial backend in this Kconfig fragment to prevent conflicting with the serial one

Fixes #100546