### PR TITLE
boards: nxp: Fix NXP FRDM names in yaml

### DIFF
--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa153
-name: NXP FRDM MCXA153
+name: NXP FRDM-MCXA153
 type: mcu
 arch: arm
 ram: 24

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa156
-name: NXP FRDM MCXA156
+name: NXP FRDM-MCXA156
 type: mcu
 arch: arm
 ram: 128

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa344
-name: NXP FRDM MCXA344
+name: NXP FRDM-MCXA344
 type: mcu
 arch: arm
 ram: 48

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa577
-name: NXP FRDM MCXA577
+name: NXP FRDM-MCXA577
 type: mcu
 arch: arm
 ram: 640

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa266
-name: NXP FRDM MCXA266
+name: NXP FRDM-MCXA266
 type: mcu
 arch: arm
 ram: 240

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa346
-name: NXP FRDM MCXA346
+name: NXP FRDM-MCXA346
 type: mcu
 arch: arm
 ram: 240

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxa366
-name: NXP FRDM MCXA366
+name: NXP FRDM-MCXA366
 type: mcu
 arch: arm
 ram: 240

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: frdm_mcxe31b
-name: NXP FRDM MCXE31B
+name: NXP FRDM-MCXE31B
 type: mcu
 arch: arm
 ram: 288

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn236
-name: NXP FRDM MCXN236
+name: NXP FRDM-MCXN236
 type: mcu
 arch: arm
 ram: 256

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn947/mcxn947/cpu0
-name: NXP FRDM MCXN947 (CPU0)
+name: NXP FRDM-MCXN947 (CPU0)
 type: mcu
 arch: arm
 ram: 320

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn947/mcxn947/cpu0/ns
-name: NXP FRDM MCXN947 (CPU0) (Non-Secure)
+name: NXP FRDM-MCXN947 (CPU0) (Non-Secure)
 type: mcu
 arch: arm
 ram: 128

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn947/mcxn947/cpu0/qspi
-name: NXP FRDM MCXN947 QSPI (CPU0)
+name: NXP FRDM-MCXN947 QSPI (CPU0)
 type: mcu
 arch: arm
 ram: 320

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn947/mcxn947/cpu1
-name: NXP FRDM MCXN947 (CPU1)
+name: NXP FRDM-MCXN947 (CPU1)
 type: mcu
 arch: arm
 ram: 64

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxw71
-name: NXP FRDM_MCXW71
+name: NXP FRDM-MCXW71
 type: mcu
 arch: arm
 ram: 64

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
@@ -1,5 +1,5 @@
 identifier: frdm_mcxw72/mcxw727c/cpu0
-name: NXP FRDM_MCXW72
+name: NXP FRDM-MCXW72
 type: mcu
 arch: arm
 ram: 264

--- a/boards/nxp/frdm_rw612/board.yml
+++ b/boards/nxp/frdm_rw612/board.yml
@@ -1,6 +1,6 @@
 board:
   name: frdm_rw612
-  full_name: FRDM_RW612
+  full_name: FRDM-RW612
   vendor: nxp
   socs:
     - name: rw612

--- a/boards/nxp/frdm_rw612/frdm_rw612.yaml
+++ b/boards/nxp/frdm_rw612/frdm_rw612.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_rw612
-name: NXP FRDM_RW612
+name: NXP FRDM-RW612
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
- Fixes NXP FRDM names in yaml files.
- The '-' was missed for some NXP FRDM boards.
- It caused an inconsistent board list in MCUx-VSCode extension.