### PR TITLE
scripts: west_commands: build: support --cmake-opt

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -263,7 +263,7 @@ class Build(Forceable):
             else:
                 self.die("test item path does not exist")
 
-        self._run_cmake(board, origin, self.args.cmake_opts)
+        self._run_cmake(board, origin)
         if args.cmake_only:
             return
 
@@ -625,7 +625,7 @@ class Build(Forceable):
                 self.source_dir = self._find_source_dir()
                 self._sanity_check_source_dir()
 
-    def _run_cmake(self, board, origin, cmake_opts):
+    def _run_cmake(self, board, origin):
         if board is None and config_getboolean('board_warn', True):
             self.wrn('This looks like a fresh build and BOARD is unknown;',
                     "so it probably won't work. To fix, use",

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -13,11 +13,11 @@ import pytest
 
 TEST_CASES = [
     {'r': [],
-     's': None, 'c': None},
+     's': None, 'c': []},
     {'r': ['source_dir'],
-     's': 'source_dir', 'c': None},
+     's': 'source_dir', 'c': []},
     {'r': ['source_dir', '--'],
-     's': 'source_dir', 'c': None},
+     's': 'source_dir', 'c': []},
     {'r': ['source_dir', '--', 'cmake_opt'],
      's': 'source_dir', 'c': ['cmake_opt']},
     {'r': ['source_dir', '--', 'cmake_opt', 'cmake_opt2'],
@@ -27,7 +27,7 @@ TEST_CASES = [
     {'r': ['thing_one', 'thing_two', 'thing_three'],
      's': 'thing_one', 'c': ['thing_two', 'thing_three']},
     {'r': ['--'],
-     's': None, 'c': None},
+     's': None, 'c': []},
     {'r': ['--', '--'],
      's': None, 'c': ['--']},
     {'r': ['--', 'cmake_opt'],

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -4,9 +4,10 @@
 
 from argparse import Namespace
 
-from build import Build
+from build import Build, SYSBUILD_PROJ_DIR
 from build_helpers import DEFAULT_BUILD_DIR
 from pathlib import Path
+import argparse
 import configparser
 import os
 import pytest
@@ -59,6 +60,121 @@ def test_parse_remainder(test_case):
     b._parse_remainder(test_case['r'])
     assert b.args.source_dir == test_case['s']
     assert b.args.cmake_opts == test_case['c']
+
+
+TEST_CASES_CMAKE_ARGS = [
+    # check that given args (a) lead to expected cmake arguments (e) in correct oder
+    # cmake_opts
+    {'a': ['--cmake-opt=-Da=1', '--cmake-opt=-Db=2'],
+     'e': ['-Da=1', '-Db=2']},
+    {'a': ['--cmake-opt=-Da=1', '--', '-Db=2'],
+     'e': ['-Da=1', '-Db=2']},
+    # build_dir
+    {'a': ['-d', 'test_dir'],
+     'e': ['-Btest_dir']},
+    {'a': ['--build-dir=test_dir'],
+     'e': ['-Btest_dir']},
+    # source_dir
+    {'a': ['-s', 'test_dir'],
+     'e': ['-Stest_dir']},
+    {'a': ['--source-dir=test_dir'],
+     'e': ['-Stest_dir']},
+    # snippets
+    {'a': ['-S', 'first', '-Ssecond', '-S=third', '--snippet=fourth', '--snippet', 'fifth'],
+     'e': ['-DSNIPPET=first;second;third;fourth;fifth']},
+    {'a': ['--cmake-opt=-DSNIPPET=cmake_opt', '-S=arg'],
+     'e': ['-DSNIPPET=cmake_opt', '-DSNIPPET=arg']},
+    # shields
+    {'a': ['--shield', 'first', '--shield=second'],
+     'e': ['-DSHIELD=first;second']},
+    {'a': ['--cmake-opt=-DSHIELD=cmake_opt', '--shield=arg'],
+     'e': ['-DSHIELD=cmake_opt', '-DSHIELD=arg']},
+    # extra_conf_files
+    {'a': ['--extra-conf', 'first', '--extra-conf=second'],
+     'e': ['-DEXTRA_CONF_FILE=first;second']},
+    {'a': ['--cmake-opt=-DEXTRA_CONF_FILE=cmake', '--extra-conf=arg'],
+     'e': ['-DEXTRA_CONF_FILE=cmake', '-DEXTRA_CONF_FILE=arg']},
+    # extra_dtc_overlay_files
+    {'a': ['--extra-dtc-overlay', 'first', '--extra-dtc-overlay=second'],
+     'e': ['-DEXTRA_DTC_OVERLAY_FILE=first;second']},
+    {'a': ['--cmake-opt=-DEXTRA_DTC_OVERLAY_FILE=cmake', '--extra-dtc-overlay=arg'],
+     'e': ['-DEXTRA_DTC_OVERLAY_FILE=cmake', '-DEXTRA_DTC_OVERLAY_FILE=arg']},
+    # sysbuild
+    {'a': ['--sysbuild'],
+     'e': [f'-S{SYSBUILD_PROJ_DIR}']},
+    {'a': ['--no-sysbuild', '--source-dir=test_dir'],
+     'e': ['-Stest_dir']},
+    # combination of multiple arguments (in correct order)
+    {'a': [
+            '--cmake-opt=-Dx',
+            '--build-dir=x',
+            '--source-dir=x',
+            '--snippet=x',
+            '--shield=x',
+            '--extra-conf=x',
+            '--extra-dtc-overlay=x',
+            '--',
+            '-Dy',
+            '-Dz',
+          ],
+     'e': [
+            '-Bx',
+            '-Dx',
+            '-Dy',
+            '-Dz',
+            '-DSNIPPET=x',
+            '-DSHIELD=x',
+            '-DEXTRA_CONF_FILE=x',
+            '-DEXTRA_DTC_OVERLAY_FILE=x',
+            '-Sx',
+          ]},
+]
+
+@pytest.mark.parametrize('test_case', TEST_CASES_CMAKE_ARGS)
+def test_cmake_args(monkeypatch, test_case):
+    """
+    Test that 'west build' arguments are correctly forwarded to CMake.
+    """
+    args = test_case['a']
+    expected = test_case['e']
+
+    b = Build()
+
+    # --- Setup argument parser ---
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    subparser = parser.add_subparsers()
+    command_parser = b.do_add_parser(subparser)
+
+    # Parse known args
+    b.args, remainder = command_parser.parse_known_args(args)
+
+    # Set some class variables for the test
+    b.run_cmake = True
+    b.source_dir = b.args.source_dir
+    b.build_dir = b.args.build_dir
+
+    # Parse remainder
+    b._parse_remainder(remainder)
+
+    # --- Monkeypatch run_cmake ---
+    def run_cmake_mock(final_cmake_args, dry_run, env):
+        """
+        Check that all expected arguments occur in correct order.
+        """
+        previous_position = -1
+        for arg in expected:
+            assert arg in final_cmake_args, f"{arg} not found in {final_cmake_args}"
+            current_position = final_cmake_args.index(arg)
+            assert current_position > previous_position, (
+                f"{arg} is out of order in {final_cmake_args}"
+            )
+            previous_position = current_position
+
+    monkeypatch.setattr('build.run_cmake', run_cmake_mock)
+    monkeypatch.setattr(b, '_banner', lambda _: True)
+
+    # --- Trigger CMake run ---
+    b._run_cmake(board='any', origin=None)
 
 
 cwd = Path(os.getcwd())


### PR DESCRIPTION
## Why?
When using west aliases, it is helpful for users to give cmake arguments, e.g. to make building specific variants as easy as possible. Currently `--` must be used, e.g.
```
[alias]
build-llvm = build -- -DZEPHYR_TOOLCHAIN_VARIANT=llvm
build-codechecker = build -- -DZEPHYR_SCA_VARIANT=codechecker
build-llvm-codechecker = build -- -DZEPHYR_TOOLCHAIN_VARIANT=llvm -DZEPHYR_SCA_VARIANT=codechecker
```
With this approach it is not possible anymore to specify west arguments when the alias is used (e.g. board `-b native_sim`), as the argument comes behind `--` and therefore it is handled as cmake argument.

## Solution
Support for `--cmake-opt` argument is added which allows specifiying cmake options via `west build --cmake-opt=<arg>`, in order to avoid `--` in alias commands. This argument can be specified multiple times, e.g.
```
[alias]
build-llvm = build --cmake-opt=-DZEPHYR_TOOLCHAIN_VARIANT=llvm
build-codechecker = build --cmake-opt=-DZEPHYR_SCA_VARIANT=codechecker
build-llvm-codechecker = build --cmake-opt=-DZEPHYR_TOOLCHAIN_VARIANT=llvm --cmake-opt=-DZEPHYR_SCA_VARIANT=codechecker

# or even easier: build-llvm can be reused
build-llvm-codechecker = build-llvm --cmake-opt=-DZEPHYR_SCA_VARIANT=codechecker
```

