### PR TITLE
twister: replace pykwalify with jsonschema

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -399,7 +399,7 @@ class HardwareMap:
                     for h in hwm:
                         if h['product'] != 'BOOT-SERIAL' :
                             h['connected'] = False
-                            h['serial'] = None
+                            h.pop('serial', None)
                         else :
                             boot_ids.append(h['id'])
 
@@ -412,7 +412,8 @@ class HardwareMap:
                                 h['connected'] is False
                             ]):
                                 h['connected'] = True
-                                h['serial'] = _detected.serial
+                                if _detected.serial:
+                                    h['serial'] = _detected.serial
                                 _detected.match = True
                                 break
 
@@ -445,16 +446,16 @@ class HardwareMap:
                 platform  = _connected.platform
                 id = _connected.id
                 runner = _connected.runner
-                serial = _connected.serial
                 product = _connected.product
                 d = {
                     'platform': platform,
                     'id': id,
                     'runner': runner,
-                    'serial': serial,
                     'product': product,
                     'connected': _connected.connected
                 }
+                if _connected.serial:
+                    d['serial'] = _connected.serial
                 dl.append(d)
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(dl, yaml_file, Dumper=Dumper, default_flow_style=False)

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -1,82 +1,65 @@
-type: seq
-sequence:
-  - type: map
-    required: false
-    mapping:
-      "available":
-        type: bool
-        required: false
-      "connected":
-        type: bool
-        required: true
-      "id":
-        type: str
-        required: true
-      "notes":
-        type: str
-        required: false
-      "platform":
-        type: any
-        required: true
-      "probe_id":
-        type: str
-        required: false
-      "product":
-        type: str
-        required: true
-      "runner":
-        type: str
-        required: true
-      "runner_params":
-        type: seq
-        required: false
-        sequence:
-          - type: str
-      "serial_pty":
-        type: str
-        required: false
-      "serial":
-        type: str
-        required: false
-      "baud":
-        type: int
-        required: false
-      "serial_baud":
-        type: int
-        required: false
-      "post_script":
-        type: str
-        required: false
-      "post_flash_script":
-        type: str
-        required: false
-      "pre_script":
-        type: str
-        required: false
-      "fixtures":
-        type: seq
-        required: false
-        sequence:
-          - type: str
-      "flash_timeout":
-        type: int
-        required: false
-      "flash_with_test":
-        type: bool
-        required: false
-      "flash_before":
-        type: bool
-        required: false
-      "script_param":
-        type: map
-        required: false
-        mapping:
-          "pre_script_timeout":
-            type: int
-            required: false
-          "post_script_timeout":
-            type: int
-            required: false
-          "post_flash_timeout":
-            type: int
-            required: false
+$schema: "https://json-schema.org/draft/2020-12/schema"
+type: array
+items:
+  type: object
+  properties:
+    available:
+      type: boolean
+    connected:
+      type: boolean
+    id:
+      type: string
+    notes:
+      type: string
+    platform: {}
+    probe_id:
+      type: string
+    product:
+      type: string
+    runner:
+      type: string
+    runner_params:
+      type: array
+      items:
+        type: string
+    serial_pty:
+      type: string
+    serial:
+      type: string
+    baud:
+      type: integer
+    serial_baud:
+      type: integer
+    post_script:
+      type: string
+    post_flash_script:
+      type: string
+    pre_script:
+      type: string
+    fixtures:
+      type: array
+      items:
+        type: string
+    flash_timeout:
+      type: integer
+    flash_with_test:
+      type: boolean
+    flash_before:
+      type: boolean
+    script_param:
+      type: object
+      properties:
+        pre_script_timeout:
+          type: integer
+        post_script_timeout:
+          type: integer
+        post_flash_timeout:
+          type: integer
+      additionalProperties: false
+  required:
+    - connected
+    - id
+    - platform
+    - product
+    - runner
+  additionalProperties: false

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -1,130 +1,119 @@
 #
 # Schema to validate a YAML file describing a Zephyr test platform
 #
