### PR TITLE
drivers: stepper: gpio: honor update interval for work timing

### DIFF
--- a/drivers/stepper/gpio_stepper/common/include/gpio_stepper_common.h
+++ b/drivers/stepper/gpio_stepper/common/include/gpio_stepper_common.h
@@ -67,6 +67,7 @@ struct gpio_stepper_common_data {
 	enum stepper_direction direction;
 	enum stepper_run_mode run_mode;
 	uint64_t microstep_interval_ns;
+	uint64_t timing_source_interval_ns;
 	atomic_t actual_position;
 	atomic_t step_count;
 	stepper_event_callback_t callback;


### PR DESCRIPTION
The work-queue based timing source ignored the interval passed via .update() and always scheduled using the configured microstep interval. In single-edge mode the step/dir driver programs the timing source with half the microstep period to generate the required high/low edges, so ignoring .update() causes the step toggling rate to be wrong (half of the actually requested one).

Store the timing-source interval on update and schedule work using that value.