### PR TITLE
doc: kernel: threads: fix mistake in "What Cannot be Expected to Work"

### DIFF
--- a/doc/kernel/services/threads/nothread.rst
+++ b/doc/kernel/services/threads/nothread.rst
@@ -47,8 +47,8 @@ The expectations above affect selection of other features; for example
 What Cannot be Expected to Work
 *******************************
 
-Functionality that will not work with :kconfig:option:`CONFIG_MULTITHREADING`
-includes majority of the kernel API:
+Functionality that will not work when :kconfig:option:`CONFIG_MULTITHREADING`
+is disabled includes majority of the kernel API:
 
 * :ref:`threads_v2`
 


### PR DESCRIPTION
Correct the description in the "What Cannot be Expected to Work" section to state that the listed functionality fails when CONFIG_MULTITHREADING is **disabled**, as the previous wording implied the opposite.

Fixes zephyrproject-rtos/zephyr#101718