### PR TITLE
drivers: ethernet: remove redunant tx mutex

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -80,7 +80,6 @@ int nxp_s32_eth_initialize_common(const struct device *dev)
 		}
 	}
 
-	k_mutex_init(&ctx->tx_mutex);
 	k_sem_init(&ctx->rx_sem, 0, 1);
 
 	k_thread_create(&ctx->rx_thread, ctx->rx_thread_stack,
@@ -122,7 +121,7 @@ void nxp_s32_eth_mcast_filter(const struct device *dev, const struct ethernet_fi
 
 int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
-	struct nxp_s32_eth_data *ctx = dev->data;
+	__maybe_unused struct nxp_s32_eth_data *ctx = dev->data;
 	const struct nxp_s32_eth_config *cfg = dev->config;
 	size_t pkt_len = net_pkt_get_len(pkt);
 	int res = 0;
@@ -130,8 +129,6 @@ int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	Netc_Eth_Ip_BufferType buf;
 
 	__ASSERT(pkt, "Packet pointer is NULL");
-
-	k_mutex_lock(&ctx->tx_mutex, K_FOREVER);
 
 	buf.length = (uint16_t)pkt_len;
 	buf.data = NULL;
@@ -163,8 +160,6 @@ int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 error:
-	k_mutex_unlock(&ctx->tx_mutex);
-
 	if (res != 0) {
 		eth_stats_update_errors_tx(ctx->iface);
 	}

--- a/drivers/ethernet/eth_nxp_s32_netc_priv.h
+++ b/drivers/ethernet/eth_nxp_s32_netc_priv.h
@@ -121,7 +121,6 @@ struct nxp_s32_eth_config {
 struct nxp_s32_eth_data {
 	struct net_if *iface;
 	uint8_t mac_addr[6];
-	struct k_mutex tx_mutex;
 	struct k_sem rx_sem;
 	struct k_thread rx_thread;
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -124,7 +124,6 @@ struct eth_stm32_hal_dev_data {
 	struct net_if *iface;
 	uint8_t mac_addr[6];
 	ETH_HandleTypeDef heth;
-	struct k_mutex tx_mutex;
 	struct k_sem rx_int_sem;
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)
 	struct k_sem tx_int_sem;

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -169,8 +169,6 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		return -EIO;
 	}
 
-	k_mutex_lock(&dev_data->tx_mutex, K_FOREVER);
-
 	while (ctx == NULL) {
 		ctx = allocate_tx_context_async(pkt);
 		if (ctx == NULL) {
@@ -232,8 +230,6 @@ error:
 		HAL_ETH_TxFreeCallback((uint32_t *)ctx);
 	}
 
-	k_mutex_unlock(&dev_data->tx_mutex);
-
 	return res;
 }
 #else
@@ -276,8 +272,6 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		LOG_ERR("PKT too big");
 		return -EIO;
 	}
-
-	k_mutex_lock(&dev_data->tx_mutex, K_FOREVER);
 
 	ctx = allocate_tx_context(pkt);
 	buf_header = &dma_tx_buffer_header[ctx->first_tx_buffer_index];
@@ -389,8 +383,6 @@ error:
 		/* We need to release the tx context and its buffers */
 		HAL_ETH_TxFreeCallback(STM32_ETH_ARGS(heth, (uint32_t *)ctx));
 	}
-
-	k_mutex_unlock(&dev_data->tx_mutex);
 
 	return res;
 }
@@ -635,7 +627,6 @@ int eth_stm32_hal_init(const struct device *dev)
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	/* Initialize semaphores */
-	k_mutex_init(&dev_data->tx_mutex);
 	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
 	k_sem_init(&dev_data->tx_int_sem, 0, 1);
 

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -120,7 +120,6 @@ struct netc_eth_data {
 	struct net_if *iface;
 	uint8_t mac_addr[6];
 	/* TX */
-	struct k_mutex tx_mutex;
 	uint8_t *tx_buff;
 	volatile bool tx_done;
 	/* RX */


### PR DESCRIPTION
remove redunant tx mutex, as the networking
subsystem already provides one since
61c392c5b13fbc448ca0e4c047848c72c3096a07 https://github.com/zephyrproject-rtos/zephyr/pull/65049