### PR TITLE
drivers: sensor: stm32_vref: misc. improvements

### DIFF
--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -23,9 +23,6 @@ LOG_MODULE_REGISTER(stm32_vref, CONFIG_SENSOR_LOG_LEVEL);
 #define MEAS_RES	(12U)
 
 struct stm32_vref_data {
-	const struct device *adc;
-	const struct adc_channel_cfg adc_cfg;
-	ADC_TypeDef *adc_base;
 	struct adc_sequence adc_seq;
 	struct k_mutex mutex;
 	int16_t sample_buffer;
@@ -33,6 +30,10 @@ struct stm32_vref_data {
 };
 
 struct stm32_vref_config {
+	const struct device *adc;
+	struct adc_channel_cfg adc_cfg;
+	ADC_TypeDef *adc_base;
+
 	uint16_t *cal_addr;
 	int cal_mv;
 	uint8_t cal_shift;
@@ -40,6 +41,7 @@ struct stm32_vref_config {
 
 static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
+	const struct stm32_vref_config *cfg = dev->config;
 	struct stm32_vref_data *data = dev->data;
 	struct adc_sequence *sp = &data->adc_seq;
 	int rc;
@@ -50,34 +52,34 @@ static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
-	pm_device_runtime_get(data->adc);
+	pm_device_runtime_get(cfg->adc);
 
-	rc = adc_channel_setup(data->adc, &data->adc_cfg);
+	rc = adc_channel_setup(cfg->adc, &cfg->adc_cfg);
 	if (rc) {
-		LOG_DBG("Setup AIN%u got %d", data->adc_cfg.channel_id, rc);
+		LOG_DBG("Setup AIN%u got %d", cfg->adc_cfg.channel_id, rc);
 		goto unlock;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base),
+	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base));
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base),
 				       LL_ADC_PATH_INTERNAL_VREFINT | path);
 
 #ifdef LL_ADC_DELAY_VREFINT_STAB_US
 	k_usleep(LL_ADC_DELAY_VREFINT_STAB_US);
 #endif
 
-	rc = adc_read(data->adc, sp);
+	rc = adc_read(cfg->adc, sp);
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base),
+	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base));
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base),
 				       path &= ~LL_ADC_PATH_INTERNAL_VREFINT);
 
 
 unlock:
-	pm_device_runtime_put(data->adc);
+	pm_device_runtime_put(cfg->adc);
 	k_mutex_unlock(&data->mutex);
 
 	return rc;
@@ -123,18 +125,19 @@ static DEVICE_API(sensor, stm32_vref_driver_api) = {
 
 static int stm32_vref_init(const struct device *dev)
 {
+	const struct stm32_vref_config *cfg = dev->config;
 	struct stm32_vref_data *data = dev->data;
 	struct adc_sequence *asp = &data->adc_seq;
 
 	k_mutex_init(&data->mutex);
 
-	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
+	if (!device_is_ready(cfg->adc)) {
+		LOG_ERR("Device %s is not ready", cfg->adc->name);
 		return -ENODEV;
 	}
 
 	*asp = (struct adc_sequence){
-		.channels = BIT(data->adc_cfg.channel_id),
+		.channels = BIT(cfg->adc_cfg.channel_id),
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
 		.resolution = MEAS_RES,
@@ -160,7 +163,9 @@ BUILD_ASSERT(0,	"ADC '" DT_NODE_FULL_NAME(DT_INST_IO_CHANNELS_CTLR(0)) "' needed
  */
 #else
 
-static struct stm32_vref_data stm32_vref_dev_data = {
+static struct stm32_vref_data stm32_vref_dev_data;
+
+static const struct stm32_vref_config stm32_vref_dev_config = {
 	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
 	.adc_base = (ADC_TypeDef *)DT_REG_ADDR(DT_INST_IO_CHANNELS_CTLR(0)),
 	.adc_cfg = {.gain = ADC_GAIN_1,
@@ -168,9 +173,7 @@ static struct stm32_vref_data stm32_vref_dev_data = {
 		    .acquisition_time = ADC_ACQ_TIME_MAX,
 		    .channel_id = DT_INST_IO_CHANNELS_INPUT(0),
 		    .differential = 0},
-};
 
-static const struct stm32_vref_config stm32_vref_dev_config = {
 	.cal_addr = (uint16_t *)DT_INST_PROP(0, vrefint_cal_addr),
 	.cal_mv = DT_INST_PROP(0, vrefint_cal_mv),
 	.cal_shift = (DT_INST_PROP(0, vrefint_cal_resolution) - MEAS_RES),


### PR DESCRIPTION
* move constants to instance configuration
* read calibration data once during init and pre-compute `Num` used for Vref calculation:
  * `Num = <device-specific VREFINT calib data> * <SoC-specific constant>`
  * `Vref = Num / <ADC read result>`

Remark: as the three drivers `stm32_temp`, `stm32_vref` and `stm32_vbat` are strikingly similar, it would be possible to implement a common "ADC sensor" core on top of which these would be implemented instead. This is left as an exercise for a future PR.