### PR TITLE
drivers: video: stm32_dcmipp: fixing driver initialization issue

### DIFF
--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -356,6 +356,10 @@ static int stm32_dcmipp_conf_parallel(const struct device *dev,
 	parallel_cfg.ExtendedDataMode = DCMIPP_INTERFACE_8BITS;
 	parallel_cfg.SynchroMode      = DCMIPP_SYNCHRO_HARDWARE;
 
+	/* There may be the case when HAL_DCMIPP_PARALLEL_SetConfig called second time
+	 * so reset state so it doesn't fail
+	 */
+	dcmipp->hdcmipp.State = HAL_DCMIPP_STATE_INIT;
 	hal_ret = HAL_DCMIPP_PARALLEL_SetConfig(&dcmipp->hdcmipp, &parallel_cfg);
 	if (hal_ret != HAL_OK) {
 		LOG_ERR("Failed to configure DCMIPP Parallel interface");


### PR DESCRIPTION
when pipe 1 or 2 is selected and parallel bus is chosen HAL_DCMIPP_PARALLEL_SetConfig is failing, since it gets called twice and driver is already in HAL_DCMIPP_STATE_READY state