### PR TITLE
Add arm scmi power domain driver

### DIFF
--- a/drivers/power_domain/CMakeLists.txt
+++ b/drivers/power_domain/CMakeLists.txt
@@ -4,6 +4,7 @@
 zephyr_library()
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_POWER_DOMAIN_ARM_SCMI power_domain_arm_scmi.c)
 zephyr_library_sources_ifdef(CONFIG_POWER_DOMAIN_GPIO power_domain_gpio.c)
 zephyr_library_sources_ifdef(CONFIG_POWER_DOMAIN_GPIO_MONITOR power_domain_gpio_monitor.c)
 zephyr_library_sources_ifdef(CONFIG_POWER_DOMAIN_INTEL_ADSP power_domain_intel_adsp.c)

--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -123,6 +123,25 @@ config SOC_POWER_DOMAIN_INIT
 
 endif #POWER_DOMAIN_TISCI
 
+config POWER_DOMAIN_ARM_SCMI
+	bool "ARM SCMI Power Domain driver"
+	default y
+	depends on ARM_SCMI_POWER_DOMAIN_HELPERS
+	depends on DT_HAS_ARM_SCMI_POWER_DOMAIN_ENABLED
+	select DEVICE_DEPS
+	help
+	  Enable SCMI-based power domain driver.
+
+if POWER_DOMAIN_ARM_SCMI
+
+config POWER_DOMAIN_ARM_SCMI_INIT_PRIORITY
+	int "ARM SCMI PD driver init priority"
+	default 10
+	help
+	  ARM SCMI PD driver initialization priority.
+
+endif #POWER_DOMAIN_ARM_SCMI
+
 # zephyr-keep-sorted-start
 rsource "Kconfig.nrfs_gdpwr"
 rsource "Kconfig.nrfs_swext"

--- a/drivers/power_domain/power_domain_arm_scmi.c
+++ b/drivers/power_domain/power_domain_arm_scmi.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT arm_scmi_power_domain
+
+#include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/drivers/firmware/scmi/power.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(scmi_power_domain, CONFIG_POWER_DOMAIN_LOG_LEVEL);
+
+struct scmi_pd_config {
+	uint32_t domain_id;
+};
+
+static int scmi_pd_pm_action(const struct device *dev,
+			      enum pm_device_action action)
+{
+	const struct scmi_pd_config *cfg = dev->config;
+	struct scmi_power_state_config pwr_cfg;
+	int ret;
+
+	LOG_INF("attempting PM action %d on domain %d", action, cfg->domain_id);
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		pwr_cfg.domain_id = cfg->domain_id;
+		pwr_cfg.flags = 0;
+		pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_ON;
+
+		ret = scmi_power_state_set(&pwr_cfg);
+		if (ret < 0) {
+			return ret;
+		}
+		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_ON, NULL);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_OFF, NULL);
+
+		pwr_cfg.domain_id = cfg->domain_id;
+		pwr_cfg.flags = 0;
+		pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_OFF;
+
+		ret = scmi_power_state_set(&pwr_cfg);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int scmi_pd_init(const struct device *dev)
+{
+	return pm_device_driver_init(dev, scmi_pd_pm_action);
+}
+#define SCMI_PD_DEVICE(inst)							\
+	static const struct scmi_pd_config scmi_pd_cfg_##inst = {		\
+		.domain_id = DT_INST_REG_ADDR(inst),				\
+	};									\
+										\
+	PM_DEVICE_DT_INST_DEFINE(inst, scmi_pd_pm_action);			\
+	DEVICE_DT_INST_DEFINE(inst, scmi_pd_init,				\
+			      PM_DEVICE_DT_INST_GET(inst),			\
+			      NULL,						\
+			      &scmi_pd_cfg_##inst,				\
+			      PRE_KERNEL_2,					\
+			      CONFIG_POWER_DOMAIN_ARM_SCMI_INIT_PRIORITY,	\
+			      NULL);
+DT_INST_FOREACH_STATUS_OKAY(SCMI_PD_DEVICE)

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -108,6 +108,17 @@
 		};
 	};
 
+	power-domains {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		netc_mix: power-domain@12 {
+			compatible = "arm,scmi-power-domain";
+			reg = <18>;
+			#power-domain-cells = <0>;
+		};
+	};
+
 	soc {
 		itcm: itcm@0 {
 			compatible = "zephyr,memory-region", "nxp,imx-itcm";
@@ -742,6 +753,7 @@
 			reg-names = "ierb", "prb", "netcmix";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			power-domains = <&netc_mix>;
 			ranges;
 
 			netc: ethernet {
@@ -759,6 +771,7 @@
 					reg-names = "port", "pfconfig";
 					mac-index = <0>;
 					si-index = <0>;
+					power-domains = <&netc_mix>;
 					status = "disabled";
 				};
 
@@ -769,6 +782,7 @@
 					reg-names = "port", "pfconfig";
 					mac-index = <1>;
 					si-index = <1>;
+					power-domains = <&netc_mix>;
 					status = "disabled";
 				};
 
@@ -779,6 +793,7 @@
 					reg-names = "port", "pfconfig";
 					mac-index = <2>;
 					si-index = <2>;
+					power-domains = <&netc_mix>;
 					status = "disabled";
 				};
 
@@ -790,6 +805,7 @@
 					clocks = <&scmi_clk IMX95_CLK_ENET>;
 					#address-cells = <1>;
 					#size-cells = <0>;
+					power-domains = <&netc_mix>;
 					status = "disabled";
 				};
 
@@ -797,6 +813,7 @@
 					compatible = "nxp,netc-ptp-clock";
 					reg = <0x4ccc0000 0x10000>;
 					clocks = <&scmi_clk IMX95_CLK_ENET>;
+					power-domains = <&netc_mix>;
 					status = "disabled";
 				};
 			};

--- a/dts/bindings/power-domain/arm,scmi-power-domain.yaml
+++ b/dts/bindings/power-domain/arm,scmi-power-domain.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM SCMI Power Domain
+
+compatible: "arm,scmi-power-domain"
+
+include: power-domain.yaml
+
+properties:
+  reg:
+    required: true
+    description: SCMI power domain ID

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -57,6 +57,13 @@ config IDLE_STACK_SIZE
 	default 640
 endif
 
+if PM_DEVICE
+
+config POWER_DOMAIN
+	default y
+
+endif # PM_DEVICE
+
 config ROM_START_OFFSET
 	default 0x800 if BOOTLOADER_MCUBOOT
 


### PR DESCRIPTION
add scmi power domain driver, this driver take domain init and turn off/resume into its children device

Complete netc mix power off/on fucntion flow, after suspend netc mix, netc mix will power off and lost all register, after resume netc-mix, this networking can resume to continue work, ping pass.

it depend on another netc driver PR: https://github.com/zephyrproject-rtos/zephyr/pull/102369