### PR TITLE
drivers: usb: uhc: dwc2: Added port state handling [part4]

### DIFF
--- a/drivers/usb/uhc/CMakeLists.txt
+++ b/drivers/usb/uhc/CMakeLists.txt
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/usb/common/)
 
 zephyr_library_sources(uhc_common.c)
+zephyr_library_sources_ifdef(CONFIG_UHC_DWC2 uhc_dwc2.c)
 zephyr_library_sources_ifdef(CONFIG_UHC_MAX3421E uhc_max3421e.c)
 zephyr_library_sources_ifdef(CONFIG_UHC_VIRTUAL uhc_virtual.c)
 zephyr_library_sources_ifdef(CONFIG_UHC_NXP_EHCI uhc_mcux_common.c uhc_mcux_ehci.c)

--- a/drivers/usb/uhc/Kconfig
+++ b/drivers/usb/uhc/Kconfig
@@ -43,6 +43,7 @@ module = UHC_DRIVER
 module-str = uhc drv
 source "subsys/logging/Kconfig.template.log_config"
 
+source "drivers/usb/uhc/Kconfig.dwc2"
 source "drivers/usb/uhc/Kconfig.max3421e"
 source "drivers/usb/uhc/Kconfig.virtual"
 source "drivers/usb/uhc/Kconfig.mcux"

--- a/drivers/usb/uhc/Kconfig.dwc2
+++ b/drivers/usb/uhc/Kconfig.dwc2
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Roman Leonov <jam_roma@yahoo.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config UHC_DWC2
+	bool "DWC2 USB host controller driver"
+	depends on DT_HAS_SNPS_DWC2_ENABLED
+	default y
+	select EVENTS
+	help
+	  DWC2 USB host controller driver.
+
+if UHC_DWC2
+
+config UHC_DWC2_STACK_SIZE
+	int "UHC DWC2 driver thread stack size"
+	default 512
+	help
+	  DWC2 driver thread stack size.
+
+config UHC_DWC2_THREAD_PRIORITY
+	int "UHC DWC2 driver thread priority"
+	default 8
+	help
+	  DWC2 driver thread priority.
+
+endif # UHC_DWC2

--- a/drivers/usb/uhc/Kconfig.dwc2
+++ b/drivers/usb/uhc/Kconfig.dwc2
@@ -23,4 +23,38 @@ config UHC_DWC2_THREAD_PRIORITY
 	help
 	  DWC2 driver thread priority.
 
+config UHC_DWC2_DEBOUNCE_DELAY_MS
+	int "Debounce delay in ms"
+	default 250
+	help
+	  On connection of a USB device, the USB 2.0 specification requires
+	  a "debounce interval with a minimum duration of 100ms" to allow the connection to stabilize
+	  (see USB 2.0 chapter 7.1.7.3 for more details).
+	  During the debounce interval, no new connection/disconnection events are registered.
+
+	  The default value is set to 250 ms to be safe.
+
+config UHC_DWC2_RESET_HOLD_MS
+	int "Reset hold in ms"
+	default 30
+	help
+	  The reset signaling can be generated on any Hub or Host Controller port by request from
+	  the USB System Software. The USB 2.0 specification requires that "the reset signaling must
+	  be driven for a minimum of 10ms" (see USB 2.0 chapter 7.1.7.5 for more details).
+	  After the reset, the hub port will transition to the Enabled state (refer to Section 11.5).
+
+	  The default value is set to 30 ms to be safe.
+
+config UHC_DWC2_RESET_RECOVERY_MS
+	int "Reset recovery delay in ms"
+	default 30
+	help
+	  After a port stops driving the reset signal, the USB 2.0 specification requires that
+	  the "USB System Software guarantees a minimum of 10 ms for reset recovery" before the
+	  attached device is expected to respond to data transfers (see USB 2.0 chapter 7.1.7.3 for
+	  more details).
+	  The device may ignore any data transfers during the recovery interval.
+
+	  The default value is set to 30 ms to be safe.
+
 endif # UHC_DWC2

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -18,32 +18,633 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uhc_dwc2, CONFIG_UHC_DRIVER_LOG_LEVEL);
 
-#define UHC_DWC2_CHAN_REG(base, chan_idx)					\
+#define DEBOUNCE_DELAY_MS	CONFIG_UHC_DWC2_DEBOUNCE_DELAY_MS
+#define RESET_HOLD_MS		CONFIG_UHC_DWC2_RESET_HOLD_MS
+#define RESET_RECOVERY_MS	CONFIG_UHC_DWC2_RESET_RECOVERY_MS
+
+enum uhc_dwc2_event {
+	/* No event has occurred or the event is no longer valid */
+	UHC_DWC2_EVENT_NONE,
+	/* A device has been connected to the port */
+	UHC_DWC2_EVENT_PORT_CONNECTION,
+	/* A device is connected to the port but has not been reset. */
+	UHC_DWC2_EVENT_PORT_DISABLED,
+	/* A device has completed reset and enabled on the port */
+	UHC_DWC2_EVENT_PORT_ENABLED,
+	/* A device disconnection has been detected */
+	UHC_DWC2_EVENT_PORT_DISCONNECTION,
+	/* Port error detected */
+	UHC_DWC2_EVENT_PORT_ERROR,
+	/* Overcurrent detected */
+	UHC_DWC2_EVENT_PORT_OVERCURRENT,
+	/* Port has pending channel event */
+	UHC_DWC2_EVENT_PORT_PEND_CHANNEL
+};
+
+enum uhc_dwc2_speed {
+	UHC_DWC2_SPEED_HIGH = 0,
+	UHC_DWC2_SPEED_FULL = 1,
+	UHC_DWC2_SPEED_LOW = 2,
+};
+
+#define UHC_DWC2_CHANNEL_REGS(base, chan_idx)					\
 	((struct usb_dwc2_host_chan *)(((mem_addr_t)(base)) + USB_DWC2_HCCHAR(chan_idx)))
+
+/* Mask to clear HPRT register */
+#define USB_DWC2_HPRT_W1C_MSK	(USB_DWC2_HPRT_PRTENA |				\
+				USB_DWC2_HPRT_PRTCONNDET |			\
+				USB_DWC2_HPRT_PRTENCHNG |			\
+				USB_DWC2_HPRT_PRTOVRCURRCHNG)
+
+/* Interrupts that pertain to core events */
+#define CORE_EVENTS_INTRS_MSK	(USB_DWC2_GINTSTS_DISCONNINT |			\
+				USB_DWC2_GINTSTS_HCHINT)
+
+/* Interrupt that pertain to host port events */
+#define PORT_EVENTS_INTRS_MSK	(USB_DWC2_HPRT_PRTCONNDET |			\
+				USB_DWC2_HPRT_PRTENCHNG |			\
+				USB_DWC2_HPRT_PRTOVRCURRCHNG)
 
 struct uhc_dwc2_data {
 	struct k_thread thread;
+	/* Event bitmask the driver thread waits for */
 	struct k_event event;
+	/* Bit mask of channels with pending interrupts */
+	uint32_t pending_channels_msk;
+	/* Root Port flags */
+	uint8_t debouncing: 1;
+	uint8_t has_device: 1;
 };
