### PR TITLE
scripts: build: Accept python object in Domain's constructor

### DIFF
--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 Intel Corporation
+# Copyright 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -174,7 +175,7 @@ def test_get_domains(
     default_flash_order,
     expected_result,
 ):
-    doms = domains.Domains(
+    doms = domains.Domains.from_yaml(
         """
 domains:
 - name: dummy
@@ -225,7 +226,7 @@ def test_get_domain(
     expected_logs,
     expected_result,
 ):
-    doms = domains.Domains(
+    doms = domains.Domains.from_yaml(
         """
 domains:
 - name: dummy

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -153,14 +153,17 @@ def load_domains(path):
     domains_file = Path(path) / 'domains.yaml'
 
     if not domains_file.is_file():
-        return Domains.from_yaml(f'''\
-default: app
-build_dir: {path}
-domains:
-  - name: app
-    build_dir: {path}
-flash_order:
-  - app
-''')
+        default_domains = {
+            "default": "app",
+            "build_dir": path,
+            "domains": [
+                {
+                    "name": "app",
+                    "build_dir": path
+                }
+            ],
+            "flash_order": ["app"]
+        }
+        return Domains(default_domains)
 
     return Domains.from_file(domains_file)


### PR DESCRIPTION
When the build dir is numeric, yaml parser will coerce it as number type. Then it will volatile the schema of `domains.yaml`,
```bash
build_helpers - CRITICAL - malformed domains.yaml
```