### PR TITLE
drivers: misc: nxp_xbar: Add unified XBAR driver header

### DIFF
--- a/drivers/pinctrl/Kconfig.imx
+++ b/drivers/pinctrl/Kconfig.imx
@@ -1,4 +1,4 @@
-# Copyright 2022, 2024 NXP
+# Copyright 2022, 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config PINCTRL_IMX
@@ -25,12 +25,24 @@ config PINCTRL_IMX_SCMI
 # TODO: Find better place for this option
 config MCUX_XBARA
 	bool "MCUX XBARA driver"
-	depends on DT_HAS_NXP_MCUX_XBAR_ENABLED
+	depends on DT_HAS_NXP_MCUX_XBARA_ENABLED
 	help
 	  Enable the MCUX XBARA driver.
 
 config MCUX_XBARB
 	bool "MCUX XBARB driver"
-	depends on DT_HAS_NXP_MCUX_XBAR_ENABLED
+	depends on DT_HAS_NXP_MCUX_XBARB_ENABLED
 	help
 	  Enable the MCUX XBARB driver.
+
+config MCUX_XBAR
+	bool "MCUX XBAR driver"
+	depends on DT_HAS_NXP_MCUX_XBAR_ENABLED
+	help
+	  Enable the MCUX XBAR driver.
+
+config MCUX_XBAR_1
+	bool "MCUX XBAR_1 driver"
+	depends on DT_HAS_NXP_MCUX_XBAR_1_ENABLED
+	help
+	  Enable the MCUX XBAR_1 driver.

--- a/drivers/sensor/nxp/qdec_mcux/Kconfig
+++ b/drivers/sensor/nxp/qdec_mcux/Kconfig
@@ -1,11 +1,16 @@
 # Copyright (c) 2022, Prevas A/S
+# Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config QDEC_MCUX
 	bool "NXP QDEC MCUX driver"
 	default y
 	depends on DT_HAS_NXP_MCUX_QDEC_ENABLED
-	select MCUX_XBARA
+	# Add if condition to indicate not all of the following are required
+	select MCUX_XBAR if DT_HAS_NXP_MCUX_XBAR_ENABLED
+	select MCUX_XBAR_1 if DT_HAS_NXP_MCUX_XBAR_1_ENABLED
+	select MCUX_XBARA if DT_HAS_NXP_MCUX_XBARA_ENABLED
+	select MCUX_XBARB if DT_HAS_NXP_MCUX_XBARB_ENABLED
 	select PINCTRL
 	help
 	  Enable support for NXP MCUX Quadrature Encoder driver.

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -1155,20 +1155,20 @@
 		};
 
 		xbar1: xbar1@403bc000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbara";
 			reg = <0x403bc000 0x4000>;
 			interrupts = <116 0>, <117 0>;
 			status = "disabled";
 		};
 
 		xbar2: xbar2@403c0000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbarb";
 			reg = <0x403c0000 0x4000>;
 			status = "disabled";
 		};
 
 		xbar3: xbar3@403c4000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbarb";
 			reg = <0x403c4000 0x4000>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -684,6 +684,25 @@
 		};
 	};
 
+	xbar1: xbar1@2750000 {
+		compatible = "nxp,mcux-xbar-1";
+		reg = <0x2750000 0x4000>;
+		interrupts = <144 0>, <145 0>;
+		status = "disabled";
+	};
+
+	xbar2: xbar2@2760000 {
+		compatible = "nxp,mcux-xbar-1";
+		reg = <0x2760000 0x4000>;
+		status = "disabled";
+	};
+
+	xbar3: xbar3@2770000 {
+		compatible = "nxp,mcux-xbar-1";
+		reg = <0x2770000 0x4000>;
+		status = "disabled";
+	};
+
 	netc: ethernet {
 		compatible = "nxp,imx-netc";
 		#address-cells = <1>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -1219,20 +1219,20 @@
 		};
 
 		xbar1: xbar1@4003c000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbara";
 			reg = <0x4003c000 0x4000>;
 			interrupts = <143 0>, <144 0>;
 			status = "disabled";
 		};
 
 		xbar2: xbar2@40040000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbarb";
 			reg = <0x40040000 0x4000>;
 			status = "disabled";
 		};
 
 		xbar3: xbar3@40044000 {
-			compatible = "nxp,mcux-xbar";
+			compatible = "nxp,mcux-xbarb";
 			reg = <0x40044000 0x4000>;
 			status = "disabled";
 		};

