### PR TITLE
llext: sys_mem_blocks as optional alt backing data struct for heap

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -90,6 +90,17 @@ struct llext_loader;
 /** Maximum number of dependency LLEXTs */
 #define LLEXT_MAX_DEPENDENCIES 8
 
+#ifdef CONFIG_LLEXT_HEAP_MEMBLK
+struct llext_alloc {
+	int num_blocks;
+	void *memblk_ptr;
+};
+struct llext_alloc_map {
+	int idx;
+	struct llext_alloc map[LLEXT_MEM_COUNT];
+};
+#endif
+
 /**
  * @brief Structure describing a linkable loadable extension
  *
@@ -114,6 +125,10 @@ struct llext {
 
 	/** Is the memory for this region allocated on heap? */
 	bool mem_on_heap[LLEXT_MEM_COUNT];
+
+#ifdef CONFIG_LLEXT_HEAP_MEMBLK
+	struct llext_alloc_map mem_alloc_map;
+#endif
 
 	/** Size of each stored region */
 	size_t mem_size[LLEXT_MEM_COUNT];

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -483,7 +483,7 @@ int llext_relink_dependency(struct llext *ext, unsigned int n_ext);
  * During suspend the user has saved all the extension and loader descriptors
  * and related objects and called @ref llext_relink_dependency() to prepare
  * dependency pointers.
- * When resuming llext_alloc_data() has to be used to re-allocate all the objects,
+ * When resuming llext_alloc_metadata() has to be used to re-allocate all the objects,
  * therefore the user needs support from LLEXT core to accomplish that.
  * This function takes arrays of pointers to saved copies of extensions and
  * loaders as arguments and re-allocates all the objects, while also adding them

--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_LLEXT)
   zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM fs_loader.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_SHELL shell.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_EXPERIMENTAL llext_experimental.c)
+  zephyr_library_sources_ifdef(CONFIG_LLEXT_HEAP_K_HEAP llext_kheap.c)
 
   if(CONFIG_RISCV AND CONFIG_USERSPACE)
     message(WARNING "Running LLEXT extensions from user-space threads on RISC-V is not supported!")

--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -19,6 +19,7 @@ if(CONFIG_LLEXT)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_SHELL shell.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_EXPERIMENTAL llext_experimental.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_HEAP_K_HEAP llext_kheap.c)
+  zephyr_library_sources_ifdef(CONFIG_LLEXT_HEAP_MEMBLK llext_memblk.c)
 
   if(CONFIG_RISCV AND CONFIG_USERSPACE)
     message(WARNING "Running LLEXT extensions from user-space threads on RISC-V is not supported!")

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -55,6 +55,24 @@ config LLEXT_HEAP_DYNAMIC
 	  does not need LLEXT functionality any more, it should call llext_heap_uninit(),
 	  which releases control of the buffer back to the application.
 
+choice LLEXT_HEAP_MANAGEMENT
+	prompt "llext heap memory management"
+	default LLEXT_HEAP_K_HEAP
+	help
+	  Select the memory management API used to store extension regions in
+	  LLEXT heap memory. This choice does not affect LLEXT metadata, which is always
+	  managed with k_heap.
+
+config LLEXT_HEAP_K_HEAP
+	bool "Use k_heap"
+	help
+	  Use the k_heap API to manage LLEXT heap memory for extension regions.
+	  k_heap allocates additional memory for bookkeeping data after the
+	  requested allocation, which increases the memory overhead slightly
+	  and may cause misalignment with MPU regions.
+
+endchoice
+
 config LLEXT_HEAP_SIZE
 	int "llext heap memory size in kilobytes"
 	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD
@@ -63,20 +81,19 @@ config LLEXT_HEAP_SIZE
 	  Heap size in kilobytes available to llext for dynamic allocation
 
 config LLEXT_INSTR_HEAP_SIZE
-	int "llext ICCM heap memory size in kilobytes"
+	int "llext instruction heap memory size in kilobytes"
 	depends on !LLEXT_HEAP_DYNAMIC && HARVARD
 	default 4
 	help
