### PR TITLE
serial: uart: assume irq_update is not needed, when NULL

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -789,6 +789,10 @@ Serial
   :c:func:`pl011_err_check`, which is the appropriate place to detect,
   and report receive error conditions. (:github:`101715`)
 
+* :c:func:`uart_irq_update` will no longer return ``-ENOSYS`` and will return
+  ``1`` instead, as it is now allowed to not implement this function, when it is not
+  needed. (:github:`102725`)
+
 Settings
 ========
 

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -215,11 +215,6 @@ static int leuart_gecko_irq_is_pending(const struct device *dev)
 	return leuart_gecko_irq_tx_ready(dev) || leuart_gecko_irq_rx_ready(dev);
 }
 
-static int leuart_gecko_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void leuart_gecko_irq_callback_set(const struct device *dev,
 					  uart_irq_callback_user_data_t cb,
 					  void *cb_data)
@@ -312,7 +307,6 @@ static DEVICE_API(uart, leuart_gecko_driver_api) = {
 	.irq_err_enable = leuart_gecko_irq_err_enable,
 	.irq_err_disable = leuart_gecko_irq_err_disable,
 	.irq_is_pending = leuart_gecko_irq_is_pending,
-	.irq_update = leuart_gecko_irq_update,
 	.irq_callback_set = leuart_gecko_irq_callback_set,
 #endif
 };

--- a/drivers/serial/serial_test.c
+++ b/drivers/serial/serial_test.c
@@ -155,11 +155,6 @@ static void irq_callback_set(const struct device *dev, uart_irq_callback_user_da
 	LOG_DBG("callback set");
 }
 
-static int irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static int fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)
 {
 	struct serial_vnd_data *data = dev->data;
@@ -438,7 +433,6 @@ static DEVICE_API(uart, serial_vnd_api) = {
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_callback_set = irq_callback_set,
-	.irq_update = irq_update,
 	.irq_rx_enable = irq_rx_enable,
 	.irq_rx_disable = irq_rx_disable,
 	.irq_rx_ready = irq_rx_ready,

--- a/drivers/serial/uart_altera_jtag.c
+++ b/drivers/serial/uart_altera_jtag.c
@@ -411,18 +411,6 @@ static int uart_altera_jtag_irq_rx_ready(const struct device *dev)
 }
 
 /**
- * @brief Update cached contents of IIR
- *
- * @param dev UART device instance
- *
- * @return Always 1
- */
-static int uart_altera_jtag_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
-/**
  * @brief Check if any IRQ is pending
  *
  * @param dev UART device instance
@@ -505,7 +493,6 @@ static DEVICE_API(uart, uart_altera_jtag_driver_api) = {
 	.irq_rx_disable = uart_altera_jtag_irq_rx_disable,
 	.irq_rx_ready = uart_altera_jtag_irq_rx_ready,
 	.irq_is_pending = uart_altera_jtag_irq_is_pending,
-	.irq_update = uart_altera_jtag_irq_update,
 	.irq_callback_set = uart_altera_jtag_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_ambiq.c
+++ b/drivers/serial/uart_ambiq.c
@@ -504,11 +504,6 @@ static int uart_ambiq_irq_is_pending(const struct device *dev)
 	return uart_ambiq_irq_rx_ready(dev) || uart_ambiq_irq_tx_ready(dev);
 }
 
-static int uart_ambiq_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_ambiq_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					void *cb_data)
 {
@@ -1095,7 +1090,6 @@ static DEVICE_API(uart, uart_ambiq_driver_api) = {
 	.irq_err_enable = uart_ambiq_irq_err_enable,
 	.irq_err_disable = uart_ambiq_irq_err_disable,
 	.irq_is_pending = uart_ambiq_irq_is_pending,
-	.irq_update = uart_ambiq_irq_update,
 	.irq_callback_set = uart_ambiq_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_ameba_loguart.c
+++ b/drivers/serial/uart_ameba_loguart.c
@@ -210,11 +210,6 @@ static int loguart_ameba_irq_is_pending(const struct device *dev)
 	return loguart_ameba_irq_tx_ready(dev) || loguart_ameba_irq_rx_ready(dev);
 }
 
-static int loguart_ameba_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void loguart_ameba_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -297,7 +292,6 @@ static const struct uart_driver_api loguart_ameba_driver_api = {
 	.irq_err_enable = loguart_ameba_irq_err_enable,
 	.irq_err_disable = loguart_ameba_irq_err_disable,
 	.irq_is_pending = loguart_ameba_irq_is_pending,
-	.irq_update = loguart_ameba_irq_update,
 	.irq_callback_set = loguart_ameba_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -459,11 +459,6 @@ static int apbuart_irq_is_pending(const struct device *dev)
 	return 0;
 }
 
-static int apbuart_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void apbuart_irq_callback_set(const struct device *dev,
 				     uart_irq_callback_user_data_t cb,
 				     void *cb_data)
@@ -535,7 +530,6 @@ static DEVICE_API(uart, apbuart_driver_api) = {
 	.irq_tx_complete        = apbuart_irq_tx_complete,
 	.irq_rx_ready           = apbuart_irq_rx_ready,
 	.irq_is_pending         = apbuart_irq_is_pending,
-	.irq_update             = apbuart_irq_update,
 	.irq_callback_set       = apbuart_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -320,12 +320,6 @@ int z_uart_async_to_irq_irq_is_pending(const struct device *dev)
 	return tx_rdy || rx_rdy || err_pending;
 }
 
-/** Interrupt driven interrupt update function */
-int z_uart_async_to_irq_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 /** Set the irq callback function */
 void z_uart_async_to_irq_irq_callback_set(const struct device *dev,
 			 uart_irq_callback_user_data_t cb,

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -500,15 +500,6 @@ static int uart_b91_irq_is_pending(const struct device *dev)
 	return ((uart->status & UART_IRQ_STATUS) != 0) ? 1 : 0;
 }
 
-/* API implementation: irq_update */
-static int uart_b91_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/* nothing to be done */
-	return 1;
-}
-
 /* API implementation: irq_callback_set */
 static void uart_b91_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
