### PR TITLE
modules: hal_nordic: set MDK configuration symbols with a config file

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -35,81 +35,7 @@ zephyr_include_directories(.)
 
 include(${BSP_DIR}/zephyr/nrfx.cmake OPTIONAL)
 
-# Define MDK defines globally
-zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF51       NRF51)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAA       NRF51422_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAB       NRF51422_XXAB)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF51822_QFAC       NRF51422_XXAC)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52805            NRF52805_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52810            NRF52810_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52811            NRF52811_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52820            NRF52820_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52832            NRF52832_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF52833 NRF52833_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF52840            NRF52840_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP NRF5340_XXAA_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET NRF5340_XXAA_NETWORK)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUAPP     NRF54H20_XXAA
-                                                                NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPURAD     NRF54H20_XXAA
-                                                                NRF_RADIOCORE)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
-                                                                NRF_PPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
-                                                                NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA
-                                                                DEVELOP_IN_NRF54L15)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUAPP     NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA
-                                                                DEVELOP_IN_NRF54L15)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUAPP     NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15 NRF54L15_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA     NRF54LM20A_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A NRF54LM20A_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54LM20A_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF7120_ENGA NRF7120_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF7120_ENGA_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF7120_ENGA_CPUFLPR NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA NRF7120_ENGA_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA_CPUAPP NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9120             NRF9120_XXAA)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9160             NRF9160_XXAA)
-
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUAPP NRF9230_ENGB_XXAA
-                                                                NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPURAD NRF9230_ENGB_XXAA
-                                                                NRF_RADIOCORE)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUPPR NRF9230_ENGB_XXAA
-                                                                NRF_PPR)
-
-zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_LOCK
-                                 ENABLE_APPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_USER_HANDLING
-                                 ENABLE_APPROTECT_USER_HANDLING
-                                 ENABLE_AUTHENTICATED_APPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
-                                 ENABLE_SECURE_APPROTECT
-                                 ENABLE_SECUREAPPROTECT)
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
-                                 ENABLE_SECURE_APPROTECT_USER_HANDLING
-                                 ENABLE_AUTHENTICATED_SECUREAPPROTECT)
-zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
-                                 ENABLE_TRACE)
-
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUAPP
-                                 NRF_SKIP_FICR_NS_COPY_TO_RAM)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_SERIES_NRF91
-                                 NRF_SKIP_FICR_NS_COPY_TO_RAM)
-
-# Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx
-zephyr_compile_definitions_ifdef(CONFIG_ARM_NONSECURE_FIRMWARE NRF_TRUSTZONE_NONSECURE)
-zephyr_compile_definitions_ifdef(CONFIG_LOG_BACKEND_SWO ENABLE_SWO)
+zephyr_compile_definitions(NRF_CONFIG_USE_MDK_CONFIG_FILE)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_NRF51  ${MDK_DIR}/system_nrf51.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_NRF52805       ${MDK_DIR}/system_nrf52805.c)
@@ -191,58 +117,6 @@ zephyr_library_sources_ifdef(CONFIG_NRFX_WDT     ${SRC_DIR}/nrfx_wdt.c)
 if(CONFIG_NRFX_TWI OR CONFIG_NRFX_TWIM)
   zephyr_library_sources(${SRC_DIR}/nrfx_twi_twim.c)
 endif()
