### PR TITLE
drivers: dma: Infineon PDL DMA driver bug fixes

### DIFF
--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -234,19 +234,22 @@ static int ifx_cat1_dma_config(const struct device *dev, uint32_t channel,
 		descriptor_config.dstXincrement =
 			convert_dma_xy_increment_z_to_pdl(block_config->dest_addr_adj);
 
+		/* Calculate total number of data elements in this block */
+		uint32_t total_elements = block_config->block_size / config->dest_data_size;
+
 		/* Setup 1D/2D descriptor for each data block */
 		if (config->dest_burst_length != 0) {
 			descriptor_config.descriptorType = CY_DMA_2D_TRANSFER;
 			descriptor_config.xCount = config->dest_burst_length;
 			descriptor_config.yCount =
-				DIV_ROUND_UP(block_config->block_size, config->dest_burst_length);
+				DIV_ROUND_UP(total_elements, config->dest_burst_length);
 			descriptor_config.srcYincrement =
 				descriptor_config.srcXincrement * config->dest_burst_length;
 			descriptor_config.dstYincrement =
 				descriptor_config.dstXincrement * config->dest_burst_length;
 		} else {
 			descriptor_config.descriptorType = CY_DMA_1D_TRANSFER;
-			descriptor_config.xCount = block_config->block_size;
+			descriptor_config.xCount = total_elements;
 			descriptor_config.yCount = 1;
 			descriptor_config.srcYincrement = 0;
 			descriptor_config.dstYincrement = 0;
@@ -256,10 +259,10 @@ static int ifx_cat1_dma_config(const struct device *dev, uint32_t channel,
 		 * Note: In devices with CBUS and SAHB address spaces, the DMA only supports SAHB
 		 * mapped transactions.
 		 */
-		descriptor_config.srcAddress = (void *)CY_REMAP_ADDRESS_CBUS_TO_SAHB(
-			(void *)config->head_block->source_address);
-		descriptor_config.dstAddress = (void *)CY_REMAP_ADDRESS_CBUS_TO_SAHB(
-			(void *)config->head_block->dest_address);
+		descriptor_config.srcAddress =
+			(void *)CY_REMAP_ADDRESS_CBUS_TO_SAHB((void *)block_config->source_address);
+		descriptor_config.dstAddress =
+			(void *)CY_REMAP_ADDRESS_CBUS_TO_SAHB((void *)block_config->dest_address);
 
 		/* Allocate next descriptor if need */
 		if (i + 1u < config->block_count) {

--- a/tests/drivers/dma/scatter_gather/boards/kit_psc3m5_evk.conf
+++ b/tests/drivers/dma/scatter_gather/boards/kit_psc3m5_evk.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_SG_XFER_SIZE=256

--- a/tests/drivers/dma/scatter_gather/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
+++ b/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_SG_XFER_SIZE=256

--- a/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_SG_XFER_SIZE=256

--- a/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
- Corrects an incorrect transfer size calculation when setting up DMA transfers with a data size other than one byte.
- Corrects an error in address selection when dma transactions are chained together.  
- Adds testing overlay files for kit_pse84_eval and kit_psc3m5_evk boards for tests/drivers/dma/scatter_gather.