### PR TITLE
drivers: wifi: eswifi: eswifi_socket: fix listen backlog error handling

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -273,7 +273,7 @@ int __eswifi_listen(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket,
 	err = eswifi_at_cmd(eswifi, eswifi->buf);
 	if (err < 0) {
 		LOG_ERR("Unable to start set listen backlog");
-		err = -EIO;
+		return -EIO;
 	}
 
 	socket->is_server = true;


### PR DESCRIPTION
__eswifi_listen() ignored errors from eswifi_at_cmd() and always reported success, leaving the local error variable unused.

Return an error when setting the listen backlog fails and avoid marking the socket as a server in that case.