### PR TITLE
drivers: flash: stm32_xspi: Enable instantiation 

### DIFF
--- a/drivers/flash/Kconfig.stm32_xspi
+++ b/drivers/flash/Kconfig.stm32_xspi
@@ -17,9 +17,20 @@ config FLASH_STM32_XSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
 	select PINCTRL
-	select DMA if $(DT_STM32_XSPI_HAS_DMA)
+	help
+	  Enable XSPI-NOR support on the STM32 family of processors.
+
+if FLASH_STM32_XSPI
+
+config FLASH_STM32_XSPI_DMA
+	bool "DMA Support for STM32 XSPI Flash"
+	depends on $(DT_STM32_XSPI_HAS_DMA)
+	default y
+	select DMA
 	select USE_STM32_HAL_DMA if $(DT_STM32_XSPI_HAS_DMA)
 	select USE_STM32_HAL_DMA_EX if (SOC_SERIES_STM32H5X || SOC_SERIES_STM32N6X) && \
 					$(DT_STM32_XSPI_HAS_DMA)
 	help
-	  Enable XSPI-NOR support on the STM32 family of processors.
+	  Enable the DMA mode for XSPI flash driver instance
+
+endif # FLASH_STM32_XSPI

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -913,7 +913,7 @@ static int stm32_ospi_mem_reset(const struct device *dev)
 
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
-	k_msleep(DT_INST_PROP(0, reset_gpios_duration));
+	k_msleep(DT_INST_PROP_OR(0, reset_gpios_duration, 1));
 	gpio_pin_set_dt(&dev_cfg->reset, 0);
 #else
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1469,7 +1469,7 @@ static void flash_stm32_qspi_gpio_reset(const struct device *dev)
 
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
-	k_msleep(DT_INST_PROP(0, reset_gpios_duration));
+	k_msleep(DT_INST_PROP_OR(0, reset_gpios_duration, 1));
 	gpio_pin_set_dt(&dev_cfg->reset, 0);
 }
 #endif

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -31,7 +31,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
-#define STM32_XSPI_NODE DT_INST_PARENT(0)
+#define STM32_XSPI_NODE(inst) DT_INST_PARENT(inst)
 
 #define STM32_XSPI_RESET_GPIO DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 
@@ -2130,31 +2130,30 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -EIO;
 	}
 
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
-	/* Kernel clock config for peripheral if any */
-	if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &dev_cfg->pclken_ker,
-					NULL) != 0) {
-		LOG_ERR("Could not select XSPI domain clock");
-		return -EIO;
+	if (dev_cfg->has_pclken_ker) {
+		/* Kernel clock config for peripheral if any */
+		if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			(clock_control_subsys_t) &dev_cfg->pclken_ker, NULL) != 0) {
+			LOG_ERR("Could not select XSPI domain clock");
+			return -EIO;
+		}
+
+		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			(clock_control_subsys_t) &dev_cfg->pclken_ker,
+								&ahb_clock_freq) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclken_ker)");
+			return -EIO;
+		}
 	}
 
-	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &dev_cfg->pclken_ker,
-					&ahb_clock_freq) < 0) {
-		LOG_ERR("Failed call clock_control_get_rate(pclken_ker)");
-		return -EIO;
-	}
-#endif /* xspi_ker */
-
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
-	/* Clock domain corresponding to the IO-Mgr (XSPIM) */
-	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+	if (dev_cfg->has_pclken_mgr) {
+		/* Clock domain corresponding to the IO-Mgr (XSPIM) */
+		if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				(clock_control_subsys_t) &dev_cfg->pclken_mgr) != 0) {
-		LOG_ERR("Could not enable XSPI Manager clock");
-		return -EIO;
+			LOG_ERR("Could not enable XSPI Manager clock");
+			return -EIO;
+		}
 	}
-#endif /* xspi_mgr */
 
 	for (; prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX; prescaler++) {
 		uint32_t clk = STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
@@ -2475,83 +2474,116 @@ static int flash_stm32_xspi_init(const struct device *dev)
 			     DT_STRING_TOKEN(DT_DRV_INST(inst), quad_enable_requirements))),	\
 		    ((default_value)))
 
-PINCTRL_DT_DEFINE(STM32_XSPI_NODE);
-
-static void flash_stm32_xspi_irq_config_func(const struct device *dev)
-{
-	IRQ_CONNECT(DT_IRQN(STM32_XSPI_NODE), DT_IRQ(STM32_XSPI_NODE, priority),
-		    flash_stm32_xspi_isr, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_IRQN(STM32_XSPI_NODE));
-}
-
-static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
-	/* Properties of the controller */
-	.pclken = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspix),
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
-	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_ker),
-#endif /* xspi_ker */
-#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
-	.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_mgr),
-#endif /* xspi_mgr */
-	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE),
-	.irq_config = flash_stm32_xspi_irq_config_func,
-	.mem_map_based_address = DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE, 1),
-
-	/* Properties of the flash device */
-	.flash_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
-	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
-	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
-	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */
-	.four_byte_opcodes = DT_INST_PROP_OR(0, four_byte_opcodes, 0),
-	.requires_ulbpr = DT_INST_PROP_OR(0, requires_ulbpr, 0),
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
-	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
-	.reset_gpios_duration = DT_INST_PROP(0, reset_gpios_duration),
-#endif /* reset_gpios */
-};
-
-static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {
-	.hxspi = {
-		.Instance = (XSPI_TypeDef *)DT_REG_ADDR(STM32_XSPI_NODE),
-		.Init = {
-			.FifoThresholdByte = STM32_XSPI_FIFO_THRESHOLD,
-			.SampleShifting = (DT_PROP(STM32_XSPI_NODE, ssht_enable)
-					? HAL_XSPI_SAMPLE_SHIFT_HALFCYCLE
-					: HAL_XSPI_SAMPLE_SHIFT_NONE),
-			.ChipSelectHighTimeCycle = 1,
-			.ClockMode = HAL_XSPI_CLOCK_MODE_0,
-			.ChipSelectBoundary = 0,
-			.MemoryMode = HAL_XSPI_SINGLE_MEM,
 #if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
-			.MemorySelect = ((DT_INST_PROP(0, ncs_line) == 1)
-					? HAL_XSPI_CSSEL_NCS1
+#define DT_XSPI_STM32_MEMORY_SELECT(inst)				\
+		.MemorySelect = ((DT_INST_PROP(inst, ncs_line) == 1)	\
+					? HAL_XSPI_CSSEL_NCS1		\
 					: HAL_XSPI_CSSEL_NCS2),
-#endif
-			.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,
-#if defined(XSPI_DCR1_DLYBYP)
-			.DelayBlockBypass = (DT_PROP(STM32_XSPI_NODE, dlyb_bypass)
-					? HAL_XSPI_DELAY_BLOCK_BYPASS
-					: HAL_XSPI_DELAY_BLOCK_ON),
-#endif /* XSPI_DCR1_DLYBYP */
-#if defined(XSPI_DCR3_MAXTRAN)
-			.MaxTran = 0,
-#endif /* XSPI_DCR3_MAXTRAN */
-#if defined(XSPI_DCR4_REFRESH)
-			.Refresh = 0,
-#endif /* XSPI_DCR4_REFRESH */
-		},
-	},
-	.qer_type = DT_QER_PROP_OR(0, JESD216_DW15_QER_VAL_S1B6),
-	.write_opcode = DT_WRITEOC_PROP_OR(0, SPI_NOR_WRITEOC_NONE),
-	.page_size = SPI_NOR_PAGE_SIZE, /* by default, to be updated by sfdp */
-#if DT_INST_NODE_HAS_PROP(0, jedec_id)
-	.jedec_id = DT_INST_PROP(0, jedec_id),
-#endif /* jedec_id */
-	XSPI_DMA_CHANNEL(STM32_XSPI_NODE, tx, TX, MEMORY, PERIPHERAL)
-	XSPI_DMA_CHANNEL(STM32_XSPI_NODE, rx, RX, PERIPHERAL, MEMORY)
-};
+#else
+#define DT_XSPI_STM32_MEMORY_SELECT(inst)	 /* Not used */
+#endif /* HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2 */
 
-DEVICE_DT_INST_DEFINE(0, &flash_stm32_xspi_init, NULL,
-		      &flash_stm32_xspi_dev_data, &flash_stm32_xspi_cfg,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		      &flash_stm32_xspi_driver_api);
+#if defined(XSPI_DCR1_DLYBYP)
+#define DT_XSPI_STM32_DELAY_BLOCK_BYPASS(inst)						\
+		.DelayBlockBypass = (DT_PROP(STM32_XSPI_NODE(inst), dlyb_bypass)	\
+					? HAL_XSPI_DELAY_BLOCK_BYPASS			\
+					: HAL_XSPI_DELAY_BLOCK_ON),
+#else
+#define DT_XSPI_STM32_DELAY_BLOCK_BYPASS(inst)	/* Not used */
+#endif /* XSPI_DCR1_DLYBYP */
+
+#if defined(XSPI_DCR3_MAXTRAN)
+#define XSPI_STM32_MAXTRAN	\
+		.MaxTran = 0,
+#else
+#define XSPI_STM32_MAXTRAN	 /* Not used */
+#endif /* XSPI_DCR3_MAXTRAN */
+
+#if defined(XSPI_DCR4_REFRESH)
+#define XSPI_STM32_REFRESH	\
+		.Refresh = 0,	 /* Not used */
+#else
+#define XSPI_STM32_REFRESH
+#endif /* XSPI_DCR4_REFRESH */
+
+#define XSPI_NOR_STM32_INIT(inst)								\
+												\
+	PINCTRL_DT_DEFINE(STM32_XSPI_NODE(inst));						\
+												\
+	static void flash_stm32_xspi_irq_config_func_##inst(const struct device *dev)		\
+	{											\
+		IRQ_CONNECT(DT_IRQN(STM32_XSPI_NODE(inst)),					\
+			    DT_IRQ(STM32_XSPI_NODE(inst), priority),				\
+			    flash_stm32_xspi_isr, DEVICE_DT_INST_GET(inst), 0);			\
+		irq_enable(DT_IRQN(STM32_XSPI_NODE(inst)));					\
+	}											\
+												\
+	static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg_##inst = {		\
+		/* Properties of the controller */						\
+		.pclken = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE(inst), xspix),		\
+		IF_ENABLED(DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE(inst), xspi_ker),	(		\
+			.has_pclken_ker = true,							\
+			.pclken_ker = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE(inst), xspi_ker),\
+		))										\
+		IF_ENABLED(DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE(inst),  xspi_mgr), (		\
+			.has_pclken_mgr = true,							\
+			.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE(inst), xspi_mgr),\
+		))										\
+		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE(inst)),			\
+		.irq_config = flash_stm32_xspi_irq_config_func_##inst,				\
+		.mem_map_based_address = DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE(inst), 1),		\
+												\
+		/* Properties of the flash device */						\
+		.flash_size = DT_INST_PROP(inst, size) / 8,			/* In Bytes */	\
+		.max_frequency = DT_INST_PROP(inst, ospi_max_frequency),			\
+		.data_mode = DT_INST_PROP(inst, spi_bus_width),			/* SPI or OPI */\
+		.data_rate = DT_INST_PROP(inst, data_rate),			/* DTR or STR */\
+		.four_byte_opcodes = DT_INST_PROP_OR(inst, four_byte_opcodes, 0),		\
+		.requires_ulbpr = DT_INST_PROP_OR(inst, requires_ulbpr, 0),			\
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, reset_gpios), (				\
+			.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),				\
+			.reset_gpios_duration = DT_INST_PROP(inst, reset_gpios_duration),	\
+		))										\
+	};											\
+												\
+	static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data_##inst = {		\
+		.hxspi = {									\
+			.Instance = (XSPI_TypeDef *)DT_REG_ADDR(STM32_XSPI_NODE(inst)),		\
+			.Init = {								\
+				.FifoThresholdByte = STM32_XSPI_FIFO_THRESHOLD,			\
+				.SampleShifting = (DT_PROP(STM32_XSPI_NODE(inst), ssht_enable)	\
+						? HAL_XSPI_SAMPLE_SHIFT_HALFCYCLE		\
+						: HAL_XSPI_SAMPLE_SHIFT_NONE),			\
+				.ChipSelectHighTimeCycle = 2,					\
+				.ClockMode = HAL_XSPI_CLOCK_MODE_0,				\
+				.ChipSelectBoundary = 0,					\
+				.MemoryMode = HAL_XSPI_SINGLE_MEM,				\
+				.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,		\
+				DT_XSPI_STM32_MEMORY_SELECT(inst)				\
+				DT_XSPI_STM32_DELAY_BLOCK_BYPASS(inst)				\
+				XSPI_STM32_MAXTRAN						\
+				XSPI_STM32_REFRESH						\
+			},									\
+		},										\
+												\
+		.qer_type = DT_QER_PROP_OR(inst, JESD216_DW15_QER_VAL_S1B6),			\
+		.write_opcode = DT_WRITEOC_PROP_OR(inst, SPI_NOR_WRITEOC_NONE),			\
+		.page_size = SPI_NOR_PAGE_SIZE, /* by default, to be updated by sfdp */		\
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, jedec_id), (				\
+			.jedec_id = DT_INST_PROP(inst, jedec_id),				\
+		))										\
+												\
+		XSPI_DMA_CHANNEL(STM32_XSPI_NODE(inst), tx, TX, MEMORY, PERIPHERAL)		\
+		XSPI_DMA_CHANNEL(STM32_XSPI_NODE(inst), rx, RX, PERIPHERAL, MEMORY)		\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, &flash_stm32_xspi_init, NULL,				\
+			      &flash_stm32_xspi_dev_data_##inst, &flash_stm32_xspi_cfg_##inst,	\
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+			      &flash_stm32_xspi_driver_api);
+
+#define XSPI_STM32_INIT(inst)							\
+	IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(STM32_XSPI_NODE(inst)),		\
+		   (XSPI_NOR_STM32_INIT(inst)))
+
+DT_INST_FOREACH_STATUS_OKAY(XSPI_STM32_INIT)

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2542,7 +2542,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		.requires_ulbpr = DT_INST_PROP_OR(inst, requires_ulbpr, 0),			\
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, reset_gpios), (				\
 			.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),				\
