### PR TITLE
tests: twister: only instantiate the Linux instance

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -27,9 +27,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-24.04, macos-14, windows-2022]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -54,7 +53,6 @@ jobs:
         west-project-filter: -nrf_hw_models,+cmsis,+hal_xtensa,+cmsis_6
 
     - name: Run Pytest For Twister Black Box Tests
-      if: ${{ runner.os == 'Linux' }}
       working-directory: zephyr
       shell: bash
       env:


### PR DESCRIPTION
This test has been changed in d7a8f29ce71 to drop all the steps that were running on the other platforms, change it to just instantiate the Linux instance and drop the conditional.
