### PR TITLE
Add DMA support to OMAP McSPI

### DIFF
--- a/drivers/spi/Kconfig.omap
+++ b/drivers/spi/Kconfig.omap
@@ -8,3 +8,10 @@ config SPI_OMAP_MCSPI
 	select PINCTRL
 	help
 	  Enable support for TI OMAP MCSPI driver.
+
+config SPI_OMAP_DMA
+	bool "SPI DMA enabled"
+	depends on SPI_ASYNC
+	depends on DMA
+	help
+		Enables DMA support for OMAP McSPI driver.


### PR DESCRIPTION
This patch adds DMA support to omap_mcspi driver.

Notable changes:
- Use work-queue based model to perform DMA transfers
- Added structures for per-channel tracking of DMA
- Added Kconfig option to enable SPI+DMA
