### PR TITLE
net: lib: zperf: Add raw socket upload support

### DIFF
--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -19,6 +19,7 @@
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
 #include <zephyr/net/conn_mgr_monitor.h>
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/reboot.h>
 
 #include "net_private.h"
@@ -426,7 +427,13 @@ int nrf_wifi_if_send(const struct device *dev,
 	}
 
 #ifdef CONFIG_NRF70_RAW_DATA_TX
-	if ((*(unsigned int *)pkt->frags->data) == NRF_WIFI_MAGIC_NUM_RAWTX) {
+	/*
+	 * Check for raw TX magic number in both byte orders:
+	 * - Little-endian: programmatic API stores native uint32_t
+	 * - Big-endian: shell hex input "12345678" stores bytes 0x12,0x34,0x56,0x78
+	 */
+	if (sys_get_le32(pkt->frags->data) == NRF_WIFI_MAGIC_NUM_RAWTX ||
+	    sys_get_be32(pkt->frags->data) == NRF_WIFI_MAGIC_NUM_RAWTX) {
 		if (vif_ctx_zep->if_carr_state != NRF_WIFI_FMAC_IF_CARR_STATE_ON) {
 			goto drop;
 		}

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -76,6 +76,32 @@ struct zperf_download_params {
 	char if_name[NET_IFNAMSIZ];
 };
 
+#ifdef CONFIG_NET_ZPERF_RAW_TX
+/**
+ * Raw TX upload parameters
+ *
+ * Buffer structure sent to driver:
+ * [User-provided header] + [Payload 'z']
+ *
+ * The user provides everything as a single header blob (vendor metadata,
+ * frame header like 802.11/Ethernet, etc.). Zperf appends 'z' payload
+ * bytes to reach the desired packet_size. This is generic and works
+ * with any frame format.
+ *
+ * Header bytes are transmitted exactly as provided - no byte order conversion
+ * is performed. Users must provide bytes in the format expected by their
+ * target driver/hardware.
+ */
+struct zperf_raw_upload_params {
+	uint32_t duration_ms;         /**< Duration of the test in milliseconds */
+	uint32_t rate_kbps;           /**< Target rate in kilobits per second */
+	uint16_t packet_size;         /**< Total packet size (header + payload) */
+	uint8_t *hdr;                 /**< Header bytes (vendor metadata + frame hdr) */
+	uint16_t hdr_len;             /**< Length of header in bytes */
+	int if_index;                 /**< Network interface index */
+};
+#endif /* CONFIG_NET_ZPERF_RAW_TX */
+
 /** @endcond */
 
 /** Performance results */
@@ -199,6 +225,35 @@ int zperf_udp_download_stop(void);
  * @return 0 if server was stopped successfully, a negative error code otherwise.
  */
 int zperf_tcp_download_stop(void);
+
+#ifdef CONFIG_NET_ZPERF_RAW_TX
+/**
+ * @brief Synchronous raw packet TX upload operation. The function blocks until
+ *        the upload is complete.
+ *
+ * @param param Upload parameters including custom header and destination MAC.
+ * @param result Session results.
+ *
+ * @return 0 if session completed successfully, a negative error code otherwise.
+ */
+int zperf_raw_upload(const struct zperf_raw_upload_params *param,
+		     struct zperf_results *result);
+
+/**
+ * @brief Asynchronous raw packet TX upload operation.
+ *
+ * @note Only one asynchronous raw TX upload can be performed at a time.
+ *
+ * @param param Upload parameters including custom header and destination MAC.
+ * @param callback Session results callback.
+ * @param user_data A pointer to the user data to be provided with the callback.
+ *
+ * @return 0 if session was scheduled successfully, a negative error code
+ *         otherwise.
+ */
+int zperf_raw_upload_async(const struct zperf_raw_upload_params *param,
+			   zperf_callback callback, void *user_data);
+#endif /* CONFIG_NET_ZPERF_RAW_TX */
 
 #ifdef __cplusplus
 }

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -105,3 +105,16 @@ tests:
     extra_configs:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp
+  sample.net.zperf.raw_tx:
+    harness: net
+    platform_allow: qemu_x86
+    extra_configs:
+      - CONFIG_NET_SOCKETS_PACKET=y
+      - CONFIG_NET_ZPERF_RAW_TX=y
+  sample.net.zperf.raw_tx.nrf7002dk:
+    extra_args: SNIPPET=wifi-ipv4
+    extra_configs:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+      - CONFIG_NET_SOCKETS_PACKET=y
+      - CONFIG_NET_ZPERF_RAW_TX=y
+    platform_allow: nrf7002dk/nrf5340/cpuapp

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1020,6 +1020,7 @@ int net_eth_promisc_mode(struct net_if *iface, bool enable)
 
 int net_eth_txinjection_mode(struct net_if *iface, bool enable)
 {
+#ifdef CONFIG_NET_L2_ETHERNET_MGMT
 	struct ethernet_req_params params;
 
 	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_TXINJECTION_MODE)) {
@@ -1030,6 +1031,12 @@ int net_eth_txinjection_mode(struct net_if *iface, bool enable)
 
 	return net_mgmt(NET_REQUEST_ETHERNET_SET_TXINJECTION_MODE, iface,
 			&params, sizeof(struct ethernet_req_params));
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(enable);
+
+	return -ENOTSUP;
+#endif
 }
 
 int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,

