### PR TITLE
dts: bindings: input: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/input/renesas,ra-ctsu-button.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-button.yaml
@@ -8,33 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      button1 {
-        compatible = "renesas,ra-ctsu-button";
-        elements = <0>;
-        threshold = <769>;
-        hysteresis = <38>;
-        event-code = <INPUT_KEY_0>;
-      };
-
-      button2 {
-        compatible = "renesas,ra-ctsu-button";
-        elements = <1>;
-        threshold = <769>;
-        hysteresis = <38>;
-        event-code = <INPUT_KEY_1>;
-      };
-    };
-  };
-
   Notes: The order of the CTSU button nodes in the same group must follow these elements index.
 
 compatible: "renesas,ra-ctsu-button"
@@ -67,3 +40,30 @@ properties:
     default: 0
     description: |
       Threshold hysteresis for chattering prevention for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        button1 {
+          compatible = "renesas,ra-ctsu-button";
+          elements = <0>;
+          threshold = <769>;
+          hysteresis = <38>;
+          event-code = <INPUT_KEY_0>;
+        };
+
+        button2 {
+          compatible = "renesas,ra-ctsu-button";
+          elements = <1>;
+          threshold = <769>;
+          hysteresis = <38>;
+          event-code = <INPUT_KEY_1>;
+        };
+      };
+    };

--- a/dts/bindings/input/renesas,ra-ctsu-slider.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-slider.yaml
@@ -8,24 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      slider {
-        compatible = "renesas,ra-ctsu-slider";
-        elements = <1>, <0>, <2>, <4>, <3>;
-        threshold = <573>;
-        event-code = <INPUT_ABS_THROTTLE>;
-      };
-    };
-  };
-
 compatible: "renesas,ra-ctsu-slider"
 
 include: [base.yaml]
@@ -50,3 +32,21 @@ properties:
     default: 0
     description: |
       Touch/non-touch judgement threshold for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        slider {
+          compatible = "renesas,ra-ctsu-slider";
+          elements = <1>, <0>, <2>, <4>, <3>;
+          threshold = <573>;
+          event-code = <INPUT_ABS_THROTTLE>;
+        };
+      };
+    };

--- a/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
@@ -8,24 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      wheel {
-        compatible = "renesas,ra-ctsu-wheel";
-        elements = <0>, <3>, <2>, <1>;
-        threshold = <711>;
-        event-code = <INPUT_ABS_WHEEL>;
-      };
-    };
-  };
-
 compatible: "renesas,ra-ctsu-wheel"
 
 include: [base.yaml]
@@ -50,3 +32,21 @@ properties:
     default: 0
     description: |
       Touch/non-touch judgement threshold for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        wheel {
+          compatible = "renesas,ra-ctsu-wheel";
+          elements = <0>, <3>, <2>, <1>;
+          threshold = <711>;
+          event-code = <INPUT_ABS_WHEEL>;
+        };
+      };
+    };

--- a/dts/bindings/input/tsc-keys.yaml
+++ b/dts/bindings/input/tsc-keys.yaml
@@ -8,25 +8,6 @@ description: |
   calculations to detect an input event on a group which is the child of
   st,stm32-tsc. For more information see drivers/misc/st,stm32-tsc.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &tsc {
-    compatible = "st,stm32-tsc";
-
-    tsc_group6: g6 {
-      ...
-      ts1 {
-        compatible = "tsc-keys";
-        sampling-interval-ms = <10>;
-        oversampling = <10>;
-        noise-threshold = <50>;
-        zephyr,code = <INPUT_KEY_0>;
-      };
-    };
-  };
-
 compatible: "tsc-keys"
 
 include:
@@ -69,3 +50,22 @@ properties:
     type: int
     required: true
     description: Key code to emit.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &tsc {
+      compatible = "st,stm32-tsc";
+
+      tsc_group6: g6 {
+        /* ... */
+        ts1 {
+          compatible = "tsc-keys";
+          sampling-interval-ms = <10>;
+          oversampling = <10>;
+          noise-threshold = <50>;
+          zephyr,code = <INPUT_KEY_0>;
+        };
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="1441" height="736" alt="image" src="https://github.com/user-attachments/assets/2687fdb3-986a-4767-b125-6b141da91e0e" />


Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
