### PR TITLE
samples: sysbuild: hello_world: Skip test if no second UART

### DIFF
--- a/samples/sysbuild/hello_world/pytest/test_both_uart.py
+++ b/samples/sysbuild/hello_world/pytest/test_both_uart.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+import pytest
 from twister_harness import DeviceAdapter
 
 timeout = 5
@@ -16,4 +17,7 @@ def test_uart_in_app(dut: DeviceAdapter):
 
 def test_uart_in_second_core(dut: DeviceAdapter):
     """Verify logs from uart in second core"""
+    if len(dut.connections) < 2:
+        pytest.skip("Only one UART connection configured for this device")
+
     dut.readlines_until(connection_index=1, regex=regex, print_output=True, timeout=timeout)


### PR DESCRIPTION
If a second UART was not configured in the hardware map, then skip the testcase instead of failing.

To reproduce:
Generate hardware map:
`$ZEPHYR_BASE/scripts/twister --no-clean --generate-hardware-map ~/tmp/temp_hw.yaml`
Update platform and runner for APP core:
```
- baud: 115200
  connected: true
  flash_timeout: 60
  id: 00105XXXXXX
  platform: unknown
  product: J-Link
  runner: jlink
  serial: /dev/ttyACM0
- baud: 115200
  connected: true
  flash_timeout: 60
  id: 00105XXXXXXX
  platform: nrf54l15dk/nrf54l15/cpuapp
  product: J-Link
  runner: nrfutil
  serial: /dev/ttyACM1
```

Run test:
`$ZEPHYR_BASE/scripts/twister -vv -ll debug -T $ZEPHYR_BASE/samples/sysbuild/hello_world -s sample.sysbuild.hello_world.nrf54l15_cpuflpr --west-flash=--erase --device-testing --hardware-map ~/tmp/temp_hw.yaml --no-clean`
Received:
```
INFO    - 1/1 nrf54l15dk/nrf54l15/cpuapp sample.sysbuild.hello_world.nrf54l15_cpuflpr      PASSED (device: 001057793403, 2.844s <zephyr>)
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_app               PASSED      
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_second_core       PASSED 
```

When secnd UART is not provided:
cat ~/tmp/temp_hw.yaml
```
- baud: 115200
  connected: true
  flash_timeout: 60
  id: 00105XXXXXXX
  platform: nrf54l15dk/nrf54l15/cpuapp
  product: J-Link
  runner: nrfutil
  serial: /dev/ttyACM1
```
then `test_uart_in_second_core` fails:
```
INFO    - 1/1 nrf54l15dk/nrf54l15/cpuapp sample.sysbuild.hello_world.nrf54l15_cpuflpr      FAILED 1/2 pytest scenario(s) failed (device: 001057793403, 2.835s <zephyr>)
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_app               PASSED      
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_second_core       FAILED       twister_harness.exceptions.TwisterHarnessException: Connection index 1 is out of range.
```

With changes from that PR, test will be skipped:
```
INFO    - 1/1 nrf54l15dk/nrf54l15/cpuapp sample.sysbuild.hello_world.nrf54l15_cpuflpr      PASSED (device: 001057793403, 2.838s <zephyr>)
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_app               PASSED      
INFO    -                                    sample.sysbuild.hello_world.nrf54l15_cpuflpr.test_uart_in_second_core       SKIPPED      Only one UART connection configured for this device
```