### PR TITLE
scripts: edtlib: preserve hexadecimal notation for integer values

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -33,6 +33,20 @@ DETAILS_IN_IMPORTANT_PROPS = {'compatible', 'label', 'reg', 'status', 'interrupt
 
 logger = logging.getLogger('gen_devicetree_rest')
 
+
+def format_value(value) -> str:
+    """
+    Format a property value, preserving hexadecimal notation for HexInt values.
+    For lists/arrays, formats each element individually and joins with ", ".
+    """
+    if isinstance(value, list):
+        return "[" + ", ".join(map(format_value, value)) + "]"
+    elif isinstance(value, edtlib.HexInt):
+        return hex(value)
+    else:
+        return str(value)
+
+
 class VndLookup:
     """
     A convenience class for looking up information based on a
@@ -744,13 +758,13 @@ def print_property_table(prop_specs, string_io, deprecated=False):
             details += '\n\nThis property is **required**.'
 
         if prop_spec.default:
-            details += f'\n\nDefault value: ``{prop_spec.default}``'
+            details += f'\n\nDefault value: ``{format_value(prop_spec.default)}``'
 
         if prop_spec.const:
-            details += f'\n\nConstant value: ``{prop_spec.const}``'
+            details += f'\n\nConstant value: ``{format_value(prop_spec.const)}``'
         elif prop_spec.enum:
             details += ('\n\nLegal values: ' +
-                        ', '.join(f'``{repr(val)}``' for val in
+                        ', '.join(f'``{format_value(val)}``' for val in
                                   prop_spec.enum))
 
         if prop_spec.name in DETAILS_IN_IMPORTANT_PROPS:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3408,6 +3408,48 @@ class _BindingLoader(Loader):
     pass
 
 
+class HexInt(int):
+    """
+    An integer subclass that indicates the value was expressed in hexadecimal
+    notation in the original YAML binding file.
+
+    This allows downstream tools (e.g., documentation generators) to preserve
+    the original representation when displaying default values.
+
+    Example usage:
+        if isinstance(prop_spec.default, HexInt):
+            # Format as hex: f"0x{prop_spec.default:x}"
+        else:
+            # Format as decimal: str(prop_spec.default)
+    """
+
+    def __new__(cls, value: int) -> "HexInt":
+        return super().__new__(cls, value)
+
+
+def _binding_int_constructor(
+    loader: _BindingLoader, node: yaml.ScalarNode
+) -> int:
+    """
+    Custom YAML constructor for integers that preserves hexadecimal notation.
+
+    Returns a HexInt instance if the original YAML value was in hex format,
+    otherwise returns a regular int.
+    """
+    # Get the original string representation from the YAML
+    value_str = node.value.lower()
+    # Use the standard YAML int parsing
+    value = loader.construct_yaml_int(node)
+
+    # Check if the original was hexadecimal (0x prefix, possibly with sign)
+    if value_str.lstrip("+-").startswith("0x"):
+        return HexInt(value)
+    return value
+
+
+# Override the default integer constructor to track hex notation
+_BindingLoader.add_constructor("tag:yaml.org,2002:int", _binding_int_constructor)
+
 # Add legacy '!include foo.yaml' handling
 _BindingLoader.add_constructor("!include", _binding_include)
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -690,7 +690,9 @@ def test_prop_defaults():
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
 
-    verify_props(edt.get_node("/defaults"),
+    node = edt.get_node("/defaults")
+
+    verify_props(node,
                  ['int',
                   'array', 'uint8-array',
                   'string', 'string-array',
@@ -703,6 +705,13 @@ def test_prop_defaults():
                   [1,2,3], b'\x89\xab\xcd',
                   'hello', ['hello','there'],
                   234])
+
+    # Verify HexInt preservation in PropertySpec.default (raw binding values)
+    # uint8-array default [0x89, 0xAB, 0xCD] should have HexInt elements
+    assert all(isinstance(v, edtlib.HexInt) for v in node.props["uint8-array"].spec.default)
+    # int/array defaults (decimal in binding) should NOT be HexInt
+    assert not isinstance(node.props["int"].spec.default, edtlib.HexInt)
+    assert not any(isinstance(v, edtlib.HexInt) for v in node.props["array"].spec.default)
 
 def test_prop_enums():
     '''test properties with enum: in the binding'''


### PR DESCRIPTION
When YAML binding files specify values in hexadecimal notation, this information was previously lost during parsing as PyYAML converts hex to regular integers.

Adapt documentation generation script accordingly.

## Now

<img width="1383" height="846" alt="image" src="https://github.com/user-attachments/assets/298ac59a-0449-4e34-81b2-b2ebba7cd951" />

## Before

<img width="1384" height="849" alt="image" src="https://github.com/user-attachments/assets/a4d84a5b-ffcc-4ce4-aae6-f24a2ec5bf8b" />
