### PR TITLE
manifest: update hal_ti revision 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -270,7 +270,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: cc049020152585c4e968b83c084d230234b6d852
+      revision: b141deb61a34e257afa16381c5d25e2f3d56d5a5
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Update west manifest to point to the latest revision of the hal_ti repository which fixes an issue where MSPM0 directory were being unconditionally included in the build process.


Fixes: [](https://github.com/zephyrproject-rtos/zephyr/issues/102504)<https://github.com/zephyrproject-rtos/zephyr/issues/102504>

west pointer update for the hal_ti PR: 
(https://github.com/zephyrproject-rtos/hal_ti/pull/81)