### PR TITLE
usb: host: ch9: Add string descriptor request helper function

### DIFF
--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -180,6 +180,15 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 	return ret;
 }
 
+int usbh_req_desc_str(struct usb_device *const udev,
+		      const uint8_t index, const uint16_t lang_id,
+		      struct net_buf *const desc_buf)
+{
+	uint16_t len = MIN(net_buf_tailroom(desc_buf), UINT8_MAX);
+
+	return usbh_req_desc(udev, USB_DESC_STRING, index, lang_id, len, desc_buf);
+}
+
 int usbh_req_set_address(struct usb_device *const udev,
 			 const uint8_t addr)
 {

--- a/subsys/usb/host/usbh_ch9.h
+++ b/subsys/usb/host/usbh_ch9.h
@@ -41,6 +41,10 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 		      const uint16_t len,
 		      struct usb_cfg_descriptor *const desc);
 
+int usbh_req_desc_str(struct usb_device *const udev,
+		      const uint8_t index, const uint16_t lang_id,
+		      struct net_buf *const desc_buf);
+
 int usbh_req_set_alt(struct usb_device *const udev,
 		     const uint8_t iface,
 		     const uint8_t alt);

--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -1,15 +1,18 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
- * SPDX-FileCopyrightText: Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/drivers/usb/uhc.h>
 #include <zephyr/usb/usb_ch9.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 
 #include "usbh_class.h"
 #include "usbh_desc.h"
+#include "usbh_ch9.h"
+#include "usbh_device.h"
 
 LOG_MODULE_REGISTER(usbh_desc, CONFIG_USBH_LOG_LEVEL);
 
@@ -57,6 +60,12 @@ bool usbh_desc_is_valid_endpoint(const void *const desc)
 {
 	return usbh_desc_is_valid(desc, sizeof(struct usb_ep_descriptor),
 				  USB_DESC_ENDPOINT);
+}
+
+bool usbh_desc_is_valid_string(const void *const desc)
+{
+	return usbh_desc_is_valid(desc, sizeof(struct usb_string_descriptor),
+				  USB_DESC_STRING);
 }
 
 const void *usbh_desc_get_next(const void *const desc)
@@ -217,4 +226,64 @@ const void *usbh_desc_get_next_function(const void *const desc)
 	}
 
 	return NULL;
+}
+
+int usbh_desc_get_lang_ids(const void *const desc, const uint8_t len, uint16_t *const lang_ids,
+			   const uint8_t lang_ids_len)
+{
+	const struct usb_desc_header *const head = desc;
+	const uint8_t *data = (const uint8_t *)desc + sizeof(struct usb_desc_header);
+	uint8_t lang_id_count;
+
+	if (len < sizeof(struct usb_string_descriptor) || !usbh_desc_is_valid_string(desc)) {
+		return -EINVAL;
+	}
+
+	/* Calculate number of LANGIDs that buffer can hold */
+	lang_id_count =
+		(MIN(head->bLength, len) - sizeof(struct usb_desc_header)) / sizeof(uint16_t);
+	lang_id_count = MIN(lang_id_count, lang_ids_len);
+
+	for (unsigned int i = 0; i < lang_id_count; i++) {
+		lang_ids[i] = sys_get_le16(&data[i * 2]);
+	}
+
+	return (int)lang_id_count;
+}
+
+int usbh_desc_str_to_ascii(const void *const desc, const uint8_t len, char *const str,
+			   const uint8_t str_len)
+{
+	const struct usb_desc_header *const head = desc;
+	const uint8_t *data = (const uint8_t *)desc + sizeof(struct usb_desc_header);
+	uint8_t char_count;
+
+	if (len < sizeof(struct usb_string_descriptor) || !usbh_desc_is_valid_string(desc)) {
+		return -EINVAL;
+	}
+
+	if (str_len == 0) {
+		return -EINVAL;
+	}
+
+	/* Calculate number of characters */
+	char_count = (MIN(head->bLength, len) - sizeof(struct usb_desc_header)) / sizeof(uint16_t);
+
+	memset(str, '\0', str_len);
+
+	for (unsigned int i = 0; i < MIN(char_count, str_len - 1); i++) {
+		uint16_t utf16le_code = sys_get_le16(&data[i * 2]);
+
+		if (utf16le_code > 0x7F) {
+			return -ENOTSUP;
+		}
+
+		if (utf16le_code == 0) {
+			break;
+		}
+
+		str[i] = (char)utf16le_code;
+	}
+
+	return 0;
 }

