### PR TITLE
drivers: i2c: place API into iterable section

### DIFF
--- a/drivers/i2c/i2c_cc23x0.c
+++ b/drivers/i2c/i2c_cc23x0.c
@@ -300,8 +300,8 @@ static void i2c_cc23x0_isr(const struct device *dev)
 	}
 }
 
-static const struct i2c_driver_api i2c_cc23x0_driver_api = {.configure = i2c_cc23x0_configure,
-							    .transfer = i2c_cc23x0_transfer};
+static DEVICE_API(i2c, i2c_cc23x0_driver_api) = {.configure = i2c_cc23x0_configure,
+						 .transfer = i2c_cc23x0_transfer};
 
 #define I2C_CC23X0_INIT_FUNC(id)                                                                   \
 	static int i2c_cc23x0_init##id(const struct device *dev)                                   \

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -694,7 +694,7 @@ void ifx_cat1_i2c_cb_wrapper(const struct device *dev, uint32_t event)
 }
 
 /* I2C API structure */
-static const struct i2c_driver_api i2c_cat1_driver_api = {
+static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 	.configure = ifx_cat1_i2c_configure,
 	.transfer = ifx_cat1_i2c_transfer,
 	.get_config = ifx_cat1_i2c_get_config,

--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -396,7 +396,7 @@ static int i2c_max32_init(const struct device *dev)
 	return ret;
 }
 
-static const struct i2c_driver_api max32_driver_api = {
+static DEVICE_API(i2c, max32_driver_api) = {
 	.configure = max32_configure,
 	.transfer = max32_transfer,
 	.iodev_submit = max32_submit,

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -252,7 +252,7 @@ static int shim_nrf_twis_target_unregister(const struct device *dev,
 	return 0;
 }
 
-const struct i2c_driver_api shim_nrf_twis_api = {
+static DEVICE_API(i2c, shim_nrf_twis_api) = {
 	.target_register = shim_nrf_twis_target_register,
 	.target_unregister = shim_nrf_twis_target_unregister,
 };

--- a/drivers/i2c/i2c_renesas_ra_sci.c
+++ b/drivers/i2c/i2c_renesas_ra_sci.c
@@ -602,7 +602,7 @@ static void calc_sci_iic_clock_setting(const struct device *dev, const uint32_t 
 	clk_cfg->cycles_value = (uint8_t)sda_delay_counts;
 }
 
-static const struct i2c_driver_api renesas_ra_sci_i2c_driver_api = {
+static DEVICE_API(i2c, renesas_ra_sci_i2c_driver_api) = {
 	.configure = renesas_ra_sci_i2c_configure,
 	.get_config = renesas_ra_sci_i2c_get_config,
 	.transfer = renesas_ra_sci_i2c_transfer,

--- a/drivers/i2c/i2c_renesas_ra_sci_b.c
+++ b/drivers/i2c/i2c_renesas_ra_sci_b.c
@@ -585,7 +585,7 @@ static void calc_sci_b_iic_clock_setting(const struct device *dev, const uint32_
 	clk_cfg->cycles_value = (uint8_t)sda_delay_counts;
 }
 
-static const struct i2c_driver_api renesas_ra_sci_b_i2c_driver_api = {
+static DEVICE_API(i2c, renesas_ra_sci_b_i2c_driver_api) = {
 	.configure = renesas_ra_sci_b_i2c_configure,
 	.get_config = renesas_ra_sci_b_i2c_get_config,
 	.transfer = renesas_ra_sci_b_i2c_transfer,

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -209,7 +209,7 @@ static void i2c_stm32_submit(const struct device *dev, struct rtio_iodev_sqe *io
 	}
 }
 
-static const struct i2c_driver_api api_funcs = {
+static DEVICE_API(i2c, api_funcs) = {
 	.configure = i2c_stm32_configure,
 	.transfer = i2c_stm32_transfer,
 	.get_config = i2c_stm32_get_config,


### PR DESCRIPTION
Add the `DEVICE_API` wrapper to the remaining `i2c_driver_api` instances, ensuring that each driver API is placed in its respective linker section.