### PR TITLE
drivers: usb: stm32: move PHY configuration to common code

### DIFF
--- a/drivers/usb/common/stm32/CMakeLists.txt
+++ b/drivers/usb/common/stm32/CMakeLists.txt
@@ -7,4 +7,28 @@ if(CONFIG_STM32_USB_COMMON)
   zephyr_include_directories(.)
 
   zephyr_library_sources(stm32_usb_pwr.c)
+
+  # PHY interface drivers
+  #
+  # These drivers don't control a particular PHY; instead,
+  # they merely configure clocks/etc such that a specific
+  # PHY interface can be used by the USB controller.
+  #
+  # These drivers must be added to all builds where they
+  # might be useful since there is no (easy) way to detect
+  # whether or not they are required; however, the linker
+  # should ultimately discard their code if not needed.
+  if(CONFIG_SOC_SERIES_STM32F4X OR CONFIG_SOC_SERIES_STM32H7X)
+    zephyr_library_sources(phy_embeddedfs_ulpi_off.c)
+  endif()
+  if(CONFIG_SOC_SERIES_STM32F7X OR CONFIG_SOC_SERIES_STM32H7X)
+    zephyr_library_sources(phy_ulpi_itf.c)
+  endif()
+
+  # Embedded HS PHY drivers
+  if(CONFIG_STM32_PHY_USBPHYC)
+    zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_STM32F7X phy_usbphyc_f7.c)
+    zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_STM32N6X phy_usbphyc_n6.c)
+  endif()
+  zephyr_library_sources_ifdef(CONFIG_STM32_PHY_U5OTGHSPHY phy_u5otghs.c)
 endif()

--- a/drivers/usb/common/stm32/Kconfig
+++ b/drivers/usb/common/stm32/Kconfig
@@ -9,6 +9,18 @@ config STM32_USB_COMMON
 	  Enable compilation of STM32 USB common code.
 	  This option is selected by the USB drivers when appropriate.
 
