### PR TITLE
boards: seeed: xiao_nrf54l15: enable key SoC peripherals and HFXO config

### DIFF
--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
@@ -150,5 +150,31 @@ dmic_dev: &pdm20 {
 	status = "okay";
 };
 
+&hfxo {
+	load-capacitors = "internal";
+	load-capacitance-femtofarad = <16000>;
+	status = "okay";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+&temp {
+	status = "okay";
+};
+
+&radio {
+	status = "okay";
+};
+
+&nfct {
+	status = "okay";
+};
+
+&clock {
+	status = "okay";
+};
+
 /* Include default memory partition configuration file */
 #include <nordic/nrf54l15_partition.dtsi>


### PR DESCRIPTION
Enable and configure essential peripherals that are typically required for meaningful use of the XIAO nRF54L15 board, especially for wireless and sensing applications:

- Configure HFXO with internal load capacitors (16 pF) for better RF performance/stability
- Enable IEEE 802.15.4 radio support
- Enable temperature sensor
- Enable radio core
- Enable NFCT (NFC tag)
- Enable clock controller

These changes make the board usable out-of-the-box for Bluetooth LE, Thread, Matter, NFC and basic temperature monitoring use cases.