### PR TITLE
boards: st: steval_stwinbx1: add missing accel0 node alias

### DIFF
--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -55,6 +55,7 @@
 	};
 
 	aliases {
+		accel0 = &iis2dlpc;
 		led0 = &green_led;
 		led1 = &orange_led;
 		pwm-led0 = &green_pwm_led;


### PR DESCRIPTION

This PR fixes  the build error encountered when running `sample.sensor.accel_trig.generic-tap` sample scenario  on steval_stwinbx1 board: 

`error (Build failure - error: '__device_dts_ord_DT_N_ALIAS_accel0_ORD' undeclared (first use in this function))`


To reproduce : 

- west build -p -b steval_stwinbx1/stm32u585xx samples/sensor/accel_trig -T sample.sensor.accel_trig.generic-tap