--- a/subsys/net/lib/zperf/CMakeLists.txt
+++ b/subsys/net/lib/zperf/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_named(zperf)
 zephyr_library_sources(zperf_common.c)
 zephyr_library_sources_ifdef(CONFIG_NET_UDP zperf_udp_uploader.c)
 zephyr_library_sources_ifdef(CONFIG_NET_TCP zperf_tcp_uploader.c)
+zephyr_library_sources_ifdef(CONFIG_NET_ZPERF_RAW_TX zperf_raw_uploader.c)
 
 if(CONFIG_NET_ZPERF_SERVER)
   zephyr_library_sources(zperf_session.c)

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -81,5 +81,20 @@ config NET_ZPERF_UDP_REPORT_RETANSMISSION_COUNT
 	  report from the server. `0` means the report will not be requested
 	  at all, which is useful for testing purposes.
 
+config NET_ZPERF_RAW_TX
+	bool "Raw packet TX support"
+	depends on NET_SOCKETS_PACKET
+	help
+	  Enable raw packet socket TX support in zperf. This allows sending
+	  custom raw packets with user-defined headers for performance testing.
+	  Useful for testing vendor-specific protocols or custom L2 frames.
+
+config NET_ZPERF_RAW_TX_MAX_HDR_SIZE
+	int "Maximum raw TX header size"
+	depends on NET_ZPERF_RAW_TX
+	default 64
+	help
+	  Maximum size of the custom header that can be prepended to raw TX
+	  packets. The header is provided as hex bytes by the user.
 
 endif

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -56,6 +56,7 @@
 enum session_proto {
 	SESSION_UDP = 0,
 	SESSION_TCP = 1,
+	SESSION_RAW = 2,
 	SESSION_PROTO_END
 };
 
@@ -136,6 +137,7 @@ uint32_t zperf_packet_duration(uint32_t packet_size, uint32_t rate_in_kbps);
 void zperf_async_work_submit(enum session_proto proto, int session_id, struct k_work *work);
 void zperf_udp_uploader_init(void);
 void zperf_tcp_uploader_init(void);
+void zperf_raw_uploader_init(void);
 
 void zperf_shell_init(void);
 

