### PR TITLE
boards: teensy41: Add sdhc0 alias

### DIFF
--- a/boards/pjrc/teensy4/teensy41.dts
+++ b/boards/pjrc/teensy4/teensy41.dts
@@ -9,6 +9,10 @@
 / {
 	model = "PJRC TEENSY 4.1 board";
 
+	aliases {
+		sdhc0 = &usdhc1;
+	};
+
 	chosen {
 		zephyr,flash-controller = &w25q64jvxgim;
 		zephyr,flash = &w25q64jvxgim;


### PR DESCRIPTION
Add a sdhc0 alias to the board so tests/subsys/sd/sdmmc can be build.

Fixes error in weekly CI run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/20547737865/job/59020612530#step:14:3936