### PR TITLE
drivers: udc: renesas: enable auto status for UDC control transfer

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: f30a54e266292fd0b958b49ef24eb1ca2afd1981
+      revision: f44af23f0cc1e5e6d06e2c3030b8e401840e314f
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Fix https://github.com/zephyrproject-rtos/zephyr/issues/102157

- Enable control transfer auto completion for s-in-status and s-out-status
- Add stub for s-status (no-data control) to fake handle SET_ADDRESS request