### PR TITLE
drivers: cache: fix typos in comments

### DIFF
--- a/drivers/cache/cache_andes.c
+++ b/drivers/cache/cache_andes.c
@@ -85,7 +85,7 @@ static ALWAYS_INLINE int nds_cctl_range_operations(void *addr, size_t size, int 
 	align_addr = ROUND_DOWN(addr, line_size);
 
 	/*
-	 * In memory access privilige U mode, applications should use ucctl CSRs
+	 * In memory access privilege U mode, applications should use ucctl CSRs
 	 * for VA type commands.
 	 */
 	if ((status & MSTATUS_MPRV) && !(status & MSTATUS_MPP)) {
@@ -112,7 +112,7 @@ static ALWAYS_INLINE int nds_l1i_cache_all(int op)
 
 	if (csr_read(NDS_MMSC_CFG) & MMSC_CFG_VCCTL_2) {
 		/*
-		 * In memory access privilige U mode, applications can only use
+		 * In memory access privilege U mode, applications can only use
 		 * VA type commands for specific range.
 		 */
 		if ((status & MSTATUS_MPRV) && !(status & MSTATUS_MPP)) {
@@ -140,7 +140,7 @@ static ALWAYS_INLINE int nds_l1d_cache_all(int op)
 
 	if (csr_read(NDS_MMSC_CFG) & MMSC_CFG_VCCTL_2) {
 		/*
-		 * In memory access privilige U mode, applications can only use
+		 * In memory access privilege U mode, applications can only use
 		 * VA type commands for specific range.
 		 */
 		if ((status & MSTATUS_MPRV) && !(status & MSTATUS_MPP)) {

--- a/drivers/cache/cache_aspeed.c
+++ b/drivers/cache/cache_aspeed.c
@@ -66,7 +66,7 @@ static void aspeed_cache_init(void)
 }
 
 /**
- * @brief get aligned address and the number of cachline to be invalied
+ * @brief get aligned address and the number of cacheline to be invalidated
  * @param [IN] addr - start address to be invalidated
  * @param [IN] size - size in byte
  * @param [OUT] p_aligned_addr - pointer to the cacheline aligned address variable


### PR DESCRIPTION
Fix typos in comments in cache_andes and cache_aspeed.

No functional change.