### PR TITLE
drivers: ethernet: eth_nxp_enet: Support MAC address configuration

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -413,6 +413,7 @@ Ethernet
   * :dtcompatible:`litex,liteeth` (:github:`100620`)
   * :dtcompatible:`microchip,lan865x` (:github:`100318`)
   * :dtcompatible:`microchip,lan9250` (:github:`99127`)
+  * :dtcompatible:`nxp,enet-mac` (:github:`102775`)
   * :dtcompatible:`sensry,sy1xx-mac` (:github:`100619`)
   * :dtcompatible:`virtio,net` (:github:`100106`)
   * :dtcompatible:`vnd,ethernet` (:github:`96598`)

--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -16,6 +16,7 @@ config ETH_NXP_ENET
 	select ETH_DSA_SUPPORT_DEPRECATED
 	select PINCTRL
 	select HWINFO if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_ENET_MAC),$(DT_NXP_UNIQUE_MAC_PROP),True)
+	imply NVMEM if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_ENET_MAC),nvmem-cells)
 	help
 	  Enable NXP ENET Ethernet driver.
 

--- a/dts/bindings/ethernet/nxp,enet-mac.yaml
+++ b/dts/bindings/ethernet/nxp,enet-mac.yaml
@@ -34,3 +34,36 @@ properties:
     description: |
       Use the MAC address from fuse shadow register.
       Not all platforms have a fusable MAC address.
+
+      Deprecated, use an NVMEM cell instead, like in the example.
+
+examples:
+  - |
+    &enet_mac {
+            status = "okay";
+
+            pinctrl-0 = <&pinmux_enet>;
+            pinctrl-names = "default";
+
+            phy-handle = <&phy>;
+            phy-connection-type = "rmii";
+
+            nvmem-cells = <&mac_address0>;
+            nvmem-cell-names = "mac-address";
+    };
+
+    &ocotp {
+            status = "okay";
+
+            nvmem-layout {
+                    compatible = "fixed-layout";
+
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+
+                    mac_address0: mac-address@88 {
+                            reg = <0x88 0x6>;
+                            #nvmem-cell-cells = <0>;
+                    };
+            };
+    };


### PR DESCRIPTION
Add support for a MAC address from NVMEM memory.