### PR TITLE
scripts: check_compliance: fix broken URL in ruff compliance error

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2494,7 +2494,7 @@ class Ruff(ComplianceTest):
             for m in messages:
                 self.fmtd_failure(
                     "error",
-                    f'Python lint error ({m.get("code")}) see {m.get("url")}',
+                    f'Python lint error ({m.get("code")}) see {m.get("url")} ',
                     m.get("filename"),
                     line=m.get("location", {}).get("row"),
                     col=m.get("location", {}).get("column"),


### PR DESCRIPTION
Add a trailing space to the Ruff error message string in the compliance
checking script. Previously, the error message concatenated the URL and
the description with a colon (e.g., ".../unsorted-imports:Import").
This caused the terminal to interpret the description as part of the URL,
resulting in a 404 error when clicked.

Signed-off-by: Thamaraimanalan M <devthamaraimanalan.m@gmail.com>