-	  ICCM heap size in kilobytes available to llext for dynamic allocation.
+	  Instruction heap size in kilobytes available to llext.
 	  Only executable sections will be placed in this heap.
 
 config LLEXT_DATA_HEAP_SIZE
-	int "llext DCCM heap memory size in kilobytes"
+	int "llext data heap memory size in kilobytes"
 	depends on !LLEXT_HEAP_DYNAMIC && HARVARD
 	default 8
 	help
-	  DCCM heap size in kilobytes available to llext for dynamic allocation.
-	  Extension data and metadata will be placed in this heap.
+	  Data heap size in kilobytes available to llext.
 
 config LLEXT_BUILD_PIC
 	bool "Use -fPIC when building LLEXT"

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -71,11 +71,49 @@ config LLEXT_HEAP_K_HEAP
 	  requested allocation, which increases the memory overhead slightly
 	  and may cause misalignment with MPU regions.
 
+config LLEXT_HEAP_MEMBLK
+	bool "Use sys_mem_blocks"
+	depends on !LLEXT_HEAP_DYNAMIC
+	select SYS_MEM_BLOCKS
+	help
+	  Use sys_mem_blocks API to manage LLEXT heap memory for extension regions.
+	  A minimum of one block will be allocated per region. Block size must be
+	  selected with care to ensure proper alignment for extension regions.
+
 endchoice
+
+if LLEXT_HEAP_MEMBLK
+
+config LLEXT_METADATA_HEAP_SIZE
+	int "llext metadata heap memory size in kilobytes"
+	default 4
+	help
+	  Heap size in kilobytes available for LLEXT metadata.
+
+config LLEXT_EXT_HEAP_SIZE
+	int "llext extension heap memory size in kilobytes"
+	depends on !HARVARD
+	default 16
+	help
+	  Heap size in kilobytes available for LLEXT extension data. Must be a multiple of
+	  LLEXT_HEAP_MEMBLK_BLOCK_SIZE. Replaced by LLEXT_INSTR_HEAP_SIZE and
+	  LLEXT_DATA_HEAP_SIZE if HARVARD is selected.
+
+config LLEXT_HEAP_MEMBLK_BLOCK_SIZE
+	int "llext sys_mem_blocks block size in bytes"
+	default 32
+	help
+	  Block size in bytes for LLEXT sys_mem_blocks heap(s). Must be equal to or
+	  a multiple of LLEXT_PAGE_SIZE. The block size must also be equal to or a
+	  multiple of the largest alignment needed for any extension region.
+	  If MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT is selected and regions are large,
+	  an unreasonably large block size may be needed to satisfy alignment requirements.
+
+endif
 
 config LLEXT_HEAP_SIZE
 	int "llext heap memory size in kilobytes"
-	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD
+	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD && !LLEXT_HEAP_MEMBLK
 	default 8
 	help
 	  Heap size in kilobytes available to llext for dynamic allocation

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -179,7 +179,7 @@ int llext_load(struct llext_loader *ldr, const char *name, struct llext **ext,
 		goto out;
 	}
 
