### PR TITLE
samples: counter: alarm: add esp32h2 overlay

### DIFF
--- a/samples/drivers/counter/alarm/socs/esp32h2.overlay
+++ b/samples/drivers/counter/alarm/socs/esp32h2.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
add device tree overlay for esp32h2 to enable timer0 counter in the counter alarm sample.