### PR TITLE
boards: arm: use zephyr:board-supported-hw

### DIFF
--- a/boards/arm/fvp_base_revc_2xaem/doc/index.rst
+++ b/boards/arm/fvp_base_revc_2xaem/doc/index.rst
@@ -22,21 +22,7 @@ Hardware
 Supported Features
 ==================
 
-The following hardware features are supported:
-
-+-----------------------+------------+----------------------+
-| Interface             | Controller | Driver/Component     |
-+=======================+============+======================+
-| GICv3                 | on-chip    | interrupt controller |
-+-----------------------+------------+----------------------+
-| PL011 UART            | on-chip    | serial port          |
-+-----------------------+------------+----------------------+
-| ARM GENERIC TIMER     | on-chip    | system clock         |
-+-----------------------+------------+----------------------+
-| SMSC_91C111           | on-chip    | ethernet device      |
-+-----------------------+------------+----------------------+
-
-The kernel currently does not support other hardware features on this platform.
+.. zephyr:board-supported-hw::
 
 Board Variants
 ==============

--- a/boards/arm/mps2/doc/index.rst
+++ b/boards/arm/mps2/doc/index.rst
@@ -7,4 +7,7 @@ the links below to get more information about each board target.
 * :ref:`mps2_armv6m_board`
 * :ref:`mps2_armv7m_board`
 
+Supported Features
+===================
+
 .. zephyr:board-supported-hw::

--- a/boards/arm/mps2/doc/mps2_an521.rst
+++ b/boards/arm/mps2/doc/mps2_an521.rst
@@ -150,33 +150,7 @@ The mps2/an521 board provides the following user push buttons:
 Supported Features
 ===================
 
-The mps2/an521 board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | timer                               |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `MPS2 FPGA Website`_ for a complete list of MPS2+ AN521 board hardware
-features.
-
-The default configuration can be found in
-:zephyr_file:`boards/arm/mps2/mps2_an521_cpu0_defconfig`.
+* Refer to :zephyr:board:`mps2` for details.
 
 Interrupt Controller
 ====================

--- a/boards/arm/mps2/doc/mps2_armv6m.rst
+++ b/boards/arm/mps2/doc/mps2_armv6m.rst
@@ -61,33 +61,7 @@ ARM V2M MPS2 AN383 provides the following hardware components:
 Supported Features
 ==================
 
-The ``mps2/an383`` board target supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | counter                             |
-+-----------+------------+-------------------------------------+
-| DUALTIMER | on-chip    | counter                             |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `V2M MPS2 Website`_ for a complete list of V2M MPS2 board hardware
-features.
-
-The default configuration can be found in
-:zephyr_file:`boards/arm/mps2/mps2_an383_defconfig`
+* Refer to :zephyr:board:`mps2` for details.
 
 Interrupt Controller
 ====================

--- a/boards/arm/mps2/doc/mps2_armv7m.rst
+++ b/boards/arm/mps2/doc/mps2_armv7m.rst
@@ -68,34 +68,7 @@ ARM V2M MPS2 provides the following hardware components:
 Supported Features
 ==================
 
-The ``mps2/an385``, ``mps2/an386``, and ``mps2/an500`` board targets support the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | counter                             |
-+-----------+------------+-------------------------------------+
-| DUALTIMER | on-chip    | counter                             |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `V2M MPS2 Website`_ for a complete list of V2M MPS2 board hardware
-features.
-
-The default configuration can be found in
-:zephyr_file:`boards/arm/mps2/mps2_an385_defconfig`
-or similarly in ``mps2_anxxx_defconfig`` for the other applicable boards.
+* Refer to :zephyr:board:`mps2` for details.
 
 Interrupt Controller
 ====================

--- a/boards/arm/mps3/doc/index.rst
+++ b/boards/arm/mps3/doc/index.rst
@@ -221,31 +221,7 @@ ARM MPS3 provides the following hardware components:
 Supported Features
 ===================
 
-The ``MPS3`` board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `MPS3 FPGA Website`_ for a complete list of MPS3 AN547 board hardware
-features.
-
-The default configuration can be found in
- - For AN547: :zephyr_file:`boards/arm/mps3/mps3_corstone300_an547_defconfig`.
- - For AN552: :zephyr_file:`boards/arm/mps3/mps3_corstone300_an552_defconfig`.
- - For FVP  : :zephyr_file:`boards/arm/mps3/mps3_corstone300_fvp_defconfig`.
- - For AN555: :zephyr_file:`boards/arm/mps3/mps3_corstone310_an555_defconfig`.
-
+.. zephyr:board-supported-hw::
 
 Serial Port
 ===========
