### PR TITLE
boards: blackberry: qnxhv_vm: Add VIRTIO devices definitions

### DIFF
--- a/boards/blackberry/qnxhv_vm/doc/index.rst
+++ b/boards/blackberry/qnxhv_vm/doc/index.rst
@@ -49,6 +49,16 @@ The above features are supported by following configuration.
           loc 0x1c090000
           intr gic:37
 
+  # Enable virtio-console (Need to disable CONFIG_BOOT_BANNER)
+  vdev virtio-console
+          loc 0x20000000
+          intr gic:42
+
+  # Enable random number generator
+  vdev virtio-entropy
+          loc 0x1c0e0000
+          intr  gic:43
+
 
 Building and Running
 ********************

--- a/boards/blackberry/qnxhv_vm/qnxhv_vm.dts
+++ b/boards/blackberry/qnxhv_vm/qnxhv_vm.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &qvm_console;
 		zephyr,shell-uart = &qvm_console;
+		zephyr,entropy = &virtio_entropy;
 	};
 
 	cpus {
@@ -80,6 +81,30 @@
 			clocks = <&uartclk>;
 			current-speed = <115200>;
 			status = "okay";
+		};
+
+		virtio_mmio@20000000 {
+			compatible = "virtio,mmio";
+			reg = <0x0 0x20000000 0x0 0x1000>;
+			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "okay";
+
+			virtio_console: virtio-console {
+				compatible = "virtio,console";
+				status = "okay";
+			};
+		};
+
+		virtio_mmio@1c0e0000 {
+			compatible = "virtio,mmio";
+			reg = <0x0 0x1c0e0000 0x0 0x1000>;
+			interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "okay";
+
+			virtio_entropy: virtio-entropy {
+				compatible = "virtio,device4";
+				status = "okay";
+			};
 		};
 	};
 };

--- a/tests/drivers/entropy/api/boards/qnxhv_vm.conf
+++ b/tests/drivers/entropy/api/boards/qnxhv_vm.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_HEAP_MEM_POOL_SIZE=1024


### PR DESCRIPTION
Add `virtio-console` and `virtio-entropy` definitions.