### PR TITLE
bluetooth: hci: nxp: Reduce the fw sending buffer size

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -175,7 +175,7 @@ struct change_speed_config {
 	uint32_t fcr_val;
 };
 
-#define SEND_BUFFER_MAX_LENGTH  0xFFFFU /* Maximum 2 byte value */
+#define SEND_BUFFER_MAX_LENGTH  4096 /* The supported maximum FW chunk size is 4 KB */
 #define RECV_RING_BUFFER_LENGTH 1024
 
 struct nxp_ctlr_fw_upload_state {
@@ -184,7 +184,7 @@ struct nxp_ctlr_fw_upload_state {
 
 	uint8_t buffer[A6REQ_PAYLOAD_LEN + REQ_HEADER_LEN + 1];
 
-	uint8_t send_buffer[SEND_BUFFER_MAX_LENGTH + 1];
+	uint8_t send_buffer[SEND_BUFFER_MAX_LENGTH];
 
 	struct {
 		uint8_t buffer[RECV_RING_BUFFER_LENGTH];
@@ -880,6 +880,15 @@ static int fw_upload_v1_send_data(uint16_t len)
 		len = fw_upload.fw_length - fw_upload.current_length;
 	}
 
+	__ASSERT(sizeof(fw_upload.send_buffer) >= len, "V1: Out of sending buffer range (%u < %u)",
+		 sizeof(fw_upload.send_buffer), len);
+
+	if (sizeof(fw_upload.send_buffer) < len) {
+		LOG_ERR("V1: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+			len);
+		return -ENOMEM;
+	}
+
 	memcpy(fw_upload.send_buffer, fw_upload.fw + fw_upload.current_length, len);
 	fw_upload.current_length += len;
 	cmd = sys_get_le32(fw_upload.send_buffer);
@@ -930,6 +939,16 @@ static int fw_upload_v3_send_data(void)
 	if ((fw_upload.length + start) > fw_upload.fw_length) {
 		fw_upload.length = fw_upload.fw_length - start;
 	}
+	__ASSERT(sizeof(fw_upload.send_buffer) >= fw_upload.length,
+		 "V3: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+		 fw_upload.length);
+
+	if (sizeof(fw_upload.send_buffer) < fw_upload.length) {
+		LOG_ERR("V3: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+			fw_upload.length);
+		return -ENOMEM;
+	}
+
 	memcpy(fw_upload.send_buffer, fw_upload.fw + start, fw_upload.length);
 	fw_upload.current_length = start + fw_upload.length;
 


### PR DESCRIPTION
In current implementation, the sending buffer size is 0x10000. This will result in a very small amount of RAM available for the application. Actually, the maximum required sending buffer size is 4KB.

Reduce the maximum sending buffer size by changing `SEND_BUFFER_MAX_LENGTH` from 64KB to 4KB.
And add runtime assertions to prevent buffer overflows during firmware upload.

- Change SEND_BUFFER_MAX_LENGTH from 0xFFFF to 4096 (4 KB)
  * Reflects the actual maximum FW chunk size supported by hardware
  * Reduces memory footprint from 64 KB to 4 KB
- Remove unnecessary +1 from send_buffer array size
- Add __ASSERT checks in fw_upload_v1_send_data() to validate memcpy does not exceed buffer size
- Add __ASSERT checks in fw_upload_v3_send_data() to validate memcpy does not exceed buffer size

This prevents potential buffer overflows when copying firmware data and ensures the buffer size matches hardware capabilities.