### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -344,7 +344,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 0f0c43748111c65800c6920f1c0690676423a351
+      revision: 4d11a73d62bf999205f16de21a0ef675501f5b21
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: eaf223da0c3f987caa1156cbed54b513bee4ba37


### PR DESCRIPTION
Update the HW models module to:
4d11a73d62bf999205f16de21a0ef675501f5b21

Including the following:
4d11a73 makefile: Check for more types of build warnings 
e53f8db hal: Disable unused-parameter warning when building hal files
5dfba9f RADIO: Avoid 2 shadow redefinition warnings 
4a4f979 nrf_hack: Avoid a shadowed redefinition warning
4b9e63b misc: Fix a couple of signedness comparison warnings 
d46094f CRACEN: Fix an unused parameter warning
1cf2b04 CLOCK: Fix prototype and one warning
2dab612 nrf_clock: Select header based on symbol instead of platform 
0b45a30 54 CRACEN: Make it clear that fallthrough is intentional 
7945bf8 GRTC: Add PASTCC model
0a997e5 nrf_hack: Trivial refactoring to remove duplicate code 
f328e9b cmake: Add build defines to nrfx library
3824f9c hal: nrf_common: Add repl. for nrf_address_{bus,slave}_get()