### PR TITLE
dts: arm: ti: j722s_main: Use GPIO Proxy

### DIFF
--- a/dts/arm/ti/j722s_main.dtsi
+++ b/dts/arm/ti/j722s_main.dtsi
@@ -19,21 +19,133 @@
 		status = "okay";
 	};
 
-	gpio0: gpio@600010 {
+	main_gpio0: main-gpio0 {
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &main_gpio0_0 0 0>, <1 0 &main_gpio0_0 1 0>,
+			   <2 0 &main_gpio0_0 2 0>, <3 0 &main_gpio0_0 3 0>,
+			   <4 0 &main_gpio0_0 4 0>, <5 0 &main_gpio0_0 5 0>,
+			   <6 0 &main_gpio0_0 6 0>, <7 0 &main_gpio0_0 7 0>,
+			   <8 0 &main_gpio0_0 8 0>, <9 0 &main_gpio0_0 9 0>,
+			   <10 0 &main_gpio0_0 10 0>, <11 0 &main_gpio0_0 11 0>,
+			   <12 0 &main_gpio0_0 12 0>, <13 0 &main_gpio0_0 13 0>,
+			   <14 0 &main_gpio0_0 14 0>, <15 0 &main_gpio0_0 15 0>,
+			   <16 0 &main_gpio0_0 16 0>, <17 0 &main_gpio0_0 17 0>,
+			   <18 0 &main_gpio0_0 18 0>, <19 0 &main_gpio0_0 19 0>,
+			   <20 0 &main_gpio0_0 20 0>, <21 0 &main_gpio0_0 21 0>,
+			   <22 0 &main_gpio0_0 22 0>, <23 0 &main_gpio0_0 23 0>,
+			   <24 0 &main_gpio0_0 24 0>, <25 0 &main_gpio0_0 25 0>,
+			   <26 0 &main_gpio0_0 26 0>, <27 0 &main_gpio0_0 27 0>,
+			   <28 0 &main_gpio0_0 28 0>, <29 0 &main_gpio0_0 29 0>,
+			   <30 0 &main_gpio0_0 30 0>, <31 0 &main_gpio0_0 31 0>,
+			   <32 0 &main_gpio0_1 0 0>, <33 0 &main_gpio0_1 1 0>,
+			   <34 0 &main_gpio0_1 2 0>, <35 0 &main_gpio0_1 3 0>,
+			   <36 0 &main_gpio0_1 4 0>, <37 0 &main_gpio0_1 5 0>,
+			   <38 0 &main_gpio0_1 6 0>, <39 0 &main_gpio0_1 7 0>,
+			   <40 0 &main_gpio0_1 8 0>, <41 0 &main_gpio0_1 9 0>,
+			   <42 0 &main_gpio0_1 10 0>, <43 0 &main_gpio0_1 11 0>,
+			   <44 0 &main_gpio0_1 12 0>, <45 0 &main_gpio0_1 13 0>,
+			   <46 0 &main_gpio0_1 14 0>, <47 0 &main_gpio0_1 15 0>,
+			   <48 0 &main_gpio0_1 16 0>, <49 0 &main_gpio0_1 17 0>,
+			   <50 0 &main_gpio0_1 18 0>, <51 0 &main_gpio0_1 19 0>,
+			   <52 0 &main_gpio0_1 20 0>, <53 0 &main_gpio0_1 21 0>,
+			   <54 0 &main_gpio0_1 22 0>, <55 0 &main_gpio0_1 23 0>,
+			   <56 0 &main_gpio0_1 24 0>, <57 0 &main_gpio0_1 25 0>,
+			   <58 0 &main_gpio0_1 26 0>, <59 0 &main_gpio0_1 27 0>,
+			   <60 0 &main_gpio0_1 28 0>, <61 0 &main_gpio0_1 29 0>,
+			   <62 0 &main_gpio0_1 30 0>, <63 0 &main_gpio0_1 31 0>,
+			   <64 0 &main_gpio0_2 0 0>, <65 0 &main_gpio0_2 1 0>,
+			   <66 0 &main_gpio0_2 2 0>, <67 0 &main_gpio0_2 3 0>,
+			   <68 0 &main_gpio0_2 4 0>, <69 0 &main_gpio0_2 5 0>,
+			   <70 0 &main_gpio0_2 6 0>, <71 0 &main_gpio0_2 7 0>,
+			   <72 0 &main_gpio0_2 8 0>, <73 0 &main_gpio0_2 9 0>,
+			   <74 0 &main_gpio0_2 10 0>, <75 0 &main_gpio0_2 11 0>,
+			   <76 0 &main_gpio0_2 12 0>, <77 0 &main_gpio0_2 13 0>,
+			   <78 0 &main_gpio0_2 14 0>, <79 0 &main_gpio0_2 15 0>,
+			   <80 0 &main_gpio0_2 16 0>, <81 0 &main_gpio0_2 17 0>,
+			   <82 0 &main_gpio0_2 18 0>, <83 0 &main_gpio0_2 17 0>,
+			   <84 0 &main_gpio0_2 20 0>, <85 0 &main_gpio0_2 21 0>,
+			   <86 0 &main_gpio0_2 22 0>, <87 0 &main_gpio0_2 23 0>,
+			   <88 0 &main_gpio0_2 24 0>, <89 0 &main_gpio0_2 25 0>,
+			   <90 0 &main_gpio0_2 26 0>, <91 0 &main_gpio0_2 27 0>;
+		gpio-map-mask = <0xffff 0x0>;
+		gpio-map-pass-thru = <0x0 0x1>;
+	};
+
+	main_gpio0_0: gpio@600010 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x00600010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		ngpios = <92>;
+		ngpios = <32>;
 		status = "disabled";
 	};
 
