### PR TITLE
net: dsa: include soc.h in the dsa_tag_netc driver

### DIFF
--- a/subsys/net/l2/ethernet/dsa/dsa_tag_netc.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_tag_netc.c
@@ -10,6 +10,8 @@ LOG_MODULE_REGISTER(net_dsa_tag_netc, CONFIG_NET_DSA_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dsa_core.h>
 #include <zephyr/net/dsa_tag_netc.h>
+
+#include "soc.h"
 #include "fsl_netc_tag.h"
 
 struct net_if *dsa_tag_netc_recv(struct net_if *iface, struct net_pkt *pkt)


### PR DESCRIPTION
The header file "fsl_netc_tag.h" depends on some SoC's feature definition in SoC's hal header file, so include soc.h to fix the building error for the following building:
west build -p -b imx943_evk/mimx94398/a55 samples/net/ethernet/dsa