### PR TITLE
bluetooth: Classic: l2cap: fix RX MTU calculation for non-basic modes

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -221,10 +221,10 @@ static void br_tx_buf_destroy(struct net_buf *buf)
 	bt_tx_irq_raise();
 }
 
-/* Pool for outgoing BR/EDR signaling packets, min MTU is 48 */
+/* Pool for outgoing BR/EDR RET/FC transmit PDUs (I-frames/S-frames) */
 NET_BUF_POOL_FIXED_DEFINE(br_tx_pool, CONFIG_BT_L2CAP_TX_BUF_COUNT,
-			  BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_MPS), CONFIG_BT_CONN_TX_USER_DATA_SIZE,
-			  br_tx_buf_destroy);
+			  BT_L2CAP_RT_FC_MAX_SDU_BUF_SIZE(CONFIG_BT_L2CAP_MPS),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, br_tx_buf_destroy);
 #endif /* CONFIG_BT_L2CAP_RET_FC */
 
 /* BR/EDR L2CAP signalling channel specific context */

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -5954,20 +5954,6 @@ static void bt_l2cap_br_ret_fc_i_recv(struct bt_l2cap_br_chan *br_chan, struct n
 	}
 
 valid_frame:
-	switch (sar) {
-	case BT_L2CAP_CONTROL_SAR_START:
-		if (buf->len < 2) {
-			LOG_WRN("Too short data packet");
-			bt_l2cap_chan_disconnect(&br_chan->chan);
-			return;
-		}
-		break;
-	case BT_L2CAP_CONTROL_SAR_UNSEG:
-	case BT_L2CAP_CONTROL_SAR_END:
-	case BT_L2CAP_CONTROL_SAR_CONTI:
-		break;
-	}
-
 	/* Redirect to experimental API. */
 	IF_ENABLED(CONFIG_BT_L2CAP_SEG_RECV, ({
 		if (br_chan->chan.ops->seg_recv) {
@@ -6059,6 +6045,7 @@ static void bt_l2cap_br_ret_fc_recv(struct bt_l2cap_br_chan *br_chan, struct net
 	uint16_t control;
 	uint32_t ext_control;
 	uint8_t type;
+	uint8_t sar = BT_L2CAP_CONTROL_SAR_UNSEG;
 	struct net_buf_simple_state state;
 
 	hdr = (struct bt_l2cap_hdr *)buf->data;
@@ -6085,26 +6072,50 @@ static void bt_l2cap_br_ret_fc_recv(struct bt_l2cap_br_chan *br_chan, struct net
 	/* Pull L2CAP Header from received frame */
 	net_buf_pull_mem(buf, sizeof(*hdr));
 
-	if (buf->len > br_chan->rx.mps) {
-		LOG_WRN("PDU size > MPS (%u > %u)", buf->len, br_chan->rx.mps);
-		bt_l2cap_chan_disconnect(&br_chan->chan);
-		return;
-	}
-
 	net_buf_simple_save(&buf->b, &state);
 	if ((br_chan->rx.mode == BT_L2CAP_BR_LINK_MODE_ERET) ||
 	    (br_chan->rx.mode == BT_L2CAP_BR_LINK_MODE_STREAM)) {
 		if (br_chan->rx.extended_control) {
 			ext_control = net_buf_pull_le32(buf);
 			type = (uint8_t)BT_L2CAP_S_FRAME_EXT_CONTROL_GET_TYPE(ext_control);
+			if (type == BT_L2CAP_CONTROL_TYPE_I) {
+				sar = (uint8_t)BT_L2CAP_I_FRAME_EXT_CONTROL_GET_SAR(ext_control);
+			}
 		} else {
 			control = net_buf_pull_le16(buf);
 			type = (uint8_t)BT_L2CAP_S_FRAME_ENH_CONTROL_GET_TYPE(control);
+			if (type == BT_L2CAP_CONTROL_TYPE_I) {
+				sar = (uint8_t)BT_L2CAP_I_FRAME_ENH_CONTROL_GET_SAR(control);
+			}
 		}
 	} else {
 		control = net_buf_pull_le16(buf);
 		type = (uint8_t)BT_L2CAP_S_FRAME_STD_CONTROL_GET_TYPE(control);
+		if (type == BT_L2CAP_CONTROL_TYPE_I) {
+			sar = (uint8_t)BT_L2CAP_I_FRAME_STD_CONTROL_GET_SAR(control);
+		}
 	}
+
+	if (sar == BT_L2CAP_CONTROL_SAR_START) {
+		__maybe_unused uint16_t sdu_length;
+
+		if (buf->len < sizeof(sdu_length)) {
+			LOG_WRN("Too short data packet");
+			bt_l2cap_chan_disconnect(&br_chan->chan);
+			return;
+		}
+
+		sdu_length = net_buf_pull_le16(buf);
+
+		LOG_DBG("New segment i-frame arrived (SDU Len %u)", sdu_length);
+	}
+
+	if (buf->len > br_chan->rx.mps) {
+		LOG_WRN("PDU size > MPS (%u > %u)", buf->len, br_chan->rx.mps);
+		bt_l2cap_chan_disconnect(&br_chan->chan);
+		return;
+	}
+
 	net_buf_simple_restore(&buf->b, &state);
 
 	if (type == BT_L2CAP_CONTROL_TYPE_S) {


### PR DESCRIPTION
#### bluetooth: Classic: l2cap: fix RX MTU calculation for non-basic modes

Fix incorrect RX MTU calculation when retransmission/flow control modes are enabled. The previous implementation did not account for I-frame overhead (control field and FCS), which could cause MTU to exceed the maximum I-frame payload.

- Add l2cap_br_get_rx_mtu() helper to calculate proper RX MTU
- Discount extended control field size (4 bytes) when enhanced retransmission or streaming mode is enabled
- Discount standard control field size (2 bytes) for basic mode
- Always discount FCS size (2 bytes) as it may be required by peer
- Add assertion to validate MTU meets minimum requirements
- Update l2cap_br_check_chan_config() to use new MTU calculation

This ensures the negotiated MTU fits within the I-frame payload limits and prevents buffer overruns in non-basic L2CAP modes.

#### bluetooth: Classic: l2cap: extract SDU length before MPS validation

Fix incorrect MPS validation for segmented I-frames by extracting the SDU length field before checking payload size against MPS.

When an I-frame has SAR (Segmentation and Reassembly) set to START, it contains a 2-byte SDU length field that precedes the actual payload. The previous implementation validated buf->len against MPS before removing this header, causing false positives when the SDU length field pushed the total size over MPS.

- Extract SAR field from control header for all L2CAP modes
- Initialize SAR to UNSEG by default
- Pull SDU length (2 bytes) when SAR indicates START segment
- Perform MPS validation after SDU length extraction
- Move net_buf_simple_save/restore to encompass SDU length handling

This ensures MPS validation checks only the actual payload size, preventing spurious disconnections for legitimate segmented transfers.

#### bluetooth: Classic: l2cap: simplify get_pdu_len() MPS calculation

Simplify the PDU length calculation in get_pdu_len() by using the configured MPS value directly without manual adjustments for overhead.

The previous implementation attempted to manually calculate available payload space by subtracting header/tail sizes and then adding back the SDU length field size, which was unnecessarily complex and error-prone.

- Remove manual calculation of actual_mps with header/tail overhead
- Use br_chan->tx.mps directly as the MPS limit
- Remove special handling for start segments (SDU length field
  adjustment)
- Simplify logic: return pdu_len if within MPS, otherwise return MPS

The MPS value already represents the maximum PDU size that can be transmitted, so no additional adjustments are needed. This aligns with the recent fixes to MPS validation and MTU calculation.

#### bluetooth: Classic: l2cap: Correct segment buffer size

Fix buffer pool allocation size for BR/EDR L2CAP non-basic modes by using the appropriate macro that accounts for SDU segmentation overhead.

The previous implementation used BT_L2CAP_BUF_SIZE() which is designed for basic mode and does not account for the additional overhead required when segmenting SDUs in retransmission or flow control modes (I-frame control field, FCS, and SDU length field).

- Replace BT_L2CAP_BUF_SIZE() with BT_L2CAP_RT_FC_MAX_SDU_BUF_SIZE()
- Ensures sufficient buffer space for segmented I-frames
- Aligns buffer allocation with recent MPS and MTU calculation fixes

This prevents potential buffer overruns when transmitting segmented SDUs in non-basic modes.
