### PR TITLE
charger: bq2518x: support notifications

### DIFF
--- a/drivers/charger/charger_bq2518x.c
+++ b/drivers/charger/charger_bq2518x.c
@@ -64,6 +64,7 @@ enum bq2518x_device_id {
 #define BQ2518X_IC_CTRL_VLOWV_SEL_2_8            BIT(6)
 #define BQ2518X_IC_CTRL_VLOWV_SEL_3_0            0x00
 #define BQ2518X_IC_CTRL_TS_AUTO_EN               BIT(7)
+#define BQ2518X_IC_CTRL_TS_AUTO_DIS              0x00
 #define BQ2518X_SYS_REG_CTRL_OFFSET              5
 #define BQ2518X_DEVICE_ID_MSK                    GENMASK(3, 0)
 #define BQ2518X_DEVICE_ID                        0x00
@@ -351,8 +352,7 @@ static int bq2518x_init(const struct device *dev)
 	/* Setup register IC_CTRL.
 	 * Values from devicetree + device defaults
 	 */
-	val = BQ2518X_IC_CTRL_WDOG_DISABLE | BQ2518X_IC_CTRL_SAFETY_6_HOUR |
-	      BQ2518X_IC_CTRL_TS_AUTO_EN | cfg->reg_ic_ctrl;
+	val = BQ2518X_IC_CTRL_WDOG_DISABLE | BQ2518X_IC_CTRL_SAFETY_6_HOUR | cfg->reg_ic_ctrl;
 	ret = i2c_reg_write_byte_dt(&cfg->i2c, BQ2518X_IC_CTRL, val);
 	if (ret < 0) {
 		return ret;
@@ -400,7 +400,10 @@ static int bq2518x_init(const struct device *dev)
 				 : BQ2518X_IC_CTRL_VRCH_200) |                                     \
 			(DT_INST_PROP(inst, precharge_voltage_threshold_microvolt) == 2800000      \
 				 ? BQ2518X_IC_CTRL_VLOWV_SEL_2_8                                   \
-				 : BQ2518X_IC_CTRL_VLOWV_SEL_3_0),                                 \
+				 : BQ2518X_IC_CTRL_VLOWV_SEL_3_0) |                                \
+			(DT_INST_PROP_OR(inst, ntc_charger_control_disable, 0)                     \
+				 ? BQ2518X_IC_CTRL_TS_AUTO_DIS                                     \
+				 : BQ2518X_IC_CTRL_TS_AUTO_EN),                                    \
 		.reg_charge_control1 =                                                             \
 			(DT_INST_ENUM_IDX(inst, battery_discharge_current_limit_milliamp)          \
 			 << BQ2518X_CHARGE_CTRL1_DISCHARGE_OFFSET) |                               \

--- a/drivers/charger/charger_bq2518x.c
+++ b/drivers/charger/charger_bq2518x.c
@@ -129,12 +129,12 @@ static uint32_t bq2518x_ichg_to_ma(uint8_t ichg)
 static int bq2518x_mv_to_vbatreg(const struct bq2518x_config *cfg, uint32_t voltage_mv,
 				 uint8_t *vbat)
 {
-	if (!IN_RANGE(voltage_mv, BQ2518X_VOLTAGE_MIN_MV, cfg->max_voltage_microvolt)) {
+	if (!IN_RANGE(voltage_mv, BQ2518X_VOLTAGE_MIN_MV, BQ2518X_VOLTAGE_MAX_MV)) {
 		LOG_WRN("charging voltage out of range: %dmV, "
 			"clamping to the nearest limit",
 			voltage_mv);
 	}
-	voltage_mv = CLAMP(voltage_mv, BQ2518X_VOLTAGE_MIN_MV, cfg->max_voltage_microvolt);
+	voltage_mv = CLAMP(voltage_mv, BQ2518X_VOLTAGE_MIN_MV, BQ2518X_VOLTAGE_MAX_MV);
 
 	*vbat = (voltage_mv - BQ2518X_VOLTAGE_MIN_MV) / BQ2518X_FACTOR_VBAT_TO_MV;
 

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -544,6 +544,7 @@ static void max20335_int_routine_work_handler(struct k_work *work)
 		if (ret < 0) {
 			LOG_WRN("Failed to read charger status: %d", ret);
 		} else {
+			LOG_INF("Charging status: %d", data->charger_status);
 			if (data->charger_status_notifier != NULL) {
 				data->charger_status_notifier(data->charger_status);
 			}
@@ -555,6 +556,7 @@ static void max20335_int_routine_work_handler(struct k_work *work)
 		if (ret < 0) {
 			LOG_WRN("Failed to read charger online %d", ret);
 		} else {
+			LOG_INF("Online status: %d", data->charger_online);
 			if (data->charger_online_notifier != NULL) {
 				data->charger_online_notifier(data->charger_online);
 			}

--- a/drivers/charger/charger_pf1550.c
+++ b/drivers/charger/charger_pf1550.c
@@ -561,6 +561,8 @@ static void pf1550_int_routine_work_handler(struct k_work *work)
 		return;
 	}
 
+	LOG_INF("Online status: %d", data->charger_online);
+	LOG_INF("Charging status: %d", data->charger_status);
 	if (data->charger_status_notifier != NULL) {
 		data->charger_status_notifier(data->charger_status);
 	}

--- a/dts/bindings/charger/ti,bq2518x-common.yaml
+++ b/dts/bindings/charger/ti,bq2518x-common.yaml
@@ -4,6 +4,10 @@
 include: [battery.yaml, i2c-device.yaml]
 
 properties:
+  int-gpios:
+    type: phandle-array
+    description: GPIO for interrupt input
+
   constant-charge-current-max-microamp:
     type: int
     default: 0

--- a/dts/bindings/charger/ti,bq2518x-common.yaml
+++ b/dts/bindings/charger/ti,bq2518x-common.yaml
@@ -84,3 +84,9 @@ properties:
       BAT pin falls below this value, the BAT to SYS path will be disengaged.
       There is a 150 mV hysterisis before the path will be re-enabled. Default
       matches the register reset value.
+
+  ntc-charger-control-disable:
+    type: boolean
+    description: |
+      Disable thermistor control over the charger. Alerts are still generated.
+      Clears the TS_EN bit in the control register.


### PR DESCRIPTION
Add support for charging status notifications if the interrupt pin is connected to the application.

Property to disable the NTC based control of the charger.

Relax the voltage clamping applied when configuring the maximum charge voltage from software. Instead of treating the devicetree value as the top limit, allow the full IC charge range to be selected.