### PR TITLE
tests: drivers: gpio: 1pin: Restore port state between tests

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
@@ -479,4 +479,23 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_clr_bits)
 	}
 }
 
-ZTEST_SUITE(gpio_api_1pin_port, NULL, NULL, NULL, NULL, NULL);
+static gpio_port_value_t test_gpio_port_value;
+
+void test_gpio_port_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	const struct device *port = DEVICE_DT_GET(TEST_NODE);
+
+	gpio_port_get_raw(port, &test_gpio_port_value);
+}
+
+void test_gpio_port_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	const struct device *port = DEVICE_DT_GET(TEST_NODE);
+	const struct gpio_driver_config *const cfg = port->config;
+
+	gpio_port_set_masked_raw(port, cfg->port_pin_mask, test_gpio_port_value);
+}
+
+ZTEST_SUITE(gpio_api_1pin_port, NULL, NULL, test_gpio_port_before, test_gpio_port_after, NULL);


### PR DESCRIPTION
The GPIO port test modifies the state of the entire port (gpio controller) associated with the test pin (typically a LED).

Support running GPIO port tests on a port that is also used for other functions by saving and restoring the output state of the GPIO port between each testcase.

This is required on certain Silicon Labs boards where the LED used for the test is on the same port as the GPIO used to enable console output ("vcom enable"). If the port state isn't restored after the test, subsequent console output isn't received by the debugger.