### PR TITLE
boards native nrf_bsim: Add model of LDREX/STREX/CLREX

### DIFF
--- a/boards/native/nrf_bsim/common/cmsis/cmsis.c
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.c
@@ -97,3 +97,156 @@ void __SEV(void)
 {
 	nrfbsim_SEV_model();
 }
+
+/*
+ *  Implement the following ARM instructions
+ *
+ *  - STR Exclusive(8,16 & 32bit) (__STREX{B,H,W})
+ *  - LDR Exclusive(8,16 & 32bit) (__LDREX{B,H,W})
+ *  - CLREX : Exclusive lock removal (__CLREX)
+ *
+ *  Description:
+ *    From ARMs description it is relatively unclear how the LDREX/STREX/CLREX
+ *    are really implemented in M4/M33 devices.
+ *
+ *    The current model simply sets a local monitor (local to the processor)
+ *    exclusive lock for the current MCU when a LDREX is executed.
+ *    STREX check this lock, and succeeds if set, fails otherwise.
+ *    The lock is cleared whenever STREX or CLREX are run, or when we return
+ *    from an interrupt handler.
+ *    See Arm v8-M Architecture Reference Manual: "B9.2 The local monitors" and
+ *    "B9.4 Exclusive access instructions and the monitors".
+ *
+ *    The address is ignored, and we do not model a "system/global" monitor.
+ *    The access width is ignored from the locking point of view.
+ *    In principle this model would seem to fulfill the functionality described
+ *    by ARM.
+ *
+ *    Note that as the POSIX arch will not make an embedded
+ *    thread lose context while just executing its own code, and it does not
+ *    allow parallel embedded SW threads to execute at the same exact time,
+ *    there is no real need to protect atomicity.
+ *    But, some embedded code may use this instructions in between busy waits,
+ *    and expect that an interrupt in the meanwhile will indeed cause a
+ *    following STREX to fail.
+ *
+ *    As this ARM exclusive access monitor mechanism can in principle be
+ *    used for other, unexpected, purposes, this simple replacement may not be
+ *    enough.
+ */
+
+static bool ex_lock; /* LDREX/STREX/CLREX lock state */
+
+bool nrfbsim_STREXlock_model(void)
+{
+	if (ex_lock == false) {
+		return true;
+	}
+
+	ex_lock = false;
+	return false;
+}
+
+void nrfbsim_clear_excl_access(void)
+{
+	ex_lock = false;
+}
+
+/**
+ * \brief   Pretend to execute a STR Exclusive (8 bit)
+ * \details Executes an exclusive STR instruction for 8 bit values.
+ * \param [in]  value  Value to store
+ * \param [in]    ptr  Pointer to location
+ * \return          0  Function succeeded
+ * \return          1  Function did not succeeded (value not changed)
+ */
+uint32_t __STREXB(uint8_t value, volatile uint8_t *ptr)
+{
+	if (nrfbsim_STREXlock_model()) {
+		return 1;
+	}
+	*ptr = value;
+	return 0;
+}
+
+/**
+ * \brief   Pretend to execute a STR Exclusive (16 bit)
+ * \details Executes a exclusive STR instruction for 16 bit values.
+ * \param [in]  value  Value to store
+ * \param [in]    ptr  Pointer to location
+ * \return          0  Function succeeded
+ * \return          1  Function did not succeeded (value not changed)
+ */
+uint32_t __STREXH(uint16_t value, volatile uint16_t *ptr)
+{
+	if (nrfbsim_STREXlock_model()) {
+		return 1;
+	}
+	*ptr = value;
+	return 0;
+}
+
+/**
+ * \brief   Pretend to execute a STR Exclusive (32 bit)
+ * \details Executes a exclusive~ STR instruction for 32 bit values.
+ * \param [in]  value  Value to store
+ * \param [in]    ptr  Pointer to location
+ * \return          0  Function succeeded
+ * \return          1  Function did not succeeded (value not changed)
+ */
+uint32_t __STREXW(uint32_t value, volatile uint32_t *ptr)
+{
+	if (nrfbsim_STREXlock_model()) {
+		return 1;
+	}
+	*ptr = value;
+	return 0;
+}
+
+/**
+ * \brief   Pretend to execute a LDR Exclusive (8 bit)
+ * \details Executes an exclusive LDR instruction for 8 bit value.
+ *          Meaning, set an exclusive lock, and load the stored value
+ * \param [in]    ptr  Pointer to data
+ * \return             value of type uint8_t at (*ptr)
+ */
+uint8_t __LDREXB(volatile uint8_t *ptr)
+{
+	ex_lock = true;
+	return *ptr;
+}
+
+/**
+ * \brief   Pretend to execute a LDR Exclusive (16 bit)
+ * \details Executes an ~exclusive~ LDR instruction for 16 bit value.
+ *          Meaning, set an exclusive lock, and load the stored value
+ * \param [in]    ptr  Pointer to data
+ * \return             value of type uint8_t at (*ptr)
+ */
+uint16_t __LDREXH(volatile uint16_t *ptr)
+{
+	ex_lock = true;
+	return *ptr;
+}
+
+/**
+ * \brief   Execute a LDR Exclusive (32 bit)
+ * \details Executes an exclusive LDR instruction for 32 bit value.
+ *          Meaning, set an exclusive lock, and load the stored value
+ * \param [in]    ptr  Pointer to data
+ * \return             value of type uint8_t at (*ptr)
+ */
+uint32_t __LDREXW(volatile uint32_t *ptr)
+{
+	ex_lock = true;
+	return *ptr;
+}
+
+/**
+ * \brief   Remove the exclusive lock
+ * \details Removes the exclusive lock which is created by LDREX
+ */
+void __CLREX(void)
+{
+	ex_lock = false;
+}

