### PR TITLE
bluetooth: audio: Fix potential NULL pointer dereferences in Bluetooth Audio controller discovery

### DIFF
--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -242,7 +242,6 @@ static void micp_mic_ctlr_aics_discover_cb(struct bt_aics *inst, int err)
 
 	if (mic_ctlr == NULL) {
 		LOG_ERR("Could not lookup mic_ctlr from aics");
-		micp_mic_ctlr_discover_complete(mic_ctlr, BT_GATT_ERR(BT_ATT_ERR_UNLIKELY));
 
 		return;
 	}

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -674,7 +674,6 @@ static void vcp_vol_ctlr_aics_discover_cb(struct bt_aics *inst, int err)
 
 	if (vol_ctlr == NULL) {
 		LOG_ERR("Could not lookup vol_ctlr from aics");
-		vcp_vol_ctlr_discover_complete(vol_ctlr, BT_GATT_ERR(BT_ATT_ERR_UNLIKELY));
 
 		return;
 	}


### PR DESCRIPTION
This PR fixes potential NULL pointer dereferences in Bluetooth Audio controller discovery callbacks by avoiding calls to discover_complete() helpers with NULL controller pointers.

The fixes are split into two commits, one for micp_mic_ctlr and one for vcp_vol_ctlr, to keep changes isolated and easy to review.
