### PR TITLE
Bluetooth: BAP: Broadcast: Add missing NULL check for meta

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -1088,8 +1088,11 @@ int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *sour
 	 */
 	SYS_SLIST_FOR_EACH_CONTAINER(&source->subgroups, subgroup, _node) {
 		memset(subgroup->codec_cfg->meta, 0, sizeof(subgroup->codec_cfg->meta));
-		memcpy(subgroup->codec_cfg->meta, meta, meta_len);
-		subgroup->codec_cfg->meta_len = meta_len;
+
+		if (meta != NULL) {
+			(void)memcpy(subgroup->codec_cfg->meta, meta, meta_len);
+		}
+		subgroup->codec_cfg->meta_len = meta_len; /* may be 0 */
 	}
 
 	return 0;


### PR DESCRIPTION
`meta` may be NULL if `meta_len == 0`, in which case we should not call `memcpy`.