### PR TITLE
dts: bindings: serial: pl011: `interrupts` are not always required.

### DIFF
--- a/dts/bindings/serial/arm,pl011.yaml
+++ b/dts/bindings/serial/arm,pl011.yaml
@@ -8,9 +8,6 @@ properties:
   reg:
     required: true
 
-  interrupts:
-    required: true
-
   fifo-disable:
     type: boolean
     description: Disable the UART FIFO


### PR DESCRIPTION
There are cases where the device can operate by polling without using interrupts, so `interrupts` are not mark as required.