### PR TITLE
tracing: added missing weak function prototypes for USER_TRACING

### DIFF
--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -9,520 +9,857 @@
 #include <zephyr/kernel.h>
 #include <zephyr/debug/cpu_load.h>
 #include <zephyr/init.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/socket.h>
 
-void __weak sys_trace_thread_create_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_abort_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_suspend_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_resume_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_name_set_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_switched_in_user(void) {}
-void __weak sys_trace_thread_switched_out_user(void) {}
-void __weak sys_trace_thread_info_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_sched_ready_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_pend_user(struct k_thread *thread) {}
-void __weak sys_trace_thread_priority_set_user(struct k_thread *thread, int prio) {}
-void __weak sys_trace_isr_enter_user(void) {}
-void __weak sys_trace_isr_exit_user(void) {}
-void __weak sys_trace_idle_user(void) {}
-void __weak sys_trace_sys_init_enter_user(const struct init_entry *entry, int level) {}
-void __weak sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result) {}
-void __weak sys_trace_gpio_pin_interrupt_configure_enter_user(const struct device *port,
-							      gpio_pin_t pin, gpio_flags_t flags) {}
-void __weak sys_trace_gpio_pin_interrupt_configure_exit_user(const struct device *port,
-							     gpio_pin_t pin, int ret) {}
-void __weak sys_trace_gpio_pin_configure_enter_user(const struct device *port, gpio_pin_t pin,
-						    gpio_flags_t flags) {}
-void __weak sys_trace_gpio_pin_configure_exit_user(const struct device *port, gpio_pin_t pin,
-						   int ret) {}
-void __weak sys_trace_gpio_port_get_direction_enter_user(const struct device *port,
-							 gpio_port_pins_t map,
-							 gpio_port_pins_t inputs,
-							 gpio_port_pins_t outputs) {}
-void __weak sys_trace_gpio_port_get_direction_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_pin_get_config_enter_user(const struct device *port, gpio_pin_t pin,
-						     int ret) {}
-void __weak sys_trace_gpio_pin_get_config_exit_user(const struct device *port, gpio_pin_t pin,
-						    int ret) {}
-void __weak sys_trace_gpio_port_get_raw_enter_user(const struct device *port,
-						   gpio_port_value_t *value) {}
-void __weak sys_trace_gpio_port_get_raw_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_port_set_masked_raw_enter_user(const struct device *port,
-							  gpio_port_pins_t mask,
-							  gpio_port_value_t value) {}
-void __weak sys_trace_gpio_port_set_masked_raw_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_port_set_bits_raw_enter_user(const struct device *port,
-							gpio_port_pins_t pins) {}
-void __weak sys_trace_gpio_port_set_bits_raw_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_port_clear_bits_raw_enter_user(const struct device *port,
-							  gpio_port_pins_t pins) {}
-void __weak sys_trace_gpio_port_clear_bits_raw_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_port_toggle_bits_enter_user(const struct device *port,
-						       gpio_port_pins_t pins) {}
-void __weak sys_trace_gpio_port_toggle_bits_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_init_callback_enter_user(struct gpio_callback *callback,
-						    gpio_callback_handler_t handler,
-						    gpio_port_pins_t pin_mask) {}
-void __weak sys_trace_gpio_init_callback_exit_user(struct gpio_callback *callback) {}
-void __weak sys_trace_gpio_add_callback_enter_user(const struct device *port,
-						   struct gpio_callback *callback) {}
-void __weak sys_trace_gpio_add_callback_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_remove_callback_enter_user(const struct device *port,
-						      struct gpio_callback *callback) {}
-void __weak sys_trace_gpio_remove_callback_exit_user(const struct device *port, int ret) {}
-void __weak sys_trace_gpio_get_pending_int_enter_user(const struct device *dev) {}
-void __weak sys_trace_gpio_get_pending_int_exit_user(const struct device *dev, int ret) {}
-void __weak sys_trace_gpio_fire_callbacks_enter_user(sys_slist_t *list, const struct device *port,
-						     gpio_pin_t pins) {}
-void __weak sys_trace_gpio_fire_callback_user(const struct device *port,
-					      struct gpio_callback *callback) {}
-void __weak sys_trace_timer_init_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_start_user(struct k_timer *timer, k_timeout_t duration,
-							    k_timeout_t period)
+void __weak sys_trace_thread_abort_enter(struct k_thread *thread) {}
+void __weak sys_trace_thread_abort_exit(struct k_thread *thread) {}
+void __weak sys_trace_thread_resume_exit(struct k_thread *thread) {}
+void __weak sys_trace_thread_sched_abort(struct k_thread *thread) {}
+void __weak sys_trace_thread_sched_resume(struct k_thread *thread) {}
+void __weak sys_trace_thread_sched_suspend(struct k_thread *thread) {}
+void __weak sys_trace_thread_foreach_enter(void) {}
+void __weak sys_trace_thread_foreach_exit(void) {}
+void __weak sys_trace_thread_foreach_unlocked_enter(void) {}
+void __weak sys_trace_thread_foreach_unlocked_exit(void) {}
+void __weak sys_trace_thread_user_mode_enter(void) {}
+void __weak sys_trace_thread_heap_assign(struct k_thread *thread, struct k_heap *heap) {}
+void __weak sys_trace_thread_join_blocking(struct k_thread *thread, k_timeout_t timeout) {}
+void __weak sys_trace_thread_join_enter(struct k_thread *thread, k_timeout_t timeout) {}
+void __weak sys_trace_thread_join_exit(struct k_thread *thread, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_thread_sleep_enter(k_timeout_t timeout) {}
+void __weak sys_trace_thread_sleep_exit(k_timeout_t timeout, int ret) {}
+void __weak sys_trace_thread_msleep_enter(int32_t ms) {}
+void __weak sys_trace_thread_msleep_exit(int32_t ms, int ret) {}
+void __weak sys_trace_thread_usleep_enter(int32_t us) {}
+void __weak sys_trace_thread_usleep_exit(int32_t us, int ret) {}
+void __weak sys_trace_thread_busy_wait_enter(uint32_t usec_to_wait) {}
+void __weak sys_trace_thread_busy_wait_exit(uint32_t usec_to_wait) {}
+void __weak sys_trace_thread_yield(void) {}
+void __weak sys_trace_thread_wakeup(struct k_thread *thread) {}
+void __weak sys_trace_thread_start(struct k_thread *thread) {}
+void __weak sys_trace_thread_priority_set(struct k_thread *thread) {}
+void __weak sys_trace_thread_sched_lock(void) {}
+void __weak sys_trace_thread_sched_unlock(void) {}
+void __weak sys_trace_thread_name_set(struct k_thread *thread, int ret) {}
+void __weak sys_trace_thread_ready(struct k_thread *thread) {}
+
+/* Work tracing weak stubs */
+void __weak sys_trace_k_work_init(struct k_work *work) {}
+void __weak sys_trace_k_work_submit_to_queue_enter(struct k_work_q *queue,
+							    struct k_work *work)
 {}
-void __weak sys_trace_timer_stop_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_status_sync_enter_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_status_sync_blocking_user(struct k_timer *timer, k_timeout_t timeout)
+void __weak sys_trace_k_work_submit_to_queue_exit(struct k_work_q *queue,
+							   struct k_work *work,
+							   int ret)
 {}
-void __weak sys_trace_timer_status_sync_exit_user(struct k_timer *timer, uint32_t result) {}
-void __weak sys_trace_timer_expiry_enter_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_expiry_exit_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_stop_fn_expiry_enter_user(struct k_timer *timer) {}
-void __weak sys_trace_timer_stop_fn_expiry_exit_user(struct k_timer *timer) {}
+void __weak sys_trace_k_work_submit_enter(struct k_work *work) {}
+void __weak sys_trace_k_work_submit_exit(struct k_work *work, int ret) {}
+void __weak sys_trace_k_work_flush_enter(struct k_work *work) {}
+void __weak sys_trace_k_work_flush_blocking(struct k_work *work, k_timeout_t timeout) {}
+void __weak sys_trace_k_work_flush_exit(struct k_work *work, bool ret) {}
+void __weak sys_trace_k_work_cancel_enter(struct k_work *work) {}
+void __weak sys_trace_k_work_cancel_exit(struct k_work *work, int ret) {}
+void __weak sys_trace_k_work_cancel_sync_enter(struct k_work *work,
+							struct k_work_sync *sync)
+{}
+void __weak sys_trace_k_work_cancel_sync_blocking(struct k_work *work,
+							   struct k_work_sync *sync)
+{}
+void __weak sys_trace_k_work_cancel_sync_exit(struct k_work *work,
+						       struct k_work_sync *sync,
+						       bool ret)
+{}
 
-void __weak sys_trace_rtio_submit_enter_user(const struct rtio *r, uint32_t wait_count)
-{
-	printk("rtio_submit_enter_user: %p, wait_count: %d\n", r, wait_count);
-}
-void __weak sys_trace_rtio_submit_exit_user(const struct rtio *r)
-{
-	printk("rtio_submit_exit: rtio: %p\n", r);
-}
-void __weak sys_trace_rtio_sqe_acquire_enter_user(const struct rtio *r)
-{
-	printk("sqe_acquire_enter: rtio: %p\n", r);
-}
-void __weak sys_trace_rtio_sqe_acquire_exit_user(const struct rtio *r, const struct rtio_sqe *sqe)
-{
-	printk("sqe_acquire_exit: rtio: %p\t sqe: %p\n", r, sqe);
-}
-void __weak sys_trace_rtio_sqe_cancel_user(const struct rtio_sqe *sqe)
-{
-	printk("sqe_cancel_user: sqe: %p", sqe);
-}
-void __weak sys_trace_rtio_cqe_submit_enter_user(const struct rtio *r, int result, uint32_t flags)
-{
-	printk("cqe_submit_enter_user: rtio: %p\t result: %d\t flags: %d\n", r, result, flags);
-}
-void __weak sys_trace_rtio_cqe_submit_exit_user(const struct rtio *r)
-{
-	printk("cqe_submit_exit: rtio: %p\n", r);
-}
-void __weak sys_trace_rtio_cqe_acquire_enter_user(const struct rtio *r)
-{
-	printk("cqe_acquire_enter_user: rtio: %p\n", r);
-}
-void __weak sys_trace_rtio_cqe_acquire_exit_user(const struct rtio *r, const struct rtio_cqe *cqe)
-{
-	printk("cqe_acquire_exit_user: rtio: %p\t cqe: %p\n", r, cqe);
-}
-void __weak sys_trace_rtio_cqe_release_user(const struct rtio *r, const struct rtio_cqe *cqe)
-{
-	printk("cqe_release: rtio: %p\t cqe: %p\n", r, cqe);
-}
-void __weak sys_trace_rtio_cqe_consume_enter_user(const struct rtio *r)
-{
-	printk("cqe_consume_enter: rtio: %p\n", r);
-}
-void __weak sys_trace_rtio_cqe_consume_exit_user(const struct rtio *r, const struct rtio_cqe *cqe)
-{
-	printk("cqe_consume_exit: rtio: %p\t cqe: %p\n", r, cqe);
-}
-void __weak sys_trace_rtio_txn_next_enter_user(const struct rtio *r,
-					       const struct rtio_iodev_sqe *iodev_sqe)
-{
-	printk("txn_next_enter: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
-}
-void __weak sys_trace_rtio_txn_next_exit_user(const struct rtio *r,
-					      const struct rtio_iodev_sqe *iodev_sqe)
-{
-	printk("txn_next_exit: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
-}
-void __weak sys_trace_rtio_chain_next_enter_user(const struct rtio *r,
-						 const struct rtio_iodev_sqe *iodev_sqe)
-{
-	printk("chain_next_enter: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
-}
-void __weak sys_trace_rtio_chain_next_exit_user(const struct rtio *r,
-						const struct rtio_iodev_sqe *iodev_sqe)
-{
-	printk("chain_next_exit: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
-}
+/* Work queue tracing weak stubs */
+void __weak sys_trace_k_work_queue_init(struct k_work_q *queue) {}
+void __weak sys_trace_k_work_queue_start_enter(struct k_work_q *queue) {}
+void __weak sys_trace_k_work_queue_start_exit(struct k_work_q *queue) {}
+void __weak sys_trace_k_work_queue_stop_enter(struct k_work_q *queue, k_timeout_t timeout) {}
+void __weak sys_trace_k_work_queue_stop_blocking(struct k_work_q *queue,
+							  k_timeout_t timeout)
+{}
+void __weak sys_trace_k_work_queue_stop_exit(struct k_work_q *queue,
+						      k_timeout_t timeout,
+						      int ret)
+{}
+void __weak sys_trace_k_work_queue_drain_enter(struct k_work_q *queue) {}
+void __weak sys_trace_k_work_queue_drain_exit(struct k_work_q *queue, int ret) {}
+void __weak sys_trace_k_work_queue_unplug_enter(struct k_work_q *queue) {}
+void __weak sys_trace_k_work_queue_unplug_exit(struct k_work_q *queue, int ret) {}
 
-void sys_trace_thread_create(struct k_thread *thread)
-{
-	sys_trace_thread_create_user(thread);
-}
+/* Delayable work tracing weak stubs */
+void __weak sys_trace_k_work_delayable_init(struct k_work_delayable *dwork) {}
+void __weak sys_trace_k_work_schedule_for_queue_enter(struct k_work_q *queue,
+							       struct k_work_delayable *dwork,
+							       k_timeout_t delay)
+{}
+void __weak sys_trace_k_work_schedule_for_queue_exit(struct k_work_q *queue,
+							      struct k_work_delayable *dwork,
+							      k_timeout_t delay,
+							      int ret)
+{}
+void __weak sys_trace_k_work_schedule_enter(struct k_work_delayable *dwork,
+						     k_timeout_t delay)
+{}
+void __weak sys_trace_k_work_schedule_exit(struct k_work_delayable *dwork,
+						    k_timeout_t delay,
+						    int ret)
+{}
+void __weak sys_trace_k_work_reschedule_for_queue_enter(struct k_work_q *queue,
+								struct k_work_delayable *dwork,
+								k_timeout_t delay)
+{}
+void __weak sys_trace_k_work_reschedule_for_queue_exit(struct k_work_q *queue,
+							       struct k_work_delayable *dwork,
+							       k_timeout_t delay,
+							       int ret)
+{}
+void __weak sys_trace_k_work_reschedule_enter(struct k_work_delayable *dwork,
+						       k_timeout_t delay)
+{}
+void __weak sys_trace_k_work_reschedule_exit(struct k_work_delayable *dwork,
+						      k_timeout_t delay,
+						      int ret)
+{}
+void __weak sys_trace_k_work_flush_delayable_enter(struct k_work_delayable *dwork,
+							    struct k_work_sync *sync)
+{}
+void __weak sys_trace_k_work_flush_delayable_exit(struct k_work_delayable *dwork,
+							   struct k_work_sync *sync,
+							   bool ret)
+{}
+void __weak sys_trace_k_work_cancel_delayable_enter(
+					struct k_work_delayable *dwork)
+{}
+void __weak sys_trace_k_work_cancel_delayable_exit(
+					struct k_work_delayable *dwork, int ret)
+{}
+void __weak sys_trace_k_work_cancel_delayable_sync_enter(
+					struct k_work_delayable *dwork,
+					struct k_work_sync *sync)
+{}
+void __weak sys_trace_k_work_cancel_delayable_sync_exit(
+					struct k_work_delayable *dwork,
+					struct k_work_sync *sync,
+					bool ret)
+{}
 
-void sys_trace_thread_abort(struct k_thread *thread)
-{
-	sys_trace_thread_abort_user(thread);
-}
+/* Work poll tracing weak stubs */
+void __weak sys_trace_k_work_poll_init_enter(struct k_work_poll *work) {}
+void __weak sys_trace_k_work_poll_init_exit(struct k_work_poll *work) {}
+void __weak sys_trace_k_work_poll_submit_to_queue_enter(
+						struct k_work_q *work_q,
+						struct k_work_poll *work,
+						k_timeout_t timeout)
+{}
+void __weak sys_trace_k_work_poll_submit_to_queue_blocking(
+							struct k_work_q *work_q,
+							struct k_work_poll *work,
+							k_timeout_t timeout)
+{}
+void __weak sys_trace_k_work_poll_submit_to_queue_exit(
+							struct k_work_q *work_q,
+							struct k_work_poll *work,
+							k_timeout_t timeout,
+							int ret)
+{}
+void __weak sys_trace_k_work_poll_submit_enter(struct k_work_poll *work,
+							k_timeout_t timeout)
+{}
+void __weak sys_trace_k_work_poll_submit_exit(struct k_work_poll *work,
+						       k_timeout_t timeout,
+						       int ret)
+{}
+void __weak sys_trace_k_work_poll_cancel_enter(struct k_work_poll *work) {}
+void __weak sys_trace_k_work_poll_cancel_exit(struct k_work_poll *work, int ret) {}
 
-void sys_trace_thread_suspend(struct k_thread *thread)
-{
-	sys_trace_thread_suspend_user(thread);
-}
+/* Poll API tracing weak stubs */
+void __weak sys_trace_k_poll_api_event_init(struct k_poll_event *event) {}
+void __weak sys_trace_k_poll_api_poll_enter(struct k_poll_event *events) {}
+void __weak sys_trace_k_poll_api_poll_exit(struct k_poll_event *events, int ret) {}
+void __weak sys_trace_k_poll_api_signal_init(struct k_poll_signal *sig) {}
+void __weak sys_trace_k_poll_api_signal_reset(struct k_poll_signal *sig) {}
+void __weak sys_trace_k_poll_api_signal_check(struct k_poll_signal *sig) {}
+void __weak sys_trace_k_poll_api_signal_raise(struct k_poll_signal *sig, int ret) {}
 
-void sys_trace_thread_resume(struct k_thread *thread)
-{
-	sys_trace_thread_resume_user(thread);
-}
+/* Semaphore tracing weak stubs */
+void __weak sys_trace_k_sem_init(struct k_sem *sem, int ret) {}
+void __weak sys_trace_k_sem_give_enter(struct k_sem *sem) {}
+void __weak sys_trace_k_sem_give_exit(struct k_sem *sem) {}
+void __weak sys_trace_k_sem_take_enter(struct k_sem *sem, k_timeout_t timeout) {}
+void __weak sys_trace_k_sem_take_blocking(struct k_sem *sem, k_timeout_t timeout) {}
+void __weak sys_trace_k_sem_take_exit(struct k_sem *sem, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_sem_reset(struct k_sem *sem) {}
 
-void sys_trace_thread_name_set(struct k_thread *thread)
-{
-	sys_trace_thread_name_set_user(thread);
-}
+/* Mutex tracing weak stubs */
+void __weak sys_trace_k_mutex_init(struct k_mutex *mutex, int ret) {}
+void __weak sys_trace_k_mutex_lock_enter(struct k_mutex *mutex, k_timeout_t timeout) {}
+void __weak sys_trace_k_mutex_lock_blocking(struct k_mutex *mutex, k_timeout_t timeout) {}
+void __weak sys_trace_k_mutex_lock_exit(struct k_mutex *mutex, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_mutex_unlock_enter(struct k_mutex *mutex) {}
+void __weak sys_trace_k_mutex_unlock_exit(struct k_mutex *mutex, int ret) {}
 
-void sys_trace_k_thread_switched_in(void)
-{
-	sys_trace_thread_switched_in_user();
-}
+/* Condition variable tracing weak stubs */
+void __weak sys_trace_k_condvar_init(struct k_condvar *condvar, int ret) {}
+void __weak sys_trace_k_condvar_signal_enter(struct k_condvar *condvar) {}
+void __weak sys_trace_k_condvar_signal_blocking(struct k_condvar *condvar,
+							 k_timeout_t timeout)
+{}
+void __weak sys_trace_k_condvar_signal_exit(struct k_condvar *condvar,
+						    int ret)
+{}
+void __weak sys_trace_k_condvar_broadcast_enter(struct k_condvar *condvar) {}
+void __weak sys_trace_k_condvar_broadcast_exit(struct k_condvar *condvar,
+						       int ret)
+{}
+void __weak sys_trace_k_condvar_wait_enter(struct k_condvar *condvar,
+						   k_timeout_t timeout)
+{}
+void __weak sys_trace_k_condvar_wait_exit(struct k_condvar *condvar,
+						  k_timeout_t timeout, int ret)
+{}
 
-void sys_trace_k_thread_switched_out(void)
-{
-	sys_trace_thread_switched_out_user();
-}
+/* Queue tracing weak stubs */
+void __weak sys_trace_k_queue_init(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_cancel_wait(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_queue_insert_enter(struct k_queue *queue, bool alloc) {}
+void __weak sys_trace_k_queue_queue_insert_blocking(struct k_queue *queue,
+							     bool alloc,
+							     k_timeout_t timeout)
+{}
+void __weak sys_trace_k_queue_queue_insert_exit(struct k_queue *queue,
+							bool alloc, int ret)
+{}
+void __weak sys_trace_k_queue_append_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_append_exit(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_alloc_append_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_alloc_append_exit(struct k_queue *queue, int ret) {}
+void __weak sys_trace_k_queue_prepend_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_prepend_exit(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_alloc_prepend_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_alloc_prepend_exit(struct k_queue *queue, int ret) {}
+void __weak sys_trace_k_queue_insert_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_insert_blocking(struct k_queue *queue, k_timeout_t timeout) {}
+void __weak sys_trace_k_queue_insert_exit(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_append_list_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_append_list_exit(struct k_queue *queue, int ret) {}
+void __weak sys_trace_k_queue_merge_slist_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_merge_slist_exit(struct k_queue *queue, int ret) {}
+void __weak sys_trace_k_queue_get_enter(struct k_queue *queue, k_timeout_t timeout) {}
+void __weak sys_trace_k_queue_get_blocking(struct k_queue *queue, k_timeout_t timeout) {}
+void __weak sys_trace_k_queue_get_exit(struct k_queue *queue, k_timeout_t timeout, void *ret) {}
+void __weak sys_trace_k_queue_remove_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_remove_exit(struct k_queue *queue, bool ret) {}
+void __weak sys_trace_k_queue_unique_append_enter(struct k_queue *queue) {}
+void __weak sys_trace_k_queue_unique_append_exit(struct k_queue *queue, bool ret) {}
+void __weak sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret) {}
+void __weak sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret) {}
 
-void sys_trace_thread_info(struct k_thread *thread)
-{
-	sys_trace_thread_info_user(thread);
-}
+/* FIFO tracing weak stubs */
+void __weak sys_trace_k_fifo_init_enter(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_init_exit(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_cancel_wait_enter(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_cancel_wait_exit(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_put_enter(struct k_fifo *fifo, void *data) {}
+void __weak sys_trace_k_fifo_put_exit(struct k_fifo *fifo, void *data) {}
+void __weak sys_trace_k_fifo_alloc_put_enter(struct k_fifo *fifo, void *data) {}
+void __weak sys_trace_k_fifo_alloc_put_exit(struct k_fifo *fifo, void *data, int ret) {}
+void __weak sys_trace_k_fifo_put_list_enter(struct k_fifo *fifo, void *head, void *tail) {}
+void __weak sys_trace_k_fifo_put_list_exit(struct k_fifo *fifo, void *head, void *tail) {}
+void __weak sys_trace_k_fifo_put_slist_enter(struct k_fifo *fifo, sys_slist_t *list) {}
+void __weak sys_trace_k_fifo_put_slist_exit(struct k_fifo *fifo, sys_slist_t *list) {}
+void __weak sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout) {}
+void __weak sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret) {}
+void __weak sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret) {}
+void __weak sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo) {}
+void __weak sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret) {}
 
-void sys_trace_thread_sched_priority_set(struct k_thread *thread, int prio)
-{
-	sys_trace_thread_priority_set_user(thread, prio);
-}
+/* Stack tracing weak stubs */
+void __weak sys_trace_k_stack_init(struct k_stack *stack) {}
+void __weak sys_trace_k_stack_alloc_init_enter(struct k_stack *stack) {}
+void __weak sys_trace_k_stack_alloc_init_exit(struct k_stack *stack, int ret) {}
+void __weak sys_trace_k_stack_cleanup_enter(struct k_stack *stack) {}
+void __weak sys_trace_k_stack_cleanup_exit(struct k_stack *stack, int ret) {}
+void __weak sys_trace_k_stack_push_enter(struct k_stack *stack) {}
+void __weak sys_trace_k_stack_push_exit(struct k_stack *stack, int ret) {}
+void __weak sys_trace_k_stack_pop_enter(struct k_stack *stack, k_timeout_t timeout) {}
+void __weak sys_trace_k_stack_pop_blocking(struct k_stack *stack, k_timeout_t timeout) {}
+void __weak sys_trace_k_stack_pop_exit(struct k_stack *stack, k_timeout_t timeout, int ret) {}
 
-void sys_trace_thread_sched_ready(struct k_thread *thread)
-{
-	sys_trace_thread_sched_ready_user(thread);
-}
+/* Message queue tracing weak stubs */
+void __weak sys_trace_k_msgq_init(struct k_msgq *msgq) {}
+void __weak sys_trace_k_msgq_alloc_init_enter(struct k_msgq *msgq) {}
+void __weak sys_trace_k_msgq_alloc_init_exit(struct k_msgq *msgq, int ret) {}
+void __weak sys_trace_k_msgq_cleanup_enter(struct k_msgq *msgq) {}
+void __weak sys_trace_k_msgq_cleanup_exit(struct k_msgq *msgq, int ret) {}
+void __weak sys_trace_k_msgq_put_enter(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_put_blocking(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_put_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_msgq_put_front_enter(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_put_front_blocking(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_put_front_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_msgq_get_enter(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_get_blocking(struct k_msgq *msgq, k_timeout_t timeout) {}
+void __weak sys_trace_k_msgq_get_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_msgq_peek(struct k_msgq *msgq, int ret) {}
+void __weak sys_trace_k_msgq_purge(struct k_msgq *msgq) {}
 
-void sys_trace_thread_pend(struct k_thread *thread)
-{
-	sys_trace_thread_pend_user(thread);
-}
+/* Mailbox tracing weak stubs */
+void __weak sys_trace_k_mbox_init(struct k_mbox *mbox) {}
+void __weak sys_trace_k_mbox_message_put_enter(struct k_mbox *mbox, k_timeout_t timeout) {}
+void __weak sys_trace_k_mbox_message_put_blocking(struct k_mbox *mbox, k_timeout_t timeout) {}
+void __weak sys_trace_k_mbox_message_put_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_mbox_put_enter(struct k_mbox *mbox, k_timeout_t timeout) {}
+void __weak sys_trace_k_mbox_put_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_mbox_async_put_enter(struct k_mbox *mbox, struct k_sem *sem) {}
+void __weak sys_trace_k_mbox_async_put_exit(struct k_mbox *mbox, struct k_sem *sem) {}
+void __weak sys_trace_k_mbox_get_enter(struct k_mbox *mbox, k_timeout_t timeout) {}
+void __weak sys_trace_k_mbox_get_blocking(struct k_mbox *mbox, k_timeout_t timeout) {}
+void __weak sys_trace_k_mbox_get_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret) {}
+void __weak sys_trace_k_mbox_data_get(struct k_mbox_msg *rx_msg) {}
 
-void sys_trace_isr_enter(void)
-{
-	sys_trace_isr_enter_user();
-}
+/* Pipe tracing weak stubs */
+void __weak sys_trace_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer,
+					   size_t size)
+{}
+void __weak sys_trace_k_pipe_reset_enter(struct k_pipe *pipe) {}
+void __weak sys_trace_k_pipe_reset_exit(struct k_pipe *pipe) {}
+void __weak sys_trace_k_pipe_close_enter(struct k_pipe *pipe) {}
+void __weak sys_trace_k_pipe_close_exit(struct k_pipe *pipe) {}
+void __weak sys_trace_k_pipe_write_enter(struct k_pipe *pipe, void *data,
+						 size_t len,
+						 k_timeout_t timeout)
+{}
+void __weak sys_trace_k_pipe_write_blocking(struct k_pipe *pipe,
+						     k_timeout_t timeout)
+{}
+void __weak sys_trace_k_pipe_write_exit(struct k_pipe *pipe, int ret) {}
+void __weak sys_trace_k_pipe_read_enter(struct k_pipe *pipe, void *data,
+						size_t len,
+						k_timeout_t timeout)
+{}
+void __weak sys_trace_k_pipe_read_blocking(struct k_pipe *pipe, k_timeout_t timeout) {}
+void __weak sys_trace_k_pipe_read_exit(struct k_pipe *pipe, int ret) {}
 
-void sys_trace_isr_exit(void)
-{
-	sys_trace_isr_exit_user();
-}
+/* Heap tracing weak stubs */
+void __weak sys_trace_k_heap_init(struct k_heap *heap) {}
+void __weak sys_trace_k_heap_aligned_alloc_enter(struct k_heap *heap,
+							 k_timeout_t timeout)
+{}
+void __weak sys_trace_k_heap_alloc_helper_blocking(struct k_heap *heap,
+							    k_timeout_t timeout)
+{}
+void __weak sys_trace_k_heap_aligned_alloc_exit(struct k_heap *heap,
+							k_timeout_t timeout,
+							void *ret)
+{}
+void __weak sys_trace_k_heap_alloc_enter(struct k_heap *heap, k_timeout_t timeout) {}
+void __weak sys_trace_k_heap_alloc_exit(struct k_heap *heap, k_timeout_t timeout, void *ret) {}
+void __weak sys_trace_k_heap_calloc_enter(struct k_heap *heap,
+						   k_timeout_t timeout)
+{}
+void __weak sys_trace_k_heap_calloc_exit(struct k_heap *heap,
+						  k_timeout_t timeout,
+						  void *ret)
+{}
+void __weak sys_trace_k_heap_free(struct k_heap *heap) {}
+void __weak sys_trace_k_heap_realloc_enter(struct k_heap *h, void *ptr,
+						   size_t bytes,
+						   k_timeout_t timeout)
+{}
+void __weak sys_trace_k_heap_realloc_exit(struct k_heap *h, void *ptr,
+						  size_t bytes,
+						  k_timeout_t timeout,
+						  void *ret)
+{}
+void __weak sys_trace_k_heap_sys_k_aligned_alloc_enter(
+							struct k_heap *heap)
+{}
+void __weak sys_trace_k_heap_sys_k_aligned_alloc_exit(
+							struct k_heap *heap,
+							void *ret)
+{}
+void __weak sys_trace_k_heap_sys_k_malloc_enter(struct k_heap *heap) {}
+void __weak sys_trace_k_heap_sys_k_malloc_exit(struct k_heap *heap,
+						       void *ret)
+{}
+void __weak sys_trace_k_heap_sys_k_free_enter(struct k_heap *heap,
+						       struct k_heap **heap_ref)
+{}
+void __weak sys_trace_k_heap_sys_k_free_exit(struct k_heap *heap,
+						      struct k_heap **heap_ref)
+{}
+void __weak sys_trace_k_heap_sys_k_calloc_enter(struct k_heap *heap) {}
+void __weak sys_trace_k_heap_sys_k_calloc_exit(struct k_heap *heap,
+						       void *ret)
+{}
+void __weak sys_trace_k_heap_sys_k_realloc_enter(struct k_heap *heap,
+							 void *ptr)
+{}
+void __weak sys_trace_k_heap_sys_k_realloc_exit(struct k_heap *heap,
+							void *ptr, void *ret)
+{}
 
-void sys_trace_idle(void)
-{
-	sys_trace_idle_user();
+/* Memory slab tracing weak stubs */
+void __weak sys_trace_k_mem_slab_init(struct k_mem_slab *slab, int rc) {}
+void __weak sys_trace_k_mem_slab_alloc_enter(struct k_mem_slab *slab,
+						     k_timeout_t timeout)
+{}
+void __weak sys_trace_k_mem_slab_alloc_blocking(struct k_mem_slab *slab,
+							k_timeout_t timeout)
+{}
+void __weak sys_trace_k_mem_slab_alloc_exit(struct k_mem_slab *slab,
+						    k_timeout_t timeout,
+						    int ret)
+{}
+void __weak sys_trace_k_mem_slab_free_enter(struct k_mem_slab *slab) {}
+void __weak sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab) {}
 
+/* Event tracing weak stubs */
+void __weak sys_trace_k_event_init(struct k_event *event) {}
+void __weak sys_trace_k_event_post_enter(struct k_event *event,
+						 uint32_t events,
+						 uint32_t events_mask)
+{}
+void __weak sys_trace_k_event_post_exit(struct k_event *event,
+						uint32_t events,
+						uint32_t events_mask)
+{}
+void __weak sys_trace_k_event_wait_enter(struct k_event *event,
+						 uint32_t events,
+						 uint32_t options,
+						 k_timeout_t timeout)
+{}
+void __weak sys_trace_k_event_wait_blocking(struct k_event *event,
+						    uint32_t events,
+						    uint32_t options,
+						    k_timeout_t timeout)
+{}
+void __weak sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_t ret) {}
+
+/* PM tracing weak stubs */
+void __weak sys_trace_pm_system_suspend_enter(int32_t ticks) {}
+void __weak sys_trace_pm_system_suspend_exit(int32_t ticks, uint32_t state) {}
+void __weak sys_trace_pm_device_runtime_get_enter(const struct device *dev) {}
+void __weak sys_trace_pm_device_runtime_get_exit(const struct device *dev, int ret) {}
+void __weak sys_trace_pm_device_runtime_put_enter(
+							const struct device *dev)
+{}
+void __weak sys_trace_pm_device_runtime_put_exit(const struct device *dev,
+							 int ret)
+{}
+void __weak sys_trace_pm_device_runtime_put_async_enter(
+							const struct device *dev,
+							k_timeout_t delay)
+{}
+void __weak sys_trace_pm_device_runtime_put_async_exit(
+							const struct device *dev,
+							k_timeout_t delay,
+							int ret)
+{}
+void __weak sys_trace_pm_device_runtime_enable_enter(const struct device *dev) {}
+void __weak sys_trace_pm_device_runtime_enable_exit(const struct device *dev, int ret) {}
+void __weak sys_trace_pm_device_runtime_disable_enter(const struct device *dev) {}
+void __weak sys_trace_pm_device_runtime_disable_exit(const struct device *dev, int ret) {}
+
+/* Socket tracing weak stubs */
+void __weak sys_trace_socket_init(int sock, int family, int type,
+					   int proto)
+{}
+void __weak sys_trace_socket_close_enter(int sock) {}
+void __weak sys_trace_socket_close_exit(int sock, int ret) {}
+void __weak sys_trace_socket_shutdown_enter(int sock, int how) {}
+void __weak sys_trace_socket_shutdown_exit(int sock, int ret) {}
+void __weak sys_trace_socket_bind_enter(int sock,
+						const struct sockaddr *addr,
+						socklen_t addrlen)
+{}
+void __weak sys_trace_socket_bind_exit(int sock, int ret) {}
+void __weak sys_trace_socket_connect_enter(int sock,
+						   const struct sockaddr *addr,
+						   socklen_t addrlen)
+{}
+void __weak sys_trace_socket_connect_exit(int sock, int ret) {}
+void __weak sys_trace_socket_listen_enter(int sock, int backlog) {}
+void __weak sys_trace_socket_listen_exit(int sock, int ret) {}
+void __weak sys_trace_socket_accept_enter(int sock) {}
+void __weak sys_trace_socket_accept_exit(int sock,
+						 const struct sockaddr *addr,
+						 const socklen_t *addrlen,
+						 int ret)
+{}
+void __weak sys_trace_socket_sendto_enter(int sock, size_t len, int flags,
+						  const struct sockaddr *dest_addr,
+						  socklen_t addrlen)
+{}
+void __weak sys_trace_socket_sendto_exit(int sock, int ret) {}
+void __weak sys_trace_socket_sendmsg_enter(int sock,
+						   const struct msghdr *msg,
+						   int flags)
+{}
+void __weak sys_trace_socket_sendmsg_exit(int sock, int ret) {}
+void __weak sys_trace_socket_recvfrom_enter(int sock, size_t max_len,
+						    int flags,
+						    struct sockaddr *addr,
+						    socklen_t *addrlen)
+{}
+void __weak sys_trace_socket_recvfrom_exit(int sock,
+						   const struct sockaddr *src_addr,
+						   const socklen_t *addrlen,
+						   int ret)
+{}
+void __weak sys_trace_socket_recvmsg_enter(int sock,
+						    const struct msghdr *msg,
+						    int flags)
+{}
+void __weak sys_trace_socket_recvmsg_exit(int sock,
+						  const struct msghdr *msg,
+						  int ret)
+{}
+void __weak sys_trace_socket_fcntl_enter(int sock, int cmd, int flags) {}
+void __weak sys_trace_socket_fcntl_exit(int sock, int ret) {}
+void __weak sys_trace_socket_ioctl_enter(int sock, int req) {}
+void __weak sys_trace_socket_ioctl_exit(int sock, int ret) {}
+void __weak sys_trace_socket_poll_enter(struct zsock_pollfd *fds, int nfds,
+						int timeout)
+{}
+void __weak sys_trace_socket_poll_exit(struct zsock_pollfd *fds, int nfds,
+					       int ret)
+{}
+void __weak sys_trace_socket_getsockopt_enter(int sock, int level,
+						       int optname)
+{}
+void __weak sys_trace_socket_getsockopt_exit(int sock, int level,
+						      int optname, void *optval,
+						      const socklen_t *optlen,
+						      int ret)
+{}
+void __weak sys_trace_socket_setsockopt_enter(int sock, int level,
+						       int optname,
+						       const void *optval,
+						       socklen_t optlen)
+{}
+void __weak sys_trace_socket_setsockopt_exit(int sock, int ret) {}
+void __weak sys_trace_socket_getpeername_enter(int sock) {}
+void __weak sys_trace_socket_getpeername_exit(int sock,
+						       struct sockaddr *addr,
+						       const socklen_t *addrlen,
+						       int ret)
+{}
+void __weak sys_trace_socket_getsockname_enter(int sock) {}
+void __weak sys_trace_socket_getsockname_exit(int sock,
+						       struct sockaddr *addr,
+						       const socklen_t *addrlen,
+						       int ret)
+{}
+void __weak sys_trace_socket_socketpair_enter(int family, int type, int proto, int *sv) {}
+void __weak sys_trace_socket_socketpair_exit(int sockA, int sockB, int ret) {}
+
+/* Network tracing weak stubs */
+void __weak sys_trace_net_recv_data_enter(struct net_if *iface, struct net_pkt *pkt) {}
+void __weak sys_trace_net_recv_data_exit(struct net_if *iface, struct net_pkt *pkt, int ret) {}
+void __weak sys_trace_net_send_data_enter(struct net_pkt *pkt) {}
+void __weak sys_trace_net_send_data_exit(struct net_pkt *pkt, int ret) {}
+void __weak sys_trace_net_rx_time(struct net_pkt *pkt, uint32_t end_time) {}
+void __weak sys_trace_net_tx_time(struct net_pkt *pkt, uint32_t end_time) {}
+
+void __weak sys_trace_thread_create(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_abort(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_suspend(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_resume(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_name_set(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_switched_in(void) {}
+
+void __weak sys_trace_thread_switched_out(void) {}
+
+void __weak sys_trace_thread_info(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_sched_priority_set(struct k_thread *thread, int prio) {}
+
+void __weak sys_trace_thread_sched_ready(struct k_thread *thread) {}
+
+void __weak sys_trace_thread_pend(struct k_thread *thread) {}
+
+void __weak sys_trace_isr_enter(void) {}
+
+void __weak sys_trace_isr_exit(void) {}
+
+void __weak sys_trace_idle(void)
+{
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		cpu_load_on_enter_idle();
 	}
 }
 
-void sys_trace_idle_exit(void)
+void __weak sys_trace_idle_exit(void)
 {
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		cpu_load_on_exit_idle();
 	}
 }
 
-void sys_trace_sys_init_enter(const struct init_entry *entry, int level)
-{
-	sys_trace_sys_init_enter_user(entry, level);
-}
+void __weak sys_trace_sys_init_enter(const struct init_entry *entry, int level) {}
 
-void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result)
-{
-	sys_trace_sys_init_exit_user(entry, level, result);
-}
+void __weak sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result) {}
 
-void sys_trace_gpio_pin_interrupt_configure_enter(const struct device *port, gpio_pin_t pin,
-						  gpio_flags_t flags)
-{
-	sys_trace_gpio_pin_interrupt_configure_enter_user(port, pin, flags);
-}
+void __weak sys_trace_gpio_pin_interrupt_configure_enter(
+						const struct device *port,
+						gpio_pin_t pin,
+						gpio_flags_t flags)
+{}
 
-void sys_trace_gpio_pin_interrupt_configure_exit(const struct device *port, gpio_pin_t pin,
-						  int ret)
-{
-	sys_trace_gpio_pin_interrupt_configure_exit_user(port, pin, ret);
-}
+void __weak sys_trace_gpio_pin_interrupt_configure_exit(
+						const struct device *port,
+						gpio_pin_t pin,
+						int ret)
+{}
 
-void sys_trace_gpio_pin_configure_enter(const struct device *port, gpio_pin_t pin,
-					gpio_flags_t flags)
-{
-	sys_trace_gpio_pin_configure_enter_user(port, pin, flags);
-}
+void __weak sys_trace_gpio_pin_configure_enter(const struct device *port,
+							gpio_pin_t pin,
+							gpio_flags_t flags)
+{}
 
-void sys_trace_gpio_pin_configure_exit(const struct device *port, gpio_pin_t pin, int ret)
-{
-	sys_trace_gpio_pin_configure_exit_user(port, pin, ret);
-}
+void __weak sys_trace_gpio_pin_configure_exit(const struct device *port,
+						       gpio_pin_t pin,
+						       int ret)
+{}
 
-void sys_trace_gpio_port_get_direction_enter(const struct device *port, gpio_port_pins_t map,
-					     gpio_port_pins_t inputs, gpio_port_pins_t outputs)
-{
-	sys_trace_gpio_port_get_direction_enter_user(port, map, inputs, outputs);
-}
+void __weak sys_trace_gpio_port_get_direction_enter(
+					const struct device *port,
+					gpio_port_pins_t map,
+					gpio_port_pins_t inputs,
+					gpio_port_pins_t outputs)
+{}
 
-void sys_trace_gpio_port_get_direction_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_get_direction_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_get_direction_exit(
+						const struct device *port, int ret)
+{}
 
-void sys_trace_gpio_pin_get_config_enter(const struct device *port, gpio_pin_t pin, int ret)
-{
-	sys_trace_gpio_pin_get_config_enter_user(port, pin, ret);
-}
+void __weak sys_trace_gpio_pin_get_config_enter(
+						const struct device *port,
+						gpio_pin_t pin, int ret)
+{}
 
-void sys_trace_gpio_pin_get_config_exit(const struct device *port, gpio_pin_t pin, int ret)
-{
-	sys_trace_gpio_pin_get_config_exit_user(port, pin, ret);
-}
+void __weak sys_trace_gpio_pin_get_config_exit(const struct device *port,
+						       gpio_pin_t pin,
+						       int ret)
+{}
 
-void sys_trace_gpio_port_get_raw_enter(const struct device *port, gpio_port_value_t *value)
-{
-	sys_trace_gpio_port_get_raw_enter_user(port, value);
-}
+void __weak sys_trace_gpio_port_get_raw_enter(
+					const struct device *port,
+					gpio_port_value_t *value)
+{}
 
-void sys_trace_gpio_port_get_raw_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_get_raw_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_get_raw_exit(const struct device *port,
+						      int ret)
+{}
 
-void sys_trace_gpio_port_set_masked_raw_enter(const struct device *port, gpio_port_pins_t mask,
-					      gpio_port_value_t value)
-{
-	sys_trace_gpio_port_set_masked_raw_enter_user(port, mask, value);
-}
+void __weak sys_trace_gpio_port_set_masked_raw_enter(
+						const struct device *port,
+						gpio_port_pins_t mask,
+						gpio_port_value_t value)
+{}
 
-void sys_trace_gpio_port_set_masked_raw_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_set_masked_raw_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_set_masked_raw_exit(
+						const struct device *port,
+						int ret)
+{}
 
-void sys_trace_gpio_port_set_bits_raw_enter(const struct device *port, gpio_port_pins_t pins)
-{
-	sys_trace_gpio_port_set_bits_raw_enter_user(port, pins);
-}
+void __weak sys_trace_gpio_port_set_bits_raw_enter(
+						const struct device *port,
+						gpio_port_pins_t pins)
+{}
 
-void sys_trace_gpio_port_set_bits_raw_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_set_bits_raw_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_set_bits_raw_exit(
+						const struct device *port,
+						int ret)
+{}
 
-void sys_trace_gpio_port_clear_bits_raw_enter(const struct device *port, gpio_port_pins_t pins)
-{
-	sys_trace_gpio_port_clear_bits_raw_enter_user(port, pins);
-}
+void __weak sys_trace_gpio_port_clear_bits_raw_enter(
+						const struct device *port,
+						gpio_port_pins_t pins)
+{}
 
-void sys_trace_gpio_port_clear_bits_raw_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_clear_bits_raw_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_clear_bits_raw_exit(
+						const struct device *port,
+						int ret)
+{}
 
-void sys_trace_gpio_port_toggle_bits_enter(const struct device *port, gpio_port_pins_t pins)
-{
-	sys_trace_gpio_port_toggle_bits_enter_user(port, pins);
-}
+void __weak sys_trace_gpio_port_toggle_bits_enter(
+						const struct device *port,
+						gpio_port_pins_t pins)
+{}
 
-void sys_trace_gpio_port_toggle_bits_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_port_toggle_bits_exit_user(port, ret);
-}
+void __weak sys_trace_gpio_port_toggle_bits_exit(
+						const struct device *port,
+						int ret)
+{}
 
-void sys_trace_gpio_init_callback_enter(struct gpio_callback *callback,
-					gpio_callback_handler_t handler, gpio_port_pins_t pin_mask)
-{
-	sys_trace_gpio_init_callback_enter_user(callback, handler, pin_mask);
-}
+void __weak sys_trace_gpio_init_callback_enter(
+						struct gpio_callback *callback,
+						gpio_callback_handler_t handler,
+						gpio_port_pins_t pin_mask)
+{}
 
-void sys_trace_gpio_init_callback_exit(struct gpio_callback *callback)
-{
-	sys_trace_gpio_init_callback_exit_user(callback);
-}
-
-void sys_trace_gpio_add_callback_enter(const struct device *port, struct gpio_callback *callback)
-{
-	sys_trace_gpio_add_callback_enter_user(port, callback);
-}
-
-void sys_trace_gpio_add_callback_exit(const struct device *port, int ret)
-{
-	sys_trace_gpio_add_callback_exit_user(port, ret);
-}
-
-void sys_trace_gpio_remove_callback_enter(const struct device *port,
+void __weak sys_trace_gpio_init_callback_exit(
 						struct gpio_callback *callback)
+{}
+
+void __weak sys_trace_gpio_add_callback_enter(
+						const struct device *port,
+						struct gpio_callback *callback)
+{}
+
+void __weak sys_trace_gpio_add_callback_exit(const struct device *port,
+						      int ret)
+{}
+
+void __weak sys_trace_gpio_remove_callback_enter(
+						const struct device *port,
+						struct gpio_callback *callback)
+{}
+
+void __weak sys_trace_gpio_remove_callback_exit(
+						const struct device *port,
+						int ret)
+{}
+
+void __weak sys_trace_gpio_get_pending_int_enter(
+						const struct device *dev)
+{}
+
+void __weak sys_trace_gpio_get_pending_int_exit(
+						const struct device *port,
+						int ret)
+{}
+
+void __weak sys_trace_gpio_fire_callbacks_enter(
+						sys_slist_t *list,
+						const struct device *port,
+						gpio_pin_t pins)
+{}
+
+void __weak sys_trace_gpio_fire_callback(const struct device *port,
+						 struct gpio_callback *callback)
+{}
+
+void __weak sys_trace_rtio_submit_enter(const struct rtio *r, uint32_t wait_count)
 {
-	sys_trace_gpio_remove_callback_enter_user(port, callback);
+	printk("rtio_submit_enter_user: %p, wait_count: %d\n", r, wait_count);
 }
 
-void sys_trace_gpio_remove_callback_exit(const struct device *port, int ret)
+void __weak sys_trace_rtio_submit_exit(const struct rtio *r)
 {
-	sys_trace_gpio_remove_callback_exit_user(port, ret);
+	printk("rtio_submit_exit: rtio: %p\n", r);
 }
 
-void sys_trace_gpio_get_pending_int_enter(const struct device *dev)
+void __weak sys_trace_rtio_sqe_acquire_enter(const struct rtio *r)
 {
-	sys_trace_gpio_get_pending_int_enter_user(dev);
+	printk("sqe_acquire_enter: rtio: %p\n", r);
 }
 
-void sys_trace_gpio_get_pending_int_exit(const struct device *dev, int ret)
+void __weak sys_trace_rtio_sqe_acquire_exit(const struct rtio *r, const struct rtio_sqe *sqe)
 {
-	sys_trace_gpio_get_pending_int_exit_user(dev, ret);
+	printk("sqe_acquire_exit: rtio: %p\t sqe: %p\n", r, sqe);
 }
 
-void sys_trace_gpio_fire_callbacks_enter(sys_slist_t *list, const struct device *port,
-					 gpio_pin_t pins)
+void __weak sys_trace_rtio_sqe_cancel(const struct rtio_sqe *sqe)
 {
-	sys_trace_gpio_fire_callbacks_enter_user(list, port, pins);
+	printk("sqe_cancel_user: sqe: %p", sqe);
 }
 
-void sys_trace_gpio_fire_callback(const struct device *port, struct gpio_callback *callback)
+void __weak sys_trace_rtio_cqe_submit_enter(const struct rtio *r, int result, uint32_t flags)
 {
-	sys_trace_gpio_fire_callback_user(port, callback);
+	printk("cqe_submit_enter_user: rtio: %p\t result: %d\t flags: %d\n", r, result, flags);
 }
 
-void sys_trace_rtio_submit_enter(const struct rtio *r, uint32_t wait_count)
+void __weak sys_trace_rtio_cqe_submit_exit(const struct rtio *r)
 {
-	sys_trace_rtio_submit_enter_user(r, wait_count);
+	printk("cqe_submit_exit: rtio: %p\n", r);
 }
 
-void sys_trace_rtio_submit_exit(const struct rtio *r)
+void __weak sys_trace_rtio_cqe_acquire_enter(const struct rtio *r)
 {
-	sys_trace_rtio_submit_exit_user(r);
+	printk("cqe_acquire_enter_user: rtio: %p\n", r);
 }
 
-void sys_trace_rtio_sqe_acquire_enter(const struct rtio *r)
+void __weak sys_trace_rtio_cqe_acquire_exit(const struct rtio *r, const struct rtio_cqe *cqe)
 {
-	sys_trace_rtio_sqe_acquire_enter_user(r);
+	printk("cqe_acquire_exit_user: rtio: %p\t cqe: %p\n", r, cqe);
 }
 
-void sys_trace_rtio_sqe_acquire_exit(const struct rtio *r, const struct rtio_sqe *sqe)
+void __weak sys_trace_rtio_cqe_release(const struct rtio *r, const struct rtio_cqe *cqe)
 {
-	sys_trace_rtio_sqe_acquire_exit_user(r, sqe);
+	printk("cqe_release: rtio: %p\t cqe: %p\n", r, cqe);
 }
 
-void sys_trace_rtio_sqe_cancel(const struct rtio_sqe *sqe)
+void __weak sys_trace_rtio_cqe_consume_enter(const struct rtio *r)
 {
-	sys_trace_rtio_sqe_cancel_user(sqe);
+	printk("cqe_consume_enter: rtio: %p\n", r);
 }
 
-void sys_trace_rtio_cqe_submit_enter(const struct rtio *r, int result, uint32_t flags)
+void __weak sys_trace_rtio_cqe_consume_exit(const struct rtio *r, const struct rtio_cqe *cqe)
 {
-	sys_trace_rtio_cqe_submit_enter_user(r, result, flags);
+	printk("cqe_consume_exit: rtio: %p\t cqe: %p\n", r, cqe);
 }
 
-void sys_trace_rtio_cqe_submit_exit(const struct rtio *r)
+void __weak sys_trace_rtio_txn_next_enter(
+					const struct rtio *r,
+					const struct rtio_iodev_sqe *iodev_sqe)
 {
-	sys_trace_rtio_cqe_submit_exit_user(r);
+	printk("txn_next_enter: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
 }
 
-void sys_trace_rtio_cqe_acquire_enter(const struct rtio *r)
+void __weak sys_trace_rtio_txn_next_exit(
+					const struct rtio *r,
+					const struct rtio_iodev_sqe *iodev_sqe)
 {
-	sys_trace_rtio_cqe_acquire_enter_user(r);
+	printk("txn_next_exit: rtio: %p\t iodev_sqe: %p\n", r, iodev_sqe);
 }
 
-void sys_trace_rtio_cqe_acquire_exit(const struct rtio *r, const struct rtio_cqe *cqe)
+void __weak sys_trace_rtio_chain_next_enter(
+					const struct rtio *r,
+					const struct rtio_iodev_sqe *iodev_sqe)
 {
-	sys_trace_rtio_cqe_acquire_exit_user(r, cqe);
+	printk("chain_next_enter: rtio: %p\t iodev_sqe: %p\n", r,
+	       iodev_sqe);
 }
 
-void sys_trace_rtio_cqe_release(const struct rtio *r, const struct rtio_cqe *cqe)
+void __weak sys_trace_rtio_chain_next_exit(
+					const struct rtio *r,
+					const struct rtio_iodev_sqe *iodev_sqe)
 {
-	sys_trace_rtio_cqe_release_user(r, cqe);
+	printk("chain_next_exit: rtio: %p\t iodev_sqe: %p\n", r,
+	       iodev_sqe);
 }
 
-void sys_trace_rtio_cqe_consume_enter(const struct rtio *r)
-{
-	sys_trace_rtio_cqe_consume_enter_user(r);
-}
+void __weak sys_trace_timer_init(struct k_timer *timer) {}
 
-void sys_trace_rtio_cqe_consume_exit(const struct rtio *r, const struct rtio_cqe *cqe)
-{
-	sys_trace_rtio_cqe_consume_exit_user(r, cqe);
-}
+void __weak sys_trace_timer_start(struct k_timer *timer,
+					   k_timeout_t duration,
+					   k_timeout_t period)
+{}
 
-void sys_trace_rtio_txn_next_enter(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe)
-{
-	sys_trace_rtio_txn_next_enter_user(r, iodev_sqe);
-}
+void __weak sys_trace_timer_stop(struct k_timer *timer) {}
 
-void sys_trace_rtio_txn_next_exit(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe)
-{
-	sys_trace_rtio_txn_next_exit_user(r, iodev_sqe);
-}
+void __weak sys_trace_timer_status_sync_enter(struct k_timer *timer) {}
 
-void sys_trace_rtio_chain_next_enter(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe)
-{
-	sys_trace_rtio_chain_next_enter_user(r, iodev_sqe);
-}
+void __weak sys_trace_timer_status_sync_blocking(struct k_timer *timer, k_timeout_t timeout) {}
 
-void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe)
-{
-	sys_trace_rtio_chain_next_exit_user(r, iodev_sqe);
-}
+void __weak sys_trace_timer_status_sync_exit(struct k_timer *timer, uint32_t result) {}
 
-void sys_trace_timer_init(struct k_timer *timer)
-{
-	sys_trace_timer_init_user(timer);
-}
+void __weak sys_trace_timer_expiry_enter(struct k_timer *timer) {}
 
-void sys_trace_timer_start(struct k_timer *timer, k_timeout_t duration, k_timeout_t period)
-{
-	sys_trace_timer_start_user(timer, duration, period);
-}
+void __weak sys_trace_timer_expiry_exit(struct k_timer *timer) {}
 
-void sys_trace_timer_stop(struct k_timer *timer)
-{
-	sys_trace_timer_stop_user(timer);
-}
+void __weak sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer) {}
 
-void sys_trace_timer_status_sync_enter(struct k_timer *timer)
-{
-	sys_trace_timer_status_sync_enter_user(timer);
-}
-
-void sys_trace_timer_status_sync_blocking(struct k_timer *timer, k_timeout_t timeout)
-{
-	sys_trace_timer_status_sync_blocking_user(timer, timeout);
-}
-
-void sys_trace_timer_status_sync_exit(struct k_timer *timer, uint32_t result)
-{
-	sys_trace_timer_status_sync_exit_user(timer, result);
-}
-
-void sys_trace_timer_expiry_enter(struct k_timer *timer)
-{
-	sys_trace_timer_expiry_enter_user(timer);
-}
-
-void sys_trace_timer_expiry_exit(struct k_timer *timer)
-{
-	sys_trace_timer_expiry_exit_user(timer);
-}
-
-void sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer)
-{
-	sys_trace_timer_stop_fn_expiry_enter_user(timer);
-}
-
-void sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer)
-{
-	sys_trace_timer_stop_fn_expiry_exit_user(timer);
-}
+void __weak sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer) {}

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -10,39 +10,59 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/socket.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void sys_trace_thread_create_user(struct k_thread *thread);
-void sys_trace_thread_abort_user(struct k_thread *thread);
-void sys_trace_thread_suspend_user(struct k_thread *thread);
-void sys_trace_thread_resume_user(struct k_thread *thread);
-void sys_trace_thread_name_set_user(struct k_thread *thread);
-void sys_trace_thread_switched_in_user(void);
-void sys_trace_thread_switched_out_user(void);
-void sys_trace_thread_info_user(struct k_thread *thread);
-void sys_trace_thread_priority_set_user(struct k_thread *thread, int prio);
-void sys_trace_thread_sched_ready_user(struct k_thread *thread);
-void sys_trace_thread_pend_user(struct k_thread *thread);
-void sys_trace_isr_enter_user(void);
-void sys_trace_isr_exit_user(void);
-void sys_trace_idle_user(void);
-void sys_trace_sys_init_enter_user(const struct init_entry *entry, int level);
-void sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result);
-
 void sys_trace_thread_create(struct k_thread *thread);
 void sys_trace_thread_abort(struct k_thread *thread);
 void sys_trace_thread_suspend(struct k_thread *thread);
 void sys_trace_thread_resume(struct k_thread *thread);
-void sys_trace_thread_name_set(struct k_thread *thread);
-void sys_trace_k_thread_switched_in(void);
-void sys_trace_k_thread_switched_out(void);
+void sys_trace_thread_switched_in(void);
+void sys_trace_thread_switched_out(void);
 void sys_trace_thread_info(struct k_thread *thread);
 void sys_trace_thread_sched_priority_set(struct k_thread *thread, int prio);
 void sys_trace_thread_sched_ready(struct k_thread *thread);
 void sys_trace_thread_pend(struct k_thread *thread);
+
+void sys_trace_thread_abort_exit(struct k_thread *thread);
+void sys_trace_thread_abort_enter(struct k_thread *thread);
+void sys_trace_thread_resume_exit(struct k_thread *thread);
+void sys_trace_thread_sched_abort(struct k_thread *thread);
+
+void sys_trace_thread_sched_resume(struct k_thread *thread);
+void sys_trace_thread_sched_suspend(struct k_thread *thread);
+
+void sys_trace_thread_foreach_enter(void);
+void sys_trace_thread_foreach_exit(void);
+void sys_trace_thread_foreach_unlocked_enter(void);
+void sys_trace_thread_foreach_unlocked_exit(void);
+void sys_trace_thread_user_mode_enter(void);
+void sys_trace_thread_heap_assign(struct k_thread *thread, struct k_heap *heap);
+void sys_trace_thread_join_blocking(struct k_thread *thread, k_timeout_t timeout);
+void sys_trace_thread_join_enter(struct k_thread *thread, k_timeout_t timeout);
+void sys_trace_thread_join_exit(struct k_thread *thread, k_timeout_t timeout, int ret);
+void sys_trace_thread_sleep_enter(k_timeout_t timeout);
+void sys_trace_thread_sleep_exit(k_timeout_t timeout, int ret);
+void sys_trace_thread_msleep_enter(int32_t ms);
+void sys_trace_thread_msleep_exit(int32_t ms, int ret);
+void sys_trace_thread_usleep_enter(int32_t us);
+void sys_trace_thread_usleep_exit(int32_t us, int ret);
+void sys_trace_thread_busy_wait_enter(uint32_t usec_to_wait);
+void sys_trace_thread_busy_wait_exit(uint32_t usec_to_wait);
+void sys_trace_thread_yield(void);
+void sys_trace_thread_wakeup(struct k_thread *thread);
+void sys_trace_thread_start(struct k_thread *thread);
+void sys_trace_thread_priority_set(struct k_thread *thread);
+void sys_trace_thread_sched_lock(void);
+void sys_trace_thread_sched_unlock(void);
+void sys_trace_thread_name_set(struct k_thread *thread, int ret);
+void sys_trace_thread_ready(struct k_thread *thread);
+
 void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
 void sys_trace_idle(void);
@@ -71,46 +91,51 @@ typedef uint32_t gpio_port_pins_t;
 typedef uint32_t gpio_port_value_t;
 typedef void (*gpio_callback_handler_t)(const struct device *port, struct gpio_callback *cb,
 					gpio_port_pins_t pins);
-void sys_trace_gpio_pin_interrupt_configure_enter_user(const struct device *port, gpio_pin_t pin,
-						       gpio_flags_t flags);
-void sys_trace_gpio_pin_interrupt_configure_exit_user(const struct device *port, gpio_pin_t pin,
-						      int ret);
-void sys_trace_gpio_pin_configure_enter_user(const struct device *port, gpio_pin_t pin,
-					     gpio_flags_t flags);
-void sys_trace_gpio_pin_configure_exit_user(const struct device *port, gpio_pin_t pin, int ret);
-void sys_trace_gpio_port_get_direction_enter_user(const struct device *port, gpio_port_pins_t map,
-						  gpio_port_pins_t inputs,
-						  gpio_port_pins_t outputs);
-void sys_trace_gpio_port_get_direction_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_pin_get_config_enter_user(const struct device *port, gpio_pin_t pin, int ret);
-void sys_trace_gpio_pin_get_config_exit_user(const struct device *port, gpio_pin_t pin, int ret);
-void sys_trace_gpio_port_get_raw_enter_user(const struct device *port, gpio_port_value_t *value);
-void sys_trace_gpio_port_get_raw_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_port_set_masked_raw_enter_user(const struct device *port, gpio_port_pins_t mask,
-						   gpio_port_value_t value);
-void sys_trace_gpio_port_set_masked_raw_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_port_set_bits_raw_enter_user(const struct device *port, gpio_port_pins_t pins);
-void sys_trace_gpio_port_set_bits_raw_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_port_clear_bits_raw_enter_user(const struct device *port,
-						   gpio_port_pins_t pins);
-void sys_trace_gpio_port_clear_bits_raw_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_port_toggle_bits_enter_user(const struct device *port, gpio_port_pins_t pins);
-void sys_trace_gpio_port_toggle_bits_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_init_callback_enter_user(struct gpio_callback *callback,
-					     gpio_callback_handler_t handler,
-					     gpio_port_pins_t pin_mask);
-void sys_trace_gpio_init_callback_exit_user(struct gpio_callback *callback);
-void sys_trace_gpio_add_callback_enter_user(const struct device *port,
-					    struct gpio_callback *callback);
-void sys_trace_gpio_add_callback_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_remove_callback_enter_user(const struct device *port,
-					       struct gpio_callback *callback);
-void sys_trace_gpio_remove_callback_exit_user(const struct device *port, int ret);
-void sys_trace_gpio_get_pending_int_enter_user(const struct device *dev);
-void sys_trace_gpio_get_pending_int_exit_user(const struct device *dev, int ret);
-void sys_trace_gpio_fire_callbacks_enter_user(sys_slist_t *list, const struct device *port,
-					      gpio_pin_t pins);
-void sys_trace_gpio_fire_callback_user(const struct device *port, struct gpio_callback *callback);
+void sys_trace_gpio_pin_interrupt_configure_enter(
+				const struct device *port,
+				gpio_pin_t pin,
+				gpio_flags_t flags);
+void sys_trace_gpio_pin_interrupt_configure_exit(
+				const struct device *port,
+				gpio_pin_t pin, int ret);
+void sys_trace_gpio_pin_configure_enter(const struct device *port,
+						 gpio_pin_t pin,
+						 gpio_flags_t flags);
+void sys_trace_gpio_pin_configure_exit(const struct device *port,
+						       gpio_pin_t pin, int ret);
+void sys_trace_gpio_port_get_direction_enter(const struct device *port, gpio_port_pins_t map,
+					      gpio_port_pins_t inputs,
+					      gpio_port_pins_t outputs);
+void sys_trace_gpio_port_get_direction_exit(const struct device *port, int ret);
+void sys_trace_gpio_pin_get_config_enter(const struct device *port, gpio_pin_t pin, int ret);
+void sys_trace_gpio_pin_get_config_exit(const struct device *port, gpio_pin_t pin, int ret);
+void sys_trace_gpio_port_get_raw_enter(const struct device *port, gpio_port_value_t *value);
+void sys_trace_gpio_port_get_raw_exit(const struct device *port, int ret);
+void sys_trace_gpio_port_set_masked_raw_enter(const struct device *port, gpio_port_pins_t mask,
+					       gpio_port_value_t value);
+void sys_trace_gpio_port_set_masked_raw_exit(const struct device *port, int ret);
+void sys_trace_gpio_port_set_bits_raw_enter(const struct device *port, gpio_port_pins_t pins);
+void sys_trace_gpio_port_set_bits_raw_exit(const struct device *port, int ret);
+void sys_trace_gpio_port_clear_bits_raw_enter(const struct device *port, gpio_port_pins_t pins);
+void sys_trace_gpio_port_clear_bits_raw_exit(const struct device *port, int ret);
+void sys_trace_gpio_port_toggle_bits_enter(const struct device *port, gpio_port_pins_t pins);
+void sys_trace_gpio_port_toggle_bits_exit(const struct device *port, int ret);
+void sys_trace_gpio_init_callback_enter(struct gpio_callback *callback,
+					 gpio_callback_handler_t handler,
+					 gpio_port_pins_t pin_mask);
+void sys_trace_gpio_init_callback_exit(struct gpio_callback *callback);
+void sys_trace_gpio_add_callback_enter(const struct device *port,
+						       struct gpio_callback *callback);
+void sys_trace_gpio_add_callback_exit(const struct device *port, int ret);
+void sys_trace_gpio_remove_callback_enter(
+				const struct device *port,
+				struct gpio_callback *callback);
+void sys_trace_gpio_remove_callback_exit(const struct device *port, int ret);
+void sys_trace_gpio_get_pending_int_enter(const struct device *dev);
+void sys_trace_gpio_get_pending_int_exit(const struct device *dev, int ret);
+void sys_trace_gpio_fire_callbacks_enter(sys_slist_t *list, const struct device *port,
+					  gpio_pin_t pins);
+void sys_trace_gpio_fire_callback(const struct device *port, struct gpio_callback *callback);
 
 void sys_trace_rtio_submit_enter(const struct rtio *r, uint32_t wait_count);
 void sys_trace_rtio_submit_exit(const struct rtio *r);
@@ -129,183 +154,669 @@ void sys_trace_rtio_txn_next_exit(const struct rtio *r, const struct rtio_iodev_
 void sys_trace_rtio_chain_next_enter(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe);
 void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe);
 
-#define sys_port_trace_k_thread_foreach_enter()
-#define sys_port_trace_k_thread_foreach_exit()
-#define sys_port_trace_k_thread_foreach_unlocked_enter()
-#define sys_port_trace_k_thread_foreach_unlocked_exit()
+/* Work tracing */
+void sys_trace_k_work_init(struct k_work *work);
+void sys_trace_k_work_submit_to_queue_enter(struct k_work_q *queue, struct k_work *work);
+void sys_trace_k_work_submit_to_queue_exit(struct k_work_q *queue, struct k_work *work, int ret);
+void sys_trace_k_work_submit_enter(struct k_work *work);
+void sys_trace_k_work_submit_exit(struct k_work *work, int ret);
+void sys_trace_k_work_flush_enter(struct k_work *work);
+void sys_trace_k_work_flush_blocking(struct k_work *work, k_timeout_t timeout);
+void sys_trace_k_work_flush_exit(struct k_work *work, bool ret);
+void sys_trace_k_work_cancel_enter(struct k_work *work);
+void sys_trace_k_work_cancel_exit(struct k_work *work, int ret);
+void sys_trace_k_work_cancel_sync_enter(struct k_work *work, struct k_work_sync *sync);
+void sys_trace_k_work_cancel_sync_blocking(struct k_work *work, struct k_work_sync *sync);
+void sys_trace_k_work_cancel_sync_exit(struct k_work *work, struct k_work_sync *sync, bool ret);
+
+/* Work queue tracing */
+void sys_trace_k_work_queue_init(struct k_work_q *queue);
+void sys_trace_k_work_queue_start_enter(struct k_work_q *queue);
+void sys_trace_k_work_queue_start_exit(struct k_work_q *queue);
+void sys_trace_k_work_queue_stop_enter(struct k_work_q *queue, k_timeout_t timeout);
+void sys_trace_k_work_queue_stop_blocking(struct k_work_q *queue, k_timeout_t timeout);
+void sys_trace_k_work_queue_stop_exit(struct k_work_q *queue, k_timeout_t timeout, int ret);
+void sys_trace_k_work_queue_drain_enter(struct k_work_q *queue);
+void sys_trace_k_work_queue_drain_exit(struct k_work_q *queue, int ret);
+void sys_trace_k_work_queue_unplug_enter(struct k_work_q *queue);
+void sys_trace_k_work_queue_unplug_exit(struct k_work_q *queue, int ret);
+
+/* Delayable work tracing */
+void sys_trace_k_work_delayable_init(struct k_work_delayable *dwork);
+void sys_trace_k_work_schedule_for_queue_enter(
+				struct k_work_q *queue,
+				struct k_work_delayable *dwork,
+				k_timeout_t delay);
+void sys_trace_k_work_schedule_for_queue_exit(
+				struct k_work_q *queue,
+				struct k_work_delayable *dwork,
+				k_timeout_t delay, int ret);
+void sys_trace_k_work_schedule_enter(struct k_work_delayable *dwork,
+					      k_timeout_t delay);
+void sys_trace_k_work_schedule_exit(struct k_work_delayable *dwork,
+					     k_timeout_t delay, int ret);
+void sys_trace_k_work_reschedule_for_queue_enter(
+				struct k_work_q *queue,
+				struct k_work_delayable *dwork,
+				k_timeout_t delay);
+void sys_trace_k_work_reschedule_for_queue_exit(
+				struct k_work_q *queue,
+				struct k_work_delayable *dwork,
+				k_timeout_t delay, int ret);
+void sys_trace_k_work_reschedule_enter(struct k_work_delayable *dwork,
+					       k_timeout_t delay);
+void sys_trace_k_work_reschedule_exit(struct k_work_delayable *dwork,
+					      k_timeout_t delay, int ret);
+void sys_trace_k_work_flush_delayable_enter(
+				struct k_work_delayable *dwork,
+				struct k_work_sync *sync);
+void sys_trace_k_work_flush_delayable_exit(
+				struct k_work_delayable *dwork,
+				struct k_work_sync *sync,
+				bool ret);
+void sys_trace_k_work_cancel_delayable_enter(
+				struct k_work_delayable *dwork);
+void sys_trace_k_work_cancel_delayable_exit(
+				struct k_work_delayable *dwork,
+				int ret);
+void sys_trace_k_work_cancel_delayable_sync_enter(
+				struct k_work_delayable *dwork,
+				struct k_work_sync *sync);
+void sys_trace_k_work_cancel_delayable_sync_exit(
+				struct k_work_delayable *dwork,
+				struct k_work_sync *sync,
+				bool ret);
+
+/* Work poll tracing */
+void sys_trace_k_work_poll_init_enter(struct k_work_poll *work);
+void sys_trace_k_work_poll_init_exit(struct k_work_poll *work);
+void sys_trace_k_work_poll_submit_to_queue_enter(
+				struct k_work_q *work_q,
+				struct k_work_poll *work,
+				k_timeout_t timeout);
+void sys_trace_k_work_poll_submit_to_queue_blocking(
+				struct k_work_q *work_q,
+				struct k_work_poll *work,
+				k_timeout_t timeout);
+void sys_trace_k_work_poll_submit_to_queue_exit(
+				struct k_work_q *work_q,
+				struct k_work_poll *work,
+				k_timeout_t timeout, int ret);
+void sys_trace_k_work_poll_submit_enter(struct k_work_poll *work, k_timeout_t timeout);
+void sys_trace_k_work_poll_submit_exit(struct k_work_poll *work, k_timeout_t timeout, int ret);
+void sys_trace_k_work_poll_cancel_enter(struct k_work_poll *work);
+void sys_trace_k_work_poll_cancel_exit(struct k_work_poll *work, int ret);
+
+/* Poll API tracing */
+void sys_trace_k_poll_api_event_init(struct k_poll_event *event);
+void sys_trace_k_poll_api_poll_enter(struct k_poll_event *events);
+void sys_trace_k_poll_api_poll_exit(struct k_poll_event *events, int ret);
+void sys_trace_k_poll_api_signal_init(struct k_poll_signal *sig);
+void sys_trace_k_poll_api_signal_reset(struct k_poll_signal *sig);
+void sys_trace_k_poll_api_signal_check(struct k_poll_signal *sig);
+void sys_trace_k_poll_api_signal_raise(struct k_poll_signal *sig, int ret);
+
+/* Semaphore tracing */
+void sys_trace_k_sem_init(struct k_sem *sem, int ret);
+void sys_trace_k_sem_give_enter(struct k_sem *sem);
+void sys_trace_k_sem_give_exit(struct k_sem *sem);
+void sys_trace_k_sem_take_enter(struct k_sem *sem, k_timeout_t timeout);
+void sys_trace_k_sem_take_blocking(struct k_sem *sem, k_timeout_t timeout);
+void sys_trace_k_sem_take_exit(struct k_sem *sem, k_timeout_t timeout, int ret);
+void sys_trace_k_sem_reset(struct k_sem *sem);
+
+/* Mutex tracing */
+void sys_trace_k_mutex_init(struct k_mutex *mutex, int ret);
+void sys_trace_k_mutex_lock_enter(struct k_mutex *mutex, k_timeout_t timeout);
+void sys_trace_k_mutex_lock_blocking(struct k_mutex *mutex, k_timeout_t timeout);
+void sys_trace_k_mutex_lock_exit(struct k_mutex *mutex, k_timeout_t timeout, int ret);
+void sys_trace_k_mutex_unlock_enter(struct k_mutex *mutex);
+void sys_trace_k_mutex_unlock_exit(struct k_mutex *mutex, int ret);
+
+/* Condition variable tracing */
+void sys_trace_k_condvar_init(struct k_condvar *condvar, int ret);
+void sys_trace_k_condvar_signal_enter(struct k_condvar *condvar);
+void sys_trace_k_condvar_signal_blocking(struct k_condvar *condvar, k_timeout_t timeout);
+void sys_trace_k_condvar_signal_exit(struct k_condvar *condvar, int ret);
+void sys_trace_k_condvar_broadcast_enter(struct k_condvar *condvar);
+void sys_trace_k_condvar_broadcast_exit(struct k_condvar *condvar, int ret);
+void sys_trace_k_condvar_wait_enter(struct k_condvar *condvar, k_timeout_t timeout);
+void sys_trace_k_condvar_wait_exit(struct k_condvar *condvar, k_timeout_t timeout, int ret);
+
+/* Queue tracing */
+void sys_trace_k_queue_init(struct k_queue *queue);
+void sys_trace_k_queue_cancel_wait(struct k_queue *queue);
+void sys_trace_k_queue_queue_insert_enter(struct k_queue *queue,
+							  bool alloc);
+void sys_trace_k_queue_queue_insert_blocking(
+				struct k_queue *queue,
+				bool alloc,
+				k_timeout_t timeout);
+void sys_trace_k_queue_queue_insert_exit(struct k_queue *queue, bool alloc, int ret);
+void sys_trace_k_queue_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_append_exit(struct k_queue *queue);
+void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_alloc_append_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_prepend_enter(struct k_queue *queue);
+void sys_trace_k_queue_prepend_exit(struct k_queue *queue);
+void sys_trace_k_queue_alloc_prepend_enter(struct k_queue *queue);
+void sys_trace_k_queue_alloc_prepend_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_insert_enter(struct k_queue *queue);
+void sys_trace_k_queue_insert_blocking(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_insert_exit(struct k_queue *queue);
+void sys_trace_k_queue_append_list_enter(struct k_queue *queue);
+void sys_trace_k_queue_append_list_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_merge_slist_enter(struct k_queue *queue);
+void sys_trace_k_queue_merge_slist_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_get_enter(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_get_blocking(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_get_exit(struct k_queue *queue, k_timeout_t timeout, void *ret);
+void sys_trace_k_queue_remove_enter(struct k_queue *queue);
+void sys_trace_k_queue_remove_exit(struct k_queue *queue, bool ret);
+void sys_trace_k_queue_unique_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, bool ret);
+void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret);
+void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret);
+
+/* FIFO tracing */
+void sys_trace_k_fifo_init_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_init_exit(struct k_fifo *fifo);
+void sys_trace_k_fifo_cancel_wait_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_cancel_wait_exit(struct k_fifo *fifo);
+void sys_trace_k_fifo_put_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_put_exit(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_alloc_put_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_alloc_put_exit(struct k_fifo *fifo, void *data, int ret);
+void sys_trace_k_fifo_put_list_enter(struct k_fifo *fifo, void *head, void *tail);
+void sys_trace_k_fifo_put_list_exit(struct k_fifo *fifo, void *head, void *tail);
+void sys_trace_k_fifo_put_slist_enter(struct k_fifo *fifo, sys_slist_t *list);
+void sys_trace_k_fifo_put_slist_exit(struct k_fifo *fifo, sys_slist_t *list);
+void sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout);
+void sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret);
+void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret);
+void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret);
+
+/* Stack tracing */
+void sys_trace_k_stack_init(struct k_stack *stack);
+void sys_trace_k_stack_alloc_init_enter(struct k_stack *stack);
+void sys_trace_k_stack_alloc_init_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_cleanup_enter(struct k_stack *stack);
+void sys_trace_k_stack_cleanup_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_push_enter(struct k_stack *stack);
+void sys_trace_k_stack_push_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_pop_enter(struct k_stack *stack, k_timeout_t timeout);
+void sys_trace_k_stack_pop_blocking(struct k_stack *stack, k_timeout_t timeout);
+void sys_trace_k_stack_pop_exit(struct k_stack *stack, k_timeout_t timeout, int ret);
+
+/* Message queue tracing */
+void sys_trace_k_msgq_init(struct k_msgq *msgq);
+void sys_trace_k_msgq_alloc_init_enter(struct k_msgq *msgq);
+void sys_trace_k_msgq_alloc_init_exit(struct k_msgq *msgq, int ret);
+void sys_trace_k_msgq_cleanup_enter(struct k_msgq *msgq);
+void sys_trace_k_msgq_cleanup_exit(struct k_msgq *msgq, int ret);
+void sys_trace_k_msgq_put_enter(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_put_blocking(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_put_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret);
+void sys_trace_k_msgq_put_front_enter(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_put_front_blocking(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_put_front_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret);
+void sys_trace_k_msgq_get_enter(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_get_blocking(struct k_msgq *msgq, k_timeout_t timeout);
+void sys_trace_k_msgq_get_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret);
+void sys_trace_k_msgq_peek(struct k_msgq *msgq, int ret);
+void sys_trace_k_msgq_purge(struct k_msgq *msgq);
+
+/* Mailbox tracing */
+void sys_trace_k_mbox_init(struct k_mbox *mbox);
+void sys_trace_k_mbox_message_put_enter(struct k_mbox *mbox, k_timeout_t timeout);
+void sys_trace_k_mbox_message_put_blocking(struct k_mbox *mbox, k_timeout_t timeout);
+void sys_trace_k_mbox_message_put_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret);
+void sys_trace_k_mbox_put_enter(struct k_mbox *mbox, k_timeout_t timeout);
+void sys_trace_k_mbox_put_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret);
+void sys_trace_k_mbox_async_put_enter(struct k_mbox *mbox, struct k_sem *sem);
+void sys_trace_k_mbox_async_put_exit(struct k_mbox *mbox, struct k_sem *sem);
+void sys_trace_k_mbox_get_enter(struct k_mbox *mbox, k_timeout_t timeout);
+void sys_trace_k_mbox_get_blocking(struct k_mbox *mbox, k_timeout_t timeout);
+void sys_trace_k_mbox_get_exit(struct k_mbox *mbox, k_timeout_t timeout, int ret);
+void sys_trace_k_mbox_data_get(struct k_mbox_msg *rx_msg);
+
+/* Pipe tracing */
+void sys_trace_k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size);
+void sys_trace_k_pipe_reset_enter(struct k_pipe *pipe);
+void sys_trace_k_pipe_reset_exit(struct k_pipe *pipe);
+void sys_trace_k_pipe_close_enter(struct k_pipe *pipe);
+void sys_trace_k_pipe_close_exit(struct k_pipe *pipe);
+void sys_trace_k_pipe_write_enter(struct k_pipe *pipe, void *data, size_t len, k_timeout_t timeout);
+void sys_trace_k_pipe_write_blocking(struct k_pipe *pipe, k_timeout_t timeout);
+void sys_trace_k_pipe_write_exit(struct k_pipe *pipe, int ret);
+void sys_trace_k_pipe_read_enter(struct k_pipe *pipe, void *data, size_t len, k_timeout_t timeout);
+void sys_trace_k_pipe_read_blocking(struct k_pipe *pipe, k_timeout_t timeout);
+void sys_trace_k_pipe_read_exit(struct k_pipe *pipe, int ret);
+
+/* Heap tracing */
+void sys_trace_k_heap_init(struct k_heap *heap);
+void sys_trace_k_heap_aligned_alloc_enter(struct k_heap *heap, k_timeout_t timeout);
+void sys_trace_k_heap_alloc_helper_blocking(struct k_heap *heap, k_timeout_t timeout);
+void sys_trace_k_heap_aligned_alloc_exit(struct k_heap *heap, k_timeout_t timeout, void *ret);
+void sys_trace_k_heap_alloc_enter(struct k_heap *heap, k_timeout_t timeout);
+void sys_trace_k_heap_alloc_exit(struct k_heap *heap, k_timeout_t timeout, void *ret);
+void sys_trace_k_heap_calloc_enter(struct k_heap *heap,
+					    k_timeout_t timeout);
+void sys_trace_k_heap_calloc_exit(struct k_heap *heap, k_timeout_t timeout,
+					  void *ret);
+void sys_trace_k_heap_free(struct k_heap *heap);
+void sys_trace_k_heap_realloc_enter(struct k_heap *h, void *ptr,
+					    size_t bytes,
+					    k_timeout_t timeout);
+void sys_trace_k_heap_realloc_exit(struct k_heap *h, void *ptr,
+					   size_t bytes,
+					   k_timeout_t timeout, void *ret);
+void sys_trace_k_heap_sys_k_aligned_alloc_enter(struct k_heap *heap);
+void sys_trace_k_heap_sys_k_aligned_alloc_exit(struct k_heap *heap, void *ret);
+void sys_trace_k_heap_sys_k_malloc_enter(struct k_heap *heap);
+void sys_trace_k_heap_sys_k_malloc_exit(struct k_heap *heap, void *ret);
+void sys_trace_k_heap_sys_k_free_enter(struct k_heap *heap, void *heap_ref);
+void sys_trace_k_heap_sys_k_free_exit(struct k_heap *heap, void *heap_ref);
+void sys_trace_k_heap_sys_k_calloc_enter(struct k_heap *heap);
+void sys_trace_k_heap_sys_k_calloc_exit(struct k_heap *heap, void *ret);
+void sys_trace_k_heap_sys_k_realloc_enter(struct k_heap *heap, void *ptr);
+void sys_trace_k_heap_sys_k_realloc_exit(struct k_heap *heap, void *ptr, void *ret);
+
+/* Memory slab tracing */
+void sys_trace_k_mem_slab_init(struct k_mem_slab *slab, int rc);
+void sys_trace_k_mem_slab_alloc_enter(struct k_mem_slab *slab, k_timeout_t timeout);
+void sys_trace_k_mem_slab_alloc_blocking(struct k_mem_slab *slab, k_timeout_t timeout);
+void sys_trace_k_mem_slab_alloc_exit(struct k_mem_slab *slab, k_timeout_t timeout, int ret);
+void sys_trace_k_mem_slab_free_enter(struct k_mem_slab *slab);
+void sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab);
+
+/* Event tracing */
+void sys_trace_k_event_init(struct k_event *event);
+void sys_trace_k_event_post_enter(struct k_event *event, uint32_t events,
+					  uint32_t events_mask);
+void sys_trace_k_event_post_exit(struct k_event *event, uint32_t events,
+					 uint32_t events_mask);
+void sys_trace_k_event_wait_enter(struct k_event *event, uint32_t events,
+					  uint32_t options,
+					  k_timeout_t timeout);
+void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events,
+					     uint32_t options,
+					     k_timeout_t timeout);
+void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_t ret);
+
+/* PM tracing */
+void sys_trace_pm_system_suspend_enter(int32_t ticks);
+void sys_trace_pm_system_suspend_exit(int32_t ticks, uint32_t state);
+void sys_trace_pm_device_runtime_get_enter(const struct device *dev);
+void sys_trace_pm_device_runtime_get_exit(const struct device *dev, int ret);
+void sys_trace_pm_device_runtime_put_enter(const struct device *dev);
+void sys_trace_pm_device_runtime_put_exit(const struct device *dev,
+						  int ret);
+void sys_trace_pm_device_runtime_put_async_enter(
+				const struct device *dev,
+				k_timeout_t delay);
+void sys_trace_pm_device_runtime_put_async_exit(
+				const struct device *dev,
+				k_timeout_t delay, int ret);
+void sys_trace_pm_device_runtime_enable_enter(const struct device *dev);
+void sys_trace_pm_device_runtime_enable_exit(const struct device *dev, int ret);
+void sys_trace_pm_device_runtime_disable_enter(const struct device *dev);
+void sys_trace_pm_device_runtime_disable_exit(const struct device *dev, int ret);
+
+/* Socket tracing */
+void sys_trace_socket_init(int sock, int family, int type, int proto);
+void sys_trace_socket_close_enter(int sock);
+void sys_trace_socket_close_exit(int sock, int ret);
+void sys_trace_socket_shutdown_enter(int sock, int how);
+void sys_trace_socket_shutdown_exit(int sock, int ret);
+void sys_trace_socket_bind_enter(int sock, const struct net_sockaddr *addr, size_t addrlen);
+void sys_trace_socket_bind_exit(int sock, int ret);
+void sys_trace_socket_connect_enter(int sock, const struct net_sockaddr *addr, size_t addrlen);
+void sys_trace_socket_connect_exit(int sock, int ret);
+void sys_trace_socket_listen_enter(int sock, int backlog);
+void sys_trace_socket_listen_exit(int sock, int ret);
+void sys_trace_socket_accept_enter(int sock);
+void sys_trace_socket_accept_exit(int sock, const struct net_sockaddr *addr,
+					  const size_t *addrlen, int ret);
+void sys_trace_socket_sendto_enter(int sock, size_t len, int flags,
+					   const struct net_sockaddr *dest_addr,
+					   size_t addrlen);
+void sys_trace_socket_sendto_exit(int sock, int ret);
+void sys_trace_socket_sendmsg_enter(int sock, const struct msghdr *msg,
+					    int flags);
+void sys_trace_socket_sendmsg_exit(int sock, int ret);
+void sys_trace_socket_recvfrom_enter(int sock, size_t max_len, int flags,
+					     struct sockaddr *addr,
+					     size_t *addrlen);
+void sys_trace_socket_recvfrom_exit(int sock,
+					    const struct net_sockaddr *src_addr,
+					    const size_t *addrlen, int ret);
+void sys_trace_socket_recvmsg_enter(int sock, const struct msghdr *msg, int flags);
+void sys_trace_socket_recvmsg_exit(int sock, const struct msghdr *msg, int ret);
+void sys_trace_socket_fcntl_enter(int sock, int cmd, int flags);
+void sys_trace_socket_fcntl_exit(int sock, int ret);
+void sys_trace_socket_ioctl_enter(int sock, int req);
+void sys_trace_socket_ioctl_exit(int sock, int ret);
+void sys_trace_socket_poll_enter(struct zsock_pollfd *fds, int nfds,
+					  int timeout);
+void sys_trace_socket_poll_exit(struct zsock_pollfd *fds, int nfds,
+					int ret);
+void sys_trace_socket_getsockopt_enter(int sock, int level, int optname);
+void sys_trace_socket_getsockopt_exit(int sock, int level, int optname,
+					      void *optval,
+					      const size_t *optlen,
+					      int ret);
+void sys_trace_socket_setsockopt_enter(int sock, int level, int optname,
+					       const void *optval,
+					       size_t optlen);
+void sys_trace_socket_setsockopt_exit(int sock, int ret);
+void sys_trace_socket_getpeername_enter(int sock);
+void sys_trace_socket_getpeername_exit(int sock, struct sockaddr *addr,
+					       const size_t *addrlen,
+					       int ret);
+void sys_trace_socket_getsockname_enter(int sock);
+void sys_trace_socket_getsockname_exit(int sock, struct sockaddr *addr,
+					       const size_t *addrlen,
+					       int ret);
+void sys_trace_socket_socketpair_enter(int family, int type, int proto, int *sv);
+void sys_trace_socket_socketpair_exit(int sockA, int sockB, int ret);
+
+/* Network tracing */
+void sys_trace_net_recv_data_enter(struct net_if *iface, struct net_pkt *pkt);
+void sys_trace_net_recv_data_exit(struct net_if *iface, struct net_pkt *pkt, int ret);
+void sys_trace_net_send_data_enter(struct net_pkt *pkt);
+void sys_trace_net_send_data_exit(struct net_pkt *pkt, int ret);
+void sys_trace_net_rx_time(struct net_pkt *pkt, uint32_t end_time);
+void sys_trace_net_tx_time(struct net_pkt *pkt, uint32_t end_time);
+
+#define sys_port_trace_k_thread_foreach_enter() sys_trace_thread_foreach_enter()
+#define sys_port_trace_k_thread_foreach_exit() sys_trace_thread_foreach_exit()
+#define sys_port_trace_k_thread_foreach_unlocked_enter() sys_trace_thread_foreach_unlocked_enter()
+#define sys_port_trace_k_thread_foreach_unlocked_exit() sys_trace_thread_foreach_unlocked_exit()
 #define sys_port_trace_k_thread_create(new_thread) sys_trace_thread_create(new_thread)
-#define sys_port_trace_k_thread_user_mode_enter()
-#define sys_port_trace_k_thread_heap_assign(thread, heap)
-#define sys_port_trace_k_thread_join_enter(thread, timeout)
-#define sys_port_trace_k_thread_join_blocking(thread, timeout)
-#define sys_port_trace_k_thread_join_exit(thread, timeout, ret)
-#define sys_port_trace_k_thread_sleep_enter(timeout)
-#define sys_port_trace_k_thread_sleep_exit(timeout, ret)
-#define sys_port_trace_k_thread_msleep_enter(ms)
-#define sys_port_trace_k_thread_msleep_exit(ms, ret)
-#define sys_port_trace_k_thread_usleep_enter(us)
-#define sys_port_trace_k_thread_usleep_exit(us, ret)
-#define sys_port_trace_k_thread_busy_wait_enter(usec_to_wait)
-#define sys_port_trace_k_thread_busy_wait_exit(usec_to_wait)
-#define sys_port_trace_k_thread_yield()
-#define sys_port_trace_k_thread_wakeup(thread)
-#define sys_port_trace_k_thread_start(thread)
+#define sys_port_trace_k_thread_user_mode_enter() sys_trace_thread_user_mode_enter()
+#define sys_port_trace_k_thread_heap_assign(thread, heap) sys_trace_thread_heap_assign(thread, heap)
+#define sys_port_trace_k_thread_join_enter(thread, timeout) \
+	sys_trace_thread_join_enter(thread, timeout)
+#define sys_port_trace_k_thread_join_blocking(thread, timeout) \
+	sys_trace_thread_join_blocking(thread, timeout)
+#define sys_port_trace_k_thread_join_exit(thread, timeout, ret) \
+	sys_trace_thread_join_exit(thread, timeout, ret)
+#define sys_port_trace_k_thread_sleep_enter(timeout) sys_trace_thread_sleep_enter(timeout)
+#define sys_port_trace_k_thread_sleep_exit(timeout, ret) sys_trace_thread_sleep_exit(timeout, ret)
+#define sys_port_trace_k_thread_msleep_enter(ms) sys_trace_thread_msleep_enter(ms)
+#define sys_port_trace_k_thread_msleep_exit(ms, ret) sys_trace_thread_msleep_exit(ms, ret)
+#define sys_port_trace_k_thread_usleep_enter(us) sys_trace_thread_usleep_enter(us)
+#define sys_port_trace_k_thread_usleep_exit(us, ret) sys_trace_thread_usleep_exit(us, ret)
+#define sys_port_trace_k_thread_busy_wait_enter(usec_to_wait) \
+	sys_trace_thread_busy_wait_enter(usec_to_wait)
+#define sys_port_trace_k_thread_busy_wait_exit(usec_to_wait) \
+	sys_trace_thread_busy_wait_exit(usec_to_wait)
+#define sys_port_trace_k_thread_yield() sys_trace_thread_yield()
+#define sys_port_trace_k_thread_wakeup(thread) sys_trace_thread_wakeup(thread)
+#define sys_port_trace_k_thread_start(thread) sys_trace_thread_start(thread)
 #define sys_port_trace_k_thread_abort(thread) sys_trace_thread_abort(thread)
 #define sys_port_trace_k_thread_suspend_enter(thread) sys_trace_thread_suspend(thread)
-#define sys_port_trace_k_thread_suspend_exit(thread)
+#define sys_port_trace_k_thread_suspend_exit(thread) sys_trace_thread_sched_suspend(thread)
 #define sys_port_trace_k_thread_resume_enter(thread) sys_trace_thread_resume(thread)
-#define sys_port_trace_k_thread_sched_lock()
-#define sys_port_trace_k_thread_sched_unlock()
-#define sys_port_trace_k_thread_name_set(thread, ret) sys_trace_thread_name_set(thread)
-#define sys_port_trace_k_thread_switched_out() sys_trace_k_thread_switched_out()
-#define sys_port_trace_k_thread_switched_in() sys_trace_k_thread_switched_in()
+#define sys_port_trace_k_thread_resume_exit(thread) sys_trace_thread_resume_exit(thread)
+#define sys_port_trace_k_thread_sched_lock() sys_trace_thread_sched_lock()
+#define sys_port_trace_k_thread_sched_unlock() sys_trace_thread_sched_unlock()
+#define sys_port_trace_k_thread_name_set(thread, ret) sys_trace_thread_name_set(thread, ret)
+#define sys_port_trace_k_thread_switched_out() sys_trace_thread_switched_out()
+#define sys_port_trace_k_thread_switched_in() sys_trace_thread_switched_in()
+#define sys_port_trace_k_thread_ready(thread) sys_trace_thread_ready(thread)
+#define sys_port_trace_k_thread_pend(thread) sys_trace_thread_pend(thread)
 #define sys_port_trace_k_thread_info(thread) sys_trace_thread_info(thread)
 
-#define sys_port_trace_k_thread_sched_wakeup(thread)
-#define sys_port_trace_k_thread_sched_abort(thread)
+#define sys_port_trace_k_thread_sched_wakeup(thread) sys_trace_thread_wakeup(thread)
+#define sys_port_trace_k_thread_sched_abort(thread) sys_trace_thread_sched_abort(thread)
 #define sys_port_trace_k_thread_sched_priority_set(thread, prio) \
 	sys_trace_thread_sched_priority_set(thread, prio)
 #define sys_port_trace_k_thread_sched_ready(thread) sys_trace_thread_sched_ready(thread)
 #define sys_port_trace_k_thread_sched_pend(thread) sys_trace_thread_pend(thread)
-#define sys_port_trace_k_thread_sched_resume(thread)
-#define sys_port_trace_k_thread_sched_suspend(thread)
+#define sys_port_trace_k_thread_sched_resume(thread) sys_trace_thread_sched_resume(thread)
+#define sys_port_trace_k_thread_sched_suspend(thread) sys_trace_thread_sched_suspend(thread)
 
-#define sys_port_trace_k_work_init(work)
-#define sys_port_trace_k_work_submit_to_queue_enter(queue, work)
-#define sys_port_trace_k_work_submit_to_queue_exit(queue, work, ret)
-#define sys_port_trace_k_work_submit_enter(work)
-#define sys_port_trace_k_work_submit_exit(work, ret)
-#define sys_port_trace_k_work_flush_enter(work)
-#define sys_port_trace_k_work_flush_blocking(work, timeout)
-#define sys_port_trace_k_work_flush_exit(work, ret)
-#define sys_port_trace_k_work_cancel_enter(work)
-#define sys_port_trace_k_work_cancel_exit(work, ret)
-#define sys_port_trace_k_work_cancel_sync_enter(work, sync)
-#define sys_port_trace_k_work_cancel_sync_blocking(work, sync)
-#define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret)
+#define sys_port_trace_k_work_init(work) sys_trace_k_work_init(work)
+#define sys_port_trace_k_work_submit_to_queue_enter(queue, work) \
+	sys_trace_k_work_submit_to_queue_enter(queue, work)
+#define sys_port_trace_k_work_submit_to_queue_exit(queue, work, ret) \
+	sys_trace_k_work_submit_to_queue_exit(queue, work, ret)
+#define sys_port_trace_k_work_submit_enter(work) sys_trace_k_work_submit_enter(work)
+#define sys_port_trace_k_work_submit_exit(work, ret) sys_trace_k_work_submit_exit(work, ret)
+#define sys_port_trace_k_work_flush_enter(work) sys_trace_k_work_flush_enter(work)
+#define sys_port_trace_k_work_flush_blocking(work, timeout) \
+	sys_trace_k_work_flush_blocking(work, timeout)
+#define sys_port_trace_k_work_flush_exit(work, ret) \
+	sys_trace_k_work_flush_exit(work, ret)
+#define sys_port_trace_k_work_cancel_enter(work) \
+	sys_trace_k_work_cancel_enter(work)
+#define sys_port_trace_k_work_cancel_exit(work, ret) \
+	sys_trace_k_work_cancel_exit(work, ret)
+#define sys_port_trace_k_work_cancel_sync_enter(work, sync) \
+	sys_trace_k_work_cancel_sync_enter(work, sync)
+#define sys_port_trace_k_work_cancel_sync_blocking(work, sync) \
+	sys_trace_k_work_cancel_sync_blocking(work, sync)
+#define sys_port_trace_k_work_cancel_sync_exit(work, sync, ret) \
+	sys_trace_k_work_cancel_sync_exit(work, sync, ret)
 
-#define sys_port_trace_k_work_queue_init(queue)
-#define sys_port_trace_k_work_queue_start_enter(queue)
-#define sys_port_trace_k_work_queue_start_exit(queue)
-#define sys_port_trace_k_work_queue_stop_enter(queue, timeout)
-#define sys_port_trace_k_work_queue_stop_blocking(queue, timeout)
-#define sys_port_trace_k_work_queue_stop_exit(queue, timeout, ret)
-#define sys_port_trace_k_work_queue_drain_enter(queue)
-#define sys_port_trace_k_work_queue_drain_exit(queue, ret)
-#define sys_port_trace_k_work_queue_unplug_enter(queue)
-#define sys_port_trace_k_work_queue_unplug_exit(queue, ret)
+#define sys_port_trace_k_work_queue_init(queue) sys_trace_k_work_queue_init(queue)
+#define sys_port_trace_k_work_queue_start_enter(queue) sys_trace_k_work_queue_start_enter(queue)
+#define sys_port_trace_k_work_queue_start_exit(queue) sys_trace_k_work_queue_start_exit(queue)
+#define sys_port_trace_k_work_queue_stop_enter(queue, timeout) \
+	sys_trace_k_work_queue_stop_enter(queue, timeout)
+#define sys_port_trace_k_work_queue_stop_blocking(queue, timeout) \
+	sys_trace_k_work_queue_stop_blocking(queue, timeout)
+#define sys_port_trace_k_work_queue_stop_exit(queue, timeout, ret) \
+	sys_trace_k_work_queue_stop_exit(queue, timeout, ret)
+#define sys_port_trace_k_work_queue_drain_enter(queue) \
+	sys_trace_k_work_queue_drain_enter(queue)
+#define sys_port_trace_k_work_queue_drain_exit(queue, ret) \
+	sys_trace_k_work_queue_drain_exit(queue, ret)
+#define sys_port_trace_k_work_queue_unplug_enter(queue) \
+	sys_trace_k_work_queue_unplug_enter(queue)
+#define sys_port_trace_k_work_queue_unplug_exit(queue, ret) \
+	sys_trace_k_work_queue_unplug_exit(queue, ret)
 
-#define sys_port_trace_k_work_delayable_init(dwork)
-#define sys_port_trace_k_work_schedule_for_queue_enter(queue, dwork, delay)
-#define sys_port_trace_k_work_schedule_for_queue_exit(queue, dwork, delay,     \
-						      ret)
-#define sys_port_trace_k_work_schedule_enter(dwork, delay)
-#define sys_port_trace_k_work_schedule_exit(dwork, delay, ret)
-#define sys_port_trace_k_work_reschedule_for_queue_enter(queue, dwork, delay)
-#define sys_port_trace_k_work_reschedule_for_queue_exit(queue, dwork, delay,   \
-							ret)
-#define sys_port_trace_k_work_reschedule_enter(dwork, delay)
-#define sys_port_trace_k_work_reschedule_exit(dwork, delay, ret)
-#define sys_port_trace_k_work_flush_delayable_enter(dwork, sync)
-#define sys_port_trace_k_work_flush_delayable_exit(dwork, sync, ret)
-#define sys_port_trace_k_work_cancel_delayable_enter(dwork)
-#define sys_port_trace_k_work_cancel_delayable_exit(dwork, ret)
-#define sys_port_trace_k_work_cancel_delayable_sync_enter(dwork, sync)
-#define sys_port_trace_k_work_cancel_delayable_sync_exit(dwork, sync, ret)
+#define sys_port_trace_k_work_delayable_init(dwork) \
+	sys_trace_k_work_delayable_init(dwork)
+#define sys_port_trace_k_work_schedule_for_queue_enter(queue, dwork, delay) \
+	sys_trace_k_work_schedule_for_queue_enter(queue, dwork, delay)
+#define sys_port_trace_k_work_schedule_for_queue_exit(queue, dwork, delay, ret) \
+	sys_trace_k_work_schedule_for_queue_exit(queue, dwork, delay, ret)
+#define sys_port_trace_k_work_schedule_enter(dwork, delay) \
+	sys_trace_k_work_schedule_enter(dwork, delay)
+#define sys_port_trace_k_work_schedule_exit(dwork, delay, ret) \
+	sys_trace_k_work_schedule_exit(dwork, delay, ret)
+#define sys_port_trace_k_work_reschedule_for_queue_enter(queue, dwork, delay) \
+	sys_trace_k_work_reschedule_for_queue_enter(queue, dwork, delay)
+#define sys_port_trace_k_work_reschedule_for_queue_exit(queue, dwork, delay, ret) \
+	sys_trace_k_work_reschedule_for_queue_exit(queue, dwork, delay, ret)
+#define sys_port_trace_k_work_reschedule_enter(dwork, delay) \
+	sys_trace_k_work_reschedule_enter(dwork, delay)
+#define sys_port_trace_k_work_reschedule_exit(dwork, delay, ret) \
+	sys_trace_k_work_reschedule_exit(dwork, delay, ret)
+#define sys_port_trace_k_work_flush_delayable_enter(dwork, sync) \
+	sys_trace_k_work_flush_delayable_enter(dwork, sync)
+#define sys_port_trace_k_work_flush_delayable_exit(dwork, sync, ret) \
+	sys_trace_k_work_flush_delayable_exit(dwork, sync, ret)
+#define sys_port_trace_k_work_cancel_delayable_enter(dwork) \
+	sys_trace_k_work_cancel_delayable_enter(dwork)
+#define sys_port_trace_k_work_cancel_delayable_exit(dwork, ret) \
+	sys_trace_k_work_cancel_delayable_exit(dwork, ret)
+#define sys_port_trace_k_work_cancel_delayable_sync_enter(dwork, sync) \
+	sys_trace_k_work_cancel_delayable_sync_enter(dwork, sync)
+#define sys_port_trace_k_work_cancel_delayable_sync_exit(dwork, sync, ret) \
+	sys_trace_k_work_cancel_delayable_sync_exit(dwork, sync, ret)
 
