### PR TITLE
drivers: clock: stm32-mco: Add support for STM32N6

### DIFF
--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -280,7 +280,8 @@ csi_interface: &dcmipp {
  * enabled by a shield when camera pipeline is enabled
  */
 &mco1 {
-	clocks = <&rcc STM32_SRC_HSE MCO1_SEL(MCO1_SEL_HSE)>;
+	clocks = <&rcc MCO1CFGR_REG BIT(12)>, <&rcc STM32_SRC_HSE MCO1_SEL(MCO1_SEL_HSE)>;
+	clock-names = "clken", "clksel";
 	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
 	pinctrl-0 = <&rcc_mco_1_pd7>;
 	pinctrl-names = "default";

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -112,4 +112,11 @@ config CLOCK_STM32_MCO
 	  Allows to output various different clock sources onto the MCO pin
 	  using a configurable prescaler.
 
+config CLOCK_STM32_MCO_HAS_ENABLE_BIT
+	def_bool y
+	depends on DT_HAS_ST_STM32_CLOCK_MCO_ENABLED
+	depends on SOC_SERIES_STM32MP13X
+	help
+	  Hidden option indicating the series has a dedicated bit to enable MCO output
+
 endif # CLOCK_CONTROL_STM32_CUBE

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -115,7 +115,7 @@ config CLOCK_STM32_MCO
 config CLOCK_STM32_MCO_HAS_ENABLE_BIT
 	def_bool y
 	depends on DT_HAS_ST_STM32_CLOCK_MCO_ENABLED
-	depends on SOC_SERIES_STM32MP13X
+	depends on SOC_SERIES_STM32N6X || SOC_SERIES_STM32MP13X
 	help
 	  Hidden option indicating the series has a dedicated bit to enable MCO output
 

--- a/drivers/clock_control/clock_stm32_ll_n6.c
+++ b/drivers/clock_control/clock_stm32_ll_n6.c
@@ -143,7 +143,7 @@ static uint32_t get_sysclk_frequency(void)
 
 
 /** @brief Verifies clock is part of active clock configuration */
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 	if ((src_clk == STM32_SRC_SYSCLK) ||
 	    (src_clk == STM32_SRC_HCLK1) ||

--- a/drivers/clock_control/clock_stm32_mco.c
+++ b/drivers/clock_control/clock_stm32_mco.c
@@ -26,12 +26,18 @@ struct stm32_mco_config {
 #endif
 	/* clock subsystem driving this peripheral */
 	const struct stm32_pclken clksel;
+#if defined(CONFIG_CLOCK_STM32_MCO_HAS_ENABLE_BIT)
+	const struct stm32_pclken clken;
+#endif
 };
 
 static int stm32_mco_init(const struct device *dev)
 {
 	const struct stm32_mco_config *config = dev->config;
 	const struct stm32_pclken *clksel = &config->clksel;
+#if defined(CONFIG_CLOCK_STM32_MCO_HAS_ENABLE_BIT)
+	const struct stm32_pclken *clken = &config->clken;
+#endif
 	uint32_t enr = clksel->enr;
 	uint32_t reg = STM32_DT_CLKSEL_REG_GET(enr);
 	uint32_t shift = STM32_DT_CLKSEL_SHIFT_GET(enr);
@@ -51,10 +57,10 @@ static int stm32_mco_init(const struct device *dev)
 			      STM32_DT_CLKSEL_MASK_GET(enr) << shift,
 			      STM32_DT_CLKSEL_VAL_GET(enr) << shift);
 
-#if defined(MCOX_ON)
-	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_DT_CLKSEL_REG_GET(clksel->enr),
-		     MCOX_ON);
-#endif
+#if defined(CONFIG_CLOCK_STM32_MCO_HAS_ENABLE_BIT)
+	/* MCO enable */
+	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + clken->bus, clken->enr);
+#endif /* defined(CONFIG_CLOCK_STM32_MCO_HAS_ENABLE_BIT) */
 
 #if defined(HAS_PRESCALER)
 	/* MCO prescaler */
@@ -72,6 +78,8 @@ static int stm32_mco_init(const struct device *dev)
 	const static struct stm32_mco_config stm32_mco_config_##inst = {		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
 		.clksel = STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, clksel),		\
+		IF_ENABLED(CONFIG_CLOCK_STM32_MCO_HAS_ENABLE_BIT,			\
+			   (.clken = STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, clken),))	\
 		IF_ENABLED(HAS_PRESCALER,						\
 			   (.prescaler = DT_PROP(DT_DRV_INST(inst), prescaler),))	\
 	};										\

