### PR TITLE
doc: Supplement the DT extension API documentation

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -296,6 +296,16 @@ and properties related to them.
 
 .. doxygengroup:: devicetree-mbox
 
+.. _devicetree-nvmem-api:
+
+NVMEM
+=====
+
+These conveniences may be used for nodes which describe Non-Volatile
+Memory, and properties related to them.
+
+.. doxygengroup:: devicetree-nvmem
+
 .. _devicetree-pinctrl-api:
 
 Pinctrl (pin control)

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -257,6 +257,16 @@ controllers or channels, and properties related to them.
 
 .. doxygengroup:: devicetree-dmas
 
+.. _devicetree-display-api:
+
+Display
+=======
+
+These conveniences may be used for nodes which describe display
+controllers, and properties related to them.
+
+.. doxygengroup:: devicetree-display
+
 .. _devicetree-flash-api:
 
 Fixed flash partitions

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -288,6 +288,16 @@ and properties related to them.
 
 .. doxygengroup:: devicetree-gpio
 
+.. _devicetree-hwspinlock-api:
+
+HWSpinlock
+==========
+
+These conveniences may be used for nodes which describe hardware spinlock,
+and properties related to them.
+
+.. doxygengroup:: devicetree-hwspinlock
+
 IO channels
 ===========
 

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -316,6 +316,16 @@ Memory, and properties related to them.
 
 .. doxygengroup:: devicetree-nvmem
 
+.. _devicetree-ordinals-api:
+
+Ordinals
+========
+
+These conveniences may be used for nodes which describe Dependency
+tracking, and properties related to them.
+
+.. doxygengroup:: devicetree-dep-ord
+
 .. _devicetree-pinctrl-api:
 
 Pinctrl (pin control)


### PR DESCRIPTION
It looks like the homepage is missing some documentation :(
<img width="331" height="379" alt="image" src="https://github.com/user-attachments/assets/4105ef0a-d423-4894-acef-14c47f6547ab" />
