### PR TITLE
bluetooth : stm32wbax : bluetooth disable support

### DIFF
--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -125,6 +125,15 @@ void link_layer_register_isr(bool force)
 	irq_enable(RADIO_SW_LOW_INTR_NUM);
 }
 
+void link_layer_disable_isr(void)
+{
+	irq_disable(RADIO_INTR_NUM);
+
+	irq_disable(RADIO_SW_LOW_INTR_NUM);
+
+	local_basepri_value = __get_BASEPRI();
+	__set_BASEPRI_MAX(RADIO_INTR_PRIO_LOW_Z << 4);
+}
 
 void LINKLAYER_PLAT_TriggerSwLowIT(uint8_t priority)
 {

--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_local.h
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_local.h
@@ -14,4 +14,9 @@
  */
 void link_layer_register_isr(bool force);
 
+/*
+ * @brief  Link Layer related ISR disable
+ */
+void link_layer_disable_isr(void);
+
 #endif /* _STM32WBA_LINK_LAYER_PLAT_LOCAL_H_ */


### PR DESCRIPTION
Implementation of bluetooth disable functionality for stm32wbax.
Call of bt_disable() function, on stm32wbax, disable bluetooth driver and deinitialized, if possible, the clock sources used fur the radio.