### PR TITLE
maintainers: Add fundakol as twister collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5263,6 +5263,7 @@ Twister:
     - gchwier
     - LukaszMrugala
     - KamilxPaszkiet
+    - fundakol
   files:
     - scripts/twister
     - scripts/schemas/twister/


### PR DESCRIPTION
Lukasz Fundakowski is a python expert with an interest in testing frameworks and coding standards. He is a valuable reviewer with attention to details. He had a major impact on design and implementation of the pytest plugin for twister.