### PR TITLE
scripts: dts: gen_dts_cmake: Add DT_UNIT_ADDR to CMake pickled output

### DIFF
--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -156,6 +156,10 @@ def main():
             cmake_props.append(f'"DT_REG|{node.path}|ADDR" "{cmake_addr}"')
             cmake_props.append(f'"DT_REG|{node.path}|SIZE" "{cmake_size}"')
 
+            cmake_unit_addr_int = 'NONE' if node.unit_addr is None else hex(node.unit_addr)
+
+            cmake_props.append(f'"DT_UNIT_ADDR|{node.path}" "{cmake_unit_addr_int}"')
+
     for comp in compatible2paths.keys():
         cmake_path = ''
         for path in compatible2paths[comp]:


### PR DESCRIPTION
Adds a new property which outputs the absolute address of a dts device (if it is available) which will take the parent nodes into consideration without a user having to manually trawl through devices (which is error prone depending upon how they are layered)

Debatable on what the property name should be