### PR TITLE
boards: microchip: pic32cx: Add comparator support

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - comparator
   - dma
   - flash
   - gpio

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - comparator
   - dma
   - flash
   - gpio

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -244,6 +244,17 @@
 			status = "disabled";
 		};
 
+		ac: ac@42002000 {
+			compatible = "microchip,ac-g1-comparator";
+			reg = <0x42002000 0x26>;
+			interrupts = <122 0>;
+			interrupt-names = "ac";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_AC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_AC>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
 		tcc3: tcc@42001000 {
 			compatible = "microchip,tcc-g1";
 			reg = <0x42001000 0x2000>;

--- a/tests/drivers/comparator/gpio_loopback/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* connect the PA04 to PA03 for the test */
+
+/ {
+	aliases {
+		test-comp = &ac;
+	};
+
+	zephyr,user {
+		test-gpios = <&porta 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ac {
+	comparator-channel = <0>;
+	positive-mux-input = "pin0";
+	negative-mux-input = "bandgap";
+	run-standby;
+	hysteresis-enable;
+	hysteresis-level = "hyst150";
+	filter-length = "maj5";
+	// single-shot-mode;
+
+	/* Assign pinctrl for PA04 */
+	pinctrl-0 = <&pinctrl_ac>;
+	pinctrl-names = "default";
+
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_ac: ac_pins {
+		group1 {
+			pinmux = <PA4B_AC_AIN0>;
+		};
+	};
+};

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -64,3 +64,7 @@ tests:
       - frdm_mcxn947/mcxn947/cpu0
       - mcx_n9xx_evk/mcxn947/cpu0/qspi
       - mcx_n9xx_evk/mcxn947/cpu0
+  drivers.comparator.gpio_loopback.mchp:
+    platform_allow:
+      - sam_e54_xpro
+      - pic32cx_sg41_cult


### PR DESCRIPTION
This PR adds the analog comparator devicetree node for the PIC32CX-SG family and includes a test overlay file to enable comparator test cases.