### PR TITLE
tests: net: use zsock APIs instead of POSIX APIs

### DIFF
--- a/include/zephyr/net/net_compat.h
+++ b/include/zephyr/net/net_compat.h
@@ -298,10 +298,6 @@ extern "C" {
 #define IN6_IS_ADDR_MC_SITELOCAL(addr)  ZSOCK_IN6_IS_ADDR_MC_SITELOCAL(addr)
 #define IN6_IS_ADDR_MC_ORGLOCAL(addr)   ZSOCK_IN6_IS_ADDR_MC_ORGLOCAL(addr)
 
-#if !defined(ARPHRD_ETHER)
-#define ARPHRD_ETHER NET_ARPHRD_ETHER
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -20,7 +20,6 @@ LOG_MODULE_REGISTER(net_ipv4_test, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/net_buf.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <net_private.h>
 #include <ipv4.h>

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -12,7 +12,6 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/sys/mutex.h>
 #include <zephyr/ztest_assert.h>
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_ip.h>

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/net_if.h>
@@ -473,12 +472,12 @@ ZTEST(net_socket_offload_udp, test_fcntl_not_bound)
 {
 	int ret;
 
-	ret = zsock_fcntl(test_sock, F_SETFL, 0);
-	zassert_equal(0, ret, "fcntl() failed");
+	ret = zsock_fcntl(test_sock, ZVFS_F_SETFL, 0);
+	zassert_equal(0, ret, "zsock_fcntl() failed");
 	zassert_true(test_socket_ctx[OFFLOAD_1].socket_called,
 		     "Socket should've been dispatched");
 	zassert_true(test_socket_ctx[OFFLOAD_1].ioctl_called,
-		     "fcntl() should've been dispatched");
+		     "zsock_fcntl() should've been dispatched");
 }
 
 /* Verify that socket is automatically dispatched to a default socket

--- a/tests/net/socket/socketpair/src/_main.h
+++ b/tests/net/socket/socketpair/src/_main.h
@@ -11,7 +11,6 @@
 #include <string.h>
 
 #include <zephyr/logging/log.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>

--- a/tests/net/socket/socketpair/src/fcntl.c
+++ b/tests/net/socket/socketpair/src/fcntl.c
@@ -11,19 +11,19 @@ ZTEST_USER_F(net_socketpair, test_fcntl)
 	int res;
 	int flags;
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
-	zassert_not_equal(res, -1,
-		"fcntl(fixture->sv[0], F_GETFL) failed. errno: %d", errno);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
+	zassert_not_equal(res, -1, "zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL) failed. errno: %d",
+			  errno);
 
 	flags = res;
-	zassert_equal(res & O_NONBLOCK, 0,
-		"socketpair should block by default");
+	zassert_equal(res & ZVFS_O_NONBLOCK, 0, "socketpair should block by default");
 
-	res = zsock_fcntl(fixture->sv[0], F_SETFL, flags | O_NONBLOCK);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 	zassert_not_equal(res, -1,
-		"fcntl(fixture->sv[0], F_SETFL, flags | O_NONBLOCK) failed. errno: %d",
-		errno);
+			  "zsock_fcntl(fixture->sv[0], ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK) "
+			  "failed. errno: %d",
+			  errno);
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
-	zassert_equal(res ^ flags, O_NONBLOCK, "expected O_NONBLOCK set");
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
+	zassert_equal(res ^ flags, ZVFS_O_NONBLOCK, "expected ZVFS_O_NONBLOCK set");
 }

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -18,12 +18,12 @@ ZTEST_USER_F(net_socketpair, test_write_nonblock)
 			zassert_equal(res, 1, "send() failed: %d", errno);
 		}
 
-		/* then set the O_NONBLOCK flag */
-		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
-		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
+		/* then set the ZVFS_O_NONBLOCK flag */
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
+		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
 
-		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
-		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
+		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
 
 		/* then, try to write one more byte */
 		res = zsock_send(fixture->sv[i], "x", 1, 0);
@@ -40,11 +40,11 @@ ZTEST_USER_F(net_socketpair, test_read_nonblock)
 
 	for (size_t i = 0; i < 2; ++i) {
 		/* set the O_NONBLOCK flag */
-		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
-		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
+		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
 
-		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
-		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
+		zassert_not_equal(res, -1, "zsock_fcntl() %d failed: %d", i, errno);
 
 		/* then, try to read one byte */
 		res = zsock_recv(fixture->sv[i], &c, 1, 0);

--- a/tests/net/socket/socketpair/src/poll.c
+++ b/tests/net/socket/socketpair/src/poll.c
@@ -54,16 +54,16 @@ ZTEST_USER_F(net_socketpair, test_poll_timeout_nonblocking)
 {
 	int res;
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
-	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
+	zassert_not_equal(res, -1, "zsock_fcntl() failed: %d", errno);
 
 	int flags = res;
 
-	res = zsock_fcntl(fixture->sv[0], F_SETFL, O_NONBLOCK | flags);
-	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_SETFL, ZVFS_O_NONBLOCK | flags);
+	zassert_not_equal(res, -1, "zsock_fcntl() failed: %d", errno);
 
-	res = zsock_fcntl(fixture->sv[1], F_SETFL, O_NONBLOCK | flags);
-	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
+	res = zsock_fcntl(fixture->sv[1], ZVFS_F_SETFL, ZVFS_O_NONBLOCK | flags);
+	zassert_not_equal(res, -1, "zsock_fcntl() failed: %d", errno);
 
 	test_socketpair_poll_timeout_common(fixture);
 }

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -8,7 +8,6 @@
 LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/ztest_assert.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/loopback.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
@@ -108,9 +107,7 @@ static void test_connect(int sock, struct net_sockaddr *addr, net_socklen_t addr
 {
 	k_yield();
 
-	zassert_equal(zsock_connect(sock, addr, addrlen),
-		      0,
-		      "connect failed");
+	zassert_equal(zsock_connect(sock, addr, addrlen), 0, "zsock_connect() failed");
 
 	if (IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)) {
 		/* Let the connection proceed */
@@ -135,9 +132,7 @@ static void test_sendmsg(int sock, const struct net_msghdr *msg, int flags)
 		total_len += vec->iov_len;
 	}
 
-	zassert_equal(zsock_sendmsg(sock, msg, flags),
-		      total_len,
-		      "sendmsg failed");
+	zassert_equal(zsock_sendmsg(sock, msg, flags), total_len, "zsock_sendmsg() failed");
 }
 
 static void test_accept(int sock, int *new_sock, struct net_sockaddr *addr,
@@ -146,7 +141,7 @@ static void test_accept(int sock, int *new_sock, struct net_sockaddr *addr,
 	zassert_not_null(new_sock, "null newsock");
 
 	*new_sock = zsock_accept(sock, addr, addrlen);
-	zassert_true(*new_sock >= 0, "accept failed");
+	zassert_true(*new_sock >= 0, "zsock_accept() failed");
 }
 
 static void test_shutdown(int sock, int how)
@@ -212,14 +207,14 @@ ZTEST(net_socket_tls, test_so_type)
 	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &sock2, &bind_addr6, NET_IPPROTO_TLS_1_2);
 
 	rv = zsock_getsockopt(sock1, ZSOCK_SOL_SOCKET, ZSOCK_SO_TYPE, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, NET_SOCK_STREAM, "getsockopt got invalid type");
-	zassert_equal(optlen, sizeof(optval), "getsockopt got invalid size");
+	zassert_equal(rv, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, NET_SOCK_STREAM, "zsock_getsockopt() got invalid type");
+	zassert_equal(optlen, sizeof(optval), "zsock_getsockopt() got invalid size");
 
 	rv = zsock_getsockopt(sock2, ZSOCK_SOL_SOCKET, ZSOCK_SO_TYPE, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, NET_SOCK_STREAM, "getsockopt got invalid type");
-	zassert_equal(optlen, sizeof(optval), "getsockopt got invalid size");
+	zassert_equal(rv, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, NET_SOCK_STREAM, "zsock_getsockopt() got invalid type");
+	zassert_equal(optlen, sizeof(optval), "zsock_getsockopt() got invalid size");
 
 	test_close(sock1);
 	test_close(sock2);
@@ -237,16 +232,14 @@ ZTEST(net_socket_tls, test_so_protocol)
 	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &sock2, &bind_addr6, NET_IPPROTO_TLS_1_1);
 
 	rv = zsock_getsockopt(sock1, ZSOCK_SOL_SOCKET, ZSOCK_SO_PROTOCOL, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, NET_IPPROTO_TLS_1_2,
-		      "getsockopt got invalid protocol");
-	zassert_equal(optlen, sizeof(optval), "getsockopt got invalid size");
+	zassert_equal(rv, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, NET_IPPROTO_TLS_1_2, "zsock_getsockopt() got invalid protocol");
+	zassert_equal(optlen, sizeof(optval), "zsock_getsockopt() got invalid size");
 
 	rv = zsock_getsockopt(sock2, ZSOCK_SOL_SOCKET, ZSOCK_SO_PROTOCOL, &optval, &optlen);
