### PR TITLE
Add support Flash driver for Renesas RZ/T2L

### DIFF
--- a/boards/renesas/rzt2l_rsk/rzt2l_rsk-pinctrl.dtsi
+++ b/boards/renesas/rzt2l_rsk/rzt2l_rsk-pinctrl.dtsi
@@ -41,4 +41,15 @@
 				 <RZT_PINMUX(PORT_10, 0, 4)>; /* SDA */
 		};
 	};
+
+	/omit-if-no-ref/ xspi1_default: xspi1_default {
+		xspi1-pinmux {
+			pinmux = <RZT_PINMUX(PORT_17, 7, 7)>, /* XSPI0_CKP */
+				 <RZT_PINMUX(PORT_18, 2, 5)>, /* XSPI0_CS0 */
+				 <RZT_PINMUX(PORT_18, 0, 8)>, /* XSPI0_IO0 */
+				 <RZT_PINMUX(PORT_17, 0, 2)>, /* XSPI0_IO1 */
+				 <RZT_PINMUX(PORT_17, 3, 7)>, /* XSPI0_IO2 */
+				 <RZT_PINMUX(PORT_17, 4, 7)>; /* XSPI0_IO3 */
+		};
+	};
 };

--- a/boards/renesas/rzt2l_rsk/rzt2l_rsk.dts
+++ b/boards/renesas/rzt2l_rsk/rzt2l_rsk.dts
@@ -16,7 +16,7 @@
 
 	chosen {
 		zephyr,sram = &atcm;
-		zephyr,flash = &xspi1_cs0;
+		zephyr,flash = &at25sf128a;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
@@ -105,4 +105,18 @@
 
 &adc1 {
 	status = "okay";
+};
+
+&xspi1 {
+	pinctrl-0 = <&xspi1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	at25sf128a: qspi-nor-flash@68000000 {
+		compatible = "renesas,rz-qspi-xspi";
+		reg = <0x68000000 DT_SIZE_M(16)>; /* 128 Mbits */
+		write-block-size = <1>;
+		erase-block-size = <4096>;
+		status = "okay";
+	};
 };

--- a/drivers/flash/Kconfig.renesas_rz_qspi
+++ b/drivers/flash/Kconfig.renesas_rz_qspi
@@ -32,6 +32,6 @@ config FLASH_RENESAS_RZ_QSPI_SPIBSC
 config FLASH_RENESAS_RZ_MIRROR_OFFSET
 	hex
 	default 0x0 if SOC_SERIES_RZA3UL
-	default 0x20000000 if SOC_SERIES_RZT2M || SOC_SERIES_RZN2L
+	default 0x20000000 if SOC_SERIES_RZT2M || SOC_SERIES_RZN2L || SOC_SERIES_RZT2L
 	help
 	  Offset of mirror area in flash memory

--- a/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
+++ b/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
@@ -1372,6 +1372,7 @@
 		xspi0: xspi@80220000 {
 			compatible = "renesas,rz-xspi";
 			reg = <0x80220000 0x1000>;
+			unit = <0>;
 			interrupts = <GIC_SPI 339 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 340 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			#address-cells = <1>;
@@ -1382,6 +1383,7 @@
 		xspi1: xspi@80221000 {
 			compatible = "renesas,rz-xspi";
 			reg = <0x80221000 0x1000>;
+			unit = <1>;
 			interrupts = <GIC_SPI 341 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 342 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			#address-cells = <1>;

--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -1144,5 +1144,27 @@
 				status = "disabled";
 			};
 		};
+
+		xspi0: xspi@80220000 {
+			compatible = "renesas,rz-xspi";
+			reg = <0x80220000 0x1000>;
+			unit = <0>;
+			interrupts = <GIC_SPI 339 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 340 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "disabled";
+		};
+
+		xspi1: xspi@80221000 {
+			compatible = "renesas,rz-xspi";
+			reg = <0x80221000 0x1000>;
+			unit = <1>;
+			interrupts = <GIC_SPI 341 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 342 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
@@ -1396,6 +1396,7 @@
 		xspi0: xspi@80220000 {
 			compatible = "renesas,rz-xspi";
 			reg = <0x80220000 0x1000>;
+			unit = <0>;
 			interrupts = <GIC_SPI 339 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 340 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			#address-cells = <1>;
@@ -1406,6 +1407,7 @@
 		xspi1: xspi@80221000 {
 			compatible = "renesas,rz-xspi";
 			reg = <0x80221000 0x1000>;
+			unit = <1>;
 			interrupts = <GIC_SPI 341 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 342 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			#address-cells = <1>;

--- a/dts/bindings/qspi/renesas,rz-xspi.yaml
+++ b/dts/bindings/qspi/renesas,rz-xspi.yaml
@@ -13,6 +13,11 @@ properties:
   reg:
     required: true
 
+  unit:
+    type: int
+    required: true
+    description: XSPI unit number
+
   pinctrl-0:
     required: true
 

--- a/tests/drivers/flash/common/boards/rzt2l_rsk.conf
+++ b/tests/drivers/flash/common/boards/rzt2l_rsk.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_TEST_DRIVER_FLASH_SIZE=16777216

--- a/tests/drivers/flash/common/boards/rzt2l_rsk.overlay
+++ b/tests/drivers/flash/common/boards/rzt2l_rsk.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&at25sf128a {
+	status = "okay";
+};


### PR DESCRIPTION
Add support Flash driver for Renesas RZ/T2L:
- Update `drivers/flash/flash_renesas_rz_qspi.c` to use common source code for Renesas RZ devices
- Retrieve unit number and memory size from devicetree
- Add nodes to dts and dtsi of Renesas RZ/T2L
- Enable `common` flash test for RZ/T2L-RSK
- Enable `jesd216` and `spi_flash` samples for RZ/T2L-RSK