### PR TITLE
drivers: usb: uhc: handle stall status in transfer callback of mcux

### DIFF
--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -162,6 +162,10 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
+	if (status == kStatus_USB_TransferStall) {
+		err = -EPIPE;
+	}
+
 #if defined(CONFIG_NOCACHE_MEMORY)
 	if (transfer->setupPacket != NULL) {
 		uhc_mcux_nocache_free(transfer->setupPacket);

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -137,6 +137,10 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
+	if (status == kStatus_USB_TransferStall) {
+		err = -EPIPE;
+	}
+
 	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
 	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
 		net_buf_add(xfer->buf, transfer->transferSofar);

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -123,6 +123,10 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
+	if (status == kStatus_USB_TransferStall) {
+		err = -EPIPE;
+	}
+
 	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
 	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
 		net_buf_add(xfer->buf, transfer->transferSofar);

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -123,6 +123,10 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
+	if (status == kStatus_USB_TransferStall) {
+		err = -EPIPE;
+	}
+
 	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
 	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
 		net_buf_add(xfer->buf, transfer->transferSofar);


### PR DESCRIPTION
Return -EPIPE when status is kStatus_USB_TransferStall.