### PR TITLE
bluetooth: mesh: Fix bearer suspend/resume state

### DIFF
--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -636,7 +636,13 @@ void bt_mesh_reset(void);
  *  If at all possible, the Friendship feature should be used instead, to
  *  make the node into a Low Power Node.
  *
- *  @return 0 on success, or (negative) error code on failure.
+ *  @note Provisioning has not been designed to be suspended. If this API is
+ *  called while provisioning is in progress, suspension is not possible and
+ *  the function returns an error.
+ *
+ *  @retval 0 Success.
+ *  @retval -EBUSY Provisioning is active.
+ *  @retval Other negative errno code on failure.
  */
 int bt_mesh_suspend(void);
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -446,6 +446,10 @@ int bt_mesh_suspend(void)
 		return -EINVAL;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_PROV) && bt_mesh_prov_active()) {
+		return -EBUSY;
+	}
+
 	if (atomic_test_and_set_bit(bt_mesh.flags, BT_MESH_SUSPENDED)) {
 		return -EALREADY;
 	}
@@ -469,13 +473,14 @@ int bt_mesh_suspend(void)
 
 	bt_mesh_access_suspend();
 
-	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		err = bt_mesh_pb_gatt_srv_disable();
-		if (err && err != -EALREADY) {
-			LOG_WRN("Disabling PB-GATT failed (err %d)", err);
-			return err;
-		}
+#if defined(CONFIG_BT_MESH_PROVISIONEE)
+	err = bt_mesh_provisionee_suspend();
+	if (err && err != -EALREADY) {
+		LOG_WRN("Suspending provisioning bearers failed (err %d)", err);
+		atomic_clear_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
+		return err;
 	}
+#endif
 
 	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 		err = bt_mesh_proxy_gatt_disable();
@@ -546,13 +551,14 @@ int bt_mesh_resume(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) && !bt_mesh_is_provisioned()) {
-		err = bt_mesh_pb_gatt_srv_enable();
-		if (err) {
-			LOG_WRN("Re-enabling PB-GATT failed (err %d)", err);
-			return err;
-		}
+#if defined(CONFIG_BT_MESH_PROVISIONEE)
+	err = bt_mesh_provisionee_resume();
+	if (err) {
+		LOG_WRN("Resuming provisioning bearers failed (err %d)", err);
+		atomic_set_bit(bt_mesh.flags, BT_MESH_SUSPENDED);
+		return err;
 	}
+#endif
 
 	bt_mesh_hb_resume();
 

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -192,6 +192,9 @@ bool bt_mesh_prov_active(void);
 
 int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, size_t size);
 
+int bt_mesh_provisionee_suspend(void);
+int bt_mesh_provisionee_resume(void);
+
 int bt_mesh_pb_remote_open(struct bt_mesh_rpr_cli *cli,
 			   const struct bt_mesh_rpr_node *srv, const uint8_t uuid[16],
 			   uint16_t net_idx, uint16_t addr);

--- a/subsys/bluetooth/mesh/provisionee.c
+++ b/subsys/bluetooth/mesh/provisionee.c
@@ -803,3 +803,75 @@ int bt_mesh_prov_disable(bt_mesh_prov_bearer_t bearers)
 
 	return 0;
 }
+
+int bt_mesh_provisionee_suspend(void)
+{
+	int err;
+
+	if (bt_mesh_is_provisioned()) {
+		/* When provisioned, only PB-Remote may be active (reprovisioning). */
+		if (IS_ENABLED(CONFIG_BT_MESH_RPR_SRV) &&
+		    (active_bearers & BT_MESH_PROV_REMOTE)) {
+			pb_remote_srv.link_cancel();
+		}
+		return 0;
+	}
+
+	/* Suspend only previously requested bearers (link_cancel / disable). */
+	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
+	    (active_bearers & BT_MESH_PROV_GATT)) {
+		err = bt_mesh_pb_gatt_srv_disable();
+		if (err && err != -EALREADY) {
+			LOG_WRN("Disabling PB-GATT failed (err %d)", err);
+			return err;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV) &&
+	    (active_bearers & BT_MESH_PROV_ADV)) {
+		bt_mesh_pb_adv.link_cancel();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_RPR_SRV) &&
+	    (active_bearers & BT_MESH_PROV_REMOTE)) {
+		pb_remote_srv.link_cancel();
+	}
+
+	return 0;
+}
+
+int bt_mesh_provisionee_resume(void)
+{
+	int err;
+
+	if (bt_mesh_is_provisioned()) {
+		/* When provisioned, only re-enable PB-Remote if it was active. */
+		if (IS_ENABLED(CONFIG_BT_MESH_RPR_SRV) &&
+		    (active_bearers & BT_MESH_PROV_REMOTE)) {
+			pb_remote_srv.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
+		}
+		return 0;
+	}
+
+	/* Re-enable only previously requested bearers (link_accept / enable). */
+	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
+	    (active_bearers & BT_MESH_PROV_GATT)) {
+		err = bt_mesh_pb_gatt_srv_enable();
+		if (err) {
+			LOG_WRN("Re-enabling PB-GATT failed (err %d)", err);
+			return err;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV) &&
+	    (active_bearers & BT_MESH_PROV_ADV)) {
+		bt_mesh_pb_adv.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_RPR_SRV) &&
+	    (active_bearers & BT_MESH_PROV_REMOTE)) {
+		pb_remote_srv.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
bt_mesh_suspend/resume now only re-enable provisioning bearers that were previously active.

Adds internal bt_mesh_provisionee_suspend/resume APIs.

bt_mesh_suspend() now return -EBUSY if provisioning is active before any
suspend actions are performed.