### PR TITLE
cmake: Remove old deprecated code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,8 +473,6 @@ zephyr_compile_options(
   $<$<COMPILE_LANGUAGE:ASM>:-D_ASMLANGUAGE>
 )
 
-find_package(Deprecated COMPONENTS toolchain_ld_base)
-
 if(DEFINED TOOLCHAIN_LD_FLAGS)
   zephyr_ld_options(${TOOLCHAIN_LD_FLAGS})
 endif()
@@ -505,8 +503,6 @@ toolchain_ld_force_undefined_symbols(
 )
 
 if(NOT CONFIG_NATIVE_BUILD)
-  find_package(Deprecated COMPONENTS toolchain_ld_baremetal)
-
   zephyr_link_libraries(PROPERTY baremetal)
 
   # Note that some architectures will skip this flag if set to error, even
@@ -531,10 +527,6 @@ if(NOT CONFIG_NATIVE_BUILD)
 endif()
 
 if(CONFIG_CPP)
-  if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY)
-    find_package(Deprecated COMPONENTS toolchain_ld_cpp)
-  endif()
-
   zephyr_link_libraries(PROPERTY cpp_base)
 endif()
 

--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -37,54 +37,6 @@ if("${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(WARNING "find_package(Deprecated) missing required COMPONENTS keyword")
 endif()
 
-if("toolchain_ld_base" IN_LIST Deprecated_FIND_COMPONENTS)
-  # This code was deprecated after Zephyr v4.0.0
-  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_base)
-
-  if(COMMAND toolchain_ld_base)
-    message(DEPRECATION
-      "The macro/function 'toolchain_ld_base' is deprecated. "
-      "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
-      "linker flags as properties instead. "
-      "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
-      "known linker properties."
-    )
-    toolchain_ld_base()
-  endif()
-endif()
-
-if("toolchain_ld_baremetal" IN_LIST Deprecated_FIND_COMPONENTS)
-  # This code was deprecated after Zephyr v4.0.0
-  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_baremetal)
-
-  if(COMMAND toolchain_ld_baremetal)
-    message(DEPRECATION
-      "The macro/function 'toolchain_ld_baremetal' is deprecated. "
-      "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
-      "linker flags as properties instead. "
-      "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
-      "known linker properties."
-    )
-    toolchain_ld_baremetal()
-  endif()
-endif()
-
-if("toolchain_ld_cpp" IN_LIST Deprecated_FIND_COMPONENTS)
-  # This code was deprecated after Zephyr v4.0.0
-  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_cpp)
-
-  if(COMMAND toolchain_ld_cpp)
-    message(DEPRECATION
-      "The macro/function 'toolchain_ld_cpp' is deprecated. "
-      "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
-      "linker flags as properties instead. "
-      "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
-      "known linker properties."
-    )
-    toolchain_ld_cpp()
-  endif()
-endif()
-
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
     "${Deprecated_FIND_COMPONENTS}")


### PR DESCRIPTION
Removes code that was deprecated in Zephyr 4.0