### PR TITLE
Bluetooth: Tester: Remove empty file hci_ipc.conf

### DIFF
--- a/tests/bluetooth/tester/hci_ipc.conf
+++ b/tests/bluetooth/tester/hci_ipc.conf
@@ -1,1 +1,0 @@
-# left empty until autopts has been updated to stop using it


### PR DESCRIPTION
The file is unused and the use of it has been removed from autopts.

depends on https://github.com/auto-pts/auto-pts/pull/1662