### PR TITLE
drivers: clock_control: litex: make litex_clk_dts_clkouts_read void

### DIFF
--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1637,7 +1637,7 @@ static int litex_clk_dts_timeout_read(struct litex_clk_timeout *timeout)
 	return 0;
 }
 
-static int litex_clk_dts_clkouts_read(void)
+static void litex_clk_dts_clkouts_read(void)
 {
 	struct litex_clk_range clkout_div;
 	struct litex_clk_clkout *lcko;
@@ -1665,7 +1665,6 @@ static int litex_clk_dts_clkouts_read(void)
 #if CLKOUT_EXIST(6) == 1
 		CLKOUT_INIT(6)
 #endif
-	return 0;
 }
 
 static void litex_clk_init_clkouts(void)
@@ -1756,10 +1755,7 @@ static int litex_clk_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = litex_clk_dts_clkouts_read();
-	if (ret != 0) {
-		return ret;
-	}
+	litex_clk_dts_clkouts_read();
 
 	litex_clk_init_clkouts();
 

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1248,7 +1248,7 @@ static int litex_clk_calc_clkout_params(struct litex_clk_clkout *lcko,
 					 uint64_t vco_freq)
 {
 	int delta_f;
-	uint64_t m, clk_freq = 0;
+	uint64_t m, clk_freq;
 	uint32_t d, margin = 1;
 
 	if (lcko->margin.exp) {
@@ -1311,13 +1311,13 @@ static int litex_clk_calc_all_clkout_params(uint64_t vco_freq)
 static int litex_clk_calc_all_params(void)
 {
 	uint32_t div, mul;
-	uint64_t vco_freq = 0;
+	uint64_t vco_freq;
 
 	for (div = ldev->divclk.min; div <= ldev->divclk.max; div++) {
 		ldev->ts_g_config.div = div;
 		for (mul = ldev->clkfbout.max; mul >= ldev->clkfbout.min;
 								 mul--) {
-			int below, above, all_valid = true;
+			int below, above, all_valid;
 
 			vco_freq = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * (uint64_t)mul;
 			vco_freq /= div;


### PR DESCRIPTION
litex_clk_dts_clkouts_read() never reports errors and always returns 0.

The error check at the call site is therefore dead code.

Make the function void and drop the unused error handling.