### PR TITLE
dts: bindings: can: nxp: flexcan: fix clock configuration in examples

### DIFF
--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -26,7 +26,8 @@ examples:
       interrupts = <154 0>;
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
-      clk-source = <2>;
+      clock-names = "clksrc1";
+      clk-source = <1>;
       number-of-mb = <64>;
       number-of-mb-fd = <14>;
       pinctrl-0 = <&pinmux_flexcan3>;

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -52,6 +52,7 @@ examples:
       interrupts = <78 0>, <79 0>, <80 0>, <81 0>;
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
+      clock-names = "clksrc1";
       clk-source = <1>;
       number-of-mb = <16>;
       pinctrl-0 = <&pinmux_flexcan0>;


### PR DESCRIPTION
Fix the clock configuration shown in the NXP FlexCAN devicetree binding examples.