-	*ext = llext_alloc_data(sizeof(struct llext));
+	*ext = llext_alloc_metadata(sizeof(struct llext));
 	if (*ext == NULL) {
 		LOG_ERR("Not enough memory for extension metadata");
 		ret = -ENOMEM;
@@ -188,7 +188,7 @@ int llext_load(struct llext_loader *ldr, const char *name, struct llext **ext,
 
 	ret = do_llext_load(ldr, *ext, ldr_parm);
 	if (ret < 0) {
-		llext_free(*ext);
+		llext_free_metadata(*ext);
 		*ext = NULL;
 		goto out;
 	}
@@ -238,13 +238,13 @@ int llext_unload(struct llext **ext)
 	k_mutex_unlock(&llext_lock);
 
 	if (tmp->sect_hdrs_on_heap) {
-		llext_free(tmp->sect_hdrs);
+		llext_free_metadata(tmp->sect_hdrs);
 	}
 
 	llext_free_regions(tmp);
-	llext_free(tmp->sym_tab.syms);
-	llext_free(tmp->exp_tab.syms);
-	llext_free(tmp);
+	llext_free_metadata(tmp->sym_tab.syms);
+	llext_free_metadata(tmp->exp_tab.syms);
+	llext_free_metadata(tmp);
 
 	return 0;
 }

--- a/subsys/llext/llext_kheap.c
+++ b/subsys/llext/llext_kheap.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "llext_kheap.h"
+
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+#ifdef CONFIG_HARVARD
+struct k_heap llext_instr_heap;
+struct k_heap llext_data_heap;
+#else
+struct k_heap llext_heap;
+#endif
+#else /* !CONFIG_LLEXT_HEAP_DYNAMIC */
+#ifdef CONFIG_HARVARD
+Z_HEAP_DEFINE_IN_SECT(llext_instr_heap, (CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1)),
+		      __attribute__((section(".rodata.llext_instr_heap"))));
+Z_HEAP_DEFINE_IN_SECT(llext_data_heap, (CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1)),
+		      __attribute__((section(".data.llext_data_heap"))));
+#else /* !CONFIG_HARVARD */
+K_HEAP_DEFINE(llext_heap, CONFIG_LLEXT_HEAP_SIZE * KB(1));
+#endif
+#endif /* CONFIG_LLEXT_HEAP_DYNAMIC */

--- a/subsys/llext/llext_kheap.h
+++ b/subsys/llext/llext_kheap.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LLEXT_KHEAP_H_
+#define ZEPHYR_SUBSYS_LLEXT_KHEAP_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/llext/llext.h>
+
+#ifdef CONFIG_HARVARD
+extern struct k_heap llext_instr_heap;
+extern struct k_heap llext_data_heap;
+#define llext_metadata_heap llext_data_heap
+#else
+extern struct k_heap llext_heap;
+#define llext_instr_heap    llext_heap
+#define llext_data_heap     llext_heap
+#define llext_metadata_heap llext_heap
+#endif /* CONFIG_HARVARD */
+
+static inline bool llext_heap_is_inited(void)
+{
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+	extern bool llext_heap_inited;
+
+	return llext_heap_inited;
+#else
+	return true;
+#endif
+}
+
+static inline void *llext_alloc_metadata(size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return k_heap_alloc(&llext_metadata_heap, bytes, K_NO_WAIT);
+	}
+
+	return NULL;
+}
+
+static inline void *llext_aligned_alloc_data(struct llext *ext, size_t align, size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return k_heap_aligned_alloc(&llext_data_heap, align, bytes, K_NO_WAIT);
+	}
+
+	return NULL;
+}
+
+static inline void *llext_aligned_alloc_instr(struct llext *ext, size_t align, size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return k_heap_aligned_alloc(&llext_instr_heap, align, bytes, K_NO_WAIT);
+	}
+
+	return NULL;
+}
+
+static inline void llext_free_metadata(void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		k_heap_free(&llext_metadata_heap, ptr);
+	}
+}
+
+static inline void llext_free_data(struct llext *ext, void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		k_heap_free(&llext_data_heap, ptr);
+	}
+}
+
+static inline void llext_free_instr(struct llext *ext, void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		k_heap_free(&llext_instr_heap, ptr);
+	}
+}
+
+static inline void llext_heap_reset(struct llext *ext)
+{
+	ARG_UNUSED(ext);
+}
+
+#endif /* ZEPHYR_SUBSYS_LLEXT_KHEAP_H_ */

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -107,7 +107,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 
 	size_t sect_map_sz = ext->sect_cnt * sizeof(ldr->sect_map[0]);
 
