### PR TITLE
boards: st: add netif:eth twister support for nucleo_f207zg

### DIFF
--- a/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
@@ -8,22 +8,23 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - i2c
-  - spi
-  - gpio
-  - can
-  - usb_device
-  - watchdog
-  - counter
-  - adc
-  - dac
   - backup_sram
+  - can
+  - counter
+  - dac
+  - dma
+  - gpio
+  - i2c
+  - netif:eth
   - pwm
   - rng
-  - dma
   - rtc
+  - spi
+  - usb_device
   - usbd
+  - watchdog
 vendor: st


### PR DESCRIPTION
This PR adds the Twister `netif:eth` attribute that was missing in the YAML files for the STM32H7S78 and STM32F207ZG boards.
Now, they can be built and run net tests/samples.