### PR TITLE
boards: imx943_evk: add i2c support for A55

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -141,3 +141,9 @@
 &wdog4 {
 	status = "okay";
 };
+
+&lpi2c6 {
+	pinctrl-0 = <&lpi2c6_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -15,6 +15,7 @@ ram: 10240
 supported:
   - counter
   - gpio
+  - i2c
   - net
   - uart
   - watchdog

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -9,6 +9,7 @@
 #include <arm64/armv8-a.dtsi>
 #include <zephyr/dt-bindings/clock/imx943_clock.h>
 #include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
@@ -115,6 +116,94 @@
 				};
 			};
 		};
+	};
+
+	lpi2c3: i2c@42530000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x42530000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C3>;
+		status = "disabled";
+	};
+
+	lpi2c4: i2c@42540000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x42540000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C4>;
+		status = "disabled";
+	};
+
+	lpi2c5: i2c@426b0000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x426b0000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 108 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C5>;
+		status = "disabled";
+	};
+
+	lpi2c6: i2c@426c0000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x426c0000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 109 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C6>;
+		status = "disabled";
+	};
+
+	lpi2c7: i2c@426d0000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x426d0000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C7>;
+		status = "disabled";
+	};
+
+	lpi2c8: i2c@426e0000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x426e0000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 111 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C8>;
+		status = "disabled";
+	};
+
+	lpi2c1: i2c@44340000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x44340000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C1>;
+		status = "disabled";
+	};
+
+	lpi2c2: i2c@44350000 {
+		compatible = "nxp,lpi2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x44350000 DT_SIZE_K(16)>;
+		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		clocks = <&scmi_clk IMX943_CLK_LPI2C2>;
+		status = "disabled";
 	};
 
 	lpuart3: serial@42570000 {


### PR DESCRIPTION
dts: arm64: mimx943: add i2c device tree nodes
boards: imx943_evk: add i2c support for A55