### PR TITLE
MAINTAINERS: rename the Aesc Silicon platform label

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -302,7 +302,7 @@ Aesc Platform:
   files-regex:
     - ^drivers/.*aesc(\.c)?$
   labels:
-    - "area: Aesc Silicon Platform"
+    - "platform: Aesc Silicon"
 
 Ambiq Platforms:
   status: maintained


### PR DESCRIPTION
Rename the Aesc Silicon platform label used on GitHub to match the rest of the platform labels.