### PR TITLE
drivers: dai: intel: dmic: make dai_dmic_probe void

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -328,7 +328,7 @@ static inline void dai_dmic_dis_power(const struct dai_intel_dmic *dmic)
 		     base + DMICLCTL_OFFSET);
 }
 
-static int dai_dmic_probe(struct dai_intel_dmic *dmic)
+static void dai_dmic_probe(struct dai_intel_dmic *dmic)
 {
 	LOG_INF("dmic_probe()");
 
@@ -346,8 +346,6 @@ static int dai_dmic_probe(struct dai_intel_dmic *dmic)
 
 	/* DMIC Owner Select to DSP */
 	dai_dmic_claim_ownership(dmic);
-
-	return 0;
 }
 
 static int dai_dmic_remove(struct dai_intel_dmic *dmic)
@@ -812,25 +810,20 @@ out:
 	return ret;
 }
 
-static int dai_dmic_probe_wrapper(const struct device *dev)
+static void dai_dmic_probe_wrapper(const struct device *dev)
 {
 	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *)dev->data;
 	k_spinlock_key_t key;
-	int ret = 0;
 
 	key = k_spin_lock(&dmic->lock);
 
 	if (dmic->sref == 0) {
-		ret = dai_dmic_probe(dmic);
+		dai_dmic_probe(dmic);
 	}
 
-	if (!ret) {
-		dmic->sref++;
-	}
+	dmic->sref++;
 
 	k_spin_unlock(&dmic->lock, key);
-
-	return ret;
 }
 
 static int dai_dmic_remove_wrapper(const struct device *dev)


### PR DESCRIPTION
dai_dmic_probe() and dai_dmic_probe_wrapper() never reports errors and always returns 0.
The error check at the call site is therefore dead code.

Make functions void and drop the unused error handling.