### PR TITLE
manifest: Update TF-M for STM32 non-secure flash locking issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -386,7 +386,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 3a128df2bdebedf5a01726e86de3880991d6bb63
+      revision: 3ddfef0edd4fe5672cd63afbe3538509568170df
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update TF-M to prevent TF-M runtime secure firmware to lock the internal non-secure flash when it erases or re-program a secure area (e.g., ITS or PS). This prevents flash lock management conflicts when Zephyr erases or re-program a non-secure flash area it owns.