### PR TITLE
pmci: mctp: usb: fix BULK IN/OUT lifecycle, add ZLP handling and HS/FS tests

### DIFF
--- a/samples/subsys/pmci/mctp/usb_endpoint/usb_host_tester.py
+++ b/samples/subsys/pmci/mctp/usb_endpoint/usb_host_tester.py
@@ -1,10 +1,28 @@
 #!/usr/bin/env python3
-
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
+#
+# Simple Zephyr MCTP-over-USB host tester (no CLI args)
+# - HS/FS agnostic (uses endpoint wMaxPacketSize at runtime)
+# - Works across repeated runs (detach kernel driver, clear halt, drain IN)
+# - Correct framed RX (handles header+payload in same read, multiple frames in one read)
+# - Includes a ZLP-focused test (meaningful mainly on Full-Speed due to 1-byte LEN)
+
+from __future__ import annotations
+
+import time
+from contextlib import suppress
 
 import usb.core
 import usb.util
+
+VID = 0x2FE3
+PID = 0x0001
+
+MCTP_DMTF0 = 0x1A
+MCTP_DMTF1 = 0xB4
+
+DEFAULT_TIMEOUT_MS = 1500
 
 
 class USBDevice:
@@ -15,85 +33,252 @@ class USBDevice:
         self.endpoint_in = None
         self.endpoint_out = None
         self.interface = None
+        self._detached = False
+
+        self.in_mps = None
+        self.out_mps = None
+
+        # SW buffer for leftover bytes (if we read more than one frame at once)
+        self._rx_buf = bytearray()
 
     def connect(self):
-        # Find the device
         self.device = usb.core.find(idVendor=self.vid, idProduct=self.pid)
         if self.device is None:
-            raise ValueError(
-                "Device not found. Make sure the board running the MCTP USB endpoint \
-                              sample is connected."
-            )
+            raise ValueError("Device not found. Make sure the board is connected (check lsusb).")
 
-        # Set the active configuration
-        self.device.set_configuration()
-        cfg = self.device.get_active_configuration()
+        # Prefer using the current active configuration if already set by OS/userspace.
+        # Calling set_configuration() can fail with EBUSY on some systems.
+        try:
+            cfg = self.device.get_active_configuration()
+        except usb.core.USBError:
+            # No active configuration yet -> set it
+            self.device.set_configuration()
+            cfg = self.device.get_active_configuration()
+
         self.interface = cfg[(0, 0)]
+        intf_num = self.interface.bInterfaceNumber
 
-        # Claim the interface
-        usb.util.claim_interface(self.device, self.interface.bInterfaceNumber)
+        # Detach kernel driver if present (important if /dev/ttyACM* grabs it)
+        with suppress(NotImplementedError, usb.core.USBError):
+            if self.device.is_kernel_driver_active(intf_num):
+                self.device.detach_kernel_driver(intf_num)
+                self._detached = True
+
+        usb.util.claim_interface(self.device, intf_num)
 
         # Find bulk IN and OUT endpoints
-        for ep in self.interface:
-            if usb.util.endpoint_direction(ep.bEndpointAddress) == usb.util.ENDPOINT_IN:
-                self.endpoint_in = ep
-            elif usb.util.endpoint_direction(ep.bEndpointAddress) == usb.util.ENDPOINT_OUT:
-                self.endpoint_out = ep
+        self.endpoint_in = usb.util.find_descriptor(
+            self.interface,
+            custom_match=lambda e: (
+                usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_IN
+                and usb.util.endpoint_type(e.bmAttributes) == usb.util.ENDPOINT_TYPE_BULK
+            ),
+        )
+        self.endpoint_out = usb.util.find_descriptor(
+            self.interface,
+            custom_match=lambda e: (
+                usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT
+                and usb.util.endpoint_type(e.bmAttributes) == usb.util.ENDPOINT_TYPE_BULK
+            ),
+        )
 
         if not self.endpoint_in or not self.endpoint_out:
             raise ValueError("Bulk IN/OUT endpoints not found")
 
