### PR TITLE
boards: renesas: ek_ra4l1: added mikrobus node labels

### DIFF
--- a/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1-pinctrl.dtsi
@@ -4,6 +4,14 @@
  */
 
 &pinctrl {
+	sci1_default: sci1_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_1, 1, 15)>,
+				<RA_PSEL(RA_PSEL_SCI_1, 6, 8)>;
+		};
+	};
+
 	sci5_default: sci5_default {
 		group1 {
 			/* tx rx */

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.dts
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.dts
@@ -44,6 +44,29 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &ioport5 10 0>,	/* AN  */
+			   <1 0 &ioport1 13 0>,	/* RST */
+			   <2 0 &ioport2 4 0>,	/* CS   */
+			   <3 0 &ioport2 9 0>,	/* SCK  */
+			   <4 0 &ioport2 10 0>,	/* MISO */
+			   <5 0 &ioport2 11 0>,	/* MOSI */
+			   /* +3.3V */
+			   /* GND */
+			   <6 0 &ioport4 5 0>,	/* PWM  */
+			   <7 0 &ioport4 3 0>,	/* INT  */
+			   <8 0 &ioport6 8 0>,	/* RX   */
+			   <9 0 &ioport1 15 0>,	/* TX   */
+			   <10 0 &ioport4 0 0>,	/* SCL  */
+			   <11 0 &ioport4 1 0>;	/* SDA  */
+		/* +5V */
+		/* GND */
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 
@@ -110,6 +133,19 @@
 	status = "okay";
 };
 
+&sci1 {
+	pinctrl-0 = <&sci1_default>;
+	pinctrl-names = "default";
+	interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	uart1: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};
+
 &sci5 {
 	pinctrl-0 = <&sci5_default>;
 	pinctrl-names = "default";
@@ -126,6 +162,10 @@
 };
 
 &ioport1 {
+	status = "okay";
+};
+
+&ioport2 {
 	status = "okay";
 };
 
@@ -230,3 +270,5 @@
 &crc {
 	status = "okay";
 };
+
+mikrobus_serial: &uart1 {};


### PR DESCRIPTION
Added mikrobus_serial and mikrobus_header node labels to EK-RA4L1 device tree board definition, allowing compatible shield boards to be used.