-
-# Inject HAL "NFCT_PINS_AS_GPIOS" definition if user requests to
-# configure the NFCT pins as GPIOS. Do the same with "CONFIG_GPIO_AS_PINRESET"
-# to configure the reset GPIO as nRESET. This way, the HAL will take care of
-# doing the proper configuration sequence during system init
-
-dt_nodelabel(uicr_path NODELABEL "uicr")
-if(DEFINED uicr_path)
-  dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
-  if(${nfct_pins_as_gpios})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_NFCT_PINS_AS_GPIOS
-    )
-  endif()
-
-  dt_prop(gpio_as_nreset PATH ${uicr_path} PROPERTY "gpio-as-nreset")
-  if(${gpio_as_nreset})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_GPIO_AS_PINRESET
-    )
-  endif()
-endif()
-
-dt_nodelabel(tampc_path NODELABEL "tampc")
-if(DEFINED tampc_path)
-  dt_prop(swd_pins_as_gpios PATH ${tampc_path} PROPERTY "swd-pins-as-gpios")
-  if(${swd_pins_as_gpios})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_SWD_PINS_AS_GPIOS
-    )
-  endif()
-endif()
-
-if(CONFIG_SOC_NRF54L_CPUAPP_COMMON)
-  # Ideally, hfpll should taken as a phandle from clocks property from cpu but it
-  # seems that there is no such option in DT cmake functions. Assuming that nrf54l
-  # is using hfpll as CPU clock source (true for all existing devices).
-  dt_prop(clock_frequency PATH "/clocks/hfpll" PROPERTY "clock-frequency")
-  math(EXPR clock_frequency_mhz "${clock_frequency} / 1000000")
-  zephyr_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
-endif()
-
-if(CONFIG_SOC_NRF7120_ENGA_CPUAPP)
-  dt_prop(clock_frequency PATH "/cpus/cpu@0" PROPERTY "clock-frequency")
-  math(EXPR clock_frequency_mhz "${clock_frequency} / 1000000")
-  zephyr_compile_definitions("NRF_CONFIG_CPU_FREQ_MHZ=${clock_frequency_mhz}")
-endif()
-
-zephyr_compile_definitions_ifdef(CONFIG_NRF_SKIP_CLOCK_CONFIG NRF_SKIP_CLOCK_CONFIGURATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF NRF_DISABLE_FICR_TRIMCNF)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE NRF_SKIP_GLITCHDETECTOR_DISABLE)
-zephyr_compile_definitions_ifndef(CONFIG_SOC_NRF54L_ANOMALY_56_WORKAROUND NRF54L_CONFIGURATION_56_ENABLE=0)
 
 if(CONFIG_SOC_SERIES_NRF54H AND CONFIG_NRFX_GPPI_V1)
   zephyr_library_sources(${HELPERS_DIR}/internal/nrfx_gppiv1_ipct.c)

