### PR TITLE
drivers: bluetooth: hci: add host wakeup for IW612 BT controller

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,7 @@
 			fw-download-primary-speed = <115200>;
 			fw-download-secondary-speed = <3000000>;
 			fw-download-secondary-flowcontrol;
+			wakeup-bt-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2025 NXP
+# Copyright 2023-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -11,6 +11,19 @@ config HCI_NXP_ENABLE_AUTO_SLEEP
 	  Auto sleep mode means the Controller will handle its low power state automatically.
 	  Enabling this feature will allow to save power at the cost of some latency when sending a HCI
 	  message to the Controller as the Host will need to wake it up.
+
+config BT_NXP_CTRL_WAKE_ON_BT
+	bool "Config to enable/disable wake on BT/BLE for NXP controllers"
+	help
+	  Enable/Disable BT wakeup IO triggers for NXP BT IW416/NW612/IW610 SOC.
+
+config BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK
+	bool "Config LED0 to blink upon observing activity on BT wakeup IO"
+	depends on BT_NXP_CTRL_WAKE_ON_BT
+	depends on $(dt_alias_enabled,led0)
+	help
+	  Enable LED blinking to indicate Bluetooth activity when wake-on-BT
+	  is triggered. Requires led0 alias to be defined in device tree.
 
 config HCI_NXP_SET_CAL_DATA
 	bool "Bluetooth Controller calibration data"

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -71,6 +71,40 @@ static struct nxp_ctlr_dev_data uart_dev_data;
 
 static unsigned long crc_table[256U];
 static bool made_table;
+#if (defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT) && defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK))
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec led_gpio = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+#define BLINK_ONOFF K_MSEC(1000)
+static struct k_work_delayable led_blink_work;
+static void led_blink_cb(struct k_work *work)
+{
+	int current_state = gpio_pin_get_dt(&led_gpio);
+
+	if (current_state == 0) {
+		/* LED is OFF, turn it ON briefly */
+		gpio_pin_set_dt(&led_gpio, 1);
+		k_work_reschedule(&led_blink_work, BLINK_ONOFF);
+	} else {
+		/* LED is ON, turn it OFF and keep it OFF */
+		gpio_pin_set_dt(&led_gpio, 0);
+		/* Don't reschedule - wait for next interrupt */
+	}
+}
+
+#endif /* CONFIG_BT_NXP_CTRL_WAKE_ON_BT && CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK */
+
+#if defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT)
+static struct gpio_callback bt_wakeup_callback;
+static void gpio_wakeup_callback_bt(const struct device *port, struct gpio_callback *cb,
+				 gpio_port_pins_t pins)
+{
+#if (defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK))
+	/* Schedule LED blink when activity is detected on wake-up IO */
+	k_work_schedule(&led_blink_work, BLINK_ONOFF);
+#endif
+}
+#endif
 
 static void fw_upload_gen_crc32_table(void)
 {
@@ -1464,7 +1498,61 @@ int bt_h4_vnd_setup(const struct device *dev)
 			LOG_ERR("Fail to load annex-100 calibration data");
 			return err;
 		}
+#if defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT)
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), wakeup_bt_gpios)
+	struct gpio_dt_spec wakeup = GPIO_DT_SPEC_GET(DT_DRV_INST(0), wakeup_bt_gpios);
 
+	LOG_DBG("Configuring Wakeup IOs\n");
+	if (!gpio_is_ready_dt(&wakeup)) {
+		LOG_ERR("Error: failed to configure wakeup %s pin %d", wakeup.port->name,
+			wakeup.pin);
+		return -EIO;
+	}
+
+	/* Configure wakeup gpio as input  */
+	err = gpio_pin_configure_dt(&wakeup, GPIO_INPUT);
+	if (err) {
+		LOG_ERR("Error %d: failed to configure wakeup %s pin %d", err,
+			wakeup.port->name, wakeup.pin);
+		return err;
+	}
+
+	err = gpio_pin_set_dt(&wakeup, 0);
+	if (err) {
+		return err;
+	}
+
+	/* Configure wakeup gpio interrupt */
+	err = gpio_pin_interrupt_configure_dt(&wakeup, GPIO_INT_EDGE_FALLING);
+	if (err) {
+		return err;
+	}
+
+	/* Set wakeup gpio callback function */
+	gpio_init_callback(&bt_wakeup_callback, gpio_wakeup_callback_bt, BIT(wakeup.pin));
+	err = gpio_add_callback_dt(&wakeup, &bt_wakeup_callback);
+	if (err) {
+		return err;
+	}
+#endif
+
+#if (defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK))
+	LOG_DBG("Configuring LED0 for BT Activity\n");
+	if (!gpio_is_ready_dt(&led_gpio)) {
+		return 0;
+	}
+
+	err = gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT_ACTIVE);
+	if (err < 0) {
+		return 0;
+	}
+
+	/* Setting the default value for LED0 to off*/
+	gpio_pin_set_dt(&led_gpio, 0);
+
+	k_work_init_delayable(&led_blink_work, led_blink_cb);
+#endif /* CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK */
+#endif /* CONFIG_BT_NXP_CTRL_WAKE_ON_BT */
 		fw_upload.is_setup_done = true;
 	}
 

--- a/dts/bindings/bluetooth/nxp,bt-hci-uart.yaml
+++ b/dts/bindings/bluetooth/nxp,bt-hci-uart.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024,2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -48,3 +48,11 @@ properties:
     type: boolean
     description: |
       Flow control setting for secondary speed.
+
+  wakeup-bt-gpios:
+    type: phandle-array
+    description: |
+      BT wakeup host pin
+      This pin defaults to active low when consumed by the SDK card. The
+      property value should ensure the flags properly describe the signal
+      that is presented to the driver.


### PR DESCRIPTION
Add host wakeup functionality for NXP hosted SOC's:

- Add wakeup IO config for IW612 shield for wakeup functionality.
- Add kconfig to enable/disable BT host wakeup functionality 
- Add kconfig to enable/disable toggling of onboard LED upon detecting BT activity

The PR adds option to test wake on BT functionality using a kconfig option. Further if the user wants to monitor the BT activity it can be done by enabling onboard LED by enabling BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK kconfig option.