--- a/dts/bindings/arm/nxp,mcux-xbar-1.yaml
+++ b/dts/bindings/arm/nxp,mcux-xbar-1.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: MCUX Inter-Peripheral Crossbar Switch 1 (XBAR_1)
+
+compatible: "nxp,mcux-xbar-1"
+
+include: nxp,mcux-xbar.yaml
+
+properties:
+
+  xbar-instance:
+    type: int
+    description: |
+      XBAR instance number. The desired values can be
+      found by searching for 'xbar_instance_t' enum in
+      modules/hal/nxp/mcux/mcux-sdk/devices/<device>/<device>_COMMON.h.
+    required: true
+
+  xbar-maps:
+    required: true

--- a/dts/bindings/arm/nxp,mcux-xbara.yaml
+++ b/dts/bindings/arm/nxp,mcux-xbara.yaml
@@ -1,0 +1,12 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: MCUX Inter-Peripheral Crossbar Switch A (XBARA)
+
+compatible: "nxp,mcux-xbara"
+
+include: nxp,mcux-xbar.yaml
+
+properties:
+  xbar-maps:
+    required: true

--- a/dts/bindings/arm/nxp,mcux-xbarb.yaml
+++ b/dts/bindings/arm/nxp,mcux-xbarb.yaml
@@ -1,0 +1,12 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: MCUX Inter-Peripheral Crossbar Switch B (XBARB)
+
+compatible: "nxp,mcux-xbarb"
+
+include: nxp,mcux-xbar.yaml
+
+properties:
+  xbar-maps:
+    required: true

