### PR TITLE
twister: pytest: restore live logging with --log-cli-level=INFO

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -415,6 +415,12 @@ class Pytest(Harness):
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
 
+        # Always pass output from the pytest test and the test image up to Twister log.
+        command.extend([
+            '--log-cli-level=INFO',
+            '--log-cli-format=%(levelname)s: %(message)s'
+        ])
+
         # Use the test timeout as the base timeout for pytest
         base_timeout = handler.get_test_timeout()
         command.append(f'--base-timeout={base_timeout}')


### PR DESCRIPTION
Commit 96985a32e862 ("twister: pytest: fix duplicate log lines from pytest") removed --log-cli-level=DEBUG to eliminate duplicate log output, but this broke recording data for power management tests.
This mechanism was parsing stdout via _output_reader() for patterns like "INFO: RECORD: {...}". Without --log-cli-level, pytest live logging is disabled, so lines never appear in stdout and cant be parsed, which lead to missing data in twister.json.

Restore live logging with --log-cli-level=INFO instead of DEBUG:
- Enables pytest live log output for stdout parsing
- DEBUG logs remain hidden - avoiding the duplicate issue
- --log-level=DEBUG still captures all logs for pytest reports
- -s option preserved for tests using print() statements