### PR TITLE
boards: nxp: Fix NXP MCU board names in yaml

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: frdm_mcxn947/mcxn947/cpu0/qspi
-name: NXP FRDM-MCXN947 QSPI (CPU0)
+name: NXP FRDM-MCXN947 (CPU0) (QSPI)
 type: mcu
 arch: arm
 ram: 320

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -1,5 +1,5 @@
 identifier: lpcxpresso11u68
-name: NXP LPCxpresso 11U68
+name: NXP LPCxpresso11U68
 type: mcu
 arch: arm
 ram: 32

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.yaml
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso54114/lpc54114/m0
-name: NXP LPCXpresso54114 M0
+name: NXP LPCXpresso54114 (M0)
 type: mcu
 arch: arm
 ram: 32

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso54114/lpc54114/m4
-name: NXP LPCXpresso54114 M4
+name: NXP LPCXpresso54114 (M4)
 type: mcu
 arch: arm
 ram: 64

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso55s69/lpc55s69/cpu0/ns
-name: NXP LPCXpresso55S69 (Non-Secure)
+name: NXP LPCXpresso55S69 (CPU0) (Non-Secure)
 type: mcu
 arch: arm
 ram: 136

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mcx_n9xx_evk/mcxn947/cpu0/qspi
-name: NXP MCX-N9XX-EVK QSPI (CPU0)
+name: NXP MCX-N9XX-EVK (CPU0) (QSPI)
 type: mcu
 arch: arm
 ram: 320

--- a/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.yaml
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.yaml
@@ -1,5 +1,5 @@
 identifier: mcxw72_evk/mcxw727c/cpu0
-name: NXP MCXW72_EVK
+name: NXP MCXW72-EVK
 type: mcu
 arch: arm
 ram: 264

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1050_evk/mimxrt1052/qspi
-name: NXP MIMXRT1050-EVK-QSPI
+name: NXP MIMXRT1050-EVK (QSPI)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1060_evk/mimxrt1062/hyperflash
-name: NXP MIMXRT1060-EVK-HYPERFLASH
+name: NXP MIMXRT1060-EVK (HyperFlash)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1062_fmurt6/board.yml
+++ b/boards/nxp/mimxrt1062_fmurt6/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mimxrt1062_fmurt6
-  full_name: FMURT6
+  full_name: MIMXRT1062-FMURT6
   vendor: nxp
   socs:
     - name: mimxrt1062

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1160_evk/mimxrt1166/cm4
-name: NXP MIMXRT1160-EVK CM4
+name: NXP MIMXRT1160-EVK (CM4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1160_evk/mimxrt1166/cm7
-name: NXP MIMXRT1160-EVK CM7
+name: NXP MIMXRT1160-EVK (CM7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1170_evk@A/mimxrt1176/cm4
-name: NXP MIMXRT1170-EVK CM4
+name: NXP MIMXRT1170-EVK (CM4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1170_evk@B/mimxrt1176/cm4
-name: NXP MIMXRT1170-EVKB CM4
+name: NXP MIMXRT1170-EVKB (CM4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1170_evk@A/mimxrt1176/cm7
-name: NXP MIMXRT1170-EVK CM7
+name: NXP MIMXRT1170-EVK (CM7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1170_evk@B/mimxrt1176/cm7
-name: NXP MIMXRT1170-EVKB CM7
+name: NXP MIMXRT1170-EVKB (CM7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1180_evk/mimxrt1189/cm33
-name: NXP MIMXRT1180-EVK CM33
+name: NXP MIMXRT1180-EVK (CM33)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt1180_evk/mimxrt1189/cm7
-name: NXP MIMXRT1180-EVK CM7
+name: NXP MIMXRT1180-EVK (CM7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
@@ -1,5 +1,5 @@
 identifier: mimxrt595_evk/mimxrt595s/f1
-name: i.MXRT595 Fusion F1 DSP
+name: NXP MIMXRT595-EVK (Fusion F1 DSP)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt685_evk/mimxrt685s/hifi4
-name: NXP MIMXRT685-EVK (HiFi 4)
+name: NXP MIMXRT685-EVK (HiFi4)
 type: mcu
 arch: xtensa
 ram: 64

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt700_evk/mimxrt798s/cm33_cpu0
-name: NXP MIMXRT700-EVK (CM33_CPU0)
+name: NXP MIMXRT700-EVK (CPU0)
 type: mcu
 arch: arm
 ram: 512

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt700_evk/mimxrt798s/cm33_cpu1
-name: NXP MIMXRT700-EVK (CM33_CPU1)
+name: NXP MIMXRT700-EVK (CPU1)
 type: mcu
 arch: arm
 ram: 256

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt700_evk/mimxrt798s/hifi1
-name: NXP MIMXRT700-EVK HiFi1
+name: NXP MIMXRT700-EVK (HiFi1)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mimxrt700_evk/mimxrt798s/hifi4
-name: NXP MIMXRT700-EVK HiFi4
+name: NXP MIMXRT700-EVK (HiFi4)
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: rd_rw612_bga
-name: NXP RD_RW612_BGA
+name: NXP RD-RW612-BGA
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: rd_rw612_bga/rw612/ethernet
-name: NXP RD_RW612_BGA ETHERNET
+name: NXP RD-RW612-BGA (Ethernet)
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
- Fixes an inconsistency in the board list of the MCUx-VSCode extension. No functional change.
- Adjusts names in .yaml files to follow the currently used approach "NXP <board_name> [(cpu)] [(type)]".