### PR TITLE
boards: st: added tsc peripheral to F0 series

### DIFF
--- a/boards/st/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.dts
@@ -8,6 +8,7 @@
 #include <st/f0/stm32f072Xb.dtsi>
 #include <st/f0/stm32f072r(8-b)tx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/stm32-tsc-defines.h>
 
 / {
 	model = "STMicroelectronics STM32F072B-DISCO board";
@@ -139,5 +140,65 @@
 		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pc6>;
 		pinctrl-names = "default";
+	};
+};
+
+&tsc {
+	status = "okay";
+	pinctrl-0 = <&tsc_g1_io3_pa2 &tsc_g1_io4_pa3 &tsc_g2_io3_pa6 &tsc_g2_io4_pa7 &tsc_g3_io2_pb0
+		     &tsc_g3_io3_pb1>;
+	pinctrl-names = "default";
+
+	st,pulse-generator-prescaler = <2>;
+	st,charge-transfer-pulse-high = <2>;
+	st,charge-transfer-pulse-low = <2>;
+	st,spread-spectrum;
+	st,spread-spectrum-prescaler = <2>;
+	st,spread-spectrum-deviation = <100>;
+	st,max-count-value = <8191>;
+
+	tsc_group1: g1 {
+		group = <1>;
+		channel-ios = <TSC_IO3>;
+		sampling-io = <TSC_IO4>;
+
+		ts2 {
+			compatible = "tsc-keys";
+			sampling-interval-ms = <10>;
+			oversampling = <10>;
+			noise-threshold = <50>;
+			sticky-key-timeout-ms = <10000>;
+			zephyr,code = <INPUT_KEY_2>;
+		};
+	};
+
+	tsc_group2: g2 {
+		group = <2>;
+		channel-ios = <TSC_IO3>;
+		sampling-io = <TSC_IO4>;
+
+		ts0 {
+			compatible = "tsc-keys";
+			sampling-interval-ms = <10>;
+			oversampling = <10>;
+			noise-threshold = <50>;
+			sticky-key-timeout-ms = <10000>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	tsc_group3: g3 {
+		group = <3>;
+		channel-ios = <TSC_IO2>;
+		sampling-io = <TSC_IO3>;
+
+		ts1 {
+			compatible = "tsc-keys";
+			sampling-interval-ms = <10>;
+			oversampling = <10>;
+			noise-threshold = <50>;
+			sticky-key-timeout-ms = <10000>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
 	};
 };

--- a/boards/st/stm32f072b_disco/stm32f072b_disco.yaml
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.yaml
@@ -13,6 +13,7 @@ supported:
   - spi
   - can
   - watchdog
+  - tsc
 testing:
   ignore_tags:
     - net

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -376,6 +376,16 @@
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
 			status = "disabled";
 		};
+
+		tsc: tsc@40024000 {
+			compatible = "st,stm32-tsc";
+			reg = <0x40024000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 24)>;
+			resets = <&rctl STM32_RESET(AHB1, 24)>;
+			interrupts = <8 0>;
+			interrupt-names = "global";
+			status = "disabled";
+		};
 	};
 
 	vref: vref {

--- a/tests/drivers/input/tsc_keys/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/input/tsc_keys/boards/stm32f072b_disco.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Arif Balik <arifbalik@outlook.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		/* This will be used to trigger the SYNC (PB8) pin high and low programmatically.
+		 * They have to be connected.
+		 */
+		signal-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tsc {
+	status = "okay";
+
+	pinctrl-0 = <&tsc_g1_io3_pa2 &tsc_g1_io4_pa3 &tsc_g2_io3_pa6 &tsc_g2_io4_pa7 &tsc_g3_io2_pb0
+		     &tsc_sync_pb8>;
+	pinctrl-names = "default";
+
+	st,pulse-generator-prescaler = <128>;
+
+	st,spread-spectrum;
+	st,spread-spectrum-prescaler = <2>;
+	st,spread-spectrum-deviation = <10>;
+
+	st,max-count-value = <16383>;
+
+	st,synced-acquisition;
+	st,syncpol-rising;
+};


### PR DESCRIPTION
This PR adds the TSC peripheral definition for the STM32F0 series.
Additionally, the peripheral is enabled for the STM32F072B-DISCO board.

FYI: The STM32F072B-DISCO board features three electrodes that are positioned close together. The board's designer intended for these electrodes to function as a single linear touch sensor. However, since Zephyr doesn't support this functionality yet, the electrodes are currently treated as three separate touch keys. As a result, depending on environmental conditions, a touch on a single electrode may trigger presses on two separate buttons or, in some cases, may not register a press at all.