### PR TITLE
serial: uart_native_pty: send UART_RX_DISABLED event

### DIFF
--- a/drivers/serial/uart_native_pty.c
+++ b/drivers/serial/uart_native_pty.c
@@ -402,6 +402,11 @@ static void native_pty_uart_async_poll_function(void *arg1, void *arg2, void *ar
 			k_sleep(K_MSEC(10));
 		}
 	}
+
+	if (data->async.user_callback) {
+		evt.type = UART_RX_DISABLED;
+		data->async.user_callback(data->async.dev, &evt, data->async.user_data);
+	}
 }
 
 static int np_uart_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)


### PR DESCRIPTION
When uart_rx_disable is called, or rx gets otherwise disabled, `UART_RX_DISABLED` event should be emitted.

See the documentation at https://docs.zephyrproject.org/latest/doxygen/html/group__uart__async.html#gafd4753bee51b230091a3c6ddb26ea734

> [UART_RX_BUF_RELEASED](https://docs.zephyrproject.org/latest/doxygen/html/group__uart__async.html#ggaf0c9513cbafa36d86b4c83f2b6a03dcdab2d152bd84f659d4fc4060df29811b48) event will be generated for every buffer scheduled, after that [UART_RX_DISABLED](https://docs.zephyrproject.org/latest/doxygen/html/group__uart__async.html#ggaf0c9513cbafa36d86b4c83f2b6a03dcdaa8ff5629c002a61bc3bdf5baa2ebc203) event will be generated. Additionally, if there is any pending received data, the [UART_RX_RDY](https://docs.zephyrproject.org/latest/doxygen/html/group__uart__async.html#ggaf0c9513cbafa36d86b4c83f2b6a03dcda7c70c3a56f64602f3d808b46e7b047f7) event for that data will be generated before the [UART_RX_BUF_RELEASED](https://docs.zephyrproject.org/latest/doxygen/html/group__uart__async.html#ggaf0c9513cbafa36d86b4c83f2b6a03dcdab2d152bd84f659d4fc4060df29811b48) events.

This PR adds just `UART_RX_DISABLED`  event, not considering `UART_RX_BUF_RELEASED` events as the driver is not implementing `UART_RX_BUF_REQUEST` events either.