### PR TITLE
testsuite: Correct broken link to coverage documentation

### DIFF
--- a/subsys/testsuite/Kconfig.coverage
+++ b/subsys/testsuite/Kconfig.coverage
@@ -17,7 +17,7 @@ config COVERAGE
 	  This option will build your application with the -coverage option
 	  which will generate data that can be used to create coverage reports.
 	  For more information see
-	  https://docs.zephyrproject.org/latest/guides/coverage.html
+	  https://docs.zephyrproject.org/latest/develop/test/coverage.html
 
 choice
 	prompt "Coverage mode"


### PR DESCRIPTION
The existing documentation link pointed to a non-existent page. Update the link to use the current documentation URL.

The existing link is not covered by the [redirects.py](https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/_scripts/redirects.py#L152) entry:
```py
('guides/test/coverage', 'develop/test/coverage'),
```