### PR TITLE
soc: stm32wba : adjust Thread size if BT enabled

### DIFF
--- a/soc/st/stm32/stm32wbax/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wbax/Kconfig.defconfig
@@ -43,7 +43,11 @@ config FPU
 	default y
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 2048
+	default 2048 if !BT_TX_PROCESSOR_THREAD
+	default 1024
+
+config BT_TX_PROCESSOR_STACK_SIZE
+	default 2048 if BT_TX_PROCESSOR_THREAD
 
 endif
 


### PR DESCRIPTION
In the https://github.com/zephyrproject-rtos/zephyr/pull/97913, a new thread is added and dedicated to the bluetooth tx process. The stack size associated to this tx thread is BT_TX_PROCESSOR_STACK_SIZE with a value of 1048.
This thread is used if BT_TX_PROCESSOR_THREAD is enabled

In some case (for example extended advertising), the thread size is insufficient : stack overflow issue.
Set specific configuration in the stm32wbax soc to increase the BT_TX_PROCESSOR_STACK_SIZE KConfig value.
Decrease the SYSTEM_WORKQUEUE_STACK_SIZE KConfig value if BT_TX_PROCESSOR_THREAD is enabled because a part of the process is done in the tx thread

@asm5878 