### PR TITLE
doc: Add links to the generated Kconfig symbols from devicetree

### DIFF
--- a/doc/build/dts/dt-vs-kconfig.rst
+++ b/doc/build/dts/dt-vs-kconfig.rst
@@ -70,6 +70,8 @@ There are **exceptions** to these rules:
   instance of a hardware device to be used for a particular purpose. An example
   of this is selecting a particular UART for use as the system's console.
 
+.. _auto-dts-kconfig:
+
 Automatic Kconfig symbols from devicetree
 *****************************************
 

--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -633,6 +633,7 @@ argument, as follows:
    A variable :samp:`DT_COMPAT_{VND_MY_DEVICE} := {vnd,my-device}`
    is automatically created by Zephyr for every ``compatible`` found
    in Devicetree bindings; there is no need to define such variables.
+   See :ref:`auto-dts-kconfig` for details.
 
 Checking changes in menuconfig/guiconfig
 ****************************************

--- a/doc/contribute/style/kconfig.rst
+++ b/doc/contribute/style/kconfig.rst
@@ -64,11 +64,13 @@ Naming Conventions
      because one can filter by a scope keyword.
 
 * When the enabling symbol is dependent on a devicetree node, consider
-  depending on the automatically created ``DT_HAS_<node>_ENABLED`` symbol.
+  depending on the :ref:`automatically created <auto-dts-kconfig>`
+  ``DT_HAS_<node>_ENABLED`` symbol.
 
 * When building complex expressions based on devicetree node compatibles,
-  use the automatically defined :samp:`DT_COMPAT_{VND_DEVICE}` instead
-  of defining a variable equal to :samp:`{vnd,device}` manually.
+  use the :ref:`automatically defined <auto-dts-kconfig>`
+  :samp:`DT_COMPAT_{VND_DEVICE}` instead of defining a variable equal to
+  :samp:`{vnd,device}` manually.
 
 The specific formats by subtree:
 


### PR DESCRIPTION
A couple paragraphs refer to automatically generated Kconfig symbols, add references to detailed information.

Previews:
https://builds.zephyrproject.io/zephyr/pr/102985/docs/contribute/style/kconfig.html#naming-conventions
https://builds.zephyrproject.io/zephyr/pr/102985/docs/build/kconfig/tips.html#commas-in-macro-arguments