--- a/drivers/clock_control/clock_stm32_mco.c
+++ b/drivers/clock_control/clock_stm32_mco.c
@@ -25,14 +25,14 @@ struct stm32_mco_config {
 	uint32_t prescaler;
 #endif
 	/* clock subsystem driving this peripheral */
-	const struct stm32_pclken pclken[1];
+	const struct stm32_pclken clksel;
 };
 
 static int stm32_mco_init(const struct device *dev)
 {
 	const struct stm32_mco_config *config = dev->config;
-	const struct stm32_pclken *pclken = &config->pclken[0];
-	uint32_t enr = pclken->enr;
+	const struct stm32_pclken *clksel = &config->clksel;
+	uint32_t enr = clksel->enr;
 	uint32_t reg = STM32_DT_CLKSEL_REG_GET(enr);
 	uint32_t shift = STM32_DT_CLKSEL_SHIFT_GET(enr);
 	uint32_t prescaler = config->prescaler;
@@ -40,7 +40,7 @@ static int stm32_mco_init(const struct device *dev)
 	uint32_t pres_shift = STM32_DT_CLKSEL_SHIFT_GET(prescaler);
 	int err;
 
-	err = enabled_clock(pclken->bus);
+	err = enabled_clock(clksel->bus);
 	if (err < 0) {
 		/* Attempt to configure a src clock not available or not valid */
 		return err;
@@ -52,7 +52,7 @@ static int stm32_mco_init(const struct device *dev)
 			      STM32_DT_CLKSEL_VAL_GET(enr) << shift);
 
 #if defined(MCOX_ON)
-	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_DT_CLKSEL_REG_GET(pclken->enr),
+	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_DT_CLKSEL_REG_GET(clksel->enr),
 		     MCOX_ON);
 #endif
 
@@ -71,7 +71,7 @@ static int stm32_mco_init(const struct device *dev)
 											\
 	const static struct stm32_mco_config stm32_mco_config_##inst = {		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
