### PR TITLE
drivers: wifi: esp_at: esp_offload: drop unused dev variable in esp_bind

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -154,10 +154,8 @@ static int esp_bind(struct net_context *context, const struct net_sockaddr *addr
 		    net_socklen_t addrlen)
 {
 	struct esp_socket *sock;
-	struct esp_data *dev;
 
 	sock = (struct esp_socket *)context->offload_context;
-	dev = esp_socket_to_dev(sock);
 
 	if (esp_socket_ip_proto(sock) == NET_IPPROTO_TCP) {
 		return 0;


### PR DESCRIPTION
The esp_data pointer is no longer used after removing the premature _sock_connect() call. Drop the unused variable.

_sock_connect() call was removed by c368c33.