### PR TITLE
boards: xiao_esp32s3: Enable SPIRAM for camera support on Sense variant

### DIFF
--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense_defconfig
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense_defconfig
@@ -4,3 +4,13 @@ CONFIG_CONSOLE=y
 CONFIG_SERIAL=y
 CONFIG_UART_CONSOLE=y
 CONFIG_GPIO=y
+
+# Camera (OV2640) support requires external SPIRAM
+CONFIG_ESP_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+
+# Enable I2C for camera sensor communication
+CONFIG_I2C=y
+
+# Enable DMA for camera data transfer
+CONFIG_DMA=y


### PR DESCRIPTION
The XIAO ESP32S3 Sense variant includes an OV2640 camera sensor that requires significant memory for video frame buffers. Without SPIRAM enabled, video applications fail with DRAM overflow.

Enable SPIRAM in octal mode and include I2C/DMA drivers required for camera operation. This allows the video capture sample and camera-based applications to build and run successfully.

Tested with samples/drivers/video/capture showing successful video frame capture from the OV2640 sensor.