### PR TITLE
drivers: can: mcux_flexcan: split IRQ handling to avoid unused registers

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1112,9 +1112,6 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 	ARG_UNUSED(base);
 
 	switch (status) {
-	case kStatus_FLEXCAN_UnHandled:
-		/* Not all fault confinement state changes are handled by the HAL */
-		__fallthrough;
 	case kStatus_FLEXCAN_ErrorStatus:
 		mcux_flexcan_transfer_error_status(data->dev, status_flags);
 		break;
@@ -1141,6 +1138,12 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 	case kStatus_FLEXCAN_RxIdle:
 		mcux_flexcan_transfer_rx_idle(data->dev, mb);
 		break;
+	case kStatus_FLEXCAN_UnHandled:
+		/*
+		 * Unhandled status during Message Buffer processing.
+		 * If result field is 0xFF, it means no message buffer interrupt occurred.
+		 */
+		__fallthrough;
 	default:
 		LOG_WRN("Unhandled status 0x%08x (result = 0x%016llx)",
 			status, status_flags);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1149,10 +1149,12 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 
 static void mcux_flexcan_isr(const struct device *dev)
 {
+	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
 
-	FLEXCAN_TransferHandleIRQ(base, &data->handle);
+	FLEXCAN_BusoffErrorHandleIRQ(base, &data->handle);
+	FLEXCAN_MbHandleIRQ(base, &data->handle, 0U, config->number_of_mb);
 }
 
 static int mcux_flexcan_init(const struct device *dev)


### PR DESCRIPTION
Replace FLEXCAN_TransferHandleIRQ() with separate calls to FLEXCAN_BusoffErrorHandleIRQ() and FLEXCAN_MbHandleIRQ() to handle FlexCAN interrupts.
    
The original FLEXCAN_TransferHandleIRQ() API accesses registers for features that may not be used, including Enhanced RX FIFO. This can cause issues when different FlexCAN instances have different hardware features, as it may attempt to access non-existent registers.
    
By using the more targeted FLEXCAN_BusoffErrorHandleIRQ() and FLEXCAN_MbHandleIRQ() functions, we only access the registers that are actually needed for the enabled features. This approach:
 - Prevents accessing non-existent registers on instances lacking certain features
 - Provides a more lightweight interrupt handling path
 - Slightly improves code efficiency by avoiding unnecessary register operations
    
The config structure is now used in the ISR to pass the number of message buffers to FLEXCAN_MbHandleIRQ().