### PR TITLE
dts: nordic: Fix ngpios in gpio1 for nRF54L15 (and variants)

### DIFF
--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -530,7 +530,7 @@
 				gpio-controller;
 				reg = <0xd8200 0x300>;
 				#gpio-cells = <2>;
-				ngpios = <16>;
+				ngpios = <17>;
 				status = "disabled";
 				port = <1>;
 				gpiote-instance = <&gpiote20>;


### PR DESCRIPTION
This is a follow-up to commit 15716542c20dea8d32a4e8e3072a90c6635ee589.

See:
https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/chapters/pin.html#ariaid-title6