### PR TITLE
scripts: add dt_compat_all_has_prop kconfig preprocessor function

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -39,6 +39,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_chosen_reg_addr_int,<property in /chosen>[,<index>,<unit>])
    $(dt_chosen_reg_size_hex,<property in /chosen>[,<index>,<unit>])
    $(dt_chosen_reg_size_int,<property in /chosen>[,<index>,<unit>])
+   $(dt_compat_all_has_prop,<compatible string>,<prop>[,<value>])
    $(dt_compat_any_has_prop,<compatible string>,<prop>[,<value>])
    $(dt_compat_any_on_bus,<compatible string>,<prop>)
    $(dt_compat_enabled,<compatible string>)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -889,16 +889,19 @@ def dt_compat_any_has_prop(kconf, _, compat, prop, value=None):
     if doc_mode or edt is None:
         return "n"
 
-    if compat in edt.compat2okay:
-        for node in edt.compat2okay[compat]:
-            if prop in node.props:
-                if value is None:
-                    return "y"
-                if isinstance(node.props[prop].val, list):
-                    if value in map(str, node.props[prop].val):
-                        return "y"
-                elif str(node.props[prop].val) == value:
-                    return "y"
+    if compat not in edt.compat2okay:
+        return "n"
+
+    for node in edt.compat2okay[compat]:
+        if prop not in node.props:
+            continue
+        if value is None:
+            return "y"
+        if isinstance(node.props[prop].val, list):
+            if value in map(str, node.props[prop].val):
+                return "y"
+        elif str(node.props[prop].val) == value:
+            return "y"
     return "n"
 
 def dt_compat_any_not_has_prop(kconf, _, compat, prop):

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -850,6 +850,33 @@ def dt_compat_on_bus(kconf, _, compat, bus):
 
     return "n"
 
+def dt_compat_all_has_prop(kconf, _, compat, prop, value=None):
+    """
+    This function takes a 'compat', a 'prop', and a 'value'.
+    If value=None, the function returns "y" if all
+    enabled node with compatible 'compat' also has a valid property 'prop'.
+    If value is given, the function returns "y" if all enabled node with compatible 'compat'
+    also has a valid property 'prop' with value 'value'.
+    It returns "n" otherwise.
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    if compat not in edt.compat2okay or len(edt.compat2okay[compat]) == 0:
+        return "n"
+
+    for node in edt.compat2okay[compat]:
+        if prop not in node.props:
+            return "n"
+        if value is None:
+            continue
+        if isinstance(node.props[prop].val, list):
+            if value not in map(str, node.props[prop].val):
+                return "n"
+        elif str(node.props[prop].val) != value:
+            return "n"
+    return "y"
+
 def dt_compat_any_has_prop(kconf, _, compat, prop, value=None):
     """
     This function takes a 'compat', a 'prop', and a 'value'.
@@ -1143,6 +1170,7 @@ functions = {
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
         "dt_compat_enabled_num": (dt_compat_enabled_num, 1, 1),
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),
+        "dt_compat_all_has_prop": (dt_compat_all_has_prop, 2, 3),
         "dt_compat_any_has_prop": (dt_compat_any_has_prop, 2, 3),
         "dt_compat_any_not_has_prop": (dt_compat_any_not_has_prop, 2, 2),
         "dt_chosen_label": (dt_chosen_label, 1, 1),

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -867,6 +867,9 @@ def dt_compat_any_has_prop(kconf, _, compat, prop, value=None):
             if prop in node.props:
                 if value is None:
                     return "y"
+                if isinstance(node.props[prop].val, list):
+                    if value in map(str, node.props[prop].val):
+                        return "y"
                 elif str(node.props[prop].val) == value:
                     return "y"
     return "n"


### PR DESCRIPTION
Add the dt_compat_all_has_prop kconfig preprocessor function, simillar to dt_compat_any_has_prop.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>