### PR TITLE
doc: fix additional instances of build/built typos

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -713,14 +713,14 @@ Given the following example project layout:
 * If this is built normally without ``FILE_SUFFIX`` being defined for ``native_sim`` then
   ``prj.conf`` and ``boards/native_sim.overlay`` will be used.
 
-* If this is build normally without ``FILE_SUFFIX`` being defined for ``qemu_cortex_m3`` then
+* If this is built normally without ``FILE_SUFFIX`` being defined for ``qemu_cortex_m3`` then
   ``prj.conf`` will be used, no application devicetree overlay will be used.
 
 * If this is built with ``FILE_SUFFIX`` set to ``mouse`` for ``native_sim`` then
   ``prj_mouse.conf`` and ``boards/native_sim.overlay`` will be used (there is no
   ``native_sim_mouse.overlay`` file so it falls back to ``native_sim.overlay``).
 
-* If this is build with ``FILE_SUFFIX`` set to ``mouse`` for ``qemu_cortex_m3`` then
+* If this is built with ``FILE_SUFFIX`` set to ``mouse`` for ``qemu_cortex_m3`` then
   ``prj_mouse.conf`` will be used and ``boards/qemu_cortex_m3_mouse.overlay`` will be used.
 
 Application-Specific Code

--- a/samples/net/ethernet/gptp/README.rst
+++ b/samples/net/ethernet/gptp/README.rst
@@ -179,7 +179,7 @@ Compile Zephyr application.
    :goals: build
    :compact:
 
-When the Zephyr image is build, you can start it like this:
+When the Zephyr image is built, you can start it like this:
 
 .. code-block:: console
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5267,7 +5267,7 @@ static void vs_read_tx_power_level(struct net_buf *buf, struct net_buf **evt)
 /* A memory pool for vandor specific events for fatal error reporting purposes. */
 NET_BUF_POOL_FIXED_DEFINE(vs_err_tx_pool, 1, BT_BUF_EVT_RX_SIZE, 0, NULL);
 
-/* The alias for convenience of Controller HCI implementation. Controller is build for
+/* The alias for convenience of Controller HCI implementation. Controller is built for
  * a particular architecture hence the alias will allow to avoid conditional compilation.
  * Host may be not aware of hardware architecture the Controller is working on, hence
  * all CPU data types for supported architectures should be available during build, hence

--- a/tests/boot/test_mcuboot/README.rst
+++ b/tests/boot/test_mcuboot/README.rst
@@ -4,7 +4,7 @@ MCUBoot Swap Testing
 Tests MCUBoot's image swap support. This application is built in three parts
 using sysbuild. The first application is the MCUBoot bootloader. The second
 application is the main sysbuild target, and will request an image swap
-from MCUBoot when booted. The third application is build with a load address
+from MCUBoot when booted. The third application is built with a load address
 adjustment using CONFIG_BUILD_OUTPUT_ADJUST_LMA, and will be the application
 that MCUBoot swaps to when the image swap is requested.
 


### PR DESCRIPTION
In some cases, "is build" was written instead of "is built"

This is a follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/101827 triggered by this comment: https://github.com/zephyrproject-rtos/zephyr/pull/101827#issuecomment-3716368566