### PR TITLE
Bluetooth: CCP: Modify get_bearer_uci to use output buffer

### DIFF
--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -124,14 +124,15 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
  * @brief Get the bearer UCI.
  *
  * @param[in]  bearer  The bearer to get the UCI for.
- * @param[out] uci     Pointer that will be updated to be the bearer uci.
+ * @param[out] uci Pointer to a buffer of size @ref BT_TBS_MAX_UCI_SIZE that the bearer UCI will be
+ *                 written to.
  *
  * @retval 0 Success
  * @retval -EINVAL @p bearer or @p uci is NULL
  * @retval -EFAULT @p bearer is not registered
  */
 int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_bearer *bearer,
-					      const char **uci);
+					      char uci[BT_TBS_MAX_UCI_SIZE]);
 
 /** @} */ /* End of group bt_ccp_call_control_server */
 

--- a/subsys/bluetooth/audio/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/ccp_call_control_server.c
@@ -14,6 +14,7 @@
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_utf8.h>
 
@@ -178,8 +179,10 @@ int bt_ccp_call_control_server_get_bearer_provider_name(
 }
 
 int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_bearer *bearer,
-					      const char **uci)
+					      char uci[BT_TBS_MAX_UCI_SIZE])
 {
+	size_t uci_len;
+
 	if (bearer == NULL) {
 		LOG_DBG("bearer is NULL");
 
@@ -198,7 +201,10 @@ int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_
 		return -EFAULT;
 	}
 
-	*uci = bearer->uci;
+	uci_len = strlen(bearer->uci);
+	__ASSERT_NO_MSG(uci_len < BT_TBS_MAX_UCI_SIZE);
+	(void)memcpy(uci, bearer->uci, uci_len);
+	uci[uci_len] = '\0';
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -158,7 +158,7 @@ static int cmd_ccp_call_control_server_get_bearer_name(const struct shell *sh, s
 static int cmd_ccp_call_control_server_get_bearer_uci(const struct shell *sh, size_t argc,
 						      char *argv[])
 {
-	const char *uci;
+	char uci[BT_TBS_MAX_UCI_SIZE];
 	int index = 0;
 	int err = 0;
 
@@ -169,7 +169,7 @@ static int cmd_ccp_call_control_server_get_bearer_uci(const struct shell *sh, si
 		}
 	}
 
-	err = bt_ccp_call_control_server_get_bearer_uci(bearers[index], &uci);
+	err = bt_ccp_call_control_server_get_bearer_uci(bearers[index], uci);
 	if (err != 0) {
 		shell_error(sh, "Failed to get bearer[%d] UCI: %d", index, err);
 

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -114,7 +114,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 	for (int i = 1; i < CONFIG_BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT; i++) {
 		struct bt_tbs_register_param register_param = {
 			.provider_name = "test",
-			.uci = "un999",
+			.uci = DEFAULT_BEARER_UCI,
 			.uri_schemes_supported = "tel",
 			.gtbs = false,
 			.authorization_required = false,
@@ -143,7 +143,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 {
 	const struct bt_tbs_register_param register_param = {
 		.provider_name = "test",
-		.uci = "un999",
+		.uci = DEFAULT_BEARER_UCI,
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
@@ -161,7 +161,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 {
 	const struct bt_tbs_register_param register_param = {
 		.provider_name = "test",
-		.uci = "un999",
+		.uci = DEFAULT_BEARER_UCI,
 		.uri_schemes_supported = "tel",
 		.gtbs = false,
 		.authorization_required = false,
@@ -179,7 +179,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 {
 	const struct bt_tbs_register_param register_param = {
 		.provider_name = "test",
-		.uci = "un999",
+		.uci = DEFAULT_BEARER_UCI,
 		.uri_schemes_supported = "tel",
 		.gtbs = true,
 		.authorization_required = false,
@@ -203,7 +203,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 {
 	const struct bt_tbs_register_param register_param = {
 		.provider_name = "test",
-		.uci = "un999",
+		.uci = DEFAULT_BEARER_UCI,
 		.uri_schemes_supported = "tel",
 		.gtbs = false,
 		.authorization_required = false,
@@ -412,12 +412,12 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 
 static ZTEST_F(ccp_call_control_server_test_suite, test_bt_ccp_call_control_server_get_bearer_uci)
 {
-	const char *res_bearer_uci;
+	char res_bearer_uci[BT_TBS_MAX_UCI_SIZE];
 	int err;
 
 	register_default_bearer(fixture);
 
-	err = bt_ccp_call_control_server_get_bearer_uci(fixture->bearers[0], &res_bearer_uci);
+	err = bt_ccp_call_control_server_get_bearer_uci(fixture->bearers[0], res_bearer_uci);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zassert_str_equal(DEFAULT_BEARER_UCI, res_bearer_uci, "%s != %s", DEFAULT_BEARER_UCI,
@@ -427,7 +427,7 @@ static ZTEST_F(ccp_call_control_server_test_suite, test_bt_ccp_call_control_serv
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_uci_inval_not_registered)
 {
-	const char *res_bearer_uci;
+	char res_bearer_uci[BT_TBS_MAX_UCI_SIZE];
 	int err;
 
 	/* Register and unregister bearer to get a valid pointer but where it is unregistered*/
@@ -435,19 +435,19 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 	err = bt_ccp_call_control_server_unregister_bearer(fixture->bearers[0]);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	err = bt_ccp_call_control_server_get_bearer_uci(fixture->bearers[0], &res_bearer_uci);
+	err = bt_ccp_call_control_server_get_bearer_uci(fixture->bearers[0], res_bearer_uci);
 	zassert_equal(err, -EFAULT, "Unexpected return value %d", err);
 }
 
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_get_bearer_uci_inval_null_bearer)
 {
-	const char *res_bearer_uci;
+	char res_bearer_uci[BT_TBS_MAX_UCI_SIZE];
 	int err;
 
 	register_default_bearer(fixture);
 
-	err = bt_ccp_call_control_server_get_bearer_uci(NULL, &res_bearer_uci);
+	err = bt_ccp_call_control_server_get_bearer_uci(NULL, res_bearer_uci);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 }
 


### PR DESCRIPTION
Modify bt_ccp_call_control_server_get_bearer_uci to store the bearer UCI in an output buffer, instead of just providing the pointer.

The reason for this is to make the result thread safe, and avoid the user/application having a direct pointer to internal storage.