### PR TITLE
subsys: console: add functions to set the timeout

### DIFF
--- a/include/zephyr/console/console.h
+++ b/include/zephyr/console/console.h
@@ -110,6 +110,28 @@ void console_getline_init(void);
  */
 char *console_getline(void);
 
+/**
+ * @brief Set receive timeout for console operations.
+ *
+ * Set timeout for console_getchar() and console_read() operations.
+ * Default timeout after initialization is K_FOREVER.
+ *
+ * @param timeout Maximum time to wait when reading.
+ */
+void console_set_rx_timeout(k_timeout_t timeout);
+
+
+/**
+ * @brief Set transmit timeout for console operations.
+ *
+ * Set timeout for console_putchar() and console_write() operations, for
+ * a case when output buffer is full.
+ * Default timeout after initialization is K_FOREVER.
+ *
+ * @param timeout Maximum time to wait when writing.
+ */
+void console_set_tx_timeout(k_timeout_t timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/console/tty.h
+++ b/include/zephyr/console/tty.h
@@ -22,13 +22,13 @@ struct tty_serial {
 	uint8_t *rx_ringbuf;
 	uint32_t rx_ringbuf_sz;
 	uint16_t rx_get, rx_put;
-	int32_t rx_timeout;
+	k_timeout_t rx_timeout;
 
 	struct k_sem tx_sem;
 	uint8_t *tx_ringbuf;
 	uint32_t tx_ringbuf_sz;
 	uint16_t tx_get, tx_put;
-	int32_t tx_timeout;
+	k_timeout_t tx_timeout;
 };
 
 /**
@@ -62,7 +62,7 @@ int tty_init(struct tty_serial *tty, const struct device *uart_dev);
  */
 static inline void tty_set_rx_timeout(struct tty_serial *tty, int32_t timeout)
 {
-	tty->rx_timeout = timeout;
+	tty->rx_timeout = SYS_TIMEOUT_MS(timeout);
 }
 
 /**
@@ -76,7 +76,7 @@ static inline void tty_set_rx_timeout(struct tty_serial *tty, int32_t timeout)
  */
 static inline void tty_set_tx_timeout(struct tty_serial *tty, int32_t timeout)
 {
-	tty->tx_timeout = timeout;
+	tty->tx_timeout = SYS_TIMEOUT_MS(timeout);
 }
 
 /**

--- a/subsys/console/getchar.c
+++ b/subsys/console/getchar.c
@@ -47,6 +47,16 @@ int console_getchar(void)
 	return c;
 }
 
+void console_set_rx_timeout(k_timeout_t timeout)
+{
+	console_serial.rx_timeout = timeout;
+}
+
+void console_set_tx_timeout(k_timeout_t timeout)
+{
+	console_serial.tx_timeout = timeout;
+}
+
 int console_init(void)
 {
 	const struct device *uart_dev;


### PR DESCRIPTION
While the tty_* api already has functions
to set the rx and the tx timeout, the console_*
api didn't had one.


use k_timeout_t internally, that way
the timeout has only to be calculated, when setting it and not everytime when it is used.

Also use the ys_timepoint* api instead of
counting the ms.
