### PR TITLE
boards: microchip: pic32cx_sg : Add TCC nodes for counter for the boards

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -181,6 +181,13 @@
 	status = "okay";
 };
 
+&tcc1 {
+	compatible = "microchip,tcc-g1-counter";
+	max-bit-width = <24>;
+	prescaler = <8>;
+	status = "okay";
+};
+
 &porta {
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -12,6 +12,7 @@ ram: 256
 supported:
   - clock_control
   - comparator
+  - counter
   - dma
   - flash
   - gpio

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -175,6 +175,13 @@
 	status = "okay";
 };
 
+&tcc1 {
+	compatible = "microchip,tcc-g1-counter";
+	max-bit-width = <24>;
+	prescaler = <8>;
+	status = "okay";
+};
+
 &porta {
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -12,6 +12,7 @@ ram: 256
 supported:
   - clock_control
   - comparator
+  - counter
   - dma
   - flash
   - gpio

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -8,6 +8,7 @@ tests:
     platform_exclude:
       - nucleo_f302r8
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     timeout: 600
   drivers.counter.basic_api.nrf_zli:
     tags:
@@ -75,7 +76,10 @@ tests:
     tags:
       - drivers
       - counter
-    platform_allow: sam_e54_xpro
+    depends_on: counter
+    platform_allow:
+      - sam_e54_xpro
+      - pic32cx_sg41_cult
     timeout: 600
     extra_args:
       DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc2.overlay"


### PR DESCRIPTION
- Adds sample node in board files of pic32cx_sg61_cult and pic32cx_sg41_cult boards.
- Adds counter tag in the board yaml to trigger ci for testing.
- Adds the test files to validate the counter with tcc on pic32cx_sg41_cult board