### PR TITLE
doc: Fix reference to generated event when calling uart_tx_abort()

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -799,7 +799,7 @@ __syscall int uart_tx_u16(const struct device *dev, const uint16_t *buf,
 /**
  * @brief Abort current TX transmission.
  *
- * #UART_TX_DONE event will be generated with amount of data sent.
+ * #UART_TX_ABORTED event will be generated with amount of data sent.
  *
  * @param dev UART device instance.
  *


### PR DESCRIPTION
This commit replaces in the documentation of uart_tx_abort() function, the generated event type `UART_TX_DONE` with the correct one: `UART_TX_ABORTED`.