### PR TITLE
drivers: crc: add NXP LPC CRC driver support

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -33,6 +33,7 @@
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &iap;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -166,4 +167,8 @@ zephyr_uhc1: &usbhhs {
 		status = "okay";
 		disk-name = "SD";
 	};
+};
+
+&crc {
+	status = "okay";
 };

--- a/drivers/crc/CMakeLists.txt
+++ b/drivers/crc/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_library()
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_NXP crc_nxp.c)
+zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_NXP_LPC crc_nxp_lpc.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_RENESAS_RA crc_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_SF32LB crc_sf32lb.c)
 # zephyr-keep-sorted-stop

--- a/drivers/crc/Kconfig.nxp
+++ b/drivers/crc/Kconfig.nxp
@@ -14,3 +14,13 @@ config CRC_DRIVER_NXP
 	select CRC_DRIVER_HAS_CRC32_IEEE
 	help
 	  Enable the driver implementation for NXP microcontrollers
+
+config CRC_DRIVER_NXP_LPC
+	bool
+	depends on DT_HAS_NXP_LPC_CRC_ENABLED
+	default y
+	select CRC_DRIVER_HAS_CRC16
+	select CRC_DRIVER_HAS_CRC16_CCITT
+	select CRC_DRIVER_HAS_CRC32_IEEE
+	help
+	  Enable the LPC CRC driver implementation for NXP microcontrollers

