### PR TITLE
doc: document bt_l2cap_chan_ops.seg_recv

### DIFF
--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -52,9 +52,10 @@ marked as processed by returning 0 or using
 :c:func:`bt_l2cap_chan_recv_complete` API if processing is asynchronous.
 
 For channels that support segmentation, the ``seg_recv`` callback can be
-provided in :c:struct:`bt_l2cap_chan_ops`. This callback is invoked when
-incoming L2CAP data is delivered in multiple segments. Each segment is
-passed to the application as it is received.
+provided in :c:struct:`bt_l2cap_chan_ops`. This callback is called for each
+received L2CAP segment. Each segment is passed to the application as it is
+received, regardless of whether the SDU fits in a single segment or spans
+multiple segments.
 
 The ``seg_recv`` callback allows applications to process large or streaming
 data incrementally without waiting for full reassembly. It is an alternative

--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -59,10 +59,11 @@ passed to the application as it is received.
 The ``seg_recv`` callback allows applications to process large or streaming
 data incrementally without waiting for full reassembly.
 
-The callback should return 0 when the segment has been handled successfully,
-or a negative error code on failure.
-
-
+Since :c:member:`bt_l2cap_chan_ops.seg_recv` is a ``void`` callback, it
+cannot report errors using a return value. If an unrecoverable error occurs
+while processing a segment, the application should handle it explicitly, for
+example by disconnecting the channel with
+:c:func:`bt_l2cap_chan_disconnect` or closing the underlying connection.
 .. note::
   The ``recv`` callback is called directly from RX Thread thus it is not
   recommended to block for long periods of time.

--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -51,6 +51,18 @@ whenever an incoming data has been received. Data received this way can be
 marked as processed by returning 0 or using
 :c:func:`bt_l2cap_chan_recv_complete` API if processing is asynchronous.
 
+For channels that support segmentation, the ``seg_recv`` callback can be
+provided in :c:struct:`bt_l2cap_chan_ops`. This callback is invoked when
+incoming L2CAP data is delivered in multiple segments. Each segment is
+passed to the application as it is received.
+
+The ``seg_recv`` callback allows applications to process large or streaming
+data incrementally without waiting for full reassembly.
+
+The callback should return 0 when the segment has been handled successfully,
+or a negative error code on failure.
+
+
 .. note::
   The ``recv`` callback is called directly from RX Thread thus it is not
   recommended to block for long periods of time.

--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -57,8 +57,14 @@ incoming L2CAP data is delivered in multiple segments. Each segment is
 passed to the application as it is received.
 
 The ``seg_recv`` callback allows applications to process large or streaming
-data incrementally without waiting for full reassembly.
+data incrementally without waiting for full reassembly. It is an alternative
+to the ``recv`` callback, and both must not be used at the same time on the
+same channel instance.
 
+When using ``seg_recv``, the application is responsible for managing flow
+control explicitly by giving credits to the channel, for example with
+:c:func:`bt_l2cap_chan_give_credits`. Failing to grant sufficient credits
+will prevent further segments from being delivered.
 Since :c:member:`bt_l2cap_chan_ops.seg_recv` is a ``void`` callback, it
 cannot report errors using a return value. If an unrecoverable error occurs
 while processing a segment, the application should handle it explicitly, for

--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -68,9 +68,9 @@ control explicitly by giving credits to the channel, for example with
 will prevent further segments from being delivered.
 Since :c:member:`bt_l2cap_chan_ops.seg_recv` is a ``void`` callback, it
 cannot report errors using a return value. If an unrecoverable error occurs
-while processing a segment, the application should handle it explicitly, for
-example by disconnecting the channel with
-:c:func:`bt_l2cap_chan_disconnect` or closing the underlying connection.
+When using ``seg_recv``, the application should handle unrecoverable errors
+explicitly, for example by triggering a channel disconnect using
+:c:func:`bt_l2cap_chan_disconnect`, potentially deferred outside the callback.
 .. note::
   The ``recv`` callback is called directly from RX Thread thus it is not
   recommended to block for long periods of time.


### PR DESCRIPTION
Fixes #102726

This PR adds documentation for the bt_l2cap_chan_ops.seg_recv callback,
explaining when it is invoked and how it can be used to process segmented
L2CAP data.