+config STM32_PHY_USBPHYC
+	def_bool y
+	depends on DT_HAS_ST_STM32_USBPHYC_ENABLED
+	help
+	  Enable STM32 USBPHYC embedded High-Speed PHY driver.
+
+config STM32_PHY_U5OTGHSPHY
+	def_bool y
+	depends on DT_HAS_ST_STM32U5_OTGHS_PHY_ENABLED
+	help
+	  Enable STM32 U5OTGHS embedded High-Speed PHY driver.
+
 module = STM32_USB_COMMON
 module-str = STM32 USB common code
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/usb/common/stm32/phy_embeddedfs_ulpi_off.c
+++ b/drivers/usb/common/stm32/phy_embeddedfs_ulpi_off.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Embedded FS PHY driver for STM32H7 & STM32F4
+ *
+ * The embedded FS PHY itself never needs to be configured;
+ * this is really only needed due to a silly quirk on STM32H7
+ * and some STM32F4 parts, where the ULPI clock low-power sleep
+ * must be disabled when using an USB instance in Full-Speed mode.
+ *
+ * Note use of __maybe_unused because this is included
+ * unconditionally in the build, but we may end up not
+ * instancing any device.
+ */
+#include <stm32_ll_bus.h>
+
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include "stm32_usb_common.h"
+
+__maybe_unused
+static int stm32_embedded_fs_phy_enable(const struct stm32_usb_phy *phy)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	LL_AHB1_GRP1_DisableClockSleep(phy->cfg);
+#elif defined(CONFIG_SOC_SERIES_STM32F4X)
+	if (phy->cfg != 0U) {
+		LL_AHB1_GRP1_DisableClockLowPower(phy->cfg);
+	}
+#endif
+	return 0;
+}
+
+__maybe_unused
+static int stm32_embedded_fs_phy_disable(const struct stm32_usb_phy *phy)
+{
+	/* Re-enable low-power sleep when PHY is no longer used. */
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	LL_AHB1_GRP1_EnableClockSleep(phy->cfg);
+#elif defined(CONFIG_SOC_SERIES_STM32F4X)
+	if (phy->cfg != 0U) {
+		LL_AHB1_GRP1_EnableClockLowPower(phy->cfg);
+	}
+#endif
+	return 0;
+}
+
+/* PHY configuration */
+
+/*
+ * STM32H7 has two instances of the same OTGHS IP; however, the
+ * second instance "USB2OTGHS" can only be used in FS mode since
+ * it has no HS PHY nor ULPI interface. As such, "USB1OTGHS" has
+ * compatible "st,stm32-otghs" in Devicetree whereas "USB2OTGHS"
+ * has compatible "st,stm32-otgfs".
+ *
+ * Use compatible here to distinguish between the two controllers.
+ */
+#define STM32H7_PHY_CFG(usb_node)						\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(usb_node, st_stm32_otghs),		\
+		(LL_AHB1_GRP1_PERIPH_USB1OTGHSULPI),				\
+		(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI))
+
+/**
+ * STM32F4 has one instance of OTGHS and one instance of OTGFS.
+ * Use same trick as on H7 to distinguish them, and set cfg=0
+ * on OTG_FS as sentinel for skipping the MMIO write at runtime.
+ */
+#define STM32F4_PHY_CFG(usb_node)						\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(usb_node, st_stm32_otghs),		\
+		(LL_AHB1_GRP1_PERIPH_OTGHSULPI), (0))
+
+#define EMBFS_PHY_CFG(usb_node)							\
+	IF_ENABLED(CONFIG_SOC_SERIES_STM32H7X,					\
+		(STM32H7_PHY_CFG(usb_node)))					\
+	IF_ENABLED(CONFIG_SOC_SERIES_STM32F4X,					\
+		(STM32F4_PHY_CFG(usb_node)))
+
+#define DEFINE_EMBFS_PHY(usb_node)						\
+	const struct stm32_usb_phy USB_STM32_PHY_PSEUDODEV_NAME(usb_node) = {	\
+		.enable = stm32_embedded_fs_phy_enable,				\
+		.disable = stm32_embedded_fs_phy_disable,			\
+		.cfg = EMBFS_PHY_CFG(usb_node),					\
+	};
+
+/* Iterate all USB nodes and instantiate PHY when appropriate */
+#define _FOREACH_NODE(usb_node)							\
+	IF_ENABLED(USB_STM32_NODE_PHY_IS_EMBEDDED_FS(usb_node),			\
+		(DEFINE_EMBFS_PHY(usb_node)))
+#define _FOREACH_COMPAT(compat) DT_FOREACH_STATUS_OKAY(compat, _FOREACH_NODE)
+FOR_EACH(_FOREACH_COMPAT, (), STM32_USB_COMPATIBLES)

