### PR TITLE
samples/tfm_integration: Restore SFN backend on tfm_secure_partition sample

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
@@ -14,6 +14,17 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/dummy_partition/tfm_manifest_list.yaml
 )
 
+if(CONFIG_TFM_IPC)
+    set(SPM_BACKEND "IPC")
+else()
+    set(SPM_BACKEND "SFN")
+endif()
+
+configure_file(
+  ${CMAKE_CURRENT_LIST_DIR}/dummy_partition/tfm_dummy_partition.yaml.in
+  ${CMAKE_CURRENT_BINARY_DIR}/dummy_partition/tfm_dummy_partition.yaml
+)
+
 set_property(TARGET zephyr_property_target
   APPEND PROPERTY TFM_CMAKE_OPTIONS
   -DTFM_EXTRA_MANIFEST_LIST_FILES=${CMAKE_CURRENT_BINARY_DIR}/dummy_partition/tfm_manifest_list.yaml

--- a/samples/tfm_integration/tfm_secure_partition/README.rst
+++ b/samples/tfm_integration/tfm_secure_partition/README.rst
@@ -33,7 +33,8 @@ files inside "partition".
 Building and Running
 ********************
 
-This sample can be built with or without CONFIG_TFM_IPC, since it contains code for both.
+This sample can be built with either :kconfig:option:`CONFIG_TFM_IPC` or :kconfig:option:`CONFIG_TFM_SFN`,
+since it contains code for both.
 
 On Target
 =========

--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
@@ -89,6 +89,8 @@ static psa_status_t tfm_dp_secret_digest_ipc(psa_msg_t *msg)
 				    (void *)msg->handle);
 }
 
+#if CONFIG_TFM_SPM_BACKEND_IPC == 1
+#pragma message "Dummy partition SPM backend: IPC"
 static void dp_signal_handle(psa_signal_t signal, dp_func_t pfn)
 {
 	psa_status_t status;
@@ -127,3 +129,15 @@ psa_status_t tfm_dp_req_mngr_init(void)
 
 	return PSA_ERROR_SERVICE_FAILURE;
 }
+#elif CONFIG_TFM_SPM_BACKEND_SFN == 1
+#pragma message "Dummy partition SPM backend: SFN"
+psa_status_t tfm_dp_secret_digest_sfn(const psa_msg_t *msg)
+{
+	if (msg->type == PSA_IPC_CONNECT || msg->type == PSA_IPC_DISCONNECT) {
+		return PSA_SUCCESS;
+	}
+	return tfm_dp_secret_digest_ipc((psa_msg_t *)msg);
+}
+#else
+#error "No SPM backend selected"
+#endif

--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_dummy_partition.yaml.in
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_dummy_partition.yaml.in
@@ -11,7 +11,8 @@
   "name": "TFM_SP_DP",
   "type": "APPLICATION-ROT",
   "priority": "NORMAL",
-  "model": "IPC",
+  "model": "${SPM_BACKEND}",
+  # entry_point below is ignored when using the SFN backend
   "entry_point": "tfm_dp_req_mngr_init",
   "stack_size": "0x800",
 

--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
@@ -15,7 +15,7 @@
     {
       "description": "Dummy Partition",
       "short_name": "TFM_DP",
-      "manifest": "${APPLICATION_SOURCE_DIR}/dummy_partition/tfm_dummy_partition.yaml",
+      "manifest": "${CMAKE_CURRENT_BINARY_DIR}/dummy_partition/tfm_dummy_partition.yaml",
       "output_path": "${TFM_BINARY_DIR}/dummy_partition",
       "tfm_partition_ipc": true,
       "version_major": 0,

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - trusted-firmware-m
+    - mcuboot
   platform_allow:
     - mps2/an521/cpu0/ns
     - v2m_musca_s1/musca_s1/ns
@@ -25,7 +26,9 @@ sample:
   name: "TFM Secure Partition Sample"
 
 tests:
-  sample.tfm.secure_partition:
-    tags:
-      - trusted-firmware-m
-      - mcuboot
+  sample.tfm.secure_partition.ipc:
+    extra_configs:
+      - CONFIG_TFM_IPC=y
+  sample.tfm.secure_partition.sfn:
+    extra_configs:
+      - CONFIG_TFM_SFN=y

--- a/samples/tfm_integration/tfm_secure_partition/src/dummy_partition.c
+++ b/samples/tfm_integration/tfm_secure_partition/src/dummy_partition.c
@@ -8,7 +8,6 @@
 
 #include "dummy_partition.h"
 
-#if defined(CONFIG_TFM_IPC)
 #include "psa/client.h"
 #include "psa_manifest/sid.h"
 
@@ -40,25 +39,3 @@ psa_status_t dp_secret_digest(uint32_t secret_index,
 
 	return status;
 }
-#else /* defined(CONFIG_TFM_IPC) */
-psa_status_t dp_secret_digest(uint32_t secret_index,
-			void *p_digest,
-			size_t digest_size)
-{
-	psa_status_t status;
-	psa_invec in_vec[] = {
-		{ .base = &secret_index, .len = sizeof(secret_index) },
-	};
-
-	psa_outvec out_vec[] = {
-		{ .base = p_digest, .len = digest_size }
-	};
-
-	status = tfm_ns_interface_dispatch(
-				(veneer_fn)tfm_dp_secret_digest_req_veneer,
-				(uint32_t)in_vec,  IOVEC_LEN(in_vec),
-				(uint32_t)out_vec, IOVEC_LEN(out_vec));
-
-	return status;
-}
-#endif /* defined(CONFIG_TFM_IPC) */

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1610,6 +1610,8 @@ flagged.
         "STACK_SIZE",  # Used as an example in the Kconfig docs
         "STD_CPP",  # Referenced in CMake comment
         "TEST1",
+        "TFM_SPM_BACKEND_IPC",  # Used in TFM sample dummy partition - belongs to TFM
+        "TFM_SPM_BACKEND_SFN",  # Used in TFM sample dummy partition - belongs to TFM
         # Defined in modules/hal_nxp/mcux/mcux-sdk-ng/basic.cmake.
         # It is used by MCUX SDK cmake functions to add content
         # based on current toolchain.


### PR DESCRIPTION
Support was lost when the "library model" was removed from TF-M - add support back to the "spiritual successor" of the Library model on the FF-M 1.1 - the Secure Function (SFN).