### PR TITLE
drivers: i2c: i2c_nrfx: add support for custom frequencies

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -17,17 +17,49 @@ extern "C" {
 #endif
 
 #define I2C_NRFX_TWIM_INVALID_FREQUENCY ((nrf_twim_frequency_t)-1)
-#define I2C_NRFX_TWIM_FREQUENCY(bitrate)                                                           \
+
+#if defined(LUMOS_XXAA)
+#define DIV_ROUND_NEAREST(a, b) (((a) + (b) / 2) / (b))
+
+/* Formula for getting the frequency settings is following:
+ * 2^12 * (2^20 / (f_PCLK / desired_frequency)) where f_PCLK is a frequency that
+ * drives the TWIM.
+ *
+ * @param f_pclk Frequency of the clock that drives the peripheral.
+ * @param baudrate Desired baudrate.
+ *
+ * @return Frequency setting to be written to the FREQUENCY register
+ */
+#define I2C_NRFX_TWIM_GET_CUSTOM_FREQUENCY(f_pclk, frequency) \
+	((nrf_twim_frequency_t)((BIT(20) / DIV_ROUND_NEAREST(f_pclk, frequency)) << 12))
+
+#define I2C_NRFX_TWIM_MIN_FREQUENCY KHZ(100)
+#define I2C_NRFX_TWIM_MAX_FREQUENCY COND_CODE_1(NRF_TWIM_HAS_1000_KHZ_FREQ, KHZ(1000), KHZ(400))
+
+#define I2C_NRFX_TWIM_CUSTOM_FREQUENCY_VALID_CHECK(frequency) \
+	((frequency >= I2C_NRFX_TWIM_MIN_FREQUENCY) && (frequency <= I2C_NRFX_TWIM_MAX_FREQUENCY))
+
+#define I2C_NRFX_TWIM_GET_CUSTOM_FREQUENCY_IF_VALID(f_pclk, frequency)  \
+	(I2C_NRFX_TWIM_CUSTOM_FREQUENCY_VALID_CHECK(frequency)          \
+		? I2C_NRFX_TWIM_GET_CUSTOM_FREQUENCY(f_pclk, frequency) \
+		: I2C_NRFX_TWIM_INVALID_FREQUENCY)
+#else
+#define I2C_NRFX_TWIM_GET_CUSTOM_FREQUENCY_IF_VALID(f_pclk, frequency) \
+	I2C_NRFX_TWIM_INVALID_FREQUENCY
+#endif
+
+#define I2C_NRFX_TWIM_FREQUENCY(bitrate, f_pclk)                                                   \
 	(bitrate == I2C_BITRATE_STANDARD ? NRF_TWIM_FREQ_100K                                      \
 	 : bitrate == 250000             ? NRF_TWIM_FREQ_250K                                      \
 	 : bitrate == I2C_BITRATE_FAST                                                             \
 		 ? NRF_TWIM_FREQ_400K                                                              \
 		 : IF_ENABLED(NRF_TWIM_HAS_1000_KHZ_FREQ,                                          \
 			      (bitrate == I2C_BITRATE_FAST_PLUS ? NRF_TWIM_FREQ_1000K :))          \
-			   I2C_NRFX_TWIM_INVALID_FREQUENCY)
+			I2C_NRFX_TWIM_GET_CUSTOM_FREQUENCY_IF_VALID(f_pclk, bitrate))
 
-#define I2C_FREQUENCY(inst) \
-	I2C_NRFX_TWIM_FREQUENCY(DT_INST_PROP_OR(inst, clock_frequency, I2C_BITRATE_STANDARD))
+#define I2C_FREQUENCY(inst)                                                                   \
+	I2C_NRFX_TWIM_FREQUENCY(DT_INST_PROP_OR(inst, clock_frequency, I2C_BITRATE_STANDARD), \
+				NRF_PERIPH_GET_FREQUENCY(inst))
 
 /* Macro determines PM actions interrupt safety level.
  *

--- a/tests/boards/nrf/i2c/i2c_slave/i2c_speed_custom.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/i2c_speed_custom.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dut_twim {
+	clock-frequency = <300000>; /* 300 kHz */
+};

--- a/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
+++ b/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
@@ -59,3 +59,11 @@ tests:
       - nrf54h20dk/nrf54h20/cpuppr
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="i2c_speed_fast_plus.overlay"
+  boards.nrf.i2c.i2c_slave.custom:
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="i2c_speed_custom.overlay"


### PR DESCRIPTION
Add support for custom clock frequencies.