--- a/drivers/usb/common/stm32/phy_u5otghs.c
+++ b/drivers/usb/common/stm32/phy_u5otghs.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * STM32 U5OTGHS embedded HS PHY driver
+ *
+ * Covers the unnamed PHY first found in STM32U5 series,
+ * and later used in other series such as STM32WBA, ...
+ *
+ * Note: the HAL SYSCFG used is provided by stm32XXX_hal.c
+ * which is always included in the build, and the __HAL_RCC
+ * function is actually an in-header/LL-like macro.
+ */
+#include <soc.h>
+#include <stm32_ll_system.h>
+
+#include <stm32_bitops.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include "stm32_usb_common.h"
+
+/* Even though we won't use this macro, define it for grep-ability */
+#define DT_DRV_COMPAT st_stm32u5_otghs_phy
+
+struct stm32_u5otghs_phy_config {
+	uint32_t reference;
+	uint32_t num_clocks;
+	struct stm32_pclken clocks[];
+};
+
+static const struct device *rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+
+static int stm32_u5otghs_phy_enable(const struct stm32_usb_phy *phy)
+{
+	const struct stm32_u5otghs_phy_config *cfg = phy->pcfg;
+	int res;
+
+	/* Enable SYSCFG where PHY configuration registers reside */
+	__HAL_RCC_SYSCFG_CLK_ENABLE();
+
+	/* Configure PHY input frequency selection  */
+	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(cfg->reference);
+
+	/* Deassert PHY reset */
+	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
+
+	/* Configure PHY input mux (if provided) */
+	if (cfg->num_clocks > 1) {
+		res = clock_control_configure(rcc, (clock_control_subsys_t)&cfg->clocks[1], NULL);
+		if (res != 0) {
+			return res;
+		}
+	}
+
+	/* Turn on the PHY's clock */
+	return clock_control_on(rcc, (clock_control_subsys_t)&cfg->clocks[0]);
+}
+
+static int stm32_u5otghs_phy_disable(const struct stm32_usb_phy *phy)
+{
+	const struct stm32_u5otghs_phy_config *cfg = phy->pcfg;
+
+	return clock_control_off(rcc, (clock_control_subsys_t)&cfg->clocks[0]);
+}
+
+/*
+ * SYSCFG_OTG_HS_PHY_CLK_SELECT_<> values go from 1 to N,
+ * but DT_ENUM_IDX() is zero-based, hence the UTIL_INC().
+ */
+#define PHY_CLK_REF(n)	\
+	CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_, UTIL_INC(DT_ENUM_IDX(n, clock_reference)))
+
+/*
+ * Note that SYSCFG_OTG_HS_PHY_CLK_SELECT goes from 1 to N whereas
+ * DT_ENUM_IDX() goes from 0 to (N-1), hence the UTIL_INC()
+ */
+#define DEFINE_U5OTGHS_PHY(usb_node, phy_node)							\
+	static const struct stm32_u5otghs_phy_config CONCAT(phy, DT_DEP_ORD(phy_node), _cfg) = {\
+		.reference = PHY_CLK_REF(phy_node),						\
+		.num_clocks = DT_NUM_CLOCKS(phy_node),						\
+		.clocks = STM32_DT_CLOCKS(phy_node)						\
+	};											\
+	const struct stm32_usb_phy USB_STM32_PHY_PSEUDODEV_NAME(usb_node) = {			\
+		.enable = stm32_u5otghs_phy_enable,						\
+		.disable = stm32_u5otghs_phy_disable,						\
+		.pcfg = &CONCAT(phy, DT_DEP_ORD(phy_node), _cfg),				\
+	};
+
+/*
+ * Iterate all USB nodes and instantiate PHY when appropriate.
+ * We could implement a stricter check but this should suffice;
+ * there are no series with different type of embedded HS PHYs.
+ */
+#define _FOREACH_NODE(usb_node)									\
+	IF_ENABLED(USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node),					\
+		(DEFINE_U5OTGHS_PHY(usb_node, USB_STM32_PHY(usb_node))))
+#define _FOREACH_COMPAT(compat) DT_FOREACH_STATUS_OKAY(compat, _FOREACH_NODE)
+FOR_EACH(_FOREACH_COMPAT, (), STM32_USB_COMPATIBLES)

