### PR TITLE
twister: refactor DUT class to dataclass for serialization support

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -765,7 +765,7 @@ class DeviceHandler(Handler):
             ser_pty_master, slave = pty.openpty()
             serial_device = os.ttyname(slave)
 
-        logger.debug(f"Using serial device {serial_device} @ {hardware.baud} baud")
+        logger.debug(f"Using serial device {serial_device} @ {hardware.serial_baud} baud")
 
         command = self._create_command(runner, hardware)
 
@@ -787,7 +787,7 @@ class DeviceHandler(Handler):
             ser = self._create_serial_connection(
                 hardware,
                 serial_port,
-                hardware.baud,
+                hardware.serial_baud,
                 flash_timeout,
                 serial_pty,
                 ser_pty_process
@@ -848,7 +848,7 @@ class DeviceHandler(Handler):
             try:
                 if serial_pty:
                     ser_pty_process = self._start_serial_pty(serial_pty, ser_pty_master)
-                logger.debug(f"Attach serial device {serial_device} @ {hardware.baud} baud")
+                logger.debug(f"Attach serial device {serial_device} @ {hardware.serial_baud} baud")
                 ser.port = serial_device
 
                 # Apply ESP32-specific RTS/DTR reset logic

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -463,7 +463,7 @@ class Pytest(Harness):
         else:
             command.extend([
                 f'--device-serial={hardware.serial}',
-                f'--device-serial-baud={hardware.baud}'
+                f'--device-serial-baud={hardware.serial_baud}'
             ])
             for extra_serial in handler.get_more_serials_from_device(hardware):
                 command.append(f'--device-serial={extra_serial}')

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -41,6 +41,9 @@ sequence:
       "baud":
         type: int
         required: false
+      "serial_baud":
+        type: int
+        required: false
       "post_script":
         type: str
         required: false

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -37,7 +37,7 @@ def mocked_hm():
 TESTDATA_1 = [
     (
         {},
-        {'baud': 115200, 'lock': mock.ANY, 'flash_timeout': 60},
+        {'serial_baud': 115200, 'flash_timeout': 60},
         '<None (None) on None>'
     ),
     (
@@ -63,10 +63,9 @@ TESTDATA_1 = [
                 }
         },
         {
-            'lock': mock.ANY,
             'id': 'dummy id',
             'serial': 'dummy serial',
-            'baud': 4400,
+            'serial_baud': 4400,
             'platform': 'dummy platform',
             'product': 'dummy product',
             'serial_pty': 'dummy serial pty',
@@ -269,7 +268,7 @@ def test_hardwaremap_load():
   runner: r0
   flash_with_test: True
   flash_timeout: 15
-  baud: 14400
+  serial_baud: 14400
   fixtures:
   - dummy fixture 1
   - dummy fixture 2
@@ -310,7 +309,7 @@ def test_hardwaremap_load():
             'runner': 'r0',
             'flash_timeout': 15,
             'flash_with_test': True,
-            'baud': 14400,
+            'serial_baud': 14400,
             'fixtures': ['dummy fixture 1', 'dummy fixture 2'],
             'connected': True,
             'serial': 'dummy',
@@ -322,7 +321,7 @@ def test_hardwaremap_load():
             'runner': 'r1',
             'flash_timeout': 30,
             'flash_with_test': False,
-            'baud': 115200,
+            'serial_baud': 115200,
             'fixtures': [],
             'connected': True,
             'serial': None,
@@ -503,50 +502,45 @@ TESTDATA_5 = [
         '',
         [{
             'serial': 's1',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p1',
             'connected': True,
             'id': 1,
             'product': 'pr1',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's2',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p2',
             'id': 2,
             'product': 'pr2',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's3',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p3',
             'connected': True,
             'id': 3,
             'product': 'pr3',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's4',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p4',
             'id': 4,
             'product': 'pr4',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's5',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p5',
             'connected': True,
             'id': 5,
             'product': 'pr5',
-            'lock': mock.ANY,
             'flash_timeout': 60
         }]
     ),
@@ -603,41 +597,37 @@ TESTDATA_5 = [
         },
         {
             'serial': 's1',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p1',
             'connected': True,
             'id': 1,
             'product': 'pr1',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's2',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p2',
             'id': 2,
             'product': 'pr2',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's3',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p3',
             'connected': True,
             'id': 3,
             'product': 'pr3',
-            'lock': mock.ANY,
             'flash_timeout': 60
         },
         {
             'serial': 's5',
-            'baud': 115200,
+            'serial_baud': 115200,
             'platform': 'p5',
             'connected': True,
             'id': 5,
             'product': 'pr5',
-            'lock': mock.ANY,
             'flash_timeout': 60
         }]
     ),

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -552,7 +552,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
     hardware = mock.Mock()
     hardware.serial_pty = pty_value
     hardware.serial = "serial"
-    hardware.baud = 115200
+    hardware.serial_baud = 115200
     hardware.runner = "runner"
     hardware.runner_params = ["--runner-param1", "runner-param2"]
     hardware.fixtures = ["fixture1:option1", "fixture2"]

--- a/scripts/tests/twister_blackbox/test_hardwaremap.py
+++ b/scripts/tests/twister_blackbox/test_hardwaremap.py
@@ -112,7 +112,7 @@ class TestHardwaremap:
     def test_generate(self, capfd, out_path, manufacturer, product, serial, runner):
         file_name = "test-map.yaml"
         path = os.path.join(ZEPHYR_BASE, file_name)
-        args = ['--outdir', out_path, '--generate-hardware-map', file_name]
+        args = ['--outdir', out_path, '--generate-hardware-map', path]
 
         if os.path.exists(path):
             os.remove(path)
@@ -164,7 +164,7 @@ class TestHardwaremap:
     def test_few_generate(self, capfd, out_path, manufacturer, product, serial, runner):
         file_name = "test-map.yaml"
         path = os.path.join(ZEPHYR_BASE, file_name)
-        args = ['--outdir', out_path, '--generate-hardware-map', file_name]
+        args = ['--outdir', out_path, '--generate-hardware-map', path]
 
         if os.path.exists(path):
             os.remove(path)
@@ -245,7 +245,7 @@ class TestHardwaremap:
     def test_texas_exeption(self, capfd, out_path, manufacturer, product, serial, location):
         file_name = "test-map.yaml"
         path = os.path.join(ZEPHYR_BASE, file_name)
-        args = ['--outdir', out_path, '--generate-hardware-map', file_name]
+        args = ['--outdir', out_path, '--generate-hardware-map', path]
 
         if os.path.exists(path):
             os.remove(path)


### PR DESCRIPTION
Convert the DUT class from a traditional class to a dataclass to enable proper serialization and support for future multi-device testing with pytest-harness.

Key changes:
- Migrated DUT class to use `dataclass` decorator with proper type hints
- Renamed `baud` property to `serial_baud` for consistency
- Updated hardware map schema to support both `baud` (legacy) and `serial_baud` fields for backward compatibility
- Updated tests