### PR TITLE
native_simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdint.h>
+#include <inttypes.h>
 #include <time.h>
 #include <stdbool.h>
 #include <math.h>
@@ -190,8 +191,8 @@ static void hwtimer_tick_timer_reached(void)
 
 		us_time_to_str(es, expected_rt - boot_time);
 		us_time_to_str(rs, real_time - boot_time);
-		printf("tick @%5llims: diff = expected_rt - real_time = "
-			"%5lli = %s - %s\n",
+		printf("tick @%5"PRIu64"ms: diff = expected_rt - real_time = "
+			"%5"PRIi64" = %s - %s\n",
 			hw_timer_tick_timer/1000U, diff, es, rs);
 #endif
 
@@ -325,7 +326,7 @@ void hwtimer_adjust_rt_ratio(double ratio_correction)
 	last_drift_offset += r_drift;
 	us_time_to_str(ct, current_stime);
 
-	printf("%s(): @%s, s_diff= %llius after last adjust\n"
+	printf("%s(): @%s, s_diff= %"PRIi64"us after last adjust\n"
 		" during which we drifted %.3fms\n"
 		" total acc drift (last_drift_offset) = %.3fms\n"
 		" last_radj_rtime = %.3fms (+%.3fms )\n"


### PR DESCRIPTION
Align with native_simulator's upstream main
215ee859eee5e49dc09eda8f17a956ee7318caf2

Which includes:
215ee85: native timer_model: Fix printf format specifier warnings w debug logs

Relates to:
* #102095
* https://github.com/BabbleSim/native_simulator/pull/11