### PR TITLE
net: tcp: Fix possible assertion when peer advertises zero window

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -3289,7 +3289,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 			}
 		}
 #endif
-		NET_ASSERT((conn->send_data_total == 0) ||
+		NET_ASSERT((conn->send_data_total == 0) || (conn->send_win == 0) ||
 			   k_work_delayable_is_pending(&conn->send_data_timer),
 			   "conn: %p, Missing a subscription "
 				"of the send_data queue timer", conn);


### PR DESCRIPTION
If peer lowered its receive window and advertised zero-window length, TCP stack would pause the retransmission timer until non-empty window is advertised again. This however could trigger an assertion, that verified that the retransmission timer is running whenever there is data to transmit. Add an exception to the assertion for the zero-window case.

Fixes #101748