### PR TITLE
modules: hal_infineon: Add blob support for TVIIBE1M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -185,7 +185,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 470f874ce432763a2b82cd322d0ff6efc89240cd
+      revision: 0fa9d51aa5228342ec301ab49160f46257a9c444
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Adds blob support for tviibe1m family which updates the module.yml to pull pre-built CM0+ images for tviibe1m and 'c' file to include array of binaries.