### PR TITLE
boards: st: refine boards embedding a scratch partition

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -65,14 +65,10 @@
 		slot1_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00078000 DT_SIZE_K(416)>;
+			reg = <0x00078000 DT_SIZE_K(420)>;
 		};
 
-		scratch_partition: partition@e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000e0000 DT_SIZE_K(64)>;
-		};
+		/* Unused range [0xe1000..0xeffff] */
 
 		storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/nucleo_f207zg/Kconfig.sysbuild
+++ b/boards/st/nucleo_f207zg/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -233,6 +233,7 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 		ranges;
 
+		/* Sectors 0 and 1 (2x16kByte) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
@@ -241,10 +242,14 @@ zephyr_udc0: &usbotg_fs {
 		};
 
 		/*
+		 * Sectors 2 and 3 (2x16kByte)
+		 *
 		 * nvs subsystem requires 2 sectors with a max total of 32K
 		 * On F2 series, the only option is to use the following
 		 * partition, which is compatible with mcuboot usage.
-		 * Keep it commented in order it is not used by CI.
+		 * Keep it commented in order it is not used by CI
+		 * since, when MCUBoot is not embedded, Zephyr image starts
+		 * from flash0 beginning and overlaps storage_partition.
 		 *
 		 * storage_partition: partition@8000 {
 		 *	compatible = "zephyr,mapped-partition";
@@ -253,22 +258,27 @@ zephyr_udc0: &usbotg_fs {
 		 * };
 		 */
 
+		/* Sector 4 (64kByte): spare/unused */
+
+		/* Sectors 5 to 7 (3x128kByte) */
 		slot0_partition: partition@20000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(384)>;
 		};
 
-		slot1_partition: partition@60000 {
+		/* Sectors 8 to 10 (3x128kByte) */
+		slot1_partition: partition@80000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x60000 DT_SIZE_K(384)>;
+			reg = <0x80000 DT_SIZE_K(384)>;
 		};
 
-		scratch_partition: partiimagtion@c0000 {
+		/* Sector 11 (128kByte) */
+		scratch_partition: partition@e0000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
-			reg = <0xc0000 DT_SIZE_K(128)>;
+			reg = <0xe0000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/st/nucleo_f401re/Kconfig.sysbuild
+++ b/boards/st/nucleo_f401re/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f410rb/Kconfig.sysbuild
+++ b/boards/st/nucleo_f410rb/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -132,6 +132,7 @@
 		#size-cells = <1>;
 		ranges;
 
+		/* Sectors 0 & 1 (2x16kB) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
@@ -139,30 +140,18 @@
 			read-only;
 		};
 
-		/*
-		 * The flash sectors 2&3 at 0x00008000 and ending at
-		 * 0x0000ffff
-		 */
+		/* Sectors 2 & 3 (2x16kB) */
 		slot0_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
 
-		/*
-		 * The flash sectors 4 at 0x00010000 and ending at
-		 * 0x001ffff
-		 */
+		/* Sectors 4 (only the first 32kB) */
 		slot1_partition: partition@10000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00010000 DT_SIZE_K(32)>;
-		};
-
-		scratch_partition: partition@18000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x00018000 DT_SIZE_K(32)>;
 		};
 	};
 };

--- a/boards/st/nucleo_f413zh/Kconfig.sysbuild
+++ b/boards/st/nucleo_f413zh/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f429zi/Kconfig.sysbuild
+++ b/boards/st/nucleo_f429zi/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f446re/Kconfig.sysbuild
+++ b/boards/st/nucleo_f446re/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can2;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -173,36 +173,38 @@
 		#size-cells = <1>;
 		ranges;
 
