### PR TITLE
boards: common: Fix MAX32660 remaining halted after flashing

### DIFF
--- a/boards/common/openocd-adi-max32.boards.cmake
+++ b/boards/common/openocd-adi-max32.boards.cmake
@@ -23,6 +23,9 @@ board_runner_args(openocd --cmd-pre-init "source [find target/${MAX32_TARGET_CFG
 board_runner_args(openocd "--target-handle=_CHIPNAME.cpu")
 
 if(CONFIG_SOC_FAMILY_MAX32_M4 OR CONFIG_SOC_FAMILY_MAX32_M33)
-  board_runner_args(openocd --cmd-pre-init "allow_low_pwr_dbg")
+  # allow_low_pwr_dbg causes reset to fail on some boards after flashing
+  if(NOT DEFINED CONFIG_SOC_MAX32660)
+    board_runner_args(openocd --cmd-pre-init "allow_low_pwr_dbg")
+  endif()
   board_runner_args(openocd "--cmd-erase=max32xxx mass_erase 0")
 endif()


### PR DESCRIPTION
The allow_low_pwr_dbg option causes the MAX32660EVSYS to remain halted after flashing, unlike the MAX32662, or MAX32670.

The actual flashing of MAX32 devices also seems to be broken in Zephyr's OpenOCD fork.
OpenOCD upstream has been fixed, and I have opened a PR for Zephyr's fork [here.](https://github.com/zephyrproject-rtos/openocd/pull/75)