### PR TITLE
Bluetooth: CCP: Add support for bearer technology

### DIFF
--- a/doc/services/connectivity/bluetooth/shell/audio/ccp.rst
+++ b/doc/services/connectivity/bluetooth/shell/audio/ccp.rst
@@ -25,6 +25,8 @@ to :code:`0` which is the GTBS bearer.
      set_bearer_name  : Set bearer name [index] <name>
      get_bearer_name  : Get bearer name [index]
      get_bearer_uci   : Get bearer UCI [index]
+     set_bearer_tech  : Set bearer technology [index] <technology>
+     get_bearer_tech  : Get bearer technology [index]
 
 
 Example Usage
@@ -68,6 +70,17 @@ Getting the bearer UCI
    Bearer[0] UCI: un999
    uart:~$ ccp_call_control_server get_bearer_uci 1
    Bearer[1] UCI: skype
+
+
+Setting and getting the bearer technology
+-----------------------------------------
+
+.. code-block:: console
+
+   uart:~$ ccp_call_control_server get_bearer_tech
+   Bearer[0] technology: 3G (0x01)
+   uart:~$ ccp_call_control_server set_bearer_tech 0x02
+   Bearer[0] new technology: 4G (0x02)
 
 Call Control Client
 *******************

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -35,6 +35,7 @@
 #include <stddef.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/slist.h>
@@ -143,6 +144,31 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
 int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_bearer *bearer,
 					      char uci[BT_TBS_MAX_UCI_SIZE]);
 