+		/* Sectors 0 and 1 (2x16kByte) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
-		 */
-		storage_partition: partition@10000 {
+		/* Sectors 2 and 3 (2x16kByte) */
+		storage_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00010000 DT_SIZE_K(64)>;
+			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
 
+		/* Sector 4 (64kByte): spare/unused */
+
+		/* Sector 5 (128kByte) */
 		slot0_partition: partition@20000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 6 (128kByte) */
 		slot1_partition: partition@40000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 7 (128kByte) */
 		scratch_partition: partition@60000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -171,36 +171,38 @@
 		#size-cells = <1>;
 		ranges;
 
+		/* Sectors 0 and 1 (2x16kByte) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
-		 */
-		storage_partition: partition@10000 {
+		/* Sectors 2 and 3 (2x16kByte) */
+		storage_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00010000 DT_SIZE_K(64)>;
+			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
 
+		/* Sector 4 (64kByte): spare/unused */
+
+		/* Sector 5 (128kByte) */
 		slot0_partition: partition@20000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 6 (128kByte) */
 		slot1_partition: partition@40000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 7 (128kByte) */
 		scratch_partition: partition@60000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";

--- a/boards/st/nucleo_f446ze/Kconfig.sysbuild
+++ b/boards/st/nucleo_f446ze/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -194,36 +194,38 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 		ranges;
 
+		/* Sectors 0 and 1 (2x16kByte) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
-		 */
-		storage_partition: partition@10000 {
+		/* Sectors 2 and 3 (2x16kByte) */
+		storage_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00010000 DT_SIZE_K(64)>;
+			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
 
+		/* Sector 4 (64kByte): spare/unused */
+
+		/* Sector 5 (128kByte) */
 		slot0_partition: partition@20000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 6 (128kByte) */
 		slot1_partition: partition@40000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
+		/* Sector 7 (128kByte) */
 		scratch_partition: partition@60000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -248,35 +248,41 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 		ranges;
 
-		/* set  4* 32KB */
+		/* Sectors 0 and 1 (2x32kByte) */
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(128)>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
-		storage_partition: partition@20000 {
+		/* Sectors 2 and 3 (2x32kByte) */
+		storage_partition: partition@10000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00020000 DT_SIZE_K(256)>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
-		slot0_partition: partition@60000 {
+		/* Sector 4 (128kByte): spare/unused */
+
+		/* Sectors 5 (256kByte) */
+		slot0_partition: partition@40000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
-			reg = <0x00060000 DT_SIZE_K(128)>;
+			reg = <0x00040000 DT_SIZE_K(256)>;
 		};
 
+		/* Sectors 6 (256kByte) */
 		slot1_partition: partition@80000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00080000 DT_SIZE_K(128)>;
+			reg = <0x00080000 DT_SIZE_K(256)>;
 		};
 
-		scratch_partition: partition@a0000 {
+		/* Sectors 7 (256kByte) */
+		scratch_partition: partition@c0000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
-			reg = <0x000a0000 DT_SIZE_K(256)>;
+			reg = <0x000c0000 DT_SIZE_K(256)>;
 		};
 	};
 };

--- a/boards/st/nucleo_f756zg/Kconfig.sysbuild
+++ b/boards/st/nucleo_f756zg/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_h743zi/Kconfig.sysbuild
+++ b/boards/st/nucleo_h743zi/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_SCRATCH if BOOTLOADER_MCUBOOT
+endchoice

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -262,12 +262,18 @@ zephyr_udc0: &usbotg_fs {
 			read-only;
 		};
 
-		/* storage: 128KB for settings */
-		storage_partition: partition@20000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x00020000 DT_SIZE_K(128)>;
-		};
+		/* storage: 128KB for settings
+		 *
+		 * NVS needs at least 2 sectors of 32kB each max
+		 * which does not match H743x internal flash whose
+		 * sectors are all 128kB.
+		 *
+		 * storage_partition: partition@20000 {
+		 *	compatible = "zephyr,mapped-partition";
+		 *	label = "storage";
+		 *	reg = <0x00020000 DT_SIZE_K(128)>;
+		 * };
+		 */
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -260,12 +260,18 @@ zephyr_udc0: &usbotg_fs {
 			read-only;
 		};
 
-		/* storage: 128KB for settings */
-		storage_partition: partition@20000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x00020000 DT_SIZE_K(128)>;
-		};
+		/* storage: 128KB for settings
+		 *
+		 * NVS needs at least 2 sectors of 32kB each max
+		 * which does not match H743x internal flash whose
+		 * sectors are all 128kB.
+		 *
+		 * storage_partition: partition@20000 {
+		 *	compatible = "zephyr,mapped-partition";
+		 *	label = "storage";
+		 *	reg = <0x00020000 DT_SIZE_K(128)>;
+		 * };
+		 */
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -251,10 +251,10 @@ zephyr_udc0: &usbotg_fs {
 			reg = <0x000f8000 DT_SIZE_K(24)>;
 		};
 
