### PR TITLE
build: cmake: print the board's qualifiers in the elf postbuild phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2294,7 +2294,7 @@ endif()
 add_custom_command(
   TARGET ${logical_target_for_zephyr_elf}
   POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E echo "Generating files from ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME} for board: ${BOARD}"
+  COMMAND ${CMAKE_COMMAND} -E echo "Generating files from ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME} for board: ${BOARD}${BOARD_QUALIFIERS}"
   ${post_build_commands}
   BYPRODUCTS
   ${post_build_byproducts}


### PR DESCRIPTION
When building for several cores of the same system it can be hard to identify which build is currently running.
This addition helps disambiguate the logs.