### PR TITLE
drivers: uart: pl011: fix poll_in function

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -207,7 +207,7 @@ static int pl011_poll_in(const struct device *dev, unsigned char *c)
 	/* got a character */
 	*c = (unsigned char)uart->dr;
 
-	return uart->rsr & PL011_RSR_ERROR_MASK;
+	return 0;
 }
 
 static void pl011_poll_out(const struct device *dev,


### PR DESCRIPTION
RSR handling is already implemented in pl011_err_check(), which is the appropriate place to detect, and report receive error conditions.

This also aligns poll_in() behavior with pl011_fifo_read(), which reads and delivers characters without returning RSR status to the caller.

**nxp imx uart poll_in implementation**
<img width="613" height="309" alt="image" src="https://github.com/user-attachments/assets/3cb5a7ad-234d-4b11-ae25-ba023a13570f" />

Reference: https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/serial/uart_imx.c
