### PR TITLE
xtensa: userspace: Fix preserving of EXCCAUSE and EXCVADDR registers

### DIFF
--- a/arch/xtensa/core/gen_zsr.py
+++ b/arch/xtensa/core/gen_zsr.py
@@ -36,7 +36,7 @@ args = parse_args()
 
 NEEDED = ["A0SAVE", "CPU"]
 if args.mmu:
-    NEEDED += ["DBLEXC", "DEPC_SAVE"]
+    NEEDED += ["DBLEXC", "DEPC_SAVE", "EXCCAUSE_SAVE"]
 if args.flush_reg:
     NEEDED += ["FLUSH"]
 

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -580,6 +580,10 @@ _handle_tlb_miss_dblexc:
 	rsr.ptevaddr a0
 	l32i a0, a0, 0
 
+	/* Restore EXCCAUSE and a0 values */
+	rsr a0, ZSR_EXCCAUSE_SAVE
+	wsr.exccause a0
+
 	rsr a0, ZSR_DBLEXC
 	rfde
 #endif

--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -726,13 +726,10 @@ _not_triple_fault:
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
 	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 
-	/* Save registers needed for handling the exception as
-	 * these registers can be overwritten during nested
+	/* Save register needed for handling the exception as
+	 * this register can be overwritten during nested
 	 * exceptions.
 	 */
-	rsr.exccause a0
-	s32i a0, a1, ___xtensa_irq_bsa_t_exccause_OFFSET
-
 	rsr.excvaddr a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_excvaddr_OFFSET
 

--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -677,16 +677,19 @@ _Level\LVL\()Vector:
 .if \LVL == 1
 	/* If there are any TLB misses during interrupt handling,
 	 * the user/kernel/double exception vector will be triggered
-	 * to handle these misses. This results in DEPC and EXCCAUSE
-	 * being overwritten, and then execution returned back to
-	 * this site of TLB misses. When it gets to the C handler,
-	 * it will not see the original cause. So stash
-	 * the EXCCAUSE here so C handler can see the original cause.
+	 * to handle these misses. This results in DEPC, EXCCAUSE
+	 * and EXCVADDR being overwritten, and then execution returned
+	 * back to this site of TLB misses. When it gets to the C handler,
+	 * it will not see the original cause. So stash the EXCCAUSE
+	 * and EXCVADDR here so C handler can see the original cause.
 	 *
 	 * For double exception, DEPC in saved in earlier vector
 	 * code.
 	 */
 	wsr a0, ZSR_A0SAVE
+
+	rsr.exccause a0
+	wsr a0, ZSR_EXCCAUSE_SAVE
 
 	esync
 
@@ -717,21 +720,41 @@ _Level\LVL\()Vector:
 	j _TripleFault
 
 _not_triple_fault:
-	rsr a0, ZSR_A0SAVE
 .endif
 #endif
 
 	addi a1, a1, -___xtensa_irq_bsa_t_SIZEOF
+
+#ifdef CONFIG_XTENSA_MMU
+.if \LVL == 1
+	/* Save EXCVADDR register needed for handling the exception
+	 * as this register can be overwritten during nested
+	 * exceptions.  It has to be saved first, because
+	 * executing the store instruction may trigger a
+	 * TLB miss, which will modify its value.
+	 */
+	rsr.excvaddr a0
+	s32i a0, a1, ___xtensa_irq_bsa_t_excvaddr_OFFSET
+	rsr a0, ZSR_A0SAVE
+.endif
+#endif
+
 	s32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
 	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 
+#ifdef CONFIG_XTENSA_MMU
+.if \LVL != 1
+#endif
 	/* Save register needed for handling the exception as
 	 * this register can be overwritten during nested
 	 * exceptions.
 	 */
 	rsr.excvaddr a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_excvaddr_OFFSET
+#ifdef CONFIG_XTENSA_MMU
+.endif
+#endif
 
 	/* Level "1" is the exception handler, which uses a different
 	 * calling convention.  No special register holds the


### PR DESCRIPTION
Occasionally, while executing code in userspace, a `LoadStorePrivilegeException` may occur. In such cases, the function `xtensa_exc_load_store_ring_error_check` is called to verify whether the thread has access to the memory that triggered the exception and, if necessary, invalidates all auto-refilled DTLBs.

At the start of exception handling, `_Level1Vector` saves register values to the IRQ BSA. During the first write, a `LoadStoreTLBMissException` may occur, which modifies the values of `EXCCAUSE` and `EXCVADDR` before they are stored in BSA. As a result, the original cause of the exception is lost, and it is not properly handled by the `xtensa_excint1_c` function.

This PR addresses the issue by:
 * Preserving the original EXCVADDR value.
 * Restoring the original EXCCAUSE value when exiting the Double Exception handler.