### PR TITLE
bluetooth: classic: GOEP: refactor L2CAP and RFCOMM initialization

### DIFF
--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -159,13 +159,52 @@ static const struct bt_obex_transport_ops goep_rfcomm_transport_ops = {
 	.disconnect = goep_rfcomm_disconnect,
 };
 
+static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
+{
+	uint32_t mtu;
+	uint32_t hdr_size;
+	int err;
+
+	hdr_size = sizeof(struct bt_l2cap_hdr);
+	hdr_size += BT_RFCOMM_HDR_SIZE + BT_RFCOMM_FCS_SIZE;
+
+	mtu = CONFIG_BT_GOEP_RFCOMM_MTU - hdr_size;
+	/* Use default MTU if it is not given */
+	if (goep->obex.rx.mtu == 0) {
+		goep->obex.rx.mtu = mtu;
+	}
+
+	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
+		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
+			GOEP_MIN_MTU);
+		goep->obex.rx.mtu = GOEP_MIN_MTU;
+	}
+
+	if (goep->obex.rx.mtu > mtu) {
+		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
+		goep->obex.rx.mtu = mtu;
+	}
+
+	err = bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
+	if (err != 0) {
+		LOG_ERR("Fail to reg transport ops");
+		return err;
+	}
+
+	goep->_goep_v2 = false;
+	goep->_acl = conn;
+	goep->_transport.dlc.mtu = goep->obex.rx.mtu;
+	goep->_transport.dlc.ops = &goep_rfcomm_ops;
+	goep->_transport.dlc.required_sec_level = BT_SECURITY_L2;
+
+	return 0;
+}
+
 static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
 			      struct bt_rfcomm_dlc **dlc)
 {
 	struct bt_goep_transport_rfcomm_server *rfcomm_server;
 	struct bt_goep *goep;
-	uint32_t mtu;
-	uint32_t hdr_size;
 	int err;
 
 	rfcomm_server = CONTAINER_OF(server, struct bt_goep_transport_rfcomm_server, rfcomm);
@@ -186,38 +225,13 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 		return -EINVAL;
 	}
 
-	hdr_size = sizeof(struct bt_l2cap_hdr);
-	hdr_size += BT_RFCOMM_HDR_SIZE + BT_RFCOMM_FCS_SIZE;
-
-	mtu = CONFIG_BT_GOEP_RFCOMM_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (!goep->obex.rx.mtu) {
-		goep->obex.rx.mtu = mtu;
-	}
-
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
-	}
-
-	err = bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
-	if (err) {
-		LOG_WRN("Fail to reg transport ops");
+	err = goep_rfcomm_init(conn, goep);
+	if (err != 0) {
+		LOG_ERR("Fail to init goep");
 		return err;
 	}
 
-	goep->_goep_v2 = false;
-	goep->_acl = conn;
 	*dlc = &goep->_transport.dlc;
-	goep->_transport.dlc.mtu = goep->obex.rx.mtu;
-	goep->_transport.dlc.ops = &goep_rfcomm_ops;
-	goep->_transport.dlc.required_sec_level = BT_SECURITY_L2;
 
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTING);
 
