### PR TITLE
arch: riscv: avoid GNU statement-expr CSR write macros

### DIFF
--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -202,12 +202,13 @@
 })
 
 #define csr_write(csr, val)					\
-({								\
-	unsigned long __wv = (unsigned long)(val);		\
-	__asm__ volatile ("csrw " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__wv)			\
-				: "memory");			\
-})
+	do {							\
+		unsigned long __wv = (unsigned long)(val);	\
+		__asm__ volatile ("csrw " STRINGIFY(csr) ", %0"	\
+				  :				\
+				  : "rK" (__wv)		\
+				  : "memory");		\
+	} while (0)
 
 
 #define csr_read_set(csr, val)					\
@@ -220,12 +221,13 @@
 })
 
 #define csr_set(csr, val)					\
-({								\
-	unsigned long __sv = (unsigned long)(val);		\
-	__asm__ volatile ("csrs " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__sv)			\
-				: "memory");			\
-})
+	do {							\
+		unsigned long __sv = (unsigned long)(val);	\
+		__asm__ volatile ("csrs " STRINGIFY(csr) ", %0"	\
+				  :				\
+				  : "rK" (__sv)		\
+				  : "memory");		\
+	} while (0)
 
 #define csr_read_clear(csr, val)				\
 ({								\
@@ -237,12 +239,13 @@
 })
 
 #define csr_clear(csr, val)					\
-({								\
-	unsigned long __cv = (unsigned long)(val);		\
-	__asm__ volatile ("csrc " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__cv)			\
-				: "memory");			\
-})
+	do {							\
+		unsigned long __cv = (unsigned long)(val);	\
+		__asm__ volatile ("csrc " STRINGIFY(csr) ", %0"	\
+				  :				\
+				  : "rK" (__cv)		\
+				  : "memory");		\
+	} while (0)
 
 #ifdef CONFIG_RISCV_ISA_EXT_SMCSRIND
 


### PR DESCRIPTION
csr_write(), csr_set(), and csr_clear() use GNU C statement expressions, which triggers SonarQube/clang warnings like:

  use of GNU statement expression extension from macro expansion

Rewrite these write-only macros as do { ... } while (0) statement macros.

Originally found in this PR - https://github.com/zephyrproject-rtos/zephyr/pull/99767#issuecomment-3707281271 but propagates to all the calls of those expressions in RISC-V common code, i.e. https://sonarcloud.io/project/issues?issues=AZrq1UakVaa-_XHkDih5&open=AZrq1UakVaa-_XHkDih5&id=zephyrproject-rtos_zephyr.