### PR TITLE
subsys: net: lib: websocket: remove usage of legacy Mbed TLS crypto

### DIFF
--- a/subsys/net/lib/shell/websocket.c
+++ b/subsys/net/lib/shell/websocket.c
@@ -14,11 +14,12 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
-#include "websocket/websocket_internal.h"
-
 #include <zephyr/sys/fdtable.h>
 
 #if defined(CONFIG_WEBSOCKET_CLIENT)
+
+#include "websocket/websocket_internal.h"
+
 static void websocket_context_cb(struct websocket_context *context,
 				 void *user_data)
 {

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -7,9 +7,9 @@ config WEBSOCKET_CLIENT
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	select HTTP_CLIENT
-	select MBEDTLS
 	select BASE64
-	select MBEDTLS_SHA1 if MBEDTLS_BUILTIN
+	select PSA_CRYPTO
+	select PSA_WANT_ALG_SHA_256
 	select EXPERIMENTAL
 	help
 	  Enable Websocket client library.

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -30,11 +30,7 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/base64.h>
 
-#ifdef CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT
 #include <psa/crypto.h>
-#else
-#include <mbedtls/sha1.h>
-#endif /* CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT */
 
 #include "net_private.h"
 #include "sockets_internal.h"
@@ -253,10 +249,8 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 		"Sec-WebSocket-Version: 13\r\n",
 		NULL
 	};
-#ifdef CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT
 	psa_status_t psa_status;
 	size_t hash_length;
-#endif /* CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT */
 
 	fd = -1;
 
@@ -284,7 +278,6 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	ctx->http_cb = wreq->http_cb;
 	ctx->is_client = 1;
 
-#ifdef CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT
 	psa_status = psa_hash_compute(PSA_ALG_SHA_1, (const uint8_t *)&rnd_value, sizeof(rnd_value),
 				      sec_accept_key, sizeof(sec_accept_key), &hash_length);
 	if (psa_status != PSA_SUCCESS) {
@@ -292,15 +285,6 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 		ret = -EPROTO;
 		goto out;
 	}
-#else
-	ret = mbedtls_sha1((const unsigned char *)&rnd_value, sizeof(rnd_value), sec_accept_key);
-	if (ret != 0) {
-		NET_DBG("[%p] Cannot calculate sha1 (%d)", ctx, ret);
-		ret = -EPROTO;
-		goto out;
-	}
-#endif /* CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT */
-
 
 	ret = base64_encode(sec_ws_key + sizeof("Sec-Websocket-Key: ") - 1,
 			    sizeof(sec_ws_key) -
@@ -363,7 +347,6 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	memcpy(key_accept + key_len, WS_MAGIC, olen);
 
 	/* This SHA-1 value is then checked when we receive the response */
-#ifdef CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT
 	psa_status = psa_hash_compute(PSA_ALG_SHA_1, (const uint8_t *)key_accept, olen + key_len,
 				      sec_accept_key, sizeof(sec_accept_key), &hash_length);
 	if (psa_status != PSA_SUCCESS) {
@@ -371,14 +354,6 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 		ret = -EPROTO;
 		goto out;
 	}
-#else
-	ret = mbedtls_sha1(key_accept, olen + key_len, sec_accept_key);
-	if (ret != 0) {
-		NET_DBG("[%p] Cannot calculate sha1 (%d)", ctx, ret);
-		ret = -EPROTO;
-		goto out;
-	}
-#endif /* CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT */
 
 	ret = http_client_req(sock, &req, timeout, ctx);
 	if (ret < 0) {

--- a/subsys/net/lib/websocket/websocket_internal.h
+++ b/subsys/net/lib/websocket/websocket_internal.h
@@ -11,8 +11,9 @@
  */
 
 #include <zephyr/toolchain/common.h>
+#include <psa/crypto.h>
 
-#define WS_SHA1_OUTPUT_LEN 20
+#define WS_SHA1_OUTPUT_LEN PSA_HASH_LENGTH(PSA_ALG_SHA_1)
 
 /* Min Websocket header length */
 #define MIN_HEADER_LEN 2


### PR DESCRIPTION
Remove optional use of legacy Mbed TLS crypto in favor of the already existing PSA Crypto API alternative. This is required in order to jump to the next version of Mbed TLS (i.e. 4.0) where all this legacy crypto support is no more available.