### PR TITLE
scripts: tests: twister: mock listed serial ports to reduce test time by ~300 seconds

### DIFF
--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1473,10 +1473,18 @@ def test_devicehandler_handle(
     openpty_mock = mock.Mock(return_value=('master', 'slave'))
     ttyname_mock = mock.Mock(side_effect=lambda x: x + ' name')
 
+    lp_mock = SimpleNamespace(
+        comports=mock.Mock(return_value=[
+            SimpleNamespace(name='dummy serial'),
+            SimpleNamespace(name='slave name'),
+        ])
+    )
+
     with mock.patch('builtins.open', mock.mock_open(read_data='')), \
          mock.patch('subprocess.Popen', side_effect=mock_popen), \
          mock.patch('threading.Event', mock.Mock()), \
          mock.patch('threading.Thread', side_effect=mock_thread), \
+         mock.patch('twisterlib.handlers.list_ports', lp_mock, create=True), \
          mock.patch('pty.openpty', openpty_mock), \
          mock.patch('os.ttyname', ttyname_mock):
         handler.handle(harness)


### PR DESCRIPTION
Noticed this while working on another test in this folder for https://github.com/zephyrproject-rtos/zephyr/issues/101592 

Reduce the test time by ~300 seconds by mocking the listed serial port

Result from running:
`pytest --durations=0 ./scripts/tests/twister/test_handlers.py`

Before:
```
60.12s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[valid pty]
60.12s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[communicate timeout]
60.06s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[popen called process error]
60.05s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[valid dev]
60.03s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[nonzero returncode]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[create serial failure]
```

After:
```
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[valid dev]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[valid pty]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[nonzero returncode]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[create serial failure]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[communicate timeout]
0.01s call     scripts/tests/twister/test_handlers.py::test_devicehandler_handle[popen called process error]
```