-	zassert_equal(rv, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, NET_IPPROTO_TLS_1_1,
-		      "getsockopt got invalid protocol");
-	zassert_equal(optlen, sizeof(optval), "getsockopt got invalid size");
+	zassert_equal(rv, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, NET_IPPROTO_TLS_1_1, "zsock_getsockopt() got invalid protocol");
+	zassert_equal(optlen, sizeof(optval), "zsock_getsockopt() got invalid size");
 
 	test_close(sock1);
 	test_close(sock2);
@@ -402,7 +395,7 @@ static void test_prepare_dtls_connection(net_sa_family_t family)
 
 	/* Flush the dummy byte. */
 	ret = zsock_recv(s_sock, &rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, sizeof(rx_buf), "recv() failed");
+	zassert_equal(ret, sizeof(rx_buf), "zsock_recv() failed");
 
 	test_work_wait(&test_data.work);
 }
@@ -442,7 +435,7 @@ ZTEST(net_socket_tls, test_v4_msg_waitall)
 	 */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO, &timeo_optval,
 			       sizeof(timeo_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 	test_data.offset = 0;
@@ -498,7 +491,7 @@ ZTEST(net_socket_tls, test_v6_msg_waitall)
 	 */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO, &timeo_optval,
 			       sizeof(timeo_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 	test_data.offset = 0;
@@ -629,7 +622,7 @@ static void test_dtls_sendmsg_no_buf(net_sa_family_t family)
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 	rv = zsock_recv(s_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "recv failed");
+	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, "invalid rx data");
 
 	test_work_wait(&test_data.tx_work);
@@ -643,7 +636,7 @@ static void test_dtls_sendmsg_no_buf(net_sa_family_t family)
 
 	memset(rx_buf, 0, sizeof(rx_buf));
 	rv = zsock_recv(s_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "recv failed");
+	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, "invalid rx data");
 
 	test_work_wait(&test_data.tx_work);
