### PR TITLE
arch: riscv: avoid the use of "sanity check" term

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -318,7 +318,7 @@ extern void z_riscv_write_pmp_entries(unsigned int start, unsigned int end,
 /**
  * @brief Write a range of PMP entries to corresponding PMP registers
  *
- * This performs some sanity checks before calling z_riscv_write_pmp_entries().
+ * This performs some coherence checks before calling z_riscv_write_pmp_entries().
  *
  * @param start Start of the PMP range to be written
  * @param end End (exclusive) of the PMP range to be written

--- a/arch/riscv/custom/andes/pma.c
+++ b/arch/riscv/custom/andes/pma.c
@@ -141,7 +141,7 @@ static void region_init(const uint32_t index,
 }
 
 /*
- * This internal function performs run-time sanity check for
+ * This internal function performs run-time coherence check for
  * PMA region start address and size.
  */
 static int pma_region_is_valid(const struct pma_region *region)


### PR DESCRIPTION
As per coding guidelines, "sanity check" must be avoided.