### PR TITLE
drivers: flash: shell: print partitions from all partition tables

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -768,10 +768,11 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 #define PRINT_PARTITION_INFO(part)                                                                 \
 	shell_print(sh, "%-32s %-15s 0x%08x %d KiB", DT_NODE_FULL_NAME(part),                      \
 		    DT_PROP_OR(part, label, ""), DT_REG_ADDR(part), DT_REG_SIZE(part) / 1024);
+#define PRINT_ALL_PARTITIONS(parts) DT_FOREACH_CHILD(parts, PRINT_PARTITION_INFO);
 
 static int cmd_partitions(const struct shell *sh, size_t argc, char *argv[])
 {
-	DT_FOREACH_CHILD(DT_COMPAT_GET_ANY_STATUS_OKAY(fixed_partitions), PRINT_PARTITION_INFO);
+	DT_FOREACH_STATUS_OKAY(fixed_partitions, PRINT_ALL_PARTITIONS);
 
 	return 0;
 }


### PR DESCRIPTION
If a device has multiple flashes, likely it has multiple partition tables. This change updates the `flash partitions` command to print all partitions for all partition tables, instead of just the partitions of one partition table.