### PR TITLE
boards: cy8ckit_041s_max: i2c support

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
@@ -17,4 +17,5 @@ supported:
   - gpio
   - clock_control
   - pinctrl
+  - i2c
 vendor: infineon


### PR DESCRIPTION
This enables I2C driver support for PSOC4-based boards including cy8ckit_041s_max.

This PR will be marked DRAFT until the following PR is merged:
- Depends on https://github.com/zephyrproject-rtos/zephyr/pull/100707

Also relates to https://github.com/zephyrproject-rtos/zephyr/pull/100823