### PR TITLE
drivers: memc: {stm32_xspi_psram,stm32_ospi_psram}: make refresh configurable in dt

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -152,6 +152,7 @@ stm32_lp_tick_source: &lptim1 {
 		fixed-latency;
 		burst-length = <3>;
 		st,csbound = <10>;
+		st,refresh = <320>;
 		status = "okay";
 	};
 };

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -304,6 +304,7 @@ st_cam_i2c: &i2c1 {
 		write-latency = <1>;
 		burst-length = <0>;
 		st,csbound = <11>;
+		st,refresh = <129>;
 		status = "okay";
 	};
 };

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -375,6 +375,7 @@ zephyr_udc0: &usbotg_hs1 {
 		write-latency = <1>;
 		burst-length = <0>;
 		st,csbound = <11>;
+		st,refresh = <129>;
 		status = "okay";
 	};
 };

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -498,6 +498,15 @@ MDIO
   MDIO bus enabling/disabling is now handled internally by the MDIO drivers.
   (:github:`99690`).
 
+MEMC
+====
+
+* :dtcompatible:`st,stm32-xspi-psram` and :dtcompatible:`st,stm32-ospi-psram`
+  compatible nodes now need to include the ``st,refresh`` property to specify
+  the PSRAM refresh rate in number of memory clock cycles. (:github:`102735`).
+  Hard-coded default values in drivers, of 320 (:dtcompatible:`st,stm32-xspi-psram`) and 129
+  (:dtcompatible:`st,stm32-ospi-psram`), have been removed.
+
 QSPI
 ====
 

--- a/drivers/memc/memc_stm32_ospi_psram.c
+++ b/drivers/memc/memc_stm32_ospi_psram.c
@@ -437,7 +437,7 @@ static struct memc_stm32_ospi_psram_data memc_stm32_ospi_data = {
 			.ChipSelectBoundary = DT_INST_PROP(0, st_csbound),
 			.DelayBlockBypass = HAL_OSPI_DELAY_BLOCK_USED,
 			.MaxTran = 0,
-			.Refresh = 320,
+			.Refresh = DT_INST_PROP(0, st_refresh),
 		},
 	},
 	.ospim_cfg = {

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -413,7 +413,7 @@ static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
 			.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE,
 			.ChipSelectBoundary = DT_INST_PROP(0, st_csbound),
 			.MaxTran = 0U,
-			.Refresh = 0x81U,
+			.Refresh = DT_INST_PROP(0, st_refresh),
 			.MemorySelect = HAL_XSPI_CSSEL_NCS1,
 		},
 	},

--- a/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
@@ -160,3 +160,13 @@ properties:
       of the PSRAM device for the linear burst command.
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
            21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+
+  st,refresh:
+    type: int
+    required: true
+    description: |
+      Refresh rate in number of memory clock cycles. The chip select must not
+      stay low for a period longer than the refresh rate. This value effectively
+      defines the maximum length of a transaction. It should be configured
+      depending on the memory datasheet.
+      A value of 0 means the feature is disabled.

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -159,3 +159,13 @@ properties:
       of the PSRAM device for the linear burst command.
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
            21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+
+  st,refresh:
+    type: int
+    required: true
+    description: |
+      Refresh rate in number of memory clock cycles. The chip select must not
+      stay low for a period longer than the refresh rate. This value effectively
+      defines the maximum length of a transaction. It should be configured
+      depending on the memory datasheet.
+      A value of 0 means the feature is disabled.


### PR DESCRIPTION
Limit a transaction maximum length. Each PSRAM may specify different configuration.

https://www.st.com/resource/en/reference_manual/rm0477-stm32h7rx7sx-armbased-32bit-mcus-stmicroelectronics.pdf#page=1038 at chapter _24.7.5 XSPI device configuration register 4 (XSPI_DCR4)_