### PR TITLE
dts: bindings: regulator: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/regulator/adi,adp5360-regulator.yaml
+++ b/dts/bindings/regulator/adi,adp5360-regulator.yaml
@@ -6,23 +6,7 @@ description: |
 
   The PMIC has one buck converter and one buck-boost converter. Both need to be
   defined as children nodes, strictly following the BUCK and BUCKBOOST node
-  names. For example:
-
-  pmic@46 {
-    compatible = "adi,adp5360";
-    reg = <0x46>;
-    ...
-    regulators {
-      compatible = "adi,adp5360-regulator";
-
-      BUCK {
-        /* all properties for BUCK */
-      };
-      BUCKBOOST {
-        /* all properties for BUCKBOOST */
-      };
-    };
-  };
+  names.
 
 compatible: "adi,adp5360-regulator"
 
@@ -84,3 +68,21 @@ child-binding:
     adi,enable-output-discharge:
       type: boolean
       description: Enable output discharge functionality
+
+examples:
+  - |
+    pmic@46 {
+      compatible = "adi,adp5360";
+      reg = <0x46>;
+      /* ... */
+      regulators {
+        compatible = "adi,adp5360-regulator";
+
+        BUCK {
+          /* all properties for BUCK */
+        };
+        BUCKBOOST {
+          /* all properties for BUCKBOOST */
+        };
+      };
+    };

--- a/dts/bindings/regulator/cirrus,cp9314.yaml
+++ b/dts/bindings/regulator/cirrus,cp9314.yaml
@@ -10,7 +10,6 @@ description: |
 
     cirrus,initial-switched-capacitor-mode = "2:1";
   };
-
 compatible: "cirrus,cp9314"
 
 include:

--- a/dts/bindings/regulator/maxim,max20335-regulator.yaml
+++ b/dts/bindings/regulator/maxim,max20335-regulator.yaml
@@ -5,32 +5,7 @@ description: |
   Maxim MAX20335 PMIC
 
   The PMIC has two buck converters and three LDOs. All need to be defined as
-  children nodes, strictly following the BUCK1..2, LDO1..3 node names. For
-  example:
-
-  pmic@28 {
-    reg = <0x28>;
-    ...
-    regulators {
-      compatible = maxim,max20335-regulator";
-
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-      LDO2 {
-        /* all properties for LDO2 */
-      };
-      LDO3 {
-        /* all properties for LDO3 */
-      };
-    };
-  };
+  children nodes, strictly following the BUCK1..2, LDO1..3 node names.
 
 compatible: "maxim,max20335-regulator"
 
@@ -49,3 +24,29 @@ child-binding:
         - regulator-boot-on
         - regulator-initial-mode
         - regulator-allowed-modes
+
+examples:
+  - |
+    pmic@28 {
+      reg = <0x28>;
+      /* ... */
+      regulators {
+        compatible = maxim,max20335-regulator";
+
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+        LDO2 {
+          /* all properties for LDO2 */
+        };
+        LDO3 {
+          /* all properties for LDO3 */
+        };
+      };
+    };

--- a/dts/bindings/regulator/mps,mpm54304.yaml
+++ b/dts/bindings/regulator/mps,mpm54304.yaml
@@ -7,27 +7,27 @@ description: |
   See https://www.monolithicpower.com/en/mpm54304.html.
 
   The MPM54304 has four buck regulators. All need to be defined as
-  children nodes, strictly following the BUCK1..4 node names. For
-  example:
-
-  mpm54304@68 {
-    reg = <0x68>;
-    ...
-
-    BUCK1 {
-      /* all properties for BUCK1 */
-    };
-    BUCK2 {
-      /* all properties for BUCK2 */
-    };
-    BUCK3 {
-      /* all properties for BUCK3 */
-    };
-    BUCK4 {
-      /* all properties for BUCK4 */
-    };
-  };
+  children nodes, strictly following the BUCK1..4 node names.
 
 compatible: "mps,mpm54304"
 
 include: i2c-device.yaml
