### PR TITLE
ipc: ipc_service: move shared configuration to the lib's Kconfig

### DIFF
--- a/include/zephyr/ipc/ipc_rpmsg.h
+++ b/include/zephyr/ipc/ipc_rpmsg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ * Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,7 +24,7 @@ extern "C" {
  */
 
 /** Number of endpoints. */
-#define NUM_ENDPOINTS	CONFIG_IPC_SERVICE_BACKEND_RPMSG_NUM_ENDPOINTS_PER_INSTANCE
+#define NUM_ENDPOINTS CONFIG_IPC_SERVICE_RPMSG_NUM_ENDPOINTS_PER_INSTANCE
 
 struct ipc_rpmsg_ept;
 
@@ -105,14 +106,9 @@ struct ipc_rpmsg_instance {
  *  @retval 0 If successful.
  *  @retval Other errno codes depending on the OpenAMP implementation.
  */
-int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
-		   unsigned int role,
-		   unsigned int buffer_size,
-		   struct metal_io_region *shm_io,
-		   struct virtio_device *vdev,
-		   void *shb, size_t size,
-		   rpmsg_ns_bind_cb ns_bind_cb);
-
+int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance, unsigned int role, unsigned int buffer_size,
+		   struct metal_io_region *shm_io, struct virtio_device *vdev, void *shb,
+		   size_t size, rpmsg_ns_bind_cb ns_bind_cb);
 
 /** @brief
  *
@@ -124,8 +120,7 @@ int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
  * @retval -EINVAL When some parameter is missing
  * @retval 0 If successful
  */
-int ipc_rpmsg_deinit(struct ipc_rpmsg_instance *instance,
-		   unsigned int role);
+int ipc_rpmsg_deinit(struct ipc_rpmsg_instance *instance, unsigned int role);
 
 /** @brief Register an endpoint.
  *

--- a/subsys/ipc/ipc_service/backends/Kconfig.rpmsg
+++ b/subsys/ipc/ipc_service/backends/Kconfig.rpmsg
@@ -21,11 +21,4 @@ config IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET
 	  When this parameter is set to 'y' the status region of the shared
 	  memory is reset on kernel initialization.
 
-config IPC_SERVICE_BACKEND_RPMSG_NUM_ENDPOINTS_PER_INSTANCE
-	int "Max number of registered endpoints per instance"
-	default 2
-	help
-	  Maximal number of endpoints that can be registered for one instance
-	  for RPMSG backend.
-
 endif # IPC_SERVICE_BACKEND_RPMSG

--- a/subsys/ipc/ipc_service/lib/Kconfig
+++ b/subsys/ipc/ipc_service/lib/Kconfig
@@ -29,6 +29,10 @@ if IPC_SERVICE_ICMSG
 	rsource "Kconfig.icmsg"
 endif
 
+if IPC_SERVICE_RPMSG
+	rsource "Kconfig.rpmsg"
+endif
+
 config IPC_SERVICE_ICMSG_ME
 	bool "icmsg IPC library with multi-endpoint functionality"
 	select IPC_SERVICE_ICMSG

--- a/subsys/ipc/ipc_service/lib/Kconfig.rpmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.rpmsg
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config IPC_SERVICE_RPMSG_NUM_ENDPOINTS_PER_INSTANCE
+	int "Max number of registered endpoints per instance"
+	default 2
+	help
+	  Maximal number of endpoints that can be registered for one instance
+	  for RPMSG backend.


### PR DESCRIPTION
The NUM_ENDPOINT_PER_INSTANCE configuration controls the ipc_rpmsg library rather than the backend.