### PR TITLE
Bluetooth: TBS: Client: Fix reset issue with net_buf

### DIFF
--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -761,8 +761,13 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 static void initialize_net_buf_read_buffer(struct bt_tbs_instance *inst)
 {
-	net_buf_simple_init_with_data(&inst->net_buf, &inst->read_buf,
-				      sizeof(inst->read_buf));
+	if (inst->net_buf.data == NULL) {
+		net_buf_simple_init_with_data(&inst->net_buf, &inst->read_buf,
+					      sizeof(inst->read_buf));
+	} else {
+		(void)memset(inst->net_buf.data, 0, inst->net_buf.len);
+	}
+
 	net_buf_simple_reset(&inst->net_buf);
 }
 


### PR DESCRIPTION
The net_buf was always initialized with net_buf_simple_init_with_data which was a bit wasteful as we only need to do that once. Since `inst` is `static`ally allocated, we can check for `.data == NULL`.

Additionally the read callbacks expect the buffer to be 0-initialized between each usage, which wasn't the case. We can use the `buf.len` to determine how many bytes we need to reset to `0`.