### PR TITLE
boards: qnx: Add support for QNX Hypervisor virtual machine

### DIFF
--- a/boards/blackberry/index.rst
+++ b/boards/blackberry/index.rst
@@ -1,0 +1,10 @@
+.. _boards-blackberry:
+
+BlackBerry
+##########
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/blackberry/qnxhv_vm/Kconfig.qnxhv_vm
+++ b/boards/blackberry/qnxhv_vm/Kconfig.qnxhv_vm
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_QNXHV_VM
+	select SOC_QNXHV_VM

--- a/boards/blackberry/qnxhv_vm/board.yml
+++ b/boards/blackberry/qnxhv_vm/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: qnxhv_vm
+  full_name: QNX Hypervisor Virtual Machine
+  vendor: blackberry
+  socs:
+  - name: qnxhv_vm

--- a/boards/blackberry/qnxhv_vm/doc/index.rst
+++ b/boards/blackberry/qnxhv_vm/doc/index.rst
@@ -1,0 +1,105 @@
+.. zephyr:board:: qnxhv_vm
+
+Overview
+********
+
+This board enables running Zephyr as a guest inside a QNX Hypervisor virtual
+machine.
+
+This is an example configuration. VM layouts are typically unique per product,
+so you will likely need to adjust the devicetree and Kconfig options to match
+your VM configuration (memory map, interrupt routing, clocks, devices, etc.).
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+.. _qvmconf:
+
+QNX Hypervisor Virtual Machine Configuration
+--------------------------------------------
+
+The virtual hardware exposed to the guest depends on the VM configuration file.
+The above features are supported by following configuration.
+
+.. code-block::
+
+  # Guest name (optional)
+  system zephyr
+
+  # One vCPU
+  cpu
+
+  # Guest RAM base/size
+  ram 0x80000000,128M
+
+  # Virtual interrupt controller
+  vdev gic version 2
+
+  # Load Zephyr image (ELF is supported by qvm)
+  load ./zephyr.elf
+
+  # PL011 UART mapped into the guest at loc, routed to a host device/endpoint
+  vdev pl011
+          hostdev >-        # QVM console (stdout/stderr), keeps early output visible
+          loc 0x1c090000
+          intr gic:37
+
+
+Building and Running
+********************
+
+Build an application
+====================
+
+Use this board configuration to run basic Zephyr applications as a guest.
+For example, build the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :board: qnxhv_vm
+   :goals: build
+
+This produces a guest image (e.g. ``zephyr/zephyr.elf``) under the build directory.
+
+Create a VM Configuration file
+==============================
+
+You also need to create ``.qvmconf`` file to configure virtual machine.
+:ref:`qvmconf` is a example QVM configuration which is support by default
+``qnxhv_vm`` configuration.
+
+Here, create a file named ``zephyr.qvmconf`` with the contents of this example.
+
+Running an application
+======================
+
+Transfer both the Zephyr image and the QVM configuration file to the QNX
+Hypervisor machine, then start the VM:
+
+.. code-block:: console
+
+   qvm @zephyr.qvmconf
+
+You will see Zephyr output:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v4.3.0-3524-g5c47f098ffc4 ***
+   thread_a: Hello World from cpu 0 on qnxhv_vm!
+   thread_b: Hello World from cpu 0 on qnxhv_vm!
+   thread_a: Hello World from cpu 0 on qnxhv_vm!
+   thread_b: Hello World from cpu 0 on qnxhv_vm!
+   thread_a: Hello World from cpu 0 on qnxhv_vm!
+
+Use :kbd:`CTRL+C` to stop the virtual machine.
+
+
+References
+**********
+
+- `QNX Hypervisor User's Guide (VM configuration) <https://www.qnx.com/developers/docs/8.0/com.qnx.doc.hypervisor.user/topic/vm/vm.html>`_

