### PR TITLE
Re-send mDNS announcements with DHCPv4

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -546,6 +546,11 @@ struct dns_resolve_context {
 	/** DNS packet forwarding callback. */
 	dns_resolve_pkt_fw_cb_t pkt_fw_cb;
 #endif /* CONFIG_DNS_RESOLVER_PACKET_FORWARDING */
+
+/** @cond INTERNAL_HIDDEN */
+	/** How many times the DNS context init been called. */
+	int init_called;
+/** @endcond */
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/subsys/net/ip/ipv4.h
+++ b/subsys/net/ip/ipv4.h
@@ -450,7 +450,16 @@ int net_ipv4_acd_start(struct net_if *iface, struct net_if_addr *ifaddr);
  * @param iface Network interface the address belongs to.
  * @param ifaddr IPv4 address to probe.
  */
+#if defined(CONFIG_NET_IPV4_ACD)
 void net_ipv4_acd_cancel(struct net_if *iface, struct net_if_addr *ifaddr);
+#else
+static inline void net_ipv4_acd_cancel(struct net_if *iface,
+				       struct net_if_addr *ifaddr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ifaddr);
+}
+#endif /* CONFIG_NET_IPV4_ACD */
 
 /**
  * @brief Notify no conflict was detected for an IPv4 address.

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4534,7 +4534,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_addr_ipv4 *cur;
 	struct net_if_ipv4 *ipv4;
-	bool do_acd = false;
+	bool do_acd = false, override = false;
 	int idx;
 
 	net_if_lock(iface);
@@ -4567,6 +4567,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 		    && cur->ipv4.addr_type == NET_ADDR_OVERRIDABLE) {
 			ifaddr = &cur->ipv4;
 			idx = i;
+			override = true;
 			break;
 		}
 
@@ -4578,6 +4579,21 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	}
 
 	if (ifaddr) {
+		/* If we are overriding an existing address, remember to cancel
+		 * acd and send del event. Without these, mDNS announcement will
+		 * send also the old address that is no longer in use.
+		 */
+		if (override) {
+			/* But do not send address removal if the address is the same */
+			if (!net_ipv4_addr_cmp(&ifaddr->address.in_addr, addr)) {
+				net_ipv4_acd_cancel(iface, ifaddr);
+				net_mgmt_event_notify_with_info(NET_EVENT_IPV4_ADDR_DEL,
+								iface,
+								&ifaddr->address.in_addr,
+								sizeof(struct net_in_addr));
+			}
+		}
+
 		ifaddr->is_used = true;
 		ifaddr->is_added = true;
 		ifaddr->address.family = NET_AF_INET;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5419,9 +5419,7 @@ static void remove_ipv4_ifaddr(struct net_if *iface,
 		goto out;
 	}
 
-#if defined(CONFIG_NET_IPV4_ACD)
 	net_ipv4_acd_cancel(iface, ifaddr);
-#endif
 
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_ADDR_DEL,
 					iface,

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -726,6 +726,7 @@ static int add_address(struct net_if *iface, net_sa_family_t family,
 		}
 
 		if (memcmp(&mon_if[j].addr.in_addr, address, expected_len) == 0) {
+			mon_if[j].in_use = true;
 			return -EALREADY;
 		}
 	}


### PR DESCRIPTION
This is related to the way mDNS works if DHCPv4 is enabled. It might happen that we do not announce the proper IPv4 address if DHCPv4 address bound event comes after we have already sent the mDNS announcement.
Change this so that we re-send the mDNS announcement after IPv4 address is being set.
Other implementation alternative could be to wait for the DHCPv4 bound event before sending the announcement. The problem with this is that the mDNS and DHCPv4 are separate entities and we do not have control how the application is enabling DHCPv4 and mDNS for a given network interface.

Fixes #102718
