### PR TITLE
tests: net: lwm2m: interop: client: make lwm2m_setup void

### DIFF
--- a/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
+++ b/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
@@ -100,7 +100,7 @@ static int create_appdata(uint16_t obj_inst_id)
 	return 0;
 }
 
-static int lwm2m_setup(void)
+static void lwm2m_setup(void)
 {
 	/* setup DEVICE object */
 
@@ -131,8 +131,6 @@ static int lwm2m_setup(void)
 	lwm2m_set_res_buf(&LWM2M_OBJ(3, 0, 8, 1), &usb_ma, sizeof(usb_ma), sizeof(usb_ma), 0);
 
 	lwm2m_register_create_callback(19, create_appdata);
-
-	return 0;
 }
 
 static void rd_client_event(struct lwm2m_ctx *client,
@@ -236,13 +234,7 @@ static void observe_cb(enum lwm2m_observe_event event,
 
 int main(void)
 {
-	int ret;
-
-	ret = lwm2m_setup();
-	if (ret < 0) {
-		LOG_ERR("Cannot setup LWM2M fields (%d)", ret);
-		return 0;
-	}
+	lwm2m_setup();
 
 	client.tls_tag = 1;
 	client.set_socketoptions = set_socketoptions;


### PR DESCRIPTION
lwm2m_setup() never reports errors and always returns 0. The error check at the call site is therefore dead code.

Make the function void and drop the unused error handling.