### PR TITLE
MAINTAINERS: remove jfischer-no from display collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1181,7 +1181,6 @@ Display drivers:
   maintainers:
     - JarmouniA
   collaborators:
-    - jfischer-no
     - danieldegrasse
     - VynDragon
     - KATE-WANG-NXP


### PR DESCRIPTION
I do not have any plans in the near future to collaborate in this area.