### PR TITLE
dts: bindings: input: move DTS snippets from `description` to `examples`

### DIFF
--- a/dts/bindings/input/adc-keys.yaml
+++ b/dts/bindings/input/adc-keys.yaml
@@ -8,30 +8,6 @@ description: |
   values. Instead, users are required to specify the voltage for each single
   key press or for combinations of key presses.
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  / {
-          buttons {
-                  compatible = "adc-keys";
-                  io-channels = <&adc 2>;
-                  keyup-threshold-mv = <0>;
-
-                  key_0 {
-                          press-thresholds-mv = <1650>,  /* KEY0 */
-                                                <2536>;  /* KEY0 + KEY1 */
-                          zephyr,code = <INPUT_KEY_0>;
-                  };
-
-                  key_1 {
-                          press-thresholds-mv = <2300>,  /* KEY1 */
-                                                <2536>;  /* KEY0 + KEY1 */
-                          zephyr,code = <INPUT_KEY_1>;
-                  };
-          };
-  };
-
 compatible: "adc-keys"
 
 include: base.yaml
@@ -68,3 +44,27 @@ child-binding:
       type: int
       required: true
       description: Key code to emit.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    / {
+            buttons {
+                    compatible = "adc-keys";
+                    io-channels = <&adc 2>;
+                    keyup-threshold-mv = <0>;
+
+                    key_0 {
+                            press-thresholds-mv = <1650>,  /* KEY0 */
+                                                  <2536>;  /* KEY0 + KEY1 */
+                            zephyr,code = <INPUT_KEY_0>;
+                    };
+
+                    key_1 {
+                            press-thresholds-mv = <2300>,  /* KEY1 */
+                                                  <2536>;  /* KEY0 + KEY1 */
+                            zephyr,code = <INPUT_KEY_1>;
+                    };
+            };
+    };

--- a/dts/bindings/input/espressif,esp32-touch-sensor.yaml
+++ b/dts/bindings/input/espressif,esp32-touch-sensor.yaml
@@ -8,33 +8,6 @@ description: |
   sensor is defined in a child node of the touch-sensor node and defines a specific key
   code.
 
-  For example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-  #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
-
-  &touch {
-         compatible = "espressif,esp32-touch";
-         status = "okay";
-
-         debounce-interval-ms = <30>;
-         href-microvolt = <27000000>;
-         lref-microvolt = <500000>;
-         href-atten-microvolt = <1000000>;
-         filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
-         filter-debounce-cnt = <1>;
-         filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
-         filter-jitter-step = <4>;
-         filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
-
-         touch_sensor_0 {
-                 channel-num = <1>;
-                 channel-sens = <20>;
-                 zephyr,code = <INPUT_KEY_0>;
-         };
-  };
-
-
 compatible: "espressif,esp32-touch"
 
 include: base.yaml
@@ -129,3 +102,29 @@ child-binding:
       type: int
       required: true
       description: Key code to emit.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+    #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+    &touch {
+           compatible = "espressif,esp32-touch";
+           status = "okay";
+
+           debounce-interval-ms = <30>;
+           href-microvolt = <27000000>;
+           lref-microvolt = <500000>;
+           href-atten-microvolt = <1000000>;
+           filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+           filter-debounce-cnt = <1>;
+           filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+           filter-jitter-step = <4>;
+           filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
+
+           touch_sensor_0 {
+                   channel-num = <1>;
+                   channel-sens = <20>;
+                   zephyr,code = <INPUT_KEY_0>;
+           };
+    };

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -8,21 +8,6 @@ description: |
   is defined in a child node of the gpio-keys node and defines a specific key
   code.
 
-  For example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  / {
-         buttons {
-                 compatible = "gpio-keys";
-                 button_0 {
-                         gpios = <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-                         zephyr,code = <INPUT_KEY_0>;
-                 };
-         };
-  };
-
-
 compatible: "gpio-keys"
 
 include: base.yaml
@@ -61,3 +46,17 @@ child-binding:
     zephyr,code:
       type: int
       description: Key code to emit.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    / {
+           buttons {
+                   compatible = "gpio-keys";
+                   button_0 {
+                           gpios = <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+                           zephyr,code = <INPUT_KEY_0>;
+                   };
+           };
+    };

