### PR TITLE
samples: i2s: output: nucleo_n657x0_q disable i2c4

### DIFF
--- a/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
@@ -41,3 +41,9 @@
 	mclk-divider = "div-256";
 	dma-names = "tx";
 };
+
+/* SAI2_B MCLK conflicts with I2C SDA */
+/* SAI2_B FS conflicts with I2C SCK */
+&i2c4 {
+	status = "disabled";
+};


### PR DESCRIPTION
This change disables i2c4 node on `samples/drivers/i2s/output` on nucleo_n657x0_q due to conflicts with sai2_b

[i2c4](https://github.com/zephyrproject-rtos/zephyr/blob/a5d4626b8c16550666983f793d8d3789850115fb/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi#L208C1-L215C3)
```
&i2c4 {
	clocks = <&rcc STM32_CLOCK(APB4, 7)>,
		 <&rcc STM32_SRC_CKPER I2C4_SEL(1)>;
	pinctrl-0 = <&i2c4_scl_pe13 &i2c4_sda_pe14>;
	pinctrl-names = "default";
	clock-frequency = <I2C_BITRATE_STANDARD>;
	status = "okay";
};
```

[sai2_b](https://github.com/zephyrproject-rtos/zephyr/blob/a5d4626b8c16550666983f793d8d3789850115fb/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay#L32C1-L43C3)
```
/* 44.084KHz (-0.03% Error) */
&sai2_b {
	clocks = <&rcc STM32_CLOCK(APB2, 22)>,
		 <&rcc STM32_SRC_IC7 SAI2_SEL(2)>;
	pinctrl-0 = <&sai2_mclk_b_pe14 &sai2_sd_b_pe7
		     &sai2_fs_b_pe13 &sai2_sck_b_pe12>;
	pinctrl-names = "default";
	status = "okay";
	mclk-enable;
	mclk-divider = "div-256";
	dma-names = "tx";
};
```