+/**
+ * @brief Set a new bearer technology.
+ *
+ * @param[out] bearer The bearer to set the name for.
+ * @param tech The new bearer technology.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p bearer or is NULL or @p tech is invalid.
+ * @retval -EFAULT @p bearer is not registered.
+ */
+int bt_ccp_call_control_server_set_bearer_tech(struct bt_ccp_call_control_server_bearer *bearer,
+					       enum bt_bearer_tech tech);
+
+/**
+ * @brief Get the bearer technology.
+ *
+ * @param[in] bearer The bearer to get the technology for.
+ * @param[out] tech Pointer that will be updated to be the bearer technology.
+ *
+ * @retval 0 Success.
+ * @retval -EINVAL @p bearer or @p tech is NULL.
+ * @retval -EFAULT @p bearer is not registered.
+ */
+int bt_ccp_call_control_server_get_bearer_tech(
+	const struct bt_ccp_call_control_server_bearer *bearer, enum bt_bearer_tech *tech);
 /** @} */ /* End of group bt_ccp_call_control_server */
 
 /**

--- a/subsys/bluetooth/audio/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/ccp_call_control_server.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -29,6 +30,7 @@ LOG_MODULE_REGISTER(bt_ccp_call_control_server, CONFIG_BT_CCP_CALL_CONTROL_SERVE
 struct bt_ccp_call_control_server_bearer {
 	char provider_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	char uci[BT_TBS_MAX_UCI_SIZE];
+	enum bt_bearer_tech bearer_tech;
 	uint8_t tbs_index;
 	bool registered;
 	struct k_mutex mutex;
@@ -97,6 +99,7 @@ int bt_ccp_call_control_server_register_bearer(const struct bt_tbs_register_para
 		(void)utf8_lcpy(free_bearer->provider_name, param->provider_name,
 				sizeof(free_bearer->provider_name));
 		(void)utf8_lcpy(free_bearer->uci, param->uci, sizeof(free_bearer->uci));
+		free_bearer->bearer_tech = param->technology;
 		*bearer = free_bearer;
 
 		ret = 0;
@@ -285,6 +288,67 @@ int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
+}
+
+int bt_ccp_call_control_server_set_bearer_tech(struct bt_ccp_call_control_server_bearer *bearer,
+					       enum bt_bearer_tech tech)
+{
+	int err;
+
+	if (bearer == NULL) {
+		LOG_DBG("bearer is NULL");
+
+		return -EINVAL;
+	}
+
+	if (!bearer->registered) {
+		LOG_DBG("Bearer %p not registered", bearer);
+
+		return -EFAULT;
+	}
+
+	if (!IN_RANGE(tech, BT_BEARER_TECH_3G, BT_BEARER_TECH_WCDMA)) {
+		LOG_DBG("Invalid tech param: %d", tech);
+
+		return -EINVAL;
+	}
+
+	if (bearer->bearer_tech == tech) {
+		return 0;
+	}
+
+	err = bt_tbs_set_bearer_technology(bearer->tbs_index, tech);
+	if (err == 0) {
+		bearer->bearer_tech = tech;
+	}
+
+	return err;
+}
+
+int bt_ccp_call_control_server_get_bearer_tech(
+	const struct bt_ccp_call_control_server_bearer *bearer, enum bt_bearer_tech *tech)
+{
+	if (bearer == NULL) {
+		LOG_DBG("bearer is NULL");
+
+		return -EINVAL;
+	}
+
+	if (tech == NULL) {
+		LOG_DBG("tech is NULL");
+
+		return -EINVAL;
+	}
+
+	if (!bearer->registered) {
+		LOG_DBG("Bearer %p not registered", bearer);
+
+		return -EFAULT;
+	}
+
+	*tech = bearer->bearer_tech;
+
+	return 0;
 }
 
 static int ccp_server_init(void)

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -17,7 +17,10 @@
 #include <zephyr/bluetooth/audio/ccp.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+
+#include "audio/tbs_internal.h"
 
 static struct bt_ccp_call_control_server_bearer
 	*bearers[CONFIG_BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT];
@@ -188,6 +191,75 @@ static int cmd_ccp_call_control_server_get_bearer_uci(const struct shell *sh, si
 	return 0;
 }
 
+static int cmd_ccp_call_control_server_set_bearer_tech(const struct shell *sh, size_t argc,
+						       char *argv[])
+{
+	enum bt_bearer_tech tech;
+	unsigned long tech_arg;
+	int index = 0;
+	int err = 0;
+
+	if (argc > 2) {
+		index = validate_and_get_index(sh, argv[1]);
+		if (index < 0) {
+			return -ENOEXEC;
+		}
+	}
+
+	tech_arg = shell_strtoul(argv[argc - 1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse technology: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	tech = (enum bt_bearer_tech)tech_arg;
+	if (!IN_RANGE(tech, BT_BEARER_TECH_3G, BT_BEARER_TECH_WCDMA)) {
+		shell_error(sh, "Invalid technology: %d", tech);
+
+		return -ENOEXEC;
+	}
+
+	err = bt_ccp_call_control_server_set_bearer_tech(bearers[index], (enum bt_bearer_tech)tech);
+	if (err != 0) {
+		shell_error(sh, "Failed to set bearer[%d] tech: %d", index, err);
+
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Bearer[%d] new technology: %s (0x%02X)", index, bt_bearer_tech_str(tech),
+		    tech);
+
+	return 0;
+}
+
+static int cmd_ccp_call_control_server_get_bearer_tech(const struct shell *sh, size_t argc,
+						       char *argv[])
+{
+	enum bt_bearer_tech tech;
+	int index = 0;
+	int err = 0;
+
+	if (argc > 1) {
+		index = validate_and_get_index(sh, argv[1]);
+		if (index < 0) {
+			return -ENOEXEC;
+		}
+	}
+
+	err = bt_ccp_call_control_server_get_bearer_tech(bearers[index], &tech);
+	if (err != 0) {
+		shell_error(sh, "Failed to get bearer[%d] tech: %d", index, err);
+
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Bearer[%d] technology: %s (0x%02X)", index, bt_bearer_tech_str(tech),
+		    tech);
+
+	return 0;
+}
+
 static int cmd_ccp_call_control_server(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc > 1) {
@@ -209,6 +281,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(ccp_call_control_server_cmds,
 					     cmd_ccp_call_control_server_get_bearer_name, 1, 1),
 			       SHELL_CMD_ARG(get_bearer_uci, NULL, "Get bearer UCI [index]",
 					     cmd_ccp_call_control_server_get_bearer_uci, 1, 1),
+			       SHELL_CMD_ARG(set_bearer_tech, NULL,
+					     "Set bearer technology [index] <technology>",
+					     cmd_ccp_call_control_server_set_bearer_tech, 2, 1),
+			       SHELL_CMD_ARG(get_bearer_tech, NULL, "Get bearer technology [index]",
+					     cmd_ccp_call_control_server_get_bearer_tech, 1, 1),
 			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_ARG_REGISTER(ccp_call_control_server, &ccp_call_control_server_cmds,

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -28,6 +28,7 @@ DEFINE_FFF_GLOBALS;
 
 #define DEFAULT_BEARER_NAME "test"
 #define DEFAULT_BEARER_UCI  "un999"
+#define DEFAULT_BEARER_TECH BT_BEARER_TECH_3G
 
 struct ccp_call_control_server_test_suite_fixture {
 	/** Need 1 additional bearer than the max to trigger some corner cases */
