### PR TITLE
net: ppp: Fixes to peer LCP_OPTION_MRU handling

### DIFF
--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -60,13 +60,6 @@ config NET_L2_PPP_OPTION_MRU
 	help
 	  Enable support for LCP MRU option.
 
-config NET_L2_PPP_OPTION_MAX_MRU
-	int "LCP MRU maximum size"
-	default 1500
-	help
-	  Set the maximal MRU size which is allowed while negotiation with peer over LCP.
-	  The default value is defined by RFC 1661.
-
 config NET_L2_PPP_OPTION_SERVE_IP
 	bool "Serve IP address to peer"
 	help


### PR DESCRIPTION
- Use the minimum of our and peer MRU as the MTU of the link. Allows for cases where our MRU is < 1500.

- Move all of the MRU handling under CONFIG_NET_L2_PPP_OPTION_MRU. So that we handle both sending the LCP_OPTION_MRU in Configure-Request and receiving it in Configure-Request.

- Remove CONFIG_NET_L2_PPP_OPTION_MAX_MRU. From RFC 1661, 6.1 Implementation note: ... The peer need not Configure-Nak to indicate that it will only send smaller packets, since the implementation will always require support for at least 1500 octets.

- Set ppp_my_options_parse_conf_ack so that ack's are parsed.