### PR TITLE
MAINTAINERS: Update WCH Platforms status to 'odd fixes'

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5434,11 +5434,10 @@ VFS:
     - filesystem
 
 WCH Platforms:
-  status: maintained
-  maintainers:
+  status: odd fixes
+  collaborators:
     - nzmichaelh
     - kholia
-  collaborators:
     - VynDragon
   files:
     - boards/wch/


### PR DESCRIPTION
None of the current maintainers are engaging with incoming issues and pull requests for WCH Platforms.
This commit makes them collaborators in an attempt to reflect better the atatus quo and help some of the current PRs get merged by means of other volunteers stepping in to review on a best effort basis.

@nzmichaelh hasn't engaged in over 3 months as per https://github.com/nzmichaelh ; same for @kholia https://github.com/kholia and this is despite multiple pings over the course of the past many weeks.

This is blocking the following 4 pull requests:
- https://github.com/zephyrproject-rtos/zephyr/pull/99286
- https://github.com/zephyrproject-rtos/zephyr/pull/101391
- https://github.com/zephyrproject-rtos/zephyr/pull/101688
- https://github.com/zephyrproject-rtos/zephyr/pull/94547
- https://github.com/zephyrproject-rtos/zephyr/pull/98978

@nzmichaelh @kholia by all means please do chime in if you feel you will be able to engage again in the near future. If not, you are of course welcome to come back at any time!

@VynDragon - as a current collaborator, you would IMO also be a good candidate to step up as a maintainer if that's of interest.