### PR TITLE
doc: hardware: porting: board_porting: describe board variants

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -187,7 +187,8 @@ Glossary of Terms
       and :term:`CPU cluster`. Common uses of the variant concept include
       introducing both secure and non-secure builds for platforms with Trusted
       Execution Environment support, or selecting the type of RAM used in a
-      build.
+      build. Variants are also used to distinguish between boards with
+      varying peripherals.
 
    west
       A multi-repo meta-tool developed for the Zephyr project. See :ref:`west`.

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -176,6 +176,13 @@ For ``thingy52`` the board target ``thingy52/nrf52832`` can be read as:
 - ``nrf52832``: The board qualifiers, in this case identical to the SoC, which
   is a Nordic nRF52832.
 
+Besides SoCs, variants can also be used to describe boards with varying peripherals.
+A board target ``esp32s3_luatos_core/esp32s3/procpu/usb`` can be read as:
+
+- ``esp32s3_luatos_core``: board name.
+- ``esp32s3``: The SoC.
+- ``procpu``: The core to use.
+- ``usb``: A board variant, in this case including USB serial support.
 
 Make sure your SoC is supported
 *******************************


### PR DESCRIPTION
After a chat with @sylvioalves on how to properly structure board support (as part of https://github.com/zephyrproject-rtos/zephyr/pull/99922) if you have to variants of a board with very similar peripherals, we came to the conclusion, that the documentation is not describing this use case yet.

With this pull request, I propose to extend the documentation in this regard.
The PR provides a description and an example for this case, as basis for discussion.

As described in the proposal, using variants for this use case it done for example in [ESP32 S3 Luatos Core board](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/luatos/esp32s3_luatos_core/board.yml).
