### PR TITLE
drivers: spi: esp32: move pinctrl to init

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -361,6 +361,12 @@ static int spi_esp32_init(const struct device *dev)
 	}
 #endif
 
+	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (err < 0) {
+		LOG_ERR("Failed to configure SPI pins");
+		return err;
+	}
+
 	err = spi_context_cs_configure_all(&data->ctx);
 	if (err < 0) {
 		return err;
@@ -442,13 +448,6 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 		hal_dev->cs_pin_id = -1;
 	} else {
 		hal_dev->cs_pin_id = ctx->config->slave;
-	}
-
-	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-
-	if (ret) {
-		LOG_ERR("Failed to configure SPI pins");
-		return ret;
 	}
 
 	/* input parameters to calculate timing configuration */


### PR DESCRIPTION
Move pinctrl_apply_state() from configure to init to ensure pinctrl is applied once at boot rather than on every transaction.

When cs-gpios is defined, spi_context_cs_configure_all() runs after pinctrl and reconfigures the CS pin as GPIO, properly overriding any CS routing set by pinctrl.