### PR TITLE
soc: nordic: common: nrf_sys_event: Fix missing return

### DIFF
--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+sample_counter: &timer20 {
+	status = "okay";
+};

--- a/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
+++ b/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import re
+
+from twister_harness import DeviceAdapter
+
+
+def test_rramc_wakeup(dut: DeviceAdapter):
+    """
+    PyTest code for samples/boards/nordic/nrf_sys_event, sample configurations:
+    - sample.boards.nordic.nrf_sys_event.rramc_wakeup,
+    - sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi.
+    Parse logs from serial port. If the Register Event API was used correctly,
+    code execution shall be faster by ~14 us when event was registered.
+    If the API works correctly, RRAMC is woken up just before event occures.
+    Thus, there is no delay resulting from RRAMC getting ready.
+    """
+
+    TIMEOUT = 5
+    MIN_DIFF = 10  # Minimal difference to pass the check
+
+    # Get output from serial port
+    output = "\n".join(
+        dut.readlines_until(
+            regex="All done",
+            print_output=True,
+            timeout=TIMEOUT,
+        )
+    )
+
+    # Get execution times
+    t_default_str = re.search(
+        r"Alarm set for 100 us, execution took:(.+) \(default RRAMC mode\)", output
+    ).group(1)
+    assert t_default_str is not None, "Timing for the default RRAMC mode was NOT found"
+    t_default = int(t_default_str)
+
+    t_standby_str = re.search(
+        r"Alarm set for 100 us, execution took:(.+) \(RRAMC Standby mode\)", output
+    ).group(1)
+    assert t_standby_str is not None, "Timing for RRAMC Standby mode was NOT found"
+    t_standby = int(t_standby_str)
+
+    t_ppi_str = re.search(
+        r"Alarm set for 100 us, execution took:(.+) \(RRAMC waken by PPI\)", output
+    ).group(1)
+    assert t_ppi_str is not None, "Timing for RRAMC Standby mode was NOT found"
+    t_ppi = int(t_ppi_str)
+
+    # Check if RRAMC standby mode results in faster code execution
+    assert t_default > t_standby + MIN_DIFF, (
+        f"{t_default} is NOT larger than {t_standby} + {MIN_DIFF}"
+    )
+    # Check if RRAMC waken by PPI results in faster code execution
+    assert t_default > t_ppi + MIN_DIFF, f"{t_default} is NOT larger than {t_ppi} + {MIN_DIFF}"

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -56,16 +56,7 @@ tests:
   sample.boards.nordic.nrf_sys_event.rramc_wakeup:
     extra_configs:
       - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
-      - CONFIG_NRF_SYS_EVENT_GRTC_CHAN_CNT=0
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-  sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi:
-    extra_configs:
-      - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
-    platform_allow:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54l15dk/nrf54l15/cpuflpr/xip
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -54,6 +54,10 @@ tests:
     extra_configs:
       - CONFIG_SOC_NRF_FORCE_CONSTLAT=y
   sample.boards.nordic.nrf_sys_event.rramc_wakeup:
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_reg_event.py::test_rramc_wakeup"
     extra_configs:
       - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
     platform_allow:

--- a/samples/boards/nordic/nrf_sys_event/src/main.c
+++ b/samples/boards/nordic/nrf_sys_event/src/main.c
@@ -137,6 +137,8 @@ int main(void)
 
 #ifdef CONFIG_NRF_SYS_EVENT_IRQ_LATENCY
 	sys_event_irq_latency();
+
+	printf("All done\n");
 #endif
 	return 0;
 }

--- a/samples/boards/nordic/nrf_sys_event/src/main.c
+++ b/samples/boards/nordic/nrf_sys_event/src/main.c
@@ -97,7 +97,9 @@ static void sys_event_irq_latency_run(enum rramc_mode mode)
 static void sys_event_irq_latency(void)
 {
 	sys_event_irq_latency_run(RRAMC_DEFAULT);
+#if !defined(CONFIG_SOC_NRF54LM20A)
 	sys_event_irq_latency_run(RRAMC_POWER_MODE);
+#endif
 	sys_event_irq_latency_run(RRAMC_PPI_WAKEUP);
 }
 #endif /* CONFIG_NRF_SYS_EVENT_IRQ_LATENCY */

--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -112,6 +112,12 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY_MANUAL) ||
 static uint32_t event_ref_cnt;
 static uint32_t chan_mask;
 
+/* Handle returned by the registering function can be a GRTC channel that was used which indicates
+ * that PPI RRAMC wake up is used. If manual mode is used (changing RRAMC power mode) than that
+ * handle value is used which exceeds any potential GRTC channel number.
+ */
+#define NRF_SYS_EVENT_MANUAL_HANDLE 32
+
 #define NVM_HW_WAKEUP_US 16
 #define NVM_MANUAL_SUPPORT IS_ENABLED(CONFIG_NRF_SYS_EVENT_IRQ_LATENCY_MANUAL)
 /* Due to software performance and risk of waking up too early (then RRAMC may go
@@ -154,7 +160,7 @@ union nrf_sys_evt_us {
 	uint64_t abs;
 };
 
-int event_register(union nrf_sys_evt_us us, bool force, bool abs)
+static int event_register(union nrf_sys_evt_us us, bool force, bool abs)
 {
 	int rv;
 
@@ -181,7 +187,7 @@ int event_register(union nrf_sys_evt_us us, bool force, bool abs)
 				irq_low_latency_on(true);
 			}
 			event_ref_cnt++;
-			rv = 32;
+			rv = NRF_SYS_EVENT_MANUAL_HANDLE;
 		}
 	}
 
@@ -203,11 +209,12 @@ int nrf_sys_event_unregister(int handle, bool cancel)
 	__ASSERT_NO_MSG(handle >= 0);
 	int rv = 0;
 
-	if (handle < 32) {
+	if (handle != NRF_SYS_EVENT_MANUAL_HANDLE) {
 		if (cancel) {
 			nrf_grtc_sys_counter_compare_event_disable(NRF_GRTC, handle);
 		}
 		atomic_or((atomic_t *)&chan_mask, BIT(handle));
+		return rv;
 	}
 
 	LOCKED() {

--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -166,13 +166,12 @@ static int event_register(union nrf_sys_evt_us us, bool force, bool abs)
 
 	LOCKED() {
 		if ((CONFIG_NRF_SYS_EVENT_GRTC_CHAN_CNT > 0) &&
-		    ((abs == false) && ((us.rel >= NVM_WAKEUP_US) || !NVM_MANUAL_SUPPORT)) &&
+		    ((abs == true) || ((us.rel >= NVM_WAKEUP_US) || !NVM_MANUAL_SUPPORT)) &&
 		    (chan_mask != 0)) {
 			rv = __builtin_ctz(chan_mask);
 			chan_mask &= ~BIT(rv);
 			if (abs) {
-				nrfy_grtc_sys_counter_cc_set(NRF_GRTC, rv,
-							us.abs - NVM_WAKEUP_US);
+				nrfy_grtc_sys_counter_cc_set(NRF_GRTC, rv, us.abs - NVM_WAKEUP_US);
 			} else {
 				uint32_t val = (NVM_MANUAL_SUPPORT || (us.rel >= NVM_WAKEUP_US)) ?
 					(us.rel - NVM_WAKEUP_US) : 1;


### PR DESCRIPTION
nrf_sys_event_unregister was missing an immediate return when PPI was used by the handle. It was stepping into non-PPI case where an assert might have been triggered.