### PR TITLE
doc: add license/terms to external module template

### DIFF
--- a/doc/develop/manifest/external/external.rst.tmpl
+++ b/doc/develop/manifest/external/external.rst.tmpl
@@ -6,7 +6,7 @@
 Introduction
 ************
 
-Short intro into the module and how it relates to Zephyr.
+Short intro into the module, how it relates to Zephyr, and the license/terms of use.
 
 Usage with Zephyr
 *****************


### PR DESCRIPTION
It is important to include license and terms of use information in the documentation for external modules. This helps users understand their rights and obligations when using these modules within the Zephyr project.