-	ldr->sect_map = llext_alloc_data(sect_map_sz);
+	ldr->sect_map = llext_alloc_metadata(sect_map_sz);
 	if (!ldr->sect_map) {
 		LOG_ERR("Failed to allocate section map, size %zu", sect_map_sz);
 		return -ENOMEM;
@@ -125,7 +125,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 		size_t sect_hdrs_sz = ext->sect_cnt * sizeof(ext->sect_hdrs[0]);
 
 		ext->sect_hdrs_on_heap = true;
-		ext->sect_hdrs = llext_alloc_data(sect_hdrs_sz);
+		ext->sect_hdrs = llext_alloc_metadata(sect_hdrs_sz);
 		if (!ext->sect_hdrs) {
 			LOG_ERR("Failed to allocate section headers, size %zu", sect_hdrs_sz);
 			return -ENOMEM;
@@ -611,7 +611,7 @@ static int llext_allocate_symtab(struct llext_loader *ldr, struct llext *ext)
 	struct llext_symtable *sym_tab = &ext->sym_tab;
 	size_t syms_size = sym_tab->sym_cnt * sizeof(struct llext_symbol);
 
-	sym_tab->syms = llext_alloc_data(syms_size);
+	sym_tab->syms = llext_alloc_metadata(syms_size);
 	if (!sym_tab->syms) {
 		return -ENOMEM;
 	}
@@ -644,7 +644,7 @@ static int llext_export_symbols(struct llext_loader *ldr, struct llext *ext,
 		return 0;
 	}
 
-	exp_tab->syms = llext_alloc_data(exp_tab->sym_cnt * sizeof(struct llext_symbol));
+	exp_tab->syms = llext_alloc_metadata(exp_tab->sym_cnt * sizeof(struct llext_symbol));
 	if (!exp_tab->syms) {
 		return -ENOMEM;
 	}
@@ -895,7 +895,7 @@ out:
 	 * is enabled and no error is detected.
 	 */
 	if (!(IS_ENABLED(CONFIG_LLEXT_LOG_LEVEL_DBG) && ret == 0)) {
-		llext_free(ext->sym_tab.syms);
+		llext_free_metadata(ext->sym_tab.syms);
 		ext->sym_tab.sym_cnt = 0;
 		ext->sym_tab.syms = NULL;
 	}
@@ -908,7 +908,7 @@ out:
 		 * such as regions and exported symbols.
 		 */
 		llext_free_regions(ext);
-		llext_free(ext->exp_tab.syms);
+		llext_free_metadata(ext->exp_tab.syms);
 		ext->exp_tab.sym_cnt = 0;
 		ext->exp_tab.syms = NULL;
 	} else {
@@ -925,7 +925,7 @@ int llext_free_inspection_data(struct llext_loader *ldr, struct llext *ext)
 {
 	if (ldr->sect_map) {
 		ext->alloc_size -= ext->sect_cnt * sizeof(ldr->sect_map[0]);
-		llext_free(ldr->sect_map);
+		llext_free_metadata(ldr->sect_map);
 		ldr->sect_map = NULL;
 	}
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -17,33 +17,10 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 #include <string.h>
 
 #include "llext_priv.h"
-
-#ifdef CONFIG_MMU_PAGE_SIZE
-#define LLEXT_PAGE_SIZE CONFIG_MMU_PAGE_SIZE
-#elif CONFIG_ARC_MPU_VER == 2
-#define LLEXT_PAGE_SIZE 2048
-#else
-/* Arm and non-v2 ARC MPUs want a 32 byte minimum MPU region */
-#define LLEXT_PAGE_SIZE 32
-#endif
+#include "llext_mem.h"
 
 #ifdef CONFIG_LLEXT_HEAP_DYNAMIC
-#ifdef CONFIG_HARVARD
-struct k_heap llext_instr_heap;
-struct k_heap llext_data_heap;
-#else
-struct k_heap llext_heap;
-#endif
 bool llext_heap_inited;
-#else
-#ifdef CONFIG_HARVARD
-Z_HEAP_DEFINE_IN_SECT(llext_instr_heap, (CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1)),
-		      __attribute__((section(".rodata.llext_instr_heap"))));
-Z_HEAP_DEFINE_IN_SECT(llext_data_heap, (CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1)),
-		      __attribute__((section(".data.llext_data_heap"))));
-#else
-K_HEAP_DEFINE(llext_heap, CONFIG_LLEXT_HEAP_SIZE * KB(1));
-#endif
 #endif
 
 /*
@@ -181,9 +158,9 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 
 	/* Allocate a suitably aligned area for the region. */
 	if (region->sh_flags & SHF_EXECINSTR) {
-		ext->mem[mem_idx] = llext_aligned_alloc_instr(region_align, region_alloc);
+		ext->mem[mem_idx] = llext_aligned_alloc_instr(ext, region_align, region_alloc);
 	} else {
-		ext->mem[mem_idx] = llext_aligned_alloc_data(region_align, region_alloc);
+		ext->mem[mem_idx] = llext_aligned_alloc_data(ext, region_align, region_alloc);
 	}
 
 	if (!ext->mem[mem_idx]) {
@@ -231,7 +208,11 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 	return 0;
 
 err:
-	llext_free(ext->mem[mem_idx]);
+	if (region->sh_flags & SHF_EXECINSTR) {
+		llext_free_instr(ext, ext->mem[mem_idx]);
+	} else {
+		llext_free_data(ext, ext->mem[mem_idx]);
+	}
 	ext->mem[mem_idx] = NULL;
 	return ret;
 }
@@ -239,6 +220,8 @@ err:
 int llext_copy_strings(struct llext_loader *ldr, struct llext *ext,
 		       const struct llext_load_param *ldr_parm)
 {
+	llext_heap_reset(ext);
+
 	int ret = llext_copy_region(ldr, ext, LLEXT_MEM_SHSTRTAB, ldr_parm);
 
 	if (!ret) {
@@ -334,14 +317,16 @@ void llext_free_regions(struct llext *ext)
 			LOG_DBG("freeing memory region %d", i);
 
 			if (i == LLEXT_MEM_TEXT) {
-				llext_free_instr(ext->mem[i]);
+				llext_free_instr(ext, ext->mem[i]);
 			} else {
-				llext_free(ext->mem[i]);
+				llext_free_data(ext, ext->mem[i]);
 			}
 
 			ext->mem[i] = NULL;
 		}
 	}
+
+	llext_heap_reset(ext);
 }
 
 int llext_add_domain(struct llext *ext, struct k_mem_domain *domain)

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -156,6 +156,11 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 		return -EFAULT;
 	}
 
