### PR TITLE
drivers: i2c: Add support i2c_target for Renesas RA I2C driver

### DIFF
--- a/boards/renesas/ek_ra2a1/ek_ra2a1.dts
+++ b/boards/renesas/ek_ra2a1/ek_ra2a1.dts
@@ -115,7 +115,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <0 1>, <1 1>, <2 1>, <3 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4c1/ek_ra4c1.dts
+++ b/boards/renesas/ek_ra4c1/ek_ra4c1.dts
@@ -164,7 +164,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <13 1>, <14 1>, <15 1>, <16 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.dts
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.dts
@@ -263,7 +263,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4m1/ek_ra4m1.dts
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1.dts
@@ -132,7 +132,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4m2/ek_ra4m2.dts
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2.dts
@@ -161,7 +161,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <87 1>, <88 1>, <89 1>, <90 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4m3/ek_ra4m3.dts
+++ b/boards/renesas/ek_ra4m3/ek_ra4m3.dts
@@ -159,7 +159,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <87 1>, <88 1>, <89 1>, <90 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra4w1/ek_ra4w1.dts
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.dts
@@ -115,7 +115,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/renesas/ek_ra6m1/ek_ra6m1.dts
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1.dts
@@ -69,7 +69,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m2/ek_ra6m2.dts
+++ b/boards/renesas/ek_ra6m2/ek_ra6m2.dts
@@ -69,7 +69,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -104,7 +104,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -201,7 +201,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra6m5/ek_ra6m5.dts
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5.dts
@@ -161,7 +161,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -361,7 +361,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra8d2/ek_ra8d2_r7ka8d2kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8d2/ek_ra8d2_r7ka8d2kflcac_cm85.dts
@@ -82,7 +82,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 	interrupts = <14 1>, <15 1>, <16 1>, <17 1>;

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -317,7 +317,7 @@ mikrobus_spi: &spi1 {};
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/ek_ra8m2/ek_ra8m2_r7ka8m2jflcac_cm85.dts
+++ b/boards/renesas/ek_ra8m2/ek_ra8m2_r7ka8m2jflcac_cm85.dts
@@ -74,7 +74,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 	interrupts = <12 1>, <13 1>, <14 1>, <15 1>;

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm33.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm33.dts
@@ -75,7 +75,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 	interrupts = <54 1>, <55 1>, <56 1>, <57 1>;

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -90,7 +90,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 	interrupts = <14 1>, <15 1>, <16 1>, <17 1>;

--- a/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
+++ b/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
@@ -110,7 +110,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
+++ b/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
@@ -74,7 +74,7 @@
 	#size-cells = <0>;
 	interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&iic0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -194,7 +194,7 @@
 &iic1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	pinctrl-0 = <&iic1_default>;
 	pinctrl-names = "default";
 };

--- a/drivers/i2c/Kconfig.renesas_ra
+++ b/drivers/i2c/Kconfig.renesas_ra
@@ -4,13 +4,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config I2C_RENESAS_RA_IIC
-	bool "Renesas RA I2C IIC Controller"
+	bool "Renesas RA I2C IIC driver"
 	default y
 	depends on DT_HAS_RENESAS_RA_IIC_ENABLED
 	select USE_RA_FSP_I2C_IIC_CONTROLLER
+	select USE_RA_FSP_I2C_IIC_TARGET if I2C_TARGET
 	select PINCTRL
 	help
-	  Enable Renesas RA I2C IIC Controller Driver.
+	  Enable Renesas RA I2C IIC Driver.
+
+if I2C_RENESAS_RA_IIC && I2C_TARGET && I2C_TARGET_BUFFER_MODE
+
+config I2C_TARGET_RENESAS_RA_IIC_BUFFER_SIZE
+	int "I2C Target data buffer length"
+	range 1 1024
+	default 256
+	help
+	  Specify the size of the data buffer used
+	  in the Renesas RA I2C IIC target driver.
+
+endif
 
 config I2C_RENESAS_RA_SCI
 	bool "Renesas RA SCI I2C"

--- a/drivers/i2c/i2c_renesas_ra_iic.c
+++ b/drivers/i2c/i2c_renesas_ra_iic.c
@@ -6,50 +6,63 @@
 
 #define DT_DRV_COMPAT renesas_ra_iic
 
-#include <math.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
-#include "r_iic_master.h"
+#include <r_iic_master.h>
+#include <r_iic_slave.h>
 #include <errno.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(renesas_ra_iic);
+LOG_MODULE_REGISTER(renesas_ra_iic, CONFIG_I2C_LOG_LEVEL);
 
-typedef void (*init_func_t)(const struct device *dev);
-static const double RA_IIC_MASTER_DIV_TIME_NS = 1000000000;
+#define OPERATION(msg) (((struct i2c_msg *)msg)->flags & I2C_MSG_RW_MASK)
 
 struct i2c_ra_iic_config {
-	void (*irq_config_func)(const struct device *dev);
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *clock_dev;
 	const struct clock_control_ra_subsys_cfg clock_subsys;
-	uint32_t noise_filter_stage;
-	double rise_time_s;
-	double fall_time_s;
-	uint32_t duty_cycle_percent;
+	uint32_t ctrl_rise_time_ns;
+	uint32_t ctrl_fall_time_ns;
+	uint32_t ctrl_noise_filter_stage;
+	uint32_t ctrl_duty_cycle_percent;
 	uint32_t max_bitrate_supported;
 };
 
 struct i2c_ra_iic_data {
-	iic_master_instance_ctrl_t ctrl;
-	i2c_master_cfg_t fsp_config;
+	iic_master_instance_ctrl_t control_ctrl;
+	i2c_master_cfg_t ctrl_fconfig;
+	i2c_master_event_t ctrl_event;
+	iic_master_extended_cfg_t iic_ctrl_ext_cfg;
+#ifdef CONFIG_I2C_TARGET
+	iic_slave_instance_ctrl_t target_ctrl;
+	i2c_slave_cfg_t target_fconfig;
+	iic_slave_extended_cfg_t iic_target_ext_cfg;
+	struct i2c_target_config *target_cfg;
+	bool transaction_completed;
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	uint8_t target_buf[CONFIG_I2C_TARGET_RENESAS_RA_IIC_BUFFER_SIZE];
+#else
+	uint8_t target_buf;
+#endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
+#endif /* CONFIG_I2C_TARGET */
 	struct k_mutex bus_mutex;
 	struct k_sem complete_sem;
-	i2c_master_event_t event;
-	iic_master_extended_cfg_t iic_master_ext_cfg;
 	uint32_t dev_config;
 };
 
-/* IIC master clock setting calculation function. */
-static int calc_iic_master_clock_setting(const struct device *dev, const uint32_t fsp_i2c_rate,
-					  iic_master_clock_settings_t *clk_cfg);
+/* IIC clock setting calculation function. */
+static int calc_iic_ctrl_clock_setting(const struct device *dev, const uint32_t ctrl_rate,
+				       iic_master_clock_settings_t *clk_cfg);
+#ifdef CONFIG_I2C_TARGET
+static int calc_iic_target_clock_setting(const struct device *dev, const uint32_t slave_rate,
+					 iic_slave_clock_settings_t *clk_cfg);
+#endif /* CONFIG_I2C_TARGET */
 
 /* FSP interruption handlers. */
 void iic_master_rxi_isr(void);
