### PR TITLE
dts: binding: adc: siwx91x: fix typo in description

### DIFF
--- a/dts/bindings/adc/silabs,siwx91x-adc.yaml
+++ b/dts/bindings/adc/silabs,siwx91x-adc.yaml
@@ -14,7 +14,7 @@ properties:
   silabs,adc-ref-voltage:
     type: int
     description: |
-        ADC reference volatge in mv. This voltage is common for all
+        ADC reference voltage in mv. This voltage is common for all
         the channels.
         Valid range: 1800 - 3600
     required: true


### PR DESCRIPTION
Fix voltage typo in description field in silabs,siwx91x-adc.yaml

No functional change.