### PR TITLE
dts: bindings: can: nxp: flexcan-fd: remove number-of-mb-fd property

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -176,8 +176,8 @@ Controller Area Network (CAN)
   * :kconfig:option:`CONFIG_CAN_XMC4XXX_MAX_FILTERS` for :dtcompatible:`infineon,xmc4xxx-can-node`
 
 * Replaced Kconfig option ``CONFIG_CAN_MAX_MB`` for :dtcompatible:`nxp,flexcan` and
-  :dtcompatible:`nxp,flexcan-fd` with per-instance ``number-of-mb`` and
-  ``number-of-mb-fd`` devicetree properties (:github:`99483`).
+  :dtcompatible:`nxp,flexcan-fd` with per-instance a ``number-of-mb`` devicetree property
+  (:github:`99483`).
 
 * The :dtcompatible:`nxp,flexcan` ``clk-source`` devicetree property, if present, now automatically
   selects between the named input clocks ``clksrc0`` and ``clksrc1`` for use as the CAN protocol

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1498,10 +1498,11 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 #define FLEXCAN_DRIVER_API(id) mcux_flexcan_driver_api
 #endif /* !CONFIG_CAN_MCUX_FLEXCAN_FD */
 
+/* Each 512-byte RAM region can contain up to 32 x 8-byte MBs or 7 x 64-byte MBs (CAN FD). */
 #define FLEXCAN_INST_NUMBER_OF_MB(id)						\
 	COND_CODE_1(UTIL_AND(IS_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD),		\
 			DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT)),	\
