### PR TITLE
boards: nxp: fix typos in comments

### DIFF
--- a/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
@@ -109,7 +109,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
@@ -109,7 +109,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
@@ -112,7 +112,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -238,7 +238,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -352,7 +352,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
@@ -111,7 +111,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -237,7 +237,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -351,7 +351,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
@@ -111,7 +111,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -241,7 +241,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
@@ -111,7 +111,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -237,7 +237,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -351,7 +351,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -353,7 +353,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
@@ -112,7 +112,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -238,7 +238,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -352,7 +352,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -353,7 +353,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -353,7 +353,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -237,7 +237,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -351,7 +351,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
@@ -112,7 +112,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -242,7 +242,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -358,7 +358,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
@@ -112,7 +112,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -242,7 +242,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -358,7 +358,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
@@ -190,7 +190,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;

--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
@@ -88,7 +88,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 	/* Bit for DLLCR settings under all modes */
 	FLEXSPI_MISC_OFFSET_USE_VALID_TIME_FOR_ALL_FREQ = 7,

--- a/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
@@ -95,7 +95,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -201,7 +201,7 @@ typedef struct flexspi_config {
 	 * 1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* !< [0x046-0x046] Serial Flash Frequencey,
+	/* !< [0x046-0x046] Serial Flash Frequency,
 	 * device specific definitions,
 	 * See System Boot Chapter for more details
 	 */
@@ -275,7 +275,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* !< Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* !< Need to Restore NoCmd mode after IP commmand execution */
+	/* !< Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* !< Block size */
 	uint32_t block_size;

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
@@ -96,7 +96,7 @@ enum {
 	FC_XSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* !< Bit for Safe Configuration Frequency enable */
 	FC_XSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
-	/* !< Bit for DDR clock confiuration indication. */
+	/* !< Bit for DDR clock configuration indication. */
 	FC_XSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -194,7 +194,7 @@ typedef struct xspi_config {
 	 *1 - Single, 2 - Dual, 4 - Quad, 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* !< [0x046-0x046] Serial Flash Frequencey
+	/* !< [0x046-0x046] Serial Flash Frequency
 	 * 1: 30 mhz
 	 * 2: 50 mhz
 	 * 3: 60 mhz
@@ -295,7 +295,7 @@ typedef struct _fc_xspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* !< Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* !< Need to Restore NoCmd mode after IP commmand execution */
+	/* !< Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* !< Block size */
 	uint32_t block_size;

--- a/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;


### PR DESCRIPTION
Fix spelling and wording issues in comments across NXP board FlexSPI NOR configuration headers.

No functional change.