### PR TITLE
STM32: implement NVM OTP driver + migrate ADC sensor drivers

### DIFF
--- a/drivers/otp/CMakeLists.txt
+++ b/drivers/otp/CMakeLists.txt
@@ -8,4 +8,5 @@ zephyr_library_sources_ifdef(CONFIG_OTP_EMULATOR otp_emulator.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_MCUX_OCOTP otp_mcux_ocotp.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_SIFLI_EFUSE otp_sifli_efuse.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_STM32_BSEC otp_bsec_stm32.c)
+zephyr_library_sources_ifdef(CONFIG_OTP_STM32_NVM otp_nvm_stm32.c)
 # zephyr-keep-sorted-stop

--- a/drivers/otp/Kconfig.stm32
+++ b/drivers/otp/Kconfig.stm32
@@ -8,3 +8,13 @@ config OTP_STM32_BSEC
 	depends on DT_HAS_ST_STM32_BSEC_ENABLED
 	help
 	  Enable OTP fuse access for STM32 SoCs embedding a BSEC peripheral.
+
+config OTP_STM32_NVM
+	bool "STM32 embedded NVM OTP driver"
+	default y
+	depends on DT_HAS_ST_STM32_NVM_OTP_ENABLED
+	help
+	  Enable driver for OTP regions inside embedded non-volatile memory
+	  found in STM32 SoCs.
+
+	  N.B.: the "program" operation is currently not supported.

