### PR TITLE
samples: sensor/drivers: stream_drdy/display:  fix dt-bindings enum names in stream_drdy sample and GFX01M2 shield

### DIFF
--- a/boards/shields/x_nucleo_gfx01m2/x_nucleo_gfx01m2.overlay
+++ b/boards/shields/x_nucleo_gfx01m2/x_nucleo_gfx01m2.overlay
@@ -74,7 +74,7 @@
 			width = <240>;
 			height = <320>;
 			rotation = <180>;
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB565>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 			frmctr1 = [00 1f]; /* 60Hz frame rate */
 		};
 	};

--- a/samples/sensor/stream_drdy/boards/nucleo_f401re.overlay
+++ b/samples/sensor/stream_drdy/boards/nucleo_f401re.overlay
@@ -22,7 +22,7 @@
 	lsm6dsv16x_6b_x_nucleo_iks4a1: lsm6dsv16x@6b {
 		compatible = "st,lsm6dsv16x";
 		reg = <0x6b>;
-		accel-odr = <LSM6DSV16X_DT_ODR_AT_120Hz>;
+		accel-odr = <LSM6DSVXXX_DT_ODR_AT_120Hz>;
 		accel-range = <LSM6DSV16X_DT_FS_16G>;
 		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 (PB5) */
 		drdy-pin = <2>;

--- a/samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay
+++ b/samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay
@@ -22,7 +22,7 @@
 	lsm6dsv16x_6b_x_nucleo_iks4a1: lsm6dsv16x@6b {
 		compatible = "st,lsm6dsv16x";
 		reg = <0x6b>;
-		accel-odr = <LSM6DSV16X_DT_ODR_AT_120Hz>;
+		accel-odr = <LSM6DSVXXX_DT_ODR_AT_120Hz>;
 		accel-range = <LSM6DSV16X_DT_FS_16G>;
 		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 (PB5) */
 		drdy-pin = <2>;


### PR DESCRIPTION
This PR fixes two Devicetree parsing errors caused by incorrect dt-bindings enum names being used in DTS overlay files.

1. samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay
   The accelerometer ODR enum was using a sensor-specific macro name `LSM6DSV16X_DT_ODR_AT_120Hz` which is not 
   defined for Devicetree usage. This is corrected to the generic `LSM6DSVXXX_DT_ODR_AT_120Hz` enum defined
   in `zephyr/dt-bindings/sensor/lsm6dsvxxx.h.`

2. boards/shields/x_nucleo_gfx01m2/x_nucleo_gfx01m2.overlay
   The panel pixel format enum was incorrectly referenced as `PANEL_PIXEL_FORMAT_RGB565`. 
   The correct dt-bindings enum name `PANEL_PIXEL_FORMAT_RGB_565` is now used, matching
   `zephyr/dt-bindings/display/panel.h`.

  These fixes resolve Devicetree compile-time errors such as:
  "parse error: expected number or parenthesized expression"
  
  
  To reproduce :  
  - `west build -p -b nucleo_h503rb/stm32h503xx samples/sensor/stream_drdy -T sample.sensor.stream_drdy`
  - `west build -p -b nucleo_g071rb/stm32g071xx samples/drivers/display -T sample.display.shield`
  