### PR TITLE
boards: renesas: ek_ra2l1: added pmod node labels

### DIFF
--- a/boards/renesas/ek_ra2l1/ek_ra2l1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1-pinctrl.dtsi
@@ -12,6 +12,24 @@
 		};
 	};
 
+	sci9_default: sci9_default {
+		group1 {
+			/* tx rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_9, 2, 3)>,
+				<RA_PSEL(RA_PSEL_SCI_9, 2, 2)>;
+		};
+	};
+
+	spi0_default: spi0_default {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+
 	adc0_default: adc0_default {
 		group1 {
 			/* input */

--- a/boards/renesas/ek_ra2l1/ek_ra2l1.dts
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.dts
@@ -51,6 +51,36 @@
 		};
 	};
 
+	pmod1_header: pmod-connector-1 {
+		compatible = "digilent,pmod";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &ioport1 3 0>,	/* IO1 */
+			   <1 0 &ioport1 1 0>,	/* IO2 */
+			   <2 0 &ioport1 0 0>,	/* IO3 */
+			   <3 0 &ioport1 2 0>,	/* IO4 */
+			   <4 0 &ioport4 2 0>,	/* IO5 */
+			   <5 0 &ioport2 8 0>,	/* IO6 */
+			   <6 0 &ioport1 5 0>,	/* IO7 */
+			   <7 0 &ioport1 6 0>;	/* IO8 */
+	};
+
+	pmod2_header: pmod-connector-2 {
+		compatible = "digilent,pmod";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &ioport2 5 0>,	/* IO1 */
+			   <1 0 &ioport2 3 0>,	/* IO2 */
+			   <2 0 &ioport2 2 0>,	/* IO3 */
+			   <3 0 &ioport2 4 0>,	/* IO4 */
+			   <4 0 &ioport4 9 0>,	/* IO5 */
+			   <5 0 &ioport3 3 0>,	/* IO6 */
+			   <6 0 &ioport2 6 0>,	/* IO7 */
+			   <7 0 &ioport3 4 0>;	/* IO8 */
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 
@@ -84,6 +114,22 @@
 	status = "okay";
 };
 
+&ioport1 {
+	status = "okay";
+};
+
+&ioport2 {
+	status = "okay";
+};
+
+&ioport3 {
+	status = "okay";
+};
+
+&ioport4 {
+	status = "okay";
+};
+
 &sci0 {
 	pinctrl-0 = <&sci0_default>;
 	pinctrl-names = "default";
@@ -93,6 +139,25 @@
 		current-speed = <115200>;
 		status = "okay";
 	};
+};
+
+&sci9 {
+	pinctrl-0 = <&sci9_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	uart9: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};
+
+&spi0 {
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+	interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
 };
 
 &wdt {
@@ -143,3 +208,13 @@
 		};
 	};
 };
+
+pmod1_spi: &spi0 {};
+
+pmod2_serial: &uart9 {};
+
+pmod_spi: &pmod1_spi {};
+
+pmod_serial: &pmod2_serial {};
+
+pmod_header: &pmod1_header {};


### PR DESCRIPTION
Added pmod_serial, pmod_spi and pmod_header node labels to EK-RA2L1 device tree board definition, allowing compatible shield boards to be used.