### PR TITLE
tests: Bluetooth: Tester: Various format fixes for the Readme

### DIFF
--- a/tests/bluetooth/tester/README.rst
+++ b/tests/bluetooth/tester/README.rst
@@ -8,7 +8,7 @@ stack. BTP commands and events are received and buffered for further processing
 over the same serial.
 
 BTP specification can be found in auto-pts project repository:
-https://github.com/intel/auto-pts
+https://github.com/auto-pts/auto-pts
 The auto-pts is an automation framework for PTS Bluetooth testing tool provided
 by Bluetooth SIG.
 
@@ -67,39 +67,38 @@ QEMU should have connection with the external host Bluetooth hardware.
 The btproxy tool from BlueZ can be used to give access to a Bluetooth controller
 attached to the Linux host OS:
 
-$ sudo tools/btproxy -u
-Listening on /tmp/bt-server-bredr
+.. code-block::
 
-/tmp/bt-server-bredr option is already set in Makefile through QEMU_EXTRA_FLAGS.
+    $ sudo tools/btproxy -u
+    Listening on /tmp/bt-server-bredr
 
-To build tester application for QEMU use BOARD=qemu_cortex_m3 and
-CONF_FILE=qemu.conf. After this qemu can be started through the "run"
-build target.
+``/tmp/bt-server-bredr`` option is already set in Makefile through ``QEMU_EXTRA_FLAGS``.
 
-Note: Target board have to support enough UARTs for BTP and controller.
-      We recommend using qemu_cortex_m3.
+To build tester application for QEMU use ``BOARD=qemu_cortex_m3`` and ``CONF_FILE=qemu.conf``.
+After this qemu can be started through the "run" build target.
 
-'bt-stack-tester' UNIX socket (previously set in Makefile) can be used for now
+Note: Target board has to support enough UARTs for BTP and controller. We recommend using ``qemu_cortex_m3``.
+
+``bt-stack-tester`` UNIX socket (previously set in Makefile) can be used for now
 to control tester application.
 
-Next, build and flash tester application by employing the "flash" build
-target.
+Next, build and flash tester application by using ``west build`` and ``west flash``.
 
-Use serial client, e.g. PUTTY to communicate over the serial port
-(typically /dev/ttyUSBx) with the tester using BTP.
+Use serial client, e.g. ``PuTTY`` to communicate over the serial port
+(typically ``/dev/ttyUSBx``) with the tester using BTP.
 
-Building and running on :zephyr:board:`native_sim <native_sim>` on Linux
-************************************************************************
+Building and running on ``native_sim`` on Linux
+***********************************************
 
 It is possible to build and run the tester application using the
-:zephyr:board:`native_sim <native_sim>` board, and any compatible HCI controller.
-This has the advantage of allowing the use of Linux debugging tools like valgrind and gdb,
-as well as tools like btmon.
+``native_sim`` board, and any compatible HCI controller.
+This has the advantage of allowing the use of Linux debugging tools like ``valgrind`` and ``gdb``,
+as well as tools like ``btmon``.
 It is also faster to apply changes to the code,
-as building for :zephyr:board:`native_sim <native_sim>` is usually faster,
+as building for ``native_sim`` is usually faster,
 and there is no flashing step involved.
 
-Building for :zephyr:board:`native_sim <native_sim>` is just
+Building for ``native_sim`` is just
 
 .. code-block::
 
@@ -116,13 +115,14 @@ However for the purpose of running the tester application with auto-pts,
 running the application is left to the auto-pts client.
 
 
-Building the Zephyr controller for a :zephyr:board:`native_sim <native_sim>` host on Linux
-==========================================================================================
+Building the Zephyr controller for a ``native_sim`` host on Linux
+=================================================================
 
 To build and flash the Zephyr controller as an HCI controller usable by Linux,
-either the :zephyr:code-sample:`bluetooth_hci_uart` or :zephyr:code-sample:`bluetooth_hci_usb`
+either the `bluetooth_hci_uart <https://docs.zephyrproject.org/latest/samples/bluetooth/hci_uart/README.html>`__
+or `bluetooth_hci_usb <https://docs.zephyrproject.org/latest/samples/bluetooth/hci_usb/README.html>`__
 samples can be used.
-See also :ref:`bluetooth-tools`.
+See also `bluetooth-tools <https://docs.zephyrproject.org/latest/connectivity/bluetooth/bluetooth-tools.html>`__.
 When building these samples, the tester application controller overlay should be supplied.
 For example
 
@@ -142,7 +142,7 @@ For single core boards like the nRF52840 DK it is a bit simpler and can be done 
     west build -b nrf52840dk/nrf52840 ${ZEPHYR_BASE}/samples/bluetooth/hci_uart/ -- -DEXTRA_CONF_FILE=${ZEPHYR_BASE}/tests/bluetooth/tester/overlay-bt_ll_sw_split.conf
     west flash
 
-The :zephyr:code-sample:`bluetooth_hci_usb` sample can also be used,
+The `bluetooth_hci_usb <https://docs.zephyrproject.org/latest/samples/bluetooth/hci_usb/README.html>`__ sample can also be used,
 but support for Bluetooth Isochronous channels is not yet fully supported.
 
 Building for LE Audio
@@ -154,21 +154,22 @@ e.g.:
 
 .. code-block::
 
-    west build -b nrf5340dk/nrf5340/cpuapp --sysbuild \
-        -- -DEXTRA_CONF_FILE=overlay-le-audio.conf;hci_ipc.conf
+    west build -b nrf5340dk/nrf5340/cpuapp --sysbuild -- -DEXTRA_CONF_FILE=overlay-le-audio.conf;hci_ipc.conf
 
-Building with support for btsnoop and rtt logs
+Building with support for BTSnoop and RTT logs
 **********************************************
 
 Add following options in desired configuration file:
 
-CONFIG_LOG=n
-CONFIG_LOG_BACKEND_RTT=y
-CONFIG_LOG_BACKEND_RTT_BUFFER=1
-CONFIG_LOG_BACKEND_RTT_MODE_DROP=n
+.. code-block::
 
-CONFIG_USE_SEGGER_RTT=y
-CONFIG_SEGGER_RTT_SECTION_CUSTOM=y
+    CONFIG_LOG=n
+    CONFIG_LOG_BACKEND_RTT=y
+    CONFIG_LOG_BACKEND_RTT_BUFFER=1
+    CONFIG_LOG_BACKEND_RTT_MODE_DROP=n
 
-CONFIG_BT_DEBUG_MONITOR_RTT=y
-CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER=2
+    CONFIG_USE_SEGGER_RTT=y
+    CONFIG_SEGGER_RTT_SECTION_CUSTOM=y
+
+    CONFIG_BT_DEBUG_MONITOR_RTT=y
+    CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER=2


### PR DESCRIPTION
Since this file is not built with the documentation system, some of the references didn't work. References to tools, boards, etc. have been encapsulated by the appropriate ticks.