### PR TITLE
drivers: serial: cmsdk_apb: improve stability

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -289,6 +289,7 @@ static void uart_cmsdk_apb_irq_tx_enable(const struct device *dev)
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 	unsigned int key;
 
+	key = irq_lock();
 	dev_cfg->uart->ctrl |= UART_TX_IN_EN;
 	/* The expectation is that TX is a level interrupt, active for as
 	 * long as TX buffer is empty. But in CMSDK UART it's an edge
@@ -298,7 +299,6 @@ static void uart_cmsdk_apb_irq_tx_enable(const struct device *dev)
 	 * full state to allow a transition from full to empty buffer
 	 * that will trigger a TX interrupt.
 	 */
-	key = irq_lock();
 	if (!(dev_cfg->uart->state & UART_TX_BF)) {
 		uart_cmsdk_apb_isr(dev);
 	}
@@ -313,10 +313,13 @@ static void uart_cmsdk_apb_irq_tx_enable(const struct device *dev)
 static void uart_cmsdk_apb_irq_tx_disable(const struct device *dev)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+	unsigned int key;
 
+	key = irq_lock();
 	dev_cfg->uart->ctrl &= ~UART_TX_IN_EN;
 	/* Clear any pending TX interrupt after disabling it */
 	dev_cfg->uart->intclear = UART_TX_IN;
+	irq_unlock(key);
 }
 
 /**
@@ -344,9 +347,9 @@ static void uart_cmsdk_apb_irq_rx_enable(const struct device *dev)
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 	unsigned int key;
 
+	key = irq_lock();
 	dev_cfg->uart->ctrl |= UART_RX_IN_EN;
 	/* "Prime" the interrupt as described above */
-	key = irq_lock();
 	if (dev_cfg->uart->state & UART_RX_BF) {
 		uart_cmsdk_apb_isr(dev);
 	}
@@ -361,10 +364,13 @@ static void uart_cmsdk_apb_irq_rx_enable(const struct device *dev)
 static void uart_cmsdk_apb_irq_rx_disable(const struct device *dev)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
+	unsigned int key;
 
+	key = irq_lock();
 	dev_cfg->uart->ctrl &= ~UART_RX_IN_EN;
 	/* Clear any pending RX interrupt after disabling it */
 	dev_cfg->uart->intclear = UART_RX_IN;
+	irq_unlock(key);
 }
 
 /**

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -328,7 +328,8 @@ static int uart_cmsdk_apb_irq_tx_ready(const struct device *dev)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
-	return !(dev_cfg->uart->state & UART_TX_BF);
+	return !(dev_cfg->uart->state & UART_TX_BF) &&
+	       (dev_cfg->uart->ctrl & UART_TX_IN_EN);
 }
 
 /**
@@ -380,7 +381,8 @@ static int uart_cmsdk_apb_irq_rx_ready(const struct device *dev)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
-	return (dev_cfg->uart->state & UART_RX_BF) == UART_RX_BF;
+	return (dev_cfg->uart->state & UART_RX_BF) &&
+	       (dev_cfg->uart->ctrl & UART_RX_IN_EN);
 }
 
 /**


### PR DESCRIPTION
I tried using _cmsdk_apb_ together with the _zephyr,bt-hci-uart_ driver and found a few issues. See the commit messages for detailed comments.

_zephyr,bt-hci-uart_ is now stable on the _mps2_an521_cpu0_ board in QEMU.