### PR TITLE
Bluetooth: Host: make TX processor stack size configurable

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -148,8 +148,12 @@ config BT_TX_PROCESSOR_THREAD_PRIO
 	default SYSTEM_WORKQUEUE_PRIORITY
 
 config BT_TX_PROCESSOR_STACK_SIZE
-	int
+	int "TX processor thread stack size"
 	default 1024
+	help
+	  Size of the TX processor thread stack. How much stack is needed depends on which
+	  and how many host features are enabled. One might try to decrease it to save RAM,
+	  or increase it if there are stack overflows.
 
 endif
 


### PR DESCRIPTION
While the tx processor thread is needed to prevent deadlocks and is as such always enabled, its stack size may be adjusted based on need. What is needed is dependent on which features are enabled in the zephyr host as well as other project configurations impacting the zephyr host.