### PR TITLE
MAINTAINER: Add william-tang914 as CAN Collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1321,6 +1321,7 @@ Documentation Infrastructure:
     - alexanderwachter
     - martinjaeger
     - str4t0m
+    - william-tang914
   files:
     - boards/shields/canis_canpico/
     - boards/shields/mcp2515/


### PR DESCRIPTION
Add william-tang914 as a collaborator for the CAN driver.

Supporting materials:

[Merged PRS](https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+author%3Awilliam-tang914+label%3A%22area%3A+CAN%22+is%3Aclosed)
[Opened PRS](https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+author%3Awilliam-tang914+label%3A%22area%3A+CAN%22+is%3Aopen)
[Reviewed PRS](https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+reviewed-by%3A%40me+is%3Aclosed+label%3A%22area%3A+CAN%22)