### PR TITLE
xen: arch-arm: sync xen_arch_domainconfig with Xen

### DIFF
--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -316,6 +316,10 @@ DEFINE_XEN_GUEST_HANDLE(vcpu_guest_context_t);
 struct xen_arch_domainconfig {
 	/* IN/OUT */
 	uint8_t gic_version;
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
+	/* IN - Contains SVE vector length divided by 128 */
+	uint8_t sve_vl;
+#endif /* CONFIG_XEN_DOMCTL_INTERFACE_VERSION */
 	/* IN */
 	uint16_t tee_type;
 	/* IN */


### PR DESCRIPTION
The `xen_sysctl_getdomaininfo` function (which calls the XEN_SYSCTL_getdomaininfolist hypercall) returned meaningless data because the `xen_domctl_getdomaininfo` structure in Zephyr was 8 bits smaller than in Xen.

This happened because the `xen_arch_domainconfig` structure, which is used in both `xen_domctl_getdomaininfo` and `xen_domctl_createdomain`, was missing the uint8_t sve_vl field introduced in Xen Domctl interface version 0x16.

To fix this, the `sve_vl` field was added to `xen_arch_domainconfig` under the appropriate config macro, synchronizing the structure with Xen and resolving the data mismatch.