### PR TITLE
bindings: scmi: modify description format

### DIFF
--- a/dts/bindings/firmware/arm,scmi-clock.yaml
+++ b/dts/bindings/firmware/arm,scmi-clock.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) clock protocol
+description: SCMI (System Control and Management Interface) clock protocol
 
 compatible: "arm,scmi-clock"
 

--- a/dts/bindings/firmware/arm,scmi-pinctrl.yaml
+++ b/dts/bindings/firmware/arm,scmi-pinctrl.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) pinctrl protocol
+description: SCMI (System Control and Management Interface) pinctrl protocol
 
 compatible: "arm,scmi-pinctrl"
 

--- a/dts/bindings/firmware/arm,scmi-power.yaml
+++ b/dts/bindings/firmware/arm,scmi-power.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) power domain protocol
+description: SCMI (System Control and Management Interface) power domain protocol
 
 compatible: "arm,scmi-power"
 

--- a/dts/bindings/firmware/arm,scmi-shmem.yaml
+++ b/dts/bindings/firmware/arm,scmi-shmem.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) shared memory (SHMEM)
+description: SCMI (System Control and Management Interface) SHMEM (shared memory)
 
 compatible: "arm,scmi-shmem"
 

--- a/dts/bindings/firmware/arm,scmi-system.yaml
+++ b/dts/bindings/firmware/arm,scmi-system.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) system power protocol
+description: SCMI (System Control and Management Interface) system power protocol
 
 compatible: "arm,scmi-system"
 

--- a/dts/bindings/firmware/arm,scmi.yaml
+++ b/dts/bindings/firmware/arm,scmi.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-        System Control and Management Interface (SCMI) with doorbell
-        and shared memory (SHMEM) transport.
+        SCMI (System Control and Management Interface) with doorbell
+        and SHMEM (shared memory) transport.
 
         Devicetree example:
             #include <mem.h>

--- a/dts/bindings/firmware/nxp,scmi-cpu.yaml
+++ b/dts/bindings/firmware/nxp,scmi-cpu.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: System Control and Management Interface (SCMI) cpu domain protocol
+description: SCMI (System Control and Management Interface) cpu domain protocol
 
 compatible: "nxp,scmi-cpu"
 

--- a/dts/bindings/power-domain/arm,scmi-power-domain.yaml
+++ b/dts/bindings/power-domain/arm,scmi-power-domain.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: ARM SCMI Power Domain
+description: SCMI (System Control and Management Interface) power domain
 
 compatible: "arm,scmi-power-domain"
 


### PR DESCRIPTION
Modify the description format of all SCMI-related bindings such that the
SCMI/SHMEM acronym is spelled out in between parentheses and not the other
way around. This will make the generated documentation more compact.