### PR TITLE
arch: arm64: Setup ICC_SRE_EL2

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -119,7 +119,7 @@ void z_arm64_el3_init(void)
 	reg |= (ICC_SRE_ELx_DFB_BIT |	/* Disable FIQ bypass */
 		ICC_SRE_ELx_DIB_BIT |	/* Disable IRQ bypass */
 		ICC_SRE_ELx_SRE_BIT |	/* System register interface is used */
-		ICC_SRE_EL3_EN_BIT);	/* Enables lower Exception level access to ICC_SRE_EL1 */
+		ICC_SRE_ELx_EN_BIT);	/* Enables lower Exception level access to ICC_SRE_EL1 */
 	write_sysreg(reg, ICC_SRE_EL3);
 #endif
 
@@ -161,6 +161,17 @@ void z_arm64_el2_init(void)
 		SCTLR_I_BIT |		/* Enable i-cache */
 		SCTLR_SA_BIT);		/* Enable SP alignment check */
 	write_sctlr_el2(reg);
+
+#if defined(CONFIG_GIC_V3)
+	if (!is_in_secure_state() || is_el2_sec_supported()) {
+		reg = read_sysreg(ICC_SRE_EL2);
+		reg |= (ICC_SRE_ELx_DFB_BIT |   /* Disable FIQ bypass */
+			ICC_SRE_ELx_DIB_BIT |   /* Disable IRQ bypass */
+			ICC_SRE_ELx_SRE_BIT |   /* System register interface is used */
+			ICC_SRE_ELx_EN_BIT);    /* Enables Exception access to ICC_SRE_EL1 */
+		write_sysreg(reg, ICC_SRE_EL2);
+	}
+#endif
 
 	reg = read_hcr_el2();
 	/* when EL2 is enable in current security status:

--- a/include/zephyr/arch/arm/cortex_a_r/cpu.h
+++ b/include/zephyr/arch/arm/cortex_a_r/cpu.h
@@ -89,7 +89,7 @@
 #define ICC_SRE_ELx_SRE_BIT	BIT(0)
 #define ICC_SRE_ELx_DFB_BIT	BIT(1)
 #define ICC_SRE_ELx_DIB_BIT	BIT(2)
-#define ICC_SRE_EL3_EN_BIT	BIT(3)
+#define ICC_SRE_ELx_EN_BIT	BIT(3) /**< ICC SRE Enable */
 
 /* MPIDR mask to extract Aff0, Aff1, and Aff2 */
 #define MPIDR_AFFLVL_MASK (0xffffff)

--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -204,7 +204,7 @@
 #define ICC_SRE_ELx_SRE_BIT	BIT(0)
 #define ICC_SRE_ELx_DFB_BIT	BIT(1)
 #define ICC_SRE_ELx_DIB_BIT	BIT(2)
-#define ICC_SRE_EL3_EN_BIT	BIT(3)
+#define ICC_SRE_ELx_EN_BIT	BIT(3) /**< ICC SRE Enable */
 
 /* ICC SGI macros */
 #define SGIR_TGT_MASK		(0xffff)


### PR DESCRIPTION
ICC_SRE_EL2 needs the same setup as ICC_SRE_EL3 for SPI IRQs to work.