### PR TITLE
modbus: Fixed bug where serial rx isn't started when using async mode

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -693,8 +693,11 @@ int modbus_serial_init(struct modbus_context *ctx,
 		if (!err) {
 			k_timer_init(&cfg->rtu_timer, rtu_tmr_handler, NULL);
 			k_timer_user_data_set(&cfg->rtu_timer, ctx);
-			modbus_serial_rx_on(ctx);
 		}
+	}
+
+	if (!err && !ctx->client) {
+		modbus_serial_rx_on(ctx);
 	}
 
 	LOG_INF("RTU timeout %u us", cfg->rtu_timeout);


### PR DESCRIPTION
Modbus is failing to turn on RX when using serial ASYNC mode. This causes modbus to never receive inbound requests leaving it inoperable. Fixing this by enabling rx upon success init when using serial ASYNC mode.