### PR TITLE
drivers: uart: bcm2711: fix poll_in

### DIFF
--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -154,7 +154,10 @@ static int uart_bcm2711_poll_in(const struct device *dev, unsigned char *c)
 		;
 	}
 
-	return sys_read32(uart_data->uart_addr + BCM2711_MU_IO) & 0xFF;
+	/* got a character */
+	*c = sys_read32(uart_data->uart_addr + BCM2711_MU_IO) & 0xFF;
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
uart_bcm2711_poll_in() incorrectly returned the received byte instead of writing it to the provided buffer.

Update the implementation to store the character in `*c` and return 0 on success, matching the UART poll_in API.

<img width="720" height="457" alt="image" src="https://github.com/user-attachments/assets/8639d5a3-144e-4a24-bc4a-ad5337fb7349" />

Reference: https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf