### PR TITLE
dts: bindings: clock: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/clock/atmel,sam0-mclk.yaml
+++ b/dts/bindings/clock/atmel,sam0-mclk.yaml
@@ -25,24 +25,26 @@ properties:
       clock for an specific peripheral. The generator 2 is used on this
       example and can be defined by the user at board.
 
-      Example: Enable SERCOM0 on SAMD21
-        &sercom0 {
-          clocks = <&gclk 0x14>, <&pm 0x20 2>;
-          clock-names = "GCLK", "PM";
-
-          atmel,assigned-clocks = <&gclk 2>;
-          atmel,assigned-clock-names = "GCLK";
-        };
-
-      Example: Enable SERCOM0 on SAME54
-        &sercom0 {
-          clocks = <&gclk 7>, <&mclk 0x14 12>;
-          clock-names = "GCLK", "MCLK";
-
-          atmel,assigned-clocks = <&gclk 2>;
-          atmel,assigned-clock-names = "GCLK";
-        };
-
 clock-cells:
   - offset
   - bit
+
+examples:
+  - |
+    /* Enable SERCOM0 on SAMD21 */
+    &sercom0 {
+      clocks = <&gclk 0x14>, <&pm 0x20 2>;
+      clock-names = "GCLK", "PM";
+
+      atmel,assigned-clocks = <&gclk 2>;
+      atmel,assigned-clock-names = "GCLK";
+    };
+  - |
+    /* Enable SERCOM0 on SAME54 */
+    &sercom0 {
+      clocks = <&gclk 7>, <&mclk 0x14 12>;
+      clock-names = "GCLK", "MCLK";
+
+      atmel,assigned-clocks = <&gclk 2>;
+      atmel,assigned-clock-names = "GCLK";
+    };

--- a/dts/bindings/clock/atmel,sam0-osc32kctrl.yaml
+++ b/dts/bindings/clock/atmel,sam0-osc32kctrl.yaml
@@ -24,15 +24,16 @@ properties:
     description: |
       It selects the OSC32CTRL clock to be routed to RTC peripheral
 
-      Example: Connect the XOSC32K to RTC on SAMD5x
-
-        &rtc {
-          clocks = <&mclk 0x14 9 &osc32kctrl>;
-          clock-names = "MCLK", "OSC32KCTRL";
-
-          atmel,assigned-clocks = <&osc32kctrl 4>;
-          atmel,assigned-clock-names = "OSC32KCTRL";
-        };
-
 atmel,assigned-clock-cells:
   - src
+
+examples:
+  - |
+    /* Connect the XOSC32K to RTC on SAMD5x */
+    &rtc {
+      clocks = <&mclk 0x14 9 &osc32kctrl>;
+      clock-names = "MCLK", "OSC32KCTRL";
+
+      atmel,assigned-clocks = <&osc32kctrl 4>;
+      atmel,assigned-clock-names = "OSC32KCTRL";
+    };

--- a/dts/bindings/clock/nordic,nrf-fll16m.yaml
+++ b/dts/bindings/clock/nordic,nrf-fll16m.yaml
@@ -14,15 +14,6 @@ description: |
       FLL16M mode is closed-loop and the LFXO clock is
       available.
 
-  Devicetree example:
-
-    fll16m {
-            open-loop-accuracy-ppm = <20000>;
-            open-loop-startup-time-us = <400>;
-            clocks = <&hfxo>, <&lfxo>;
-            clock-names = "hfxo", "lfxo";
-    };
-
 compatible: "nordic,nrf-fll16m"
 
 include: fixed-clock.yaml
@@ -40,3 +31,12 @@ properties:
     type: int
     description: Clock startup time if open-loop clock source is used.
     required: true
+
+examples:
+  - |
+    fll16m {
+            open-loop-accuracy-ppm = <20000>;
+            open-loop-startup-time-us = <400>;
+            clocks = <&hfxo>, <&lfxo>;
+            clock-names = "hfxo", "lfxo";
+    };

--- a/dts/bindings/clock/nordic,nrf-hsfll-global.yaml
+++ b/dts/bindings/clock/nordic,nrf-hsfll-global.yaml
@@ -7,19 +7,6 @@ description: |
   The lowest supported clock frequency is the default
   clock frequency.
 
