### PR TITLE
doc: releases: 4.4: Add nxp,ocotp OTP entry

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -334,6 +334,7 @@ New Drivers
 
   * Added new stm32 BSEC driver that provides means to program and read OTP fuses
     (:dtcompatible:`st,stm32-bsec`). (:github:`102403`)
+  * :dtcompatible:`nxp,ocotp` (:github:`102567` & :github:`103089`)
 
 New Samples
 ***********


### PR DESCRIPTION
Add a new driver entry for the OTP from NXP, MCUX OCOTP.