### PR TITLE
pm: Fix wrong type promotion

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -214,7 +214,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 * is not passed as the next timeout.
 		 *
 		 */
-		sys_clock_set_timeout(MAX(0, ticks - exit_latency_ticks), true);
+		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
 	}
 
 	/*


### PR DESCRIPTION
In pm_system_suspend there is a possible invalid type promotion in sys_clock_set_timeout(MAX(0, ticks - exit_latency_ticks), true);

ticks is int32_t and exit_latency_ticks is uint32_t consequently ticks is promoted to uint32_t resulting in a possible underflow and setting a wrong value in sys_clock_set_timeout().

Fixes #100005
Coverity CID: 535628