### PR TITLE
boards: nrf52832_mdk: Change I2C compatible from nrf-twi to nrf-twim

### DIFF
--- a/boards/makerdiary/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/makerdiary/nrf52832_mdk/nrf52832_mdk.dts
@@ -118,7 +118,7 @@
 };
 
 &i2c0 {
-	compatible = "nordic,nrf-twi";
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-1 = <&i2c0_sleep>;
@@ -126,7 +126,7 @@
 };
 
 &i2c1 {
-	compatible = "nordic,nrf-twi";
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-1 = <&i2c1_sleep>;


### PR DESCRIPTION
I2C on this board does not work without this modification.

Signed-off-by: Stephen Gordon <stephen@gordonfamily.com.au>