### PR TITLE
drivers/wdt/it8xxx2: support setting time interval of warning msg

### DIFF
--- a/drivers/watchdog/Kconfig.it8xxx2
+++ b/drivers/watchdog/Kconfig.it8xxx2
@@ -25,5 +25,14 @@ config WDT_ITE_REDUCE_WARNING_LEADING_TIME
 	depends on WDT_ITE_IT8XXX2
 	help
 	  Once warning timer triggered, if watchdog timer isn't reloaded,
-	  then we will reduce interval of warning timer to 30ms to print
-	  more warning messages before watchdog reset.
+	  then we will reduce interval of warning timer to
+	  WDT_ITE_PRINT_WARNING_MSG_TIME_MS for printing more warning messages
+	  before watchdog reset.
+
+config WDT_ITE_PRINT_WARNING_MSG_TIME_MS
+	int "Time interval to print warning message in milliseconds"
+	depends on WDT_ITE_IT8XXX2
+	default 100
+	range 30 WDT_ITE_WARNING_LEADING_TIME_MS
+	help
+	  Time interval to print warning message in milliseconds.

--- a/drivers/watchdog/wdt_ite_it8xxx2.c
+++ b/drivers/watchdog/wdt_ite_it8xxx2.c
@@ -217,11 +217,12 @@ static void wdt_it8xxx2_isr(const struct device *dev)
 	if (IS_ENABLED(CONFIG_WDT_ITE_REDUCE_WARNING_LEADING_TIME)) {
 		/*
 		 * Once warning timer triggered: if watchdog timer isn't reloaded,
-		 * then we will reduce interval of warning timer to 30ms to print
-		 * more warning messages before watchdog reset.
+		 * then we will reduce interval of warning timer to CONFIG_ value
+		 * for printing more warning messages before watchdog reset.
 		 */
 		if (!wdt_warning_fired) {
-			uint16_t cnt0 = WARNING_TIMER_PERIOD_MS_TO_1024HZ_COUNT(30);
+			uint16_t cnt0 = WARNING_TIMER_PERIOD_MS_TO_1024HZ_COUNT((
+					CONFIG_WDT_ITE_PRINT_WARNING_MSG_TIME_MS));
 
 			/* pre-warning timer1 is 16-bit counter down timer */
 			inst->ET1CNTLHR = (cnt0 >> 8) & 0xff;


### PR DESCRIPTION
Add the config to support that warning message time interval can be set.

We also find that printing all the warning messages takes about 50ms on Chromebook. Therefore, we increase the default time to 100ms to leave some time for EC to run non-print instructions.