### PR TITLE
hal: st: add Kconfig option for LSM6DSV320X support

### DIFF
--- a/modules/hal_st/Kconfig
+++ b/modules/hal_st/Kconfig
@@ -192,6 +192,9 @@ config USE_STDC_LSM6DSRX
 config USE_STDC_LSM6DSV16X
 	bool
 
+config USE_STDC_LSM6DSV320X
+	bool
+
 config USE_STDC_LSM9DS1
 	bool
 


### PR DESCRIPTION
Add a Kconfig symbol required by the ST HAL to enable LSM6DSV320X support. Without this option, the HAL objects are not linked, causing unresolved symbol errors when trying to enable the HAL for this sensor.

Tested by building with `CONFIG_USE_STDC_LSM6DSV320X` and using lsm6dsv320x_STdC functions