### PR TITLE
Upgrade Renesas RZ/G HAL to v3.1.0

### DIFF
--- a/drivers/adc/adc_renesas_rz.c
+++ b/drivers/adc/adc_renesas_rz.c
@@ -386,6 +386,7 @@ static int adc_rz_init(const struct device *dev)
 		.buffer_mode = ADC_C_BUFFER_MODE_1,                                                \
 		.sampling_time = 100,                                                              \
 		.external_trigger_filter = ADC_C_FILTER_STAGE_SETTING_DISABLE,                     \
+		.p_reg = (void *)DT_INST_REG_ADDR(idx),                                            \
 	};                                                                                         \
 	static const struct adc_rz_config adc_rz_config_##idx = {                                  \
 		.channel_available_mask = DT_INST_PROP(idx, channel_available_mask),               \

--- a/drivers/can/can_renesas_rz_canfd.c
+++ b/drivers/can/can_renesas_rz_canfd.c
@@ -706,7 +706,7 @@ static void can_renesas_rz_set_state_change_callback(const struct device *dev,
 		/* Clear error flags */
 		p_ctrl->p_reg->CFDC->ERFL &=
 			~(BIT(R_CANFD_CFDC_ERFL_BOEF_Pos) | BIT(R_CANFD_CFDC_ERFL_EWF_Pos) |
-			BIT(R_CANFD_CFDC_ERFL_EPF_Pos) | BIT(R_CANFD_CFDC_ERFL_BEF_Pos));
+			  BIT(R_CANFD_CFDC_ERFL_EPF_Pos) | BIT(R_CANFD_CFDC_ERFL_BEF_Pos));
 	}
 
 	data->common.state_change_cb = callback;
@@ -948,7 +948,7 @@ DEVICE_DT_DEFINE(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_rz_canfd_global), can_ren
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, ch_err, irq),                               \
 			    DT_INST_IRQ_BY_NAME(index, ch_err, priority), canfd_error_isr, NULL,   \
 			    0);                                                                    \
-	                                                                                           \
+                                                                                                   \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, ch_rec, irq));                               \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, ch_trx, irq));                               \
 		irq_enable(DT_INST_IRQ_BY_NAME(index, ch_err, irq));                               \
@@ -999,6 +999,7 @@ DEVICE_DT_DEFINE(DT_COMPAT_GET_ANY_STATUS_OKAY(renesas_rz_canfd_global), can_ren
 		.txmb_txi_enable = CANFD_CFG_TXMB_TXI_ENABLE,                                      \
 		.error_interrupts = 0U,                                                            \
 		.p_global_cfg = &g_canfd_global_cfg,                                               \
+		.p_reg = (void *)DT_REG_ADDR(DT_INST_PARENT(index)),                               \
 	};                                                                                         \
 	static can_cfg_t g_canfd_ch##index##cfg = {                                                \
 		.channel = DT_INST_PROP(index, channel),                                           \

--- a/drivers/counter/counter_renesas_rz_gtm.c
+++ b/drivers/counter/counter_renesas_rz_gtm.c
@@ -601,6 +601,7 @@ void counter_rz_gtm_ovf_isr(const struct device *dev)
 	static gtm_extended_cfg_t g_timer##inst##_extend = {                                       \
 		.generate_interrupt_when_starts = GTM_GIWS_TYPE_DISABLED,                          \
 		.gtm_mode = GTM_TIMER_MODE_FREERUN,                                                \
+		.p_reg = (void *)DT_REG_ADDR(RZ_GTM(inst)),                                        \
 	};                                                                                         \
 	static timer_cfg_t g_timer##inst##_cfg = {                                                 \
 		.mode = TIMER_MODE_PERIODIC,                                                       \

--- a/drivers/dma/dma_renesas_rz.c
+++ b/drivers/dma/dma_renesas_rz.c
@@ -766,12 +766,16 @@ static void rz_dma_err_isr(const struct device *dev)
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dma_unit),                                         \
 				(DT_INST_PROP(inst, dma_unit)), (0))
 
+#define RZ_DMA_EXT_CFG_INIT(idx, inst) [idx] = {.p_reg = (void *)DT_INST_REG_ADDR(inst)},
+
 #define DMA_RZ_INIT(inst)                                                                          \
 	static dma_instance_ctrl_t g_transfer_ctrl[DT_INST_PROP(inst, dma_channels)];              \
 	RZ_DMA_EXTERN_INFO_DECLARATION(DT_INST_PROP(inst, dma_channels));                          \
 	static transfer_info_t g_transfer_info[DT_INST_PROP(inst, dma_channels)] =                 \
 		RZ_DMA_TRANSFER_INFO_ARRAY(inst);                                                  \
-	static dma_extended_cfg_t g_transfer_extend[DT_INST_PROP(inst, dma_channels)];             \
+	static dma_extended_cfg_t g_transfer_extend[DT_INST_PROP(inst, dma_channels)] = {          \
+		LISTIFY(DT_INST_PROP(inst, dma_channels), RZ_DMA_EXT_CFG_INIT, (), inst)           \
+	};                                                                                         \
 	static struct dma_channel_data                                                             \
 		dma_rz_##inst##_channels[DT_INST_PROP(inst, dma_channels)] =                       \
 			RZ_DMA_CHANNEL_DATA_ARRAY(inst);                                           \

