### PR TITLE
NXP wdog allow multiple instance

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -293,6 +293,29 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	}
 #endif
 
+#if defined(CONFIG_WDT_MCUX_WWDT)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0)) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt))
+	if ((uint32_t)sub_system == MCUX_WWDT0_CLK) {
+#if defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_EnableClock(kCLOCK_GateWWDT0);
+#elif defined(CONFIG_SOC_SERIES_MCXW2XX) || defined(CONFIG_SOC_FAMILY_LPC)
+		CLOCK_EnableClock(kCLOCK_Wwdt);
+#else
+		CLOCK_EnableClock(kCLOCK_Wwdt0);
+#endif
+	}
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt1))
+	if ((uint32_t)sub_system == MCUX_WWDT1_CLK) {
+#if defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_EnableClock(kCLOCK_GateWWDT1);
+#else
+		CLOCK_EnableClock(kCLOCK_Wwdt1);
+#endif
+	}
+#endif
+#endif /* defined(CONFIG_WDT_MCUX_WWDT) */
+
 	return 0;
 }
 
@@ -744,6 +767,38 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetMicfilClkFreq();
 		break;
 #endif
+
+#if defined(CONFIG_WDT_MCUX_WWDT)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0)) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt))
+	case MCUX_WWDT0_CLK:
+#if defined(CONFIG_SOC_MIMXRT685S_CM33) || defined(CONFIG_SOC_MIMXRT595S_CM33) ||                  \
+	defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_MIMXRT798S_CM33_CPU0) ||             \
+	defined(CONFIG_SOC_MIMXRT798S_CM33_CPU1)
+		*rate = CLOCK_GetWdtClkFreq(0);
+#elif defined(CONFIG_SOC_MCXA577)
+		*rate = CLOCK_GetWwdt0ClkFreq();
+#elif defined(CONFIG_SOC_FAMILY_MCXA)
+		*rate = CLOCK_GetWwdtClkFreq();
+#else
+		*rate = CLOCK_GetWdtClkFreq();
+#endif
+		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt1))
+	case MCUX_WWDT1_CLK:
+#if defined(CONFIG_SOC_MIMXRT685S_CM33) || defined(CONFIG_SOC_MIMXRT595S_CM33) ||                  \
+	defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_MIMXRT798S_CM33_CPU0) ||             \
+	defined(CONFIG_SOC_MIMXRT798S_CM33_CPU1)
+		*rate = CLOCK_GetWdtClkFreq(1);
+#elif defined(CONFIG_SOC_MCXA577)
+		*rate = CLOCK_GetWwdt1ClkFreq();
+#else
+		*rate = 0;
+		return -EINVAL;
+#endif
+		break;
+#endif
+#endif
 	}
 
 	return 0;
@@ -827,6 +882,8 @@ static int mcux_lpc_syscon_clock_control_configure(const struct device *dev,
 	case MCUX_FLEXCOMM3_LP_CLK:
 		flexcomm_num = 3;
 		break;
+	case MCUX_WWDT0_CLK:
+		return 0;
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, NXP
+ * Copyright (C) 2020, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -178,30 +178,33 @@ static DEVICE_API(wdt, mcux_wdog_api) = {
 	.feed = mcux_wdog_feed,
 };
 
-static void mcux_wdog_config_func(const struct device *dev);
+#define MCUX_WDOG_INIT(id)								\
+	static void mcux_wdog_config_func_##id(const struct device *dev);		\
+											\
+	PINCTRL_DT_INST_DEFINE(id);							\
+											\
+	static const struct mcux_wdog_config mcux_wdog_config_##id = {			\
+		DEVICE_MMIO_NAMED_ROM_INIT(reg, DT_DRV_INST(id)),			\
+		.irq_config_func = mcux_wdog_config_func_##id,				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),				\
+	};										\
+											\
+	static struct mcux_wdog_data mcux_wdog_data_##id;				\
+											\
+	DEVICE_DT_INST_DEFINE(id,							\
+			      &mcux_wdog_init,						\
+			      NULL,							\
+			      &mcux_wdog_data_##id, &mcux_wdog_config_##id,		\
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			      &mcux_wdog_api);						\
+											\
+	static void mcux_wdog_config_func_##id(const struct device *dev)		\
+	{										\
+		IRQ_CONNECT(DT_INST_IRQN(id),						\
+			    DT_INST_IRQ(id, priority),					\
+			    mcux_wdog_isr, DEVICE_DT_INST_GET(id), 0);			\
+											\
+		irq_enable(DT_INST_IRQN(id));						\
+	}
 
