### PR TITLE
bluetooth: avdtp: Fix the avdtp tx keeps raising

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -445,6 +445,17 @@ static void avdtp_tx_frags(struct bt_avdtp *session, struct net_buf *buf,
 
 		if (frag == NULL) {
 			LOG_DBG("No Buff available, wait tx cb to trigger this work again");
+			/* Do NOT call `avdtp_tx_raise` here.
+			 * When there is no idle net_buf available while AVDTP TX is still pending,
+			 * the worker cannot proceed. If `avdtp_tx_raise` is invoked here, it will
+			 * immediately reschedule the worker again, causing it to spin and occupy
+			 * the CPU continuously because TX is pending but no idle net_buf exists.
+			 *
+			 * `avdtp_tx_raise` should only be triggered when at least one idle net_buf
+			 * is available. After the previously transmitted avdtp net_buf is released,
+			 * `avdtp_tx_cb` will run, and that callback will safely trigger
+			 * `avdtp_tx_raise` again.
+			 */
 			return;
 		}
 
@@ -515,6 +526,8 @@ static void avdtp_tx_frags(struct bt_avdtp *session, struct net_buf *buf,
 		avdtp_tx_remove(buf);
 		net_buf_unref(buf);
 	}
+
+	avdtp_tx_raise();
 }
 
 static void avdtp_tx_processor(struct k_work *item)
@@ -547,8 +560,6 @@ static void avdtp_tx_processor(struct k_work *item)
 	}
 
 	avdtp_tx_frags(session, buf, user_data);
-
-	avdtp_tx_raise();
 }
 
 static void avdtp_buf_init_user_data(struct bt_avdtp *session, struct net_buf *buf)


### PR DESCRIPTION
Move the avdtp_tx_raise() call from avdtp_tx_processor() into avdtp_tx_frags() to ensure the tx is not raised if there is no idle net_buf.