### PR TITLE
Bluetooth: ISO: Add send_failed callback

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -182,6 +182,7 @@ New APIs and options
     * :c:func:`bt_conn_drop`
     * :c:func:`bt_le_per_adv_update_did`
     * :c:member:`bt_conn_cb.le_param_update_rejected`
+    * :c:member:`bt_iso_chan_ops.send_failed`
 
   * Mesh
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -437,6 +437,7 @@ New APIs and options
     * :c:func:`bt_conn_take`
     * :c:func:`bt_conn_drop`
     * :c:func:`bt_iso_chan_state_str`
+    * :c:member:`bt_iso_chan_ops.send_failed`
     * :c:func:`bt_iso_get_chan_by_conn`
     * :c:func:`bt_le_per_adv_update_did`
     * :c:member:`bt_le_adv_param.tx_power` and :c:enumerator:`BT_LE_ADV_OPT_TX_POWER`

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -763,6 +763,18 @@ struct bt_iso_chan_ops {
 	 * @param chan The channel which has sent data.
 	 */
 	void (*sent)(struct bt_iso_chan *chan);
+
+	/**
+	 * @brief Channel send failed callback
+	 *
+	 * This callback will be called if the call to bt_iso_chan_send() was successful, but
+	 * where the send operation later failed before the request was sent to the Bluetooth
+	 * Controller. This can happen if the @p chan has disconnected.
+	 *
+	 * @param chan The channel for which the send operation failed.
+	 * @param err The reason for the send failure.
+	 */
+	void (*send_failed)(struct bt_iso_chan *chan, int err);
 };
 
 /** @brief ISO Accept Info Structure */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -773,6 +773,18 @@ struct bt_iso_chan_ops {
 	 * @param chan The channel which has sent data.
 	 */
 	void (*sent)(struct bt_iso_chan *chan);
+
+	/**
+	 * @brief Channel send failed callback
+	 *
+	 * This callback will be called if the call to bt_iso_chan_send() was successful, but
+	 * where the send operation later failed before the request was sent to the Bluetooth
+	 * Controller. This can happen if the @p chan has disconnected.
+	 *
+	 * @param chan The channel for which the send operation failed.
+	 * @param err The reason for the send failure.
+	 */
+	void (*send_failed)(struct bt_iso_chan *chan, int err);
 };
 
 /** @brief ISO Accept Info Structure */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -107,8 +107,14 @@ static void bt_iso_sent_cb(struct bt_conn *iso, void *user_data, int err)
 
 	ops = chan->ops;
 
-	if (!err && ops != NULL && ops->sent != NULL) {
-		ops->sent(chan);
+	if (ops != NULL) {
+		if (err == 0 && ops->sent != NULL) {
+			ops->sent(chan);
+		} else if (err != 0 && ops->send_failed != NULL) {
+			ops->send_failed(chan, err);
+		} else {
+			/* no op */
+		}
 	}
 #endif /* CONFIG_BT_ISO_TX */
 }

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -122,8 +122,14 @@ static void bt_iso_sent_cb(struct bt_conn *iso, void *user_data, int err)
 
 	ops = chan->ops;
 
-	if (!err && ops != NULL && ops->sent != NULL) {
-		ops->sent(chan);
+	if (ops != NULL) {
+		if (err == 0 && ops->sent != NULL) {
+			ops->sent(chan);
+		} else if (err != 0 && ops->send_failed != NULL) {
+			ops->send_failed(chan, err);
+		} else {
+			/* no op */
+		}
 	}
 #endif /* CONFIG_BT_ISO_TX */
 }

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
@@ -132,6 +132,7 @@ static void init(void)
 		.disconnected = iso_disconnected_cb,
 		.connected = iso_connected_cb,
 		.sent = iso_tx_sent_cb,
+		.send_failed = iso_tx_send_failed_cb,
 	};
 	struct bt_le_local_features local_features;
 	int err;

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -173,6 +173,7 @@ static void init(void)
 		.connected = iso_connected,
 		.disconnected = iso_disconnected,
 		.sent = iso_tx_sent_cb,
+		.send_failed = iso_tx_send_failed_cb,
 	};
 	static struct bt_iso_chan_io_qos iso_tx = {
 		.sdu = CONFIG_BT_ISO_TX_MTU,

--- a/tests/bsim/bluetooth/host/iso/common/iso_tx.h
+++ b/tests/bsim/bluetooth/host/iso/common/iso_tx.h
@@ -69,6 +69,14 @@ bool iso_tx_can_send(const struct bt_iso_chan *iso_chan);
 void iso_tx_sent_cb(struct bt_iso_chan *iso_chan);
 
 /**
+ * @brief Callback to indicate a TX failure
+ *
+ * @param iso_chan The channel that failed TX
+ * @param err The reason for the failure
+ */
+void iso_tx_send_failed_cb(struct bt_iso_chan *iso_chan, int err);
+
+/**
  * @brief Get the number of sent SDUs for an ISO channel
  *
  * Counter will be unavailable after iso_tx_unregister()


### PR DESCRIPTION
Adds a way to handle failed ISO TXes

depends on https://github.com/zephyrproject-rtos/zephyr/pull/97365