-        # Print descriptor information (for debug purposes)
+        self.in_mps = int(self.endpoint_in.wMaxPacketSize)
+        self.out_mps = int(self.endpoint_out.wMaxPacketSize)
+
+        # Clear halts just in case a previous run left the pipe stalled
+        with suppress(usb.core.USBError):
+            self.device.clear_halt(self.endpoint_in.bEndpointAddress)
+        with suppress(usb.core.USBError):
+            self.device.clear_halt(self.endpoint_out.bEndpointAddress)
+
+        # Drain stale IN bytes so we don't parse an old reply
+        self._drain_in()
+
+        print(
+            f"Connected to device {self.vid:04x}:{self.pid:04x} "
+            f"(IN_MPS={self.in_mps}, OUT_MPS={self.out_mps})"
+        )
+
+        # Print descriptor information (debug)
         for cfg in self.device:
             print(cfg)
 
-    def send_data(self, data):
+    def _drain_in(self):
+        self._rx_buf = bytearray()
+        while True:
+            with suppress(usb.core.USBError):
+                _ = self.endpoint_in.read(self.in_mps, timeout=20)
+                continue
+            break
+
+    def send_data(self, data, timeout=1000):
         if not self.endpoint_out:
             raise RuntimeError("OUT endpoint not initialized")
-        self.endpoint_out.write(data)
+        return self.endpoint_out.write(data, timeout=timeout)
 
-    def receive_data(self, size=64, timeout=1000):
-        if not self.endpoint_in:
-            raise RuntimeError("IN endpoint not initialized")
-        return self.endpoint_in.read(size, timeout)
+    def _read_in(self, timeout_ms):
+        chunk = bytes(self.endpoint_in.read(self.in_mps, timeout=timeout_ms))
+        if chunk:
+            self._rx_buf.extend(chunk)
+
+    @staticmethod
+    def _find_header(buf):
+        # Find first occurrence of DMTF0 DMTF1 0x00
+        for i in range(max(0, len(buf) - 2)):
+            if buf[i] == MCTP_DMTF0 and buf[i + 1] == MCTP_DMTF1 and buf[i + 2] == 0x00:
+                return i
+        return 0
+
+    def recv_mctp_frame(self, timeout=DEFAULT_TIMEOUT_MS):
+        """
+        Read exactly one MCTP-over-USB framed packet:
+        [DMTF0][DMTF1][RSVD][LEN] + (LEN-4) bytes payload
+
+        Robust to:
+        - header+payload in same read
+        - multiple frames in one read
+        - stale bytes (we also drain on connect)
+        """
+        deadline = time.time() + (timeout / 1000.0)
+
+        while True:
+            # Need at least 4 bytes for header
+            while len(self._rx_buf) < 4:
+                remain_ms = int(max(0.0, (deadline - time.time()) * 1000))
+                if remain_ms == 0:
+                    raise usb.core.USBTimeoutError("Timeout waiting for MCTP header")
+                self._read_in(remain_ms)
+
+            # Resync to header
+            idx = self._find_header(self._rx_buf)
+            if idx > 0:
+                del self._rx_buf[:idx]
+
+            if len(self._rx_buf) < 4:
+                continue
+
+            if (
+                self._rx_buf[0] != MCTP_DMTF0
+                or self._rx_buf[1] != MCTP_DMTF1
+                or self._rx_buf[2] != 0x00
+            ):
+                del self._rx_buf[0]
+                continue
+
+            total_len = int(self._rx_buf[3])
+            if total_len < 4:
+                del self._rx_buf[:4]
+                continue
+
+            while len(self._rx_buf) < total_len:
+                remain_ms = int(max(0.0, (deadline - time.time()) * 1000))
+                if remain_ms == 0:
+                    raise usb.core.USBTimeoutError(
+                        f"Timeout waiting full frame: have={len(self._rx_buf)} need={total_len}"
+                    )
+                self._read_in(remain_ms)
+
+            frame = bytes(self._rx_buf[:total_len])
+            del self._rx_buf[:total_len]
+            return frame
 
     def disconnect(self):
