### PR TITLE
Add Microchip MEC174x/5x to MEC I2C byte mode version driver

### DIFF
--- a/boards/microchip/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/microchip/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -129,7 +129,8 @@
 &i2c_smb_0 {
 	status = "okay";
 	port-sel = <0>;
-
+	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
 	pinctrl-0 = <&i2c00_scl_gpio004 &i2c00_sda_gpio003>;
 	pinctrl-names = "default";
 };
@@ -149,6 +150,8 @@
 &i2c_smb_1 {
 	status = "okay";
 	port-sel = <1>;
+	sda-gpios = <MCHP_GPIO_DECODE_130 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_131 0>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 
@@ -184,6 +187,8 @@
 &i2c_smb_2 {
 	status = "okay";
 	port-sel = <7>;
+	sda-gpios = <MCHP_GPIO_DECODE_012 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_013 0>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };

--- a/boards/microchip/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
+++ b/boards/microchip/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
@@ -123,7 +123,8 @@
 &i2c_smb_0 {
 	status = "okay";
 	port-sel = <0>;
-
+	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
 	pinctrl-0 = <&i2c00_scl_gpio004 &i2c00_sda_gpio003>;
 	pinctrl-names = "default";
 };
@@ -143,6 +144,8 @@
 &i2c_smb_1 {
 	status = "okay";
 	port-sel = <1>;
+	sda-gpios = <MCHP_GPIO_DECODE_130 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_131 0>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 };
@@ -162,6 +165,8 @@
 &i2c_smb_2 {
 	status = "okay";
 	port-sel = <7>;
+	sda-gpios = <MCHP_GPIO_DECODE_012 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_013 0>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };

--- a/drivers/i2c/Kconfig.xec
+++ b/drivers/i2c/Kconfig.xec
@@ -18,3 +18,24 @@ config I2C_XEC_V2
 	select PINCTRL
 	help
 	  Enable the Microchip XEC I2C V2 driver.
+
+if I2C_XEC_V2
+
+config I2C_XEC_PORT_MUX
+	bool "Allow I2C configuration to switch port and frequency"
+	default y
+	help
+	  Microhip MEC I2C-SMBus controllers each have a hardware port
+	  multiplexer. The MUX allows each controller to be connected to
+	  one of the 16 ports the specific chip implements. This can be
+	  used to dynamically switch controllers between multiple ports.
+	  Multiple controllers may also be connected to the same port.
+	  It is recommended the controller be reset and reconfigured after
+	  switching to a new port. The controller samples the pins over
+	  a time window when it is released from reset. This feature
+	  enodes the 4-bit port select field in unused bits[19:16] of
+	  the 32-bit I2C driver configuration word. This allows the
+	  application to switch the port and configure a new frequency
+	  in one API call.
+
+endif # I2C_XEC_V2

--- a/drivers/i2c/i2c_mchp_xec_v2.c
+++ b/drivers/i2c/i2c_mchp_xec_v2.c
@@ -7,1113 +7,1837 @@
 
 #define DT_DRV_COMPAT microchip_xec_i2c_v2
 
-#include <zephyr/kernel.h>
 #include <soc.h>
-#include <errno.h>
-#include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
+#include <zephyr/drivers/i2c/mchp_xec_i2c.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/sys/printk.h>
-#include <zephyr/sys/sys_io.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 #include <zephyr/irq.h>
-LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/atomic.h>
+#include "zephyr/sys/slist.h"
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
 
-#include "i2c-priv.h"
+LOG_MODULE_REGISTER(i2c_xec_v3, CONFIG_I2C_LOG_LEVEL);
 
-#define SPEED_100KHZ_BUS	0
-#define SPEED_400KHZ_BUS	1
-#define SPEED_1MHZ_BUS		2
+#include "i2c-priv.h"        /* dependency on logging */
+#include "i2c_mchp_xec_v2.h" /* register defines */
 
-#define EC_OWN_I2C_ADDR		0x7F
-#define RESET_WAIT_US		20
+/* Microchip MEC I2C controller using byte mode.
+ * This driver is for HW version 3.7 and above.
+ */
+
+/* #define XEC_I2C_DEBUG_USE_SPIN_LOOP */
+/* #define XEC_I2C_DEBUG_ISR */
+/* #define XEC_I2C_DEBUG_STATE */
+/* #define XEC_I2C_DEBUG_STATE_ENTRIES 256 */
+
+#define RESET_WAIT_US 20
 
 /* I2C timeout is  10 ms (WAIT_INTERVAL * WAIT_COUNT) */
-#define WAIT_INTERVAL		50
-#define WAIT_COUNT		200
-#define STOP_WAIT_COUNT		500
-#define PIN_CFG_WAIT		50
-
-/* I2C Read/Write bit pos */
-#define I2C_READ_WRITE_POS	0
+#define WAIT_INTERVAL   50
+#define WAIT_COUNT      200
+#define STOP_WAIT_COUNT 500
+#define PIN_CFG_WAIT    50
 
 /* I2C recover SCL low retries */
-#define I2C_RECOVER_SCL_LOW_RETRIES	10
+#define I2C_XEC_RECOVER_SCL_LOW_RETRIES 10
 /* I2C recover SDA low retries */
-#define I2C_RECOVER_SDA_LOW_RETRIES	3
+#define I2C_XEC_RECOVER_SDA_LOW_RETRIES 3
 /* I2C recovery bit bang delay */
-#define I2C_RECOVER_BB_DELAY_US		5
+#define I2C_XEC_RECOVER_BB_DELAY_US     5
 /* I2C recovery SCL sample delay */
-#define I2C_RECOVER_SCL_DELAY_US	50
+#define I2C_XEC_RECOVER_SCL_DELAY_US    50
 
-/* I2C SCL and SDA lines(signals) */
-#define I2C_LINES_SCL_HI	BIT(SOC_I2C_SCL_POS)
-#define I2C_LINES_SDA_HI	BIT(SOC_I2C_SDA_POS)
-#define I2C_LINES_BOTH_HI	(I2C_LINES_SCL_HI | I2C_LINES_SDA_HI)
+#define I2C_XEC_CTRL_WR_DLY 8
 
-#define I2C_START		0U
-#define I2C_RPT_START		1U
+/* get_lines bit positions */
+#define XEC_I2C_SCL_LINE_POS 0
+#define XEC_I2C_SDA_LINE_POS 1
+#define XEC_I2C_LINES_MSK    (BIT(XEC_I2C_SCL_LINE_POS) | BIT(XEC_I2C_SDA_LINE_POS))
 
-#define I2C_ENI_DIS		0U
-#define I2C_ENI_EN		1U
+#define XEC_I2C_CR_PIN_ESO_ACK                                                                     \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ACK_POS))
 
-#define I2C_WAIT_PIN_DEASSERT	0U
-#define I2C_WAIT_PIN_ASSERT	1U
+#define XEC_I2C_CR_PIN_ESO_ENI_ACK (XEC_I2C_CR_PIN_ESO_ACK | BIT(XEC_I2C_CR_ENI_POS))
 
-#define I2C_XEC_CTRL_WR_DLY	8
+#define XEC_I2C_CR_START                                                                           \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STA_POS) |             \
+	 BIT(XEC_I2C_CR_ACK_POS))
 
-#define I2C_XEC_STATE_STOPPED	1U
-#define I2C_XEC_STATE_OPEN	2U
+#define XEC_I2C_CR_START_ENI (XEC_I2C_CR_START | BIT(XEC_I2C_CR_ENI_POS))
 
-#define I2C_XEC_OK		0
-#define I2C_XEC_ERR_LAB		1
-#define I2C_XEC_ERR_BUS		2
-#define I2C_XEC_ERR_TMOUT	3
+#define XEC_I2C_CR_RPT_START                                                                       \
+	(BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STA_POS) | BIT(XEC_I2C_CR_ACK_POS))
 
-#define XEC_GPIO_CTRL_BASE	DT_REG_ADDR(DT_NODELABEL(gpio_000_036))
+#define XEC_I2C_CR_RPT_START_ENI (XEC_I2C_CR_RPT_START | BIT(XEC_I2C_CR_ENI_POS))
 
-struct xec_speed_cfg {
-	uint32_t bus_clk;
-	uint32_t data_timing;
-	uint32_t start_hold_time;
-	uint32_t idle_scale;
-	uint32_t timeout_scale;
+#define XEC_I2C_CR_STOP                                                                            \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STO_POS) |             \
+	 BIT(XEC_I2C_CR_ACK_POS))
+
+#define XEC_I2C_TM_HOST_READ_IGNORE_VAL 0xffu
+
+enum xec_i2c_state {
+	XEC_I2C_STATE_CLOSED = 0,
+	XEC_I2C_STATE_OPEN,
+};
+
+enum xec_i2c_error {
+	XEC_I2C_ERR_NONE = 0,
+	XEC_I2C_ERR_BUS,
+	XEC_I2C_ERR_LOST_ARB,
+	XEC_I2C_ERR_TIMEOUT,
+};
+
+enum xec_i2c_direction {
+	XEC_I2C_DIR_NONE = 0,
+	XEC_I2C_DIR_WR,
+	XEC_I2C_DIR_RD,
+};
+
+enum xec_i2c_start {
+	XEC_I2C_START_NONE = 0,
+	XEC_I2C_START_NORM,
+	XEC_I2C_START_RPT,
+};
+
+enum i2c_xec_isr_state {
+	I2C_XEC_ISR_STATE_GEN_START = 0,
+	I2C_XEC_ISR_STATE_CHK_ACK,
+	I2C_XEC_ISR_STATE_WR_DATA,
+	I2C_XEC_ISR_STATE_RD_DATA,
+	I2C_XEC_ISR_STATE_GEN_STOP,
+	I2C_XEC_ISR_STATE_EV_IDLE,
+	I2C_XEC_ISR_STATE_NEXT_MSG,
+	I2C_XEC_ISR_STATE_EXIT_1,
+#ifdef CONFIG_I2C_TARGET
+	I2C_XEC_ISR_STATE_TM_HOST_RD,
+	I2C_XEC_ISR_STATE_TM_HOST_WR,
+	I2C_XEC_ISR_STATE_TM_EV_STOP,
+#endif
+	I2C_XEC_ISR_STATE_MAX
+};
+
+enum i2c_xec_std_freq {
+	XEC_I2C_STD_FREQ_100K = 0,
+	XEC_I2C_STD_FREQ_400K,
+	XEC_I2C_STD_FREQ_1M,
+	XEC_I2C_STD_FREQ_MAX,
+};
+
+struct xec_i2c_timing {
+	uint32_t freq_hz;
+	uint32_t data_tm;    /* data timing  */
+	uint32_t idle_sc;    /* idle scaling */
+	uint32_t timeout_sc; /* timeout scaling */
+	uint32_t bus_clock;  /* bus clock hi/lo pulse widths */
+	uint8_t rpt_sta_htm; /* repeated start hold time */
 };
 
 struct i2c_xec_config {
-	uint32_t port_sel;
-	uint32_t base_addr;
+	mem_addr_t base;
 	uint32_t clock_freq;
-	uint8_t girq;
-	uint8_t girq_pos;
-	uint8_t pcr_idx;
-	uint8_t pcr_bitpos;
+	struct gpio_dt_spec sda_gpio;
+	struct gpio_dt_spec scl_gpio;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config_func)(void);
+	uint8_t girq;
+	uint8_t girq_pos;
+	uint8_t enc_pcr;
+	uint8_t port;
+};
+
+#define I2C_XEC_XFR_FLAG_START_REQ 0x01
+#define I2C_XEC_XFR_FLAG_STOP_REQ  0x02
+
+#define I2C_XEC_XFR_STS_NACK 0x01
+#define I2c_MEC5_XFR_STS_BER 0x02
+#define I2c_MEC5_XFR_STS_LAB 0x04
+
+struct i2c_xec_cm_xfr {
+	volatile uint8_t *mbuf;
+	volatile size_t mlen;
+	volatile uint8_t xfr_sts;
+	uint8_t mdir;
+	uint8_t target_addr;
+	uint8_t mflags;
 };
 
 struct i2c_xec_data {
-	uint8_t state;
-	uint8_t read_discard;
-	uint8_t speed_id;
-	struct i2c_target_config *target_cfg;
-	bool target_attached;
-	bool target_read;
+	struct k_work kworkq;
+	const struct device *dev;
+	struct k_mutex lock_mut;
+	struct k_sem sync_sem;
+	uint32_t i2c_config;
+	uint32_t clock_freq;
 	uint32_t i2c_compl;
-	uint8_t i2c_ctrl;
-	uint8_t i2c_addr;
-	uint8_t i2c_status;
+	uint8_t i2c_cr_shadow;
+	uint8_t i2c_sr;
+	uint8_t port_sel;
+	uint8_t wraddr;
+	uint8_t state;
+	uint8_t xfr_state;
+	uint8_t cm_dir;
+	uint8_t tm_dir;
+	uint8_t read_discard;
+	uint8_t msg_idx;
+	uint8_t num_msgs;
+	struct i2c_msg *msgs;
+	struct i2c_xec_cm_xfr cm_xfr;
+	volatile uint8_t mdone;
+#ifdef CONFIG_I2C_TARGET
+	uint16_t targ_addr;
+	uint8_t targ_data;
+	uint8_t targ_ignore;
+	uint8_t targ_active;
+	uint8_t ntargets;
+	sys_slist_t target_list;
+	struct i2c_target_config *curr_target;
+	uint8_t *targ_buf_ptr;
+	uint32_t targ_buf_len;
+#endif
+#ifdef XEC_I2C_DEBUG_STATE
+	volatile uint32_t dbg_state_idx;
+	uint8_t dbg_states[XEC_I2C_DEBUG_STATE_ENTRIES];
+#endif
 };
 
-/* Recommended programming values based on 16MHz
- * i2c_baud_clk_period/bus_clk_period - 2 = (low_period + hi_period)
- * bus_clk_reg (16MHz/100KHz -2) = 0x4F + 0x4F
- *             (16MHz/400KHz -2) = 0x0F + 0x17
- *             (16MHz/1MHz -2) = 0x05 + 0x09
- */
-static const struct xec_speed_cfg xec_cfg_params[] = {
-	[SPEED_100KHZ_BUS] = {
-		.bus_clk            = 0x00004F4F,
-		.data_timing        = 0x0C4D5006,
-		.start_hold_time    = 0x0000004D,
-		.idle_scale         = 0x01FC01ED,
-		.timeout_scale      = 0x4B9CC2C7,
-	},
-	[SPEED_400KHZ_BUS] = {
-		.bus_clk            = 0x00000F17,
-		.data_timing        = 0x040A0A06,
-		.start_hold_time    = 0x0000000A,
-		.idle_scale         = 0x01000050,
-		.timeout_scale      = 0x159CC2C7,
-	},
-	[SPEED_1MHZ_BUS] = {
-		.bus_clk            = 0x00000509,
-		.data_timing        = 0x04060601,
-		.start_hold_time    = 0x00000006,
-		.idle_scale         = 0x10000050,
-		.timeout_scale      = 0x089CC2C7,
-	},
+static const struct xec_i2c_timing xec_i2c_timing_tbl[] = {
+	{KHZ(100), XEC_I2C_SMB_DATA_TM_100K, XEC_I2C_SMB_IDLE_SC_100K, XEC_I2C_SMB_TMO_SC_100K,
+	 XEC_I2C_SMB_BUS_CLK_100K, XEC_I2C_SMB_RSHT_100K},
+	{KHZ(400), XEC_I2C_SMB_DATA_TM_400K, XEC_I2C_SMB_IDLE_SC_400K, XEC_I2C_SMB_TMO_SC_400K,
+	 XEC_I2C_SMB_BUS_CLK_400K, XEC_I2C_SMB_RSHT_400K},
+	{MHZ(1), XEC_I2C_SMB_DATA_TM_1M, XEC_I2C_SMB_IDLE_SC_1M, XEC_I2C_SMB_TMO_SC_1M,
+	 XEC_I2C_SMB_BUS_CLK_1M, XEC_I2C_SMB_RSHT_1M},
 };
 
-static void i2c_ctl_wr(const struct device *dev, uint8_t ctrl)
+#ifdef XEC_I2C_DEBUG_ISR
+volatile uint32_t i2c_xec_isr_cnt;
+volatile uint32_t i2c_xec_isr_sts;
+volatile uint32_t i2c_xec_isr_compl;
+volatile uint32_t i2c_xec_isr_cfg;
+
+static inline void i2c_xec_dbg_isr_init(void)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
+	i2c_xec_isr_cnt = 0;
+}
+#define XEC_I2C_DEBUG_ISR_INIT() i2c_xec_dbg_isr_init()
+#else
+#define XEC_I2C_DEBUG_ISR_INIT()
+#endif
 
-	data->i2c_ctrl = ctrl;
-	regs->CTRLSTS = ctrl;
-	for (int i = 0; i < I2C_XEC_CTRL_WR_DLY; i++) {
-		regs->BLKID = ctrl;
-	}
+#ifdef XEC_I2C_DEBUG_STATE
+static void xec_i2c_dbg_state_init(struct i2c_xec_data *data)
+{
+	data->dbg_state_idx = 0u;
+	memset((void *)data->dbg_states, 0, sizeof(data->dbg_states));
 }
 