--- a/subsys/usb/host/usbh_desc.h
+++ b/subsys/usb/host/usbh_desc.h
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -122,6 +123,16 @@ bool usbh_desc_is_valid_association(const void *const desc);
 bool usbh_desc_is_valid_endpoint(const void *const desc);
 
 /**
+ * @brief Checks that the pointed descriptor is an string descriptor.
+ *
+ * @param[in] desc The descriptor to validate
+ *
+ * @return true if the descriptor size and type are correct
+ * @return false if the descriptor size or type is wrong
+ */
+bool usbh_desc_is_valid_string(const void *const desc);
+
+/**
  * @brief Get the next function in the descriptor list.
  *
  * This searches the interface or interface association of the next USB
@@ -151,4 +162,42 @@ const void *usbh_desc_get_next_function(const void *const desc);
  */
 const void *usbh_desc_get_next_alt_setting(const void *const desc);
 
+/**
+ * @brief Parse supported USB LANGIDs from string descriptor 0.
+ *
+ * Parses the list of supported LANGIDs from USB string descriptor index 0 and
+ * stores them in the provided buffer. The number of LANGIDs copied is limited
+ * by both the descriptor content and the buffer size.
+ *
+ * @param[in] desc Pointer to the string descriptor index 0 to parse.
+ * @param[in] len Length of the string descriptor in bytes.
+ * @param[out] lang_ids Buffer to store the parsed LANGIDs.
+ * @param[in] lang_ids_len Maximum number of LANGIDs the buffer can hold.
+ *
+ * @retval Number of available LANGIDs copied to @p lang_ids buffer.
+ * @retval -EINVAL if descriptor @p desc is malformed.
+ */
+int usbh_desc_get_lang_ids(const void *const desc, const uint8_t len, uint16_t *const lang_ids,
+			   const uint8_t lang_ids_len);
+
+/**
+ * @brief Convert UTF-16LE encoded string descriptor to ASCII.
+ *
+ * Converts the UTF-16LE encoded string descriptor to an ASCII string. The ASCII
+ * string is always null-terminated. Only characters in the ASCII range (0x00 -
+ * 0x7F) are supported; characters outside this range will cause the conversion
+ * to fail.
+ *
+ * @param[in] desc Pointer to the string descriptor to convert.
+ * @param[in] len Length of the string descriptor in bytes.
+ * @param[out] str Buffer to store the converted ASCII string.
+ * @param[in] str_len Maximum length of the ASCII buffer (including null
+ *            terminator).
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p str_len is zero, or descriptor @p desc is malformed.
+ * @retval -ENOTSUP if a non-ASCII character (> 0x7F) is encountered.
+ */
+int usbh_desc_str_to_ascii(const void *const desc, const uint8_t len, char *const str,
+			   const uint8_t str_len);
 #endif /* ZEPHYR_INCLUDE_USBH_DESC_H */

--- a/tests/subsys/usb/device_next/src/main.c
+++ b/tests/subsys/usb/device_next/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/usb/usbh.h>
 
 #include "usbh_ch9.h"
+#include "usbh_desc.h"
 #include "usbh_device.h"
 
 #include <zephyr/logging/log.h>
