### PR TITLE
tests: drivers: build_all: input: Fix warning

### DIFF
--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/keymap.h>
 
 / {
 	test {
@@ -88,9 +89,10 @@
 
 			keymap {
 				compatible = "input-keymap";
-				keymap = <0 1 2>;
 				row-size = <2>;
 				col-size = <2>;
+				keymap = <MATRIX_KEY(0, 0, 0) MATRIX_KEY(0, 1, 1)
+					  MATRIX_KEY(1, 0, 2)>;
 			};
 		};
 


### PR DESCRIPTION
When building the drivers.input.adc_keys test with clang and
-Winitializer-overrides, it warns:

subsys/input/input_keymap.c:123:29: error: initializer overrides prior
initialization of this subobject [-Werror,-Winitializer-overrides]
  123 | DT_INST_FOREACH_STATUS_OKAY(INPUT_KEYMAP_DEFINE)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
/include/zephyr/devicetree.h:5306:25: note: expanded from macro
'DT_INST_FOREACH_STATUS_OKAY'
 5304 |         COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),   \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 5305 |                     (UTIL_CAT(DT_FOREACH_OKAY_INST_,            \
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 5306 |                               DT_DRV_COMPAT)(fn)),              \
      |                               ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 5307 |                     ())
      |                     ~~~