### PR TITLE
dts: bindings: ethernet: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/ethernet/adi,adin1110.yaml
+++ b/dts/bindings/ethernet/adi,adin1110.yaml
@@ -4,30 +4,33 @@
 description: |
   ADIN1110 standalone 10BASE-T1L Ethernet controller with SPI interface.
 
-  An example:
-
-  adin1110: adin1110@0 {
-          compatible = "adi,adin1110";
-          reg = <0x0>;
-          spi-max-frequency = <25000000>;
-          int-gpios   = <&gpioe 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-          reset-gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
-          port1 {
-              local-mac-address = [ CA 2F B7 10 23 63 ];
-          };
-          mdio: mdio {
-                  compatible = "adi,adin2111-mdio";
-                  status = "okay";
-                  #address-cells = <1>;
-                  #size-cells = <0>;
-                  ethernet-phy@1 {
-                    reg = <0x1>;
-                    compatible = "adi,adin2111-phy";
-                    status = "okay";
-                  };
-          };
-  };
-
 compatible: "adi,adin1110"
 
 include: adi,adin2111.yaml
+
+examples:
+  - |
+    adin1110: adin1110@0 {
+            compatible = "adi,adin1110";
+            reg = <0x0>;
+            spi-max-frequency = <25000000>;
+            int-gpios = <&gpioe 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+            reset-gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
+
+            port1 {
+                    local-mac-address = [CA 2F B7 10 23 63];
+            };
+
+            mdio: mdio {
+                    compatible = "adi,adin2111-mdio";
+                    status = "okay";
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+
+                    ethernet-phy@1 {
+                            reg = <0x1>;
+                            compatible = "adi,adin2111-phy";
+                            status = "okay";
+                    };
+            };
+    };

--- a/dts/bindings/ethernet/adi,adin2111.yaml
+++ b/dts/bindings/ethernet/adi,adin2111.yaml
@@ -3,39 +3,6 @@
 
 description: |
   ADIN2111 standalone 10BASE-T1L Ethernet controller with SPI interface.
-
-  An example:
-
-  adin2111: adin2111@0 {
-          compatible = "adi,adin2111";
-          reg = <0x0>;
-          spi-max-frequency = <25000000>;
-          int-gpios   = <&gpioe 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-          reset-gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
-          port1 {
-              local-mac-address = [ CA 2F B7 10 23 63 ];
-          };
-          port2 {
-              local-mac-address = [ 3C 82 D4 A2 29 8E ];
-          };
-          mdio: mdio {
-                  compatible = "adi,adin2111-mdio";
-                  status = "okay";
-                  #address-cells = <1>;
-                  #size-cells = <0>;
-                  ethernet-phy@1 {
-                    reg = <0x1>;
-                    compatible = "adi,adin2111-phy";
-                    status = "okay";
-                  };
-                  ethernet-phy@2 {
-                    reg = <0x2>;
-                    compatible = "adi,adin2111-phy";
-                    status = "okay";
-                  };
-          };
-  };
-
 compatible: "adi,adin2111"
 
 include: [spi-device.yaml]
@@ -67,3 +34,40 @@ child-binding:
       type: uint8-array
       description: |
         Specifies the MAC address that was assigned to the network device.
+
+examples:
+  - |
+    adin2111: adin2111@0 {
+            compatible = "adi,adin2111";
+            reg = <0x0>;
+            spi-max-frequency = <25000000>;
+            int-gpios = <&gpioe 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+            reset-gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
+
+            port1 {
+                    local-mac-address = [CA 2F B7 10 23 63];
+            };
+
+            port2 {
+                    local-mac-address = [3C 82 D4 A2 29 8E];
+            };
+
+            mdio: mdio {
+                    compatible = "adi,adin2111-mdio";
+                    status = "okay";
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+
+                    ethernet-phy@1 {
+                            reg = <0x1>;
+                            compatible = "adi,adin2111-phy";
+                            status = "okay";
+                    };
+
+                    ethernet-phy@2 {
+                            reg = <0x2>;
+                            compatible = "adi,adin2111-phy";
+                            status = "okay";
+                    };
+            };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="931" height="838" alt="image" src="https://github.com/user-attachments/assets/2ca241bb-a1f5-4bf2-a992-f54b9f5100c4" />

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
