### PR TITLE
scripts: twister: don't parse west modules in `TestPlan`

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1073,28 +1073,28 @@ class TwisterEnv:
         self.outdir = os.path.abspath(options.outdir)
 
         self.snippet_roots = [Path(ZEPHYR_BASE)]
-        modules = zephyr_module.parse_modules(ZEPHYR_BASE)
-        for module in modules:
-            snippet_root = module.meta.get("build", {}).get("settings", {}).get("snippet_root")
-            if snippet_root:
-                self.snippet_roots.append(Path(module.project) / snippet_root)
-
-
         self.soc_roots = [Path(ZEPHYR_BASE), Path(ZEPHYR_BASE) / 'subsys' / 'testsuite']
         self.dts_roots = [Path(ZEPHYR_BASE)]
         self.arch_roots = [Path(ZEPHYR_BASE)]
 
+        modules = zephyr_module.parse_modules(ZEPHYR_BASE)
         for module in modules:
-            soc_root = module.meta.get("build", {}).get("settings", {}).get("soc_root")
+            settings = module.meta.get("build", {}).get("settings", {})
+            project = Path(module.project)
+            snippet_root = settings.get("snippet_root")
+            if snippet_root:
+                self.snippet_roots.append(project / snippet_root)
+            soc_root = settings.get("soc_root")
             if soc_root:
-                self.soc_roots.append(Path(module.project) / Path(soc_root))
-            dts_root = module.meta.get("build", {}).get("settings", {}).get("dts_root")
+                self.soc_roots.append(project / Path(soc_root))
+            dts_root = settings.get("dts_root")
             if dts_root:
-                self.dts_roots.append(Path(module.project) / Path(dts_root))
-            arch_root = module.meta.get("build", {}).get("settings", {}).get("arch_root")
+                self.dts_roots.append(project / Path(dts_root))
+            arch_root = settings.get("arch_root")
             if arch_root:
-                self.arch_roots.append(Path(module.project) / Path(arch_root))
+                self.arch_roots.append(project / Path(arch_root))
 
+        self.modules = [m.meta for m in modules]
         self.hwm = None
 
         self.test_config = options.test_config

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -37,7 +37,6 @@ from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite, scan_testsuite_path
-from zephyr_module import parse_modules
 
 logger = logging.getLogger('twister')
 
@@ -186,7 +185,7 @@ class TestPlan:
         self.hwm = env.hwm
         # used during creating shorter build paths
         self.link_dir_counter = 0
-        self.modules = []
+        self.modules = [module.get('name') for module in self.env.modules]
 
         self.run_individual_testsuite = []
         self.levels = []
@@ -210,7 +209,6 @@ class TestPlan:
                 raise TwisterRuntimeError("Tests not found")
 
     def discover(self):
-        self.handle_modules()
         self.test_config = TestConfiguration(self.env.test_config)
 
         self.add_configurations()
@@ -363,12 +361,6 @@ class TestPlan:
             # to the first set to allow for better distribution among all sets.
             self.instances.update(skipped)
             self.instances.update(errors)
-
-
-    def handle_modules(self):
-        # get all enabled west projects
-        modules_meta = parse_modules(ZEPHYR_BASE)
-        self.modules = [module.meta.get('name') for module in modules_meta]
 
 
     def report(self):


### PR DESCRIPTION
`TwisterEnv` already parses west modules during initialization, but `TestPlan` was parsing them again via `zephyr_module.parse_modules()`, duplicating work.

Store the parsed module objects in `TwisterEnv` (`self.modules`) and have `TestPlan` derive its module name list from `env.modules` instead. This drops the redundant parse in `TestPlan` by removing `handle_modules()` and its call site.

Each call to `parse_modules()` takes around 250-300ms on my end (Ubuntu 24.04).

Update twister unit tests.

----

Currently on `main`, `zephyr_module.parse_modules()` is being called 3 times during a Twister run, this PR reduces that to 2.