@@ -57,7 +70,14 @@ void iic_master_txi_isr(void);
 void iic_master_tei_isr(void);
 void iic_master_eri_isr(void);
 
-struct ra_iic_master_bitrate {
+#ifdef CONFIG_I2C_TARGET
+void iic_slave_rxi_isr(void);
+void iic_slave_txi_isr(void);
+void iic_slave_tei_isr(void);
+void iic_slave_eri_isr(void);
+#endif /* CONFIG_I2C_TARGET */
+
+struct ra_iic_ctrl_bitrate {
 	uint32_t bitrate;
 	uint32_t duty;
 	uint32_t divider;
@@ -71,9 +91,12 @@ static int i2c_ra_iic_configure(const struct device *dev, uint32_t dev_config)
 	const struct i2c_ra_iic_config *config = dev->config;
 	struct i2c_ra_iic_data *data = (struct i2c_ra_iic_data *const)dev->data;
 	uint32_t desire_bitrate;
+	fsp_err_t fsp_err;
+	int err;
 
 	if (!(dev_config & I2C_MODE_CONTROLLER)) {
-		LOG_ERR("Only I2C Master mode supported.");
+		LOG_ERR("Please configure I2C in Controller mode, target should be registered via "
+			"i2c_target_register API");
 		return -EIO;
 	}
 
@@ -93,19 +116,31 @@ static int i2c_ra_iic_configure(const struct device *dev, uint32_t dev_config)
 	}
 
 	if (desire_bitrate <= config->max_bitrate_supported) {
-		data->fsp_config.rate = desire_bitrate;
-	} else{
-		LOG_ERR("%s: Requested bitrate %u exceeds max supported bitrate %u",
-			__func__, desire_bitrate, config->max_bitrate_supported);
+		data->ctrl_fconfig.rate = desire_bitrate;
+	} else {
+		LOG_ERR("%s: Requested bitrate %u exceeds max supported bitrate %u", __func__,
+			desire_bitrate, config->max_bitrate_supported);
 		return -EIO;
 	}
 
 	/* Recalc clock setting after updating config. */
-	calc_iic_master_clock_setting(dev, data->fsp_config.rate,
-				      &data->iic_master_ext_cfg.clock_settings);
+	err = calc_iic_ctrl_clock_setting(dev, data->ctrl_fconfig.rate,
+					  &data->iic_ctrl_ext_cfg.clock_settings);
+	if (err != 0) {
+		LOG_ERR("Failed to calculate I2C clock settings");
+		return err;
+	}
 
-	R_IIC_MASTER_Close(&data->ctrl);
-	R_IIC_MASTER_Open(&data->ctrl, &data->fsp_config);
+	fsp_err = R_IIC_MASTER_Close(&data->control_ctrl);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("Failed to close I2C master instance. FSP_ERR=%d", fsp_err);
+		return -EIO;
+	}
+	fsp_err = R_IIC_MASTER_Open(&data->control_ctrl, &data->ctrl_fconfig);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("Failed to open I2C master instance. FSP_ERR=%d", fsp_err);
+		return -EIO;
+	}
 
 	/* save current devconfig. */
 	data->dev_config = dev_config;
@@ -120,8 +155,6 @@ static int i2c_ra_iic_get_config(const struct device *dev, uint32_t *dev_config)
 
 	return 0;
 }
-
-#define OPERATION(msg) (((struct i2c_msg *)msg)->flags & I2C_MSG_RW_MASK)
 
 static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 			       uint16_t addr)
