### PR TITLE
soc/ite/it8xxx2: put pigweed lib to ram

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -231,6 +231,14 @@ config SOC_IT8XXX2_SERIAL_IN_RAM
 	  Place serial handling (Include uart_ns16550.c and uart_ite_it8xxx2.c) code
 	  in ILM. This can improve performance.
 
+config SOC_IT8XXX2_PIGWEED_IN_RAM
+	bool "Put pigweed relative library code in RAM"
+	depends on PIGWEED_TOKENIZER && PIGWEED_LOG_TOKENIZED_LIB
+	select SOC_IT8XXX2_USE_ILM
+	select SOC_IT8XXX2_LIBRARY_TO_RAM
+	help
+	  Put pigweed relative library code in ILM. This can improve performance.
+
 config SOC_IT8XXX2_KERNEL_IN_RAM
 	bool "Place kernel handling code in RAM"
 	select SOC_IT8XXX2_USE_ILM

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -176,6 +176,12 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
 #endif
+#ifdef CONFIG_SOC_IT8XXX2_PIGWEED_IN_RAM
+			*libpw_tokenizer.a:*
+			*libpw_varint.a:*
+			*libpw_base64.a:*
+			*libpw_log_tokenized.a:*
+#endif
 #ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
 			*libkernel.a:*
 #endif
@@ -196,6 +202,12 @@ SECTIONS
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_PIGWEED_IN_RAM
+			*libpw_tokenizer.a:*
+			*libpw_varint.a:*
+			*libpw_base64.a:*
+			*libpw_log_tokenized.a:*
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
 			*libkernel.a:*
@@ -237,6 +249,20 @@ SECTIONS
 		*libdrivers__serial.a:*(.text .text.*)
 		*libdrivers__serial.a:*(.rodata .rodata.*)
 		*libdrivers__serial.a:*(.srodata .srodata.*)
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_PIGWEED_IN_RAM
+		*libpw_tokenizer.a:*(.text .text.*)
+		*libpw_tokenizer.a:*(.rodata .rodata.*)
+		*libpw_tokenizer.a:*(.srodata .srodata.*)
+		*libpw_varint.a:*(.text .text.*)
+		*libpw_varint.a:*(.rodata .rodata.*)
+		*libpw_varint.a:*(.srodata .srodata.*)
+		*libpw_base64.a:*(.text .text.*)
+		*libpw_base64.a:*(.rodata .rodata.*)
+		*libpw_base64.a:*(.srodata .srodata.*)
+		*libpw_log_tokenized.a:*(.text .text.*)
+		*libpw_log_tokenized.a:*(.rodata .rodata.*)
+		*libpw_log_tokenized.a:*(.srodata .srodata.*)
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
 		*libkernel.a:*(.text .text.*)


### PR DESCRIPTION
Some Chromebook projects use downstream third-party pigweed module to print UART log. There is an EC crash issue due to printing too much log, which affects EC performance. Therefore, put the pigweed relative library code in RAM to improve performance.