-PINCTRL_DT_INST_DEFINE(0);
-
-static const struct mcux_wdog_config mcux_wdog_config = {
-	DEVICE_MMIO_NAMED_ROM_INIT(reg, DT_DRV_INST(0)),
-	.irq_config_func = mcux_wdog_config_func,
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-};
-
-static struct mcux_wdog_data mcux_wdog_data;
-
-DEVICE_DT_INST_DEFINE(0,
-		    &mcux_wdog_init,
-		    NULL,
-		    &mcux_wdog_data, &mcux_wdog_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &mcux_wdog_api);
-
-static void mcux_wdog_config_func(const struct device *dev)
-{
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    mcux_wdog_isr, DEVICE_DT_INST_GET(0), 0);
-
-	irq_enable(DT_INST_IRQN(0));
-}
+DT_INST_FOREACH_STATUS_OKAY(MCUX_WDOG_INIT)

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -3,7 +3,7 @@
  *
  * Based on wdt_mcux_wdog32.c, which is:
  * Copyright (c) 2019 Vestas Wind Systems A/S
- * Copyright 2018, 2025 NXP
+ * Copyright 2018, 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,8 @@
 #define DT_DRV_COMPAT nxp_lpc_wwdt
 
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/pm/device.h>
@@ -27,6 +29,8 @@ LOG_MODULE_REGISTER(wdt_mcux_wwdt);
 struct mcux_wwdt_config {
 	WWDT_Type *base;
 	uint8_t clk_divider;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 };
 
@@ -36,6 +40,52 @@ struct mcux_wwdt_data {
 	bool timeout_valid;
 	bool active_before_sleep;
 };
