### PR TITLE
drivers: serial: uart_nrfx_uarte: patch disable and pinctrl order

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3122,8 +3122,8 @@ static void uarte_pm_suspend(const struct device *dev)
 		wait_for_tx_stopped(dev);
 	}
 
-	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 	nrf_uarte_disable(uarte);
+	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 }
 
 static int uarte_nrfx_pm_action(const struct device *dev, enum pm_device_action action)


### PR DESCRIPTION
The UARTE instance must be disabled before the pinctrl state is updated like it is done other places in this driver.

While the uarte is enabled, it controls the pins, keeping TX high for example. Trying to apply pinctrl will have no effect other than enabling pin retention, so the TX pin which should now be low and configured as disconnected input, stays an output driven high.

Issue was discovered as the suspended UARTE was backpowering devices connected to it because of the driven output pins.