### PR TITLE
github: dependabot: configure cooldown time for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci: github: "
     labels: []
@@ -17,6 +19,8 @@ updates:
     directory: "/doc"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci: doc: "
     labels: []


### PR DESCRIPTION
This will delay non security Dependabot updates to packages, giving automated tools and researchers more time to catch updates with malicious intent, thus reducing the supply chain security risks.

See Dependabot documentation:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-