@@ -155,8 +188,8 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 			if (OPERATION(current) != OPERATION(next)) {
 				if (!(next->flags & I2C_MSG_RESTART)) {
 					LOG_ERR("%s: Restart condition between messages of "
-						"different directions is required."
-						"Current/Total: [%d/%d]",
+						"different directions is required. Current/Total: "
+						"[%d/%d]",
 						__func__, i, num_msgs);
 					ret = -EIO;
 					break;
@@ -166,8 +199,7 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 			/* Stop condition is only allowed on last message */
 			if (current->flags & I2C_MSG_STOP) {
 				LOG_ERR("%s: Invalid stop flag. Stop condition is only allowed on "
-					"last message. "
-					"Current/Total: [%d/%d]",
+					"last message. Current/Total: [%d/%d]",
 					__func__, i, num_msgs);
 				ret = -EIO;
 				break;
@@ -195,7 +227,7 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 		addr_mode = I2C_MASTER_ADDR_MODE_7BIT;
 	}
 
-	R_IIC_MASTER_SlaveAddressSet(&data->ctrl, addr, addr_mode);
+	R_IIC_MASTER_SlaveAddressSet(&data->control_ctrl, addr, addr_mode);
 
 	/* Process input `msgs`. */
 
@@ -210,11 +242,11 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 
 		if (current->flags & I2C_MSG_READ) {
 			fsp_err =
-				R_IIC_MASTER_Read(&data->ctrl, current->buf, current->len,
+				R_IIC_MASTER_Read(&data->control_ctrl, current->buf, current->len,
 						  next != NULL && (next->flags & I2C_MSG_RESTART));
 		} else {
 			fsp_err =
-				R_IIC_MASTER_Write(&data->ctrl, current->buf, current->len,
+				R_IIC_MASTER_Write(&data->control_ctrl, current->buf, current->len,
 						   next != NULL && (next->flags & I2C_MSG_RESTART));
 		}
 
@@ -243,7 +275,7 @@ static int i2c_ra_iic_transfer(const struct device *dev, struct i2c_msg *msgs, u
 		k_sem_take(&data->complete_sem, K_FOREVER);
 
 		/* Handle event msg from callback. */
-		switch (data->event) {
+		switch (data->ctrl_event) {
 		case I2C_MASTER_EVENT_ABORTED:
 			LOG_ERR("%s: %s failed.", __func__,
 				(current->flags & I2C_MSG_READ) ? "Read" : "Write");
@@ -267,21 +299,164 @@ RELEASE_BUS:
 	return ret;
 }
 
-static void i2c_ra_iic_callback(i2c_master_callback_args_t *p_args)
+static void i2c_ra_iic_ctrl_callback(i2c_master_callback_args_t *p_args)
 {
 	const struct device *dev = p_args->p_context;
 	struct i2c_ra_iic_data *data = dev->data;
 
-	data->event = p_args->event;
+	data->ctrl_event = p_args->event;
 
 	k_sem_give(&data->complete_sem);
 }
+
+#ifdef CONFIG_I2C_TARGET
+
+static void i2c_ra_iic_target_callback(i2c_slave_callback_args_t *p_args)
+{
+	const struct device *dev = p_args->p_context;
+	struct i2c_ra_iic_data *data = dev->data;
+	const struct i2c_target_callbacks *target_cb = data->target_cfg->callbacks;
+	fsp_err_t fsp_err;
+	int err;
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	uint8_t *buf = NULL;
+	uint32_t len;
+#endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
+
+	switch (p_args->event) {
+
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	case I2C_SLAVE_EVENT_RX_COMPLETE:
+		if (p_args->bytes > 0) {
+			target_cb->buf_write_received(data->target_cfg, data->target_buf,
+						      p_args->bytes);
+		}
+		__fallthrough;
+	case I2C_SLAVE_EVENT_TX_COMPLETE:
+		if (data->transaction_completed) {
+			target_cb->stop(data->target_cfg);
+		}
+		break;
+	case I2C_SLAVE_EVENT_RX_REQUEST:
+		err = target_cb->write_requested(data->target_cfg);
+		if (err == 0) {
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, data->target_buf,
+						   sizeof(data->target_buf));
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		} else {
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, data->target_buf, 0);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+			LOG_DBG("I2C target does not want to receive data."
+				"Send a NACK to Controller device to terminate the transaction.");
+		}
+		data->transaction_completed = false;
+		break;
+	case I2C_SLAVE_EVENT_TX_REQUEST:
+		err = target_cb->buf_read_requested(data->target_cfg, &buf, &len);
+		if (err == 0) {
+			if (buf != NULL && len != 0) {
+				fsp_err = R_IIC_SLAVE_Write(&data->target_ctrl, buf, len);
+				__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+			} else {
+				LOG_ERR("buf is NULL or len is 0, Controller device will read 0xFF "
+					"for the remaining bytes");
+			}
+		} else {
+			LOG_DBG("I2C target doesn't provide new data. The I2C bus will be left "
+				"floating, Controller device will read the value 0xFF for the "
+				"remaining bytes.");
+		}
+		data->transaction_completed = false;
+		break;
+	case I2C_SLAVE_EVENT_RX_MORE_REQUEST:
+		fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, data->target_buf, 0);
+		__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		LOG_ERR("The buffer is full, target device cannot receive more data. Please "
+			"increase I2C_TARGET_RENESAS_RA_IIC_BUFFER_SIZE");
+		target_cb->stop(data->target_cfg);
+		break;
+	case I2C_SLAVE_EVENT_TX_MORE_REQUEST:
+		LOG_ERR("Out of data to send to the controller device, Controller device will read "
+			"0xFF for the remaining bytes");
+		break;
+#else  /* !CONFIG_I2C_TARGET_BUFFER_MODE */
+
+	case I2C_SLAVE_EVENT_RX_COMPLETE:
+		if (p_args->bytes > 0) {
+			target_cb->write_received(data->target_cfg, data->target_buf);
+		}
+		__fallthrough;
+	case I2C_SLAVE_EVENT_TX_COMPLETE:
+		if (data->transaction_completed) {
+			target_cb->stop(data->target_cfg);
+		}
+		break;
+	case I2C_SLAVE_EVENT_RX_REQUEST:
+		err = target_cb->write_requested(data->target_cfg);
+		if (err == 0) {
+			/* Continue to receive data */
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, &data->target_buf, 1);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		} else {
+			/* NACK the received data */
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, &data->target_buf, 0);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+			LOG_DBG("I2C target does not want to receive data."
+				"Send a NACK to Controller device to terminate the transaction.");
+		}
+		data->transaction_completed = false;
+		break;
+	case I2C_SLAVE_EVENT_TX_REQUEST:
+		err = target_cb->read_requested(data->target_cfg, &data->target_buf);
+		if (err == 0) {
+			fsp_err = R_IIC_SLAVE_Write(&data->target_ctrl, &data->target_buf, 1);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		} else {
+			LOG_DBG("I2C target doesn't provide new data. The I2C bus will be left "
+				"floating, Controller device will read the value 0xFF for the "
+				"remaining bytes.");
+		}
+		data->transaction_completed = false;
+		break;
+	case I2C_SLAVE_EVENT_RX_MORE_REQUEST:
+		err = target_cb->write_received(data->target_cfg, data->target_buf);
+		if (err == 0) {
+			/* Continue to receive data */
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, &data->target_buf, 1);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		} else {
+			/* NACK the received data */
+			fsp_err = R_IIC_SLAVE_Read(&data->target_ctrl, &data->target_buf, 0);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+			LOG_DBG("I2C target does not want to receive data."
+				"Send a NACK to Controller device to terminate the transaction.");
+		}
+		break;
+	case I2C_SLAVE_EVENT_TX_MORE_REQUEST:
+		err = target_cb->read_processed(data->target_cfg, &data->target_buf);
+		if (err == 0) {
+			fsp_err = R_IIC_SLAVE_Write(&data->target_ctrl, &data->target_buf, 1);
+			__ASSERT_NO_MSG(fsp_err == FSP_SUCCESS);
+		} else {
+			LOG_DBG("I2C target doesn't provide new data. The I2C bus will be left "
+				"floating, Controller device will read the value 0xFF for the "
+				"remaining bytes.");
+		}
+		break;
+#endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
+	case I2C_SLAVE_EVENT_ABORTED:
+	case I2C_SLAVE_EVENT_GENERAL_CALL:
+	default:
+		break;
+	}
+}
+#endif /* CONFIG_I2C_TARGET */
 
 static int i2c_ra_iic_init(const struct device *dev)
 {
 	const struct i2c_ra_iic_config *config = dev->config;
 	struct i2c_ra_iic_data *data = (struct i2c_ra_iic_data *)dev->data;
-	fsp_err_t fsp_err = FSP_SUCCESS;
+	fsp_err_t fsp_err;
 	int ret = 0;
 
 	/* Configure dt provided device signals when available */
@@ -300,23 +475,23 @@ static int i2c_ra_iic_init(const struct device *dev)
 	k_mutex_init(&data->bus_mutex);
 	k_sem_init(&data->complete_sem, 0, 1);
 
-	switch (data->fsp_config.rate) {
+	switch (data->ctrl_fconfig.rate) {
 	case I2C_MASTER_RATE_STANDARD:
 	case I2C_MASTER_RATE_FAST:
 	case I2C_MASTER_RATE_FASTPLUS:
-		ret = calc_iic_master_clock_setting(dev, data->fsp_config.rate,
-						    &data->iic_master_ext_cfg.clock_settings);
+		ret = calc_iic_ctrl_clock_setting(dev, data->ctrl_fconfig.rate,
+						  &data->iic_ctrl_ext_cfg.clock_settings);
 		if (ret != 0) {
 			LOG_ERR("Failed to calculate I2C clock settings");
 			break;
 		}
-		data->iic_master_ext_cfg.timeout_mode = IIC_MASTER_TIMEOUT_MODE_SHORT;
-		data->iic_master_ext_cfg.timeout_scl_low = IIC_MASTER_TIMEOUT_SCL_LOW_ENABLED;
+		data->iic_ctrl_ext_cfg.timeout_mode = IIC_MASTER_TIMEOUT_MODE_SHORT;
+		data->iic_ctrl_ext_cfg.timeout_scl_low = IIC_MASTER_TIMEOUT_SCL_LOW_ENABLED;
 
-		data->fsp_config.p_extend = &data->iic_master_ext_cfg;
+		data->ctrl_fconfig.p_extend = &data->iic_ctrl_ext_cfg;
 		break;
 	default:
-		LOG_ERR("%s: Invalid I2C speed rate: %d", __func__, data->fsp_config.rate);
+		LOG_ERR("%s: Invalid I2C speed rate: %d", __func__, data->ctrl_fconfig.rate);
 		return -ENOTSUP;
 	}
 
@@ -324,45 +499,46 @@ static int i2c_ra_iic_init(const struct device *dev)
 		return ret;
 	}
 
-	fsp_err = R_IIC_MASTER_Open(&data->ctrl, &data->fsp_config);
+	fsp_err = R_IIC_MASTER_Open(&data->control_ctrl, &data->ctrl_fconfig);
 	__ASSERT(fsp_err == FSP_SUCCESS, "%s: Open iic master failed. FSP_ERR=%d", __func__,
 		 fsp_err);
 
-	config->irq_config_func(dev);
+#ifdef CONFIG_I2C_TARGET
+	data->target_fconfig.p_extend = &data->iic_target_ext_cfg;
+#endif /* CONFIG_I2C_TARGET */
 
 	return 0;
 }
 
