### PR TITLE
modules: nanopb: fix race condition in zephyr_nanopb_sources

### DIFF
--- a/modules/nanopb/nanopb.cmake
+++ b/modules/nanopb/nanopb.cmake
@@ -41,4 +41,5 @@ function(zephyr_nanopb_sources target)
 
   add_custom_target(${gen_target_name} DEPENDS ${proto_hdrs})
   add_dependencies(nanopb_generated_headers ${gen_target_name})
+  add_dependencies(${target} nanopb_generated_headers)
 endfunction()


### PR DESCRIPTION
When one generated .pb.h file includes another generated .pb.h file, the build can fail because compilation may start before all headers are generated.

The nanopb_generated_headers target collects all proto generation targets as dependencies, but the calling target was not depending on it. This can cause a race condition where the compiler fails with "No such file or directory" for included headers.

Make the calling target depend on nanopb_generated_headers to ensure all protobuf headers are generated before source compilation begins.