### PR TITLE
doc: release: add entries in the release note for OTP subsystem and drivers

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -320,6 +320,11 @@ New Drivers
 
   * :dtcompatible:`solomon,ssd1325`
 
+* OTP
+
+  * Added new stm32 BSEC driver that provides means to program and read OTP fuses
+    (:dtcompatible:`st,stm32-bsec`). (:github:`102403`)
+
 New Samples
 ***********
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -218,6 +218,17 @@ New APIs and options
 
     * Add support for Wi-Fi Direct (P2P) mode.
 
+* OTP
+
+  * New OTP driver API providing means to provision (:c:func:`otp_program()`) and
+    read (:c:func:`otp_read()`) :abbr:`OTP(One Time Programmable)` memory devices
+    (:github:`101292`). OTP devices can also be accessed through the
+    :ref:`Non-Volatile Memory (NVMEM)<nvmem>` subsystem. Available options are:
+
+    * :kconfig:option:`CONFIG_OTP`
+    * :kconfig:option:`CONFIG_OTP_PROGRAM`
+    * :kconfig:option:`CONFIG_OTP_INIT_PRIORITY`
+
 * PWM
 
   * Extended API with PWM events


### PR DESCRIPTION
Add entry in the release note for the OTP subsystem and the stm32 BSEC driver