### PR TITLE
drivers: i3c: Move i3c_bus_mode() to common layer

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3429,45 +3429,6 @@ static int cdns_i3c_target_controller_handoff(const struct device *dev, bool acc
 #endif
 #ifdef CONFIG_I3C_CONTROLLER
 /**
- * Determine I3C bus mode from the i2c devices on the bus
- *
- * Reads the LVR of all I2C devices and returns the I3C bus
- * Mode
- *
- * @param dev_list Pointer to device list
- *
- * @return @see enum i3c_bus_mode.
- */
-static enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
-{
-	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
-
-	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_LVR_I2C_DEV_IDX_0:
-			if (mode < I3C_BUS_MODE_MIXED_FAST) {
-				mode = I3C_BUS_MODE_MIXED_FAST;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_1:
-			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
-				mode = I3C_BUS_MODE_MIXED_LIMITED;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_2:
-			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
-				mode = I3C_BUS_MODE_MIXED_SLOW;
-			}
-			break;
-		default:
-			mode = I3C_BUS_MODE_INVALID;
-			break;
-		}
-	}
-	return mode;
-}
-
-/**
  * Determine THD_DEL value for CTRL register
  *
  * Should be MIN(t_cf, t_cr) + 3ns

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -899,6 +899,38 @@ static int i3c_bus_prepare_setdasa(const struct device *dev, const struct i3c_de
 	return 0;
 }
 
+enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
+{
+	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
+
+	__ASSERT_NO_MSG(dev_list != NULL);
+
+	for (int i = 0; i < dev_list->num_i2c; i++) {
+		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
+		case I3C_LVR_I2C_DEV_IDX_0:
+			if (mode < I3C_BUS_MODE_MIXED_FAST) {
+				mode = I3C_BUS_MODE_MIXED_FAST;
+			}
+			break;
+		case I3C_LVR_I2C_DEV_IDX_1:
+			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
+				mode = I3C_BUS_MODE_MIXED_LIMITED;
+			}
+			break;
+		case I3C_LVR_I2C_DEV_IDX_2:
+			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
+				mode = I3C_BUS_MODE_MIXED_SLOW;
+			}
+			break;
+		default:
+			mode = I3C_BUS_MODE_INVALID;
+			break;
+		}
+	}
+
+	return mode;
+}
+
 bool i3c_bus_has_sec_controller(const struct device *dev)
 {
 	struct i3c_device_desc *i3c_desc;

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1532,45 +1532,6 @@ static int dw_i3c_init_scl_timing(const struct device *dev, struct i3c_config_co
 }
 
 #ifdef CONFIG_I3C_CONTROLLER
-/**
- * Determine I3C bus mode from the i2c devices on the bus
- *
- * Reads the LVR of all I2C devices and returns the I3C bus
- * Mode
- *
- * @param dev_list Pointer to device list
- *
- * @return @see enum i3c_bus_mode.
- */
-static enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
-{
-	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
-
-	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_LVR_I2C_DEV_IDX_0:
-			if (mode < I3C_BUS_MODE_MIXED_FAST) {
-				mode = I3C_BUS_MODE_MIXED_FAST;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_1:
-			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
-				mode = I3C_BUS_MODE_MIXED_LIMITED;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_2:
-			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
-				mode = I3C_BUS_MODE_MIXED_SLOW;
-			}
-			break;
-		default:
-			mode = I3C_BUS_MODE_INVALID;
-			break;
-		}
-	}
-	return mode;
-}
-
 static int dw_i3c_attach_device(const struct device *dev, struct i3c_device_desc *desc)
 {
 	const struct dw_i3c_config *config = dev->config;

--- a/drivers/i3c/i3c_renesas_ra.c
+++ b/drivers/i3c/i3c_renesas_ra.c
@@ -109,35 +109,6 @@ extern void i3c_tx_isr(void);
 extern void i3c_rcv_isr(void);
 extern void i3c_eei_isr(void);
 
-static enum i3c_bus_mode i3c_renesas_ra_get_bus_mode(const struct i3c_dev_list *dev_list)
-{
-	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
-
-	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_LVR_I2C_DEV_IDX_0:
-			if (mode < I3C_BUS_MODE_MIXED_FAST) {
-				mode = I3C_BUS_MODE_MIXED_FAST;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_1:
-			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
-				mode = I3C_BUS_MODE_MIXED_LIMITED;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_2:
-			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
-				mode = I3C_BUS_MODE_MIXED_SLOW;
-			}
-			break;
-		default:
-			mode = I3C_BUS_MODE_INVALID;
-			break;
-		}
-	}
-	return mode;
-}
-
 static int i3c_renesas_ra_address_slots_init(const struct device *dev)
 {
 	const struct i3c_renesas_ra_config *config = dev->config;
@@ -1102,7 +1073,7 @@ static int i3c_renesas_ra_init(const struct device *dev)
 	config->bus_enable_irq();
 
 #ifdef CONFIG_I3C_CONTROLLER
-	data->mode = i3c_renesas_ra_get_bus_mode(&config->common.dev_list);
+	data->mode = i3c_bus_mode(&config->common.dev_list);
 
 	/* Clear bus internal device info */
 	memset(data->device_info, 0x00,

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -162,44 +162,6 @@ struct i3c_stm32_data {
 	bool hj_pm_lock;           /* Used as flag for setting pm */
 #endif
 };
-/**
- * Determine I3C bus mode from the i2c devices on the bus.
- *
- * Reads the LVR of all I2C devices and returns the I3C bus
- * Mode.
- *
- * @param dev_list Pointer to device list
- *
- * @return @see enum i3c_bus_mode.
- */
-static enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
-{
-	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
-
-	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_LVR_I2C_DEV_IDX_0:
-			if (mode < I3C_BUS_MODE_MIXED_FAST) {
-				mode = I3C_BUS_MODE_MIXED_FAST;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_1:
-			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
-				mode = I3C_BUS_MODE_MIXED_LIMITED;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_2:
-			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
-				mode = I3C_BUS_MODE_MIXED_SLOW;
-			}
-			break;
-		default:
-			mode = I3C_BUS_MODE_INVALID;
-			break;
-		}
-	}
-	return mode;
-}
 
 static int get_i3c_lvr_ic_mode(const struct i3c_dev_list *dev_list)
 {

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1108,36 +1108,6 @@ static int it51xxx_i3cm_ibi_disable(const struct device *dev, struct i3c_device_
 }
 #endif /* CONFIG_I3C_USE_IBI */
 
-static enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
-{
-	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
-
-	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_LVR_I2C_DEV_IDX_0:
-			if (mode < I3C_BUS_MODE_MIXED_FAST) {
-				mode = I3C_BUS_MODE_MIXED_FAST;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_1:
-			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
-				mode = I3C_BUS_MODE_MIXED_LIMITED;
-			}
-			break;
-		case I3C_LVR_I2C_DEV_IDX_2:
-			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
-				mode = I3C_BUS_MODE_MIXED_SLOW;
-			}
-			break;
-		default:
-			mode = I3C_BUS_MODE_INVALID;
-			break;
-		}
-	}
-
-	return mode;
-}
-
 static int it51xxx_i3cm_init(const struct device *dev)
 {
 	const struct it51xxx_i3cm_config *cfg = dev->config;

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -2338,6 +2338,18 @@ static inline int i3c_device_info_get(struct i3c_device_desc *target)
 }
 
 /**
+ * @brief Determine I3C bus mode from the I2C devices on the bus.
+ *
+ * Reads the LVR of all I2C devices and returns the I3C bus
+ * mode.
+ *
+ * @param dev_list Pointer to the device list struct.
+ *
+ * @return @see enum i3c_bus_mode
+ */
+enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list);
+
+/**
  * @brief Check if the bus has a secondary controller.
  *
  * This reads the BCR from the device descriptor struct of all targets


### PR DESCRIPTION
`i3c_bus_mode()` is duplicated across several drivers. Move it into `i3c_common.c` to eliminate that.