### PR TITLE
MAINTAINERS: Add Space Cubics Platforms entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4904,6 +4904,17 @@ Silabs SiM3U Platforms:
   description: >-
     SiM3U SoCs, dts files, and related drivers. Boards based on SiM3U SoCs.
 
+Space Cubics Platforms:
+  status: maintained
+  maintainers:
+    - yashi
+  files:
+    - boards/sc/
+  labels:
+    - "platform: Space Cubics"
+  description: >-
+    Space Cubics on-board computers (OBCs).
+
 State machine framework:
   status: maintained
   maintainers:


### PR DESCRIPTION
Register Space Cubics on-board computer platforms in MAINTAINERS.yml.

Mark the area as maintained, set yashi as maintainer, and scope it to boards/sc/. Add a short description for the platform group.

Related to #102275.