@@ -543,7 +534,6 @@ static DEVICE_API(uart, uart_b91_driver_api) = {
 	.irq_err_enable = uart_b91_irq_err_enable,
 	.irq_err_disable = uart_b91_irq_err_disable,
 	.irq_is_pending = uart_b91_irq_is_pending,
-	.irq_update = uart_b91_irq_update,
 	.irq_callback_set = uart_b91_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -240,11 +240,6 @@ static int uart_bcm2711_irq_is_pending(const struct device *dev)
 		bcm2711_mu_lowlevel_can_putc(uart_data->uart_addr);
 }
 
-static int uart_bcm2711_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_bcm2711_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
@@ -289,7 +284,6 @@ static DEVICE_API(uart, uart_bcm2711_driver_api) = {
 	.irq_rx_disable   = uart_bcm2711_irq_rx_disable,
 	.irq_rx_ready	  = uart_bcm2711_irq_rx_ready,
 	.irq_is_pending   = uart_bcm2711_irq_is_pending,
-	.irq_update		  = uart_bcm2711_irq_update,
 	.irq_callback_set = uart_bcm2711_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_bflb.c
+++ b/drivers/serial/uart_bflb.c
@@ -253,13 +253,6 @@ int uart_bflb_irq_is_pending(const struct device *dev)
 	return (((tmp & ~maskVal) & 0xFF) != 0 ? 1 : 0);
 }
 
-int uart_bflb_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 void uart_bflb_irq_callback_set(const struct device *dev,
 			      uart_irq_callback_user_data_t cb,
 			      void *user_data)
@@ -569,7 +562,6 @@ static DEVICE_API(uart, uart_bflb_driver_api) = {
 	.irq_err_enable = uart_bflb_irq_err_enable,
 	.irq_err_disable = uart_bflb_irq_err_disable,
 	.irq_is_pending = uart_bflb_irq_is_pending,
-	.irq_update = uart_bflb_irq_update,
 	.irq_callback_set = uart_bflb_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_bitbang.c
+++ b/drivers/serial/uart_bitbang.c
@@ -551,11 +551,6 @@ static int uart_bitbang_irq_is_pending(const struct device *dev)
 	return 0;
 }
 
-static int uart_bitbang_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_bitbang_irq_callback_set(const struct device *dev,
 					  uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -598,7 +593,6 @@ static DEVICE_API(uart, uart_bitbang_api) = {
 	.irq_err_enable = uart_bitbang_irq_err_enable,
 	.irq_err_disable = uart_bitbang_irq_err_disable,
 	.irq_is_pending = uart_bitbang_irq_is_pending,
-	.irq_update = uart_bitbang_irq_update,
 	.irq_callback_set = uart_bitbang_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -272,13 +272,6 @@ static int uart_bt_irq_is_pending(const struct device *dev)
 	return uart_bt_irq_rx_ready(dev);
 }
 
-static int uart_bt_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void uart_bt_irq_callback_set(const struct device *dev,
 				     uart_irq_callback_user_data_t cb,
 				     void *cb_data)
@@ -301,7 +294,6 @@ static DEVICE_API(uart, uart_bt_driver_api) = {
 	.irq_rx_disable = uart_bt_irq_rx_disable,
 	.irq_rx_ready = uart_bt_irq_rx_ready,
 	.irq_is_pending = uart_bt_irq_is_pending,
-	.irq_update = uart_bt_irq_update,
 	.irq_callback_set = uart_bt_irq_callback_set,
 };
 

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -357,12 +357,6 @@ static int uart_cc13xx_cc26xx_irq_is_pending(const struct device *dev)
 	return status & (UART_INT_TX | UART_INT_RX) ? 1 : 0;
 }
 
-static int uart_cc13xx_cc26xx_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void uart_cc13xx_cc26xx_irq_callback_set(const struct device *dev,
 						uart_irq_callback_user_data_t cb,
 						void *user_data)
@@ -485,7 +479,6 @@ static DEVICE_API(uart, uart_cc13xx_cc26xx_driver_api) = {
 	.irq_err_enable = uart_cc13xx_cc26xx_irq_err_enable,
 	.irq_err_disable = uart_cc13xx_cc26xx_irq_err_disable,
 	.irq_is_pending = uart_cc13xx_cc26xx_irq_is_pending,
-	.irq_update = uart_cc13xx_cc26xx_irq_update,
 	.irq_callback_set = uart_cc13xx_cc26xx_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_cc23x0.c
+++ b/drivers/serial/uart_cc23x0.c
@@ -383,12 +383,6 @@ static int uart_cc23x0_irq_is_pending(const struct device *dev)
 	return status ? 1 : 0;
 }
 