-  Example:
-
-    global_hsfll: global_hsfll {
-            compatible = "nordic,nrf-hsfll-global";
-            clocks = <&fll16>;
-            #clock-cells = <0>;
-            clock-frequency = <320000000>;
-            supported-clock-frequencies = <64000000
-                                           128000000
-                                           256000000
-                                           320000000>;
-    };
-
 compatible: "nordic,nrf-hsfll-global"
 
 include:
@@ -42,3 +29,16 @@ properties:
     description: |
       Optional fixed frequency specified if used in fixed
       frequency mode.
+
+examples:
+  - |
+    global_hsfll: global_hsfll {
+            compatible = "nordic,nrf-hsfll-global";
+            clocks = <&fll16>;
+            #clock-cells = <0>;
+            clock-frequency = <320000000>;
+            supported-clock-frequencies = <64000000
+                                           128000000
+                                           256000000
+                                           320000000>;
+    };

--- a/dts/bindings/clock/nordic,nrf-hsfll-local.yaml
+++ b/dts/bindings/clock/nordic,nrf-hsfll-local.yaml
@@ -7,19 +7,6 @@ description: |
   The local HSFLL mixed-mode IP generates several clock frequencies in the range
   from 64 MHz to 400 MHz (in steps of 16 MHz).
 
-  Usage example:
-
-    hsfll: clock@deadbeef {
-        compatible = "nordic,nrf-hsfll-local";
-        reg = <0xdeadbeef 0x1000>;
-        clocks = <&fll16m>;
-        clock-frequency = <DT_FREQ_M(320)>;
-        nordic,ficrs = <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_VSUP>,
-                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_COARSE_0>,
-                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>;
-        nordic,ficr-names = "vsup", "coarse", "fine";
-    };
-
   Required FICR entries are for VSUP, COARSE and FINE trim values.
 
 compatible: "nordic,nrf-hsfll-local"
@@ -57,3 +44,16 @@ properties:
       - 368000000
       - 384000000
       - 400000000
+
+examples:
+  - |
+    hsfll: clock@deadbeef {
+        compatible = "nordic,nrf-hsfll-local";
+        reg = <0xdeadbeef 0x1000>;
+        clocks = <&fll16m>;
+        clock-frequency = <DT_FREQ_M(320)>;
+        nordic,ficrs = <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_VSUP>,
+                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_COARSE_0>,
+                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>;
+        nordic,ficr-names = "vsup", "coarse", "fine";
+    };

--- a/dts/bindings/clock/nordic,nrf-iron-hsfll-local.yaml
+++ b/dts/bindings/clock/nordic,nrf-iron-hsfll-local.yaml
@@ -7,19 +7,6 @@ description: |
   The local HSFLL mixed-mode IP generates several clock frequencies in the range
   from 64 MHz to 400 MHz (in steps of 16 MHz).
 
-  Usage example:
-
-    hsfll: clock@deadbeef {
-        compatible = "nordic,nrf-hsfll-local";
-        reg = <0xdeadbeef 0x1000>;
-        clocks = <&fll16m>;
-        clock-frequency = <DT_FREQ_M(320)>;
-        nordic,ficrs = <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_VSUP>,
-                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_COARSE_0>,
-                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>;
-        nordic,ficr-names = "vsup", "coarse", "fine";
-    };
-
   Required FICR entries are for VSUP, COARSE and FINE trim values.
 
 compatible: "nordic,nrf-iron-hsfll-local"
@@ -57,3 +44,16 @@ properties:
       - 368000000
       - 384000000
       - 400000000
+
+examples:
+  - |
+    hsfll: clock@deadbeef {
+        compatible = "nordic,nrf-hsfll-local";
+        reg = <0xdeadbeef 0x1000>;
+        clocks = <&fll16m>;
+        clock-frequency = <DT_FREQ_M(320)>;
+        nordic,ficrs = <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_VSUP>,
+                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_COARSE_0>,
+                       <&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>;
+        nordic,ficr-names = "vsup", "coarse", "fine";
+    };

--- a/dts/bindings/clock/nordic,nrf-lfclk.yaml
+++ b/dts/bindings/clock/nordic,nrf-lfclk.yaml
@@ -16,17 +16,6 @@ description: |
       available. The LFXO clock is used indirectly through
       the FLL16M clock in BYPASS mode.
 
-  Devicetree example:
-
-    lfclk {
-            lfrc-accuracy-ppm = <500>;
-            lflprc-accuracy-ppm = <1000>;
-            lfrc-startup-time-us = <400>;
-            lflprc-startup-time-us = <400>;
-            clocks = <&hfxo>, <&lfxo>;
-            clock-names = "hfxo", "lfxo";
-    };
-
 compatible: "nordic,nrf-lfclk"
 
 include: fixed-clock.yaml
