### PR TITLE
tests: bluetooth: btp_mesh: return error when blob target list is full

### DIFF
--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -4486,7 +4486,7 @@ static int cmd_blob_target(uint16_t addr)
 
 	if (blob_cli_xfer.target_count == ARRAY_SIZE(blob_cli_xfer.targets)) {
 		LOG_ERR("No more room");
-		return 0;
+		return -ENOMEM;
 	}
 
 	t = &blob_cli_xfer.targets[blob_cli_xfer.target_count];


### PR DESCRIPTION
cmd_blob_target() always returned 0 even when the target list was full, making error checks at call sites unreachable.

Return a proper error code when no more targets can be added so callers can correctly detect and handle the failure.