### PR TITLE
Bluetooth: TBS: Add enum, move and rename TECHNOLOGY

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -144,14 +144,25 @@ Bluetooth Audio
     :c:member:`bt_cap_commander_cb.broadcast_reception_start` is called. This also applies for
     :c:func:`bt_cap_commander_broadcast_reception_stop` in a similar manner. (:github:`101070`)
 
+* CCP
+
+  * :c:member:`bt_tbs_client_cb.technology` has changed the ``value`` parameter from ``uint32_t``
+    to ``enum bt_bearer_tech``. Applications using this application should switch the type.
+    (:github:`102430`)
+  * All ``BT_TBS_TECHNOLOGY_*`` values like ``BT_TBS_TECHNOLOGY_3G`` are renamed to
+    ``BT_BEARER_TECH_*`` like ``BT_BEARER_TECH_3G``. Applications can do search-and-replace from
+    ``BT_TBS_TECHNOLOGY`` to ``BT_BEARER_TECH``. Additionally the values are now defined in
+    :zephyr_file:`include/zephyr/bluetooth/assigned_numbers.h` instead of
+    :zephyr_file:`include/zephyr/bluetooth/audio/tbs.h`. (:github:`102430`)
+
 * CSIP
 
-   * Optional CSIS characteristics have been made configurable via Kconfig and must be enabled
-     explicitly:
+  * Optional CSIS characteristics have been made configurable via Kconfig and must be enabled
+    explicitly:
 
