### PR TITLE
soc: xlnx: versal: Select VFPv3-D16

### DIFF
--- a/soc/xlnx/versal/Kconfig
+++ b/soc/xlnx/versal/Kconfig
@@ -9,4 +9,5 @@ config SOC_VERSAL_RPU
 	select CPU_CORTEX_R5
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_DCLS
+	select VFP_DP_D16
 	select SOC_RESET_HOOK


### PR DESCRIPTION
The Versal RPU uses Arm Cortex-R5F cores, which implement VFPv3-D16 (single and double precision with 16 double-word registers):.

Select VFP_DP_D16 to describe the available VFP configuration for this SoC.