### PR TITLE
drivers: sensor: ina2xx: remove redundant channel NULL checks

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
@@ -13,10 +13,6 @@ static int ina2xx_fetch_bus_voltage(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->voltage;
 		struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
 		return ina2xx_reg_read(&config->bus, ch->reg, data->voltage, sizeof(data->voltage));
 	}
 
@@ -29,10 +25,6 @@ static int ina2xx_fetch_shunt_voltage(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->vshunt;
 		struct ina2xx_data *data = dev->data;
-
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->vshunt, sizeof(data->vshunt));
 	}
@@ -47,10 +39,6 @@ static int ina2xx_fetch_current(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->current;
 		struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
 		return ina2xx_reg_read(&config->bus, ch->reg, data->current, sizeof(data->current));
 	}
 
@@ -64,10 +52,6 @@ static int ina2xx_fetch_power(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->power;
 		struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
 		return ina2xx_reg_read(&config->bus, ch->reg, data->power, sizeof(data->power));
 	}
 
@@ -80,10 +64,6 @@ static int ina2xx_fetch_die_temp(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->die_temp;
 		struct ina2xx_data *data = dev->data;
-
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->die_temp,
 			sizeof(data->die_temp));
@@ -99,10 +79,6 @@ static int ina2xx_fetch_energy(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->energy;
 		struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
 		return ina2xx_reg_read(&config->bus, ch->reg, data->energy, sizeof(data->energy));
 	}
 
@@ -115,10 +91,6 @@ static int ina2xx_fetch_charge(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->charge;
 		struct ina2xx_data *data = dev->data;
-
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->charge, sizeof(data->charge));
 	}

--- a/drivers/sensor/ti/ina2xx/ina2xx_get.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_get.c
@@ -20,10 +20,6 @@ static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value 
 		int32_t s32;
 	} value;
 
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
-
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
 		value.u32 = sys_get_be16(data->voltage) >> ch->shift;
@@ -50,10 +46,6 @@ static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_valu
 		uint32_t u32;
 		int32_t s32;
 	} value;
-
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
 
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
@@ -82,10 +74,6 @@ static int ina2xx_get_current(const struct device *dev, struct sensor_value *val
 		int32_t s32;
 	} value;
 
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
-
 	/* 16 or 20 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 2) {
 		value.u32 = sys_get_be16(data->current) >> ch->shift;
@@ -109,10 +97,6 @@ static int ina2xx_get_power(const struct device *dev, struct sensor_value *val)
 	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
 	uint64_t value;
-
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
 
 	/* 16 or 24 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 2) {
@@ -139,10 +123,6 @@ static int ina2xx_get_die_temp(const struct device *dev, struct sensor_value *va
 		int64_t s64;
 	} value;
 
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
-
 	/* 12 or 16 bit, two's complement. */
 	if (bytes == 2) {
 		value.u64 = sys_get_be16(data->die_temp) >> ch->shift;
@@ -163,10 +143,6 @@ static int ina2xx_get_energy(const struct device *dev, struct sensor_value *val)
 	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
 	uint64_t value;
-
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
 
 	/* 40 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 5) {
@@ -190,10 +166,6 @@ static int ina2xx_get_charge(const struct device *dev, struct sensor_value *val)
 		uint64_t u64;
 		int64_t s64;
 	} value;
-
-	if (ch == NULL) {
-		return -ENOTSUP;
-	}
 
 	/* 40 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 5) {


### PR DESCRIPTION
The INA2xx fetch and get helpers assumes valid channel descriptors for all
supported sensor channels.

NULL checks performed after channel data is accessed are ineffective
and misleading, as invalid channel definitions indicate a
configuration error rather than a runtime condition.

Remove the redundant checks and keep the channel handling consistent
with the driver expectations.

No functional change intended.