### PR TITLE
Bluetooth: BAP: Broadcast Sink: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -31,7 +31,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -914,7 +913,7 @@ int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb)
 {
 	static bool iso_big_cb_registered;
 
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 
 		return -EINVAL;
@@ -1058,19 +1057,19 @@ int bt_bap_broadcast_sink_create(struct bt_le_per_adv_sync *pa_sync, uint32_t br
 	const struct bt_bap_scan_delegator_recv_state *recv_state;
 	struct bt_bap_broadcast_sink *sink;
 
-	CHECKIF(pa_sync == NULL) {
+	if (pa_sync == NULL) {
 		LOG_DBG("pa_sync is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
+	if (broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
 		LOG_DBG("Invalid broadcast_id: 0x%X", broadcast_id);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(out_sink == NULL) {
+	if (out_sink == NULL) {
 		LOG_DBG("sink was NULL");
 
 		return -EINVAL;
@@ -1272,17 +1271,17 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	int err;
 	int ret;
 
-	CHECKIF(sink == NULL) {
+	if (sink == NULL) {
 		LOG_DBG("sink is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(indexes_bitfield == 0U || indexes_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
+	if (indexes_bitfield == 0U || indexes_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
 		LOG_DBG("Invalid indexes_bitfield: 0x%08X", indexes_bitfield);
 		return -EINVAL;
 	}
 
-	CHECKIF(streams == NULL) {
+	if (streams == NULL) {
 		LOG_DBG("streams is NULL");
 		return -EINVAL;
 	}
@@ -1339,7 +1338,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	stream_count = data.stream_count;
 
 	for (size_t i = 0; i < stream_count; i++) {
-		CHECKIF(streams[i] == NULL) {
+		if (streams[i] == NULL) {
 			LOG_DBG("streams[%zu] is NULL", i);
 			return -EINVAL;
 		}
@@ -1401,7 +1400,7 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink)
 {
 	int err;
 
-	CHECKIF(sink == NULL) {
+	if (sink == NULL) {
 		LOG_DBG("sink is NULL");
 		return -EINVAL;
 	}
@@ -1428,7 +1427,7 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink)
 int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink)
 {
 
-	CHECKIF(sink == NULL) {
+	if (sink == NULL) {
 		LOG_DBG("sink is NULL");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.