### PR TITLE
input: allow batching events until sync

### DIFF
--- a/subsys/input/Kconfig
+++ b/subsys/input/Kconfig
@@ -65,6 +65,14 @@ config INPUT_THREAD_STACK_SIZE
 	  Stack size for the thread processing the input events, must have
 	  enough space for executing the registered callbacks.
 
+config INPUT_THREAD_SIGNAL_SYNC
+	bool "Signal input thread on sync event"
+	default n
+	help
+	  Waits for a sync event before waking the input thread to process
+	  the queue. This batches events (e.g. X, Y, Touch), reducing
+	  context switching overhead.
+
 endif # INPUT_MODE_THREAD
 
 config INPUT_EVENT_DUMP


### PR DESCRIPTION
Currently, the input thread wakes up and performs a context switch for every single event reported via input_report(). For devices that report multiple data points per frame (e.g., touchscreens reporting X, Y, Pressure, and Touch ID), this results in excessive scheduler overhead.

This commit introduces CONFIG_INPUT_THREAD_SIGNAL_SYNC. When enabled, the input thread waits on a semaphore instead of blocking directly on the message queue. The semaphore is signaled only when:
1. An event with sync=true is reported.
2. The message queue is full (to prevent producer-consumer deadlocks).

Once woken, the thread drains all available events from the queue in a single batch, significantly reducing context switches for multi-event devices.