### PR TITLE
BeagleY-AI: mcu_r5: Enable watchdog timer

### DIFF
--- a/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
@@ -23,6 +23,10 @@
 		zephyr,ipc_shm = &ddr0;
 	};
 
+	aliases {
+		watchdog0 = &mcu_rti0;
+	};
+
 	cpus {
 		cpu@0 {
 			status = "okay";
@@ -61,5 +65,9 @@
 };
 
 &systick_timer {
+	status = "okay";
+};
+
+&mcu_rti0 {
 	status = "okay";
 };

--- a/dts/arm/ti/j722s_mcu.dtsi
+++ b/dts/arm/ti/j722s_mcu.dtsi
@@ -31,4 +31,11 @@
 		reg-shift = <2>;
 		status = "disabled";
 	};
+
+	mcu_rti0: watchdog@4880000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x04880000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
- Using mcu_rti0 as watchdog timer.
- Tested with samples/drivers/watchdog.