### PR TITLE
bluetooth: host: classic: add option to accept connection as central

### DIFF
--- a/samples/bluetooth/classic/a2dp_sink/src/main.c
+++ b/samples/bluetooth/classic/a2dp_sink/src/main.c
@@ -231,7 +231,7 @@ static void bt_ready(int err)
 	bt_a2dp_register_ep(&sbc_sink_ep, BT_AVDTP_AUDIO, BT_AVDTP_SINK);
 	bt_a2dp_register_cb(&a2dp_cb);
 
-	err = bt_br_set_connectable(true);
+	err = bt_br_set_connectable(true, NULL);
 	if (err != 0) {
 		printk("BR/EDR set/rest connectable failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/classic/handsfree/src/main.c
+++ b/samples/bluetooth/classic/handsfree/src/main.c
@@ -247,7 +247,7 @@ static void bt_ready(int err)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_br_set_connectable(true);
+	err = bt_br_set_connectable(true, NULL);
 	if (err) {
 		printk("BR/EDR set/rest connectable failed (err %d)\n", err);
 		return;

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -44,6 +44,14 @@ config BT_MAX_SCO_CONN
 	  Maximum number of simultaneous Bluetooth synchronous connections
 	  supported. The minimum (and default) number is 1.
 
+config BT_ACCEPT_CONN_AS_CENTRAL
+	bool "Accept a new incoming ACL connection request as central role"
+	help
+	  By default, the device will accept the ACL connection request as the peripheral role.
+	  If the option is enabled, the device will accept the ACL connection request as the
+	  central role. Normally, the HCI Role Change event will be generated after the HCI command
+	  Accept Connection Request is succeeded.
+
 config BT_L2CAP_RX_FLUSH_TO
 	hex "Minimum Bluetooth L2CAP RX flush Timeout accepted in milliseconds"
 	default 0x0001 if BT_A2DP_SINK

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -51,6 +51,8 @@ config BT_ACCEPT_CONN_AS_CENTRAL
 	  If the option is enabled, the device will accept the ACL connection request as the
 	  central role. Normally, the HCI Role Change event will be generated after the HCI command
 	  Accept Connection Request is succeeded.
+	  The kconfig option only works when calling function bt_br_set_discoverable to enable
+	  connectable mode with a NULL callback parameter.
 
 config BT_L2CAP_RX_FLUSH_TO
 	hex "Minimum Bluetooth L2CAP RX flush Timeout accepted in milliseconds"

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -35,6 +35,8 @@ static size_t discovery_results_size;
 static size_t discovery_results_count;
 static sys_slist_t discovery_cbs = SYS_SLIST_STATIC_INIT(&discovery_cbs);
 
+static bt_br_conn_req_func_t br_conn_req_func;
+
 static int reject_conn(const bt_addr_t *bdaddr, uint8_t reason)
 {
 	struct bt_hci_cp_reject_conn_req *cp;
@@ -58,40 +60,62 @@ static int reject_conn(const bt_addr_t *bdaddr, uint8_t reason)
 	return 0;
 }
 
-static int accept_conn(const bt_addr_t *bdaddr)
+static uint8_t accept_conn(const struct bt_hci_evt_conn_request *evt)
 {
 	struct bt_hci_cp_accept_conn_req *cp;
 	struct net_buf *buf;
+	uint32_t cod;
 	int err;
+	enum bt_br_conn_req_rsp rsp;
+	uint8_t role;
+
+	if (br_conn_req_func != NULL) {
+		cod = sys_get_le24(evt->dev_class);
+		rsp = br_conn_req_func(&evt->bdaddr, cod);
+
+		switch (rsp) {
+		case BT_BR_CONN_REQ_ACCEPT_CENTRAL:
+		case BT_BR_CONN_REQ_ACCEPT_PERIPHERAL:
+			role = (uint8_t)rsp;
+			break;
+		case BT_BR_CONN_REQ_REJECT_NO_RESOURCES:
+		case BT_BR_CONN_REQ_REJECT_SECURITY:
+		case BT_BR_CONN_REQ_REJECT_ADDR:
+			return (uint8_t)rsp;
+		default:
+			return BT_HCI_ERR_UNSPECIFIED;
+		}
+	} else {
+		role = IS_ENABLED(CONFIG_BT_ACCEPT_CONN_AS_CENTRAL) ?
+			BT_HCI_ROLE_CENTRAL : BT_HCI_ROLE_PERIPHERAL;
+	}
 
 	buf = bt_hci_cmd_alloc(K_FOREVER);
-	if (!buf) {
-		return -ENOBUFS;
+	if (buf == NULL) {
+		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	bt_addr_copy(&cp->bdaddr, bdaddr);
-	cp->role = IS_ENABLED(CONFIG_BT_ACCEPT_CONN_AS_CENTRAL) ? BT_HCI_ROLE_CENTRAL :
-			BT_HCI_ROLE_PERIPHERAL;
+	bt_addr_copy(&cp->bdaddr, &evt->bdaddr);
+	cp->role = role;
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_ACCEPT_CONN_REQ, buf, NULL);
-	if (err) {
-		return err;
+	if (err != 0) {
+		return BT_HCI_ERR_UNSPECIFIED;
 	}
 
-	return 0;
+	return BT_HCI_ERR_SUCCESS;
 }
 
 void bt_hci_conn_req(struct net_buf *buf)
 {
 	struct bt_hci_evt_conn_request *evt = (void *)buf->data;
 	struct bt_conn *conn;
+	uint8_t err;
 
 	LOG_DBG("conn req from %s, type 0x%02x", bt_addr_str(&evt->bdaddr), evt->link_type);
 
 	if (evt->link_type != BT_HCI_ACL) {
-		uint8_t err;
-
 		err = bt_esco_conn_req(evt);
 		if (err != BT_HCI_ERR_SUCCESS) {
 			reject_conn(&evt->bdaddr, err);
@@ -105,7 +129,13 @@ void bt_hci_conn_req(struct net_buf *buf)
 		return;
 	}
 
-	accept_conn(&evt->bdaddr);
+	err = accept_conn(evt);
+	if (err != BT_HCI_ERR_SUCCESS) {
+		LOG_ERR("Failed to accept conn from %s (err %u)", bt_addr_str(&evt->bdaddr), err);
+		reject_conn(&evt->bdaddr, err);
+		bt_conn_unref(conn);
+		return;
+	}
 
 	/* The role is peripheral by default. If CONFIG_BT_ACCEPT_CONN_AS_CENTRAL is enabled,
 	 * the role will be updated by the role change event if the role switch is accepted by
@@ -1144,21 +1174,22 @@ static int write_scan_enable(uint8_t scan)
 	return 0;
 }
 
-int bt_br_set_connectable(bool enable)
+int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func)
 {
 	if (enable) {
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
 			return -EALREADY;
-		} else {
-			return write_scan_enable(BT_BREDR_SCAN_PAGE);
 		}
-	} else {
-		if (!atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
-			return -EALREADY;
-		} else {
-			return write_scan_enable(BT_BREDR_SCAN_DISABLED);
-		}
+
+		br_conn_req_func = func;
+		return write_scan_enable(BT_BREDR_SCAN_PAGE);
 	}
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
+		return -EALREADY;
+	}
+
+	return write_scan_enable(BT_BREDR_SCAN_DISABLED);
 }
 
 #define BT_LIAC 0x9e8b00

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -800,9 +800,9 @@ static int cmd_connectable(const struct shell *sh, size_t argc, char *argv[])
 	action = argv[1];
 
 	if (!strcmp(action, "on")) {
-		err = bt_br_set_connectable(true);
+		err = bt_br_set_connectable(true, NULL);
 	} else if (!strcmp(action, "off")) {
-		err = bt_br_set_connectable(false);
+		err = bt_br_set_connectable(false, NULL);
 	} else {
 		shell_help(sh);
 		return SHELL_CMD_HELP_PRINTED;

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -71,6 +71,19 @@ tests:
     platform_exclude: nrf52dk/nrf52810
     tags: bluetooth
     harness: keyboard
+  bluetooth.shell.shell_br.accept_conn_as_central:
+    extra_configs:
+      - CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+      - CONFIG_BT_ACCEPT_CONN_AS_CENTRAL=y
+    extra_args: CONF_FILE="prj_br.conf"
+    platform_allow:
+      - qemu_cortex_m3
+      - qemu_x86
+      - native_sim
+      - native_sim/native/64
+    platform_exclude: nrf52dk/nrf52810
+    tags: bluetooth
+    harness: keyboard
   bluetooth.shell.no_privacy:
     build_only: true
     extra_args: CONFIG_BT_PRIVACY=n

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -571,7 +571,7 @@ static uint8_t set_connectable(const void *cmd, uint16_t cmd_len,
 	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 		int err;
 
-		err = bt_br_set_connectable(cp->connectable ? true : false);
+		err = bt_br_set_connectable(cp->connectable ? true : false, NULL);
 		if ((err < 0) && (err != -EALREADY)) {
 			return BTP_STATUS_FAILED;
 		}
@@ -721,7 +721,7 @@ static uint8_t set_discoverable(const void *cmd, uint16_t cmd_len,
 		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 			int err;
 
-			err = bt_br_set_connectable(true);
+			err = bt_br_set_connectable(true, NULL);
 			if (err == -EALREADY) {
 				err = bt_br_set_discoverable(false, false);
 				if ((err < 0) && (err != -EALREADY)) {
@@ -746,7 +746,7 @@ static uint8_t set_discoverable(const void *cmd, uint16_t cmd_len,
 		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 			int err;
 
-			err = bt_br_set_connectable(true);
+			err = bt_br_set_connectable(true, NULL);
 			if (err == -EALREADY) {
 				err = bt_br_set_discoverable(false, false);
 				if ((err < 0) && (err != -EALREADY)) {


### PR DESCRIPTION
#### bluetooth: host: classic: add option to accept connection as central

Add a new Kconfig option BT_ACCEPT_CONN_AS_CENTRAL to allow accepting incoming ACL connection requests as the central role instead of the default peripheral role.

When enabled, the accept_conn() function sets the role to central in the HCI accept connection request command when handling the connection request event.

The actual role will be updated in Role Change event.

#### tests: bluetooth: shell: add test for accept_conn_as_central

Add a new test case for the Bluetooth shell to verify the BT_ACCEPT_CONN_AS_CENTRAL configuration option.

The test uses the BR/EDR configuration and enables the option to accept incoming ACL connections as central role.

#### bluetooth: classic: add callback for incoming connection requests

Add a callback mechanism to allow applications to handle incoming BR/EDR connection requests and decide whether to accept or reject them, as well as specify the desired role (central/peripheral).

Update bt_br_set_connectable() to accept an optional callback function parameter. When provided, callback is invoked on incoming connection requests, allowing the application to inspect the remote device address and Class of Device before accepting or rejecting the connection.

If no callback is provided, the connection request is accepted internally with the default behavior based on the `CONFIG_BT_ACCEPT_CONN_AS_CENTRAL` configuration option.

The accept_conn() function is updated to:
- Call the registered callback if available
- Pass the remote device address and Class of Device to the callback
- Allow the callback to specify the desired role via output parameter
- Reject the connection if the callback returns an error
- Add error handling and logging for failed connection acceptance

Update all existing callers of bt_br_set_connectable() to pass NULL for the callback parameter to maintain backward compatibility.

#### bluetooth: shell: add commands to test connection request callback

Add shell commands to test the BR/EDR connection request callback functionality introduced in the previous commit.

Add a `br_conn_req_cb()` callback function that demonstrates how applications can handle incoming connection requests. The callback supports:
- Accepting connections with a specified role (central/peripheral)
- Rejecting connections when auto-reject is enabled

Update the `pscan` (connectable) command to accept an optional "central/peripheral" parameter. When provided, the connection request callback is registered and configured to accept incoming connections as the central/peripheral role. Without the parameter, the default behavior is used.

Add `auto_reject_conn` shell command to enable/disable automatic rejection of incoming connection requests for testing purposes. This setting only takes effect if the `connectable` command has the optional parameter `central/peripheral` set.