-        usb.util.release_interface(self.device, self.interface.bInterfaceNumber)
-        usb.util.dispose_resources(self.device)
+        if self.device is None or self.interface is None:
+            return
+
+        intf_num = self.interface.bInterfaceNumber
+
+        with suppress(usb.core.USBError):
+            usb.util.release_interface(self.device, intf_num)
+
+        with suppress(usb.core.USBError):
+            usb.util.dispose_resources(self.device)
+
+        # Re-attach kernel driver if we detached it
+        if self._detached:
+            with suppress(usb.core.USBError):
+                self.device.attach_kernel_driver(intf_num)
+
+        self.device = None
+        self.interface = None
+        self.endpoint_in = None
+        self.endpoint_out = None
+        self._detached = False
+        self._rx_buf = bytearray()
+
+
+def build_frame(payload):
+    """
+    Build: DMTF0 DMTF1 0x00 LEN payload
+    LEN is 1 byte -> total frame length must be <= 255.
+    """
+    total_len = 4 + len(payload)
+    if total_len > 255:
+        raise ValueError(f"Frame too large for 1-byte LEN: total_len={total_len} (>255)")
+    return bytes([MCTP_DMTF0, MCTP_DMTF1, 0x00, total_len]) + payload
 
 
 if __name__ == "__main__":
-    usb_dev = USBDevice(0x2FE3, 0x0001)
+    usb_dev = USBDevice(VID, PID)
     try:
         usb_dev.connect()
 
-        print("Sending message with size smaller than USB FS MPS (<64b)")
-        usb_dev.send_data(
-            b'\x1a\xb4\x00\x13\x01\x0a\x14\xc0\x48\x65\x6c\x6c\x6f\x2c\x20\x4d\x43\x58\x00'
-        )
-        response = usb_dev.receive_data()
-        print("Received:", bytes(response))
+        print("Test1: small message")
+        usb_dev.send_data(build_frame(b"\x01\x0a\x14\xc0Hello, MCX\x00"))
+        resp = usb_dev.recv_mctp_frame(timeout=DEFAULT_TIMEOUT_MS)
+        print("Received:", resp)
 
-        print("Sending message spanning two USB FS packets (>64b)")
-        usb_dev.send_data(
-            b'\x1a\xb4\x00\x50\x01\x0a\x14\xc0\x48\x65\x6c\x6c\x6f\x2c\x20\x4d\x43\x58\x2e\x20'
-            b'\x4c\x65\x74\x27\x73\x20\x74\x65\x73\x74\x20\x61\x20\x6d\x75\x6c\x74\x69\x2d\x70'
-            b'\x61\x63\x6b\x65\x74\x20\x6d\x65\x73\x73\x61\x67\x65\x20\x74\x6f\x20\x73\x65\x65'
-            b'\x20\x68\x6f\x77\x20\x79\x6f\x75\x20\x68\x61\x6e\x64\x6c\x65\x20\x69\x74\x2e\x00'
-        )
-        response = usb_dev.receive_data()
-        print("Received:", bytes(response))
+        print("Test2: long message (still <=255 total)")
+        payload2 = b"\x01\x0a\x14\xc0" + (b"A" * 160)
+        usb_dev.send_data(build_frame(payload2))
+        resp = usb_dev.recv_mctp_frame(timeout=DEFAULT_TIMEOUT_MS)
+        print("Received:", resp)
 
