### PR TITLE
boards: vicharak: shrike_lite: Add full name to the board.yml

### DIFF
--- a/boards/vicharak/shrike_lite/board.yml
+++ b/boards/vicharak/shrike_lite/board.yml
@@ -1,5 +1,6 @@
 board:
   name: shrike_lite
+  full_name: Shrike-lite
   vendor: vicharak
   socs:
   - name: rp2040


### PR DESCRIPTION
Add the missing `full_name` field for the shrike_lite board added in 3f3b528997a815d84a13fbc4a0b686129fc38b91

It fixes #102218 