### PR TITLE
dts: arm: microchip: mec: Fix compatible on last GPIO bank

### DIFF
--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -220,7 +220,7 @@
 			};
 
 			gpio_240_276: gpio@40081280 {
-				compatible = "microchip,mec5-gpio";
+				compatible = "microchip,xec-gpio";
 				reg = <0x40081280 0x80 0x40081314 0x04
 				       0x40081394 0x04 0x400813e8 0x04>;
 				gpio-controller;


### PR DESCRIPTION
The compatible for the last GPIO banks in Microchip MEC5 chip DTSI was not changed when the GPIO driver was updated. We changed the compatible to the correct name.