### PR TITLE
dts: arm: nxp: normalize hexadecimal digits in node names to lowercase

### DIFF
--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -81,7 +81,7 @@
 			clock-frequency = <32768>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/nxp_k32l2b3.dtsi
@@ -87,7 +87,7 @@
 			#clock-cells = <1>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -112,7 +112,7 @@
 			prescaler = <32768>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -45,7 +45,7 @@
 			status = "disabled";
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -25,7 +25,7 @@
 		};
 	};
 
-	sram0: memory@1FFFF000 {
+	sram0: memory@1ffff000 {
 		compatible = "mmio-sram";
 		reg = <0x1FFFF000 DT_SIZE_K(16)>;
 	};
@@ -82,7 +82,7 @@
 			status = "disabled";
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -40,7 +40,7 @@
 			status = "disabled";
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -83,7 +83,7 @@
 			clock-frequency = <32768>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -60,7 +60,7 @@
 			clock-frequency = <32768>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -63,7 +63,7 @@
 			prescaler = <32768>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -55,7 +55,7 @@
 		reg = <0x20008000 DT_SIZE_K(16)>;
 	};
 
-	sram2: memory@2000C000 {
+	sram2: memory@2000c000 {
 		compatible = "mmio-sram";
 		reg = <0x2000C000 DT_SIZE_K(16)>;
 	};

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -210,7 +210,7 @@
 		prescale = <0>;
 	};
 
