### PR TITLE
drivers: dma: stm32: only control IRQ settings in dma_config

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -518,11 +518,15 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	/* Enable transfer complete ISR if in non-cyclic mode or a callback is requested */
 	if (!stream->cyclic || stream->dma_callback != NULL) {
 		LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
+	} else {
+		LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
 	}
 
 	/* Enable Half-Transfer irq if circular mode is enabled and a callback is requested */
 	if (stream->cyclic && stream->dma_callback != NULL) {
 		LL_DMA_EnableIT_HT(dma, dma_stm32_id_to_stream(id));
+	} else {
+		LL_DMA_DisableIT_HT(dma, dma_stm32_id_to_stream(id));
 	}
 
 #if defined(CONFIG_DMA_STM32_V1)
@@ -641,15 +645,6 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 	if (!stm32_dma_is_enabled_stream(dma, id)) {
 		return 0;
 	}
-
-#if !defined(CONFIG_DMAMUX_STM32) \
-	|| defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32MP1X)
-	LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
-#endif /* CONFIG_DMAMUX_STM32 */
-
-#if defined(CONFIG_DMA_STM32_V1)
-	stm32_dma_disable_fifo_irq(dma, id);
-#endif
 
 	dma_stm32_clear_stream_irq(dev, id);
 	dma_stm32_disable_stream(dma, id);


### PR DESCRIPTION
The current implementation doesn't allow (re)starting a DMA transfer either via `dma_start` or `dma_reload` after `dma_stop` has been called, as `dma_stop` disables the completion IRQ, and `dma_start` and `dma_reload` don't enable them.

Since the DMA stream doesn't trigger interrupts when disabled, disabling the stream itself in `dma_stop` is sufficient, so `dma_config` shall be responsible for enabling and for disabling the IRQs, depending on the configuration.

With this change in place, many drivers using dma could perform the `dma_config` in their `init` method (as most of the configuration is fixed or defined in DT), and only rely on `dma_reload` / `dma_start` and `dma_stop` API at the rest of the runtime.