### PR TITLE
drivers: display: st7796s: Set default orientation in st7796 driver init

### DIFF
--- a/drivers/display/display_st7796s.h
+++ b/drivers/display/display_st7796s.h
@@ -43,5 +43,7 @@
 #define ST7796S_MADCTL_MH  BIT(2) /* Set horizontal refresh order */
 #define ST7796S_MADCTL_BGR BIT(3) /* Sets BGR color mode */
 
+/* Define a mask of all bits that control orientation */
+#define ST7796S_MADCTL_ORIENTATION_MASK (ST7796S_MADCTL_MX | ST7796S_MADCTL_MY | ST7796S_MADCTL_MV)
 
 #endif /* _ZEPHYR_DRIVERS_DISPLAY_ST7796S_H_ */


### PR DESCRIPTION
 Initialize device data and preserve MADCTL bits
  - Initialize default orientation to prevent random values in get_capabilities.
  - Correctly pass device data pointers in the ST7796S_INIT macro.
  - Use bitwise masks when updating orientation to preserve existing MADCTL settings. Refactoring follows up on commit 132ab06.