### PR TITLE
tests: bluetooth: classic: Remove self assignment

### DIFF
--- a/tests/bluetooth/classic/sdp_s/src/sdp_server.c
+++ b/tests/bluetooth/classic/sdp_s/src/sdp_server.c
@@ -255,8 +255,6 @@ static int cmd_register_sdp_all(const struct shell *sh, size_t argc, char *argv[
 {
 	int err;
 
-	sh = sh;
-
 	for (size_t i = 0; i < ARRAY_SIZE(spp_rec); i++) {
 		if (!sdp_rec_reg[i]) {
 			err = bt_sdp_register_service(&spp_rec[i]);
@@ -274,8 +272,6 @@ static int cmd_register_sdp_large(const struct shell *sh, size_t argc, char *arg
 {
 	int err;
 
-	sh = sh;
-
 	err = bt_sdp_register_service(&spp_rec_large);
 	if (err) {
 		shell_error(sh, "Register SDP large record failed (err %d)", err);
@@ -286,8 +282,6 @@ static int cmd_register_sdp_large(const struct shell *sh, size_t argc, char *arg
 static int cmd_register_sdp_large_valid(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
-
-	sh = sh;
 
 	err = bt_sdp_register_service(&spp_rec_large_valid);
 	if (err) {
@@ -364,8 +358,6 @@ static struct bt_sdp_record spp_rec_uuid128 = BT_SDP_RECORD(spp_attrs_uuid128);
 static int cmd_register_sdp_uuid128(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
-
-	sh = sh;
 
 	err = bt_sdp_register_service(&spp_rec_uuid128);
 	if (err) {


### PR DESCRIPTION
When building with clang it warns about self-assignment in the
bluetooth.classic.sdp_s test:

tests/bluetooth/classic/sdp_s/src/sdp_server.c:258:5: error: explicitly
assigning value of variable of type 'const struct shell *' to itself
[-Werror,-Wself-assign]
  258 |         sh = sh;
      |         ~~ ^ ~~
tests/bluetooth/classic/sdp_s/src/sdp_server.c:277:5: error: explicitly
assigning value of variable of type 'const struct shell *' to itself
[-Werror,-Wself-assign]
  277 |         sh = sh;
      |         ~~ ^ ~~
tests/bluetooth/classic/sdp_s/src/sdp_server.c:290:5: error: explicitly
assigning value of variable of type 'const struct shell *' to itself
[-Werror,-Wself-assign]
  290 |         sh = sh;
      |         ~~ ^ ~~
tests/bluetooth/classic/sdp_s/src/sdp_server.c:368:5: error: explicitly
assigning value of variable of type 'const struct shell *' to itself
[-Werror,-Wself-assign]
  368 |         sh = sh;
      |         ~~ ^ ~~
4 errors generated.

The "sh" variable is used later in the functions.