### PR TITLE
drivers: sdhc: imx_usdhc: Automatically mask SDIO interrupt

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -135,10 +135,20 @@ static void sdio_interrupt_cb(USDHC_Type *usdhc, void *user_data)
 {
 	const struct device *dev = user_data;
 	struct usdhc_data *data = dev->data;
+	USDHC_Type *base = get_base(dev);
 
 	if (data->sdhc_cb) {
 		data->sdhc_cb(dev, SDHC_INT_SDIO, data->sdhc_cb_user_data);
 	}
+
+	/*
+	 * Match the behavior of other Zephyr sdhc drivers, which automatically
+	 * mask the card interrupt when it arrives and expect an asynchronous
+	 * handler to re-enable it once the card's interrupt condition has been
+	 * cleared.
+	 */
+	USDHC_DisableInterruptStatus(base, kUSDHC_CardInterruptFlag);
+	USDHC_DisableInterruptSignal(base, kUSDHC_CardInterruptFlag);
 }
 
 static void card_inserted_cb(USDHC_Type *usdhc, void *user_data)


### PR DESCRIPTION
There are currently two other sdhc drivers that support this interrupt: Infineon and Ambiq. Both those vendor HALs automatically mask the interrupt after invoking the callback ([Infineon][1], [Ambiq][2]), expecting the user to unmask it asynchronously once they've cleared the card's interrupt condition.

The NXP usdhc driver doesn't do this and so is inconsistent with the other two. This has caused bugs with higher-level drivers, such as the AIROC Wi-Fi driver (#101100). Fix the issue by masking the interrupt ourselves.

[1]: https://github.com/zephyrproject-rtos/hal_infineon/blob/470f874ce432763a2b82cd322d0ff6efc89240cd/mtb-hal-cat1/source/cyhal_sdhc.c#L1251-L1260
[2]: https://github.com/zephyrproject-rtos/hal_ambiq/blob/5efc0228528a8adce5eae0d226fac85d2551eb3b/mcu/apollo510/hal/mcu/am_hal_sdhc.c#L2256

Fixes #101100