### PR TITLE
drivers: flash: spi_nor: fix typo in an error log message

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -848,7 +848,7 @@ static int mxicy_configure(const struct device *dev, const uint8_t *jedec_id)
 		}
 
 		if (ret < 0) {
-			LOG_ERR("Enable high performace mode failed: %d", ret);
+			LOG_ERR("Enable high performance mode failed: %d", ret);
 		}
 
 		release_device(dev);


### PR DESCRIPTION
Fix a typo in an error log message in mxicy_configure.

No functional change.