### PR TITLE
boards: infineon: Correct uart compatible name

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
@@ -23,7 +23,7 @@
 };
 
 uart0: &scb0 {
-	compatible = "infineon,cat1-uart";
+	compatible = "infineon,uart";
 	status = "okay";
 	current-speed = <115200>;
 	clocks = <&peri0_group0_16bit_0>;

--- a/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.cm0p.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.cm0p.dtsi
@@ -28,7 +28,7 @@
 
 		/* Pinctrl node for Infineon PSOC4 SoC */
 		pinctrl0: pinctrl@40310000 {
-			compatible = "infineon,cat1-pinctrl";
+			compatible = "infineon,pinctrl";
 			reg = <0x40310000 0x1000>;
 			status = "okay";
 		};

--- a/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.dtsi
@@ -23,7 +23,7 @@
 
 	soc {
 		pinctrl: pinctrl@40020000 {
-			compatible = "infineon,cat1-pinctrl";
+			compatible = "infineon,pinctrl";
 			reg = <0x40020000 0x24000>;
 		};
 


### PR DESCRIPTION
Correct the non-existing infineon,cat1-uart compatible string and pinctrl for it.

Found by weekly CI run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/20403530595/job/58629493151#step:14:4185

`west twister -p cy8cproto_041tp/cy8c4147azq_t495 -s subsys.crc`