### PR TITLE
usb: device_next: Allocate data IN stage in handler

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -606,6 +606,12 @@ USB
   :c:struct:`usbd_vreq_node` are now called with NULL ``buf`` before data stage is received.
   This allows the stack to return STALL during data stage. Out-of-tree class and vendor handlers
   need to be updated. (:github:`108840`)
+* USB control transfer callbacks ``control_to_host`` in :c:struct:`usbd_class_api` and
+  ``to_host`` in :c:struct:`usbd_vreq_node` are now expected to allocate the data stage buffer
+  themselves. This allows allocating only as much memory as is actually needed which makes
+  the worst case memory usage dependent on the handlers implementation and not on tainted wLength
+  value coming from host. Out-of-tree class and vendor handlers need to be updated.
+  (:github:`102491`)
 * The Espressif USB-OTG full-speed controller compatible ``espressif,esp32-usb-otg`` has been
   renamed to :dtcompatible:`espressif,esp32-usb-otg-fs`. The internal PHY D+/D- pad numbers are
   now provided through the ``phy-dp-pin`` and ``phy-dm-pin`` properties. Out-of-tree devicetrees

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -101,9 +101,8 @@ struct usbd_str_desc_data {
  * Example callback code fragment:
  *
  * @code{.c}
- * static int foo_to_host_cb(const struct usbd_context *const ctx,
- *                           const struct usb_setup_packet *const setup,
- *                           struct net_buf **const pbuf)
+ * static struct net_buf *foo_to_host_cb(const struct usbd_context *const ctx,
+ *                                       const struct usb_setup_packet *const setup)
  * {
  *     if (setup->wIndex == WEBUSB_REQ_GET_URL) {
  *         struct net_buf *buf;
@@ -111,23 +110,21 @@ struct usbd_str_desc_data {
  *         uint8_t index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
  *
  *         if (index != SAMPLE_WEBUSB_LANDING_PAGE) {
- *             return -ENOTSUP;
+ *             return NULL;
  *         }
  *
  *         len = MIN(setup->wLength, sizeof(webusb_origin_url));
  *         buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
  *         if (buf == NULL) {
- *             return -ENOMEM;
+ *             return NULL;
  *         }
- *
- *         *pbuf = buf;
  *
  *         net_buf_add_mem(buf, &webusb_origin_url, len);
  *
- *         return 0;
+ *         return buf;
  *     }
  *
- *     return -ENOTSUP;
+ *     return NULL;
  * }
  * @endcode
  */
@@ -137,9 +134,8 @@ struct usbd_vreq_node {
 	/** Vendor code (bRequest value) */
 	const uint8_t code;
 	/** Vendor request callback for device-to-host direction */
-	int (*to_host)(const struct usbd_context *const ctx,
-		       const struct usb_setup_packet *const setup,
-		       struct net_buf **const pbuf);
+	struct net_buf *(*to_host)(const struct usbd_context *const ctx,
+				   const struct usb_setup_packet *const setup);
 	/**
 	 * Vendor request callback for host-to-device direction
 	 *
@@ -361,9 +357,8 @@ struct usbd_class_api {
 			      const struct net_buf *const buf);
 
 	/** USB control request handler to host */
-	int (*control_to_host)(struct usbd_class_data *const c_data,
-			       const struct usb_setup_packet *const setup,
-			       struct net_buf **const pbuf);
+	struct net_buf *(*control_to_host)(struct usbd_class_data *const c_data,
+					   const struct usb_setup_packet *const setup);
 
 	/** Endpoint request completion event handler */
 	int (*request)(struct usbd_class_data *const c_data,

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -103,17 +103,26 @@ struct usbd_str_desc_data {
  * @code{.c}
  * static int foo_to_host_cb(const struct usbd_context *const ctx,
  *                           const struct usb_setup_packet *const setup,
- *                           struct net_buf *const buf)
+ *                           struct net_buf **const pbuf)
  * {
  *     if (setup->wIndex == WEBUSB_REQ_GET_URL) {
+ *         struct net_buf *buf;
+ *         uint16_t len;
  *         uint8_t index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
  *
  *         if (index != SAMPLE_WEBUSB_LANDING_PAGE) {
  *             return -ENOTSUP;
  *         }
  *
- *         net_buf_add_mem(buf, &webusb_origin_url,
- *                         MIN(net_buf_tailroom(buf), sizeof(webusb_origin_url)));
+ *         len = MIN(setup->wLength, sizeof(webusb_origin_url));
+ *         buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
+ *         if (buf == NULL) {
+ *             return -ENOMEM;
+ *         }
+ *
+ *         *pbuf = buf;
+ *
+ *         net_buf_add_mem(buf, &webusb_origin_url, len);
  *
  *         return 0;
  *     }
@@ -130,7 +139,7 @@ struct usbd_vreq_node {
 	/** Vendor request callback for device-to-host direction */
 	int (*to_host)(const struct usbd_context *const ctx,
 		       const struct usb_setup_packet *const setup,
-		       struct net_buf *const buf);
+		       struct net_buf **const pbuf);
 	/**
 	 * Vendor request callback for host-to-device direction
 	 *
@@ -354,7 +363,7 @@ struct usbd_class_api {
 	/** USB control request handler to host */
 	int (*control_to_host)(struct usbd_class_data *const c_data,
 			       const struct usb_setup_packet *const setup,
-			       struct net_buf *const buf);
+			       struct net_buf **const pbuf);
 
 	/** Endpoint request completion event handler */
 	int (*request)(struct usbd_class_data *const c_data,

--- a/samples/subsys/dap/src/msosv2.h
+++ b/samples/subsys/dap/src/msosv2.h
@@ -113,9 +113,8 @@ struct bos_msosv2_descriptor bos_msosv2_desc = {
 	},
 };
 
-static int msosv2_to_host_cb(const struct usbd_context *const ctx,
-			     const struct usb_setup_packet *const setup,
-			     struct net_buf **const pbuf)
+static struct net_buf *msosv2_to_host_cb(const struct usbd_context *const ctx,
+					 const struct usb_setup_packet *const setup)
 {
 	LOG_INF("Vendor callback to host");
 
@@ -128,17 +127,15 @@ static int msosv2_to_host_cb(const struct usbd_context *const ctx,
 
 		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		net_buf_add_mem(buf, &msosv2_desc, len);
 
-		return 0;
+		return buf;
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 USBD_DESC_BOS_VREQ_DEFINE(bos_vreq_msosv2, sizeof(bos_msosv2_desc), &bos_msosv2_desc,

--- a/samples/subsys/dap/src/webusb.h
+++ b/samples/subsys/dap/src/webusb.h
@@ -63,9 +63,8 @@ static const uint8_t webusb_origin_url[] = {
 	'o', 'r', 'g', '/',
 };
 
-static int webusb_to_host_cb(const struct usbd_context *const ctx,
-			     const struct usb_setup_packet *const setup,
-			     struct net_buf **const pbuf)
+static struct net_buf *webusb_to_host_cb(const struct usbd_context *const ctx,
+					 const struct usb_setup_packet *const setup)
 {
 	LOG_INF("Vendor callback to host");
 
@@ -75,24 +74,22 @@ static int webusb_to_host_cb(const struct usbd_context *const ctx,
 		uint8_t index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
 
 		if (index != SAMPLE_WEBUSB_LANDING_PAGE) {
-			return -ENOTSUP;
+			return NULL;
 		}
 
 		len = MIN(setup->wLength, sizeof(webusb_origin_url));
 		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		LOG_INF("Get URL request, index %u", index);
 		net_buf_add_mem(buf, &webusb_origin_url, len);
 
-		return 0;
+		return buf;
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 USBD_DESC_BOS_VREQ_DEFINE(bos_vreq_webusb, sizeof(bos_cap_webusb), &bos_cap_webusb,

--- a/samples/subsys/usb/webusb/src/msosv2.h
+++ b/samples/subsys/usb/webusb/src/msosv2.h
@@ -115,16 +115,26 @@ struct bos_msosv2_descriptor bos_msosv2_desc = {
 
 static int msosv2_to_host_cb(const struct usbd_context *const ctx,
 			     const struct usb_setup_packet *const setup,
-			     struct net_buf *const buf)
+			     struct net_buf **const pbuf)
 {
 	LOG_INF("Vendor callback to host");
 
 	if (setup->bRequest == SAMPLE_MSOS2_VENDOR_CODE &&
 	    setup->wIndex == MS_OS_20_DESCRIPTOR_INDEX) {
+		struct net_buf *buf;
+		uint16_t len;
+
 		LOG_INF("Get MS OS 2.0 Descriptor Set");
 
-		net_buf_add_mem(buf, &msosv2_desc,
-				MIN(net_buf_tailroom(buf), sizeof(msosv2_desc)));
+		len = MIN(setup->wLength, sizeof(msosv2_desc));
+		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		*pbuf = buf;
+
+		net_buf_add_mem(buf, &msosv2_desc, len);
 
 		return 0;
 	}

--- a/samples/subsys/usb/webusb/src/msosv2.h
+++ b/samples/subsys/usb/webusb/src/msosv2.h
@@ -113,9 +113,8 @@ struct bos_msosv2_descriptor bos_msosv2_desc = {
 	},
 };
 
-static int msosv2_to_host_cb(const struct usbd_context *const ctx,
-			     const struct usb_setup_packet *const setup,
-			     struct net_buf **const pbuf)
+static struct net_buf *msosv2_to_host_cb(const struct usbd_context *const ctx,
+					 const struct usb_setup_packet *const setup)
 {
 	LOG_INF("Vendor callback to host");
 
@@ -129,17 +128,15 @@ static int msosv2_to_host_cb(const struct usbd_context *const ctx,
 		len = MIN(setup->wLength, sizeof(msosv2_desc));
 		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		net_buf_add_mem(buf, &msosv2_desc, len);
 
-		return 0;
+		return buf;
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 USBD_DESC_BOS_VREQ_DEFINE(bos_vreq_msosv2, sizeof(bos_msosv2_desc), &bos_msosv2_desc,

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -63,20 +63,29 @@ static const uint8_t webusb_origin_url[] = {
 
 static int webusb_to_host_cb(const struct usbd_context *const ctx,
 			     const struct usb_setup_packet *const setup,
-			     struct net_buf *const buf)
+			     struct net_buf **const pbuf)
 {
 	LOG_INF("Vendor callback to host");
 
 	if (setup->wIndex == WEBUSB_REQ_GET_URL) {
+		struct net_buf *buf;
+		uint16_t len;
 		uint8_t index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
 
 		if (index != SAMPLE_WEBUSB_LANDING_PAGE) {
 			return -ENOTSUP;
 		}
 
+		len = MIN(setup->wLength, sizeof(webusb_origin_url));
+		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		*pbuf = buf;
+
 		LOG_INF("Get URL request, index %u", index);
-		net_buf_add_mem(buf, &webusb_origin_url,
-				MIN(net_buf_tailroom(buf), sizeof(webusb_origin_url)));
+		net_buf_add_mem(buf, &webusb_origin_url, len);
 
 		return 0;
 	}

--- a/samples/subsys/usb/webusb/src/webusb.h
+++ b/samples/subsys/usb/webusb/src/webusb.h
@@ -61,9 +61,8 @@ static const uint8_t webusb_origin_url[] = {
 	'l', 'o', 'c', 'a', 'l', 'h', 'o', 's', 't', ':', '8', '0', '0', '0'
 };
 
-static int webusb_to_host_cb(const struct usbd_context *const ctx,
-			     const struct usb_setup_packet *const setup,
-			     struct net_buf **const pbuf)
+static struct net_buf *webusb_to_host_cb(const struct usbd_context *const ctx,
+					 const struct usb_setup_packet *const setup)
 {
 	LOG_INF("Vendor callback to host");
 
@@ -73,24 +72,22 @@ static int webusb_to_host_cb(const struct usbd_context *const ctx,
 		uint8_t index = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
 
 		if (index != SAMPLE_WEBUSB_LANDING_PAGE) {
-			return -ENOTSUP;
+			return NULL;
 		}
 
 		len = MIN(setup->wLength, sizeof(webusb_origin_url));
 		buf = usbd_ep_ctrl_data_in_alloc(ctx, len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		LOG_INF("Get URL request, index %u", index);
 		net_buf_add_mem(buf, &webusb_origin_url, len);
 
-		return 0;
+		return buf;
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 USBD_DESC_BOS_VREQ_DEFINE(bos_vreq_webusb, sizeof(bos_cap_webusb), &bos_cap_webusb,

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -202,12 +202,11 @@ static void lb_update(struct usbd_class_data *c_data,
 		c_data, iface, alternate);
 }
 
-static int lb_control_to_host(struct usbd_class_data *c_data,
-			      const struct usb_setup_packet *const setup,
-			      struct net_buf **const pbuf)
+static struct net_buf *lb_control_to_host(struct usbd_class_data *c_data,
+					  const struct usb_setup_packet *const setup)
 {
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (setup->bRequest == LB_VENDOR_REQ_IN) {
@@ -216,20 +215,19 @@ static int lb_control_to_host(struct usbd_class_data *c_data,
 
 		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		net_buf_add_mem(buf, lb_buf, len);
 
 		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength, len);
 
-		return 0;
+		return buf;
 	}
 
 	LOG_ERR("Class request 0x%x not supported", setup->bRequest);
-	return -ENOTSUP;
+
+	return NULL;
 }
 
 static int lb_control_to_dev(struct usbd_class_data *c_data,

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -204,18 +204,26 @@ static void lb_update(struct usbd_class_data *c_data,
 
 static int lb_control_to_host(struct usbd_class_data *c_data,
 			      const struct usb_setup_packet *const setup,
-			      struct net_buf *const buf)
+			      struct net_buf **const pbuf)
 {
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
 		return -ENOTSUP;
 	}
 
 	if (setup->bRequest == LB_VENDOR_REQ_IN) {
-		net_buf_add_mem(buf, lb_buf,
-				MIN(sizeof(lb_buf), setup->wLength));
+		struct net_buf *buf;
+		uint16_t len = MIN(sizeof(lb_buf), setup->wLength);
 
-		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength,
-			MIN(sizeof(lb_buf), setup->wLength));
+		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		*pbuf = buf;
+
+		net_buf_add_mem(buf, lb_buf, len);
+
+		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength, len);
 
 		return 0;
 	}

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -499,9 +499,8 @@ static void cdc_acm_update_linestate(struct cdc_acm_uart_data *const data)
 	}
 }
 
-static int usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
-			    const struct usb_setup_packet *const setup,
-			    struct net_buf **const pbuf)
+static struct net_buf *usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
+					const struct usb_setup_packet *const setup)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_acm_uart_data *data = dev->data;
@@ -513,19 +512,18 @@ static int usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
 
 		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), min_len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		net_buf_add_mem(buf, &data->line_coding, min_len);
 
-		return 0;
+		return buf;
 	}
 
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x unsupported",
 		setup->bmRequestType, setup->bRequest);
-	return -ENOTSUP;
+
+	return NULL;
 }
 
 static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -501,18 +501,23 @@ static void cdc_acm_update_linestate(struct cdc_acm_uart_data *const data)
 
 static int usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
 			    const struct usb_setup_packet *const setup,
-			    struct net_buf *const buf)
+			    struct net_buf **const pbuf)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_acm_uart_data *data = dev->data;
+	struct net_buf *buf;
 	size_t min_len;
 
 	if (setup->bRequest == GET_LINE_CODING) {
+		min_len = MIN(sizeof(data->line_coding), setup->wLength);
+
+		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), min_len);
 		if (buf == NULL) {
 			return -ENOMEM;
 		}
 
-		min_len = MIN(sizeof(data->line_coding), setup->wLength);
+		*pbuf = buf;
+
 		net_buf_add_mem(buf, &data->line_coding, min_len);
 
 		return 0;

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -929,35 +929,30 @@ static int usbd_cdc_ncm_ctd(struct usbd_class_data *const c_data,
 	return -ENOTSUP;
 }
 
-static int cdc_ncm_cth_response(struct usbd_class_data *const c_data,
-				const struct usb_setup_packet *const setup,
-				struct net_buf **const pbuf,
-				const void *data, uint16_t data_len)
+static struct net_buf *cdc_ncm_cth_response(struct usbd_class_data *const c_data,
+					    const struct usb_setup_packet *const setup,
+					    const void *data, uint16_t data_len)
 {
 	struct net_buf *buf;
 	uint16_t len = MIN(setup->wLength, data_len);
 
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
 
-	*pbuf = buf;
-
 	net_buf_add_mem(buf, data, len);
-
-	return 0;
+	return buf;
 }
 
-static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
-			    const struct usb_setup_packet *const setup,
-			    struct net_buf **const pbuf)
+static struct net_buf *usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
+					const struct usb_setup_packet *const setup)
 {
 	LOG_DBG("%d: %d %d %d %d", setup->RequestType.type, setup->bRequest,
 		setup->wLength, setup->wIndex, setup->wValue);
 
 	if (setup->RequestType.type != USB_REQTYPE_TYPE_CLASS) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	switch (setup->bRequest) {
@@ -978,7 +973,7 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 		};
 
 		LOG_DBG("GET_NTB_PARAMETERS");
-		return cdc_ncm_cth_response(c_data, setup, pbuf, &ntb_params, sizeof(ntb_params));
+		return cdc_ncm_cth_response(c_data, setup, &ntb_params, sizeof(ntb_params));
 	}
 
 	case GET_NTB_INPUT_SIZE: {
@@ -989,15 +984,14 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 		};
 
 		LOG_DBG("GET_NTB_INPUT_SIZE");
-		return cdc_ncm_cth_response(c_data, setup, pbuf, &input_size, sizeof(input_size));
+		return cdc_ncm_cth_response(c_data, setup, &input_size, sizeof(input_size));
 	}
 
 	default:
 		LOG_DBG("bRequest 0x%02x not supported", setup->bRequest);
-		return -ENOTSUP;
 	}
 
-	return 0;
+	return NULL;
 }
 
 static int usbd_cdc_ncm_init(struct usbd_class_data *const c_data)

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -929,9 +929,29 @@ static int usbd_cdc_ncm_ctd(struct usbd_class_data *const c_data,
 	return -ENOTSUP;
 }
 
