### PR TITLE
arch: arm: cortex_m: add missing include in `__aeabi_read_tp` & cleanup linker scripts

### DIFF
--- a/arch/arm/core/cortex_m/__aeabi_read_tp.S
+++ b/arch/arm/core/cortex_m/__aeabi_read_tp.S
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 
 _ASM_FILE_PROLOGUE
 

--- a/arch/arm/core/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/cortex_m/pm_s2ram.S
@@ -13,6 +13,7 @@
 #include <offsets_short.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/common/pm_s2ram.h>
+#include <zephyr/linker/sections.h>
 
 /**
  * Macro expanding to an integer literal equal to the offset of

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -108,7 +108,6 @@ zephyr_linker_section_configure(SECTION .rela.plt INPUT ".rela.iplt")
 
 include(${COMMON_ZEPHYR_LINKER_DIR}/kobject-text.cmake)
 
-zephyr_linker_section_configure(SECTION .text INPUT ".TEXT.*")
 zephyr_linker_section_configure(SECTION .text INPUT ".gnu.linkonce.t.*")
 
 zephyr_linker_section_configure(SECTION .text INPUT ".glue_7t")

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -168,7 +168,6 @@ GROUP_END(ITCM)
 
 	*(.text)
 	*(".text.*")
-	*(".TEXT.*")
 	*(.gnu.linkonce.t.*)
 
 	/*


### PR DESCRIPTION
The eponymous function in `__aeabi_read_tp.S` is declared as follows:
https://github.com/zephyrproject-rtos/zephyr/blob/bf747b8e037eef1a873c998fc6642ba32a28d84b/arch/arm/core/cortex_m/__aeabi_read_tp.S#L22

Note the first argument (section name) is `TEXT` in capital letters, which a define in `include/zephyr/linker/sections.h` is supposed to be replace with the lowercase `text` such that the resulting section name is correct: `.text.__aeabi_read_tp`.
https://github.com/zephyrproject-rtos/zephyr/blob/bf747b8e037eef1a873c998fc6642ba32a28d84b/include/zephyr/linker/sections.h#L104-L106

However, this include is missing from the file so the substitution never happens, and the function is placed in section `.TEXT.__aeabi_read_tp` instead (notice uppercase!).

This bug was never noticed because 388725870fbaa82328d24779042551b19651b329, the very same commit which introduced TLS/`__aeabi_read_tp`, by simply adding `.TEXT.*` to the input sections of the output `text` section. Looking at the PR thread, this was done for no apparent reason and never explain, so I can only assume it was done as a work around for the missing include bug.

The linker warning can be seen by including the Cortex-A/R linker script but building for a Cortex-M target:
```
  warning: orphan section `.TEXT.__aeabi_read_tp' from `<...>/libarch__arm__core__cortex_m.a(__aeabi_read_tp.S.obj)' being placed in section `.TEXT.__aeabi_read_tp'
```

Fix this issue by adding the missing include which ensures the proper section name is always used. Also get rid of `.TEXT.*` sections being accepted: no other architecture in tree accepts these.

I have left the following two files, which are copies of the Cortex-M linker script, untouched:

https://github.com/zephyrproject-rtos/zephyr/blob/4d0852b0051c9b13b59f34bceb0c38148ad12eb1/soc/infineon/cat1b/cyw20829/linker.ld#L163

https://github.com/zephyrproject-rtos/zephyr/blob/4d0852b0051c9b13b59f34bceb0c38148ad12eb1/soc/infineon/edge/pse84/linker_exclude_syslib.ld#L148-L152

I will let Infineon maintainers backport the fix in their copy if they desire so (although I believe it would be much better to stop using these copies; the second of which, by the way, straight up removed the original copyright notice...)

---

P.S.: note that the Cortex-A/R version of this file *also* lacks `#include <zephyr/linker/sections.h>` but, critically, it uses `text` (lowercase) instead of `TEXT` (uppercase) as the section name!
https://github.com/zephyrproject-rtos/zephyr/blob/bf747b8e037eef1a873c998fc6642ba32a28d84b/arch/arm/core/cortex_a_r/__aeabi_read_tp.S#L7-L18