### PR TITLE
dts: wch: Add missing 20x/30x SPI and I2C nodes

### DIFF
--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -148,6 +148,28 @@
 			#size-cells = <0>;
 		};
 
+		i2c1: i2c@40005400 {
+			compatible = "wch,i2c";
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <47>, <48>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "wch,rcc";
 			reg = <0x40021000 16>;

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -188,6 +188,28 @@
 			#size-cells = <0>;
 		};
 
+		i2c1: i2c@40005400 {
+			compatible = "wch,i2c";
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <47>, <48>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "wch,rcc";
 			reg = <0x40021000 16>;

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -191,6 +191,50 @@
 			status = "disabled";
 		};
 
+		spi1: spi@40013000 {
+			compatible = "wch,spi";
+			reg = <0x40013000 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <51>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1: i2c@40005400 {
+			compatible = "wch,i2c";
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <47>, <48>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "wch,rcc";
 			reg = <0x40021000 16>;

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -191,6 +191,61 @@
 			status = "disabled";
 		};
 
+		spi1: spi@40013000 {
+			compatible = "wch,spi";
+			reg = <0x40013000 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <51>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi3: spi@4003c00 {
+			compatible = "wch,spi";
+			reg = <0x4003c00 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <67>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1: i2c@40005400 {
+			compatible = "wch,i2c";
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <47>, <48>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		rcc: rcc@40021000 {
 			compatible = "wch,rcc";
 			reg = <0x40021000 16>;


### PR DESCRIPTION
Adds some missing peripheral bindings for the CH32V20x/30x SOCs.

Has been tested on a CH32V303 / CH32V307, driver is identical for all SOCs in the family.