### PR TITLE
Minor fixes for nRF CAN for cpuflpr core

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
@@ -9,12 +9,7 @@
 #include "nrf54h20dk_nrf54h20-pinctrl.dtsi"
 
 &hfxo {
-	status = "okay";
 	accuracy-ppm = <30>;
-};
-
-&lfxo {
-	status = "okay";
 };
 
 /* Get a node label for wi-fi spi to use in shield files */

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -322,6 +322,14 @@ zephyr_udc0: &usbhs {
 	pinctrl-names = "default";
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&lfxo {
+	status = "okay";
+};
+
 &pwm130 {
 	status = "okay";
 	pinctrl-0 = <&pwm130_default>;

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -95,6 +95,14 @@ slot1_partition: &cpurad_slot1_partition {
 	status = "okay";
 };
 
+&hfxo {
+	status = "okay";
+};
+
+&lfxo {
+	status = "okay";
+};
+
 &uart135 {
 	status = "okay";
 	memory-regions = <&cpurad_dma_region>;

--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
+#include <soc.h>
 
 /* nRF CAN wrapper offsets */
 #define CAN_TASKS_START	  offsetof(NRF_CAN_Type, TASKS_START)


### PR DESCRIPTION
Minor fixes to the nrf_can.c device driver and clock nodes for the nrf54h20dk to allow using the nRF CAN peripheral from the FLPR core.