### PR TITLE
Add board: frdm_mcxe247 hwinfo feature

### DIFF
--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -643,6 +643,11 @@
 			clocks = <&pcc 0x134 KINETIS_PCC_SRC_NONE_OR_EXT>;
 		};
 
+		rcm: rcm@4007F000 {
+			compatible = "nxp,rcm-hwinfo";
+			reg = <0x4007F000 0x1000>;
+		};
+
 		rtc: rtc@4003d000 {
 			compatible = "nxp,rtc";
 			reg = <0x4003d000 0x1000>;
@@ -704,6 +709,11 @@
 			compatible = "nxp,crc";
 			reg = <0x40032000 0x1000>;
 			status = "disabled";
+		};
+
+		uuid: uuid@40048000 {
+			compatible = "nxp,sim-uuid";
+			reg = <0x40048000 0x1000>;
 		};
 	};
 };


### PR DESCRIPTION
1. Support uuid/get reset flags features for mcxe24x platorm.

2. Test passed on hwinfo/api cases:


<details><summary>Details</summary>
<p>

*** Booting Zephyr OS build v4.3.0-3077-g9d9529f0dbce ***
Running TESTSUITE hwinfo_device_id_api
===================================================================
START - test_clear_reset_cause
 PASS - test_clear_reset_cause in 0.001 seconds
===================================================================
START - test_device_id_get
 PASS - test_device_id_get in 0.001 seconds
===================================================================
START - test_get_reset_cause
 PASS - test_get_reset_cause in 0.001 seconds
===================================================================
START - test_get_supported_reset_cause
 PASS - test_get_supported_reset_cause in 0.001 seconds
===================================================================
TESTSUITE hwinfo_device_id_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [hwinfo_device_id_api]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.004 seconds
 - PASS - [hwinfo_device_id_api.test_clear_reset_cause] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_device_id_get] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_get_reset_cause] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_get_supported_reset_cause] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

</p>
</details> 