### PR TITLE
drivers: counter: mcux_lptmr: enhance idle timer support for cortex_m_systick

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -20,6 +20,7 @@ struct mcux_lptmr_config {
 	lptmr_prescaler_clock_select_t clk_source;
 	lptmr_prescaler_glitch_value_t prescaler_glitch;
 	bool bypass_prescaler_glitch;
+	bool free_running;
 	lptmr_timer_mode_t mode;
 	lptmr_pin_select_t pin;
 	lptmr_pin_polarity_t polarity;
@@ -269,7 +270,7 @@ static int mcux_lptmr_init(const struct device *dev)
 
 	LPTMR_GetDefaultConfig(&lptmr_config);
 	lptmr_config.timerMode = config->mode;
-	lptmr_config.enableFreeRunning = false;
+	lptmr_config.enableFreeRunning = config->free_running;
 	lptmr_config.prescalerClockSource = config->clk_source;
 	lptmr_config.bypassPrescaler = config->bypass_prescaler_glitch;
 	lptmr_config.value = config->prescaler_glitch;
@@ -323,6 +324,9 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 			(DT_INST_PROP(n, clock_frequency) / MCUX_LPTMR_TIME_DIV(n)) : \
 			(DT_INST_PROP(n, clock_frequency) / MCUX_LPTMR_PULSE_DIV(n))))
 
