### PR TITLE
boards: renesas: ek_ra2l1: add LEDs and alias

### DIFF
--- a/boards/renesas/ek_ra2l1/ek_ra2l1.dts
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.dts
@@ -39,6 +39,16 @@
 			gpios = <&ioport5 3 GPIO_ACTIVE_HIGH>;
 			label = "LED1";
 		};
+
+		led2: led2 {
+			gpios = <&ioport5 4 GPIO_ACTIVE_HIGH>;
+			label = "LED2";
+		};
+
+		led3: led3 {
+			gpios = <&ioport5 5 GPIO_ACTIVE_HIGH>;
+			label = "LED3";
+		};
 	};
 
 	buttons {
@@ -59,6 +69,7 @@
 
 	aliases {
 		led0 = &led1;
+		led1 = &led2;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdt;


### PR DESCRIPTION
Added additional LEDs and an alias so that examples such basic/threads will build/run on this board.