+static int cdc_ncm_cth_response(struct usbd_class_data *const c_data,
+				const struct usb_setup_packet *const setup,
+				struct net_buf **const pbuf,
+				const void *data, uint16_t data_len)
+{
+	struct net_buf *buf;
+	uint16_t len = MIN(setup->wLength, data_len);
+
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
+
+	net_buf_add_mem(buf, data, len);
+
+	return 0;
+}
+
 static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 			    const struct usb_setup_packet *const setup,
-			    struct net_buf *const buf)
+			    struct net_buf **const pbuf)
 {
 	LOG_DBG("%d: %d %d %d %d", setup->RequestType.type, setup->bRequest,
 		setup->wLength, setup->wIndex, setup->wValue);
@@ -956,11 +976,9 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 			.wNdbOutAlignment = sys_cpu_to_le16(CDC_NCM_ALIGNMENT),
 			.wNtbOutMaxDatagrams = sys_cpu_to_le16(CDC_NCM_RECV_MAX_DATAGRAMS_PER_NTB),
 		};
-		const uint16_t len = MIN(sizeof(ntb_params), setup->wLength);
 
 		LOG_DBG("GET_NTB_PARAMETERS");
-		net_buf_add_mem(buf, &ntb_params, len);
-		break;
+		return cdc_ncm_cth_response(c_data, setup, pbuf, &ntb_params, sizeof(ntb_params));
 	}
 
 	case GET_NTB_INPUT_SIZE: {
@@ -969,11 +987,9 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 			.wNtbInMaxDatagrams = sys_cpu_to_le16(CDC_NCM_SEND_MAX_DATAGRAMS_PER_NTB),
 			.wReserved = sys_cpu_to_le16(0),
 		};
-		const uint16_t len = MIN(sizeof(input_size), setup->wLength);
 
 		LOG_DBG("GET_NTB_INPUT_SIZE");
