### PR TITLE
framework_laptop16_keyboard: Add full_name

### DIFF
--- a/boards/framework/laptop16_keyboard/board.yml
+++ b/boards/framework/laptop16_keyboard/board.yml
@@ -1,5 +1,6 @@
 boards:
 - name: framework_laptop16_keyboard
+  full_name: Framework Laptop 16 Keyboard
   vendor: framework
   socs:
   - name: rp2040


### PR DESCRIPTION
Add a full, pretty name for the docs page.