### PR TITLE
samples: boards: st: add SPI master sample

### DIFF
--- a/samples/boards/st/spi_master/CMakeLists.txt
+++ b/samples/boards/st/spi_master/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(spi_master)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/st/spi_master/README.rst
+++ b/samples/boards/st/spi_master/README.rst
@@ -1,0 +1,207 @@
+.. zephyr:code-sample:: spi_master
+   :name: SPI Master
+
+   Demonstrate SPI master communication with DMA support on STM32 boards.
+
+Overview
+********
+
+This sample demonstrates how to use the SPI driver in master mode on STM32
+microcontrollers with DMA support. It continuously sends messages to an SPI
+slave device and displays the received responses.
+
+The sample showcases:
+
+* SPI master configuration using devicetree
+* GPIO-based chip select control
+* DMA-accelerated SPI transfers
+* Full-duplex SPI communication
+* Zephyr logging system integration
+
+Requirements
+************
+
+* STM32 board with SPI and DMA support (tested on NUCLEO-L4R5ZI)
+* SPI slave device (another microcontroller or SPI peripheral)
+* Proper wiring between master and slave:
+
+  * MOSI (Master Out Slave In)
+  * MISO (Master In Slave Out)
+  * SCK (Serial Clock)
+  * CS (Chip Select)
+  * GND (Common Ground)
+
+Wiring
+******
+
+For NUCLEO-L4R5ZI (SPI1):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 15 25 45
+
+   * - Function
+     - STM32 Pin
+     - Arduino Connector
+     - Description
+   * - SCK
+     - PA5
+     - CN7 Pin 10
+     - SPI Clock
+   * - MISO
+     - PA6
+     - CN7 Pin 12
+     - Master In Slave Out
+   * - MOSI
+     - PA7
+     - CN7 Pin 14
+     - Master Out Slave In
+   * - CS
+     - PA15
+     - CN7 Pin 17
+     - Chip Select (Active Low)
+   * - GND
+     - GND
+     - CN7 Pin 8
+     - Common Ground
+
+Connect these pins to your SPI slave device accordingly. Ensure proper voltage
+level compatibility between devices.
+
+Building and Running
+********************
+
+Build and flash the sample as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/st/spi_master
+   :board: nucleo_l4r5zi
+   :goals: build flash
+   :compact:
+
+After flashing, open a serial terminal (115200 8N1) to see the output.
+
+Sample Output
+*************
+
+The sample outputs the following to the console:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v3.x.x ***
+   [00:00:00.010,000] <inf> spi_master_sample: SPI Master Sample
+   [00:00:00.015,000] <inf> spi_master_sample: SPI device ready
+   [00:00:00.020,000] <inf> spi_master_sample: === SPI Configuration ===
+   [00:00:00.025,000] <inf> spi_master_sample: Frequency: 312500 Hz
+   [00:00:00.030,000] <inf> spi_master_sample: Operation: 0x00040000
+   [00:00:00.035,000] <inf> spi_master_sample: Slave: 0
+   [00:00:00.040,000] <inf> spi_master_sample: CS GPIO port: 0x48000000
+   [00:00:00.045,000] <inf> spi_master_sample: CS GPIO pin: 15
+   [00:00:00.050,000] <inf> spi_master_sample: CS delay: 10 us
+   [00:00:00.055,000] <inf> spi_master_sample: ========================
+   [00:00:00.060,000] <inf> spi_master_sample: Waiting for slave initialization...
+   [00:00:02.065,000] <inf> spi_master_sample: Starting SPI communication loop
+   [00:00:02.070,000] <inf> spi_master_sample: TX string: [Hello from master 1] Message Length: 32
+   [00:00:02.075,000] <inf> spi_master_sample: RX string: [Response from slave] Message Length: 32
+
+Configuration
+*************
+
+SPI Frequency
+=============
+
+Adjust the SPI frequency in ``src/main.c`` by modifying the ``spi_cfg`` structure:
+
+.. code-block:: c
+
+   static struct spi_config spi_cfg = {
+       .frequency = 312500,  /* 312.5 kHz */
+       ...
+   };
+
+Common frequencies:
+
+* 312500 (312.5 kHz) - Default, safe for most slaves
+* 1000000 (1 MHz) - Faster, ensure slave supports it
+* 4000000 (4 MHz) - High speed, check signal integrity
+
+Message Size
+============
+
+Modify ``MSG_BUF_SIZE`` in ``src/main.c``:
+
+.. code-block:: c
+
+   #define MSG_BUF_SIZE 32  /* Bytes per transaction */
+
+Transmission Interval
+=====================
+
+Change the delay between transmissions in ``main()``:
+
+.. code-block:: c
+
+   k_sleep(K_SECONDS(1));  /* Send every 1 second */
+
+DMA Configuration
+=================
+
+DMA is enabled by default for efficient transfers. To disable DMA, remove
+these lines from ``prj.conf``:
+
+.. code-block:: kconfig
+
+   CONFIG_DMA=n
+   CONFIG_DMA_STM32=n
+   CONFIG_SPI_STM32_DMA=n
+
+Troubleshooting
+***************
+
+No Output
+=========
+
+1. Verify UART connection (ST-Link virtual COM port)
+2. Check baud rate: 115200 8N1
+3. Ensure board is powered
+
+SPI Transaction Fails
+=====================
+
+1. **Verify wiring**: Especially GND connection
+2. **Check slave power**: Ensure slave device is powered and initialized
+3. **Signal integrity**: Use shorter wires, add pull-ups if needed
+4. **Enable debug logging**: Set ``CONFIG_SPI_LOG_LEVEL_DBG=y``
+5. **Reduce frequency**: Try 100 kHz first, then increase
+
+CS Not Working
+==============
+
+1. Verify CS pin in overlay matches your wiring
+2. Check CS polarity (active low vs active high)
+3. Measure CS signal with oscilloscope/logic analyzer
+
+No Slave Response
+=================
+
+1. Ensure slave is in SPI slave mode
+2. Check MOSI/MISO aren't swapped
+3. Verify clock polarity/phase match between master and slave
+4. Add delay before first transaction: ``k_sleep(K_SECONDS(2))``
+
+Logic Analyzer
+==============
+
+For detailed signal analysis:
+
+1. Connect logic analyzer to SCK, MOSI, MISO, CS
+2. Configure: SPI Mode 0, 312.5 kHz, MSB first
+3. Verify clock edges and data alignment
+4. Check CS assertion timing (should precede data by ~10 µs)
+
+References
+**********
+
+* `STM32L4 SPI Documentation <https://www.st.com/resource/en/reference_manual/rm0432-stm32l4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf>`_
+* `Zephyr SPI API <https://docs.zephyrproject.org/latest/hardware/peripherals/spi.html>`_
+* `NUCLEO-L4R5ZI User Manual <https://www.st.com/resource/en/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf>`_