@@ -654,7 +647,7 @@ static void test_dtls_sendmsg_no_buf(net_sa_family_t family)
 	iov[0].iov_len = sizeof(TEST_STR_SMALL) - 1;
 
 	rv = zsock_sendmsg(c_sock, &msg, 0);
-	zassert_equal(rv, -1, "sendmsg succeeded");
+	zassert_equal(rv, -1, "zsock_sendmsg() succeeded");
 	zassert_equal(errno, EMSGSIZE, "incorrect errno value");
 
 	test_sockets_close();
@@ -717,7 +710,7 @@ static void test_dtls_sendmsg(net_sa_family_t family)
 
 	memset(buf, 0, sizeof(buf));
 	rv = zsock_recv(s_sock, buf, sizeof(buf), 0);
-	zassert_equal(rv, sizeof(expected_str) - 1, "recv failed");
+	zassert_equal(rv, sizeof(expected_str) - 1, "zsock_recv() failed");
 	zassert_mem_equal(buf, expected_str, sizeof(expected_str) - 1, "invalid rx data");
 
 	test_work_wait(&test_data.tx_work);
@@ -735,7 +728,7 @@ static void test_dtls_sendmsg(net_sa_family_t family)
 
 	memset(buf, 0, sizeof(buf));
 	rv = zsock_recv(s_sock, buf, sizeof(buf), 0);
-	zassert_equal(rv, sizeof(expected_str) - 1, "recv failed");
+	zassert_equal(rv, sizeof(expected_str) - 1, "zsock_recv() failed");
 	zassert_mem_equal(buf, expected_str, sizeof(expected_str) - 1, "invalid rx data");
 
 	test_work_wait(&test_data.tx_work);
