### PR TITLE
tests: input: double_tap: add timeout coverage test

### DIFF
--- a/dts/bindings/input/zephyr,input-double-tap.yaml
+++ b/dts/bindings/input/zephyr,input-double-tap.yaml
@@ -7,7 +7,7 @@ description: |
   Listens for key events as an input and produces key events as output
   corresponding to double taps.
 
-  Can be optionally be associated to a specific device to listen for events
+  Can optionally be associated to a specific device to listen for events
   only from that device.
 
   Example configuration:

--- a/tests/subsys/input/double_tap/src/main.c
+++ b/tests/subsys/input/double_tap/src/main.c
@@ -75,4 +75,40 @@ ZTEST(double_tap, test_double_tap_test)
 	zassert_equal(last_events[0].value, 0);
 }
 
+ZTEST(double_tap, test_double_tap_timeout)
+{
+	event_count = 0;
+
+	/* single tap */
+	input_report_key(fake_dev, INPUT_KEY_0, 1, true, K_FOREVER);
+	k_sleep(K_MSEC(50));
+	input_report_key(fake_dev, INPUT_KEY_0, 0, true, K_FOREVER);
+	zassert_equal(event_count, 0);
+
+	/* wait for timeout to expire - triggers double_tap_deferred */
+	k_sleep(K_MSEC(350));
+
+	/* another single tap - should NOT trigger double tap since first_tap was reset */
+	input_report_key(fake_dev, INPUT_KEY_0, 1, true, K_FOREVER);
+	k_sleep(K_MSEC(50));
+	input_report_key(fake_dev, INPUT_KEY_0, 0, true, K_FOREVER);
+	zassert_equal(event_count, 0);
+
+	/* now do a proper double tap to confirm it still works */
+	input_report_key(fake_dev, INPUT_KEY_0, 1, true, K_FOREVER);
+	k_sleep(K_MSEC(50));
+	input_report_key(fake_dev, INPUT_KEY_0, 0, true, K_FOREVER);
+	k_sleep(K_MSEC(50));
+	input_report_key(fake_dev, INPUT_KEY_0, 1, true, K_FOREVER);
+	k_sleep(K_MSEC(50));
+	input_report_key(fake_dev, INPUT_KEY_0, 0, true, K_FOREVER);
+	zassert_equal(event_count, 2);
+	zassert_equal(last_events[1].type, INPUT_EV_KEY);
+	zassert_equal(last_events[1].code, INPUT_KEY_X);
+	zassert_equal(last_events[1].value, 1);
+	zassert_equal(last_events[0].type, INPUT_EV_KEY);
+	zassert_equal(last_events[0].code, INPUT_KEY_X);
+	zassert_equal(last_events[0].value, 0);
+}
+
 ZTEST_SUITE(double_tap, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/input/double_tap/src/main.c
+++ b/tests/subsys/input/double_tap/src/main.c
@@ -86,7 +86,7 @@ ZTEST(double_tap, test_double_tap_timeout)
 	zassert_equal(event_count, 0);
 
 	/* wait for timeout to expire - triggers double_tap_deferred */
-	k_sleep(K_MSEC(350));
+	k_sleep(K_MSEC(150));
 
 	/* another single tap - should NOT trigger double tap since first_tap was reset */
 	input_report_key(fake_dev, INPUT_KEY_0, 1, true, K_FOREVER);


### PR DESCRIPTION
x