-static void calc_iic_master_bitrate(const struct i2c_ra_iic_config *config, uint32_t total_brl_brh,
-				    uint32_t brh, uint32_t divider, uint32_t peripheral_clock,
-				    struct ra_iic_master_bitrate *result)
+static void calc_iic_ctrl_bitrate(const struct i2c_ra_iic_config *config, uint32_t total_brl_brh,
+				  uint32_t brh, uint32_t divider, uint32_t peripheral_clock,
+				  struct ra_iic_ctrl_bitrate *result)
 {
-	const uint32_t noise_filter_stage = config->noise_filter_stage;
-	const double rise_time_s = config->rise_time_s;
-	const double fall_time_s = config->fall_time_s;
-	const uint32_t requested_duty = config->duty_cycle_percent;
-	uint32_t constant_add;
-	uint32_t divided_pclk;
+	const uint32_t requested_duty = config->ctrl_duty_cycle_percent;
+	uint32_t constant_add, divided_pclk, clock_edge, clock_rise_edge;
 
 	/* A constant is added to BRL and BRH in all formulas. This constand is 3 + nf
 	 * when CKS == 0, or 2 + nf when CKS != 0.
 	 */
 	if (divider == 0) {
-		constant_add = 3 + noise_filter_stage;
+		constant_add = 3 + config->ctrl_noise_filter_stage;
 	} else {
-		/* All dividers other than 0 use an addition of 2 + noise_filter_stages. */
-		constant_add = 2 + noise_filter_stage;
+		/* All dividers other than 0 use an addition of 2 + ctrl_noise_filter_stages. */
+		constant_add = 2 + config->ctrl_noise_filter_stage;
 	}
 
-	/* Converts all divided numbers to double to avoid data loss. */
 	divided_pclk = (peripheral_clock >> divider);
 
-	result->bitrate =
-		1 / ((total_brl_brh + 2 * constant_add) / divided_pclk + rise_time_s + fall_time_s);
-	result->duty =
-		100 *
-		((rise_time_s + ((brh + constant_add) / divided_pclk)) /
-		 (rise_time_s + fall_time_s + ((total_brl_brh + 2 * constant_add)) / divided_pclk));
+	clock_edge = (uint32_t)((uint64_t)((uint64_t)(divided_pclk) * (config->ctrl_rise_time_ns +
+								       config->ctrl_fall_time_ns)) /
+				1000000000);
+	clock_rise_edge =
+		(uint32_t)((uint64_t)((uint64_t)(divided_pclk)*config->ctrl_rise_time_ns) /
+			   1000000000);
+
+	result->bitrate = divided_pclk / (total_brl_brh + 2 * constant_add + clock_edge);
+	result->duty = (clock_rise_edge + brh + constant_add) /
+		       (clock_edge + total_brl_brh + 2 * constant_add) * 100;
 	result->divider = divider;
 	result->brh = brh;
 	result->brl = total_brl_brh - brh;
@@ -378,28 +554,26 @@ static void calc_iic_master_bitrate(const struct i2c_ra_iic_config *config, uint
 		result->divider, result->brh, result->brl, result->duty_error_percent);
 }
 