-		net_buf_add_mem(buf, &input_size, len);
-		break;
+		return cdc_ncm_cth_response(c_data, setup, pbuf, &input_size, sizeof(input_size));
 	}
 
 	default:

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -516,24 +516,21 @@ static int dfu_set_next_state(struct usbd_class_data *const c_data,
 
 /* Run-Time mode instance implementation, for instance "dfu_runtime" */
 
-static int handle_get_status(struct usbd_class_data *const c_data,
-			     const struct usb_setup_packet *const setup,
-			     struct net_buf **const pbuf)
+static struct net_buf *handle_get_status(struct usbd_class_data *const c_data,
+					 const struct usb_setup_packet *const setup)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 	struct net_buf *buf;
 	const size_t getstatus_len = 6;
 
 	if (setup->wLength != getstatus_len) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), getstatus_len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/*
 	 * Add GET_STATUS response consisting of
@@ -545,38 +542,36 @@ static int handle_get_status(struct usbd_class_data *const c_data,
 	net_buf_add_u8(buf, data->state);
 	net_buf_add_u8(buf, 0);
 
-	return 0;
+	return buf;
 }
 
-static int handle_get_state(struct usbd_class_data *const c_data,
-			    const struct usb_setup_packet *const setup,
-			    struct net_buf **const pbuf)
+static struct net_buf *handle_get_state(struct usbd_class_data *const c_data,
+					const struct usb_setup_packet *const setup)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 	struct net_buf *buf;
 	const size_t getstate_len = 1;
 
 	if (setup->wLength != getstate_len) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), getstate_len);
-	if (buf == NULL) {
-		return -ENOMEM;
-	}
 
-	*pbuf = buf;
+	if (buf == NULL) {
+		return NULL;
+	}
 
 	net_buf_add_u8(buf, data->state);
 
-	return 0;
+	return buf;
 }
 
-static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
-					const struct usb_setup_packet *const setup,
-					struct net_buf **const pbuf)
+static struct net_buf *runtime_mode_control_to_host(struct usbd_class_data *const c_data,
+						    const struct usb_setup_packet *const setup)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	struct net_buf *buf = NULL;
 	int ret;
 
 	ret = dfu_set_next_state(c_data, setup);
@@ -584,10 +579,10 @@ static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			ret = handle_get_status(c_data, setup, pbuf);
+			buf = handle_get_status(c_data, setup);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			ret = handle_get_state(c_data, setup, pbuf);
+			buf = handle_get_state(c_data, setup);
 			break;
 		default:
 			break;
@@ -596,7 +591,7 @@ static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 
 	data->state = data->next;
 
-	return ret;
+	return buf;
 }
 
 static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
@@ -657,9 +652,8 @@ USBD_DEFINE_CLASS(dfu_runtime, &runtime_mode_api, &dfu_data, NULL);
 
 /* DFU mode instance implementation, for instance "dfu_dfu" */
 
-static int handle_upload(struct usbd_class_data *const c_data,
-			 const struct usb_setup_packet *const setup,
-			 struct net_buf **const pbuf)
+static struct net_buf *handle_upload(struct usbd_class_data *const c_data,
+				     const struct usb_setup_packet *const setup)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 	uint16_t size;
@@ -671,10 +665,8 @@ static int handle_upload(struct usbd_class_data *const c_data,
 	size = CONFIG_USBD_DFU_TRANSFER_SIZE;
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), size);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/* Do not return more than requested */
 	size = MIN(setup->wLength, size);
@@ -687,10 +679,10 @@ static int handle_upload(struct usbd_class_data *const c_data,
 		}
 	} else {
 		dfu_error(c_data, DFU_ERROR, ERR_UNKNOWN);
-		return -ENOTSUP;
+		net_buf_drop(&buf);
 	}
 
-	return 0;
+	return buf;
 }
 
 static int handle_download(struct usbd_class_data *const c_data,
@@ -717,11 +709,11 @@ static int handle_download(struct usbd_class_data *const c_data,
 	return 0;
 }
 
-static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
-				    const struct usb_setup_packet *const setup,
-				    struct net_buf **const pbuf)
+static struct net_buf *dfu_mode_control_to_host(struct usbd_class_data *const c_data,
+						const struct usb_setup_packet *const setup)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	struct net_buf *buf = NULL;
 	int ret;
 
 	ret = dfu_set_next_state(c_data, setup);
@@ -729,13 +721,13 @@ static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			ret = handle_get_status(c_data, setup, pbuf);
+			buf = handle_get_status(c_data, setup);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			ret = handle_get_state(c_data, setup, pbuf);
+			buf = handle_get_state(c_data, setup);
 			break;
 		case USB_DFU_REQ_UPLOAD:
-			ret = handle_upload(c_data, setup, pbuf);
+			buf = handle_upload(c_data, setup);
 			break;
 		default:
 			break;
@@ -744,7 +736,7 @@ static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 
 	data->state = data->next;
 
-	return ret;
+	return buf;
 }
 
 static int dfu_mode_control_to_dev(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -518,15 +518,22 @@ static int dfu_set_next_state(struct usbd_class_data *const c_data,
 
 static int handle_get_status(struct usbd_class_data *const c_data,
 			     const struct usb_setup_packet *const setup,
-			     struct net_buf *const buf)
+			     struct net_buf **const pbuf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
-	size_t len = MIN(setup->wLength, net_buf_tailroom(buf));
+	struct net_buf *buf;
 	const size_t getstatus_len = 6;
 
-	if (len != getstatus_len) {
+	if (setup->wLength != getstatus_len) {
 		return -ENOTSUP;
 	}
+
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), getstatus_len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	/*
 	 * Add GET_STATUS response consisting of
@@ -543,15 +550,22 @@ static int handle_get_status(struct usbd_class_data *const c_data,
 
 static int handle_get_state(struct usbd_class_data *const c_data,
 			    const struct usb_setup_packet *const setup,
-			    struct net_buf *const buf)
+			    struct net_buf **const pbuf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
-	size_t len = MIN(setup->wLength, net_buf_tailroom(buf));
+	struct net_buf *buf;
 	const size_t getstate_len = 1;
 
-	if (len != getstate_len) {
+	if (setup->wLength != getstate_len) {
 		return -ENOTSUP;
 	}
+
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), getstate_len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	net_buf_add_u8(buf, data->state);
 
@@ -560,7 +574,7 @@ static int handle_get_state(struct usbd_class_data *const c_data,
 
 static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 					const struct usb_setup_packet *const setup,
-					struct net_buf *const buf)
+					struct net_buf **const pbuf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 	int ret;
@@ -570,10 +584,10 @@ static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			ret = handle_get_status(c_data, setup, buf);
+			ret = handle_get_status(c_data, setup, pbuf);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			ret = handle_get_state(c_data, setup, buf);
+			ret = handle_get_state(c_data, setup, pbuf);
 			break;
 		default:
 			break;
@@ -645,12 +659,25 @@ USBD_DEFINE_CLASS(dfu_runtime, &runtime_mode_api, &dfu_data, NULL);
 
 static int handle_upload(struct usbd_class_data *const c_data,
 			 const struct usb_setup_packet *const setup,
-			 struct net_buf *const buf)
+			 struct net_buf **const pbuf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
-	uint16_t size = MIN(setup->wLength, net_buf_tailroom(buf));
+	uint16_t size;
 	struct usbd_dfu_image *const image = data->image;
+	struct net_buf *buf;
 	int ret;
+
+	/* read_cb() requires buffer size CONFIG_USBD_DFU_TRANSFER_SIZE */
+	size = CONFIG_USBD_DFU_TRANSFER_SIZE;
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), size);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
+
+	/* Do not return more than requested */
+	size = MIN(setup->wLength, size);
 
 	ret = image->read_cb(image->priv, setup->wValue, size, buf->data);
 	if (ret >= 0) {
@@ -692,7 +719,7 @@ static int handle_download(struct usbd_class_data *const c_data,
 
 static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 				    const struct usb_setup_packet *const setup,
-				    struct net_buf *const buf)
+				    struct net_buf **const pbuf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 	int ret;
@@ -702,13 +729,13 @@ static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			ret = handle_get_status(c_data, setup, buf);
+			ret = handle_get_status(c_data, setup, pbuf);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			ret = handle_get_state(c_data, setup, buf);
+			ret = handle_get_state(c_data, setup, pbuf);
 			break;
 		case USB_DFU_REQ_UPLOAD:
-			ret = handle_upload(c_data, setup, buf);
+			ret = handle_upload(c_data, setup, pbuf);
 			break;
 		default:
 			break;

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -430,10 +430,23 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 
 static int usbd_hid_cth(struct usbd_class_data *const c_data,
 			const struct usb_setup_packet *const setup,
-			struct net_buf *const buf)
+			struct net_buf **const pbuf)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
+	struct net_buf *buf;
 	int ret = 0;
+
+	/* Get Report is problematic because ops->get_report() currently does
+	 * not make it possible to determine report size without passing
+	 * sufficiently large buffer first. For the time being, just allocate
+	 * setup->wLength bytes.
+	 */
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), setup->wLength);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	switch (setup->bRequest) {
 	case USB_HID_GET_IDLE:

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -428,9 +428,8 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 	return ret;
 }
 
-static int usbd_hid_cth(struct usbd_class_data *const c_data,
-			const struct usb_setup_packet *const setup,
-			struct net_buf **const pbuf)
+static struct net_buf *usbd_hid_cth(struct usbd_class_data *const c_data,
+				    const struct usb_setup_packet *const setup)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct net_buf *buf;
@@ -443,10 +442,8 @@ static int usbd_hid_cth(struct usbd_class_data *const c_data,
 	 */
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), setup->wLength);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	switch (setup->bRequest) {
 	case USB_HID_GET_IDLE:
@@ -466,7 +463,11 @@ static int usbd_hid_cth(struct usbd_class_data *const c_data,
 		break;
 	}
 
-	return ret;
+	if (ret) {
+		net_buf_drop(&buf);
+	}
+
+	return buf;
 }
 
 static void usbd_hid_sof(struct usbd_class_data *const c_data)