-static int uart_cc23x0_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void uart_cc23x0_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					 void *user_data)
 {
@@ -889,7 +883,6 @@ static DEVICE_API(uart, uart_cc23x0_driver_api) = {
 	.irq_err_enable = uart_cc23x0_irq_err_enable,
 	.irq_err_disable = uart_cc23x0_irq_err_disable,
 	.irq_is_pending = uart_cc23x0_irq_is_pending,
-	.irq_update = uart_cc23x0_irq_update,
 	.irq_callback_set = uart_cc23x0_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #if CONFIG_UART_CC23X0_DMA_DRIVEN

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -245,11 +245,6 @@ static int uart_cc32xx_irq_is_pending(const struct device *dev)
 	return (int_status & (UART_INT_TX | UART_INT_RX));
 }
 
-static int uart_cc32xx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_cc32xx_irq_callback_set(const struct device *dev,
 					 uart_irq_callback_user_data_t cb,
 					 void *cb_data)
@@ -307,7 +302,6 @@ static DEVICE_API(uart, uart_cc32xx_driver_api) = {
 	.irq_err_enable	  = uart_cc32xx_irq_err_enable,
 	.irq_err_disable  = uart_cc32xx_irq_err_disable,
 	.irq_is_pending	  = uart_cc32xx_irq_is_pending,
-	.irq_update	  = uart_cc32xx_irq_update,
 	.irq_callback_set = uart_cc32xx_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_cdns.c
+++ b/drivers/serial/uart_cdns.c
@@ -195,12 +195,6 @@ static int uart_cdns_is_irq_pending(const struct device *dev)
 	return (uart_regs->channel_intr_status != 0);
 }
 
-/** Check for IRQ updates */
-static int uart_cdns_update_irq(const struct device *dev)
-{
-	return 1;
-}
-
 /** Set the callback function pointer for IRQ. */
 void uart_cdns_set_irq_callback(const struct device *dev, uart_irq_callback_user_data_t cb,
 				   void *cb_data)
@@ -229,7 +223,6 @@ static DEVICE_API(uart, uart_cdns_driver_api) = {
 	.irq_err_enable = uart_cdns_enable_irq_err,
 	.irq_err_disable = uart_cdns_disable_irq_err,
 	.irq_is_pending = uart_cdns_is_irq_pending,
-	.irq_update = uart_cdns_update_irq,
 	.irq_callback_set = uart_cdns_set_irq_callback
 #endif
 };

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -416,18 +416,6 @@ static int uart_cmsdk_apb_irq_is_pending(const struct device *dev)
 }
 
 /**
- * @brief Update the interrupt status
- *
- * @param dev UART device struct
- *
- * @return always 1
- */
-static int uart_cmsdk_apb_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
-/**
  * @brief Set the callback function pointer for an Interrupt.
  *
  * @param dev UART device structure
@@ -479,7 +467,6 @@ static DEVICE_API(uart, uart_cmsdk_apb_driver_api) = {
 	.irq_err_enable = uart_cmsdk_apb_irq_err_enable,
 	.irq_err_disable = uart_cmsdk_apb_irq_err_disable,
 	.irq_is_pending = uart_cmsdk_apb_irq_is_pending,
-	.irq_update = uart_cmsdk_apb_irq_update,
 	.irq_callback_set = uart_cmsdk_apb_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_emul.c
+++ b/drivers/serial/uart_emul.c
@@ -378,11 +378,6 @@ static void uart_emul_irq_callback_set(const struct device *dev, uart_irq_callba
 	data->irq_cb = cb;
 	data->irq_cb_udata = user_data;
 }
-
-static int uart_emul_irq_update(const struct device *dev)
-{
-	return 1;
-}
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 #ifdef CONFIG_UART_ASYNC_API
@@ -894,7 +889,6 @@ static DEVICE_API(uart, uart_emul_api) = {
 	.irq_rx_ready = uart_emul_irq_rx_ready,
 	.irq_tx_complete = uart_emul_irq_tx_complete,
 	.irq_callback_set = uart_emul_irq_callback_set,
-	.irq_update = uart_emul_irq_update,
 	.irq_is_pending = uart_emul_irq_is_pending,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_ft9001.c
+++ b/drivers/serial/uart_ft9001.c
@@ -498,14 +498,6 @@ static int uart_ft9001_irq_is_pending(const struct device *dev)
 }
 
 /**
- * @brief Update interrupt status
- */
-static int uart_ft9001_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
-/**
  * @brief Set interrupt callback
  */
 static void uart_ft9001_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
@@ -553,7 +545,6 @@ static const struct uart_driver_api uart_ft9001_driver_api = {
 	.irq_err_enable = uart_ft9001_irq_err_enable,
 	.irq_err_disable = uart_ft9001_irq_err_disable,
 	.irq_is_pending = uart_ft9001_irq_is_pending,
-	.irq_update = uart_ft9001_irq_update,
 	.irq_callback_set = uart_ft9001_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -322,11 +322,6 @@ static int uart_gecko_irq_is_pending(const struct device *dev)
 	return uart_gecko_irq_tx_ready(dev) || uart_gecko_irq_rx_ready(dev);
 }
 
-static int uart_gecko_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_gecko_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
@@ -715,7 +710,6 @@ static DEVICE_API(uart, uart_gecko_driver_api) = {
 	.irq_err_enable = uart_gecko_irq_err_enable,
 	.irq_err_disable = uart_gecko_irq_err_disable,
 	.irq_is_pending = uart_gecko_irq_is_pending,
-	.irq_update = uart_gecko_irq_update,
 	.irq_callback_set = uart_gecko_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -182,12 +182,6 @@ static int xen_hvc_irq_is_pending(const struct device *dev)
 	return xen_hvc_irq_rx_ready(dev);
 }
 
