### PR TITLE
drivers: i3c: i3c_npcx: fix redundant NULL check

### DIFF
--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -1514,7 +1514,7 @@ static int npcx_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 	uint32_t intmask;
 	int xfered_len;
 
-	if (dev == NULL || payload == NULL) {
+	if (payload == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
npcx_i3c_do_ccc() dereferences the device pointer before checking it against NULL, making the defensive check ineffective.

Remove the redundant check.