-# We load this with pykwalify
-# (http://pykwalify.readthedocs.io/en/unstable/validation-rules.html),
-# a YAML structure validator, to validate the YAML files that describe
-# Zephyr test platforms
-#
-# The original spec comes from Zephyr's twister script
-#
-
-schema;platform-schema:
-  type: map
-  mapping:
-    "variants":
-      type: map
-      matching-rule: "any"
-      mapping:
-        regex;(([a-zA-Z0-9_]+)):
-          include: platform-schema
-    "identifier":
-      type: str
-    "maintainers":
-      type: seq
-      seq:
-        - type: str
-    "name":
-      type: str
-    "type":
-      type: str
-      enum: ["mcu", "qemu", "sim", "unit", "native"]
-    "simulation":
-      type: seq
-      seq:
-        - type: map
-          mapping:
-            "name":
-              type: str
-              required: true
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$defs:
+  platform:
+    type: object
+    properties:
+      variants:
+        type: object
+        patternProperties:
+          "[a-zA-Z0-9_]+":
+            $ref: "#/$defs/platform"
+        additionalProperties: false
+      identifier:
+        type: string
+      maintainers:
+        type: array
+        items:
+          type: string
+      name:
+        type: string
+      type:
+        type: string
+        enum: ["mcu", "qemu", "sim", "unit", "native"]
+      simulation:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
               enum:
-                [
-                  "qemu",
-                  "simics",
-                  "xt-sim",
-                  "renode",
-                  "nsim",
-                  "mdb-nsim",
-                  "tsim",
-                  "armfvp",
-                  "native",
-                  "custom",
-                ]
-            "exec":
-              type: str
-    "arch":
-      type: str
-      enum:
-        [
-          # architectures
-          "arc",
-          "arm",
-          "arm64",
-          "mips",
-          "nios2",
-          "posix",
-          "riscv",
-          "rx",
-          "sparc",
-          "x86",
-          "xtensa",
-
-          # unit testing
-          "unit",
-        ]
-    "vendor":
-      type: str
-    "tier":
-      type: int
-    "toolchain":
-      type: seq
-      seq:
-        - type: str
-    "sysbuild":
-      type: bool
-    "env":
-      type: seq
-      seq:
-        - type: str
-    "ram":
-      type: int
-    "flash":
-      type: int
-    "twister":
-      type: bool
-    "supported":
-      type: seq
-      seq:
-        - type: str
-    "testing":
-      type: map
-      mapping:
-        "timeout_multiplier":
-          type: number
-          required: false
-        "default":
-          type: bool
-        "flash_before":
-          type: bool
-          required: false
-        "binaries":
-          type: seq
-          seq:
-            - type: str
-        "only_tags":
-          type: seq
-          seq:
-            - type: str
-        "ignore_tags":
-          type: seq
-          seq:
-            - type: str
-        "renode":
-          type: map
-          mapping:
-            "uart":
-              type: str
-            "resc":
-              type: str
-
-include: platform-schema
+                - qemu
+                - simics
+                - xt-sim
+                - renode
+                - nsim
+                - mdb-nsim
+                - tsim
+                - armfvp
+                - native
+                - custom
+            exec:
+              type: string
+          required:
+            - name
+          additionalProperties: false
+      arch:
+        type: string
+        enum:
+          - arc
+          - arm
+          - arm64
+          - mips
+          - nios2
+          - posix
+          - riscv
+          - rx
+          - sparc
+          - x86
+          - xtensa
+          - unit
+      vendor:
+        type: string
+      tier:
+        type: integer
+      toolchain:
+        type: array
+        items:
+          type: string
+      sysbuild:
+        type: boolean
+      env:
+        type: array
+        items:
+          type: string
+      ram:
+        type: integer
+      flash:
+        type: integer
+      twister:
+        type: boolean
+      supported:
+        type: array
+        items:
+          type: string
+      testing:
+        type: object
+        properties:
+          timeout_multiplier:
+            type: number
+          default:
+            type: boolean
+          flash_before:
+            type: boolean
+          binaries:
+            type: array
+            items:
+              type: string
+          only_tags:
+            type: array
+            items:
+              type: string
+          ignore_tags:
+            type: array
+            items:
+              type: string
+          renode:
+            type: object
+            properties:
+              uart:
+                type: string
+              resc:
+                type: string
+            additionalProperties: false
+        additionalProperties: false
+    additionalProperties: false
+$ref: "#/$defs/platform"

