### PR TITLE
dts: bindings: Move the dts clips to examples 

### DIFF
--- a/dts/bindings/firmware/arm,scmi.yaml
+++ b/dts/bindings/firmware/arm,scmi.yaml
@@ -5,43 +5,6 @@ description: |
         SCMI (System Control and Management Interface) with doorbell
         and SHMEM (shared memory) transport.
 
-        Devicetree example:
-            #include <mem.h>
-
-            scmi_res0: memory@44611000 {
-                compatible = "arm,scmi-shmem";
-                reg = <0x44611000 0x80>;
-            };
-
-            mu5: mailbox@44610000 {
-                compatible = "nxp,mbox-imx-mu";
-                reg = <0x44610000 DT_SIZE_K(4)>;
-                interrupts = <205 0>;
-                #mbox-cells = <1>;
-            };
-
-            scmi {
-                compatible = "arm,scmi";
-                shmem = <&scmi_res0>;
-                mboxes = <&mu5 0>;
-                mbox-names = "tx";
-
-                protocol@14 {
-                    compatible = "arm,scmi-clock";
-                    reg = <0x14>;
-                    #clock-cells = <1>;
-                };
-
-                protocol@19 {
-                    compatible = "arm,scmi-pinctrl";
-                    reg = <0x19>;
-
-                    pinctrl {
-                        compatible = "nxp,imx95-pinctrl", "nxp,imx93-pinctrl";
-                    };
-                };
-            };
-
 compatible: "arm,scmi"
 
 include: [base.yaml]
@@ -66,3 +29,41 @@ properties:
   mbox-names:
     required: true
     description: mailbox channel specifier names
+
+examples:
+  - |
+    #include <mem.h>
+
+    scmi_res0: memory@44611000 {
+        compatible = "arm,scmi-shmem";
+        reg = <0x44611000 0x80>;
+    };
+
+    mu5: mailbox@44610000 {
+        compatible = "nxp,mbox-imx-mu";
+        reg = <0x44610000 DT_SIZE_K(4)>;
+        interrupts = <205 0>;
+        #mbox-cells = <1>;
+    };
+
+    scmi {
+        compatible = "arm,scmi";
+        shmem = <&scmi_res0>;
+        mboxes = <&mu5 0>;
+        mbox-names = "tx";
+
+        protocol@14 {
+            compatible = "arm,scmi-clock";
+            reg = <0x14>;
+            #clock-cells = <1>;
+        };
+
+        protocol@19 {
+            compatible = "arm,scmi-pinctrl";
+            reg = <0x19>;
+
+            pinctrl {
+                compatible = "nxp,imx95-pinctrl", "nxp,imx93-pinctrl";
+            };
+        };
+    };

--- a/dts/bindings/flash_controller/adi,max32-spixf-nor.yaml
+++ b/dts/bindings/flash_controller/adi,max32-spixf-nor.yaml
@@ -4,19 +4,6 @@
 description: |
     MAX32 SPIXF NOR Flash controller supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a SPIXF bus:
-
-        mx25u64: mx25u6432f@0 {
-            compatible = "adi,max32-spixf-nor";
-            reg = <0x0 DT_SIZE_M(8)>; /* 64 Mbits */
-            qspi-max-frequency = <80000000>;
-            jedec-id = [c2 37 25];
-            reset-cmd;
-            spi-bus-width = <4>;
-            writeoc = "PP_1_1_4";
-            status = "okay";
-        };
-
 compatible: "adi,max32-spixf-nor"
 
 include: ["flash-controller.yaml", "jedec,jesd216.yaml", "jedec,spi-nor-common.yaml"]
@@ -79,3 +66,16 @@ properties:
       The number of dummy-cycles required when reading jedec id. Default value is zero, which
       matches most parts, but this can be set for parts that require any dummy bytes before the
       response is sent.
+
+examples:
+  - |
+    mx25u64: mx25u6432f@0 {
+        compatible = "adi,max32-spixf-nor";
+        reg = <0x0 DT_SIZE_M(8)>; /* 64 Mbits */
+        qspi-max-frequency = <80000000>;
+        jedec-id = [c2 37 25];
+        reset-cmd;
+        spi-bus-width = <4>;
+        writeoc = "PP_1_1_4";
+        status = "okay";
+    };

--- a/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
+++ b/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
@@ -4,19 +4,6 @@
 description: |
     The SPI NOR flash devices accessed by Nuvoton Flash Interface Unit (FIU).
 
