### PR TITLE
Checkpatch CONCAT() macro patch

### DIFF
--- a/drivers/comparator/comparator_mcux_acmp.c
+++ b/drivers/comparator/comparator_mcux_acmp.c
@@ -77,7 +77,7 @@ LOG_MODULE_REGISTER(nxp_kinetis_acmp, CONFIG_COMPARATOR_LOG_LEVEL);
 #endif
 
 #define MCUX_ACMP_ENUM(name, value) \
-	_CONCAT_4(COMP_MCUX_ACMP_, name, _, value)
+	CONCAT(COMP_MCUX_ACMP_, name, _, value)
 
 #define MCUX_ACMP_DT_INST_ENUM(inst, name, prop) \
 	MCUX_ACMP_ENUM(name, DT_INST_STRING_TOKEN(inst, prop))

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -237,7 +237,7 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 	)
 
 #define MSG_BUF_SYM(inst) \
-	_CONCAT_3(twim_, inst, _msg_buf)
+	CONCAT(twim_, inst, _msg_buf)
 
 #define MSG_BUF_DEFINE(inst) \
 	static uint8_t MSG_BUF_SYM(inst)[MSG_BUF_SIZE(inst)] MSG_BUF_ATTR(inst)

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -307,7 +307,7 @@ static int shim_nrf_twis_deinit(const struct device *dev)
 #endif
 
 #define SHIM_NRF_TWIS_NAME(id, name) \
-	_CONCAT_4(shim_nrf_twis_, name, _, id)
+	CONCAT(shim_nrf_twis_, name, _, id)
 
 #define SHIM_NRF_TWIS_DEVICE_DEFINE(id)                                                            \
 	static struct shim_nrf_twis_data SHIM_NRF_TWIS_NAME(id, data);                             \

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -3031,7 +3031,7 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 #endif
 
 #define MODEM_CELLULAR_INST_NAME(name, inst) \
-	_CONCAT_4(name, _, DT_DRV_COMPAT, inst)
+	CONCAT(name, _, DT_DRV_COMPAT, inst)
 
 #define MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(inst, name, size)                                     \
 	MODEM_PIPELINK_DT_INST_DEFINE(inst, name);                                                 \

--- a/drivers/power_domain/power_domain_nrfs_gdpwr.c
+++ b/drivers/power_domain/power_domain_nrfs_gdpwr.c
@@ -255,7 +255,7 @@ static int domain_init(const struct device *dev)
 }
 
 #define DOMAIN_NODE_SYMNAME(node, sym) \
-	_CONCAT_4(domain, _, sym, DT_NODE_CHILD_IDX(node))
+	CONCAT(domain, _, sym, DT_NODE_CHILD_IDX(node))
 
 #define DOMAIN_NODE_TO_GDPWR_ENUM(node) \
 	_CONCAT(GDPWR_GD_, DT_NODE_FULL_NAME_UPPER_TOKEN(node))

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -434,7 +434,7 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 #define GNSS_DT_DATA_CALLBACK_DEFINE(_node_id, _callback)                                          \
 	static const STRUCT_SECTION_ITERABLE(                                                      \
 		gnss_data_callback,                                                                \
-		_CONCAT_4(_gnss_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {           \
+		CONCAT(_gnss_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {              \
 		.dev = DEVICE_DT_GET(_node_id),                                                    \
 		.callback = _callback,                                                             \
 	}
@@ -460,7 +460,7 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 #define GNSS_DT_SATELLITES_CALLBACK_DEFINE(_node_id, _callback)                                    \
 	static const STRUCT_SECTION_ITERABLE(                                                      \
 		gnss_satellites_callback,                                                          \
-		_CONCAT_4(_gnss_satellites_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {     \
+		CONCAT(_gnss_satellites_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {        \
 		.dev = DEVICE_DT_GET(_node_id),                                                    \
 		.callback = _callback,                                                             \
 	}

--- a/include/zephyr/gnss/rtk/rtk.h
+++ b/include/zephyr/gnss/rtk/rtk.h
@@ -40,7 +40,7 @@ struct gnss_rtk_data_callback {
 #define GNSS_DT_RTK_DATA_CALLBACK_DEFINE(_node_id, _callback)                                      \
 	static const STRUCT_SECTION_ITERABLE(                                                      \
 		gnss_rtk_data_callback,                                                            \
-		_CONCAT_4(_gnss_rtk_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {       \
+		CONCAT(_gnss_rtk_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {          \
 		.dev = DEVICE_DT_GET(_node_id),                                                    \
 		.callback = _callback,                                                             \
 	}

--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -115,7 +115,7 @@ void modem_pipelink_notify_disconnected(struct modem_pipelink *link);
  * @param name Pipelink name
  */
 #define MODEM_PIPELINK_DT_SYM(node_id, name) \
-	_CONCAT_4(__modem_pipelink_, DT_DEP_ORD(node_id), _, name)
+	CONCAT(__modem_pipelink_, DT_DEP_ORD(node_id), _, name)
 
 /** @endcond */
 

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -385,7 +385,7 @@ struct pm_state_constraints {
 	PM_STATE_CONSTRAINT_INIT(DT_PHANDLE_BY_IDX(node_id, phandle, idx))
 
 #define Z_PM_STATE_CONSTRAINTS_LIST_NAME(node_id, phandles)                   \
-	_CONCAT_4(node_id, _, phandles, _constraints)
+	CONCAT(node_id, _, phandles, _constraints)
 
 /**
  * @brief Define a list of power state constraints from devicetree.

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5300,7 +5300,7 @@ sub process {
 			#print "LINE<$lines[$ln-1]> len<" . length($lines[$ln-1]) . "\n";
 
 			$has_flow_statement = 1 if ($ctx =~ /\b(goto|return)\b/);
-			$has_arg_concat = 1 if (($ctx =~ /\#\#/ || $ctx =~ /UTIL_CAT/) && $ctx !~ /\#\#\s*(?:__VA_ARGS__|args)\b/);
+			$has_arg_concat = 1 if (($ctx =~ /\#\#/ || $ctx =~ /UTIL_CAT/ || $ctx =~ /CONCAT/) && $ctx !~ /\#\#\s*(?:__VA_ARGS__|args)\b/);
 
 			$dstat =~ s/^.\s*\#\s*define\s+$Ident(\([^\)]*\))?\s*//;
 			my $define_args = $1;


### PR DESCRIPTION
The `has_arg_concat` check checks for `##` and `UTIL_CAT`, but is missing the `CONCAT` macro.
This is causing spurious occurances of `MACRO_WITH_FLOW_CONTROL` warnings for functions defined with macros
if they use the `CONCAT` macro.