### PR TITLE
drivers: usb: Adjust log level for empty queue

### DIFF
--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -1235,7 +1235,7 @@ static void udc_event_xfer_in(const struct device *dev, const uint8_t ep)
 
 	buf = udc_buf_get(ep_cfg);
 	if (buf == NULL) {
-		LOG_ERR("ep 0x%02x queue is empty", ep);
+		LOG_WRN("ep 0x%02x queue is empty", ep);
 		__ASSERT_NO_MSG(false);
 		return;
 	}


### PR DESCRIPTION
Adjusting the log level from err to wrn for when the queue is empty. This is not an unrecoverable error and should therefore not be a LOG_ERR.