-    Representation of a SPI NOR flash on a qspi bus looks like:
-
-      int_flash: w25q40@0 {
-            compatible ="nuvoton,npcx-fiu-nor";
-            size = <DT_SIZE_K(512 * 8)>;
-            reg = <0>;
-
-            qspi-flags = <NPCX_QSPI_SW_CS1>;
-            mapped-addr = <0x64000000>;
-            pinctrl-0 = <&int_flash_sl>;
-            pinctrl-names = "default";
-      };
-
 compatible: "nuvoton,npcx-fiu-nor"
 
 include: [flash-controller.yaml, pinctrl-device.yaml, "jedec,spi-nor-common.yaml"]
@@ -61,3 +48,15 @@ properties:
       - "NPCX_SPI_DEV_SIZE_32M"
       - "NPCX_SPI_DEV_SIZE_64M"
       - "NPCX_SPI_DEV_SIZE_128M"
+
+examples:
+  - |
+    int_flash: w25q40@0 {
+        compatible ="nuvoton,npcx-fiu-nor";
+        size = <DT_SIZE_K(512 * 8)>;
+        reg = <0>;
+        qspi-flags = <NPCX_QSPI_SW_CS1>;
+        mapped-addr = <0x64000000>;
+        pinctrl-0 = <&int_flash_sl>;
+        pinctrl-names = "default";
+    };

--- a/dts/bindings/flash_controller/nuvoton,npcx-fiu-qspi.yaml
+++ b/dts/bindings/flash_controller/nuvoton,npcx-fiu-qspi.yaml
@@ -3,25 +3,6 @@
 
 description: |
     Properties defining the NPCX Quad-SPI peripheral of Flash Interface Unit (FIU).
-    A npcx quad-spi dt node would typically looks like:
-
-        &qspi_fiu0 {
-            status = "okay";
-
-            int_flash: w25q400@0 {
-                status = "okay";
-                reg = <0>;
-                ...
-            };
-
-            ext_flash: w25q256@1 {
-                status = "okay";
-                reg = <1>;
-                ...
-            };
-        };
-
-    `int_flash` and `ext_flash` are the devices accessed by this peripheral.
 
 compatible: "nuvoton,npcx-fiu-qspi"
 
@@ -58,3 +39,21 @@ properties:
     type: boolean
     description: |
       This option enables the FIU support for NPCKn V1.
+
+examples:
+  - |
+    &qspi_fiu0 {
+        status = "okay";
+
+        int_flash: w25q400@0 {
+            status = "okay";
+            reg = <0>;
+            /* ... */
+        };
+
+        ext_flash: w25q256@1 {
+            status = "okay";
+            reg = <1>;
+            /* ... */
+        };
+    };

--- a/dts/bindings/flash_controller/renesas,rz-qspi-spibsc.yaml
+++ b/dts/bindings/flash_controller/renesas,rz-qspi-spibsc.yaml
@@ -4,16 +4,6 @@
 description: |
     Renesas RZ SPIBSC NOR FLASH supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a quadspi bus:
-
-      at25ql128a: qspi-nor-flash@20000000 {
-        compatible = "renesas,rz-qspi-spibsc";
-        reg = <0x20000000 DT_SIZE_M(16)>; /* 128 Mbits */
-        write-block-size = <1>;
-        erase-block-size = <4096>;
-        status = "okay";
-      };
-
 compatible: "renesas,rz-qspi-spibsc"
 
 include: ["flash-controller.yaml", "jedec,jesd216.yaml"]
@@ -34,3 +24,13 @@ properties:
     type: int
     default: 1
     description: Address alignment required by flash write operations
+
+examples:
+  - |
+    at25ql128a: qspi-nor-flash@20000000 {
+        compatible = "renesas,rz-qspi-spibsc";
+        reg = <0x20000000 DT_SIZE_M(16)>; /* 128 Mbits */
+        write-block-size = <1>;
+        erase-block-size = <4096>;
+        status = "okay";
+    };

--- a/dts/bindings/flash_controller/renesas,rz-qspi-xspi.yaml
+++ b/dts/bindings/flash_controller/renesas,rz-qspi-xspi.yaml
@@ -4,16 +4,6 @@
 description: |
     Renesas RZ XSPI NOR FLASH supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a quadspi bus:
-
-        mx25u51245g: qspi-nor-flash@60000000 {
-          compatible = "renesas,rz-qspi-xspi";
-          reg = <0x60000000 DT_SIZE_M(64)>; /* 512 Mbits */
-          write-block-size = <1>;
-          erase-block-size = <4096>;
-          status = "okay";
-        };
-
 compatible: "renesas,rz-qspi-xspi"
 
 include: ["flash-controller.yaml", "jedec,jesd216.yaml"]
