### PR TITLE
boards: shields: nxp_m2_wifi_bt: wakeup support for 1XK & 2LL shield

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@
 		m2_bt_module: m2_bt_module {
 			sdio-reset-gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 			w-disable-gpios = <&gpio1 19 GPIO_ACTIVE_HIGH>;
+			wakeup-bt-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2el_wifi_bt.overlay
@@ -25,7 +25,6 @@
 			fw-download-primary-speed = <115200>;
 			fw-download-secondary-speed = <3000000>;
 			fw-download-secondary-flowcontrol;
-			wakeup-bt-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
Add wakeup IO config for 1XK & 2LL shields for wakeup functionality