### PR TITLE
drivers: ethernet: nxp: fix things regarding to multicast mac filtering

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -537,7 +537,7 @@ static int eth_nxp_s32_set_config(const struct device *dev,
 		break;
 #endif
 #if defined(CONFIG_ETH_NXP_S32_MULTICAST_FILTER)
-	case ETHERNET_HW_FILTERING:
+	case ETHERNET_CONFIG_TYPE_FILTER:
 		if (config->filter.set) {
 			Gmac_Ip_AddDstAddrToHashFilter(cfg->instance,
 						       config->filter.mac_address.addr);

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -575,7 +575,7 @@ enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev)
 	uint32_t caps;
 
 	caps = (ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE |
-		ETHERNET_HW_RX_CHKSUM_OFFLOAD | ETHERNET_HW_FILTERING
+		ETHERNET_HW_RX_CHKSUM_OFFLOAD
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
 #endif


### PR DESCRIPTION
eth_nxp_s32_gmac.c:

the enum ethernet_config_type for the
multicast filter is ETHERNET_CONFIG_TYPE_FILTER.
ETHERNET_HW_FILTERING is only the according
ethernet_hw_caps.

eth_nxp_imx_netc.c:

ETHERNET_CONFIG_TYPE_FILTER is not supported
in the set_config, therefore remove
ETHERNET_HW_FILTERING from the
ethernet_hw_caps of this driver.