-#define sys_port_trace_k_work_poll_init_enter(work)
-#define sys_port_trace_k_work_poll_init_exit(work)
-#define sys_port_trace_k_work_poll_submit_to_queue_enter(work_q, work,         \
-							 timeout)
-#define sys_port_trace_k_work_poll_submit_to_queue_blocking(work_q, work,      \
-							    timeout)
-#define sys_port_trace_k_work_poll_submit_to_queue_exit(work_q, work, timeout, \
-							ret)
-#define sys_port_trace_k_work_poll_submit_enter(work, timeout)
-#define sys_port_trace_k_work_poll_submit_exit(work, timeout, ret)
-#define sys_port_trace_k_work_poll_cancel_enter(work)
-#define sys_port_trace_k_work_poll_cancel_exit(work, ret)
+#define sys_port_trace_k_work_poll_init_enter(work) \
+	sys_trace_k_work_poll_init_enter(work)
+#define sys_port_trace_k_work_poll_init_exit(work) \
+	sys_trace_k_work_poll_init_exit(work)
+#define sys_port_trace_k_work_poll_submit_to_queue_enter(work_q, work, timeout) \
+	sys_trace_k_work_poll_submit_to_queue_enter(work_q, work, timeout)
+#define sys_port_trace_k_work_poll_submit_to_queue_blocking(work_q, work, timeout) \
+	sys_trace_k_work_poll_submit_to_queue_blocking(work_q, work, timeout)
+#define sys_port_trace_k_work_poll_submit_to_queue_exit(work_q, work, timeout, ret) \
+	sys_trace_k_work_poll_submit_to_queue_exit(work_q, work, timeout, ret)
+#define sys_port_trace_k_work_poll_submit_enter(work, timeout) \
+	sys_trace_k_work_poll_submit_enter(work, timeout)
+#define sys_port_trace_k_work_poll_submit_exit(work, timeout, ret) \
+	sys_trace_k_work_poll_submit_exit(work, timeout, ret)
+#define sys_port_trace_k_work_poll_cancel_enter(work) \
+	sys_trace_k_work_poll_cancel_enter(work)
+#define sys_port_trace_k_work_poll_cancel_exit(work, ret) \
+	sys_trace_k_work_poll_cancel_exit(work, ret)
 
