### PR TITLE
drivers: i2c: mcux: add support for target mode

### DIFF
--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -46,6 +46,14 @@ struct i2c_mcux_data {
 	i2c_callback_t cb;
 	void *userdata;
 #endif /* CONFIG_I2C_CALLBACK */
+#ifdef CONFIG_I2C_TARGET
+	i2c_slave_handle_t target_handle;
+	struct i2c_target_config *target_cfg;
+	uint8_t target_buffer;
+	bool target_attached;
+	bool target_receiving;
+	bool target_first_rxtx;
+#endif
 };
 
 static int i2c_mcux_configure(const struct device *dev,
@@ -299,12 +307,176 @@ static int i2c_mcux_transfer_cb(const struct device *dev, struct i2c_msg *msgs, 
 
 #endif /* CONFIG_I2C_CALLBACK */
 
+#ifdef CONFIG_I2C_TARGET
+static void i2c_mcux_target_transfer_cb(I2C_Type *base, i2c_slave_transfer_t *transfer,
+					void *userData)
+{
+	const struct device *dev = (const struct device *)userData;
+	struct i2c_mcux_data *data = dev->data;
+	const struct i2c_target_callbacks *target_cb = data->target_cfg->callbacks;
+	int ret = 0;
+
+	ARG_UNUSED(base);
+
+	switch (transfer->event) {
+	case kI2C_SlaveStartEvent:
+		/* start or repeated start of a transfer */
+		transfer->dataSize = 0;
+		data->target_first_rxtx = true;
+
+		if (data->target_receiving) {
+			/* In case of a repeated start after a kI2C_SlaveReceiveEvent,
+			 * the kI2C_SlaveCompletionEvent is not fired. We need to fetch the last
+			 * byte here.
+			 */
+			data->target_receiving = false;
+			if (target_cb->write_received) {
+				target_cb->write_received(data->target_cfg, data->target_buffer);
+			}
+		}
+		break;
+
+	case kI2C_SlaveReceiveEvent:
+		/* request to provide a buffer in which to place received data */
+		data->target_receiving = true;
+
+		transfer->data = &data->target_buffer;
+		transfer->dataSize = 1;
+
+		if (data->target_first_rxtx) {
+			data->target_first_rxtx = false;
+			if (target_cb->write_requested) {
+				ret = target_cb->write_requested(data->target_cfg);
+			}
+		} else {
+			if (target_cb->write_received) {
+				ret = target_cb->write_received(data->target_cfg,
+								data->target_buffer);
+			}
+		}
+		break;
+
+	case kI2C_SlaveTransmitEvent:
+		/* request to provide data to transmit */
+		transfer->data = &data->target_buffer;
+		transfer->dataSize = 1;
+
+		if (data->target_first_rxtx) {
+			data->target_first_rxtx = false;
+			if (target_cb->read_requested) {
+				ret = target_cb->read_requested(data->target_cfg,
+								&data->target_buffer);
+			}
+		} else {
+			if (target_cb->read_processed) {
+				ret = target_cb->read_processed(data->target_cfg,
+								&data->target_buffer);
+			}
+		}
+		break;
+
+	case kI2C_SlaveCompletionEvent:
+		/* transfer finished */
+		data->target_first_rxtx = false;
+
+		if (data->target_receiving) {
+			/* fetch last received byte */
+			data->target_receiving = false;
+			if (target_cb->write_received) {
+				target_cb->write_received(data->target_cfg, data->target_buffer);
+			}
+		}
+
+		if (target_cb->stop) {
+			target_cb->stop(data->target_cfg);
+		}
+		break;
+
+	default:
+		LOG_INF("Unhandled event: %d", transfer->event);
+		break;
+	}
+
+	if (ret < 0) {
+		/* abort communication by not providing a buffer in case of an error */
+		transfer->dataSize = 0;
+	}
+}
+
+static int i2c_mcux_target_register(const struct device *dev,
+				    struct i2c_target_config *target_config)
+{
+	I2C_Type *base = DEV_BASE(dev);
+	const struct i2c_mcux_config *config = dev->config;
+	struct i2c_mcux_data *data = dev->data;
+	i2c_slave_config_t slave_config;
+	uint32_t clock_freq;
+
+	if (!target_config || !target_config->callbacks) {
+		return -EINVAL;
+	}
+
+	if (data->target_attached) {
+		return -EBUSY;
+	}
+
+	I2C_MasterDeinit(base);
+
+	data->target_attached = true;
+	data->target_cfg = target_config;
+	data->target_first_rxtx = true;
+	data->target_receiving = false;
+
+	I2C_SlaveGetDefaultConfig(&slave_config);
+	slave_config.slaveAddress = target_config->address;
+
+	clock_freq = CLOCK_GetFreq(config->clock_source);
+
+	I2C_SlaveInit(base, &slave_config, clock_freq);
+	I2C_SlaveClearStatusFlags(base, kClearFlags);
+	I2C_SlaveTransferCreateHandle(base, &data->target_handle, i2c_mcux_target_transfer_cb,
+				      (void *)dev);
+	I2C_SlaveTransferNonBlocking(base, &data->target_handle,
+				     kI2C_SlaveStartEvent | kI2C_SlaveCompletionEvent);
+
+	return 0;
+}
+
+static int i2c_mcux_target_unregister(const struct device *dev,
+				      struct i2c_target_config *target_config)
+{
+	I2C_Type *base = DEV_BASE(dev);
+	struct i2c_mcux_data *data = dev->data;
+
+	ARG_UNUSED(target_config);
+
+	if (!data->target_attached) {
+		return -EINVAL;
+	}
+
+	I2C_SlaveDeinit(base);
+
+	data->target_cfg = NULL;
+	data->target_attached = false;
+
+	return 0;
+}
+#endif /* CONFIG_I2C_TARGET */
+
 static void i2c_mcux_isr(const struct device *dev)
 {
 	I2C_Type *base = DEV_BASE(dev);
 	struct i2c_mcux_data *data = dev->data;
 
+#ifdef CONFIG_I2C_TARGET
+	if (data->target_attached) {
+		I2C_SlaveTransferHandleIRQ(base, &data->target_handle);
+	} else {
+		I2C_MasterTransferHandleIRQ(base, &data->handle);
+	}
+#else
 	I2C_MasterTransferHandleIRQ(base, &data->handle);
+#endif /* CONFIG_I2C_TARGET */
 }
 
 static int i2c_mcux_init(const struct device *dev)
@@ -350,6 +522,10 @@ static DEVICE_API(i2c, i2c_mcux_driver_api) = {
 #endif
 #ifdef CONFIG_I2C_RTIO
 	.iodev_submit = i2c_iodev_submit_fallback,
+#endif
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_mcux_target_register,
+	.target_unregister = i2c_mcux_target_unregister,
 #endif
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxc242.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Maximilian Werner <maximilian.werner96@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/mcx/MCXC242VLH-pinctrl.h>
+
+&pinctrl {
+	pinmux_i2c0: pinmux_i2c0 {
+		group0 {
+			pinmux = <I2C0_SCL_PTB0>,
+				 <I2C0_SDA_PTB1>;
+			drive-strength = "low";
+			drive-open-drain;
+			slew-rate = "fast";
+		};
+	};
+
+	pinmux_i2c1: pinmux_i2c1 {
+		group0 {
+			pinmux = <I2C1_SCL_PTD7>,
+				 <I2C1_SDA_PTD6>;
+			drive-strength = "low";
+			drive-open-drain;
+			slew-rate = "fast";
+		};
+	};
+};
+
+/* To test this sample, connect
+ * I2C0 SCL(J4-12, PTB0) --> I2C1 SCL(J2-20, PTD7)
+ * I2C0 SDA(J4-10, PTB1) --> I2C1 SDA(J2-18, PTD6)
+ */
+&i2c0 {
+	pinctrl-0 = <&pinmux_i2c0>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&pinmux_i2c1>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -58,6 +58,7 @@ tests:
       - frdm_mcxa346
       - frdm_mcxa266
       - frdm_mcxa366
+      - frdm_mcxc242
       - max32655evkit/max32655/m4
       - max32662evkit
       - max32666evkit/max32666/cpu0


### PR DESCRIPTION
Add i2c target support to the i2c_mcux driver.
Add the frdm_mcxc242 board to i2c_target_api tests.