### PR TITLE
[drivers: spi: stm32] [Simplex mode support for SPI transfers over DMA]

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1420,11 +1420,17 @@ static int transceive_dma(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	// We need this for creating clocks on spi line internally to support supposedly simplex mode at higher layers.
-	if((tx_bufs == NULL) && (rx_bufs != NULL)) {
-		tx_bufs = rx_bufs;
-	} else if((tx_bufs != NULL) && (rx_bufs == NULL)) {
-		rx_bufs = tx_bufs;
+	/**
+	 * We need this for creating clocks on spi line 
+	 * internally to support supposedly simplex mode 
+	 * at higher layers.
+	 * */
+	if(LL_SPI_GetTransferDirection(spi) == SPI_FULL_DUPLEX) {
+		if((tx_bufs == NULL) && (rx_bufs != NULL)) {
+			tx_bufs = rx_bufs;
+		} else if((tx_bufs != NULL) && (rx_bufs == NULL)) {
+			rx_bufs = tx_bufs;
+		}
 	}
 
 #ifdef CONFIG_DCACHE

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1420,6 +1420,13 @@ static int transceive_dma(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	// We need this for creating clocks on spi line internally to support supposedly simplex mode at higher layers.
+	if((tx_bufs == NULL) && (rx_bufs != NULL)) {
+		tx_bufs = rx_bufs;
+	} else if((tx_bufs != NULL) && (rx_bufs == NULL)) {
+		rx_bufs = tx_bufs;
+	}
+
 #ifdef CONFIG_DCACHE
 	if ((tx_bufs != NULL && !spi_buf_set_in_nocache(tx_bufs)) ||
 	    (rx_bufs != NULL && !spi_buf_set_in_nocache(rx_bufs))) {


### PR DESCRIPTION
The existing implementation of transciev_dma function in spi_stm32.c file did not support simplex mode of transfers when high level application used spi_write or spi_read interfaces. The SPI TX would not fail as the TX usually is the source to creates clocks. However, for SPI RX if there is no TX buffer or dummy data to generate clock on the bus, the SPI RX will fail to receive the data. In order to cater the simplex mode, a simple change has been introduced whereby if either tx_bufs or rx_bufs is null, the other buffers address is assigned to the buffer pointer which has null assigned to it. This makes sure that at lower level, in full duplex mode a simplex transfer (be it tx or rx) succeeds without an explicit always need the use of spi_transceive interface.