### PR TITLE
dts: fix nxp mcxn94x opamp1 reg value

### DIFF
--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -95,7 +95,7 @@
 
 	opamp1: opamp@113000 {
 		compatible = "nxp,opamp";
-		reg = <0x40113000 0x1000>;
+		reg = <0x113000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		functional-mode = "follower";


### PR DESCRIPTION
It seems there is currently no impact except a warning displayed when building: "unit address and first address in 'reg' (0x40113000) don't match for /soc/peripheral@50000000/opamp@113000"