### PR TITLE
boards: infineon: standardize pinctrl in supported list

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
@@ -15,5 +15,5 @@ toolchain:
 supported:
   - uart
   - clock_control
-  - pin_ctrl
+  - pinctrl
 vendor: infineon

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -14,5 +14,5 @@ toolchain:
 supported:
   - clock_control
   - gpio
-  - pin_ctrl
+  - pinctrl
   - uart

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -14,5 +14,5 @@ toolchain:
 supported:
   - clock_control
   - gpio
-  - pin_ctrl
+  - pinctrl
   - uart

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -15,6 +15,6 @@ supported:
   - clock_control
   - dma
   - gpio
-  - pin_ctrl
+  - pinctrl
   - uart
   - spi

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -15,6 +15,6 @@ supported:
   - clock_control
   - dma
   - gpio
-  - pin_ctrl
+  - pinctrl
   - uart
   - spi


### PR DESCRIPTION
Addresses review comments from https://github.com/zephyrproject-rtos/zephyr/pull/100707 , specifically this [comment](https://github.com/zephyrproject-rtos/zephyr/pull/100707#discussion_r2701322363).

Changes 'pin_ctrl' to 'pinctrl' in the supported features list for consistency with Zephyr naming conventions.