### PR TITLE
sensor: bmm150: fix init when no trigger is selected

### DIFF
--- a/drivers/sensor/bosch/bmm150/bmm150.c
+++ b/drivers/sensor/bosch/bmm150/bmm150.c
@@ -651,8 +651,8 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 		else {
 			ret = bmm150_trigger_mode_power_ctrl(dev, true);
 		}
-		break;
 #endif
+		break;
 #ifdef CONFIG_PM_DEVICE
 	case PM_DEVICE_ACTION_SUSPEND:
 		ret = bmm150_power_control(dev, 0); /* Suspend */


### PR DESCRIPTION
When no trigger was chosen case statement fell through to default which causes the return code to -ENOTSUPP