### PR TITLE
boards: nxp: s32k5xxcvb: add support for counter (pit & stm)

### DIFF
--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_m7.yaml
@@ -11,4 +11,5 @@ toolchain:
   - zephyr
 supported:
   - gpio
+  - counter
 vendor: nxp

--- a/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
+++ b/boards/nxp/s32k5xxcvb/s32k5xxcvb_s32k566_r52.yaml
@@ -11,4 +11,5 @@ toolchain:
   - zephyr
 supported:
   - gpio
+  - counter
 vendor: nxp

--- a/drivers/counter/counter_nxp_pit.c
+++ b/drivers/counter/counter_nxp_pit.c
@@ -300,7 +300,7 @@ static DEVICE_API(counter, nxp_pit_driver_api) = {
 
 #define NXP_PIT_SETUP_IRQ_ARRAY(n)								\
 	/* Create Array of IRQs -> 1 irq func per channel */					\
-	void (*nxp_pit_irq_config_array[DT_INST_FOREACH_CHILD_SEP_VARGS(n,			\
+	void (*nxp_pit_irq_config_array_##n[DT_INST_FOREACH_CHILD_SEP_VARGS(n,			\
 					DT_NODE_HAS_COMPAT, (+), nxp_pit_channel)])		\
 				(const struct device *dev) = {					\
 					DT_INST_FOREACH_CHILD_STATUS_OKAY(n,			\
@@ -355,7 +355,7 @@ static DEVICE_API(counter, nxp_pit_driver_api) = {
 		.irq_config_func = COND_CODE_1(DT_NODE_HAS_PROP(				\
 					DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_pit), interrupts),	\
 					(nxp_pit_irq_config_func_##n),				\
-					(&nxp_pit_irq_config_array[0])),			\
+					(&nxp_pit_irq_config_array_##n[0])),			\
 		.num_channels = DT_INST_FOREACH_CHILD_SEP_VARGS(				\
 			n, DT_NODE_HAS_COMPAT, (+), nxp_pit_channel),				\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),				\

--- a/dts/arm/nxp/nxp_s32k566_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_m7.dtsi
@@ -44,6 +44,178 @@
 
 	soc {
 		interrupt-parent = <&nvic>;
+
+		stm0: stm@405a4000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x405a4000 0x4000>;
+			interrupts = <93 0>;
+			clocks = <&clock NXP_S32_STM0_IPG_CLK>;
+			status = "disabled";
+		};
+
+		stm1: stm@40b98000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x40b98000 0x4000>;
+			interrupts = <94 0>;
+			clocks = <&clock NXP_S32_STM1_IPG_CLK>;
+			status = "disabled";
+		};
+
+		stm2: stm@40b9c000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x40b9c000 0x4000>;
+			interrupts = <95 0>;
+			clocks = <&clock NXP_S32_STM2_IPG_CLK>;
+			status = "disabled";
+		};
+
+		stm3: stm@40ba0000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x40ba0000 0x4000>;
+			interrupts = <96 0>;
+			clocks = <&clock NXP_S32_STM3_IPG_CLK>;
+			status = "disabled";
+		};
+
+		pit0: pit@405a0000 {
+			compatible = "nxp,pit";
+			reg = <0x405a0000 0x4000>;
+			interrupts = <88 0>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit0_channel0: pit0_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			pit0_channel1: pit0_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			pit0_channel2: pit0_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			pit0_channel3: pit0_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
+
+		pit1: pit@40b8c000 {
+			compatible = "nxp,pit";
+			reg = <0x40b8c000 0x4000>;
+			interrupts = <89 0>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit1_channel0: pit1_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			pit1_channel1: pit1_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			pit1_channel2: pit1_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			pit1_channel3: pit1_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
+
+		pit2: pit@40b90000 {
+			compatible = "nxp,pit";
+			reg = <0x40b90000 0x4000>;
+			interrupts = <90 0>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit2_channel0: pit2_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			pit2_channel1: pit2_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			pit2_channel2: pit2_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			pit2_channel3: pit2_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
+
+		pit3: pit@40b94000 {
+			compatible = "nxp,pit";
+			reg = <0x40b94000 0x4000>;
+			interrupts = <91 0>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit3_channel0: pit3_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			pit3_channel1: pit3_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			pit3_channel2: pit3_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			pit3_channel3: pit3_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_s32k566_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32k566_r52.dtsi
@@ -48,6 +48,98 @@
 			#interrupt-cells = <4>;
 			status = "okay";
 		};
+
+		stm0: stm@410a4000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x410a4000 0x4000>;
+			interrupts = <GIC_SPI 283 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_STM0_IPG_CLK>;
+			status = "disabled";
+		};
+
+		stm1: stm@41154000 {
+			compatible = "nxp,s32-sys-timer";
+			reg = <0x41154000 0x4000>;
+			interrupts = <GIC_SPI 287 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_STM1_IPG_CLK>;
+			status = "disabled";
+		};
+
+		pit0: pit@410a0000 {
+			compatible = "nxp,pit";
+			reg = <0x410a0000 0x4000>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit0_channel0: pit0_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				interrupts = <GIC_SPI 271 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit0_channel1: pit0_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				interrupts = <GIC_SPI 272 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit0_channel2: pit0_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				interrupts = <GIC_SPI 273 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit0_channel3: pit0_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				interrupts = <GIC_SPI 274 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		pit1: pit@41150000 {
+			compatible = "nxp,pit";
+			reg = <0x41150000 0x4000>;
+			clocks = <&clock NXP_S32_PLTDIV2_CLK>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit1_channel0: pit1_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				interrupts = <GIC_SPI 275 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit1_channel1: pit1_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				interrupts = <GIC_SPI 276 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit1_channel2: pit1_channel@2 {
+				compatible = "nxp,pit-channel";
+				reg = <2>;
+				interrupts = <GIC_SPI 277 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			pit1_channel3: pit1_channel@3 {
+				compatible = "nxp,pit-channel";
+				reg = <3>;
+				interrupts = <GIC_SPI 278 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/samples/drivers/counter/alarm/boards/s32k5xxcvb_s32k566_m7.overlay
+++ b/samples/drivers/counter/alarm/boards/s32k5xxcvb_s32k566_m7.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&stm0 {
+	prescaler = <1>;
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/s32k5xxcvb_s32k566_r52.overlay
+++ b/samples/drivers/counter/alarm/boards/s32k5xxcvb_s32k566_r52.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "s32k5xxcvb_s32k566_m7.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/s32k5xxcvb_s32k566_m7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32k5xxcvb_s32k566_m7.overlay
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&stm0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&stm1 {
+	prescaler = <8>;
+	status = "okay";
+};
+
+&stm2 {
+	prescaler = <32>;
+	status = "okay";
+};
+
+&stm3 {
+	prescaler = <64>;
+	status = "okay";
+};
+
+&pit0 {
+	status = "okay";
+};
+
+&pit0_channel0 {
+	status = "okay";
+};
+
+&pit0_channel1 {
+	status = "okay";
+};
+
+&pit0_channel2 {
+	status = "okay";
+};
+
+&pit0_channel3 {
+	status = "okay";
+};
+
+&pit1 {
+	status = "okay";
+};
+
+&pit1_channel0 {
+	status = "okay";
+};
+
+&pit1_channel1 {
+	status = "okay";
+};
+
+&pit1_channel2 {
+	status = "okay";
+};
+
+&pit1_channel3 {
+	status = "okay";
+};
+
+&pit2 {
+	status = "okay";
+};
+
+&pit2_channel0 {
+	status = "okay";
+};
+
+&pit2_channel1 {
+	status = "okay";
+};
+
+&pit2_channel2 {
+	status = "okay";
+};
+
+&pit2_channel3 {
+	status = "okay";
+};
+
+&pit3 {
+	status = "okay";
+};
+
+&pit3_channel0 {
+	status = "okay";
+};
+
+&pit3_channel1 {
+	status = "okay";
+};
+
+&pit3_channel2 {
+	status = "okay";
+};
+
+&pit3_channel3 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/s32k5xxcvb_s32k566_r52.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32k5xxcvb_s32k566_r52.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&stm0 {
+	prescaler = <1>;
+	status = "okay";
+};
+
+&stm1 {
+	prescaler = <8>;
+	status = "okay";
+};
+
+&pit0 {
+	status = "okay";
+};
+
+&pit0_channel0 {
+	status = "okay";
+};
+
+&pit0_channel1 {
+	status = "okay";
+};
+
+&pit0_channel2 {
+	status = "okay";
+};
+
+&pit0_channel3 {
+	status = "okay";
+};
+
+&pit1 {
+	status = "okay";
+};
+
+&pit1_channel0 {
+	status = "okay";
+};
+
+&pit1_channel1 {
+	status = "okay";
+};
+
+&pit1_channel2 {
+	status = "okay";
+};
+
+&pit1_channel3 {
+	status = "okay";
+};


### PR DESCRIPTION
Add support for Counter (PIT & STM)
Tested with `samples\drivers\counter\alarm` and `tests\drivers\counter\counter_basic_apis`
