### PR TITLE
drivers: serial: uart_cc13xx_cc26xx: make irq_tx_ready check interrupt

### DIFF
--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -282,8 +282,9 @@ static void uart_cc13xx_cc26xx_irq_tx_disable(const struct device *dev)
 static int uart_cc13xx_cc26xx_irq_tx_ready(const struct device *dev)
 {
 	const struct uart_cc13xx_cc26xx_config *config = dev->config;
+	uint32_t status = UARTIntStatus(config->reg, true);
 
-	return UARTSpaceAvail(config->reg) ? 1 : 0;
+	return (status & UART_INT_TX) ? 1 : 0;
 }
 
 static void uart_cc13xx_cc26xx_irq_rx_enable(const struct device *dev)


### PR DESCRIPTION
Make cc13xx_cc26xx_irq_tx_ready check that the TX Ready interrupt occurred, instead of checking whether there is some free space in the UART TX FIFO. This prevents a race condition from occurring in OpenThread Spinel protocol implementation, when a UART RX interrupt is received right after otPlatUartSend was called, between the assignement of 1 to ot_uart.tx_busy and the initialization of write_length.