--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -287,9 +287,8 @@ static void usbd_midi_class_resumed(struct usbd_class_data *const class_data)
 	k_work_submit(&data->rx_work);
 }
 
-static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
-			       const struct usb_setup_packet *const setup,
-			       struct net_buf **const pbuf)
+static struct net_buf *usbd_midi_class_cth(struct usbd_class_data *const class_data,
+					   const struct usb_setup_packet *const setup)
 {
 	const struct device *dev = usbd_class_get_private(class_data);
 	const struct usbd_midi_config *config = dev->config;
@@ -310,16 +309,14 @@ static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
 	if (data->altsetting != MIDI2_ALTERNATE ||
 	    setup->bRequest != USB_SREQ_GET_DESCRIPTOR ||
 	    setup->wValue != ((CS_GR_TRM_BLOCK << 8) | MIDI2_ALTERNATE)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(class_data),
 					 MIN(total_len, setup->wLength));
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/* Group terminal block header */
 	net_buf_add_mem(buf, (void *) &config->desc->grptrm_header,
@@ -332,7 +329,7 @@ static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
 	}
 	LOG_HEXDUMP_DBG(buf->data, buf->len, "Control to host");
 
-	return 0;
+	return buf;
 }
 
 static int usbd_midi_class_init(struct usbd_class_data *const class_data)

--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -289,11 +289,12 @@ static void usbd_midi_class_resumed(struct usbd_class_data *const class_data)
 
 static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
 			       const struct usb_setup_packet *const setup,
-			       struct net_buf *const buf)
+			       struct net_buf **const pbuf)
 {
 	const struct device *dev = usbd_class_get_private(class_data);
 	const struct usbd_midi_config *config = dev->config;
 	struct usbd_midi_data *data = dev->data;
+	struct net_buf *buf;
 
 	size_t head_len = config->desc->grptrm_header.bLength;
 	size_t total_len = sys_le16_to_cpu(config->desc->grptrm_header.wTotalLength);
@@ -311,6 +312,14 @@ static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
 	    setup->wValue != ((CS_GR_TRM_BLOCK << 8) | MIDI2_ALTERNATE)) {
 		return -ENOTSUP;
 	}
+
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(class_data),
+					 MIN(total_len, setup->wLength));
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	/* Group terminal block header */
 	net_buf_add_mem(buf, (void *) &config->desc->grptrm_header,

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -818,9 +818,10 @@ static int msc_bot_control_to_dev(struct usbd_class_data *const c_data,
 /* USB control request handler to host */
 static int msc_bot_control_to_host(struct usbd_class_data *const c_data,
 				   const struct usb_setup_packet *const setup,
-				   struct net_buf *const buf)
+				   struct net_buf **const pbuf)
 {
 	struct msc_bot_ctx *ctx = usbd_class_get_private(c_data);
+	struct net_buf *buf;
 	uint8_t max_lun;
 
 	if (setup->bRequest == GET_MAX_LUN &&
@@ -830,6 +831,14 @@ static int msc_bot_control_to_host(struct usbd_class_data *const c_data,
 		 * support multiple LUNs and host should only address LUN 0.
 		 */
 		max_lun = ctx->registered_luns ? ctx->registered_luns - 1 : 0;
+
+		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), 1);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		*pbuf = buf;
+
 		net_buf_add_mem(buf, &max_lun, 1);
 	} else {
 		return -ENOTSUP;

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -816,12 +816,11 @@ static int msc_bot_control_to_dev(struct usbd_class_data *const c_data,
 }
 
 /* USB control request handler to host */
-static int msc_bot_control_to_host(struct usbd_class_data *const c_data,
-				   const struct usb_setup_packet *const setup,
-				   struct net_buf **const pbuf)
+static struct net_buf *msc_bot_control_to_host(struct usbd_class_data *const c_data,
+					       const struct usb_setup_packet *const setup)
 {
 	struct msc_bot_ctx *ctx = usbd_class_get_private(c_data);
-	struct net_buf *buf;
+	struct net_buf *buf = NULL;
 	uint8_t max_lun;
 
 	if (setup->bRequest == GET_MAX_LUN &&
@@ -834,17 +833,13 @@ static int msc_bot_control_to_host(struct usbd_class_data *const c_data,
 
 		buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), 1);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
 
-		*pbuf = buf;
-
 		net_buf_add_mem(buf, &max_lun, 1);
-	} else {
-		return -ENOTSUP;
 	}
 
-	return 0;
+	return buf;
 }
 
 /* Endpoint request completion event handler */

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -571,14 +571,26 @@ static uint32_t find_closest(const uint32_t input, const uint32_t *values,
 }
 
 /* Table 5-6: 4-byte Control CUR Parameter Block */
-static void layout3_cur_response(struct net_buf *const buf, uint16_t length,
-				 const uint32_t value)
+static int layout3_cur_response(struct usbd_class_data *const c_data,
+				struct net_buf **const pbuf, uint16_t length,
+				const uint32_t value)
 {
+	struct net_buf *buf;
 	uint8_t tmp[4];
+
+	length = MIN(length, 4);
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), length);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	/* dCUR */
 	sys_put_le32(value, tmp);
-	net_buf_add_mem(buf, tmp, MIN(length, 4));
+	net_buf_add_mem(buf, tmp, length);
+
+	return 0;
 }
 
 static int layout3_cur_request(const struct net_buf *const buf, uint32_t *out)
@@ -595,14 +607,28 @@ static int layout3_cur_request(const struct net_buf *const buf, uint32_t *out)
 }
 
 /* Table 5-7: 4-byte Control RANGE Parameter Block */
-static void layout3_range_response(struct net_buf *const buf, uint16_t length,
-				   const uint32_t *min, const uint32_t *max,
-				   const uint32_t *res, int n)
+static int layout3_range_response(struct usbd_class_data *const c_data,
+				  struct net_buf **const pbuf, uint16_t length,
+				  const uint32_t *min, const uint32_t *max,
+				  const uint32_t *res, int n)
 {
+	struct net_buf *buf;
 	uint16_t to_add;
 	uint8_t tmp[4];
 	int i;
 	int item;
+
+	/* Host can set wLength as large as it wants, but we only need to
+	 * allocate memory for maximum number of entries consisting of:
+	 *   2 (wNumSubRanges) + 12 (dMIN, dMAX, dRES) * n
+	 */
+	length = MIN(2 + 12 * n, length);
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), length);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	/* wNumSubRanges */
 	sys_put_le16(n, tmp);
@@ -635,11 +661,13 @@ static void layout3_range_response(struct net_buf *const buf, uint16_t length,
 			i++;
 		}
 	}
+
+	return 0;
 }
 
 static int get_clock_source_request(struct usbd_class_data *const c_data,
 				    const struct usb_setup_packet *const setup,
-				    struct net_buf *const buf)
+				    struct net_buf **const pbuf)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct uac2_ctx *ctx = dev->data;
@@ -659,9 +687,8 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 	if (CONTROL_SELECTOR(setup) == CS_SAM_FREQ_CONTROL) {
 		if (CONTROL_ATTRIBUTE(setup) == CUR) {
 			if (count == 1) {
-				layout3_cur_response(buf, setup->wLength,
-						     frequencies[0]);
-				return 0;
+				return layout3_cur_response(c_data, pbuf, setup->wLength,
+							    frequencies[0]);
 			}
 
 			if (ctx->ops->get_sample_rate) {
@@ -669,13 +696,11 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 
 				hz = ctx->ops->get_sample_rate(dev, clock_id,
 							       ctx->user_data);
-				layout3_cur_response(buf, setup->wLength, hz);
-				return 0;
+				return layout3_cur_response(c_data, pbuf, setup->wLength, hz);
 			}
 		} else if (CONTROL_ATTRIBUTE(setup) == RANGE) {
-			layout3_range_response(buf, setup->wLength, frequencies,
-					       frequencies, NULL, count);
-			return 0;
+			return layout3_range_response(c_data, pbuf, setup->wLength, frequencies,
+						      frequencies, NULL, count);
 		}
 	} else {
 		LOG_DBG("Unhandled clock control selector 0x%02x",
@@ -770,7 +795,7 @@ static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 
 static int uac2_control_to_host(struct usbd_class_data *const c_data,
 				const struct usb_setup_packet *const setup,
-				struct net_buf *const buf)
+				struct net_buf **const pbuf)
 {
 	entity_type_t entity_type;
 
@@ -782,7 +807,7 @@ static int uac2_control_to_host(struct usbd_class_data *const c_data,
 	if (setup->bmRequestType == GET_CLASS_REQUEST_TYPE) {
 		entity_type = id_type(c_data, CONTROL_ENTITY_ID(setup));
 		if (entity_type == ENTITY_TYPE_CLOCK_SOURCE) {
-			return get_clock_source_request(c_data, setup, buf);
+			return get_clock_source_request(c_data, setup, pbuf);
 		}
 	}
 

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -571,9 +571,8 @@ static uint32_t find_closest(const uint32_t input, const uint32_t *values,
 }
 
 /* Table 5-6: 4-byte Control CUR Parameter Block */
-static int layout3_cur_response(struct usbd_class_data *const c_data,
-				struct net_buf **const pbuf, uint16_t length,
-				const uint32_t value)
+static struct net_buf *layout3_cur_response(struct usbd_class_data *const c_data,
+					    uint16_t length, const uint32_t value)
 {
 	struct net_buf *buf;
 	uint8_t tmp[4];
@@ -581,16 +580,14 @@ static int layout3_cur_response(struct usbd_class_data *const c_data,
 	length = MIN(length, 4);
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), length);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/* dCUR */
 	sys_put_le32(value, tmp);
 	net_buf_add_mem(buf, tmp, length);
 
-	return 0;
+	return buf;
 }
 
 static int layout3_cur_request(const struct net_buf *const buf, uint32_t *out)
@@ -607,10 +604,10 @@ static int layout3_cur_request(const struct net_buf *const buf, uint32_t *out)
 }
 
 /* Table 5-7: 4-byte Control RANGE Parameter Block */
-static int layout3_range_response(struct usbd_class_data *const c_data,
-				  struct net_buf **const pbuf, uint16_t length,
-				  const uint32_t *min, const uint32_t *max,
-				  const uint32_t *res, int n)
+static struct net_buf *layout3_range_response(struct usbd_class_data *const c_data,
+					      uint16_t length,
+					      const uint32_t *min, const uint32_t *max,
+					      const uint32_t *res, int n)
 {
 	struct net_buf *buf;
 	uint16_t to_add;
@@ -625,10 +622,8 @@ static int layout3_range_response(struct usbd_class_data *const c_data,
 	length = MIN(2 + 12 * n, length);
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), length);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/* wNumSubRanges */
 	sys_put_le16(n, tmp);
@@ -662,12 +657,11 @@ static int layout3_range_response(struct usbd_class_data *const c_data,
 		}
 	}
 