-static int i2c_xec_reset_config(const struct device *dev);
+static void xec_i2c_dbg_state_update(struct i2c_xec_data *data, uint8_t state)
+{
+	uint32_t idx = data->dbg_state_idx;
+
+	if (data->dbg_state_idx < XEC_I2C_DEBUG_STATE_ENTRIES) {
+		data->dbg_states[idx] = state;
+		data->dbg_state_idx = ++idx;
+	}
+}
+#define XEC_I2C_DEBUG_STATE_INIT(pd)          xec_i2c_dbg_state_init(pd)
+#define XEC_I2C_DEBUG_STATE_UPDATE(pd, state) xec_i2c_dbg_state_update(pd, state)
+#else
+#define XEC_I2C_DEBUG_STATE_INIT(pd)
+#define XEC_I2C_DEBUG_STATE_UPDATE(pd, state)
+#endif
+
+static int xec_i2c_prog_standard_timing(const struct device *dev, uint32_t freq_hz)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	for (size_t n = 0; n < ARRAY_SIZE(xec_i2c_timing_tbl); n++) {
+		const struct xec_i2c_timing *p = &xec_i2c_timing_tbl[n];
+
+		if (freq_hz == p->freq_hz) {
+			sys_write32(p->data_tm, rb + XEC_I2C_DT_OFS);
+			sys_write32(p->idle_sc, rb + XEC_I2C_ISC_OFS);
+			sys_write32(p->timeout_sc, rb + XEC_I2C_TMOUT_SC_OFS);
+			sys_write16(p->bus_clock, rb + XEC_I2C_BCLK_OFS);
+			sys_write8(p->rpt_sta_htm, rb + XEC_I2C_RSHT_OFS);
+
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static void xec_i2c_cr_write(const struct device *dev, uint8_t ctrl_val)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+
+	data->i2c_cr_shadow = ctrl_val;
+	sys_write8(ctrl_val, devcfg->base + XEC_I2C_CR_OFS);
+}
+
+#ifdef CONFIG_I2C_TARGET
+static void xec_i2c_cr_write_mask(const struct device *dev, uint8_t clr_msk, uint8_t set_msk)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+
+	data->i2c_cr_shadow = (data->i2c_cr_shadow & (uint8_t)~clr_msk) | set_msk;
+	sys_write8(data->i2c_cr_shadow, devcfg->base + XEC_I2C_CR_OFS);
+}
+#endif
 
 static int wait_bus_free(const struct device *dev, uint32_t nwait)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
 	uint32_t count = nwait;
 	uint8_t sts = 0;
 
 	while (count--) {
-		sts = regs->CTRLSTS;
-		data->i2c_status = sts;
-		if (sts & MCHP_I2C_SMB_STS_NBB) {
+		sts = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_sr = sts;
+
+		if ((sts & BIT(XEC_I2C_SR_NBB_POS)) != 0) {
 			break; /* bus is free */
 		}
+
 		k_busy_wait(WAIT_INTERVAL);
 	}
 
-	/* NBB -> 1 not busy can occur for STOP, BER, or LAB */
-	if (sts == (MCHP_I2C_SMB_STS_PIN | MCHP_I2C_SMB_STS_NBB)) {
-		/* No service requested(PIN=1), NotBusy(NBB=1), and no errors */
+	/* check for bus error, lost arbitration or external stop */
+	if (sts == (BIT(XEC_I2C_SR_NBB_POS) | BIT(XEC_I2C_SR_PIN_POS))) {
 		return 0;
 	}
 
-	if (sts & MCHP_I2C_SMB_STS_BER) {
-		return I2C_XEC_ERR_BUS;
+	if ((sts & BIT(XEC_I2C_SR_BER_POS)) != 0) {
+		return XEC_I2C_ERR_BUS;
 	}
 
-	if (sts & MCHP_I2C_SMB_STS_LAB) {
-		return I2C_XEC_ERR_LAB;
+	if ((sts & BIT(XEC_I2C_SR_LAB_POS)) != 0) {
+		return XEC_I2C_ERR_LOST_ARB;
 	}
 
-	return I2C_XEC_ERR_TMOUT;
+	return XEC_I2C_ERR_TIMEOUT;
 }
 
-/*
- * returns state of I2C SCL and SDA lines.
- * b[0] = SCL, b[1] = SDA
- * Call soc specific routine to read GPIO pad input.
- * Why? We can get the pins from our PINCTRL info but
- * we do not know which pin is I2C clock and which pin
- * is I2C data. There's no ordering in PINCTRL DT unless
- * we impose an order.
- */
-static uint32_t get_lines(const struct device *dev)
+/* return 0 if SCL and SDA are both high else return -EIO */
+#if defined(CONFIG_SOC_SERIES_MEC172X)
+static int check_lines(const struct device *dev)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	uint8_t port = regs->CFG & MCHP_I2C_SMB_CFG_PORT_SEL_MASK;
-	uint32_t lines = 0u;
+	const struct i2c_xec_config *devcfg = dev->config;
+	gpio_port_value_t sda = 0, scl = 0;
 
-	soc_i2c_port_lines_get(port, &lines);
+	gpio_port_get_raw(devcfg->sda_gpio.port, &sda);
+	scl = sda;
+	if (devcfg->sda_gpio.port != devcfg->scl_gpio.port) {
+		gpio_port_get_raw(devcfg->scl_gpio.port, &scl);
+	}
+
+	if ((sda & BIT(devcfg->sda_gpio.pin)) && (scl & BIT(devcfg->scl_gpio.pin))) {
+		return 0;
+	}
+
+	return -EIO;
+}
+
+/* returns uint8_t with bit[0] = SCL and bit[1] = SDA */
+static uint8_t get_lines(const struct device *dev)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	gpio_port_value_t sda = 0, scl = 0;
+	uint8_t lines = 0;
+
+	gpio_port_get_raw(devcfg->scl_gpio.port, &scl);
+	gpio_port_get_raw(devcfg->sda_gpio.port, &sda);
+
+	if ((sda & BIT(devcfg->scl_gpio.pin)) != 0) {
+		lines |= BIT(XEC_I2C_SCL_LINE_POS);
+	}
+
+	if ((sda & BIT(devcfg->sda_gpio.pin)) != 0) {
+		lines |= BIT(XEC_I2C_SDA_LINE_POS);
+	}
 
 	return lines;
 }
-
-static int i2c_xec_reset_config(const struct device *dev)
+#else
+static int check_lines(const struct device *dev)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	uint8_t himsk = BIT(XEC_I2C_BBCR_SCL_IN_POS) | BIT(XEC_I2C_BBCR_SDA_IN_POS);
+	uint8_t bbcr = 0;
 
-	data->state = I2C_XEC_STATE_STOPPED;
-	data->read_discard = 0;
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+	bbcr = sys_read8(rb + XEC_I2C_BBCR_OFS);
 
-	/* Assert RESET */
-	z_mchp_xec_pcr_periph_reset(cfg->pcr_idx, cfg->pcr_bitpos);
-
-	regs->CFG = MCHP_I2C_SMB_CFG_FLUSH_SXBUF_WO |
-		    MCHP_I2C_SMB_CFG_FLUSH_SRBUF_WO |
-		    MCHP_I2C_SMB_CFG_FLUSH_MXBUF_WO |
-		    MCHP_I2C_SMB_CFG_FLUSH_MRBUF_WO;
-
-	mchp_xec_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
-
-	/* PIN=1 to clear all status except NBB and synchronize */
-	i2c_ctl_wr(dev, MCHP_I2C_SMB_CTRL_PIN);
-
-	/*
-	 * Controller implements two peripheral addresses for itself.
-	 * It always monitors whether an external controller issues START
-	 * plus target address. We should write valid peripheral addresses
-	 * that do not match any peripheral on the bus.
-	 * An alternative is to use the default 0 value which is the
-	 * general call address and disable the general call match
-	 * enable in the configuration register.
-	 */
-	regs->OWN_ADDR = EC_OWN_I2C_ADDR | (EC_OWN_I2C_ADDR << 8);
-#ifdef CONFIG_I2C_TARGET
-	if (data->target_cfg) {
-		regs->OWN_ADDR = data->target_cfg->address;
+	if ((bbcr & himsk) == himsk) {
+		return 0;
 	}
+
+	return -EIO;
+}
+
+/* returns uint8_t with bit[0] = SCL and bit[1] = SDA */
+static uint8_t get_lines(const struct device *dev)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	uint8_t bbcr = 0;
+	uint8_t lines = 0;
+
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+	bbcr = sys_read8(rb + XEC_I2C_BBCR_OFS);
+
+	if ((bbcr & BIT(XEC_I2C_BBCR_SCL_IN_POS)) != 0) {
+		lines |= BIT(XEC_I2C_SCL_LINE_POS);
+	}
+
+	if ((bbcr & BIT(XEC_I2C_BBCR_SDA_IN_POS)) != 0) {
+		lines |= BIT(XEC_I2C_SDA_LINE_POS);
+	}
+
+	return lines;
+}
 #endif
-	/* Port number and filter enable MUST be written before enabling */
-	regs->CFG |= BIT(14); /* disable general call */
-	regs->CFG |= MCHP_I2C_SMB_CFG_FEN;
-	regs->CFG |= (cfg->port_sel & MCHP_I2C_SMB_CFG_PORT_SEL_MASK);
 
-	/*
-	 * Before enabling the controller program the desired bus clock,
-	 * repeated start hold time, data timing, and timeout scaling
-	 * registers.
-	 */
-	regs->BUSCLK = xec_cfg_params[data->speed_id].bus_clk;
-	regs->RSHTM = xec_cfg_params[data->speed_id].start_hold_time;
-	regs->DATATM = xec_cfg_params[data->speed_id].data_timing;
-	regs->TMOUTSC = xec_cfg_params[data->speed_id].timeout_scale;
-	regs->IDLSC = xec_cfg_params[data->speed_id].idle_scale;
+#ifdef CONFIG_I2C_TARGET
+static uint32_t prog_target_addresses(const struct device *dev)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	sys_snode_t *sn = NULL;
+	uint32_t val = 0, n = 0;
 
-	/*
-	 * PIN=1 clears all status except NBB
-	 * ESO=1 enables output drivers
-	 * ACK=1 enable ACK generation when data/address is clocked in.
-	 */
-	i2c_ctl_wr(dev, MCHP_I2C_SMB_CTRL_PIN |
-			MCHP_I2C_SMB_CTRL_ESO |
-			MCHP_I2C_SMB_CTRL_ACK);
+	SYS_SLIST_FOR_EACH_NODE(&data->target_list, sn) {
+		struct i2c_target_config *ptc = CONTAINER_OF(sn, struct i2c_target_config, node);
 
-	/* Enable controller */
-	regs->CFG |= MCHP_I2C_SMB_CFG_ENAB;
-	k_busy_wait(RESET_WAIT_US);
+		if (ptc != NULL) {
+			n++;
+			if (ptc->address == 0) {
+				sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+			} else if ((ptc->address == 0x08u) || (ptc->address == 0x61u)) {
+				sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+			} else {
+				if (val == 0) {
+					val |= XEC_I2C_OA_1_SET(ptc->address);
+				} else {
+					val |= XEC_I2C_OA_2_SET(ptc->address);
+				}
+			}
+		}
+
+		if (val != 0) {
+			sys_write32(val, rb + XEC_I2C_OA_OFS);
+		}
+	}
+
+	return n;
+}
+#endif /* CONFIG_I2C_TARGET */
+
+static int i2c_xec_reset_config(const struct device *dev, uint8_t port)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	uint32_t val = 0;
+	int rc = 0;
+	uint8_t crval = 0;
+
+	data->i2c_cr_shadow = 0;
+
+	data->state = XEC_I2C_STATE_CLOSED;
+	data->i2c_cr_shadow = 0;
+	data->i2c_sr = 0;
+	data->i2c_compl = 0;
+	data->read_discard = 0;
+	data->mdone = 0;
+
+	soc_xec_pcr_sleep_en_clear(devcfg->enc_pcr);
+	/* reset I2C controller using PCR reset feature */
+	soc_xec_pcr_reset_en(devcfg->enc_pcr);
+
+	/* make sure general call and SMBus target address decodes disabled */
+	sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+	sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+
+	crval = BIT(XEC_I2C_CR_PIN_POS);
+	xec_i2c_cr_write(dev, crval);
+
+#ifdef CONFIG_I2C_TARGET
+	prog_target_addresses(dev);
+#endif
+
+	/* timing registers */
+	xec_i2c_prog_standard_timing(dev, data->clock_freq);
+
+	/* enable output driver and ACK logic */
+	crval = XEC_I2C_CR_PIN_ESO_ENI_ACK;
+	xec_i2c_cr_write(dev, crval);
+
+	/* port and filter enable */
+	val = XEC_I2C_CFG_PORT_SET((uint32_t)port);
+	val |= BIT(XEC_I2C_CFG_FEN_POS);
+	sys_set_bits(rb + XEC_I2C_CFG_OFS, val);
+
+	/* Enable live monitoring of SDA and SCL. No effect on MEC15xx and MEC172x */
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+
+	/* enable */
+	sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
 
 	/* wait for NBB=1, BER, LAB, or timeout */
-	int rc = wait_bus_free(dev, WAIT_COUNT);
+	rc = wait_bus_free(dev, WAIT_COUNT);
 
 	return rc;
 }
 
-/*
- * If SCL is low sample I2C_RECOVER_SCL_LOW_RETRIES times with a 5 us delay
- * between samples. If SCL remains low then return -EBUSY
- * If SCL is High and SDA is low then loop up to I2C_RECOVER_SDA_LOW_RETRIES
- * times driving the pins:
- * Drive SCL high
- * delay I2C_RECOVER_BB_DELAY_US
- * Generate 9 clock pulses on SCL checking SDA before each falling edge of SCL
- *   If SDA goes high exit clock loop else to all 9 clocks
- * Drive SDA low, delay 5 us, release SDA, delay 5 us
- * Both lines are high then exit SDA recovery loop
- * Both lines should not be driven
- * Check both lines: if any bad return error else return success
- * NOTE 1: Bit-bang mode uses a HW MUX to switch the lines away from the I2C
- * controller logic to BB logic.
- * NOTE 2: Bit-bang mode requires HW timeouts to be disabled.
- * NOTE 3: Bit-bang mode requires the controller's configuration enable bit
- * to be set.
- * NOTE 4: The controller must be reset after using bit-bang mode.
- */
-static int i2c_xec_recover_bus(const struct device *dev)
+static int i2c_xec_bb_recover(const struct device *dev)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	int i, j, ret;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int ret = 0;
+	uint32_t cnt = I2C_XEC_RECOVER_SCL_LOW_RETRIES;
+	uint8_t bbcr = 0;
+	uint8_t lines = 0u;
 
-	LOG_ERR("I2C attempt bus recovery\n");
+	i2c_xec_reset_config(dev, data->port_sel);
 
-	/* reset controller to a known state */
-	z_mchp_xec_pcr_periph_reset(cfg->pcr_idx, cfg->pcr_bitpos);
-
-	regs->CFG = BIT(14) | MCHP_I2C_SMB_CFG_FEN |
-		    (cfg->port_sel & MCHP_I2C_SMB_CFG_PORT_SEL_MASK);
-	regs->CFG |= MCHP_I2C_SMB_CFG_FLUSH_SXBUF_WO |
-		     MCHP_I2C_SMB_CFG_FLUSH_SRBUF_WO |
-		     MCHP_I2C_SMB_CFG_FLUSH_MXBUF_WO |
-		     MCHP_I2C_SMB_CFG_FLUSH_MRBUF_WO;
-	regs->CTRLSTS = MCHP_I2C_SMB_CTRL_PIN;
-	regs->BBCTRL = MCHP_I2C_SMB_BB_EN | MCHP_I2C_SMB_BB_CL |
-		       MCHP_I2C_SMB_BB_DAT;
-	regs->CFG |= MCHP_I2C_SMB_CFG_ENAB;
-
-	if (!(regs->BBCTRL & MCHP_I2C_SMB_BB_CLKI_RO)) {
-		for (i = 0;; i++) {
-			if (i >= I2C_RECOVER_SCL_LOW_RETRIES) {
-				ret = -EBUSY;
-				goto recov_exit;
-			}
-			k_busy_wait(I2C_RECOVER_SCL_DELAY_US);
-			if (regs->BBCTRL & MCHP_I2C_SMB_BB_CLKI_RO) {
-				break; /* SCL went High */
-			}
-		}
+	lines = get_lines(dev);
+	if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) {
+		return 0;
 	}
 
-	if (regs->BBCTRL & MCHP_I2C_SMB_BB_DATI_RO) {
-		ret = 0;
-		goto recov_exit;
-	}
+	/* Disconnect SDL and SDA from I2C logic and connect to bit-bang logic */
+	bbcr = BIT(XEC_I2C_BBCR_EN_POS) | BIT(XEC_I2C_BBCR_CM_POS);
+	sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
 
