### PR TITLE
mem_mgmt: add mem_attr_get_region_index_by_name()

### DIFF
--- a/include/zephyr/mem_mgmt/mem_attr.h
+++ b/include/zephyr/mem_mgmt/mem_attr.h
@@ -105,6 +105,16 @@ size_t mem_attr_get_regions(const struct mem_attr_region_t **region);
  */
 int mem_attr_check_buf(void *addr, size_t size, uint32_t attr);
 
+/**
+ * @brief Find the index of a memory region by its node name.
+ *
+ * @param target_name The memory node full name to search for.
+ *
+ * @return The index of the memory region in the regions array.
+ * @retval -ENOENT The region was not found.
+ */
+int mem_attr_get_region_index_by_name(const char *target_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mem_mgmt/mem_attr.c
+++ b/subsys/mem_mgmt/mem_attr.c
@@ -7,6 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 
+#include <string.h>
+
 #define _BUILD_MEM_ATTR_REGION(node_id)					\
 	{								\
 		.dt_name = DT_NODE_FULL_NAME(node_id),			\
@@ -58,4 +60,21 @@ int mem_attr_check_buf(void *v_addr, size_t size, uint32_t attr)
 		}
 	}
 	return -ENOBUFS;
+}
+
+int mem_attr_get_region_index_by_name(const char *target_name)
+{
+	const struct mem_attr_region_t *regions;
+	size_t num_regions;
+
+	num_regions = mem_attr_get_regions(&regions);
+
+	for (int i = 0; i < num_regions; ++i) {
+		if (regions[i].dt_name != NULL &&
+		    strcmp(regions[i].dt_name, target_name) == 0) {
+			return i;
+		}
+	}
+
+	return -ENOENT;
 }

--- a/tests/subsys/mem_mgmt/mem_attr/src/main.c
+++ b/tests/subsys/mem_mgmt/mem_attr/src/main.c
@@ -84,4 +84,26 @@ ZTEST(mem_attr, test_mem_attr)
 		      -ENOBUFS, "Unexpected return value");
 }
 
+ZTEST(mem_attr, test_get_index_by_name_success)
+{
+	int index;
+
+	/* Check first region */
+	index = mem_attr_get_region_index_by_name("memory@10000000");
+	zassert_equal(index, 0, "Index for 'memory@10000000 should be 0");
+
+	/* Check second region */
+	index = mem_attr_get_region_index_by_name("memory@20000000");
+	zassert_equal(index, 1, "Index for 'memory@20000000 should be 1");
+}
+
+ZTEST(mem_attr, test_get_index_by_name_not_found)
+{
+	int index;
+
+	/* Search for a non-existent memory node name */
+	index = mem_attr_get_region_index_by_name("memory@30000000");
+	zassert_equal(index, -ENOENT, "Should return -ENOENT for unknown names");
+}
+
 ZTEST_SUITE(mem_attr, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add a new API to look up a memory region's index using its DeviceTree node name. This allows callers to identify specific regions within the internal regions array.

Includes unit tests for successful lookups and error handling for non-existent names.