### PR TITLE
doc: develop: add 'which' to Arch Linux dependencies

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -119,7 +119,7 @@ need one.
       .. code-block:: console
 
          sudo pacman -S git cmake ninja gperf ccache dfu-util dtc wget \
-             python-pip python-setuptools python-wheel tk xz file make
+             python-pip python-setuptools python-wheel tk xz file make which
 
 CMake
 =====


### PR DESCRIPTION
The setup.sh script of the Zephyr SDK runs `which cmake` to find out whether CMake and wget are installed:
https://github.com/zephyrproject-rtos/sdk-ng/blob/71df6c27da446e5b1da7bf3d0326afc3eb6bad8d/scripts/template_setup_posix#L43

`which` is not installed by default on Arch Linux, so the check will fail and the script will yield:
```
Zephyr SDK setup requires 'cmake' to be installed and available in the PATH. Please install 'cmake and run this script again.
```
Although CMake is already installed.
Fix this by adding `which` to the list of dependencies.