### PR TITLE
dts: nxp,sar-adc.yaml: remove 'type: array' from interrupts property

### DIFF
--- a/dts/bindings/adc/nxp,sar-adc.yaml
+++ b/dts/bindings/adc/nxp,sar-adc.yaml
@@ -13,7 +13,6 @@ properties:
     required: true
 
   interrupts:
-    type: array
     required: true
 
   has-external-channels:


### PR DESCRIPTION
`type: array` is unnecessary for the interrupts property in `nxp,sar-adc.yaml`.