### PR TITLE
xtensa: mmu: add doxygen doc

### DIFF
--- a/arch/xtensa/core/mmu.c
+++ b/arch/xtensa/core/mmu.c
@@ -18,6 +18,15 @@ BUILD_ASSERT((CONFIG_PRIVILEGED_STACK_SIZE > 0) &&
 
 extern uint32_t *xtensa_kernel_ptables;
 
+/**
+ * @brief Precompute register values needed during page table switching.
+ *
+ * This precomputes the necessary values for registers that must be
+ * programmed when switching page tables. This is on a per-domain basis as
+ * each domain has a corresponding set of page tables.
+ *
+ * @param domain Pointer to the memory domain.
+ */
 void xtensa_mmu_compute_domain_regs(struct arch_mem_domain *domain)
 {
 	uint32_t vecbase = XTENSA_RSR("VECBASE");
@@ -60,7 +69,10 @@ void xtensa_mmu_compute_domain_regs(struct arch_mem_domain *domain)
 				| XTENSA_MMU_VECBASE_WAY;
 }
 
-/* Switch to a new page table.  There are four items we have to set in
+/**
+ * @brief Switch to new page tables of a memory domain.
+ *
+ * Switch to a new page table. There are four items that must be set in
  * the hardware: the PTE virtual address, the ring/ASID mapping
  * register, and two pinned entries in the data TLB handling refills
  * for the page tables and the vector handlers.
@@ -74,6 +86,9 @@ void xtensa_mmu_compute_domain_regs(struct arch_mem_domain *domain)
  * holds our five instructions is sufficient to guarantee that: I
  * couldn't think of a way to do the alignment statically that also
  * interoperated well with inline assembly).
+ *
+ * @param domain Pointer to the memory domain containing the page tables
+ *               to be used after switching.
  */
 void xtensa_mmu_set_paging(struct arch_mem_domain *domain)
 {
@@ -90,7 +105,12 @@ void xtensa_mmu_set_paging(struct arch_mem_domain *domain)
 			    "r"(domain->reg_vecpin_at), "r"(domain->reg_vecpin_as));
 }
 
-/* This is effectively the same algorithm from xtensa_mmu_set_paging(),
+/**
+ * @brief Initialize paging to enable MMU.
+ *
+ * This routine initializes paging which enables MMU.
+ *
+ * This is effectively the same algorithm from xtensa_mmu_set_paging(),
  * but it also disables the hardware-initialized 512M TLB entries in
  * way 6 (because the hardware disallows duplicate TLB mappings).  For
  * instruction fetches this produces a critical ordering constraint:

--- a/arch/xtensa/core/mmu.c
+++ b/arch/xtensa/core/mmu.c
@@ -208,3 +208,41 @@ void xtensa_mmu_init_paging(void)
 	}
 	__asm__ volatile("isync");
 }
+
+__weak void arch_xtensa_mmu_post_init(bool is_core0)
+{
+	ARG_UNUSED(is_core0);
+}
+
+void xtensa_mmu_init(void)
+{
+	xtensa_init_page_tables();
+
+	xtensa_mmu_init_paging();
+
+	/*
+	 * This is used to determine whether we are faulting inside double
+	 * exception if this is not zero. Sometimes SoC starts with this not
+	 * being set to zero. So clear it during boot.
+	 */
+	XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
+
+	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
+}
+
+void xtensa_mmu_reinit(void)
+{
+	/* First initialize the hardware */
+	xtensa_mmu_init_paging();
+
+#ifdef CONFIG_USERSPACE
+	struct k_thread *thread = _current_cpu->current;
+	struct arch_mem_domain *domain = &(thread->mem_domain_info.mem_domain->arch);
+
+
+	/* Set the page table for current context */
+	xtensa_mmu_set_paging(domain);
+#endif /* CONFIG_USERSPACE */
+
+	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
+}

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -474,7 +474,7 @@ static void map_memory_range(const uint32_t start, const uint32_t end,
 	}
 }
 