-		.pclken = STM32_DT_INST_CLOCKS(inst),					\
+		.clksel = STM32_DT_INST_CLOCK_INFO_BY_NAME(inst, clksel),		\
 		IF_ENABLED(HAS_PRESCALER,						\
 			   (.prescaler = DT_PROP(DT_DRV_INST(inst), prescaler),))	\
 	};										\

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -142,11 +142,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -98,6 +98,7 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32f1-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -97,11 +97,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -112,11 +112,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -100,11 +100,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -110,11 +110,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -145,11 +145,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -169,11 +169,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -118,6 +118,7 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -29,14 +29,20 @@
 
 	mcos {
 		mco1: mco1 {
+			#clock-cells = <2>;
 			compatible = "st,stm32-clock-mco";
-			clock-names = "clksel";
+			clocks = <&rcc MCO1CFGR_REG BIT(12)>,
+				 <&rcc STM32_SRC_HSI MCO1_SEL(MCO1_SEL_HSI)>;
+			clock-names = "clken", "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
+			#clock-cells = <2>;
 			compatible = "st,stm32-clock-mco";
-			clock-names = "clksel";
+			clocks = <&rcc MCO2CFGR_REG BIT(12)>,
+				 <&rcc STM32_SRC_HSI MCO2_SEL(MCO2_SEL_HSI)>;
+			clock-names = "clken", "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -30,11 +30,13 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 
 		mco2: mco2 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -239,6 +239,26 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			#clock-cells = <2>;
+			compatible = "st,stm32-clock-mco";
+			clocks = <&rcc STM32_CLOCK(MISC, 1)>,
+				 <&rcc STM32_SRC_HSI MCO1_SEL(MCO1_SEL_HSI)>;
+			clock-names = "clken", "clksel";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			#clock-cells = <2>;
+			compatible = "st,stm32-clock-mco";
+			clocks = <&rcc STM32_CLOCK(MISC, 2)>,
+				 <&rcc STM32_SRC_HSI MCO2_SEL(MCO2_SEL_HSI)>;
+			clock-names = "clken", "clksel";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		iocell: iocell {
 			compatible = "st,stm32-iocell";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -155,6 +155,7 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -128,6 +128,7 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -112,6 +112,7 @@
 	mcos {
 		mco1: mco1 {
 			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/clock/st,stm32-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mco.yaml
@@ -28,8 +28,13 @@ properties:
 
   clocks:
     required: true
+    description: |
+      Two clocks can be configured depending on SoC
+        * "clksel" for selecting the MCO multiplexer
+        * "clken" (optional) dedicated MCO enable bit
 
   clock-names:
+    enum: ["clksel", "clken"]
     required: true
 
   prescaler:

--- a/dts/bindings/clock/st,stm32-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mco.yaml
@@ -15,6 +15,7 @@ description: |
         Example:
                 &mco1 {
                         clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
+                        clock-names = "clksel"
                         prescaler = <MCO1_PRE(MCO_PRE_DIV_5)>;
                         pinctrl-0 = <&rcc_mco_pa8>;
                         pinctrl-names = "default";
@@ -26,6 +27,9 @@ include: [base.yaml, pinctrl-device.yaml]
 properties:
 
   clocks:
+    required: true
+
+  clock-names:
     required: true
 
   prescaler:

--- a/include/zephyr/dt-bindings/clock/stm32n6_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32n6_clock.h
@@ -61,6 +61,7 @@
 /* #define STM32_SRC_I2SCKIN	TBD */
 
 /** Bus clocks */
+#define STM32_CLOCK_BUS_MISC	0x248
 #define STM32_CLOCK_BUS_MEM	0x24C
 #define STM32_CLOCK_BUS_AHB1	0x250
 #define STM32_CLOCK_BUS_AHB2	0x254
@@ -77,7 +78,7 @@
 
 #define STM32_CLOCK_LP_BUS_SHIFT	0x40
 
-#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_MEM
+#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_MISC
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB5
 
 /** @brief RCC_CCIPRx register offset (RM0486.pdf) */
@@ -122,6 +123,45 @@
 #define MCO1_PRE(val)		STM32_DT_CLOCK_SELECT((val), 7, 4, CCIPR5_REG)
 #define MCO2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR5_REG)
 #define MCO2_PRE(val)		STM32_DT_CLOCK_SELECT((val), 15, 12, CCIPR5_REG)
+
+/* MCO1 source */
+#define MCO1_SEL_HSI  0
+#define MCO1_SEL_LSE  1
+#define MCO1_SEL_MSI  2
+#define MCO1_SEL_LSI  3
+#define MCO1_SEL_HSE  4
+#define MCO1_SEL_IC5  5
+#define MCO1_SEL_IC10 6
+#define MCO1_SEL_SYSA 7
+
+/* MCO2 source */
+#define MCO2_SEL_HSI  0
+#define MCO2_SEL_LSE  1
+#define MCO2_SEL_MSI  2
+#define MCO2_SEL_LSI  3
+#define MCO2_SEL_HSE  4
+#define MCO2_SEL_IC15 5
+#define MCO2_SEL_IC20 6
+#define MCO2_SEL_SYSB 7
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1  0
+#define MCO_PRE_DIV_2  1
+#define MCO_PRE_DIV_3  2
+#define MCO_PRE_DIV_4  3
+#define MCO_PRE_DIV_5  4
+#define MCO_PRE_DIV_6  5
+#define MCO_PRE_DIV_7  6
+#define MCO_PRE_DIV_8  7
+#define MCO_PRE_DIV_9  8
+#define MCO_PRE_DIV_10 9
+#define MCO_PRE_DIV_11 10
+#define MCO_PRE_DIV_12 11
+#define MCO_PRE_DIV_13 12
+#define MCO_PRE_DIV_14 13
+#define MCO_PRE_DIV_15 14
+#define MCO_PRE_DIV_16 15
+
 #define MDF1SEL(val)		STM32_DT_CLOCK_SELECT((val), 18, 16, CCIPR5_REG)
 /** CCIPR6 devices */
 #define XSPI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR6_REG)

--- a/samples/boards/st/mco/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/samples/boards/st/mco/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 STMicroelectronics
+ */
+
+&mco2 {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(MISC, 2)>, <&rcc STM32_SRC_HSE MCO2_SEL(MCO2_SEL_HSE)>;
+	clock-names = "clken", "clksel";
+	/* 48MHz (HSE) / 8 => 6MHz on the output */
+	prescaler = <MCO2_PRE(MCO_PRE_DIV_8)>;
+	/* PC9, pin 13 on STMOD+ connector (CN4) */
+	pinctrl-0 = <&rcc_mco_2_pc9>;
+	pinctrl-names = "default";
+};

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nucleo_u5a5zj_q
       - nucleo_wba55cg
       - nucleo_wl55jc
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - stm32f746g_disco
     tags: board


### PR DESCRIPTION
Adds MCO support for STM32N6 family, including example for stm32n6570_dk board.