### PR TITLE
drivers: usbc: adopt SHELL_HELP in shell modules

### DIFF
--- a/drivers/usb_c/ppc/shell.c
+++ b/drivers/usb_c/ppc/shell.c
@@ -118,16 +118,16 @@ SHELL_DYNAMIC_CMD_CREATE(list_device_names, device_name_get);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_ppc_cmds,
 			       SHELL_CMD_ARG(dump, &list_device_names,
-					     "Dump PPC registers\n"
-					     "Usage: ppc dump [<ppc device>]",
+					     SHELL_HELP("Dump PPC registers",
+							"[<ppc device>]"),
 					     cmd_ppc_dump, 1, 1),
 			       SHELL_CMD_ARG(status, &list_device_names,
-					     "Write PPC power status\n"
-					     "Usage: ppc status [<ppc device>]",
+					     SHELL_HELP("Display PPC power status",
+							"[<ppc device>]"),
 					     cmd_ppc_status, 1, 1),
 			       SHELL_CMD_ARG(exitdb, &list_device_names,
-					     "Exit from the dead battery mode\n"
-					     "Usage: ppc exitdb [<ppc device>]",
+					     SHELL_HELP("Exit from the dead battery mode",
+							"[<ppc device>]"),
 					     cmd_ppc_exit_db, 1, 1),
 			       SHELL_SUBCMD_SET_END);
 

--- a/drivers/usb_c/tcpc/shell.c
+++ b/drivers/usb_c/tcpc/shell.c
@@ -141,16 +141,16 @@ SHELL_DYNAMIC_CMD_CREATE(list_device_names, device_name_get);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_tcpc_cmds,
 			       SHELL_CMD_ARG(dump, &list_device_names,
-					     "Dump TCPC registers\n"
-					     "Usage: tcpc dump [<tcpc device>]",
+					     SHELL_HELP("Dump TCPC registers",
+							"[<tcpc device>]"),
 					     cmd_tcpc_dump, 1, 1),
 			       SHELL_CMD_ARG(vbus, &list_device_names,
-					     "Display VBUS voltage\n"
-					     "Usage: tcpc vbus [<vbus device>]",
+					     SHELL_HELP("Display VBUS voltage",
+							"[<vbus device>]"),
 					     cmd_tcpc_vbus, 1, 1),
 			       SHELL_CMD_ARG(chip, &list_device_names,
-					     "Display chip information\n"
-					     "Usage: tcpc chip [<tcpc device>]",
+					     SHELL_HELP("Display chip information",
+							"[<tcpc device>]"),
 					     cmd_tcpc_chip_info, 1, 1),
 			       SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
Use SHELL_HELP macro for help strings to ensure consistency across various shell modules and to save on code size.