### PR TITLE
doc: hardware: porting: board_porting: Fix typo

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -943,7 +943,7 @@ The skeleton of the board YAML file for extending a board is:
 
    board:
      extend: <existing-board-name>
-      variants:
+     variants:
        - name: <new-variant>
          qualifier: <existing-qualifier>
 


### PR DESCRIPTION
Fixes a small typo in the example which, if copied, would result in a error in the python file