### PR TITLE
drivers: gpio: infineon: remove redundant NULL check in ISR

### DIFF
--- a/drivers/gpio/gpio_infineon.c
+++ b/drivers/gpio/gpio_infineon.c
@@ -172,10 +172,7 @@ static void gpio_isr_handler(const struct device *dev)
 		Cy_GPIO_ClearInterrupt(base, i);
 	}
 
-	if (dev) {
-		gpio_fire_callbacks(&((struct gpio_cat1_data *const)(dev)->data)->callbacks, dev,
-				    pins);
-	}
+	gpio_fire_callbacks(&((struct gpio_cat1_data *const)(dev)->data)->callbacks, dev, pins);
 }
 #endif
 


### PR DESCRIPTION
Remove a redundant NULL check on the device pointer in the GPIO interrupt handler.

The device pointer is dereferenced unconditionally before the check and cannot be NULL in this context.

No functional change intended.