### PR TITLE
drivers: uart: mcux_flexcomm: Avoid reading registers when no clock

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -165,6 +165,15 @@ static void mcux_flexcomm_poll_out(const struct device *dev,
 					     unsigned char c)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
+	uint32_t clock_rate;
+
+	/* Avoid touching UART registers while the peripheral clock is unavailable.
+	 * Some clock drivers report this as an error, while others return 0 Hz.
+	 */
+	if (((clock_control_get_rate(config->clock_dev, config->clock_subsys,
+				     &clock_rate)) != 0) || (clock_rate == 0U)) {
+		return;
+	}
 
 	/* Wait until space is available in TX FIFO, as per API description:
 	 * This routine checks if the transmitter is full.
@@ -177,8 +186,8 @@ static void mcux_flexcomm_poll_out(const struct device *dev,
 	USART_WriteByte(config->base, c);
 
 	/* Wait for the transfer to complete, as per API description:
-	 * This function is a blocking call. It blocks the calling thread until the character
-	 * is sent.
+	 * This function is a blocking call. It blocks the calling thread until the
+	 * character is sent.
 	 */
 	while (!(USART_GetStatusFlags(config->base) & kUSART_TxFifoEmptyFlag)) {
 	}


### PR DESCRIPTION
The uart_mcux_flexcomm driver must avoid reading registers from the uart when the clocks are not enabled. This will cause and infinite wait state blocking execution.
Fixes #102678 