### PR TITLE
cmake: align board qualifiers in CMake with Kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2287,7 +2287,7 @@ endif()
 add_custom_command(
   TARGET ${logical_target_for_zephyr_elf}
   POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E echo "Generating files from ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME} for board: ${BOARD}${BOARD_QUALIFIERS}"
+  COMMAND ${CMAKE_COMMAND} -E echo "Generating files from ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME} for board: ${BOARD}/${BOARD_QUALIFIERS}"
   ${post_build_commands}
   BYPRODUCTS
   ${post_build_byproducts}

--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -31,7 +31,7 @@ zephyr_get(TC_NAME)
 
 if(NOT CODECHECKER_NAME)
   if(TC_NAME)
-    set(CODECHECKER_NAME "${BOARD}${BOARD_QUALIFIERS}:${TC_NAME}")
+    set(CODECHECKER_NAME "${BOARD}/${BOARD_QUALIFIERS}:${TC_NAME}")
   else()
     set(CODECHECKER_NAME zephyr)
   endif()

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -23,7 +23,7 @@ else()
 endif()
 
 # ECLAIR Settings
-set(ECLAIR_PROJECT_NAME "Zephyr-${BOARD}${BOARD_QUALIFIERS}")
+set(ECLAIR_PROJECT_NAME "Zephyr-${BOARD}/${BOARD_QUALIFIERS}")
 set(ECLAIR_PROJECT_ROOT "${ZEPHYR_BASE}")
 set(ECLAIR_OUTPUT_DIR "${CMAKE_BINARY_DIR}/sca/eclair")
 set(ECLAIR_ECL_DIR "${ZEPHYR_BASE}/cmake/sca/eclair/ECL")

--- a/samples/boards/nordic/coresight_stm/CMakeLists.txt
+++ b/samples/boards/nordic/coresight_stm/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(NOT (CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP))
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(nrf_coresight_stm)

--- a/samples/boards/nordic/nrf53_sync_rtc/CMakeLists.txt
+++ b/samples/boards/nordic/nrf53_sync_rtc/CMakeLists.txt
@@ -9,9 +9,9 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR
    CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP)
-  message(INFO " ${BOARD}${BOARD_QUALIFIERS} used for Application Core")
+  message(INFO " ${BOARD}/${BOARD_QUALIFIERS} used for Application Core")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(sync_rtc)

--- a/samples/boards/nordic/nrf53_sync_rtc/net/CMakeLists.txt
+++ b/samples/boards/nordic/nrf53_sync_rtc/net/CMakeLists.txt
@@ -9,9 +9,9 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET OR
    CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUNET)
-  message(INFO " ${BOARD}${BOARD_QUALIFIERS} used for Network Core")
+  message(INFO " ${BOARD}/${BOARD_QUALIFIERS} used for Network Core")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(sync_rtc_net)

--- a/samples/drivers/mbox/CMakeLists.txt
+++ b/samples/drivers/mbox/CMakeLists.txt
@@ -37,9 +37,9 @@ if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR
    CONFIG_BOARD_EK_RA8P1_R7KA8P1KFLCAC_CM85 OR
    CONFIG_BOARD_VERSALNET_RPU OR
    CONFIG_BOARD_VERSAL2_RPU)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as Main in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as Main in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_ipc)

--- a/samples/drivers/mbox/remote/CMakeLists.txt
+++ b/samples/drivers/mbox/remote/CMakeLists.txt
@@ -37,9 +37,9 @@ if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET OR
    CONFIG_BOARD_EK_RA8P1_R7KA8P1KFLCAC_CM33 OR
    CONFIG_BOARD_VERSALNET_RPU OR
    CONFIG_BOARD_VERSAL2_RPU)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as remote in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as remote in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_ipc_remote)

--- a/samples/drivers/mbox/sysbuild.cmake
+++ b/samples/drivers/mbox/sysbuild.cmake
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
-  message(FATAL_ERROR "Target ${BOARD}${BOARD_QUALIFIERS} not supported for this sample. "
+  message(FATAL_ERROR "Target ${BOARD}/${BOARD_QUALIFIERS} not supported for this sample. "
     "There is no remote board selected in Kconfig.sysbuild")
 endif()
 

--- a/samples/drivers/mbox_data/CMakeLists.txt
+++ b/samples/drivers/mbox_data/CMakeLists.txt
@@ -20,9 +20,9 @@ if(CONFIG_BOARD_MIMXRT1170_EVK_MIMXRT1176_CM7 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M7_0 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M7_1 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M33)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as Main in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as Main in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_data_ipc)

--- a/samples/drivers/mbox_data/remote/CMakeLists.txt
+++ b/samples/drivers/mbox_data/remote/CMakeLists.txt
@@ -18,9 +18,9 @@ if(CONFIG_BOARD_MIMXRT1170_EVK_MIMXRT1176_CM4 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M7_0 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M7_1 OR
    CONFIG_BOARD_IMX943_EVK_MIMX94398_M33)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as remote in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as remote in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_data_ipc_remote)

--- a/samples/subsys/logging/multidomain/CMakeLists.txt
+++ b/samples/subsys/logging/multidomain/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(NOT (CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR
    CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP))
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(log_multidomain)

--- a/tests/boards/nrf/coresight_stm/CMakeLists.txt
+++ b/tests/boards/nrf/coresight_stm/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(NOT (CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP))
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(nrf_coresight_stm)

--- a/tests/drivers/mbox/mbox_data/CMakeLists.txt
+++ b/tests/drivers/mbox/mbox_data/CMakeLists.txt
@@ -15,9 +15,9 @@ if(CONFIG_BOARD_MIMXRT1170_EVK_MIMXRT1176_CM7 OR
    CONFIG_BOARD_MIMXRT1180_EVK_MIMXRT1189_CM33 OR
    CONFIG_BOARD_S32Z2XXDC2 OR
    CONFIG_BOARD_EK_RA8P1_R7KA8P1KFLCAC_CM85)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as Main in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as Main in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_data_ipc)

--- a/tests/drivers/mbox/mbox_data/remote/CMakeLists.txt
+++ b/tests/drivers/mbox/mbox_data/remote/CMakeLists.txt
@@ -12,9 +12,9 @@ if(CONFIG_BOARD_MIMXRT1170_EVK_MIMXRT1176_CM4 OR
    CONFIG_BOARD_LPCXPRESSO55S69_LPC55S69_CPU1 OR
    CONFIG_BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7 OR
    CONFIG_BOARD_EK_RA8P1_R7KA8P1KFLCAC_CM33)
-  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as remote in this sample")
+  message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as remote in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_data_ipc_remote)

--- a/tests/ztest/fail/CMakeLists.txt
+++ b/tests/ztest/fail/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 ExternalProject_Add(core
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/core
     CMAKE_ARGS
-      -DBOARD:STRING=${BOARD}${BOARD_QUALIFIERS}
+      -DBOARD:STRING=${BOARD}/${BOARD_QUALIFIERS}
       -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/core
       ${fail_test_config}
 )


### PR DESCRIPTION
Follow-up to PR #102385.

Some occurrences of ${BOARD}${BOARD_QUALIFIERS} was missed in the original alignment PR.

This commit adjusts the remaining occurrences to now include `/`.