@@ -757,7 +750,7 @@ static void test_dtls_sendmsg(net_sa_family_t family)
 
 	memset(buf, 0, sizeof(buf));
 	rv = zsock_recv(s_sock, buf, sizeof(buf), 0);
-	zassert_equal(rv, sizeof(buf), "recv failed");
+	zassert_equal(rv, sizeof(buf), "zsock_recv() failed");
 	for (int i = 0; i < sizeof(buf); i++) {
 		zassert_equal(buf[i], 'a', "invalid rx data");
 	}
@@ -774,7 +767,7 @@ static void test_dtls_sendmsg(net_sa_family_t family)
 	msg.msg_iovlen = 2;
 
 	rv = zsock_sendmsg(c_sock, &msg, 0);
-	zassert_equal(rv, -1, "sendmsg succeeded");
+	zassert_equal(rv, -1, "zsock_sendmsg() succeeded");
 	zassert_equal(errno, EMSGSIZE, "incorrect errno value");
 
 	test_sockets_close();
@@ -838,7 +831,7 @@ ZTEST(net_socket_tls, test_close_while_accept)
 	 * another thread and return an error.
 	 */
 	new_sock = zsock_accept(s_sock, &addr, &addrlen);
-	zassert_equal(new_sock, -1, "accept did not return error");
+	zassert_equal(new_sock, -1, "zsock_accept() did not return error");
 	zassert_equal(errno, EINTR, "Unexpected errno value: %d", errno);
 
 	test_work_wait(&close_work_data.work);
@@ -859,7 +852,7 @@ ZTEST(net_socket_tls, test_close_while_recv)
 	test_work_reschedule(&close_work_data.work, K_MSEC(10));
 
 	ret = zsock_recv(new_sock, &rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, -1, "recv did not return error");
+	zassert_equal(ret, -1, "zsock_recv() did not return error");
 	zassert_equal(errno, EINTR, "Unexpected errno value: %d", errno);
 
 	test_work_wait(&close_work_data.work);
@@ -882,15 +875,13 @@ ZTEST(net_socket_tls, test_connect_timeout)
 	s_saddr.sin6_family = NET_AF_INET6;
 	s_saddr.sin6_port = net_htons(SERVER_PORT);
 	ret = zsock_inet_pton(NET_AF_INET6, MY_IPV6_ADDR, &s_saddr.sin6_addr);
-	zassert_equal(ret, 1, "inet_pton failed");
+	zassert_equal(ret, 1, "zsock_inet_pton() failed");
 
 	loopback_set_packet_drop_ratio(1.0f);
 
-	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr,
-				    sizeof(s_saddr)),
-		      -1, "connect succeed");
-	zassert_equal(errno, ETIMEDOUT,
-		      "connect should be timed out, got %d", errno);
+	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr)), -1,
+		      "zsock_connect() succeed");
+	zassert_equal(errno, ETIMEDOUT, "zsock_connect() should be timed out, got %d", errno);
 
 	test_sockets_close();
 
@@ -911,13 +902,11 @@ ZTEST(net_socket_tls, test_connect_closed_port)
 	s_saddr.sin6_family = NET_AF_INET6;
 	s_saddr.sin6_port = net_htons(SERVER_PORT);
 	ret = zsock_inet_pton(NET_AF_INET6, MY_IPV6_ADDR, &s_saddr.sin6_addr);
-	zassert_equal(ret, 1, "inet_pton failed");
+	zassert_equal(ret, 1, "zsock_inet_pton() failed");
 
-	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr,
-				    sizeof(s_saddr)),
-		      -1, "connect succeed");
-	zassert_equal(errno, ECONNREFUSED,
-		      "connect should fail, got %d", errno);
+	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr)), -1,
+		      "zsock_connect() succeed");
+	zassert_equal(errno, ECONNREFUSED, "zsock_connect() should fail, got %d", errno);
 
 	test_sockets_close();
 	k_sleep(TCP_TEARDOWN_TIMEOUT);
@@ -999,11 +988,9 @@ ZTEST(net_socket_tls, test_connect_invalid_handshake_data)
 	test_prepare_fake_tcp_server(&server_data, NET_AF_INET6, &s_sock,
 				     (struct net_sockaddr *)&s_saddr, true);
 
