### PR TITLE
Enhancement Settings NVS Cache

### DIFF
--- a/subsys/settings/include/settings/settings_nvs.h
+++ b/subsys/settings/include/settings/settings_nvs.h
@@ -45,7 +45,7 @@ struct settings_nvs {
 	} cache[CONFIG_SETTINGS_NVS_NAME_CACHE_SIZE];
 
 	uint16_t cache_next;
-	uint16_t cache_total;
+	bool overflowed;
 	bool loaded;
 #endif
 };


### PR DESCRIPTION
The NVS settings name cache previously only supported insertion. When a
setting was deleted, the corresponding cache entry was left intact. As a
result, subsequent operations involving the same name would still consult
the cache, even though the name no longer existed in NVS.