### PR TITLE
drivers: pwm: stm32: show the period cycles for the 16-bit limit error

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -236,7 +236,8 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 	 */
 	if (!IS_TIM_32B_COUNTER_INSTANCE(timer) &&
 	    (period_cycles > UINT16_MAX + 1)) {
-		LOG_ERR("Cannot set PWM output, value exceeds 16-bit timer limit.");
+		LOG_ERR("Cannot set PWM output, period cycles %u exceeds 16-bit timer limit.",
+			period_cycles);
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
The settings and calculations are often done in micro or nano seconds and the result is not always shown. So, just add the period cycles as part of the error message to get the calculated value.