-			.reset_gpios_duration = DT_INST_PROP(inst, reset_gpios_duration),	\
+			.reset_gpios_duration = DT_INST_PROP_OR(inst, reset_gpios_duration, 1),	\
 		))										\
 	};											\
 												\

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -33,15 +33,7 @@ LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
 #define STM32_XSPI_NODE DT_INST_PARENT(0)
 
-#define DT_XSPI_IO_PORT_PROP_OR(prop, default_value)					\
-	COND_CODE_1(DT_NODE_HAS_PROP(STM32_XSPI_NODE, prop),				\
-		    (_CONCAT(HAL_XSPIM_, DT_STRING_TOKEN(STM32_XSPI_NODE, prop))),	\
-		    ((default_value)))
-
-/* Get the base address of the flash from the DTS st,stm32-xspi node */
-#define STM32_XSPI_BASE_ADDRESS DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE, 1)
-
-#define STM32_XSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
+#define STM32_XSPI_RESET_GPIO DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 
 #ifdef CONFIG_FLASH_STM32_XSPI_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -799,7 +791,7 @@ static int stm32_xspi_mem_reset(const struct device *dev)
 
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
-	k_msleep(DT_INST_PROP(0, reset_gpios_duration));
+	k_msleep(dev_cfg->reset_gpios_duration);
 	gpio_pin_set_dt(&dev_cfg->reset, 0);
 #else
 
