### PR TITLE
drivers: rtc: ds3231: drop impossible negative id check

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -608,7 +608,7 @@ static int rtc_ds3231_get_alarm_states(const struct device *dev, bool *states)
 static int rtc_ds3231_alarm_set_callback(const struct device *dev, uint16_t id,
 					 rtc_alarm_callback cb, void *user_data)
 {
-	if (id < 0 || id >= ALARM_COUNT) {
+	if (id >= ALARM_COUNT) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
rtc_ds3231_alarm_set_callback() takes an unsigned alarm id, making the negative value check impossible.

The id < 0 condition is therefore dead code and can never be true. Remove it and keep only the upper bound check.

No functional change intended.