### PR TITLE
boards: st: *wba*: update openocd board config file

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/support/openocd.cfg
+++ b/boards/st/nucleo_u5a5zj_q/support/openocd.cfg
@@ -32,6 +32,11 @@ set GDB_PORT 3333
 
 source [find target/stm32u5x.cfg]
 
+# STM32U5Axx support was added in OpenOCD after release tag 0.12.0.
+# Disable device identification with 'gdb_memory_map disable' and enforce use
+# of hardware breakpoint with 'gdb_breakpoint_override hard' in case OpenOCD
+# does not support the target.
+
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"
 	reset halt
@@ -42,3 +47,5 @@ $_TARGETNAME configure -event gdb-detach {
 	echo "Debugger detaching: resuming execution"
 	resume
 }
+
+gdb_memory_map disable

--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -232,7 +232,11 @@ Debugging
 Debugging using OpenOCD
 -----------------------
 
-You can debug an application in the usual way using OpenOCD. Here is an example for the
+OpenOCD added STM32WB6xx full support in September 2023 (`OpenOCD WBA5xx commit`_),
+after v0.12.0 release tag. Zephyr SDK fork of OpenOCD includes this STM32WBA5x support.
+
+Assuming your OpenOCD tool (local or from the Zephyr SDK) supports STM32WBA5x,
+you can debug an application in the usual way using OpenOCD. Here is an example for the
 :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -264,3 +268,6 @@ For that:
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OpenOCD WBA5xx commit:
+   https://github.com/openocd-org/openocd/commit/870769b0ba9f4dae6ada9d8b1a40d75bd83aaa06

--- a/boards/st/nucleo_wba55cg/support/openocd.cfg
+++ b/boards/st/nucleo_wba55cg/support/openocd.cfg
@@ -21,4 +21,10 @@ set CLOCK_FREQ 8000
 # connect_assert_srst needed if low power mode application running (WFI...)
 reset_config srst_nogate
 
-source [find target/stm32wbax.cfg]
+# STM32WBA65 was renamed recently added in OpenOCD (Jan-2026). Fallback to
+# target config file old name if not found.
+if {[catch {ocd_find target/stm32wba5x.cfg} t]==0} {
+	source [find target/stm32wba5x.cfg]
+} else {
+	source [find target/stm32wbax.cfg]
+}

--- a/boards/st/nucleo_wba55cg/support/openocd.cfg
+++ b/boards/st/nucleo_wba55cg/support/openocd.cfg
@@ -1,5 +1,5 @@
-# Note: Using OpenOCD using nucloe_wba52cg requires using openocd fork.
-# See board documentation for more information
+# Note: Using OpenOCD on nucleo_wba55cg requires a recent or patched
+# openocd tool. See board documentation for more information.
 
 source [find interface/stlink-dap.cfg]
 

--- a/boards/st/nucleo_wba65ri/doc/index.rst
+++ b/boards/st/nucleo_wba65ri/doc/index.rst
@@ -278,7 +278,14 @@ Debugging
 Debugging using OpenOCD
 -----------------------
 
-You can debug an application in the usual way using OpenOCD. Here is an example for the
+OpenOCD added STM32WB65x full support in January 2026 (`OpenOCD WBA6xx commit`_),
+after v0.12.0 release tag. Leveraging OpenOCD support for STM32WBA5x (merged
+in `OpenOCD WBA5xx commit`_, September 2023, after v0.12.0 release tag) allows
+basic support. Zephyr SDK fork of OpenOCD currently only includes this STM32WBA5x
+support.
+
+Assuming your OpenOCD tool (local or from the Zephyr SDK) supports at least STM32WBA5x,
+you can debug an application in the usual way using OpenOCD. Here is an example for the
 :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -295,3 +302,9 @@ You can debug an application in the usual way using OpenOCD. Here is an example 
 
 .. _How to disable STM32WBA65 TZEN Option Byte:
    https://wiki.st.com/stm32mcu/wiki/Connectivity:STM32WBA_BLE_%26_TrustZone#How_to_disable_the_TrustZone
+
+.. _OpenOCD WBA6xx commit:
+   https://github.com/openocd-org/openocd/commit/df14f586629a70878636d138ec3bffd9148aaf1b
+
+.. _OpenOCD WBA5xx commit:
+   https://github.com/openocd-org/openocd/commit/870769b0ba9f4dae6ada9d8b1a40d75bd83aaa06

--- a/boards/st/nucleo_wba65ri/support/openocd.cfg
+++ b/boards/st/nucleo_wba65ri/support/openocd.cfg
@@ -1,5 +1,5 @@
-# Note: Using OpenOCD using nucleo_wba65ri requires using openocd fork.
-# See board documentation for more information
+# Note: Using OpenOCD on nucleo_wba65ri requires a recent or patched
+# openocd tool. See board documentation for more information.
 
 source [find interface/stlink-dap.cfg]
 

--- a/boards/st/nucleo_wba65ri/support/openocd.cfg
+++ b/boards/st/nucleo_wba65ri/support/openocd.cfg
@@ -21,6 +21,14 @@ set CLOCK_FREQ 8000
 # connect_assert_srst needed if low power mode application running (WFI...)
 reset_config srst_only srst_nogate
 