@@ -40,7 +41,9 @@ USBH_CONTROLLER_DEFINE(uhs_ctx, DEVICE_DT_GET(DT_NODELABEL(zephyr_uhc0)));
 static int test_cmp_string_desc(struct net_buf *const buf, const int idx)
 {
 	static struct usbd_desc_node *desc_nd;
-	size_t len;
+	char ascii_str[253];
+	uint16_t len;
+	int err;
 
 	if (idx == test_mfg.str.idx) {
 		desc_nd = &test_mfg;
@@ -52,19 +55,15 @@ static int test_cmp_string_desc(struct net_buf *const buf, const int idx)
 		return -ENOTSUP;
 	}
 
-	if (net_buf_pull_u8(buf) != desc_nd->bLength) {
-		return -EINVAL;
+	err = usbh_desc_str_to_ascii(buf->data, buf->len, ascii_str, ARRAY_SIZE(ascii_str));
+	if (err != 0) {
+		return err;
 	}
 
-	if (net_buf_pull_u8(buf) != USB_DESC_STRING) {
-		return -EINVAL;
-	}
-
-	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
-	len = MIN(buf->len / 2, desc_nd->bLength / 2);
+	len = MIN(sizeof(ascii_str), desc_nd->bLength / 2);
 	for (size_t i = 0; i < len; i++) {
-		uint16_t a = net_buf_pull_le16(buf);
-		uint16_t b = ((uint8_t *)(desc_nd->ptr))[i];
+		char a = ascii_str[i];
+		char b = ((const uint8_t *)(desc_nd->ptr))[i];
 
 		if (a != b) {
 			LOG_INF("%c != %c", a, b);
@@ -77,9 +76,9 @@ static int test_cmp_string_desc(struct net_buf *const buf, const int idx)
 
 ZTEST(device_next, test_get_desc_string)
 {
-	const uint8_t type = USB_DESC_STRING;
-	const uint16_t id = 0x0409;
 	static struct usb_device *udev;
+	const uint16_t our_id = 0x0409;
+	uint16_t lang_ids[2];
 	struct net_buf *buf;
 	int err;
 
@@ -92,19 +91,29 @@ ZTEST(device_next, test_get_desc_string)
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));
 	zassert_equal(err, 0, "Failed to lock device");
 
-	err = usbh_req_desc(udev, type, 1, id, UINT8_MAX, buf);
+	err = usbh_req_desc_str(udev, 0, 0, buf);
+	zassert_equal(err, 0, "Failed to get string descriptor index 0");
+
+	err = usbh_desc_get_lang_ids(buf->data, buf->len, lang_ids, ARRAY_SIZE(lang_ids));
+	zassert_true(err > 0, "Failed to get LANGIDs");
+
+	zassert_true(err == 1, "Wrong number of LANGIDs");
+	zassert_equal(lang_ids[0], our_id, "Wrong LANGID");
+
+	net_buf_reset(buf);
+	err = usbh_req_desc_str(udev, 1, our_id, buf);
 	zassert_equal(err, 0, "Transfer status is an error");
 	err = test_cmp_string_desc(buf, 1);
 	zassert_equal(err, 0, "Descriptor comparison failed");
 
 	net_buf_reset(buf);
-	err = usbh_req_desc(udev, type, 2, id, UINT8_MAX, buf);
+	err = usbh_req_desc_str(udev, 2, our_id, buf);
 	zassert_equal(err, 0, "Transfer status is an error");
 	err = test_cmp_string_desc(buf, 2);
 	zassert_equal(err, 0, "Descriptor comparison failed");
 
 	net_buf_reset(buf);
-	err = usbh_req_desc(udev, type, 3, id, UINT8_MAX, buf);
+	err = usbh_req_desc_str(udev, 3, our_id, buf);
 	zassert_equal(err, 0, "Transfer status is an error");
 	err = test_cmp_string_desc(buf, 3);
 	zassert_equal(err, 0, "Descriptor comparison failed");


### PR DESCRIPTION
Add helpers to get USB device string descriptors, obtain a list of the supported LANGIDs, and convert UTF-16LE encoded string descriptors to ASCII.
Add the recently introduced descriptor helper in the device stack tests.