### PR TITLE
bbram: shell: adopt SHELL_HELP

### DIFF
--- a/drivers/bbram/bbram_shell.c
+++ b/drivers/bbram/bbram_shell.c
@@ -187,10 +187,13 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(bbram_cmds,
 			       SHELL_CMD_ARG(read, &dsub_device_name,
-					     "<device> [<address>] [<count>]", cmd_read, 2, 2),
+					     SHELL_HELP("Read data from BBRAM",
+							"<device> [<address> [<count>]]"),
+					     cmd_read, 2, 2),
 			       SHELL_CMD_ARG(write, &dsub_device_name,
-					     "<device> <address> <byte> [<byte>...]", cmd_write, 4,
-					     BUF_ARRAY_CNT),
+					     SHELL_HELP("Write data to BBRAM",
+							 "<device> <address> <byte> [<byte>...]"),
+					     cmd_write, 4, BUF_ARRAY_CNT),
 			       SHELL_SUBCMD_SET_END);
 
 static int cmd_bbram(const struct shell *sh, size_t argc, char **argv)


### PR DESCRIPTION
Have bbram shell commands use the new SHELL_HELP macro
Also fix the syntax for "read" command as it wasn't correctly indicating that count cannot be specified without address.