### PR TITLE
drivers: w1: test: vnd,w1: fix parameter handling in W1_VND_INIT()

### DIFF
--- a/drivers/w1/w1_test.c
+++ b/drivers/w1/w1_test.c
@@ -62,13 +62,11 @@ static DEVICE_API(w1, w1_vnd_api) = {
 	.configure = w1_vnd_configure,
 };
 
-#define W1_VND_INIT(n)							\
-static const struct w1_vnd_config w1_vnd_cfg_##inst = {			\
-	.master_config.slave_count = W1_INST_SLAVE_COUNT(inst)		\
-};									\
-static struct w1_vnd_data w1_vnd_data_##inst = {};			\
-DEVICE_DT_INST_DEFINE(n, NULL, NULL, &w1_vnd_data_##inst,		\
-		      &w1_vnd_cfg_##inst, POST_KERNEL,			\
-		      CONFIG_W1_INIT_PRIORITY, &w1_vnd_api);
+#define W1_VND_INIT(inst)                                                                          \
+	static const struct w1_vnd_config w1_vnd_cfg_##inst = {.master_config.slave_count =        \
+								       W1_INST_SLAVE_COUNT(inst)}; \
+	static struct w1_vnd_data w1_vnd_data_##inst = {};                                         \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &w1_vnd_data_##inst, &w1_vnd_cfg_##inst,           \
+			      POST_KERNEL, CONFIG_W1_INIT_PRIORITY, &w1_vnd_api);
 
 DT_INST_FOREACH_STATUS_OKAY(W1_VND_INIT)


### PR DESCRIPTION
The `W1_VND_INIT()` has defined the one parameter `n`, but the variable name `inst` was used inside the stringifications.

In addition, clang-format was invoked to meet the CI conformance rule ClangFormat.