### PR TITLE
bluetooth: services: cts: Add local time information characteristic

### DIFF
--- a/include/zephyr/bluetooth/services/cts.h
+++ b/include/zephyr/bluetooth/services/cts.h
@@ -22,6 +22,57 @@ extern "C" {
 #endif
 
 /**
+ * @brief ATT error code for ignored values during CTS write operations
+ */
+#define BT_CTS_ATT_ERR_VALUES_IGNORED 0x80U
+
+/**
+ * @brief Maximum value for the 1/256-second fractions field in CTS time format
+ */
+#define BT_CTS_FRACTION_256_MAX_VALUE 255U
+
+/**
+ * @brief Default timezone offset value indicating the timezone is unknown (15-minute increments)
+ */
+#define BT_CTS_TIMEZONE_DEFAULT_VALUE -128
+
+/**
+ * @brief Timezone offset increment in minutes
+ */
+#define BT_CTS_TIMEZONE_INCREMENT_MIN 15U
+
+/**
+ * @brief DST offset increment in minutes
+ */
+#define BT_CTS_DST_INCREMENT_MIN 15U
+
+/**
+ * @brief Minimum valid timezone offset in 15-minute increments (-48 means UTC-12:00)
+ */
+#define BT_CTS_TIMEZONE_MIN -48
+
+/**
+ * @brief Maximum valid timezone offset in 15-minute increments (56 means UTC+14:00)
+ */
+#define BT_CTS_TIMEZONE_MAX 56
+
+/**
+ * @brief Daylight Saving Time (DST) offsets as defined in the specification
+ */
+enum bt_cts_dst_offset {
+	/** Standard Time */
+	BT_CTS_DST_OFFSET_STANDARD_TIME = 0,
+	/** Half an hour daylight saving time */
+	BT_CTS_DST_OFFSET_HALF_HOUR_DAYLIGHT_TIME = 2,
+	/** One hour daylight saving time */
+	BT_CTS_DST_OFFSET_DAYLIGHT_TIME = 4,
+	/** Two hour daylight saving time */
+	BT_CTS_DST_OFFSET_DOUBLE_DAYLIGHT_TIME = 8,
+	/** Offset unknown */
+	BT_CTS_DST_OFFSET_UNKNOWN = 255,
+};
+
+/**
  * @brief CTS time update reason bits as defined in the specification
  */
 enum bt_cts_update_reason {
@@ -53,88 +104,134 @@ struct bt_cts_time_format {
 	uint8_t reason;
 } __packed;
 
+/**
+ * @brief CTS Local Time Information
+ */
+struct bt_cts_local_time {
+	/**
+	 * @brief Represents the offset from UTC in number in 15-minute increments.
+	 *
+	 * Valid range from -48 (@ref BT_CTS_TIMEZONE_MIN) to +56 (@ref BT_CTS_TIMEZONE_MAX).
+	 * A value of -128 (@ref BT_CTS_TIMEZONE_DEFAULT_VALUE) means that the timezone offset
+	 * is not known. All other values are Reserved for Future Use.
+	 * The offset defined in this characteristic is constant regardless of whether
+	 * daylight savings is in effect.
+	 */
+	int8_t timezone_offset;
+	/**
+	 * @brief Represents the daylight saving time offset in 15-minute increments.
+	 */
+	enum bt_cts_dst_offset dst_offset;
+};
+
 /** @brief Current Time Service callback structure */
 struct bt_cts_cb {
-	/** @brief Current Time Service notifications changed
+	/**
+	 * @brief Current Time Service notifications changed
 	 *
 	 * @param enabled True if notifications are enabled, false if disabled
 	 */
 	void (*notification_changed)(bool enabled);
 
 	/**
-	 * @brief The Current Time has been updated by a peer.
+	 * @brief The Current Time has been requested to update by a peer.
+	 *
 	 * It is the responsibility of the application to store the new time.
 	 *
-	 * @param cts_time [IN] updated time
+	 * @param[in] cts_time Requested time to write
 	 *
-	 * @return 0 application has decoded it successfully
-	 * @return negative error codes on failure
-	 *
+	 * @return 0 if written successfully, negative error code on failure
 	 */
 	int (*cts_time_write)(struct bt_cts_time_format *cts_time);
 
 	/**
-	 * @brief When current time Read request or notification is triggered, CTS uses
-	 * this callback to retrieve current time information from application. Application
-	 * must implement it and provide cts formatted current time information
+	 * @brief Callback to get current time.
 	 *
-	 * @note this callback is mandatory
+	 * When current time Read request or notification is triggered, CTS uses
+	 * this callback to retrieve current time information from application.
+	 * Application must implement it and provide cts formatted current time
+	 * information
 	 *
-	 * @param cts_time [IN] updated time
+	 * @param[out] cts_time Current time for the application to be filled
 	 *
-	 * @return 0 application has encoded it successfully
-	 * @return negative error codes on failure
+	 * @return 0 if filled successfully, negative error code on failure
 	 */
 	int (*fill_current_cts_time)(struct bt_cts_time_format *cts_time);
+
+	/**
+	 * @brief The Local Time Information has been requested to update by a peer.
+	 *
+	 * It is the responsibility of the application to store the new Local time.
+	 *
+	 * @param[in] local_time Requested local time to write
+	 *
+	 * @return 0 if written successfully, negative error code on failure
+	 *
+	 */
+	int (*cts_local_time_write)(const struct bt_cts_local_time *cts_local_time);
+
+	/**
+	 * @brief Request to get current local time
+	 *
+	 * CTS uses this callback to retrieve local time information from application.
+	 * Application must implement it and provide cts local time information
+	 *
+	 * @param[out] local_time Current local time struct to be filled
+	 *
+	 * @return 0 if filled successfully, negative error code on failure
+	 */
+	int (*fill_current_cts_local_time)(struct bt_cts_local_time *local_time);
 };
 
 /**
  * @brief This API should be called at application init.
- * it is safe to call this API before or after bt_enable API
+ *
+ * It is safe to call this API before or after bt_enable API
  *
  * @param cb pointer to required callback
  *
- * @return 0 on success
- * @return negative error codes on failure
+ * @return 0 on success, negative error code on failure
  */
 int bt_cts_init(const struct bt_cts_cb *cb);
 
 /**
- * @brief Notify all connected clients that have enabled the
- * current time update notification
+ * @brief Notify all connected clients with CTS enabled
  *
  * @param reason update reason to be sent to the clients
  *
- * @return 0 on success
- * @return negative error codes on failure
+ * @return 0 on success, negative error code on failure
  */
 int bt_cts_send_notification(enum bt_cts_update_reason reason);
 
 /**
- * @brief Helper API to decode CTS formatted time into milliseconds since epoch
+ * @brief Convert CTS formatted time to milliseconds since epoch
  *
- * @note @kconfig{CONFIG_BT_CTS_HELPER_API} needs to be enabled to use this API.
+ * @param[in] ct_time CTS formatted time
+ * @param[out] unix_ms pointer to store parsed millisecond since epoch
  *
- * @param ct_time [IN]  cts time formatted time
- * @param unix_ms [OUT] pointer to store parsed millisecond since epoch
- *
- * @return 0 on success
- * @return negative error codes on failure
+ * @return 0 on success, negative error code on failure
  */
 int bt_cts_time_to_unix_ms(const struct bt_cts_time_format *ct_time, int64_t *unix_ms);
 
 /**
- * @brief Helper API to encode milliseconds since epoch to CTS formatted time
+ * @brief Convert milliseconds since epoch to CTS formatted time
  *
- * @note @kconfig{CONFIG_BT_CTS_HELPER_API} needs to be enabled to use this API.
+ * @param[out] ct_time Pointer to store CTS formatted time
+ * @param[in] unix_ms  milliseconds since epoch to be converted
  *
- * @param ct_time [OUT] Pointer to store CTS formatted time
- * @param unix_ms [IN]  milliseconds since epoch to be converted
- *
- * @return 0 on success
- * @return negative error codes on failure
+ * @return 0 on success, negative error code on failure
  */
 int bt_cts_time_from_unix_ms(struct bt_cts_time_format *ct_time, int64_t unix_ms);
+
+/**
+ * @brief Convert CTS local time to milliseconds
+ *
+ * @param[in] local_time Pointer to local time information containing timezone and DST offset
+ * @param[out] relative_ms Pointer to variable containing the result value in milliseconds
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int bt_cts_local_time_to_ms(const struct bt_cts_local_time *local_time, int32_t *relative_ms);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

This PR adds the Local Time Information characteristic to the Current Time Service (CTS). It also updates the `peripheral` example in order to implement this characteristic for other users to test this out.

# Testing/Example

Compile and flash the peripheral example:
```
cd samples/bluetooth/peripheral && west build -b <your_board> -p always && west flash
```

use your bluetooth app (in this case the nrf connect app was used and a [bug](https://github.com/NordicSemiconductor/Android-nRF-Connect/issues/244) was flagged) and play with the Local Time Information service.