+
+examples:
+  - |
+    mpm54304@68 {
+      reg = <0x68>;
+      /* ... */
+      BUCK1 {
+        /* all properties for BUCK1 */
+      };
+      BUCK2 {
+        /* all properties for BUCK2 */
+      };
+      BUCK3 {
+        /* all properties for BUCK3 */
+      };
+      BUCK4 {
+        /* all properties for BUCK4 */
+      };
+    };

--- a/dts/bindings/regulator/nordic,npm1100.yaml
+++ b/dts/bindings/regulator/nordic,npm1100.yaml
@@ -5,15 +5,7 @@ description: |
   Nordic nPM1100 PMIC
 
   The PMIC has one buck converter. It needs to be defined as a child node,
-  strictly following the BUCK node name. For example:
-
-  pmic {
-    compatible = "nordic,npm1100";
-
-    BUCK {
-      /* all properties for BUCK */
-    };
-  };
+  strictly following the BUCK node name.
 
   Note that only mode can be controlled (via GPIO pin MODE).
 
@@ -39,3 +31,13 @@ child-binding:
       property-allowlist:
         - regulator-allowed-modes
         - regulator-initial-mode
+
+examples:
+  - |
+    pmic {
+      compatible = "nordic,npm1100";
+
+      BUCK {
+        /* all properties for BUCK */
+      };
+    };

--- a/dts/bindings/regulator/nordic,npm1300-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm1300-regulator.yaml
@@ -6,30 +6,31 @@ description: |
 
   The PMIC has two buck converters and two LDOs.
   The regulators need to be defined as child nodes, strictly following the
-  BUCK1,2 LDO1..2, node names. For
-  example:
-
-  pmic@6b {
-    reg = <0x6b>;
-    ...
-    regulators {
-      compatible = "nordic,npm1300-regulator";
-
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-      LDO2 {
-        /* all properties for LDO2 */
-      };
-    };
-  };
+  BUCK1,2 LDO1..2, node names.
 
 compatible: "nordic,npm1300-regulator"
 
 include: "nordic,npm13xx-regulator-common.yaml"
+
+examples:
+  - |
+    pmic@6b {
+      reg = <0x6b>;
+      /* ... */
+      regulators {
+        compatible = "nordic,npm1300-regulator";
+
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+        LDO2 {
+          /* all properties for LDO2 */
+        };
+      };
+    };

--- a/dts/bindings/regulator/nordic,npm1304-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm1304-regulator.yaml
@@ -6,30 +6,31 @@ description: |
 
   The PMIC has two buck converters and two LDOs.
   The regulators need to be defined as child nodes, strictly following the
-  BUCK1,2 LDO1..2, node names. For
-  example:
-
-  pmic@6b {
-    reg = <0x6b>;
-    ...
-    regulators {
-      compatible = "nordic,npm1304-regulator";
-
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-      LDO2 {
-        /* all properties for LDO2 */
-      };
-    };
-  };
+  BUCK1,2 LDO1..2, node names.
 
 compatible: "nordic,npm1304-regulator"
 
 include: "nordic,npm13xx-regulator-common.yaml"
+
+examples:
+  - |
+    pmic@6b {
+      reg = <0x6b>;
+      /* ... */
+      regulators {
+        compatible = "nordic,npm1304-regulator";
+
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+        LDO2 {
+          /* all properties for LDO2 */
+        };
+      };
+    };

--- a/dts/bindings/regulator/nordic,npm2100-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm2100-regulator.yaml
@@ -7,22 +7,6 @@ description: |
   The PMIC has one boost converter and one LDO/LDSW.
   The regulators need to be defined as child nodes,
   strictly following the BOOST, LDOSW node names.
-  For example:
-
-  pmic@74 {
-    reg = <0x74>;
-    ...
-    regulators {
-      compatible = "nordic,npm2100-regulator";
-
-      BOOST {
-        /* all properties for BOOST */
-      };
-      LDOSW {
-        /* all properties for LDOSW */
-      };
-    };
-  };
 
 compatible: "nordic,npm2100-regulator"
 
@@ -79,3 +63,20 @@ child-binding:
       type: int
       description: |
         DPS coil pulse limit per refresh cycle.
