### PR TITLE
soc: nxp: mcxe24x: set WDT_DISABLE_AT_BOOT as y

### DIFF
--- a/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_MCXE24X
@@ -26,5 +26,8 @@ configdefault CACHE_MANAGEMENT
 choice CACHE_TYPE
 	default EXTERNAL_CACHE
 endchoice
+
+config WDT_DISABLE_AT_BOOT
+	default y
 
 endif # SOC_SERIES_MCXE24X


### PR DESCRIPTION
Enable WDT_DISABLE_AT_BOOT by default for MCXE24X SoC series to prevent unexpected system resets during initialization and development.

Fix #102551 