### PR TITLE
net: mdns_responder/dns_sd: Include all IPv4/IPv6 addresses in responses 

### DIFF
--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -801,7 +801,7 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct net_in_a
 	rsp->arcount++;
 	offset += r;
 
-	if (addr6 != NULL) {
+	if (addr6 != NULL && !net_ipv6_is_addr_unspecified(addr6)) {
 		r = add_aaaa_record(inst, DNS_SD_AAAA_TTL, host_offset, addr6->s6_addr, buf, offset,
 				    buf_size - offset); /* LCOV_EXCL_LINE */
 		if (r < 0) {
@@ -812,7 +812,7 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct net_in_a
 		offset += r;
 	}
 
-	if (addr4 != NULL) {
+	if (addr4 != NULL && !net_ipv4_is_addr_unspecified(addr4)) {
 		tmp = net_htonl(*(addr4->s4_addr32));
 		r = add_a_record(inst, DNS_SD_A_TTL, host_offset, tmp, buf, offset,
 				 buf_size - offset);

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -569,6 +569,115 @@ int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	return offset - buf_offset;
 }
 
+struct answer_addr_ctx {
+	uint8_t *buf;
+	uint16_t buf_offset;
+	uint16_t buf_size;
+	union {
+		const struct net_in_addr *skip_addr4;
+		const struct net_in6_addr *skip_addr6;
+	};
+	int answer_count;
+	const struct dns_sd_rec *inst;
+	uint16_t host_offset;
+	enum dns_rr_type qtype;
+};
+
+static void answer_addr_cb(struct net_if *iface, struct net_if_addr *ifaddr,
+			   void *user_data)
+{
+	struct answer_addr_ctx *ctx = (struct answer_addr_ctx *)user_data;
+	int ret;
+
+	if (ifaddr->addr_state != NET_ADDR_PREFERRED &&
+	    ifaddr->addr_state != NET_ADDR_DEPRECATED) {
+		return;
+	}
+
+	if (ctx->qtype == DNS_RR_TYPE_AAAA) {
+		if (ctx->skip_addr6 != NULL &&
+		    net_ipv6_addr_cmp(&ifaddr->address.in6_addr, ctx->skip_addr6)) {
+			/* Already included */
+			return;
+		}
+
+		ret = add_aaaa_record(ctx->inst, DNS_SD_AAAA_TTL, ctx->host_offset,
+				      ifaddr->address.in6_addr.s6_addr,
+				      ctx->buf, ctx->buf_offset, ctx->buf_size);
+	} else {
+		if (ctx->skip_addr4 != NULL &&
+		    net_ipv4_addr_cmp(&ifaddr->address.in_addr, ctx->skip_addr4)) {
+			/* Already included */
+			return;
+		}
+
+		ret = add_a_record(ctx->inst, DNS_SD_A_TTL, ctx->host_offset,
+				   net_htonl(ifaddr->address.in_addr.s_addr),
+				   ctx->buf, ctx->buf_offset, ctx->buf_size);
+	}
+
+	if (ret > 0) {
+		ctx->buf_offset += ret;
+		ctx->buf_size -= ret;
+		ctx->answer_count++;
+	} else {
+		NET_DBG("Not enough buffer space to include additional A/AAAA record");
+	}
+}
+
+
+int add_remaining_a_records(struct net_if *iface, const struct dns_sd_rec *inst,
+			    uint16_t host_offset, const struct net_in_addr *addr4,
+			    uint8_t *buf, uint16_t *buf_offset, uint16_t buf_size)
+{
+	struct answer_addr_ctx ctx = {
+		.buf = buf,
+		.buf_offset = *buf_offset,
+		.buf_size = buf_size,
+		.skip_addr4 = addr4,
+		.answer_count = 0,
+		.inst = inst,
+		.host_offset = host_offset,
+		.qtype = DNS_RR_TYPE_A,
+	};
+
+	if (iface == NULL) {
+		return 0;
+	}
+
+	net_if_ipv4_addr_foreach(iface, answer_addr_cb, &ctx);
+
+	*buf_offset = ctx.buf_offset;
+
+	return ctx.answer_count;
+}
+
+int add_remaining_aaaa_records(struct net_if *iface, const struct dns_sd_rec *inst,
+			       uint16_t host_offset, const struct net_in6_addr *addr6,
+			       uint8_t *buf, uint16_t *buf_offset, uint16_t buf_size)
+{
+	struct answer_addr_ctx ctx = {
+		.buf = buf,
+		.buf_offset = *buf_offset,
+		.buf_size = buf_size,
+		.skip_addr6 = addr6,
+		.answer_count = 0,
+		.inst = inst,
+		.host_offset = host_offset,
+		.qtype = DNS_RR_TYPE_AAAA,
+	};
+
+	if (iface == NULL) {
+		return 0;
+	}
+
+	net_if_ipv6_addr_foreach(iface, answer_addr_cb, &ctx);
+
+	*buf_offset = ctx.buf_offset;
+
+	return ctx.answer_count;
+}
+
 int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		   uint16_t instance_offset, uint16_t domain_offset,
 		   uint8_t *buf, uint16_t buf_offset, uint16_t buf_size,
@@ -719,8 +828,9 @@ static inline bool port_in_use(uint16_t proto, uint16_t port, const struct net_i
 #endif /* CONFIG_NET_TEST */
 
 
-int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct net_in_addr *addr4,
-			    const struct net_in6_addr *addr6, uint8_t *buf, uint16_t buf_size)
+int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
+			    const struct net_in_addr *addr4, const struct net_in6_addr *addr6,
+			    uint8_t *buf, uint16_t buf_size)
 {
 	/*
 	 * RFC 6763 Section 12.1
@@ -822,6 +932,26 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct net_in_a
 
 		rsp->arcount++;
 		offset += r;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		/* Best effort here, include AAAA records for the remaining IPv6
+		 * addresses if they fit.
+		 */
+		r = add_remaining_aaaa_records(iface, inst, host_offset, addr6,
+					       buf, &offset, buf_size - offset);
+		/* offset was updated inside the function */
+		rsp->arcount += r;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		/* Best effort here, include A records for the remaining IPv4
+		 * addresses if they fit.
+		 */
+		r = add_remaining_a_records(iface, inst, host_offset, addr4,
+					    buf, &offset, buf_size - offset);
+		/* offset was updated inside the function */
+		rsp->arcount += r;
 	}
 
 	/* Set the Response and AA bits */

--- a/subsys/net/lib/dns/dns_sd.h
+++ b/subsys/net/lib/dns/dns_sd.h
@@ -127,6 +127,7 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
  * If there is no IPv6 address to advertise, then @p addr6 should be
  * NULL.
  *
+ * @param iface the network interface the query was received on
  * @param inst the DNS-SD record to advertise
  * @param addr4 pointer to the IPv4 address
  * @param addr6 pointer to the IPv6 address
@@ -136,7 +137,7 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
  * @return on success, number of bytes written to @p buf
  * @return on failure, a negative errno value
  */
-int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst,
+int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 	const struct net_in_addr *addr4, const struct net_in6_addr *addr6,
 	uint8_t *buf, uint16_t buf_size);
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -247,7 +247,7 @@ static int get_socket(net_sa_family_t family)
 
 static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
 {
-	uint16_t offset;
+	struct dns_header *hdr = (struct dns_header *)buf;
 	uint16_t flags;
 
 	/* See RFC 1035, ch 4.1.1 for header details */
@@ -255,22 +255,12 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
 	flags = BIT(15);  /* This is response */
 	flags |= BIT(10); /* Authoritative Answer */
 
-	UNALIGNED_PUT(0, (uint16_t *)(buf)); /* Identifier, RFC 6762 ch 18.1 */
-	offset = DNS_HEADER_ID_LEN;
-
-	UNALIGNED_PUT(net_htons(flags), (uint16_t *)(buf+offset));
-	offset += DNS_HEADER_FLAGS_LEN;
-
-	UNALIGNED_PUT(0, (uint16_t *)(buf + offset));
-	offset += DNS_QDCOUNT_LEN;
-
-	UNALIGNED_PUT(net_htons(answers), (uint16_t *)(buf + offset));
-	offset += DNS_ANCOUNT_LEN;
-
-	UNALIGNED_PUT(0, (uint16_t *)(buf + offset));
-	offset += DNS_NSCOUNT_LEN;
-
-	UNALIGNED_PUT(0, (uint16_t *)(buf + offset));
+	UNALIGNED_PUT(0, &hdr->id); /* Identifier, RFC 6762 ch 18.1 */
+	UNALIGNED_PUT(net_htons(flags), &hdr->flags);
+	UNALIGNED_PUT(0, &hdr->qdcount);
+	UNALIGNED_PUT(net_htons(answers), &hdr->ancount);
+	UNALIGNED_PUT(0, &hdr->nscount);
+	UNALIGNED_PUT(0, &hdr->arcount);
 }
 
 static int init_name_labels(struct net_buf *query)

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -273,16 +273,22 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
 	UNALIGNED_PUT(0, (uint16_t *)(buf + offset));
 }
 
