### PR TITLE
boards: motion_2350_pro: split the pwm_default pin list

### DIFF
--- a/boards/cytron/motion_2350_pro/motion_2350_pro-pinctrl.dtsi
+++ b/boards/cytron/motion_2350_pro/motion_2350_pro-pinctrl.dtsi
@@ -35,9 +35,16 @@
 	pwm_default: pwm_default {
 		group1 {
 			pinmux = <PWM_0A_P0>, <PWM_0B_P1>, <PWM_1A_P2>, <PWM_1B_P3>,
-				 <PWM_2A_P4>, <PWM_2B_P5>, <PWM_3A_P6>, <PWM_3B_P7>,
-				 <PWM_4A_P8>, <PWM_4B_P9>, <PWM_5A_P10>, <PWM_5B_P11>,
-				 <PWM_6A_P12>, <PWM_6B_P13>, <PWM_7A_P14>, <PWM_7B_P15>,
+				 <PWM_2A_P4>, <PWM_2B_P5>;
+		};
+
+		group2 {
+			pinmux = <PWM_3A_P6>, <PWM_3B_P7>, <PWM_4A_P8>, <PWM_4B_P9>,
+				 <PWM_5A_P10>, <PWM_5B_P11>;
+		};
+
+		group3 {
+			pinmux = <PWM_6A_P12>, <PWM_6B_P13>, <PWM_7A_P14>, <PWM_7B_P15>,
 				 <PWM_3A_P22>;
 		};
 	};


### PR DESCRIPTION
Raspberry pi based boards are now using binary info by default (96b9b0f2df9), and that limits pinctrl groups to 4 or 6 nodes. Split this node in multiple groups.