@@ -254,49 +268,21 @@ int bt_goep_transport_rfcomm_server_register(struct bt_goep_transport_rfcomm_ser
 int bt_goep_transport_rfcomm_connect(struct bt_conn *conn, struct bt_goep *goep, uint8_t channel)
 {
 	int err;
-	uint32_t mtu;
-	uint32_t hdr_size;
 
 	if (conn == NULL || goep == NULL || goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
 
-	hdr_size = sizeof(struct bt_l2cap_hdr);
-	hdr_size += BT_RFCOMM_HDR_SIZE + BT_RFCOMM_FCS_SIZE;
-
-	mtu = CONFIG_BT_GOEP_RFCOMM_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (!goep->obex.rx.mtu) {
-		goep->obex.rx.mtu = mtu;
-	}
-
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
-	}
-
-	err = bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
-	if (err) {
-		LOG_WRN("Fail to reg transport ops");
+	err = goep_rfcomm_init(conn, goep);
+	if (err != 0) {
+		LOG_ERR("Fail to init goep");
 		return err;
 	}
 
-	goep->_goep_v2 = false;
-	goep->_acl = conn;
-	goep->_transport.dlc.mtu = goep->obex.rx.mtu;
-	goep->_transport.dlc.ops = &goep_rfcomm_ops;
-	goep->_transport.dlc.required_sec_level = BT_SECURITY_L2;
-
 	err = bt_rfcomm_dlc_connect(conn, &goep->_transport.dlc, channel);
-	if (err) {
-		LOG_WRN("Fail to create RFCOMM connection");
+	if (err != 0) {
+		LOG_ERR("Fail to create RFCOMM connection");
 		return err;
 	}
 

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -1,7 +1,7 @@
 /* goep.c - Bluetooth Generic Object Exchange Profile handling */
 
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -467,13 +467,63 @@ static const struct bt_obex_transport_ops goep_l2cap_transport_ops = {
 	.disconnect = goep_l2cap_disconnect,
 };
 
+static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
+{
+	uint32_t mtu;
+	uint32_t hdr_size;
+	int err;
+
+	hdr_size = sizeof(struct bt_l2cap_hdr);
+
+	mtu = CONFIG_BT_GOEP_L2CAP_MTU - hdr_size;
+	/* Use default MTU if it is not given */
+	if (goep->obex.rx.mtu == 0) {
+		goep->obex.rx.mtu = mtu;
+	}
+
+	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
+		LOG_WRN("GOEP L2CAP MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
+			GOEP_MIN_MTU);
+		goep->obex.rx.mtu = GOEP_MIN_MTU;
+	}
+
+	if (goep->obex.rx.mtu > mtu) {
+		LOG_WRN("GOEP L2CAP MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
+		goep->obex.rx.mtu = mtu;
+	}
+
+	err = bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
+	if (err != 0) {
+		LOG_ERR("Fail to reg transport ops");
+		return err;
+	}
+
+	goep->_goep_v2 = true;
+	goep->_acl = conn;
+	goep->_transport.chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
+	goep->_transport.chan.rx.optional = false;
+	goep->_transport.chan.rx.max_transmit = 3;
+	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
+	goep->_transport.chan.rx.extended_control = false;
+	/*
+	 * There is an issue found that the FCS option is not correctly set when connecting to an
+	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
+	 * option will be applied while the 'No FCS' option is not added in an
+	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
+	 * Force 16 bits FCS option for enhance retransmission mode by default.
+	 */
+	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
+	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
+	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
+
+	return 0;
+}
+
 static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 			     struct bt_l2cap_chan **chan)
 {
 	struct bt_goep_transport_l2cap_server *l2cap_server;
 	struct bt_goep *goep;
-	uint32_t mtu;
-	uint32_t hdr_size;
 	int err;
 
 	l2cap_server = CONTAINER_OF(server, struct bt_goep_transport_l2cap_server, l2cap);
@@ -494,50 +544,13 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 		return -EINVAL;
 	}
 
-	hdr_size = sizeof(struct bt_l2cap_hdr);
-
-	mtu = CONFIG_BT_GOEP_L2CAP_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (!goep->obex.rx.mtu) {
-		goep->obex.rx.mtu = mtu;
-	}
-
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
-	}
-
-	err = bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
-	if (err) {
-		LOG_WRN("Fail to reg transport ops");
+	err = goep_l2cap_init(conn, goep);
+	if (err != 0) {
+		LOG_ERR("Fail to init goep");
 		return err;
 	}
 
-	goep->_goep_v2 = true;
-	goep->_acl = conn;
 	*chan = &goep->_transport.chan.chan;
-	goep->_transport.chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
-	goep->_transport.chan.rx.optional = false;
-	goep->_transport.chan.rx.max_transmit = 3;
-	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
-	goep->_transport.chan.rx.extended_control = false;
-	/*
-	 * There is an issue found that the FCS option is not correctly set when connecting to an
-	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
-	 * option will be applied while the 'No FCS' option is not added in an
-	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
-	 * Force 16 bits FCS option for enhance retransmission mode by default.
-	 */
-	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
-	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
-	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
-
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTING);
 
 	return 0;
@@ -574,8 +587,6 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 {
 	int err;
 	uint32_t state;
-	uint32_t mtu;
-	uint32_t hdr_size;
 
 	if (conn == NULL || goep == NULL || goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
@@ -588,52 +599,15 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 		return -EBUSY;
 	}
 
-	hdr_size = sizeof(struct bt_l2cap_hdr);
-
-	mtu = CONFIG_BT_GOEP_L2CAP_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (!goep->obex.rx.mtu) {
-		goep->obex.rx.mtu = mtu;
-	}
-
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
-	}
-
-	err = bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
-	if (err) {
-		LOG_WRN("Fail to reg transport ops");
+	err = goep_l2cap_init(conn, goep);
+	if (err != 0) {
+		LOG_ERR("Fail to init goep");
 		return err;
 	}
 
-	goep->_goep_v2 = true;
-	goep->_acl = conn;
-	goep->_transport.chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
-	goep->_transport.chan.rx.optional = false;
-	goep->_transport.chan.rx.max_transmit = 3;
-	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
-	goep->_transport.chan.rx.extended_control = false;
-	/*
-	 * There is an issue found that the FCS option is not correctly set when connecting to an
-	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
-	 * option will be applied while the 'No FCS' option is not added in an
-	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
-	 * Force 16 bits FCS option for enhance retransmission mode by default.
-	 */
-	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
-	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
-	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
-
 	err = bt_l2cap_chan_connect(conn, &goep->_transport.chan.chan, psm);
-	if (err) {
-		LOG_WRN("Fail to create L2CAP connection");
+	if (err != 0) {
+		LOG_ERR("Fail to create L2CAP connection");
 		return err;
 	}
 


### PR DESCRIPTION
* bluetooth: classic: GOEP: refactor L2CAP initialization

Extract common GOEP L2CAP initialization logic into a separate function to eliminate code duplication between accept and connect paths.

- Add new goep_l2cap_init() function containing shared initialization:
  * MTU calculation and validation
  * Transport operations registration
  * L2CAP channel configuration
  * GOEP state setup
- Update goep_l2cap_accept() to use the new init function
- Update bt_goep_transport_l2cap_connect() to use the new init function

This refactoring reduces code duplication and ensures consistent initialization behavior for both server (accept) and client (connect) code paths.

* bluetooth: classic: GOEP: refactor RFCOMM initialization

Extract common GOEP RFCOMM initialization logic into a separate function to eliminate code duplication between accept and connect paths.

- Add new goep_rfcomm_init() function containing shared initialization:
  * MTU calculation and validation
  * Transport operations registration
  * RFCOMM DLC configuration
  * GOEP state setup
- Update goep_rfcomm_accept() to use the new init function
- Update bt_goep_transport_rfcomm_connect() to use the new init function

This refactoring reduces code duplication and ensures consistent initialization behavior for both server (accept) and client (connect) code paths.
