### PR TITLE
Bluetooth: Classic: Fix initialization to support re-initialization

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
- * Copyright 2021,2024 NXP
+ * Copyright 2021,2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1463,23 +1463,25 @@ static struct bt_avdtp_event_cb avdtp_cb = {
 	.accept = a2dp_accept,
 };
 
-int bt_a2dp_init(void)
+void bt_a2dp_init(void)
 {
-	int err;
+	__maybe_unused int err;
+
+	static bool initialized;
+
+	if (initialized) {
+		return;
+	}
 
 	/* Register event handlers with AVDTP */
 	err = bt_avdtp_register(&avdtp_cb);
-	if (err < 0) {
-		LOG_ERR("A2DP registration failed");
-		return err;
-	}
-
-	ARRAY_FOR_EACH(connection, i) {
-		memset(&connection[i], 0, sizeof(struct bt_a2dp));
+	if ((err < 0) && (err != -EALREADY)) {
+		LOG_ERR("A2DP registration failed (err %d)", err);
+		return;
 	}
 
 	LOG_DBG("A2DP Initialized successfully.");
-	return 0;
+	initialized = true;
 }
 
 struct bt_a2dp *bt_a2dp_connect(struct bt_conn *conn)

--- a/subsys/bluetooth/host/classic/a2dp_internal.h
+++ b/subsys/bluetooth/host/classic/a2dp_internal.h
@@ -4,9 +4,10 @@
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /* To be called when first SEP is being registered */
-int bt_a2dp_init(void);
+void bt_a2dp_init(void);

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -5,6 +5,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (C) 2024 Xiaomi Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -718,12 +719,18 @@ int bt_avctp_server_register(struct bt_avctp_server *server)
 	return err;
 }
 
-int bt_avctp_init(void)
+void bt_avctp_init(void)
 {
+	static bool initialized;
+
+	if (initialized) {
+		return;
+	}
+
+	initialized = true;
+
 	LOG_DBG("Initializing AVCTP");
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&avctp_lock, 1, 1);
 	k_work_init_delayable(&avctp_tx_work, avctp_tx_processor);
-
-	return 0;
 }

--- a/subsys/bluetooth/host/classic/avctp_internal.h
+++ b/subsys/bluetooth/host/classic/avctp_internal.h
@@ -5,6 +5,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (C) 2024 Xiaomi Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -158,7 +159,7 @@ struct bt_avctp_event_cb {
 };
 
 /* Initialize AVCTP layer*/
-int bt_avctp_init(void);
+void bt_avctp_init(void);
 
 /* Application register with AVCTP layer */
 int bt_avctp_server_register(struct bt_avctp_server *server);

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -2,7 +2,7 @@
  * avdtp_internal.h - avdtp handling
 
  * Copyright (c) 2015-2016 Intel Corporation
- * Copyright 2021,2024 NXP
+ * Copyright 2021,2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -279,7 +279,7 @@ struct bt_avdtp_event_cb {
 };
 
 /* Initialize AVDTP layer*/
-int bt_avdtp_init(void);
+void bt_avdtp_init(void);
 
 /* Application register with AVDTP layer */
 int bt_avdtp_register(struct bt_avdtp_event_cb *cb);

--- a/subsys/bluetooth/host/classic/avrcp_internal.h
+++ b/subsys/bluetooth/host/classic/avrcp_internal.h
@@ -5,6 +5,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (C) 2024 Xiaomi Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -279,7 +280,7 @@ struct bt_avrcp_frame {
 	uint8_t data[];
 } __packed;
 
-int bt_avrcp_init(void);
+void bt_avrcp_init(void);
 
 int bt_avrcp_tg_cover_art_init(uint16_t *psm);
 

--- a/subsys/bluetooth/host/classic/did.c
+++ b/subsys/bluetooth/host/classic/did.c
@@ -65,7 +65,21 @@ static struct bt_sdp_attribute did_attrs[] = {
 
 static struct bt_sdp_record did_rec = BT_SDP_RECORD(did_attrs);
 
-int bt_did_init(void)
+void bt_did_init(void)
 {
-	return bt_sdp_register_service(&did_rec);
+	__maybe_unused int err;
+
+	static bool initialized;
+
+	if (initialized) {
+		return;
+	}
+
+	err = bt_sdp_register_service(&did_rec);
+	if (err != 0) {
+		LOG_ERR("Failed to register DID SDP record (err %d)", err);
+		return;
+	}
+
+	initialized = true;
 }

--- a/subsys/bluetooth/host/classic/did_internal.h
+++ b/subsys/bluetooth/host/classic/did_internal.h
@@ -9,4 +9,4 @@
  */
 
 /** Device Identification Init. **/
-int bt_did_init(void);
+void bt_did_init(void);

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -6193,8 +6194,6 @@ BT_L2CAP_BR_CHANNEL_DEFINE(br_fixed_chan, BT_L2CAP_CID_BR_SIG, l2cap_br_accept);
 
 void bt_l2cap_br_init(void)
 {
-	sys_slist_init(&br_servers);
-
 	if (IS_ENABLED(CONFIG_BT_RFCOMM)) {
 		bt_rfcomm_init();
 	}

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1861,15 +1862,24 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 
 void bt_rfcomm_init(void)
 {
+	__maybe_unused int err;
+
+	static bool initialized;
 	static struct bt_l2cap_server server = {
 		.psm       = BT_L2CAP_PSM_RFCOMM,
 		.accept    = rfcomm_accept,
 		.sec_level = BT_SECURITY_L1,
 	};
-	__maybe_unused int err;
+
+	if (initialized) {
+		return;
+	}
 
 	err = bt_l2cap_br_server_register(&server);
-	if (err != 0) {
+	if ((err != 0) && (err != -EEXIST)) {
 		LOG_ERR("Failed to register L2CAP server for RFCOMM (err %d)", err);
+		return;
 	}
+
+	initialized = true;
 }


### PR DESCRIPTION
In current implementation, the Classic L2CAP server list will be cleared when the function `bt_enable()` called. It causes the registered Classic L2CAP servers are unregistered. However, the higher-ups were completely unaware of this behavior. It causes the Classic L2CAP server cannot work after executing the sequence `bt_enable()`, `bt_disable()`, and `bt_enable()`. Also this behavior is inconsistent with LE L2CAP server.

Remove the initialization of Classic L2CAP server list from function `bt_l2cap_br_init()` to fix the issue.

Make Bluetooth Classic profile initialization functions idempotent by adding static initialized flags to prevent re-initialization. Change return type from int to void since errors are now logged but not propagated.

Changes include:
- Add initialized flag to prevent multiple initialization
- Change return type to void for init functions
- Mark err variables as __maybe_unused where appropriate
- Improve error logging with error codes
- Handle -EEXIST and -EALREADY errors for re-registration
- Initialize connection pools before checking initialized flag in AVRCP to support re-initialization scenarios
- Remove unnecessary sys_slist_init in bt_l2cap_br_init