### PR TITLE
video: Add video_transform_caps API

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -248,6 +248,7 @@ New APIs and options
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE`
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION`
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME`
+  * :c:func:`video_transform_cap`
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1446,6 +1446,7 @@ static int stm32_dcmipp_get_caps(const struct device *dev, struct video_caps *ca
 	}
 
 	caps->min_vbuf_count = 1;
+	caps->buf_align = 16;
 
 	return 0;
 }

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -122,6 +122,8 @@ struct video_caps {
 	 * the stream.
 	 */
 	uint8_t min_vbuf_count;
+	/** requirement on the buffer alignment, in bytes */
+	size_t buf_align;
 };
 
 /**

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -405,8 +405,9 @@ static inline int video_set_format(const struct device *dev, struct video_format
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(fmt != NULL);
+	if (dev == NULL || fmt == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_format == NULL) {
@@ -430,8 +431,9 @@ static inline int video_get_format(const struct device *dev, struct video_format
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(fmt != NULL);
+	if (dev == NULL || fmt == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->get_format == NULL) {
@@ -461,8 +463,9 @@ static inline int video_set_frmival(const struct device *dev, struct video_frmiv
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(frmival != NULL);
+	if (dev == NULL || frmival == NULL) {
+		return -EINVAL;
+	}
 
 	if (frmival->numerator == 0 || frmival->denominator == 0) {
 		return -EINVAL;
@@ -493,8 +496,9 @@ static inline int video_get_frmival(const struct device *dev, struct video_frmiv
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(frmival != NULL);
+	if (dev == NULL || frmival == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->get_frmival == NULL) {
@@ -525,9 +529,9 @@ static inline int video_enum_frmival(const struct device *dev, struct video_frmi
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(fie != NULL);
-	__ASSERT_NO_MSG(fie->format != NULL);
+	if (dev == NULL || fie == NULL || fie->format == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->enum_frmival == NULL) {
@@ -554,9 +558,9 @@ static inline int video_enqueue(const struct device *dev, struct video_buffer *b
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(buf != NULL);
-	__ASSERT_NO_MSG(buf->buffer != NULL);
+	if (dev == NULL || buf == NULL || buf->buffer == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->enqueue == NULL) {
@@ -585,8 +589,9 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(buf != NULL);
+	if (dev == NULL || buf == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->dequeue == NULL) {
@@ -613,7 +618,9 @@ static inline int video_flush(const struct device *dev, bool cancel)
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
+	if (dev == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->flush == NULL) {
@@ -635,14 +642,17 @@ static inline int video_flush(const struct device *dev, bool cancel)
  * @param dev Pointer to the device structure.
  * @param type The type of the buffers stream to start.
  *
- * @retval 0 Is successful.
+ * @retval 0 Successful.
+ * @retval -EINVAL Parameters are invalid.
  * @retval -EIO General input / output error.
  */
 static inline int video_stream_start(const struct device *dev, enum video_buf_type type)
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
+	if (dev == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_stream == NULL) {
@@ -661,7 +671,8 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
  * @param dev Pointer to the device structure.
  * @param type The type of the buffers stream to stop.
  *
- * @retval 0 Is successful.
+ * @retval 0 Successful.
+ * @retval -EINVAL Parameters are invalid.
  * @retval -EIO General input / output error.
  */
 static inline int video_stream_stop(const struct device *dev, enum video_buf_type type)
@@ -669,7 +680,9 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 	const struct video_driver_api *api;
 	int ret;
 
-	__ASSERT_NO_MSG(dev != NULL);
+	if (dev == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_stream == NULL) {
@@ -694,8 +707,10 @@ static inline int video_get_caps(const struct device *dev, struct video_caps *ca
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(caps != NULL);
+	if (dev == NULL || caps == NULL ||
+	    (caps->type != VIDEO_BUF_TYPE_INPUT && caps->type != VIDEO_BUF_TYPE_OUTPUT)) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->get_caps == NULL) {
@@ -786,8 +801,9 @@ static inline int video_set_signal(const struct device *dev, struct k_poll_signa
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(sig != NULL);
+	if (dev == NULL || sig == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_signal == NULL) {
@@ -820,8 +836,9 @@ static inline int video_set_selection(const struct device *dev, struct video_sel
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(sel != NULL);
+	if (dev == NULL || sel == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_selection == NULL) {
@@ -852,8 +869,9 @@ static inline int video_get_selection(const struct device *dev, struct video_sel
 {
 	const struct video_driver_api *api;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(sel != NULL);
+	if (dev == NULL || sel == NULL) {
+		return -EINVAL;
+	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->get_selection == NULL) {
@@ -913,8 +931,9 @@ int video_format_caps_index(const struct video_format_cap *fmts, const struct vi
  */
 static inline uint64_t video_frmival_nsec(const struct video_frmival *frmival)
 {
-	__ASSERT_NO_MSG(frmival != NULL);
-	__ASSERT_NO_MSG(frmival->denominator != 0);
+	if (frmival == NULL || frmival->denominator == 0) {
+		return -EINVAL;
+	}
 
 	return (uint64_t)NSEC_PER_SEC * frmival->numerator / frmival->denominator;
 }

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -19,7 +19,7 @@
  * @brief Interfaces for video devices.
  * @defgroup video_interface Video
  * @since 2.1
- * @version 1.1.0
+ * @version 1.2.0
  * @ingroup io_interfaces
  * @{
  */
@@ -353,6 +353,18 @@ typedef int (*video_api_ctrl_t)(const struct device *dev, uint32_t cid);
 typedef int (*video_api_get_caps_t)(const struct device *dev, struct video_caps *caps);
 
 /**
+ * @typedef video_api_transform_cap_t
+ * @brief Function pointer type for transforming a @ref video_format_cap from one end
+ * to the other end of a m2m video device.
+ *
+ * See @ref video_transform_cap for argument descriptions.
+ */
+typedef int (*video_api_transform_cap_t)(const struct device *const dev,
+					 const struct video_format_cap *const cap,
+					 struct video_format_cap *const res_cap,
+					 enum video_buf_type type, uint16_t ind);
+
+/**
  * @typedef video_api_set_signal_t
  * @brief Register/Unregister poll signal for buffer events.
  *
@@ -386,6 +398,8 @@ __subsystem struct video_driver_api {
 	video_api_enum_frmival_t enum_frmival;
 	video_api_selection_t set_selection;
 	video_api_selection_t get_selection;
+	/** Transform capability from one end to the other end of an m2m device */
+	video_api_transform_cap_t transform_cap;
 };
 
 /**
@@ -718,6 +732,60 @@ static inline int video_get_caps(const struct device *dev, struct video_caps *ca
 	}
 
 	return api->get_caps(dev, caps);
+}
+
+/**
+ * @brief Transform a video format capability from one end to the other end of a m2m video device.
+ *
+ * This function transforms a @ref video_format_cap from one end to the other end of an m2m video
+ * device. It allows applications to iteratively get all the supported capabilities on one end of
+ * the device given a single input capability on the other end.
+ *
+ * Applications pass the addresses of a single input cap and a single res_cap together with the
+ * type of the res_cap and the index (started from 0) to iterate through to the function. The
+ * driver fills the res_cap structure and return 0 each time. Index should be incremented to get
+ * the next res_cap until the function returns an errno e.g., -EINVAL. For example:
+ *
+ * @code{.c}
+ *  struct video_format_cap cap = {.pixelformat = VIDEO_PIX_FMT_RGB565};
+ *  struct video_format_cap res_cap = {0};
+ *  uint8_t ind = 0;
+ *  while (video_transform_cap(dev, &cap, &res_cap, VIDEO_BUF_TYPE_OUTPUT, ind) == 0) {
+ *		// Process output_cap here
+ *		ind++;
+ *  }
+ * @endcode
+ *
+ * @param dev Pointer to the device structure.
+ * @param cap Pointer to the source video format capability structure.
+ * @param res_cap Pointer to the resulting video format capability structure, filled by the driver.
+ * @param type The @ref video_buf_type of the resulting transformed cap.
+ * @param ind Index of the resulting transformed cap.
+ *
+ * @retval 0 Success.
+ * @retval -ENOSYS API is not implemented.
+ * @retval -EINVAL Parameters are invalid.
+ * @retval -ENOTSUP The transformation is not supported.
+ * @retval -EIO General input / output error.
+ */
+static inline int video_transform_cap(const struct device *const dev,
+				      const struct video_format_cap *const cap,
+				      struct video_format_cap *const res_cap,
+				      enum video_buf_type type, uint16_t ind)
+{
+	const struct video_driver_api *api;
+
+	if (dev == NULL || cap == NULL || res_cap == NULL ||
+	    (type != VIDEO_BUF_TYPE_INPUT && type != VIDEO_BUF_TYPE_OUTPUT)) {
+		return -EINVAL;
+	}
+
+	api = (const struct video_driver_api *)dev->api;
+	if (api->transform_cap == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->transform_cap(dev, cap, res_cap, type, ind);
 }
 
 /**


### PR DESCRIPTION
For m2m video device, the get_caps() API give us the supported caps of either input or output side. However, there is currently no guaranteed way to know the relationship between input and output caps.
Introduce a new `video_transform_caps()` API that helps to transform a video format cap from one end to the other end of a m2m device.

Also, add a buffer alignment requirement field into the video_caps struct.

Example of driver implementation can be found here: https://github.com/zephyrproject-rtos/zephyr/pull/92366/commits/94ea2de7d3dd8a465386f2b932639183b9d48c1e#diff-a7307ae0494c812091bb5ee7e8bfb4a1676b8b21112f9f8b12dd3abf5d0a2f0eR174

Usage in application can be found here: https://github.com/zephyrproject-rtos/zephyr/pull/98514/commits/4b486a8ece1d6224c6c478c920bd84fca4c06a64#diff-5f2911ee1e7a41d16d5650326ff94aa6280a7f783be998b50d0a0243f2ce0985R115