-#define sys_port_trace_k_poll_api_event_init(event)
-#define sys_port_trace_k_poll_api_poll_enter(events)
-#define sys_port_trace_k_poll_api_poll_exit(events, ret)
-#define sys_port_trace_k_poll_api_signal_init(signal)
-#define sys_port_trace_k_poll_api_signal_reset(signal)
-#define sys_port_trace_k_poll_api_signal_check(signal)
-#define sys_port_trace_k_poll_api_signal_raise(signal, ret)
+#define sys_port_trace_k_poll_api_event_init(event) sys_trace_k_poll_api_event_init(event)
+#define sys_port_trace_k_poll_api_poll_enter(events) sys_trace_k_poll_api_poll_enter(events)
+#define sys_port_trace_k_poll_api_poll_exit(events, ret) sys_trace_k_poll_api_poll_exit(events, ret)
+#define sys_port_trace_k_poll_api_signal_init(sig) \
+	sys_trace_k_poll_api_signal_init(sig)
+#define sys_port_trace_k_poll_api_signal_reset(sig) \
+	sys_trace_k_poll_api_signal_reset(sig)
+#define sys_port_trace_k_poll_api_signal_check(sig) \
+	sys_trace_k_poll_api_signal_check(sig)
+#define sys_port_trace_k_poll_api_signal_raise(sig, ret) \
+	sys_trace_k_poll_api_signal_raise(sig, ret)
 
