### PR TITLE
drivers: timer: mcux_lptmr: add tickless kernel support

### DIFF
--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -9,6 +9,7 @@ config MCUX_LPTMR_TIMER
 	depends on DT_HAS_NXP_LPTMR_ENABLED
 	depends on !COUNTER_MCUX_LPTMR
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -32,16 +32,55 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define CYCLES_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() \
 			/ (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 
+#define LPTMR_COUNTER_MAX (0xFFFFFFFFU)
+
+
+/* Define maximum ticks(By limit to half of counter size, we ensure that
+ * timeout calculations will never overflow in sys_clock_set_timeout)
+ */
+#define MAX_TICKS (LPTMR_COUNTER_MAX / 2) / CYCLES_PER_TICK
 /* 32 bit cycle counter */
 static volatile uint32_t cycles;
+static struct k_spinlock lock;
+static uint32_t last_announced_cycles;
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
-	ARG_UNUSED(idle);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (idle && (ticks == K_TICKS_FOREVER)) {
 		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+		k_spin_unlock(&lock, key);
+		return;
 	}
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
+	if (ticks < 1) {
+		ticks = 1;
+	} else if (ticks > (int32_t)MAX_TICKS) {
+		ticks = (int32_t)MAX_TICKS;
+	}
+	uint32_t timeout_cycles = (uint32_t)ticks * CYCLES_PER_TICK;
+	uint32_t current = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+	/* Automatically handle overflow.
+	 * uint32_t is an unsigned 32‑bit integer. In C, unsigned arithmetic
+	 * wraps around modulo 2^32.
+	 * If current is close to 0xFFFFFFFF and will add timeout_cycles,
+	 * the result will wrap around to the low range automatically 
+	 * (e.g., 0xFFFFFFF0 + 0x40 → 0x30).
+	 * This wraparound behavior is intentional for timers/counters: 
+	 * the arithmetic naturally works in a circular space (2^32),
+	 * so we can schedule future times without special overflow checks.
+	 */
+	uint32_t compare = current + timeout_cycles;
+	
+	LPTMR_SetTimerPeriod(LPTMR_BASE, compare);
+
+	k_spin_unlock(&lock, key);
 }
 
 void sys_clock_idle_exit(void)
@@ -59,7 +98,17 @@ void sys_clock_disable(void)
 
 uint32_t sys_clock_elapsed(void)
 {
-	return 0;
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		k_spinlock_key_t key = k_spin_lock(&lock);
+		uint32_t current_cycles= LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+		uint32_t delta_cycles = current_cycles - last_announced_cycles;
+		uint32_t elapsed_ticks = delta_cycles / CYCLES_PER_TICK;
+		
+		k_spin_unlock(&lock, key);
+		return elapsed_ticks;
+	} else {
+		return 0;
+	}
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -71,19 +120,43 @@ static void mcux_lptmr_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	cycles += CYCLES_PER_TICK;
+	uint32_t next_compare;
+	uint32_t current;
+	uint32_t delta_ticks = 0U;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	sys_clock_announce(1);
 	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
+
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		current = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+
+		uint32_t delta_cycles;
+
+		delta_cycles = current - last_announced_cycles;
+		delta_ticks = delta_cycles / CYCLES_PER_TICK;
+		last_announced_cycles = current;
+
+		uint32_t next_timeout = MAX_TICKS * CYCLES_PER_TICK;
+		next_compare = current + next_timeout;
+		cycles += delta_cycles;
+	} else {		
+		current = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+		next_compare = current + CYCLES_PER_TICK;
+		cycles += CYCLES_PER_TICK;
+	}
+	k_spin_unlock(&lock, key);
+	LPTMR_SetTimerPeriod(LPTMR_BASE, next_compare);
+	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
 static int sys_clock_driver_init(void)
 {
 	lptmr_config_t config;
+	uint32_t init_compare;
 
 	LPTMR_GetDefaultConfig(&config);
 	config.timerMode = kLPTMR_TimerModeTimeCounter;
-	config.enableFreeRunning = false;
+	config.enableFreeRunning = true;
 	config.prescalerClockSource = LPTMR_CLK_SOURCE;
 	config.bypassPrescaler = (LPTMR_PRESCALER == 0);
 	config.value = (LPTMR_PRESCALER == 0) ? 0 : (LPTMR_PRESCALER - 1);
@@ -94,7 +167,14 @@ static int sys_clock_driver_init(void)
 	irq_enable(LPTMR_IRQN);
 
 	LPTMR_EnableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
-	LPTMR_SetTimerPeriod(LPTMR_BASE, CYCLES_PER_TICK);
+
+	last_announced_cycles = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		init_compare = MAX_TICKS * CYCLES_PER_TICK;
+	} else {
+		init_compare = CYCLES_PER_TICK;
+	}
+	LPTMR_SetTimerPeriod(LPTMR_BASE, init_compare);
 	LPTMR_StartTimer(LPTMR_BASE);
 
 	return 0;


### PR DESCRIPTION
Enhance the MCUX LPTMR timer driver to support tickless kernel mode:

1. Add TICKLESS_CAPABLE selection in Kconfig to enable tickless
   operation for this timer driver.
2. Implement dynamic timeout scheduling in sys_clock_set_timeout()
   that programs the timer compare register based on requested ticks,
   with proper bounds checking (1 to MAX_TICKS).
3. Implement sys_clock_elapsed() to calculate elapsed ticks since
   last announcement by tracking the delta between current and last
   announced cycle counts.
4. Update ISR to handle both tickless and periodic modes:
   - In tickless mode: calculate actual elapsed ticks and schedule
     next interrupt at MAX_TICKS in the future
   - In periodic mode: maintain original single-tick behavior
5. Switch timer to free-running mode to support continuous counting
   and proper wraparound handling for timeout calculations.
6. Add spinlock protection for shared state (cycles counter and
   last_announced_cycles) to ensure thread-safe access.
7. Define MAX_TICKS as half of counter range to prevent overflow
   in timeout calculations.

Signed-off-by: Albort Xue <yao.xue@nxp.com>