### PR TITLE
Improve snippet overlays for xen_dom0

### DIFF
--- a/boards/raspberrypi/rpi_5/doc/index.rst
+++ b/boards/raspberrypi/rpi_5/doc/index.rst
@@ -140,3 +140,24 @@ When you power on the Raspberry Pi 5, you will see the following output in the s
 
 .. _Raspberry Pi Debug Probe:
    https://www.raspberrypi.com/products/debug-probe/
+
+XEN Dom0
+========
+
+The Raspberry Pi 5 platform can be used to run as Xen Zephyr Dom0. For such
+purposes the ``xen_dom0`` snippet can be used.
+
+Run below command as an example of RPI 5 Zephyr build as Dom0:
+
+.. code-block:: bash
+
+   west build -b rpi_5 -p always -S xen_dom0 samples/hello_world
+
+It is expected to be used with special application performing Xen Domain-0/Dom0 functions.
+
+.. note::
+
+   The "hypervisor@x" and "memory@x" DT nodes need to be specified in
+   DT application overlay with values provided on the Xen boot, because
+   normaly Xen will update DT for the target Kernel, but this is not possible
+   in case of Zephyr. More details described in :ref:`xen_dom0`.

--- a/snippets/xen_dom0/README.rst
+++ b/snippets/xen_dom0/README.rst
@@ -12,8 +12,9 @@ is implemented as configuration snippet to allow support for any compatible plat
 How to add support of a new board
 *********************************
 
-* add board dts overlay to this snippet which deletes/adds memory and deletes UART nodes;
-* add correct memory and hypervisor nodes, based on regions Xen picked for Domain-0 on your setup.
+* add board dt overlay to this snippet which deletes UART nodes.
+* in application dt overlay add correct memory and hypervisor nodes, based on regions
+  Xen picked for Domain-0 on your setup.
 
 Programming
 ***********
@@ -37,6 +38,56 @@ To run such setup, you need to:
 * fetch and build Xen (e.g. RELEASE-4.17.0) for arm64 platform
 * take and compile sample device tree from :file:`example/` directory
 * build your Zephyr sample/application with ``xen_dom0`` snippet and start it as Xen control domain
+
+Important notice regarding device tree
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Xen allocates addresses used for Dom0 image and grant tables/extended regions dynamically so they
+may differ on specific setups (they depend on memory banks location and size, application
+image size, hypervisor load address used by bootloader etc.). Since Zephyr does not parse device
+tree in runtime and is not a position independent executable, it needs to know exact values on
+build time. To make it you need to build your final binary, try to boot it with Xen and analyze
+the hypervisor output to get exact addresses for your setup. They will look as follows:
+
+Grant table region (first reg in hypervisor node):
+
+.. code-block:: console
+
+    (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+
+Extended regions (2nd and further regs in hypervisor node):
+
+.. code-block:: console
+
+    (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+
+Zephyr Dom0 memory:
+
+.. code-block:: console
+
+    (XEN) Allocating 1:1 mappings for dom0:
+    (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
+
+Device tree nodes, that should be added by application overlay for provided example
+(based on R-Car H3ULCB with extended region):
+
+.. code-block:: devicetree
+
+    hypervisor: hypervisor@88080000 {
+        compatible = "xen,xen";
+        reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+        interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+        interrupt-parent = <&gic>;
+        status = "okay";
+    };
+
+    ram: memory@60000000 {
+        device_type = "mmio-sram";
+        reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
+    };
+
+Start the example
+^^^^^^^^^^^^^^^^^
 
 For starting you can use QEMU from Zephyr SDK by following command:
 

--- a/snippets/xen_dom0/boards/qemu_cortex_a53.overlay
+++ b/snippets/xen_dom0/boards/qemu_cortex_a53.overlay
@@ -4,44 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &sram0;
-
 &uart0 {
 	/* Xen consoleio will be used */
 	status = "disabled";
-};
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000040200000-0x00000040240000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@40200000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x40200000 0x0 0x40000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000058000000-0x00000060000000 (128MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	soc {
-		sram0: memory@58000000 {
-			device_type = "mmio-sram";
-			reg = <0x00 0x58000000 0x00 DT_SIZE_M(128)>;
-		};
-	};
 };

--- a/snippets/xen_dom0/boards/rcar_h3ulcb_r8a77951_a57.overlay
+++ b/snippets/xen_dom0/boards/rcar_h3ulcb_r8a77951_a57.overlay
@@ -4,38 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &scif2;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@88080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x88080000 0x0 0x40000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@60000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
-	};
-};

--- a/snippets/xen_dom0/boards/rcar_salvator_xs.overlay
+++ b/snippets/xen_dom0/boards/rcar_salvator_xs.overlay
@@ -4,38 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &scif2;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@88080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x88080000 0x0 0x40000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@60000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
-	};
-};

--- a/snippets/xen_dom0/boards/rcar_spider_s4_r8a779f0_a55.overlay
+++ b/snippets/xen_dom0/boards/rcar_spider_s4_r8a779f0_a55.overlay
@@ -4,40 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &hscif0;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000078080000-0x000000780c0000
-	 * Also, add extended region 1:
-	 * (XEN) Extended region 1: 0x40000000->0x47e00000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@78080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x78080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000080000000-0x00000090000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@80000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x80000000 0x00 DT_SIZE_M(256)>;
-	};
-};


### PR DESCRIPTION
Snippets allow modification of Kconfig build options and board device
trees during application or sample builds. However, in the case of device
trees, snippet modifications are applied at the end of device tree
generation.

This prevents the final application from setting correct values for memory
and hypervisor nodes, which may be changed at runtime by the Xen
hypervisor (depends on the final configuration, such as image size, memory
bank sizes, and load addresses, etc) since these are allocated
dynamically.

Remove these nodes from the snippet to enable applications to set these
values through their own application overlay.

**Changes:**
- remove Xen DT nodes modification from boards:
  - h3ulcb
  - salvator_xs_m3
  - spider_ca55
  - qemu_cortex_a53
- update documentation