### PR TITLE
doc: link-roles: Update path handling to use document name

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -119,7 +119,8 @@ def modulelink(default_module=None, format="blob"):
             )
 
         if module == config.link_roles_manifest_project:
-            p = Path(source).relative_to(inliner.document.settings.env.srcdir)
+            docname = inliner.document.settings.env.docname
+            p = Path(docname)
             if (
                 not any(
                     p.match(glob)

--- a/doc/releases/release-notes-2.0.rst
+++ b/doc/releases/release-notes-2.0.rst
@@ -451,10 +451,10 @@ Build and Infrastructure
 * The devicetree Python scripts have been rewritten to be more robust and
   easier to understand and change. The new scripts are these three files:
 
-  - :zephyr_file:`scripts/dts/dtlib.py` -- a low-level :file:`.dts` parsing
+  - ``scripts/dts/dtlib.py`` -- a low-level :file:`.dts` parsing
     library
 
-  - :zephyr_file:`scripts/dts/edtlib.py` -- a higher-level library that adds
+  - ``scripts/dts/edtlib.py`` -- a higher-level library that adds
     information from bindings
 
   - :zephyr_file:`scripts/dts/gen_defines.py` -- generates a C header from the

--- a/doc/releases/release-notes-2.1.rst
+++ b/doc/releases/release-notes-2.1.rst
@@ -412,7 +412,7 @@ Build and Infrastructure
   :zephyr_file:`scripts/kconfig/kconfigfunctions.py`.  See
   :ref:`kconfig-functions` for usage details.  For sanitycheck yaml usage
   we should utilize functions from
-  :zephyr_file:`scripts/sanity_chk/expr_parser.py`.  Its possible that a
+  ``scripts/sanity_chk/expr_parser.py``.  Its possible that a
   new function might be required for a particular use pattern that isn't
   currently supported.
 

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -854,7 +854,7 @@ Build and Infrastructure
 
     * pyocd runner: board-specific pyOCD configuration files in YAML can now be
       placed in :file:`support/pyocd.yaml` inside the board directory. See
-      :zephyr_file:`boards/arm/reel_board/support/pyocd.yaml` for an example,
+      ``boards/arm/reel_board/support/pyocd.yaml`` for an example,
       and the pyOCD documentation for details on its configuration format.
 
   * ``west spdx``: new command which can be used to generate SPDX software

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -52,14 +52,14 @@ Changes in this release
   release.  The :zephyr_file:`scripts/utils/migrate_includes.py` script is
   provided to automate the migration.
 
-* :zephyr_file:`include/zephyr/zephyr.h` no longer defines ``__ZEPHYR__``.
+* ``include/zephyr/zephyr.h`` no longer defines ``__ZEPHYR__``.
   This definition can be used by third-party code to compile code conditional
   to Zephyr. The definition is already injected by the Zephyr build system.
   Therefore, any third-party code integrated using the Zephyr build system will
   require no changes. External build systems will need to inject the definition
   by themselves, if they did not already.
 
-* :zephyr_file:`include/zephyr/zephyr.h` has been deprecated in favor of
+* ``include/zephyr/zephyr.h`` has been deprecated in favor of
   :zephyr_file:`include/zephyr/kernel.h`, since it only included that header. No
   changes are required by applications other than replacing ``#include
   <zephyr/zephyr.h>`` with ``#include <zephyr/kernel.h>``.


### PR DESCRIPTION
Use docname instead of source from get_source_and_line() because source can be a relative path to an included file (e.g., .rst.inc), while docname is always the main document being processed.

Fixes doc failure in `main`

Tested with:
```
make html HW_FEATURES_VENDOR_FILTER=ezurio DT_TURBO_MODE=1  
```