### PR TITLE
NXP support pm device runtime for lpi2c on imx943

### DIFF
--- a/dts/arm/nxp/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/nxp_imx94x.dtsi
@@ -91,6 +91,7 @@
 			reg = <0x42530000 0x4000>;
 			interrupts = <67 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C3>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -102,6 +103,7 @@
 			reg = <0x42540000 0x4000>;
 			interrupts = <68 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C4>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -175,6 +177,7 @@
 			reg = <0x426b0000 0x4000>;
 			interrupts = <108 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C5>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -186,6 +189,7 @@
 			reg = <0x426c0000 0x4000>;
 			interrupts = <109 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C6>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -197,6 +201,7 @@
 			reg = <0x426d0000 0x4000>;
 			interrupts = <110 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C7>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -208,6 +213,7 @@
 			reg = <0x426e0000 0x4000>;
 			interrupts = <111 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C8>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -442,6 +448,7 @@
 			reg = <0x44340000 0x4000>;
 			interrupts = <15 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C1>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -453,6 +460,7 @@
 			reg = <0x44350000 0x4000>;
 			interrupts = <16 0>;
 			clocks = <&scmi_clk IMX943_CLK_LPI2C2>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
1. Add lpi2c pm device callback to support its suspend and resume operation, clock off in suspend, and clock on in resume. 
2. enabled pm device runtime auto in imx943 device node, as zephyr system device not consider how to deal with device operation with interrupt, irq will be locked in idle.c, so for this imx943 or imx95 with system manager, only can support runtime device suspend now