### PR TITLE
pm: add optional custom ticks hook for system suspend

### DIFF
--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -122,6 +122,30 @@ remaining time until the next scheduled timeout.
 An example of an application that defines its own policy can be found in
 :zephyr_file:`tests/subsys/pm/power_mgmt/`.
 
+Custom ticks hook
+-----------------
+
+In addition to the kernel tick expiration and the PM policy event list,
+applications and SoC-specific code may need to derive the next wake-up time
+from proprietary or hardware-specific data sources. Examples include hardware
+registers, binary-only third-party modules, or complex/legacy data structures
+that are not practical to model as standard PM policy events.
+
+When :kconfig:option:`CONFIG_PM_CUSTOM_TICKS_HOOK` is enabled, the PM core calls the
+optional function :c:func:`pm_policy_next_custom_ticks()` during
+:c:func:`pm_system_suspend()`. The hook returns the ticks to the next custom
+event, or ``K_TICKS_FOREVER`` if no custom event needs to be considered.
+
+The PM core then selects the earliest expiration among:
+
+* kernel tick expiration,
+* PM policy event list ticks (from :c:func:`pm_policy_next_event_ticks()`),
+* the custom ticks value (from :c:func:`pm_policy_next_custom_ticks()`).
+
+This mechanism allows boards and applications to integrate additional timing
+sources into the system power management decisions without modifying the PM
+event list infrastructure.
+
 .. _pm-policy-power-states:
 
 Policy and Power States

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -273,6 +273,23 @@ bool pm_policy_device_is_disabling_state(const struct device *dev,
  */
 int64_t pm_policy_next_event_ticks(void);
 
+#if defined(CONFIG_PM_CUSTOM_TICKS_HOOK) || defined(__DOXYGEN__)
+/**
+ * @brief Get ticks to custom next event for PM policy.
+ *
+ * This optional hook allows providing an additional "next event"
+ * tick value derived from proprietary or hardware-specific sources
+ * that are not modeled via pm_policy_next_event_ticks().
+ *
+ * @kconfig_dep{CONFIG_PM_CUSTOM_TICKS_HOOK}
+ *
+ * @retval >0 If next custom event is in the future
+ * @retval 0 If next custom event is now or in the past
+ * @retval -1 If there is no custom event pending
+ */
+int64_t pm_policy_next_custom_ticks(void);
+#endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
+
 #else
 static inline void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 {
@@ -323,6 +340,13 @@ static inline int64_t pm_policy_next_event_ticks(void)
 {
 	return -1;
 }
+#ifdef CONFIG_PM_CUSTOM_TICKS_HOOK
+
+static inline int64_t pm_policy_next_custom_ticks(void)
+{
+	return -1;
+}
+#endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
 
 #endif /* CONFIG_PM */
 

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -27,6 +27,27 @@ config PM
 	  power management subsystem of the number of ticks until the next kernel
 	  timer is due to expire.
 
+config PM_CUSTOM_TICKS_HOOK
+	bool "Custom ticks hook for PM policy"
+	depends on PM
+	help
+	  This option enables a policy-level hook that can provide a
+	  custom "next event" tick value during pm_system_suspend().
+
+	  This is intended for cases where the next event timing is derived
+	  from proprietary or complex data sources that are not practical
+	  to translate into the standard PM policy event list. Typical
+	  examples include:
+	  - timing information stored in hardware registers
+	  - binary-only modules
+	  - complex scheduling data structures
+
+	  When enabled, the PM core will call pm_policy_next_custom_ticks()
+	  to obtain an additional candidate tick value, and will consider
+	  it when choosing the earliest expiry.
+
+	  If unsure, say N.
+
 rsource "policy/Kconfig"
 
 if PM

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -173,6 +173,12 @@ bool pm_system_suspend(int32_t kernel_ticks)
 	events_ticks = pm_policy_next_event_ticks();
 	ticks = ticks_expiring_sooner(kernel_ticks, events_ticks);
 
+#ifdef CONFIG_PM_CUSTOM_TICKS_HOOK
+	int32_t custom_ticks = pm_policy_next_custom_ticks();
+
+	ticks = ticks_expiring_sooner(custom_ticks, ticks);
+#endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
+
 	key = k_spin_lock(&pm_forced_state_lock);
 	if (z_cpus_pm_forced_state[id] != NULL) {
 		z_cpus_pm_state[id] = z_cpus_pm_forced_state[id];


### PR DESCRIPTION
Add an optional power policy hook to provide custom "next event" ticks during pm_system_suspend(), in addition to the existing kernel ticks and policy event list.

This hook enables applications and SoC-specific code to derive the next wake-up time directly from proprietary or hardware-specific data structures (e.g. hardware registers, binary-only modules, complex schedulers) that are not practical to convert into the standard PM policy event list.

The feature is gated by CONFIG_PM_CUSTOM_TICKS_HOOK and is fully backwards compatible when disabled.
@FrancescoCiminoST, @msmttchr, @vtardy-st, @Chastillon, @carnalfromst