### PR TITLE
sysbuild: Link MCUboot output with main app configuration

### DIFF
--- a/share/sysbuild/images/bootloader/CMakeLists.txt
+++ b/share/sysbuild/images/bootloader/CMakeLists.txt
@@ -14,6 +14,9 @@ if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} ${image})
   sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} ${image})
 
+  # Link the footer size output of this MCUboot build with the main sysbuild image
+  set_target_properties(${image} PROPERTIES MCUBOOT_FOOTER_UPDATE_IMAGES ${DEFAULT_IMAGE})
+
   set_config_string(${image} CONFIG_BOOT_SIGNATURE_KEY_FILE "${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}")
 
   if(SB_CONFIG_MCUBOOT_DIRECT_XIP_GENERATE_VARIANT)

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 19807014b69b2dc24edb7a1b49c915fd58083527
+      revision: 2e6348fd9534226fc0829915e0c15d780855a012
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:

--- a/west.yml
+++ b/west.yml
@@ -326,7 +326,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 9ac72969f281491d677e669d053281fc2d538ed4
+      revision: cb6e4ceaacd4dfe1e3cdeb92c7f5680f62967837
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Links the output from the default MCUboot build with the estimated size of the overhead with the main image. This also allowes used to remove the linkage between them, if they so wish