### PR TITLE
samples: net: sockets: http_server: fix buffer undeclared error

### DIFF
--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -340,7 +340,7 @@ resource handler, which echoes received data back to the client:
         enum http_method method = client->method;
         static size_t processed;
 
-        __ASSERT_NO_MSG(buffer != NULL);
+        __ASSERT_NO_MSG(request_ctx->data != NULL);
 
         if (status == HTTP_SERVER_DATA_ABORTED) {
             LOG_DBG("Transaction aborted after %zd bytes.", processed);

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -87,7 +87,7 @@ static int echo_handler(struct http_client_ctx *client, enum http_data_status st
 		return 0;
 	}
 
-	__ASSERT_NO_MSG(buffer != NULL);
+	__ASSERT_NO_MSG(request_ctx->data != NULL);
 
 	processed += request_ctx->data_len;
 


### PR DESCRIPTION
Fix regression introduced in commit ddaeb13 which removed the 'buffer' function parameter from the dynamic endpoint callback function signature but did not update the http_server sample and docs accordingly.