### PR TITLE
kernel: timer: let `k_timer_status_sync()` idle the CPU when MT is off

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -268,18 +268,20 @@ uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 		uint32_t result;
 
 		do {
-			k_spinlock_key_t key = k_spin_lock(&lock);
+			unsigned int key = irq_lock();
 
 			if (!z_is_inactive_timeout(&timer->timeout)) {
 				result = *(volatile uint32_t *)&timer->status;
 				timer->status = 0U;
-				k_spin_unlock(&lock, key);
 				if (result > 0) {
+					irq_unlock(key);
 					break;
+				} else {
+					k_cpu_atomic_idle(key);
 				}
 			} else {
 				result = timer->status;
-				k_spin_unlock(&lock, key);
+				irq_unlock(key);
 				break;
 			}
 		} while (true);


### PR DESCRIPTION
This patch modifies `k_timer_status_sync()` to idle the CPU when MT is disabled, instead of busy-looping. For this purpose, the spinlock in the `MULTITHREADING=n` case has been reduced to a `irq_lock()`, which works in pair with `k_cpu_atomic_idle()` to ensure the atomicity of enabling the IRQs and idling the CPU.

See also #101192 