### PR TITLE
boards: amd: versalnet_rpu: fix timer init sequence in xsdb.cfg

### DIFF
--- a/boards/amd/versalnet_rpu/support/xsdb.cfg
+++ b/boards/amd/versalnet_rpu/support/xsdb.cfg
@@ -25,8 +25,8 @@ proc load_image args  {
 	after 100
 	# Configure timestamp generator to run global timer gracefully
 	# Ideally these registers should be set from bootloader (cdo)
-	mwr -force 0xeb5b0000 0x1
 	mwr -force 0xeb5b0020 100000000
+	mwr -force 0xeb5b0000 0x1
 	after 100
 
 	targets -set -nocase -filter {name =~ "*Cortex-R52 #0.0"}


### PR DESCRIPTION
Configure the timestamp generator frequency before enabling the timer to ensure proper initialization order.