### PR TITLE
net: shell: fix qbv command documentation and help text

### DIFF
--- a/doc/connectivity/networking/api/net_shell.rst
+++ b/doc/connectivity/networking/api/net_shell.rst
@@ -38,6 +38,8 @@ The following net-shell commands are implemented:
    "net nbr", "Print neighbor information. Only available if
    :kconfig:option:`CONFIG_NET_IPV6` is set."
    "net ping", "Ping a network host."
+   "net qbv", "Show and configure IEEE 802.1Qbv Time-Aware Shaper (TAS) information.
+   Only available if :kconfig:option:`CONFIG_NET_QBV` is set."
    "net route", "Show IPv6 network routes. Only available if
    :kconfig:option:`CONFIG_NET_ROUTE` is set."
    "net sockets", "Show network socket information and statistics. Only available if

--- a/subsys/net/lib/shell/qbv_shell.c
+++ b/subsys/net/lib/shell/qbv_shell.c
@@ -52,8 +52,8 @@ static int cmd_net_qbv(const struct shell *sh, size_t argc, char **argv)
 	shell_print(sh, "For example:");
 	shell_print(sh, "  1. net qbv enable 1 on");
 	shell_print(sh, "  2. net qbv set_config 1 200 0 0 10000000 0 2");
-	shell_print(sh, "  3. qbv set_gc 1 0 0x1 5000000");
-	shell_print(sh, "  4. qbv set_gc 1 0 0x2 5000000");
+	shell_print(sh, "  3. net qbv set_gc 1 0 0x1 5000000");
+	shell_print(sh, "  4. net qbv set_gc 1 0 0x2 5000000");
 #else
 	shell_print(sh, "Set %s to enable %s support.\n", "CONFIG_NET_QBV", "qbv");
 	shell_print(sh, "Set %s to enable %s support.\n", "CONFIG_NET_L2_ETHERNET_MGMT",
@@ -321,10 +321,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_qbv,
 		"Enable: enable <iface_index> <value(off, on)>",
 		cmd_qbv_enable, 3, 0),
 	SHELL_CMD_ARG(set_config, NULL,
-		"Set config: set <iface_index> <base_time(s)> <base_time(2*(-16)ns)> <cycle_time(s)> <cycle_time(ns)> <cycle_time_ext(ns)> <list_len>",
+		"Set config: set_config <iface_index> <base_time(s)> <base_time(2*(-16)ns)> <cycle_time(s)> <cycle_time(ns)> <cycle_time_ext(ns)> <list_len>",
 		cmd_qbv_set_config, 8, 0),
 	SHELL_CMD_ARG(set_gc, NULL,
-		"Set gate control: set <iface_index> <row> <gate_control> <interval>",
+		"Set gate control: set_gc <iface_index> <row> <gate_control> <interval>",
 		cmd_qbv_set_gc, 5, 0),
 	SHELL_CMD_ARG(get_info, NULL,
 		"Get info: get_info <iface_index>",


### PR DESCRIPTION
Fix inconsistencies in the QBV (IEEE 802.1Qbv Time-Aware Shaper) shell command documentation and help messages:

1. Add missing "net qbv" command documentation to net_shell.rst
2. Correct command examples in help text - add missing "net" prefix to "qbv set_gc" commands
3. Fix command usage descriptions for set_config and set_gc to match actual command names

This ensures users see correct command syntax in both documentation and interactive help.