-static int calc_iic_master_clock_setting(const struct device *dev, const uint32_t fsp_i2c_rate,
-					 iic_master_clock_settings_t *clk_cfg)
+static int calc_iic_ctrl_clock_setting(const struct device *dev, const uint32_t ctrl_rate,
+				       iic_master_clock_settings_t *clk_cfg)
 {
 	const struct i2c_ra_iic_config *config = dev->config;
-	struct ra_iic_master_bitrate bitrate = {};
-	const double rise_time_s = config->rise_time_s;
-	const double fall_time_s = config->fall_time_s;
-	const uint32_t noise_filter_stage = config->noise_filter_stage;
-	const uint32_t requested_duty = config->duty_cycle_percent;
+	const uint32_t ctrl_noise_filter_stage = config->ctrl_noise_filter_stage;
+	const uint32_t requested_duty = config->ctrl_duty_cycle_percent;
+	struct ra_iic_ctrl_bitrate bitrate = {};
 	uint32_t peripheral_clock;
 	uint32_t min_brh, min_brl_brh, total_brl_brh;
 	uint32_t divided_pclk, constant_add, requested_bitrate;
 	int ret;
 
-	switch (fsp_i2c_rate) {
+	switch (ctrl_rate) {
 	case I2C_MASTER_RATE_STANDARD:
 	case I2C_MASTER_RATE_FAST:
 	case I2C_MASTER_RATE_FASTPLUS:
-		requested_bitrate = fsp_i2c_rate;
+		requested_bitrate = ctrl_rate;
 		break;
 	default:
-		LOG_ERR("%s: Invalid I2C speed rate: %d", __func__, fsp_i2c_rate);
+		LOG_ERR("%s: Invalid I2C speed rate: %d", __func__, ctrl_rate);
 		return -EINVAL;
 	}
 
@@ -411,31 +585,36 @@ static int calc_iic_master_clock_setting(const struct device *dev, const uint32_
 	}
 
 	/* Start with maximum possible bitrate. */
-	min_brh = noise_filter_stage + 1;
+	min_brh = ctrl_noise_filter_stage + 1;
 	min_brl_brh = 2 * min_brh;
 
-	calc_iic_master_bitrate(config, min_brl_brh, min_brh, 0, peripheral_clock, &bitrate);
+	calc_iic_ctrl_bitrate(config, min_brl_brh, min_brh, 0, peripheral_clock, &bitrate);
 
 	/* Start with the smallest divider because it gives the most resolution. */
-	constant_add = 3 + noise_filter_stage;
+	constant_add = 3 + ctrl_noise_filter_stage;
 
-	for (int temp_divider = 0; temp_divider <= 7; ++temp_divider) {
-		struct ra_iic_master_bitrate temp_bitrate = {};
-		uint32_t temp_brh;
+	for (uint32_t temp_divider = 0; temp_divider <= 7; ++temp_divider) {
+		struct ra_iic_ctrl_bitrate temp_bitrate = {};
+		uint32_t temp_brh, clock_edge;
 
 		if (1 == temp_divider) {
-			/* All dividers other than 0 use an addition of 2 + noise_filter_stages.
+			/* All dividers other than 0 use an addition of 2 +
+			 * ctrl_noise_filter_stages.
 			 */
-			constant_add = 2 + noise_filter_stage;
+			constant_add = 2 + ctrl_noise_filter_stage;
 		}
 
 		/* If the requested bitrate cannot be achieved with this divider, continue.
 		 */
 		divided_pclk = (peripheral_clock >> temp_divider);
-		total_brl_brh =
-			ceil(((1 / (double)requested_bitrate) - (rise_time_s + fall_time_s)) *
-				     divided_pclk -
-			     (2 * constant_add));
+
+		clock_edge = (uint32_t)((uint64_t)((uint64_t)(divided_pclk) *
+						   (config->ctrl_rise_time_ns +
+						    config->ctrl_fall_time_ns)) /
+					1000000000);
+
+		total_brl_brh = DIV_ROUND_UP(divided_pclk, requested_bitrate) - clock_edge -
+				(2 * constant_add);
 
 		if ((total_brl_brh > 62) || (total_brl_brh < min_brl_brh)) {
 			continue;
@@ -448,20 +627,21 @@ static int calc_iic_master_clock_setting(const struct device *dev, const uint32_
 		}
 
 		/* Calculate the actual bitrate and duty cycle. */
-		calc_iic_master_bitrate(config, total_brl_brh, temp_brh, temp_divider,
-					peripheral_clock, &temp_bitrate);
+		calc_iic_ctrl_bitrate(config, total_brl_brh, temp_brh, temp_divider,
+				      peripheral_clock, &temp_bitrate);
 
 		/* Adjust duty cycle down if it helps. */
 		while (temp_bitrate.duty > requested_duty) {
-			struct ra_iic_master_bitrate new_bitrate = {};
+			struct ra_iic_ctrl_bitrate new_bitrate = {};
+
 			temp_brh--;
 
 			if ((temp_brh < min_brh) || ((total_brl_brh - temp_brh) > 31)) {
 				break;
 			}
 
-			calc_iic_master_bitrate(config, total_brl_brh, temp_brh, temp_divider,
-						peripheral_clock, &new_bitrate);
+			calc_iic_ctrl_bitrate(config, total_brl_brh, temp_brh, temp_divider,
+					      peripheral_clock, &new_bitrate);
 
 			if (new_bitrate.duty_error_percent < temp_bitrate.duty_error_percent) {
 				temp_bitrate = new_bitrate;
@@ -472,7 +652,8 @@ static int calc_iic_master_clock_setting(const struct device *dev, const uint32_
 
 		/* Adjust duty cycle up if it helps. */
 		while (temp_bitrate.duty < requested_duty) {
-			struct ra_iic_master_bitrate new_bitrate = {};
+			struct ra_iic_ctrl_bitrate new_bitrate = {};
+
 			temp_brh++;
 
 			if ((temp_brh > total_brl_brh) || (temp_brh > 31) ||
@@ -480,8 +661,8 @@ static int calc_iic_master_clock_setting(const struct device *dev, const uint32_
 				break;
 			}
 
-			calc_iic_master_bitrate(config, total_brl_brh, temp_brh, temp_divider,
-						peripheral_clock, &new_bitrate);
+			calc_iic_ctrl_bitrate(config, total_brl_brh, temp_brh, temp_divider,
+					      peripheral_clock, &new_bitrate);
 
 			if (new_bitrate.duty_error_percent < temp_bitrate.duty_error_percent) {
 				temp_bitrate = new_bitrate;
@@ -501,28 +682,256 @@ static int calc_iic_master_clock_setting(const struct device *dev, const uint32_
 	clk_cfg->brh_value = bitrate.brh;
 	clk_cfg->cks_value = bitrate.divider;
 
-	LOG_DBG("%s: [input] rate[%u] [output] brl[%u] brh[%u] cks[%u]\n", __func__, fsp_i2c_rate,
+	LOG_DBG("%s: [input] rate[%u] [output] brl[%u] brh[%u] cks[%u]\n", __func__, ctrl_rate,
 		clk_cfg->brl_value, clk_cfg->brh_value, clk_cfg->cks_value);
 
 	return 0;
 }
 
+#ifdef CONFIG_I2C_TARGET
+static int calc_iic_target_clock_setting(const struct device *dev, const uint32_t slave_rate,
+					 iic_slave_clock_settings_t *clk_cfg)
+{
+	const struct i2c_ra_iic_config *config = dev->config;
+	struct i2c_ra_iic_data *data = dev->data;
+	uint32_t requested_delay_ns;
+	uint32_t peripheral_clock;
+	uint32_t min_brl, brl;
+	uint64_t brl_ns;
+	int ret;
+
+	ret = clock_control_get_rate(config->clock_dev,
+				     (clock_control_subsys_t)&config->clock_subsys,
+				     &peripheral_clock);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (slave_rate == I2C_SLAVE_RATE_FASTPLUS) {
+		requested_delay_ns = 50;
+	} else if (slave_rate == I2C_SLAVE_RATE_FAST) {
+		requested_delay_ns = 100;
+	} else {
+		requested_delay_ns = 250;
+	}
+
+	min_brl = data->iic_target_ext_cfg.clock_settings.digital_filter_stages + 1;
+	brl_ns = (uint64_t)(peripheral_clock * requested_delay_ns);
+	brl = (uint32_t)DIV_ROUND_UP(brl_ns, 1000000000);
+
+	if (brl < min_brl) {
+		brl = min_brl;
+	}
+
+	clk_cfg->brl_value = brl;
+
+	return 0;
+}
+
+static int i2c_ra_iic_target_register(const struct device *dev, struct i2c_target_config *cfg)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+	fsp_err_t fsp_err;
+	int ret;
+
+	if (!cfg) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+
+	if (data->control_ctrl.open == 0) {
+		LOG_ERR("%s: I2C Controller instance is not opened.", __func__);
+		ret = -EIO;
+		goto RELEASE_BUS;
+	}
+
+	fsp_err = R_IIC_MASTER_Close(&data->control_ctrl);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("%s: Failed to close I2C Controller instance. FSP_ERR=%d", __func__,
+			fsp_err);
+		ret = -EIO;
+		goto RELEASE_BUS;
+	}
+
+	if (I2C_TARGET_FLAGS_ADDR_10_BITS & cfg->flags) {
+		data->target_fconfig.addr_mode = I2C_SLAVE_ADDR_MODE_10BIT;
+	} else {
+		data->target_fconfig.addr_mode = I2C_SLAVE_ADDR_MODE_7BIT;
+	}
+	data->target_cfg = cfg;
+	data->target_fconfig.slave = cfg->address;
+	data->target_fconfig.rate = data->ctrl_fconfig.rate;
+
+	ret = calc_iic_target_clock_setting(dev, data->target_fconfig.rate,
+					    &data->iic_target_ext_cfg.clock_settings);
+	if (ret != 0) {
+		LOG_ERR("Failed to calculate I2C Target clock settings");
+		ret = -EIO;
+		goto RELEASE_BUS;
+	}
+
+	data->target_fconfig.p_callback = i2c_ra_iic_target_callback;
+
+	fsp_err = R_IIC_SLAVE_Open(&data->target_ctrl, &data->target_fconfig);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("%s: Failed to enter I2C Target mode. Try to re-open Controller mode",
+			__func__);
+		fsp_err = R_IIC_MASTER_Open(&data->control_ctrl, &data->ctrl_fconfig);
+		if (fsp_err != FSP_SUCCESS) {
+			LOG_ERR("Failed to re-open I2C Controller instance: %s", dev->name);
+		}
+		ret = -EIO;
+	}
+
+RELEASE_BUS:
+	k_mutex_unlock(&data->bus_mutex);
+
+	return ret;
+}
+
+static int i2c_ra_iic_target_unregister(const struct device *dev, struct i2c_target_config *cfg)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+	fsp_err_t fsp_err;
+	int ret = 0;
+
+	if (data->target_cfg != cfg) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->bus_mutex, K_FOREVER);
+
+	if (data->target_ctrl.open == 0) {
+		LOG_ERR("%s: I2C Target instance is not opened.", __func__);
+		ret = -EINVAL;
+		goto RELEASE_BUS;
+	}
+
+	fsp_err = R_IIC_SLAVE_Close(&data->target_ctrl);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("%s: Failed to close I2C Target instance. FSP_ERR=%d", __func__, fsp_err);
+		ret = -EIO;
+		goto RELEASE_BUS;
+	}
+
+	data->target_cfg = NULL;
+
+	fsp_err = R_IIC_MASTER_Open(&data->control_ctrl, &data->ctrl_fconfig);
+	if (fsp_err != FSP_SUCCESS) {
+		LOG_ERR("Failed to re-open I2C Controller instance: %s", dev->name);
+		return -EIO;
+	}
+RELEASE_BUS:
+	k_mutex_unlock(&data->bus_mutex);
+
+	return ret;
+}
+
+#endif /* CONFIG_I2C_TARGET */
+
 static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 	.configure = i2c_ra_iic_configure,
 	.get_config = i2c_ra_iic_get_config,
 	.transfer = i2c_ra_iic_transfer,
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_ra_iic_target_register,
+	.target_unregister = i2c_ra_iic_target_unregister,
+#endif /* CONFIG_I2C_TARGET */
 };
+
+#ifdef CONFIG_I2C_TARGET
+#define IIC_RXI_ISR iic_rxi_isr
+#define IIC_TXI_ISR iic_txi_isr
+#define IIC_TEI_ISR iic_tei_isr
+#define IIC_ERI_ISR iic_eri_isr
+#define TARGET_FCONFIG_DEFAULT(index)                                                              \
+	.target_fconfig =                                                                          \
+		{                                                                                  \
+			.channel = DT_INST_PROP(index, channel),                                   \
+			.addr_mode = I2C_SLAVE_ADDR_MODE_7BIT,                                     \
+			.rate = DT_INST_PROP(index, clock_frequency),                              \
+			.rxi_irq = DT_INST_IRQ_BY_NAME(index, rxi, irq),                           \
+			.txi_irq = DT_INST_IRQ_BY_NAME(index, txi, irq),                           \
+			.tei_irq = DT_INST_IRQ_BY_NAME(index, tei, irq),                           \
+			.eri_irq = DT_INST_IRQ_BY_NAME(index, eri, irq),                           \
+			.eri_ipl = DT_INST_IRQ_BY_NAME(index, eri, priority),                      \
+			.ipl = DT_INST_IRQ_BY_NAME(index, rxi, priority),                          \
+			.p_callback = i2c_ra_iic_target_callback,                                  \
+			.p_context = (void *)DEVICE_DT_INST_GET(index),                            \
+			.clock_stretching_enable = false,                                          \
+			.general_call_enable = false,                                              \
+	},                                                                                         \
+	.iic_target_ext_cfg = {                                                                    \
+		.clock_settings =                                                                  \
+			{                                                                          \
+				.cks_value = 0,                                                    \
+				.digital_filter_stages =                                           \
+					DT_INST_PROP(index, target_digital_noise_filter),          \
+			},                                                                         \
+	},
+
+void iic_rxi_isr(const struct device *dev)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+
+	if (data->target_ctrl.open) {
+		iic_slave_rxi_isr();
+	} else {
+		iic_master_rxi_isr();
+	}
+}
+
+void iic_txi_isr(const struct device *dev)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+
+	if (data->target_ctrl.open) {
+		iic_slave_txi_isr();
+	} else {
+		iic_master_txi_isr();
+	}
+}
+
+void iic_tei_isr(const struct device *dev)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+
+	if (data->target_ctrl.open) {
+		iic_slave_tei_isr();
+	} else {
+		iic_master_tei_isr();
+	}
+}
+
+void iic_eri_isr(const struct device *dev)
+{
+	struct i2c_ra_iic_data *data = dev->data;
+
+	if (data->target_ctrl.open) {
+		if (data->target_ctrl.p_reg->ICSR2_b.STOP == 1) {
+			data->transaction_completed = true;
+		}
+		iic_slave_eri_isr();
+	} else {
+		iic_master_eri_isr();
+	}
+}
+
+#else /* !CONFIG_I2C_TARGET */
+#define IIC_RXI_ISR iic_master_rxi_isr
+#define IIC_TXI_ISR iic_master_txi_isr
+#define IIC_TEI_ISR iic_master_tei_isr
+#define IIC_ERI_ISR iic_master_eri_isr
+#define TARGET_FCONFIG_DEFAULT(index)
+#endif /* CONFIG_I2C_TARGET */
 
 #define EVENT_IIC_RXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _RXI))
 #define EVENT_IIC_TXI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _TXI))
 #define EVENT_IIC_TEI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _TEI))
 #define EVENT_IIC_ERI(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_IIC, channel, _ERI))
 
-#define I2C_RA_IIC_INIT(index)                                                                     \
-                                                                                                   \
-	PINCTRL_DT_INST_DEFINE(index);                                                             \
-                                                                                                   \
-	static void i2c_ra_iic_irq_config_func##index(const struct device *dev)                    \
+#define IIC_RENESAS_RA_IRQ_INIT(index)                                                             \
 	{                                                                                          \
 		R_ICU->IELSR[DT_INST_IRQ_BY_NAME(index, rxi, irq)] =                               \
 			EVENT_IIC_RXI(DT_INST_PROP(index, channel));                               \
@@ -539,25 +948,29 @@ static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 		BSP_ASSIGN_EVENT_TO_CURRENT_CORE(EVENT_IIC_ERI(DT_INST_PROP(index, channel)));     \
                                                                                                    \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, rxi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, rxi, priority), iic_master_rxi_isr,         \
+			    DT_INST_IRQ_BY_NAME(index, rxi, priority), IIC_RXI_ISR,                \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, txi, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, txi, priority), iic_master_txi_isr,         \
+			    DT_INST_IRQ_BY_NAME(index, txi, priority), IIC_TXI_ISR,                \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, tei, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, tei, priority), iic_master_tei_isr,         \
+			    DT_INST_IRQ_BY_NAME(index, tei, priority), IIC_TEI_ISR,                \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, eri, irq),                                  \
-			    DT_INST_IRQ_BY_NAME(index, eri, priority), iic_master_eri_isr,         \
+			    DT_INST_IRQ_BY_NAME(index, eri, priority), IIC_ERI_ISR,                \
 			    DEVICE_DT_INST_GET(index), 0);                                         \
                                                                                                    \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, rxi, irq));                                  \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, txi, irq));                                  \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, tei, irq));                                  \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, eri, irq));                                  \
