### PR TITLE
lib: heap: Add Address Sanitizer memory poisoning support

### DIFF
--- a/lib/heap/CMakeLists.txt
+++ b/lib/heap/CMakeLists.txt
@@ -18,3 +18,23 @@ zephyr_sources_ifdef(CONFIG_SHARED_MULTI_HEAP shared_multi_heap.c)
 zephyr_sources_ifdef(CONFIG_MULTI_HEAP multi_heap.c)
 zephyr_sources_ifdef(CONFIG_HEAP_LISTENER heap_listener.c)
 zephyr_sources_ifdef(CONFIG_SYS_HEAP_ARRAY_SIZE heap_array.c)
+zephyr_sources_ifdef(CONFIG_SYS_HEAP_SANITIZER_ASAN heap_sanitizer_asan.c)
+
+if(CONFIG_SYS_HEAP_SANITIZER_ASAN)
+  # The heap implementation owns the bytes it poisons (chunk headers,
+  # free-list links, canaries) and must read and write them freely, so the
+  # heap internal sources are excluded from ASAN instrumentation. The
+  # public-API hooks still call the __asan_* runtime to poison and unpoison
+  # the user-visible regions so instrumented application code is checked.
+  # These sources are added to the root-scoped "zephyr" target, so the
+  # COMPILE_OPTIONS property must be set in that target's directory scope.
+  set_property(SOURCE
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap_stats.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap_info.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap_validate.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap_stress.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/heap_array.c
+    TARGET_DIRECTORY zephyr
+    APPEND PROPERTY COMPILE_OPTIONS -fno-sanitize=address)
+endif()

--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -164,6 +164,16 @@ config SYS_HEAP_CANARIES_RANDOM
 	  Without this, canaries are still effective at detecting
 	  accidental corruption but are predictable.
 
+config SYS_HEAP_SANITIZER_HOOKS
+	bool
+	help
+	  Hidden symbol selected by any sys_heap sanitizer backend. When set,
+	  heap.c emits the generic poison/unpoison hook calls
+	  (heap_sanitizer_on_init / _alloc / _free) at the public-API boundary. The
+	  active backend implements those three entry points. Keeping the call
+	  sites gated on this single symbol means heap.c carries no
+	  backend-specific conditionals.
+
 module = SYS_HEAP
 module-str = sys_heap
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -174,6 +174,38 @@ config SYS_HEAP_SANITIZER_HOOKS
 	  sites gated on this single symbol means heap.c carries no
 	  backend-specific conditionals.
 
+config SYS_HEAP_SANITIZER_ASAN
+	bool "Full Address Sanitizer (ASAN) heap poisoning (native_sim)"
+	depends on ASAN && ARCH_POSIX
+	depends on SYS_HEAP_BIG_ONLY || (64BIT && !SYS_HEAP_SMALL_ONLY)
+	select SYS_HEAP_SANITIZER_HOOKS
+	help
+	  Enables integration with the toolchain's Address Sanitizer (ASAN)
+	  runtime to implement memory poisoning for the sys_heap allocator.
+
+	  The whole heap buffer is poisoned at initialization; an allocation
+	  unpoisons the user region it returns and a free re-poisons it. This
+	  lets ASAN report accesses to freed, never-allocated and out-of-bounds
+	  heap memory with a full backtrace and shadow dump.
+
+	  When enabled, the following classes of memory error are detected:
+	  - Use-after-free: accessing memory after it has been freed
+	  - Unallocated access: accessing memory that was never allocated
+	  - Buffer overruns: writing beyond the requested allocation size
+
+	  This feature is only available on native simulator based platforms
+	  where ASAN is supported. It works with any toolchain that provides
+	  the ASAN runtime and the manual poisoning API, e.g. GCC (libasan) or
+	  Clang/LLVM (compiler-rt).
+
+	  The big-heap chunk format is required so the user pointer and the end
+	  of the usable region are 8-byte aligned, matching ASAN's shadow
+	  granularity. On 64-bit this is implied; on 32-bit SYS_HEAP_BIG_ONLY
+	  must be chosen explicitly, which means the small-heap chunk format is
+	  not exercised under this configuration.
+
+	  Use for debugging and validation only.
+
 module = SYS_HEAP
 module-str = sys_heap
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -688,7 +688,7 @@ void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 	if (ptr2 != NULL) {
 		size_t prev_size = sys_heap_usable_size(heap, ptr);
 
-		memcpy(ptr2, ptr, min(prev_size, bytes));
+		memcpy(ptr2, ptr, MIN(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
 	return ptr2;
@@ -722,7 +722,7 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 	if (ptr2 != NULL) {
 		size_t prev_size = sys_heap_usable_size(heap, ptr);
 
-		memcpy(ptr2, ptr, min(prev_size, bytes));
+		memcpy(ptr2, ptr, MIN(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
 	return ptr2;

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -21,6 +21,10 @@ LOG_MODULE_REGISTER(os_heap, CONFIG_SYS_HEAP_LOG_LEVEL);
 #include <zephyr/random/random.h>
 #endif
 
+#ifdef CONFIG_SYS_HEAP_SANITIZER_HOOKS
+#include "heap_sanitizer.h"
+#endif
+
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)
 {
@@ -345,6 +349,9 @@ void sys_heap_free(struct sys_heap *heap, void *mem)
 				  chunk_usable_bytes(h, c) - mem_align_gap(h, mem));
 #endif
 
+	IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+		   (heap_sanitizer_on_free(heap, mem,
+				      chunk_usable_bytes(h, c) - mem_align_gap(h, mem))));
 	free_chunk(h, c);
 }
 
@@ -457,6 +464,7 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 				   chunk_usable_bytes(h, c));
 #endif
 
+	IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS, (heap_sanitizer_on_alloc(heap, mem, bytes)));
 	IF_ENABLED(CONFIG_MSAN, (__msan_allocated_memory(mem, bytes)));
 	return mem;
 }
