### PR TITLE
scripts: kconfig: Fix dt_chosen_partition_addr function

### DIFF
--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuflpr.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuflpr.dts
@@ -34,6 +34,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuflpr.dts
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuflpr.dts
@@ -34,6 +34,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -38,6 +38,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.dts
@@ -30,6 +30,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuflpr.dts
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuflpr.dts
@@ -33,6 +33,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuflpr.dts
+++ b/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuflpr.dts
@@ -34,6 +34,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuflpr.dts
@@ -31,6 +31,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuflpr.dts
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuflpr.dts
@@ -33,9 +33,9 @@
 &cpuflpr_rram {
 	partitions {
 		compatible = "fixed-partitions";
-
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/dts/vendor/nordic/nrf54l05.dtsi
+++ b/dts/vendor/nordic/nrf54l05.dtsi
@@ -33,6 +33,9 @@
 	cpuflpr_rram: rram@75800 {
 		compatible = "soc-nv-flash";
 		reg = <0x75800 DT_SIZE_K(30)>;
+		ranges = <0x0 0x75800 DT_SIZE_K(30)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		erase-block-size = <4096>;
 		write-block-size = <16>;
 	};

--- a/dts/vendor/nordic/nrf54l10.dtsi
+++ b/dts/vendor/nordic/nrf54l10.dtsi
@@ -33,6 +33,9 @@
 	cpuflpr_rram: rram@ed800 {
 		compatible = "soc-nv-flash";
 		reg = <0xed800 DT_SIZE_K(62)>;
+		ranges = <0x0 0xed800 DT_SIZE_K(62)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		erase-block-size = <4096>;
 		write-block-size = <16>;
 	};

--- a/dts/vendor/nordic/nrf54l15.dtsi
+++ b/dts/vendor/nordic/nrf54l15.dtsi
@@ -33,6 +33,9 @@
 	cpuflpr_rram: rram@165000 {
 		compatible = "soc-nv-flash";
 		reg = <0x165000 DT_SIZE_K(96)>;
+		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		erase-block-size = <4096>;
 		write-block-size = <16>;
 	};

--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -863,19 +863,35 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+#ifdef USE_NON_SECURE_ADDRESS_MAP
 			cpuapp_rram: rram@0 {
 				compatible = "soc-nv-flash";
 				reg = <0x0 DT_SIZE_K(2036)>;
+				ranges = <0x0 0x0 DT_SIZE_K(2036)>;
 				erase-block-size = <4096>;
 				write-block-size = <16>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+#else
+			cpuapp_rram: rram@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x0 DT_SIZE_K(1940)>;
+				ranges = <0x0 0x0 DT_SIZE_K(1940)>;
+				erase-block-size = <4096>;
+				write-block-size = <16>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
-#ifndef USE_NON_SECURE_ADDRESS_MAP
 			cpuflpr_rram: rram@1e5000 {
 				compatible = "soc-nv-flash";
 				reg = <0x1e5000 DT_SIZE_K(96)>;
+				ranges = <0x0 0x1e5000 DT_SIZE_K(96)>;
 				erase-block-size = <4096>;
 				write-block-size = <16>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 #endif
 		};

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -192,6 +192,16 @@ def _node_reg_addr(node, index, unit):
     return node.regs[int(index)].addr >> _dt_units_to_scale(unit)
 
 
+def _node_unit_addr(node, unit):
+    if not node:
+        return 0
+
+    if not node.unit_addr:
+        return 0
+
+    return node.unit_addr >> _dt_units_to_scale(unit)
+
+
 def _node_reg_addr_by_name(node, name, unit):
     if not node:
         return 0
@@ -374,13 +384,10 @@ def dt_chosen_reg(kconf, name, chosen, index=0, unit=None):
         return hex(_dt_chosen_reg_addr(kconf, chosen, index, unit))
 
 
-def _dt_chosen_partition_addr(kconf, chosen, index=0, unit=None):
+def _dt_chosen_partition_addr(kconf, chosen, unit=None):
     """
-    This function takes a 'chosen' property and treats that property as a path
-    to an EDT node.  If it finds an EDT node, it will look to see if that
-    node has a register, and if that node has a grandparent that has a register
-    at the given 'index'. The addition of both addresses will be returned, if
-    not, we return 0.
+    This function takes a 'chosen' property and treats that property as a path to an EDT node.
+    If it finds an EDT node, it will return the unit address of that node, and if not, we return 0.
 
     The function will divide the value based on 'unit':
         None        No division
@@ -395,25 +402,19 @@ def _dt_chosen_partition_addr(kconf, chosen, index=0, unit=None):
         return 0
 
     node = edt.chosen_node(chosen)
-    if not node:
-        return 0
 
-    p_node = node.parent
-    if not p_node:
-        return 0
-
-    return _node_reg_addr(p_node.parent, index, unit) + _node_reg_addr(node, 0, unit)
+    return _node_unit_addr(node, unit)
 
 
 def dt_chosen_partition_addr(kconf, name, chosen, index=0, unit=None):
     """
     This function just routes to the proper function and converts
-    the result to either a string int or string hex value.
+    the result to either a string int or string hex value. The index value is not used.
     """
     if name == "dt_chosen_partition_addr_int":
-        return str(_dt_chosen_partition_addr(kconf, chosen, index, unit))
+        return str(_dt_chosen_partition_addr(kconf, chosen, unit))
     if name == "dt_chosen_partition_addr_hex":
-        return hex(_dt_chosen_partition_addr(kconf, chosen, index, unit))
+        return hex(_dt_chosen_partition_addr(kconf, chosen, unit))
 
 
 def _dt_node_reg_addr(kconf, path, index=0, unit=None):

--- a/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr-xip/soc/nrf54l15_cpuapp.overlay
@@ -3,17 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			cpuflpr_code_partition: image@165000 {
-				/* FLPR core code partition */
-				reg = <0x165000 DT_SIZE_K(96)>;
-			};
-		};
+&rram_controller {
+	cpuflpr_rram: rram@165000 {
+		compatible = "soc-nv-flash";
+		reg = <0x165000 DT_SIZE_K(96)>;
+		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		erase-block-size = <0x1000>;
+		write-block-size = <0x10>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };
 
@@ -22,7 +20,7 @@
 };
 
 &cpuflpr_vpr {
-	execution-memory = <&cpuflpr_code_partition>;
+	execution-memory = <&cpuflpr_rram>;
 };
 
 &cpuapp_vevif_tx {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
@@ -5,22 +5,13 @@
 
 / {
 	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			cpuflpr_code_partition: image@165000 {
-				/* FLPR core code partition */
-				reg = <0x165000 DT_SIZE_K(96)>;
-			};
-		};
-
 		cpuflpr_sram_code_data: memory@20028000 {
 			compatible = "mmio-sram";
 			reg = <0x20028000 DT_SIZE_K(96)>;
+			ranges = <0x0 0x20028000 0x18000>;
+			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20028000 0x18000>;
 		};
 	};
 };
@@ -34,9 +25,21 @@
 	ranges = <0x0 0x20000000 0x28000>;
 };
 
+&rram_controller {
+	cpuflpr_rram: rram@165000 {
+		compatible = "soc-nv-flash";
+		reg = <0x165000 DT_SIZE_K(96)>;
+		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		erase-block-size = <0x1000>;
+		write-block-size = <0x10>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
 &cpuflpr_vpr {
 	execution-memory = <&cpuflpr_sram_code_data>;
-	source-memory = <&cpuflpr_code_partition>;
+	source-memory = <&cpuflpr_rram>;
 };
 
 &cpuapp_vevif_tx {

--- a/snippets/nordic/nordic-flpr/soc/nrf54lm20a_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54lm20a_cpuapp.overlay
@@ -5,22 +5,13 @@
 
 / {
 	soc {
-		reserved-memory {
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			cpuflpr_code_partition: image@1e5000 {
-				/* FLPR core code partition */
-				reg = <0x1e5000 DT_SIZE_K(96)>;
-			};
-		};
-
 		cpuflpr_sram_code_data: memory@20067c00 {
 			compatible = "mmio-sram";
 			reg = <0x20067c00 DT_SIZE_K(96)>;
+			ranges = <0x0 0x20067c00 0x18000>;
+			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20067c00 DT_SIZE_K(96)>;
 		};
 	};
 };
@@ -30,13 +21,25 @@
 	ranges = <0x0 0x20000000 DT_SIZE_K(415)>;
 };
 
+&rram_controller {
+	cpuflpr_rram: rram@1e5000 {
+		compatible = "soc-nv-flash";
+		reg = <0x1e5000 DT_SIZE_K(96)>;
+		ranges = <0x0 0x1e5000 DT_SIZE_K(96)>;
+		erase-block-size = <0x1000>;
+		write-block-size = <0x10>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
 &uart30 {
 	status = "reserved";
 };
 
 &cpuflpr_vpr {
 	execution-memory = <&cpuflpr_sram_code_data>;
-	source-memory = <&cpuflpr_code_partition>;
+	source-memory = <&cpuflpr_rram>;
 };
 
 &cpuapp_vevif_tx {

--- a/soc/nordic/validate_rram_partitions.c
+++ b/soc/nordic/validate_rram_partitions.c
@@ -43,7 +43,6 @@
 
 /* clang-format off */
 
-#define RRAM_BASE REG_ADDR_NS(DT_CHOSEN(zephyr_flash))
 #define RRAM_CONTROLLER DT_NODELABEL(rram_controller)
 
 #if !DT_NODE_EXISTS(RRAM_CONTROLLER)
@@ -56,9 +55,9 @@
 			" (required for all children of " DT_NODE_PATH(RRAM_CONTROLLER) ")")
 
 #define CHECK_RRAM_PARTITION_WITHIN_PARENT(node_id)                                            \
-	BUILD_ASSERT(RRAM_BASE + REG_ADDR_NS(node_id) >= REG_ADDR_NS(DT_GPARENT(node_id)) && \
-			RRAM_BASE + REG_END_NS(node_id) <= REG_END_NS(DT_GPARENT(node_id)),      \
-			DT_NODE_FULL_NAME(node_id) " is not fully contained within its parent "  \
+	BUILD_ASSERT(REG_ADDR_NS(node_id) >= REG_ADDR_NS(DT_GPARENT(node_id)) && \
+			REG_END_NS(node_id) <= REG_END_NS(DT_GPARENT(node_id)), \
+			DT_NODE_FULL_NAME(node_id) " is not fully contained within its parent " \
 			DT_NODE_PATH(DT_GPARENT(node_id)))
 
 #define CHECK_NODES_NON_OVERLAPPING(node_id_1, node_id_2)                                \

--- a/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -6,6 +6,7 @@
 
 &cpuflpr_rram {
 	reg = <0x15D000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x15D000 DT_SIZE_K(128)>;
 };
 
 &cpuflpr_code_partition {


### PR DESCRIPTION
Fixes this function so that it returns the unit address of the node, without having to rely on odd tricks to locate various parent nodes and check that they have reg addresses and perform additions