### PR TITLE
Drivers: Silabs: Kconfig: replace 'depends on DMA' with 'select DMA'

### DIFF
--- a/drivers/adc/Kconfig.silabs
+++ b/drivers/adc/Kconfig.silabs
@@ -25,7 +25,8 @@ if ADC_SILABS_IADC
 
 config ADC_SILABS_IADC_DMA
 	bool "Silabs IADC async DMA support"
-	depends on DMA
+	select DMA
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SILABS_IADC),dmas)
 	help
 	  Enable DMA support with the Silabs IADC driver.
 	  This allows ADC conversions to be performed (asynchronously or not)

--- a/drivers/flash/Kconfig.silabs
+++ b/drivers/flash/Kconfig.silabs
@@ -17,11 +17,13 @@ if SOC_FLASH_SILABS_S2
 
 config SOC_FLASH_SILABS_S2_DMA_WRITE
 	bool "Use DMA for flash write operations"
-	depends on DMA
-	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_SILABS_SERIES2_FLASH_CONTROLLER),dmas)
+	default y
+	select DMA
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SILABS_SERIES2_FLASH_CONTROLLER),dmas)
 
 config SOC_FLASH_SILABS_S2_DMA_READ
 	bool "Use DMA for flash read operations"
-	depends on DMA
+	select DMA
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SILABS_SERIES2_FLASH_CONTROLLER),dmas)
 
 endif


### PR DESCRIPTION
When a driver requires the usage of a low level driver subsystem (like SPI, I2C, DMA...), it shall enable it instead of depending on it.

Also, make DMA usage depend on its DT properties being defined.