-	return 0;
+	return buf;
 }
 
-static int get_clock_source_request(struct usbd_class_data *const c_data,
-				    const struct usb_setup_packet *const setup,
-				    struct net_buf **const pbuf)
+static struct net_buf *get_clock_source_request(struct usbd_class_data *const c_data,
+						const struct usb_setup_packet *const setup)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct uac2_ctx *ctx = dev->data;
@@ -679,7 +673,7 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 	if (CONTROL_CHANNEL_NUMBER(setup) != 0) {
 		LOG_DBG("Clock source control with channel %d",
 			CONTROL_CHANNEL_NUMBER(setup));
-		return -EINVAL;
+		return NULL;
 	}
 
 	count = clock_frequencies(c_data, clock_id, &frequencies);
@@ -687,7 +681,7 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 	if (CONTROL_SELECTOR(setup) == CS_SAM_FREQ_CONTROL) {
 		if (CONTROL_ATTRIBUTE(setup) == CUR) {
 			if (count == 1) {
-				return layout3_cur_response(c_data, pbuf, setup->wLength,
+				return layout3_cur_response(c_data, setup->wLength,
 							    frequencies[0]);
 			}
 
@@ -696,10 +690,10 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 
 				hz = ctx->ops->get_sample_rate(dev, clock_id,
 							       ctx->user_data);
-				return layout3_cur_response(c_data, pbuf, setup->wLength, hz);
+				return layout3_cur_response(c_data, setup->wLength, hz);
 			}
 		} else if (CONTROL_ATTRIBUTE(setup) == RANGE) {
-			return layout3_range_response(c_data, pbuf, setup->wLength, frequencies,
+			return layout3_range_response(c_data, setup->wLength, frequencies,
 						      frequencies, NULL, count);
 		}
 	} else {
@@ -707,7 +701,7 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 			CONTROL_SELECTOR(setup));
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 static int set_clock_source_request(struct usbd_class_data *const c_data,
@@ -793,25 +787,24 @@ static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 	return -ENOTSUP;
 }
 
-static int uac2_control_to_host(struct usbd_class_data *const c_data,
-				const struct usb_setup_packet *const setup,
-				struct net_buf **const pbuf)
+static struct net_buf *uac2_control_to_host(struct usbd_class_data *const c_data,
+					    const struct usb_setup_packet *const setup)
 {
 	entity_type_t entity_type;
 
 	if ((CONTROL_ATTRIBUTE(setup) != CUR) &&
 	    (CONTROL_ATTRIBUTE(setup) != RANGE)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (setup->bmRequestType == GET_CLASS_REQUEST_TYPE) {
 		entity_type = id_type(c_data, CONTROL_ENTITY_ID(setup));
 		if (entity_type == ENTITY_TYPE_CLOCK_SOURCE) {
-			return get_clock_source_request(c_data, setup, pbuf);
+			return get_clock_source_request(c_data, setup);
 		}
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *buf,

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1024,10 +1024,12 @@ err:
 
 static int uvc_control_to_host(struct usbd_class_data *const c_data,
 			       const struct usb_setup_packet *const setup,
-			       struct net_buf *const buf)
+			       struct net_buf **const pbuf)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_control_map *map = NULL;
+	struct net_buf *buf;
+	const size_t size = MIN(sizeof(struct uvc_probe), setup->wLength);
 	uint8_t request = setup->bRequest;
 	int err;
 
@@ -1037,6 +1039,13 @@ static int uvc_control_to_host(struct usbd_class_data *const c_data,
 		request == UVC_GET_LEN ? "GET_LEN" : request == UVC_GET_DEF ? "GET_DEF" :
 		request == UVC_GET_INFO ? "GET_INFO" : "bad",
 		setup->wValue, setup->wIndex, setup->wLength);
+
+	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), size);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	switch (uvc_get_control_op(dev, setup, &map)) {
 	case UVC_OP_VS_PROBE:

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1022,9 +1022,8 @@ err:
 	return UVC_OP_RETURN_ERROR;
 }
 
-static int uvc_control_to_host(struct usbd_class_data *const c_data,
-			       const struct usb_setup_packet *const setup,
-			       struct net_buf **const pbuf)
+static struct net_buf *uvc_control_to_host(struct usbd_class_data *const c_data,
+					   const struct usb_setup_packet *const setup)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_control_map *map = NULL;
@@ -1042,10 +1041,8 @@ static int uvc_control_to_host(struct usbd_class_data *const c_data,
 
 	buf = usbd_ep_ctrl_data_in_alloc(usbd_class_get_ctx(c_data), size);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	switch (uvc_get_control_op(dev, setup, &map)) {
 	case UVC_OP_VS_PROBE:
@@ -1061,15 +1058,19 @@ static int uvc_control_to_host(struct usbd_class_data *const c_data,
 		err = uvc_get_errno(dev, buf, setup);
 		break;
 	case UVC_OP_RETURN_ERROR:
-		return -EINVAL;
+		net_buf_unref(buf);
+		return NULL;
 	default:
 		LOG_WRN("Unhandled operation, stalling control command");
 		err = -EINVAL;
 	}
 
 	uvc_set_errno(dev, -err);
+	if (err != 0) {
+		net_buf_drop(&buf);
+	}
 
-	return err;
+	return buf;
 }
 
 static int uvc_control_to_dev(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(usbd_ch9, CONFIG_USBD_LOG_LEVEL);
 #define SF_TEST_LOWER_BYTE(wIndex)		((uint8_t)(wIndex))
 
 static int nonstd_request(struct usbd_context *const uds_ctx,
-			  struct net_buf *const dbuf);
+			  struct net_buf **const pbuf);
 
 static bool reqtype_is_to_host(const struct usb_setup_packet *const setup)
 {
@@ -355,9 +355,10 @@ static int std_request_to_device(struct usbd_context *const uds_ctx,
 }
 
 static int sreq_get_status(struct usbd_context *const uds_ctx,
-			   struct net_buf *const buf)
+			   struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
+	struct net_buf *buf;
 	uint8_t ep = setup->wIndex;
 	uint16_t response = 0;
 
@@ -397,9 +398,12 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 		break;
 	}
 
-	if (net_buf_tailroom(buf) < setup->wLength) {
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(response));
+	if (buf == NULL) {
 		return -ENOMEM;
 	}
+
+	*pbuf = buf;
 
 	LOG_DBG("Get Status response 0x%04x", response);
 	net_buf_add_le16(buf, response);
@@ -412,7 +416,7 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
  * descriptor type requests.
  */
 static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
-			     struct net_buf *const buf,
+			     struct net_buf **const pbuf,
 			     const uint8_t idx,
 			     const bool other_cfg)
 {
@@ -423,6 +427,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	struct usbd_config_node *cfg_nd;
 	enum usbd_speed get_desc_speed;
 	struct usbd_class_node *c_nd;
+	struct net_buf *buf;
 	uint16_t len;
 
 	/*
@@ -459,6 +464,14 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	} else {
 		cfg_desc = cfg_nd->desc;
 	}
+
+	len = MIN(sys_le16_to_cpu(cfg_desc->wTotalLength), setup->wLength);
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	net_buf_add_mem(buf, cfg_desc, MIN(net_buf_tailroom(buf), cfg_desc->bLength));
 
@@ -516,13 +529,15 @@ static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_SN_ASCII7_LENGTH])
 }
 
 /* Copy and convert ASCII-7 string descriptor to UTF16-LE */
-static int string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
-				    struct net_buf *const buf, const uint16_t wLength)
+static int string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
+				    struct usbd_desc_node *const dn,
+				    struct net_buf **const pbuf, const uint16_t wLength)
 {
 	uint8_t sn_ascii7_str[USBD_SN_ASCII7_LENGTH];
 	struct usb_desc_header head = {
 		.bDescriptorType = dn->bDescriptorType,
 	};
+	struct net_buf *buf;
 	const uint8_t *ascii7_str;
 	size_t len;
 	size_t i;
@@ -542,10 +557,15 @@ static int string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 		ascii7_str = (uint8_t *)dn->ptr;
 	}
 
-	LOG_DBG("wLength %u, bLength %u, tailroom %zu",
-		wLength, head.bLength, net_buf_tailroom(buf));
+	LOG_DBG("wLength %u, bLength %u", wLength, head.bLength);
 
-	len = MIN(net_buf_tailroom(buf), MIN(head.bLength,  wLength));
+	len = MIN(head.bLength, wLength);
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
 
 	/* Add bLength and bDescriptorType */
 	net_buf_add_mem(buf, &head, MIN(len, sizeof(head)));
@@ -566,13 +586,12 @@ static int string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 }
 
 static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
-			     struct net_buf *const buf)
+			     struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_desc_header *head;
+	struct net_buf *buf;
 	size_t len;
-
-	len = MIN(setup->wLength, net_buf_tailroom(buf));
 
 	switch (usbd_bus_speed(uds_ctx)) {
 	case USBD_SPEED_FS:
@@ -589,13 +608,21 @@ static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
 		return -EINVAL;
 	}
 
-	net_buf_add_mem(buf, head, MIN(len, head->bLength));
+	len = MIN(setup->wLength, head->bLength);
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
+
+	net_buf_add_mem(buf, head, len);
 
 	return 0;
 }
 
 static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
-			     struct net_buf *const buf, const uint8_t idx)
+			     struct net_buf **const pbuf, const uint8_t idx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usbd_desc_node *d_nd;
@@ -614,19 +641,27 @@ static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
 			.bDescriptorType = d_nd->bDescriptorType,
 			.bString =  *(uint16_t *)d_nd->ptr,
 		};
