### PR TITLE
modules: lvgl: add initial support for vg_lite acceleration of LVGL under Zephyr

### DIFF
--- a/boards/nxp/mimxrt595_evk/board.c
+++ b/boards/nxp/mimxrt595_evk/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2023, 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -413,5 +413,5 @@ SYS_INIT(board_config_pmic, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
 /* Framebuffers should be setup after PSRAM is initialized but before
  * Graphics framework init
  */
-SYS_INIT(init_psram_framebufs, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(init_psram_framebufs, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 #endif

--- a/boards/nxp/mimxrt595_evk/dc_ram.ld
+++ b/boards/nxp/mimxrt595_evk/dc_ram.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,5 +12,6 @@ GROUP_START(FLEXSPI2)
 	{
 		__flexspi2_start = .;
 		*(.lvgl_buf);
+		*(.vg_lite_heap);
 		__flexspi2_end = .;
 	} GROUP_LINK_IN(FLEXSPI2)

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk.overlay
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Replace existing SRAM bus mapping */
+&sram {
+	reg = <0x20000000 0x480000>;
+	ranges = <0x20000000 0x20000000 0x480000>;
+};
+
+/* Fix actual SRAM physical region */
+&sram0 {
+	reg = <0x20080000 DT_SIZE_K(4608)>;
+};
+
+/* Increase PSRAM clock frequency */
+&aps6408l {
+	spi-max-frequency = <DT_FREQ_M(396)>;
+};
+
+&os_timer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/boards/nxp/mimxrt700_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt700_evk/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -27,3 +27,6 @@ endif()
 if(CONFIG_IMX_USDHC)
   zephyr_compile_definitions(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL=1)
 endif()
+
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
+  SECTIONS psram_sections.ld)

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -8,6 +8,10 @@
 #include <fsl_clock.h>
 #include <soc.h>
 #include <fsl_glikey.h>
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pmc_tmpsns))
+#include "fsl_romapi_otp.h"
+#endif
+#include <zephyr/cache.h>
 
 /*!< System oscillator settling time in us */
 #define SYSOSC_SETTLING_US 220U