-	ret = -EBUSY;
-	/* SDA recovery */
-	for (i = 0; i < I2C_RECOVER_SDA_LOW_RETRIES; i++) {
-		/* SCL output mode and tri-stated */
-		regs->BBCTRL = MCHP_I2C_SMB_BB_EN |
-			       MCHP_I2C_SMB_BB_SCL_DIR_OUT |
-			       MCHP_I2C_SMB_BB_CL |
-			       MCHP_I2C_SMB_BB_DAT;
-		k_busy_wait(I2C_RECOVER_BB_DELAY_US);
+	lines = get_lines(dev);
 
-		for (j = 0; j < 9; j++) {
-			if (regs->BBCTRL & MCHP_I2C_SMB_BB_DATI_RO) {
-				break;
-			}
-			/* drive SCL low */
-			regs->BBCTRL = MCHP_I2C_SMB_BB_EN |
-				       MCHP_I2C_SMB_BB_SCL_DIR_OUT |
-				       MCHP_I2C_SMB_BB_DAT;
-			k_busy_wait(I2C_RECOVER_BB_DELAY_US);
-			/* release SCL: pulled high by external pull-up */
-			regs->BBCTRL = MCHP_I2C_SMB_BB_EN |
-				       MCHP_I2C_SMB_BB_SCL_DIR_OUT |
-				       MCHP_I2C_SMB_BB_CL |
-				       MCHP_I2C_SMB_BB_DAT;
-			k_busy_wait(I2C_RECOVER_BB_DELAY_US);
-		}
-
-		/* SCL is High. Produce rising edge on SCL for STOP */
-		regs->BBCTRL = MCHP_I2C_SMB_BB_EN | MCHP_I2C_SMB_BB_CL |
-				MCHP_I2C_SMB_BB_SDA_DIR_OUT; /* drive low */
-		k_busy_wait(I2C_RECOVER_BB_DELAY_US);
-		regs->BBCTRL = MCHP_I2C_SMB_BB_EN | MCHP_I2C_SMB_BB_CL |
-				MCHP_I2C_SMB_BB_DAT; /* release SCL */
-		k_busy_wait(I2C_RECOVER_BB_DELAY_US);
-
-		/* check if SCL and SDA are both high */
-		uint8_t bb = regs->BBCTRL &
-			(MCHP_I2C_SMB_BB_CLKI_RO | MCHP_I2C_SMB_BB_DATI_RO);
-
-		if (bb == (MCHP_I2C_SMB_BB_CLKI_RO | MCHP_I2C_SMB_BB_DATI_RO)) {
-			ret = 0; /* successful recovery */
-			goto recov_exit;
-		}
-	}
-
-recov_exit:
-	/* BB mode disable reconnects SCL and SDA to I2C logic. */
-	regs->BBCTRL = 0;
-	regs->CTRLSTS = MCHP_I2C_SMB_CTRL_PIN; /* clear status */
-	i2c_xec_reset_config(dev); /* reset controller */
-
-	return ret;
-}
-
-#ifdef CONFIG_I2C_TARGET
-/*
- * Restart I2C controller as target for ACK of address match.
- * Setting PIN clears all status in I2C.Status register except NBB.
- */
-static void restart_target(const struct device *dev)
-{
-	i2c_ctl_wr(dev, MCHP_I2C_SMB_CTRL_PIN | MCHP_I2C_SMB_CTRL_ESO |
-			MCHP_I2C_SMB_CTRL_ACK | MCHP_I2C_SMB_CTRL_ENI);
-}
-
-/*
- * Configure I2C controller acting as target to NACK the next received byte.
- * NOTE: Firmware must re-enable ACK generation before the start of the next
- * transaction otherwise the controller will NACK its target addresses.
- */
-static void target_config_for_nack(const struct device *dev)
-{
-	i2c_ctl_wr(dev, MCHP_I2C_SMB_CTRL_PIN | MCHP_I2C_SMB_CTRL_ESO |
-			MCHP_I2C_SMB_CTRL_ENI);
-}
-#endif
-
-static int wait_pin(const struct device *dev, bool pin_assert, uint32_t nwait)
-{
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-
-	for (;;) {
-		k_busy_wait(WAIT_INTERVAL);
-
-		data->i2c_compl = regs->COMPL;
-		data->i2c_status = regs->CTRLSTS;
-
-		if (data->i2c_status & MCHP_I2C_SMB_STS_BER) {
-			return I2C_XEC_ERR_BUS;
-		}
-
-		if (data->i2c_status & MCHP_I2C_SMB_STS_LAB) {
-			return I2C_XEC_ERR_LAB;
-		}
-
-		if (!(data->i2c_status & MCHP_I2C_SMB_STS_PIN)) {
-			if (pin_assert) {
-				return 0;
-			}
-		} else if (!pin_assert) {
-			return 0;
-		}
-
-		if (nwait) {
-			--nwait;
+	/* If SCL is low continue sampling hoping it will go high on its own */
+	while (!(lines & BIT(XEC_I2C_SCL_LINE_POS))) {
+		if (cnt) {
+			cnt--;
 		} else {
 			break;
 		}
+		k_busy_wait(I2C_XEC_RECOVER_SCL_DELAY_US);
+		lines = get_lines(dev);
 	}
 
-	return I2C_XEC_ERR_TMOUT;
-}
-
-static int gen_start(const struct device *dev, uint8_t addr8,
-		     bool is_repeated)
-{
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	uint8_t ctrl = MCHP_I2C_SMB_CTRL_ESO | MCHP_I2C_SMB_CTRL_STA |
-		       MCHP_I2C_SMB_CTRL_ACK;
-
-	data->i2c_addr = addr8;
-
-	if (is_repeated) {
-		i2c_ctl_wr(dev, ctrl);
-		regs->I2CDATA = addr8;
-	} else {
-		ctrl |= MCHP_I2C_SMB_CTRL_PIN;
-		regs->I2CDATA = addr8;
-		i2c_ctl_wr(dev, ctrl);
+	lines = get_lines(dev);
+	if ((lines & BIT(XEC_I2C_SCL_LINE_POS)) == 0) {
+		ret = -EBUSY;
+		goto disable_bb_exit;
 	}
 
-	return 0;
-}
+	/* SCL is high, check SDA */
+	if ((lines & BIT(XEC_I2C_SDA_LINE_POS)) != 0) {
+		ret = 0; /* both high */
+		goto disable_bb_exit;
+	}
 
-static int gen_stop(const struct device *dev)
-{
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	uint8_t ctrl = MCHP_I2C_SMB_CTRL_PIN | MCHP_I2C_SMB_CTRL_ESO |
-		       MCHP_I2C_SMB_CTRL_STO | MCHP_I2C_SMB_CTRL_ACK;
+	/* SCL is high and SDA is low. Loop generating 9 clocks until
+	 * we observe SDA high or loop terminates
+	 */
+	ret = -EBUSY;
+	for (int i = 0; i < I2C_XEC_RECOVER_SDA_LOW_RETRIES; i++) {
+		bbcr = 0x81u; /* SCL & SDA tri-state (inputs) */
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
 
-	data->i2c_ctrl = ctrl;
-	regs->CTRLSTS = ctrl;
+		/* 9 clocks */
+		for (int j = 0; j < 9; j++) {
+			/* drive SCL low */
+			bbcr = 0x83u; /* SCL output drive low, SDA tri-state input */
+			sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+			k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+			/* drive SCL high */
+			bbcr = 0x81u; /* SCL & SDA tri-state inputs */
+			sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+			k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+		}
 
-	return 0;
-}
+		lines = get_lines(dev);
+		if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) { /* Both high? */
+			ret = 0;
+			goto disable_bb_exit;
+		}
 
-static int do_stop(const struct device *dev, uint32_t nwait)
-{
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	int ret;
+		/* generate I2C STOP.  While SCL is high SDA transitions low to high */
+		bbcr = 0x85u; /* SCL tri-state input (high), drive SDA low */
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+		k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+		bbcr = 0x81u; /* SCL and SDA tri-state inputs. */
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+		k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
 
-	data->state = I2C_XEC_STATE_STOPPED;
-	data->read_discard = 0;
-
-	gen_stop(dev);
-	ret = wait_bus_free(dev, nwait);
-	if (ret) {
-		uint32_t lines = get_lines(dev);
-
-		if (lines != I2C_LINES_BOTH_HI) {
-			i2c_xec_recover_bus(dev);
-		} else {
-			ret = i2c_xec_reset_config(dev);
+		lines = get_lines(dev);
+		if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) { /* Both high? */
+			ret = 0;
+			goto disable_bb_exit;
 		}
 	}
 
+disable_bb_exit:
+	bbcr = 0x80u;
+	sys_write8(0x80u, rb + XEC_I2C_BBCR_OFS);
+
+	return ret;
+}
+
+static int i2c_xec_recover_bus(const struct device *dev)
+{
+	struct i2c_xec_data *const data = dev->data;
+	int ret = 0;
+
+	LOG_ERR("I2C attempt bus recovery\n");
+
+	/* Try controller reset first */
+	ret = i2c_xec_reset_config(dev, data->port_sel);
 	if (ret == 0) {
-		/* stop success: prepare for next transaction */
-		regs->CTRLSTS = MCHP_I2C_SMB_CTRL_PIN | MCHP_I2C_SMB_CTRL_ESO |
-				MCHP_I2C_SMB_CTRL_ACK;
+		ret = check_lines(dev);
+	}
+
+	if (ret != 0) {
+		return 0;
+	}
+
+	ret = i2c_xec_bb_recover(dev);
+	if (ret == 0) {
+		ret = wait_bus_free(dev, WAIT_COUNT);
 	}
 
 	return ret;
 }
 
-static int do_start(const struct device *dev, uint8_t addr8, bool is_repeated)
+static int i2c_xec_cfg(const struct device *dev, uint32_t dev_config_raw)
 {
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	int ret;
-
-	gen_start(dev, addr8, is_repeated);
-	ret = wait_pin(dev, I2C_WAIT_PIN_ASSERT, WAIT_COUNT);
-	if (ret) {
-		i2c_xec_reset_config(dev);
-		return ret;
-	}
-
-	/* PIN 1->0: check for NACK */
-	if (data->i2c_status & MCHP_I2C_SMB_STS_LRB_AD0) {
-		gen_stop(dev);
-		ret = wait_bus_free(dev, WAIT_COUNT);
-		if (ret) {
-			i2c_xec_reset_config(dev);
-		}
-		return -EIO;
-	}
-
-	return 0;
-}
-
-static int i2c_xec_configure(const struct device *dev,
-			     uint32_t dev_config_raw)
-{
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-
-	if (!(dev_config_raw & I2C_MODE_CONTROLLER)) {
-		return -ENOTSUP;
-	}
-
-	if (dev_config_raw & I2C_ADDR_10_BITS) {
-		return -ENOTSUP;
-	}
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	uint8_t port = devcfg->port;
 
 	switch (I2C_SPEED_GET(dev_config_raw)) {
 	case I2C_SPEED_STANDARD:
-		data->speed_id = SPEED_100KHZ_BUS;
+		data->clock_freq = KHZ(100);
 		break;
 	case I2C_SPEED_FAST:
-		data->speed_id = SPEED_400KHZ_BUS;
+		data->clock_freq = KHZ(400);
 		break;
 	case I2C_SPEED_FAST_PLUS:
-		data->speed_id = SPEED_1MHZ_BUS;
+		data->clock_freq = MHZ(1);
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	int ret = i2c_xec_reset_config(dev);
+	data->i2c_config = dev_config_raw;
+#ifdef CONFIG_I2C_XEC_PORT_MUX
+	port = I2C_XEC_PORT_GET(dev_config_raw);
+#endif
 
-	return ret;
+	return i2c_xec_reset_config(dev, port);
 }
 
-/* I2C Controller transmit: polling implementation */
-static int ctrl_tx(const struct device *dev, struct i2c_msg *msg, uint16_t addr)
+/* i2c_configure API */
+static int i2c_xec_configure(const struct device *dev, uint32_t dev_config_raw)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	int ret = 0;
-	uint8_t mflags = msg->flags;
-	uint8_t addr8 = (uint8_t)((addr & 0x7FU) << 1);
+	struct i2c_xec_data *const data = dev->data;
+	int rc = 0;
 
-	if (data->state == I2C_XEC_STATE_STOPPED) {
-		data->i2c_addr = addr8;
-		/* Is bus free and controller ready? */
-		ret = wait_bus_free(dev, WAIT_COUNT);
-		if (ret) {
-			ret = i2c_xec_recover_bus(dev);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		ret = do_start(dev, addr8, I2C_START);
-		if (ret) {
-			return ret;
-		}
-
-		data->state = I2C_XEC_STATE_OPEN;
-
-	} else if (mflags & I2C_MSG_RESTART) {
-		data->i2c_addr = addr8;
-		ret = do_start(dev, addr8, I2C_RPT_START);
-		if (ret) {
-			return ret;
-		}
+	if (!(dev_config_raw & I2C_MODE_CONTROLLER)) {
+		return -ENOTSUP;
 	}
 
-	for (size_t n = 0; n < msg->len; n++) {
-		regs->I2CDATA = msg->buf[n];
-		ret = wait_pin(dev, I2C_WAIT_PIN_ASSERT, WAIT_COUNT);
-		if (ret) {
-			i2c_xec_reset_config(dev);
-			return ret;
-		}
-		if (data->i2c_status & MCHP_I2C_SMB_STS_LRB_AD0) { /* NACK? */
-			do_stop(dev, STOP_WAIT_COUNT);
-			return -EIO;
-		}
+	rc = k_mutex_lock(&data->lock_mut, K_NO_WAIT);
+	if (rc != 0) {
+		return rc;
 	}
 
-	if (mflags & I2C_MSG_STOP) {
-		ret = do_stop(dev, STOP_WAIT_COUNT);
-	}
+	rc = i2c_xec_cfg(dev, dev_config_raw);
 
-	return ret;
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
 }
 
-/*
- * I2C Controller receive: polling implementation
- * Transmitting a target address with BIT[0] == 1 causes the controller
- * to enter controller-read mode where every read of I2CDATA generates
- * clocks for the next byte. When we generate START or Repeated-START
- * and transmit an address the address is also clocked in during
- * address transmission. The address must read and discarded.
- * Read of I2CDATA returns data currently in I2C read buffer, sets
- * I2CSTATUS.PIN = 1, and !!generates clocks for the next
- * byte!!
- * For this controller to NACK the last byte we must clear the
- * I2C CTRL register ACK bit BEFORE reading the next to last
- * byte. Before reading the last byte we configure I2C CTRL to generate a STOP
- * and then read the last byte from I2 DATA.
- * When controller is in STOP mode it will not generate clocks when I2CDATA is
- * read. UGLY HW DESIGN.
- * We will NOT attempt to follow this HW design for Controller read except
- * when all information is available: STOP message flag set AND number of
- * bytes to read including dummy is >= 2. General usage can result in the
- * controller not NACK'ing the last byte.
- */
-static int ctrl_rx(const struct device *dev, struct i2c_msg *msg, uint16_t addr)
+/* i2c_get_config API */
+static int i2c_xec_get_config(const struct device *dev, uint32_t *dev_config)
 {
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	int ret = 0;
-	size_t data_len = msg->len;
-	uint8_t mflags = msg->flags;
-	uint8_t addr8 = (uint8_t)(((addr & 0x7FU) << 1) | BIT(0));
-	uint8_t temp = 0;
+	struct i2c_xec_data *const data = dev->data;
+	uint32_t dcfg = 0u;
 
-	if (data->state == I2C_XEC_STATE_STOPPED) {
-		data->i2c_addr = addr8;
-		/* Is bus free and controller ready? */
-		ret = wait_bus_free(dev, WAIT_COUNT);
-		if (ret) {
-			i2c_xec_reset_config(dev);
-			return ret;
-		}
-
-		ret = do_start(dev, addr8, I2C_START);
-		if (ret) {
-			return ret;
-		}
-
-		data->state = I2C_XEC_STATE_OPEN;
-
-		/* controller clocked address into I2CDATA */
-		data->read_discard = 1U;
-
-	} else if (mflags & I2C_MSG_RESTART) {
-		data->i2c_addr = addr8;
-		ret = do_start(dev, addr8, I2C_RPT_START);
-		if (ret) {
-			return ret;
-		}
-
-		/* controller clocked address into I2CDATA */
-		data->read_discard = 1U;
+	if (dev_config == NULL) {
+		return -EINVAL;
 	}
 
-	if (!data_len) { /* requested message length is 0 */
-		ret = 0;
-		if (mflags & I2C_MSG_STOP) {
-			data->state = I2C_XEC_STATE_STOPPED;
-			data->read_discard = 0;
-			ret = do_stop(dev, STOP_WAIT_COUNT);
-		}
-		return ret;
-	}
-
-	if (data->read_discard) {
-		data_len++;
-	}
-
-	uint8_t *p8 = &msg->buf[0];
-
-	while (data_len) {
-		if (mflags & I2C_MSG_STOP) {
-			if (data_len == 2) {
-				i2c_ctl_wr(dev, MCHP_I2C_SMB_CTRL_ESO);
-			} else if (data_len == 1) {
-				break;
-			}
-		}
-		temp = regs->I2CDATA; /* generates clocks */
-		if (data->read_discard) {
-			data->read_discard = 0;
-		} else {
-			*p8++ = temp;
-		}
-		ret = wait_pin(dev, I2C_WAIT_PIN_ASSERT, WAIT_COUNT);
-		if (ret) {
-			i2c_xec_reset_config(dev);
-			return ret;
-		}
-		data_len--;
-	}
-
-	if (mflags & I2C_MSG_STOP) {
-		data->state = I2C_XEC_STATE_STOPPED;
-		data->read_discard = 0;
-		ret = do_stop(dev, STOP_WAIT_COUNT);
-		if (ret == 0) {
-			*p8 = regs->I2CDATA;
-		}
-	}
-
-	return ret;
-}
-
-static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs,
-			    uint8_t num_msgs, uint16_t addr)
-{
-	struct i2c_xec_data *data = dev->data;
-	int ret = 0;
+	dcfg = data->i2c_config;
 
 #ifdef CONFIG_I2C_TARGET
-	if (data->target_attached) {
-		LOG_ERR("Device is registered as target");
+	if (data->ntargets == 0) {
+		dcfg |= I2C_MODE_CONTROLLER;
+	} else {
+		dcfg &= ~I2C_MODE_CONTROLLER;
+	}
+#else
+	dcfg |= I2C_MODE_CONTROLLER;
+#endif
+	*dev_config = dcfg;
+
+	return 0;
+}
+
+/* XEC I2C controller support 7-bit addressing only.
+ * Format 7-bit address for as it appears on the bus as an 8-bit
+ * value with R/W bit at bit[0], 0(write), 1(read).
+ */
+static inline uint8_t i2c_xec_fmt_addr(uint16_t addr, uint8_t read)
+{
+	uint8_t fmt_addr = (uint8_t)((addr & 0x7fu) << 1);
+
+	if (read != 0) {
+		fmt_addr |= BIT(0);
+	}
+
+	return fmt_addr;
+}
+
+/* I2C STOP only if controller owns the bus otherwise
+ * clear driver state and re-arm controller for next
+ * controller-mode or target-mode transaction.
+ * Reason for ugly code sequence:
+ * Brain-dead I2C controller has write-only control register
+ * containing enable interrupt bit. This is the enable for ACK/NACK,
+ * bus error and lost arbitration.
+ * NOTE: IDLE interrupt has issues. If it is enabled it can fire if the bus
+ * goes IDLE before we perform an action such as generate the STOP.
+ */
+static int i2c_xec_stop(const struct device *dev, uint32_t flags)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+	uint8_t ctrl = 0, sts = 0;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x20);
+
+	/* Is the bus busy? */
+	sts = sys_read8(rb + XEC_I2C_SR_OFS);
+	if ((sts & BIT(XEC_I2C_SR_NBB_POS)) == 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x21);
+		data->mdone = 0;
+		ctrl = (BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) |
+			BIT(XEC_I2C_CR_STO_POS) | BIT(XEC_I2C_CR_ACK_POS));
+
+		/* disable IDLE interrupt in config register */
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+		/* clear IDLE R/W1C status in completion register */
+		sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+		/* clear GIRQ status */
+		soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+		/* generate STOP */
+		xec_i2c_cr_write(dev, ctrl);
+
+		if (flags & BIT(0)) { /* detect STOP completion with interrupt */
+			/* enable IDLE interrupt in config register */
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x22);
+			sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+			rc = k_sem_take(&data->sync_sem, K_MSEC(10));
+		} else {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x23);
+			rc = wait_bus_free(dev, WAIT_COUNT);
+		}
+
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x24);
+	}
+
+	data->cm_dir = XEC_I2C_DIR_NONE;
+	data->state = XEC_I2C_STATE_CLOSED;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x25);
+
+	return rc;
+}
+
+static int check_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	for (uint8_t n = 0u; n < num_msgs; n++) {
+		struct i2c_msg *m = &msgs[n];
+
+		if ((m->flags & I2C_MSG_ADDR_10_BITS) != 0) {
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int i2c_xec_xfr_begin(const struct device *dev, uint16_t addr)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	struct i2c_msg *m = data->msgs;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+	uint8_t target_addr = 0;
+	uint8_t ctrl = XEC_I2C_CR_START_ENI;
+	uint8_t start = XEC_I2C_START_NORM;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x10);
+
+	target_addr = i2c_xec_fmt_addr(addr, 0);
+	data->wraddr = target_addr;
+
+	if ((data->msgs[0].flags & I2C_MSG_READ) != 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x11);
+		target_addr |= BIT(0);
+		xfr->mdir = XEC_I2C_DIR_RD;
+	} else {
+		xfr->mdir = XEC_I2C_DIR_WR;
+	}
+
+	data->mdone = 0;
+	xfr->mbuf = m->buf;
+	xfr->mlen = m->len;
+	xfr->xfr_sts = 0;
+	xfr->target_addr = target_addr;
+	xfr->mflags = I2C_XEC_XFR_FLAG_START_REQ;
+
+	if ((sys_read8(rb + XEC_I2C_SR_OFS) & BIT(XEC_I2C_SR_NBB_POS)) == 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x12);
+		if ((data->cm_dir != xfr->mdir) || (m->flags & I2C_MSG_RESTART)) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x13);
+			start = XEC_I2C_START_RPT;
+			ctrl = XEC_I2C_CR_RPT_START_ENI;
+		}
+	}
+
+	data->cm_dir = xfr->mdir;
+	if (m->flags & I2C_MSG_STOP) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x14);
+		xfr->mflags |= I2C_XEC_XFR_FLAG_STOP_REQ;
+	}
+
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 0);
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x15);
+
+	/* Generate (RPT)-START and transmit address for write or read */
+	if (ctrl == XEC_I2C_CR_START_ENI) { /* START? */
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x16);
+		sys_write8(target_addr, rb + XEC_I2C_DATA_OFS);
+		xec_i2c_cr_write(dev, ctrl);
+	} else { /* RPT-START */
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x17);
+		xec_i2c_cr_write(dev, ctrl);
+		sys_write8(target_addr, rb + XEC_I2C_DATA_OFS);
+	}
+
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 1u);
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x18);
+
+#ifdef XEC_I2C_DEBUG_USE_SPIN_LOOP
+	while (!data->mdone) {
+		;
+	}
+#else
+	rc = k_sem_take(&data->sync_sem, K_MSEC(100));
+	if (rc != 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x19);
+		return -ETIMEDOUT;
+	}
+#endif
+	if (xfr->xfr_sts) { /* error */
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x1A);
+		return -EIO;
+	}
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x1B);
+
+	return 0;
+}
+
+/* i2c_transfer API - Synchronous using interrupts
+ * The call wrapper in i2c.h returns if num_msgs is 0.
+ * It does not check for msgs being a NULL pointer and accesses msgs.
+ * NOTE 1: Zephyr I2C documentation states an I2C driver can be switched
+ * between Host and Target modes by registering and unregistering targets.
+ * NOTE 2:
+ * XEC I2C controller supports up to 5 target addresses:
+ * Two address match registers.
+ * I2C general call (address 0). UNTESTED!
+ * Two SMBus fixed addresses defined in the SMBus spec. UNTESTED!
+ * We many need to remove general call and the two SMBus fixed address code logic!
+ */
+static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			    uint16_t addr)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+
+	k_mutex_lock(&data->lock_mut, K_FOREVER);
+#ifdef CONFIG_I2C_TARGET
+	if (data->ntargets != 0) {
+		k_mutex_unlock(&data->lock_mut);
 		return -EBUSY;
 	}
 #endif
