### PR TITLE
 dts: arm: microchip: pic32cx_sg: Add dts node of watchdog

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -20,4 +20,5 @@ supported:
   - reset
   - rtc
   - uart
+  - watchdog
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -20,4 +20,5 @@ supported:
   - reset
   - rtc
   - uart
+  - watchdog
 vendor: microchip

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,10 @@
 #include <zephyr/dt-bindings/clock/mchp_sam_d5x_e5x_clock.h>
 
 / {
+	aliases {
+		watchdog0 = &wdt;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -90,6 +94,20 @@
 		rstc: rstc@40000c00 {
 			compatible = "microchip,rstc-g1-reset";
 			reg = <0x40000c00 0x400>;
+		};
+
+		wdt: watchdog@40002000 {
+			compatible = "microchip,wdt-g1";
+			reg = <0x40002000 13>;
+			interrupts = <10 0>;
+			interrupt-names = "wdt-ew";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_WDT>;
+			clock-names = "mclk";
+			max-installable-timeout-count = <1>;
+			max-timeout-window = <0x4000>; /* 16384 milliseconds */
+			max-timeout-window-mode = <0x8000>; /* 32768 milliseconds */
+			min-window-limit = <0x8>; /* 8 milliseconds */
+			status = "disabled";
 		};
 
 		rtc: rtc@40002400 {

--- a/samples/drivers/watchdog/boards/pic32cx_sg41_cult.overlay
+++ b/samples/drivers/watchdog/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/boards/pic32cx_sg61_cult.overlay
+++ b/samples/drivers/watchdog/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -37,6 +37,7 @@ tests:
       - raytac_an54lq_db_15/nrf54l15/cpuapp/ns
       - frdm_mcxw23
       - mcxw23_evk
+      - pic32cx_sg61_cult
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"

--- a/tests/drivers/watchdog/wdt_error_cases/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -69,7 +69,8 @@
 #define MAX_INSTALLABLE_TIMEOUTS (1)
 #define WDT_WINDOW_MAX_ALLOWED   (0x40001U)
 #define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
-#elif defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X)
+#elif defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X) ||					   \
+	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
 #define WDT_TEST_FLAGS                                                                             \
 	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
 	 WDT_FLAG_RESET_CPU_CORE_SUPPORTED | WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED |           \

--- a/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       - xg27_dk2602a
       - raytac_an54lq_db_15/nrf54l15/cpuapp
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp


### PR DESCRIPTION
- Adds device tree node of watchdog in pic32cx_sg common dtsi file
- Adds overlay for watchdog sample
- Adds the test files for pic32cxsg_41 board