### PR TITLE
dts: bindings: stepper: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -4,14 +4,6 @@
 description: |
   Analog Devices TMC2209 stepper motor driver.
 
-  Example:
-  tmc2209: tmc2209 {
-      compatible = "adi,tmc2209";
-      enable-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-      m0-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-      m1-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-  }
-
 compatible: "adi,tmc2209"
 
 include:
@@ -35,3 +27,12 @@ properties:
     description: |
       If present, the stepper motor controller supports dual edge step signals.
       This means that the step signal can be toggled on both the rising and falling edge.
+
+examples:
+  - |
+    tmc2209: tmc2209 {
+        compatible = "adi,tmc2209";
+        enable-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+        m0-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+        m1-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+    }

--- a/dts/bindings/stepper/adi/adi,tmc50xx.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc50xx.yaml
@@ -4,8 +4,45 @@
 description: |
   Analog Devices TMC50XX Stepper Motor Controller
 
-  Example:
+compatible: "adi,tmc50xx"
 
+include:
+  - name: spi-device.yaml
+  - name: adi,trinamic-gconf.yaml
+    property-allowlist:
+      - poscmp-enable
+      - test-mode
+      - lock-gconf
+
+properties:
+  clock-frequency:
+    type: int
+    required: true
+    description: |
+      The frequency of the clock signal provided to the TMC50XX.
+      This is used for real world conversion.
+
+      Hint: µstep velocity v[Hz] µsteps / s v[Hz] = v[50xx] * ( fCLK[Hz]/2 / 2^23 )
+            where v[50xx] is the value written to the TMC50XX.
+
+  shaft1:
+    type: boolean
+    description: |
+      Inverse motor 1 direction
+
+  shaft2:
+    type: boolean
+    description: |
+      Inverse motor 2 direction
+
+child-binding:
+  include:
+    - name: base.yaml
+      property-allowlist:
+        - reg
+
+examples:
+  - |
     &spi0 {
         /* SPI bus options here, not shown */
 
@@ -49,41 +86,3 @@ description: |
             };
         };
     };
-
-
-compatible: "adi,tmc50xx"
-
-include:
-  - name: spi-device.yaml
-  - name: adi,trinamic-gconf.yaml
-    property-allowlist:
-      - poscmp-enable
-      - test-mode
-      - lock-gconf
-
-properties:
-  clock-frequency:
-    type: int
-    required: true
-    description: |
-      The frequency of the clock signal provided to the TMC50XX.
-      This is used for real world conversion.
-
-      Hint: µstep velocity v[Hz] µsteps / s v[Hz] = v[50xx] * ( fCLK[Hz]/2 / 2^23 )
-            where v[50xx] is the value written to the TMC50XX.
-
-  shaft1:
-    type: boolean
-    description: |
-      Inverse motor 1 direction
-
-  shaft2:
-    type: boolean
-    description: |
-      Inverse motor 2 direction
-
-child-binding:
-  include:
-    - name: base.yaml
-      property-allowlist:
-        - reg

--- a/dts/bindings/stepper/adi/adi,tmc51xx-spi.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc51xx-spi.yaml
@@ -4,8 +4,24 @@
 description: |
   Analog Devices TMC51XX Stepper Motor Controller (SPI mode)
 
-  Example:
+compatible: "adi,tmc51xx"
 
+include: [spi-device.yaml, "adi,tmc51xx-base.yaml"]
+
+properties:
+  reg:
+    required: true
+
+  diag0-gpios:
+    type: phandle-array
+    description: |
+      Diagnostics output DIAG0 pin. This pin enables interrupt-based
+      rampstat handling, allowing the driver to respond to motor events
+      like position reached or stall detection without polling.
+      Should be configured as push-pull output (active high).
+
+examples:
+  - |
     &spi0 {
         tmc51xx: tmc51xx@0 {
             compatible = "adi,tmc51xx";
@@ -51,19 +67,3 @@ description: |
             };
         };
     };
