### PR TITLE
drivers: ethernet: nxp_imx_netc: netc_blk: make ierb_init() void

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_blk.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_blk.c
@@ -147,7 +147,7 @@ static int ierb_unlock(const struct device *dev)
 
 #ifdef CONFIG_SOC_MIMX9596
 /* Set LDID */
-static int ierb_init(const struct device *dev)
+static void ierb_init(const struct device *dev)
 {
 	uintptr_t base = DEVICE_MMIO_NAMED_GET(dev, ierb);
 
@@ -173,8 +173,6 @@ static int ierb_init(const struct device *dev)
 	sys_write32(6, base + IERB_VFAUXR(5));
 	/* NETC TIMER */
 	sys_write32(7, base + IERB_T0FAUXR);
-
-	return 0;
 }
 
 static int netcmix_init(const struct device *dev)
@@ -190,9 +188,9 @@ static int netcmix_init(const struct device *dev)
 	return 0;
 }
 #elif defined(CONFIG_SOC_MIMX94398)
-static int ierb_init(const struct device *dev)
+static void ierb_init(const struct device *dev)
 {
-	return 0;
+	ARG_UNUSED(dev);
 }
 
 
@@ -240,10 +238,7 @@ static int eth_nxp_imx_netc_blk_init(const struct device *dev)
 		}
 	}
 
-	if (ierb_init(dev) != 0) {
-		LOG_ERR("Failed to initialize IERB");
-		return -EIO;
-	}
+	ierb_init(dev);
 
 	ret = ierb_lock(dev);
 	if (ret) {


### PR DESCRIPTION
ierb_init() never reports an error and cannot fail in practice. Returning an int led to a dead error.

Convert ierb_init() to a void function, drop the unused return value checks, and provide a no-op implementation for SoCs that do not require IERB initialization.

This simplifies the control flow and removes an unnecessary error condition.