### PR TITLE
tests: arch: arm_irq_advanced_features: allow overriding IRQ offset

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/Kconfig
+++ b/tests/arch/arm/arm_irq_advanced_features/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_DIRECT_IRQ_MAX
+	int "Max offset of direct IRQ used for the test"
+	default NUM_IRQS
+
+source "Kconfig.zephyr"

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -13,7 +13,7 @@
 #ifdef CONFIG_2ND_LVL_ISR_TBL_OFFSET
 #define DIRECT_ISR_OFFSET (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
 #else
-#define DIRECT_ISR_OFFSET (CONFIG_NUM_IRQS - 1)
+#define DIRECT_ISR_OFFSET (CONFIG_TEST_DIRECT_IRQ_MAX - 1)
 #endif
 
 static volatile int test_flag;


### PR DESCRIPTION
The default (CONFIG_NUM_IRQS - 1) does not always work, as proven in other cases in this test. Finding the free IRQ during runtime is not possible, as DIRECT_DYNAMIC_CONNECT requires constant value. Thus, added Kconfig option to override the maximum IRQ offset at build time.