### PR TITLE
Bluetooth: Controller: LLL prepare at margin Kconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -914,6 +914,26 @@ config BT_CTLR_ULL_LOW_PRIO
 	  The interrupt priority for Ticker's Job IRQ and Upper Link Layer
 	  lower priority functions.
 
+config BT_CTLR_LLL_PREPARE_AT_MARGIN
+	bool "LLL prepare at margin"
+	depends on !BT_CTLR_LOW_LAT
+	default y if SOC_COMPATIBLE_NRF54LX
+	help
+	  Execute LLL prepare callback at the prepare margin, even when no
+	  overlapping state/role is currently active.
+
+	  This will lead to an additional CPU wake up after initial one at the
+	  prepare tick. LLL prepare callback is executed sufficient time before
+	  the hard real time radio transmission or reception instant so that any
+	  resource that may otherwise consume current if setup at prepare tick
+	  can be delayed until the prepare margin elapses.
+
+	  Disable this option if resources that need to be ready at the hard
+	  real time radio transmission or reception instant can be setup at
+	  prepare tick without impacting current consumption until actual
+	  requirement at the hard real time radio transmission or reception
+	  instant.
+
 config BT_CTLR_LOW_LAT
 	bool "Low latency non-negotiating event preemption"
 	depends on BT_CTLR_LOW_LAT_ULL && BT_CTLR_LOW_LAT_ULL_DONE

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1479,8 +1479,8 @@ uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 	SW_SWITCH_TIMER->MODE = 0;
 	SW_SWITCH_TIMER->PRESCALER = HAL_EVENT_TIMER_PRESCALER_VALUE;
 	SW_SWITCH_TIMER->BITMODE = 0; /* 16 bit */
-	/* FIXME: start along with EVENT_TIMER, to save power */
-	nrf_timer_task_trigger(SW_SWITCH_TIMER, NRF_TIMER_TASK_START);
+
+	hal_sw_switch_timer_start_ppi_config();
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	hal_sw_switch_timer_clear_ppi_config();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -264,6 +264,13 @@ static inline void hal_trigger_aar_ppi_config(void)
 #define HAL_RADIO_GROUP_TASK_ENABLE_PUBLISH_END HAL_RADIO_PUBLISH_PHYEND
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER || CONFIG_BT_CTLR_DF */
 
+/* Start SW-switch timer on event timer start.
+ */
+static inline void hal_sw_switch_timer_start_ppi_config(void)
+{
+	nrf_timer_subscribe_set(SW_SWITCH_TIMER, NRF_TIMER_TASK_START, HAL_EVENT_TIMER_START_PPI);
+}
+
 /* Clear SW-switch timer on packet end:
  * wire the RADIO EVENTS_END event to SW_SWITCH_TIMER TASKS_CLEAR task.
  *

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -292,6 +292,14 @@ static inline void hal_trigger_aar_ppi_config(void)
 
 #if !defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
 
+/* Start SW-switch timer on event timer start.
+ */
+static inline void hal_sw_switch_timer_start_ppi_config(void)
+{
+	nrf_ppi_fork_endpoint_setup(NRF_PPI, HAL_EVENT_TIMER_START_PPI,
+				    (uint32_t)&(SW_SWITCH_TIMER->TASKS_START));
+}
+
 /* Clear SW-switch timer on packet end:
  * wire the RADIO EVENTS_END event to SW_SWITCH_TIMER TASKS_CLEAR task.
  *

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -47,6 +47,7 @@ static struct {
 		void              *param;
 		lll_is_abort_cb_t is_abort_cb;
 		lll_abort_cb_t    abort_cb;
+		uint8_t           has_margin:1;
 	} curr;
 
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -934,9 +935,13 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	}
 
 	/* Current event active or another prepare is ready in the pipeline */
