### PR TITLE
bluetooth: host: Allow unregistering per adv sync cbs

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -123,6 +123,7 @@ New APIs and options
   * Host
 
     * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
+    * :c:func:`bt_le_per_adv_sync_cb_unregister`
 
   * Mesh
 

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2116,6 +2116,18 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync);
 int bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb);
 
 /**
+ * @brief Unregister periodic advertising sync callbacks.
+ *
+ * Removes the callback structure from the list of periodic advertising
+ * sync callbacks.
+ *
+ * @param cb Callback struct.
+ *
+ * @retval Zero on success or (negative) error code otherwise.
+ */
+int bt_le_per_adv_sync_cb_unregister(struct bt_le_per_adv_sync_cb *cb);
+
+/**
  * @brief Enables receiving periodic advertising reports for a sync.
  *
  * If the sync is already receiving the reports, -EALREADY is returned.

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1022,9 +1022,9 @@ void bt_hci_le_per_adv_report_recv(struct bt_le_per_adv_sync *per_adv_sync,
 				   const struct bt_le_per_adv_sync_recv_info *info)
 {
 	struct net_buf_simple_state state;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->recv) {
 			net_buf_simple_save(buf, &state);
 			listener->recv(per_adv_sync, info, buf);
@@ -1037,9 +1037,9 @@ void bt_hci_le_per_adv_report_recv(struct bt_le_per_adv_sync *per_adv_sync,
 static void bt_hci_le_per_adv_report_recv_failure(struct bt_le_per_adv_sync *per_adv_sync,
 						  const struct bt_le_per_adv_sync_recv_info *info)
 {
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->recv) {
 			listener->recv(per_adv_sync, info, NULL);
 		}
@@ -1180,14 +1180,14 @@ static void per_adv_sync_terminated(struct bt_le_per_adv_sync *per_adv_sync, uin
 		.sid = per_adv_sync->sid,
 		.reason = reason,
 	};
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 
 	/* Deleting before callback, so the caller will be able
 	 * to restart sync in the callback.
 	 */
 	per_adv_sync_delete(per_adv_sync);
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->term) {
 			listener->term(per_adv_sync, &term_info);
 		}
@@ -1206,7 +1206,7 @@ static void bt_hci_le_per_adv_sync_established_common(struct net_buf *buf)
 
 	struct bt_le_per_adv_sync_synced_info sync_info;
 	struct bt_le_per_adv_sync *pending_per_adv_sync;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 	bt_addr_le_t id_addr;
 	bool unexpected_evt;
 	int err;
@@ -1312,7 +1312,7 @@ static void bt_hci_le_per_adv_sync_established_common(struct net_buf *buf)
 	sync_info.recv_enabled =
 		!atomic_test_bit(pending_per_adv_sync->flags, BT_PER_ADV_SYNC_RECV_DISABLED);
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->synced) {
 			listener->synced(pending_per_adv_sync, &sync_info);
 		}
@@ -1443,7 +1443,7 @@ static void bt_hci_le_past_received_common(struct net_buf *buf)
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC_RSP) */
 
 	struct bt_le_per_adv_sync_synced_info sync_info;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 	struct bt_le_per_adv_sync *per_adv_sync;
 	bt_addr_le_t id_addr;
 
@@ -1517,7 +1517,7 @@ static void bt_hci_le_past_received_common(struct net_buf *buf)
 	sync_info.response_slot_spacing = per_adv_sync->response_slot_spacing;
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC_RSP) */
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->synced) {
 			listener->synced(per_adv_sync, &sync_info);
 		}
@@ -1562,7 +1562,7 @@ void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_biginfo_adv_report *evt;
 	struct bt_le_per_adv_sync *per_adv_sync;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 	struct bt_iso_biginfo biginfo;
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
@@ -1590,7 +1590,7 @@ void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
 	biginfo.framing = evt->framing;
 	biginfo.encryption = evt->encryption ? true : false;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->biginfo) {
 			listener->biginfo(per_adv_sync, &biginfo);
 		}
@@ -1604,7 +1604,7 @@ static void bt_hci_le_df_connectionless_iq_report_common(uint8_t event, struct n
 
 	struct bt_df_per_adv_sync_iq_samples_report cte_report;
 	struct bt_le_per_adv_sync *per_adv_sync;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 
 	if (event == BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT) {
 		err = hci_df_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
@@ -1624,7 +1624,7 @@ static void bt_hci_le_df_connectionless_iq_report_common(uint8_t event, struct n
 		return;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->cte_report_cb) {
 			listener->cte_report_cb(per_adv_sync, &cte_report);
 		}
@@ -2065,10 +2065,23 @@ int bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
 	return 0;
 }
 
+int bt_le_per_adv_sync_cb_unregister(struct bt_le_per_adv_sync_cb *cb)
+{
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&pa_sync_cbs, &cb->node)) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
 static int bt_le_set_per_adv_recv_enable(struct bt_le_per_adv_sync *per_adv_sync, bool enable)
 {
 	struct bt_hci_cp_le_set_per_adv_recv_enable *cp;
-	struct bt_le_per_adv_sync_cb *listener;
+	struct bt_le_per_adv_sync_cb *listener, *tmp;
 	struct bt_le_per_adv_sync_state_info info;
 	struct net_buf *buf;
 	struct bt_hci_cmd_state_set state;
@@ -2113,7 +2126,7 @@ static int bt_le_set_per_adv_recv_enable(struct bt_le_per_adv_sync *per_adv_sync
 
 	info.recv_enabled = !atomic_test_bit(per_adv_sync->flags, BT_PER_ADV_SYNC_RECV_DISABLED);
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&pa_sync_cbs, listener, tmp, node) {
 		if (listener->state_changed) {
 			listener->state_changed(per_adv_sync, &info);
 		}

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_unregister_sync_cb.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_unregister_sync_cb.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Basic periodic advertising sync test: an advertiser advertises with periodic
+# advertising, and a scanner scans for and syncs to the periodic advertising.
+# Tests if sync callbacks are properly unregistered.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="per_adv_unregister_sync_cb"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
+  -testid=per_adv_long_data_advertiser -rs=23
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=0 \
+  -testid=per_adv_unregister_sync_cb -rs=6
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=15e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Introduce bt_le_per_adv_sync_cb_unregister to allow unregistering of the periodic sync callbacks.