### PR TITLE
tests: Bluetooth: CAP: Fix issues in BAP BA mock

### DIFF
--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -130,7 +130,7 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 	inst->recv_states.broadcast_id = param->broadcast_id;
 	inst->pa_sync_state = param->pa_sync;
 	inst->num_subgroups = param->num_subgroups;
-	state.pa_sync_state = param->pa_sync;
+	state.pa_sync_state = param->pa_sync ? BT_BAP_PA_STATE_SYNCED : BT_BAP_PA_STATE_NOT_SYNCED;
 	state.src_id = max_src_id;
 	state.num_subgroups = param->num_subgroups;
 	for (size_t i = 0; i < param->num_subgroups; i++) {
@@ -205,6 +205,9 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
 		if (listener->rem_src != NULL) {
 			listener->rem_src(conn, 0);
+		}
+		if (listener->recv_state_removed != NULL) {
+			listener->recv_state_removed(conn, src_id);
 		}
 	}
 


### PR DESCRIPTION
Fix wrong assignment to pa_sync_state.
Add missing call to recv_state_removed