### PR TITLE
drivers: rtc: rpi_pico: avoid corrupted data in tm_wday

### DIFF
--- a/drivers/rtc/rtc_rpi_pico.c
+++ b/drivers/rtc/rtc_rpi_pico.c
@@ -136,21 +136,21 @@ static int rtc_rpi_pico_get_time(const struct device *dev, struct rtc_time *time
 	int err = 0;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	if (!rtc_get_datetime(&dt)) {
+	if (rtc_get_datetime(&dt)) {
+		timeptr->tm_sec = dt.sec;
+		timeptr->tm_min = dt.min;
+		timeptr->tm_hour = dt.hour;
+		timeptr->tm_mday = dt.day;
+		timeptr->tm_mon = dt.month - 1;
+		timeptr->tm_year = dt.year - TM_YEAR_REF;
+		timeptr->tm_wday = dt.dotw;
+		/* unknown values */
+		timeptr->tm_yday = -1;
+		timeptr->tm_isdst = -1;
+		timeptr->tm_nsec = 0;
+	} else {
 		err = -ENODATA;
 	}
-
-	timeptr->tm_sec = dt.sec;
-	timeptr->tm_min = dt.min;
-	timeptr->tm_hour = dt.hour;
-	timeptr->tm_mday = dt.day;
-	timeptr->tm_mon = dt.month - 1;
-	timeptr->tm_year = dt.year - TM_YEAR_REF;
-	timeptr->tm_wday = dt.dotw;
-	/* unknown values */
-	timeptr->tm_yday = -1;
-	timeptr->tm_isdst = -1;
-	timeptr->tm_nsec = 0;
 	k_spin_unlock(&data->lock, key);
 
 	return err;


### PR DESCRIPTION
`tm_wday` (and potentially all other time and date values in the TM structure) may retrieve corrupted data during readout from the hardware via the Pico SDK.

If the referenced data structure `datetime_t dt` is only partially filled or not filled at all via the Pico SDK due to invalid RTC data in the hardware, random data will be copied from the stack to the TM structure without further verification.

Now the Pico RTC driver follows the general idiom: If the answer is unknown, the caller-provided TM structure must not be updated.