### PR TITLE
boards: nxp: lpcxpresso55s28: fix GPIO polarity for user LEDs

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
@@ -21,19 +21,19 @@
 		compatible = "gpio-leds";
 
 		green_led: led_1 {
-			gpios = <&gpio1 7 0>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 			status = "disabled";
 		};
 
 		blue_led: led_2 {
-			gpios = <&gpio1 4 0>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 			status = "disabled";
 		};
 
 		red_led: led_3 {
-			gpios = <&gpio1 6 0>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
 			status = "disabled";
 		};


### PR DESCRIPTION
All three user LEDs are active low. This fix aligns the definitions for the three user LEDs on the LPCXpresso55S28 with the identical LPCXpresso55S69 board.