### PR TITLE
boards: shrike_lite: add missing full_name field

### DIFF
--- a/boards/vicharak/shrike_lite/board.yml
+++ b/boards/vicharak/shrike_lite/board.yml
@@ -1,5 +1,6 @@
 board:
   name: shrike_lite
+  full_name: Shrike-lite
   vendor: vicharak
   socs:
   - name: rp2040


### PR DESCRIPTION
Make sure board adds mandatory full_name field.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102218