### PR TITLE
sensor: tmp1075: guard optional devicetree properties

### DIFF
--- a/dts/bindings/sensor/ti,tmp1075.yaml
+++ b/dts/bindings/sensor/ti,tmp1075.yaml
@@ -11,13 +11,17 @@ include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   conversion-rate:
-    description: Conversion rate in us.
+    description: |
+      Conversion rate in us.
+      Defaults to 27500 us (27.5 ms), which matches the hardware
+      power-on reset value per the TMP1075 datasheet.
     type: int
     enum:
       - 27500 # 27.5ms
       - 55000 # 55ms
       - 110000 # 110ms
       - 220000 # 220ms
+    default: 27500
   alert-gpios:
     type: phandle-array
     description: |
@@ -27,13 +31,17 @@ properties:
     description: One-shot conversion mode.
     type: boolean
   consecutive-fault-measurements:
-    description: Number of consecutive measured faults that will trigger the alert.
+    description: |
+      Number of consecutive measured faults that will trigger the alert.
+      Defaults to 1, which matches the hardware power-on reset value
+      per the TMP1075 datasheet.
     type: int
     enum:
       - 1
       - 2
       - 3
       - 4
+    default: 1
   alert-pin-active-high:
     description: Polarity of the alert pin.
     type: boolean


### PR DESCRIPTION
The TMP1075 driver accessed optional devicetree properties (conversion-rate and consecutive-fault-measurements) using DT_INST_ENUM_IDX(), which causes build failures when the properties are not present in the devicetree.

Guard the accesses using DT_INST_NODE_HAS_PROP() and fall back to default values when the properties are missing, aligning the driver implementation with the binding definition.

No behavior change when the properties are present.