### PR TITLE
Samples: bluetooth: a2dp_sink: Audio support for 1060EVKC

### DIFF
--- a/samples/bluetooth/classic/a2dp_sink/boards/mimxrt1060_evk_mimxrt1062_qspi_C.conf
+++ b/samples/bluetooth/classic/a2dp_sink/boards/mimxrt1060_evk_mimxrt1062_qspi_C.conf
@@ -1,0 +1,10 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I2S=y
+CONFIG_AUDIO=y
+CONFIG_AUDIO_CODEC=y
+CONFIG_DMA_TCD_QUEUE_SIZE=4

--- a/samples/bluetooth/classic/a2dp_sink/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/samples/bluetooth/classic/a2dp_sink/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sai1 {
+	mclk-output;
+	podf = <15>;
+	pll-clocks = <&anatop 0 0 0>,
+		     <&anatop 0 0 30>,
+		     <&anatop 0 0 1>,
+		     <&anatop 0 0 106>,
+		     <&anatop 0 0 1000>;
+};


### PR DESCRIPTION
Add codec driver overlay file to enable audio rendering for A2DP sink sample application for1060EVKC platform