### PR TITLE
safety_test: subsystem

### DIFF
--- a/include/zephyr/safety_test/safety_test.h
+++ b/include/zephyr/safety_test/safety_test.h
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) 2026 Aerlync Labs Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Safety Test subsystem API
+ *
+ * This subsystem provides a framework for hardware and software self-testing at boot time and
+ * runtime. Tests can be registered at different initialization levels and optionally executed
+ * from userspace. Provides macros for integrating third-party self-test libraries with the Zephyr
+ * safety test framework
+ */
+
+#ifndef ZEPHYR_INCLUDE_SAFETY_TEST_H_
+#define ZEPHYR_INCLUDE_SAFETY_TEST_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup safety_test_api Safety Test
+ * @ingroup os_services
+ * @{
+ */
+
+/**
+ * @brief Safety test result codes
+ */
+enum safety_test_result {
+	/** Test passed successfully */
+	SAFETY_TEST_RESULT_PASS = 0,
+	/** Test failed - fault detected */
+	SAFETY_TEST_RESULT_FAIL = 1,
+	/** Test skipped (precondition not met) */
+	SAFETY_TEST_RESULT_SKIP = 2,
+	/** Test has not been executed yet */
+	SAFETY_TEST_RESULT_NOT_RUN = 0xFF,
+};
+
+/**
+ * @brief Safety test categories
+ */
+enum safety_test_category {
+	/** CPU register and instruction tests */
+	SAFETY_TEST_CAT_CPU = BIT(0),
+	/** RAM integrity tests */
+	SAFETY_TEST_CAT_RAM = BIT(1),
+	/** Flash/ROM integrity tests */
+	SAFETY_TEST_CAT_FLASH = BIT(2),
+	/** Clock and timing tests */
+	SAFETY_TEST_CAT_CLOCK = BIT(3),
+	/** Stack integrity tests */
+	SAFETY_TEST_CAT_STACK = BIT(4),
+	/** Watchdog tests */
+	SAFETY_TEST_CAT_WATCHDOG = BIT(5),
+	/** GPIO tests */
+	SAFETY_TEST_CAT_GPIO = BIT(6),
+	/** Communication peripheral tests */
+	SAFETY_TEST_CAT_COMM = BIT(7),
+	/** ADC tests */
+	SAFETY_TEST_CAT_ADC = BIT(8),
+	/** Max Category */
+	SAFETY_TEST_CAT_MAX = 9,
+};
+
+/**
+ * @brief Safety test flags
+ */
+enum safety_test_flags {
+	/** Test to run at boot time */
+	SAFETY_TEST_FLAG_BOOT_OK = BIT(0),
+	/** Test is safe to run at runtime */
+	SAFETY_TEST_FLAG_RUNTIME_OK = BIT(1),
+	/** Test may affect system state */
+	SAFETY_TEST_FLAG_DESTRUCTIVE = BIT(2),
+	/** Test can be called from userspace */
+	SAFETY_TEST_FLAG_USERSPACE_OK = BIT(3),
+	/** Failure of this test should halt boot */
+	SAFETY_TEST_FLAG_CRITICAL = BIT(4),
+	/** Test only runs on-demand, never automatically at boot */
+	SAFETY_TEST_FLAG_ON_DEMAND_ONLY = BIT(5),
+};
+
+/**
+ * @brief Safety test initialization levels (matches Zephyr init levels)
+ *
+ * @note Safety tests execute **after** their corresponding SYS_INIT level completes.
+ *
+ * This ensures tests run when the system is in the expected state for that init level.
+ */
+enum safety_test_init_level {
+	/** SAFETY_TEST_LEVEL_EARLY: After all SYS_INIT_LEVEL(0, ...) callbacks */
+	SAFETY_TEST_LEVEL_EARLY = 0,
+	/** SAFETY_TEST_LEVEL_PRE_KERNEL_1: After all SYS_INIT_LEVEL(1, ...) callbacks */
+	SAFETY_TEST_LEVEL_PRE_KERNEL_1 = 1,
+	/** SAFETY_TEST_LEVEL_PRE_KERNEL_2: After all SYS_INIT_LEVEL(2, ...) callbacks */
+	SAFETY_TEST_LEVEL_PRE_KERNEL_2 = 2,
+	/** SAFETY_TEST_LEVEL_POST_KERNEL: After all SYS_INIT_LEVEL(3, ...) callbacks */
+	SAFETY_TEST_LEVEL_POST_KERNEL = 3,
+	/** SAFETY_TEST_LEVEL_APPLICATION: After all SYS_INIT_LEVEL(4, ...) callbacks */
+	SAFETY_TEST_LEVEL_APPLICATION = 4,
+};
+
+/* Forward declaration */
+struct safety_test;
+
+/**
+ * @brief Safety test execution context
+ *
+ * Provides information to the test function about its execution environment.
+ * Test functions can set error_code before returing to provide additional failure information.
+ */
+struct safety_test_context {
+	/** Current initialization level */
+	enum safety_test_init_level init_level;
+	/** Unique test identifier */
+	uint32_t test_id;
+	/** Optional user data */
+	void *user_data;
+	/** Test-specific error code (set by test function) */
+	int error_code;
+};
+
+/**
+ * @brief Safety test function signature
+ *
+ * Test functions receive a non-const context pointer so they can set error_code before returning.
+ *
+ * @param ctx Execution context (non-const to allow setting error fields)
+ * @return Test result
+ */
+typedef enum safety_test_result (*safety_test_fn)(struct safety_test_context *ctx);
+
+/**
+ * @brief Safety test descriptor
+ *
+ * Describes a single safety test including metadata and the test function.
+ */
+struct safety_test {
+	/** Readable test name */
+	const char *name;
+	/** Detailed description */
+	const char *description;
+	/** Unique test ID (for traceability) */
+	uint32_t id;
+	/** Test category (SAFETY_TEST_CAT_*) */
+	enum safety_test_category category;
+	/** Earliest init level this test can run */
+	enum safety_test_init_level init_level;
+	/** Execution priority within level (0 = highest) */
+	uint8_t priority;
+	/** Test flags (SAFETY_TEST_FLAG_*) */
+	enum safety_test_flags flags;
+	/** Test function */
+	safety_test_fn test_fn;
+	/** Test timeout in microseconds (0 = no timeout) */
+	uint32_t timeout_us;
+};
+
+/**
+ * @brief Safety test result record
+ *
+ * Stores the result of a test execution.
+ */
+struct safety_test_result_record {
+	/** Test ID */
+	uint32_t test_id;
+	/** Test result */
+	enum safety_test_result result;
+	/** Detailed error code (test-specific) */
+	int error_code;
+	/** Execution time in microseconds */
+	uint64_t duration_us;
+};
+
+/**
+ * @brief Safety test category summary statistics
+ *
+ * Statistics for a single category.
+ */
+struct safety_test_category_summary {
+	/** Total number of tests in this category */
+	uint32_t total;
+	/** Number of passed tests */
+	uint32_t passed;
+	/** Number of failed tests */
+	uint32_t failed;
+	/** Number of skipped tests */
+	uint32_t skipped;
+};
+
+/**
+ * @brief Safety test summary statistics
+ *
+ * Contains global statistics and per-category breakdown.
+ */
+struct safety_test_summary {
+	/** Global statistics */
+	struct safety_test_category_summary global;
+
+	/** Per-category statistics (indexed by category bit position) */
+	struct safety_test_category_summary categories[16];
+};
+
+/**
+ * @brief Safety test failure callback signature
+ *
+ * Called whenever any test fails (critical or non-critical).
+ */
+typedef void (*safety_test_failure_cb)(const struct safety_test *test,
+				       const struct safety_test_result_record *result,
+				       void *user_data);
+
+/**
+ * @brief Safe state transition callback signature
+ *
+ * Called when a critical test fails, before system halt.
+ * Allows application to define its safe state transition:
+ * - Disable peripherals
+ * - Set GPIOs to safe states
+ * - Log to non-volatile storage
+ * - Notify external systems
+ *
+ * @param test The failed test
+ * @param result Test result with error details
+ * @param user_data Application-specific data
+ */
+typedef void (*safety_test_safe_state_cb_t)(const struct safety_test *test,
+					    const struct safety_test_result_record *result,
+					    void *user_data);
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Internal macro to generate test entry name */
+#define Z_SAFETY_TEST_NAME(name) _CONCAT(__safety_test_, name)
+
+/** @endcond */
+
+/**
+ * @brief Define a safety test
+ *
+ * Registers a test function to be executed at the specified init level. Tests are
+ * automatically collected into an iterable section. Test IDs are automatically assigned at
+ * link time (0, 1, 2, ...) based on the test's position in the sorted array.
+ *
+ * @param _name Unique C identifier for the test
+ * @param _cat  Test category (SAFETY_TEST_CAT_*)
+ * @param _level Earliest init level (SAFETY_TEST_LEVEL_*)
+ * @param _prio Priority within level (0-255, lower = earlier)
+ * @param _flags Test flags (SAFETY_TEST_FLAG_*)
+ * @param _fn Test function (safety_test_fn)
+ * @param _desc Human-readable description string
+ */
+#define SAFETY_TEST_DEFINE(_name, _cat, _level, _prio, _flags, _fn, _desc)                         \
+	static const STRUCT_SECTION_ITERABLE(safety_test, Z_SAFETY_TEST_NAME(_name)) = {           \
+		.name = STRINGIFY(_name), .description = _desc,                                    \
+				  .id = 0, /* This gets computed at runtime */                     \
+				  .category = _cat, .init_level = _level, .priority = _prio,       \
+				  .flags = _flags, .test_fn = _fn, .timeout_us = 0,                \
+	}
+
+/**
+ * @brief Define a safety test with timeout
+ *
+ * Same as SAFETY_TEST_DEFINE but with a timeout value.
+ * Test IDs are automatically assigned sequentially at link time (0, 1, 2, ...).
+ */
+#define SAFETY_TEST_DEFINE_TIMEOUT(_name, _cat, _level, _prio, _flags, _fn, _desc, _timeout_us)    \
+	static const STRUCT_SECTION_ITERABLE(safety_test, Z_SAFETY_TEST(_name)) = {                \
+		.name = STRINGIFY(_name), .description = _desc, .id = 0, .category = _cat,         \
+				  .init_level = _level, .priority = _prio, .flags = _flags,        \
+				  .test_fn = _fn, .timeout_us = _timeout_us,                       \
+	}
+
+/**
+ * @brief CPU test (convenience macro)
+ */
+#define SAFETY_TEST_CPU(_name, _level, _fn)                                                        \
+	SAFETY_TEST_DEFINE(_name, SAFETY_TEST_CAT_CPU, _level, 0,                                  \
+			   SAFETY_TEST_FLAG_BOOT_OK | SAFETY_TEST_FLAG_RUNTIME_OK |                \
+				   SAFETY_TEST_FLAG_CRITICAL,                                      \
+			   _fn, "CPU test: " STRINGIFY(_name))
+
+/**
+ * @brief RAM test (convenience macro)
+ */
+#define SAFETY_TEST_RAM(_name, _level, _fn)                                                        \
+	SAFETY_TEST_DEFINE(_name, SAFETY_TEST_CAT_RAM, _level, 10,                                 \
+			   SAFETY_TEST_FLAG_BOOT_OK | SAFETY_TEST_FLAG_DESTRUCTIVE |               \
+				   SAFETY_TEST_FLAG_CRITICAL,                                      \
+			   _fn, "Stack test: " STRINGIFY(_name))
+
+/**
+ * @brief FLASH test (convenience macro)
+ */
+#define SAFETY_TEST_FLASH(_name, _level, _fn)                                                      \
+	SAFETY_TEST_DEFINE(_name, SAFETY_TEST_CAT_FLASH, _level, 30,                               \
+			   SAFETY_TEST_FLAG_BOOT_OK | SAFETY_TEST_FLAG_RUNTIME_OK |                \
+				   SAFETY_TEST_FLAG_USERSPACE_OK,                                  \
+			   _fn, "Flash test: " STRINGIFY(_name))
+
+/**
+ * @brief Wrap a test function for safety test registration
+ *
+ * This macro wraps a function that returns 0 on success and non-zero on failure,
+ * converting it to the safety test result format.
+ * Test IDs are automatically assigned sequentially at link time (0, 1, 2, ...).
+ *
+ * @param _name Unique C identifier for the test
+ * @param _cat Test category (SAFETY_TEST_CAT_*)
+ * @param _level Earliest init level (SAFETY_TEST_LEVEL_*)
+ * @param _safety_test_fn Test function (must return 0=pass, negative=fail)
+ * @param _desc Readable description
+ */
+#define SAFETY_TEST_WRAP(_name, _cat, _level, _safety_test_fn, _desc)                              \
+	static enum safety_test_result _name##_wrapper(struct safety_test_context *ctx)            \
+	{                                                                                          \
+		int test_result = (_safety_test_fn)();                                             \
+		if (test_result < 0 && ctx != NULL) {                                              \
+			ctx->error_code = test_result;                                             \
+		}                                                                                  \
+		return (test_result == 0) ? SAFETY_TEST_RESULT_PASS : SAFETY_TEST_RESULT_FAIL;     \
+	}                                                                                          \
+	SAFETY_TEST_DEFINE(_name, _cat, _level, 50,                                                \
+			   SAFETY_TEST_FLAG_BOOT_OK | SAFETY_TEST_FLAG_RUNTIME_OK,                 \
+			   _name##_wrapper, _desc)
+
+/**
+ * @brief Wrap a test with custom flags
+ *
+ * Test IDs are automatically assigned sequentially at link time (0, 1, 2, ...).
+ *
+ * @param _name Unique C identifier for the test
+ * @param _cat Test category (SAFETY_TEST_CAT_*)
+ * @param _level Earliest init level (SAFETY_TEST_LEVEL_*)
+ * @param _flags Additional flags
+ * @param _safety_test_fn Test function (must return 0=pass, negative=fail)
+ * @param _desc Human-readable description
+ */
+#define SAFETY_TEST_WRAP_FLAGS(_name, _cat, _level, _flags, _safety_test_fn, _desc)                \
+	static enum safety_test_result _name##_wrapper(struct safety_test_context *ctx)            \
+	{                                                                                          \
+		int test_result = (_safety_test_fn)();                                             \
+		if (test_result < 0 && ctx != NULL) {                                              \
+			ctx->error_code = test_result;                                             \
+		}                                                                                  \
+		return (test_result == 0) ? SAFETY_TEST_RESULT_PASS : SAFETY_TEST_RESULT_FAIL;     \
+	}                                                                                          \
+	SAFETY_TEST_DEFINE(_name, _cat, _level, 50, _flags, _name##_wrapper, _desc)
+
+/**
+ * @brief Wrap a test with init and cleanup callbacks
+ *
+ * For tests that require hardware init before running and cleanup afterward. Test IDs are
+ * automatically assigned sequentially at link time (0, 1, 2, ...).
+ *
+ * @param _name Unique C identifier for the test
+ * @param _cat test category (SAFETY_TEST_CAT_*)
+ * @param _level Earliest init level (SAFETY_TEST_LEVEL_*)
+ * @param _flags Additional flags
+ * @param _init_fn Init function(Called before test)
+ * @param _safety_test_fn Test function (0=pass, negative=fail)
+ * @param _cleanup_fn Cleanup function (called after test)
+ * @param _desc Readable description
+ */
+#define SAFETY_TEST_WRAP_EX(_name, _cat, _level, _flags, _init_fn, _safety_test_fn, _cleanup_fn,   \
+			    _desc)                                                                 \
+	static enum safety_test_result _name##_wrapper(struct safety_test_context *ctx)            \
+	{                                                                                          \
+		enum safety_test_result result;                                                    \
+		if ((_init_fn) != NULL) {                                                          \
+			(_init_fn)();                                                              \
+		}                                                                                  \
+		int test_result = (_safety_test_fn)();                                             \
+		if (test_result < 0 && ctx != NULL) {                                              \
+			ctx->error_code = test_result;                                             \
+		}                                                                                  \
+		result = (test_result == 0) ? SAFETY_TEST_RESULT_PASS : SAFETY_TEST_RESULT_FAIL;   \
+		if ((_cleanup_fn) != NULL) {                                                       \
+			(_cleanup_fn)();                                                           \
+		}                                                                                  \
+		return result;                                                                     \
+	}                                                                                          \
+	SAFETY_TEST_DEFINE(_name, _cat, _level, 50, _flags, _name##_wrapper, _desc)
+
+/*
+ * Kernel API
+ */
+
+/**
+ * @brief Run all safety tests for a given init level
+ *
+ * This is called automatically during boot. Tests are executed in priority order within
+ * the level.
+ *
+ * @param level Initialization to run
+ * @return Number of failed tests
+ */
+int safety_test_result safety_test_run_level(enum safety_test_init_level level);
+
+/**
+ * @brief Run a specific test by ID
+ *
+ * @param test_id Test ID to execute
+ * @return Number of failed tests
+ */
+enum safety_test_result safety_test_run_test(uint32_t test_id);
+
+/**
+ * @brief Run all tests in a category
+ *
+ * @param category test category bitmask (SAFETY_TEST_CAT_*)
+ * @return Number of failed tests
+ */
+int safety_test_run_category(uint32_t category);
+
+/**
+ * @brief Get test result record
+ *
+ * @param test_id test ID to query
+ * @param record Pointer to result record to fill
+ * @return 0 on success, -ENOENT if not found, -EINVAL if record is NULL
+ */
+int safety_test_get_result(uint32_t test_id, struct safety_test_result_record *record);
+
+/**
+ * @brief get summary of all safety test results
+ *
+ * Populates the summary structure with global statistics and per-category breakdown.
+ *
+ * @param summary Pointer to summary structure to populate
+ * @return 0 on success, negative errno on error
+ */
+int safety_test_get_summary(struct safety_test_summary *summary);
+
+/**
+ * @brief get summary for specific category
+ *
+ * Populates the summary structure with statistics for the specified category only.
+ * The global statistics will reflect only tests in the specified category.
+ *
+ * @param category Category bitmask (SAFETY_TEST_CAT_*)
+ * @param summary Pointer to summary structure to populate
+ * @return 0 on success, negative error on error
+ */
+int safety_test_get_category_summary(uint32_t category, struct safety_test_summary *summary);
+
+/**
+ * @brief Register a failure callback
+ *
+ * The callback is invoked whenever a test fails (critical or non-critical).
+ *
+ * @param cb Callback function
+ * @param user_data User data passed to callback
+ * @return 0 on success, negative errno on error
+ */
+int safety_test_register_failure_hook(safety_test_failure_cb cb, void *user_data);
+
+/**
+ * @brief Register safe state callback
+ *
+ * This callback is invoked when a critical test fails, before system halt.
+ * This allows the application to transition to a defined safe state.
+ *
+ * @param cb Callback function
+ * @param user_data User data passed to callback
+ * @return 0 on success, negative errno on error
+ */
+int safety_test_register_safe_state_cb(safety_test_safe_state_cb cb, void *user_data);
+
+/**
+ * @brief Mark a category as safety-critical
+ *
+ * If any test in a critical category fails, the system will halt.
+ *
+ * @param category Category bitmask (SAFETY_TEST_CAT_*)
+ * @param critical true to mark as critical, false to clear.
+ */
+void safety_test_category_critical(uint32_t category, bool critical);
+
+/**
+ * @brief Get test descriptor by ID
+ *
+ * @param test_id Test ID to find
+ * @return Pointer to the test descriptor, or NULL if not found
+ */
+const struct safety_test *safety_test_get_test(uint32_t test_id);
+
+/**
+ * @brief Get total number of registered tests
+ *
+ * @return Number of tests
+ */
+uint32_t safety_test_get_test_count(void);
+
+#ifdef CONFIG_USERSPACE
+/*
+ * Userspace API (syscalls)
+ */
+
+/**
+ * @brief Run a test from userspace
+ *
+ * Only tests with SAFETY_TEST_FLAG_USERSPACE_OK can be executed.
+ *
+ * @param test_id Test ID to execute
+ * @return Test result, or negative errno on error
+ */
+__syscall int safety_test_run_test_user(uint32_t test_d);
+
+/**
+ * @brief Get test result from userspace
+ *
+ * @param test_id Test ID to query
+ * @param result Pointer to store result
+ * @return 0 on success, negative errno on error
+ */
+__syscall int safety_test_get_result_user(uint32_t test_id, enum safety_test_result *result);
+
+/**
+ * @brief Get safety test summary from userspace
+ *
+ * @param summary Pointer to summary structure to populate
+ * @return 0 on success, negative errno on error
+ */
+__syscall int safety_test_get_summary_user(struct safety_test_summary *summary);
+
+/**
+ * @brief Get category summary from userspace
+ *
+ * @param category Category bitmask (SAFETY_TEST_CAT_*)
+ * @param summary Pointer to summary structure to populate
+ * @return 0 on success, negative errno on error
+ */
+__syscall int safety_test_get_category_summary_user(uint32_t category,
+						    struct safety_test_summary *summary);
+
+#include <zephyr/syscalls/safety_test.h>
+#endif /* CONFIG_USERSPACE */
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SAFETY_TEST_H_ */

--- a/subsys/safety_test/Kconfig
+++ b/subsys/safety_test/Kconfig
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Aerlync Labs Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig SAFETY_TEST
+	bool "Safety Test subsystem"
+	help
+	  Safety Test subsystem for hardware and software self-testing.
+	  This provides a framework for registering and executing tests at boot time and runtime.
+
+if SAFETY_TEST
+
+config SAFETY_TEST_EARLY_TESTS
+	bool "Enable EARLY level tests"
+	default y
+	help
+	  Run safety tests at the EARLY init level, before any kernel services
+	  are available. Only minimal tests can run at this level
+
+config SAFETY_TEST_RESULT_BUFFER_SIZE
+	int "Number of test results to buffer"
+	default 32
+	range 8 256
+	help
+	  Maximum number of test results stored for later query.
+	  Each result uses approximately 24 bytes of RAM.
+
+config SAFETY_TEST_USERSPACE
+	bool "Enable userspace Safety Test API"
+	depends on USERSPACE
+	default y if USERSPACE
+	help
+	  Syscall interface for safety test execution and result queries
+	  from userspace. Only tests marked with SAFETY_TEST_FLAG_USERSPACE_OK
+	  can be executed from userspace.
+
+config SAFETY_TEST_SHELL
+	bool "Safety Test shell commands"
+	depends on SHELL
+	default y if SHELL
+	help
+	  Shell commands for safety test execution and status.
+	  Commands include: safety_test list, safety_test run, safety_test status.
+
+config SAFETY_TEST_LOG_LEVEL
+	int "Safety Test log level"
+	depends on LOG
+	default 3
+	range 0 4
+	help
+	  Log level for safety Test subsystem
+	  0 = off, 1 = error, 2 = warning, 3 = info, 4 = debug
+
+config SAFETY_TEST_MAX_FAILURE_HOOKS
+	int "Maximum number of failure hooks"
+	default 4
+	range 1 16
+	help
+	  Maximum number of failure callbacks that can be registered.
+
+#endif # SAFETY_TEST

--- a/subsys/safety_test/safety_test.c
+++ b/subsys/safety_test/safety_test.c
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) 2026 Aerlync Labs Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Safety Test subsystem core implementation
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/safety_test/safety_test.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(safety_test, CONFIG_SAFETY_TEST_LOG_LEVEL);
+
+/* Iterable section bounds */
+STRUCT_SECTION_START_EXTERN(safety_test);
+STRUCT_SECTION_END_EXTERN(safety_test);
+
+/* Result storage */
+static struct safety_test_result_record results[CONFIG_SAFETY_TEST_RESULT_BUFFER_SIZE];
+static uint32_t result_count;
+
+/* Failure hooks */
+struct failure_hook {
+	safety_test_failure_cb cb;
+	void *user_data;
+};
+
+static struct failure_hook failure_hooks[CONFIG_SAFETY_TEST_RESULT_BUFFER_SIZE];
+static uint32_t hook_count;
+
+/* Safe state callback (for critical test failures) */
+static safety_test_safe_state_cb_t safe_state_cb;
+static void *safe_state_user_data;
+
+/* Category critical flags (bitmask of critical categories) */
+static uint32_t critical_categories;
+
+/* Statistics */
+static uint32_t total_passed;
+static uint32_t total_failed;
+static uint32_t total_skipped;
+
+/*
+ * Internal helpers
+ */
+
+/**
+ * @brief Compute test ID from test pointer position
+ *
+ * Test IDs are computed from the test's position in the sorted array.
+ * This provides sequential IDs based on linker sort order
+ */
+static inline uint32_t safety_test_compute_test_id(const struct safety_test *test)
+{
+	extern struct safety_test _safety_test_list_start[];
+
+	return (uint32_t)(test - _safety_test_list_start);
+}
+
+static struct safety_test_result_record *find_result(uint32_t test_id)
+{
+	for (uint32_t i = 0; i < result_count; i++) {
+		if (results[i].test_id == test_id) {
+			return results + i;
+		}
+	}
+
+	return NULL;
+}
+
+static struct safety_test_result_record *alloc_result(const struct safety_test *test)
+{
+	uint32_t test_id = safety_test_compute_test_id(test);
+
+	struct safety_test_result_record *rec = find_result(test_id);
+
+	if (rec != NULL) {
+		return rec;
+	}
+
+	if (result_count < CONFIG_SAFETY_TEST_RESULT_BUFFER_SIZE) {
+		rec = &results[result_count++];
+		rec->test_id = test_id;
+		rec->result = SAFETY_TEST_RESULT_NOT_RUN;
+		return rec;
+	}
+
+	LOG_WRN("Result buffer full, cannot store result for test %u", test_id);
+
+	return NULL;
+}
+
+static void invoke_failure_hooks(const struct safety_test *test,
+				 const struct safety_test_result_record *result)
+{
+	for (uint32_t i = 0; i < hook_count; i++) {
+		if (failure_hooks[i].cb != NULL) {
+			failure_hooks[i].cb(test, result, failure_hooks[i].user_data);
+		}
+	}
+}
+
+static enum safety_test_result execute_test(const struct safety_test *test)
+{
+	uint32_t test_id = safety_test_compute_test_id(test);
+
+	struct safety_test_context ctx = {
+		.init_level = test->init_level,
+		.test_id = test_id,
+		.user_data = NULL,
+		.error_code = 0,
+	};
+
+	uint64_t start_us = 0;
+	uint64_t duration = 0;
+	enum safety_test_result result;
+
+	/* Only use timing APIs after POST_KERNEL level */
+	if (test->init_level >= SAFETY_TEST_LEVEL_POST_KERNEL) {
+		start_us = k_ticks_to_us_floor64(k_uptime_ticks());
+	}
+
+	LOG_INF("Running test: %s (ID=%u)", test->name, test_id);
+
+	/* Execute the test - pass non-const context */
+	result = test->test_fn(&ctx);
+
+	if (test->init_level >= SAFETY_TEST_LEVEL_POST_KERNEL) {
+		uint64_t end_us = k_ticks_to_us_floor64(k_uptime_ticks());
+
+		duration = end_us - start_us;
+	}
+
+	if ((test->timeout_us != 0) && (duration > test->timeout_us)) {
+		result = SAFETY_TEST_RESULT_FAIL;
+		LOG_ERR("Test timed out");
+	}
+
+	struct safety_test_result_record *rec = alloc_result(test);
+
+	if (rec != NULL) {
+		rec->result = result;
+		rec->error_code = ctx.error_code;
+		rec->duration_us = duration;
+
+		/* If test failed but didn't set error code, set a default one */
+		if ((result == SAFETY_TEST_RESULT_FAIL) && (ctx.error_code == 0)) {
+			/* Set default error code based on result type */
+			rec->error_code = -(int)(0x10000 | (test_id & 0xFFFF));
+		}
+	}
+
+	/* Update statistics */
+	switch (result) {
+	case SAFETY_TEST_RESULT_PASS:
+		total_passed++;
+		LOG_INF("  PASS (%u us)", (uint32_t)duration);
+		break;
+	case SAFETY_TEST_RESULT_FAIL:
+		total_failed++;
+		LOG_ERR("  FAIL (%u us)", (uint32_t)duration);
+		invoke_failure_hooks(test, rec);
+		break;
+	case SAFETY_TEST_RESULT_SKIP:
+		total_skipped++;
+		LOG_WRN("  SKIP");
+		break;
+	default:
+		break;
+	}
+
+	return result;
+}
+
+/**
+ * @brief Check if the test is critical
+ *
+ * @param test Test descriptor
+ * @return true if critical, false otherwise
+ */
+static bool is_test_critical(const struct safety_test *test)
+{
+	if (test->flags & SAFETY_TEST_FLAG_CRITICAL) {
+		return true;
+	}
+
+	if (critical_categories & test->category) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Handle critical test failure
+ *
+ * Invokes safe state callback (if registered) and then halts the system.
+ *
+ * @param test Failed test
+ * @param result Test result record
+ */
+static void handle_critical_failure(const struct safety_test *test,
+				    const struct safety_test_result_record *result)
+{
+	LOG_ERR("Critical test '%s' (ID=%u) failed, transitioning to safe state", test->name,
+		test->id);
+
+	/* Invoke safe state callback if registered */
+	if (safe_state_cb != NULL) {
+		safe_state_cb(test, result, safe_state_user_data);
+	}
+
+	/* Halt the system */
+	LOG_ERR("System halted due to critical test failure");
+	k_panic();
+}
+
+/*
+ * Public API
+ */
+
+int safety_test_run_level(enum safety_test_init_level level)
+{
+	int failures = 0;
+
+	LOG_INF("Safety test: Running level %d tests", level);
+
+	STRUCT_SECTION_FOREACH(safety_test, test) {
+		if (test->init_level != level) {
+			continue;
+		}
+
+		if (test->flags & SAFETY_TEST_FLAG_ON_DEMAND_ONLY) {
+			continue;
+		}
+
+		if (test->flags & SAFETY_TEST_FLAG_BOOT_OK) {
+			enum safety_test_result result = execute_test(test);
+
+			if (result == SAFETY_TEST_RESULT_FAIL) {
+				failures++;
+				if (is_test_critical(test)) {
+					struct safety_test_result_record *rec =
+						find_result(safety_test_compute_test_id(test));
+
+					handle_critical_failure(test, rec);
+				}
+			}
+		}
+	}
+
+	return failures;
+}
+
+/* Runtime test execution */
+enum safety_test_result safety_test_run_test(uint32_t test_id)
+{
+	extern struct safety_test _safety_test_list_start[];
+
+	enum safety_test_result result;
+	uint32_t test_count = safety_test_get_test_count();
+
+	if (test_id >= test_count) {
+		LOG_ERR("Test ID %u not found", test_id);
+		return SAFETY_TEST_RESULT_FAIL;
+	}
+
+	const struct safety_test *test = &_safety_test_list_start[test_id];
+
+	/* Execute on demand flags */
+	if (test->flags & SAFETY_TEST_FLAG_ON_DEMAND_ONLY) {
+		return execute_test(test);
+	}
+
+	/* If flag is destructive, skip execution */
+	if (test->flags & SAFETY_TEST_FLAG_DESTRUCTIVE) {
+		LOG_WRN("Test %u is destructive may affect system state", test_id);
+		return SAFETY_TEST_RESULT_SKIP;
+	}
+
+	/* If flag is runtime ok then execute test */
+	if (test->flags & SAFETY_TEST_FLAG_RUNTIME_OK) {
+		/* Warn user that test is critical */
+		if (is_test_critical(test)) {
+			LOG_WRN("Test %u is Critical", test_id);
+		}
+
+		/* Warn user that test is executed from user space */
+		if (test->flags & SAFETY_TEST_FLAG_USERSPACE_OK) {
+			LOG_WRN("Test %u is called from user space", test_id);
+		}
+
+		/* Execute test */
+		result = execute_test(test);
+
+		/* Handle if critical test fails */
+		if ((result == SAFETY_TEST_RESULT_FAIL) && is_test_critical(test)) {
+			struct safety_test_result_record *rec = find_result(test_id);
+
+			handle_critical_failure(test, rec);
+		}
+
+		return result;
+	}
+
+	LOG_WRN("Test can only be executed at boot time");
+	return SAFETY_TEST_RESULT_SKIP;
+}
+
+int safety_test_run_category(uint32_t category)
+{
+	int failures = 0;
+
+	STRUCT_SECTION_FOREACH(safety_test, test) {
+		if (!(test->category & category)) {
+			continue;
+		}
+
+		if (!(test->flags & SAFETY_TEST_FLAG_RUNTIME_OK) &&
+		    !(test->flags & SAFETY_TEST_FLAG_ON_DEMAND_ONLY)) {
+			continue;
+		}
+
+		enum safety_test_result result = execute_test(test);
+
+		if (result == SAFETY_TEST_RESULT_FAIL) {
+			failures++;
+
+			if (is_test_critical(test)) {
+				struct safety_test_result_record *rec;
+
+				test_id = safety_test_compute_test_id(test);
+				rec = find_result(test_id);
+				handle_critical_failure(test, rec);
+			}
+		}
+	}
+
+	return failures;
+}
+
+int safety_test_get_result(uint32_t test_id, struct safety_test_result_record *record)
+{
+	if (record == NULL) {
+		return -EINVAL;
+	}
+
+	struct safety_test_result_record *rec = find_result(test_id);
+
+	if (rec == NULL) {
+		return -ENOENT;
+	}
+
+	*record = *rec;
+
+	return 0;
+}
+
+static void update_category_summary(const struct safety_test *test, enum safety_test_result result,
+				    struct safety_test_category_summary *cat_summary)
+{
+	cat_summary->total++;
+
+	switch (result) {
+	case SAFETY_TEST_RESULT_PASS:
+		cat_summary->passed++;
+		break;
+	case SAFETY_TEST_RESULT_FAIL:
+		cat_summary->failed++;
+		break;
+	case SAFETY_TEST_RESULT_SKIP:
+		cat_summary->skipped++;
+		break;
+	default:
+		break;
+	}
+}
+
+int safety_test_get_summary(struct safety_test_summary *summary)
+{
+	if (summary == NULL) {
+		return -EINVAL;
+	}
+
+	memset(summary, 0, sizeof(*summary));
+
+	STRUCT_SECTION_FOREACH(safety_test, test) {
+		uint32_t test_id = safety_test_compute_test_id(test);
+		struct safety_test_result_record *rec = find_result(test_id);
+		enum safety_test_result result;
+
+		result = (rec != NULL) ? rec->result : SAFETY_TEST_RESULT_NOT_RUN;
+		summary->global.total++;
+
+		switch (result) {
+		case SAFETY_TEST_RESULT_PASS:
+			summary->global.passed++;
+			break;
+		case SAFETY_TEST_RESULT_FAIL:
+			summary->global.failed++;
+			break;
+		case SAFETY_TEST_RESULT_SKIP:
+			summary->global.skipped++;
+			break;
+		default:
+			break;
+		}
+
+		for (int i = 0; i < SAFETY_TEST_CAT_MAX; i++) {
+			uint32_t cat_bit = BIT(i);
+
+			if (test->category & cat_bit) {
+				update_category_summary(test, result, &summary->categories[i]);
+			}
+		}
+	}
+
+	return 0;
+}
+
+int safety_test_get_category_summary(uint32_t category, struct safety_test_summary *summary)
+{
+	if (summary == NULL) {
+		return -EINVAL;
+	}
+
+	memset(summary, 0, sizeof(*summary));
+
+	STRUCT_SECTION_FOREACH(safety_test, test) {
+		if ((test->category & category) == 0) {
+			continue;
+		}
+
+		uint32_t test_id = safety_test_compute_test_id(test);
+		struct safety_test_result_record *rec = find_result(test_id);
+		enum safety_test_result result;
+
+		result = (rec != NULL) ? rec->result : SAFETY_TEST_RESULT_NOT_RUN;
+		summary->global.total++;
+
+		switch (result) {
+		case SAFETY_TEST_RESULT_PASS:
+			summary->global.passed++;
+			break;
+		case SAFETY_TEST_RESULT_FAIL:
+			summary->global.failed++;
+			break;
+		case SAFETY_TEST_RESULT_SKIP:
+			summary->global.skipped++;
+			break;
+		default:
+			break;
+		}
+
+		for (int i = 0; i < SAFETY_TEST_CAT_MAX; i++) {
+			uint32_t cat_bit = BIT(i);
+
+			if ((category & cat_bit) && (test->category & cat_bit)) {
+				update_category_summary(test, result, &summary->categories[i]);
+			}
+		}
+	}
+
+	return 0;
+}
+
+int safety_test_register_failure_hook(safety_test_failure_cb cb, void *user_data)
+{
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	if (hook_count >= CONFIG_SAFETY_TEST_MAX_FAILURE_HOOKS) {
+		return -ENOMEM;
+	}
+
+	failure_hooks[hook_count].cb = cb;
+	failure_hooks[hook_count].user_data = user_data;
+	hook_count++;
+
+	return 0;
+}
+
+int safety_test_register_safe_state_cb(safety_test_safe_state_cb_t cb, void *user_data)
+{
+	safe_state_cb = cb;
+	safe_state_user_data = user_data;
+
+	return 0;
+}
+
+void safety_test_set_category_critical(uint32_t category, bool critical)
+{
+	if (critical) {
+		critical_categories |= category;
+		LOG_INF("Category 0x%x marked as critical", category);
+	} else {
+		critical_categories &= ~category;
+		LOG_INF("Category 0x%x no longer critical", category);
+	}
+}
+
+const struct safety_test *safety_test_get_test(uint32_t test_id)
+{
+	extern struct safety_test _safety_test_list_start[];
+
+	uint32_t test_count = safety_test_get_test_count();
+
+	if (test_id >= test_count) {
+		return NULL;
+	}
+
+	return &_safety_test_list_start[test_id];
+}
+
+uint32_t safety_test_get_test_count(void)
+{
+	uint32_t count = 0;
+
+	STRUCT_SECTION_FOREACH(safety_test, test) {
+		ARG_UNUSED(test);
+		count++;
+	}
+
+	return count;
+}
+
+/*
+ * Boot-time init
+ */
+
+#ifdef CONFIG_SAFETY_TEST_EARLY_TESTS
+static int safety_test_init_early(void)
+{
+	return safety_test_run_level(SAFETY_TEST_LEVEL_EARLY);
+}
+
+/*
+ * TODO: Make the priority a configuration
+ */
+SYS_INIT(safety_test_init_early, EARLY, 199);
+#endif
+
+static int safety_test_init_pre_kernel_1(void)
+{
+	return safety_test_run_level(SAFETY_TEST_LEVEL_PRE_KERNEL_1);
+}
+
+/*
+ * TODO: Make the priority a configuration
+ */
+SYS_INIT(safety_test_init_pre_kernel_1, PRE_KERNEL_1, 199);
+
+static int safety_test_init_pre_kernel_2(void)
+{
+	return safety_test_run_level(SAFETY_TEST_LEVEL_PRE_KERNEL_2);
+}
+
+/*
+ * TODO: Make the priority a configuration
+ */
+SYS_INIT(safety_test_init_pre_kernel_2, PRE_KERNEL_2, 199);
+
+static int safety_test_init_post_kernel(void)
+{
+	return safety_test_run_level(SAFETY_TEST_LEVEL_POST_KERNEL);
+}
+
+/*
+ * TODO: Make the priority a configuration
+ */
+SYS_INIT(safety_test_init_post_kernel, POST_KERNEL, 199);
+
+static int safety_test_init_application(void)
+{
+	int result = safety_test_run_level(SAFETY_TEST_LEVEL_APPLICATION);
+	struct safety_test_summary summary;
+
+	safety_test_get_summary(&summary);
+
+	LOG_INF("Safety Test complete: %u passed, %u failed, %u skipped", summary.global.passed,
+		summary.global.failed, summary.global.skipped);
+
+	return result;
+}
+
+/*
+ * TODO: Make the priority a configuration
+ */
+SYS_INIT(safety_test_init_application, APPLICATION, 199);


### PR DESCRIPTION
Add header file defining the Safety Test subsystem API, including test registration, execution and result querying interfaces.