+	pm_device_busy_set(dev);
+	k_sem_reset(&data->sync_sem);
 
-	for (uint8_t i = 0; i < num_msgs; i++) {
-		struct i2c_msg *m = &msgs[i];
+	XEC_I2C_DEBUG_ISR_INIT();
 
-		if ((m->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
-			ret = ctrl_tx(dev, m, addr);
-		} else {
-			ret = ctrl_rx(dev, m, addr);
-		}
-		if (ret) {
-			data->state = I2C_XEC_STATE_STOPPED;
-			data->read_discard = 0;
-			LOG_ERR("i2x_xfr: flags: %x error: %d", m->flags, ret);
-			break;
+	memset(&data->cm_xfr, 0, sizeof(struct i2c_xec_cm_xfr));
+
+	rc = check_msgs(msgs, num_msgs);
+	if (rc != 0) {
+		goto xec_unlock;
+	}
+
+	if (data->state != XEC_I2C_STATE_OPEN) {
+		XEC_I2C_DEBUG_STATE_INIT(data);
+
+		rc = check_lines(dev);
+		data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+
+		if (rc || (data->i2c_sr & BIT(XEC_I2C_SR_BER_POS))) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x50);
+			rc = i2c_xec_recover_bus(dev);
 		}
 	}
 
-	return ret;
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x1);
+
+	if (rc) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x2);
+		data->state = XEC_I2C_STATE_CLOSED;
+		goto xec_unlock;
+	}
+
+	data->state = XEC_I2C_STATE_OPEN;
+
+	data->msg_idx = 0;
+	data->num_msgs = num_msgs;
+	data->msgs = msgs;
+
+	rc = i2c_xec_xfr_begin(dev, addr);
+	if (rc) { /* if error issue STOP if bus is still owned by controller */
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x7);
+		i2c_xec_stop(dev, 0);
+	}
+
+xec_unlock:
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x8);
+
+	if ((sys_read8(rb + XEC_I2C_SR_OFS) & BIT(XEC_I2C_SR_NBB_POS)) == 0) {
+		data->cm_dir = XEC_I2C_DIR_NONE;
+		data->state = XEC_I2C_STATE_CLOSED;
+	}
+
+	pm_device_busy_clear(dev);
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
 }
 
-static void i2c_xec_bus_isr(const struct device *dev)
-{
 #ifdef CONFIG_I2C_TARGET
-	const struct i2c_xec_config *cfg =
-		(const struct i2c_xec_config *const) (dev->config);
+static struct i2c_target_config *find_target(struct i2c_xec_data *data, uint16_t i2c_addr)
+{
+	sys_snode_t *sn = NULL;
+
+	SYS_SLIST_FOR_EACH_NODE(&data->target_list, sn) {
+		struct i2c_target_config *ptc = CONTAINER_OF(sn, struct i2c_target_config, node);
+
+		if ((ptc != NULL) && (ptc->address == i2c_addr)) {
+			return ptc;
+		}
+	}
+
+	return NULL;
+}
+
+/* I2C can respond to 3 fixed address and 2 configurable
+ * address 0x00 if GC_DIS == 0 in configuration register
+ * addresses 0x08 and 0x61 if DSA == 1 in configuration register
+ * Own addresses 1 and 2 which are programmable.
+ * NOTE: Zephyr uses target_register to enable target mode and
+ * target_unregister to disable target mode. The app will use
+ * these for switching between host and target modes.
+ * Since our HW supports multiple target, the app must unregister all
+ * targets before Host mode is allowed.
+ */
+static int i2c_xec_target_register(const struct device *dev, struct i2c_target_config *cfg)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
 	struct i2c_xec_data *data = dev->data;
-	const struct i2c_target_callbacks *target_cb =
-		data->target_cfg->callbacks;
-	struct i2c_smb_regs *regs = (struct i2c_smb_regs *)cfg->base_addr;
-	int ret;
-	uint32_t status;
-	uint32_t compl_status;
-	uint8_t val;
-	uint8_t dummy = 0U;
+	mem_addr_t rb = devcfg->base;
+	uint32_t oaval = 0;
+	int rc = 0;
 
-	/* Get current status */
-	status = regs->CTRLSTS;
-	compl_status = regs->COMPL & MCHP_I2C_SMB_CMPL_RW1C_MASK;
-
-	/* Idle interrupt enabled and active? */
-	if ((regs->CFG & MCHP_I2C_SMB_CFG_ENIDI) &&
-	    (compl_status & MCHP_I2C_SMB_CMPL_IDLE_RWC)) {
-		regs->CFG &= ~MCHP_I2C_SMB_CFG_ENIDI;
-		if (status & MCHP_I2C_SMB_STS_NBB) {
-			restart_target(dev);
-			goto clear_iag;
-		}
+	if (cfg == NULL) {
+		return -EINVAL;
 	}
 
-	if (!data->target_attached) {
-		goto clear_iag;
+	if (((cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) || (cfg->address > 0x7FU)) {
+		return -EINVAL;
 	}
 
-	/* Bus Error */
-	if (status & MCHP_I2C_SMB_STS_BER) {
-		if (target_cb->stop) {
-			target_cb->stop(data->target_cfg);
-		}
-		restart_target(dev);
-		goto clear_iag;
-	}
+	k_mutex_lock(&data->lock_mut, K_FOREVER);
 
-	/* External stop */
-	if (status & MCHP_I2C_SMB_STS_EXT_STOP) {
-		if (target_cb->stop) {
-			target_cb->stop(data->target_cfg);
-		}
-		restart_target(dev);
-		goto clear_iag;
-	}
+	rc = -ENFILE;
+	if (data->ntargets < 5) {
+		struct i2c_target_config *ptc = find_target(data, cfg->address);
 
-	/* Address byte handling */
-	if (status & MCHP_I2C_SMB_STS_AAS) {
-		if (status & MCHP_I2C_SMB_STS_PIN) {
-			goto clear_iag;
-		}
-
-		uint8_t rx_data = regs->I2CDATA;
-
-		if (rx_data & BIT(I2C_READ_WRITE_POS)) {
-			/* target transmitter mode */
-			data->target_read = true;
-			val = dummy;
-			if (target_cb->read_requested) {
-				target_cb->read_requested(
-					data->target_cfg, &val);
-
-				/* Application target transmit handler
-				 * does not have data to send. In
-				 * target transmit mode the external
-				 * Controller is ACK's data we send.
-				 * All we can do is keep sending dummy
-				 * data. We assume read_requested does
-				 * not modify the value pointed to by val
-				 * if it has not data(returns error).
-				 */
-			}
-			/*
-			 * Writing I2CData causes this HW to release SCL
-			 * ending clock stretching. The external Controller
-			 * senses SCL released and begins generating clocks
-			 * and capturing data driven by this controller
-			 * on SDA. External Controller ACK's data until it
-			 * wants no more then it will NACK.
-			 */
-			regs->I2CDATA = val;
-			goto clear_iag; /* Exit ISR */
-		} else {
-			/* target receiver mode */
-			data->target_read = false;
-			if (target_cb->write_requested) {
-				ret = target_cb->write_requested(
-							data->target_cfg);
-				if (ret) {
-					/*
-					 * Application handler can't accept
-					 * data. Configure HW to NACK next
-					 * data transmitted by external
-					 * Controller.
-					 * !!! TODO We must re-program our HW
-					 * for address ACK before next
-					 * transaction is begun !!!
-					 */
-					target_config_for_nack(dev);
+		if (ptc == NULL) {
+			data->ntargets++;
+			sys_slist_append(&data->target_list, &cfg->node);
+			if (cfg->address == XEC_I2C_GEN_CALL_ADDR) {
+				/* enable general call */
+				sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+			} else if ((cfg->address == XEC_I2C_SMB_HOST_ADDR) ||
+				   (cfg->address == XEC_I2C_SMB_DEVICE_ADDR)) {
+				/* enable DSA */
+				sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+			} else { /* use one of the two own addresses */
+				oaval = sys_read32(rb + XEC_I2C_OA_OFS);
+				if (XEC_I2C_OA_1_GET(oaval) == 0) {
+					oaval |= XEC_I2C_OA_1_SET(cfg->address);
+					sys_write32(oaval, rb + XEC_I2C_OA_OFS);
+				} else if (XEC_I2C_OA_2_GET(oaval) == 0) {
+					oaval |= XEC_I2C_OA_2_SET(cfg->address);
+					sys_write32(oaval, rb + XEC_I2C_OA_OFS);
 				}
 			}
-			goto clear_iag; /* Exit ISR */
+			rc = 0;
 		}
 	}
 
-	if (data->target_read) { /* Target transmitter mode */
+	if (rc == 0) {
+		soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 1u);
+	}
 
-		/* Master has Nacked, then just write a dummy byte */
-		status = regs->CTRLSTS;
-		if (status & MCHP_I2C_SMB_STS_LRB_AD0) {
+	k_mutex_unlock(&data->lock_mut);
 
-			/*
-			 * ISSUE: HW will not detect external STOP in
-			 * target transmit mode. Enable IDLE interrupt
-			 * to catch PIN 0 -> 1 and NBB 0 -> 1.
-			 */
-			regs->CFG |= MCHP_I2C_SMB_CFG_ENIDI;
+	return 0;
+}
 
-			/*
-			 * dummy write causes this controller's PIN status
-			 * to de-assert 0 -> 1. Data is not transmitted.
-			 * SCL is not driven low by this controller.
-			 */
-			regs->I2CDATA = dummy;
+static int i2c_xec_target_unregister(const struct device *dev, struct i2c_target_config *cfg)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_data *data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	uint32_t oaval = 0;
+	uint16_t taddr1 = 0, taddr2 = 0;
+	int rc = 0;
+	bool removed = false;
 
-			status = regs->CTRLSTS;
+	if (cfg == NULL) {
+		return -EINVAL;
+	}
 
+	k_mutex_lock(&data->lock_mut, K_FOREVER);
+
+	if (data->ntargets == 0) {
+		goto targ_unreg_release_lock;
+	}
+
+	removed = sys_slist_find_and_remove(&data->target_list, &cfg->node);
+
+	if (removed == false) {
+		rc = -ENOSYS;
+		goto targ_unreg_release_lock;
+	}
+
+	data->ntargets--;
+
+	if (cfg->address == XEC_I2C_GEN_CALL_ADDR) { /* disable general call */
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+	} else if ((cfg->address == XEC_I2C_SMB_HOST_ADDR) ||
+		   (cfg->address == XEC_I2C_SMB_DEVICE_ADDR)) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+	} else { /* one of the own addresses */
+		oaval = sys_read32(rb + XEC_I2C_OA_OFS);
+		taddr1 = XEC_I2C_OA_1_GET(oaval);
+		taddr2 = XEC_I2C_OA_2_GET(oaval);
+		if (taddr1 == (uint32_t)cfg->address) {
+			oaval &= ~XEC_I2C_OA_1_MSK;
+			sys_write32(oaval, rb + XEC_I2C_OA_OFS);
+		} else if (taddr2 == (uint32_t)cfg->address) {
+			oaval &= ~XEC_I2C_OA_2_MSK;
+			sys_write32(oaval, rb + XEC_I2C_OA_OFS);
+		}
+	}
+
+targ_unreg_release_lock:
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
+}
+#endif /* CONFIG_I2C_TARGET */
+
+/* ISR helpers and state handlers */
+static int i2c_xec_is_ber_lab(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+
+	if ((data->i2c_sr & (BIT(XEC_I2C_SR_BER_POS) | BIT(XEC_I2C_SR_LAB_POS))) != 0) {
+		if (data->i2c_sr & BIT(XEC_I2C_SR_BER_POS)) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x82);
+			xfr->xfr_sts |= XEC_I2C_ERR_BUS;
 		} else {
-			val = dummy;
-			if (target_cb->read_processed) {
-				target_cb->read_processed(
-					data->target_cfg, &val);
-			}
-			regs->I2CDATA = val;
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x83);
+			xfr->xfr_sts |= XEC_I2C_ERR_LOST_ARB;
 		}
-	} else { /* target receiver mode */
-		/*
-		 * Reading the I2CData register causes this target to release
-		 * SCL. The external Controller senses SCL released generates
-		 * clocks for transmitting the next data byte.
-		 * Reading I2C Data register causes PIN status 0 -> 1.
-		 */
-		val = regs->I2CDATA;
-		if (target_cb->write_received) {
-			/*
-			 * Call back returns error if we should NACK
-			 * next byte.
+
+		soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 0);
+		data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+		data->mdone = 0x51;
+
+		return 1;
+	}
+
+	return 0;
+}
+
+static int i2c_xec_next_msg(struct i2c_xec_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	struct i2c_msg *m = NULL;
+	uint32_t idx = (uint32_t)data->msg_idx;
+
+	if (++idx >= (uint32_t)data->num_msgs) {
+		xfr->mbuf = NULL;
+		xfr->mlen = 0;
+		xfr->mflags = 0;
+		xfr->mdir = XEC_I2C_DIR_NONE;
+		return 0;
+	}
+
+	data->msg_idx = (uint8_t)(idx & 0xffu);
+	m = &data->msgs[idx];
+
+	xfr->mbuf = m->buf;
+	xfr->mlen = m->len;
+	xfr->mdir = XEC_I2C_DIR_WR;
+	xfr->mflags = 0;
+	xfr->target_addr = data->wraddr;
+
+	if ((m->flags & I2C_MSG_READ) != 0) {
+		xfr->mdir = XEC_I2C_DIR_RD;
+		xfr->target_addr |= BIT(0);
+	}
+
+	if ((m->flags & I2C_MSG_STOP) != 0) {
+		xfr->mflags = I2C_XEC_XFR_FLAG_STOP_REQ;
+	}
+
+	if (((m->flags & I2C_MSG_RESTART) != 0) || (data->cm_dir != xfr->mdir)) {
+		xfr->mflags |= I2C_XEC_XFR_FLAG_START_REQ;
+	}
+
+	data->cm_dir = xfr->mdir;
+
+	return 1;
+}
+
+#ifdef CONFIG_I2C_TARGET
+static int state_check_ack_tm(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+	int rc = 0;
+	uint16_t i2c_addr = 0;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC0);
+
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_AAT_POS)) != 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC1);
+		/* enable STOP detect and IDLE interrupts */
+		sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+		sys_set_bits(rb + XEC_I2C_CFG_OFS,
+			     (BIT(XEC_I2C_CFG_IDLE_IEN_POS) | BIT(XEC_I2C_CFG_STD_IEN_POS)));
+
+		data->targ_active = 1u;
+		data->targ_ignore = 1u;
+		data->targ_data = XEC_I2C_TM_HOST_READ_IGNORE_VAL;
+		data->targ_addr = sys_read8(rb + XEC_I2C_IAS_OFS);
+		/* extract I2C address from bus value */
+		i2c_addr = (data->targ_addr >> 1); /* bits[7:1]=address, bit[0]=R/nW */
+		data->curr_target = find_target(data, i2c_addr);
+
+		const struct i2c_target_callbacks *tcbs = data->curr_target->callbacks;
+
+		if ((data->targ_addr & BIT(0)) != 0) { /* Host requesting read from target */
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC2);
+			if ((tcbs != NULL) && (tcbs->read_requested != NULL)) {
+				rc = tcbs->read_requested(data->curr_target, &data->targ_data);
+				if (rc == 0) {
+					XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC3);
+					data->targ_ignore = 0;
+				}
+			}
+
+			/* read & discard target address clears I2C.SR.AAT */
+			sys_read8(rb + XEC_I2C_DATA_OFS);
+			/* as target transmitter writing I2C.DATA releases clock stretching */
+			sys_write8(data->targ_data, rb + XEC_I2C_DATA_OFS);
+		} else { /* Host requesting write to target */
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC4);
+			if ((tcbs != NULL) && (tcbs->write_requested != NULL)) {
+				rc = tcbs->write_requested(data->curr_target);
+				if (rc == 0) {
+					XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC5);
+					data->targ_ignore = 0u;
+				}
+			}
+
+			if (data->targ_ignore != 0) {
+				xec_i2c_cr_write_mask(dev, BIT(XEC_I2C_CR_ACK_POS), 0);
+			}
+
+			/* as target receiver reading I2C.DATA releases clock stretching
+			 * and clears I2C.SR.AAT.
 			 */
-			ret = target_cb->write_received(data->target_cfg, val);
-			if (ret) {
-				/*
-				 * Configure HW to NACK next byte. It will not
-				 * generate clocks for another byte of data
-				 */
-				target_config_for_nack(dev);
-			}
+			sys_read8(rb + XEC_I2C_DATA_OFS);
+		}
+
+		return I2C_XEC_ISR_STATE_EXIT_1;
+	}
+
+	if (data->targ_active != 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC6);
+		next_state = I2C_XEC_ISR_STATE_TM_HOST_WR;
+		if ((data->targ_addr & BIT(0)) != 0) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC7);
+			next_state = I2C_XEC_ISR_STATE_TM_HOST_RD;
 		}
 	}
 