--- a/scripts/schemas/twister/quarantine-schema.yaml
+++ b/scripts/schemas/twister/quarantine-schema.yaml
@@ -2,42 +2,31 @@
 # Schema to validate a YAML file providing the list of configurations
 # under quarantine
 #
-# We load this with pykwalify
-# (http://pykwalify.readthedocs.io/en/unstable/validation-rules.html),
-# a YAML structure validator, to validate the YAML files that provide
-# a list of configurations (scenarios + platforms) under quarantine
-#
-type: seq
-matching: all
-sequence:
-  - type: map
-    required: true
-    matching: all
-    mapping:
-      "scenarios":
-        type: seq
-        required: false
-        sequence:
-          - type: str
-          - unique: true
-      "platforms":
-        required: false
-        type: seq
-        sequence:
-          - type: str
-          - unique: true
-      "architectures":
-        required: false
-        type: seq
-        sequence:
-          - type: str
-          - unique: true
-      "simulations":
-        required: false
-        type: seq
-        sequence:
-          - type: str
-          - unique: true
-      "comment":
-        type: str
-        required: false
+$schema: "https://json-schema.org/draft/2020-12/schema"
+type: array
+items:
+  type: object
+  properties:
+    scenarios:
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+    platforms:
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+    architectures:
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+    simulations:
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+    comment:
+      type: string
+  additionalProperties: false

--- a/scripts/schemas/twister/test-config-schema.yaml
+++ b/scripts/schemas/twister/test-config-schema.yaml
@@ -1,53 +1,47 @@
 #
 # Schema to validate a YAML file describing a Zephyr test configuration.
 #
-
-type: map
-mapping:
-  "options":
-    type: map
-    required: false
-    mapping:
-      "integration_mode":
-        type: seq
-        required: false
-        sequence:
-          - type: str
-  "platforms":
-    type: map
-    required: false
-    mapping:
-      "override_default_platforms":
-        type: bool
-        required: false
-      "increased_platform_scope":
-        type: bool
-        required: false
-      "default_platforms":
-        type: seq
-        required: false
-        sequence:
-          - type: str
-  "levels":
-    type: seq
-    required: false
-    sequence:
-      - type: map
-        required: false
-        mapping:
-          "name":
-            type: str
-            required: true
-          "description":
-            type: str
-            required: false
-          "adds":
-            type: seq
-            required: false
-            sequence:
-              - type: str
-          "inherits":
-            type: seq
-            required: false
-            sequence:
-              - type: str
+$schema: "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  options:
+    type: object
+    properties:
+      integration_mode:
+        type: array
+        items:
+          type: string
+    additionalProperties: false
+  platforms:
+    type: object
+    properties:
+      override_default_platforms:
+        type: boolean
+      increased_platform_scope:
+        type: boolean
+      default_platforms:
+        type: array
+        items:
+          type: string
+    additionalProperties: false
+  levels:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        adds:
+          type: array
+          items:
+            type: string
+        inherits:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+      additionalProperties: false
+additionalProperties: false

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -1,311 +1,230 @@
 #
 # Schema to validate a YAML file describing a Zephyr test platform
 #