+#ifdef CONFIG_LLEXT_HEAP_MEMBLK
+	/* If allocating to heap, allocation must be multiple of block size */
+	region_alloc = ROUND_UP(region_alloc, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE);
+#endif
+
 	/* Allocate a suitably aligned area for the region. */
 	if (region->sh_flags & SHF_EXECINSTR) {
 		ext->mem[mem_idx] = llext_aligned_alloc_instr(ext, region_align, region_alloc);

--- a/subsys/llext/llext_mem.h
+++ b/subsys/llext/llext_mem.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LLEXT_MEM_H_
+#define ZEPHYR_SUBSYS_LLEXT_MEM_H_
+
+#ifdef CONFIG_MMU_PAGE_SIZE
+#define LLEXT_PAGE_SIZE CONFIG_MMU_PAGE_SIZE
+#elif CONFIG_ARC_MPU_VER == 2
+#define LLEXT_PAGE_SIZE 2048
+#else
+/* Arm and non-v2 ARC MPUs want a 32 byte minimum MPU region */
+#define LLEXT_PAGE_SIZE 32
+#endif
+
+#endif /* ZEPHYR_SUBSYS_LLEXT_MEM_H_ */

--- a/subsys/llext/llext_memblk.c
+++ b/subsys/llext/llext_memblk.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/llext/llext.h>
+#include <zephyr/sys/mem_blocks.h>
+
+#include "llext_mem.h"
+#include "llext_memblk.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
+
+#ifdef CONFIG_HARVARD
+BUILD_ASSERT(CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1) % CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE == 0,
+	     "CONFIG_LLEXT_INSTR_HEAP_SIZE must be multiple of "
+	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE");
+BUILD_ASSERT(CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1) % CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE == 0,
+	     "CONFIG_LLEXT_DATA_HEAP_SIZE must be multiple of "
+	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE");
+BUILD_ASSERT(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE % LLEXT_PAGE_SIZE == 0,
+	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE must be multiple of LLEXT_PAGE_SIZE");
+uint8_t llext_instr_heap_buf[CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1)]
+	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE)
+	__attribute__((section(".rodata.llext_instr_heap")));
+uint8_t llext_data_heap_buf[CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1)]
+	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE)
+	__attribute__((section(".data.llext_data_heap")));
+SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(llext_instr_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1) /
+					   CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   llext_instr_heap_buf);
+SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(llext_data_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1) /
+					   CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   llext_data_heap_buf);
+K_HEAP_DEFINE(llext_metadata_heap, CONFIG_LLEXT_METADATA_HEAP_SIZE * KB(1));
+#else  /* !CONFIG_HARVARD */
+BUILD_ASSERT(CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1) % CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE == 0,
+	     "CONFIG_LLEXT_EXT_HEAP_SIZE must be multiple of "
+	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE");
+BUILD_ASSERT(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE % LLEXT_PAGE_SIZE == 0,
+	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE must be multiple of LLEXT_PAGE_SIZE");
+SYS_MEM_BLOCKS_DEFINE(llext_ext_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+		      CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1) / CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+		      CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE);
+K_HEAP_DEFINE(llext_metadata_heap, CONFIG_LLEXT_METADATA_HEAP_SIZE * KB(1));
+#endif /* CONFIG_HARVARD */
+
+static inline struct llext_alloc *get_llext_alloc(struct llext_alloc_map *map, void *alloc_ptr)
+{
+	for (int i = 0; i < map->idx; i++) {
+		if (map->map[i].memblk_ptr == alloc_ptr) {
+			return &map->map[i];
+		}
+	}
+	return NULL;
+}
+
+void *llext_memblk_aligned_alloc_data_instr(struct llext *ext, sys_mem_blocks_t *memblk_heap,
+					    size_t align, size_t bytes)
+{
+	if (ext->mem_alloc_map.idx >= LLEXT_MEM_COUNT) {
+		return NULL;
+	}
+
+	if (CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE % align != 0) {
+		LOG_ERR("Requested alignment %zu not possible with block alignment %d", align,
+			CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE);
+		return NULL;
+	}
+
+	struct llext_alloc *mem_alloc = &ext->mem_alloc_map.map[ext->mem_alloc_map.idx];
+
+	mem_alloc->num_blocks = DIV_ROUND_UP(bytes, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE);
+	int ret = sys_mem_blocks_alloc_contiguous(memblk_heap, mem_alloc->num_blocks,
+						  &mem_alloc->memblk_ptr);
+
+	if (ret != 0) {
+		return NULL;
+	}
+
+	ext->mem_alloc_map.idx++;
+
+	return mem_alloc->memblk_ptr;
+}
+
+void llext_memblk_free_data_instr(struct llext *ext, sys_mem_blocks_t *memblk_heap, void *ptr)
+{
+	struct llext_alloc *mem_alloc = get_llext_alloc(&ext->mem_alloc_map, ptr);
+
+	if (!mem_alloc) {
+		LOG_ERR("Could not find sys_mem_blocks alloc to free pointer %p", ptr);
+		return;
+	}
+
+	sys_mem_blocks_free_contiguous(memblk_heap, mem_alloc->memblk_ptr, mem_alloc->num_blocks);
+	mem_alloc->num_blocks = 0;
+	mem_alloc->memblk_ptr = NULL;
+}