-static int xen_hvc_irq_update(const struct device *dev)
-{
-	/* Nothing needs to be updated before actual ISR */
-	return 1;
-}
-
 static void xen_hvc_irq_callback_set(const struct device *dev,
 		 uart_irq_callback_user_data_t cb, void *user_data)
 {
@@ -210,7 +204,6 @@ static DEVICE_API(uart, xen_hvc_api) = {
 	.irq_tx_complete = xen_hvc_irq_tx_complete,
 	.irq_rx_ready = xen_hvc_irq_rx_ready,
 	.irq_is_pending = xen_hvc_irq_is_pending,
-	.irq_update = xen_hvc_irq_update,
 	.irq_callback_set = xen_hvc_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -232,11 +232,6 @@ static int uart_imx_irq_is_pending(const struct device *dev)
 		UART_GetStatusFlag(uart, uartStatusTxReady);
 }
 
-static int uart_imx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_imx_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
@@ -283,7 +278,6 @@ static DEVICE_API(uart, uart_imx_driver_api) = {
 	.irq_err_enable   = uart_imx_irq_err_enable,
 	.irq_err_disable  = uart_imx_irq_err_disable,
 	.irq_is_pending   = uart_imx_irq_is_pending,
-	.irq_update		  = uart_imx_irq_update,
 	.irq_callback_set = uart_imx_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_litex.c
+++ b/drivers/serial/uart_litex.c
@@ -267,11 +267,6 @@ static int uart_litex_irq_is_pending(const struct device *dev)
 	return (uart_litex_irq_tx_ready(dev) || uart_litex_irq_rx_ready(dev));
 }
 
-static int uart_litex_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 /**
  * @brief Set the callback function pointer for IRQ.
  *
@@ -317,7 +312,6 @@ static DEVICE_API(uart, uart_litex_driver_api) = {
 	.irq_err_enable		= uart_litex_irq_err,
 	.irq_err_disable	= uart_litex_irq_err,
 	.irq_is_pending		= uart_litex_irq_is_pending,
-	.irq_update		= uart_litex_irq_update,
 	.irq_callback_set	= uart_litex_irq_callback_set
 #endif
 };

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -297,11 +297,6 @@ static int uart_mcux_irq_is_pending(const struct device *dev)
 	return uart_mcux_irq_tx_ready(dev) || uart_mcux_irq_rx_pending(dev);
 }
 
-static int uart_mcux_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_mcux_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
@@ -388,7 +383,6 @@ static DEVICE_API(uart, uart_mcux_driver_api) = {
 	.irq_err_enable = uart_mcux_irq_err_enable,
 	.irq_err_disable = uart_mcux_irq_err_disable,
 	.irq_is_pending = uart_mcux_irq_is_pending,
-	.irq_update = uart_mcux_irq_update,
 	.irq_callback_set = uart_mcux_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -348,11 +348,6 @@ static int mcux_flexcomm_irq_is_pending(const struct device *dev)
 		|| mcux_flexcomm_irq_rx_pending(dev));
 }
 
-static int mcux_flexcomm_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void mcux_flexcomm_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb,
 					   void *cb_data)
@@ -1276,7 +1271,6 @@ static DEVICE_API(uart, mcux_flexcomm_driver_api) = {
 	.irq_err_enable = mcux_flexcomm_irq_err_enable,
 	.irq_err_disable = mcux_flexcomm_irq_err_disable,
 	.irq_is_pending = mcux_flexcomm_irq_is_pending,
-	.irq_update = mcux_flexcomm_irq_update,
 	.irq_callback_set = mcux_flexcomm_irq_callback_set,
 #endif
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -197,11 +197,6 @@ static int mcux_iuart_irq_is_pending(const struct device *dev)
 	return mcux_iuart_irq_tx_ready(dev) || mcux_iuart_irq_rx_pending(dev);
 }
 
-static int mcux_iuart_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void mcux_iuart_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
@@ -290,7 +285,6 @@ static DEVICE_API(uart, mcux_iuart_driver_api) = {
 	.irq_err_enable = mcux_iuart_irq_err_enable,
 	.irq_err_disable = mcux_iuart_irq_err_disable,
 	.irq_is_pending = mcux_iuart_irq_is_pending,
-	.irq_update = mcux_iuart_irq_update,
 	.irq_callback_set = mcux_iuart_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -210,11 +210,6 @@ static int mcux_lpsci_irq_is_pending(const struct device *dev)
 		|| mcux_lpsci_irq_rx_pending(dev));
 }
 
-static int mcux_lpsci_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void mcux_lpsci_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
@@ -287,7 +282,6 @@ static DEVICE_API(uart, mcux_lpsci_driver_api) = {
 	.irq_err_enable = mcux_lpsci_irq_err_enable,
 	.irq_err_disable = mcux_lpsci_irq_err_disable,
 	.irq_is_pending = mcux_lpsci_irq_is_pending,
-	.irq_update = mcux_lpsci_irq_update,
 	.irq_callback_set = mcux_lpsci_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -396,11 +396,6 @@ static int mcux_lpuart_irq_is_pending(const struct device *dev)
 		|| mcux_lpuart_irq_rx_pending(dev));
 }
 
-static int mcux_lpuart_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void mcux_lpuart_irq_callback_set(const struct device *dev,
 					 uart_irq_callback_user_data_t cb,
 					 void *cb_data)
@@ -1424,7 +1419,6 @@ static DEVICE_API(uart, mcux_lpuart_driver_api) = {
 	.irq_err_enable = mcux_lpuart_irq_err_enable,
 	.irq_err_disable = mcux_lpuart_irq_err_disable,
 	.irq_is_pending = mcux_lpuart_irq_is_pending,
-	.irq_update = mcux_lpuart_irq_update,
 	.irq_callback_set = mcux_lpuart_irq_callback_set,
 #endif
 #if LPUART_ASYNC_ENABLE

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -288,11 +288,6 @@ static int uart_miv_irq_is_pending(const struct device *dev)
 	return !!(uart->status & STATUS_RXFULL_MASK);
 }
 
-static int uart_miv_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_miv_irq_handler(const struct device *dev)
 {
 	struct uart_miv_data *data = dev->data;
@@ -378,7 +373,6 @@ static DEVICE_API(uart, uart_miv_driver_api) = {
 	.irq_err_enable   = uart_miv_irq_err_enable,
 	.irq_err_disable  = uart_miv_irq_err_disable,
 	.irq_is_pending   = uart_miv_irq_is_pending,
-	.irq_update       = uart_miv_irq_update,
 	.irq_callback_set = uart_miv_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -286,11 +286,6 @@ static int uart_msp432p4xx_irq_is_pending(const struct device *dev)
 	return (int_status & (EUSCI_A_IE_TXIE | EUSCI_A_IE_RXIE));
 }
 
-static int uart_msp432p4xx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_msp432p4xx_irq_callback_set(const struct device *dev,
 					     uart_irq_callback_user_data_t cb,
 					     void *cb_data)
@@ -343,7 +338,6 @@ static DEVICE_API(uart, uart_msp432p4xx_driver_api) = {
 	.irq_err_enable	  = uart_msp432p4xx_irq_err_enable,
 	.irq_err_disable  = uart_msp432p4xx_irq_err_disable,
 	.irq_is_pending	  = uart_msp432p4xx_irq_is_pending,
-	.irq_update	  = uart_msp432p4xx_irq_update,
 	.irq_callback_set = uart_msp432p4xx_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_native_pty.c
+++ b/drivers/serial/uart_native_pty.c
@@ -104,7 +104,6 @@ static void np_uart_irq_rx_enable(const struct device *dev);
 static void np_uart_irq_rx_disable(const struct device *dev);
 static int np_uart_irq_rx_ready(const struct device *dev);
 static int np_uart_irq_is_pending(const struct device *dev);
-static int np_uart_irq_update(const struct device *dev);
 static void np_uart_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				     void *cb_data);
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -131,7 +130,6 @@ static DEVICE_API(uart, np_uart_driver_api) = {
 	.irq_rx_disable   = np_uart_irq_rx_disable,
 	.irq_rx_ready     = np_uart_irq_rx_ready,
 	.irq_is_pending   = np_uart_irq_is_pending,
-	.irq_update       = np_uart_irq_update,
 	.irq_callback_set = np_uart_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
@@ -646,13 +644,6 @@ static int np_uart_irq_is_pending(const struct device *dev)
 {
 	return np_uart_irq_rx_ready(dev) ||
 		np_uart_irq_tx_ready(dev);
-}
-
-static int np_uart_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
 }
 
 static void np_uart_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,

--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -335,12 +335,6 @@ static int native_tty_uart_irq_is_pending(const struct device *dev)
 		native_tty_uart_irq_tx_ready(dev);
 }
 
-static int native_tty_uart_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void native_tty_uart_irq_handler(const struct device *dev)
 {
 	struct native_tty_data *data = dev->data;
@@ -470,7 +464,6 @@ static DEVICE_API(uart, native_tty_uart_driver_api) = {
 	.irq_rx_disable   = native_tty_uart_irq_rx_disable,
 	.irq_rx_ready     = native_tty_uart_irq_rx_ready,
 	.irq_is_pending   = native_tty_uart_irq_is_pending,
-	.irq_update       = native_tty_uart_irq_update,
 	.irq_callback_set = native_tty_uart_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -411,13 +411,6 @@ static int uart_npcx_irq_is_pending(const struct device *dev)
 	       (uart_npcx_irq_rx_ready(dev) && uart_npcx_irq_rx_is_enabled(dev));
 }
 
-static int uart_npcx_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void uart_npcx_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				       void *cb_data)
 {
@@ -1069,7 +1062,6 @@ static DEVICE_API(uart, uart_npcx_driver_api) = {
 	.irq_err_enable = uart_npcx_irq_err_enable,
 	.irq_err_disable = uart_npcx_irq_err_disable,
 	.irq_is_pending = uart_npcx_irq_is_pending,
-	.irq_update = uart_npcx_irq_update,
 	.irq_callback_set = uart_npcx_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -915,12 +915,6 @@ static int uart_nrfx_irq_is_pending(const struct device *dev)
 		 uart_nrfx_irq_rx_ready(dev)));
 }
 
-/** Interrupt driven interrupt update function */
-static int uart_nrfx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 /** Set the callback function */
 static void uart_nrfx_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
@@ -1073,7 +1067,6 @@ static DEVICE_API(uart, uart_nrfx_uart_driver_api) = {
 	.irq_err_enable   = uart_nrfx_irq_err_enable,
 	.irq_err_disable  = uart_nrfx_irq_err_disable,
 	.irq_is_pending   = uart_nrfx_irq_is_pending,
-	.irq_update       = uart_nrfx_irq_update,
 	.irq_callback_set = uart_nrfx_irq_callback_set,
 #endif /* CONFIG_UART_0_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2943,12 +2943,6 @@ static int uarte_nrfx_irq_is_pending(const struct device *dev)
 		 uarte_nrfx_irq_rx_ready(dev)));
 }
 
