### PR TITLE
tests: drivers: flash: split mixed error conditions in negative tests

### DIFF
--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -96,8 +96,12 @@ ZTEST(flash_driver_negative, test_negative_flash_erase)
 	rc = flash_erase(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
 	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
 
-	/* Check error returned when erasing unaligned memory or too large chunk of memory */
-	rc = flash_erase(flash_dev, (TEST_AREA_OFFSET + 1), (TEST_FLASH_SIZE + 1));
+	/* Check error returned when erasing unaligned memory */
+	rc = flash_erase(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
+	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
+
+	/* Check error returned when erasing too large chunk of memory */
+	rc = flash_erase(flash_dev, TEST_AREA_OFFSET, (TEST_FLASH_SIZE + 1));
 	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
 
 	/* Erasing 0 bytes shall succeed */
@@ -230,8 +234,12 @@ ZTEST(flash_driver_negative, test_negative_flash_write)
 	rc = flash_write(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), expected, page_info.size);
 	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
 
-	/* Check error returned when writing at unaligned memory or too large chunk of memory */
-	rc = flash_write(flash_dev, (TEST_AREA_OFFSET + 1), expected, (TEST_FLASH_SIZE + 1));
+	/* Check error returned when writing at unaligned memory */
+	rc = flash_write(flash_dev, (TEST_AREA_OFFSET + 1), expected, page_info.size);
+	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
+
+	/* Check error returned when writing too large chunk of memory */
+	rc = flash_write(flash_dev, TEST_AREA_OFFSET, expected, (TEST_FLASH_SIZE + 1));
 	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
 
 	/* Writing 0 bytes shall succeed */


### PR DESCRIPTION
Some flash negative tests were validating multiple error conditions in a single API call, such as combining unaligned offsets with oversized operations.

This makes it unclear which condition is actually being tested and can lead to fragile tests if drivers change the order of validation.

Split these cases so that each call checks a single expected error condition, improving test clarity and robustness.

While working on these negative tests, I noticed a related point that I did
not address in this patch, but I’d like to confirm the intent.

Several tests expect operations with offset+1 or size+1 to fail due to
“unaligned” accesses (e.g. flash_fill / flash_write). However, according to
the flash API, alignment requirements are device-specific and defined by
flash_parameters::write_block_size:

https://docs.zephyrproject.org/latest/doxygen/html/structflash__parameters.html#a9795a3e4fae4d7b81745e876f62ab3a8

If a driver reports write_block_size == 1 (which is common for many NOR flash
drivers), these accesses are valid and the test would fail even though the
driver is behaving correctly.

This suggests that the tests currently assume write_block_size is aligned implicitly.
Is this assumption intentional for this test suite, or should alignment-related
negative tests be conditional on the device write_block_size ?

I kept this patch focused on splitting mixed error conditions, but I’m happy
to follow up with a separate change if alignment handling should be clarified
or made device-aware.
