### PR TITLE
ci: doc-build: download only the arm toolchain

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -111,7 +111,7 @@ jobs:
       uses: zephyrproject-rtos/action-zephyr-setup@b2453c72966ee67b1433be22b250348d48283286 # v1.0.7
       with:
         app-path: zephyr
-        toolchains: 'all'
+        toolchains: 'arm-zephyr-eabi'
 
     - name: install-pip
       working-directory: zephyr


### PR DESCRIPTION
Sync up the doc-build toolchain in the branch to only use the arm one, should save some disk space on backport PRs.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102307