### PR TITLE
arch: riscv: Add the support for Zbkb ISA extension

### DIFF
--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -237,6 +237,14 @@ config RISCV_ISA_EXT_ZBC
 	  The Zbc instructions can be used for carry-less multiplication that
 	  is the multiplication in the polynomial ring over GF(2).
 
+config RISCV_ISA_EXT_ZBKB
+	bool
+	help
+	  (Zbkb) - Zbkb BitManip Extension (Bit-manipulation for Cryptography)
+
+	  The Zbkb instructions can be used for accelerating cryptography workloads
+	  and contain rotation, reversion, packing and some advanced bit-manipulation.
+
 config RISCV_ISA_EXT_ZBS
 	bool
 	help

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -118,6 +118,10 @@ if(CONFIG_RISCV_ISA_EXT_ZBC)
   string(CONCAT riscv_march ${riscv_march} "_zbc")
 endif()
 
+if(CONFIG_RISCV_ISA_EXT_ZBKB)
+  string(CONCAT riscv_march ${riscv_march} "_zbkb")
+endif()
+
 if(CONFIG_RISCV_ISA_EXT_ZBS)
   string(CONCAT riscv_march ${riscv_march} "_zbs")
 endif()


### PR DESCRIPTION
Introduce the missing flag to compile code with `Zbkb` extension,
which has already been supported by the GCC 12 in current SDK.

Will be used in the RP235x:Hazard3 later.