-/** Interrupt driven interrupt update function */
-static int uarte_nrfx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 /** Set the callback function */
 static void uarte_nrfx_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
@@ -2990,7 +2984,6 @@ static DEVICE_API(uart, uart_nrfx_uarte_driver_api) = {
 	.irq_err_enable		= uarte_nrfx_irq_err_enable,
 	.irq_err_disable	= uarte_nrfx_irq_err_disable,
 	.irq_is_pending		= uarte_nrfx_irq_is_pending,
-	.irq_update		= uarte_nrfx_irq_update,
 	.irq_callback_set	= uarte_nrfx_irq_callback_set,
 #endif /* UARTE_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_numaker.c
+++ b/drivers/serial/uart_numaker.c
@@ -358,14 +358,6 @@ static int uart_numaker_irq_is_pending(const struct device *dev)
 	return (uart_numaker_irq_tx_ready(dev) || (uart_numaker_irq_rx_ready(dev)));
 }
 
-static int uart_numaker_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/* nothing to be done */
-	return 1;
-}
-
 static void uart_numaker_irq_callback_set(const struct device *dev,
 					  uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -407,7 +399,6 @@ static DEVICE_API(uart, uart_numaker_driver_api) = {
 	.irq_err_enable = uart_numaker_irq_err_enable,
 	.irq_err_disable = uart_numaker_irq_err_disable,
 	.irq_is_pending = uart_numaker_irq_is_pending,
-	.irq_update = uart_numaker_irq_update,
 	.irq_callback_set = uart_numaker_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_nxp_s32_linflexd.c
+++ b/drivers/serial/uart_nxp_s32_linflexd.c
@@ -232,11 +232,6 @@ static int uart_nxp_s32_irq_is_pending(const struct device *dev)
 	return (uart_nxp_s32_irq_tx_ready(dev)) || (uart_nxp_s32_irq_rx_ready(dev));
 }
 
-static int uart_nxp_s32_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_nxp_s32_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
@@ -346,7 +341,6 @@ static DEVICE_API(uart, uart_nxp_s32_driver_api) = {
 	.irq_err_enable   = uart_nxp_s32_irq_err_enable,
 	.irq_err_disable  = uart_nxp_s32_irq_err_disable,
 	.irq_is_pending   = uart_nxp_s32_irq_is_pending,
-	.irq_update	  = uart_nxp_s32_irq_update,
 	.irq_callback_set = uart_nxp_s32_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -502,11 +502,6 @@ static int pl011_irq_is_pending(const struct device *dev)
 	return pl011_irq_rx_ready(dev) || pl011_irq_tx_ready(dev);
 }
 
-static int pl011_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void pl011_irq_callback_set(const struct device *dev,
 					    uart_irq_callback_user_data_t cb,
 					    void *cb_data)
@@ -549,7 +544,6 @@ static DEVICE_API(uart, pl011_driver_api) = {
 	.irq_err_enable = pl011_irq_err_enable,
 	.irq_err_disable = pl011_irq_err_disable,
 	.irq_is_pending = pl011_irq_is_pending,
-	.irq_update = pl011_irq_update,
 	.irq_callback_set = pl011_irq_callback_set,
 };
 #endif /* PL011_USE_IRQ */

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -275,13 +275,6 @@ static int uart_psoc6_irq_is_pending(const struct device *dev)
 	return (intcause & (CY_SCB_TX_INTR | CY_SCB_RX_INTR));
 }
 