-	gpio1: gpio@601010 {
+	main_gpio0_1: gpio@600038 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00600038 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio0_2: gpio@600060 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00600060 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <28>;
+		status = "disabled";
+	};
+
+	main_gpio1: main-gpio1 {
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &main_gpio1_0 0 0>, <1 0 &main_gpio1_0 1 0>,
+			   <2 0 &main_gpio1_0 2 0>, <3 0 &main_gpio1_0 3 0>,
+			   <4 0 &main_gpio1_0 4 0>, <5 0 &main_gpio1_0 5 0>,
+			   <6 0 &main_gpio1_0 6 0>, <7 0 &main_gpio1_0 7 0>,
+			   <8 0 &main_gpio1_0 8 0>, <9 0 &main_gpio1_0 9 0>,
+			   <10 0 &main_gpio1_0 10 0>, <11 0 &main_gpio1_0 11 0>,
+			   <12 0 &main_gpio1_0 12 0>, <13 0 &main_gpio1_0 13 0>,
+			   <14 0 &main_gpio1_0 14 0>, <15 0 &main_gpio1_0 15 0>,
+			   <16 0 &main_gpio1_0 16 0>, <17 0 &main_gpio1_0 17 0>,
+			   <18 0 &main_gpio1_0 18 0>, <19 0 &main_gpio1_0 19 0>,
+			   <20 0 &main_gpio1_0 20 0>, <21 0 &main_gpio1_0 21 0>,
+			   <22 0 &main_gpio1_0 22 0>, <23 0 &main_gpio1_0 23 0>,
+			   <24 0 &main_gpio1_0 24 0>, <25 0 &main_gpio1_0 25 0>,
+			   <26 0 &main_gpio1_0 26 0>, <27 0 &main_gpio1_0 27 0>,
+			   <28 0 &main_gpio1_0 28 0>, <29 0 &main_gpio1_0 29 0>,
+			   <30 0 &main_gpio1_0 30 0>, <31 0 &main_gpio1_0 31 0>,
+			   <32 0 &main_gpio1_1 0 0>, <33 0 &main_gpio1_1 1 0>,
+			   <34 0 &main_gpio1_1 2 0>, <35 0 &main_gpio1_1 3 0>,
+			   <36 0 &main_gpio1_1 4 0>, <37 0 &main_gpio1_1 5 0>,
+			   <38 0 &main_gpio1_1 6 0>, <39 0 &main_gpio1_1 7 0>,
+			   <40 0 &main_gpio1_1 8 0>, <41 0 &main_gpio1_1 9 0>,
+			   <42 0 &main_gpio1_1 10 0>, <43 0 &main_gpio1_1 11 0>,
+			   <44 0 &main_gpio1_1 12 0>, <45 0 &main_gpio1_1 13 0>,
+			   <46 0 &main_gpio1_1 14 0>, <47 0 &main_gpio1_1 15 0>,
+			   <48 0 &main_gpio1_1 16 0>, <49 0 &main_gpio1_1 17 0>,
+			   <50 0 &main_gpio1_1 18 0>, <51 0 &main_gpio1_1 19 0>,
+			   <52 0 &main_gpio1_1 20 0>;
+		gpio-map-mask = <0xffff 0x0>;
+		gpio-map-pass-thru = <0x0 0x1>;
+	};
+
+	main_gpio1_0: gpio@601010 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x00601010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		ngpios = <52>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio1_1: gpio@601038 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00601038 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <20>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
Use GPIO Proxy nodes to allow using all the GPIOs. Similar to am62 [0].

[0]: https://github.com/zephyrproject-rtos/zephyr/pull/93360