### PR TITLE
drivers: mspi: refactor stm32 mspi max frequency handling

### DIFF
--- a/drivers/mspi/Kconfig.stm32
+++ b/drivers/mspi/Kconfig.stm32
@@ -25,16 +25,6 @@ config MSPI_STM32_BUFFER_ALIGNMENT
 	  in order for DMA to work correctly. This represents the alignment
 	  of buffers required in bytes.
 
-config MSPI_STM32_MAX_FREQ
-	int "MSPI max frequency"
-	default 250000000 if SOC_SERIES_STM32H5X
-	default 280000000 if SOC_SERIES_STM32H7X
-	default 160000000 if SOC_SERIES_STM32U5X
-	default 120000000 if SOC_SERIES_STM32L4X
-	default 110000000 if SOC_SERIES_STM32L5X
-	default 96000000  if SOC_SERIES_STM32U3X
-	default 250000000
-
 config MSPI_STM32_OSPI
 	bool "STM32 OSPI Controller driver"
 	depends on DT_HAS_ST_STM32_OSPI_CONTROLLER_ENABLED

--- a/drivers/mspi/mspi_stm32.h
+++ b/drivers/mspi/mspi_stm32.h
@@ -17,7 +17,6 @@
 #include "mspi_nor.h"
 
 #define MSPI_STM32_FIFO_THRESHOLD 4U
-#define MSPI_MAX_FREQ            CONFIG_MSPI_STM32_MAX_FREQ
 #define MSPI_MAX_DEVICE          1
 
 #if defined(CONFIG_SOC_SERIES_STM32U5X)
@@ -33,7 +32,6 @@
 #endif
 
 #define MSPI_STM32_WRITE_REG_MAX_TIME          40U