-static int uart_psoc6_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void uart_psoc6_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
@@ -320,7 +313,6 @@ static DEVICE_API(uart, uart_psoc6_driver_api) = {
 	.irq_err_enable = uart_psoc6_irq_err_enable,
 	.irq_err_disable = uart_psoc6_irq_err_disable,
 	.irq_is_pending = uart_psoc6_irq_is_pending,
-	.irq_update = uart_psoc6_irq_update,
 	.irq_callback_set = uart_psoc6_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -482,11 +482,6 @@ static int uart_rcar_irq_is_pending(const struct device *dev)
 	       (uart_rcar_irq_tx_ready(dev) && uart_rcar_irq_is_enabled(dev, SCSCR_TIE));
 }
 
-static int uart_rcar_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_rcar_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
@@ -534,7 +529,6 @@ static DEVICE_API(uart, uart_rcar_driver_api) = {
 	.irq_err_enable = uart_rcar_irq_err_enable,
 	.irq_err_disable = uart_rcar_irq_err_disable,
 	.irq_is_pending = uart_rcar_irq_is_pending,
-	.irq_update = uart_rcar_irq_update,
 	.irq_callback_set = uart_rcar_irq_callback_set,
 #endif  /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_renesas_rx_sci.c
+++ b/drivers/serial/uart_renesas_rx_sci.c
@@ -385,11 +385,6 @@ static int uart_rx_irq_is_pending(const struct device *dev)
 	return tx_pending || rx_pending;
 }
 
