### PR TITLE
display: ltdc: ensure to properly flush data into memory and enabled cached access to memory

### DIFF
--- a/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
+++ b/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
@@ -17,11 +17,6 @@
 	};
 };
 
-&sdram1 {
-	/* Frame buffer memory cache will cause screen flickering. */
-	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
-};
-
 &zephyr_lcd_controller {
 	status = "okay";
 	ext-sdram = <&sdram1>;

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sdram1 {
-	/* Frame buffer memory when cached causes screen flickering. */
-	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
-};
-
 &zephyr_lcd_controller {
 	ext-sdram = <&sdram1>;
 	def-back-color-red = <0>;

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sdram2 {
-	/* Frame buffer memory when cached causes screen flickering. */
-	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
-};
-
 &zephyr_lcd_controller {
 	status = "okay";
 	ext-sdram = <&sdram2>;

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h757i_eval_stm32h757xx_m7.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h757i_eval_stm32h757xx_m7.overlay
@@ -5,11 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&sdram2 {
-	/* Frame buffer memory when cached causes screen flickering. */
-	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
-};
-
 &zephyr_lcd_controller {
 	status = "okay";
 	ext-sdram = <&sdram2>;

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -54,8 +54,7 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM2";
-		/* Frame buffer memory cache will cause screen flickering. */
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	octo_nor: memory@90000000 {

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -228,6 +228,9 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 	    (desc->width == config->width) &&
 	    (desc->height == config->height) &&
 	    (desc->pitch == desc->width)) {
+		sys_cache_data_flush_range((void *)buf, config->height * config->width *
+					   data->current_pixel_size);
+
 		stm32_ltdc_sync_frame(data, buf);
 		return 0;
 	}
@@ -253,6 +256,9 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 		memcpy(dst, data->front_buf, data->frame_buffer_len);
 
 		stm32_ltdc_partial_write(dev, x, y, desc, dst, buf);
+
+		sys_cache_data_flush_range(dst, config->height * config->width *
+						data->current_pixel_size);
 
 		stm32_ltdc_sync_frame(data, dst);
 	} else {


### PR DESCRIPTION
While the partial write via display_write was properly taking care of flushing the cache into the memory, this was missing in case of full frame swap. In same situation, such as when the frame has been generated by a DMA or another IP, the data might be already correct into memory since not going through the cache, however we cannot guarantee this with the current display API.
Hence, always ensure to flush the cache related to this memory to be sure that the LTDC will be able to properly read the proper data.

That done, it is not possible to avoid forcing the framebuffer with NOCACHE attribute, allowing to increase performances.