### PR TITLE
drivers: wifi: nrf_wifi: configure GPIO pins early during driver init

### DIFF
--- a/drivers/wifi/nrf_wifi/src/coex.c
+++ b/drivers/wifi/nrf_wifi/src/coex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -289,6 +289,35 @@ int nrf_wifi_coex_hw_reset(void)
 }
 
 #ifdef CONFIG_NRF70_SR_COEX_RF_SWITCH
+/**
+ * @brief Configure SR RF switch GPIO to OUTPUT_INACTIVE state during
+ * driver initialization.
+ *
+ * This function configures the SR RF switch GPIO pin to OUTPUT_INACTIVE
+ * state to prevent it from floating. This should be called early during
+ * driver initialization, before the interface is brought up.
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int sr_gpio_config_early(void)
+{
+	int ret;
+
+	if (!device_is_ready(sr_rf_switch_spec.port)) {
+		return -ENODEV;
+	}
+
+	/* Configure SR RF switch as output in inactive (low) state to
+	 * prevent floating pin from accidentally switching the antenna.
+	 */
+	ret = gpio_pin_configure_dt(&sr_rf_switch_spec, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		LOG_ERR("SR GPIO early configuration failed %d", ret);
+	}
+
+	return ret;
+}
+
 int sr_gpio_config(void)
 {
 	int ret;

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,9 @@
 #include <util.h>
 #include "common/fmac_util.h"
 #include <fmac_main.h>
+#ifndef CONFIG_NRF71_ON_IPC
+#include <zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h>
+#endif /* !CONFIG_NRF71_ON_IPC */
 
 #ifndef CONFIG_NRF70_RADIO_TEST
 #ifdef CONFIG_NRF70_STA_MODE
@@ -794,6 +797,23 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 		/* FMAC is already initialized for VIF-0 */
 		return 0;
 	}
+
+#ifndef CONFIG_NRF71_ON_IPC
+	int ret;
+
+	/* Configure all nRF70 GPIO pins to OUTPUT_INACTIVE state early
+	 * during driver initialization to prevent floating pins from
+	 * accidentally powering the module or affecting RF switch. This is
+	 * done before any other RPU initialization to ensure pins are in a
+	 * known state.
+	 */
+	ret = nrf_wifi_gpio_config_early();
+	if (ret) {
+		LOG_ERR("%s: nrf_wifi_gpio_config_early failed with error %d",
+			__func__, ret);
+		return ret;
+	}
+#endif /* !CONFIG_NRF71_ON_IPC */
 
 #ifdef CONFIG_NRF70_DATA_TX
 	data_config.aggregation = aggregation;

--- a/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -72,11 +72,13 @@ int rpu_read_reg(uint8_t reg_addr, uint8_t *reg_value);
  */
 int rpu_write_reg(uint8_t reg_addr, uint8_t reg_value);
 
+int nrf_wifi_gpio_config_early(void);
 int rpu_init(void);
 int rpu_enable(void);
 int rpu_disable(void);
 
 #ifdef CONFIG_NRF70_SR_COEX_RF_SWITCH
+int sr_gpio_config_early(void);
 int sr_ant_switch(unsigned int ant_switch);
 int sr_gpio_remove(void);
 int sr_gpio_config(void);


### PR DESCRIPTION
Configure all nRF70 GPIO pins (BUCKEN, VDDIO_CTRL, SR RF switch) to OUTPUT_INACTIVE state during driver initialization to prevent floating pins from accidentally powering the module or affecting RF switch before the interface is brought up.

This addresses an issue where GPIO configuration was delayed until the interface was brought up for the first time, leaving voltage control pins floating which could result in unintended power supply.

Fixes #100993