### PR TITLE
net: ip: Fix warning when building with clang

### DIFF
--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -73,7 +73,7 @@ struct net_nbr *net_nbr_get(struct net_nbr_table *table)
 		struct net_nbr *nbr = get_nbr(table->nbr, i);
 
 		if (!nbr->ref) {
-			nbr->data = nbr->__nbr;
+			nbr->data = (uint8_t *)nbr + sizeof(struct net_nbr);
 
 			return net_nbr_ref(nbr);
 		}

--- a/subsys/net/ip/nbr.h
+++ b/subsys/net/ip/nbr.h
@@ -65,10 +65,6 @@ struct net_nbr {
 	/** Function to be called when the neighbor is removed. */
 	void (*const remove)(struct net_nbr *nbr);
 
-	/** Start of the data storage. Not to be accessed directly
-	 *  (the data pointer should be used instead).
-	 */
-	uint8_t __nbr[] __net_nbr_align;
 };
 
 /* This is an array of struct net_nbr + some additional data */

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -69,7 +69,8 @@ static inline struct net_nbr *get_nexthop_nbr(struct net_nbr *start, int idx)
 
 static void release_nexthop_route(struct net_route_nexthop *route_nexthop)
 {
-	struct net_nbr *nbr = CONTAINER_OF((uint8_t *)route_nexthop, struct net_nbr, __nbr[0]);
+	struct net_nbr *nbr = (struct net_nbr *)((uint8_t *)route_nexthop -
+						 sizeof(struct net_nbr));
 
 	net_nbr_unref(nbr);
 }
@@ -83,7 +84,7 @@ static struct net_nbr *get_nexthop_route(void)
 			(struct net_nbr *)net_route_nexthop_pool, i);
 
 		if (!nbr->ref) {
-			nbr->data = nbr->__nbr;
+			nbr->data = (uint8_t *)nbr + sizeof(struct net_nbr);
 
 			nbr->idx = NET_NBR_LLADDR_UNKNOWN;
 


### PR DESCRIPTION
When building the sample.net.capture test with clang and -Wgnu, it
warns:

subsys/net/ip/ipv6_nbr.c:91:1: error: field 'nbr' with variable sized
type 'struct net_nbr' not at the end of a struct or class is a GNU
extension [-Werror,-Wgnu-variable-sized-type-not-at-end]
   91 | NET_NBR_POOL_INIT(net_neighbor_pool,
      | ^
subsys/net/ip/nbr.h:77:18: note: expanded from macro 'NET_NBR_POOL_INIT'
   77 |                 struct net_nbr nbr;                                     \
      |                                ^
1 error generated.