-static int uart_rx_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_rx_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				     void *cb_data)
 {
@@ -890,7 +885,6 @@ static DEVICE_API(uart, uart_rx_driver_api) = {
 	.irq_err_enable = uart_rx_irq_err_enable,
 	.irq_err_disable = uart_rx_irq_err_disable,
 	.irq_is_pending = uart_rx_irq_is_pending,
-	.irq_update = uart_rx_irq_update,
 	.irq_callback_set = uart_rx_irq_callback_set,
 #endif
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_renesas_rz_sci.c
+++ b/drivers/serial/uart_renesas_rz_sci.c
@@ -358,12 +358,6 @@ static void uart_rz_sci_irq_callback_set(const struct device *dev, uart_irq_call
 	data->callback_data = cb_data;
 }
 
-static int uart_rz_sci_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void uart_rz_sci_rxi_isr(const struct device *dev)
 {
 	struct uart_rz_sci_data *data = dev->data;
@@ -442,7 +436,6 @@ static DEVICE_API(uart, uart_rz_sci_driver_api) = {
 	.irq_rx_ready = uart_rz_sci_irq_rx_ready,
 	.irq_is_pending = uart_rz_sci_irq_is_pending,
 	.irq_callback_set = uart_rz_sci_irq_callback_set,
-	.irq_update = uart_rz_sci_irq_update,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 

--- a/drivers/serial/uart_renesas_rz_scif.c
+++ b/drivers/serial/uart_renesas_rz_scif.c
@@ -319,12 +319,6 @@ static void uart_rz_scif_irq_callback_set(const struct device *dev,
 	data->callback_data = cb_data;
 }
 
-static int uart_rz_scif_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void uart_rz_scif_rxi_isr(const struct device *dev)
 {
 	struct uart_rz_scif_data *data = dev->data;
@@ -424,7 +418,6 @@ static DEVICE_API(uart, uart_rz_scif_driver_api) = {
 	.irq_rx_ready = uart_rz_scif_irq_rx_ready,
 	.irq_is_pending = uart_rz_scif_irq_is_pending,
 	.irq_callback_set = uart_rz_scif_irq_callback_set,
-	.irq_update = uart_rz_scif_irq_update,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 

--- a/drivers/serial/uart_renesas_rza2m_scif.c
+++ b/drivers/serial/uart_renesas_rza2m_scif.c
@@ -665,13 +665,6 @@ static int uart_rza2m_scif_irq_is_pending(const struct device *dev)
 		uart_rza2m_scif_irq_is_enabled(dev, RZA2M_SCR_TIE));
 }
 
-static int uart_rza2m_scif_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void uart_rza2m_scif_irq_callback_set(const struct device *dev,
 					     uart_irq_callback_user_data_t cb, void *cb_data)
 {
@@ -718,7 +711,6 @@ static DEVICE_API(uart, uart_rza2m_scif_driver_api) = {
 	.irq_err_enable = uart_rza2m_scif_irq_err_enable,
 	.irq_err_disable = uart_rza2m_scif_irq_err_disable,
 	.irq_is_pending = uart_rza2m_scif_irq_is_pending,
-	.irq_update = uart_rza2m_scif_irq_update,
 	.irq_callback_set = uart_rza2m_scif_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -213,11 +213,6 @@ static int rv32m1_lpuart_irq_is_pending(const struct device *dev)
 		|| rv32m1_lpuart_irq_rx_pending(dev));
 }
 
-static int rv32m1_lpuart_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void rv32m1_lpuart_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb,
 					   void *cb_data)
@@ -298,7 +293,6 @@ static DEVICE_API(uart, rv32m1_lpuart_driver_api) = {
 	.irq_err_enable = rv32m1_lpuart_irq_err_enable,
 	.irq_err_disable = rv32m1_lpuart_irq_err_disable,
 	.irq_is_pending = rv32m1_lpuart_irq_is_pending,
-	.irq_update = rv32m1_lpuart_irq_update,
 	.irq_callback_set = rv32m1_lpuart_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -352,13 +352,6 @@ static int uart_sam_irq_is_pending(const struct device *dev)
 		(uart->UART_SR & (UART_SR_TXRDY | UART_SR_RXRDY));
 }
 
-static int uart_sam_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void uart_sam_irq_callback_set(const struct device *dev,
 				      uart_irq_callback_user_data_t cb,
 				      void *cb_data)
@@ -438,7 +431,6 @@ static DEVICE_API(uart, uart_sam_driver_api) = {
 	.irq_err_enable = uart_sam_irq_err_enable,
 	.irq_err_disable = uart_sam_irq_err_disable,
 	.irq_is_pending = uart_sam_irq_is_pending,
-	.irq_update = uart_sam_irq_update,
 	.irq_callback_set = uart_sam_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_sf32lb.c
+++ b/drivers/serial/uart_sf32lb.c
@@ -390,12 +390,6 @@ static int uart_sf32lb_irq_is_pending(const struct device *dev)
 	return sys_read32(config->base + UART_ISR) == 0U ? 0 : 1;
 }
 
-static int uart_sf32lb_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 static void uart_sf32lb_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					 void *user_data)
 {
@@ -822,7 +816,6 @@ static const struct uart_driver_api uart_sf32lb_api = {
 	.irq_err_enable = uart_sf32lb_irq_err_enable,
 	.irq_err_disable = uart_sf32lb_irq_err_disable,
 	.irq_is_pending = uart_sf32lb_irq_is_pending,
-	.irq_update = uart_sf32lb_irq_update,
 	.irq_callback_set = uart_sf32lb_irq_callback_set,
 #endif
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_si32_usart.c
+++ b/drivers/serial/uart_si32_usart.c
@@ -191,13 +191,6 @@ static int usart_si32_irq_is_pending(const struct device *dev)
 	return usart_si32_irq_rx_ready(dev) || usart_si32_irq_tx_ready(dev);
 }
 
-static int usart_si32_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void usart_si32_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					void *cb_data)
 {
@@ -236,7 +229,6 @@ static DEVICE_API(uart, usart_si32_driver_api) = {
 	.irq_err_enable = usart_si32_irq_err_enable,
 	.irq_err_disable = usart_si32_irq_err_disable,
 	.irq_is_pending = usart_si32_irq_is_pending,
-	.irq_update = usart_si32_irq_update,
 	.irq_callback_set = usart_si32_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -288,11 +288,6 @@ static int uart_sifive_irq_is_pending(const struct device *dev)
 	return !!(uart->ip & (IE_RXWM | IE_TXWM));
 }
 
-static int uart_sifive_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 /**
  * @brief Set the callback function pointer for IRQ.
  *
@@ -371,7 +366,6 @@ static DEVICE_API(uart, uart_sifive_driver_api) = {
 	.irq_err_enable   = uart_sifive_irq_err_enable,
 	.irq_err_disable  = uart_sifive_irq_err_disable,
 	.irq_is_pending   = uart_sifive_irq_is_pending,
-	.irq_update       = uart_sifive_irq_update,
 	.irq_callback_set = uart_sifive_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -312,11 +312,6 @@ static int eusart_irq_is_pending(const struct device *dev)
 	return eusart_irq_tx_ready(dev) || eusart_irq_rx_ready(dev);
 }
 
-static int eusart_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void eusart_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				    void *cb_data)
 {
@@ -1170,7 +1165,6 @@ static DEVICE_API(uart, eusart_driver_api) = {
 	.irq_err_enable = eusart_irq_err_enable,
 	.irq_err_disable = eusart_irq_err_disable,
 	.irq_is_pending = eusart_irq_is_pending,
-	.irq_update = eusart_irq_update,
 	.irq_callback_set = eusart_irq_callback_set,
 #endif
 #ifdef CONFIG_UART_SILABS_EUSART_ASYNC

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -291,11 +291,6 @@ static int uart_silabs_irq_is_pending(const struct device *dev)
 	return uart_silabs_irq_tx_ready(dev) || uart_silabs_irq_rx_ready(dev);
 }
 
-static int uart_silabs_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_silabs_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					 void *cb_data)
 {
@@ -1112,7 +1107,6 @@ static DEVICE_API(uart, uart_silabs_driver_api) = {
 	.irq_err_enable = uart_silabs_irq_err_enable,
 	.irq_err_disable = uart_silabs_irq_err_disable,
 	.irq_is_pending = uart_silabs_irq_is_pending,
-	.irq_update = uart_silabs_irq_update,
 	.irq_callback_set = uart_silabs_irq_callback_set,
 #endif
 #ifdef CONFIG_UART_SILABS_USART_ASYNC

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -503,18 +503,6 @@ static int uart_stellaris_irq_is_pending(const struct device *dev)
 }
 
 /**
- * @brief Update IRQ status
- *
- * @param dev UART device struct
- *
- * @return Always 1
- */
-static int uart_stellaris_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
-/**
  * @brief Set the callback function pointer for IRQ.
  *
  * @param dev UART device struct
@@ -566,7 +554,6 @@ static DEVICE_API(uart, uart_stellaris_driver_api) = {
 	.irq_err_enable = uart_stellaris_irq_err_enable,
 	.irq_err_disable = uart_stellaris_irq_err_disable,
 	.irq_is_pending = uart_stellaris_irq_is_pending,
-	.irq_update = uart_stellaris_irq_update,
 	.irq_callback_set = uart_stellaris_irq_callback_set,
 
 #endif

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1136,11 +1136,6 @@ static int uart_stm32_irq_is_pending(const struct device *dev)
 		 LL_USART_IsEnabledIT_TC(usart)));
 }
 
-static int uart_stm32_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void uart_stm32_irq_callback_set(const struct device *dev,
 					uart_irq_callback_user_data_t cb,
 					void *cb_data)
@@ -2171,7 +2166,6 @@ static DEVICE_API(uart, uart_stm32_driver_api) = {
 	.irq_err_enable = uart_stm32_irq_err_enable,
 	.irq_err_disable = uart_stm32_irq_err_disable,
 	.irq_is_pending = uart_stm32_irq_is_pending,
-	.irq_update = uart_stm32_irq_update,
 	.irq_callback_set = uart_stm32_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_virtio_console.c
+++ b/drivers/serial/uart_virtio_console.c
@@ -487,11 +487,6 @@ static int virtconsole_irq_is_pending(const struct device *dev)
 {
 	return virtconsole_irq_rx_ready(dev);
 }
-static int virtconsole_irq_update(const struct device *dev)
-{
-	/* Nothing to be done */
-	return 1;
-}
 static void virtconsole_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 					 void *user_data)
 {
@@ -581,7 +576,6 @@ static DEVICE_API(uart, virtconsole_api) = {
 	.irq_rx_enable = virtconsole_irq_rx_enable,
 	.irq_rx_ready = virtconsole_irq_rx_ready,
 	.irq_is_pending = virtconsole_irq_is_pending,
-	.irq_update = virtconsole_irq_update,
 	.irq_callback_set = virtconsole_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -266,11 +266,6 @@ static int usart_wch_irq_is_pending(const struct device *dev)
 	return (statr & stat_mask) > 0;
 }
 
-static int usart_wch_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void usart_wch_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				       void *user_data)
 {
@@ -298,7 +293,6 @@ static DEVICE_API(uart, usart_wch_driver_api) = {
 	.irq_err_enable = usart_wch_irq_err_enable,
 	.irq_err_disable = usart_wch_irq_err_disable,
 	.irq_is_pending = usart_wch_irq_is_pending,
-	.irq_update = usart_wch_irq_update,
 	.irq_callback_set = usart_wch_irq_callback_set,
 #endif
 };

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -307,11 +307,6 @@ static int xlnx_uartlite_irq_is_pending(const struct device *dev)
 		xlnx_uartlite_irq_rx_ready(dev));
 }
 
