### PR TITLE
hal_nxp: move multicore middleware to mcux-sdk-ng integration

### DIFF
--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -93,6 +93,11 @@ config NXP_IEEE802154_MAC
 	   If enabled, the NBU firmware used by the device will be use the 802.15.4
 	   MAC interface.
 
+config NXP_MULTICORE
+	bool "NXP Multicore Manager support"
+	help
+	  Includes NXP Multicore Manager support.
+
 endif # HAS_MCUX
 
 config BT_NXP_PCM_PINS_DIR_REVERSE

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
@@ -57,3 +57,4 @@ add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/usb
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/connectivity_framework.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/multicore.cmake)

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/multicore.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/multicore.cmake
@@ -1,0 +1,14 @@
+if(CONFIG_NXP_MULTICORE)
+    set(CONFIG_MCUX_COMPONENT_middleware.multicore.mcmgr ON)
+    set_variable_ifdef(CONFIG_SOC_MCXW716C      CONFIG_MCUX_COMPONENT_middleware.multicore.mcmgr.mcxw716)
+    set_variable_ifdef(CONFIG_SOC_MCXW727C_CPU0 CONFIG_MCUX_COMPONENT_middleware.multicore.mcmgr.mcxw727)
+
+    set(CONFIG_MCUX_COMPONENT_middleware.multicore.rpmsg-lite ON)
+    set(CONFIG_MCUX_COMPONENT_middleware.multicore.rpmsg-lite.zephyr ON)
+    set_variable_ifdef(CONFIG_SOC_MCXW716C      CONFIG_MCUX_COMPONENT_middleware.multicore.rpmsg-lite.mcxw71x)
+    set_variable_ifdef(CONFIG_SOC_MCXW727C_CPU0 CONFIG_MCUX_COMPONENT_middleware.multicore.rpmsg-lite.mcxw72x)
+
+    add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/mcuxsdk-middleware-multicore
+        ${CMAKE_CURRENT_BINARY_DIR}/mcuxsdk-middleware-multicore
+    )
+endif()

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
@@ -7,3 +7,11 @@ rsource "../../../common/Kconfig.nbu"
 config MCUX_CORE_SUFFIX
 	default "_cm33_core0" if SOC_MCXW727C_CPU0
 	default "_cm33_core1" if SOC_MCXW727C_CPU1
+
+config SOC_MCXW716C
+	bool
+	select NXP_MULTICORE if NXP_NBU
+
+config SOC_MCXW727C_CPU0
+	bool
+	select NXP_MULTICORE if NXP_NBU

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0a0c1680179b286997f0bfec4cb89ca90f2b8685
+      revision: 26ab97dc6e55e01a43db486ace71b57b6ee3ff06
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Move the multicore middleware to the new mcux-sdk-ng integration from hal_nxp, instead of using the legacy integration method. This will allow for easier integration of future releases.