### PR TITLE
MAINTAINERS: remove anangl as I2S maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1849,11 +1849,10 @@ Documentation Infrastructure:
     - drivers.i2c
 
 "Drivers: I2S":
-  status: maintained
-  maintainers:
-    - anangl
+  status: odd fixes
   collaborators:
     - TomasBarakNXP
+    - anangl
   files:
     - doc/hardware/peripherals/audio/i2s.rst
     - drivers/i2s/


### PR DESCRIPTION
I can no longer act as a maintainer in this area. Degrade my role to collaborator.