### PR TITLE
linker: Added linker generator support for section k_timer_observer

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -272,3 +272,7 @@ endif()
 if(CONFIG_GNSS_RTK)
   zephyr_iterable_section(NAME gnss_rtk_data_callback KVMA RAM_REGION GROUP RODATA_REGION)
 endif()
+
+if(CONFIG_TIMER_OBSERVER)
+  zephyr_iterable_section(NAME k_timer_observer KVMA RAM_REGION GROUP RODATA_REGION)
+endif()


### PR DESCRIPTION
Added missing section k_timer_observer to linker file generator, to fix missing section definitions for IAR linker.