### PR TITLE
runners: openocd: migrate to standard --file/--file-type interface

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/board.cmake
+++ b/boards/aithinker/ai_m61_32s_kit/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl61x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/aithinker/ai_m62_12f_kit/board.cmake
+++ b/boards/aithinker/ai_m62_12f_kit/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl61x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/aithinker/ai_wb2_12f_kit/board.cmake
+++ b/boards/aithinker/ai_wb2_12f_kit/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl60x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/bflb/bl60x/bl604e_iot_dvk/board.cmake
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl60x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -11,7 +11,7 @@ board_runner_args(openocd  --gdb-init "mon esp appimage_offset ${CONFIG_FLASH_LO
 board_runner_args(openocd  --gdb-init "mon reset halt")
 board_runner_args(openocd  --gdb-init "thb main")
 
-board_runner_args(openocd  --use-bin)
+board_runner_args(openocd  --file-type=bin)
 board_runner_args(openocd  "--flash-address=${CONFIG_FLASH_LOAD_OFFSET}")
 board_runner_args(openocd  --cmd-load "program_esp")
 board_runner_args(openocd  --cmd-verify "esp verify_bank_hash 0")

--- a/boards/digilent/arty_a7/board.cmake
+++ b/boards/digilent/arty_a7/board.cmake
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_ARTY_A7_DESIGNSTART_FPGA_CORTEX_M1)
-  board_runner_args(openocd "--use-elf" "--config=${BOARD_DIR}/support/openocd_arty_a7_arm_designstart_m1.cfg")
+  board_runner_args(openocd "--file-type=elf" "--config=${BOARD_DIR}/support/openocd_arty_a7_arm_designstart_m1.cfg")
   board_runner_args(jlink "--device=Cortex-M1" "--reset-after-load")
 elseif(CONFIG_BOARD_ARTY_A7_DESIGNSTART_FPGA_CORTEX_M3)
-  board_runner_args(openocd "--use-elf" "--config=${BOARD_DIR}/support/openocd_arty_a7_arm_designstart_m3.cfg")
+  board_runner_args(openocd "--file-type=elf" "--config=${BOARD_DIR}/support/openocd_arty_a7_arm_designstart_m3.cfg")
   board_runner_args(jlink "--device=Cortex-M3" "--reset-after-load")
 endif()
 

--- a/boards/digilent/zybo/board.cmake
+++ b/boards/digilent/zybo/board.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/doiting/dt_xt_zb1_devkit/board.cmake
+++ b/boards/doiting/dt_xt_zb1_devkit/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl70x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/openhwgroup/cv32a6_genesys_2/board.cmake
+++ b/boards/openhwgroup/cv32a6_genesys_2/board.cmake
@@ -1,7 +1,7 @@
 # Copyright 2024 CISPA Helmholtz Center for Information Security gGmbH
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(openocd "--config=${BOARD_DIR}/support/ariane.cfg")
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(openocd "--verify")
 board_runner_args(openocd "--cmd-pre-init=riscv.cpu configure -work-area-phys 0x90000000 -work-area-size 16780000")
 

--- a/boards/openhwgroup/cv64a6_genesys_2/board.cmake
+++ b/boards/openhwgroup/cv64a6_genesys_2/board.cmake
@@ -1,7 +1,7 @@
 # Copyright 2024 CISPA Helmholtz Center for Information Security gGmbH
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(openocd "--config=${BOARD_DIR}/support/ariane.cfg")
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(openocd "--verify")
 board_runner_args(openocd "--cmd-pre-init=riscv.cpu configure -work-area-phys 0x90000000 -work-area-size 16780000")
 

--- a/boards/others/neorv32/board.cmake
+++ b/boards/others/neorv32/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2021,2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
 if("${BOARD_QUALIFIERS}" STREQUAL "/neorv32")

--- a/boards/renesas/rcar_h3ulcb/board.cmake
+++ b/boards/renesas/rcar_h3ulcb/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_RCAR_H3ULCB_R8A77951_R7)
-  board_runner_args(openocd "--use-elf")
+  board_runner_args(openocd "--file-type=elf")
   include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 endif()

--- a/boards/renesas/rcar_salvator_x/board.cmake
+++ b/boards/renesas/rcar_salvator_x/board.cmake
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/renesas/rcar_spider_s4/board.cmake
+++ b/boards/renesas/rcar_spider_s4/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 if(CONFIG_BOARD_RCAR_SPIDER_S4_R8A779F0_R52)
-  board_runner_args(openocd "--use-elf")
+  board_runner_args(openocd "--file-type=elf")
   include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 endif()

--- a/boards/sc/scobc_a1/board.cmake
+++ b/boards/sc/scobc_a1/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--config=${BOARD_DIR}/support/scobc-a1.cfg")
+board_runner_args(openocd "--file-type=elf" "--config=${BOARD_DIR}/support/scobc-a1.cfg")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/sipeed/maix_m0s_dock/board.cmake
+++ b/boards/sipeed/maix_m0s_dock/board.cmake
@@ -4,7 +4,7 @@
 
 board_runner_args(openocd --cmd-pre-init "source [find bl61x.cfg]")
 
