### PR TITLE
boards: esp32s3_touch_lcd_1_28: remove cs-gpios to use hardware CS

### DIFF
--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -135,7 +135,6 @@
 	#size-cells = <0>;
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 };
 
 &trng0 {


### PR DESCRIPTION
The board has hardware CS configured via pinctrl (SPIM2_CSEL_GPIO9) but also defines cs-gpios for the same pin. After commit 5d1e443bdf8e, the driver disables hardware CS when cs-gpios is present, breaking display communication. Remove cs-gpios to rely on hardware CS via pinctrl.