### PR TITLE
drivers: clock_control: mspm0: Conditionally set syspllclk0 as the source of MCLK

### DIFF
--- a/drivers/clock_control/clock_control_mspm0.c
+++ b/drivers/clock_control/clock_control_mspm0.c
@@ -168,7 +168,9 @@ static int clock_mspm0_init(const struct device *dev)
 
 #if MSPM0_SYSPLL_ENABLED
 #if DT_SAME_NODE(DT_MCLK_CLOCKS_CTRL, DT_NODELABEL(syspll))
-	clock_mspm0_cfg_syspll.sysPLLMCLK = DL_SYSCTL_SYSPLL_MCLK_CLK0;
+	if (clock_mspm0_cfg_syspll.enableCLK0 == DL_SYSCTL_SYSPLL_CLK0_ENABLE) {
+		clock_mspm0_cfg_syspll.sysPLLMCLK = DL_SYSCTL_SYSPLL_MCLK_CLK0;
+	}
 #endif
 #if DT_SAME_NODE(DT_SYSPLL_CLOCKS_CTRL, DT_NODELABEL(hfclk))
 	clock_mspm0_cfg_syspll.sysPLLRef = DL_SYSCTL_SYSPLL_REF_HFCLK;


### PR DESCRIPTION
The mspm0g.dtsi DT sets the clk2x-div property for the syspll node in the DT to enable syspllclk2x. The MSPM0 clock control code has a compile-time check to ensure either syspllclk2x or syspllclk0 is enabled at a time. The clock control code; however, sets clk0 as the MCLK source even when syspllck2x is enabled (and syspllclk0 disabled). The changes in this commit would ensure syspllclk0 is only set as the source for MCLK if syspllclk0 is enabled. The syspllclk0 is considered enabled if clk0-div property is defined for the syspll node.

Fixes #100734.