### PR TITLE
Add SENSOR_TRIG_TIMER to sensor_stream_shell trigger selection.

### DIFF
--- a/drivers/sensor/sensor_shell_stream.c
+++ b/drivers/sensor/sensor_shell_stream.c
@@ -90,6 +90,8 @@ int cmd_sensor_stream(const struct shell *sh, size_t argc, char *argv[])
 		iodev_sensor_shell_trigger.trigger = SENSOR_TRIG_FIFO_FULL;
 	} else if (strcmp("tap", argv[3]) == 0) {
 		iodev_sensor_shell_trigger.trigger = SENSOR_TRIG_TAP;
+	} else if (strcmp("timer", argv[3]) == 0) {
+		iodev_sensor_shell_trigger.trigger = SENSOR_TRIG_TIMER;
 	} else {
 		shell_error(sh, "Invalid trigger (%s)", argv[3]);
 		return -EINVAL;


### PR DESCRIPTION
In sensor_shell_stream.c, cmd_sensor_stream() checks for valid trigger types, but it is missing SENSOR_TRIG_TIMER option.