### PR TITLE
fs: nvs: handle power loss during ATE write at sector end

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -945,6 +945,19 @@ static int nvs_startup(struct nvs_fs *fs)
 		}
 
 		fs->data_wra += fs->flash_parameters->write_block_size;
+
+		/*
+		 * If the loop exits because data_wra has caught up with ate_wra,
+		 * this does not indicate an error, but that no erased space
+		 * remains for further data writes in this sector.
+		 *
+		 * In this case, the sector is logically full and will be closed
+		 * by the next write, which will also trigger garbage collection.
+		 *
+		 * Therefore, ensure rc is set to 0 so startup does not fail
+		 * due to the absence of writable space.
+		 */
+		rc = 0;
 	}
 
 	/* If the ate_wra is pointing to the first ate write location in a


### PR DESCRIPTION
NVS writes an entry by first programming the data area and then writing the corresponding ATE. If a power loss occurs after the data has been written but while the ATE is being programmed, and the remaining space in the sector is only large enough for a single ATE, the ATE may end up partially written.

1) Power loss while writing the last data ATE, leaving only space for
   a delete ATE but no space for additional data entries:

       [ data ][ data ][ erase ][ ATE ][ ATE ][ erase ](sector end)
                                  ^^^
In this cases, nvs_startup() scans the sector and fails to find any erased space usable for data writes, causing mount to fail.

       [ data ][ data ][ erase ][ ATE ][ ATE ][ erase ]
               ^       ^           ^
                    ate_wra     Invalid
            data_wra

The sector is logically exhausted and should be closed and garbage collected.

Detect this condition during startup. If no erased space exists after the last ATE write, explicitly close the sector and trigger garbage collection to restore a writable sector.

This completes the missing recovery path for power-loss scenarios where a sector becomes effectively full due to ATE writes.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103029