### PR TITLE
net: lib: midi2: fix reverse null dereference in auth_session

### DIFF
--- a/subsys/net/lib/midi2/netmidi2.c
+++ b/subsys/net/lib/midi2/netmidi2.c
@@ -104,14 +104,19 @@ static bool netmidi2_auth_session(const struct netmidi2_session *sess,
 	const uint8_t *auth_digest = buf->data;
 	const struct netmidi2_user *user;
 	uint8_t output[NETMIDI2_DIGEST_SIZE];
-	struct hash_ctx ctx = {.flags = crypto_query_hwcaps(hasher)};
-	struct hash_pkt hash = {.out_buf = output, .ctx = &ctx};
+	struct hash_ctx ctx = {0};
+	struct hash_pkt hash = {0};
 	int ret;
 
 	if (hasher == NULL) {
 		SESS_LOG_ERR(sess, "mbedtls crypto pseudo-device unavailable");
 		return false;
 	}
+
+	/* Assign values after the NULL check */
+	ctx.flags = crypto_query_hwcaps(hasher);
+	hash.out_buf = output;
+	hash.ctx = &ctx;
 
 	if (buf->len < NETMIDI2_DIGEST_SIZE || payload_len < NETMIDI2_DIGEST_SIZE) {
 		SESS_LOG_ERR(sess, "Incomplete authentication digest");


### PR DESCRIPTION
Coverity identified a REVERSE_INULL defect (CID 551615). The 'hasher' pointer was dereferenced in crypto_query_hwcaps() before it was checked for NULL.

This patch reorders the logic to check the pointer immediately after device_get_binding().

Fixes CID 551615