### PR TITLE
boards: deprecated: Remove old deprecated boards

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -22,27 +22,6 @@ set(arduino_uno_r4_wifi_DEPRECATED
 set(esp32c6_devkitc_DEPRECATED
     esp32c6_devkitc/esp32c6/hpcore
 )
-set(qemu_xtensa_DEPRECATED
-    qemu_xtensa/dc233c
-)
-set(mimx8mp_phyboard_pollux/mimx8ml8/m7_DEPRECATED
-    phyboard_pollux/mimx8ml8/m7
-)
-set(mimx8mm_phyboard_polis/mimx8mm6/m4_DEPRECATED
-    phyboard_polis/mimx8mm6/m4
-)
-set(mimxrt1050_evk_DEPRECATED
-    mimxrt1050_evk/mimxrt1052/hyperflash
-)
-set(mimxrt1060_evk_DEPRECATED
-    mimxrt1060_evk/mimxrt1064/hyperflash
-)
-set(mimxrt1060_evk_DEPRECATED
-     mimxrt1060_evk/mimxrt1062/qspi
-)
-set(mimxrt1060_evkb_DEPRECATED
-    mimxrt1060_evk@B/mimxrt1062/qspi
-)
 set(neorv32_DEPRECATED
     neorv32/neorv32/up5kdemo
 )


### PR DESCRIPTION
Removes boards that were deprecated in Zephyr 4.0