### PR TITLE
drivers: disk: sdmmc: fix return value if sd card not present

### DIFF
--- a/drivers/disk/sdmmc_subsys.c
+++ b/drivers/disk/sdmmc_subsys.c
@@ -39,7 +39,7 @@ static int disk_sdmmc_access_init(struct disk_info *disk)
 	int ret;
 
 	if (!sd_is_card_present(cfg->host_controller)) {
-		return DISK_STATUS_NOMEDIA;
+		return -ENODEV;
 	}
 
 	ret = sd_init(cfg->host_controller, &data->card);


### PR DESCRIPTION
according to the api in include/zephyr/storage/disk_access.h
a negative errno value should be returned on fail.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>