@@ -50,3 +39,14 @@ properties:
   lflprc-startup-time-us:
     type: int
     description: Clock startup time in microseconds if LFLPRC clock source is used.
+
+examples:
+  - |
+    lfclk {
+            lfrc-accuracy-ppm = <500>;
+            lflprc-accuracy-ppm = <1000>;
+            lfrc-startup-time-us = <400>;
+            lflprc-startup-time-us = <400>;
+            clocks = <&hfxo>, <&lfxo>;
+            clock-names = "hfxo", "lfxo";
+    };

--- a/dts/bindings/clock/renesas,rz-cgc.yaml
+++ b/dts/bindings/clock/renesas,rz-cgc.yaml
@@ -4,18 +4,6 @@
 description: |
   Renesas RZ Clock Generator Circuit
 
-  Usage example:
-
-    #include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
-
-    sci0: sci@xxx {
-        ...
-        channel = <0>;
-        /* Cell encodes HWIP, channel, clock source */
-        clocks = <&cgc RZ_CLOCK(RZ_IP_SCI, 0, RZ_CLOCK_PCLKSCI0)>;
-        ...
-    }
-
 compatible: "renesas,rz-cgc"
 
 include: [base.yaml, clock-controller.yaml]
@@ -26,3 +14,15 @@ properties:
 
 clock-cells:
   - clk-id
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
+
+    sci0: sci@xxx {
+        /* ... */
+        channel = <0>;
+        /* Cell encodes HWIP, channel, clock source */
+        clocks = <&cgc RZ_CLOCK(RZ_IP_SCI, 0, RZ_CLOCK_PCLKSCI0)>;
+        /* ... */
+    }

--- a/dts/bindings/clock/renesas,rz-cpg.yaml
+++ b/dts/bindings/clock/renesas,rz-cpg.yaml
@@ -4,18 +4,6 @@
 description: |
   Renesas RZ Clock Pulse Generator
 
-  Usage example:
-
-    #include <zephyr/dt-bindings/clock/renesas_rz[agv]_clock.h>
-
-    scif0: serial@xxx {
-        ...
-        channel = <0>;
-        /* Cell encodes HWIP, channel, clock source and division */
-        clocks = <&cpg RZ_CLOCK_SCIF(0)>;
-        ...
-    }
-
 compatible: "renesas,rz-cpg"
 
 include: [base.yaml, clock-controller.yaml]
@@ -27,3 +15,15 @@ properties:
 
 clock-cells:
   - clk-id
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/clock/renesas_rz[agv]_clock.h>
+
+    scif0: serial@xxx {
+        /* ... */
+        channel = <0>;
+        /* Cell encodes HWIP, channel, clock source and division */
+        clocks = <&cpg RZ_CLOCK_SCIF(0)>;
+        /* ... */
+    }

--- a/dts/bindings/clock/st,stm32-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mco.yaml
@@ -12,15 +12,6 @@ description: |
         Used to output a clock signal from the MCU to a GPIO pin.
         The selected signal goes through a configurable prescaler before output.
 
-        Example:
-                &mco1 {
-                        clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
-                        prescaler = <MCO1_PRE(MCO_PRE_DIV_5)>;
-                        pinctrl-0 = <&rcc_mco_pa8>;
-                        pinctrl-names = "default";
-                        status = "okay";
-                };
-
 include: [base.yaml, pinctrl-device.yaml]
 
 properties:
@@ -37,3 +28,13 @@ properties:
 
   pinctrl-names:
     required: true
+
+examples:
+  - |
+    &mco1 {
+            clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
+            prescaler = <MCO1_PRE(MCO_PRE_DIV_5)>;
+            pinctrl-0 = <&rcc_mco_pa8>;
+            pinctrl-names = "default";
+            status = "okay";
+    };

--- a/dts/bindings/clock/st,stm32-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mux.yaml
@@ -7,11 +7,6 @@ description: |
         Describes a clock multiplexer, such as per_ck on STM32H7 or
         CLK48 on STM32WB.
         The only property of this node is to select a clock input.
-        For instance:
-                &perck {
-                        clocks = <&rcc STM32_SRC_HSI_KER CKPER_SEL(0)>;
-                        status = "okay";
-                };
 
 compatible: "st,stm32-clock-mux"
 
