### PR TITLE
net: http_server: Add transaction complete status

### DIFF
--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -189,13 +189,13 @@ customised 404 response.
 
 .. code-block:: c
 
-    static int default_handler(struct http_client_ctx *client, enum http_data_status status,
+    static int default_handler(struct http_client_ctx *client, enum http_transaction_status status,
 		       const struct http_request_ctx *request_ctx,
 		       struct http_response_ctx *response_ctx, void *user_data)
     {
         static const char response_404[] = "Oops, page not found!";
 
-        if (status == HTTP_SERVER_DATA_FINAL) {
+        if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
             response_ctx->status = 404;
             response_ctx->body = response_404;
             response_ctx->body_len = sizeof(response_404) - 1;
@@ -331,7 +331,7 @@ resource handler, which echoes received data back to the client:
 
 .. code-block:: c
 
-    static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
+    static int dyn_handler(struct http_client_ctx *client, enum http_transaction_status status,
                            const struct http_request_ctx *request_ctx,
                            struct http_response_ctx *response_ctx, void *user_data)
     {
@@ -342,7 +342,7 @@ resource handler, which echoes received data back to the client:
 
         __ASSERT_NO_MSG(buffer != NULL);
 
-        if (status == HTTP_SERVER_DATA_ABORTED) {
+        if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
             LOG_DBG("Transaction aborted after %zd bytes.", processed);
             processed = 0;
             return 0;
@@ -354,7 +354,7 @@ resource handler, which echoes received data back to the client:
                  http_method_str(method), request_ctx->data_len);
         LOG_HEXDUMP_DBG(request_ctx->data, request_ctx->data_len, print_str);
 
-        if (status == HTTP_SERVER_DATA_FINAL) {
+        if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
             LOG_DBG("All data received (%zd bytes).", processed);
             processed = 0;
         }
@@ -362,7 +362,7 @@ resource handler, which echoes received data back to the client:
         /* Echo data back to client */
         response_ctx->body = request_ctx->data;
         response_ctx->body_len = request_ctx->data_len;
-        response_ctx->final_chunk = (status == HTTP_SERVER_DATA_FINAL);
+        response_ctx->final_chunk = (status == HTTP_SERVER_REQUEST_DATA_FINAL);
 
         return 0;
     }
@@ -386,14 +386,14 @@ the application should be able to keep track of the received data progress.
 
 The ``status`` field informs the application about the progress in passing
 request payload from the server to the application. As long as the status
-reports :c:enumerator:`HTTP_SERVER_DATA_MORE`, the application should expect
+reports :c:enumerator:`HTTP_SERVER_REQUEST_DATA_MORE`, the application should expect
 more data to be provided in a consecutive callback calls.
 Once all request payload has been passed to the application, the server reports
-:c:enumerator:`HTTP_SERVER_DATA_FINAL` status. In case of communication errors
-during request processing (for example client closed the connection before
+:c:enumerator:`HTTP_SERVER_REQUEST_DATA_FINAL` status. In case of communication
+errors during request processing (for example client closed the connection before
 complete payload has been received), the server reports
-:c:enumerator:`HTTP_SERVER_DATA_ABORTED`. Either of the two events indicate that
-the application shall reset any progress recorded for the resource, and await
+:c:enumerator:`HTTP_SERVER_TRANSACTION_ABORTED`. Either of the two events indicate
+that the application shall reset any progress recorded for the resource, and await
 a new request to come. The server guarantees that the resource can only be
 accessed by single client at a time.
 
@@ -488,7 +488,7 @@ from within the dynamic resource callback:
 
     HTTP_SERVER_REGISTER_HEADER_CAPTURE(capture_user_agent, "User-Agent");
 
-    static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
+    static int dyn_handler(struct http_client_ctx *client, enum http_transaction_status status,
                            uint8_t *buffer, size_t len, void *user_data)
     {
         size_t header_count = client->header_capture_ctx.count;

--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -342,8 +342,11 @@ resource handler, which echoes received data back to the client:
 
         __ASSERT_NO_MSG(buffer != NULL);
 
-        if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
-            LOG_DBG("Transaction aborted after %zd bytes.", processed);
+        if (status == HTTP_SERVER_TRANSACTION_ABORTED ||
+            status == HTTP_SERVER_TRANSACTION_COMPLETE) {
+            if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
+                LOG_DBG("Transaction aborted after %zd bytes.", processed);
+            }
             processed = 0;
             return 0;
         }
@@ -392,8 +395,11 @@ Once all request payload has been passed to the application, the server reports
 :c:enumerator:`HTTP_SERVER_REQUEST_DATA_FINAL` status. In case of communication
 errors during request processing (for example client closed the connection before
 complete payload has been received), the server reports
-:c:enumerator:`HTTP_SERVER_TRANSACTION_ABORTED`. Either of the two events indicate
-that the application shall reset any progress recorded for the resource, and await
+:c:enumerator:`HTTP_SERVER_TRANSACTION_ABORTED`.
+When the response has been sent completely to the client, the server reports
+:c:enumerator:`HTTP_SERVER_TRANSACTION_COMPLETE` status.
+Either of the two events indicate that the request processing is finished, and
+the application shall reset any progress recorded for the resource, and await
 a new request to come. The server guarantees that the resource can only be
 accessed by single client at a time.
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -502,6 +502,18 @@ Networking
   code cannot use POSIX APIs, then the relevant network API prefix needs to be added to the
   code calling a network API.
 
+* The enum for HTTP server transaction status has been renamed from ``http_data_status``
+  to ``http_transaction_status`` to better reflect its purpose. The enum values have also been
+  renamed as follows:
+
+  - ``HTTP_SERVER_DATA_ABORTED`` → ``HTTP_SERVER_TRANSACTION_ABORTED``
+  - ``HTTP_SERVER_DATA_MORE`` → ``HTTP_SERVER_REQUEST_DATA_MORE``
+  - ``HTTP_SERVER_DATA_FINAL`` → ``HTTP_SERVER_REQUEST_DATA_FINAL``
+
+  The handler callback type for dynamic resources has been updated accordingly to use the new enum
+  and its renamed values. Applications using dynamic HTTP resources must update their handler
+  callbacks to use the new enum and handle the renamed values.
+
 Modem
 *****
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -514,6 +514,11 @@ Networking
   and its renamed values. Applications using dynamic HTTP resources must update their handler
   callbacks to use the new enum and handle the renamed values.
 
+* The HTTP server now reports for dynamic resources the ``HTTP_SERVER_TRANSACTION_COMPLETE``
+  status when the response has been sent completely to the client. Applications should now also
+  handle this status in the handler callback to properly reset resource state after successful
+  response transmission.
+
 Modem
 *****
 

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -178,6 +178,8 @@ enum http_transaction_status {
 	HTTP_SERVER_REQUEST_DATA_MORE = 0,
 	/** Final data fragment in current transaction. */
 	HTTP_SERVER_REQUEST_DATA_FINAL = 1,
+	/** Transaction completed, response sent completely. */
+	HTTP_SERVER_TRANSACTION_COMPLETE = 2,
 };
 
 /** @brief Status of captured request headers */
@@ -218,7 +220,10 @@ struct http_response_ctx {
  *        can be specified.
  *
  * @param client HTTP context information for this client connection.
- * @param status HTTP data status, indicate whether more data is expected or not.
+ * @param status HTTP transaction status, HTTP_SERVER_REQUEST_DATA_MORE and
+ *               HTTP_SERVER_REQUEST_DATA_FINAL describe the request-body delivery progress.
+ *               HTTP_SERVER_TRANSACTION_ABORTED and HTTP_SERVER_TRANSACTION_COMPLETE are
+ *               terminal notifications.
  * @param request_ctx Request context structure containing HTTP request data that was received.
  * @param response_ctx Response context structure for application to populate with response data.
  * @param user_data User specified data.

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -171,13 +171,13 @@ struct http_content_type {
 struct http_client_ctx;
 
 /** Indicates the status of the currently processed piece of data.  */
-enum http_data_status {
+enum http_transaction_status {
 	/** Transaction aborted, data incomplete. */
-	HTTP_SERVER_DATA_ABORTED = -1,
+	HTTP_SERVER_TRANSACTION_ABORTED = -1,
 	/** Transaction incomplete, more data expected. */
-	HTTP_SERVER_DATA_MORE = 0,
+	HTTP_SERVER_REQUEST_DATA_MORE = 0,
 	/** Final data fragment in current transaction. */
-	HTTP_SERVER_DATA_FINAL = 1,
+	HTTP_SERVER_REQUEST_DATA_FINAL = 1,
 };
 
 /** @brief Status of captured request headers */
@@ -227,7 +227,7 @@ struct http_response_ctx {
  *         <0 error, close the connection.
  */
 typedef int (*http_resource_dynamic_cb_t)(struct http_client_ctx *client,
-					  enum http_data_status status,
+					  enum http_transaction_status status,
 					  const struct http_request_ctx *request_ctx,
 					  struct http_response_ctx *response_ctx,
 					  void *user_data);

--- a/samples/net/prometheus/src/main.c
+++ b/samples/net/prometheus/src/main.c
@@ -41,14 +41,14 @@ static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_P
 HTTP_SERVICE_DEFINE(test_http_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_http_service_port,
 		    CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, NULL);
 
-static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
+static int dyn_handler(struct http_client_ctx *client, enum http_transaction_status status,
 		       const struct http_request_ctx *request_ctx,
 		       struct http_response_ctx *response_ctx, void *user_data)
 {
 	int ret;
 	static uint8_t prom_buffer[256];
 
-	if (status == HTTP_SERVER_DATA_FINAL) {
+	if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 
 		/* incrase counter per request */
 		prometheus_counter_inc(prom_context.counter);

--- a/samples/net/prometheus/src/stats.c
+++ b/samples/net/prometheus/src/stats.c
@@ -31,14 +31,14 @@ static struct prometheus_counter *http_request_counter;
 static struct prometheus_collector *stats_collector;
 static struct prometheus_collector_walk_context walk_ctx;
 
-static int stats_handler(struct http_client_ctx *client, enum http_data_status status,
+static int stats_handler(struct http_client_ctx *client, enum http_transaction_status status,
 			 const struct http_request_ctx *request_ctx,
 			 struct http_response_ctx *response_ctx, void *user_data)
 {
 	int ret;
 	static uint8_t prom_buffer[1024];
 
-	if (status == HTTP_SERVER_DATA_FINAL) {
+	if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 
 		/* incrase counter per request */
 		prometheus_counter_inc(http_request_counter);

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -72,7 +72,7 @@ static struct http_resource_detail_static main_js_gz_resource_detail = {
 	.static_data_len = sizeof(main_js_gz),
 };
 
-static int echo_handler(struct http_client_ctx *client, enum http_data_status status,
+static int echo_handler(struct http_client_ctx *client, enum http_transaction_status status,
 			const struct http_request_ctx *request_ctx,
 			struct http_response_ctx *response_ctx, void *user_data)
 {
@@ -81,7 +81,7 @@ static int echo_handler(struct http_client_ctx *client, enum http_data_status st
 	enum http_method method = client->method;
 	static size_t processed;
 
-	if (status == HTTP_SERVER_DATA_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
 		LOG_DBG("Transaction aborted after %zd bytes.", processed);
 		processed = 0;
 		return 0;
@@ -95,7 +95,7 @@ static int echo_handler(struct http_client_ctx *client, enum http_data_status st
 		 request_ctx->data_len);
 	LOG_HEXDUMP_DBG(request_ctx->data, request_ctx->data_len, print_str);
 
-	if (status == HTTP_SERVER_DATA_FINAL) {
+	if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 		LOG_DBG("All data received (%zd bytes).", processed);
 		processed = 0;
 	}
@@ -103,7 +103,7 @@ static int echo_handler(struct http_client_ctx *client, enum http_data_status st
 	/* Echo data back to client */
 	response_ctx->body = request_ctx->data;
 	response_ctx->body_len = request_ctx->data_len;
-	response_ctx->final_chunk = (status == HTTP_SERVER_DATA_FINAL);
+	response_ctx->final_chunk = (status == HTTP_SERVER_REQUEST_DATA_FINAL);
 
 	return 0;
 }
@@ -117,7 +117,7 @@ static struct http_resource_detail_dynamic echo_resource_detail = {
 	.user_data = NULL,
 };
 
-static int uptime_handler(struct http_client_ctx *client, enum http_data_status status,
+static int uptime_handler(struct http_client_ctx *client, enum http_transaction_status status,
 			  const struct http_request_ctx *request_ctx,
 			  struct http_response_ctx *response_ctx, void *user_data)
 {
@@ -129,7 +129,7 @@ static int uptime_handler(struct http_client_ctx *client, enum http_data_status 
 	/* A payload is not expected with the GET request. Ignore any data and wait until
 	 * final callback before sending response
 	 */
-	if (status == HTTP_SERVER_DATA_FINAL) {
+	if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 		ret = snprintf(uptime_buf, sizeof(uptime_buf), "%" PRId64, k_uptime_get());
 		if (ret < 0) {
 			LOG_ERR("Failed to snprintf uptime, err %d", ret);
@@ -176,7 +176,7 @@ static void parse_led_post(uint8_t *buf, size_t len)
 	}
 }
 
-static int led_handler(struct http_client_ctx *client, enum http_data_status status,
+static int led_handler(struct http_client_ctx *client, enum http_transaction_status status,
 		       const struct http_request_ctx *request_ctx,
 		       struct http_response_ctx *response_ctx, void *user_data)
 {
@@ -185,7 +185,7 @@ static int led_handler(struct http_client_ctx *client, enum http_data_status sta
 
 	LOG_DBG("LED handler status %d, size %zu", status, request_ctx->data_len);
 
-	if (status == HTTP_SERVER_DATA_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
 		cursor = 0;
 		return 0;
 	}
@@ -202,7 +202,7 @@ static int led_handler(struct http_client_ctx *client, enum http_data_status sta
 	memcpy(post_payload_buf + cursor, request_ctx->data, request_ctx->data_len);
 	cursor += request_ctx->data_len;
 
-	if (status == HTTP_SERVER_DATA_FINAL) {
+	if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 		parse_led_post(post_payload_buf, cursor);
 		cursor = 0;
 	}

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -81,8 +81,11 @@ static int echo_handler(struct http_client_ctx *client, enum http_transaction_st
 	enum http_method method = client->method;
 	static size_t processed;
 
-	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
-		LOG_DBG("Transaction aborted after %zd bytes.", processed);
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED ||
+	    status == HTTP_SERVER_TRANSACTION_COMPLETE) {
+		if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
+			LOG_DBG("Transaction aborted after %zd bytes.", processed);
+		}
 		processed = 0;
 		return 0;
 	}
@@ -185,7 +188,8 @@ static int led_handler(struct http_client_ctx *client, enum http_transaction_sta
 
 	LOG_DBG("LED handler status %d, size %zu", status, request_ctx->data_len);
 
-	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED ||
+	    status == HTTP_SERVER_TRANSACTION_COMPLETE) {
 		cursor = 0;
 		return 0;
 	}

--- a/subsys/net/lib/http/headers/server_internal.h
+++ b/subsys/net/lib/http/headers/server_internal.h
@@ -53,7 +53,7 @@ void http_server_get_content_type_from_extension(char *url, char *content_type,
 int http_server_find_file(char *fname, size_t fname_size, size_t *file_size,
 			  uint8_t supported_compression, enum http_compression *chosen_compression);
 void http_client_timer_restart(struct http_client_ctx *client);
-bool http_response_is_final(struct http_response_ctx *rsp, enum http_data_status status);
+bool http_response_is_final(struct http_response_ctx *rsp, enum http_transaction_status status);
 bool http_response_is_provided(struct http_response_ctx *rsp);
 
 /* TODO Could be static, but currently used in tests. */

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -344,7 +344,7 @@ static void client_release_resources(struct http_client_ctx *client)
 
 			populate_request_ctx(&request_ctx, NULL, 0, NULL);
 
-			dynamic_detail->cb(client, HTTP_SERVER_DATA_ABORTED, &request_ctx,
+			dynamic_detail->cb(client, HTTP_SERVER_TRANSACTION_ABORTED, &request_ctx,
 					   &response_ctx, dynamic_detail->user_data);
 		}
 	}
@@ -909,9 +909,9 @@ int http_server_sendall(struct http_client_ctx *client, const void *buf, size_t 
 	return 0;
 }
 
-bool http_response_is_final(struct http_response_ctx *rsp, enum http_data_status status)
+bool http_response_is_final(struct http_response_ctx *rsp, enum http_transaction_status status)
 {
-	if (status != HTTP_SERVER_DATA_FINAL) {
+	if (status != HTTP_SERVER_REQUEST_DATA_FINAL) {
 		return false;
 	}
 

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -407,14 +407,14 @@ static int dynamic_get_del_req(struct http_resource_detail_dynamic *dynamic_deta
 {
 	int ret, len;
 	char *ptr;
-	enum http_data_status status;
+	enum http_transaction_status status;
 	struct http_request_ctx request_ctx;
 	struct http_response_ctx response_ctx;
 
 	/* Start of GET params */
 	ptr = &client->url_buffer[dynamic_detail->common.path_len];
 	len = strlen(ptr);
-	status = HTTP_SERVER_DATA_FINAL;
+	status = HTTP_SERVER_REQUEST_DATA_FINAL;
 
 	do {
 		memset(&response_ctx, 0, sizeof(response_ctx));
@@ -453,7 +453,7 @@ static int dynamic_post_put_req(struct http_resource_detail_dynamic *dynamic_det
 {
 	int ret;
 	char *ptr = client->cursor;
-	enum http_data_status status;
+	enum http_transaction_status status;
 	struct http_request_ctx request_ctx;
 	struct http_response_ctx response_ctx;
 
@@ -462,9 +462,9 @@ static int dynamic_post_put_req(struct http_resource_detail_dynamic *dynamic_det
 	}
 
 	if (client->parser_state == HTTP1_MESSAGE_COMPLETE_STATE) {
-		status = HTTP_SERVER_DATA_FINAL;
+		status = HTTP_SERVER_REQUEST_DATA_FINAL;
 	} else {
-		status = HTTP_SERVER_DATA_MORE;
+		status = HTTP_SERVER_REQUEST_DATA_MORE;
 	}
 
 	memset(&response_ctx, 0, sizeof(response_ctx));
@@ -492,7 +492,8 @@ static int dynamic_post_put_req(struct http_resource_detail_dynamic *dynamic_det
 	}
 
 	/* Once all data is transferred to application, repeat cb until response is complete */
-	while (!http_response_is_final(&response_ctx, status) && status == HTTP_SERVER_DATA_FINAL) {
+	while (!http_response_is_final(&response_ctx, status) &&
+	       status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 		memset(&response_ctx, 0, sizeof(response_ctx));
 		populate_request_ctx(&request_ctx, ptr, 0, &client->header_capture_ctx);
 

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -557,12 +557,13 @@ out:
 #endif /* CONFIG_FILE_SYSTEM */
 
 static int http2_dynamic_response(struct http_client_ctx *client, struct http2_frame *frame,
-				  struct http_response_ctx *rsp, enum http_data_status data_status,
+				  struct http_response_ctx *rsp,
+				  enum http_transaction_status status,
 				  struct http_resource_detail_dynamic *dynamic_detail)
 {
 	int ret;
 	uint8_t flags = 0;
-	bool final_response = http_response_is_final(rsp, data_status);
+	bool final_response = http_response_is_final(rsp, status);
 
 	if (client->current_stream->headers_sent && (rsp->header_count > 0 || rsp->status != 0)) {
 		LOG_WRN("Already sent headers, dropping new headers and/or response code");
@@ -622,7 +623,7 @@ static int dynamic_get_del_req_v2(struct http_resource_detail_dynamic *dynamic_d
 	int ret, len;
 	char *ptr;
 	struct http2_frame *frame = &client->current_frame;
-	enum http_data_status status;
+	enum http_transaction_status status;
 	struct http_request_ctx request_ctx;
 	struct http_response_ctx response_ctx;
 
@@ -633,7 +634,7 @@ static int dynamic_get_del_req_v2(struct http_resource_detail_dynamic *dynamic_d
 	/* Start of GET params */
 	ptr = &client->url_buffer[dynamic_detail->common.path_len];
 	len = strlen(ptr);
-	status = HTTP_SERVER_DATA_FINAL;
+	status = HTTP_SERVER_REQUEST_DATA_FINAL;
 
 	do {
 		memset(&response_ctx, 0, sizeof(response_ctx));
@@ -674,7 +675,7 @@ static int dynamic_post_put_req_v2(struct http_resource_detail_dynamic *dynamic_
 	int ret = 0;
 	char *ptr = client->cursor;
 	size_t data_len;
-	enum http_data_status status;
+	enum http_transaction_status status;
 	struct http2_frame *frame = &client->current_frame;
 	struct http_request_ctx request_ctx;
 	struct http_response_ctx response_ctx;
@@ -700,9 +701,9 @@ static int dynamic_post_put_req_v2(struct http_resource_detail_dynamic *dynamic_
 
 	if (frame->length == 0 && is_header_flag_set(frame->flags, HTTP2_FLAG_END_STREAM) &&
 	    !headers_only) {
-		status = HTTP_SERVER_DATA_FINAL;
+		status = HTTP_SERVER_REQUEST_DATA_FINAL;
 	} else {
-		status = HTTP_SERVER_DATA_MORE;
+		status = HTTP_SERVER_REQUEST_DATA_MORE;
 	}
 
 	memset(&response_ctx, 0, sizeof(response_ctx));
@@ -725,7 +726,8 @@ static int dynamic_post_put_req_v2(struct http_resource_detail_dynamic *dynamic_
 	}
 
 	/* Once all data is transferred to application, repeat cb until response is complete */
-	while (!http_response_is_final(&response_ctx, status) && status == HTTP_SERVER_DATA_FINAL) {
+	while (!http_response_is_final(&response_ctx, status) &&
+	       status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 		memset(&response_ctx, 0, sizeof(response_ctx));
 		populate_request_ctx(&request_ctx, ptr, 0, request_headers_ctx);
 
@@ -751,7 +753,8 @@ static int dynamic_post_put_req_v2(struct http_resource_detail_dynamic *dynamic_
 			memset(&response_ctx, 0, sizeof(response_ctx));
 			response_ctx.final_chunk = true;
 			ret = http2_dynamic_response(client, frame, &response_ctx,
-						     HTTP_SERVER_DATA_FINAL, dynamic_detail);
+						     HTTP_SERVER_REQUEST_DATA_FINAL,
+						     dynamic_detail);
 		}
 
 		if (ret < 0) {
@@ -1492,7 +1495,7 @@ static int handle_http_frame_headers_end_stream(struct http_client_ctx *client)
 		memset(&response_ctx, 0, sizeof(response_ctx));
 		populate_request_ctx(&request_ctx, NULL, 0, NULL);
 
-		ret = dynamic_detail->cb(client, HTTP_SERVER_DATA_FINAL, &request_ctx,
+		ret = dynamic_detail->cb(client, HTTP_SERVER_REQUEST_DATA_FINAL, &request_ctx,
 					 &response_ctx, dynamic_detail->user_data);
 		if (ret < 0) {
 			dynamic_detail->holder = NULL;
@@ -1502,8 +1505,8 @@ static int handle_http_frame_headers_end_stream(struct http_client_ctx *client)
 		/* Force end stream */
 		response_ctx.final_chunk = true;
 
-		ret = http2_dynamic_response(client, frame, &response_ctx, HTTP_SERVER_DATA_FINAL,
-					     dynamic_detail);
+		ret = http2_dynamic_response(client, frame, &response_ctx,
+					     HTTP_SERVER_REQUEST_DATA_FINAL, dynamic_detail);
 		dynamic_detail->holder = NULL;
 
 		if (ret < 0) {

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -32,13 +32,13 @@ HTTP_RESOURCE_DEFINE(static_resource, test_http_service, "/static",
 static uint8_t dynamic_buf[TEST_BUF_SIZE];
 static size_t dynamic_len;
 
-static int dynamic_cb(struct http_client_ctx *client, enum http_data_status status,
+static int dynamic_cb(struct http_client_ctx *client, enum http_transaction_status status,
 		      const struct http_request_ctx *request_ctx,
 		      struct http_response_ctx *response_ctx, void *user_data)
 {
 	static size_t offset;
 
-	if (status == HTTP_SERVER_DATA_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
 		offset = 0;
 		return 0;
 	}
@@ -60,7 +60,7 @@ static int dynamic_cb(struct http_client_ctx *client, enum http_data_status stat
 			offset += request_ctx->data_len;
 		}
 
-		if (status == HTTP_SERVER_DATA_FINAL) {
+		if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 			/* All data received, reset progress. */
 			dynamic_len = offset;
 			offset = 0;

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -38,7 +38,8 @@ static int dynamic_cb(struct http_client_ctx *client, enum http_transaction_stat
 {
 	static size_t offset;
 
-	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED ||
+	    status == HTTP_SERVER_TRANSACTION_COMPLETE) {
 		offset = 0;
 		return 0;
 	}

--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -253,13 +253,13 @@ static uint8_t dynamic_payload[32];
 static size_t dynamic_payload_len = sizeof(dynamic_payload);
 static bool dynamic_error;
 
-static int dynamic_cb(struct http_client_ctx *client, enum http_data_status status,
+static int dynamic_cb(struct http_client_ctx *client, enum http_transaction_status status,
 		      const struct http_request_ctx *request_ctx,
 		      struct http_response_ctx *response_ctx, void *user_data)
 {
 	static size_t offset;
 
-	if (status == HTTP_SERVER_DATA_ABORTED) {
+	if (status == HTTP_SERVER_TRANSACTION_ABORTED) {
 		offset = 0;
 		return 0;
 	}
@@ -291,7 +291,7 @@ static int dynamic_cb(struct http_client_ctx *client, enum http_data_status stat
 			offset += request_ctx->data_len;
 		}
 
-		if (status == HTTP_SERVER_DATA_FINAL) {
+		if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 			/* All data received, reset progress. */
 			dynamic_payload_len = offset;
 			offset = 0;
@@ -327,7 +327,8 @@ struct test_headers_clone {
 	enum http_header_status status;
 };
 
-static int dynamic_request_headers_cb(struct http_client_ctx *client, enum http_data_status status,
+static int dynamic_request_headers_cb(struct http_client_ctx *client,
+				      enum http_transaction_status status,
 				      const struct http_request_ctx *request_ctx,
 				      struct http_response_ctx *response_ctx, void *user_data)
 {
@@ -425,7 +426,8 @@ enum dynamic_response_headers_variant {
 static uint8_t dynamic_response_headers_variant;
 static uint8_t dynamic_response_headers_buffer[sizeof(long_payload)];
 
-static int dynamic_response_headers_cb(struct http_client_ctx *client, enum http_data_status status,
+static int dynamic_response_headers_cb(struct http_client_ctx *client,
+				       enum http_transaction_status status,
 				       const struct http_request_ctx *request_ctx,
 				       struct http_response_ctx *response_ctx, void *user_data)
 {
@@ -440,7 +442,7 @@ static int dynamic_response_headers_cb(struct http_client_ctx *client, enum http
 		{.name = "Content-Type", .value = "application/json"},
 	};
 
-	if (status != HTTP_SERVER_DATA_FINAL &&
+	if (status != HTTP_SERVER_REQUEST_DATA_FINAL &&
 	    dynamic_response_headers_variant != DYNAMIC_RESPONSE_HEADERS_VARIANT_BODY_LONG) {
 		/* Long body variant is the only one which needs to take some action before final
 		 * data has been received from server
@@ -515,7 +517,7 @@ static int dynamic_response_headers_cb(struct http_client_ctx *client, enum http
 			       request_ctx->data_len);
 			offset += request_ctx->data_len;
 
-			if (status == HTTP_SERVER_DATA_FINAL) {
+			if (status == HTTP_SERVER_REQUEST_DATA_FINAL) {
 				offset = 0;
 			}
 		} else {


### PR DESCRIPTION
This PR adds a new status  `HTTP_SERVER_DATA_COMPLETE` for dynamic resources. When the response has been sent completely to the client, the server reports the new `HTTP_SERVER_DATA_COMPLETE` status. Together with the existing `HTTP_SERVER_DATA_ABORTED` status, the application can now also for successful completions of requests clean up any resources allocated for handling the request.

This especially allows to dynamically allocate the response buffer passed to the server in the request callback and free it when the request is done. Previously, it was necessary that the response buffer has a static lifetime and therefore to have static buffers in the handlers causing increased memory consumption.