### PR TITLE
doc: add caption to developer documentation toctree

### DIFF
--- a/doc/develop/index.rst
+++ b/doc/develop/index.rst
@@ -5,7 +5,7 @@ Developing with Zephyr
 
 .. toctree::
    :maxdepth: 1
-
+   :caption: Developer Guides
    getting_started/index.rst
    beyond-GSG.rst
    env_vars.rst


### PR DESCRIPTION
 While reviewing the developer documentation structure, I noticed that the doc/develop/index.rst toctree groups several developer-facing sections but does not include a caption describing the group.

This small change adds a :caption: to the existing toctree to improve readability and navigation in the rendered documentation, particularly for new contributors.

No filenames, paths, or content are modified. The change is purely presentational and has no functional or behavioral impact.

Happy to adjust the caption wording if there is an established convention here.