### PR TITLE
ci: twister: download only the arm toolchain

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: zephyrproject-rtos/action-zephyr-setup@b2453c72966ee67b1433be22b250348d48283286 # v1.0.7
         with:
           app-path: zephyr
-          toolchains: all
+          toolchains: 'arm-zephyr-eabi'
 
       - name: Environment Setup
         working-directory: zephyr


### PR DESCRIPTION
Looks like this workflow is running out of space too. Only install the arm toolchain.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102307