### PR TITLE
bluetooth: at: add explicit cast to char pointer in return statements

### DIFF
--- a/subsys/bluetooth/host/classic/at.c
+++ b/subsys/bluetooth/host/classic/at.c
@@ -755,7 +755,7 @@ char *at_get_string(struct at_client *at)
 	skip_space(at);
 	next_list(at);
 
-	return data.start;
+	return (char *)data.start;
 }
 
 struct get_raw_string_data {
@@ -800,5 +800,5 @@ char *at_get_raw_string(struct at_client *at, size_t *string_len)
 	skip_space(at);
 	next_list(at);
 
-	return data.start;
+	return (char *)data.start;
 }


### PR DESCRIPTION
Add explicit casts from 'uint8_t *' to 'char *' in at_get_string() and at_get_raw_string() return statements to resolve implicit cast warnings. The data.start field is uint8_t *, but the functions return char *.