### PR TITLE
Boards: Align memory nodes to comply with spec

### DIFF
--- a/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
@@ -14,7 +14,6 @@
 	compatible = "altr,socfpga-cyclonev-socdk", "altr,socfpga-cyclonev", "altr,socfpga";
 
 	ddr0: memory@0 {
-		name = "memory";
 		device_type = "memory";
 		reg = <0x0 0x40000000>; /* 1GB */
 	};

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
@@ -21,7 +21,7 @@
 	};
 
 	ram: memory@48000000 {
-		device_type = "mmio-sram";
+		device_type = "memory";
 		reg = <0x0 0x48000000 0x0 DT_SIZE_M(512)>;
 	};
 

--- a/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
+++ b/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
@@ -25,7 +25,7 @@
 	};
 
 	ram: memory@48000000 {
-		device_type = "mmio-sram";
+		device_type = "memory";
 		reg = <0x0 0x48000000 0x0 DT_SIZE_M(512)>;
 	};
 };

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
@@ -20,7 +20,7 @@
 	};
 
 	ram: memory@48000000 {
-		device_type = "mmio-sram";
+		device_type = "memory";
 		reg = <0x0 0x48000000 0x0 DT_SIZE_M(512)>;
 	};
 };

--- a/boards/xen/xenvm/xenvm.dts
+++ b/boards/xen/xenvm/xenvm.dts
@@ -47,7 +47,7 @@
 	};
 
 	ram: memory@40000000 {
-		device_type = "mmio-sram";
+		device_type = "memory";
 		reg = <0x00 0x40000000 0x00 DT_SIZE_M(16)>;
 	};
 


### PR DESCRIPTION
The DTS spec makes it clear that `device_type` can only be set to 'memory'. See Table 3.3

The DTS spec make it clear that property name is deprecated 2.3.12 and Given that the `name` property value matches the node name, this property can and should be removed.