+		struct net_buf *buf;
 
-		len = MIN(setup->wLength, net_buf_tailroom(buf));
-		net_buf_add_mem(buf, &langid, MIN(len, langid.bLength));
+		len = MIN(setup->wLength, langid.bLength);
+		buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		*pbuf = buf;
+
+		net_buf_add_mem(buf, &langid, len);
 	} else {
 		/* String descriptors in ASCII7 format */
-		return string_ascii7_to_utf16le(d_nd, buf, setup->wLength);
+		return string_ascii7_to_utf16le(uds_ctx, d_nd, pbuf, setup->wLength);
 	}
 
 	return 0;
 }
 
 static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
-				  struct net_buf *const buf)
+				  struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	/* At Full-Speed we want High-Speed descriptor and vice versa */
@@ -638,6 +673,7 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 		.bDescriptorType = USB_DESC_DEVICE_QUALIFIER,
 		.bReserved = 0U,
 	};
+	struct net_buf *buf;
 	size_t len;
 
 	/*
@@ -661,8 +697,16 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 	q_desc.bNumConfigurations = d_desc->bNumConfigurations;
 
 	LOG_DBG("Get Device Qualifier");
-	len = MIN(setup->wLength, net_buf_tailroom(buf));
-	net_buf_add_mem(buf, &q_desc, MIN(len, q_desc.bLength));
+
+	len = MIN(setup->wLength, q_desc.bLength);
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
+
+	net_buf_add_mem(buf, &q_desc, len);
 
 	return 0;
 }
@@ -686,12 +730,13 @@ static void desc_fill_bos_root(struct usbd_context *const uds_ctx,
 }
 
 static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
-			     struct net_buf *const buf)
+			     struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_device_descriptor *dev_dsc;
 	struct usb_bos_descriptor bos;
 	struct usbd_desc_node *desc_nd;
+	struct net_buf *buf;
 	size_t len;
 
 	if (!IS_ENABLED(CONFIG_USBD_BOS_SUPPORT)) {
@@ -718,13 +763,22 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	}
 
 	desc_fill_bos_root(uds_ctx, &bos);
-	len = MIN(net_buf_tailroom(buf), MIN(setup->wLength, bos.wTotalLength));
+
+	len = MIN(setup->wLength, bos.wTotalLength);
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	*pbuf = buf;
+
 	LOG_DBG("wLength %u, bLength %u, wTotalLength %u, tailroom %zu",
 		setup->wLength, bos.bLength, bos.wTotalLength, net_buf_tailroom(buf));
 
+	bos.wTotalLength = sys_cpu_to_le16(bos.wTotalLength);
 	net_buf_add_mem(buf, &bos, MIN(len, bos.bLength));
 
-	len -= MIN(len, sizeof(bos));
+	len -= MIN(len, bos.bLength);
 	if (len == 0) {
 		return 0;
 	}
@@ -746,7 +800,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 }
 
 static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
-			       struct net_buf *const buf)
+			       struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	uint8_t desc_type = USB_GET_DESCRIPTOR_TYPE(setup->wValue);
@@ -762,22 +816,22 @@ static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
 		 * number or endpoint and not the language ID. e.g. HID
 		 * Class Get Descriptor request.
 		 */
-		return nonstd_request(uds_ctx, buf);
+		return nonstd_request(uds_ctx, pbuf);
 	}
 
 	switch (desc_type) {
 	case USB_DESC_DEVICE:
-		return sreq_get_desc_dev(uds_ctx, buf);
+		return sreq_get_desc_dev(uds_ctx, pbuf);
 	case USB_DESC_CONFIGURATION:
-		return sreq_get_desc_cfg(uds_ctx, buf, desc_idx, false);
+		return sreq_get_desc_cfg(uds_ctx, pbuf, desc_idx, false);
 	case USB_DESC_OTHER_SPEED:
-		return sreq_get_desc_cfg(uds_ctx, buf, desc_idx, true);
+		return sreq_get_desc_cfg(uds_ctx, pbuf, desc_idx, true);
 	case USB_DESC_STRING:
-		return sreq_get_desc_str(uds_ctx, buf, desc_idx);
+		return sreq_get_desc_str(uds_ctx, pbuf, desc_idx);
 	case USB_DESC_DEVICE_QUALIFIER:
-		return sreq_get_dev_qualifier(uds_ctx, buf);
+		return sreq_get_dev_qualifier(uds_ctx, pbuf);
 	case USB_DESC_BOS:
-		return sreq_get_desc_bos(uds_ctx, buf);
+		return sreq_get_desc_bos(uds_ctx, pbuf);
 	case USB_DESC_INTERFACE:
 	case USB_DESC_ENDPOINT:
 	default:
@@ -788,10 +842,11 @@ static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
 }
 
 static int sreq_get_configuration(struct usbd_context *const uds_ctx,
-				  struct net_buf *const buf)
+				  struct net_buf **const pbuf)
 
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
+	struct net_buf *buf;
 	uint8_t cfg = usbd_get_config_value(uds_ctx);
 
 	/* Not specified in default state, treat as error */
@@ -803,9 +858,12 @@ static int sreq_get_configuration(struct usbd_context *const uds_ctx,
 		return -ENOTSUP;
 	}
 
-	if (net_buf_tailroom(buf) < setup->wLength) {
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(cfg));
+	if (buf == NULL) {
 		return -ENOMEM;
 	}
+
+	*pbuf = buf;
 
 	net_buf_add_u8(buf, cfg);
 
@@ -813,11 +871,12 @@ static int sreq_get_configuration(struct usbd_context *const uds_ctx,
 }
 
 static int sreq_get_interface(struct usbd_context *const uds_ctx,
-			      struct net_buf *const buf)
+			      struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_cfg_descriptor *cfg_desc;
 	struct usbd_config_node *cfg_nd;
+	struct net_buf *buf;
 	uint8_t cur_alt;
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
@@ -848,9 +907,12 @@ static int sreq_get_interface(struct usbd_context *const uds_ctx,
 		return -ENOTSUP;
 	}
 
-	if (net_buf_tailroom(buf) < setup->wLength) {
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(cur_alt));
+	if (buf == NULL) {
 		return -ENOMEM;
 	}
+
+	*pbuf = buf;
 
 	net_buf_add_u8(buf, cur_alt);
 
@@ -858,23 +920,23 @@ static int sreq_get_interface(struct usbd_context *const uds_ctx,
 }
 
 static int std_request_to_host(struct usbd_context *const uds_ctx,
-			       struct net_buf *const buf)
+			       struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	int ret;
 
 	switch (setup->bRequest) {
 	case USB_SREQ_GET_STATUS:
-		ret = sreq_get_status(uds_ctx, buf);
+		ret = sreq_get_status(uds_ctx, pbuf);
 		break;
 	case USB_SREQ_GET_DESCRIPTOR:
-		ret = sreq_get_descriptor(uds_ctx, buf);
+		ret = sreq_get_descriptor(uds_ctx, pbuf);
 		break;
 	case USB_SREQ_GET_CONFIGURATION:
-		ret = sreq_get_configuration(uds_ctx, buf);
+		ret = sreq_get_configuration(uds_ctx, pbuf);
 		break;
 	case USB_SREQ_GET_INTERFACE:
-		ret = sreq_get_interface(uds_ctx, buf);
+		ret = sreq_get_interface(uds_ctx, pbuf);
 		break;
 	default:
 		ret = -ENOTSUP;
@@ -885,7 +947,7 @@ static int std_request_to_host(struct usbd_context *const uds_ctx,
 }
 
 static int vendor_device_request(struct usbd_context *const uds_ctx,
-				 struct net_buf *const buf)
+				 struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usbd_vreq_node *vreq_nd;
@@ -901,19 +963,19 @@ static int vendor_device_request(struct usbd_context *const uds_ctx,
 
 	if (reqtype_is_to_device(setup) && vreq_nd->to_dev != NULL) {
 		LOG_DBG("Vendor request 0x%02x to device", setup->bRequest);
-		return vreq_nd->to_dev(uds_ctx, setup, buf);
+		return vreq_nd->to_dev(uds_ctx, setup, *pbuf);
 	}
 
 	if (reqtype_is_to_host(setup) && vreq_nd->to_host != NULL) {
 		LOG_DBG("Vendor request 0x%02x to host", setup->bRequest);
-		return vreq_nd->to_host(uds_ctx, setup, buf);
+		return vreq_nd->to_host(uds_ctx, setup, pbuf);
 	}
 
 	return -ENOTSUP;
 }
 
 static int nonstd_request(struct usbd_context *const uds_ctx,
-			  struct net_buf *const dbuf)
+			  struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usbd_class_node *c_nd = NULL;
@@ -935,19 +997,19 @@ static int nonstd_request(struct usbd_context *const uds_ctx,
 
 	if (c_nd != NULL) {
 		if (reqtype_is_to_device(setup)) {
-			ret = usbd_class_control_to_dev(c_nd->c_data, setup, dbuf);
+			ret = usbd_class_control_to_dev(c_nd->c_data, setup, *pbuf);
 		} else {
-			ret = usbd_class_control_to_host(c_nd->c_data, setup, dbuf);
+			ret = usbd_class_control_to_host(c_nd->c_data, setup, pbuf);
 		}
 	} else {
-		return vendor_device_request(uds_ctx, dbuf);
+		return vendor_device_request(uds_ctx, pbuf);
 	}
 
 	return ret;
 }
 
 static int handle_setup_request(struct usbd_context *const uds_ctx,
-				struct net_buf *const buf)
+				struct net_buf **const pbuf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	int ret;
@@ -957,14 +1019,14 @@ static int handle_setup_request(struct usbd_context *const uds_ctx,
 	switch (setup->RequestType.type) {
 	case USB_REQTYPE_TYPE_STANDARD:
 		if (reqtype_is_to_device(setup)) {
-			ret = std_request_to_device(uds_ctx, buf);
+			ret = std_request_to_device(uds_ctx, *pbuf);
 		} else {
-			ret = std_request_to_host(uds_ctx, buf);
+			ret = std_request_to_host(uds_ctx, pbuf);
 		}
 		break;
 	case USB_REQTYPE_TYPE_CLASS:
 	case USB_REQTYPE_TYPE_VENDOR:
-		ret = nonstd_request(uds_ctx, buf);
+		ret = nonstd_request(uds_ctx, pbuf);
 		break;
 	default:
 		ret = -ENOTSUP;
@@ -1118,24 +1180,17 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 				net_buf_unref(next_buf);
 				goto ctrl_xfer_stall;
 			}
-
-			if (reqtype_is_to_host(setup) && setup->wLength) {
-				/* Stack is supposed to allocate buffer */
-				next_buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, setup->wLength);
-				if (next_buf == NULL) {
-					goto ctrl_xfer_stall;
-				}
-			}
 		} else {
 			/* Data OUT received */
 			next_buf = buf;
 		}
 
 		/*
-		 * Handle request and data stage, next_buf is either
-		 * data buffer or is NULL.
+		 * Handle request and data stage, next_buf holds either received
+		 * data OUT buffer or is NULL.
 		 */
