### PR TITLE
drivers: watchdog: wdt_mcux_wdog32: Add dynamic clock configuration support

### DIFF
--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (2) 2019 Vestas Wind Systems A/S
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * Based on wdt_mcux_wdog.c, which is:
  * Copyright (c) 2018, NXP
@@ -205,6 +205,27 @@ static int mcux_wdog32_init(const struct device *dev)
 {
 	const struct mcux_wdog32_config *config = dev->config;
 
+#if (!DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency))
+	int ret;
+
+	ret = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	if (ret != 0) {
+		/* Check if error is due to lack of support */
+		if (ret != -ENOSYS) {
+			/* Real error occurred */
+			LOG_ERR("Failed to configure clock: %d", ret);
+			return ret;
+		}
+	}
+
+#if FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL
+	ret = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (ret) {
+		LOG_ERR("Failed to enable clock: %d", ret);
+		return ret;
+	}
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+#endif
 	/* Map the named MMIO region */
 	DEVICE_MMIO_NAMED_MAP(dev, reg, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
@@ -223,15 +244,32 @@ static DEVICE_API(wdt, mcux_wdog32_api) = {
 #define TO_WDOG32_CLK_SRC(val) _DO_CONCAT(kWDOG32_ClockSource, val)
 #define TO_WDOG32_CLK_DIV(val) _DO_CONCAT(kWDOG32_ClockPrescalerDivide, val)
 
+#define WDOG32_CLK_SOURCE(id) DT_INST_PROP(id, clk_source)
+#define WDOG32_CLK_SOURCE_NAME(id) CONCAT(clksrc, WDOG32_CLK_SOURCE(id))
+
+#define WDOG32_INST_CLOCKS_FROM_CLK_SOURCE(id)							\
+	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(id, WDOG32_CLK_SOURCE_NAME(id))), \
+	.clock_subsys = (clock_control_subsys_t)						\
+		DT_INST_CLOCKS_CELL_BY_NAME(id, WDOG32_CLK_SOURCE_NAME(id), name)
+
+#define WDOG32_INST_CLOCKS(id)							\
+	WDOG32_INST_CLOCKS_FROM_CLK_SOURCE(id)
+
+#define WDOG32_CHECK_CLK_SOURCES(id)				\
+	IF_DISABLED(DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency),		\
+	(BUILD_ASSERT(DT_INST_CLOCKS_HAS_NAME(id, WDOG32_CLK_SOURCE_NAME(id)),		\
+			"WDOG32 instance " STRINGIFY(id) " clk-source without named clock")))
+
 static void mcux_wdog32_config_func_0(const struct device *dev);
+
+WDOG32_CHECK_CLK_SOURCES(0);
 
 static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 	DEVICE_MMIO_NAMED_ROM_INIT(reg, DT_DRV_INST(0)),
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
 	.clock_frequency = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
-#else  /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
-	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, name),
+#else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
+	WDOG32_INST_CLOCKS(0),
 #endif /* DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
 	.clk_source = TO_WDOG32_CLK_SRC(DT_INST_PROP(0, clk_source)),
 	.clk_divider = TO_WDOG32_CLK_DIV(DT_INST_PROP(0, clk_divider)),

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -299,6 +299,7 @@
 			reg = <0x40052000 0x1000>;
 			interrupts = <22 0>;
 			clocks = <&lpo>;
+			clock-names = "clksrc1";
 			clk-source = <1>;
 			clk-divider = <256>;
 		};

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -254,6 +254,7 @@
 			reg = <0x40052000 0x1000>;
 			interrupts = <28 0>;
 			clocks = <&lpo>;
+			clock-names = "clksrc1";
 			clk-source = <1>;
 			clk-divider = <256>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -693,6 +693,7 @@
 			reg = <0x40052000 0x1000>;
 			interrupts = <22 0>;
 			clocks = <&lpo>;
+			clock-names = "clksrc1";
 			clk-source = <1>;
 			clk-divider = <256>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -315,6 +315,7 @@
 		reg = <0x1a000 10>;
 		interrupts = <23 0>;
 		clocks = <&scg SCG_K4_RTCOSC_CLK 0x68>;
+		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <1>;
 		status = "okay";
@@ -325,6 +326,7 @@
 		reg = <0x1b000 10>;
 		interrupts = <24 0>;
 		clocks = <&scg SCG_K4_RTCOSC_CLK 0x6c>;
+		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <1>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -139,6 +139,7 @@
 			reg = <0x40052000 0x1000>;
 			interrupts = <22 0>;
 			clocks = <&clock NXP_S32_LPO_128K_CLK>;
+			clock-names = "clksrc1";
 			clk-source = <1>;
 			clk-divider = <256>;
 		};

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -123,6 +123,7 @@
 		interrupt-parent = <&gic>;
 		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
 		clocks = <&lpo_clk>;
+		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <256>;
 		status = "disabled";
@@ -135,6 +136,7 @@
 		interrupt-parent = <&gic>;
 		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
 		clocks = <&lpo_clk>;
+		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <256>;
 		status = "disabled";


### PR DESCRIPTION
drivers: watchdog: wdt_mcux_wdog32: Support named clocks for clock sources
Add support for named clocks in the WDOG32 driver to properly handle
different clock sources. The driver now uses clock-names property to
identify which clock source is being used, based on the clk-source
property.

This change enables proper clock configuration and control for platforms
where the clock frequency is not statically defined in the device tree.
The driver will now configure and enable the appropriate clock during
initialization.

Updated all affected device tree files to include the clock-names
property aligned with their clk-source configuration.
