### PR TITLE
scripts: dts: gen_dts_cmake.py: Prevent trailing semicolon for lists

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -902,7 +902,6 @@ exclude = [
     "./scripts/check_maintainers.py",
     "./scripts/ci/upload_test_results_es.py",
     "./scripts/dts/gen_defines.py",
-    "./scripts/dts/gen_dts_cmake.py",
     "./scripts/dts/gen_edt.py",
     "./scripts/dts/python-devicetree/src/devicetree/_private.py",
     "./scripts/dts/python-devicetree/src/devicetree/dtlib.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -147,9 +147,6 @@
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
     "UP045",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional
 ]
-"./scripts/dts/gen_dts_cmake.py" = [
-    "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
-]
 "./scripts/dts/python-devicetree/src/devicetree/_private.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -158,7 +158,7 @@ def main():
 
             cmake_props.append(f'"DT_UNIT_ADDR|{node.path}" "{cmake_unit_addr_int}"')
 
-    for comp in compatible2paths.keys():
+    for comp in compatible2paths:
         cmake_path = ';'.join(compatible2paths[comp])
 
         cmake_comp = f'DT_COMP|{comp}'

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -44,14 +44,13 @@ import pickle
 import sys
 from collections import defaultdict
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
-                                'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree', 'src'))
 
 ESCAPE_TABLE = str.maketrans(
     {
         "\n": "\\n",
         "\r": "\\r",
-        '\"': '\\"',
+        '"': '\\"',
         "\\": "\\\\",
     }
 )
@@ -68,10 +67,10 @@ def parse_args():
     # Returns parsed command-line arguments
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--cmake-out", required=True,
-                        help="path to write the CMake property file")
-    parser.add_argument("--edt-pickle", required=True,
-                        help="path to read the pickled edtlib.EDT object from")
+    parser.add_argument("--cmake-out", required=True, help="path to write the CMake property file")
+    parser.add_argument(
+        "--edt-pickle", required=True, help="path to read the pickled edtlib.EDT object from"
+    )
 
     return parser.parse_args()
 
@@ -180,8 +179,7 @@ def main():
         cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')
 
     cmake_props = map(
-        'set_target_properties(${{DEVICETREE_TARGET}} PROPERTIES {})'.format,
-        cmake_props
+        'set_target_properties(${{DEVICETREE_TARGET}} PROPERTIES {})'.format, cmake_props
     )
     with open(args.cmake_out, "w", encoding="utf-8") as cmake_file:
         print("\n".join(cmake_props), file=cmake_file)

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -123,9 +123,7 @@ def main():
                 if "phandle" not in node.props[item].type:
                     if "array" in node.props[item].type:
                         # Convert array to CMake list
-                        cmake_value = ''
-                        for val in node.props[item].val:
-                            cmake_value = f'{cmake_value}{val};'
+                        cmake_value = ';'.join(str(val) for val in node.props[item].val)
                     else:
                         cmake_value = node.props[item].val
 
@@ -135,9 +133,8 @@ def main():
                     cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
         elif node.compats:
             # Manually output compatibles for nodes that have no properties
-            cmake_value = ''
-            for val in node.compats:
-                cmake_value = f'{cmake_value}{val};'
+            cmake_value = ';'.join(node.compats)
+
             cmake_prop = f'DT_PROP|{node.path}|compatible'
             cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
 
@@ -146,19 +143,13 @@ def main():
 
         if node.regs is not None:
             cmake_props.append(f'"DT_REG|{node.path}|NUM" "{len(node.regs)}"')
-            cmake_addr = ''
-            cmake_size = ''
 
-            for reg in node.regs:
-                if reg.addr is None:
-                    cmake_addr = f'{cmake_addr}NONE;'
-                else:
-                    cmake_addr = f'{cmake_addr}{hex(reg.addr)};'
-
-                if reg.size is None:
-                    cmake_size = f'{cmake_size}NONE;'
-                else:
-                    cmake_size = f'{cmake_size}{hex(reg.size)};'
+            cmake_addr = ';'.join(
+                'NONE' if reg.addr is None else hex(reg.addr) for reg in node.regs
+            )
+            cmake_size = ';'.join(
+                'NONE' if reg.size is None else hex(reg.size) for reg in node.regs
+            )
 
             cmake_props.append(f'"DT_REG|{node.path}|ADDR" "{cmake_addr}"')
             cmake_props.append(f'"DT_REG|{node.path}|SIZE" "{cmake_size}"')
@@ -168,12 +159,7 @@ def main():
             cmake_props.append(f'"DT_UNIT_ADDR|{node.path}" "{cmake_unit_addr_int}"')
 
     for comp in compatible2paths.keys():
-        cmake_path = ''
-        for path in compatible2paths[comp]:
-            cmake_path = f'{cmake_path}{path};'
-
-        # Remove the last ';'
-        cmake_path = cmake_path[:-1]
+        cmake_path = ';'.join(compatible2paths[comp])
 
         cmake_comp = f'DT_COMP|{comp}'
         cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')


### PR DESCRIPTION
The generated lists have a trailing semicolon, which for CMake would indicate a trailing empty item.