### PR TITLE
drivers: timer: cortex_m_systick: add devicetree clock-source property

### DIFF
--- a/dts/bindings/timer/cortex-m-systick.yaml
+++ b/dts/bindings/timer/cortex-m-systick.yaml
@@ -7,3 +7,11 @@ include: base.yaml
 properties:
   reg:
     required: true
+
+  external-clock-source:
+    type: boolean
+    description: |
+      For ARM Cortex-M SysTick timer, the CLKSOURCE bit in the
+      SysTick Control and Status Register (CSR) selects the clock source.
+      If this property is present, the external reference clock is selected.
+      If absent, the processor/core clock is selected.


### PR DESCRIPTION
Add support for configuring the SysTick clock source via devicetree using a new `clock-source` property. This allows selecting between the external reference clock (0) and the processor clock (1).

Previously, the driver always set the CLKSOURCE bit, forcing the use of the processor clock. This change introduces a helper function `systick_ctrl_clksource_flag_from_dt()` that reads the devicetree property and returns the appropriate CTRL register flag.

The CTRL register is now programmed deterministically using direct assignment instead of `|=` to ensure the CLKSOURCE bit is properly cleared when switching to external clock, preventing potential interrupt storms when CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC reflects the external clock rate.

If the property is absent, the driver defaults to legacy behavior (processor clock).

SysTick Control and Status Register: https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/system-timer--systick/systick-control-and-status-register?lang=en