### PR TITLE
drivers: i2s: fix userspace syscall validation for stream unconfigure

### DIFF
--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -23,6 +23,13 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&config, (const void *)cfg_ptr,
 				sizeof(struct i2s_config)));
 
+	/* When frame_clk_freq is 0, the stream is being disabled/unconfigured
+	 * and other config fields are not used, so skip validation.
+	 */
+	if (config.frame_clk_freq == 0U) {
+		goto do_configure;
+	}
+
 	/* Check that the k_mem_slab provided is a valid pointer and that
 	 * the caller has permission on it
 	 */
@@ -37,6 +44,7 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 		goto out;
 	}
 
+do_configure:
 	ret = z_impl_i2s_configure((const struct device *)dev, dir, &config);
 out:
 	return ret;

--- a/tests/drivers/i2s/i2s_api/src/common.c
+++ b/tests/drivers/i2s/i2s_api/src/common.c
@@ -175,7 +175,7 @@ int rx_block_read(const struct device *dev_i2s, int att)
 int configure_stream(const struct device *dev_i2s, enum i2s_dir dir)
 {
 	int ret;
-	struct i2s_config i2s_cfg;
+	struct i2s_config i2s_cfg = {0};
 
 	i2s_cfg.word_size = 16U;
 	i2s_cfg.channels = 2U;

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
@@ -18,7 +18,7 @@
  */
 ZTEST_USER(i2s_states, test_i2s_state_not_ready_neg)
 {
-	struct i2s_config i2s_cfg;
+	struct i2s_config i2s_cfg = {0};
 	size_t rx_size;
 	int ret;
 	char rx_buf[BLOCK_SIZE];

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -129,7 +129,7 @@ static int verify_buf(int16_t *rx_block, int att)
 static int configure_stream(const struct device *dev_i2s, enum i2s_dir dir, uint32_t frame_clk_freq)
 {
 	int ret;
-	struct i2s_config i2s_cfg;
+	struct i2s_config i2s_cfg = {0};
 
 	i2s_cfg.word_size = 16U;
 	i2s_cfg.channels = 2U;


### PR DESCRIPTION
This PR fixes the I2S API test failure on platforms with userspace
support.

When unconfiguring a stream by setting frame_clk_freq to 0, the
syscall handler was validating mem_slab and block_size fields even
though these are not used. This caused failures when these fields
contained uninitialized values.

API reference:
https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/i2s.h#L345