### PR TITLE
drivers: ipm: ipm_mbox: mark payload pointer as volatile

### DIFF
--- a/drivers/ipm/ipm_mbox.c
+++ b/drivers/ipm/ipm_mbox.c
@@ -48,7 +48,7 @@ static void ipm_mbox_callback(const struct device *mboxdev,
 {
 	const struct device *ipmdev = user_data;
 	struct ipm_mbox_data *ipm_mbox_data = ipmdev->data;
-	void *payload = NULL;
+	volatile void *payload = NULL;
 
 	if (!ipm_mbox_data || !ipm_mbox_data->callback) {
 		return;
@@ -56,7 +56,7 @@ static void ipm_mbox_callback(const struct device *mboxdev,
 
 	/* Only use the payload if the mailbox provides a non-empty buffer */
 	if (data && data->data && data->size > 0) {
-		payload = data->data;
+		payload = (volatile void *)(uintptr_t)data->data;
 	}
 
 	ipm_mbox_data->callback(ipmdev,


### PR DESCRIPTION
`struct mbox_msg::data` is `const void *`, but the IPM callback requires `volatile void *`. The current intermediate variable is `void *`, which causes the const qualifier to be lost. Add an explicit cast in the function `ipm_mbox_callback` to eliminate this compilation warning.

fix: https://github.com/zephyrproject-rtos/zephyr/issues/102057