### PR TITLE
cmake: boards: add default_qualifier support for multi-core SoCs

### DIFF
--- a/boards/espressif/esp32_devkitc/board.yml
+++ b/boards/espressif/esp32_devkitc/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp32_devkitc
   full_name: ESP32-DevKitC
   vendor: espressif
+  default_qualifier: esp32/procpu
   socs:
   - name: esp32

--- a/boards/espressif/esp32_ethernet_kit/board.yml
+++ b/boards/espressif/esp32_ethernet_kit/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp32_ethernet_kit
   full_name: ESP32-Ethernet-Kit
   vendor: espressif
+  default_qualifier: esp32/procpu
   socs:
   - name: esp32

--- a/boards/espressif/esp32c6_devkitc/board.yml
+++ b/boards/espressif/esp32c6_devkitc/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp32c6_devkitc
   full_name: ESP32-C6-DevKitC
   vendor: espressif
+  default_qualifier: esp32c6/hpcore
   socs:
   - name: esp32c6

--- a/boards/espressif/esp32s3_devkitc/board.yml
+++ b/boards/espressif/esp32s3_devkitc/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp32s3_devkitc
   full_name: ESP32-S3-DevKitC
   vendor: espressif
+  default_qualifier: esp32s3/procpu
   socs:
   - name: esp32s3

--- a/boards/espressif/esp32s3_eye/board.yml
+++ b/boards/espressif/esp32s3_eye/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp32s3_eye
   full_name: ESP32-S3-EYE
   vendor: espressif
+  default_qualifier: esp32s3/procpu
   socs:
   - name: esp32s3

--- a/boards/espressif/esp_wrover_kit/board.yml
+++ b/boards/espressif/esp_wrover_kit/board.yml
@@ -2,5 +2,6 @@ board:
   name: esp_wrover_kit
   full_name: ESP-WROVER-KIT
   vendor: espressif
+  default_qualifier: esp32/procpu
   socs:
   - name: esp32

--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -178,7 +178,7 @@ endif()
 
 set(format_str "{NAME}\;{DIR}\;")
 set(format_str "${format_str}{REVISION_FORMAT}\;{REVISION_DEFAULT}\;{REVISION_EXACT}\;")
-set(format_str "${format_str}{REVISIONS}\;{SOCS}\;{QUALIFIERS}")
+set(format_str "${format_str}{REVISIONS}\;{SOCS}\;{QUALIFIERS}\;{DEFAULT_QUALIFIER}")
 
 list(TRANSFORM BOARD_DIRECTORIES PREPEND "--board-dir=" OUTPUT_VARIABLE board_dir_arg)
 execute_process(${list_boards_commands} --board=${BOARD} ${board_dir_arg}
@@ -193,7 +193,7 @@ endif()
 
 if(NOT "${ret_board}" STREQUAL "")
   string(STRIP "${ret_board}" ret_board)
-  set(single_val "NAME;REVISION_FORMAT;REVISION_DEFAULT;REVISION_EXACT")
+  set(single_val "NAME;REVISION_FORMAT;REVISION_DEFAULT;REVISION_EXACT;DEFAULT_QUALIFIER")
   set(multi_val  "DIR;REVISIONS;SOCS;QUALIFIERS")
   cmake_parse_arguments(LIST_BOARD "" "${single_val}" "${multi_val}" ${ret_board})
   list(GET LIST_BOARD_DIR 0 BOARD_DIR)
@@ -261,6 +261,11 @@ elseif(DEFINED BOARD_REVISION)
 endif()
 
 if(LIST_BOARD_QUALIFIERS)
+  # Allow users to omit qualifier when board defines default_qualifier.
+  if(NOT DEFINED BOARD_QUALIFIERS AND LIST_BOARD_DEFAULT_QUALIFIER)
+    set(BOARD_QUALIFIERS "/${LIST_BOARD_DEFAULT_QUALIFIER}")
+  endif()
+
   # Allow users to omit the SoC when building for a board with a single SoC.
   list(LENGTH LIST_BOARD_SOCS socs_length)
   if(socs_length EQUAL 1)

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -108,6 +108,7 @@ class Board:
     revisions: list[str] = field(default_factory=list, compare=False)
     socs: list[Soc] = field(default_factory=list, compare=False)
     variants: list[str] = field(default_factory=list, compare=False)
+    default_qualifier: str | None = None
 
     @property
     def dir(self):
@@ -194,6 +195,7 @@ def load_v2_boards(board_name, board_yml, systems):
                 socs=socs,
                 variants=[Variant.from_dict(v) for v in board.get('variants', [])],
                 hwm='v2',
+                default_qualifier=board.get('default_qualifier'),
             )
             board_qualifiers = board_v2_qualifiers(boards[board['name']])
             duplicates = [q for q, n in Counter(board_qualifiers).items() if n > 1]
