### PR TITLE
versal2_rpu board fixes

### DIFF
--- a/boards/amd/versal2_rpu/versal2_rpu.dts
+++ b/boards/amd/versal2_rpu/versal2_rpu.dts
@@ -25,6 +25,12 @@
 		compatible = "mmio-sram";
 		reg = <0x30000 0x7ffd0000>;
 	};
+
+	/* RPU-local TCM address (system address: 0xEBA00000) */
+	tcm: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(64)>;
+	};
 };
 
 &ocm {

--- a/soc/xlnx/versal2/Kconfig.defconfig
+++ b/soc/xlnx/versal2/Kconfig.defconfig
@@ -11,7 +11,7 @@ if SOC_AMD_VERSAL2_RPU
 config NUM_IRQS
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts
-	default 256
+	default 288
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)


### PR DESCRIPTION
This pull request does the below
--> Add tcm node
--> fix NUM_IRQS to cover all hardware interrupts