### PR TITLE
include: video: rollback video api version to 0.8.0

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -19,7 +19,7 @@
  * @brief Interfaces for video devices.
  * @defgroup video_interface Video
  * @since 2.1
- * @version 1.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The video API is currently set to v1.1.0 after having been promoted to version v1.0.0 (leading to making the API stable) after its introduction in Zephyr version 2.1.

The API is still going though extensive changes, such as ControlFramework, video buffer pool handling, RTIO based buffer managements updates in order to allow making it fit with intended use-cases.

Considering its current adoption situation in Zephyr, platforms relying on it and tests, it should rather be considered as Unstable instead of Stable. As such, set the version to 0.8.0.