### PR TITLE
drivers: sensor: lm75: return full resolution

### DIFF
--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -115,14 +115,11 @@ static void lm75_sensor_value_to_temp(const struct sensor_value *val, int16_t *t
 
 static void lm75_temp_to_sensor_value(int16_t temp, struct sensor_value *val)
 {
-	/* shift right by 7, multiply by 10 to get 0.1° and divide by 2 to get °C */
-	temp = (temp / 128) * 10 / 2;
-
 	/* Integer part in degrees Celsius */
-	val->val1 = temp / 10;
+	val->val1 = (temp / 256);
 
 	/* Fractional part in micro degrees Celsius */
-	val->val2 = (temp - val->val1 * 10) * 100000U;
+	val->val2 = ((temp - (val->val1 * 256)) * 1000000) / 256;
 }
 
 static int lm75_attr_set(const struct device *dev, enum sensor_channel chan,


### PR DESCRIPTION
There are many lm75 variants differing in temperature resolution. Typical values are 9, 10, 11, and 12 bit. They all use the same format (16 bit signed integer with LSB at 1/256 degree C). Depending on the on the actual variant some of the LSB are not defined. The new calculation scheme uses all 16 bits independent on the actual sensor resolution. In the worst this leads to some pseudo-resolution in case the undefined bits are not reported as 0 by the sensor.