### PR TITLE
boards: st: nucleo_c071rb: add jlink runner

### DIFF
--- a/boards/st/nucleo_c071rb/board.cmake
+++ b/boards/st/nucleo_c071rb/board.cmake
@@ -2,8 +2,10 @@
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+board_runner_args(jlink "--device=STM32C071RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_c071rb/doc/index.rst
+++ b/boards/st/nucleo_c071rb/doc/index.rst
@@ -95,6 +95,13 @@ Flashing
 The board is configured to be flashed using west `STM32CubeProgrammer`_ runner,
 so its :ref:`installation <stm32cubeprog-flash-host-tools>` is required.
 
+Alternatively, an external JLink can also be used to flash the board using
+the ``--runner`` (or ``-r``) option:
+
+.. code-block:: console
+
+   $ west flash --runner jlink
+
 Flashing an application to Nucleo C071RB
 ----------------------------------------
 


### PR DESCRIPTION
add jlink as a runner to the nucleo_c071rb board.

It's tested, works perfectly.