### PR TITLE
maintainers: Add dts/riscv/raspberrypi to Raspberry Pi Pico maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4452,6 +4452,7 @@ Raspberry Pi Pico Platforms:
     - boards/wiznet/w5500_evb_pico*/
     - dts/arm/raspberrypi/rpi_pico/
     - dts/bindings/*/raspberrypi,pico*
+    - dts/riscv/raspberrypi/
     - drivers/*/*rpi_pico
     - drivers/*/*rpi_pico*/
     - drivers/*/*rpi_pico*.c


### PR DESCRIPTION
Relates to #102839 which didn't get assigned to any Raspberry Pi maintainers.

The RP23xxx microcontrollers include two RiSC-V Hazard3 cores. Update the MAINTAINERS.yml file to include the relevant DTS directory.