+
+examples:
+  - |
+    pmic@74 {
+      reg = <0x74>;
+      /* ... */
+      regulators {
+        compatible = "nordic,npm2100-regulator";
+
+        BOOST {
+          /* all properties for BOOST */
+        };
+        LDOSW {
+          /* all properties for LDOSW */
+        };
+      };
+    };

--- a/dts/bindings/regulator/nordic,npm6001-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm6001-regulator.yaml
@@ -5,35 +5,7 @@ description: |
   Nordic nPM6001 PMIC
 
   The PMIC has four buck converters and two LDOs. All need to be defined as
-  children nodes, strictly following the BUCK0..3, LDO0..1 node names. For
-  example:
-
-  pmic@70 {
-    reg = <0x70>;
-    ...
-    regulators {
-      compatible = "nordic,npm6001-regulator";
-
-      BUCK0 {
-        /* all properties for BUCK0 */
-      };
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      BUCK3 {
-        /* all properties for BUCK3 */
-      };
-      LDO0 {
-        /* all properties for LDO0 */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-    };
-  };
+  children nodes, strictly following the BUCK0..3, LDO0..1 node names.
 
 compatible: "nordic,npm6001-regulator"
 
@@ -51,3 +23,32 @@ child-binding:
         - regulator-max-microvolt
         - regulator-allowed-modes
         - regulator-initial-mode
+
+examples:
+  - |
+    pmic@70 {
+      reg = <0x70>;
+      /* ... */
+      regulators {
+        compatible = "nordic,npm6001-regulator";
+
+        BUCK0 {
+          /* all properties for BUCK0 */
+        };
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        BUCK3 {
+          /* all properties for BUCK3 */
+        };
+        LDO0 {
+          /* all properties for LDO0 */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+      };
+    };

--- a/dts/bindings/regulator/nxp,pca9420.yaml
+++ b/dts/bindings/regulator/nxp,pca9420.yaml
@@ -6,25 +6,6 @@ description: |
 
   The PMIC has two buck converters and two LDOs. All need to be defined as
   children nodes, strictly following the BUCK1, BUCK2, LDO1 and LDO2 node names.
-  For example:
-
-  pmic@61 {
-    reg = <0x61>;
-    ...
-    BUCK1 {
-      /* all properties for BUCK1 */
-    };
-    BUCK2 {
-      /* all properties for BUCK2 */
-    };
-    LDO1 {
-      /* all properties for LDO1 */
-    };
-    LDO2 {
-      /* all properties for LDO2 */
-    };
-  };
-
 
 compatible: "nxp,pca9420"
 
@@ -115,3 +96,27 @@ child-binding:
       description: |
         The voltage level to be configured for mode 3, in microvolts. Setting
         this value to zero will disable the source in mode 3.
+
+examples:
+  - |
+    pmic@61 {
+      reg = <0x61>;
+
+      /* ... */
+
+      BUCK1 {
+        /* all properties for BUCK1 */
+      };
+
+      BUCK2 {
+        /* all properties for BUCK2 */
+      };
+
+      LDO1 {
+        /* all properties for LDO1 */
+      };
+
+      LDO2 {
+        /* all properties for LDO2 */
+      };
+    };

--- a/dts/bindings/regulator/nxp,pca9422-regulator.yaml
+++ b/dts/bindings/regulator/nxp,pca9422-regulator.yaml
@@ -7,39 +7,6 @@ description: |
   The PMIC has three buck converters, one buck-boost converter and four LDOs.
   All need to be defined as children nodes, strictly following the BUCK1, BUCK2,
   BUCK3, BUCKBOOST, LDO1, LDO2, LDO3 and LDO4 node names.
-  For example:
-
-  pmic@61 {
-    reg = <0x61>;
-    ...
-    regulators {
-      compatible = "nxp,pca9422-regulator";
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      BUCK3 {
-        /* all properties for BUCK2 */
-      };
-      BUCKBOOST {
-        /* all properties for BUCKBOOST */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-      LDO2 {
-        /* all properties for LDO2 */
-      };
-      LDO3 {
-        /* all properties for LDO3 */
-      };
-      LDO4 {
-        /* all properties for LDO4 */
-      };
-    };
-  }
 
 compatible: "nxp,pca9422-regulator"
 
@@ -124,3 +91,37 @@ child-binding:
       description: |
         The voltage level to be configured for standby and dpstandby modes,
         in microvolts.
+
+examples:
+  - |
+    pmic@61 {
+      reg = <0x61>;
+      /* ... */
+      regulators {
+        compatible = "nxp,pca9422-regulator";
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        BUCK3 {
+          /* all properties for BUCK2 */
+        };
+        BUCKBOOST {
+          /* all properties for BUCKBOOST */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+        LDO2 {
+          /* all properties for LDO2 */
+        };
+        LDO3 {
+          /* all properties for LDO3 */
+        };
+        LDO4 {
+          /* all properties for LDO4 */
+        };
+      };
+    }

--- a/dts/bindings/regulator/nxp,pf1550-regulator.yaml
+++ b/dts/bindings/regulator/nxp,pf1550-regulator.yaml
@@ -5,35 +5,7 @@ description: |
   NXP PF1550 PMIC
 
   The PMIC has two buck converters and three LDOs. All need to be defined as
-  children nodes, strictly following the BUCK1..3, LDO1..3 node names. For
-  example:
-
-  pmic@8 {
-    reg = <0x8>;
-    ...
-    regulators {
-      compatible = nxp,pf1550-regulator";
-
-      BUCK1 {
-        /* all properties for BUCK1 */
-      };
-      BUCK2 {
-        /* all properties for BUCK2 */
-      };
-      BUCK3 {
-        /* all properties for BUCK3 */
-      };
-      LDO1 {
-        /* all properties for LDO1 */
-      };
-      LDO2 {
-        /* all properties for LDO2 */
-      };
-      LDO3 {
-        /* all properties for LDO3 */
-      };
-    };
-  };
+  children nodes, strictly following the BUCK1..3, LDO1..3 node names.
 
 compatible: "nxp,pf1550-regulator"
 
@@ -52,3 +24,32 @@ child-binding:
         - regulator-boot-on
         - regulator-initial-mode
         - regulator-allowed-modes
+
+examples:
+  - |
+    pmic@8 {
+      reg = <0x8>;
+      /* ... */
+      regulators {
+        compatible = nxp,pf1550-regulator";
+
+        BUCK1 {
+          /* all properties for BUCK1 */
+        };
+        BUCK2 {
+          /* all properties for BUCK2 */
+        };
+        BUCK3 {
+          /* all properties for BUCK3 */
+        };
+        LDO1 {
+          /* all properties for LDO1 */
+        };
+        LDO2 {
+          /* all properties for LDO2 */
+        };
+        LDO3 {
+          /* all properties for LDO3 */
+        };
+      };
+    };

--- a/dts/bindings/regulator/regulator-gpio.yaml
+++ b/dts/bindings/regulator/regulator-gpio.yaml
@@ -19,7 +19,6 @@ description: |
 
       regulator-boot-on;
     };
-
   In the above example, three GPIO pins are used for controlling the regulator:
     * two of them for controlling voltage;
     * third for enabling/disabling the regulator.

--- a/dts/bindings/regulator/x-powers,axp192-regulator.yaml
+++ b/dts/bindings/regulator/x-powers,axp192-regulator.yaml
@@ -7,36 +7,6 @@ description: |
 
   The PMIC has three DCDC converters and two LDOs (LDO1 cannot be disabled).
   All need to be defined as children nodes.
-  For example:
-
-  i2c {
-    pmic@34 {
-      reg = <0x34>;
-      ...
-      regulators {
-        compatible = "x-powers,axp192-regulator";
-
-        DCDC1 {
-          /* all properties for DCDC1 */
-        };
-        DCDC2 {
-          /* all properties for DCDC2 */
-        };
-        DCDC3 {
-          /* all properties for DCDC3 */
-        };
-        LDOIO0 {
-          /* all properties for LDOIO0 */
-        };
-        LDO2 {
-          /* all properties for LDO2 */
-        };
-        LDO3 {
-          /* all properties for LDO3 */
-        };
-      };
-    };
-  };
 
 compatible: "x-powers,axp192-regulator"
 
@@ -68,3 +38,34 @@ child-binding:
         Initial operating mode. AXP192 supports 2 different power modes:
         AXP192_DCDC_MODE_AUTO: Auto (0, default)
         AXP192_DCDC_MODE_PWM:  PWM
+
+examples:
+  - |
+    i2c {
+      pmic@34 {
+        reg = <0x34>;
+        /* ... */
+        regulators {
+          compatible = "x-powers,axp192-regulator";
+
+          DCDC1 {
+            /* all properties for DCDC1 */
+          };
+          DCDC2 {
+            /* all properties for DCDC2 */
+          };
+          DCDC3 {
+            /* all properties for DCDC3 */
+          };
+          LDOIO0 {
+            /* all properties for LDOIO0 */
+          };
+          LDO2 {
+            /* all properties for LDO2 */
+          };
+          LDO3 {
+            /* all properties for LDO3 */
+          };
+        };
+      };
+    };

--- a/dts/bindings/regulator/x-powers,axp2101-regulator.yaml
+++ b/dts/bindings/regulator/x-powers,axp2101-regulator.yaml
@@ -7,61 +7,6 @@ description: |
 
   The PMIC has five DCDC converters and nine LDOs.
   All need to be defined as children nodes.
-  For example:
-
-  i2c {
-    axp2101@34 {
-      compatible = "x-powers,axp2101";
-      reg = <0x34>;
-      ...
-      regulators {
-        compatible = "x-powers,axp2101-regulator";
-
-        DCDC1 {
-          /* all properties for DCDC1 */
-        };
-        DCDC2 {
-          /* all properties for DCDC2 */
-        };
-        DCDC3 {
-          /* all properties for DCDC3 */
-        };
-        DCDC4 {
-          /* all properties for DCDC4 */
-        };
-        DCDC5 {
-          /* all properties for DCDC5 */
-        };
-        LDOA1 {
-          /* all properties for LDOA1 */
-        };
-        LDOA2 {
-          /* all properties for LDOA2 */
-        };
-        LDOA3 {
-          /* all properties for LDOA3 */
-        };
-        LDOA4 {
-          /* all properties for LDOA4 */
-        };
-        LDOB1 {
-          /* all properties for LDOB1 */
-        };
-        LDOB2 {
-          /* all properties for LDOB2 */
-        };
-        LDOC {
-          /* all properties for LDOC */
-        };
-        LDOD1 {
-          /* all properties for LDOD1 */
-        };
-        LDOD2 {
-          /* all properties for LDOD2 */
-        };
-      };
-    };
-  };
 
 compatible: "x-powers,axp2101-regulator"
 
@@ -91,3 +36,59 @@ child-binding:
         Initial operating mode. AXP2101 supports 2 different power modes:
         AXP2101_DCDC_MODE_AUTO: Auto (0, default)
         AXP2101_DCDC_MODE_PWM:  PWM
+
+examples:
+  - |
+    i2c {
+      axp2101@34 {
+        compatible = "x-powers,axp2101";
+        reg = <0x34>;
+        /* ... */
+        regulators {
+          compatible = "x-powers,axp2101-regulator";
+
+          DCDC1 {
+            /* all properties for DCDC1 */
+          };
+          DCDC2 {
+            /* all properties for DCDC2 */
+          };
+          DCDC3 {
+            /* all properties for DCDC3 */
+          };
+          DCDC4 {
+            /* all properties for DCDC4 */
+          };
+          DCDC5 {
+            /* all properties for DCDC5 */
+          };
+          LDOA1 {
+            /* all properties for LDOA1 */
+          };
+          LDOA2 {
+            /* all properties for LDOA2 */
+          };
+          LDOA3 {
+            /* all properties for LDOA3 */
+          };
+          LDOA4 {
+            /* all properties for LDOA4 */
+          };
+          LDOB1 {
+            /* all properties for LDOB1 */
+          };
+          LDOB2 {
+            /* all properties for LDOB2 */
+          };
+          LDOC {
+            /* all properties for LDOC */
+          };
+          LDOD1 {
+            /* all properties for LDOD1 */
+          };
+          LDOD2 {
+            /* all properties for LDOD2 */
+          };
+        };
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="1120" height="738" alt="image" src="https://github.com/user-attachments/assets/865fdc56-221c-43e1-b849-dfcadbc40bc8" />

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
