### PR TITLE
soc: microchip: mec: Disable deprecated MEC5 HAL for MEC165xB/174x/175x

### DIFF
--- a/soc/microchip/mec/Kconfig
+++ b/soc/microchip/mec/Kconfig
@@ -218,7 +218,7 @@ endif # MCHP_MEC_UNSIGNED_HEADER
 choice
 	prompt "MEC debug interface general configuration"
 	default SOC_MEC_DEBUG_AND_TRACING
-	depends on SOC_SERIES_MEC174X || SOC_SERIES_MEC175X
+	depends on SOC_SERIES_MEC174X || SOC_SERIES_MEC175X || SOC_SERIES_MEC165XB
 	help
 	  Select Debug SoC interface support for MEC SoC family
 

--- a/soc/microchip/mec/common/CMakeLists.txt
+++ b/soc/microchip/mec/common/CMakeLists.txt
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(.)
-zephyr_library_sources(soc_ecia.c soc_pcr.c)
+zephyr_library_sources(soc_ecia.c soc_pcr.c soc_cmn_init.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_MEC172X
   soc_i2c.c
-)
-zephyr_library_sources_ifdef(CONFIG_HAS_MEC5_HAL
-  soc_cmn_init.c
 )
 
 if(DEFINED CONFIG_MCHP_HEADER_VERBOSE_OUTPUT)

--- a/soc/microchip/mec/common/soc_cmn_init.c
+++ b/soc/microchip/mec/common/soc_cmn_init.c
@@ -4,36 +4,102 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
+#include <soc.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <soc.h>
-#include <mec_ecs_api.h>
+#include <zephyr/sys/util.h>
 