@@ -642,3 +646,39 @@ static int second_core_boot(void)
 
 SYS_INIT(second_core_boot, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
+
+#if defined(CONFIG_LV_USE_DRAW_VG_LITE)
+static int gpu_init_imxrt7xx(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	POWER_DisablePD(kPDRUNCFG_APD_GPU);
+	POWER_DisablePD(kPDRUNCFG_PPD_GPU);
+	POWER_ApplyPD();
+
+	/* VGPU clock enablement and divider selection */
+	CLOCK_EnableClock(kCLOCK_MediaAccessRamArbiter0);
+	CLOCK_EnableClock(kCLOCK_MediaAccessRamArbiter1);
+	CLOCK_EnableClock(kCLOCK_Gpu);
+
+	CLOCK_AttachClk(kFRO0_DIV1_to_VGPU);
+	CLOCK_SetClkDiv(kCLOCK_DivVgpuClk, 1U);
+
+	/* Enable GPU interrupt */
+	RESET_ClearPeripheralReset(kVGPU_RST_SHIFT_RSTn);
+	NVIC_SetPriority(VGPU_IRQn, CONFIG_VG_LITE_INTERRUPT_PRIORITY);
+	EnableIRQ((IRQn_Type)VGPU_IRQn);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_INST(0, nxp_gpu), gpu_init_imxrt7xx, NULL,
+		NULL, NULL, POST_KERNEL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+#endif /* CONFIG_LV_USE_DRAW_VG_LITE */
+
+void clear_cache_op(void)
+{
+	sys_cache_data_flush_all();
+}

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_basic.overlay
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_basic.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&xspi0 {
+	reg = <0x50184000 0x1000>, <0x28000000 0x08000000>; /* 128 MB */
+};
+
+&sram0 {
+	reg = <0x20080000 0x005fe000>; /* 6136 KB */
+};

--- a/boards/nxp/mimxrt700_evk/psram_sections.ld
+++ b/boards/nxp/mimxrt700_evk/psram_sections.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/linker/linker-tool.h>
+
+
+GROUP_START(PSRAM)
+  SECTION_PROLOGUE(.vg_fb_bss,(NOLOAD),SUBALIGN(4))
+  {
+    __vg_psram_start = .;
+    *(.lvgl_buf*);
+    __vg_psram_end = .;
+  } GROUP_LINK_IN(PSRAM)

--- a/doc/develop/manifest/external/gpu-vglite.rst
+++ b/doc/develop/manifest/external/gpu-vglite.rst
@@ -1,0 +1,46 @@
+.. _external_module_gpu_vglite:
+
+GPU VGLite Driver
+#################
+
+Introduction
+************
+
+The VGLite GPU Driver module provides hardware-accelerated 2D graphics rendering
+capabilities for embedded systems. VGLite is a lightweight, high-performance 2D
+vector graphics library designed for resource-constrained embedded applications
+with GPU acceleration support.
+
+The driver enables efficient vector graphics rendering, image processing, and
+advanced 2D graphics operations with minimal CPU overhead, making it ideal for
+GUI applications, industrial displays, and consumer electronics.
+
+The VGLite driver integrates with Zephyr's display subsystem and provides a
+hardware abstraction layer for VGLite GPU operations within the Zephyr RTOS
+environment. It supports various SoCs with integrated VGLite GPU hardware,
+including NXP i.MX RT series microcontrollers.
+
+Usage with Zephyr
+*****************
+
+To pull in gpu-vglite as a Zephyr module, add it using a submanifest
+(for example, ``zephyr/submanifests/gpu-vglite.yaml``) with the
+following content, and then run ``west update``:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: gpu-vglite
+         url: https://github.com/VeriSilicon/VGLite_4.x.git
+         revision: master
+         path: modules/gpu-vglite
+
+For more detailed instructions and API documentation, refer to the
+`gpu-vglite documentation <https://github.com/nxp-mcuxpresso/gpu-vglite>`_.
+
+Reference
+*********
+
+- `VGLite API Documentation <https://www.nxp.com/docs/en/reference-manual/IMXRTVGLITEAPIRM.pdf>`_
+- `NXP i.MX RT Series <https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus:IMX-RT-SERIES>`_

--- a/dts/arm/nxp/imxrt/nxp_rt1160.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1160.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,14 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "OCRAMCOMBINED";
 			reg = <0x20340000 DT_SIZE_K(256)>;
+		};
+
+		gpu: gpu@41800000 {
+			compatible = "nxp,gpu";
+			reg = <0x41800000 0x4000>;
+			interrupts = <60 0>;
+			clocks = <&ccm 128 0 0>;
+			status = "okay";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt1170.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1170.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,14 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "OCRAM2";
 			reg = <0x202c0000 DT_SIZE_K(512)>;
+		};
+
+		gpu: gpu@41800000 {
+			compatible = "nxp,gpu";
+			reg = <0x41800000 0x4000>;
+			interrupts = <60 0>;
+			clocks = <&ccm 128 0 0>;
+			status = "okay";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -738,6 +738,14 @@
 			status = "disabled";
 		};
 	};
+
+	gpu: gpu@40240000 {
+		compatible = "nxp,gpu";
+		reg = <0x40240000 0x4000>;
+		interrupts = <70 0>;
+		clocks = <&clkctl0 26>;
+		status = "okay";
+	};
 };
 
 &flexspi {

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,6 +26,14 @@
 
 		xspi2: spi@50411000 {
 			reg = <0x50411000 0x1000>, <0x70000000 DT_SIZE_M(128)>;
+		};
+
+		gpu: gpu@40486000 {
+			compatible = "nxp,gpu";
+			reg = <0x40486000 0x4000>;
+			interrupts = <57 0>;
+			clocks = <&clkctl2 2>;
+			status = "okay";
 		};
 	};
 

