### PR TITLE
hostap: fix incorrect link mode selection for SAP

### DIFF
--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -771,13 +771,14 @@ int hostapd_ap_status(const struct device *dev, struct wifi_iface_status *status
 
 	hw_mode = iface->current_mode;
 
-	status->link_mode = conf->ieee80211ax                          ? WIFI_6
-			    : conf->ieee80211ac                        ? WIFI_5
-			    : conf->ieee80211n                         ? WIFI_4
-			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211G ? WIFI_3
-			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211A ? WIFI_2
-			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211B ? WIFI_1
-								       : WIFI_0;
+	status->link_mode = (hw_mode->he_capab[IEEE80211_MODE_AP].he_supported
+			    && conf->ieee80211ax)                       ? WIFI_6
+			    : (hw_mode->vht_capab && conf->ieee80211ac) ? WIFI_5
+			    : (hw_mode->ht_capab && conf->ieee80211n)   ? WIFI_4
+			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211G  ? WIFI_3
+			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211A  ? WIFI_2
+			    : hw_mode->mode == HOSTAPD_MODE_IEEE80211B  ? WIFI_1
+									: WIFI_0;
 	status->twt_capable = (hw_mode->he_capab[IEEE80211_MODE_AP].mac_cap[0] & 0x04);
 
 out:


### PR DESCRIPTION
When SAP runs on hostapd, the HE (11ax) capability should be determined based on hw_mode->he_capab, which reflects the Wi-Fi FW capability. Using conf->ieee80211ax is incorrect because it only represents the default value derived from build-time configuration macros, and does not accurately represent real hardware capabilities.
Same change is also needed for VHT and HT check.