### PR TITLE
drivers: serial: pl011: fix SBSA IRQ config function reference

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -787,7 +787,8 @@ DT_INST_FOREACH_STATUS_OKAY(PL011_INIT)
 	                                                                                           \
 	static struct pl011_config pl011_cfg_sbsa_##n = {                                          \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),                                              \
-		IRQ_CONFIG_FUNC_INIT(n)                                                            \
+		IF_ENABLED(PL011_NODE_USE_IRQ(n),                                                  \
+			   (.irq_config_func = pl011_irq_config_func_sbsa_##n,))		   \
 	};
 
 #define PL011_SBSA_INIT(n)					\


### PR DESCRIPTION
Commit 45cde341dc9e ("drivers: serial: pl011: Allows mixed IRQ settings.") introduced a bug where PL011_SBSA_CONFIG_PORT defines the IRQ config function as pl011_irq_config_func_sbsa_##n but IRQ_CONFIG_FUNC_INIT(n) references pl011_irq_config_func_##n, causing a compilation error when building for boards with SBSA UART and interrupt support enabled.

Fix by using the correct function name with the _sbsa_ suffix in the SBSA config port macro.

Fixes: 45cde341dc9e ("drivers: serial: pl011: Allows mixed IRQ settings.")

This fixes a regression introduced in PR #101882 where the SBSA UART variant fails to compile when interrupts are enabled.

Below pull requests CI tests are failing due this issue
https://github.com/zephyrproject-rtos/zephyr/pull/102990
https://github.com/zephyrproject-rtos/zephyr/pull/102989
https://github.com/zephyrproject-rtos/zephyr/pull/102988