-	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr,
-				    sizeof(s_saddr)),
-		      -1, "connect succeed");
-	zassert_equal(errno, ECONNABORTED,
-		      "connect should fail, got %d", errno);
+	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr)), -1,
+		      "zsock_connect() succeed");
+	zassert_equal(errno, ECONNABORTED, "zsock_connect() should fail, got %d", errno);
 
 	test_close(c_sock);
 	c_sock = -1;
@@ -1026,11 +1013,9 @@ ZTEST(net_socket_tls, test_connect_no_handshake_data)
 	test_prepare_fake_tcp_server(&server_data, NET_AF_INET6, &s_sock,
 				     (struct net_sockaddr *)&s_saddr, false);
 
-	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr,
-				    sizeof(s_saddr)),
-		      -1, "connect succeed");
-	zassert_equal(errno, ECONNABORTED,
-		      "connect should fail, got %d", errno);
+	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr)), -1,
+		      "zsock_connect() succeed");
+	zassert_equal(errno, ECONNABORTED, "zsock_connect() should fail, got %d", errno);
 
 	test_work_wait(&server_data.work);
 	test_sockets_close();
@@ -1047,14 +1032,14 @@ ZTEST(net_socket_tls, test_accept_non_block)
 			    NET_IPPROTO_TLS_1_2);
 
 	test_config_psk(s_sock, -1);