+/* DT run-mode enum order: restart(0), free-run(1). Default: restart(0). */
+#define MCUX_LPTMR_IS_FREE_RUN(n) (DT_INST_ENUM_IDX_OR(n, run_mode, 0) == 1)
+
 #define COUNTER_MCUX_LPTMR_DEVICE_INIT(n)					\
 	static void mcux_lptmr_irq_config_##n(const struct device *dev)		\
 	{									\
@@ -358,6 +362,7 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		.base = (LPTMR_Type *)DT_INST_REG_ADDR(n),			\
 		.clk_source = DT_INST_PROP(n, clk_source),			\
 		.bypass_prescaler_glitch = MCUX_LPTMR_BYPASS(n),	\
+		.free_running = MCUX_LPTMR_IS_FREE_RUN(n),			\
 		.mode = DT_INST_PROP(n, timer_mode_sel),			\
 		.pin = DT_INST_PROP_OR(n, input_pin, 0),			\
 		.polarity = DT_INST_PROP(n, active_low),			\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -11,6 +11,9 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
+#if defined(CONFIG_GIC)
+#include <zephyr/drivers/interrupt_controller/gic.h>
+#endif /* CONFIG_GIC */
 #include <fsl_lptmr.h>
 #include <zephyr/spinlock.h>
 
@@ -24,8 +27,27 @@ struct mcux_lptmr_config {
 	lptmr_timer_mode_t mode;
 	lptmr_pin_select_t pin;
 	lptmr_pin_polarity_t polarity;
+	unsigned int irqn;
 	void (*irq_config_func)(const struct device *dev);
 };
+
+static ALWAYS_INLINE void irq_set_pending(unsigned int irq)
+{
+#if defined(CONFIG_GIC)
+	arm_gic_irq_set_pending(irq);
+#else
+	NVIC_SetPendingIRQ(irq);
+#endif /* CONFIG_GIC */
+}
+
+static ALWAYS_INLINE bool irq_is_pending(unsigned int irq)
+{
+#if defined(CONFIG_GIC)
+	return arm_gic_irq_is_pending(irq);
+#else
+	return NVIC_GetPendingIRQ((IRQn_Type)irq) != 0U;
+#endif /* CONFIG_GIC */
+}
 
 struct mcux_lptmr_data {
 #if defined(CONFIG_COUNTER_MCUX_LPTMR_ALARM)
@@ -80,7 +102,7 @@ static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 	struct mcux_lptmr_data *data = dev->data;
 
 	/* Counter API: Alarm callback cannot be NULL. */
-	if ((alarm_cfg == NULL) || (alarm_cfg->callback == NULL) || (alarm_cfg->ticks == 0U) ||
+	if ((alarm_cfg == NULL) || (alarm_cfg->callback == NULL) ||
 		(alarm_cfg->ticks > config->info.max_top_value)) {
 		return -EINVAL;
 	}
@@ -98,18 +120,29 @@ static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 
 	k_spin_unlock(&data->lock, key);
 
+	/* Handle timer state: stop if running, clear flags if stopped */
 	if (config->base->CSR & LPTMR_CSR_TEN_MASK) {
 		/* Already enabled, first stop then set period (HW constraint). */
 		LPTMR_StopTimer(config->base);
-		LPTMR_SetTimerPeriod(config->base, alarm_cfg->ticks);
-	} else {
-		LPTMR_SetTimerPeriod(config->base, alarm_cfg->ticks);
-		/* RM recommendation: clear status flag after setting period
-		 * when timer is disabled.
-		 */
-		LPTMR_ClearStatusFlags(config->base, kLPTMR_TimerCompareFlag);
 	}
 
+	if (alarm_cfg->ticks == 0U) {
+		/*
+		 * Trigger the alarm callback immediately by setting the IRQ pending.
+		 * The ISR checks alarm_active/callback and does not require HW flags.
+		 */
+		LPTMR_EnableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
+		LPTMR_StartTimer(config->base);
+		irq_set_pending(config->irqn);
+		return 0;
+	}
+
+	/* Normal case: set period and start timer */
+	LPTMR_SetTimerPeriod(config->base, alarm_cfg->ticks);
+	/* RM recommendation: clear status flag after setting period
+	 * when timer is disabled.
+	 */
+	LPTMR_ClearStatusFlags(config->base, kLPTMR_TimerCompareFlag);
 	LPTMR_EnableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
 	LPTMR_StartTimer(config->base);
 
@@ -204,7 +237,19 @@ static uint32_t mcux_lptmr_get_pending_int(const struct device *dev)
 	const struct mcux_lptmr_config *config = dev->config;
 	uint32_t mask = LPTMR_CSR_TCF_MASK | LPTMR_CSR_TIE_MASK;
 
-	return (uint32_t)!!((config->base->CSR & mask) == mask);
+	/* "Pending" if the peripheral has a real compare pending (TCF+TIE). */
+	if ((config->base->CSR & mask) == mask) {
+		return 1U;
+	}
+
+	/* Also report pending if the IRQ is pending in the interrupt controller.
+	 * This covers the ticks==0 path where we set NVIC pending without TCF.
+	 */
+	if ((config->base->CSR & LPTMR_CSR_TIE_MASK) && irq_is_pending(config->irqn)) {
+		return 1U;
+	}
+
+	return 0U;
 }
 
 static uint32_t mcux_lptmr_get_top_value(const struct device *dev)
@@ -368,6 +413,7 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		.polarity = DT_INST_PROP(n, active_low),			\
 		.prescaler_glitch = (lptmr_prescaler_glitch_value_t)		\
 			MCUX_LPTMR_PRESCALE_GLITCH_VAL(n),			\
+		.irqn = DT_INST_IRQN(n),					\
 		.irq_config_func = mcux_lptmr_irq_config_##n,			\
 	};									\
 										\

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -85,3 +85,14 @@ properties:
       for Time-Counter mode or for Pulse mode.
       0 <- LPTMR is configured for Time Counter Mode.
       1 <- LPTMR is configured for Pulse Mode.
+
+  run-mode:
+    type: string
+    description: |
+      Selects how the LPTMR counter behaves on compare events.
+      - restart(default): Counter resets after matching the compare value.
+      - free-run: Compare events do not reset the counter; it resets on overflow.
+    enum:
+      - restart
+      - free-run
+    default: restart


### PR DESCRIPTION
## Overview

This PR enhances the NXP MCUX LPTMR counter driver to better support its use as a companion idle timer for the Cortex-M SysTick driver during low-power mode operation.

## Motivation

When using `CONFIG_CORTEX_M_SYSTICK_LPM_TIMER_COUNTER`, an LPTMR instance serves as the timekeeping source while SysTick is not clocked during low-power states. The current driver has limitations that require workarounds in the idle timer integration code:

1. **No free-running mode control**: The driver hardcodes `enableFreeRunning = false`, requiring code modification to maintain continuous timekeeping across multiple wake events
2. **No support for immediate alarms**: Setting `ticks=0` returns `-EINVAL`, forcing special-case handling when calculated sleep duration is minimal
3. **Incomplete pending status**: `get_pending_int()` doesn't detect manually-triggered interrupts

## Changes

### Patch 1: Add device tree support for free-running mode

Adds `run-mode` property to configure LPTMR reset behavior per instance:
- `restart` (default): Counter resets after compare match (backward compatible)
- `free-run`: Counter continues after compare, resets only on overflow

**Benefits:**
- Devicetree-based configuration without code changes
- Supports different operational modes for different instances
- Essential for continuous timekeeping in idle timer scenarios

**Example:**
```dts
&lptmr0 {
    status = "okay";
    run-mode = "free-run";  /* Don't reset on compare */
};
```

### Patch 2: Fire alarm immediately when ticks=0

Allows `counter_set_alarm()` with `ticks=0` to trigger immediate callback via interrupt pending flag.

**Implementation:**
- Remove validation that rejects `ticks == 0`
- Add `irq_set_pending()` and `irq_is_pending()` helpers supporting both NVIC and GIC interrupt controllers
- Store IRQ number in device config structure
- When `ticks == 0`, set interrupt pending to trigger ISR immediately
- Refactor timer state handling to eliminate code duplication
- Enhance `mcux_lptmr_get_pending_int()` to check both hardware flags and interrupt controller pending state

**Benefits:**
- Eliminates special-case handling for zero/minimal sleep durations
- Provides consistent Counter API behavior for all tick values

## Backward Compatibility

Both patches maintain full backward compatibility:
- Default `run-mode` is `restart` (existing behavior)
- Normal alarm operations (ticks > 0) are unchanged
- Existing devicetree configurations work without modification