--- a/subsys/net/lib/zperf/zperf_raw_uploader.c
+++ b/subsys/net/lib/zperf/zperf_raw_uploader.c
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/zperf.h>
+
+#include "zperf_internal.h"
+
+#if defined(CONFIG_NET_ZPERF_RAW_TX)
+
+/* Buffer for raw packet: user-provided header + payload */
+static uint8_t raw_packet_buffer[PACKET_SIZE_MAX];
+
+struct zperf_raw_async_upload_context {
+	struct k_work work;
+	struct zperf_raw_upload_params param;
+	uint8_t hdr_storage[CONFIG_NET_ZPERF_RAW_TX_MAX_HDR_SIZE];
+	zperf_callback callback;
+	void *user_data;
+};
+
+static struct zperf_raw_async_upload_context raw_async_upload_ctx;
+
+/**
+ * @brief Internal raw packet TX upload implementation
+ *
+ * Buffer structure for raw TX:
+ * [User-provided header] + [Payload 'z']
+ *
+ * The user provides everything (vendor metadata + frame header) as a single
+ * blob. Zperf appends 'z' payload bytes to reach the desired packet_size.
+ * This is generic and works with any frame format (802.11, Ethernet, etc.).
+ *
+ * @param param Upload parameters
+ * @param results Pointer to store results
+ *
+ * @return 0 on success, negative errno on failure
+ */
+static int raw_upload(const struct zperf_raw_upload_params *param,
+		      struct zperf_results *results)
+{
+	uint32_t duration_in_ms = param->duration_ms;
+	uint32_t packet_size = param->packet_size;
+	uint32_t rate_in_kbps = param->rate_kbps;
+	uint32_t packet_duration_us;
+	uint32_t packet_duration;
+	uint32_t delay;
+	uint32_t nb_packets = 0U;
+	int64_t start_time, end_time;
+	int64_t last_loop_time;
+	int raw_sock;
+	struct net_sockaddr_ll raw_addr;
+	ssize_t sent_bytes;
+	int ret;
+
+	if (packet_size > PACKET_SIZE_MAX) {
+		NET_WARN("Packet size too large! max size: %u", PACKET_SIZE_MAX);
+		packet_size = PACKET_SIZE_MAX;
+	}
+
+	if (packet_size < param->hdr_len) {
+		NET_ERR("Packet size (%u) must be >= header length (%u)",
+			packet_size, param->hdr_len);
+		return -EINVAL;
+	}
+
+	/* Rate limiting based on total packet size */
+	packet_duration_us = zperf_packet_duration(packet_size, rate_in_kbps);
+	packet_duration = k_us_to_ticks_ceil32(packet_duration_us);
+	delay = packet_duration;
+
+	/* Create raw packet socket (proto=0 for TX only) */
+	raw_sock = zsock_socket(NET_AF_PACKET, NET_SOCK_RAW, 0);
+	if (raw_sock < 0) {
+		NET_ERR("Cannot create raw socket (%d)", errno);
+		return -errno;
+	}
+
+	/* Set up net_sockaddr_ll structure */
+	memset(&raw_addr, 0, sizeof(raw_addr));
+	raw_addr.sll_family = NET_AF_PACKET;
+	raw_addr.sll_ifindex = param->if_index;
+
+	/* Bind to the interface */
+	ret = zsock_bind(raw_sock, (struct net_sockaddr *)&raw_addr, sizeof(raw_addr));
+	if (ret < 0) {
+		NET_ERR("Failed to bind raw socket (%d)", errno);
+		zsock_close(raw_sock);
+		return -errno;
+	}
+
+	/*
+	 * Build buffer: [User-provided header] + [Payload 'z']
+	 * User provides everything (vendor metadata + frame header).
+	 * We just append 'z' payload to reach packet_size.
+	 */
+	memset(raw_packet_buffer, 'z', packet_size);
+
+	/* Copy user-provided header (vendor metadata + frame header) */
+	if (param->hdr && param->hdr_len > 0) {
+		memcpy(raw_packet_buffer, param->hdr, param->hdr_len);
+	}
+
+	/* Rest is already filled with 'z' from memset above */
+
+	/* Start the transmission loop */
+	start_time = k_uptime_ticks();
+	last_loop_time = start_time;
+	end_time = start_time + k_ms_to_ticks_ceil64(duration_in_ms);
+
+	do {
+		int64_t loop_time;
+		int32_t adjust;
+
+		/* Timestamp */
+		loop_time = k_uptime_ticks();
+
+		/* Algorithm to maintain a given baud rate */
+		if (last_loop_time != loop_time) {
+			adjust = packet_duration;
+			adjust -= (int32_t)(loop_time - last_loop_time);
+		} else {
+			adjust = 0;
+		}
+
+		if ((adjust >= 0) || (-adjust < (int32_t)delay)) {
+			delay += adjust;
+		} else {
+			delay = 0U;
+		}
+
+		last_loop_time = loop_time;
+
+		/* Send the raw packet */
+		sent_bytes = zsock_sendto(raw_sock, raw_packet_buffer, packet_size, 0,
+					  (struct net_sockaddr *)&raw_addr, sizeof(raw_addr));
+
+		if (sent_bytes < 0) {
+			NET_DBG("Failed to send raw packet (%d)", errno);
+			results->nb_packets_errors++;
+		} else {
+			nb_packets++;
+		}
+
+		/* Wait to maintain rate */
+#if defined(CONFIG_ARCH_POSIX)
+		k_busy_wait(USEC_PER_MSEC);
+#else
+		if (delay > 0) {
+			k_sleep(K_TICKS(delay));
+		}
+#endif
+	} while (last_loop_time < end_time);
+
+	end_time = k_uptime_ticks();
+
+	zsock_close(raw_sock);
+
+	/* Fill in results */
+	results->nb_packets_sent = nb_packets;
+	results->client_time_in_us = k_ticks_to_us_ceil64(end_time - start_time);
+	results->packet_size = packet_size;
+	results->nb_packets_rcvd = 0;        /* TX only, no RX stats */
+	results->nb_packets_lost = 0;
+	results->nb_packets_outorder = 0;
+	results->total_len = (uint64_t)nb_packets * packet_size;
+	results->time_in_us = results->client_time_in_us;
+	results->jitter_in_us = 0;
+	results->is_multicast = false;
+
+	return 0;
+}
+
+int zperf_raw_upload(const struct zperf_raw_upload_params *param,
+		     struct zperf_results *result)
+{
+	if (param == NULL || result == NULL) {
+		return -EINVAL;
+	}
+
+	if (param->if_index <= 0) {
+		NET_ERR("Invalid interface index");
+		return -EINVAL;
+	}
+
+	if (param->hdr_len > CONFIG_NET_ZPERF_RAW_TX_MAX_HDR_SIZE) {
+		NET_ERR("Header length exceeds maximum (%d > %d)",
+			param->hdr_len, CONFIG_NET_ZPERF_RAW_TX_MAX_HDR_SIZE);
+		return -EINVAL;
+	}
+
+	memset(result, 0, sizeof(*result));
+
+	return raw_upload(param, result);
+}
+
+static void raw_upload_async_work(struct k_work *work)
+{
+	struct zperf_raw_async_upload_context *upload_ctx =
+		CONTAINER_OF(work, struct zperf_raw_async_upload_context, work);
+	struct zperf_results result = { 0 };
+	int ret;
+
+	upload_ctx->callback(ZPERF_SESSION_STARTED, NULL, upload_ctx->user_data);
+
+	ret = raw_upload(&upload_ctx->param, &result);
+	if (ret < 0) {
+		upload_ctx->callback(ZPERF_SESSION_ERROR, NULL, upload_ctx->user_data);
+	} else {
+		upload_ctx->callback(ZPERF_SESSION_FINISHED, &result, upload_ctx->user_data);
+	}
+}
+
+int zperf_raw_upload_async(const struct zperf_raw_upload_params *param,
+			   zperf_callback callback, void *user_data)
+{
+	if (param == NULL || callback == NULL) {
+		return -EINVAL;
+	}
+
+	if (param->if_index <= 0) {
+		NET_ERR("Invalid interface index");
+		return -EINVAL;
+	}
+
+	if (param->hdr_len > CONFIG_NET_ZPERF_RAW_TX_MAX_HDR_SIZE) {
+		NET_ERR("Header length exceeds maximum (%d > %d)",
+			param->hdr_len, CONFIG_NET_ZPERF_RAW_TX_MAX_HDR_SIZE);
+		return -EINVAL;
+	}
+
+	if (k_work_is_pending(&raw_async_upload_ctx.work)) {
+		return -EBUSY;
+	}
+
+	memcpy(&raw_async_upload_ctx.param, param, sizeof(*param));
+
+	/* Store metadata in local buffer since caller's buffer may go out of scope */
+	if (param->hdr && param->hdr_len > 0) {
+		memcpy(raw_async_upload_ctx.hdr_storage, param->hdr, param->hdr_len);
+		raw_async_upload_ctx.param.hdr = raw_async_upload_ctx.hdr_storage;
+	}
+
+	raw_async_upload_ctx.callback = callback;
+	raw_async_upload_ctx.user_data = user_data;
+
+	zperf_async_work_submit(SESSION_RAW, -1, &raw_async_upload_ctx.work);
+
+	return 0;
+}
+
+void zperf_raw_uploader_init(void)
+{
+	k_work_init(&raw_async_upload_ctx.work, raw_upload_async_work);
+}
+
+#endif /* CONFIG_NET_ZPERF_RAW_TX */

--- a/west.yml
+++ b/west.yml
@@ -347,7 +347,7 @@ manifest:
       revision: 0f0c43748111c65800c6920f1c0690676423a351
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: eaf223da0c3f987caa1156cbed54b513bee4ba37
+      revision: 29afb11a512787bc68e2afd58c9dfde4bb4d5dc4
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 5efe7974f9546582e99f5a842a816ea4b65f5227


### PR DESCRIPTION
This helps in benchamrking raw socket (packet socket) performance in the lines of UDP/TCP. And is also L2 and vendor agnostic and take meta-data + headers as input (I have only tested using nRF70 over Wi-Fi).