### PR TITLE
samples: net: secure_mqtt_sensor_actuator: add missing POSIX libraries

### DIFF
--- a/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
+++ b/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
@@ -7,10 +7,13 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app_mqtt, LOG_LEVEL_DBG);
 
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/mqtt.h>
 #include <zephyr/data/json.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/mqtt.h>
+#include <zephyr/posix/arpa/inet.h>
+#include <zephyr/posix/netdb.h>
+#include <zephyr/posix/poll.h>
+#include <zephyr/posix/sys/socket.h>
 #include <zephyr/random/random.h>
 
 #include "mqtt_client.h"


### PR DESCRIPTION
In order to compile the demo application for a secure MQTT connection, several networking API functions are used, which is properly defined by some of the POSIX libraries already integrated onto Zephyr project. By adding the missing libraries, compilation to the reference board adi_eval_adin1110ebz passes.

As a minor change, reordered the sequence of included libraries to be in alphabetical order.

Fixes #102372.