### PR TITLE
llext: Option for overwriting FLIX generation

### DIFF
--- a/cmake/compiler/xt-clang/target.cmake
+++ b/cmake/compiler/xt-clang/target.cmake
@@ -28,6 +28,17 @@ set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
 else()
 set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
   -ffreestanding
-  -mno-generate-flix
 )
+endif()
+
+if(CONFIG_LLEXT_CODEGEN_VLIW_ENABLED)
+  set(LLEXT_REMOVE_FLAGS ${LLEXT_REMOVE_FLAGS}
+    -mno-generate-flix
+  )
+endif()
+
+if(CONFIG_LLEXT_CODEGEN_VLIW_DISABLED)
+  set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
+    -mno-generate-flix
+  )
 endif()

--- a/cmake/compiler/xt-clang/target.cmake
+++ b/cmake/compiler/xt-clang/target.cmake
@@ -18,17 +18,17 @@ set(LLEXT_APPEND_FLAGS
 )
 
 if(CONFIG_LLEXT_BUILD_PIC)
-set(LLEXT_REMOVE_FLAGS ${LLEXT_REMOVE_FLAGS}
-  -fno-pic
-  -fno-pie
-)
-set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
-  -fPIC
-)
+  set(LLEXT_REMOVE_FLAGS ${LLEXT_REMOVE_FLAGS}
+    -fno-pic
+    -fno-pie
+  )
+  set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
+    -fPIC
+  )
 else()
-set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
-  -ffreestanding
-)
+  set(LLEXT_APPEND_FLAGS ${LLEXT_APPEND_FLAGS}
+    -ffreestanding
+  )
 endif()
 
 if(CONFIG_LLEXT_CODEGEN_VLIW_ENABLED)

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -224,6 +224,37 @@ config LLEXT_EXPERIMENTAL
 	  Include support for LLEXT experimental and unstable functionality that
 	  has a very high likelihood to change in the future.
 
+menu "Customize compiler options for LLEXT"
+
+choice LLEXT_CODEGEN_VLIW
+	prompt "VLIW code generation"
+	default LLEXT_CODEGEN_VLIW_INHERIT
+	help
+	  This option allows customization of global compiler settings with regards to
+	  generating VLIW (Very Long Instruction Word) instructions for all LLEXT
+	  modules.
+
+config LLEXT_CODEGEN_VLIW_INHERIT
+	bool "Inherit settings"
+	help
+	  Preserve global complier settings with regards to VLIW.
+
+config LLEXT_CODEGEN_VLIW_ENABLED
+	bool "Generate VLIW"
+	help
+	  Customize global complier settings by instructing the compiler to generate
+	  VLIW instructions for LLEXT modules if possible.
+
+config LLEXT_CODEGEN_VLIW_DISABLED
+	bool "DO NOT generate VLIW"
+	help
+	  Customize global complier settings by instructing the compiler to NEVER
+	  generate VLIW instructions for LLEXT modules.
+
+endchoice # LLEXT_CODEGEN_VLIW
+
+endmenu # Customize Compiler Options for LLEXT
+
 menu "Exported symbol groups"
 
 config LLEXT_EXPORT_DEFAULT_GROUPS


### PR DESCRIPTION
Compiler-generated FLIX instructions are currently disabled for LLEXT due to a historic issue with LLEXT feature that appears to be already resolved. However, another issue with FLIX is now being investigated. The latter issue is not related to LLEXT but userspace feature. To mitigate impact of global complier settings, this change adds a kconfig choice for controlling FLIX generation independently for LLEXT modules.