### PR TITLE
Bluetooth: Conn: Only recycle ACL connections

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2124,6 +2124,8 @@ struct bt_conn_cb {
 	 *
 	 * This callback notifies the application that it might be able to
 	 * allocate a connection object. No guarantee, first come, first serve.
+	 * Only connections that are configurable by @kconfig{CONFIG_BT_MAX_CONN} trigger this
+	 * callback, i.e. connections of type @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR.
 	 *
 	 * The maximum number of simultaneous connections is configured
 	 * by @kconfig{CONFIG_BT_MAX_CONN}.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -96,12 +96,11 @@ static void conn_tx_destroy(struct bt_conn *conn, struct bt_conn_tx *tx)
 static void tx_complete_work(struct k_work *work);
 #endif /* CONFIG_BT_CONN_TX */
 
-static void notify_recycled_conn_slot(void);
-
 void bt_tx_irq_raise(void);
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
+static void notify_recycled_conn_slot(void);
 /* Peripheral timeout to initialize Connection Parameter Update procedure */
 #define CONN_UPDATE_TIMEOUT  K_MSEC(CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT)
 
@@ -1466,6 +1465,7 @@ struct bt_conn *bt_conn_ref(struct bt_conn *conn)
 	return conn;
 }
 
+#if defined(CONFIG_BT_CONN)
 static K_SEM_DEFINE(pending_recycled_events, 0, K_SEM_MAX_LIMIT);
 
 static void recycled_work_handler(struct k_work *work)
@@ -1477,6 +1477,7 @@ static void recycled_work_handler(struct k_work *work)
 }
 
 static K_WORK_DEFINE(recycled_work, recycled_work_handler);
+#endif /* CONFIG_BT_CONN */
 
 void bt_conn_unref(struct bt_conn *conn)
 {
@@ -1515,12 +1516,16 @@ void bt_conn_unref(struct bt_conn *conn)
 		   (__ASSERT(!conn_tx_is_pending,
 			     "tx_complete_work is pending when conn is deallocated");))
 
+#if defined(CONFIG_BT_CONN)
 	/* Notify listeners that a slot has been freed and can be taken.
 	 * No guarantees are made on requests to claim connection object
 	 * as only the first claim will be served.
 	 */
-	k_sem_give(&pending_recycled_events);
-	k_work_submit(&recycled_work);
+	if (IS_ARRAY_ELEMENT(acl_conns, conn)) {
+		k_sem_give(&pending_recycled_events);
+		k_work_submit(&recycled_work);
+	}
+#endif /* CONFIG_BT_CONN */
 }
 
 uint8_t bt_conn_index(const struct bt_conn *conn)
@@ -1630,9 +1635,9 @@ static void tx_complete_work(struct k_work *work)
 }
 #endif /* CONFIG_BT_CONN_TX */
 
+#if defined(CONFIG_BT_CONN)
 static void notify_recycled_conn_slot(void)
 {
-#if defined(CONFIG_BT_CONN)
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->recycled) {
 			callback->recycled();
@@ -1644,8 +1649,8 @@ static void notify_recycled_conn_slot(void)
 			cb->recycled();
 		}
 	}
-#endif
 }
+#endif
 
 #if !defined(CONFIG_BT_CONN)
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)


### PR DESCRIPTION
Add check for ACL connection before submitting recycled.
Since ISO and SCO connections do not trigger the disconnected
callback, nor affects e.g. advertising, they should not
trigger the recycled callback.