@@ -1198,6 +1190,8 @@ erase_end:
 static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 				 void *data, size_t size)
 {
+	__maybe_unused const struct flash_stm32_xspi_config *dev_cfg = dev->config;
+	__maybe_unused struct flash_stm32_xspi_data *dev_data = dev->data;
 	int ret = 0;
 
 	if (!xspi_address_is_valid(dev, addr, size)) {
@@ -1232,15 +1226,13 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 
 	__ASSERT_NO_MSG(stm32_xspi_is_memorymap(dev));
 #endif /* CONFIG_STM32_MEMMAP */
-	uintptr_t mmap_addr = STM32_XSPI_BASE_ADDRESS + addr;
+	uintptr_t mmap_addr = dev_cfg->mem_map_based_address + addr;
 
 	LOG_DBG("Memory-mapped read from 0x%08lx, len %zu", mmap_addr, size);
 	memcpy(data, (void *)mmap_addr, size);
 	return ret;
 
 #else /* CONFIG_STM32_MEMMAP || (CONFIG_STM32_APP_IN_EXT_FLASH && CONFIG_XIP) */
-	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
-	struct flash_stm32_xspi_data *dev_data = dev->data;
 
 	XSPI_RegularCmdTypeDef cmd = xspi_prepare_cmd(dev_cfg->data_mode, dev_cfg->data_rate);
 
@@ -1302,7 +1294,7 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 
 	LOG_DBG("XSPI: read %zu data at 0x%lx",
 		size,
-		(long)(STM32_XSPI_BASE_ADDRESS + addr));
+		(long)(dev_cfg->mem_map_based_address + addr));
 	xspi_lock_thread(dev);
 
 	ret = xspi_read_access(dev, &cmd, data, size);
@@ -1392,7 +1384,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 
 	LOG_DBG("XSPI: write %zu data at 0x%lx",
 		size,
-		(long)(STM32_XSPI_BASE_ADDRESS + addr));
+		(long)(dev_cfg->mem_map_based_address + addr));
 
 	ret = stm32_xspi_mem_ready(dev,
 				   dev_cfg->data_mode, dev_cfg->data_rate);
