### PR TITLE
drivers: can: nxp: mcux: flexcan: add proper support for clock multiplexer

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -104,6 +104,10 @@ Controller Area Network (CAN)
   :dtcompatible:`nxp,flexcan-fd` with per-instance ``number-of-mb`` and
   ``number-of-mb-fd`` devicetree properties (:github:`99483`).
 
+* The :dtcompatible:`nxp,flexcan` ``clk-source`` devicetree property, if present, now automatically
+  selects between the named input clocks ``clksrc0`` and ``clksrc1`` for use as the CAN protocol
+  engine clock.
+
 Counter
 =======
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2026 Vestas Wind Systems A/S
  * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -64,7 +64,7 @@ struct mcux_flexcan_config {
 
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
-	int clk_source;
+	uint32_t clk_source;
 	uint32_t number_of_mb;
 	uint32_t rx_mb;
 	uint32_t tx_mb;
@@ -1521,7 +1521,7 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
 		.clock_subsys = (clock_control_subsys_t)		\
 			DT_INST_CLOCKS_CELL(id, name),			\
-		.clk_source = DT_INST_PROP(id, clk_source),		\
+		.clk_source = DT_INST_PROP_OR(id, clk_source, 0U),	\
 		.number_of_mb = FLEXCAN_INST_NUMBER_OF_MB(id),		\
 		.rx_mb = FLEXCAN_INST_RX_MB(id),			\
 		.tx_mb = FLEXCAN_INST_TX_MB(id),			\

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -30,7 +30,9 @@
 			interrupts = <94 0>, <95 0>, <96 0>, <97 0>, <98 0>, <99 0>;
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning",
 					  "rx-warning", "wake-up";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
+			clocks = <&sim KINETIS_SIM_OSCERCLK 0x1030 4>,
+				 <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -521,7 +521,9 @@
 			interrupts = <75 0>, <76 0>, <77 0>, <78 0>, <79 0>, <80 0>;
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning",
 					  "wake-up";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
+			clocks = <&sim KINETIS_SIM_OSCERCLK 0x103C 4>,
+				 <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2026 Vestas Wind Systems A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -407,9 +407,9 @@
 			compatible = "nxp,flexcan";
 			reg = <0x40024000 0x1000>;
 			interrupts = <78 0>, <79 0>, <80 0>, <81 0>;
-			interrupt-names = "warning", "error", "wake-up",
-					  "mb-0-15";
-			clocks = <&scg KINETIS_SCG_BUS_CLK>;
+			interrupt-names = "warning", "error", "wake-up", "mb-0-15";
+			clocks = <&scg KINETIS_SCG_SOSC_ASYNC_DIV2_CLK>, <&scg KINETIS_SCG_BUS_CLK>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
 			status = "disabled";
@@ -419,9 +419,9 @@
 			compatible = "nxp,flexcan";
 			reg = <0x40025000 0x1000>;
 			interrupts = <85 0>, <86 0>, <87 0>, <88 0>;
-			interrupt-names = "warning", "error", "wake-up",
-					  "mb-0-15";
-			clocks = <&scg KINETIS_SCG_BUS_CLK>;
+			interrupt-names = "warning", "error", "wake-up", "mb-0-15";
+			clocks = <&scg KINETIS_SCG_SOSC_ASYNC_DIV2_CLK>, <&scg KINETIS_SCG_BUS_CLK>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -293,7 +293,6 @@
 			interrupts = <19 0>;
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
-			clk-source = <0>;
 			number-of-mb = <32>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -288,7 +288,6 @@
 			interrupts = <19 0>;
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
-			clk-source = <0>;
 			number-of-mb = <32>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxa5x_common.dtsi
@@ -487,7 +487,6 @@
 		interrupts = <19 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		status = "disabled";
 	};
@@ -498,7 +497,6 @@
 		interrupts = <20 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -289,8 +289,9 @@
 			interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 			interrupt-names = "ored-warning-bus-off", "error", "wake-up",
 					  "mb-0-15", "mb-16-31";
-
-			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
+			clocks = <&scg KINETIS_SCG_SOSC_ASYNC_DIV2_CLK>,
+				 <&scg KINETIS_SCG_CORESYS_CLK>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			status = "disabled";
 		};
@@ -300,7 +301,9 @@
 			reg = <0x40025000 0x1000>;
 			interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 			interrupt-names = "ored-warning-bus-off", "error", "mb-0-15", "mb-16-31";
