### PR TITLE
tests: drivers: flash: negative_tests: check for unaligned write size

### DIFF
--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -160,6 +160,7 @@ ZTEST(flash_driver_negative, test_negative_flash_fill_unaligned)
 	rc = flash_fill(flash_dev, fill_val, TEST_AREA_OFFSET + 1, page_info.size);
 	zassert_true(rc < 0, "Invalid use of flash_fill returned %d", rc);
 
+	/* Check error returned when filling unaligned size */
 	rc = flash_fill(flash_dev, fill_val, TEST_AREA_OFFSET, page_info.size + 1);
 	zassert_true(rc < 0, "Invalid use of flash_fill returned %d", rc);
 }
@@ -275,6 +276,10 @@ ZTEST(flash_driver_negative, test_negative_flash_write_unaligned)
 	ztest_test_skip();
 #endif
 
+	/*  Write size and offset must be multiples of the minimum write block size
+	 *  supported by the driver.
+	 */
+
 	write_block_size = flash_get_write_block_size(flash_dev);
 
 	if (write_block_size <= 1) {
@@ -282,7 +287,11 @@ ZTEST(flash_driver_negative, test_negative_flash_write_unaligned)
 	}
 	/* Check error returned when writing at unaligned memory */
 	rc = flash_write(flash_dev, (TEST_AREA_OFFSET + 1), expected, page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
+	zassert_true(rc < 0, "Invalid use of flash_write (unaligned write size) returned %d", rc);
+
+	/* Check error returned when writing unaligned size */
+	rc = flash_write(flash_dev, TEST_AREA_OFFSET, expected, page_info.size + 1);
+	zassert_true(rc < 0, "Invalid use of flash_write (unaligned size) returned %d", rc);
 }
 
 ZTEST_SUITE(flash_driver_negative, NULL, flash_driver_setup, NULL, NULL, NULL);

