### PR TITLE
MAINTAINERS: add neeliajay as Xilinx collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6353,6 +6353,7 @@ Xilinx Platforms:
     - henrikbrixandersen
     - ibirnbaum
     - kedareswararao
+    - neeliajay
   files:
     - boards/amd/
     - drivers/*/*xilinx*


### PR DESCRIPTION
- Add neeliajay (Ajay Neeli) as a collaborator for "Xilinx Platforms"
- I have been actively contributing and will continue reviewing and testing patches for the Xilinx subsystems

Selected contributions:
- https://github.com/zephyrproject-rtos/zephyr/pull/86400 
- https://github.com/zephyrproject-rtos/zephyr/pull/92768
- https://github.com/zephyrproject-rtos/zephyr/pull/84897

