### PR TITLE
hal_nxp: integrate mcuxsdk ble controller ng

### DIFF
--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -1,7 +1,7 @@
 # MCUXpresso SDK
 
 # Copyright (c) 2016, Freescale Semiconductor, Inc.
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config HAS_MCUX
@@ -85,6 +85,12 @@ config NXP_MULTICORE
 	bool "NXP Multicore Manager support"
 	help
 	  Includes NXP Multicore Manager support.
+
+config NXP_SNPS_BLE_CTRL
+	bool "Include NXP SNPS BLE Controller"
+	depends on BT
+	help
+	  If enabled, the NXP SNPS BLE Controller will be included.
 
 endif # HAS_MCUX
 

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bluetooth_controller.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bluetooth_controller.cmake
@@ -1,0 +1,31 @@
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_NXP_SNPS_BLE_CTRL)
+    set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll ON)
+    set(CONFIG_MCUX_COMPONENT_middleware.wireless.snps_ll_os ON)
+
+    if(CONFIG_SOC_SERIES_MCXW2XX)
+        set(BLE_LIBS_PATH ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/mcxw23)
+    endif()
+
+    set(BLELIBOS_PATH       ${BLE_LIBS_PATH}/libble_ll_os.a)
+    set(BLELIBUTILS_PATH    ${BLE_LIBS_PATH}/libble_ll_utils_os.a)
+
+    zephyr_compile_definitions(
+        gUseHciTransportDownward_d=1
+        OSA_USED
+    )
+
+    zephyr_blobs_verify(FILES
+        ${BLELIBOS_PATH}
+        ${BLELIBUTILS_PATH}
+    )
+    zephyr_library_import(ble_lib_os ${BLELIBOS_PATH})
+    zephyr_library_import(ble_lib_utils ${BLELIBUTILS_PATH})
+
+    add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/mcuxsdk-middleware-bluetooth-controller
+        ${CMAKE_CURRENT_BINARY_DIR}/mcuxsdk-middleware-bluetooth-controller
+    )
+endif()

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -57,4 +57,5 @@ add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/usb
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/connectivity_framework.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/bluetooth_controller.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/multicore.cmake)

--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig
@@ -1,6 +1,7 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MCXW2XX
 	select HAS_POWEROFF
+	select NXP_SNPS_BLE_CTRL if BT

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: af5d95d3e6be13f1b993d2c466595e7cc71ba57b
+      revision: 796e242aabb37f50de0d90c44249e36d8de4268d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Move the ble controller middleware to the new mcux-sdk-ng integration from hal_nxp, instead of using the legacy integration method. This will allow for easier integration of future releases.