### PR TITLE
arch: arm: core: Disable task WDT in fatal error

### DIFF
--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -16,6 +16,8 @@
 #include <zephyr/arch/exception.h>
 #include <kernel_arch_data.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/task_wdt/task_wdt.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_EXCEPTION_DEBUG
@@ -70,6 +72,11 @@ static void esf_dump(const struct arch_esf *esf)
 void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf)
 {
 #ifdef CONFIG_EXCEPTION_DEBUG
+	/* Suspend Task WDT to fully print out exception info. */
+#ifdef CONFIG_TASK_WDT
+	task_wdt_suspend();
+#endif
+
 	if (esf != NULL) {
 		esf_dump(esf);
 	}

--- a/subsys/task_wdt/Kconfig
+++ b/subsys/task_wdt/Kconfig
@@ -37,6 +37,10 @@ config TASK_WDT_HW_FALLBACK
 	  application that is used as an additional safety layer if the task
 	  watchdog itself gets stuck.
 
+	  If ``DEBUG_COREDUMP`` is enabled, make sure to reserve enough timeout
+	  (TASK_WDT_MIN_TIMEOUT + TASK_WDT_HW_FALLBACK_DELAY) to prevent it
+	  from being truncated.
+
 config TASK_WDT_MIN_TIMEOUT
 	int "Minimum timeout for task watchdog (ms)"
 	depends on TASK_WDT_HW_FALLBACK
@@ -54,7 +58,8 @@ config TASK_WDT_MIN_TIMEOUT
 config TASK_WDT_HW_FALLBACK_DELAY
 	int "Additional delay for hardware watchdog (ms)"
 	depends on TASK_WDT_HW_FALLBACK
-	default 20
+	default 20   if !DEBUG_COREDUMP
+	default 2000 if DEBUG_COREDUMP
 	range 1 10000
 	help
 	  The timeout of the hardware watchdog fallback will be increased by


### PR DESCRIPTION
If the task watchdog is enabled, the system may be reset by the watchdog during a crash, before the exception info output is completed.