### PR TITLE
imx943: fix switch dsa

### DIFF
--- a/boards/nxp/imx943_evk/doc/index.rst
+++ b/boards/nxp/imx943_evk/doc/index.rst
@@ -73,6 +73,10 @@ For A55 Core, ENET0, ENETC1, ENETC2 ports are enabled by default, so no overlay 
 needed, but NETC depends on GIC ITS, so need to make sure to allocate heap memory to
 be larger than 851968 byes by setting CONFIG_HEAP_MEM_POOL_SIZE.
 
+On the EVK board, switch port0 and port2 are connected to both SGMII port (SGMII-swp0
+and SGMII-swp1) and 100M port (swp0 and swp1), currently only 100M port (swp0 and swp1)
+is enabled, so could connect to 100M port for verify two switch ports.
+
 The two switch ports could be verified via :zephyr:code-sample:`dsa` on M33 core
 or on A55 Core, for example for A55 Core:
 

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -53,13 +53,13 @@
 
 	phy0: phy@2 {
 		compatible = "ethernet-phy";
-		reg = <0xf>;
+		reg = <0x2>;
 		status = "disabled";
 	};
 
 	phy1: phy@3 {
 		compatible = "ethernet-phy";
-		reg = <0x10>;
+		reg = <0x3>;
 		status = "disabled";
 	};
 

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -474,6 +474,7 @@
 				reg = <0x4cd40000 0x40000>,
 				      <0x4ca00000 0x1000>;
 				reg-names = "port", "pfconfig";
+				msi-device-id = <0x68>;
 				mac-index = <3>;
 				si-index = <3>;
 				phy-connection-type = "internal";


### PR DESCRIPTION
1. Added MSI device ID for switch internal port.
2. Changed to use 100M port for switch port testing.