### PR TITLE
[api: spi] [SPI API Interface extension to support CPU only transfers]

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1499,7 +1499,6 @@ static int transceive_dma(const struct device *dev,
 
 		if (transfer_dir == LL_SPI_FULL_DUPLEX) {
 			dma_len = spi_context_max_continuous_chunk(&data->ctx);
-
 			ret = spi_dma_move_buffers(dev, dma_len);
 		} else if (transfer_dir == LL_SPI_HALF_DUPLEX_TX) {
 			dma_len = data->ctx.tx_len;
@@ -1653,6 +1652,14 @@ static int spi_stm32_transceive(const struct device *dev,
 	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
+static int spi_stm32_transceive_cpu(const struct device *dev,
+				const struct spi_config *config,
+				const struct spi_buf_set *tx_bufs,
+				const struct spi_buf_set *rx_bufs)
+{
+	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
+}
+
 #ifdef CONFIG_SPI_ASYNC
 static int spi_stm32_transceive_async(const struct device *dev,
 				      const struct spi_config *config,
@@ -1667,6 +1674,7 @@ static int spi_stm32_transceive_async(const struct device *dev,
 
 static DEVICE_API(spi, api_funcs) = {
 	.transceive = spi_stm32_transceive,
+	.transceive_cpu = spi_stm32_transceive_cpu,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_stm32_transceive_async,
 #endif


### PR DESCRIPTION
Currently, the spi.h does not expose any explicit interfaces for the transfer and receive employing only through CPU. This is needed in the use cases where sending only a few bytes using the dma is overkill before starting a major chunk of transfer via dma. For example, external flash memories often require upfront function code or command transfers which do not need dma and for those cpu only transfers are more efficient.