### PR TITLE
drivers: mspi: fix typo in brief description

### DIFF
--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -7,7 +7,7 @@
 /**
  * @file
  * @ingroup mspi_interface
- * @brief Main header file for MSPI (Multi-Master Serial Peripheral Interface) driver API.
+ * @brief Main header file for MSPI (Multi-bit Serial Peripheral Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_MSPI_H_


### PR DESCRIPTION
mspi is the multi-bit SPI api and not the
multi-master SPI api.