### PR TITLE
drivers: entropy + random: Add implementations for ARM64 RNG

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -460,4 +460,10 @@ config ARM64_SVE_VL_MAX
 	  limited to the specified length. Having a larger value than what
 	  the hardware supports will only waste memory.
 
+config ARM64_RNG
+	bool
+	help
+	  This option signifies that the processor has the FEAT_RNG or FEAT_RNG_TRAP
+	  extension.
+
 endif # CPU_CORTEX_A || CPU_AARCH64_CORTEX_R

--- a/cmake/compiler/gcc/target_arm64.cmake
+++ b/cmake/compiler/gcc/target_arm64.cmake
@@ -16,6 +16,12 @@ elseif(CONFIG_ARMV9_A)
   endif()
 endif()
 
+if(CONFIG_ARM64_RNG)
+  if(DEFINED GCC_M_ARCH)
+    set(GCC_M_ARCH "${GCC_M_ARCH}+rng")
+  endif()
+endif()
+
 if(DEFINED GCC_M_CPU)
   list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
   list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -363,7 +363,7 @@ static int ble_pm_action(const struct device *dev,
 
 static void rng_get_random(void *num, size_t size)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *dev = entropy_get_default_device();
 	int res;
 
 	/* try to allocate from pool */

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -13,6 +13,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE entropy_handlers.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_AMBIQ_PUF_TRNG entropy_ambiq_puf_trng.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_ARM64_RNG entropy_arm64.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BFLB_SEC_ENG entropy_bflb_sec_eng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BRCM_IPROC_RNG200 entropy_iproc_rng200.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BT_HCI entropy_bt_hci.c)

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -62,6 +62,13 @@ config ENTROPY_HAS_DRIVER
 	  This is an option to be enabled by individual entropy driver
 	  to signal that there is a true entropy driver.
 
+config ARCH_HAS_ENTROPY
+	bool
+	select ENTROPY_HAS_DRIVER
+	help
+	  This is a hidden option to indicate that the architecture supports
+	  entropy without a dedicated device.
+
 config ENTROPY_NEEDS_PRNG
 	bool
 	help

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -22,6 +22,7 @@ config ENTROPY_INIT_PRIORITY
 
 # zephyr-keep-sorted-start
 source "drivers/entropy/Kconfig.ambiq"
+source "drivers/entropy/Kconfig.arm64"
 source "drivers/entropy/Kconfig.b91"
 source "drivers/entropy/Kconfig.bflb"
 source "drivers/entropy/Kconfig.bt_hci"

--- a/drivers/entropy/Kconfig.arm64
+++ b/drivers/entropy/Kconfig.arm64
@@ -1,0 +1,29 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+config ENTROPY_ARM64_RNG
+	bool "Use ARM64 entropy driver"
+	depends on ARM64_RNG
+	select ARCH_HAS_ENTROPY
+	default y
+	help
+	  Enables the architectural entropy driver based on the RNDRRS instruction
+	  from the ARM extension FEAT_RNG.
+
+if ENTROPY_ARM64_RNG
+
+config ENTROPY_ARM64_RNG_MAX_RETRIES
+	int "Maximum number of retries for ARM64 entropy driver"
+	default 10
+	help
+	  Maximum number of consecutive RNDRRS instruction failures after which the
+	  driver should return error.
+
+config ENTROPY_ARM64_RNG_RETRY_WAIT_USEC
+	int "Retry wait time for ARM64 entropy driver"
+	default 500
+	help
+	  Number of microseconds driver should wait before retrying after RNDRRS
+	  instruction failure.
+
+endif # ENTROPY_ARM64_RNG

