### PR TITLE
samples: drivers: crc: fix twister regex and run in CI

### DIFF
--- a/samples/drivers/crc/sample.yaml
+++ b/samples/drivers/crc/sample.yaml
@@ -6,8 +6,10 @@ tests:
     tags:
       - drivers
       - crc
+    integration_platforms:
+      - ek_ra8m1
     harness: console
     harness_config:
       type: one_line
       regex:
-        - "CRC verification succeeded"
+        - "verification succeeded"

--- a/samples/drivers/crc/src/main.c
+++ b/samples/drivers/crc/src/main.c
@@ -102,7 +102,6 @@ int main(void)
 
 	LOG_INF("%s result: 0x%08x", CRC_SAMPLE_NAME, (unsigned int)ctx.result);
 
-#if defined(CRC_SAMPLE_EXPECTED) && (CRC_SAMPLE_EXPECTED != 0)
 	ret = crc_verify(&ctx, CRC_SAMPLE_EXPECTED);
 	if (ret != 0) {
 		LOG_ERR("%s verification failed (expected 0x%08x): %d", CRC_SAMPLE_NAME,
@@ -111,7 +110,6 @@ int main(void)
 	}
 	LOG_INF("%s verification succeeded (expected 0x%08x)", CRC_SAMPLE_NAME,
 		CRC_SAMPLE_EXPECTED);
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
1. Update the CRC sample’s Twister console regex to match the current log output.
2. Add an integration_platforms entry (ek_ra8m1) so the sample runs in PR CI.
3. Make CRC verification unconditional so the expected “verification succeeded” log is always emitted and mismatches fail the test.