### PR TITLE
dts: nordic: nrf54h: Enable lfclk by default for cpurad

### DIFF
--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -131,3 +131,7 @@ wdt011: &cpurad_wdt011 {};
 &gdpwr_slow_main {
 	status = "okay";
 };
+
+&lfclk {
+	status = "okay";
+};


### PR DESCRIPTION
Most CPURAD applications need the lfclk to be enabled. Therefore it should be enabled by default.