### PR TITLE
twister: cache YAML schema validator to improve config performance

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -5,6 +5,7 @@
 
 import copy
 import warnings
+from collections.abc import Callable
 from typing import Any
 
 import scl
@@ -91,19 +92,19 @@ class TwisterConfigParser:
         "sysbuild": {"type": "bool", "default": False}
     }
 
-    def __init__(self, filename: str, schema: dict[str, Any]) -> None:
+    def __init__(self, filename: str, schema_validator: Callable[[dict[str, Any]], None]) -> None:
         """Instantiate a new TwisterConfigParser object
 
         @param filename Source .yaml file to read
         """
-        self.schema = schema
-        self.filename = filename
+        self.schema_validator: Callable[[dict[str, Any]], None] = schema_validator
+        self.filename: str = filename
         self.data: dict[str, Any] = {}
         self.scenarios: dict[str, Any] = {}
         self.common: dict[str, Any] = {}
 
     def load(self) -> dict[str, Any]:
-        data = scl.yaml_load_verify(self.filename, self.schema)
+        data = scl.yaml_load_verify(self.filename, self.schema_validator)
         self.data = data
 
         if 'tests' in self.data:

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -130,6 +130,7 @@ class DUT:
 
 class HardwareMap:
     schema_path = os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister", "hwmap-schema.yaml")
