### PR TITLE
boards: infineon: kit_pse84_eval: board.cmake: Fix CM55 debug support

### DIFF
--- a/boards/infineon/kit_pse84_ai/board.cmake
+++ b/boards/infineon/kit_pse84_ai/board.cmake
@@ -5,6 +5,7 @@
 
 if(CONFIG_CPU_CORTEX_M55)
   # Connect to the second port for CM55 (default port is 3333)
+  board_runner_args(openocd "--gdb-init=disconnect")
   board_runner_args(openocd "--gdb-init=target extended-remote :3334")
 endif()
 

--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -5,6 +5,7 @@
 
 if(CONFIG_CPU_CORTEX_M55)
   # Connect to the second port for CM55 (default port is 3333)
+  board_runner_args(openocd "--gdb-init=disconnect")
   board_runner_args(openocd "--gdb-init=target extended-remote :3334")
 endif()
 


### PR DESCRIPTION
After connect to cat1d.cm33, do disconnect and connect to cat1d.cm55
-> in order to avoid "program is being debugged already" message while do "west attach" on CM55