### PR TITLE
drivers: haptics: Add IRQ acks in CS40L5x driver

### DIFF
--- a/drivers/haptics/cs40l5x.c
+++ b/drivers/haptics/cs40l5x.c
@@ -95,17 +95,17 @@ LOG_MODULE_REGISTER(CS40L5X, CONFIG_HAPTICS_LOG_LEVEL);
 #define CS40L5X_REG_CUSTOM_HEADER2_1   (CS40L5X_REG_CUSTOM_HEADER1_1 + 0xC)
 #define CS40L5X_REG_CUSTOM_DATA_1      (CS40L5X_REG_CUSTOM_HEADER1_1 + 0x14)
 
-#define CS40L5X_MASK_IRQ1_AMP        BIT(31)
-#define CS40L5X_MASK_IRQ8_TEMP       BIT(31)
-#define CS40L5X_MASK_IRQ9_UVP        BIT(6)
-#define CS40L5X_MASK_IRQ9_IND_SHORT  BIT(7)
-#define CS40L5X_MASK_IRQ9_CUR_LIMIT  BIT(8)
-#define CS40L5X_MASK_IRQ1_VDDB       BIT(16)
-#define CS40L5X_MASK_IRQ1_V2MBOX1    BIT(21)
-#define CS40L5X_MASK_INDEX           GENMASK(7, 0)
-#define CS40L5X_MASK_BANK            (GENMASK(27, 20) | BIT(7))
-#define CS40L5X_MASK_ATTENUATION     GENMASK(11, 9)
-#define CS40L5X_MASK_CUSTOM_PLAYBACK BIT(16)
+#define CS40L5X_MASK_IRQ1_AMPLIFIER_SHORT BIT(31)
+#define CS40L5X_MASK_IRQ8_OVERTEMPERATURE BIT(31)
+#define CS40L5X_MASK_IRQ9_UNDERVOLTAGE    BIT(6)
+#define CS40L5X_MASK_IRQ9_INDUCTOR_SHORT  BIT(7)
+#define CS40L5X_MASK_IRQ9_OVERCURRENT     BIT(8)
+#define CS40L5X_MASK_IRQ10_VDDB           BIT(16)
+#define CS40L5X_MASK_IRQ1_V2MBOX1         BIT(21)
+#define CS40L5X_MASK_INDEX                GENMASK(7, 0)
+#define CS40L5X_MASK_BANK                 (GENMASK(27, 20) | BIT(7))
+#define CS40L5X_MASK_ATTENUATION          GENMASK(11, 9)
+#define CS40L5X_MASK_CUSTOM_PLAYBACK      BIT(16)
 
 #define CS40L5X_MBOX_PREVENT_HIBERNATION 0x02000003
 #define CS40L5X_MBOX_ALLOW_HIBERNATION   0x02000004
