### PR TITLE
bluetooth: Classic: hfp_hf: make at_get_raw_string() return const char *

### DIFF
--- a/subsys/bluetooth/host/classic/at.c
+++ b/subsys/bluetooth/host/classic/at.c
@@ -778,7 +778,7 @@ static bool at_get_raw_string_cb(uint8_t *c, void *data)
 	return true;
 }
 
-char *at_get_raw_string(struct at_client *at, size_t *string_len)
+const char *at_get_raw_string(struct at_client *at, size_t *string_len)
 {
 	struct get_raw_string_data data;
 
@@ -800,5 +800,5 @@ char *at_get_raw_string(struct at_client *at, size_t *string_len)
 	skip_space(at);
 	next_list(at);
 
-	return (char *)data.start;
+	return (const char *)data.start;
 }

--- a/subsys/bluetooth/host/classic/at.h
+++ b/subsys/bluetooth/host/classic/at.h
@@ -115,4 +115,4 @@ int at_close_list(struct at_client *at);
 int at_open_list(struct at_client *at);
 bool at_has_next_list(struct at_client *at);
 const char *at_get_string(struct at_client *at);
-char *at_get_raw_string(struct at_client *at, size_t *string_len);
+const char *at_get_raw_string(struct at_client *at, size_t *string_len);

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -905,7 +905,7 @@ static int bvra_handle(struct at_client *hf_at)
 	int err;
 	uint32_t activate;
 	uint32_t state;
-	char *id;
+	const char *id;
 	char text_id[BT_HFP_BVRA_TEXT_ID_MAX_LEN + 1];
 	size_t id_len;
 	uint32_t type;
@@ -946,7 +946,7 @@ static int bvra_handle(struct at_client *hf_at)
 
 #if defined(CONFIG_BT_HFP_HF_VOICE_RECG_TEXT)
 	id = at_get_raw_string(hf_at, &id_len);
-	if (!id) {
+	if (id == NULL) {
 		LOG_INF("Error getting text ID");
 		return 0;
 	}
@@ -1726,7 +1726,7 @@ static int get_chld_feature(const char *name)
 int chld_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
-	char *value;
+	const char *value;
 	uint32_t chld_features = 0;
 	int err;
 
@@ -1738,7 +1738,7 @@ int chld_handle(struct at_client *hf_at)
 
 	while (at_has_next_list(hf_at)) {
 		value = at_get_raw_string(hf_at, NULL);
-		if (!value) {
+		if (value == NULL) {
 			LOG_ERR("Could not get value");
 			goto error;
 		}
@@ -1780,10 +1780,10 @@ static int cnum_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
 	int err;
-	char *alpha;
+	__maybe_unused const char *alpha;
 	const char *number;
 	uint32_t type;
-	char *speed;
+	__maybe_unused const char *speed;
 	uint32_t service = 4;
 
 	alpha = at_get_raw_string(hf_at, NULL);


### PR DESCRIPTION
Change at_get_raw_string() return type from 'char *' to 'const char *' to match at_get_string() and improve const-correctness. This function returns read-only AT command response data that should not be modified.

- Update at_get_raw_string() signature in at.h and at.c
- Update return statement cast from 'char *' to 'const char *'
- Update local variables in hfp_hf.c to use 'const char *':
  * bvra_handle: 'id' variable
  * chld_handle: 'value' variable
  * cnum_handle: 'alpha' and 'speed' variables
- Mark unused 'alpha' and 'speed' in cnum_handle with __maybe_unused
- Change NULL check style from '!id' to 'id == NULL' for consistency

This completes the const-correctness improvements started in the previous commit for HFP HF AT command string handling.