### PR TITLE
drivers: sdhc: imx_usdhc: add retry for DAT3 card detection

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -124,6 +124,9 @@ endif # WIFI_NM_HOSTAPD_AP
 
 endif # WIFI
 
+configdefault IMX_USDHC_DAT3_DETECT_RETRY
+	default 10
+
 endif # SHIELD_NXP_M2_2LL_WIFI_BT
 
 if (BT_NXP_IW416) || (BT_NXP_NW612) || (BT_NXP_IW610) || (NXP_IW416) || (NXP_IW61X) || (NXP_IW610)

--- a/drivers/sdhc/Kconfig.imx
+++ b/drivers/sdhc/Kconfig.imx
@@ -20,6 +20,12 @@ config IMX_USDHC_DAT3_PWR_TOGGLE
 	help
 	  Toggle power to SD card to clear DAT3 pull when pulling line low
 
+config IMX_USDHC_DAT3_DETECT_RETRY
+	int "Number of retries for DAT3-based card detection"
+	default 1
+	help
+	  Number of retries for DAT3 card detection to reduce false negatives
+
 config IMX_USDHC_DMA_SUPPORT
 	bool "DMA support for USDHC"
 	default y


### PR DESCRIPTION
DAT3-based card detection may fail for the first attempt on RT1060evkc + NXP_IW610x_v1 card, caused by transient signal states during initialization. Add a short retry loop (by default 10 attempts, 1 ms delay) to improve detection reliability.