### PR TITLE
disk: nvme/sd: Provide correct erase block size

### DIFF
--- a/drivers/disk/nvme/nvme_disk.c
+++ b/drivers/disk/nvme/nvme_disk.c
@@ -169,13 +169,13 @@ static int nvme_disk_ioctl(struct disk_info *disk, uint8_t cmd, void *buff)
 		*(uint32_t *)buff = nvme_namespace_get_sector_size(ns);
 
 		break;
-	case DISK_IOCTL_GET_ERASE_BLOCK_SZ:
+	case DISK_IOCTL_GET_ERASE_BLOCK_SZ: /* in sectors */
 		if (!buff) {
 			ret = -EINVAL;
 			break;
 		}
 
-		*(uint32_t *)buff = nvme_namespace_get_sector_size(ns);
+		*(uint32_t *)buff = 1;
 
 		break;
 	case DISK_IOCTL_CTRL_DEINIT:

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -864,8 +864,10 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		(*(uint32_t *)buf) = card->block_count;
 		break;
 	case DISK_IOCTL_GET_SECTOR_SIZE:
-	case DISK_IOCTL_GET_ERASE_BLOCK_SZ:
 		(*(uint32_t *)buf) = card->block_size;
+		break;
+	case DISK_IOCTL_GET_ERASE_BLOCK_SZ: /* in sectors */
+		(*(uint32_t *)buf) = 1;
 		break;
 	case DISK_IOCTL_CTRL_SYNC:
 		/* Ensure card is not busy with data write.


### PR DESCRIPTION
Erase block size should be provided in sectors, not in bytes.