### PR TITLE
drivers: video: imx335: Add 2x2 binning and high refresh rate support

### DIFF
--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -21,10 +21,18 @@
 
 LOG_MODULE_REGISTER(video_imx335, CONFIG_VIDEO_LOG_LEVEL);
 
-#define IMX335_WIDTH	2592
-#define IMX335_HEIGHT	1944
+#define IMX335_NATIVE_WIDTH	2592
+#define IMX335_NATIVE_HEIGHT	1944
+
+#define IMX335_BIN_2X2_WIDTH	1296
+#define IMX335_BIN_2X2_HEIGHT	972
 
 #define IMX335_PIXEL_RATE	396000000
+
+enum imx335_res {
+	IMX335_RES_2592x1944,
+	IMX335_RES_1296x972,
+};
 
 struct imx335_config {
 	struct i2c_dt_spec i2c;
@@ -43,6 +51,7 @@ struct imx335_ctrls {
 struct imx335_data {
 	struct imx335_ctrls ctrls;
 	struct video_format fmt;
+	bool enabled;
 };
 
 #define IMX335_REG8(addr)  ((addr) | VIDEO_REG_ADDR16_DATA8)
@@ -60,12 +69,15 @@ struct imx335_data {
 #define IMX335_HTRIMMING_START		IMX335_REG16(0x302c)
 #define IMX335_HNUM			IMX335_REG16(0x302e)
 #define IMX335_VMAX			IMX335_REG24(0x3030)
+#define IMX335_HMAX			IMX335_REG16(0x3034)
 #define IMX335_VMAX_DEFAULT		4500
 #define IMX335_OPB_SIZE_V		IMX335_REG8(0x304c)
 #define IMX335_ADBIT			IMX335_REG8(0x3050)
 #define IMX335_Y_OUT_SIZE		IMX335_REG16(0x3056)
 #define IMX335_SHR0			IMX335_REG24(0x3058)
 #define IMX335_SHR0_MIN			9
+#define IMX335_SHR0_MIN_BINNING		17
+#define IMX335_AREA2_WIDTH_1		IMX335_REG16(0x3072)
 #define IMX335_AREA3_ST_ADR_1		IMX335_REG16(0x3074)
 #define IMX335_AREA3_WIDTH_1		IMX335_REG16(0x3076)
 #define IMX335_GAIN			IMX335_REG16(0x30e8)
@@ -76,17 +88,17 @@ struct imx335_data {
 #define IMX335_INCKSEL2_PLL_IF_GC	IMX335_REG8(0x315a)
 #define IMX335_INCKSEL3			IMX335_REG8(0x3168)
 #define IMX335_INCKSEL4			IMX335_REG8(0x316a)
+#define IMX335_HADD_VADD		IMX335_REG8(0x3199)
 #define IMX335_MDBIT			IMX335_REG8(0x319d)
 #define IMX335_XVS_XHS_DRV		IMX335_REG8(0x31a1)
+#define IMX335_TCYCLE			IMX335_REG8(0x3300)
 #define IMX335_ADBIT1			IMX335_REG16(0x341c)
 #define IMX335_LANEMODE			IMX335_REG8(0x3a01)
 static const struct video_reg imx335_init_params[] = {
 	{IMX335_STANDBY, 0x01},
 	{IMX335_XMSTA, 0x00},
-	{IMX335_WINMODE, 0x04},
 	{IMX335_HTRIMMING_START, 0x3c},
 	{IMX335_HNUM, 0x0a20},
-	{IMX335_OPB_SIZE_V, 0x00},
 	{IMX335_Y_OUT_SIZE, 0x0798},
 	{IMX335_AREA3_ST_ADR_1, 0x00c8},
 	{IMX335_AREA3_WIDTH_1, 0x0f30},
@@ -164,6 +176,87 @@ static const struct video_reg16 imx335_fixed_regs[] = {
 	{0x3a00, 0x01},
 };
 
+static const struct video_reg imx335_bin_2x2[] = {
+	{IMX335_WINMODE, 0x01},
+	{IMX335_Y_OUT_SIZE, 0x03D8},
+	{IMX335_AREA2_WIDTH_1, 0x0030},
+	{IMX335_AREA3_ST_ADR_1, 0x00A8},
+	{IMX335_AREA3_WIDTH_1, 0x0F60},
+	{IMX335_HADD_VADD, 0x30},
+	{IMX335_TCYCLE, 0x01},
+	/* Fixed regs for 2/2 binning */
+	{IMX335_REG8(0x3078), 0x04},
+	{IMX335_REG8(0x3079), 0xFD},
+	{IMX335_REG8(0x307A), 0x04},
+	{IMX335_REG8(0x307B), 0xFE},
+	{IMX335_REG8(0x307C), 0x04},
+	{IMX335_REG8(0x307D), 0xFB},
+	{IMX335_REG8(0x307E), 0x04},
+	{IMX335_REG8(0x307F), 0x02},
+	{IMX335_REG8(0x3080), 0x04},
+	{IMX335_REG8(0x3081), 0xFD},
+	{IMX335_REG8(0x3082), 0x04},
+	{IMX335_REG8(0x3083), 0xFE},
+	{IMX335_REG8(0x3084), 0x04},
+	{IMX335_REG8(0x3085), 0xFB},
+	{IMX335_REG8(0x3086), 0x04},
+	{IMX335_REG8(0x3087), 0x02},
+	{IMX335_REG8(0x30A4), 0x77},
+	{IMX335_REG8(0x30A8), 0x20},
+	{IMX335_REG8(0x30A9), 0x00},
+	{IMX335_REG8(0x30AC), 0x08},
+	{IMX335_REG8(0x30AD), 0x08},
+	{IMX335_REG8(0x30B0), 0x20},
+	{IMX335_REG8(0x30B1), 0x00},
+	{IMX335_REG8(0x30B4), 0x10},
+	{IMX335_REG8(0x30B5), 0x10},
+	{IMX335_REG16(0x30B6), 0x0000},
+	{IMX335_REG16(0x3112), 0x0010},
+	{IMX335_REG16(0x3116), 0x0010},
+};
+
+/* Note that this only contains registers that need to be reset when switching away from
+ * 2x2 binning mode
+ */
+static const struct video_reg imx335_bin_none[] = {
+	{IMX335_WINMODE, 0x00},
+	{IMX335_Y_OUT_SIZE, 0x07AC},
+	{IMX335_AREA2_WIDTH_1, 0x0028},
+	{IMX335_AREA3_ST_ADR_1, 0x00B0},
+	{IMX335_AREA3_WIDTH_1, 0x0F58},
+	{IMX335_HADD_VADD, 0x00},
+	{IMX335_TCYCLE, 0x00},
+	/* Reset fixed regs from binning to all-pixel scan */
+	{IMX335_REG8(0x3078), 0x01},
+	{IMX335_REG8(0x3079), 0x02},
+	{IMX335_REG8(0x307A), 0xFF},
+	{IMX335_REG8(0x307B), 0x02},
+	{IMX335_REG8(0x307C), 0x00},
+	{IMX335_REG8(0x307D), 0x00},
+	{IMX335_REG8(0x307E), 0x00},
+	{IMX335_REG8(0x307F), 0x00},
+	{IMX335_REG8(0x3080), 0x01},
+	{IMX335_REG8(0x3081), 0x02},
+	{IMX335_REG8(0x3082), 0xFF},
+	{IMX335_REG8(0x3083), 0x02},
+	{IMX335_REG8(0x3084), 0x00},
+	{IMX335_REG8(0x3085), 0x00},
+	{IMX335_REG8(0x3086), 0x00},
+	{IMX335_REG8(0x3087), 0x00},
+	{IMX335_REG8(0x30A4), 0x33},
+	{IMX335_REG8(0x30A8), 0x10},
+	{IMX335_REG8(0x30A9), 0x04},
+	{IMX335_REG8(0x30AC), 0x00},
+	{IMX335_REG8(0x30AD), 0x00},
+	{IMX335_REG8(0x30B0), 0x10},
+	{IMX335_REG8(0x30B1), 0x08},
+	{IMX335_REG8(0x30B4), 0x00},
+	{IMX335_REG8(0x30B5), 0x00},
+	{IMX335_REG16(0x30B6), 0x0000},
+	{IMX335_REG16(0x3112), 0x0008},
+	{IMX335_REG16(0x3116), 0x0008},
+};
+
 static const struct video_reg imx335_mode_2l_10b[] = {
 	{IMX335_ADBIT, 0x00},
 	{IMX335_MDBIT, 0x00},
@@ -217,33 +310,28 @@ static const struct video_reg imx335_inck_6mhz[] = {
 };
 
 static const struct video_format_cap imx335_fmts[] = {
-	{
+	/* all-pixel scan mode */
+	[IMX335_RES_2592x1944] = {
 		.pixelformat = VIDEO_PIX_FMT_SRGGB10P,
-		.width_min = IMX335_WIDTH,
-		.width_max = IMX335_WIDTH,
-		.height_min = IMX335_HEIGHT,
-		.height_max = IMX335_HEIGHT,
+		.width_min = IMX335_NATIVE_WIDTH,
+		.width_max = IMX335_NATIVE_WIDTH,
+		.height_min = IMX335_NATIVE_HEIGHT,
+		.height_max = IMX335_NATIVE_HEIGHT,
+		.width_step = 0,
+		.height_step = 0,
+	},
+	/* 2x2 binning mode */
+	[IMX335_RES_1296x972] = {
+		.pixelformat = VIDEO_PIX_FMT_SRGGB10P,
+		.width_min = IMX335_BIN_2X2_WIDTH,
+		.width_max = IMX335_BIN_2X2_WIDTH,
+		.height_min = IMX335_BIN_2X2_HEIGHT,
+		.height_max = IMX335_BIN_2X2_HEIGHT,
 		.width_step = 0,
 		.height_step = 0,
 	},
 	{0}
 };
-
-static int imx335_set_fmt(const struct device *dev, struct video_format *fmt)
-{
-	/*
-	 * Only support RGGB10 for now and resolution is fixed hence only check
-	 * values here
-	 */
-	if (fmt->pixelformat != VIDEO_PIX_FMT_SRGGB10P ||
-	    fmt->width != IMX335_WIDTH ||
-	    fmt->height != IMX335_HEIGHT) {
-		LOG_ERR("Unsupported pixel format or resolution");
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
 
 static int imx335_get_fmt(const struct device *dev, struct video_format *fmt)
 {
@@ -263,14 +351,17 @@ static int imx335_get_caps(const struct device *dev, struct video_caps *caps)
 static int imx335_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct imx335_config *cfg = dev->config;
+	struct imx335_data *drv_data = dev->data;
 	int ret;
 
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_STANDBY,
 				  enable ? IMX335_STANDBY_OPERATING : IMX335_STANDBY_STANDBY);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Failed to set standby register\n");
 		return ret;
 	}
+
+	drv_data->enabled = enable;
 
 	k_sleep(K_USEC(20));
 
@@ -285,13 +376,13 @@ static int imx335_set_ctrl_gain(const struct device *dev)
 	int ret;
 
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_REGHOLD, 1);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
 	/* Apply gain upon conversion to gain unit */
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_GAIN, ctrls->gain.val / IMX335_GAIN_UNIT_MDB);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -306,14 +397,14 @@ static int imx335_set_ctrl_exposure(const struct device *dev)
 	int ret;
 
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_REGHOLD, 1);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
 	/* Since we never update VMAX, we can use the default value directly */
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_SHR0,
 				  IMX335_VMAX_DEFAULT - ctrls->exposure.val);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -330,6 +421,66 @@ static int imx335_set_ctrl(const struct device *dev, unsigned int cid)
 	default:
 		return -ENOTSUP;
 	}
+}
+
+static int imx335_set_fmt(const struct device *dev, struct video_format *fmt)
+{
+	struct imx335_data *drv_data = dev->data;
+	const struct imx335_config *cfg = dev->config;
+	struct imx335_ctrls *ctrls = &drv_data->ctrls;
+	int ret;
+	size_t fmt_idx;
+
+	if (drv_data->enabled) {
+		LOG_ERR("Cannot set format while the stream is running");
+		return -EBUSY;
+	}
+
+	ret = video_format_caps_index(imx335_fmts, fmt, &fmt_idx);
+	if (ret < 0) {
+		LOG_ERR("Unsupported pixel format or resolution");
+		return ret;
+	}
+
+	if (fmt_idx == IMX335_RES_2592x1944) {
+		/* Full resolution */
+
+		ret = video_write_cci_multiregs(&cfg->i2c, imx335_bin_none,
+						ARRAY_SIZE(imx335_bin_none));
+		if (ret < 0) {
+			LOG_ERR("Failed to disable binning");
+			return ret;
+		}
+
+		ctrls->exposure.range.max = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN;
+		ctrls->exposure.range.def = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN;
+	} else if (fmt_idx == IMX335_RES_1296x972) {
+		/* 2x2 binning mode */
+
+		LOG_DBG("2x2 binning mode active");
+		ret = video_write_cci_multiregs(&cfg->i2c, imx335_bin_2x2,
+						ARRAY_SIZE(imx335_bin_2x2));
+		if (ret < 0) {
+			LOG_ERR("Failed to enable binning");
+			return ret;
+		}
+
+		ctrls->exposure.range.max = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN_BINNING;
+		ctrls->exposure.range.def = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN_BINNING;
+
+		/* update exposure, since the upper limit is lower if binning is active */
+		ctrls->exposure.val = MIN(ctrls->exposure.range.max, ctrls->exposure.val);
+		ret = imx335_set_ctrl_exposure(dev);
+		if (ret < 0) {
+			LOG_ERR("Failed to update exposure while enabling binning");
+			return ret;
+		}
+	}
+
+	drv_data->fmt.width = fmt->width;
+	drv_data->fmt.height = fmt->height;
+
+	return 0;
 }
 
 static int imx335_get_frmival(const struct device *dev, struct video_frmival *frmival)
@@ -413,7 +564,7 @@ static int imx335_init_controls(const struct device *dev)
 			.max = IMX335_GAIN_MAX,
 			.step = IMX335_GAIN_UNIT_MDB,
 			.def = 0});
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -424,7 +575,7 @@ static int imx335_init_controls(const struct device *dev)
 			.max = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN,
 			.step = 1,
 			.def = IMX335_VMAX_DEFAULT - IMX335_SHR0_MIN});
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -440,6 +591,7 @@ static int imx335_init_controls(const struct device *dev)
 static int imx335_init(const struct device *dev)
 {
 	const struct imx335_config *cfg = dev->config;
+	struct imx335_data *drv_data = dev->data;
 	int ret;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
@@ -457,7 +609,7 @@ static int imx335_init(const struct device *dev)
 
 		/* Power up sequence */
 		ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_ACTIVE);
