### PR TITLE
doc: shell: improve wildcard feature documentation

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -631,6 +631,10 @@ modules you can execute the following command:
 
 This feature is activated by :kconfig:option:`CONFIG_SHELL_WILDCARD` set to ``y``.
 
+.. note::
+	When the wildcard feature is enabled, the characters ``*`` and ``?``
+	cannot be used as normal characters in commands or arguments.
+
 Meta Keys Feature
 *****************
 


### PR DESCRIPTION
Add a note about '*' and '?' characters usage.