### PR TITLE
drivers: sensor: icm45686: Fix compiler warning

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -136,13 +136,13 @@ struct icm45686_stream {
 
 struct icm45686_data {
 	struct icm45686_bus bus;
-	/** Single-shot encoded data instance to support fetch/get API */
-	struct icm45686_encoded_data edata;
 #if defined(CONFIG_ICM45686_TRIGGER)
 	struct icm45686_triggers triggers;
 #elif defined(CONFIG_ICM45686_STREAM)
 	struct icm45686_stream stream;
 #endif /* CONFIG_ICM45686_TRIGGER */
+	/** Single-shot encoded data instance to support fetch/get API */
+	struct icm45686_encoded_data edata;
 };
 
 struct icm45686_config {


### PR DESCRIPTION
When building the drivers.sensor.build test with clang when -Wgnu is
enabled, it fails with:

zephyr/drivers/sensor/tdk/icm45686/icm45686.h:140:31: error: field
'edata' with variable sized type 'struct icm45686_encoded_data' not at
the end of a struct or class is a GNU extension
[-Werror,-Wgnu-variable-sized-type-not-at-end]
  140 |         struct icm45686_encoded_data edata;