### PR TITLE
drivers: display: ls0xx: add Kconfig setting VCOM thread priority

### DIFF
--- a/drivers/display/Kconfig.ls0xx
+++ b/drivers/display/Kconfig.ls0xx
@@ -8,3 +8,10 @@ config LS0XX
 	select SPI
 	help
 	  Enable driver for sharp memory display series LS0XXX7DXXX
+
+config LS0XX_VCOM_THREAD_PRIO
+	int "Priority for the VCOM inversion thread"
+	default 3
+	depends on LS0XX
+	help
+	  Set the VCOM inversion thread priority

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -42,6 +42,7 @@ LOG_MODULE_REGISTER(ls0xx, CONFIG_DISPLAY_LOG_LEVEL);
 #define LS0XX_BIT_WRITECMD    0x01
 #define LS0XX_BIT_VCOM        0x02
 #define LS0XX_BIT_CLEAR       0x04
+#define LS0XX_VCOM_PRIO       CONFIG_LS0XX_VCOM_THREAD_PRIO
 
 /* These timings are based on:
  * - A view that 1 frame dropped at 10fps is more than any reasonable wait.
@@ -329,7 +330,7 @@ static int ls0xx_init(const struct device *dev)
 	/* Start thread for toggling VCOM */
 	k_tid_t vcom_toggle_tid = k_thread_create(
 		&vcom_toggle_thread, vcom_toggle_stack, K_THREAD_STACK_SIZEOF(vcom_toggle_stack),
-		ls0xx_vcom_toggle, (void *)dev, NULL, NULL, 3, 0, K_NO_WAIT);
+		ls0xx_vcom_toggle, (void *)dev, NULL, NULL, LS0XX_VCOM_PRIO, 0, K_NO_WAIT);
 	k_thread_name_set(vcom_toggle_tid, "ls0xx_vcom");
 #endif /* USE_VCOM_THREAD */
 


### PR DESCRIPTION
This is a follow-up to what I did in #96396 which added support for serial VCOM inversion (in addition to using the EXTCOMIN pin).

The ls0xx driver VCOM inversion thread has a hardcoded priority of 3, which predated my addition of serial VCOM inversion  support. However, in some applications this may be considered lower priority than other time sensitive tasks. With an LCD, maintaining close to an even polarity balance is best, but this change allows developers to determine the approach.

Given people have ran these display DC biased for long periods – in some cases for years, I expect that the prioritization of inversion will balance over time, and this setting lets developers prioritize tasks based on their choices instead of a hardcoded and high priority setting. The default is set as 3 so no behavior is changed without intentional action by the developer.