### PR TITLE
stm32: tests: lib: cpp: cxx: exclude nucleo_wb07 platform

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -4,6 +4,8 @@ common:
   integration_platforms:
     - mps2/an385
     - qemu_cortex_a53
+  platform_exclude:
+    - nucleo_wb07cc
 
 tests:
   cpp.main.minimal:


### PR DESCRIPTION
Power Management is not yet supported on nucleo_wb07 platform which is required for this test.
This change help to skip/avoid build error generated by cmake `#error "PM is not supported yet for WB06/WB07"`


To reproduce:  
- `west build -p -b nucleo_wb07cc/stm32wb07 tests/lib/cpp/cxx -T cpp.main.newlib_nano`