-		ret = handle_setup_request(uds_ctx, next_buf);
+		ret = handle_setup_request(uds_ctx, &next_buf);
+
 		if (ret) {
 			if (next_buf) {
 				net_buf_unref(next_buf);
@@ -1168,6 +1223,10 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 			ret = usbd_enqueue_status_in(uds_ctx);
 		} else {
 			/* Enqueue Data IN */
+			if (next_buf == NULL) {
+				goto ctrl_xfer_stall;
+			}
+
 			ret = usbd_ep_ctrl_enqueue(uds_ctx, next_buf);
 			if (ret) {
 				net_buf_unref(next_buf);

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -354,8 +354,7 @@ static int std_request_to_device(struct usbd_context *const uds_ctx,
 	return ret;
 }
 
-static int sreq_get_status(struct usbd_context *const uds_ctx,
-			   struct net_buf **const pbuf)
+static struct net_buf *sreq_get_status(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct net_buf *buf;
@@ -363,22 +362,22 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 	uint16_t response = 0;
 
 	if (setup->wLength != sizeof(response)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	/* Not specified in default state, treat as error */
 	if (usbd_state_is_default(uds_ctx)) {
-		return -EPERM;
+		return NULL;
 	}
 
 	if (usbd_state_is_address(uds_ctx) && setup->wIndex) {
-		return -EPERM;
+		return NULL;
 	}
 
 	switch (setup->RequestType.recipient) {
 	case USB_REQTYPE_RECIPIENT_DEVICE:
 		if (setup->wIndex != 0) {
-			return -EPERM;
+			return NULL;
 		}
 
 		response = uds_ctx->status.rwup ?
@@ -400,25 +399,22 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(response));
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	LOG_DBG("Get Status response 0x%04x", response);
 	net_buf_add_le16(buf, response);
 
-	return 0;
+	return buf;
 }
 
 /*
  * This function handles configuration and USB2.0 other-speed-configuration
  * descriptor type requests.
  */
-static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
-			     struct net_buf **const pbuf,
-			     const uint8_t idx,
-			     const bool other_cfg)
+static struct net_buf *sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
+					 const uint8_t idx,
+					 const bool other_cfg)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	enum usbd_speed speed = usbd_bus_speed(uds_ctx);
@@ -437,7 +433,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	 */
 	if (other_cfg && !(USBD_SUPPORTS_HIGH_SPEED &&
 	    (usbd_caps_speed(uds_ctx) == USBD_SPEED_HS))) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (other_cfg) {
@@ -453,7 +449,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	cfg_nd = usbd_config_get(uds_ctx, get_desc_speed, idx + 1);
 	if (cfg_nd == NULL) {
 		LOG_ERR("Configuration descriptor %u not found", idx + 1);
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (other_cfg) {
@@ -468,10 +464,8 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	len = MIN(sys_le16_to_cpu(cfg_desc->wTotalLength), setup->wLength);
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	net_buf_add_mem(buf, cfg_desc, MIN(net_buf_tailroom(buf), cfg_desc->bLength));
 
@@ -496,7 +490,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 
 	LOG_DBG("Get Configuration descriptor %u, len %u", idx, buf->len);
 
-	return 0;
+	return buf;
 }
 
 #define USBD_SN_ASCII7_LENGTH (CONFIG_USBD_HWINFO_DEVID_LENGTH * 2)
@@ -529,9 +523,9 @@ static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_SN_ASCII7_LENGTH])
 }
 
 /* Copy and convert ASCII-7 string descriptor to UTF16-LE */
-static int string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
-				    struct usbd_desc_node *const dn,
-				    struct net_buf **const pbuf, const uint16_t wLength)
+static struct net_buf *string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
+						struct usbd_desc_node *const dn,
+						const uint16_t wLength)
 {
 	uint8_t sn_ascii7_str[USBD_SN_ASCII7_LENGTH];
 	struct usb_desc_header head = {
@@ -547,7 +541,7 @@ static int string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
 		ssize_t sn_ascii7_str_len = get_sn_from_hwid(sn_ascii7_str);
 
 		if (sn_ascii7_str_len < 0) {
-			return -ENOTSUP;
+			return NULL;
 		}
 
 		head.bLength = sizeof(head) + sn_ascii7_str_len * 2;
@@ -562,10 +556,8 @@ static int string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
 	len = MIN(head.bLength, wLength);
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	/* Add bLength and bDescriptorType */
 	net_buf_add_mem(buf, &head, MIN(len, sizeof(head)));
@@ -582,11 +574,10 @@ static int string_ascii7_to_utf16le(struct usbd_context *const uds_ctx,
 		net_buf_add_u8(buf, ascii7_str[i]);
 	}
 
-	return 0;
+	return buf;
 }
 
-static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
-			     struct net_buf **const pbuf)
+static struct net_buf *sreq_get_desc_dev(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_desc_header *head;
@@ -601,37 +592,36 @@ static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
 		head = uds_ctx->hs_desc;
 		break;
 	default:
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (head == NULL) {
-		return -EINVAL;
+		return NULL;
 	}
 
 	len = MIN(setup->wLength, head->bLength);
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	net_buf_add_mem(buf, head, len);
 
-	return 0;
+	return buf;
 }
 
-static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
-			     struct net_buf **const pbuf, const uint8_t idx)
+static struct net_buf *sreq_get_desc_str(struct usbd_context *const uds_ctx,
+					 const uint8_t idx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usbd_desc_node *d_nd;
+	struct net_buf *buf = NULL;
 	size_t len;
 
 	/* Get string descriptor */
 	d_nd = usbd_get_descriptor(uds_ctx, USB_DESC_STRING, idx);
 	if (d_nd == NULL) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (usbd_str_desc_get_idx(d_nd) == 0U) {
@@ -641,27 +631,23 @@ static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
 			.bDescriptorType = d_nd->bDescriptorType,
 			.bString =  *(uint16_t *)d_nd->ptr,
 		};
-		struct net_buf *buf;
 
 		len = MIN(setup->wLength, langid.bLength);
 		buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 		if (buf == NULL) {
-			return -ENOMEM;
+			return NULL;
 		}
-
-		*pbuf = buf;
 
 		net_buf_add_mem(buf, &langid, len);
 	} else {
 		/* String descriptors in ASCII7 format */
-		return string_ascii7_to_utf16le(uds_ctx, d_nd, pbuf, setup->wLength);
+		return string_ascii7_to_utf16le(uds_ctx, d_nd, setup->wLength);
 	}
 
-	return 0;
+	return buf;
 }
 
-static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
-				  struct net_buf **const pbuf)
+static struct net_buf *sreq_get_dev_qualifier(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	/* At Full-Speed we want High-Speed descriptor and vice versa */
@@ -682,11 +668,11 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 	 */
 	if (!USBD_SUPPORTS_HIGH_SPEED ||
 	    usbd_caps_speed(uds_ctx) != USBD_SPEED_HS) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (d_desc == NULL) {
-		return -EINVAL;
+		return NULL;
 	}
 
 	q_desc.bcdUSB = d_desc->bcdUSB;
@@ -701,14 +687,12 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 	len = MIN(setup->wLength, q_desc.bLength);
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	net_buf_add_mem(buf, &q_desc, len);
 
-	return 0;
+	return buf;
 }
 
 static void desc_fill_bos_root(struct usbd_context *const uds_ctx,
@@ -729,8 +713,7 @@ static void desc_fill_bos_root(struct usbd_context *const uds_ctx,
 	}
 }
 
-static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
-			     struct net_buf **const pbuf)
+static struct net_buf *sreq_get_desc_bos(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_device_descriptor *dev_dsc;
@@ -740,7 +723,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	size_t len;
 
 	if (!IS_ENABLED(CONFIG_USBD_BOS_SUPPORT)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	switch (usbd_bus_speed(uds_ctx)) {
@@ -751,15 +734,15 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 		dev_dsc = uds_ctx->hs_desc;
 		break;
 	default:
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (dev_dsc == NULL) {
-		return -EINVAL;
+		return NULL;
 	}
 
 	if (sys_le16_to_cpu(dev_dsc->bcdUSB) < 0x0201U) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	desc_fill_bos_root(uds_ctx, &bos);
@@ -767,10 +750,8 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	len = MIN(setup->wLength, bos.wTotalLength);
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, len);
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	LOG_DBG("wLength %u, bLength %u, wTotalLength %u, tailroom %zu",
 		setup->wLength, bos.bLength, bos.wTotalLength, net_buf_tailroom(buf));
@@ -780,7 +761,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 
 	len -= MIN(len, bos.bLength);
 	if (len == 0) {
-		return 0;
+		return buf;
 	}
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&uds_ctx->descriptors, desc_nd, node) {
@@ -796,11 +777,10 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 		}
 	}
 
-	return 0;
+	return buf;
 }
 
