### PR TITLE
boards: rpi_4b: remove empty file from raspberry pi 4 board

### DIFF
--- a/boards/raspberrypi/rpi_4b/CMakeLists.txt
+++ b/boards/raspberrypi/rpi_4b/CMakeLists.txt
@@ -1,1 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0

--- a/boards/raspberrypi/rpi_4b/Kconfig.defconfig
+++ b/boards/raspberrypi/rpi_4b/Kconfig.defconfig
@@ -1,2 +1,0 @@
-# Copyright 2023 honglin leng <a909204013@gmail.com>
-# SPDX-License-Identifier: Apache-2.0

--- a/boards/raspberrypi/rpi_4b/board.cmake
+++ b/boards/raspberrypi/rpi_4b/board.cmake
@@ -1,1 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0

--- a/boards/raspberrypi/rpi_4b/rpi_4b.dts
+++ b/boards/raspberrypi/rpi_4b/rpi_4b.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Raspberry Pi 4 Model B";
-	compatible = "raspberrypi,4-model-b", "brcm,bcm2838";
+	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
 	#address-cells = <1>;
 	#size-cells = <1>;
 


### PR DESCRIPTION
- Remove empty file from raspberry pi 4 board.
- Update compatible in root node to use bcm2711.