-			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
+			clocks = <&scg KINETIS_SCG_SOSC_ASYNC_DIV2_CLK>,
+				 <&scg KINETIS_SCG_CORESYS_CLK>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			status = "disabled";
 		};
@@ -310,7 +313,9 @@
 			reg = <0x4002b000 0x1000>;
 			interrupts = <92 0>, <93 0>, <95 0>, <96 0>;
 			interrupt-names = "ored-warning-bus-off", "error", "mb-0-15", "mb-16-31";
-			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
+			clocks = <&scg KINETIS_SCG_SOSC_ASYNC_DIV2_CLK>,
+				 <&scg KINETIS_SCG_CORESYS_CLK>;
+			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe31x_common.dtsi
@@ -324,7 +324,6 @@
 		interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
 		interrupt-names = "flexcan0-0", "flexcan0-1", "flexcan0-2", "flexcan0-3";
 		clocks = <&mc_cgm MCUX_FLEXCAN0_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 
@@ -334,7 +333,6 @@
 		interrupts = <113 0>, <114 0>, <115 0>;
 		interrupt-names = "flexcan1-0", "flexcan1-1", "flexcan1-2";
 		clocks = <&mc_cgm MCUX_FLEXCAN1_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 
@@ -344,7 +342,6 @@
 		interrupts = <116 0>, <117 0>, <118 0>;
 		interrupt-names = "flexcan2-0", "flexcan2-1", "flexcan2-2";
 		clocks = <&mc_cgm MCUX_FLEXCAN2_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 
@@ -354,7 +351,6 @@
 		interrupts = <119 0>, <120 0>;
 		interrupt-names = "flexcan3-0", "flexcan3-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN3_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 
@@ -364,7 +360,6 @@
 		interrupts = <121 0>, <122 0>;
 		interrupt-names = "flexcan4-0", "flexcan4-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN4_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 
@@ -374,7 +369,6 @@
 		interrupts = <123 0>, <124 0>;
 		interrupt-names = "flexcan5-0", "flexcan5-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN5_CLK>;
-		clk-source = <0>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -923,7 +923,6 @@
 		interrupts = <62 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		number-of-mb-fd = <7>;
 		status = "disabled";
@@ -935,7 +934,6 @@
 		interrupts = <63 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		number-of-mb-fd = <7>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -117,7 +117,6 @@
 		interrupts = <63 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		number-of-mb-fd = <7>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1105,7 +1105,6 @@
 		interrupts = <62 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
-		clk-source = <0>;
 		number-of-mb = <32>;
 		number-of-mb-fd = <7>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -376,7 +376,6 @@
 		interrupts = <47 0>;
 		interrupt-names = "common";
 		clocks = <&scg SCG_K4_FIRC_CLK 0xec>;
-		clk-source = <2>;
 		number-of-mb = <32>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -969,7 +969,6 @@
 			interrupts = <36 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
-			clk-source = <2>;
 			number-of-mb = <64>;
 			status = "disabled";
 		};
@@ -980,7 +979,6 @@
 			interrupts = <37 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
-			clk-source = <2>;
 			number-of-mb = <64>;
 			status = "disabled";
 		};
@@ -991,7 +989,6 @@
 			interrupts = <154 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
-			clk-source = <2>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -785,6 +785,7 @@
 		interrupts = <8 0>, <9 0>;
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
+		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
 		number-of-mb-fd = <21>;
@@ -797,6 +798,7 @@
 		interrupts = <51 0>, <52 0>;
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
+		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
 		number-of-mb-fd = <21>;
@@ -809,6 +811,7 @@
 		interrupts = <191 0>, <192 0>;
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
+		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
 		number-of-mb-fd = <21>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -916,6 +916,7 @@
 			interrupts = <44 0>, <45 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
+			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;
@@ -928,6 +929,7 @@
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
+			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;
@@ -940,6 +942,7 @@
 			interrupts = <48 0>, <49 0>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
+			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -73,6 +73,8 @@
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	clock-names = "clksrc1";
+	clk-source = <1>;
 	number-of-mb = <32>;
 	number-of-mb-fd = <7>;
 };
@@ -82,5 +84,7 @@
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "warning", "error", "mb-0-15";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	clock-names = "clksrc1";
+	clk-source = <1>;
 	number-of-mb = <16>;
 };

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -96,6 +96,8 @@
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	clock-names = "clksrc1";
+	clk-source = <1>;
 	number-of-mb = <32>;
 	number-of-mb-fd = <7>;
 };
@@ -104,6 +106,8 @@
 	interrupts = <92 0>, <93 0>, <95 0>, <96 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	clock-names = "clksrc1";
