### PR TITLE
tests: secure_storage: skip flash erase if no storage partition

### DIFF
--- a/tests/subsys/secure_storage/psa/its/src/main.c
+++ b/tests/subsys/secure_storage/psa/its/src/main.c
@@ -9,7 +9,8 @@
 
 /* The flash must be erased after this test suite is run for the write-once entry test to pass. */
 #if !defined(CONFIG_BUILD_WITH_TFM) && defined(CONFIG_FLASH_PAGE_LAYOUT) &&                        \
-	DT_HAS_CHOSEN(zephyr_flash_controller)
+	DT_HAS_CHOSEN(zephyr_flash_controller) &&                                                  \
+	DT_FIXED_PARTITION_EXISTS(DT_NODELABEL(storage_partition))
 static int erase_flash(void)
 {
 	const struct device *const fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));


### PR DESCRIPTION
On the it51xxx soc, the psa/its twister test was failing because there is no storage partition defined. This change ensures the flash erase function in the psa/its test only runs if fixed partition labeled 'storage_partition' exists.

Tested with:
- west twister -p it51xxx_evb/it51526aw \ -s secure_storage.psa.its.secure_storage.custom.both
- west twister -p it51xxx_evb/it51526aw \ -s secure_storage.psa.its.secure_storage.custom.store