--- a/drivers/crc/crc_nxp_lpc.c
+++ b/drivers/crc/crc_nxp_lpc.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_lpc_crc
+
+#include <zephyr/drivers/crc.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(nxp_lpc_crc, CONFIG_CRC_LOG_LEVEL);
+
+#include <fsl_crc.h>
+
+struct crc_nxp_lpc_config {
+	CRC_Type *base;
+};
+
+struct crc_nxp_lpc_data {
+	struct k_sem lock;
+};
+
+static inline void crc_nxp_lpc_lock(const struct device *dev)
+{
+	struct crc_nxp_lpc_data *data = dev->data;
+
+	k_sem_take(&data->lock, K_FOREVER);
+}
+
+static inline void crc_nxp_lpc_unlock(const struct device *dev)
+{
+	struct crc_nxp_lpc_data *data = dev->data;
+
+	k_sem_give(&data->lock);
+}
+
+static int crc_nxp_lpc_prepare_config(const struct crc_ctx *ctx, crc_config_t *cfg, bool *use32)
+{
+	if ((ctx == NULL) || (cfg == NULL) || (use32 == NULL)) {
+		return -EINVAL;
+	}
+
+	cfg->reverseIn = (ctx->reversed & CRC_FLAG_REVERSE_INPUT) != 0U;
+	cfg->reverseOut = (ctx->reversed & CRC_FLAG_REVERSE_OUTPUT) != 0U;
+	cfg->complementIn = false;
+	cfg->complementOut = false;
+	cfg->seed = ctx->seed;
+
+	switch (ctx->type) {
+	case CRC16:
+		if (ctx->polynomial != CRC16_POLY) {
+			return -EINVAL;
+		}
+		cfg->polynomial = kCRC_Polynomial_CRC_16;
+		cfg->seed &= 0xFFFFU;
+		*use32 = false;
+		break;
+	case CRC16_CCITT:
+		if (ctx->polynomial != CRC16_CCITT_POLY) {
+			return -EINVAL;
+		}
+		cfg->polynomial = kCRC_Polynomial_CRC_CCITT;
+		cfg->seed &= 0xFFFFU;
+		*use32 = false;
+		break;
+	case CRC32_IEEE:
+		if (ctx->polynomial != CRC32_IEEE_POLY) {
+			return -EINVAL;
+		}
+		cfg->polynomial = kCRC_Polynomial_CRC_32;
+		/* IEEE uses final XOR */
+		cfg->complementOut = true;
+		*use32 = true;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int crc_nxp_lpc_begin(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_nxp_lpc_config *config = dev->config;
+	crc_config_t cfg;
+	bool use32 = false;
+	int ret;
+
+	if ((ctx == NULL) || (ctx->state != CRC_STATE_IDLE)) {
+		return -EINVAL;
+	}
+
+	crc_nxp_lpc_lock(dev);
+
+	ret = crc_nxp_lpc_prepare_config(ctx, &cfg, &use32);
+	if (ret != 0) {
+		crc_nxp_lpc_unlock(dev);
+		return ret;
+	}
+
+	CRC_Init(config->base, &cfg);
+
+	ctx->state = CRC_STATE_IN_PROGRESS;
+	ctx->result = 0U;
+
+	return 0;
+}
+
+static int crc_nxp_lpc_update(const struct device *dev, struct crc_ctx *ctx, const void *buffer,
+			      size_t bufsize)
+{
+	const struct crc_nxp_lpc_config *config = dev->config;
+
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	if (ctx->state != CRC_STATE_IN_PROGRESS) {
+		return -EINVAL;
+	}
+
+	/* Allow zero-length updates */
+	if ((bufsize > 0U) && (buffer == NULL)) {
+		ctx->state = CRC_STATE_IDLE;
+		crc_nxp_lpc_unlock(dev);
+		return -EINVAL;
+	}
+
+	if (bufsize > 0U) {
+		/*
+		 * Hardware processes data in 8-bit chunks internally.
+		 * 32-bit writes take 4 cycles (8-bit x 4).
+		 */
+		CRC_WriteData(config->base, (const uint8_t *)buffer, bufsize);
+	}
+
+	/* Keep an updated result for streaming verification */
+	if (ctx->type == CRC32_IEEE) {
+		ctx->result = CRC_Get32bitResult(config->base);
+	} else {
+		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
+	}
+
+	return 0;
+}
+
+static int crc_nxp_lpc_finish(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_nxp_lpc_config *config = dev->config;
+
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	if (ctx->state != CRC_STATE_IN_PROGRESS) {
+		return -EINVAL;
+	}
+
+	if (ctx->type == CRC32_IEEE) {
+		ctx->result = CRC_Get32bitResult(config->base);
+	} else {
+		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
+	}
+
+	ctx->state = CRC_STATE_IDLE;
+	crc_nxp_lpc_unlock(dev);
+	return 0;
+}
+
+static DEVICE_API(crc, crc_nxp_lpc_driver_api) = {
+	.begin = crc_nxp_lpc_begin,
+	.update = crc_nxp_lpc_update,
+	.finish = crc_nxp_lpc_finish,
+};
+
+static int crc_nxp_lpc_init(const struct device *dev)
+{
+	struct crc_nxp_lpc_data *data = dev->data;
+
+	k_sem_init(&data->lock, 1, 1);
+	return 0;
+}
+
+#define CRC_NXP_LPC_INIT(inst)                                                           \
+	static struct crc_nxp_lpc_data crc_nxp_lpc_data_##inst;                          \
+	static const struct crc_nxp_lpc_config crc_nxp_lpc_config_##inst = {             \
+		.base = (CRC_Type *)DT_INST_REG_ADDR(inst),                              \
+	};                                                                               \
+	DEVICE_DT_INST_DEFINE(inst, crc_nxp_lpc_init, NULL, &crc_nxp_lpc_data_##inst,    \
+			      &crc_nxp_lpc_config_##inst, POST_KERNEL,                   \
+			      CONFIG_CRC_DRIVER_INIT_PRIORITY, &crc_nxp_lpc_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(CRC_NXP_LPC_INIT)

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -359,6 +359,12 @@
 		reg = <0x38000 0x1000>;
 		status = "disabled";
 	};
+
+	crc: crc@95000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x95000 0x1000>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/bindings/crc/nxp,lpc-crc.yaml
+++ b/dts/bindings/crc/nxp,lpc-crc.yaml
@@ -1,0 +1,14 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+title: NXP LPC CRC (Cyclic Redundancy Check) device
+
+description: NXP LPC CRC (Cyclic Redundancy Check) driver
+
+compatible: "nxp,lpc-crc"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -152,6 +152,7 @@ set_variable_ifdef(CONFIG_NXP_TMPSNS                CONFIG_MCUX_COMPONENT_driver
 set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP          CONFIG_MCUX_COMPONENT_driver.opamp)
 set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP_FAST     CONFIG_MCUX_COMPONENT_driver.opamp_fast)
 set_variable_ifdef(CONFIG_CRC_DRIVER_NXP        CONFIG_MCUX_COMPONENT_driver.crc)
+set_variable_ifdef(CONFIG_CRC_DRIVER_NXP_LPC    CONFIG_MCUX_COMPONENT_driver.lpc_crc)
 
 if(NOT CONFIG_SOC_MIMX9596)
   set_variable_ifdef(CONFIG_ETH_NXP_IMX_NETC          CONFIG_MCUX_COMPONENT_driver.netc_switch)

--- a/samples/drivers/crc/boards/lpcxpresso55s28.conf
+++ b/samples/drivers/crc/boards/lpcxpresso55s28.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SAMPLE_CRC_VARIANT_CRC16_CCITT=y


### PR DESCRIPTION
## Summary

Add hardware CRC driver for NXP LPC55S2x microcontrollers supporting CRC-CCITT, CRC-16, and CRC-32 IEEE polynomials.

## Changes

1. **HAL Integration**: Enable `driver.lpc_crc` component
2. **DTS Binding**: Add `nxp,lpc-crc` compatible string
3. **Driver**: Implement CRC driver with streaming API and thread-safety
4. **Board**: Enable CRC on lpcxpresso55s28

## Features

- Three polynomial modes: CRC-CCITT, CRC-16, CRC-32 IEEE
- Configurable bit reversal and seed values
- Thread-safe with semaphore locking
- Streaming calculation via begin/update/finish API

Depends on 
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/101523