-#define sys_port_trace_k_sem_init(sem, ret)
-#define sys_port_trace_k_sem_give_enter(sem)
-#define sys_port_trace_k_sem_give_exit(sem)
-#define sys_port_trace_k_sem_take_enter(sem, timeout)
-#define sys_port_trace_k_sem_take_blocking(sem, timeout)
-#define sys_port_trace_k_sem_take_exit(sem, timeout, ret)
-#define sys_port_trace_k_sem_reset(sem)
+#define sys_port_trace_k_sem_init(sem, ret) sys_trace_k_sem_init(sem, ret)
+#define sys_port_trace_k_sem_give_enter(sem) sys_trace_k_sem_give_enter(sem)
+#define sys_port_trace_k_sem_give_exit(sem) sys_trace_k_sem_give_exit(sem)
+#define sys_port_trace_k_sem_take_enter(sem, timeout) \
+	sys_trace_k_sem_take_enter(sem, timeout)
+#define sys_port_trace_k_sem_take_blocking(sem, timeout) \
+	sys_trace_k_sem_take_blocking(sem, timeout)
+#define sys_port_trace_k_sem_take_exit(sem, timeout, ret) \
+	sys_trace_k_sem_take_exit(sem, timeout, ret)
+#define sys_port_trace_k_sem_reset(sem) sys_trace_k_sem_reset(sem)
 
