### PR TITLE
Bluetooth: Host: GOEP: force 16-bit FCS for L2CAP ERTM

### DIFF
--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -527,6 +527,14 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 	goep->_transport.chan.rx.max_transmit = 3;
 	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
 	goep->_transport.chan.rx.extended_control = false;
+	/*
+	 * There is an issue found that the FCS option is not correctly set when connecting to an
+	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
+	 * option will be applied while the 'No FCS' option is not added in an
+	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
+	 * Force 16 bits FCS option for enhance retransmission mode by default.
+	 */
+	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
 	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
 	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
 
@@ -612,6 +620,14 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 	goep->_transport.chan.rx.max_transmit = 3;
 	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
 	goep->_transport.chan.rx.extended_control = false;
+	/*
+	 * There is an issue found that the FCS option is not correctly set when connecting to an
+	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
+	 * option will be applied while the 'No FCS' option is not added in an
+	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
+	 * Force 16 bits FCS option for enhance retransmission mode by default.
+	 */
+	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
 	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
 	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
 


### PR DESCRIPTION
Set the FCS option to BT_L2CAP_BR_FCS_16BIT for enhanced retransmission mode in both L2CAP accept and connect paths to work around an interoperability issue with iPhone devices.

The issue occurs when connecting to iPhone for PBAP or MAP profiles, where the iPhone expects the 'No FCS' option to be applied but does not include the 'No FCS' option in its L2CAP_CONFIGURATION_REQ packet. Forcing 16-bit FCS ensures proper configuration negotiation.

Changes include:
- Set rx.fcs to BT_L2CAP_BR_FCS_16BIT in goep_l2cap_accept()
- Set rx.fcs to BT_L2CAP_BR_FCS_16BIT in bt_goep_transport_l2cap_connect()