### PR TITLE
doc: develop: picolibc: fix reference to libc hooks location

### DIFF
--- a/doc/develop/languages/c/picolibc.rst
+++ b/doc/develop/languages/c/picolibc.rst
@@ -16,7 +16,7 @@ each supported architecture (:file:`libc.a`).
 
 Zephyr implements the “API hook” functions that are invoked by the C
 standard library functions in the Picolibc. These hook functions are
-implemented in :file:`lib/libc/picolibc/libc-hooks.c` and translate
+implemented in :zephyr_file:`lib/libc/picolibc/` and translate
 the library internal system calls to the equivalent Zephyr API calls.
 
 .. _`Picolibc`: https://github.com/picolibc/picolibc


### PR DESCRIPTION
The documentation incorrectly pointed to a single file (libc-hooks.c) for the Picolibc API hook implementations.

These hooks are implemented across the lib/libc/picolibc/ directory, not in a single file.

Update the documentation to reference the directory instead to avoid confusion.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/102847