### PR TITLE
boards: adi: fix evaluation typo in board names

### DIFF
--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.yaml
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.yaml
@@ -1,5 +1,5 @@
 identifier: adi_eval_adin1110ebz
-name: ADI EVAL-ADIN1110EBZ evaulation board
+name: ADI EVAL-ADIN1110EBZ evaluation board
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/eval_adin2111d1z/adi_eval_adin2111d1z_max32690_m4.yaml
+++ b/boards/adi/eval_adin2111d1z/adi_eval_adin2111d1z_max32690_m4.yaml
@@ -1,5 +1,5 @@
 identifier: adi_eval_adin2111d1z/max32690/m4
-name: ADI EVAL-ADIN2111D1Z evaulation board
+name: ADI EVAL-ADIN2111D1Z evaluation board
 type: mcu
 arch: arm
 vendor: adi

--- a/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.yaml
+++ b/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.yaml
@@ -1,5 +1,5 @@
 identifier: adi_eval_adin2111ebz
-name: ADI EVAL-ADIN2111EBZ evaulation board
+name: ADI EVAL-ADIN2111EBZ evaluation board
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
Fix a spelling mistake in the board name description for ADI evaluation boards.

No functional change.