--- a/drivers/otp/otp_nvm_stm32.c
+++ b/drivers/otp/otp_nvm_stm32.c
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Driver for one-time programmable areas inside STM32 embedded NVM.
+ *
+ * "OTP for user data" area programming is not supported yet.
+ * It shall be implemented as a dedicated, externally visible function
+ * in the flash driver(s) called from this driver.
+ */
+
+#include <string.h>
+#include <zephyr/cache.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/otp.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#define DT_DRV_COMPAT st_stm32_nvm_otp
+
+struct otp_stm32_nvm_config {
+	/* Base address and size of OTP area */
+	const uint8_t *base;
+	size_t size;
+};
+
+static void slow_otp_readout(void *buf, const uint8_t *src, size_t len)
+{
+	uintptr_t dst = (uintptr_t)buf;
+	size_t remaining = len;
+	uint16_t tmp;
+
+	if (!IS_ALIGNED(src, sizeof(uint16_t))) {
+		/*
+		 * First byte is not aligned: read the entire halfword
+		 * but write only the byte at higher address (which is
+		 * the MSB due to STM32 CPUs being little-endian).
+		 */
+		tmp = sys_read16((mem_addr_t)(src - 1));
+		sys_write8(tmp >> 8u, dst);
+		src++; dst++; remaining--;
+	}
+
+	__ASSERT_NO_MSG(IS_ALIGNED(src, sizeof(uint16_t)));
+
+	/* Copy bulk using 16-bit reads */
+	while (remaining >= 2) {
+		UNALIGNED_PUT(sys_read16((mem_addr_t)src), (uint16_t *)dst);
+		src += sizeof(uint16_t);
+		dst += sizeof(uint16_t);
+		remaining -= sizeof(uint16_t);
+	}
+
+	__ASSERT_NO_MSG(remaining < 2);
+
+	if (remaining == 1) {
+		/*
+		 * Ditto as above but for unaligned last byte.
+		 * src was incremented at the end of the loop
+		 * and already points to the target halfword;
+		 * however, we keep the LSB this time since
+		 * we want the byte at lower address.
+		 */
+		tmp = sys_read16((mem_addr_t)src);
+		sys_write8(tmp & 0xFFu, dst);
+	}
+}
+
+static int otp_stm32_nvm_read(const struct device *dev, off_t offset, void *buf, size_t len)
+{
+	const struct otp_stm32_nvm_config *config = dev->config;
+	const size_t start = (size_t)offset;
+	size_t end;
+
+	if (size_add_overflow(start, len, &end) || end > config->size) {
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	sys_cache_instr_disable();
+#endif
+	/*
+	 * The OTP/RO area is mapped via the AHB interface which does not
+	 * support 8-bit reads on series such as STM32H5 or STM32H7R/S.
+	 *
+	 * Do NOT use memcpy() - instead, copy using only 16-bit reads
+	 * which should have the broadest compatibility.
+	 */
+	if (likely(IS_ALIGNED(start, sizeof(uint16_t)) &&
+		   IS_ALIGNED(len, sizeof(uint16_t)))) {
+		/* No unaligned head/tail to handle */
+		const uint8_t *base = config->base;
+		const char *dst = buf;
+		size_t cur = start;
+
+		while (cur < end) {
+			uint16_t v = sys_read16((mem_addr_t)&base[cur]);
+
+			UNALIGNED_PUT(v, (uint16_t *)dst);
+
+			cur += sizeof(uint16_t);
+			dst += sizeof(uint16_t);
+		}
+
+		__ASSERT_NO_MSG(cur == end);
+	} else {
+		slow_otp_readout(buf, &config->base[start], len);
+	}
+
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	sys_cache_instr_enable();
+#endif
+
+	return 0;
+}
+
+static DEVICE_API(otp, otp_stm32_nvm_api) = {
+	.read = otp_stm32_nvm_read,
+};
+
+#define OTP_STM32_NVM_INIT_INNER(inst, _cfg)							\
+	static const struct otp_stm32_nvm_config _cfg = {					\
+		.base = (void *)DT_INST_REG_ADDR(inst),						\
+		.size = DT_INST_REG_SIZE(inst),							\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &_cfg,					\
+			      PRE_KERNEL_1, CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
+
+#define OTP_STM32_NVM_INIT(inst)								\
+	OTP_STM32_NVM_INIT_INNER(inst, CONCAT(otp_stm32_nvm_cfg, inst))
+
+DT_INST_FOREACH_STATUS_OKAY(OTP_STM32_NVM_INIT)

--- a/drivers/sensor/st/stm32_temp/Kconfig
+++ b/drivers/sensor/st/stm32_temp/Kconfig
@@ -14,3 +14,15 @@ config STM32_TEMP
 	select ADC
 	help
 	  Enable driver for STM32 temperature sensor.
+
+if STM32_TEMP
+
+config STM32_TEMP_READ_CALIB_VIA_NVMEM
+	bool "Read Temperature Sensor calibration data using NVMEM"
+	default y
+	depends on OTP && NVMEM
+	help
+	  Read calibration data using the NVMEM subsystem
+	  instead of using raw memory accesses.
+
+endif # STM32_TEMP

--- a/drivers/sensor/st/stm32_vref/Kconfig
+++ b/drivers/sensor/st/stm32_vref/Kconfig
@@ -12,3 +12,15 @@ config STM32_VREF
 	select ADC
 	help
 	  Enable driver for STM32 Vref sensor.
+
+if STM32_VREF
+
+config STM32_VREF_READ_CALIB_VIA_NVMEM
+	bool "Read VREF calibration data using NVMEM"
+	default y
+	depends on OTP && NVMEM
+	help
+	  Read calibration data using the NVMEM subsystem
+	  instead of using raw memory accesses.
+
+endif # STM32_VREF

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/nvmem.h>
 #include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
@@ -34,12 +35,18 @@ struct stm32_vref_data {
 	int16_t raw; /* raw adc Sensor value */
 };
 
+#if defined(CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM)
+typedef struct nvmem_cell calib_info_t;
+#else
+typedef const uint16_t *calib_info_t;
+#endif /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
+
 struct stm32_vref_config {
 	const struct device *adc;
 	struct adc_channel_cfg adc_cfg;
 	ADC_TypeDef *adc_base;
 
-	uint16_t *cal_addr;
+	calib_info_t vrefint_cal;
 	int cal_mv;
 	uint8_t cal_shift;
 };
@@ -140,15 +147,28 @@ static int stm32_vref_init(const struct device *dev)
  * Read calibration data and compute numerator once during init.
  * STM32H5X: accesses to flash RO region must be done with caching disabled.
  */
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	uint16_t vrefint_cal;
+#if defined(CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM)
+	int res;
+
+	res = nvmem_cell_read(&cfg->vrefint_cal, &vrefint_cal, 0, sizeof(vrefint_cal));
+	if (res < 0) {
+		LOG_ERR("Failed to read VREFINT calibration data: %d", res);
+		return res;
+	}
+#else /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
+# if defined(CONFIG_SOC_SERIES_STM32H5X)
 	sys_cache_instr_disable();
-#endif /* CONFIG_SOC_SERIES_STM32H5X */
+# endif /* CONFIG_SOC_SERIES_STM32H5X */
 
-	data->vrefint_cal_numerator = ((*cfg->cal_addr) >> cfg->cal_shift) * cfg->cal_mv;
+	vrefint_cal = *cfg->vrefint_cal;
 
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+# if defined(CONFIG_SOC_SERIES_STM32H5X)
 	sys_cache_instr_enable();
-#endif /* CONFIG_SOC_SERIES_STM32H5X */
+# endif /* CONFIG_SOC_SERIES_STM32H5X */
+#endif /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
+
+	data->vrefint_cal_numerator = cfg->cal_mv * (vrefint_cal >> cfg->cal_shift);
 
 	return 0;
 }
@@ -170,6 +190,16 @@ BUILD_ASSERT(0,	"ADC '" DT_NODE_FULL_NAME(DT_INST_IO_CHANNELS_CTLR(0)) "' needed
  */
 #else
 
+#if defined(CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM)
+#define VREFINT_CAL_INIT(inst) NVMEM_CELL_INST_GET_BY_IDX(inst, 0)
+#else
+/* MMIO address = base of OTP flash area + offset of cell in OTP */
+#define VREFINT_CAL_INIT_INNER(nvmc)							\
+	((void *)(DT_REG_ADDR(DT_MTD_FROM_NVMEM_CELL(nvmc)) + DT_REG_ADDR(nvmc)))
+#define VREFINT_CAL_INIT(inst)							\
+	VREFINT_CAL_INIT_INNER(DT_INST_NVMEM_CELL(inst))
+#endif /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
+
 static struct stm32_vref_data stm32_vref_dev_data;
 
 static const struct stm32_vref_config stm32_vref_dev_config = {
@@ -181,7 +211,7 @@ static const struct stm32_vref_config stm32_vref_dev_config = {
 		    .channel_id = DT_INST_IO_CHANNELS_INPUT(0),
 		    .differential = 0},
 
-	.cal_addr = (uint16_t *)DT_INST_PROP(0, vrefint_cal_addr),
+	.vrefint_cal = VREFINT_CAL_INIT(0),
 	.cal_mv = DT_INST_PROP(0, vrefint_cal_mv),
 	.cal_shift = (DT_INST_PROP(0, vrefint_cal_resolution) - MEAS_RES),
 };

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -538,7 +538,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff756a>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 10>;
 		status = "disabled";

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -527,7 +527,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32c0-temp-cal";
-		ts-cal1-addr = <0x1fff7568>;
+		nvmem-cells = <&ts_cal1_otp>;
+		nvmem-cell-names = "TS_CAL1";
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3000>;
 		avgslope = "2.53";

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -169,6 +169,36 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <40>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* "Engineering bytes" */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@68 {
+						reg = <0x68 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@6a {
+						reg = <0x6a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -99,6 +99,33 @@
 				/* maximum erase time for a 2K sector */
 				max-erase-time = <40>;
 			};
+
+			/*
+			 * Device-unique information is stored
+			 * at the end of the System memory area.
+			 */
+			flash@1ffff700 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ffff700 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@b8 {
+						reg = <0xb8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@ba {
+						reg = <0xba 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -413,7 +413,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ffff7ba>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -13,7 +13,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32c0-temp-cal";
-		ts-cal1-addr = <0x1ffff7b8>;
+		nvmem-cells = <&ts_cal1_otp>;
+		nvmem-cell-names = "TS_CAL1";
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3300>;
 		avgslope = "4.3";

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -56,8 +56,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ffff7b8>;
-		ts-cal2-addr = <0x1ffff7c2>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -40,6 +40,18 @@
 				status = "disabled";
 			};
 		};
+
+		flash-controller@40022000 {
+			flash@1ffff700 {
+				nvmem-layout {
+					ts_cal2_otp: ts-cal2@c2 {
+						reg = <0xc2 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -92,6 +92,12 @@
 				/* maximum erase time(ms) for a 128K sector */
 				max-erase-time = <4000>;
 			};
+
+			st_nvm_user_otp: flash@1fff7800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7800 512>;
+				status = "disabled";
+			};
 		};
 
 		rcc: rcc@40023800 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -94,6 +94,39 @@
 				/* maximum erase time for a 2K sector */
 				max-erase-time = <40>;
 			};
+
+			/*
+			 * Device-unique information is stored
+			 * at the end of the System memory area.
+			 */
+			flash@1ffff700 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ffff700 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@b8 {
+						reg = <0xb8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@ba {
+						reg = <0xba 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@c2 {
+						reg = <0xc2 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -448,8 +448,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ffff7b8>;
-		ts-cal2-addr = <0x1ffff7c2>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -459,7 +459,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ffff7ba>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 18>;
 		status = "disabled";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -123,6 +123,52 @@
 				/* maximum erase time (ms) for a 128K sector */
 				max-erase-time = <4000>;
 			};
+
+			st_nvm_user_otp: flash@1fff7800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7800 512>;
+				status = "disabled";
+			};
+
+			/*
+			 * Device-specific information is found in NVM
+			 * after the documented end of the "OTP area".
+			 *
+			 * Note that we encompass the last 16 bytes that
+			 * RefMan documents as part of the "OTP area" to
+			 * obtain an aligned start address for this range,
+			 * which makes the `reg` property of children NVMEM
+			 * cells easier to read; these 16 bytes can't be
+			 * used to hold any data so this is a non-issue.
+			 */
+			flash@1fff7a00 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7a00 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@2a {
+						reg = <0x2a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@2c {
+						reg = <0x2c 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@2e {
+						reg = <0x2e 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40023800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -677,7 +677,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff7a2a>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -666,8 +666,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff7a2c>;
-		ts-cal2-addr = <0x1fff7a2e>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -997,8 +997,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ff0f44c>;
-		ts-cal2-addr = <0x1ff0f44e>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -151,6 +151,52 @@
 				/* maximum erase time (ms) for a 256K sector */
 				max-erase-time = <4000>;
 			};
+
+			st_nvm_user_otp: flash@1ff0f000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff0f000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/*
+			 * Device-specific information is found in NVM
+			 * after the documented end of the "OTP area".
+			 *
+			 * Note that we encompass the last 16 bytes that
+			 * RefMan documents as part of the "OTP area" to
+			 * obtain an aligned start address for this range,
+			 * which makes the `reg` property of children NVMEM
+			 * cells easier to read; these 16 bytes can't be
+			 * used to hold any data so this is a non-issue.
+			 */
+			flash@1ff0f400 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff0f400 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@4a {
+						reg = <0x4a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@4c {
+						reg = <0x4c 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@4e {
+						reg = <0x4e 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40023800 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1008,7 +1008,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ff0f44a>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -88,11 +88,6 @@
 		};
 	};
 
-	die_temp: dietemp {
-		ts-cal1-addr = <0x1ff07a2c>;
-		ts-cal2-addr = <0x1ff07a2e>;
-	};
-
 	vref: vref {
 		vrefint-cal-addr = <0x1ff07a2a>;
 	};

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -41,6 +41,51 @@
 			interrupts = <103 0>;
 			status = "disabled";
 		};
+
+		flash-controller@40023c00 {
+			/*
+			 * Delete OTP regions declared in root DTSI
+			 * which are not correct for this product line.
+			 */
+			/delete-node/ flash@1ff0f000;
+			/delete-node/ flash@1ff0f400;
+
+			st_nvm_user_otp: flash@1ff07800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff0f000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* c.f. root DTSI file - same comment applies */
+			flash@1ff07a00 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff07a00 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@2a {
+						reg = <0x2a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@2c {
+						reg = <0x2c 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@2e {
+						reg = <0x2e 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -87,8 +87,4 @@
 			};
 		};
 	};
-
-	vref: vref {
-		vrefint-cal-addr = <0x1ff07a2a>;
-	};
 };

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -127,6 +127,42 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <40>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* "Engineering bytes" */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@ca {
+						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -576,7 +576,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff75aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 13>;
 		status = "disabled";

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -565,8 +565,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff75a8>;
-		ts-cal2-addr = <0x1fff75ca>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -174,6 +174,42 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <25>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@ca {
+						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -856,8 +856,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff75a8>;
-		ts-cal2-addr = <0x1fff75ca>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -867,7 +867,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff75aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 18>;
 		status = "disabled";

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -709,7 +709,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x08fff810>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -697,8 +697,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x08fff814>;
-		ts-cal2-addr = <0x08fff818>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -136,6 +136,42 @@
 				/* maximum erase time(ms) for a 8K sector */
 				max-erase-time = <10>;
 			};
+
+			st_nvm_user_otp: flash@8fff000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x8fff000 DT_SIZE_K(2)>;
+				status = "disabled";
+			};
+
+			/* "Flash read-only area" */
+			flash@8fff800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x08fff800 DT_SIZE_K(2)>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@10 {
+						reg = <0x10 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@14 {
+						reg = <0x14 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@18 {
+						reg = <0x18 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		backup_sram: memory@40036400 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1278,8 +1278,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ff1e820>;
-		ts-cal2-addr = <0x1ff1e840>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1296,7 +1296,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ff1e860>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		vrefint-cal-resolution = <16>;
 		status = "disabled";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -162,6 +162,39 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Device-unique information is stored
+			 * at the end of the System memory area.
+			 */
+			flash@1ff1e000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff1e000 DT_SIZE_K(8)>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@820 {
+						reg = <0x820 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@840 {
+						reg = <0x840 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@860 {
+						reg = <0x860 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@58024400 {

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -203,8 +203,6 @@
 	};
 
 	die_temp: dietemp {
-		ts-cal1-addr = <0x08fff814>;
-		ts-cal2-addr = <0x08fff818>;
 		io-channels = <&adc2 18>;
 		ts-cal2-temp = <130>;
 	};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -22,6 +22,42 @@
 				/* maximum erase time for a 8K sector */
 				max-erase-time = <3>;
 			};
+
+			/*
+			 * Delete OTP region declared in root DTSI
+			 * which is not correct for this line.
+			 */
+			/delete-node/ flash@1ff1e000;
+
+			/* "FLASH read-only area" */
+			flash@8fff800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x08fff800 512>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@10 {
+						reg = <0x10 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@14 {
+						reg = <0x14 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@18 {
+						reg = <0x18 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -208,7 +208,6 @@
 	};
 
 	vref: vref {
-		vrefint-cal-addr = <0x08fff810>;
 		io-channels = <&adc2 19>;
 	};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -211,6 +211,36 @@
 				/* maximum erase time for a 8K sector */
 				max-erase-time = <3>;
 			};
+
+			/* "FLASH read-only area" */
+			flash@8fff800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x08fff800 512>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@10 {
+						reg = <0x10 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@14 {
+						reg = <0x14 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@18 {
+						reg = <0x18 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@58024400 {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1106,8 +1106,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x08fff814>;
-		ts-cal2-addr = <0x08fff818>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1125,7 +1125,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x08fff810>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		status = "disabled";
 		io-channels = <&adc1 17>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -390,8 +390,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ff8007a>;
-		ts-cal2-addr = <0x1ff8007e>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -127,6 +127,44 @@
 				/* maximum erase time(ms) for a 128B page */
 				max-erase-time = <4>;
 			};
+
+			/*
+			 * "User Option bytes" + "Factory Options"
+			 *
+			 * We really only care about "Factory Options" but
+			 * encompassing the Option bytes allows us to obtain
+			 * an aligned start address for this range, which
+			 * makes the `reg` property of children NVMEM cells
+			 * easier to read.
+			 */
+			flash@1ff80000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff80000 128>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@78 {
+						reg = <0x78 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@7a {
+						reg = <0x7a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@7e {
+						reg = <0x7e 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -401,7 +401,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ff80078>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -628,7 +628,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1ff800f8>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -121,6 +121,44 @@
 				 */
 				max-erase-time = <4>;
 			};
+
+			/*
+			 * "Option bytes" + "Factory information"
+			 *
+			 * We really only care about "Factory information" but
+			 * encompassing the Option bytes allows us to obtain
+			 * an aligned start address for this range, which
+			 * makes the `reg` property of children NVMEM cells
+			 * easier to read.
+			 */
+			flash@1ff80000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1ff80000 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					vrefint_otp: vrefint@f8 {
+						reg = <0xf8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal1_otp: ts-cal1@fa {
+						reg = <0xfa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@fe {
+						reg = <0xfe 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40023800 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -617,8 +617,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1ff800fa>;
-		ts-cal2-addr = <0x1ff800fe>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -599,7 +599,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff75aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -588,8 +588,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff75a8>;
-		ts-cal2-addr = <0x1fff75ca>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -140,6 +140,42 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <25>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@ca {
+						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -873,7 +873,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0bfa05aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -151,6 +151,42 @@
 				 */
 				max-erase-time = <25>;
 			};
+
+			st_nvm_user_otp: flash@bfa0000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0000 512>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@bfa0500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@ca {
+						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -862,8 +862,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0bfa05a8>;
-		ts-cal2-addr = <0x0bfa05ca>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -130,6 +130,42 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <40>;
 			};
+
+			st_nvm_user_otp: flash@1fff6800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff6800 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* "Non-user area" */
+			flash@1fff6c00 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff6c00 DT_SIZE_K(5)>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@268 {
+						reg = <0x268 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@28a {
+						reg = <0x28a 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@2a4 {
+						reg = <0x2a4 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40021000 {

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -106,6 +106,42 @@
 				/* maximum erase time(ms) for a 4KB page */
 				max-erase-time = <14>;
 			};
+
+			st_nvm_user_otp: flash@bfa0000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0000 512>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@bfa0500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0500 2816>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@210 {
+						reg = <0x210 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@242 {
+						reg = <0x242 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@2a5 {
+						reg = <0x2a5 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@40030c00 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1056,8 +1056,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0bfa0710>;
-		ts-cal2-addr = <0x0bfa0742>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -176,6 +176,42 @@
 				/* maximum erase time(ms) for a 8K sector */
 				max-erase-time = <5>;
 			};
+
+			st_nvm_user_otp: flash@bfa0000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0000 512>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@bfa0500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x0bfa0500 6912>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@210 {
+						reg = <0x210 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@242 {
+						reg = <0x242 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@2a5 {
+						reg = <0x2a5 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@46020c00 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1068,7 +1068,7 @@
 
 	vref1: vref_1 {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0bfa07a5>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		vrefint-cal-resolution = <14>;
 		io-channels = <&adc1 0>;
@@ -1077,7 +1077,7 @@
 
 	vref4: vref_4 {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0bfa07a5>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3000>;
 		vrefint-cal-resolution = <14>;
 		io-channels = <&adc4 0>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -610,7 +610,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff75aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3600>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -161,6 +161,42 @@
 				/* maximum erase time(ms) for a 4K sector */
 				max-erase-time = <25>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@ca {
+						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@58000000 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -599,8 +599,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff75a8>;
-		ts-cal2-addr = <0x1fff75ca>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -131,6 +131,30 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			st_nvm_user_otp: flash@10001800 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x10001800 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@10001e00 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x10001e00 256>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_c30_otp: c30@60 {
+						reg = <0x60 0x4>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
+
 			flash0: flash@10040000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				write-block-size = <4>;

--- a/dts/arm/st/wb0/stm32wb05.dtsi
+++ b/dts/arm/st/wb0/stm32wb05.dtsi
@@ -10,6 +10,18 @@
 	soc {
 		compatible = "st,stm32wb05", "st,stm32wb0", "simple-bus";
 
+		flash-controller@40001000 {
+			flash@10001e00 {
+				nvmem-layout {
+					ts_tck_otp: tck@5c {
+						reg = <0x5c 0x4>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
+		};
+
 		timers2: timers@40002000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40002000 DT_SIZE_K(1)>;

--- a/dts/arm/st/wb0/stm32wb07.dtsi
+++ b/dts/arm/st/wb0/stm32wb07.dtsi
@@ -14,6 +14,16 @@
 			flash0: flash@10040000 {
 				reg = <0x10040000 DT_SIZE_K(256)>;
 			};
+
+			flash@10001e00 {
+				nvmem-layout {
+					ts_c85_otp: c85@68 {
+						reg = <0x68 0x4>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		i2c2: i2c@41001000 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -635,6 +635,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -17,6 +17,41 @@
 #include <freq.h>
 #include <mem.h>
 
+/*
+ * The "OTP area" and "Engineering bytes" layout
+ * in both STM32WBA5x and STM32WBA6x lines SoCs
+ * seems identical... except the areas don't have
+ * the same start address!
+ *
+ * To avoid duplication, we expect the DTSI files
+ * for STM32WBA6x (e.g., stm32wba65.dtsi) - which
+ * will #include this file - to #define the macro
+ * FLASH_LAYOUT_STM32WBA6X such that we know what
+ * base address to use for the regions. Note that
+ * we cannot use the CONFIG_SOC_STM32WBAxx option
+ * because DTS is processed before Kconfig.
+ */
+#ifdef FLASH_LAYOUT_STM32WBA6X
+/*
+ * This doesn't match the value in RM0515 Table 40
+ * but using the same offset from OTP_BASE as on
+ * STM32WBA5x results in the "Engineering bytes"
+ * area having the same layout, allowing us to
+ * define the NVMEM cells only once.
+ */
+#define ENGI_BYTES_BASE	bfa0500
+#define USER_OTP_BASE	bfa0000
+#else /* STM32WBA5x SoC */
+#define ENGI_BYTES_BASE	bf90500
+#define USER_OTP_BASE	bf90000
+#endif /* FLASH_LAYOUT_STM32WBA6X */
+
+/*
+ * "Engineering bytes" area ends at USER_OTP_BASE+0x4000
+ * on both STM32WBA5x and STM32WBA6x product lines.
+ */
+#define ENGI_BYTES_SIZE ((DT_ADDR(USER_OTP_BASE) + 0x4000) - DT_ADDR(ENGI_BYTES_BASE))
+
 / {
 	chosen {
 		zephyr,entropy = &rng;
@@ -148,6 +183,42 @@
 				erase-block-size = <8192>;
 				/* maximum erase time(ms) for a 8K sector */
 				max-erase-time = <5>;
+			};
+
+			st_nvm_user_otp: flash@USER_OTP_BASE {
+				compatible = "st,stm32-nvm-otp";
+				reg = <DT_ADDR(USER_OTP_BASE) 512>;
+				status = "disabled";
+			};
+
+			/* "Engineering bytes" */
+			flash@ENGI_BYTES_BASE {
+				compatible = "st,stm32-nvm-otp";
+				reg = <DT_ADDR(ENGI_BYTES_BASE) ENGI_BYTES_SIZE>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@210 {
+						reg = <0x210 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@242 {
+						reg = <0x242 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@2a5 {
+						reg = <0x2a5 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
 			};
 		};
 

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -9,9 +9,4 @@
 	soc {
 		compatible = "st,stm32wba52", "st,stm32wba", "simple-bus";
 	};
-
-	die_temp: dietemp {
-		ts-cal1-addr = <0x0bf90710>;
-		ts-cal2-addr = <0x0bf90742>;
-	};
 };

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define FLASH_LAYOUT_STM32WBA6X /* see stm32wba.dtsi */
 #include <st/wba/stm32wba55.dtsi>
 
 / {

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -129,11 +129,6 @@
 		#phy-cells = <0>;
 		status = "disabled";
 	};
-
-	die_temp: dietemp {
-		ts-cal1-addr = <0x0bfa0710>;
-		ts-cal2-addr = <0x0bfa0742>;
-	};
 };
 
 &pwr {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -604,7 +604,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1fff75aa>;
+		nvmem-cells = <&vrefint_otp>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 13>;
 		status = "disabled";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -593,8 +593,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1fff75a8>;
-		ts-cal2-addr = <0x1fff75c8>;
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -133,6 +133,42 @@
 				/* maximum erase time(ms) for a 2K sector */
 				max-erase-time = <25>;
 			};
+
+			st_nvm_user_otp: flash@1fff7000 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7000 DT_SIZE_K(1)>;
+				status = "disabled";
+			};
+
+			/* Undocumented/unnamed RO area */
+			flash@1fff7500 {
+				compatible = "st,stm32-nvm-otp";
+				reg = <0x1fff7500 768>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ts_cal1_otp: ts-cal1@a8 {
+						reg = <0xa8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vrefint_otp: vrefint@aa {
+						reg = <0xaa 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					ts_cal2_otp: ts-cal2@c8 {
+						reg = <0xc8 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+				};
+			};
 		};
 
 		rcc: rcc@58000000 {

--- a/dts/bindings/otp/st,stm32-nvm-otp.yaml
+++ b/dts/bindings/otp/st,stm32-nvm-otp.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32 embedded NVM OTP
+
+description: |
+  The NVM embedded in STM32 SoCs contains One-Time-Programmable regions
+  in addition to the "regular" region which can be programmed at will.
+  The OTP regions are usually provisioned by STMicroelectronics during
+  manufacturing (which makes them read-only areas). Some products also
+  provide an "OTP for user data" area which can be written in the field.
+
+  Refer to your product's Reference Manual and Data Sheet for more details.
+
+compatible: "st,stm32-nvm-otp"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+    description: |
+      Start address and size of NVM OTP area
+
+      Note: for User OTP area nodes, "locking bits" that may be found at the end
+      of the OTP area must not be included in the `size` part of this property.

--- a/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
@@ -3,13 +3,18 @@
 
 description: Common fields for STM32 family TEMP production calibrated sensors
 
-include: [base.yaml, "st,stm32-temp-common.yaml"]
+include: [base.yaml, nvmem-consumer.yaml, "st,stm32-temp-common.yaml"]
 
 properties:
-  ts-cal1-addr:
-    type: int
+  nvmem-cells:
     required: true
-    description: Address of TS_CAL1 calibration parameter
+    description: |
+      NVMEM cell(s) containing sensor calibration parameter(s).
+
+      Refer to description of `nvmem-cell-names` for details.
+
+  nvmem-cell-names:
+    required: true
 
   ts-cal1-temp:
     type: int

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -13,10 +13,14 @@ include:
       - ntc
 
 properties:
-  ts-cal2-addr:
-    type: int
-    required: true
-    description: Address of TS_CAL2 calibration parameter
+  nvmem-cell-names:
+    description: |
+      Two NVMEM cells must be provided:
+        - TS_CAL1
+        - TS_CAL2
+
+      Each cell corresponds to the eponymous calibration parameter.
+    enum: ["TS_CAL1", "TS_CAL2"]
 
   ts-cal2-temp:
     type: int

--- a/dts/bindings/sensor/st,stm32-vref.yaml
+++ b/dts/bindings/sensor/st,stm32-vref.yaml
@@ -5,15 +5,14 @@ description: STM32 VREF+.
 
 compatible: "st,stm32-vref"
 
-include: sensor-device.yaml
+include: [nvmem-consumer.yaml, sensor-device.yaml]
 
 properties:
-  vrefint-cal-addr:
-    type: int
+  nvmem-cells:
     required: true
     description: |
-      Device engineering bytes address containing the factory-measured
-      calibration bandgap voltage (VREFINT_CAL).
+      One entry corresponding to the VREFINT_CAL calibration parameter
+      (factory-measured calibration bandgap voltage) must be provided.
 
   vrefint-cal-mv:
     type: int

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -7,3 +7,11 @@ description: |
 compatible: "st,stm32c0-temp-cal"
 
 include: "st,stm32-temp-cal-common.yaml"
+
+properties:
+  nvmem-cell-names:
+    description: |
+      One NVMEM cell must be provided: TS_CAL1
+
+      This cell corresponds to the eponymous calibration parameter.
+    enum: ["TS_CAL1"]


### PR DESCRIPTION
Implement an OTP driver allowing to read data from OTP areas in STM32 Non-Volatile Memory:
* Read-only area provisioned by ST during manufacturing
  * The exact naming (and location) varies between series:
    * unnamed, at the end of `System memory`
    * unnamed, after User OTP (see below)
    * `Flash read-only area`
    * `Factory Options`
    * `Factory information`
    * `Engineering bytes`
  * This is notably the area where ADC sensors calibration data is written
  * I have attempted to keep consistency across series when possible
    * Even though this is not official documented, one can easily infer that some series are similar/identical to others
* `OTP for user data` area (not found in all series)
  * Left unprogrammed during manufacturing; can be written once in the field
    * ***The `program` operation is not supported as part of this PR*** (because SoC-specific)
  * Nodelabel **`st_nvm_otp`** is attached to this area
    * Allows easy (and portable-ish) declaration of custom OTP layout (as NVMEM cells) in board DTS or overlays

To demonstrate proper operation, the ADC sensor drivers `stm32_vref` and `stm32_temp` are migrated to obtain their calibration data using NVMEM cell nodes instead of raw addresses.

Depends (weakly) on #102971