### PR TITLE
cmake: compiler: arm64: Disable SVE for ARMv9-A when CONFIG_ARM64_SVE=n

### DIFF
--- a/cmake/compiler/clang/target_arm64.cmake
+++ b/cmake/compiler/clang/target_arm64.cmake
@@ -1,4 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# Add SVE support if enabled, or explicitly disable it for ARMv9-A
+if(CONFIG_ARM64_SVE)
+  if(DEFINED GCC_M_ARCH)
+    set(GCC_M_ARCH "${GCC_M_ARCH}+sve")
+  else()
+    set(GCC_M_ARCH "armv9-a+sve")
+  endif()
+elseif(CONFIG_ARMV9_A)
+  # ARMv9-A includes SVE by default, so explicitly disable it when not configured
+  if(DEFINED GCC_M_ARCH)
+    set(GCC_M_ARCH "${GCC_M_ARCH}+nosve")
+  else()
+    set(GCC_M_ARCH "armv9-a+nosve")
+  endif()
+endif()
+
 if(DEFINED GCC_M_CPU)
   list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
   list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})

--- a/cmake/compiler/gcc/target_arm64.cmake
+++ b/cmake/compiler/gcc/target_arm64.cmake
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Add SVE support if enabled
+# Add SVE support if enabled, or explicitly disable it for ARMv9-A
 if(CONFIG_ARM64_SVE)
   if(DEFINED GCC_M_ARCH)
     set(GCC_M_ARCH "${GCC_M_ARCH}+sve")
   else()
     set(GCC_M_ARCH "armv9-a+sve")
+  endif()
+elseif(CONFIG_ARMV9_A)
+  # ARMv9-A includes SVE by default, so explicitly disable it when not configured
+  if(DEFINED GCC_M_ARCH)
+    set(GCC_M_ARCH "${GCC_M_ARCH}+nosve")
+  else()
+    set(GCC_M_ARCH "armv9-a+nosve")
   endif()
 endif()
 


### PR DESCRIPTION
When building for ARMv9-A platforms with `CONFIG_ARM64_SVE` disabled,
compilers still emit SVE instructions because ARMv9-A includes SVE
by default in the architecture specification.

Add explicit `+nosve` flag to `-march` when `CONFIG_ARMV9_A=y` but
`CONFIG_ARM64_SVE=n` to prevent SVE instruction emission. This ensures
the compiler respects the SVE configuration and only emits SVE
instructions when explicitly enabled.
