### PR TITLE
drivers: gnss: Add L5 Constellation Support to GNSS API

### DIFF
--- a/drivers/gnss/gnss_dump.c
+++ b/drivers/gnss/gnss_dump.c
@@ -73,6 +73,18 @@ static const char *gnss_system_to_str(enum gnss_system system)
 		return "SBAS";
 	case GNSS_SYSTEM_IMES:
 		return "IMES";
+	case GNSS_SYSTEM_GPS_L5:
+		return "GPS_L5";
+	case GNSS_SYSTEM_GALILEO_L5:
+		return "GALILEO_L5";
+	case GNSS_SYSTEM_QZSS_L5:
+		return "QZSS_L5";
+	case GNSS_SYSTEM_BEIDOU_B1C:
+		return "BEIDOU B1C";
+	case GNSS_SYSTEM_BEIDOU_B2A:
+		return "BEIDOU B2a";
+	case GNSS_SYSTEM_QZSS_L1S:
+		return "QZSS L1S";
 	}
 
 	return "unknown";

--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -73,13 +73,14 @@ static void align_satellite_with_gnss_system(enum gnss_system sv_system,
 {
 	switch (sv_system) {
 	case GNSS_SYSTEM_GPS:
+	case GNSS_SYSTEM_GPS_L5:
 		if (satellite->prn > GNSS_NMEA0183_GSV_PRN_GPS_RANGE) {
 			satellite->system = GNSS_SYSTEM_SBAS;
 			satellite->prn += GNSS_NMEA0183_GSV_PRN_SBAS_OFFSET;
 			break;
 		}
 
-		satellite->system = GNSS_SYSTEM_GPS;
+		satellite->system = sv_system;
 		break;
 
 	case GNSS_SYSTEM_GLONASS:
@@ -88,16 +89,21 @@ static void align_satellite_with_gnss_system(enum gnss_system sv_system,
 		break;
 
 	case GNSS_SYSTEM_GALILEO:
-		satellite->system = GNSS_SYSTEM_GALILEO;
+	case GNSS_SYSTEM_GALILEO_L5:
+		satellite->system = sv_system;
 		break;
 
 	case GNSS_SYSTEM_BEIDOU:
-		satellite->system = GNSS_SYSTEM_BEIDOU;
+	case GNSS_SYSTEM_BEIDOU_B1C:
+	case GNSS_SYSTEM_BEIDOU_B2A:
+		satellite->system = sv_system;
 		satellite->prn -= GNSS_NMEA0183_GSV_PRN_BEIDOU_OFFSET;
 		break;
 
 	case GNSS_SYSTEM_QZSS:
-		satellite->system = GNSS_SYSTEM_QZSS;
+	case GNSS_SYSTEM_QZSS_L5:
+	case GNSS_SYSTEM_QZSS_L1S:
+		satellite->system = sv_system;
 		break;
 
 	case GNSS_SYSTEM_IRNSS:

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -88,6 +88,18 @@ enum gnss_system {
 	GNSS_SYSTEM_SBAS = BIT(6),
 	/** Indoor Messaging System (IMES) */
 	GNSS_SYSTEM_IMES = BIT(7),
+	/** Global Positioning System (GPS) L5 */
+	GNSS_SYSTEM_GPS_L5 = BIT(8),
+	/** Galileo L5 */
+	GNSS_SYSTEM_GALILEO_L5 = BIT(9),
+	/** Quasi-Zenith Satellite System (QZSS) L5 */
+	GNSS_SYSTEM_QZSS_L5 = BIT(10),
+	/** BeiDou Navigation Satellite System B1C */
+	GNSS_SYSTEM_BEIDOU_B1C = BIT(11),
+	/** BeiDou Navigation Satellite System B2a */
+	GNSS_SYSTEM_BEIDOU_B2A = BIT(12),
+	/** Quasi-Zenith Satellite System (QZSS) L1S Augmentation service */
+	GNSS_SYSTEM_QZSS_L1S = BIT(13),
 };
 
 /** Type storing bitmask of GNSS systems */


### PR DESCRIPTION
We are adding a new GNSS driver for a dual band device and wish to be able to turn on/off L1/L5 for each constellation individually.

This change adds the L5 systems to the enum ```gnss_system system```

The driver that needs these changes is currently an out of tree driver available here: https://github.com/roedan/Roedan_SonyCXD56xx