### PR TITLE
dts: arm: st: h7: Add hash node

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -279,3 +279,7 @@ zephyr_udc0: &usbotg_fs {
 &cryp {
 	status = "okay";
 };
+
+&hash {
+	status = "okay";
+};

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -11,6 +11,15 @@
 	soc {
 		compatible = "st,stm32h750", "st,stm32h7", "simple-bus";
 
+		cryp: cryp@48021000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x48021000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
+
 		hash: hash@48021400 {
 			compatible = "st,stm32-hash";
 			reg = <0x48021400 0x400>;

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -10,5 +10,14 @@
 / {
 	soc {
 		compatible = "st,stm32h750", "st,stm32h7", "simple-bus";
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -19,5 +19,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h757.dtsi
+++ b/dts/arm/st/h7/stm32h757.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -23,5 +23,14 @@
 			interrupt-names = "cryp";
 			status = "disabled";
 		};
+
+		hash: hash@48021400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48021400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/tests/crypto/crypto_hash/testcase.yaml
+++ b/tests/crypto/crypto_hash/testcase.yaml
@@ -18,4 +18,5 @@ tests:
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
       - sama7g54_ek
+      - nucleo_h753zi
     tags: crypto


### PR DESCRIPTION
- Add hash node to several STM32H7 parts
- Enable hash node on nucleo_h753zi
- Enable nucleo_h753zi platform for crypto_hash unit tests.

crypto_hash test builds and passes for me locally on nucleo_h753zi.