### PR TITLE
twister: pytest: Fix post-script calling in initialization phase

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -223,3 +223,7 @@ class DeviceAdapter(abc.ABC):
         Added to keep backward compatibility as it is used in fixtures.
         """
         return self.connections and self.connections[0].is_device_connected()
+
+    def is_reader_started(self) -> bool:
+        """Check if the reader thread is started."""
+        return self._reader_started.is_set()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -177,7 +177,9 @@ class HardwareAdapter(DeviceAdapter):
                 raise TwisterHarnessException(msg)
 
     def _close_device(self) -> None:
-        if self.device_config.post_script:
+        # Run post script only if the reader thread is started to avoid running it
+        # multiple times and when in initialization phase
+        if self.is_reader_started() and self.device_config.post_script:
             self._run_custom_script(self.device_config.post_script, self.base_timeout)
 
     @staticmethod


### PR DESCRIPTION
The post-script was being called multiple times and during the initialization phase when it should only run after the reader thread has started and the device testing is complete.

Fixes #102386