### PR TITLE
tests: net: Use ARG_UNUSED instead of self assignment

### DIFF
--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -253,9 +253,7 @@ struct net_6lo_data {
 
 int net_6lo_dev_init(const struct device *dev)
 {
-	struct net_6lo_context *net_6lo_context = dev->data;
-
-	net_6lo_context = net_6lo_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -52,9 +52,7 @@ struct net_arp_context {
 
 int net_arp_dev_init(const struct device *dev)
 {
-	struct net_arp_context *net_arp_context = dev->data;
-
-	net_arp_context = net_arp_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -141,9 +141,7 @@ struct net_icmpv4_context {
 
 static int net_icmpv4_dev_init(const struct device *dev)
 {
-	struct net_icmpv4_context *net_icmpv4_context = dev->data;
-
-	net_icmpv4_context = net_icmpv4_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/icmpv6/src/main.c
+++ b/tests/net/icmpv6/src/main.c
@@ -73,9 +73,7 @@ static struct net_icmpv6_context net_icmpv6_context_data;
 
 static int net_icmpv6_dev_init(const struct device *dev)
 {
-	struct net_icmpv6_context *net_icmpv6_context = dev->data;
-
-	net_icmpv6_context = net_icmpv6_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -115,9 +115,7 @@ struct net_test_context {
 
 int net_test_init(const struct device *dev)
 {
-	struct net_test_context *net_test_context = dev->data;
-
-	net_test_context = net_test_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -59,9 +59,7 @@ struct net_udp_context {
 
 int net_udp_dev_init(const struct device *dev)
 {
-	struct net_udp_context *net_udp_context = dev->data;
-
-	net_udp_context = net_udp_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -164,9 +164,7 @@ struct net_tcp_context {
 
 static int net_tcp_dev_init(const struct device *dev)
 {
-	struct net_tcp_context *net_tcp_context = dev->data;
-
-	net_tcp_context = net_tcp_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -61,9 +61,7 @@ struct net_udp_context {
 
 int net_udp_dev_init(const struct device *dev)
 {
-	struct net_udp_context *net_udp_context = dev->data;
-
-	net_udp_context = net_udp_context;
+	ARG_UNUSED(dev);
 
 	return 0;
 }


### PR DESCRIPTION
When building with clang it warns about self-assignment in these tests:

* net.icmpv6
* net.shell
* net.arp
* net.tcp
* net.ip_addr
* net.6lo
* net.icmpv4
* net.udp

Example:

error: explicitly assigning value of variable of type
'struct net_udp_context *' to itself [-Werror,-Wself-assign]