### PR TITLE
Nordic: Drivers: Extend CONFIG_GEN_SW_ISR_TABLE=n support

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 #include <zephyr/irq.h>
 #include <zephyr/pm/device.h>
+#include <soc.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
@@ -594,12 +595,23 @@ void gpio_nrfx_gpiote_irq_handler(void const *param)
 }
 #endif
 
-#define GPIOTE_IRQ_HANDLER_CONNECT(node_id)		\
-	IRQ_CONNECT(DT_IRQN(node_id),			\
-		    DT_IRQ(node_id, priority),		\
-		    gpio_nrfx_gpiote_irq_handler,       \
-		    &GPIOTE_NRFX_INST_BY_NODE(node_id), \
-		    0);
+#define GPIOTE_IRQ_HANDLER_CONNECT(node_id)							\
+	NRF_DT_IRQ_CONNECT(									\
+		node_id,									\
+		gpio_nrfx_gpiote_irq_handler,							\
+		&GPIOTE_NRFX_INST_BY_NODE(node_id)						\
+	)
+
+#define GPIOTE_IRQ_DIRECT_DEFINE(node_id)							\
+	NRF_DT_IRQ_DIRECT_DEFINE(								\
+		node_id,									\
+		gpio_nrfx_gpiote_irq_handler,							\
+		&GPIOTE_NRFX_INST_BY_NODE(node_id)						\
+	)
+
+#ifdef CONFIG_GPIO_NRFX_INTERRUPT
+	DT_FOREACH_STATUS_OKAY(nordic_nrf_gpiote, GPIOTE_IRQ_DIRECT_DEFINE);
+#endif /* CONFIG_GPIO_NRFX_INTERRUPT */
 
 static int gpio_nrfx_pm_hook(const struct device *port, enum pm_device_action action)
 {

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -281,12 +281,20 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 		     "Wrong I2C " #inst " frequency setting in dts");			      \
 	static struct i2c_nrfx_twim_data twim_##inst##_data;				      \
 	static struct i2c_nrfx_twim_common_config twim_##inst##z_config;		      \
+	NRF_DT_INST_IRQ_DIRECT_DEFINE(							      \
+		inst,									      \
+		nrfx_twim_irq_handler,							      \
+		&CONCAT(twim_, inst, _data.twim)					      \
+	)										      \
 	static void pre_init##inst(void)						      \
 	{										      \
 		twim_##inst##z_config.twim = &twim_##inst##_data.twim;			      \
 		twim_##inst##_data.twim.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst);     \
-		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority),		      \
-			    nrfx_twim_irq_handler, &twim_##inst##_data.twim, 0);	      \
+		NRF_DT_INST_IRQ_CONNECT(						      \
+			inst,								      \
+			nrfx_twim_irq_handler,						      \
+			&CONCAT(twim_, inst, _data.twim)				      \
+		)									      \
 	}										      \
 	IF_ENABLED(USES_MSG_BUF(inst),							      \
 		(static uint8_t twim_##inst##_msg_buf[MSG_BUF_SIZE(inst)]		      \

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -253,11 +253,19 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 				.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst),		\
 			},									\
 	};											\
+	NRF_DT_INST_IRQ_DIRECT_DEFINE(								\
+		inst,										\
+		nrfx_twim_irq_handler,								\
+		&CONCAT(twim_, inst, z_data.twim)						\
+	)											\
 	static void pre_init##inst(void)							\
 	{											\
 		twim_##inst##z_data.twim.p_twim = (NRF_TWIM_Type *)DT_INST_REG_ADDR(inst);	\
-		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority),			\
-			    nrfx_twim_irq_handler, &twim_##inst##z_data.twim, 0);		\
+		NRF_DT_INST_IRQ_CONNECT(							\
+			inst,									\
+			nrfx_twim_irq_handler,							\
+			&CONCAT(twim_, inst, z_data.twim)					\
+		)										\
 	}											\
 	IF_ENABLED(USES_MSG_BUF(inst), (MSG_BUF_DEFINE(inst);))					\
 	I2C_RTIO_DEFINE(_i2c##inst##_twim_rtio,							\

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -312,11 +312,21 @@ static int shim_nrf_twis_deinit(const struct device *dev)
 #define SHIM_NRF_TWIS_DEVICE_DEFINE(id)                                                            \
 	static struct shim_nrf_twis_data SHIM_NRF_TWIS_NAME(id, data);                             \
 	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(DT_DRV_INST(id));                            \
+                                                                                                   \
+	NRF_DT_INST_IRQ_DIRECT_DEFINE(                                                             \
+		id,                                                                                \
+		nrfx_twis_irq_handler,                                                             \
+		&SHIM_NRF_TWIS_NAME(id, data).twis                                                 \
+	)                                                                                          \
+                                                                                                   \
 	static void SHIM_NRF_TWIS_NAME(id, pre_init)(void)                                         \
 	{                                                                                          \
 		SHIM_NRF_TWIS_NAME(id, data).twis.p_reg = (NRF_TWIS_Type *)DT_INST_REG_ADDR(id);   \
-		IRQ_CONNECT(DT_INST_IRQN(id), DT_INST_IRQ(id, priority), nrfx_twis_irq_handler,    \
-			    &SHIM_NRF_TWIS_NAME(id, data).twis, 0);                                \
+		NRF_DT_INST_IRQ_CONNECT(                                                           \
+			id,                                                                        \
+			nrfx_twis_irq_handler,                                                     \
+			&SHIM_NRF_TWIS_NAME(id, data).twis                                         \
+		)                                                                                  \
 	}                                                                                          \
                                                                                                    \
 	static void SHIM_NRF_TWIS_NAME(id, event_handler)(nrfx_twis_event_t const *event)          \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -624,10 +624,18 @@ static int spi_nrfx_deinit(const struct device *dev)
 		.dev  = DEVICE_DT_GET(DT_DRV_INST(inst)),		       \
 		.busy = false,						       \
 	};								       \