--- a/include/zephyr/drivers/misc/nxp_xbar/nxp_xbar.h
+++ b/include/zephyr/drivers/misc/nxp_xbar/nxp_xbar.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_NXP_XBAR_H_
+#define ZEPHYR_DRIVERS_MISC_NXP_XBAR_H_
+
+#include <zephyr/devicetree.h>
+#include <string.h>
+
+/* Check which XBAR types are available */
+#define XBAR_AVAILABLE ( \
+	DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar) || \
+	DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbara) || \
+	DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbarb) || \
+	DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar_1))
+
+#if XBAR_AVAILABLE
+
+/* Include all available XBAR headers */
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar)
+#include <fsl_xbar.h>
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar_1)
+#include <fsl_xbar.h>
+#define XBAR_1_VARIANT
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbara)
+#include <fsl_xbara.h>
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbarb)
+#include <fsl_xbarb.h>
+#endif
+
+/**
+ * @brief Initialize XBAR peripheral based on compatible string
+ *
+ * @param compat Compatible string (e.g., "nxp,mcux-xbara")
+ * @param base Base address or instance number
+ */
+static inline void xbar_init_by_compat(const char *compat, uintptr_t base)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar)
+	if (strcmp(compat, "nxp,mcux-xbar") == 0) {
+		XBAR_Init((XBAR_Type *)base);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbara)
+	if (strcmp(compat, "nxp,mcux-xbara") == 0) {
+		XBARA_Init((XBARA_Type *)base);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbarb)
+	if (strcmp(compat, "nxp,mcux-xbarb") == 0) {
+		XBARB_Init((XBARB_Type *)base);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar_1)
+	if (strcmp(compat, "nxp,mcux-xbar-1") == 0) {
+		XBAR_Init((xbar_instance_t)base);
+		return;
+	}
+#endif
+}
+
+/**
+ * @brief Connect XBAR signals based on compatible string
+ *
+ * @param compat Compatible string
+ * @param base Base address or instance number
+ * @param input Input signal
+ * @param output Output signal
+ */
+static inline void xbar_connect_by_compat(const char *compat, uintptr_t base, uint32_t input,
+										uint32_t output)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar)
+	if (strcmp(compat, "nxp,mcux-xbar") == 0) {
+		XBAR_SetSignalsConnection((XBAR_Type *)base,
+								(xbar_input_signal_t)input,
+								(xbar_output_signal_t)output);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbara)
+	if (strcmp(compat, "nxp,mcux-xbara") == 0) {
+		XBARA_SetSignalsConnection((XBARA_Type *)base,
+								(xbar_input_signal_t)input,
+								(xbar_output_signal_t)output);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbarb)
+	if (strcmp(compat, "nxp,mcux-xbarb") == 0) {
+		XBARB_SetSignalsConnection((XBARB_Type *)base,
+								(xbar_input_signal_t)input,
+								(xbar_output_signal_t)output);
+		return;
+	}
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_mcux_xbar_1)
+	if (strcmp(compat, "nxp,mcux-xbar-1") == 0) {
+		/* XBAR_1 doesn't take base parameter */
+		XBAR_SetSignalsConnection((xbar_input_signal_t)input,
+								(xbar_output_signal_t)output);
+		return;
+	}
+#endif
+}
+
+/* Convenience macros */
+#define XBAR_INIT(compat, base) xbar_init_by_compat(compat, base)
+#define XBAR_CONNECT(compat, base, input, output) \
+	xbar_connect_by_compat(compat, base, input, output)
+
+
+/* Get XBAR compatible string from phandle */
+#define XBAR_COMPAT_STR(inst, xbar) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, xbar), \
+		((const char *)DT_PROP(DT_INST_PHANDLE(inst, xbar), compatible)), \
+		(NULL))
+
+/* Get XBAR base address or instance number */
+#ifdef XBAR_1_VARIANT
+/* XBAR_1 uses instance enum, not base address */
+#define XBAR_BASE(inst, xbar) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, xbar), \
+		(DT_PROP(DT_INST_PHANDLE(inst, xbar), xbar_instance)), \
+		(0))
+#else
+/* Other XBAR types use register base address */
+#define XBAR_BASE(inst, xbar) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, xbar), \
+		((uintptr_t)DT_REG_ADDR(DT_INST_PHANDLE(inst, xbar))), \
+		(0))
+#endif
+
+/* Get XBAR maps array */
+#define XBAR_MAPS(inst, xbar) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, xbar), \
+		(DT_PROP(DT_INST_PHANDLE(inst, xbar), xbar_maps)), \
+		(NULL))
+
+/* Get XBAR maps array length */
+#define XBAR_MAPS_LEN(inst, xbar) \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, xbar), \
+		(DT_PROP_LEN(DT_INST_PHANDLE(inst, xbar), xbar_maps)), \
+		(0))
+
+#endif /* XBAR_AVAILABLE */
+
+#endif /* ZEPHYR_DRIVERS_MISC_NXP_XBAR_H_ */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -122,6 +122,8 @@ set_variable_ifdef(CONFIG_MIPI_DSI_MCUX         CONFIG_MCUX_COMPONENT_driver.mip
 set_variable_ifdef(CONFIG_MIPI_DSI_MCUX_2L      CONFIG_MCUX_COMPONENT_driver.mipi_dsi)
 set_variable_ifdef(CONFIG_MIPI_DSI_NXP_DWC      CONFIG_MCUX_COMPONENT_driver.mipi_dsi_imx)
 set_variable_ifdef(CONFIG_MCUX_SDIF             CONFIG_MCUX_COMPONENT_driver.sdif)
+set_variable_ifdef(CONFIG_MCUX_XBAR             CONFIG_MCUX_COMPONENT_driver.xbar)
+set_variable_ifdef(CONFIG_MCUX_XBAR_1           CONFIG_MCUX_COMPONENT_driver.xbar_1)
 set_variable_ifdef(CONFIG_MCUX_XBARA            CONFIG_MCUX_COMPONENT_driver.xbara)
 set_variable_ifdef(CONFIG_MCUX_XBARB            CONFIG_MCUX_COMPONENT_driver.xbarb)
 set_variable_ifdef(CONFIG_QDEC_MCUX             CONFIG_MCUX_COMPONENT_driver.enc)


### PR DESCRIPTION
1. Add device tree binding files for nxp,mcux-xbar-1, nxp,mcux-xbara, nxp,mcux-xbarb and update device tree compatible

2. Provides a common interface(unified macros) for all XBAR variants (XBAR, XBAR_1,XBARA, XBARB)

3. Update the QDEC MCUX driver to use the new unified XBAR driver
    interface instead of directly using XBARA-specific APIs