### PR TITLE
video: samples: capture: add support for m2m transform

### DIFF
--- a/samples/drivers/video/capture/CMakeLists.txt
+++ b/samples/drivers/video/capture/CMakeLists.txt
@@ -4,5 +4,4 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(video_capture)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/video/capture/Kconfig
+++ b/samples/drivers/video/capture/Kconfig
@@ -65,6 +65,23 @@ config VIDEO_SHELL_AND_CAPTURE
 	help
 	  If set, the video capture is enabled even if the video shell is also enabled.
 
+config VIDEO_CAM_NUM_BUFS
+	int "Number of video buffers used for the camera"
+	default 2
+	help
+	  Number of buffers in the video buffer pool used for the camera device.
+	  The rest of the buffer pool will be used for other purposes such as transformation.
+
+choice VIDEO_TRANSFORM
+	prompt "Video transform implementation"
+	bool
+	help
+	  The captured frame will go through m2m transforms defined in a separate .c file.
+	  The implementation could include "transform.h" which provides helper functions
+	  for setting up and executing the transformation.
+
+endchoice
+
 endmenu
 
 source "Kconfig.zephyr"

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -111,34 +111,6 @@ static int app_setup_video_selection(const struct device *const video_dev,
 			sel.rect.left, sel.rect.top, sel.rect.width, sel.rect.height);
 	}
 
-	/*
-	 * Check (if possible) if targeted size is same as crop
-	 * and if compose is necessary
-	 */
-	sel.target = VIDEO_SEL_TGT_CROP;
-	ret = video_get_selection(video_dev, &sel);
-	if (ret < 0 && ret != -ENOSYS) {
-		LOG_ERR("Unable to get selection crop");
-		return ret;
-	}
-
-	if (ret == 0 && (sel.rect.width != fmt->width || sel.rect.height != fmt->height)) {
-		sel.target = VIDEO_SEL_TGT_COMPOSE;
-		sel.rect.left = 0;
-		sel.rect.top = 0;
-		sel.rect.width = fmt->width;
-		sel.rect.height = fmt->height;
-
-		ret = video_set_selection(video_dev, &sel);
-		if (ret < 0 && ret != -ENOSYS) {
-			LOG_ERR("Unable to set selection compose");
-			return ret;
-		}
-
-		LOG_INF("Compose window set to (%u,%u)/%ux%u",
-			sel.rect.left, sel.rect.top, sel.rect.width, sel.rect.height);
-	}
-
 	return 0;
 }
 

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Linaro Limited
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,9 +15,35 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
+/*
+ * Include transform.h unconditionally to ensure it's compiled and checked by CI,
+ * even though the functions in this header are not used here at all.
+ * This prevents silent breakage when APIs change.
+ */
+#include "transform.h"
+
 #if !DT_HAS_CHOSEN(zephyr_camera)
 #error No camera chosen in devicetree. Missing "--shield" or "--snippet video-sw-generator" flag?
 #endif
