### PR TITLE
drivers: clock_control: tisci: drop redundant curr_state check

### DIFF
--- a/drivers/clock_control/clock_control_tisci.c
+++ b/drivers/clock_control/clock_control_tisci.c
@@ -67,7 +67,7 @@ static enum clock_control_status tisci_get_status(const struct device *dev,
 	if (curr_state) {
 		return CLOCK_CONTROL_STATUS_ON;
 	}
-	if (req_state && !curr_state) {
+	if (req_state) {
 		return CLOCK_CONTROL_STATUS_STARTING;
 	}
 


### PR DESCRIPTION
curr_state is known to be false when reaching the STARTING state check, making the explicit '!curr_state' condition redundant.