### PR TITLE
firmware: scmi: core: drop early return if message read fails

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -149,9 +149,6 @@ static int scmi_send_message_polling(struct scmi_protocol *proto,
 	}
 
 	ret = scmi_transport_read_message(proto->transport, proto->tx, reply);
-	if (ret < 0) {
-		return ret;
-	}
 
 cleanup:
 	/* restore scmi interrupt enable status when disable it pass */


### PR DESCRIPTION
If, for whatever reason, scmi_transport_read_message() ever fails, scmi_send_message_polling() will return without releasing the mutex. Therefore, drop the early return conditional.

This will also modify the state of the channel interrupts. Now, even if said function call fails, the interrupts will be re-enabled, which makes more sense anyways - we want to keep the state previous to the function call.

Validated on IMX95-19x19-EVK board (M7 DDR variant) with https://github.com/zephyrproject-rtos/zephyr/pull/102270 applied on top of 7e3c5ab2bb2a ("samples: net: nsos: remove `CONFIG_HEAP_MEM_POOL_SIZE`") (my latest main). The sample I've used is `samples/hello_world`.