### PR TITLE
boards: rpi_5: update doc to include 1GB, 2GB, and 16GB variants

### DIFF
--- a/boards/raspberrypi/rpi_5/doc/index.rst
+++ b/boards/raspberrypi/rpi_5/doc/index.rst
@@ -12,7 +12,7 @@ Hardware
 - VideoCore VII GPU, supporting OpenGL ES 3.1, Vulkan 1.2
 - Dual 4Kp60 HDMI® display output with HDR support
 - 4Kp60 HEVC decoder
-- LPDDR4X-4267 SDRAM (4GB and 8GB SKUs available at launch)
+- LPDDR4X-4267 SDRAM (1GB, 2GB, 4GB, 8GB and 16GB SKUs available)
 - Dual-band 802.11ac Wi-Fi®
 - Bluetooth 5.0 / Bluetooth Low Energy (BLE)
 - microSD card slot, with support for high-speed SDR104 mode


### PR DESCRIPTION
The Raspberry Pi 5 product line has expanded since launch. The current documentation only lists the original 4GB and 8GB models.

This commit updates the board documentation to include the 1GB, 2GB, and 16GB variants, aligning the text with the current hardware availability and the linked product brief.

Signed-off-by: Thamaraimanalan M <devthamaraimanalan.m@gmail.com>