--- a/drivers/entropy/entropy_arm64.c
+++ b/drivers/entropy/entropy_arm64.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <zephyr/drivers/entropy.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+static int entropy_arm64_get_entropy_isr(const struct device *dev, uint8_t *buffer, uint16_t length,
+					 uint32_t flags)
+{
+	ARG_UNUSED(dev);
+
+	int max_retries =
+		(flags & ENTROPY_BUSYWAIT) == 0 ? 0 : CONFIG_ENTROPY_ARM64_RNG_MAX_RETRIES;
+	int failure_counter = 0;
+	uint16_t generated_bytes = 0;
+
+	while (length > 0) {
+		unsigned long value;
+
+		if (__builtin_aarch64_rndrrs(&value) != 0) {
+			if (++failure_counter > max_retries) {
+				break;
+			}
+			k_busy_wait(CONFIG_ENTROPY_ARM64_RNG_RETRY_WAIT_USEC);
+		} else {
+			size_t to_copy = MIN(length, sizeof(value));
+
+			memcpy(buffer, &value, to_copy);
+			buffer += to_copy;
+			length -= to_copy;
+			generated_bytes += to_copy;
+			failure_counter = 0;
+		}
+	}
+
+	return (int)generated_bytes;
+}
+
+static int entropy_arm64_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
+{
+	uint16_t generated_bytes =
+		(uint16_t)entropy_arm64_get_entropy_isr(dev, buffer, length, ENTROPY_BUSYWAIT);
+
+	return generated_bytes == length ? 0 : -ENODATA;
+}
+
+/* Entropy driver API */
+static DEVICE_API(entropy, entropy_arm64_rng_api) = {
+	.get_entropy = entropy_arm64_get_entropy,
+	.get_entropy_isr = entropy_arm64_get_entropy_isr,
+};
+
+DEVICE_DEFINE(arm64_rng_entropy_device, "ARM64_RNG_ENTROPY", NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+	      CONFIG_ENTROPY_INIT_PRIORITY, &entropy_arm64_rng_api);
+
+const struct device *const z_arch_entropy_dev = DEVICE_GET(arm64_rng_entropy_device);

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -79,6 +79,33 @@ __subsystem struct entropy_driver_api {
 /** @} */
 
 /**
+ * @brief Return the default entropy device if available.
+ *
+ * Returns in the following order:
+ *
+ * - The device chosen as "zephyr,entropy", if available.
+ * - The architectural entropy device, if enabled.
+ * - NULL.
+ *
+ * @retval Pointer to default entropy device.
+ * @retval NULL if not available.
+ */
+static inline const struct device *entropy_get_default_device(void)
+{
+	const struct device *device = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
+
+#ifdef CONFIG_ARCH_HAS_ENTROPY
+	if (device == NULL) {
+		extern const struct device *const z_arch_entropy_dev;
+
+		device = z_arch_entropy_dev;
+	}
+#endif
+
+	return device;
+}
+
+/**
  * @brief Fills a buffer with entropy. Blocks if required in order to
  *        generate the necessary random data.
  *

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -497,7 +497,7 @@ void __weak z_early_rand_get(uint8_t *buf, size_t length)
 	int rc;
 
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
-	const struct device *const entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
+	const struct device *const entropy = entropy_get_default_device();
 
 	if ((entropy != NULL) && device_is_ready(entropy)) {
 		/* Try to see if driver provides an ISR-specific API */

--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -19,7 +19,7 @@ static uint32_t next(void)
 
 void nrf_802154_random_init(void)
 {
-	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *const dev = entropy_get_default_device();
 	int err;
 
 	__ASSERT_NO_MSG(device_is_ready(dev));

--- a/modules/mbedtls/zephyr_entropy.c
+++ b/modules/mbedtls/zephyr_entropy.c
@@ -18,7 +18,7 @@ static int get_random_data(uint8_t *output, size_t output_size, bool allow_non_c
 	int ret = -EINVAL;
 
 #if defined(CONFIG_ENTROPY_HAS_DRIVER)
-	static const struct device *const entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *const entropy_dev = entropy_get_default_device();
 
 	if (!device_is_ready(entropy_dev)) {
 		return -ENODEV;

--- a/samples/boards/st/power_mgmt/suspend_to_ram/src/main.c
+++ b/samples/boards/st/power_mgmt/suspend_to_ram/src/main.c
@@ -220,7 +220,7 @@ int main(void)
 {
 	__ASSERT_NO_MSG(gpio_is_ready_dt(&led));
 
-	rng_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	rng_dev = entropy_get_default_device();
 	if (!device_is_ready(rng_dev)) {
 		printk("error: random device not ready");
 	}

--- a/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
+++ b/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(sys_wireless_plat);
 
 RAMCFG_HandleTypeDef hramcfg_SRAM1;
-const struct device *rng_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+const struct device *rng_dev;
 
 struct entropy_stm32_rng_dev_data {
 	RNG_TypeDef *rng;
@@ -37,7 +37,7 @@ void BLEPLAT_Init(void)
 {
 	BPKA_Reset();
 
-	rng_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	rng_dev = entropy_get_default_device();
 	if (!device_is_ready(rng_dev)) {
 		LOG_ERR("error: random device not ready");
 	}

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -50,7 +50,7 @@ static struct {
 } event;
 
 /* Entropy device */
-static const struct device *const dev_entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *dev_entropy;
 
 static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -120,6 +120,8 @@ static void swi_ull_low_rv32m1_isr(const void *arg)
 int lll_init(void)
 {
 	int err;
+
+	dev_entropy = entropy_get_default_device();
 
 	/* Check if entropy device is ready */
 	if (!device_is_ready(dev_entropy)) {

--- a/subsys/portability/posix/c_lib_ext/getentropy.c
+++ b/subsys/portability/posix/c_lib_ext/getentropy.c
@@ -10,11 +10,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/posix/unistd.h>
 
-#define ENTROPY_NODE DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy))
-
 int getentropy(void *buffer, size_t length)
 {
-	const struct device *const entropy = ENTROPY_NODE;
+	const struct device *const entropy = entropy_get_default_device();
 
 	if (!buffer) {
 		errno = EFAULT;

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_TIMER_RANDOM_GENERATOR          random_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XOSHIRO_RANDOM_GENERATOR        random_xoshiro128.c)
+zephyr_library_sources_ifdef(CONFIG_ARM64_RANDOM_GENERATOR          random_arm64.c)
 zephyr_library_sources_ifdef(CONFIG_TEST_CSPRNG_GENERATOR           random_test_csprng.c)
 
 if(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR CONFIG_HARDWARE_DEVICE_CS_GENERATOR)

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -38,10 +38,11 @@ config TIMER_RANDOM_INITIAL_STATE
 
 choice RNG_GENERATOR_CHOICE
 	prompt "Random generator"
+	default ARM64_RANDOM_GENERATOR if ARM64_RNG
 	default ENTROPY_DEVICE_RANDOM_GENERATOR if ENTROPY_HAS_DRIVER && !ENTROPY_NEEDS_PRNG
 	default XOSHIRO_RANDOM_GENERATOR if ENTROPY_HAS_DRIVER && ENTROPY_NEEDS_PRNG
 	default TIMER_RANDOM_GENERATOR if TEST_RANDOM_GENERATOR
-	depends on ENTROPY_HAS_DRIVER || TEST_RANDOM_GENERATOR
+	depends on ENTROPY_HAS_DRIVER || TEST_RANDOM_GENERATOR || ARM64_RNG
 	help
 	  Platform dependent non-cryptographically secure random number support.
 
@@ -74,8 +75,33 @@ config XOSHIRO_RANDOM_GENERATOR
 	  the entropy driver as a seed source. This is a fast general-purpose
 	  non-cryptographically secure random number generator.
 
+config ARM64_RANDOM_GENERATOR
+	bool "Use ARM64 PRNG"
+	depends on ARM64_RNG
+	help
+	  Enables the pseudo-random number generator based on the RNDR instruction
+	  from the ARM extension FEAT_RNG.
+
 endchoice # RNG_GENERATOR_CHOICE
 
+if ARM64_RANDOM_GENERATOR
+
+config ARM64_RANDOM_GENERATOR_MAX_RETRIES
+	int "Maximum number of retries for ARM64 random generator"
+	default 10
+	help
+	  Maximum number of consecutive RNDR instruction failures after which the
+	  random generator gives up. Since we cannot return error, we panic the
+	  kernel.
+
+config ARM64_RANDOM_GENERATOR_RETRY_WAIT_USEC
+	int "Retry wait time for ARM64 random generator"
+	default 500
+	help
+	  Number of microseconds generator should wait before retrying after RNDR
+	  instruction failure.
+
+endif # ARM64_RANDOM_GENERATOR
 
 DT_CHOSEN_Z_ENTROPY := zephyr,entropy
 config ENTROPY_NODE_ENABLED

--- a/subsys/random/random_arm64.c
+++ b/subsys/random/random_arm64.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+void z_impl_sys_rand_get(void *dst, size_t outlen)
+{
+	uint8_t *_dst = (uint8_t *)dst;
+	int failure_counter = 0;
+
+	while (outlen > 0) {
+		unsigned long value;
+
+		if (__builtin_aarch64_rndr(&value) != 0) {
+			if (++failure_counter > CONFIG_ARM64_RANDOM_GENERATOR_MAX_RETRIES) {
+				__ASSERT_PRINT("ARM64 RNDR keeps failing\n");
+				k_panic();
+			}
+			k_usleep(CONFIG_ARM64_RANDOM_GENERATOR_RETRY_WAIT_USEC);
+		} else {
+			size_t to_copy = MIN(outlen, sizeof(value));
+
+			memcpy(_dst, &value, to_copy);
+			_dst += to_copy;
+			outlen -= to_copy;
+			failure_counter = 0;
+		}
+	}
+}

--- a/subsys/random/random_entropy_device.c
+++ b/subsys/random/random_entropy_device.c
@@ -9,13 +9,11 @@
 #include <zephyr/drivers/entropy.h>
 #include <string.h>
 
-static const struct device *const entropy_dev =
-	DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
-
 static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 {
 	uint32_t random_num;
 	int ret;
+	const struct device *const entropy_dev = entropy_get_default_device();
 
 	if (!device_is_ready(entropy_dev)) {
 		return -ENODEV;

--- a/subsys/random/random_xoshiro128.c
+++ b/subsys/random/random_xoshiro128.c
@@ -32,8 +32,6 @@
 #include <zephyr/kernel.h>
 #include <string.h>
 
-static const struct device *const entropy_driver =
-	DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static uint32_t state[4];
 static bool initialized;
 
@@ -45,6 +43,7 @@ static inline uint32_t rotl(const uint32_t x, int k)
 static void xoshiro128_init_state(void)
 {
 	int rc;
+	const struct device *const entropy_driver = entropy_get_default_device();
 
 	/* This is not thread safe but it doesn't matter as we will just end
 	 * up with a mix of random bytes from both threads.

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(test);
 
 static bool test_end;
 
-static const struct device *const entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *entropy;
 static const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 static struct onoff_manager *hf_mgr;
 static struct onoff_client cli;
@@ -30,6 +30,8 @@ static uint32_t iteration;
 
 static void *setup(void)
 {
+	entropy = entropy_get_default_device();
+
 	zassert_true(device_is_ready(entropy));
 	zassert_true(device_is_ready(clock_dev));
 

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -75,7 +75,7 @@ static int random_entropy(const struct device *dev, char *buffer, char num)
  */
 static int get_entropy(void)
 {
-	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *const dev = entropy_get_default_device();
 	int ret;
 
 	if (!device_is_ready(dev)) {


### PR DESCRIPTION
Add new implementations for entropy driver and random subsystem based on ARM64 RNDRRS and RNDR instructions.

The sys_rand_get API does not return an error, so I can only panic if RNDR keeps failing.

Since the entropy source is chosen via the device tree, I have to add an entry for this in order to be able to select it, even if that is empty. This outputs the following warning during builds:
"/home/cbusold/zephyr-upstream/build/zephyr/zephyr.dts:98.12-101.5: Warning (simple_bus_reg): /soc/rng: missing or empty reg/ranges property"
Is there a better way? The PSA entropy driver seems to do the same.

Finally, to test this on QEMU we need a newer core than the Cortex A53 core which is currently available. Can we update this to A510 or newer?