-source [find target/stm32wbax.cfg]
+# STM32WBA65 was recently added in OpenOCD (Jan-2026). Fallback to WBA55 without
+# device indentification or software breakpoints if target config file is not
+# found.
+if {[catch {ocd_find target/stm32wba6x.cfg} t]==0} {
+	source [find target/stm32wba6x.cfg]
+} else {
+	source [find target/stm32wbax.cfg]
 
-gdb_memory_map disable
+	gdb_memory_map disable
+	gdb_breakpoint_override hard
+}

--- a/boards/st/stm32u5a9j_dk/support/openocd.cfg
+++ b/boards/st/stm32u5a9j_dk/support/openocd.cfg
@@ -32,6 +32,11 @@ set GDB_PORT 3333
 
 source [find target/stm32u5x.cfg]
 
+# STM32U5Axx support was added in OpenOCD after release tag 0.12.0.
+# Disable device identification with 'gdb_memory_map disable' and enforce use
+# of hardware breakpoint with 'gdb_breakpoint_override hard' in case OpenOCD
+# does not support the target.
+
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"
 	reset halt

--- a/boards/st/stm32u5g9j_dk1/support/openocd.cfg
+++ b/boards/st/stm32u5g9j_dk1/support/openocd.cfg
@@ -32,6 +32,11 @@ set GDB_PORT 3333
 
 source [find target/stm32u5x.cfg]
 
+# STM32U5Gxx support was added in OpenOCD after release tag 0.12.0.
+# Disable device identification with 'gdb_memory_map disable' and enforce use
+# of hardware breakpoint with 'gdb_breakpoint_override hard' in case OpenOCD
+# does not support the target.
+
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"
 	reset halt

--- a/boards/st/stm32u5g9j_dk2/support/openocd.cfg
+++ b/boards/st/stm32u5g9j_dk2/support/openocd.cfg
@@ -32,6 +32,11 @@ set GDB_PORT 3333
 
 source [find target/stm32u5x.cfg]
 
+# STM32U5Gxx support was added in OpenOCD after release tag 0.12.0.
+# Disable device identification with 'gdb_memory_map disable' and enforce use
+# of hardware breakpoint with 'gdb_breakpoint_override hard' in case OpenOCD
+# does not support the target.
+
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"
 	reset halt

--- a/boards/st/stm32wba65i_dk1/doc/index.rst
+++ b/boards/st/stm32wba65i_dk1/doc/index.rst
@@ -258,7 +258,14 @@ Debugging
 Debugging using OpenOCD
 -----------------------
 
-You can debug an application in the usual way using OpenOCD. Here is an example for the
+OpenOCD added STM32WB65x full support in January 2026 (`OpenOCD WBA6xx commit`_),
+after v0.12.0 release tag. Leveraging OpenOCD support for STM32WBA5x (merged
+in `OpenOCD WBA5xx commit`_, September 2023, after v0.12.0 release tag) allows
+basic support. Zephyr SDK fork of OpenOCD currently only includes this STM32WBA5x
+support.
+
+Assuming your OpenOCD tool (local or from the Zephyr SDK) supports at least STM32WBA5x,
+you can debug an application in the usual way using OpenOCD. Here is an example for the
 :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -275,3 +282,9 @@ You can debug an application in the usual way using OpenOCD. Here is an example 
 
 .. _How to disable STM32WBA65 TZEN Option Byte:
    https://wiki.st.com/stm32mcu/wiki/Connectivity:STM32WBA_BLE_%26_TrustZone#How_to_disable_the_TrustZone
+
+.. _OpenOCD WBA6xx commit:
+   https://github.com/openocd-org/openocd/commit/df14f586629a70878636d138ec3bffd9148aaf1b
+
+.. _OpenOCD WBA5xx commit:
+   https://github.com/openocd-org/openocd/commit/870769b0ba9f4dae6ada9d8b1a40d75bd83aaa06

--- a/boards/st/stm32wba65i_dk1/support/openocd.cfg
+++ b/boards/st/stm32wba65i_dk1/support/openocd.cfg
@@ -1,5 +1,5 @@
-# Note: Using OpenOCD using stm32wba65i_dk1 requires using openocd fork.
-# See board documentation for more information
+# Note: Using OpenOCD on stm32wba65i_dk1 requires a recent or patched
+# openocd tool. See board documentation for more information.
 
 source [find interface/stlink-dap.cfg]
 

--- a/boards/st/stm32wba65i_dk1/support/openocd.cfg
+++ b/boards/st/stm32wba65i_dk1/support/openocd.cfg
@@ -21,6 +21,14 @@ set CLOCK_FREQ 8000
 # connect_assert_srst needed if low power mode application running (WFI...)
 reset_config srst_only srst_nogate
 
-source [find target/stm32wbax.cfg]
+# STM32WBA65 was recently added in OpenOCD (Jan-2026). Fallback to WBA55 without
+# device indentification or software breakpoints if target config file is not
+# found.
+if {[catch {ocd_find target/stm32wba6x.cfg} t]==0} {
+	source [find target/stm32wba6x.cfg]
+} else {
+	source [find target/stm32wbax.cfg]
 
-gdb_memory_map disable
+	gdb_memory_map disable
+	gdb_breakpoint_override hard
+}


### PR DESCRIPTION
Add an information in STM32WBAxxx based ST boards about OpenOCD support for these target.
Update these boards' openocd config file to support latest changes in mainline OpenOCD.
Add an inline comment in STM32U5A/U5G based ST boards' openocd file explaining the specific GDB config embedded.