### PR TITLE
zvfs: eventfd: count eventfd file descriptors for fdtable size

### DIFF
--- a/lib/os/zvfs/Kconfig
+++ b/lib/os/zvfs/Kconfig
@@ -50,6 +50,10 @@ config ZVFS_EVENTFD_MAX
 	help
 	  The maximum number of supported event file descriptors.
 
+config ZVFS_OPEN_ADD_SIZE_EVENTFD
+	int "Amount of file descriptors used by ZVFS eventfd"
+	default ZVFS_EVENTFD_MAX
+
 endif # ZVFS_EVENTFD
 
 config ZVFS_POLL


### PR DESCRIPTION
Previously, eventfd file descriptors were not being counted against the required size for the global file descriptor table, which would result in the function `eventfd()` (and `zvfs_eventfd()`) failing due to insufficient resources.