### PR TITLE
Bluetooth: CCP: Modify get_bearer_provider_name to use output buffer

### DIFF
--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -101,7 +101,7 @@ int bt_ccp_call_control_server_unregister_bearer(struct bt_ccp_call_control_serv
  *
  * @retval 0 Success
  * @retval -EINVAL @p bearer or @p name is NULL, or @p name is the empty string or @p name is larger
- *                 than @kconfig{CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH}
+ *                 than @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH}
  * @retval -EFAULT @p bearer is not registered
  */
 int bt_ccp_call_control_server_set_bearer_provider_name(

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -111,14 +111,18 @@ int bt_ccp_call_control_server_set_bearer_provider_name(
  * @brief Get the bearer provider name.
  *
  * @param[in]  bearer  The bearer to get the name for.
- * @param[out] name    Pointer that will be updated to be the bearer provider name.
+ * @param[out] name Pointer a buffer that will be populated with the bearer provider name.
+ * @param name_size The size of the @p name buffer. The suggested size is
+ *                  @kconfig{CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH} + 1 to
+ *                  ensure that the name always fits.
  *
  * @retval 0 Success
  * @retval -EINVAL @p bearer or @p name is NULL
  * @retval -EFAULT @p bearer is not registered
+ * @retval -ENOMEM @p name_size is insufficient to hold the bearer name (including null terminator)
  */
 int bt_ccp_call_control_server_get_bearer_provider_name(
-	struct bt_ccp_call_control_server_bearer *bearer, const char **name);
+	struct bt_ccp_call_control_server_bearer *bearer, char *name, size_t name_size);
 
 /**
  * @brief Get the bearer UCI.

--- a/subsys/bluetooth/audio/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/ccp_call_control_server.c
@@ -152,8 +152,10 @@ int bt_ccp_call_control_server_set_bearer_provider_name(
 }
 
 int bt_ccp_call_control_server_get_bearer_provider_name(
-	struct bt_ccp_call_control_server_bearer *bearer, const char **name)
+	struct bt_ccp_call_control_server_bearer *bearer, char *name, size_t name_size)
 {
+	size_t provider_name_len;
+
 	if (bearer == NULL) {
 		LOG_DBG("bearer is NULL");
 
@@ -172,7 +174,15 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
 		return -EFAULT;
 	}
 
-	*name = bearer->provider_name;
+	provider_name_len = strlen(bearer->provider_name);
+	if (name_size <= provider_name_len) {
+		LOG_DBG("name buffer not large enough (is <= %zu)", provider_name_len);
+
+		return -ENOMEM;
+	}
+
+	(void)memcpy(name, bearer->provider_name, provider_name_len);
+	name[provider_name_len] = '\0';
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -132,7 +132,7 @@ static int cmd_ccp_call_control_server_set_bearer_name(const struct shell *sh, s
 static int cmd_ccp_call_control_server_get_bearer_name(const struct shell *sh, size_t argc,
 						       char *argv[])
 {
-	const char *name;
+	char name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	int index = 0;
 	int err = 0;
 
@@ -143,7 +143,8 @@ static int cmd_ccp_call_control_server_get_bearer_name(const struct shell *sh, s
 		}
 	}
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(bearers[index], &name);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(bearers[index], name,
+								  sizeof(name));
 	if (err != 0) {
 		shell_error(sh, "Failed to get bearer[%d] name: %d", index, err);
 

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -268,7 +268,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_set_bearer_provider_name)
 {
-	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	const char *new_bearer_name = "New bearer name";
 	int err;
 
@@ -358,7 +358,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name)
 {
-	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	int err;
 
 	register_default_bearer(fixture);
@@ -374,7 +374,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_not_registered)
 {
-	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	int err;
 
 	/* Register and unregister bearer to get a valid pointer but where it is unregistered*/
@@ -390,7 +390,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_null_bearer)
 {
-	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
 	int err;
 
 	register_default_bearer(fixture);

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -268,8 +268,8 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_set_bearer_provider_name)
 {
+	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
 	const char *new_bearer_name = "New bearer name";
-	const char *res_bearer_name;
 	int err;
 
 	register_default_bearer(fixture);
@@ -278,8 +278,8 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 								  new_bearer_name);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0],
-								  &res_bearer_name);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(
+		fixture->bearers[0], res_bearer_name, sizeof(res_bearer_name));
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zassert_str_equal(new_bearer_name, res_bearer_name, "%s != %s", new_bearer_name,
@@ -358,13 +358,13 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name)
 {
-	const char *res_bearer_name;
+	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
 	int err;
 
 	register_default_bearer(fixture);
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0],
-								  &res_bearer_name);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(
+		fixture->bearers[0], res_bearer_name, sizeof(res_bearer_name));
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zassert_str_equal(DEFAULT_BEARER_NAME, res_bearer_name, "%s != %s", DEFAULT_BEARER_NAME,
@@ -374,7 +374,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_not_registered)
 {
-	const char *res_bearer_name;
+	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
 	int err;
 
 	/* Register and unregister bearer to get a valid pointer but where it is unregistered*/
@@ -382,20 +382,21 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 	err = bt_ccp_call_control_server_unregister_bearer(fixture->bearers[0]);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0],
-								  &res_bearer_name);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(
+		fixture->bearers[0], res_bearer_name, sizeof(res_bearer_name));
 	zassert_equal(err, -EFAULT, "Unexpected return value %d", err);
 }
 
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_null_bearer)
 {
-	const char *res_bearer_name;
+	char res_bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH + 1];
 	int err;
 
 	register_default_bearer(fixture);
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(NULL, &res_bearer_name);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(NULL, res_bearer_name,
+								  sizeof(res_bearer_name));
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 }
 
@@ -406,8 +407,34 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 
 	register_default_bearer(fixture);
 
-	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0], NULL);
+	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0], NULL, 0);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_size_0)
+{
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0],
+								  res_bearer_name, 0);
+	zassert_equal(err, -ENOMEM, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(ccp_call_control_server_test_suite,
+	       test_bt_ccp_call_control_server_get_bearer_provider_name_inval_small_size)
+{
+	char res_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
+	int err;
+
+	register_default_bearer(fixture);
+
+	err = bt_ccp_call_control_server_get_bearer_provider_name(fixture->bearers[0],
+								  res_bearer_name, 1);
+	zassert_equal(err, -ENOMEM, "Unexpected return value %d", err);
 }
 
 static ZTEST_F(ccp_call_control_server_test_suite, test_bt_ccp_call_control_server_get_bearer_uci)


### PR DESCRIPTION
Modify bt_ccp_call_control_server_get_bearer_provider_name to store the bearer provider name in an output buffer, instead of just providing the pointer.

The reason for this is to make the result thread safe, and avoid the user/application having a direct pointer to internal storage.