-static void mec5_soc_init_debug_interface(void)
+#define XEC_ECS_ETM_CR_OFS      0x1cu
+#define XEC_ECS_ETM_PINS_EN_POS 0
+
+#define XEC_ECS_DGB_CR_OFS             0x20u
+#define XEC_ECS_DBG_CR_EN_POS          0
+#define XEC_ECS_DBG_CR_PIN_CFG_POS     1
+#define XEC_ECS_DBG_CR_PIN_CFG_MSK     GENMASK(2, 1)
+#define XEC_ECS_DBG_CR_PIN_CFG_JTAG    0
+#define XEC_ECS_DBG_CR_PIN_CFG_SWD_SWV 1
+#define XEC_ECS_DBG_CR_PIN_CFG_SWD     2
+#define XEC_ECS_DBG_CR_PIN_CFG_SET(c)  FIELD_PREP(XEC_ECS_DBG_CR_PIN_CFG_MSK, (c))
+#define XEC_ECS_DBG_CR_PIN_CFG_GET(r)  FIELD_GET(XEC_ECS_DBG_CR_PIN_CFG_MSK, (r))
+#define XEC_ECS_DBG_CR_PU_EN_POS       3
+#define XEC_ECS_DBG_CR_EN_LOCK_POS     5
+
+#define XEC_ECS_BASE_ADDR DT_REG_ADDR(DT_NODELABEL(ecs))
+
+#define XEC_DEBUG_FLAG_EN_POS     0
+#define XEC_DEBUG_FLAG_ETM_EN_POS 1
+#define XEC_DEBUG_IFC_SWD_POS     2
+#define XEC_DEBUG_SWD_SWV_POS     3
+#define XEC_DEBUG_IFC_LOCK_POS    4
+
+void mec_soc_debug_ifc_init(uint32_t flags)
 {
-#if defined(CONFIG_SOC_MEC_DEBUG_DISABLED)
-	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_DISABLE);
-#else
-#if defined(SOC_MEC_DEBUG_WITHOUT_TRACING)
-	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_SWD);
-#elif defined(SOC_MEC_DEBUG_AND_TRACING)
-#if defined(SOC_MEC_DEBUG_AND_ETM_TRACING)
-	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_SWD_SWV);
-#elif defined(CONFIG_SOC_MEC_DEBUG_AND_ETM_TRACING)
-	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD);
-	mec_hal_ecs_etm_pins(ECS_ETM_PINS_ENABLE);
-#endif
-#endif
-#endif
+	uint32_t msk = 0, val = 0;
+
+	if ((flags & BIT(XEC_DEBUG_FLAG_ETM_EN_POS)) != 0) {
+		/* Switch shared GPIOs to ETM mode */
+		sys_set_bit(XEC_ECS_BASE_ADDR + XEC_ECS_ETM_CR_OFS, XEC_ECS_ETM_PINS_EN_POS);
+	} else {
+		/* Disable ETM. ETM pins can be used as GPIOs */
+		sys_clear_bit(XEC_ECS_BASE_ADDR + XEC_ECS_ETM_CR_OFS, XEC_ECS_ETM_PINS_EN_POS);
+	}
+
+	if ((flags & BIT(XEC_DEBUG_FLAG_EN_POS)) != 0) {
+		msk = BIT(XEC_ECS_DBG_CR_EN_POS) | XEC_ECS_DBG_CR_PIN_CFG_MSK;
+		val = BIT(XEC_ECS_DBG_CR_EN_POS);
+
+		if ((flags & BIT(XEC_DEBUG_IFC_LOCK_POS)) != 0) {
+			msk |= BIT(XEC_ECS_DBG_CR_EN_LOCK_POS);
+			val |= BIT(XEC_ECS_DBG_CR_EN_LOCK_POS);
+		}
+
+		if ((flags & BIT(XEC_DEBUG_IFC_SWD_POS)) != 0) {
+			if ((flags & BIT(XEC_DEBUG_SWD_SWV_POS)) != 0) {
+				val |= XEC_ECS_DBG_CR_PIN_CFG_SET(XEC_ECS_DBG_CR_PIN_CFG_SWD_SWV);
+			} else {
+				val |= XEC_ECS_DBG_CR_PIN_CFG_SET(XEC_ECS_DBG_CR_PIN_CFG_SWD);
+			}
+		} else {
+			val |= XEC_ECS_DBG_CR_PIN_CFG_SET(XEC_ECS_DBG_CR_PIN_CFG_JTAG);
+		}
+
+		soc_mmcr_mask_set(XEC_ECS_BASE_ADDR + XEC_ECS_DGB_CR_OFS, val, msk);
+	} else {
+		sys_clear_bit(XEC_ECS_BASE_ADDR + XEC_ECS_DGB_CR_OFS, XEC_ECS_DBG_CR_EN_POS);
+	}
 }
 
 int mec5_soc_common_init(void)
 {
-	mec5_soc_init_debug_interface();
+	uint32_t dbg_flags = 0; /* disabled */
+	bool config_debug = false;
+
+	/* Kconfig choice items. Only one will be defined */
+#if defined(CONFIG_SOC_MEC_DEBUG_DISABLED)
+	config_debug = true;
+#endif
+#if defined(SOC_MEC_DEBUG_WITHOUT_TRACING)
+	config_debug = true;
+	dbg_flags = BIT(XEC_DEBUG_FLAG_EN_POS) | BIT(XEC_DEBUG_IFC_SWD_POS);
+#endif
+#if defined(SOC_MEC_DEBUG_AND_TRACING)
+	config_debug = true;
+#if defined(CONFIG_SOC_MEC_DEBUG_AND_SWV_TRACING)
+	dbg_flags = (BIT(XEC_DEBUG_FLAG_EN_POS) | BIT(XEC_DEBUG_IFC_SWD_POS) |
+		     BIT(XEC_DEBUG_SWD_SWV_POS));
+#endif
+#if defined(config SOC_MEC_DEBUG_AND_ETM_TRACING)
+	dbg_flags = (BIT(XEC_DEBUG_FLAG_EN_POS) | BIT(XEC_DEBUG_IFC_SWD_POS) |
+		     BIT(XEC_DEBUG_FLAG_ETM_EN_POS));
+#endif
+#endif
+
+	if (config_debug == true) {
+		mec_soc_debug_ifc_init(dbg_flags);
+	}
+
 	soc_ecia_init(MCHP_MEC_ECIA_GIRQ_AGGR_ONLY_BM, MCHP_MEC_ECIA_GIRQ_DIRECT_CAP_BM, 0);
 
 	return 0;

--- a/soc/microchip/mec/common/soc_common.h
+++ b/soc/microchip/mec/common/soc_common.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SOC_MICROCHIP_MEC_COMMON_SOC_COMMON_H
+#define __SOC_MICROCHIP_MEC_COMMON_SOC_COMMON_H
+
+#include <reg/mec_acpi_ec.h>
+#include <reg/mec_adc.h>
+#include <reg/mec_global_cfg.h>
+#include <reg/mec_gpio.h>
+#include <reg/mec_kbc.h>
+#include <reg/mec_keyscan.h>
+#include <reg/mec_peci.h>
+#include <reg/mec_ps2.h>
+#include <reg/mec_pwm.h>
+#include <reg/mec_tach.h>
+#include <reg/mec_tfdp.h>
+#include <reg/mec_timers.h>
+#include <reg/mec_uart.h>
+#include <reg/mec_vci.h>
+#include <reg/mec_wdt.h>
+
+/* common SoC API */
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
+
+#endif /* __SOC_MICROCHIP_MEC_COMMON_SOC_COMMON_H */

--- a/soc/microchip/mec/mec165xb/Kconfig
+++ b/soc/microchip/mec/mec165xb/Kconfig
@@ -9,5 +9,4 @@ config SOC_SERIES_MEC165XB
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
-	select HAS_MEC5_HAL
 	select SOC_PREP_HOOK

--- a/soc/microchip/mec/mec165xb/soc.h
+++ b/soc/microchip/mec/mec165xb/soc.h
@@ -13,33 +13,32 @@
 
 #define MCHP_HAS_UART_LSR2
 
-#include <device_mec5.h>
+/* Minimal ARM CMSIS requirements */
+typedef enum {
+	Reset_IRQn = -15,
+	NonMaskableInt_IRQn = -14,
+	HardFault_IRQn = -13,
+	MemoryManagement_IRQn = -12,
+	BusFault_IRQn = -11,
+	UsageFault_IRQn = -10,
+	SVCall_IRQn = -5,
+	DebugMonitor_IRQn = -4,
+	PendSV_IRQn = -2,
+	SysTick_IRQn = -1,
+	FirstPeriph_IRQn = 0,
+	LastPeriph_IRQn = 197,
+} IRQn_Type;
+
+#define __CM4_REV              0x0201U /* CM4 Core Revision */
+#define __NVIC_PRIO_BITS       3       /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig 0       /* Set to 1 if different SysTick Config is used */
+#define __MPU_PRESENT          1       /* MPU present */
+#define __FPU_PRESENT          0       /* FPU present */
+
+#include <core_cm4.h>
 
 /* common peripheral register defines */
-#include <reg/mec_acpi_ec.h>
-#include <reg/mec_adc.h>
-#include <reg/mec_global_cfg.h>
-#include <reg/mec_gpio.h>
-#include <reg/mec_kbc.h>
-#include <reg/mec_keyscan.h>
-#include <reg/mec_peci.h>
-#include <reg/mec_ps2.h>
-#include <reg/mec_pwm.h>
-#include <reg/mec_tach.h>
-#include <reg/mec_tfdp.h>
-#include <reg/mec_timers.h>
-#include <reg/mec_uart.h>
-#include <reg/mec_vci.h>
-#include <reg/mec_wdt.h>
-
-/* common SoC API */
-#include <soc_dt.h>
-#include <soc_ecia.h>
-#include <soc_espi_channels.h>
-#include <soc_gpio.h>
-#include <soc_mmcr.h>
-#include <soc_pcr.h>
-#include <soc_pins.h>
+#include <soc_common.h>
 
 #endif
 #endif

--- a/soc/microchip/mec/mec174x/Kconfig
+++ b/soc/microchip/mec/mec174x/Kconfig
@@ -10,7 +10,6 @@ config SOC_SERIES_MEC174X
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
-	select HAS_MEC5_HAL
 	select SOC_PREP_HOOK
 
 if SOC_SERIES_MEC174X

--- a/soc/microchip/mec/mec174x/soc.h
+++ b/soc/microchip/mec/mec174x/soc.h
@@ -13,33 +13,32 @@
 
 #define MCHP_HAS_UART_LSR2
 
-#include <device_mec5.h>
+/* Minimal ARM CMSIS requirements */
+typedef enum {
+	Reset_IRQn = -15,
+	NonMaskableInt_IRQn = -14,
+	HardFault_IRQn = -13,
+	MemoryManagement_IRQn = -12,
+	BusFault_IRQn = -11,
+	UsageFault_IRQn = -10,
+	SVCall_IRQn = -5,
+	DebugMonitor_IRQn = -4,
+	PendSV_IRQn = -2,
+	SysTick_IRQn = -1,
+	FirstPeriph_IRQn = 0,
+	LastPeriph_IRQn = 197,
+} IRQn_Type;
+
+#define __CM4_REV              0x0201U /* CM4 Core Revision */
+#define __NVIC_PRIO_BITS       3       /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig 0       /* Set to 1 if different SysTick Config is used */
+#define __MPU_PRESENT          1       /* MPU present */
+#define __FPU_PRESENT          1       /* FPU present */
+
+#include <core_cm4.h>
 
 /* common peripheral register defines */
-#include <reg/mec_acpi_ec.h>
-#include <reg/mec_adc.h>
-#include <reg/mec_global_cfg.h>
-#include <reg/mec_gpio.h>
-#include <reg/mec_kbc.h>
-#include <reg/mec_keyscan.h>
-#include <reg/mec_peci.h>
-#include <reg/mec_ps2.h>
-#include <reg/mec_pwm.h>
-#include <reg/mec_tach.h>
-#include <reg/mec_tfdp.h>
-#include <reg/mec_timers.h>
-#include <reg/mec_uart.h>
-#include <reg/mec_vci.h>
-#include <reg/mec_wdt.h>
-
-/* common SoC API */
-#include <soc_dt.h>
-#include <soc_ecia.h>
-#include <soc_espi_channels.h>
-#include <soc_gpio.h>
-#include <soc_mmcr.h>
-#include <soc_pcr.h>
-#include <soc_pins.h>
+#include <soc_common.h>
 
 #endif
 #endif

--- a/soc/microchip/mec/mec175x/Kconfig
+++ b/soc/microchip/mec/mec175x/Kconfig
@@ -10,7 +10,6 @@ config SOC_SERIES_MEC175X
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
-	select HAS_MEC5_HAL
 	select SOC_PREP_HOOK
 
 if SOC_SERIES_MEC175X

--- a/soc/microchip/mec/mec175x/soc.h
+++ b/soc/microchip/mec/mec175x/soc.h
@@ -13,33 +13,32 @@
 
 #define MCHP_HAS_UART_LSR2
 
-#include <device_mec5.h>
+/* Minimal ARM CMSIS requirements */
+typedef enum {
+	Reset_IRQn = -15,
+	NonMaskableInt_IRQn = -14,
+	HardFault_IRQn = -13,
+	MemoryManagement_IRQn = -12,
+	BusFault_IRQn = -11,
+	UsageFault_IRQn = -10,
+	SVCall_IRQn = -5,
+	DebugMonitor_IRQn = -4,
+	PendSV_IRQn = -2,
+	SysTick_IRQn = -1,
+	FirstPeriph_IRQn = 0,
+	LastPeriph_IRQn = 197,
+} IRQn_Type;
+
+#define __CM4_REV              0x0201U /* CM4 Core Revision */
+#define __NVIC_PRIO_BITS       3       /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig 0       /* Set to 1 if different SysTick Config is used */
+#define __MPU_PRESENT          1       /* MPU present */
+#define __FPU_PRESENT          1       /* FPU present */
+
+#include <core_cm4.h>
 
 /* common peripheral register defines */
-#include <reg/mec_acpi_ec.h>
-#include <reg/mec_adc.h>
-#include <reg/mec_global_cfg.h>
-#include <reg/mec_gpio.h>
-#include <reg/mec_kbc.h>
-#include <reg/mec_keyscan.h>
-#include <reg/mec_peci.h>
-#include <reg/mec_ps2.h>
-#include <reg/mec_pwm.h>
-#include <reg/mec_tach.h>
-#include <reg/mec_tfdp.h>
-#include <reg/mec_timers.h>
-#include <reg/mec_uart.h>
-#include <reg/mec_vci.h>
-#include <reg/mec_wdt.h>
-
-/* common SoC API */
-#include <soc_dt.h>
-#include <soc_ecia.h>
-#include <soc_espi_channels.h>
-#include <soc_gpio.h>
-#include <soc_mmcr.h>
-#include <soc_pcr.h>
-#include <soc_pins.h>
+#include <soc_common.h>
 
 #endif
 #endif


### PR DESCRIPTION
Due to multiple customer requests we are deprecating the MEC5 HAL. Customers prefer all code to be in the main Zephyr tree. They do not want a dependency on an outside SoC HAL. These changes remove the MEC5_HAL select from MEC165xB, MEC174x, and MEC175x. The SoC code calling the HAL for debug configuration was replaced with a small amount of code common to all SoC's. We also moved all the common header includes into a common SoC header to prevent changing multiple files if new common headers are added. Note: the in-tree drivers: kernel timer, GPIO, PINCTRL, and UART are all non-HAL.