### PR TITLE
dts: bindings: gpio: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/gpio/adi,max14915-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14915-gpio.yaml
@@ -7,41 +7,6 @@ description: |
 
   https://www.analog.com/media/en/technical-documentation/data-sheets/MAX14915.pdf
 
-  Example:
-
-  max14915: max14915@0 {
-      compatible = "adi,max14915-gpio";
-      status = "okay";
-      reg = <0x00>;
-      fault-gpios = <&gpiof 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-      sync-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
-      en-gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
-      drdy-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
-      spi-max-frequency = <10000000>;
-      gpio-controller;
-      #gpio-cells = <2>;
-      ngpios = <8>;
-      crc-en;
-      spi-addr = <0>;
-      ow-on-en = <0 0 0 0 0 0 0 0>;
-      ow-off-en = <0 0 0 0 0 0 0 0>;
-      sh-vdd-en = <0 0 0 0 0 0 0 0>;
-      /* Config Reg 1 */
-      fled-set;
-      sled-set;
-      fled-stretch = <3>;
-      ffilter-en;
-      filter-long;
-      flatch-en;
-      led-cur-lim;
-      /* Config Reg 2 */
-      vdd-on-thr;
-      synch-wd-en;
-      sht-vdd-thr = <3>;
-      ow-off-cs = <3>;
-      wd-to = <0>;
-    };
-
 compatible: "adi,max14915-gpio"
 
 properties:
@@ -62,3 +27,38 @@ properties:
       3: Set SPI and SYNCH Watchdog Timeout to 1.2s (typ)
 
 include: adi,max14916-gpio.yaml
+
+examples:
+  - |
+    max14915: max14915@0 {
+        compatible = "adi,max14915-gpio";
+        status = "okay";
+        reg = <0x00>;
+        fault-gpios = <&gpiof 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        sync-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
+        en-gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
+        drdy-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
+        spi-max-frequency = <10000000>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        ngpios = <8>;
+        crc-en;
+        spi-addr = <0>;
+        ow-on-en = <0 0 0 0 0 0 0 0>;
+        ow-off-en = <0 0 0 0 0 0 0 0>;
+        sh-vdd-en = <0 0 0 0 0 0 0 0>;
+        /* Config Reg 1 */
+        fled-set;
+        sled-set;
+        fled-stretch = <3>;
+        ffilter-en;
+        filter-long;
+        flatch-en;
+        led-cur-lim;
+        /* Config Reg 2 */
+        vdd-on-thr;
+        synch-wd-en;
+        sht-vdd-thr = <3>;
+        ow-off-cs = <3>;
+        wd-to = <0>;
+      };

--- a/dts/bindings/gpio/adi,max22190-gpio.yaml
+++ b/dts/bindings/gpio/adi,max22190-gpio.yaml
@@ -10,33 +10,6 @@ description: |
   filter-wbes = <CH0 CH1 CH2 ... CH7 >  for wire break
   To enable wire break set 1 else 0. Same principle is followed for:
   filter-fbps and filter-delays.
-  Sample binding
-  &sdp_spi {
-    status = "okay";
-    pinctrl-names = "default";
-    max22190_gpio0: max22190_gpio@0 {
-      compatible = "adi,max22190-gpio";
-      reg = <0>;
-
-      spi-max-frequency = <1000000>;
-      status = "okay";
-
-      gpio-controller;
-      #gpio-cells = <2>;
-      ngpios = <8>;
-      status = "okay";
-
-      max22190-mode = <1>; // modes range from 0-4
-
-      drdy-gpios = <&gpioj 12 GPIO_ACTIVE_LOW>; /* SDP-GPIO5 - PMOD-PIN8 */
-      fault-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>; /* SDP-SERIAL_INT - PMOD-PIN7 */
-      latch-gpios = <&gpioj 13 GPIO_ACTIVE_LOW>; /* SDP-GPIO6 - PMOD-PIN9 */
-
-      filter-wbes = <1 0 0 0  0 0 0 0>; // wirebreak WBEx
-      filter-fbps = <0 0 0 0  0 0 0 0>; // programmable filter INx
-      filter-delays = <50 100 400 800 1600 3200 12800 20000>; // 1000 us == 1ms
-    };
-  };
 
 compatible: "adi,max22190-gpio"
 
@@ -60,3 +33,32 @@ gpio-cells:
   - flags
 
 include: adi,max2219x-base-gpio.yaml
