### PR TITLE
Add RESET driver support for microchip PIC32CM JH family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: pic32cm_jh01_cpro
@@ -13,5 +13,6 @@ supported:
   - clock_control
   - gpio
   - pinctrl
+  - reset
   - uart
 vendor: microchip

--- a/drivers/reset/reset_mchp_rstc_g1.c
+++ b/drivers/reset/reset_mchp_rstc_g1.c
@@ -1,22 +1,14 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file reset_mchp_rstc_g1.c
- * @brief Zephyr reset driver for Microchip G1 peripherals
- *
- * This file implements the driver for the Microchip RSTC g1 reset controller,
- * providing APIs to assert, deassert, toggle, and query the status of reset lines.
- *
  */
 
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/reset.h>
+#include <zephyr/drivers/reset/mchp_rstc_g1.h>
 
 #define DT_DRV_COMPAT microchip_rstc_g1_reset
 
@@ -46,6 +38,8 @@ static int reset_mchp_status(const struct device *dev, uint32_t id, uint8_t *sta
 
 	if (id >= MCHP_RST_LINE_MAX) {
 		ret = -EINVAL;
+	} else if ((BIT(id) & RSTC_UNSUPPORTED_RCAUSE) != 0U) {
+		ret = -ENOTSUP;
 	} else {
 		rcause = (((const struct reset_mchp_config *)((dev)->config))->regs)->RSTC_RCAUSE;
 		*status = (rcause & BIT(id)) ? 1 : 0;

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -89,6 +89,11 @@
 				compatible = "microchip,pic32cm-jh-mclkperiph";
 				#clock-cells = <1>;
 			};
+		};
+
+		rstc: rstc@40000c00 {
+			compatible = "microchip,rstc-g1-reset";
+			reg = <0x40000c00 0x400>;
 		};
 
 		pinctrl: pinctrl@41000000 {

--- a/include/zephyr/drivers/reset/mchp_rstc_g1.h
+++ b/include/zephyr/drivers/reset/mchp_rstc_g1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,5 +31,14 @@ enum rstc_g1_rcause {
 	RSTC_G1_RCAUSE_SYST = 6,  /* System Reset Request */
 	RSTC_G1_RCAUSE_BACKUP = 7 /* Backup Reset */
 };
+
+#ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH
+/* Reserved reset-cause bits on PIC32CM JH */
+#define RSTC_RESERVED_BIT_3     BIT(3)
+#define RSTC_RESERVED_BIT_7     BIT(7)
+#define RSTC_UNSUPPORTED_RCAUSE ((RSTC_RESERVED_BIT_3) | (RSTC_RESERVED_BIT_7))
+#else
+#define RSTC_UNSUPPORTED_RCAUSE 0U
+#endif /* CONFIG_SOC_FAMILY_MICROCHIP_PIC32CM_JH */
 
 #endif /* INCLUDE_ZEPHYR_DRIVERS_RESET_MCHP_RSTC_G1_H_ */


### PR DESCRIPTION
- Add the device tree node for microchip RSTC G1 IP.
- Update the reset driver to add support for the PIC32CM JH family
- Update pic32cm_jh01_cpro.yaml to include RESET in the supported modules list.