### PR TITLE
drivers: serial: uart_stm32: make ptr to clock device const

### DIFF
--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -22,6 +22,8 @@
 struct uart_stm32_config {
 	/* USART instance */
 	USART_TypeDef *usart;
+	/* clock device */
+	const struct device *clock;
 	/* Reset controller device configuration */
 	const struct reset_dt_spec reset;
 	/* clock subsystem driving this peripheral */
@@ -81,8 +83,6 @@ struct uart_dma_stream {
 
 /* driver data */
 struct uart_stm32_data {
-	/* clock device */
-	const struct device *clock;
 	/* uart config */
 	struct uart_config *uart_cfg;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
The pointer to the clock device (`data->clock`) does never change at runtime. This PR moves the `const struct device *clock` from the `uart_stm32_data` to the `uart_stm32_config` struct and initializes it inside the init macro. The `__uart_stm32_get_clock`-function is no longer needed and removed.