### PR TITLE
boards: ti: am243x_evm: doc: fix TRM link

### DIFF
--- a/boards/ti/am243x_evm/doc/index.rst
+++ b/boards/ti/am243x_evm/doc/index.rst
@@ -256,7 +256,7 @@ References
 **********
 
 AM64x/AM243x EVM Technical Reference Manual:
-   https://www.ti.com/lit/ug/spruj63a/spruj63a.pdf
+   https://www.ti.com/lit/pdf/spruim2
 
 MCU+ SDK Github repository:
    https://github.com/TexasInstruments/mcupsdk-core


### PR DESCRIPTION
The Technical Reference Manual reference has the wrong URL which points to the User Guide instead. Fix this by changing the URL.