@@ -1956,7 +1948,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 		}
 
 		/* convert 3-Byte opcodes to 4-Byte (if required) */
-		if (IS_ENABLED(DT_INST_PROP(0, four_byte_opcodes))) {
+		if (dev_cfg->four_byte_opcodes) {
 			if (data->address_width != 4U) {
 				LOG_DBG("4-Byte opcodes require 4-Byte address width");
 				return -ENOTSUP;
@@ -2413,7 +2405,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	}
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-	if (IS_ENABLED(DT_INST_PROP(0, requires_ulbpr))) {
+	if (dev_cfg->requires_ulbpr) {
 		ret = xspi_write_unprotect(dev);
 		if (ret != 0) {
 			LOG_ERR("write unprotect failed: %d", ret);
@@ -2429,11 +2421,11 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return ret;
 	}
 	LOG_INF("Memory-mapped NOR-flash at 0x%lx (0x%x bytes)",
-		(long)(STM32_XSPI_BASE_ADDRESS),
+		(long)(dev_cfg->mem_map_based_address),
 		dev_cfg->flash_size);
 #else
 	LOG_INF("NOR external-flash at 0x%lx (0x%x bytes)",
-		(long)(STM32_XSPI_BASE_ADDRESS),
+		(long)(dev_cfg->mem_map_based_address),
 		dev_cfg->flash_size);
 #endif /* CONFIG_STM32_MEMMAP*/
 	return 0;
@@ -2496,14 +2488,18 @@ static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
 	.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_mgr),
 #endif /* xspi_mgr */
 	.irq_config = flash_stm32_xspi_irq_config_func,
+	.mem_map_based_address = DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE, 1),
 	.flash_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */
+	.four_byte_opcodes = DT_INST_PROP_OR(0, four_byte_opcodes, 0),
+	.requires_ulbpr = DT_INST_PROP_OR(0, requires_ulbpr, 0),
 	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE),
-#if STM32_XSPI_RESET_GPIO
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
-#endif /* STM32_XSPI_RESET_GPIO */
+	.reset_gpios_duration = DT_INST_PROP(0, reset_gpios_duration),
+#endif /* reset_gpios */
 };
 
 static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {
@@ -2540,7 +2536,7 @@ static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {
 	.qer_type = DT_QER_PROP_OR(0, JESD216_DW15_QER_VAL_S1B6),
 	.write_opcode = DT_WRITEOC_PROP_OR(0, SPI_NOR_WRITEOC_NONE),
 	.page_size = SPI_NOR_PAGE_SIZE, /* by default, to be updated by sfdp */
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_ospi_nor), jedec_id)
+#if DT_INST_NODE_HAS_PROP(0, jedec_id)
 	.jedec_id = DT_INST_PROP(0, jedec_id),
 #endif /* jedec_id */
 	XSPI_DMA_CHANNEL(STM32_XSPI_NODE, tx, TX, MEMORY, PERIPHERAL)

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -43,13 +43,11 @@ LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
 #define STM32_XSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