-clear_iag:
-	regs->COMPL = compl_status;
-	mchp_xec_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
+	return next_state;
+}
 #endif
+
+static int state_check_ack(struct i2c_xec_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x83);
+
+#ifdef CONFIG_I2C_TARGET
+	next_state = state_check_ack_tm(data);
+	if (next_state != I2C_XEC_ISR_STATE_MAX) {
+		return next_state;
+	}
+#endif
+
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_LRB_AD0_POS)) == 0) { /* ACK? */
+		next_state = I2C_XEC_ISR_STATE_WR_DATA;
+
+		if (xfr->mdir == XEC_I2C_DIR_RD) {
+			next_state = I2C_XEC_ISR_STATE_RD_DATA;
+		}
+	} else {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x84);
+		next_state = I2C_XEC_ISR_STATE_GEN_STOP;
+		xfr->xfr_sts |= I2C_XEC_XFR_STS_NACK;
+	}
+
+	return next_state;
+}
+
+static int state_data_wr(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_EXIT_1;
+	uint8_t msgbyte;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x90);
+
+	if (xfr->mlen > 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x91);
+		msgbyte = *xfr->mbuf;
+
+		sys_write8(msgbyte, rb + XEC_I2C_DATA_OFS);
+
+		xfr->mbuf++;
+		xfr->mlen--;
+	} else {
+		if (xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x92);
+			next_state = I2C_XEC_ISR_STATE_GEN_STOP;
+		} else {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x93);
+			next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+		}
+	}
+
+	return next_state;
+}
+
+/* NOTE: Reading I2C controller Data register causes HW to
+ * generate clocks for the next data byte plus (n)ACK bit.
+ * In addition the Controller will always ACK received data
+ * unless the I2C.CTRL auto-ACK bit is cleared.
+ * If the message has I2C_MSG_STOP flag set:
+ * Reading the next to last byte generates clocks for the last byte.
+ * Therefore we must clear the auto-ACK bit in I2C.CTRL before
+ * reading the next to last byte from I2C.Data register.
+ * Before reading the last byte we must write I2C.CTRL to begin
+ * generating the I2C STOP sequence. We can then read the
+ * last byte from the I2C.Data register without causing clocks
+ * to be generated. We hope the Controller HW does not have a
+ * race condition between STOP generation and the read of I2C.Data.
+ */
+static int state_data_rd(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+	uint8_t ctrl = 0;
+	uint8_t msgbyte = 0;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa0);
+
+	if (xfr->mlen > 0) {
+		next_state = I2C_XEC_ISR_STATE_EXIT_1;
+		if ((xfr->mflags & I2C_XEC_XFR_FLAG_START_REQ) != 0) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa1);
+			/* HW clocks in address it transmits. Read and discard.
+			 * HW generates clocks for first data byte.
+			 */
+			xfr->mflags &= ~(I2C_XEC_XFR_FLAG_START_REQ);
+			if ((xfr->mlen == 1) && ((xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) != 0)) {
+				XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa2);
+				/* disable auto-ACK and make sure ENI=1 */
+				ctrl = BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ENI_POS);
+				xec_i2c_cr_write(dev, ctrl);
+			}
+			/* read byte currently in HW buffer and generate clocks for next byte */
+			msgbyte = sys_read8(rb + XEC_I2C_DATA_OFS);
+		} else if ((xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) != 0) {
+			if (xfr->mlen != 1) {
+				XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa3);
+				if (xfr->mlen == 2) {
+					XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa4);
+					ctrl = BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ENI_POS);
+					xec_i2c_cr_write(dev, ctrl);
+				}
+
+				msgbyte = sys_read8(rb + XEC_I2C_DATA_OFS);
+
+				*xfr->mbuf = msgbyte;
+				xfr->mbuf++;
+				xfr->mlen--;
+			} else { /* Begin STOP generation and read last byte */
+				XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa5);
+				xfr->mflags &= ~(I2C_XEC_XFR_FLAG_STOP_REQ);
+
+				sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+				xec_i2c_cr_write(dev, XEC_I2C_CR_STOP);
+				/* read triggers STOP generation */
+				msgbyte = sys_read8(rb + XEC_I2C_DATA_OFS);
+
+				*xfr->mbuf = msgbyte;
+				xfr->mlen = 0;
+			}
+		} else { /* No START or STOP flags */
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xa6);
+			msgbyte = sys_read8(rb + XEC_I2C_DATA_OFS);
+
+			*xfr->mbuf = msgbyte;
+			xfr->mbuf++;
+			xfr->mlen--;
+		}
+	}
+
+	return next_state;
+}
+
+static int state_next_msg(struct i2c_xec_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+	int ret = i2c_xec_next_msg(data);
+
+	if (ret) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xb0);
+		if (xfr->mflags & I2C_XEC_XFR_FLAG_START_REQ) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xb1);
+			next_state = I2C_XEC_ISR_STATE_GEN_START;
+		} else {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xb2);
+			next_state = I2C_XEC_ISR_STATE_WR_DATA;
+			if (xfr->mdir == XEC_I2C_DIR_RD) {
+				XEC_I2C_DEBUG_STATE_UPDATE(data, 0xb3);
+				next_state = I2C_XEC_ISR_STATE_RD_DATA;
+			}
+		}
+	} else { /* no more messages */
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xb3);
+		data->mdone = 1;
+	}
+
+	return next_state;
 }
 
 #ifdef CONFIG_I2C_TARGET
-static int i2c_xec_target_register(const struct device *dev,
-				   struct i2c_target_config *config)
+/* state I2C_XEC_ISR_STATE_TM_HOST_RD (external Host I2 Read data phase)
+ * external Host I2C Read. Application callback returned error code.
+ * We "ignore" remaining protocol until STOP.
+ * This I2C controller clock stretches on target address match and
+ * on each ACK of data bytes we write from the external Host.
+ * We must write a value to the I2C.DATA register to cause this controller
+ * to release SCL allowing the external Host to generate clocks on SCL.
+ */
+static int state_tm_host_read(struct i2c_xec_data *data)
 {
-	const struct i2c_xec_config *cfg = dev->config;
-	struct i2c_xec_data *data = dev->data;
-	int ret;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = data->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
 
-	if (!config) {
-		return -EINVAL;
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC8);
+
+	if ((tcbs == NULL) || (tcbs->read_processed == NULL)) {
+		data->targ_ignore = 1u;
 	}
 
-	if (data->target_attached) {
-		return -EBUSY;
+	if (data->targ_ignore == 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xC9);
+		rc = tcbs->read_processed(tcfg, &data->targ_data);
+		if (rc != 0) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xCA);
+			data->targ_ignore = 1;
+			data->targ_data = XEC_I2C_TM_HOST_READ_IGNORE_VAL;
+		}
 	}
 
-	/* Wait for any outstanding transactions to complete so that
-	 * the bus is free
+	sys_write8(data->targ_data, rb + XEC_I2C_DATA_OFS);
+
+	return I2C_XEC_ISR_STATE_EXIT_1;
+}
+
+/* state I2C_XEC_ISR_STATE_TM_HOST_WR (external Host I2C Write data phase)
+ * external Host generated START and target write address matching this I2C target.
+ * We invoked application write requested callback which returned an error code.
+ * This means we must "ignore" I2C bus activity until the external Host generates STOP.
+ * When the external Host generates clocks and data this controller will clock stretch
+ * after the 9th clock if auto-ACK is enabled. We must read and discard the data byte
+ * from I2C.DATA.
+ */
+static int state_tm_host_write(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = data->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xCB);
+
+	/* read shadow data register. No side-effects */
+	data->targ_data = sys_read8(rb + XEC_I2C_IDS_OFS);
+
+	if (data->targ_ignore == 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xCC);
+		rc = tcbs->write_received(tcfg, data->targ_data);
+		if (rc != 0) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xCD);
+			data->targ_ignore = 1u;
+			/* clear HW auto-ACK. We NAK future received bytes */
+			xec_i2c_cr_write_mask(dev, BIT(XEC_I2C_CR_ACK_POS), 0);
+		}
+	}
+
+	/* must read I2C.DATA to release SCL */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+
+	return I2C_XEC_ISR_STATE_EXIT_1;
+}
+
+static int state_tm_stop_event(struct i2c_xec_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = data->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE4);
+
+	if (tcbs != NULL) {
+		if (tcbs->stop != NULL) {
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE5);
+			tcbs->stop(tcfg);
+		}
+	}
+
+	/* Race condition:
+	 * Docs state: "After the function(stop callback) returns the controller
+	 * shall enter a state where it is ready to react to new start conditions"
+	 *
 	 */
-	ret = wait_bus_free(dev, WAIT_COUNT);
-	if (ret) {
-		return ret;
-	}
+	data->targ_active = 0;
+	data->targ_ignore = 0;
+	data->curr_target = NULL;
+	/* HW requires a read and discard of I2C.DATA register to clear the read-only
+	 * STOP detect status in I2C.SR.
+	 */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+	xec_i2c_cr_write(dev, XEC_I2C_CR_PIN_ESO_ENI_ACK);
 
-	data->target_cfg = config;
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE6);
 
-	ret = i2c_xec_reset_config(dev);
-	if (ret) {
-		return ret;
-	}
-
-	restart_target(dev);
-
-	data->target_attached = true;
-
-	/* Clear before enabling girq bit */
-	mchp_xec_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
-	mchp_xec_ecia_girq_src_en(cfg->girq, cfg->girq_pos);
-
-	return 0;
+	return I2C_XEC_ISR_STATE_EXIT_1;
 }
 
