### PR TITLE
soc: st: stm32wb: implement CMake Linker Generator support

### DIFF
--- a/soc/st/stm32/stm32wbx/CMakeLists.txt
+++ b/soc/st/stm32/stm32wbx/CMakeLists.txt
@@ -3,10 +3,18 @@ zephyr_sources(
   soc.c
   )
 
-zephyr_linker_sources_ifdef(CONFIG_BT_STM32_IPM
-  SECTIONS
-  ipm.ld
-  )
+if(CONFIG_BT_STM32_IPM)
+  if(CONFIG_CMAKE_LINKER_GENERATOR)
+    zephyr_linker_section(NAME MAPPING_TABLE TYPE NOLOAD VMA SRAM1 NOINPUT)
+    zephyr_linker_section_configure(SECTION MAPPING_TABLE INPUT "MAPPING_TABLE" SYMBOLS _sMAPPING_TABLE _eMAPPING_TABLE)
+    zephyr_linker_section(NAME MB_MEM1 TYPE NOLOAD VMA SRAM1 NOINPUT)
+    zephyr_linker_section_configure(SECTION MB_MEM1 INPUT "MB_MEM1" SYMBOLS _sMB_MEM1 _eMB_MEM1)
+    zephyr_linker_section(NAME MB_MEM2 TYPE NOLOAD VMA SRAM1 NOINPUT)
+    zephyr_linker_section_configure(SECTION MB_MEM2 INPUT "MB_MEM2" SYMBOLS _sMB_MEM2 _eMB_MEM2)
+  else()
+    zephyr_linker_sources(SECTIONS ipm.ld)
+  endif()
+endif()
 
 zephyr_sources_ifdef(CONFIG_PM
   power.c


### PR DESCRIPTION
Add support for the CMake Linker Generator to STM32WB series.