### PR TITLE
samples: uart: async_api: Move k_sleep at the end of the loop

### DIFF
--- a/samples/drivers/uart/async_api/src/main.c
+++ b/samples/drivers/uart/async_api/src/main.c
@@ -92,9 +92,6 @@ int main(void)
 	uart_callback_set(uart_dev, uart_callback, (void *)uart_dev);
 
 	while (1) {
-		/* Wait a while until the next burst transmission */
-		k_sleep(K_SECONDS(5));
-
 		/* Each loop, try to send a random number of packets */
 		num_tx = (sys_rand32_get() % LOOP_ITER_MAX_TX) + 1;
 		LOG_INF("Loop %d: Sending %d packets", loop_counter, num_tx);
@@ -131,5 +128,8 @@ int main(void)
 		LOG_INF("RX is now %s", rx_enabled ? "enabled" : "disabled");
 
 		loop_counter += 1;
+
+		/* Wait a while until the next burst transmission */
+		k_sleep(K_SECONDS(5));
 	}
 }


### PR DESCRIPTION
The sample has a main loop that sleep 5s every iteration. The sleep is currently at the beginning of the loop, so we have to wait 5s before getting the first transfer.
This make debugging with this sample troublesome.

Move the sleep of 5s at the end of the loop.