### PR TITLE
net: core: Queue loopback packets instead of processing directly

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -365,6 +365,8 @@ static inline bool process_multicast(struct net_pkt *pkt)
 }
 #endif
 
+static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt);
+
 int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 {
 	struct net_if *iface;
@@ -413,7 +415,7 @@ int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 		NET_DBG("Loopback pkt %p back to us", pkt);
 		net_pkt_set_loopback(pkt, true);
 		net_pkt_set_l2_processed(pkt, true);
-		processing_data(pkt);
+		net_queue_rx(net_pkt_iface(pkt), pkt);
 		ret = 0;
 		goto err;
 	}


### PR DESCRIPTION
Instead of processing loopback packets from the TX thread directly, queue them for further processing by RX thread (if possible), just as regular packets. It's now possible as the information regarding the packet is a loopback one or not is stored directly in the net_pkt structure.

This allows to avoid unexpected stack consumption increases if packets are sent for loopback destinations.