### PR TITLE
tests: drivers: adc: Fix filtering for accuracy.ref_volt test

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -39,6 +39,10 @@ tests:
       - ek_ra2a1
       - ek_ra2l1
   drivers.adc.accuracy.ref_volt:
+    extra_configs:
+      - CONFIG_REFERENCE_VOLTAGE_TEST=y
+    # Test scenario is filtered if Kconfig dependencies are not satisfied
+    filter: CONFIG_REFERENCE_VOLTAGE_TEST
     harness_config:
       fixture: adc_ref_volt
     platform_allow:


### PR DESCRIPTION
The Kconfig option to include the source file containing the test implementation for the reference voltage test was accidentally dropped from the testcase configuration in `231bf62f7fb2e4ad397e15b41dcdd75751a00042` (#95710), causing the test to never be executed. Re-enable the config to allow the test to execute.

On a xg24_rb4187c board:
Before:
SUITE SKIP -   0.00% [adc_accuracy_test]: pass = 0, [...]

After:
SUITE PASS - 100.00% [adc_accuracy_test]: pass = 1, [...]