### PR TITLE
Kconfig: use configdefault to set default for FPU

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -143,7 +143,7 @@ config MAIN_STACK_SIZE
 	default 2560
 
 configdefault FPU
-	default y if CPU_HAS_FPU
+	default y
 
 configdefault LIBLC3
 	default y if BT_NXP_NW612 && BT_AUDIO && FPU

--- a/soc/nxp/s32/s32k1/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k1/Kconfig.defconfig
@@ -12,8 +12,8 @@ config NUM_IRQS
 	default 239 if CPU_CORTEX_M4
 	default 47 if CPU_CORTEX_M0PLUS
 
-config FPU
-	default y if CPU_HAS_FPU
+configdefault FPU
+	default y
 
 # The S32K1xx have 8 MPU regions, which is not enough for both HW stack protection
 # and userspace. Only enable HW stack protection if userspace is not enabled.

--- a/soc/nxp/s32/s32k5/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k5/Kconfig.defconfig
@@ -7,8 +7,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
 	default $(dt_node_int_prop_int,/timer,clock-frequency) if ARM_ARCH_TIMER
 
-config FPU
-	default y if CPU_HAS_FPU
+configdefault FPU
+	default y
 
 config CACHE_MANAGEMENT
 	default y

--- a/soc/sifive/sifive_freedom/fu500/Kconfig.defconfig
+++ b/soc/sifive/sifive_freedom/fu500/Kconfig.defconfig
@@ -22,8 +22,8 @@ config MAX_IRQ_PER_AGGREGATOR
 config NUM_IRQS
 	default 64
 
-config FPU
-	default y if CPU_HAS_FPU
+configdefault FPU
+	default y
 
 config RISCV_IMPRECISE_FPU_STATE_TRACKING
 	default y if FPU

--- a/soc/sifive/sifive_freedom/fu700/Kconfig.defconfig
+++ b/soc/sifive/sifive_freedom/fu700/Kconfig.defconfig
@@ -22,8 +22,8 @@ config MAX_IRQ_PER_AGGREGATOR
 config NUM_IRQS
 	default 64
 
-config FPU
-	default y if CPU_HAS_FPU
+configdefault FPU
+	default y
 
 config RISCV_IMPRECISE_FPU_STATE_TRACKING
 	default y if FPU


### PR DESCRIPTION
By using configdefault the original dependencies
are preserved (CPU_HAS_FPU).