### PR TITLE
boards: arm: musca: fix ci failure

### DIFF
--- a/boards/arm/v2m_musca_b1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_b1/CMakeLists.txt
@@ -1,8 +1,15 @@
 #
 # Copyright (c) 2019,2020 Linaro Limited
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
+
+if(CONFIG_BUILD_WITH_TFM)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DCRYPTO_HW_ACCELERATOR=OFF
+    )
+endif()

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Linaro Limited
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +8,7 @@
 /dts-v1/;
 
 #include <arm/armv8-m.dtsi>
+#include <mem.h>
 
 / {
 	compatible = "arm,v2m-musca";
@@ -19,6 +21,7 @@
 		zephyr,console = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partitions = &slot0_ns_partition;
 		zephyr,shell-uart = &uart1;
 	};
 
@@ -40,9 +43,31 @@
 		};
 	};
 
-	flash0: flash@a070000 {
+	flash0: flash@a000000 {
 		/* Embedded flash */
-		reg = <0xa070000 0x1a0000>;
+		compatible = "soc-nv-flash";
+		reg = <0x0a000000 DT_SIZE_M(2)>;
+		erase-block-size = <DT_SIZE_K(4)>;
+		write-block-size = <4>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* Please see the memory layout in:
+			 * https://git.trustedfirmware.org/plugins/gitiles/TF-M/trusted-firmware-m.git/+/refs/heads/main/platform/ext/target/arm/musca_b1/partition/flash_layout.h
+			 */
+			slot0_partition: partition@20000 {
+				reg = <0x20000 DT_SIZE_K(384)>;
+			};
+
+			slot0_ns_partition: partition@80000 {
+				reg = <0x80000 DT_SIZE_K(512)>;
+			};
+		};
 	};
 
 	sram0: memory@20040000 {

--- a/boards/arm/v2m_musca_s1/CMakeLists.txt
+++ b/boards/arm/v2m_musca_s1/CMakeLists.txt
@@ -1,8 +1,15 @@
 #
 # Copyright (c) 2019-2020 Linaro Limited
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 zephyr_library()
 zephyr_library_sources(pinmux.c)
+
+if(CONFIG_BUILD_WITH_TFM)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DCRYPTO_HW_ACCELERATOR=OFF
+    )
+endif()

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2020 Linaro Limited
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +8,7 @@
 /dts-v1/;
 
 #include <arm/armv8-m.dtsi>
+#include <mem.h>
 
 / {
 	compatible = "arm,v2m-musca";
@@ -19,6 +21,7 @@
 		zephyr,console = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &mram0;
+		zephyr,code-partitions = &slot0_ns_partition;
 		zephyr,shell-uart = &uart1;
 	};
 
@@ -40,9 +43,31 @@
 		};
 	};
 
-	mram0: mram@a080000 {
+	mram0: mram@a000000 {
 		/* Internal code eMRAM */
-		reg = <0x0a080000 0x80000>;
+		compatible = "soc-nv-flash";
+		reg = <0x0a000000 DT_SIZE_M(2)>;
+		erase-block-size = <DT_SIZE_K(1)>;
+		write-block-size = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* Please see the memory layout in:
+			 * https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/zephyr_tf-m_v2.2.2/platform/ext/target/arm/musca_s1/partition/flash_layout.h
+			 */
+			slot0_partition: partition@20000 {
+				reg = <0x20000 DT_SIZE_K(384)>;
+			};
+
+			slot0_ns_partition: partition@80000 {
+				reg = <0x80000 DT_SIZE_K(512)>;
+			};
+		};
 	};
 
 	sram0: memory@20040000 {


### PR DESCRIPTION
Flash layout of musca_b1 and musca_s1 is updated as recommended by mcuboot. This also fixes the below cmake build failures reported in Zephyr ci.

```
CMake Error at
/home/user/zephyrproject/zephyr/cmake/modules/extensions.cmake:3877
(message):
  required nodelabel not found: slot0_partition
Call Stack (most recent call first):
  /home/user/zephyrproject/zephyr/modules/trusted-firmware-m/CMakeLists.txt:489
  (dt_nodelabel)
```

Note that the flash address of musca_b1 board is fixed from 0x0A07_0000 to 0x0A08_0000 as this was missed after the layout was changed in TF-M in e1570bd143ef4843a531b57f77f0c2814b075dd9