### PR TITLE
drivers: spi: nxp_lpspi: Add clock configuration support

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2024-2025 NXP
+ * Copyright 2018, 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -382,6 +382,16 @@ int spi_nxp_init_common(const struct device *dev)
 	if (!device_is_ready(config->clock_dev)) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;
+	}
+
+	err = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	if (err != 0) {
+		/* Check if error is due to lack of support */
+		if (err != -ENOSYS) {
+			/* Real error occurred */
+			LOG_ERR("Failed to configure clock: %d", err);
+			return err;
+		}
 	}
 
 	lpspi_module_system_init(base);


### PR DESCRIPTION
Add clock_control_configure() call during initialization to properly
configure the LPSPI clock. The implementation gracefully handles
platforms that don't support clock configuration by checking for
-ENOTSUP and -ENOSYS return codes and continuing with default
settings. Real configuration errors are logged and propagated.

Signed-off-by: Albort Xue <yao.xue@nxp.com>