### PR TITLE
drivers: can: mcan: fix race condition when adding CAN RX filters

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1130,12 +1130,12 @@ int can_mcan_add_rx_filter_std(const struct device *dev, can_rx_callback_t callb
 		return err;
 	}
 
-	k_mutex_unlock(&data->lock);
-
-	LOG_DBG("Attached std filter at %d", filter_id);
-
 	cbs->std[filter_id].function = callback;
 	cbs->std[filter_id].user_data = user_data;
+
+	k_mutex_unlock(&data->lock);
+
+	LOG_DBG("added std filter at index %d", filter_id);
 
 	return filter_id;
 }
@@ -1181,12 +1181,12 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev, can_rx_callback_
 		return err;
 	}
 
-	k_mutex_unlock(&data->lock);
-
-	LOG_DBG("Attached ext filter at %d", filter_id);
-
 	cbs->ext[filter_id].function = callback;
 	cbs->ext[filter_id].user_data = user_data;
+
+	k_mutex_unlock(&data->lock);
+
+	LOG_DBG("added ext filter at index %d", filter_id);
 
 	return filter_id;
 }

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1053,7 +1053,6 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 		}
 	}
 
-	__ASSERT_NO_MSG(put_idx < cbs->num_tx);
 	cbs->tx[put_idx].function = callback;
 	cbs->tx[put_idx].user_data = user_data;
 
@@ -1134,7 +1133,6 @@ int can_mcan_add_rx_filter_std(const struct device *dev, can_rx_callback_t callb
 
 	LOG_DBG("Attached std filter at %d", filter_id);
 
-	__ASSERT_NO_MSG(filter_id < cbs->num_std);
 	cbs->std[filter_id].function = callback;
 	cbs->std[filter_id].user_data = user_data;
 
@@ -1185,7 +1183,6 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev, can_rx_callback_
 
 	LOG_DBG("Attached ext filter at %d", filter_id);
 
-	__ASSERT_NO_MSG(filter_id < cbs->num_ext);
 	cbs->ext[filter_id].function = callback;
 	cbs->ext[filter_id].user_data = user_data;
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1126,6 +1126,7 @@ int can_mcan_add_rx_filter_std(const struct device *dev, can_rx_callback_t callb
 				  &filter_element, sizeof(filter_element));
 	if (err != 0) {
 		LOG_ERR("failed to write std filter element (err %d)", err);
+		k_mutex_unlock(&data->lock);
 		return err;
 	}
 
@@ -1176,6 +1177,7 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev, can_rx_callback_
 				  &filter_element, sizeof(filter_element));
 	if (err != 0) {
 		LOG_ERR("failed to write std filter element (err %d)", err);
+		k_mutex_unlock(&data->lock);
 		return err;
 	}
 


### PR DESCRIPTION
- Remove useless asserts. These indexes are determined via a for loop which already uses the asserted value as its maximum.
- Add missing calls to k_mutex_unlock() in error paths when failing to add CAN RX filters.
- Move the assignment of the callback function and user data within the mutex lock when adding CAN RX filters to prevent race conditions.
