### PR TITLE
boards: native: add support for static linking

### DIFF
--- a/boards/native/common/natsim_config.cmake
+++ b/boards/native/common/natsim_config.cmake
@@ -13,6 +13,10 @@ if(SYSROOT_DIR)
   target_link_options(native_simulator INTERFACE "--sysroot=${SYSROOT_DIR}")
 endif()
 
+if(CONFIG_NATIVE_SIMULATOR_STATIC_LINKING)
+  target_link_options(native_simulator INTERFACE "-static")
+endif()
+
 if("${LINKER}" STREQUAL "lld")
   target_link_options(native_simulator INTERFACE "-fuse-ld=lld")
 endif()

--- a/soc/native/inf_clock/Kconfig
+++ b/soc/native/inf_clock/Kconfig
@@ -50,4 +50,11 @@ config NATIVE_SIMULATOR_AUTOSTART_MCU
 	  If that MCU was, by HW design, going to start at HW boot anyhow, this option does nothing.
 	  This option is meant to facilitate development.
 
+config NATIVE_SIMULATOR_STATIC_LINKING
+	bool "Attempt to use static linking"
+	help
+	  Do not link the final native simulator runner with shared libraries.
+
+	  Static linking depends on all required libraries being available as static libraries.
+
 endif # SOC_POSIX


### PR DESCRIPTION
Add support for static linking of the final native simulator runner.