+
+static inline void dwc2_hal_toggle_reset(struct usb_dwc2_reg *const dwc2, const bool reset_on)
+{
+	uint32_t hprt;
+
+	hprt = sys_read32((mem_addr_t)&dwc2->hprt);
+	if (reset_on) {
+		hprt |= USB_DWC2_HPRT_PRTRST;
+	} else {
+		hprt &= ~USB_DWC2_HPRT_PRTRST;
+	}
+	sys_write32(hprt & (~USB_DWC2_HPRT_W1C_MSK), (mem_addr_t)&dwc2->hprt);
+}
+
+static inline void dwc2_hal_set_power(struct usb_dwc2_reg *const dwc2, const bool power_on)
+{
+	uint32_t hprt;
+
+	hprt = sys_read32((mem_addr_t)&dwc2->hprt);
+	if (power_on) {
+		hprt |= USB_DWC2_HPRT_PRTPWR;
+	} else {
+		hprt &= ~USB_DWC2_HPRT_PRTPWR;
+	}
+	sys_write32(hprt & (~USB_DWC2_HPRT_W1C_MSK), (mem_addr_t)&dwc2->hprt);
+}
+
+static inline enum uhc_dwc2_speed dwc2_hal_get_speed(struct usb_dwc2_reg *const dwc2)
+{
+	uint32_t hprt = sys_read32((mem_addr_t)&dwc2->hprt);
+	uint8_t speed = usb_dwc2_get_hprt_prtspd(hprt);
+
+	switch (speed) {
+	case USB_DWC2_HPRT_PRTSPD_HIGH:
+		return UHC_DWC2_SPEED_HIGH;
+	case USB_DWC2_HPRT_PRTSPD_FULL:
+		return UHC_DWC2_SPEED_FULL;
+	case USB_DWC2_HPRT_PRTSPD_LOW:
+		return UHC_DWC2_SPEED_LOW;
+	default:
+		LOG_ERR("Unexpected speed, assign Full-speed");
+		break;
+	}
+	return UHC_DWC2_SPEED_FULL;
+}
+
+static inline void dwc2_hal_enable_port(struct usb_dwc2_reg *const dwc2,
+					const enum uhc_dwc2_speed speed)
+{
+	uint32_t hcfg = sys_read32((mem_addr_t)&dwc2->hcfg);
+	uint32_t hfir = sys_read32((mem_addr_t)&dwc2->hfir);
+	uint32_t ghwcfg2 = sys_read32((mem_addr_t)&dwc2->ghwcfg2);
+	uint8_t fslspclksel;
+	uint16_t frint;
+
+	/* We can select Buffer DMA of Scatter-Gather DMA mode here: Buffer DMA for now */
+	hcfg &= ~USB_DWC2_HCFG_DESCDMA;
+
+	/* Disable periodic scheduling, will enable later */
+	hcfg &= ~USB_DWC2_HCFG_PERSCHEDENA;
+
+	if (usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2) == 0) {
+		/* Indicate to the OTG core what speed the PHY clock is at
+		 * Note: FSLS PHY has an implicit 8 divider applied when in LS mode,
+		 * so the values of FSLSPclkSel and FrInt have to be adjusted accordingly.
+		 */
+		fslspclksel = (speed == UHC_DWC2_SPEED_FULL) ? 1 : 2;
+		hcfg &= ~USB_DWC2_HCFG_FSLSPCLKSEL_MASK;
+		hcfg |= (fslspclksel << USB_DWC2_HCFG_FSLSPCLKSEL_POS);
+
+		/* Disable dynamic loading */
+		hfir &= ~USB_DWC2_HFIR_HFIRRLDCTRL;
+		/* Set frame interval to be equal to 1ms
+		 * Note: FSLS PHY has an implicit 8 divider applied when in LS mode,
+		 * so the values of FSLSPclkSel and FrInt have to be adjusted accordingly.
+		 */
+		frint = (speed == UHC_DWC2_SPEED_FULL) ? 48000 : 6000;
+		hfir &= ~USB_DWC2_HFIR_FRINT_MASK;
+		hfir |= (frint << USB_DWC2_HFIR_FRINT_POS);
+
+		sys_write32(hcfg, (mem_addr_t)&dwc2->hcfg);
+		sys_write32(hfir, (mem_addr_t)&dwc2->hfir);
+	} else {
+		LOG_ERR("Configuring clocks for HS PHY is not implemented");
+	}
+}
+
+static inline void dwc2_hal_init_gusbcfg(struct usb_dwc2_reg *const dwc2)
+{
+	uint32_t gusbcfg = sys_read32((mem_addr_t)&dwc2->gusbcfg);
+	uint32_t ghwcfg2 = sys_read32((mem_addr_t)&dwc2->ghwcfg2);
+	uint32_t ghwcfg4 = sys_read32((mem_addr_t)&dwc2->ghwcfg4);
+
+	/* Enable Host mode */
+	sys_set_bits((mem_addr_t)&dwc2->gusbcfg, USB_DWC2_GUSBCFG_FORCEHSTMODE);
+	/* Wait until core is in host mode */
+	while ((sys_read32((mem_addr_t)&dwc2->gintsts) & USB_DWC2_GINTSTS_CURMOD) != 1) {
+	}
+
+	if (usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2) != 0) {
+		/* De-select FS PHY */
+		gusbcfg &= ~USB_DWC2_GUSBCFG_PHYSEL_USB11;
+
+		if (usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2) == USB_DWC2_GHWCFG2_HSPHYTYPE_ULPI) {
+			LOG_DBG("Highspeed ULPI PHY init");
+			/* Select ULPI PHY (external) */
+			gusbcfg |= USB_DWC2_GUSBCFG_ULPI_UTMI_SEL_ULPI;
+			/* ULPI is always 8-bit interface */
+			gusbcfg &= ~USB_DWC2_GUSBCFG_PHYIF_16_BIT;
+			/* ULPI select single data rate */
+			gusbcfg &= ~USB_DWC2_GUSBCFG_DDR_DOUBLE;
+			/* Default internal VBUS Indicator and Drive */
+			gusbcfg &= ~(USB_DWC2_GUSBCFG_ULPIEVBUSD | USB_DWC2_GUSBCFG_ULPIEVBUSI);
+			/* Disable FS/LS ULPI and Suspend mode */
+			gusbcfg &= ~(USB_DWC2_GUSBCFG_ULPIFSLS | USB_DWC2_GUSBCFG_ULPICLK_SUSM);
+		} else {
+			LOG_DBG("Highspeed UTMI+ PHY init");
+			/* Select UTMI+ PHY (internal) */
+			gusbcfg &= ~USB_DWC2_GUSBCFG_ULPI_UTMI_SEL_ULPI;
+			/* Set 16-bit interface if supported */
+			if (usb_dwc2_get_ghwcfg4_phydatawidth(ghwcfg4)) {
+				gusbcfg |= USB_DWC2_GUSBCFG_PHYIF_16_BIT;
+			} else {
+				gusbcfg &= ~USB_DWC2_GUSBCFG_PHYIF_16_BIT;
+			}
+		}
+		sys_write32(gusbcfg, (mem_addr_t)&dwc2->gusbcfg);
+	} else {
+		LOG_DBG("Fullspeed PHY init");
+		sys_set_bits((mem_addr_t)&dwc2->gusbcfg, USB_DWC2_GUSBCFG_PHYSEL_USB11);
+	}
+}
+static inline int dwc2_hal_init_gahbcfg(struct usb_dwc2_reg *const dwc2)
+
+{
+	uint32_t ghwcfg2 = sys_read32((mem_addr_t)&dwc2->ghwcfg2);
+
+	/* Disable Global Interrupt */
+	sys_clear_bits((mem_addr_t)&dwc2->gahbcfg, USB_DWC2_GAHBCFG_GLBINTRMASK);
+
+	/* TODO: Set AHB burst mode for some ECO only for ESP32S2 */
+	/* Make config quirk? */
+
+	/* TODO: Disable HNP and SRP capabilities */
+	/* Also move to quirk? */
+
+	/* Configure AHB */
+	uint32_t gahbcfg = USB_DWC2_GAHBCFG_NPTXFEMPLVL |
+				usb_dwc2_set_gahbcfg_hbstlen(USB_DWC2_GAHBCFG_HBSTLEN_INCR16);
+	sys_write32(gahbcfg, (mem_addr_t)&dwc2->gahbcfg);
+
+	if (usb_dwc2_get_ghwcfg2_otgarch(ghwcfg2) == USB_DWC2_GHWCFG2_OTGARCH_INTERNALDMA) {
+		sys_set_bits((mem_addr_t)&dwc2->gahbcfg, USB_DWC2_GAHBCFG_DMAEN);
+	} else {
+		/* TODO: Implement Slave mode */
+		LOG_ERR("DMA isn't supported by the hardware");
+		return -ENXIO;
+	}
+
+	/* Enable Global Interrupt */
+	sys_set_bits((mem_addr_t)&dwc2->gahbcfg, USB_DWC2_GAHBCFG_GLBINTRMASK);
+	return 0;
+}
+
+static int dwc2_hal_core_reset(struct usb_dwc2_reg *const dwc2, const k_timeout_t timeout)
+{
+	const k_timepoint_t timepoint = sys_timepoint_calc(timeout);
+
+	/* Check AHB master idle state */
+	while ((sys_read32((mem_addr_t)&dwc2->grstctl) & USB_DWC2_GRSTCTL_AHBIDLE) == 0) {
+		if (sys_timepoint_expired(timepoint)) {
+			LOG_ERR("Wait for AHB idle timeout, GRSTCTL 0x%08x",
+				sys_read32((mem_addr_t)&dwc2->grstctl));
+			return -EIO;
+		}
+
+		k_busy_wait(1);
+	}
+
+	/* Apply Core Soft Reset */
+	sys_write32(USB_DWC2_GRSTCTL_CSFTRST, (mem_addr_t)&dwc2->grstctl);
+
+	/* Wait for reset to complete */
+	while ((sys_read32((mem_addr_t)&dwc2->grstctl) & USB_DWC2_GRSTCTL_CSFTRST) != 0 &&
+	       (sys_read32((mem_addr_t)&dwc2->grstctl) & USB_DWC2_GRSTCTL_CSFTRSTDONE) == 0) {
+		if (sys_timepoint_expired(timepoint)) {
+			LOG_ERR("Wait for CSR done timeout, GRSTCTL 0x%08x",
+				sys_read32((mem_addr_t)&dwc2->grstctl));
+			return -EIO;
+		}
+
+		k_busy_wait(1);
+	}
+
+	/* CSFTRSTDONE is W1C so the write must have the bit set to clear it */
+	sys_clear_bits((mem_addr_t)&dwc2->grstctl, USB_DWC2_GRSTCTL_CSFTRST);
+
+	LOG_DBG("DWC2 core reset done");
+
+	return 0;
+}
+
+static int dwc2_hal_init_host(struct usb_dwc2_reg *const dwc2)
+{
+	int ret;
+
+	/* Init GUSBCFG */
+	dwc2_hal_init_gusbcfg(dwc2);
+
+	/* Init GAHBCFG */
+	ret = dwc2_hal_init_gahbcfg(dwc2);
+
+	if (ret != 0) {
+		/* TODO: Implement Slave Mode */
+		LOG_WRN("DMA isn't supported, but Slave Mode isn't implemented yet");
+		return ret;
+	}
+
+	/* Clear interrupts */
+	sys_clear_bits((mem_addr_t)&dwc2->gintmsk, 0xFFFFFFFFUL);
+	sys_set_bits((mem_addr_t)&dwc2->gintmsk, USB_DWC2_GINTSTS_DISCONNINT);
+
+	/* Clear status */
+	uint32_t core_intrs = sys_read32((mem_addr_t)&dwc2->gintsts);
+
+	sys_write32(core_intrs, (mem_addr_t)&dwc2->gintsts);
+
+	return ret;
+}
+
+static void uhc_dwc2_port_debounce_lock(const struct device *dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+
+	/* Disable connection and disconnection interrupts to prevent spurious events */
+	sys_clear_bits((mem_addr_t)&dwc2->gintmsk, USB_DWC2_GINTSTS_PRTINT |
+						USB_DWC2_GINTSTS_DISCONNINT);
+	/* Set the debounce lock flag */
+	priv->debouncing = 1;
+}
+
+static void uhc_dwc2_port_debounce_unlock(const struct device *dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+
+	/* Clear the flag */
+	priv->debouncing = 0;
+	/* Clear Connection and disconnection interrupt in case it triggered again */
+	sys_set_bits((mem_addr_t)&dwc2->gintsts, USB_DWC2_GINTSTS_DISCONNINT);
+	/* Clear the PRTCONNDET interrupt by writing 1 to the corresponding bit (W1C logic) */
+	sys_set_bits((mem_addr_t)&dwc2->hprt, USB_DWC2_HPRT_PRTCONNDET);
+	/* Re-enable the HPRT (connection) and disconnection interrupts */
+	sys_set_bits((mem_addr_t)&dwc2->gintmsk, USB_DWC2_GINTSTS_PRTINT |
+						USB_DWC2_GINTSTS_DISCONNINT);
+}
+
+static enum uhc_dwc2_event uhc_dwc2_port_get_event(const struct device *dev)
+{
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+
+	/* Read and clear core interrupt status */
+	uint32_t core_intrs = sys_read32((mem_addr_t)&dwc2->gintsts);
+
+	sys_write32(core_intrs, (mem_addr_t)&dwc2->gintsts);
+
+	uint32_t port_intrs = 0;
+
+	if (core_intrs & USB_DWC2_GINTSTS_PRTINT) {
+		/* Port interrupt occurred -> read and clear selected HPRT W1C bits */
+		port_intrs = sys_read32((mem_addr_t)&dwc2->hprt);
+		/* W1C changed bits except the PRTENA */
+		sys_write32(port_intrs & ~USB_DWC2_HPRT_PRTENA, (mem_addr_t)&dwc2->hprt);
+	}
+
+	LOG_DBG("GINTSTS=%08Xh, HPRT=%08Xh", core_intrs, port_intrs);
+
+	/* Handle disconnect first */
+	if (core_intrs & USB_DWC2_GINTSTS_DISCONNINT) {
+		/* Port disconnected */
+		uhc_dwc2_port_debounce_lock(dev);
+		return UHC_DWC2_EVENT_PORT_DISCONNECTION;
+	}
+
+	/* To have better throughput, handle channels right after disconnection */
+	if (core_intrs & USB_DWC2_GINTSTS_HCHINT) {
+		priv->pending_channels_msk = sys_read32((mem_addr_t)&dwc2->haint);
+		return UHC_DWC2_EVENT_PORT_PEND_CHANNEL;
+	}
+
+	/* Handle port overcurrent as it is a failure state */
+	if (port_intrs & USB_DWC2_HPRT_PRTOVRCURRCHNG) {
+		/* TODO: Overcurrent or overcurrent clear? */
+		return UHC_DWC2_EVENT_PORT_OVERCURRENT;
+	}
+
+	/* Handle port change bits */
+	if (port_intrs & USB_DWC2_HPRT_PRTENCHNG) {
+		if (port_intrs & USB_DWC2_HPRT_PRTENA) {
+			/* Host port was enabled */
+			return UHC_DWC2_EVENT_PORT_ENABLED;
+		}
+		/* Host port has been disabled */
+		return UHC_DWC2_EVENT_PORT_DISABLED;
+	}
+
+	/* Handle port connection */
+	if (port_intrs & USB_DWC2_HPRT_PRTCONNDET && !priv->debouncing) {
+		/* Port connected */
+		uhc_dwc2_port_debounce_lock(dev);
+		return UHC_DWC2_EVENT_PORT_CONNECTION;
+	}
+
+	return UHC_DWC2_EVENT_NONE;
+}
+
+static inline bool uhc_dwc2_port_debounce(const struct device *dev,
+					enum uhc_dwc2_event event)
+{
+	const struct uhc_dwc2_config *config = dev->config;
+	struct usb_dwc2_reg *dwc2 = config->base;
+
+	/**
+	 * HINT: Do the debounce delay outside of the global lock
+	 */
+	uhc_unlock_internal(dev);
+
+	k_msleep(DEBOUNCE_DELAY_MS);
+
+	uhc_lock_internal(dev, K_FOREVER);
+
+	bool connected = ((sys_read32((mem_addr_t)&dwc2->hprt) & USB_DWC2_HPRT_PRTCONNSTS) != 0);
+	bool want_connected = (event == UHC_DWC2_EVENT_PORT_CONNECTION);
+
+	uhc_dwc2_port_debounce_unlock(dev);
+
+	/* True if stable state matches the event */
+	return connected == want_connected;
+}
+
+static inline void uhc_dwc2_port_power_on(const struct device *dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+
+	sys_clear_bits((mem_addr_t)&dwc2->haintmsk, 0xFFFFFFFFUL);
+	sys_set_bits((mem_addr_t)&dwc2->gintmsk, USB_DWC2_GINTSTS_PRTINT | USB_DWC2_GINTSTS_HCHINT);
+	dwc2_hal_set_power(dwc2, true);
+}
+
+static inline void uhc_dwc2_port_reset(const struct device *dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+
+	/* Reset the port */
+	dwc2_hal_toggle_reset(dwc2, true);
+
+	/* Hold the bus in the reset state */
+	k_msleep(RESET_HOLD_MS);
+
+	/* Return the bus to the idle state. Port enabled event should occur */
+	dwc2_hal_toggle_reset(dwc2, false);
+
+	/* Give the port time to recover */
+	k_msleep(RESET_RECOVERY_MS);
+
+	/* TODO: verify the port state after reset */
+
+	/* Finish the port config for the appeared device */
+	/* TODO: apply FIFO settings */
+	/* TODO: set frame list for the ISOC/INTR xfer */
+	/* TODO: enable periodic transfer */
+}
+
+static inline int uhc_dwc2_soft_reset(const struct device *dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+	int ret;
+
+	/* TODO: Check that port has no ongoing transfers */
+
+	/* Disable Global IRQ */
+	config->irq_disable_func(dev);
+
+	/* Reset the core */
+	ret = dwc2_hal_core_reset(dwc2, K_MSEC(10));
+	if (ret) {
+		LOG_ERR("Failed to perform soft reset: %d", ret);
+		return ret;
+	}
+
+	/* Re-config after reset */
+	dwc2_hal_init_gahbcfg(dwc2);
+
+	/* Enable Global IRQ */
+	config->irq_enable_func(dev);
+
+	/* Prepare for device connection */
+	uhc_dwc2_port_power_on(dev);
+
+	return ret;
+}
+
+static inline void uhc_dwc2_submit_new_device(const struct device *dev, enum uhc_dwc2_speed speed)
+{
+	static const char *const uhc_dwc2_speed_str[] = {"High", "Full", "Low"};
+	enum uhc_event_type type;
+
+	LOG_WRN("New device, %s-speed", uhc_dwc2_speed_str[speed]);
+
+	switch (speed) {
+	case UHC_DWC2_SPEED_LOW:
+		type = UHC_EVT_DEV_CONNECTED_LS;
+		break;
+	case UHC_DWC2_SPEED_FULL:
+		type = UHC_EVT_DEV_CONNECTED_FS;
+		break;
+	case UHC_DWC2_SPEED_HIGH:
+		type = UHC_EVT_DEV_CONNECTED_HS;
+		break;
+	default:
+		LOG_ERR("Unsupported speed %d", speed);
+		return;
+	}
+
+	/* TODO: uhc submit event UHC_EVT_DEV_CONNECTED_XX */
+	(void) type;
+}
+
+static inline void uhc_dwc2_submit_dev_gone(const struct device *dev)
+{
+	LOG_WRN("Device removed");
+
+	/* TODO: uhc submit event UHC_EVT_DEV_REMOVED */
+}
+
+static void uhc_dwc2_port_handle_events(const struct device *dev, uint32_t event_mask)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+
+	LOG_DBG("Port events: %08Xh", event_mask);
+
+	if (event_mask & BIT(UHC_DWC2_EVENT_PORT_CONNECTION)) {
+		/* Port connected */
+		LOG_DBG("Port connected");
+		/* Debounce port connection */
+		if (uhc_dwc2_port_debounce(dev, UHC_DWC2_EVENT_PORT_CONNECTION)) {
+			/* Get port speed */
+			enum uhc_dwc2_speed speed = dwc2_hal_get_speed(dwc2);
+			/* Notify the higher logic about the new device */
+			uhc_dwc2_submit_new_device(dev, speed);
+			/* Mark that port has a device */
+			priv->has_device = 1;
+		} else {
+			/* TODO: Implement handling */
+			LOG_ERR("Port changed during debouncing connect");
+		}
+	}
+
+	if (event_mask & BIT(UHC_DWC2_EVENT_PORT_ENABLED)) {
+		/* Port has a device connected and finish the first reset, we know the speed */
+		LOG_DBG("Port enabled");
+		/* Enable the rest of the port */
+		enum uhc_dwc2_speed speed = dwc2_hal_get_speed(dwc2);
+
+		dwc2_hal_enable_port(dwc2, speed);
+	}
+
+	if (event_mask & BIT(UHC_DWC2_EVENT_PORT_DISCONNECTION)) {
+		/* Port disconnected */
+		/* Debounce port disconnection */
+		if (uhc_dwc2_port_debounce(dev, UHC_DWC2_EVENT_PORT_DISCONNECTION)) {
+			LOG_DBG("Port disconnected");
+			/* If port has a device - notify upper layer */
+			if (priv->has_device) {
+				uhc_dwc2_submit_dev_gone(dev);
+				/* Unmark that port has a device */
+				priv->has_device = 0;
+			}
+			/* Reset the controller to handle new connection */
+			uhc_dwc2_soft_reset(dev);
+		} else {
+			/* TODO: Implement handling */
+			LOG_ERR("Port changed during debouncing disconnect");
+		}
+	}
+
+	if (event_mask & BIT(UHC_DWC2_EVENT_PORT_ERROR)) {
+		LOG_DBG("Port error");
+
+		if (priv->has_device) {
+			uhc_dwc2_submit_dev_gone(dev);
+			/* Unmark that port has a device */
+			priv->has_device = 0;
+		}
+
+		/* TODO: recover from the error */
+
+		/* Reset the controller to handle new connection */
+		uhc_dwc2_soft_reset(dev);
+	}
+
+	if (event_mask & BIT(UHC_DWC2_EVENT_PORT_OVERCURRENT)) {
+		LOG_ERR("Port overcurrent");
+		/* TODO: Handle overcurrent */
+		LOG_WRN("Handle overcurrent is not implemented");
+		/* Just power off the port via registers */
+	}
+}
+
+static void uhc_dwc2_channel_handle_events(const struct device *dev, void *channel)
+{
+	LOG_WRN("Channel event handle has not been implemented");
+}
 
 static void uhc_dwc2_isr_handler(const struct device *dev)
 {
-	/* TODO: Interrupt handling */
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	enum uhc_dwc2_event port_event = uhc_dwc2_port_get_event(dev);
+
+	/**
+	 * TODO: port_event serialization might be simplified by
+	 * obsoleting uhc_dwc2_port_get_event() but after the implementation of all channels type.
+	 */
+
+	switch (port_event) {
+	case UHC_DWC2_EVENT_NONE: {
+		/* Port event occurred but should not be handled in higher logic */
+		break;
+	}
+	case UHC_DWC2_EVENT_PORT_PEND_CHANNEL: {
+		/* Handle pending channel event  */
+		/* TODO: Cycle through each pending channel */
+		break;
+	}
+	default:
+		/* Notify thread about port event */
+		k_event_set(&priv->event, BIT(port_event));
+		break;
+	}
+
+	(void) uhc_dwc2_quirk_irq_clear(dev);
 }
 
 static void uhc_dwc2_thread(void *arg0, void *arg1, void *arg2)
 {
 	const struct device *const dev = (const struct device *)arg0;
 	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
-	uint32_t event;
+	uint32_t event_mask;
 
 	while (true) {
-		event = k_event_wait_safe(&priv->event, UINT32_MAX, false, K_FOREVER);
+		event_mask = k_event_wait_safe(&priv->event, UINT32_MAX, false, K_FOREVER);
 
 		uhc_lock_internal(dev, K_FOREVER);
 
-		/* TODO: handle port and channel events */
-		(void) event;
+		/* Handle port events */
+		uhc_dwc2_port_handle_events(dev, event_mask);
+
+		if (event_mask & BIT(UHC_DWC2_EVENT_PORT_PEND_CHANNEL)) {
+			uhc_dwc2_channel_handle_events(dev, NULL /* &priv->channel[index] */);
+		}
 
 		uhc_unlock_internal(dev);
 	}
@@ -118,12 +719,6 @@ static int uhc_dwc2_preinit(const struct device *const dev)
 
 	uhc_dwc2_quirk_caps(dev);
 
-	/*
-	 * TODO:
-	 * use devicetree to get GHWCFGn values and use them to determine the
-	 * number and type of configured endpoints in the hardware as in udc?
-	 */
-
 	k_thread_create(&priv->thread,
 		config->stack,
 		config->stack_size,
@@ -139,21 +734,122 @@ static int uhc_dwc2_preinit(const struct device *const dev)
 
 static int uhc_dwc2_init(const struct device *const dev)
 {
-	LOG_WRN("%s has not been implemented", __func__);
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const dwc2 = config->base;
+	uint32_t reg;
+	int ret;
 
-	return -ENOSYS;
+	/* 1. Power-up dwc2 hardware controller */
+
+	ret = uhc_dwc2_quirk_init(dev);
+	if (ret) {
+		LOG_ERR("Quirk init failed %d", ret);
+		return ret;
+	}
+
+	/* 2. Read hardware configuration registers */
+
+	reg = sys_read32((mem_addr_t)&dwc2->gsnpsid);
+	if (reg != config->gsnpsid) {
+		LOG_ERR("Unexpected GSNPSID 0x%08x instead of 0x%08x", reg, config->gsnpsid);
+		return -ENOTSUP;
+	}
+
+	reg = sys_read32((mem_addr_t)&dwc2->ghwcfg1);
+	if (reg != config->ghwcfg1) {
+		LOG_ERR("Unexpected GHWCFG1 0x%08x instead of 0x%08x", reg, config->ghwcfg1);
+		return -ENOTSUP;
+	}
+
+	reg = sys_read32((mem_addr_t)&dwc2->ghwcfg2);
+	if (reg != config->ghwcfg2) {
+		LOG_ERR("Unexpected GHWCFG2 0x%08x instead of 0x%08x", reg, config->ghwcfg2);
+		return -ENOTSUP;
+	}
+
+	reg = sys_read32((mem_addr_t)&dwc2->ghwcfg3);
+	if (reg != config->ghwcfg3) {
+		LOG_ERR("Unexpected GHWCFG3 0x%08x instead of 0x%08x", reg, config->ghwcfg3);
+		return -ENOTSUP;
+	}
+
+	reg = sys_read32((mem_addr_t)&dwc2->ghwcfg4);
+	if (reg != config->ghwcfg4) {
+		LOG_ERR("Unexpected GHWCFG4 0x%08x instead of 0x%08x", reg, config->ghwcfg4);
+		return -ENOTSUP;
+	}
+
+	/* 3. Select PHY */
+
+	ret = uhc_dwc2_quirk_phy_pre_select(dev);
+	if (ret) {
+		LOG_ERR("Quirk PHY pre select failed %d", ret);
+		return ret;
+	}
+
+	if (uhc_dwc2_quirk_is_phy_clk_off(dev)) {
+		LOG_ERR("PHY clock is  turned off, cannot reset");
+		return -EIO;
+	}
+
+	ret = dwc2_hal_core_reset(dwc2, K_MSEC(10));
+	if (ret) {
+		LOG_ERR("DWC2 core reset failed after PHY init: %d", ret);
+		return ret;
+	}
+
+	ret = uhc_dwc2_quirk_phy_post_select(dev);
+	if (ret) {
+		LOG_ERR("Quirk PHY post select failed %d", ret);
+		return ret;
+	}
+
+	/* 4. Init DWC2 controller as a host */
+
+	ret = dwc2_hal_init_host(dwc2);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
 }
 
 static int uhc_dwc2_enable(const struct device *const dev)
 {
-	LOG_WRN("%s has not been implemented", __func__);
+	const struct uhc_dwc2_config *const config = dev->config;
 
-	return -ENOSYS;
+	int ret;
+
+	ret = uhc_dwc2_quirk_pre_enable(dev);
+	if (ret) {
+		LOG_ERR("Quirk pre enable failed %d", ret);
+		return ret;
+	}
+
+	/* 1. Flush root port config */
+
+	/* TODO: Pre-calculate FIFO configuration */
+
+	/* TODO: Flush channels */
+
+	/* 2. Enable IRQ */
+	config->irq_enable_func(dev);
+
+	/* 3. Prepare for device connection */
+	uhc_dwc2_port_power_on(dev);
+
+	return 0;
 }
 
 static int uhc_dwc2_disable(const struct device *const dev)
 {
 	LOG_WRN("%s has not been implemented", __func__);
+
+	/* 0. TODO: Check ongoing transfer? */
+
+	/* 1. Disable IRQ */
+
+	/* 2. Power down root port */
 
 	return -ENOSYS;
 }
@@ -237,6 +933,11 @@ static const struct uhc_api uhc_dwc2_api = {
 		.stack_size = K_THREAD_STACK_SIZEOF(uhc_dwc2_stack_##n),	\
 		.irq_enable_func = uhc_dwc2_irq_enable_func_##n,		\
 		.irq_disable_func = uhc_dwc2_irq_disable_func_##n,		\
+		.gsnpsid = DT_INST_PROP(n, gsnpsid),				\
+		.ghwcfg1 = DT_INST_PROP(n, ghwcfg1),				\
+		.ghwcfg2 = DT_INST_PROP(n, ghwcfg2),				\
+		.ghwcfg3 = DT_INST_PROP(n, ghwcfg3),				\
+		.ghwcfg4 = DT_INST_PROP(n, ghwcfg4),				\
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n, uhc_dwc2_preinit, NULL,			\

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 Roman Leonov <jam_roma@yahoo.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT snps_dwc2
+
+#include "uhc_common.h"
+#include "uhc_dwc2.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/usb/uhc.h>
+#include <zephyr/usb/usb_ch9.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(uhc_dwc2, CONFIG_UHC_DRIVER_LOG_LEVEL);
+
+#define UHC_DWC2_CHAN_REG(base, chan_idx)					\
+	((struct usb_dwc2_host_chan *)(((mem_addr_t)(base)) + USB_DWC2_HCCHAR(chan_idx)))
+
+struct uhc_dwc2_data {
+	struct k_thread thread;
+	struct k_event event;
+};
+
+static void uhc_dwc2_thread(void *arg0, void *arg1, void *arg2)
+{
+	const struct device *const dev = (const struct device *)arg0;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	uint32_t event;
+
+	while (true) {
+		event = k_event_wait_safe(&priv->event, UINT32_MAX, false, K_FOREVER);
+
+		uhc_lock_internal(dev, K_FOREVER);
+
+		/* TODO: handle port and channel events */
+		(void) event;
+
+		uhc_unlock_internal(dev);
+	}
+}
+
+static int uhc_dwc2_lock(const struct device *const dev)
+{
+	struct uhc_data *data = dev->data;
+
+	return k_mutex_lock(&data->mutex, K_FOREVER);
+}
+
+static int uhc_dwc2_unlock(const struct device *const dev)
+{
+	struct uhc_data *data = dev->data;
+
+	return k_mutex_unlock(&data->mutex);
+}
+
+static int uhc_dwc2_sof_enable(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_bus_suspend(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_bus_reset(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_bus_resume(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_enqueue(const struct device *const dev, struct uhc_transfer *const xfer)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_dequeue(const struct device *const dev, struct uhc_transfer *const xfer)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_preinit(const struct device *const dev)
+{
+	const struct uhc_dwc2_config *const config = dev->config;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	struct uhc_data *const data = dev->data;
+
+	/* Initialize the private data structure */
+	memset(priv, 0, sizeof(struct uhc_dwc2_data));
+	k_mutex_init(&data->mutex);
+	k_event_init(&priv->event);
+
+	uhc_dwc2_quirk_caps(dev);
+
+	/*
+	 * TODO:
+	 * use devicetree to get GHWCFGn values and use them to determine the
+	 * number and type of configured endpoints in the hardware as in udc?
+	 */
+
+	k_thread_create(&priv->thread,
+		config->stack,
+		config->stack_size,
+		uhc_dwc2_thread,
+		(void *)dev, NULL, NULL,
+		K_PRIO_COOP(CONFIG_UHC_DWC2_THREAD_PRIORITY),
+		K_ESSENTIAL,
+		K_NO_WAIT);
+	k_thread_name_set(&priv->thread, dev->name);
+
+	return 0;
+}
+
+static int uhc_dwc2_init(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_enable(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_disable(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+static int uhc_dwc2_shutdown(const struct device *const dev)
+{
+	LOG_WRN("%s has not been implemented", __func__);
+
+	return -ENOSYS;
+}
+
+/*
+ * Device Definition and Initialization
+ */
+static const struct uhc_api uhc_dwc2_api = {
+	/* Common */
+	.lock = uhc_dwc2_lock,
+	.unlock = uhc_dwc2_unlock,
+	.init = uhc_dwc2_init,
+	.enable = uhc_dwc2_enable,
+	.disable = uhc_dwc2_disable,
+	.shutdown = uhc_dwc2_shutdown,
+	/* Bus related */
+	.bus_reset = uhc_dwc2_bus_reset,
+	.sof_enable = uhc_dwc2_sof_enable,
+	.bus_suspend = uhc_dwc2_bus_suspend,
+	.bus_resume = uhc_dwc2_bus_resume,
+	/* EP related */
+	.ep_enqueue = uhc_dwc2_enqueue,
+	.ep_dequeue = uhc_dwc2_dequeue,
+};
+
+#define UHC_DWC2_DT_INST_REG_ADDR(n)						\
+	COND_CODE_1(DT_NUM_REGS(DT_DRV_INST(n)),				\
+			(DT_INST_REG_ADDR(n)),					\
+			(DT_INST_REG_ADDR_BY_NAME(n, core)))
+
+#if !defined(UHC_DWC2_IRQ_DT_INST_DEFINE)
+#define UHC_DWC2_IRQ_FLAGS_TYPE0(n)	0
+#define UHC_DWC2_IRQ_FLAGS_TYPE1(n)	DT_INST_IRQ(n, type)
+#define DW_IRQ_FLAGS(n)								\
+	_CONCAT(UHC_DWC2_IRQ_FLAGS_TYPE, DT_INST_IRQ_HAS_CELL(n, type))(n)
+
+#define UHC_DWC2_IRQ_DT_INST_DEFINE(n)						\
+	static void uhc_dwc2_irq_enable_func_##n(const struct device *dev)	\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQN(n),					\
+			    DT_INST_IRQ(n, priority),				\
+			    uhc_dwc2_isr_handler,				\
+			    DEVICE_DT_INST_GET(n),				\
+			    DW_IRQ_FLAGS(n));					\
+										\
+		irq_enable(DT_INST_IRQN(n));					\
+	}									\
+										\
+	static void uhc_dwc2_irq_disable_func_##n(const struct device *dev)	\
+	{									\
+		irq_disable(DT_INST_IRQN(n));					\
+	}
+#endif
+
+/* Multi-instance device definition for DWC2 host controller */
+#define UHC_DWC2_DEVICE_DEFINE(n)						\
+										\
+	K_THREAD_STACK_DEFINE(uhc_dwc2_stack_##n,				\
+		CONFIG_UHC_DWC2_STACK_SIZE);					\
+										\
+	UHC_DWC2_IRQ_DT_INST_DEFINE(n)						\
+										\
+	static struct uhc_dwc2_data uhc_dwc2_priv_##n = { 0 };			\
+										\
+	static struct uhc_data uhc_data_##n = {					\
+		.mutex = Z_MUTEX_INITIALIZER(uhc_data_##n.mutex),		\
+		.priv = &uhc_dwc2_priv_##n,					\
+	};									\
+										\
+	static const struct uhc_dwc2_config uhc_dwc2_config_##n = {		\
+		.base = (struct usb_dwc2_reg *)UHC_DWC2_DT_INST_REG_ADDR(n),	\
+		.quirks = UHC_DWC2_VENDOR_QUIRK_GET(n),				\
+		.stack = uhc_dwc2_stack_##n,					\
+		.stack_size = K_THREAD_STACK_SIZEOF(uhc_dwc2_stack_##n),	\
+		.irq_enable_func = uhc_dwc2_irq_enable_func_##n,		\
+		.irq_disable_func = uhc_dwc2_irq_disable_func_##n,		\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(n, uhc_dwc2_preinit, NULL,			\
+		&uhc_data_##n, &uhc_dwc2_config_##n,				\
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		&uhc_dwc2_api);
+
+DT_INST_FOREACH_STATUS_OKAY(UHC_DWC2_DEVICE_DEFINE)

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -26,6 +26,11 @@ struct uhc_dwc2_data {
 	struct k_event event;
 };
 
+static void uhc_dwc2_isr_handler(const struct device *dev)
+{
+	/* TODO: Interrupt handling */
+}
+
 static void uhc_dwc2_thread(void *arg0, void *arg1, void *arg2)
 {
 	const struct device *const dev = (const struct device *)arg0;

--- a/drivers/usb/uhc/uhc_dwc2.h
+++ b/drivers/usb/uhc/uhc_dwc2.h
@@ -55,6 +55,13 @@ struct uhc_dwc2_config {
 
 	void (*irq_enable_func)(const struct device *dev);
 	void (*irq_disable_func)(const struct device *dev);
+
+	/* Hardware configuration registers */
+	uint32_t gsnpsid;
+	uint32_t ghwcfg1;
+	uint32_t ghwcfg2;
+	uint32_t ghwcfg3;
+	uint32_t ghwcfg4;
 };
 
 #include "uhc_dwc2_vendor_quirks.h"

--- a/drivers/usb/uhc/uhc_dwc2.h
+++ b/drivers/usb/uhc/uhc_dwc2.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Roman Leonov <jam_roma@yahoo.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UHC_DWC2_H
+#define ZEPHYR_DRIVERS_USB_UHC_DWC2_H
+
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/usb/uhc.h>
+#include <usb_dwc2_hw.h>
+
+/* Vendor quirks per driver instance */
+struct uhc_dwc2_vendor_quirks {
+	/* Called at the beginning of uhc_dwc2_init() */
+	int (*init)(const struct device *dev);
+	/* Called on uhc_dwc2_enable() before the controller is initialized */
+	int (*pre_enable)(const struct device *dev);
+	/* Called on uhc_dwc2_enable() after the controller is initialized */
+	int (*post_enable)(const struct device *dev);
+	/* Called at the end of uhc_dwc2_disable() */
+	int (*disable)(const struct device *dev);
+	/* Called at the end of uhc_dwc2_shutdown() */
+	int (*shutdown)(const struct device *dev);
+	/* Called at the end of IRQ handling */
+	int (*irq_clear)(const struct device *dev);
+	/* Called on driver pre-init */
+	int (*caps)(const struct device *dev);
+	/* Called on PHY pre-select */
+	int (*phy_pre_select)(const struct device *dev);
+	/* Called on PHY post-select and core reset */
+	int (*phy_post_select)(const struct device *dev);
+	/* Called while waiting for bits that require PHY to be clocked */
+	int (*is_phy_clk_off)(const struct device *dev);
+	/* PHY get clock */
+	int (*get_phy_clk)(const struct device *dev);
+	/* Called after hibernation entry sequence */
+	int (*post_hibernation_entry)(const struct device *dev);
+	/* Called before hibernation exit sequence */
+	int (*pre_hibernation_exit)(const struct device *dev);
+};
+
+/* Driver configuration per instance */
+struct uhc_dwc2_config {
+	/* Pointer to base address of DWC_OTG registers */
+	struct usb_dwc2_reg *const base;
+	/* Pointer to vendor quirks or NULL */
+	const struct uhc_dwc2_vendor_quirks *const quirks;
+	/* Pointer to the stack used by the driver thread */
+	k_thread_stack_t *stack;
+	/* Size of the stack used by the driver thread */
+	size_t stack_size;
+
+	void (*irq_enable_func)(const struct device *dev);
+	void (*irq_disable_func)(const struct device *dev);
+};
+
+#include "uhc_dwc2_vendor_quirks.h"
+
+#define UHC_DWC2_VENDOR_QUIRK_GET(n)						\
+	COND_CODE_1(DT_NODE_VENDOR_HAS_IDX(DT_DRV_INST(n), 1),			\
+			(&uhc_dwc2_vendor_quirks_##n),				\
+			(NULL))
+
+#define DWC2_QUIRK_FUNC_DEFINE(fname)						\
+static inline int uhc_dwc2_quirk_##fname(const struct device *dev)		\
+{										\
+	const struct uhc_dwc2_config *const config = dev->config;		\
+	const struct uhc_dwc2_vendor_quirks *const quirks =			\
+		COND_CODE_1(IS_EQ(DT_NUM_INST_STATUS_OKAY(snps_dwc2), 1),	\
+		(UHC_DWC2_VENDOR_QUIRK_GET(0); ARG_UNUSED(config);),		\
+		(config->quirks;))						\
+	if (quirks != NULL && quirks->fname != NULL) {				\
+		return quirks->fname(dev);					\
+	}									\
+	return 0;								\
+}
+
+DWC2_QUIRK_FUNC_DEFINE(init)
+DWC2_QUIRK_FUNC_DEFINE(pre_enable)
+DWC2_QUIRK_FUNC_DEFINE(post_enable)
+DWC2_QUIRK_FUNC_DEFINE(disable)
+DWC2_QUIRK_FUNC_DEFINE(shutdown)
+DWC2_QUIRK_FUNC_DEFINE(irq_clear)
+DWC2_QUIRK_FUNC_DEFINE(caps)
+DWC2_QUIRK_FUNC_DEFINE(phy_pre_select)
+DWC2_QUIRK_FUNC_DEFINE(phy_post_select)
+DWC2_QUIRK_FUNC_DEFINE(is_phy_clk_off)
+DWC2_QUIRK_FUNC_DEFINE(get_phy_clk)
+DWC2_QUIRK_FUNC_DEFINE(post_hibernation_entry)
+DWC2_QUIRK_FUNC_DEFINE(pre_hibernation_exit)
+
+#endif /* ZEPHYR_DRIVERS_USB_UHC_DWC2_H */

--- a/drivers/usb/uhc/uhc_dwc2_vendor_quirks.h
+++ b/drivers/usb/uhc/uhc_dwc2_vendor_quirks.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Roman Leonov <jam_roma@yahoo.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UHC_DWC2_VENDOR_QUIRKS_H
+#define ZEPHYR_DRIVERS_USB_UHC_DWC2_VENDOR_QUIRKS_H
+
+#include "uhc_dwc2.h"
+
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/usb/uhc.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_usb_otg)
+
+#define QUIRK_ESP32_USB_OTG_DEFINE(n)						\
+	static int esp32_usb_otg_init_##n(const struct device *dev)		\
+	{									\
+		return 0;							\
+	}									\
+										\
+	static int esp32_usb_otg_enable_phy_##n(const struct device *dev)	\
+	{									\
+		return 0;							\
+	}									\
+										\
+	static int esp32_usb_otg_disable_phy_##n(const struct device *dev)	\
+	{									\
+		return 0;							\
+	}									\
+										\
+	static int esp32_usb_otg_get_phy_clk_##n(const struct device *dev)	\
+	{									\
+		return 0;							\
+	}									\
+										\
+	struct uhc_dwc2_vendor_quirks uhc_dwc2_vendor_quirks_##n = {		\
+		.init = esp32_usb_otg_init_##n,					\
+		.pre_enable = esp32_usb_otg_enable_phy_##n,			\
+		.disable = esp32_usb_otg_disable_phy_##n,			\
+		.get_phy_clk = esp32_usb_otg_get_phy_clk_##n,			\
+	};
+
+#define UHC_DWC2_IRQ_DT_INST_DEFINE(n)						\
+	static void uhc_dwc2_irq_enable_func_##n(const struct device *dev)	\
+	{									\
+		/* TODO: esp_intr_enable */					\
+	}									\
+										\
+	static void uhc_dwc2_irq_disable_func_##n(const struct device *dev)	\
+	{									\
+		/* TODO: esp_intr_disable */					\
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(QUIRK_ESP32_USB_OTG_DEFINE)
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_usb_otg) */
+
+#endif /* ZEPHYR_DRIVERS_USB_UHC_DWC2_VENDOR_QUIRKS_H */

--- a/drivers/usb/uhc/uhc_dwc2_vendor_quirks.h
+++ b/drivers/usb/uhc/uhc_dwc2_vendor_quirks.h
@@ -15,25 +15,182 @@
 
 #if DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_usb_otg)
 
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/clock_control.h>
+
+#include <esp_err.h>
+#include <esp_private/usb_phy.h>
+#include <hal/usb_wrap_hal.h>
+#include <soc/usb_dwc_cfg.h>
+#include <soc/usb_dwc_periph.h>
+
+#include <esp_rom_gpio.h>
+#include <driver/gpio.h>
+#include <soc/usb_pins.h>
+#include <soc/gpio_sig_map.h>
+
+struct phy_context_t {
+	usb_phy_target_t target;
+	usb_phy_controller_t controller;
+	usb_phy_status_t status;
+	usb_otg_mode_t otg_mode;
+	usb_phy_speed_t otg_speed;
+	usb_phy_ext_io_conf_t *ext_io_pins;
+	usb_wrap_hal_context_t wrap_hal;
+};
+
+struct usb_dw_esp32_config {
+	const struct device *clock_dev;
+	const clock_control_subsys_t clock_subsys;
+	int irq_source;
+	int irq_priority;
+	int irq_flags;
+	struct phy_context_t *phy_ctx;
+};
+
+struct usb_dw_esp32_data {
+	struct intr_handle_data_t *int_handle;
+};
+
+static void uhc_dwc2_isr_handler(const struct device *dev);
+
+static inline int esp32_usb_otg_init(const struct device *dev,
+						const struct usb_dw_esp32_config *cfg,
+						struct usb_dw_esp32_data *data)
+{
+	LOG_MODULE_DECLARE(uhc_dwc2, CONFIG_UHC_DRIVER_LOG_LEVEL);
+
+	int ret;
+
+	if (!device_is_ready(cfg->clock_dev)) {
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(cfg->clock_dev, cfg->clock_subsys);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* pinout config to work in USB_OTG_MODE_HOST */
+	esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ZERO_INPUT,
+					USB_OTG_IDDIG_IN_IDX,
+					false);
+	esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ZERO_INPUT,
+					USB_SRP_BVALID_IN_IDX,
+					false);
+	esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ONE_INPUT,
+					USB_OTG_VBUSVALID_IN_IDX,
+					false);
+	esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ONE_INPUT,
+					USB_OTG_AVALID_IN_IDX,
+					false);
+
+	if (cfg->phy_ctx->target == USB_PHY_TARGET_INT) {
+		gpio_set_drive_capability(USBPHY_DM_NUM, GPIO_DRIVE_CAP_3);
+		gpio_set_drive_capability(USBPHY_DP_NUM, GPIO_DRIVE_CAP_3);
+	}
+
+	/* allocate interrupt but keep it disabled to avoid
+	 * spurious suspend/resume event at enumeration phase
+	 */
+	ret = esp_intr_alloc(cfg->irq_source,
+			ESP_INTR_FLAG_INTRDISABLED |
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+					ESP_INT_FLAGS_CHECK(cfg->irq_flags),
+			(intr_handler_t)uhc_dwc2_isr_handler,
+			(void *)dev,
+			&data->int_handle);
+
+	return ret;
+}
+
+static inline int esp32_usb_otg_enable_phy(struct phy_context_t *phy_ctx, bool enable)
+{
+	LOG_MODULE_DECLARE(uhc_dwc2, CONFIG_UHC_DRIVER_LOG_LEVEL);
+
+	if (enable) {
+		usb_wrap_ll_enable_bus_clock(true);
+		usb_wrap_hal_init(&phy_ctx->wrap_hal);
+
+#if USB_WRAP_LL_EXT_PHY_SUPPORTED
+		usb_wrap_hal_phy_set_external(&phy_ctx->wrap_hal,
+				(phy_ctx->target == USB_PHY_TARGET_EXT));
+#endif
+		if (phy_ctx->target == USB_PHY_TARGET_INT) {
+			/* Configure pull resistors for host */
+			usb_wrap_pull_override_vals_t vals = {
+				.dp_pu = false,
+				.dm_pu = false,
+				.dp_pd = true,
+				.dm_pd = true,
+			};
+			usb_wrap_hal_phy_enable_pull_override(&phy_ctx->wrap_hal, &vals);
+		}
+		LOG_DBG("PHY enabled");
+	} else {
+		usb_wrap_ll_enable_bus_clock(false);
+		usb_wrap_ll_phy_enable_pad(phy_ctx->wrap_hal.dev, false);
+
+		LOG_DBG("PHY disabled");
+	}
+	return 0;
+}
+
+static inline int esp32_usb_otg_get_phy_clock(struct phy_context_t *phy_ctx)
+{
+	if (phy_ctx->otg_speed == USB_PHY_SPEED_FULL) {
+		return MHZ(48);
+	} else if (phy_ctx->otg_speed == USB_PHY_SPEED_LOW) {
+		return MHZ(48) / 8;
+	}
+	return 0;
+}
+
 #define QUIRK_ESP32_USB_OTG_DEFINE(n)						\
+										\
+	static struct phy_context_t phy_ctx_##n = {				\
+		.target = USB_PHY_TARGET_INT,					\
+		.controller = USB_PHY_CTRL_OTG,					\
+		.otg_mode = USB_OTG_MODE_HOST,					\
+		.otg_speed = USB_PHY_SPEED_UNDEFINED,				\
+		.ext_io_pins = NULL,						\
+		.wrap_hal = {},							\
+	};									\
+										\
+	static const struct usb_dw_esp32_config usb_otg_config_##n = {		\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
+		.clock_subsys = (clock_control_subsys_t)			\
+			DT_INST_CLOCKS_CELL(n, offset),				\
+		.irq_source = DT_INST_IRQ_BY_IDX(n, 0, irq),			\
+		.irq_priority = DT_INST_IRQ_BY_IDX(n, 0, priority),		\
+		.irq_flags = DT_INST_IRQ_BY_IDX(n, 0, flags),			\
+		.phy_ctx = &phy_ctx_##n,					\
+	};									\
+										\
+	static struct usb_dw_esp32_data usb_otg_data_##n;			\
+										\
 	static int esp32_usb_otg_init_##n(const struct device *dev)		\
 	{									\
-		return 0;							\
+		return esp32_usb_otg_init(dev,					\
+			&usb_otg_config_##n, &usb_otg_data_##n);		\
 	}									\
 										\
 	static int esp32_usb_otg_enable_phy_##n(const struct device *dev)	\
 	{									\
-		return 0;							\
+		return esp32_usb_otg_enable_phy(&phy_ctx_##n, true);		\
 	}									\
 										\
 	static int esp32_usb_otg_disable_phy_##n(const struct device *dev)	\
 	{									\
-		return 0;							\
+		return esp32_usb_otg_enable_phy(&phy_ctx_##n, false);		\
 	}									\
 										\
 	static int esp32_usb_otg_get_phy_clk_##n(const struct device *dev)	\
 	{									\
-		return 0;							\
+		return esp32_usb_otg_get_phy_clock(&phy_ctx_##n);		\
 	}									\
 										\
 	struct uhc_dwc2_vendor_quirks uhc_dwc2_vendor_quirks_##n = {		\
@@ -46,12 +203,12 @@
 #define UHC_DWC2_IRQ_DT_INST_DEFINE(n)						\
 	static void uhc_dwc2_irq_enable_func_##n(const struct device *dev)	\
 	{									\
-		/* TODO: esp_intr_enable */					\
+		esp_intr_enable(usb_otg_data_##n.int_handle);			\
 	}									\
 										\
 	static void uhc_dwc2_irq_disable_func_##n(const struct device *dev)	\
 	{									\
-		/* TODO: esp_intr_disable */					\
+		esp_intr_disable(usb_otg_data_##n.int_handle);			\
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(QUIRK_ESP32_USB_OTG_DEFINE)

--- a/dts/bindings/usb/snps,dwc2.yaml
+++ b/dts/bindings/usb/snps,dwc2.yaml
@@ -31,6 +31,12 @@ properties:
     description: |
       Number of configured IN endpoints including control endpoint.
 
+  gsnpsid:
+    type: int
+    description: |
+      Value of the GSNPSID register, used to identify the version of the core
+      and avoid mismatch by checking the register at runtime.
+
   ghwcfg1:
     type: int
     required: true
@@ -43,6 +49,12 @@ properties:
     required: true
     description: |
       Value of the GHWCFG2 register. It is used to determine available endpoint
+      types during driver pre-initialization.
+
+  ghwcfg3:
+    type: int
+    description: |
+      Value of the GHWCFG3 register. It is used to determine available endpoint
       types during driver pre-initialization.
 
   ghwcfg4:

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -434,8 +434,10 @@
 			clocks = <&clock ESP32_USB_MODULE>;
 			num-out-eps = <6>;
 			num-in-eps = <6>;
+			gsnpsid = <0x4f54400a>;
 			ghwcfg1 = <0x00000000>;
 			ghwcfg2 = <0x224dd930>;
+			ghwcfg3 = <0x00c804b5>;
 			ghwcfg4 = <0xd3f0a030>;
 		};
 

--- a/samples/subsys/usb/shell/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/subsys/usb/shell/boards/esp32s3_devkitc_procpu.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+zephyr_uhc0: &usb_otg {
+	status = "okay";
+};


### PR DESCRIPTION
- https://github.com/zephyrproject-rtos/zephyr/issues/102931

# **Collective Pull-request**

Contains the incoming features and all the prerequisites.

## Work in Progress

Things to finish: 
- [x] Use `*SET_FIELD` and `*GET_FILED` macroses where possible (FIFO management in the follow-up PR)
- [x] ~~Re-implement the IRQ handling (refer to #95723)~~ Partially done but kept the possibility to simplify it after all transfer type implementation. 
- [x] Refactor the debounce mechanism (rename and simplify)
- [ ] Remove bindings, as they will be merged separately #103015

## Description

Added initial port state handling mechanism. 
After powering on the peripheral (DWC2 controller), we are able to get IRQ, related to connection/disconnection events. 

This PR introduces the basic initialization for the controller, state handling and port-related logic. 

### Debounce logic

- **ISR**: detects `PRTCONNDET`/`DISCONNINT` -> sets `priv->debouncing` and masks `PRTINT` and `DISCONNINT` (port lock) -> notify thread (event bit) -> return.

- **Thread**: `uhc_dwc2_port_debounce()` sleeps `DEBOUNCE_DELAY_MS` -> reads `HPRT.PRTCONNSTS` -> unmasks `PRTINT` and `DISCONNINT` (port unlock) -> returns stable yes/no.


### Testing
1. From the `/samples/subsys/usb/shell` folder, run

```
$ west build -b esp32s3_devkitc/esp32s3/procpu -- \
 -DCONFIG_SHELL=y \
 -DCONFIG_USB_HOST_STACK=y \
 -DCONFIG_USBH_SHELL=y \
 -DCONFIG_UDC_DWC2=n 

```
and get: 

```
... 

Successfully created ESP32-S3 image.

```
then run: 

```
$ west flash --esp-device /dev/ttyACM0 && west espressif monitor -p /dev/ttyACM0

```
and get: 

```
...

*** Booting Zephyr OS build abcffe5041ac ***
uart:~$ 
```

3. Init & enable `usbh`, manually attach and dettach a USB Device: 
```
uart:~$ usbh init 
host: USB host initialized
uart:~$ usbh enable 
host: USB host enabled
[00:00:13.057,000] <wrn> uhc_dwc2: New device, Full-speed
[00:00:15.586,000] <wrn> uhc_dwc2: Device removed
[00:00:17.294,000] <wrn> uhc_dwc2: New device, Full-speed
[00:00:19.082,000] <wrn> uhc_dwc2: Device removed
uart:~$ 

```

When a USB device attached to the port, get the warning message `wrn> uhc_dwc2: New device, Full-speed` 
When a USB device detached from the port, get the warning message `<wrn> uhc_dwc2: Device removed`

## Changes

### Updated
- `dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi` - Added `gsnpsid` and `ghwcfg3` values
- `dts/bindings/usb/snps,dwc2.yaml` - Added description for `gsnpsid` and `ghwcfg3`
- `drivers/usb/uhc/uhc_dwc2.h` - Added hardware configuration registers 
- `drivers/usb/uhc/uhc_dwc2.c` - Added logic for: 
- `drivers/usb/uhc/Kconfig.dwc2` - Added `Root port configuration` to Kconfig. 

## Related

- Follow-up in #102967
- Prerequisites in #102965
- Refactoring of #94266
- Relates to #95723