+
+examples:
+  - |
+    &sdp_spi {
+      status = "okay";
+      pinctrl-names = "default";
+      max22190_gpio0: max22190_gpio@0 {
+        compatible = "adi,max22190-gpio";
+        reg = <0>;
+
+        spi-max-frequency = <1000000>;
+        status = "okay";
+
+        gpio-controller;
+        #gpio-cells = <2>;
+        ngpios = <8>;
+        status = "okay";
+
+        max22190-mode = <1>; // modes range from 0-4
+
+        drdy-gpios = <&gpioj 12 GPIO_ACTIVE_LOW>; /* SDP-GPIO5 - PMOD-PIN8 */
+        fault-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>; /* SDP-SERIAL_INT - PMOD-PIN7 */
+        latch-gpios = <&gpioj 13 GPIO_ACTIVE_LOW>; /* SDP-GPIO6 - PMOD-PIN9 */
+
+        filter-wbes = <1 0 0 0  0 0 0 0>; // wirebreak WBEx
+        filter-fbps = <0 0 0 0  0 0 0 0>; // programmable filter INx
+        filter-delays = <50 100 400 800 1600 3200 12800 20000>; // 1000 us == 1ms
+      };
+    };

--- a/dts/bindings/gpio/adi,max22199-gpio.yaml
+++ b/dts/bindings/gpio/adi,max22199-gpio.yaml
@@ -11,33 +11,6 @@ description: |
   24V under voltage alarm, 24V missing voltage alarm, and SPI and CRC
   communication error detection.
 
-  Sample binding
-  &sdp_spi {
-    status = "okay";
-    pinctrl-names = "default";
-    max22199_gpio0: max22199_gpio@0 {
-      compatible = "adi,max22199-gpio";
-      reg = <0>;
-
-      spi-max-frequency = <1000000>;
-      status = "okay";
-
-      gpio-controller;
-      #gpio-cells = <2>;
-      ngpios = <8>;
-      status = "okay";
-
-      max22199-mode = <1>; // modes range from 0-4
-
-      drdy-gpios = <&gpioj 12 GPIO_ACTIVE_LOW>; /* SDP-GPIO5 - PMOD-PIN8 */
-      fault-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>; /* SDP-SERIAL_INT - PMOD-PIN7 */
-      latch-gpios = <&gpioj 13 GPIO_ACTIVE_LOW>; /* SDP-GPIO6 - PMOD-PIN9 */
-
-      filter-fbps = <0 0 0 0  0 0 0 0>; // programmable filter INx
-      filter-delays = <50 100 400 800 1600 3200 12800 20000>; // 1000 us == 1ms
-    };
-  };
-
 compatible: "adi,max22199-gpio"
 
 gpio-cells:
@@ -45,3 +18,31 @@ gpio-cells:
   - flags
 
 include: adi,max2219x-base-gpio.yaml
+
+examples:
+  - |
+    &sdp_spi {
+      status = "okay";
+      pinctrl-names = "default";
+      max22199_gpio0: max22199_gpio@0 {
+        compatible = "adi,max22199-gpio";
+        reg = <0>;
+
+        spi-max-frequency = <1000000>;
+        status = "okay";
+
+        gpio-controller;
+        #gpio-cells = <2>;
+        ngpios = <8>;
+        status = "okay";
+
+        max22199-mode = <1>; // modes range from 0-4
+
+        drdy-gpios = <&gpioj 12 GPIO_ACTIVE_LOW>; /* SDP-GPIO5 - PMOD-PIN8 */
+        fault-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>; /* SDP-SERIAL_INT - PMOD-PIN7 */
+        latch-gpios = <&gpioj 13 GPIO_ACTIVE_LOW>; /* SDP-GPIO6 - PMOD-PIN9 */
+
+        filter-fbps = <0 0 0 0  0 0 0 0>; // programmable filter INx
+        filter-delays = <50 100 400 800 1600 3200 12800 20000>; // 1000 us == 1ms
+      };
+    };

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-alert.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-alert.yaml
@@ -4,13 +4,6 @@
 description: |
     Nuvoton NCT38XX series I2C-based GPIO expander alert handler.
 
-    Example:
-      nct3807_alert_1 {
-        compatible = "nuvoton,nct38xx-gpio-alert";
-        irq-gpios = <&gpiod 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-        nct38xx-dev = <&nct3808_0_P1 &nct3808_0_P2>;
-      };
-
 compatible: "nuvoton,nct38xx-gpio-alert"
 
 include: [base.yaml]
