### PR TITLE
Adds architectural metadata to RP2040 and RP2350-based boards

### DIFF
--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -144,10 +144,16 @@ zephyr_udc0: &usbd {
 
 pico_spi: &spi0 {};
 
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
 pico_i2c0: &i2c0 {};
 
 pico_i2c1: &i2c1 {};
 
 pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};
 
 zephyr_i2c: &i2c0 {};

--- a/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_hazard3.yaml
+++ b/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_hazard3.yaml
@@ -14,6 +14,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - usbd

--- a/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_m33.yaml
+++ b/boards/pimoroni/pico_plus2/pico_plus2_rp2350b_m33.yaml
@@ -15,6 +15,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - usbd

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -155,8 +155,14 @@ zephyr_udc0: &usbd {
 
 pico_spi: &spi0 {};
 
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
 pico_i2c0: &i2c0 {};
 
 pico_i2c1: &i2c1 {};
 
 pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};

--- a/boards/raspberrypi/rpi_pico/rpi_pico.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_mcuboot.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_mcuboot.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w_mcuboot.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w_mcuboot.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -121,4 +121,16 @@ zephyr_udc0: &usbd {
 	status = "okay";
 };
 
+pico_spi: &spi0 {};
+
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
+pico_i2c0: &i2c0 {};
+
+pico_i2c1: &i2c1 {};
+
 pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_hazard3.yaml
@@ -14,6 +14,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.yaml
@@ -17,6 +17,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.yaml
@@ -15,6 +15,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w.yaml
@@ -15,6 +15,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.yaml
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.yaml
@@ -15,6 +15,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/boards/waveshare/rp2040_plus/board.cmake
+++ b/boards/waveshare/rp2040_plus/board.cmake
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 David Schneider
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(uf2 "--board-id=RPI-RP2")

--- a/boards/waveshare/rp2040_plus/rp2040_plus-pinctrl.dtsi
+++ b/boards/waveshare/rp2040_plus/rp2040_plus-pinctrl.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 David Schneider
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/boards/waveshare/rp2040_plus/rp2040_plus.dts
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.dts
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 David Schneider
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/boards/waveshare/rp2040_plus/rp2040_plus.dts
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.dts
@@ -198,8 +198,14 @@ zephyr_udc0: &usbd {
 
 pico_spi: &spi0 {};
 
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
 pico_i2c0: &i2c0 {};
 
 pico_i2c1: &i2c1 {};
 
 pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};

--- a/boards/waveshare/rp2040_plus/rp2040_plus.yaml
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/waveshare/rp2040_plus/rp2040_plus_defconfig
+++ b/boards/waveshare/rp2040_plus/rp2040_plus_defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 David Schneider
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_SERIAL=y

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -188,6 +188,14 @@ zephyr_udc0: &usbd {
 
 pico_spi: &spi0 {};
 
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
 pico_i2c0: &i2c0 {};
 
 pico_i2c1: &i2c1 {};
+
+pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.yaml
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.yaml
@@ -8,6 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - pico_gpio
+  - pico_i2c
+  - pico_spi
+  - pico_serial
   - uart
   - gpio
   - adc

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -148,8 +148,14 @@ zephyr_udc0: &usbd {
 
 pico_spi: &spi0 {};
 
+pico_spi0: &spi0 {};
+
+pico_i2c: &i2c0 {};
+
 pico_i2c0: &i2c0 {};
 
 pico_i2c1: &i2c1 {};
 
 pico_serial: &uart0 {};
+
+pico_serial0: &uart0 {};

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
@@ -15,6 +15,10 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - pico_gpio
+  - pico_i2c
+  - pico_serial
+  - pico_spi
   - pwm
   - spi
   - uart

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -224,6 +224,9 @@ This is the form factor of the Raspberry Pi Pico boards.
 Relevant devicetree node labels:
 
 - ``pico_header`` See :dtcompatible:`raspberrypi,pico-header` for GPIO pin definitions.
+- ``pico_i2c`` A node label that refers to the same node as either the node label
+  ``pico_i2c0`` or ``pico_i2c1``. It references the node that should be used with
+  priority or as default.
 - ``pico_i2c0``
 - ``pico_i2c1``
 - ``pico_serial``


### PR DESCRIPTION
This is a maintenance changeset and is intended to improve and increase both the adaptability of the relevant boards in DTS overlays and their integration into Twister test cases:

- For better test case filter by `depends_on` the board must provide all supported features at the Raspberry Pi Pico connector.
- For shield or application DTS overlays, the distinction between usable standard interfaces and indexed interfaces should be clarified based on their DTS node reference, e.g.: `pico_i2c0` points to `i2c0` and `pico_i2c1` to `i2c1`, but `pico_i2c` as default points also to `i2c0`.

Boards considered and extended are (in alphabetical order):

- ~KWS Computersysteme GmbH Pico-SPE~ change removed, see: https://github.com/zephyrproject-rtos/zephyr/pull/102071#discussion_r2702618912
- ~KWS Computersysteme GmbH Pico2-SPE~ change removed, see: https://github.com/zephyrproject-rtos/zephyr/pull/102071#discussion_r2702618912
- Pimoroni Pico Plus 2
- Raspberry Pi Pico (W)
- Raspberry Pi Pico 2(W)
- Waveshare RP2040-Plus
- Wiznet W5500 Evaluation Board (W5500-EVB-Pico)
- Wiznet W5500 Evaluation Board with RP2350 (W5500-EVB-Pico2)

Unfortunately, PR #89527 (support for the “Waveshare RP2040-Plus”) included files without a copyright string, which may now lead to a violation of the CI compliance rules. Therefore, there is also a change that corrects this.

Resulting documentation: https://builds.zephyrproject.io/zephyr/pr/102071/docs/hardware/porting/shields.html#pico