### PR TITLE
dts: bindings: sensor: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -6,16 +6,6 @@ description: |
   When setting the accelerometer DTS properties, make sure to include
   adxl345.h and use the macros defined there.
 
-  Example:
-  #include <zephyr/dt-bindings/sensor/adxl345.h>
-
-  adxl345: adxl345@1d {
-    ...
-
-    range = <ADXL345_DT_RANGE_8G>;
-    odr = <ADXL345_DT_ODR_25>;
-  };
-
 include: sensor-device.yaml
 
 properties:
@@ -64,3 +54,14 @@ properties:
       The INT2 signal defaults to active high as produced by the
       sensor.  The property value should ensure the flags properly
       describe the signal that is presented to the driver.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/adxl345.h>
+
+    adxl345: adxl345@1d {
+      /* ... */
+
+      range = <ADXL345_DT_RANGE_8G>;
+      odr = <ADXL345_DT_ODR_25>;
+    };

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -7,15 +7,6 @@ description: |
   streaming functionality, make sure to include adxl362.h and
   use the macros defined there for fifo-mode and fifo-watermark properties.
 
-  Example:
-  #include <zephyr/dt-bindings/sensor/adxl362.h>
-
-  adxl362: adxl362@0 {
-    ...
-    fifo-mode = <ADXL362_FIFO_MODE_STREAM>;
-    fifo-watermark = <0x80>;
-  };
-
 compatible: "adi,adxl362"
 
 include: [sensor-device.yaml, spi-device.yaml]
@@ -60,3 +51,13 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Valid range: 0 - 511
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/adxl362.h>
+
+    adxl362: adxl362@0 {
+      /* ... */
+      fifo-mode = <ADXL362_FIFO_MODE_STREAM>;
+      fifo-watermark = <0x80>;
+    };

--- a/dts/bindings/sensor/adi,adxl367-common.yaml
+++ b/dts/bindings/sensor/adi,adxl367-common.yaml
@@ -7,15 +7,6 @@ description: |
   streaming functionality, make sure to include adxl367.h and
   use the macros defined there for fifo-mode property.
 
-  Example:
-  #include <zephyr/dt-bindings/sensor/adxl367.h>
-
-  adxl367: adxl367@0 {
-    ...
-
-    fifo-mode = <ADXL367_FIFO_MODE_STREAM>;
-  };
-
 
 include: sensor-device.yaml
 
@@ -59,3 +50,13 @@ properties:
       - 1
       - 2
       - 3
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/adxl367.h>
+
+    adxl367: adxl367@0 {
+      /* ... */
+
+      fifo-mode = <ADXL367_FIFO_MODE_STREAM>;
+    };

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -9,14 +9,6 @@ description: |
   streaming functionality, make sure to include adxl372.h and
   use the macros defined there for fifo-mode properties.
 
-  Example:
-  #include <zephyr/dt-bindings/sensor/adxl372.h>
-
-  adxl372: adxl372@0 {
-    ...
-    fifo-mode = <ADXL372_FIFO_MODE_STREAMED>;
-  };
-
 properties:
   odr:
     type: int
@@ -97,3 +89,12 @@ properties:
     description: |
       Specify the FIFO watermark level in frame count.
       Valid range: 0 - 512
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/adxl372.h>
+
+    adxl372: adxl372@0 {
+      /* ... */
+      fifo-mode = <ADXL372_FIFO_MODE_STREAMED>;
+    };

--- a/dts/bindings/sensor/bosch,bmp581.yaml
+++ b/dts/bindings/sensor/bosch,bmp581.yaml
@@ -5,19 +5,6 @@ description: |
     When setting the sensor DTS properties, make sure to include
     bmp581.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/bmp581.h>
-
-    bmp581@46 {
-        ...
-        odr = <BMP581_DT_ODR_50_HZ>;
-        press-osr = <BMP581_DT_OVERSAMPLING_8X>;
-        temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
-        press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
-        temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
-        power-mode = <BMP581_DT_MODE_NORMAL>;
-    };
-
 compatible: "bosch,bmp581"
 
 include: [sensor-device.yaml, i2c-device.yaml]
@@ -153,3 +140,17 @@ properties:
       Specify the FIFO watermark level in frame count.
       Only supports frames with both Pressure and Temperature
       Valid range: 1 - 15
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/bmp581.h>
+
+    bmp581@46 {
+        /* ... */
+        odr = <BMP581_DT_ODR_50_HZ>;
+        press-osr = <BMP581_DT_OVERSAMPLING_8X>;
+        temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
+        press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
+        temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
+        power-mode = <BMP581_DT_MODE_NORMAL>;
+    };

--- a/dts/bindings/sensor/brcm,afbr-s50.yaml
+++ b/dts/bindings/sensor/brcm,afbr-s50.yaml
@@ -13,31 +13,6 @@ description: |
     It also requires defining the GPIO pins used for the SPI bus in GPIO mode,
     under the AFBR node.
 
-    Example:
-
-    #include <zephyr/dt-bindings/sensor/afbr_s50.h>
-
-    &spi_bus {
-        status = "okay";
-        pinctrl-0 = <&spi_bus_default>;
-        pinctrl-1 = <&spi_bus_gpio>;
-        pinctrl-names = "default", "priv_start";
-        ...
-
-        afbr_s50: afbr_s50@0 {
-          compatible = "brcm,afbr-s50";
-          reg = <0>;
-          spi-max-frequency = <10000000>;
-          measurement-mode = <AFBR_S50_DT_MODE_SHORT_RANGE>;
-          dual-freq-mode = <AFBR_S50_DT_DFM_MODE_OFF>;
-          odr = <10>;
-          int-gpios = <&gpio0 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-          spi-mosi-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
-          spi-sck-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-          spi-miso-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
-        };
-    };
-
 compatible: "brcm,afbr-s50"
 include: [sensor-device.yaml, spi-device.yaml]
 
@@ -114,3 +89,28 @@ properties:
       AFBR contains (mandatory).
       This property is required since the SPI bus is configured and used
       through pinctrl, which is not directly mapped to a GPIO port/pin.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/afbr_s50.h>