-#define STM32_XSPI_USE_DMA DT_NODE_HAS_PROP(STM32_XSPI_NODE, dmas)
-
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/dma.h>
 #include <stm32_ll_dma.h>
-#endif /* STM32_XSPI_USE_DMA */
+#endif /* CONFIG_FLASH_STM32_XSPI_DMA */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
 #include <stm32_ll_pwr.h>
@@ -109,7 +107,7 @@ static int xspi_read_access(const struct device *dev, XSPI_RegularCmdTypeDef *cm
 		return -EIO;
 	}
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 	hal_ret = HAL_XSPI_Receive_DMA(&dev_data->hxspi, data);
 #else
 	hal_ret = HAL_XSPI_Receive_IT(&dev_data->hxspi, data);
@@ -151,7 +149,7 @@ static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *c
 		return -EIO;
 	}
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 	hal_ret = HAL_XSPI_Transmit_DMA(&dev_data->hxspi, (uint8_t *)data);
 #else
 	hal_ret = HAL_XSPI_Transmit_IT(&dev_data->hxspi, (uint8_t *)data);
@@ -1485,7 +1483,7 @@ __weak HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
 #endif /* !CONFIG_SOC_SERIES_STM32H7X */
 
 /* This function is executed in the interrupt context */
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 static void xspi_dma_callback(const struct device *dev, void *arg,
 			 uint32_t channel, int status)
 {
@@ -1999,7 +1997,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 	return 0;
 }
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma_stream)
 {
 	int ret;
@@ -2072,7 +2070,7 @@ static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma
 	LOG_DBG("XSPI with DMA transfer");
 	return 0;
 }
-#endif /* STM32_XSPI_USE_DMA */
+#endif /* CONFIG_FLASH_STM32_XSPI_DMA */
 
 
 static int flash_stm32_xspi_init(const struct device *dev)
@@ -2243,7 +2241,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	LOG_DBG("Delay Block Init");
 #endif /* XSPI_DCR1_DLYBYP */
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 	/* Configure and enable the DMA channels after XSPI config */
 	static DMA_HandleTypeDef hdma_tx;
 	static DMA_HandleTypeDef hdma_rx;
@@ -2442,7 +2440,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 }
 
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 #define DMA_CHANNEL_CONFIG(node, dir)						\
 		DT_DMAS_CELL_BY_NAME(node, dir, channel_config)
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2504,9 +2504,6 @@ static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
 #if STM32_XSPI_RESET_GPIO
 	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
 #endif /* STM32_XSPI_RESET_GPIO */
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_ospi_nor), sfdp_bfp)
-	.sfdp_bfp = DT_INST_PROP(0, sfdp_bfp),
-#endif /* sfdp_bfp */
 };
 
 static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2475,11 +2475,17 @@ static int flash_stm32_xspi_init(const struct device *dev)
 			     DT_STRING_TOKEN(DT_DRV_INST(inst), quad_enable_requirements))),	\
 		    ((default_value)))
 
-static void flash_stm32_xspi_irq_config_func(const struct device *dev);
-
 PINCTRL_DT_DEFINE(STM32_XSPI_NODE);
 
+static void flash_stm32_xspi_irq_config_func(const struct device *dev)
+{
+	IRQ_CONNECT(DT_IRQN(STM32_XSPI_NODE), DT_IRQ(STM32_XSPI_NODE, priority),
+		    flash_stm32_xspi_isr, DEVICE_DT_INST_GET(0), 0);
+	irq_enable(DT_IRQN(STM32_XSPI_NODE));
+}
+
 static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
+	/* Properties of the controller */
 	.pclken = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspix),
 #if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
 	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_ker),
