### PR TITLE
doc: networking: native_sim_setup: add NAT/masquerading setup

### DIFF
--- a/doc/connectivity/networking/native_sim_setup.rst
+++ b/doc/connectivity/networking/native_sim_setup.rst
@@ -170,4 +170,43 @@ troublesome.
    ./zephyr.exe --eth-if=zeth2 --ipv4-addr=192.0.2.2 --ipv4-gw=192.0.0.1
    --ipv4-nm=255.255.0.0
 
+Setting up Zephyr and NAT/masquerading on host to access Internet
+*****************************************************************
+
+To access the internet from a Zephyr application, some additional
+setup on the host may be required.
+
+To access the internet from a Zephyr application using IPv4,
+a gateway should be set via DHCP or configured manually.
+For applications using the "Settings" facility (with the config option
+:kconfig:option:`CONFIG_NET_CONFIG_SETTINGS` enabled),
+set the :kconfig:option:`CONFIG_NET_CONFIG_MY_IPV4_GW` option to the IP address
+of the gateway. For apps not using the "Settings" facility, set up the
+gateway by calling the :c:func:`net_if_ipv4_set_gw` at runtime.
+For example: ``CONFIG_NET_CONFIG_MY_IPV4_GW="192.0.2.2"``
+
+To access the internet from a custom application running in :zephyr:board:`native_sim <native_sim>`
+board, NAT (masquerading) should be set up for :zephyr:board:`native_sim <native_sim>` board
+source address. Assuming ``192.0.2.1`` is used and the Zephyr network interface is ``zeth``,
+navigate to `net-tools`_ directory and run the following command as root:
+
+.. code-block:: console
+
+   ./net-setup.sh start --config nat.conf
+
+Some applications may also require a DNS server. A number of Zephyr-provided
+samples assume by default that the DNS server is available on the host
+(IP ``192.0.2.2``), which, in modern Linux distributions, usually runs at least
+a DNS proxy. When running with :zephyr:board:`native_sim <native_sim>` board,
+it may be required to restart the host's DNS, so it can serve requests on the
+newly created TAP interface. For example, on Debian-based systems:
+
+.. code-block:: console
+
+   service dnsmasq restart
+
+An alternative to relying on the host's DNS server is to use one in the
+network. For example, ``8.8.8.8`` is a publicly available DNS server. You can
+configure it using :kconfig:option:`CONFIG_DNS_SERVER1` option.
+
 .. _`net-tools`: https://github.com/zephyrproject-rtos/net-tools


### PR DESCRIPTION
It would be nice to have this documented as well in native_sim_setup as native_sim board has much better hardware support in linux host as compared to QEMU.