### PR TITLE
drivers: counter: mcux_gpt: add configurable run mode support

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -237,6 +237,44 @@ Counter
            resolution = <16>;
        };
 
+* The NXP i.MX GPT counter driver (:dtcompatible:`nxp,imx-gpt`) now
+  defaults to ``run-mode = "restart"`` instead of the previous hardcoded free-run behavior.
+
+  * **Previous behavior** (Zephyr ≤ 4.3): GPT counter always ran in free-run mode
+    (``enableFreeRun = true``). The counter continued counting without reset on compare events.
+
+  * **New behavior** (Zephyr ≥ 4.4): GPT counter defaults to restart mode unless explicitly
+    configured. A new ``run-mode`` devicetree property controls the behavior:
+
+    * ``"restart"`` (default): Counter resets to 0 when reaching Compare Channel 1 value
+    * ``"free-run"``: Counter continues counting without reset (previous behavior)
+
+  **Migration Required**: Out-of-tree boards and applications using GPT counters must add
+  ``run-mode = "free-run";`` to their devicetree nodes to preserve the previous behavior.
+
+  .. code-block:: devicetree
+
+     /* Out-of-tree boards: add this to preserve previous behavior */
+     gpt2: gpt@400f0000 {
+         compatible = "nxp,imx-gpt";
+         /* Explicitly restore Zephyr ≤4.3 behavior */
+         run-mode = "free-run";
+         /* ... other properties ... */
+     };
+
+  .. warning::
+
+     The driver uses Compare Channel 1 for Zephyr counter alarm functionality. When using
+     ``run-mode = "restart"``, setting alarms will cause the counter to reset at the alarm
+     compare point. If your application relies on alarms and continuous counting, you must
+     use ``run-mode = "free-run"``.
+
+  .. note::
+
+     This change standardizes NXP counter driver run mode configuration.
+     GPT now uses explicit devicetree properties rather than hardcoded values, allowing
+     per-instance customization.
+
 EEPROM
 ======
 

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Linaro Limited.
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,6 +27,7 @@ struct mcux_gpt_config {
 
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	bool enable_free_run;
 	void (*irq_config_func)(void);
 };
 
@@ -204,7 +205,7 @@ static int mcux_gpt_init(const struct device *dev)
 	}
 
 	GPT_GetDefaultConfig(&gptConfig);
-	gptConfig.enableFreeRun = true; /* Do not reset on compare */
+	gptConfig.enableFreeRun = config->enable_free_run;
 	gptConfig.clockSource = kGPT_ClockSource_Periph;
 	gptConfig.divider = clock_freq / config->info.freq;
 	base = get_base(dev);
@@ -235,6 +236,7 @@ static DEVICE_API(counter, mcux_gpt_driver_api) = {
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
 		.clock_subsys =						\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.enable_free_run = (DT_INST_ENUM_IDX_OR(n, run_mode, 0) == 1),\
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
 			.freq = DT_INST_PROP(n, gptfreq),           \

--- a/dts/bindings/counter/nxp,imx-gpt.yaml
+++ b/dts/bindings/counter/nxp,imx-gpt.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP MCUX General-Purpose Timer (GPT)
@@ -18,3 +19,19 @@ properties:
     type: int
     required: true
     description: gpt frequencies
+
+  run-mode:
+    type: string
+    description: |
+      Selects how the GPT counter behaves on compare events.
+      - restart(default): When the counter reaches the Compare Channel 1 value,
+        the counter resets to 0x00000000 and starts counting again.
+      - free-run: Compare events do not reset the counter.
+      Notes:
+      - This driver uses Compare Channel 1 for the Zephyr counter alarm.
+      - With restart, using alarms may cause the counter to reset at the
+        alarm compare point.
+    enum:
+      - restart
+      - free-run
+    default: restart


### PR DESCRIPTION
Add a "run-mode" devicetree property to the NXP i.MX GPT counter
driver to control counter behavior on compare events.

The property supports two modes:
- "restart": Counter resets to 0 when reaching Compare Channel 1 value
- "free-run": Counter continues counting without reset

This change makes the GPT run mode configurable per device instance
instead of being hardcoded. The driver now derives the enableFreeRun
setting from devicetree, defaulting to "restart" mode.

This update aligns the GPT driver configuration approach with the
NXP LPTMR counter driver, which also uses devicetree properties
for runtime behavior configuration.
This provides consistency across NXP counter drivers in how hardware
behavior is controlled through devicetree.