### PR TITLE
soc: imx943: m33: Initialize DTCM to generate ECC bits

### DIFF
--- a/soc/nxp/imx/imx9/imx943/Kconfig
+++ b/soc/nxp/imx/imx9/imx943/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# SPDX-FileCopyrightText: Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_MIMX94398_A55
@@ -23,6 +23,7 @@ config SOC_MIMX94398_M33
 	select INIT_ARCH_HW_AT_BOOT
 	select SOC_EARLY_INIT_HOOK
 	select HAS_PM
+	select SOC_EARLY_RESET_HOOK
 
 config SOC_MIMX94398_M7_0
 	select ARM

--- a/soc/nxp/imx/imx9/imx943/m33/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx943/m33/CMakeLists.txt
@@ -1,8 +1,9 @@
-# Copyright 2025 NXP
+# SPDX-FileCopyrightText: Copyright 2025-2026 NXP
 
 zephyr_include_directories(.)
 
 zephyr_library()
 zephyr_library_sources(soc.c)
+zephyr_library_sources_ifdef(CONFIG_SOC_EARLY_RESET_HOOK soc.S)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imx/imx9/imx943/m33/soc.S
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.S
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+
+_ASM_FILE_PROLOGUE
+
+GTEXT(soc_early_reset_hook)
+
+SECTION_FUNC(TEXT, soc_early_reset_hook)
+	/*
+	 * Initialize DTCM with word writes to generate ECC bits.
+	 * Required before byte/halfword access to avoid ECC faults.
+	 * (TCM ECC is enabled by default after reset)
+	 */
+	mov r0, #0
+	ldr r1, = DT_REG_ADDR(DT_NODELABEL(dtcm))
+	ldr r2, = DT_REG_ADDR(DT_NODELABEL(dtcm)) + DT_REG_SIZE(DT_NODELABEL(dtcm))
+DTCM_INIT_LOOP:
+	cmp r1, r2
+	itt lt
+	strlt r0, [r1], #4
+	blt DTCM_INIT_LOOP
+
+	bx lr


### PR DESCRIPTION
The TCM ECC is enabled by default after reset, so must initialize the entire DTCM with word-aligned writes to generate vaild ECC bits before any byte or halfword access, otherwise ECC faults will occur.