### PR TITLE
boards: st: stm32h573i_dk: add ST-LINK GDB server runner

### DIFF
--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -26,9 +26,13 @@ board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
 board_runner_args(openocd "--no-halt")
 
+board_runner_args(stlink_gdbserver "--apid=1")
+board_runner_args(stlink_gdbserver "--extload=MX25LM51245G_STM32H573I-DK.stldr")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
 # FIXME: official openocd runner not yet available.


### PR DESCRIPTION

Enable stlink_gdbserver runner with --apid=1
and --extload=MX25LM51245G_STM32H573I-DK.stldr

Matching STM32N6570-DK behavior.

Signed-off-by: Roy Jamil <roy.jamil@ac6.fr>