### PR TITLE
riscv: csr: replace GNU statement expressions with inline helpers

### DIFF
--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -62,7 +62,7 @@ static inline void DBG(char *msg, struct k_thread *t) { }
 
 static void z_riscv_fpu_disable(void)
 {
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	__ASSERT((status & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
 
@@ -76,9 +76,8 @@ static void z_riscv_fpu_disable(void)
 
 static void z_riscv_fpu_load(void)
 {
-	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
-		 "must be called with IRQs disabled");
-	__ASSERT((csr_read(mstatus) & MSTATUS_FS) == 0,
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_FS) == 0,
 		 "must be called with FPU access disabled");
 
 	/* become new owner */
@@ -100,9 +99,8 @@ static void z_riscv_fpu_load(void)
  */
 void arch_flush_local_fpu(void)
 {
-	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
-		 "must be called with IRQs disabled");
-	__ASSERT((csr_read(mstatus) & MSTATUS_FS) == 0,
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_FS) == 0,
 		 "must be called with FPU access disabled");
 
 	struct k_thread *owner = atomic_ptr_get(&_current_cpu->arch.fpu_owner);
@@ -132,8 +130,7 @@ void arch_flush_local_fpu(void)
 #ifdef CONFIG_SMP
 static void flush_owned_fpu(struct k_thread *thread)
 {
-	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
-		 "must be called with IRQs disabled");
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
 
 	int i;
 	atomic_ptr_val_t owner;
@@ -206,8 +203,7 @@ void z_riscv_fpu_enter_exc(void)
  */
 void z_riscv_fpu_trap(struct arch_esf *esf)
 {
-	__ASSERT((esf->mstatus & MSTATUS_FS) == 0 &&
-		 (csr_read(mstatus) & MSTATUS_FS) == 0,
+	__ASSERT((esf->mstatus & MSTATUS_FS) == 0 && (csr_read(CSR_MSTATUS) & MSTATUS_FS) == 0,
 		 "called despite FPU being accessible");
 
 	/* save current owner's content  if any */
@@ -253,8 +249,7 @@ void z_riscv_fpu_trap(struct arch_esf *esf)
  */
 static bool fpu_access_allowed(unsigned int exc_update_level)
 {
-	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
-		 "must be called with IRQs disabled");
+	__ASSERT((csr_read(CSR_MSTATUS) & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
 
 	if (_current->arch.exception_depth == exc_update_level) {
 		/* We're about to execute non-exception code */

--- a/arch/riscv/core/ipi_clint.c
+++ b/arch/riscv/core/ipi_clint.c
@@ -47,7 +47,7 @@ static void sched_ipi_handler(const void *unused)
 {
 	ARG_UNUSED(unused);
 
-	MSIP(csr_read(mhartid)) = 0;
+	MSIP(csr_read(CSR_MHARTID)) = 0;
 
 	atomic_val_t pending_ipi = atomic_clear(&cpu_pending_ipi[_current_cpu->id]);
 

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -30,7 +30,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 
 	ARG_UNUSED(unused);
 
-	mcause = csr_read(mcause);
+	mcause = csr_read(CSR_MCAUSE);
 
 	mcause &= CONFIG_RISCV_MCAUSE_EXCEPTION_MASK;
 

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -147,17 +147,17 @@ void z_riscv_pmp_read_config(unsigned long *pmp_cfg, size_t pmp_cfg_size)
 
 #ifdef CONFIG_64BIT
 	/* RV64: pmpcfg0 holds entries 0-7; pmpcfg2 holds entries 8-15. */
-	pmp_cfg[0] = csr_read(pmpcfg0);
+	pmp_cfg[0] = csr_read(CSR_PMPCFG0);
 #if CONFIG_PMP_SLOTS > 8
-	pmp_cfg[1] = csr_read(pmpcfg2);
+	pmp_cfg[1] = csr_read(CSR_PMPCFG2);
 #endif
 #else
 	/* RV32: Each pmpcfg register holds 4 entries. */
-	pmp_cfg[0] = csr_read(pmpcfg0);
-	pmp_cfg[1] = csr_read(pmpcfg1);
+	pmp_cfg[0] = csr_read(CSR_PMPCFG0);
+	pmp_cfg[1] = csr_read(CSR_PMPCFG1);
 #if CONFIG_PMP_SLOTS > 8
-	pmp_cfg[2] = csr_read(pmpcfg2);
-	pmp_cfg[3] = csr_read(pmpcfg3);
+	pmp_cfg[2] = csr_read(CSR_PMPCFG2);
+	pmp_cfg[3] = csr_read(CSR_PMPCFG3);
 #endif
 #endif
 }
@@ -177,7 +177,7 @@ void z_riscv_pmp_read_addr(unsigned long *pmp_addr, size_t pmp_addr_size)
 {
 	__ASSERT(pmp_addr_size == (size_t)(CONFIG_PMP_SLOTS), "PMP address array size mismatch");
 
-#define PMPADDR_READ(x) pmp_addr[x] = csr_read(pmpaddr##x)
+#define PMPADDR_READ(x) pmp_addr[x] = csr_read(CSR_PMPADDR##x)
 	FOR_EACH(PMPADDR_READ, (;), 0, 1, 2, 3, 4, 5, 6, 7);
 
 #if CONFIG_PMP_SLOTS > 8

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -164,7 +164,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 				_current->stack_info.size -
 				_current->stack_info.delta);
 
-	status = csr_read(mstatus);
+	status = csr_read(CSR_MSTATUS);
 
 	/* Set next CPU status to user mode */
 	status = INSERT_FIELD(status, MSTATUS_MPP, PRV_U);

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -35,7 +35,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	csr_write(mscratch, &_kernel.cpus[0]);
 #endif
 #ifdef CONFIG_SMP
-	_kernel.cpus[0].arch.hartid = csr_read(mhartid);
+	_kernel.cpus[0].arch.hartid = csr_read(CSR_MHARTID);
 	_kernel.cpus[0].arch.online = true;
 #endif
 #if ((CONFIG_MP_MAX_NUM_CPUS) > 1)

--- a/drivers/cache/cache_andes.c
+++ b/drivers/cache/cache_andes.c
@@ -79,7 +79,7 @@ static ALWAYS_INLINE int nds_l2_cache_init(uint8_t line_size) { return 0; }
 static ALWAYS_INLINE int nds_cctl_range_operations(void *addr, size_t size, int line_size, int cmd)
 {
 	unsigned long last_byte, align_addr;
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	last_byte = (unsigned long)addr + size - 1;
 	align_addr = ROUND_DOWN(addr, line_size);
@@ -108,7 +108,7 @@ static ALWAYS_INLINE int nds_cctl_range_operations(void *addr, size_t size, int 
 static ALWAYS_INLINE int nds_l1i_cache_all(int op)
 {
 	unsigned long sets, ways, end;
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	if (csr_read(NDS_MMSC_CFG) & MMSC_CFG_VCCTL_2) {
 		/*
@@ -136,7 +136,7 @@ static ALWAYS_INLINE int nds_l1i_cache_all(int op)
 
 static ALWAYS_INLINE int nds_l1d_cache_all(int op)
 {
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	if (csr_read(NDS_MMSC_CFG) & MMSC_CFG_VCCTL_2) {
 		/*
@@ -227,7 +227,7 @@ void cache_data_enable(void)
 
 void cache_data_disable(void)
 {
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	if (IS_ENABLED(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)) {
 		return;

--- a/drivers/cache/cache_andes_l2.h
+++ b/drivers/cache/cache_andes_l2.h
@@ -81,7 +81,7 @@ static ALWAYS_INLINE int nds_l2_cache_all(int op)
 {
 	unsigned long ways, sets, index, cmd;
 	uint8_t hart_id;
-	unsigned long status = csr_read(mstatus);
+	unsigned long status = csr_read(CSR_MSTATUS);
 
 	if (!l2_cache_cfg.size) {
 		return -ENOTSUP;

--- a/drivers/interrupt_controller/intc_clic.c
+++ b/drivers/interrupt_controller/intc_clic.c
@@ -46,7 +46,7 @@ static ALWAYS_INLINE void disable_pmp_stack_guard(struct pmp_stack_guard_key_t *
 {
 	if (IS_ENABLED(CONFIG_PMP_STACK_GUARD)) {
 		key->irq_key = irq_lock();
-		key->mstatus = csr_read_clear(mstatus, MSTATUS_MPRV);
+		key->mstatus = csr_read_clear(CSR_MSTATUS, MSTATUS_MPRV);
 	} else {
 		ARG_UNUSED(key);
 	}

--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -230,7 +230,7 @@ uint8_t __soc_ram_code get_irq(void *arg)
 						find_msb_set(int_pending) - 1;
 				LOG_DBG("Pending interrupt found: %d",
 						intc_irq);
-				LOG_DBG("CPU mepc: 0x%lx", csr_read(mepc));
+				LOG_DBG("CPU mepc: 0x%lx", csr_read(CSR_MEPC));
 				break;
 			}
 		}

--- a/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
@@ -217,7 +217,7 @@ uint8_t __soc_ram_code get_irq(void *arg)
 						find_msb_set(int_pending) - 1;
 				LOG_DBG("Pending interrupt found: %d",
 						intc_irq);
-				LOG_DBG("CPU mepc: 0x%lx", csr_read(mepc));
+				LOG_DBG("CPU mepc: 0x%lx", csr_read(CSR_MEPC));
 				break;
 			}
 		}

--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -14,13 +14,13 @@
 
 static ALWAYS_INLINE uint32_t arch_proc_id(void)
 {
-	return csr_read(mhartid) & ((uintptr_t)CONFIG_RISCV_HART_MASK);
+	return csr_read(CSR_MHARTID) & ((uintptr_t)CONFIG_RISCV_HART_MASK);
 }
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 #if defined(CONFIG_SMP) || defined(CONFIG_USERSPACE)
-	return (_cpu_t *)csr_read(mscratch);
+	return (_cpu_t *)csr_read(CSR_MSCRATCH);
 #else
 	return &_kernel.cpus[0];
 #endif

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -156,6 +156,37 @@
 #define IRQ_COP		12
 #define IRQ_HOST	13
 
+/* Standard RISC-V CSR numbers */
+#define CSR_MSTATUS	0x300
+#define CSR_MIE		0x304
+#define CSR_MSCRATCH	0x340
+#define CSR_MEPC	0x341
+#define CSR_MCAUSE	0x342
+#define CSR_MHARTID	0xF14
+
+/* PMP CSR numbers */
+#define CSR_PMPCFG0	0x3A0
+#define CSR_PMPCFG1	0x3A1
+#define CSR_PMPCFG2	0x3A2
+#define CSR_PMPCFG3	0x3A3
+
+#define CSR_PMPADDR0	0x3B0
+#define CSR_PMPADDR1	0x3B1
+#define CSR_PMPADDR2	0x3B2
+#define CSR_PMPADDR3	0x3B3
+#define CSR_PMPADDR4	0x3B4
+#define CSR_PMPADDR5	0x3B5
+#define CSR_PMPADDR6	0x3B6
+#define CSR_PMPADDR7	0x3B7
+#define CSR_PMPADDR8	0x3B8
+#define CSR_PMPADDR9	0x3B9
+#define CSR_PMPADDR10	0x3BA
+#define CSR_PMPADDR11	0x3BB
+#define CSR_PMPADDR12	0x3BC
+#define CSR_PMPADDR13	0x3BD
+#define CSR_PMPADDR14	0x3BE
+#define CSR_PMPADDR15	0x3BF
+
 /* SMRNMI CSR addresses */
 #ifdef CONFIG_RISCV_SMRNMI_ENABLE_NMI_DELIVERY
 #define CSR_MNSCRATCH 0x740
@@ -207,13 +238,15 @@
 
 #ifndef _ASMLANGUAGE
 
-#define csr_read(csr)						\
-({								\
-	register unsigned long __rv;				\
-	__asm__ volatile ("csrr %0, " STRINGIFY(csr)		\
-				: "=r" (__rv));			\
-	__rv;							\
-})
+static inline unsigned long csr_read_num(unsigned int csr)
+{
+	unsigned long val;
+
+	__asm__ volatile ("csrr %0, %1" : "=r" (val) : "i" (csr));
+	return val;
+}
+
+#define csr_read(csr) csr_read_num(csr)
 
 #define csr_write(csr, val)					\
 	do {							\
@@ -225,14 +258,17 @@
 	} while (0)
 
 
-#define csr_read_set(csr, val)					\
-({								\
-	unsigned long __rsv = (unsigned long)(val);		\
-	__asm__ volatile ("csrrs %0, " STRINGIFY(csr) ", %1"	\
-				: "=r" (__rsv) : "rK" (__rsv)	\
-				: "memory");			\
-	__rsv;							\
-})
+static inline unsigned long csr_read_set_num(unsigned int csr, unsigned long val)
+{
+	unsigned long ret;
+	unsigned long set = val;
+
+	__asm__ volatile ("csrrs %0, %1, %2"
+			  : "=r" (ret) : "i" (csr), "rK" (set) : "memory");
+	return ret;
+}
+
+#define csr_read_set(csr, val) csr_read_set_num(csr, (unsigned long)(val))
 
 #define csr_set(csr, val)					\
 	do {							\
@@ -243,14 +279,17 @@
 				  : "memory");		\
 	} while (0)
 
-#define csr_read_clear(csr, val)				\
-({								\
-	unsigned long __rcv = (unsigned long)(val);		\
-	__asm__ volatile ("csrrc %0, " STRINGIFY(csr) ", %1"	\
-				: "=r" (__rcv) : "rK" (__rcv)	\
-				: "memory");			\
-	__rcv;							\
-})
+static inline unsigned long csr_read_clear_num(unsigned int csr, unsigned long val)
+{
+	unsigned long ret;
+	unsigned long clr = val;
+
+	__asm__ volatile ("csrrc %0, %1, %2"
+			  : "=r" (ret) : "i" (csr), "rK" (clr) : "memory");
+	return ret;
+}
+
+#define csr_read_clear(csr, val) csr_read_clear_num(csr, (unsigned long)(val))
 
 #define csr_clear(csr, val)					\
 	do {							\

--- a/soc/common/riscv-privileged/soc_common_irq.c
+++ b/soc/common/riscv-privileged/soc_common_irq.c
@@ -65,7 +65,7 @@ void arch_irq_enable(unsigned int irq)
 	 * CSR mie register is updated using atomic instruction csrrs
 	 * (atomic read and set bits in CSR register)
 	 */
-	mie = csr_read_set(mie, 1 << irq);
+	mie = csr_read_set(CSR_MIE, 1 << irq);
 }
 
 void arch_irq_disable(unsigned int irq)
@@ -85,7 +85,7 @@ void arch_irq_disable(unsigned int irq)
 	 * Use atomic instruction csrrc to disable device interrupt in mie CSR.
 	 * (atomic read and clear bits in CSR register)
 	 */
-	mie = csr_read_clear(mie, 1 << irq);
+	mie = csr_read_clear(CSR_MIE, 1 << irq);
 }
 
 int arch_irq_is_enabled(unsigned int irq)
@@ -100,7 +100,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	}
 #endif
 
-	mie = csr_read(mie);
+	mie = csr_read(CSR_MIE);
 
 	return !!(mie & (1 << irq));
 }

--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -274,7 +274,7 @@ void __start(void)
 			     "csrw mtvec, t0\n");
 
 	/* Disable normal interrupts. */
-	csr_read_clear(mstatus, MSTATUS_MIE);
+	csr_read_clear(CSR_MSTATUS, MSTATUS_MIE);
 
 	/* Configure the global pointer register
 	 * (This should be the first thing startup does, as any other piece of code could be

--- a/soc/ite/ec/common/soc_common_irq.c
+++ b/soc/ite/ec/common/soc_common_irq.c
@@ -34,8 +34,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	 * bit, and SOC's IER are both true.
 	 */
 	if (IS_ENABLED(CONFIG_HAS_ITE_INTC)) {
-		return ((csr_read(mie) & BIT(IRQ_M_EXT)) &&
-			ite_intc_irq_is_enable(irq));
+		return ((csr_read(CSR_MIE) & BIT(IRQ_M_EXT)) && ite_intc_irq_is_enable(irq));
 	} else {
 		return 0;
 	}

--- a/tests/arch/riscv/fpu_sharing/src/main.c
+++ b/tests/arch/riscv/fpu_sharing/src/main.c
@@ -13,7 +13,7 @@
 
 static inline unsigned long fpu_state(void)
 {
-	return csr_read(mstatus) & MSTATUS_FS;
+	return csr_read(CSR_MSTATUS) & MSTATUS_FS;
 }
 
 static inline bool fpu_is_off(void)
@@ -282,7 +282,7 @@ static void exception_context(const void *arg)
 	zassert_true(fpu_is_dirty());
 
 	/* IRQs should have been disabled on us to prevent recursive FPU usage */
-	zassert_true((csr_read(mstatus) & MSTATUS_IEN) == 0, "IRQs should be disabled");
+	zassert_true((csr_read(CSR_MSTATUS) & MSTATUS_IEN) == 0, "IRQs should be disabled");
 }
 
 ZTEST(riscv_fpu_sharing, test_thread_vs_exc_interaction)
@@ -294,11 +294,11 @@ ZTEST(riscv_fpu_sharing, test_thread_vs_exc_interaction)
 	zassert_true(fpu_is_dirty());
 
 	/* We're not in exception so IRQs should be enabled. */
-	zassert_true((csr_read(mstatus) & MSTATUS_IEN) != 0, "IRQs should be enabled");
+	zassert_true((csr_read(CSR_MSTATUS) & MSTATUS_IEN) != 0, "IRQs should be enabled");
 
 	/* Exceptions with no FPU usage shouldn't affect our state. */
 	irq_offload(exception_context, NO_FPU);
-	zassert_true((csr_read(mstatus) & MSTATUS_IEN) != 0, "IRQs should be enabled");
+	zassert_true((csr_read(CSR_MSTATUS) & MSTATUS_IEN) != 0, "IRQs should be enabled");
 	zassert_true(fpu_is_dirty());
 	__asm__ volatile ("fcvt.w.s %0, fa1" : "=r" (val));
 	zassert_true(val == 654, "got %d instead", val);
@@ -311,7 +311,7 @@ ZTEST(riscv_fpu_sharing, test_thread_vs_exc_interaction)
 	 * upon leaving the exception, but with a clean state at that point.
 	 */
 	irq_offload(exception_context, WITH_FPU);
-	zassert_true((csr_read(mstatus) & MSTATUS_IEN) != 0, "IRQs should be enabled");
+	zassert_true((csr_read(CSR_MSTATUS) & MSTATUS_IEN) != 0, "IRQs should be enabled");
 	zassert_true(fpu_is_clean());
 	__asm__ volatile ("fcvt.w.s %0, fa1" : "=r" (val));
 	zassert_true(val == 654, "got %d instead", val);
@@ -322,7 +322,7 @@ ZTEST(riscv_fpu_sharing, test_thread_vs_exc_interaction)
 	 * This means our FPU context should not be preemptively restored.
 	 */
 	irq_offload(exception_context, WITH_FPU);
-	zassert_true((csr_read(mstatus) & MSTATUS_IEN) != 0, "IRQs should be enabled");
+	zassert_true((csr_read(CSR_MSTATUS) & MSTATUS_IEN) != 0, "IRQs should be enabled");
 	zassert_true(fpu_is_off());
 
 	/* Make sure we still have proper context when accessing the FPU. */

--- a/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/src/main.c
+++ b/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/src/main.c
@@ -10,13 +10,13 @@
 /* Checks if the Machine Privilege Register Virtualization (MPRV) bit in mstatus is 1 (enabled). */
 static bool riscv_mprv_is_enabled(void)
 {
-	return csr_read(mstatus) & MSTATUS_MPRV;
+	return csr_read(CSR_MSTATUS) & MSTATUS_MPRV;
 }
 
 /* Checks if the Machine Previous Privilege (MPP) field in mstatus is set to M-Mode (0b11). */
 static bool riscv_mpp_is_m_mode(void)
 {
-	return (csr_read(mstatus) & MSTATUS_MPP) == MSTATUS_MPP;
+	return (csr_read(CSR_MSTATUS) & MSTATUS_MPP) == MSTATUS_MPP;
 }
 
 /**

--- a/tests/arch/riscv/pmp/mem-attr-entries/src/main.c
+++ b/tests/arch/riscv/pmp/mem-attr-entries/src/main.c
@@ -13,13 +13,13 @@
 /* Checks if the Machine Privilege Register Virtualization (MPRV) bit in mstatus is 1 (enabled). */
 static bool riscv_mprv_is_enabled(void)
 {
-	return csr_read(mstatus) & MSTATUS_MPRV;
+	return csr_read(CSR_MSTATUS) & MSTATUS_MPRV;
 }
 
 /* Checks if the Machine Previous Privilege (MPP) field in mstatus is set to M-Mode (0b11). */
 static bool riscv_mpp_is_m_mode(void)
 {
-	return (csr_read(mstatus) & MSTATUS_MPP) == MSTATUS_MPP;
+	return (csr_read(CSR_MSTATUS) & MSTATUS_MPP) == MSTATUS_MPP;
 }
 
 /* Helper structure to define the expected PMP regions derived from the Device Tree. */


### PR DESCRIPTION
This PR consists of:

- Add numeric CSR constants (`CSR_MSTATUS`, `CSR_MIE`, etc.) for standard RISC-V machine-mode CSRs and PMP registers, previously we were relying on assembler to identify them
- Replace `csr_read`, `csr_read_set`, `csr_read_clear` statement-expression macros with inline functions that take numeric CSR IDs
- Update all call sites to use `CSR_*` constants

This removes GNU statement expressions (`({...})`) which can cause warnings with strict compiler settings or non-GCC compilers.

Now, I have a question - this creates inconsistency from csr_read and csr_write functions, but I don't understand how we could get rid of that warning in any other possible way. Should I keep on updating the write functions to inline functions rather than macros?