### PR TITLE
drivers: sensor: lps2xdf: add PM device support and power-domain init

### DIFF
--- a/drivers/sensor/st/lps2xdf/ilps22qs.c
+++ b/drivers/sensor/st/lps2xdf/ilps22qs.c
@@ -74,17 +74,7 @@ static int ilps22qs_trigger_set(const struct device *dev,
 }
 #endif /* CONFIG_LPS2XDF_TRIGGER */
 
-const struct lps2xdf_chip_api st_ilps22qs_chip_api = {
-	.mode_set_odr_raw = ilps22qs_mode_set_odr_raw,
-	.sample_fetch = ilps22qs_sample_fetch,
-#if CONFIG_LPS2XDF_TRIGGER
-	.config_interrupt = ilps22qs_config_interrupt,
-	.handle_interrupt = ilps22qs_handle_interrupt,
-	.trigger_set = ilps22qs_trigger_set,
-#endif
-};
-
-int st_ilps22qs_init(const struct device *dev)
+static int st_ilps22qs_init(const struct device *dev)
 {
 	const struct lps2xdf_config *const cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -162,6 +152,9 @@ int st_ilps22qs_init(const struct device *dev)
 		return ret;
 	}
 
+	/* Store odr for PM resume */
+	((struct lps2xdf_data *)dev->data)->odr = cfg->odr;
+
 #ifdef CONFIG_LPS2XDF_TRIGGER
 	if (cfg->trig_enabled) {
 		if (lps2xdf_init_interrupt(dev, DEVICE_VARIANT_ILPS22QS) < 0) {
@@ -173,3 +166,14 @@ int st_ilps22qs_init(const struct device *dev)
 
 	return 0;
 }
+
+const struct lps2xdf_chip_api st_ilps22qs_chip_api = {
+	.mode_set_odr_raw = ilps22qs_mode_set_odr_raw,
+	.sample_fetch = ilps22qs_sample_fetch,
+	.power_on = st_ilps22qs_init,
+#if CONFIG_LPS2XDF_TRIGGER
+	.config_interrupt = ilps22qs_config_interrupt,
+	.handle_interrupt = ilps22qs_handle_interrupt,
+	.trigger_set = ilps22qs_trigger_set,
+#endif
+};

--- a/drivers/sensor/st/lps2xdf/ilps22qs.h
+++ b/drivers/sensor/st/lps2xdf/ilps22qs.h
@@ -18,6 +18,4 @@
 
 extern const struct lps2xdf_chip_api st_ilps22qs_chip_api;
 
-int st_ilps22qs_init(const struct device *dev);
-
 #endif /* ZEPHYR_DRIVERS_SENSOR_ILPS22QS_H_ */

--- a/drivers/sensor/st/lps2xdf/lps22df.h
+++ b/drivers/sensor/st/lps2xdf/lps22df.h
@@ -18,6 +18,4 @@
 
 extern const struct lps2xdf_chip_api st_lps22df_chip_api;
 
-int st_lps22df_init(const struct device *dev);
-
 #endif /* ZEPHYR_DRIVERS_SENSOR_LPS22DF_H_ */

--- a/drivers/sensor/st/lps2xdf/lps28dfw.c
+++ b/drivers/sensor/st/lps2xdf/lps28dfw.c
@@ -159,17 +159,7 @@ static int lps28dfw_trigger_set(const struct device *dev,
 }
 #endif /* CONFIG_LPS2XDF_TRIGGER */
 
-const struct lps2xdf_chip_api st_lps28dfw_chip_api = {
-	.mode_set_odr_raw = lps28dfw_mode_set_odr_raw,
-	.sample_fetch = lps28dfw_sample_fetch,
-#if CONFIG_LPS2XDF_TRIGGER
-	.config_interrupt = lps28dfw_config_interrupt,
-	.handle_interrupt = lps28dfw_handle_interrupt,
-	.trigger_set = lps28dfw_trigger_set,
-#endif
-};
-
-int st_lps28dfw_init(const struct device *dev)
+static int st_lps28dfw_init(const struct device *dev)
 {
 	const struct lps2xdf_config *const cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -247,6 +237,9 @@ int st_lps28dfw_init(const struct device *dev)
 		return ret;
 	}
 
+	/* Store odr for PM resume */
+	((struct lps2xdf_data *)dev->data)->odr = cfg->odr;
+
 #ifdef CONFIG_LPS2XDF_TRIGGER
 	if (cfg->trig_enabled) {
 		if (lps2xdf_init_interrupt(dev, DEVICE_VARIANT_LPS28DFW) < 0) {
@@ -258,3 +251,14 @@ int st_lps28dfw_init(const struct device *dev)
 
 	return 0;
 }
+
+const struct lps2xdf_chip_api st_lps28dfw_chip_api = {
+	.mode_set_odr_raw = lps28dfw_mode_set_odr_raw,
+	.sample_fetch = lps28dfw_sample_fetch,
+	.power_on = st_lps28dfw_init,
+#if CONFIG_LPS2XDF_TRIGGER
+	.config_interrupt = lps28dfw_config_interrupt,
+	.handle_interrupt = lps28dfw_handle_interrupt,
+	.trigger_set = lps28dfw_trigger_set,
+#endif
+};

--- a/drivers/sensor/st/lps2xdf/lps28dfw.h
+++ b/drivers/sensor/st/lps2xdf/lps28dfw.h
@@ -18,6 +18,4 @@
 
 extern const struct lps2xdf_chip_api st_lps28dfw_chip_api;
 
-int st_lps28dfw_init(const struct device *dev);
-
 #endif /* ZEPHYR_DRIVERS_SENSOR_LPS28DFW_H_ */

--- a/drivers/sensor/st/lps2xdf/lps2xdf.h
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.h
@@ -41,6 +41,7 @@
 
 typedef int32_t (*api_lps2xdf_mode_set_odr_raw)(const struct device *dev, uint8_t odr);
 typedef int32_t (*api_lps2xdf_sample_fetch)(const struct device *dev, enum sensor_channel chan);
+typedef int32_t (*api_lps2xdf_power_on)(const struct device *dev);
 #ifdef CONFIG_LPS2XDF_TRIGGER
 typedef int (*api_lps2xdf_config_interrupt)(const struct device *dev);
 typedef void (*api_lps2xdf_handle_interrupt)(const struct device *dev);
@@ -52,6 +53,7 @@ typedef int (*api_lps2xdf_trigger_set)(const struct device *dev,
 struct lps2xdf_chip_api {
 	api_lps2xdf_mode_set_odr_raw mode_set_odr_raw;
 	api_lps2xdf_sample_fetch sample_fetch;
+	api_lps2xdf_power_on power_on;
 #ifdef CONFIG_LPS2XDF_TRIGGER
 	api_lps2xdf_config_interrupt config_interrupt;
 	api_lps2xdf_handle_interrupt handle_interrupt;
@@ -109,6 +111,7 @@ struct lps2xdf_config {
 struct lps2xdf_data {
 	int32_t sample_press;
 	int16_t sample_temp;
+	uint8_t odr;
 
 #ifdef CONFIG_LPS2XDF_TRIGGER
 	struct gpio_callback gpio_cb;


### PR DESCRIPTION
Add full power‑management support to the LPS2XDF sensor family (LPS22DF, LPS28DFW, ILPS22QS). This integrates the drivers with the Zephyr PM subsystem and allows deferred initialization through power domains.

```
SENSOR_DEVICE_DT_INST_DEFINE(inst, lps2xdf_init, ...)
                             │
                             ▼
                      lps2xdf_init()
                             │
                             ▼
            pm_device_driver_init(dev, lps2xdf_pm_control)
                             │
                             ▼
              PM triggers PM_DEVICE_ACTION_TURN_ON
                             │
                             ▼
                   lps2xdf_pm_control()
                             │
                             ▼
                   chip_api->power_on(dev)
                             │
              ┌──────────────┼──────────────┐
              ▼              ▼              ▼
      st_lps22df_init  st_lps28dfw_init  st_ilps22qs_init
      (HW init)        (HW init)         (HW init)
```
Introduce a power_on() callback in lps2xdf_chip_api and track the current ODR in lps2xdf_data for suspend/resume handling. Implement a PM control callback that:

- powers on the chip on PM_DEVICE_ACTION_TURN_ON
- enters power‑down mode by setting ODR=0 on SUSPEND
- restores the previous ODR on RESUME
- performs no action on TURN_OFF

Convert initialization to use pm_device_driver_init() and update the instantiation macros to use PM_DEVICE_DT_INST_DEFINE.

Update each chip driver (lps22df, lps28dfw, ilps22qs) to provide a .power_on implementation and store the initial ODR in the driver data.

This enables proper power‑domain control and low‑power operation for all LPS2XDF‑based pressure sensors.