### PR TITLE
tests: nrf: add integration platform for rram_throttling

### DIFF
--- a/tests/boards/nrf/rram_throttling/testcase.yaml
+++ b/tests/boards/nrf/rram_throttling/testcase.yaml
@@ -13,3 +13,5 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Add the target nrf54l15dk/nrf54l15/cpuapp as the integration platform in the testcase yaml file.