### PR TITLE
boards: nxp: s32k5xxcvb: add pwm (ftm) support

### DIFF
--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
@@ -13,6 +13,7 @@ supported:
   - adc
   - can
   - gpio
+  - pwm
   - counter
   - i2c
 vendor: nxp

--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
@@ -13,6 +13,7 @@ supported:
   - adc
   - can
   - gpio
+  - pwm
   - counter
   - i2c
 vendor: nxp

--- a/dts/arm/nxp/nxp_s32k566.dtsi
+++ b/dts/arm/nxp/nxp_s32k566.dtsi
@@ -789,6 +789,15 @@
 			status = "disabled";
 		};
 
+		lpe_ftm: ftm@42158000 {
+			compatible = "nxp,ftm-pwm";
+			reg = <0x42158000 0x4000>;
+			clocks = <&clock NXP_S32_LPE_FTM_IPG_CLK>;
+			prescaler = <1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
 		sar_adc0: adc@40698000 {
 			compatible = "nxp,s32-adc-sar";
 			reg = <0x40698000 0x4000>;

--- a/dts/arm/nxp/nxp_s32k566_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_m7.dtsi
@@ -457,3 +457,7 @@
 &lpi2c3 {
 	interrupts = <146 0>;
 };
+
+&lpe_ftm {
+	interrupts = <223 0>;
+};

--- a/dts/arm/nxp/nxp_s32k566_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_r52.dtsi
@@ -407,3 +407,7 @@
 &lpi2c3 {
 	interrupts = <GIC_SPI 135 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 };
+
+&lpe_ftm {
+	interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};

--- a/tests/drivers/pwm/pwm_api/boards/s32k5xxcvb_s32k566_ftm.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/s32k5xxcvb_s32k566_ftm.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-test = &lpe_ftm;
+	};
+};
+
+&pinctrl {
+	lpe_ftm_default: lpe_ftm_default {
+		group0 {
+			pinmux = <PK13_LPE_FTM_CH0_O>; /* GPIO173 - J318 - P4*/
+			output-enable;
+		};
+	};
+};
+
+&lpe_ftm {
+	pinctrl-0 = <&lpe_ftm_default>;
+	pinctrl-names = "default";
+	clock-source = "system";
+	prescaler = <32>;
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/boards/s32k5xxcvb_s32k566_m7.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/s32k5xxcvb_s32k566_m7.overlay
@@ -8,7 +8,7 @@
 
 / {
 	aliases {
-		pwm-0 = &emios0_pwm;
+		pwm-test = &emios0_pwm;
 	};
 };
 

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -146,3 +146,13 @@ tests:
     platform_allow:
       - sam_e54_xpro
     filter: dt_alias_exists("pwm-test")
+  drivers.pwm.s32k5xxcvb_s32k566_ftm:
+    tags:
+      - drivers
+      - pwm
+      - userspace
+    extra_args: DTC_OVERLAY_FILE="boards/s32k5xxcvb_s32k566_ftm.overlay"
+    platform_allow:
+      - s32k5xxcvb/s32k566/m7
+      - s32k5xxcvb/s32k566/r52
+    depends_on: pwm

--- a/tests/drivers/pwm/pwm_loopback/boards/s32k5xxcvb_s32k566_ftm.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/s32k5xxcvb_s32k566_ftm.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&lpe_ftm 0 0 PWM_POLARITY_NORMAL>,
+		       <&lpe_ftm 4 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pinctrl {
+	lpe_ftm_default: lpe_ftm_default {
+		group0 {
+			pinmux = <PK13_LPE_FTM_CH0_O>; /* GPIO173 - J318 - P4*/
+			output-enable;
+		};
+
+		group1 {
+			pinmux = <PK7_LPE_FTM_CH4_I>; /* GPIO167 - J405 - D1 */
+			input-enable;
+		};
+	};
+};
+
+&lpe_ftm {
+	pinctrl-0 = <&lpe_ftm_default>;
+	pinctrl-names = "default";
+	clock-source = "system";
+	prescaler = <128>;
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_loopback/testcase.yaml
@@ -9,3 +9,17 @@ tests:
     harness: ztest
     harness_config:
       fixture: pwm_loopback
+  drivers.pwm.s32k5xxcvb_s32k566_ftm.loopback:
+    tags:
+      - pwm
+      - drivers
+      - userspace
+    extra_args: DTC_OVERLAY_FILE="boards/s32k5xxcvb_s32k566_ftm.overlay"
+    platform_allow:
+      - s32k5xxcvb/s32k566/m7
+      - s32k5xxcvb/s32k566/r52
+    depends_on: pwm
+    filter: dt_compat_enabled("test-pwm-loopback")
+    harness: ztest
+    harness_config:
+      fixture: pwm_loopback


### PR DESCRIPTION
Add support PWM (FTM) for S32K5XXCVB.
Tested with `tests\drivers\pwm\pwm_api` and `tests\drivers\pwm\pwm_loopback`