### PR TITLE
Bluetooth: BAP: BASE: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_base.c
+++ b/subsys/bluetooth/audio/bap_base.c
@@ -21,7 +21,6 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -177,7 +176,7 @@ const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad)
 	uint8_t subgroup_count;
 	void *uuid;
 
-	CHECKIF(ad == NULL) {
+	if (ad == NULL) {
 		LOG_DBG("data is NULL");
 
 		return NULL;
@@ -241,7 +240,7 @@ int bt_bap_base_get_size(const struct bt_bap_base *base)
 	uint8_t subgroup_count;
 	size_t size = 0;
 
-	CHECKIF(base == NULL) {
+	if (base == NULL) {
 		LOG_DBG("base is NULL");
 
 		return -EINVAL;
@@ -292,7 +291,7 @@ int bt_bap_base_get_pres_delay(const struct bt_bap_base *base)
 	struct net_buf_simple net_buf;
 	uint32_t pd;
 
-	CHECKIF(base == NULL) {
+	if (base == NULL) {
 		LOG_DBG("base is NULL");
 
 		return -EINVAL;
@@ -309,7 +308,7 @@ int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base)
 	struct net_buf_simple net_buf;
 	uint8_t subgroup_count;
 
-	CHECKIF(base == NULL) {
+	if (base == NULL) {
 		LOG_DBG("base is NULL");
 
 		return -EINVAL;
@@ -330,13 +329,13 @@ int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
 	struct net_buf_simple net_buf;
 	uint8_t subgroup_count;
 
-	CHECKIF(base == NULL) {
+	if (base == NULL) {
 		LOG_DBG("base is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(func == NULL) {
+	if (func == NULL) {
 		LOG_DBG("func is NULL");
 
 		return -EINVAL;
@@ -370,13 +369,13 @@ int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgrou
 {
 	struct net_buf_simple net_buf;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(codec_id == NULL) {
+	if (codec_id == NULL) {
 		LOG_DBG("codec_id is NULL");
 
 		return -EINVAL;
@@ -393,13 +392,13 @@ int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgr
 {
 	struct net_buf_simple net_buf;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(data == NULL) {
+	if (data == NULL) {
 		LOG_DBG("data is NULL");
 
 		return -EINVAL;
@@ -417,13 +416,13 @@ int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgr
 {
 	struct net_buf_simple net_buf;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(meta == NULL) {
+	if (meta == NULL) {
 		LOG_DBG("meta is NULL");
 
 		return -EINVAL;
@@ -448,13 +447,13 @@ int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *s
 	uint8_t *ltv_data;
 	uint8_t ltv_len;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(codec_cfg == NULL) {
+	if (codec_cfg == NULL) {
 		LOG_DBG("codec_cfg is NULL");
 
 		return -EINVAL;
@@ -500,7 +499,7 @@ int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgro
 {
 	struct net_buf_simple net_buf;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
@@ -519,13 +518,13 @@ int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup
 	struct net_buf_simple net_buf;
 	uint8_t bis_count;
 
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(func == NULL) {
+	if (func == NULL) {
 		LOG_DBG("func is NULL");
 
 		return -EINVAL;
@@ -563,13 +562,13 @@ int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup
 int bt_bap_base_subgroup_bis_codec_to_codec_cfg(const struct bt_bap_base_subgroup_bis *bis,
 						struct bt_audio_codec_cfg *codec_cfg)
 {
-	CHECKIF(bis == NULL) {
+	if (bis == NULL) {
 		LOG_DBG("bis is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(codec_cfg == NULL) {
+	if (codec_cfg == NULL) {
 		LOG_DBG("codec_cfg is NULL");
 
 		return -EINVAL;
@@ -612,13 +611,13 @@ static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *
 int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
 					 uint32_t *bis_indexes)
 {
-	CHECKIF(subgroup == NULL) {
+	if (subgroup == NULL) {
 		LOG_DBG("subgroup is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(bis_indexes == NULL) {
+	if (bis_indexes == NULL) {
 		LOG_DBG("bis_indexes is NULL");
 
 		return -EINVAL;
@@ -631,13 +630,13 @@ int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subg
 
 int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_indexes)
 {
-	CHECKIF(base == NULL) {
+	if (base == NULL) {
 		LOG_DBG("base is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(bis_indexes == NULL) {
+	if (bis_indexes == NULL) {
 		LOG_DBG("bis_indexes is NULL");
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.