### PR TITLE
Remove useless named zephyr interface library

### DIFF
--- a/lib/min_heap/CMakeLists.txt
+++ b/lib/min_heap/CMakeLists.txt
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_interface_library_named(min_heap)
-
-target_include_directories(min_heap INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-
 zephyr_library()
 
 zephyr_library_sources(min_heap.c)
-
-zephyr_library_link_libraries(min_heap)

--- a/lib/smf/CMakeLists.txt
+++ b/lib/smf/CMakeLists.txt
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_interface_library_named(smf)
-
-target_include_directories(smf INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-
 zephyr_library()
 
 zephyr_library_sources(smf.c)
-
-zephyr_library_link_libraries(smf)

--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -5,14 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# The mgmt_mcumgr is interface library for MCUmgr services.
-zephyr_interface_library_named(mgmt_mcumgr)
-
 add_subdirectory(mgmt)
 add_subdirectory(smp)
 add_subdirectory(util)
 add_subdirectory(grp)
 add_subdirectory(transport)
 add_subdirectory_ifdef(CONFIG_SMP_CLIENT    smp_client)
-
-zephyr_library_link_libraries(mgmt_mcumgr)

--- a/subsys/sd/CMakeLists.txt
+++ b/subsys/sd/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SD_STACK)
-  zephyr_interface_library_named(SD)
 
   zephyr_library()
   zephyr_library_sources(sd.c sd_ops.c)


### PR DESCRIPTION
A Zephyr interface library should be used when there exists some build information (include directories, defines, compiler flags, etc.) that should be applied to a set of Zephyr libraries.
    
Some of the named libraries don't provide any information mentioned above, now remove them to avoid confusion.