### PR TITLE
drivers: dma: emul: check complete_callback_en flag

### DIFF
--- a/drivers/dma/dma_emul.c
+++ b/drivers/dma/dma_emul.c
@@ -268,8 +268,7 @@ static void dma_emul_work_handler(struct k_work *work)
 		dma_emul_set_channel_state(dev, channel, DMA_EMUL_CHANNEL_STOPPED);
 		k_spin_unlock(&data->lock, key);
 
-		/* FIXME: tests/drivers/dma/chan_blen_transfer/ does not set complete_callback_en */
-		if (true) {
+		if (xfer_config.complete_callback_en) {
 			xfer_config.dma_callback(dev, xfer_config.user_data, channel,
 						 DMA_STATUS_COMPLETE);
 		} else {


### PR DESCRIPTION
The code was using 'if (true)' which always called the completion callback, ignoring the complete_callback_en flag. Fix by checking the flag before calling the callback, matching the intended behavior and the pattern used for error callbacks.