### PR TITLE
drivers: adc: adc_stm32: make set_sequencer void

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -925,7 +925,7 @@ static int set_resolution(const struct device *dev,
 	return 0;
 }
 
-static int set_sequencer(const struct device *dev)
+static void set_sequencer(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	struct adc_stm32_data *data = dev->data;
@@ -985,8 +985,6 @@ static int set_sequencer(const struct device *dev)
 	DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	LL_ADC_SetSequencersScanMode(adc, LL_ADC_SEQ_SCAN_ENABLE);
 #endif /* st_stm32f1_adc || st_stm32f4_adc */
-
-	return 0;
 }
 
 static int start_read(const struct device *dev,
@@ -1029,10 +1027,7 @@ static int start_read(const struct device *dev,
 	}
 
 	/* Configure the sequencer */
-	err = set_sequencer(dev);
-	if (err < 0) {
-		return err;
-	}
+	set_sequencer(dev);
 
 	err = check_buffer(sequence, data->channel_count);
 	if (err) {


### PR DESCRIPTION
set_sequencer() never reports errors and always returns 0. The error check at the call site is therefore dead code.

Make the function void and drop the unused error handling.

Today the function cannot fail and returning an error code is misleading.
If error handling is introduced later, the signature can be updated then.
This change removes dead code and aligns the API with actual behavior.