### PR TITLE
soc: nordic: uicr: Add custom user args to UICR generator script

### DIFF
--- a/soc/nordic/common/uicr/Kconfig.gen_uicr
+++ b/soc/nordic/common/uicr/Kconfig.gen_uicr
@@ -285,4 +285,11 @@ config GEN_UICR_SECONDARY_PROTECTEDMEM_SIZE_BYTES
 
 endif # GEN_UICR_SECONDARY
 
+config GEN_UICR_EXTRA_ARGS
+	string "Extra arguments to pass to the UICR generator script"
+	default ""
+	help
+	  This configuration can be used to pass extra arguments to the UICR generator
+	  script. Multiple arguments should be separated with spaces.
+
 endmenu

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -261,6 +261,12 @@ if(CONFIG_GEN_UICR_SECONDARY)
   endif()
 endif()
 
+if(NOT CONFIG_GEN_UICR_EXTRA_ARGS STREQUAL "")
+  separate_arguments(extra_args UNIX_COMMAND ${CONFIG_GEN_UICR_EXTRA_ARGS})
+else()
+  set(extra_args)
+endif()
+
 # Generate hex files (merged, uicr-only, periphconf-only, and secondary-periphconf-only)
 add_custom_command(
   OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file}
@@ -279,6 +285,7 @@ add_custom_command(
           ${securestorage_args}
           ${protectedmem_args}
           ${secondary_args}
+          ${extra_args}
   DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Using gen_uicr.py to generate ${merged_hex_file}, ${uicr_hex_file}, ${periphconf_hex_file}, and ${secondary_periphconf_hex_file} from ${periphconf_elfs} ${secondary_periphconf_elfs}"


### PR DESCRIPTION
Add a new option CONFIG_GEN_UICR_EXTRA_ARGS to the UICR generator image for passing additional user defined arguments to the UICR generator script.

While most options of the script should be available through the Kconfig interface, certain options might not exposed, such as --permit-permanently-transitioning-device-to-deployed, and this option provides a way to set them.