### PR TITLE
Enable OSS BT controller on simulated 54LM20

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
@@ -18,7 +18,6 @@
 		zephyr,bt-c2h-uart = &uart20;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
-		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,ieee802154 = &ieee802154;
 	};
 
@@ -95,10 +94,6 @@
 };
 
 &clock {
-	status = "okay";
-};
-
-&bt_hci_controller {
 	status = "okay";
 };
 

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
@@ -19,9 +19,5 @@
 	};
 };
 
-&bt_hci_controller {
-	status = "okay";
-};
-
 /* Get a node label for wi-fi spi to use in shield files */
 wifi_spi: &spi22 {};

--- a/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
@@ -22,6 +22,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 	};
 
@@ -40,6 +41,10 @@ nvic: &cpuapp_nvic {};
 		status = "okay";
 		compatible = "nordic,nrf-cracen-ctrdrbg";
 	};
+};
+
+&bt_hci_controller {
+	status = "okay";
 };
 
 &cpuflpr_vpr {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -47,7 +47,7 @@
 #elif defined(CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUNET)
 #include <hal/nrf_vreqctrl.h>
 #include "radio_sim_nrf5340.h"
-#elif defined(CONFIG_BOARD_NRF54L15BSIM_NRF54L15_CPUAPP)
+#elif defined(CONFIG_SOC_SERIES_BSIM_NRF54LX)
 #include <hal/nrf_ppib.h>
 #include "radio_sim_nrf54l.h"
 #else


### PR DESCRIPTION
The OSS controller has been enabled for a while now on the real 54lm20 targets. Let's also enable it on the simulated one (`nrf54lm20bsim/nrf54lm20a/cpuapp`).
For this we need two minor changes:
a) have the controller use the same configuration header for the simulated lm20 as for the l15
b) move the enablement in DT of the controller to the same place as for other targets (so it is enabled by default also for simulation)

Note, I do not know if the controller being enabled in DT in the board file was just an oversight or purposeful. These commits are related:
387520c867eeb6bc6048471f9d61c769d82e35fe
43e8753f86201dbb4f5650c34585139187e0ba21
https://github.com/nrfconnect/sdk-zephyr/commit/22acc285ac9f7a512b47a124f41707893f2e5bc8
https://github.com/nrfconnect/sdk-zephyr/commit/e89fd5f868c584dbda3d140ca7ff062c8a942968

Extra info:
Even though this enables the controller for this target, it does not enable any extra testing.
But if one runs the same bsim tests as for the 54L15, these 3 will fail as is, but pass if the random seed is changed in one of the devices:
tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_multiple_bis.sh
tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_multiple_bis.sh
tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh