### PR TITLE
drivers: sensor: stm32_temp: cleanup & improvements

### DIFF
--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -18,7 +18,7 @@
 
 LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 
-#define CAL_RES			12
+#define CAL_RES			12U
 #define MAX_CALIB_POINTS	2
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
@@ -275,7 +275,7 @@ static int stm32_temp_init(const struct device *dev)
 		.channels = BIT(data->adc_cfg.channel_id),
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
-		.resolution = 12U,
+		.resolution = CAL_RES,
 	};
 
 	return 0;


### PR DESCRIPTION
Cleanup various things inside the STM32 Dietemp sensor driver:
* use a macro consistently instead of the raw value sometimes
* move constant fields to instance configuration
* use a union to hold calibration data to make code easier to understand
* read calibration data once during driver init (instead of during each sensor value computation)
  * The calibration data is device-unique but fixed for a given device - it's fine to read it only once

```
$ git log --oneline HEAD~1..HEAD
00dfe39149d (HEAD -> upstream/main, upstream/HEAD) dts: fix nxp mcxn94x opamp1 reg value
$ west build samples/sensor/die_temp_polling/ -b nucleo_c071rb -p
...
[153/153] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       32092 B       128 KB     24.48%
             RAM:        4416 B        24 KB     17.97%
           SRAM0:          0 GB        24 KB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
```
```
$ git log upstream/main..HEAD --oneline
601d5897b2f (HEAD) drivers: sensor: stm32_temp: read calibration data once during init
74615034d65 drivers: sensor: stm32_temp: use union as calibration info type
b72586e6e90 drivers: sensor: stm32_temp: move constants to instance configuration
b1a518b271f drivers: sensor: stm32_temp: use CAL_RES everywhere
00dfe39149d (upstream/main, upstream/HEAD) dts: fix nxp mcxn94x opamp1 reg value
$ west build samples/sensor/die_temp_polling/ -b nucleo_c071rb -p
...
[153/153] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       32048 B       128 KB     24.45%
             RAM:        4408 B        24 KB     17.94%
           SRAM0:          0 GB        24 KB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
```