### PR TITLE
cmake: compiler: add warning_no_misleading_indentation flag

### DIFF
--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -140,6 +140,9 @@ set_property(TARGET asm PROPERTY imacros)
 # Compiler flag for disabling pointer arithmetic warnings
 set_compiler_property(PROPERTY warning_no_pointer_arithmetic)
 
+# Compiler flag for disabling misleading indentation warnings
+set_compiler_property(PROPERTY warning_no_misleading_indentation)
+
 # Compiler flags for disabling position independent code / executable
 set_compiler_property(PROPERTY no_position_independent)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -48,6 +48,8 @@ check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
 # Prohibit void pointer arithmetic. Illegal in C99
 check_set_compiler_property(APPEND PROPERTY warning_base -Wpointer-arith)
 
+check_set_compiler_property(PROPERTY warning_no_misleading_indentation -Wno-misleading-indentation)
+
 # not portable
 check_set_compiler_property(APPEND PROPERTY warning_base -Wexpansion-to-defined)
 

--- a/soc/nxp/imx/imx9/imx91/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx91/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-zephyr_compile_options(-Wno-misleading-indentation)
+
+zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warning_no_misleading_indentation>>)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warning_no_misleading_indentation>>)
 
 zephyr_include_directories(.)
 

--- a/soc/nxp/imx/imx9/imx943/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx943/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warning_no_misleading_indentation>>)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warning_no_misleading_indentation>>)
+
 zephyr_include_directories(.)
 
 if(CONFIG_SOC_MIMX94398_A55)


### PR DESCRIPTION
1. Add a new compiler property warning_no_misleading_indentation to allow disabling misleading indentation warnings. This is implemented for GCC with the -Wno-misleading-indentation flag.
2. Replace hardcoded -Wno-misleading-indentation flag with the new warning_no_misleading_indentation compiler property for both C and C++ compilation in imx91 and imx943 SoCs. This ensures compiler-agnostic handling of misleading indentation warnings.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/101182