### PR TITLE
subsys: random: Small fixes

### DIFF
--- a/subsys/random/random_ctr_drbg.c
+++ b/subsys/random/random_ctr_drbg.c
@@ -62,7 +62,7 @@ static int ctr_drbg_initialize(void)
 }
 
 
-int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
+int z_impl_sys_csrand_get(void *dst, size_t outlen)
 {
 	int ret;
 

--- a/subsys/random/random_entropy_device.c
+++ b/subsys/random/random_entropy_device.c
@@ -17,8 +17,9 @@ static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 	uint32_t random_num;
 	int ret;
 
-	__ASSERT(device_is_ready(entropy_dev), "Entropy device %s not ready",
-		 entropy_dev->name);
+	if (!device_is_ready(entropy_dev)) {
+		return -ENODEV;
+	}
 
 	ret = entropy_get_entropy(entropy_dev, dst, outlen);
 


### PR DESCRIPTION
- Fix sys_csrand_get signature in random_ctr_drbg implementation
- Always check if the device is ready in the device_entropy implementation (instead of using __ASSERT)