### PR TITLE
test: benchmarks: Fix format specifier

### DIFF
--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -11,6 +11,7 @@
 
 #include <zephyr/kernel.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #include "receiver.h"
@@ -25,7 +26,7 @@
 #include <zephyr/timing/timing.h>
 
 /* printf format defines. */
-#define FORMAT "| %-65s|%10llu|\n"
+#define FORMAT "| %-65s|%10"PRIu64"|\n"
 
 /* length of the output line */
 #define SLINE_LEN 256

--- a/tests/benchmarks/app_kernel/src/memmap_b.c
+++ b/tests/benchmarks/app_kernel/src/memmap_b.c
@@ -27,7 +27,7 @@ void memorymap_test(void)
 		alloc_status = k_mem_slab_alloc(&MAP1, &p, K_FOREVER);
 		if (alloc_status != 0) {
 			PRINT_F(FORMAT,
-				"Error: Slab allocation failed.", (int64_t)alloc_status);
+				"Error: Slab allocation failed.", (uint64_t)alloc_status);
 			break;
 		}
 		k_mem_slab_free(&MAP1, p);


### PR DESCRIPTION
uint64_t is not in general unsigned long long int, and therefore its format specifier is not llu in general.
The macro PRIu64 resolves to whatever it is.

For 64bit targets, it is relatively normal for uint64_t to just be unsigned long.
Providing this wrong format specifier results in the build warning:
```
format %llu expects argument of type long long unsigned int, but
argument <x> has type long [unsigned] int
```

The issue can be reproduced by building this test (`tests/benchmarks/app_kernel/ `) with native_sim/native/64.
Issue introduced in da6cd1a474e9ad152f78b18976dbbd6a72b713a9

This fixes 3 failures seen in the weekly run.