### PR TITLE
boards: kit_pse84_*: add ram property to boards

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -7,6 +7,7 @@ identifier: kit_pse84_ai/pse846gps2dbzc4a/m33
 name: PSOC Edge84 AI Kit (M33_S)
 type: mcu
 arch: arm
+ram: 5120
 sysbuild: true
 toolchain:
   - zephyr

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -7,6 +7,7 @@ identifier: kit_pse84_ai/pse846gps2dbzc4a/m55
 name: PSOC Edge84 AI Kit (M55)
 type: mcu
 arch: arm
+ram: 5120
 sysbuild: true
 toolchain:
   - zephyr

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -8,6 +8,7 @@ name: PSOC Edge84 Evaluation Kit (M33_S)
 type: mcu
 arch: arm
 sysbuild: true
+ram: 5120
 toolchain:
   - zephyr
 supported:

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -7,6 +7,7 @@ identifier: kit_pse84_eval/pse846gps2dbzc4a/m55
 name: PSOC Edge84 Evaluation Kit (M55)
 type: mcu
 arch: arm
+ram: 5120
 sysbuild: true
 toolchain:
   - zephyr


### PR DESCRIPTION
Adds ram property to some targets for Zephyr testing purposes