-
-compatible: "adi,tmc51xx"
-
-include: [spi-device.yaml, "adi,tmc51xx-base.yaml"]
-
-properties:
-  reg:
-    required: true
-
-  diag0-gpios:
-    type: phandle-array
-    description: |
-      Diagnostics output DIAG0 pin. This pin enables interrupt-based
-      rampstat handling, allowing the driver to respond to motor events
-      like position reached or stall detection without polling.
-      Should be configured as push-pull output (active high).

--- a/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc51xx-uart.yaml
@@ -9,8 +9,26 @@ description: |
   - SWION should be connected to half the IO level voltage (1.65V for 3.3V systems)
   - SW_SEL must be HIGH (either via GPIO control or hardwired)
 
-  Example:
+compatible: "adi,tmc51xx"
 
+include: [uart-device.yaml, "adi,tmc51xx-base.yaml"]
+
+properties:
+  sw-sel-gpios:
+    type: phandle-array
+    description: |
+      GPIO connected to the SW_SEL pin of TMC51XX.
+      Must be set HIGH for UART mode operation.
+      If not provided, it's assumed SW_SEL is hardwired to VCC/HIGH.
+
+  uart-device-addr:
+    type: int
+    description: |
+        UART device address for TMC51XX in UART mode.
+        Valid range: 0 - 253
+
+examples:
+  - |
     &uart2 {
         current-speed = <115200>;
         status = "okay";
@@ -60,21 +78,3 @@ description: |
             };
         };
     };
-
-compatible: "adi,tmc51xx"
-
-include: [uart-device.yaml, "adi,tmc51xx-base.yaml"]
-
-properties:
-  sw-sel-gpios:
-    type: phandle-array
-    description: |
-      GPIO connected to the SW_SEL pin of TMC51XX.
-      Must be set HIGH for UART mode operation.
-      If not provided, it's assumed SW_SEL is hardwired to VCC/HIGH.
-
-  uart-device-addr:
-    type: int
-    description: |
-        UART device address for TMC51XX in UART mode.
-        Valid range: 0 - 253

--- a/dts/bindings/stepper/allegro/allegro,a4979.yaml
+++ b/dts/bindings/stepper/allegro/allegro,a4979.yaml
@@ -7,17 +7,6 @@ description: |
   It is designed to operate bipolar stepper motors in full-, half-, quarter-, and sixteenth-step
   modes.
 
-  Example:
-  a4979: a4979 {
-      status = "okay";
-      compatible = "allegro,a4979";
-      micro-step-res = <2>;
-      reset-gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
-      en-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
-      m0-gpios = <&gpiod 13 0>;
-      m1-gpios = <&gpiod 12 0>;
-  };
-
 compatible: "allegro,a4979"
 
 include:
@@ -42,3 +31,15 @@ properties:
     type: phandle-array
     required: true
     description: Reset pin
+
+examples:
+  - |
+    a4979: a4979 {
+        status = "okay";
+        compatible = "allegro,a4979";
+        micro-step-res = <2>;
+        reset-gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
+        en-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+        m0-gpios = <&gpiod 13 0>;
+        m1-gpios = <&gpiod 12 0>;
+    };

--- a/dts/bindings/stepper/ti/ti,drv84xx.yaml
+++ b/dts/bindings/stepper/ti/ti,drv84xx.yaml
@@ -5,19 +5,6 @@ description: |
   TI DRV84XX stepper motor driver.
   Compatible with drv8424, drv8425, drv8426, drv8434 and drv8436.
 
-  Example:
-  drv8424: drv8424 {
-    status = "okay";
-    compatible = "ti,drv84xx";
-
-    fault-gpios = <&arduino_header 16 0>;
-    sleep-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;
-    en-gpios  = <&arduino_header 14 0>;
-    m0-gpios = <&mikroe_stepper_gpios 0 0>;
-    m1-gpios = <&mikroe_stepper_gpios 1 0>;
-  };
-
-
 compatible: "ti,drv84xx"
 
 include:
