### PR TITLE
tests: net: coap_client: allow native_sim/native/64

### DIFF
--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -537,8 +537,8 @@ ZTEST(coap_client, test_request_block)
 
 ZTEST(coap_client, test_resend_request)
 {
-	int (*sendto_fakes[])(int, void *, size_t, int, const struct net_sockaddr *,
-			      net_socklen_t) = {
+	ssize_t (*sendto_fakes[])(int, void *, size_t, int, const struct net_sockaddr *,
+				  net_socklen_t) = {
 		z_impl_zsock_sendto_custom_fake_no_reply,
 		z_impl_zsock_sendto_custom_fake_block,
 		z_impl_zsock_sendto_custom_fake,
@@ -653,8 +653,8 @@ ZTEST(coap_client, test_separate_response_ack_fail)
 
 	req.user_data = &sem1;
 
-	int (*sendto_fakes[])(int, void *, size_t, int, const struct net_sockaddr *,
-			      net_socklen_t) = {
+	ssize_t (*sendto_fakes[])(int, void *, size_t, int, const struct net_sockaddr *,
+				  net_socklen_t) = {
 		z_impl_zsock_sendto_custom_fake,
 		z_impl_zsock_sendto_custom_fake_err,
 	};

--- a/tests/net/lib/coap_client/testcase.yaml
+++ b/tests/net/lib/coap_client/testcase.yaml
@@ -4,6 +4,7 @@ tests:
   net.coap.client:
     platform_allow:
       - native_sim
+      - native_sim/native/64
     tags:
       - coap
       - net


### PR DESCRIPTION
Fix build failures when compiling for 64-bit native_sim, and add native_sim/native/64 to the platform allow list for the coap client tests.