### PR TITLE
twister: Add YAML config file support in pytest-harness - serialize parameters between Twister and pytest

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -40,7 +40,7 @@ integration.
 
 If ``harness: pytest`` is used, twister delegates the test execution to pytest, by calling it as
 a subprocess. Required parameters (such as build directory, device to be used, etc.) are passed
-through a CLI command. When pytest is done, twister looks for a pytest report (results.xml) and
+through a YAML configuration file. When pytest is done, twister looks for a pytest report (results.xml) and
 sets the test result accordingly.
 
 How to create a pytest test
@@ -296,6 +296,32 @@ How to rerun locally pytest tests without rebuilding application by Twister?
    command. Another way is running Twister with highest verbosity level (``-vv``) and then
    copy-pasting from logs command dedicated for spawning pytest (log started by ``Running pytest
    command: ...``).
+
+   First, run scenario with Twister:
+
+   .. code-block:: console
+
+      $ west twister -vv -ll debug -T samples/subsys/testsuite/pytest/shell \
+      -s sample.pytest.shell --device-testing -p nrf54l15dk/nrf54l15/cpuapp --device-serial \
+      /dev/ttyACM1 --west-flash=--erase
+
+   Twister automatically generates a configuration file ``twister_pytest_config.yaml`` in the build
+   directory containing all test parameters including device configuration etc.
+
+   Then export the required PYTHONPATH environment variable if not already set:
+
+   .. code-block:: console
+
+      $ export PYTHONPATH=$ZEPHYR_BASE/scripts/pylib/pytest-twister-harness/src
+
+   Finally, run pytest command:
+
+   .. code-block:: console
+
+      $ pytest -s -v -p twister_harness.plugin \
+      --twister-config=twister-out/.../sample.pytest.shell/twister_pytest_config.yaml \
+      samples/subsys/testsuite/pytest/shell/pytest
+
 
 Is this possible to run pytest tests in parallel?
 =================================================

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
@@ -4,6 +4,17 @@
 
 # flake8: noqa
 
