### PR TITLE
samples: drivers: memc: add support for siwx917 soc

### DIFF
--- a/samples/drivers/memc/boards/siwx917_dk2605a.overlay
+++ b/samples/drivers/memc/boards/siwx917_dk2605a.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sram-ext = &psram;
+	};
+};

--- a/samples/drivers/memc/boards/siwx917_rb4342a.overlay
+++ b/samples/drivers/memc/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sram-ext = &psram;
+	};
+};

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -37,6 +37,10 @@
 #define MSPI_BUS DT_BUS(MEMC_DEV)
 #define MEMC_BASE DT_REG_ADDR_BY_IDX(MSPI_BUS, 1)
 #define MEMC_SIZE (DT_PROP(MEMC_DEV, size) / 8)
+#elif DT_HAS_COMPAT_STATUS_OKAY(silabs_siwx91x_qspi_memory)
+#define MEMC_DEV  DT_ALIAS(sram_ext)
+#define MEMC_BASE ((void *)DT_REG_ADDR(MEMC_DEV))
+#define MEMC_SIZE (DT_REG_SIZE(MEMC_DEV) / 8)
 #else
 #error At least one driver should be selected!
 #endif


### PR DESCRIPTION
This patch adds support for the QSPI memory controller (for the SiWG917 SoC) in order to enable PSRAM testing. It also adds board overlays for this family that include PSRAM.