### PR TITLE
doc: releases: migration-guide: 4.4: remove extra backtick

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -443,7 +443,7 @@ Bluetooth Audio
 * :c:func:`bt_bap_broadcast_assistant_discover` will now no longer perform reads of the remote BASS
   receive states at the end of the procedure. Users will have to manually call
   :c:func:`bt_bap_broadcast_assistant_read_recv_state` to read the existing receive states, if any,
-  prior to performing any operations. (:github:`91587``)
+  prior to performing any operations. (:github:`91587`)
 
 Networking
 **********


### PR DESCRIPTION
This fixes compliance check by removing extra backtick.

Introduced here: https://github.com/zephyrproject-rtos/zephyr/pull/91587
Caught here: https://github.com/zephyrproject-rtos/zephyr/pull/101262/files#annotation_43738278395