### PR TITLE
arch: riscv: rename icsr_* to micsr_* for M-mode indirect CSR access

### DIFF
--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -272,37 +272,37 @@
 
 #ifdef CONFIG_RISCV_ISA_EXT_SMCSRIND
 
-static inline unsigned long icsr_read(unsigned int index)
+static inline unsigned long micsr_read(unsigned int index)
 {
 	csr_write(MISELECT, index);
 	return csr_read(MIREG);
 }
 
-static inline void icsr_write(unsigned int index, unsigned long value)
+static inline void micsr_write(unsigned int index, unsigned long value)
 {
 	csr_write(MISELECT, index);
 	csr_write(MIREG, value);
 }
 
-static inline void icsr_set(unsigned int index, unsigned long mask)
+static inline void micsr_set(unsigned int index, unsigned long mask)
 {
 	csr_write(MISELECT, index);
 	csr_set(MIREG, mask);
 }
 
-static inline void icsr_clear(unsigned int index, unsigned long mask)
+static inline void micsr_clear(unsigned int index, unsigned long mask)
 {
 	csr_write(MISELECT, index);
 	csr_clear(MIREG, mask);
 }
 
-static inline unsigned long icsr_read_set(unsigned int index, unsigned long mask)
+static inline unsigned long micsr_read_set(unsigned int index, unsigned long mask)
 {
 	csr_write(MISELECT, index);
 	return csr_read_set(MIREG, mask);
 }
 
-static inline unsigned long icsr_read_clear(unsigned int index, unsigned long mask)
+static inline unsigned long micsr_read_clear(unsigned int index, unsigned long mask)
 {
 	csr_write(MISELECT, index);
 	return csr_read_clear(MIREG, mask);


### PR DESCRIPTION
Rename indirect CSR access functions from `icsr_*` to `micsr_*` to explicitly indicate M-mode operation. Follows RISC-V naming convention (m/s prefixes for privilege levels). Called out on #102055 