### PR TITLE
samples: drivers: memc: Add support for stm32h7s78_dk PSRAM

### DIFF
--- a/samples/drivers/memc/boards/stm32h7s78_dk.overlay
+++ b/samples/drivers/memc/boards/stm32h7s78_dk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sram-ext = &psram;
+	};
+};

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -28,7 +28,8 @@
 #define mspi_get_xip_address(controller) DT_REG_ADDR_BY_IDX(controller, 1)
 #define MEMC_BASE (void *)(mspi_get_xip_address(MSPI_BUS))
 #define MEMC_SIZE (DT_PROP(MEMC_DEV, size) / 8)
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_fmc_sdram)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_fmc_sdram) || \
+	DT_HAS_COMPAT_STATUS_OKAY(st_stm32_xspi_psram)
 #define MEMC_DEV  DT_ALIAS(sram_ext)
 #define MEMC_BASE DT_REG_ADDR(MEMC_DEV)
 #define MEMC_SIZE DT_REG_SIZE(MEMC_DEV)


### PR DESCRIPTION
This patch adds support for the STM32 XSPI memory controller in order to enable PSRAM testing. It also adds a board overlay for the STM327S78 Discovery Kit that includes a PSRAM memory.