### PR TITLE
drivers: modem: HL7800: TCP socket fixes

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3982,6 +3982,11 @@ static bool on_cmd_sock_notif(struct net_buf **buf, uint16_t len)
 		err = true;
 		sock->error = -ENOTCONN;
 		break;
+	case HL7800_TCP_CONN:
+		/* Connection failed/refused on this socket; do NOT drop network. */
+		err = true;
+		sock->error = -ECONNREFUSED;
+		break;
 	default:
 		iface_ctx.network_dropped = true;
 		err = true;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3425,7 +3425,10 @@ static void iface_status_work_cb(struct k_work *work)
 	if ((iface_ctx.iface && !net_if_is_up(iface_ctx.iface)) ||
 	    (iface_ctx.low_power_mode == HL7800_LPM_PSM && state == HL7800_OUT_OF_COVERAGE)) {
 		hl7800_stop_rssi_work();
+		/* Avoid deadlock: closing sockets can re-enter hl7800. */
+		hl7800_unlock();
 		notify_all_tcp_sockets_closed();
+		hl7800_lock();
 	} else if (iface_ctx.iface && net_if_is_up(iface_ctx.iface)) {
 		hl7800_start_rssi_work();
 		/* get IP address info */


### PR DESCRIPTION
Summary
 - Handle +K**P_NOTIF value 5 (HL7800_TCP_CONN) as a per-socket connection refusal.
 - Avoid potential deadlock by releasing the hl7800 lock before notify_all_tcp_sockets_closed().

Motivation / Problem
 1) TCP connect refused triggers +K**P_NOTIF <id>,5. The current handler falls through to default, marks network_dropped, and later closes all sockets, taking down unrelated connections (e.g., MQTT).
 2) iface_status_work_cb() calls notify_all_tcp_sockets_closed() while holding hl7800_lock(). The close-all path can re-enter hl7800 via socket callbacks, causing a lock inversion deadlock.

Solution
 - Treat HL7800_TCP_CONN as a per-socket error (-ECONNREFUSED) without dropping the network.
 - Drop hl7800_lock() before notify_all_tcp_sockets_closed() and re-acquire afterward.

Testing
 - Tested that other sockets remain open, connection is not dropped when one socket fails.
 - Tested that the deadlock no longer happens
 - Ran the patched driver in the field for 2 months.