### PR TITLE
boards: phytec: phyboard_atlas: xip: fix typos in comments

### DIFF
--- a/boards/phytec/phyboard_atlas/xip/phycore_rt1170_flexspi_nor_config.h
+++ b/boards/phytec/phyboard_atlas/xip/phycore_rt1170_flexspi_nor_config.h
@@ -113,7 +113,7 @@ enum {
 	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
 	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
-	/* Bit for DDR clock confiuration indication. */
+	/* Bit for DDR clock configuration indication. */
 	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
@@ -239,7 +239,7 @@ typedef struct flexspi_config {
 	 * 8 - Octal
 	 */
 	uint8_t sflash_pad_type;
-	/* [0x046-0x046] Serial Flash Frequencey, device specific
+	/* [0x046-0x046] Serial Flash Frequency, device specific
 	 * definitions, See System Boot Chapter for more details
 	 */
 	uint8_t serial_clk_freq;
@@ -355,7 +355,7 @@ typedef struct _flexspi_nor_config {
 	uint8_t need_exit_nocmd_mode;
 	/* Half the Serial Clock for non-read command: true/false */
 	uint8_t half_clk_for_non_read_cmd;
-	/* Need to Restore NoCmd mode after IP commmand execution */
+	/* Need to Restore NoCmd mode after IP command execution */
 	uint8_t need_restore_nocmd_mode;
 	/* Block size */
 	uint32_t block_size;


### PR DESCRIPTION
Fix spelling and wording issues in comments for phytec phyboard_atlas xip FlexSPI NOR configuration headers.

No functional change.