-#define sys_port_trace_k_mutex_init(mutex, ret)
-#define sys_port_trace_k_mutex_lock_enter(mutex, timeout)
-#define sys_port_trace_k_mutex_lock_blocking(mutex, timeout)
-#define sys_port_trace_k_mutex_lock_exit(mutex, timeout, ret)
-#define sys_port_trace_k_mutex_unlock_enter(mutex)
-#define sys_port_trace_k_mutex_unlock_exit(mutex, ret)
+#define sys_port_trace_k_mutex_init(mutex, ret) \
+	sys_trace_k_mutex_init(mutex, ret)
+#define sys_port_trace_k_mutex_lock_enter(mutex, timeout) \
+	sys_trace_k_mutex_lock_enter(mutex, timeout)
+#define sys_port_trace_k_mutex_lock_blocking(mutex, timeout) \
+	sys_trace_k_mutex_lock_blocking(mutex, timeout)
+#define sys_port_trace_k_mutex_lock_exit(mutex, timeout, ret) \
+	sys_trace_k_mutex_lock_exit(mutex, timeout, ret)
+#define sys_port_trace_k_mutex_unlock_enter(mutex) \
+	sys_trace_k_mutex_unlock_enter(mutex)
+#define sys_port_trace_k_mutex_unlock_exit(mutex, ret) \
+	sys_trace_k_mutex_unlock_exit(mutex, ret)
 
