### PR TITLE
shell: Add shell_readline helper

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -240,6 +240,10 @@ New APIs and options
   * :kconfig:option:`CONFIG_SETTINGS_SAVE_SINGLE_SUBTREE_WITHOUT_MODIFICATION`
   * :kconfig:option:`CONFIG_SETTINGS_SAVE_SINGLE_SUBTREE_WITHOUT_MODIFICATION_VALUE_SIZE`
 
+* Shell
+
+  * :c:func:`shell_readline` for :ref:`user input <shell-readline>`
+
 * Sys
 
   * :c:macro:`COND_CASE_1`

--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -752,6 +752,55 @@ of any other command besides a login command, by means of the
 allows you to set the prompt upon startup, but it can be changed later with the
 ``shell_prompt_change`` function.
 
+.. _shell-readline:
+
+Reading User Input
+******************
+
+The shell provides a :c:func:`shell_readline` function that allows command handlers
+to interactively read a line of input from the user. This is useful for implementing
+commands that need to prompt the user for additional information, such as confirmation
+dialogs, multi-step wizards, or interactive data entry.
+
+The function reads from the shell transport until a newline character is received,
+storing the data in a provided buffer. The newline character itself is not included
+in the buffer. The buffer is automatically null-terminated on success.
+
+.. note::
+
+   The :c:func:`shell_readline` function should be called from the shell thread in a
+   shell command handler and blocks the thread until a result is returned.
+
+Example usage:
+
+.. code-block:: c
+
+   static int cmd_read_secret(const struct shell *sh, size_t argc, char **argv)
+   {
+           uint8_t input_buf[256];
+           int ret;
+
+           shell_fprintf_normal(sh, "Enter your secret: ");
+
+           shell_obscure_set(sh, true);
+           ret = shell_readline(sh, input_buf, sizeof(input_buf), K_SECONDS(10));
+           shell_obscure_set(sh, false);
+
+           if (ret < 0) {
+                   if (ret == -ETIMEDOUT) {
+                           shell_error(sh, "Timeout waiting for input");
+                   } else if (ret == -ECANCELED) {
+                           shell_error(sh, "Input canceled");
+                   } else if (ret == -ENOBUFS) {
+                           shell_error(sh, "Input too long");
+                   }
+                   return ret;
+           }
+
+           shell_print(sh, "Secret input received (%d bytes)", ret);
+           return 0;
+   }
+
 Shell Logger Backend Feature
 ****************************
 

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -20,11 +20,20 @@ extern const struct shell_transport_api shell_dummy_transport_api;
 struct shell_dummy {
 	bool initialized;
 
-	/** current number of bytes in buffer (0 if no output) */
+	/** current number of bytes in output buffer (0 if no output) */
 	size_t len;
 
 	/** output buffer to collect shell output */
 	char buf[CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE];
+
+	/** current number of bytes in input buffer */
+	size_t input_len;
+
+	/** current read position in input buffer */
+	size_t input_pos;
+
+	/** input buffer for simulating user input */
+	char input_buf[CONFIG_SHELL_BACKEND_DUMMY_BUF_SIZE];
 };
 
 #define SHELL_DUMMY_DEFINE(_name)					\
@@ -63,6 +72,26 @@ const char *shell_backend_dummy_get_output(const struct shell *sh,
  * @param sh	Shell pointer
  */
 void shell_backend_dummy_clear_output(const struct shell *sh);
+
+/**
+ * @brief Push input data to the dummy shell backend.
+ *
+ * This function queues input data that will be returned by subsequent
+ * read operations. Useful for testing shell input handling.
+ *
+ * @param sh	Shell pointer
+ * @param data	Input data to push
+ * @param len	Length of input data
+ * @returns 0 on success, -ENOMEM if buffer is full
+ */
+int shell_backend_dummy_push_input(const struct shell *sh, const char *data, size_t len);
+
+/**
+ * @brief Clear the input buffer in the shell backend.
+ *
+ * @param sh	Shell pointer
+ */
+void shell_backend_dummy_clear_input(const struct shell *sh);
 
 #ifdef __cplusplus
 }

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -304,6 +304,31 @@ static int cmd_bypass(const struct shell *sh, size_t argc, char **argv)
 	return set_bypass(sh, bypass_cb);
 }
 
