### PR TITLE
dts: bindings: add cpu bindings for cortex-a7 and cortex-a9

### DIFF
--- a/dts/bindings/cpu/arm,cortex-a7.yaml
+++ b/dts/bindings/cpu/arm,cortex-a7.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-A7 CPU
+
+compatible: "arm,cortex-a7"
+
+include: cpu.yaml

--- a/dts/bindings/cpu/arm,cortex-a9.yaml
+++ b/dts/bindings/cpu/arm,cortex-a9.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-A9 CPU
+
+compatible: "arm,cortex-a9"
+
+include: cpu.yaml


### PR DESCRIPTION
Add devicetree binding definitions for ARM Cortex-A7 and Cortex-A9 CPUs.