### PR TITLE
Bluetooth: Host: Add bt_keys config flag

### DIFF
--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -47,6 +47,13 @@ enum {
 	BT_KEYS_OOB = BIT(5),
 };
 
+enum bt_keys_cfg_flags {
+	BT_KEYS_CFG_SIGNING = BIT(0),
+	BT_KEYS_CFG_SC_PAIR_ONLY = BIT(1),
+	BT_KEYS_CFG_OVERWRITE_OLDEST = BIT(2),
+	/* BIT(24) and higher: Invalid. See STORAGE_CFG_FLAGS. */
+};
+
 struct bt_ltk {
 	uint8_t rand[8];
 	uint8_t ediv[2];
@@ -74,6 +81,9 @@ struct bt_keys {
 	bt_addr_le_t addr;
 	uint8_t state;
 	uint8_t storage_start[0] __aligned(sizeof(void *));
+	/* cfg_version and cfg_flags total 4 octets to maintain struct alignment */
+	uint8_t cfg_version;
+	uint8_t cfg_flags[3];
 	uint8_t enc_size;
 	uint8_t flags;
 	uint16_t keys;


### PR DESCRIPTION
Adds a flag `config_flags` to the `bt_keys` struct in order to be able to detect configuration changes between firmware updates. This is needed because the `bt_keys` struct has fields which are compiled in depending on which Kconfig options are enabled, enabling the possibility of stored data being intepreted wrongly if the struct changes.