### PR TITLE
dts: bindings: fix compatible strings missing quotes

### DIFF
--- a/dts/bindings/adc/adi,ad4130-adc.yaml
+++ b/dts/bindings/adc/adi,ad4130-adc.yaml
@@ -48,7 +48,7 @@ description: |
   For input constants such as `AD4130_ADC_AIN8`, refer to the binding header:
   `include/zephyr/dt-bindings/adc/ad4130-adc.h`
 
-compatible: adi,ad4130-adc
+compatible: "adi,ad4130-adc"
 
 include: [adc-controller.yaml, spi-device.yaml]
 

--- a/dts/bindings/adc/adi,ad4170-adc.yaml
+++ b/dts/bindings/adc/adi,ad4170-adc.yaml
@@ -52,7 +52,7 @@ description: |
   For input constants such as `AD4170_ADC_AIN0`, refer to the binding header:
   `include/zephyr/dt-bindings/adc/ad4170-adc.h`
 
-compatible: adi,ad4170-adc
+compatible: "adi,ad4170-adc"
 
 include: [adc-controller.yaml, spi-device.yaml]
 

--- a/dts/bindings/adc/adi,ad4190-adc.yaml
+++ b/dts/bindings/adc/adi,ad4190-adc.yaml
@@ -4,6 +4,6 @@
 description: |
   Bindings for the ADI AD4190 Analog-to-Digital Converter.
 
-compatible: adi,ad4190-adc
+compatible: "adi,ad4190-adc"
 
 include: adi,ad4170-adc.yaml

--- a/dts/bindings/adc/adi,ad4195-adc.yaml
+++ b/dts/bindings/adc/adi,ad4195-adc.yaml
@@ -4,6 +4,6 @@
 description: |
   Bindings for the ADI AD4195 Analog-to-Digital Converter.
 
-compatible: adi,ad4195-adc
+compatible: "adi,ad4195-adc"
 
 include: adi,ad4170-adc.yaml

--- a/dts/bindings/adc/adi,ad7124-adc.yaml
+++ b/dts/bindings/adc/adi,ad7124-adc.yaml
@@ -4,7 +4,7 @@
 description: |
   Bindings for the ADI AD7124 Analog-to-Digital Converter.
 
-compatible: adi,ad7124-adc
+compatible: "adi,ad7124-adc"
 
 include: [adc-controller.yaml, spi-device.yaml]
 

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
@@ -5,7 +5,7 @@ description: Broadcom iProc PAX(PCIE<->AXI) DMA controller version 1
 
 include: dma-controller.yaml
 
-compatible: brcm,iproc-pax-dma-v1
+compatible: "brcm,iproc-pax-dma-v1"
 
 properties:
   reg:

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
@@ -5,7 +5,7 @@ description: Broadcom iProc PAX(PCIE<->AXI) DMA controller version 2
 
 include: dma-controller.yaml
 
-compatible: brcm,iproc-pax-dma-v2
+compatible: "brcm,iproc-pax-dma-v2"
 
 properties:
   reg:

--- a/dts/bindings/dma/zephyr,dma-emul.yaml
+++ b/dts/bindings/dma/zephyr,dma-emul.yaml
@@ -5,7 +5,7 @@ description: Emulated DMA Controller
 
 include: dma-controller.yaml
 
-compatible: zephyr,dma-emul
+compatible: "zephyr,dma-emul"
 
 properties:
   stack-size:

--- a/dts/bindings/gpio/nxp,pca6408.yaml
+++ b/dts/bindings/gpio/nxp,pca6408.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCA6408 I2C GPIO expander
-compatible: nxp,pca6408
+compatible: "nxp,pca6408"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pca6416.yaml
+++ b/dts/bindings/gpio/nxp,pca6416.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCA6416 I2C GPIO expander
-compatible: nxp,pca6416
+compatible: "nxp,pca6416"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pcal6408.yaml
+++ b/dts/bindings/gpio/nxp,pcal6408.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCAL6408 I2C GPIO expander
-compatible: nxp,pcal6408
+compatible: "nxp,pcal6408"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pcal6416.yaml
+++ b/dts/bindings/gpio/nxp,pcal6416.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCAL6416 I2C GPIO expander
-compatible: nxp,pcal6416
+compatible: "nxp,pcal6416"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pcal9538.yaml
+++ b/dts/bindings/gpio/nxp,pcal9538.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCAL9538 I2C GPIO expander node
-compatible: nxp,pcal9538
+compatible: "nxp,pcal9538"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/gpio/nxp,pcal9539.yaml
+++ b/dts/bindings/gpio/nxp,pcal9539.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 description: NXP PCAL9539 I2C GPIO expander node
-compatible: nxp,pcal9539
+compatible: "nxp,pcal9539"
 include: nxp,pca_series.yaml
 
 properties:

--- a/dts/bindings/interrupt-controller/arm,gic-v1.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic-v1.yaml
@@ -2,6 +2,6 @@
 
 description: ARM Generic Interrupt Controller v1
 
