### PR TITLE
net: coap: coap_client: fix request validation order in coap_client_req

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -419,10 +419,15 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 {
 	int ret;
 	struct coap_client_internal_request *internal_req;
-	size_t pathlen = strnlen(req->path, MAX_PATH_SIZE);
+	size_t pathlen;
 
-	if (client == NULL || sock < 0 || req == NULL || pathlen == 0 ||
-	    pathlen == MAX_PATH_SIZE || req->num_options > MAX_EXTRA_OPTIONS) {
+	if (client == NULL || sock < 0 || req == NULL || req->num_options > MAX_EXTRA_OPTIONS) {
+		return -EINVAL;
+	}
+
+	pathlen = strnlen(req->path, MAX_PATH_SIZE);
+
+	if (pathlen == 0 || pathlen == MAX_PATH_SIZE) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Avoid accessing request fields before validating input arguments in coap_client_req().

The request path length is now checked only after validating the request pointer, preventing a potential NULL pointer dereference.

No functional change intended.