### PR TITLE
arch: arm: cortex_a_r: fix cache line size calculation

### DIFF
--- a/arch/arm/core/cortex_a_r/cache.c
+++ b/arch/arm/core/cortex_a_r/cache.c
@@ -40,7 +40,7 @@ size_t arch_dcache_line_size_get(void)
 		val = read_sysreg(ctr);
 		dminline = (val >> CTR_DMINLINE_SHIFT) & CTR_DMINLINE_MASK;
 		/* Log2 of the number of words */
-		dcache_line_size = 2 << dminline;
+		dcache_line_size = 4 << dminline;
 	}
 
 	return dcache_line_size;


### PR DESCRIPTION
Cortex-R5F Technical Reference Manual by Arm says DMINLINE is the Log2 of the minimum number of words (one word = four bytes) in a cache line.

For instance, say DMINLINE is 3, which means the cache line size is 2^3=8 words or 32 bytes, however with the current calculation, it comes out to be 16 bytes. Therefore, we fix this calculation by correctly calculating the number of bytes for the cache line size.

Related: https://github.com/zephyrproject-rtos/zephyr/issues/97513