### PR TITLE
include: hwspinlock.h: Optimize hw_spin_trylock function

### DIFF
--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -266,7 +266,15 @@ static inline int hw_spin_trylock(const struct device *dev, hwspinlock_ctx_t *ct
 	if (ret) {
 		return ret;
 	}
-	return api->trylock(dev, id);
+
+	ret = api->trylock(dev, id);
+	if (ret) {
+		/* HW trylock failed: release local lock before returning. */
+		k_spin_unlock(&ctx->lock, *key);
+		return ret;
+	}
+
+	return 0;
 }
 
 /**


### PR DESCRIPTION
If `api->trylock(dev, id)` fails (typically because a cross-core HW lock is held by another core and returns `-EBUSY`, or returns `-EINVAL`, etc.), the function will immediately return the error code, but the local `ctx->lock` is not released, and interrupts also remain in the locked state from the trylock. This may cause IRQ lock state leakage. If there's no opportunity in the call path to reach `k_spin_unlock()`, the system may exhibit unpredictable "freeze-like" behavior.