### PR TITLE
MAINTAINERS: Add collaborators for Microchip SAM

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3451,6 +3451,10 @@ Microchip SAM Platforms:
     - nandojve
   collaborators:
     - ArunMCHP
+    - fabin-mchp
+    - Farsin-Nasar-Microchip
+    - mchp-asif
+    - sunil-abraham
     - stephanosio
   files:
     - boards/atmel/


### PR DESCRIPTION
1) Add mchp-asif (https://github.com/mchp-asif) as collaborator for Microchip SAM devices.
Contributions: See https://github.com/zephyrproject-rtos/zephyr/pulls/mchp-asif
2) Add Farsin-Nasar-Microchip (https://github.com/Farsin-Nasar-Microchip) as collaborator for Microchip SAM devices.
Contributions: See https://github.com/zephyrproject-rtos/zephyr/pulls/Farsin-Nasar-Microchip
3) Add fabin-mchp (https://github.com/fabin-mchp) as collaborator for Microchip SAM devices.
Contributions: See https://github.com/zephyrproject-rtos/zephyr/pulls/fabin-mchp
4) Add sunil-abraham (https://github.com/sunil-abraham) as collaborator for Microchip SAM devices.
Contributions: See https://github.com/zephyrproject-rtos/zephyr/pulls/sunil-abraham
