### PR TITLE
drivers: timers: stm32: improving lptim init sequence

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -525,6 +525,9 @@ static int sys_clock_driver_init(void)
 		return -ENODEV;
 	}
 
+	/* Reset timer to default state using RCC */
+	(void)reset_line_toggle_dt(&lptim_reset);
+
 	/* Enable LPTIM bus clock */
 	err = clock_control_on(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 	if (err < 0) {
@@ -561,9 +564,6 @@ static int sys_clock_driver_init(void)
 		lptim_clock_freq = KHZ(32);
 	}
 #endif
-
-	/* Reset timer to default state using RCC */
-	(void)reset_line_toggle_dt(&lptim_reset);
 
 #if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
 	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);


### PR DESCRIPTION
Moving the reset of ltpim hw ip at the beginning of sys_clock_driver_init to improve the reliability of lptim hw init sequence. 
Reset of lptim can be made without  clcoking the lptim itself.
This sequence has been suggested by ST hw experts.
After https://github.com/zephyrproject-rtos/zephyr/pull/100613 we had a regression in s2ram management for STM32WBAX
with ble enabled.
With this fix regression has been solved.
  
@tpambor, @FrancescoCiminoST