### PR TITLE
tests: input: double_tap: add test case

### DIFF
--- a/dts/bindings/input/zephyr,input-double-tap.yaml
+++ b/dts/bindings/input/zephyr,input-double-tap.yaml
@@ -7,7 +7,7 @@ description: |
   Listens for key events as an input and produces key events as output
   corresponding to double taps.
 
-  Can be optionally be associated to a specific device to listen for events
+  Can optionally be associated to a specific device to listen for events
   only from that device.
 
 compatible: "zephyr,input-double-tap"


### PR DESCRIPTION
Add test case to exercise double tap timeout (two "slow" single taps should not fire any input event)
~~Drop the unnecessary k_work_delayable as checking the timeout can be done in a much simpler way.~~
~~Saves 144 bytes of flash and 128 bytes of RAM \o/~~

cc @hlord2000