### PR TITLE
driver: display: Add backlight supports for some screens

### DIFF
--- a/drivers/display/display_ili9806e_dsi.c
+++ b/drivers/display/display_ili9806e_dsi.c
@@ -370,6 +370,13 @@ static int ili9806e_init(const struct device *dev)
 	struct mipi_dsi_device mdev;
 	int ret;
 
+	if (cfg->backlight.port != NULL) {
+		if(!gpio_is_ready_dt(&cfg->backlight)){
+			LOG_ERR("Backlight GPIO device is not ready!");
+			return -ENODEV;
+		}
+	}
+
 	if (cfg->reset.port) {
 		if (!gpio_is_ready_dt(&cfg->reset)) {
 			LOG_ERR("Reset GPIO device is not ready!");

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -70,6 +70,7 @@ struct ili9xxx_config {
 	const struct ili9xxx_quirks *quirks;
 	const struct device *mipi_dev;
 	struct mipi_dbi_config dbi_config;
+	const struct gpio_dt_spec backlight;
 	uint8_t pixel_format;
 	uint16_t rotation;
 	uint16_t x_resolution;

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -42,3 +42,9 @@ properties:
     description:
       Display inversion mode. Every bit is inverted from the frame memory to
       the display.
+
+  bl-gpios:
+    type: phandle-array
+    description: |
+      The BLn pin is asserted to control the backlight of the panel.
+      The sensor receives this as an active-high signal.

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -108,5 +108,11 @@ properties:
       accepting commands. Defaults to 40ms (found by trial and error) if not
       provided.
 
+  bl-gpios:
+    type: phandle-array
+    description: |
+      The BLn pin is asserted to control the backlight of the panel.
+      The sensor receives this as an active-high signal.
+
   mipi-mode:
     required: true


### PR DESCRIPTION
Some boards have the backlight as part of the screen. If it is to be separated out, it would be very inconvenient. Therefore, support for the backlight of this part of the screen is added.