-#define MSPI_STM32_MAX_FREQ                    48000000
 
 typedef void (*irq_config_func_t)(void);
 

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -934,7 +934,7 @@ static int mspi_stm32_ospi_dev_cfg_save(const struct device *controller,
 	}
 
 	if ((param_mask & MSPI_DEVICE_CONFIG_FREQUENCY) != 0) {
-		if (dev_cfg->freq > MSPI_MAX_FREQ) {
+		if (dev_cfg->freq > cfg->mspicfg.max_freq) {
 			LOG_ERR("%u, freq is too large.", __LINE__);
 			return -ENOTSUP;
 		}
@@ -1393,7 +1393,7 @@ static __maybe_unused void mspi_stm32_ospi_dma_callback(const struct device *dev
 }
 #endif /* CONFIG_MSPI_DMA && !HAL_MDMA_MODULE_ENABLED */
 
-static int mspi_stm32_ospi_conf_validate(const struct mspi_cfg *config)
+static int mspi_stm32_ospi_conf_validate(const struct mspi_cfg *config, uint32_t max_frequency)
 {
 	/* Only Controller mode is supported */
 	if (config->op_mode != MSPI_OP_MODE_CONTROLLER) {
@@ -1402,7 +1402,7 @@ static int mspi_stm32_ospi_conf_validate(const struct mspi_cfg *config)
 	}
 
 	/* Check the max possible freq. */
-	if (config->max_freq > MSPI_STM32_MAX_FREQ) {
+	if (config->max_freq > max_frequency) {
 		LOG_ERR("Max_freq %d too large.", config->max_freq);
 		return -ENOTSUP;
 	}
@@ -1521,7 +1521,7 @@ static int mspi_stm32_ospi_config(const struct mspi_dt_spec *spec)
 	struct mspi_stm32_data *dev_data = spec->bus->data;
 	int ret = 0;
 
-	ret = mspi_stm32_ospi_conf_validate(config);
+	ret = mspi_stm32_ospi_conf_validate(config, dev_cfg->mspicfg.max_freq);
 	if (ret != 0) {
 		return ret;
 	}
@@ -1764,7 +1764,7 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 		.channel_num = 0,                                                                  \
 		.op_mode = DT_INST_ENUM_IDX_OR(index, op_mode, MSPI_OP_MODE_CONTROLLER),           \
 		.duplex = DT_INST_ENUM_IDX_OR(index, duplex, MSPI_HALF_DUPLEX),                    \
-		.max_freq = DT_INST_PROP_OR(index, mspi_max_frequency, MSPI_STM32_MAX_FREQ),       \
+		.max_freq = DT_INST_PROP(index, clock_frequency),                                  \
 		.dqs_support = DT_INST_PROP(index, dqs_support),                                   \
 		.num_periph = DT_INST_CHILD_NUM(index),                                            \
 		.sw_multi_periph = DT_INST_PROP(index, software_multiperipheral),                  \

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -995,44 +995,6 @@ static int mspi_stm32_ospi_dev_cfg_save(const struct device *controller,
 }
 
 /**
- * Verify if the device with dev_id is on this MSPI bus.
- *
- * @param controller Pointer to the device structure for the driver instance.
- * @param dev_id Pointer to the device ID structure from a device.
- * @return 0 The device is on this MSPI bus.
- * @return -ENODEV The device is not on this MSPI bus.
- */
-static int mspi_stm32_ospi_verify_device(const struct device *controller,
-						const struct mspi_dev_id *dev_id)
-{
-	const struct mspi_stm32_conf *cfg = controller->config;
-	int device_index = cfg->mspicfg.num_periph;
-
-	if (cfg->mspicfg.num_ce_gpios != 0) {
-		for (int i = 0; i < cfg->mspicfg.num_periph; i++) {
-			if (dev_id->ce.port == cfg->mspicfg.ce_group[i].port &&
-			    dev_id->ce.pin == cfg->mspicfg.ce_group[i].pin &&
-			    dev_id->ce.dt_flags == cfg->mspicfg.ce_group[i].dt_flags) {
-				device_index = i;
-				break;
-			}
-		}
-
-		if (device_index >= cfg->mspicfg.num_periph || device_index != dev_id->dev_idx) {
-			LOG_ERR("%u, invalid device ID.", __LINE__);
-			return -ENODEV;
-		}
-	} else {
-		if (dev_id->dev_idx >= cfg->mspicfg.num_periph) {
-			LOG_ERR("%u, invalid device ID.", __LINE__);
-			return -ENODEV;
-		}
-	}
-
-	return 0;
-}
-
-/**
  * API implementation of mspi_dev_config : controller device specific configuration
  *
  * @param controller Pointer to the device structure for the driver instance.

--- a/dts/bindings/mspi/st,stm32-ospi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-ospi-controller.yaml
@@ -133,3 +133,6 @@ properties:
       Note: You might need to enable the OCTOSPI I/O manager clock to use the
             property. Please refer to Reference Manual.
             The clock can be enabled in the devicetree.
+
+  clock-frequency:
+    required: true

--- a/dts/bindings/mspi/st,stm32-qspi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-qspi-controller.yaml
@@ -47,3 +47,6 @@ properties:
       Enables Sample Shifting half-cycle.
 
       It is recommended to be enabled in STR mode and disabled in DTR mode.
+
+  clock-frequency:
+    required: true

--- a/dts/bindings/mspi/st,stm32-xspi-controller.yaml
+++ b/dts/bindings/mspi/st,stm32-xspi-controller.yaml
@@ -39,3 +39,6 @@ properties:
       Enables Sample Shifting half-cycle.
 
       It is recommended to be enabled in STR mode and disabled in DTR mode.
+
+  clock-frequency:
+    required: true

--- a/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
@@ -22,6 +22,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB2_2, 8)>,
 				 <&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
 				 <&rcc STM32_CLOCK(AHB2, 21)>;
+			clock-frequency = <DT_FREQ_M(50)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			op-mode = "MSPI_OP_MODE_CONTROLLER";

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
@@ -21,9 +21,9 @@
 			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB4, 20U)>,
 				 <&rcc STM32_SRC_PLL1_Q OCTOSPI1_SEL(1)>;
+			clock-frequency = <DT_FREQ_M(50)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clock-frequency = <0x17d7840>;
 			op-mode = "MSPI_OP_MODE_CONTROLLER";
 			status = "okay";
 			pinctrl-0 = <&octospi1_io0_pb1 &octospi1_io1_pd12

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.overlay
@@ -20,6 +20,7 @@
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
+			clock-frequency = <DT_FREQ_M(50)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			op-mode = "MSPI_OP_MODE_CONTROLLER";


### PR DESCRIPTION
This PR refactors STM32 MSPI max frequency handling to rely on dts (clock_frequency property) instead of MSPI_STM32_MAX_FREQ Kconfig