### PR TITLE
mgmt: mcumgr: Refactor callback header, Kconfig and CMake files 

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
@@ -20,6 +20,17 @@ extern "C" {
  */
 
 /**
+ * MGMT event opcodes for enumeration management group.
+ */
+enum enum_mgmt_group_events {
+	/** Callback when fetching details on supported command groups. */
+	MGMT_EVT_OP_ENUM_MGMT_DETAILS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_ENUM, 0),
+
+	/** Used to enable all enum_mgmt_group events. */
+	MGMT_EVT_OP_ENUM_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_ENUM),
+};
+
+/**
  * Structure provided in the #MGMT_EVT_OP_ENUM_MGMT_DETAILS notification callback: This callback
  * function is called once per command group when the detail command is used, it can be used to
  * return additional information/fields in the response.

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -20,6 +20,20 @@ extern "C" {
  * @{
  */
 
+/**
+ * MGMT event opcodes for filesystem management group.
+ */
+enum fs_mgmt_group_events {
+	/** Callback when a file has been accessed, data is @ref fs_mgmt_file_access. */
+	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 0),
+
+	/** Callback when a file upload/download is finished, data is @ref fs_mgmt_file_access. */
+	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS_DONE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 1),
+
+	/** Used to enable all fs_mgmt_group events. */
+	MGMT_EVT_OP_FS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_FS),
+};
+
 /** The type of operation that is being requested for a given file access callback. */
 enum fs_mgmt_file_access_types {
 	/** Access to read file (file download). */

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
@@ -29,6 +29,50 @@ struct img_mgmt_upload_req;
  */
 
 /**
+ * MGMT event opcodes for image management group.
+ */
+enum img_mgmt_group_events {
+	/** Callback when a client sends a file upload chunk, data is @ref img_mgmt_upload_check. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
+
+	/** Callback when a DFU operation is stopped. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 1),
+
+	/** Callback when a DFU operation is started. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_STARTED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 2),
+
+	/** Callback when a DFU operation has finished being transferred. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
+
+	/** Callback when an image has been confirmed. data is @ref img_mgmt_image_confirmed. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
+
+	/** Callback when an image write command has finished writing to flash. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK_WRITE_COMPLETE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 5),
+
+	/**
+	 * Callback when an image slot's state is encoded for a response, data is
+	 * @ref img_mgmt_state_slot_encode.
+	 */
+	MGMT_EVT_OP_IMG_MGMT_IMAGE_SLOT_STATE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 6),
+
+	/**
+	 * Callback when a slot list command outputs fields for an image, data is
+	 * @ref img_mgmt_slot_info_image.
+	 */
+	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_IMAGE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 7),
+
+	/**
+	 * Callback when a slot list command outputs fields for a slot of an image, data is
+	 * @ref img_mgmt_slot_info_slot.
+	 */
+	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_SLOT		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 8),
+
+	/** Used to enable all img_mgmt_group events. */
+	MGMT_EVT_OP_IMG_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
+};
+
+/**
  * Structure provided in the #MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK notification callback: This callback
  * function is used to notify the application about a pending firmware upload packet from a client
  * and authorise or deny it. Upload will be allowed so long as all notification handlers return

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -20,6 +20,35 @@ extern "C" {
  */
 
 /**
+ * MGMT event opcodes for operating system management group.
+ */
+enum os_mgmt_group_events {
+	/** Callback when a reset command has been received, data is @ref os_mgmt_reset_data. */
+	MGMT_EVT_OP_OS_MGMT_RESET		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 0),
+
+	/** Callback when an info command is processed, data is @ref os_mgmt_info_check. */
+	MGMT_EVT_OP_OS_MGMT_INFO_CHECK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 1),
+
+	/** Callback when an info command needs to output data, data is @ref os_mgmt_info_append. */
+	MGMT_EVT_OP_OS_MGMT_INFO_APPEND		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 2),
+
+	/** Callback when a datetime get command has been received. */
+	MGMT_EVT_OP_OS_MGMT_DATETIME_GET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 3),
+
+	/** Callback when a datetime set command has been received, data is @ref rtc_time. */
+	MGMT_EVT_OP_OS_MGMT_DATETIME_SET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 4),
+
+	/**
+	 * Callback when a bootloader info command has been received, data is
+	 * os_mgmt_bootloader_info_data().
+	 */
+	MGMT_EVT_OP_OS_MGMT_BOOTLOADER_INFO	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 5),
+
+	/** Used to enable all os_mgmt_group events. */
+	MGMT_EVT_OP_OS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_OS),
+};
+
+/**
  * Structure provided in the #MGMT_EVT_OP_OS_MGMT_RESET notification callback: This callback
  * function is used to notify the application about a pending device reboot request and to
  * authorise or deny it.

--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
@@ -20,6 +20,17 @@ extern "C" {
  */
 
 /**
+ * MGMT event opcodes for settings management group.
+ */
+enum settings_mgmt_group_events {
+	/** Callback when a setting is read/written/deleted. */
+	MGMT_EVT_OP_SETTINGS_MGMT_ACCESS	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SETTINGS, 0),
+
+	/** Used to enable all settings_mgmt_group events. */
+	MGMT_EVT_OP_SETTINGS_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_SETTINGS),
+};
+
+/**
  * @name Settings access types
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/mgmt/callback_defines.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callback_defines.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_MCUMGR_CALLBACK_DEFINES_
+#define H_MCUMGR_CALLBACK_DEFINES_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MCUmgr Callback API
+ * @defgroup mcumgr_callback_api Callbacks
+ * @ingroup mcumgr
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+/** Event which signifies that all event IDs for a particular group should be enabled. */
+#define MGMT_EVT_OP_ID_ALL 0xffff
+
+/** Get event for a particular group and event ID. */
+#define MGMT_DEF_EVT_OP_ID(group, event_id) ((group << 16) | BIT(event_id))
+
+/** Get event used for enabling all event IDs of a particular group. */
+#define MGMT_DEF_EVT_OP_ALL(group) ((group << 16) | MGMT_EVT_OP_ID_ALL)
+/** @endcond  */
+
+/** Get group from event. */
+#define MGMT_EVT_GET_GROUP(event) ((event >> 16) & MGMT_EVT_OP_ID_ALL)
+
+/** Get event ID from event. */
+#define MGMT_EVT_GET_ID(event) (event & MGMT_EVT_OP_ID_ALL)
+
+/**
+ * MGMT event callback return value.
+ */
+enum mgmt_cb_return {
+	/** No error. */
+	MGMT_CB_OK,
+
+	/** SMP protocol error and ``err_rc`` contains the #mcumgr_err_t error code. */
+	MGMT_CB_ERROR_RC,
+
+	/**
+	 * Group (application-level) error and ``err_group`` contains the group ID that caused
+	 * the error and ``err_rc`` contains the error code of that group to return.
+	 */
+	MGMT_CB_ERROR_ERR,
+};
+
+/**
+ * MGMT event callback group IDs. Note that this is not a 1:1 mapping with #mcumgr_group_t values.
+ */
+enum mgmt_cb_groups {
+	MGMT_EVT_GRP_ALL			= 0,
+	MGMT_EVT_GRP_SMP,
+	MGMT_EVT_GRP_OS,
+	MGMT_EVT_GRP_IMG,
+	MGMT_EVT_GRP_FS,
+	MGMT_EVT_GRP_SETTINGS,
+	MGMT_EVT_GRP_ENUM,
+
+	MGMT_EVT_GRP_USER_CUSTOM_START		= MGMT_GROUP_ID_PERUSER,
+};
+
+/**
+ * MGMT event opcodes for all command processing.
+ */
+enum smp_all_events {
+	/** Used to enable all events. */
+	MGMT_EVT_OP_ALL				= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_ALL),
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_MCUMGR_CALLBACK_DEFINES_ */

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,24 +10,25 @@
 #include <inttypes.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
+#include "callback_defines.h"
 
-#ifdef CONFIG_MCUMGR_GRP_FS
+#if defined(CONFIG_MCUMGR_GRP_FS) || defined(__DOXYGEN__)
 #include <zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_GRP_IMG
+#if defined(CONFIG_MCUMGR_GRP_IMG) || defined(__DOXYGEN__)
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_GRP_OS
+#if defined(CONFIG_MCUMGR_GRP_OS) || defined(__DOXYGEN__)
 #include <zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_GRP_SETTINGS
+#if defined(CONFIG_MCUMGR_GRP_SETTINGS) || defined(__DOXYGEN__)
 #include <zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_GRP_ENUM
+#if defined(CONFIG_MCUMGR_GRP_ENUM) || defined(__DOXYGEN__)
 #include <zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h>
 #endif
 
