### PR TITLE
boards: shields: lcd_par_s035: fix touchscreen orientation

### DIFF
--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -29,9 +29,9 @@
 		irq-gpios = <&nxp_lcd_8080_connector 9 GPIO_ACTIVE_HIGH>;
 		zephyr,deferred-init;
 		swapped-x-y;
-		inverted-y;
-		screen-width = <480>;
-		screen-height = <320>;
+		inverted-x;
+		screen-width = <320>;
+		screen-height = <480>;
 	};
 };
 

--- a/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
@@ -30,9 +30,9 @@
 		irq-gpios = <&nxp_lcd_pmod_connector 12 GPIO_ACTIVE_HIGH>;
 		zephyr,deferred-init;
 		swapped-x-y;
-		inverted-y;
-		screen-width = <480>;
-		screen-height = <320>;
+		inverted-x;
+		screen-width = <320>;
+		screen-height = <480>;
 	};
 };
 


### PR DESCRIPTION
Fixes orientation after d4ec3fef5e7342140c7cb5faec65326a3a583d28 update from https://github.com/zephyrproject-rtos/zephyr/pull/99585

Helps fix https://github.com/zephyrproject-rtos/zephyr/issues/101750 

Tested on 2 boards with these commands:
```
west build -b frdm_rw612 --shield lcd_par_s035_spi samples/modules/lvgl/demos -p
west build -b frdm_mcxn947//cpu0 --shield lcd_par_s035_8080 samples/modules/lvgl/demos -p
```