### PR TITLE
Bluetooth: BAP: BA: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -35,7 +35,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -1051,7 +1050,7 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
 {
 	struct bt_bap_broadcast_assistant_cb *tmp;
 
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -1069,7 +1068,7 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
 
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -1262,8 +1261,8 @@ static bool valid_subgroup_params(uint8_t pa_sync, const struct bt_bap_bass_subg
 		/* BIS sync values of 0 and BT_BAP_BIS_SYNC_NO_PREF are allowed at any time, but any
 		 * other values are only allowed if PA sync state is also set
 		 */
-		CHECKIF(pa_sync == 0 && (subgroups[i].bis_sync != 0U &&
-					 subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF)) {
+		if (pa_sync == 0 && (subgroups[i].bis_sync != 0U &&
+				     subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF)) {
 			LOG_DBG("[%u]: Only syncing to BIS is not allowed", i);
 
 			return false;
@@ -1293,46 +1292,46 @@ static bool valid_subgroup_params(uint8_t pa_sync, const struct bt_bap_bass_subg
 
 static bool valid_add_src_param(const struct bt_bap_broadcast_assistant_add_src_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->addr.type > BT_ADDR_LE_RANDOM) {
+	if (param->addr.type > BT_ADDR_LE_RANDOM) {
 		LOG_DBG("Invalid address type %u", param->addr.type);
 		return false;
 	}
 
-	CHECKIF(param->adv_sid > BT_GAP_SID_MAX) {
+	if (param->adv_sid > BT_GAP_SID_MAX) {
 		LOG_DBG("Invalid adv_sid %u", param->adv_sid);
 		return false;
 	}
 
-	CHECKIF(!(param->pa_interval != BT_BAP_PA_INTERVAL_UNKNOWN) &&
-		!IN_RANGE(param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
-			  BT_GAP_PER_ADV_MAX_INTERVAL)) {
+	if (!(param->pa_interval != BT_BAP_PA_INTERVAL_UNKNOWN) &&
+	    !IN_RANGE(param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
+		      BT_GAP_PER_ADV_MAX_INTERVAL)) {
 		LOG_DBG("Invalid pa_interval 0x%04X", param->pa_interval);
 		return false;
 	}
 
-	CHECKIF(param->broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
+	if (param->broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
 		LOG_DBG("Invalid broadcast_id 0x%08X", param->broadcast_id);
 		return false;
 	}
 
-	CHECKIF(param->num_subgroups != 0 && param->subgroups == NULL) {
+	if (param->num_subgroups != 0 && param->subgroups == NULL) {
 		LOG_DBG("Subgroups are NULL when num_subgroups = %u", param->num_subgroups);
 		return false;
 	}
 
-	CHECKIF(param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
+	if (param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
 		LOG_DBG("Too many subgroups %u/%u", param->num_subgroups,
 			CONFIG_BT_BAP_BASS_MAX_SUBGROUPS);
 
 		return false;
 	}
 
-	CHECKIF(param->subgroups != NULL) {
+	if (param->subgroups != NULL) {
 		if (!valid_subgroup_params(param->pa_sync, param->subgroups,
 					   param->num_subgroups)) {
 			return false;
@@ -1443,31 +1442,31 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 
 static bool valid_add_mod_param(const struct bt_bap_broadcast_assistant_mod_src_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(!(param->pa_interval != BT_BAP_PA_INTERVAL_UNKNOWN) &&
-		!IN_RANGE(param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
-			  BT_GAP_PER_ADV_MAX_INTERVAL)) {
+	if (!(param->pa_interval != BT_BAP_PA_INTERVAL_UNKNOWN) &&
+	    !IN_RANGE(param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
+		      BT_GAP_PER_ADV_MAX_INTERVAL)) {
 		LOG_DBG("Invalid pa_interval 0x%04X", param->pa_interval);
 		return false;
 	}
 
-	CHECKIF(param->num_subgroups != 0 && param->subgroups == NULL) {
+	if (param->num_subgroups != 0 && param->subgroups == NULL) {
 		LOG_DBG("Subgroups are NULL when num_subgroups = %u", param->num_subgroups);
 		return false;
 	}
 
-	CHECKIF(param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
+	if (param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
 		LOG_DBG("Too many subgroups %u/%u", param->num_subgroups,
 			CONFIG_BT_BAP_BASS_MAX_SUBGROUPS);
 
 		return false;
 	}
 
-	CHECKIF(param->subgroups != NULL) {
+	if (param->subgroups != NULL) {
 		if (!valid_subgroup_params(param->pa_sync, param->subgroups,
 					   param->num_subgroups)) {
 			return false;
@@ -1695,7 +1694,7 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	CHECKIF(idx >= ARRAY_SIZE(inst->recv_state_handles)) {
+	if (idx >= ARRAY_SIZE(inst->recv_state_handles)) {
 		LOG_DBG("Invalid idx: %u", idx);
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.