### PR TITLE
drivers: spi: avoid duplicating tx/rx length selection logic

### DIFF
--- a/drivers/spi/spi_renesas_ra_sci_b.c
+++ b/drivers/spi/spi_renesas_ra_sci_b.c
@@ -156,13 +156,7 @@ static void spi_renesas_ra_sci_b_retransmit(struct spi_renesas_ra_sci_b_data *da
 {
 	fsp_err_t fsp_err;
 
-	if (data->ctx.rx_len == 0) {
-		data->data_len = data->ctx.tx_len;
-	} else if (data->ctx.tx_len == 0) {
-		data->data_len = data->ctx.rx_len;
-	} else {
-		data->data_len = MIN(data->ctx.tx_len, data->ctx.rx_len);
-	}
+	data->data_len = spi_context_max_continuous_chunk(&data->ctx);
 
 	if (data->ctx.rx_buf == NULL) {
 		fsp_err = R_SCI_B_SPI_Write(&data->fsp_ctrl, data->ctx.tx_buf, data->data_len,

--- a/drivers/spi/spi_renesas_rz_rspi.c
+++ b/drivers/spi/spi_renesas_rz_rspi.c
@@ -76,13 +76,7 @@ static void spi_rz_rspi_retransmit(const struct device *dev)
 	struct spi_rz_rspi_data *data = dev->data;
 	const struct spi_rz_rspi_config *config = dev->config;
 
-	if (data->ctx.rx_len == 0) {
-		data->data_len = data->ctx.tx_len;
-	} else if (data->ctx.tx_len == 0) {
-		data->data_len = data->ctx.rx_len;
-	} else {
-		data->data_len = MIN(data->ctx.tx_len, data->ctx.rx_len);
-	}
+	data->data_len = spi_context_max_continuous_chunk(&data->ctx);
 
 	if (data->ctx.tx_buf == NULL) { /* If there is only the rx buffer */
 		config->fsp_api->read(data->fsp_ctrl, data->ctx.rx_buf, data->data_len,

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1498,13 +1498,7 @@ static int transceive_dma(const struct device *dev,
 		data->status_flags = 0;
 
 		if (transfer_dir == LL_SPI_FULL_DUPLEX) {
-			if (data->ctx.rx_len == 0) {
-				dma_len = data->ctx.tx_len;
-			} else if (data->ctx.tx_len == 0) {
-				dma_len = data->ctx.rx_len;
-			} else {
-				dma_len = MIN(data->ctx.tx_len, data->ctx.rx_len);
-			}
+			dma_len = spi_context_max_continuous_chunk(&data->ctx);
 
 			ret = spi_dma_move_buffers(dev, dma_len);
 		} else if (transfer_dir == LL_SPI_HALF_DUPLEX_TX) {

--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -400,13 +400,7 @@ static int spi_xmc4xxx_transceive_dma(const struct device *dev, const struct spi
 			XMC_USIC_CH_TBUF_STATUS_BUSY) {
 		};
 
-		if (data->ctx.rx_len == 0) {
-			dma_len = data->ctx.tx_len;
-		} else if (data->ctx.tx_len == 0) {
-			dma_len = data->ctx.rx_len;
-		} else {
-			dma_len = MIN(data->ctx.tx_len, data->ctx.rx_len);
-		}
+		dma_len = spi_context_max_continuous_chunk(&data->ctx);
 
 		if (ctx->rx_buf) {
 


### PR DESCRIPTION
For clarity and compactness, use `spi_context_max_continuous_chunk()` instead of open-coding the same tx/rx length selection logic.