### PR TITLE
scripts: schemas: make `full_name` a required property for boards

### DIFF
--- a/boards/intel/wcl/board.yml
+++ b/boards/intel/wcl/board.yml
@@ -1,5 +1,6 @@
 boards:
   - name: intel_wcl_crb
+    full_name: Wildcat Lake CRB
     vendor: intel
     socs:
       - name: wildcat_lake

--- a/boards/mediatek/mt8186/board.yml
+++ b/boards/mediatek/mt8186/board.yml
@@ -1,5 +1,6 @@
 boards:
   - name: mt8186
+    full_name: MT8186 ADSP
     vendor: mediatek
     socs:
       - name: mt8186

--- a/boards/mediatek/mt8188/board.yml
+++ b/boards/mediatek/mt8188/board.yml
@@ -1,5 +1,6 @@
 boards:
   - name: mt8188
+    full_name: MT8188 ADSP
     vendor: mediatek
     socs:
       - name: mt8188

--- a/boards/mediatek/mt8196/board.yml
+++ b/boards/mediatek/mt8196/board.yml
@@ -1,5 +1,6 @@
 boards:
   - name: mt8196
+    full_name: MT8196 ADSP
     vendor: mediatek
     socs:
       - name: mt8196

--- a/boards/openhwgroup/cv32a6_genesys_2/board.yml
+++ b/boards/openhwgroup/cv32a6_genesys_2/board.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 board:
   name: cv32a6_genesys_2
+  full_name: Digilent CV32A6 on Genesys 2
   vendor: openhwgroup
   socs:
     - name: cv32a6

--- a/boards/openhwgroup/cv64a6_genesys_2/board.yml
+++ b/boards/openhwgroup/cv64a6_genesys_2/board.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 board:
   name: cv64a6_genesys_2
+  full_name: Digilent CV64A6 on Genesys 2
   vendor: openhwgroup
   socs:
     - name: cv64a6_imafdc

--- a/boards/realtek/rtl872xd_evb/board.yml
+++ b/boards/realtek/rtl872xd_evb/board.yml
@@ -1,5 +1,6 @@
 board:
   name: rtl872xd_evb
+  full_name: RTL872xD Evaluation Board
   vendor: realtek
   socs:
     - name: rtl872xd

--- a/boards/realtek/rtl872xda_evb/board.yml
+++ b/boards/realtek/rtl872xda_evb/board.yml
@@ -1,5 +1,6 @@
 board:
   name: rtl872xda_evb
+  full_name: RTL8721Dx Evaluation Board
   vendor: realtek
   socs:
     - name: rtl8721dx

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -27,6 +27,8 @@ Build System
   C standard version.  If your toolchain does not support this standard you will
   need to use one of the existing and now deprecated options:
   :kconfig:option:`CONFIG_STD_C99` or :kconfig:option:`CONFIG_STD_C11`.
+* The ``full_name`` property of ``board``/``boards`` entries corresponding to new boards in
+  board.yml files is now required.
 
 Kernel
 ******

--- a/scripts/schemas/board-schema.yaml
+++ b/scripts/schemas/board-schema.yaml
@@ -165,10 +165,10 @@ $defs:
         $ref: "#/$defs/extendVariantSchema"
     # Conditional logic for requirements
     allOf:
-      # 'name' and 'extend' are mutually exclusive: we're either defining a new board or extending
-      # an existing one.
+      # 'name'/'full_name' and 'extend' are mutually exclusive: we're either defining a new board or
+      # extending an existing one.
       - oneOf:
-          - required: [name]
+          - required: [name, full_name]
           - required: [extend]
       # A base board (identified by 'name') must define its hardware via the 'socs' property.
       - if:

--- a/subsys/testsuite/boards/unit_testing/unit_testing/board.yml
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/board.yml
@@ -1,5 +1,6 @@
 board:
   name: unit_testing
+  full_name: Unit Testing Board
   vendor: zephyr
   socs:
   - name: unit_testing


### PR DESCRIPTION
When initially introduced, the property was kept optional in an attempt to not risk disrupting downstream users by introducing a required property they wouldn't necessarily care about.

In practice, this is causing boards contributed upstream to sometimes miss this property which is important for boards to show up nicely in the boards catalog, and it is therefore being made required.
