### PR TITLE
posix: mqueue: handle pthread_create() failure in send_message

### DIFF
--- a/lib/posix/options/mqueue.c
+++ b/lib/posix/options/mqueue.c
@@ -484,6 +484,10 @@ static int32_t send_message(mqueue_desc *mqd, const char *msg_ptr, size_t msg_le
 					     sevp->sigev_notify_attributes,
 					     mq_notify_thread,
 					     mqd->mqueue);
+			if (ret != 0) {
+				errno = ret;
+				return -1;
+			}
 		}
 	}
 


### PR DESCRIPTION
Check and handle errors returned by pthread_create() when using SIGEV_THREAD notification.

Previously, the return value was ignored, which could lead to silent failures.

Proper error handling is added to propagate failures and set errno accordingly.