### PR TITLE
samples: drivers: auxdisplay: Add Teensy 4.1 board support

### DIFF
--- a/samples/drivers/auxdisplay/boards/teensy41.overlay
+++ b/samples/drivers/auxdisplay/boards/teensy41.overlay
@@ -19,7 +19,7 @@
  *
  */
 
- #include <dt-bindings/input/input-event-codes.h>
+#include <dt-bindings/input/input-event-codes.h>
 
 /* Enable LPUART6 on Teensy 4.1 (Pins 0/1) */
 &lpuart6 {
@@ -29,9 +29,9 @@
 
 /* Enable LPI2C1 on Teensy 4.1 (Pins 18/19) */
 &lpi2c1 {
-    status = "okay";
-    pinctrl-0 = <&pinmux_lpi2c1>;
-    pinctrl-names = "default";
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpi2c1>;
+	pinctrl-names = "default";
 
 	aux_display_gpio: pcf8574@20 {
 		compatible = "nxp,pcf857x";
@@ -43,10 +43,10 @@
 };
 
 / {
-    chosen {
-        zephyr,console = &lpuart6;
-        zephyr,shell-uart = &lpuart6;
-    };
+	chosen {
+		zephyr,console = &lpuart6;
+		zephyr,shell-uart = &lpuart6;
+	};
 
 	auxdisplay_0: hd44780 {
 		compatible = "hit,hd44780";

--- a/samples/drivers/auxdisplay/boards/teensy41.overlay
+++ b/samples/drivers/auxdisplay/boards/teensy41.overlay
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Hatus Vianna Wnderley
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Teensy 4.1 overlay for the auxdisplay sample application.
+ *
+ * Hardware Configuration:
+ * - LPUART6 (pins 0/1): Console output at 115200 baud
+ * - LPI2C1 (pins 18/19): I2C bus for PCF8574 GPIO expander at address 0x20
+ * - HD44780 16x2 LCD: Connected via PCF8574 I2C GPIO expander
+ *
+ * Tested Hardware:
+ * - DFRobot DFR0063 16x2 LCD with I2C backpack (PCF8574-based)
+ * - Connected to Teensy 4.1 via DFR0063 low voltage (3.3V) I2C interface
+ *
+ * Note: The read-write GPIO is omitted as the DFR0063 module has issues when
+ * this pin is configured.
+ *
+ */
+
+ #include <dt-bindings/input/input-event-codes.h>
+
+/* Enable LPUART6 on Teensy 4.1 (Pins 0/1) */
+&lpuart6 {
+    status = "okay";
+    current-speed = <115200>;
+};
+
+/* Enable LPI2C1 on Teensy 4.1 (Pins 18/19) */
+&lpi2c1 {
+    status = "okay";
+    pinctrl-0 = <&pinmux_lpi2c1>;
+    pinctrl-names = "default";
+
+	aux_display_gpio: pcf8574@20 {
+		compatible = "nxp,pcf857x";
+		reg = <0x20>;
+		gpio-controller;
+		ngpios = <8>;
+		#gpio-cells = <2>;
+	};
+};
+
+/ {
+    chosen {
+        zephyr,console = &lpuart6;
+        zephyr,shell-uart = &lpuart6;
+    };
+
+	auxdisplay_0: hd44780 {
+		compatible = "hit,hd44780";
+		columns = <16>;
+		rows = <2>;
+		mode = <4>;
+
+		enable-line-rise-delay-ns = <450>;
+		enable-line-fall-delay-ns = <550>;
+		rs-line-delay-ns = <60>;
+		clear-command-delay-us = <5000>;
+		boot-delay-ms = <0>;
+
+		register-select-gpios = <&aux_display_gpio 0 GPIO_ACTIVE_HIGH>;
+		// This pin should be ommited for the DFrobot DFR0063 16x2 LCD, otherwise it won't work.
+		// read-write-gpios = <&aux_display_gpio 1 GPIO_ACTIVE_HIGH>;
+		enable-gpios = <&aux_display_gpio 2 GPIO_ACTIVE_HIGH>;
+		backlight-gpios = <&aux_display_gpio 3 GPIO_ACTIVE_HIGH>;
+		data-bus-gpios = <0>, <0>, <0>, <0>,
+			<&aux_display_gpio 4 GPIO_ACTIVE_HIGH>,
+			<&aux_display_gpio 5 GPIO_ACTIVE_HIGH>,
+			<&aux_display_gpio 6 GPIO_ACTIVE_HIGH>,
+			<&aux_display_gpio 7 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/samples/drivers/auxdisplay/boards/teensy41.overlay
+++ b/samples/drivers/auxdisplay/boards/teensy41.overlay
@@ -14,9 +14,6 @@
  * - DFRobot DFR0063 16x2 LCD with I2C backpack (PCF8574-based)
  * - Connected to Teensy 4.1 via DFR0063 low voltage (3.3V) I2C interface
  *
- * Note: The read-write GPIO is omitted as the DFR0063 module has issues when
- * this pin is configured.
- *
  */
 
 #include <dt-bindings/input/input-event-codes.h>
@@ -61,8 +58,6 @@
 		boot-delay-ms = <0>;
 
 		register-select-gpios = <&aux_display_gpio 0 GPIO_ACTIVE_HIGH>;
-		// This pin should be ommited for the DFrobot DFR0063 16x2 LCD, otherwise it won't work.
-		// read-write-gpios = <&aux_display_gpio 1 GPIO_ACTIVE_HIGH>;
 		enable-gpios = <&aux_display_gpio 2 GPIO_ACTIVE_HIGH>;
 		backlight-gpios = <&aux_display_gpio 3 GPIO_ACTIVE_HIGH>;
 		data-bus-gpios = <0>, <0>, <0>, <0>,

--- a/samples/drivers/auxdisplay/boards/teensy41.overlay
+++ b/samples/drivers/auxdisplay/boards/teensy41.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Hatus Vianna Wnderley
+ * Copyright (c) 2026 Hatus Vianna Wanderley
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/drivers/auxdisplay/src/main.c
+++ b/samples/drivers/auxdisplay/src/main.c
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2023 Jamie McCrae
- * Copyright (c) 2026 Hatus Vianna Wnderley
- *
+  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Modifications:

--- a/samples/drivers/auxdisplay/src/main.c
+++ b/samples/drivers/auxdisplay/src/main.c
@@ -1,10 +1,8 @@
 /*
  * Copyright (c) 2023 Jamie McCrae
-  *
+ *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Modifications:
- *  - Added display backlight enable
  */
 
 #include <string.h>

--- a/samples/drivers/auxdisplay/src/main.c
+++ b/samples/drivers/auxdisplay/src/main.c
@@ -1,7 +1,11 @@
 /*
  * Copyright (c) 2023 Jamie McCrae
+ * Copyright (c) 2026 Hatus Vianna Wnderley
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications:
+ *  - Added display backlight enable
  */
 
 #include <string.h>
@@ -21,6 +25,12 @@ int main(void)
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Auxdisplay device is not ready.");
 		return 0;
+	}
+
+	rc = auxdisplay_backlight_set(dev, 1);
+
+	if (rc != 0) {
+		LOG_ERR("Failed to turn backlight on: %d", rc);
 	}
 
 	rc = auxdisplay_cursor_set_enabled(dev, true);


### PR DESCRIPTION
Add board overlay for Teensy 4.1 to enable the auxdisplay sample with HD44780 displays using PCF8574 I2C GPIO expander.

Hardware configuration:
- LPUART6 (pins 0/1) for console at 115200 baud
- LPI2C1 (pins 18/19) for PCF8574 GPIO expander at address 0x20
- HD44780 16x2 LCD in 4-bit mode via PCF8574

Tested with DFRobot DFR0063 16x2 LCD module connected via 3.3V I2C interface. Note that the read-write GPIO must be omitted for this module to work correctly.

Also enable backlight on startup in the sample application to test this feature.

Signed-off-by: Hatus Vianna Wanderley <hwanderley@mgh.harvard.edu>