### PR TITLE
doc: update Enabling Rust Support guide with west.yml and clang

### DIFF
--- a/doc/develop/languages/rust/index.rst
+++ b/doc/develop/languages/rust/index.rst
@@ -32,11 +32,22 @@ In order to enable Rust support in a Zephyr application, a few things need to be
     This should cause the Rust language support to be placed in :samp:`modules/lang/rust` in your
     Zephyr workspace.
 
+    If your west project uses its own yaml file (e.g. when using the Zephyr Example Application:
+    https://github.com/zephyrproject-rtos/example-application) you may have to edit the
+    :file:`west.yml` file for your west workspace to add the zephyr-lang-rust module:
+
+    .. code-block:: yaml
+
+        - name: zephyr-lang-rust
+          revision: main
+          path: modules/lang/rust
+          remote: zephyrproject-rtos
+
 2.  Enable Rust support, via :kconfig:option:`CONFIG_RUST` in the :file:`prj.conf`. The easiest way
     to do this (as well as the CMake setup from the next step) is to start with one of the samples
     in :module_file:`modules/lang/rust/samples <zephyr-lang-rust:samples>`.
 
-3.  Configure the application's :file:`CMakeLists.txt` file to support Rust.  Again this is easiest
+3.  Configure the application's :file:`CMakeLists.txt` file to support Rust. Again this is easiest
     to copy from a sample, but this will look something like:
 
     .. code-block:: cmake
@@ -71,7 +82,39 @@ In order to enable Rust support in a Zephyr application, a few things need to be
     The only required dependency is ``zephyr`` which provides the zephyr crate that is used to
     interface with Zephyr.
 
-5.  Build as you would any other Zephyr application.  Only a few targets currently support Rust
+5.  Make sure llvm/clang is installed too. It is part of the SDK from version 1.0.
+    You can also install it with:
+
+    .. tabs::
+
+       .. group-tab:: Ubuntu
+
+          #. Use ``apt`` to install llvm/clang:
+
+          .. code-block:: bash
+
+             sudo apt install clang
+
+       .. group-tab:: macOS
+
+          #. Use ``brew`` to install llvm/clang:
+
+          .. code-block:: bash
+
+             brew install llvm
+             export LIBCLANG_PATH=/opt/homebrew/Cellar/llvm@18/18.1.8/lib/libclang.dylib
+             export CLANG_PATH=/opt/homebrew/Cellar/llvm@18/18.1.8//bin/clang
+
+       .. group-tab:: Windows
+
+          #. Use ``winget`` to install llvm/clang:
+
+          .. code-block:: bat
+
+             winget install -e --id LLVM.LLVM
+
+
+6.  Build as you would any other Zephyr application.  Only a few targets currently support Rust
     (these can be seen in the
     :module_file:`modules/lang/rust/etc/platforms.txt <zephyr-lang-rust:etc/platforms.txt>` file).
 


### PR DESCRIPTION
Adding the optional Rust module may require manuel editing of west.yml depending on your west workspace..
Clang is another requirement which wasn't documented.