### PR TITLE
Bluetooth: CSIP: Fix set member register issue

### DIFF
--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -290,12 +290,17 @@ static void test_new_set_size_and_rank(void)
 
 static void test_register(void)
 {
-	for (size_t iteration = 1; iteration <= 5; iteration++) {
+	for (size_t iteration = 0U; iteration < 5U; iteration++) {
 		struct bt_csip_set_member_svc_inst
 			*svc_insts[CONFIG_BT_CSIP_SET_MEMBER_MAX_INSTANCE_COUNT];
 		int err;
 
-		printk("Running iteration %zu\n", iteration);
+		printk("Running iteration %zu\n", iteration + 1);
+
+		/* Run with different parameters for each iteration */
+		param.lockable = !param.lockable;
+		param.rank = iteration % 2;
+		param.set_size = iteration % 3;
 
 		ARRAY_FOR_EACH(svc_insts, i) {
 			err = bt_csip_set_member_register(&param, &svc_insts[i]);


### PR DESCRIPTION
Fix issue with re-registering CSIS where it relied on a stack allocated value during the service unregistering and reset. To fix this properly, and to allow for further optimization, the register function was refactored to dynamically create the service, rather than relying on a static allocation and dynamically remove unwanted characteristics.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/95543