### PR TITLE
doc: getting_started: Correct path in Windows getting started

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -401,7 +401,7 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
             .. code-tab:: bat
 
-               cmd /c scripts\utils\west-packages-pip-install.cmd
+               cmd /c zephyr\scripts\utils\west-packages-pip-install.cmd
 
             .. code-tab:: powershell
 


### PR DESCRIPTION
Path reference to the west-packages-pip-install.cmd is incorrect due to the previous instructions having the prompt at one level up.

Fixes #102535