### PR TITLE
kernel: nothread: fix build when CONFIG_SYS_CLOCK_EXISTS=n

### DIFF
--- a/kernel/nothread.c
+++ b/kernel/nothread.c
@@ -14,7 +14,9 @@ bool k_is_in_isr(void)
 	return arch_is_in_isr();
 }
 
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 static K_TIMER_DEFINE(sleep_timer, NULL, NULL);
+#endif
 
 /* This is a fallback implementation of k_sleep() for when multi-threading is
  * disabled. The main implementation is in sched.c.
@@ -34,6 +36,7 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 		return (int32_t) K_TICKS_FOREVER;
 	}
 
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 	k_timer_start(&sleep_timer, timeout, K_NO_WAIT);
 
 	/* When multithreading is disabled, this will enter a low power state
@@ -48,4 +51,33 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 	 * sleep for the entire timeout duration (no thread to awake).
 	 */
 	return 0;
+#else
+	/* Fallback to busy-wait when no system clock is available */
+	k_ticks_t ticks;
+	uint32_t ticks_to_wait;
+
+	ticks = timeout.ticks;
+	if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
+		/* ticks is delta timeout */
+		ticks_to_wait = ticks;
+	} else {
+		/* ticks is absolute timeout expiration */
+		uint32_t curr_ticks = sys_clock_tick_get_32();
+
+		if (Z_TICK_ABS(ticks) > curr_ticks) {
+			ticks_to_wait = Z_TICK_ABS(ticks) - curr_ticks;
+		} else {
+			ticks_to_wait = 0;
+		}
+	}
+
+	/* busy wait to be time coherent since subsystems may depend on it */
+	z_impl_k_busy_wait(k_ticks_to_us_ceil32(ticks_to_wait));
+
+	int32_t ret = k_ticks_to_ms_ceil64(0);
+
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
+
+	return ret;
+#endif
 }


### PR DESCRIPTION
The k_timer API requires CONFIG_SYS_CLOCK_EXISTS to be enabled, as timer.c is only compiled when this config is set. Guard the timer-based k_sleep() implementation and fall back to the previous busy-wait approach when no system clock exists.

Fix a regression caused by https://github.com/zephyrproject-rtos/zephyr/pull/101192