### PR TITLE
drivers: nrf: use NRF_ERRATA_DYNAMIC_CHECK macros

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -252,7 +252,7 @@ static void clkstarted_handle(const struct device *dev,
 			      enum clock_control_nrf_type type)
 {
 #if CONFIG_CLOCK_CONTROL_NRF_HFINT_CALIBRATION
-	if (nrf54l_errata_30() && (type == CLOCK_CONTROL_NRF_TYPE_HFCLK)) {
+	if (NRF_ERRATA_DYNAMIC_CHECK(54L, 30) && (type == CLOCK_CONTROL_NRF_TYPE_HFCLK)) {
 		nrf54l_errata_30_workaround();
 	}
 #endif

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -261,7 +261,7 @@ static inline void qspi_clock_div_change(const struct device *dev)
 #if NRF53_ERRATA_159_ENABLE_WORKAROUND
 	struct qspi_nor_data *dev_data = dev->data;
 
-	if (nrf53_errata_159()) {
+	if (NRF_ERRATA_DYNAMIC_CHECK(53, 159)) {
 		/* Save current hfclk configuration */
 		dev_data->prev_hclk_div = nrf_clock_hfclk_div_get(NRF_CLOCK);
 		nrf_clock_hfclk_div_set(NRF_CLOCK, NRF_CLOCK_HFCLK_DIV_2);
@@ -285,7 +285,7 @@ static inline void qspi_clock_div_restore(const struct device *dev)
 #if NRF53_ERRATA_159_ENABLE_WORKAROUND
 	struct qspi_nor_data *dev_data = dev->data;
 
-	if (nrf53_errata_159()) {
+	if (NRF_ERRATA_DYNAMIC_CHECK(53, 159)) {
 		/* Restore previous hfclk configuration */
 		nrf_clock_hfclk_div_set(NRF_CLOCK, dev_data->prev_hclk_div);
 	}
@@ -1054,7 +1054,7 @@ static int qspi_init(const struct device *dev)
 	}
 
 #if DT_INST_NODE_HAS_PROP(0, rx_delay)
-	if (!nrf53_errata_121()) {
+	if (!NRF_ERRATA_DYNAMIC_CHECK(53, 121)) {
 		nrf_qspi_iftiming_set(NRF_QSPI, DT_INST_PROP(0, rx_delay));
 	}
 #endif

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -555,7 +555,7 @@ static bool pofcon_enabled;
 
 static int suspend_pofwarn(void)
 {
-	if (!nrf52_errata_242()) {
+	if (!NRF_ERRATA_DYNAMIC_CHECK(52, 242)) {
 		return 0;
 	}
 


### PR DESCRIPTION
It is now the proper way of checking whether an anomaly workaround should be performed.