### PR TITLE
drivers: sensor: voltage_divider: Improves resolution to sub-millivolt

### DIFF
--- a/include/zephyr/drivers/adc/voltage_divider.h
+++ b/include/zephyr/drivers/adc/voltage_divider.h
@@ -79,6 +79,32 @@ static inline int voltage_divider_scale_dt(const struct voltage_divider_dt_spec 
 	return 0;
 }
 
+/**
+ * @brief Calculates the actual voltage from a measured voltage for 64-bit values
+ *
+ * @see voltage_divider_scale_dt()
+ *
+ * @param[in] spec voltage divider specification from Devicetree.
+ * @param[in,out] v_to_v Pointer to the measured voltage on input, and the
+ * corresponding scaled voltage value on output.
+ *
+ * @retval 0 on success
+ * @retval -ENOTSUP if "full_ohms" is not specified
+ */
+static inline int voltage_divider_scale64_dt(const struct voltage_divider_dt_spec *spec,
+					     int64_t *v_to_v)
+{
+	/* cannot be scaled if "full_ohms" is not specified */
+	if (spec->full_ohms == 0) {
+		return -ENOTSUP;
+	}
+
+	/* voltage scaled by voltage divider values using DT binding */
+	*v_to_v = *v_to_v * spec->full_ohms / spec->output_ohms;
+
+	return 0;
+}
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_VOLTAGE_DIVIDER_H_ */

--- a/tests/drivers/adc/adc_rescale/src/main.c
+++ b/tests/drivers/adc/adc_rescale/src/main.c
@@ -88,6 +88,16 @@ static int test_task_voltage_divider(void)
 	zassert_within(calculated_voltage, input_mv * 2, MV_OUTPUT_EPS,
 		       "%u != %u should have set value", calculated_voltage, input_mv * 2);
 
+	/* test case: voltage_divider_scale64_dt */
+	const int32_t divider_gain = 2;
+	const int32_t expected_output_uv = input_mv * 1000 * divider_gain;
+	int64_t output_uv = calculated_microvolts;
+
+	ret = voltage_divider_scale64_dt(&adc_node_0, &output_uv);
+	zassert_ok(ret, "voltage_divider_scale64_dt() failed with code %d", ret);
+	zassert_within(output_uv, expected_output_uv, divider_gain * 1000,
+		       "%lld != %d should have set value", output_uv, expected_output_uv);
+
 	return TC_PASS;
 }
 


### PR DESCRIPTION
## My issue
I have an application where a voltage divider is used that have a scaling factor of 5.7 (47k / 10k resistors). The measured voltage was strange. The sensor value had a resolution of no more than 6mV. The used ADC has 14-bits and the exceptions were that this should result in a sub-millivolt resolution.

## Root cause
The voltage divider specific calculation uses the function `adc_raw_to_millivolts_dt`. This results in a sensor value with no more than 1mV resolution which is scaled afterwards by the scaling function `voltage_divider_scale_dt()`.

So, my observation is explainable. Just wondering why this issue was never reported nor fixed.

## Proposed fix
- use `adc_raw_to_microvolts_dt()`
- 64-bit capable version of `voltage_divider_scale_dt()`. To not break existing applications, implemented as `voltage_divider_scale64_dt()`