### PR TITLE
tests: boot: mcuboot_direct_xip: escape plus signs in regex patterns

### DIFF
--- a/tests/boot/mcuboot_direct_xip/testcase.yaml
+++ b/tests/boot/mcuboot_direct_xip/testcase.yaml
@@ -21,8 +21,8 @@ tests:
       type: multi_line
       regex:
         - "Starting Direct-XIP bootloader"
-        - "Primary slot: version=0.0.0+0"
-        - "Secondary slot: version=0.0.0+0"
+        - "Primary slot: version=0.0.0\\+0"
+        - "Secondary slot: version=0.0.0\\+0"
         - "Image 0 loaded from the primary slot"
         - "Bootloader chainload address offset"
         - "Image version: v0.0.0"
@@ -36,7 +36,7 @@ tests:
       regex:
         - "Starting Direct-XIP bootloader"
         - "Image 0 Primary slot: Image not found"
-        - "Secondary slot: version=0.0.0+0"
+        - "Secondary slot: version=0.0.0\\+0"
         - "Image 0 loaded from the secondary slot"
         - "Bootloader chainload address offset"
         - "Image version: v0.0.0"


### PR DESCRIPTION
The plus signs in version strings need to be escaped with double backslashes when used in regex patterns for the test harness. This ensures proper pattern matching during test execution.

Found in internal regression, can be tested with:
`west twister --no-clean -vv -ll debug -T tests/boot/mcuboot_direct_xip --device-testing --hardware-map hardware_map.yaml --west-flash=--erase`