@@ -351,9 +327,6 @@ For more details refer to:
 
 .. _Corstone-310 FVP:
    https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/arm-ecosystem-fvps
-
-.. _MPS3 FPGA Website:
-   https://developer.arm.com/tools-and-software/development-boards/fpga-prototyping-boards/mps3
 
 .. _MPS3 AN547 Technical Reference Manual (TRM):
    https://developer.arm.com/-/media/Arm%20Developer%20Community/PDF/DAI0547B_SSE300_PLUS_U55_FPGA_for_mps3.pdf

--- a/boards/arm/v2m_beetle/doc/index.rst
+++ b/boards/arm/v2m_beetle/doc/index.rst
@@ -1,4 +1,4 @@
-.. _v2m_beetle_board:
+.. zephyr:board:: v2m_beetle
 
 ARM V2M Beetle
 ##############
@@ -49,36 +49,7 @@ ARM V2M BEETLE provides the following hardware components:
 Supported Features
 ===================
 
-The v2m_beetle board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | timer                               |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `V2M Beetle Website`_ for a complete list of V2M Beetle board hardware
-features.
-
-The default configuration can be found in the defconfig file:
-
-.. code-block:: console
-
-   boards/arm/v2m_beetle/v2m_beetle_defconfig
+.. zephyr:board-supported-hw::
 
 Interrupt Controller
 ====================

--- a/boards/arm/v2m_musca_b1/doc/index.rst
+++ b/boards/arm/v2m_musca_b1/doc/index.rst
@@ -1,4 +1,4 @@
-.. _v2m_musca_b1_board:
+.. zephyr:board:: v2m_musca_b1
 
 ARM V2M Musca B1
 ################
@@ -72,33 +72,7 @@ The v2m_musca_b1 board provides the following user push buttons:
 Supported Features
 ===================
 
-The v2m_musca_b1 board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| WATCHDOG  | on-chip    | watchdog                            |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | timer                               |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `V2M Musca B1 Website`_ for a complete list of V2M Musca board hardware
-features.
-
-The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/arm/v2m_musca_b1/v2m_musca_b1_defconfig`.
+.. zephyr:board-supported-hw::
 
 Interrupt Controller
 ====================

--- a/boards/arm/v2m_musca_s1/doc/index.rst
+++ b/boards/arm/v2m_musca_s1/doc/index.rst
@@ -1,4 +1,4 @@
-.. _v2m_musca_s1_board:
+.. zephyr:board:: v2m_musca_s1
 
 ARM V2M Musca-S1
 ################
@@ -69,33 +69,7 @@ The v2m_musca_s1 board provides the following user push buttons:
 Supported Features
 ===================
 
-The v2m_musca_s1 board configuration supports the following hardware features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| TIMER     | on-chip    | timer                               |
-+-----------+------------+-------------------------------------+
-| TrustZone | on-chip    | Trusted Firmware-M                  |
-+-----------+------------+-------------------------------------+
-
-Other hardware features are not currently supported by the port.
-See the `V2M Musca-S1 Website`_ for a complete list of V2M Musca-S1 board
-hardware features.
-
-The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/arm/v2m_musca_s1/v2m_musca_s1_defconfig`.
+.. zephyr:board-supported-hw::
 
 Interrupt Controller
 ====================

--- a/doc/services/tfm/requirements.rst
+++ b/doc/services/tfm/requirements.rst
@@ -32,9 +32,9 @@ The following are some of the boards that can be used with TF-M:
      - ``nucleo_l552ze_q/stm32l552xx/ns``
    * - :zephyr:board:`stm32l562e_dk`
      - ``stm32l562e_dk/stm32l562xx/ns``
-   * - :ref:`v2m_musca_b1_board`
+   * - :zephyr:board:`v2m_musca_b1`
      - ``v2m_musca_b1/musca_b1/ns``
-   * - :ref:`v2m_musca_s1_board`
+   * - :zephyr:board:`v2m_musca_s1`
      - ``v2m_musca_s1/musca_s1/ns``
 
 To make sure TF-M is supported for a board


### PR DESCRIPTION
Replace legacy hand-mantained tables with the new directive that generates a table automatically based on platform device tree.