+import os
+import sys
+
+# Add the directory to PYTHONPATH
+zephyr_base = os.getenv("ZEPHYR_BASE")
+if zephyr_base:
+    sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "twister"))
+    sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "build_helpers"))
+else:
+    raise OSError("ZEPHYR_BASE environment variable is not set")
+
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.helpers.mcumgr import MCUmgr, MCUmgrBle
 from twister_harness.helpers.shell import Shell

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -51,7 +51,7 @@ class HardwareAdapter(DeviceAdapter):
 
         command = [
             self.west,
-            self.device_config.west_flash_cmd,
+            self.device_config.west_flash_cmd or 'flash',
             '--no-rebuild',
             '--build-dir',
             str(self.device_config.build_dir),

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -88,8 +88,8 @@ def shell(dut: DeviceAdapter) -> Shell:
 
 
 @pytest.fixture(scope='session')
-def required_build_dirs(request: pytest.FixtureRequest) -> list[str]:
-    return request.config.getoption('--required-build')
+def required_build_dirs(twister_harness_config: TwisterHarnessConfig) -> list[str]:
+    return twister_harness_config.test_params.required_builds
 
 
 @pytest.fixture()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
@@ -3,15 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import os
-import sys
 import logging
 
 from pathlib import Path
-
-ZEPHYR_BASE = os.environ['ZEPHYR_BASE']
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'build_helpers'))
-
 from domains import Domains
 
 logger = logging.getLogger(__name__)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -32,6 +32,11 @@ def pytest_addoption(parser: pytest.Parser):
         type='bool'
     )
     twister_harness_group.addoption(
+        '--twister-config',
+        metavar='PATH',
+        help='File with test parameters in YAML format. Also activates Twister harness plugin.'
+    )
+    twister_harness_group.addoption(
         '--base-timeout',
         type=float,
         default=60.0,
@@ -150,27 +155,25 @@ def pytest_configure(config: pytest.Config):
     if config.getoption('help'):
         return
 
-    if not (config.getoption('twister_harness') or config.getini('twister_harness')):
+    if config.getoption('collectonly'):
+        return
+
+    if not (
+        config.getoption('twister_harness')
+        or config.getini('twister_harness')
+        or config.getoption('twister_config')
+    ):
         return
 
     _normalize_paths(config)
-    _validate_options(config)
 
     config.twister_harness_config = TwisterHarnessConfig.create(config)  # type: ignore
-
-
-def _validate_options(config: pytest.Config) -> None:
-    if not config.option.build_dir:
-        raise Exception('--build-dir has to be provided')
-    if not os.path.isdir(config.option.build_dir):
-        raise Exception(f'Provided --build-dir does not exist: {config.option.build_dir}')
-    if not config.option.device_type:
-        raise Exception('--device-type has to be provided')
 
 
 def _normalize_paths(config: pytest.Config) -> None:
     """Normalize paths provided by user via CLI"""
     config.option.build_dir = _normalize_path(config.option.build_dir)
+    config.option.twister_config = _normalize_path(config.option.twister_config)
     config.option.pre_script = _normalize_path(config.option.pre_script)
     config.option.post_script = _normalize_path(config.option.post_script)
     config.option.post_flash_script = _normalize_path(config.option.post_flash_script)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import csv
 import logging
+import pytest
 from dataclasses import dataclass, field
 from pathlib import Path
+from twister_harness.exceptions import TwisterHarnessException
 from twister_harness.helpers.domains_helper import get_default_domain_name
-
-import pytest
+from twisterlib.hardwaredata import HardwareData, CompoundHardwareData
+from twisterlib.harnessconfig import HarnessPytestConfig, TWISTER_PYTEST_CONFIG_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +46,7 @@ class DeviceConfig:
     fixtures: list[str] = None
     app_build_dir: Path | None = None
     extra_test_args: str = ''
-    west_flash_cmd: str = 'flash'
+    west_flash_cmd: str = ''
 
     def __post_init__(self):
         domains = self.build_dir / 'domains.yaml'
@@ -57,63 +59,112 @@ class DeviceConfig:
 @dataclass
 class TwisterHarnessConfig:
     """Store Twister harness configuration to have easy access in test."""
+
     devices: list[DeviceConfig] = field(default_factory=list, repr=False)
+    test_params: HarnessPytestConfig | None = None
 
     @classmethod
     def create(cls, config: pytest.Config) -> TwisterHarnessConfig:
         """Create new instance from pytest.Config."""
+        if test_params_file := get_test_param_file(config):
+            test_params = HarnessPytestConfig.load_from_yaml(test_params_file)
+        else:
+            test_params = HarnessPytestConfig(platform='undefined')
+
+        build_dir = get_path(config.option.build_dir)
+        if not build_dir and test_params_file:
+            build_dir = test_params_file.parent
+        if not build_dir:
+            raise TwisterHarnessException('--build-dir or --test-config has to be provided')
+
+        device_type = config.option.device_type or test_params.device_type
+        if not device_type:
+            raise TwisterHarnessException('--device-type has to be provided')
 
         devices = []
 
         west_flash_extra_args: list[str] = []
         if config.option.west_flash_extra_args:
-            west_flash_extra_args = [w.strip() for w in next(csv.reader([config.option.west_flash_extra_args]))]
+            west_flash_extra_args = [
+                w.strip() for w in next(csv.reader([config.option.west_flash_extra_args]))
+            ]
+        elif test_params.west_flash_extra_args:
+            west_flash_extra_args = [
+                w.strip() for w in next(csv.reader([test_params.west_flash_extra_args]))
+            ]
+
         flash_command: list[str] = []
         if config.option.flash_command:
             flash_command = [w.strip() for w in next(csv.reader([config.option.flash_command]))]
+        elif test_params.flash_command:
+            flash_command = [w.strip() for w in next(csv.reader([test_params.flash_command]))]
+
         runner_params: list[str] = []
         if config.option.runner_params:
             runner_params = [w.strip() for w in config.option.runner_params]
-        serial_configs: list[DeviceSerialConfig] = []
-        if config.option.device_serial:
-            for serial_port in config.option.device_serial:
+
+        # for native, qemu and backwards compatibility with DUT defined from command line
+        if not test_params.duts:
+            dut = CompoundHardwareData()
+            dut.serial = config.option.device_serial[0] if config.option.device_serial else None
+            dut.serial_baud = config.option.device_serial_baud
+            dut.serial_pty = config.option.device_serial_pty
+            if config.option.device_serial and len(config.option.device_serial) > 1:
+                for core_serial in config.option.device_serial[1:]:
+                    core_dut = HardwareData(
+                        serial=core_serial,
+                        serial_baud=config.option.device_serial_baud,
+                        serial_pty=config.option.device_serial_pty,
+                    )
+                    dut.entries.append(core_dut)
+            test_params.duts.append(dut)
+
+        for dut in test_params.duts:
+            serial_configs: list[DeviceSerialConfig] = []
+            for _dut in [dut] + dut.entries:
                 serial_configs.append(
                     DeviceSerialConfig(
-                        port=serial_port,
-                        baud=config.option.device_serial_baud,
-                        serial_pty=config.option.device_serial_pty
+                        port=_dut.serial, baud=_dut.serial_baud, serial_pty=_dut.serial_pty
                     )
                 )
-        device_from_cli = DeviceConfig(
-            type=config.option.device_type,
-            build_dir=_cast_to_path(config.option.build_dir),
-            base_timeout=config.option.base_timeout,
-            flash_timeout=config.option.flash_timeout,
-            platform=config.option.platform,
-            serial_configs=serial_configs,
-            runner=config.option.runner,
-            runner_params=runner_params,
-            id=config.option.device_id,
-            product=config.option.device_product,
-            flash_before=bool(config.option.flash_before),
-            west_flash_extra_args=west_flash_extra_args,
-            flash_command=flash_command,
-            pre_script=_cast_to_path(config.option.pre_script),
-            post_script=_cast_to_path(config.option.post_script),
-            post_flash_script=_cast_to_path(config.option.post_flash_script),
-            fixtures=config.option.fixtures,
-            extra_test_args=config.option.extra_test_args,
-            west_flash_cmd=config.option.west_flash_cmd or 'flash'
-        )
 
-        devices.append(device_from_cli)
+            device = DeviceConfig(
+                type=device_type,
+                build_dir=build_dir,
+                base_timeout=config.option.base_timeout or test_params.base_timeout,
+                flash_timeout=config.option.flash_timeout or dut.flash_timeout,
+                platform=dut.platform or config.option.platform or test_params.platform,
+                serial_configs=serial_configs,
+                runner=config.option.runner or test_params.runner or dut.runner,
+                runner_params=runner_params or dut.runner_params,
+                id=config.option.device_id or dut.id,
+                product=config.option.device_product or dut.product,
+                flash_before=config.option.flash_before or test_params.flash_before or dut.flash_before,
+                west_flash_extra_args=west_flash_extra_args,
+                west_flash_cmd=config.option.west_flash_cmd or test_params.west_flash_cmd or dut.west_flash_cmd,
+                flash_command=flash_command,
+                pre_script=get_path(config.option.pre_script) or get_path(dut.pre_script),
+                post_script=get_path(config.option.post_script) or get_path(dut.post_script),
+                post_flash_script=get_path(config.option.post_flash_script) or get_path(dut.post_flash_script),
+                fixtures=config.option.fixtures or test_params.twister_fixtures or dut.fixtures,
+                extra_test_args=config.option.extra_test_args,
+            )
+            devices.append(device)
 
-        return cls(
-            devices=devices
-        )
+        return cls(devices=devices, test_params=test_params)
 
 
-def _cast_to_path(path: str | None) -> Path | None:
-    if path is None:
+def get_test_param_file(config: pytest.Config) -> Path | None:
+    if test_params_file := get_path(config.option.twister_config):
+        return test_params_file
+    if build_dir := get_path(config.option.build_dir):
+        test_params_file = build_dir / TWISTER_PYTEST_CONFIG_FILE
+        if test_params_file.exists():
+            return test_params_file
+    return None
+
+
+def get_path(path: str | None) -> Path | None:
+    if not path:
         return None
     return Path(path)

--- a/scripts/pylib/pytest-twister-harness/tests/twister_harness_config_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/twister_harness_config_test.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import textwrap
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from twister_harness.plugin import pytest_addoption
+from twister_harness.twister_harness_config import TwisterHarnessConfig
+
+
+def create_mock_config_with_defaults() -> pytest.Config:
+    """Create a mock config with defaults from pytest_addoption"""
+    parser = pytest.Parser()
+    pytest_addoption(parser)
+    config = Mock(spec=pytest.Config)
+    config.option = Mock()
+    # Extract defaults from all parser options (including grouped ones)
+    for group in parser._groups:
+        for action in group.options:
+            if hasattr(action, 'dest'):
+                attr_name = action.dest.replace('-', '_')
+                default_value = action.default if hasattr(action, 'default') else None
+                setattr(config.option, attr_name, default_value)
+    return config
+
+
+def test_if_test_config_file_is_used(tmp_path: Path):
+    content = textwrap.dedent("""
+        base_timeout: 60
+        device_type: hardware
+        platform: sample/board/name
+        required_builds: []
+        west_flash_extra_args: --erase
+        runner: ''
+        duts:
+        - connected: true
+          flash_timeout: 60
+          id: 0123456789
+          platform: sample/board/name
+          runner: jlink
+          serial: /dev/ttyACM1
+          serial_baud: 115200
+          fixtures: ['ble_hci_adapter', 'usb']
+          entries:
+          - connected: true
+            platform: unknown
+            serial: /dev/ttyACM0
+    """)
+    twister_config = tmp_path / 'twister_config.yaml'
+    twister_config.write_text(content)
+
+    config = create_mock_config_with_defaults()
+    config.option.twister_config = str(twister_config)
+    twister_harness_config = TwisterHarnessConfig.create(config)
+
+    assert len(twister_harness_config.devices) == 1
+    device = twister_harness_config.devices[0]
+    assert device.type == 'hardware'
+    assert device.platform == 'sample/board/name'
+    assert device.id == '0123456789'
+    assert device.west_flash_extra_args == ['--erase']
+    assert device.fixtures == ['ble_hci_adapter', 'usb']
+    assert device.flash_timeout == 60
+    assert device.runner == 'jlink'
+    assert len(device.serial_configs) == 2
+    assert device.serial_configs[0].port == '/dev/ttyACM1'
+    assert device.serial_configs[0].baud == 115200
+    assert device.serial_configs[1].port == '/dev/ttyACM0'

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -685,7 +685,6 @@ class DeviceHandler(Handler):
 
         return ser
 
-
     def _handle_serial_exception(self, exception, dut, serial_pty, ser_pty_process):
         self.instance.status = TwisterStatus.FAIL
         self.instance.reason = "Serial Device Error"
@@ -697,13 +696,18 @@ class DeviceHandler(Handler):
 
         self.make_dut_available(dut)
 
-    def get_more_serials_from_device(self, hardware: DUT) -> list[str]:
-        serials = set()
-        dut_shared_hw = [_d for _d in self.duts if _d.id == hardware.id]
-        for d in dut_shared_hw:
-            if d.serial and d.serial != hardware.serial:
+    def get_other_duts_with_same_id(self, hardware: DUT) -> list[DUT]:
+        """Get all DUTs that share the same hardware ID as the provided DUT,
+        excluding the provided DUT itself."""
+        duts: list[DUT] = []
+        # get all DUTs with the same id
+        duts_shared_hw = [_d for _d in self.duts if _d.id == hardware.id]
+        serials = {hardware.serial}
+        for d in duts_shared_hw:
+            if d.serial and d.serial not in serials:
+                duts.append(d)
                 serials.add(d.serial)
-        return list(serials)
+        return duts
 
     def get_hardware(self) -> DUT | None:
         hardware = None

--- a/scripts/pylib/twister/twisterlib/hardwaredata.py
+++ b/scripts/pylib/twister/twisterlib/hardwaredata.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class HardwareData:
+    """Device Under Test configuration."""
+
+    id: str | None = None
+    serial: str | None = None
+    serial_baud: int = 115200
+    platform: str | None = None
+    product: str | None = None
+    serial_pty: str | None = None
+    connected: bool = False
+    runner_params: str | None = None
+    pre_script: str | None = None
+    post_script: str | None = None
+    post_flash_script: str | None = None
+    script_param: str | None = None
+    runner: str | None = None
+    flash_timeout: int = 60
+    flash_with_test: bool = False
+    flash_before: bool = False
+    fixtures: list[str] = field(default_factory=list)
+    probe_id: str | None = None
+    notes: str | None = None
+    match: bool = False
+    west_flash_cmd: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert DUT dataclass to dictionary for YAML serialization."""
+        result = asdict(self)
+        # Remove falsy values to keep config file clean
+        return {k: v for k, v in result.items() if v}
+
+
+@dataclass
+class CompoundHardwareData(HardwareData):
+    """DUT configuration with auxiliary connections from
+    the same physical device (same hardware ID). Entries can represent
+    other CPU cores or separate logging ports of the same device.
+    """
+
+    entries: list[HardwareData] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert DUT dataclass to dictionary for YAML serialization."""
+        result = asdict(self)
+        result['entries'] = [entry.to_dict() for entry in self.entries]
+        # Remove falsy values to keep config file clean
+        return {k: v for k, v in result.items() if v}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CompoundHardwareData:
+        """Create CompoundHardwareData from dictionary loaded from YAML."""
+        if 'entries' in data:
+            data['entries'] = [HardwareData(**entry) for entry in data['entries']]
+        return cls(**data)

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -3,21 +3,22 @@
 #
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=unexpected-keyword-arg
 from __future__ import annotations
 
 import logging
 import os
 import platform
 import re
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from multiprocessing import Lock, Value
 from pathlib import Path
-from typing import Any
 
 import scl
 import yaml
 from natsort import natsorted
 from twisterlib.constants import ZEPHYR_BASE
+from twisterlib.hardwaredata import HardwareData
 
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.
@@ -36,29 +37,8 @@ logger = logging.getLogger('twister')
 
 
 @dataclass
-class DUT:
-    """Device Under Test configuration."""
-    id: str | None = None
-    serial: str | None = None
-    serial_baud: int = 115200
-    platform: str | None = None
-    product: str | None = None
-    serial_pty: str | None = None
-    connected: bool = False
-    runner_params: str | None = None
-    pre_script: str | None = None
-    post_script: str | None = None
-    post_flash_script: str | None = None
-    script_param: str | None = None
-    runner: str | None = None
-    flash_timeout: int = 60
-    flash_with_test: bool = False
-    flash_before: bool = False
-    fixtures: list[str] = field(default_factory=list)
-    probe_id: str | None = None
-    notes: str | None = None
-    match: bool = False
-    west_flash_cmd: str | None = None
+class DUT(HardwareData):
+    """Device Under Test with runtime data."""
 
     def __post_init__(self):
         """Initialize non-serializable objects after dataclass initialization."""
@@ -109,12 +89,6 @@ class DUT:
     def failures_increment(self, value=1):
         with self._failures.get_lock():
             self._failures.value += value
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert DUT dataclass to dictionary for YAML serialization."""
-        result = asdict(self)
-        # Remove None and False values and empty lists to keep YAML clean
-        return {k: v for k, v in result.items() if v}
 
     def __repr__(self):
         return f"<{self.platform} ({self.product}) on {self.serial}>"

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -24,7 +24,9 @@ from pytest import ExitCode
 from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import ConfigurationError, StatusAttributeError
-from twisterlib.handlers import Handler, terminate_process
+from twisterlib.handlers import DeviceHandler, Handler, terminate_process
+from twisterlib.hardwaredata import CompoundHardwareData
+from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
@@ -378,6 +380,8 @@ class Pytest(Harness):
         self.pytest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
         self.reserved_dut = None
         self._output = []
+        self.pytest_config_file = os.path.join(self.running_dir, TWISTER_PYTEST_CONFIG_FILE)
+        self.pytest_params = HarnessPytestConfig(platform=instance.platform.name)
 
     def pytest_run(self, timeout):
         try:
@@ -396,66 +400,64 @@ class Pytest(Harness):
     def generate_command(self):
         config = self.instance.testsuite.harness_config
         handler: Handler = self.instance.handler
-        pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
-        pytest_args_yaml = config.get('pytest_args', []) if config else []
-        pytest_dut_scope = config.get('pytest_dut_scope', None) if config else None
         command = [
-            'pytest',
-            '--twister-harness',
-            '-s', '-v',
-            f'--build-dir={self.running_dir}',
+            'pytest', '-s', '-v',
+            '--log-cli-level=DEBUG',
+            '--log-cli-format=%(levelname)s: %(message)s',
             f'--junit-xml={self.report_file}',
-            f'--platform={self.instance.platform.name}'
+            f'--twister-config={self.pytest_config_file}'
         ]
 
-        command.extend([os.path.normpath(os.path.join(
-            self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
-
+        pytest_dut_scope = config.get('pytest_dut_scope', None) if config else None
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
 
-        # Always pass output from the pytest test and the test image up to Twister log.
-        command.extend([
-            '--log-cli-level=DEBUG',
-            '--log-cli-format=%(levelname)s: %(message)s'
-        ])
+        pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
+        command.extend([os.path.normpath(os.path.join(
+            self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
+
+        self.pytest_params.device_type = self._get_pytest_device_type(handler.type_str)
 
         # Use the test timeout as the base timeout for pytest
         base_timeout = handler.get_test_timeout()
-        command.append(f'--base-timeout={base_timeout}')
+        self.pytest_params.base_timeout = base_timeout
 
         if handler.type_str == 'device':
-            command.extend(
-                self._generate_parameters_for_hardware(handler)
-            )
-        elif handler.type_str in SUPPORTED_SIMS_IN_PYTEST:
-            command.append(f'--device-type={handler.type_str}')
-        elif handler.type_str == 'build':
-            command.append('--device-type=custom')
+            self._generate_parameters_for_hardware(handler)
         else:
-            raise PytestHarnessException(
-                f'Support for handler {handler.type_str} not implemented yet'
-            )
-
-        for req_build in self.instance.required_build_dirs:
-            command.append(f'--required-build={req_build}')
-
-        if handler.type_str != 'device':
             for fixture in handler.options.fixture:
-                command.append(f'--twister-fixture={fixture}')
+                self.pytest_params.twister_fixtures.append(fixture)
+
+        self.pytest_params.required_builds = self.instance.required_build_dirs
 
         if handler.options.extra_test_args and handler.type_str == 'native':
-            command.append(f'--extra-test-args={shlex.join(handler.options.extra_test_args)}')
+            self.pytest_params.extra_test_args = shlex.join(handler.options.extra_test_args)
 
+        # Add any additional pytest args from YAML or CLI
+        pytest_args_yaml = config.get('pytest_args', []) if config else []
         command.extend(pytest_args_yaml)
-
         if handler.options.pytest_args:
             command.extend(handler.options.pytest_args)
 
+        # Save test parameters to YAML file for pytest-harness
+        self.pytest_params.save_to_yaml(self.pytest_config_file)
+
         return command
 
-    def _generate_parameters_for_hardware(self, handler: Handler):
-        command = ['--device-type=hardware']
+    def _get_pytest_device_type(self, handler_name: str) -> str:
+        """Map handler name to pytest device type."""
+        if handler_name == 'device':
+            return 'hardware'
+        elif handler_name in SUPPORTED_SIMS_IN_PYTEST:
+            return handler_name
+        elif handler_name == 'build':
+            return 'custom'
+        else:
+            raise PytestHarnessException(
+                f'Support for handler {handler_name} not implemented yet'
+            )
+
+    def _generate_parameters_for_hardware(self, handler: DeviceHandler):
         hardware = handler.get_hardware()
         if not hardware:
             raise PytestHarnessException('Hardware is not available')
@@ -463,61 +465,28 @@ class Pytest(Harness):
         self.instance.dut = hardware.id
 
         self.reserved_dut = hardware
-        if hardware.serial_pty:
-            command.append(f'--device-serial-pty={hardware.serial_pty}')
-        else:
-            command.extend([
-                f'--device-serial={hardware.serial}',
-                f'--device-serial-baud={hardware.serial_baud}'
-            ])
-            for extra_serial in handler.get_more_serials_from_device(hardware):
-                command.append(f'--device-serial={extra_serial}')
-
-        if hardware.flash_timeout:
-            command.append(f'--flash-timeout={hardware.flash_timeout}')
 
         options = handler.options
-        if runner := hardware.runner or options.west_runner:
-            command.append(f'--runner={runner}')
-
-        if west_flash_cmd := options.west_flash_cmd or hardware.west_flash_cmd:
-            command.append(f'--west-flash-cmd={west_flash_cmd}')
-
-        if hardware.runner_params:
-            for param in hardware.runner_params:
-                command.append(f'--runner-params={param}')
+        if options.west_runner:
+            self.pytest_params.runner = options.west_runner
 
         if options.west_flash and options.west_flash != []:
-            command.append(f'--west-flash-extra-args={options.west_flash}')
+            self.pytest_params.west_flash_extra_args = str(options.west_flash)
+
+        if options.west_flash_cmd:
+            self.pytest_params.west_flash_cmd = options.west_flash_cmd
 
         if options.flash_command:
-            command.append(f'--flash-command={options.flash_command}')
+            self.pytest_params.flash_command = str(options.flash_command)
 
-        if board_id := hardware.probe_id or hardware.id:
-            command.append(f'--device-id={board_id}')
-
-        if hardware.product:
-            command.append(f'--device-product={hardware.product}')
-
-        if hardware.pre_script:
-            command.append(f'--pre-script={hardware.pre_script}')
-
-        if hardware.post_flash_script:
-            command.append(f'--post-flash-script={hardware.post_flash_script}')
-
-        if hardware.post_script:
-            command.append(f'--post-script={hardware.post_script}')
-
-        # Check flash_before from both hardware map and platform (board YAML)
         # Platform flash_before is intended for boards with USB reset issues during flashing
-        flash_before = hardware.flash_before or self.instance.platform.flash_before
-        if flash_before:
-            command.append(f'--flash-before={flash_before}')
+        self.pytest_params.flash_before = self.instance.platform.flash_before
 
-        for fixture in hardware.fixtures:
-            command.append(f'--twister-fixture={fixture}')
+        # Prepare DUT configuration for pytest
+        compound_hardware = CompoundHardwareData.from_dict(hardware.to_dict())
+        compound_hardware.entries = handler.get_other_duts_with_same_id(hardware)
 
-        return command
+        self.pytest_params.duts.append(compound_hardware)
 
     def run_command(self, cmd, timeout):
         cmd, env = self._update_command_with_env_dependencies(cmd)

--- a/scripts/pylib/twister/twisterlib/harnessconfig.py
+++ b/scripts/pylib/twister/twisterlib/harnessconfig.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from twisterlib.hardwaredata import CompoundHardwareData
+
+TWISTER_PYTEST_CONFIG_FILE = 'twister_pytest_config.yaml'
+logger = logging.getLogger('twister')
+
+
+@dataclass
+class HarnessPytestConfig:
+    """Test parameters to serialize for pytest-harness."""
+
+    platform: str
+    device_type: str = ''
+    base_timeout: float = 60.0
+    extra_test_args: str = ''
+    runner: str = ''
+    west_flash_extra_args: str = ''
+    west_flash_cmd: str = ''
+    flash_command: str = ''
+    flash_before: bool = False
+    twister_fixtures: list[str] = field(default_factory=list)
+    required_builds: list[str] = field(default_factory=list)
+    duts: list[CompoundHardwareData] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert dataclass to dictionary for YAML serialization."""
+        result = asdict(self)
+        result['duts'] = [dut.to_dict() for dut in self.duts]
+        # Remove falsy values to keep config file clean
+        return {k: v for k, v in result.items() if v}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HarnessPytestConfig:
+        """Create TestParameters from dictionary loaded from YAML."""
+        # Handle nested DUT objects
+        if 'duts' in data:
+            data['duts'] = [CompoundHardwareData.from_dict(dut_data) for dut_data in data['duts']]
+        return cls(**data)
+
+    def save_to_yaml(self, filepath: Path) -> None:
+        """Save configuration to YAML file."""
+        with open(filepath, 'w') as f:
+            yaml.dump(self.to_dict(), f, default_flow_style=False)
+        logger.debug(f"Configuration saved to {filepath}")
+
+    @classmethod
+    def load_from_yaml(cls, filepath: Path) -> HarnessPytestConfig:
+        """Load parameters from YAML file."""
+        with open(filepath) as f:
+            data = yaml.safe_load(f)
+        logger.debug(f"Configuration loaded from {filepath}")
+        return cls.from_dict(data)

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import yaml
+from twisterlib.hardwaredata import HardwareData
 from twisterlib.harness import Pytest
 from twisterlib.platform import Platform
 from twisterlib.testinstance import TestInstance
@@ -14,7 +16,7 @@ from twisterlib.testsuite import TestSuite
 
 
 @pytest.fixture
-def testinstance() -> TestInstance:
+def testinstance(tmp_path: Path) -> TestInstance:
     testsuite = TestSuite('.', 'samples/hello', 'unit.test')
     testsuite.harness_config = {}
     testsuite.harness = 'pytest'
@@ -24,16 +26,25 @@ def testinstance() -> TestInstance:
 
     testinstance = TestInstance(testsuite, platform, 'zephyr', 'outdir')
     testinstance.handler = mock.Mock()
-    testinstance.handler.options = mock.Mock()
-    testinstance.handler.options.verbose = 1
+    testinstance.handler.get_test_timeout = mock.Mock(return_value=60)
+    testinstance.handler.options = mock.Mock(
+        verbose=1,
+        pytest_args=None,
+        extra_test_args=None,
+        west_flash=None,
+        west_runner=None,
+        flash_command=None,
+        west_flash_cmd=None
+    )
     testinstance.handler.options.fixture = ['fixture1:option1', 'fixture2']
-    testinstance.handler.options.pytest_args = None
-    testinstance.handler.options.extra_test_args = []
     testinstance.handler.type_str = 'native'
+    testinstance.handler.get_hardware = mock.Mock(return_value=HardwareData())
+    testinstance.handler.get_other_duts_with_same_id = mock.Mock(return_value=[])
+    testinstance.build_dir = tmp_path
     return testinstance
 
 
-@pytest.mark.parametrize('device_type', ['native', 'qemu'])
+@pytest.mark.parametrize('device_type', ['native', 'qemu', 'device'])
 def test_pytest_command(testinstance: TestInstance, device_type):
     pytest_harness = Pytest()
     pytest_harness.configure(testinstance)
@@ -42,16 +53,21 @@ def test_pytest_command(testinstance: TestInstance, device_type):
     ref_command = [
         'pytest',
         'samples/hello/pytest',
-        f'--build-dir={testinstance.build_dir}',
-        f'--junit-xml={testinstance.build_dir}/report.xml',
-        f'--device-type={device_type}',
-        '--twister-fixture=fixture1:option1',
-        '--twister-fixture=fixture2'
+        f'--twister-config={pytest_harness.pytest_config_file}',
+        f'--junit-xml={testinstance.build_dir}/report.xml'
     ]
 
     command = pytest_harness.generate_command()
+    assert Path(pytest_harness.pytest_config_file).exists()
     for c in ref_command:
         assert c in command
+    with open(pytest_harness.pytest_config_file) as f:
+        data = yaml.safe_load(f)
+    assert data['device_type'] == pytest_harness._get_pytest_device_type(device_type)
+    if device_type == 'device':
+        assert 'twister_fixtures' not in data
+    else:
+        assert data['twister_fixtures'] == ['fixture1:option1', 'fixture2']
 
 
 def test_pytest_command_dut_scope(testinstance: TestInstance):
@@ -78,8 +94,8 @@ def test_pytest_command_extra_test_args(testinstance: TestInstance):
     extra_test_args = ['-stop_at=3', '-no-rt']
     testinstance.handler.options.extra_test_args = extra_test_args
     pytest_harness.configure(testinstance)
-    command = pytest_harness.generate_command()
-    assert f'--extra-test-args={extra_test_args[0]} {extra_test_args[1]}' in command
+    pytest_harness.generate_command()
+    assert pytest_harness.pytest_params.extra_test_args == ' '.join(extra_test_args)
 
 
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
@@ -102,9 +118,8 @@ def test_pytest_command_required_build_args(testinstance: TestInstance):
     required_builds = ['/req/build/dir', 'another/req/dir']
     testinstance.required_build_dirs = required_builds
     pytest_harness.configure(testinstance)
-    command = pytest_harness.generate_command()
-    for req_dir in required_builds:
-        assert f'--required-build={req_dir}' in command
+    pytest_harness.generate_command()
+    assert pytest_harness.pytest_params.required_builds == required_builds
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add comprehensive YAML configuration support for pytest-harness 
integration, replacing CLI argument approach with structured 
configuration files while maintaining backward compatibility.

Key changes:
- Add --twister-config option in pytest-harness to load test parameters from YAML
- Refactor TwisterHarnessConfig to support CLI and YAML configuration
- Move pytest parameter generation from CLI args to config files

This enables more flexible test configuration through structured YAML 
files and improves the overall architecture of pytest-twister integration.

Update unit tests to verify YAML-based parameter serialization instead
of CLI arguments. Add tests for twister config file parsing and update
existing tests to check pytest_params object and YAML output.

---
To test one can run:
`west twister --no-clean -vv -ll debug -T samples/subsys/testsuite/pytest/shell -s sample.pytest.shell -p native_sim -p qemu_x86`

twister_pytest_config.yaml is generated in the build dir, this file is used to run pytest:
`pytest --twister-config=twister-out/native_sim_native/host/samples/subsys/testsuite/pytest/shell/sample.pytest.shell/twister_pytest_config.yaml samples/subsys/testsuite/pytest/shell/pytest -p twister_harness.plugin`
(remember to export PYTHONPATH first: `export PYTHONPATH=$ZEPHYR_BASE/scripts/pylib/pytest-twister-harness/src`)
to simplify that command, user can also `export PYTEST_PLUGINS=twister_harness.plugin` to not need to enable plugin with `-p twister_harness.plugin`

When testing with hardware, DUT configuration from the hardware map is serialized to a YAML file and made available in pytest-harness. This enables future changes for multi-DUT testing.

