### PR TITLE
pm: Fix possible inconsistent state

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -408,6 +408,8 @@ int pm_device_driver_init(const struct device *dev,
 int pm_device_driver_deinit(const struct device *dev,
 			    pm_device_action_cb_t action_cb)
 {
+	ARG_UNUSED(action_cb);
+
 	struct pm_device_base *pm = dev->pm_base;
 
 	return pm->state == PM_DEVICE_STATE_SUSPENDED ||

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -290,6 +290,7 @@ int pm_device_runtime_get(const struct device *dev)
 		pm->base.usage--;
 		if (domain != NULL) {
 			(void)pm_device_runtime_put(domain);
+			atomic_clear_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED);
 		}
 		goto unlock;
 	}


### PR DESCRIPTION
 * In pm_device_runtime_get, when resume fails after the domain as claimed, the flag PM_DEVICE_FLAG_PD_CLAIMED is not cleared (but the domain is released). This leaves this flag in a consistent state and in a further resume this device won't resume its domain leading to bigger problems.
 * Acknowledged unused variable in pm_device_driver_deinit