### PR TITLE
boards: mixrt1170_evk: Add DCD boot header as an option

### DIFF
--- a/boards/nxp/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1170_evk/CMakeLists.txt
@@ -31,10 +31,14 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # if another SDRAM chip is used on your custom board.
     zephyr_library_compile_definitions(XIP_BOOT_HEADER_XMCD_ENABLE=1)
     zephyr_library_sources(xmcd/xmcd.c)
+  elseif (CONFIG_DEVICE_CONFIGURATION_DATA)
+    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+    zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)
       message(WARNING "You are using SDRAM as RAM but no external memory"
-        "configuration data (XMCD) is included. This configuration may not boot")
+        "configuration data (XMCD) or device configuration data (DCD) is
+        included. This configuration may not boot")
     endif()
   endif()
 endif()

--- a/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
@@ -6,8 +6,9 @@
 if BOARD_MIMXRT1170_EVK
 
 # Use External Memory Configuration Data (XMCD) by default when booting primary core (M7)
-config EXTERNAL_MEM_CONFIG_DATA
-	default y if CPU_CORTEX_M7
+choice MEM_CONFIG_DATA
+	default EXTERNAL_MEM_CONFIG_DATA
+endchoice
 
 config NXP_IMX_EXTERNAL_SDRAM
 	default y if CPU_CORTEX_M7

--- a/soc/nxp/imxrt/Kconfig
+++ b/soc/nxp/imxrt/Kconfig
@@ -100,6 +100,10 @@ config IMAGE_VECTOR_TABLE_OFFSET
 	  the application entry point and device configuration data. The boot
 	  ROM requires a fixed IVT offset for each type of boot device.
 
+choice MEM_CONFIG_DATA
+	bool "MEM_CONFIG_DATA"
+	default EXTERNAL_MEM_CONFIG_DATA
+
 config DEVICE_CONFIGURATION_DATA
 	bool "Device configuration data"
 	help
@@ -110,7 +114,6 @@ config DEVICE_CONFIGURATION_DATA
 
 config EXTERNAL_MEM_CONFIG_DATA
 	bool "External Memory Configuration Data"
-	depends on !DEVICE_CONFIGURATION_DATA
 	help
 	  External memory configuration data (XMDC) provides an alternative
 	  configuration sequences which allows to intilialize the external memory
@@ -118,6 +121,8 @@ config EXTERNAL_MEM_CONFIG_DATA
 	  external memories (such as SDRAM) with more advanced option.
 	  This is a new alternative boot header compared to DCD, and DCD must be disabled
 	  in order to select this option.
+
+endchoice
 
 config EXTERNAL_MEM_CONFIG_OFFSET
 	hex "External memory configuration offset"


### PR DESCRIPTION
This PR adds DCD boot header support for RT1170

Previously, the option to use a DCD boot header for SDRAM configuration was removed. This PR reintroduces that option, allowing users to select it as needed.

The reason for this PR is that the XMCD boot header has proven to be less stable and can lead to hard faults. In our testing, applications using the DCD boot header did not have this issue, making it a more reliable choice.