@@ -26,3 +19,11 @@ properties:
     required: true
     description: |
       List of NCT38XX multi-function devices managed by this alert handler.
+
+examples:
+  - |
+    nct3807_alert_1 {
+      compatible = "nuvoton,nct38xx-gpio-alert";
+      irq-gpios = <&gpiod 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+      nct38xx-dev = <&nct3808_0_P1 &nct3808_0_P2>;
+    };

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
@@ -6,81 +6,82 @@ description: |
 
     This must be a child of the NCT38xx multi-function device.
 
-    Example:
-      &i2c0_0 {
-        nct3807@70 {
-          compatible = "nuvoton,nct38xx";
-          reg = <0x70>;
+compatible: "nuvoton,nct38xx-gpio"
 
-          nct3807-gpio {
-            #address-cells = <1>;
-            #size-cells = <0>;
-            compatible = "nuvoton,nct38xx-gpio";
+include: [base.yaml]
 
-            gpio@0 {
-              compatible = "nuvoton,nct38xx-gpio-port";
-              reg = <0x0>;
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0xff>;
-              pinmux-mask = <0xf7>;
-            };
+examples:
+  - |
+    &i2c0_0 {
+      nct3807@70 {
+        compatible = "nuvoton,nct38xx";
+        reg = <0x70>;
 
-            gpio@1 {
-              compatible = "nuvoton,nct38xx-gpio-port";
-              reg = <0x1>;
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0xff>;
-            };
+        nct3807-gpio {
+          #address-cells = <1>;
+          #size-cells = <0>;
+          compatible = "nuvoton,nct38xx-gpio";
+
+          gpio@0 {
+            compatible = "nuvoton,nct38xx-gpio-port";
+            reg = <0x0>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            ngpios = <8>;
+            pin-mask = <0xff>;
+            pinmux-mask = <0xf7>;
           };
-        };
 
-        nct3808_0_P1@71 {
-          compatible = "nuvoton,nct38xx";
-          reg = <0x71>;
-
-          nct3808-0-p1-gpio {
-            #address-cells = <1>;
-            #size-cells = <0>;
-            compatible = "nuvoton,nct38xx-gpio";
-
-            gpio@0 {
-              compatible = "nuvoton,nct38xx-gpio-port";
-              reg = <0x0>;
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0xdc>;
-              pinmux-mask = <0xff>;
-            };
-          };
-        };
-
-        nct3808_0_P2@75 {
-          compatible = "nuvoton,nct38xx";
-          reg = <0x75>;
-
-          nct3808-0-P2-gpio {
-            #address-cells = <1>;
-            #size-cells = <0>;
-            compatible = "nuvoton,nct38xx-gpio";
-
-            gpio@0 {
-              compatible = "nuvoton,nct38xx-gpio-port";
-              reg = <0x0>;
-              gpio-controller;
-              #gpio-cells = <2>;
-              ngpios = <8>;
-              pin-mask = <0xdc>;
-              pinmux-mask = <0xff>;
-            };
+          gpio@1 {
+            compatible = "nuvoton,nct38xx-gpio-port";
+            reg = <0x1>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            ngpios = <8>;
+            pin-mask = <0xff>;
           };
         };
       };
 
-compatible: "nuvoton,nct38xx-gpio"
+      nct3808_0_P1@71 {
+        compatible = "nuvoton,nct38xx";
+        reg = <0x71>;
 
-include: [base.yaml]
+        nct3808-0-p1-gpio {
+          #address-cells = <1>;
+          #size-cells = <0>;
+          compatible = "nuvoton,nct38xx-gpio";
+
+          gpio@0 {
+            compatible = "nuvoton,nct38xx-gpio-port";
+            reg = <0x0>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            ngpios = <8>;
+            pin-mask = <0xdc>;
+            pinmux-mask = <0xff>;
+          };
+        };
+      };
+
+      nct3808_0_P2@75 {
+        compatible = "nuvoton,nct38xx";
+        reg = <0x75>;
+
+        nct3808-0-P2-gpio {
+          #address-cells = <1>;
+          #size-cells = <0>;
+          compatible = "nuvoton,nct38xx-gpio";
+
+          gpio@0 {
+            compatible = "nuvoton,nct38xx-gpio-port";
+            reg = <0x0>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            ngpios = <8>;
+            pin-mask = <0xdc>;
+            pinmux-mask = <0xff>;
+          };
+        };
+      };
+    };

--- a/dts/bindings/gpio/richtek,rt1718s-gpio-port.yaml
+++ b/dts/bindings/gpio/richtek,rt1718s-gpio-port.yaml
@@ -7,22 +7,23 @@ description: |
     "richtek,rt1718s-gpio-port" node handles GPIO feature of the RT1718S TCPC
     chip.
 
-    Example:
-      &i2c2_0 {
-          rt1718s_port0: rt1718s@40 {
-              compatible = "richtek,rt1718s";
-              reg = <0x40>;
-
-              rt1718s_gpio_port0: rt1718s_gpio {
-                  compatible = "richtek,rt1718s-gpio-port";
-
-                  gpio-controller;
-                  #gpio-cells = <2>;
-                  ngpios = <3>;
-              };
-          };
-      };
-
 include: [gpio-controller.yaml, base.yaml]
 
 compatible: "richtek,rt1718s-gpio-port"
+
+examples:
+  - |
+    &i2c2_0 {
+        rt1718s_port0: rt1718s@40 {
+            compatible = "richtek,rt1718s";
+            reg = <0x40>;
+
+            rt1718s_gpio_port0: rt1718s_gpio {
+                compatible = "richtek,rt1718s-gpio-port";
+
+                gpio-controller;
+                #gpio-cells = <2>;
+                ngpios = <3>;
+            };
+        };
+    };

--- a/dts/bindings/gpio/richtek,rt1718s.yaml
+++ b/dts/bindings/gpio/richtek,rt1718s.yaml
@@ -9,23 +9,6 @@ description: |
     address. Feature-specific(GPIO, TCPC) properties should be placed in a child
     node e.g. a number of GPIOs.
 
-    Example:
-      &i2c2_0 {
-          rt1718s_port0: rt1718s@40 {
-              compatible = "richtek,rt1718s";
-              reg = <0x40>;
-              irq-gpios = <&gpioe 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-
-              rt1718s_gpio_port0: rt1718s_gpio {
-                  compatible = "richtek,rt1718s-gpio-port";
-
-                  gpio-controller;
-                  #gpio-cells = <2>;
-                  ngpios = <3>;
-              };
-          };
-      };
-
 compatible: "richtek,rt1718s"
 
 include: [i2c-device.yaml]
@@ -34,3 +17,21 @@ properties:
   irq-gpios:
     type: phandle-array
     description: Interrupt GPIO pin connected from the chip(IRQB)
+
+examples:
+  - |
+    &i2c2_0 {
+        rt1718s_port0: rt1718s@40 {
+            compatible = "richtek,rt1718s";
+            reg = <0x40>;
+            irq-gpios = <&gpioe 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+
+            rt1718s_gpio_port0: rt1718s_gpio {
+                compatible = "richtek,rt1718s-gpio-port";
+
+                gpio-controller;
+                #gpio-cells = <2>;
+                ngpios = <3>;
+            };
+        };
+    };

--- a/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
@@ -22,29 +22,6 @@ description: |
   with standard keycode values 2, 3 and 4, corresponding to
   INPUT_KEY_1, INPUT_KEY_2 and INPUT_KEY_3 in input-event-codes.h.
 
-  /* gpio0 has to be a zephyr,gpio-emul device */
-  &gpio0 {
-    ngpios = <3>;
-
-    sdl_gpio {
-      compatible = "zephyr,gpio-emul-sdl";
-      scancodes = <30 31 32>;
-    };
-  };
-
-  keypad: keypad {
-    compatible = "gpio-keys";
-    key1: key1 {
-      gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-    };
-    key2: key2 {
-      gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-    };
-    key3: key3 {
-      gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-    };
-  };
-
   The limitations of usage are:
   - Only active high as we don't get events for keys that aren't pressed
   - Pressing multiple keys is best effort, state will be kept but no events
@@ -60,3 +37,28 @@ properties:
     required: true
     description: |
       An array of SDL scancodes mapped to its GPIO index
+
+examples:
+  - |
+    /* gpio0 has to be a zephyr,gpio-emul device */
+    &gpio0 {
+      ngpios = <3>;
+
+      sdl_gpio {
+        compatible = "zephyr,gpio-emul-sdl";
+        scancodes = <30 31 32>;
+      };
+    };
+
+    keypad: keypad {
+      compatible = "gpio-keys";
+      key1: key1 {
+        gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+      };
+      key2: key2 {
+        gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+      };
+      key3: key3 {
+        gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