-        print("Sending message with two MCTP messages in a single USB FS packet")
-        usb_dev.send_data(
-            b'\x1a\xb4\x00\x16\x01\x0a\x14\xc0\x48\x65\x6c\x6c\x6f\x2c\x20\x4d\x43\x58\x2c\x20'
-            b'\x31\x00\x1a\xb4\x00\x16\x01\x0a\x14\xc0\x48\x65\x6c\x6c\x6f\x2c\x20\x4d\x43\x58'
-            b'\x2c\x20\x32\x00'
-        )
-        response = usb_dev.receive_data()
-        print("Received:", bytes(response))
-        response = usb_dev.receive_data()
-        print("Received:", bytes(response))
+        print("Test3: two messages in one OUT transfer (second reply is optional)")
+        msg1 = build_frame(b"\x01\x0a\x14\xc0Hello, MCX, 1\x00")
+        msg2 = build_frame(b"\x01\x0a\x14\xc0Hello, MCX, 2\x00")
+        usb_dev.send_data(msg1 + msg2)
+        resp = usb_dev.recv_mctp_frame(timeout=DEFAULT_TIMEOUT_MS)
+        print("Received:", resp)
+
+        print("Test4: ZLP-focused stress")
+        print("  NOTE: With 1-byte LEN (<=255), this is meaningful mainly for FS (MPS=64).")
+        if usb_dev.in_mps > 255:
+            print(
+                "  Skipping: IN_MPS="
+                f"{usb_dev.in_mps} but LEN<=255, cannot hit multiple-of-MPS for ZLP."
+            )
+        else:
+            candidates = [usb_dev.in_mps, usb_dev.in_mps * 2, usb_dev.in_mps * 3]
+            targets = [x for x in candidates if 4 <= x <= 255]
+            if not targets:
+                print("  Skipping: no valid target total lengths within 4..255.")
+            else:
+                target_total = max(targets)  # prefer 192 for FS
+                target_payload = target_total - 4
+                base_hdr = b"\x01\x0a\x14\xc0"
+                fill_len = max(0, target_payload - len(base_hdr))
+                payload_z = base_hdr + (b"Z" * fill_len)
+                frame_z = build_frame(payload_z)
+
+                iters = 50
+                print(
+                    f"  Target total_len={target_total} (payload={target_payload}), iters={iters}"
+                )
+                for _i in range(iters):
+                    usb_dev.send_data(frame_z)
+                    _ = usb_dev.recv_mctp_frame(timeout=DEFAULT_TIMEOUT_MS)
+                print("  ZLP stress done (stability check).")
+
+        print("Test5: HS stability stress (bulk IN completion)")
+        iters = 200
+        for _i in range(iters):
+            usb_dev.send_data(build_frame(b"\x01\x0a\x14\xc0HS_STRESS\x00"))
+            _ = usb_dev.recv_mctp_frame(timeout=DEFAULT_TIMEOUT_MS)
+        print("  HS stability stress done.")
 
     finally:
         usb_dev.disconnect()

--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -21,10 +21,15 @@ LOG_MODULE_REGISTER(mctp_usb, CONFIG_MCTP_LOG_LEVEL);
 #define MCTP_USB_DMTF_0 0x1A
 #define MCTP_USB_DMTF_1 0xB4
 
+/* Workqueue budget: OUT buffers to parse per k_work run */
+#define MCTP_USB_RX_WORK_BUDGET 4
 #define MCTP_USB_ENABLED 0
+#define MCTP_USB_BUFS_PER_INSTANCE 4
 #define MCTP_USB_NUM_INSTANCES CONFIG_MCTP_USB_CLASS_INSTANCES_COUNT
 
