### PR TITLE
drivers: wifi: eswifi: eswifi_offload: fix DHCP enable error handling

### DIFF
--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -538,7 +538,7 @@ static int eswifi_off_enable_dhcp(struct eswifi_dev *eswifi)
 
 	eswifi_unlock(eswifi);
 
-	return 0;
+	return err;
 }
 
 static int eswifi_off_disable_bypass(struct eswifi_dev *eswifi)


### PR DESCRIPTION
eswifi_off_enable_dhcp() ignored the return value of eswifi_at_cmd() and always reported success, making the error check at the call site always false.

Return the command result to properly propagate failures.