+
+    &spi_bus {
+        status = "okay";
+        pinctrl-0 = <&spi_bus_default>;
+        pinctrl-1 = <&spi_bus_gpio>;
+        pinctrl-names = "default", "priv_start";
+        /* ... */
+
+        afbr_s50: afbr_s50@0 {
+          compatible = "brcm,afbr-s50";
+          reg = <0>;
+          spi-max-frequency = <10000000>;
+          measurement-mode = <AFBR_S50_DT_MODE_SHORT_RANGE>;
+          dual-freq-mode = <AFBR_S50_DT_DFM_MODE_OFF>;
+          odr = <10>;
+          int-gpios = <&gpio0 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+          spi-mosi-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+          spi-sck-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+          spi-miso-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+        };
+    };

--- a/dts/bindings/sensor/espressif,esp32-pcnt.yaml
+++ b/dts/bindings/sensor/espressif,esp32-pcnt.yaml
@@ -8,8 +8,8 @@ description: |
   The pulse counter module is designed to count the number of
   rising and/or falling edges of an input signal.
 
-  The ESP32's PCNT module has 8 independent counting “units” numbered from 0 to 7.
-  ESP32S2 and ESP32S3 have 4 independent counting “units” numbered from 0 to 3.
+  The ESP32's PCNT module has 8 independent counting "units" numbered from 0 to 7.
+  ESP32S2 and ESP32S3 have 4 independent counting "units" numbered from 0 to 3.
 
   Each pulse counter unit has a 16-bit signed counter register.
 
@@ -26,44 +26,8 @@ description: |
   By combining the usage of both signal and control inputs, a PCNT unit can
   act as a quadrature decoder.
 
-  Example: Use PCNT to read a rotary-enconder
-
-  The mapping between signal and control input and the pin is done through pinctrl:
-
-    &pinctrl {
-        pcnt_default: pcnt_default {
-            group1 {
-                pinmux = <PCNT0_CH0SIG_GPIO14>,
-                        <PCNT0_CH0CTRL_GPIO15>;
-                bias-pull-up;
-            };
-        };
-    };
-
-  Note: Check espressif,esp32-pinctrl.yaml for complete documentation regarding pinctrl.
-
-  Use the PCNT node to configure the module:
-
-    &pcnt {
-      pinctrl-0 = <&pcnt_default>;
-      pinctrl-names = "default";
-      status = "okay";
-      #address-cells = <1>;
-      #size-cells = <0>;
-      unit0@0 {
-        reg = <0>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-        filter = <100>;
-        channelA@0 {
-            reg = <0>;
-            sig-pos-mode = <2>;
-            sig-neg-mode = <1>;
-            ctrl-h-mode = <0>;
-            ctrl-l-mode = <1>;
-        };
-      };
-    };
+  The mapping between signal and control input and the pin is done through pinctrl.
+  Check espressif,esp32-pinctrl.yaml for complete documentation regarding pinctrl.
 
 compatible: "espressif,esp32-pcnt"
 
@@ -158,3 +122,36 @@ child-binding:
           0 (Default) - Don't change counter mode.
           1 - Invert counter mode(increase -> decrease, decrease -> increase).
           2 - Control mode: Inhibit counter (counter value will not change in this condition).
+
+examples:
+- |
+  /* Use PCNT to read a rotary-encoder */
+  &pinctrl {
+      pcnt_default: pcnt_default {
+          group1 {
+              pinmux = <PCNT0_CH0SIG_GPIO14>,
+                      <PCNT0_CH0CTRL_GPIO15>;
+              bias-pull-up;
+          };
+      };
+  };
+  &pcnt {
+    pinctrl-0 = <&pcnt_default>;
+    pinctrl-names = "default";
+    status = "okay";
+    #address-cells = <1>;
+    #size-cells = <0>;
+    unit0@0 {
+      reg = <0>;
+      #address-cells = <1>;
+      #size-cells = <0>;
+      filter = <100>;
+      channelA@0 {
+          reg = <0>;
+          sig-pos-mode = <2>;
+          sig-neg-mode = <1>;
+          ctrl-h-mode = <0>;
+          ctrl-l-mode = <1>;
+      };
+    };
+  };

--- a/dts/bindings/sensor/invensense,icm42686.yaml
+++ b/dts/bindings/sensor/invensense,icm42686.yaml
@@ -11,12 +11,16 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include icm42686.h
     and use the macros defined there.
 