-static int i2c_xec_target_unregister(const struct device *dev,
-				     struct i2c_target_config *config)
+static void tm_cleanup(struct i2c_xec_data *data)
 {
-	const struct i2c_xec_config *cfg = dev->config;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE8);
+
+	data->targ_active = 0;
+	data->targ_ignore = 0;
+	data->curr_target = NULL;
+
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+	/* re-arm I2C to detect external Host activity */
+	xec_i2c_cr_write(dev, XEC_I2C_CR_PIN_ESO_ENI_ACK);
+}
+#endif /* CONFIG_I2C_TARGET */
+
+static void xec_i2c_kwork_thread(struct k_work *work)
+{
+	struct i2c_xec_data *data = CONTAINER_OF(work, struct i2c_xec_data, kworkq);
+	const struct device *dev = data->dev;
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	uint32_t i2c_cfg = 0;
+	bool run_sm = true;
+	int state = I2C_XEC_ISR_STATE_CHK_ACK;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+	int idle_active = 0;
+
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x80);
+
+#ifdef XEC_I2C_DEBUG_ISR
+	i2c_xec_isr_cnt++;
+	i2c_xec_isr_sts = sys_read8(rb + XEC_I2C_SR_OFS);
+	i2c_xec_isr_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+	i2c_xec_isr_cfg = sys_read32(rb + XEC_I2C_CFG_OFS);
+	while (data->mdone) { /* should not hang here */
+		;
+	}
+#endif
+	i2c_cfg = sys_read32(rb + XEC_I2C_CFG_OFS);
+	data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+	data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+	if (((i2c_cfg & BIT(XEC_I2C_CFG_IDLE_IEN_POS)) != 0) &&
+	    ((data->i2c_sr & BIT(XEC_I2C_SR_NBB_POS)) != 0)) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+		idle_active = 1;
+		state = I2C_XEC_ISR_STATE_EV_IDLE;
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE1);
+	}
+
+#ifdef CONFIG_I2C_TARGET
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_STO_POS)) != 0) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_STD_IEN_POS);
+		state = I2C_XEC_ISR_STATE_TM_EV_STOP;
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0xE0);
+	}
+#endif
+
+	sys_write32(XEC_I2C_CMPL_RW1C_MSK, rb + XEC_I2C_CMPL_OFS);
+	sys_write32(BIT(XEC_I2C_WKSR_SB_POS), rb + XEC_I2C_WKSR_OFS);
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	/* Lost Arbitration or Bus Error? */
+	if (i2c_xec_is_ber_lab(data)) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x81);
+		run_sm = false;
+#ifdef CONFIG_I2C_TARGET
+		tm_cleanup(data);
+#endif
+	}
+
+	while (run_sm) {
+		switch (state) {
+		case I2C_XEC_ISR_STATE_GEN_START:
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x82);
+			if ((data->i2c_sr & BIT(XEC_I2C_SR_NBB_POS)) != 0) { /* START? */
+				sys_write8(xfr->target_addr, rb + XEC_I2C_DATA_OFS);
+				xec_i2c_cr_write(dev, XEC_I2C_CR_START_ENI);
+			} else { /* RPT-START */
+				xec_i2c_cr_write(dev, XEC_I2C_CR_RPT_START_ENI);
+				sys_write8(xfr->target_addr, rb + XEC_I2C_DATA_OFS);
+			}
+			run_sm = false;
+			break;
+		case I2C_XEC_ISR_STATE_CHK_ACK:
+			next_state = state_check_ack(data);
+			break;
+		case I2C_XEC_ISR_STATE_WR_DATA:
+			next_state = state_data_wr(data);
+			break;
+		case I2C_XEC_ISR_STATE_RD_DATA:
+			next_state = state_data_rd(data);
+			break;
+		case I2C_XEC_ISR_STATE_GEN_STOP:
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x85);
+			sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+			xec_i2c_cr_write(dev, XEC_I2C_CR_STOP);
+			data->cm_dir = XEC_I2C_DIR_NONE;
+			run_sm = false;
+			break;
+		case I2C_XEC_ISR_STATE_EV_IDLE:
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x87);
+			sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+			data->cm_dir = XEC_I2C_DIR_NONE;
+			next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+			if (xfr->xfr_sts != 0) {
+				data->mdone = 0x13;
+				run_sm = false;
+			}
+#ifdef CONFIG_I2C_TARGET
+			tm_cleanup(data);
+#endif
+			break;
+		case I2C_XEC_ISR_STATE_NEXT_MSG:
+			next_state = state_next_msg(data);
+			break;
+		case I2C_XEC_ISR_STATE_EXIT_1:
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x88);
+			data->mdone = 0;
+			run_sm = false;
+			break;
+#ifdef CONFIG_I2C_TARGET
+		case I2C_XEC_ISR_STATE_TM_HOST_RD:
+			next_state = state_tm_host_read(data);
+			break;
+		case I2C_XEC_ISR_STATE_TM_HOST_WR:
+			next_state = state_tm_host_write(data);
+			break;
+		case I2C_XEC_ISR_STATE_TM_EV_STOP:
+			next_state = state_tm_stop_event(data);
+			data->mdone = 0;
+			run_sm = false;
+			break;
+#endif /* CONFIG_I2C_TARGET */
+		default:
+			XEC_I2C_DEBUG_STATE_UPDATE(data, 0x89);
+			sys_write32(XEC_I2C_CMPL_RW1C_MSK, rb + XEC_I2C_CMPL_OFS);
+			soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 0);
+			if (!data->mdone) {
+				data->mdone = 0x66;
+			}
+			run_sm = false;
+			break;
+		}
+
+		state = next_state;
+	}
+
+	/* ISR common exit path */
+	XEC_I2C_DEBUG_STATE_UPDATE(data, 0x8d);
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	if (data->mdone == 0) {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x8e);
+		soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 1u);
+	} else {
+		XEC_I2C_DEBUG_STATE_UPDATE(data, 0x8f);
+		k_sem_give(&data->sync_sem);
+	}
+} /* xec_i2c_kwork_thread */
+
+/* Controller Mode ISR
+ * We need to disable interrupt before exiting ISR.
+ */
+static void i2c_xec_isr(const struct device *dev)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
 	struct i2c_xec_data *data = dev->data;
 
-	if (!data->target_attached) {
-		return -EINVAL;
+	/* clears I2C controller's GIRQ enable causing GIRQ result
+	 * signal to clear. GIRQ result is the input to the NVIC.
+	 */
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, 0);
+
+	k_work_submit(&data->kworkq);
+}
+
+#ifdef CONFIG_PM_DEVICE
+/* TODO Add logic to enable I2C wake if target mode is active.
+ * For deep sleep this requires enabling GIRQ22 wake clocks feature.
+ */
+static int i2c_xec_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct i2c_xec_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	LOG_DBG("PM action: %d", (int)action);
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
+		break;
+	default:
+		return -ENOTSUP;
 	}
-
-	data->target_cfg = NULL;
-	data->target_attached = false;
-
-	mchp_xec_ecia_girq_src_dis(cfg->girq, cfg->girq_pos);
 
 	return 0;
 }
 #endif
 
-static DEVICE_API(i2c, i2c_xec_driver_api) = {
-	.configure = i2c_xec_configure,
-	.transfer = i2c_xec_transfer,
-#ifdef CONFIG_I2C_TARGET
-	.target_register = i2c_xec_target_register,
-	.target_unregister = i2c_xec_target_unregister,
+static int i2c_mchp_xec_v2_debug_init(const struct device *dev)
+{
+#ifdef XEC_I2C_DEBUG_STATE
+	struct i2c_xec_data *data = dev->data;
+
+	XEC_I2C_DEBUG_STATE_INIT(data);
 #endif
-#ifdef CONFIG_I2C_RTIO
-	.iodev_submit = i2c_iodev_submit_fallback,
+#ifdef XEC_I2C_DEBUG_ISR
+	XEC_I2C_DEBUG_ISR_INIT();
 #endif
-};
+
+	return 0;
+}
 
 static int i2c_xec_init(const struct device *dev)
 {
 	const struct i2c_xec_config *cfg = dev->config;
-	struct i2c_xec_data *data =
-		(struct i2c_xec_data *const) (dev->data);
-	int ret;
-	uint32_t bitrate_cfg;
+	struct i2c_xec_data *data = dev->data;
+	int rc = 0;
+	uint32_t i2c_config = 0;
 
-	data->state = I2C_XEC_STATE_STOPPED;
-	data->target_cfg = NULL;
-	data->target_attached = false;
+	i2c_mchp_xec_v2_debug_init(dev);
 
-	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret != 0) {
-		LOG_ERR("XEC I2C pinctrl setup failed (%d)", ret);
-		return ret;
+	data->dev = dev;
+	data->state = XEC_I2C_STATE_CLOSED;
+	data->i2c_compl = 0;
+	data->i2c_cr_shadow = 0;
+	data->i2c_sr = 0;
+	data->mdone = 0;
+
+	rc = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (rc != 0) {
+		LOG_ERR("pinctrl setup failed (%d)", rc);
+		return rc;
 	}
 
-	bitrate_cfg = i2c_map_dt_bitrate(cfg->clock_freq);
-	if (!bitrate_cfg) {
+	i2c_config = i2c_map_dt_bitrate(cfg->clock_freq);
+	if (i2c_config == 0) {
 		return -EINVAL;
 	}
 
+	i2c_config |= I2C_MODE_CONTROLLER;
+#ifdef CONFIG_I2C_XEC_PORT_MUX
+	i2c_config |= I2C_XEC_PORT_SET((uint32_t)cfg->port);
+#endif
 	/* Default configuration */
-	ret = i2c_xec_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
-	if (ret) {
-		return ret;
+	rc = i2c_xec_configure(dev, i2c_config);
+	if (rc != 0) {
+		return rc;
 	}
 
 #ifdef CONFIG_I2C_TARGET
-	const struct i2c_xec_config *config =
-	(const struct i2c_xec_config *const) (dev->config);
-
-	config->irq_config_func();
+	sys_slist_init(&data->target_list);
 #endif
+	k_work_init(&data->kworkq, &xec_i2c_kwork_thread);
+	k_mutex_init(&data->lock_mut);
+	k_sem_init(&data->sync_sem, 0, 1);
+
+	if (cfg->irq_config_func) {
+		cfg->irq_config_func();
+	}
+
 	return 0;
 }
 
-#define I2C_XEC_DEVICE(n)						\
-									\
-	PINCTRL_DT_INST_DEFINE(n);					\
-									\
-	static void i2c_xec_irq_config_func_##n(void);			\
-									\
-	static struct i2c_xec_data i2c_xec_data_##n;			\
-	static const struct i2c_xec_config i2c_xec_config_##n = {	\
-		.base_addr =						\
-			DT_INST_REG_ADDR(n),				\
-		.port_sel = DT_INST_PROP(n, port_sel),			\
-		.clock_freq = DT_INST_PROP(n, clock_frequency),		\
-		.girq = DT_INST_PROP_BY_IDX(n, girqs, 0),		\
-		.girq_pos = DT_INST_PROP_BY_IDX(n, girqs, 1),		\
-		.pcr_idx = DT_INST_PROP_BY_IDX(n, pcrs, 0),		\
-		.pcr_bitpos = DT_INST_PROP_BY_IDX(n, pcrs, 1),		\
-		.irq_config_func = i2c_xec_irq_config_func_##n,		\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
-	};								\
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_xec_init, NULL,		\
-		&i2c_xec_data_##n, &i2c_xec_config_##n,			\
-		POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
-		&i2c_xec_driver_api);					\
-									\
-	static void i2c_xec_irq_config_func_##n(void)			\
-	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n),				\
-			    DT_INST_IRQ(n, priority),			\
-			    i2c_xec_bus_isr,				\
-			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQN(n));				\
-	}
+static DEVICE_API(i2c, i2c_xec_driver_api) = {
+	.configure = i2c_xec_configure,
+	.get_config = i2c_xec_get_config,
+	.transfer = i2c_xec_transfer,
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_xec_target_register,
+	.target_unregister = i2c_xec_target_unregister,
+#else
+	.target_register = NULL,
+	.target_unregister = NULL,
+#endif
+};
+
+#define XEC_I2C_GIRQ_DT(inst)     MCHP_XEC_ECIA_GIRQ(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+#define XEC_I2C_GIRQ_POS_DT(inst) MCHP_XEC_ECIA_GIRQ_POS(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+
+#define I2C_XEC_DEVICE(i)                                                                          \
+	PINCTRL_DT_INST_DEFINE(i);                                                                 \
+	static void i2c_xec_irq_config_func_##i(void)                                              \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(i), DT_INST_IRQ(i, priority), i2c_xec_isr,                \
+			    DEVICE_DT_INST_GET(i), 0);                                             \
+		irq_enable(DT_INST_IRQN(i));                                                       \
+	}                                                                                          \
+	static struct i2c_xec_data i2c_xec_data_##i = {.port_sel = DT_INST_PROP(i, port_sel)};     \
+	static const struct i2c_xec_config i2c_xec_config_##i = {                                  \
+		.base = (mem_addr_t)DT_INST_REG_ADDR(i),                                           \
+		.clock_freq = DT_INST_PROP(i, clock_frequency),                                    \
+		.sda_gpio = GPIO_DT_SPEC_INST_GET(i, sda_gpios),                                   \
+		.scl_gpio = GPIO_DT_SPEC_INST_GET(i, scl_gpios),                                   \
+		.irq_config_func = i2c_xec_irq_config_func_##i,                                    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),                                         \
+		.girq = (uint8_t)XEC_I2C_GIRQ_DT(i),                                               \
+		.girq_pos = (uint8_t)XEC_I2C_GIRQ_POS_DT(i),                                       \
+		.enc_pcr = (uint8_t)DT_INST_PROP(i, pcr_scr),                                      \
+		.port = (uint8_t)DT_INST_PROP(i, port_sel),                                        \
+	};                                                                                         \
+	PM_DEVICE_DT_INST_DEFINE(i, i2c_xec_pm_action);                                            \
+	I2C_DEVICE_DT_INST_DEFINE(i, i2c_xec_init, PM_DEVICE_DT_INST_GET(i), &i2c_xec_data_##i,    \
+				  &i2c_xec_config_##i, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,      \
+				  &i2c_xec_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_XEC_DEVICE)

