### PR TITLE
Introduction of spi.h interfaces for cpu based transfers only.

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1419,6 +1419,13 @@ static int transceive_dma(const struct device *dev,
 	if (asynchronous) {
 		return -ENOTSUP;
 	}
+    
+	 // We need this for creating clocks on spi line internally to support supposedly simplex mode at higher layers.
+	if((tx_bufs == NULL) && (rx_bufs != NULL)) {
+		tx_bufs = rx_bufs;
+	} else if((tx_bufs != NULL) && (rx_bufs == NULL)) {
+		rx_bufs = tx_bufs;
+	}
 
 #ifdef CONFIG_DCACHE
 	if ((tx_bufs != NULL && !spi_buf_set_in_nocache(tx_bufs)) ||
@@ -1499,7 +1506,6 @@ static int transceive_dma(const struct device *dev,
 
 		if (transfer_dir == LL_SPI_FULL_DUPLEX) {
 			dma_len = spi_context_max_continuous_chunk(&data->ctx);
-
 			ret = spi_dma_move_buffers(dev, dma_len);
 		} else if (transfer_dir == LL_SPI_HALF_DUPLEX_TX) {
 			dma_len = data->ctx.tx_len;

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1659,6 +1659,14 @@ static int spi_stm32_transceive(const struct device *dev,
 	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
+static int spi_stm32_transceive_cpu(const struct device *dev,
+				const struct spi_config *config,
+				const struct spi_buf_set *tx_bufs,
+				const struct spi_buf_set *rx_bufs)
+{
+	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
+}
+
 #ifdef CONFIG_SPI_ASYNC
 static int spi_stm32_transceive_async(const struct device *dev,
 				      const struct spi_config *config,
@@ -1673,6 +1681,7 @@ static int spi_stm32_transceive_async(const struct device *dev,
 
 static DEVICE_API(spi, api_funcs) = {
 	.transceive = spi_stm32_transceive,
+	.transceive_cpu = spi_stm32_transceive_cpu,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_stm32_transceive_async,
 #endif


### PR DESCRIPTION
This PR contains addressing of two problems.

One of the problems, related to non availability of explicit cpu based spi.h interfaces, was highlighted using this issue: https://github.com/zephyrproject-rtos/zephyr/issues/102532

The second problem was highlighted during discord discussion with STM employees on the non-support of SPI simplex mode transactions while the execution was performed over DMA.

The first issue has been solved by simply providing additional interfaces, which does not impact any existing users.

The second issue was also solved by introducing the reuse of Non-NULL pointers for supporting simplex transfers when using transceive_dma in spi_stm32.c driver file.

