### PR TITLE
twister: Improve error handling for user's errors

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -218,9 +218,11 @@ class TestPlan:
                                 testsuite_pattern=self.options.test_pattern)
 
         if num == 0:
-            raise TwisterRuntimeError("No testsuites found at the specified location...")
+            logger.error("No testsuites found at the specified location...")
+            raise SystemExit("No testsuites found at the specified location...")
         if self.load_errors:
-            raise TwisterRuntimeError(
+            logger.error(f"Found {self.load_errors} errors loading {num} test configurations.")
+            raise SystemExit(
                 f"Found {self.load_errors} errors loading {num} test configurations."
             )
 
@@ -237,7 +239,7 @@ class TestPlan:
         qv = self.options.quarantine_verify
         if qv and not ql:
             logger.error("No quarantine list given to be verified")
-            raise TwisterRuntimeError("No quarantine list given to be verified")
+            raise SystemExit("No quarantine list given to be verified")
         if ql:
             for quarantine_file in ql:
                 try:

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -629,9 +629,9 @@ def test_testplan_find_subtests(
 
 
 TESTDATA_3 = [
-    (0, 0, [], False, [], TwisterRuntimeError, []),
-    (1, 1, [], False, [], TwisterRuntimeError, []),
-    (1, 0, [], True, [], TwisterRuntimeError, ['No quarantine list given to be verified']),
+    (0, 0, [], False, [], SystemExit, []),
+    (1, 1, [], False, [], SystemExit, []),
+    (1, 0, [], True, [], SystemExit, ['No quarantine list given to be verified']),
     (1, 0, ['qfile.yaml'], False, ['- platforms:\n  - demo_board_3\n  comment: "board_3"'], None, []),
 ]
 
@@ -702,10 +702,10 @@ TESTDATA_4 = [
 ]
 
 @pytest.mark.parametrize(
-    'report_suffix, only_failed, load_tests, test_only, subset,' \
-    ' exception, expected_selected_platforms, expected_generate_subset_args',
+    'report_suffix, only_failed, load_tests, test_only, subset, ' \
+    'exception, expected_selected_platforms, expected_generate_subset_args',
     TESTDATA_4,
-    ids=['apply_filters only', 'only failed', 'load tests', 'test only']
+    ids=['apply-filters-only', 'only-failed', 'load-tests', 'test-only']
 )
 def test_testplan_load(
     tmp_path,


### PR DESCRIPTION
Exit from twister in case of user's error e.g. empty list of tests provided by user instead of throwing unhandled exception.


If one runs twister from a directory which does not contain any valid tests, twister will crash printing full stack trace like so:
```
Keeping artifacts untouched
INFO    - Using Ninja..
INFO    - Zephyr version: ncs-v3.2.0-rc1-16-gbb4ee4d078ec
DEBUG   - Running cmake script /work/twisterproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Calling cmake: /usr/bin/cmake -DFORMAT=json -P /work/twisterproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Finished running /work/twisterproject/zephyr/cmake/verify-toolchain.cmake
INFO    - Using 'zephyr' toolchain.
DEBUG   - Reading testsuite configuration files under /work/tests...
DEBUG   - Found possible testsuite in /work/twisterproject/test-sdk-mcuboot/tests/alt_root/extxip_smp_svr
DEBUG   - Found possible testsuite in /work/tests/ncs/tamper_nsib
DEBUG   - Found possible testsuite in /work/tests/ncs/image_verification_retry
ERROR   - Twister call stack dump:
  File "/work/twisterproject/zephyr/scripts/twister", line 208, in <module>
    sys.exit(main())
  File "/work/twisterproject/zephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 247, in main
    return twister(options, default_options)
  File "/work/twisterproject/zephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 99, in twister
    tplan.discover()
  File "/work/twisterproject/zephyr/scripts/pylib/twister/twisterlib/testplan.py", line 219, in discover
    raise TwisterRuntimeError("No testsuites found at the specified location...")

Traceback (most recent call last):
  File "/work/twisterproject/zephyr/scripts/twister", line 208, in <module>
    sys.exit(main())
             ^^^^^^
  File "/work/twisterproject/zephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 247, in main
    return twister(options, default_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/twisterprojectzephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 99, in twister
    tplan.discover()
  File "/work/twisterproject/zephyr/scripts/pylib/twister/twisterlib/testplan.py", line 219, in discover
    raise TwisterRuntimeError("No testsuites found at the specified location...")
twisterlib.error.TwisterRuntimeError: No testsuites found at the specified location...
```

With this change it will just print a message to the user "No testsuites found at the specified location..." without the useless stack trace.