-static void xtensa_init_page_tables(void)
+void xtensa_init_page_tables(void)
 {
 	volatile uint8_t entry;
 	static bool already_inited;
@@ -516,45 +516,6 @@ static void xtensa_init_page_tables(void)
 	if (IS_ENABLED(PAGE_TABLE_IS_CACHED)) {
 		sys_cache_data_flush_all();
 	}
-}
-
-__weak void arch_xtensa_mmu_post_init(bool is_core0)
-{
-	ARG_UNUSED(is_core0);
-}
-
-void xtensa_mmu_init(void)
-{
-	xtensa_init_page_tables();
-
-	xtensa_mmu_init_paging();
-
-	/*
-	 * This is used to determine whether we are faulting inside double
-	 * exception if this is not zero. Sometimes SoC starts with this not
-	 * being set to zero. So clear it during boot.
-	 */
-	XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
-
-	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
-}
-
-void xtensa_mmu_reinit(void)
-{
-	/* First initialize the hardware */
-	xtensa_mmu_init_paging();
-
-#ifdef CONFIG_USERSPACE
-	struct k_thread *thread = _current_cpu->current;
-	struct arch_mem_domain *domain =
-			&(thread->mem_domain_info.mem_domain->arch);
-
-
-	/* Set the page table for current context */
-	xtensa_mmu_set_paging(domain);
-#endif /* CONFIG_USERSPACE */
-
-	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
 }
 
 #ifdef CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -126,36 +126,49 @@
 #define PAGE_TABLE_IS_CACHED 1
 #endif
 
-/* Skip TLB IPI when updating page tables.
+/**
+ * @brief Option to skip TLB IPI when updating page tables.
+ *
+ * Skip TLB IPI when updating page tables.
+ *
  * This allows us to send IPI only after the last
  * changes of a series.
  */
 #define OPTION_NO_TLB_IPI BIT(0)
 
-/* Restore the PTE attributes if they have been
+/**
+ * @brief Option to restore PTE attributes.
+ *
+ * Restore the PTE attributes if they have been
  * stored in the SW bits part in the PTE.
  */
 #define OPTION_RESTORE_ATTRS BIT(1)
 
-/* Save the PTE attributes and ring in the SW bits part in the PTE. */
+/**
+ * @brief Option to save PTE attributes.
+ *
+ * Save the PTE attributes and ring in the SW bits part in the PTE.
+ */
 #define OPTION_SAVE_ATTRS BIT(2)
 
-/* Level 1 contains page table entries
- * necessary to map the page table itself.
+/**
+ * @brief Number of page table entries (PTE) in level 1 page tables.
+ *
+ * Level 1 contains page table entries necessary to map the page table itself.
  */
 #define L1_PAGE_TABLE_NUM_ENTRIES 1024U
 
-/* Size of level 1 page table.
- */
+/** Size of one level 1 page table in bytes. */
 #define L1_PAGE_TABLE_SIZE (L1_PAGE_TABLE_NUM_ENTRIES * sizeof(uint32_t))
 
-/* Level 2 contains page table entries
- * necessary to map the page table itself.
+/**
+ * @brief Number of page table entries (PTE) in level 2 page tables.
+ *
+ * Level 2 contains page table entries necessary to map memory pages.
  */
 #define L2_PAGE_TABLE_NUM_ENTRIES 1024U
 
-/* Size of level 2 page table.
- */
+/** Size of one level 2 page table in bytes. */
 #define L2_PAGE_TABLE_SIZE (L2_PAGE_TABLE_NUM_ENTRIES * sizeof(uint32_t))
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
@@ -163,7 +176,9 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 BUILD_ASSERT(CONFIG_MMU_PAGE_SIZE == 0x1000,
 	     "MMU_PAGE_SIZE value is invalid, only 4 kB pages are supported\n");
 