@@ -343,7 +345,8 @@ def dump_v2_boards(args):
                 REVISIONS='REVISIONS;' + ';'.join(
                           [x.name for x in b.revisions]),
                 SOCS='SOCS;' + ';'.join([s.name for s in b.socs]),
-                QUALIFIERS='QUALIFIERS;' + ';'.join(qualifiers_list)
+                QUALIFIERS='QUALIFIERS;' + ';'.join(qualifiers_list),
+                DEFAULT_QUALIFIER='DEFAULT_QUALIFIER;' + notfound(b.default_qualifier)
             )
             print(info)
         else:

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -252,7 +252,8 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
             else:
                 target = f"{board.name}/{qual}"
                 alias2target[target] = target
-                if '/' not in qual and len(board.socs) == 1:
+                if (('/' not in qual and len(board.socs) == 1)
+                        or (board.default_qualifier and qual == board.default_qualifier)):
                     alias2target[board.name] = target
                 target2board[target] = board
 

--- a/scripts/schemas/board-schema.yaml
+++ b/scripts/schemas/board-schema.yaml
@@ -64,6 +64,9 @@ $defs:
       vendor:
         type: string
         description: SoC family of the SoC on the board.
+      default_qualifier:
+        type: string
+        description: Default qualifier to use when board is specified without qualifier.
       revision:
         type: object
         properties:

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -167,6 +167,14 @@ TESTDATA_2 = [
         SchemaError(), # Unknown message as this is raised externally
         None,
     ),
+    (
+        ['m0', 'm6'],
+        None,
+        {
+            'p1e1/s1', 'p1e2/s1', 'p2/s1', 'p3@A/s2/c1', 'p3@B/s2/c1',
+            'p5/s3/c1',
+        },
+    ),
 ]
 
 @pytest.mark.parametrize(
@@ -179,6 +187,7 @@ TESTDATA_2 = [
         '1 extra board root, duplicate platform',
         '2 extra board roots, duplicate platform',
         '1 extra board root, malformed yaml',
+        '1 extra board root, default_qualifier',
     ]
 )
 def test_generate_platforms(
@@ -349,6 +358,29 @@ vendor: vendor2
 board:
   extend: p2
 """,
+        'm6/boards/zephyr/p5/board.yml': """\
+board:
+  name: p5
+  full_name: p5
+  vendor: zephyr
+  default_qualifier: s3/c1
+  socs:
+    - name: s3
+""",
+        'm6/boards/zephyr/p5/twister.yaml': """\
+type: mcu
+arch: xtensa
+""",
+        'm6/soc/zephyr/soc.yml': """\
+family:
+  - name: zephyr
+    series:
+      - name: zephyr_testing2
+        socs:
+          - name: s3
+            cpuclusters:
+              - name: c1
+""",
     }
 
     for filename, content in tmp_files.items():
@@ -477,6 +509,14 @@ board:
             'type': 'qemu',
             'simulators': [Simulator({'name': 'qemu'})],
             'simulation': 'qemu',
+        },
+        'p5/s3/c1': {
+            'aliases': ['p5/s3/c1', 'p5'],
+            # m6/boards/zephyr/p5/board.yml (with default_qualifier)
+            'vendor': 'zephyr',
+            # m6/boards/zephyr/p5/twister.yaml
+            'arch': 'xtensa',
+            'type': 'mcu',
         },
     }
 


### PR DESCRIPTION
This PR adds support for a `default_qualifier` field in board.yml, allowing
board vendors to specify which qualifier should be used when users build
with just the board name.

Boards with multi-core SoCs require full qualifiers:
- `west build -b esp32s3_devkitc/esp32s3/procpu`
- `west build -b esp32c6_devkitc/esp32c6/hpcore`

With this change:
- `west build -b esp32s3_devkitc`
- `west build -b esp32c6_devkitc`

### Usage

```yaml
board:
  name: esp32s3_devkitc
  default_qualifier: esp32s3/procpu
  socs:
  - name: esp32s3
  ```
  
  RFC: #102831