--- a/modules/hal_nordic/nrfx/mdk_config.h
+++ b/modules/hal_nordic/nrfx/mdk_config.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MDK_CONFIG_H__
+#define MDK_CONFIG_H__
+
+#include <zephyr/devicetree.h>
+
+#if defined(CONFIG_SOC_SERIES_NRF51) && !defined(NRF51)
+#define NRF51
+#endif
+
+#if defined(CONFIG_SOC_NRF51822_QFAA) && !defined(NRF51422_XXAA)
+#define NRF51422_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF51822_QFAB) && !defined(NRF51422_XXAB)
+#define NRF51422_XXAB
+#endif
+
+#if defined(CONFIG_SOC_NRF51822_QFAC) && !defined(NRF51422_XXAC)
+#define NRF51422_XXAC
+#endif
+
+#if defined(CONFIG_SOC_NRF52805) && !defined(NRF52805_XXAA)
+#define NRF52805_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF52810) && !defined(NRF52810_XXAA)
+#define NRF52810_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF52811) && !defined(NRF52811_XXAA)
+#define NRF52811_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF52820) && !defined(NRF52820_XXAA)
+#define NRF52820_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF52832) && !defined(NRF52832_XXAA)
+#define NRF52832_XXAA
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF52833) && !defined(NRF52833_XXAA)
+#define NRF52833_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF52840) && !defined(NRF52840_XXAA)
+#define NRF52840_XXAA
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP) && !defined(NRF5340_XXAA_APPLICATION)
+#define NRF5340_XXAA_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET) && !defined(NRF5340_XXAA_NETWORK)
+#define NRF5340_XXAA_NETWORK
+#endif
+
+#if defined(CONFIG_SOC_NRF54H20) && !defined(NRF54H20_XXAA)
+#define NRF54H20_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF54H20_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54H20_CPURAD) && !defined(NRF_RADIOCORE)
+#define NRF_RADIOCORE
+#endif
+
+#if defined(CONFIG_SOC_NRF54H20_CPUPPR) && !defined(NRF_PPR)
+#define NRF_PPR
+#endif
+
+#if defined(CONFIG_SOC_NRF54H20_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF54H20_XXAA
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_NRF54L05) && !defined(NRF54L05_XXAA) && !defined(DEVELOP_IN_NRF54L15)
+#define NRF54L05_XXAA
+#define DEVELOP_IN_NRF54L15
+#endif
+
+#if defined(CONFIG_SOC_NRF54L05_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54L05_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_NRF54L10) && !defined(NRF54L10_XXAA) && !defined(DEVELOP_IN_NRF54L15)
+#define NRF54L10_XXAA
+#define DEVELOP_IN_NRF54L15
+#endif
+
+#if defined(CONFIG_SOC_NRF54L10_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54L10_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54L15) && !defined(NRF54L15_XXAA)
+#define NRF54L15_XXAA
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54L15_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA) && !defined(NRF54LM20A_ENGA_XXAA)
+#define NRF54LM20A_ENGA_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54LM20A_ENGA_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LM20A) && !defined(NRF54LM20A_ENGA_XXAA)
+#define NRF54LM20A_ENGA_XXAA
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF54LM20A_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF7120_ENGA) && !defined(NRF7120_ENGA_XXAA)
+#define NRF7120_ENGA_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF7120_ENGA_CPUFLPR) && !defined(NRF_FLPR)
+#define NRF_FLPR
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA) && !defined(NRF7120_ENGA_XXAA)
+#define NRF7120_ENGA_XXAA
+#endif
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF9120) && !defined(NRF9120_XXAA)
+#define NRF9120_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF9160) && !defined(NRF9160_XXAA)
+#define NRF9160_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF9230_ENGB) && !defined(NRF9230_ENGB_XXAA)
+#define NRF9230_ENGB_XXAA
+#endif
+
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPUAPP) && !defined(NRF_APPLICATION)
+#define NRF_APPLICATION
+#endif
+
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPURAD) && !defined(NRF_RADIOCORE)
+#define NRF_RADIOCORE
+#endif
+
+#if defined(CONFIG_SOC_NRF9230_ENGB_CPUPPR) && !defined(NRF_PPR)
+#define NRF_PPR
+#endif
+
+#if defined(CONFIG_NRF_APPROTECT_LOCK)
+#define ENABLE_APPROTECT
+#endif
+
+#if defined(CONFIG_NRF_APPROTECT_USER_HANDLING)
+#define ENABLE_APPROTECT_USER_HANDLING
+#define ENABLE_AUTHENTICATED_APPROTECT
+#endif
+
+#if defined(CONFIG_NRF_SECURE_APPROTECT_LOCK)
+#define ENABLE_SECURE_APPROTECT
+#define ENABLE_SECUREAPPROTECT
+#endif
+
+#if defined(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING)
+#define ENABLE_SECURE_APPROTECT_USER_HANDLING
+#define ENABLE_AUTHENTICATED_SECUREAPPROTECT
+#endif
+
+#if defined(CONFIG_NRF_TRACE_PORT)
+#define ENABLE_TRACE
+#endif
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define NRF_SKIP_FICR_NS_COPY_TO_RAM
+#endif
+
+#if defined(CONFIG_SOC_SERIES_NRF91)
+#define NRF_SKIP_FICR_NS_COPY_TO_RAM
+#endif
+
+/* Connect Kconfig compilation option for Non-Secure software with option required by MDK/nrfx */
+
+#if defined(CONFIG_ARM_NONSECURE_FIRMWARE)
+#define NRF_TRUSTZONE_NONSECURE
+#endif
+
+#if defined(CONFIG_LOG_BACKEND_SWO)
+#define ENABLE_SWO
+#endif
+
+/*
+ * Inject HAL "NFCT_PINS_AS_GPIOS" definition if user requests to
+ * configure the NFCT pins as GPIOS. Do the same with "CONFIG_GPIO_AS_PINRESET"
+ * to configure the reset GPIO as nRESET. This way, the HAL will take care of
+ * doing the proper configuration sequence during system init.
+ */
+
+#if DT_NODE_EXISTS(DT_NODELABEL(uicr))
+
+#if DT_PROP(DT_NODELABEL(uicr), nfct_pins_as_gpios)
+#define NRF_CONFIG_NFCT_PINS_AS_GPIOS
+#endif
+
+#if DT_PROP(DT_NODELABEL(uicr), gpio_as_nreset)
+#define NRF_CONFIG_GPIO_AS_PINRESET
+#endif
+
+#endif /* DT_NODE_EXISTS(DT_NODELABEL(uicr)) */
+
+#if DT_NODE_EXISTS(DT_NODELABEL(tampc)) && DT_PROP(DT_NODELABEL(tampc), swd_pins_as_gpios)
+#define NRF_CONFIG_SWD_PINS_AS_GPIOS
+#endif
+
+#if defined(CONFIG_SOC_NRF54L_CPUAPP_COMMON)
+#define NRF_CONFIG_CPU_FREQ_MHZ (DT_PROP(DT_PATH(clocks, hfpll), clock_frequency) / 1000000)
+#endif
+
+#if defined(CONFIG_SOC_NRF7120_ENGA_CPUAPP) && !defined(NRF_CONFIG_CPU_FREQ_MHZ)
+#define NRF_CONFIG_CPU_FREQ_MHZ (DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) / 1000000)
+#endif
+
+#if defined(CONFIG_NRF_SKIP_CLOCK_CONFIG)
+#define NRF_SKIP_CLOCK_CONFIGURATION
+#endif
+
+#if defined(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF)
+#define NRF_DISABLE_FICR_TRIMCNF
+#endif
+
+#if defined(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE)
+#define NRF_SKIP_GLITCHDETECTOR_DISABLE
+#endif
+
+#if !defined(CONFIG_SOC_NRF54L_ANOMALY_56_WORKAROUND)
+#define NRF54L_CONFIGURATION_56_ENABLE 0
+#endif
+
+#endif /* MDK_CONFIG_H__ */

