### PR TITLE
usb: fix USBIP crash and CDC ACM polling mode

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -358,6 +358,9 @@ static void usbd_cdc_acm_enable(struct usbd_class_data *const c_data)
 
 	if (atomic_test_bit(&data->state, CDC_ACM_IRQ_RX_ENABLED)) {
 		cdc_acm_irq_rx_enable(dev);
+	} else {
+		/* For polling mode, enqueue OUT buffer to receive data */
+		cdc_acm_work_submit(&data->rx_fifo_work);
 	}
 
 	if (ring_buf_is_empty(data->tx_fifo.rb)) {


### PR DESCRIPTION
usbip.c:
- use 'udev' parameter instead of 'dev_ctx->udev' to fix crash
- cap actual_length to requested length
- handle partial TCP sends

usbd_cdc_acm.c:
- enqueue OUT buffer at class enable for polling mode

Fixes #102737