### PR TITLE
drivers: modem: cellular: Add auto APN for EG25-G

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -56,6 +56,17 @@ config MODEM_CELLULAR_APN
 	  If left empty the driver will wait for the application to call
 	  cellular_set_apn() before it proceeds to the dial phase.
 
+config MODEM_CELLULAR_APN_ALLOW_EMPTY
+	bool "Allow empty APN string"
+	default n
+	help
+	  Some cellular modem support automatic APN configuration when an
+	  empty APN string is provided. When enabled, this option allows the
+	  modem driver to accept and use empty APN strings from both the Kconfig
+	  setting and the cellular_set_apn() API. The modem will proceed with
+	  the connection sequence using the empty APN instead of waiting in the
+	  WAIT_FOR_APN state.
+
 config MODEM_CELLULAR_PERIODIC_SCRIPT_MS
 	int "Periodic script interval in milliseconds"
 	default 2000


### PR DESCRIPTION
Introduction:
the modem EG25 have an ability to get the apn via subscription according to ducument page 181 this allow the system to resolve APN by it  self. to using this ability. during PDP context creation the APN must omit or set to empty string.

<img width="660" height="63" alt="image" src="https://github.com/user-attachments/assets/704ba5d8-e11b-4b11-b343-964b3677a7d6" />

methodology:

We add new config to allow us to by pass the empty string check in APN setting function and config. we use bypass config to avoid complexity.

The result:
system can use the internet and obtain the ip address and able to ping and connect to target server

<img width="979" height="429" alt="image" src="https://github.com/user-attachments/assets/e2bff52b-b0db-46f5-a00d-b2ce2086b86a" />