### PR TITLE
dts: arm: microchip: mec: Fix MEC1653B code sram base address

### DIFF
--- a/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
@@ -10,7 +10,7 @@
 
 / {
 	flash0: flash@b0000 {
-		reg = <0x000b0000 0x58000>;
+		reg = <0x000c0000 0x58000>;
 	};
 
 	sram0: memory@118000 {


### PR DESCRIPTION
Microchip MEC1653B has 416KB of SRAM. ARM ICCM SRAM is 356KB starting at 0xC0000. ARM DCCM SRAM is 64KB starting at 0x118000. Chip DTS file had incorrect ICCM starting address.