### PR TITLE
Bluetooth: TBS: set_uri_scheme_list single string instead of array

### DIFF
--- a/doc/connectivity/bluetooth/shell/audio/tbs.rst
+++ b/doc/connectivity/bluetooth/shell/audio/tbs.rst
@@ -199,8 +199,7 @@ GTBS bearer.
                                     gtbs}>] <strength>
       set_status_flags            :Set the bearer feature and status value
                                     [<{instance_index, gtbs}>] <feature_and_status>
-      set_uri_scheme              :Set the URI prefix list <bearer_idx> <uri1 [uri2
-                                    [uri3 [...]]]>
+      set_uri_scheme              :Set the URI prefix list <bearer_idx> <uri1[,uri2[,uri3[,...]]]>
       print_calls                 :Output all calls in the debug log
 
 Example Usage

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -850,6 +850,9 @@ Bluetooth Audio
 * :kconfig:option:`CONFIG_BT_AUDIO` now depends on :kconfig:option:`CONFIG_UTF8`.
   Applications that enable :kconfig:option:`CONFIG_BT_AUDIO` must also have
   :kconfig:option:`CONFIG_UTF8` enabled. (:github:`102350`)
+* :c:func:`bt_tbs_set_uri_scheme_list` now only takes a single string value,
+  instead of a list/array of URIs. Applications will need to modify any current input
+  from e.g. ``{"tel", "skype"}`` to ``"tel,skype"``. (:github:`102724`)
 
 Bluetooth Mesh
 ==============

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -460,13 +460,11 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags);
  * @brief Sets the URI scheme list of a bearer.
  *
  * @param bearer_index  The index of the Telephone Bearer.
- * @param uri_list      List of URI prefixes (e.g. {"skype", "tel"}).
- * @param uri_count     Number of URI prefixies in @p uri_list.
+ * @param uri_scheme_list Comma-separated list of URI prefixes (e.g. "skype,tel").
  *
  * @return BT_TBS_RESULT_CODE_* if positive or 0, errno value if negative.
  */
-int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
-			       uint8_t uri_count);
+int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char *uri_scheme_list);
 /**
  * @brief Register the callbacks for TBS.
  *

--- a/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
+++ b/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
@@ -16,10 +16,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-#define URI_LIST_LEN	2
-
-static const char *uri_list[URI_LIST_LEN] = {"skype", "tel"};
-
 static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 				  const char *caller_id)
 {
@@ -65,7 +61,7 @@ int ccp_call_control_server_init(void)
 	}
 
 	bt_tbs_register_cb(&tbs_cbs);
-	err = bt_tbs_set_uri_scheme_list(BT_TBS_GTBS_INDEX, (const char **)&uri_list, URI_LIST_LEN);
+	err = bt_tbs_set_uri_scheme_list(BT_TBS_GTBS_INDEX, "skype,tel");
 
 	return err;
 }

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -698,9 +698,7 @@ static int cmd_tbs_set_uri_scheme_list(const struct shell *sh, size_t argc,
 		service_index = BT_TBS_GTBS_INDEX;
 	}
 
-	result = bt_tbs_set_uri_scheme_list((uint8_t)service_index,
-					    (const char **)&argv[2],
-					    argc - 2);
+	result = bt_tbs_set_uri_scheme_list((uint8_t)service_index, argv[2]);
 
 	if (result != BT_TBS_RESULT_CODE_SUCCESS) {
 		shell_print(sh, "Could not set URI prefix list: %d", result);
@@ -794,8 +792,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(tbs_cmds,
 		      cmd_tbs_set_status_flags, 2, 1),
 	SHELL_CMD_ARG(set_uri_scheme, NULL,
 		      "Set the URI prefix list <bearer_idx> "
-		      "<uri1 [uri2 [uri3 [...]]]>",
-		      cmd_tbs_set_uri_scheme_list, 3, 30),
+		      "<uri1[,uri2[,uri3[,...]]]>",
+		      cmd_tbs_set_uri_scheme_list, 3, 0),
 	SHELL_CMD_ARG(print_calls, NULL,
 		      "Output all calls in the debug log",
 		      cmd_tbs_print_calls, 1, 0),

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -1001,7 +1001,6 @@ static uint8_t tbs_set_uri_scheme_list(const void *cmd, uint16_t cmd_len, void *
 {
 	const struct btp_tbs_set_uri_schemes_list_cmd *cp = cmd;
 	char uri_list[CONFIG_BT_TBS_MAX_SCHEME_LIST_LENGTH];
-	char *uri_ptr = (char *)&uri_list;
 	int err;
 
 	LOG_DBG("TBS Set Uri Scheme list");
@@ -1018,7 +1017,7 @@ static uint8_t tbs_set_uri_scheme_list(const void *cmd, uint16_t cmd_len, void *
 		return BTP_STATUS_FAILED;
 	}
 
-	err = bt_tbs_set_uri_scheme_list(cp->index, (const char **)&uri_ptr, cp->uri_count);
+	err = bt_tbs_set_uri_scheme_list(cp->index, uri_list);
 	if (err) {
 		return BTP_STATUS_FAILED;
 	}


### PR DESCRIPTION
Refactor bt_tbs_set_uri_scheme_list to take a single string instead of an array of URIs. This should not affect applications much in any way (and may actually be easier to use), but simplifies the implementation significantly, and reduces memory footprint.

Additionally it also make the client and server more similar as bt_tbs_client_read_uri_list just returns it as a single string as well.