+	clk-source = <1>;
 	number-of-mb = <32>;
 	number-of-mb-fd = <7>;
 };

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -53,6 +53,7 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40024000 0x1000>;
 			clocks = <&clock NXP_S32_FLEXCAN0_CLK>;
+			clock-names = "clksrc1";
 			clk-source = <1>;
 			status = "disabled";
 		};
@@ -60,14 +61,12 @@
 		flexcan1: can@40025000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40025000 0x1000>;
-			clk-source = <1>;
 			status = "disabled";
 		};
 
 		flexcan2: can@4002b000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x4002b000 0x1000>;
-			clk-source = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -475,7 +475,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40304000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
-			clk-source = <0>;
 			interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
 			interrupt-names = "ored", "ored_0_31_mb",
 					  "ored_32_63_mb", "ored_64_95_mb";
@@ -488,7 +487,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40308000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
-			clk-source = <0>;
 			interrupts = <113 0>, <114 0>, <115 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
@@ -500,7 +498,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x4030c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
-			clk-source = <0>;
 			interrupts = <116 0>, <117 0>, <118 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
@@ -512,7 +509,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40310000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
-			clk-source = <0>;
 			interrupts = <119 0>, <120 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
@@ -524,7 +520,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40314000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
-			clk-source = <0>;
 			interrupts = <121 0>, <122 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
@@ -536,7 +531,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40318000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
-			clk-source = <0>;
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;

--- a/dts/arm/nxp/nxp_s32k566.dtsi
+++ b/dts/arm/nxp/nxp_s32k566.dtsi
@@ -551,7 +551,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x42174000 0x4000>;
 			clocks = <&clock NXP_S32_LPE_FLEXCAN_PE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -562,7 +561,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40290000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN0_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -573,7 +571,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40294000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN1_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -584,7 +581,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x40298000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN2_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -595,7 +591,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x4029c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN3_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -606,7 +601,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x402a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN4_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -617,7 +611,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x402a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN5_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -628,7 +621,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x402a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN6_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -639,7 +631,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x402ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN7_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -650,7 +641,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x406b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN8_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -661,7 +651,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x406b4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN9_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -672,7 +661,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x406ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN10_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -683,7 +671,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x4089c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN11_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -694,7 +681,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x408a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN12_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -705,7 +691,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x408a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN13_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -716,7 +701,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x408a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN14_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -727,7 +711,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x408ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN15_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
@@ -738,7 +721,6 @@
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x408b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN16_PE_NOGATE_CLK>;
-			clk-source = <0>;
 			number-of-mb = <96>;
 			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -747,7 +747,6 @@
 		flexcan0: can@449a0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x449a0000 0x4000>;
-			clk-source = <0>;
 			interrupts = <GIC_SPI 581 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 583 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 584 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -764,7 +763,6 @@
 		flexcan1: can@449b0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
 			reg = <0x449b0000 0x4000>;
