### PR TITLE
drivers: can: can_stm32_bxcan: remove redundant ret initialization

### DIFF
--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -721,7 +721,7 @@ static int can_stm32_recover(const struct device *dev, k_timeout_t timeout)
 	const struct can_stm32_config *cfg = dev->config;
 	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
-	int ret = -EAGAIN;
+	int ret;
 	int64_t start_time;
 
 	if (!data->common.started) {


### PR DESCRIPTION
The local variable 'ret' is initialized to -EAGAIN but always overwritten before being read or return.

Drop the redundant initialization.

No functional change intended.