### PR TITLE
drivers: can: mcan: reintroduce assert in can_mcan_send()

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -950,7 +950,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 #endif /* !CONFIG_CAN_FD_MODE */
 		.efc = 1U,
 	};
-	uint32_t put_idx = -1;
+	uint32_t put_idx = UINT32_MAX;
 	uint32_t reg;
 	int err;
 
@@ -1025,6 +1025,8 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 		}
 	}
 
+	/* A free TX buffer should always be available since the data->tx_sem was acquired */
+	__ASSERT_NO_MSG(put_idx < cbs->num_tx);
 	tx_hdr.mm = put_idx;
 
 	if ((frame->flags & CAN_FRAME_IDE) != 0U) {


### PR DESCRIPTION
Reintroduce the assert on `put_idx` being within the limit in `can_mcan_send()` but move it to just after the value was determined and add a comment on its purpose.

With the current code, this will never get triggered due to the `tx_sem` being acquired before (meaning a free TX slot was acquired).

Avoid assigning a signed initial literal to an unassigned type.

Fixes: 8dc4dea11243556f282926236fd76f31f17d1033