@@ -2487,15 +2493,17 @@ static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
 #if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
 	.pclken_mgr = STM32_CLOCK_INFO_BY_NAME(STM32_XSPI_NODE, xspi_mgr),
 #endif /* xspi_mgr */
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE),
 	.irq_config = flash_stm32_xspi_irq_config_func,
 	.mem_map_based_address = DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE, 1),
+
+	/* Properties of the flash device */
 	.flash_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */
 	.four_byte_opcodes = DT_INST_PROP_OR(0, four_byte_opcodes, 0),
 	.requires_ulbpr = DT_INST_PROP_OR(0, requires_ulbpr, 0),
-	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE),
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
 	.reset_gpios_duration = DT_INST_PROP(0, reset_gpios_duration),
@@ -2542,13 +2550,6 @@ static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {
 	XSPI_DMA_CHANNEL(STM32_XSPI_NODE, tx, TX, MEMORY, PERIPHERAL)
 	XSPI_DMA_CHANNEL(STM32_XSPI_NODE, rx, RX, PERIPHERAL, MEMORY)
 };
-
-static void flash_stm32_xspi_irq_config_func(const struct device *dev)
-{
-	IRQ_CONNECT(DT_IRQN(STM32_XSPI_NODE), DT_IRQ(STM32_XSPI_NODE, priority),
-		    flash_stm32_xspi_isr, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_IRQN(STM32_XSPI_NODE));
-}
 
 DEVICE_DT_INST_DEFINE(0, &flash_stm32_xspi_init, NULL,
 		      &flash_stm32_xspi_dev_data, &flash_stm32_xspi_cfg,

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -76,8 +76,12 @@ struct flash_stm32_xspi_config {
 	int data_mode; /* SPI or QSPI or OSPI */
 	int data_rate; /* DTR or STR */
 	const struct pinctrl_dev_config *pcfg;
+	bool four_byte_opcodes;
+	bool requires_ulbpr;
+	uint32_t mem_map_based_address;
 #if STM32_XSPI_RESET_GPIO
 	const struct gpio_dt_spec reset;
+	int reset_gpios_duration;
 #endif /* STM32_XSPI_RESET_GPIO */
 };
 

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -83,6 +83,8 @@ struct flash_stm32_xspi_config {
 	const struct gpio_dt_spec reset;
 	int reset_gpios_duration;
 #endif /* STM32_XSPI_RESET_GPIO */
+	bool has_pclken_ker;
+	bool has_pclken_mgr;
 };
 
 struct flash_stm32_xspi_data {

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -37,7 +37,7 @@
 /* used as default value for DTS writeoc */
 #define SPI_NOR_WRITEOC_NONE 0xFF
 
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 /* Lookup table to set dma priority from the DTS */
 static const uint32_t table_priority[] = {
 	DMA_LOW_PRIORITY_LOW_WEIGHT,
@@ -62,7 +62,7 @@ struct stream {
 	bool src_addr_increment;
 	bool dst_addr_increment;
 };
-#endif /* STM32_XSPI_USE_DMA */
+#endif /* CONFIG_FLASH_STM32_XSPI_DMA */
 
 typedef void (*irq_config_func_t)(const struct device *dev);
 
@@ -105,10 +105,10 @@ struct flash_stm32_xspi_data {
 	uint8_t jedec_id[JESD216_READ_ID_LEN];
 #endif /* CONFIG_FLASH_JESD216_API */
 	int cmd_status;
-#if STM32_XSPI_USE_DMA
+#ifdef CONFIG_FLASH_STM32_XSPI_DMA
 	struct stream dma_tx;
 	struct stream dma_rx;
-#endif /* STM32_XSPI_USE_DMA */
+#endif /* CONFIG_FLASH_STM32_XSPI_DMA */
 };
 
 #endif /* ZEPHYR_DRIVERS_FLASH_XSPI_STM32_H_ */

--- a/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
@@ -11,6 +11,7 @@ include:
     property-blocklist:
       - spi-bus-width
       - data-rate
+      - sfdp-bfp
 properties:
   size:
     required: true


### PR DESCRIPTION
As a preparation to support use of 2 xspi devices working as flash controllers in a single build, rework the driver to make it fully instantiable.