### PR TITLE
drivers: adc: refine lpadc LPADC_SetOffsetValue logic

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -298,8 +298,7 @@ static int mcux_lpadc_start_read(const struct device *dev,
 	struct mcux_lpadc_data *data = dev->data;
 	lpadc_hardware_average_mode_t hardware_average_mode;
 	uint8_t channel, last_enabled;
-#if defined(FSL_FEATURE_LPADC_HAS_CMDL_MODE) \
-	&& FSL_FEATURE_LPADC_HAS_CMDL_MODE
+#if defined(FSL_FEATURE_LPADC_HAS_CMDL_MODE) && FSL_FEATURE_LPADC_HAS_CMDL_MODE
 	lpadc_conversion_resolution_mode_t resolution_mode;
 
 	switch (sequence->resolution) {
@@ -672,8 +671,7 @@ static void mcux_lpadc_isr(const struct device *dev)
 	int16_t result;
 	uint16_t channel;
 
-#if (defined(FSL_FEATURE_LPADC_FIFO_COUNT) \
-	&& (FSL_FEATURE_LPADC_FIFO_COUNT == 2U))
+#if (defined(FSL_FEATURE_LPADC_FIFO_COUNT) && (FSL_FEATURE_LPADC_FIFO_COUNT == 2U))
 	LPADC_GetConvResult(base, &conv_result, 0U);
 #else
 	LPADC_GetConvResult(base, &conv_result);
@@ -780,38 +778,31 @@ static int mcux_lpadc_init(const struct device *dev)
 	adc_config.enableAnalogPreliminary = true;
 	adc_config.referenceVoltageSource = config->voltage_ref;
 
-#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS) \
-	&& FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS
+#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS) && FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS
 	adc_config.conversionAverageMode = config->calibration_average;
 #endif /* FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS */
 
 #if !(DT_ANY_INST_HAS_PROP_STATUS_OKAY(no_power_level))
-		adc_config.powerLevelMode = config->power_level;
+	adc_config.powerLevelMode = config->power_level;
 #endif
 
 	LPADC_Init(base, &adc_config);
 
 	/* Do ADC calibration. */
-#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CALOFS) \
-	&& FSL_FEATURE_LPADC_HAS_CTRL_CALOFS
-#if defined(FSL_FEATURE_LPADC_HAS_OFSTRIM) \
-	&& FSL_FEATURE_LPADC_HAS_OFSTRIM
+#if defined(FSL_FEATURE_LPADC_HAS_CTRL_CALOFS) && FSL_FEATURE_LPADC_HAS_CTRL_CALOFS
+#if defined(FSL_FEATURE_LPADC_HAS_OFSTRIM) && FSL_FEATURE_LPADC_HAS_OFSTRIM
 	/* Request offset calibration. */
-#if defined(CONFIG_LPADC_DO_OFFSET_CALIBRATION) \
-	&& CONFIG_LPADC_DO_OFFSET_CALIBRATION
+#if defined(CONFIG_LPADC_DO_OFFSET_CALIBRATION) && CONFIG_LPADC_DO_OFFSET_CALIBRATION
 	LPADC_DoOffsetCalibration(base);
 #else
-	LPADC_SetOffsetValue(base,
-			config->offset_a,
-			config->offset_b);
+	LPADC_SetOffsetValue(base, config->offset_a, config->offset_b);
 #endif  /* DEMO_LPADC_DO_OFFSET_CALIBRATION */
 #endif  /* FSL_FEATURE_LPADC_HAS_OFSTRIM */
 	/* Request gain calibration. */
 	LPADC_DoAutoCalibration(base);
 #endif /* FSL_FEATURE_LPADC_HAS_CTRL_CALOFS */
 
-#if (defined(FSL_FEATURE_LPADC_HAS_CFG_CALOFS) \
-	&& FSL_FEATURE_LPADC_HAS_CFG_CALOFS)
+#if (defined(FSL_FEATURE_LPADC_HAS_CFG_CALOFS) && FSL_FEATURE_LPADC_HAS_CFG_CALOFS)
 	/* Do auto calibration. */
 	LPADC_DoAutoCalibration(base);
 #endif /* FSL_FEATURE_LPADC_HAS_CFG_CALOFS */
@@ -885,29 +876,28 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 #define DMA_INIT(n)
 #endif
 
