### PR TITLE
tracing: add external tracing module support

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -24,6 +24,8 @@
 #include "tracing_test.h"
 #elif defined CONFIG_TRACING_USER
 #include "tracing_user.h"
+#elif defined CONFIG_TRACING_CUSTOM
+#include "zephyr_custom_tracing.h"
 #else
 /**
  * @brief Interfaces for the tracing subsystem.

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -63,6 +63,15 @@ config TRACING_USER
 	help
 	  Use user-defined functions for tracing task switching and irqs
 
+config TRACING_CUSTOM
+	bool "Include custom tracing header [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  When enabled, a custom application provided header, named
+	  "zephyr_custom_tracing.h", is included at the end of tracing.h. This enables
+	  extension of the sys_port_trace* APIs at the macro level. Please use cautiously!
+	  The internal TRACE APIs may change in future releases.
+
 endchoice
 
 


### PR DESCRIPTION
Enhancement request:
zephyrproject-rtos/zephyr#37912

Code reference from
zephyrproject-rtos/zephyr#39552

Adds out of tree tracing backend support

Signed-off-by: Murali Iyengar <murali.r.iyengar@intel.com>