### PR TITLE
Fix `CONFIG_BT_DID` compilation error and add test

### DIFF
--- a/subsys/bluetooth/host/classic/did.c
+++ b/subsys/bluetooth/host/classic/did.c
@@ -11,6 +11,9 @@
 
 #include "did_internal.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_did);
+
 #define DID_VER_1_3 (0x0103u)
 
 #define BLUETOOTH_DEVICE_IDENTIFY_SPEC_VERSION 0x0103

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -84,6 +84,19 @@ tests:
     platform_exclude: nrf52dk/nrf52810
     tags: bluetooth
     harness: keyboard
+  bluetooth.shell.shell_br.did:
+    extra_configs:
+      - CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+      - CONFIG_BT_DID=y
+    extra_args: CONF_FILE="prj_br.conf"
+    platform_allow:
+      - qemu_cortex_m3
+      - qemu_x86
+      - native_sim
+      - native_sim/native/64
+    platform_exclude: nrf52dk/nrf52810
+    tags: bluetooth
+    harness: keyboard
   bluetooth.shell.no_privacy:
     build_only: true
     extra_args: CONFIG_BT_PRIVACY=n


### PR DESCRIPTION
`subsys/bluetooth/host/classic/did.c` fails to compile since #101810 (cc @lylezhu2012), which added a `LOG_ERR()` invocation but didn't setup logging for the file. Fix that and add a test that builds Zephyr with `CONFIG_BT_DID=y`.