### PR TITLE
doc: releases: migration-guide: 4.4: update FlexCAN migration guide entry

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -72,16 +72,15 @@ Controller Area Network (CAN)
 =============================
 
 * Removed ``CONFIG_CAN_MAX_FILTER``, ``CONFIG_CAN_MAX_STD_ID_FILTER``,
-  ``CONFIG_CAN_MAX_EXT_ID_FILTER``, and ``CONFIG_CAN_MAX_MB`` (:github:`100596`). These are replaced
-  by the following driver-specific Kconfig symbols, some of which have had their default value
-  increased to meet typical software needs:
+  ``CONFIG_CAN_MAX_EXT_ID_FILTER`` (:github:`100596`). These are replaced by the following
+  driver-specific Kconfig symbols, some of which have had their default value increased to meet
+  typical software needs:
 
   * :kconfig:option:`CONFIG_CAN_LOOPBACK_MAX_FILTERS` for :dtcompatible:`zephyr,can-loopback`
   * :kconfig:option:`CONFIG_CAN_MAX32_MAX_FILTERS` for :dtcompatible:`adi,max32-can`
   * :kconfig:option:`CONFIG_CAN_MCP2515_MAX_FILTERS` for :dtcompatible:`microchip,mcp2515`
   * :kconfig:option:`CONFIG_CAN_MCP251XFD_MAX_FILTERS` for :dtcompatible:`microchip,mcp251xfd`
   * :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS` for :dtcompatible:`nxp,flexcan`
-  * :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_MB` for :dtcompatible:`nxp,flexcan`
   * :kconfig:option:`CONFIG_CAN_NATIVE_LINUX_MAX_FILTERS` for
     :dtcompatible:`zephyr,native-linux-can`
   * :kconfig:option:`CONFIG_CAN_RCAR_MAX_FILTERS` for :dtcompatible:`renesas,rcar-can`
@@ -92,6 +91,10 @@ Controller Area Network (CAN)
   * :kconfig:option:`CONFIG_CAN_STM32_FDCAN_MAX_EXT_ID_FILTERS` for :dtcompatible:`st,stm32-fdcan`
   * :kconfig:option:`CONFIG_CAN_STM32_FDCAN_MAX_STD_ID_FILTERS` for :dtcompatible:`st,stm32-fdcan`
   * :kconfig:option:`CONFIG_CAN_XMC4XXX_MAX_FILTERS` for :dtcompatible:`infineon,xmc4xxx-can-node`
+
+* Replaced Kconfig option ``CONFIG_CAN_MAX_MB`` for :dtcompatible:`nxp,flexcan` and
+  :dtcompatible:`nxp,flexcan-fd` with per-instance ``number-of-mb`` and
+  ``number-of-mb-fd`` devicetree properties (:github:`99483`).
 
 Counter
 =======


### PR DESCRIPTION
Update the NXP FlexCAN migration guide entry to take the latest Kconfig to devicetree change (see https://github.com/zephyrproject-rtos/zephyr/pull/99483) into account.