### PR TITLE
dts: arm: st: fix stm32h523/33Xe sram2/3 addresses

### DIFF
--- a/dts/arm/st/h5/stm32h523Xe.dtsi
+++ b/dts/arm/st/h5/stm32h523Xe.dtsi
@@ -13,15 +13,15 @@
 		zephyr,memory-region = "SRAM1";
 	};
 
-	sram2: memory@20040000 {
+	sram2: memory@20020000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20040000 DT_SIZE_K(80)>;
+		reg = <0x20020000 DT_SIZE_K(80)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
-	sram3: memory@20050000 {
+	sram3: memory@20034000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20050000 DT_SIZE_K(64)>;
+		reg = <0x20034000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM3";
 	};
 

--- a/dts/arm/st/h5/stm32h533Xe.dtsi
+++ b/dts/arm/st/h5/stm32h533Xe.dtsi
@@ -12,15 +12,15 @@
 		zephyr,memory-region = "SRAM1";
 	};
 
-	sram2: memory@20040000 {
+	sram2: memory@20020000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20040000 DT_SIZE_K(80)>;
+		reg = <0x20020000 DT_SIZE_K(80)>;
 		zephyr,memory-region = "SRAM2";
 	};
 
-	sram3: memory@20050000 {
+	sram3: memory@20034000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20050000 DT_SIZE_K(64)>;
+		reg = <0x20034000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM3";
 	};
 


### PR DESCRIPTION
stm32h523/33Xe devices have different addresses than stm32h562/72/73xx (RM0481 fig. 21).

Tested on a custom board with stm32h523cet6 where the board crashed when accessing sram3.