### PR TITLE
kvss: nvs: pack data writes during GC to reduce flash waste

### DIFF
--- a/subsys/kvss/nvs/nvs.c
+++ b/subsys/kvss/nvs/nvs.c
@@ -17,6 +17,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
+#ifdef CONFIG_ZTEST
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 static int nvs_prev_ate(struct nvs_fs *fs, uint32_t *addr, struct nvs_ate *ate);
 static int nvs_ate_valid(struct nvs_fs *fs, uint16_t entry_addr,
 			 const struct nvs_ate *entry);
@@ -106,7 +112,7 @@ static inline size_t nvs_al_size(struct nvs_fs *fs, size_t len)
  * may include a header, primary data, and a tail. All buffers are
  * written as a single contiguous stream.
  */
-static int nvs_flash_al_wrt_streams(struct nvs_fs *fs, uint32_t addr,
+STATIC int nvs_flash_al_wrt_streams(struct nvs_fs *fs, uint32_t addr,
 				    const struct nvs_flash_wrt_stream *strm)
 {
 	const struct flash_parameters *fp = fs->flash_parameters;

--- a/subsys/kvss/nvs/nvs_priv.h
+++ b/subsys/kvss/nvs/nvs_priv.h
@@ -41,6 +41,31 @@ extern "C" {
 #define NVS_DATA_CRC_SIZE 0
 #endif
 
+/**
+ * @brief Simple flash buffer descriptor
+ *
+ * Describes a single contiguous memory region to be written to flash.
+ */
+struct nvs_flash_buf {
+	const uint8_t *ptr; /**< Pointer to buffer */
+	size_t len;         /**< Length of buffer */
+};
+
+/**
+ * @brief Description of a contiguous flash write
+ *
+ * Describes a flash write consisting of up to two buffers:
+ *  - primary data
+ *  - optional tail
+ *
+ * Buffers are written sequentially as a single logical stream,
+ * respecting flash write-block alignment.
+ */
+struct nvs_flash_wrt_stream {
+	struct nvs_flash_buf data; /**< Primary data buffer */
+	struct nvs_flash_buf tail; /**< Optional tail buffer */
+};
+
 /* Allocation Table Entry */
 struct nvs_ate {
 	uint16_t id;	/* data id */

--- a/subsys/kvss/nvs/nvs_priv.h
+++ b/subsys/kvss/nvs/nvs_priv.h
@@ -66,6 +66,18 @@ struct nvs_flash_wrt_stream {
 	struct nvs_flash_buf tail; /**< Optional tail buffer */
 };
 
+/**
+ * @brief NVS GC Write entry context
+ *
+ * Holds data being written during garbage collection.
+ */
+struct nvs_gc_write_entry {
+	uint16_t id;       /**< Entry ID */
+	const void *data;  /**< Pointer to data */
+	uint16_t len;      /**< Data length in bytes */
+	bool is_written;   /**< GC written flags for upper layers */
+};
+
 /* Allocation Table Entry */
 struct nvs_ate {
 	uint16_t id;	/* data id */

--- a/subsys/kvss/nvs/nvs_priv.h
+++ b/subsys/kvss/nvs/nvs_priv.h
@@ -1,6 +1,7 @@
 /*  NVS: non volatile storage in flash
  *
  * Copyright (c) 2018 Laczen
+ * Copyright (c) 2026 Lingao Meng
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +42,19 @@ extern "C" {
 #define NVS_DATA_CRC_SIZE 0
 #endif
 
+/* Context structure for NVS flash block move operations. */
+struct nvs_block_move_ctx {
+	/* Temporary buffer of size NVS_BLOCK_SIZE used to read
+	 * and write flash data in write_block_size-aligned chunks.
+	 */
+	uint8_t buffer[NVS_BLOCK_SIZE];
+
+	/* Number of bytes currently stored in the buffer that
+	 * have not yet been written. Always < write_block_size.
+	 */
+	size_t buffer_pos;
+};
+
 /**
  * @brief Simple flash buffer descriptor
  *
@@ -54,7 +68,8 @@ struct nvs_flash_buf {
 /**
  * @brief Description of a contiguous flash write
  *
- * Describes a flash write consisting of up to two buffers:
+ * Describes a flash write consisting of up to three buffers:
+ *  - optional head
  *  - primary data
  *  - optional tail
  *
@@ -62,6 +77,7 @@ struct nvs_flash_buf {
  * respecting flash write-block alignment.
  */
 struct nvs_flash_wrt_stream {
+	struct nvs_flash_buf head; /**< Optional head buffer */
 	struct nvs_flash_buf data; /**< Primary data buffer */
 	struct nvs_flash_buf tail; /**< Optional tail buffer */
 };

--- a/subsys/kvss/nvs/nvs_priv.h
+++ b/subsys/kvss/nvs/nvs_priv.h
@@ -107,6 +107,11 @@ BUILD_ASSERT(offsetof(struct nvs_ate, crc8) ==
 		 sizeof(struct nvs_ate) - sizeof(uint8_t),
 		 "crc8 must be the last member");
 
+#if defined(CONFIG_ZTEST)
+int nvs_flash_al_wrt_streams(struct nvs_fs *fs, uint32_t addr,
+			     const struct nvs_flash_wrt_stream *strm);
+#endif /* CONFIG_ZTEST */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/subsys/kvss/nvs/boards/native_sim_gc_pack.overlay
+++ b/tests/subsys/kvss/nvs/boards/native_sim_gc_pack.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Lingao Meng
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	erase-block-size = <0x400>;
+	write-block-size = <4>;
+};

--- a/tests/subsys/kvss/nvs/testcase.yaml
+++ b/tests/subsys/kvss/nvs/testcase.yaml
@@ -31,3 +31,6 @@ tests:
   keyvalstorage.nvs.64kb_erase_block:
     extra_args: DTC_OVERLAY_FILE=boards/native_sim_64kb_erase_block.overlay
     platform_allow: native_sim
+  filesystem.nvs.gc_pack:
+    extra_args: DTC_OVERLAY_FILE=boards/native_sim_gc_pack.overlay
+    platform_allow: native_sim


### PR DESCRIPTION
During NVS garbage collection, data records are rewritten to a new location to reclaim space. The current implementation aligns each record individually to the flash write block size, which can introduce unnecessary padding between consecutive records and lead to avoidable flash space waste.

This change optimizes the GC data move path by allowing consecutive data records to be packed back-to-back. Data is written only in write_block_size-aligned chunks, while any remaining unaligned tail bytes are temporarily buffered and combined with the next record.

CRCs are not recomputed, as the data content itself remains unchanged.

This behavior is strictly limited to the GC path and does not affect normal nvs_write() semantics, which still require immediate alignment.

Benefits:
- Reduces padding between GC-moved records
- Improves flash space utilization
- Preserves existing NVS on-flash format and compatibility

This PR contains four commits that together improve NVS flash write and GC behavior:

1. fs: nvs: introduce stream-based aligned flash write helper

- Refactors the flash write path to a stream/vector-style interface and adjusts CRC handling.

2. fs: nvs: allow pending write to be committed during GC

- Adds support for GC to attempt writing a pending entry using the new write interface.

3. fs: nvs: pack data during GC and flush tail via buffered block move

- Implements data packing during GC and handles unaligned tail bytes with a buffered block move.

4. tests: nvs: verify update behavior after GC data packing

- Adds a test to confirm that entries updated during GC are written correctly and data integrity is preserved.