+	NRF_DT_INST_IRQ_DIRECT_DEFINE(					       \
+		inst,							       \
+		nrfx_spim_irq_handler,					       \
+		&CONCAT(spi_, inst, _data.spim)				       \
+	)								       \
 	static void irq_connect##inst(void)				       \
 	{								       \
-		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority),   \
-			nrfx_spim_irq_handler, &spi_##inst##_data.spim, 0);    \
+		NRF_DT_INST_IRQ_CONNECT(				       \
+			inst,						       \
+			nrfx_spim_irq_handler,				       \
+			&CONCAT(spi_, inst, _data.spim)			       \
+		);							       \
 	}								       \
 	PINCTRL_DT_INST_DEFINE(inst);					       \
 	static const struct spi_nrfx_config spi_##inst##z_config = {	       \

--- a/soc/nordic/common/soc_nrf_common.h
+++ b/soc/nordic/common/soc_nrf_common.h
@@ -324,6 +324,64 @@
 		(0)										\
 	)
 
+/**
+ * @brief Utility macro to declare and define direct IRQ if required
+ *
+ * @param node_id Devicetree node identifier
+ * @param handler IRQ handler
+ * @param param Parameter passed to IRQ handler
+ */
+#define NRF_DT_IRQ_DIRECT_DEFINE(node_id, handler, param)					\
+	COND_CODE_1(										\
+		CONFIG_GEN_SW_ISR_TABLE,							\
+		(),										\
+		(										\
+			ISR_DIRECT_DECLARE(CONCAT(handler, _, DT_DEP_ORD(node_id)))		\
+			{									\
+				handler(param);							\
+				ISR_DIRECT_PM();						\
+				return 1;							\
+			}									\
+		)										\
+	)
+
+/** Device driver instance variant of NRF_DT_IRQ_DIRECT_DEFINE() */
+#define NRF_DT_INST_IRQ_DIRECT_DEFINE(inst, handler, param) \
+	NRF_DT_IRQ_DIRECT_DEFINE(DT_DRV_INST(inst), handler, param)
+
+/**
+ * @brief Utility macro to connect IRQ handler
+ *
+ * @param node_id Devicetree node identifier
+ * @param handler IRQ handler
+ * @param param Parameter passed to IRQ handler
+ */
+#define NRF_DT_IRQ_CONNECT(node_id, handler, param)						\
+	COND_CODE_1(										\
+		CONFIG_GEN_SW_ISR_TABLE,							\
+		(										\
+			IRQ_CONNECT(								\
+				DT_IRQN(node_id),						\
+				DT_IRQ(node_id, priority),					\
+				handler,							\
+				param,								\
+				0								\
+			)									\
+		),										\
+		(										\
+			IRQ_DIRECT_CONNECT(							\
+				DT_IRQN(node_id),						\
+				DT_IRQ(node_id, priority),					\
+				CONCAT(handler, _, DT_DEP_ORD(node_id)),			\
+				0								\
+			)									\
+		)										\
+	)
+
+/** Device driver instance variant of NRF_DT_IRQ_DIRECT_DEFINE() */
+#define NRF_DT_INST_IRQ_CONNECT(inst, handler, param) \
+	NRF_DT_IRQ_CONNECT(DT_DRV_INST(inst), handler, param)
+
 #endif /* !_ASMLANGUAGE */
 
 #endif


### PR DESCRIPTION
`CONFIG_GEN_SW_ISR_TABLE` is being used commonly for cpuflpr and cpuppr builds on nordic chips, and even for cpuapp in some cases to save ROM, since all of our hardware supports it.

Add utility macros for Nordic SoCs to remove some boilerplate code from drivers, and extend some drivers which are commonly used for cpuflpr and cpuppr.