### PR TITLE
drivers: bluetooth: silabs_efr32: Fix default for max PAwR advertisers

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.silabs
+++ b/drivers/bluetooth/hci/Kconfig.silabs
@@ -164,7 +164,7 @@ if BT_PER_ADV_RSP
 
 config BT_SILABS_EFR32_MAX_PAWR_ADVERTISERS
 	int "Maximum numbers of Periodic Advertising With Response advertisers"
-	default 0
+	default 1
 	range 0 BT_SILABS_EFR32_MAX_PERIODIC_ADVERTISERS
 
 config BT_SILABS_EFR32_MAX_PAWR_ADVERTISED_DATA_LENGTH_HINT


### PR DESCRIPTION
This option already depends on BT_PER_ADV_RSP being enabled, so we should have a more reasonable default for it. This way e.g. the existing PAwR sample app should work without additional changes.