### PR TITLE
MAINTAINERS: add keith-zephyr as USB-C maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5325,7 +5325,6 @@ USB-C:
   status: maintained
   maintainers:
     - sambhurst
-  collaborators:
     - keith-zephyr
   files:
     - drivers/usb_c/


### PR DESCRIPTION
Promote keith-zephyr from collaborator to maintainer for the USB-C area.