### PR TITLE
tests: boards: nrf: rename flash.throttling test

### DIFF
--- a/tests/boards/nrf/rram_throttling/testcase.yaml
+++ b/tests/boards/nrf/rram_throttling/testcase.yaml
@@ -6,7 +6,7 @@ common:
     - drivers
     - flash
 tests:
-  flash.throttling:
+  boards.nrf.rram_throttling:
     harness: ztest
     harness_config:
       fixture: external_flash


### PR DESCRIPTION
Change the generic name to boards.nrf.rram_throtttling as this test is bound to nrf boards.