### PR TITLE
drivers: i2c_dw: Add SDA_HOLD tx,rx config

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -94,10 +94,14 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 #define I2C_DW_TX_WATERMARK 2
 #define I2C_DW_RX_WATERMARK 7
 
+#define SDA_HOLD_INVALID UINT32_MAX
+
 struct i2c_dw_rom_config {
 	DEVICE_MMIO_ROM;
 	i2c_isr_cb_t config_func;
 	uint32_t bitrate;
+	uint32_t sda_hold_tx;
+	uint32_t sda_hold_rx;
 	uint32_t irqnumber;
 	int16_t lcnt_offset;
 	int16_t hcnt_offset;

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -144,6 +144,16 @@ union ic_comp_param_1_register {
 	} bits;
 };
 
+/* SDAHOLD */
+union ic_sdahold_register {
+	uint32_t		raw;
+	struct {
+		uint32_t sdahold_tx : 16 __packed;
+		uint32_t sdahold_rx : 8 __packed;
+		uint32_t reserved : 8 __packed;
+	} bits;
+};
+
 #define DW_IC_REG_CON           (0x00)
 #define DW_IC_REG_TAR           (0x04)
 #define DW_IC_REG_SAR           (0x08)

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -11,6 +11,20 @@ properties:
   interrupts:
     required: true
 
+  sda-hold-tx:
+    description: |
+      This property specifies the amount of time that the SDA line is held
+      after a transmit operation. The value is in units of I2C clock cycles.
+      Valid range is 0 to 0xffff.
+    type: int
+
+  sda-hold-rx:
+    description: |
+      This property specifies the amount of time that the SDA line is held
+      after a receive operation. The value is in units of I2C clock cycles.
+      Valid range is 0 to 0xff.
+    type: int
+
   lcnt-offset:
     type: int
     description: |


### PR DESCRIPTION
Adds an optional configuration for SDA_HOLD_TX and SDA_HOLD_RX in the Designware I2C driver.

Change-Id: I0f60c4d3c69b7b8e1a593e874dea44b78d1bba13