### PR TITLE
dts: riscv: it51xxx: omit pinctrl and wuc nodes if not referenced

### DIFF
--- a/dts/riscv/ite/it51xxx-pinctrl-map.dtsi
+++ b/dts/riscv/ite/it51xxx-pinctrl-map.dtsi
@@ -8,451 +8,451 @@
 
 &pinctrl {
 	/* ADC alternate function */
-	adc0_ch0_gpi0_default: adc0_ch0_gpi0_default {
+	/omit-if-no-ref/ adc0_ch0_gpi0_default: adc0_ch0_gpi0_default {
 		pinmuxs = <&pinctrli 0 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch1_gpi1_default: adc0_ch1_gpi1_default {
+	/omit-if-no-ref/ adc0_ch1_gpi1_default: adc0_ch1_gpi1_default {
 		pinmuxs = <&pinctrli 1 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch2_gpi2_default: adc0_ch2_gpi2_default {
+	/omit-if-no-ref/ adc0_ch2_gpi2_default: adc0_ch2_gpi2_default {
 		pinmuxs = <&pinctrli 2 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch3_gpi3_default: adc0_ch3_gpi3_default {
+	/omit-if-no-ref/ adc0_ch3_gpi3_default: adc0_ch3_gpi3_default {
 		pinmuxs = <&pinctrli 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch4_gpi4_default: adc0_ch4_gpi4_default {
+	/omit-if-no-ref/ adc0_ch4_gpi4_default: adc0_ch4_gpi4_default {
 		pinmuxs = <&pinctrli 4 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch5_gpi5_default: adc0_ch5_gpi5_default {
+	/omit-if-no-ref/ adc0_ch5_gpi5_default: adc0_ch5_gpi5_default {
 		pinmuxs = <&pinctrli 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch6_gpi6_default: adc0_ch6_gpi6_default {
+	/omit-if-no-ref/ adc0_ch6_gpi6_default: adc0_ch6_gpi6_default {
 		pinmuxs = <&pinctrli 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	adc0_ch7_gpi7_default: adc0_ch7_gpi7_default {
+	/omit-if-no-ref/ adc0_ch7_gpi7_default: adc0_ch7_gpi7_default {
 		pinmuxs = <&pinctrli 7 IT8XXX2_ALT_FUNC_1>;
 	};
 
 	/* FSPI alternate function */
-	fspi_fsce_gpg3_default: fspi_fsce_gpg3_default {
+	/omit-if-no-ref/ fspi_fsce_gpg3_default: fspi_fsce_gpg3_default {
 		pinmuxs = <&pinctrlg 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fmosi_gpg4_default: fspi_fmosi_gpg4_default {
+	/omit-if-no-ref/ fspi_fmosi_gpg4_default: fspi_fmosi_gpg4_default {
 		pinmuxs = <&pinctrlg 4 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fmiso_gpg5_default: fspi_fmiso_gpg5_default {
+	/omit-if-no-ref/ fspi_fmiso_gpg5_default: fspi_fmiso_gpg5_default {
 		pinmuxs = <&pinctrlg 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fsce1_gpg6_default: fspi_fsce1_gpg6_default {
+	/omit-if-no-ref/ fspi_fsce1_gpg6_default: fspi_fsce1_gpg6_default {
 		pinmuxs = <&pinctrlg 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fsck_gpg7_default: fspi_fsck_gpg7_default {
+	/omit-if-no-ref/ fspi_fsck_gpg7_default: fspi_fsck_gpg7_default {
 		pinmuxs = <&pinctrlg 7 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fdio2_gph5_default: fspi_fdio2_gph5_default {
+	/omit-if-no-ref/ fspi_fdio2_gph5_default: fspi_fdio2_gph5_default {
 		pinmuxs = <&pinctrlh 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	fspi_fdio3_gph6_default: fspi_fdio3_gph6_default {
+	/omit-if-no-ref/ fspi_fdio3_gph6_default: fspi_fdio3_gph6_default {
 		pinmuxs = <&pinctrlh 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
 	/* I2C alternate function */
-	i2c0_clk_gpf2_default: i2c0_clk_gpf2_default {
+	/omit-if-no-ref/ i2c0_clk_gpf2_default: i2c0_clk_gpf2_default {
 		pinmuxs = <&pinctrlf 2 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c0_data_gpf3_default: i2c0_data_gpf3_default {
+	/omit-if-no-ref/ i2c0_data_gpf3_default: i2c0_data_gpf3_default {
 		pinmuxs = <&pinctrlf 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c1_clk_gpc1_default: i2c1_clk_gpc1_default {
+	/omit-if-no-ref/ i2c1_clk_gpc1_default: i2c1_clk_gpc1_default {
 		pinmuxs = <&pinctrlc 1 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c1_data_gpc2_default: i2c1_data_gpc2_default {
+	/omit-if-no-ref/ i2c1_data_gpc2_default: i2c1_data_gpc2_default {
 		pinmuxs = <&pinctrlc 2 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c2_clk_gpf6_default: i2c2_clk_gpf6_default {
+	/omit-if-no-ref/ i2c2_clk_gpf6_default: i2c2_clk_gpf6_default {
 		pinmuxs = <&pinctrlf 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c2_data_gpf7_default: i2c2_data_gpf7_default {
+	/omit-if-no-ref/ i2c2_data_gpf7_default: i2c2_data_gpf7_default {
 		pinmuxs = <&pinctrlf 7 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i2c3_clk_gph1_default: i2c3_clk_gph1_default {
+	/omit-if-no-ref/ i2c3_clk_gph1_default: i2c3_clk_gph1_default {
 		pinmuxs = <&pinctrlh 1 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c3_data_gph2_default: i2c3_data_gph2_default {
+	/omit-if-no-ref/ i2c3_data_gph2_default: i2c3_data_gph2_default {
 		pinmuxs = <&pinctrlh 2 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c4_clk_gpe0_default: i2c4_clk_gpe0_default {
+	/omit-if-no-ref/ i2c4_clk_gpe0_default: i2c4_clk_gpe0_default {
 		pinmuxs = <&pinctrle 0 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c4_data_gpe7_default: i2c4_data_gpe7_default {
+	/omit-if-no-ref/ i2c4_data_gpe7_default: i2c4_data_gpe7_default {
 		pinmuxs = <&pinctrle 7 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c5_clk_gpa4_default: i2c5_clk_gpa4_default {
+	/omit-if-no-ref/ i2c5_clk_gpa4_default: i2c5_clk_gpa4_default {
 		pinmuxs = <&pinctrla 4 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c5_data_gpa5_default: i2c5_data_gpa5_default {
+	/omit-if-no-ref/ i2c5_data_gpa5_default: i2c5_data_gpa5_default {
 		pinmuxs = <&pinctrla 5 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c6_clk_gpd0_default: i2c6_clk_gpd0_default {
+	/omit-if-no-ref/ i2c6_clk_gpd0_default: i2c6_clk_gpd0_default {
 		pinmuxs = <&pinctrld 0 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c6_data_gpd1_default: i2c6_data_gpd1_default {
+	/omit-if-no-ref/ i2c6_data_gpd1_default: i2c6_data_gpd1_default {
 		pinmuxs = <&pinctrld 1 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c7_clk_gpb2_default: i2c7_clk_gpb2_default {
+	/omit-if-no-ref/ i2c7_clk_gpb2_default: i2c7_clk_gpb2_default {
 		pinmuxs = <&pinctrlb 2 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c7_data_gph0_default: i2c7_data_gph0_default {
+	/omit-if-no-ref/ i2c7_data_gph0_default: i2c7_data_gph0_default {
 		pinmuxs = <&pinctrlh 0 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c8_clk_gpb5_default: i2c8_clk_gpb5_default {
+	/omit-if-no-ref/ i2c8_clk_gpb5_default: i2c8_clk_gpb5_default {
 		pinmuxs = <&pinctrlb 5 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	i2c8_data_gpj6_default: i2c8_data_gpj6_default {
+	/omit-if-no-ref/ i2c8_data_gpj6_default: i2c8_data_gpj6_default {
 		pinmuxs = <&pinctrlj 6 IT8XXX2_ALT_FUNC_4>;
 	};
 
 	/* I2C switch to interface */
-	i2c9_clk_gpj3_default: i2c9_clk_gpj3_default {
+	/omit-if-no-ref/ i2c9_clk_gpj3_default: i2c9_clk_gpj3_default {
 		pinmuxs = <&pinctrlj 3 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c9_data_gpj4_default: i2c9_data_gpj4_default {
+	/omit-if-no-ref/ i2c9_data_gpj4_default: i2c9_data_gpj4_default {
 		pinmuxs = <&pinctrlj 4 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c10_clk_gpj5_default: i2c10_clk_gpj5_default {
+	/omit-if-no-ref/ i2c10_clk_gpj5_default: i2c10_clk_gpj5_default {
 		pinmuxs = <&pinctrlj 5 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c10_data_gpe1_default: i2c10_data_gpe1_default {
+	/omit-if-no-ref/ i2c10_data_gpe1_default: i2c10_data_gpe1_default {
 		pinmuxs = <&pinctrle 1 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c11_clk_gpe2_default: i2c11_clk_gpe2_default {
+	/omit-if-no-ref/ i2c11_clk_gpe2_default: i2c11_clk_gpe2_default {
 		pinmuxs = <&pinctrle 2 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c11_data_gpe3_default: i2c11_data_gpe3_default {
+	/omit-if-no-ref/ i2c11_data_gpe3_default: i2c11_data_gpe3_default {
 		pinmuxs = <&pinctrle 3 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c12_clk_gpf0_default: i2c12_clk_gpf0_default {
+	/omit-if-no-ref/ i2c12_clk_gpf0_default: i2c12_clk_gpf0_default {
 		pinmuxs = <&pinctrlf 0 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	i2c12_data_gpf1_default: i2c12_data_gpf1_default {
+	/omit-if-no-ref/ i2c12_data_gpf1_default: i2c12_data_gpf1_default {
 		pinmuxs = <&pinctrlf 1 IT8XXX2_ALT_FUNC_3>;
 	};
 
 	/* I3C alternate function */
-	i3c0_clk_gpj3_default: i3c0_clk_gpj3_default {
+	/omit-if-no-ref/ i3c0_clk_gpj3_default: i3c0_clk_gpj3_default {
 		pinmuxs = <&pinctrlj 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c0_data_gpj4_default: i3c0_data_gpj4_default {
+	/omit-if-no-ref/ i3c0_data_gpj4_default: i3c0_data_gpj4_default {
 		pinmuxs = <&pinctrlj 4 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c1_clk_gpj5_default: i3c1_clk_gpj5_default {
+	/omit-if-no-ref/ i3c1_clk_gpj5_default: i3c1_clk_gpj5_default {
 		pinmuxs = <&pinctrlj 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c1_data_gpe1_default: i3c1_data_gpe1_default {
+	/omit-if-no-ref/ i3c1_data_gpe1_default: i3c1_data_gpe1_default {
 		pinmuxs = <&pinctrle 1 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c2_clk_gpe2_default: i3c2_clk_gpe2_default {
+	/omit-if-no-ref/ i3c2_clk_gpe2_default: i3c2_clk_gpe2_default {
 		pinmuxs = <&pinctrle 2 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c2_data_gpe3_default: i3c2_data_gpe3_default {
+	/omit-if-no-ref/ i3c2_data_gpe3_default: i3c2_data_gpe3_default {
 		pinmuxs = <&pinctrle 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c3_clk_gpf0_default: i3c3_clk_gpf0_default {
+	/omit-if-no-ref/ i3c3_clk_gpf0_default: i3c3_clk_gpf0_default {
 		pinmuxs = <&pinctrlf 0 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	i3c3_data_gpf1_default: i3c3_data_gpf1_default {
+	/omit-if-no-ref/ i3c3_data_gpf1_default: i3c3_data_gpf1_default {
 		pinmuxs = <&pinctrlf 1 IT8XXX2_ALT_FUNC_1>;
 	};
 
 	/* Keyboard alternate function */
-	kso0_default: kso0_gpk0_default: kso0_gpk0_default {
+	/omit-if-no-ref/ kso0_default: kso0_gpk0_default: kso0_gpk0_default {
 		pinmuxs = <&pinctrlk 0 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso1_default: kso1_gpk1_default: kso1_gpk1_default {
+	/omit-if-no-ref/ kso1_default: kso1_gpk1_default: kso1_gpk1_default {
 		pinmuxs = <&pinctrlk 1 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso2_default: kso2_gpk2_default: kso2_gpk2_default {
+	/omit-if-no-ref/ kso2_default: kso2_gpk2_default: kso2_gpk2_default {
 		pinmuxs = <&pinctrlk 2 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso3_default: kso3_gpk3_default: kso3_gpk3_default {
+	/omit-if-no-ref/ kso3_default: kso3_gpk3_default: kso3_gpk3_default {
 		pinmuxs = <&pinctrlk 3 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso4_default: kso4_gpk4_default: kso4_gpk4_default {
+	/omit-if-no-ref/ kso4_default: kso4_gpk4_default: kso4_gpk4_default {
 		pinmuxs = <&pinctrlk 4 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso5_default: kso5_gpk5_default: kso5_gpk5_default {
+	/omit-if-no-ref/ kso5_default: kso5_gpk5_default: kso5_gpk5_default {
 		pinmuxs = <&pinctrlk 5 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso6_default: kso6_gpk6_default: kso6_gpk6_default {
+	/omit-if-no-ref/ kso6_default: kso6_gpk6_default: kso6_gpk6_default {
 		pinmuxs = <&pinctrlk 6 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso7_default: kso7_gpk7_default: kso7_gpk7_default {
+	/omit-if-no-ref/ kso7_default: kso7_gpk7_default: kso7_gpk7_default {
 		pinmuxs = <&pinctrlk 7 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso8_default: kso8_gpl0_default: kso8_gpl0_default {
+	/omit-if-no-ref/ kso8_default: kso8_gpl0_default: kso8_gpl0_default {
 		pinmuxs = <&pinctrll 0 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso9_default: kso9_gpl1_default: kso9_gpl1_default {
+	/omit-if-no-ref/ kso9_default: kso9_gpl1_default: kso9_gpl1_default {
 		pinmuxs = <&pinctrll 1 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso10_default: kso10_gpl2_default: kso10_gpl2_default {
+	/omit-if-no-ref/ kso10_default: kso10_gpl2_default: kso10_gpl2_default {
 		pinmuxs = <&pinctrll 2 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso11_default: kso11_gpl3_default: kso11_gpl3_default {
+	/omit-if-no-ref/ kso11_default: kso11_gpl3_default: kso11_gpl3_default {
 		pinmuxs = <&pinctrll 3 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso12_default: kso12_gpl4_default: kso12_gpl4_default {
+	/omit-if-no-ref/ kso12_default: kso12_gpl4_default: kso12_gpl4_default {
 		pinmuxs = <&pinctrll 4 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso13_default: kso13_gpl5_default: kso13_gpl5_default {
+	/omit-if-no-ref/ kso13_default: kso13_gpl5_default: kso13_gpl5_default {
 		pinmuxs = <&pinctrll 5 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso14_default: kso14_gpl6_default: kso14_gpl6_default {
+	/omit-if-no-ref/ kso14_default: kso14_gpl6_default: kso14_gpl6_default {
 		pinmuxs = <&pinctrll 6 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso15_default: kso15_gpl7_default: kso15_gpl7_default {
+	/omit-if-no-ref/ kso15_default: kso15_gpl7_default: kso15_gpl7_default {
 		pinmuxs = <&pinctrll 7 IT8XXX2_ALT_FUNC_1>;
 		drive-open-drain;
 		bias-pull-up;
 	};
 
-	kso16_default: kso16_gpc3_default: kso16_gpc3_default {
+	/omit-if-no-ref/ kso16_default: kso16_gpc3_default: kso16_gpc3_default {
 		pinmuxs = <&pinctrlc 3 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	kso17_default: kso17_gpc5_default: kso17_gpc5_default {
+	/omit-if-no-ref/ kso17_default: kso17_gpc5_default: kso17_gpc5_default {
 		pinmuxs = <&pinctrlc 5 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi0_default: ksi0_gpn0_default: ksi0_gpn0_default {
+	/omit-if-no-ref/ ksi0_default: ksi0_gpn0_default: ksi0_gpn0_default {
 		pinmuxs = <&pinctrln 0 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi1_default: ksi1_gpn1_default: ksi1_gpn1_default {
+	/omit-if-no-ref/ ksi1_default: ksi1_gpn1_default: ksi1_gpn1_default {
 		pinmuxs = <&pinctrln 1 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi2_default: ksi2_gpn2_default: ksi2_gpn2_default {
+	/omit-if-no-ref/ ksi2_default: ksi2_gpn2_default: ksi2_gpn2_default {
 		pinmuxs = <&pinctrln 2 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi3_default: ksi3_gpn3_default: ksi3_gpn3_default {
+	/omit-if-no-ref/ ksi3_default: ksi3_gpn3_default: ksi3_gpn3_default {
 		pinmuxs = <&pinctrln 3 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi4_default: ksi4_gpn4_default: ksi4_gpn4_default {
+	/omit-if-no-ref/ ksi4_default: ksi4_gpn4_default: ksi4_gpn4_default {
 		pinmuxs = <&pinctrln 4 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi5_default: ksi5_gpn5_default: ksi5_gpn5_default {
+	/omit-if-no-ref/ ksi5_default: ksi5_gpn5_default: ksi5_gpn5_default {
 		pinmuxs = <&pinctrln 5 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi6_default: ksi6_gpn6_default: ksi6_gpn6_default {
+	/omit-if-no-ref/ ksi6_default: ksi6_gpn6_default: ksi6_gpn6_default {
 		pinmuxs = <&pinctrln 6 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
-	ksi7_default: ksi7_gpn7_default: ksi7_gpn7_default {
+	/omit-if-no-ref/ ksi7_default: ksi7_gpn7_default: ksi7_gpn7_default {
 		pinmuxs = <&pinctrln 7 IT8XXX2_ALT_FUNC_1>;
 		bias-pull-up;
 	};
 
 	/* PECI alternate function */
-	peci_gpf6_default: peci_gpf6_default {
+	/omit-if-no-ref/ peci_gpf6_default: peci_gpf6_default {
 		pinmuxs = <&pinctrlf 6 IT8XXX2_ALT_FUNC_3>;
 	};
 
 	/* PWM alternate function */
-	pwm0_gpa0_default: pwm0_gpa0_default {
+	/omit-if-no-ref/ pwm0_gpa0_default: pwm0_gpa0_default {
 		pinmuxs = <&pinctrla 0 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm1_gpa1_default: pwm1_gpa1_default {
+	/omit-if-no-ref/ pwm1_gpa1_default: pwm1_gpa1_default {
 		pinmuxs = <&pinctrla 1 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm2_gpa2_default: pwm2_gpa2_default {
+	/omit-if-no-ref/ pwm2_gpa2_default: pwm2_gpa2_default {
 		pinmuxs = <&pinctrla 2 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm3_gpa3_default: pwm3_gpa3_default {
+	/omit-if-no-ref/ pwm3_gpa3_default: pwm3_gpa3_default {
 		pinmuxs = <&pinctrla 3 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm4_gpa4_default: pwm4_gpa4_default {
+	/omit-if-no-ref/ pwm4_gpa4_default: pwm4_gpa4_default {
 		pinmuxs = <&pinctrla 4 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm5_gpa5_default: pwm5_gpa5_default {
+	/omit-if-no-ref/ pwm5_gpa5_default: pwm5_gpa5_default {
 		pinmuxs = <&pinctrla 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm6_gpa6_default: pwm6_gpa6_default {
+	/omit-if-no-ref/ pwm6_gpa6_default: pwm6_gpa6_default {
 		pinmuxs = <&pinctrla 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	pwm7_gpa7_default: pwm7_gpa7_default {
+	/omit-if-no-ref/ pwm7_gpa7_default: pwm7_gpa7_default {
 		pinmuxs = <&pinctrla 7 IT8XXX2_ALT_FUNC_1>;
 	};
 
 	/* SSPI alternate function */
-	ssce0_gpj7_default: ssce0_gpj7_default {
+	/omit-if-no-ref/ ssce0_gpj7_default: ssce0_gpj7_default {
 		pinmuxs = <&pinctrlj 7 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	ssce1_gph7_default: ssce1_gph7_default {
+	/omit-if-no-ref/ ssce1_gph7_default: ssce1_gph7_default {
 		pinmuxs = <&pinctrlh 7 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	ssck_gpa6_default: ssck_gpa6_default {
+	/omit-if-no-ref/ ssck_gpa6_default: ssck_gpa6_default {
 		pinmuxs = <&pinctrla 6 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	smosi_gpc6_default: smosi_gpc6_default {
+	/omit-if-no-ref/ smosi_gpc6_default: smosi_gpc6_default {
 		pinmuxs = <&pinctrlc 6 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	smiso_gpc4_default: smiso_gpc4_default {
+	/omit-if-no-ref/ smiso_gpc4_default: smiso_gpc4_default {
 		pinmuxs = <&pinctrlc 4 IT8XXX2_ALT_FUNC_3>;
 	};
 
 	/* Tachometer alternate function */
-	tach0a_gpd6_default: tach0a_gpd6_default {
+	/omit-if-no-ref/ tach0a_gpd6_default: tach0a_gpd6_default {
 		pinmuxs = <&pinctrld 6 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	tach1a_gpd7_default: tach1a_gpd7_default {
+	/omit-if-no-ref/ tach1a_gpd7_default: tach1a_gpd7_default {
 		pinmuxs = <&pinctrld 7 IT8XXX2_ALT_FUNC_1>;
 	};
 
-	tach2a_gpj0_default: tach2a_gpj0_default {
+	/omit-if-no-ref/ tach2a_gpj0_default: tach2a_gpj0_default {
 		pinmuxs = <&pinctrlj 0 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	tach0b_gpc6_default: tach0b_gpc6_default {
+	/omit-if-no-ref/ tach0b_gpc6_default: tach0b_gpc6_default {
 		pinmuxs = <&pinctrlc 6 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	tach1b_gpj6_default: tach1b_gpj6_default {
+	/omit-if-no-ref/ tach1b_gpj6_default: tach1b_gpj6_default {
 		pinmuxs = <&pinctrlj 6 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	tach2b_gpj1_default: tach2b_gpj1_default {
+	/omit-if-no-ref/ tach2b_gpj1_default: tach2b_gpj1_default {
 		pinmuxs = <&pinctrlj 1 IT8XXX2_ALT_FUNC_3>;
 	};
 
 	/* UART alternate function */
-	uart1_rx_gpc7_default: uart1_rx_gpc7_default {
+	/omit-if-no-ref/ uart1_rx_gpc7_default: uart1_rx_gpc7_default {
 		pinmuxs = <&pinctrlc 7 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	uart1_tx_gpe6_default: uart1_tx_gpe6_default {
+	/omit-if-no-ref/ uart1_tx_gpe6_default: uart1_tx_gpe6_default {
 		pinmuxs = <&pinctrle 6 IT8XXX2_ALT_FUNC_4>;
 	};
 
-	uart2_rx_gph1_default: uart2_rx_gph1_default {
+	/omit-if-no-ref/ uart2_rx_gph1_default: uart2_rx_gph1_default {
 		pinmuxs = <&pinctrlh 1 IT8XXX2_ALT_FUNC_3>;
 	};
 
-	uart2_tx_gph2_default: uart2_tx_gph2_default {
+	/omit-if-no-ref/ uart2_tx_gph2_default: uart2_tx_gph2_default {
 		pinmuxs = <&pinctrlh 2 IT8XXX2_ALT_FUNC_3>;
 	};
 };

--- a/dts/riscv/ite/it51xxx-wuc-map.dtsi
+++ b/dts/riscv/ite/it51xxx-wuc-map.dtsi
@@ -12,408 +12,408 @@
 		compatible = "ite,it51xxx-wuc-map";
 
 		/* WUC group 2 */
-		wuc_wu20: wu20 {
+		/omit-if-no-ref/ wuc_wu20: wu20 {
 			wucs = <&wuc2 BIT(0)>; /* GPD0 */
 		};
 
-		wuc_wu21: wu21 {
+		/omit-if-no-ref/ wuc_wu21: wu21 {
 			wucs = <&wuc2 BIT(1)>; /* GPD1 */
 		};
 
-		wuc_wu22: wu22 {
+		/omit-if-no-ref/ wuc_wu22: wu22 {
 			wucs = <&wuc2 BIT(2)>; /* GPC4 */
 		};
 
-		wuc_wu23: wu23 {
+		/omit-if-no-ref/ wuc_wu23: wu23 {
 			wucs = <&wuc2 BIT(3)>; /* GPC6 */
 		};
 
-		wuc_wu24: wu24 {
+		/omit-if-no-ref/ wuc_wu24: wu24 {
 			wucs = <&wuc2 BIT(4)>; /* GPD2 */
 		};
 
-		wuc_wu25: wu25 {
+		/omit-if-no-ref/ wuc_wu25: wu25 {
 			wucs = <&wuc2 BIT(5)>; /* GPB3 */
 		};
 
 		/* WUC group 3 */
-		wuc_wu30: wu30 {
+		/omit-if-no-ref/ wuc_wu30: wu30 {
 			wucs = <&wuc3 BIT(0)>; /* KSI[0] */
 		};
 
-		wuc_wu31: wu31 {
+		/omit-if-no-ref/ wuc_wu31: wu31 {
 			wucs = <&wuc3 BIT(1)>; /* KSI[1] */
 		};
 
-		wuc_wu32: wu32 {
+		/omit-if-no-ref/ wuc_wu32: wu32 {
 			wucs = <&wuc3 BIT(2)>; /* KSI[2] */
 		};
 
-		wuc_wu33: wu33 {
+		/omit-if-no-ref/ wuc_wu33: wu33 {
 			wucs = <&wuc3 BIT(3)>; /* KSI[3] */
 		};
 
-		wuc_wu34: wu34 {
+		/omit-if-no-ref/ wuc_wu34: wu34 {
 			wucs = <&wuc3 BIT(4)>; /* KSI[4] */
 		};
 
-		wuc_wu35: wu35 {
+		/omit-if-no-ref/ wuc_wu35: wu35 {
 			wucs = <&wuc3 BIT(5)>; /* KSI[5] */
 		};
 
-		wuc_wu36: wu36 {
+		/omit-if-no-ref/ wuc_wu36: wu36 {
 			wucs = <&wuc3 BIT(6)>; /* KSI[6] */
 		};
 
-		wuc_wu37: wu37 {
+		/omit-if-no-ref/ wuc_wu37: wu37 {
 			wucs = <&wuc3 BIT(7)>; /* KSI[7] */
 		};
 
 		/* WUC group 4 */
-		wuc_wu40: wu40 {
+		/omit-if-no-ref/ wuc_wu40: wu40 {
 			wucs = <&wuc4 BIT(0)>; /* GPE5 */
 		};
 
-		wuc_wu42: wu42 {
+		/omit-if-no-ref/ wuc_wu42: wu42 {
 			wucs = <&wuc4 BIT(2)>; /* eSPI transaction */
 		};
 
-		wuc_wu45: wu45 {
+		/omit-if-no-ref/ wuc_wu45: wu45 {
 			wucs = <&wuc4 BIT(5)>; /* GPE6 */
 		};
 
-		wuc_wu46: wu46 {
+		/omit-if-no-ref/ wuc_wu46: wu46 {
 			wucs = <&wuc4 BIT(6)>; /* GPE7 */
 		};
 
 		/* WUC group 6 */
-		wuc_wu60: wu60 {
+		/omit-if-no-ref/ wuc_wu60: wu60 {
 			wucs = <&wuc6 BIT(0)>; /* GPH0 */
 		};
 
-		wuc_wu61: wu61 {
+		/omit-if-no-ref/ wuc_wu61: wu61 {
 			wucs = <&wuc6 BIT(1)>; /* GPH1 */
 		};
 
-		wuc_wu62: wu62 {
+		/omit-if-no-ref/ wuc_wu62: wu62 {
 			wucs = <&wuc6 BIT(2)>; /* GPH2 */
 		};
 
-		wuc_wu63: wu63 {
+		/omit-if-no-ref/ wuc_wu63: wu63 {
 			wucs = <&wuc6 BIT(3)>; /* GPH3 */
 		};
 
-		wuc_wu64: wu64 {
+		/omit-if-no-ref/ wuc_wu64: wu64 {
 			wucs = <&wuc6 BIT(4)>; /* GPF4 */
 		};
 
-		wuc_wu65: wu65 {
+		/omit-if-no-ref/ wuc_wu65: wu65 {
 			wucs = <&wuc6 BIT(5)>; /* GPF5 */
 		};
 
-		wuc_wu66: wu66 {
+		/omit-if-no-ref/ wuc_wu66: wu66 {
 			wucs = <&wuc6 BIT(6)>; /* GPF6 */
 		};
 
-		wuc_wu67: wu67 {
+		/omit-if-no-ref/ wuc_wu67: wu67 {
 			wucs = <&wuc6 BIT(7)>; /* GPF7 */
 		};
 
 		/* WUC group 7 */
-		wuc_wu70: wu70 {
+		/omit-if-no-ref/ wuc_wu70: wu70 {
 			wucs = <&wuc7 BIT(0)>; /* GPE0 */
 		};
 
-		wuc_wu71: wu71 {
+		/omit-if-no-ref/ wuc_wu71: wu71 {
 			wucs = <&wuc7 BIT(1)>; /* GPE1 */
 		};
 
-		wuc_wu72: wu72 {
+		/omit-if-no-ref/ wuc_wu72: wu72 {
 			wucs = <&wuc7 BIT(2)>; /* GPE2 */
 		};
 
-		wuc_wu73: wu73 {
+		/omit-if-no-ref/ wuc_wu73: wu73 {
 			wucs = <&wuc7 BIT(3)>; /* GPE3 */
 		};
 
-		wuc_wu74: wu74 {
+		/omit-if-no-ref/ wuc_wu74: wu74 {
 			wucs = <&wuc7 BIT(4)>; /* GPI4 */
 		};
 
-		wuc_wu75: wu75 {
+		/omit-if-no-ref/ wuc_wu75: wu75 {
 			wucs = <&wuc7 BIT(5)>; /* GPI5 */
 		};
 
-		wuc_wu76: wu76 {
+		/omit-if-no-ref/ wuc_wu76: wu76 {
 			wucs = <&wuc7 BIT(6)>; /* GPI6 */
 		};
 
-		wuc_wu77: wu77 {
+		/omit-if-no-ref/ wuc_wu77: wu77 {
 			wucs = <&wuc7 BIT(7)>; /* GPI7 */
 		};
 
 		/* WUC group 8 */
-		wuc_wu80: wu80 {
+		/omit-if-no-ref/ wuc_wu80: wu80 {
 			wucs = <&wuc8 BIT(0)>; /* GPA3 */
 		};
 
-		wuc_wu81: wu81 {
+		/omit-if-no-ref/ wuc_wu81: wu81 {
 			wucs = <&wuc8 BIT(1)>; /* GPA4 */
 		};
 
-		wuc_wu82: wu82 {
+		/omit-if-no-ref/ wuc_wu82: wu82 {
 			wucs = <&wuc8 BIT(2)>; /* GPA5 */
 		};
 
-		wuc_wu83: wu83 {
+		/omit-if-no-ref/ wuc_wu83: wu83 {
 			wucs = <&wuc8 BIT(3)>; /* GPA6 */
 		};
 
-		wuc_wu84: wu84 {
+		/omit-if-no-ref/ wuc_wu84: wu84 {
 			wucs = <&wuc8 BIT(4)>; /* GPB2 */
 		};
 
-		wuc_wu85: wu85 {
+		/omit-if-no-ref/ wuc_wu85: wu85 {
 			wucs = <&wuc8 BIT(5)>; /* GPC0 */
 		};
 
-		wuc_wu86: wu86 {
+		/omit-if-no-ref/ wuc_wu86: wu86 {
 			wucs = <&wuc8 BIT(6)>; /* GPC7 */
 		};
 
-		wuc_wu87: wu87 {
+		/omit-if-no-ref/ wuc_wu87: wu87 {
 			wucs = <&wuc8 BIT(7)>; /* GPD7 */
 		};
 
 		/* WUC group 9 */
-		wuc_wu88: wu88 {
+		/omit-if-no-ref/ wuc_wu88: wu88 {
 			wucs = <&wuc9 BIT(0)>; /* GPH4 */
 		};
 
-		wuc_wu89: wu89 {
+		/omit-if-no-ref/ wuc_wu89: wu89 {
 			wucs = <&wuc9 BIT(1)>; /* GPH5 */
 		};
 
-		wuc_wu90: wu90 {
+		/omit-if-no-ref/ wuc_wu90: wu90 {
 			wucs = <&wuc9 BIT(2)>; /* GPH6 */
 		};
 
-		wuc_wu91: wu91 {
+		/omit-if-no-ref/ wuc_wu91: wu91 {
 			wucs = <&wuc9 BIT(3)>; /* GPA0 */
 		};
 
-		wuc_wu92: wu92 {
+		/omit-if-no-ref/ wuc_wu92: wu92 {
 			wucs = <&wuc9 BIT(4)>; /* GPA1 */
 		};
 
-		wuc_wu93: wu93 {
+		/omit-if-no-ref/ wuc_wu93: wu93 {
 			wucs = <&wuc9 BIT(5)>; /* GPA2 */
 		};
 
-		wuc_wu95: wu95 {
+		/omit-if-no-ref/ wuc_wu95: wu95 {
 			wucs = <&wuc9 BIT(7)>; /* GPC2 */
 		};
 
 		/* WUC group 10 */
-		wuc_wu96: wu96 {
+		/omit-if-no-ref/ wuc_wu96: wu96 {
 			wucs = <&wuc10 BIT(0)>; /* GPF0 */
 		};
 
-		wuc_wu97: wu97 {
+		/omit-if-no-ref/ wuc_wu97: wu97 {
 			wucs = <&wuc10 BIT(1)>; /* GPF1 */
 		};
 
-		wuc_wu98: wu98 {
+		/omit-if-no-ref/ wuc_wu98: wu98 {
 			wucs = <&wuc10 BIT(2)>; /* GPF2 */
 		};
 
-		wuc_wu99: wu99 {
+		/omit-if-no-ref/ wuc_wu99: wu99 {
 			wucs = <&wuc10 BIT(3)>; /* GPF3 */
 		};
 
-		wuc_wu100: wu100 {
+		/omit-if-no-ref/ wuc_wu100: wu100 {
 			wucs = <&wuc10 BIT(4)>; /* GPA7 */
 		};
 
-		wuc_wu101: wu101 {
+		/omit-if-no-ref/ wuc_wu101: wu101 {
 			wucs = <&wuc10 BIT(5)>; /* GPB0 */
 		};
 
-		wuc_wu102: wu102 {
+		/omit-if-no-ref/ wuc_wu102: wu102 {
 			wucs = <&wuc10 BIT(6)>; /* GPB1 */
 		};
 
-		wuc_wu103: wu103 {
+		/omit-if-no-ref/ wuc_wu103: wu103 {
 			wucs = <&wuc10 BIT(7)>; /* GPB3 */
 		};
 
 		/* WUC group 11 */
-		wuc_wu104: wu104 {
+		/omit-if-no-ref/ wuc_wu104: wu104 {
 			wucs = <&wuc11 BIT(0)>; /* GPB5 */
 		};
 
-		wuc_wu105: wu105 {
+		/omit-if-no-ref/ wuc_wu105: wu105 {
 			wucs = <&wuc11 BIT(1)>; /* GPB6 */
 		};
 
-		wuc_wu107: wu107 {
+		/omit-if-no-ref/ wuc_wu107: wu107 {
 			wucs = <&wuc11 BIT(3)>; /* GPC1 */
 		};
 
-		wuc_wu108: wu108 {
+		/omit-if-no-ref/ wuc_wu108: wu108 {
 			wucs = <&wuc11 BIT(4)>; /* GPC3 */
 		};
 
-		wuc_wu109: wu109 {
+		/omit-if-no-ref/ wuc_wu109: wu109 {
 			wucs = <&wuc11 BIT(5)>; /* GPC5 */
 		};
 
-		wuc_wu110: wu110 {
+		/omit-if-no-ref/ wuc_wu110: wu110 {
 			wucs = <&wuc11 BIT(6)>; /* GPD3 */
 		};
 
-		wuc_wu111: wu111 {
+		/omit-if-no-ref/ wuc_wu111: wu111 {
 			wucs = <&wuc11 BIT(7)>; /* GPD4 */
 		};
 
 		/* WUC group 12 */
-		wuc_wu112: wu112 {
+		/omit-if-no-ref/ wuc_wu112: wu112 {
 			wucs = <&wuc12 BIT(0)>; /* GPD5 */
 		};
 
-		wuc_wu113: wu113 {
+		/omit-if-no-ref/ wuc_wu113: wu113 {
 			wucs = <&wuc12 BIT(1)>; /* GPD6 */
 		};
 
-		wuc_wu114: wu114 {
+		/omit-if-no-ref/ wuc_wu114: wu114 {
 			wucs = <&wuc12 BIT(2)>; /* GPE4 */
 		};
 
-		wuc_wu115: wu115 {
+		/omit-if-no-ref/ wuc_wu115: wu115 {
 			wucs = <&wuc12 BIT(3)>; /* GPG0 */
 		};
 
-		wuc_wu116: wu116 {
+		/omit-if-no-ref/ wuc_wu116: wu116 {
 			wucs = <&wuc12 BIT(4)>; /* GPG1 */
 		};
 
-		wuc_wu117: wu117 {
+		/omit-if-no-ref/ wuc_wu117: wu117 {
 			wucs = <&wuc12 BIT(5)>; /* GPG2 */
 		};
 
-		wuc_wu118: wu118 {
+		/omit-if-no-ref/ wuc_wu118: wu118 {
 			wucs = <&wuc12 BIT(6)>; /* GPG6 */
 		};
 
-		wuc_wu119: wu119 {
+		/omit-if-no-ref/ wuc_wu119: wu119 {
 			wucs = <&wuc12 BIT(7)>; /* GPI0 */
 		};
 
 		/* WUC group 13 */
-		wuc_wu120: wu120 {
+		/omit-if-no-ref/ wuc_wu120: wu120 {
 			wucs = <&wuc13 BIT(0)>; /* GPI1 */
 		};
 
-		wuc_wu121: wu121 {
+		/omit-if-no-ref/ wuc_wu121: wu121 {
 			wucs = <&wuc13 BIT(1)>; /* GPI2 */
 		};
 
-		wuc_wu122: wu122 {
+		/omit-if-no-ref/ wuc_wu122: wu122 {
 			wucs = <&wuc13 BIT(2)>; /* GPI3 */
 		};
 
-		wuc_wu127: wu127 {
+		/omit-if-no-ref/ wuc_wu127: wu127 {
 			wucs = <&wuc13 BIT(7)>; /* GPH7 */
 		};
 
 		/* WUC group 14 */
-		wuc_wu128: wu128 {
+		/omit-if-no-ref/ wuc_wu128: wu128 {
 			wucs = <&wuc14 BIT(0)>; /* GPJ0 */
 		};
 
-		wuc_wu129: wu129 {
+		/omit-if-no-ref/ wuc_wu129: wu129 {
 			wucs = <&wuc14 BIT(1)>; /* GPJ1 */
 		};
 
-		wuc_wu131: wu131 {
+		/omit-if-no-ref/ wuc_wu131: wu131 {
 			wucs = <&wuc14 BIT(3)>; /* GPJ3 */
 		};
 
-		wuc_wu132: wu132 {
+		/omit-if-no-ref/ wuc_wu132: wu132 {
 			wucs = <&wuc14 BIT(4)>; /* GPJ4 */
 		};
 
-		wuc_wu133: wu133 {
+		/omit-if-no-ref/ wuc_wu133: wu133 {
 			wucs = <&wuc14 BIT(5)>; /* GPJ5 */
 		};
 
-		wuc_wu134: wu134 {
+		/omit-if-no-ref/ wuc_wu134: wu134 {
 			wucs = <&wuc14 BIT(6)>; /* GPJ6 */
 		};
 
-		wuc_wu135: wu135 {
+		/omit-if-no-ref/ wuc_wu135: wu135 {
 			wucs = <&wuc14 BIT(7)>; /* GPJ7 */
 		};
 
 		/* WUC group 15 */
-		wuc_wu136: wu136 {
+		/omit-if-no-ref/ wuc_wu136: wu136 {
 			wucs = <&wuc15 BIT(0)>; /* GPL0 */
 		};
 
-		wuc_wu137: wu137 {
+		/omit-if-no-ref/ wuc_wu137: wu137 {
 			wucs = <&wuc15 BIT(1)>; /* GPL1 */
 		};
 
-		wuc_wu138: wu138 {
+		/omit-if-no-ref/ wuc_wu138: wu138 {
 			wucs = <&wuc15 BIT(2)>; /* GPL2 */
 		};
 
-		wuc_wu139: wu139 {
+		/omit-if-no-ref/ wuc_wu139: wu139 {
 			wucs = <&wuc15 BIT(3)>; /* GPL3 */
 		};
 
-		wuc_wu140: wu140 {
+		/omit-if-no-ref/ wuc_wu140: wu140 {
 			wucs = <&wuc15 BIT(4)>; /* GPL4 */
 		};
 
-		wuc_wu141: wu141 {
+		/omit-if-no-ref/ wuc_wu141: wu141 {
 			wucs = <&wuc15 BIT(5)>; /* GPL5 */
 		};
 
-		wuc_wu142: wu142 {
+		/omit-if-no-ref/ wuc_wu142: wu142 {
 			wucs = <&wuc15 BIT(6)>; /* GPL6 */
 		};
 
 		/* WUC group 16 */
-		wuc_wu144: wu144 {
+		/omit-if-no-ref/ wuc_wu144: wu144 {
 			wucs = <&wuc16 BIT(0)>; /* GPM0 */
 		};
 
-		wuc_wu145: wu145 {
+		/omit-if-no-ref/ wuc_wu145: wu145 {
 			wucs = <&wuc16 BIT(1)>; /* GPM1 */
 		};
 
-		wuc_wu146: wu146 {
+		/omit-if-no-ref/ wuc_wu146: wu146 {
 			wucs = <&wuc16 BIT(2)>; /* GPM2 */
 		};
 
-		wuc_wu147: wu147 {
+		/omit-if-no-ref/ wuc_wu147: wu147 {
 			wucs = <&wuc16 BIT(3)>; /* GPM3 */
 		};
 
-		wuc_wu148: wu148 {
+		/omit-if-no-ref/ wuc_wu148: wu148 {
 			wucs = <&wuc16 BIT(4)>; /* GPM4 */
 		};
 
-		wuc_wu149: wu149 {
+		/omit-if-no-ref/ wuc_wu149: wu149 {
 			wucs = <&wuc16 BIT(5)>; /* GPM5 */
 		};
 
-		wuc_wu150: wu150 {
+		/omit-if-no-ref/ wuc_wu150: wu150 {
 			wucs = <&wuc16 BIT(6)>; /* GPM6 */
 		};
 
-		wuc_no_func: no_func {
+		/omit-if-no-ref/ wuc_no_func: no_func {
 			wucs = <&wuc_fake 0>;
 		};
 	};


### PR DESCRIPTION
This commit prefixes pre-generated nodes with `/omit-if-no-ref/` to keep the generated devicetree C headers minimal.