@@ -34,3 +24,13 @@ properties:
     type: int
     default: 1
     description: Address alignment required by flash write operations
+
+examples:
+  - |
+    mx25u51245g: qspi-nor-flash@60000000 {
+        compatible = "renesas,rz-qspi-xspi";
+        reg = <0x60000000 DT_SIZE_M(64)>; /* 512 Mbits */
+        write-block-size = <1>;
+        erase-block-size = <4096>;
+        status = "okay";
+    };

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -4,18 +4,6 @@
 description: |
     STM32 OSPI Flash controller supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a octospi bus:
-
-        mx25lm51245: ospi-nor-flash@0 {
-                compatible = "st,stm32-ospi-nor";
-                reg = <0>;
-                size = <DT_SIZE_M(512)>; /* 512 Mbits */
-                data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
-                data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
-                ospi-max-frequency = <DT_FREQ_M(50)>;
-                status = "okay";
-        };
-
 compatible: "st,stm32-ospi-nor"
 
 include: ["flash-controller.yaml", "jedec,jesd216.yaml"]
@@ -118,3 +106,15 @@ properties:
       protection register that initializes to write-protected. Use this
       property to indicate that the BPR must be unlocked before write
       operations can proceed.
+
+examples:
+  - |
+    mx25lm51245: ospi-nor-flash@0 {
+        compatible = "st,stm32-ospi-nor";
+        reg = <0>;
+        size = <DT_SIZE_M(512)>; /* 512 Mbits */
+        data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
+        data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
+        ospi-max-frequency = <DT_FREQ_M(50)>;
+        status = "okay";
+    };

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -4,19 +4,6 @@
 description: |
     STM32 QSPI Flash controller supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a quadspi bus:
-
-        mx25r6435f: qspi-nor-flash@0 {
-                compatible = "st,stm32-qspi-nor";
-                reg = <0>;
-                size = <DT_SIZE_M(64)>; /* 64 Mbits */
-                qspi-max-frequency = <80000000>;
-                reset-gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
-                reset-gpios-duration = <1>;
-                spi-bus-width = <4>;
-                status = "okay";
-        };
-
 compatible: "st,stm32-qspi-nor"
 
 include: ["flash-controller.yaml", "jedec,jesd216.yaml"]
@@ -103,3 +90,16 @@ properties:
       suboptimal as it would reduce the throughput.
 
       Defaults to 8 clock cycles, which is the maximum supported value.
+
+examples:
+  - |
+    mx25r6435f: qspi-nor-flash@0 {
+        compatible = "st,stm32-qspi-nor";
+        reg = <0>;
+        size = <DT_SIZE_M(64)>; /* 64 Mbits */
+        qspi-max-frequency = <80000000>;
+        reset-gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
+        reset-gpios-duration = <1>;
+        spi-bus-width = <4>;
+        status = "okay";
+    };

--- a/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
@@ -4,18 +4,6 @@
 description: |
     STM32 XSPI Flash controller supporting the JEDEC CFI interface
 
-    Representation of a serial flash on a xspi bus:
-
-        mx25lm51245: xspi-nor-flash@0 {
-                compatible = "st,stm32-xspi-nor";
-                reg = <0>;
-                size = <DT_SIZE_M(512)>; /* 512 Mbits */
-                data-mode = <XSPI_OCTO_MODE>; /* access on 8 data lines */
-                data-rate = <XSPI_DTR_TRANSFER>; /* access in DTR */
-                ospi-max-frequency = <DT_FREQ_M(50)>;
-                status = "okay";
-        };
-
 compatible: "st,stm32-xspi-nor"
 
 include:
@@ -64,3 +52,15 @@ properties:
       - 2
     description: |
       Specifies which nCS line of the XSPI IO Manager is connected to the Flash.
+
+examples:
+  - |
+    mx25lm51245: xspi-nor-flash@0 {
+        compatible = "st,stm32-xspi-nor";
+        reg = <0>;
+        size = <DT_SIZE_M(512)>; /* 512 Mbits */
+        data-mode = <XSPI_OCTO_MODE>; /* access on 8 data lines */
+        data-rate = <XSPI_DTR_TRANSFER>; /* access in DTR */
+        ospi-max-frequency = <DT_FREQ_M(50)>;
+        status = "okay";
+    };


### PR DESCRIPTION
Move the dts sample nodes from the binding `description`
into  `examples` block.