### PR TITLE
scripts: runners: nrf: Add support for nRF7120

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -39,6 +39,9 @@ UICR_RANGES = {
     'nrf54l': {
         'Application': (0x00FFD000, 0x00FFDA00),
     },
+    'nrf71': {
+        'Application': (0x00FFD000, 0x00FFDA00)
+    },
     'nrf91': {
         'Application': (0x00FF8000, 0x00FF8800),
     },
@@ -90,7 +93,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
     def do_add_parser(cls, parser):
         parser.add_argument('--nrf-family',
                             choices=['NRF51', 'NRF52', 'NRF53', 'NRF54L',
-                                     'NRF54H', 'NRF91', 'NRF92'],
+                                     'NRF54H', 'NRF71', 'NRF91', 'NRF92'],
                             help='''MCU family; still accepted for
                             compatibility only''')
         # Not using a mutual exclusive group for softreset and pinreset due to
@@ -226,6 +229,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
             self.family = 'nrf54l'
         elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF54H'):
             self.family = 'nrf54h'
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF71'):
+            self.family = 'nrf71'
         elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF91'):
             self.family = 'nrf91'
         elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF92'):


### PR DESCRIPTION
Add support for nrf7120 to use nrfutil runner in
upstream zephyr.