### PR TITLE
ci: Drop preemptible||preemptable spellcheck

### DIFF
--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -1194,7 +1194,6 @@ preceeding||preceding
 preceed||precede
 precendence||precedence
 precission||precision
-preemptable||preemptible
 prefered||preferred
 prefferably||preferably
 prefitler||prefilter


### PR DESCRIPTION
Preemptable and preemptible are both commonly used spellings. Infineon had chosen preemptable as the spelling and lead to CI failures when using struct members in the PDL. Removing the check in Zephyr allows for flexibility in spellings of this word.

Related PR where this showed up #101583