### PR TITLE
checkpatch: warn on sizeof used with character literals

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -6192,6 +6192,13 @@ sub process {
 			}
 		}
 
+# check for sizeof used on character literals
+		if ($line =~ /\bsizeof\s*\(\s*'(?:X+)'\s*\)/) {
+			WARN("SIZEOF_CHAR_LITERAL",
+			     "sizeof() used on a character literal; character literals have type int\n" .
+			     "Suggestion: use sizeof((char)'x') instead, e.g.sizeof((char)'/') \n" . $herecurr);
+		}
+
 # check for struct spinlock declarations
 		if ($line =~ /^.\s*\bstruct\s+spinlock\s+\w+\s*;/) {
 			WARN("USE_SPINLOCK_T",


### PR DESCRIPTION
Related :  #102707

Summary:
Add a checkpatch warning to flag use of sizeof() on character literals,
which evaluate to sizeof(int) in C and can lead to subtle size
miscalculations.

Details:
This adds a WARN rule to scripts/checkpatch.pl that detects patterns
such as sizeof('/') and suggests using sizeof((char)'x') instead.

Testing:
Verified locally by running scripts/checkpatch.pl -f on a test file
containing sizeof('/').

Notes:
This is my first open-source contribution feedback is very welcome.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/102707