### PR TITLE
Revert "drivers: display: st7796s: Add display_set_orientation API"

### DIFF
--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -51,11 +51,6 @@ struct st7796s_config {
 	bool rgb_is_inverted;
 };
 
-/* Display data struct */
-struct st7796s_data {
-	enum display_orientation orientation;
-};
-
 static int st7796s_send_cmd(const struct device *dev,
 			uint8_t cmd, const uint8_t *data, size_t len)
 {
@@ -190,7 +185,6 @@ static int st7796s_write(const struct device *dev,
 static void st7796s_get_capabilities(const struct device *dev,
 				     struct display_capabilities *capabilities)
 {
-	struct st7796s_data *data = dev->data;
 	const struct st7796s_config *config = dev->config;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
@@ -199,7 +193,7 @@ static void st7796s_get_capabilities(const struct device *dev,
 
 	capabilities->x_resolution = config->width;
 	capabilities->y_resolution = config->height;
-	capabilities->current_orientation = data->orientation;
+	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
 }
 
 static int st7796s_lcd_config(const struct device *dev)
@@ -314,39 +308,6 @@ static int st7796s_lcd_config(const struct device *dev)
 	return st7796s_send_cmd(dev, ST7796S_CMD_CSCON, &param, sizeof(param));
 }
 
-static int st7796s_set_orientation(const struct device *dev,
-				   const enum display_orientation orientation)
-{
-	struct st7796s_data *data = dev->data;
-	uint8_t tx_data = ST7796S_MADCTL_BGR;
-	int ret;
-
-	if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-		/* works 0° - default */
-		tx_data |= ST7796S_MADCTL_MV;
-	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-		/* works CW 90° */
-		tx_data |= ST7796S_MADCTL_MY;
-	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-		/* works CW 180° */
-		tx_data |= ST7796S_MADCTL_MX | ST7796S_MADCTL_MY | ST7796S_MADCTL_MV;
-	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-		/* works CW 270° */
-		tx_data |= ST7796S_MADCTL_MX;
-	} else {
-		return -EINVAL;
-	}
-
-	ret = st7796s_send_cmd(dev, ST7796S_CMD_MADCTL, &tx_data, 1U);
-	if (ret < 0) {
-		return ret;
-	}
-
-	data->orientation = orientation;
-
-	return 0;
-}
-
 static int st7796s_init(const struct device *dev)
 {
 	const struct st7796s_config *config = dev->config;
@@ -406,7 +367,6 @@ static DEVICE_API(display, st7796s_api) = {
 	.blanking_off = st7796s_blanking_off,
 	.write = st7796s_write,
 	.get_capabilities = st7796s_get_capabilities,
-	.set_orientation = st7796s_set_orientation,
 };
 
 

--- a/drivers/display/display_st7796s.h
+++ b/drivers/display/display_st7796s.h
@@ -35,12 +35,6 @@
 #define ST7796S_CMD_CSCON	0xF0 /* Command set control */
 
 #define ST7796S_CONTROL_16BIT 0x5 /* Sets control interface to 16 bit mode */
-
-#define ST7796S_MADCTL_MY  BIT(7) /* Set row address order */
-#define ST7796S_MADCTL_MX  BIT(6) /* Set column address order */
-#define ST7796S_MADCTL_MV  BIT(5) /* Set row/column exchange */
-#define ST7796S_MADCTL_ML  BIT(4) /* Set vertical refresh order */
-#define ST7796S_MADCTL_MH  BIT(2) /* Set horizontal refresh order */
 #define ST7796S_MADCTL_BGR BIT(3) /* Sets BGR color mode */
 
 


### PR DESCRIPTION
This reverts commit 132ab06a3fe48d8197c1bce034adde095d68126b from #95163.

The author did not actually test the changes even thought they stated in the PR's description that they did.
 
Fixes #101750

See https://github.com/zephyrproject-rtos/zephyr/pull/101793#issuecomment-3719550789