### PR TITLE
drivers: spi: place API into iterable section

### DIFF
--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -715,7 +715,7 @@ int spi_atcspi200_init(const struct device *dev)
 	return 0;
 }
 
-static struct spi_driver_api spi_atcspi200_api = {
+static DEVICE_API(spi, spi_atcspi200_api) = {
 	.transceive = spi_atcspi200_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_atcspi200_transceive_async,

--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -486,7 +486,7 @@ static int ifx_cat1_spi_release(const struct device *dev, const struct spi_confi
 	return 0;
 }
 
-static const struct spi_driver_api ifx_cat1_spi_api = {
+static DEVICE_API(spi, ifx_cat1_spi_api) = {
 	.transceive = ifx_cat1_spi_transceive_sync,
 #if defined(CONFIG_SPI_ASYNC)
 	.transceive_async = ifx_cat1_spi_transceive_async,


### PR DESCRIPTION
Add the `DEVICE_API` wrapper to the remaining `spi_driver_api` instances, ensuring that each driver API is placed in its respective linker section.