--- a/boards/native/nrf_bsim/common/cmsis/cmsis.h
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.h
@@ -36,6 +36,8 @@ void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority);
 uint32_t NVIC_GetPriority(IRQn_Type IRQn);
 void NVIC_SystemReset(void);
 
+void nrfbsim_clear_excl_access(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/native/nrf_bsim/common/cmsis/cmsis_instr.h
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis_instr.h
@@ -40,116 +40,13 @@ void __WFE(void);
 void __WFI(void);
 void __SEV(void);
 
-/*
- *  Implement the following ARM intrinsics as non-exclusive accesses
- *
- *  - STR Exclusive(8,16 & 32bit) (__STREX{B,H,W})
- *  - LDR Exclusive(8,16 & 32bit) (__LDREX{B,H,W})
- *  - CLREX : Exclusive lock removal (__CLREX) - no-op
- *
- *  Description:
- *    These accesses always succeed, and do NOT set any kind of internal
- *    exclusive access flag;
- *    There is no local/global memory monitors, MPU control of what are
- *    shareable regions, exclusive reservations granules, automatic clearing
- *    on context switch, or so.
- *
- *    This should be enough for the expected uses of LDR/STREXB
- *    (locking mutexes or guarding other atomic operations, inside a few lines
- *    of code in the same function): As the POSIX arch will not make an embedded
- *    thread lose context while just executing its own code, and it does not
- *    allow parallel embedded SW threads to execute at the same exact time,
- *    there is no actual need to protect atomicity.
- *
- *    But as this ARM exclusive access monitor mechanism can in principle be
- *    used for other, unexpected, purposes, this simple replacement may not be
- *    enough.
- */
-
-/**
- * \brief   Pretend to execute a STR Exclusive (8 bit)
- * \details Executes a ~exclusive~ STR instruction for 8 bit values.
- * \param [in]  value  Value to store
- * \param [in]    ptr  Pointer to location
- * \return          0  Function succeeded (always)
- */
-static inline uint32_t __STREXB(uint8_t value, volatile uint8_t *ptr)
-{
-	*ptr = value;
-	return 0;
-}
-
-/**
- * \brief   Pretend to execute a STR Exclusive (16 bit)
- * \details Executes a ~exclusive~ STR instruction for 16 bit values.
- * \param [in]  value  Value to store
- * \param [in]    ptr  Pointer to location
- * \return          0  Function succeeded (always)
- */
-static inline uint32_t __STREXH(uint16_t value, volatile uint16_t *ptr)
-{
-	*ptr = value;
-	return 0;
-}
-
-/**
- * \brief   Pretend to execute a STR Exclusive (32 bit)
- * \details Executes a ~exclusive~ STR instruction for 32 bit values.
- * \param [in]  value  Value to store
- * \param [in]    ptr  Pointer to location
- * \return          0  Function succeeded (always)
- */
-static inline uint32_t __STREXW(uint32_t value, volatile uint32_t *ptr)
-{
-	*ptr = value;
-	return 0;
-}
-
-/**
- * \brief   Pretend to execute a LDR Exclusive (8 bit)
- * \details Executes an ~exclusive~ LDR instruction for 8 bit value.
- *          Meaning, it does not set a exclusive lock,
- *          instead just loads the stored value
- * \param [in]    ptr  Pointer to data
- * \return             value of type uint8_t at (*ptr)
- */
-static inline uint8_t __LDREXB(volatile uint8_t *ptr)
-{
-	return *ptr;
-}
-
-/**
- * \brief   Pretend to execute a LDR Exclusive (16 bit)
- * \details Executes an ~exclusive~ LDR instruction for 16 bit value.
- *          Meaning, it does not set a exclusive lock,
- *          instead just loads the stored value
- * \param [in]    ptr  Pointer to data
- * \return             value of type uint8_t at (*ptr)
- */
-static inline uint16_t __LDREXH(volatile uint16_t *ptr)
-{
-	return *ptr;
-}
-
-/**
- * \brief   Pretend to execute a LDR Exclusive (32 bit)
- * \details Executes an ~exclusive~ LDR instruction for 32 bit value.
- *          Meaning, it does not set a exclusive lock,
- *          instead just loads the stored value
- * \param [in]    ptr  Pointer to data
- * \return             value of type uint8_t at (*ptr)
- */
-static inline uint32_t __LDREXW(volatile uint32_t *ptr)
-{
-	return *ptr;
-}
-
-/**
- * \brief   Pretend to remove the exclusive lock
- * \details The real function would removes the exclusive lock which is created
- *          by LDREX, this one does nothing
- */
-static inline void __CLREX(void) { /* Nothing to be done */ }
+uint32_t __STREXB(uint8_t value, volatile uint8_t *ptr);
+uint32_t __STREXH(uint16_t value, volatile uint16_t *ptr);
+uint32_t __STREXW(uint32_t value, volatile uint32_t *ptr);
+uint8_t __LDREXB(volatile uint8_t *ptr);
+uint16_t __LDREXH(volatile uint16_t *ptr);
+uint32_t __LDREXW(volatile uint32_t *ptr);
+void __CLREX(void);
 
 /**
  * \brief Model of an ARM CLZ instruction

--- a/boards/native/nrf_bsim/irq_handler.c
+++ b/boards/native/nrf_bsim/irq_handler.c
@@ -117,6 +117,7 @@ void posix_irq_handler(void)
 
 		currently_running_irq = irq_nbr;
 		vector_to_irq(irq_nbr, &may_swap);
+		nrfbsim_clear_excl_access();
 		currently_running_irq = last_running_irq;
 
 		hw_irq_ctrl_reeval_level_irq(cpu_n, irq_nbr);


### PR DESCRIPTION
Add a model of LDREX/STREX/CLREX, that although simple may be correct enough to cover the needs of SW using these instructions.

Ref: https://developer.arm.com/documentation/100235/0100/The-Cortex-M33-Instruction-Set/Memory-access-instructions/LDREX-and-STREX?lang=en

[Arm v8-M Architecture Reference Manual](https://documentation-service.arm.com/static/64b7f5c638511951cb79fc45): "B9.2 The local monitors" and "B9.4 Exclusive access instructions and the monitors".