-static void add_answer(struct net_buf *query, enum dns_rr_type qtype,
-		       uint32_t ttl, uint16_t addr_len, uint8_t *addr)
+static int init_name_labels(struct net_buf *query)
 {
 	char *dot = query->data + DNS_MSG_HEADER_SIZE + 1;
 	char *prev = query->data + DNS_MSG_HEADER_SIZE;
-	uint16_t offset;
 
-	/* For the length of the first label. */
-	query->len += 1;
+	/* Verify the buffer has enough space to store header and query name
+	 * + 2 for the length of the first label and the terminator byte
+	 */
+	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 2)) {
+		return -ENOBUFS;
+	}
 
+	/* Move the name, making space for the header. +1 for the initial label length */
+	memmove(query->data + DNS_MSG_HEADER_SIZE + 1, query->data, query->len);
+
+	/* Loop over labels, inserting the label length */
 	while ((dot = strchr(dot, '.')) != NULL) {
 		*prev = dot - prev - 1;
 		prev = dot++;
@@ -290,53 +296,133 @@ static void add_answer(struct net_buf *query, enum dns_rr_type qtype,
 
 	*prev = strlen(prev + 1);
 
-	/* terminator byte (0x00) */
+	/* Query length increased by the header size and the length field of the
+	 * first label
+	 */
+	query->len += DNS_MSG_HEADER_SIZE + 1;
+
+	/* Append the terminator byte (0x00) */
+	query->data[query->len] = 0x00;
 	query->len += 1;
 
-	offset = DNS_MSG_HEADER_SIZE + query->len;
-	UNALIGNED_PUT(net_htons(qtype), (uint16_t *)(query->data+offset));
+	return 0;
+}
+
+struct answer_ctx {
+	struct net_buf *query;
+	enum dns_rr_type qtype;
+	int answer_count;
+	uint16_t name_offset;
+};
+
+static void add_a_aaaa_answer(struct answer_ctx *ctx, uint32_t ttl,
+			      uint16_t addr_len, const uint8_t *addr,
+			      bool include_name_ptr)
+{
+
+	uint16_t offset;
+	uint16_t name_len = 0;
+
+	if (include_name_ptr) {
+		name_len = DNS_POINTER_SIZE;
+	}
+
+	if (net_buf_tailroom(ctx->query) < (DNS_QTYPE_LEN + DNS_QCLASS_LEN +
+					    DNS_TTL_LEN + DNS_RDLENGTH_LEN +
+					    addr_len + name_len)) {
+		return;
+	}
+
+	offset = ctx->query->len;
+
+	if (include_name_ptr) {
+		ctx->query->data[offset] = NS_CMPRSFLGS | ((ctx->name_offset >> 8) & 0x3f);
+		ctx->query->data[offset + 1] = ctx->name_offset & 0xff;
+		offset += DNS_POINTER_SIZE;
+	}
+
+	UNALIGNED_PUT(net_htons(ctx->qtype), (uint16_t *)(ctx->query->data + offset));
 
 	/* Bit 15 tells to flush the cache */
 	offset += DNS_QTYPE_LEN;
 	UNALIGNED_PUT(net_htons(DNS_CLASS_IN | BIT(15)),
-		      (uint16_t *)(query->data+offset));
-
+		      (uint16_t *)(ctx->query->data + offset));
 
 	offset += DNS_QCLASS_LEN;
-	UNALIGNED_PUT(net_htonl(ttl), query->data + offset);
+	UNALIGNED_PUT(net_htonl(ttl), ctx->query->data + offset);
 
 	offset += DNS_TTL_LEN;
-	UNALIGNED_PUT(net_htons(addr_len), query->data + offset);
+	UNALIGNED_PUT(net_htons(addr_len), ctx->query->data + offset);
 
 	offset += DNS_RDLENGTH_LEN;
-	memcpy(query->data + offset, addr, addr_len);
+	memcpy(ctx->query->data + offset, addr, addr_len);
+
+	ctx->query->len += DNS_QTYPE_LEN + DNS_QCLASS_LEN + DNS_TTL_LEN +
+			   DNS_RDLENGTH_LEN + addr_len + name_len;
+
+	ctx->answer_count++;
 }
 
