### PR TITLE
soc: ite: Add idle exit tracing

### DIFF
--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -78,6 +78,7 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	/* CPU has been woken up, the interrupt is no longer needed */
 	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, false);
 #endif
+	sys_trace_idle_exit();
 	/*
 	 * Enable M-mode external interrupt
 	 * An interrupt can not be fired yet until we enable global interrupt

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -375,6 +375,7 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	/* CPU has been woken up, the interrupt is no longer needed */
 	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, false);
 #endif
+	sys_trace_idle_exit();
 	/*
 	 * Enable M-mode external interrupt
 	 * An interrupt can not be fired yet until we enable global interrupt


### PR DESCRIPTION
The idle enter was being traced but idle exit was not. This change adds the missing call to sys_trace_idle_exit() to the idle exit path for the it51xxx and it8xxx2 SoCs.