### PR TITLE
firmware: scmi: core: don't allow mutex usage in PRE_KERNEL stage

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -116,8 +116,7 @@ static int scmi_send_message_polling(struct scmi_protocol *proto,
 	int status;
 
 	/* wait for channel to be free */
-	ret = k_mutex_lock(&proto->tx->lock, K_NO_WAIT);
-	if (ret < 0) {
+	if (!k_is_pre_kernel() && k_mutex_lock(&proto->tx->lock, K_NO_WAIT)) {
 		LOG_ERR("failed to acquire chan lock");
 		return -EBUSY;
 	}
@@ -159,7 +158,9 @@ cleanup:
 		scmi_interrupt_enable(proto->tx, true);
 	}
 
-	k_mutex_unlock(&proto->tx->lock);
+	if (!k_is_pre_kernel()) {
+		k_mutex_unlock(&proto->tx->lock);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
While in PRE_KERNEL stage, scmi_send_message_polling() attempts to acquire the transmit channel mutex, which should not be allowed as the kernel is not fully initialized at this point.

Since there's no multithreading at this point, there's no need to use a mutex anyways. Therefore, perform mutex acquire()/release() only if not in PRE_KERNEL phase.

Note that the return value of k_mutex_lock() is already suppressed via an -EBUSY return value so no behavioral change here.

Validated on IMX95-19x19-EVK board (M7 DDR variant) with https://github.com/zephyrproject-rtos/zephyr/pull/102270 applied on top of 7e3c5ab2bb2a ("samples: net: nsos: remove `CONFIG_HEAP_MEM_POOL_SIZE`") (my latest main). The sample I've used is `samples/hello_world`.