### PR TITLE
scripts: snippets: optimize parsing performance

### DIFF
--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -17,7 +17,7 @@ Output CMake variables:
 from collections import defaultdict, UserDict
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Dict, Iterable, List, Set
+from collections.abc import Iterable
 from jsonschema.exceptions import best_match
 import argparse
 import logging
@@ -36,8 +36,8 @@ except ImportError:
 
 # Marker type for an 'append:' configuration. Maps variables
 # to the list of values to append to them.
-Appends = Dict[str, List[str]]
-BoardRevisionAppends = Dict[str, Dict[str, List[str]]]
+Appends = dict[str, list[str]]
+BoardRevisionAppends = dict[str, dict[str, list[str]]]
 
 def _new_append():
     return defaultdict(list)
@@ -52,7 +52,7 @@ class Snippet:
 
     name: str
     appends: Appends = field(default_factory=_new_append)
-    board2appends: Dict[str, BoardRevisionAppends] = field(default_factory=_new_board2appends)
+    board2appends: dict[str, BoardRevisionAppends] = field(default_factory=_new_board2appends)
 
     def process_data(self, pathobj: Path, snippet_data: dict, sysbuild: bool):
         '''Process the data in a snippet.yml file, after it is loaded into a
@@ -95,8 +95,8 @@ class Snippets(UserDict):
 
     def __init__(self, requested: Iterable[str] = None):
         super().__init__()
-        self.paths: Set[Path] = set()
-        self.requested: List[str] = list(requested or [])
+        self.paths: set[Path] = set()
+        self.requested: list[str] = list(requested or [])
 
 class SnippetsError(Exception):
     '''Class for signalling expected errors'''

--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -28,6 +28,12 @@ import yaml
 import platform
 import jsonschema
 
+try:
+    # Use the C LibYAML parser if available, rather than the Python parser.
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader     # type: ignore
+
 # Marker type for an 'append:' configuration. Maps variables
 # to the list of values to append to them.
 Appends = Dict[str, List[str]]
@@ -207,8 +213,12 @@ if("${{BOARD}}${{BOARD_QUALIFIERS}}" STREQUAL "{board}")
 # Name of the file containing the jsonschema schema for snippet.yml
 # files.
 SCHEMA_PATH = str(Path(__file__).parent / 'schemas' / 'snippet-schema.yaml')
-with open(SCHEMA_PATH, 'r') as f:
-    SNIPPET_SCHEMA = yaml.safe_load(f.read())
+with open(SCHEMA_PATH, 'rb') as f:
+    SNIPPET_SCHEMA = yaml.load(f.read(), Loader=SafeLoader)
+
+SNIPPET_VALIDATOR_CLASS = jsonschema.validators.validator_for(SNIPPET_SCHEMA)
+SNIPPET_VALIDATOR_CLASS.check_schema(SNIPPET_SCHEMA)
+SNIPPET_VALIDATOR = SNIPPET_VALIDATOR_CLASS(SNIPPET_SCHEMA)
 
 # The name of the file which contains metadata about the snippets
 # being defined in a directory.
@@ -309,16 +319,13 @@ def load_snippet_yml(snippet_yml: Path) -> dict:
     against the schema, and do other basic checks. Return the dict
     of the resulting YAML data.'''
 
-    with open(snippet_yml, 'r') as f:
+    with open(snippet_yml, 'rb') as f:
         try:
-            snippet_data = yaml.safe_load(f.read())
+            snippet_data = yaml.load(f.read(), Loader=SafeLoader)
         except yaml.scanner.ScannerError:
             _err(f'snippets file {snippet_yml} is invalid YAML')
 
-    validator_class = jsonschema.validators.validator_for(SNIPPET_SCHEMA)
-    validator_class.check_schema(SNIPPET_SCHEMA)
-    snippet_validator = validator_class(SNIPPET_SCHEMA)
-    errors = list(snippet_validator.iter_errors(snippet_data))
+    errors = list(SNIPPET_VALIDATOR.iter_errors(snippet_data))
 
     if errors:
         sys.exit('ERROR: Malformed snippet YAML file: '


### PR DESCRIPTION
1. Load and validate the schema only once
2. Use `CSafeLoader` if it's available
3. Read YAML files in binary mode

This reduces the execution time of `snippets.py `from ~380ms down to ~160ms when I build samples/basic/blinky for nrf52dk/nrf52832 (Tested on Ubuntu 24.04)

For reference, this is the command I used: `west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky --cmake -- --profiling-format=google-trace --profiling-output=cmake-configure-trace.json`


Before:

<img width="1839" height="921" alt="image" src="https://github.com/user-attachments/assets/935f045b-4631-4b61-a090-96e474ad0e94" />


After:

<img width="1839" height="921" alt="image" src="https://github.com/user-attachments/assets/7638902f-a7d4-47f2-834f-6f7d3a76aca8" />
