### PR TITLE
Bluetooth: TBS: Fix issue with compare in set_uri_scheme_list

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -463,7 +463,17 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
  * @param uri_list      List of URI prefixes (e.g. {"skype", "tel"}).
  * @param uri_count     Number of URI prefixies in @p uri_list.
  *
- * @return BT_TBS_RESULT_CODE_* if positive or 0, errno value if negative.
+ * @retval 0 Success. If the URI scheme list is equal to the existing one for the bearer,
+ *           then no notifications to connected clients are sent.
+ * @retval -ENOMEM @kconfig{CONFIG_BT_TBS_MAX_SCHEME_LIST_LENGTH} not large enough for provided
+ *                 arguments.
+ * @retval -EBUSY Could not access the current bearer.
+ * @retval -EINVAL
+ *         - @p bearer_index does not identify a registered bearer.
+ *         - @p uri_list is NULL.
+ *         - @p uri_count is 0.
+ *         - @p uri_list contain duplicate values.
+ *         - @p uri_list contain empty values.
  */
 int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
 			       uint8_t uri_count);


### PR DESCRIPTION
The function only compared lenghts, and only considered additions (while the function is supposed to _set_ and not just _add_).

This meant that calling bt_tbs_set_uri_scheme_list with {"tel", "moz"} and then with {"tel", "mss"} would yield an unexpected result.

Additionally the function were slightly refactored to apply additional fixes, and was changed to use memcpy and direct assignments over strcat for performance reasons: strcat performs two O(n) scans followed by a copy and strcpy performs one O(n) scan followed by a copy. When we already know the size, memcpy is superior in terms of performance.