-# We load this with pykwalify
-# (http://pykwalify.readthedocs.io/en/unstable/validation-rules.html),
-# a YAML structure validator, to validate the YAML files that describe
-# Zephyr test platforms
-#
-# The original spec comes from Zephyr's twister script
-#
-schema;scenario-schema:
-  type: map
-  # has to be not-required, otherwise the parser gets
-  # confused and things it never found it
-  required: false
-  mapping:
-    "arch_exclude":
-      type: any
-      required: false
-    "arch_allow":
-      type: any
-      required: false
-    "vendor_exclude":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "vendor_allow":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "testcases":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "build_only":
-      type: bool
-      required: false
-    "build_on_all":
-      type: bool
-      required: false
-    "depends_on":
-      type: any
-      required: false
-    "extra_args":
-      type: any
-      required: false
-    "extra_configs":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "extra_conf_files":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "extra_overlay_confs":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "extra_dtc_overlay_files":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "extra_sections":
-      type: any
-      required: false
-    "expect_reboot":
-      type: bool
-      required: false
-    "required_applications":
-      type: seq
-      required: false
-      sequence:
-        - type: map
-          mapping:
-            "name":
-              type: str
-              required: true
-            "platform":
-              type: str
-    "required_snippets":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "filter":
-      type: str
-      required: false
-    "levels":
-      type: seq
-      required: false
-      sequence:
-        - type: str
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$defs:
+  scenario:
+    type: object
+    properties:
+      arch_exclude: {}
+      arch_allow: {}
+      vendor_exclude:
+        type: array
+        items:
+          type: string
+      vendor_allow:
+        type: array
+        items:
+          type: string
+      testcases:
+        type: array
+        items:
+          type: string
+      build_only:
+        type: boolean
+      build_on_all:
+        type: boolean
+      depends_on: {}
+      extra_args: {}
+      extra_configs:
+        type: array
+        items:
+          type: string
+      extra_conf_files:
+        type: array
+        items:
+          type: string
+      extra_overlay_confs:
+        type: array
+        items:
+          type: string
+      extra_dtc_overlay_files:
+        type: array
+        items:
+          type: string
+      extra_sections: {}
+      expect_reboot:
+        type: boolean
+      required_applications:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            platform:
+              type: string
+          required: [name]
+          additionalProperties: false
+      required_snippets:
+        type: array
+        items:
+          type: string
+      filter:
+        type: string
+      levels:
+        type: array
+        items:
+          type: string
           enum: ["smoke", "unit", "integration", "acceptance", "system", "regression"]
-    "integration_platforms":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "integration_toolchains":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "ignore_faults":
-      type: bool
-      required: false
-    "ignore_qemu_crash":
-      type: bool
-      required: false
-    "harness":
-      type: str
-      required: false
-    "harness_config":
-      type: map
-      required: false
-      mapping:
-        "power_measurements":
-          type: any
-          required: false
-        "shell_commands_file":
-          type: str
-          required: false
-        "shell_commands":
-          type: seq
-          required: false
-          sequence:
-            - type: map
-              mapping:
-                "command":
-                  type: str
-                  required: true
-                "expected":
-                  type: str
-        "display_capture_config":
-          type: str
-          required: false
-        "type":
-          type: str
-          required: false
-        "fixture":
-          type: str
-          required: false
-        "ordered":
-          type: bool
-          required: false
-        "pytest_root":
-          type: seq
-          required: false
-          sequence:
-            - type: str
-        "pytest_args":
-          type: seq
-          required: false
-          sequence:
-            - type: str
-        "pytest_dut_scope":
-          type: str
-          enum: ["function", "class", "module", "package", "session"]
-          required: false
-        "ctest_args":
-          type: seq
-          required: false
-          sequence:
-            - type: str
-        "regex":
-          type: seq
-          required: false
-          sequence:
-            - type: str
-        "robot_testsuite":
-          type: any
-          required: false
-        "robot_option":
-          type: any
-          required: false
-        "record":
-          type: map
-          required: false
-          mapping:
-            "regex":
-              type: seq
-              required: true
-              sequence:
-                - type: str
-            "merge":
-              type: bool
-              required: false
-            "as_json":
-              type: seq
-              required: false
-              sequence:
-                - type: str
-        "bsim_exe_name":
-          type: str
-          required: false
-        "ztest_suite_repeat":
-          type: int
-          required: false
-        "ztest_test_repeat":
-          type: int
-          required: false
-        "ztest_test_shuffle":
-          type: bool
-          required: false
-    "min_ram":
-      type: int
-      required: false
-    "min_flash":
-      type: int
-      required: false
-    "modules":
-      type: seq
-      required: false
-      sequence:
-        - type: str
-    "platform_exclude":
-      type: any
-      required: false
-    "platform_allow":
-      type: any
-      required: false
-    "platform_type":
-      type: seq
-      required: false
-      sequence:
-        - type: str
+      integration_platforms:
+        type: array
+        items:
+          type: string
+      integration_toolchains:
+        type: array
+        items:
+          type: string
+      ignore_faults:
+        type: boolean
+      ignore_qemu_crash:
+        type: boolean
+      harness:
+        type: string
+      harness_config:
+        type: object
+        properties:
+          power_measurements: {}
+          shell_commands_file:
+            type: string
+          shell_commands:
+            type: array
+            items:
+              type: object
+              properties:
+                command:
+                  type: string
+                expected:
+                  type: string
+              required: [command]
+              additionalProperties: false
+          display_capture_config:
+            type: string
+          type:
+            type: string
+          fixture:
+            type: string
+          ordered:
+            type: boolean
+          pytest_root:
+            type: array
+            items:
+              type: string
+          pytest_args:
+            type: array
+            items:
+              type: string
+          pytest_dut_scope:
+            type: string
+            enum: ["function", "class", "module", "package", "session"]
+          ctest_args:
+            type: array
+            items:
+              type: string
+          regex:
+            type: array
+            items:
+              type: string
+          robot_testsuite: {}
+          robot_option: {}
+          record:
+            type: object
+            properties:
+              regex:
+                type: array
+                items:
+                  type: string
+              merge:
+                type: boolean
+              as_json:
+                type: array
+                items:
+                  type: string
+            required: [regex]
+            additionalProperties: false
+          bsim_exe_name:
+            type: string
+          ztest_suite_repeat:
+            type: integer
+          ztest_test_repeat:
+            type: integer
+          ztest_test_shuffle:
+            type: boolean
+        additionalProperties: false
+      min_ram:
+        type: integer
+      min_flash:
+        type: integer
+      modules:
+        type: array
+        items:
+          type: string
+      platform_exclude: {}
+      platform_allow: {}
+      platform_type:
+        type: array
+        items:
+          type: string
           enum: ["mcu", "qemu", "sim", "unit", "native"]
