### PR TITLE
boards: silabs: siwx917_dk2605a: fix LED polarity (active-low)

### DIFF
--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
@@ -39,17 +39,17 @@
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 			label = "LED0";
 		};
 
 		led1: led_1 {
-			gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiod 2 GPIO_ACTIVE_LOW>;
 			label = "LED1";
 		};
 
 		led2: led_2 {
-			gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
 			label = "LED2";
 		};
 	};


### PR DESCRIPTION
Fix incorrect LED polarity definitions for the siwx917_dk2605a board.

The user LEDs on the SiWx917 DK are wired as active-low according to the board schematic,
but the device tree currently defines them as GPIO_ACTIVE_HIGH.

This patch updates the LED gpio definitions to GPIO_ACTIVE_LOW so that:
- LED behavior matches the hardware
- gpio-leds semantics are correct
- sample applications (e.g. blinky) behave as expected without inversion

This was verified against the SiWx917 DK schematic.

Testing:
- Built and flashed on siwx917_dk2605a
- Verified LED behavior matches hardware (active-low)

Fixes #102135