### PR TITLE
drivers: serial: mcux_lpuart: make ISR support optional

### DIFF
--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -15,7 +15,7 @@ config UART_MCUX_LPUART
 if UART_MCUX_LPUART
 
 config UART_MCUX_LPUART_ISR_SUPPORT
-	bool
+	bool "MCUX LPUART interrupt support"
 	default y if UART_INTERRUPT_DRIVEN || PM || UART_ASYNC_API
 	help
 	  Enable UART interrupt service routine.


### PR DESCRIPTION
Some SoCs like KE17Z use LPUART interrupts as wake-up sources. When LPUART is only used as a debug console, always-enabled interrupts can cause unwanted CPU wake-ups from low power states.

Make UART_MCUX_LPUART_ISR_SUPPORT user-configurable (defaults to enabled). When disabled with PM enabled, poll_out busy-waits for transmission completion instead of using interrupts.