### PR TITLE
ci: pr_metadata_check: do not rerun on edited

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -8,7 +8,6 @@ on:
       - reopened
       - labeled
       - unlabeled
-      - edited
 
 permissions:
   contents: read


### PR DESCRIPTION
This workflow used to host the "empty" description check and had to rerun on PR title edit, but that has been moved to into the (faster) dnm workflow in db18e4c5079. Drop the "edited" trigger from this one as it's not needed anymore.