### PR TITLE
dts: auxdisplay: add auxdisplay_0 label to sparkfun,serlcd example

### DIFF
--- a/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
+++ b/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
@@ -46,7 +46,7 @@ properties:
 examples:
   - |
     &i2c1 {
-      serlcd@72 {
+      auxdisplay_0: serlcd@72 {
         compatible = "sparkfun,serlcd";
         reg = <0x72>;
         columns = <16>;


### PR DESCRIPTION
This is technically a workaround for a limitation in the Pygments DTS lexer causing the highlighting to break when rendering this example in the documentation, but this is also an excuse to plug the label that is used in the official auxdisplay sample.

**This fixes doc CI currently broken on main. https://github.com/zephyrproject-rtos/zephyr/actions/runs/21241718739**

Not clear why the lexer is unhappy with the original construct but I'll try to look into it ~~and submit a pygments patch at some point.~~ see https://github.com/pygments/pygments/pull/3021

<img width="1444" height="474" alt="image" src="https://github.com/user-attachments/assets/0c7cbc72-9feb-41b3-9706-c1f52f028741" />

@rruuaanng once again, in the future please try to test locally when you're making changes that impact the "full" HTML build :)