### PR TITLE
drivers: ipm: ipm_mbox: handle mailbox notifications without payload

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -153,6 +153,12 @@ New APIs and options
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and
     control commands separately via devicetree.
 
+* IPM
+
+  * IPM callbacks for the mailbox backend now correctly handle signal-only mailbox
+    mailbox usage. Applications should be prepared to receive a NULL payload pointer
+    in IPM callbacks when no data buffer is provided by the mailbox.
+
 * Modem
 
   * :kconfig:option:`CONFIG_MODEM_HL78XX_AT_SHELL`


### PR DESCRIPTION
Some mailbox backends may deliver notifications without an associated data payload. This can occur when the mailbox is used as a signal-only mechanism, where struct mbox_msg is NULL, data is NULL, or size is zero.

The IPM mailbox callback currently assumes a valid data payload and unconditionally dereferences data->data, which can lead to a NULL pointer dereference for such mailbox implementations.

Update the IPM mailbox callback to tolerate empty mailbox messages and invoke the IPM callback with a NULL payload pointer when no data is present. This preserves notification semantics while preventing runtime faults.