### PR TITLE
logging: Fix backoff calculation to use K_CYC instead of K_TICK

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -759,9 +759,9 @@ union log_msg_generic *z_log_msg_claim_oldest(k_timeout_t *backoff)
 				* long processing shall back off.
 				*/
 				if (timestamp_freq == sys_clock_hw_cycles_per_sec()) {
-					*backoff = K_TICKS(diff);
+					*backoff = K_CYC(diff);
 				} else {
-					*backoff = K_TICKS((diff * sys_clock_hw_cycles_per_sec()) /
+					*backoff = K_CYC((diff * sys_clock_hw_cycles_per_sec()) /
 							timestamp_freq);
 				}
 


### PR DESCRIPTION
in sample:
zephyr\samples\subsys\logging\multidomain\
my .config is 
```
CONFIG_LOG_TIMESTAMP_64BIT=y
#define CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC 64000000
#define CONFIG_SYS_CLOCK_TICKS_PER_SEC 10000

```

The backoff timeout calculation in z_log_msg_claim_oldest() was incorrectly using K_TICK macro. Changed to K_CYC to properly convert cycle-based timing differences to kernel timeouts for accurate backoff in multi-domain message processing.

```
static log_timestamp_t default_get_timestamp(void)
{
	return IS_ENABLED(CONFIG_LOG_TIMESTAMP_64BIT) ?
		sys_clock_tick_get() : k_cycle_get_32();
}

static log_timestamp_t default_lf_get_timestamp(void)
{
	return IS_ENABLED(CONFIG_LOG_TIMESTAMP_64BIT) ?
		k_uptime_get() : k_uptime_get_32();
}
```

in log_core_init:
```

	if (sys_clock_hw_cycles_per_sec() > 1000000) {
		log_set_timestamp_func(default_lf_get_timestamp, 1000U);
	} else {
		uint32_t freq = IS_ENABLED(CONFIG_LOG_TIMESTAMP_64BIT) ?
			CONFIG_SYS_CLOCK_TICKS_PER_SEC : sys_clock_hw_cycles_per_sec();
		log_set_timestamp_func(default_get_timestamp, freq);
	}
```
1.  if sys_clock_hw_cycles_per_sec < 1000000 and  CONFIG_LOG_TIMESTAMP_64BIT=n, 
    freq == sys_clock_hw_cycles_per_sec.
default_get_timestamp get from `k_cycle_get_32`, k_cycle_get_32 return cycle.
so timestamp_func is cycle , *backoff = K_CYC(diff);
3.  if sys_clock_hw_cycles_per_sec > 1000000
    timestamp_freq = 1000
    freq != sys_clock_hw_cycles_per_sec
default_lf_get_timestamp get value from k_uptime_get or k_uptime_get_32, the unit is ms.
So diff is ms, diff * sys_clock_hw_cycles_per_sec()) / timestamp_freq the unit is cycle. 
```
*backoff = K_CYC((diff * sys_clock_hw_cycles_per_sec()) /timestamp_freq);
```
3.  sys_clock_hw_cycles_per_sec() < 1000000
and CONFIG_LOG_TIMESTAMP_64BIT=y
freq != sys_clock_hw_cycles_per_sec 

default_get_timestamp from sys_clock_tick_get(), unit is tick.
timestamp_freq = CONFIG_SYS_CLOCK_TICKS_PER_SEC 
so 
```
*backoff = K_CYC((diff * sys_clock_hw_cycles_per_sec()) /CONFIG_SYS_CLOCK_TICKS_PER_SEC);
```
K_CYC is right. K_TICK is incorrect.