@@ -41,40 +42,6 @@ extern "C" {
  * @ingroup mcumgr
  * @{
  */
-
-/** @cond INTERNAL_HIDDEN */
-/** Event which signifies that all event IDs for a particular group should be enabled. */
-#define MGMT_EVT_OP_ID_ALL 0xffff
-
-/** Get event for a particular group and event ID. */
-#define MGMT_DEF_EVT_OP_ID(group, event_id) ((group << 16) | BIT(event_id))
-
-/** Get event used for enabling all event IDs of a particular group. */
-#define MGMT_DEF_EVT_OP_ALL(group) ((group << 16) | MGMT_EVT_OP_ID_ALL)
-/** @endcond  */
-
-/** Get group from event. */
-#define MGMT_EVT_GET_GROUP(event) ((event >> 16) & MGMT_EVT_OP_ID_ALL)
-
-/** Get event ID from event. */
-#define MGMT_EVT_GET_ID(event) (event & MGMT_EVT_OP_ID_ALL)
-
-/**
- * MGMT event callback return value.
- */
-enum mgmt_cb_return {
-	/** No error. */
-	MGMT_CB_OK,
-
-	/** SMP protocol error and ``err_rc`` contains the #mcumgr_err_t error code. */
-	MGMT_CB_ERROR_RC,
-
-	/**
-	 * Group (application-level) error and ``err_group`` contains the group ID that caused
-	 * the error and ``err_rc`` contains the error code of that group to return.
-	 */
-	MGMT_CB_ERROR_ERR,
-};
 
 /**
  * @typedef mgmt_cb
@@ -110,29 +77,6 @@ typedef enum mgmt_cb_return (*mgmt_cb)(uint32_t event, enum mgmt_cb_return prev_
 				       size_t data_size);
 
 /**
- * MGMT event callback group IDs. Note that this is not a 1:1 mapping with #mcumgr_group_t values.
- */
-enum mgmt_cb_groups {
-	MGMT_EVT_GRP_ALL			= 0,
-	MGMT_EVT_GRP_SMP,
-	MGMT_EVT_GRP_OS,
-	MGMT_EVT_GRP_IMG,
-	MGMT_EVT_GRP_FS,
-	MGMT_EVT_GRP_SETTINGS,
-	MGMT_EVT_GRP_ENUM,
-
-	MGMT_EVT_GRP_USER_CUSTOM_START		= MGMT_GROUP_ID_PERUSER,
-};
-
-/**
- * MGMT event opcodes for all command processing.
- */
-enum smp_all_events {
-	/** Used to enable all events. */
-	MGMT_EVT_OP_ALL				= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_ALL),
-};
-
-/**
  * MGMT event opcodes for base SMP command processing.
  */
 enum smp_group_events {
@@ -147,115 +91,6 @@ enum smp_group_events {
 
 	/** Used to enable all smp_group events. */
 	MGMT_EVT_OP_CMD_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_SMP),
-};
-
-/**
- * MGMT event opcodes for filesystem management group.
- */
-enum fs_mgmt_group_events {
-	/** Callback when a file has been accessed, data is @ref fs_mgmt_file_access. */
-	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 0),
-
-	/** Callback when a file upload/download is finished, data is @ref fs_mgmt_file_access. */
-	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS_DONE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 1),
-
-	/** Used to enable all fs_mgmt_group events. */
-	MGMT_EVT_OP_FS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_FS),
-};
-
-/**
- * MGMT event opcodes for image management group.
- */
-enum img_mgmt_group_events {
-	/** Callback when a client sends a file upload chunk, data is @ref img_mgmt_upload_check. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
-
-	/** Callback when a DFU operation is stopped. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 1),
-
-	/** Callback when a DFU operation is started. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_STARTED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 2),
-
-	/** Callback when a DFU operation has finished being transferred. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
-
-	/** Callback when an image has been confirmed. data is @ref img_mgmt_image_confirmed. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
-
-	/** Callback when an image write command has finished writing to flash. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK_WRITE_COMPLETE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 5),
-
-	/**
-	 * Callback when an image slot's state is encoded for a response, data is
-	 * @ref img_mgmt_state_slot_encode.
-	 */
-	MGMT_EVT_OP_IMG_MGMT_IMAGE_SLOT_STATE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 6),
-
-	/**
-	 * Callback when a slot list command outputs fields for an image, data is
-	 * @ref img_mgmt_slot_info_image.
-	 */
-	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_IMAGE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 7),
-
-	/**
-	 * Callback when a slot list command outputs fields for a slot of an image, data is
-	 * @ref img_mgmt_slot_info_slot.
-	 */
-	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_SLOT		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 8),
-
-	/** Used to enable all img_mgmt_group events. */
-	MGMT_EVT_OP_IMG_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
-};
-
-/**
- * MGMT event opcodes for operating system management group.
- */
-enum os_mgmt_group_events {
-	/** Callback when a reset command has been received, data is @ref os_mgmt_reset_data. */
-	MGMT_EVT_OP_OS_MGMT_RESET		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 0),
-
-	/** Callback when an info command is processed, data is @ref os_mgmt_info_check. */
-	MGMT_EVT_OP_OS_MGMT_INFO_CHECK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 1),
-
-	/** Callback when an info command needs to output data, data is @ref os_mgmt_info_append. */
-	MGMT_EVT_OP_OS_MGMT_INFO_APPEND		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 2),
-
-	/** Callback when a datetime get command has been received. */
-	MGMT_EVT_OP_OS_MGMT_DATETIME_GET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 3),
-
-	/** Callback when a datetime set command has been received, data is @ref rtc_time. */
-	MGMT_EVT_OP_OS_MGMT_DATETIME_SET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 4),
-
-	/**
-	 * Callback when a bootloader info command has been received, data is
-	 * os_mgmt_bootloader_info_data().
-	 */
-	MGMT_EVT_OP_OS_MGMT_BOOTLOADER_INFO	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 5),
-
-	/** Used to enable all os_mgmt_group events. */
-	MGMT_EVT_OP_OS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_OS),
-};
-
-/**
- * MGMT event opcodes for settings management group.
- */
-enum settings_mgmt_group_events {
-	/** Callback when a setting is read/written/deleted. */
-	MGMT_EVT_OP_SETTINGS_MGMT_ACCESS	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SETTINGS, 0),
-
-	/** Used to enable all settings_mgmt_group events. */
-	MGMT_EVT_OP_SETTINGS_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_SETTINGS),
-};
-
-/**
- * MGMT event opcodes for enumeration management group.
- */
-enum enum_mgmt_group_events {
-	/** Callback when fetching details on supported command groups. */
-	MGMT_EVT_OP_ENUM_MGMT_DETAILS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_ENUM, 0),
-
-	/** Used to enable all enum_mgmt_group events. */
-	MGMT_EVT_OP_ENUM_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_ENUM),
 };
 
 /**

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MCUMGR
-	bool "mcumgr Support"
+	bool "MCUmgr Support"
 	depends on NET_BUF
 	depends on ZCBOR
 	help
-	  This option enables the mcumgr management library.
+	  This option enables the MCUmgr management library.
 
 if MCUMGR
 
@@ -23,14 +23,13 @@ config MCUMGR_SMP_LEGACY_RC_BEHAVIOUR
 	bool "Legacy rc (result code) response behaviour"
 	depends on MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
 	help
-	  This will enable legacy result code response behaviour of having rc
-	  present in responses when the status is 0. With this option disabled,
-	  mcumgr acts with new behaviour and will only return rc is the result
-	  code is non-zero (i.e. an error occurred).
+	  This will enable legacy result code response behaviour of having rc present in responses
+	  when the status is 0. With this option disabled, MCUmgr acts with new behaviour and will
+	  only return rc is the result code is non-zero (i.e. an error occurred).
 
-	  If a command only returns a result code, this will mean that the
-	  response will be empty with the new behaviour enabled, as opposed to
-	  the old behaviour where the rc field will be present in the response.
+	  If a command only returns a result code, this will mean that the response will be empty
+	  with the new behaviour enabled, as opposed to the old behaviour where the rc field will
+	  be present in the response.
 
 menu "SMP Client"
 

--- a/subsys/mgmt/mcumgr/grp/enum_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/enum_mgmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Enumeration management group public API is exported by MCUmgr interface API,
 # when Enumeration Management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_enum_mgmt)
 zephyr_library_sources(src/enum_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/enum_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/enum_mgmt/Kconfig
@@ -16,8 +16,8 @@ menuconfig MCUMGR_GRP_ENUM
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_3 if ZCBOR_CANONICAL
 	help
-	  Enables MCUmgr handlers for enumeration management. This allows
-	  for listing supported command groups.
+	  Enables MCUmgr handlers for enumeration management. This allows for listing supported
+	  command groups.
 
 if MCUMGR_GRP_ENUM
 

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # File System management group public API is exposed by MCUmgr API
 # interface, when File System management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_fs_mgmt)
 zephyr_library_sources(src/fs_mgmt.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH src/fs_mgmt_hash_checksum.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32 src/fs_mgmt_hash_checksum_crc32.c)

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -19,13 +19,11 @@ menuconfig MCUMGR_GRP_FS
 	help
 	  Enables MCUmgr handlers for file management
 
-	  This option allows MCUmgr clients to access anything in the
-	  file system, including application-stored secrets like
-	  private keys. Use of this feature in production without adequate
-	  protection mechanisms is strongly discouraged (applications can
-	  enable MCUMGR_GRP_FS_FILE_ACCESS_HOOK and register to receive
-	  callbacks when file access is attempted, which they can then filter,
-	  allow, deny or rewrite paths).
+	  Note: This option allows MCUmgr clients to access anything in the file system, including
+	  application-stored secrets like private keys. Use of this feature in production without
+	  adequate protection mechanisms is strongly discouraged (applications can enable
+	  MCUMGR_GRP_FS_FILE_ACCESS_HOOK and register to receive callbacks when file access is
+	  attempted, which they can then filter, allow, deny or rewrite paths).
 
 if MCUMGR_GRP_FS
 
@@ -33,16 +31,15 @@ choice MCUMGR_GRP_FS_MAX_FILE_SIZE
 	prompt "Maximum file size that could be uploaded/downloaded"
 	default MCUMGR_GRP_FS_MAX_FILE_SIZE_64KB
 	help
-	  Maximum file size that will be allowed to be downloaded from
-	  device.
-	  This option decides on number of bytes that are reserved in
-	  CBOR frame for storage of offset/size of file downloaded.
+	  Maximum file size that will be allowed to be downloaded from device. This option decides
+	  on number of bytes that are reserved in CBOR frame for storage of offset/size of file
+	  downloaded.
 
 config MCUMGR_GRP_FS_MAX_FILE_SIZE_64KB
 	bool "<= 64KB"
 	help
-	  Files that have size up to 64KB require 1 to 3 bytes to encode
-	  size/offset within CBOR frame with file chunk.
+	  Files that have size up to 64KB require 1 to 3 bytes to encode size/offset within CBOR
+	  frame with file chunk.
 
 config MCUMGR_GRP_FS_MAX_FILE_SIZE_4GB
 	bool "<= 4GB"
@@ -57,23 +54,21 @@ config MCUMGR_GRP_FS_MAX_OFFSET_LEN
 	default	3 if MCUMGR_GRP_FS_MAX_FILE_SIZE_64KB
 	default 5 if MCUMGR_GRP_FS_MAX_FILE_SIZE_4GB
 	help
-	  Maximal byte length of encoded offset/size, within transferred
-	  CBOR frame containing chunk of downloaded file.
-	  This value affects how much of data will fit into download buffer,
-	  as it selects sizes of fields within headers.
-	  NOTE: This option is hidden intentionally as it is intended
-	  to be assigned from limited set of allowed values, depending on
-	  the selection made in MCUMGR_GRP_FS_MAX_FILE_SIZE menu.
+	  Maximal byte length of encoded offset/size, within transferred CBOR frame containing
+	  chunk of downloaded file. This value affects how much of data will fit into download
+	  buffer, as it selects sizes of fields within headers.
+
+	  Note: This option is hidden intentionally as it is intended to be assigned from limited
+	  set of allowed values, depending on the selection made in MCUMGR_GRP_FS_MAX_FILE_SIZE
+	  menu.
 
 config MCUMGR_GRP_FS_DL_CHUNK_SIZE_LIMIT
 	bool "Setting custom size of download file chunk"
 	help
-	  By default file chunk, that will be read off storage and fit into
-	  MCUmgr frame, is automatically calculated to fit into buffer
-	  of size MCUMGR_TRANSPORT_NETBUF_SIZE with all headers.
-	  Enabling this option allows to set MAXIMUM value that will be
-	  allowed for such chunk.
-	  Look inside fs_mgmt_config.h for details.
+	  By default file chunk, that will be read off storage and fit into MCUmgr frame, is
+	  automatically calculated to fit into buffer of size MCUMGR_TRANSPORT_NETBUF_SIZE with
+	  all headers. Enabling this option allows to set MAXIMUM value that will be allowed for
+	  such chunk. Look inside fs_mgmt_config.h for details.
 
 if MCUMGR_GRP_FS_DL_CHUNK_SIZE_LIMIT
 
@@ -82,12 +77,11 @@ config MCUMGR_GRP_FS_DL_CHUNK_SIZE
 	range 65 MCUMGR_TRANSPORT_NETBUF_SIZE
 	default MCUMGR_TRANSPORT_NETBUF_SIZE
 	help
-	  Sets the MAXIMUM size of chunk which will be rounded down to
-	  number of bytes that, with all the required headers, will fit
-	  into MCUMGR_TRANSPORT_NETBUF_SIZE. This means that actual value
-	  might be lower then selected, in which case compiler warning will
-	  be issued.  Look inside fs_mgmt_config.h for details.
-	  Note that header sizes are affected by MCUMGR_GRP_FS_MAX_OFFSET_LEN.
+	  Sets the MAXIMUM size of chunk which will be rounded down to number of bytes that, with
+	  all the required headers, will fit into MCUMGR_TRANSPORT_NETBUF_SIZE. This means that
+	  actual value might be lower then selected, in which case compiler warning will be issued.
+	  Look inside fs_mgmt_config.h for details. Note that header sizes are affected by
+	  MCUMGR_GRP_FS_MAX_OFFSET_LEN.
 
 endif
 
@@ -95,16 +89,15 @@ config MCUMGR_GRP_FS_FILE_STATUS
 	bool "File status command"
 	default y
 	help
-	  This command allows a remote device to retrieve the status of a file,
-	  at present only the size of the file is returned (if it exists).
+	  This command allows a remote device to retrieve the status of a file, at present only the
+	  size of the file is returned (if it exists).
 
 config MCUMGR_GRP_FS_CHECKSUM_HASH
 	bool "Checksum/hash MCUmgr functions"
 	help
-	  Enable this to support the hash/checksum MCUmgr functionality,
-	  individual checksum and hash types need to be enabled below.
-	  Note that this requires enough stack space to buffer data
-	  from the file being read and generate the output hash/checksum.
+	  Enable this to support the hash/checksum MCUmgr functionality, individual checksum and
+	  hash types need to be enabled below. Note that this requires enough stack space to buffer
+	  data from the file being read and generate the output hash/checksum.
 
 if MCUMGR_GRP_FS_CHECKSUM_HASH
 
@@ -113,8 +106,7 @@ config MCUMGR_GRP_FS_CHECKSUM_HASH_CHUNK_SIZE
 	range 32 16384
 	default 128
 	help
-	  Chunk size of buffer to use when calculating file checksum or hash
-	  (uses stack).
+	  Chunk size of buffer to use when calculating file checksum or hash (uses stack).
 
 config MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32
 	bool "IEEE CRC32 checksum support"
@@ -134,17 +126,17 @@ config MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD
 	bool "Supported hash/checksum command"
 	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
 	help
-	  Enable the supported hash/checksum command which will return details on
-	  supported hash and checksum types that can be used.
+	  Enable the supported hash/checksum command which will return details on supported hash
+	  and checksum types that can be used.
 
 config MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_MAX_TYPES
 	int "Predicted maximum number of types to return on supported list"
 	default 10
 	depends on MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD
 	help
-	  This is used for defining CBOR map holding supported hash/checksum info.
-	  The value does not affect memory allocation, it is used by zcbor to
-	  figure out how to encode map depending on its predicted size.
+	  This is used for defining CBOR map holding supported hash/checksum info. The value does
+	  not affect memory allocation, it is used by zcbor to figure out how to encode map
+	  depending on its predicted size.
 
 endif
 
@@ -152,41 +144,35 @@ config MCUMGR_GRP_FS_PATH_LEN
 	int "Maximum file path length"
 	default 64
 	help
-	  Limits the maximum path length for file operations, in bytes.  A buffer
-	  of this size gets allocated on the stack during handling of file upload
-	  and download commands.
+	  Limits the maximum path length for file operations, in bytes. A buffer of this size gets
+	  allocated on the stack during handling of file upload and download commands.
 
 config MCUMGR_GRP_FS_FILE_ACCESS_HOOK
 	bool "File access hooks"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
-	  Allows applications to control file access (e.g. for uploading and
-	  downloading of files) by registering for a callback which is then
-	  triggered whenever a files are accessed using the FS management group
-	  function. This also, optionally, allows re-writing or changing of
-	  supplied file paths.
-	  Note that this may be called multiple times for each file read and
-	  write due to MCUmgr's method of operation with a single file state.
+	  Allows applications to control file access (e.g. for uploading and downloading of files)
+	  by registering for a callback which is then triggered whenever a files are accessed
+	  using the FS management group function. This also, optionally, allows re-writing or
+	  changing of supplied file paths. Note that this may be called multiple times for each
+	  file read and write due to MCUmgr's method of operation with a single file state.
 
 config MCUMGR_GRP_FS_FILE_SEMAPHORE_TAKE_TIME
 	int "File handle semaphore take time (ms)"
 	default 100
 	help
-	  Maximum time (in ms) to acquire the file handle semaphore when a file
-	  upload/download command is used. If unable to acquire the semaphore,
-	  then MGMT_ERR_EBUSY will be returned.
-
-	  Can specify 0 to not wait for the lock and return instantly if it
-	  cannot be acquired.
+	  Maximum time (in ms) to acquire the file handle semaphore when a file upload/download
+	  command is used. If unable to acquire the semaphore, then MGMT_ERR_EBUSY will be
+	  returned. Can specify 0 to not wait for the lock and return instantly if it cannot be
+	  acquired.
 
 config MCUMGR_GRP_FS_FILE_AUTOMATIC_IDLE_CLOSE_TIME
 	int "Automatic file handle close time (ms)"
 	default 4000
 	range 1 99999999
 	help
-	  Time (in ms) for a file upload/download to be declared aborted and
-	  file handle cleaned up. Each access to the file will reset the idle
-	  time to 0.
+	  Time (in ms) for a file upload/download to be declared aborted and file handle cleaned
+	  up. Each access to the file will reset the idle time to 0.
 
 module = MCUMGR_GRP_FS
 module-str = mcumgr_grp_fs

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Image management group public API is exported by MCUmgr interface API,
 # when Image Management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_img_mgmt)
 zephyr_library_sources(
   src/zephyr_img_mgmt.c
   src/img_mgmt_state.c

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -13,7 +13,7 @@
 # try to group them together by the same stem after prefix.
 
 menuconfig MCUMGR_GRP_IMG
-	bool "Mcumgr handlers for image management"
+	bool "MCUmgr handlers for image management"
 	depends on FLASH
 	depends on IMG_MANAGER
 	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
@@ -50,7 +50,8 @@ config MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
 	help
 	  Sets how many application images are supported (pairs of secondary and primary slots).
 	  Setting this to 2 requires MCUMGR_TRANSPORT_NETBUF_SIZE to be at least 512b.
-	  NOTE: The UPDATEABLE_IMAGE_NUMBER of MCUBOOT configuration, even for Zephyr build,
+
+	  Note: The UPDATEABLE_IMAGE_NUMBER of MCUBOOT configuration, even for Zephyr build,
 	  needs to be set to the same value; this is due to the fact that the MCUmgr uses
 	  boot_util and the UPDATEABLE_IMAGE_NUMBER controls number of images supported
 	  by that library.
@@ -59,50 +60,48 @@ config MCUMGR_GRP_IMG_VERBOSE_ERR
 	bool "Verbose error responses when uploading application image"
 	select MCUMGR_SMP_VERBOSE_ERR_RESPONSE
 	help
-	  Add additional "rsn" key to SMP responses, where provided, explaining
-	  non-0 "rc" codes.
+	  Add additional "rsn" key to SMP responses, where provided, explaining non-0 "rc" codes.
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
 	bool "Allow to confirm secondary slot of non-active image"
 	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	default y
 	help
-	  Allows to confirm secondary (non-active) slot of non-active image.
-	  Normally it should not be allowed to confirm any slots of non-active
-	  image, via MCUmgr commands, to prevent confirming something that is
-	  broken and may not boot in other slot; instead application should
-	  have means to test and confirm the image.
+	  Allows to confirm secondary (non-active) slot of non-active image. Normally it should not
+	  be allowed to confirm any slots of non-active image, via MCUmgr commands, to prevent
+	  confirming something that is broken and may not boot in other slot; instead application
+	  should have a means to test and confirm the image.
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
 	bool "Allow to confirm slots of non-active image"
 	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	select MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
 	help
-	  Allows to confirm any slot of non-active image.
-	  Normally it should not be allowed to confirm any slots of non-active
-	  image, via MCUmgr commands, to prevent confirming something that is
-	  broken and may not boot in other slot; instead application should
-	  have means to test and confirm the image.
+	  Allows to confirm any slot of non-active image. Normally it should not be allowed to
+	  confirm any slots of non-active image, via MCUmgr commands, to prevent confirming
+	  something that is broken and may not boot in other slot; instead application should have
+	  a means to test and confirm the image.
 
 config MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
 	bool "Allow to erase pending slot"
 	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	default y
 	help
-	  Allows erasing secondary slot which is marked for test or confirmed; this allows
-	  erasing slots that have been set for next boot but the device has not
-	  reset yet, so has not yet been swapped.
+	  Allows erasing secondary slot which is marked for test or confirmed; this allows erasing
+	  slots that have been set for next boot but the device has not reset yet, so have not yet
+	  been swapped.
 
 config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 	bool "Allow direct image upload"
 	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	help
-	  Enables directly uploading image to selected image partition.
-	  This changes how "image" is understood by MCUmgr: normally MCUmgr allows uploading to
-	  the first slot of the only image it knows, where image is understood as two slots
-	  (two DTS images for Zephyr); this allows to treat every DTS defined image as direct
-	  target for upload, and more than two may be used (4 at this time).
-	  NOTE: When direct upload is used the image numbers are shifted by + 1, and the default
+	  Enables directly uploading image to selected image partition. This changes how "image" is
+	  understood by MCUmgr: normally MCUmgr allows uploading to the first slot of the only
+	  image it knows, where image is understood as two slots (two DTS images for Zephyr); this
+	  allows to treat every DTS defined image as direct target for upload, and more than two
+	  may be used (4 at this time).
+
+	  Note: When direct upload is used the image numbers are shifted by + 1, and the default
 	  behaviour is, when image is not selected, to upload to image that represents secondary
 	  slot in normal operation.
 
@@ -110,12 +109,10 @@ config MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
 	bool "Reject Direct-XIP applications with mismatched address"
 	depends on MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP || MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
 	help
-	  When enabled, the MCUmgr will compare base address of application,
-	  encoded into .bin file header with use of imgtool, on upload and will
-	  reject binaries that would not be able to start from available
-	  Direct-XIP address.
-	  The base address can be set, to an image binary header, with imgtool,
-	  using the --rom-fixed command line option.
+	  When enabled, the MCUmgr will compare base address of application, encoded into .bin
+	  file header with use of imgtool, on upload and will reject binaries that would not be
+	  able to start from available Direct-XIP address. The base address can be set, to an image
+	  binary header, with imgtool, using the --rom-fixed command line option.
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
 	bool "Allow to confirm non-active slots of any image" if !MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
@@ -127,28 +124,25 @@ config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
 		   MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
 	default y
 	help
-	  Allows to confirm non-active slot of any image.
-	  Normally it should not be allowed to confirm any slots via MCUmgr
-	  commands, to prevent confirming something that is broken and was not
-	  verified to boot correctly.
-	  Option always enabled in the overwrite mode, because the permanent
-	  update, that uses the confirm flag, is the intended way to provide
+	  Allows to confirm non-active slot of any image. Normally it should not be allowed to
+	  confirm any slots via MCUmgr commands, to prevent confirming something that is broken
+	  and was not verified to boot correctly. Option is always enabled when in overwrite only
+	  mode, because updates are permanent and using the confirm flag is the intended method for
 	  updates.
 
 config MCUMGR_GRP_IMG_FRUGAL_LIST
 	bool "Omit zero, empty or false values from status list"
 	help
 	  The status list send back from the device will only be filled with data that is non-zero,
-	  non-empty or true.  This option slightly reduces number of bytes transferred back from
+	  non-empty or true. This option slightly reduces number of bytes transferred back from
 	  a device but requires support in client software, which has to default omitted values.
 	  Works correctly with the go mcumgr-cli application.
 
 config MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER
 	bool "Use build number while comparing image version"
 	help
-	  By default, the image version comparison relies only on version major,
-	  minor and revision. Enable this option to take into account the build
-	  number as well.
+	  By default, the image version comparison relies only on version major, minor and
+	  revision. Enable this option to take into account the build number as well.
 
 config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
 	bool "Upload check hook"
@@ -219,9 +213,9 @@ config MCUMGR_GRP_IMG_IMAGE_SLOT_STATE_STATES
 	prompt "Predicted maximum number of entries per group" if MCUMGR_GRP_IMG_IMAGE_SLOT_STATE_HOOK
 	default 15
 	help
-	  This is used for defining CBOR map holding group data.
-	  The value does not affect memory allocation, it is used by zcbor
-	  to figure out how to encode map depending on its predicted size.
+	  This is used for defining CBOR map holding group data. The value does not affect memory
+	  allocation, it is used by zcbor to figure out how to encode map depending on its
+	  predicted size.
 
 config MCUMGR_GRP_IMG_SLOT_INFO
 	bool "Slot info"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt_client/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Image management client group public API is exported by MCUmgr interface API,
 # when Image Management client is enabled.
 
-zephyr_library()
+zephyr_library_named(mcumgr_grp_img_mgmt_client)
 zephyr_library_sources(
   src/img_mgmt_client.c
 )

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # OS Management group public API is exposed through zephyr_interface,
 # when OS Management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_os_mgmt)
 zephyr_library_sources(src/os_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -13,7 +13,7 @@
 # try to group them together by the same stem after prefix.
 
 menuconfig MCUMGR_GRP_OS
-	bool "Mcumgr handlers for OS management"
+	bool "MCUmgr handlers for OS management"
 	imply REBOOT
 	help
 	  Enables MCUmgr handlers for OS management
@@ -27,21 +27,19 @@ config MCUMGR_GRP_OS_RESET_MS
 	default 250
 	depends on MULTITHREADING
 	help
-	  When a reset command is received, the system waits this many milliseconds
-	  before performing the reset.  This delay allows time for the MCUmgr
-	  response to be delivered.
+	  When a reset command is received, the system waits this many milliseconds before
+	  performing the reset. This delay allows time for the MCUmgr response to be delivered.
 
 config MCUMGR_GRP_OS_RESET_HOOK
 	bool "Reset hook"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
-	  Allows applications to control and get notifications of when a reset
-	  command has been issued via an MCUmgr command. With this option
-	  disabled, modules will reboot when the command is received without
-	  notification, when this is enabled and a handler is registered, the
-	  application will be notified that a reset command has been received
-	  and will allow the application to perform any required operations
-	  before accepting or declining the reset request.
+	  Allows applications to control and get notifications of when a reset command has been
+	  issued via an MCUmgr command. With this option disabled, modules will reboot when the
+	  command is received without notification, when this is enabled and a handler is
+	  registered, the application will be notified that a reset command has been received and
+	  will allow the application to perform any required operations before accepting or
+	  declining the reset request.
 
 config MCUMGR_GRP_OS_RESET_BOOT_MODE
 	bool "Boot mode"
@@ -64,10 +62,9 @@ config MCUMGR_GRP_OS_TASKSTAT_ONLY_SUPPORTED_STATS
 	bool "Send only data gathered by Zephyr"
 	default y
 	help
-	  Response will not include fields the Zephyr does not collect statistic for.
-	  Enable this if your client software is able to process "taskstat" response
-	  that would be missing "runtime", "cswcnt", "last_checkin" and "next_checkin"
-	  map entries for each listed task.
+	  Response will not include fields the Zephyr does not collect statistic for. Enable this
+	  if your client software is able to process "taskstat" response that would be missing
+	  "runtime", "cswcnt", "last_checkin" and "next_checkin" map entries for each listed task.
 	  Enabling this option will slightly reduce code size.
 
 choice MCUMGR_GRP_OS_TASKSTAT_THREAD_NAME_CHOICE
@@ -75,8 +72,8 @@ choice MCUMGR_GRP_OS_TASKSTAT_THREAD_NAME_CHOICE
 	default MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_NAME_FOR_NAME if THREAD_NAME
 	default MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_PRIO_FOR_NAME
 	help
-	  Select what will serve as thread name in "taskstat" response.
-	  By default taskstat responses use thread priority, when THREAD_NAME is disabled,
+	  Select what will serve as thread name in "taskstat" response. By default taskstat
+	  responses use thread priority, when THREAD_NAME is disabled,
 
 config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_NAME_FOR_NAME
 	bool "Thread name"
@@ -94,9 +91,9 @@ config MCUMGR_GRP_OS_TASKSTAT_MAX_NUM_THREADS
 	int "Predicted maximum number of threads to return on taskstat list"
 	default 50
 	help
-	  This is used for defining CBOR map holding thread info.
-	  The value does not affect memory allocation, it is used by zcbor
-	  to figure out how to encode map depending on its predicted size.
+	  This is used for defining CBOR map holding thread info. The value does not affect memory
+	  allocation, it is used by zcbor to figure out how to encode map depending on its
+	  predicted size.
 
 config MCUMGR_GRP_OS_TASKSTAT_THREAD_NAME_LEN
 	int "Length of thread name to return in response"
@@ -105,35 +102,31 @@ config MCUMGR_GRP_OS_TASKSTAT_THREAD_NAME_LEN
 	range 3 THREAD_MAX_NAME_LEN if THREAD_NAME
 	range 3 6 if !THREAD_NAME
 	help
-	  The length of the string that is sent in response to taskstat command,
-	  as a thread name.
+	  The length of the string that is sent in response to taskstat command, as a thread name.
 	  When THREAD_NAME is enabled then this defaults to THREAD_MAX_NAME_LEN.
-	  When THREAD_NAME is disabled the name is generated from thread priority,
-	  signed integer, and this number regulates how many digits will be used;
-	  in such case this value should also take into account possible '-'
-	  sign.
+	  When THREAD_NAME is disabled the name is generated from thread priority, signed integer,
+	  and this number regulates how many digits will be used; in such case this value should
+	  also take into account possible '-' sign.
 
 config MCUMGR_GRP_OS_TASKSTAT_SIGNED_PRIORITY
 	bool "Signed priorities"
 	default y
 	help
-	  Zephyr uses int8_t as thread priorities, but in taskstat response it encodes
-	  them as unsigned.  Enabling this option will use signed int for priorities in
-	  responses, which is more natural for Zephyr.
-	  Disable this option if your client software is unable to properly decode and
-	  accept signed integers as priorities.
+	  Zephyr uses int8_t as thread priorities, but in taskstat response it encodes them as
+	  unsigned. Enabling this option will use signed int for priorities in responses, which is
+	  more natural for Zephyr. Disable this option if your client software is unable to
+	  properly decode and accept signed integers as priorities.
 
 config MCUMGR_GRP_OS_TASKSTAT_STACK_INFO
 	bool "Include stack info in taskstat responses"
 	depends on THREAD_STACK_INFO
 	help
-	  Enabling this option adds stack information into "taskstat" command
-	  responses, this is default when THREAD_STACK_INFO is selected.
-	  Disable this option only when your client application is able to
-	  process "taskstat" response without the "stksiz" and "stkuse" fields.
-	  It is worth disabling this option when THREAD_STACK_INFO is disabled,
-	  as it will prevent sending zeroed stack information just to fill
-	  all the fields in "taskstat" responses, and it will slightly reduce code size.
+	  Enabling this option adds stack information into "taskstat" command responses, this is
+	  default when THREAD_STACK_INFO is selected. Disable this option only when your client
+	  application is able to process "taskstat" response without the "stksiz" and "stkuse"
+	  fields. It is worth disabling this option when THREAD_STACK_INFO is disabled, as it will
+	  prevent sending zeroed stack information just to fill all the fields in "taskstat"
+	  responses, and it will slightly reduce code size.
 
 endif
 
@@ -180,8 +173,8 @@ config MCUMGR_GRP_OS_DATETIME_HOOK
 	depends on MCUMGR_GRP_OS_DATETIME
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
-	  Allows applications to control and get notifications of when a datetime set/get
-	  command has been issued via an MCUmgr command.
+	  Allows applications to control and get notifications of when a datetime set/get command
+	  has been issued via an MCUmgr command.
 
 config MCUMGR_GRP_OS_MCUMGR_PARAMS
 	bool "MCUMGR Parameters retrieval command"

--- a/subsys/mgmt/mcumgr/grp/os_mgmt_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt_client/CMakeLists.txt
@@ -6,6 +6,6 @@
 
 # OS Management client group public API is exposed through zephyr_interface,
 # when OS Management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_os_mgmt_client)
 zephyr_library_sources(src/os_mgmt_client.c)
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Settings management group public API is exposed by MCUmgr API
 # interface, when settings management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_settings_mgmt)
 zephyr_library_sources(src/settings_mgmt.c)
 
 if(CONFIG_MCUMGR_GRP_SETTINGS AND NOT CONFIG_MCUMGR_GRP_SETTINGS_ACCESS_HOOK)

--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/Kconfig
@@ -17,14 +17,14 @@ choice MCUMGR_GRP_SETTINGS_BUFFER_TYPE
 	prompt "Buffer type"
 	default MCUMGR_GRP_SETTINGS_BUFFER_TYPE_STACK
 	help
-	  Selects if the stack or heap will be used for variables that are
-	  needed when processing requests.
+	  Selects if the stack or heap will be used for variables that are needed when processing
+	  requests.
 
 config MCUMGR_GRP_SETTINGS_BUFFER_TYPE_STACK
 	bool "Stack (fixed size)"
 	help
-	  Use a fixed size stack buffer, any user-supplied values longer than
-	  this will be rejected.
+	  Use a fixed size stack buffer, any user-supplied values longer than this will be
+	  rejected.
 
 	  Note that stack usage for parameter storage alone will be
 	  MCUMGR_GRP_SETTINGS_NAME_LEN + MCUMGR_GRP_SETTINGS_VALUE_LEN,
@@ -34,9 +34,8 @@ config MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
 	bool "Heap (dynamic size)"
 	depends on COMMON_LIBC_MALLOC_ARENA_SIZE > 0
 	help
-	  Use dynamic heap memory allocation through malloc, if there is
-	  insufficient heap memory for the allocation then the request will be
-	  rejected.
+	  Use dynamic heap memory allocation through malloc, if there is insufficient heap memory
+	  for the allocation then the request will be rejected.
 
 endchoice
 
@@ -44,25 +43,22 @@ config MCUMGR_GRP_SETTINGS_NAME_LEN
 	int "Maximum setting name length"
 	default 32
 	help
-	  Maximum length of a key to lookup, this will be the size of the
-	  variable if placed on the stack or the maximum allocated size of the
-	  variable if placed on the heap.
+	  Maximum length of a key to lookup, this will be the size of the variable if placed on
+	  the stack or the maximum allocated size of the variable if placed on the heap.
 
 config MCUMGR_GRP_SETTINGS_VALUE_LEN
 	int "Maximum setting value length"
 	default 32
 	help
-	  Maximum length of a value to read, this will be the size of the
-	  variable if placed on the stack or the allocated size of the
-	  variable if placed on the heap (settings does not support getting
-	  the size of a value prior to looking it up).
+	  Maximum length of a value to read, this will be the size of the variable if placed on
+	  the stack or the allocated size of the variable if placed on the heap (settings does not
+	  support getting the size of a value prior to looking it up).
 
 config MCUMGR_GRP_SETTINGS_ACCESS_HOOK
 	bool "Settings access hook"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
-	  Allows applications to control settings management access by
-	  registering for a callback which is then triggered whenever a
-	  settings read or write attempt is made.
+	  Allows applications to control settings management access by registering for a callback
+	  which is then triggered whenever a settings read or write attempt is made.
 
 endif

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Shell Management group public API is exposed by MCUmgr API
 # interface, when Shell Management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_shell_mgmt)
 zephyr_library_sources(src/shell_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
@@ -13,42 +13,31 @@
 # try to group them together by the same stem after prefix.
 
 menuconfig MCUMGR_GRP_SHELL
-	bool "Mcumgr handlers for shell management"
+	bool "MCUmgr handlers for shell management"
 	depends on SHELL
 	depends on SHELL_BACKEND_DUMMY
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help
-	  Enables MCUmgr handlers for shell management. The handler will utilize
-	  the dummy backend to execute shell commands and capture the output to
-	  an internal memory buffer. This way, there is no interaction with
-	  physical interfaces outside of the scope of the user.
-	  It is possible to use additional shell backends in coordination
-	  with this handler and they will not interfere.
-	  The MCUMGR_GRP_SHELL_BACKEND_DUMMY_BUF_SIZE will affect how many characters
-	  will be returned from command output, if your output gets cut, then
-	  increase the value. Remember to set MCUMGR_TRANSPORT_NETBUF_SIZE accordingly.
-	  Note that maximum length of shell command accepted is regulated by
-	  the CONFIG_SHELL_CMD_BUFF_SIZE, and a buffer for a command is allocated
-	  on a stack, by the MCUmgr, so enabling MCUMGR_GRP_SHELL and
-	  changes to the CONFIG_SHELL_CMD_BUFF_SIZE may increase stack size
-	  requirements.
+	  Enables MCUmgr handlers for shell management. The handler will utilize the dummy backend
+	  to execute shell commands and capture the output to an internal memory buffer. This way,
+	  there is no interaction with physical interfaces outside of the scope of the user. It is
+	  possible to use additional shell backends in coordination with this handler and they will
+	  not interfere. The CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE Kconfig will affect how many
+	  characters will be returned from command output, if your output gets cut, then increase
+	  the value. Remember to set MCUMGR_TRANSPORT_NETBUF_SIZE accordingly. Note that maximum
+	  length of shell command accepted is regulated by the CONFIG_SHELL_CMD_BUFF_SIZE, and a
+	  buffer for a command is allocated on a stack, by the MCUmgr, so enabling MCUMGR_GRP_SHELL
+	  and changes to the CONFIG_SHELL_CMD_BUFF_SIZE may increase stack size requirements.
 
 if MCUMGR_GRP_SHELL
-
-# Show dummy shell buffer size here, will show help text of original prompt so
-# nothing extra is needed here, nor a default value.
-config SHELL_BACKEND_DUMMY_BUF_SIZE
-	int "Shell output buffer size (Size of dummy buffer size)"
 
 config MCUMGR_GRP_SHELL_LEGACY_RC_RETURN_CODE
 	bool "Legacy behaviour: Use rc field for shell function return code"
 	help
-	  Enabling this options brings back legacy behaviour where the shell
-	  return code is returned, incorrectly, in the rc field that was
-	  originally designated for returning SMP processing errors. When
-	  disabled, there will be an additional ret field which contains the
-	  shell command exit code, and rc will be used for SMP processing
-	  error codes.
+	  Enabling this options brings back legacy behaviour where the shell return code is
+	  returned, incorrectly, in the rc field that was originally designated for returning SMP
+	  processing errors. When disabled, there will be an additional ret field which contains
+	  the shell command exit code, and rc will be used for SMP processing error codes.
 
 module = MCUMGR_GRP_SHELL
 module-str = mcumgr_grp_shell

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Statistics management group public API is exposed by MCUmgr API
 # interface, when Statistics management is enabled.
-zephyr_library()
+zephyr_library_named(mcumgr_grp_stat_mgmt)
 zephyr_library_sources(src/stat_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
@@ -13,7 +13,7 @@
 # try to group them together by the same stem after prefix.
 
 menuconfig MCUMGR_GRP_STAT
-	bool "Mcumgr handlers for statistics management"
+	bool "MCUmgr handlers for statistics management"
 	depends on STATS
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
@@ -27,13 +27,11 @@ config MCUMGR_GRP_STAT_MAX_NAME_LEN
 	default 32
 	depends on MCUMGR_GRP_STAT
 	help
-	  Limits the maximum stat group name length in MCUmgr requests, in bytes.
-	  For stat group names. a buffer of this size gets allocated on the stack
-	  during handling of all stat read commands. If a stat group's name
-	  exceeds this limit, it will be impossible to retrieve its values with
-	  a stat show command.
-	  For stat names s_name and snm_name, this is the maximum length when
-	  encoding the name to cbor.
+	  Limits the maximum stat group name length in MCUmgr requests, in bytes. For stat group
+	  names, a buffer of this size gets allocated on the stack during handling of all stat read
+	  commands. If a stat group's name exceeds this limit, it will be impossible to retrieve
+	  its values with a stat show command. For stat names s_name and snm_name, this is the
+	  maximum length when encoding the name to CBOR.
 
 module = MCUMGR_GRP_STAT
 module-str = mcumgr_grp_stat

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library()
+zephyr_library_named(mcumgr_grp_zephyr_basic)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_ZBASIC_STORAGE_ERASE src/basic_mgmt.c)

--- a/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Provides MCUmgr services, group registration, event handling etc.
-zephyr_library()
+zephyr_library_named(mcumgr_mgmt)
 zephyr_library_sources(src/mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/mgmt/Kconfig
@@ -35,6 +35,6 @@ config MCUMGR_MGMT_HANDLER_USER_DATA
 config MCUMGR_MGMT_CUSTOM_PAYLOAD
 	bool "MCUmgr custom payload"
 	help
-	  When this config is enabled, a user can use the field `custom_payload` in `mgmt_handler` to
-	  skip the generation of the cbor start- and end byte in `smp_handle_single_payload` and
-	  instead use a user defined payload in SMP messages.
+	  When this config is enabled, a user can use the field `custom_payload` in `mgmt_handler`
+	  to skip the generation of the CBOR start- and end byte in `smp_handle_single_payload`
+	  and instead use a user defined payload in SMP messages.

--- a/subsys/mgmt/mcumgr/smp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp/CMakeLists.txt
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Protocol API is only exposed to MCUmgr internals.
-zephyr_library()
+zephyr_library_named(mcumgr_smp)
 zephyr_library_sources(src/smp.c)

--- a/subsys/mgmt/mcumgr/smp/Kconfig
+++ b/subsys/mgmt/mcumgr/smp/Kconfig
@@ -15,26 +15,16 @@ config MCUMGR_SMP_CBOR_MAX_MAIN_MAP_ENTRIES
 	int "Number of predicted maximum entries to main response map"
 	default 15
 	help
-	  This is number of predicted entries in main response map,
-	  the one that encapsulates everything within response.
-	  This value is used by zcbor to predict needed map encoding,
-	  and does not affect memory allocation or usage.
-	  Builtin command processors rarely add large amounts of
-	  data directly to main map, creating sub-maps instead so
-	  the default value works fine with them.
-	  If your app directly adds fields to main map, without
-	  encapsulating them, you may want to increase this value
-	  in case when encoding starts to fail.
+	  This is number of predicted entries in main response map, the one that encapsulates
+	  everything within response. This value is used by zcbor to predict needed map encoding,
+	  and does not affect memory allocation or usage. Builtin command processors rarely add
+	  large amounts of data directly to main map, creating sub-maps instead so the default
+	  value works fine with them. If your app directly adds fields to main map, without
+	  encapsulating them, you may want to increase this value in case when encoding starts to
+	  fail.
 
 config MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	int
-	help
-	  Minimal decoding levels, map/list encapsulation, required
-	  to be supported by zcbor decoding of SMP responses
-	  is auto generated from MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_? options.
-	  A group or command that adds additional maps/lists above the
-	  base map, which is already taken into account, should
-	  select one of the MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_?.
 	default 7 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_7
 	default 6 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_6
 	default 5 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_5
@@ -43,6 +33,11 @@ config MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	default 2 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	default 1 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_1
 	default 0
+	help
+	  Minimal decoding levels, map/list encapsulation, required to be supported by zcbor
+	  decoding of SMP responses is auto generated from MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_?
+	  options. A group or command that adds additional maps/lists above the base map, which is
+	  already taken into account, should select one of the MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_?.
 
 config MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_1
 	bool
@@ -70,27 +65,16 @@ config MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS
 	range MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS 15
 	default MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	help
-	  This is a maximum number of levels of maps/lists that will
-	  be expected to be decoded within different command groups.
-	  SMP commands/groups that provide no CBOR encoded payload
-	  have no requirements.
-	  Commands that provide CBOR payload require at least 1 level,
-	  and additional levels for each map/list encapsulation.
-	  For example if command accepts payload of map of parameters
-	  it will need 2 levels.
-	  This number translates to zcbor backup states, it increases
-	  size of cbor_nb_reader structure by zcbor_state_t size per
-	  one unit selected here.
+	  This is a maximum number of levels of maps/lists that will be expected to be decoded
+	  within different command groups. SMP commands/groups that provide no CBOR encoded payload
+	  have no requirements. Commands that provide CBOR payload require at least 1 level, and
+	  additional levels for each map/list encapsulation. For example if command accepts payload
+	  of map of parameters it will need 2 levels. This number translates to zcbor backup states,
+	  it increases size of cbor_nb_reader structure by zcbor_state_t size per one unit selected
+	  here.
 
 config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
 	int
-	help
-	  Minimal encoding levels, map/list encapsulation, required
-	  to be supported by zcbor encoding of SMP responses
-	  is auto generated from MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_? options.
-	  A group or command that adds additional maps/lists above the
-	  base map, which is already taken into account, should
-	  select one of the MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_?.
 	default 7 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_7
 	default 6 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_6
 	default 5 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_5
@@ -99,6 +83,11 @@ config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
 	default 2 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_2
 	default 1 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_1 || ZCBOR_CANONICAL
 	default 0
+	help
+	  Minimal encoding levels, map/list encapsulation, required to be supported by zcbor
+	  encoding of SMP responses is auto generated from MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_?
+	  options. A group or command that adds additional maps/lists above the base map, which is
+	  already taken into account, should select one of the MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_?.
 
 config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_1
 	bool
@@ -126,11 +115,9 @@ config MCUMGR_SMP_CBOR_MAX_ENCODING_LEVELS
 	range MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS 15
 	default MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
 	help
-	  This is a maximum number of levels of maps/lists that will
-	  be encoded within different comm&& groups.
-	  This number translates to zcbor backup states, it increases
-	  size of cbor_nb_writer structure by zcbor_state_t size per
-	  one unit selected here.
+	  This is a maximum number of levels of maps/lists that will be encoded within different
+	  commmand groups. This number translates to zcbor backup states, it increases size of
+	  cbor_nb_writer structure by zcbor_state_t size per one unit selected here.
 
 config MCUMGR_SMP_COMMAND_STATUS_HOOKS
 	bool "SMP command status hooks"
@@ -143,19 +130,16 @@ config MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
 	bool "Support original protocol"
 	default y
 	help
-	  This option will enable supporting the original SMP protocol whereby
-	  all errors are returned in the "rc" field as well as the new protocol
-	  whereby there is a dedicated entry for command error/result codes.
-	  The protocol selection is indicated by the request header sent by the
-	  client.
+	  This option will enable supporting the original SMP protocol whereby all errors are
+	  returned in the "rc" field as well as the new protocol whereby there is a dedicated
+	  entry for command error/result codes. The protocol selection is indicated by the request
+	  header sent by the client.
 
 config MCUMGR_SMP_VERBOSE_ERR_RESPONSE
 	bool "Support verbose error response"
 	depends on MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
 	help
-	  Support for encoding "rc" code explanation in form of "rsn"
-	  text string.  This is useful, when returning MGMT_ERR_EUNKNOWN,
-	  to add additional information on the source of an error.
-	  Note that the "rsn" is string additional to "rc" code,
-	  so MCUMGR_TRANSPORT_NETBUF_SIZE should be large enough to be able
-	  to encode both.
+	  Support for encoding "rc" code explanation in form of "rsn" text string. This is useful,
+	  when returning MGMT_ERR_EUNKNOWN, to add additional information on the source of an
+	  error. Note that the "rsn" is string additional to "rc" code, so
+	  MCUMGR_TRANSPORT_NETBUF_SIZE should be large enough to be able to encode both.

--- a/subsys/mgmt/mcumgr/smp_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp_client/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 # Protocol API is only exposed to MCUmgr internals.
 
-zephyr_library()
+zephyr_library_named(mcumgr_smp_client)
 zephyr_library_sources(src/client.c)

--- a/subsys/mgmt/mcumgr/smp_client/Kconfig
+++ b/subsys/mgmt/mcumgr/smp_client/Kconfig
@@ -26,8 +26,8 @@ config SMP_CMD_RETRY_TIME
 	range 100 1000
 	default 500
 	help
-	  The time (in ms) which the SMP client will wait for a response before re-sending
-	  a command.
+	  The time (in ms) which the SMP client will wait for a response before re-sending a
+	  command.
 
 config SMP_CLIENT_CMD_MAX
 	int "SMP client max buffer count"

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # mgmt_mcumgr_transport covers interface API, allowing to implement transports.
 # It is exposed with mgmt_mcumgr interface.
-zephyr_library()
+zephyr_library_named(mcumgr_transport)
 zephyr_library_sources(src/smp.c)
 
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_REASSEMBLY

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -30,23 +30,23 @@ config MCUMGR_TRANSPORT_REASSEMBLY
 	  Enable structures and functions needed for packet reassembly by SMP backend.
 
 config MCUMGR_TRANSPORT_NETBUF_COUNT
-	int "Number of mcumgr buffers"
+	int "Number of MCUmgr buffers"
 	default 2 if MCUMGR_TRANSPORT_UDP
 	default 4
 	help
-	  The number of net_bufs to allocate for mcumgr.  These buffers are
-	  used for both requests and responses.
+	  The number of net_bufs to allocate for MCUmgr. These buffers are used for both requests
+	  and responses.
 
 config MCUMGR_TRANSPORT_NETBUF_SIZE
-	int "Size of each mcumgr buffer"
+	int "Size of each MCUmgr buffer"
 	default 2048 if MCUMGR_TRANSPORT_UDP
 	default 384
 	help
-	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
-	  the following relation:
+	  The size, in bytes, of each MCUmgr buffer. This value must satisfy the following
+	  relation:
 	  MCUMGR_TRANSPORT_NETBUF_SIZE >= transport-specific-MTU + transport-overhead
-	  In case when MCUMGR_TRANSPORT_SHELL is enabled this value should be set to
-	  at least MCUMGR_GRP_SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
+	  In case when MCUMGR_TRANSPORT_SHELL is enabled this value should be set to at least
+	  CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
 
 config MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
 	int
@@ -59,16 +59,15 @@ config MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
 	  Hidden option to determine minimum user data size.
 
 config MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE
-	int "Size of mcumgr buffer user data"
+	int "Size of MCUmgr buffer user data"
 	range MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE 128
 	default MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
 	help
-	  The size, in bytes, of user data to allocate for each mcumgr buffer.
+	  The size, in bytes, of user data to allocate for each MCUmgr buffer.
 
-	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART and shell, a value of 8
-	  is sufficient for Bluetooth. For UDP, the userdata must be large
-	  enough to hold IPv4/IPv6 addresses.
+	  Different MCUmgr transports impose different requirements for this setting. A value of 4
+	  is sufficient for UART and shell, a value of 8 is sufficient for Bluetooth. For UDP, the
+	  userdata must be large enough to hold IPv4/IPv6 addresses.
 
 module = MCUMGR_TRANSPORT
 module-str = mcumgr_transport

--- a/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
@@ -10,7 +10,7 @@
 #  MCUMGR_TRANSPORT_BT_
 
 menuconfig MCUMGR_TRANSPORT_BT
-	bool "Bluetooth mcumgr SMP transport"
+	bool "Bluetooth MCUmgr SMP transport"
 	depends on BT_PERIPHERAL
 	help
 	  Enables handling of SMP commands received over Bluetooth.
@@ -21,8 +21,8 @@ config MCUMGR_TRANSPORT_BT_REASSEMBLY
 	bool "Reassemble packets in Bluetooth SMP transport"
 	select MCUMGR_TRANSPORT_REASSEMBLY
 	help
-	  When enabled, the SMP BT transport will buffer and reassemble received
-	  packet fragments before passing it for further processing.
+	  When enabled, the SMP BT transport will buffer and reassemble received packet fragments
+	  before passing it for further processing.
 
 choice MCUMGR_TRANSPORT_BT_PERM
 	prompt "Permission used for the SMP service"
@@ -49,10 +49,9 @@ config MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL
 	depends on SYSTEM_WORKQUEUE_PRIORITY < 0
 	depends on BT_GAP_PERIPHERAL_PREF_PARAMS
 	help
-	  Enables support for requesting specific connection parameters when
-	  SMP commands are handled. This option allows to speed up the command
-	  exchange process.
-	  Its recommended to enable this if SMP is used for DFU.
+	  Enables support for requesting specific connection parameters when SMP commands are
+	  handled. This option allows to speed up the command exchange process.
+	  It is recommended to enable this if SMP is used for DFU.
 
 if MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL
 
@@ -89,17 +88,16 @@ config MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL_RESTORE_TIME
 	default 5000
 	range 1000 $(UINT16_MAX)
 	help
-	  The value is a time of inactivity on the SMP characteristic after which
-	  connection parameters are restored to peripheral preferred values
-	  (BT_GAP_PERIPHERAL_PREF_PARAMS).
+	  The value is a time of inactivity on the SMP characteristic after which connection
+	  parameters are restored to peripheral preferred values (BT_GAP_PERIPHERAL_PREF_PARAMS).
 
 config MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL_RETRY_TIME
 	int "Connection parameters update retry time in milliseconds"
 	default 1000
 	range 1 5000
 	help
-	  In case connection parameters update fails due to an error, this
-	  option specifies the time of the next update attempt.
+	  In case connection parameters update fails due to an error, this option specifies the
+	  time of the next update attempt.
 
 endif # MCUMGR_TRASNPORT_BT_CONN_PARAM_CONTROL
 
@@ -108,8 +106,8 @@ config MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION
 	depends on BT_GATT_DYNAMIC_DB
 	default y
 	help
-	  When enabled, the SMP service will be automatically registered at boot time
-	  and can then be dynamically registered/unregistered using a dedicated API.
-	  Otherwise, the SMP service will be statically defined and registered.
+	  When enabled, the SMP service will be automatically registered at boot time and can then
+	  be dynamically registered/unregistered using a dedicated API. Otherwise, the SMP service
+	  will be statically defined and registered.
 
 endif # MCUMGR_TRANSPORT_BT

--- a/subsys/mgmt/mcumgr/transport/Kconfig.dummy
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.dummy
@@ -13,8 +13,8 @@ menuconfig MCUMGR_TRANSPORT_DUMMY
 	bool "Dummy SMP backend"
 	depends on BASE64
 	help
-	  Enables the dummy SMP backend which can be used for unit testing
-	  SMP functionality without needing a real interface or driver.
+	  Enables the dummy SMP backend which can be used for unit testing SMP functionality
+	  without needing a real interface or driver.
 
 if MCUMGR_TRANSPORT_DUMMY
 
@@ -22,8 +22,7 @@ config MCUMGR_TRANSPORT_DUMMY_RX_BUF_SIZE
 	int "Size of receive buffer for dummy interface mcumgr fragments"
 	default 128
 	help
-	  Specifies the size of the mcumgr dummy backend receive buffer,
-	  in bytes. This value must be large enough to accommodate any
-	  line sent by an mcumgr client.
+	  Specifies the size of the MCUmgr dummy backend receive buffer, in bytes. This value
+	  must be large enough to accommodate any line sent by an MCUmgr client.
 
 endif # MCUMGR_TRANSPORT_DUMMY

--- a/subsys/mgmt/mcumgr/transport/Kconfig.shell
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.shell
@@ -10,13 +10,13 @@
 #  MCUMGR_TRANSPORT_SHELL_
 
 menuconfig MCUMGR_TRANSPORT_SHELL
-	bool "Shell mcumgr SMP transport"
+	bool "Shell MCUmgr SMP transport"
 	depends on SHELL
 	depends on BASE64
 	depends on CRC
 	help
-	  Enables handling of SMP commands received over shell.  This allows
-	  the shell to be use for both mcumgr commands and shell commands.
+	  Enables handling of SMP commands received over shell. This allows the shell to be use
+	  for both MCUmgr commands and shell commands.
 
 if MCUMGR_TRANSPORT_SHELL
 
@@ -24,8 +24,8 @@ config MCUMGR_TRANSPORT_SHELL_MTU
 	int "Shell SMP MTU"
 	default 256
 	help
-	  Maximum size of SMP frames sent and received over shell.  This value
-	  must satisfy the following relation:
+	  Maximum size of SMP frames sent and received over shell. This value must satisfy the
+	  following relation:
 	  MCUMGR_TRANSPORT_SHELL_MTU <= MCUMGR_TRANSPORT_NETBUF_SIZE + 2
 
 config MCUMGR_TRANSPORT_SHELL_RX_BUF_COUNT
@@ -37,18 +37,16 @@ config MCUMGR_TRANSPORT_SHELL_RX_BUF_COUNT
 config MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
 	bool "Shell input expiration"
 	help
-	  If enabled, will time out a partial or erroneous MCUmgr command
-	  received via the shell transport after a given time. This prevents
-	  the shell from becoming locked if it never receives the full packet
-	  that a header indicated it would receive.
+	  If enabled, will time out a partial or erroneous MCUmgr command received via the shell
+	  transport after a given time. This prevents the shell from becoming locked if it never
+	  receives the full packet that a header indicated it would receive.
 
 config MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT_TIME
 	int "Shell input expiration timeout"
 	depends on MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
 	default 3000
 	help
-	  Time (in msec) after receiving a valid MCUmgr header on the serial
-	  transport before considering it as timed out and returning the shell
-	  to normal operation.
+	  Time (in msec) after receiving a valid MCUmgr header on the serial transport before
+	  considering it as timed out and returning the shell to normal operation.
 
 endif # MCUMGR_TRANSPORT_SHELL

--- a/subsys/mgmt/mcumgr/transport/Kconfig.uart
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.uart
@@ -10,16 +10,15 @@
 #  MCUMGR_TRANSPORT_UART_
 
 menuconfig MCUMGR_TRANSPORT_UART
-	bool "UART mcumgr SMP transport"
+	bool "UART MCUmgr SMP transport"
 	depends on CONSOLE
 	depends on BASE64
 	depends on CRC
 	select UART_MCUMGR
 	help
-	  Enables handling of SMP commands received over UART.  This is a
-	  lightweight alternative to MCUMGR_TRANSPORT_SHELL.  It allows mcumgr
-	  commands to be received over UART without requiring an additional
-	  thread.
+	  Enables handling of SMP commands received over UART. This is a lightweight alternative
+	  to MCUMGR_TRANSPORT_SHELL. It allows MCUmgr commands to be received over UART without
+	  requiring an additional thread.
 
 if MCUMGR_TRANSPORT_UART
 
@@ -28,7 +27,7 @@ if UART_ASYNC_API
 menuconfig MCUMGR_TRANSPORT_UART_ASYNC
 	bool "Use async UART API when available"
 	help
-	  The option enables use of UART async API when available for selected mcumgr uart port.
+	  The option enables use of UART async API when available for selected MCUmgr UART port.
 
 if MCUMGR_TRANSPORT_UART_ASYNC
 
@@ -39,7 +38,7 @@ config MCUMGR_TRANSPORT_UART_ASYNC_BUFS
 	help
 	  The asynchronous UART API requires registering RX buffers for received data; when the RX
 	  reaches the end of a buffer, it will send event requesting next buffer, to be able to
-	  receive data without stopping due to running out of buffer space.  At least two buffers
+	  receive data without stopping due to running out of buffer space. At least two buffers
 	  area required for smooth RX operation.
 
 config MCUMGR_TRANSPORT_UART_ASYNC_BUF_SIZE
@@ -56,8 +55,8 @@ config MCUMGR_TRANSPORT_UART_MTU
 	int "UART SMP MTU"
 	default 256
 	help
-	  Maximum size of SMP frames sent and received over UART, in bytes.
-	  This value must satisfy the following relation:
+	  Maximum size of SMP frames sent and received over UART, in bytes. This value must
+	  satisfy the following relation:
 	  MCUMGR_TRANSPORT_UART_MTU <= MCUMGR_TRANSPORT_NETBUF_SIZE + 2
 
 endif # MCUMGR_TRANSPORT_UART

--- a/subsys/mgmt/mcumgr/transport/Kconfig.udp
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.udp
@@ -10,7 +10,7 @@
 #  MCUMGR_TRANSPORT_UDP_
 
 menuconfig MCUMGR_TRANSPORT_UDP
-	bool "UDP mcumgr SMP transport"
+	bool "UDP MCUmgr SMP transport"
 	depends on NET_UDP
 	depends on NET_SOCKETS
 	select NET_CONNECTION_MANAGER
@@ -88,9 +88,8 @@ config MCUMGR_TRANSPORT_UDP_AUTOMATIC_INIT
 	default y
 	depends on !MCUMGR_TRANSPORT_UDP_DTLS
 	help
-	  Enable starting the UDP SMP transport at boot time without needing
-	  any code in the application to do this, otherwise will need the user
-	  application to manually start and stop the transport using
-	  `smp_udp_open` and `smp_udp_close`.
+	  Enable starting the UDP SMP transport at boot time without needing any code in the
+	  application to do this, otherwise will need the user application to manually start and
+	  stop the transport using `smp_udp_open` and `smp_udp_close`.
 
 endif # MCUMGR_TRANSPORT_UDP

--- a/subsys/mgmt/mcumgr/util/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/util/CMakeLists.txt
@@ -8,7 +8,7 @@
 # MCUmgr utilities, for use within the library.
 # API interface for utilities is exposed by mgmt_mcumgr_util,
 # and should not be exposed outside of mgmt_mcumgr.
-zephyr_library()
+zephyr_library_named(mcumgr_util)
 zephyr_library_sources(src/zcbor_bulk.c)
 
 zephyr_include_directories(include)


### PR DESCRIPTION
    Fixes various issues in the Kconfigs including not properly having
    abbreviations in the correct case, line lengths, duplicating other
    Kconfigs, etc.


    Refactors these so that each group defines the events it raises


    Adds names to these libraries to prevent using auto-generated names
    of the paths, which can be longer than the maximum supported
    length on the current version of gcc for windows