@@ -26,3 +21,10 @@ properties:
 
   clocks:
     required: true
+
+examples:
+  - |
+    &perck {
+            clocks = <&rcc STM32_SRC_HSI_KER CKPER_SEL(0)>;
+            status = "okay";
+    };

--- a/dts/bindings/clock/st,stm32f1-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32f1-clock-mco.yaml
@@ -14,25 +14,26 @@ description: |
         the MCO are fitted with a fixed prescaler, making it possible to
         output a slowed down variation of certain clocks.
 
-        Example:
-                &mco1 {
-                        clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
-                        pinctrl-0 = <&rcc_mco_pa8>;
-                        pinctrl-names = "default";
-                        status = "okay";
-                };
-
         Note: in the `clocks` property, the domain clock source cell should
         use the value representing the base clock, regardless of whether or
         not the selected input is fitted with a prescaler.
-
-        Example:
-                /* PLL3 clock divided by 2 */
-                clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(9)>;
-                /* PLL3 clock */
-                clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(11)>;
 
 include:
   - name: st,stm32-clock-mco.yaml
     property-blocklist:
       - prescaler
+
+examples:
+  - |
+    &mco1 {
+            clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
+            pinctrl-0 = <&rcc_mco_pa8>;
+            pinctrl-names = "default";
+            status = "okay";
+    };
+  - |
+    /* PLL3 clock divided by 2 */
+    clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(9)>;
+  - |
+    /* PLL3 clock */
+    clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(11)>;

--- a/dts/bindings/clock/st,stm32mp13-cpu-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32mp13-cpu-clock-mux.yaml
@@ -2,17 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32MP13 CPU Clock
+  STM32MP13 CPU Clock.
+
   Describes the STM32MP13 CPU armv7 timer multiplexer.
   For the STM32MP13 the CPU armv7 timer input can either be the HSI or the HSE.
-  For instance:
-  cpusw: cpusw {
-    #clock-cells = <0>;
-    clocks = <&clk_hsi>;
-    clock-frequency = <DT_FREQ_M(64)>;
-    compatible = "st,stm32mp13-cpu-clock-mux", "st,stm32-clock-mux";
-    status = "okay";
-  };
 
 compatible: "st,stm32mp13-cpu-clock-mux"
 
@@ -29,3 +22,13 @@ properties:
     type: int
     description: |
       default frequency in Hz for the timer
+
+examples:
+  - |
+    cpusw: cpusw {
+      #clock-cells = <0>;
+      clocks = <&clk_hsi>;
+      clock-frequency = <DT_FREQ_M(64)>;
+      compatible = "st,stm32mp13-cpu-clock-mux", "st,stm32-clock-mux";
+      status = "okay";
+    };

--- a/dts/bindings/clock/st,stm32n6-cpu-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-cpu-clock-mux.yaml
@@ -7,13 +7,6 @@ description: |
   Describes the STM32N6 CPU clock multiplexer. On STM32N6, this is the CPU
   clock that feeds the SysTick.
 
-  For instance:
-  &cpusw {
-    clocks = <&rcc STM32_SRC_IC1 CPU_SEL(3)>;
-    clock-frequency = <DT_FREQ_M(600)>;
-    status = "okay";
-  };
-
 compatible: "st,stm32n6-cpu-clock-mux"
 
 include:
@@ -29,3 +22,11 @@ properties:
     type: int
     description: |
       default frequency in Hz for CPU clock (sysa_ck/sys_cpu_ck)
+
+examples:
+  - |
+    &cpusw {
+            clocks = <&rcc STM32_SRC_IC1 CPU_SEL(3)>;
+            clock-frequency = <DT_FREQ_M(600)>;
+            status = "okay";
+    };

--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -6,13 +6,6 @@ description: |
 
   This node selects a clock input and a divider.
 
-  For instance:
-    &ic6 {
-      pll-src = <2>;
-      div = <16>;
-      status = "okay";
-    };
-
 compatible: "st,stm32n6-ic-clock-mux"
 
 properties:
@@ -33,3 +26,11 @@ properties:
         ICx integer division factor
         The input ICx frequency is divided by the specified value
         Valid range: 1 - 256
+
+examples:
+  - |
+    &ic6 {
+      pll-src = <2>;
+      div = <16>;
+      status = "okay";
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
