### PR TITLE
MAINTAINERS: update Zephyr 4.4 release engineers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4463,6 +4463,9 @@ Release:
 Release Notes:
   status: maintained
   maintainers:
+    - MaureenHelm
+    - stephanosio
+  collaborators:
     - kartben
   files:
     - doc/releases/migration-guide-*


### PR DESCRIPTION
Make Zephyr 4.4 release engineers maintainers of release notes and migration guide for the time being.