### PR TITLE
dts: arm: st: n6: fix `reg` property of NPU

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1331,9 +1331,9 @@
 			status = "disabled";
 		};
 
-		npu: npu@580c0000 {
+		npu: npu@580e0000 {
 			compatible = "st,stm32-npu";
-			reg = <0x580c0000 0x1000>;
+			reg = <0x580e0000 DT_SIZE_K(128)>;
 			clocks = <&rcc STM32_CLOCK(AHB5, 31)>,
 				 <&rcc STM32_CLOCK(AHB5, 30)>;
 			clock-names = "npu", "cacheaxi";


### PR DESCRIPTION
The reg property on the NPU node indicated a base address of 0x580C0000 and size of 4 KiB, neither of which are correct (in fact, this base address is the one of the OTGPHYC2).

Set the reg property to the correct values: the NPU instance is mapped at 0x580E0000 and occupies 128 KiB of address space.

(this had no impact because the property is currently not used)

From RM0486:
<img width="637" height="266" alt="image" src="https://github.com/user-attachments/assets/d4bf7ffb-abd1-4e6d-92b5-cf425d1731dc" />