-    "platform_key":
-      required: false
-      type: seq
-      matching: "all"
-      sequence:
-        - type: str
-    "simulation_exclude":
-      type: seq
-      required: false
-      sequence:
-        - type: str
+      platform_key:
+        type: array
+        items:
+          type: string
+      simulation_exclude:
+        type: array
+        items:
+          type: string
           enum:
-            [
-              "qemu",
-              "simics",
-              "xt-sim",
-              "renode",
-              "nsim",
-              "mdb-nsim",
-              "tsim",
-              "armfvp",
-              "native",
-              "custom",
-            ]
-    "tags":
-      type: any
-      required: false
-    "timeout":
-      type: int
-      required: false
-    "toolchain_exclude":
-      type: any
-      required: false
-    "toolchain_allow":
-      type: any
-      required: false
-    "type":
-      type: str
-      enum: ["unit"]
-    "skip":
-      type: bool
-      required: false
-    "slow":
-      type: bool
-      required: false
-    "sysbuild":
-      type: bool
-      required: false
+            - qemu
+            - simics
+            - xt-sim
+            - renode
+            - nsim
+            - mdb-nsim
+            - tsim
+            - armfvp
+            - native
+            - custom
+      tags: {}
+      timeout:
+        type: integer
+      toolchain_exclude: {}
+      toolchain_allow: {}
+      type:
+        type: string
+        enum: ["unit"]
+      skip:
+        type: boolean
+      slow:
+        type: boolean
+      sysbuild:
+        type: boolean
+    additionalProperties: false
 
-type: map
-mapping:
-  "common":
-    include: scenario-schema
+type: object
+properties:
+  common:
+    $ref: "#/$defs/scenario"
   # The sample descriptor, if present
-  "sample":
-    type: map
-    required: false
-    mapping:
-      "name":
-        type: str
-        required: true
-      "description":
-        type: str
-        required: false
+  sample:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+    required: [name]
+    additionalProperties: false
   # The list of testcases -- IDK why this is a sequence of
   # maps maps, shall just be a sequence of maps
   # maybe it is just an artifact?
-  "tests":
-    type: map
-    required: true
-    matching-rule: "any"
-    mapping:
-      # The key for the testname is any, so
-      # regex;(([a-zA-Z0-9_]+)) for this to work, note below we
-      # make it required: false
-      regex;(([a-zA-Z0-9_]+)):
-        include: scenario-schema
+  tests:
+    type: object
+    patternProperties:
+      # The key for the testname is any
+      "[a-zA-Z0-9_]+":
+        $ref: "#/$defs/scenario"
+    additionalProperties: false
+required:
+  - tests
+additionalProperties: false

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -324,7 +324,6 @@ def test_hardwaremap_load():
             'serial_baud': 115200,
             'fixtures': [],
             'connected': True,