-	ctimer4: ctimer@2A000 {
+	ctimer4: ctimer@2a000 {
 		compatible = "nxp,lpc-ctimer";
 		reg = <0x2A000 0x1000>;
 		interrupts = <37 0>;

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -339,7 +339,7 @@
 		status = "disabled";
 	};
 
-	usbhfs: usbhfs@A2000 {
+	usbhfs: usbhfs@a2000 {
 		compatible = "nxp,uhc-ohci";
 		reg = <0xa2000 0x1000>;
 		interrupts = <28 1>;
@@ -347,7 +347,7 @@
 		status = "disabled";
 	};
 
-	usbhhs: usbhhs@A3000 {
+	usbhhs: usbhhs@a3000 {
 		compatible = "nxp,uhc-ip3516hs";
 		reg = <0xa3000 0x1000>;
 		interrupts = <47 1>;

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -293,7 +293,7 @@
 		#size-cells = <0>;
 	};
 
-	adc0: adc@A0000 {
+	adc0: adc@a0000 {
 		compatible = "nxp,lpc-lpadc";
 		reg = <0xA0000 0x1000>;
 		interrupts = <22 0>;
@@ -410,7 +410,7 @@
 		status = "disabled";
 	};
 
-	flexpwm0: flexpwm@400C3000 {
+	flexpwm0: flexpwm@400c3000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x400C3000 0x1000>;
 		interrupt-names = "INPUT-CAPTURE", "FAULT", "RELOAD-ERROR";
@@ -465,7 +465,7 @@
 		};
 	};
 
-	flexpwm1: flexpwm@400C5000 {
+	flexpwm1: flexpwm@400c5000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x400C5000 0x1000>;
 		interrupt-names = "INPUT-CAPTURE", "FAULT", "RELOAD-ERROR";

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -137,7 +137,7 @@
 			write-block-size = <512>;
 		};
 
-		flash_reserved: flash@9D800 {
+		flash_reserved: flash@9d800 {
 			compatible = "soc-nv-flash";
 			reg = <0x9D800 DT_SIZE_K(9)>;
 			status = "disabled";
@@ -364,7 +364,7 @@
 		clk-divider = <1>;
 	};
 
-	adc0: adc@A0000 {
+	adc0: adc@a0000 {
 		compatible = "nxp,lpc-lpadc";
 		reg = <0xA0000 0x1000>;
 		interrupts = <22 0>;
@@ -397,7 +397,7 @@
 		status = "disabled";
 	};
 
-	usbhfs: usbhfs@A2000 {
+	usbhfs: usbhfs@a2000 {
 		compatible = "nxp,uhc-ohci";
 		reg = <0xa2000 0x1000>;
 		interrupts = <28 1>;
@@ -405,7 +405,7 @@
 		status = "disabled";
 	};
 
-	usbhhs: usbhhs@A3000 {
+	usbhhs: usbhhs@a3000 {
 		compatible = "nxp,uhc-ip3516hs";
 		reg = <0xa3000 0x1000>;
 		interrupts = <47 1>;
@@ -466,7 +466,7 @@
 		prescale = <0>;
 	};
 
-	ctimer4: ctimer@2A000 {
+	ctimer4: ctimer@2a000 {
 		compatible = "nxp,lpc-ctimer";
 		reg = <0x2A000 0x1000>;
 		interrupts = <37 0>;
@@ -488,7 +488,7 @@
 		#pwm-cells = <3>;
 	};
 
-	rtc: rtc@2C000 {
+	rtc: rtc@2c000 {
 		compatible = "nxp,lpc-rtc";
 		reg = <0x2C000 0x1000>;
 		interrupts = <29 0>;

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -451,7 +451,7 @@
 			interrupts = <18 0>;
 		};
 
-		cmc: system-modules@4008B000 {
+		cmc: system-modules@4008b000 {
 			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008B000 0x1000>;
 			interrupts = <1 0>;

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -587,7 +587,7 @@
 			interrupts = <18 0>;
 		};
 
-		cmc: system-modules@4008B000 {
+		cmc: system-modules@4008b000 {
 			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008B000 0x1000>;
 			interrupts = <1 0>;

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -519,7 +519,7 @@
 			interrupts = <18 0>;
 		};
 
-		cmc: system-modules@4008B000 {
+		cmc: system-modules@4008b000 {
 			compatible = "nxp,cmc";
 			reg = <0x4008B000 0x1000>;
 			interrupts = <1 0>;

--- a/dts/arm/nxp/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxa5x_common.dtsi
@@ -145,7 +145,7 @@
 		nxp,kinetis-port = <&porta>;
 	};
 
-	gpio1: gpio@4A000 {
+	gpio1: gpio@4a000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		reg = <0x4A000 0x1000>;
@@ -155,7 +155,7 @@
 		nxp,kinetis-port = <&portb>;
 	};
 
-	gpio2: gpio@4C000 {
+	gpio2: gpio@4c000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		reg = <0x4C000 0x1000>;
@@ -165,7 +165,7 @@
 		nxp,kinetis-port = <&portc>;
 	};
 
-	gpio3: gpio@4E000 {
+	gpio3: gpio@4e000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		reg = <0x4E000 0x1000>;

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -544,7 +544,7 @@
 			interrupts = <18 0>;
 		};
 
-		cmc: system-modules@4008B000 {
+		cmc: system-modules@4008b000 {
 			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008B000 0x1000>;
 			interrupts = <1 0>;

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -35,7 +35,7 @@
 		};
 	};
 
-	sram0: memory@1FFFF000 {
+	sram0: memory@1ffff000 {
 		compatible = "mmio-sram";
 	};
 
@@ -92,7 +92,7 @@
 			#clock-cells = <1>;
 		};
 
-		rcm: rcm@4007F000 {
+		rcm: rcm@4007f000 {
 			compatible = "nxp,rcm-hwinfo";
 			reg = <0x4007F000 0x1000>;
 		};

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -1054,7 +1054,7 @@
 		#dma-cells = <0>;
 	};
 
-	ewm0: ewm@C0000 {
+	ewm0: ewm@c0000 {
 		compatible = "nxp,ewm";
 		reg = <0xC0000 0x6>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -76,7 +76,7 @@
 	 * or nxp_rt118x_cm7.dtsi. The base addresses on cm33 core differ
 	 * between non-secure (0x40000000) and secure modes (0x50000000).
 	 */
-	iomuxc: pinctrl@2A10000 {
+	iomuxc: pinctrl@2a10000 {
 		compatible = "nxp,imx-iomuxc";
 		reg = <0x2A10000 0x4000>;
 
@@ -86,7 +86,7 @@
 		};
 	};
 
-	iomuxc_aon: pinctrl@43C0000 {
+	iomuxc_aon: pinctrl@43c0000 {
 		compatible = "nxp,mcux-rt-pinctrl";
 		reg = <0x43C0000 0x4000>;
 		status = "okay";
@@ -168,7 +168,7 @@
 		status = "disabled";
 	};
 
-	lpuart6: serial@25A0000 {
+	lpuart6: serial@25a0000 {
 		compatible = "nxp,lpuart";
 		reg = <0x25A0000 0x4000>;
 		interrupts = <71 0>;
@@ -188,7 +188,7 @@
 		status = "disabled";
 	};
 
-	lpuart8: serial@2DA0000 {
+	lpuart8: serial@2da0000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2DA0000 0x4000>;
 		interrupts = <197 0>;
@@ -198,7 +198,7 @@
 		status = "disabled";
 	};
 
-	lpuart9: serial@2D70000 {
+	lpuart9: serial@2d70000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D70000 0x4000>;
 		interrupts = <156 0>;
@@ -208,7 +208,7 @@
 		status = "disabled";
 	};
 
-	lpuart10: serial@2D80000 {
+	lpuart10: serial@2d80000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D80000 0x4000>;
 		interrupts = <157 0>;
@@ -218,7 +218,7 @@
 		status = "disabled";
 	};
 
-	lpuart11: serial@2D90000 {
+	lpuart11: serial@2d90000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D90000 0x4000>;
 		interrupts = <158 0>;
@@ -1182,7 +1182,7 @@
 		#pwm-cells = <3>;
 	};
 
-	tpm3: pwm@24E0000 {
+	tpm3: pwm@24e0000 {
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x24E0000 0x88>;
 		interrupts = <75 0>;
@@ -1192,7 +1192,7 @@
 		#pwm-cells = <3>;
 	};
 
-	tpm4: pwm@24F0000 {
+	tpm4: pwm@24f0000 {
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x24F0000 0x88>;
 		interrupts = <76 0>;

--- a/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	soc {
-		itcm: itcm@FFE0000 {
+		itcm: itcm@ffe0000 {
 			compatible = "zephyr,memory-region", "nxp,imx-itcm";
 			reg = <0xFFE0000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "ITCM";

--- a/dts/arm/nxp/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_common.dtsi
@@ -88,7 +88,7 @@
 		zephyr,memory-region = "SRAM1";
 	};
 
-	sram3: memory@205C0000 {
+	sram3: memory@205c0000 {
 		compatible = "mmio-sram";
 		/* Only use 256K, align with SDK */
 		reg = <0x205C0000 DT_SIZE_K(256)>;

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -80,7 +80,7 @@
 		ranges = <0x0 0x41380000 DT_SIZE_K(510)>;
 	};
 
-	smu2: sram@443C0000 {
+	smu2: sram@443c0000 {
 		ranges = <0x0 0x443C0000 DT_SIZE_K(140)>;
 	};
 


### PR DESCRIPTION
Convert uppercase hexadecimal digits to lowercase in device tree node unit addresses across NXP ARM device tree files. This ensures consistency with device tree naming conventions where hexadecimal addresses should use lowercase letters (a-f).
This also eliminate build warnings related to uppercase hexadecimal.

No functional changes, only cosmetic updates to node naming.