### PR TITLE
drivers: intc: plic: Add features for simplifying AMP and future support of PIC64GX

### DIFF
--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -90,4 +90,10 @@ config PLIC_SHELL_IRQ_AFFINITY
 
 endif # PLIC_SHELL
 
+config PLIC_WARM_BOOT
+	bool "PLIC warm boot"
+	help
+	  Disable part of the initialisation in case of a warm boot, for example
+	  in case of Assymetric Multi Processing
+
 endif # PLIC

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -595,7 +595,9 @@ static int plic_init(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 	mem_addr_t en_addr, thres_prio_addr;
+#if !defined(CONFIG_PLIC_WARM_BOOT)
 	mem_addr_t prio_addr = config->prio;
+#endif
 
 	/* Iterate through each of the contexts, HART + PRIV */
 	for (uint32_t cpu_num = 0; cpu_num < arch_num_cpus(); cpu_num++) {
@@ -611,10 +613,12 @@ static int plic_init(const struct device *dev)
 		sys_write32(0U, thres_prio_addr);
 	}
 
+#if !defined(CONFIG_PLIC_WARM_BOOT)
 	/* Set priority of each interrupt line to 0 initially */
 	for (uint32_t i = 0; i < config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
+#endif
 
 	/* Configure IRQ for PLIC driver */
 	config->irq_config_func();

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -262,6 +262,23 @@ static void plic_irq_enable_set_state(uint32_t irq, bool enable)
 }
 
 /**
+ * @brief Clear a riscv PLIC-specific interrupt line
+ *
+ * This routine clear a RISCV PLIC-specific interrupt line.
+ * riscv_plic_irq_complete is called by RISCV_PRIVILEGED
+ *
+ * @param irq IRQ number to enable
+ */
+void riscv_plic_irq_complete(uint32_t irq)
+{
+	const struct device *dev = get_plic_dev_from_irq(irq);
+	const uint32_t local_irq = irq_from_level_2(irq);
+	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
+
+	sys_write32(local_irq, claim_complete_addr);
+}
+
+/**
  * @brief Enable a riscv PLIC-specific interrupt line
  *
  * This routine enables a RISCV PLIC-specific interrupt line.

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -15,6 +15,13 @@
 #include <zephyr/device.h>
 
 /**
+ * @brief Mark interrupt as completed
+ *
+ * @param irq IRQ number to claim as completed
+ */
+void riscv_plic_irq_complete(uint32_t irq);
+
+/**
  * @brief Enable interrupt
  *
  * @param irq Multi-level encoded interrupt ID

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -40,3 +40,6 @@ tests:
       - CONFIG_MP_MAX_NUM_CPUS=4
       - CONFIG_PLIC_IRQ_AFFINITY=y
       - CONFIG_PLIC_IRQ_AFFINITY_MASK=0xf
+  drivers.interrupt_controller.intc_plic.warm_boot.build:
+    extra_configs:
+      - CONFIG_PLIC_WARM_BOOT=y


### PR DESCRIPTION
@luphiax and I are working on porting the PIC64GX curiosity board to the latest version of Zephyr. We are working using [Microchip's fork](https://github.com/pic64gx/pic64gx-zephyr) as a reference (Zephyr 3.6).

We already have a first version working, and want to start contributing to upstream.

This first contribution pushes a few new features for the PLIC driver that are needed for AMP. Namely:

- New `riscv_plic_irq_complete` function to clear a pending interrupt line.
- New `PLIC_WARM_BOOT` configuration parameter that allows skipping the interrupt priority initialization to 0 (required when Linux is in charge of initializing the PLIC in AMP setups).