### PR TITLE
tests: drivers: gpio: gpio_basic_api: Updated pins for cy8cproto_063_ble

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_063_ble.overlay
@@ -8,8 +8,8 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&gpio_prt9 4 0>;
-		in-gpios = <&gpio_prt9 2 0>;
+		out-gpios = <&gpio_prt12 6 0>;
+		in-gpios = <&gpio_prt12 7 0>;
 	};
 };
 


### PR DESCRIPTION
Updated pins for the gpio basic tests for cy8cproto_063_ble to pins not used by other tests so that a single board can be wired for all tests without overlaps.