### PR TITLE
usb: device_next: uvc: fix ordering of frame interval

### DIFF
--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1257,7 +1257,15 @@ static int uvc_compare_frmival_desc(const void *const a, const void *const b)
 	memcpy(&ia, a, sizeof(uint32_t));
 	memcpy(&ib, b, sizeof(uint32_t));
 
-	return ia - ib;
+	if (ia < ib) {
+		return -1;
+	}
+
+	if (ia > ib) {
+		return 1;
+	}
+
+	return 0;
 }
 
 static void uvc_set_vs_bitrate_range(struct uvc_frame_common_descriptor *const desc,


### PR DESCRIPTION
Fix the qsort comparison function that was hitting an integer underflow.

Some video sources such as `video-sw-generator` have `UINT32_MAX` for maximum frame interval (arbitrarily slow), which made the comparison underflow, which in turn lead to frame interval being listed in the wrong order, breaking Windows support.

Fixes #101259.