### PR TITLE
video: Some trivial misc fixes and adds

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -28,8 +28,9 @@ config VIDEO_BUFFER_POOL_HEAP_SIZE
 	default 2097152
 
 config VIDEO_BUFFER_POOL_NUM_MAX
-	int "Number of maximum sized buffer in the video pool"
+	int "Number of buffers in the video buffer pool"
 	default 2
+	range 1 65535
 
 config VIDEO_BUFFER_POOL_ALIGN
 	int "Alignment of the video pool’s buffer"

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -571,7 +571,7 @@ static const struct ov5640_mode_config csi2_modes[] = {
 		.def_frmrate = OV5640_30_FPS,
 	}};
 
-static const int ov5640_frame_rates[] = {OV5640_15_FPS, OV5640_30_FPS, OV5640_60_FPS};
+static const int ov5640_frame_rates[] = {OV5640_60_FPS, OV5640_30_FPS, OV5640_15_FPS};
 
 /* Initialization sequence for QQVGA resolution (160x120) */
 static const struct video_reg16 dvp_160x120_res_params[] = {

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -62,23 +62,14 @@ static void *video_buffer_k_heap_aligned_alloc(size_t align, size_t bytes, k_tim
 
 static struct video_buffer video_buf[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
 
-struct mem_block {
-	void *data;
-};
-
-static struct mem_block video_block[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
-
 struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_timeout_t timeout)
 {
 	struct video_buffer *vbuf = NULL;
-	struct mem_block *block;
-	int i;
 
 	/* find available video buffer */
-	for (i = 0; i < ARRAY_SIZE(video_buf); i++) {
+	for (uint16_t i = 0; i < ARRAY_SIZE(video_buf); i++) {
 		if (video_buf[i].buffer == NULL) {
 			vbuf = &video_buf[i];
-			block = &video_block[i];
 			break;
 		}
 	}
@@ -88,12 +79,11 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_tim
 	}
 
 	/* Alloc buffer memory */
-	block->data = VIDEO_COMMON_HEAP_ALLOC(align, size, timeout);
-	if (block->data == NULL) {
+	vbuf->buffer = VIDEO_COMMON_HEAP_ALLOC(align, size, timeout);
+	if (vbuf->buffer == NULL) {
 		return NULL;
 	}
 
-	vbuf->buffer = block->data;
 	vbuf->size = size;
 	vbuf->bytesused = 0;
 
@@ -107,22 +97,22 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
 
 void video_buffer_release(struct video_buffer *vbuf)
 {
-	struct mem_block *block = NULL;
-	int i;
+	if (vbuf == NULL || vbuf->buffer == NULL) {
+		return;
+	}
 
-	__ASSERT_NO_MSG(vbuf != NULL);
-
-	/* vbuf to block */
-	for (i = 0; i < ARRAY_SIZE(video_block); i++) {
-		if (video_block[i].data == vbuf->buffer) {
-			block = &video_block[i];
+	for (uint16_t i = 0; i < ARRAY_SIZE(video_buf); i++) {
+		if (video_buf[i].buffer == vbuf->buffer) {
+			video_buf[i].buffer = NULL;
+			video_buf[i].size = 0;
+			video_buf[i].bytesused = 0;
 			break;
 		}
 	}
 
-	vbuf->buffer = NULL;
-	if (block) {
-		VIDEO_COMMON_FREE(block->data);
+	if (vbuf->buffer != NULL) {
+		VIDEO_COMMON_FREE(vbuf->buffer);
+		vbuf->buffer = NULL;
 	}
 }
 

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -489,6 +489,8 @@ static inline const char *video_get_ctrl_name(uint32_t id)
 		return "Brightness, Automatic";
 	case VIDEO_CID_BAND_STOP_FILTER:
 		return "Band-Stop Filter";
+	case VIDEO_CID_ROTATE:
+		return "Rotate";
 	case VIDEO_CID_ALPHA_COMPONENT:
 		return "Alpha Component";
 

--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -152,6 +152,13 @@ enum video_colorfx {
  */
 #define VIDEO_CID_BAND_STOP_FILTER (VIDEO_CID_BASE + 33)
 
+/**
+ * @brief Rotate control
+ *
+ * Rotate the image by a given angle, e.g. 90, 180, 270 degree.
+ */
+#define VIDEO_CID_ROTATE (VIDEO_CID_BASE + 34)
+
 /** Sets the alpha color component.
  * Some devices produce data with a user-controllable alpha component. Set the value applied to
  * the alpha channel of every pixel produced.

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -137,8 +137,8 @@ struct video_buffer {
 	enum video_buf_type type;
 	/** pointer to the start of the buffer. */
 	uint8_t *buffer;
-	/** index of the buffer, optionally set by the application */
-	uint8_t index;
+	/** index of the buffer in the video buffer pool */
+	uint16_t index;
 	/** size of the buffer in bytes. */
 	uint32_t size;
 	/** number of bytes occupied by the valid data in the buffer. */

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -46,9 +46,9 @@ struct video_control;
  */
 enum video_buf_type {
 	/** input buffer type */
-	VIDEO_BUF_TYPE_INPUT,
+	VIDEO_BUF_TYPE_INPUT = 1,
 	/** output buffer type */
-	VIDEO_BUF_TYPE_OUTPUT,
+	VIDEO_BUF_TYPE_OUTPUT = 2,
 };
 
 /**

--- a/tests/drivers/video/api/src/video_emul.c
+++ b/tests/drivers/video/api/src/video_emul.c
@@ -25,7 +25,7 @@ ZTEST(video_common, test_video_device)
 
 ZTEST(video_common, test_video_format)
 {
-	struct video_caps caps = {0};
+	struct video_caps caps = {.type = VIDEO_BUF_TYPE_OUTPUT};
 	struct video_format fmt = {0};
 
 	zexpect_ok(video_get_caps(imager_dev, &caps));


### PR DESCRIPTION
- video: controls: Add VIDEO_CID_ROTATE
- drivers: video: ov5640: Expose the high framerates first
- drivers: video: video_common: Drop mem_block structure
- include: drivers: video: Add YVU multi-planar formats
- include: drivers: video: Explicitly assign values to video_buf_type
- include: drivers: video: Use uint16 for buffer index