### PR TITLE
docs: api_lifecycle: remove deprecated api after one release

### DIFF
--- a/doc/develop/api/api_lifecycle.rst
+++ b/doc/develop/api/api_lifecycle.rst
@@ -218,9 +218,9 @@ Deprecated
 The following are the requirements for deprecating an existing API:
 
 - Deprecation Time (stable APIs): 2 Releases
-  The API needs to be marked as deprecated in at least two full releases.
-  For example, if an API was first deprecated in release 4.0,
-  it will be ready to be removed in 4.2 at the earliest.
+  The API needs to be marked as deprecated in at least one full release.
+  For example, if an API was first deprecated in release 4.4,
+  it will be ready to be removed in 4.5 at the earliest.
   There may be special circumstances, determined by the Architecture working group,
   where an API is deprecated sooner.
 - What is required when deprecating:


### PR DESCRIPTION
Hey, would it make sense to update the deprecation timeline to maintain the same timing now that we release more often? Keeping every old api for 1y+ seems like a lot.

--

Since we now release half as often, change the requirement for api deprecation to only wait for one release instead of two.