### PR TITLE
bluetooth: Classic: L2CAP: Improve I-frame and S-frame sending logic

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -498,6 +498,8 @@ struct bt_l2cap_br_window {
 	uint8_t sar;
 	/** srej flag */
 	bool srej;
+	/** retransmit flag */
+	bool retransmit;
 	/* Save PDU state */
 	struct net_buf_simple_state sdu_state;
 	/** @internal Holds the sending buffer. */

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -644,7 +644,8 @@ static int bt_l2cap_br_update_req_seq_direct(struct bt_l2cap_br_chan *br_chan, u
 		}
 	}
 
-	if (!atomic_test_bit(br_chan->flags, L2CAP_FLAG_RECV_FRAME_R)) {
+	if (!atomic_test_bit(br_chan->flags, L2CAP_FLAG_RECV_FRAME_R) &&
+	    !atomic_test_bit(br_chan->flags, L2CAP_FLAG_REMOTE_BUSY)) {
 		if (bt_l2cap_br_get_outstanding_count(br_chan)) {
 			/*
 			 * If unacknowledged I-frames have been sent but the retransmission


### PR DESCRIPTION
#### bluetooth: Classic: l2cap: fix S-frame sending logic

There is a corner case that the S-frame (RR) needs to be sent. And there is an I-frame (and only one I-frame) is in pending. But the I-frame is pending for waiting for ack instead of sending. In this case, the S-frame (RR) will not be preformed.

The previous implementation incorrectly checked for pending data before sending S-frames, which could prevent timely acknowledgments.

Fix the S-frame sending logic to ensure proper flow control in L2CAP BR/EDR channels.

Simplify the S-frame sending mechanism by removing the dedicated S-frame buffer allocation and transmission path. Instead, rely on the existing data ready mechanism to trigger S-frame transmission when needed.

Key changes:
- Remove S-frame specific macros and flags for identifying S-frames
- Change `l2cap_br_send_s_frame()` to only set the pending flag instead of allocating and sending buffers directly
- Remove error handling paths that would disconnect on S-frame send failures since S-frames are now queued through the normal path
- Simplify `l2cap_br_get_next_sdu()` and `l2cap_br_ret_fc_data_pull()` by removing S-frame specific handling
- Update `bt_l2cap_br_chan_recv_complete()` to always return 0

These changes ensure S-frames are sent promptly for flow control regardless of pending I-frames in the transmission queue.

#### bluetooth: Classic: l2cap: refactor I-frame retransmission logic

Refactor the I-frame retransmission mechanism to improve clarity and correctness in L2CAP BR/EDR flow control.

The previous implementation used multiple flags (L2CAP_FLAG_PDU_RETRANS and L2CAP_FLAG_REQ_SEQ_UPDATED) to track retransmission state, which made the logic complex and error-prone. This change introduces a per-window retransmit flag and dedicated helper functions to manage retransmission of all unacknowledged I-frames.

Key changes:
- Replace L2CAP_FLAG_PDU_RETRANS with L2CAP_FLAG_RET_I_FRAME for timeout-triggered retransmission of the first unacked I-frame
- Replace L2CAP_FLAG_REQ_SEQ_UPDATED with L2CAP_FLAG_RET_I_FRAMES for retransmission of all unacked I-frames
- Add `retransmit` flag to `bt_l2cap_br_window` structure to track which I-frames need retransmission
- Add `l2cap_br_retansmit_i_frames()` to mark all outstanding I-frames for retransmission
- Add `l2cap_br_stop_retansmit_i_frames()` to clear retransmission state
- Add `l2cap_br_get_ret_win()` to retrieve the next I-frame marked for retransmission
- Update `l2cap_br_ret_fc_data_pull()` to handle both single I-frame timeout retransmission and bulk retransmission separately
- Fix window memory management to only free newly allocated windows on error, not retransmitted ones
- Update S-frame handlers (RR, REJ, RNR) to use new retransmission helpers instead of setting flags directly
- Update comment for L2CAP_FLAG_RET_I_FRAME to clarify it handles timeout retransmission

These changes make the retransmission logic more explicit and easier to maintain while ensuring proper flow control behavior.

#### bluetooth: Classic: l2cap: fix retransmit timer start condition

Fix the retransmit timer start logic to account for remote busy state in L2CAP BR/EDR flow control.

The previous implementation would start the retransmit timer when there are outstanding unacknowledged I-frames, but it didn't check if the remote side is in a busy state (RNR received). Starting the timer while the remote is busy is incorrect since the remote cannot process I-frames until it sends an RR to clear the busy condition.

Add a check for L2CAP_FLAG_REMOTE_BUSY before starting the retransmit timer to ensure the timer is only started when the remote side is ready to receive I-frames.

This prevents unnecessary timer expirations and retransmissions when the remote peer has signaled it cannot accept additional I-frames.

#### bluetooth: Classic: l2cap: refactor R-bit handling for RET mode

Refactor the Retransmission Disable (R) bit handling in L2CAP BR/EDR to reuse the existing L2CAP_FLAG_REMOTE_BUSY flag instead of maintaining separate R-bit tracking flags.

The previous implementation used dedicated flags (`L2CAP_FLAG_RECV_FRAME_R` and `L2CAP_FLAG_RECV_FRAME_R_CHANGED`) to track the R-bit state, which duplicated the functionality of L2CAP_FLAG_REMOTE_BUSY and added unnecessary complexity.

Key changes:
- Remove `L2CAP_FLAG_RECV_FRAME_R` and `L2CAP_FLAG_RECV_FRAME_R_CHANGED` flags
- Update `bt_l2cap_br_update_r()` to directly use `L2CAP_FLAG_REMOTE_BUSY` for tracking remote busy state
- Trigger I-frame retransmission when R-bit transitions from 1 to 0
- Update I-frame and S-frame header packing to set R-bit based on local busy state in retransmission mode
- Simplify I-frame sending logic by consolidating remote busy checks 
- Remove redundant R-bit checks in data pull path
- Add RET mode specific handling in S-frame reception for RR and REJ frames
- Enhance `bt_l2cap_br_chan_recv_complete()` to support both RET and ERET modes with proper local busy state management
- Set S-frame type to REJ when local busy and in RET mode

These changes eliminate code duplication and make the remote busy state management more consistent across the L2CAP implementation.