### PR TITLE
bluetooth: Classic: hfp_hf: make at_get_string() return const char *

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -275,7 +275,7 @@ struct bt_hfp_hf_cb {
 	 *  @param number Notified phone number.
 	 *  @param type Specify the format of the phone number.
 	 */
-	void (*clip)(struct bt_hfp_hf_call *call, char *number, uint8_t type);
+	void (*clip)(struct bt_hfp_hf_call *call, const char *number, uint8_t type);
 	/** HF microphone gain notification callback to application
 	 *
 	 *  If this callback is provided it will be called whenever there
@@ -326,7 +326,7 @@ struct bt_hfp_hf_cb {
 	 *                  representing the name of the network
 	 *                  operator.
 	 */
-	void (*operator)(struct bt_hfp_hf *hf, uint8_t mode, uint8_t format, char *operator);
+	void (*operator)(struct bt_hfp_hf *hf, uint8_t mode, uint8_t format, const char *operator);
 	/** Codec negotiate callback
 	 *
 	 *  If this callback is provided it will be called whenever the
@@ -375,7 +375,7 @@ struct bt_hfp_hf_cb {
 	 *  @param number Notified phone number.
 	 *  @param type Specify the format of the phone number.
 	 */
-	void (*call_waiting)(struct bt_hfp_hf_call *call, char *number, uint8_t type);
+	void (*call_waiting)(struct bt_hfp_hf_call *call, const char *number, uint8_t type);
 	/** Voice recognition activation/deactivation callback
 	 *
 	 *  If this callback is provided it will be called whenever the
@@ -443,7 +443,7 @@ struct bt_hfp_hf_cb {
 	 *  @param text Value of `<string>`.
 	 */
 	void (*textual_representation)(struct bt_hfp_hf *hf, char *id, uint8_t type,
-				       uint8_t operation, char *text);
+				       uint8_t operation, const char *text);
 	/** Request phone number callback
 	 *
 	 *  If this callback is provided it will be called whenever the

--- a/subsys/bluetooth/host/classic/at.c
+++ b/subsys/bluetooth/host/classic/at.c
@@ -735,7 +735,7 @@ void at_register(struct at_client *at, at_resp_cb_t resp, at_finish_cb_t finish)
 	at->state = AT_STATE_START;
 }
 
-char *at_get_string(struct at_client *at)
+const char *at_get_string(struct at_client *at)
 {
 	struct get_string_data data;
 
@@ -755,7 +755,7 @@ char *at_get_string(struct at_client *at)
 	skip_space(at);
 	next_list(at);
 
-	return (char *)data.start;
+	return (const char *)data.start;
 }
 
 struct get_raw_string_data {

--- a/subsys/bluetooth/host/classic/at.h
+++ b/subsys/bluetooth/host/classic/at.h
@@ -114,5 +114,5 @@ int at_list_get_string(struct at_client *at, char *name, uint8_t len);
 int at_close_list(struct at_client *at);
 int at_open_list(struct at_client *at);
 bool at_has_next_list(struct at_client *at);
-char *at_get_string(struct at_client *at);
+const char *at_get_string(struct at_client *at);
 char *at_get_raw_string(struct at_client *at, size_t *string_len);

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -798,7 +798,7 @@ static int clcc_handle(struct at_client *hf_at)
 	uint32_t status;
 	uint32_t mode;
 	uint32_t mpty;
-	char *number = NULL;
+	const char *number;
 	uint32_t type = 0;
 	bool incoming = false;
 	bool new_call = false;
@@ -910,7 +910,7 @@ static int bvra_handle(struct at_client *hf_at)
 	size_t id_len;
 	uint32_t type;
 	uint32_t operation;
-	char *text;
+	const char *text;
 
 	err = at_get_number(hf_at, &activate);
 	if (err < 0) {
@@ -972,14 +972,13 @@ static int bvra_handle(struct at_client *hf_at)
 	}
 
 	text = at_get_string(hf_at);
-	if (!text) {
+	if (text == NULL) {
 		LOG_INF("Error getting text string");
 		return 0;
 	}
 
 	if (bt_hf->textual_representation) {
-		bt_hf->textual_representation(hf, text_id, (uint8_t)type,
-			(uint8_t)operation, text);
+		bt_hf->textual_representation(hf, text_id, (uint8_t)type, (uint8_t)operation, text);
 	}
 #endif /* CONFIG_BT_HFP_HF_VOICE_RECG_TEXT */
 	return 0;
