### PR TITLE
dts: arm: microchip: pic32cx_sg: Adds support for pwm with tc peripheral

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -21,6 +21,13 @@
 		};
 	};
 
+	tc5_pwm_default: tc5_pwm_default {
+		group1 {
+			pinmux = <PB14E_TC5_WO0>,
+				 <PB15E_TC5_WO1>;
+		};
+	};
+
 	tcc0_pwm_default: tcc0_pwm_default {
 		group1 {
 			pinmux = <PC21F_TCC0_WO5>;

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -223,3 +223,13 @@
 	dma-names = "rx", "tx";
 	status = "okay";
 };
+
+&tc5 {
+	compatible = "microchip,tc-g1-pwm";
+	#pwm-cells = <3>;
+	pinctrl-0 = <&tc5_pwm_default>;
+	pinctrl-names = "default";
+	max-bit-width = <16>;
+	prescaler = <64>;
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -21,6 +21,13 @@
 		};
 	};
 
+	tc5_pwm_default: tc5_pwm_default {
+		group1 {
+			pinmux = <PB14E_TC5_WO0>,
+				 <PB15E_TC5_WO1>;
+		};
+	};
+
 	tcc0_pwm_default: tcc0_pwm_default {
 		group1 {
 			pinmux = <PC21F_TCC0_WO5>;

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -217,3 +217,13 @@
 	dma-names = "rx", "tx";
 	status = "okay";
 };
+
+&tc5 {
+	compatible = "microchip,tc-g1-pwm";
+	#pwm-cells = <3>;
+	pinctrl-0 = <&tc5_pwm_default>;
+	pinctrl-names = "default";
+	max-bit-width = <16>;
+	prescaler = <64>;
+	status = "okay";
+};

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -127,6 +127,33 @@
 			status = "disabled";
 		};
 
+		tc0: tc@40003800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x40003800 0x400>;
+			interrupts = <107 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_TC0>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC0>,
+				 <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_TC1>;
+			clock-names = "mclk", "gclk", "client_mclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc1: tc@40003c00 {
+			compatible = "microchip,tc-g1";
+			reg = <0x40003c00 0x400>;
+			interrupts = <108 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_TC1>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC1>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
 		nvmctrl: nvmctrl@41004000 {
 			compatible = "microchip,nvmctrl-g1-flash";
 			reg = <0x41004000 0x30>;
@@ -237,6 +264,33 @@
 			status = "disabled";
 		};
 
+		tc2: tc@4101a000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x4101a000 0x400>;
+			interrupts = <109 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_TC2>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC2>,
+				 <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_TC3>;
+			clock-names = "mclk", "gclk", "client_mclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc3: tc@4101c000 {
+			compatible = "microchip,tc-g1";
+			reg = <0x4101c000 0x400>;
+			interrupts = <110 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_TC3>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC3>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			prescaler = <1>;
+			channels = <2>;
+			status = "disabled";
+		};
+
 		tcc2: tcc@42000c00 {
 			compatible = "microchip,tcc-g1";
 			reg = <0x42000c00 0x2000>;
@@ -255,6 +309,30 @@
 			interrupts = <101 0>, <102 0>, <103 0>;
 			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TCC3>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC3>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc4: tc@42001400 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42001400 0x400>;
+			interrupts = <111 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC4>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc5: tc@42001800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x42001800 0x400>;
+			interrupts = <112 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TC5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC5>;
 			clock-names = "mclk", "gclk";
 			max-bit-width = <16>;
 			channels = <2>;

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_100.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_100.dtsi
@@ -31,6 +31,30 @@
 			clock-names = "mclk", "gclk";
 			status = "disabled";
 		};
+
+		tc6: tc@43001400 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001400 0x400>;
+			interrupts = <113 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC6>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc7: tc@43001800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001800 0x400>;
+			interrupts = <114 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC7>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_128.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_128.dtsi
@@ -31,6 +31,30 @@
 			clock-names = "mclk", "gclk";
 			status = "disabled";
 		};
+
+		tc6: tc@43001400 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001400 0x400>;
+			interrupts = <113 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC6>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
+
+		tc7: tc@43001800 {
+			compatible = "microchip,tc-g1";
+			reg = <0x43001800 0x400>;
+			interrupts = <114 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TC7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TC7>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/pwm/pwm_api/Kconfig
+++ b/tests/drivers/pwm/pwm_api/Kconfig
@@ -7,14 +7,14 @@ source "Kconfig.zephyr"
 
 config DEFAULT_PWM_PORT
 	int "Default PWM port/channel"
-	default 1 if PWM_STM32 || PWM_MCHP_G1_TCC || PWM_MCHP_G1_TC
+	default 1 if PWM_STM32 || PWM_MCHP_G1_TCC || PWM_MCHP_TC_G1
 	default 0
 	help
 	  PWM port matching the channel associated with PWM pin.
 
 config INVALID_PWM_PORT
 	int "Invalid PWM port/channel"
-	default 9 if PWM_NRFX || PWM_MCHP_G1_TCC || PWM_MCHP_G1_TC
+	default 9 if PWM_NRFX || PWM_MCHP_G1_TCC || PWM_MCHP_TC_G1
 	default -1
 	help
 	  Invalid PWM port/channel for negative testing.
@@ -38,7 +38,7 @@ config DEFAULT_PULSE_CYCLE
 config DEFAULT_PERIOD_NSEC
 	int "Default PWM period in nanoseconds"
 	default 4000000 if SOC_FAMILY_MCXW
-	default 546000 if PWM_MCHP_G1_TCC || PWM_MCHP_G1_TC
+	default 546000 if PWM_MCHP_G1_TCC
 	default 2000000
 	help
 	  Default PWM period in nanoseconds.
@@ -48,7 +48,7 @@ config DEFAULT_PULSE_NSEC
 	default 500000 if SOC_MK64F12 || SOC_MKW41Z4 || SOC_ESP32S2 || SOC_ESP32S3 || SOC_ESP32C3
 	default 500000 if PWM_INTEL_BLINKY
 	default 2000000 if SOC_FAMILY_MCXW
-	default 273000 if PWM_MCHP_G1_TCC || PWM_MCHP_G1_TC
+	default 273000 if PWM_MCHP_G1_TCC
 	default 1000000
 	help
 	  Default PWM pulse in nanoseconds.

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg41_cult_tc5.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg41_cult_tc5.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tc5;
+	};
+};
+
+&tcc0 {
+	status = "disabled";
+};
+
+&tc5 {
+	prescaler = <256>;
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -132,9 +132,12 @@ tests:
       - sam_e54_xpro
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tc5:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc5.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc5.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg41_cult_tc5.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tc6:
     extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc6.overlay"


### PR DESCRIPTION
- Adds tc nodes in the dts of pic32cx_sg
- Adds the support for pwm with tc peripheral by re-using pwm tc g1 driver.
- Adds test files for testing the same