### PR TITLE
Clarify revision naming

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -974,13 +974,14 @@ support files to make minor adjustments to a board configuration without
 duplicating all the files described in :ref:`create-your-board-directory` for
 each revision.
 
-To build for a particular revision, use ``<board>@<revision>`` instead of plain
-``<board>``. For example:
+To build for a particular revision, use ``<board>@<revision>`` or
+``<board>@<revision>/<qualifiers>`` instead of plain ``<board>`` or
+``<board>/<qualifiers>``. For example:
 
 .. zephyr-app-commands::
    :tool: all
    :cd-into:
-   :board: <board>@<revision>
+   :board: nrf9160dk@0.14.0/nrf9160/ns
    :goals: build
    :compact:
 

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -799,9 +799,9 @@ The build system will print this at CMake configuration time:
 This allows you to only create revision configuration files for board revision
 numbers that introduce incompatible changes.
 
-Similar for ``letter`` where revision ``A``, ``D``, and ``F`` could be defined
-and the user builds for ``plank@E``, the build system will target revision ``D``
-.
+Similarly for ``letter`` revision format, if revisions ``A``, ``D``, and ``F``
+are defined and the user builds for ``plank@E``, the build system will target
+revision ``D``.
 
 Exact revision matching
 =======================


### PR DESCRIPTION
The existing documentation was not explicit on how qualifiers should be
combined with board revisions. This PR makes it explicit and adds a
concrete example. It also makes a minor correction to grammar.