### PR TITLE
dts: firmware: SCMI bindings cleanup

### DIFF
--- a/dts/bindings/firmware/arm,scmi-clock.yaml
+++ b/dts/bindings/firmware/arm,scmi-clock.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) clock protocol
+title: SCMI (System Control and Management Interface) clock control
+
+description: SCMI clock control for SoC-managed clocks exposed to agents.
 
 compatible: "arm,scmi-clock"
 

--- a/dts/bindings/firmware/arm,scmi-pinctrl.yaml
+++ b/dts/bindings/firmware/arm,scmi-pinctrl.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) pinctrl protocol
+title: SCMI (System Control and Management Interface) pin control
+
+description: SCMI pin control groups used to configure multiplexing and bias.
 
 compatible: "arm,scmi-pinctrl"
 

--- a/dts/bindings/firmware/arm,scmi-power.yaml
+++ b/dts/bindings/firmware/arm,scmi-power.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) power domain protocol
+title: SCMI (System Control and Management Interface) power domain
+
+description: SCMI power domain controller for agent-requested power state changes.
 
 compatible: "arm,scmi-power"
 

--- a/dts/bindings/firmware/arm,scmi-shmem.yaml
+++ b/dts/bindings/firmware/arm,scmi-shmem.yaml
@@ -1,7 +1,9 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) SHMEM (shared memory)
+title: SCMI (System Control and Management Interface) shared memory
+
+description: Shared memory region used for SCMI message payload exchange.
 
 compatible: "arm,scmi-shmem"
 

--- a/dts/bindings/firmware/arm,scmi-system.yaml
+++ b/dts/bindings/firmware/arm,scmi-system.yaml
@@ -1,7 +1,9 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) system power protocol
+title: SCMI (System Control and Management Interface) system power
+
+description: SCMI interface for requesting system-wide power state changes.
 
 compatible: "arm,scmi-system"
 

--- a/dts/bindings/firmware/arm,scmi.yaml
+++ b/dts/bindings/firmware/arm,scmi.yaml
@@ -5,43 +5,6 @@ description: |
         SCMI (System Control and Management Interface) with doorbell
         and SHMEM (shared memory) transport.
 
-        Devicetree example:
-            #include <mem.h>
-
-            scmi_res0: memory@44611000 {
-                compatible = "arm,scmi-shmem";
-                reg = <0x44611000 0x80>;
-            };
-
-            mu5: mailbox@44610000 {
-                compatible = "nxp,mbox-imx-mu";
-                reg = <0x44610000 DT_SIZE_K(4)>;
-                interrupts = <205 0>;
-                #mbox-cells = <1>;
-            };
-
-            scmi {
-                compatible = "arm,scmi";
-                shmem = <&scmi_res0>;
-                mboxes = <&mu5 0>;
-                mbox-names = "tx";
-
-                protocol@14 {
-                    compatible = "arm,scmi-clock";
-                    reg = <0x14>;
-                    #clock-cells = <1>;
-                };
-
-                protocol@19 {
-                    compatible = "arm,scmi-pinctrl";
-                    reg = <0x19>;
-
-                    pinctrl {
-                        compatible = "nxp,imx95-pinctrl", "nxp,imx93-pinctrl";
-                    };
-                };
-            };
-
 compatible: "arm,scmi"
 
 include: [base.yaml]
@@ -66,3 +29,41 @@ properties:
   mbox-names:
     required: true
     description: mailbox channel specifier names
+
+examples:
+  - |
+    #include <mem.h>
+
+    scmi_res0: memory@44611000 {
+        compatible = "arm,scmi-shmem";
+        reg = <0x44611000 0x80>;
+    };
+
+    mu5: mailbox@44610000 {
+        compatible = "nxp,mbox-imx-mu";
+        reg = <0x44610000 DT_SIZE_K(4)>;
+        interrupts = <205 0>;
+        #mbox-cells = <1>;
+    };
+
+    scmi {
+        compatible = "arm,scmi";
+        shmem = <&scmi_res0>;
+        mboxes = <&mu5 0>;
+        mbox-names = "tx";
+
+        protocol@14 {
+            compatible = "arm,scmi-clock";
+            reg = <0x14>;
+            #clock-cells = <1>;
+        };
+
+        protocol@19 {
+            compatible = "arm,scmi-pinctrl";
+            reg = <0x19>;
+
+            pinctrl {
+                compatible = "nxp,imx95-pinctrl", "nxp,imx93-pinctrl";
+            };
+        };
+    };

--- a/dts/bindings/firmware/arm,scmi.yaml
+++ b/dts/bindings/firmware/arm,scmi.yaml
@@ -1,9 +1,10 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-        SCMI (System Control and Management Interface) with doorbell
-        and SHMEM (shared memory) transport.
+title: |
+  SCMI (System Control and Management Interface) with doorbell and shared memory transport.
+
+description: SCMI transport using mailbox doorbells with shared memory payloads.
 
 compatible: "arm,scmi"
 

--- a/dts/bindings/firmware/nxp,scmi-cpu.yaml
+++ b/dts/bindings/firmware/nxp,scmi-cpu.yaml
@@ -1,7 +1,9 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) cpu domain protocol
+title: SCMI (System Control and Management Interface) CPU (Central Processing Unit) domain
+
+description: NXP SCMI CPU domain management for per-core power and state control.
 
 compatible: "nxp,scmi-cpu"
 

--- a/dts/bindings/firmware/ti,k2g-sci.yaml
+++ b/dts/bindings/firmware/ti,k2g-sci.yaml
@@ -1,7 +1,9 @@
 # Copyright 2025 Texas Instruments Incorporated.
 # SPDX-License-Identifier: Apache-2.0
 
-description: TISCI Client Driver
+title: TI SCI (Texas Instruments System Control Interface) client
+
+description: Client interface to TI SCI firmware using mailbox channels.
 
 compatible: "ti,k2g-sci"
 

--- a/dts/bindings/power-domain/arm,scmi-power-domain.yaml
+++ b/dts/bindings/power-domain/arm,scmi-power-domain.yaml
@@ -1,7 +1,9 @@
 # Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: SCMI (System Control and Management Interface) power domain
+title: SCMI (System Control and Management Interface) power domain
+
+description: SCMI power domain provider for SoC-managed domains.
 
 compatible: "arm,scmi-power-domain"
 


### PR DESCRIPTION
- Use title in lieu of description
- Put DTS snippets in "examples:" section

<img width="1453" height="764" alt="image" src="https://github.com/user-attachments/assets/b5d39c04-fdc6-466d-ad5a-b4d11e09fe8e" />
