### PR TITLE
posix: c_lib_ext: fnmatch: fix llvm warning

### DIFF
--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -230,7 +230,7 @@ static int rangematch(const char **pattern, char test, int flags)
 			}
 
 			if (flags & FNM_CASEFOLD) {
-				c2 = tolower(c2);
+				c2 = tolower((int)c2);
 			}
 
 			if (c <= test && test <= c2) {


### PR DESCRIPTION
The tolower() function takes an int parameter. LLVM compilers generate a warning if a char is passed instead.