### PR TITLE
Enabled async read function for NXP SAR ADC driver

### DIFF
--- a/drivers/adc/adc_nxp_sar_adc.c
+++ b/drivers/adc/adc_nxp_sar_adc.c
@@ -339,8 +339,8 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repe
 	}
 }
 
-/* Configure sequence resolution, buffer, oversampling. Then submit to context. */
-static int nxp_sar_adc_read(const struct device *dev, const struct adc_sequence *sequence)
+static int nxp_sar_adc_read_async(const struct device *dev, const struct adc_sequence *sequence,
+				  struct k_poll_signal *async)
 {
 	struct nxp_sar_adc_data *data = dev->data;
 
@@ -396,7 +396,7 @@ static int nxp_sar_adc_read(const struct device *dev, const struct adc_sequence 
 	}
 #endif
 
-	adc_context_lock(&data->ctx, false, NULL);
+	adc_context_lock(&data->ctx, async ? true : false, async);
 	data->buffer = sequence->buffer;
 	adc_context_start_read(&data->ctx, sequence);
 	int err = adc_context_wait_for_completion(&data->ctx);
@@ -404,6 +404,11 @@ static int nxp_sar_adc_read(const struct device *dev, const struct adc_sequence 
 	adc_context_release(&data->ctx, err);
 
 	return err;
+}
+
+static int nxp_sar_adc_read(const struct device *dev, const struct adc_sequence *sequence)
+{
+	return nxp_sar_adc_read_async(dev, sequence, NULL);
 }
 
 /* Configure an ADC channel from a struct 'adc_dt_spec'. Mapping from logical
@@ -514,6 +519,9 @@ static int nxp_sar_adc_init(const struct device *dev)
 static const struct adc_driver_api nxp_sar_adc_api = {
 	.channel_setup = nxp_sar_adc_channel_setup,
 	.read = nxp_sar_adc_read,
+#ifdef CONFIG_ADC_ASYNC
+	.read_async = nxp_sar_adc_read_async,
+#endif
 };
 
 #if IS_ENABLED(CONFIG_ADC_NXP_SAR_ADC_INTERRUPT)

--- a/tests/drivers/adc/adc_api/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc_0 0>, <&adc_0 1>;
+	};
+};
+
+&adc_0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* logic channel 0 => physical channel 48 (Internal 1.2v bandgap) */
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <15>;
+		zephyr,input-positive = <48>;
+	};
+
+	/* logic channel 1 => physical channel 55 (VREFH 3.3v) */
+	channel@1 {
+		reg = <0x1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <15>;
+		zephyr,input-positive = <55>;
+	};
+};


### PR DESCRIPTION
1. enabled async read function for NXP SAR ADC driver by implementing `nxp_sar_adc_read_async()` and modifying  `nxp_sar_adc_read()` to call it with a NULL signal for synchronous operation.
2. enable adc_api test for frdm_mcxe31b.
<details>
<summary>Logs</summary>

```
*** Booting Zephyr OS build v4.3.0-2928-g23354f3cad32 ***
Running TESTSUITE adc_basic
===================================================================
START - test_adc_asynchronous_call
Samples read: 0x2df2 0x2e6a 0x2e5a 0x2e72 0x2e3a 0x8000
 PASS - test_adc_asynchronous_call in 0.006 seconds
===================================================================
START - test_adc_invalid_request
Samples read: 0x2eea 0x8000 0x8000 0x8000 0x8000 0x8000
 PASS - test_adc_invalid_request in 0.006 seconds
===================================================================
START - test_adc_repeated_samplings
repeated_samplings_callback: done 1
Samples read: 0x2e5a 0x7de0 0x8000 0x8000 0x8000 0x8000
repeated_samplings_callback: done 2
Samples read: 0x2e5a 0x7de0 0x2eda 0x7de8 0x8000 0x8000
repeated_samplings_callback: done 3
Samples read: 0x2e5a 0x7de0 0x2eda 0x7df0 0x8000 0x8000
repeated_samplings_callback: done 4
Samples read: 0x2e5a 0x7de0 0x2efc 0x7de8 0x8000 0x8000
repeated_samplings_callback: done 5
Samples read: 0x2e5a 0x7de0 0x2eda 0x7df0 0x8000 0x8000
repeated_samplings_callback: done 6
Samples read: 0x2e5a 0x7de0 0x2eec 0x7df0 0x8000 0x8000
repeated_samplings_callback: done 7
Samples read: 0x2e5a 0x7de0 0x2ef4 0x7de0 0x8000 0x8000
repeated_samplings_callback: done 8
Samples read: 0x2e5a 0x7de0 0x2eda 0x7de0 0x8000 0x8000
repeated_samplings_callback: done 9
Samples read: 0x2e5a 0x7de0 0x2eda 0x7de8 0x8000 0x8000
repeated_samplings_callback: done 10
Samples read: 0x2e5a 0x7de0 0x2eda 0x7de8 0x8000 0x8000
 PASS - test_adc_repeated_samplings in 0.083 seconds
===================================================================
START - test_adc_sample_one_channel
Samples read: 0x2e8a 0x8000 0x8000 0x8000 0x8000 0x8000
 PASS - test_adc_sample_one_channel in 0.006 seconds
===================================================================
START - test_adc_sample_two_channels
Samples read: 0x2e7a 0x7de0 0x8000 0x8000 0x8000 0x8000
 PASS - test_adc_sample_two_channels in 0.006 seconds
===================================================================
START - test_adc_sample_with_interval
 SKIP - test_adc_sample_with_interval in 0.001 seconds
===================================================================
TESTSUITE adc_basic succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 5, fail = 0, skip = 1, total = 6 duration = 0.108 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.083 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.006 seconds
 - SKIP - [adc_basic.test_adc_sample_with_interval] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```

</details>