### PR TITLE
drivers: haptics: Add error callback mechanism to haptics API

### DIFF
--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -32,9 +32,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief Haptics error types
+ */
+enum haptics_error_type {
+	HAPTICS_ERROR_OVERCURRENT = BIT(0),     /**< Output overcurrent error */
+	HAPTICS_ERROR_OVERTEMPERATURE = BIT(1), /**< Device overtemperature error */
+	HAPTICS_ERROR_UNDERVOLTAGE = BIT(2),    /**< Power source undervoltage error */
+	HAPTICS_ERROR_OVERVOLTAGE = BIT(3),     /**< Power source overvoltage error */
+	HAPTICS_ERROR_DC = BIT(4),              /**< Output direct-current error */
+
+	/* Device-specific error codes can follow, refer to the device’s header file */
+	HAPTICS_ERROR_PRIV_START = BIT(5),
+};
+
+/**
  * @typedef haptics_stop_output_t
  * @brief Set the haptic device to stop output
- * @param dev Pointer to the device structure for haptic device instance
  */
 typedef int (*haptics_stop_output_t)(const struct device *dev);
 
@@ -45,11 +58,31 @@ typedef int (*haptics_stop_output_t)(const struct device *dev);
 typedef int (*haptics_start_output_t)(const struct device *dev);
 
 /**
+ * @typedef haptics_error_callback_t
+ * @brief Callback function for error interrupt
+ *
+ * @param dev Pointer to the haptic device
+ * @param errors Device errors (bitmask of @ref haptics_error_type values)
+ * @param user_data User data provided when the error callback was registered
+ */
+typedef void (*haptics_error_callback_t)(const struct device *dev, const uint32_t errors,
+					 void *const user_data);
+
+/**
+ * @typedef haptics_register_error_callback_t
+ * @brief Register a callback function for haptics errors
+ */
+typedef int (*haptics_register_error_callback_t)(const struct device *dev,
+						 haptics_error_callback_t cb,
+						 void *const user_data);
+
+/**
  * @brief Haptic device API
  */
 __subsystem struct haptics_driver_api {
 	haptics_start_output_t start_output;
 	haptics_stop_output_t stop_output;
+	haptics_register_error_callback_t register_error_callback;
 };
 
 /**
@@ -84,6 +117,29 @@ static inline int z_impl_haptics_stop_output(const struct device *dev)
 	const struct haptics_driver_api *api = (const struct haptics_driver_api *)dev->api;
 
 	return api->stop_output(dev);
+}
+
+/**
+ * @brief Register a callback function for haptics errors
+ *
+ * @param dev Pointer to the haptic device
+ * @param cb Callback function (of type @ref haptics_error_callback_t)
+ * @param user_data User data to be provided back to the application via the callback
+ *
+ * @retval 0 if successful
+ * @retval <0 if failed
+ */
+static inline int haptics_register_error_callback(const struct device *dev,
+						  haptics_error_callback_t cb,
+						  void *const user_data)
+{
+	const struct haptics_driver_api *api = (const struct haptics_driver_api *)dev->api;
+
+	if (api->register_error_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->register_error_callback(dev, cb, user_data);
 }
 
 /**

--- a/include/zephyr/drivers/haptics/cs40l5x.h
+++ b/include/zephyr/drivers/haptics/cs40l5x.h
@@ -78,20 +78,6 @@ enum cs40l5x_custom_index {
 };
 
 /**
- * @brief Types of fatal CS40L5x hardware errors
- *
- * @details Provided to application callback function. See @ref cs40l5x_register_error_callback().
- */
-enum cs40l5x_error_type {
-	CS40L5X_ERROR_AMPLIFIER_SHORT = BIT(0),      /**< Amplifier short detected */
-	CS40L5X_ERROR_OVERTEMPERATURE = BIT(1),      /**< Overtemperature detected */
-	CS40L5X_ERROR_UNDERVOLTAGE = BIT(2),         /**< Undervoltage detected */
-	CS40L5X_ERROR_INDUCTOR_SHORT = BIT(3),       /**< Inductor short detected */
-	CS40L5X_ERROR_OVERCURRENT = BIT(4),          /**< Overcurrent condition detected */
-	CS40L5X_ERROR_BATTERY_UNDERVOLTAGE = BIT(4), /**< Vdd_batt undervoltage detected */
-};
-
-/**
  * @brief Options for runtime haptics logging
  *
  * @details Provide to @ref cs40l5x_logger() to update runtime haptics logging.
@@ -318,7 +304,9 @@ struct cs40l5x_data {
 	/**< Callback handler for trigger logging */
 	struct gpio_callback trigger_callback;
 	/**< Application-provided callback to recover from fatal hardware errors */
-	void (*error_callback)(const struct device *const haptic_dev, const uint32_t errors);
+	haptics_error_callback_t error_callback;
+	/**< Application-provided user data for callback context */
+	void *user_data;
 	/**< Semaphore used to sequence the calibration routine */
 	struct k_sem calibration_semaphore;
 	/**< F0 and ReDC data derived from calibration */
@@ -417,17 +405,6 @@ int cs40l5x_logger(const struct device *const dev, enum cs40l5x_logger logger_st
  */
 int cs40l5x_logger_get(const struct device *const dev, enum cs40l5x_logger_source source,
 		       enum cs40l5x_logger_source_type type, uint32_t *const value);
-
-/**
- * @brief Register an application callback to handle fatal hardware errors
- *
- * @param dev Pointer to the device structure for haptic device instance
- * @param error_callback Application function that takes a pointer to the device structure for a
- * haptic device instance and a bitmask of @ref cs40l5x_error_type
- */
-void cs40l5x_register_error_callback(const struct device *dev,
-				     void (*error_callback)(const struct device *const haptic_dev,
-							    const uint32_t errors));
 
 /**
  * @brief Select haptic effect triggered via @ref haptics_start_output()

--- a/samples/drivers/haptics/cs40l5x/src/main.c
+++ b/samples/drivers/haptics/cs40l5x/src/main.c
@@ -288,7 +288,8 @@ static const struct cs40l5x_pwle_section pwle_sections[] = {
 	},
 };
 
-static void cs40l5x_dummy_callback(const struct device *const dev, const uint32_t errors)
+static void cs40l5x_dummy_callback(const struct device *const dev, const uint32_t errors,
+				   void *const user_data)
 {
 	LOG_INF("fatal errors detected (0x%08X)", errors);
 }
@@ -310,7 +311,7 @@ int main(void)
 		}
 	}
 
-	(void)cs40l5x_register_error_callback(cs40l5x, cs40l5x_dummy_callback);
+	(void)haptics_register_error_callback(cs40l5x, cs40l5x_dummy_callback, NULL);
 
 	/* Demonstration of PCM upload (CUSTOM0) */
 	error = cs40l5x_upload_pcm(cs40l5x, CS40L5X_CUSTOM_0, CS40L5X_DEMO_REDC, CS40L5X_DEMO_F0,


### PR DESCRIPTION
Adds an error callback mechanism to the haptics subsystem API and updates the cs40l5x driver and sample application accordingly.

See #101842 for the accompanying RFC.