-	if ((!is_dequeue && !is_done_sync()) ||
-	    event.curr.abort_cb || ready_short ||
-	    (ready && is_resume)) {
+	if (((is_dequeue == 0U) && (is_done_sync() == 0U)) ||
+	    (event.curr.abort_cb != NULL) ||
+	    (ready_short != NULL) ||
+	    ((ready != NULL) && (is_resume != 0U)) ||
+	    (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN) &&
+	     (prepare_param->defer == 0U) &&
+	     (event.curr.has_margin == 0U))) {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
 		lll_prepare_cb_t resume_cb;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
@@ -1018,6 +1023,10 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	event.curr.param = prepare_param->param;
 	event.curr.is_abort_cb = is_abort_cb;
 	event.curr.abort_cb = abort_cb;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+		event.curr.has_margin = 0U;
+	}
 
 	err = prepare_cb(prepare_param);
 
@@ -1277,6 +1286,23 @@ static void preempt(void *param)
 
 	/* No event to abort */
 	if (!event.curr.abort_cb || !event.curr.param) {
+		/* When a radio event is placed back in the prepare pipeline as
+		 * resume prepare and a done event is not to be generated; in
+		 * these cases, event.curr.abort_cb is not NULL, but
+		 * event.curr.param is NULL. Let us setup the preempt timeout to
+		 * ensure the margin for certain.
+		 */
+		if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN) &&
+		    (event.curr.abort_cb == NULL)) {
+			/* Previous event is done before the prepare margin for
+			 * the event ready in the pipeline when we are here now.
+			 */
+			event.curr.has_margin = 1U;
+
+			/* Execute the enqueued ready LLL prepare callbacks */
+			ull_prepare_dequeue(TICKER_USER_ID_LLL);
+		}
+
 		return;
 	}
 
@@ -1372,6 +1398,13 @@ preempt_find_preemptor:
 		}
 
 		LL_ASSERT_ERR(ready->prepare_param.param == param);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+		/* Here prepare margin has expired while a previous event is
+		 * active, set the flag and proceed with abort.
+		 */
+		event.curr.has_margin = 1U;
 	}
 
 	/* Check if current event want to continue */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2849,7 +2849,7 @@ static void ticker_get_offset_op_cb(uint32_t status, void *param)
 	*((uint32_t volatile *)param) = status;
 }
 