--- a/boards/blackberry/qnxhv_vm/qnxhv_vm.dts
+++ b/boards/blackberry/qnxhv_vm/qnxhv_vm.dts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <mem.h>
+#include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	model = "QNX Hypervisor Virtual Machine";
+	compatible = "blackberry,qnxhv_vm";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &qvm_console;
+		zephyr,shell-uart = &qvm_console;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			enable-method = "psci";
+			reg = <0x00>;
+		};
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "hvc";
+	};
+
+	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		interrupt-parent = <&gic>;
+
+		sram0: memory@80000000 {
+			compatible = "mmio-sram";
+			reg = <0x0 0x80000000 0x0 DT_SIZE_M(128)>;
+		};
+
+		gic: interrupt-controller@2c001000 {
+			compatible = "arm,gic-v2", "arm,gic";
+			reg = <0x00 0x2c001000 0x00 0x00001000>,
+			      <0x00 0x2c002000 0x00 0x00002000>;
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			status = "okay";
+		};
+
+		timer: timer {
+			compatible = "arm,armv8-timer";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clock-frequency = <54000000>;
+		};
+
+		qvm_console: uart@1c090000 {
+			compatible = "arm,pl011";
+			reg = <0x00 0x1c090000 0x00 0x1000>;
+			interrupts = <GIC_SPI 5 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_0";
+			clocks = <&uartclk>;
+			current-speed = <115200>;
+			status = "okay";
+		};
+	};
+};

--- a/boards/blackberry/qnxhv_vm/qnxhv_vm.yaml
+++ b/boards/blackberry/qnxhv_vm/qnxhv_vm.yaml
@@ -1,0 +1,9 @@
+identifier: qnxhv_vm
+name: QNX Hypervisor Virtual Machine
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072
+vendor: blackberry

--- a/boards/blackberry/qnxhv_vm/qnxhv_vm_defconfig
+++ b/boards/blackberry/qnxhv_vm/qnxhv_vm_defconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -107,6 +107,7 @@ beagle	BeagleBoard.org Foundation
 bflb	Bouffalo Lab (Nanjing) Co., Ltd.
 bhf	Beckhoff Automation GmbH & Co. KG
 bitmain	Bitmain Technologies
+blackberry	BlackBerry Limited
 blues	Blues Wireless
 blutek	BluTek Power
 boe	BOE Technology Group Co., Ltd.

--- a/soc/blackberry/qnxhv_vm/CMakeLists.txt
+++ b/soc/blackberry/qnxhv_vm/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/blackberry/qnxhv_vm/Kconfig
+++ b/soc/blackberry/qnxhv_vm/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QNXHV_VM
+	select ARM64
+	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
+	select CPU_CORTEX_A72

--- a/soc/blackberry/qnxhv_vm/Kconfig.defconfig
+++ b/soc/blackberry/qnxhv_vm/Kconfig.defconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_QNXHV_VM
+
+DT_TIMER_PATH := $(dt_nodelabel_path,timer)
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,$(DT_TIMER_PATH),clock-frequency)
+
+config NUM_IRQS
+	default 256
+
+endif

--- a/soc/blackberry/qnxhv_vm/Kconfig.soc
+++ b/soc/blackberry/qnxhv_vm/Kconfig.soc
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QNXHV_VM
+	bool
+
+config SOC
+	default "qnxhv_vm" if SOC_QNXHV_VM

--- a/soc/blackberry/qnxhv_vm/mmu_regions.c
+++ b/soc/blackberry/qnxhv_vm/mmu_regions.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Broadcom
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/blackberry/qnxhv_vm/soc.yml
+++ b/soc/blackberry/qnxhv_vm/soc.yml
@@ -1,0 +1,4 @@
+series:
+- name: qnxhv_vm
+  socs:
+  - name: qnxhv_vm


### PR DESCRIPTION
Adding support for running Zephyr OS as a guest virtual machine
in the QNX Hypervisor environment.
This change introduces a new board configuration for ARM64-based
QNX Hypervisor VM.