### PR TITLE
Bluetooth: Classic: Fix net_buf leak

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -960,6 +960,7 @@ int bt_br_init(void)
 
 	rp = (void *)rsp->data;
 	default_link_policy_settings = rp->default_link_policy_settings;
+	net_buf_unref(rsp);
 
 	bool should_enable = IS_ENABLED(CONFIG_BT_DEFAULT_ROLE_SWITCH_ENABLE);
 	bool is_enabled = (default_link_policy_settings &


### PR DESCRIPTION
Release the buffer with net_buf_unref(rsp) once the reading default link policy settings response has
been parsed.