### PR TITLE
drivers: sensor: qdec_ra: Add QDEC support for Renesas RA GPT

### DIFF
--- a/drivers/sensor/renesas/CMakeLists.txt
+++ b/drivers/sensor/renesas/CMakeLists.txt
@@ -5,4 +5,5 @@
 add_subdirectory_ifdef(CONFIG_HS300X hs300x)
 add_subdirectory_ifdef(CONFIG_HS400X hs400x)
 add_subdirectory_ifdef(CONFIG_ISL29035 isl29035)
+add_subdirectory_ifdef(CONFIG_QDEC_RENESAS_RA qdec_ra)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/renesas/Kconfig
+++ b/drivers/sensor/renesas/Kconfig
@@ -5,4 +5,5 @@
 source "drivers/sensor/renesas/hs300x/Kconfig"
 source "drivers/sensor/renesas/hs400x/Kconfig"
 source "drivers/sensor/renesas/isl29035/Kconfig"
+source "drivers/sensor/renesas/qdec_ra/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/renesas/qdec_ra/CMakeLists.txt
+++ b/drivers/sensor/renesas/qdec_ra/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2025, Pivot International Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(qdec_renesas_ra.c)

--- a/drivers/sensor/renesas/qdec_ra/Kconfig
+++ b/drivers/sensor/renesas/qdec_ra/Kconfig
@@ -1,0 +1,14 @@
+# Renesas RA family Quadrature Decoder driver configuration options
+#
+# Copyright (c) 2025, Pivot International Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config QDEC_RENESAS_RA
+	bool "Renesas RA family QDEC driver"
+	default y
+	depends on DT_HAS_RENESAS_RA_QDEC_ENABLED
+	select USE_RA_FSP_GPT
+	select PINCTRL
+	help
+	  Enable Renesas RA family Quadrature Decoder driver.

