### PR TITLE
drivers: pwm: pwm_mcux_ctimer: Fix multi-line assertion message formatting

### DIFF
--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -1,6 +1,6 @@
 /*
  * (c) Meta Platforms, Inc. and affiliates.
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -208,8 +208,8 @@ static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t
 	}
 
 	*cycles /= (uint64_t)config->prescale + 1;
-	__ASSERT((*cycles) > 0, "Invalid PWM frequency: cycles per second is 0(check clock rate
-		and prescaler)");
+	__ASSERT((*cycles) > 0, "Invalid PWM frequency: cycles per second is 0(check clock rate "
+				"and prescaler)");
 
 	return err;
 }


### PR DESCRIPTION
Fix formatting of the __ASSERT message in mcux_ctimer_pwm_get_cycles_per_sec to properly concatenate the string across multiple lines.