### PR TITLE
samples: net: sockets: coap_upload: Fix compiler warning

### DIFF
--- a/samples/net/sockets/coap_upload/src/main.c
+++ b/samples/net/sockets/coap_upload/src/main.c
@@ -85,7 +85,7 @@ static int block_payload_cb(size_t offset, const uint8_t **payload, size_t *len,
 		return -EINVAL;
 	}
 
-	*payload = LOREM_IPSUM_SHORT + offset;
+	*payload = &LOREM_IPSUM_SHORT[offset];
 
 	data_left = LOREM_IPSUM_SHORT_STRLEN - offset;
 	if (data_left <= *len) {


### PR DESCRIPTION
When building sample.net.sockets.coap_upload, it warns:

samples/net/sockets/coap_upload/src/main.c:88:31: error: adding 'size_t'
(aka 'unsigned int') to a string does not append to the string
[-Werror,-Wstring-plus-int]
   88 |         *payload = LOREM_IPSUM_SHORT + offset;
      |                    ~~~~~~~~~~~~~~~~~~^~~~~~~~
samples/net/sockets/coap_upload/src/main.c:88:31: note: use array
indexing to silence this warning
   88 |         *payload = LOREM_IPSUM_SHORT + offset;
      |                                      ^
      |                    &                 [       ]

We're not attempting to append to a string in this case, so use the
suggestion from the compiler to silence the warning.