### PR TITLE
tests: drivers: disk: disk_access: relax out-of-bounds erase assertion

### DIFF
--- a/tests/drivers/disk/disk_access/src/main.c
+++ b/tests/drivers/disk/disk_access/src/main.c
@@ -285,14 +285,11 @@ static void test_sector_erase(uint8_t *wbuf, uint8_t *rbuf, uint32_t num_sectors
 
 	/* Try and erase past the last sector */
 	rc = erase_sector_checked(rbuf, disk_sector_count - num_sectors + 1, num_sectors);
-	zassert_equal(rc, -EINVAL,
-		      "Unexpected error code when attempting to erase past end of disk");
+	zassert_not_equal(rc, 0, "Should fail when attempting to erase past end of disk");
 	rc = erase_sector_checked(rbuf, disk_sector_count + 1, num_sectors);
-	zassert_equal(rc, -EINVAL,
-		      "Unexpected error code when attempting to erase past end of disk");
+	zassert_not_equal(rc, 0, "Should fail when attempting to erase past end of disk");
 	rc = erase_sector_checked(rbuf, UINT32_MAX, num_sectors);
-	zassert_equal(rc, -EINVAL,
-		      "Unexpected error code when attempting to erase past end of disk");
+	zassert_not_equal(rc, 0, "Should fail when attempting to erase past end of disk");
 }
 
 /* Test multiple reads in series, and reading from a variety of blocks */


### PR DESCRIPTION

This PR adjusts the disk access tests to be tolerant of driver-specific error codes for out-of-bounds sector erase operations. Instead of requiring -EINVAL, the tests now assert that the operation fails (rc != 0), maintaining the correctness requirement while avoiding false negatives with drivers that report generic errors.
