### PR TITLE
boards: Add Grove headers for Cytron Maker Uno RP2040

### DIFF
--- a/boards/cytron/maker_uno_rp2040/grove_connectors.dtsi
+++ b/boards/cytron/maker_uno_rp2040/grove_connectors.dtsi
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Jonas Berg
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	grove_header1: grove_header1 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 1 0>, /* RX */
+			   <1 0 &gpio0 0 0>; /* TX */
+	};
+
+	grove_header2: grove_header2 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 5 0>,
+			   <1 0 &gpio0 4 0>;
+	};
+
+	grove_header3: grove_header3 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 26 0>, /* ADC0 */
+			   <1 0 &gpio0 6 0>;
+	};
+
+	grove_header4: grove_header4 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 27 0>, /* ADC1 */
+			   <1 0 &gpio0 7 0>;
+	};
+
+	grove_header5: grove_header5 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 29 0>, /* ADC3 */
+			   <1 0 &gpio0 28 0>; /* ADC2 */
+	};
+
+	grove_header6: grove_header6 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 21 0>, /* SCL */
+			   <1 0 &gpio0 20 0>; /* SDA */
+	};
+
+	stemma_connector: stemma_connector {
+		compatible = "stemma-qt-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 21 0>, /* SCL */
+			   <1 0 &gpio0 20 0>; /* SDA */
+	};
+};

--- a/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
+++ b/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "arduino_r3_connector.dtsi"
+#include "grove_connectors.dtsi"
 #include "maker_uno_rp2040-pinctrl.dtsi"
 
 / {
@@ -56,15 +57,6 @@
 			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
 			label = "LED GP3";
 		};
-	};
-
-	stemma_connector: stemma_connector {
-		compatible = "stemma-qt-connector";
-		#gpio-cells = <2>;
-		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 21 0>, /* SCL */
-			   <1 0 &gpio0 20 0>; /* SDA */
 	};
 };
 


### PR DESCRIPTION
Added the six Grove headers (and the Stemma QT header) to a separate devicetree include file.