### PR TITLE
soc: espressif: esp32: increase bootloader dram length

### DIFF
--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -63,7 +63,7 @@
 					SRAM1_IRAM_START)
 
 /* Set bootloader segments size */
-#define BOOTLOADER_DRAM_SEG_LEN        0x7a00
+#define BOOTLOADER_DRAM_SEG_LEN        0x8000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x4000
 #define BOOTLOADER_IRAM_SEG_LEN        0xa000
 


### PR DESCRIPTION
Following recent updates, the bootloader dram segment length must be increased to compile mcuboot on esp32.

The error I get before doing this modification is the following:
```
/home/joel/zephyr-sdk-0.17.4/xtensa-espressif_esp32_zephyr-elf/bin/../lib/gcc/xtensa-espressif_esp32_zephyr-elf/12.2.0/../../../../xtensa-espressif_esp32_zephyr-elf/bin/ld.bfd: zephyr/zephyr_pre0.elf section `.bss' will not fit in region `dram_seg'
/home/joel/zephyr-sdk-0.17.4/xtensa-espressif_esp32_zephyr-elf/bin/../lib/gcc/xtensa-espressif_esp32_zephyr-elf/12.2.0/../../../../xtensa-espressif_esp32_zephyr-elf/bin/ld.bfd: DRAM segment data does not fit.
/home/joel/zephyr-sdk-0.17.4/xtensa-espressif_esp32_zephyr-elf/bin/../lib/gcc/xtensa-espressif_esp32_zephyr-elf/12.2.0/../../../../xtensa-espressif_esp32_zephyr-elf/bin/ld.bfd: region `dram_seg' overflowed by 400 bytes
collect2: error: ld returned 1 exit status
```