### PR TITLE
kconfig: Fix subpartitions handling in Kconfig

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -402,8 +402,10 @@ def _dt_chosen_partition_addr(kconf, chosen, index=0, unit=None):
     if not p_node:
         return 0
 
-    return _node_reg_addr(p_node.parent, index, unit) + _node_reg_addr(node, 0, unit)
-
+    if 'fixed-subpartitions' in p_node.compats:
+        return _node_reg_addr(p_node.parent.parent, index, unit) + _node_reg_addr(node, 0, unit)
+    else:
+        return _node_reg_addr(p_node.parent, index, unit) + _node_reg_addr(node, 0, unit)
 
 def dt_chosen_partition_addr(kconf, name, chosen, index=0, unit=None):
     """


### PR DESCRIPTION
Fix handling of the fixed-supartitions node inside the dt_chosen_partition_addr(..) Kconfig function.
This function is commonly used to calculate the value of BUILD_OUTPUT_ADJUST_LMA promptless symbol.
This change should allow to use a fixed subpartition as the chosen zephyr,code-partition node.