### PR TITLE
drivers: timer: cortex_m_systick: fix LPM handling with RESET_BY_LPM

### DIFF
--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -105,8 +105,10 @@ config CORTEX_M_SYSTICK_RESET_BY_LPM
 	  special care from the driver - notably, SysTick needs to be restarted
 	  after waking up from such a low-power mode.
 
-	  Select this symbol if your SoC has a low-power mode that places SysTick
-	  under reset. Note that this requires that the platform provides a timer
-	  active in low-power mode, since SysTick cannot be used for timekeeping.
+	  Select this option if your SoC has at least one such low-power mode with
+	  its corresponding "zephyr,power-state" node enabled (i.e., if the system
+	  may enter in a low-power mode that resets SysTick). Note that a low-power
+	  mode timer must be provided by the platform in such configurations since
+	  SysTick cannot be reliably used for timekeeping.
 
 	  Refer to CONFIG_CORTEX_M_SYSTICK_LPM_TIMER for more details.

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -380,6 +380,17 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		 * to it after waking up.
 		 */
 		sys_clock_disable();
+		/* Ensure the SysTick interrupt is not pending. This is safe
+		 * as we just did the ISR's job, and MUST be done because
+		 * a pending interrupt could inhibit low-power mode entry.
+		 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
+		 * writing the write-1-to-clear PENDSTCLR bit.
+		 */
+#ifdef SCB_ICSR_STTNS_Msk
+		SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+		SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
 
 		cycle_count += elapsed();
 		overflow_cyc = 0;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -172,9 +172,9 @@ uint64_t z_cms_lptim_hook_on_lpm_exit(void)
 	uint32_t idle_timer_post, idle_timer_diff, idle_timer_top;
 	bool idle_timer_int_pending, idle_timer_wrap;
 
-	counter_get_value(idle_timer, &idle_timer_post);
 	idle_timer_int_pending = counter_get_pending_int(idle_timer) ? true : false;
 	idle_timer_top = counter_get_top_value(idle_timer);
+	counter_get_value(idle_timer, &idle_timer_post);
 
 	/**
 	 * Check for counter timer overflow


### PR DESCRIPTION
This PR fixes two issues related to low-power mode (LPM) handling in the Cortex-M SysTick timer driver:

### Fix LPM entry with RESET_BY_LPM (Patch 1/2)

When `CONFIG_CORTEX_M_SYSTICK_RESET_BY_LPM` is enabled, clear the pending SysTick interrupt before entering low-power mode. A pending interrupt can inhibit LPM entry or cause immediate wakeup after entry. This is safe since `cycle_count` has already been updated with the elapsed time.

Additionally, improves the `CORTEX_M_SYSTICK_RESET_BY_LPM` Kconfig help text to better clarify when this option should be selected and its requirements.

### Fix counter read order on LPM exit (Patch 2/2)

Read the idle timer counter value **after** getting the interrupt status and top value to ensure more accurate timing measurements when exiting low-power mode. The previous order could result in slight timing inaccuracies due to the counter continuing to run while other values were being read.