### PR TITLE
imx95: Cortex-M7 add FlexCAN controllers

### DIFF
--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -307,6 +307,71 @@
 			rx-fifo-size = <16>;
 		};
 
+		flexcan1: can@443a0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x443a0000 DT_SIZE_K(64)>;
+			interrupts = <8 0>, <9 0>;
+			interrupt-names = "common", "error";
+			clocks = <&scmi_clk IMX95_CLK_CAN1>;
+			clock-names = "clksrc0";
+			clk-source = <0>;
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
+			status = "disabled";
+		};
+
+		flexcan2: can@425b0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x425b0000 DT_SIZE_K(64)>;
+			interrupts = <38 0>, <39 0>;
+			interrupt-names = "common", "error";
+			clocks = <&scmi_clk IMX95_CLK_CAN2>;
+			clock-names = "clksrc0";
+			clk-source = <0>;
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
+			status = "disabled";
+		};
+
+		flexcan3: can@42600000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x42600000 DT_SIZE_K(64)>;
+			interrupts = <40 0>, <41 0>;
+			interrupt-names = "common", "error";
+			clocks = <&scmi_clk IMX95_CLK_CAN3>;
+			clock-names = "clksrc0";
+			clk-source = <0>;
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
+			status = "disabled";
+		};
+
+		flexcan4: can@427c0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x427c0000 DT_SIZE_K(64)>;
+			interrupts = <42 0>, <43 0>;
+			interrupt-names = "common", "error";
+			clocks = <&scmi_clk IMX95_CLK_CAN4>;
+			clock-names = "clksrc0";
+			clk-source = <0>;
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
+			status = "disabled";
+		};
+
+		flexcan5: can@427d0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x427d0000 DT_SIZE_K(64)>;
+			interrupts = <44 0>, <45 0>;
+			interrupt-names = "common", "error";
+			clocks = <&scmi_clk IMX95_CLK_CAN5>;
+			clock-names = "clksrc0";
+			clk-source = <0>;
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
+			status = "disabled";
+		};
+
 		lpuart3: serial@42570000 {
 			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x42570000 DT_SIZE_K(64)>;


### PR DESCRIPTION
Adds FlexCAN definitions and 80Mhz clock for correct timing

Test results
```

*** Booting Zephyr OS build v4.3.0-4667-g0af6ae816817 ***


------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [can_classic]: pass = 47, fail = 0, skip = 3, total = 50 duration = 0.521 seconds
 - PASS - [can_classic.test_add_filter] duration = 0.001 seconds
 - PASS - [can_classic.test_add_filter_without_callback] duration = 0.001 seconds
 - PASS - [can_classic.test_add_invalid_ext_filter] duration = 0.015 seconds
 - PASS - [can_classic.test_add_invalid_null_filter] duration = 0.001 seconds
 - PASS - [can_classic.test_add_invalid_std_filter] duration = 0.013 seconds
 - PASS - [can_classic.test_bitrate_limits] duration = 0.001 seconds
 - PASS - [can_classic.test_classic_get_capabilities] duration = 0.001 seconds
 - PASS - [can_classic.test_filters_added_while_stopped] duration = 0.002 seconds
 - PASS - [can_classic.test_filters_preserved_through_bitrate_change] duration = 0.003 seconds
 - PASS - [can_classic.test_filters_preserved_through_mode_change] duration = 0.003 seconds
 - PASS - [can_classic.test_get_core_clock] duration = 0.001 seconds
 - PASS - [can_classic.test_get_state] duration = 0.001 seconds
 - PASS - [can_classic.test_invalid_sample_point] duration = 0.001 seconds
 - PASS - [can_classic.test_max_ext_filters] duration = 0.001 seconds
 - PASS - [can_classic.test_max_std_filters] duration = 0.001 seconds
 - PASS - [can_classic.test_receive_timeout] duration = 0.101 seconds
 - PASS - [can_classic.test_recover] duration = 0.001 seconds
 - PASS - [can_classic.test_recover_while_stopped] duration = 0.001 seconds
 - PASS - [can_classic.test_reject_ext_id_rtr] duration = 0.101 seconds
 - PASS - [can_classic.test_reject_std_id_rtr] duration = 0.101 seconds
 - PASS - [can_classic.test_send_and_forget] duration = 0.001 seconds
 - PASS - [can_classic.test_send_callback] duration = 0.001 seconds
 - PASS - [can_classic.test_send_ext_id_dlc_of_range] duration = 0.003 seconds
 - PASS - [can_classic.test_send_ext_id_out_of_range] duration = 0.006 seconds
 - PASS - [can_classic.test_send_fd_format] duration = 0.004 seconds
 - PASS - [can_classic.test_send_invalid_dlc] duration = 0.003 seconds
 - PASS - [can_classic.test_send_null_frame] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_ext_id] duration = 0.004 seconds
 - PASS - [can_classic.test_send_receive_ext_id_masked] duration = 0.004 seconds
 - SKIP - [can_classic.test_send_receive_ext_id_rtr] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_msgq] duration = 0.010 seconds
 - PASS - [can_classic.test_send_receive_std_id] duration = 0.004 seconds
 - PASS - [can_classic.test_send_receive_std_id_masked] duration = 0.004 seconds
 - PASS - [can_classic.test_send_receive_std_id_no_data] duration = 0.001 seconds
 - SKIP - [can_classic.test_send_receive_std_id_rtr] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_wrong_id] duration = 0.102 seconds
 - PASS - [can_classic.test_send_std_id_dlc_of_range] duration = 0.003 seconds
 - PASS - [can_classic.test_send_std_id_out_of_range] duration = 0.005 seconds
 - PASS - [can_classic.test_send_while_stopped] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate_too_high] duration = 0.001 seconds
 - SKIP - [can_classic.test_set_bitrate_too_low] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_set_mode_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_set_state_change_callback] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_max] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_min] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_start_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_stop_while_stopped] duration = 0.001 seconds

SUITE PASS - 100.00% [can_stats]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
 - PASS - [can_stats.test_can_stats_accessors] duration = 0.001 seconds

SUITE SKIP -   0.00% [can_transceiver]: pass = 0, fail = 0, skip = 1, total = 1 duration = 0.000 seconds
 - SKIP - [can_transceiver.test_get_transceiver] duration = 0.000 seconds

SUITE PASS - 100.00% [can_utilities]: pass = 3, fail = 0, skip = 0, total = 3 duration = 0.003 seconds
 - PASS - [can_utilities.test_can_bytes_to_dlc] duration = 0.001 seconds
 - PASS - [can_utilities.test_can_dlc_to_bytes] duration = 0.001 seconds
 - PASS - [can_utilities.test_can_frame_matches_filter] duration = 0.001 seconds

SUITE PASS - 100.00% [canfd]: pass = 14, fail = 0, skip = 1, total = 15 duration = 0.034 seconds
 - PASS - [canfd.test_canfd_get_capabilities] duration = 0.001 seconds
 - PASS - [canfd.test_filters_preserved_through_classic_to_fd_mode_change] duration = 0.004 seconds
 - PASS - [canfd.test_filters_preserved_through_fd_to_classic_mode_change] duration = 0.004 seconds
 - PASS - [canfd.test_invalid_sample_point] duration = 0.001 seconds
 - PASS - [canfd.test_send_fd_dlc_out_of_range] duration = 0.004 seconds
 - PASS - [canfd.test_send_fd_incorrect_esi] duration = 0.004 seconds
 - PASS - [canfd.test_send_receive_classic] duration = 0.004 seconds
 - PASS - [canfd.test_send_receive_fd] duration = 0.003 seconds
 - PASS - [canfd.test_send_receive_mixed] duration = 0.003 seconds
 - SKIP - [canfd.test_set_bitrate_data_too_low] duration = 0.001 seconds
 - PASS - [canfd.test_set_bitrate_data_while_started] duration = 0.001 seconds
 - PASS - [canfd.test_set_bitrate_too_high] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_max] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_min] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_while_started] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL


TESTSUITE can_timing succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [can_timing]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.102 seconds
 - PASS - [can_timing.test_timing] duration = 0.089 seconds
 - PASS - [can_timing.test_timing_data] duration = 0.013 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```