### PR TITLE
mcumgr: fs_mgmt: forward return values from fs_close

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -93,6 +93,9 @@ enum fs_mgmt_err_code_t {
 
 	/** The operation cannot be performed because the file is empty with no contents. */
 	FS_MGMT_ERR_FILE_EMPTY,
+
+	/** Error occurred whilst attempting to close a file. */
+	FS_MGMT_ERR_FILE_CLOSE_FAILED,
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
A new error code FS_MGMT_ERR_FILE_CLOSE_FAILED is returned when closing a file fails. This applies for writing and closing files. On read operations closing errors are still ignored.