-/*
+/**
+ * @brief Array of level 1 page tables.
+ *
  * Level 1 page table has to be 4Kb to fit into one of the wired entries.
  * All entries are initialized as INVALID, so an attempt to read an unmapped
  * area will cause a double exception.
@@ -174,19 +189,25 @@ BUILD_ASSERT(CONFIG_MMU_PAGE_SIZE == 0x1000,
 static uint32_t l1_page_tables[CONFIG_XTENSA_MMU_NUM_L1_TABLES][L1_PAGE_TABLE_NUM_ENTRIES]
 		__aligned(KB(4));
 
-/*
- * That is an alias for the page tables set used by the kernel.
+/**
+ * @brief Alias for the page tables set used by the kernel.
  */
 uint32_t *xtensa_kernel_ptables = (uint32_t *)l1_page_tables[0];
 
-/*
+/**
+ * @brief Array of level 2 page tables.
+ *
  * Each table in the level 2 maps a 4Mb memory range. It consists of 1024 entries each one
  * covering a 4Kb page.
  */
 static uint32_t l2_page_tables[CONFIG_XTENSA_MMU_NUM_L2_TABLES][L2_PAGE_TABLE_NUM_ENTRIES]
 		__aligned(KB(4));
 
-/*
+/**
+ * @brief Usage tracking for level 1 page tables.
+ *
+ * This is a bit mask of which L1 tables are being used.
+ *
  * This additional variable tracks which l1 tables are in use. This is kept separated from
  * the tables to keep alignment easier.
  *
@@ -194,7 +215,12 @@ static uint32_t l2_page_tables[CONFIG_XTENSA_MMU_NUM_L2_TABLES][L2_PAGE_TABLE_NU
  */
 static ATOMIC_DEFINE(l1_page_tables_track, CONFIG_XTENSA_MMU_NUM_L1_TABLES);
 
-/*
+/**
+ * @brief Usage tracking for level 2 page tables.
+ *
+ * This is an array of integer counter indicating how many times one L2 tables is
+ * referenced by L1 tables.
+ *
  * This additional variable tracks which l2 tables are in use. This is kept separated from
  * the tables to keep alignment easier.
  */
@@ -208,9 +234,7 @@ static uint32_t l1_page_tables_max_usage;
 static uint32_t l2_page_tables_max_usage;
 #endif /* CONFIG_XTENSA_MMU_PAGE_TABLE_STATS */
 
-/*
- * Protects xtensa_domain_list and serializes access to page tables.
- */
+/** Spin lock to protect xtensa_domain_list and serializes access to page tables. */
 static struct k_spinlock xtensa_mmu_lock;
 
 /** Spin lock to guard update to page table counters. */
@@ -218,19 +242,22 @@ static struct k_spinlock xtensa_counter_lock;
 
 #ifdef CONFIG_USERSPACE
 
-/*
+/**
+ * @brief Number of ASIDs has been allocated.
+ *
  * Each domain has its own ASID. ASID can go through 1 (kernel) to 255.
  * When a TLB entry matches, the hw will check the ASID in the entry and finds
  * the correspondent position in the RASID register. This position will then be
  * compared with the current ring (CRING) to check the permission.
+ *
+ * This keeps track of how many ASIDs have been allocated for memory domains.
  */
 static uint8_t asid_count = 3;
 
-/*
- * List with all active and initialized memory domains.
- */
+/** Linked list with all active and initialized memory domains. */
 static sys_slist_t xtensa_domain_list;
 
