### PR TITLE
dts: bindings: vendor-prefixes: Remove "The" from Zephyr Project

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -803,7 +803,7 @@ zarlink	Zarlink Semiconductor
 zb	Zbit Semiconductor, Inc.
 zealz	Zealz
 zeitec	ZEITEC Semiconductor Co., LTD.
-zephyr	The Zephyr Project
+zephyr	Zephyr Project
 zidoo	Shenzhen Zidoo Technology Co., Ltd.
 zii	Zodiac Inflight Innovations
 zinitix	Zinitix Co., Ltd

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -614,7 +614,7 @@ ZTEST(devicetree_api, test_bus)
 #define DT_DRV_COMPAT vnd_vendor
 
 #define VND_VENDOR "A stand-in for a real vendor which can be used in examples and tests"
-#define ZEP_VENDOR "The Zephyr Project"
+#define ZEP_VENDOR "Zephyr Project"
 
 ZTEST(devicetree_api, test_vendor)
 {


### PR DESCRIPTION
Drop the leading article from the 'zephyr' vendor name in vendor-prefixes.txt so vendor names sort more naturally in the [Supported Boards][1] lists.

[1]: https://docs.zephyrproject.org/latest/boards/index.html

This fixes #94624
This is related to #101741