### PR TITLE
drivers: i2c_dw: recovery i2c bus after when user abort

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -133,6 +133,11 @@ static int i2c_dw_error_chk(const struct device *dev)
 			dw->state |= I2C_DW_SDA_STUCK;
 			LOG_ERR("SDA Stuck Low on %s", dev->name);
 		}
+		/* check if user abort the transmit */
+		if (ic_txabrt_src.bits.USRABRT) {
+			dw->state |= I2C_DW_USER_ABRT;
+			LOG_ERR("User Abort on %s", dev->name);
+		}
 		/* clear RTS5912_INTR_STAT_TX_ABRT */
 		value = read_clr_tx_abrt(reg_base);
 	}

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -39,14 +39,14 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 #define I2C_DW_CMD_RECV    (1 << 1)
 #define I2C_DW_CMD_ERROR   (1 << 2)
 #define I2C_DW_BUSY        (1 << 3)
-#define I2C_DW_TX_ABRT     (1 << 4)
+#define I2C_DW_USER_ABRT   (1 << 4)
 #define I2C_DW_NACK        (1 << 5)
 #define I2C_DW_SCL_STUCK   (1 << 6)
 #define I2C_DW_SDA_STUCK   (1 << 7)
 
 #define I2C_DW_ERR_MASK (I2C_DW_CMD_ERROR | I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK | I2C_DW_NACK)
 
-#define I2C_DW_STUCK_ERR_MASK (I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK)
+#define I2C_DW_STUCK_ERR_MASK (I2C_DW_SCL_STUCK | I2C_DW_SDA_STUCK | I2C_DW_USER_ABRT)
 
 #ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
 #define DW_ENABLE_TX_INT_I2C_MASTER                                                                \


### PR DESCRIPTION
When the transfer timeout and driver set user abort, we need go recovery flow to make sure bus recovery and reg recovery.