### PR TITLE
drivers: can: mcan: consolidate `filter_id` bounds checking

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1224,7 +1224,7 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 	struct can_mcan_data *data = dev->data;
 	int err;
 
-	if (filter_id < 0) {
+	if (filter_id < 0 || filter_id >= (cbs->num_std + cbs->num_ext)) {
 		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
@@ -1233,11 +1233,6 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 
 	if (filter_id >= cbs->num_std) {
 		filter_id -= cbs->num_std;
-		if (filter_id >= cbs->num_ext) {
-			LOG_ERR("filter ID %d out of bounds", filter_id);
-			k_mutex_unlock(&data->lock);
-			return;
-		}
 
 		cbs->ext[filter_id].function = NULL;
 		cbs->ext[filter_id].user_data = NULL;


### PR DESCRIPTION
Consolidate lower and upper bounds checking of `filter_id` at `can_mcan_remove_rx_filter` function entry to avoid checking upper bounds while holding the mutex.