### PR TITLE
tests: drivers: gpio: added gpio test support files

### DIFF
--- a/tests/drivers/gpio/gpio_hogs/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/sam_e54_xpro.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&portb 7 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&portb 8 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&portb 9 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&portb {
+	status = "okay";
+
+	hog1 {
+		gpio-hog;
+		gpios = <7 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_LOW>;
+		input;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/testcase.yaml
+++ b/tests/drivers/gpio/gpio_hogs/testcase.yaml
@@ -24,6 +24,7 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu1
       - xg29_rb4412a
       - bg29_rb4420a
+      - sam_e54_xpro
     integration_platforms:
       - native_sim
       - native_sim/native/64


### PR DESCRIPTION
- Added sam_e54_xpro overlay file for gpio_hogs test project.
- Added sam_e54_xpro platform allow in testcase.yaml