### PR TITLE
arch: riscv: allow fatal error handler return and enable essential thread abort test

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -77,7 +77,7 @@ const char *z_riscv_mcause_str(unsigned long cause)
 	return mcause_str[MIN(cause, ARRAY_SIZE(mcause_str) - 1)];
 }
 
-FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
+void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf)
 {
 	__maybe_unused _callee_saved_t *csf = NULL;
@@ -142,7 +142,6 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 #endif /* CONFIG_EXCEPTION_STACK_TRACE */
 
 	z_fatal_error(reason, esf);
-	CODE_UNREACHABLE;
 }
 
 static bool bad_stack_pointer(struct arch_esf *esf)
@@ -232,6 +231,7 @@ void z_riscv_fault(struct arch_esf *esf)
 	}
 
 	z_riscv_fatal_error(reason, esf);
+	CODE_UNREACHABLE;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -257,6 +257,7 @@ void z_impl_user_fault(unsigned int reason)
 		reason = K_ERR_KERNEL_OOPS;
 	}
 	z_riscv_fatal_error(reason, oops_esf);
+	CODE_UNREACHABLE;
 }
 
 static void z_vrfy_user_fault(unsigned int reason)

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -44,6 +44,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 	}
 #endif
 	z_riscv_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
+	CODE_UNREACHABLE;
 #endif /* CONFIG_EMPTY_IRQ_SPURIOUS */
 }
 

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -479,7 +479,8 @@ do_fault:
 	addi sp, sp, -__callee_saved_t_SIZEOF
 	STORE_CALLEE_SAVED(a1)
 #endif /* CONFIG_EXCEPTION_DEBUG */
-	tail z_riscv_fatal_error
+	call z_riscv_fatal_error
+	j check_reschedule
 
 #if defined(CONFIG_IRQ_OFFLOAD)
 do_irq_offload:

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -72,7 +72,7 @@ arch_switch(void *switch_to, void **switched_from)
 #endif
 }
 
-FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
+void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf);
 
 static inline bool arch_is_in_isr(void)

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -135,7 +135,7 @@ ZTEST(threads_lifecycle, test_essential_thread_abort_self)
 	 * But run it for everyone else to catch regressions in the
 	 * code we are actually trying to test.
 	 */
-	if (IS_ENABLED(CONFIG_RISCV) || IS_ENABLED(CONFIG_X86) || IS_ENABLED(CONFIG_SPARC)) {
+	if (IS_ENABLED(CONFIG_X86) || IS_ENABLED(CONFIG_SPARC)) {
 		ztest_test_skip();
 	}
 


### PR DESCRIPTION
On the RISC-V architecture, `z_riscv_fatal_error` was historically marked as `FUNC_NORETURN`. However, the Zephyr kernel’s core `z_fatal_error()` handler is designed to return in specific scenarios, such as when an essential thread self-aborts. This mismatch caused incorrect behavior or unreachable code assertions when essential threads attempted to exit on RISC-V platforms.

This PR aligns the RISC-V architecture port with core kernel expectations by allowing the fatal error path to return.

**Key Architectural Changes:**

- Removed `FUNC_NORETURN` attribute from `z_riscv_fatal_error` declarations in `fatal.c` and `kernel_arch_func.h`.

- Updated `isr.S` to use `call` instead of `tail` for the fatal error handler, followed by a jump to `check_reschedule` to properly handle the return path.

- Maintained compiler optimizations by adding `CODE_UNREACHABLE` only at specific call sites that are strictly terminal.

**Tests:**

- Enabled `test_essential_thread_abort_self` in `tests/kernel/threads/thread_apis` for `RISC-V` by removing it from the skip list.

```
./twister -v -i -p qemu_riscv64 -s kernel.threads.apis -c
```
