### PR TITLE
drivers: serial: place API into iterable section

### DIFF
--- a/drivers/serial/uart_ameba_loguart.c
+++ b/drivers/serial/uart_ameba_loguart.c
@@ -281,7 +281,7 @@ static void loguart_ameba_isr(const struct device *dev)
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-static const struct uart_driver_api loguart_ameba_driver_api = {
+static DEVICE_API(uart, loguart_ameba_driver_api) = {
 	.poll_in = loguart_ameba_poll_in,
 	.poll_out = loguart_ameba_poll_out,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_ft9001.c
+++ b/drivers/serial/uart_ft9001.c
@@ -532,7 +532,7 @@ static void uart_ft9001_isr(const struct device *dev)
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 /* UART driver API structure */
-static const struct uart_driver_api uart_ft9001_driver_api = {
+static DEVICE_API(uart, uart_ft9001_driver_api) = {
 	.poll_in = uart_ft9001_poll_in,
 	.poll_out = uart_ft9001_poll_out,
 	.err_check = uart_ft9001_err_check,

--- a/drivers/serial/uart_sf32lb.c
+++ b/drivers/serial/uart_sf32lb.c
@@ -801,7 +801,7 @@ static void uart_sf32lb_async_rx_timeout(struct k_work *work)
 }
 #endif /* CONFIG_UART_ASYNC_API */
 
-static const struct uart_driver_api uart_sf32lb_api = {
+static DEVICE_API(uart, uart_sf32lb_api) = {
 	.poll_in = uart_sf32lb_poll_in,
 	.poll_out = uart_sf32lb_poll_out,
 	.err_check = uart_sf32lb_err_check,


### PR DESCRIPTION
Add the `DEVICE_API` wrapper to the remaining `uart_driver_api` instances, ensuring that each driver API is placed in its respective linker section.