### PR TITLE
Bluetooth: Classic: HFP: CLCC report NULL when finish

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -493,7 +493,8 @@ struct bt_hfp_hf_cb {
 	 *  If this callback is provided it will be called whenever the
 	 *  result code `+CLCC: <idx>,<dir>,<status>,<mode>,<mprty>[,<number>,<type>]`
 	 *  is received from AG.
-	 *  If the request is failed or no active calls, the callback will not be called.
+	 *  If the request is finished (success or fail), the callback will be called
+	 *  with call set to NULL.
 	 *  If the @ref bt_hfp_hf_current_call::number is NULL, the
 	 *  @ref bt_hfp_hf_current_call::type shall be ignored.
 	 *

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -522,6 +522,11 @@ static int clcc_finish(struct at_client *hf_at, enum at_result result,
 		clear_call_without_clcc(hf);
 	}
 
+	if (atomic_test_bit(hf->flags, BT_HFP_HF_FLAG_USR_CLCC_CMD) &&
+	    (bt_hf->query_call != NULL)) {
+		bt_hf->query_call(hf, NULL);
+	}
+
 	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_USR_CLCC_CMD);
 	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_CLCC_PENDING);
 

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -307,6 +307,7 @@ void hf_subscriber_number(struct bt_hfp_hf *hf, const char *number, uint8_t type
 void hf_query_call(struct bt_hfp_hf *hf, struct bt_hfp_hf_current_call *call)
 {
 	if (call == NULL) {
+		bt_shell_print("CLCC finished");
 		return;
 	}
 


### PR DESCRIPTION
The CLCC API does not report when it finishes, so the app cannot
determine whether the CLCC procedure has ended. This commit modifies the
behavior of the CLCC API to call the callback with a NULL Call pointer to
indicate that the CLCC procedure has completed.