### PR TITLE
samples: canopennode: add nativesim overlay

### DIFF
--- a/samples/modules/canopennode/boards/native_sim.overlay
+++ b/samples/modules/canopennode/boards/native_sim.overlay
@@ -1,0 +1,10 @@
+
+/ {
+    chosen {
+        zephyr,canbus = &can0;
+    };
+};
+
+&can0 {
+    status = "okay";
+};


### PR DESCRIPTION
Enabling SocketCAN allows the Zephyr application to interface with standard Linux CAN utilities such as candump, cansend, and wireshark