### PR TITLE
boards: xtensa: m5stack_atoms3:correct the GPIO pin comments for user button in atoms3_procpu.dts

### DIFF
--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
@@ -38,7 +38,7 @@
 		/* This is the button that's underneath the LCD display  */
 		user_button_0: button_0 {
 			label = "User button 0";
-			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>; // G42
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>; // G41
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
According to the official documentation (https://docs.m5stack.com/en/core/AtomS3), the user button gpio should be G41