-static int xlnx_uartlite_irq_update(const struct device *dev)
-{
-	return 1;
-}
-
 static void xlnx_uartlite_irq_callback_set(const struct device *dev,
 					   uart_irq_callback_user_data_t cb,
 					   void *user_data)
@@ -369,7 +364,6 @@ static DEVICE_API(uart, xlnx_uartlite_driver_api) = {
 	.irq_rx_disable = xlnx_uartlite_irq_rx_disable,
 	.irq_rx_ready = xlnx_uartlite_irq_rx_ready,
 	.irq_is_pending = xlnx_uartlite_irq_is_pending,
-	.irq_update = xlnx_uartlite_irq_update,
 	.irq_callback_set = xlnx_uartlite_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -402,12 +402,6 @@ int usart_gd32_irq_is_pending(const struct device *dev)
 		 usart_interrupt_flag_get(cfg->reg, USART_INT_FLAG_TC)));
 }
 
-int usart_gd32_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 1;
-}
-
 void usart_gd32_irq_callback_set(const struct device *dev,
 				 uart_irq_callback_user_data_t cb,
 				 void *user_data)
@@ -440,7 +434,6 @@ static DEVICE_API(uart, usart_gd32_driver_api) = {
 	.irq_err_enable = usart_gd32_irq_err_enable,
 	.irq_err_disable = usart_gd32_irq_err_disable,
 	.irq_is_pending = usart_gd32_irq_is_pending,
-	.irq_update = usart_gd32_irq_update,
 	.irq_callback_set = usart_gd32_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -458,13 +458,6 @@ static int usart_sam_irq_is_pending(const struct device *dev)
 		(usart->US_CSR & (US_CSR_TXRDY | US_CSR_RXRDY));
 }
 
-static int usart_sam_irq_update(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 1;
-}
-
 static void usart_sam_irq_callback_set(const struct device *dev,
 				       uart_irq_callback_user_data_t cb,
 				       void *cb_data)
@@ -547,7 +540,6 @@ static DEVICE_API(uart, usart_sam_driver_api) = {
 	.irq_err_enable = usart_sam_irq_err_enable,
 	.irq_err_disable = usart_sam_irq_err_disable,
 	.irq_is_pending = usart_sam_irq_is_pending,
-	.irq_update = usart_sam_irq_update,
 	.irq_callback_set = usart_sam_irq_callback_set,
 #endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
 };

--- a/include/zephyr/drivers/serial/uart_async_to_irq.h
+++ b/include/zephyr/drivers/serial/uart_async_to_irq.h
@@ -71,7 +71,7 @@ void uart_async_to_irq_trampoline_cb(const struct device *dev);
 	.irq_err_enable	  = z_uart_async_to_irq_irq_err_enable,	\
 	.irq_err_disable  = z_uart_async_to_irq_irq_err_disable,\
 	.irq_is_pending	  = z_uart_async_to_irq_irq_is_pending,	\
-	.irq_update	  = z_uart_async_to_irq_irq_update,	\
+	.irq_update	  = NULL,				\
 	.irq_callback_set = z_uart_async_to_irq_irq_callback_set
 
 /** @brief Configuration structure initializer.
@@ -263,9 +263,6 @@ void z_uart_async_to_irq_irq_err_disable(const struct device *dev);
 
 /** Interrupt driven pending status function */
 int z_uart_async_to_irq_irq_is_pending(const struct device *dev);
-
-/** Interrupt driven interrupt update function */
-int z_uart_async_to_irq_irq_update(const struct device *dev);
 
 /** Set the irq callback function */
 void z_uart_async_to_irq_irq_callback_set(const struct device *dev,

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -19,7 +19,7 @@
  *        controllers.
  * @defgroup uart_interface UART
  * @since 1.0
- * @version 1.0.0
+ * @version 1.0.1
  * @ingroup io_interfaces
  * @{
  */
@@ -680,14 +680,13 @@ __syscall int uart_irq_is_pending(const struct device *dev);
  * * For devices with explicit acknowledgment of interrupts, to ack
  *   any pending interrupts and likewise to cache the original value.
  * * For devices with implicit acknowledgment, this function will be
- *   empty. But the ISR must perform the actions needs to ack the
+ *   not implemented. But the ISR must perform the actions needs to ack the
  *   interrupts (usually, call uart_fifo_read() on rx_ready, and
  *   uart_fifo_fill() on tx_ready).
  *
  * @param dev UART device instance.
  *
- * @retval 1 On success.
- * @retval -ENOSYS If this function is not implemented.
+ * @retval 1 On success or if it is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_irq_update(const struct device *dev);

--- a/include/zephyr/drivers/uart/uart_internal.h
+++ b/include/zephyr/drivers/uart/uart_internal.h
@@ -448,7 +448,7 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
 	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
 
 	if (api->irq_update == NULL) {
-		return -ENOSYS;
+		return 1;
 	}
 	return api->irq_update(dev);
 #else


### PR DESCRIPTION
most uart drivers don't need irq_update, therefore
allow drivers to not implement it, instead of them
needing to have a empty function that just returns 1.
