### PR TITLE
doc: releases: Add haptics API change to release notes

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -194,6 +194,14 @@ New APIs and options
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and
     control commands separately via devicetree.
 
+* Haptics
+
+  * Added error callback to API
+
+    * :c:enum:`haptics_error_type` to enumerate common fault conditions in haptics devices.
+    * :c:type:`haptics_error_callback_t` to provide function prototype for error callbacks.
+    * :c:func:`haptics_register_error_callback` to register an error callback with a driver.
+
 * IPM
 
   * IPM callbacks for the mailbox backend now correctly handle signal-only mailbox


### PR DESCRIPTION
Adds release notes related to newly added error callback mechanism in haptics API (#101841). Includes:

 - haptics_error_type
 - haptics_error_callback_t
 - haptics_register_error_callback()