### PR TITLE
enable SMP support for GIC ITS interrupt controller

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -290,7 +290,7 @@ static struct its_cmd_block *its_allocate_entry(struct gicv3_its_data *data)
 			LOG_ERR("ITS queue not draining");
 			return NULL;
 		}
-		k_usleep(1);
+		k_busy_wait(1);
 	}
 
 	cmd = data->cmd_write++;
@@ -351,11 +351,7 @@ static int its_post_command(struct gicv3_its_data *data, struct its_cmd_block *c
 				rd_idx, idx, wr_idx);
 			return -ETIMEDOUT;
 		}
-		if (k_is_pre_kernel()) {
-			k_busy_wait(1);
-		} else {
-			k_usleep(1);
-		}
+		k_busy_wait(1);
 	}
 
 	return 0;


### PR DESCRIPTION
1. add lock to protect posting its command.
2. use busy wait in during posting its command as schedule is not ready for secondary core.