-		storage_partition: partition@fc000 {
+		storage_partition: partition@fe000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x000fc000 DT_SIZE_K(24)>;
+			reg = <0x000fe000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -361,14 +361,10 @@ zephyr_udc0: &usbotg_fs {
 		slot1_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00078000 DT_SIZE_K(416)>;
+			reg = <0x00078000 DT_SIZE_K(424)>;
 		};
 
-		scratch_partition: partition@e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000e0000 DT_SIZE_K(64)>;
-		};
+		/* Range [0xe2000..0xf0000] is unused. */
 
 		storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -362,14 +362,10 @@ zephyr_udc0: &usbotg_fs {
 		slot1_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00078000 DT_SIZE_K(416)>;
+			reg = <0x00078000 DT_SIZE_K(424)>;
 		};
 
-		scratch_partition: partition@e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000e0000 DT_SIZE_K(64)>;
-		};
+		/* Range [0xe2000..0xf0000] is unused. */
 
 		storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -330,14 +330,10 @@ zephyr_udc0: &usbotg_fs {
 		slot1_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00078000 DT_SIZE_K(416)>;
+			reg = <0x00078000 DT_SIZE_K(424)>;
 		};
 
-		scratch_partition: partition@e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000e0000 DT_SIZE_K(64)>;
-		};
+		/* Range [0xe2000..0xf0000] is unused. */
 
 		storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -331,14 +331,10 @@ zephyr_udc0: &usbotg_fs {
 		slot1_partition: partition@78000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00078000 DT_SIZE_K(416)>;
+			reg = <0x00078000 DT_SIZE_K(424)>;
 		};
 
-		scratch_partition: partition@e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000e0000 DT_SIZE_K(64)>;
-		};
+		/* Range [0xe2000..0xf0000] is unused. */
 
 		storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -134,13 +134,7 @@
 		slot1_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00008000 DT_SIZE_K(16)>;
-		};
-
-		scratch_partition: partition@c000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x0000c000 DT_SIZE_K(16)>;
+			reg = <0x00008000 DT_SIZE_K(20)>;
 		};
 	};
 };

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -120,21 +120,20 @@
 			read-only;
 		};
 
-		/*
-		 * The flash starting at offset 0x2000 and ending at
-		 * offset 0x3fff is reserved for use by the application.
-		 */
-
-		slot0_partition: partition@4000 {
-			compatible = "zephyr,mapped-partition";
+		slot0_partition: partition@2000 {
 			label = "image-0";
-			reg = <0x00004000 DT_SIZE_K(16)>;
+			reg = <0x00002000 DT_SIZE_K(20)>;
 		};
 
 		slot1_partition: partition@8000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00008000 DT_SIZE_K(20)>;
+			reg = <0x00008000 DT_SIZE_K(24)>;
+		};
+
+		storage_partition: partition@e000 {
+			label = "storage";
+			reg = <0x0000e000 DT_SIZE_K(12)>;
 		};
 	};
 };

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -160,14 +160,10 @@ zephyr_udc0: &usb {
 		slot1_partition: partition@70000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00070000 DT_SIZE_K(400)>;
+			reg = <0x00070000 DT_SIZE_K(404)>;
 		};
 
-		scratch_partition: partition@d4000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x000d4000 DT_SIZE_K(16)>;
-		};
+		/* Area [0xd5000..0xd7fff] is unused */
 
 		storage_partition: partition@d8000 {
 			compatible = "zephyr,mapped-partition";

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.dts
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.dts
@@ -104,5 +104,10 @@ zephyr_udc0: &usb {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
+
+		slot1_partition: partition@70000 {
+			label = "image-1";
+			reg = <0x0070000 DT_SIZE_K(404)>;
+		};
 	};
 };

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/delete-node/ &storage_partition;
 
 &sdmmc1 {
 	status = "okay";


### PR DESCRIPTION
This P-R targets ST boards that are currently embedded a scratch partition in their flash layout (for MCUBoot use).

Some need to use *swap-with-scratch* MCUBoot mode due to big size of the sectors of the slot0/slot1 partitions (from 128kB to 256kB). For these boards, add a **Kconf.sysbuild** file to default enable `MCUBOOT_MODE_SWAP_SCRATCH` when needed.

Some do not need and can leverage the recommended *swap-using-offset* MCUBoot mode (that is the default mode enabled). Update the flash layout for these boards: by enlarging the slot1 partition and removing the useless scratch partition.

This P-R proposes the fix some DTS flash layout inconsistencies regarding the internal flash sector distribution (nucleo_f746zg, sensor_tile, nucleo_f207zg). This changes really apply only when MCUBoot is embedded unless what these board assigns the full internal flash to the Zephyr application.