### PR TITLE
drivers: usb: udc: stm32: implement multi-instance support

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -731,6 +731,11 @@ int udc_stm32_init(const struct device *dev)
 	return 0;
 }
 
+/*
+ * NOTE: This will no longer work if a new SoC contains
+ * both an instance of the ST USB IP and an instance of
+ * of the ST OTGFS or ST OTGHS USB IPs.
+ */
 #if defined(USB) || defined(USB_DRD_FS)
 static inline void udc_stm32_mem_init(const struct device *dev)
 {
@@ -1221,62 +1226,6 @@ static const struct udc_api udc_stm32_api = {
 	.device_speed = udc_stm32_device_speed,
 };
 
-/* ----------------- Instance/Device specific data ----------------- */
-
-/*
- * USB, USB_OTG_FS and USB_DRD_FS are defined in STM32Cube HAL and allows to
- * distinguish between two kind of USB DC. STM32 F0, F3, L0 and G4 series
- * support USB device controller. STM32 F4 and F7 series support USB_OTG_FS
- * device controller. STM32 F1 and L4 series support either USB or USB_OTG_FS
- * device controller.STM32 G0 series supports USB_DRD_FS device controller.
- *
- * WARNING: Don't mix USB defined in STM32Cube HAL and CONFIG_USB_* from Zephyr
- * Kconfig system.
- */
-K_THREAD_STACK_DEFINE(udc0_thr_stk, CONFIG_UDC_STM32_STACK_SIZE);
-
-static struct udc_ep_config udc0_in_ep_cfg[DT_INST_PROP(0, num_bidir_endpoints)];
-static struct udc_ep_config udc0_out_ep_cfg[DT_INST_PROP(0, num_bidir_endpoints)];
-
-static struct udc_stm32_data udc0_priv;
-
-static struct udc_data udc0_data = {
-	.mutex = Z_MUTEX_INITIALIZER(udc0_data.mutex),
-	.priv = &udc0_priv,
-};
-
-static void udc0_irq_connect(void)
-{
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, UDC_STM32_IRQ_NAME, irq),
-		    DT_INST_IRQ_BY_NAME(0, UDC_STM32_IRQ_NAME, priority),
-		    HAL_PCD_IRQHandler, &udc0_priv.pcd, 0);
-}
-
-PINCTRL_DT_INST_DEFINE(0);
-
-static const struct stm32_pclken udc0_pclken[] = STM32_DT_INST_CLOCKS(0);
-
-static const struct udc_stm32_config udc0_cfg  = {
-	.base = (void *)DT_INST_REG_ADDR(0),
-	.num_endpoints = DT_INST_PROP(0, num_bidir_endpoints),
-	.dram_size = DT_INST_PROP(0, ram_size),
-	.irq_connect = udc0_irq_connect,
-	.irqn = DT_INST_IRQ_BY_NAME(0, UDC_STM32_IRQ_NAME, irq),
-	.pclken = (struct stm32_pclken *)udc0_pclken,
-	.num_clocks = DT_INST_NUM_CLOCKS(0),
-	.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-	.phy = USB_STM32_PHY_PSEUDODEV_GET_OR_NULL(DT_DRV_INST(0)),
-	.in_eps = udc0_in_ep_cfg,
-	.out_eps = udc0_out_ep_cfg,
-	.ep_mps = UDC_STM32_NODE_EP_MPS(DT_DRV_INST(0)),
-	.selected_phy = UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)),
-	.selected_speed = UDC_STM32_NODE_SPEED(DT_DRV_INST(0)),
-	.thread_stack = udc0_thr_stk,
-	.thread_stack_size = K_THREAD_STACK_SIZEOF(udc0_thr_stk),
-	.disconnect_gpio = GPIO_DT_SPEC_INST_GET_OR(0, disconnect_gpios, {0}),
-	.ulpi_reset_gpio = GPIO_DT_SPEC_GET_OR(USB_STM32_PHY(DT_DRV_INST(0)), reset_gpios, {0}),
-};
-
 static int udc_stm32_clock_enable(const struct device *dev)
 {
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
@@ -1359,7 +1308,7 @@ static int udc_stm32_clock_disable(const struct device *dev)
 	return 0;
 }
 
