### PR TITLE
net: sockets: tls: Enforce minimum TLS version 

### DIFF
--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -153,6 +153,9 @@ A secure socket can be created by specifying secure protocol type, for instance:
 
    sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
 
+The protocol version specified when creating the secure socket indicates the
+minimum TLS version used for the TLS session.
+
 Once created, it can be configured with socket options. For instance, the
 CA certificate and hostname can be set:
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -656,6 +656,9 @@ Networking
   handle this status in the handler callback to properly reset resource state after successful
   response transmission.
 
+* The protocol version passed to :c:func:`zsock_socket` when creating a secure socket is now
+  enforced as the minimum TLS version to use for the TLS session.
+
 Modem
 *****
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1321,6 +1321,24 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
 	}
 	tls_set_max_frag_len(&context->config, context->type);
 
+	switch (context->tls_version) {
+	case NET_IPPROTO_TLS_1_3:
+		mbedtls_ssl_conf_min_tls_version(&context->config, MBEDTLS_SSL_VERSION_TLS1_3);
+		break;
+	case NET_IPPROTO_TLS_1_2:
+	case NET_IPPROTO_DTLS_1_2:
+		mbedtls_ssl_conf_min_tls_version(&context->config, MBEDTLS_SSL_VERSION_TLS1_2);
+		break;
+	case NET_IPPROTO_TLS_1_0:
+	case NET_IPPROTO_TLS_1_1:
+	case NET_IPPROTO_DTLS_1_0:
+		/* Nothing to do */
+		break;
+	default:
+		NET_ASSERT(false, "Unknown (D)TLS version, cannot specify minimum requirement");
+		break;
+	}
+
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 	mbedtls_ssl_conf_legacy_renegotiation(&context->config,
 					   MBEDTLS_SSL_LEGACY_BREAK_HANDSHAKE);


### PR DESCRIPTION
Enforce the minimum TLS version on mbed TLS, based on the protocol
version provided by the application when creating socket. This ensures
that when application creates a TLS 1.3 socket, mbed TLS won't downgrade
the session to TLS 1.2 for instance.