### PR TITLE
boards: nxp: s32k5xxcvb: add support for watchdog

### DIFF
--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566.dtsi
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566.dtsi
@@ -15,6 +15,7 @@
 		led2 = &user_led_blue;
 		sw0 = &user_button_0;
 		sw1 = &user_button_1;
+		watchdog0 = &swt_startup;
 	};
 
 	chosen {
@@ -82,5 +83,8 @@
 &flexcan0 {
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
+};
+
+&swt_startup {
 	status = "okay";
 };

--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
@@ -16,4 +16,5 @@ supported:
   - pwm
   - counter
   - i2c
+  - watchdog
 vendor: nxp

--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
@@ -16,4 +16,5 @@ supported:
   - pwm
   - counter
   - i2c
+  - watchdog
 vendor: nxp

--- a/dts/arm/nxp/nxp_s32k566.dtsi
+++ b/dts/arm/nxp/nxp_s32k566.dtsi
@@ -780,6 +780,22 @@
 			status = "disabled";
 		};
 
+		lpe_swt: watchdog@4207c000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x4207c000 0x4000>;
+			clocks = <&clock NXP_S32_SAFE_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
+		swt_startup: watchdog@404a8000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x404a8000 0x4000>;
+			clocks = <&clock NXP_S32_SWT_STARTUP_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
 		sar_adc0: adc@40698000 {
 			compatible = "nxp,s32-adc-sar";
 			reg = <0x40698000 0x4000>;

--- a/dts/arm/nxp/nxp_s32k566_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_m7.dtsi
@@ -216,6 +216,43 @@
 				status = "disabled";
 			};
 		};
+
+		/* SWT_0 -> SWT_3 for Cortex-M7_0 -> Cortex-M7_3 */
+		swt0: watchdog@40b18000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x40b18000 0x4000>;
+			interrupts = <28 0>;
+			clocks = <&clock NXP_S32_SWT0_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
+		swt1: watchdog@40b1c000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x40b1c000 0x4000>;
+			interrupts = <28 0>;
+			clocks = <&clock NXP_S32_SWT1_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
+		swt2: watchdog@40b20000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x40b20000 0x4000>;
+			interrupts = <28 0>;
+			clocks = <&clock NXP_S32_SWT2_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
+		swt3: watchdog@40b24000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x40b24000 0x4000>;
+			interrupts = <28 0>;
+			clocks = <&clock NXP_S32_SWT3_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
 	};
 };
 
@@ -465,4 +502,12 @@
 &canxl {
 	interrupts = <97 0>;
 	interrupt-names = "rx_tx_mru_error";
+};
+
+&lpe_swt {
+	interrupts = <210 0>;
+};
+
+&swt_startup {
+	interrupts = <27 0>;
 };

--- a/dts/arm/nxp/nxp_s32k566_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_r52.dtsi
@@ -140,6 +140,24 @@
 				status = "disabled";
 			};
 		};
+
+		swt0: watchdog@4105c000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x4105c000 0x4000>;
+			interrupts = <GIC_SPI 265 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SWT0_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
+
+		swt1: watchdog@4113c000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x4113c000 0x4000>;
+			interrupts = <GIC_SPI 266 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SWT1_IPG_COUNTER_CLK>;
+			service-mode = "fixed";
+			status = "disabled";
+		};
 	};
 };
 
@@ -415,4 +433,12 @@
 &canxl {
 	interrupts = <GIC_SPI 86 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-names = "rx_tx_mru_error";
+};
+
+&lpe_swt {
+	interrupts = <GIC_SPI 197 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+};
+
+&swt_startup {
+	interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 };

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -22,6 +22,7 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      - s32k5xxcvb/s32k566/r52
       - panb611evb/nrf54l15/cpuapp
       - panb611evb/nrf54l15/cpuapp/ns
       - panb611evb/nrf54l15/cpuflpr
@@ -149,12 +150,13 @@ tests:
       - longan_nano
     integration_platforms:
       - gd32e103v_eval
-  sample.drivers.watchdog.s32z270dc2_r52:
+  sample.drivers.watchdog.nxp_s32_swt:
     build_only: true
     platform_allow:
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      - s32k5xxcvb/s32k566/r52
     integration_platforms:
       - s32z2xxdc2/s32z270/rtu0

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -18,6 +18,7 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      - s32k5xxcvb/s32k566/r52
       - mps2/an383
       - mps2/an385
       - mps2/an386
@@ -147,6 +148,7 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      - s32k5xxcvb/s32k566/r52
       - mr_canhubk3
     integration_platforms:
       - s32z2xxdc2/s32z270/rtu0


### PR DESCRIPTION
Add support for Watchdog (SWT)
Tested `wdt_basic_reset_none` for both core
Tested `samples\drivers\watchdog` and `wdt_basic_api` for core m7 only