### PR TITLE
Bluetooth: Audio: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -23,7 +23,6 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
@@ -34,13 +33,13 @@ LOG_MODULE_REGISTER(bt_audio, CONFIG_BT_AUDIO_LOG_LEVEL);
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data)
 {
-	CHECKIF(ltv == NULL) {
+	if (ltv == NULL) {
 		LOG_DBG("ltv is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(func == NULL) {
+	if (func == NULL) {
 		LOG_DBG("func is NULL");
 
 		return -EINVAL;
@@ -112,12 +111,12 @@ int bt_audio_data_get_val(const uint8_t ltv_data[], size_t size, uint8_t type, c
 	};
 	int err;
 
-	CHECKIF(ltv_data == NULL) {
+	if (ltv_data == NULL) {
 		LOG_DBG("ltv_data is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(data == NULL) {
+	if (data == NULL) {
 		LOG_DBG("data is NULL");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.