### PR TITLE
drivers: usb: usb_dc_numaker: make usbd_ep_fifo_copy_from_user void

### DIFF
--- a/drivers/usb/device/usb_dc_numaker.c
+++ b/drivers/usb/device/usb_dc_numaker.c
@@ -536,7 +536,7 @@ static int numaker_usbd_ep_fifo_copy_to_user(struct numaker_usbd_ep *ep_cur, uin
  *
  * size_p holds size to copy/copied on input/output
  */
-static int numaker_usbd_ep_fifo_copy_from_user(struct numaker_usbd_ep *ep_cur,
+static void numaker_usbd_ep_fifo_copy_from_user(struct numaker_usbd_ep *ep_cur,
 					       const uint8_t *usrbuf, uint32_t *size_p)
 {
 	const struct device *dev = ep_cur->dev;
@@ -562,8 +562,6 @@ static int numaker_usbd_ep_fifo_copy_from_user(struct numaker_usbd_ep *ep_cur,
 	if (ep_cur->write_fifo_free == 0) {
 		ep_cur->write_fifo_pos = ep_cur->dmabuf_base;
 	}
-
-	return 0;
 }
 
 /* Update EP read/write FIFO on DATA OUT/IN completed */
@@ -1701,11 +1699,7 @@ int usb_dc_ep_write(const uint8_t ep, const uint8_t *const data_buf, const uint3
 	/* NOTE: Null data or zero data length are valid, used for ZLP */
 	if (data_buf && data_len) {
 		data_len_act = data_len;
-		rc = numaker_usbd_ep_fifo_copy_from_user(ep_cur, data_buf, &data_len_act);
-		if (rc < 0) {
-			LOG_ERR("Copy to FIFO from user buffer");
-			goto cleanup;
-		}
+		numaker_usbd_ep_fifo_copy_from_user(ep_cur, data_buf, &data_len_act);
 	} else {
 		data_len_act = 0;
 	}

--- a/drivers/usb/device/usb_dc_numaker.c
+++ b/drivers/usb/device/usb_dc_numaker.c
@@ -506,7 +506,7 @@ static void numaker_usbd_setup_fifo_copy_to_user(const struct device *dev, uint8
  *
  * size_p holds size to copy/copied on input/output
  */
-static int numaker_usbd_ep_fifo_copy_to_user(struct numaker_usbd_ep *ep_cur, uint8_t *usrbuf,
+static void numaker_usbd_ep_fifo_copy_to_user(struct numaker_usbd_ep *ep_cur, uint8_t *usrbuf,
 					     uint32_t *size_p)
 {
 	const struct device *dev = ep_cur->dev;
@@ -528,8 +528,6 @@ static int numaker_usbd_ep_fifo_copy_to_user(struct numaker_usbd_ep *ep_cur, uin
 	if (ep_cur->read_fifo_used == 0) {
 		ep_cur->read_fifo_pos = ep_cur->dmabuf_base;
 	}
-
-	return 0;
 }
 
 /* Copy data from user buffer to EP FIFO
@@ -1807,12 +1805,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data_buf, uint32_t max_data_len, ui
 	 */
 	if (data_buf) {
 		data_len_act = max_data_len;
-		rc = numaker_usbd_ep_fifo_copy_to_user(ep_cur, data_buf, &data_len_act);
-		if (rc < 0) {
-			LOG_ERR("Copy from FIFO to user buffer");
-			goto cleanup;
-		}
-
+		numaker_usbd_ep_fifo_copy_to_user(ep_cur, data_buf, &data_len_act);
 		if (read_bytes) {
 			*read_bytes = data_len_act;
 		}


### PR DESCRIPTION
numaker_usbd_ep_fifo_copy_from_user() never reports errors and always returns 0.
The error check at the call site is therefore dead code.

Make the function void and drop the unused error handling.