### PR TITLE
hal_nxp: Add PWM WAITEN bitfield support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 796e242aabb37f50de0d90c44249e36d8de4268d
+      revision: 683b4077c6760ece043e55bb2d7dc9d1996c7ffd
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp module to add PWM WAITEN bitfield
support.
This enables sleep mode control for PWM modules
on MCXA devices.