### PR TITLE
soc: native: Remove old note from kconfig option

### DIFF
--- a/soc/native/inf_clock/Kconfig
+++ b/soc/native/inf_clock/Kconfig
@@ -14,8 +14,6 @@ config NATIVE_SIMULATOR_MCU_N
 	default 0
 	help
 	  Which native simulator microcontroller/CPU number is this image targeting.
-	  This option is only applicable for targets which use the
-	  native simulator as their runner.
 
 config NATIVE_SIMULATOR_NUMBER_MCUS
 	int "Total number of MCUs this target has"


### PR DESCRIPTION
Since e150ffb92c83a52f88f467e625028952f9574a74, Zephyr only really supports native_simulator based targets when building native/posix arch based targets.
So this comment is not relevant anymore. Let's remove it.