### PR TITLE
bluetooth: audio: Fix redundant initialization

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -315,7 +315,6 @@ static struct obj_t obj = {
 	.selected_id = 0,
 	.add_type = MPL_OBJ_NONE,
 	.add_track = NULL,
-	.add_group = NULL,
 	.content = NET_BUF_SIMPLE(CONFIG_BT_MPL_MAX_OBJ_SIZE),
 };
 


### PR DESCRIPTION
When building the bluetooth.general.tester_le_audio test with clang and
-Winitializer-overrides, it warns:

subsys/bluetooth/audio/mpl.c:318:2: error: initializer overrides prior
initialization of this subobject [-Werror,-Winitializer-overrides]
  318 |         .add_group = NULL,
      |         ^~~~~~~~~~~~~~~~~
subsys/bluetooth/audio/mpl.c:317:15: note: previous initialization is here
  317 |         .add_track = NULL,
      |                      ^~~~

Remove redundant initializer for add_group which overlaps with add_track
in an anonymous union.