-static uint32_t get_ticker_offset(uint8_t ticker_id, uint16_t *lazy)
+static uint32_t get_ticker_offset(const struct ll_conn *conn, uint8_t ticker_id, uint16_t *lazy)
 {
 	uint32_t volatile ret_cb;
 	uint32_t ticks_to_expire;
@@ -2888,6 +2888,7 @@ static uint32_t get_ticker_offset(uint8_t ticker_id, uint16_t *lazy)
 	/* Add a tick for negative remainder and return positive remainder
 	 * value.
 	 */
+	remainder = conn->llcp.prep.remainder;
 	hal_ticker_add_jitter(&ticks_to_expire, &remainder);
 	start_us = remainder;
 
@@ -2921,7 +2922,8 @@ static void mfy_past_sender_offset_get(void *param)
 
 		LL_ASSERT_DBG(adv_sync);
 
-		ticker_offset_us = get_ticker_offset(TICKER_ID_ADV_SYNC_BASE + adv_sync_handle,
+		ticker_offset_us = get_ticker_offset(conn,
+						     (TICKER_ID_ADV_SYNC_BASE + adv_sync_handle),
 						     &lazy);
 
 		pa_event_counter = adv_sync->lll.event_counter;
@@ -2933,7 +2935,8 @@ static void mfy_past_sender_offset_get(void *param)
 
 		LL_ASSERT_DBG(sync);
 
-		ticker_offset_us = get_ticker_offset(TICKER_ID_SCAN_SYNC_BASE + sync_handle,
+		ticker_offset_us = get_ticker_offset(conn,
+						     (TICKER_ID_SCAN_SYNC_BASE + sync_handle),
 						     &lazy);
 
 		if (lazy && ticker_offset_us > interval_us) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1552,20 +1552,19 @@ void ull_lp_past_offset_calc_reply(struct ll_conn *conn, uint32_t offset_us,
 
 			/* Update offset_us */
 			offset_us = offset_us - (conn_event_offset * conn_interval_us);
-
-			ctx->data.periodic_sync.conn_event_count = ull_conn_event_counter(conn) +
-								   conn_event_offset;
 		}
 
 		llcp_pdu_fill_sync_info_offset(&ctx->data.periodic_sync.sync_info, offset_us);
+
 #if defined(CONFIG_BT_PERIPHERAL)
 		/* Save the result for later use */
 		ctx->data.periodic_sync.offset_us = offset_us;
 #endif /* CONFIG_BT_PERIPHERAL */
 
-		ctx->data.periodic_sync.sync_conn_event_count = ull_conn_event_counter(conn);
-		ctx->data.periodic_sync.conn_event_count = ull_conn_event_counter(conn) +
-							   conn_event_offset;
+		ctx->data.periodic_sync.sync_conn_event_count =
+			ull_conn_event_counter_at_prepare(conn) - 1U;
+		ctx->data.periodic_sync.conn_event_count =
+			ull_conn_event_counter_at_prepare(conn) + conn_event_offset - 1U;
 
 		ctx->data.periodic_sync.sync_info.evt_cntr = pa_event_counter;
 

--- a/tests/bluetooth/controller/ctrl_periodic_sync/src/main.c
+++ b/tests/bluetooth/controller/ctrl_periodic_sync/src/main.c
@@ -147,14 +147,14 @@ ZTEST(periodic_sync_transfer, test_periodic_sync_transfer_loc)
 
 	struct pdu_data_llctrl_periodic_sync_ind local_periodic_sync_ind = {
 		.id = 0x00,
-		.conn_event_count = 0x00,
+		.conn_event_count = 0xFFFFU,
 		.last_pa_event_counter = 0x00,
 		.sid = 0x00,
 		.addr_type = 0x00,
 		.sca = 0x00,
 		.phy = 0x00,
 		.adv_addr = { 0, 0, 0, 0, 0, 0},
-		.sync_conn_event_count = 0
+		.sync_conn_event_count = 0xFFFFU,
 	};
 
 	/* Reset and setup mayfly_enqueue_custom_fake */
@@ -346,26 +346,26 @@ ZTEST(periodic_sync_transfer, test_periodic_sync_transfer_rem_2)
 
 	struct pdu_data_llctrl_periodic_sync_ind local_periodic_sync_ind = {
 		.id = 0x00,
-		.conn_event_count = 0x01,
+		.conn_event_count = 0x0000U,
 		.last_pa_event_counter = 0x00,
 		.sid = 0x00,
 		.addr_type = 0x00,
 		.sca = 0x00,
 		.phy = 0x00,
 		.adv_addr = { 0, 0, 0, 0, 0, 0},
-		.sync_conn_event_count = 0x01
+		.sync_conn_event_count = 0x0000U,
 	};
 
 	struct pdu_data_llctrl_periodic_sync_ind remote_periodic_sync_ind = {
 		.id = 0x01,
-		.conn_event_count = 0x00,
+		.conn_event_count = 0x0000U,
 		.last_pa_event_counter = 0x00,
 		.sid = 0x00,
 		.addr_type = 0x01,
 		.sca = 0x00,
 		.phy = 0x01,
 		.adv_addr = { 0, 0, 0, 0, 0, 0},
-		.sync_conn_event_count = 0
+		.sync_conn_event_count = 0x0000U,
 	};
 
 	/* Reset and setup fake functions */
@@ -481,14 +481,14 @@ ZTEST(periodic_sync_transfer, test_periodic_sync_transfer_loc_twice)
 
 	struct pdu_data_llctrl_periodic_sync_ind local_periodic_sync_ind = {
 		.id = 0x00,
-		.conn_event_count = 0x00,
+		.conn_event_count = 0xFFFFU,
 		.last_pa_event_counter = 0x00,
 		.sid = 0x00,
 		.addr_type = 0x00,
 		.sca = 0x00,
 		.phy = 0x00,
 		.adv_addr = { 0, 0, 0, 0, 0, 0},
-		.sync_conn_event_count = 0
+		.sync_conn_event_count = 0xFFFFU,
 	};
 
 	/* Reset and setup mayfly_enqueue_custom_fake */

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -25,7 +25,7 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
-  -RealEncryption=1 -rs=79 -D=3 -start_offset=6e3
+  -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \


### PR DESCRIPTION
Introduce Kconfig option to enfore LLL prepare at margin irrespective of whether there is an overlapping state/role.