### PR TITLE
doc: develop: getting_started: fedora dnf5 group installation

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -85,7 +85,7 @@ need one.
 
       .. code-block:: console
 
-         sudo dnf group install "Development Tools" "C Development Tools and Libraries"
+         sudo dnf group install development-tools c-development
          sudo dnf install cmake ninja-build gperf dfu-util dtc wget which \
            python3-pip python3-tkinter xz file python3-devel SDL2-devel
 


### PR DESCRIPTION
The group display names don't work with dnf5.
As display names can depend on the locale and are not unique, dnf5 only supports the group identifiers.

Distributions with dnf4 like RHEL<=10, Fedora<41, and CentOS stream shouldn't have any issues with the group id, but have not been tested.

Alternatives considered: use the @-sytax for groups introduced in dnf5, but using the group command makes it more clear that package groups are installed and is backwards compatible.