### PR TITLE
soc: raspberrypi: rpi_pico: Defaultly turn off BINARY_INFO feature

### DIFF
--- a/soc/raspberrypi/rpi_pico/common/Kconfig.binary_info
+++ b/soc/raspberrypi/rpi_pico/common/Kconfig.binary_info
@@ -3,7 +3,6 @@
 
 config RPI_PICO_BINARY_INFO
 	bool "Generate Raspberry Pi Pico binary info"
-	default y
 	help
 	  Binary info is able to embed machine readable information with the binary in flash.
 	  It can be read with picotool (https://github.com/raspberrypi/picotool).


### PR DESCRIPTION
The binary-info feature that introduced in #54290 causing trouble with some rp2xxx variant boards.
Turning off this feature defaultly to solve these problems.

fix: #101855