### PR TITLE
lib: posix: Add shared multi-heap support for pthread stacks.

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -551,6 +551,23 @@ int pthread_spin_unlock(pthread_spinlock_t *lock);
 
 #endif
 
+#ifdef CONFIG_SHARED_MULTI_HEAP
+/**
+ * @brief Set if a pthread attr_t's stack is in the
+ *        shared multi-heap.
+ *
+ * Sets the insmh property, which is used to determine
+ * the free method of the attr's block.
+ * pthread_attr_setstack should be called beforehand.
+ *
+ * @param attr pthread_attr_t to modify
+ * @param val value to set insmh to
+ * @retval 0 Success
+ * @retval EINVAL attr is not initialized
+ */
+int pthread_attr_setinsmh(pthread_attr_t *_attr, bool val);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/posix/options/posix_internal.h
+++ b/lib/posix/options/posix_internal.h
@@ -44,6 +44,9 @@ struct posix_thread_attr
 	bool cancelstate: 1;
 	bool canceltype: 1;
 	bool detachstate: 1;
+#ifdef CONFIG_SHARED_MULTI_HEAP
+	bool insmh: 1;
+#endif
 };
 
 struct posix_thread {


### PR DESCRIPTION
This adds the attribute `insmh` to `struct posix_thread_attr` that should be set to `true` when the pthread stack is allocated in the shared multi-heap, and should otherwise be `false`. This also modifies `pthread_attr_destroy` such that the correct free method is used based on `insmh`. This also adds the function `pthread_attr_setinsmh` to set `insmh`. The following sequence or similar should be used when initializing a pthread with a stack in the shared multi-heap:
```
pthread_attr_init(&attr);
if ((pthread_stack = shared_multi_heap_alloc(SMH_REG_ATTR_EXTERNAL, stack_size)) == NULL)
goto out;

pthread_attr_setstack(&attr, pthread_stack, stack_size);
pthread_attr_setinsmh(&attr, true);
err = pthread_create(&top_th, &attr, func, NULL);
```

This is the second of two main changes that I made to the Zephyr libraries for my Google Summer of Code 2025 [project](https://summerofcode.withgoogle.com/archive/2025/projects/f9CKDFJW). The applications I was porting made frequent use of pthreads but were also very memory-demanding. Therefore, I decided to allow the use of external memory in the shared multi-heap for pthread stacks. This feature is currently tied to `CONFIG_SHARED_MULTI_HEAP`, but a new Kconfig option can be added if needed.