### PR TITLE
debug: stack: fix missing kernel.h include

### DIFF
--- a/include/zephyr/debug/stack.h
+++ b/include/zephyr/debug/stack.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_DEBUG_STACK_H_
 
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
The header include/zephyr/debug/stack.h uses several kernel APIs and
types (struct k_thread, k_tid_t, k_thread_stack_space_get(),
k_thread_name_get(), ARG_UNUSED), but does not include <zephyr/kernel.h>.

This causes the header to depend on transitive includes and can break
builds depending on include order or future header refactoring.

This change adds an explicit include of <zephyr/kernel.h>, making the
header self-contained and compliant with Zephyr header inclusion
guidelines. No functional changes are introduced.