-		(DT_INST_PROP(id, number_of_mb_fd)),				\
+		((DT_INST_PROP(id, number_of_mb) * 7U) / 32U),			\
 		(DT_INST_PROP(id, number_of_mb)))
 
 /*

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -322,7 +322,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -335,7 +334,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -348,7 +346,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -361,7 +358,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -374,7 +370,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -562,7 +562,6 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			number-of-mb = <32>;
-			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 
@@ -573,7 +572,6 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 			number-of-mb = <32>;
-			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxe245.dtsi
+++ b/dts/arm/nxp/nxp_mcxe245.dtsi
@@ -47,7 +47,6 @@
 
 &flexcan0 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {

--- a/dts/arm/nxp/nxp_mcxe246.dtsi
+++ b/dts/arm/nxp/nxp_mcxe246.dtsi
@@ -47,12 +47,10 @@
 
 &flexcan0 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {

--- a/dts/arm/nxp/nxp_mcxe247.dtsi
+++ b/dts/arm/nxp/nxp_mcxe247.dtsi
@@ -49,15 +49,12 @@
 
 &flexcan0 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -924,7 +924,6 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		number-of-mb = <32>;
-		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 
@@ -935,7 +934,6 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
-		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -118,7 +118,6 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
-		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1106,7 +1106,6 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		number-of-mb = <32>;
-		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -990,7 +990,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -788,7 +788,6 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
-		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -801,7 +800,6 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
-		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -814,7 +812,6 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
-		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -928,7 +928,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -941,7 +940,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -954,7 +952,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -66,7 +66,6 @@
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
@@ -76,7 +75,6 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -89,7 +89,6 @@
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
@@ -99,7 +98,6 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {
@@ -109,5 +107,4 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
-	number-of-mb-fd = <7>;
 };

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -479,7 +479,6 @@
 			interrupt-names = "ored", "ored_0_31_mb",
 					  "ored_32_63_mb", "ored_64_95_mb";
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -490,7 +489,6 @@
 			interrupts = <113 0>, <114 0>, <115 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -501,7 +499,6 @@
 			interrupts = <116 0>, <117 0>, <118 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -512,7 +509,6 @@
 			interrupts = <119 0>, <120 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
-			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 
@@ -523,7 +519,6 @@
 			interrupts = <121 0>, <122 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
-			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 
@@ -534,7 +529,6 @@
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
-			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32k566.dtsi
+++ b/dts/arm/nxp/nxp_s32k566.dtsi
@@ -552,7 +552,6 @@
 			reg = <0x42174000 0x4000>;
 			clocks = <&clock NXP_S32_LPE_FLEXCAN_PE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -562,7 +561,6 @@
 			reg = <0x40290000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN0_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -572,7 +570,6 @@
 			reg = <0x40294000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN1_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -582,7 +579,6 @@
 			reg = <0x40298000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN2_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -592,7 +588,6 @@
 			reg = <0x4029c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN3_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -602,7 +597,6 @@
 			reg = <0x402a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN4_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -612,7 +606,6 @@
 			reg = <0x402a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN5_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -622,7 +615,6 @@
 			reg = <0x402a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN6_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -632,7 +624,6 @@
 			reg = <0x402ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN7_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -642,7 +633,6 @@
 			reg = <0x406b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN8_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -652,7 +642,6 @@
 			reg = <0x406b4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN9_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -662,7 +651,6 @@
 			reg = <0x406ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN10_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -672,7 +660,6 @@
 			reg = <0x4089c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN11_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -682,7 +669,6 @@
 			reg = <0x408a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN12_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -692,7 +678,6 @@
 			reg = <0x408a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN13_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -702,7 +687,6 @@
 			reg = <0x408a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN14_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -712,7 +696,6 @@
 			reg = <0x408ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN15_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -722,7 +705,6 @@
 			reg = <0x408b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN16_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
-			number-of-mb-fd = <21>;
 			interrupt-names = "ored", "ored_0_96_mb";
 		};
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -756,7 +756,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -772,7 +771,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -788,7 +786,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -804,7 +801,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -820,7 +816,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -836,7 +831,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -852,7 +846,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -868,7 +861,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -884,7 +876,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -900,7 +891,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -916,7 +906,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -932,7 +921,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -948,7 +936,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -964,7 +951,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -980,7 +966,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -996,7 +981,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1012,7 +996,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1028,7 +1011,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1044,7 +1026,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1060,7 +1041,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1076,7 +1056,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1092,7 +1071,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1108,7 +1086,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1124,7 +1101,6 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
-			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -200,7 +200,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";
@@ -217,7 +216,6 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
-			number-of-mb-fd = <14>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -424,7 +424,6 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
-		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -439,7 +438,6 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
-		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -11,12 +11,6 @@ compatible: "nxp,flexcan-fd"
 include: ["nxp,flexcan.yaml", "can-fd-controller.yaml", "pinctrl-device.yaml",
           "nxp,rdc-policy.yaml"]
 
-properties:
-  number-of-mb-fd:
-    type: int
-    required: true
-    description: Number of 64-byte payload message buffers FlexCAN FD instance supported
-
 examples:
   - |
     flexcan3: can@401d8000 {
@@ -29,7 +23,6 @@ examples:
       clock-names = "clksrc1";
       clk-source = <1>;
       number-of-mb = <64>;
-      number-of-mb-fd = <14>;
       pinctrl-0 = <&pinmux_flexcan3>;
       pinctrl-names = "default";
 

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -40,8 +40,15 @@ properties:
 
   number-of-mb:
     type: int
+    enum:
+      - 16
+      - 32
+      - 64
+      - 96
+      - 128
     required: true
-    description: Number of 8-byte payload message buffers FlexCAN instance supported
+    description: |
+      Number of 8-byte sized message buffers supported by this FlexCAN instance.
 
 examples:
   - |


### PR DESCRIPTION
Remove the "number-of-mb-fd" property from the NXP FlexCAN FD binding. The number of Message Buffers (MBs) supported by a given FlexCAN instance is always specified in 8-byte sized MBs using the "number-of-mb" property present in the "nxp,flexcan" binding.

The fact that the Zephyr FlexCAN shim driver sets the MB size to 64-byte when CAN FD is enabled is purely a software construct which should not be described in devicetree.

Each 512 byte message buffer RAM region can either contain up to 32 x 8-byte MBs or 7 x 64-byte MBs, so just calculate the number of CAN FD MBs at driver build time.

The FlexCAN IP can either support 16 (CAN classic only), 32, 64, 96, or 128 8-byte MBs, so limit the property to these values.

This was found during development of an alternative, Zephyr-native FlexCAN driver.