### PR TITLE
spi: infineon: Support SPI-DMA for PSE84 board

### DIFF
--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -192,8 +192,7 @@ static int ifx_cat1_dma_config(const struct device *dev, uint32_t channel,
 		descriptor_config.interruptType = CY_DMA_DESCR;
 	}
 
-	/* Keep CHANNEL_ENABLED if BURST transfer (config->dest_burst_length != 0) */
-	if (config->dest_burst_length != 0) {
+	if (config->block_count > 1U) {
 		descriptor_config.channelState = CY_DMA_CHANNEL_ENABLED;
 	} else {
 		descriptor_config.channelState = CY_DMA_CHANNEL_DISABLED;

--- a/drivers/spi/Kconfig.infineon
+++ b/drivers/spi/Kconfig.infineon
@@ -27,18 +27,10 @@ config SPI_INFINEON_CAT1_PDL
 
 if USE_INFINEON_SPI
 
-config IFX_CAT1_SPI_DMA
-	bool "Infineon CAT1 SPI Interrupt Support"
+config SPI_INFINEON_DMA
+	bool "Infineon SPI DMA Support"
 	select DMA
 	help
 		Enable DMA during usage of SPI driver.
-
-config IFX_CAT1_SPI_DMA_TX_AUTO_TRIGGER
-	bool "Infineon CAT1 SPI Tx DMA channel trigger mechanism"
-	default y
-	depends on IFX_CAT1_SPI_DMA
-	select DMA
-	help
-		Automatically trigger SPI Tx DMA after config
 
 endif # USE_INFINEON_SPI

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
@@ -28,6 +28,9 @@ spi1: &scb10 {
 		reg = <0>;
 		spi-max-frequency = <3000000>;
 	};
+
+	dmas = <&dma0 0>, <&dma0 1>;
+	dma-names = "tx", "rx";
 };
 
 &peri0_group1_16bit_2 {
@@ -49,4 +52,8 @@ spi1: &scb10 {
 &p16_0_scb10_spi_m_clk {
 	drive-strength = "full";
 	drive-push-pull;
+};
+
+&dma0 {
+	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INFINEON_DMA=y

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INFINEON_DMA=y


### PR DESCRIPTION
Based on spi_driver_api, we added support interrupt mode and DMA mode for SPI on PSE84.
if define CONFIG_SPI_INFINEON_DMA,
-> Using interrupt mode or DMA mode depends on transfer length
if not define CONFIG_SPI_INFINEON_DMA,
-> Using interrupt mode only.

