### PR TITLE
drivers: gpio: place API into iterable section

### DIFF
--- a/drivers/gpio/gpio_ameba.c
+++ b/drivers/gpio/gpio_ameba.c
@@ -250,7 +250,7 @@ static void gpio_ameba_isr(const struct device *dev)
 	gpio_fire_callbacks(&data->callbacks, dev, int_status);
 }
 
-static const struct gpio_driver_api gpio_ameba_driver_api = {
+static DEVICE_API(gpio, gpio_ameba_driver_api) = {
 	.pin_configure = gpio_ameba_configure,
 	.port_get_raw = gpio_ameba_port_get_raw,
 	.port_set_masked_raw = gpio_ameba_port_set_masked_raw,

--- a/drivers/gpio/gpio_bflb_bl60x_70x.c
+++ b/drivers/gpio/gpio_bflb_bl60x_70x.c
@@ -336,7 +336,7 @@ static int gpio_bflb_manage_callback(const struct device *port,
 	return gpio_manage_callback(&(data->callbacks), callback, set);
 }
 
-static const struct gpio_driver_api gpio_bflb_api = {
+static DEVICE_API(gpio, gpio_bflb_api) = {
 	.pin_configure = gpio_bflb_config,
 	.port_get_raw = gpio_bflb_port_get_raw,
 	.port_set_masked_raw = gpio_bflb_port_set_masked_raw,

--- a/drivers/gpio/gpio_bflb_bl61x.c
+++ b/drivers/gpio/gpio_bflb_bl61x.c
@@ -325,7 +325,7 @@ static int gpio_bflb_manage_callback(const struct device *port,
 	return gpio_manage_callback(&(data->callbacks), callback, set);
 }
 
-static const struct gpio_driver_api gpio_bflb_api = {
+static DEVICE_API(gpio, gpio_bflb_api) = {
 	.pin_configure = gpio_bflb_config,
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = gpio_bflb_get_config,

--- a/drivers/gpio/gpio_ene_kb106x.c
+++ b/drivers/gpio/gpio_ene_kb106x.c
@@ -204,7 +204,7 @@ static uint32_t kb106x_gpio_get_pending_int(const struct device *dev)
 	return config->gptd_regs->GPTDPF;
 }
 
-static const struct gpio_driver_api kb106x_gpio_api = {
+static DEVICE_API(gpio, kb106x_gpio_api) = {
 	.pin_configure = kb106x_gpio_pin_configure,
 	.port_get_raw = kb106x_gpio_port_get_raw,
 	.port_set_masked_raw = kb106x_gpio_port_set_masked_raw,


### PR DESCRIPTION
Add the `DEVICE_API` wrapper to the remaining `gpio_driver_api` instances, ensuring that each driver API is placed in its respective linker section.