-	test_fcntl(s_sock, F_SETFL, O_NONBLOCK);
+	test_fcntl(s_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	test_bind(s_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
 	test_listen(s_sock);
 
 	timestamp = k_uptime_get_32();
 	new_sock = zsock_accept(s_sock, NULL, NULL);
 	zassert_true(k_uptime_get_32() - timestamp <= 100, "");
-	zassert_equal(new_sock, -1, "accept did not return error");
+	zassert_equal(new_sock, -1, "zsock_accept() did not return error");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1079,7 +1064,7 @@ ZTEST(net_socket_tls, test_accept_invalid_handshake_data)
 	test_send(c_sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL), 0);
 
 	new_sock = zsock_accept(s_sock, NULL, NULL);
-	zassert_equal(new_sock, -1, "accept did not return error");
+	zassert_equal(new_sock, -1, "zsock_accept() did not return error");
 	zassert_equal(errno, ECONNABORTED, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1095,29 +1080,29 @@ ZTEST(net_socket_tls, test_recv_non_block)
 
 	/* Verify ZSOCK_MSG_DONTWAIT flag first */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv()) should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
-	/* Verify fcntl and O_NONBLOCK */
-	test_fcntl(new_sock, F_SETFL, O_NONBLOCK);
+	/* Verify zsock_fcntl() and ZVFS_O_NONBLOCK */
+	test_fcntl(new_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Let the data got through. */
 	k_sleep(K_MSEC(10));
 
 	/* Should get data now */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "recv() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	/* And EAGAIN on consecutive read */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1142,7 +1127,7 @@ ZTEST(net_socket_tls, test_recv_block)
 
 	/* recv() shall block until send work sends the data. */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	test_sockets_close();
@@ -1178,11 +1163,11 @@ ZTEST(net_socket_tls, test_send_non_block)
 	/* Simulate window full scenario with SO_RCVBUF option. */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVBUF, &buf_optval,
 			       sizeof(buf_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	/* Fill out the window */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Wait for ACK (empty window, min. 100 ms due to silly window
 	 * protection).
@@ -1192,17 +1177,17 @@ ZTEST(net_socket_tls, test_send_non_block)
 	/* Verify ZSOCK_MSG_DONTWAIT flag first */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL),
 			 ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "send() should've failed");
+	zassert_equal(ret, -1, "zsock_send() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
-	/* Verify fcntl and O_NONBLOCK */
-	test_fcntl(c_sock, F_SETFL, O_NONBLOCK);
+	/* Verify zsock_fcntl() and ZVFS_O_NONBLOCK */
+	test_fcntl(c_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, -1, "send() should've failed");
+	zassert_equal(ret, -1, "zsock_send() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "recv() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	/* Wait for the window to update. */
@@ -1210,16 +1195,16 @@ ZTEST(net_socket_tls, test_send_non_block)
 
 	/* Should succeed now. */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Flush the data */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "recv() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	/* And make sure there's no more data left. */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1246,7 +1231,7 @@ static void recv_work_handler(struct k_work *work)
 		size_t recvlen = MIN(sizeof(rx_buf), test_data->datalen - off);
 
 		ret = zsock_recv(test_data->sock, rx_buf, recvlen, 0);
-		zassert_true(ret > 0, "recv() error");
+		zassert_true(ret > 0, "zsock_recv() error");
 		zassert_mem_equal(rx_buf, test_data->data + off, ret,
 				  "unexpected data");
 
@@ -1271,11 +1256,11 @@ ZTEST(net_socket_tls, test_send_block)
 	/* Simulate window full scenario with SO_RCVBUF option. */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVBUF, &buf_optval,
 			       sizeof(buf_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	/* Fill out the window */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Wait for ACK (empty window, min. 100 ms due to silly window
 	 * protection).
@@ -1288,16 +1273,16 @@ ZTEST(net_socket_tls, test_send_block)
 
 	/* Should block and succeed. */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Flush the data */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "recv() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	/* And make sure there's no more data left. */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1320,12 +1305,12 @@ ZTEST(net_socket_tls, test_send_on_close)
 
 	/* Verify send() reports an error after connection is closed. */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, -1, "send() should've failed");
+	zassert_equal(ret, -1, "zsock_send() should've failed");
 	zassert_equal(errno, ECONNABORTED, "Unexpected errno value: %d", errno);
 
 	/* recv() on closed connection marked error on a socket. */
 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, ECONNABORTED, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1342,11 +1327,11 @@ ZTEST(net_socket_tls, test_send_on_close)
 
 	/* Graceful connection close should be reported first. */
 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, 0, "recv() should've reported connection close");
+	zassert_equal(ret, 0, "zsock_recv() should've reported connection close");
 
 	/* And consecutive send() should fail. */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, -1, "send() should've failed");
+	zassert_equal(ret, -1, "zsock_send() should've failed");
 	zassert_equal(errno, ECONNABORTED, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1372,13 +1357,13 @@ ZTEST(net_socket_tls, test_so_rcvtimeo)
 
 	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO, &optval,
 			       sizeof(optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	start_time = k_uptime_get_32();
 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
 	time_diff = k_uptime_get_32() - start_time;
 
-	zassert_equal(ret, -1, "recv() should've failed");
+	zassert_equal(ret, -1, "zsock_recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 	zassert_true(time_diff >= 500, "Expected timeout after 500ms but "
 		     "was %dms", time_diff);
@@ -1389,7 +1374,7 @@ ZTEST(net_socket_tls, test_so_rcvtimeo)
 
 	/* recv() shall return as soon as it gets data, regardless of timeout. */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	test_sockets_close();
@@ -1415,15 +1400,15 @@ ZTEST(net_socket_tls, test_so_sndtimeo)
 
 	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_SNDTIMEO, &timeo_optval,
 			       sizeof(timeo_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	/* Simulate window full scenario with SO_RCVBUF option. */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVBUF, &buf_optval,
 			       sizeof(buf_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	ret = zsock_send(c_sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "send() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_send() failed");
 
 	/* Wait for ACK (empty window). */
 	k_msleep(150);
@@ -1433,7 +1418,7 @@ ZTEST(net_socket_tls, test_so_sndtimeo)
 	ret = zsock_send(c_sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0);
 	time_diff = k_uptime_get_32() - start_time;
 
-	zassert_equal(ret, -1, "send() should've failed");
+	zassert_equal(ret, -1, "zsock_send() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 	zassert_true(time_diff >= 500, "Expected timeout after 500ms but "
 			"was %dms", time_diff);
@@ -1444,7 +1429,7 @@ ZTEST(net_socket_tls, test_so_sndtimeo)
 
 	/* Should block and succeed. */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	test_sockets_close();
 
@@ -1529,12 +1514,12 @@ ZTEST(net_socket_tls, test_send_while_recv)
 	 * will execute only if the first one won't block.
 	 */
 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	/* Check if the server sock got its data. */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	test_sockets_close();
@@ -1557,7 +1542,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollin)
 	zassert_equal(ret, 0, "Unexpected poll() event");
 
 	ret = zsock_send(c_sock, TEST_STR_SMALL, sizeof(TEST_STR_SMALL) - 1, 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	ret = zsock_poll(fds, 1, 100);
 	zassert_equal(ret, 1, "poll() should've report event");
@@ -1565,7 +1550,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollin)
 
 	/* Check that data is really available */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	test_sockets_close();
@@ -1601,7 +1586,7 @@ ZTEST(net_socket_tls, test_poll_dtls_pollin)
 
 	/* Check that data is really available */
 	ret = zsock_recv(s_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	test_sockets_close();
@@ -1629,11 +1614,11 @@ ZTEST(net_socket_tls, test_poll_tls_pollout)
 	/* Simulate window full scenario with SO_RCVBUF option. */
 	ret = zsock_setsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVBUF, &buf_optval,
 			       sizeof(buf_optval));
-	zassert_equal(ret, 0, "setsockopt failed (%d)", errno);
+	zassert_equal(ret, 0, "zsock_setsockopt() failed (%d)", errno);
 
 	/* Fill out the window */
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-	zassert_equal(ret, strlen(TEST_STR_SMALL), "send() failed");
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "zsock_send() failed");
 
 	/* Wait for ACK (empty window, min. 100 ms due to silly window
 	 * protection).
@@ -1646,7 +1631,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollout)
 
 	/* Consume the data, and check if the client sock is writeable again */
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "zsock_recv() failed");
 	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
 
 	ret = zsock_poll(fds, 1, 100);
@@ -1700,7 +1685,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollhup)
 
 	/* Check that connection was indeed closed */
 	ret = zsock_recv(new_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, 0, "recv() did not report connection close");
+	zassert_equal(ret, 0, "zsock_recv() did not report connection close");
 
 	test_sockets_close();
 
@@ -1727,7 +1712,7 @@ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
 
 	/* Check that connection was indeed closed */
 	ret = zsock_recv(s_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv() should report EAGAIN");
+	zassert_equal(ret, -1, "zsock_recv() should report EAGAIN");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1762,12 +1747,11 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
 	zassert_true(fds[0].revents & ZSOCK_POLLERR, "No POLLERR event");
 
 	ret = zsock_getsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_ERROR, &optval, &optlen);
-	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, ECONNABORTED, "getsockopt got invalid error %d",
-		      optval);
+	zassert_equal(ret, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, ECONNABORTED, "zsock_getsockopt() got invalid error %d", optval);
 
 	ret = zsock_recv(new_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv() did not report error");
+	zassert_equal(ret, -1, "zsock_recv() did not report error");
 	zassert_equal(errno, ECONNABORTED, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1799,13 +1783,12 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
 	zassert_true(fds[0].revents & ZSOCK_POLLERR, "No POLLERR event");
 
 	ret = zsock_getsockopt(s_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_ERROR, &optval, &optlen);
-	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
-	zassert_equal(optval, ECONNABORTED, "getsockopt got invalid error %d",
-		      optval);
+	zassert_equal(ret, 0, "zsock_getsockopt() failed (%d)", errno);
+	zassert_equal(optval, ECONNABORTED, "zsock_getsockopt() got invalid error %d", optval);
 
 	/* DTLS server socket should recover and be ready to accept new session. */
 	ret = zsock_recv(s_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
-	zassert_equal(ret, -1, "recv() did not report error");
+	zassert_equal(ret, -1, "zsock_recv() did not report error");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
 	test_sockets_close();
@@ -1866,7 +1849,7 @@ static void test_bad_cred_common(bool test_dtls)
 		s_sock = zsock_socket(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TLS_1_2);
 	}
 
-	zassert_true(s_sock >= 0, "socket open failed");
+	zassert_true(s_sock >= 0, "zsock_socket() failed");
 
 	for (int i = 0; i < ARRAY_SIZE(bad_tags); i++) {
 		sec_tag_t test_tag = bad_tags[i];
@@ -1874,7 +1857,8 @@ static void test_bad_cred_common(bool test_dtls)
 
 		ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
 				       &test_tag, sizeof(test_tag));
-		zassert_equal(ret, -1, "zsock_setsockopt should've failed with invalid credential");
+		zassert_equal(ret, -1,
+			      "zsock_setsockopt() should've failed with invalid credential");
 		if (test_tag == BAD_NO_CRED_TAG) {
 			zassert_equal(errno, ENOENT, "Unfound credential should fail with ENOENT");
 		} else {


### PR DESCRIPTION
Use zsock APIs rather than POSIX APIs in the net subsys testsuites.

It's convention to use native zephyr APIs in the testsuites and POSIX APIs in samples.