### PR TITLE
entropy: gd32: Fix driver issues

### DIFF
--- a/drivers/entropy/entropy_gd32.c
+++ b/drivers/entropy/entropy_gd32.c
@@ -58,7 +58,7 @@ static bool entropy_gd32_ck48m_ready(void)
 	return (RCU_CTL & RCU_CTL_PLLSTB) != 0U;
 }
 
-static entropy_gd32_recover(void)
+static void entropy_gd32_recover(void)
 {
 	/*
 	 * For GD32F4xx TRNG the HAL exposes status bits (CECS/SECS) but provides
@@ -69,8 +69,6 @@ static entropy_gd32_recover(void)
 	trng_deinit();
 	entropy_gd32_clear_int_flags();
 	trng_enable();
-
-	return 0;
 }
 
 static int entropy_gd32_wait_drdy(void)

--- a/dts/arm/gd/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gd/gd32f4xx/gd32f4xx.dtsi
@@ -13,6 +13,10 @@
 #include <zephyr/dt-bindings/reset/gd32f4xx.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng0;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
- Missing function signature causing build issue
- Missing chosen node for entropy that is needed by random subsys