+/** Actions when duplicating page tables. */
 enum dup_action {
 	/* Restore all entries when duplicating. */
 	RESTORE,
@@ -246,7 +273,9 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 extern char _heap_end[];
 extern char _heap_start[];
 
-/*
+/**
+ * @brief Memory regions to initialize page tables at boot.
+ *
  * Static definition of all code & data memory regions of the
  * current Zephyr image. This information must be available &
  * processed upon MMU initialization.
@@ -361,6 +390,14 @@ static inline int l2_table_to_counter_pos(uint32_t *l2_table)
 	return (l2_table - (uint32_t *)l2_page_tables) / (L2_PAGE_TABLE_NUM_ENTRIES);
 }
 
+/**
+ * @brief Allocate a level 2 page table from the L2 table array.
+ *
+ * This allocates a new level 2 page table from the L2 table array.
+ *
+ * @return Pointer to the newly allocated L2 table. NULL if no free table
+ *         in the array.
+ */
 static inline uint32_t *alloc_l2_table(void)
 {
 	uint16_t idx;
@@ -384,6 +421,16 @@ static inline uint32_t *alloc_l2_table(void)
 	return ret;
 }
 
+/**
+ * @brief Map memory in the kernel page tables.
+ *
+ * This is used during boot, and is to map a region of memory in the kernel page tables.
+ *
+ * @param[in] start Start address of the memory region.
+ * @param[in] end End address of the memory region.
+ * @param[in] attrs Page table attributes for the memory region.
+ * @param[in] options Options for the memory region.
+ */
 static void map_memory_range(const uint32_t start, const uint32_t end,
 			     const uint32_t attrs, const uint32_t options)
 {
@@ -511,14 +558,15 @@ void xtensa_mmu_reinit(void)
 }
 
 #ifdef CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES
-/* Zephyr's linker scripts for Xtensa usually puts
- * something before z_mapped_start (aka .text),
- * i.e. vecbase, so that we need to reserve those
- * space or else k_mem_map() would be mapping those,
- * resulting in faults.
- */
 __weak void arch_reserved_pages_update(void)
 {
+	/* Zephyr's linker scripts for Xtensa usually puts
+	 * something before z_mapped_start (aka .text),
+	 * i.e. vecbase, so that we need to reserve those
+	 * space or else k_mem_map() would be mapping those,
+	 * resulting in faults.
+	 */
+
 	uintptr_t page;
 	int idx;
 
@@ -530,6 +578,22 @@ __weak void arch_reserved_pages_update(void)
 }
 #endif /* CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES */
 
+/**
+ * @brief Map one memory page in the L2 table.
+ *
+ * This maps exactly one memory page in the L2 table.
+ *
+ * A new L2 table will be allocated if necessary.
+ *
+ * @param[in] l1_table Pointer to the level 1 page table.
+ * @param[in] vaddr Virtual address to be mapped.
+ * @param[in] phys Physical address to map to.
+ * @param[in] attrs Page table attributes (actual hardware attributes).
+ * @param[in] is_user True if this mapping can be used in user mode, false if kernel mode only.
+ *
+ * @retval true Mapping is successful.
+ * @retval false Mapping failed. Usually means there are no free L2 tables to be allocated.
+ */
 static bool l2_page_table_map(uint32_t *l1_table, void *vaddr, uintptr_t phys,
 			      uint32_t attrs, bool is_user)
 {
@@ -574,6 +638,18 @@ static bool l2_page_table_map(uint32_t *l1_table, void *vaddr, uintptr_t phys,
 	return true;
 }
 
+/**
+ * @brief Called by @ref arch_mem_map to map one memory page.
+ *
+ * @see arch_mem_map
+ *
+ * This should only be called by @ref arch_mem_map to perform the mapping in the L2 tables.
+ *
+ * @param[in] vaddr Virtual address to be mapped.
+ * @param[in] paddr Physical address to map to.
+ * @param[in] attrs Page table attributes (actual hardware attributes).
+ * @param[in] is_user True if mapping for user mode, false if kernel mode only.
+ */
 static inline void __arch_mem_map(void *vaddr, uintptr_t paddr, uint32_t attrs, bool is_user)
 {
 	bool ret;
@@ -745,6 +821,15 @@ end:
 	}
 }
 
+/**
+ * @brief Called by @ref arch_mem_unmap to unmap one memory page.
+ *
+ * @see arch_mem_unmap
+ *
+ * This should only be called by @ref arch_mem_unmap to remove the mapping in the L2 tables.
+ *
+ * @param[in] vaddr Virtual address to be unmapped.
+ */
 static inline void __arch_mem_unmap(void *vaddr)
 {
 	l2_page_table_unmap(xtensa_kernel_ptables, vaddr);
@@ -916,6 +1001,11 @@ static bool is_l2_table_inside_array(uint32_t *l2_table)
 	return (addr >= l2_table_begin) && (addr < l2_table_end);
 }
 
+/**
+ * @brief Increment the tracking counter for one L2 table.
+ *
+ * @param[in] l2_table Pointer to the level 2 page table.
+ */
 static ALWAYS_INLINE void l2_page_tables_counter_inc(uint32_t *l2_table)
 {
 	if (is_l2_table_inside_array(l2_table)) {
@@ -923,6 +1013,11 @@ static ALWAYS_INLINE void l2_page_tables_counter_inc(uint32_t *l2_table)
 	}
 }
 
+/**
+ * @brief Decrement the tracking counter for one L2 table.
+ *
+ * @param[in] l2_table Pointer to the level 2 page table.
+ */
 static ALWAYS_INLINE void l2_page_tables_counter_dec(uint32_t *l2_table)
 {
 	if (is_l2_table_inside_array(l2_table)) {
@@ -932,6 +1027,13 @@ static ALWAYS_INLINE void l2_page_tables_counter_dec(uint32_t *l2_table)
 
 #ifdef CONFIG_USERSPACE
 
+/**
+ * @brief Get the page table for the thread.
+ *
+ * @param[in] thread Pointer to the thread object.
+ *
+ * @return Pointer to the L1 table corresponding to the thread.
+ */
 static inline uint32_t *thread_page_tables_get(const struct k_thread *thread)
 {
 	if ((thread->base.user_options & K_USER) != 0U) {
@@ -941,6 +1043,14 @@ static inline uint32_t *thread_page_tables_get(const struct k_thread *thread)
 	return xtensa_kernel_ptables;
 }
 
+/**
+ * @brief Allocate a level 1 page table from the L1 table array.
+ *
+ * This allocates a new level 1 page table from the L1 table array.
+ *
+ * @return Pointer to the newly allocated L2 table. NULL if no free table
+ *         in the array.
+ */
 static inline uint32_t *alloc_l1_table(void)
 {
 	uint16_t idx;
@@ -974,10 +1084,10 @@ static inline uint32_t *alloc_l1_table(void)
 }
 
 /**
- * Given page table position, calculate the corresponding virtual address.
+ * @brief Given page table position, calculate the corresponding virtual address.
  *
- * @param l1_pos Position in L1 page table.
- * @param l2_pos Position in L2 page table.
+ * @param[in] l1_pos Position in L1 page table.
+ * @param[in] l2_pos Position in L2 page table.
  * @return Virtual address.
  */
 static ALWAYS_INLINE uint32_t vaddr_from_pt_pos(uint32_t l1_pos, uint32_t l2_pos)
@@ -985,6 +1095,19 @@ static ALWAYS_INLINE uint32_t vaddr_from_pt_pos(uint32_t l1_pos, uint32_t l2_pos
 	return (l1_pos << 22U) | (l2_pos << 12U);
 }
 
+/**
+ * @brief Duplicate an existing level 2 page table.
+ *
+ * This allocates a new level 2 page table and duplicates the PTEs from an existing
+ * L2 table.
+ *
+ * @param[in] src_l2_table Pointer to the source L2 table to be duplicated.
+ * @param[in] action Action during duplication.
+ *                   RESTORE to restore PTEs to the attributes stored in the backup bits.
+ *                   COPY to copy PTEs from source without modifications.
+ *
+ * @return Pointer to the newly duplicated L2 table. NULL if table allocation fails.
+ */
 static uint32_t *dup_l2_table(uint32_t *src_l2_table, enum dup_action action)
 {
 	uint32_t *l2_table;
@@ -1020,6 +1143,14 @@ static uint32_t *dup_l2_table(uint32_t *src_l2_table, enum dup_action action)
 	return l2_table;
 }
 
+/**
+ * @brief Duplicate the kernel page table into a new level 1 page table.
+ *
+ * This allocates a new level 1 page table and copy the PTEs from the kernel
+ * page table.
+ *
+ * @return Pointer to the newly duplicated L1 table. NULL if table allocation fails.
+ */
 static uint32_t *dup_l1_table(void)
 {
 	uint32_t *l1_table = alloc_l1_table();
@@ -1090,6 +1221,26 @@ static uint32_t *dup_l1_table(void)
 	return l1_table;
 }
 
+/**
+ * @brief Duplicate an existing level 2 page table if needed.
+ *
+ * If a L2 table is referenced by multiple L1 tables, we need to make a copy of
+ * the existing L2 table and modify the new table, basically a copy-on-write
+ * operation.
+ *
+ * If a new L2 table needs to be allocated, the corresponding PTE in the L1 table
+ * will be modified to point to the new table.
+ *
+ * If the L2 table is only referenced by exactly one L1 table, no duplication
+ * will be performed.
+ *
+ * @param[in] l1_table Pointer to the level 1 page table.
+ * @param[in] l1_pos Index of the PTE within the L1 table pointing to the L2 table
+ *                   to be examined.
+ * @param[in] action Action during duplication.
+ *                   RESTORE to restore PTEs to the attributes stored in the backup bits.
+ *                   COPY to copy PTEs from source without modifications.
+ */
 static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup_action action)
 {
 	uint32_t *l2_table, *src_l2_table;
@@ -1165,8 +1316,22 @@ err:
 	return ret;
 }
 
+/**
+ * @brief Update the mappings of a memory region.
+ *
+ * @note This does not lock the necessary spin locks to prevent simultaneous updates
+ *       to the page tables. Use @ref update_region instead if locking is desired.
+ *
+ * @param[in] l1_table Pointer to the L1 table.
+ * @param[in] start Starting virtual address of the memory region to be updated.
+ * @param[in] size Size of the memory region to be updated.
+ * @param[in] ring Ring value to set to.
+ * @param[in] attrs Page table attributes to set to (not used if option is RESTORE).
+ * @param[in] option Option for the memory region.
+ *                   OPTION_RESTORE_ATTRS will restore the attributes from the backup bits.
+ */
 static void region_map_update(uint32_t *l1_table, uintptr_t start,
-			      size_t size, uint32_t ring, uint32_t flags, uint32_t option)
+			      size_t size, uint32_t ring, uint32_t attrs, uint32_t option)
 {
 	for (size_t offset = 0; offset < size; offset += CONFIG_MMU_PAGE_SIZE) {
 		uint32_t *l2_table, pte;
@@ -1197,7 +1362,7 @@ static void region_map_update(uint32_t *l1_table, uintptr_t start,
 			new_attrs = PTE_BCKUP_ATTR_GET(pte);
 			new_ring = PTE_BCKUP_RING_GET(pte);
 		} else {
-			new_attrs = flags;
+			new_attrs = attrs;
 			new_ring = ring;
 		}
 
@@ -1214,14 +1379,28 @@ static void region_map_update(uint32_t *l1_table, uintptr_t start,
 	}
 }
 
+/**
+ * @brief Update the attributes of the memory region.
+ *
+ * @note This locks the necessary spin locks to prevent simultaneous updates
+ *       to the page tables.
+ *
+ * @param[in] ptables Pointer to the L1 table.
+ * @param[in] start Starting virtual address of the memory region to be updated.
+ * @param[in] size Size of the memory region to be updated.
+ * @param[in] ring Ring value to set to.
+ * @param[in] attrs Page table attributes to set to (not used if option is RESTORE).
+ * @param[in] option Option for the memory region.
+ *                   OPTION_RESTORE_ATTRS will restore the attributes from the backup bits.
+ */
 static void update_region(uint32_t *ptables, uintptr_t start, size_t size,
-			  uint32_t ring, uint32_t flags, uint32_t option)
+			  uint32_t ring, uint32_t attrs, uint32_t option)
 {
 	k_spinlock_key_t key;
 
 	key = k_spin_lock(&xtensa_mmu_lock);
 
-	region_map_update(ptables, start, size, ring, flags, option);
+	region_map_update(ptables, start, size, ring, attrs, option);
 
 #if CONFIG_MP_MAX_NUM_CPUS > 1
 	if ((option & OPTION_NO_TLB_IPI) != OPTION_NO_TLB_IPI) {
@@ -1235,6 +1414,22 @@ static void update_region(uint32_t *ptables, uintptr_t start, size_t size,
 	k_spin_unlock(&xtensa_mmu_lock, key);
 }
 
+/**
+ * @brief Reset the attributes of the memory region.
+ *
+ * This restores the ring and PTE attributes to the backup bits.
+ * Usually this restores the PTEs corresponding to the memory region to
+ * the ring and attributes at boot time just before MMU is enabled.
+ *
+ * @note This calls @ref update_region which locks the necessary spin locks to
+ *       prevent simultaneous updates to the page tables.
+ *
+ * @param[in] ptables Pointer to the L1 table.
+ * @param[in] start Starting virtual address of the memory region to be updated.
+ * @param[in] size Size of the memory region to be updated.
+ * @param[in] option Option for the memory region.
+ *                   OPTION_RESTORE_ATTRS will restore the attributes from the backup bits.
+ */
 static inline void reset_region(uint32_t *ptables, uintptr_t start, size_t size, uint32_t option)
 {
 	update_region(ptables, start, size, RING_KERNEL, XTENSA_MMU_PERM_W,
@@ -1286,7 +1481,6 @@ int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 	return 0;
 }
 
-/* These APIs don't need to do anything */
 int arch_mem_domain_thread_add(struct k_thread *thread)
 {
 	bool is_user, is_migration;
@@ -1371,6 +1565,17 @@ int arch_mem_domain_thread_remove(struct k_thread *thread)
 	return 0;
 }
 
+/**
+ * @brief Check if a page can be legally accessed.
+ *
+ * @param[in] ptables Pointer to the level 1 page table.
+ * @param[in] page Virtual address of the page to be checked.
+ * @param[in] ring Ring value for the access.
+ * @param[in] write True if the access needs to write to this page, false if read only.
+ *
+ * @retval true Access is legal.
+ * @retval false Access is not legal and will probably generate page fault.
+ */
 static bool page_validate(uint32_t *ptables, uint32_t page, uint8_t ring, bool write)
 {
 	uint8_t asid_ring;
@@ -1409,6 +1614,20 @@ static bool page_validate(uint32_t *ptables, uint32_t page, uint8_t ring, bool w
 	return true;
 }
 
+/**
+ * @brief Check if a memory region can be legally accessed.
+ *
+ * @param[in] ptables Pointer to the level 1 page table.
+ * @param[in] addr Start virtual address of the memory region to be checked.
+ * @param[in] size Size of the memory region to be checked.
+ * @param[in] write True if the access needs to write to this page, false if read only.
+ * @param[in] ring Ring value for the access.
+ *
+ * @retval 0 Access is legal.
+ * @retval -1 Access is not legal and will probably generate page fault.
+ *
+ * @see arch_buffer_validate
+ */
 static int mem_buffer_validate(const void *addr, size_t size, int write, int ring)
 {
 	int ret = 0;

--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -486,6 +486,11 @@ void xtensa_mmu_set_paging(struct arch_mem_domain *domain);
 void xtensa_mmu_compute_domain_regs(struct arch_mem_domain *domain);
 
 /**
+ * @brief Initialize page tables needed for boot.
+ */
+void xtensa_init_page_tables(void);
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Add doxygen documentation to the Xtensa MMU code as we are missing quite a bit.

Also moves some of the MMU related functions out of `ptables.c` into `mmu.c`.