### PR TITLE
stm32: tests: boot: with_mcumgr: exclude stm32h5_dk platform from test_upgrade_ble scenario

### DIFF
--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -50,6 +50,7 @@ tests:
       - nucleo_wba65ri
       - nucleo_wl55jc
       - stm32f3_disco
+      - stm32h573i_dk
       - stm32l562e_dk
       - stm32u083c_dk
       - stm32wba65i_dk1


### PR DESCRIPTION
The stm32h573i_dk platform was mistakenly not excluded during PR #100385.