### PR TITLE
runners: openocd: use new port command syntax

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -247,6 +247,16 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         (major, minor, rev) = self.read_version()
         return (major, minor, rev) > (0, 11, 0)
 
+    def supports_new_port_syntax(self):
+        (major, minor, rev) = self.read_version()
+        return (major, minor, rev) >= (1, 0, 0)
+
+    def port_commands(self):
+        sep = ' ' if self.supports_new_port_syntax() else '_'
+        return ['-c', f'tcl{sep}port {self.tcl_port}',
+                '-c', f'telnet{sep}port {self.telnet_port}',
+                '-c', f'gdb{sep}port {self.gdb_port}']
+
     def do_run(self, command, **kwargs):
         self.require(self.openocd_cmd[0])
         if globals().get('ELFFile') is None:
@@ -388,9 +398,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append(rtos_command)
 
         server_cmd = (self.openocd_cmd + self.serial + self.cfg_cmd +
-                      ['-c', f'tcl_port {self.tcl_port}',
-                       '-c', f'telnet_port {self.telnet_port}',
-                       '-c', f'gdb_port {self.gdb_port}'] +
+                      self.port_commands() +
                       pre_init_cmd + self.init_arg + self.targets_arg +
                       self.halt_arg)
 
@@ -486,9 +494,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append(rtos_command)
 
         cmd = (self.openocd_cmd + self.cfg_cmd +
-               ['-c', f'tcl_port {self.tcl_port}',
-                '-c', f'telnet_port {self.telnet_port}',
-                '-c', f'gdb_port {self.gdb_port}'] +
+               self.port_commands() +
                pre_init_cmd + self.init_arg + self.targets_arg +
                ['-c', self.reset_halt_cmd])
 


### PR DESCRIPTION
In v1.0.0, OpenOCD restructured TCL server commands to use subcommand groups instead of underscore-prefixed commands. The port configuration commands changed from 'tcl_port', 'telnet_port', 'gdb_port' to 'tcl port', 'telnet port', 'gdb port' respectively.

The old underscore syntax still works but is deprecated and prints warning messages. This commit detects the OpenOCD version and uses the appropriate command syntax to avoid deprecation warnings on newer versions while maintaining compatibility with older ones.

Link: https://github.com/openocd-org/openocd/commit/73b1519