### PR TITLE
drivers: spi_nxp_lpspi: simplify `lpspi_rx_buf_write_words`

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -45,14 +45,12 @@ static inline size_t lpspi_rx_buf_write_words(const struct device *dev, uint8_t 
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
-	size_t buf_len = ctx->rx_len;
-	uint8_t words_read = 0;
+	size_t words_read = MIN(ctx->rx_len, (size_t)max_read);
 	size_t offset = 0;
 
-	while (buf_len-- > 0 && max_read-- > 0) {
+	for (size_t i = 0; i < words_read; i++) {
 		lpspi_rx_word_write_bytes(dev, offset);
 		offset += lpspi_data->word_size_bytes;
-		words_read++;
 	}
 
 	return words_read;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -29,7 +29,7 @@ static inline void lpspi_rx_word_write_bytes(const struct device *dev, size_t of
 	uint8_t *buf = ctx->rx_buf + offset;
 	uint32_t word = base->RDR;
 
-	if (!spi_context_rx_buf_on(ctx) && spi_context_rx_on(ctx)) {
+	if (!spi_context_rx_buf_on(ctx)) {
 		/* receive no actual data if rx buf is NULL */
 		return;
 	}


### PR DESCRIPTION
- Refactor `lpspi_rx_buf_write_words()` to compute `words_read` upfront using `MIN(rx_len, max_read)`, simplifying control flow and making the read limit explicit without changing behavior.
- Prevent null pointer dereference in `lpspi_rx_word_write_bytes`
