### PR TITLE
drivers: spi: spi_rpi_pico_pio: Fix pio_program variable constness

### DIFF
--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -68,8 +68,8 @@ struct spi_pico_pio_data {
 	uint32_t tx_count;
 	uint32_t rx_count;
 	size_t pio_sm;
-	pio_program_t *pio_tx_program;
-	pio_program_t *pio_rx_program;
+	const pio_program_t *pio_tx_program;
+	const pio_program_t *pio_rx_program;
 	uint32_t pio_tx_offset;
 	uint32_t pio_rx_offset;
 	uint32_t pio_rx_wrap_target;


### PR DESCRIPTION
Since RPI_PICO_PIO_GET_PROGRAM returns const variable, so changed `pio_program_t *` variables in data to `const pio_program_t *`.