### PR TITLE
boards: arduino: portenta_h7 : Update doc about WiFi functionality

### DIFF
--- a/boards/arduino/portenta_h7/doc/index.rst
+++ b/boards/arduino/portenta_h7/doc/index.rst
@@ -36,8 +36,6 @@ information on how to build for specific revisions of the board).
 
 Applications that intend to use BLE must specify hardware revision at build time.
 
-Currently only BLE is supported on this board, WiFi is not supported.
-
 Fetch Binary Blobs
 ******************
 


### PR DESCRIPTION
Removes a forgotten note about the WiFi feature, which is now supported.