### PR TITLE
dts: raspberrypi: riscv: add support for Zbb and Zbkb ISA extensions

### DIFF
--- a/dts/riscv/raspberrypi/hazard3.dtsi
+++ b/dts/riscv/raspberrypi/hazard3.dtsi
@@ -35,11 +35,11 @@
 &cpu0 {
 	compatible = "riscv";
 	riscv,isa-base = "rv32i";
-	riscv,isa-extensions = "i", "m", "a", "c", "zicsr", "zifencei", "zba", "zbs";
+	riscv,isa-extensions = "i", "m", "a", "c", "zicsr", "zifencei", "zba", "zbb", "zbkb", "zbs";
 };
 
 &cpu1 {
 	compatible = "riscv";
 	riscv,isa-base = "rv32i";
-	riscv,isa-extensions = "i", "m", "a", "c", "zicsr", "zifencei", "zba", "zbs";
+	riscv,isa-extensions = "i", "m", "a", "c", "zicsr", "zifencei", "zba", "zbb", "zbkb", "zbs";
 };


### PR DESCRIPTION
Add support for Zbb and Zbkb ISA extensions. They are used
by some `pico-sdk` library code.