-static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
-			       struct net_buf **const pbuf)
+static struct net_buf *sreq_get_descriptor(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	uint8_t desc_type = USB_GET_DESCRIPTOR_TYPE(setup->wValue);
@@ -810,39 +790,42 @@ static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
 		desc_type, desc_idx);
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
+		struct net_buf *buf = NULL;
+
 		/*
 		 * If the recipient is not the device then it is probably a
 		 * class specific  request where wIndex is the interface
 		 * number or endpoint and not the language ID. e.g. HID
 		 * Class Get Descriptor request.
 		 */
-		return nonstd_request(uds_ctx, pbuf);
+		nonstd_request(uds_ctx, &buf);
+
+		return buf;
 	}
 
 	switch (desc_type) {
 	case USB_DESC_DEVICE:
-		return sreq_get_desc_dev(uds_ctx, pbuf);
+		return sreq_get_desc_dev(uds_ctx);
 	case USB_DESC_CONFIGURATION:
-		return sreq_get_desc_cfg(uds_ctx, pbuf, desc_idx, false);
+		return sreq_get_desc_cfg(uds_ctx, desc_idx, false);
 	case USB_DESC_OTHER_SPEED:
-		return sreq_get_desc_cfg(uds_ctx, pbuf, desc_idx, true);
+		return sreq_get_desc_cfg(uds_ctx, desc_idx, true);
 	case USB_DESC_STRING:
-		return sreq_get_desc_str(uds_ctx, pbuf, desc_idx);
+		return sreq_get_desc_str(uds_ctx, desc_idx);
 	case USB_DESC_DEVICE_QUALIFIER:
-		return sreq_get_dev_qualifier(uds_ctx, pbuf);
+		return sreq_get_dev_qualifier(uds_ctx);
 	case USB_DESC_BOS:
-		return sreq_get_desc_bos(uds_ctx, pbuf);
+		return sreq_get_desc_bos(uds_ctx);
 	case USB_DESC_INTERFACE:
 	case USB_DESC_ENDPOINT:
 	default:
 		break;
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
-static int sreq_get_configuration(struct usbd_context *const uds_ctx,
-				  struct net_buf **const pbuf)
+static struct net_buf *sreq_get_configuration(struct usbd_context *const uds_ctx)
 
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
@@ -851,27 +834,24 @@ static int sreq_get_configuration(struct usbd_context *const uds_ctx,
 
 	/* Not specified in default state, treat as error */
 	if (usbd_state_is_default(uds_ctx)) {
-		return -EPERM;
+		return NULL;
 	}
 
 	if (setup->wLength != sizeof(cfg)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(cfg));
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	net_buf_add_u8(buf, cfg);
 
-	return 0;
+	return buf;
 }
 
-static int sreq_get_interface(struct usbd_context *const uds_ctx,
-			      struct net_buf **const pbuf)
+static struct net_buf *sreq_get_interface(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usb_cfg_descriptor *cfg_desc;
@@ -880,70 +860,67 @@ static int sreq_get_interface(struct usbd_context *const uds_ctx,
 	uint8_t cur_alt;
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
-		return -EPERM;
+		return NULL;
 	}
 
 	/* Treat as error in default (not specified) and addressed states. */
 	cfg_nd = usbd_config_get_current(uds_ctx);
 	if (cfg_nd == NULL) {
-		return -EPERM;
+		return NULL;
 	}
 
 	cfg_desc = cfg_nd->desc;
 
 	if (setup->wIndex > UINT8_MAX ||
 	    setup->wIndex > cfg_desc->bNumInterfaces) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	if (usbd_get_alt_value(uds_ctx, setup->wIndex, &cur_alt)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	LOG_DBG("Get Interfaces %u, alternate %u",
 		setup->wIndex, cur_alt);
 
 	if (setup->wLength != sizeof(cur_alt)) {
-		return -ENOTSUP;
+		return NULL;
 	}
 
 	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, sizeof(cur_alt));
 	if (buf == NULL) {
-		return -ENOMEM;
+		return NULL;
 	}
-
-	*pbuf = buf;
 
 	net_buf_add_u8(buf, cur_alt);
 
-	return 0;
+	return buf;
 }
 
-static int std_request_to_host(struct usbd_context *const uds_ctx,
-			       struct net_buf **const pbuf)
+static struct net_buf *std_request_to_host(struct usbd_context *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
-	int ret;
+	struct net_buf *buf;
 
 	switch (setup->bRequest) {
 	case USB_SREQ_GET_STATUS:
-		ret = sreq_get_status(uds_ctx, pbuf);
+		buf = sreq_get_status(uds_ctx);
 		break;
 	case USB_SREQ_GET_DESCRIPTOR:
-		ret = sreq_get_descriptor(uds_ctx, pbuf);
+		buf = sreq_get_descriptor(uds_ctx);
 		break;
 	case USB_SREQ_GET_CONFIGURATION:
-		ret = sreq_get_configuration(uds_ctx, pbuf);
+		buf = sreq_get_configuration(uds_ctx);
 		break;
 	case USB_SREQ_GET_INTERFACE:
-		ret = sreq_get_interface(uds_ctx, pbuf);
+		buf = sreq_get_interface(uds_ctx);
 		break;
 	default:
-		ret = -ENOTSUP;
+		buf = NULL;
 		break;
 	}
 
-	return ret;
+	return buf;
 }
 
 static int vendor_device_request(struct usbd_context *const uds_ctx,
@@ -968,7 +945,8 @@ static int vendor_device_request(struct usbd_context *const uds_ctx,
 
 	if (reqtype_is_to_host(setup) && vreq_nd->to_host != NULL) {
 		LOG_DBG("Vendor request 0x%02x to host", setup->bRequest);
-		return vreq_nd->to_host(uds_ctx, setup, pbuf);
+		*pbuf = vreq_nd->to_host(uds_ctx, setup);
+		return 0;
 	}
 
 	return -ENOTSUP;
@@ -999,7 +977,7 @@ static int nonstd_request(struct usbd_context *const uds_ctx,
 		if (reqtype_is_to_device(setup)) {
 			ret = usbd_class_control_to_dev(c_nd->c_data, setup, *pbuf);
 		} else {
-			ret = usbd_class_control_to_host(c_nd->c_data, setup, pbuf);
+			*pbuf = usbd_class_control_to_host(c_nd->c_data, setup);
 		}
 	} else {
 		return vendor_device_request(uds_ctx, pbuf);
@@ -1021,7 +999,8 @@ static int handle_setup_request(struct usbd_context *const uds_ctx,
 		if (reqtype_is_to_device(setup)) {
 			ret = std_request_to_device(uds_ctx, *pbuf);
 		} else {
-			ret = std_request_to_host(uds_ctx, pbuf);
+			*pbuf = std_request_to_host(uds_ctx);
+			ret = 0;
 		}
 		break;
 	case USB_REQTYPE_TYPE_CLASS:
@@ -1186,8 +1165,10 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 		}
 
 		/*
-		 * Handle request and data stage, next_buf holds either received
-		 * data OUT buffer or is NULL.
+		 * Handle request and data stage. For to-device requests, next_buf is
+		 * the received data OUT buffer or NULL, unchanged by this call. For
+		 * to-host requests, the handler sets it to a handler-allocated data
+		 * IN buffer, or NULL to respond with STALL handshake.
 		 */
 		ret = handle_setup_request(uds_ctx, &next_buf);
 

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -53,23 +53,28 @@ static inline int usbd_class_request(struct usbd_class_data *const c_data,
  *
  * The execution of the handler must not block.
  *
+ * @note The handler is responsible for allocating the buffer. If the
+ * request is valid, ownership of the buffer is transferred to the
+ * stack. If the handler has already allocated a buffer but determines
+ * the response should be a STALL handshake, it must free the buffer
+ * before returning NULL.
+ *
  * @param[in] c_data Pointer to USB device class data
  * @param[in] setup Pointer to USB Setup Packet
- * @param[in] pbuf Pointer to handler allocated Control Request Data buffer
  *
- * @return 0 on success, other values on fail.
+ * @return Buffer with data to send to host on success, NULL on fail.
  */
-static inline int usbd_class_control_to_host(struct usbd_class_data *const c_data,
-					     struct usb_setup_packet *const setup,
-					     struct net_buf **const pbuf)
+static inline struct net_buf *
+usbd_class_control_to_host(struct usbd_class_data *const c_data,
+			   struct usb_setup_packet *const setup)
 {
 	const struct usbd_class_api *api = c_data->api;
 
 	if (api->control_to_host != NULL) {
-		return api->control_to_host(c_data, setup, pbuf);
+		return api->control_to_host(c_data, setup);
 	}
 
-	return -ENOTSUP;
+	return NULL;
 }
 
 /**

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -55,18 +55,18 @@ static inline int usbd_class_request(struct usbd_class_data *const c_data,
  *
  * @param[in] c_data Pointer to USB device class data
  * @param[in] setup Pointer to USB Setup Packet
- * @param[in] buf Control Request Data buffer
+ * @param[in] pbuf Pointer to handler allocated Control Request Data buffer
  *
  * @return 0 on success, other values on fail.
  */
 static inline int usbd_class_control_to_host(struct usbd_class_data *const c_data,
 					     struct usb_setup_packet *const setup,
-					     struct net_buf *const buf)
+					     struct net_buf **const pbuf)
 {
 	const struct usbd_class_api *api = c_data->api;
 
 	if (api->control_to_host != NULL) {
-		return api->control_to_host(c_data, setup, buf);
+		return api->control_to_host(c_data, setup, pbuf);
 	}
 
 	return -ENOTSUP;


### PR DESCRIPTION
For control transfers with data stage from device to host, only the handler knows how large buffer is necessary (by specification host is allowed to request up to 65535 bytes for every control read transfer). While generally hosts do keep wLength relatively low, there are cases where the value is big enough that the buffer cannot be allocated with
default UDC_BUF_POOL_SIZE value. Right now the only workaround is to increase UDC_BUF_POOL_SIZE to large enough value but this is not a viable solution on memory constrained targets. For example USB3CV Mass Storage tests read string descriptor 0 with wLength set to 4096, while the Zephyr response to this request is 4 bytes (and therefore 4 byte long buffer is enough).

Move the allocation to handler to allow the code to allocate as small buffer as possible to handle the transfer. This allows MSC sample to pass USB3CV with default UDC_BUF_POOL_SIZE value.