### PR TITLE
drivers: spi: Add STM32 SPI RTIO DMA support

### DIFF
--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -71,7 +71,12 @@ struct spi_stm32_data {
 #endif /* CONFIG_SPI_RTIO */
 	struct spi_context ctx;
 #ifdef CONFIG_SPI_STM32_DMA
+#if defined(CONFIG_SPI_RTIO)
+	struct k_timer tx_empty_timer;
+	const struct device *dev;
+#else
 	struct k_sem status_sem;
+#endif
 	volatile uint32_t status_flags;
 	struct stream dma_rx;
 	struct stream dma_tx;

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2023 Graphcore Ltd, All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h723zg.overlay
@@ -10,11 +10,23 @@
 	div-q = <8>;
 };
 
+&dmamux1 {
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
 /* Define PLL1_Q as SPI1 kernel clock source */
 &spi1 {
 	/delete-property/ clocks;
 	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
 		 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
+
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -38,6 +38,19 @@ tests:
       - xg29_rb4412a
     integration_platforms:
       - robokit1
+  drivers.spi.loopback.rtio_stm32_dma:
+    extra_configs:
+      - CONFIG_SPI_RTIO=y
+      - CONFIG_SPI_RTIO_FALLBACK_MSGS=5
+      - CONFIG_DMA=y
+      - CONFIG_SPI_STM32_DMA=y
+      - CONFIG_SPI_ASYNC=n
+    platform_allow:
+      - nucleo_h723zg
+      - nucleo_wb55rg
+    integration_platforms:
+      - nucleo_h723zg
+      - nucleo_wb55rg
   drivers.spi.mcux_dspi_dma.loopback:
     extra_args:
       - EXTRA_CONF_FILE="overlay-mcux-dspi-dma.conf"


### PR DESCRIPTION
Add support for using DMA when using SPI RTIO on stm32.

Creating this as a draft just to provide another view of the effort to add STM32 SPI+DMA RTIO support. See #101331 for the existing open PR for this same functionality, but I've noted several issues there with stability and with the design.

I've added testing as well for the `spi_loopback` test, but only on the two platforms I've validated locally. Would appreciate testing on additional platforms from others if possible.

I've also tested this with the EVAL-ADXL362-ARDZ shield and the `sensor_shell` sample with sensor streaming, to really stress test this, and it's working fine there as well. That needs #101912 in order to easily test it.