--- a/subsys/llext/llext_memblk.h
+++ b/subsys/llext/llext_memblk.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_LLEXT_MEMBLK_H_
+#define ZEPHYR_SUBSYS_LLEXT_MEMBLK_H_
+
+#include <zephyr/llext/llext.h>
+#include <zephyr/sys/mem_blocks.h>
+
+#ifdef CONFIG_HARVARD
+extern sys_mem_blocks_t llext_instr_heap;
+extern sys_mem_blocks_t llext_data_heap;
+extern struct k_heap llext_metadata_heap;
+#else
+extern sys_mem_blocks_t llext_ext_heap;
+extern struct k_heap llext_metadata_heap;
+#define llext_instr_heap llext_ext_heap
+#define llext_data_heap  llext_ext_heap
+#endif
+
+void *llext_memblk_aligned_alloc_data_instr(struct llext *ext, sys_mem_blocks_t *memblk_heap,
+					    size_t align, size_t bytes);
+
+void llext_memblk_free_data_instr(struct llext *ext, sys_mem_blocks_t *memblk_heap, void *ptr);
+
+static inline bool llext_heap_is_inited(void)
+{
+	return true;
+}
+
+static inline void *llext_alloc_metadata(size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return k_heap_alloc(&llext_metadata_heap, bytes, K_NO_WAIT);
+	}
+
+	return NULL;
+}
+
+static inline void *llext_aligned_alloc_data(struct llext *ext, size_t align, size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return llext_memblk_aligned_alloc_data_instr(ext, &llext_data_heap, align, bytes);
+	}
+
+	return NULL;
+}
+
+static inline void *llext_aligned_alloc_instr(struct llext *ext, size_t align, size_t bytes)
+{
+	if (bytes != 0 && llext_heap_is_inited()) {
+		return llext_memblk_aligned_alloc_data_instr(ext, &llext_instr_heap, align, bytes);
+	}
+
+	return NULL;
+}
+
+static inline void llext_free_metadata(void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		k_heap_free(&llext_metadata_heap, ptr);
+	}
+}
+
+static inline void llext_free_data(struct llext *ext, void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		llext_memblk_free_data_instr(ext, &llext_data_heap, ptr);
+	}
+}
+
+static inline void llext_free_instr(struct llext *ext, void *ptr)
+{
+	if (llext_heap_is_inited()) {
+		llext_memblk_free_data_instr(ext, &llext_instr_heap, ptr);
+	}
+}
+
+static inline void llext_heap_reset(struct llext *ext)
+{
+	ext->mem_alloc_map.idx = 0;
+}
+
+#endif /* ZEPHYR_SUBSYS_LLEXT_MEMBLK_H_ */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -16,6 +16,8 @@
 
 #ifdef CONFIG_LLEXT_HEAP_K_HEAP
 #include "llext_kheap.h"
