### PR TITLE
net: net_if: remove obsolete documentation about buffer lifetime

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1348,7 +1348,6 @@ extern struct net_if_addr *net_if_addr_ref(struct net_if *iface,
  *
  * @param iface Pointer to a network interface structure
  * @param addr A pointer to a uint8_t buffer representing the address.
- *             The buffer must remain valid throughout interface lifetime.
  * @param len length of the address buffer
  * @param type network bearer type of this link address
  *


### PR DESCRIPTION
The `net_linkaddr` struct used to use pointers instead of copying the data. Thankfully this was fixed in
https://github.com/zephyrproject-rtos/zephyr/pull/87027.

Remove the old comment to reflect the current state.