### PR TITLE
STM32 video encoder fixes

### DIFF
--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1166,6 +1166,17 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 		if (ret < 0) {
 			goto out;
 		}
+
+		/* Limit the amount of hardware handshake interrupts received by slave IP */
+		if (pipe->id == DCMIPP_PIPE1) {
+			stm32_reg_modify_bits(&dcmipp->hdcmipp.Instance->P1PPCR,
+					      DCMIPP_P1PPCR_LINEMULT_Msk,
+					      DCMIPP_MULTILINE_128_LINES);
+		} else {
+			stm32_reg_modify_bits(&dcmipp->hdcmipp.Instance->P2PPCR,
+					      DCMIPP_P1PPCR_LINEMULT_Msk,
+					      DCMIPP_MULTILINE_128_LINES);
+		}
 	}
 #endif
 

--- a/drivers/video/video_stm32_venc.c
+++ b/drivers/video/video_stm32_venc.c
@@ -601,12 +601,15 @@ static int encoder_start(struct stm32_venc_data *data, struct video_buffer *outp
 
 static int encoder_end(struct stm32_venc_data *data)
 {
+	struct stm32_venc_ewl *inst = &ewl_instance;
 	H264EncIn enc_in = {0};
 	H264EncOut enc_out = {0};
 
 	if (data->encoder != NULL) {
 		H264EncStrmEnd(data->encoder, &enc_in, &enc_out);
+		H264EncRelease(data->encoder);
 		data->encoder = NULL;
+		inst->mem_cnt = 0;
 	}
 
 	return 0;

--- a/drivers/video/video_stm32_venc.c
+++ b/drivers/video/video_stm32_venc.c
@@ -349,69 +349,24 @@ i32 EWLWaitHwRdy(const void *instance, uint32_t *slices_ready)
 {
 	struct stm32_venc_ewl *inst = (struct stm32_venc_ewl *)instance;
 	const struct stm32_venc_config *config = inst->config;
-	int32_t ret = EWL_HW_WAIT_TIMEOUT;
-	volatile uint32_t irq_stats;
-	uint32_t prev_slices_ready = 0;
-	k_timepoint_t timeout = sys_timepoint_calc(K_MSEC(EWL_TIMEOUT));
 	uint32_t start = sys_clock_tick_get_32();
 
 	__ASSERT_NO_MSG(inst != NULL);
 
-	/* check how to clear IRQ flags for VENC */
-	uint32_t clr_by_write_1 = EWLReadReg(inst, BASE_HWFuse2) & HWCFGIrqClearSupport;
+	if (k_sem_take(&inst->complete, K_MSEC(EWL_TIMEOUT))) {
+		uint32_t irq_status = sys_read32(config->reg + BASE_HEncIRQ);
 
-	do {
-		irq_stats = sys_read32(config->reg + BASE_HEncIRQ);
-		/* get the number of completed slices from ASIC registers. */
-		if (slices_ready != NULL && *slices_ready > prev_slices_ready) {
-			*slices_ready = FIELD_GET(NUM_SLICES_READY_MASK,
-						 sys_read32(config->reg + BASE_HEncControl7));
-		}
-
-		LOG_DBG("IRQ stat = %08x", irq_stats);
-
-		uint32_t hw_handshake_status = IS_BIT_SET(
-			sys_read32(config->reg + BASE_HEncInstantInput), LOW_LATENCY_HW_ITF_EN);
-
-		/* ignore the irq status of input line buffer in hw handshake mode */
-		if ((irq_stats == ASIC_STATUS_LINE_BUFFER_DONE) && (hw_handshake_status != 0UL)) {
-			sys_write32(ASIC_STATUS_FUSE, config->reg + BASE_HEncIRQ);
-			continue;
-		}
-
-		if ((irq_stats & ASIC_STATUS_ALL) != 0UL) {
-			/* clear IRQ and slice ready status */
-			uint32_t clr_stats;
-
-			irq_stats &= ~(ASIC_STATUS_SLICE_READY | ASIC_IRQ_LINE);
-
-			if (clr_by_write_1 != 0UL) {
-				clr_stats = ASIC_STATUS_SLICE_READY | ASIC_IRQ_LINE;
-			} else {
-				clr_stats = irq_stats;
-			}
-
-			sys_write32(clr_stats, config->reg + BASE_HEncIRQ);
-			ret = EWL_OK;
-			break;
-		}
-
-		if (slices_ready != NULL && *slices_ready > prev_slices_ready) {
-			ret = EWL_OK;
-			break;
-		}
-
-	} while (!sys_timepoint_expired(timeout));
-
-	if (ret != EWL_OK) {
-		LOG_ERR("Timeout");
-		return ret;
+		LOG_ERR("timeout, status=0x%x", irq_status);
+		return EWL_HW_WAIT_TIMEOUT;
 	}
 
 	LOG_DBG("encoding = %d ms", k_ticks_to_ms_ceil32(sys_clock_tick_get_32() - start));
 
+	/* get the number of completed slices from ASIC registers. */
 	if (slices_ready != NULL) {
-		LOG_DBG("slices_ready = %d", *slices_ready);
+		*slices_ready = FIELD_GET(NUM_SLICES_READY_MASK,
+					  sys_read32(config->reg + BASE_HEncControl7));
+		LOG_DBG("slices=%d", *slices_ready);
 	}
 
 	return EWL_OK;
@@ -801,9 +756,9 @@ ISR_DIRECT_DECLARE(stm32_venc_isr)
 		 * and signal to EWLWaitHwRdy
 		 */
 		sys_write32(ASIC_STATUS_SLICE_READY | ASIC_IRQ_LINE, config->reg + BASE_HEncIRQ);
-	}
 
-	k_sem_give(&inst->complete);
+		k_sem_give(&inst->complete);
+	}
 
 	return 0;
 }

--- a/drivers/video/video_stm32_venc.c
+++ b/drivers/video/video_stm32_venc.c
@@ -647,10 +647,11 @@ static int encode_frame(struct stm32_venc_data *data)
 		goto out;
 	}
 
-	/* one key frame every seconds */
+	/* one key frame every VENC_DEFAULT_FRAMERATE frames */
 	if ((data->frame_nb % VENC_DEFAULT_FRAMERATE) == 0 || data->resync) {
 		/* if frame is the first or resync needed: set as intra coded */
 		enc_in.codingType = H264ENC_INTRA_FRAME;
+		data->resync = false;
 	} else {
 		/* if there was a frame previously, set as predicted */
 		enc_in.timeIncrement = 1;

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -187,6 +187,12 @@ int encode_frame(struct video_buffer *in, struct video_buffer **out)
 		return ret;
 	}
 
+	ret = video_dequeue(encoder_dev, &in, K_FOREVER);
+	if (ret) {
+		LOG_ERR("Unable to dequeue encoder input buf");
+		return ret;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Various fixes around video streaming use-case with STM32N6 video encoder:
- fix multiple streaming session
- fix video encoder P frames generation
- fix video encoder interrupt mode
- enhance framerate versus frames memory consumption