### PR TITLE
sensor: adi: adxl372: stream: check return value of adxl372_set_op_mode

### DIFF
--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -114,7 +114,10 @@ void adxl372_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 		adxl372_configure_fifo(dev, current_fifo_mode, data->fifo_config.fifo_format,
 					data->fifo_config.fifo_samples);
 
-		adxl372_set_op_mode(dev, cfg_372->op_mode);
+		rc = adxl372_set_op_mode(dev, cfg_372->op_mode);
+		if (rc < 0) {
+			return;
+		}
 	}
 
 	rc = gpio_pin_interrupt_configure_dt(&cfg_372->interrupt, GPIO_INT_EDGE_TO_ACTIVE);


### PR DESCRIPTION
Check the return value of adxl372_set_op_mode() in adxl372_submit_stream() and abort on error.

CID: 516239

Fix https://github.com/zephyrproject-rtos/zephyr/issues/90537