### PR TITLE
nxp-fix-lpuart-dma-race-condition-issue

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -842,10 +842,16 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 						     config->rx_dma_config.dma_channel,
 						     &status);
 
-	if (get_status_result < 0 || status.busy) {
-		LOG_ERR("Unable to start receive on UART.");
+	if (get_status_result < 0) {
 		irq_unlock(key);
-		return get_status_result < 0 ? get_status_result : -EBUSY;
+		LOG_ERR("Failed to get DMA(Rx) status (%d)", get_status_result);
+		return get_status_result;
+	}
+
+	if (status.busy) {
+		irq_unlock(key);
+		LOG_DBG("UART RX busy (DMA ch %u)", config->rx_dma_config.dma_channel);
+		return -EBUSY;
 	}
 
 	rx_dma_params->timeout_us = timeout_us;

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -468,19 +468,37 @@ static void async_evt_rx_rdy(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = dev->data;
 	struct mcux_lpuart_rx_dma_params *dma_params = &data->async.rx_dma_params;
+	unsigned int key;
+	uint8_t *buf;
+	size_t counter;
+	size_t offset;
+	size_t len;
+
+	/*
+	 * Snapshot buf/counter/offset under irq_lock() (ISR + workqueue update rx_dma_params).
+	 * Locals ensure len = counter - offset uses a consistent view (prevents underflow).
+	 * Keep lock short: snapshot + offset update only; log/callback outside critical section.
+	 */
+	key = irq_lock();
+	buf = dma_params->buf;
+	counter = dma_params->counter;
+	offset = dma_params->offset;
+
+	len = counter - offset;
+
+	/* Update the current pos for new data */
+	dma_params->offset = counter;
+	irq_unlock(key);
 
 	struct uart_event event = {
 		.type = UART_RX_RDY,
-		.data.rx.buf = dma_params->buf,
-		.data.rx.len = dma_params->counter - dma_params->offset,
-		.data.rx.offset = dma_params->offset
+		.data.rx.buf = buf,
+		.data.rx.len = len,
+		.data.rx.offset = offset
 	};
 
-	LOG_DBG("RX Ready: (len: %d off: %d buf: %x)", event.data.rx.len, event.data.rx.offset,
-		(uint32_t)event.data.rx.buf);
-
-	/* Update the current pos for new data */
-	dma_params->offset = dma_params->counter;
+	LOG_DBG("RX Ready: (len: %zu off: %zu buf: %p)", event.data.rx.len,
+		event.data.rx.offset, event.data.rx.buf);
 
 	/* Only send event for new data */
 	if (event.data.rx.len > 0) {
@@ -500,16 +518,33 @@ static void async_evt_rx_buf_request(const struct device *dev)
 static void async_evt_rx_buf_release(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
+	unsigned int key;
+	uint8_t *released_buf;
+
+	/* Snapshot the buffer pointer atomically for the event payload. */
+	key = irq_lock();
+	released_buf = data->async.rx_dma_params.buf;
+	irq_unlock(key);
+
 	struct uart_event evt = {
 		.type = UART_RX_BUF_RELEASED,
-		.data.rx_buf.buf = data->async.rx_dma_params.buf,
+		.data.rx_buf.buf = released_buf,
 	};
 
 	async_user_callback(dev, &evt);
-	data->async.rx_dma_params.buf = NULL;
-	data->async.rx_dma_params.buf_len = 0U;
-	data->async.rx_dma_params.offset = 0U;
-	data->async.rx_dma_params.counter = 0U;
+
+	/*
+	 * Clear RX state, but avoid clobbering a new buffer if RX was restarted or
+	 * swapped concurrently.
+	 */
+	key = irq_lock();
+	if (data->async.rx_dma_params.buf == released_buf) {
+		data->async.rx_dma_params.buf = NULL;
+		data->async.rx_dma_params.buf_len = 0U;
+		data->async.rx_dma_params.offset = 0U;
+		data->async.rx_dma_params.counter = 0U;
+	}
+	irq_unlock(key);
 }
 
 static void mcux_lpuart_async_rx_flush(const struct device *dev)
@@ -523,11 +558,34 @@ static void mcux_lpuart_async_rx_flush(const struct device *dev)
 						     &status);
 
 	if (get_status_result == 0) {
-		const size_t rx_rcv_len = data->async.rx_dma_params.buf_len -
-					  status.pending_length;
+		size_t buf_len;
+		size_t counter;
+		size_t rx_rcv_len;
+		bool notify = false;
+		unsigned int key;
 
-		if (rx_rcv_len > data->async.rx_dma_params.counter && status.pending_length) {
-			data->async.rx_dma_params.counter = rx_rcv_len;
+		key = irq_lock();
+		buf_len = data->async.rx_dma_params.buf_len;
+		counter = data->async.rx_dma_params.counter;
+		irq_unlock(key);
+
+		if (buf_len >= status.pending_length) {
+			rx_rcv_len = buf_len - status.pending_length;
+
+			if (status.pending_length && rx_rcv_len > counter) {
+				key = irq_lock();
+				if (rx_rcv_len > data->async.rx_dma_params.counter) {
+					data->async.rx_dma_params.counter = rx_rcv_len;
+					notify = true;
+				}
+				irq_unlock(key);
+			}
+		} else {
+			LOG_WRN("RX DMA status pending_length > buf_len (%u > %zu)",
+				status.pending_length, buf_len);
+		}
+
+		if (notify) {
 			async_evt_rx_rdy(dev);
 		}
 		LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag);
@@ -857,6 +915,8 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 	rx_dma_params->timeout_us = timeout_us;
 	rx_dma_params->buf = buf;
 	rx_dma_params->buf_len = len;
+	rx_dma_params->offset = 0U;
+	rx_dma_params->counter = 0U;
 	data->async.next_rx_buffer = NULL;
 	data->async.next_rx_buffer_len = 0U;
 


### PR DESCRIPTION
This resolve https://github.com/zephyrproject-rtos/zephyr/issues/102001

## Overview

This PR fixes a critical race condition in the LPUART async driver that causes system crashes due to RX buffer length underflow, and improves error diagnostics in the RX enable path.

## Problem

### Race Condition (Patch 2/2)
A race condition exists between the system work queue executing `mcux_lpuart_async_rx_timeout()` and the DMA ISR executing `dma_callback()`. Both contexts access and modify `data->async.rx_dma_params` without synchronization.

**Crash symptom:**
```
[00:12:11.098,000] <dbg> uart_mcux_lpuart: RX Ready: (len: -68 off: 68 buf: 20200140)
```

When the ISR preempts during the length calculation `len = counter - offset`, it can update these values mid-calculation, resulting in integer underflow (0xFFFFFFBC for size_t), leading to system crash.

### Error Handling (Patch 1/2)
The original error handling in `mcux_lpuart_rx_enable()` combined two different error conditions with unclear messaging, making debugging difficult.

## Solution

### Patch 1: Improve rx_enable error reporting
- Split DMA status query failures from busy status checks
- Use appropriate log levels (LOG_ERR for failures, LOG_DBG for busy)
- Provide specific error messages for better diagnostics

### Patch 2: Fix race condition
- Add `irq_lock()`/`irq_unlock()` protection around all `rx_dma_params` accesses in:
  - `async_evt_rx_rdy()` - protect counter/offset calculation
  - `mcux_lpuart_async_rx_flush()` - protect counter updates
  - `async_evt_rx_buf_release()` - atomic buffer pointer snapshot
- Initialize `offset`/`counter` to 0 in `mcux_lpuart_rx_enable()` for clean state
- Add overflow check in `mcux_lpuart_async_rx_flush()`
- Fix log format specifiers (%d → %zu for size_t, %x → %p for pointers)


Here is the test uart_async_rx run result:
```
[17:07:00.384]*** Booting Zephyr OS build v4.3.0-3941-g2ac20b86f1cf ***
Running TESTSUITE uart_async_rx
===================================================================
START - test_rx
 PASS - test_rx in 0.001 seconds
===================================================================
START - test_rx_late_consume
 PASS - test_rx_late_consume in 0.001 seconds
===================================================================
START - test_rx_ztress_no_chunks

[17:07:01.432]0% remaining:4000 ms
[17:07:02.429]0% remaining:3000 ms
[17:07:03.428]0% remaining:2000 ms
[17:07:04.428]0% remaining:1000 ms
[17:07:05.428]0% remaining:0 ms
Ztress execution report:
	 context 0:
		 - executed:8042, preempted:0
		 - ticks initial:20, optimized:4
	 context 1:
		 - executed:8036, preempted:0
		 - ticks initial:20, optimized:4
	Average CPU load:12%, measurements:50
total bytes: 29055
 PASS - test_rx_ztress_no_chunks in 5.067 seconds
===================================================================
START - test_rx_ztress_with_chunks

[17:07:06.467]0% remaining:4000 ms
[17:07:07.462]0% remaining:3000 ms
[17:07:08.461]0% remaining:2000 ms
[17:07:09.457]0% remaining:1000 ms
[17:07:10.452]0% remaining:0 ms
Ztress execution report:
	 context 0:
		 - executed:8031, preempted:0
		 - ticks initial:20, optimized:4
	 context 1:
		 - executed:8031, preempted:0
		 - ticks initial:20, optimized:4
	Average CPU load:14%, measurements:50
total bytes: 26372
 PASS - test_rx_ztress_with_chunks in 5.052 seconds
===================================================================
TESTSUITE uart_async_rx succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [uart_async_rx]: pass = 4, fail = 0, skip = 0, total = 4 duration = 10.121 seconds
 - PASS - [uart_async_rx.test_rx] duration = 0.001 seconds
 - PASS - [uart_async_rx.test_rx_late_consume] duration = 0.001 seconds
 - PASS - [uart_async_rx.test_rx_ztress_no_chunks] duration = 5.067 seconds
 - PASS - [uart_async_rx.test_rx_ztress_with_chunks] duration = 5.052 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```