### PR TITLE
net: lwm2m: Don't allow bootstrap finish on registered client

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2371,9 +2371,12 @@ static int handle_request(struct coap_packet *request, struct lwm2m_message *msg
 	/* check for bootstrap-finish */
 	if ((code & COAP_REQUEST_MASK) == COAP_METHOD_POST && r == 1 &&
 	    strncmp(options[0].value, "bs", options[0].len) == 0) {
-		engine_bootstrap_finish();
-
-		msg->code = COAP_RESPONSE_CODE_CHANGED;
+		if (!lwm2m_rd_client_is_registred(ctx)) {
+			engine_bootstrap_finish();
+			msg->code = COAP_RESPONSE_CODE_CHANGED;
+		} else {
+			msg->code = COAP_RESPONSE_CODE_BAD_REQUEST;
+		}
 
 		r = lwm2m_init_message(msg);
 		if (r < 0) {


### PR DESCRIPTION
A bootstrap finish command sets a registered client into an undesired state. It is considered as invalid request and is reported to the server as such.