### PR TITLE
tests: drivers: adc: adc_api: Enable adc node for Adafruit trinket m0

### DIFF
--- a/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
+++ b/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
@@ -13,6 +13,7 @@
 };
 
 &adc {
+	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 


### PR DESCRIPTION
Enable the adc node to prevent undefined node reference error in adc_api test.

Fixes issue in weekly CI run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/20403530595/job/58629493133#step:14:3728