@@ -89,7 +90,7 @@ static void register_default_bearer(struct ccp_call_control_server_test_suite_fi
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
-		.technology = BT_BEARER_TECH_3G,
+		.technology = DEFAULT_BEARER_TECH,
 		.optional_opcodes = 0,
 	};
 	int err;
@@ -488,5 +489,113 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 	register_default_bearer(fixture);
 
 	err = bt_ccp_call_control_server_get_bearer_uci(fixture->bearers[0], NULL);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite, test_bt_ccp_call_control_server_set_bearer_tech)
+{
+	const enum bt_bearer_tech new_bearer_tech = BT_BEARER_TECH_3G;
+	enum bt_bearer_tech res_bearer_tech;
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_set_bearer_tech(fixture->bearers[0], new_bearer_tech);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_ccp_call_control_server_get_bearer_tech(fixture->bearers[0], &res_bearer_tech);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zassert_equal(new_bearer_tech, res_bearer_tech, "%d != %d", new_bearer_tech,
+		      res_bearer_tech);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_set_bearer_tech_inval_not_registered)
+{
+	const enum bt_bearer_tech new_bearer_tech = BT_BEARER_TECH_3G;
+	int err;
+
+	/* Register and unregister bearer to get a valid pointer but where it is unregistered*/
+	register_default_bearer(fixture);
+	err = bt_ccp_call_control_server_unregister_bearer(fixture->bearers[0]);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_ccp_call_control_server_set_bearer_tech(fixture->bearers[0], new_bearer_tech);
+	zassert_equal(err, -EFAULT, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_set_bearer_tech_inval_null_bearer)
+{
+	const enum bt_bearer_tech new_bearer_tech = BT_BEARER_TECH_3G;
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_set_bearer_tech(NULL, new_bearer_tech);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_set_bearer_tech_inval_tech)
+{
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_set_bearer_tech(fixture->bearers[0], 0x10);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite, test_bt_ccp_call_control_server_get_bearer_tech)
+{
+	enum bt_bearer_tech res_bearer_tech;
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_get_bearer_tech(fixture->bearers[0], &res_bearer_tech);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zassert_equal(DEFAULT_BEARER_TECH, res_bearer_tech, "%d != %d", DEFAULT_BEARER_TECH,
+		      res_bearer_tech);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_get_bearer_tech_inval_not_registered)
+{
+	enum bt_bearer_tech res_bearer_tech;
+	int err;
+
+	/* Register and unregister bearer to get a valid pointer but where it is unregistered*/
+	register_default_bearer(fixture);
+	err = bt_ccp_call_control_server_unregister_bearer(fixture->bearers[0]);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_ccp_call_control_server_get_bearer_tech(fixture->bearers[0], &res_bearer_tech);
+	zassert_equal(err, -EFAULT, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_get_bearer_tech_inval_null_bearer)
+{
+	enum bt_bearer_tech res_bearer_tech;
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_get_bearer_tech(NULL, &res_bearer_tech);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_get_bearer_tech_inval_null_tech)
+{
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_get_bearer_tech(fixture->bearers[0], NULL);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 }


### PR DESCRIPTION
Add support for setting and getting the bearer technology using the CCP API.

depends on https://github.com/zephyrproject-rtos/zephyr/pull/102430