### PR TITLE
kernel: Increase default system workqueue stack size for net shell

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -608,6 +608,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 	int "System workqueue stack size"
 	default 4096 if COVERAGE_GCOV || WIFI_NRF70
 	default 2560 if WIFI_NM_WPA_SUPPLICANT
+	default 1536 if NET_SHELL
 	default 1024
 
 config SYSTEM_WORKQUEUE_PRIORITY


### PR DESCRIPTION
Net shell utilizes system workqueue for scheduling ping requests and the default 1k stack size is not enough in case of loopback packets. Instead of trying to patch individual samples, just increase the default system workqueue stack size if network shell is enabled to fix the issue globally.