### PR TITLE
boards: kconfig: add `BOARD_WITH_REVISION`

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -18,6 +18,16 @@ config BOARD_REVISION
 	  "plank@foo", this option will be "foo". If building for "plank",
 	  this option will be the empty string.
 
+config BOARD_WITH_REVISION
+	string
+	default "$(BOARD)@$(BOARD_REVISION)" if "$(BOARD_REVISION)" != ""
+	default "$(BOARD)"
+	help
+	  Contains the name of the board, including any revision if present.
+	  For example, if building for "plank@foo/cpu0", this option
+	  will be "plank@foo". If building for "plank/cpu0", this
+	  option will be "plank".
+
 config BOARD_TARGET
 	string
 	default "$(BOARD)@$(BOARD_REVISION)$(BOARD_QUALIFIERS)" if "$(BOARD_REVISION)" != ""

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -14,8 +14,8 @@ config BOARD_REVISION
 	def_string "$(BOARD_REVISION)"
 	help
 	  If the BOARD has a revision field set, this is the revision.
-	  Otherwise, it is the empty string. For example, if BOARD is
-	  "plank@foo", this option will be "foo". If BOARD is "plank",
+	  Otherwise, it is the empty string. For example, if building for
+	  "plank@foo", this option will be "foo". If building for "plank",
 	  this option will be the empty string.
 
 config BOARD_TARGET


### PR DESCRIPTION
Add a new string option, `BOARD_WITH_REVISION`, which contains the board name together with any revision information. This can be useful as a more precise source of the hardware target in the application, when board qualifiers are not useful.

For example, the qualifers for a given application are almost certainly going to be the same for every software version on every board revision, but the board revision by definition will change. `LOG_INF("BOARD: %s", CONFIG_BOARD_WITH_REVISION)` is therefore much more informative than `LOG_INF("BOARD: %s", CONFIG_BOARD)`.