### PR TITLE
﻿boards: seeed: xiao_nrf54l15: add OpenOCD AP lock recovery

### DIFF
--- a/boards/seeed/xiao_nrf54l15/support/openocd.cfg
+++ b/boards/seeed/xiao_nrf54l15/support/openocd.cfg
@@ -67,3 +67,116 @@ proc nrf54l-load {file} {
 	mww 0x5004b500 0x101
 	load_image $file
 }
+
+# Define CTRL_AP_NUM explicitly to avoid variable errors
+set CTRL_AP_NUM 2
+
+# Custom _nrf_check_ap_lock for nRF54L (adjusted unlocked_value to 1, based on PyOCD's CSW check)
+proc _nrf_check_ap_lock { ctrl_ap_num unlocked_value } {
+    set target [target current]
+    set dap [$target cget -dap]
+    set err [catch {set APPROTECTSTATUS [$dap apreg $ctrl_ap_num 0xc]}]  ;# 0xc is ERASEPROTECTSTATUS register
+    if {$err == 0 && $APPROTECTSTATUS < $unlocked_value} {
+        echo "\[$target\] device has AP lock engaged, trying recover."
+        poll off
+        return 1
+    }
+    return 0
+}
+
+# Custom _nrf_ctrl_ap_recover for nRF54L (adjusted IDR to 0x32880000)
+proc _nrf_ctrl_ap_recover { ctrl_ap_num {is_cpunet 0} } {
+    set target [target current]
+    set dap [$target cget -dap]
+
+    set IDR [$dap apreg $ctrl_ap_num 0xfc]
+    if {$IDR != 0x32880000} {  ;# IDR for nRF54L CTRL-AP
+        echo "Error: Cannot access nRF54L CTRL-AP! (IDR: 0x$IDR)"
+        return
+    }
+
+    poll off
+
+    # Reset and trigger ERASEALL task
+    $dap apreg $ctrl_ap_num 4 0  ;# CTRL_AP_ERASEALL = 0x004
+    $dap apreg $ctrl_ap_num 4 1
+
+    # First, wait for BUSY state
+    set timeout 300  ;# ~30s
+    for {set i 0} {$i < $timeout} {incr i} {
+        set ERASEALLSTATUS [$dap apreg $ctrl_ap_num 8]
+        if {$ERASEALLSTATUS == 2} {  ;# BUSY status
+            break
+        }
+        if {$ERASEALLSTATUS == 3} {  ;# ERROR status
+            echo "Error: Erase failed with ERROR status."
+            return
+        }
+        sleep 100
+    }
+    if {$i >= $timeout} {
+        echo "Error: Timeout waiting for BUSY status."
+        return
+    }
+
+    # Then, wait for READYTORESET state
+    for {set i 0} {$i < $timeout} {incr i} {
+        set ERASEALLSTATUS [$dap apreg $ctrl_ap_num 8]
+        if {$ERASEALLSTATUS == 1} {  ;# READYTORESET status
+            echo "\[$target\] device has been successfully erased and unlocked."
+            break
+        }
+        if {$ERASEALLSTATUS == 3} {  ;# ERROR status
+            echo "Error: Erase failed with ERROR status."
+            break
+        }
+        sleep 100
+    }
+    if {$i >= $timeout} {
+        echo "Error: Timeout waiting for READYTORESET status."
+        return
+    }
+
+    # Short delay before reset
+    sleep 10
+
+    # Assert reset: write 2 then 0
+    $dap apreg $ctrl_ap_num 0 2  ;# CTRL_AP_RESET = 0x000
+    sleep 10
+    $dap apreg $ctrl_ap_num 0 0
+
+    # Reset ERASEALL task
+    $dap apreg $ctrl_ap_num 4 0
+
+    if { $is_cpunet } {
+        reset init
+    } else {
+        sleep 200  ;# Slightly increased delay
+        $target arp_examine
+        poll on
+    }
+}
+
+lappend _telnet_autocomplete_skip _nrf_check_ap_lock _nrf_ctrl_ap_recover
+
+if { ![using_hla] } {
+    # Check AP lock on examine-fail and auto-recover if locked
+    $_TARGETNAME configure -event examine-fail {
+        global CTRL_AP_NUM
+        set target [target current]
+        if { [_nrf_check_ap_lock $CTRL_AP_NUM 1] } {
+            nrf54l_mass_erase
+            $target arp_examine  ;# Re-examine after recover
+        }
+    }
+
+    # Mass erase and unlock the device using proprietary nRF CTRL-AP (AP #2)
+    proc nrf54l_mass_erase {} {
+        global CTRL_AP_NUM
+        _nrf_ctrl_ap_recover $CTRL_AP_NUM  ;# No cpunet for nRF54L
+    }
+    add_help_text nrf54l_mass_erase "Mass erase flash and unlock nRF54L device"
+}
+
+flash bank $_CHIPNAME.flash nrf5 0x00000000 0x0017D000 0 0 $_TARGETNAME
+# flash bank $_CHIPNAME.uicr nrf5 0x00FFD000 0 0 0 $_TARGETNAME


### PR DESCRIPTION
Add CTRL-AP based mass-erase recovery support for nRF54L15 to help recover AP-locked devices.

The script adds a user-facing `nrf54l_mass_erase` helper and triggers it automatically on `examine-fail` when AP lock is detected.