### PR TITLE
MAINTAINERS: Add edersondisouza as PMCI collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4227,6 +4227,7 @@ PMCI:
   collaborators:
     - nashif
     - kehintel
+    - edersondisouza
   files:
     - subsys/pmci/
     - samples/subsys/pmci/


### PR DESCRIPTION
Add edersondisouza as a collaborator to PMCI - it should've been done when edersondisouza was added as libmctp West module collaborator, but it was missed.