### PR TITLE
samples: fs: fs_sample: fix typo in board overlay files

### DIFF
--- a/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -19,7 +19,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		slot0_partition: parition@10000 {
+		slot0_partition: partition@10000 {
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 

--- a/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -19,7 +19,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		slot0_partition: parition@10000 {
+		slot0_partition: partition@10000 {
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 

--- a/samples/subsys/fs/fs_sample/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -18,7 +18,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		slot0_partition: parition@10000 {
+		slot0_partition: partition@10000 {
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 

--- a/samples/subsys/fs/fs_sample/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -19,7 +19,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		slot0_partition: parition@10000 {
+		slot0_partition: partition@10000 {
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
 


### PR DESCRIPTION
Fix a typo in several filesystem sample board overlay files where 'parition' was used instead of 'partition'.

This is a spelling-only change with no functional impact.