-     * Coordinated Set Size → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_SIZE_SUPPORT`
-     * Set Member Lock → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_LOCK_SUPPORT`
-     * Set Member Rank → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_RANK_SUPPORT`
+    * Coordinated Set Size → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_SIZE_SUPPORT`
+    * Set Member Lock → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_LOCK_SUPPORT`
+    * Set Member Rank → :kconfig:option:`CONFIG_BT_CSIP_SET_MEMBER_RANK_SUPPORT`
 
 .. zephyr-keep-sorted-stop
 

--- a/include/zephyr/bluetooth/assigned_numbers.h
+++ b/include/zephyr/bluetooth/assigned_numbers.h
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2015-2025 Intel Corporation
- * Copyright (c) 2017-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,7 @@
  */
 
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -920,6 +921,29 @@ extern "C" {
  * @ingroup bt_assigned_numbers
  * @{
  */
+
+/** Enum for valid bearer technology values */
+enum __packed bt_bearer_tech {
+	/** 3G */
+	BT_BEARER_TECH_3G = 0x01,
+	/** 4G */
+	BT_BEARER_TECH_4G = 0x02,
+	/** Long-term evolution (LTE) */
+	BT_BEARER_TECH_LTE = 0x03,
+	/** Wifi */
+	BT_BEARER_TECH_WIFI = 0x04,
+	/** 5G */
+	BT_BEARER_TECH_5G = 0x05,
+	/** Global System for Mobile Communications (GSM) */
+	BT_BEARER_TECH_GSM = 0x06,
+	/** Code-Division Multiple Access (CDMA) */
+	BT_BEARER_TECH_CDMA = 0x07,
+	/** 2G */
+	BT_BEARER_TECH_2G = 0x08,
+	/** Wideband Code-Division Multiple Access (WCDMA) */
+	BT_BEARER_TECH_WCDMA = 0x09,
+	/* Values 0x0A to 0xFF are reserved for future use */
+};
 
 /**
  * @brief Codec capability types

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -3,7 +3,7 @@
  * @brief Public APIs for Bluetooth Telephone Bearer Service.
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util_macro.h>
@@ -145,30 +146,6 @@ extern "C" {
 #define BT_TBS_SIGNAL_STRENGTH_MAX                      100
 /** Signal strength is unknown  */
 #define BT_TBS_SIGNAL_STRENGTH_UNKNOWN                  255
-/** @} */
-
-/**
- * @name Bearer Technology
- * @{
- */
-/** 3G */
-#define BT_TBS_TECHNOLOGY_3G                       0x01
-/** 4G */
-#define BT_TBS_TECHNOLOGY_4G                       0x02
-/** Long-term evolution (LTE) */
-#define BT_TBS_TECHNOLOGY_LTE                      0x03
-/** Wifi */
-#define BT_TBS_TECHNOLOGY_WIFI                     0x04
-/** 5G */
-#define BT_TBS_TECHNOLOGY_5G                       0x05
-/** Global System for Mobile Communications (GSM) */
-#define BT_TBS_TECHNOLOGY_GSM                      0x06
-/** Code-Division Multiple Access (CDMA) */
-#define BT_TBS_TECHNOLOGY_CDMA                     0x07
-/** 2G */
-#define BT_TBS_TECHNOLOGY_2G                       0x08
-/** Wideband Code-Division Multiple Access (WCDMA) */
-#define BT_TBS_TECHNOLOGY_WCDMA                    0x09
 /** @} */
 
 /**
@@ -432,7 +409,7 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name);
  * @return int           BT_TBS_RESULT_CODE_* if positive or 0,
  *                       errno value if negative.
  */
-int bt_tbs_set_bearer_technology(uint8_t bearer_index, uint8_t new_technology);
+int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_technology);
 
 /**
  * @brief Update the signal strength reported by the server.
@@ -495,6 +472,9 @@ struct bt_tbs_register_param {
 	 */
 	char *uri_schemes_supported;
 
+	/** @brief The technology of the bearer */
+	enum bt_bearer_tech technology;
+
 	/**
 	 * @brief Whether this bearer shall be registered as a Generic Telephone Bearer server
 	 *
@@ -509,13 +489,6 @@ struct bt_tbs_register_param {
 	 * If set to false then the service will automatically accept write requests from clients.
 	 */
 	bool authorization_required;
-
-	/**
-	 * @brief The technology of the bearer
-	 *
-	 * See the BT_TBS_TECHNOLOGY_* values.
-	 */
-	uint8_t technology;
 
 	/**
 	 * @brief The optional supported features of the bearer
@@ -740,8 +713,16 @@ struct bt_tbs_client_cb {
 	bt_tbs_client_read_string_cb         bearer_uci;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) || defined(__DOXYGEN__)
-	/** Bearer technology has been read */
-	bt_tbs_client_read_value_cb          technology;
+	/**
+	 * @brief Bearer technology has been read.
+	 *
+	 * @param conn The connection used in the function.
+	 * @param err Error value. BT_TBS_CLIENT_RESULT_CODE_* or GATT error.
+	 * @param inst_index The index of the TBS instance that was updated.
+	 * @param tech The technology read. The value may be outside the values of the enum.
+	 */
+	void (*technology)(struct bt_conn *conn, int err, uint8_t inst_index,
+			   enum bt_bearer_tech tech);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) || defined(__DOXYGEN__)
 	/** Bearer URI list has been read */

--- a/samples/bluetooth/ccp_call_control_server/src/main.c
+++ b/samples/bluetooth/ccp_call_control_server/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -157,7 +157,7 @@ static int init_ccp_call_control_server(void)
 		.uri_schemes_supported = "tel,skype",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD,
 	};
 	int err;
@@ -189,7 +189,7 @@ static int init_ccp_call_control_server(void)
 			.gtbs = false,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
-			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
 			.supported_features = BT_TBS_FEATURE_HOLD,
 		};
 

--- a/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
+++ b/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
@@ -2,7 +2,7 @@
  *  @brief Bluetooth Call Control Profile (CCP) Server role.
  *
  *  Copyright 2023,2025 NXP
- *  Copyright (c) 2024 Nordic Semiconductor ASA
+ *  Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,7 @@
 #include <stdint.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/kernel.h>
@@ -51,7 +52,7 @@ int ccp_call_control_server_init(void)
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 	};
 

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -3,7 +3,7 @@
  */
 
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/audio/ccp.h>
 #include <zephyr/shell/shell.h>
@@ -36,7 +37,7 @@ static int cmd_ccp_call_control_server_init(const struct shell *sh, size_t argc,
 		.uri_schemes_supported = "tel,skype",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 	};
 	int err;
@@ -59,7 +60,7 @@ static int cmd_ccp_call_control_server_init(const struct shell *sh, size_t argc,
 			.gtbs = false,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
-			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
 			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 		};
 

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -3,7 +3,7 @@
  */
 
 /*
- * Copyright (c) 2020-2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,7 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
@@ -71,7 +72,7 @@ static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 		.uri_schemes_supported = "tel,skype",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 	};
 	int err;
@@ -94,7 +95,7 @@ static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 			.gtbs = false,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
-			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
 			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 		};
 

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1,7 +1,7 @@
 /* Bluetooth TBS - Telephone Bearer Service
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/audio/ccid.h>
 #include <zephyr/bluetooth/audio/tbs.h>
@@ -74,7 +75,7 @@ struct tbs_inst {
 	 */
 	char provider_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH];
 	char uci[BT_TBS_MAX_UCI_SIZE];
-	uint8_t technology;
+	enum bt_bearer_tech technology;
 	uint8_t signal_strength;
 	uint8_t signal_strength_interval;
 	uint8_t ccid;
@@ -1037,11 +1038,12 @@ static void notify_handler_cb(struct bt_conn *conn, void *data)
 	}
 
 	if (flags->bearer_technology_changed) {
-		LOG_DBG("Notifying Bearer Technology: %s (0x%02x)",
-			bt_tbs_technology_str(inst->technology), inst->technology);
+		const uint8_t tech = (uint8_t)inst->technology;
 
-		err = notify(conn, BT_UUID_TBS_TECHNOLOGY, inst->attrs, &inst->technology,
-			     sizeof(inst->technology));
+		LOG_DBG("Notifying Bearer Technology: %s (0x%02x)",
+			bt_bearer_tech_str(inst->technology), tech);
+
+		err = notify(conn, BT_UUID_TBS_TECHNOLOGY, inst->attrs, &tech, sizeof(tech));
 		if (err == 0) {
 			flags->bearer_technology_changed = false;
 		} else {
@@ -1292,11 +1294,11 @@ static ssize_t read_technology(struct bt_conn *conn, const struct bt_gatt_attr *
 			       uint16_t len, uint16_t offset)
 {
 	const struct tbs_inst *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	const uint8_t tech = (uint8_t)inst->technology;
 
-	LOG_DBG("Index %u: Technology 0x%02x", inst_index(inst), inst->technology);
+	LOG_DBG("Index %u: Technology 0x%02x", inst_index(inst), tech);
 
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->technology,
-				 sizeof(inst->technology));
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &tech, sizeof(tech));
 }
 
 static void technology_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
@@ -2558,7 +2560,7 @@ static bool valid_register_param(const struct bt_tbs_register_param *param)
 		return false;
 	}
 
-	if (!IN_RANGE(param->technology, BT_TBS_TECHNOLOGY_3G, BT_TBS_TECHNOLOGY_WCDMA)) {
+	if (!IN_RANGE(param->technology, BT_BEARER_TECH_3G, BT_BEARER_TECH_WCDMA)) {
 		LOG_DBG("Invalid technology: %u", param->technology);
 
 		return false;
@@ -3181,12 +3183,12 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name)
 	return 0;
 }
 
-int bt_tbs_set_bearer_technology(uint8_t bearer_index, uint8_t new_technology)
+int bt_tbs_set_bearer_technology(uint8_t bearer_index, enum bt_bearer_tech new_technology)
 {
 	struct tbs_inst *inst = inst_lookup_index(bearer_index);
 	int err;
 
-	if (new_technology < BT_TBS_TECHNOLOGY_3G || new_technology > BT_TBS_TECHNOLOGY_WCDMA) {
+	if (new_technology < BT_BEARER_TECH_3G || new_technology > BT_BEARER_TECH_WCDMA) {
 		return -EINVAL;
 	} else if (inst == NULL) {
 		return -EINVAL;

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1,7 +1,7 @@
 /*  Bluetooth TBS - Telephone Bearer Service - Client
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -403,7 +404,7 @@ static void provider_name_notify_handler(struct bt_conn *conn,
 
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 static void technology_changed(struct bt_conn *conn, int err, uint8_t inst_index,
-			       uint8_t technology)
+			       enum bt_bearer_tech technology)
 {
 	struct bt_tbs_client_cb *listener, *next;
 
@@ -424,9 +425,11 @@ static void technology_notify_handler(struct bt_conn *conn,
 
 	if (length == sizeof(technology)) {
 		(void)memcpy(&technology, data, length);
-		LOG_DBG("%s (0x%02x)", bt_tbs_technology_str(technology), technology);
+		LOG_DBG("%s (0x%02x)", bt_bearer_tech_str((enum bt_bearer_tech)technology),
+			technology);
 
-		technology_changed(conn, 0, tbs_index(conn, tbs_inst), technology);
+		technology_changed(conn, 0, tbs_index(conn, tbs_inst),
+				   (enum bt_bearer_tech)technology);
 	}
 }
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
@@ -1035,7 +1038,8 @@ static uint8_t read_technology_cb(struct bt_conn *conn, uint8_t err,
 		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(technology)) {
 			(void)memcpy(&technology, data, length);
-			LOG_DBG("%s (0x%02x)", bt_tbs_technology_str(technology), technology);
+			LOG_DBG("%s (0x%02x)", bt_bearer_tech_str((enum bt_bearer_tech)technology),
+				technology);
 		} else {
 			LOG_DBG("Invalid length");
 			cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
@@ -1044,7 +1048,11 @@ static uint8_t read_technology_cb(struct bt_conn *conn, uint8_t err,
 
 	tbs_client_gatt_read_complete(inst);
 
-	technology_changed(conn, cb_err, inst_index, technology);
+	/* TODO: We should probably verify that the read value is valid before calling
+	 * technology_changed with a non-0 error
+	 */
+
+	technology_changed(conn, cb_err, inst_index, (enum bt_bearer_tech)technology);
 
 	return BT_GATT_ITER_STOP;
 }

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,7 @@
 #include <stdint.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -123,26 +124,26 @@ static inline const char *bt_tbs_status_str(uint8_t status)
 	}
 }
 
-static inline const char *bt_tbs_technology_str(uint8_t status)
+static inline const char *bt_bearer_tech_str(enum bt_bearer_tech tech)
 {
-	switch (status) {
-	case BT_TBS_TECHNOLOGY_3G:
+	switch (tech) {
+	case BT_BEARER_TECH_3G:
 		return "3G";
-	case BT_TBS_TECHNOLOGY_4G:
+	case BT_BEARER_TECH_4G:
 		return "4G";
-	case BT_TBS_TECHNOLOGY_LTE:
+	case BT_BEARER_TECH_LTE:
 		return "LTE";
-	case BT_TBS_TECHNOLOGY_WIFI:
+	case BT_BEARER_TECH_WIFI:
 		return "WIFI";
-	case BT_TBS_TECHNOLOGY_5G:
+	case BT_BEARER_TECH_5G:
 		return "5G";
-	case BT_TBS_TECHNOLOGY_GSM:
+	case BT_BEARER_TECH_GSM:
 		return "GSM";
-	case BT_TBS_TECHNOLOGY_CDMA:
+	case BT_BEARER_TECH_CDMA:
 		return "CDMA";
-	case BT_TBS_TECHNOLOGY_2G:
+	case BT_BEARER_TECH_2G:
 		return "2G";
-	case BT_TBS_TECHNOLOGY_WCDMA:
+	case BT_BEARER_TECH_WCDMA:
 		return "WCDMA";
 	default:
 		return "unknown technology";

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -1,7 +1,7 @@
 /* main.c - Application main entry point */
 
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/ccp.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -88,7 +89,7 @@ static void register_default_bearer(struct ccp_call_control_server_test_suite_fi
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = 0,
 	};
 	int err;
@@ -118,7 +119,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 			.uri_schemes_supported = "tel",
 			.gtbs = false,
 			.authorization_required = false,
-			.technology = BT_TBS_TECHNOLOGY_3G,
+			.technology = BT_BEARER_TECH_3G,
 			.supported_features = 0,
 		};
 		int err;
@@ -147,7 +148,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = 0,
 	};
 	int err;
@@ -165,7 +166,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.uri_schemes_supported = "tel",
 		.gtbs = false,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = 0,
 	};
 	int err;
@@ -183,7 +184,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = 0,
 	};
 	int err;
@@ -207,7 +208,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.uri_schemes_supported = "tel",
 		.gtbs = false,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = 0,
 	};
 	int err;

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2023 Oticon
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,7 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -226,6 +228,13 @@ static void tbs_client_read_val_cb(struct bt_conn *conn, int err, uint8_t inst_i
 			       value);
 }
 
+static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst_index,
+				     enum bt_bearer_tech technology)
+{
+	tbs_client_chrc_val_ev(conn, err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS, inst_index,
+			       (uint32_t)technology);
+}
+
 static void tbs_client_current_calls_cb(struct bt_conn *conn, int err, uint8_t inst_index,
 					uint8_t call_count, const struct bt_tbs_client_call *calls)
 {
@@ -249,7 +258,7 @@ static struct bt_tbs_client_cb tbs_client_callbacks = {
 	.termination_reason = tbs_client_termination_reason_cb,
 	.bearer_provider_name = tbs_client_read_string_cb,
 	.bearer_uci = tbs_client_read_string_cb,
-	.technology = tbs_client_read_val_cb,
+	.technology = tbs_client_technology_cb,
 	.uri_list = tbs_client_read_string_cb,
 	.signal_strength = tbs_client_read_val_cb,
 	.signal_interval = tbs_client_read_val_cb,
@@ -970,7 +979,7 @@ static uint8_t tbs_set_bearer_technology(const void *cmd, uint16_t cmd_len, void
 
 	LOG_DBG("TBS Set bearer technology");
 
-	err = bt_tbs_set_bearer_technology(cp->index, cp->tech);
+	err = bt_tbs_set_bearer_technology(cp->index, (enum bt_bearer_tech)cp->tech);
 	if (err != 0) {
 		return BTP_STATUS_FAILED;
 	}

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -182,7 +182,7 @@ static void init(void)
 			.uri_schemes_supported = "tel,skype",
 			.gtbs = true,
 			.authorization_required = false,
-			.technology = BT_TBS_TECHNOLOGY_3G,
+			.technology = BT_BEARER_TECH_3G,
 			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 		};
 

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/audio/ccp.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -54,7 +55,7 @@ static void init(void)
 		.uri_schemes_supported = "tel,skype",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 	};
 	int err;
@@ -100,7 +101,7 @@ static void init(void)
 			.gtbs = false,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
-			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
 			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 		};
 

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -36,7 +37,7 @@ CREATE_FLAG(call_terminated);
 CREATE_FLAG(provider_name);
 CREATE_FLAG(ccid_read_flag);
 CREATE_FLAG(signal_strength);
-CREATE_FLAG(technology);
+CREATE_FLAG(flag_technology);
 CREATE_FLAG(status_flags);
 CREATE_FLAG(signal_interval);
 CREATE_FLAG(call_accepted);
@@ -151,18 +152,17 @@ static void tbs_client_retrieve_call_cb(struct bt_conn *conn, int err,
 						  call_index);
 }
 
-static void tbs_client_technology_cb(struct bt_conn *conn, int err,
-				    uint8_t inst_index,
-				    uint32_t value)
+static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst_index,
+				     enum bt_bearer_tech technology)
 {
 	if (err != 0) {
 		FAIL("Client bearer technology error: (%d)\n", err);
 		return;
 	}
 
-	printk("%s Instance: %u Technology: %u\n", __func__, inst_index, value);
+	printk("%s Instance: %u Technology: %d\n", __func__, inst_index, technology);
 
-	SET_FLAG(technology);
+	SET_FLAG(flag_technology);
 }
 
 static void tbs_client_signal_strength_cb(struct bt_conn *conn, int err,
@@ -407,7 +407,7 @@ static void test_technology(uint8_t index)
 {
 	int err;
 
-	UNSET_FLAG(technology);
+	UNSET_FLAG(flag_technology);
 
 	printk("%s\n", __func__);
 
@@ -417,7 +417,7 @@ static void test_technology(uint8_t index)
 		return;
 	}
 
-	WAIT_FOR_FLAG(technology);
+	WAIT_FOR_FLAG(flag_technology);
 
 	printk("Client read technology test success\n");
 }

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -148,7 +149,7 @@ static int test_set_bearer_technology(uint8_t bearer_index)
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_set_bearer_technology(bearer_index, BT_TBS_TECHNOLOGY_GSM);
+	err = bt_tbs_set_bearer_technology(bearer_index, BT_BEARER_TECH_GSM);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer technology: %d\n", err);
 		return err;
@@ -332,7 +333,7 @@ static void init(void)
 		.uri_schemes_supported = "skype",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_TBS_TECHNOLOGY_3G,
+		.technology = BT_BEARER_TECH_3G,
 		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 	};
 	int err;
@@ -380,7 +381,7 @@ static void init(void)
 			.gtbs = false,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
-			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
 			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
 		};
 

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/hci_types.h>
@@ -33,10 +34,10 @@ static void test_ccp_peripheral(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_core_register(BTP_SERVICE_ID_TBS);
 
-	bsim_btp_tbs_register_bearer(true, BT_TBS_TECHNOLOGY_3G, BT_TBS_FEATURE_ALL,
-				     "GTBS Provider", "un000", "tel");
-	bsim_btp_tbs_register_bearer(false, BT_TBS_TECHNOLOGY_3G, BT_TBS_FEATURE_ALL,
-				     "TBS Provider", "un000", "tel");
+	bsim_btp_tbs_register_bearer(true, BT_BEARER_TECH_3G, BT_TBS_FEATURE_ALL, "GTBS Provider",
+				     "un000", "tel");
+	bsim_btp_tbs_register_bearer(false, BT_BEARER_TECH_3G, BT_TBS_FEATURE_ALL, "TBS Provider",
+				     "un000", "tel");
 
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);


### PR DESCRIPTION
The technology values defined in tbs.h are actually defined
in assigned numbers under the HFP. They have been moved to
the assigned_numbers.h file, and name to match the placement
in Assigned Numbers. They have been defined in an enum instead
of multiple #define's, to more easily refer to them.
    
The callback for reading technology was likewise updated to use
the new enum.

Related erratum: https://bluetooth.atlassian.net/browse/ES-28778