### PR TITLE
drivers: firmware: scmi: inclusive language fixes

### DIFF
--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -41,7 +41,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 	struct scmi_clock_rate_set_reply reply_buffer;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !rate) {
 		return -EINVAL;
 	}
@@ -81,7 +81,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -120,7 +120,7 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	struct scmi_clock_parent_get_reply reply_buffer;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !parent_id) {
 		return -EINVAL;
 	}
@@ -161,7 +161,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto) {
 		return -EINVAL;
 	}
@@ -196,7 +196,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -246,7 +246,7 @@ int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attrib
 	int ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !attributes) {
 		return -EINVAL;
 	}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -23,7 +23,7 @@ int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -61,7 +61,7 @@ int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -95,7 +95,7 @@ int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 	struct scmi_message msg, reply;
 	int status, ret;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -127,7 +127,7 @@ int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 	struct scmi_message msg, reply;
 	int status, ret;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}
@@ -160,7 +160,7 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 	struct scmi_nxp_cpu_info_get_reply reply_buffer;
 	int ret;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -20,7 +20,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 
 	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PINCTRL);
 
-	/* sanity checks */
+	/* input validation */
 	if (!settings) {
 		return -EINVAL;
 	}

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -24,7 +24,7 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 	int ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !power_state) {
 		return -EINVAL;
 	}
@@ -65,7 +65,7 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	int status, ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -68,7 +68,7 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 	cfg = shmem->config;
 	layout = (struct scmi_shmem_layout *)data->regmap;
 
-	/* some sanity checks first */
+	/* some input validation first */
 	if (!msg) {
 		return -EINVAL;
 	}
@@ -120,7 +120,7 @@ int scmi_shmem_write_message(const struct device *shmem, struct scmi_message *ms
 	cfg = shmem->config;
 	layout = (struct scmi_shmem_layout *)data->regmap;
 
-	/* some sanity checks first */
+	/* some input validation first */
 	if (!msg) {
 		return -EINVAL;
 	}

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -47,7 +47,7 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 	int ret;
 	bool use_polling;
 
-	/* sanity checks */
+	/* input validation */
 	if (!proto || !cfg) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
As per coding guidelines, "sanity check" must be avoided.