### PR TITLE
drivers: sensor: bosch: bma4xx: add attr_get to device API

### DIFF
--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -275,6 +275,17 @@ static int bma4xx_chip_init(const struct device *dev)
 	}
 	LOG_DBG("chip_id is 0x%02x", bma4xx->chip_id);
 
+	switch (bma4xx->chip_id) {
+	case BMA4XX_CHIP_ID_BMA423:
+		LOG_WRN("Driver tested for BMA422/BMA400. Check for unintended operation.");
+	case BMA4XX_CHIP_ID_BMA400:
+	case BMA4XX_CHIP_ID_BMA422:
+		break;
+	default:
+		LOG_ERR("Chip id (0x%02X) not supported", bma4xx->chip_id);
+		return -ENODEV;
+	}
+
 	if (bma4xx->chip_id != BMA4XX_CHIP_ID_BMA422) {
 		LOG_WRN("Driver tested for BMA422. Check for unintended operation.");
 	}
@@ -308,11 +319,27 @@ static int bma4xx_chip_init(const struct device *dev)
 	return 0;
 }
 
+static int bma4xx_attr_get(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, struct sensor_value *val)
+{
+	struct bma4xx_data *bma4xx = dev->data;
+
+	switch (attr) {
+	case SENSOR_ATTR_CHIP_ID:
+		val->val1 = bma4xx->chip_id;
+		return 0;
+	default:
+		LOG_ERR("Attribute not supported");
+		return -EINVAL;
+	}
+}
+
 /*
  * Sensor driver API
  */
 
 static DEVICE_API(sensor, bma4xx_driver_api) = {
+	.attr_get = bma4xx_attr_get,
 	.attr_set = bma4xx_attr_set,
 	.get_decoder = bma4xx_get_decoder,
 	.submit = bma4xx_submit,

--- a/drivers/sensor/bosch/bma4xx/bma4xx_defs.h
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_defs.h
@@ -173,6 +173,7 @@
 /* BMA4xx chip id */
 #define BMA4XX_CHIP_ID_BMA422 (0x12)
 #define BMA4XX_CHIP_ID_BMA423 (0x13)
+#define BMA4XX_CHIP_ID_BMA400 (0x90)
 
 #define BMA4XX_REG_I2C_READ_BIT BIT(7)
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -374,6 +374,8 @@ enum sensor_attribute {
 	SENSOR_ATTR_GAIN,
 	/* Configure the resolution of a sensor. */
 	SENSOR_ATTR_RESOLUTION,
+	/* Chip ID of the sensor*/
+	SENSOR_ATTR_CHIP_ID,
 	/**
 	 * Number of all common sensor attributes.
 	 */


### PR DESCRIPTION
## Summary

Adds `attr_get` functionality to bma4xx's driver allowing user to fetch the device id over the Sensor's API.

## Example/Testing

- Add sensor to dts
```
&i2cx {
        g_sensor: g-sensor@14 {
                compatible = "bosch,bma4xx";
                status = "okay";
                reg = <0x14>;
                int1-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
        };
};
```

- fetch id on app:
```
#include <zephyr/drivers/sensor.h>
#include <zephyr/drivers/sensor/bma4xx.h>

int main() {
    sensor_value val;
    
    int ret = sensor_attr_get(DEVICE_DT_GET(DT_NODELABEL(g_sensor)), , SENSOR_CHAN_ALL, (sensor_attribute) SENSOR_ATTR_BMA4XX_CHIP_ID, &val);
    if(ret) {
        printk("Failed to get sensor id (%d)"; ret);
        return ret;
    }
    printk("Sensor ID is 0x%02X", (int) sensor_value);
    return 0;
}
```

on a BMA400, this will print:
```
Sensor ID is 0x90
```