@@ -43,3 +30,16 @@ properties:
   m1-gpios:
     type: phandle-array
     description: Microstep configuration pin 1.
+
+examples:
+  - |
+    drv8424: drv8424 {
+      status = "okay";
+      compatible = "ti,drv84xx";
+
+      fault-gpios = <&arduino_header 16 0>;
+      sleep-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;
+      en-gpios  = <&arduino_header 14 0>;
+      m0-gpios = <&mikroe_stepper_gpios 0 0>;
+      m1-gpios = <&mikroe_stepper_gpios 1 0>;
+    };

--- a/dts/bindings/stepper/zephyr,gpio-step-dir-stepper.yaml
+++ b/dts/bindings/stepper/zephyr,gpio-step-dir-stepper.yaml
@@ -4,16 +4,6 @@
 description: |
   CPU based Stepper Motion Controller for controlling stepper motors using GPIO pins.
   It is used to generate step and direction signals for a stepper motor driver.
-  Example:
-  step_dir_motion_control: step_dir_motion_control {
-      compatible = "zephyr,gpio-step-dir-stepper";
-      step-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
-      dir-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-      invert-direction;
-      counter = <&counter1>;
-      stepper-drv = <&tmc2209>; /* Optional stepper-drv driver reference */
-  };
-
 
 compatible: "zephyr,gpio-step-dir-stepper"
 
@@ -53,3 +43,14 @@ properties:
       Reference to the stepper driver device.
       This property, if provided, will result in configuring the driver with the
       step-width-ns and dual-edge-step properties from the stepper driver node.
+
+examples:
+  - |
+    step_dir_motion_control: step_dir_motion_control {
+        compatible = "zephyr,gpio-step-dir-stepper";
+        step-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+        dir-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+        invert-direction;
+        counter = <&counter1>;
+        stepper-drv = <&tmc2209>; /* Optional stepper-drv driver reference */
+    };

--- a/dts/bindings/stepper/zephyr,h-bridge-stepper.yaml
+++ b/dts/bindings/stepper/zephyr,h-bridge-stepper.yaml
@@ -5,16 +5,6 @@
 description: |
   GPIO Stepper Controller for darlington transistor arrays or dual H-bridge
 
-  Example:
-    /* Lead A is connected Lead C and Lead B is connected to Lead D*/
-    h_bridge_stepper: h_bridge_stepper {
-        compatible = "zephyr,h-bridge-stepper";
-        gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>,  /* Lead A1/A */
-                <&gpioc 7 GPIO_ACTIVE_HIGH>,  /* Lead B1/B */
-                <&gpiob 0 GPIO_ACTIVE_HIGH>,  /* Lead A2/C */
-                <&gpioa 7 GPIO_ACTIVE_HIGH>;  /* Lead B2/D */
-    };
-
 compatible: "zephyr,h-bridge-stepper"
 
 properties:
@@ -52,3 +42,14 @@ properties:
       Note: The counter needs to support both set_top_value functionalities:
             - Setting a new top value
             - Attaching an ISR to the turnaround
+
+examples:
+  - |
+    /* Lead A is connected Lead C and Lead B is connected to Lead D*/
+    h_bridge_stepper: h_bridge_stepper {
+        compatible = "zephyr,h-bridge-stepper";
+        gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>,  /* Lead A1/A */
+                <&gpioc 7 GPIO_ACTIVE_HIGH>,  /* Lead B1/B */
+                <&gpiob 0 GPIO_ACTIVE_HIGH>,  /* Lead A2/C */
+                <&gpioa 7 GPIO_ACTIVE_HIGH>;  /* Lead B2/D */
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="1431" height="448" alt="image" src="https://github.com/user-attachments/assets/dad206b3-0018-490a-a4e9-43f11ce5832d" />

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
