### PR TITLE
arch: *: remove check for CONFIG_SOC_PER_CORE_INIT_HOOK

### DIFF
--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -117,9 +117,7 @@ void arch_secondary_cpu_init(int cpu_num)
 	irq_enable(DT_IRQN(DT_NODELABEL(ici)));
 #endif
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 
 	/* call the function set by arch_cpu_start */
 	fn = arc_cpu_init[cpu_num].fn;

--- a/arch/arc/include/kernel_arch_func.h
+++ b/arch/arc/include/kernel_arch_func.h
@@ -36,9 +36,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 {
 	z_irq_setup();
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -199,9 +199,7 @@ void arch_secondary_cpu_init(void)
 	 */
 #endif
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 
 	fn = arm_cpu_boot_params.fn;
 	arg = arm_cpu_boot_params.arg;

--- a/arch/arm/include/cortex_a_r/kernel_arch_func.h
+++ b/arch/arm/include/cortex_a_r/kernel_arch_func.h
@@ -31,9 +31,7 @@ extern "C" {
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 #ifndef CONFIG_USE_SWITCH

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -57,9 +57,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	z_arm_configure_static_mpu_regions();
 #endif /* CONFIG_ARM_MPU */
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static ALWAYS_INLINE void arch_thread_return_value_set(struct k_thread *thread, unsigned int value)

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -166,9 +166,7 @@ void arch_secondary_cpu_init(int cpu_num)
 #endif
 #endif
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 
 	fn = arm64_cpu_boot_params.fn;
 	arg = arm64_cpu_boot_params.arg;

--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -32,10 +32,7 @@ extern "C" {
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static inline void arch_switch(void *switch_to, void **switched_from)

--- a/arch/mips/include/kernel_arch_func.h
+++ b/arch/mips/include/kernel_arch_func.h
@@ -28,9 +28,7 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static ALWAYS_INLINE void

--- a/arch/posix/include/kernel_arch_func.h
+++ b/arch/posix/include/kernel_arch_func.h
@@ -22,9 +22,7 @@ extern "C" {
 
 static inline void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static ALWAYS_INLINE void

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -79,8 +79,6 @@ void arch_secondary_cpu_init(int hartid)
 	/* Enable on secondary cores so that they can respond to PLIC */
 	irq_enable(RISCV_IRQ_MEXT);
 #endif /* CONFIG_PLIC_IRQ_AFFINITY */
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -55,9 +55,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #ifdef CONFIG_RISCV_PMP
 	z_riscv_pmp_init();
 #endif
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static ALWAYS_INLINE void

--- a/arch/sparc/include/kernel_arch_func.h
+++ b/arch/sparc/include/kernel_arch_func.h
@@ -26,9 +26,7 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 void z_sparc_context_switch(struct k_thread *newt, struct k_thread *oldt);

--- a/arch/x86/include/ia32/kernel_arch_func.h
+++ b/arch/x86/include/ia32/kernel_arch_func.h
@@ -22,9 +22,7 @@ extern "C" {
 
 static inline void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 static ALWAYS_INLINE void

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -29,9 +29,7 @@ extern void z_x86_ipi_setup(void);
 
 static inline void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot);

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -26,9 +26,7 @@ K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 	soc_per_core_init_hook();
-#endif /* CONFIG_SOC_PER_CORE_INIT_HOOK */
 }
 
 void xtensa_switch(void *switch_to, void **switched_from);


### PR DESCRIPTION
`soc_per_core_init_hook()` is usually called from `arch_kernel_init()` and `arch_secondary_cpu_init()` which are C functions. As such, there is no need to check for `CONFIG_SOC_PER_CORE_INIT_HOOK` since platform/hooks.h provides a no-op function-like macro implementation if the Kconfig option is not enabled.

Remove the Kconfig option check from all files.

(must have missed it while cleaning up in #97099...)