### PR TITLE
tracing: add external tracing module support

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -24,6 +24,8 @@
 #include "tracing_test.h"
 #elif defined CONFIG_TRACING_USER
 #include "tracing_user.h"
+#elif defined CONFIG_TRACING_EXTERNAL
+#include "tracing_external.h"
 #else
 /**
  * @brief Interfaces for the tracing subsystem.

--- a/modules/external-tracing/Kconfig
+++ b/modules/external-tracing/Kconfig
@@ -1,0 +1,10 @@
+# Zephyr module config for external tracing.
+# The real Kconfig for the module is located externally,
+# this file is to ensure ZEPHYR_EXTERNALTRACING_MODULE is defined also when the
+# module is unavailable.
+
+# Copyright (c) 2021 Jon Lamb <jon@auxon.io>
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_EXTERNAL_TRACING_MODULE
+	bool

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -63,6 +63,12 @@ config TRACING_USER
 	help
 	  Use user-defined functions for tracing task switching and irqs
 
+config TRACING_EXTERNAL
+	bool "External tracing support"
+	depends on ZEPHYR_EXTERNAL_TRACING_MODULE
+	help
+	  Enable external tracing module support.
+
 endchoice
 
 


### PR DESCRIPTION
Enhancement request:
zephyrproject-rtos/zephyr#37912

Code reference from
zephyrproject-rtos/zephyr#39552

Adds out of tree tracing backend support

Signed-off-by: Murali Iyengar <murali.r.iyengar@intel.com>