### PR TITLE
shell: adc_shell: fix read values for 16-bit adcs

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -379,7 +379,7 @@ static int cmd_adc_read(const struct shell *sh, size_t argc, char **argv)
 	uint8_t adc_channel_id = strtol(argv[1], NULL, 10);
 	/* -1 index of adc label name */
 	struct adc_hdl *adc = get_adc(argv[-1]);
-	int16_t m_sample_buffer[BUFFER_SIZE];
+	uint16_t m_sample_buffer[BUFFER_SIZE];
 	int retval;
 
 	if (!device_is_ready(adc->dev)) {
@@ -397,7 +397,7 @@ static int cmd_adc_read(const struct shell *sh, size_t argc, char **argv)
 
 	retval = adc_read(adc->dev, &sequence);
 	if (retval >= 0) {
-		shell_print(sh, "read: %i", m_sample_buffer[0]);
+		shell_print(sh, "read: %u", m_sample_buffer[0]);
 	}
 
 	return retval;


### PR DESCRIPTION
The ADC shell was showing incorrect values for ADCs with 16-bit resolution, as the 16th bit was being misinterpreted as the sign bit.

This PR aims to fix that by changing the type of the sample buffer to unsigned 16-bit values.
