### PR TITLE
arch: xtensa: avoid the use of "sanity check" term

### DIFF
--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -344,7 +344,7 @@ noflush:
 	/* Switch stack pointer and restore.  The jump to
 	 * _restore_context does not return as such, but we arrange
 	 * for the restored "next" address to be immediately after for
-	 * sanity.
+	 * coherence.
 	 */
 	 l32i a1, a2, ___xtensa_irq_bsa_t_a2_OFFSET
 


### PR DESCRIPTION
As per coding guidelines, "sanity check" must be avoided.