### PR TITLE
drivers: flash: npcx: add qspi_npcx_fiu_mutex_is_locked function

### DIFF
--- a/drivers/flash/flash_npcx_fiu_qspi.c
+++ b/drivers/flash/flash_npcx_fiu_qspi.c
@@ -383,6 +383,13 @@ void qspi_npcx_fiu_mutex_unlock(const struct device *dev)
 	k_sem_give(&data->lock_sem);
 }
 
+bool qspi_npcx_fiu_mutex_is_locked(const struct device *dev)
+{
+	struct npcx_qspi_fiu_data *const data = dev->data;
+
+	return (k_sem_count_get(&data->lock_sem) == 0);
+}
+
 void qspi_npcx_fiu_apply_cfg(const struct device *dev,
 			     const struct npcx_qspi_cfg *cfg,
 			     const uint32_t operation)

--- a/drivers/flash/flash_npcx_fiu_qspi.h
+++ b/drivers/flash/flash_npcx_fiu_qspi.h
@@ -109,6 +109,15 @@ void qspi_npcx_fiu_mutex_lock(const struct device *dev);
 void qspi_npcx_fiu_mutex_unlock(const struct device *dev);
 
 /**
+ * @brief Check if the npcx qspi bus controller is locked.
+ *
+ * @param dev Pointer to the device structure for qspi bus controller instance.
+ *
+ * @return true if the mutex is locked, false otherwise.
+ */
+bool qspi_npcx_fiu_mutex_is_locked(const struct device *dev);
+
+/**
  * @brief Apply qspi configuration
  *
  * @param dev Pointer to the device structure for qspi bus controller instance.


### PR DESCRIPTION
Add a helper function to check the lock status of the QSPI-FIU bus controller mutex. This is useful for debug assertions and verifying exclusive access in high-level drivers.