### PR TITLE
Bluetooth: Classic: L2CAP: Fix sending buffer reference counting

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1565,11 +1566,12 @@ done:
 
 	struct net_buf *buf;
 
-	buf = br_chan->_pdu_buf;
+	buf = net_buf_ref(br_chan->_pdu_buf);
 
 	if (br_chan->_pdu_remaining > amount) {
 		br_chan->_pdu_remaining -= amount;
 	} else {
+		net_buf_unref(br_chan->_pdu_buf);
 		br_chan->_pdu_buf = NULL;
 		br_chan->_pdu_remaining = 0;
 		if (pdu && !pdu->len) {


### PR DESCRIPTION
There is a corner case that the ACL_Data_Packet_Length is less than the MPS of the L2CAP BR channel connection. Then the partial data will be sent and the remaining data will be sent in sequence in the function `l2cap_br_data_pull()`. The issue occurs when sending the continuing fragment HCI ACL packet, due to the reference counting of sending buffer is 0. Therefore, the application will be asserted in the function `send_buf()`.

Fix the issue by managing the reference count of the sending buffer.

Use the function `net_buf_ref()` to increment the reference count of the sending buffer.

If the sending buffer is the last fragment, use `net_buf_unref()` to decrement the reference count of the sending buffer to ensure that the send buffer can be properly released when the data is sent out.