### PR TITLE
drivers: audio: wm8904: support platforms without MCLK access

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -23,6 +23,7 @@ struct wm8904_driver_config {
 	int clock_source;
 	const struct device *mclk_dev;
 	clock_control_subsys_t mclk_name;
+	int fs_ratio;
 };
 
 #define DEV_CFG(dev) ((const struct wm8904_driver_config *const)dev->config)
@@ -483,17 +484,35 @@ static int wm8904_configure(const struct device *dev, struct audio_codec_cfg *cf
 			  (uint16_t)(dev_cfg->clock_source));
 
 	if (dev_cfg->clock_source == 0) {
-		int err = clock_control_on(dev_cfg->mclk_dev, dev_cfg->mclk_name);
+		LOG_DBG("MCLK selected as clock source");
 
-		if (err < 0) {
-			LOG_ERR("MCLK clock source enable fail: %d", err);
-		}
+		/* Both MCLK dev & MCLK name should be present */
+		if (dev_cfg->mclk_dev != NULL && dev_cfg->mclk_name != NULL) {
+			int err = clock_control_on(dev_cfg->mclk_dev, dev_cfg->mclk_name);
 
-		err = clock_control_get_rate(dev_cfg->mclk_dev, dev_cfg->mclk_name,
-					     &cfg->mclk_freq);
-		if (err < 0) {
-			LOG_ERR("MCLK clock source freq acquire fail: %d", err);
+			if (err < 0) {
+				LOG_ERR("MCLK clock source enable fail: %d", err);
+				return err;
+			}
+
+			err = clock_control_get_rate(dev_cfg->mclk_dev, dev_cfg->mclk_name,
+						     &cfg->mclk_freq);
+			if (err < 0) {
+				LOG_ERR("MCLK clock source freq acquire fail: %d", err);
+				return err;
+			}
+		} else {
+			if (dev_cfg->fs_ratio == 0) {
+				LOG_ERR("Cannot compute MCLK: missing MCLK and fs_ratio in DT");
+				return -EINVAL;
+			}
+
+			cfg->mclk_freq = cfg->dai_cfg.i2s.frame_clk_freq * dev_cfg->fs_ratio;
+			LOG_WRN("Cannot obtain MCLK from DT, using computed MCLK=%u from fs_ratio",
+				cfg->mclk_freq);
 		}
+	} else {
+		LOG_DBG("FLL selected as clock source");
 	}
 
 	wm8904_audio_fmt_config(dev, &cfg->dai_cfg, cfg->mclk_freq);
@@ -665,11 +684,15 @@ static const struct audio_codec_api wm8904_driver_api = {
 #define WM8904_INIT(n)                                                                             \
 	static const struct wm8904_driver_config wm8904_device_config_##n = {                      \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
-		.clock_source = DT_INST_ENUM_IDX(n, clock_source),				   \
-		.mclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, mclk)),                   \
-		.mclk_name = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)};  \
+		.clock_source = DT_INST_ENUM_IDX(n, clock_source),                                 \
+		.mclk_dev = COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(n, mclk),                          \
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, mclk))), (NULL)),            \
+		.mclk_name = COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(n, mclk),                         \
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)),      \
+			(NULL)),                                                                   \
+		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0)};                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n,        \
-			      POST_KERNEL, CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &wm8904_device_config_##n, POST_KERNEL,         \
+			      CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WM8904_INIT)

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -23,3 +23,13 @@ properties:
     enum:
       - "MCLK"
       - "FLL"
+  fs-ratio:
+    type: int
+    default: 256
+    enum: [64, 128, 192, 256, 384, 512, 768, 1024, 1408, 1536]
+    description: |
+      This property is intended for platforms where the MCLK frequency is
+      not directly available to the driver.
+      On such platforms, the driver assumes the MCLK frequency to be equal
+      to (fs-ratio * <sample rate>), where the sample rate comes from the
+      audio codec configuration provided at runtime.


### PR DESCRIPTION
Enable use of the WM8904 driver on platforms that do not provide direct access to the MCLK signal. 
Introduce fs-ratio, which is used to derive the MCLK value from the selected frame sync (FS) rate.

Tested on: nucleo_h563zi + [PIC32 AUDIO CODEC DAUGHTER CARD](https://www.microchip.com/en-us/development-tool/ac328904)

Test Patch: [nucleo_h563zi_wm8904.patch](https://github.com/user-attachments/files/24846845/nucleo_h563zi_wm8904.patch)
