### PR TITLE
drivers: gpio: pcf857x: fix race condition in port_set_raw

### DIFF
--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -177,6 +177,7 @@ static int pcf857x_port_set_raw(const struct device *dev, uint16_t mask, uint16_
 		return -EOPNOTSUPP;
 	}
 
+	k_sem_take(&drv_data->lock, K_FOREVER);
 	tx_buf = (drv_data->pins_cfg.outputs_state & ~mask);
 	tx_buf |= (value & mask);
 	tx_buf ^= toggle;
@@ -186,9 +187,9 @@ static int pcf857x_port_set_raw(const struct device *dev, uint16_t mask, uint16_
 	rc = i2c_write_dt(&drv_cfg->i2c, tx_buf_p, drv_data->num_bytes);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to write output port: %d", dev->name, rc);
+		k_sem_give(&drv_data->lock);
 		return -EIO;
 	}
-	k_sem_take(&drv_data->lock, K_FOREVER);
 	drv_data->pins_cfg.outputs_state = tx_buf;
 	k_sem_give(&drv_data->lock);
 


### PR DESCRIPTION
The pcf857x_port_set_raw() function has a race condition where the lock is only taken after the I2C write to update the cached outputs_state. This allows concurrent threads to read stale outputs_state values and compute tx_buf based on outdated data.

Since PCF8574/PCF8575 devices have a single output register that is written atomically (all pins at once), a stale read causes one thread's pin changes to be overwritten by another thread's write.