@@ -1483,7 +1482,7 @@ int ring_handle(struct at_client *hf_at)
 int clip_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
-	char *number;
+	const char *number;
 	uint32_t type;
 	int err;
 	struct bt_hfp_hf_call *call;
@@ -1669,7 +1668,7 @@ static int btrh_handle(struct at_client *hf_at)
 static int ccwa_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
-	char *number;
+	const char *number;
 	uint32_t type;
 	int err;
 	struct bt_hfp_hf_call *call;
@@ -1782,7 +1781,7 @@ static int cnum_handle(struct at_client *hf_at)
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
 	int err;
 	char *alpha;
-	char *number;
+	const char *number;
 	uint32_t type;
 	char *speed;
 	uint32_t service = 4;
@@ -2538,7 +2537,7 @@ static int cops_handle(struct at_client *hf_at)
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
 	uint32_t mode;
 	uint32_t format;
-	char *operator;
+	const char *operator;
 	int err;
 
 	err = at_get_number(hf_at, &mode);
@@ -2614,7 +2613,7 @@ int bt_hfp_hf_get_operator(struct bt_hfp_hf *hf)
 static int binp_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
-	char *number;
+	const char *number;
 
 	number = at_get_string(hf_at);
 

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -208,7 +208,7 @@ void hf_dialing(struct bt_hfp_hf *hf, int err)
 }
 
 #if defined(CONFIG_BT_HFP_HF_CLI)
-void hf_clip(struct bt_hfp_hf_call *call, char *number, uint8_t type)
+void hf_clip(struct bt_hfp_hf_call *call, const char *number, uint8_t type)
 {
 	bt_shell_print("HF call %p CLIP %s %d", call, number, type);
 }
@@ -231,7 +231,7 @@ static void hf_inband_ring(struct bt_hfp_hf *hf, bool inband)
 	bt_shell_print("HF ring: %s", inband ? "in-band" : "no in-hand");
 }
 
-static void hf_operator(struct bt_hfp_hf *hf, uint8_t mode, uint8_t format, char *operator)
+static void hf_operator(struct bt_hfp_hf *hf, uint8_t mode, uint8_t format, const char *operator)
 {
 	bt_shell_print("HF mode %d, format %d, operator %s", mode, format, operator);
 }
@@ -261,7 +261,7 @@ static void hf_ecnr_turn_off(struct bt_hfp_hf *hf, int err)
 #endif /* CONFIG_BT_HFP_HF_ECNR */
 
 #if defined(CONFIG_BT_HFP_HF_3WAY_CALL)
-static void hf_call_waiting(struct bt_hfp_hf_call *call, char *number, uint8_t type)
+static void hf_call_waiting(struct bt_hfp_hf_call *call, const char *number, uint8_t type)
 {
 	bt_shell_print("3way call %p waiting. number %s type %d", call, number, type);
 }
@@ -282,7 +282,7 @@ void hf_vre_state(struct bt_hfp_hf *hf, uint8_t state)
 
 #if defined(CONFIG_BT_HFP_HF_VOICE_RECG_TEXT)
 void hf_textual_representation(struct bt_hfp_hf *hf, char *id, uint8_t type, uint8_t operation,
-			       char *text)
+			       const char *text)
 {
 	bt_shell_print("Text id %s, type %d, operation %d, string %s", id, type, operation, text);
 }


### PR DESCRIPTION
Change at_get_string() return type to 'const char *'. Correspondingly, change string parameters in HFP HF callbacks and related functions from 'char *' to 'const char *' to reflect that these strings are read-only data returned from AT command parsing.

- Update bt_hfp_hf_cb callback signatures for clip, operator, call_waiting, and textual_representation
- Update at_get_string() return type to 'const char *'
- Update local variables in hfp_hf.c handlers to use 'const char *'
- Update shell callback implementations to match new signatures
- Change NULL check style from '!text' to 'text == NULL' for consistency
- Remove unnecessary initialization of 'number' variable in clcc_handle

This improves const-correctness and prevents accidental modification of AT command response strings.