### PR TITLE
pmci: mctp: mctp_i3c_controller: remove dead code in controller start

### DIFF
--- a/subsys/pmci/mctp/mctp_i3c_controller.c
+++ b/subsys/pmci/mctp/mctp_i3c_controller.c
@@ -128,14 +128,10 @@ int mctp_i3c_controller_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt
 
 int mctp_i3c_controller_start(struct mctp_binding *binding)
 {
-	int rc = 0;
+	int rc;
 
 	struct mctp_binding_i3c_controller *b =
 		CONTAINER_OF(binding, struct mctp_binding_i3c_controller, binding);
-
-	if (rc != 0) {
-		LOG_WRN("Could not do dynamic address assignment");
-	}
 
 	for (int i = 0; i < b->num_endpoints; i++) {
 		mctp_i3c_endpoint_bind(b->devices[i], b, &b->endpoint_i3c_devs[i]);


### PR DESCRIPTION
mctp_i3c_controller_start() contains a conditional check on a return code that is never updated, making the error handling path unreachable.

Remove the dead code to avoid misleading logic and make the current controller startup behavior explicit.