### PR TITLE
drivers: display: rm67162: avoid uninitialized variable

### DIFF
--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -355,7 +355,7 @@ static int rm67162_write_fb(const struct device *dev, bool first_write,
 {
 	const struct rm67162_config *config = dev->config;
 	struct rm67162_data *data = dev->data;
-	ssize_t wlen;
+	ssize_t wlen = 0;
 	struct mipi_dsi_msg msg = {0};
 	uint8_t *local_src = (uint8_t *)src;
 	uint32_t len = desc->height * desc->width * data->bytes_per_pixel;


### PR DESCRIPTION
Warning as error was:

```
.../drivers/display/display_rm67162.c: In function ‘rm67162_write_fb’: .../drivers/display/display_rm67162.c:383:9: error: ‘wlen’ may be used
          uninitialized in this function [-Werror=maybe-uninitialized]
  383 |  return wlen;
      |         ^~~~
cc1: all warnings being treated as errors
```