### PR TITLE
soc: nordic: disable cache for event report

### DIFF
--- a/soc/nordic/common/nrf54hx_nrf92x_mpu_regions.c
+++ b/soc/nordic/common/nrf54hx_nrf92x_mpu_regions.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
+#include <ironside/se/memory_map.h>
 
 #define USBHS_BASE	DT_REG_ADDR_BY_NAME(DT_NODELABEL(usbhs), core)
 #define USBHS_SIZE	DT_REG_SIZE_BY_NAME(DT_NODELABEL(usbhs), core)
@@ -49,6 +50,9 @@ static struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("SOFTPERIPH_RAM", SOFTPERIPH_BASE,
 			 REGION_RAM_NOCACHE_ATTR(SOFTPERIPH_BASE, SOFTPERIPH_SIZE)),
 #endif
+	MPU_REGION_ENTRY("EVENT_REPORT", IRONSIDE_SE_EVENT_REPORT_ADDRESS,
+			 REGION_RAM_NOCACHE_ATTR(IRONSIDE_SE_EVENT_REPORT_ADDRESS,
+						 IRONSIDE_SE_EVENT_REPORT_SIZE)),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
The data is updated by both local domains (cpuapp/cpuapp) and IronSide SE (cpusec), so disable caching to avoid coherency issues.