-		if (ret) {
+		if (ret < 0) {
 			return ret;
 		}
 
@@ -472,7 +624,7 @@ static int imx335_init(const struct device *dev)
 	/* Initialize register values */
 	ret = video_write_cci_multiregs(&cfg->i2c, imx335_init_params,
 					ARRAY_SIZE(imx335_init_params));
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to initialize the sensor");
 		return ret;
 	}
@@ -480,21 +632,27 @@ static int imx335_init(const struct device *dev)
 	/* Apply the fixed value registers */
 	ret = video_write_cci_multiregs16(&cfg->i2c, imx335_fixed_regs,
 					  ARRAY_SIZE(imx335_fixed_regs));
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to initialize the sensor");
+		return ret;
+	}
+
+	ret = imx335_set_fmt(dev, &drv_data->fmt);
+	if (ret < 0) {
+		LOG_ERR("Unable to apply format");
 		return ret;
 	}
 
 	/* TODO - Only 10bit - 2 data lanes mode is supported for the time being */
 	ret = video_write_cci_multiregs(&cfg->i2c, imx335_mode_2l_10b,
 					ARRAY_SIZE(imx335_mode_2l_10b));
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to initialize the sensor");
 		return ret;
 	}
 
 	ret = imx335_set_input_clk(dev, cfg->input_clk);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to configure INCK");
 		return ret;
 	}
