### PR TITLE
manifest: hal_nxp: upgrade wifi version to r53.p2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2f8883b3358e7be2101075cd0f00dd2e0fa68050
+      revision: af5d95d3e6be13f1b993d2c466595e7cc71ba57b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Upgrade wifi driver version to r53.p2.
Support static ipv4 address connection for STA interface. Improved throughput value for SDIO case.
Support event based FW dump for IW61x.
Fix several bugs.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102153