+#elif defined(CONFIG_LLEXT_HEAP_MEMBLK)
+#include "llext_memblk.h"
 #else
 #error "No LLEXT heap implementation selected; see CONFIG_LLEXT_HEAP_MANAGEMENT"
 #endif

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -162,6 +162,7 @@ void load_call_unload(const struct llext_test *test_case)
 	res = llext_add_domain(ext, &domain);
 	if (res == -ENOSPC) {
 		TC_PRINT("Too many memory partitions for this particular hardware\n");
+		llext_unload(&ext);
 		ztest_test_skip();
 		return;
 	}

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -17,6 +17,7 @@ common:
   filter: not CONFIG_HARVARD
   extra_configs:
     - arch:arm64:CONFIG_LLEXT_HEAP_SIZE=128
+    - arch:arm64:CONFIG_LLEXT_EXT_HEAP_SIZE=64
   extra_conf_files:
     - prj.conf
   min_ram: 172                # Size on arm: max: 145, min: 79
@@ -45,6 +46,20 @@ tests:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_RODATA_NO_RELOC=y
+  llext.readonly.memblk:
+    arch_allow:               # Xtensa needs writable storage
+      - arm
+      - riscv
+      - arc
+      - x86
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_RODATA_NO_RELOC=y
+      - CONFIG_LLEXT_HEAP_MEMBLK=y
+      - arch:arc:CONFIG_LLEXT_EXT_HEAP_SIZE=64
+      - arch:arc:CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=2048
   llext.readonly_mpu:
     arch_allow:
       - arm # Xtensa needs writable storage, currently not supported on RISC-V
