### PR TITLE
drivers: i2c: update sy1xx driver for improved read/write support

### DIFF
--- a/drivers/i2c/Kconfig.sy1xx
+++ b/drivers/i2c/Kconfig.sy1xx
@@ -7,3 +7,10 @@ config I2C_SY1XX
 	depends on DT_HAS_SENSRY_SY1XX_I2C_ENABLED
 	help
 	  Enable Sensry SY1xx SOC Family I2C driver.
+
+config I2C_SY1XX_BUFFER_SIZE
+	int "SY1XX I2C buffer size"
+	default 128
+	depends on I2C_SY1XX
+	help
+	  Default buffer size in bytes for the SY1XX I2C driver used for chunked transfers.


### PR DESCRIPTION
- Refactor read and write functions to handle large transfers with chunking. 
- Adjust buffer size to 128 bytes. 
- Simplify start/stop condition logic.
- buffer sets of 2 (rx/tx) reduced to one buffer set, as we have only one active transfer
- instead of putting the whole `data` struct into dma-section, now only the required buffer is in dma-section