-static int create_answer(int sock,
-			 struct net_buf *query,
-			 enum dns_rr_type qtype,
-			 uint16_t addr_len, uint8_t *addr)
+static void answer_addr_cb(struct net_if *iface, struct net_if_addr *ifaddr,
+			   void *user_data)
 {
-	/* Prepare the response into the query buffer: move the name
-	 * query buffer has to get enough free space: dns_hdr + answer
-	 */
-	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 1 +
-					  DNS_QTYPE_LEN + DNS_QCLASS_LEN +
-					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
-					  addr_len)) {
-		return -ENOBUFS;
+	struct answer_ctx *ctx = (struct answer_ctx *)user_data;
+	bool include_name_ptr = true;
+	const uint8_t *addr;
+	uint16_t addr_len;
+
+	if (ifaddr->addr_state != NET_ADDR_PREFERRED &&
+	    ifaddr->addr_state != NET_ADDR_DEPRECATED) {
+		return;
 	}
 
-	/* +1 for the initial label length */
-	memmove(query->data + DNS_MSG_HEADER_SIZE + 1, query->data, query->len);
+	if (ifaddr->address.family == NET_AF_INET6) {
+		addr_len = sizeof(struct net_in6_addr);
+		addr = ifaddr->address.in6_addr.s6_addr;
+	} else {
+		addr_len = sizeof(struct net_in_addr);
+		addr = ifaddr->address.in_addr.s4_addr;
+	}
 
-	setup_dns_hdr(query->data, 1);
+	/* First answer contains full DNS name (already encoded). Consecutive
+	 * answers use label compression and encode label pointers.
+	 */
+	if (ctx->answer_count == 0) {
+		include_name_ptr = false;
+	}
 
-	add_answer(query, qtype, MDNS_TTL, addr_len, addr);
+	add_a_aaaa_answer(ctx, MDNS_TTL, addr_len, addr, include_name_ptr);
+}
 
