### PR TITLE
drivers: sensor: bosh: bmp581: fix redundant NULL check

### DIFF
--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -464,7 +464,7 @@ static int set_iir_config(const struct sensor_value *iir, const struct device *d
 	struct bmp581_config *conf = (struct bmp581_config *)dev->config;
 	int ret = BMP5_OK;
 
-	CHECKIF(iir == NULL || dev == NULL) {
+	CHECKIF(iir == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
set_iir_config() dereferences the device pointer before checking it against NULL, making the defensive check ineffective.

Remove the redundant check.