--- a/samples/boards/st/spi_master/boards/nucleo_l4r5zi.overlay
+++ b/samples/boards/st/spi_master/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Waqar Ahmed
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,spi = &spi1;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};
+
+spi_master: &spi1 {
+	status = "okay";
+	/* SPI1 default pins */
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	overrun-character = <0xFF>;
+	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
+	dmas = <&dmamux1 10 11 0x20440>,   /* SPI1_TX: slot 10, request 11, M2P+MINC */
+	       <&dmamux1 11 10 0x20480>;   /* SPI1_RX: slot 11, request 10, P2M+MINC */
+	dma-names = "tx", "rx";
+};

--- a/samples/boards/st/spi_master/prj.conf
+++ b/samples/boards/st/spi_master/prj.conf
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# GPIO driver for CS control
+CONFIG_GPIO=y
+
+# SPI driver
+CONFIG_SPI=y
+CONFIG_SPI_ASYNC=y
+
+# DMA support for efficient data transfer
+CONFIG_DMA=y
+CONFIG_DMA_STM32=y
+CONFIG_SPI_STM32_DMA=y
+
+# Logging
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=2
+CONFIG_PRINTK=y
+
+# Increase main stack size for logging overhead
+CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/boards/st/spi_master/sample.yaml
+++ b/samples/boards/st/spi_master/sample.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: SPI Master with DMA
+  description: |
+    Demonstrates SPI master communication with DMA support on STM32 boards.
+    Continuously sends messages to an SPI slave and displays the responses.
+
+tests:
+  sample.boards.st.spi_master:
+    harness: console
+    platform_allow:
+      - nucleo_l4r5zi
+    tags:
+      - spi
+      - stm32
+      - dma
+      - gpio
+    vendor_allow:
+      - st
+    integration_platforms:
+      - nucleo_l4r5zi
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "SPI Master Sample"
+        - "SPI device ready"
+        - "Starting SPI communication loop"
+        - "TX string:"

