### PR TITLE
tests: spi: disable mx25r64 flash for nRF54L15DK SPI loopback test

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -9,7 +9,6 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_MISO, 2, 9)>;
 		};
-
 		group2 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
 				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
@@ -27,7 +26,9 @@
 	};
 };
 
-/delete-node/ &mx25r64;
+&mx25r64 {
+	status = "disabled";
+};
 
 &spi00 {
 	status = "okay";
@@ -36,13 +37,11 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
-
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 	};
-
 	dut_fast: fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;


### PR DESCRIPTION
The test overlay attempts to delete the mx25r64 flash node using '/delete-node/ &mx25r64', but this causes a devicetree parse error on nRF54L15DK:

  devicetree error: undefined node label 'mx25r64'

The mx25r64 label is not visible during overlay parsing due to devicetree include ordering. Replace the '/delete-node/' directive with 'status = "disabled"' to properly disable the flash chip and allow the SPI loopback test devices exclusive access to the SPI bus.

Fixes build of tests/drivers/spi/spi_loopback for nRF54L15DK.