-static int udc_stm32_driver_init0(const struct device *dev)
+static int udc_stm32_driver_preinit(const struct device *dev)
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	const struct udc_stm32_config *cfg = dev->config;
@@ -1467,6 +1416,62 @@ static int udc_stm32_driver_init0(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, udc_stm32_driver_init0, NULL, &udc0_data, &udc0_cfg,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		      &udc_stm32_api);
+#define UDC_STM32_DEFINE(node_id, phy_node, ord, _irq_name)					\
+	K_THREAD_STACK_DEFINE(CONCAT(udc, ord, _thr_stk), CONFIG_UDC_STM32_STACK_SIZE);		\
+												\
+	static struct udc_ep_config CONCAT(udc, ord, _in_ep_cfg)				\
+		[DT_PROP(node_id, num_bidir_endpoints)];					\
+	static struct udc_ep_config CONCAT(udc, ord, _out_ep_cfg)				\
+		[DT_PROP(node_id, num_bidir_endpoints)];					\
+												\
+	static struct udc_stm32_data CONCAT(udc, ord, _priv);					\
+												\
+	static struct udc_data CONCAT(udc, ord, _data) = {					\
+		.mutex = Z_MUTEX_INITIALIZER(CONCAT(udc, ord, _data).mutex),			\
+		.priv = &CONCAT(udc, ord, _priv),						\
+	};											\
+												\
+	static void CONCAT(udc, ord, _irq_connect)(void) {					\
+		IRQ_CONNECT(									\
+			DT_IRQ_BY_NAME(node_id, _irq_name, irq),				\
+			DT_IRQ_BY_NAME(node_id, _irq_name, priority),				\
+			HAL_PCD_IRQHandler, &CONCAT(udc, ord, _priv).pcd, 0);			\
+	}											\
+												\
+	PINCTRL_DT_DEFINE(node_id);								\
+												\
+	static const struct stm32_pclken CONCAT(udc, ord, _pclken)[] =				\
+		STM32_DT_CLOCKS(node_id);							\
+												\
+	static const struct udc_stm32_config CONCAT(udc, ord, _cfg) = {				\
+		.base = (void *)DT_REG_ADDR(node_id),						\
+		.num_endpoints = DT_PROP(node_id, num_bidir_endpoints),				\
+		.dram_size = DT_PROP(node_id, ram_size),					\
+		.irq_connect = &CONCAT(udc, ord, _irq_connect),					\
+		.irqn = DT_IRQ_BY_NAME(node_id, _irq_name, irq),				\
+		.pclken = (struct stm32_pclken *)&CONCAT(udc, ord, _pclken),			\
+		.num_clocks = DT_NUM_CLOCKS(node_id),						\
+		.pinctrl = PINCTRL_DT_DEV_CONFIG_GET(node_id),					\
+		.phy = USB_STM32_PHY_PSEUDODEV_GET_OR_NULL(node_id),				\
+		.in_eps = CONCAT(udc, ord, _in_ep_cfg),						\
+		.out_eps = CONCAT(udc, ord, _out_ep_cfg),					\
+		.ep_mps = UDC_STM32_NODE_EP_MPS(node_id),					\
+		.selected_phy = UDC_STM32_NODE_PHY_ITFACE(node_id),				\
+		.selected_speed = UDC_STM32_NODE_SPEED(node_id),				\
+		.thread_stack = CONCAT(udc, ord, _thr_stk),					\
+		.thread_stack_size = K_THREAD_STACK_SIZEOF(CONCAT(udc, ord, _thr_stk)),		\
+		.disconnect_gpio = GPIO_DT_SPEC_GET_OR(node_id, disconnect_gpios, {0}),		\
+		.ulpi_reset_gpio = GPIO_DT_SPEC_GET_OR(phy_node, reset_gpios, {0}),		\
+	};											\
+												\
+	DEVICE_DT_DEFINE(node_id, udc_stm32_driver_preinit, NULL, &CONCAT(udc, ord, _data),	\
+		&CONCAT(udc, ord, _cfg), POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		&udc_stm32_api);
+
+#define UDC_STM32_FOREACH_DEFINE(node_id, _irq_name)						\
+	UDC_STM32_DEFINE(node_id, USB_STM32_PHY(node_id), DT_DEP_ORD(node_id), _irq_name)
+
+/* Third argument = name of global IRQ */
+DT_FOREACH_STATUS_OKAY_VARGS(st_stm32_otghs, UDC_STM32_FOREACH_DEFINE, otghs)
+DT_FOREACH_STATUS_OKAY_VARGS(st_stm32_otgfs, UDC_STM32_FOREACH_DEFINE, otgfs)
+DT_FOREACH_STATUS_OKAY_VARGS(st_stm32_usb, UDC_STM32_FOREACH_DEFINE, usb)


### PR DESCRIPTION
Depends on #100519 and #102493

After regrouping all instanced data together and implementing PHY management in an instance-aware fashion, make the final leap and implement multi-instance support in the STM32 UDC driver.