### PR TITLE
bluetooth: classic: GOEP: fix L2CAP MTU calculation

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -50,11 +50,17 @@ config BT_BUF_ACL_TX_COUNT
 
 config BT_BUF_ACL_RX_SIZE
 	int "Maximum supported ACL size for incoming data"
-	# For GOEP over RFCOMM, including,
+	# For GOEP over RFCOMM, the minimum MTU of GOEP is 264, including,
 	# 255 bytes - the minimum MTU of GOEP,
 	# 4 bytes - L2CAP Header,
 	# 5 bytes - 4 bytes for RFCOMM header with extended length, 1 byte for FCS.
-	default 264 if BT_CLASSIC && BT_GOEP
+	# For GOEP over L2CAP, the minimum MTU of GOEP is 265, including,
+	# 255 bytes - the minimum MTU of GOEP,
+	# 4 bytes - L2CAP Header,
+	# 6 bytes - Field length of L2CAP I-frame, including,
+	#   4 bytes - extended control field,
+	#   2 bytes - FCS field.
+	default 265 if BT_CLASSIC && BT_GOEP
 	default 200 if BT_CLASSIC
 	default 70 if BT_EATT
 	default 69 if BT_SMP

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -685,7 +685,10 @@ config BT_GOEP_L2CAP_MTU
 	# For GOEP over L2CAP, including,
 	# 255 bytes - the minimum MTU of GOEP,
 	# 4 bytes - L2CAP Header,
-	range 259 BT_BUF_ACL_RX_SIZE
+	# 6 bytes - Field length of L2CAP I-frame, including,
+	#   4 bytes - extended control field,
+	#   2 bytes - FCS field.
+	range 265 BT_BUF_ACL_RX_SIZE
 	help
 	  Maximum size of L2CAP MTU for GOEP.
 	  RX MTU will be truncated to account for ACL data and type overhead, and the L2CAP PDU


### PR DESCRIPTION
Correct the minimum MTU calculation for GOEP over L2CAP to account for the L2CAP I-frame overhead.

- Update BT_BUF_ACL_RX_SIZE default from 264 to 265 bytes for GOEP
- Update BT_GOEP_L2CAP_MTU minimum range from 259 to 265 bytes
- Add detailed comment explaining L2CAP I-frame field length (6 bytes):
  * 4 bytes for extended control field
  * 2 bytes for FCS field

The previous calculation only accounted for the L2CAP header (4 bytes) but missed the 6-byte L2CAP I-frame overhead (extended control field and FCS), resulting in an incorrect minimum of 264 bytes instead of the correct 265 bytes. And it causes the minimum MTU of L2CAP to be incorrectly set to 254. The MTU cannot meet the minimum requirement of GOEP MOPL.

The correct calculation for GOEP over L2CAP is:
255 bytes (GOEP minimum MTU) + 4 bytes (L2CAP header) + 6 bytes (L2CAP I-frame) = 265 bytes total.

Set the default value of CONFIG_BT_BUF_ACL_RX_SIZE to 265 if GOEP is enabled.