-compatible: arm,gic-v1
+compatible: "arm,gic-v1"
 
 include: arm,gic.yaml

--- a/dts/bindings/interrupt-controller/arm,gic-v2.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic-v2.yaml
@@ -2,6 +2,6 @@
 
 description: ARM Generic Interrupt Controller v2
 
-compatible: arm,gic-v2
+compatible: "arm,gic-v2"
 
 include: arm,gic.yaml

--- a/dts/bindings/interrupt-controller/arm,gic-v3.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic-v3.yaml
@@ -30,7 +30,7 @@ description: |
       status = "okay";
     };
 
-compatible: arm,gic-v3
+compatible: "arm,gic-v3"
 
 include: arm,gic.yaml
 

--- a/dts/bindings/led/ti,lp5009.yaml
+++ b/dts/bindings/led/ti,lp5009.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5009 I2C LED controller node
 
-compatible: ti,lp5009
+compatible: "ti,lp5009"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/led/ti,lp5012.yaml
+++ b/dts/bindings/led/ti,lp5012.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5012 I2C LED controller node
 
-compatible: ti,lp5012
+compatible: "ti,lp5012"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/led/ti,lp5018.yaml
+++ b/dts/bindings/led/ti,lp5018.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5018 I2C LED controller node
 
-compatible: ti,lp5018
+compatible: "ti,lp5018"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/led/ti,lp5024.yaml
+++ b/dts/bindings/led/ti,lp5024.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5024 I2C LED controller node
 
-compatible: ti,lp5024
+compatible: "ti,lp5024"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/led/ti,lp5030.yaml
+++ b/dts/bindings/led/ti,lp5030.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5030 I2C LED controller node
 
-compatible: ti,lp5030
+compatible: "ti,lp5030"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/led/ti,lp5036.yaml
+++ b/dts/bindings/led/ti,lp5036.yaml
@@ -1,5 +1,5 @@
 description: Texas Instruments LP5036 I2C LED controller node
 
-compatible: ti,lp5036
+compatible: "ti,lp5036"
 
 include: ti,lp50xx.yaml

--- a/dts/bindings/mdio/xilinx,axi-ethernet-1.00.a-mdio.yaml
+++ b/dts/bindings/mdio/xilinx,axi-ethernet-1.00.a-mdio.yaml
@@ -5,7 +5,7 @@
 
 include: mdio-controller.yaml
 
-compatible: xlnx,axi-ethernet-1.00.a-mdio
+compatible: "xlnx,axi-ethernet-1.00.a-mdio"
 
 description: MDIO interface of Xilinx AXI 1G/2.5G Ethernet Subsystem.
 

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v1.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v1.yaml
@@ -18,7 +18,7 @@ description: |
 
 include: soc-nv-flash.yaml
 
-compatible: gd,gd32-nv-flash-v1
+compatible: "gd,gd32-nv-flash-v1"
 
 properties:
   max-erase-time-ms:

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v2.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v2.yaml
@@ -12,7 +12,7 @@ description: |
 
 include: soc-nv-flash.yaml
 
-compatible: gd,gd32-nv-flash-v2
+compatible: "gd,gd32-nv-flash-v2"
 
 properties:
   max-erase-time-ms:

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v3.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v3.yaml
@@ -9,7 +9,7 @@ description: |
 
 include: soc-nv-flash.yaml
 
-compatible: gd,gd32-nv-flash-v3
+compatible: "gd,gd32-nv-flash-v3"
 
 properties:
   max-erase-time-ms:

--- a/dts/bindings/mtd/nordic,mram.yaml
+++ b/dts/bindings/mtd/nordic,mram.yaml
@@ -3,7 +3,7 @@
 
 description: Nordic MRAM
 
-compatible: nordic,mram
+compatible: "nordic,mram"
 
 include: soc-nv-flash.yaml
 

--- a/dts/bindings/mtd/st,stm32-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32-nv-flash.yaml
@@ -6,7 +6,7 @@ description: |
 
 include: soc-nv-flash.yaml
 
-compatible: st,stm32-nv-flash
+compatible: "st,stm32-nv-flash"
 
 properties:
   max-erase-time:

--- a/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
@@ -3,7 +3,7 @@ description: |
 
 include: st,stm32-nv-flash.yaml
 
-compatible: st,stm32f4-nv-flash
+compatible: "st,stm32f4-nv-flash"
 
 properties:
   write-block-size:

--- a/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
@@ -3,7 +3,7 @@ description: |
 
 include: st,stm32-nv-flash.yaml
 
-compatible: st,stm32l0-nv-flash
+compatible: "st,stm32l0-nv-flash"
 
 properties:
   write-block-size:

--- a/dts/bindings/pinctrl/renesas,rza-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,rza-pinctrl.yaml
@@ -25,7 +25,7 @@ description: |
       };
 
 
