### PR TITLE
drivers: wifi: Skip firmware/device boot during VIF teardown

### DIFF
--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -104,6 +104,7 @@ struct nrf_wifi_vif_ctx_zep {
 #endif /* CONFIG_NRF_WIFI_RPU_RECOVERY */
 	int rts_threshold_value;
 	unsigned short bss_max_idle_period;
+	bool teardown_ongoing; /* VIF teardown in progress */
 };
 
 struct nrf_wifi_vif_ctx_map {

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -647,6 +647,16 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv
 
 	rpu_ctx_zep->drv_priv_zep = drv_priv_zep;
 
+	/* Skip device add/init if VIF teardown is in progress.
+	 * Teardown is terminal for this VIF; the context will be destroyed,
+	 * so firmware boot must not be retriggered.
+	 */
+	if (rpu_ctx_zep->teardown_ongoing) {
+		LOG_INF("%s: VIF teardown ongoing, skipping device add/init", __func__);
+		return NRF_WIFI_STATUS_SUCCESS;
+	}
+
+
 #ifdef CONFIG_NRF70_RADIO_TEST
 	rpu_ctx = nrf_wifi_rt_fmac_dev_add(drv_priv_zep->fmac_priv, rpu_ctx_zep);
 #else

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -983,6 +983,13 @@ int nrf_wifi_if_stop_zep(const struct device *dev)
 		goto out;
 	}
 
+	/* Teardown starts here: mark VIF as permanently stopping to prevent
+	 * any concurrent or late firmware/device boot attempts. This flag is
+	 * intentionally one-way and is not reset for this VIF lifecycle.
+	 */
+	vif_ctx_zep->teardown_ongoing = true;
+
+
 	ret = k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
 	if (ret != 0) {
 		LOG_ERR("%s: Failed to lock vif_lock", __func__);


### PR DESCRIPTION
This PR prevents the WiFi driver from attempting to boot the firmware or initialize the device
while a VIF teardown is in progress.

Changes:
1. Added `bool teardown_ongoing; /* VIF teardown in progress */` to `struct nrf_wifi_vif_ctx_zep` in fmac_main.h
2. Set `vif_ctx_zep->teardown_ongoing = true;` at the start of `nrf_wifi_if_stop_zep()` in net_if.c
3. Added a guard in `nrf_wifi_fmac_dev_add_zep()` (fmac_main.c) to skip device add/init if teardown is ongoing:
   if (rpu_ctx_zep->teardown_ongoing) {
       LOG_INF("%s: VIF teardown ongoing, skipping device add/init", __func__);
       return NRF_WIFI_STATUS_SUCCESS;
   }

Note:
This PR only guards `nrf_wifi_fmac_dev_add_zep()` since that is sufficient to prevent unwanted firmware boot during teardown.

Rationale:
Device boot should only happen if a VIF teardown is not in progress. Attempting to boot during teardown can cause the firmware to not respond properly and can lead to unstable device behavior. This patch ensures that concurrent boot/init and teardown operations are avoided.

This PR ensures proper sequencing: only boot if teardown is not in progress.

Mentions / Review Request:
@krish2718 

Please review this change for the nRF WiFi driver.

This change addresses the firmware boot timeout observed during VIF teardown as discussed in #97512
Addresses #97512