@@ -546,6 +554,7 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 #endif
 
 	IF_ENABLED(CONFIG_MSAN, (__msan_allocated_memory(mem, bytes)));
+	IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS, (heap_sanitizer_on_alloc(heap, mem, bytes)));
 	return mem;
 }
 
@@ -678,7 +687,15 @@ void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 		return NULL;
 	}
 
+#ifdef CONFIG_SYS_HEAP_SANITIZER_HOOKS
+	size_t old_usable = sys_heap_usable_size(heap, ptr);
+#endif
+
 	if (inplace_realloc(heap, ptr, bytes)) {
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_free(heap, ptr, old_usable)));
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_alloc(heap, ptr, bytes)));
 		return ptr;
 	}
 
@@ -688,6 +705,14 @@ void *sys_heap_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 	if (ptr2 != NULL) {
 		size_t prev_size = sys_heap_usable_size(heap, ptr);
 
+		/*
+		 * The copy reads the source block's whole usable region, which
+		 * a sanitizer backend keeps poisoned past the user-requested
+		 * size. Re-grant access to the full region for the duration of
+		 * the copy; the free below re-poisons it.
+		 */
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_alloc(heap, ptr, prev_size)));
 		memcpy(ptr2, ptr, MIN(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
@@ -708,8 +733,16 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 
 	__ASSERT((align & (align - 1)) == 0, "align must be a power of 2");
 
+#ifdef CONFIG_SYS_HEAP_SANITIZER_HOOKS
+	size_t old_usable = sys_heap_usable_size(heap, ptr);
+#endif
+
 	if ((align == 0 || ((uintptr_t)ptr & (align - 1)) == 0) &&
 	    inplace_realloc(heap, ptr, bytes)) {
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_free(heap, ptr, old_usable)));
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_alloc(heap, ptr, bytes)));
 		return ptr;
 	}
 
@@ -722,6 +755,14 @@ void *sys_heap_aligned_realloc(struct sys_heap *heap, void *ptr,
 	if (ptr2 != NULL) {
 		size_t prev_size = sys_heap_usable_size(heap, ptr);
 
+		/*
+		 * The copy reads the source block's whole usable region, which
+		 * a sanitizer backend keeps poisoned past the user-requested
+		 * size. Re-grant access to the full region for the duration of
+		 * the copy; the free below re-poisons it.
+		 */
+		IF_ENABLED(CONFIG_SYS_HEAP_SANITIZER_HOOKS,
+			   (heap_sanitizer_on_alloc(heap, ptr, prev_size)));
 		memcpy(ptr2, ptr, MIN(prev_size, bytes));
 		sys_heap_free(heap, ptr);
 	}
@@ -742,6 +783,9 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 
 	/* Reserve the end marker chunk's header */
 	__ASSERT(bytes > heap_footer_bytes(bytes), "heap size is too small");
+#ifdef CONFIG_SYS_HEAP_SANITIZER_HOOKS
+	const size_t orig_bytes = bytes; /* preserve for heap_sanitizer_on_init */
+#endif
 	bytes -= heap_footer_bytes(bytes);
 
 	/* Round the start up, the end down */
@@ -800,4 +844,8 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	set_chunk_used(h, heap_sz, true);
 
 	free_list_add(h, chunk0_size);
+
+#ifdef CONFIG_SYS_HEAP_SANITIZER_HOOKS
+	heap_sanitizer_on_init(heap, mem, orig_bytes);
+#endif
 }

--- a/lib/heap/heap_sanitizer.h
+++ b/lib/heap/heap_sanitizer.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Internal sys_heap sanitizer hook interface.
+ *
+ * heap.c calls these three entry points at the public-API boundary when
+ * CONFIG_SYS_HEAP_SANITIZER_HOOKS is set. A sanitizer backend selects that
+ * symbol and implements the hooks; the call sites in heap.c carry no
+ * backend-specific conditionals.
+ */
+
+#ifndef ZEPHYR_LIB_HEAP_HEAP_SANITIZER_H_
+#define ZEPHYR_LIB_HEAP_HEAP_SANITIZER_H_
+
+#include <zephyr/sys/sys_heap.h>
+
+/* Called at the end of sys_heap_init(); backend poisons the heap buffer. */
+void heap_sanitizer_on_init(struct sys_heap *heap, void *mem, size_t bytes);
+
+/* Called after a successful allocation; backend unpoisons [mem, mem+bytes). */
+void heap_sanitizer_on_alloc(struct sys_heap *heap, void *mem, size_t bytes);
+
+/*
+ * Called before a chunk is freed; backend re-poisons [mem, mem+bytes) where
+ * bytes is the usable allocation size (sys_heap_usable_size).
+ */
+void heap_sanitizer_on_free(struct sys_heap *heap, void *mem, size_t bytes);
+
+#endif /* ZEPHYR_LIB_HEAP_HEAP_SANITIZER_H_ */