@@ -512,9 +670,10 @@ static int imx335_init(const struct device *dev)
 	static struct imx335_data imx335_data_##n = {						\
 		.fmt = {									\
 			.pixelformat = VIDEO_PIX_FMT_SRGGB10P,					\
-			.width = IMX335_WIDTH,							\
-			.height = IMX335_HEIGHT,						\
+			.width = IMX335_NATIVE_WIDTH,						\
+			.height = IMX335_NATIVE_HEIGHT,						\
 		},										\
+		.enabled = false,								\
 	};											\
 	static const struct imx335_config imx335_cfg_##n = {					\
 		.i2c = I2C_DT_SPEC_INST_GET(n),							\

--- a/samples/drivers/video/capture/Kconfig
+++ b/samples/drivers/video/capture/Kconfig
@@ -58,6 +58,13 @@ config VIDEO_CTRL_VFLIP
 	help
 	  If set, mirror the video frame vertically
 
+config VIDEO_SHELL_AND_CAPTURE
+	bool "Capture video even if the video shell is enabled"
+	depends on VIDEO_SHELL
+	default n
+	help
+	  If set, the video capture is enabled even if the video shell is also enabled.
+
 endmenu
 
 source "Kconfig.zephyr"

--- a/samples/drivers/video/capture/README.rst
+++ b/samples/drivers/video/capture/README.rst
@@ -30,6 +30,9 @@ Supported boards and camera modules include:
 - :zephyr:board:`stm32h7b3i_dk`
   with the :ref:`st_b_cams_omv_mb1683` shield and a compatible camera module.
 
