### PR TITLE
drivers: led: sct2024: add write_channels function

### DIFF
--- a/drivers/led/sct2024.c
+++ b/drivers/led/sct2024.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/led.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/math_extras.h>
 
 LOG_MODULE_REGISTER(sct2024, CONFIG_LED_LOG_LEVEL);
 
@@ -146,6 +147,10 @@ static int sct2024_set_brightness(const struct device *dev, uint32_t led, uint8_
 		return led_index;
 	}
 
+	/* Max led_index being within the bitmap size is checked in
+	 * BUILD_ASSERT in SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE.
+	 */
+
 	if (value > 0) {
 		data->led_bitmap[led_index / 16] |= BIT(led_index % 16);
 	} else {
@@ -155,9 +160,57 @@ static int sct2024_set_brightness(const struct device *dev, uint32_t led, uint8_
 	return sct2024_write(dev);
 }
 
+static int sct2024_led_write_channels(const struct device *dev, uint32_t start_channel,
+				      uint32_t num_channels, const uint8_t *brightness_values)
+{
+	struct sct2024_data *data = dev->data;
+	uint16_t led_bitmap[SCT2024_MAX_CHAIN_LENGTH];
+	const size_t led_bitmap_size = MIN(sizeof(led_bitmap), sizeof(data->led_bitmap));
+	int ret = 0;
+
+	/* start_channel + num_channels overflow would be detected by invalid channel number passed
+	 * to sct2024_get_led_index() below. There is no need to make an additional check.
+	 */
+
+	memcpy(led_bitmap, data->led_bitmap, led_bitmap_size);
+
+	for (uint32_t i = 0; i < num_channels; i++) {
+		int led_index = sct2024_get_led_index(dev, start_channel + i);
+		uint32_t mask_index;
+		uint8_t bit_index;
+
+		if (led_index < 0) {
+			LOG_ERR("Invalid LED index for channel %u", start_channel + i);
+			ret = led_index;
+			continue;
+		}
+
+		/* Max led_index being within the bitmap size is checked in
+		 * BUILD_ASSERT in SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE.
+		 */
+
+		mask_index = led_index / 16;
+		bit_index = led_index % 16;
+
+		if (brightness_values[i] > 0) {
+			led_bitmap[mask_index] |= BIT(bit_index);
+		} else {
+			led_bitmap[mask_index] &= ~BIT(bit_index);
+		}
+	}
+
+	if (ret == 0) {
+		memcpy(data->led_bitmap, led_bitmap, led_bitmap_size);
+		ret = sct2024_write(dev);
+	}
+
+	return ret;
+}
+
 static DEVICE_API(led, sct2024_led_api) = {
 	.get_info = sct2024_get_info,
 	.set_brightness = sct2024_set_brightness,
+	.write_channels = sct2024_led_write_channels,
 };
 
 static int sct2024_init(const struct device *dev)
@@ -207,11 +260,16 @@ static bool sct2024_is_oe_pin_defined(const struct device *dev)
 		.label = DT_PROP_OR(child, label, NULL), \
 	},
 
+#define SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE(child) \
+	BUILD_ASSERT(DT_PROP(child, index) < SCT2024_MAX_CHAIN_LENGTH * SCT2024_LED_COUNT, \
+		     "LED index out of range");
+
 #define SCT2024_INIT(inst) \
 	static struct sct2024_data sct2024_data_##inst; \
 	static const struct led_info sct2024_leds_##inst[] = { \
 		DT_INST_FOREACH_CHILD(inst, SCT2024_LED_INFO_INIT) \
 	}; \
+	DT_INST_FOREACH_CHILD(inst, SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE); \
 	static const struct sct2024_cfg sct2024_cfg_##inst = { \
 		.spi = SPI_DT_SPEC_INST_GET(inst, \
 			SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB), \

--- a/drivers/led/sct2024.c
+++ b/drivers/led/sct2024.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/led.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/math_extras.h>
 
 LOG_MODULE_REGISTER(sct2024, CONFIG_LED_LOG_LEVEL);
 
@@ -155,9 +156,43 @@ static int sct2024_set_brightness(const struct device *dev, uint32_t led, uint8_
 	return sct2024_write(dev);
 }
 
