### PR TITLE
boards: nxp: mimxrt1170_evk: unify the documentation title

### DIFF
--- a/boards/nxp/mimxrt1170_evk/board.yml
+++ b/boards/nxp/mimxrt1170_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mimxrt1170_evk
-  full_name: MIMXRT1170-EVK/EVKB
+  full_name: MIMXRT1170-EVK
   vendor: nxp
   socs:
     - name: mimxrt1176


### PR DESCRIPTION
Removed revision from the MIMXRT1170-EVK documentation title, to be consistent with all other MIMXRT boards.