### PR TITLE
Fix DMA buffer shifting on STM32F1

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1107,8 +1107,9 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	data->repeat_buffer = data->buffer;
 
 #ifdef CONFIG_ADC_STM32_DMA
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc) || DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc)
 	/* Make sure DMA bit of ADC register CR2 is set to 0 before starting a DMA transfer */
+	/*Reseting the dma buffer after every sequence just like for stm32f4 to avoid channel shifting*/
 	LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_NONE);
 #endif
 	adc_stm32_dma_start(dev, data->buffer, data->channel_count);


### PR DESCRIPTION
Added reset dma buffer condition to fix channel/buffer-shifting issue for smt32f1
Added a or condition for checking if board is stm32f on line 1110 , 

```
#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc) || DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc)
``` 
to perform dma buffer reset  before starting the dma for new sequence, avoiding continuation of buffer pointer from older sequence.

Tested on medium density stm32f103 board.


Hangs on a high density stm32f103 board i had . Not sure if its hardware issue. could not verify.
 
Fixes #101190