### PR TITLE
test: arch: riscv: test essential thread abort

### DIFF
--- a/tests/arch/riscv/pmp/thread-abort/CMakeLists.txt
+++ b/tests/arch/riscv/pmp/thread-abort/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(riscv_pmp)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/arch/riscv/pmp/thread-abort/prj.conf
+++ b/tests/arch/riscv/pmp/thread-abort/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/arch/riscv/pmp/thread-abort/src/main.c
+++ b/tests/arch/riscv/pmp/thread-abort/src/main.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+static volatile bool valid_fault;
+
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
+static struct k_thread tdata;
+static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+{
+	TC_PRINT("Caught system error -- reason %d %d\n", reason, valid_fault);
+	if (!valid_fault) {
+		TC_PRINT("fatal error was unexpected, aborting\n");
+		TC_END_REPORT(TC_FAIL);
+		k_fatal_halt(reason);
+	}
+
+	TC_PRINT("fatal error expected as part of test case\n");
+	valid_fault = false; /* reset back to normal */
+	TC_END_REPORT(TC_PASS);
+}
+
+static void thread_call_thread_abort(void *p1, void *p2, void *p3)
+{
+	valid_fault = true;
+
+	k_tid_t thread = k_current_get();
+	k_thread_abort(thread);
+
+	if (valid_fault) {
+		/*
+		 * valid_fault gets cleared if an expected exception took place
+		 */
+		TC_PRINT("test function was supposed to fault but didn't\n");
+		ztest_test_fail();
+	}
+}
+
+ZTEST(riscv_thread_abort, test_essential_thread_abort)
+{
+	/* Testing an essential thread. */
+	k_tid_t tid;
+	tid = k_thread_create(&tdata, tstack, STACK_SIZE, thread_call_thread_abort,
+			      NULL, NULL, NULL, 0, K_ESSENTIAL, K_NO_WAIT);
+	k_thread_join(tid, K_FOREVER);
+
+	zassert_unreachable("Write to stack guard did not fault");
+	TC_END_REPORT(TC_FAIL);
+}
+
+ZTEST_SUITE(riscv_thread_abort, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/riscv/pmp/thread-abort/testcase.yaml
+++ b/tests/arch/riscv/pmp/thread-abort/testcase.yaml
@@ -1,0 +1,5 @@
+common:
+  filter: CONFIG_RISCV_PMP
+
+tests:
+  arch.riscv.pmp.thread_abort: {}


### PR DESCRIPTION
```
(.venv) fsammoura@fsammoura2:~/zephyrproject/zephyr/scripts$  ./twister -v -i -p qemu_riscv32 -s arch.riscv.pmp.thread_abort -c
ZEPHYR_BASE unset, using "/usr/local/google/home/fsammoura/zephyrproject/zephyr"
Deleting output directory /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-4236-g258eef1017c4
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/testplan.json
INFO    - JOBS: 128
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/1 qemu_riscv32/qemu_virt_riscv32 arch.riscv.pmp.thread_abort                   FAILED Testsuite failed (qemu 1.042s <zephyr>)
INFO    - /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/qemu_riscv32_qemu_virt_riscv32/zephyr/tests/arch/riscv/pmp/thread-abort/arch.riscv.pmp.thread_abort/handler.log
ERROR   - *** Booting Zephyr OS build v4.3.0-4236-g258eef1017c4 ***
Running TESTSUITE riscv_thread_abort
===================================================================
START - test_essential_thread_abort
E: 
E:  mcause: 11, Environment call from M-mode
E:   mtval: 0
E:      a0: 00000004    t0: 00000000
E:      a1: 00000000    t1: 00000000
E:      a2: 00000000    t2: 00000000
E:      a3: 800090a8    t3: 00000000
E:      a4: 00000000    t4: 00000000
E:      a5: 80009634    t5: 00000000
E:      a6: 0000c34f    t6: 00000000
E:      a7: 00000000
E:      sp: 8000a040
E:      ra: 80004020
E:    mepc: 80004030
E: mstatus: 00021880
E: 
E:      s0: 800090a8    s6: 00000000
E:      s1: 80000784    s7: 00000000
E:      s2: 00020088    s8: 00000000
E:      s3: 80009634    s9: 00000000
E:      s4: 00000008   s10: 00000000
E:      s5: 00000001   s11: 00000000
E: 
E: call trace:
E:       0: sp: 8000a040 ra: 80004030
E:       1: sp: 8000a058 ra: 80000784
E:       2: sp: 8000a060 ra: 80004164
E:       3: sp: 8000a070 ra: 800007d0
E:       4: sp: 8000a074 ra: 80000784
E:       5: sp: 8000a080 ra: 80000cba
E: 
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x800090a8 (unknown)
Caught system error -- reason 4 1
fatal error expected as part of test case
===================================================================
RunID: 041b010d9249b1fcecf3cd7486aa77b7
PROJECT EXECUTION SUCCESSFUL
E:      a0: 00000004    t0: 00000000
E:      a1: 00000000    t1: 00000000
E:      a2: 00000000    t2: 00000000
E:      a3: 800090a8    t3: 00000000
E:      a4: 00000000    t4: 00000000
E:      a5: 80009634    t5: 00000000
E:      a6: 0000c34f    t6: 00000000
E:      a7: 00000000
E:      sp: 8000a040
E:      ra: 80004020
E:    mepc: 80004030
E: mstatus: 00021880
E: 
E:      s0: 800090a8    s6: 00000000
E:      s1: 80000784    s7: 00000000
E:      s2: 00020088    s8: 00000000
E:      s3: 80009634    s9: 00000000
E:      s4: 00000008   s10: 00000000
E:      s5: 00000001   s11: 00000000
E: 
E: call trace:
E:       0: sp: 8000a040 ra: 80004030
E:       1: sp: 8000a058 ra: 80000784
E:       2: sp: 8000a060 ra: 80004164
E:       3: sp: 8000a070 ra: 800007d0
E:       4: sp: 8000a074 ra: 80000784
E:       5: sp: 8000a080 ra: 80000cba
E: 
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x800090a8 (unknown)
Caught system error -- reason 4 0
fatal error was unexpected, aborting
===================================================================
RunID: 041b010d9249b1fcecf3cd7486aa77b7
PROJECT EXECUTION FAILED

INFO    - /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/qemu_riscv32_qemu_virt_riscv32/zephyr/tests/arch/riscv/pmp/thread-abort/arch.riscv.pmp.thread_abort/handler.log

INFO    - 1 test scenarios (1 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 0 of 1 executed test configurations passed (0.00%), 0 built (not run), 1 failed, 0 errored, with no warnings in 22.03 seconds.
INFO    - 0 of 2 executed test cases passed (0.00%), 2 failed on 1 out of total 1343 platforms (0.07%).
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/twister.json
INFO    - Writing xunit report /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/twister.xml...
INFO    - Writing xunit report /usr/local/google/home/fsammoura/zephyrproject/zephyr/scripts/twister-out/twister_report.xml...
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) arch.riscv.pmp.thread_abort on qemu_riscv32/qemu_virt_riscv32 failed (Testsuite failed)
INFO    - 
INFO    - To rerun the tests, call twister using the following commandline:
INFO    - west twister -p <PLATFORM> -s <TEST ID>, for example:
INFO    - 
INFO    - west twister -p qemu_riscv32/qemu_virt_riscv32 -s arch.riscv.pmp.thread_abort
INFO    - or with west:
INFO    - west build -p -b qemu_riscv32/qemu_virt_riscv32 ../tests/arch/riscv/pmp/thread-abort -T arch.riscv.pmp.thread_abort
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed
```