### PR TITLE
samples: drivers: i2s: add overlay for rb4342 board

### DIFF
--- a/samples/drivers/i2s/output/boards/siwx917_rb4342a.overlay
+++ b/samples/drivers/i2s/output/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-tx = &i2s0;
+	};
+};
+
+&pinctrl0 {
+	i2s0_default: i2s0_default {
+		out {
+			/* I2S0_CLK_HP25 - P25,  I2S0_DOUT0_HP28 - P31, I2S0_WS_HP26 - P27*/
+			pinmux = <I2S0_CLK_HP25>, <I2S0_DOUT0_HP28>, <I2S0_WS_HP26>;
+		};
+
+		in {
+			/* I2S0_DIN0_HP27 - P29 */
+			pinmux = <I2S0_DIN0_HP27>;
+		};
+	};
+};
+
+&i2s0 {
+	status = "okay";
+	pinctrl-0 = <&i2s0_default>;
+	pinctrl-names = "default";
+
+	dmas = <&dma0 15>, <&dma0 14>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
This patch enables the output sample for the board siwx917_rb4342a by adding an overlay.