+static int sct2024_led_write_channels(const struct device *dev, uint32_t start_channel,
+				      uint32_t num_channels, const uint8_t *brightness_values)
+{
+	struct sct2024_data *data = dev->data;
+	uint16_t led_bitmap[SCT2024_MAX_CHAIN_LENGTH];
+	const size_t led_bitmap_size = MIN(sizeof(led_bitmap), sizeof(data->led_bitmap));
+
+	memcpy(led_bitmap, data->led_bitmap, led_bitmap_size);
+
+	for (uint32_t i = 0; i < num_channels; i++) {
+		int led_index = sct2024_get_led_index(dev, start_channel + i);
+		uint32_t mask_index;
+		uint8_t bit_index;
+
+		if (led_index < 0) {
+			LOG_ERR("Invalid LED index for channel %u", start_channel + i);
+			return led_index;
+		}
+
+		mask_index = led_index / 16;
+		bit_index = led_index % 16;
+
+		if (brightness_values[i] > 0) {
+			led_bitmap[mask_index] |= BIT(bit_index);
+		} else {
+			led_bitmap[mask_index] &= ~BIT(bit_index);
+		}
+	}
+
+	memcpy(data->led_bitmap, led_bitmap, led_bitmap_size);
+	return sct2024_write(dev);
+}
+
 static DEVICE_API(led, sct2024_led_api) = {
 	.get_info = sct2024_get_info,
 	.set_brightness = sct2024_set_brightness,
+	.write_channels = sct2024_led_write_channels,
 };
 
 static int sct2024_init(const struct device *dev)
@@ -207,11 +242,16 @@ static bool sct2024_is_oe_pin_defined(const struct device *dev)
 		.label = DT_PROP_OR(child, label, NULL), \
 	},
 
+#define SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE(child) \
+	BUILD_ASSERT(DT_PROP(child, index) < SCT2024_MAX_CHAIN_LENGTH * SCT2024_LED_COUNT, \
+		     "LED index out of range");
+
 #define SCT2024_INIT(inst) \
 	static struct sct2024_data sct2024_data_##inst; \
 	static const struct led_info sct2024_leds_##inst[] = { \
 		DT_INST_FOREACH_CHILD(inst, SCT2024_LED_INFO_INIT) \
 	}; \
+	DT_INST_FOREACH_CHILD(inst, SCT2024_ASSERT_LED_INFO_INDEX_IN_RANGE); \
 	static const struct sct2024_cfg sct2024_cfg_##inst = { \
 		.spi = SPI_DT_SPEC_INST_GET(inst, \
 			SPI_OP_MODE_CONTROLLER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB), \

--- a/samples/drivers/led/sct2024/README.rst
+++ b/samples/drivers/led/sct2024/README.rst
@@ -9,9 +9,11 @@ Overview
 
 This sample controls up to 16 LEDs connected to a SCT2024 driver.
 
-In an infinite loop, a test pattern is applied to each LED one by one. The
-pattern is a sequence of turning each LED on; when all LEDs are on, each of the
-LEDs is turned off.
+In an infinite loop, a test pattern is applied to each LED one at a time. The pattern consists of
+turning each LED on individually. Once all LEDs are on, they are all switched off simultaneously,
+followed by being switched on simultaneously twice. After this, each LED is turned off one at a
+time in sequence. And then all LEDs are again turned on and off simultaneously twice. Then the
+pattern is repeated.
 
 Building and Running
 ********************

--- a/samples/drivers/led/sct2024/README.rst
+++ b/samples/drivers/led/sct2024/README.rst
@@ -9,9 +9,10 @@ Overview
 
 This sample controls up to 16 LEDs connected to a SCT2024 driver.
 
-In an infinite loop, a test pattern is applied to each LED one by one. The
-pattern is a sequence of turning each LED on; when all LEDs are on, each of the
-LEDs is turned off.
+In an infinite loop, a test pattern is applied to each LED one at a time. The pattern consists of
+turning each LED on individually. Once all LEDs are on, they are all switched off simultaneously,
+followed by being switched on simultaneously. After this, each LED is turned off one at a
+time in sequence. Then the pattern is repeated.
 
 Building and Running
 ********************