-#define sys_port_trace_k_condvar_init(condvar, ret)
-#define sys_port_trace_k_condvar_signal_enter(condvar)
-#define sys_port_trace_k_condvar_signal_blocking(condvar, timeout)
-#define sys_port_trace_k_condvar_signal_exit(condvar, ret)
-#define sys_port_trace_k_condvar_broadcast_enter(condvar)
-#define sys_port_trace_k_condvar_broadcast_exit(condvar, ret)
-#define sys_port_trace_k_condvar_wait_enter(condvar, timeout)
-#define sys_port_trace_k_condvar_wait_exit(condvar, timeout, ret)
+#define sys_port_trace_k_condvar_init(condvar, ret) \
+	sys_trace_k_condvar_init(condvar, ret)
+#define sys_port_trace_k_condvar_signal_enter(condvar) \
+	sys_trace_k_condvar_signal_enter(condvar)
+#define sys_port_trace_k_condvar_signal_blocking(condvar, timeout) \
+	sys_trace_k_condvar_signal_blocking(condvar, timeout)
+#define sys_port_trace_k_condvar_signal_exit(condvar, ret) \
+	sys_trace_k_condvar_signal_exit(condvar, ret)
+#define sys_port_trace_k_condvar_broadcast_enter(condvar) \
+	sys_trace_k_condvar_broadcast_enter(condvar)
+#define sys_port_trace_k_condvar_broadcast_exit(condvar, ret) \
+	sys_trace_k_condvar_broadcast_exit(condvar, ret)
+#define sys_port_trace_k_condvar_wait_enter(condvar, timeout) \
+	sys_trace_k_condvar_wait_enter(condvar, timeout)
+#define sys_port_trace_k_condvar_wait_exit(condvar, timeout, ret) \
+	sys_trace_k_condvar_wait_exit(condvar, timeout, ret)
 
-#define sys_port_trace_k_queue_init(queue)
-#define sys_port_trace_k_queue_cancel_wait(queue)
-#define sys_port_trace_k_queue_queue_insert_enter(queue, alloc)
-#define sys_port_trace_k_queue_queue_insert_blocking(queue, alloc, timeout)
-#define sys_port_trace_k_queue_queue_insert_exit(queue, alloc, ret)
-#define sys_port_trace_k_queue_append_enter(queue)
-#define sys_port_trace_k_queue_append_exit(queue)
-#define sys_port_trace_k_queue_alloc_append_enter(queue)
-#define sys_port_trace_k_queue_alloc_append_exit(queue, ret)
-#define sys_port_trace_k_queue_prepend_enter(queue)
-#define sys_port_trace_k_queue_prepend_exit(queue)
-#define sys_port_trace_k_queue_alloc_prepend_enter(queue)
-#define sys_port_trace_k_queue_alloc_prepend_exit(queue, ret)
-#define sys_port_trace_k_queue_insert_enter(queue)
-#define sys_port_trace_k_queue_insert_blocking(queue, timeout)
-#define sys_port_trace_k_queue_insert_exit(queue)
-#define sys_port_trace_k_queue_append_list_enter(queue)
-#define sys_port_trace_k_queue_append_list_exit(queue, ret)
-#define sys_port_trace_k_queue_merge_slist_enter(queue)
-#define sys_port_trace_k_queue_merge_slist_exit(queue, ret)
-#define sys_port_trace_k_queue_get_enter(queue, timeout)
-#define sys_port_trace_k_queue_get_blocking(queue, timeout)
-#define sys_port_trace_k_queue_get_exit(queue, timeout, ret)
-#define sys_port_trace_k_queue_remove_enter(queue)
-#define sys_port_trace_k_queue_remove_exit(queue, ret)
-#define sys_port_trace_k_queue_unique_append_enter(queue)
-#define sys_port_trace_k_queue_unique_append_exit(queue, ret)
-#define sys_port_trace_k_queue_peek_head(queue, ret)
-#define sys_port_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_init(queue) sys_trace_k_queue_init(queue)
+#define sys_port_trace_k_queue_cancel_wait(queue) \
+	sys_trace_k_queue_cancel_wait(queue)
+#define sys_port_trace_k_queue_queue_insert_enter(queue, alloc) \
+	sys_trace_k_queue_queue_insert_enter(queue, alloc)
+#define sys_port_trace_k_queue_queue_insert_blocking(queue, alloc, timeout) \
+	sys_trace_k_queue_queue_insert_blocking(queue, alloc, timeout)
+#define sys_port_trace_k_queue_queue_insert_exit(queue, alloc, ret) \
+	sys_trace_k_queue_queue_insert_exit(queue, alloc, ret)
+#define sys_port_trace_k_queue_append_enter(queue) \
+	sys_trace_k_queue_append_enter(queue)
+#define sys_port_trace_k_queue_append_exit(queue) \
+	sys_trace_k_queue_append_exit(queue)
+#define sys_port_trace_k_queue_alloc_append_enter(queue) \
+	sys_trace_k_queue_alloc_append_enter(queue)
+#define sys_port_trace_k_queue_alloc_append_exit(queue, ret) \
+	sys_trace_k_queue_alloc_append_exit(queue, ret)
+#define sys_port_trace_k_queue_prepend_enter(queue) \
+	sys_trace_k_queue_prepend_enter(queue)
+#define sys_port_trace_k_queue_prepend_exit(queue) \
+	sys_trace_k_queue_prepend_exit(queue)
+#define sys_port_trace_k_queue_alloc_prepend_enter(queue) \
+	sys_trace_k_queue_alloc_prepend_enter(queue)
+#define sys_port_trace_k_queue_alloc_prepend_exit(queue, ret) \
+	sys_trace_k_queue_alloc_prepend_exit(queue, ret)
+#define sys_port_trace_k_queue_insert_enter(queue) \
+	sys_trace_k_queue_insert_enter(queue)
+#define sys_port_trace_k_queue_insert_blocking(queue, timeout) \
+	sys_trace_k_queue_insert_blocking(queue, timeout)
+#define sys_port_trace_k_queue_insert_exit(queue) \
+	sys_trace_k_queue_insert_exit(queue)
+#define sys_port_trace_k_queue_append_list_enter(queue) \
+	sys_trace_k_queue_append_list_enter(queue)
+#define sys_port_trace_k_queue_append_list_exit(queue, ret) \
+	sys_trace_k_queue_append_list_exit(queue, ret)
+#define sys_port_trace_k_queue_merge_slist_enter(queue) \
+	sys_trace_k_queue_merge_slist_enter(queue)
+#define sys_port_trace_k_queue_merge_slist_exit(queue, ret) \
+	sys_trace_k_queue_merge_slist_exit(queue, ret)
+#define sys_port_trace_k_queue_get_enter(queue, timeout) \
+	sys_trace_k_queue_get_enter(queue, timeout)
+#define sys_port_trace_k_queue_get_blocking(queue, timeout) \
+	sys_trace_k_queue_get_blocking(queue, timeout)
+#define sys_port_trace_k_queue_get_exit(queue, timeout, ret) \
+	sys_trace_k_queue_get_exit(queue, timeout, ret)
+#define sys_port_trace_k_queue_remove_enter(queue) \
+	sys_trace_k_queue_remove_enter(queue)
+#define sys_port_trace_k_queue_remove_exit(queue, ret) \
+	sys_trace_k_queue_remove_exit(queue, ret)
+#define sys_port_trace_k_queue_unique_append_enter(queue) \
+	sys_trace_k_queue_unique_append_enter(queue)
+#define sys_port_trace_k_queue_unique_append_exit(queue, ret) \
+	sys_trace_k_queue_unique_append_exit(queue, ret)
+#define sys_port_trace_k_queue_peek_head(queue, ret) \
+	sys_trace_k_queue_peek_head(queue, ret)
+#define sys_port_trace_k_queue_peek_tail(queue, ret) \
+	sys_trace_k_queue_peek_tail(queue, ret)
 
