### PR TITLE
lib: posix: add missing getopt_long guard

### DIFF
--- a/lib/posix/c_lib_ext/getopt_shim.c
+++ b/lib/posix/c_lib_ext/getopt_shim.c
@@ -34,6 +34,7 @@ void z_getopt_global_state_update_shim(struct sys_getopt_state *state)
 	optarg = state->optarg;
 }
 
+#if CONFIG_GETOPT_LONG
 int getopt_long(int argc, char *const argv[], const char *shortopts,
 		const struct option *longopts, int *longind)
 {
@@ -45,3 +46,4 @@ int getopt_long_only(int argc, char *const argv[], const char *shortopts,
 {
 	return sys_getopt_long_only(argc, argv, shortopts, longopts, longind);
 }
+#endif


### PR DESCRIPTION
Added ifdef guard (CONFIG_GETOPT_LONG) around the functions in getopt_shim.c that requires getopt_long implementation.

This fix is required for linking samples that have disabled discarding of unused sections the in linker options.