--- a/samples/drivers/led/sct2024/src/main.c
+++ b/samples/drivers/led/sct2024/src/main.c
@@ -14,13 +14,21 @@
 LOG_MODULE_REGISTER(main);
 
 #define LED_DELAY_MS    500
-#define ON_OFF_DELAY_MS 1000
+#define ON_OFF_DELAY_MS 125
 
 #define NUM_LEDS 16
 
 int main(void)
 {
 	static const struct device *dev = DEVICE_DT_GET_ANY(sct_sct2024);
+	const uint8_t channels_on[NUM_LEDS] = {255, 255, 255, 255,
+		255, 255, 255, 255,
+		255, 255, 255, 255,
+		255, 255, 255, 255};
+	const uint8_t channels_off[NUM_LEDS] = {0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0};
 
 	if (!dev) {
 		LOG_ERR("No SCT2024 LED controller found");
@@ -40,6 +48,14 @@ int main(void)
 			k_msleep(LED_DELAY_MS);
 		}
 
+		led_write_channels(dev, 0, NUM_LEDS, channels_off);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_on);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_off);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_on);
+
 		k_msleep(ON_OFF_DELAY_MS);
 
 		for (int i = 0; i < NUM_LEDS; i++) {
@@ -48,6 +64,14 @@ int main(void)
 			}
 			k_msleep(LED_DELAY_MS);
 		}
+
+		led_write_channels(dev, 0, NUM_LEDS, channels_on);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_off);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_on);
+		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_off);
 
 		k_msleep(ON_OFF_DELAY_MS);
 	} while (true);

--- a/samples/drivers/led/sct2024/src/main.c
+++ b/samples/drivers/led/sct2024/src/main.c
@@ -14,13 +14,21 @@
 LOG_MODULE_REGISTER(main);
 
 #define LED_DELAY_MS    500
-#define ON_OFF_DELAY_MS 1000
+#define ON_OFF_DELAY_MS 125
 
 #define NUM_LEDS 16
 
 int main(void)
 {
 	static const struct device *dev = DEVICE_DT_GET_ANY(sct_sct2024);
+	const uint8_t channels_on[NUM_LEDS] = {255, 255, 255, 255,
+		255, 255, 255, 255,
+		255, 255, 255, 255,
+		255, 255, 255, 255};
+	const uint8_t channels_off[NUM_LEDS] = {0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0};
 
 	if (!dev) {
 		LOG_ERR("No SCT2024 LED controller found");
@@ -33,6 +41,8 @@ int main(void)
 	}
 
 	do {
+		LOG_INF("Turning LEDs on sequentially");
+
 		for (int i = 0; i < NUM_LEDS; i++) {
 			if (led_on(dev, i)) {
 				LOG_ERR("Failed to turn on LED %d", i);
@@ -40,7 +50,14 @@ int main(void)
 			k_msleep(LED_DELAY_MS);
 		}
 
+		LOG_INF("Blinking all LEDs");
+
+		led_write_channels(dev, 0, NUM_LEDS, channels_off);
 		k_msleep(ON_OFF_DELAY_MS);
+		led_write_channels(dev, 0, NUM_LEDS, channels_on);
+		k_msleep(ON_OFF_DELAY_MS);
+
+		LOG_INF("Turning LEDs off sequentially");
 
 		for (int i = 0; i < NUM_LEDS; i++) {
 			if (led_off(dev, i)) {
@@ -48,8 +65,6 @@ int main(void)
 			}
 			k_msleep(LED_DELAY_MS);
 		}
-
-		k_msleep(ON_OFF_DELAY_MS);
 	} while (true);
 
 	return 0;


### PR DESCRIPTION
This pull request adds support for writing brightness values to multiple LED channels at once in the SCT2024 LED driver, and updates the sample application to demonstrate this new functionality.

**Driver enhancements:**

* Added a new `sct2024_led_write_channels` function to the `sct2024.c` driver, enabling batch updates of brightness values for multiple LED channels, and exposed it via the device API as `write_channels`.

**Sample application updates:**

* Updated the sample in `main.c` to use the new `led_write_channels` function, turning all LEDs on or off simultaneously using arrays of brightness values.
* Reduced the `ON_OFF_DELAY_MS` from 1000ms to 125ms for faster LED toggling in the sample.