### PR TITLE
boards: stm32h7s78_dk: update board documentation

### DIFF
--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -12,7 +12,8 @@ STM32H7S7L8H6H microcontroller. Here are some highlights of the STM32H7S78-DK Di
 - USB Type-C |reg| Host and device with USB power-delivery controller
 - SAI Audio DAC stereo with one audio jacks for input/output,
 - ST MEMS digital microphone with PDM interface
-- Octo-SPI interface connected to 512Mbit Octo-SPI NORFlash memory device (MX66UW1G45GXD100 from MACRONIX)
+- Octo-SPI interface connected to 1Gbit Octo-SPI NORFlash memory device (MX66UW1G45GXDI00 from Macronix)
+- Hexadeca-SPI interface connected to 256Mbit PSRAM memory device (APS256XXN-OBRx from AP Memory)
 - 10/100-Mbit Ethernet,
 
 - Board connectors
@@ -44,12 +45,12 @@ Hardware
 
 The STM32H7S7xx devices are a high-performance microcontrollers family (STM32H7
 Series) based on the high-performance Arm |reg| Cortex |reg|-M7 32-bit RISC core.
-They operate at a frequency of up to 500 MHz.
+They operate at a frequency of up to 600 MHz.
 
 - Core: ARM |reg| 32-bit Cortex |reg| -M7 CPU with FPU.
 - Performance benchmark:
 
-  - 1284 DMPIS/MHz (Dhrystone 2.1)
+  - 3196 CoreMark |reg| (5.33 CoreMark |reg|/MHz)
 
 - Security
 
@@ -83,19 +84,18 @@ They operate at a frequency of up to 500 MHz.
 
 - RTC with HW calendar, alarms and calibration
 - Up to 152 fast I/Os, most 5 V-tolerant, up to 10 I/Os with independent supply down to 1.08 V
-- Up to 16 timers and 2 watchdogs
+- Up to 23 timers, including 2 watchdogs
 
-  - 16x 16-bit
+  - 16x 16-bit (including 5x low-power 16-bit timers available in Stop mode, one graphic timer)
   - 4x 32-bit timers with up to 4 IC/OC/PWM or pulse counter and quadrature (incremental) encoder input
-  - 5x 16-bit low-power 16-bit timers (available in Stop mode)
   - 2x watchdogs
   - 1x SysTick timer
 
 - Memories
 
-  - Up to 64KB Flash, 2 banks read-while-write
+  - Up to 64 Kbytes Flash, 2 banks read-while-write
   - 1 Kbyte OTP (one-time programmable)
-  - 640 KB of SRAM including 64 KB with hardware parity check and 320 Kbytes with flexible ECC
+  - 620 Kbytes of SRAM (548 Kbytes usable with optional ECC enabled)
   - 4 Kbytes of backup SRAM available in the lowest power modes
   - Flexible external memory controller with up to 16-bit data bus: SRAM, PSRAM, FRAM, SDRAM/LPSDR SDRAM, NOR/NAND memories
   - 2x OCTOSPI memory interface with on-the-fly decryption and support for serial PSRAM/NAND/NOR, Hyper RAM/Flash frame formats
@@ -112,7 +112,7 @@ They operate at a frequency of up to 500 MHz.
   - 1x USB Type-C / USB power-delivery controller
   - 1x USB OTG full-speed with PHY
   - 1x USB OTG high-speed with PHY
-  - 3x I2C FM+ interfaces (SMBus/PMBus)
+  - 3x I2C FM+ interfaces (SMBus/PMBus |trade|)
   - 1x I3C interface
   - 7x U(S)ARTS (ISO7816 interface, LIN, IrDA, modem control)
   - 2x LP UART
@@ -188,7 +188,7 @@ System Clock
 
 STM32H7S78-DK System Clock could be driven by internal or external oscillator,
 as well as main PLL clock. By default System clock is driven by PLL clock at
-500MHz, driven by 24MHz external oscillator (HSE).
+250MHz, driven by 24MHz external oscillator (HSE).
 
 Serial Port
 -----------
@@ -269,8 +269,8 @@ You can debug an application in the usual way.  Here is an example for the
 Application in External Flash
 =============================
 
-Because of the limited amount of SoC Flash (64KB), you may want to store the application
-in external QSPI Flash instead, and run it from there. In that case, the MCUboot bootloader
+Because of the limited amount of SoC Flash (64 Kbytes), you may want to store the application
+in external OSPI Flash instead, and run it from there. In that case, the MCUboot bootloader
 is needed to chainload the application. A dedicated board variant, ``ext_flash_app``, was created
 for this usecase.
 


### PR DESCRIPTION
## Changes
- Updated the documentation for the STM32H7S78-DK board according to official documentation from ST: [STM32H7S78-DK
](https://www.st.com/en/evaluation-tools/stm32h7s78-dk.html) and [STM32H7S7L8](https://www.st.com/en/microcontrollers-microprocessors/stm32h7s7l8.html)
- Added PSRAM memory device: APS256XXN-OBRx

## Notes
- I got the default system clock frequency (250 MHz) from here: https://github.com/zephyrproject-rtos/zephyr/blob/5f2d9f5e7b2650242773f416e0f7d1f47a346be1/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi#L144-L146