### PR TITLE
net: dns: Fix CNAME record handling

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -530,6 +530,11 @@ struct dns_resolve_context {
 		 */
 		uint16_t query_hash;
 
+		/* Number of additional queries sent to resolve CNAME record
+		 * name aliases.
+		 */
+		uint8_t additional_queries;
+
 		/** Flag to indicate that the callback has been called at least once. */
 		bool cb_called;
 	} queries[DNS_NUM_CONCUR_QUERIES];

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1490,12 +1490,12 @@ static int dns_read(struct dns_resolve_context *ctx,
 	ret = dns_validate_msg(ctx, &dns_msg, dns_id, &query_idx,
 			       dns_cname, query_hash);
 	if (ret == DNS_EAI_AGAIN) {
-		goto finished;
+		return ret;
 	}
 
 	if ((ret < 0 && ret != DNS_EAI_ALLDONE) || query_idx < 0 ||
 	    query_idx > CONFIG_DNS_NUM_CONCUR_QUERIES) {
-		goto quit;
+		return ret;
 	}
 
 #if defined(CONFIG_DNS_RESOLVER_PACKET_FORWARDING)
@@ -1518,13 +1518,6 @@ static int dns_read(struct dns_resolve_context *ctx,
 	}
 
 	return 0;
-
-finished:
-	dns_resolve_cancel_with_name(ctx, *dns_id,
-				     ctx->queries[query_idx].query,
-				     ctx->queries[query_idx].query_type);
-quit:
-	return ret;
 }
 
 static int set_ttl_hop_limit(int sock, int level, int option, int new_limit)

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1395,6 +1395,14 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 			goto quit;
 		}
 
+
+		if (answer_type == DNS_RR_TYPE_CNAME) {
+			/* Don't report CNAME records to the application, they're used internally
+			 * for query redirection.
+			 */
+			continue;
+		}
+
 		invoke_query_callback(DNS_EAI_INPROGRESS, &info, &ctx->queries[*query_idx]);
 
 		if (dns_msg->response_type == DNS_RESPONSE_IP ||


### PR DESCRIPTION
* Fix a regression, where CNAME record were reported in the application cb,
* Don't release the query context when a follow up CNAME query is intended,
* Limit the maximum number of follow-up CNAME queries.

Fixes #102498
Fixes #102483
