### PR TITLE
mspi_dw: Fix dma transfer size logic

### DIFF
--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -160,6 +160,9 @@ DEFINE_MM_REG_WR(xip_write_wrap_inst,	0x144)
 DEFINE_MM_REG_WR(xip_write_ctrl,	0x148)
 #endif
 
+/* Ceiling division by 32 */
+#define CEIL_DIV_32(x) (((x) + 31U) >> 5)
+
 #include "mspi_dw_vendor_specific.h"
 
 static int start_next_packet(const struct device *dev);
@@ -1260,15 +1263,15 @@ static int start_next_packet(const struct device *dev)
 #if defined(CONFIG_MSPI_DMA)
 	if (dev_data->xfer.xfer_mode == MSPI_DMA) {
 		/* For DMA mode, set start level based on transfer length to prevent underflow */
-		uint32_t total_transfer_bytes = packet->num_bytes + dev_data->xfer.addr_length +
-						dev_data->xfer.cmd_length;
-		uint32_t transfer_frames = total_transfer_bytes >> dev_data->bytes_per_frame_exp;
+		uint32_t transfer_frames = (packet->num_bytes >> dev_data->bytes_per_frame_exp) +
+					   CEIL_DIV_32(dev_data->xfer.addr_length)
+					 + CEIL_DIV_32(dev_data->xfer.cmd_length);
 
-		/* Use minimum of transfer length or FIFO depth, but at least 1 */
+		/* Above dma_start_level, the transfer will start.
+		 * Use minimum of transfer length and FIFO depth.
+		 */
 		uint8_t dma_start_level = MIN(transfer_frames - 1,
 					      dev_config->tx_fifo_depth_minus_1);
-
-		dma_start_level = (dma_start_level > 0 ? dma_start_level : 1);
 
 		/* Only TXFTHR needs to be set to the minimum number of frames */
 		write_txftlr(dev, FIELD_PREP(TXFTLR_TXFTHR_MASK, dma_start_level));

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -138,6 +138,7 @@ static inline void vendor_specific_irq_clear(const struct device *dev)
 	preg->EVENTS_DMA.DONE = 0;
 }
 
+#if defined(CONFIG_MSPI_DMA)
 /* DMA support */
 
 #define EVDMA_ATTR_LEN_Pos (0UL)
@@ -308,6 +309,7 @@ static inline bool vendor_specific_read_dma_irq(const struct device *dev)
 
 	return (bool) preg->EVENTS_DMA.DONE;
 }
+#endif /*defined(CONFIG_MSPI_DMA)*/
 
 #else /* Supply empty vendor specific macros for generic case */
 

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -251,9 +251,8 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 		transfer_list->rx_job = &joblist[job_idx];
 		tmod = QSPI_TMOD_TX_ONLY;
 	} else {
-		preg->CONFIG.RXTRANSFERLENGTH = ((packet->num_bytes + dev_data->xfer.addr_length +
-						dev_data->xfer.cmd_length) >>
-						dev_data->bytes_per_frame_exp) - 1;
+		preg->CONFIG.RXTRANSFERLENGTH = ((packet->num_bytes) >>
+						dev_data->bytes_per_frame_exp);
 
 		/* If sending address or command while being configured as controller */
 		if (job_idx > 0 && config->op_mode == MSPI_OP_MODE_CONTROLLER) {

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -140,18 +140,8 @@ static inline void vendor_specific_irq_clear(const struct device *dev)
 
 #if defined(CONFIG_MSPI_DMA)
 /* DMA support */
-
-#define EVDMA_ATTR_LEN_Pos (0UL)
-#define EVDMA_ATTR_LEN_Msk (0x00FFFFFFUL)
-
 #define EVDMA_ATTR_ATTR_Pos (24UL)
 #define EVDMA_ATTR_ATTR_Msk (0x3FUL << EVDMA_ATTR_ATTR_Pos)
-
-#define EVDMA_ATTR_32AXI_Pos (30UL)
-#define EVDMA_ATTR_32AXI_Msk (0x1UL << EVDMA_ATTR_32AXI_Pos)
-
-#define EVDMA_ATTR_EVENTS_Pos (31UL)
-#define EVDMA_ATTR_EVENTS_Msk (0x1UL << EVDMA_ATTR_EVENTS_Pos)
 
 typedef enum {
 	EVDMA_BYTE_SWAP = 0,
@@ -160,12 +150,8 @@ typedef enum {
 	EVDMA_FIXED_ATTR = 3,
 	EVDMA_STATIC_ADDR = 4,
 	EVDMA_PLAIN_DATA_BUF_WR = 5,
+	EVDMA_PLAIN_DATA = 0x3f,
 } EVDMA_ATTR_Type;
-
-/* Setup EVDMA attribute with the following configuratrion */
-#define EVDMA_ATTRIBUTE (BIT(EVDMA_BYTE_SWAP)   | BIT(EVDMA_JOBLIST)    | \
-			 BIT(EVDMA_BUFFER_FILL) | BIT(EVDMA_FIXED_ATTR) | \
-			 BIT(EVDMA_STATIC_ADDR) | BIT(EVDMA_PLAIN_DATA_BUF_WR))
 
 typedef struct {
 	uint8_t *addr;
@@ -229,13 +215,14 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 	/*
 	 * The Command and Address will always have a length of 4 from the DMA's
-	 * perspective. QSPI peripheral will use length of data specified in core registers
+	 * perspective. QSPI peripheral will use length of data specified in core registers.
+	 * Since the cmd and address are stored as uint32_t, byte swap is never needed.
 	 */
 	if (dev_data->xfer.cmd_length > 0) {
-		joblist[job_idx++] = EVDMA_JOB(&packet->cmd, 4, EVDMA_ATTRIBUTE);
+		joblist[job_idx++] = EVDMA_JOB(&packet->cmd, 4, EVDMA_PLAIN_DATA);
 	}
 	if (dev_data->xfer.addr_length > 0) {
-		joblist[job_idx++] = EVDMA_JOB(&packet->address, 4, EVDMA_ATTRIBUTE);
+		joblist[job_idx++] = EVDMA_JOB(&packet->address, 4, EVDMA_PLAIN_DATA);
 	}
 
 	if (packet->dir == MSPI_TX) {
@@ -243,7 +230,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 		if (packet->num_bytes > 0) {
 			joblist[job_idx++] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-						EVDMA_ATTRIBUTE);
+						       EVDMA_PLAIN_DATA);
 		}
 
 		/* Always terminate with null job */
@@ -263,7 +250,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 			joblist[job_idx++] = EVDMA_NULL_JOB();
 			transfer_list->rx_job = &joblist[job_idx];
 			joblist[job_idx++] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-						       EVDMA_ATTRIBUTE);
+						       EVDMA_PLAIN_DATA);
 			joblist[job_idx]   = EVDMA_NULL_JOB();
 		} else {
 			/* Sending command or address while configured as target isn't supported */
@@ -271,7 +258,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 			transfer_list->rx_job = &joblist[0];
 			joblist[0] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-					       EVDMA_ATTRIBUTE);
+					       EVDMA_PLAIN_DATA);
 			joblist[1] = EVDMA_NULL_JOB();
 			transfer_list->tx_job = &joblist[1];
 		}


### PR DESCRIPTION
This PR fixes issues regarding the setup of the transfer sizes of the mspi_dw driver when in DMA mode. It also adds clarity to the EVDMA definitions by removing redundant macros.