### PR TITLE
cmake: modules: boards: Remove deprecated HWMv1 extension handling

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -5,9 +5,7 @@
 # Validate board and setup boards target.
 #
 # This CMake module will validate the BOARD argument as well as splitting the
-# BOARD argument into <BOARD> and <BOARD_REVISION>. When BOARD_EXTENSIONS option
-# is enabled (default) this module will also take care of finding board
-# extension directories.
+# BOARD argument into <BOARD> and <BOARD_REVISION>.
 #
 # If a board implementation is not found for the specified board an error will
 # be raised and list of valid boards will be printed.
@@ -31,8 +29,6 @@
 # - BOARD_DIR:                   Board directory with the implementation for selected board
 # - ARCH_DIR:                    Arch dir for extracted from selected board
 # - BOARD_ROOT:                  BOARD_ROOT with ZEPHYR_BASE appended
-# - BOARD_EXTENSION_DIRS:        List of board extension directories (If
-#                                BOARD_EXTENSIONS is not explicitly disabled)
 #
 # The following targets will be defined when this CMake module completes:
 # - board: when invoked, a list of valid boards will be printed
@@ -314,23 +310,6 @@ message(STATUS "${board_message}")
 
 add_custom_target(boards ${list_boards_commands} USES_TERMINAL)
 
-# Board extensions are enabled by default
-set(BOARD_EXTENSIONS ON CACHE BOOL "Support board extensions")
-zephyr_get(BOARD_EXTENSIONS)
-
-# Process board extensions
-if(BOARD_EXTENSIONS)
-  get_filename_component(board_dir_name ${BOARD_DIR} NAME)
-
-  foreach(root ${BOARD_ROOT})
-    set(board_extension_dir ${root}/boards/extensions/${board_dir_name})
-    if(NOT EXISTS ${board_extension_dir})
-      continue()
-    endif()
-
-    list(APPEND BOARD_EXTENSION_DIRS ${board_extension_dir})
-  endforeach()
-endif()
 build_info(board name VALUE ${BOARD})
 string(REGEX REPLACE "^/" "" qualifiers "${BOARD_QUALIFIERS}")
 build_info(board qualifiers VALUE ${qualifiers})


### PR DESCRIPTION
This code was deprecated and removed from the documentation many releases ago, remove the feature from the code