### PR TITLE
drivers: flash: place API into iterable section

### DIFF
--- a/drivers/flash/flash_infineon_serial_memory_qspi.c
+++ b/drivers/flash/flash_infineon_serial_memory_qspi.c
@@ -257,7 +257,7 @@ static int ifx_serial_memory_flash_init(const struct device *dev)
 	return result;
 }
 
-static const struct flash_driver_api ifx_serial_memory_flash_driver_api = {
+static DEVICE_API(flash, ifx_serial_memory_flash_driver_api) = {
 	.read = ifx_serial_memory_flash_read,
 	.write = ifx_serial_memory_flash_write,
 	.erase = ifx_serial_memory_flash_erase,

--- a/drivers/flash/flash_mcux_c40.c
+++ b/drivers/flash/flash_mcux_c40.c
@@ -313,7 +313,7 @@ static int flash_mcux_c40_init(const struct device *dev)
 	return 0;
 }
 
-static const struct flash_driver_api mcux_c40_api = {
+static DEVICE_API(flash, mcux_c40_api) = {
 	.read = flash_mcux_c40_read,
 	.write = flash_mcux_c40_write,
 	.erase = flash_mcux_c40_erase,

--- a/drivers/flash/flash_renesas_ra_qspi.c
+++ b/drivers/flash/flash_renesas_ra_qspi.c
@@ -463,7 +463,7 @@ static const struct flash_parameters *qspi_flash_ra_get_parameters(const struct 
 
 	return &qspi_flash_ra_config_para;
 }
-static const struct flash_driver_api qspi_flash_ra_api = {
+static DEVICE_API(flash, qspi_flash_ra_api) = {
 	.erase = qspi_flash_ra_erase,
 	.write = qspi_flash_ra_write,
 	.read = qspi_flash_ra_read,


### PR DESCRIPTION
Add the `DEVICE_API` wrapper to the remaining `flash_driver_api` instances, ensuring that each driver API is placed in its respective linker section.