--- a/lib/heap/heap_sanitizer_asan.c
+++ b/lib/heap/heap_sanitizer_asan.c
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * AddressSanitizer (ASAN) runtime backend for the sys_heap sanitizer hooks.
+ *
+ * Implements the heap_sanitizer_on_{init,alloc,free} seam (see heap_sanitizer.h) on top
+ * of the toolchain's Address Sanitizer manual poisoning runtime (GCC's libasan
+ * or Clang/LLVM's compiler-rt), for use on native simulator based platforms.
+ * The whole heap buffer is poisoned at init; an allocation unpoisons exactly
+ * the user-requested region and a free re-poisons the usable region. Accesses
+ * to freed, never-allocated or out-of-bounds heap memory are therefore
+ * reported by ASAN with a full backtrace and shadow dump.
+ *
+ * The heap implementation itself is compiled with -fno-sanitize=address (see
+ * CMakeLists.txt) so it can freely access the chunk headers, free-list links
+ * and canaries that live inside the poisoned regions. Because that leaves
+ * __SANITIZE_ADDRESS__ undefined in the heap translation units, the
+ * convenience macros from <sanitizer/asan_interface.h> would compile away;
+ * the runtime entry points (__asan_{,un}poison_memory_region) are therefore
+ * called directly. They still update the ASAN shadow because the runtime is
+ * linked into the instrumented application.
+ *
+ * Chunk headers and internal metadata are poisoned once at init and never
+ * unpoisoned, so they act as permanent redzones: an overflow from one
+ * allocation into a neighbour's header (even a live one) and an underflow
+ * into an allocation's own header are both caught. This relies on the
+ * big-heap chunk format (enforced via Kconfig) to keep the user pointer and
+ * the end of the usable region 8-byte aligned, matching ASAN's shadow
+ * granularity.
+ */
+
+#include <sanitizer/asan_interface.h>
+
+#include "heap_sanitizer.h"
+
+void heap_sanitizer_on_init(struct sys_heap *heap, void *mem, size_t bytes)
+{
+	ARG_UNUSED(heap);
+
+	__asan_poison_memory_region(mem, bytes);
+}
+
+void heap_sanitizer_on_alloc(struct sys_heap *heap, void *mem, size_t bytes)
+{
+	ARG_UNUSED(heap);
+
+	/*
+	 * Unpoison only the user-requested region. The slack between the
+	 * requested size and the usable size stays poisoned, so writing past
+	 * the requested size is reported as an overflow.
+	 */
+	__asan_unpoison_memory_region(mem, bytes);
+}
+
+void heap_sanitizer_on_free(struct sys_heap *heap, void *mem, size_t bytes)
+{
+	ARG_UNUSED(heap);
+
+	__asan_poison_memory_region(mem, bytes);
+}


### PR DESCRIPTION
This PR introduces ASAN memory poisoning support for the heap allocator through the following modifications:

## Core Implementation

- **lib/heap/heap.c**: Integrated ASAN poisoning/unpoisoning calls at key heap operations:
  - Poison entire heap memory on initialization
  - Poison freed memory to detect use-after-free
  - Unpoison memory when allocated to allow normal access
  - Poison free chunk bodies while preserving free-list metadata
  - Handle poisoning during realloc operations (both shrink and expand)

- **lib/heap/heap.h**: Added ASAN-specific macros and attributes:
  - `HEAP_NO_SANITIZE_ADDRESS` attribute for chunk field accessors
  - `ASAN_POISON_HEAP_MEMORY()` and `ASAN_UNPOISON_HEAP_MEMORY()` wrapper macros
  - Conditional compilation based on `CONFIG_SYS_HEAP_ASAN_POISONING`

- **lib/heap/Kconfig**: Added `CONFIG_SYS_HEAP_ASAN_POISONING` configuration option
  - Depends on `ASAN && ARCH_POSIX`
  - Available only on POSIX-based simulation platforms (e.g., native_sim)

## Memory Error Detection

When enabled, ASAN can detect:
- **Use-after-free**: Accessing memory after it has been freed
- **Unallocated access**: Accessing heap memory that was never allocated
- **Buffer overflows**: Writing beyond allocated boundaries into adjacent freed/unallocated regions
- **Use-after-realloc**: Accessing old pointer after realloc() relocates memory

## Implementation Details

The implementation maintains heap functionality while adding error detection:
- Metadata regions (heap structure, buckets, chunk headers) remain unpoisoned for heap operations
- Free-list pointers (first 16 bytes of free chunks) remain unpoisoned for list maintenance
- Rest of free chunk memory is poisoned to detect invalid access