### PR TITLE
manifest: fix DPP remain_on_channel wait timeout

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -291,7 +291,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 1a2fbb7910f23822a785294eab9f4922c6119711
+      revision: 7c5d886f4b1afd6d00192e346268f03f5f44354c
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
The remain_on_channel callback triggers cookie_event, which checks pending_remain_on_channel before giving drv_resp_sem. Previously, pending_remain_on_channel was set after calling
dev_ops->remain_on_channel, causing drv_resp_sem to timeout. Move the pending_remain_on_channel assignment before invoking dev_ops->remain_on_channel to ensure proper synchronization.