+
+static inline int mcux_wwdt_get_clock_frequency(const struct device *dev, uint32_t *freq)
+{
+	const struct mcux_wwdt_config *config = dev->config;
+	int ret;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	switch ((uint32_t)config->clock_subsys) {
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0)) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt))
+	case MCUX_WWDT0_CLK:
+#if defined(CONFIG_SOC_SERIES_MCXW2XX) || defined(CONFIG_SOC_SERIES_LPC55XXX) ||                   \
+	defined(CONFIG_SOC_SERIES_LPC54XXX) || defined(CONFIG_SOC_SERIES_LPC51U68) ||              \
+	defined(CONFIG_SOC_SERIES_LPC11U6X)
+		CLOCK_SetClkDiv(kCLOCK_DivWdtClk, config->clk_divider, true);
+#elif defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_SetClockDiv(kCLOCK_DivWWDT0, config->clk_divider);
+#elif defined(CONFIG_SOC_FAMILY_MCXN)
+		CLOCK_SetClkDiv(kCLOCK_DivWdt0Clk, config->clk_divider);
+#endif
+		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt1))
+	case MCUX_WWDT1_CLK:
+#if defined(CONFIG_SOC_FAMILY_MCXA)
+		CLOCK_SetClockDiv(kCLOCK_DivWWDT1, config->clk_divider);
+#elif defined(CONFIG_SOC_FAMILY_MCXN)
+		CLOCK_SetClkDiv(kCLOCK_DivWdt1Clk, config->clk_divider);
+#endif
+		break;
+#endif
+	default:
+		break;
+	}
+
+	ret = clock_control_get_rate(config->clock_dev, config->clock_subsys, freq);
+	if (ret) {
+		LOG_ERR("Failed to get clock frequency: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
 
 static int mcux_wwdt_setup(const struct device *dev, uint8_t options)
 {
@@ -80,34 +130,17 @@ static int mcux_wwdt_install_timeout(const struct device *dev,
 {
 	struct mcux_wwdt_data *data = dev->data;
 	uint32_t clock_freq;
+	int ret;
 
 	if (data->timeout_valid) {
 		LOG_ERR("No more timeouts can be installed");
 		return -ENOMEM;
 	}
 
-#if defined(CONFIG_SOC_MIMXRT685S_CM33) || defined(CONFIG_SOC_MIMXRT595S_CM33) \
-	|| defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_MIMXRT798S_CM33_CPU0) \
-	|| defined(CONFIG_SOC_MIMXRT798S_CM33_CPU1)
-	clock_freq = CLOCK_GetWdtClkFreq(0);
-#elif defined(CONFIG_SOC_SERIES_RW6XX)
-	clock_freq = CLOCK_GetWdtClkFreq();
-#elif defined(CONFIG_SOC_MCXA577)
-	const struct mcux_wwdt_config *config = dev->config;
-
-	if (config->base == WWDT0) {
-		clock_freq = CLOCK_GetWwdt0ClkFreq();
-	} else {
-		clock_freq = CLOCK_GetWwdt1ClkFreq();
+	ret = mcux_wwdt_get_clock_frequency(dev, &clock_freq);
+	if (ret) {
+		return ret;
 	}
-#elif defined(CONFIG_SOC_FAMILY_MCXA)
-	clock_freq = CLOCK_GetWwdtClkFreq();
-#else
-	const struct mcux_wwdt_config *config = dev->config;
-
-	CLOCK_SetClkDiv(kCLOCK_DivWdtClk, config->clk_divider, true);
-	clock_freq = CLOCK_GetWdtClkFreq();
-#endif
 
 	WWDT_GetDefaultConfig(&data->wwdt_config);
 
@@ -118,7 +151,8 @@ static int mcux_wwdt_install_timeout(const struct device *dev,
 
 	if (data->wwdt_config.timeoutValue > MAX_TIMEOUT ||
 	    data->wwdt_config.timeoutValue < MIN_TIMEOUT) {
-		LOG_ERR("Timeout value out of range");
+		LOG_ERR("Timeout value %d out of range %d - %d", data->wwdt_config.timeoutValue,
+			MIN_TIMEOUT, MAX_TIMEOUT);
 		return -EINVAL;
 	}
 
@@ -231,6 +265,22 @@ static int mcux_wwdt_driver_pm_action(const struct device *dev,
 static int mcux_wwdt_init(const struct device *dev)
 {
 	const struct mcux_wwdt_config *config = dev->config;
+	int ret;
+
+	ret = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	if (ret && ret != -ENOSYS) {
+		/* Real error occurred */
+		LOG_ERR("Failed to configure clock: %d", ret);
+		return ret;
+	}
+
+#if FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL
+	ret = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (ret) {
+		LOG_ERR("Failed to enable clock: %d", ret);
+		return ret;
+	}
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 	/* The rest of the device init is done from the
 	 * PM_DEVICE_ACTION_TURN_ON in the pm callback
@@ -247,30 +297,30 @@ static DEVICE_API(wdt, mcux_wwdt_api) = {
 	.feed = mcux_wwdt_feed,
 };
 
-static void mcux_wwdt_config_func_0(const struct device *dev);
+#define MCUX_WWDT_INIT_CONFIG(id)                                                                  \
+	static void mcux_wwdt_config_func_##id(const struct device *dev);                          \
+                                                                                                   \
+	static const struct mcux_wwdt_config mcux_wwdt_config_##id = {                             \
+		.base = (WWDT_Type *)DT_INST_REG_ADDR(id),                                         \
+		.clk_divider = DT_INST_PROP(id, clk_divider),                                      \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),                               \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),             \
+		.irq_config_func = mcux_wwdt_config_func_##id,                                     \
+	};                                                                                         \
+                                                                                                   \
+	static struct mcux_wwdt_data mcux_wwdt_data_##id;                                          \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(id, mcux_wwdt_driver_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(id, &mcux_wwdt_init, PM_DEVICE_DT_INST_GET(id),                      \
+			      &mcux_wwdt_data_##id, &mcux_wwdt_config_##id, POST_KERNEL,           \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcux_wwdt_api);                 \
+                                                                                                   \
+	static void mcux_wwdt_config_func_##id(const struct device *dev)                           \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(id), DT_INST_IRQ(id, priority), mcux_wwdt_isr,            \
+			    DEVICE_DT_INST_GET(id), 0);                                            \
+		irq_enable(DT_INST_IRQN(id));                                                      \
+	}
 
-static const struct mcux_wwdt_config mcux_wwdt_config_0 = {
-	.base = (WWDT_Type *) DT_INST_REG_ADDR(0),
-	.clk_divider =
-		DT_INST_PROP(0, clk_divider),
-	.irq_config_func = mcux_wwdt_config_func_0,
-};
-
-static struct mcux_wwdt_data mcux_wwdt_data_0;
-
-PM_DEVICE_DT_INST_DEFINE(0, mcux_wwdt_driver_pm_action);
-
-DEVICE_DT_INST_DEFINE(0, &mcux_wwdt_init,
-		    PM_DEVICE_DT_INST_GET(0), &mcux_wwdt_data_0,
-		    &mcux_wwdt_config_0, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		    &mcux_wwdt_api);
-
-static void mcux_wwdt_config_func_0(const struct device *dev)
-{
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
-		    mcux_wwdt_isr, DEVICE_DT_INST_GET(0), 0);
-
-	irq_enable(DT_INST_IRQN(0));
-}
+DT_INST_FOREACH_STATUS_OKAY(MCUX_WWDT_INIT_CONFIG)

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 NXP
+ * Copyright 2022-2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -539,6 +539,7 @@
 	wwdt0: watchdog@e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xe000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT0_CLK>;
 		interrupts = <0 0>;
 		status = "disabled";
 		clk-divider = <1>;
@@ -547,6 +548,7 @@
 	wwdt1: watchdog@2e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0x2e000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT1_CLK>;
 		interrupts = <52 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -476,6 +476,7 @@
 	wwdt0: watchdog@e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xe000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT0_CLK>;
 		interrupts = <0 0>;
 		status = "disabled";
 		clk-divider = <1>;
@@ -484,6 +485,7 @@
 	wwdt1: watchdog@2e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0x2e000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT1_CLK>;
 		interrupts = <52 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1016,6 +1016,7 @@
 	wwdt0: watchdog@e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xe000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT0_CLK>;
 		interrupts = <42 0>;
 		status = "disabled";
 		clk-divider = <1>;
@@ -1024,6 +1025,7 @@
 	wwdt1: watchdog@2e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0x2e000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT1_CLK>;
 		interrupts = <43 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/lpc/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S2x_common.dtsi
@@ -326,6 +326,7 @@
 	wwdt0: watchdog@c000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <0 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -375,6 +375,7 @@
 	wwdt0: watchdog@c000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <0 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -433,6 +433,7 @@
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;
+			clocks = <&syscon MCUX_WWDT0_CLK>;
 			interrupts = <60 0>;
 			status = "disabled";
 			clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -569,6 +569,7 @@
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;
+			clocks = <&syscon MCUX_WWDT0_CLK>;
 			interrupts = <60 0>;
 			status = "disabled";
 			clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -500,6 +500,7 @@
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;
+			clocks = <&syscon MCUX_WWDT0_CLK>;
 			interrupts = <60 0>;
 			status = "disabled";
 			clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -336,6 +336,7 @@
 	wwdt0: watchdog@c000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <60 0>;
 		status = "disabled";
 		clk-divider = <1>;
@@ -344,6 +345,7 @@
 	wwdt1: watchdog@d000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xd000 0x1000>;
+		clocks = <&syscon MCUX_WWDT1_CLK>;
 		interrupts = <61 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -510,6 +510,7 @@
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;
+			clocks = <&syscon MCUX_WWDT0_CLK>;
 			interrupts = <60 0>;
 			status = "disabled";
 			clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -668,6 +668,7 @@
 	wwdt0: watchdog@16000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0x16000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <152 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -866,6 +866,7 @@
 	wwdt0: watchdog@16000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0x16000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <152 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
@@ -364,6 +364,7 @@
 	wwdt0: watchdog@c000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xc000 0x1000>;
+		clocks = <&syscon MCUX_WWDT0_CLK>;
 		interrupts = <0 1>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 NXP
+ * Copyright 2022-2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -211,6 +211,7 @@
 	wwdt: watchdog@e000 {
 		compatible = "nxp,lpc-wwdt";
 		reg = <0xe000 0x1000>;
+		clocks = <&clkctl0 MCUX_WWDT0_CLK>;
 		interrupts = <0 0>;
 		status = "disabled";
 		power-domains = <&peripheral_domain>;

--- a/dts/bindings/watchdog/nxp,lpc-wwdt.yaml
+++ b/dts/bindings/watchdog/nxp,lpc-wwdt.yaml
@@ -14,6 +14,9 @@ properties:
   interrupts:
     required: true
 
+  clocks:
+    required: true
+
   clk-divider:
     type: int
     description: Watchdog clock divider

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -162,4 +162,9 @@
 /** TSI (Touch Sensing Input) clock identifier */
 #define MCUX_TSI_CLK MCUX_LPC_CLK_ID(0x25, 0x0)
 
+/** WWDT0 peripheral clock identifier. */
+#define MCUX_WWDT0_CLK MCUX_LPC_CLK_ID(0x26, 0x00)
+/** WWDT1 peripheral clock identifier. */
+#define MCUX_WWDT1_CLK MCUX_LPC_CLK_ID(0x26, 0x01)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
Support multiple devices for nxp watchdog drivers: wdog32, wwdt and imx_wdog.
For wwdt, support clock control api.