-	}                                                                                          \
+	}
+
+#define I2C_RA_IIC_INIT(index)                                                                     \
                                                                                                    \
-	BUILD_ASSERT(DT_INST_PROP(index, clock_frequency) <=                                        \
+	PINCTRL_DT_INST_DEFINE(index);                                                             \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_PROP(index, clock_frequency) <=                                       \
 			     DT_INST_PROP(index, max_bitrate_supported),                           \
 		     "The desire clock-frequency in devicetree exceeds max-bitrate-supported");    \
                                                                                                    \
@@ -569,33 +982,38 @@ static DEVICE_API(i2c, i2c_ra_iic_driver_api) = {
 				.mstp = (uint32_t)DT_INST_CLOCKS_CELL_BY_IDX(index, 0, mstp),      \
 				.stop_bit = DT_INST_CLOCKS_CELL_BY_IDX(index, 0, stop_bit),        \
 			},                                                                         \
-		.irq_config_func = i2c_ra_iic_irq_config_func##index,                              \
-		.noise_filter_stage = 1, /* Cannot be configured. */                               \
-		.rise_time_s = DT_INST_PROP(index, rise_time_ns) / RA_IIC_MASTER_DIV_TIME_NS,      \
-		.fall_time_s = DT_INST_PROP(index, fall_time_ns) / RA_IIC_MASTER_DIV_TIME_NS,      \
-		.duty_cycle_percent = DT_INST_PROP(index, duty_cycle_percent),                     \
+		.ctrl_noise_filter_stage = 1, /* Cannot be configured. */                          \
+		.ctrl_rise_time_ns = DT_INST_PROP(index, rise_time_ns),                            \
+		.ctrl_fall_time_ns = DT_INST_PROP(index, fall_time_ns),                            \
+		.ctrl_duty_cycle_percent = DT_INST_PROP(index, duty_cycle_percent),                \
 		.max_bitrate_supported = DT_INST_PROP(index, max_bitrate_supported),               \
 	};                                                                                         \
                                                                                                    \
 	static struct i2c_ra_iic_data i2c_ra_iic_data_##index = {                                  \
