### PR TITLE
stm32:  tests: drivers: memc: ram: boards:  delete mac node to fix build error 

### DIFF
--- a/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
@@ -1,4 +1,5 @@
 /delete-node/ &sram2;
+/delete-node/ &mac;
 
 /* D2 domain, AHB SRAM */
 &sram1 {


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/zephyr/commit/b0b306ca24c170deea9a3aad42b57998681c9fdc from PR #100910 assigns SRAM2 memory regions to the MAC node, which does not exist because SRAM2 was deleted and combined with SRAM1 to increase the memory needed for the test to run.


To reproduce: 

- `west build -p -b stm32h735g_disco/stm32h735xx tests/drivers/memc/ram -T drivers.memc`