### PR TITLE
drivers: display: sdl: add display orientation support

### DIFF
--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -166,7 +166,8 @@ int sdl_display_init_bottom(struct sdl_display_init_params *params)
 
 	SDL_SetRenderDrawColor(*params->renderer, 0, 0, 0, 0xFF);
 	SDL_RenderClear(*params->renderer);
-	SDL_RenderCopy(*params->renderer, *params->background_texture, NULL, NULL);
+	SDL_RenderCopyEx(*params->renderer, *params->background_texture, NULL, NULL,
+		params->angle, NULL, SDL_FLIP_NONE);
 	SDL_RenderPresent(*params->renderer);
 
 	return 0;
@@ -192,18 +193,21 @@ void sdl_display_write_bottom(const struct sdl_display_write_params *params)
 
 	if (params->display_on && !params->frame_incomplete) {
 		SDL_RenderClear(params->renderer);
-		SDL_RenderCopy(params->renderer, params->background_texture, NULL, NULL);
+		SDL_RenderCopyEx(params->renderer, params->background_texture, NULL,
+			NULL, params->angle, NULL, SDL_FLIP_NONE);
 		SDL_SetTextureColorMod(params->texture,
 				       (params->color_tint >> 16) & 0xff,
 				       (params->color_tint >> 8) & 0xff,
 				       params->color_tint & 0xff);
-		SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+		SDL_RenderCopyEx(params->renderer, params->texture, NULL, NULL,
+			params->angle, NULL, SDL_FLIP_NONE);
 		SDL_SetTextureColorMod(params->texture, 255, 255, 255);
 
 		/* Apply ellipse mask if enabled */
 		if (params->round_disp_mask != NULL) {
 			SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_MOD);
-			SDL_RenderCopy(params->renderer, params->round_disp_mask, NULL, NULL);
+			SDL_RenderCopyEx(params->renderer, params->round_disp_mask, NULL,
+				NULL, params->angle, NULL, SDL_FLIP_NONE);
 			SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_BLEND);
 		}
 
@@ -233,7 +237,8 @@ int sdl_display_read_bottom(const struct sdl_display_read_params *params)
 	SDL_SetTextureBlendMode(params->texture, SDL_BLENDMODE_NONE);
 
 	SDL_RenderClear(params->renderer);
-	SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+	SDL_RenderCopyEx(params->renderer, params->texture, NULL, NULL,
+		params->angle, NULL, SDL_FLIP_NONE);
 	SDL_RenderReadPixels(params->renderer, &rect, SDL_PIXELFORMAT_BGRA32, params->buf,
 			     params->width * 4);
 
@@ -248,16 +253,19 @@ int sdl_display_read_bottom(const struct sdl_display_read_params *params)
 void sdl_display_blanking_off_bottom(const struct sdl_display_blanking_off_params *params)
 {
 	SDL_RenderClear(params->renderer);
-	SDL_RenderCopy(params->renderer, params->background_texture, NULL, NULL);
+	SDL_RenderCopyEx(params->renderer, params->background_texture, NULL, NULL,
+		params->angle, NULL, SDL_FLIP_NONE);
 	SDL_SetTextureColorMod(params->texture, (params->color_tint >> 16) & 0xff,
 			       (params->color_tint >> 8) & 0xff, params->color_tint & 0xff);
-	SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+	SDL_RenderCopyEx(params->renderer, params->texture, NULL, NULL,
+		params->angle, NULL, SDL_FLIP_NONE);
 	SDL_SetTextureColorMod(params->texture, 255, 255, 255);
 
 	/* Apply ellipse mask if enabled */
 	if (params->round_disp_mask != NULL) {
 		SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_MOD);
-		SDL_RenderCopy(params->renderer, params->round_disp_mask, NULL, NULL);
+		SDL_RenderCopyEx(params->renderer, params->round_disp_mask, NULL, NULL,
+			params->angle, NULL, SDL_FLIP_NONE);
 		SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_BLEND);
 	}
 

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -38,6 +38,7 @@ struct sdl_display_init_params {
 	uint16_t transparency_grid_cell_size;
 	void **round_disp_mask;
 	uint32_t mask_color;
+	double angle;
 };
 
 struct sdl_display_write_params {
@@ -54,6 +55,7 @@ struct sdl_display_write_params {
 	bool frame_incomplete;
 	uint32_t color_tint;
 	void *round_disp_mask;
+	double angle;
 };
 
 struct sdl_display_read_params {
@@ -67,6 +69,7 @@ struct sdl_display_read_params {
 	void *mutex;
 	void *texture;
 	void *read_texture;
+	double angle;
 };
 
 struct sdl_display_blanking_off_params {
@@ -75,6 +78,7 @@ struct sdl_display_blanking_off_params {
 	void *background_texture;
 	uint32_t color_tint;
 	void *round_disp_mask;
+	double angle;
 };
 
 struct sdl_display_cleanup_params {


### PR DESCRIPTION
Add support for display orientation to the SDL display driver by implementing the set_orientation API.
It will rotate around the center point.