### PR TITLE
drivers: i2c: sam: fix garbage reads when following a write

### DIFF
--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -168,13 +168,14 @@ static void read_msg_start(Twihs *const twihs, struct twihs_msg *msg,
 	/* Set slave address and number of internal address bytes */
 	twihs->TWIHS_MMR = TWIHS_MMR_MREAD | TWIHS_MMR_DADR(daddr);
 
-	/* Enable Receive Ready and Transmission Completed interrupts */
-	twihs->TWIHS_IER = TWIHS_IER_RXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
-
 	/* In single data byte read the START and STOP must both be set */
 	twihs_cr_stop = (msg->len == 1U) ? TWIHS_CR_STOP : 0;
+
 	/* Start the transfer by sending START condition */
 	twihs->TWIHS_CR = TWIHS_CR_START | twihs_cr_stop;
+
+	/* Enable Receive Ready and Transmission Completed interrupts */
+	twihs->TWIHS_IER = TWIHS_IER_RXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
 }
 
 static int i2c_sam_twihs_transfer(const struct device *dev,

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -159,11 +159,11 @@ static void read_msg_start(Twihs *const twihs, const uint32_t len, const uint8_t
 	/* In single data byte read the START and STOP must both be set */
 	twihs_cr_stop = (len == 1U) ? TWIHS_CR_STOP : 0;
 
-	/* Enable Receive Ready and Transmission Completed interrupts */
-	twihs->TWIHS_IER = TWIHS_IER_RXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
-
 	/* Start the transfer by sending START condition */
 	twihs->TWIHS_CR = TWIHS_CR_START | twihs_cr_stop;
+
+	/* Enable Receive Ready and Transmission Completed interrupts */
+	twihs->TWIHS_IER = TWIHS_IER_RXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
 }
 
 static void i2c_sam_twihs_complete(const struct device *dev, int status);


### PR DESCRIPTION
The interrupts should only be enabled after the START condition is set by either writing to TWIHS_THR(for writes) or by writing TWIHS_CR_START to TWIHS_CR. Otherwise, the TXCOMP interrupt may fire before the driver is ready, causing invalid reads and the semaphore to deadlock.

The sam_twi.c driver does not have this issue as it enables the interrupts only after setting the read bit

Fixes #67339

Link: https://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf