### PR TITLE
ci: twister, twister_tests_blackbox: download only the arm toolchain

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: zephyrproject-rtos/action-zephyr-setup@b2453c72966ee67b1433be22b250348d48283286 # v1.0.7
         with:
           app-path: zephyr
-          toolchains: all
+          toolchains: 'arm-zephyr-eabi'
 
       - name: Environment Setup
         working-directory: zephyr

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -48,7 +48,7 @@ jobs:
       uses: zephyrproject-rtos/action-zephyr-setup@b2453c72966ee67b1433be22b250348d48283286 # v1.0.7
       with:
         app-path: zephyr
-        toolchains: all
+        toolchains: 'arm-zephyr-eabi'
 
     - name: Run Pytest For Twister Black Box Tests
       if: ${{ startsWith(runner.os, 'ubuntu') }}


### PR DESCRIPTION
Looks like these two workflows are running out of space too. Only install the arm toolchain.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102307