### PR TITLE
modules: hostap: Add new APIs to set operating mode for SoftAP

### DIFF
--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -785,6 +785,103 @@ out:
 	return ret;
 }
 
+int hostapd_11n_cfg(const struct device *dev, uint8_t enable)
+{
+	int ret = 0;
+	struct hostapd_iface *iface;
+
+	k_mutex_lock(&hostapd_mutex, K_FOREVER);
+
+	iface = get_hostapd_handle(dev);
+	if (!iface) {
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		ret = -ENODEV;
+		goto out;
+	}
+
+	if (iface->state == HAPD_IFACE_ENABLED) {
+		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		ret = -EACCES;
+		goto out;
+	}
+
+	if (!hostapd_cli_cmd_v("set ieee80211n %d", enable)) {
+		wpa_printf(MSG_ERROR, "Failed to set ieee80211n");
+		ret = -EINVAL;
+		goto out;
+	}
+
+out:
+	k_mutex_unlock(&hostapd_mutex);
+	return ret;
+}
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
+int hostapd_11ac_cfg(const struct device *dev, uint8_t enable)
+{
+	int ret = 0;
+	struct hostapd_iface *iface;
+
+	k_mutex_lock(&hostapd_mutex, K_FOREVER);
+
+	iface = get_hostapd_handle(dev);
+	if (!iface) {
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		ret = -ENODEV;
+		goto out;
+	}
+
+	if (iface->state == HAPD_IFACE_ENABLED) {
+		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		ret = -EACCES;
+		goto out;
+	}
+
+	if (!hostapd_cli_cmd_v("set ieee80211ac %d", enable)) {
+		wpa_printf(MSG_ERROR, "Failed to set ieee80211ac");
+		ret = -EINVAL;
+		goto out;
+	}
+
+out:
+	k_mutex_unlock(&hostapd_mutex);
+	return ret;
+}
+#endif
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
+int hostapd_11ax_cfg(const struct device *dev, uint8_t enable)
+{
+	int ret = 0;
+	struct hostapd_iface *iface;
+
+	k_mutex_lock(&hostapd_mutex, K_FOREVER);
+
+	iface = get_hostapd_handle(dev);
+	if (!iface) {
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		ret = -ENODEV;
+		goto out;
+	}
+
+	if (iface->state == HAPD_IFACE_ENABLED) {
+		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		ret = -EACCES;
+		goto out;
+	}
+
+	if (!hostapd_cli_cmd_v("set ieee80211ax %d", enable)) {
+		wpa_printf(MSG_ERROR, "Failed to set ieee80211ax");
+		ret = -EINVAL;
+		goto out;
+	}
+
+out:
+	k_mutex_unlock(&hostapd_mutex);
+	return ret;
+}
+#endif
+
 #ifdef CONFIG_WIFI_NM_HOSTAPD_WPS
 static int hapd_ap_wps_pbc(const struct device *dev)
 {

--- a/modules/hostap/src/hapd_api.h
+++ b/modules/hostap/src/hapd_api.h
@@ -90,4 +90,35 @@ int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *param
 #endif /* CONFIG_WIFI_NM_HOSTAPD_AP */
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
+/**
+ * @brief Enable or disable 11N for AP
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param enable Enable or disable
+ * @return 0 for OK; -1 for ERROR
+ */
+int hostapd_11n_cfg(const struct device *dev, uint8_t enable);
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
+/**
+ * @brief Enable or disable 11AC for AP
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param enable Enable or disable
+ * @return 0 for OK; -1 for ERROR
+ */
+int hostapd_11ac_cfg(const struct device *dev, uint8_t enable);
+#endif
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
+/**
+ * @brief Enable or disable 11AX for AP
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param enable Enable or disable
+ * @return 0 for OK; -1 for ERROR
+ */
+int hostapd_11ax_cfg(const struct device *dev, uint8_t enable);
+#endif
+
 #endif /* __HAPD_API_H_ */


### PR DESCRIPTION
Add new APIs to set operating mode 11n, 11ac and 11ax for SoftAP. Currently, the 11n, 11ac and 11ax are enabled by default. Theses APIs can be used to configure operating modes enable/disable for SoftAP.