-#define sys_port_trace_k_fifo_init_enter(fifo)
-#define sys_port_trace_k_fifo_init_exit(fifo)
-#define sys_port_trace_k_fifo_cancel_wait_enter(fifo)
-#define sys_port_trace_k_fifo_cancel_wait_exit(fifo)
-#define sys_port_trace_k_fifo_put_enter(fifo, data)
-#define sys_port_trace_k_fifo_put_exit(fifo, data)
-#define sys_port_trace_k_fifo_alloc_put_enter(fifo, data)
-#define sys_port_trace_k_fifo_alloc_put_exit(fifo, data, ret)
-#define sys_port_trace_k_fifo_put_list_enter(fifo, head, tail)
-#define sys_port_trace_k_fifo_put_list_exit(fifo, head, tail)
-#define sys_port_trace_k_fifo_put_slist_enter(fifo, list)
-#define sys_port_trace_k_fifo_put_slist_exit(fifo, list)
-#define sys_port_trace_k_fifo_get_enter(fifo, timeout)
-#define sys_port_trace_k_fifo_get_exit(fifo, timeout, ret)
-#define sys_port_trace_k_fifo_peek_head_enter(fifo)
-#define sys_port_trace_k_fifo_peek_head_exit(fifo, ret)
-#define sys_port_trace_k_fifo_peek_tail_enter(fifo)
-#define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+#define sys_port_trace_k_fifo_init_enter(fifo) \
+	sys_trace_k_fifo_init_enter(fifo)
+#define sys_port_trace_k_fifo_init_exit(fifo) sys_trace_k_fifo_init_exit(fifo)
+#define sys_port_trace_k_fifo_cancel_wait_enter(fifo) \
+	sys_trace_k_fifo_cancel_wait_enter(fifo)
+#define sys_port_trace_k_fifo_cancel_wait_exit(fifo) \
+	sys_trace_k_fifo_cancel_wait_exit(fifo)
+#define sys_port_trace_k_fifo_put_enter(fifo, data) \
+	sys_trace_k_fifo_put_enter(fifo, data)
+#define sys_port_trace_k_fifo_put_exit(fifo, data) \
+	sys_trace_k_fifo_put_exit(fifo, data)
+#define sys_port_trace_k_fifo_alloc_put_enter(fifo, data) \
+	sys_trace_k_fifo_alloc_put_enter(fifo, data)
+#define sys_port_trace_k_fifo_alloc_put_exit(fifo, data, ret) \
+	sys_trace_k_fifo_alloc_put_exit(fifo, data, ret)
+#define sys_port_trace_k_fifo_put_list_enter(fifo, head, tail) \
+	sys_trace_k_fifo_put_list_enter(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_list_exit(fifo, head, tail) \
+	sys_trace_k_fifo_put_list_exit(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_slist_enter(fifo, list) \
+	sys_trace_k_fifo_put_slist_enter(fifo, list)
+#define sys_port_trace_k_fifo_put_slist_exit(fifo, list) \
+	sys_trace_k_fifo_put_slist_exit(fifo, list)
+#define sys_port_trace_k_fifo_get_enter(fifo, timeout) \
+	sys_trace_k_fifo_get_enter(fifo, timeout)
+#define sys_port_trace_k_fifo_get_exit(fifo, timeout, ret) \
+	sys_trace_k_fifo_get_exit(fifo, timeout, ret)
+#define sys_port_trace_k_fifo_peek_head_enter(fifo) \
+	sys_trace_k_fifo_peek_head_enter(fifo)
+#define sys_port_trace_k_fifo_peek_head_exit(fifo, ret) \
+	sys_trace_k_fifo_peek_head_exit(fifo, ret)
+#define sys_port_trace_k_fifo_peek_tail_enter(fifo) \
+	sys_trace_k_fifo_peek_tail_enter(fifo)
+#define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret) \
+	sys_trace_k_fifo_peek_tail_exit(fifo, ret)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)
 #define sys_port_trace_k_lifo_init_exit(lifo)
@@ -316,87 +827,153 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 #define sys_port_trace_k_lifo_get_enter(lifo, timeout)
 #define sys_port_trace_k_lifo_get_exit(lifo, timeout, ret)
 
-#define sys_port_trace_k_stack_init(stack)
-#define sys_port_trace_k_stack_alloc_init_enter(stack)
-#define sys_port_trace_k_stack_alloc_init_exit(stack, ret)
-#define sys_port_trace_k_stack_cleanup_enter(stack)
-#define sys_port_trace_k_stack_cleanup_exit(stack, ret)
-#define sys_port_trace_k_stack_push_enter(stack)
-#define sys_port_trace_k_stack_push_exit(stack, ret)
-#define sys_port_trace_k_stack_pop_enter(stack, timeout)
-#define sys_port_trace_k_stack_pop_blocking(stack, timeout)
-#define sys_port_trace_k_stack_pop_exit(stack, timeout, ret)
+#define sys_port_trace_k_stack_init(stack) sys_trace_k_stack_init(stack)
+#define sys_port_trace_k_stack_alloc_init_enter(stack) \
+	sys_trace_k_stack_alloc_init_enter(stack)
+#define sys_port_trace_k_stack_alloc_init_exit(stack, ret) \
+	sys_trace_k_stack_alloc_init_exit(stack, ret)
+#define sys_port_trace_k_stack_cleanup_enter(stack) \
+	sys_trace_k_stack_cleanup_enter(stack)
+#define sys_port_trace_k_stack_cleanup_exit(stack, ret) \
+	sys_trace_k_stack_cleanup_exit(stack, ret)
+#define sys_port_trace_k_stack_push_enter(stack) \
+	sys_trace_k_stack_push_enter(stack)
+#define sys_port_trace_k_stack_push_exit(stack, ret) \
+	sys_trace_k_stack_push_exit(stack, ret)
+#define sys_port_trace_k_stack_pop_enter(stack, timeout) \
+	sys_trace_k_stack_pop_enter(stack, timeout)
+#define sys_port_trace_k_stack_pop_blocking(stack, timeout) \
+	sys_trace_k_stack_pop_blocking(stack, timeout)
+#define sys_port_trace_k_stack_pop_exit(stack, timeout, ret) \
+	sys_trace_k_stack_pop_exit(stack, timeout, ret)
 
-#define sys_port_trace_k_msgq_init(msgq)
-#define sys_port_trace_k_msgq_alloc_init_enter(msgq)
-#define sys_port_trace_k_msgq_alloc_init_exit(msgq, ret)
-#define sys_port_trace_k_msgq_cleanup_enter(msgq)
-#define sys_port_trace_k_msgq_cleanup_exit(msgq, ret)
-#define sys_port_trace_k_msgq_put_enter(msgq, timeout)
-#define sys_port_trace_k_msgq_put_blocking(msgq, timeout)
-#define sys_port_trace_k_msgq_put_exit(msgq, timeout, ret)
-#define sys_port_trace_k_msgq_put_front_enter(msgq, timeout)
-#define sys_port_trace_k_msgq_put_front_blocking(msgq, timeout)
-#define sys_port_trace_k_msgq_put_front_exit(msgq, timeout, ret)
-#define sys_port_trace_k_msgq_get_enter(msgq, timeout)
-#define sys_port_trace_k_msgq_get_blocking(msgq, timeout)
-#define sys_port_trace_k_msgq_get_exit(msgq, timeout, ret)
-#define sys_port_trace_k_msgq_peek(msgq, ret)
-#define sys_port_trace_k_msgq_purge(msgq)
+#define sys_port_trace_k_msgq_init(msgq) sys_trace_k_msgq_init(msgq)
+#define sys_port_trace_k_msgq_alloc_init_enter(msgq) \
+	sys_trace_k_msgq_alloc_init_enter(msgq)
+#define sys_port_trace_k_msgq_alloc_init_exit(msgq, ret) \
+	sys_trace_k_msgq_alloc_init_exit(msgq, ret)
+#define sys_port_trace_k_msgq_cleanup_enter(msgq) \
+	sys_trace_k_msgq_cleanup_enter(msgq)
+#define sys_port_trace_k_msgq_cleanup_exit(msgq, ret) \
+	sys_trace_k_msgq_cleanup_exit(msgq, ret)
+#define sys_port_trace_k_msgq_put_enter(msgq, timeout) \
+	sys_trace_k_msgq_put_enter(msgq, timeout)
+#define sys_port_trace_k_msgq_put_blocking(msgq, timeout) \
+	sys_trace_k_msgq_put_blocking(msgq, timeout)
+#define sys_port_trace_k_msgq_put_exit(msgq, timeout, ret) \
+	sys_trace_k_msgq_put_exit(msgq, timeout, ret)
+#define sys_port_trace_k_msgq_put_front_enter(msgq, timeout) \
+	sys_trace_k_msgq_put_front_enter(msgq, timeout)
+#define sys_port_trace_k_msgq_put_front_blocking(msgq, timeout) \
+	sys_trace_k_msgq_put_front_blocking(msgq, timeout)
+#define sys_port_trace_k_msgq_put_front_exit(msgq, timeout, ret) \
+	sys_trace_k_msgq_put_front_exit(msgq, timeout, ret)
+#define sys_port_trace_k_msgq_get_enter(msgq, timeout) \
+	sys_trace_k_msgq_get_enter(msgq, timeout)
+#define sys_port_trace_k_msgq_get_blocking(msgq, timeout) \
+	sys_trace_k_msgq_get_blocking(msgq, timeout)
+#define sys_port_trace_k_msgq_get_exit(msgq, timeout, ret) \
+	sys_trace_k_msgq_get_exit(msgq, timeout, ret)
+#define sys_port_trace_k_msgq_peek(msgq, ret) sys_trace_k_msgq_peek(msgq, ret)
+#define sys_port_trace_k_msgq_purge(msgq) sys_trace_k_msgq_purge(msgq)
 
-#define sys_port_trace_k_mbox_init(mbox)
-#define sys_port_trace_k_mbox_message_put_enter(mbox, timeout)
-#define sys_port_trace_k_mbox_message_put_blocking(mbox, timeout)
-#define sys_port_trace_k_mbox_message_put_exit(mbox, timeout, ret)
-#define sys_port_trace_k_mbox_put_enter(mbox, timeout)
-#define sys_port_trace_k_mbox_put_exit(mbox, timeout, ret)
-#define sys_port_trace_k_mbox_async_put_enter(mbox, sem)
-#define sys_port_trace_k_mbox_async_put_exit(mbox, sem)
-#define sys_port_trace_k_mbox_get_enter(mbox, timeout)
-#define sys_port_trace_k_mbox_get_blocking(mbox, timeout)
-#define sys_port_trace_k_mbox_get_exit(mbox, timeout, ret)
-#define sys_port_trace_k_mbox_data_get(rx_msg)
+#define sys_port_trace_k_mbox_init(mbox) sys_trace_k_mbox_init(mbox)
+#define sys_port_trace_k_mbox_message_put_enter(mbox, timeout) \
+	sys_trace_k_mbox_message_put_enter(mbox, timeout)
+#define sys_port_trace_k_mbox_message_put_blocking(mbox, timeout) \
+	sys_trace_k_mbox_message_put_blocking(mbox, timeout)
+#define sys_port_trace_k_mbox_message_put_exit(mbox, timeout, ret) \
+	sys_trace_k_mbox_message_put_exit(mbox, timeout, ret)
+#define sys_port_trace_k_mbox_put_enter(mbox, timeout) \
+	sys_trace_k_mbox_put_enter(mbox, timeout)
+#define sys_port_trace_k_mbox_put_exit(mbox, timeout, ret) \
+	sys_trace_k_mbox_put_exit(mbox, timeout, ret)
+#define sys_port_trace_k_mbox_async_put_enter(mbox, sem) \
+	sys_trace_k_mbox_async_put_enter(mbox, sem)
+#define sys_port_trace_k_mbox_async_put_exit(mbox, sem) \
+	sys_trace_k_mbox_async_put_exit(mbox, sem)
+#define sys_port_trace_k_mbox_get_enter(mbox, timeout) \
+	sys_trace_k_mbox_get_enter(mbox, timeout)
+#define sys_port_trace_k_mbox_get_blocking(mbox, timeout) \
+	sys_trace_k_mbox_get_blocking(mbox, timeout)
+#define sys_port_trace_k_mbox_get_exit(mbox, timeout, ret) \
+	sys_trace_k_mbox_get_exit(mbox, timeout, ret)
+#define sys_port_trace_k_mbox_data_get(rx_msg) \
+	sys_trace_k_mbox_data_get(rx_msg)
 
-#define sys_port_trace_k_pipe_init(pipe, buffer, size)
-#define sys_port_trace_k_pipe_reset_enter(pipe)
-#define sys_port_trace_k_pipe_reset_exit(pipe)
-#define sys_port_trace_k_pipe_close_enter(pipe)
-#define sys_port_trace_k_pipe_close_exit(pipe)
-#define sys_port_trace_k_pipe_write_enter(pipe, data, len, timeout)
-#define sys_port_trace_k_pipe_write_blocking(pipe, timeout)
-#define sys_port_trace_k_pipe_write_exit(pipe, ret)
-#define sys_port_trace_k_pipe_read_enter(pipe, data, len, timeout)
-#define sys_port_trace_k_pipe_read_blocking(pipe, timeout)
-#define sys_port_trace_k_pipe_read_exit(pipe, ret)
+#define sys_port_trace_k_pipe_init(pipe, buffer, size) \
+	sys_trace_k_pipe_init(pipe, buffer, size)
+#define sys_port_trace_k_pipe_reset_enter(pipe) \
+	sys_trace_k_pipe_reset_enter(pipe)
+#define sys_port_trace_k_pipe_reset_exit(pipe) \
+	sys_trace_k_pipe_reset_exit(pipe)
+#define sys_port_trace_k_pipe_close_enter(pipe) \
+	sys_trace_k_pipe_close_enter(pipe)
+#define sys_port_trace_k_pipe_close_exit(pipe) \
+	sys_trace_k_pipe_close_exit(pipe)
+#define sys_port_trace_k_pipe_write_enter(pipe, data, len, timeout) \
+	sys_trace_k_pipe_write_enter(pipe, data, len, timeout)
+#define sys_port_trace_k_pipe_write_blocking(pipe, timeout) \
+	sys_trace_k_pipe_write_blocking(pipe, timeout)
+#define sys_port_trace_k_pipe_write_exit(pipe, ret) \
+	sys_trace_k_pipe_write_exit(pipe, ret)
+#define sys_port_trace_k_pipe_read_enter(pipe, data, len, timeout) \
+	sys_trace_k_pipe_read_enter(pipe, data, len, timeout)
+#define sys_port_trace_k_pipe_read_blocking(pipe, timeout) \
+	sys_trace_k_pipe_read_blocking(pipe, timeout)
+#define sys_port_trace_k_pipe_read_exit(pipe, ret) \
+	sys_trace_k_pipe_read_exit(pipe, ret)
 
-#define sys_port_trace_k_heap_init(heap)
-#define sys_port_trace_k_heap_aligned_alloc_enter(heap, timeout)
-#define sys_port_trace_k_heap_alloc_helper_blocking(heap, timeout)
-#define sys_port_trace_k_heap_aligned_alloc_exit(heap, timeout, ret)
-#define sys_port_trace_k_heap_alloc_enter(heap, timeout)
-#define sys_port_trace_k_heap_alloc_exit(heap, timeout, ret)
-#define sys_port_trace_k_heap_calloc_enter(heap, timeout)
-#define sys_port_trace_k_heap_calloc_exit(heap, timeout, ret)
-#define sys_port_trace_k_heap_free(heap)
-#define sys_port_trace_k_heap_realloc_enter(h, ptr, bytes, timeout)
-#define sys_port_trace_k_heap_realloc_exit(h, ptr, bytes, timeout, ret)
-#define sys_port_trace_k_heap_sys_k_aligned_alloc_enter(heap)
-#define sys_port_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_malloc_enter(heap)
-#define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref)
-#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref)
-#define sys_port_trace_k_heap_sys_k_calloc_enter(heap)
-#define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret)
-#define sys_port_trace_k_heap_sys_k_realloc_enter(heap, ptr)
-#define sys_port_trace_k_heap_sys_k_realloc_exit(heap, ptr, ret)
+#define sys_port_trace_k_heap_init(heap) sys_trace_k_heap_init(heap)
+#define sys_port_trace_k_heap_aligned_alloc_enter(heap, timeout) \
+	sys_trace_k_heap_aligned_alloc_enter(heap, timeout)
+#define sys_port_trace_k_heap_alloc_helper_blocking(heap, timeout) \
+	sys_trace_k_heap_alloc_helper_blocking(heap, timeout)
+#define sys_port_trace_k_heap_aligned_alloc_exit(heap, timeout, ret) \
+	sys_trace_k_heap_aligned_alloc_exit(heap, timeout, ret)
+#define sys_port_trace_k_heap_alloc_enter(heap, timeout) \
+	sys_trace_k_heap_alloc_enter(heap, timeout)
+#define sys_port_trace_k_heap_alloc_exit(heap, timeout, ret) \
+	sys_trace_k_heap_alloc_exit(heap, timeout, ret)
+#define sys_port_trace_k_heap_calloc_enter(heap, timeout) \
+	sys_trace_k_heap_calloc_enter(heap, timeout)
+#define sys_port_trace_k_heap_calloc_exit(heap, timeout, ret) \
+	sys_trace_k_heap_calloc_exit(heap, timeout, ret)
+#define sys_port_trace_k_heap_free(heap) sys_trace_k_heap_free(heap)
+#define sys_port_trace_k_heap_realloc_enter(h, ptr, bytes, timeout) \
+	sys_trace_k_heap_realloc_enter(h, ptr, bytes, timeout)
+#define sys_port_trace_k_heap_realloc_exit(h, ptr, bytes, timeout, ret) \
+	sys_trace_k_heap_realloc_exit(h, ptr, bytes, timeout, ret)
+#define sys_port_trace_k_heap_sys_k_aligned_alloc_enter(heap) \
+	sys_trace_k_heap_sys_k_aligned_alloc_enter(heap)
+#define sys_port_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret) \
+	sys_trace_k_heap_sys_k_aligned_alloc_exit(heap, ret)
+#define sys_port_trace_k_heap_sys_k_malloc_enter(heap) \
+	sys_trace_k_heap_sys_k_malloc_enter(heap)
+#define sys_port_trace_k_heap_sys_k_malloc_exit(heap, ret) \
+	sys_trace_k_heap_sys_k_malloc_exit(heap, ret)
+#define sys_port_trace_k_heap_sys_k_free_enter(heap, heap_ref) \
+	sys_trace_k_heap_sys_k_free_enter(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_free_exit(heap, heap_ref) \
+	sys_trace_k_heap_sys_k_free_exit(heap, heap_ref)
+#define sys_port_trace_k_heap_sys_k_calloc_enter(heap) \
+	sys_trace_k_heap_sys_k_calloc_enter(heap)
+#define sys_port_trace_k_heap_sys_k_calloc_exit(heap, ret) \
+	sys_trace_k_heap_sys_k_calloc_exit(heap, ret)
+#define sys_port_trace_k_heap_sys_k_realloc_enter(heap, ptr) \
+	sys_trace_k_heap_sys_k_realloc_enter(heap, ptr)
+#define sys_port_trace_k_heap_sys_k_realloc_exit(heap, ptr, ret) \
+	sys_trace_k_heap_sys_k_realloc_exit(heap, ptr, ret)
 
-#define sys_port_trace_k_mem_slab_init(slab, rc)
-#define sys_port_trace_k_mem_slab_alloc_enter(slab, timeout)
-#define sys_port_trace_k_mem_slab_alloc_blocking(slab, timeout)
-#define sys_port_trace_k_mem_slab_alloc_exit(slab, timeout, ret)
-#define sys_port_trace_k_mem_slab_free_enter(slab)
-#define sys_port_trace_k_mem_slab_free_exit(slab)
+#define sys_port_trace_k_mem_slab_init(slab, rc) sys_trace_k_mem_slab_init(slab, rc)
+#define sys_port_trace_k_mem_slab_alloc_enter(slab, timeout) \
+	sys_trace_k_mem_slab_alloc_enter(slab, timeout)
+#define sys_port_trace_k_mem_slab_alloc_blocking(slab, timeout) \
+	sys_trace_k_mem_slab_alloc_blocking(slab, timeout)
+#define sys_port_trace_k_mem_slab_alloc_exit(slab, timeout, ret) \
+	sys_trace_k_mem_slab_alloc_exit(slab, timeout, ret)
+#define sys_port_trace_k_mem_slab_free_enter(slab) sys_trace_k_mem_slab_free_enter(slab)
+#define sys_port_trace_k_mem_slab_free_exit(slab) sys_trace_k_mem_slab_free_exit(slab)
 
 #define sys_port_trace_k_timer_init(timer)					\
 					sys_trace_timer_init(timer)
@@ -419,134 +996,190 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)			\
 					sys_trace_timer_stop_fn_expiry_exit(timer)
 
-#define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, events_mask)
-#define sys_port_trace_k_event_post_exit(event, events, events_mask)
-#define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
-#define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
-#define sys_port_trace_k_event_wait_exit(event, events, ret)
+#define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask) \
+	sys_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask) \
+	sys_trace_k_event_post_exit(event, events, events_mask)
+#define sys_port_trace_k_event_wait_enter(event, events, options, timeout) \
+	sys_trace_k_event_wait_enter(event, events, options, timeout)
+#define sys_port_trace_k_event_wait_blocking(event, events, options, timeout) \
+	sys_trace_k_event_wait_blocking(event, events, options, timeout)
+#define sys_port_trace_k_event_wait_exit(event, events, ret) \
+	sys_trace_k_event_wait_exit(event, events, ret)
 
