### PR TITLE
fs: nvs: prevent ATE writes at sector boundary

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -1176,7 +1176,13 @@ no_cached_entry:
 			goto end;
 		}
 
-		if (fs->ate_wra >= (fs->data_wra + required_space)) {
+		/* ATEs grow backwards within a sector. In delete-only scenarios,
+		 * a sector may contain only delete ATEs and no data entries.
+		 * Prevent ATE writes at current start of sector to avoid crossing
+		 * into the previous sector.
+		 */
+		if (fs->ate_wra >= (fs->data_wra + required_space) &&
+		    (fs->ate_wra & ADDR_OFFS_MASK) != 0) {
 
 			rc = nvs_flash_wrt_entry(fs, id, data, len);
 			if (rc) {


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/102556

In NVS, allocation table entries (ATEs) are written backwards within each sector. Under delete-only or delete-heavy workloads, a sector may contain only delete ATEs, causing the ATE write pointer to approach the sector boundary.

Without an explicit boundary check, ATE writes may occur at offset 0 of the current sector, allowing the write pointer to underflow into the previous sector and corrupt unrelated data or metadata.

Fix this by disallowing ATE writes when the write pointer is at the sector boundary. This ensures that ATE writes remain confined to the current sector and prevents pointer underflow across sectors.