### PR TITLE
drivers: video: esp32: fix camera sensor init race condition

### DIFF
--- a/soc/espressif/common/esp_lcd_cam.c
+++ b/soc/espressif/common/esp_lcd_cam.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <hal/cam_ll.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
@@ -12,6 +13,7 @@
 LOG_MODULE_REGISTER(esp32_lcd_cam, CONFIG_SOC_LOG_LEVEL);
 
 #define ESP32_LCD_CAM_INST DT_COMPAT_GET_ANY_STATUS_OKAY(espressif_esp32_lcd_cam)
+#define ESP32_LCD_CAM_DVP_INST DT_COMPAT_GET_ANY_STATUS_OKAY(espressif_esp32_lcd_cam_dvp)
 
 PINCTRL_DT_DEFINE(ESP32_LCD_CAM_INST);
 
@@ -20,6 +22,10 @@ static const struct pinctrl_dev_config *pcfg = PINCTRL_DT_DEV_CONFIG_GET(ESP32_L
 static const struct device *clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(ESP32_LCD_CAM_INST));
 static const clock_control_subsys_t clock_subsys =
 	(clock_control_subsys_t)DT_CLOCKS_CELL(ESP32_LCD_CAM_INST, offset);
+
+#if DT_NODE_HAS_STATUS_OKAY(ESP32_LCD_CAM_DVP_INST)
+static const uint32_t cam_clk = DT_PROP_OR(ESP32_LCD_CAM_DVP_INST, cam_clk, 0);
+#endif
 
 static int esp32_lcd_cam_init(void)
 {
@@ -35,7 +41,22 @@ static int esp32_lcd_cam_init(void)
 		return -ENODEV;
 	}
 
-	return clock_control_on(clock_dev, clock_subsys);
+	ret = clock_control_on(clock_dev, clock_subsys);
+	if (ret < 0) {
+		return ret;
+	}
+
+#if DT_NODE_HAS_STATUS_OKAY(ESP32_LCD_CAM_DVP_INST)
+	if (cam_clk && (ESP32_CLK_CPU_PLL_160M % cam_clk) == 0) {
+		cam_ll_select_clk_src(0, LCD_CLK_SRC_PLL160M);
+		cam_ll_set_group_clock_coeff(0, ESP32_CLK_CPU_PLL_160M / cam_clk, 0, 0);
+	} else {
+		LOG_ERR("Invalid cam_clk value. It must be a non-zero divisor of 160M");
+		return -EINVAL;
+	}
+#endif
+
+	return 0;
 }
 
 SYS_INIT(esp32_lcd_cam_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Move camera XCLK setup from DVP driver (POST_KERNEL) to esp_lcd_cam.c (PRE_KERNEL_2) to ensure the image sensor receives clock before its I2C initialization. This fixes a race condition where sensors like ov2640 would fail to respond during probe because XCLK wasn't yet configured.

Also adds timestamp to captured video buffers and removes a noisy error log for set_selection when the source returns -ENOSYS.

Possible regression in #99863