### PR TITLE
MAINTAINERS: Update Devicetree area status to 'odd fixes'

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1111,10 +1111,9 @@ Device Driver Model:
     - init
 
 Devicetree:
-  status: maintained
-  maintainers:
-    - mbolivar
+  status: odd fixes
   collaborators:
+    - mbolivar
     - decsny
     - rruuaanng
   files-regex:


### PR DESCRIPTION
The current maintainer hasn't been engaging with incoming issues and pull requests for well over a month and this is causing many PRs to be effectively stalled.

This commit makes them a collaborator in an attempt to reflect better the atatus quo and help some of the current PRs get merged by means of other volunteers stepping up to review on a best-effort basis.

@mbolivar, by all means, please do chime in if you feel you will be able to engage again in the near future. If not, you are of course welcome to come back at any time! Meanwhile, this PR acts as a way to help "unstuck" the couple dozens of pull requests currently blocked and causing confusion/frustration for contributors and reviewers alike. 

Thanks!