--- a/drivers/usb/common/stm32/phy_ulpi_itf.c
+++ b/drivers/usb/common/stm32/phy_ulpi_itf.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * ULPI PHY interface driver
+ *
+ * Note use of __maybe_unused because this is included
+ * unconditionally in the build, but we may end up not
+ * instancing any device.
+ */
+#include <stm32_ll_bus.h>
+
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include "stm32_usb_common.h"
+
+/*
+ * A single implementation works across all series
+ * because it turns out they all have ULPI clock
+ * in the same RCC register.
+ */
+
+__maybe_unused
+static int stm32_ulpi_itf_enable(const struct stm32_usb_phy *phy)
+{
+	LL_AHB1_GRP1_EnableClock(phy->cfg);
+	return 0;
+}
+
+__maybe_unused
+static int stm32_ulpi_itf_disable(const struct stm32_usb_phy *phy)
+{
+	LL_AHB1_GRP1_DisableClock(phy->cfg);
+	return 0;
+}
+
+/* Pseudo-PHY configuration */
+
+/*
+ * Most series with ULPI interface have only one OTG_HS instance,
+ * so the bit is simply called "OTGHSULPI".
+ *
+ * STM32H7 has two instances but only USB1 can be use an ULPI PHY;
+ * as such, it is safe to hardcode "USB1OTGHSULPI" here.
+ */
+#define ULPI_ITF_CFG(usb_node)							\
+	COND_CODE_1(CONFIG_SOC_SERIES_STM32H7X,					\
+		(LL_AHB1_GRP1_PERIPH_USB1OTGHSULPI),				\
+		(LL_AHB1_GRP1_PERIPH_OTGHSULPI))
+
+/* Instantiate ULPI pseudo-PHY devices */
+#define DEFINE_ULPI_PHY(usb_node)						\
+	const struct stm32_usb_phy USB_STM32_PHY_PSEUDODEV_NAME(usb_node) = {	\
+		.enable = stm32_ulpi_itf_enable,				\
+		.disable = stm32_ulpi_itf_disable,				\
+		.cfg = ULPI_ITF_CFG(usb_node),					\
+	};
+
+/* Iterate all USB nodes and instantiate PHY when appropriate */
+#define _FOREACH_NODE(usb_node)							\
+	IF_ENABLED(USB_STM32_NODE_PHY_IS_ULPI(usb_node),			\
+		(DEFINE_ULPI_PHY(usb_node)))
+#define _FOREACH_COMPAT(compat) DT_FOREACH_STATUS_OKAY(compat, _FOREACH_NODE)
+FOR_EACH(_FOREACH_COMPAT, (), STM32_USB_COMPATIBLES)

--- a/drivers/usb/common/stm32/phy_usbphyc_f7.c
+++ b/drivers/usb/common/stm32/phy_usbphyc_f7.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* STM32F7 USBPHYC driver */
+#define DT_DRV_COMPAT st_stm32_usbphyc /* Unused; defined for grep-ability */
+
+#include <stm32_ll_bus.h>
+
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include "stm32_usb_common.h"
+
+static int stm32f7_usbphyc_enable(const struct stm32_usb_phy *phy)
+{
+	/*
+	 * The USBPHYC is configured by the USB HAL, but it needs
+	 * to have its clock enabled beforehand. For some unknown
+	 * reason, the OTGHSULPI clock must also be enabled, even
+	 * though we are NOT using the ULPI interface...
+	 *
+	 * We _could_ require both OTGPHYCEN and OTGHSULPIEN bits
+	 * to be provided via DTS as clock configuration, but this
+	 * would create an ugly mismatch between STM32F7 and other
+	 * series. To avoid this, we provide only OTGPHYCEN at DTS
+	 * level but straight up ignore the property, instead using
+	 * hardcoded LL Bus API calls. This is fine because STM32F7
+	 * has only one OTG_HS and USBPHYC instance, so we don't
+	 * need to distinguish them...
+	 */
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
+	return 0;
+}
+
+static int stm32f7_usbphyc_disable(const struct stm32_usb_phy *phy)
+{
+	LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
+	return 0;
+}
+
+#define DEFINE_USBPHYC_F7(usb_node)						\
+	const struct stm32_usb_phy USB_STM32_PHY_PSEUDODEV_NAME(usb_node) = {	\
+		.enable = stm32f7_usbphyc_enable,				\
+		.disable = stm32f7_usbphyc_disable,				\
+	};
+
+/*
+ * Iterate all USB nodes and instantiate PHY when appropriate.
+ * We could implement a stricter check but this should suffice
+ * since this driver is only compiled for STM32F7 series.
+ */
+#define _FOREACH_NODE(usb_node)							\
+	IF_ENABLED(USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node),			\
+		(DEFINE_USBPHYC_F7(usb_node)))
+#define _FOREACH_COMPAT(compat) DT_FOREACH_STATUS_OKAY(compat, _FOREACH_NODE)
+FOR_EACH(_FOREACH_COMPAT, (), STM32_USB_COMPATIBLES)

