### PR TITLE
manifest: update hal_nordic to get cache hal fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 248eadcacf976bbd27f1c0bc0dd3f11d8ec8657e
+      revision: a83db66acbeca0bfef157a0c3482c07ddbb82555
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update hal_nordic to get a fix in the definition of nrf_cache_data_unit_validity_check()

Fixes #100735
west pointer update for:
* https://github.com/zephyrproject-rtos/hal_nordic/pull/335