### PR TITLE
west: runners: openocd: Add flash-specific pre inits

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -49,7 +49,8 @@ def to_num(number):
 class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for openocd.'''
 
-    def __init__(self, cfg, pre_init=None, reset_halt_cmd=DEFAULT_OPENOCD_RESET_HALT_CMD,
+    def __init__(self, cfg, pre_init=None, pre_init_flash=None,
+                 reset_halt_cmd=DEFAULT_OPENOCD_RESET_HALT_CMD,
                  pre_load=None, erase_cmd=None, load_cmd=None, verify_cmd=None,
                  post_verify=None, do_verify=False, do_verify_only=False, do_erase=False,
                  tui=None, config=None, serial=None, image_type=None,
@@ -100,6 +101,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.elf_name = Path(cfg.elf_file).as_posix() if cfg.elf_file else None
         self.hex_name = Path(cfg.hex_file).as_posix() if cfg.hex_file else None
         self.bin_name = Path(cfg.bin_file).as_posix() if cfg.bin_file else None
+        self.pre_init_flash = pre_init_flash or []
         self.pre_init = pre_init or []
         self.reset_halt_cmd = reset_halt_cmd
         self.pre_load = pre_load or []
@@ -161,6 +163,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--cmd-pre-init', action='append',
                             help='''Command to run before calling init;
                             may be given multiple times''')
+        parser.add_argument('--cmd-pre-init-flash', action='append',
+                            help='''Command to run before calling init when performing a flash;
+                            may be given multiple times;
+                            When set, existing --cmd-pre-init will be ignored when flashing''')
         parser.add_argument('--cmd-reset-halt', default=DEFAULT_OPENOCD_RESET_HALT_CMD,
                             help=f'''Command to run for resetting and halting the target,
                             defaults to "{DEFAULT_OPENOCD_RESET_HALT_CMD}"''')
@@ -232,7 +238,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
         return OpenOcdBinaryRunner(
             cfg,
-            pre_init=args.cmd_pre_init, reset_halt_cmd=args.cmd_reset_halt,
+            pre_init=args.cmd_pre_init, pre_init_flash=args.cmd_pre_init_flash,
+            reset_halt_cmd=args.cmd_reset_halt,
             pre_load=args.cmd_pre_load, erase_cmd=args.cmd_erase, load_cmd=args.cmd_load,
             verify_cmd=args.cmd_verify, post_verify=args.cmd_post_verify,
             do_verify=args.verify, do_verify_only=args.verify_only, do_erase=args.erase,
@@ -333,7 +340,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
         self.logger.info(f'Flashing file: {image_file}')
 
-        pre_init_cmd = self._openocd_cmd(self.pre_init)
+        pre_init = self.pre_init_flash if self.pre_init_flash else self.pre_init
+        pre_init_cmd = self._openocd_cmd(pre_init)
 
         if self.image_type == FileType.ELF:
             pre_load_cmd = []


### PR DESCRIPTION
Add the ability to specify different pre init commands for flashing, in the case flashing needs to use a different transport/target than other operations like debug for heterogeneous targets.

Extracted from the larger MAX32 RV32 work that's in #97309 in order to allow focused review on the changes to the runner.

Copying my comment from https://github.com/zephyrproject-rtos/zephyr/pull/97309#discussion_r2662936885 for clarity on the need this is addressing:

> Ok, so here's the need, and I'm happy to move this to a separate issue/PR to discuss possible solutions:
> 
> Flashing via the RV32 debug connection is not possible(*) for MAX32 targets, so flashing code to the flash region we'll use for that core has to be orchestrated over the ARM core SWD connection.
> 
> On kits like the MAX78002-EVKIT, that has connections for jlink/MAX32625PICO to the ARM core, and another connection to use the included OLIMEX debugger to debug the RV32 core, you may have both connections active on your host, and want to easily west flash or west debug and have this "Just do the right thing" for each command.
> 
> To do so, we can override the flash operation to use a different config than the debug/attach one, so the flash operation is performed over the correct interface and with the correct target details. Having to manually specify the command every time you want to flash (or every time you want to debug/attach) is what this change is designed to avoid.
> 
> Footnote:
> 
> (*) in theory it may be possible for a very small subset of conditions where the ARM core is already set up to start the RV32 core, and is either not using the flash controller peripheral, or you're targeting one of the MAX32 variants with two flash controllers, but such conditions are rarely met, and not a solution for the need here generally.