### PR TITLE
usb: device: audio: Fix compiler warning

### DIFF
--- a/subsys/usb/device/class/audio/audio.c
+++ b/subsys/usb/device/class/audio/audio.c
@@ -162,9 +162,9 @@ static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		  \
 		  .in_frame_size = __in_pool_size,			\
 		  .controls = {dev##_controls_##i, NULL},		\
 		  .ch_cnt = {(CH_CNT(dev, i) + 1), 0},			\
-		  .volumes.volume_max = GET_VOLUME(dev, i, volume_max), \
-		  .volumes.volume_min = GET_VOLUME(dev, i, volume_min), \
-		  .volumes.volume_res = GET_VOLUME(dev, i, volume_res), \
+		  .volumes.volume_max = (int16_t)GET_VOLUME(dev, i, volume_max), \
+		  .volumes.volume_min = (int16_t)GET_VOLUME(dev, i, volume_min), \
+		  .volumes.volume_res = (int16_t)GET_VOLUME(dev, i, volume_res), \
 		}
 
 #define DEFINE_AUDIO_DEV_DATA_BIDIR(dev, i, __out_pool, __in_pool_size)	   \
@@ -176,9 +176,9 @@ static struct usb_ep_cfg_data dev##_usb_audio_ep_data_##i[] = {		  \
 		  .controls = {dev##_controls0_##i, dev##_controls1_##i},  \
 		  .ch_cnt = {(CH_CNT(dev##_MIC, i) + 1),		   \
 			     (CH_CNT(dev##_HP, i) + 1)},		   \
-		  .volumes.volume_max = GET_VOLUME(dev, i, volume_max),	   \
-		  .volumes.volume_min = GET_VOLUME(dev, i, volume_min),	   \
-		  .volumes.volume_res = GET_VOLUME(dev, i, volume_res),	   \
+		  .volumes.volume_max = (int16_t)GET_VOLUME(dev, i, volume_max), \
+		  .volumes.volume_min = (int16_t)GET_VOLUME(dev, i, volume_min), \
+		  .volumes.volume_res = (int16_t)GET_VOLUME(dev, i, volume_res), \
 		}
 
 /**


### PR DESCRIPTION
When building sample.usb.legacy.audio.headphones_microphone, clang
warns:

subsys/usb/device/class/audio/audio.c:1053:34: error: implicit
conversion from 'int' to 'int16_t' (aka 'short') changes value from
47616 to -17920 [-Werror,-Wconstant-conversion]
 1053 | LISTIFY(HEADPHONES_DEVICE_COUNT, HEADPHONES_DEVICE, (), HP)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~

The constant 0xBA00 (47616) is coming from "volume-min" in
samples/subsys/usb/legacy/audio_headphones_microphone/app.overlay.

According to the documentation, volume-min and volume-max are expected
to be signed:
https://docs.zephyrproject.org/latest/build/dts/api/bindings/usb/usb-audio-feature-volume.html,
so we explicitly cast to int16_t to suppress the warning.