### PR TITLE
dts: arm: silabs: Clean up radio feature selection

### DIFF
--- a/dts/arm/silabs/xg21/efr32xg21.dtsi
+++ b/dts/arm/silabs/xg21/efr32xg21.dtsi
@@ -11,6 +11,8 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x01000000>;
+			ble-2mbps-supported;
+			ble-coded-phy-supported;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "prortc", "synth";
 			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
@@ -19,8 +21,6 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
-			ble-2mbps-supported;
-			ble-coded-phy-supported;
 			radio-tx-high-power-supported;
 
 			bt_hci_silabs: bt_hci_silabs {

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -43,6 +43,10 @@
 };
 
 &radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
@@ -29,6 +29,8 @@
 };
 
 &radio {
+	ble-2mbps-supported;
+	ble-cte-tx-supported;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
@@ -31,6 +31,10 @@
 };
 
 &radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
@@ -19,6 +19,11 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
@@ -19,6 +19,11 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
@@ -19,6 +19,11 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
@@ -19,6 +19,13 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+	ble-coded-phy-supported;
+	ble-cte-rx-supported;
+	ble-cte-tx-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/xg22/efr32xg22.dtsi
+++ b/dts/arm/silabs/xg22/efr32xg22.dtsi
@@ -20,10 +20,6 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
-			ble-2mbps-supported;
-			ble-coded-phy-supported;
-			ble-cte-tx-supported;
-			ble-cte-rx-supported;
 			radio-tx-high-power-supported;
 
 			pti: pti {

--- a/dts/arm/silabs/xg23/efr32xg23.dtsi
+++ b/dts/arm/silabs/xg23/efr32xg23.dtsi
@@ -20,6 +20,7 @@
 			pa-ramp-time-us = <10>;
 			pa-subghz = "highest";
 			pa-voltage-mv = <3300>;
+			radio-tx-high-power-supported;
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -11,6 +11,11 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x01000000>;
+			ble-2mbps-supported;
+			ble-coded-phy-supported;
+			ble-cs-supported;
+			ble-cte-rx-supported;
+			ble-cte-tx-supported;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "hostmailbox", "synth", "rfeca0",
 					  "rfeca1";
@@ -20,11 +25,6 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
-			ble-2mbps-supported;
-			ble-coded-phy-supported;
-			ble-cte-tx-supported;
-			ble-cte-rx-supported;
-			ble-cs-supported;
 			radio-tx-high-power-supported;
 
 			bt_hci_silabs: bt_hci_silabs {

--- a/dts/arm/silabs/xg26/efr32xg26.dtsi
+++ b/dts/arm/silabs/xg26/efr32xg26.dtsi
@@ -11,6 +11,10 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x01000000>;
+			ble-2mbps-supported;
+			ble-coded-phy-supported;
+			ble-cte-rx-supported;
+			ble-cte-tx-supported;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "hostmailbox", "synth", "rfeca0",
 					  "rfeca1";
@@ -20,6 +24,7 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
+			radio-tx-high-power-supported;
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg27/efr32xg27.dtsi
+++ b/dts/arm/silabs/xg27/efr32xg27.dtsi
@@ -11,6 +11,9 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x01000000>;
+			ble-2mbps-supported;
+			ble-coded-phy-supported;
+			ble-cte-tx-supported;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "synth",
 					  "prortc";
@@ -20,9 +23,6 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
-			ble-2mbps-supported;
-			ble-coded-phy-supported;
-			ble-cte-tx-supported;
 			radio-tx-high-power-supported;
 
 			bt_hci_silabs: bt_hci_silabs {

--- a/dts/arm/silabs/xg28/efr32xg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32xg28.dtsi
@@ -21,6 +21,7 @@
 			pa-ramp-time-us = <10>;
 			pa-subghz = "highest";
 			pa-voltage-mv = <3300>;
+			radio-tx-high-power-supported;
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
@@ -19,6 +19,10 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&radio {
+	ble-2mbps-supported;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32xg29.dtsi
+++ b/dts/arm/silabs/xg29/efr32xg29.dtsi
@@ -11,6 +11,9 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x01000000>;
+			ble-2mbps-supported;
+			ble-coded-phy-supported;
+			ble-cte-tx-supported;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "synth",
 					  "prortc";
@@ -20,9 +23,6 @@
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
-			ble-2mbps-supported;
-			ble-coded-phy-supported;
-			ble-cte-tx-supported;
 			radio-tx-high-power-supported;
 
 			bt_hci_silabs: bt_hci_silabs {


### PR DESCRIPTION
Sort ble radio feature properties alphabetically according to the coding standard.

Certain features on xg22 and xg28 depend on the specific SoC selected, move the properties from the generic .dtsi file to the SoC specific one.