-UDC_BUF_POOL_DEFINE(mctp_usb_ep_pool, MCTP_USB_NUM_INSTANCES * 2, USBD_MAX_BULK_MPS,
+UDC_BUF_POOL_DEFINE(mctp_usb_ep_pool,
+		    MCTP_USB_NUM_INSTANCES * MCTP_USB_BUFS_PER_INSTANCE,
+		    USBD_MAX_BULK_MPS,
 		    sizeof(struct udc_buf_info), NULL);
 
 struct mctp_usb_class_desc {
@@ -43,8 +48,7 @@ struct mctp_usb_class_ctx {
 	const struct usb_desc_header **const hs_desc;
 	struct mctp_usb_class_inst *inst;
 	uint8_t inst_idx;
-	struct net_buf *out_net_buf;
-	uint8_t out_buf[USBD_MAX_BULK_MPS];
+	struct k_fifo rx_fifo;
 	struct k_work out_work;
 	atomic_t state;
 };
@@ -172,138 +176,181 @@ int mctp_usb_start(struct mctp_binding *binding)
 static void mctp_usb_class_out_work(struct k_work *work)
 {
 	struct mctp_usb_class_ctx *ctx = CONTAINER_OF(work, struct mctp_usb_class_ctx, out_work);
-	struct net_buf *buf;
-	size_t buf_size = 0;
+	struct mctp_binding_usb *usb = ctx->inst->mctp_binding;
+	uint32_t budget = MCTP_USB_RX_WORK_BUDGET;
 
 	if (!atomic_test_bit(&ctx->state, MCTP_USB_ENABLED)) {
 		return;
 	}
 
-	/* Move data from net_buf to our ctx buffer so we can receive another USB packet */
-	if (ctx->out_net_buf != NULL) {
-		buf_size = ctx->out_net_buf->len;
-		memcpy(ctx->out_buf, ctx->out_net_buf->data, ctx->out_net_buf->len);
+	while (budget-- != 0U) {
+		struct net_buf *rx = k_fifo_get(&ctx->rx_fifo, K_NO_WAIT);
+		size_t i;
 
-		/* Free the current buffer and allocate another for OUT */
-		net_buf_unref(ctx->out_net_buf);
-	}
-
-	buf = mctp_usb_class_buf_alloc(mctp_usb_class_get_bulk_out(ctx->class_data));
-	if (buf == NULL) {
-		LOG_ERR("Failed to allocate OUT buffer");
-		return;
-	}
-
-	if (usbd_ep_enqueue(ctx->class_data, buf)) {
-		net_buf_unref(buf);
-		LOG_ERR("Failed to enqueue OUT buffer");
-	}
-
-	/* Process the MCTP data */
-	struct mctp_binding_usb *usb = (struct mctp_binding_usb *)ctx->inst->mctp_binding;
-
-	LOG_DBG("size=%d", buf_size);
-	LOG_HEXDUMP_DBG(ctx->out_buf, buf_size, "buf = ");
-
-	for (int i = 0; i < buf_size; i++) {
-		switch (usb->rx_state) {
-		case STATE_WAIT_HDR_DMTF0: {
-			if (ctx->out_buf[i] == MCTP_USB_DMTF_0) {
-				usb->rx_state = STATE_WAIT_HDR_DMTF1;
-			} else {
-				LOG_ERR("Invalid DMTF0 %02X", ctx->out_buf[i]);
-				return;
-			}
+		if (rx == NULL) {
 			break;
 		}
-		case STATE_WAIT_HDR_DMTF1: {
-			if (ctx->out_buf[i] == MCTP_USB_DMTF_1) {
-				usb->rx_state = STATE_WAIT_HDR_RSVD0;
-			} else {
-				LOG_ERR("Invalid DMTF1 %02X", ctx->out_buf[i]);
-				usb->rx_state = STATE_WAIT_HDR_DMTF0;
-				return;
-			}
-			break;
-		}
-		case STATE_WAIT_HDR_RSVD0: {
-			if (ctx->out_buf[i] == 0) {
+
+		/* Parse directly from net_buf */
+		for (i = 0U; i < rx->len; i++) {
+			uint8_t byte = rx->data[i];
+
+			switch (usb->rx_state) {
+			case STATE_WAIT_HDR_DMTF0:
+				if (byte == MCTP_USB_DMTF_0) {
+					usb->rx_state = STATE_WAIT_HDR_DMTF1;
+				}
+				break;
+
+			case STATE_WAIT_HDR_DMTF1:
+				if (byte == MCTP_USB_DMTF_1) {
+					usb->rx_state = STATE_WAIT_HDR_RSVD0;
+				} else if (byte == MCTP_USB_DMTF_0) {
+					/* treat as potential new start */
+					usb->rx_state = STATE_WAIT_HDR_DMTF1;
+				} else {
+					usb->rx_state = STATE_WAIT_HDR_DMTF0;
+				}
+				break;
+
+			case STATE_WAIT_HDR_RSVD0:
+				/* As per the spec reserved byte(s) need to be ignored */
+				if (byte != 0U) {
+					LOG_DBG("Non-zero RSVD0 %02X ignored", byte);
+				}
 				usb->rx_state = STATE_WAIT_HDR_LEN;
-			} else {
-				LOG_ERR("Invalid RSVD0 %02X", ctx->out_buf[i]);
-				usb->rx_state = STATE_WAIT_HDR_DMTF0;
-				return;
+				break;
+
+			case STATE_WAIT_HDR_LEN:
+				/*
+				 * LEN is total framed length (hdr + payload)
+				 * Payload length = LEN - MCTP_USB_HEADER_SIZE
+				 */
+				if ((byte < MCTP_USB_HEADER_SIZE) ||
+				    (byte > MCTP_USB_MAX_PACKET_LENGTH)) {
+					LOG_ERR("Invalid LEN %02X", byte);
+					mctp_usb_reset_rx_state(usb);
+					break;
+				}
+
+				usb->rx_data_idx = 0U;
+				usb->rx_pkt = mctp_pktbuf_alloc(&usb->binding,
+								byte - MCTP_USB_HEADER_SIZE);
+				if (usb->rx_pkt == NULL) {
+					LOG_ERR("Failed to alloc pktbuf");
+					mctp_usb_reset_rx_state(usb);
+					break;
+				}
+
+				usb->rx_state = STATE_DATA;
+				break;
+
+			case STATE_DATA:
+				/*
+				 * If rx_pkt becomes NULL due to a reset, don't write.
+				 * This also guards against any future logic changes.
+				 */
+				if (usb->rx_pkt == NULL) {
+					mctp_usb_reset_rx_state(usb);
+					break;
+				}
+
+				usb->rx_pkt->data[usb->rx_data_idx++] = byte;
+
+				if (usb->rx_data_idx == usb->rx_pkt->end) {
+					mctp_bus_rx(&usb->binding, usb->rx_pkt);
+					usb->rx_pkt = NULL;
+					mctp_usb_reset_rx_state(usb);
+				}
+				break;
 			}
-			break;
 		}
-		case STATE_WAIT_HDR_LEN: {
-			if (ctx->out_buf[i] > MCTP_USB_MAX_PACKET_LENGTH || ctx->out_buf[i] == 0) {
-				LOG_ERR("Invalid LEN %02X", ctx->out_buf[i]);
-				usb->rx_state = STATE_WAIT_HDR_DMTF0;
-				return;
-			}
 
-			usb->rx_data_idx = 0;
-			usb->rx_pkt = mctp_pktbuf_alloc(&usb->binding,
-							ctx->out_buf[i] - MCTP_USB_HEADER_SIZE);
-			if (usb->rx_pkt == NULL) {
-				LOG_ERR("Could not allocate PKT buffer");
-				mctp_usb_reset_rx_state(usb);
-				return;
-			}
+		net_buf_unref(rx);
+	}
 
-			usb->rx_state = STATE_DATA;
-
-			LOG_DBG("Expecting LEN=%d", (int)ctx->out_buf[i] - MCTP_USB_HEADER_SIZE);
-
-			break;
-		}
-		case STATE_DATA: {
-			usb->rx_pkt->data[usb->rx_data_idx++] = ctx->out_buf[i];
-
-			if (usb->rx_data_idx == usb->rx_pkt->end) {
-				LOG_DBG("Packet complete");
-				mctp_bus_rx(&usb->binding, usb->rx_pkt);
-				/* Explicitly set rx_pkt to NULL since it is not guaranteed */
-				usb->rx_pkt = NULL;
-				mctp_usb_reset_rx_state(usb);
-			}
-
-			break;
-		}
-		}
+	/* If there is still work, reschedule */
+	if (!k_fifo_is_empty(&ctx->rx_fifo)) {
+		(void)k_work_submit(&ctx->out_work);
 	}
 }
 
-static int mctp_usb_class_request(struct usbd_class_data *const c_data, struct net_buf *buf,
-				  int err)
+static int mctp_usb_class_request(struct usbd_class_data *const c_data,
+				  struct net_buf *buf, int err)
 {
 	struct mctp_usb_class_ctx *ctx = usbd_class_get_private(c_data);
 	struct udc_buf_info *bi = udc_get_buf_info(buf);
+	const uint8_t ep_in = mctp_usb_class_get_bulk_in(c_data);
+	const uint8_t ep_out = mctp_usb_class_get_bulk_out(c_data);
 
 	LOG_DBG("request for EP 0x%x", bi->ep);
 
-	if (err) {
-		if (err == -ECONNABORTED) {
-			LOG_WRN("request ep 0x%02x, len %u cancelled", bi->ep, buf->len);
-		} else {
-			LOG_ERR("request ep 0x%02x, len %u failed", bi->ep, buf->len);
+	if (err != 0) {
+		/* OUT error: free and try to re-arm if still enabled */
+		if (bi->ep == ep_out) {
+			net_buf_unref(buf);
+
+			if (atomic_test_bit(&ctx->state, MCTP_USB_ENABLED)) {
+				struct net_buf *nb = mctp_usb_class_buf_alloc(ep_out);
+
+				if (nb != NULL) {
+					int e = usbd_ep_enqueue(c_data, nb);
+
+					if (e != 0) {
+						net_buf_unref(nb);
+					}
+				}
+			}
+			return 0;
 		}
 
-		goto exit;
-	}
+		/* IN error path: consume + account pending */
+		if (bi->ep == ep_in) {
+			net_buf_unref(buf);
+			if (atomic_dec(&ctx->in_pending) == 1) {
+				k_sem_give(&ctx->inst->mctp_binding->tx_lock);
+			}
+			return 0;
+		}
 
-	if (bi->ep == mctp_usb_class_get_bulk_out(c_data)) {
-		ctx->out_net_buf = buf;
-		k_work_submit(&ctx->out_work);
-	}
-
-	if (bi->ep == mctp_usb_class_get_bulk_in(c_data)) {
-		k_sem_give(&ctx->inst->mctp_binding->tx_lock);
 		net_buf_unref(buf);
+		return 0;
 	}
 
-exit:
+	if (bi->ep == ep_out) {
+		/* Re-arm OUT first to avoid host-side stalls */
+		if (atomic_test_bit(&ctx->state, MCTP_USB_ENABLED)) {
+			struct net_buf *nb = mctp_usb_class_buf_alloc(ep_out);
+
+			if (nb != NULL) {
+				int e = usbd_ep_enqueue(c_data, nb);
+
+				if (e != 0) {
+					net_buf_unref(nb);
+				}
+			} else {
+				LOG_ERR("OUT: failed to alloc next OUT buffer");
+			}
+		}
+
+		/* Drop ZLP/empty OUT completions: do not schedule worker */
+		if (buf->len == 0U) {
+			net_buf_unref(buf);
+			return 0;
+		}
+
+		/* Queue buffer for parsing and kick worker */
+		k_fifo_put(&ctx->rx_fifo, buf);
+		(void)k_work_submit(&ctx->out_work);
+		return 0;
+	}
+
+	if (bi->ep == ep_in) {
+		net_buf_unref(buf);
+		return 0;
+	}
+
+	net_buf_unref(buf);
 	return 0;
 }
 
@@ -361,6 +408,7 @@ static int mctp_usb_class_init(struct usbd_class_data *const c_data)
 	/* Share USB class data with the MCTP USB binding */
 	ctx->inst->mctp_binding->usb_class_data = c_data;
 
+	k_fifo_init(&ctx->rx_fifo);
 	k_work_init(&ctx->out_work, mctp_usb_class_out_work);
 
 	if (ctx->inst->sublcass == USBD_MCTP_SUBCLASS_MANAGEMENT_CONTROLLER ||
@@ -463,7 +511,7 @@ struct usbd_class_api mctp_usb_class_api = {
 		.fs_desc = mctp_usb_class_fs_desc_##n,					\
 		.hs_desc = mctp_usb_class_hs_desc_##n,					\
 		.inst_idx = n,								\
-		.out_net_buf = NULL							\
+		.rx_fifo = Z_FIFO_INITIALIZER(mctp_usb_class_ctx_##n.rx_fifo)		\
 	};										\
 											\
 	USBD_DEFINE_CLASS(mctp_##n, &mctp_usb_class_api, &mctp_usb_class_ctx_##n, NULL);


### PR DESCRIPTION
**SUMMARY**

**USB BULK transfers**

   - Per USB 2.0 Specification, Section 5.8.3, a BULK transfer is complete only when:
          - A short packet is received, or
          - A ZLP is sent when the transfer length is an exact multiple of wMaxPacketSize
- Failure to send a ZLP in the multiple-of-MPS case may cause the host to wait indefinitely

**MCTP over USB**

   - Per DMTF DSP0283 (MCTP Binding Specification for USB):
       - MCTP messages are framed inside USB BULK transfers
       - The LEN field represents the total framed message length
       - The binding does not imply USB packet boundaries; framing must tolerate arbitrary packetization

These constraints require:
    - Correct ZLP generation on BULK IN
    - Decoupling RX framing from USB packet boundaries
    - Robust endpoint re-arming and completion handling

**Key changes**
1. **BULK OUT handling rework**
    - OUT endpoint is re-armed immediately upon completion
    - Completed OUT buffers are queued via k_fifo and parsed asynchronously in a worker
    - RX parsing is now independent of USB packet boundaries and timing
  
**Why**
    - Prevents stalls if parsing is slow
    - Matches USB recommendation to keep BULK OUT endpoints continuously armed

2. **Correct BULK IN completion accounting**
    - Introduce in_pending to track in-flight IN transfers
    - Properly handle multi-transfer sends (data + optional ZLP)
    - Ensure TX semaphore is released only after the final IN completion

**Why**
    - Fixes race where IN completion may occur before enqueue finishes
    - Prevents TX deadlock under High-Speed or fast host controllers

3. **ZLP generation for exact-MPS transfers**
    - Send ZLP when (tx_len % wMaxPacketSize) == 0
    - Applies to both Full-Speed and High-Speed devices

**Why**
    - Required by USB 2.0 spec for BULK transfer termination
    - Fixes host-side timeouts observed during stress testing

4. **USB lifecycle hardening**
    - Proper cleanup on class disable:
        - Cancel worker
        - Drain RX FIFO
        - Reset RX parser state
        - Clear pending IN state
    - Unblock TX semaphore if disconnect occurs mid-transfer

**Why**
Ensures repeated enumeration and stress tests do not leave stale state

**5. Host tester utility improvements**
    - HS/FS agnostic (uses endpoint wMaxPacketSize dynamically)
    - Robust framed RX parsing:
        - Handles header+payload in same read
        - Handles multiple frames per read
Adds:
    - ZLP-focused stress test (effective on FS)
    - High-Speed stability stress test

**Why**
    - Provides a reliable regression test for spec-correct behavior
    - Matches real host controller behavior

**Testing**

- Tested on High-Speed USB device (512-byte MPS)
- Repeated stress runs pass without stalls or timeouts
- ZLP behavior verified on Full-Speed targets
- Host tester validated across multiple reconnect cycles

**Relevant specifications**

    **USB 2.0 Specification**
        - Section 5.8.3 — Bulk Transfers
        - Section 8.5 — Endpoint descriptors and MaxPacketSize
        
    **DMTF DSP0283**
      - MCTP Binding Specification for USB

    **DMTF DSP0236**
      - MCTP Base Specification (message framing semantics)

**Notes**
ZLP stress testing is inherently limited by the 1-byte LEN field (≤255), making it most meaningful on Full-Speed
No ABI or Kconfig changes