### PR TITLE
twister: avoid scanning subcases for unselected test suites

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -589,6 +589,11 @@ class TestPlan:
                             detailed_test_id=self.options.detailed_test_id
                         )
 
+                        if not self._is_testsuite_selected(suite, testsuite_filter,
+                                                       testsuite_patterns_r):
+                            # skip testsuite if they were not selected directly by the user
+                            continue
+
                         # convert to fully qualified names
                         suite.integration_platforms = self.verify_platforms_existence(
                                 suite.integration_platforms,
@@ -608,10 +613,6 @@ class TestPlan:
                         else:
                             suite.add_subcases(suite_dict)
 
-                        if not self._is_testsuite_selected(suite, testsuite_filter,
-                                                       testsuite_patterns_r):
-                            # skip testsuite if they were not selected directly by the user
-                            continue
                         if suite.name in self.testsuites:
                             msg = (
                                 f"test suite '{suite.name}' in '{suite.yamlfile}' is already added"


### PR DESCRIPTION
Optimize testsuite discovery by skipping subcase scans for filtered suites

----

When I run a single test like this:

`viztracer --min_duration 0.1ms -o twister.trace.json -- west twister -j 1 -s utilities.lists`

Currently 4048 subcases are processed via `add_subcases()` but after this commit, only 1 subcase is processed. This reduces the execution time of `TestPlan.add_testsuites` by ~1.5 seconds on my end.

----

This is just an idea for optimizing things. Hopefully it passes CI.

We can probably squeeze more speed here by avoiding to create `TestSuite` instance for unused test suites. Mainly to avoid calls to `os.path.relpath` and `os.path.realpath`