### PR TITLE
Bluetooth: BAP: Stream: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -28,7 +28,6 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -113,13 +112,13 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 {
 	enum bt_audio_dir dir;
 
-	CHECKIF(ep == NULL) {
+	if (ep == NULL) {
 		LOG_DBG("ep is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(info == NULL) {
+	if (info == NULL) {
 		LOG_DBG("info is NULL");
 
 		return -EINVAL;
@@ -457,13 +456,13 @@ int bt_bap_stream_get_tx_sync(struct bt_bap_stream *stream, struct bt_iso_tx_inf
 {
 	struct bt_iso_chan *iso_chan;
 
-	CHECKIF(stream == NULL) {
+	if (stream == NULL) {
 		LOG_DBG("stream is null");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(info == NULL) {
+	if (info == NULL) {
 		LOG_DBG("info is null");
 
 		return -EINVAL;
@@ -638,7 +637,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 	       codec_cfg, codec_cfg ? codec_cfg->id : 0, codec_cfg ? codec_cfg->cid : 0,
 	       codec_cfg ? codec_cfg->vid : 0);
 
-	CHECKIF(conn == NULL || stream == NULL || codec_cfg == NULL || ep == NULL) {
+	if (conn == NULL || stream == NULL || codec_cfg == NULL || ep == NULL) {
 		LOG_DBG("NULL value(s) supplied)");
 		return -EINVAL;
 	}
@@ -704,12 +703,12 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 
 	LOG_DBG("conn %p group %p", (void *)conn, group);
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(group == NULL) {
+	if (group == NULL) {
 		LOG_DBG("group is NULL");
 		return -EINVAL;
 	}
@@ -814,12 +813,12 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
 
 	LOG_DBG("stream %p codec_cfg %p", stream, codec_cfg);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
 
-	CHECKIF(codec_cfg == NULL) {
+	if (codec_cfg == NULL) {
 		LOG_DBG("codec_cfg is NULL");
 		return -EINVAL;
 	}
@@ -863,7 +862,7 @@ int bt_bap_stream_connect(struct bt_bap_stream *stream)
 
 	LOG_DBG("stream %p ep %p", stream, stream == NULL ? NULL : stream->ep);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
@@ -898,7 +897,7 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 
 	LOG_DBG("stream %p ep %p", stream, stream == NULL ? NULL : stream->ep);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
@@ -938,12 +937,12 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
 
 	LOG_DBG("stream %p meta_len %zu", stream, meta_len);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
 
-	CHECKIF((meta == NULL && meta_len != 0U) || (meta != NULL && meta_len == 0U)) {
+	if ((meta == NULL && meta_len != 0U) || (meta != NULL && meta_len == 0U)) {
 		LOG_DBG("Invalid meta (%p) or len (%zu)", meta, meta_len);
 		return -EINVAL;
 	}
@@ -985,7 +984,7 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 
 	LOG_DBG("stream %p", stream);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
@@ -1027,7 +1026,7 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 
 	LOG_DBG("stream %p", stream);
 
-	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		LOG_DBG("Invalid stream (ep %p, conn %p)", stream->ep, (void *)stream->conn);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.