### PR TITLE
bluetooth: Classic: l2cap_br: fix pdu_len parameter type issue

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1100,7 +1100,7 @@ static int bt_l2cap_br_pack_s_frame_header(struct bt_l2cap_br_chan *br_chan, str
 }
 
 static void bt_l2cap_br_pack_i_frame_header(struct bt_l2cap_br_chan *br_chan, struct net_buf *buf,
-					    uint8_t pdu_len, uint8_t sar, uint8_t tx_seq)
+					    uint16_t pdu_len, uint8_t sar, uint8_t tx_seq)
 {
 	struct bt_l2cap_hdr *hdr;
 	uint16_t std_control;


### PR DESCRIPTION
Change the `pdu_len` parameter type from `uint8_t` to `uint16_t` in function `bt_l2cap_br_pack_i_frame_header()`.

This fixes a potential overflow issue as PDU length can exceed 255 bytes, which is the maximum value that can be stored in a uint8_t.