--- a/drivers/i2c/i2c_mchp_xec_v2.h
+++ b/drivers/i2c/i2c_mchp_xec_v2.h
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_
+#define ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_
+
+#include <zephyr/sys/util.h>
+
+#define XEC_I2C_SMB0_ID    0
+#define XEC_I2C_SMB1_ID    1
+#define XEC_I2C_SMB2_ID    2
+#define XEC_I2C_SMB3_ID    3
+#define XEC_I2C_SMB4_ID    4
+#define XEC_I2C_SMB_MAX_ID 5
+
+#define XEC_I2C_SMB_INST_SIZE 0x400u
+
+#define XEC_I2C_SMB_BASE(base, instance)                                                           \
+	((uint32_t)(base) + ((uint32_t)(instance) * (XEC_I2C_SMB_INST_SIZE)))
+
+/* Hardware only supports 7-bit I2C addressing */
+#define XEC_I2C_TARGET_ADDR_MSK GENMASK(6, 0)
+
+/* Hardware supports two target 7-bit addresses */
+#define XEC_I2C_MAX_TARGETS 2
+
+#define XEC_I2C_CR_OFS     0 /* WO */
+#define XEC_I2C_CR_MSK     0xcfu
+#define XEC_I2C_CR_ACK_POS 0
+#define XEC_I2C_CR_STO_POS 1
+#define XEC_I2C_CR_STA_POS 2
+#define XEC_I2C_CR_ENI_POS 3
+#define XEC_I2C_CR_ESO_POS 6
+#define XEC_I2C_CR_PIN_POS 7
+
+#define XEC_I2C_SR_OFS         0 /* RO */
+#define XEC_I2C_SR_MSK         0xffu
+#define XEC_I2C_SR_NBB_POS     0
+#define XEC_I2C_SR_LAB_POS     1
+#define XEC_I2C_SR_AAT_POS     2
+#define XEC_I2C_SR_LRB_AD0_POS 3
+#define XEC_I2C_SR_BER_POS     4
+#define XEC_I2C_SR_STO_POS     5
+#define XEC_I2C_SR_SAD_POS     6
+#define XEC_I2C_SR_PIN_POS     7
+
+/* XEC I2C hardware can match the following addresses in addition
+ * to the two programmable 7-bit OWN addresses.
+ * I2C general call 7-bit address 0x00. I2C.CONFIG.GC_DIS bit = 0
+ * SMBus Host and Device addresses 0x08 and 0x61. I2C.CONFIG.DSA bit = 1
+ * Detection using I2C.STATUS register.
+ * AAT SAD LRB/AD0 address
+ *  1   1   0      0x08 SMBus Host address
+ *  1   1   1      0x61 SMBus Device address
+ *  1   0   1      0x00 I2C general call address
+ *  1   0   0      One of the two programmable OWN addresses.
+ * The actual address can be viewed without side-effect by reading I2C.SHAD_ADDR
+ * register. It can be read from I2C.DATA with side-effect of clearing AAT, SAD, and LRB/AD0.
+ * In network layer mode the HW stores the address via DMA into the configured memory buffer.
+ */
+#define XEC_I2C_GEN_CALL_ADDR   0u
+#define XEC_I2C_SMB_HOST_ADDR   0x08u
+#define XEC_I2C_SMB_DEVICE_ADDR 0x61u
+
+#define XEC_I2C_SR_ADDR_MATCH_MSK                                                                  \
+	(BIT(XEC_I2C_SR_PIN_POS) | BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_LRB_AD0_POS) |         \
+	 BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_GEN_CALL (BIT(XEC_I2C_SR_LRB_AD0_POS) | BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_SMB_HOST (BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_SMB_DEV                                                              \
+	(BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_LRB_AD0_POS) | BIT(XEC_I2C_SR_AAT_POS))
+
+#define XEC_I2C_OA_OFS       0x4u /* own(target) address */
+#define XEC_I2C_OA_1_POS     0
+#define XEC_I2C_OA_2_POS     8
+#define XEC_I2C_OA_1_MSK     GENMASK(6, 0)
+#define XEC_I2C_OA_2_MSK     GENMASK(14, 8)
+#define XEC_I2C_OA_1_SET(a)  FIELD_PREP(XEC_I2C_OA_1_MSK, (a))
+#define XEC_I2C_OA_2_SET(a)  FIELD_PREP(XEC_I2C_OA_2_MSK, (a))
+#define XEC_I2C_OA_1_GET(r)  FIELD_GET(XEC_I2C_OA_1_MSK, (r))
+#define XEC_I2C_OA_2_GET(r)  FIELD_GET(XEC_I2C_OA_2_MSK, (r))
+#define XEC_I2C_OA_POS(n)    ((n) * 8u)
+#define XEC_I2C_OA_MSK(n)    (0x7Fu << XEC_I2C_OA_POS(n))
+#define XEC_I2C_OA_SET(n, a) (((uint32_t)(a) << XEC_I2C_OA_POS(n)) & XEC_I2C_OA_MSK(n))
+#define XEC_I2C_OA_GET(n, r) (((uint32_t)(r) & XEC_I2C_OA_MSK(n)) >> XEC_I2C_OA_POS(n))
+
+#define XEC_I2C_DATA_OFS 0x8u
+#define XEC_I2C_DATA_MSK GENMASK(7, 0)
+
+#define XEC_I2C_HCMD_OFS        0x0cu /* network layer host command */
+#define XEC_I2C_HCMD_RUN_POS    0
+#define XEC_I2C_HCMD_PROC_POS   1
+#define XEC_I2C_HCMD_START0_POS 8
+#define XEC_I2C_HCMD_STARTN_POS 9
+#define XEC_I2C_HCMD_STOP_POS   10
+#define XEC_I2C_HCMD_PEC_TX_POS 11
+#define XEC_I2C_HCMD_RDM_POS    12
+#define XEC_I2C_HCMD_PEC_RD_POS 13
+#define XEC_I2C_HCMD_WCL_POS    16
+#define XEC_I2C_HCMD_WCL_MSK    GENMASK(23, 16)
+#define XEC_I2C_HCMD_WCL_SET(n) FIELD_PREP(XEC_I2C_HCMD_WCL_MSK, (n))
+#define XEC_I2C_HCMD_WCL_GET(r) FIELD_GET(XEC_I2C_HCMD_WCL_MSK, (r))
+#define XEC_I2C_HCMD_RCL_POS    24
+#define XEC_I2C_HCMD_RCL_MSK    GENMASK(31, 24)
+#define XEC_I2C_HCMD_RCL_SET(n) FIELD_PREP(XEC_I2C_HCMD_RCL_MSK, (n))
+#define XEC_I2C_HCMD_RCL_GET(r) FIELD_GET(XEC_I2C_HCMD_RCL_MSK, (r))
+
+#define XEC_I2C_TCMD_OFS        0x10u /* network layer target command */
+#define XEC_I2C_TCMD_RUN_POS    0
+#define XEC_I2C_TCMD_PROC_POS   1
+#define XEC_I2C_TCMD_TX_PEC_POS 2
+#define XEC_I2C_TCMD_WCL_POS    8
+#define XEC_I2C_TCMD_WCL_MSK    GENMASK(15, 8)
+#define XEC_I2C_TCMD_WCL_SET(n) FIELD_PREP(XEC_I2C_TCMD_WCL_MSK, (n))
+#define XEC_I2C_TCMD_WCL_GET(r) FIELD_GET(XEC_I2C_TCMD_WCL_MSK, (r))
+#define XEC_I2C_TCMD_RCL_POS    16
+#define XEC_I2C_TCMD_RCL_MSK    GENMASK(23, 16)
+#define XEC_I2C_TCMD_RCL_SET(n) FIELD_PREP(XEC_I2C_TCMD_RCL_MSK, (n))
+#define XEC_I2C_TCMD_RCL_GET(r) FIELD_GET(XEC_I2C_TCMD_RCL_MSK, (r))
+
+#define XEC_I2C_PEC_OFS 0x14u
+#define XEC_I2C_PEC_MSK GENMASK(7, 0)
+
+#define XEC_I2C_RSHT_OFS 0x18u /* Repeated-START hold time */
+#define XEC_I2C_RSHT_MSK GENMASK(7, 0)
+
+/* Network layer mode extended length. Contains bit[15:8] of write and read counts */
+#define XEC_I2C_ELEN_OFS        0x1cu
+#define XEC_I2C_ELEN_HWR_POS    0
+#define XEC_I2C_ELEN_HWR_MSK    GENMASK(7, 0)
+#define XEC_I2C_ELEN_HWR_SET(n) FIELD_PREP(XEC_I2C_ELEN_HWR_MSK, (n))
+#define XEC_I2C_ELEN_HWR_GET(r) FIELD_GET(XEC_I2C_ELEN_HWR_MSK, (r))
+#define XEC_I2C_ELEN_HRD_POS    8
+#define XEC_I2C_ELEN_HRD_MSK    GENMASK(15, 8)
+#define XEC_I2C_ELEN_HRD_SET(n) FIELD_PREP(XEC_I2C_ELEN_HRD_MSK, (n))
+#define XEC_I2C_ELEN_HRD_GET(r) FIELD_GET(XEC_I2C_ELEN_HRD_MSK, (r))
+#define XEC_I2C_ELEN_TWR_POS    16
+#define XEC_I2C_ELEN_TWR_MSK    GENMASK(23, 16)
+#define XEC_I2C_ELEN_TWR_SET(n) FIELD_PREP(XEC_I2C_ELEN_TWR_MSK, (n))
+#define XEC_I2C_ELEN_TWR_GET(r) FIELD_GET(XEC_I2C_ELEN_TWR_MSK, (r))
+#define XEC_I2C_ELEN_TRD_POS    24
+#define XEC_I2C_ELEN_TRD_MSK    GENMASK(31, 24)
+#define XEC_I2C_ELEN_TRD_SET(n) FIELD_PREP(XEC_I2C_ELEN_TRD_MSK, (n))
+#define XEC_I2C_ELEN_TRD_GET(r) FIELD_GET(XEC_I2C_ELEN_TRD_MSK, (r))
+
+#define XEC_I2C_CMPL_OFS 0x20u /* Completion: R/W1C status and timeout check enables */
+#define XEC_I2C_CMPL_MSK                                                                           \
+	(GENMASK(6, 2) | GENMASK(14, 8) | GENMASK(17, 16) | GENMASK(21, 19) | GENMASK(25, 24) |    \
+	 GENMASK(31, 29))
+#define XEC_I2C_CMPL_RW_MSK GENMASK(5, 2)
+#define XEC_I2C_CMPL_RO_MSK (BIT(6) | BIT(17) | BIT(25))
+#define XEC_I2C_CMPL_RW1C_MSK                                                                      \
+	(GENMASK(14, 8) | BIT(16) | GENMASK(21, 19) | BIT(24) | GENMASK(31, 29))
+#define XEC_I2C_CMPL_DTEN_POS      2
+#define XEC_I2C_CMPL_HCEN_POS      3
+#define XEC_I2C_CMPL_TCEN_POS      4
+#define XEC_I2C_CMPL_BIDEN_POS     5
+#define XEC_I2C_CMPL_TMO_STS_POS   6 /* RO - any of 4 timeouts detected */
+#define XEC_I2C_CMPL_DTS_STS_POS   8
+#define XEC_I2C_CMPL_HCTO_STS_POS  9
+#define XEC_I2C_CMPL_TCTO_STS_POS  10
+#define XEC_I2C_CMPL_CHDL_STS_POS  11
+#define XEC_I2C_CMPL_CHDH_STS_POS  12
+#define XEC_I2C_CMPL_BER_STS_POS   13
+#define XEC_I2C_CMPL_LAB_STS_POS   14
+#define XEC_I2C_CMPL_TNAKR_STS_POS 16
+#define XEC_I2C_CMPL_TTR_POS       17 /* RO */
+#define XEC_I2C_CMPL_TPROT_POS     19
+#define XEC_I2C_CMPL_RPT_RD_POS    20
+#define XEC_I2C_CMPL_RPT_WR_POS    21
+#define XEC_I2C_CMPL_HNAKX_POS     24
+#define XEC_I2C_CMPL_HTR_POS       25 /* RO */
+#define XEC_I2C_CMPL_IDLE_POS      29
+#define XEC_I2C_CMPL_HDONE_POS     30
+#define XEC_I2C_CMPL_TDONE_POS     31
+
+#define XEC_I2C_ISC_OFS         0x24u /* fairness idle time scaling */
+#define XEC_I2C_ISC_FBI_POS     0
+#define XEC_I2C_ISC_FBI_MSK     GENMASK(11, 0)
+#define XEC_I2C_ISC_FBI_SET(n)  FIELD_PREP(XEC_I2C_ISC_FBI_MSK, (n))
+#define XEC_I2C_ISC_FBI_GET(r)  FIELD_GET(XEC_I2C_ISC_FBI_MSK, (r))
+#define XEC_I2C_ISC_FIDD_POS    16
+#define XEC_I2C_ISC_FIDD_MSK    GENMASK(27, 16)
+#define XEC_I2C_ISC_FIDD_SET(n) FIELD_PREP(XEC_I2C_ISC_FIDD_MSK, (n))
+#define XEC_I2C_ISC_FIDD_GET(r) FIELD_GET(XEC_I2C_ISC_FIDD_MSK, (r))
+
+#define XEC_I2C_CFG_OFS            0x28u
+#define XEC_I2C_CFG_PORT_POS       0
+#define XEC_I2C_CFG_PORT_MSK       GENMASK(3, 0)
+#define XEC_I2C_CFG_PORT_SET(p)    FIELD_PREP(XEC_I2C_CFG_PORT_MSK, (p))
+#define XEC_I2C_CFG_PORT_GET(r)    FIELD_GET(XEC_I2C_CFG_PORT_MSK, (r))
+#define XEC_I2C_CFG_TCEN_POS       4
+#define XEC_I2C_CFG_SLOW_CLK_POS   5
+#define XEC_I2C_CFG_PECEN_POS      7
+#define XEC_I2C_CFG_FEN_POS        8
+#define XEC_I2C_CFG_RST_POS        9
+#define XEC_I2C_CFG_ENAB_POS       10
+#define XEC_I2C_CFG_DSA_POS        11
+#define XEC_I2C_CFG_FAIR_POS       12
+#define XEC_I2C_CFG_GC_DIS_POS     14
+#define XEC_I2C_CFG_PROM_EN_POS    15
+#define XEC_I2C_CFG_FTTX_POS       16 /* WO */
+#define XEC_I2C_CFG_FTRX_POS       17 /* WO */
+#define XEC_I2C_CFG_FHTX_POS       18 /* WO */
+#define XEC_I2C_CFG_FHRX_POS       19 /* WO */
+#define XEC_I2C_CFG_STD_IEN_POS    24 /* v3.8 HW only */
+#define XEC_I2C_CFG_STD_NL_IEN_POS 27 /* v3.8 HW only */
+#define XEC_I2C_CFG_AAT_IEN_POS    28
+#define XEC_I2C_CFG_IDLE_IEN_POS   29
+#define XEC_I2C_CFG_HD_IEN_POS     30
+#define XEC_I2C_CFG_TD_IEN_POS     31
+
+#define XEC_I2C_BCLK_OFS        0x2cu /* bus clock */
+#define XEC_I2C_BCLK_LOP_POS    0
+#define XEC_I2C_BCLK_LOP_MSK    GENMASK(7, 0)
+#define XEC_I2C_BCLK_LOP_SET(n) FIELD_PREP(XEC_I2C_BCLK_LOP_MSK, (n))
+#define XEC_I2C_BCLK_LOP_GET(r) FIELD_GET(XEC_I2C_BCLK_LOP_MSK, (r))
+#define XEC_I2C_BCLK_HIP_POS    8
+#define XEC_I2C_BCLK_HIP_MSK    GENMASK(15, 8)
+#define XEC_I2C_BCLK_HIP_SET(n) FIELD_PREP(XEC_I2C_BCLK_HIP_MSK, (n))
+#define XEC_I2C_BCLK_HIP_GET(r) FIELD_GET(XEC_I2C_BCLK_HIP_MSK, (r))
+
+#define XEC_I2C_BLKID_OFS 0x30u /* RO HW block ID */
+#define XEC_I2C_REV_OFS   0x34u /* RO HW revision */
+
+#define XEC_I2C_BBCR_OFS        0x38u /* bit-bang control */
+#define XEC_I2C_BBCR_EN_POS     0     /* MUX SCL/SDA pins from I2C to BB logic */
+#define XEC_I2C_BBCR_CD_POS     1
+#define XEC_I2C_BBCR_DD_POS     2
+#define XEC_I2C_BBCR_SCL_POS    3
+#define XEC_I2C_BBCR_SDA_POS    4
+#define XEC_I2C_BBCR_SCL_IN_POS 5
+#define XEC_I2C_BBCR_SDA_IN_POS 6
+#define XEC_I2C_BBCR_CM_POS     7 /* ver3.8 only */
+
+#define XEC_I2C_MR0_OFS 0x3cu /* MCHP reserved 0 */
+
+#define XEC_I2C_DT_OFS         0x40u /* data timing */
+#define XEC_I2C_DT_DH_POS      0
+#define XEC_I2C_DT_DH_MSK      GENMASK(7, 0)
+#define XEC_I2C_DT_DH_SET(n)   FIELD_PREP(XEC_I2C_DT_DH_MSK, (n))
+#define XEC_I2C_DT_DH_GET(r)   FIELD_GET(XEC_I2C_DT_DH_MSK, (r))
+#define XEC_I2C_DT_RSS_POS     8
+#define XEC_I2C_DT_RSS_MSK     GENMASK(15, 8)
+#define XEC_I2C_DT_RSS_SET(n)  FIELD_PREP(XEC_I2C_DT_RSS_MSK, (n))
+#define XEC_I2C_DT_RSS_GET(r)  FIELD_GET(XEC_I2C_DT_RSS_MSK, (r))
+#define XEC_I2C_DT_STPS_POS    16
+#define XEC_I2C_DT_STPS_MSK    GENMASK(23, 16)
+#define XEC_I2C_DT_STPS_SET(n) FIELD_PREP(XEC_I2C_DT_STPS_MSK, (n))
+#define XEC_I2C_DT_STPS_GET(r) FIELD_GET(XEC_I2C_DT_STPS_MSK, (r))
+#define XEC_I2C_DT_FSH_POS     24
+#define XEC_I2C_DT_FSH_MSK     GENMASK(31, 24)
+#define XEC_I2C_DT_FSH_SET(n)  FIELD_PREP(XEC_I2C_DT_FSH_MSK, (n))
+#define XEC_I2C_DT_FSH_GET(r)  FIELD_GET(XEC_I2C_DT_FSH_MSK, (r))
+
+#define XEC_I2C_TMOUT_SC_OFS         0x44u /* timeout scaling */
+#define XEC_I2C_TMOUT_SC_CHTO_POS    0
+#define XEC_I2C_TMOUT_SC_CHTO_MSK    GENMASK(7, 0)
+#define XEC_I2C_TMOUT_SC_CHTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_CHTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_CHTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_CHTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_TCTO_POS    8
+#define XEC_I2C_TMOUT_SC_TCTO_MSK    GENMASK(15, 8)
+#define XEC_I2C_TMOUT_SC_TCTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_TCTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_TCTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_TCTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_HCTO_POS    16
+#define XEC_I2C_TMOUT_SC_HCTO_MSK    GENMASK(23, 16)
+#define XEC_I2C_TMOUT_SC_HCTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_HCTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_HCTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_HCTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_BIM_POS     24
+#define XEC_I2C_TMOUT_SC_BIM_MSK     GENMASK(31, 24)
+#define XEC_I2C_TMOUT_SC_BIM_SET(n)  FIELD_PREP(XEC_I2C_TMOUT_SC_BIM_MSK, (n))
+#define XEC_I2C_TMOUT_SC_BIM_GET(r)  FIELD_GET(XEC_I2C_TMOUT_SC_BIM_MSK, (r))
+
+/* 8-bit data register for network layer mode */
+#define XEC_I2C_TTX_OFS 0x48u /* network layer mode target transmit */
+#define XEC_I2C_TRX_OFS 0x4cu /* network layer mode target receive */
+#define XEC_I2C_HTX_OFS 0x50u /* network layer mode host transmit */
+#define XEC_I2C_HRX_OFS 0x54u /* network layer mode host receive */
+
+#define XEC_I2C_IFSM_OFS                  0x58u /* RO I2C HW FSM */
+#define XEC_I2C_IFSM_HM_ST_POS            0
+#define XEC_I2C_IFSM_HM_ST_MSK            GENMASK(7, 0)
+#define XEC_I2C_IFSM_HM_ST_IDLE           0
+#define XEC_I2C_IFSM_HM_ST_W4STA          1u
+#define XEC_I2C_IFSM_HM_ST_TXADDR         2u
+#define XEC_I2C_IFSM_HM_ST_CHK_AACK       3u
+#define XEC_I2C_IFSM_HM_ST_RXDATA         4u /* debug I2C0 was here */
+#define XEC_I2C_IFSM_HM_ST_CHK_DACK       5u
+#define XEC_I2C_IFSM_HM_ST_TXDATA         6u
+#define XEC_I2C_IFSM_HM_ST_TXDATA_LD      7u
+#define XEC_I2C_IFSM_HM_ST_W4ACK          8u
+#define XEC_I2C_IFSM_HM_ST_W4STO          9u
+#define XEC_I2C_IFSM_HM_ST_LARB           10u
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA      11u
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA_DLY1 12u
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA_DLY2 13u
+#define XEC_I2C_IFSM_HM_ST_W4STA_HLD      14u
+#define XEC_I2C_IFSM_HM_ST_GET(r)         FIELD_GET(XEC_I2C_IFSM_HM_ST_MSK, (r))
+
+#define XEC_I2C_IFSM_TM_ST_POS     8
+#define XEC_I2C_IFSM_TM_ST_MSK     GENMASK(15, 8)
+#define XEC_I2C_IFSM_TM_ST_IDLE    0
+#define XEC_I2C_IFSM_TM_ST_HDRACK  1u
+#define XEC_I2C_IFSM_TM_ST_TXDATA  2u /* debug I2C1 was here */
+#define XEC_I2C_IFSM_TM_ST_W4ACK   3u
+#define XEC_I2C_IFSM_TM_ST_RXDATA  4u
+#define XEC_I2C_IFSM_TM_ST_ACKDATA 5u
+#define XEC_I2C_IFSM_TM_ST_GET(r)  FIELD_GET(XEC_I2C_IFSM_TM_ST_MSK, (r))
+
+#define XEC_I2C_IFSM_PHY_POS     16
+#define XEC_I2C_IFSM_PHY_MSK     GENMASK(19, 16)
+#define XEC_I2C_IFSM_PHY_IDLE    0
+#define XEC_I2C_IFSM_PHY_CLKHI   1u
+#define XEC_I2C_IFSM_PHY_STA_STO 2u
+#define XEC_I2C_IFSM_PHY_CLKLO   3u
+#define XEC_I2C_IFSM_PHY_SDATCR  4u
+#define XEC_I2C_IFSM_PHY_ARBLOSS 5u
+#define XEC_I2C_IFSM_PHY_GET(r)  FIELD_GET(XEC_I2C_IFSM_TM_PHY_MSK, (r))
+
+#define XEC_I2C_IFSM_HMCTO_POS    20
+#define XEC_I2C_IFSM_HMCTO_MSK    GENMASK(23, 20)
+#define XEC_I2C_IFSM_HMCTO_IDLE   0
+#define XEC_I2C_IFSM_HMCTO_CNT    1u
+#define XEC_I2C_IFSM_HMCTO_GET(r) FIELD_GET(XEC_I2C_IFSM_HMCTO_MSK, (r))
+
+#define XEC_I2C_IFSM_SMCTO_POS    24
+#define XEC_I2C_IFSM_SMCTO_MSK    GENMASK(27, 24)
+#define XEC_I2C_IFSM_SMCTO_IDLE   0
+#define XEC_I2C_IFSM_SMCTO_CNT    1u
+#define XEC_I2C_IFSM_SMCTO_GET(r) FIELD_GET(XEC_I2C_IFSM_SMCTO_MSK, (r))
+
+#define XEC_I2C_IFSM_TMBI_POS    28
+#define XEC_I2C_IFSM_TMBI_MSK    GENMASK(31, 28)
+#define XEC_I2C_IFSM_TMBI_IDLE   0
+#define XEC_I2C_IFSM_TMBI_CNT    1u
+#define XEC_I2C_IFSM_TMBI_GET(r) FIELD_GET(XEC_I2C_IFSM_TMBI_MSK, (r))
+
+#define XEC_I2C_NFSM_OFS               0x5cu /* RO Network layer mode HW FSM */
+#define XEC_I2C_NFSM_HC_STATE_POS      0
+#define XEC_I2C_NFSM_HC_STATE_MSK      GENMASK(7, 0)
+#define XEC_I2C_NFSM_HC_STATE_IDLE     0
+#define XEC_I2C_NFSM_HC_STATE_SOP      1u
+#define XEC_I2C_NFSM_HC_STATE_STA      2u
+#define XEC_I2C_NFSM_HC_STATE_STA_PIN  3u
+#define XEC_I2C_NFSM_HC_STATE_WDATA    4u
+#define XEC_I2C_NFSM_HC_STATE_WPEC     5u
+#define XEC_I2C_NFSM_HC_STATE_RSTA     6u
+#define XEC_I2C_NFSM_HC_STATE_RSTA_PIN 7u
+#define XEC_I2C_NFSM_HC_STATE_RDN      8u
+#define XEC_I2C_NFSM_HC_STATE_RD_PEC   9u
+#define XEC_I2C_NFSM_HC_STATE_RPEC     10u
+#define XEC_I2C_NFSM_HC_STATE_PAUSE    11u
+#define XEC_I2C_NFSM_HC_STATE_STO      12u
+#define XEC_I2C_NFSM_HC_STATE_EOP      13u
+#define XEC_I2C_NFSM_HC_STATE_GET(r)   FIELD_GET(XEC_I2C_NFSM_HC_STATE_MSK, (r))
+#define XEC_I2C_NFSM_TC_STATE_POS      8
+#define XEC_I2C_NFSM_TC_STATE_MSK      GENMASK(15, 8)
+#define XEC_I2C_NFSM_TC_STATE_IDLE     0
+#define XEC_I2C_NFSM_TC_STATE_ADDR     1u
+#define XEC_I2C_NFSM_TC_STATE_WPIN     2u
+#define XEC_I2C_NFSM_TC_STATE_RPIN     3u
+#define XEC_I2C_NFSM_TC_STATE_WDATA    4u
+#define XEC_I2C_NFSM_TC_STATE_RDATA    5u
+#define XEC_I2C_NFSM_TC_STATE_RBE      6u
+#define XEC_I2C_NFSM_TC_STATE_RPEC     7u
+#define XEC_I2C_NFSM_TC_STATE_RPECRPT  8u
+#define XEC_I2C_NFSM_TC_STATE_GET(r)   FIELD_GET(XEC_I2C_NFSM_TC_STATE_MSK, (r))
+#define XEC_I2C_NFSM_FAIR_POS          16
+#define XEC_I2C_NFSM_FAIR_MSK          GENMASK(23, 16)
+#define XEC_I2C_NFSM_FAIR_IDLE         0
+#define XEC_I2C_NFSM_FAIR_BUSY         1u
+#define XEC_I2C_NFSM_FAIR_WIN          2u
+#define XEC_I2C_NFSM_FAIR_DLY          3u
+#define XEC_I2C_NFSM_FAIR_WAIT         4u
+#define XEC_I2C_NFSM_FAIR_WAIT_DONE    5u
+#define XEC_I2C_NFSM_FAIR_ACTIVE       6u
+
+#define XEC_I2C_WKSR_OFS    0x60u /* wake status */
+#define XEC_I2C_WKSR_SB_POS 0     /* start bit detected R/W1C */
+
+#define XEC_I2C_WKCR_OFS      0x64u /* wake control */
+#define XEC_I2C_WKCR_SBEN_POS 0     /* start bit detection interrupt enable */
+
+#define XEC_I2C_MR1_OFS 0x68u /* MCHP reserved 1 */
+
+#define XEC_I2C_IAS_OFS 0x6cu /* RO I2C address shadow */
+
+#define XEC_I2C_PIS_OFS     0x70u /* I2C promiscuous mode interrupt status */
+/* I2C has captured 8 address bits and is stretching the clock
+ * software sets HW to (n)ACK
+ */
+#define XEC_I2C_PIS_CAP_POS 0
+
+#define XEC_I2C_PIE_OFS     0x74u /* I2C promiscuous mode interrupt enable */
+#define XEC_I2C_PIE_CAP_POS 0
+
+#define XEC_I2C_PCR_OFS     0x78u /* I2C promiscuous mode control */
+#define XEC_I2C_PCR_ACK_POS 0     /* write 1 to ACK the captured address */
+
+#define XEC_I2C_IDS_OFS 0x7Cu /* RO I2C data shadow */
+
+#define XEC_I2C_SMB_DATA_TM_100K 0x0C4D5006U
+#define XEC_I2C_SMB_IDLE_SC_100K 0x01FC01EDU
+#define XEC_I2C_SMB_TMO_SC_100K  0x4B9CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_100K 0x4F4FU
+#define XEC_I2C_SMB_RSHT_100K    0x4DU
+
+#define XEC_I2C_SMB_DATA_TM_400K 0x040A0A06U
+#define XEC_I2C_SMB_IDLE_SC_400K 0x01000050U
+#define XEC_I2C_SMB_TMO_SC_400K  0x159CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_400K 0x0F17U
+#define XEC_I2C_SMB_RSHT_400K    0x0AU
+
+#define XEC_I2C_SMB_DATA_TM_1M 0x04060601U
+#define XEC_I2C_SMB_IDLE_SC_1M 0x10000050U
+#define XEC_I2C_SMB_TMO_SC_1M  0x089CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_1M 0x0509U
+#define XEC_I2C_SMB_RSHT_1M    0x06U
+
+#define XEC_I2C_NL_MAX_LEN 0xfff8U
+
+#define XEC_I2C_MAX_PORTS (((XEC_I2C_CFG_PORT_MSK) >> (XEC_I2C_CFG_PORT_POS)) + 1u)
+
+#endif /* ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_ */

--- a/dts/arm/microchip/mec/mec1727nsz.dtsi
+++ b/dts/arm/microchip/mec/mec1727nsz.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
+#include <zephyr/dt-binding/gpio/microchip-xec-gpio.h>
 #include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 
 #include "mec172x/mec172x-vw-routing.dtsi"

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -506,8 +506,8 @@ i2c_smb_0: i2c@40004000 {
 	reg = <0x40004000 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <20 1>;
-	girqs = <13 0>;
-	pcrs = <1 10>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 0)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 1)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 10)>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "disabled";
@@ -518,8 +518,8 @@ i2c_smb_1: i2c@40004400 {
 	reg = <0x40004400 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <21 1>;
-	girqs = <13 1>;
-	pcrs = <3 13>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 1)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 2)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 13)>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "disabled";
@@ -530,8 +530,8 @@ i2c_smb_2: i2c@40004800 {
 	reg = <0x40004800 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <22 1>;
-	girqs = <13 2>;
-	pcrs = <3 14>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 2)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 3)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 14)>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "disabled";
@@ -542,8 +542,8 @@ i2c_smb_3: i2c@40004c00 {
 	reg = <0x40004C00 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <23 1>;
-	girqs = <13 3>;
-	pcrs = <3 15>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 3)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 4)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 15)>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "disabled";
@@ -554,8 +554,8 @@ i2c_smb_4: i2c@40005000 {
 	reg = <0x40005000 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <158 1>;
-	girqs = <13 4>;
-	pcrs = <3 20>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 4)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 5)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 20)>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "disabled";

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -417,9 +417,10 @@
 
 		i2c_smb_0: i2c@40004000 {
 			reg = <0x40004000 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <20 2>;
-			girqs = <13 0>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 0)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 1)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 10)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -427,9 +428,10 @@
 
 		i2c_smb_1: i2c@40004400 {
 			reg = <0x40004400 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <21 2>;
-			girqs = <13 1>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 1)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 2)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 13)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -437,9 +439,10 @@
 
 		i2c_smb_2: i2c@40004800 {
 			reg = <0x40004800 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <22 2>;
-			girqs = <13 2>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 2)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 3)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 14)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -447,9 +450,10 @@
 
 		i2c_smb_3: i2c@40004c00 {
 			reg = <0x40004C00 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <23 2>;
-			girqs = <13 3>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 3)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 4)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 15)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -457,9 +461,10 @@
 
 		i2c_smb_4: i2c@40005000 {
 			reg = <0x40005000 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <158 2>;
-			girqs = <13 4>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 4)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 5)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 20)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -1,7 +1,8 @@
 # Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Microchip I2C/SMB V2 controller
