### PR TITLE
Fix ztest shell compilation for native sim

### DIFF
--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -208,7 +208,7 @@ static inline void print_nothing(const char *fmt, ...)
 	} while (false)
 #endif
 
-#if defined(CONFIG_ARCH_POSIX)
+#if defined(CONFIG_ARCH_POSIX) && !defined(CONFIG_ZTEST_SHELL)
 #include <zephyr/logging/log_ctrl.h>
 #define TC_END_POST(result) do { \
 	LOG_PANIC(); \

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -86,6 +86,20 @@ bool z_ztest_get_list_test(void)
 	return list_tests;
 }
 
+void ztest_reset_test_args(void)
+{
+	if (test_args != NULL) {
+		nsi_host_free((void *)test_args);
+	}
+	test_args = NULL;
+}
+
+void ztest_set_test_args(char *args)
+{
+	ztest_reset_test_args();
+	test_args = nsi_host_strdup(args);
+}
+
 /**
  * @brief Helper function to get command line test arguments
  *

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -16,6 +16,7 @@
 static const char *test_args;
 static bool list_tests;
 
+#if !defined(CONFIG_ZTEST_SHELL)
 static void add_test_filter_option(void)
 {
 	static struct args_struct_t test_filter_s[] = {
@@ -39,6 +40,7 @@ static void add_test_filter_option(void)
 }
 
 NATIVE_TASK(add_test_filter_option, PRE_BOOT_1, 10);
+#endif
 
 /**
  * @brief Try to shorten a filename by removing the current directory


### PR DESCRIPTION
When CONFIG_ZTEST_SHELL=y, the system failed to compile due unsatisfied  references to `ztest_set_test_args` and `test_reset_test_args`.  Adding the functions to `ztest_posix.c` fixes the issue.

Also forces `TC_END_POST` to evaluate to an empty statement if `ZTEST_SHELL` is selected, ensuring the application won't call `posix_end()`, allowing the application to continue running.

Fix #102866 