### PR TITLE
Bluetooth: CAP: Log ADV address when starting via handover

### DIFF
--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -27,6 +27,7 @@
 
 #include "bap_endpoint.h"
 #include "cap_internal.h"
+#include "common/bt_str.h"
 #include "csip_internal.h"
 
 LOG_MODULE_REGISTER(bt_cap_handover, CONFIG_BT_CAP_HANDOVER_LOG_LEVEL);
@@ -198,11 +199,13 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 	}
 
 	if (adv_info.ext_adv_state != BT_LE_EXT_ADV_STATE_ENABLED) {
+		struct bt_le_ext_adv_info info;
+
 		/* Start advertising to get the actual adv addr */
 		err = bt_le_ext_adv_start(proc_param->unicast_to_broadcast.ext_adv,
 					  BT_LE_EXT_ADV_START_DEFAULT);
 		if (err != 0) {
-			LOG_DBG("Failed to start advertising set (err %d)\n", err);
+			LOG_DBG("Failed to start advertising set (err %d)", err);
 
 			active_proc->err = err;
 			active_proc->failed_conn = NULL;
@@ -211,6 +214,11 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 
 			return;
 		}
+
+		err = bt_le_ext_adv_get_info(proc_param->unicast_to_broadcast.ext_adv, &info);
+		__ASSERT_NO_MSG(err == 0);
+
+		LOG_DBG("Started advertising with addr %s", bt_addr_le_str(info.addr));
 
 		/* Since bt_le_ext_adv_get_info returns the pointer to actual advertising address we
 		 * do not need to call it again to get the address


### PR DESCRIPTION
When starting adv via handover, we log the address used for the advertising set for debugging purposes.