### PR TITLE
cmake: sysbuild: propagate WEST_PYTHON & Python3_EXECUTABLE

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -320,6 +320,8 @@ function(ExternalZephyrProject_Add)
     shared_cmake_variables_list
     CMAKE_BUILD_TYPE
     CMAKE_VERBOSE_MAKEFILE
+    WEST_PYTHON        # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
+    Python3_EXECUTABLE # Temporary export. Waiting for #87083 and extensions.cmake to be cleaned up.
   )
 
   set(sysbuild_cache_file ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}_sysbuild_cache.txt)


### PR DESCRIPTION
Without this, the parent CMake and the sub-processes may use different Python environment.
So we need to propagate these two variable to make sure the sub processes use the same value as the parent cmake.