### PR TITLE
boards: silabs: Add PWM LED for slwrb418x 

### DIFF
--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
@@ -27,4 +27,12 @@
 			silabs,analog-bus = <ABUS_AEVEN0_IADC0>;
 		};
 	};
+
+	timer0_pwm_default: timer0_pwm_default {
+		group0 {
+			pins = <TIMER0_CC0_PB0>;
+			drive-push-pull;
+			output-low;
+		};
+	};
 };

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "slwrb4180a-pinctrl.dtsi"
 
@@ -28,6 +29,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
@@ -45,6 +47,15 @@
 		led1: led_1 {
 			gpios = <&gpiob 1 0>;
 			label = "LED 1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			label = "PWM LED0";
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 
@@ -263,5 +274,15 @@
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
+	};
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_pwm_default>;
+		pinctrl-names = "default";
+		status = "okay";
 	};
 };

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
@@ -26,4 +26,12 @@
 			silabs,analog-bus = <ABUS_AEVEN0_IADC0>;
 		};
 	};
+
+	timer0_pwm_default: timer0_pwm_default {
+		group0 {
+			pins = <TIMER0_CC0_PD2>;
+			drive-push-pull;
+			output-low;
+		};
+	};
 };

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "slwrb4180b-pinctrl.dtsi"
 
@@ -28,6 +29,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
@@ -45,6 +47,15 @@
 		led1: led_1 {
 			gpios = <&gpiod 3 0>;
 			label = "LED1";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			label = "PWM LED0";
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 
@@ -260,5 +271,15 @@
 			reg = <0x000F8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
+	};
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_pwm_default>;
+		pinctrl-names = "default";
+		status = "okay";
 	};
 };


### PR DESCRIPTION
Zephyr supports the slwrb4180a and slwrb4180b boards, but building the
blinky_pwm sample for these boards fails due to missing PWM
configuration.

This PR adds a board-specific overlay for Silicon Labs slwrb418x to
enable the blinky_pwm sample with the correct PWM configuration.

Tested by building and running the blinky_pwm sample on slwrb4181x.