### PR TITLE
drivers: display: co5300: fix missing GPIO error check

### DIFF
--- a/drivers/display/display_co5300.c
+++ b/drivers/display/display_co5300.c
@@ -376,7 +376,7 @@ static int co5300_reset(const struct device *dev)
 		}
 
 		k_sleep(K_MSEC(30));
-		gpio_pin_set_dt(&config->reset_gpios, 1);
+		ret = gpio_pin_set_dt(&config->reset_gpios, 1);
 		if (ret < 0) {
 			LOG_ERR("Could not pull reset high (%d)", ret);
 			return ret;


### PR DESCRIPTION
gpio_pin_set_dt() return value was not assigned when pulling the reset GPIO high, making the subsequent error check always false.

Store the return value to properly detect and report failures.