### PR TITLE
drivers: entropy: GD32F4xx: Fix missing function return type

### DIFF
--- a/drivers/entropy/entropy_gd32.c
+++ b/drivers/entropy/entropy_gd32.c
@@ -58,7 +58,7 @@ static bool entropy_gd32_ck48m_ready(void)
 	return (RCU_CTL & RCU_CTL_PLLSTB) != 0U;
 }
 
-static entropy_gd32_recover(void)
+static void entropy_gd32_recover(void)
 {
 	/*
 	 * For GD32F4xx TRNG the HAL exposes status bits (CECS/SECS) but provides
@@ -69,8 +69,6 @@ static entropy_gd32_recover(void)
 	trng_deinit();
 	entropy_gd32_clear_int_flags();
 	trng_enable();
-
-	return 0;
 }
 
 static int entropy_gd32_wait_drdy(void)


### PR DESCRIPTION
Fix a function which was missing its return type, and remove an unnecessary 0 return.
This avoids the following build warning, which fails to build when building with -Werror:
`return type defaults to 'int'`
As the function does not really return anything, let's just make it return void.

The issue can be reproduced with
```
mkdir build && cd build
cmake -GNinja -DBOARD=gd32f450i_eval/gd32f450 ../tests/drivers/entropy/api/
ninja
```

Issue introduced with this new driver in:
* https://github.com/zephyrproject-rtos/zephyr/pull/101559