-#define LPADC_MCUX_INIT(n)						\
-									\
-	static void mcux_lpadc_config_func_##n(const struct device *dev);	\
-									\
-	PINCTRL_DT_INST_DEFINE(n);						\
-	static const struct mcux_lpadc_config mcux_lpadc_config_##n = {	\
-		.base = (ADC_Type *)DT_INST_REG_ADDR(n),	\
-		.voltage_ref =	DT_INST_PROP(n, voltage_ref),	\
-		.calibration_average = DT_INST_ENUM_IDX_OR(n, calibration_average, 0),	\
-		.power_level = DT_INST_PROP_OR(n, power_level, 0),	\
-		.offset_a = DT_INST_PROP(n, offset_value_a),	\
-		.offset_b = DT_INST_PROP(n, offset_value_b),	\
-		.irq_config_func = mcux_lpadc_config_func_##n,				\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-		.ref_supplies = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_references),\
-						(DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n),\
-						nxp_references))), (NULL)),\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
-		.ref_supply_val = COND_CODE_1(\
-						DT_INST_NODE_HAS_PROP(n, nxp_references),\
-						(DT_PHA(DT_DRV_INST(n), nxp_references, vref_mv)), \
-						(0)),\
+#define LPADC_MCUX_INIT(n)									\
+												\
+	static void mcux_lpadc_config_func_##n(const struct device *dev);			\
+												\
+	PINCTRL_DT_INST_DEFINE(n);								\
+	static const struct mcux_lpadc_config mcux_lpadc_config_##n = {				\
+		.base = (ADC_Type *)DT_INST_REG_ADDR(n),					\
+		.voltage_ref =	DT_INST_PROP(n, voltage_ref),					\
+		.calibration_average = DT_INST_ENUM_IDX_OR(n, calibration_average, 0),		\
+		.power_level = DT_INST_PROP_OR(n, power_level, 0),				\
+		.offset_a = DT_INST_PROP(n, offset_value_a),					\
+		.offset_b = DT_INST_PROP(n, offset_value_b),					\
+		.irq_config_func = mcux_lpadc_config_func_##n,					\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
+		.ref_supplies = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_references),		\
+					    (DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n),		\
+					    nxp_references))), (NULL)),				\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),				\
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),		\
+		.ref_supply_val = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_references),		\
+					      (DT_PHA(DT_DRV_INST(n), nxp_references, vref_mv)),\
+					      (0)),						\
 		.opamp = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_opamps),			\
 			(DEVICE_DT_GET(DT_INST_PHANDLE_BY_IDX(n, nxp_opamps, 0))), (NULL)),	\
 		.opamp_channel = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, nxp_opamps),		\
@@ -921,29 +911,27 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 			(DT_PROP_BY_IDX(DT_DRV_INST(n), ideal_sample_range, 1)), (UINT32_MAX)),	\
 			OPAMP_GAINS_INIT(n)							\
 		DMA_INIT(n)									\
-	};									\
-	static struct mcux_lpadc_data mcux_lpadc_data_##n = {	\
-		ADC_CONTEXT_INIT_TIMER(mcux_lpadc_data_##n, ctx),	\
-		ADC_CONTEXT_INIT_LOCK(mcux_lpadc_data_##n, ctx),	\
-		ADC_CONTEXT_INIT_SYNC(mcux_lpadc_data_##n, ctx),	\
-	};														\
-										\
-	DEVICE_DT_INST_DEFINE(n,						\
-		mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
-		&mcux_lpadc_config_##n, POST_KERNEL,				\
-		CONFIG_ADC_INIT_PRIORITY,					\
-		&mcux_lpadc_driver_api);							\
-										\
-	static void mcux_lpadc_config_func_##n(const struct device *dev)	\
-	{									\
-		IRQ_CONNECT(DT_INST_IRQN(n),					\
-			DT_INST_IRQ(n, priority), mcux_lpadc_isr,	\
-			DEVICE_DT_INST_GET(n), 0);				\
-										\
-		irq_enable(DT_INST_IRQN(n));					\
-	}	\
-										\
-	BUILD_ASSERT((DT_INST_PROP_OR(n, power_level, 0) >= 0) && \
-		(DT_INST_PROP_OR(n, power_level, 0) <= 3), "power_level: wrong value");
+	};											\
+												\
+	static struct mcux_lpadc_data mcux_lpadc_data_##n = {					\
+		ADC_CONTEXT_INIT_TIMER(mcux_lpadc_data_##n, ctx),				\
+		ADC_CONTEXT_INIT_LOCK(mcux_lpadc_data_##n, ctx),				\
+		ADC_CONTEXT_INIT_SYNC(mcux_lpadc_data_##n, ctx),				\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(n, mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
+			      &mcux_lpadc_config_##n, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,	\
+			      &mcux_lpadc_driver_api);						\
+												\
+	static void mcux_lpadc_config_func_##n(const struct device *dev)			\
+	{											\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_lpadc_isr,		\
+			    DEVICE_DT_INST_GET(n), 0);						\
+												\
+		irq_enable(DT_INST_IRQN(n));							\
+	}											\
+												\
+	BUILD_ASSERT((DT_INST_PROP_OR(n, power_level, 0) >= 0) &&				\
+		     (DT_INST_PROP_OR(n, power_level, 0) <= 3), "power_level: wrong value");
 
 DT_INST_FOREACH_STATUS_OKAY(LPADC_MCUX_INIT)


### PR DESCRIPTION
1. Fix inconsistent formatting in the LPADC driver.
2. Fix offset calibration handling and improve type safety in the LPADC driver.
3. Use LPADC_SetOffsetValue() with appropriate parameters based on `FSL_FEATURE_LPADC_OFSTRIM_COUNT` when auto-calibration is disabled

fix FRDM-MCXW70 adc sample/test build issue reported in https://github.com/zephyrproject-rtos/zephyr/pull/102088