-    Example:
+compatible: "invensense,icm42686"
+include: ["invensense,icm4268x.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/icm42686.h>
 
     icm42686: icm42686@0 {
       compatible = "invensense,icm42686", "invensense,icm4268x"
-      ...
+      /* ... */
 
       accel-pwr-mode = <ICM42686_DT_ACCEL_LN>;
       accel-fs = <ICM42686_DT_ACCEL_FS_16>;
@@ -25,5 +29,3 @@ description: |
       gyro-fs = <ICM42686_DT_GYRO_FS_2000>;
       gyro-odr = <ICM42686_DT_GYRO_ODR_2000>;
     };
-compatible: "invensense,icm42686"
-include: ["invensense,icm4268x.yaml"]

--- a/dts/bindings/sensor/invensense,icm42688.yaml
+++ b/dts/bindings/sensor/invensense,icm42688.yaml
@@ -11,12 +11,16 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include icm42688.h
     and use the macros defined there.
 
-    Example:
+compatible: "invensense,icm42688"
+include: ["invensense,icm4268x.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/icm42688.h>
 
     icm42688: icm42688@0 {
       compatible = "invensense,icm42688", "invensense,icm4268x"
-      ...
+      /* ... */
 
       accel-pwr-mode = <ICM42688_DT_ACCEL_LN>;
       accel-fs = <ICM42688_DT_ACCEL_FS_16>;
@@ -25,5 +29,3 @@ description: |
       gyro-fs = <ICM42688_DT_GYRO_FS_2000>;
       gyro-odr = <ICM42688_DT_GYRO_ODR_2000>;
     };
-compatible: "invensense,icm42688"
-include: ["invensense,icm4268x.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i2c.yaml
@@ -7,14 +7,19 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
     and use the macros defined there.
 
-    Example:
+compatible: "invensense,icm45686"
+
+include: ["i2c-device.yaml", "invensense,icm45686-common.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/icm45686.h>
 
     &i2c0 {
-      ...
+      /* ... */
 
       icm45686: icm45686@68 {
-        ...
+        /* ... */
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
         accel-fs = <ICM45686_DT_ACCEL_FS_32>;
@@ -24,7 +29,3 @@ description: |
         gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
       };
     };
-
-compatible: "invensense,icm45686"
-
-include: ["i2c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i3c.yaml
@@ -7,14 +7,19 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
     and use the macros defined there.
 
-    Example:
+compatible: "invensense,icm45686"
+
+include: ["i3c-device.yaml", "invensense,icm45686-common.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/icm45686.h>
 
     &i3c1 {
-      ...
+      /* ... */
 
       icm45686: icm45686@680000046a00000011 {
-        ...
+        /* ... */
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
         accel-fs = <ICM45686_DT_ACCEL_FS_32>;
@@ -24,7 +29,3 @@ description: |
         gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
       };
     };
-
-compatible: "invensense,icm45686"
-
-include: ["i3c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-spi.yaml
@@ -7,14 +7,19 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
     and use the macros defined there.
 
-    Example:
+compatible: "invensense,icm45686"
+
+include: ["spi-device.yaml", "invensense,icm45686-common.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/icm45686.h>
 
     &spi0 {
-      ...
+      /* ... */
 
       icm45686: icm45686@0 {
-        ...
+        /* ... */
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
         accel-fs = <ICM45686_DT_ACCEL_FS_32>;
@@ -24,7 +29,3 @@ description: |
         gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
       };
     };
-
-compatible: "invensense,icm45686"
-
-include: ["spi-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/ist,tsic-xx6.yaml
+++ b/dts/bindings/sensor/ist,tsic-xx6.yaml
@@ -5,16 +5,6 @@ description: |
   TSic xx6 temperature sensor.
   https://www.ist-ag.com/sites/default/files/downloads/ATTSic_E.pdf
 
-  Example:
-    tsic_716: tsic_716 {
-      status = "okay";
-      compatible = "ist,tsic-xx6";
-      pwms = <&pwm2 1 PWM_USEC(5) PWM_POLARITY_NORMAL>;
-      data-bits = <14>;
-      lower-temperature-limit = <(-10)>;
-      higher-temperature-limit = <60>;
-    };
-
 compatible: "ist,tsic-xx6"
 
 include: sensor-device.yaml
@@ -40,3 +30,14 @@ properties:
     type: int
     description: Data bits per reading.
     enum: [11, 14]
+
+examples:
+  - |
+    tsic_716: tsic_716 {
+      status = "okay";
+      compatible = "ist,tsic-xx6";
+      pwms = <&pwm2 1 PWM_USEC(5) PWM_POLARITY_NORMAL>;
+      data-bits = <14>;
+      lower-temperature-limit = <(-10)>;
+      higher-temperature-limit = <60>;
+    };

--- a/dts/bindings/sensor/memsic,mc3419.yaml
+++ b/dts/bindings/sensor/memsic,mc3419.yaml
@@ -4,16 +4,6 @@
 description: |
     MC3419 3-axis accel sensor
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/mc3419.h>
-
-    mc3419: mc3419@0 {
-      ...
-
-      lpf-fc-sel = <MC3419_LPF_DISABLE>;
-      decimation-rate = <MC3419_DECIMATE_IDR_BY_1>;
-    };
-
 compatible: "memsic,mc3419"
 
 include: [sensor-device.yaml, i2c-device.yaml]
@@ -79,3 +69,14 @@ properties:
       | 15        | MC3419_DECIMATE_IDR_BY_1000   |
       +-----------+-------------------------------+
       Default is Decimation 0 (reset value of the register).
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/mc3419.h>
+
+    mc3419: mc3419@0 {
+      /* ... */
+
+      lpf-fc-sel = <MC3419_LPF_DISABLE>;
+      decimation-rate = <MC3419_DECIMATE_IDR_BY_1>;
+    };

--- a/dts/bindings/sensor/microchip,mcp9600.yaml
+++ b/dts/bindings/sensor/microchip,mcp9600.yaml
@@ -11,18 +11,6 @@ description: |
   When setting the DTS properties, make sure to include
   mcp9600.h and use the macros defined there.
 
-  Example:
-  #include <zephyr/dt-bindings/sensor/mcp9600.h>
-
-  mcp9600: mcp9600@60 {
-    ...
-
-    thermocouple-type = <MCP9600_DT_TYPE_K>;
-    adc-resolution = <MCP9600_DT_ADC_RES_18BIT>;
-    filter-coefficient = <0>;
-    cold-junction-temp-resolution: <MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C>;
-  };
-
 compatible: "microchip,mcp9600"
 
 include: [sensor-device.yaml, i2c-device.yaml]
@@ -93,3 +81,16 @@ properties:
     enum:
       - 0 # MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C
       - 1 # MCP9600_DT_COLD_JUNC_TMP_RES_0_25C
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/mcp9600.h>
+
+    mcp9600: mcp9600@60 {
+      /* ... */
+
+      thermocouple-type = <MCP9600_DT_TYPE_K>;
+      adc-resolution = <MCP9600_DT_ADC_RES_18BIT>;
+      filter-coefficient = <0>;
+      cold-junction-temp-resolution: <MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C>;
+    };

--- a/dts/bindings/sensor/nxp,tempsense.yaml
+++ b/dts/bindings/sensor/nxp,tempsense.yaml
@@ -5,34 +5,7 @@ description: |
   NXP on-die temperature sensor (TEMPSENSE)
 
   Note: The temperature value calculation depends on the ADC reference voltage
-  and resolution. These must be configured in the ADC node. Here is an example
-  tempsense and ADC channel configuration:
-
-  tempsense: tempsense@1234 {
-    status = "okay";
-    reg = <0x1234 0x100>;
-    compatible = "nxp,tempsense";
-    io-channels = <&adc_0 0>;
-  };
-
-  adc_0: adc@5678 {
-    status = "okay";
-    compatible = "nxp,sar-adc";
-    reg = <0x5678 0x1000>;
-    ...
-    #address-cells = <1>;
-    #size-cells = <0>;
-
-    channel@0 {
-      reg = <0>;
-      zephyr,gain = "ADC_GAIN_1";
-      zephyr,reference = "ADC_REF_VDD_1";
-      zephyr,vref-mv = <3300>;
-      zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-      zephyr,resolution = <15>;
-      zephyr,input-positive = <49>;
-    };
-  };
+  and resolution. These must be configured in the ADC node.
 
 compatible: "nxp,tempsense"
 
@@ -51,3 +24,31 @@ properties:
       If present, set ETSCTL[GNDSEL] to expose the ETS ground on the ADC
       output (requires ETS_EN=1). This can improve precision when the ADC
       ground and ETS ground differ.
+
+examples:
+  - |
+    tempsense: tempsense@1234 {
+      status = "okay";
+      reg = <0x1234 0x100>;
+      compatible = "nxp,tempsense";
+      io-channels = <&adc_0 0>;
+    };
+
+    adc_0: adc@5678 {
+      status = "okay";
+      compatible = "nxp,sar-adc";
+      reg = <0x5678 0x1000>;
+      /* ... */
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      channel@0 {
+        reg = <0>;
+        zephyr,gain = "ADC_GAIN_1";
+        zephyr,reference = "ADC_REF_VDD_1";
+        zephyr,vref-mv = <3300>;
+        zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+        zephyr,resolution = <15>;
+        zephyr,input-positive = <49>;
+      };
+    };

--- a/dts/bindings/sensor/pni,rm3100-i2c.yaml
+++ b/dts/bindings/sensor/pni,rm3100-i2c.yaml
@@ -7,18 +7,18 @@ description: |
     The RM3100 can use either I2C or SPI as a communication bus.
     When setting the odr property in a .dts or .dtsi file you may include rm3100.h
     and use the macros defined there.
+compatible: "pni,rm3100"
 
-    Example:
+include: ["i2c-device.yaml", "pni,rm3100-common.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/rm3100.h>
 
     &i2c0 {
-        rm3100@20 {
+        rm3100: rm3100@20 {
             compatible = "pni,rm3100";
             reg = <0x20>;
             odr = <RM3100_DT_ODR_600>;
         };
     };
-
-compatible: "pni,rm3100"
-
-include: ["i2c-device.yaml", "pni,rm3100-common.yaml"]

--- a/dts/bindings/sensor/pni,rm3100-spi.yaml
+++ b/dts/bindings/sensor/pni,rm3100-spi.yaml
@@ -9,7 +9,12 @@ description: |
     When setting the odr property in a .dts or .dtsi file you may include rm3100.h
     and use the macros defined there.
 
-    Example:
+compatible: "pni,rm3100"
+
+include: ["spi-device.yaml", "pni,rm3100-common.yaml"]
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/rm3100.h>
 
     &spi0 {
@@ -19,14 +24,10 @@ description: |
             reg = <0x0>;
             spi-max-frequency = <8000000>;
 
-            // Enable SPI mode 3. Remove to use mode 0.
+            /* Enable SPI mode 3. Remove to use mode 0. */
             spi-cpol;
             spi-pha;
 
             odr = <RM3100_DT_ODR_600>;
         };
     };
-
-compatible: "pni,rm3100"
-
-include: ["spi-device.yaml", "pni,rm3100-common.yaml"]

--- a/dts/bindings/sensor/sensor-axis-align.yaml
+++ b/dts/bindings/sensor/sensor-axis-align.yaml
@@ -27,26 +27,6 @@ description: |
     y -> -y
     z -> -z
 
-    Example of how to encode that into DTS:
-    #include <zephyr/dt-bindings/sensor/sensor_axis_align.h>
-
-    sensor-top-90: sensor-top-90@0 {
-      ...
-      axis-align-x = <SENSOR_AXIS_ALIGN_DT_Y>
-      axis-align-y = <SENSOR_AXIS_ALIGN_DT_X>
-      axis-align-y-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
-      axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>
-    };
-
-    sensor-bottom: sensor-bottom@1 {
-      ...
-      axis-align-x = <SENSOR_AXIS_ALIGN_DT_X>
-      axis-align-y = <SENSOR_AXIS_ALIGN_DT_Y>
-      axis-align-y-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
-      axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>
-      axis-align-z-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
-    };
-
 include: base.yaml
 properties:
   axis-align-x:
@@ -111,3 +91,24 @@ properties:
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_NEG
       - 2 # SENSOR_AXIS_ALIGN_DT_POS
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/sensor_axis_align.h>
+
+    sensor-top-90: sensor-top-90@0 {
+      /* ... */
+      axis-align-x = <SENSOR_AXIS_ALIGN_DT_Y>
+      axis-align-y = <SENSOR_AXIS_ALIGN_DT_X>
+      axis-align-y-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
+      axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>
+    };
+
+    sensor-bottom: sensor-bottom@1 {
+      /* ... */
+      axis-align-x = <SENSOR_AXIS_ALIGN_DT_X>
+      axis-align-y = <SENSOR_AXIS_ALIGN_DT_Y>
+      axis-align-y-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
+      axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>
+      axis-align-z-sign = <SENSOR_AXIS_ALIGN_DT_NEG>
+    };

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -5,16 +5,6 @@ description: |
     When setting the odr property in a .dts or .dtsi file you may include
     iis2dlpc.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/iis2dlpc.h>
-
-    iis2dlpc: iis2dlpc@0 {
-      ...
-
-      tap-mode = <IIS2DLPC_DT_SINGLE_DOUBLE_TAP>;
-      power-mode = <IIS2DLPC_DT_HP_MODE>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -132,3 +122,14 @@ properties:
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/iis2dlpc.h>
+
+    iis2dlpc: iis2dlpc@0 {
+      /* ... */
+
+      tap-mode = <IIS2DLPC_DT_SINGLE_DOUBLE_TAP>;
+      power-mode = <IIS2DLPC_DT_HP_MODE>;
+    };

--- a/dts/bindings/sensor/st,iis2iclx-common.yaml
+++ b/dts/bindings/sensor/st,iis2iclx-common.yaml
@@ -5,16 +5,6 @@ description: |
     When setting the range, odr properties in a .dts or .dtsi file you may
     include iis2iclx.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/iis2iclx.h>
-
-    iis2iclx: iis2iclx@0 {
-      ...
-
-      range = <IIS2ICLX_DT_FS_2G>;
-      odr = <IIS2ICLX_DT_ODR_833Hz>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -72,3 +62,14 @@ properties:
       - 7  # IIS2ICLX_DT_ODR_833Hz
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/iis2iclx.h>
+
+    iis2iclx: iis2iclx@0 {
+      /* ... */
+
+      range = <IIS2ICLX_DT_FS_2G>;
+      odr = <IIS2ICLX_DT_ODR_833Hz>;
+    };

--- a/dts/bindings/sensor/st,ilps22qs-common.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-common.yaml
@@ -6,17 +6,6 @@ description: |
     When setting the odr, lpf, avg properties in a .dts or .dtsi file
     you may include ilps22qs.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/ilps22qs.h>
-
-    ilps22qs@5d {
-      ...
-
-      odr = <LPS2xDF_DT_ODR_10HZ>;
-      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
-      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -81,3 +70,15 @@ properties:
         - 0 # ILPS22QS_DT_FS_MODE_1_1260
         - 1 # ILPS22QS_DT_FS_MODE_2_4060
     enum: [0, 1]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/ilps22qs.h>
+
+    ilps22qs@5d {
+      /* ... */
+
+      odr = <LPS2xDF_DT_ODR_10HZ>;
+      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
+      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
+    };

--- a/dts/bindings/sensor/st,ism330dhcx-common.yaml
+++ b/dts/bindings/sensor/st,ism330dhcx-common.yaml
@@ -5,16 +5,6 @@ description: |
     When setting the accel-odr and gyro-odr properties in a .dts or .dtsi file you may include
     ism330dhcx.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/ism330dhcx.h>
-
-    ism330dhcx: ism330dhcx@0 {
-      ...
-
-      accel-odr = <ISM330DHCX_DT_ODR_104Hz>;
-      gyro-odr = <ISM330DHCX_DT_ODR_104Hz>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -112,3 +102,14 @@ properties:
       - 2000 # +/- 2000dps
 
     enum: [125, 250, 500, 1000, 2000]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/ism330dhcx.h>
+
+    ism330dhcx: ism330dhcx@0 {
+      /* ... */
+
+      accel-odr = <ISM330DHCX_DT_ODR_104Hz>;
+      gyro-odr = <ISM330DHCX_DT_ODR_104Hz>;
+    };

--- a/dts/bindings/sensor/st,ism6hg256x-common.yaml
+++ b/dts/bindings/sensor/st,ism6hg256x-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include ism6hg256x.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/ism6hg256x.h>
-
-    ism6hg256x: ism6hg256x@0 {
-      ...
-
-      accel-range = <ISM6HG256X_DT_FS_8G>;
-      accel-odr = <ISM6HG256XDT_ODR_AT_60Hz>;
-      gyro-range = <ISM6HG256X_DT_FS_4000DPS>;
-      gyro-odr = <ISM6HG256XDT_ODR_AT_60Hz>;
-    };
-
 include: st,lsm6dsvxxx-common.yaml
 
 properties:
@@ -73,3 +61,16 @@ properties:
       - 0x5 # ISM6HG256X_DT_FS_4000DPS (140 mdps/LSB)
 
     enum: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/ism6hg256x.h>
+
+    ism6hg256x: ism6hg256x@0 {
+      /* ... */
+
+      accel-range = <ISM6HG256X_DT_FS_8G>;
+      accel-odr = <ISM6HG256XDT_ODR_AT_60Hz>;
+      gyro-range = <ISM6HG256X_DT_FS_4000DPS>;
+      gyro-odr = <ISM6HG256XDT_ODR_AT_60Hz>;
+    };

--- a/dts/bindings/sensor/st,lis2de12-common.yaml
+++ b/dts/bindings/sensor/st,lis2de12-common.yaml
@@ -5,16 +5,6 @@ description: |
     When setting the accel-range, accel-odr, properties in a .dts or .dtsi
     file you may include lis2de12.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2de12.h>
-
-    lis2de12: lis2de12@0 {
-      ...
-
-      accel-range = <LIS2DE12_DT_FS_16G>;
-      accel-odr = <LIS2DE12_DT_ODR_AT_100Hz>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -76,3 +66,14 @@ properties:
     description: |
       Selects the pulsed mode for data-ready interrupt when enabled,
       and the latched mode when disabled.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2de12.h>
+
+    lis2de12: lis2de12@0 {
+      /* ... */
+
+      accel-range = <LIS2DE12_DT_FS_16G>;
+      accel-odr = <LIS2DE12_DT_ODR_AT_100Hz>;
+    };

--- a/dts/bindings/sensor/st,lis2dh-common.yaml
+++ b/dts/bindings/sensor/st,lis2dh-common.yaml
@@ -5,17 +5,6 @@ description: |
     When setting the int1-gpio-config/int2-gpio-config and anym-mode properties
     in a .dts or .dtsi file you may include lis2dh.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2dh.h>
-
-    lis2dh: lis2dh@0 {
-      ...
-
-      int1-gpio-config = <LIS2DH_DT_GPIO_INT_LEVEL_LOW>;
-      int2-gpio-config = <LIS2DH_DT_GPIO_INT_LEVEL_LOW>;
-      anym-mode = <LIS2DH_DT_ANYM_6D_POSITION>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -93,3 +82,15 @@ properties:
       - 3 # LIS2DH_DT_ANYM_6D_POSITION
 
     enum: [0, 1, 2, 3]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2dh.h>
+
+    lis2dh: lis2dh@0 {
+      /* ... */
+
+      int1-gpio-config = <LIS2DH_DT_GPIO_INT_LEVEL_LOW>;
+      int2-gpio-config = <LIS2DH_DT_GPIO_INT_LEVEL_LOW>;
+      anym-mode = <LIS2DH_DT_ANYM_6D_POSITION>;
+    };

--- a/dts/bindings/sensor/st,lis2ds12-common.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-common.yaml
@@ -5,16 +5,6 @@ description: |
     When setting the odr and power-mode properties in a .dts or .dtsi file you may include
     lis2ds12.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2ds12.h>
-
-    lis2ds12: lis2ds12@0 {
-      ...
-
-      power-mode = <LIS2DS12_DT_LOW_POWER>;
-      odr = <LIS2DS12_DT_ODR_12Hz5>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -74,3 +64,14 @@ properties:
         - 11 # LIS2DS12_DT_ODR_6400Hz_HF
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2ds12.h>
+
+    lis2ds12: lis2ds12@0 {
+      /* ... */
+
+      power-mode = <LIS2DS12_DT_LOW_POWER>;
+      odr = <LIS2DS12_DT_ODR_12Hz5>;
+    };

--- a/dts/bindings/sensor/st,lis2du12-common.yaml
+++ b/dts/bindings/sensor/st,lis2du12-common.yaml
@@ -6,16 +6,6 @@ description: |
     When setting the accel-range, accel-odr, properties in a .dts or .dtsi
     file you may include lis2du12.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2du12.h>
-
-    lis2du12: lis2du12@0 {
-      ...
-
-      accel-range = <LIS2DU12_DT_FS_16G>;
-      accel-odr = <LIS2DU12_DT_ODR_AT_50Hz>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -115,3 +105,14 @@ properties:
     description: |
       Selects the pulsed mode for data-ready interrupt when enabled,
       and the latched mode when disabled.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2du12.h>
+
+    lis2du12: lis2du12@0 {
+      /* ... */
+
+      accel-range = <LIS2DU12_DT_FS_16G>;
+      accel-odr = <LIS2DU12_DT_ODR_AT_50Hz>;
+    };

--- a/dts/bindings/sensor/st,lis2dux12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dux12-common.yaml
@@ -4,14 +4,6 @@
 description: |
     When setting the odr, power-mode, and range properties in a .dts or .dtsi file you may include
     st_lis2dux12.h and use the macros defined there.
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2dux12.h>
-    lis2dux12: lis2dux12@0 {
-      ...
-      power-mode = <LIS2DUX12_OPER_MODE_LOW_POWER>;
-      odr = <LIS2DUX12_DT_ODR_12Hz5>;
-      range = <LIS2DUX12_DT_FS_16G>;
-    };
 
 include: sensor-device.yaml
 
@@ -148,3 +140,13 @@ properties:
       - 0x3 # LIS2DUX12_DT_DEC_TS_32
 
     enum: [0x00, 0x01, 0x02, 0x03]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2dux12.h>
+    lis2dux12: lis2dux12@0 {
+      /* ... */
+      power-mode = <LIS2DUX12_OPER_MODE_LOW_POWER>;
+      odr = <LIS2DUX12_DT_ODR_12Hz5>;
+      range = <LIS2DUX12_DT_FS_16G>;
+    };

--- a/dts/bindings/sensor/st,lis2duxs12-common.yaml
+++ b/dts/bindings/sensor/st,lis2duxs12-common.yaml
@@ -4,14 +4,16 @@
 description: |
     When setting the odr, power-mode, and range properties in a .dts or .dtsi file you may include
     st_lis2dux12.h and use the macros defined there.
-    Example:
+
+# LIS2DUXS12 is a superset of LIS2DUX12
+include: st,lis2dux12-common.yaml
+
+examples:
+  - |
     #include <zephyr/dt-bindings/sensor/st_lis2dux12.h>
     lis2duxs12: lis2duxs12@0 {
-      ...
+      /* ... */
       power-mode = <LIS2DUX12_OPER_MODE_LOW_POWER>;
       odr = <LIS2DUX12_DT_ODR_12Hz5>;
       range = <LIS2DUX12_DT_FS_16G>;
     };
-
-# LIS2DUXS12 is a superset of LIS2DUX12
-include: st,lis2dux12-common.yaml

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -5,19 +5,6 @@ description: |
     When setting the odr property in a .dts or .dtsi file you may include
     lis2dw12.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lis2dw12.h>
-
-    lis2dw12: lis2dw12@0 {
-      ...
-
-      wakeup-duration = <LIS2DW12_DT_WAKEUP_4_ODR>;
-      ff-threshold = <LIS2DW12_DT_FF_THRESHOLD_500_mg>;
-      tap-mode = <LIS2DW12_DT_SINGLE_DOUBLE_TAP>;
-      power-mode = <LIS2DW12_DT_HP_MODE>;
-      bw-filt = <LIS2DW12_DT_FILTER_BW_ODR_DIV_2>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -265,3 +252,17 @@ properties:
       - 15 # LIS2DW12_DT_SLEEP_15_ODR
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lis2dw12.h>
+
+    lis2dw12: lis2dw12@0 {
+      /* ... */
+
+      wakeup-duration = <LIS2DW12_DT_WAKEUP_4_ODR>;
+      ff-threshold = <LIS2DW12_DT_FF_THRESHOLD_500_mg>;
+      tap-mode = <LIS2DW12_DT_SINGLE_DOUBLE_TAP>;
+      power-mode = <LIS2DW12_DT_HP_MODE>;
+      bw-filt = <LIS2DW12_DT_FILTER_BW_ODR_DIV_2>;
+    };

--- a/dts/bindings/sensor/st,lps22df-common.yaml
+++ b/dts/bindings/sensor/st,lps22df-common.yaml
@@ -6,17 +6,6 @@ description: |
     When setting the odr, lpf, avg properties in a .dts or .dtsi file
     you may include lps22df.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lps22df.h>
-
-    lps22df@5d {
-      ...
-
-      odr = <LPS2xDF_DT_ODR_10HZ>;
-      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
-      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -85,3 +74,15 @@ properties:
         - 7 # LPS2xDF_DT_AVG_512_SAMPLES
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lps22df.h>
+
+    lps22df@5d {
+      /* ... */
+
+      odr = <LPS2xDF_DT_ODR_10HZ>;
+      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
+      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
+    };

--- a/dts/bindings/sensor/st,lps22hh-common.yaml
+++ b/dts/bindings/sensor/st,lps22hh-common.yaml
@@ -5,15 +5,6 @@ description: |
     When setting the odr property in a .dts or .dtsi file you may include
     lps22hh.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lps22hh.h>
-
-    lps22hh: lps22hh@0 {
-      ...
-
-      odr = <LPS22HH_DT_ODR_200HZ>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -43,3 +34,13 @@ properties:
         - 7  # LPS22HH_DT_ODR_200HZ
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lps22hh.h>
+
+    lps22hh: lps22hh@0 {
+      /* ... */
+
+      odr = <LPS22HH_DT_ODR_200HZ>;
+    };

--- a/dts/bindings/sensor/st,lps28dfw-common.yaml
+++ b/dts/bindings/sensor/st,lps28dfw-common.yaml
@@ -6,17 +6,6 @@ description: |
     STMicroelectronics LPS28DFW pressure and temperature sensor. This is an
     extension of st,lps22df driver binding.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lps2xdf.h>
-
-    lps28dfw@5d {
-      ...
-
-      odr = <LPS2xDF_DT_ODR_10HZ>;
-      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
-      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
-    };
-
 include: st,lps22df-common.yaml
 
 properties:
@@ -30,3 +19,15 @@ properties:
         - 0 # LPS28DFW_DT_FS_MODE_1_1260
         - 1 # LPS28DFW_DT_FS_MODE_2_4060
     enum: [0, 1]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lps2xdf.h>
+
+    lps28dfw@5d {
+      /* ... */
+
+      odr = <LPS2xDF_DT_ODR_10HZ>;
+      lpf = <LPS2xDF_DT_LP_FILTER_ODR_4>;
+      avg = <LPS2xDF_DT_AVG_128_SAMPLES>;
+    };

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -6,20 +6,6 @@ description: |
     gyro-odr properties in a .dts or .dtsi file you may include lsm6dso.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dso.h>
-
-    lsm6dso: lsm6dso@0 {
-      ...
-
-      accel-pm = <LSM6DSO_DT_XL_ULP_MODE>;
-      accel-range = <LSM6DSO_DT_FS_8G>;
-      accel-odr = <LSM6DSO_DT_ODR_1Hz6>;
-      gyro-pm = <LSM6DSO_DT_GY_NORMAL_MODE>;
-      gyro-range = <LSM6DSO_DT_FS_2000DPS>;
-      gyro-odr = <LSM6DSO_DT_ODR_6667Hz>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -229,3 +215,18 @@ properties:
       This register represents the time after the first detected tap in which
       there must not be any overthreshold event. Where 0 equals 2*1/ODR
       and 1LSB = 4*1/ODR.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dso.h>
+
+    lsm6dso: lsm6dso@0 {
+      /* ... */
+
+      accel-pm = <LSM6DSO_DT_XL_ULP_MODE>;
+      accel-range = <LSM6DSO_DT_FS_8G>;
+      accel-odr = <LSM6DSO_DT_ODR_1Hz6>;
+      gyro-pm = <LSM6DSO_DT_GY_NORMAL_MODE>;
+      gyro-range = <LSM6DSO_DT_FS_2000DPS>;
+      gyro-odr = <LSM6DSO_DT_ODR_6667Hz>;
+    };

--- a/dts/bindings/sensor/st,lsm6dso16is-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso16is-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include lsm6dso16is.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dso16is.h>
-
-    lsm6dso16is: lsm6dso16is@0 {
-      ...
-
-      accel-range = <LSM6DSO16IS_DT_FS_8G>;
-      accel-odr = <LSM6DSO16IS_DT_ODR_104Hz_LP>;
-      gyro-range = <LSM6DSO16IS_DT_FS_2000DPS>;
-      gyro-odr = <LSM6DSO16IS_DT_ODR_104Hz_LP>;
-    };
-
 include: sensor-device.yaml
 
 properties:
@@ -145,3 +133,16 @@ properties:
     description: |
       Selects the pulsed mode for data-ready interrupt when enabled,
       and the latched mode when disabled.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dso16is.h>
+
+    lsm6dso16is: lsm6dso16is@0 {
+      /* ... */
+
+      accel-range = <LSM6DSO16IS_DT_FS_8G>;
+      accel-odr = <LSM6DSO16IS_DT_ODR_104Hz_LP>;
+      gyro-range = <LSM6DSO16IS_DT_FS_2000DPS>;
+      gyro-odr = <LSM6DSO16IS_DT_ODR_104Hz_LP>;
+    };

--- a/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include lsm6dsv16x.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
-
-    lsm6dsv16x: lsm6dsv16x@0 {
-      ...
-
-      accel-range = <LSM6DSV16X_DT_FS_8G>;
-      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-      gyro-range = <LSM6DSV16X_DT_FS_4000DPS>;
-      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-    };
-
 include: st,lsm6dsvxxx-common.yaml
 
 properties:
@@ -48,3 +36,16 @@ properties:
       - 0xc # LSM6DSV16X_DT_FS_4000DPS (140 mdps/LSB)
 
     enum: [0x0, 0x1, 0x2, 0x3, 0x4, 0xc]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
+
+    lsm6dsv16x: lsm6dsv16x@0 {
+      /* ... */
+
+      accel-range = <LSM6DSV16X_DT_FS_8G>;
+      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+      gyro-range = <LSM6DSV16X_DT_FS_4000DPS>;
+      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+    };

--- a/dts/bindings/sensor/st,lsm6dsv320x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv320x-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include lsm6dsv320x.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dsv320x.h>
-
-    lsm6dsv320x: lsm6dsv320x@0 {
-      ...
-
-      accel-range = <LSM6DSV320X_DT_FS_8G>;
-      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-      gyro-range = <LSM6DSV320X_DT_FS_4000DPS>;
-      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-    };
-
 include: st,lsm6dsvxxx-common.yaml
 
 properties:
@@ -74,3 +62,16 @@ properties:
       - 0x5 # LSM6DSV320X_DT_FS_4000DPS (140 mdps/LSB)
 
     enum: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dsv320x.h>
+
+    lsm6dsv320x: lsm6dsv320x@0 {
+      /* ... */
+
+      accel-range = <LSM6DSV320X_DT_FS_8G>;
+      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+      gyro-range = <LSM6DSV320X_DT_FS_4000DPS>;
+      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+    };

--- a/dts/bindings/sensor/st,lsm6dsv32x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv32x-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include lsm6dsv32x.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dsv32x.h>
-
-    lsm6dsv32x: lsm6dsv32x@0 {
-      ...
-
-      accel-range = <LSM6DSV32X_DT_FS_8G>;
-      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-      gyro-range = <LSM6DSV32X_DT_FS_4000DPS>;
-      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-    };
-
 include: st,lsm6dsvxxx-common.yaml
 
 properties:
@@ -48,3 +36,16 @@ properties:
       - 0xc # LSM6DSV32X_DT_FS_4000DPS (140 mdps/LSB)
 
     enum: [0x0, 0x1, 0x2, 0x3, 0x4, 0xc]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dsv32x.h>
+
+    lsm6dsv32x: lsm6dsv32x@0 {
+      /* ... */
+
+      accel-range = <LSM6DSV32X_DT_FS_8G>;
+      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+      gyro-range = <LSM6DSV32X_DT_FS_4000DPS>;
+      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+    };

--- a/dts/bindings/sensor/st,lsm6dsv80x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv80x-common.yaml
@@ -6,18 +6,6 @@ description: |
     a .dts or .dtsi file you may include lsm6dsv80x.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm6dsv80x.h>
-
-    lsm6dsv80x: lsm6dsv80x@0 {
-      ...
-
-      accel-range = <LSM6DSV80X_DT_FS_8G>;
-      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-      gyro-range = <LSM6DSV80X_DT_FS_4000DPS>;
-      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
-    };
-
 include: st,lsm6dsvxxx-common.yaml
 
 properties:
@@ -72,3 +60,16 @@ properties:
       - 0x5 # LSM6DSV80X_DT_FS_4000DPS (140 mdps/LSB)
 
     enum: [0x0, 0x1, 0x2, 0x3, 0x4, 0x5]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm6dsv80x.h>
+
+    lsm6dsv80x: lsm6dsv80x@0 {
+      /* ... */
+
+      accel-range = <LSM6DSV80X_DT_FS_8G>;
+      accel-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+      gyro-range = <LSM6DSV80X_DT_FS_4000DPS>;
+      gyro-odr = <LSM6DSVXXX_DT_ODR_AT_60Hz>;
+    };

--- a/dts/bindings/sensor/st,lsm9ds1.yaml
+++ b/dts/bindings/sensor/st,lsm9ds1.yaml
@@ -11,17 +11,6 @@ description: |
     a .dts or .dtsi file you may include lsm9ds1.h and use the macros
     defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm9ds1.h>
-
-    lsm9ds1: lsm9ds1@0 {
-      ...
-
-      accel-range = <LSM9DS1_DT_FS_4G>;
-      imu-odr   =  <LSM9DS1_IMU_14Hz9>;
-      gyro-range = <LSM9DS1_DT_FS_2000DPS>;
-    };
-
 compatible: "st,lsm9ds1"
 
 include: [sensor-device.yaml, i2c-device.yaml]
@@ -88,3 +77,15 @@ properties:
 
     enum: [0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x11,
            0x22, 0x33, 0x44, 0x55, 0x66, 0x81, 0x82, 0x83, 0x91, 0xA2, 0xB3]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm9ds1.h>
+
+    lsm9ds1: lsm9ds1@0 {
+      /* ... */
+
+      accel-range = <LSM9DS1_DT_FS_4G>;
+      imu-odr   =  <LSM9DS1_IMU_14Hz9>;
+      gyro-range = <LSM9DS1_DT_FS_2000DPS>;
+    };

--- a/dts/bindings/sensor/st,lsm9ds1_mag.yaml
+++ b/dts/bindings/sensor/st,lsm9ds1_mag.yaml
@@ -9,17 +9,7 @@ description: |
 
     When setting the mag-range and mag-odr properties in
     a .dts or .dtsi file you may include lsm9ds1.h and use the macros
-    defined here.
-
-    Example:
-    #include <zephyr/dt-bindings/sensor/lsm9ds1.h>
-
-    lsm9ds1_mag: lsm9ds1_mag@0 {
-      ...
-
-      mag-range = <LSM9DS1_DT_FS_4Ga>;
-      mag-odr = <LSM9DS1_MAG_MP_40Hz>;
-    };
+    defined there.
 
 compatible: "st,lsm9ds1_mag"
 
@@ -87,3 +77,14 @@ properties:
     enum: [0xC0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x10, 0x11, 0x12, 0x13,
            0x14, 0x15, 0x16, 0x17, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x30, 0x31,
            0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x28, 0x18, 0x08, 0x70]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/lsm9ds1.h>
+
+    lsm9ds1_mag: lsm9ds1_mag@0 {
+      /* ... */
+
+      mag-range = <LSM9DS1_DT_FS_4Ga>;
+      mag-odr = <LSM9DS1_MAG_MP_40Hz>;
+    };

--- a/dts/bindings/sensor/st,stts22h-i2c.yaml
+++ b/dts/bindings/sensor/st,stts22h-i2c.yaml
@@ -6,15 +6,6 @@ description: |
     When setting the sampling-rate property in a .dts or .dtsi file you
     may include stts22h.h and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/stts22h.h>
-
-    stts22h: stts22h@0 {
-      ...
-
-      sampling-rate = <STTS22H_100Hz>;
-    };
-
 compatible: "st,stts22h"
 
 include: [sensor-device.yaml, i2c-device.yaml]
@@ -66,3 +57,13 @@ properties:
       - 0x32 # STTS22H_200Hz
 
     enum: [0x00, 0x01, 0x02, 0x04, 0x12, 0x22, 0x32]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/stts22h.h>
+
+    stts22h: stts22h@0 {
+      /* ... */
+
+      sampling-rate = <STTS22H_100Hz>;
+    };

--- a/dts/bindings/sensor/ti,tmag5273.yaml
+++ b/dts/bindings/sensor/ti,tmag5273.yaml
@@ -9,17 +9,8 @@ description: |
   The specification of the sensor can be found at:
     https://www.ti.com/lit/ds/symlink/tmag5273.pdf
 
-    When setting the enum properties in a .dts or .dtsi file you may
-    include tmag5273.h and use the macros defined there.
-
-    Example:
-    #include <zephyr/dt-bindings/sensor/tmag5273.h>
-
-    tmag5273: tmag5273@0 {
-      ...
-      axis = <TMAG5273_DT_AXIS_XYZ>;
-      range = <TMAG5273_DT_AXIS_RANGE_HIGH>;
-    };
+  When setting the enum properties in a .dts or .dtsi file you may
+  include tmag5273.h and use the macros defined there.
 
 compatible: "ti,tmag5273"
 
@@ -179,3 +170,13 @@ properties:
     description: |
       Ignore detected diagnostic fail.
       According to the manual, this should be done if VCC < 2.3V.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/tmag5273.h>
+
+    tmag5273: tmag5273@0 {
+      /* ... */
+      axis = <TMAG5273_DT_AXIS_XYZ>;
+      range = <TMAG5273_DT_AXIS_RANGE_HIGH>;
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.

<img width="972" height="825" alt="image" src="https://github.com/user-attachments/assets/41581336-6771-4fbe-ad60-4f19a21766a6" />

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