-		.fsp_config =                                                                      \
+		.ctrl_fconfig =                                                                    \
 			{                                                                          \
 				.channel = DT_INST_PROP(index, channel),                           \
 				.slave = 0,                                                        \
 				.rate = DT_INST_PROP(index, clock_frequency),                      \
 				.addr_mode = I2C_MASTER_ADDR_MODE_7BIT,                            \
-				.ipl = DT_INST_PROP(index, interrupt_priority_level),              \
 				.rxi_irq = DT_INST_IRQ_BY_NAME(index, rxi, irq),                   \
 				.txi_irq = DT_INST_IRQ_BY_NAME(index, txi, irq),                   \
 				.tei_irq = DT_INST_IRQ_BY_NAME(index, tei, irq),                   \
 				.eri_irq = DT_INST_IRQ_BY_NAME(index, eri, irq),                   \
-				.p_callback = i2c_ra_iic_callback,                                 \
+				.ipl = DT_INST_IRQ_BY_NAME(index, eri, priority),                  \
+				.p_callback = i2c_ra_iic_ctrl_callback,                            \
 				.p_context = (void *)DEVICE_DT_GET(DT_DRV_INST(index)),            \
 			},                                                                         \
-	};                                                                                         \
+		TARGET_FCONFIG_DEFAULT(index)};                                                    \
                                                                                                    \
-	I2C_DEVICE_DT_INST_DEFINE(index, i2c_ra_iic_init, NULL, &i2c_ra_iic_data_##index,          \
-				  &i2c_ra_iic_config_##index, POST_KERNEL,                         \
-				  CONFIG_I2C_INIT_PRIORITY, &i2c_ra_iic_driver_api);
+	static int i2c_renesas_ra_init##index(const struct device *dev)                            \
+	{                                                                                          \
+		IIC_RENESAS_RA_IRQ_INIT(index)                                                     \
+		return i2c_ra_iic_init(dev);                                                       \
+	}                                                                                          \
+                                                                                                   \
+	I2C_DEVICE_DT_INST_DEFINE(index, i2c_renesas_ra_init##index, NULL,                         \
+				  &i2c_ra_iic_data_##index, &i2c_ra_iic_config_##index,            \
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &i2c_ra_iic_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_RA_IIC_INIT)

--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -486,6 +486,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x40053000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -493,6 +494,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x40053100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -487,6 +488,7 @@
 			channel = <0>;
 			reg = <0x40053000 0x100>;
 			clocks = <&pclkb MSTPB 9>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 
