### PR TITLE
samples: drivers: counter: alarm: kit_psc3m5_evk

### DIFF
--- a/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Infineon Technologies AG,
+ * Copyright (c) 2026 Infineon Technologies AG,
  * or an affiliate of Infineon Technologies AG.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -7,21 +7,19 @@
 
 #include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
 
-&tcpwm0_0 {
+&tcpwm0_1 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <0>;
-	divider-val = <2399>;
 
-	counter0_0 {
+	counter0_1 {
 		status = "okay";
-		clocks = <&peri0_group4_16bit_0>;
-		clock-frequency = <20000>;
+		clocks = <&peri0_group5_16bit_0>;
 	};
 };
 
-&peri0_group4_16bit_0 {
+&peri0_group5_16bit_0 {
 	status = "okay";
-	scb-block = <0>;
-	div-value = <109>;
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <1>;
+	clock-div = <2400>;
 };


### PR DESCRIPTION
Updating overlay file for the kit_psc3m5_evk board to work with device tree updates.