+
+/* The default transform implementation is a pass-through when no transform device is available */
+int __weak app_setup_video_transform(const struct device *const transform_dev,
+				     struct video_format *const in_fmt,
+				     struct video_format *const out_fmt,
+				     struct video_buffer **out_buf)
+{
+	*out_fmt = *in_fmt;
+
+	return 0;
+}
+
+int __weak app_transform_frame(const struct device *const transform_dev,
+			       struct video_buffer *in_buf, struct video_buffer **out_buf)
+{
+	*out_buf = in_buf;
+
+	return 0;
+}
 
 static inline int app_setup_display(const struct device *const display_dev, const uint32_t pixfmt)
 {
@@ -274,12 +300,12 @@ static int app_setup_video_buffers(const struct device *const camera_dev,
 	int ret;
 
 	/* Alloc video buffers and enqueue for capture */
-	if (caps->min_vbuf_count > CONFIG_VIDEO_BUFFER_POOL_NUM_MAX) {
+	if (caps->min_vbuf_count > CONFIG_VIDEO_CAM_NUM_BUFS) {
 		LOG_ERR("Not enough buffers to start streaming");
 		return -EINVAL;
 	}
 
-	for (int i = 0; i < CONFIG_VIDEO_BUFFER_POOL_NUM_MAX; i++) {
+	for (uint8_t i = 0; i < CONFIG_VIDEO_CAM_NUM_BUFS; i++) {
 		struct video_buffer *vbuf;
 
 		/*
@@ -309,8 +335,13 @@ int main(void)
 {
 	const struct device *const camera_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 	const struct device *const display_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_display));
-	struct video_buffer *vbuf = &(struct video_buffer){};
-	struct video_format fmt = {
+	const struct device *transform_dev = NULL;
+	struct video_buffer *camera_vbuf = &(struct video_buffer){};
+	struct video_buffer *transformed_vbuf = &(struct video_buffer){};
+	struct video_format camera_fmt = {
+		.type = VIDEO_BUF_TYPE_OUTPUT,
+	};
+	struct video_format transformed_fmt = {
 		.type = VIDEO_BUF_TYPE_OUTPUT,
 	};
 	struct video_caps caps = {
@@ -326,22 +357,27 @@ int main(void)
 		return 0;
 	}
 
-	ret = app_query_video_info(camera_dev, &caps, &fmt);
+	transform_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_videotrans));
+	if (transform_dev == NULL) {
+		transform_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_videodec));
+	}
+
+	ret = app_query_video_info(camera_dev, &caps, &camera_fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_selection(camera_dev, &fmt);
+	ret = app_setup_video_selection(camera_dev, &camera_fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_format(camera_dev, &fmt);
+	ret = app_setup_video_format(camera_dev, &camera_fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_frmival(camera_dev, &fmt);
+	ret = app_setup_video_frmival(camera_dev, &camera_fmt);
 	if (ret < 0) {
 		goto err;
 	}
@@ -351,14 +387,21 @@ int main(void)
 		goto err;
 	}
 
+	ret = app_setup_video_transform(transform_dev, &camera_fmt, &transformed_fmt,
+					&transformed_vbuf);
+	if (ret < 0) {
+		LOG_ERR("Unable to setup video transform");
+		goto err;
+	}
+
 	if (DT_HAS_CHOSEN(zephyr_display)) {
-		ret = app_setup_display(display_dev, fmt.pixelformat);
+		ret = app_setup_display(display_dev, transformed_fmt.pixelformat);
 		if (ret < 0) {
 			goto err;
 		}
 	}
 
-	ret = app_setup_video_buffers(camera_dev, &caps, &fmt);
+	ret = app_setup_video_buffers(camera_dev, &caps, &camera_fmt);
 	if (ret < 0) {
 		goto err;
 	}
@@ -371,26 +414,33 @@ int main(void)
 
 	LOG_INF("Capture started");
 
-	vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
+	camera_vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
 	while (1) {
-		ret = video_dequeue(camera_dev, &vbuf, K_FOREVER);
+		ret = video_dequeue(camera_dev, &camera_vbuf, K_FOREVER);
 		if (ret < 0) {
 			LOG_ERR("Unable to dequeue video buf");
 			goto err;
 		}
 
-		LOG_INF("Got frame %u! size: %u; timestamp %u ms (delta %u ms)",
-			frame++, vbuf->bytesused, vbuf->timestamp, vbuf->timestamp - last_ts);
-		last_ts = vbuf->timestamp;
+		LOG_INF("Got frame %u! size: %u; timestamp %u ms (delta %u ms)", frame++,
+			camera_vbuf->bytesused, camera_vbuf->timestamp,
+			camera_vbuf->timestamp - last_ts);
+		last_ts = camera_vbuf->timestamp;
+
+		ret = app_transform_frame(transform_dev, camera_vbuf, &transformed_vbuf);
+		if (ret < 0) {
+			LOG_ERR("Unable to transform video frame");
+			goto err;
+		}
 
 		if (DT_HAS_CHOSEN(zephyr_display)) {
-			ret = app_display_frame(display_dev, vbuf, &fmt);
+			ret = app_display_frame(display_dev, transformed_vbuf, &transformed_fmt);
 			if (ret != 0) {
 				LOG_WRN("Failed to display this frame");
 			}
 		}
 
-		ret = video_enqueue(camera_dev, vbuf);
+		ret = video_enqueue(camera_dev, camera_vbuf);
 		if (ret < 0) {
 			LOG_ERR("Unable to requeue video buf");
 			goto err;

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -85,7 +85,7 @@ static int app_display_frame(const struct device *const display_dev,
 	return display_write(display_dev, 0, vbuf->line_offset, &buf_desc, vbuf->buffer);
 }
 
-static int app_setup_video_selection(const struct device *const video_dev,
+static int app_setup_video_selection(const struct device *const camera_dev,
 				     const struct video_format *const fmt)
 {
 	struct video_selection sel = {
@@ -101,7 +101,7 @@ static int app_setup_video_selection(const struct device *const video_dev,
 		sel.rect.width = CONFIG_VIDEO_SOURCE_CROP_WIDTH;
 		sel.rect.height = CONFIG_VIDEO_SOURCE_CROP_HEIGHT;
 
-		ret = video_set_selection(video_dev, &sel);
+		ret = video_set_selection(camera_dev, &sel);
 		if (ret < 0) {
 			LOG_ERR("Unable to set selection crop");
 			return ret;
@@ -114,21 +114,21 @@ static int app_setup_video_selection(const struct device *const video_dev,
 	return 0;
 }
 
-static int app_query_video_info(const struct device *const video_dev,
+static int app_query_video_info(const struct device *const camera_dev,
 				struct video_caps *const caps,
 				struct video_format *const fmt)
 {
 	int ret;
 
-	LOG_INF("Video device: %s", video_dev->name);
+	LOG_INF("Camera device: %s", camera_dev->name);
 
-	if (!device_is_ready(video_dev)) {
-		LOG_ERR("%s: video device is not ready", video_dev->name);
+	if (!device_is_ready(camera_dev)) {
+		LOG_ERR("%s: camera device is not ready", camera_dev->name);
 		return -ENOSYS;
 	}
 
 	/* Get capabilities */
-	ret = video_get_caps(video_dev, caps);
+	ret = video_get_caps(camera_dev, caps);
 	if (ret < 0) {
 		LOG_ERR("Unable to retrieve video capabilities");
 		return ret;
@@ -145,7 +145,7 @@ static int app_query_video_info(const struct device *const video_dev,
 	}
 
 	/* Get default/native format */
-	ret = video_get_format(video_dev, fmt);
+	ret = video_get_format(camera_dev, fmt);
 	if (ret < 0) {
 		LOG_ERR("Unable to retrieve video format");
 	}
@@ -164,7 +164,7 @@ static int app_query_video_info(const struct device *const video_dev,
 	return 0;
 }
 
-static int app_setup_video_format(const struct device *const video_dev,
+static int app_setup_video_format(const struct device *const camera_dev,
 				  struct video_format *const fmt)
 {
 	int ret;
@@ -172,7 +172,7 @@ static int app_setup_video_format(const struct device *const video_dev,
 	LOG_INF("- Video format: %s %ux%u",
 		VIDEO_FOURCC_TO_STR(fmt->pixelformat), fmt->width, fmt->height);
 
-	ret = video_set_compose_format(video_dev, fmt);
+	ret = video_set_compose_format(camera_dev, fmt);
 	if (ret < 0) {
 		LOG_ERR("Unable to set format");
 		return ret;
@@ -181,7 +181,7 @@ static int app_setup_video_format(const struct device *const video_dev,
 	return 0;
 }
 
-static int app_setup_video_frmival(const struct device *const video_dev,
+static int app_setup_video_frmival(const struct device *const camera_dev,
 				   struct video_format *const fmt)
 {
 	struct video_frmival frmival = {};
@@ -192,7 +192,7 @@ static int app_setup_video_frmival(const struct device *const video_dev,
 
 	LOG_INF("- Supported frame intervals for the default format:");
 
-	while (video_enum_frmival(video_dev, &fie) == 0) {
+	while (video_enum_frmival(camera_dev, &fie) == 0) {
 		if (fie.type == VIDEO_FRMIVAL_TYPE_DISCRETE) {
 			LOG_INF("   %u/%u", fie.discrete.numerator, fie.discrete.denominator);
 		} else {
@@ -204,7 +204,7 @@ static int app_setup_video_frmival(const struct device *const video_dev,
 		fie.index++;
 	}
 
-	ret = video_get_frmival(video_dev, &frmival);
+	ret = video_get_frmival(camera_dev, &frmival);
 	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		LOG_WRN("The video source does not support frame rate control");
 	} else if (ret < 0) {
@@ -218,14 +218,14 @@ static int app_setup_video_frmival(const struct device *const video_dev,
 	return 0;
 }
 
-static int app_setup_video_controls(const struct device *const video_dev)
+static int app_setup_video_controls(const struct device *const camera_dev)
 {
 	int ret;
 
 	/* Get supported controls */
 	LOG_INF("- Supported controls:");
 	const struct device *last_dev = NULL;
-	struct video_ctrl_query cq = {.dev = video_dev, .id = VIDEO_CTRL_FLAG_NEXT_CTRL};
+	struct video_ctrl_query cq = {.dev = camera_dev, .id = VIDEO_CTRL_FLAG_NEXT_CTRL};
 
 	while (video_query_ctrl(&cq) == 0) {
 		if (cq.dev != last_dev) {
@@ -240,7 +240,7 @@ static int app_setup_video_controls(const struct device *const video_dev)
 	struct video_control ctrl = {.id = VIDEO_CID_HFLIP, .val = 1};
 
 	if (IS_ENABLED(CONFIG_VIDEO_CTRL_HFLIP)) {
-		ret = video_set_ctrl(video_dev, &ctrl);
+		ret = video_set_ctrl(camera_dev, &ctrl);
 		if (ret < 0) {
 			LOG_ERR("Failed to set horizontal flip");
 			return ret;
@@ -249,7 +249,7 @@ static int app_setup_video_controls(const struct device *const video_dev)
 
 	if (IS_ENABLED(CONFIG_VIDEO_CTRL_VFLIP)) {
 		ctrl.id = VIDEO_CID_VFLIP;
-		ret = video_set_ctrl(video_dev, &ctrl);
+		ret = video_set_ctrl(camera_dev, &ctrl);
 		if (ret < 0) {
 			LOG_ERR("Failed to set vertical flip");
 			return ret;
@@ -258,7 +258,7 @@ static int app_setup_video_controls(const struct device *const video_dev)
 
 	if (IS_ENABLED(CONFIG_TEST)) {
 		ctrl.id = VIDEO_CID_TEST_PATTERN;
-		ret = video_set_ctrl(video_dev, &ctrl);
+		ret = video_set_ctrl(camera_dev, &ctrl);
 		if (ret < 0 && ret != -ENOTSUP) {
 			LOG_WRN("Failed to set the test pattern");
 		}
@@ -267,7 +267,7 @@ static int app_setup_video_controls(const struct device *const video_dev)
 	return 0;
 }
 
-static int app_setup_video_buffers(const struct device *const video_dev,
+static int app_setup_video_buffers(const struct device *const camera_dev,
 				   struct video_caps *const caps,
 				   struct video_format *const fmt)
 {
@@ -295,7 +295,7 @@ static int app_setup_video_buffers(const struct device *const video_dev,
 
 		vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
 
-		ret = video_enqueue(video_dev, vbuf);
+		ret = video_enqueue(camera_dev, vbuf);
 		if (ret < 0) {
 			LOG_ERR("Failed to enqueue video buffer");
 			return ret;
@@ -307,7 +307,7 @@ static int app_setup_video_buffers(const struct device *const video_dev,
 
 int main(void)
 {
-	const struct device *const video_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
+	const struct device *const camera_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 	const struct device *const display_dev = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_display));
 	struct video_buffer *vbuf = &(struct video_buffer){};
 	struct video_format fmt = {
@@ -317,6 +317,7 @@ int main(void)
 		.type = VIDEO_BUF_TYPE_OUTPUT,
 	};
 	unsigned int frame = 0;
+	uint32_t last_ts = 0;
 	int ret;
 
 	/* When the video shell is enabled, do not run the capture loop unless requested */
@@ -325,27 +326,27 @@ int main(void)
 		return 0;
 	}
 
-	ret = app_query_video_info(video_dev, &caps, &fmt);
+	ret = app_query_video_info(camera_dev, &caps, &fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_selection(video_dev, &fmt);
+	ret = app_setup_video_selection(camera_dev, &fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_format(video_dev, &fmt);
+	ret = app_setup_video_format(camera_dev, &fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_frmival(video_dev, &fmt);
+	ret = app_setup_video_frmival(camera_dev, &fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = app_setup_video_controls(video_dev);
+	ret = app_setup_video_controls(camera_dev);
 	if (ret < 0) {
 		goto err;
 	}
@@ -357,12 +358,12 @@ int main(void)
 		}
 	}
 
-	ret = app_setup_video_buffers(video_dev, &caps, &fmt);
+	ret = app_setup_video_buffers(camera_dev, &caps, &fmt);
 	if (ret < 0) {
 		goto err;
 	}
 
-	ret = video_stream_start(video_dev, VIDEO_BUF_TYPE_OUTPUT);
+	ret = video_stream_start(camera_dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		LOG_ERR("Unable to start capture (interface)");
 		goto err;
@@ -370,18 +371,16 @@ int main(void)
 
 	LOG_INF("Capture started");
 
-	uint32_t last_ts = 0;
-
 	vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
 	while (1) {
-		ret = video_dequeue(video_dev, &vbuf, K_FOREVER);
+		ret = video_dequeue(camera_dev, &vbuf, K_FOREVER);
 		if (ret < 0) {
 			LOG_ERR("Unable to dequeue video buf");
 			goto err;
 		}
 
 		LOG_INF("Got frame %u! size: %u; timestamp %u ms (delta %u ms)",
-			frame++, vbuf->bytesused, vbuf->timestamp, vbuf->timestamp-last_ts);
+			frame++, vbuf->bytesused, vbuf->timestamp, vbuf->timestamp - last_ts);
 		last_ts = vbuf->timestamp;
 
 		if (DT_HAS_CHOSEN(zephyr_display)) {
@@ -391,7 +390,7 @@ int main(void)
 			}
 		}
 
-		ret = video_enqueue(video_dev, vbuf);
+		ret = video_enqueue(camera_dev, vbuf);
 		if (ret < 0) {
 			LOG_ERR("Unable to requeue video buf");
 			goto err;

--- a/samples/drivers/video/capture/src/transform.h
+++ b/samples/drivers/video/capture/src/transform.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/video.h>
+#include <zephyr/logging/log.h>
+
+static inline int setup_video_transform(const struct device *const transform_dev,
+					struct video_format *const in_fmt,
+					struct video_format *const out_fmt,
+					struct video_buffer **out_buf)
+{
+	int ret;
+
+	/* Set input and output formats */
+	in_fmt->type = VIDEO_BUF_TYPE_INPUT;
+	ret = video_set_format(transform_dev, in_fmt);
+	if (ret < 0) {
+		LOG_ERR("Unable to set input format");
+		return ret;
+	}
+
+	ret = video_set_format(transform_dev, out_fmt);
+	if (ret < 0) {
+		LOG_ERR("Unable to set output format");
+		return ret;
+	}
+
+	/* Allocate a buffer for output queue */
+	*out_buf = video_buffer_aligned_alloc(out_fmt->size,
+					      CONFIG_VIDEO_BUFFER_POOL_ALIGN, K_NO_WAIT);
+	if (*out_buf == NULL) {
+		LOG_ERR("Unable to allocate output video buffer");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static inline int transform_frame(const struct device *const transform_dev,
+				  struct video_buffer *in_buf, struct video_buffer **out_buf)
+{
+	int ret;
+	/* Store the input buffer type to recover later */
+	enum video_buf_type in_buf_type = in_buf->type;
+	static bool started;
+
+	in_buf->type = VIDEO_BUF_TYPE_INPUT;
+	ret = video_enqueue(transform_dev, in_buf);
+	if (ret < 0) {
+		LOG_ERR("Unable to enqueue input buffer");
+		return ret;
+	}
+
+	(*out_buf)->type = VIDEO_BUF_TYPE_OUTPUT;
+	ret = video_enqueue(transform_dev, *out_buf);
+	if (ret < 0) {
+		LOG_ERR("Unable to enqueue output buffer");
+		return ret;
+	}
+
+	if (!started) {
+		ret = video_stream_start(transform_dev, VIDEO_BUF_TYPE_INPUT);
+		if (ret < 0) {
+			LOG_ERR("Unable to start the transform input");
+			return ret;
+		}
+
+		ret = video_stream_start(transform_dev, VIDEO_BUF_TYPE_OUTPUT);
+		if (ret < 0) {
+			LOG_ERR("Unable to start the transform output");
+			return ret;
+		}
+
+		started = true;
+	}
+
+	ret = video_dequeue(transform_dev, &in_buf, K_FOREVER);
+	if (ret < 0) {
+		LOG_ERR("Unable to dequeue input buffer");
+		return ret;
+	}
+
+	ret = video_dequeue(transform_dev, out_buf, K_FOREVER);
+	if (ret < 0) {
+		LOG_ERR("Unable to dequeue output buffer");
+		return ret;
+	}
+
+	/* Keep the input buffer intact */
+	in_buf->type = in_buf_type;
+
+	return 0;
+}


### PR DESCRIPTION
- Add support for additional m2m transforms such as rotation, color conversion, decoding which need to be applied on the video frame before displaying it.
- Some minor fixes