### PR TITLE
drivers: gpio: pca_series: fix GPIO_DISCONNECTED as not supported

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1024,6 +1024,10 @@ static int gpio_pca_series_pin_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if ((flags & (GPIO_INPUT | GPIO_OUTPUT)) == GPIO_DISCONNECTED) {
+		return -ENOTSUP;
+	}
+
 	if ((flags & GPIO_SINGLE_ENDED) &&
 		(cfg->part_cfg->flags & PCA_HAS_OUT_CONFIG) == 0U) {
 		return -ENOTSUP;


### PR DESCRIPTION
Configuring a pin with GPIO_DISCONNECTED currently
results in the pin being set as output due to a
fallthrough in the code. This is not supported by
the driver and should return -ENOTSUP instead.

This commit ensures that configuring GPIO_DISCONNECTED
is explicitly rejected and not applied to the hardware.

This is in line with the behavior of the gpio_pcal64xxa driver. 