### PR TITLE
samples: usb: support numaker_pfm_m467/numaker_m55m1 for hsusbd

### DIFF
--- a/samples/subsys/usb/cdc_acm/boards/numaker_m55m1.overlay
+++ b/samples/subsys/usb/cdc_acm/boards/numaker_m55m1.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+&zephyr_udc0 {
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "Zephyr USB CDC-ACM";
+	};
+};

--- a/samples/subsys/usb/cdc_acm/boards/numaker_pfm_m467.overlay
+++ b/samples/subsys/usb/cdc_acm/boards/numaker_pfm_m467.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+&zephyr_udc0 {
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "Zephyr USB CDC-ACM";
+	};
+};

--- a/samples/subsys/usb/hid-mouse/boards/numaker_m55m1.overlay
+++ b/samples/subsys/usb/hid-mouse/boards/numaker_m55m1.overlay
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+/ {
+	hid_dev_0: hid_dev_0 {
+		compatible = "zephyr,hid-device";
+		label = "HID0";
+		protocol-code = "none";
+		in-polling-period-us = <1000>;
+		in-report-size = <64>;
+	};
+};

--- a/samples/subsys/usb/hid-mouse/boards/numaker_pfm_m467.overlay
+++ b/samples/subsys/usb/hid-mouse/boards/numaker_pfm_m467.overlay
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+/ {
+	hid_dev_0: hid_dev_0 {
+		compatible = "zephyr,hid-device";
+		label = "HID0";
+		protocol-code = "none";
+		in-polling-period-us = <1000>;
+		in-report-size = <64>;
+	};
+};

--- a/samples/subsys/usb/mass/boards/numaker_m55m1.overlay
+++ b/samples/subsys/usb/mass/boards/numaker_m55m1.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};

--- a/samples/subsys/usb/mass/boards/numaker_pfm_m467.overlay
+++ b/samples/subsys/usb/mass/boards/numaker_pfm_m467.overlay
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};

--- a/samples/subsys/usb/uvc/boards/numaker_m55m1.overlay
+++ b/samples/subsys/usb/uvc/boards/numaker_m55m1.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+/ {
+	uvc: uvc {
+		compatible = "zephyr,uvc-device";
+	};
+};

--- a/samples/subsys/usb/uvc/boards/numaker_pfm_m467.overlay
+++ b/samples/subsys/usb/uvc/boards/numaker_pfm_m467.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove USBD */
+/delete-node/ &zephyr_udc0;
+
+/* Change to HSUSBD as default */
+zephyr_udc0: &hsusbd {
+	/* Needn't pinctrl for pins being dedicated */
+	status = "okay";
+};
+
+/* Enable HXT to clock HSUSB PHY */
+&scc {
+	hxt = "enable";
+};
+
+/* Copy from app.overlay */
+/ {
+	uvc: uvc {
+		compatible = "zephyr,uvc-device";
+	};
+};


### PR DESCRIPTION
This supports hsusbd on numaker_pfm_m467 and numaker_m55m1 boards by changing default udc driver from usbd to hsusbd. The support samples include:
- cdc_acm
- hid-mouse
- mass
- uvc