--- a/modules/hal_nordic/nrfx/nrfx_kconfig.h
+++ b/modules/hal_nordic/nrfx/nrfx_kconfig.h
@@ -14,16 +14,6 @@
  * supported by nrfx (see the corresponding nrfx_config_*.h files).
  */
 
-#if defined(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA) && !defined(NRF7120_ENGA_XXAA)
-#define NRF7120_ENGA_XXAA
-#endif
-#if defined(CONFIG_SOC_COMPATIBLE_NRF7120_ENGA_CPUAPP) && !defined(NRF_APPLICATION)
-#define NRF_APPLICATION
-#endif
-#if defined(CONFIG_SOC_NRF7120_ENGA_CPUFLPR) && !defined(NRF_FLPR)
-#define NRF_FLPR
-#endif
-
 #ifdef CONFIG_NRFX_ADC
 #define NRFX_ADC_ENABLED 1
 #endif

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d7dc801ab175e286205fd6229b0c05ec7886e2ac
+      url: https://github.com/mib1-nordic/hal_nordic
+      revision: mdk_config_poc
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: daad38f2e9f6c641849010d74fe02ea736d4d921
+      revision: d7dc801ab175e286205fd6229b0c05ec7886e2ac
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Instead of configuring MDK with compile definitions use a configuration header file.