@@ -882,67 +882,67 @@ static int cs40l5x_process_interrupts(const struct device *const dev,
 	uint32_t error_bitmask = 0;
 	int ret;
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ1_AMP, irq_ints[CS40L5X_INT1]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ1_AMPLIFIER_SHORT, irq_ints[CS40L5X_INT1]) != 0) {
 		LOG_INST_WRN(config->log, "amplifier short detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT1, CS40L5X_MASK_IRQ1_AMP);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT1, CS40L5X_MASK_IRQ1_AMPLIFIER_SHORT);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ8_TEMP, irq_ints[CS40L5X_INT8]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ8_OVERTEMPERATURE, irq_ints[CS40L5X_INT8]) != 0) {
 		LOG_INST_WRN(config->log, "overtemperature detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERTEMPERATURE;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT8, CS40L5X_MASK_IRQ8_TEMP);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT8, CS40L5X_MASK_IRQ8_OVERTEMPERATURE);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ9_UVP, irq_ints[CS40L5X_INT9]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ9_UNDERVOLTAGE, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "undervoltage detected");
 
 		error_bitmask |= HAPTICS_ERROR_UNDERVOLTAGE;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_UVP);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_UNDERVOLTAGE);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ9_IND_SHORT, irq_ints[CS40L5X_INT9]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ9_INDUCTOR_SHORT, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "inductor short detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_IND_SHORT);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_INDUCTOR_SHORT);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ9_CUR_LIMIT, irq_ints[CS40L5X_INT9]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ9_OVERCURRENT, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "overcurrent condition detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_CUR_LIMIT);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_OVERCURRENT);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	if (FIELD_GET(CS40L5X_MASK_IRQ1_VDDB, irq_ints[CS40L5X_INT10]) != 0) {
+	if (FIELD_GET(CS40L5X_MASK_IRQ10_VDDB, irq_ints[CS40L5X_INT10]) != 0) {
 		LOG_INST_WRN(config->log, "battery undervoltage detected");
 
 		error_bitmask |= HAPTICS_ERROR_UNDERVOLTAGE;
 
-		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT10, CS40L5X_MASK_IRQ1_VDDB);
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT10, CS40L5X_MASK_IRQ10_VDDB);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/haptics/cs40l5x.c
+++ b/drivers/haptics/cs40l5x.c
@@ -46,6 +46,9 @@ LOG_MODULE_REGISTER(CS40L5X, CONFIG_HAPTICS_LOG_LEVEL);
 #define CS40L5X_REG_IRQ1_STATUS        0x0000E004
 #define CS40L5X_REG_IRQ1_INT1          0x0000E010
 #define CS40L5X_REG_IRQ1_INT2          (CS40L5X_REG_IRQ1_INT1 + 0x4)
+#define CS40L5X_REG_IRQ1_INT8          (CS40L5X_REG_IRQ1_INT2 + 0x18)
+#define CS40L5X_REG_IRQ1_INT9          (CS40L5X_REG_IRQ1_INT8 + 0x4)
+#define CS40L5X_REG_IRQ1_INT10         (CS40L5X_REG_IRQ1_INT9 + 0x4)
 #define CS40L5X_REG_IRQ1_INT14         0x0000E044
 #define CS40L5X_REG_IRQ1_INT18         0x0000E054
 #define CS40L5X_REG_IRQ1_MASK1         0x0000E090
@@ -877,41 +880,72 @@ static int cs40l5x_process_interrupts(const struct device *const dev,
 {
 	__maybe_unused const struct cs40l5x_config *const config = dev->config;
 	uint32_t error_bitmask = 0;
+	int ret;
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ1_AMP, irq_ints[CS40L5X_INT1]) != 0) {
 		LOG_INST_WRN(config->log, "amplifier short detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT1, CS40L5X_MASK_IRQ1_AMP);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ8_TEMP, irq_ints[CS40L5X_INT8]) != 0) {
 		LOG_INST_WRN(config->log, "overtemperature detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERTEMPERATURE;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT8, CS40L5X_MASK_IRQ8_TEMP);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ9_UVP, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "undervoltage detected");
 
 		error_bitmask |= HAPTICS_ERROR_UNDERVOLTAGE;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_UVP);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ9_IND_SHORT, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "inductor short detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_IND_SHORT);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ9_CUR_LIMIT, irq_ints[CS40L5X_INT9]) != 0) {
 		LOG_INST_WRN(config->log, "overcurrent condition detected");
 
 		error_bitmask |= HAPTICS_ERROR_OVERCURRENT;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT9, CS40L5X_MASK_IRQ9_CUR_LIMIT);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (FIELD_GET(CS40L5X_MASK_IRQ1_VDDB, irq_ints[CS40L5X_INT10]) != 0) {
 		LOG_INST_WRN(config->log, "battery undervoltage detected");
 
 		error_bitmask |= HAPTICS_ERROR_UNDERVOLTAGE;
+
+		ret = cs40l5x_write(dev, CS40L5X_REG_IRQ1_INT10, CS40L5X_MASK_IRQ1_VDDB);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (error_bitmask != 0) {


### PR DESCRIPTION
Currently, the driver does not acknowledge error interrupts from the device, resulting in the IRQ being continuously set in certain cases. Add writes to acknowledge these interrupts and cleans up macro names to be more descriptive.