### PR TITLE
doc: code_data_relocation: Add syntax highlight to cmake snippets

### DIFF
--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -69,7 +69,7 @@ for  data copy operations from ROM to required memory type.
 
   .. note::
 
-     function zephyr_code_relocate() can be called  as many times as required.
+     function ``zephyr_code_relocate()`` can be called  as many times as required.
 
 Additional Configurations
 =========================
@@ -79,7 +79,7 @@ This section shows additional configuration options that can be set in
 * If the memory is ``SRAM1``, ``SRAM2``, ``CCD``, or ``AON``, then place the
   full object in the sections. For example:
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      zephyr_code_relocate(FILES src/file1.c LOCATION SRAM2)
      zephyr_code_relocate(FILES src/file2.c LOCATION SRAM)
@@ -88,7 +88,7 @@ This section shows additional configuration options that can be set in
   ``_BSS`` or ``_NOINIT``, only the selected memory is placed in the required
   memory region. For example:
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      zephyr_code_relocate(FILES src/file1.c LOCATION SRAM2_DATA)
      zephyr_code_relocate(FILES src/file2.c LOCATION SRAM2_TEXT)
@@ -100,7 +100,7 @@ This section shows additional configuration options that can be set in
 * Multiple files can be passed to the ``FILES`` argument, or CMake generator
   expressions can be used to relocate a comma-separated list of files.
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      file(GLOB sources "file*.c")
      zephyr_code_relocate(FILES ${sources} LOCATION SRAM)
@@ -118,7 +118,7 @@ select the file's symbols when this one has been built with
 ``-ffunction-sections`` and ``-fdata-sections`` which is the case by
 default.
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      zephyr_code_relocate(FILES src/file1.c FILTER ".*\\.func1|.*\\.func2" LOCATION SRAM2_TEXT)
 
@@ -133,7 +133,7 @@ contain unused symbols, then they will not be discarded by the linker, even when
 it is invoked with ``--gc-sections``. If you'd like to override this behavior,
 you can pass ``NOKEEP`` to your ``zephyr_code_relocate()`` call.
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      zephyr_code_relocate(FILES src/file1.c LOCATION SRAM2_TEXT NOKEEP)
 
@@ -152,7 +152,7 @@ This example will place the .text section of the ``xip_external_flash.c`` file
 to the ``EXTFLASH`` memory region where it will be executed from (XIP). The
 .data will be relocated as usual into SRAM.
 
-  .. code-block:: none
+  .. code-block:: cmake
 
      zephyr_code_relocate(FILES src/xip_external_flash.c LOCATION EXTFLASH_TEXT NOCOPY)
      zephyr_code_relocate(FILES src/xip_external_flash.c LOCATION SRAM_DATA)
@@ -164,7 +164,7 @@ Libraries can be relocated using the LIBRARY argument to
 ``zephyr_code_relocation()`` with the library name. For example, the following
 snippet will relocate serial drivers to SRAM2:
 
-  .. code-block:: none
+  .. code-block:: cmake
 
     zephyr_code_relocate(LIBRARY drivers__serial LOCATION SRAM2)
 


### PR DESCRIPTION
Fix code-blocks that had improper syntax highlighting set
https://builds.zephyrproject.io/zephyr/pr/102431/docs/kernel/code-relocation.html#additional-configurations