### PR TITLE
modules: Update Kconfig USE_RA_FSP for RA I2C Controller

### DIFF
--- a/drivers/i2c/Kconfig.renesas_ra
+++ b/drivers/i2c/Kconfig.renesas_ra
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config I2C_RENESAS_RA_IIC
-	bool "Renesas RA I2C IIC Master"
+	bool "Renesas RA I2C IIC Controller"
 	default y
 	depends on DT_HAS_RENESAS_RA_IIC_ENABLED
-	select USE_RA_FSP_I2C_IIC
+	select USE_RA_FSP_I2C_IIC_CONTROLLER
 	select PINCTRL
 	help
-	  Enable Renesas RA I2C IIC Driver.
+	  Enable Renesas RA I2C IIC Controller Driver.
 
 config I2C_RENESAS_RA_SCI
 	bool "Renesas RA SCI I2C"

--- a/modules/Kconfig.renesas
+++ b/modules/Kconfig.renesas
@@ -40,10 +40,10 @@ config USE_RA_FSP_DTC
 	help
 	  Enable RA FSP DTC driver
 
-config USE_RA_FSP_I2C_IIC
+config USE_RA_FSP_I2C_IIC_CONTROLLER
 	bool
 	help
-	  Enable Renesas RA I2C IIC Master driver
+	  Enable Renesas RA I2C IIC Controller driver
 
 config USE_RA_FSP_SCI_I2C
 	bool

--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 6894582f2d7ff750caa60d60dd5ccac7927b72e4
+      revision: 56c35ce22bac062a9d6b1fc87f145b5d48571efb
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Since the latest `hal_renesas` has updated the I2C Controller config to build the IIC Controller source. Without this update, many current PRs on mainstream that have the update for `hal_renesas` revision will fail.