### PR TITLE
pm: Fixes in headers

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -163,7 +163,7 @@ bool pm_device_runtime_is_enabled(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @returns the current usage counter.
+ * @retval The current usage counter.
  * @retval -ENOTSUP If the device is not using runtime PM.
  * @retval -ENOSYS If the runtime PM is not enabled at all.
  */

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -91,7 +91,7 @@ int pm_device_runtime_disable(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
- * @retval -EWOUDBLOCK If call would block but it is not allowed (e.g. in ISR).
+ * @retval -EWOULDBLOCK If call would block but it is not allowed (e.g. in ISR).
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -302,16 +302,16 @@ static inline bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t s
 	return false;
 }
 
-static inline void pm_policy_event_register(struct pm_policy_event *evt, uint32_t cycle)
+static inline void pm_policy_event_register(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
 	ARG_UNUSED(evt);
-	ARG_UNUSED(cycle);
+	ARG_UNUSED(uptime_ticks);
 }
 
-static inline void pm_policy_event_update(struct pm_policy_event *evt, uint32_t cycle)
+static inline void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
 	ARG_UNUSED(evt);
-	ARG_UNUSED(cycle);
+	ARG_UNUSED(uptime_ticks);
 }
 
 static inline void pm_policy_event_unregister(struct pm_policy_event *evt)

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -499,8 +499,8 @@ static inline const struct pm_state_info *pm_state_get(uint8_t cpu,
 	return NULL;
 }
 
-static inline bool pm_state_in_constraints(struct pm_state_constraints *constraints,
-					   struct pm_state_constraint match)
+static inline bool pm_state_in_constraints(const struct pm_state_constraints *constraints,
+					   const struct pm_state_constraint match)
 {
 	ARG_UNUSED(constraints);
 	ARG_UNUSED(match);


### PR DESCRIPTION
Fixes for:

- API signature inconsistencies (when PM is disabled)
- Fix doxygen return value in pm_device_runtime_is_enabled
- Fix a typo in a return value in pm_device_runtime_get