+    hwm_schema_validator = scl.make_yaml_validator(schema_path)
 
     manufacturer = [
         'ARM',
@@ -268,8 +269,7 @@ class HardwareMap:
         self.duts.append(device)
 
     def load(self, map_file):
-        hwm_schema = scl.yaml_load(self.schema_path)
-        duts = scl.yaml_load_verify(map_file, hwm_schema)
+        duts = scl.yaml_load_verify(map_file, self.hwm_schema_validator)
         for dut in duts:
             pre_script = dut.get('pre_script')
             script_param = dut.get('script_param')

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -50,9 +50,8 @@ class Platform:
 
     Maps directly to BOARD when building"""
 
-    platform_schema = scl.yaml_load(
-        os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister", "platform-schema.yaml")
-    )
+    schema_path = os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister", "platform-schema.yaml")
+    schema_validator = scl.make_yaml_validator(schema_path)
 
     def __init__(self):
         """Constructor.
@@ -215,7 +214,7 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
                 continue
             file = board_dir / "twister.yaml"
             if file.is_file():
-                data = scl.yaml_load_verify(file, Platform.platform_schema)
+                data = scl.yaml_load_verify(file, Platform.schema_validator)
             else:
                 data = None
             dir2data[board_dir] = data
@@ -287,7 +286,7 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
         target2aliases[target] = aliases
 
     for file in legacy_files:
-        data = scl.yaml_load_verify(file, Platform.platform_schema)
+        data = scl.yaml_load_verify(file, Platform.schema_validator)
         target = alias2target.get(data.get("identifier"))
         if target is None:
             continue

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -65,12 +65,12 @@ def test_load_yaml_with_extra_args_and_retrieve_scenario_data(zephyr_base):
       filter: 'filter2'
     '''
 
-    loaded_schema = scl.yaml_load(
+    schema_validator = scl.make_yaml_validator(
         os.path.join(zephyr_base, 'scripts', 'schemas','twister', 'testsuite-schema.yaml')
     )
 
     with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
-        parser = TwisterConfigParser(filename, loaded_schema)
+        parser = TwisterConfigParser(filename, schema_validator)
         parser.load()
 
     scenario_data = parser.get_scenario('scenario1')
@@ -91,12 +91,12 @@ def test_default_values(zephyr_base):
         extra_args: ''
     '''
 
-    loaded_schema = scl.yaml_load(
+    schema_validator = scl.make_yaml_validator(
         os.path.join(zephyr_base, 'scripts', 'schemas', 'twister','testsuite-schema.yaml')
     )
 
     with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
-        parser = TwisterConfigParser(filename, loaded_schema)
+        parser = TwisterConfigParser(filename, schema_validator)
         parser.load()
 
     expected_scenario_data = { 'type': 'integration',
@@ -153,11 +153,11 @@ def test_default_values(zephyr_base):
 )
 
 def test_cast_value(zephyr_base, value, typestr, expected, expected_warning):
-    loaded_schema = scl.yaml_load(
+    schema_validator = scl.make_yaml_validator(
         os.path.join(zephyr_base, 'scripts', 'schemas', 'twister','testsuite-schema.yaml')
     )
 
-    parser = TwisterConfigParser("config.yaml", loaded_schema)
+    parser = TwisterConfigParser("config.yaml", schema_validator)
     with mock.patch('warnings.warn') as warn_mock:
         with pytest.raises(expected) if isinstance(expected, type) and issubclass(expected, Exception) else nullcontext():
             result = parser._cast_value(value, typestr)
@@ -174,12 +174,12 @@ def test_load_invalid_test_config_yaml(zephyr_base):
     gibberish data
     '''
 
-    loaded_schema = scl.yaml_load(
+    schema_validator = scl.make_yaml_validator(
         os.path.join(zephyr_base, 'scripts', 'schemas','twister', 'test-config-schema.yaml')
     )
 
     with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
-        parser = TwisterConfigParser(filename, loaded_schema)
+        parser = TwisterConfigParser(filename, schema_validator)
         with pytest.raises(Exception):
             parser.load()
 
@@ -193,12 +193,12 @@ def test_load_yaml_with_no_scenario_data(zephyr_base):
         extra_args: '--CONF_FILE=file2.conf --OVERLAY_CONFIG=config2.conf'
     '''
 
-    loaded_schema = scl.yaml_load(
+    schema_validator = scl.make_yaml_validator(
         os.path.join(zephyr_base, 'scripts', 'schemas','twister', 'testsuite-schema.yaml')
     )
 
     with mock.patch('builtins.open', mock.mock_open(read_data=yaml_data)):
-        parser = TwisterConfigParser(filename, loaded_schema)
+        parser = TwisterConfigParser(filename, schema_validator)
         parser.load()
 
     with pytest.raises(KeyError):

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -8,6 +8,7 @@ Tests for scl.py functions
 
 import logging
 import sys
+import types
 from contextlib import nullcontext
 from importlib import reload
 from unittest import mock
@@ -17,116 +18,38 @@ import scl
 from pykwalify.errors import SchemaError
 from yaml.scanner import ScannerError
 
-TESTDATA_1 = [
-    (False,),
-    (True,),
-]
 
-@pytest.mark.parametrize(
-    'fail_c',
-    TESTDATA_1,
-    ids=['C YAML', 'non-C YAML']
-)
-def test_yaml_imports(fail_c):
-    class ImportRaiser:
-        def find_spec(self, fullname, path, target=None):
-            if fullname == 'yaml.CLoader' and fail_c:
-                raise ImportError()
-            if fullname == 'yaml.CSafeLoader' and fail_c:
-                raise ImportError()
-            if fullname == 'yaml.CDumper' and fail_c:
-                raise ImportError()
+@pytest.mark.parametrize("has_cyaml", [True, False], ids=["C YAML", "non-C YAML"])
+def test_yaml_imports(has_cyaml):
+    """
+    scl.py does:
+        from yaml import CSafeLoader as SafeLoader
+    falling back to:
+        from yaml import SafeLoader
+    So we simulate a yaml module with/without CSafeLoader.
+    """
+    fake_yaml = types.ModuleType("yaml")
+    fake_yaml.load = mock.Mock()
+    fake_yaml.SafeLoader = object()
+    if has_cyaml:
+        fake_yaml.CSafeLoader = object()
 
-    modules_mock = sys.modules.copy()
-
-    if hasattr(modules_mock['yaml'], 'CLoader'):
-        del modules_mock['yaml'].CLoader
-        del modules_mock['yaml'].CSafeLoader
-        del modules_mock['yaml'].CDumper
-
-    cloader_mock = mock.Mock()
-    loader_mock = mock.Mock()
-    csafeloader_mock = mock.Mock()
-    safeloader_mock = mock.Mock()
-    cdumper_mock = mock.Mock()
-    dumper_mock = mock.Mock()
-
-    if not fail_c:
-        modules_mock['yaml'].CLoader = cloader_mock
-        modules_mock['yaml'].CSafeLoader = csafeloader_mock
-        modules_mock['yaml'].CDumper = cdumper_mock
-
-    modules_mock['yaml'].Loader = loader_mock
-    modules_mock['yaml'].SafeLoader = safeloader_mock
-    modules_mock['yaml'].Dumper = dumper_mock
-
-    meta_path_mock = sys.meta_path[:]
-    meta_path_mock.insert(0, ImportRaiser())
-
-    with mock.patch.dict('sys.modules', modules_mock, clear=True), \
-         mock.patch('sys.meta_path', meta_path_mock):
+    with mock.patch.dict(sys.modules, {"yaml": fake_yaml}):
         reload(scl)
+        assert scl.SafeLoader is (fake_yaml.CSafeLoader if has_cyaml else fake_yaml.SafeLoader)
 
-    assert sys.modules['scl'].Loader == loader_mock if fail_c else \
-                                        cloader_mock
-
-    assert sys.modules['scl'].SafeLoader == safeloader_mock if fail_c else \
-                                        csafeloader_mock
-
-    assert sys.modules['scl'].Dumper == dumper_mock if fail_c else \
-                                        cdumper_mock
-
-    import yaml
-    reload(yaml)
-
-
-TESTDATA_2 = [
-    (False, logging.CRITICAL, []),
-    (True, None, ['can\'t import pykwalify; won\'t validate YAML']),
-]
-
-@pytest.mark.parametrize(
-    'fail_pykwalify, log_level, expected_logs',
-    TESTDATA_2,
-    ids=['pykwalify OK', 'no pykwalify']
-)
-def test_pykwalify_import(caplog, fail_pykwalify, log_level, expected_logs):
-    class ImportRaiser:
-        def find_spec(self, fullname, path, target=None):
-            if fullname == 'pykwalify.core' and fail_pykwalify:
-                raise ImportError()
-
-    modules_mock = sys.modules.copy()
-    modules_mock['pykwalify'] = None if fail_pykwalify else \
-                                modules_mock['pykwalify']
-
-    meta_path_mock = sys.meta_path[:]
-    meta_path_mock.insert(0, ImportRaiser())
-
-    with mock.patch.dict('sys.modules', modules_mock, clear=True), \
-         mock.patch('sys.meta_path', meta_path_mock):
-        reload(scl)
-
-    if log_level:
-        assert logging.getLogger('pykwalify.core').level == log_level
-
-    assert all([log in caplog.text for log in expected_logs])
-
-    if fail_pykwalify:
-        assert scl._yaml_validate(None, None) is None
-        assert scl._yaml_validate(mock.Mock(), mock.Mock()) is None
-
+    # cleanup
     reload(scl)
 
 
-TESTDATA_3 = [
+TESTDATA_1 = [
     (False),
     (True),
 ]
 
 @pytest.mark.parametrize(
     'fail_parsing',
-    TESTDATA_3,
+    TESTDATA_1,
     ids=['ok', 'parsing error']
 )
 def test_yaml_load(caplog, fail_parsing):
@@ -166,8 +89,7 @@ def test_yaml_load(caplog, fail_parsing):
                ' dummy context)' in caplog.text
 
 
-
-TESTDATA_4 = [
+TESTDATA_2 = [
     (True, False, None),
     (False, False, SchemaError),
     (False, True, ScannerError),
@@ -175,76 +97,103 @@ TESTDATA_4 = [
 
 @pytest.mark.parametrize(
     'validate, fail_load, expected_error',
-    TESTDATA_4,
+    TESTDATA_2,
     ids=['successful validation', 'failed validation', 'failed load']
 )
 def test_yaml_load_verify(validate, fail_load, expected_error):
     filename = 'dummy/file.yaml'
-    schema_mock = mock.Mock()
     data_mock = mock.Mock()
 
-    def mock_load(file_name, *args, **kwargs):
+    def mock_load(file_name):
         assert file_name == filename
         if fail_load:
             raise ScannerError
         return data_mock
 
-    def mock_validate(data, schema, *args, **kwargs):
+    def mock_validate(data):
         assert data == data_mock
-        assert schema == schema_mock
         if validate:
             return True
         raise SchemaError(u'Schema validation failed.')
 
     with mock.patch('scl.yaml_load', side_effect=mock_load), \
-         mock.patch('scl._yaml_validate', side_effect=mock_validate), \
          pytest.raises(expected_error) if expected_error else nullcontext():
-        res = scl.yaml_load_verify(filename, schema_mock)
+        res = scl.yaml_load_verify(filename, mock_validate)
 
     if validate:
         assert res == data_mock
 
 
-TESTDATA_5 = [
-    (True, True, None),
-    (True, False, SchemaError),
-    (False, None, None),
-]
+def test_make_yaml_validator_no_schema_path():
+    v = scl.make_yaml_validator("")
+    # should be a no-op
+    assert v({"any": "thing"}) is None
 
-@pytest.mark.parametrize(
-    'schema_exists, validate, expected_error',
-    TESTDATA_5,
-    ids=['successful validation', 'failed validation', 'no schema']
-)
-def test_yaml_validate(schema_exists, validate, expected_error):
-    data_mock = mock.Mock()
-    schema_mock = mock.Mock() if schema_exists else None
 
-    def mock_validate(raise_exception, *args, **kwargs):
-        assert raise_exception
-        if validate:
-            return True
-        raise SchemaError(u'Schema validation failed.')
+def test_make_yaml_validator_pykwalify_ok(monkeypatch):
+    """
+    make_yaml_validator(schema_path) should:
+      - yaml_load(schema_path) to get schema
+      - create pykwalify.core.Core(source_data={}, schema_data=schema)
+      - return validator that sets core.source = data and calls core.validate(raise_exception=True)
+    """
+    schema = {"type": "map", "mapping": {}}
+    core_instance = mock.Mock()
 
-    def mock_core(source_data, schema_data, *args, **kwargs):
-        assert source_data == data_mock
-        assert schema_data == schema_mock
-        return mock.Mock(validate=mock_validate)
 
-    core_mock = mock.Mock(side_effect=mock_core)
+    def core_ctor(*, source_data, schema_data):
+        assert source_data == {}
+        assert schema_data == schema
+        return core_instance
 
-    with mock.patch('pykwalify.core.Core', core_mock), \
-         pytest.raises(expected_error) if expected_error else nullcontext():
-        scl._yaml_validate(data_mock, schema_mock)
+    # Create a fake pykwalify.core module with Core
+    fake_pykwalify_core = types.ModuleType("pykwalify.core")
+    fake_pykwalify_core.Core = mock.Mock(side_effect=core_ctor)
 
-    if schema_exists:
-        core_mock.assert_called_once()
-    else:
-        core_mock.assert_not_called()
+    fake_pykwalify = types.ModuleType("pykwalify")
+    fake_pykwalify.core = fake_pykwalify_core
+
+    monkeypatch.setitem(sys.modules, "pykwalify", fake_pykwalify)
+    monkeypatch.setitem(sys.modules, "pykwalify.core", fake_pykwalify_core)
+
+    monkeypatch.setattr(scl, "yaml_load", mock.Mock(return_value=schema))
+
+    validator = scl.make_yaml_validator("schema.yaml")
+    data = {"any": "thing"}
+    validator(data)
+
+    assert core_instance.source == data
+    core_instance.validate.assert_called_once_with(raise_exception=True)
+    assert logging.getLogger("pykwalify.core").level == 50
+
+
+def test_make_yaml_validator_no_pykwalify(caplog, monkeypatch):
+    """
+    If importing pykwalify.core fails, make_yaml_validator should:
+      - log warning
+      - return no-op validator
+    """
+    monkeypatch.setattr(scl, "yaml_load", mock.Mock(return_value={"type": "map"}))
+
+    real_import = __import__
+
+    def import_hook(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pykwalify.core" or name.startswith("pykwalify"):
+            raise ImportError("no pykwalify for test")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with mock.patch("builtins.__import__", side_effect=import_hook):
+        v = scl.make_yaml_validator("schema.yaml")
+
+    assert "can't import pykwalify; won't validate YAML" in caplog.text
+
+    # no-op
+    assert v({"any": "thing"}) is None
 
 
 def test_yaml_load_empty_file(tmp_path):
     quarantine_file = tmp_path / 'empty_quarantine.yml'
-    quarantine_file.write_text("# yaml file without data")
+    quarantine_file.write_text("# yaml file without data", encoding="utf-8")
     with pytest.raises(scl.EmptyYamlFileException):
-        scl.yaml_load_verify(quarantine_file, None)
+        # validate callable shouldn't be reached, but must be provided
+        scl.yaml_load_verify(quarantine_file, lambda _data: None)

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -15,6 +15,7 @@ import scl
 from twisterlib.error import ConfigurationError
 from twisterlib.testplan import TwisterConfigParser
 
+# pylint: disable=no-name-in-module
 from . import ZEPHYR_BASE
 
 
@@ -31,8 +32,8 @@ def test_yamlload():
 def test_correct_schema(filename, schema, test_data):
     """ Test to validate the testsuite schema"""
     filename = test_data + filename
-    schema = scl.yaml_load(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
-    data = TwisterConfigParser(filename, schema)
+    schema_validator = scl.make_yaml_validator(ZEPHYR_BASE +'/scripts/schemas/twister//' + schema)
+    data = TwisterConfigParser(filename, schema_validator)
     data.load()
     assert data
 
@@ -51,8 +52,8 @@ def test_incorrect_schema(filename, schema, test_data):
 def test_testsuite_config_files():
     """ Test to validate conf and overlay files are extracted properly """
     filename = Path(ZEPHYR_BASE) / "scripts/tests/twister/test_data/test_data_with_deprecation_warnings.yaml"
-    schema = scl.yaml_load(Path(ZEPHYR_BASE) / "scripts/schemas/twister/testsuite-schema.yaml")
-    data = TwisterConfigParser(filename, schema)
+    schema_validator = scl.make_yaml_validator(Path(ZEPHYR_BASE) / "scripts/schemas/twister/testsuite-schema.yaml")
+    data = TwisterConfigParser(filename, schema_validator)
     data.load()
 
     with mock.patch('warnings.warn') as warn_mock:


### PR DESCRIPTION
Avoid reconstructing the YAML validator on every file by creating it once via `make_yaml_validator` and reusing it in `yaml_load_verify`, reducing Twister configuration time.

Unit tests are updated to reflect the changes.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/101592