--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -150,6 +150,10 @@ ZTEST(flash_driver_negative, test_negative_flash_erase_unaligned)
 	/* Check error returned when erasing unaligned memory */
 	rc = flash_erase(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
 	zassert_true(rc < 0, "Invalid use of flash_erase (unaligned erase size) returned %d", rc);
+
+	/* Check error returned when erasing unaligned size */
+	rc = flash_erase(flash_dev, TEST_AREA_OFFSET, page_info.size + 1);
+	zassert_true(rc < 0, "Invalid use of flash_erase (unaligned size) returned %d", rc);
 }
 
 /*  Erase page offset and size are constrains of paged, explicit erase devices,

--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -73,7 +73,10 @@ static void *flash_driver_setup(void)
 	return NULL;
 }
 
-ZTEST(flash_driver_negative, test_negative_flash_erase)
+/*  Acceptable values of erase size and offset are subject to
+ *  hardware-specific multiples of page size and offset.
+ */
+ZTEST(flash_driver_negative, test_negative_flash_erase_zero_length)
 {
 	int rc;
 
@@ -84,32 +87,75 @@ ZTEST(flash_driver_negative, test_negative_flash_erase)
 	ztest_test_skip();
 #endif
 
-	/*  Acceptable values of erase size and offset are subject to
-	 *  hardware-specific multiples of page size and offset.
-	 */
-
-	/* Check error returned when erasing memory at wrong address (too low) */
-	rc = flash_erase(flash_dev, (TEST_FLASH_START - page_info.size), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
-
-	/* Check error returned when erasing memory at wrong address (too high) */
-	rc = flash_erase(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
-
-	/* Check error returned when erasing unaligned memory */
-	rc = flash_erase(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
-
-	/* Check error returned when erasing too large chunk of memory */
-	rc = flash_erase(flash_dev, TEST_AREA_OFFSET, (TEST_FLASH_SIZE + 1));
-	zassert_true(rc < 0, "Invalid use of flash_erase returned %d", rc);
-
 	/* Erasing 0 bytes shall succeed */
 	rc = flash_erase(flash_dev, TEST_AREA_OFFSET, 0);
 	zassert_true(rc == 0, "flash_erase 0 bytes returned %d", rc);
 }
 
-ZTEST(flash_driver_negative, test_negative_flash_fill)
+ZTEST(flash_driver_negative, test_negative_flash_erase_oversized_length)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when erasing too large chunk of memory */
+	rc = flash_erase(flash_dev, TEST_AREA_OFFSET, (TEST_FLASH_SIZE + 1));
+	zassert_true(rc < 0,
+		     "Invalid use of flash_erase (erasing too large chunk of memory) returned %d",
+		     rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_erase_wrong_address)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when erasing memory at wrong address (too low) */
+	rc = flash_erase(flash_dev, (TEST_FLASH_START - page_info.size), page_info.size);
+	zassert_true(rc < 0,
+		     "Invalid use of flash_erase (erasing memory at wrong address (too low)) "
+		     "returned %d",
+		     rc);
+
+	/* Check error returned when erasing memory at wrong address (too high) */
+	rc = flash_erase(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
+	zassert_true(rc < 0,
+		     "Invalid use of flash_erase (erasing memory at wrong address (too high)) "
+		     "returned %d",
+		     rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_erase_unaligned)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when erasing unaligned memory */
+	rc = flash_erase(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
+	zassert_true(rc < 0, "Invalid use of flash_erase (unaligned erase size) returned %d", rc);
+}
+
+/*  Erase page offset and size are constrains of paged, explicit erase devices,
+ *  but can be relaxed with devices without such requirement.
+ */
+ZTEST(flash_driver_negative, test_negative_flash_fill_zero_length)
 {
 	int rc;
 	uint8_t fill_val = 0xA; /* Dummy value */
@@ -121,21 +167,36 @@ ZTEST(flash_driver_negative, test_negative_flash_fill)
 	ztest_test_skip();
 #endif
 
-	/*  Erase page offset and size are constrains of paged, explicit erase devices,
-	 *  but can be relaxed with devices without such requirement.
-	 */
-
-	/* Check error returned when filling memory at wrong address (too low) */
-	rc = flash_fill(flash_dev, fill_val, (TEST_FLASH_START - page_info.size), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_fill returned %d", rc);
-
-	/* Check error returned when filling memory at wrong address (too high) */
-	rc = flash_fill(flash_dev, fill_val, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_fill returned %d", rc);
-
 	/* Filling 0 bytes shall succeed */
 	rc = flash_fill(flash_dev, fill_val, TEST_AREA_OFFSET, 0);
 	zassert_true(rc == 0, "flash_fill 0 bytes returned %d", rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_fill_wrong_address)
+{
+	int rc;
+	uint8_t fill_val = 0xA; /* Dummy value */
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when filling memory at wrong address (too low) */
+	rc = flash_fill(flash_dev, fill_val, (TEST_FLASH_START - page_info.size), page_info.size);
+	zassert_true(
+		rc < 0,
+		"Invalid use of flash_fill (filling memory at wrong address (too low)) returned %d",
+		rc);
+
+	/* Check error returned when filling memory at wrong address (too high) */
+	rc = flash_fill(flash_dev, fill_val, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
+	zassert_true(rc < 0,
+		     "Invalid use of flash_fill (filling memory at wrong address (too high)) "
+		     "returned %d",
+		     rc);
 }
 
 ZTEST(flash_driver_negative, test_negative_flash_fill_unaligned)
@@ -165,7 +226,10 @@ ZTEST(flash_driver_negative, test_negative_flash_fill_unaligned)
 	zassert_true(rc < 0, "Invalid use of flash_fill returned %d", rc);
 }
 
-ZTEST(flash_driver_negative, test_negative_flash_flatten)
+/*  Erase page offset and size are constrains of paged, explicit erase devices,
+ *  but can be relaxed with devices without such requirement.
+ */
+ZTEST(flash_driver_negative, test_negative_flash_flatten_zero_length)
 {
 	int rc;
 
@@ -176,30 +240,61 @@ ZTEST(flash_driver_negative, test_negative_flash_flatten)
 	ztest_test_skip();
 #endif
 
-	/*  Erase page offset and size are constrains of paged, explicit erase devices,
-	 *  but can be relaxed with devices without such requirement.
-	 */
-
-	/* Check error returned when flatten memory at wrong address (too low) */
-	rc = flash_flatten(flash_dev, (TEST_FLASH_START - page_info.size), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_flatten returned %d", rc);
-
-	/* Check error returned when flatten memory at wrong address (too high) */
-	rc = flash_flatten(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_flatten returned %d", rc);
-
-	/* Check error returned when flatten unaligned memory */
-	rc = flash_flatten(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_flatten returned %d", rc);
-	rc = flash_flatten(flash_dev, TEST_AREA_OFFSET, (page_info.size + 1));
-	zassert_true(rc < 0, "Invalid use of flash_flatten returned %d", rc);
-
 	/* Flatten 0 bytes shall succeed */
 	rc = flash_flatten(flash_dev, TEST_AREA_OFFSET, 0);
 	zassert_true(rc == 0, "flash_flatten 0 bytes returned %d", rc);
 }
 
-ZTEST(flash_driver_negative, test_negative_flash_read)
+ZTEST(flash_driver_negative, test_negative_flash_flatten_wrong_address)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when flatten memory at wrong address (too low) */
+	rc = flash_flatten(flash_dev, (TEST_FLASH_START - page_info.size), page_info.size);
+	zassert_true(rc < 0,
+		     "Invalid use of flash_flatten (flatten memory at wrong address (too low)) "
+		     "returned %d",
+		     rc);
+
+	/* Check error returned when flatten memory at wrong address (too high) */
+	rc = flash_flatten(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), page_info.size);
+	zassert_true(rc < 0,
+		     "Invalid use of flash_flatten (flatten memory at wrong address (too high)) "
+		     "returned %d",
+		     rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_flatten_unaligned)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when flatten unaligned memory */
+	rc = flash_flatten(flash_dev, (TEST_AREA_OFFSET + 1), page_info.size);
+	zassert_true(rc < 0, "Invalid use of flash_flatten (unaligned flatten size) returned %d",
+		     rc);
+
+	rc = flash_flatten(flash_dev, TEST_AREA_OFFSET, (page_info.size + 1));
+	zassert_true(rc < 0, "Invalid use of flash_flatten (unaligned size) returned %d", rc);
+}
+
+/*  All flash drivers support reads without alignment restrictions on
+ *  the read offset, the read size, or the destination address.
+ */
+ZTEST(flash_driver_negative, test_negative_flash_read_zero_length)
 {
 	int rc;
 	uint8_t read_buf[EXPECTED_SIZE];
@@ -211,28 +306,56 @@ ZTEST(flash_driver_negative, test_negative_flash_read)
 	ztest_test_skip();
 #endif
 
-	/*  All flash drivers support reads without alignment restrictions on
-	 *  the read offset, the read size, or the destination address.
-	 */
-
-	/* Check error returned when reading from a wrong address (too low) */
-	rc = flash_read(flash_dev, (TEST_FLASH_START - page_info.size), read_buf, EXPECTED_SIZE);
-	zassert_true(rc < 0, "Invalid use of flash_read returned %d", rc);
-
-	/* Check error returned when reading from a wrong address (too high) */
-	rc = flash_read(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), read_buf, EXPECTED_SIZE);
-	zassert_true(rc < 0, "Invalid use of flash_read returned %d", rc);
-
-	/* Check error returned when reading too many data */
-	rc = flash_read(flash_dev, TEST_AREA_OFFSET, read_buf, (TEST_FLASH_SIZE + page_info.size));
-	zassert_true(rc < 0, "Invalid use of flash_read returned %d", rc);
-
 	/* Reading 0 bytes shall succeed */
 	rc = flash_read(flash_dev, TEST_AREA_OFFSET, read_buf, 0);
 	zassert_true(rc == 0, "flash_read 0 bytes returned %d", rc);
 }
 
-ZTEST(flash_driver_negative, test_negative_flash_write)
+ZTEST(flash_driver_negative, test_negative_flash_read_oversized_length)
+{
+	int rc;
+	uint8_t read_buf[EXPECTED_SIZE];
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when reading too many data */
+	rc = flash_read(flash_dev, TEST_AREA_OFFSET, read_buf, (TEST_FLASH_SIZE + page_info.size));
+	zassert_true(rc < 0, "Invalid use of flash_read (reading too many data) returned %d", rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_read_wrong_address)
+{
+	int rc;
+	uint8_t read_buf[EXPECTED_SIZE];
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when reading from a wrong address (too low) */
+	rc = flash_read(flash_dev, (TEST_FLASH_START - page_info.size), read_buf, EXPECTED_SIZE);
+	zassert_true(
+		rc < 0,
+		"Invalid use of flash_read (reading from a wrong address (too low)) returned %d",
+		rc);
+
+	/* Check error returned when reading from a wrong address (too high) */
+	rc = flash_read(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), read_buf, EXPECTED_SIZE);
+	zassert_true(
+		rc < 0,
+		"Invalid use of flash_read (reading from a wrong address (too high)) returned %d",
+		rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_write_zero_length)
 {
 	int rc;
 
@@ -247,21 +370,53 @@ ZTEST(flash_driver_negative, test_negative_flash_write)
 	 *  supported by the driver.
 	 */
 
-	/* Check error returned when writing to a wrong address (too low) */
-	rc = flash_write(flash_dev, (TEST_FLASH_START - page_info.size), expected, page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
-
-	/* Check error returned when writing to a wrong address (too high) */
-	rc = flash_write(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), expected, page_info.size);
-	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
-
-	/* Check error returned when writing too large chunk of memory */
-	rc = flash_write(flash_dev, TEST_AREA_OFFSET, expected, (TEST_FLASH_SIZE + 1));
-	zassert_true(rc < 0, "Invalid use of flash_write returned %d", rc);
-
 	/* Writing 0 bytes shall succeed */
 	rc = flash_write(flash_dev, TEST_AREA_OFFSET, expected, 0);
 	zassert_true(rc == 0, "flash_write 0 bytes returned %d", rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_write_oversized_length)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when writing too large chunk of memory */
+	rc = flash_write(flash_dev, TEST_AREA_OFFSET, expected, (TEST_FLASH_SIZE + 1));
+	zassert_true(rc < 0,
+		     "Invalid use of flash_write (writing too large chunk of memory) returned %d",
+		     rc);
+}
+
+ZTEST(flash_driver_negative, test_negative_flash_write_wrong_address)
+{
+	int rc;
+
+#if !defined(TEST_AREA)
+	/* Flash memory boundaries are correctly calculated
+	 * only for storage_partition.
+	 */
+	ztest_test_skip();
+#endif
+
+	/* Check error returned when writing to a wrong address (too low) */
+	rc = flash_write(flash_dev, (TEST_FLASH_START - page_info.size), expected, page_info.size);
+	zassert_true(
+		rc < 0,
+		"Invalid use of flash_write (writing to a wrong address (too low)) returned %d",
+		rc);
+
+	/* Check error returned when writing to a wrong address (too high) */
+	rc = flash_write(flash_dev, (TEST_FLASH_START + TEST_FLASH_SIZE), expected, page_info.size);
+	zassert_true(
+		rc < 0,
+		"Invalid use of flash_write (writing to a wrong address (too high)) returned %d",
+		rc);
 }
 
 ZTEST(flash_driver_negative, test_negative_flash_write_unaligned)


### PR DESCRIPTION
This PR have 3 commits :
The first one add a check for unaligned write size.
The second one split negative tests in smaller test case.
The third one add a check for unaligned erase size.