### PR TITLE
bluetooth: tbs: Fix GTBS invalid call index handling and add (G)TBS b…

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1529,7 +1529,7 @@ static uint8_t join_calls(struct tbs_inst *inst, const struct bt_tbs_call_cp_joi
 	uint8_t call_state;
 
 	if ((inst->optional_opcodes & BT_TBS_FEATURE_JOIN) == 0) {
-		return BT_TBS_RESULT_CODE_OPCODE_NOT_SUPPORTED;
+		return BT_TBS_RESULT_CODE_OPERATION_NOT_POSSIBLE;
 	}
 
 	/* Check length */

--- a/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
@@ -80,3 +80,18 @@ struct btp_tbs_set_signal_strength_cmd {
 struct btp_tbs_terminate_call_cmd {
 	uint8_t index;
 } __packed;
+
+#define BTP_TBS_REGISTER_BEARER		0x0c
+struct btp_tbs_register_bearer_cmd {
+	uint8_t gtbs;
+	uint8_t technology;
+	uint16_t optional_opcodes;
+	uint8_t provider_name_len;
+	uint8_t uci_len;
+	uint8_t uri_scheme_list_len;
+	uint8_t strings[]; /* provider_name, uci, uri_scheme_list packed in order */
+} __packed;
+
+struct btp_tbs_register_bearer_rp {
+	uint8_t index;
+} __packed;

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
@@ -32,6 +32,11 @@ static void test_ccp_peripheral(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_core_register(BTP_SERVICE_ID_TBS);
 
+	bsim_btp_tbs_register_bearer(true, BT_TBS_TECHNOLOGY_3G, BT_TBS_FEATURE_ALL,
+				     "GTBS Provider", "un000", "tel");
+	bsim_btp_tbs_register_bearer(false, BT_TBS_TECHNOLOGY_3G, BT_TBS_FEATURE_ALL,
+				     "TBS Provider", "un000", "tel");
+
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -1670,6 +1670,8 @@ static bool is_valid_tbs_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 		return buf_simple->len == 0U;
 	case BTP_TBS_SET_SIGNAL_STRENGTH:
 		return buf_simple->len == 0U;
+	case BTP_TBS_REGISTER_BEARER:
+		return buf_simple->len == sizeof(struct btp_tbs_register_bearer_rp);
 
 	/* No events */
 	default:

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -1092,6 +1092,38 @@ static inline void bsim_btp_wait_for_mcp_cmd_ntf(uint8_t *requested_opcode)
 	net_buf_unref(buf);
 }
 
+static inline void bsim_btp_tbs_register_bearer(
+	bool gtbs, uint8_t technology,
+	uint16_t optional_opcodes,
+	const char *provider_name,
+	const char *uci,
+	const char *uri_scheme_list)
+{
+	struct btp_tbs_register_bearer_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_TBS;
+	cmd_hdr->opcode = BTP_TBS_REGISTER_BEARER;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->gtbs = gtbs ? 1U : 0U;
+	cmd->technology = technology;
+	cmd->optional_opcodes = sys_cpu_to_le16(optional_opcodes);
+	cmd->provider_name_len = strlen(provider_name);
+	cmd->uci_len = strlen(uci);
+	cmd->uri_scheme_list_len = strlen(uri_scheme_list);
+	net_buf_simple_add_mem(&cmd_buffer, provider_name, cmd->provider_name_len);
+	net_buf_simple_add_mem(&cmd_buffer, uci, cmd->uci_len);
+	net_buf_simple_add_mem(&cmd_buffer, uri_scheme_list, cmd->uri_scheme_list_len);
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
 static inline void bsim_btp_tmap_discover(const bt_addr_le_t *address)
 {
 	struct btp_tmap_discover_cmd *cmd;


### PR DESCRIPTION
Description
This patch updates the GTBS invalid call index handling to return OPERATION_NOT_POSSIBLE, which is required for passing several PTS test cases.
Additionally, it implements the TBS/GTBS bearer registration command in the Bluetooth Tester (BTP) so AutoPTS can dynamically register bearers during LE Audio qualification.
GTBS/SR/CP/BV-10-C
TBS/SR/CP/BV-10-C

Testing
nRF5340 Audio DK
nRF54L15 DK