-			clk-source = <0>;
 			interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 589 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 590 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -780,7 +778,6 @@
 
 		flexcan2: can@449c0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x449c0000 0x4000>;
 			interrupts = <GIC_SPI 593 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 595 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -797,7 +794,6 @@
 
 		flexcan3: can@449d0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x449d0000 0x4000>;
 			interrupts = <GIC_SPI 599 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 601 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -814,7 +810,6 @@
 
 		flexcan4: can@449e0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x449e0000 0x4000>;
 			interrupts = <GIC_SPI 605 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 607 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -831,7 +826,6 @@
 
 		flexcan5: can@449f0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x449f0000 0x4000>;
 			interrupts = <GIC_SPI 611 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 613 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -848,7 +842,6 @@
 
 		flexcan6: can@44ba0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44ba0000 0x4000>;
 			interrupts = <GIC_SPI 617 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 619 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -865,7 +858,6 @@
 
 		flexcan7: can@44bb0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44bb0000 0x4000>;
 			interrupts = <GIC_SPI 623 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 625 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -882,7 +874,6 @@
 
 		flexcan8: can@44bc0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44bc0000 0x4000>;
 			interrupts = <GIC_SPI 629 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 631 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -899,7 +890,6 @@
 
 		flexcan9: can@44bd0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44bd0000 0x4000>;
 			interrupts = <GIC_SPI 635 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 637 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -916,7 +906,6 @@
 
 		flexcan10: can@44be0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44be0000 0x4000>;
 			interrupts = <GIC_SPI 641 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 643 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -933,7 +922,6 @@
 
 		flexcan11: can@44bf0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44bf0000 0x4000>;
 			interrupts = <GIC_SPI 647 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 649 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -950,7 +938,6 @@
 
 		flexcan12: can@44da0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44da0000 0x4000>;
 			interrupts = <GIC_SPI 653 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 655 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -967,7 +954,6 @@
 
 		flexcan13: can@44db0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44db0000 0x4000>;
 			interrupts = <GIC_SPI 659 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 661 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -984,7 +970,6 @@
 
 		flexcan14: can@44dc0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44dc0000 0x4000>;
 			interrupts = <GIC_SPI 665 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 667 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1001,7 +986,6 @@
 
 		flexcan15: can@44dd0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44dd0000 0x4000>;
 			interrupts = <GIC_SPI 671 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 673 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1018,7 +1002,6 @@
 
 		flexcan16: can@44de0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44de0000 0x4000>;
 			interrupts = <GIC_SPI 677 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 679 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1035,7 +1018,6 @@
 
 		flexcan17: can@44df0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44df0000 0x4000>;
 			interrupts = <GIC_SPI 683 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 685 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1052,7 +1034,6 @@
 
 		flexcan18: can@44fa0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44fa0000 0x4000>;
 			interrupts = <GIC_SPI 689 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 691 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1069,7 +1050,6 @@
 
 		flexcan19: can@44fb0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44fb0000 0x4000>;
 			interrupts = <GIC_SPI 695 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 697 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1086,7 +1066,6 @@
 
 		flexcan20: can@44fc0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44fc0000 0x4000>;
 			interrupts = <GIC_SPI 701 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 703 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1103,7 +1082,6 @@
 
 		flexcan21: can@44fd0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44fd0000 0x4000>;
 			interrupts = <GIC_SPI 707 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 709 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1120,7 +1098,6 @@
 
 		flexcan22: can@44fe0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44fe0000 0x4000>;
 			interrupts = <GIC_SPI 713 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 715 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -1137,7 +1114,6 @@
 
 		flexcan23: can@44ff0000 {
 			compatible = "nxp,flexcan-fd", "nxp,flexcan";
-			clk-source = <0>;
 			reg = <0x44ff0000 0x4000>;
 			interrupts = <GIC_SPI 719 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 721 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -197,6 +197,7 @@
 				     <GIC_SPI 143 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
+			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;
@@ -213,6 +214,7 @@
 				     <GIC_SPI 145 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
+			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
 			number-of-mb-fd = <14>;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -419,6 +419,7 @@
 			     <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
+		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
 		number-of-mb-fd = <21>;
@@ -433,6 +434,7 @@
 			     <GIC_SPI 52 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
+		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
 		number-of-mb-fd = <21>;

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -36,12 +36,25 @@ properties:
   clocks:
     required: true
 
+  clock-names:
+    description: |
+      Required if the "clk-source" property is present.
+
   clk-source:
     type: int
     enum:
       - 0
       - 1
-    description: CAN engine clock source
+    description: |
+      CAN engine clock source. The value of this property, if present, selects the corresponding
+      named clock from the "clocks" property. A value of "0" selects "clksrc0" whereas a value of
+      "1" selects "clksrc1".
+
+      The value of this property is written to the CLKSRC bit of the FlexCAN CTRL1 register for
+      controlling the 1-bit, internal clock multiplexer.
+
+      Omit this property for FlexCAN instances that do not have a 1-bit, internal multiplexer
+      (FlexCAN CTRL1 register bit 13 is marked as "reserved").
 
   number-of-mb:
     type: int

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Vestas Wind Systems A/S
+# Copyright (c) 2019-2026 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -38,7 +38,9 @@ properties:
 
   clk-source:
     type: int
-    required: true
+    enum:
+      - 0
+      - 1
     description: CAN engine clock source
 
   number-of-mb:


### PR DESCRIPTION
Add proper support for the 1-bit CAN protocol engine clock multiplexer present in some NXP FlexCAN instances.

Make the clk-source property of the NXP FlexCAN devicetree nodes optional as not all FlexCAN instances have an internal clock multiplexer.

Remove the clk-source property from the SoCs where the internal clock multiplexer is not present, limit the values this property can be assigned, and default the clock selection bit to 0 in the driver.

Both possible input clocks are now represented as named clocks in the devicetree nodes ("clksrc0" and "clksrc1") and the existing devicetree property "clk-source" now selects the correct clock in addition to setting the multiplexer bit (CLKSRC) in the FlexCAN CTRL1 register.
    
Fixes: #94517