### PR TITLE
net: posix: Avoid multiple definitions of IFNAMSIZ symbol

### DIFF
--- a/include/zephyr/net/net_compat.h
+++ b/include/zephyr/net/net_compat.h
@@ -140,7 +140,9 @@ extern "C" {
 #define IN6ADDR_ANY_INIT       NET_IN6ADDR_ANY_INIT
 #define IN6ADDR_LOOPBACK_INIT  NET_IN6ADDR_LOOPBACK_INIT
 
+#if !defined(IFNAMSIZ)
 #define IFNAMSIZ NET_IFNAMSIZ
+#endif /* IFNAMSIZ */
 
 #define in_pktinfo   net_in_pktinfo
 #define ip_mreqn     net_ip_mreqn


### PR DESCRIPTION
One might see this compile error depending on what order the POSIX headers are included

include/zephyr/net/net_compat.h:143: error: "IFNAMSIZ" redefined .../zephyr/include/zephyr/net/net_compat.h:143:
                                error: "IFNAMSIZ" redefined [-Werror]
  143 | #define IFNAMSIZ NET_IFNAMSIZ
      |
In file included from ...
.../zephyr/include/zephyr/posix/net/if.h:16:
                note: this is the location of the previous definition
   16 | #define IFNAMSIZ IF_NAMESIZE
      |