-            'serial': None,
             'serial_pty': 'dummy',
         },
     }
@@ -572,7 +571,6 @@ TESTDATA_5 = [
             'platform': 'p0',
             'product': 'pr0',
             'connected': False,
-            'serial': None
         },
         {
             'id': 4,
@@ -586,14 +584,12 @@ TESTDATA_5 = [
             'platform': 'p5-5',
             'product': 'pr5-5',
             'connected': False,
-            'serial': None
         },
         {
             'id': 10,
             'platform': 'p10',
             'product': 'pr10',
             'connected': False,
-            'serial': None
         },
         {
             'serial': 's1',
@@ -721,3 +717,83 @@ def test_hardwaremap_dump(
     sys.stderr.write(err)
 
     assert out.strip() == expected_out.strip()
+
+def _run_save_and_get_dump(mocked_hm, *, exists, filename='hwm.yaml', read_data=None):
+    """
+    Run HardwareMap.save() with mocked file I/O and return the object passed to yaml.dump()
+    """
+    dump_mock = mock.Mock()
+
+    if read_data is None:
+        write_mock = mock.mock_open()
+        open_mock = mock.Mock(return_value=write_mock())
+    else:
+        read_mock = mock.mock_open(read_data=read_data)
+        write_mock = mock.mock_open()
+
+        def mock_open(filename, mode='r'):
+            if mode == 'r':
+                return read_mock()
+            if mode == 'w':
+                return write_mock()
+            raise AssertionError(f"unexpected mode {mode}")
+
+        open_mock = mock.Mock(side_effect=mock_open)
+
+    mocked_hm.load = mock.Mock()
+    mocked_hm.dump = mock.Mock()
+
+    with mock.patch('os.path.exists', return_value=exists), \
+         mock.patch('builtins.open', open_mock), \
+         mock.patch('twisterlib.hardwaremap.yaml.dump', dump_mock):
+        mocked_hm.save(filename)
+
+    return dump_mock.call_args.args[0]
+
+def test_hardwaremap_save_omits_serial_when_none(mocked_hm):
+    """
+    Verify 'serial' key is omitted when from the generated hardware map
+    when it is unknown. 'serial' is not required.
+    """
+    # Force one detected device to have no serial
+    mocked_hm.detected = list(mocked_hm.detected)
+    mocked_hm.detected[1].serial = None  # id=2 in mocked_hm fixture
+
+    dumped = _run_save_and_get_dump(mocked_hm, exists=False, filename='hwm.yaml')
+
+    entry = next(d for d in dumped if d['id'] == 2)
+    assert 'serial' not in entry
+
+    # And ensure nobody writes serial=None
+    assert all(d.get('serial') is not None for d in dumped if 'serial' in d)
+
+def test_hardwaremap_save_existing_map_disconnect_omits_serial(mocked_hm):
+    """
+    If the hardware map contained a 'serial' value, then the next time a
+    hardmap is generated and the device is disconnected, and the serial value
+    is unknown, then the new file should not contain the 'serial'.
+    """
+    mocked_hm.detected = []  # simulate unplugged
+
+    hwm = """
+- id: 4
+  platform: p4
+  product: pr4
+  runner: r4
+  connected: True
+  serial: s4
+"""
+
+    dumped = _run_save_and_get_dump(
+        mocked_hm,
+        exists=True,
+        filename='hwmap1.yaml',
+        read_data=hwm,
+    )
+
+    entry = next(d for d in dumped if d['id'] == 4)
+    assert entry['connected'] is False
+    assert 'serial' not in entry
+
+    # And ensure nobody writes serial=None
+    assert all(d.get('serial') is not None for d in dumped if 'serial' in d)


### PR DESCRIPTION
Replace all usage of `pykwalify` with `jsonschema` in twister. For reference see: https://github.com/zephyrproject-rtos/zephyr/issues/90272

Review of the converted YAML files is very much appreciated.

Running twister tests, and the pytests work fine locally for me.