--- a/dts/bindings/graphics_accelerator/nxp,gpu.yaml
+++ b/dts/bindings/graphics_accelerator/nxp,gpu.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Felipe Neves ryukokki.felipe@gmail.com
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+
+description: NXP GPU2D graphics accelerator
+
+compatible: "nxp,gpu"
+
+include: [reset-device.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clocks:
+    required: true

--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) 2019 jan.van_winkel@dxplore.eu
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # Copyright (c) 2023 Fabian Blatz <fabianblatz@gmail.com>
+# Copyright 2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +19,15 @@ zephyr_include_directories(include)
 zephyr_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
 zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
 zephyr_compile_definitions(LV_CONF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h")
+
+# Allow passing GCID_REV_CID via -D on the cmake/west command line and forward
+# it to the compiler so vg_lite_options.h can use it in an #include path.
+  if(CONFIG_LV_USE_GPU_VG_LITE AND NOT CONFIG_LV_USE_VG_LITE_DRIVER)
+    if(DEFINED GCID_REV_CID)
+      # GCID_REV_CID is expected to be something like: gc355/0x0_1216
+      zephyr_compile_definitions(GCID_REV_CID=${GCID_REV_CID})
+    endif()
+  endif()
 
 file(GLOB_RECURSE LVGL_SRC_FILES CONFIGURE_DEPENDS
     ${LVGL_DIR}/src/*.c
@@ -51,6 +61,14 @@ set(LVGL_EXCLUDE_PATTERNS
     "${LVGL_DIR}/src/debugging/test/*"
 )
 
+  if(CONFIG_LV_USE_GPU_VG_LITE)
+    if(CONFIG_LV_USE_VG_LITE_DRIVER)
+    else()
+      # Exclude vg_lite_driver from LVGL source tree
+      list(APPEND LVGL_EXCLUDE_PATTERNS "${LVGL_DIR}/src/libs/vg_lite_driver/*")
+    endif()
+  endif()
+
 foreach(pattern IN LISTS LVGL_EXCLUDE_PATTERNS)
     file(GLOB_RECURSE LVGL_EXCLUDED CONFIGURE_DEPENDS ${pattern})
     list(REMOVE_ITEM LVGL_SRC_FILES ${LVGL_EXCLUDED})
@@ -69,6 +87,34 @@ zephyr_library_sources(
     lvgl_display_mono.c
     lvgl_zephyr_osal.c
 )
+
+  if(CONFIG_LV_USE_GPU_VG_LITE)
+    if(CONFIG_LV_USE_VG_LITE_DRIVER)
+    else()
+      zephyr_include_directories(
+      ${ZEPHYR_BASE}/../modules/gpu-vglite
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLiteKernel/zephyr
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLiteKernel
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/inc
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${ZEPHYR_BASE}/include
+      ${ZEPHYR_BASE}/include/zephyr
+    )
+
+      zephyr_library_sources(
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLiteKernel/vg_lite_kernel.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/vg_lite.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/vg_lite_image.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/vg_lite_matrix.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/vg_lite_path.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/vg_lite_stroke.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLite/Series/common/vg_lite_chip.c
+      ${ZEPHYR_BASE}/../modules/gpu-vglite/VGLiteKernel/zephyr/vg_lite_hal.c
+    )
+
+    endif()
+  endif()
 
 zephyr_library_sources_ifdef(CONFIG_LV_Z_USE_FILESYSTEM lvgl_fs.c)
 zephyr_library_sources_ifdef(CONFIG_LV_Z_MEM_POOL_SYS_HEAP lvgl_mem.c)

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 Fabian Blatz <fabianblatz@gmail.com>
-# Copyright 2023 NXP
+# Copyright 2023, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config ZEPHYR_LVGL_MODULE
@@ -226,6 +226,30 @@ config LV_Z_PXP_INTERRUPT_PRIORITY
 	default 3
 	help
 	  Sets the interrupt priority for PXP
+
+config LV_USE_DRAW_VG_LITE
+	bool
+
+config LV_USE_GPU_VG_LITE
+	bool
+	default y if LV_USE_DRAW_VG_LITE
+
+config LV_Z_VGLITE_HEAP_SIZE
+	int "VG Lite driver internal heap bytes"
+	depends on LV_USE_DRAW_VG_LITE
+	default 2097152
+	help
+	  Sets the internal heap for VG Lite driver allocations
+	  This area is separated from LVGL heap.
+
+config LV_USE_VG_LITE_DRIVER
+	bool "VG-Lite GPU acceleration"
+	default n
+	help
+	  Select vglite driver.
+
+	  If enabled, Use internal VGLite Driver from inside LVGL.
+	  If disabled, the external vglite driver is used instead.
 
 rsource "Kconfig.memory"
 rsource "Kconfig.input"

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
  * Copyright (c) 2025 Abderrahmane JARMOUNI
- *
+ * Copyright 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -58,9 +58,13 @@ struct lvgl_disp_data disp_data[DT_ZEPHYR_DISPLAYS_COUNT] = {{
 	  100) / 8 +                                                                               \
 	 8)
 #else
-#define BUFFER_SIZE(n)                                                                             \
-	(CONFIG_LV_Z_BITS_PER_PIXEL *                                                              \
-	 ((CONFIG_LV_Z_VDB_SIZE * DISPLAY_WIDTH(n) * DISPLAY_HEIGHT(n)) / 100) / 8)
+#define BUFFER_STRIDE(n) \
+	ROUND_UP(DISPLAY_WIDTH(n) * (CONFIG_LV_Z_BITS_PER_PIXEL / 8), \
+			CONFIG_LV_DRAW_BUF_STRIDE_ALIGN)
+
+#define BUFFER_SIZE(n) \
+	(ROUND_UP((CONFIG_LV_Z_VDB_SIZE * DISPLAY_HEIGHT(n)) / 100, 1) * BUFFER_STRIDE(n))
+
 #endif /* IS_MONOCHROME_DISPLAY */
 
 static uint32_t disp_buf_size[DT_ZEPHYR_DISPLAYS_COUNT] = {0};
@@ -139,12 +143,25 @@ static void lvgl_log(lv_log_level_t level, const char *buf)
 
 static void lvgl_allocate_rendering_buffers_static(lv_display_t *display, int disp_idx)
 {
+	int32_t width = lv_display_get_horizontal_resolution(display);
+	uint32_t bpp = lv_color_format_get_size(lv_display_get_color_format(display));
+	uint32_t stride = ROUND_UP(width * bpp, CONFIG_LV_DRAW_BUF_STRIDE_ALIGN);
 #ifdef CONFIG_LV_Z_DOUBLE_VDB
-	lv_display_set_buffers(display, buf0_p[disp_idx], buf1_p[disp_idx], disp_buf_size[disp_idx],
-			       LV_DISPLAY_RENDER_MODE_PARTIAL);
+	lv_display_set_buffers_with_stride(
+		display,
+		buf0_p[disp_idx],
+		buf1_p[disp_idx],
+		disp_buf_size[disp_idx],
+		stride,
+		LV_DISPLAY_RENDER_MODE_PARTIAL);
 #else
-	lv_display_set_buffers(display, buf0_p[disp_idx], NULL, disp_buf_size[disp_idx],
-			       LV_DISPLAY_RENDER_MODE_PARTIAL);
+	lv_display_set_buffers_with_stride(
+		display,
+		buf0_p[disp_idx],
+		NULL,
+		disp_buf_size[disp_idx],
+		stride,
+		LV_DISPLAY_RENDER_MODE_PARTIAL);
 #endif /* CONFIG_LV_Z_DOUBLE_VDB */
 
 #if ALLOC_MONOCHROME_CONV_BUFFER

--- a/samples/subsys/display/lvgl/boards/mimxrt1160_evk_mimxrt1166_cm7.conf
+++ b/samples/subsys/display/lvgl/boards/mimxrt1160_evk_mimxrt1166_cm7.conf
@@ -1,11 +1,3 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable PXP DMA engine and set rotation angle to 0 degrees.
-# This allows us to verify the DMA driver functions without altering
-# the output image
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y
 CONFIG_LV_Z_MEM_POOL_SIZE=262144
 CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_HEAP_MEM_POOL_SIZE=262144

--- a/samples/subsys/display/lvgl/boards/mimxrt595_evk_mimxrt595s_cm33.conf
+++ b/samples/subsys/display/lvgl/boards/mimxrt595_evk_mimxrt595s_cm33.conf
@@ -1,11 +1,3 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable PXP DMA engine and set rotation angle to 0 degrees.
-# This allows us to verify the DMA driver functions without altering
-# the output image
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y
 CONFIG_LV_Z_MEM_POOL_SIZE=262144
 CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_HEAP_MEM_POOL_SIZE=262144
@@ -17,3 +9,4 @@ CONFIG_LV_USE_DRAW_VG_LITE=y
 CONFIG_GPU_DEV=y
 CONFIG_GPU_DEV_NAME="GPU"
 CONFIG_VG_LITE_K_MEM_POOL_SIZE=0x200000
+CONFIG_MEMC=y

--- a/samples/subsys/display/lvgl/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
+++ b/samples/subsys/display/lvgl/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
@@ -1,11 +1,3 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable PXP DMA engine and set rotation angle to 0 degrees.
-# This allows us to verify the DMA driver functions without altering
-# the output image
-CONFIG_DMA=y
-CONFIG_MCUX_ELCDIF_PXP=y
 CONFIG_LV_Z_MEM_POOL_SIZE=262144
 CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_HEAP_MEM_POOL_SIZE=262144
@@ -17,3 +9,5 @@ CONFIG_LV_USE_DRAW_VG_LITE=y
 CONFIG_GPU_DEV=y
 CONFIG_GPU_DEV_NAME="GPU"
 CONFIG_VG_LITE_K_MEM_POOL_SIZE=0x200000
+CONFIG_LV_Z_VDB_CUSTOM_SECTION=y
+CONFIG_MEMC=y

--- a/samples/subsys/display/lvgl/tests.yaml
+++ b/samples/subsys/display/lvgl/tests.yaml
@@ -31,6 +31,8 @@ tests:
     min_ram: 32
     harness: none
     extra_args: SHIELD="rk055hdmipi4ma0"
+    modules:
+      - gpu_vglite
     platform_allow:
       - mimxrt1170_evk/mimxrt1176/cm7
       - mimxrt595_evk/mimxrt595s/cm33

--- a/scripts/ci/undef_kconfig_allowlist.txt
+++ b/scripts/ci/undef_kconfig_allowlist.txt
@@ -81,6 +81,17 @@ FOO
 FOO_LOG_LEVEL
 FOO_SETTING_1
 FOO_SETTING_2
+GPU_DEV  # Defined by the external gpu-vglite module (VeriSilicon)
+GPU_DEV_NAME  # Defined by the external gpu-vglite module (VeriSilicon)
+VG_LITE_INTERRUPT_PRIORITY # Defined by the external gpu-vglite module (VeriSilicon)
+PM_DEVICE  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_STACK_SIZE  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_TESS_WIDTH  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_TESS_HEIGHT  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_CMD_BUF_SIZE  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_CONTIGUOUS_ALIGN  # Defined by the external gpu-vglite module (VeriSilicon)
+VGLITE_HEAP_USE_CUSTOM_SECTION  # Defined by the external gpu-vglite module (VeriSilicon)
+VG_LITE_K_MEM_POOL_SIZE  # Defined by the external gpu-vglite module (VeriSilicon)
 HEAP_MEM_POOL_ADD_SIZE_  # Used as an option matching prefix
 HUGETLBFS  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
 IAR_BUFFERED_WRITE

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 NXP
+ * Copyright 2021-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -929,3 +929,33 @@ static int second_core_boot(void)
 
 SYS_INIT(second_core_boot, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
+
+#if defined(CONFIG_LV_USE_DRAW_VG_LITE)
+static int gpu_init_imxrt11xx(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	const clock_root_config_t gpu2d_clock_cfg = {
+		.clockOff = false,
+		.mux      = kCLOCK_GC355_ClockRoot_MuxVideoPllOut,
+		.div      = 2,
+	};
+
+	CLOCK_SetRootClock(kCLOCK_Root_Gc355, &gpu2d_clock_cfg);
+	CLOCK_EnableClock(kCLOCK_Gpu2d);
+	NVIC_SetPriority(GPU2D_IRQn, CONFIG_VG_LITE_INTERRUPT_PRIORITY);
+	EnableIRQ((IRQn_Type)GPU2D_IRQn);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_INST(0, nxp_gpu), gpu_init_imxrt11xx, NULL,
+		NULL, NULL, POST_KERNEL,
+		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+#endif /* CONFIG_LV_USE_DRAW_VG_LITE */
+
+void clear_cache_op(void)
+{
+	sys_cache_data_flush_all();
+}

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023, NXP
+ * Copyright 2022-2023, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,7 +19,7 @@
 #include <soc.h>
 #include <fsl_power.h>
 #include <fsl_clock.h>
-#include <fsl_cache.h>
+#include <zephyr/cache.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -554,5 +554,37 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_PM
 	rt5xx_power_init();
 #endif
+}
 
+#if defined(CONFIG_LV_USE_DRAW_VG_LITE)
+static int gpu_init_imxrt5xx(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	SYSCTL0->PDRUNCFG1_CLR = SYSCTL0_PDRUNCFG1_GPU_SRAM_APD_MASK;
+	SYSCTL0->PDRUNCFG1_CLR = SYSCTL0_PDRUNCFG1_GPU_SRAM_PPD_MASK;
+	POWER_ApplyPD();
+
+	CLOCK_AttachClk(kMAIN_CLK_to_GPU_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivGpuClk, 2);
+	CLOCK_EnableClock(kCLOCK_Gpu);
+	CLOCK_EnableClock(kCLOCK_AxiSwitch);
+
+	RESET_ClearPeripheralReset(kGPU_RST_SHIFT_RSTn);
+	RESET_ClearPeripheralReset(kAXI_SWITCH_RST_SHIFT_RSTn);
+
+	NVIC_SetPriority(GPU_IRQn, CONFIG_VG_LITE_INTERRUPT_PRIORITY);
+	EnableIRQ((IRQn_Type)GPU_IRQn);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_INST(0, nxp_gpu), gpu_init_imxrt5xx, NULL,
+		      NULL, NULL, POST_KERNEL,
+		      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+#endif /* CONFIG_LV_USE_DRAW_VG_LITE */
+
+void clear_cache_op(void)
+{
+	sys_cache_data_flush_all();
 }


### PR DESCRIPTION
This patch series adds what is required to get the VG_Lite hardware acceleration enabled for supported chips, which include:

* VGLite bindings + LVGL Zephyr HAL;
* GPU2D from NXP bring-up code plus its bindings.

The VGLite low-level part on zephyr has some duplicated code and some empty functions that needs to be, at least, defined from the VGLite driver perpspective. This is made intialliy to make the support self-contained, once the VGLite standard HAL gets a cleanup in a next release we can remove them in another PR when LVGL new version gets to Zephyr, please take this in mind when reviewing the PR.