### PR TITLE
[Backport v3.7-branch] drivers: gpio: mcux: Fix updating ICR registers without IRQ lock

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -274,6 +274,10 @@ static int mcux_igpio_pin_interrupt_configure(const struct device *dev,
 	uint8_t icr;
 	int shift;
 
+	if (pin >= 32) {
+		return -EINVAL;
+	}
+
 	if (mode == GPIO_INT_MODE_DISABLED) {
 		key = irq_lock();
 
@@ -296,17 +300,15 @@ static int mcux_igpio_pin_interrupt_configure(const struct device *dev,
 		icr = 0;
 	}
 
+	key = irq_lock();
+
 	if (pin < 16) {
 		shift = 2 * pin;
 		base->ICR1 = (base->ICR1 & ~(3 << shift)) | (icr << shift);
-	} else if (pin < 32) {
+	} else {
 		shift = 2 * (pin - 16);
 		base->ICR2 = (base->ICR2 & ~(3 << shift)) | (icr << shift);
-	} else {
-		return -EINVAL;
 	}
-
-	key = irq_lock();
 
 	WRITE_BIT(base->EDGE_SEL, pin, trig == GPIO_INT_TRIG_BOTH);
 	WRITE_BIT(base->ISR, pin, 1);


### PR DESCRIPTION
Backport 8402a4f8e5b49c09f65bbfb7d93164375eceaf4b from #102630.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102635
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102800