### PR TITLE
dts: bindings: i2c: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/i2c/cdns,i2c.yaml
+++ b/dts/bindings/i2c/cdns,i2c.yaml
@@ -5,18 +5,6 @@
 description: |
   Cadence I2C controller.
 
-  Example I2C device tree node:
-    i2c@e0004000 {
-        compatible = "cdns,i2c";
-        clocks = <&clkc 38>;
-        interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
-        reg = <0xe0004000 0x1000>;
-        clock-frequency = <400000>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-        fifo-depth = <8>;
-    };
-
 compatible: "cdns,i2c"
 
 include: [i2c-controller.yaml, reset-device.yaml]
@@ -40,3 +28,16 @@ properties:
     type: int
     required: true
     description: Size of the data FIFO in bytes.
+
+examples:
+  - |
+    i2c@e0004000 {
+        compatible = "cdns,i2c";
+        clocks = <&clkc 38>;
+        interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
+        reg = <0xe0004000 0x1000>;
+        clock-frequency = <400000>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+        fifo-depth = <8>;
+    };

--- a/dts/bindings/i2c/infineon,i2c.yaml
+++ b/dts/bindings/i2c/infineon,i2c.yaml
@@ -8,38 +8,6 @@ description: |
 
   This driver configures the SCB as an I2C device.
 
-  Example devicetree configuration with vl53l0x Time-of-Flight (ToF)
-  ranging sensor connected on the bus:
-
-  i2c3: &scb3 {
-      compatible = "infineon,i2c";
-      status = "okay";
-
-      #address-cells = <1>;
-      #size-cells = <0>;
-
-      pinctrl-0 = <&p6_0_scb3_i2c_scl &p6_1_scb3_i2c_sda>;
-      pinctrl-names = "default";
-
-      vl53l0x@29 {
-        compatible = "st,vl53l0x";
-        reg = <0x29>;
-      };
-  };
-
-  The pinctrl nodes need to be configured as open-drain and
-  input-enable:
-
-  &p6_0_scb3_i2c_scl {
-    drive-open-drain;
-    input-enable;
-  };
-
-  &p6_1_scb3_i2c_sda {
-    drive-open-drain;
-    input-enable;
-  };
-
 compatible: "infineon,i2c"
 
 include: [i2c-controller.yaml, pinctrl-device.yaml, "infineon,scb.yaml"]
@@ -72,3 +40,34 @@ properties:
     type: int
     description: |
       Frequency that the I2C bus runs
+
+examples:
+  - |
+    /* Example devicetree configuration with vl53l0x Time-of-Flight (ToF)
+       ranging sensor connected on the bus */
+    i2c3: &scb3 {
+        compatible = "infineon,i2c";
+        status = "okay";
+
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        pinctrl-0 = <&p6_0_scb3_i2c_scl &p6_1_scb3_i2c_sda>;
+        pinctrl-names = "default";
+
+        vl53l0x@29 {
+          compatible = "st,vl53l0x";
+          reg = <0x29>;
+        };
+    };
+
+    /* The associated pinctrl nodes need to be configured as open-drain and input-enable */
+    &p6_0_scb3_i2c_scl {
+      drive-open-drain;
+      input-enable;
+    };
+
+    &p6_1_scb3_i2c_sda {
+      drive-open-drain;
+      input-enable;
+    };

--- a/dts/bindings/i2c/infineon,xmc4xxx-i2c.yaml
+++ b/dts/bindings/i2c/infineon,xmc4xxx-i2c.yaml
@@ -9,44 +9,6 @@ description: |
 
   This driver configures the USIC as an I2C device.
 
-  Example devicetree configuration with an adt7420 temperature sensor
-  connected on the bus:
-
-  &usic1ch1 {
-      compatible = "infineon,xmc4xxx-i2c";
-      status = "okay";
-
-      pinctrl-0 = <&i2c_scl_p0_13_u1c1 &i2c_sda_p3_15_u1c1>;
-      pinctrl-names = "default";
-      scl-src = "DX1B";
-      sda-src = "DX0A";
-      interrupts = <94 1>;
-
-      #address-cells = <1>;
-      #size-cells = <0>;
-
-      clock-frequency = <I2C_BITRATE_STANDARD>;
-      adt7420@48 {
-          compatible = "adi,adt7420";
-          reg = <0x48>;
-      };
-  };
-
-  The pinctrl nodes need to be configured as open-drain and
-  hwctrl should be disabled:
-
-  &i2c_scl_p0_13_u1c1 {
-      drive-strength = "strong-sharp-edge";
-      drive-open-drain;
-      hwctrl = "disabled";
-  };
-
-  &i2c_sda_p3_15_u1c1 {
-      drive-strength = "strong-soft-edge";
-      drive-open-drain;
-      hwctrl = "disabled";
-  };
-
 compatible: "infineon,xmc4xxx-i2c"
 
 include: [i2c-controller.yaml, pinctrl-device.yaml]
