### PR TITLE
drivers: sensor: lis2dux12: Allow routing of int1 to res pin

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_api.c
@@ -310,6 +310,9 @@ static int32_t st_lis2dux12_init_interrupt(const struct device *dev)
 	}
 
 	route.drdy = 1;
+	if (cfg->drdy_pin == 3) {
+		route.int_on_res = 1;
+	}
 
 	err = lis2dux12_pin_int1_route_set(ctx, &route);
 	if (err < 0) {

--- a/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
@@ -70,8 +70,9 @@ int lis2dux12_trigger_init(const struct device *dev)
 	const struct lis2dux12_config *cfg = dev->config;
 	int ret;
 
-	data->drdy_gpio = (cfg->drdy_pin == 1) ? (struct gpio_dt_spec *)&cfg->int1_gpio
-							 : (struct gpio_dt_spec *)&cfg->int2_gpio;
+	data->drdy_gpio = ((cfg->drdy_pin == 1) || (cfg->drdy_pin == 3))
+				  ? (struct gpio_dt_spec *)&cfg->int1_gpio
+				  : (struct gpio_dt_spec *)&cfg->int2_gpio;
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(data->drdy_gpio)) {

--- a/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
@@ -310,7 +310,9 @@ static int32_t st_lis2duxs12_init_interrupt(const struct device *dev)
 	}
 
 	route.drdy = 1;
-
+	if (cfg->drdy_pin == 3) {
+		route.int_on_res = 1;
+	}
 	err = lis2duxs12_pin_int1_route_set(ctx, &route);
 	if (err < 0) {
 		return err;

--- a/dts/bindings/sensor/st,lis2dux12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dux12-common.yaml
@@ -19,7 +19,7 @@ properties:
   int1-gpios:
     type: phandle-array
     description: |
-      INT1 pin
+      INT1 (or RES) pin
 
       This pin defaults to active high when produced by the sensor.
       The property value should ensure the flags properly describe
@@ -39,10 +39,11 @@ properties:
     enum:
       - 1 # drdy is generated from INT1
       - 2 # drdy is generated from INT2
+      - 3 # drdy is generated from INT1 via RES
     description: |
-      Select DRDY pin number (1 or 2).
-      This number represents which of the two interrupt pins
-      (INT1 or INT2) the drdy line is attached to. This property is not
+      Select DRDY pin number (1, 2 or 3).
+      This number represents which of the three interrupt pins
+      (INT1, INT2 or RES) the drdy line is attached to. This property is not
       mandatory and if not present it defaults to 1 which is the
       configuration at power-up.
 


### PR DESCRIPTION
The LIS2DUX12 and LIS2DUXS12 can optionally have int1 routed to the res pin.

This changes allows that configuration to be set.