### PR TITLE
boards: arduino: fix intereface typo in openocd cfg file

### DIFF
--- a/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m4.cfg
+++ b/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m4.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set DUAL_BANK 1

--- a/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m7.cfg
+++ b/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m7.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]

--- a/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m4.cfg
+++ b/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m4.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set DUAL_BANK 1

--- a/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m7.cfg
+++ b/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m7.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]

--- a/boards/arduino/opta/support/openocd_opta_stm32h747xx_m7.cfg
+++ b/boards/arduino/opta/support/openocd_opta_stm32h747xx_m7.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]


### PR DESCRIPTION
Fix a spelling mistake in the board openocd cfg file for arduino boards.

No functional change.