--- a/samples/boards/st/spi_master/src/main.c
+++ b/samples/boards/st/spi_master/src/main.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Waqar Ahmed
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(spi_master_sample, LOG_LEVEL_DBG);
+
+/* SPI device from devicetree */
+#define SPI_NODE DT_NODELABEL(spi_master)
+
+/* Message buffer size */
+#define MSG_BUF_SIZE 32
+
+/* Separate CS control struct for proper initialization */
+static const struct spi_cs_control cs_ctrl = {
+	.gpio = GPIO_DT_SPEC_GET(SPI_NODE, cs_gpios),
+	.delay = 10,
+	.cs_is_gpio = true,
+};
+
+/* SPI configuration */
+static struct spi_config spi_cfg = {
+	.frequency = 312500,
+	.operation = SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_OP_MODE_MASTER,
+	.slave = 0,
+	.cs = cs_ctrl,
+};
+
+/**
+ * @brief Print SPI configuration for debugging
+ *
+ * @param cfg Pointer to SPI configuration
+ */
+static void print_spi_config(const struct spi_config *cfg)
+{
+	LOG_INF("=== SPI Configuration ===");
+	LOG_INF("Frequency: %u Hz", cfg->frequency);
+	LOG_INF("Operation: 0x%08X", cfg->operation);
+	LOG_INF("Slave: %u", cfg->slave);
+
+	if (cfg->cs.cs_is_gpio) {
+		LOG_INF("CS GPIO port: %p", cfg->cs.gpio.port);
+		LOG_INF("CS GPIO pin: %u", cfg->cs.gpio.pin);
+		LOG_INF("CS GPIO flags: 0x%04X", cfg->cs.gpio.dt_flags);
+		LOG_INF("CS delay: %u us", cfg->cs.delay);
+	}
+
+	LOG_INF("========================");
+}
+
+/**
+ * @brief Prepare transmission buffer with message and padding
+ *
+ * @param buf Buffer to prepare
+ * @param buf_size Size of buffer
+ * @param msg_number Message sequence number
+ * @return Length of prepared message
+ */
+static size_t prepare_tx_buffer(uint8_t *buf, size_t buf_size, uint32_t msg_number)
+{
+	int msg_len;
+
+	/* Format message */
+	msg_len = snprintf((char *)buf, buf_size,
+			   "Hello from master %u", msg_number);
+
+	/* Pad remaining bytes with pattern for debugging */
+	if (msg_len < buf_size) {
+		memset(buf + msg_len, 0xAA, buf_size - msg_len);
+	}
+
+	return buf_size;
+}
+
+int main(void)
+{
+	const struct device *spi_dev;
+	uint8_t tx_buf[MSG_BUF_SIZE];
+	uint8_t rx_buf[MSG_BUF_SIZE];
+	uint32_t msg_number = 0;
+	struct spi_buf tx_spi_buf;
+	struct spi_buf rx_spi_buf;
+	struct spi_buf_set tx_set;
+	struct spi_buf_set rx_set;
+	int ret;
+
+	LOG_INF("SPI Master Sample");
+
+	/* Get SPI device from devicetree */
+	spi_dev = DEVICE_DT_GET(SPI_NODE);
+	if (!device_is_ready(spi_dev)) {
+		LOG_ERR("SPI device not ready");
+		return -ENODEV;
+	}
+
+	LOG_INF("SPI device ready");
+
+	/* Print configuration for debugging */
+	print_spi_config(&spi_cfg);
+
+	/* Initialize SPI buffer structures */
+	tx_spi_buf.buf = tx_buf;
+	rx_spi_buf.buf = rx_buf;
+
+	tx_set.buffers = &tx_spi_buf;
+	tx_set.count = 1;
+
+	rx_set.buffers = &rx_spi_buf;
+	rx_set.count = 1;
+
+	/* Wait for slave device to initialize */
+	LOG_INF("Waiting for slave initialization...");
+	k_sleep(K_SECONDS(2));
+
+	LOG_INF("Starting SPI communication loop");
+
+	while (1) {
+		msg_number++;
+
+		/* Prepare transmission buffer */
+		size_t msg_len = prepare_tx_buffer(tx_buf, MSG_BUF_SIZE, msg_number);
+
+		/* Set buffer lengths */
+		tx_spi_buf.len = msg_len;
+		rx_spi_buf.len = msg_len;
+
+		/* Clear receive buffer */
+		memset(rx_buf, 0, MSG_BUF_SIZE);
+
+		LOG_DBG("[%lld ms] Sending message #%u", k_uptime_get(), msg_number);
+		LOG_INF("TX string: [%s] Message Length: %d", tx_buf, msg_len);
+
+		/* Perform SPI transaction */
+		ret = spi_transceive(spi_dev, &spi_cfg, &tx_set, &rx_set);
+
+		if (ret == 0) {
+			/* Null-terminate for safe string printing */
+			rx_buf[msg_len < MSG_BUF_SIZE ? msg_len : MSG_BUF_SIZE - 1] = '\0';
+			LOG_INF("RX string: [%s] Message Length: %d", rx_buf, msg_len);
+		} else {
+			LOG_ERR("SPI transaction failed: %d", ret);
+		}
+
+		/* Wait before next transmission */
+		k_sleep(K_SECONDS(1));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add a sample demonstrating SPI master communication with DMA support on STM32 boards. The sample uses the NUCLEO-L4R5ZI board and shows:
- SPI master configuration via devicetree
- GPIO-based chip select control
- DMA-accelerated full-duplex transfers
- Zephyr logging integration
-  Built and tested on NUCLEO-L4R5ZI board
- Verified SPI communication with slave device
- Confirmed DMA transfers working correctly