### PR TITLE
soc: nordic: kconfig: Fix dt function usage

### DIFF
--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -104,7 +104,6 @@ config TFM_NRF_NS_STORAGE
 
 endif # BUILD_WITH_TFM
 
-
 config NRF_MPU_FLASH_REGION_SIZE
 	hex
 	default 0x1000
@@ -112,16 +111,19 @@ config NRF_MPU_FLASH_REGION_SIZE
 	help
 	  FLASH region size for the NRF_MPU peripheral.
 
+DT_CHOSEN_ZEPHYR_FLASH := zephyr,flash
+DT_CHOSEN_ZEPHYR_FLASH_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_FLASH))
+
 config NRF_BPROT_FLASH_REGION_SIZE
 	hex
-	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH_PATH),erase-block-size)
 	depends on HAS_HW_NRF_BPROT
 	help
 	  FLASH region size for the NRF_BPROT peripheral (nRF52).
 
 config NRF_ACL_FLASH_REGION_SIZE
 	hex
-	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH_PATH),erase-block-size)
 	depends on HAS_HW_NRF_ACL
 	help
 	  FLASH region size for the NRF_ACL peripheral.


### PR DESCRIPTION
Fixes using a dt function which suffered from firstly trying to take the value from a variable that isn't defined, and which if is ignored, was entirely invalid due to supplying a chosen node, not a path as the dt function explicitly requires