### PR TITLE
lib/midi2: Do not add to include path always

### DIFF
--- a/lib/midi2/CMakeLists.txt
+++ b/lib/midi2/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright (c) 2025 Titouan Christophe
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(.)
-
 if(CONFIG_MIDI2_UMP_STREAM_RESPONDER)
+  zephyr_include_directories(.)
   zephyr_sources(ump_stream_responder.c)
 endif()


### PR DESCRIPTION
Do not add this folder to the include path when this component is not enabled. As that creates noise and slows down builds.