--- a/drivers/usb/common/stm32/phy_usbphyc_n6.c
+++ b/drivers/usb/common/stm32/phy_usbphyc_n6.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* STM32N6 USBPHYC driver */
+#define DT_DRV_COMPAT st_stm32_usbphyc /* Unused; defined for grep-ability */
+
+#include <soc.h>
+
+#include <stm32_bitops.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include "stm32_usb_common.h"
+
+/* TODO: should not be hardcoded! */
+#define USB_USBPHYC_CR_FSEL_24MHZ        USB_USBPHYC_CR_FSEL_1
+
+struct stm32n6_usbphyc_config {
+	USB_HS_PHYC_GlobalTypeDef *reg;
+	uint32_t num_clocks;
+	struct stm32_pclken clocks[];
+};
+
+static const struct device *rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+
+/*
+ * NOTE: the USBPHYC MMIO interface is clock gated by
+ * the same bit as the OTG_HS instance itself; this
+ * function MUST be called after clock_control_on()
+ * in the main USB driver or the SoC will deadlock.
+ */
+static int stm32n6_usbphyc_enable(const struct stm32_usb_phy *phy)
+{
+	const struct stm32n6_usbphyc_config *cfg = phy->pcfg;
+	int res;
+
+	/* Configure PHY input frequency selection */
+	stm32_reg_modify_bits(&cfg->reg->USBPHYC_CR,
+			      USB_USBPHYC_CR_FSEL_Msk,
+			      USB_USBPHYC_CR_FSEL_24MHZ);
+
+	/* Configure PHY input mux (if provided) */
+	if (cfg->num_clocks > 1) {
+		res = clock_control_configure(rcc, (clock_control_subsys_t)&cfg->clocks[1], NULL);
+		if (res != 0) {
+			return res;
+		}
+	}
+
+	/* Turn on the PHY's clock */
+	return clock_control_on(rcc, (clock_control_subsys_t)&cfg->clocks[0]);
+}
+
+static int stm32n6_usbphyc_disable(const struct stm32_usb_phy *phy)
+{
+	const struct stm32n6_usbphyc_config *cfg = phy->pcfg;
+
+	return clock_control_off(rcc, (clock_control_subsys_t)&cfg->clocks[0]);
+}
+
+#define DEFINE_USBPHYC_N6(usb_node, phy_node)							\
+	static const struct stm32n6_usbphyc_config CONCAT(phy, DT_DEP_ORD(phy_node), _cfg) = {	\
+		.reg = (void *)DT_REG_ADDR(phy_node),						\
+		.num_clocks = DT_NUM_CLOCKS(phy_node),						\
+		.clocks = STM32_DT_CLOCKS(phy_node)						\
+	};											\
+	const struct stm32_usb_phy USB_STM32_PHY_PSEUDODEV_NAME(usb_node) = {			\
+		.enable = stm32n6_usbphyc_enable,						\
+		.disable = stm32n6_usbphyc_disable,						\
+		.pcfg = &CONCAT(phy, DT_DEP_ORD(phy_node), _cfg),				\
+	};
+
+/*
+ * Iterate all USB nodes and instantiate PHY when appropriate.
+ * We could implement a stricter check but this should suffice
+ * since this pseudo-driver is only compiled for STM32N6 series.
+ */
+#define _FOREACH_NODE(usb_node)									\
+	IF_ENABLED(USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node),					\
+		(DEFINE_USBPHYC_N6(usb_node, USB_STM32_PHY(usb_node))))
+#define _FOREACH_COMPAT(compat) DT_FOREACH_STATUS_OKAY(compat, _FOREACH_NODE)
+FOR_EACH(_FOREACH_COMPAT, (), STM32_USB_COMPATIBLES)