-	query->len += DNS_MSG_HEADER_SIZE +
-		DNS_QTYPE_LEN + DNS_QCLASS_LEN +
-		DNS_TTL_LEN + DNS_RDLENGTH_LEN + addr_len;
+static int create_answer(struct net_buf *query, enum dns_rr_type qtype,
+			 struct net_if *iface)
+{
+	struct answer_ctx ctx = {
+		.query = query,
+		.qtype = qtype,
+		.name_offset = DNS_MSG_HEADER_SIZE,
+	};
+	int ret;
+
+	ret = init_name_labels(query);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (qtype == DNS_RR_TYPE_A) {
+		net_if_ipv4_addr_foreach(iface, answer_addr_cb, &ctx);
+	} else if (qtype == DNS_RR_TYPE_AAAA) {
+		net_if_ipv6_addr_foreach(iface, answer_addr_cb, &ctx);
+	} else {
+		return -EINVAL;
+	}
+
+	if (ctx.answer_count == 0) {
+		/* No addresses added */
+		return -ENOMEM;
+	}
+
+	setup_dns_hdr(query->data, ctx.answer_count);
 
 	return 0;
 }
@@ -367,45 +453,14 @@ static int send_response(int sock,
 		iface = net_if_ipv4_select_src_iface(&net_sin(src_addr)->sin_addr);
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && qtype == DNS_RR_TYPE_A) {
-		const struct net_in_addr *addr;
-
-		if (family == NET_AF_INET) {
-			addr = net_if_ipv4_select_src_addr(iface,
-							   &net_sin(src_addr)->sin_addr);
-		} else {
-			struct net_sockaddr_in tmp_addr;
-
-			create_ipv4_addr(&tmp_addr);
-			addr = net_if_ipv4_select_src_addr(iface, &tmp_addr.sin_addr);
-		}
-
-		ret = create_answer(sock, query, qtype, sizeof(struct net_in_addr),
-				    (uint8_t *)addr);
-		if (ret != 0) {
-			return ret;
-		}
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) && qtype == DNS_RR_TYPE_AAAA) {
-		const struct net_in6_addr *addr;
-
-		if (family == NET_AF_INET6) {
-			addr = net_if_ipv6_select_src_addr(iface,
-							   &net_sin6(src_addr)->sin6_addr);
-		} else {
-			struct net_sockaddr_in6 tmp_addr;
-
-			create_ipv6_addr(&tmp_addr);
-			addr = net_if_ipv6_select_src_addr(iface, &tmp_addr.sin6_addr);
-		}
-
-		ret = create_answer(sock, query, qtype, sizeof(struct net_in6_addr),
-				    (uint8_t *)addr);
-		if (ret != 0) {
-			return -ENOMEM;
-		}
-	} else {
-		/* TODO: support also service PTRs */
+	if ((qtype == DNS_RR_TYPE_A && !IS_ENABLED(CONFIG_NET_IPV4)) ||
+	    (qtype == DNS_RR_TYPE_AAAA && !IS_ENABLED(CONFIG_NET_IPV6))) {
 		return -EINVAL;
+	}
+
+	ret = create_answer(query, qtype, iface);
+	if (ret != 0) {
+		return -ENOMEM;
 	}
 
 	ret = zsock_sendto(sock, query->data, query->len, 0,

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -587,7 +587,7 @@ static void send_sd_response(int sock,
 					continue;
 				}
 			} else {
-				ret = dns_sd_handle_ptr_query(record, addr4, addr6,
+				ret = dns_sd_handle_ptr_query(iface, record, addr4, addr6,
 						result->data, net_buf_max_len(result));
 				if (ret < 0) {
 					NET_DBG("dns_sd_handle_ptr_query() failed (%d)", ret);

--- a/tests/net/lib/dns_sd/src/main.c
+++ b/tests/net/lib/dns_sd/src/main.c
@@ -531,7 +531,7 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 		0x04, 0xb1, 0x05, 0xf0, 0x0d,
 	};
 	int expected_int = sizeof(expected_rsp);
-	int actual_int = dns_sd_handle_ptr_query(&nasxxxxxx,
+	int actual_int = dns_sd_handle_ptr_query(NULL, &nasxxxxxx,
 						 &addr,
 						 NULL,
 						 &actual_rsp[0],
@@ -549,7 +549,7 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 
 	/* show non-advertisement for uninitialized port */
 	nonconst_port = 0;
-	zassert_equal(-EHOSTDOWN, dns_sd_handle_ptr_query(&nasxxxxxx_ephemeral,
+	zassert_equal(-EHOSTDOWN, dns_sd_handle_ptr_query(NULL, &nasxxxxxx_ephemeral,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
 		sizeof(struct dns_header)), "port zero should not "
 		"produce any DNS-SD query response");
@@ -557,12 +557,12 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 	/* show advertisement for initialized port */
 	nonconst_port = CONST_PORT;
 	expected_int = sizeof(expected_rsp);
-	zassert_equal(expected_int, dns_sd_handle_ptr_query(&nasxxxxxx_ephemeral,
+	zassert_equal(expected_int, dns_sd_handle_ptr_query(NULL, &nasxxxxxx_ephemeral,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
 		sizeof(struct dns_header)), "");
 
 	zassert_equal(-EINVAL, dns_sd_handle_ptr_query(
-		&invalid_dns_sd_record,
+		NULL, &invalid_dns_sd_record,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
 		sizeof(struct dns_header)), "");
 }


### PR DESCRIPTION
Align with RFCs when it comes to A/AAAA record inclusion in mDNS responses.

[RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762), chapter 6.2:

> When a Multicast DNS responder sends a Multicast DNS response message
containing its own address records, it **MUST include all addresses**
that are valid on the interface on which it is sending the message,


[RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763), chapter 12.1:

> When including a DNS-SD Service Instance Enumeration or Selective
Instance Enumeration (subtype) PTR record in a response packet, the
server/responder SHOULD include the following additional records:
...
   o  **All address records** (type "A" and "AAAA") named in the SRV rdata.

Fixes #100591
