### PR TITLE
enable watchdog for Cortex-A55 on i.MX 943 EVK

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,10 @@
 / {
 	model = "NXP i.MX943 A55";
 	compatible = "fsl,mimx943";
+
+	aliases {
+		watchdog0 = &wdog4;
+	};
 
 	chosen {
 		zephyr,console = &lpuart1;
@@ -132,4 +136,8 @@
 &switch_port3 {
 	zephyr,random-mac-address;
 	status = "disabled";
+};
+
+&wdog4 {
+	status = "okay";
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,4 +17,5 @@ supported:
   - gpio
   - net
   - uart
+  - watchdog
 vendor: nxp

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -415,6 +415,58 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <16>;
+		status = "disabled";
+	};
+
+	ext_clk: ext24m {
+		/* WDOG ext clock: 24MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	lpo_clk: lpo32k {
+		/* WDOG LPO clock: 32KHz */
+		compatible = "fixed-clock";
+		clock-frequency = <32000>;
+		#clock-cells = <0>;
+	};
+
+	int_clk: int133m {
+		/* WDOG int clock: 133MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <133000000>;
+		#clock-cells = <0>;
+	};
+
+	ipg_clk: ipg133m {
+		/* WDOG ipg clock: 133MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <133000000>;
+		#clock-cells = <0>;
+	};
+
+	wdog3: watchdog@49220000 {
+		compatible = "nxp,wdog32";
+		reg = <0x49220000 0x1000>;
+		interrupts = <GIC_SPI 90 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
+		status = "disabled";
+	};
+
+	wdog4: watchdog@49230000 {
+		compatible = "nxp,wdog32";
+		reg = <0x49230000 0x1000>;
+		interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
Enabled WDOG4 for A55 on i.MX93 EVK board. It could be verified by building application by:
    west build -p always -b imx943_evk/mimx94398/a55 samples/drivers/watchdog