-compatible: renesas,rza-pinctrl
+compatible: "renesas,rza-pinctrl"
 
 include: base.yaml
 properties:

--- a/dts/bindings/pinctrl/renesas,rzg-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,rzg-pinctrl.yaml
@@ -31,7 +31,7 @@ description: |
       };
 
 
-compatible: renesas,rzg-pinctrl
+compatible: "renesas,rzg-pinctrl"
 
 include: base.yaml
 properties:

--- a/dts/bindings/pinctrl/renesas,rzv-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,rzv-pinctrl.yaml
@@ -29,7 +29,7 @@ description: |
       };
 
 
-compatible: renesas,rzv-pinctrl
+compatible: "renesas,rzv-pinctrl"
 
 include: base.yaml
 properties:

--- a/dts/bindings/test/vnd,non-deprecated-label.yaml
+++ b/dts/bindings/test/vnd,non-deprecated-label.yaml
@@ -6,7 +6,7 @@ description: |
   of generating deprecation warnings, which are errors in some
   configurations.
 
-compatible: vnd,non-deprecated-label
+compatible: "vnd,non-deprecated-label"
 
 properties:
   label:

--- a/dts/bindings/test/vnd,pcie.yaml
+++ b/dts/bindings/test/vnd,pcie.yaml
@@ -3,7 +3,7 @@
 
 description: Test PCIe bus controller
 
-compatible: vnd,pcie
+compatible: "vnd,pcie"
 
 include: base.yaml
 

--- a/dts/bindings/usb/nxp,ehci.yaml
+++ b/dts/bindings/usb/nxp,ehci.yaml
@@ -3,7 +3,7 @@
 
 description: NXP EHCI USB device mode
 
-compatible: nxp,ehci
+compatible: "nxp,ehci"
 
 include: "nxp,mcux-usbd.yaml"
 

--- a/dts/bindings/usb/nxp,lpcip3511.yaml
+++ b/dts/bindings/usb/nxp,lpcip3511.yaml
@@ -3,7 +3,7 @@
 
 description: NXP LPCIP3511 USB device mode
 
-compatible: nxp,lpcip3511
+compatible: "nxp,lpcip3511"
 
 include: "nxp,mcux-usbd.yaml"
 

--- a/dts/bindings/wifi/nordic,nrf7000-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-coex.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7000 Wi-Fi chip with COEX interface.
 
-compatible: nordic,nrf7000-coex
+compatible: "nordic,nrf7000-coex"
 
 include:
   - "nordic,nrf70-coex.yaml"

--- a/dts/bindings/wifi/nordic,nrf7000-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-qspi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with QSPI interface.
 
-compatible: nordic,nrf7000-qspi
+compatible: "nordic,nrf7000-qspi"
 
 include:
   - "nordic,nrf70-qspi.yaml"

--- a/dts/bindings/wifi/nordic,nrf7000-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7000-spi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with SPI interface.
 
-compatible: nordic,nrf7000-spi
+compatible: "nordic,nrf7000-spi"
 
 include:
   - "nordic,nrf70-spi.yaml"

--- a/dts/bindings/wifi/nordic,nrf7001-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-coex.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7001 Wi-Fi chip with COEX interface.
 
-compatible: nordic,nrf7001-coex
+compatible: "nordic,nrf7001-coex"
 
 include:
   - "nordic,nrf70-coex.yaml"

--- a/dts/bindings/wifi/nordic,nrf7001-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-qspi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with QSPI interface.
 
-compatible: nordic,nrf7001-qspi
+compatible: "nordic,nrf7001-qspi"
 
 include:
   - "nordic,nrf70-qspi.yaml"

--- a/dts/bindings/wifi/nordic,nrf7001-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7001-spi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with SPI interface.
 
-compatible: nordic,nrf7001-spi
+compatible: "nordic,nrf7001-spi"
 
 include:
   - "nordic,nrf70-spi.yaml"

--- a/dts/bindings/wifi/nordic,nrf7002-coex.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-coex.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with COEX interface.
 
-compatible: nordic,nrf7002-coex
+compatible: "nordic,nrf7002-coex"
 
 include:
   - "nordic,nrf70-coex.yaml"

--- a/dts/bindings/wifi/nordic,nrf7002-qspi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-qspi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with QSPI interface.
 
-compatible: nordic,nrf7002-qspi
+compatible: "nordic,nrf7002-qspi"
 
 include:
   - "nordic,nrf70-qspi.yaml"

--- a/dts/bindings/wifi/nordic,nrf7002-spi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002-spi.yaml
@@ -3,7 +3,7 @@
 
 description: nRF7002 Wi-Fi chip with SPI interface.
 
-compatible: nordic,nrf7002-spi
+compatible: "nordic,nrf7002-spi"
 
 include:
   - "nordic,nrf70-spi.yaml"


### PR DESCRIPTION
Add quotes to compatible strings missing them. Reported in #101383
https://docs.zephyrproject.org/latest/build/dts/bindings-syntax.html#compatible