### PR TITLE
soc: st: stm32: {h5, l5, u5, wbax}: Correct cache line size

### DIFF
--- a/soc/st/stm32/stm32h5x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32h5x/Kconfig.defconfig
@@ -10,8 +10,14 @@ rsource "Kconfig.defconfig.stm32h5*"
 config ICACHE
 	default y
 
+config ICACHE_LINE_SIZE
+	default 16
+
 config DCACHE
 	default y if !SOC_STM32H503XX
+
+config DCACHE_LINE_SIZE
+	default 16
 
 config CACHE_MANAGEMENT
 	default y

--- a/soc/st/stm32/stm32l5x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32l5x/Kconfig.defconfig
@@ -10,6 +10,9 @@ rsource "Kconfig.defconfig.stm32l5*"
 config ICACHE
 	default y
 
+config ICACHE_LINE_SIZE
+	default 16
+
 config CACHE_MANAGEMENT
 	default y
 

--- a/soc/st/stm32/stm32u5x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32u5x/Kconfig.defconfig
@@ -13,8 +13,17 @@ config ROM_START_OFFSET
 config ICACHE
 	default y
 
+config ICACHE_LINE_SIZE
+	default 16
+
 config DCACHE
 	default y
+
+config DCACHE_LINE_SIZE
+	default 32 if (SOC_STM32U595XX || SOC_STM32U599XX || \
+		SOC_STM32U5A5XX || SOC_STM32U5A9XX || \
+		SOC_STM32U5F9XX || SOC_STM32U5G9XX)
+	default 16
 
 config CACHE_MANAGEMENT
 	default y

--- a/soc/st/stm32/stm32wbax/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wbax/Kconfig.defconfig
@@ -10,6 +10,9 @@ rsource "Kconfig.defconfig.stm32wba*"
 config ICACHE
 	default y
 
+config ICACHE_LINE_SIZE
+	default 16
+
 config CACHE_MANAGEMENT
 	default y
 


### PR DESCRIPTION
STM32H5, STM32L5, STM32U5 and STM32WBA series MCUs have external ICACHE/DCACHE with a cache line size of 16 bytes. The previous configuration incorrectly set the cache line size to 32 bytes (the default cache line size for Cortex-M cores).