### PR TITLE
Fix clang unaligned access warnings sensors

### DIFF
--- a/drivers/sensor/bosch/bmi08x/bmi08x.h
+++ b/drivers/sensor/bosch/bmi08x/bmi08x.h
@@ -605,7 +605,7 @@ struct bmi08x_accel_frame {
 	union {
 		struct {
 			uint16_t payload[3];
-		} accel;
+		} __packed accel;
 		struct {
 			uint8_t skipped_frames;
 		} skip;

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -49,12 +49,12 @@ struct icm45686_encoded_fifo_payload {
 				int16_t x;
 				int16_t y;
 				int16_t z;
-			} accel;
+			} __attribute__((__packed__)) accel;
 			struct {
 				int16_t x;
 				int16_t y;
 				int16_t z;
-			} gyro;
+			} __attribute__((__packed__)) gyro;
 			int16_t temp;
 			uint16_t timestamp;
 			struct {


### PR DESCRIPTION
fixed clang warnings reported with -Wunaligned-access flag.