### PR TITLE
dts: bindings: dwc2: add extra hardware registers and devicetree entries

### DIFF
--- a/dts/arm/syna/sr100.dtsi
+++ b/dts/arm/syna/sr100.dtsi
@@ -189,8 +189,10 @@
 			num-out-eps = <8>;
 			num-in-eps = <8>;
 			clocks = <&gcr SYNA_USB_CLK>;
+			gsnpsid = <0x5532430a>;
 			ghwcfg1 = <0x00000000>;
 			ghwcfg2 = <0x02882054>; // 8 endpoints, dynamic sizing
+			ghwcfg3 = <0x0c78c468>;
 			ghwcfg4 = <0xe2003e20>; // 9 in endpoints, desc-DMA
 			status = "disabled";
 		};

--- a/dts/bindings/usb/snps,dwc2.yaml
+++ b/dts/bindings/usb/snps,dwc2.yaml
@@ -31,6 +31,11 @@ properties:
     description: |
       Number of configured IN endpoints including control endpoint.
 
+  gsnpsid:
+    type: int
+    description: |
+      Value of the GSNPSID register, used to declare the version of the core.
+
   ghwcfg1:
     type: int
     required: true
@@ -43,6 +48,12 @@ properties:
     required: true
     description: |
       Value of the GHWCFG2 register. It is used to determine available endpoint
+      types during driver pre-initialization.
+
+  ghwcfg3:
+    type: int
+    description: |
+      Value of the GHWCFG3 register. It is used to determine available endpoint
       types during driver pre-initialization.
 
   ghwcfg4:

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -670,8 +670,10 @@
 				interrupts = <134 NRF_DEFAULT_IRQ_PRIORITY>;
 				num-in-eps = <8>;
 				num-out-eps = <10>;
+				gsnpsid = <0x4f54430a>;
 				ghwcfg1 = <0xaa555000>;
 				ghwcfg2 = <0x22abfc72>;
+				ghwcfg3 = <0x0beac0e8>;
 				ghwcfg4 = <0x1e10aa60>;
 				status = "disabled";
 			};

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -249,8 +249,10 @@
 					interrupts = <90 NRF_DEFAULT_IRQ_PRIORITY>;
 					num-in-eps = <16>;
 					num-out-eps = <16>;
+					gsnpsid = <0x4f54500b>;
 					ghwcfg1 = <0x0>;
 					ghwcfg2 = <0x22affc52>;
+					ghwcfg3 = <0x0be0c0e8>;
 					ghwcfg4 = <0x3e10aa60>;
 					status = "disabled";
 				};

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -436,8 +436,10 @@
 			clocks = <&clock ESP32_USB_MODULE>;
 			num-out-eps = <6>;
 			num-in-eps = <6>;
+			gsnpsid = <0x4f54400a>;
 			ghwcfg1 = <0x00000000>;
 			ghwcfg2 = <0x224dd930>;
+			ghwcfg3 = <0x00c804b5>;
 			ghwcfg4 = <0xd3f0a030>;
 		};
 


### PR DESCRIPTION
- https://github.com/zephyrproject-rtos/zephyr/issues/102931

Very small PR to add extra hardware registers that can later be used inside drivers.

Given this has no dependency, I thought I might as well submit it directly on `main` so it's possible to use it from everywhere (device, host).

The registers were obtained by logging their value out.