@@ -495,6 +497,7 @@
 			channel = <1>;
 			reg = <0x40053100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {
@@ -312,6 +313,7 @@
 			channel = <0>;
 			reg = <0x40053000 0x100>;
 			clocks = <&pclkb MSTPB 9>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 
@@ -320,6 +322,7 @@
 			channel = <1>;
 			reg = <0x40053100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -311,6 +311,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x40053000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -318,6 +319,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x40053100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -306,6 +306,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4009f000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -313,6 +314,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h>
 #include <freq.h>
 
@@ -315,6 +316,7 @@
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -403,6 +403,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4009f000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h>
 #include <freq.h>
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -372,6 +372,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4009f000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -379,6 +380,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {
@@ -381,6 +382,7 @@
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -320,6 +320,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x40053000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -327,6 +328,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x40053100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {
@@ -321,6 +322,7 @@
 			channel = <0>;
 			reg = <0x40053000 0x100>;
 			clocks = <&pclkb MSTPB 9>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 
@@ -329,6 +331,7 @@
 			channel = <1>;
 			reg = <0x40053100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -116,6 +116,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <2>;
 			reg = <0x40053200 0x100>;
+			clocks = <&pclkb MSTPB 7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -117,6 +117,7 @@
 			channel = <2>;
 			reg = <0x40053200 0x100>;
 			clocks = <&pclkb MSTPB 7>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -156,6 +156,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <2>;
 			reg = <0x40053200 0x100>;
+			clocks = <&pclkb MSTPB 7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -157,6 +157,7 @@
 			channel = <2>;
 			reg = <0x40053200 0x100>;
 			clocks = <&pclkb MSTPB 7>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -336,6 +336,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <2>;
 			reg = <0x4009f200 0x100>;
+			clocks = <&pclkb MSTPB 7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -337,6 +337,7 @@
 			channel = <2>;
 			reg = <0x4009f200 0x100>;
 			clocks = <&pclkb MSTPB 7>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -192,6 +192,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4009f000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -199,6 +200,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {
@@ -201,6 +202,7 @@
 			channel = <1>;
 			reg = <0x4009f100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {
@@ -371,6 +372,7 @@
 			channel = <1>;
 			reg = <0x40053100 0x100>;
 			clocks = <&pclkb MSTPB 8>;
+			max-bitrate-supported = <I2C_BITRATE_FAST>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -362,6 +362,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x40053000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -369,6 +370,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x40053100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -231,6 +231,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4025e000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -240,6 +241,7 @@
 			interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4025e100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -248,6 +248,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <0>;
 			reg = <0x4025e000 0x100>;
+			clocks = <&pclkb MSTPB 9>;
 			status = "disabled";
 		};
 
@@ -255,6 +256,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <1>;
 			reg = <0x4025e100 0x100>;
+			clocks = <&pclkb MSTPB 8>;
 			status = "disabled";
 		};
 
@@ -262,6 +264,7 @@
 			compatible = "renesas,ra-iic";
 			channel = <2>;
 			reg = <0x4025e200 0x100>;
+			clocks = <&pclkb MSTPB 7>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/i2c/renesas,ra-iic.yaml
+++ b/dts/bindings/i2c/renesas,ra-iic.yaml
@@ -33,3 +33,10 @@ properties:
   interrupt-priority-level:
     type: int
     default: 12
+
+  max-bitrate-supported:
+    type: int
+    default: 1000000
+    description: |
+      Maximum supported I2C bitrate in Hz, with the default set to I2C_BITRATE_FAST_PLUS.
+      This property may be overlayed if the device supports higher or lower speeds.

--- a/dts/bindings/i2c/renesas,ra-iic.yaml
+++ b/dts/bindings/i2c/renesas,ra-iic.yaml
@@ -1,7 +1,7 @@
-# Copyright (c) 2024 Renesas Electronics Corporation
+# Copyright (c) 2024-2025 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Renesas RA I2C Master controller
+description: Renesas RA I2C controller
 
 compatible: "renesas,ra-iic"
 
@@ -11,12 +11,19 @@ properties:
   reg:
     required: true
 
+  clocks:
+    required: true
+
   channel:
     required: true
     type: int
 
   interrupts:
     required: true
+
+  interrupt-names:
+    required: true
+    enum: ["tei", "eri", "rxi", "txi"]
 
   rise-time-ns:
     type: int
@@ -30,13 +37,16 @@ properties:
     type: int
     default: 50
 
-  interrupt-priority-level:
-    type: int
-    default: 12
-
   max-bitrate-supported:
     type: int
     default: 1000000
     description: |
       Maximum supported I2C bitrate in Hz, with the default set to I2C_BITRATE_FAST_PLUS.
       This property may be overlayed if the device supports higher or lower speeds.
+
+  target-digital-noise-filter:
+    type: int
+    enum: [0, 1, 2, 3, 4]
+    default: 3
+    description: |
+      Select the number of digital filter stages for IIC target

--- a/modules/Kconfig.renesas
+++ b/modules/Kconfig.renesas
@@ -45,6 +45,11 @@ config USE_RA_FSP_I2C_IIC_CONTROLLER
 	help
 	  Enable Renesas RA I2C IIC Controller driver
 
+config USE_RA_FSP_I2C_IIC_TARGET
+	bool
+	help
+	  Enable Renesas RA I2C IIC Target driver
+
 config USE_RA_FSP_SCI_I2C
 	bool
 	help

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra2a1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra2a1.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P000  -->  SCL1 P109
+ * SDA0 P401  -->  SDA1 P400
+ * Need to connect I2C pull up with 4.7k ohms
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 1, 9)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 0)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <27 1>, <28 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra2l1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra2l1.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P408  -->  SCL1 P205
+ * SDA0 P407  -->  SDA1 P206
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 8)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 7)>;
+			drive-strength = "medium";
+		};
+	};
+
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <24 1>, <25 1>, <20 1>, <21 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra4c1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra4c1.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P400  -->  SCL0 P302
+ * SDA1 P401  -->  SDA0 P301
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 3, 2)>,
+				<RA_PSEL(RA_PSEL_I2C, 3, 1)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <60 1>, <61 1>, <62 1>, <63 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P100  -->  SCL0 P400
+ * SDA1 P206  -->  SDA0 P401
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 0)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 1)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m2.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m2.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P400  -->  SCL1 P205
+ * SDA0 P401  -->  SDA1 P206
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m3.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra4m3.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P400  -->  SCL1 P512
+ * SDA0 P401  -->  SDA1 P511
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 5, 12)>,
+				<RA_PSEL(RA_PSEL_I2C, 5, 11)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra4w1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra4w1.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P407  -->  SCL1 P205
+ * SDA0 P204  -->  SDA1 P206
+ * Need to connect I2C pull up with 4.7k ohms
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m1.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P400  -->  SCL1 P100
+ * SDA0 P401  -->  SDA1 P101
+ * Need to connect I2C pull up with 4.7k ohms
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 1, 0)>,
+				<RA_PSEL(RA_PSEL_I2C, 1, 1)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m2.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m2.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL2 P512  -->  SCL1 P100
+ * SDA2 P511  -->  SDA1 P206
+ * Need to connect I2C pull up with 4.7k ohms
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 1, 0)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic2 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m3.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m3.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P408  -->  SCL2 P512
+ * SDA0 P401  -->  SDA2 P511
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 8)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 1)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic2 {
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m4.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P408
+ * SDA1 P511  -->  SDA0 P401
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 8)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 1)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m5.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra6m5.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL2 P414
+ * SDA1 P511  -->  SDA2 P415
+ */
+
+&pinctrl {
+	iic2_default: iic2_default {
+		group1 {
+			/* SCL2 SDA2*/
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 14)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 15)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic2_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra8d1.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P410
+ * SDA1 P511  -->  SDA0 P409
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 10)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 9)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra8d2_r7ka8d2kflcac_cm85.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P410
+ * SDA1 P511  -->  SDA0 P409
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 10)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 9)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra8m1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra8m1.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P410
+ * SDA1 P511  -->  SDA0 P409
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 10)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 9)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra8m2_r7ka8m2jflcac_cm85.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P410
+ * SDA1 P511  -->  SDA0 P409
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 10)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 9)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P512  -->  SCL0 P410
+ * SDA1 P511  -->  SDA0 P409
+ */
+
+&pinctrl {
+	iic0_default: iic0_default {
+		group1 {
+			/* SCL0 SDA0 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 4, 10)>,
+				<RA_PSEL(RA_PSEL_I2C, 4, 9)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic0_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/fpb_ra6e1.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL0 P400  -->  SCL1 P205
+ * SDA0 P401  -->  SDA1 P206
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic0 {
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <84 1>, <85 1>, <86 1>, <87 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/mck_ra8t2_r7ka8t2lfecac_cm85.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mck_ra8t2_r7ka8t2lfecac_cm85.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SCL1 P205  -->  SCL2 P515
+ * SDA1 P204  -->  SDA2 P514
+ */
+
+&pinctrl {
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+				<RA_PSEL(RA_PSEL_I2C, 2, 4)>;
+			drive-strength = "medium";
+		};
+	};
+
+	iic2_default: iic2_default {
+		group1 {
+			/* SCL2 SDA2 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 5, 15)>,
+				<RA_PSEL(RA_PSEL_I2C, 5, 14)>;
+			drive-strength = "medium";
+		};
+	};
+};
+
+&iic1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	interrupts = <88 1>, <89 1>, <90 1>, <91 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		address-width = <8>;
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&iic2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	pinctrl-0 = <&iic2_default>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};


### PR DESCRIPTION
- Add support I2C target mode for Renesas RA I2C driver
- Update I2C clock source for all Renesas RA I2C node
- Add `max-bitrate-supported` property for Renesas RA I2C binding
- Add support test app `i2c_target_api` for Renesas RA devices