### PR TITLE
Bluetooth: BAP: SD: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -35,7 +35,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -1530,12 +1529,12 @@ static bool valid_bt_bap_scan_delegator_add_src_param(
 		return false;
 	}
 
-	CHECKIF(param->addr.type > BT_ADDR_LE_RANDOM) {
+	if (param->addr.type > BT_ADDR_LE_RANDOM) {
 		LOG_DBG("param->addr.type %u is invalid", param->addr.type);
 		return false;
 	}
 
-	CHECKIF(param->sid > BT_GAP_SID_MAX) {
+	if (param->sid > BT_GAP_SID_MAX) {
 		LOG_DBG("param->sid %d is invalid", param->sid);
 		return false;
 	}
@@ -1583,7 +1582,7 @@ int bt_bap_scan_delegator_add_src(const struct bt_bap_scan_delegator_add_src_par
 	struct bt_bap_scan_delegator_recv_state *state;
 	int err;
 
-	CHECKIF(!valid_bt_bap_scan_delegator_add_src_param(param)) {
+	if (!valid_bt_bap_scan_delegator_add_src_param(param)) {
 		return -EINVAL;
 	}
 
@@ -1700,7 +1699,7 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
 	int ret = 0;
 	int err;
 
-	CHECKIF(!valid_bt_bap_scan_delegator_mod_src_param(param)) {
+	if (!valid_bt_bap_scan_delegator_mod_src_param(param)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.