### PR TITLE
boards: nxp: frdm_mcxn947: list usbd as supported feature

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -36,6 +36,7 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - video
   - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -33,5 +33,6 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
 vendor: nxp


### PR DESCRIPTION
List USB device controller as a supported feature in order to increase test coverage.