### PR TITLE
samples: adc_dt: Fix adc_dt run issue on NXP MCXN boards

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/frdm_mcxn236.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_mcxn236.overlay
@@ -6,12 +6,18 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 	};
+};
+
+/* Vref output is the LPADC reference voltage. */
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {

--- a/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -6,12 +6,18 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 	};
+};
+
+/* Vref output is the LPADC reference voltage. */
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {

--- a/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -6,12 +6,18 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 	};
+};
+
+/* Vref output is the LPADC reference voltage. */
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {

--- a/samples/drivers/adc/adc_dt/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -6,12 +6,18 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 	};
+};
+
+/* Vref output is the LPADC reference voltage. */
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {

--- a/samples/drivers/adc/adc_dt/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
+++ b/samples/drivers/adc/adc_dt/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
@@ -6,12 +6,18 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 	};
+};
+
+/* Vref output is the LPADC reference voltage. */
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {


### PR DESCRIPTION
Fix adc_dt run issue on NXP MCXN boards, the default mode of vref is standby mode, the BUF21 is not enabled, so the LPADC can not work normally. Need to set the vref mode to 'NXP_VREF_MODE_LOW_POWER' or 'NXP_VREF_MODE_HIGH_POWER' to enable the BUF21.

apply 0.9v to channel 1:
- before this patch, we get the result: channel 1: 3584 = 1575 mV
- after this patch, we get the result: channel 1: 2035 = 894 mV
