### PR TITLE
Bluetooth: BAP: US: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -18,7 +18,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/check.h>
 
 #include "ascs_internal.h"
 #include "bap_iso.h"
@@ -53,7 +52,7 @@ int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
 {
 	int err;
 
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.