### PR TITLE
doc: _extensions: show boards as maintained/not actively maintained in docs

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -299,9 +299,23 @@ class ConvertBoardNode(SphinxTransform):
             field_list = nodes.field_list()
             sidebar += field_list
 
+            if node.get("maintained", False):
+                status_text = nodes.abbreviation(
+                    "Maintained",
+                    "Maintained",
+                    explanation="At least one active maintainer is looking after this board",
+                )
+            else:
+                status_text = nodes.abbreviation(
+                    "Not actively maintained",
+                    "Not actively maintained",
+                    explanation="No active maintainer on file, but contributions are welcome",
+                )
+
             details = [
                 ("Name", nodes.literal(text=node["id"])),
                 ("Vendor", node["vendor"]),
+                ("Status", status_text),
                 ("Architecture", ", ".join(node["archs"])),
                 ("SoC", ", ".join(node["socs"])),
             ]
@@ -744,6 +758,7 @@ class BoardDirective(SphinxDirective):
             board_node["supported_runners"] = board["supported_runners"]
             board_node["flash_runner"] = board["flash_runner"]
             board_node["debug_runner"] = board["debug_runner"]
+            board_node["maintained"] = board.get("maintained", False)
             return [board_node]
 
 

--- a/doc/_extensions/zephyr/domain/templates/board-card.html
+++ b/doc/_extensions/zephyr/domain/templates/board-card.html
@@ -37,6 +37,7 @@
     {%- endfor -%}
     {{- all_compatibles|join(' ') -}}
   "
+  data-maintained="{{ board.maintained | tojson }}"
   tabindex="0">
   <div class="vendor">{{ vendors[board.vendor] }}</div>
   {% if board.image -%}


### PR DESCRIPTION
This uses the MAINTAINERS file to determine if a board is maintained or not, stores the information in the catalog and shows this in the "wikipedia sidebar" of the board documentation (adding search/filtering based on this is a future enhancement opportunity, I guess).

Special attention to the wording has been given to not convey "unmaintained means it won't work" impression

https://builds.zephyrproject.io/zephyr/pr/102275/docs/boards/mikroe/clicker_ra4m1/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/102275/docs/boards/nxp/frdm_k64f/doc/index.html