### PR TITLE
MAINTAINERS.yml: add maass-hamburg to i2c colaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1832,6 +1832,8 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - teburd
+  collaborators:
+    - maass-hamburg
   files:
     - drivers/i2c/
     - include/zephyr/drivers/i2c/


### PR DESCRIPTION
add me to the i2c collaborators, that we are going to
have at least 2 reviewers for that area.

I wrote the drivers/i2c/i2c_litex_litei2c.c driver and
the acording i2c core https://github.com/litex-hub/litei2c
