### PR TITLE
bluetooth: host: add kconfig for evt synchronous buffer pool

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -1204,4 +1204,13 @@ config BT_HCI_VS_EVT_USER
 	  Enable registering a callback for delegating to the user the handling of
 	  VS events that are not known to the stack
 
+config BT_BUF_SYNC_EVT_POOL_COUNT
+	int "Num of Sync event buffer pool count"
+	range 1 $(UINT8_MAX)
+	default 1
+	help
+	  This option enables vendor to configure number of sync event buffer count
+	  based on application needs. The default value for sync event buf pool
+	  count would be 1.
+
 endmenu

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -74,7 +74,7 @@ static void iso_rx_freed_cb(void)
  * the HCI transport to fill buffers in parallel with `bt_recv`
  * consuming them.
  */
-NET_BUF_POOL_FIXED_DEFINE(sync_evt_pool, 1, SYNC_EVT_SIZE, 0, NULL);
+NET_BUF_POOL_FIXED_DEFINE(sync_evt_pool, CONFIG_BT_BUF_SYNC_EVT_POOL_COUNT, SYNC_EVT_SIZE, 0, NULL);
 
 NET_BUF_POOL_FIXED_DEFINE(discardable_pool, CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT,
 			  BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE),


### PR DESCRIPTION
- Add kconfig for HCI event synchronous buf pool to allow vendors to configure buffer count based on the application/host platform requirements