+static int cmd_demo_readline(const struct shell *sh, size_t argc, char **argv)
+{
+	uint8_t input_buf[256];
+	int ret;
+
+	shell_fprintf_normal(sh, "Input: ");
+
+	if (argc == 2 && strcmp(argv[1], "obscured") == 0) {
+		shell_obscure_set(sh, true);
+	}
+
+	ret = shell_readline(sh, input_buf, sizeof(input_buf), K_SECONDS(10));
+	shell_obscure_set(sh, false);
+
+	if (ret < 0) {
+		shell_error(sh, "Input error (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Got %d characters:", ret);
+	shell_hexdump(sh, input_buf, ret);
+
+	return 0;
+}
+
 static int cmd_dict(const struct shell *sh, size_t argc, char **argv,
 		    void *data)
 {
@@ -325,6 +350,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_demo,
 	SHELL_CMD(params, NULL, "Print params command.", cmd_demo_params),
 	SHELL_CMD(ping, NULL, "Ping command.", cmd_demo_ping),
 	SHELL_CMD(board, NULL, "Show board name command.", cmd_demo_board),
+	SHELL_CMD_ARG(readline, NULL, SHELL_HELP("Read user input", "[obscured]"),
+		      cmd_demo_readline, 1, 1),
 #if defined CONFIG_SHELL_GETOPT
 	SHELL_CMD(getopt_thread_safe, NULL,
 		  "Cammand using getopt in thread safe way"

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -196,6 +196,11 @@ static void history_handle(const struct shell *sh, bool up)
 		return;
 	}
 
+	/* No history when capturing user input */
+	if (sh->ctx->readline_state != SHELL_READLINE_INACTIVE) {
+		return;
+	}
+
 	/* Checking if history process has been stopped */
 	if (z_flag_history_exit_get(sh)) {
 		z_flag_history_exit_set(sh, false);
@@ -831,6 +836,11 @@ static void tab_handle(const struct shell *sh)
 	size_t argc;
 	size_t cnt;
 
+	/* Disable tab handling when readline is active */
+	if (sh->ctx->readline_state != SHELL_READLINE_INACTIVE) {
+		return;
+	}
+
 	bool tab_possible = tab_prepare(sh, &cmd, &argv, &argc, &arg_idx,
 					&d_entry);
 
@@ -899,7 +909,11 @@ static void ctrl_metakeys_handle(const struct shell *sh, char data)
 			z_cursor_next_line_move(sh);
 		}
 		z_flag_history_exit_set(sh, true);
-		state_set(sh, SHELL_STATE_ACTIVE);
+		if (sh->ctx->readline_state == SHELL_READLINE_ACTIVE) {
+			sh->ctx->readline_state = SHELL_READLINE_CANCELED;
+		} else {
+			state_set(sh, SHELL_STATE_ACTIVE);
+		}
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_D: /* CTRL + D */
@@ -1037,6 +1051,13 @@ static void state_collect(const struct shell *sh)
 		switch (sh->ctx->receive_state) {
 		case SHELL_RECEIVE_DEFAULT:
 			if (process_nl(sh, data)) {
+				/* Running in a re-entry for user input */
+				if (sh->ctx->readline_state == SHELL_READLINE_ACTIVE) {
+					z_cursor_next_line_move(sh);
+					sh->ctx->readline_state = SHELL_READLINE_DONE;
+					return;
+				}
+
 				if (!sh->ctx->cmd_buff_len) {
 					history_mode_exit(sh);
 					z_cursor_next_line_move(sh);
@@ -1834,6 +1855,68 @@ bool shell_ready(const struct shell *sh)
 	__ASSERT_NO_MSG(sh);
 
 	return state_get(sh) ==	SHELL_STATE_ACTIVE;
+}
+
+int shell_readline(const struct shell *sh, uint8_t *buf, size_t len, k_timeout_t timeout)
+{
+	k_timepoint_t end = sys_timepoint_calc(timeout);
+	int ret;
+
+	__ASSERT_NO_MSG(sh != NULL);
+
+	/* Only allow calling from inside a shell command with no bypass active */
+	if (!z_flag_cmd_ctx_get(sh) || sh->ctx->bypass != NULL) {
+		return -EACCES;
+	}
+
+	sh->ctx->readline_state = SHELL_READLINE_ACTIVE;
+
+	/* Save the current command buffer */
+	sh->ctx->cmd_tmp_buff_len = sh->ctx->cmd_buff_len;
+	sh->ctx->cmd_tmp_buff_pos = sh->ctx->cmd_buff_pos;
+	memcpy(sh->ctx->temp_buff, sh->ctx->cmd_buff, sh->ctx->cmd_buff_len);
+
+	/* Clear the buffer for user input */
+	cmd_buffer_clear(sh);
+
+	while (true) {
+		state_collect(sh);
+
+		if (sh->ctx->readline_state == SHELL_READLINE_DONE) {
+			if (buf == NULL || sh->ctx->cmd_buff_len >= len) {
+				ret = -ENOBUFS;
+				break;
+			}
+
+			memcpy(buf, sh->ctx->cmd_buff, sh->ctx->cmd_buff_len);
+			buf[sh->ctx->cmd_buff_len] = '\0';
+
+			ret = sh->ctx->cmd_buff_len;
+			break;
+		}
+
+		if (sh->ctx->readline_state == SHELL_READLINE_CANCELED) {
+			ret = -ECANCELED;
+			break;
+		}
+
+		/* Check for timeout */
+		if (sys_timepoint_expired(end)) {
+			ret = -ETIMEDOUT;
+			break;
+		}
+
+		/* Small delay to avoid busy-waiting */
+		k_msleep(1);
+	}
+
+	/* Restore the command state */
+	sh->ctx->cmd_buff_len = sh->ctx->cmd_tmp_buff_len;
+	sh->ctx->cmd_buff_pos = sh->ctx->cmd_tmp_buff_pos;
+	memcpy(sh->ctx->cmd_buff, sh->ctx->temp_buff, sh->ctx->cmd_buff_len);
+
+	sh->ctx->readline_state = SHELL_READLINE_INACTIVE;
+	return ret;
 }
 
 static int cmd_help(const struct shell *sh, size_t argc, char **argv)

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -388,6 +388,10 @@ void z_shell_cmd_line_erase(const struct shell *sh)
 
 static void print_prompt(const struct shell *sh)
 {
+	if (sh->ctx->readline_state != SHELL_READLINE_INACTIVE) {
+		return;
+	}
+
 	z_shell_fprintf(sh, SHELL_INFO, "%s", sh->ctx->prompt);
 }
 

--- a/tests/subsys/shell/shell/testcase.yaml
+++ b/tests/subsys/shell/shell/testcase.yaml
@@ -6,6 +6,13 @@ tests:
     min_ram: 32
     integration_platforms:
       - native_sim
+  shell.core.metakeys:
+    min_flash: 64
+    min_ram: 32
+    extra_configs:
+      - CONFIG_SHELL_METAKEYS=y
+    integration_platforms:
+      - native_sim
   # all tests below are just a build test verifying config options, it fails if run
   # and can be covered with one platform.
   shell.min:


### PR DESCRIPTION
Introduce a `shell_readline` function to interactively request input from the user running shell commands.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102586

Doc preview: https://builds.zephyrproject.io/zephyr/pr/102645/docs/services/shell/index.html#shell-readline

To-Dos:
- ~~Disable history in readline mode~~
- ~~CTRL+C should cancel~~
- Play nice with the shell logging backend