### PR TITLE
drivers: crypto: intel_sha: make set_ctl_enable and intel_sha_set_resume_length_dw1 void

### DIFF
--- a/drivers/crypto/crypto_intel_sha.c
+++ b/drivers/crypto/crypto_intel_sha.c
@@ -29,7 +29,7 @@ static int intel_sha_get_unused_session_idx(void)
 	return -1;
 }
 
-static int intel_sha_set_ctl_enable(struct sha_container *sha, int status)
+static void intel_sha_set_ctl_enable(struct sha_container *sha, int status)
 {
 	/* wait until not busy when turning off */
 	if (status == 0 && sha->dfsha->shactl.part.en == 1) {
@@ -38,7 +38,6 @@ static int intel_sha_set_ctl_enable(struct sha_container *sha, int status)
 	}
 
 	sha->dfsha->shactl.part.en = status;
-	return 0;
 }
 
 static int intel_sha_set_resume_length_dw0(struct sha_container *sha, uint32_t lower_length)
@@ -87,10 +86,7 @@ static int intel_sha_device_run(const struct device *dev, const void *buf_in, si
 	/* align to OWORD */
 	const size_t aligned_buff_size = ROUND_UP(buf_in_size, 0x10);
 
-	err = intel_sha_set_ctl_enable(self, 0);
-	if (err) {
-		return err;
-	}
+	intel_sha_set_ctl_enable(self, 0);
 
 	/* set processing element disable */
 	self->dfsha->pibcs.part.peen = 0;
@@ -142,14 +138,11 @@ static int intel_sha_device_run(const struct device *dev, const void *buf_in, si
 	/* increment pointer */
 	self->dfsha->pibfpi.full = buf_in_size;
 
-	err = intel_sha_set_ctl_enable(self, 1);
-	if (err) {
-		return err;
-	}
+	intel_sha_set_ctl_enable(self, 1);
 
-	err = intel_sha_set_ctl_enable(self, 0);
+	intel_sha_set_ctl_enable(self, 0);
 
-	return err;
+	return 0;
 }
 
 static int intel_sha_copy_hash(struct sha_container *const self, void *dst, size_t len)

--- a/drivers/crypto/crypto_intel_sha.c
+++ b/drivers/crypto/crypto_intel_sha.c
@@ -52,10 +52,9 @@ static int intel_sha_set_resume_length_dw0(struct sha_container *sha, uint32_t l
 	return err;
 }
 
-static int intel_sha_set_resume_length_dw1(struct sha_container *sha, uint32_t upper_length)
+static void intel_sha_set_resume_length_dw1(struct sha_container *sha, uint32_t upper_length)
 {
 	sha->dfsha->sharldw1.full = upper_length;
-	return 0;
 }
 
 static int intel_sha_regs_cpy(void *dst, const void *src, size_t len)
@@ -116,10 +115,8 @@ static int intel_sha_device_run(const struct device *dev, const void *buf_in, si
 		if (err) {
 			return err;
 		}
-		err = intel_sha_set_resume_length_dw1(self, self->dfsha->shaaldw1.full);
-		if (err) {
-			return err;
-		}
+		intel_sha_set_resume_length_dw1(self, self->dfsha->shaaldw1.full);
+
 		err = intel_sha_regs_cpy((void *)self->dfsha->initial_vector,
 					 (void *)self->dfsha->sha_result,
 					 sizeof(self->dfsha->initial_vector));


### PR DESCRIPTION
intel_sha_set_ctl_enable() and intel_sha_set_resume_length_dw1() never reports errors and always returns 0.
The error check at the call site is therefore dead code.

Make the function void and drop the unused error handling.