### PR TITLE
Improve use of target compile definitions

### DIFF
--- a/lib/posix/c_lang_support_r/CMakeLists.txt
+++ b/lib/posix/c_lang_support_r/CMakeLists.txt
@@ -4,5 +4,5 @@
 set(POSIX_VERSION 200809L)
 
 if(CONFIG_POSIX_C_LANG_SUPPORT_R)
-  zephyr_compile_definitions(-D_POSIX_THREAD_SAFE_FUNCTIONS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_THREAD_SAFE_FUNCTIONS=${POSIX_VERSION})
 endif()

--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(POSIX_VERSION 200809L)
 set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 
-zephyr_compile_definitions(-D_POSIX_C_SOURCE=${POSIX_VERSION})
+zephyr_compile_definitions(_POSIX_C_SOURCE=${POSIX_VERSION})
 
 zephyr_syscall_header_ifdef(CONFIG_POSIX_CLOCK_SELECTION posix_clock.h)
 zephyr_syscall_header_ifdef(CONFIG_POSIX_TIMERS posix_clock.h)
@@ -43,7 +43,7 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_CLOCK_SELECTION)
   zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK_SELECTION clock_selection.c)
 endif()
 if(CONFIG_POSIX_CLOCK_SELECTION)
-  zephyr_compile_definitions(-D_POSIX_CLOCK_SELECTION=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_CLOCK_SELECTION=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_POSIX_DEVICE_IO)
@@ -68,7 +68,7 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_FILE_SYSTEM_R)
   zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM_R file_system_r.c)
 endif()
 if(CONFIG_POSIX_FILE_SYSTEM_R)
-  zephyr_compile_definitions(-D_POSIX_THREAD_SAFE_FUNCTIONS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_THREAD_SAFE_FUNCTIONS=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_POSIX_MEMORY_PROTECTION)
@@ -86,7 +86,7 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_MULTI_PROCESS)
   )
 endif()
 if(CONFIG_POSIX_MULTI_PROCESS)
-  zephyr_compile_definitions(-D_POSIX_MULTI_PROCESS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_MULTI_PROCESS=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_POSIX_NETWORKING)
@@ -94,7 +94,7 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_NETWORKING)
 endif()
 
 if(CONFIG_POSIX_REALTIME_SIGNALS)
-  zephyr_compile_definitions(-D_POSIX_REALTIME_SIGNALS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_REALTIME_SIGNALS=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_POSIX_SIGNALS)
@@ -123,13 +123,13 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_TIMERS)
   )
 endif()
 if(CONFIG_POSIX_TIMERS)
-  zephyr_compile_definitions(-D_POSIX_TIMERS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_TIMERS=${POSIX_VERSION})
   # FIXME: Until we have a Kconfig for XSI_ADVANCED_REALTIME, define _POSIX_CPUTIME and
   # _POSIX_MONOTONIC_CLOCK with _POSIX_TIMERS.
   # For more information on the Advanced Realtime Option Group, please see
   # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap02.html
-  zephyr_compile_definitions(-D_POSIX_CPUTIME=${POSIX_VERSION})
-  zephyr_compile_definitions(-D_POSIX_MONOTONIC_CLOCK=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_CPUTIME=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_MONOTONIC_CLOCK=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_POSIX_RW_LOCKS)
@@ -153,7 +153,7 @@ if(NOT CONFIG_TC_PROVIDES_POSIX_THREADS)
   )
 endif()
 if(CONFIG_POSIX_THREADS)
-  zephyr_compile_definitions(-D_POSIX_THREADS=${POSIX_VERSION})
+  zephyr_compile_definitions(_POSIX_THREADS=${POSIX_VERSION})
 endif()
 
 if(NOT CONFIG_TC_PROVIDES_XSI_REALTIME)

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_options(boot_stage2 PRIVATE
 
 # The second stage bootloader is compiled without kconfig definitions.
 # Therefore, in order to use toolchain.h, it needs to define CONFIG_ARM.
-target_compile_definitions(boot_stage2 PRIVATE -DCONFIG_ARM=1)
+target_compile_definitions(boot_stage2 PRIVATE CONFIG_ARM=1)
 
 # Generates a binary file from the compiled bootloader
 add_custom_command(TARGET boot_stage2

--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -189,7 +189,7 @@ target_compile_definitions(ot-config INTERFACE ${OT_PARAM_LIST})
 # Since Mbed TLS 3.1.0 MBEDTLS_SSL_EXPORT_KEYS was removed as build symbol and
 # it's always assumed to be enabled. Corresponding kconfig was removed from
 # Zephyr as well, but OpenThread code still uses it, so we add it here.
-target_compile_definitions(ot-config INTERFACE -DMBEDTLS_SSL_EXPORT_KEYS)
+target_compile_definitions(ot-config INTERFACE MBEDTLS_SSL_EXPORT_KEYS)
 
 # Zephyr compiler options
 target_include_directories(ot-config INTERFACE

--- a/soc/ti/mspm0/CMakeLists.txt
+++ b/soc/ti/mspm0/CMakeLists.txt
@@ -6,5 +6,5 @@ add_subdirectory(common)
 
 if(CONFIG_SOC_FAMILY_TI_MSPM0)
   string(TOUPPER ${CONFIG_SOC} SDK_SOC_SELECT)
-  zephyr_compile_definitions(-D__${SDK_SOC_SELECT}__)
+  zephyr_compile_definitions(__${SDK_SOC_SELECT}__)
 endif()

--- a/soc/ti/simplelink/msp432p4xx/CMakeLists.txt
+++ b/soc/ti/simplelink/msp432p4xx/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_compile_definitions(-D__MSP432P401R__)
+zephyr_compile_definitions(__MSP432P401R__)
 zephyr_sources(soc.c)
 zephyr_include_directories(.)
 

--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -4,7 +4,7 @@ if(CONFIG_LLEXT)
   zephyr_library()
 
   # For strnlen()
-  zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)
+  zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
 
   zephyr_library_sources(
     llext.c


### PR DESCRIPTION
Any leading -D passed to target_compile_definitions on an item will be removed, here remove them to make code style consistent with other code.