### PR TITLE
serial: gd32: add UART runtime configure support

### DIFF
--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -114,3 +114,12 @@ tests:
     extra_configs:
       - CONFIG_NRF_SYS_EVENT=y
       - CONFIG_SOC_NRF_FORCE_CONSTLAT=y
+  drivers.uart.uart_elementary.build_gd32:
+    build_only: true
+    harness: ""
+    depends_on: []
+    platform_allow:
+      - gd32f470i_eval
+    extra_configs:
+      - CONFIG_SERIAL=y
+      - CONFIG_UART_USE_RUNTIME_CONFIGURE=y


### PR DESCRIPTION
This PR adds UART runtime configuration support to the GD32 USART driver when `CONFIG_UART_USE_RUNTIME_CONFIGURE` is enabled.

## Changes
- Add `uart_configure()` / `uart_config_get()` support to `drivers/serial/usart_gd32.c`.
- Add a **build-only** Twister scenario to ensure the GD32 USART driver builds with `CONFIG_UART_USE_RUNTIME_CONFIGURE=y` on selected GD32 boards.

## Testing
- `west twister -s drivers.uart.uart_elementary.build_gd32 -p gd32f470i_eval`
- Tested on custom GD32-based board (UART bring-up + `uart_configure()`/`uart_config_get()`).

## Notes
- Runtime configuration currently supports `UART_CFG_FLOW_CTRL_NONE` only.
- 7 data bits without parity is rejected (HW limitation).