### PR TITLE
Add entropy driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &sercom4;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,flash-controller = &nvmctrl;
+		zephyr,entropy = &trng;
 	};
 
 	aliases {

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - comparator
   - dma
+  - entropy
   - flash
   - gpio
   - hwinfo

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &sercom4;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,flash-controller = &nvmctrl;
+		zephyr,entropy = &trng;
 	};
 
 	aliases {

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - comparator
   - dma
+  - entropy
   - flash
   - gpio
   - hwinfo

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -376,6 +376,16 @@
 			status = "disabled";
 		};
 
+		trng: random@42002800 {
+			compatible = "microchip,trng-g1-entropy";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TRNG>;
+			clock-names = "mclk";
+			reg = <0x42002800 0x24>;
+			interrupts = <131 0>;
+			interrupt-names = "datardy";
+			status = "disabled";
+		};
+
 		sercom4: sercom@43000000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x43000000 0x29>;

--- a/tests/drivers/entropy/api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/entropy/api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&trng {
+	status = "okay";
+};

--- a/tests/drivers/entropy/api/boards/pic32cx_sg61_cult.overlay
+++ b/tests/drivers/entropy/api/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&trng {
+	status = "okay";
+};


### PR DESCRIPTION
- Added trng node in the pic32cx_sg.dtsi file.
- Add zephyr,entropy to chosen node and entropy in supported list
- Add pic32cx_sg overlay files