### PR TITLE
doc: domain: Disable warnings when board catalog not present

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -1155,7 +1155,7 @@ class ZephyrDomain(Domain):
         "code-sample": XRefRole(innernodeclass=nodes.inline, warn_dangling=True),
         "code-sample-category": XRefRole(innernodeclass=nodes.inline, warn_dangling=True),
         "board": XRefRole(innernodeclass=nodes.inline, warn_dangling=True),
-        "board-catalog": XRefRole(innernodeclass=nodes.inline, warn_dangling=True),
+        "board-catalog": XRefRole(innernodeclass=nodes.inline, warn_dangling=False),
     }
 
     directives = {


### PR DESCRIPTION
With the introduction of the board-catalog role in cd6b1f5c61a0beb98331614a77262fecbf9bff5e, using the Zephyr doc infrastructure without a board catalog instantiated leads to a warning. Avoid this by disabling the warnings for this role.