### PR TITLE
drivers: clock_control: renesas_ra_cgc: fix NULL subsys handling + Fix typo in api name

### DIFF
--- a/drivers/clock_control/clock_control_renesas_ra_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc.c
@@ -114,7 +114,7 @@ static int clock_control_ra_init(const struct device *dev)
 	return 0;
 }
 
-static DEVICE_API(clock_control, clock_control_reneas_ra_api) = {
+static DEVICE_API(clock_control, clock_control_renesas_ra_api) = {
 	.on = clock_control_renesas_ra_on,
 	.off = clock_control_renesas_ra_off,
 	.get_rate = clock_control_renesas_ra_get_rate,
@@ -131,7 +131,7 @@ static DEVICE_API(clock_control, clock_control_reneas_ra_api) = {
 		    DEVICE_DT_DEFINE(node_id, &clock_control_ra_init_pclk, NULL, NULL,             \
 				     &node_id##_cfg, PRE_KERNEL_1,                                 \
 				     CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,                          \
-				     &clock_control_reneas_ra_api)));
+				     &clock_control_renesas_ra_api)));
 
 DEVICE_DT_DEFINE(DT_NODELABEL(pclkblock), &clock_control_ra_init, NULL, NULL, NULL, PRE_KERNEL_1,
 		 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS, NULL);

--- a/drivers/clock_control/clock_control_renesas_ra_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc.c
@@ -49,7 +49,9 @@ static int clock_control_renesas_ra_on(const struct device *dev, clock_control_s
 {
 	struct clock_control_ra_subsys_cfg *subsys_clk = (struct clock_control_ra_subsys_cfg *)sys;
 
-	if (!dev || !sys) {
+	ARG_UNUSED(dev);
+
+	if (!subsys_clk) {
 		return -EINVAL;
 	}
 	WRITE_BIT(*mstp_regs[subsys_clk->mstp], subsys_clk->stop_bit, false);
@@ -60,7 +62,9 @@ static int clock_control_renesas_ra_off(const struct device *dev, clock_control_
 {
 	struct clock_control_ra_subsys_cfg *subsys_clk = (struct clock_control_ra_subsys_cfg *)sys;
 
-	if (!dev || !sys) {
+	ARG_UNUSED(dev);
+
+	if (!subsys_clk) {
 		return -EINVAL;
 	}
 
@@ -77,7 +81,7 @@ static int clock_control_renesas_ra_get_rate(const struct device *dev, clock_con
 	uint32_t clk_src_rate;
 	uint32_t clk_div_val;
 
-	if (!dev || !rate) {
+	if (!rate) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Commit 1 :
Fix unsafe handling of the clock control subsystem pointer.

The subsystem argument was cast before being validated, which could
lead to invalid memory access when NULL is passed.

Rework the on/off callbacks to validate the subsystem pointer before
casting it, drop unnecessary device checks, and mark the device
argument as unused.

Also simplify get_rate() validation by checking only the rate
pointer.

Commit 2 :
Fix a typo in the Renesas RA clock control API symbol name.