### PR TITLE
samples: net: sockets: http_get: Fix addrinfo dump

### DIFF
--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -89,8 +89,10 @@ int main(void)
 	}
 
 #if 0
-	for (; res; res = res->ai_next) {
-		dump_addrinfo(res);
+	struct addrinfo *temp_res = res;
+
+	for (; temp_res; temp_res = temp_res->ai_next) {
+		dump_addrinfo(temp_res);
 	}
 #endif
 


### PR DESCRIPTION
The debug code for dumping resolved addresses was modifying the addrinfo res pointer (effectively setting it to NULL), causing crash later in the sample. Fix this, by using a temporary pointer copy for iterating over resolved addresses.