### PR TITLE
bluetooth: classic: obex: fix abort response handling for last client

### DIFF
--- a/include/zephyr/bluetooth/classic/obex.h
+++ b/include/zephyr/bluetooth/classic/obex.h
@@ -1,7 +1,7 @@
 /* obex.h - IrDA Oject Exchange Protocol handling */
 
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -598,6 +598,9 @@ struct bt_obex {
 
 	/** @internal OBEX executing client */
 	atomic_ptr_t _active_client;
+
+	/** @internal OBEX last executed client */
+	atomic_ptr_t _last_client;
 
 	/** @internal OBEX executing client */
 	atomic_ptr_t _active_server;


### PR DESCRIPTION
Fix OBEX abort response handling when no active client exists by tracking the last executing client and its previous opcode.

- Add _last_client pointer to track the most recent executing client
- Add _pre_opcode to store the opcode before clearing _opcode
- Save client state before clearing opcode in all operation handlers
- Implement obex_get_last_client() to recover client context for abort
- Handle abort responses even when _active_client is already cleared
- Clear last client tracking on transport connect/disconnect

This ensures abort responses are properly delivered to the correct client callback even if the operation has already completed.