### PR TITLE
ipc: intel_adsp: fix inverted sync wait condition

### DIFF
--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -98,7 +98,7 @@ int intel_adsp_ipc_send_message_sync(const struct device *dev, uint32_t data, ui
 
 	int ret = ipc_service_send(&intel_adsp_ipc_ept, &msg, sizeof(msg));
 
-	if (ret < 0) {
+	if (ret == 0) {
 		k_sem_take(&devdata->sem, timeout);
 	}
 

--- a/tests/boards/intel_adsp/smoke/src/clock.c
+++ b/tests/boards/intel_adsp/smoke/src/clock.c
@@ -41,6 +41,7 @@ void clock_ipc_receive_cb(const void *data, size_t len, void *priv)
 
 	/* Store returned timestamp from the extended payload word. */
 	tpd->priv = (void *)(uintptr_t)msg[1];
+	tpd->msg_done = true;
 }
 
 struct ipc_ept_cfg clock_ipc_ept_cfg = {

--- a/tests/boards/intel_adsp/smoke/src/clock.c
+++ b/tests/boards/intel_adsp/smoke/src/clock.c
@@ -63,6 +63,8 @@ ZTEST(intel_adsp, test_clock_calibrate)
 
 #ifdef CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE
 	host_dt = &old_host_dt;
+	/* Set handler early so all messages get ACK'd, even if we don't care about the response */
+	intel_adsp_ipc_set_message_handler(INTEL_ADSP_IPC_HOST_DEV, clock_msg, (void *)host_dt);
 #else
 	int ret;
 
@@ -79,9 +81,6 @@ ZTEST(intel_adsp, test_clock_calibrate)
 
 	k_msleep(1000);
 	*host_dt = 0;
-#ifdef CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE
-	intel_adsp_ipc_set_message_handler(INTEL_ADSP_IPC_HOST_DEV, clock_msg, (void *)host_dt);
-#endif /* CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE */
 
 	/* Now do it again, but with a handler to catch the result */
 	cyc1 = k_cycle_get_32();

--- a/tests/boards/intel_adsp/smoke/src/hostipc.c
+++ b/tests/boards/intel_adsp/smoke/src/hostipc.c
@@ -49,8 +49,6 @@ void ipc_receive_cb(const void *data, size_t len, void *priv)
 
 	const uint32_t *msg = (const uint32_t *)data;
 
-	ARG_UNUSED(priv_data);
-
 	zassert_equal(len, sizeof(uint32_t) * 2, "unexpected IPC message length");
 	zassert_not_null(data, "IPC payload pointer is NULL");
 
@@ -58,6 +56,7 @@ void ipc_receive_cb(const void *data, size_t len, void *priv)
 	zassert_true(msg[0] == RETURN_MSG_SYNC_VAL ||
 		     msg[0] == RETURN_MSG_ASYNC_VAL, "unexpected msg data");
 	msg_flag = true;
+	priv_data->msg_done = true;
 }
 
 static struct intel_adsp_ipc_ept_priv_data host_ipc_priv_data;


### PR DESCRIPTION
The synchronous send helper intel_adsp_ipc_send_message_sync() had inverted logic for determining when to wait for host acknowledgment.

Before this fix, the function would:
- Return immediately (without waiting) when send succeeded (ret == 0)
- Try to wait on semaphore when send failed (ret < 0)

This is backwards. The correct behavior is to wait for the host ACK semaphore only when the message was successfully queued for transmission.

The inverted logic caused multiple test failures:
- HDA tests received -EBUSY on subsequent sends because tx_ack_pending remained true when no wait occurred
- Smoke IPC tests timed out waiting for msg_flag/done_flag because messages were sent without waiting for host responses
- Clock calibration tests failed because timestamp responses were never received

This aligns the SoC glue implementation with the test-local helper implementations and restores the original pre-refactoring behavior.

Related to: #102103
Related to: #102106