### PR TITLE
tests: debug: coredump: use k_panic() for Espressif SoCs

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -43,6 +43,7 @@ __no_optimization void func_3(uint32_t *addr)
 	defined(CONFIG_BOARD_RISCV32_VIRTUAL) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ISH) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP) || \
+	defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32) || \
 	defined(CONFIG_SOC_FAMILY_OPENHWGROUP_CVA6)
 	/* clang-format on */
 	ARG_UNUSED(addr);


### PR DESCRIPTION
Espressif RISC-V chips (ESP32-C3, ESP32-C6, etc.) with PMP enabled use dynamic PMP mode (CONFIG_PMP_NO_LOCK_GLOBAL). In this mode, null pointer dereference to address 0 causes a bus hang instead of generating a clean exception, since address 0 is outside any valid memory region and there's no PMP entry protecting it.

Use k_panic() instead, which reliably triggers the coredump path on all Espressif chips.