--- a/drivers/usb/common/stm32/stm32_usb_common.h
+++ b/drivers/usb/common/stm32/stm32_usb_common.h
@@ -7,6 +7,45 @@
 #ifndef ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_
 #define ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_
 
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/types.h>
+
+/* Compatible of all STM32 USB controllers */
+#define STM32_USB_COMPATIBLES								\
+	st_stm32_usb, st_stm32_otgfs, st_stm32_otghs
+
+/* Shorthand to obtain PHY node for an instance */
+#define USB_STM32_PHY(usb_node)			DT_PROP_BY_IDX(usb_node, phys, 0)
+
+/* Evaluates to 1 if `usb_node` is High-Speed capable, 0 otherwise. */
+#define USB_STM32_NODE_IS_HS_CAPABLE(usb_node)	DT_NODE_HAS_COMPAT(usb_node, st_stm32_otghs)
+
+/* Evaluates to 1 if PHY of `usb_node` is an ULPI PHY, 0 otherwise. */
+#define USB_STM32_NODE_PHY_IS_ULPI(usb_node)						\
+	UTIL_AND(USB_STM32_NODE_IS_HS_CAPABLE(usb_node),				\
+		DT_NODE_HAS_COMPAT(USB_STM32_PHY(usb_node), usb_ulpi_phy))
+
+/*
+ * Evaluates to 1 if PHY of `usb_node` is an embedded HS PHY, 0 otherwise.
+ *
+ * Implementation notes:
+ * All embedded HS PHYs have specific compatibles (with ST vendor).
+ */
+#define USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node)					\
+	UTIL_OR(DT_NODE_HAS_COMPAT(USB_STM32_PHY(usb_node), st_stm32_usbphyc),		\
+		DT_NODE_HAS_COMPAT(USB_STM32_PHY(usb_node), st_stm32u5_otghs_phy))
+
+/*
+ * Evaluates to 1 if PHY of `usb_node` is an embedded FS PHY, 0 otherwise.
+ *
+ * Implementation notes:
+ * USB PHYs are either ULPI, embedded HS or embedded FS.
+ */
+#define USB_STM32_NODE_PHY_IS_EMBEDDED_FS(usb_node)					\
+	UTIL_AND(UTIL_NOT(USB_STM32_NODE_PHY_IS_ULPI(usb_node)),			\
+		 UTIL_NOT(USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node)))
+
 /**
  * @brief Configures the Power Controller as necessary
  * for proper operation of the USB controllers

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -13,6 +13,7 @@
 		usbphyc: usbphyc@40017c00 {
 			compatible = "st,stm32-usbphyc";
 			reg = <0x40017c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 31)>;
 			#phy-cells = <0>;
 			status = "disabled";
 		};

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -11,5 +11,23 @@ properties:
   reg:
     required: true
 
+  clocks:
+    required: true
+    description: |
+      Clock configuration of USBPHYC
+
+      The first cell is mandatory and corresponds
+      to the clock gate of the USBPHYC. The second
+      cell is optional and corresponds to the mux
+      configuration.
+
   "#phy-cells":
     const: 0
+
+examples:
+  - |
+    /* In DTS for STM32N6-based board */
+    &usbphyc1 {
+      clocks = <&rcc STM32_CLOCK(AHB5, 27)>,
+               <&rcc STM32_SRC_HSE OTGPHY1CKREF_SEL(1)>;
+    };


### PR DESCRIPTION
Depends on #100519 from which the first two commits are taken (the only dependency is really on the build system boilerplate introduced, nothing functional...)

Move the PHY (or PHY ***interface***) configuration code from the STM32 UDC driver to dedicated *minidrivers* in USB common code. This tidies up the UDC driver while also enabling reuse from a future STM32 UHC implementation.

The term "*minidriver*" is used here because the common code are **not** drivers which fit the Zephyr Device Driver model (i.e., not `struct device`-backed). This choice was made for several reasons:
* The PHY node may correspond to **external** hardware (i.e., ULPI HS PHY) for which we **cannot** provide a `struct device`
  * Providing a `struct device` from ST code in addition to the PHY's driver providing one would result in a link-time error ("symbol provided twice")...
  * ...but we still need to run ST-specific code when such a PHY is used to initialize internal HW (e.g., turn on the ULPI ***interface***)
  * *(N.B.: this is not immediately visible due to an historical layering violation where the ST USB driver actually takes responsibility for performing some tasks that a proper, dedicated USB PHY driver should have - this PR doesn't attempt to address this question)*
* Zephyr currently doesn't provide any API which the driver could implement
  * The current `PHY` API is explicitly documented as being for *Ethernet* PHYs
* Minimized modifications
  * e.g., no need to introduce additional compatibles

Some points probably need harmonization but the overall idea is exposed here.