--- a/drivers/i2c/i2c_renesas_rz_riic.c
+++ b/drivers/i2c/i2c_renesas_rz_riic.c
@@ -580,6 +580,7 @@ static DEVICE_API(i2c, i2c_rz_riic_driver_api) = {
 		.spi_irq = DT_INST_IRQ_BY_NAME(index, spi, irq),                                   \
 		.ali_irq = DT_INST_IRQ_BY_NAME(index, ali, irq),                                   \
 		.tmoi_irq = DT_INST_IRQ_BY_NAME(index, tmoi, irq),                                 \
+		.p_reg = (void *)DT_INST_REG_ADDR(index),                                          \
 	};
 #endif /* CONFIG_I2C_RENESAS_RZ_RIIC */
 

--- a/drivers/mbox/mbox_renesas_rz_mhu.c
+++ b/drivers/mbox/mbox_renesas_rz_mhu.c
@@ -295,6 +295,9 @@ static DEVICE_API(mbox, mbox_rz_mhu_driver_api) = {
 #define MHU_RZG_CONFIG_FUNC(idx) MHU_RZG_IRQ_CONNECT(idx, mhuns, mbox_rz_mhu_isr);
 
 #define MHU_RZG_INIT(idx)                                                                          \
+	static const mhu_ns_extended_cfg_t g_mhu_ns##idx##_cfg_extend = {                          \
+		.p_reg = (void *)DT_INST_REG_ADDR(idx),                                            \
+	};                                                                                         \
 	static mhu_ns_instance_ctrl_t g_mhu_ns##idx##_ctrl;                                        \
 	static mhu_cfg_t g_mhu_ns##idx##_cfg = {                                                   \
 		.channel = DT_INST_PROP(idx, channel),                                             \
@@ -302,6 +305,7 @@ static DEVICE_API(mbox, mbox_rz_mhu_driver_api) = {
 		.rx_irq = DT_INST_IRQ_BY_NAME(idx, mhuns, irq),                                    \
 		.p_callback = mhu_ns_callback,                                                     \
 		.p_context = NULL,                                                                 \
+		.p_extend = &g_mhu_ns##idx##_cfg_extend,                                           \
 		.p_shared_memory = (void *)COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, shared_memory),  \
 		      (DT_REG_ADDR(DT_INST_PHANDLE(idx, shared_memory))), (NULL)),                 \
 	};                                                                                         \

--- a/drivers/pwm/pwm_renesas_rz_gpt.c
+++ b/drivers/pwm/pwm_renesas_rz_gpt.c
@@ -702,6 +702,7 @@ static void intc_connect_irq_event(IRQn_Type irq, IRQSELn_Type event)
 		.capture_filter_gtioca = GPT_CAPTURE_FILTER_NONE,                                  \
 		.capture_filter_gtiocb = GPT_CAPTURE_FILTER_NONE,                                  \
 		.p_pwm_cfg = NULL,                                                                 \
+		.p_reg = (void *)DT_REG_ADDR(GPT(inst)),                                           \
 	};                                                                                         \
 	static timer_cfg_t g_timer##inst##_cfg = {                                                 \
 		.mode = TIMER_MODE_PWM,                                                            \

--- a/drivers/serial/uart_renesas_rz_scif.c
+++ b/drivers/serial/uart_renesas_rz_scif.c
@@ -492,6 +492,7 @@ static int uart_rz_scif_init(const struct device *dev)
 				.de_control_pin =                                                  \
 					(bsp_io_port_pin_t)SCIF_UART_INVALID_16BIT_PARAM,          \
 			},                                                                         \
+		.p_reg = (void *)DT_INST_REG_ADDR(n),                                              \
 	};                                                                                         \
 	static uart_cfg_t g_uart##n##_cfg = {                                                      \
 		.channel = DT_INST_PROP(n, channel),                                               \

--- a/drivers/spi/spi_renesas_rz_rspi.c
+++ b/drivers/spi/spi_renesas_rz_rspi.c
@@ -717,6 +717,7 @@ static int spi_rz_rspi_init(const struct device *dev)
 		.ssl_level_keep = RSPI_SSL_LEVEL_KEEP_DISABLE,                                     \
 		.rx_trigger_level = RSPI_RX_TRIGGER_24,                                            \
 		.tx_trigger_level = RSPI_TX_TRIGGER_4,                                             \
+		.p_reg = (void *)DT_INST_REG_ADDR(n),                                              \
 	};                                                                                         \
 	IF_ENABLED(CONFIG_SPI_RENESAS_RZ_RSPI_DMAC,                                           \
 				    (RSPI_DMA_RZG_DEFINE(n, tx, TI, DT_INST_PROP(n, channel))))    \

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -212,6 +212,7 @@ static int sys_clock_driver_init(void)
 	const gtm_extended_cfg_t g_timer0_extend = {                                               \
 		.generate_interrupt_when_starts = GTM_GIWS_TYPE_DISABLED,                          \
 		.gtm_mode = GTM_TIMER_MODE_FREERUN,                                                \
+		.p_reg = (void *)DT_REG_ADDR(TIMER_NODE),                                          \
 	};                                                                                         \
                                                                                                    \
 	static timer_cfg_t g_timer0_cfg = {                                                        \

--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 14f3c2bdd307009eaf9520cdfda2cbabb81e8d10
+      revision: f30a54e266292fd0b958b49ef24eb1ca2afd1981
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Upgrade Renesas RZ/G HAL (rzg-fsp) from v2.1.0 to v3.1.0 to support new Renesas boards.
To adapt to the new version, `p_reg` member is added to extended structure and initialized with register base address from devicetree for all drivers supporting RZ/G series