### PR TITLE
[twister]: have extra_test_args available in testcase.yaml

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1037,6 +1037,23 @@ pytest_dut_scope: <function|class|module|package|session> (default function)
               - test_file_2.py::test_A
               - test_file_2.py::test_B[param_a]
 
+.. _extra_test_args:
+
+extra_test_args: <list of arguments> (default empty)
+    Specify a list of additional arguments to pass to the build executable when building
+    for the ``native_sim`` target e.g.:
+    ``<build_folder>/zephyr.exe -no-color``. Note that the arguments
+    must be supported by the executable, otherwise an error will occur.
+
+    The following is an example yaml file:
+
+    .. code-block:: yaml
+
+        harness_config:
+          extra_test_args:
+            - -no-color
+            - -stop_at=3
+            - -no-rt
 
 .. _twister_console_harness:
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -399,6 +399,7 @@ class Pytest(Harness):
         pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
         pytest_args_yaml = config.get('pytest_args', []) if config else []
         pytest_dut_scope = config.get('pytest_dut_scope', None) if config else None
+        extra_test_args = config.get('extra_test_args', []) if config else []
         command = [
             'pytest',
             '--twister-harness',
@@ -439,8 +440,9 @@ class Pytest(Harness):
             for fixture in handler.options.fixture:
                 command.append(f'--twister-fixture={fixture}')
 
-        if handler.options.extra_test_args and handler.type_str == 'native':
-            command.append(f'--extra-test-args={shlex.join(handler.options.extra_test_args)}')
+        extra_test_args += handler.options.extra_test_args
+        if extra_test_args and handler.type_str == 'native':
+            command.append(f'--extra-test-args={shlex.join(extra_test_args)}')
 
         command.extend(pytest_args_yaml)
 

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -164,6 +164,11 @@ schema;scenario-schema:
           type: str
           enum: ["function", "class", "module", "package", "session"]
           required: false
+        "extra_test_args":
+          type: seq
+          required: false
+          sequence:
+            - type: str
         "ctest_args":
           type: seq
           required: false

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -75,11 +75,17 @@ def test_pytest_command_extra_args(testinstance: TestInstance):
 
 def test_pytest_command_extra_test_args(testinstance: TestInstance):
     pytest_harness = Pytest()
+    extra_test_args_yaml = ['-no-color']
     extra_test_args = ['-stop_at=3', '-no-rt']
+    testinstance.testsuite.harness_config['extra_test_args'] = extra_test_args_yaml
     testinstance.handler.options.extra_test_args = extra_test_args
     pytest_harness.configure(testinstance)
     command = pytest_harness.generate_command()
-    assert f'--extra-test-args={extra_test_args[0]} {extra_test_args[1]}' in command
+    expected = (
+        f'--extra-test-args={extra_test_args_yaml[0]} '
+        f'{extra_test_args[0]} {extra_test_args[1]}'
+    )
+    assert expected in command
 
 
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):


### PR DESCRIPTION
Twister has the ability to pass arguments to the build executable from the command line, but not from the testcase.yaml. The changes enable arguments to be specified in harness_config.