-#define sys_port_trace_k_thread_abort_exit(thread)
-#define sys_port_trace_k_thread_abort_enter(thread)
-#define sys_port_trace_k_thread_resume_exit(thread)
+#define sys_port_trace_pm_system_suspend_enter(ticks) \
+	sys_trace_pm_system_suspend_enter(ticks)
+#define sys_port_trace_pm_system_suspend_exit(ticks, state) \
+	sys_trace_pm_system_suspend_exit(ticks, state)
 
-#define sys_port_trace_pm_system_suspend_enter(ticks)
-#define sys_port_trace_pm_system_suspend_exit(ticks, state)
+#define sys_port_trace_pm_device_runtime_get_enter(dev) \
+	sys_trace_pm_device_runtime_get_enter(dev)
+#define sys_port_trace_pm_device_runtime_get_exit(dev, ret) \
+	sys_trace_pm_device_runtime_get_exit(dev, ret)
+#define sys_port_trace_pm_device_runtime_put_enter(dev) \
+	sys_trace_pm_device_runtime_put_enter(dev)
+#define sys_port_trace_pm_device_runtime_put_exit(dev, ret) \
+	sys_trace_pm_device_runtime_put_exit(dev, ret)
+#define sys_port_trace_pm_device_runtime_put_async_enter(dev, delay) \
+	sys_trace_pm_device_runtime_put_async_enter(dev, delay)
+#define sys_port_trace_pm_device_runtime_put_async_exit(dev, delay, ret) \
+	sys_trace_pm_device_runtime_put_async_exit(dev, delay, ret)
+#define sys_port_trace_pm_device_runtime_enable_enter(dev) \
+	sys_trace_pm_device_runtime_enable_enter(dev)
+#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret) \
+	sys_trace_pm_device_runtime_enable_exit(dev, ret)
+#define sys_port_trace_pm_device_runtime_disable_enter(dev) \
+	sys_trace_pm_device_runtime_disable_enter(dev)
+#define sys_port_trace_pm_device_runtime_disable_exit(dev, ret) \
+	sys_trace_pm_device_runtime_disable_exit(dev, ret)
 
-#define sys_port_trace_pm_device_runtime_get_enter(dev)
-#define sys_port_trace_pm_device_runtime_get_exit(dev, ret)
-#define sys_port_trace_pm_device_runtime_put_enter(dev)
-#define sys_port_trace_pm_device_runtime_put_exit(dev, ret)
-#define sys_port_trace_pm_device_runtime_put_async_enter(dev, delay)
-#define sys_port_trace_pm_device_runtime_put_async_exit(dev, delay, ret)
-#define sys_port_trace_pm_device_runtime_enable_enter(dev)
-#define sys_port_trace_pm_device_runtime_enable_exit(dev, ret)
-#define sys_port_trace_pm_device_runtime_disable_enter(dev)
-#define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
+#define sys_port_trace_socket_init(sock, family, type, proto) \
+	sys_trace_socket_init(sock, family, type, proto)
+#define sys_port_trace_socket_close_enter(sock) \
+	sys_trace_socket_close_enter(sock)
+#define sys_port_trace_socket_close_exit(sock, ret) \
+	sys_trace_socket_close_exit(sock, ret)
+#define sys_port_trace_socket_shutdown_enter(sock, how) \
+	sys_trace_socket_shutdown_enter(sock, how)
+#define sys_port_trace_socket_shutdown_exit(sock, ret) \
+	sys_trace_socket_shutdown_exit(sock, ret)
+#define sys_port_trace_socket_bind_enter(sock, addr, addrlen) \
+	sys_trace_socket_bind_enter(sock, addr, addrlen)
+#define sys_port_trace_socket_bind_exit(sock, ret) \
+	sys_trace_socket_bind_exit(sock, ret)
+#define sys_port_trace_socket_connect_enter(sock, addr, addrlen) \
+	sys_trace_socket_connect_enter(sock, addr, addrlen)
+#define sys_port_trace_socket_connect_exit(sock, ret) \
+	sys_trace_socket_connect_exit(sock, ret)
+#define sys_port_trace_socket_listen_enter(sock, backlog) \
+	sys_trace_socket_listen_enter(sock, backlog)
+#define sys_port_trace_socket_listen_exit(sock, ret) \
+	sys_trace_socket_listen_exit(sock, ret)
+#define sys_port_trace_socket_accept_enter(sock) \
+	sys_trace_socket_accept_enter(sock)
+#define sys_port_trace_socket_accept_exit(sock, addr, addrlen, ret) \
+	sys_trace_socket_accept_exit(sock, addr, addrlen, ret)
+#define sys_port_trace_socket_sendto_enter(sock, len, flags, dest_addr, addrlen) \
+	sys_trace_socket_sendto_enter(sock, len, flags, dest_addr, addrlen)
+#define sys_port_trace_socket_sendto_exit(sock, ret) \
+	sys_trace_socket_sendto_exit(sock, ret)
+#define sys_port_trace_socket_sendmsg_enter(sock, msg, flags) \
+	sys_trace_socket_sendmsg_enter(sock, msg, flags)
+#define sys_port_trace_socket_sendmsg_exit(sock, ret) \
+	sys_trace_socket_sendmsg_exit(sock, ret)
+#define sys_port_trace_socket_recvfrom_enter(sock, max_len, flags, addr, addrlen) \
+	sys_trace_socket_recvfrom_enter(sock, max_len, flags, addr, addrlen)
+#define sys_port_trace_socket_recvfrom_exit(sock, src_addr, addrlen, ret) \
+	sys_trace_socket_recvfrom_exit(sock, src_addr, addrlen, ret)
+#define sys_port_trace_socket_recvmsg_enter(sock, msg, flags) \
+	sys_trace_socket_recvmsg_enter(sock, msg, flags)
+#define sys_port_trace_socket_recvmsg_exit(sock, msg, ret) \
+	sys_trace_socket_recvmsg_exit(sock, msg, ret)
+#define sys_port_trace_socket_fcntl_enter(sock, cmd, flags) \
+	sys_trace_socket_fcntl_enter(sock, cmd, flags)
+#define sys_port_trace_socket_fcntl_exit(sock, ret) \
+	sys_trace_socket_fcntl_exit(sock, ret)
+#define sys_port_trace_socket_ioctl_enter(sock, req) \
+	sys_trace_socket_ioctl_enter(sock, req)
+#define sys_port_trace_socket_ioctl_exit(sock, ret) \
+	sys_trace_socket_ioctl_exit(sock, ret)
+#define sys_port_trace_socket_poll_enter(fds, nfds, timeout) \
+	sys_trace_socket_poll_enter(fds, nfds, timeout)
+#define sys_port_trace_socket_poll_exit(fds, nfds, ret) \
+	sys_trace_socket_poll_exit(fds, nfds, ret)
+#define sys_port_trace_socket_getsockopt_enter(sock, level, optname) \
+	sys_trace_socket_getsockopt_enter(sock, level, optname)
+#define sys_port_trace_socket_getsockopt_exit(sock, level, optname, optval, optlen, ret) \
+	sys_trace_socket_getsockopt_exit(sock, level, optname, optval, optlen, ret)
+#define sys_port_trace_socket_setsockopt_enter(sock, level, optname, optval, optlen) \
+	sys_trace_socket_setsockopt_enter(sock, level, optname, optval, optlen)
+#define sys_port_trace_socket_setsockopt_exit(sock, ret) \
+	sys_trace_socket_setsockopt_exit(sock, ret)
+#define sys_port_trace_socket_getpeername_enter(sock) \
+	sys_trace_socket_getpeername_enter(sock)
+#define sys_port_trace_socket_getpeername_exit(sock, addr, addrlen, ret) \
+	sys_trace_socket_getpeername_exit(sock, addr, addrlen, ret)
+#define sys_port_trace_socket_getsockname_enter(sock) \
+	sys_trace_socket_getsockname_enter(sock)
+#define sys_port_trace_socket_getsockname_exit(sock, addr, addrlen, ret) \
+	sys_trace_socket_getsockname_exit(sock, addr, addrlen, ret)
+#define sys_port_trace_socket_socketpair_enter(family, type, proto, sv) \
+	sys_trace_socket_socketpair_enter(family, type, proto, sv)
+#define sys_port_trace_socket_socketpair_exit(sockA, sockB, ret) \
+	sys_trace_socket_socketpair_exit(sockA, sockB, ret)
 
-#define sys_port_trace_socket_init(sock, family, type, proto)
-#define sys_port_trace_socket_close_enter(sock)
-#define sys_port_trace_socket_close_exit(sock, ret)
-#define sys_port_trace_socket_shutdown_enter(sock, how)
-#define sys_port_trace_socket_shutdown_exit(sock, ret)
-#define sys_port_trace_socket_bind_enter(sock, addr, addrlen)
-#define sys_port_trace_socket_bind_exit(sock, ret)
-#define sys_port_trace_socket_connect_enter(sock, addr, addrlen)
-#define sys_port_trace_socket_connect_exit(sock, ret)
-#define sys_port_trace_socket_listen_enter(sock, backlog)
-#define sys_port_trace_socket_listen_exit(sock, ret)
-#define sys_port_trace_socket_accept_enter(sock)
-#define sys_port_trace_socket_accept_exit(sock, addr, addrlen, ret)
-#define sys_port_trace_socket_sendto_enter(sock, len, flags, dest_addr, addrlen)
-#define sys_port_trace_socket_sendto_exit(sock, ret)
-#define sys_port_trace_socket_sendmsg_enter(sock, msg, flags)
-#define sys_port_trace_socket_sendmsg_exit(sock, ret)
-#define sys_port_trace_socket_recvfrom_enter(sock, max_len, flags, addr, addrlen)
-#define sys_port_trace_socket_recvfrom_exit(sock, src_addr, addrlen, ret)
-#define sys_port_trace_socket_recvmsg_enter(sock, msg, flags)
-#define sys_port_trace_socket_recvmsg_exit(sock, msg, ret)
-#define sys_port_trace_socket_fcntl_enter(sock, cmd, flags)
-#define sys_port_trace_socket_fcntl_exit(sock, ret)
-#define sys_port_trace_socket_ioctl_enter(sock, req)
-#define sys_port_trace_socket_ioctl_exit(sock, ret)
-#define sys_port_trace_socket_poll_enter(fds, nfds, timeout)
-#define sys_port_trace_socket_poll_exit(fds, nfds, ret)
-#define sys_port_trace_socket_getsockopt_enter(sock, level, optname)
-#define sys_port_trace_socket_getsockopt_exit(sock, level, optname, optval, optlen, ret)
-#define sys_port_trace_socket_setsockopt_enter(sock, level, optname, optval, optlen)
-#define sys_port_trace_socket_setsockopt_exit(sock, ret)
-#define sys_port_trace_socket_getpeername_enter(sock)
-#define sys_port_trace_socket_getpeername_exit(sock, addr, addrlen, ret)
-#define sys_port_trace_socket_getsockname_enter(sock)
-#define sys_port_trace_socket_getsockname_exit(sock, addr, addrlen, ret)
-#define sys_port_trace_socket_socketpair_enter(family, type, proto, sv)
-#define sys_port_trace_socket_socketpair_exit(sockA, sockB, ret)
-
-#define sys_port_trace_net_recv_data_enter(iface, pkt)
-#define sys_port_trace_net_recv_data_exit(iface, pkt, ret)
-#define sys_port_trace_net_send_data_enter(pkt)
-#define sys_port_trace_net_send_data_exit(pkt, ret)
-#define sys_port_trace_net_rx_time(pkt, end_time)
-#define sys_port_trace_net_tx_time(pkt, end_time)
+#define sys_port_trace_net_recv_data_enter(iface, pkt) \
+	sys_trace_net_recv_data_enter(iface, pkt)
+#define sys_port_trace_net_recv_data_exit(iface, pkt, ret) \
+	sys_trace_net_recv_data_exit(iface, pkt, ret)
+#define sys_port_trace_net_send_data_enter(pkt) \
+	sys_trace_net_send_data_enter(pkt)
+#define sys_port_trace_net_send_data_exit(pkt, ret) \
+	sys_trace_net_send_data_exit(pkt, ret)
+#define sys_port_trace_net_rx_time(pkt, end_time) \
+	sys_trace_net_rx_time(pkt, end_time)
+#define sys_port_trace_net_tx_time(pkt, end_time) \
+	sys_trace_net_tx_time(pkt, end_time)
 
 #define sys_trace_named_event(name, arg0, arg1)
 
 #define sys_port_trace_gpio_pin_interrupt_configure_enter(port, pin, flags) \
-	sys_trace_gpio_pin_interrupt_configure_enter_user(port, pin, flags)
+	sys_trace_gpio_pin_interrupt_configure_enter(port, pin, flags)
 #define sys_port_trace_gpio_pin_interrupt_configure_exit(port, pin, ret) \
-	sys_trace_gpio_pin_interrupt_configure_exit_user(port, pin, ret)
+	sys_trace_gpio_pin_interrupt_configure_exit(port, pin, ret)
 #define sys_port_trace_gpio_pin_configure_enter(port, pin, flags) \
-	sys_trace_gpio_pin_configure_enter_user(port, pin, flags)
+	sys_trace_gpio_pin_configure_enter(port, pin, flags)
 #define sys_port_trace_gpio_pin_configure_exit(port, pin, ret) \
-	sys_trace_gpio_pin_configure_exit_user(port, pin, ret)
+	sys_trace_gpio_pin_configure_exit(port, pin, ret)
 #define sys_port_trace_gpio_port_get_direction_enter(port, map, inputs, outputs) \
-	sys_trace_gpio_port_get_direction_enter_user(port, map, inputs, outputs)
+	sys_trace_gpio_port_get_direction_enter(port, map, inputs, outputs)
 #define sys_port_trace_gpio_port_get_direction_exit(port, ret) \
-	sys_trace_gpio_port_get_direction_exit_user(port, ret)
+	sys_trace_gpio_port_get_direction_exit(port, ret)
 #define sys_port_trace_gpio_pin_get_config_enter(port, pin, ret) \
-	sys_trace_gpio_pin_get_config_enter_user(port, pin, ret)
+	sys_trace_gpio_pin_get_config_enter(port, pin, ret)
 #define sys_port_trace_gpio_pin_get_config_exit(port, pin, ret) \
-	sys_trace_gpio_pin_get_config_exit_user(port, pin, ret)
+	sys_trace_gpio_pin_get_config_exit(port, pin, ret)
 #define sys_port_trace_gpio_port_get_raw_enter(port, value) \
-	sys_trace_gpio_port_get_raw_enter_user(port, value)
+	sys_trace_gpio_port_get_raw_enter(port, value)
 #define sys_port_trace_gpio_port_get_raw_exit(port, ret) \
-	sys_trace_gpio_port_get_raw_exit_user(port, ret)
+	sys_trace_gpio_port_get_raw_exit(port, ret)
 #define sys_port_trace_gpio_port_set_masked_raw_enter(port, mask, value) \
-	sys_trace_gpio_port_set_masked_raw_enter_user(port, mask, value)
+	sys_trace_gpio_port_set_masked_raw_enter(port, mask, value)
 #define sys_port_trace_gpio_port_set_masked_raw_exit(port, ret) \
-	sys_trace_gpio_port_set_masked_raw_exit_user(port, ret)
+	sys_trace_gpio_port_set_masked_raw_exit(port, ret)
 #define sys_port_trace_gpio_port_set_bits_raw_enter(port, pins) \
-	sys_trace_gpio_port_set_bits_raw_enter_user(port, pins)
+	sys_trace_gpio_port_set_bits_raw_enter(port, pins)
 #define sys_port_trace_gpio_port_set_bits_raw_exit(port, ret) \
-	sys_trace_gpio_port_set_bits_raw_exit_user(port, ret)
+	sys_trace_gpio_port_set_bits_raw_exit(port, ret)
 #define sys_port_trace_gpio_port_clear_bits_raw_enter(port, pins) \
-	sys_trace_gpio_port_clear_bits_raw_enter_user(port, pins)
+	sys_trace_gpio_port_clear_bits_raw_enter(port, pins)
 #define sys_port_trace_gpio_port_clear_bits_raw_exit(port, ret) \
-	sys_trace_gpio_port_clear_bits_raw_exit_user(port, ret)
+	sys_trace_gpio_port_clear_bits_raw_exit(port, ret)
 #define sys_port_trace_gpio_port_toggle_bits_enter(port, pins) \
-	sys_trace_gpio_port_toggle_bits_enter_user(port, pins)
+	sys_trace_gpio_port_toggle_bits_enter(port, pins)
 #define sys_port_trace_gpio_port_toggle_bits_exit(port, ret) \
-	sys_trace_gpio_port_toggle_bits_exit_user(port, ret)
+	sys_trace_gpio_port_toggle_bits_exit(port, ret)
 #define sys_port_trace_gpio_init_callback_enter(callback, handler, pin_mask) \
-	sys_trace_gpio_init_callback_enter_user(callback, handler, pin_mask)
+	sys_trace_gpio_init_callback_enter(callback, handler, pin_mask)
 #define sys_port_trace_gpio_init_callback_exit(callback) \
-	sys_trace_gpio_init_callback_exit_user(callback)
+	sys_trace_gpio_init_callback_exit(callback)
 #define sys_port_trace_gpio_add_callback_enter(port, callback) \
-	sys_trace_gpio_add_callback_enter_user(port, callback)
+	sys_trace_gpio_add_callback_enter(port, callback)
 #define sys_port_trace_gpio_add_callback_exit(port, ret) \
-	sys_trace_gpio_add_callback_exit_user(port, ret)
+	sys_trace_gpio_add_callback_exit(port, ret)
 #define sys_port_trace_gpio_remove_callback_enter(port, callback) \
-	sys_trace_gpio_remove_callback_enter_user(port, callback)
+	sys_trace_gpio_remove_callback_enter(port, callback)
 #define sys_port_trace_gpio_remove_callback_exit(port, ret) \
-	sys_trace_gpio_remove_callback_exit_user(port, ret)
+	sys_trace_gpio_remove_callback_exit(port, ret)
 #define sys_port_trace_gpio_get_pending_int_enter(dev) \
-	sys_trace_gpio_get_pending_int_enter_user(dev)
+	sys_trace_gpio_get_pending_int_enter(dev)
 #define sys_port_trace_gpio_get_pending_int_exit(dev, ret) \
-	sys_trace_gpio_get_pending_int_exit_user(dev, ret)
+	sys_trace_gpio_get_pending_int_exit(dev, ret)
 #define sys_port_trace_gpio_fire_callbacks_enter(list, port, pins) \
-	sys_trace_gpio_fire_callbacks_enter_user(list, port, pins)
+	sys_trace_gpio_fire_callbacks_enter(list, port, pins)
 #define sys_port_trace_gpio_fire_callback(port, callback) \
-	sys_trace_gpio_fire_callback_user(port, callback)
+	sys_trace_gpio_fire_callback(port, callback)
 
 #define sys_port_trace_rtio_submit_enter(rtio, wait_count)                                         \
 	sys_trace_rtio_submit_enter(rtio, wait_count)


### PR DESCRIPTION
Updated all trace_user macros that were undefined to
empty weak functions.
This helps to override all kernel logs to user defined tracing.

Signed-off-by: Murali Iyengar <murali.r.iyengar@intel.com>