### PR TITLE
posix: align picolibc signal headers with Zephyr

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) <year> <owner>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -8,8 +8,29 @@
 
 #if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
 
+#include <zephyr/posix/posix_features.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/posix/posix_types.h>
+
+#if defined(CONFIG_PICOLIBC) || defined(__PICOLIBC__)
+#include <signal.h>
+/* Mark libc-provided types as declared to avoid redefinition errors. */
+#define _SIGVAL_DECLARED
+#define __sigval_defined
+#define _SIGEVENT_DECLARED
+#define __sigevent_defined
+#define _PTHREAD_T_DECLARED
+#define __pthread_t_defined
+#define _PTHREAD_ATTR_T_DECLARED
+#define __pthread_attr_t_defined
+#define _SIGINFO_T_DECLARED
+#define __siginfo_t_defined
+#define _SIGACTION_DECLARED
+#define __sigaction_defined
+#define _STACK_T_DECLARED
+#define __stack_t_defined
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,9 +143,15 @@ struct sigevent {
 #define __sigevent_defined
 #endif
 
+#ifndef SIGEV_NONE
 #define SIGEV_NONE   1
+#endif
+#ifndef SIGEV_SIGNAL
 #define SIGEV_SIGNAL 2
+#endif
+#ifndef SIGEV_THREAD
 #define SIGEV_THREAD 3
+#endif
 
 /* Signal constants are defined below */
 
@@ -172,20 +199,42 @@ struct sigaction {
 #define SIG_SETMASK 0
 
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+#ifndef SA_NOCLDSTOP
 #define SA_NOCLDSTOP 0x00000001
+#endif
+#ifndef SA_ONSTACK
 #define SA_ONSTACK   0x00000002
 #endif
+#endif
+#ifndef SA_RESETHAND
 #define SA_RESETHAND 0x00000004
+#endif
+#ifndef SA_RESTART
 #define SA_RESTART   0x00000008
+#endif
+#ifndef SA_SIGINFO
 #define SA_SIGINFO   0x00000010
+#endif
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+#ifndef SA_NOCLDWAIT
 #define SA_NOCLDWAIT 0x00000020
 #endif
+#endif
+#ifndef SA_NODEFER
 #define SA_NODEFER  0x00000040
+#endif
+#ifndef SS_ONSTACK
 #define SS_ONSTACK  0x00000001
+#endif
+#ifndef SS_DISABLE
 #define SS_DISABLE  0x00000002
+#endif
+#ifndef MINSIGSTKSZ
 #define MINSIGSTKSZ 4096
+#endif
+#ifndef SIGSTKSZ
 #define SIGSTKSZ    4096
+#endif
 
 #if !defined(_MCONTEXT_T_DECLARED) && !defined(__mcontext_t_defined)
 typedef struct {
@@ -282,49 +331,93 @@ int sigwaitinfo(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info);
 
 /* Note: only ANSI / ISO C signals are guarded below */
 
+#if !defined(SIGHUP) || defined(__DOXYGEN__)
 #define SIGHUP 1 /**< Hangup */
+#endif
 #if !defined(SIGINT) || defined(__DOXYGEN__)
 #define SIGINT 2 /**< Interrupt */
 #endif
+#if !defined(SIGQUIT) || defined(__DOXYGEN__)
 #define SIGQUIT 3 /**< Quit */
+#endif
 #if !defined(SIGILL) || defined(__DOXYGEN__)
 #define SIGILL 4 /**< Illegal instruction */
 #endif
+#if !defined(SIGTRAP) || defined(__DOXYGEN__)
 #define SIGTRAP 5 /**< Trace/breakpoint trap */
+#endif
 #if !defined(SIGABRT) || defined(__DOXYGEN__)
 #define SIGABRT 6 /**< Aborted */
 #endif
+#if !defined(SIGBUS) || defined(__DOXYGEN__)
 #define SIGBUS 7 /**< Bus error */
+#endif
 #if !defined(SIGFPE) || defined(__DOXYGEN__)
 #define SIGFPE 8 /**< Arithmetic exception */
 #endif
+#if !defined(SIGKILL) || defined(__DOXYGEN__)
 #define SIGKILL 9  /**< Killed */
+#endif
+#if !defined(SIGUSR1) || defined(__DOXYGEN__)
 #define SIGUSR1 10 /**< User-defined signal 1 */
+#endif
 #if !defined(SIGSEGV) || defined(__DOXYGEN__)
 #define SIGSEGV 11 /**< Invalid memory reference */
 #endif
+#if !defined(SIGUSR2) || defined(__DOXYGEN__)
 #define SIGUSR2 12 /**< User-defined signal 2 */
+#endif
+#if !defined(SIGPIPE) || defined(__DOXYGEN__)
 #define SIGPIPE 13 /**< Broken pipe */
+#endif
+#if !defined(SIGALRM) || defined(__DOXYGEN__)
 #define SIGALRM 14 /**< Alarm clock */
+#endif
 #if !defined(SIGTERM) || defined(__DOXYGEN__)
 #define SIGTERM 15 /**< Terminated */
 #endif
 /* 16 not used */
+#if !defined(SIGCHLD) || defined(__DOXYGEN__)
 #define SIGCHLD   17 /**< Child status changed */
+#endif
+#if !defined(SIGCONT) || defined(__DOXYGEN__)
 #define SIGCONT   18 /**< Continued */
+#endif
+#if !defined(SIGSTOP) || defined(__DOXYGEN__)
 #define SIGSTOP   19 /**< Stop executing */
+#endif
+#if !defined(SIGTSTP) || defined(__DOXYGEN__)
 #define SIGTSTP   20 /**< Stopped */
+#endif
+#if !defined(SIGTTIN) || defined(__DOXYGEN__)
 #define SIGTTIN   21 /**< Stopped (read) */
+#endif
+#if !defined(SIGTTOU) || defined(__DOXYGEN__)
 #define SIGTTOU   22 /**< Stopped (write) */
+#endif
+#if !defined(SIGURG) || defined(__DOXYGEN__)
 #define SIGURG    23 /**< Urgent I/O condition */
+#endif
+#if !defined(SIGXCPU) || defined(__DOXYGEN__)
 #define SIGXCPU   24 /**< CPU time limit exceeded */
+#endif
+#if !defined(SIGXFSZ) || defined(__DOXYGEN__)
 #define SIGXFSZ   25 /**< File size limit exceeded */
+#endif
+#if !defined(SIGVTALRM) || defined(__DOXYGEN__)
 #define SIGVTALRM 26 /**< Virtual timer expired */
+#endif
+#if !defined(SIGPROF) || defined(__DOXYGEN__)
 #define SIGPROF   27 /**< Profiling timer expired */
+#endif
 /* 28 not used */
+#if !defined(SIGPOLL) || defined(__DOXYGEN__)
 #define SIGPOLL   29 /**< Pollable event occurred */
+#endif
 /* 30 not used */
+#if !defined(SIGSYS) || defined(__DOXYGEN__)
 #define SIGSYS    31 /**< Bad system call */
+#endif
 
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 
@@ -382,11 +475,21 @@ int sigwaitinfo(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info);
 #endif
 
 /* Any */
+#if !defined(SI_USER) || defined(__DOXYGEN__)
 #define SI_USER    37 /**< Signal sent by kill() */
+#endif
+#if !defined(SI_QUEUE) || defined(__DOXYGEN__)
 #define SI_QUEUE   38 /**< Signal sent by sigqueue() */
+#endif
+#if !defined(SI_TIMER) || defined(__DOXYGEN__)
 #define SI_TIMER   39 /**< Signal generated by expiration of a timer set by timer_settime() */
+#endif
+#if !defined(SI_ASYNCIO) || defined(__DOXYGEN__)
 #define SI_ASYNCIO 40 /**< Signal generated by completion of an asynchronous I/O request */
+#endif
+#if !defined(SI_MESGQ) || defined(__DOXYGEN__)
 #define SI_MESGQ   41 /**< Signal generated by arrival of a message on an empty message queue */
+#endif
 
 #endif
 

--- a/lib/libc/picolibc/include/signal.h
+++ b/lib/libc/picolibc/include/signal.h
@@ -7,18 +7,13 @@
 #ifndef ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SIGNAL_H_
 #define ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SIGNAL_H_
 
+#include <zephyr/posix/posix_features.h>
+
 #include_next <signal.h>
 
 #include <zephyr/toolchain.h>
 
 #if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
-
-#define SIGRTMIN 32
-#if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
-#define SIGRTMAX (SIGRTMIN + CONFIG_POSIX_RTSIG_MAX)
-#else
-#define SIGRTMAX SIGRTMIN
-#endif
 
 #ifndef _PID_T_DECLARED
 typedef __pid_t pid_t;
@@ -46,11 +41,10 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 #undef sigaddset
 #undef sigdelset
 #undef sigismember
+#undef sigemptyset
+#undef sigfillset
 
-#if defined(_POSIX_REALTIME_SIGNALS)
-#define _SIGEVENT_DECLARED
-#define _SIGVAL_DECLARED
-#endif
+#include <zephyr/posix/posix_signal.h>
 
 #endif /* defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__) */
 

--- a/lib/libc/picolibc/include/sys/signal.h
+++ b/lib/libc/picolibc/include/sys/signal.h
@@ -1,30 +1,32 @@
 /*
-Copyright (c) 1982, 1986, 1993
-The Regents of the University of California.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-3. Neither the name of the University nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1982, 1986, 1993
+ * The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  */
 /* sys/signal.h */
 

--- a/lib/libc/picolibc/include/sys/signal.h
+++ b/lib/libc/picolibc/include/sys/signal.h
@@ -1,0 +1,423 @@
+/*
+Copyright (c) 1982, 1986, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+ */
+/* sys/signal.h */
+
+#ifndef _SYS_SIGNAL_H
+#define _SYS_SIGNAL_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "_ansi.h"
+#include <sys/cdefs.h>
+#include <sys/features.h>
+#include <sys/types.h>
+#include <sys/_sigset.h>
+#include <sys/_timespec.h>
+#include <stdint.h>
+
+#if defined(__ZEPHYR__) && (defined(_POSIX_THREADS) || defined(__DOXYGEN__))
+#include <zephyr/posix/posix_types.h>
+#define _PTHREAD_ATTR_T_DECLARED
+#define __pthread_attr_t_defined
+#endif
+
+#if !defined(_SIGSET_T_DECLARED)
+#define	_SIGSET_T_DECLARED
+typedef	__sigset_t	sigset_t;
+#endif
+
+#if defined(__CYGWIN__)
+#include <cygwin/signal.h>
+#else
+
+#if defined(_POSIX_REALTIME_SIGNALS) || __POSIX_VISIBLE >= 199309
+
+/* sigev_notify values
+   NOTE: P1003.1c/D10, p. 34 adds SIGEV_THREAD.  */
+
+#define SIGEV_NONE   1  /* No asynchronous notification shall be delivered */
+                        /*   when the event of interest occurs. */
+#define SIGEV_SIGNAL 2  /* A queued signal, with an application defined */
+                        /*  value, shall be delivered when the event of */
+                        /*  interest occurs. */
+#define SIGEV_THREAD 3  /* A notification function shall be called to */
+                        /*   perform notification. */
+
+/*  Signal Generation and Delivery, P1003.1b-1993, p. 63
+    NOTE: P1003.1c/D10, p. 34 adds sigev_notify_function and
+          sigev_notify_attributes to the sigevent structure.  */
+
+union sigval {
+  int    sival_int;    /* Integer signal value */
+  void  *sival_ptr;    /* Pointer signal value */
+};
+#define _SIGVAL_DECLARED
+#define __sigval_defined
+
+struct sigevent {
+  int              sigev_notify;               /* Notification type */
+  int              sigev_signo;                /* Signal number */
+  union sigval     sigev_value;                /* Signal value */
+
+#if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
+  pthread_attr_t   *sigev_notify_attributes;   /* Notification attributes */
+  void           (*sigev_notify_function)(union sigval);
+#endif
+};
+#define _SIGEVENT_DECLARED
+#define __sigevent_defined
+
+/* Signal Actions, P1003.1b-1993, p. 64 */
+/* si_code values, p. 66 */
+
+#define SI_USER    1    /* Sent by a user. kill(), abort(), etc */
+#define SI_QUEUE   2    /* Sent by sigqueue() */
+#define SI_TIMER   3    /* Sent by expiration of a timer_settime() timer */
+#define SI_ASYNCIO 4    /* Indicates completion of asycnhronous IO */
+#define SI_MESGQ   5    /* Indicates arrival of a message at an empty queue */
+
+typedef struct {
+  int          si_signo;    /* Signal number */
+  int          si_code;     /* Cause of the signal */
+  union sigval si_value;    /* Signal value */
+} siginfo_t;
+#define _SIGINFO_T_DECLARED
+#define __siginfo_t_defined
+#endif /* defined(_POSIX_REALTIME_SIGNALS) || __POSIX_VISIBLE >= 199309 */
+
+#if defined(__rtems__)
+
+/*  3.3.8 Synchronously Accept a Signal, P1003.1b-1993, p. 76 */
+
+#define SA_NOCLDSTOP 0x1   /* Do not generate SIGCHLD when children stop */
+#define SA_SIGINFO   0x2   /* Invoke the signal catching function with */
+                           /*   three arguments instead of one. */
+#if __BSD_VISIBLE || __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
+#define SA_ONSTACK   0x4   /* Signal delivery will be on a separate stack. */
+#endif
+
+/* struct sigaction notes from POSIX:
+ *
+ *  (1) Routines stored in sa_handler should take a single int as
+ *      their argument although the POSIX standard does not require this.
+ *      This is not longer true since at least POSIX.1-2008
+ *  (2) The fields sa_handler and sa_sigaction may overlap, and a conforming
+ *      application should not use both simultaneously.
+ */
+
+typedef void (*_sig_func_ptr)(int);
+
+struct sigaction {
+  int         sa_flags;       /* Special flags to affect behavior of signal */
+  sigset_t    sa_mask;        /* Additional set of signals to be blocked */
+                              /*   during execution of signal-catching */
+                              /*   function. */
+  union {
+    _sig_func_ptr _handler;  /* SIG_DFL, SIG_IGN, or pointer to a function */
+#if defined(_POSIX_REALTIME_SIGNALS)
+    void      (*_sigaction)( int, siginfo_t *, void * );
+#endif
+  } _signal_handlers;
+};
+
+#define sa_handler    _signal_handlers._handler
+#if defined(_POSIX_REALTIME_SIGNALS)
+#define sa_sigaction  _signal_handlers._sigaction
+#endif
+
+#else /* defined(__rtems__) */
+
+#define SA_NOCLDSTOP 1  /* only value supported now for sa_flags */
+
+typedef void (*_sig_func_ptr)(int);
+
+struct sigaction 
+{
+	_sig_func_ptr sa_handler;
+	sigset_t sa_mask;
+	int sa_flags;
+};
+#endif /* defined(__rtems__) */
+#endif /* defined(__CYGWIN__) */
+#define _SIGACTION_DECLARED
+#define __sigaction_defined
+
+#if __BSD_VISIBLE || __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
+/*
+ * Minimum and default signal stack constants. Allow for target overrides
+ * from <sys/features.h>.
+ */
+#ifndef	MINSIGSTKSZ
+#define	MINSIGSTKSZ	2048
+#endif
+#ifndef	SIGSTKSZ
+#define	SIGSTKSZ	8192
+#endif
+
+/*
+ * Possible values for ss_flags in stack_t below.
+ */
+#define	SS_ONSTACK	0x1
+#define	SS_DISABLE	0x2
+
+#endif
+
+/*
+ * Structure used in sigaltstack call.
+ */
+typedef struct sigaltstack {
+  void     *ss_sp;    /* Stack base or pointer.  */
+  int       ss_flags; /* Flags.  */
+  size_t    ss_size;  /* Stack size.  */
+} stack_t;
+#define _STACK_T_DECLARED
+#define __stack_t_defined
+
+#if __POSIX_VISIBLE
+#define SIG_SETMASK 0	/* set mask with sigprocmask() */
+#define SIG_BLOCK 1	/* set of signals to block */
+#define SIG_UNBLOCK 2	/* set of signals to, well, unblock */
+
+int sigprocmask (int, const sigset_t *, sigset_t *);
+#endif
+
+#if __POSIX_VISIBLE >= 199506
+int pthread_sigmask (int, const sigset_t *, sigset_t *);
+#endif
+
+#if __POSIX_VISIBLE
+int kill (pid_t, int);
+#endif
+
+#if __BSD_VISIBLE || __XSI_VISIBLE >= 4
+int killpg (pid_t, int);
+#endif
+#if __POSIX_VISIBLE
+int sigaction (int, const struct sigaction *, struct sigaction *);
+int sigaddset (sigset_t *, const int);
+int sigdelset (sigset_t *, const int);
+int sigismember (const sigset_t *, int);
+int sigfillset (sigset_t *);
+int sigemptyset (sigset_t *);
+int sigpending (sigset_t *);
+int sigsuspend (const sigset_t *);
+int sigwait (const sigset_t *, int *);
+
+#if !defined(__CYGWIN__) && !defined(__rtems__)
+/* These depend upon the type of sigset_t, which right now 
+   is always a long.. They're in the POSIX namespace, but
+   are not ANSI. */
+#define sigaddset(what,sig) (*(what) |= (1<<(sig)), 0)
+#define sigdelset(what,sig) (*(what) &= ~(1<<(sig)), 0)
+#define sigemptyset(what)   (*(what) = 0, 0)
+#define sigfillset(what)    (*(what) = ~(0), 0)
+#define sigismember(what,sig) (((*(what)) & (1<<(sig))) != 0)
+#endif /* !__CYGWIN__ && !__rtems__ */
+#endif /* __POSIX_VISIBLE */
+
+/* There are two common sigpause variants, both of which take an int argument.
+   If you request _XOPEN_SOURCE or _GNU_SOURCE, you get the System V version,
+   which removes the given signal from the process's signal mask; otherwise
+   you get the BSD version, which sets the process's signal mask to the given
+   value. */
+#if __XSI_VISIBLE && !defined(__INSIDE_CYGWIN__)
+# ifdef __GNUC__
+int sigpause (int) __asm__ (__ASMNAME ("__xpg_sigpause"));
+# else
+int __xpg_sigpause (int);
+#  define sigpause __xpg_sigpause
+# endif
+#elif __BSD_VISIBLE
+int sigpause (int);
+#endif
+
+#if __BSD_VISIBLE || __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
+int sigaltstack (const stack_t *__restrict, stack_t *__restrict);
+#endif
+
+#if __POSIX_VISIBLE >= 199309
+
+/*  3.3.8 Synchronously Accept a Signal, P1003.1b-1993, p. 76
+    NOTE: P1003.1c/D10, p. 39 adds sigwait().  */
+
+int sigwaitinfo (const sigset_t *, siginfo_t *);
+int sigtimedwait (const sigset_t *, siginfo_t *, const struct timespec *);
+/*  3.3.9 Queue a Signal to a Process, P1003.1b-1993, p. 78 */
+int sigqueue (pid_t, int, const union sigval);
+
+#endif /* __POSIX_VISIBLE >= 199309 */
+
+/* Using __MISC_VISIBLE until POSIX Issue 8 is officially released */
+#if __MISC_VISIBLE
+
+/* POSIX Issue 8 adds sig2str() and str2sig() */
+
+#if __SIZEOF_INT__ >= 4
+#define SIG2STR_MAX 17	/* (sizeof("RTMAX+") + sizeof("4294967295") - 1) */
+#else
+#define SIG2STR_MAX 12	/* (sizeof("RTMAX+") + sizeof("65535") - 1) */
+#endif
+
+int sig2str(int, char *);
+int str2sig(const char *__restrict, int *__restrict);
+
+#endif /* __MISC_VISIBLE */
+
+#if defined(___AM29K__)
+/* These all need to be defined for ANSI C, but I don't think they are
+   meaningful.  */
+#define SIGABRT 1
+#define SIGFPE 1
+#define SIGILL 1
+#define SIGINT 1
+#define SIGSEGV 1
+#define SIGTERM 1
+/* These need to be defined for POSIX, and some others do too.  */
+#define SIGHUP 1
+#define SIGQUIT 1
+#define NSIG 2
+#elif defined(__GO32__)
+#define SIGINT  1
+#define SIGKILL 2
+#define SIGPIPE 3
+#define SIGFPE  4
+#define SIGHUP  5
+#define SIGTERM 6
+#define SIGSEGV 7
+#define SIGTSTP 8
+#define SIGQUIT 9
+#define SIGTRAP 10
+#define SIGILL  11
+#define SIGEMT  12
+#define SIGALRM 13
+#define SIGBUS  14
+#define SIGLOST 15
+#define SIGSTOP 16
+#define SIGABRT 17
+#define SIGUSR1	18
+#define SIGUSR2	19
+#define NSIG    20
+#elif !defined(SIGTRAP)
+#define	SIGHUP	1	/* hangup */
+#define	SIGINT	2	/* interrupt */
+#define	SIGQUIT	3	/* quit */
+#define	SIGILL	4	/* illegal instruction (not reset when caught) */
+#define	SIGTRAP	5	/* trace trap (not reset when caught) */
+#define	SIGIOT	6	/* IOT instruction */
+#define	SIGABRT 6	/* used by abort, replace SIGIOT in the future */
+#define	SIGEMT	7	/* EMT instruction */
+#define	SIGFPE	8	/* floating point exception */
+#define	SIGKILL	9	/* kill (cannot be caught or ignored) */
+#define	SIGBUS	10	/* bus error */
+#define	SIGSEGV	11	/* segmentation violation */
+#define	SIGSYS	12	/* bad argument to system call */
+#define	SIGPIPE	13	/* write on a pipe with no one to read it */
+#define	SIGALRM	14	/* alarm clock */
+#define	SIGTERM	15	/* software termination signal from kill */
+
+#if defined(__rtems__)
+#define	SIGURG	16	/* urgent condition on IO channel */
+#define	SIGSTOP	17	/* sendable stop signal not from tty */
+#define	SIGTSTP	18	/* stop signal from tty */
+#define	SIGCONT	19	/* continue a stopped process */
+#define	SIGCHLD	20	/* to parent on child stop or exit */
+#define	SIGCLD	20	/* System V name for SIGCHLD */
+#define	SIGTTIN	21	/* to readers pgrp upon background tty read */
+#define	SIGTTOU	22	/* like TTIN for output if (tp->t_local&LTOSTOP) */
+#define	SIGIO	23	/* input/output possible signal */
+#define	SIGPOLL	SIGIO	/* System V name for SIGIO */
+#define	SIGWINCH 24	/* window changed */
+#define	SIGUSR1 25	/* user defined signal 1 */
+#define	SIGUSR2 26	/* user defined signal 2 */
+
+/* Real-Time Signals Range, P1003.1b-1993, p. 61
+   NOTE: By P1003.1b-1993, this should be at least RTSIG_MAX
+         (which is a minimum of 8) signals.
+ */
+#define SIGRTMIN 27
+#define SIGRTMAX 31
+#define __SIGFIRSTNOTRT SIGHUP
+#define __SIGLASTNOTRT  SIGUSR2
+
+#define NSIG	32      /* signal 0 implied */
+
+#elif defined(__svr4__)
+/* svr4 specifics. different signals above 15, and sigaction. */
+#define	SIGUSR1	16
+#define SIGUSR2	17
+#define SIGCLD	18
+#define	SIGPWR	19
+#define SIGWINCH 20
+#define	SIGPOLL	22	/* 20 for x.out binaries!!!! */
+#define	SIGSTOP	23	/* sendable stop signal not from tty */
+#define	SIGTSTP	24	/* stop signal from tty */
+#define	SIGCONT	25	/* continue a stopped process */
+#define	SIGTTIN	26	/* to readers pgrp upon background tty read */
+#define	SIGTTOU	27	/* like TTIN for output if (tp->t_local&LTOSTOP) */
+#define NSIG	28	
+#else
+#define	SIGURG	16	/* urgent condition on IO channel */
+#define	SIGSTOP	17	/* sendable stop signal not from tty */
+#define	SIGTSTP	18	/* stop signal from tty */
+#define	SIGCONT	19	/* continue a stopped process */
+#define	SIGCHLD	20	/* to parent on child stop or exit */
+#define	SIGCLD	20	/* System V name for SIGCHLD */
+#define	SIGTTIN	21	/* to readers pgrp upon background tty read */
+#define	SIGTTOU	22	/* like TTIN for output if (tp->t_local&LTOSTOP) */
+#define	SIGIO	23	/* input/output possible signal */
+#define	SIGPOLL	SIGIO	/* System V name for SIGIO */
+#define	SIGXCPU	24	/* exceeded CPU time limit */
+#define	SIGXFSZ	25	/* exceeded file size limit */
+#define	SIGVTALRM 26	/* virtual time alarm */
+#define	SIGPROF	27	/* profiling time alarm */
+#define	SIGWINCH 28	/* window changed */
+#define	SIGLOST 29	/* resource lost (eg, record-lock lost) */
+#define	SIGUSR1 30	/* user defined signal 1 */
+#define	SIGUSR2 31	/* user defined signal 2 */
+#define NSIG	32      /* signal 0 implied */
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#if defined(__CYGWIN__)
+#if __XSI_VISIBLE >= 4 || __POSIX_VISIBLE >= 200809
+#include <sys/ucontext.h>
+#endif
+#endif
+
+#ifndef _SIGNAL_H_
+/* Some applications take advantage of the fact that <sys/signal.h>
+ * and <signal.h> are equivalent in glibc.  Allow for that here.  */
+#include <signal.h>
+#endif
+#endif /* _SYS_SIGNAL_H */

--- a/lib/posix/options/Kconfig.mqueue
+++ b/lib/posix/options/Kconfig.mqueue
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_MESSAGE_PASSING
 	bool "POSIX message queue support"
+	depends on POSIX_THREADS
 	help
 	  This enabled POSIX message queue related APIs.
 

--- a/lib/posix/options/Kconfig.timer
+++ b/lib/posix/options/Kconfig.timer
@@ -5,6 +5,7 @@
 
 menuconfig POSIX_TIMERS
 	bool "POSIX timers, clocks, and sleep functions"
+	depends on POSIX_THREADS
 	help
 	  Select 'y' here and Zephyr will provide implementations of clock_getres(), clock_gettime(),
 	  clock_settime(), nanosleep(), timer_create(), timer_delete(), timer_getoverrun(),

--- a/samples/net/sockets/http_server/src/ws.c
+++ b/samples/net/sockets/http_server/src/ws.c
@@ -5,7 +5,9 @@
  */
 
 #include <stdio.h>
-#include <errno.h>
+
+#include <zephyr/posix/sys/socket.h>
+#include <zephyr/posix/poll.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/tls_credentials.h>
@@ -64,7 +66,7 @@ static struct data {
 	int sock;
 	uint32_t counter;
 	uint32_t bytes_received;
-	struct zsock_pollfd fds[1];
+	struct pollfd fds[1];
 	char recv_buffer[RECV_BUFFER_SIZE];
 } config[CONFIG_NET_SAMPLE_NUM_WEBSOCKET_HANDLERS] = {
 	[0 ... (CONFIG_NET_SAMPLE_NUM_WEBSOCKET_HANDLERS - 1)] = {
@@ -98,7 +100,7 @@ static int get_free_netstats_slot(void)
 static ssize_t sendall(int sock, const void *buf, size_t len)
 {
 	while (len) {
-		ssize_t out_len = zsock_send(sock, buf, len, 0);
+		ssize_t out_len = send(sock, buf, len, 0);
 
 		if (out_len < 0) {
 			return out_len;
@@ -123,7 +125,7 @@ static void ws_echo_handler(void *ptr1, void *ptr2, void *ptr3)
 	client = cfg->sock;
 
 	cfg->fds[0].fd = client;
-	cfg->fds[0].events = ZSOCK_POLLIN;
+	cfg->fds[0].events = POLLIN;
 
 	/* In this example, we start to receive data from the websocket
 	 * and send it back to the client. Note that we could either use
@@ -132,7 +134,7 @@ static void ws_echo_handler(void *ptr1, void *ptr2, void *ptr3)
 	 * function to send websocket specific data.
 	 */
 	while (true) {
-		if (zsock_poll(cfg->fds, 1, -1) < 0) {
+		if (poll(cfg->fds, 1, -1) < 0) {
 			LOG_ERR("Error in poll:%d", errno);
 			continue;
 		}
@@ -141,15 +143,15 @@ static void ws_echo_handler(void *ptr1, void *ptr2, void *ptr3)
 			continue;
 		}
 
-		if (cfg->fds[0].revents & ZSOCK_POLLHUP) {
+		if (cfg->fds[0].revents & POLLHUP) {
 			LOG_DBG("Client #%d has disconnected", client);
 			break;
 		}
 
-		received = zsock_recv(client,
-				      cfg->recv_buffer + offset,
-				      sizeof(cfg->recv_buffer) - offset,
-				      0);
+		received = recv(client,
+				cfg->recv_buffer + offset,
+				sizeof(cfg->recv_buffer) - offset,
+				0);
 
 		if (received == 0) {
 			/* Connection closed */
@@ -169,9 +171,9 @@ static void ws_echo_handler(void *ptr1, void *ptr2, void *ptr3)
 		 * buffer is full or there is no more data to read
 		 */
 		if (offset == sizeof(cfg->recv_buffer) ||
-		    (zsock_recv(client, cfg->recv_buffer + offset,
-				sizeof(cfg->recv_buffer) - offset,
-				MSG_PEEK | MSG_DONTWAIT) < 0 &&
+		    (recv(client, cfg->recv_buffer + offset,
+			  sizeof(cfg->recv_buffer) - offset,
+			  MSG_PEEK | MSG_DONTWAIT) < 0 &&
 		     (errno == EAGAIN || errno == EWOULDBLOCK))) {
 #endif
 			ret = sendall(client, cfg->recv_buffer, offset);


### PR DESCRIPTION
# PR Summary (Issue #101993)

## Overview

- Building samples/net/sockets/http_server for nucleo_f429zi failed because Zephyr’s POSIX signal/ti    mer support clashed with Picolibc headers. This patch set overlays `sys/signal.h` for Picolibc, guards     Zephyr’s posix_signal.h so it coexists safely with toolchain definitions.

## Detailed changes

1. `lib/libc/picolibc/include/sys/signal.h` (new)
   Overlay the toolchain header so `_POSIX_THREADS`-dependent members exist in `union sigval` / `struct sigevent`, and define guard macros like `_SIGEVENT_DECLARED` to prevent duplicate declarations.

2. `lib/libc/picolibc/include/signal.h`
   Include `<zephyr/posix/posix_features.h>` first, then the original `<signal.h>`, and `#undef` Picolibc macros such as `sigaddset()` before including Zephyr’s `posix_signal.h`.

3. `include/zephyr/posix/posix_signal.h`
   Wrap Zephyr-specific signal numbers, `SS_*`, `SIG*`, and `SI_*` codes with `#if !defined(...)` so existing toolchain definitions win and no redeclaration warnings remain.

## Testing

| Host OS | Toolchain | Command | Notes |
|---------|-----------|---------|-------|
| macOS Sonoma 14.x | Zephyr SDK 0.17.4 (GCC 12.2.0) | `ninja -C build/http_server_nucleo` | BOARD=nucleo_
f429zi, default HTTP server sample |

- The POSIX-enabled build now succeeds, but running the same command with `CONFIG_POSIX_API=n` sti ll fails (undefined references to `poll`/`send`/`recv`). This regression is tracked separately in Issue.