-board_runner_args(openocd --use-elf --no-load --no-init)
+board_runner_args(openocd --file-type=elf --no-load --no-init)
 board_runner_args(openocd --gdb-init "set mem inaccessible-by-default off")
 board_runner_args(openocd --gdb-init "set architecture riscv:rv32")
 board_runner_args(openocd --gdb-init "set remotetimeout 250")

--- a/boards/snps/em_starterkit/board.cmake
+++ b/boards/snps/em_starterkit/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2017 Synopsys
 
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(mdb-hw "--jtag=digilent")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/mdb-hw.board.cmake)

--- a/boards/snps/emsdp/board.cmake
+++ b/boards/snps/emsdp/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(mdb-hw "--jtag=digilent")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/mdb-hw.board.cmake)

--- a/boards/snps/hsdk/board.cmake
+++ b/boards/snps/hsdk/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 
 if(${CONFIG_MP_MAX_NUM_CPUS} EQUAL 2)
   board_runner_args(openocd "--config=${CMAKE_CURRENT_LIST_DIR}/support/openocd-2-cores.cfg")

--- a/boards/snps/hsdk4xd/board.cmake
+++ b/boards/snps/hsdk4xd/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(mdb-hw "--jtag=digilent" "--cores=${CONFIG_MP_MAX_NUM_CPUS}")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/mdb-hw.board.cmake)

--- a/boards/snps/iotdk/board.cmake
+++ b/boards/snps/iotdk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf")
+board_runner_args(openocd "--file-type=elf")
 board_runner_args(mdb-hw "--jtag=digilent")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/mdb-hw.board.cmake)

--- a/boards/wch/ch32v003evt/board.cmake
+++ b/boards/wch/ch32v003evt/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(minichlink)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/ch32v003f4p6_dev_board/board.cmake
+++ b/boards/wch/ch32v003f4p6_dev_board/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(minichlink)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/ch32v006evt/board.cmake
+++ b/boards/wch/ch32v006evt/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(minichlink)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/ch32v303vct6_evt/board.cmake
+++ b/boards/wch/ch32v303vct6_evt/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(minichlink "--dt-flash=y")
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/linkw/board.cmake
+++ b/boards/wch/linkw/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
 board_runner_args(minichlink)

--- a/boards/weact/bluepillplus_ch32v203/board.cmake
+++ b/boards/weact/bluepillplus_ch32v203/board.cmake
@@ -4,5 +4,5 @@
 board_runner_args(minichlink)
 include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
 
-board_runner_args(openocd "--use-elf" "--cmd-reset-halt" "halt")
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -36,6 +36,25 @@ Kernel
 Boards
 ******
 
+* The OpenOCD runner now uses the standard ``--file`` and ``--file-type`` interface for specifying
+  flash files, aligning with other runners like JLink. The following changes apply:
+
+  * The ``--use-hex``, ``--use-elf``, and ``--use-bin`` flags are deprecated. Use ``--file-type``
+    instead:
+
+    * ``--use-elf`` → ``--file-type=elf``
+    * ``--use-bin`` → ``--file-type=bin``
+    * ``--use-hex`` → ``--file-type=hex`` (or omit, as hex is the default)
+
+  * The ``--file`` option is now supported to specify a custom file path, similar to the JLink
+    runner.
+
+  * Board cmake files using the deprecated flags will continue to work but will emit a deprecation
+    warning.
+
+  * The ``--file-type`` option can now be used without ``--file`` to select between build artifacts
+    (hex, elf, bin).
+
 * m5stack_fire: Removed unused pinctrl entries for UART2, and updated the UART1
   pin mapping from GPIO32/GPIO33 to GPIO16/GPIO17 to match the documented Grove
   PORT.C wiring.
@@ -613,6 +632,7 @@ Modem HL78XX
 
 Other subsystems
 ****************
+
 * The DAP subsystem initialization and configuration has changed. Please take a look at
   :zephyr:code-sample:`cmsis-dap` sample on how to initialize Zephyr DAP Link with USB backend.
 

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -700,8 +700,6 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--tool-opt')
         if args.file and not caps.file:
             _missing_cap(cls, '--file')
-        if args.file_type and not args.file:
-            raise ValueError("--file-type requires --file")
         if args.file_type and not caps.file:
             _missing_cap(cls, '--file-type')
         if args.rtt_address and not caps.rtt:


### PR DESCRIPTION
1. Migrate OpenOCD runner to use the framework's standard --file and --file-type interface
2. Deprecate the OpenOCD-specific --use-hex, --use-elf, --use-bin flags
3. Update all board.cmake files to use --file-type instead of deprecated flags
4. Allow --file-type to be used without --file for selecting build artifacts

References: #52262 #101994 #101888