### PR TITLE
[sysbuild] Improve image build target handling

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3352,6 +3352,8 @@ function(zephyr_scope_exists result scope)
   get_property(scope_defined GLOBAL PROPERTY scope:${scope})
   if(scope_defined)
     set(${result} TRUE PARENT_SCOPE)
+  elseif(scope STREQUAL cache)
+    set(${result} TRUE PARENT_SCOPE)
   else()
     set(${result} FALSE PARENT_SCOPE)
   endif()
@@ -3362,6 +3364,9 @@ endfunction()
 #
 # Get the current value of <var> in a specific <scope>, as defined by a
 # previous zephyr_set() call. The value will be stored in the <output> var.
+#
+# Note: the scope `cache` will return the CMake cache value of the variable set
+#       in current CMake run. (cache values from earlier runs are ignored).
 #
 # <output> : Variable to store the value in
 # <scope>  : Scope for the variable look up
@@ -3388,6 +3393,9 @@ endfunction()
 # scope. The scope is used on later zephyr_get() invocation for precedence
 # handling when a variable it set in multiple scopes.
 #
+# Note: the scope `cache` sets the CMake cache value of the variable but cache
+#       values from earlier CMake runs are ignored.
+#
 # <variable>   : Name of variable
 # <value>      : Value of variable, multiple values will create a list.
 #                The SCOPE argument identifies the end of value list.
@@ -3411,6 +3419,11 @@ function(zephyr_set variable)
   set_property(GLOBAL ${property_args} PROPERTY
                ${SET_VAR_SCOPE}_scope:${variable} ${SET_VAR_UNPARSED_ARGUMENTS}
   )
+
+  if(SET_VAR_SCOPE STREQUAL cache)
+    zephyr_get_scoped(value ${SET_VAR_SCOPE} ${variable})
+    set(${variable} "${value}" CACHE INTERNAL "")
+  endif()
 endfunction()
 
 # Usage:

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1876,6 +1876,30 @@ function(zephyr_blobs_verify)
   endif()
 endfunction()
 
+#
+# Usage:
+#   zephyr_custom_target_shared(<arguments>)
+#
+# Extension function of add_custom_command().
+#
+# The purpose of this function is to add the custom target to a CMake cache `ZEPHYR_SHARED_TARGETS`
+# list of targets.
+# The list of targets provides a possibility for external tools or build system to fetch important
+# build targets expected to be available to users.
+#
+# For example, Sysbuild will use this list for making build targets available to the user for the
+# image.
+#
+# All arguments to this function is passed to CMake add_custom_command() function as-is.
+#
+# Arguments:
+#  - See `add_custom_target` documentation
+#
+macro(zephyr_custom_target_shared)
+  add_custom_target(${ARGN})
+
+  zephyr_set(ZEPHYR_SHARED_TARGETS ${ARGV0} SCOPE cache APPEND)
+endmacro()
 ########################################################
 # 2. Kconfig-aware extensions
 ########################################################

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -203,7 +203,7 @@ foreach(kconfig_target
     ${KCONFIG_TARGETS}
     ${EXTRA_KCONFIG_TARGETS}
     )
-  add_custom_target(
+  zephyr_custom_target_shared(
     ${kconfig_target}
     ${CMAKE_COMMAND} -E env
     ZEPHYR_BASE=${ZEPHYR_BASE}

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -339,24 +339,6 @@ function(ExternalZephyrProject_Add)
     endif()
   endforeach()
 
-  foreach(kconfig_target
-      menuconfig
-      hardenconfig
-      guiconfig
-      $CACHE{EXTRA_KCONFIG_TARGETS}
-      )
-
-    if(NOT ZBUILD_APP_TYPE STREQUAL "MAIN")
-      set(image_prefix "${ZBUILD_APPLICATION}_")
-    endif()
-
-    add_custom_target(${image_prefix}${kconfig_target}
-      ${CMAKE_MAKE_PROGRAM} ${kconfig_target}
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}
-      USES_TERMINAL
-      )
-  endforeach()
-
   set(list_separator ",")
   set(image_extra_kconfig_targets "-DEXTRA_KCONFIG_TARGETS=$CACHE{EXTRA_KCONFIG_TARGETS}")
   string(REPLACE ";" "${list_separator}" image_extra_kconfig_targets "${image_extra_kconfig_targets}")
@@ -544,6 +526,25 @@ function(ExternalZephyrProject_Cmake)
                     BYPRODUCTS ${${ZCMAKE_APPLICATION}_byproducts}
                     DEPENDS ${ZCMAKE_APPLICATION}
   )
+
+  get_target_property(${ZCMAKE_APPLICATION}_shared_targets
+    ${ZCMAKE_APPLICATION}_cache
+    ZEPHYR_SHARED_TARGETS
+  )
+
+  get_target_property(${ZCMAKE_APPLICATION}_MAIN_APP ${ZCMAKE_APPLICATION} MAIN_APP)
+  foreach(shared_target ${${ZCMAKE_APPLICATION}_shared_targets})
+    if(NOT ${ZCMAKE_APPLICATION}_MAIN_APP)
+      set(image_prefix "${ZCMAKE_APPLICATION}_")
+    endif()
+
+    add_custom_target(${image_prefix}${shared_target}
+      ${CMAKE_MAKE_PROGRAM} ${shared_target}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${ZCMAKE_APPLICATION}
+      USES_TERMINAL
+    )
+  endforeach()
+
 endfunction()
 
 # Usage:


### PR DESCRIPTION
Introduce `zephyr_custom_target_shared()` which allows a Zephyr image to mark a custom target to be shared (re-exported) as a build target in sysbuild.

This will make it easier to have a custom build target from an image build made available by sysbuild.

Also it will avoid making a build target available in sysbuild when there is no corresponding target available in the included image.

Finally, it remove the need for maintaining a list of image  targets in sysbuild itself.