+- :zephyr:board:`stm32n6570_dk`
+  with the :ref:`st_b_cams_imx_mb1854` camera module.
+
 Also :zephyr:board:`arduino_nicla_vision` can be used in this sample as capture device, in that case
 The user can transfer the captured frames through on board USB.
 
@@ -47,6 +50,10 @@ USB debug connector (J11) in order to get console output via the daplink interfa
 On :zephyr:board:`stm32h7b3i_dk`, connect the :ref:`st_b_cams_omv_mb1683` shield to the
 board on CN7 connector. A USB cable should be connected from a host to the micro USB
 connector in order to get console output.
+
+On :zephyr:board:`stm32n6570_dk`, connect the :ref:`st_b_cams_imx_mb1854` camera module
+to the J4 CSI connector. A USB cable should be connected from a host to both USB-C ports for
+power, flashing and console output.
 
 For :zephyr:board:`arduino_nicla_vision` there is no extra wiring required.
 
@@ -97,6 +104,16 @@ using the :ref:`st_b_cams_omv_mb1683` shield with a compatible camera module:
    :zephyr-app: samples/drivers/video/capture
    :board: stm32h7b3i_dk
    :shield: st_b_cams_omv_mb1683
+   :goals: build
+   :compact:
+
+For :zephyr:board:`stm32n6570_dk`, build this sample application with the following commands,
+using the :ref:`st_b_cams_imx_mb1854` camera module:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/video/capture
+   :board: stm32n6570_dk
+   :shield: st_b_cams_imx_mb1854
    :goals: build
    :compact:
 

