### PR TITLE
soc: atmel: samd2x: Enable internal OSC32K as RTC source

### DIFF
--- a/soc/atmel/sam0/common/Kconfig.samd2x
+++ b/soc/atmel/sam0/common/Kconfig.samd2x
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2024-2026 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_SAMD20 || SOC_SERIES_SAMD21 || SOC_SERIES_SAMR21
@@ -27,6 +27,8 @@ config SOC_ATMEL_SAMD_XOSC32K
 	help
 	  Enable the external 32.768 kHz clock source at startup.
 	  This can then be selected as the main clock reference for the SOC.
+	  The External OSC32K has high priority over the internal OSC32K and
+	  once enabled will be the default 32.768 kHz clock source for RTC.
 
 config SOC_ATMEL_SAMD_XOSC32K_CRYSTAL
 	bool "External 32.768 kHz clock is a crystal oscillator"
@@ -39,17 +41,17 @@ config SOC_ATMEL_SAMD_XOSC32K_CRYSTAL
 DT_ATMEL_RTC := $(dt_nodelabel_path,rtc)
 DT_ATMEL_RTC_COUNTER_CLOCK_MODE := $(dt_node_str_prop_equals,$(DT_ATMEL_RTC),counter-mode,clock)
 
-config SOC_ATMEL_SAMD_XOSC32K_PRESCALER
-	int "XOSC32 Generic Clock Prescaler"
+config SOC_ATMEL_SAMD_32768HZ_RTC_PRESCALER
+	int "32.768 kHz RTC Generic Clock Prescaler"
 	range 1 512
 	default 32 if "$(DT_ATMEL_RTC_COUNTER_CLOCK_MODE)"
 	default 1
-	depends on SOC_ATMEL_SAMD_XOSC32K
+	depends on SOC_ATMEL_SAMD_XOSC32K || \
+		   SOC_ATMEL_SAMD_OSC32K
 	help
-	  Configure the prescaler for the generic clock output
-	  connected on the xosc32. When using RTC in calendar mode
-	  the GCLK should be divided by 32 to RTC receive the
-	  1024 Hz reference clock.
+	  Configure the prescaler for the generic clock output connected on
+	  the xosc32 or osc32k input. When using RTC in calendar mode the GCLK
+	  should be divided by 32 to RTC receive the 1024 Hz reference clock.
 
 config SOC_ATMEL_SAMD_XOSC
 	bool "External 0.4..32 MHz clock source"

--- a/soc/atmel/sam0/common/soc_samd2x.c
+++ b/soc/atmel/sam0/common/soc_samd2x.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Google LLC.
  * Copyright (c) 2023 Ionut Catalin Pavel <iocapa@iocapa.com>
- * Copyright (c) 2023-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2023-2026 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,9 +18,9 @@
  *
  * GCLK Gen 0 -> GCLK_MAIN
  * GCLK Gen 1 -> DFLL48M (variable)
- * GCLK Gen 2 -> WDT @ 32768 Hz
+ * GCLK Gen 2 -> WDT @ 32.768 kHz
  * GCLK Gen 3 -> ADC @ 8 MHz
- * GCLK Gen 4 -> RTC @ xtal 32768 Hz
+ * GCLK Gen 4 -> RTC @ xosc32k (xtal or clock) | osc32k 32.768 kHz
  */
 
 #include <zephyr/device.h>
@@ -237,7 +237,11 @@ static inline void gclk_adc_configure(void)
 #else
 static inline void gclk_rtc_configure(void)
 {
-	gclk_connect(4, GCLK_GENCTRL_SRC_XOSC32K, CONFIG_SOC_ATMEL_SAMD_XOSC32K_PRESCALER, 0);
+#if CONFIG_SOC_ATMEL_SAMD_XOSC32K
+	gclk_connect(4, GCLK_GENCTRL_SRC_XOSC32K, CONFIG_SOC_ATMEL_SAMD_32768HZ_RTC_PRESCALER, 0);
+#else
+	gclk_connect(4, GCLK_GENCTRL_SRC_OSC32K, CONFIG_SOC_ATMEL_SAMD_32768HZ_RTC_PRESCALER, 0);
+#endif
 }
 #endif
 


### PR DESCRIPTION
In the current implementation the platforms samd20/21 and samr21 can only use an external crystal or clock to drive RTC. This enable the possibility to select the internal OSC32K as an alternative for low cost boards that don't use an external 32.768 kHz source.

Fixes #102352