### PR TITLE
Bluetooth: AICS: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -24,7 +24,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
@@ -501,7 +500,7 @@ static ssize_t read_description(struct bt_conn *conn,
 /************************ PUBLIC API ************************/
 void *bt_aics_svc_decl_get(struct bt_aics *aics)
 {
-	CHECKIF(!aics) {
+	if (!aics) {
 		LOG_DBG("NULL instance");
 		return NULL;
 	}
@@ -521,12 +520,12 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 	int err;
 	static bool instance_prepared;
 
-	CHECKIF(!aics) {
+	if (!aics) {
 		LOG_DBG("NULL aics pointer");
 		return -ENOTCONN;
 	}
 
-	CHECKIF(!param) {
+	if (!param) {
 		LOG_DBG("NULL param");
 		return -EINVAL;
 	}
@@ -536,37 +535,37 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 		instance_prepared = true;
 	}
 
-	CHECKIF(aics->srv.initialized) {
+	if (aics->srv.initialized) {
 		return -EALREADY;
 	}
 
-	CHECKIF(param->mute > BT_AICS_STATE_MUTE_DISABLED) {
+	if (param->mute > BT_AICS_STATE_MUTE_DISABLED) {
 		LOG_DBG("Invalid AICS mute value: %u", param->mute);
 		return -EINVAL;
 	}
 
-	CHECKIF(param->gain_mode > BT_AICS_MODE_AUTO) {
+	if (param->gain_mode > BT_AICS_MODE_AUTO) {
 		LOG_DBG("Invalid AICS mode value: %u", param->gain_mode);
 		return -EINVAL;
 	}
 
-	CHECKIF(param->type > BT_AICS_INPUT_TYPE_AMBIENT) {
+	if (param->type > BT_AICS_INPUT_TYPE_AMBIENT) {
 		LOG_DBG("Invalid AICS input type value: %u", param->type);
 		return -EINVAL;
 	}
 
-	CHECKIF(param->units == 0) {
+	if (param->units == 0) {
 		LOG_DBG("AICS units value shall not be 0");
 		return -EINVAL;
 	}
 
-	CHECKIF(!(param->min_gain <= param->max_gain)) {
+	if (!(param->min_gain <= param->max_gain)) {
 		LOG_DBG("AICS min gain (%d) shall be lower than or equal to max gain (%d)",
 			param->min_gain, param->max_gain);
 		return -EINVAL;
 	}
 
-	CHECKIF(param->gain < param->min_gain || param->gain > param->max_gain) {
+	if (param->gain < param->min_gain || param->gain > param->max_gain) {
 		LOG_DBG("AICS gain (%d) shall be not lower than min gain (%d) "
 		       "or higher than max gain (%d)",
 		       param->gain, param->min_gain, param->max_gain);
@@ -644,7 +643,7 @@ struct bt_aics *bt_aics_free_instance_get(void)
 /****************************** PUBLIC API ******************************/
 int bt_aics_deactivate(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -671,7 +670,7 @@ int bt_aics_deactivate(struct bt_aics *inst)
 
 int bt_aics_activate(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -699,7 +698,7 @@ int bt_aics_activate(struct bt_aics *inst)
 #endif /* CONFIG_BT_AICS */
 int bt_aics_gain_set_manual_only(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -713,7 +712,7 @@ int bt_aics_gain_set_manual_only(struct bt_aics *inst)
 
 int bt_aics_gain_set_auto_only(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -727,7 +726,7 @@ int bt_aics_gain_set_auto_only(struct bt_aics *inst)
 
 int bt_aics_state_get(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -750,7 +749,7 @@ int bt_aics_state_get(struct bt_aics *inst)
 
 int bt_aics_gain_setting_get(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -774,7 +773,7 @@ int bt_aics_gain_setting_get(struct bt_aics *inst)
 
 int bt_aics_type_get(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -795,7 +794,7 @@ int bt_aics_type_get(struct bt_aics *inst)
 
 int bt_aics_status_get(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -816,7 +815,7 @@ int bt_aics_status_get(struct bt_aics *inst)
 
 int bt_aics_disable_mute(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -830,7 +829,7 @@ int bt_aics_disable_mute(struct bt_aics *inst)
 
 int bt_aics_unmute(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -851,7 +850,7 @@ int bt_aics_unmute(struct bt_aics *inst)
 
 int bt_aics_mute(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -872,7 +871,7 @@ int bt_aics_mute(struct bt_aics *inst)
 
 int bt_aics_manual_gain_set(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -893,7 +892,7 @@ int bt_aics_manual_gain_set(struct bt_aics *inst)
 
 int bt_aics_automatic_gain_set(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -914,7 +913,7 @@ int bt_aics_automatic_gain_set(struct bt_aics *inst)
 
 int bt_aics_gain_set(struct bt_aics *inst, int8_t gain)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -936,7 +935,7 @@ int bt_aics_gain_set(struct bt_aics *inst, int8_t gain)
 
 int bt_aics_description_get(struct bt_aics *inst)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
@@ -958,12 +957,12 @@ int bt_aics_description_get(struct bt_aics *inst)
 
 int bt_aics_description_set(struct bt_aics *inst, const char *description)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!description) {
+	if (!description) {
 		LOG_DBG("NULL description");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -27,7 +27,6 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
@@ -460,17 +459,17 @@ static int aics_client_common_control(uint8_t opcode, struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -708,20 +707,20 @@ int bt_aics_discover(struct bt_conn *conn, struct bt_aics *inst,
 {
 	int err = 0;
 
-	CHECKIF(!inst || !conn || !param) {
+	if (!inst || !conn || !param) {
 		LOG_DBG("%s cannot be NULL", inst == NULL   ? "inst"
 					     : conn == NULL ? "conn"
 							    : "param");
 		return -EINVAL;
 	}
 
-	CHECKIF(param->end_handle <= param->start_handle) {
+	if (param->end_handle <= param->start_handle) {
 		LOG_DBG("start_handle (%u) shall be less than end_handle (%u)", param->start_handle,
 			param->end_handle);
 		return -EINVAL;
 	}
 
-	CHECKIF(!atomic_test_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_ACTIVE)) {
+	if (!atomic_test_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_ACTIVE)) {
 		LOG_DBG("Inactive instance");
 		return -EINVAL;
 	}
@@ -765,7 +764,7 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 
 int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn)
 {
-	CHECKIF(aics == NULL) {
+	if (aics == NULL) {
 		LOG_DBG("NULL aics pointer");
 		return -EINVAL;
 	}
@@ -789,17 +788,17 @@ int bt_aics_client_state_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -827,17 +826,17 @@ int bt_aics_client_gain_setting_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -865,17 +864,17 @@ int bt_aics_client_type_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -903,17 +902,17 @@ int bt_aics_client_status_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -961,17 +960,17 @@ int bt_aics_client_gain_set(struct bt_aics *inst, int8_t gain)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -1004,17 +1003,17 @@ int bt_aics_client_description_get(struct bt_aics *inst)
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -1043,17 +1042,17 @@ int bt_aics_client_description_set(struct bt_aics *inst,
 {
 	int err;
 
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	if (!inst->client_instance) {
 		LOG_DBG("Not a client instance instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	if (inst->cli.conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -1079,7 +1078,7 @@ int bt_aics_client_description_set(struct bt_aics *inst,
 
 void bt_aics_client_cb_register(struct bt_aics *inst, struct bt_aics_cb *cb)
 {
-	CHECKIF(!inst) {
+	if (!inst) {
 		LOG_DBG("inst cannot be NULL");
 		return;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.