+description: Microchip XEC 2C/SMB V2 controller byte mode driver
 
 compatible: "microchip,xec-i2c-v2"
 
@@ -11,23 +12,56 @@ properties:
   reg:
     required: true
 
+  interrupts:
+    required: true
+
   port-sel:
     type: int
-    description: soc block mapping to pin
     required: true
+    description: |
+      XEC I2C controller has a hardware MUX to select among
+      multiple I2C ports. I2C pins must be set to their I2C
+      mode using PINCTRL. The driver can then select the pins
+      by programming the port select register field in the
+      controller's configuration register.
 
   girqs:
     type: array
     required: true
     description: array of GIRQ numbers [8:26] and bit positions [0:31]
 
-  pcrs:
-    type: array
+  pcr-scr:
+    type: int
     required: true
-    description: PCR sleep register index and bit position
+    description: |
+      I2C controller PCR register index and bit position encoded
+      in an integer.
 
   pinctrl-0:
     required: true
 
   pinctrl-names:
     required: true
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      I2C controller versions older than v3.8 do not make pin
+      state monitoring visible in the bit-bang register without
+      switching the pins from I2C control to bit-bang control.
+      This can cause disruption of an open I2C session. For older
+      hardware use access pin state using the GPIO driver.
+
+  scl-gpios:
+    type: phandle-array
+    description: |
+      Refer to the description of sda-gpios.
+
+  target-buf-write-req-buffer-size:
+    type: int
+    default: 8
+    description: |
+      The property allows each instance of the driver to have
+      a unique target buffer write request buffer size in bytes.
+      This property is only used if the driver is built with
+      I2C target buffer mode enabled.

--- a/include/zephyr/drivers/i2c/mchp_xec_i2c.h
+++ b/include/zephyr/drivers/i2c/mchp_xec_i2c.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_MCHP_XEC_I2C_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I2C_MCHP_XEC_I2C_H_
+
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+
+#define MCHP_I2C_NUM_PORTS (16)
+
+#ifdef CONFIG_I2C_XEC_PORT_MUX
+
+#define I2C_XEC_PORT_POS      (16)
+#define I2C_XEC_PORT_MSK0     (0xfu)
+#define I2C_XEC_PORT_MSK      GENMASK(19, 16)
+#define I2C_XEC_PORT_SET(p)   FIELD_PREP(I2C_XEC_PORT_MSK, (p))
+#define I2C_XEC_PORT_GET(cfg) FIELD_GET(I2C_XEC_PORT_MSK, (cfg))
+
+#endif
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I2C_MCHP_XEC_I2C_H_ */

--- a/tests/drivers/i2c/i2c_target_api/boards/mec172xevb_assy6906.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec172xevb_assy6906.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# Disable driver hardware port multiplexer support.
+CONFIG_I2C_XEC_PORT_MUX=n

--- a/tests/drivers/i2c/i2c_target_api/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/microchip-xec-gpio.h>
+
+/* We configure i2c_smb_0 to use HW port 0 pins
+ * and i2c_smb_1 to use HW port 4 pins.
+ * MEC I2C controllers have a HW mux allowing each controller to
+ * access any of the port pin pairs.
+ * For this test we need to connect both controllers together.
+ * We set port-sel of both controllers to port 0 connecting the
+ * the two controller to port 0 pins
+ */
+&i2c_smb_0 {
+	compatible = "microchip,xec-i2c-v2";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
+	pinctrl-0 = <&i2c00_sda_gpio003 &i2c00_scl_gpio004>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+&i2c_smb_1 {
+	compatible = "microchip,xec-i2c-v2";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_143 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_144 0>;
+	pinctrl-0 = <&i2c04_sda_gpio143 &i2c04_scl_gpio144>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+/* I2C Port 0 */
+&i2c00_sda_gpio003 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c00_scl_gpio004 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+/* I2C Port 4 */
+&i2c04_sda_gpio143 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c04_scl_gpio144 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# Disable driver hardware port multiplexer support.
+CONFIG_I2C_XEC_PORT_MUX=n

--- a/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.overlay
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* We configure i2c_smb_0 to use HW port 0 pins
+ * and i2c_smb_1 to use HW port 4 pins.
+ * MEC I2C controllers have a HW mux allowing each controller to
+ * access any of the port pin pairs.
+ * For this test we need to connect both controllers together.
+ * We set port-sel of both controllers to port 0 connecting the
+ * the two controller to port 0 pins
+ */
+&i2c_smb_0 {
+	compatible = "microchip,xec-i2c-v2";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
+	pinctrl-0 = <&i2c00_sda_gpio003 &i2c00_scl_gpio004>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+&i2c_smb_1 {
+	compatible = "microchip,xec-i2c-v2";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_143 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_144 0>;
+	pinctrl-0 = <&i2c04_sda_gpio143 &i2c04_scl_gpio144>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+/* I2C Port 0 */
+&i2c00_sda_gpio003 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c00_scl_gpio004 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+/* I2C Port 4 */
+&i2c04_sda_gpio143 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c04_scl_gpio144 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};


### PR DESCRIPTION
We added support for Microchip MEC174x/5x to the version 2 I2C byte mode driver.  The driver was hooked up to the I2C target API test.  The driver was also modified to be "linux style" by adding a header with register definitions to the I2C driver folder and using Zephyr's sys_read/write register inline functions.