### PR TITLE
soc: st: stm32mp2x: add OpenAMP resource table section to linker script

### DIFF
--- a/soc/st/stm32/stm32mp2x/m33/linker.ld
+++ b/soc/st/stm32/stm32mp2x/m33/linker.ld
@@ -9,3 +9,13 @@
 #define rom_start .isr_vectors
 
 #include <zephyr/arch/arm/cortex_m/scripts/linker.ld>
+
+SECTIONS
+{
+#ifdef CONFIG_OPENAMP_RSC_TABLE
+	SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
+	{
+		KEEP(*(.resource_table*))
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+}


### PR DESCRIPTION
The `.resource_table` section was not declared anywhere, leading to an "orphan section" linker warning when OpenAMP was used with the resource table enabled.

Fix it by adding the missing section to the SoC-specific linker script. (the section is identical to the one defined for STM32MP1x series)