--- a/drivers/sensor/renesas/qdec_ra/qdec_renesas_ra.c
+++ b/drivers/sensor/renesas/qdec_ra/qdec_renesas_ra.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2025 Pivot International Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/qdec_renesas_ra.h>
+#include <zephyr/drivers/pinctrl.h>
+#include "r_gpt.h"
+#include "r_gpt_cfg.h"
+#include <zephyr/logging/log.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+LOG_MODULE_REGISTER(qdec_renesas_ra, CONFIG_SENSOR_LOG_LEVEL);
+
+#define DT_DRV_COMPAT renesas_ra_qdec
+
+struct qdec_renesas_ra_data {
+	gpt_instance_ctrl_t fsp_ctrl;
+	timer_cfg_t fsp_cfg;
+	gpt_extended_cfg_t extend_cfg;
+	double micro_ticks_per_rev;
+
+	int32_t counts;
+};
+
+struct qdec_renesas_ra_config {
+	const struct device *clock_dev;
+	struct clock_control_ra_subsys_cfg clock_subsys;
+	const struct pinctrl_dev_config *pincfg;
+};
+
+static int qdec_renesas_ra_attr_set(const struct device *dev, enum sensor_channel chan,
+				     enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct qdec_renesas_ra_data *data = dev->data;
+
+	if ((chan != SENSOR_CHAN_ALL) &&
+	    (chan != SENSOR_CHAN_ROTATION) && (chan != SENSOR_CHAN_ENCODER_COUNT)) {
+		return -ENOTSUP;
+	}
+
+	switch ((enum sensor_attribute_qdec_renesas_ra)attr) {
+	case SENSOR_ATTR_QDEC_MOD_VAL:
+		data->micro_ticks_per_rev = val->val1 / 1000000.0f;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int qdec_renesas_ra_attr_get(const struct device *dev, enum sensor_channel chan,
+				     enum sensor_attribute attr, struct sensor_value *val)
+{
+	struct qdec_renesas_ra_data *data = dev->data;
+
+	if ((chan != SENSOR_CHAN_ALL) &&
+	    (chan != SENSOR_CHAN_ROTATION) && (chan != SENSOR_CHAN_ENCODER_COUNT)) {
+		return -ENOTSUP;
+	}
+
+	switch ((enum sensor_attribute_qdec_renesas_ra)attr) {
+	case SENSOR_ATTR_QDEC_MOD_VAL:
+		val->val1 = data->micro_ticks_per_rev * 1000000;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int qdec_renesas_ra_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct qdec_renesas_ra_data *const data = dev->data;
+	timer_status_t stat;
+
+	if ((chan != SENSOR_CHAN_ALL) &&
+	    (chan != SENSOR_CHAN_ROTATION) && (chan != SENSOR_CHAN_ENCODER_COUNT)) {
+		return -ENOTSUP;
+	}
+
+	/* Read position register content */
+	R_GPT_StatusGet(&data->fsp_ctrl, &stat);
+	data->counts = (int32_t)stat.counter;
+
+	return 0;
+}
+
+static int qdec_renesas_ra_get(const struct device *dev, enum sensor_channel chan,
+			struct sensor_value *val)
+{
+	struct qdec_renesas_ra_data *const data = dev->data;
+	double rotation = (data->counts * 2.0 * M_PI) / (data->micro_ticks_per_rev);
+
+	switch (chan) {
+	case SENSOR_CHAN_ROTATION:
+		sensor_value_from_double(val, rotation);
+		break;
+	case SENSOR_CHAN_ENCODER_COUNT:
+		val->val1 = data->counts;
+		val->val2 = 0;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int qdec_renesas_ra_init(const struct device *dev)
+{
+	struct qdec_renesas_ra_data *data = dev->data;
+	const struct qdec_renesas_ra_config *cfg = dev->config;
+	int err;
+
+	if (!device_is_ready(cfg->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	err = clock_control_on(cfg->clock_dev, (clock_control_subsys_t)&cfg->clock_subsys);
+	if (err < 0) {
+		LOG_ERR("Could not initialize clock (%d)", err);
+		return err;
+	}
+
+	err = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err) {
+		LOG_ERR("Failed to configure pins for PWM (%d)", err);
+		return err;
+	}
+
+	data->fsp_cfg.p_context = (void *)dev;
+	data->fsp_cfg.p_extend = &data->extend_cfg;
+
+	err = R_GPT_Open(&data->fsp_ctrl, &data->fsp_cfg);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	/* Enable capture source */
+	err = R_GPT_Enable(&data->fsp_ctrl);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	/* Start timer */
+	err = R_GPT_Start(&data->fsp_ctrl);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, qdec_renesas_ra_driver_api) = {
+	.attr_set = &qdec_renesas_ra_attr_set,
+	.attr_get = &qdec_renesas_ra_attr_get,
+	.sample_fetch = qdec_renesas_ra_fetch,
+	.channel_get = qdec_renesas_ra_get,
+};
+
+#define QDEC_RENESAS_RA_INIT(index)                                                               \
+	PINCTRL_DT_DEFINE(DT_INST_PARENT(index));                                                  \
+	static const gpt_extended_cfg_t g_timer1_extend_##index = {                                \
+		.gtioca =                                                                          \
+			{                                                                          \
+				.output_enabled = false,                                           \
+				.stop_level = GPT_PIN_LEVEL_LOW,                                   \
+			},                                                                         \
+		.gtiocb =                                                                          \
+			{                                                                          \
+				.output_enabled = false,                                           \
+				.stop_level = GPT_PIN_LEVEL_LOW,                                   \
+			},                                                                         \
+		.start_source = (gpt_source_t)(GPT_SOURCE_NONE),                                   \
+		.stop_source = (gpt_source_t)(GPT_SOURCE_NONE),                                    \
+		.clear_source = (gpt_source_t)(GPT_SOURCE_NONE),                                   \
+		.count_up_source = (gpt_source_t)                                                  \
+		(                                                                                  \
+			GPT_SOURCE_GTIOCA_RISING_WHILE_GTIOCB_LOW |                                \
+			GPT_SOURCE_GTIOCA_FALLING_WHILE_GTIOCB_HIGH |                              \
+			GPT_SOURCE_GTIOCB_RISING_WHILE_GTIOCA_HIGH |                               \
+			GPT_SOURCE_GTIOCB_FALLING_WHILE_GTIOCA_LOW                                 \
+		),                                                                                 \
+		.count_down_source = (gpt_source_t)                                                \
+		(                                                                                  \
+			GPT_SOURCE_GTIOCB_RISING_WHILE_GTIOCA_LOW |                                \
+			GPT_SOURCE_GTIOCB_FALLING_WHILE_GTIOCA_HIGH |                              \
+			GPT_SOURCE_GTIOCA_RISING_WHILE_GTIOCB_HIGH |                               \
+			GPT_SOURCE_GTIOCA_FALLING_WHILE_GTIOCB_LOW                                 \
+		),                                                                                 \
+		.capture_a_source = (gpt_source_t)(GPT_SOURCE_NONE),                               \
+		.capture_b_source = (gpt_source_t)(GPT_SOURCE_NONE),                               \
+		.capture_a_ipl = BSP_IRQ_DISABLED,                                                 \
+		.capture_b_ipl = BSP_IRQ_DISABLED,                                                 \
+		.capture_a_irq = FSP_INVALID_VECTOR,                                               \
+		.capture_b_irq = FSP_INVALID_VECTOR,                                               \
+		.capture_filter_gtioca = GPT_CAPTURE_FILTER_NONE,                                  \
+		.capture_filter_gtiocb = GPT_CAPTURE_FILTER_NONE,                                  \
+		.p_pwm_cfg = NULL,                                                                 \
+		.gtior_setting.gtior = (0x0U),                                                     \
+		.gtioca_polarity = GPT_GTIOC_POLARITY_NORMAL,                                      \
+		.gtiocb_polarity = GPT_GTIOC_POLARITY_NORMAL,                                      \
+	};                                                                                         \
+	static struct qdec_renesas_ra_data qdec_renesas_ra_data_##index = {                        \
+		.fsp_cfg =                                                                         \
+			{                                                                          \
+				.mode = TIMER_MODE_PERIODIC,                                       \
+				.source_div = DT_PROP(DT_INST_PARENT(index), divider),             \
+				.channel = DT_PROP(DT_INST_PARENT(index), channel),                \
+				.cycle_end_ipl = BSP_IRQ_DISABLED,                                 \
+				.cycle_end_irq = FSP_INVALID_VECTOR,                               \
+			},                                                                         \
+		.extend_cfg = g_timer1_extend_##index,                                             \
+		.micro_ticks_per_rev =                                                             \
+			(double)(DT_INST_PROP(index, micro_ticks_per_rev) / 1000000.0f)            \
+	};                                                                                         \
+	static const struct qdec_renesas_ra_config qdec_renesas_ra_config_##index = {              \
+		.pincfg = PINCTRL_DT_DEV_CONFIG_GET(DT_INST_PARENT(index)),                        \
+		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_INST_PARENT(index))),                 \
+		.clock_subsys = {                                                                  \
+			.mstp = (uint32_t)DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(index), 0, mstp),   \
+			.stop_bit = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(index), 0, stop_bit),     \
+		},                                                                                 \
+	};                                                                                         \
+	static int qdec_renesas_ra_init_##index(const struct device *dev)                          \
+	{                                                                                          \
+		int err = qdec_renesas_ra_init(dev);                                               \
+		if (err != 0) {                                                                    \
+			return err;                                                                \
+		}                                                                                  \
+		return 0;                                                                          \
+	}                                                                                          \
+	DEVICE_DT_INST_DEFINE(index, qdec_renesas_ra_init_##index, NULL,                           \
+			      &qdec_renesas_ra_data_##index, &qdec_renesas_ra_config_##index,      \
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,                            \
+			      &qdec_renesas_ra_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(QDEC_RENESAS_RA_INIT);

--- a/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
+++ b/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
@@ -37,6 +37,11 @@
 			reg = <0x40078100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40078200 {
@@ -47,6 +52,11 @@
 			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40078300 {
@@ -57,6 +67,11 @@
 			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40078400 {
@@ -67,6 +82,11 @@
 			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40078500 {
@@ -77,6 +97,11 @@
 			reg = <0x40078500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40078600 {
@@ -87,6 +112,11 @@
 			reg = <0x40078600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -315,6 +315,11 @@
 			reg = <0x40078000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40078100 {
@@ -325,6 +330,11 @@
 			reg = <0x40078100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40078200 {
@@ -335,6 +345,11 @@
 			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40078300 {
@@ -345,6 +360,11 @@
 			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40078400 {
@@ -355,6 +375,11 @@
 			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40078500 {
@@ -365,6 +390,11 @@
 			reg = <0x40078500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40078600 {
@@ -375,6 +405,11 @@
 			reg = <0x40078600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40078700 {
@@ -385,6 +420,11 @@
 			reg = <0x40078700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm7@40078800 {
@@ -395,6 +435,11 @@
 			reg = <0x40078800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm7@40078900 {
@@ -405,6 +450,11 @@
 			reg = <0x40078900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		agt0: agt@40084000 {

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -432,6 +432,11 @@
 			reg = <0x40078000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		dac_global: dac_global@4005e000 {

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -334,6 +334,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40169100 {
@@ -344,6 +349,11 @@
 			reg = <0x40169100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40169200 {
@@ -354,6 +364,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -364,6 +379,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40169400 {
@@ -374,6 +394,11 @@
 			reg = <0x40169400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40169500 {
@@ -384,6 +409,11 @@
 			reg = <0x40169500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		canfd_global: canfd_global@400b0000 {

--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -78,6 +78,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -360,6 +360,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40169100 {
@@ -370,6 +375,11 @@
 			reg = <0x40169100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40169200 {
@@ -380,6 +390,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -390,6 +405,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40169400 {
@@ -400,6 +420,11 @@
 			reg = <0x40169400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40169500 {
@@ -410,6 +435,11 @@
 			reg = <0x40169500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		canfd_global: canfd_global@400b0000 {

--- a/dts/arm/renesas/ra/ra4/r7fa4m1ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m1ax.dtsi
@@ -122,6 +122,11 @@
 			reg = <0x40078600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40078700 {
@@ -132,6 +137,11 @@
 			reg = <0x40078700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -144,6 +144,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -154,6 +159,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40169600 {
@@ -164,6 +174,11 @@
 			reg = <0x40169600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40169700 {
@@ -174,6 +189,11 @@
 			reg = <0x40169700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -157,6 +157,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -167,6 +172,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40169600 {
@@ -177,6 +187,11 @@
 			reg = <0x40169600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40169700 {
@@ -187,6 +202,11 @@
 			reg = <0x40169700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra4/r7fa4t1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4t1bx.dtsi
@@ -42,6 +42,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -52,6 +57,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		canfd_global: canfd_global@400b0000 {

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -79,6 +79,11 @@
 			reg = <0x40078800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -532,6 +532,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40169100 {
@@ -542,6 +547,11 @@
 			reg = <0x40169100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40169400 {
@@ -552,6 +562,11 @@
 			reg = <0x40169400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40169500 {
@@ -562,6 +577,11 @@
 			reg = <0x40169500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		wdt: wdt@40083400 {

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -426,6 +426,11 @@
 			reg = <0x40078000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40078100 {
@@ -436,6 +441,11 @@
 			reg = <0x40078100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40078200 {
@@ -445,6 +455,11 @@
 			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40078300 {
@@ -454,6 +469,11 @@
 			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40078400 {
@@ -464,6 +484,11 @@
 			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40078500 {
@@ -474,6 +499,11 @@
 			reg = <0x40078500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		wdt: wdt@40044200 {

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -143,6 +143,11 @@
 			reg = <0x40169600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40169700 {
@@ -153,6 +158,11 @@
 			reg = <0x40169700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -71,6 +71,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -81,6 +86,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -108,6 +108,11 @@
 			reg = <0x40078d00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec13: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		option_setting_ofs0: option-setting-ofs0@400 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -164,6 +164,11 @@
 			reg = <0x40078d00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec13: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		option_setting_ofs0: option-setting-ofs0@400 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -246,6 +246,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -256,6 +261,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40169600 {
@@ -266,6 +276,11 @@
 			reg = <0x40169600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40169700 {
@@ -276,6 +291,11 @@
 			reg = <0x40169700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm8@40169800 {
@@ -286,6 +306,11 @@
 			reg = <0x40169800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm9@40169900 {
@@ -296,6 +321,11 @@
 			reg = <0x40169900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -299,6 +299,11 @@
 			reg = <0x40169000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40169300 {
@@ -309,6 +314,11 @@
 			reg = <0x40169300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40169600 {
@@ -319,6 +329,11 @@
 			reg = <0x40169600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40169700 {
@@ -329,6 +344,11 @@
 			reg = <0x40169700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm8@40169800 {
@@ -339,6 +359,11 @@
 			reg = <0x40169800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm9@40169900 {
@@ -349,6 +374,11 @@
 			reg = <0x40169900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: trng {

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -523,6 +523,11 @@
 			reg = <0x40169100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40169200 {
@@ -533,6 +538,11 @@
 			reg = <0x40169200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40169400 {
@@ -543,6 +553,11 @@
 			reg = <0x40169400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40169500 {
@@ -553,6 +568,11 @@
 			reg = <0x40169500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		wdt: wdt@40083400 {

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -577,6 +577,11 @@
 			reg = <0x40078000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40078100 {
@@ -587,6 +592,11 @@
 			reg = <0x40078100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40078200 {
@@ -597,6 +607,11 @@
 			reg = <0x40078200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40078300 {
@@ -607,6 +622,11 @@
 			reg = <0x40078300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40078400 {
@@ -617,6 +637,11 @@
 			reg = <0x40078400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40078500 {
@@ -627,6 +652,11 @@
 			reg = <0x40078500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40078600 {
@@ -637,6 +667,11 @@
 			reg = <0x40078600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40078700 {
@@ -647,6 +682,11 @@
 			reg = <0x40078700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm8@40078800 {
@@ -657,6 +697,11 @@
 			reg = <0x40078800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm9@40078900 {
@@ -667,6 +712,11 @@
 			reg = <0x40078900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm10: pwm10@40078a00 {
@@ -677,6 +727,11 @@
 			reg = <0x40078a00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec10: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm11: pwm11@40078b00 {
@@ -687,6 +742,11 @@
 			reg = <0x40078b00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec11: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm12: pwm12@40078c00 {
@@ -697,6 +757,11 @@
 			reg = <0x40078c00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec12: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		eth: ethernet@40064100 {

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -538,6 +538,11 @@
 			reg = <0x40322000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40322100 {
@@ -548,6 +553,11 @@
 			reg = <0x40322100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40322200 {
@@ -558,6 +568,11 @@
 			reg = <0x40322200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40322300 {
@@ -568,6 +583,11 @@
 			reg = <0x40322300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40322400 {
@@ -578,6 +598,11 @@
 			reg = <0x40322400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40322500 {
@@ -588,6 +613,11 @@
 			reg = <0x40322500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40322600 {
@@ -598,6 +628,11 @@
 			reg = <0x40322600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40322700 {
@@ -608,6 +643,11 @@
 			reg = <0x40322700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm8@40322800 {
@@ -618,6 +658,11 @@
 			reg = <0x40322800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm9@40322900 {
@@ -628,6 +673,11 @@
 			reg = <0x40322900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm10: pwm10@40322a00 {
@@ -638,6 +688,11 @@
 			reg = <0x40322a00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec10: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm11: pwm11@40322b00 {
@@ -648,6 +703,11 @@
 			reg = <0x40322b00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec11: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm12: pwm12@40322c00 {
@@ -658,6 +718,11 @@
 			reg = <0x40322c00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec12: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm13: pwm13@40322d00 {
@@ -668,6 +733,11 @@
 			reg = <0x40322d00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec13: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		ulpt0: ulpt@40220000 {

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -595,6 +595,11 @@
 			reg = <0x40322000 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec0: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm1: pwm1@40322100 {
@@ -605,6 +610,11 @@
 			reg = <0x40322100 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec1: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm2: pwm2@40322200 {
@@ -615,6 +625,11 @@
 			reg = <0x40322200 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec2: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm3: pwm3@40322300 {
@@ -625,6 +640,11 @@
 			reg = <0x40322300 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec3: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm4: pwm4@40322400 {
@@ -635,6 +655,11 @@
 			reg = <0x40322400 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec4: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm5: pwm5@40322500 {
@@ -645,6 +670,11 @@
 			reg = <0x40322500 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec5: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm6: pwm6@40322600 {
@@ -655,6 +685,11 @@
 			reg = <0x40322600 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec6: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm7: pwm7@40322700 {
@@ -665,6 +700,11 @@
 			reg = <0x40322700 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec7: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm8: pwm8@40322800 {
@@ -675,6 +715,11 @@
 			reg = <0x40322800 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec8: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm9: pwm9@40322900 {
@@ -685,6 +730,11 @@
 			reg = <0x40322900 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec9: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm10: pwm10@40322a00 {
@@ -695,6 +745,11 @@
 			reg = <0x40322a00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec10: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm11: pwm11@40322b00 {
@@ -705,6 +760,11 @@
 			reg = <0x40322b00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec11: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm12: pwm12@40322c00 {
@@ -715,6 +775,11 @@
 			reg = <0x40322c00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec12: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		pwm13: pwm13@40322d00 {
@@ -725,6 +790,11 @@
 			reg = <0x40322d00 0x100>;
 			#pwm-cells = <3>;
 			status = "disabled";
+
+			qdec13: qdec {
+				compatible = "renesas,ra-qdec";
+				status = "disabled";
+			};
 		};
 
 		agt0: agt@40221000 {

--- a/dts/bindings/sensor/renesas,ra-qdec.yaml
+++ b/dts/bindings/sensor/renesas,ra-qdec.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, Pivot International
+# SPDX-License-Identifier: Apache-2.0
+description: |
+  Renesas RA quadrature decoder
+
+compatible: "renesas,ra-qdec"
+
+include:
+  - name: base.yaml
+  - name: pinctrl-device.yaml
+  - name: sensor-device.yaml
+
+properties:
+  micro-ticks-per-rev:
+    type: int
+    required: true
+    description: |
+      This is a number that is used to determine how many revolutions * 1000000
+      were done based on the current counter's value.

--- a/include/zephyr/drivers/sensor/qdec_renesas_ra.h
+++ b/include/zephyr/drivers/sensor/qdec_renesas_ra.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Pivot International Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_RENESAS_RA_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_RENESAS_RA_H_
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_attribute_qdec_renesas_ra {
+	/* Number of counts per revolution */
+	SENSOR_ATTR_QDEC_MOD_VAL = SENSOR_ATTR_PRIV_START,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_RENESAS_RA_H_ */


### PR DESCRIPTION
Allows using the Renesas RA General PWM Timer (GPT) in Quadrature Decoder Mode.