@@ -53,6 +68,26 @@ tests:
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
+  llext.readonly_mpu.memblk:
+    arch_allow:
+      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arc
+    filter: CONFIG_ARCH_HAS_USERSPACE and not CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+    extra_configs:
+      - CONFIG_USERSPACE=y
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_HEAP_MEMBLK=y
+  llext.readonly_mpu.memblk.power_of_two_alignment:
+    arch_allow:
+      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arc
+    filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+    extra_configs:
+      - CONFIG_USERSPACE=y
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_HEAP_MEMBLK=y
+      - CONFIG_LLEXT_EXT_HEAP_SIZE=64
+      - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=8192
   llext.readonly_mmu:
     arch_allow:
       - arm64
@@ -66,6 +101,21 @@ tests:
       - CONFIG_LLEXT_HEAP_SIZE=128 # qemu_cortex_a9 requires larger heap
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_RODATA_NO_RELOC=y
+  llext.readonly_mmu.memblk:
+    arch_allow:
+      - arm64
+      - arm
+      - riscv
+      - x86
+    filter: CONFIG_MMU or CONFIG_RISCV_PMP
+    integration_platforms:
+      - qemu_cortex_a53         # ARM Cortex-A53 (ARMv8-A ISA)
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_RODATA_NO_RELOC=y
+      - CONFIG_LLEXT_HEAP_MEMBLK=y
+      - CONFIG_LLEXT_EXT_HEAP_SIZE=64
+      - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=4096
   llext.writable:
     arch_allow:
       - arm
@@ -79,6 +129,27 @@ tests:
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
+  llext.writable.memblk:
+    arch_allow:
+      - arm
+      - xtensa
+      - riscv
+      - arc
+      - x86
+    platform_exclude:
+      - qemu_arc/qemu_arc_hs5x     # See #80949
+      - nsim/nsim_hs5x             # See #80949
+      - nsim/nsim_hs5x/smp         # See #80949
+      - nsim/nsim_hs5x/smp/12cores # See #80949
+    integration_platforms:
+      - qemu_xtensa/dc233c      # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_HEAP_MEMBLK=y
+      - arch:arc:CONFIG_LLEXT_EXT_HEAP_SIZE=64
+      - arch:arc:CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=2048
   llext.writable_relocatable:
     arch_allow:
       - arm


### PR DESCRIPTION
Adds sys_mem_blocks as an optional alternative backing data structure for the heap. Users have reported that k_heap allocating additional bytes for bookkeeping data when allocating e.g. a LLEXT_PAGE for an extension region causes them to skip an entire page for the next allocation. This also causes problems RE: MPU slot usage. sys_mem_blocks stores bookkeeping data outside of the memory it allocates from and does not have this issue.

Note that sys_mem_blocks is only used to allocate extension regions. Metadata is still stored in a k_heap.
    
Note also that tracking data for sys_mem_blocks is stored per extension, as unlike k_heap it can't deallocate with just a pointer to the memory. (At least that's what I thought, probably people have better suggestions?)
    
**Further limitations:**
 * sys_mem_blocks is statically allocated, so this option cannot be used with CONFIG_LLEXT_HEAP_DYNAMIC
 * A minimum of 1 block must be allocated per region regardless of size. If using the MPU / MMU where small allocations are rounded up to LLEXT_PAGE regardless, this penalty is not quite as noticeable.
 * sys_mem_blocks does not support aligned allocations. However, by selecting a sufficiently large power of 2 for the block size and aligning the backing buffer to the block size, any allocation will be automatically aligned for the block size and smaller powers of 2. For LLEXT, this means users must select a block size equal to or a multiple of the maximum requested region alignment of regions going on the heap
 * If your MPU selects CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT, large regions may cause unreasonably large maximum requested region alignments
 * Block size must also be equal to or a multiple of LLEXT_PAGE_SIZE so each allocation is LLEXT page aligned
