### PR TITLE
modem: chat: add support for sending requests without delimiter

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -118,6 +118,8 @@ struct modem_chat_script_chat {
 	uint16_t response_matches_size;
 	/** Timeout before chat script may continue to next step in milliseconds */
 	uint16_t timeout;
+	/** Set if request shall be sent without delimiter */
+	bool no_delimiter;
 };
 
 #define MODEM_CHAT_SCRIPT_CMD_RESP(_request, _response_match)                                      \
@@ -145,6 +147,34 @@ struct modem_chat_script_chat {
 		.response_matches = NULL,                                                          \
 		.response_matches_size = 0,                                                        \
 		.timeout = _timeout_ms,                                                            \
+	}
+
+/**
+ * @brief Send request without delimiter, wait for response
+ * @details Useful for escape sequences like "+++" that must not have trailing delimiter
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_NO_DELIM(_request, _response_match)                             \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = &_response_match,                                              \
+		.response_matches_size = 1,                                                        \
+		.timeout = 0,                                                                      \
+		.no_delimiter = true,                                                              \
+	}
+
+/**
+ * @brief Send request without delimiter, no response expected
+ * @details Useful for escape sequences like "+++" that must not have trailing delimiter
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_NONE_NO_DELIM(_request, _timeout_ms)                            \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = NULL,                                                          \
+		.response_matches_size = 0,                                                        \
+		.timeout = _timeout_ms,                                                            \
+		.no_delimiter = true,                                                              \
 	}
 
 #define MODEM_CHAT_SCRIPT_CMDS_DEFINE(_sym, ...)                                                   \
@@ -485,6 +515,15 @@ int modem_chat_script_chat_set_response_matches(struct modem_chat_script_chat *s
  */
 void modem_chat_script_chat_set_timeout(struct modem_chat_script_chat *script_chat,
 					uint16_t timeout_ms);
+
+/**
+ * @brief Set modem chat script chat no_delimiter flag
+ * @param script_chat Modem chat script chat instance
+ * @param no_delimiter If true, request is sent without trailing delimiter
+ * @note Useful for escape sequences like "+++" that must not have trailing delimiter
+ */
+void modem_chat_script_chat_set_no_delimiter(struct modem_chat_script_chat *script_chat,
+						 bool no_delimiter);
 
 /**
  * @brief Initialize modem chat script


### PR DESCRIPTION
The current modem_chat implementation always appends a delimiter (e.g., \r\n) after every request sent via modem_chat_run_script() or modem_chat_run_script_async(). This behavior is hardcoded in modem_chat_script_send_handler(), which unconditionally transitions from MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST to MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER.

However, some modems require escape sequences to be sent without a trailing delimiter. A common example is the Hayes escape sequence "+++" or EOF_PATTERN used to switch from DATA mode back to COMMAND mode.

Example use case (Sierra Wireless HL78xx):

When GNSS NMEA streaming is enabled with AT+GNSSNMEA=4, the modem switches to DATA mode and continuously outputs NMEA sentences. The only way to return to command mode is to send +++ without any trailing \r\n:

```
AT+GNSSNMEA=4
CONNECT
$GPGGA,235436.00,4910.3542,N,12304.2419,W,0,00,1.2,-0.4,M,-17.6,M,,*7B
$GPGSA,A,1,,,,,,,,,,,,,2.1,1.2,1.7*36
...
+++      <-- must be sent WITHOUT \r\n
OK

```

It is the same problem for socket data. After sending socket data, an EOF pattern needs to be sent without any trailing to switch back to command mode from data mode. 

I believe the best and lightest way to send this kind of data is using existing infrastructure.

Currently, users must use modem_pipe_transmit() directly, which bypasses the benefits of modem_chat:

- No response matching/waiting
- No script flow control
- No handling of pipe busy state

Solution
Add a no_delimiter flag to struct modem_chat_script_chat that, when set to true, causes the chat module to skip sending the delimiter after the request.

Changes:

- struct modem_chat_script_chat - Added bool no_delimiter field
- modem_chat_script_send_handler() - Skip delimiter state when no_delimiter is true
- New macros:
   - MODEM_CHAT_SCRIPT_CMD_RESP_NO_DELIM() - Send without delimiter, expect response
   - MODEM_CHAT_SCRIPT_CMD_RESP_NONE_NO_DELIM() - Send without delimiter, no response expected
- New API function:
  - modem_chat_script_chat_set_no_delimiter() - Runtime setter for the flag

Usage example:

```
MODEM_CHAT_MATCH_DEFINE(ok_match, "OK", "", NULL);

MODEM_CHAT_SCRIPT_CMDS_DEFINE(gnss_escape_cmds,
    /* Send "+++" without delimiter to escape DATA mode */
    MODEM_CHAT_SCRIPT_CMD_RESP_NO_DELIM("+++", ok_match),
);

MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(gnss_escape_script, 
                                   gnss_escape_cmds, 
                                   my_callback, 10);
```

Backward Compatibility
This change is fully backward compatible:

- The no_delimiter field defaults to false (zero-initialized)
- Existing scripts work unchanged
- No changes required to existing code

Testing

- Tested with Sierra Wireless HL7812 modem
- Verified +++ escape sequence successfully returns modem from GNSS NMEA DATA mode to COMMAND mode
- Verified normal AT commands still work with delimiter