### PR TITLE
drivers: pinctrl: mspm0: Add validation for pin configurations

### DIFF
--- a/drivers/pinctrl/pinctrl_mspm0.c
+++ b/drivers/pinctrl/pinctrl_mspm0.c
@@ -6,7 +6,10 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
 #include <ti/driverlib/dl_gpio.h>
+
+LOG_MODULE_REGISTER(pinctrl_mspm0, CONFIG_PINCTRL_LOG_LEVEL);
 
 #define DT_DRV_COMPAT ti_mspm0_pinctrl
 
@@ -27,6 +30,15 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins,
 		pin_cm = MSPM0_PINCM(pins[i].pinmux);
 		pin_function = MSPM0_PIN_FUNCTION(pins[i].pinmux);
 		iomux = pins[i].iomux;
+
+		/* Check for invalid pull-up/pull-down configuration */
+		if (((iomux >> MSP_GPIO_RESISTOR_PULL_UP) & 0x1) &&
+		    ((iomux >> MSP_GPIO_RESISTOR_PULL_DOWN) & 0x1)) {
+			LOG_ERR("Pin CM%d: Cannot enable both pull-up and pull-down "
+				"simultaneously", pin_cm);
+			return -EINVAL;
+		}
+
 		if (pin_function == 0x00) {
 			DL_GPIO_initPeripheralAnalogFunction(pin_cm);
 		} else {


### PR DESCRIPTION
This PR improves the MSPM0 pinctrl driver by adding validation for GPIO pin configurations to prevent invalid hardware states.

### Changes
- Add validation to prevent simultaneous pull-up and pull-down configurations
- Add error logging for invalid configurations using Zephyr's logging subsystem
- Add necessary header includes for kernel error codes and logging