### PR TITLE
stm32: drivers: flash: ospi: fix erase regression in OPI mode by using OPI opcode instead of SFDP SPI opcode

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1288,7 +1288,12 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 			}
 
 			if (bet != NULL) {
-				cmd_erase.Instruction = bet->cmd;
+				/* In OPI mode, do not use the SFDP SPI opcode (bet->cmd). */
+				if (dev_cfg->data_mode == OSPI_OPI_MODE) {
+					cmd_erase.Instruction = SPI_NOR_OCMD_SE;
+				} else {
+					cmd_erase.Instruction = bet->cmd;
+				}
 			} else {
 				/* Use the default sector erase cmd */
 				if (dev_cfg->data_mode == OSPI_OPI_MODE) {


### PR DESCRIPTION
Fix a regression introduced after c42c8a4da4 where, in OPI mode, the driver uses

`bet->cmd` (SPI opcode) for erase once a best erase type is found via SFDP.

In Octal OPI, this opcode is invalid and leads to erase failures (observed on
`b_u585i_iot02a` at offset 0xff000). 

The patch forces the OPI sector erase opcode
(SPI_NOR_OCMD_SE) in OPI mode when bet != NULL, restoring correct behavior.
