### PR TITLE
drivers: adc: adc_ambiq: check return value of adc power control

### DIFF
--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -437,6 +437,11 @@ static int adc_ambiq_init(const struct device *dev)
 	/* power on ADC*/
 	ret = am_hal_adc_power_control(data->adcHandle, AM_HAL_SYSCTRL_WAKE, false);
 
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("Failed to power on ADC, code: %d", ret);
+		return -EIO;
+	}
+
 	ret = pinctrl_apply_state(cfg->pin_cfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
Handle the return value of am_hal_adc_power_control() during ADC initialization.

The previous code overwrote the return value before it was checked, which could silently ignore failures when powering on the ADC.

Fix this by validating the return code and propagating an error if the operation fails.