### PR TITLE
scripts: west: build: Add 'normalized_board' variable in build.dir-fmt

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -397,7 +397,8 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
 
          - ``west_topdir``: The absolute path to the west workspace, as
            returned by the ``west_topdir`` command
-         - ``board``: The board name
+         - ``board``: The board name in ``board/SoC/CPU`` format.
+         - ``normalized_board``: The board name in ``board_SoC_CPU`` format.
          - ``source_dir``: Path to the CMake source directory, relative to the
            current working directory. If the current working directory is
            inside the source directory, this is an empty string. If no source

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -467,6 +467,7 @@ class Build(Forceable):
             "source_dir": str(source_dir),
             "app": app,
             "board": board,
+            "normalized_board": board.replace('/', '_') if board else None,
         }
         if source_dir.is_relative_to(west_top_dir):
             context['source_dir_workspace'] = str(source_dir.relative_to(west_top_dir))

--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -57,6 +57,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
         None,
         {
             'board': None,
+            'normalized_board': None,
             'west_topdir': str(west_topdir),
             'app': TEST_CWD.name,
             'source_dir': str(TEST_CWD),
@@ -69,6 +70,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
         west_topdir / 'my' / 'project',
         {
             'board': None,
+            'normalized_board': None,
             'west_topdir': str(west_topdir),
             'app': 'project',
             'source_dir': str(west_topdir / 'my' / 'project'),
@@ -81,6 +83,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
         ROOT / 'path' / 'to' / 'my-project',
         {
             'board': None,
+            'normalized_board': None,
             'west_topdir': str(west_topdir),
             'app': 'my-project',
             'source_dir': str(ROOT / 'path' / 'to' / 'my-project'),
@@ -93,6 +96,20 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
         None,
         {
             'board': 'native_sim',
+            'normalized_board': 'native_sim',
+            'west_topdir': str(west_topdir),
+            'app': TEST_CWD.name,
+            'source_dir': str(TEST_CWD),
+            'source_dir_workspace': str(TEST_CWD_RELATIVE_TO_ROOT),
+        },
+    ),
+    # check for correct board with extended name
+    (
+        Namespace(board='board/SoC/cluster'),
+        None,
+        {
+            'board': 'board/SoC/cluster',
+            'normalized_board': 'board_SoC_cluster',
             'west_topdir': str(west_topdir),
             'app': TEST_CWD.name,
             'source_dir': str(TEST_CWD),


### PR DESCRIPTION
The board variable in build.dir-fmt will create multiple nested directories if the board name has several slashes. Add a new `board_flat` configuration variable that provides the board identifier as a single string with underscores instead of slashes (e.g., `board_SoC_CPU` instead of `board/SoC/CPU`).

Update documentation to clarify the format of the existing `board` variable and document the new `board_flat` variable.