### PR TITLE
smf: add compile check for ancestors.

### DIFF
--- a/include/zephyr/smf.h
+++ b/include/zephyr/smf.h
@@ -15,6 +15,14 @@
 
 #include <zephyr/sys/util.h>
 
+#define CHECK_SMF_PARENT(_parent)                                                                  \
+	({                                                                                         \
+		BUILD_ASSERT(                                                                      \
+			IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT) || (_parent == NULL),              \
+			"Parent state assigned, but CONFIG_SMF_ANCESTOR_SUPPORT is disabled!");    \
+		_parent;                                                                           \
+	})
+
 /**
  * @brief State Machine Framework API
  * @defgroup smf State Machine Framework API
@@ -33,13 +41,14 @@
  * @param _initial State initial transition object or NULL
  */
 /* clang-format off */
-#define SMF_CREATE_STATE(_entry, _run, _exit, _parent, _initial)           \
-{                                                                          \
-	.entry   = _entry,                                                 \
-	.run     = _run,                                                   \
-	.exit    = _exit,                                                  \
-	IF_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT, (.parent = _parent,))      \
-	IF_ENABLED(CONFIG_SMF_INITIAL_TRANSITION, (.initial = _initial,))  \
+#define SMF_CREATE_STATE(_entry, _run, _exit, _parent, _initial)            \
+{                                                                           \
+	.entry   = _entry,                                                      \
+	.run     = _run,                                                        \
+	.exit    = _exit,                                                       \
+	IF_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT, (.parent = _parent,))           \
+	IF_DISABLED(CONFIG_SMF_ANCESTOR_SUPPORT, (.parent = CHECK_SMF_PARENT(_parent),)) \
+	IF_ENABLED(CONFIG_SMF_INITIAL_TRANSITION, (.initial = _initial,))       \
 }
 /* clang-format on */
 


### PR DESCRIPTION
currently in SMF when `CONFIG_SMF_ANCESTOR_SUPPORT` or `CONFIG_SMF_INITIAL_TRANSITION` is disabled the value assigned to the member silently gets dropped when using the `SMF_CREATE_STATE()` macro. The goal of this PR is to add a clear compile time error which instructs the developer that this is happening when they are providing a non null value to the disabled member.

I spent time debugging what I assumed to be bad application level logic but it turned out that I forgot to enable ancestors; maybe this change could save someone else some time aswell.