### PR TITLE
drivers: gpio: max14906: Fix initialization

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -471,9 +471,9 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 				.OW_OFF_EN3 = DT_INST_PROP_BY_IDX(id, ow_en, 2),                   \
 				.OW_OFF_EN4 = DT_INST_PROP_BY_IDX(id, ow_en, 3),                   \
 				.GDRV_EN1 = DT_INST_PROP_BY_IDX(id, gdrv_en, 0),                   \
-				.GDRV_EN1 = DT_INST_PROP_BY_IDX(id, gdrv_en, 1),                   \
-				.GDRV_EN2 = DT_INST_PROP_BY_IDX(id, gdrv_en, 2),                   \
-				.GDRV_EN3 = DT_INST_PROP_BY_IDX(id, gdrv_en, 3),                   \
+				.GDRV_EN2 = DT_INST_PROP_BY_IDX(id, gdrv_en, 1),                   \
+				.GDRV_EN3 = DT_INST_PROP_BY_IDX(id, gdrv_en, 2),                   \
+				.GDRV_EN4 = DT_INST_PROP_BY_IDX(id, gdrv_en, 3),                   \
 			},                                                                         \
 		.chan_en.sht_vdd_en.reg_bits =                                                     \
 			{                                                                          \


### PR DESCRIPTION
Found when building with clang with -Winitializer-overrides:

drivers/gpio/gpio_max14906.c:495:29: error: initializer overrides prior
initialization of this subobject [-Werror,-Winitializer-overrides]
  495 | DT_INST_FOREACH_STATUS_OKAY(GPIO_MAX14906_DEVICE)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~