### PR TITLE
samples: sensor: stream_drdy: fix dt-bindings enum names in stream_drdy sample

### DIFF
--- a/samples/sensor/stream_drdy/boards/sensortile_box_pro.overlay
+++ b/samples/sensor/stream_drdy/boards/sensortile_box_pro.overlay
@@ -20,7 +20,7 @@
 	lsm6dsv16x_0: lsm6dsv16x@0 {
 		compatible = "st,lsm6dsv16x";
 
-		accel-odr = <LSM6DSV16X_DT_ODR_AT_960Hz>;
+		accel-odr = <LSM6DSVXXX_DT_ODR_AT_960Hz>;
 		accel-range = <LSM6DSV16X_DT_FS_16G>;
 	};
 };


### PR DESCRIPTION

The accelerometer ODR enum was using a sensor-specific macro name LSM6DSV16X_DT_ODR_AT_960Hz which is not
defined for Devicetree usage. This is corrected to the generic `LSM6DSVXXX_DT_ODR_AT_960Hz` enum defined
in zephyr/dt-bindings/sensor/lsm6dsvxxx.h.



To reproduce on lastest main : 
`west build -p -b sensortile_box_pro samples/sensor/stream_drdy -T sample.sensor.stream_drdy
`

Missing to add this in  PR https://github.com/zephyrproject-rtos/zephyr/pull/102636
