### PR TITLE
soc: st: stm32: h7rsxx: Add MPU region on OTP area

### DIFF
--- a/soc/st/stm32/stm32h7rsx/mpu_regions.c
+++ b/soc/st/stm32/stm32h7rsx/mpu_regions.c
@@ -34,14 +34,17 @@ static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 3 */
 	MPU_REGION_ENTRY("SRAM_0", CONFIG_SRAM_BASE_ADDRESS, REGION_RAM_ATTR(REGION_SRAM_SIZE)),
 
-	/* Region 4 - Ready only flash with unique device id, package code and VREF/TS calib*/
+	/* Region 4 - OTP area */
+	MPU_REGION_ENTRY("OTP", 0x08FFF000, REGION_IO_ATTR(REGION_1K)),
+
+	/* Region 5 - Read-only area provisioned by ST */
 	MPU_REGION_ENTRY("ID", 0x08FFF800, REGION_IO_ATTR(REGION_512B)),
 
 #if defined(sram_eth_node) && DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
-	/* Region 5 - Ethernet DMA buffer RAM */
+	/* Region 6 - Ethernet DMA buffer RAM */
 	MPU_REGION_ENTRY("SRAM_ETH_BUF", DT_REG_ADDR(sram_eth_node),
 			 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
-	/* Region 6 - Ethernet DMA descriptor RAM (overlays the first 256B of SRAM_ETH_BUF)*/
+	/* Region 7 - Ethernet DMA descriptor RAM (overlays the first 256B of SRAM_ETH_BUF) */
 	MPU_REGION_ENTRY("SRAM_ETH_DESC", DT_REG_ADDR(sram_eth_node), REGION_PPB_ATTR(REGION_256B)),
 #endif
 };


### PR DESCRIPTION
By default (configured [here](https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/st/stm32/stm32h7rsx/mpu_regions.c#L16)) a MPU region is defined over all the memory to prevent any access in order to detect wrong memory access.

This PR adds a MPU region over OTP area in order to allow to access it. It define it as a flash memory as OTP access are made like flash memory (using `HAL_FLASH_*` API to write and can be directly read).