### PR TITLE
scripts: twister: use `os.scandir` for platform YAML discovery

### DIFF
--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -213,16 +213,19 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
             if board_dir in dir2data:
                 # don't load the same board data twice
                 continue
-            file = board_dir / "twister.yaml"
-            if file.is_file():
-                data = scl.yaml_load_verify(file, Platform.platform_schema)
-            else:
-                data = None
-            dir2data[board_dir] = data
+            data = None
 
-            legacy_files.extend(
-                file for file in board_dir.glob("*.yaml") if file.name != "twister.yaml"
-            )
+            with os.scandir(board_dir) as it:
+                for entry in it:
+                    if not entry.is_file():
+                        continue
+
+                    if entry.name == "twister.yaml":
+                        data = scl.yaml_load_verify(entry.path, Platform.platform_schema)
+                    elif entry.name.endswith(".yaml"):
+                        legacy_files.append(entry.path)
+
+            dir2data[board_dir] = data
 
         for qual in list_boards.board_v2_qualifiers(board):
             if board.revisions:
@@ -295,7 +298,7 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
         board = target2board[target]
         if dir2data[board.dir] is not None:
             # all targets are already loaded for this board
-            logger.error(f"Duplicate platform {target} in {file.parent}")
+            logger.error(f"Duplicate platform {target} in {os.path.dirname(file)}")
             raise Exception(f"Duplicate platform identifier {target} found")
 
         platform = Platform()

--- a/scripts/tests/twister/test_data/boards/1_level/2_level/board.yml
+++ b/scripts/tests/twister/test_data/boards/1_level/2_level/board.yml
@@ -1,14 +1,17 @@
 boards:
 
   - name: demo_board_1
+    full_name: Demo Board 1
     vendor: zephyr
     socs:
       - name: unit_testing
   - name: demo_board_2
+    full_name: Demo Board 2
     vendor: zephyr
     socs:
       - name: unit_testing
   - name: demo_board_3
+    full_name: Demo Board 3
     vendor: zephyr
     socs:
       - name: unit_testing

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -191,10 +191,12 @@ def test_generate_platforms(
         'm0/boards/zephyr/p1/board.yml': """\
 boards:
   - name: p1e1
+    full_name: p1e1
     vendor: zephyr
     socs:
       - name: s1
   - name: p1e2
+    full_name: p1e2
     vendor: zephyr
     socs:
       - name: s1
@@ -211,6 +213,7 @@ variants:
         'm0/boards/zephyr/p2/board.yml': """\
 boards:
   - name: p2
+    full_name: p2
     vendor: zephyr
     socs:
       - name: s1
@@ -226,6 +229,7 @@ testing:
         'm0/boards/arm/p3/board.yml': """\
 board:
   name: p3
+  full_name: p3
   vendor: arm
   revision:
     format: letter
@@ -296,6 +300,7 @@ identifier: p2/s1/v1
 boards:
   - extend: p3
   - name: p4
+    full_name: p4
     vendor: misc
     socs:
       - name: s1

--- a/scripts/tests/twister_blackbox/test_data/boards/others/dummy_board/board.yml
+++ b/scripts/tests/twister_blackbox/test_data/boards/others/dummy_board/board.yml
@@ -1,5 +1,6 @@
 board:
   name: dummy
+  full_name: dummy
   vendor: others
   socs:
   - name: unit_testing


### PR DESCRIPTION
Use a single `os.scandir()` pass per board directory to load `twister.yaml` and collect legacy `*.yaml` files, replacing `Path` checks and globbing.

On my end this reduces execution time by ~50ms on Ubuntu 24.04 and eliminates  ~80k Python function calls.