### PR TITLE
arch: arm: avoid the use of "sanity check" term

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -210,11 +210,11 @@ static int mpu_configure_region(const uint8_t index,
 	!defined(CONFIG_MPU_GAP_FILLING)
 /* This internal function programs a set of given MPU regions
  * over a background memory area, optionally performing a
- * sanity check of the memory regions to be programmed.
+ * coherence check of the memory regions to be programmed.
  */
 static int mpu_configure_regions(const struct z_arm_mpu_partition
 	regions[], uint8_t regions_num, uint8_t start_reg_index,
-	bool do_sanity_check)
+	bool do_coherence_check)
 {
 	int i;
 	int reg_index = start_reg_index;
@@ -225,9 +225,9 @@ static int mpu_configure_regions(const struct z_arm_mpu_partition
 		}
 		/* Non-empty region. */
 
-		if (do_sanity_check &&
+		if (do_coherence_check &&
 				(!mpu_partition_is_valid(&regions[i]))) {
-			LOG_ERR("Partition %u: sanity check failed.", i);
+			LOG_ERR("Partition %u: coherence check failed.", i);
 			return -EINVAL;
 		}
 
@@ -620,7 +620,7 @@ int z_arm_mpu_init(void)
 #endif
 #endif /* CONFIG_NULL_POINTER_EXCEPTION_DETECTION_MPU */
 
-	/* Sanity check for number of regions in Cortex-M0+, M3, and M4. */
+	/* Coherence check for number of regions in Cortex-M0+, M3, and M4. */
 #if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
 	defined(CONFIG_CPU_CORTEX_M3) || \
 	defined(CONFIG_CPU_CORTEX_M4)

--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -52,9 +52,9 @@ static void region_init(const uint32_t index,
 #endif
 }
 
-/* @brief Partition sanity check
+/* @brief Partition coherence check
  *
- * This internal function performs run-time sanity check for
+ * This internal function performs run-time coherence check for
  * MPU region start address and size.
  *
  * @param part Pointer to the data structure holding the partition
@@ -207,7 +207,7 @@ static int mpu_configure_region(const uint8_t index,
 
 static int mpu_configure_regions(const struct z_arm_mpu_partition
 	regions[], uint8_t regions_num, uint8_t start_reg_index,
-	bool do_sanity_check);
+	bool do_coherence_check);
 
 /* This internal function programs the static MPU regions.
  *

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -184,9 +184,9 @@ static void region_init(const uint32_t index,
 			region_conf->attr.mair_idx, region_conf->attr.r_limit);
 }
 
-/* @brief Partition sanity check
+/* @brief Partition coherence check
  *
- * This internal function performs run-time sanity check for
+ * This internal function performs run-time coherence check for
  * MPU region start address and size.
  *
  * @param part Pointer to the data structure holding the partition
@@ -519,19 +519,19 @@ static int mpu_configure_region(const uint8_t index,
 #if !defined(CONFIG_MPU_GAP_FILLING)
 static int mpu_configure_regions(const struct z_arm_mpu_partition
 	regions[], uint8_t regions_num, uint8_t start_reg_index,
-	bool do_sanity_check);
+	bool do_coherence_check);
 #endif
 
 /* This internal function programs a set of given MPU regions
  * over a background memory area, optionally performing a
- * sanity check of the memory regions to be programmed.
+ * coherence check of the memory regions to be programmed.
  *
  * The function performs a full partition of the background memory
  * area, effectively, leaving no space in this area uncovered by MPU.
  */
 static int mpu_configure_regions_and_partition(const struct z_arm_mpu_partition
 	regions[], uint8_t regions_num, uint8_t start_reg_index,
-	bool do_sanity_check)
+	bool do_coherence_check)
 {
 	int i;
 	int reg_index = start_reg_index;
@@ -542,9 +542,9 @@ static int mpu_configure_regions_and_partition(const struct z_arm_mpu_partition
 		}
 		/* Non-empty region. */
 
-		if (do_sanity_check &&
+		if (do_coherence_check &&
 			(!mpu_partition_is_valid(&regions[i]))) {
-			LOG_ERR("Partition %u: sanity check failed.", i);
+			LOG_ERR("Partition %u: coherence check failed.", i);
 			return -EINVAL;
 		}
 

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -51,9 +51,9 @@ static inline uint8_t get_num_regions(void)
 	return FSL_FEATURE_SYSMPU_DESCRIPTOR_COUNT;
 }
 
-/* @brief Partition sanity check
+/* @brief Partition coherence check
  *
- * This internal function performs run-time sanity check for
+ * This internal function performs run-time coherence check for
  * MPU region start address and size.
  *
  * @param part Pointer to the data structure holding the partition
@@ -297,11 +297,11 @@ static int mpu_sram_partitioning(uint8_t index,
 
 /* This internal function programs a set of given MPU regions
  * over a background memory area, optionally performing a
- * sanity check of the memory regions to be programmed.
+ * coherence check of the memory regions to be programmed.
  */
 static int mpu_configure_regions(const struct z_arm_mpu_partition regions[],
 				 uint8_t regions_num, uint8_t start_reg_index,
-				 bool do_sanity_check)
+				 bool do_coherence_check)
 {
 	int i;
 	int reg_index = start_reg_index;
@@ -312,9 +312,9 @@ static int mpu_configure_regions(const struct z_arm_mpu_partition regions[],
 		}
 		/* Non-empty region. */
 
-		if (do_sanity_check &&
+		if (do_coherence_check &&
 				(!mpu_partition_is_valid(&regions[i]))) {
-			LOG_ERR("Partition %u: sanity check failed.", i);
+			LOG_ERR("Partition %u: coherence check failed.", i);
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
As per coding guidelines, "sanity check" must be avoided.