### PR TITLE
include: display: cfb: add proper API version & group

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -23,7 +23,9 @@ extern "C" {
 /**
  * @brief Public Monochrome Character Framebuffer API
  * @defgroup monochrome_character_framebuffer Monochrome Character Framebuffer
- * @ingroup utilities
+ * @since 1.14.0
+ * @version 0.9.0
+ * @ingroup display_interface
  * @{
  */
 


### PR DESCRIPTION
Add CFB API version (as unstable), and correct Doxygen parent group.