### PR TITLE
drivers: sensor: adi: max30210: Fix build with Clang/LLVM

### DIFF
--- a/drivers/sensor/adi/max30210/max30210_trigger.c
+++ b/drivers/sensor/adi/max30210/max30210_trigger.c
@@ -140,7 +140,7 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 	}
 
 	switch ((int)trig->type) {
-	case SENSOR_TRIG_THRESHOLD:
+	case SENSOR_TRIG_THRESHOLD: {
 		uint8_t temp_hi_setup[2];
 
 		max30210_reg_read(dev, TEMP_ALARM_HIGH_MSB, temp_hi_setup, 2);
@@ -170,8 +170,9 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 			int_mask |= TEMP_LO_MASK;
 		}
 		break;
+	}
 
-	case SENSOR_TRIG_TEMP_INC_FAST:
+	case SENSOR_TRIG_TEMP_INC_FAST: {
 		uint8_t temp_inc_fast_thresh;
 
 		ret = max30210_reg_read(dev, TEMP_INC_FAST_THRESH, &temp_inc_fast_thresh, 1);
@@ -191,8 +192,9 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 			int_mask |= TEMP_INC_FAST_MASK;
 		}
 		break;
+	}
 
-	case SENSOR_TRIG_TEMP_DEC_FAST:
+	case SENSOR_TRIG_TEMP_DEC_FAST: {
 		uint8_t temp_dec_fast_thresh;
 
 		ret = max30210_reg_read(dev, TEMP_DEC_FAST_THRESH, &temp_dec_fast_thresh, 1);
@@ -212,6 +214,7 @@ int max30210_trigger_set(const struct device *dev, const struct sensor_trigger *
 			int_mask |= TEMP_DEC_FAST_MASK;
 		}
 		break;
+	}
 
 	case SENSOR_TRIG_DATA_READY:
 		data->temp_rdy_handler = handler;


### PR DESCRIPTION
Seen in https://github.com/zephyrproject-rtos/zephyr/actions/runs/20916799163/job/60092152584:

drivers/sensor/adi/max30210/max30210_trigger.c:144:3: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
  144 |                 uint8_t temp_hi_setup[2];
      |                 ^

drivers/sensor/adi/max30210/max30210_trigger.c:175:3: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
  175 |                 uint8_t temp_inc_fast_thresh;
      |                 ^

drivers/sensor/adi/max30210/max30210_trigger.c:196:3: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
  196 |                 uint8_t temp_dec_fast_thresh;
      |                 ^