### PR TITLE
runners: auto-select build artifact when --file-type is specified

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -705,6 +705,16 @@ def get_runner_config(build_dir, yaml_path, runners_yaml, args=None):
         # OTHER and let the runner deal with it
         return FileType.OTHER
 
+    file_path = config('file')
+    file_type_arg = getattr(args, 'file_type', None)
+    if file_type_arg and not file_path:
+        file_path = output_file(file_type_arg.lower())
+        if file_path:
+            log.inf(f'Using {file_path}')
+        else:
+            log.die(f'--file-type {file_type_arg} specified but no '
+                    f'{file_type_arg} build artifact found')
+
     return RunnerConfig(build_dir,
                         yaml_config['board_dir'],
                         output_file('elf'),
@@ -713,7 +723,7 @@ def get_runner_config(build_dir, yaml_path, runners_yaml, args=None):
                         output_file('bin'),
                         output_file('uf2'),
                         output_file('mot'),
-                        config('file'),
+                        file_path,
                         filetype('file_type'),
                         config('gdb'),
                         config('openocd'),

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -583,7 +583,8 @@ class ZephyrBinaryRunner(abc.ABC):
                                 help="path to binary file")
             parser.add_argument('-t', '--file-type',
                                 dest='file_type',
-                                help="type of binary file")
+                                help="type of binary file. If --file is not given, "
+                                     "selects the build artifact (hex, bin, elf)")
         else:
             parser.add_argument('-f', '--file', help=argparse.SUPPRESS)
             parser.add_argument('-t', '--file-type', help=argparse.SUPPRESS)


### PR DESCRIPTION
When `--file-type` is provided without `--file`, automatically select the corresponding build artifact (zephyr.hex, zephyr.bin, or zephyr.elf) instead of requiring the user to specify both flags.

See how current runners use `--file`:

`jlink.py`:	Always checks if self.file is not None before using file_type (lines 395, 436)
`silabs_commander.py`:	Always checks if self.file is not None before using file_type (line 157)
`linkserver.py`:	Stores file_type but never uses it
`spsdk.py`:	Stores file_type but never uses it
`openocd.py`:	Checks if self.file is not None first (line 305), then falls back to using image_type to select from build artifacts

The only runner that does not check `--file`:
`probe_rs.py`: Uses file_type to set the format even when self.file is None
