### PR TITLE
boards: nxp: mimxrt1064_evk: Fix PWM polarity for user LED

### DIFF
--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -85,7 +85,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&flexpwm2_pwm3 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&flexpwm2_pwm3 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 


### PR DESCRIPTION
The user LED is active low, or when using the PWM, polarity inverted.