### PR TITLE
Bluetooth: Host: Give option to disable TX processor thread

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -136,7 +136,7 @@ config BT_DRIVER_RX_HIGH_PRIO
 config BT_TX_PROCESSOR_THREAD
 	# This thread is used to send pending HCI Commands, ACL and ISO data to
 	# Controller.
-	bool
+	bool "TX processor thread. Disabling may cause deadlocks."
 	# This option is automatically selected for all platforms except nRF51
 	# due to limited RAM on nRF51 devices.
 	default y if !SOC_SERIES_NRF51X


### PR DESCRIPTION
This is not recommended as otherwise deadlocks may occur, but it has been observed that some boards and configurations may have too little RAM to accommodate the TX processor thread stack.
As such BT_TX_PROCESSOR_THREAD_DISABLE_TOO_LITTLE_RAM is introduced to disable it.