--- a/dts/bindings/input/renesas,ra-ctsu-button.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-button.yaml
@@ -8,33 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      button1 {
-        compatible = "renesas,ra-ctsu-button";
-        elements = <0>;
-        threshold = <769>;
-        hysteresis = <38>;
-        event-code = <INPUT_KEY_0>;
-      };
-
-      button2 {
-        compatible = "renesas,ra-ctsu-button";
-        elements = <1>;
-        threshold = <769>;
-        hysteresis = <38>;
-        event-code = <INPUT_KEY_1>;
-      };
-    };
-  };
-
   Notes: The order of the CTSU button nodes in the same group must follow these elements index.
 
 compatible: "renesas,ra-ctsu-button"
@@ -67,3 +40,30 @@ properties:
     default: 0
     description: |
       Threshold hysteresis for chattering prevention for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        button1 {
+          compatible = "renesas,ra-ctsu-button";
+          elements = <0>;
+          threshold = <769>;
+          hysteresis = <38>;
+          event-code = <INPUT_KEY_0>;
+        };
+
+        button2 {
+          compatible = "renesas,ra-ctsu-button";
+          elements = <1>;
+          threshold = <769>;
+          hysteresis = <38>;
+          event-code = <INPUT_KEY_1>;
+        };
+      };
+    };

--- a/dts/bindings/input/renesas,ra-ctsu-slider.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-slider.yaml
@@ -8,24 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      slider {
-        compatible = "renesas,ra-ctsu-slider";
-        elements = <1>, <0>, <2>, <4>, <3>;
-        threshold = <573>;
-        event-code = <INPUT_ABS_THROTTLE>;
-      };
-    };
-  };
-
 compatible: "renesas,ra-ctsu-slider"
 
 include: [base.yaml]
@@ -50,3 +32,21 @@ properties:
     default: 0
     description: |
       Touch/non-touch judgement threshold for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        slider {
+          compatible = "renesas,ra-ctsu-slider";
+          elements = <1>, <0>, <2>, <4>, <3>;
+          threshold = <573>;
+          event-code = <INPUT_ABS_THROTTLE>;
+        };
+      };
+    };

--- a/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
@@ -8,24 +8,6 @@ description: |
   to detect an input event on a group which is the child of renesas,ra-ctsu.
   For more information see input/renesas,ra-ctsu.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &ctsu {
-    compatible = "renesas,ra-ctsu";
-
-    group1 {
-      ...
-      wheel {
-        compatible = "renesas,ra-ctsu-wheel";
-        elements = <0>, <3>, <2>, <1>;
-        threshold = <711>;
-        event-code = <INPUT_ABS_WHEEL>;
-      };
-    };
-  };
-
 compatible: "renesas,ra-ctsu-wheel"
 
 include: [base.yaml]
@@ -50,3 +32,21 @@ properties:
     default: 0
     description: |
       Touch/non-touch judgement threshold for automatic judgement.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &ctsu {
+      compatible = "renesas,ra-ctsu";
+
+      group1 {
+        /* ... */
+        wheel {
+          compatible = "renesas,ra-ctsu-wheel";
+          elements = <0>, <3>, <2>, <1>;
+          threshold = <711>;
+          event-code = <INPUT_ABS_WHEEL>;
+        };
+      };
+    };

--- a/dts/bindings/input/tsc-keys.yaml
+++ b/dts/bindings/input/tsc-keys.yaml
@@ -8,25 +8,6 @@ description: |
   calculations to detect an input event on a group which is the child of
   st,stm32-tsc. For more information see drivers/misc/st,stm32-tsc.yaml
 
-  Example:
-
-  #include <zephyr/dt-bindings/input/input-event-codes.h>
-
-  &tsc {
-    compatible = "st,stm32-tsc";
-
-    tsc_group6: g6 {
-      ...
-      ts1 {
-        compatible = "tsc-keys";
-        sampling-interval-ms = <10>;
-        oversampling = <10>;
-        noise-threshold = <50>;
-        zephyr,code = <INPUT_KEY_0>;
-      };
-    };
-  };
-
 compatible: "tsc-keys"
 
 include:
@@ -69,3 +50,22 @@ properties:
     type: int
     required: true
     description: Key code to emit.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/input/input-event-codes.h>
+
+    &tsc {
+      compatible = "st,stm32-tsc";
+
+      tsc_group6: g6 {
+        /* ... */
+        ts1 {
+          compatible = "tsc-keys";
+          sampling-interval-ms = <10>;
+          oversampling = <10>;
+          noise-threshold = <50>;
+          zephyr,code = <INPUT_KEY_0>;
+        };
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more
structured way.

<img width="1441" height="736" alt="image" src="https://github.com/user-attachments/assets/2687fdb3-986a-4767-b125-6b141da91e0e" />


Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
