### PR TITLE
include: logging: Fix compiler warning

### DIFF
--- a/include/zephyr/logging/log.h.orig
+++ b/include/zephyr/logging/log.h.orig
@@ -804,10 +804,8 @@ extern struct k_mem_partition k_log_partition;
  * @see LOG_MODULE_REGISTER
  */
 #define LOG_MODULE_DECLARE(...)                                                                    \
-	extern const struct log_source_const_data                                                  \
-		Z_LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__))                                   \
-		__in_section(_log_const, static,                                                   \
-			     _CONCAT(Z_LOG_ITEM_CONST_DATA(GET_ARG_N(1, __VA_ARGS__)), _));        \
+	extern const struct log_source_const_data Z_LOG_ITEM_CONST_DATA(                           \
+		GET_ARG_N(1, __VA_ARGS__));                                                        \
 	extern struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(GET_ARG_N(1, __VA_ARGS__));    \
                                                                                                    \
 	Z_LOG_MODULE_PARTITION(K_APP_DMEM)                                                         \


### PR DESCRIPTION
When building the tests in tests/subsys/logging (e.g.,
logging.deferred.api.func_prefix_cpp.tagged_args) with -Wsection, clang
fails with:

tests/subsys/logging/log_api/src/main.c:23:1: error: section attribute
is specified on redeclared variable [-Werror,-Wsection]
   23 | LOG_MODULE_REGISTER(test, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
      | ^

LOG_MODULE_DECLARE was declaring variables without section attributes,
while LOG_MODULE_REGISTER defined them with section attributes.