@@ -168,3 +130,37 @@ properties:
 
   pinctrl-names:
     required: true
+
+examples:
+  - |
+    /* Example devicetree configuration with an adt7420 temperature sensor connected on the bus */
+    &usic1ch1 {
+        compatible = "infineon,xmc4xxx-i2c";
+        status = "okay";
+
+        pinctrl-0 = <&i2c_scl_p0_13_u1c1 &i2c_sda_p3_15_u1c1>;
+        pinctrl-names = "default";
+        scl-src = "DX1B";
+        sda-src = "DX0A";
+        interrupts = <94 1>;
+
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        clock-frequency = <I2C_BITRATE_STANDARD>;
+        adt7420@48 {
+            compatible = "adi,adt7420";
+            reg = <0x48>;
+
+      /* The associated pinctrl nodes need to be configured as open-drain and input-enable */
+      &i2c_scl_p0_13_u1c1 {
+        drive-strength = "strong-sharp-edge";
+        drive-open-drain;
+        hwctrl = "disabled";
+      };
+
+      &i2c_sda_p3_15_u1c1 {
+        drive-strength = "strong-soft-edge";
+        drive-open-drain;
+        hwctrl = "disabled";
+      };

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -11,8 +11,14 @@ description: |
   and TWIS, along with the pinctrl instances to select between TWIM/TWI
   and TWIS pin functions.
 
-  Example:
+compatible: "nordic,nrf-twis"
 
+include:
+  - "nordic,nrf-twi-common.yaml"
+  - "memory-region.yaml"
+
+examples:
+  - |
     &pinctrl {
             i2c2_default: i2c2_default {
                     group1 {
@@ -38,9 +44,3 @@ description: |
             pinctrl-names = "default", "sleep";
             status = "okay";
     };
-
-compatible: "nordic,nrf-twis"
-
-include:
-  - "nordic,nrf-twi-common.yaml"
-  - "memory-region.yaml"

--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -8,41 +8,7 @@ description: |
 
   Each channel is represented by a separate devicetree child node.
   The channel node can then be used as a standard i2c bus controller
-  like in the following simplified example:
-
-      /* The tca954x node must be a child of an i2c controller */
-      mux: tca9546a@77 {
-          compatible = "ti,tca9546a";
-          reg = <0x77>;
-          status = "okay";
-          #address-cells = <1>;
-          #size-cells = <0>;
-          reset-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;
-
-          mux_i2c@0 {
-              compatible = "ti,tca9546a-channel";
-              reg = <0>;
-              #address-cells = <1>;
-              #size-cells = <0>;
-
-              temp_sens_0: tmp11x@49 {
-                  compatible = "ti,tmp11x";
-                  reg = <0x49>;
-              };
-          };
-
-          mux_i2c@1 {
-              compatible = "ti,tca9546a-channel";
-              reg = <1>;
-              #address-cells = <1>;
-              #size-cells = <0>;
-
-              temp_sens_1: tmp11x@49 {
-                  compatible = "ti,tmp11x";
-                  reg = <0x49>;
-              };
-          };
-      };
+  like in the following simplified
 
 include: [i2c-device.yaml]
 
@@ -63,3 +29,39 @@ child-binding:
   description: TCA954x I2C switch channel node
   include: [i2c-controller.yaml]
   on-bus: i2c
+
+examples:
+  - |
+    /* The tca954x node must be a child of an i2c controller */
+    mux: tca9546a@77 {
+        compatible = "ti,tca9546a";
+        reg = <0x77>;
+        status = "okay";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reset-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;
+
+        mux_i2c@0 {
+            compatible = "ti,tca9546a-channel";
+            reg = <0>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            temp_sens_0: tmp11x@49 {
+                compatible = "ti,tmp11x";
+                reg = <0x49>;
+            };
+        };
+
+        mux_i2c@1 {
+            compatible = "ti,tca9546a-channel";
+            reg = <1>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            temp_sens_1: tmp11x@49 {
+                compatible = "ti,tmp11x";
+                reg = <0x49>;
+            };
+        };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="927" height="831" alt="image" src="https://github.com/user-attachments/assets/9b57cfe4-fd3d-4900-966e-0293c19a2a68" />

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
