### PR TITLE
boards: adi: Fix APARD32690 QSPI flash jedec ID

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -338,7 +338,7 @@ pmod_spi: &spi4 {
 		compatible = "adi,max32-spixf-nor";
 		reg = <0x08000000 DT_SIZE_M(8)>; /* 64 Mbits */
 		qspi-max-frequency = <60000000>;
-		jedec-id = [c2 37 25];
+		jedec-id = [25 37 c2];
 		sfdp-bfp = [e5 20 f1 ff ff ff ff 03 44 eb 08 6b 08 3b 04 bb
 			    fe ff ff ff ff ff 00 ff ff ff 44 eb 0c 20 0f 52
 			    10 d8 00 ff d3 49 c9 00 83 a6 04 c4 44 03 17 38


### PR DESCRIPTION
Correct an ordering issue with the expected JEDEC ID for the APARD32690 board, so testing code relocation works as expected.