--- a/samples/drivers/video/capture/README.rst
+++ b/samples/drivers/video/capture/README.rst
@@ -153,17 +153,19 @@ Sample Output
       current_pixel_format = 32, current_orientation = 0
 
     Capture started
-    Got frame 0! size: 261120; timestamp 249 ms
-    Got frame 1! size: 261120; timestamp 282 ms
-    Got frame 2! size: 261120; timestamp 316 ms
-    Got frame 3! size: 261120; timestamp 350 ms
-    Got frame 4! size: 261120; timestamp 384 ms
-    Got frame 5! size: 261120; timestamp 418 ms
-    Got frame 6! size: 261120; timestamp 451 ms
+    Got frame 0! size: 261120; timestamp 249 ms (delta 249 ms)
+    Got frame 1! size: 261120; timestamp 282 ms (delta 33 ms)
+    Got frame 2! size: 261120; timestamp 316 ms (delta 34 ms)
+    Got frame 3! size: 261120; timestamp 350 ms (delta 34 ms)
+    Got frame 4! size: 261120; timestamp 384 ms (delta 34 ms)
+    Got frame 5! size: 261120; timestamp 418 ms (delta 34 ms)
+    Got frame 6! size: 261120; timestamp 451 ms (delta 33 ms)
 
    <repeats endlessly>
 
-If using the shell, the capture would not start, and instead it is possible to access the shell
+If using the shell, the capture will not start unless the Kconfig option
+:kconfig:option:`VIDEO_SHELL_AND_CAPTURE` is set. In both cases, the shell can be used to change
+parameters on the fly:
 
 .. code-block:: console
 


### PR DESCRIPTION
This PR implements support for the 2x2 binning mode of the IMX335 camera sensor. It also enables changing the refresh rate. The binning mode is needed to reduce the bandwidth requirements for higher refresh rates.

The current driver only supports the full sensor resolution of 2592x1944 at 30Hz. With this PR, the resolution can be reduced by the sensor to 1296x972, allowing 50Hz and 60Hz operation. Additionally, support for 25Hz was added.

Note that while the driver and sensor support changing the binning mode on the fly, the rest of the video pipeline likely doesn't expect it. Especially when initially starting with the binning mode enabled and then disabling it the output buffers would need to grow. Due to this, I added a Kconfig option to enable binning on boot, since most applications will not need to switch at runtime.

I can add an assertion to prevent changing the binning mode during runtime, if needed. 

Additionally, this PR also adds a Kconfig option to the video capture sample to enable the video shell and capture at the same time. The delta between subsequent frames is now also printed. This is very helpful for testing dynamic refresh rate changes.
I've also added the STM32N6570_DK to the video capture sample docs, since it uses the IMX335.