### PR TITLE
scripts: add a provision script for ZMS

### DIFF
--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -492,6 +492,79 @@ ID size
   This is expected to have a slight impact on code size and performance, even on 64-bit systems,
   because the byte position of IDs in storage is not aligned to an 8-byte boundary.
 
+ZMS provisioning data generation
+********************************
+
+For products that need pre-loaded key-value data at manufacturing or first boot,
+ZMS provides a build-time provisioning generator script:
+``scripts/build/gen_zms_provision_data.py``.
+
+Purpose
+=======
+
+The script generates ZMS-formatted provisioning data and exports it as an Intel HEX image.
+This allows an application to start with pre-populated ZMS entries, without writing them
+at runtime.
+
+Typical use cases include:
+
+- Device identity records
+- Per-device calibration values
+- Production configuration values
+
+How it is used
+==============
+
+The script takes ZMS layout parameters (storage base, size, sector geometry, and flash
+characteristics) and one or more data sources:
+
+- ``-i`` for a text file containing ID/data pairs
+- ``-d`` for inline ID/data pairs
+
+It can also merge the generated provisioning data directly into an application HEX file with
+``-x``.
+
+If no input data is provided using ``-i`` or ``-d`` then only the sector headers will be generated.
+
+Example workflow
+================
+
+1. Generate a raw provisioning image:
+
+.. code-block:: shell
+
+   python3 ${ZEPHYR_BASE}/scripts/build/gen_zms_provision_data.py \
+     -f <storage_base_hex> \
+     -s <storage_size_hex> \
+     -n <nvm_base_hex> \
+     -z <nvm_size_hex> \
+     -w <write_block_size> \
+     -c <sector_size_hex> \
+     -i <input_data_file> \
+     -o provisioned_raw.hex
+
+2. Optionally generate a merged application image:
+
+.. code-block:: shell
+
+   python3 ${ZEPHYR_BASE}/scripts/build/gen_zms_provision_data.py \
+     -f <storage_base_hex> \
+     -s <storage_size_hex> \
+     -n <nvm_base_hex> \
+     -z <nvm_size_hex> \
+     -w <write_block_size> \
+     -c <sector_size_hex> \
+     -i <input_data_file> \
+     -x zephyr.hex \
+     -o zephyr_with_provision.hex
+
+Sample
+======
+
+See :zephyr:code-sample:`zms-provisioning` for a complete sample that integrates
+``gen_zms_provision_data.py`` into the build, supports merged and non-merged modes,
+and configures ``west flash`` to program the provisioned image.
+
 API Reference
 *************
 

--- a/samples/subsys/kvss/kvss.rst
+++ b/samples/subsys/kvss/kvss.rst
@@ -3,3 +3,9 @@
    :show-listing:
 
    Samples that demonstrate how to interact with Key-Value Storage Systems
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   zms/zms_provisioning/README

--- a/samples/subsys/kvss/zms/zms_provisioning/CMakeLists.txt
+++ b/samples/subsys/kvss/zms/zms_provisioning/CMakeLists.txt
@@ -1,0 +1,186 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(zms_provisioning)
+
+target_sources(app PRIVATE src/main.c)
+
+# Extract configuration from device tree
+# Storage partition node (labeled as storage_partition)
+dt_nodelabel(storage_partition_node NODELABEL "storage_partition")
+
+if(DEFINED storage_partition_node)
+    # Get storage partition address and size
+    dt_reg_addr(storage_base PATH ${storage_partition_node})
+    dt_reg_size(storage_size PATH ${storage_partition_node})
+
+    # Get flash device from chosen node
+    dt_chosen(flash_node PROPERTY "zephyr,flash")
+
+    if(NOT DEFINED flash_node)
+        # Fallback: try to get flash device by label
+        dt_nodelabel(flash_node NODELABEL "mram1x")
+    endif()
+
+    if(DEFINED flash_node)
+        # Get NVM base address and size from flash device
+        dt_reg_addr(nvm_address PATH ${flash_node})
+        dt_reg_size(nvm_size PATH ${flash_node})
+
+        # Get write block size from flash device
+        dt_prop(write_block_size PATH ${flash_node} PROPERTY "write-block-size")
+    else()
+        message(WARNING "Flash device node not found. Using defaults for NVM settings.")
+        set(nvm_address "0x0")
+        set(nvm_size "0x0")
+        set(write_block_size "16")
+    endif()
+
+    set(ZMS_STORAGE_BASE "${storage_base}")
+    set(ZMS_STORAGE_SIZE "${storage_size}")
+    set(ZMS_NVM_ADDRESS "${nvm_address}")
+    set(ZMS_NVM_SIZE "${nvm_size}")
+    set(ZMS_WRITE_BLOCK_SIZE "${write_block_size}")
+
+    message(STATUS "Device tree configuration found:")
+    message(STATUS "  Storage partition: ${storage_partition_node}")
+    if(DEFINED flash_node)
+        message(STATUS "  Flash device: ${flash_node}")
+    endif()
+else()
+    message(WARNING "Device tree node 'storage_partition' not found. Using default values.")
+    # Fallback to CMake cache variables
+    set(ZMS_STORAGE_BASE "0x0" CACHE STRING "Storage base address in hex format")
+    set(ZMS_STORAGE_SIZE "0x1000" CACHE STRING "Storage size in bytes in hex format")
+    set(ZMS_NVM_ADDRESS "0x0" CACHE STRING "NVM base address offset in hex format")
+    set(ZMS_NVM_SIZE "0x0" CACHE STRING "NVM size in bytes in hex format")
+    set(ZMS_WRITE_BLOCK_SIZE "16" CACHE STRING "Write block size in bytes")
+endif()
+
+# Other configuration variables
+set(ZMS_SECTOR_SIZE "0x1000" CACHE STRING "Sector size in bytes in hex format")
+set(ZMS_PROVISION_DATA_FILE "example_data.txt" CACHE STRING "Optional input file with ID-data pairs")
+set(ZMS_PROVISION_DATA "" CACHE STRING "Optional ID-data pairs (semicolon-separated)")
+if(CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX)
+    set(ZMS_DEFAULT_OUTPUT_NAME "zephyr_with_provision.hex")
+else()
+    set(ZMS_DEFAULT_OUTPUT_NAME "provisioned_raw.hex")
+endif()
+
+set(ZMS_OUTPUT_NAME "${ZMS_DEFAULT_OUTPUT_NAME}" CACHE STRING
+    "Output hex file name; merged or raw depending on CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX")
+
+# Path to the provisioning script
+set(PROVISION_SCRIPT ${ZEPHYR_BASE}/scripts/build/gen_zms_provision_data.py)
+
+# Output directory and files
+set(PROVISION_OUTPUT_DIR ${CMAKE_BINARY_DIR}/zephyr)
+set(APP_HEX_FILE ${PROVISION_OUTPUT_DIR}/zephyr.hex)
+set(PROVISION_OUTPUT_FILE ${PROVISION_OUTPUT_DIR}/${ZMS_OUTPUT_NAME})
+
+# Build the command line arguments for the provisioning script
+set(PROVISION_ARGS
+    -f ${ZMS_STORAGE_BASE}
+    -s ${ZMS_STORAGE_SIZE}
+    -n ${ZMS_NVM_ADDRESS}
+    -z ${ZMS_NVM_SIZE}
+    -w ${ZMS_WRITE_BLOCK_SIZE}
+    -c ${ZMS_SECTOR_SIZE}
+)
+
+if(CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX)
+    list(APPEND PROVISION_ARGS -x ${APP_HEX_FILE})
+endif()
+
+# Add data file if specified
+if(ZMS_PROVISION_DATA_FILE)
+    list(APPEND PROVISION_ARGS -i ${ZMS_PROVISION_DATA_FILE})
+endif()
+
+# Add individual data pairs if specified
+if(ZMS_PROVISION_DATA)
+    string(REPLACE ";" " -d " DATA_ARGS "${ZMS_PROVISION_DATA}")
+    list(APPEND PROVISION_ARGS -d ${DATA_ARGS})
+endif()
+
+# Validate that at least one data source is provided
+if(NOT ZMS_PROVISION_DATA_FILE AND NOT ZMS_PROVISION_DATA)
+    message(WARNING "No provisioning data specified. Set ZMS_PROVISION_DATA_FILE or ZMS_PROVISION_DATA.")
+endif()
+
+set(PROVISION_DEPENDS
+    ${PROVISION_SCRIPT}
+    ${ZEPHYR_BASE}/scripts/build/fs_raw_instance.py
+    ${ZEPHYR_BASE}/scripts/build/fs_class.py
+    ${ZEPHYR_BASE}/scripts/build/zms.py
+)
+
+if(CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX)
+    list(APPEND PROVISION_DEPENDS ${APP_HEX_FILE})
+endif()
+
+# Create custom command to generate provisioned hex file
+add_custom_command(
+    OUTPUT ${PROVISION_OUTPUT_FILE}
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${PROVISION_OUTPUT_FILE}
+    COMMAND ${PYTHON_EXECUTABLE} ${PROVISION_SCRIPT} ${PROVISION_ARGS} -o ${PROVISION_OUTPUT_FILE}
+    DEPENDS ${PROVISION_DEPENDS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating ZMS provisioning data: ${ZMS_OUTPUT_NAME}"
+    VERBATIM
+)
+
+# Create custom target for the provisioning
+add_custom_target(provision_raw_data ALL
+    DEPENDS ${PROVISION_OUTPUT_FILE}
+)
+
+# Configure west flash to use the appropriate hex file.
+# In merge mode the provisioning script already produces a merged hex;
+# in non-merge mode we merge zephyr.hex + provisioned_raw.hex here so that
+# a single west flash call programs both the application and provisioning data.
+if(CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX)
+    # In merge mode, the provisioning script already merged the app hex.
+    set(_provision_flash_file "${PROVISION_OUTPUT_FILE}")
+else()
+    # Combine provisioned_raw.hex and zephyr.hex into one file for west flash.
+    set(PROVISION_COMBINED_FILE ${PROVISION_OUTPUT_DIR}/zephyr_with_provision.hex)
+    set(MERGEHEX_SCRIPT ${ZEPHYR_BASE}/scripts/build/mergehex.py)
+
+    add_custom_command(
+        OUTPUT ${PROVISION_COMBINED_FILE}
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${PROVISION_COMBINED_FILE}
+        COMMAND ${PYTHON_EXECUTABLE} ${MERGEHEX_SCRIPT}
+                ${PROVISION_OUTPUT_FILE} ${APP_HEX_FILE}
+                -o ${PROVISION_COMBINED_FILE}
+        DEPENDS ${PROVISION_OUTPUT_FILE} ${APP_HEX_FILE}
+        COMMENT "Merging ZMS provisioning data with application hex: zephyr_with_provision.hex"
+        VERBATIM
+    )
+
+    add_custom_target(provision_combined ALL DEPENDS ${PROVISION_COMBINED_FILE})
+
+    set(_provision_flash_file "${PROVISION_COMBINED_FILE}")
+endif()
+
+# Patch yaml_contents directly to override the default hex_file entry.
+get_target_property(_yaml runners_yaml_props_target yaml_contents)
+string(REPLACE "  hex_file: ${KERNEL_HEX_NAME}"
+               "  hex_file: ${_provision_flash_file}"
+               _yaml "${_yaml}")
+set_target_properties(runners_yaml_props_target PROPERTIES yaml_contents "${_yaml}")
+
+message(STATUS "ZMS Provisioning Configuration:")
+message(STATUS "  Storage Base: ${ZMS_STORAGE_BASE}")
+message(STATUS "  Storage Size: ${ZMS_STORAGE_SIZE}")
+message(STATUS "  NVM Address: ${ZMS_NVM_ADDRESS}")
+message(STATUS "  NVM Size: ${ZMS_NVM_SIZE}")
+message(STATUS "  Write Block Size: ${ZMS_WRITE_BLOCK_SIZE}")
+message(STATUS "  Sector Size: ${ZMS_SECTOR_SIZE}")
+message(STATUS "  Merge With App Hex: ${CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX}")
+message(STATUS "  Provision Output: ${PROVISION_OUTPUT_FILE}")

--- a/samples/subsys/kvss/zms/zms_provisioning/Kconfig
+++ b/samples/subsys/kvss/zms/zms_provisioning/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+menu "ZMS Provisioning Sample Options"
+
+config SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX
+	bool "Merge application hex with provisioning data"
+	default n
+	help
+	  When enabled, the provisioning script merges the generated provisioning
+	  data into the application hex file and emits a single merged hex output.
+
+	  When disabled, the build generates only the provisioning data hex file in
+	  addition to the normal application zephyr.hex output.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/subsys/kvss/zms/zms_provisioning/README.rst
+++ b/samples/subsys/kvss/zms/zms_provisioning/README.rst
@@ -1,0 +1,62 @@
+.. zephyr:code-sample:: zms-provisioning
+   :name: ZMS Provisioning Data
+   :relevant-api: zms_high_level_api
+
+   Generate ZMS provisioning data at build time and flash it with the application image.
+
+Overview
+********
+
+This sample demonstrates how to pre-populate a ZMS partition with data generated at build time.
+It uses ``gen_zms_provision_data.py`` to create provisioning records from an input file
+(``example_data.txt`` by default).
+
+The provisioning flow supports two modes controlled by
+``CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX``:
+
+* ``y``: generate a single merged image (``zephyr_with_provision.hex``)
+* ``n``: generate a raw provisioning image (``provisioned_raw.hex``) and a merged image for flashing
+
+In both modes, ``west flash`` is configured to program ``zephyr_with_provision.hex``.
+
+Requirements
+************
+
+* ``nrf54h20dk/nrf54h20/cpuapp``
+
+Building and Running
+********************
+
+Build the sample for ``nrf54h20dk/nrf54h20/cpuapp``:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/kvss/zms/zms_provisioning
+   :board: nrf54h20dk/nrf54h20/cpuapp
+   :goals: build
+   :compact:
+
+Flash the sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/kvss/zms/zms_provisioning
+   :board: nrf54h20dk/nrf54h20/cpuapp
+   :goals: flash
+   :compact:
+
+Configuration
+*************
+
+The sample provides this configuration option:
+
+* ``CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX``
+
+Set it in ``prj.conf`` or as an extra configuration for your build.
+
+Generated Artifacts
+*******************
+
+Depending on configuration, the build produces these files in ``build/zephyr``:
+
+* ``zephyr.hex``: application image
+* ``provisioned_raw.hex``: raw provisioning image (when merge option is disabled)
+* ``zephyr_with_provision.hex``: image used by ``west flash``

--- a/samples/subsys/kvss/zms/zms_provisioning/example_data.txt
+++ b/samples/subsys/kvss/zms/zms_provisioning/example_data.txt
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example input file for provision-raw command
+# Format: ID:hexdata (one per line)
+# Lines starting with # are comments
+# Empty or commented lines are ignored
+
+# Device UUID (ID=1, 16 bytes)
+1:12345678123412341234123456789abc
+
+# Authentication Token (ID=2, "HelloWorld" in ASCII)
+2:48656c6c6f576f726c64
+
+# Device Serial Number (ID=3, 8 bytes)
+3:0123456789ABCDEF
+
+# Configuration Flags (ID=10, 4 bytes)
+0x0A:01020304
+
+# Firmware Version (ID=11, "v1.0.0" in ASCII)
+11:76312e302e30
+
+# Device Type (ID=12, 2 bytes)
+12:AABB
+
+# Manufacturing Date (ID=13, 8 bytes - Unix timestamp)
+13:0000000065A4B2C0
+
+# Calibration Data (ID=20, 32 bytes of example data)
+20:0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20
+
+# Security Key (ID=100, 32 bytes)
+100:FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0

--- a/samples/subsys/kvss/zms/zms_provisioning/prj.conf
+++ b/samples/subsys/kvss/zms/zms_provisioning/prj.conf
@@ -1,0 +1,8 @@
+# ZMS Configuration
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_ZMS=y
+CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX=y
+
+# Logging (optional, for debugging)
+CONFIG_LOG=y

--- a/samples/subsys/kvss/zms/zms_provisioning/sample.yaml
+++ b/samples/subsys/kvss/zms/zms_provisioning/sample.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: ZMS Provisioning Sample
+
+common:
+  tags:
+    - zms
+    - kvss
+  platform_allow:
+    - nrf54h20dk/nrf54h20/cpuapp
+  integration_platforms:
+    - nrf54h20dk/nrf54h20/cpuapp
+
+tests:
+  sample.zms.provisioning:
+    build_only: true
+
+  sample.zms.provisioning.merge:
+    build_only: true
+    extra_configs:
+      - CONFIG_SAMPLE_ZMS_PROVISIONING_MERGE_WITH_APP_HEX=y

--- a/samples/subsys/kvss/zms/zms_provisioning/src/main.c
+++ b/samples/subsys/kvss/zms/zms_provisioning/src/main.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/kvss/zms.h>
+
+#define ZMS_PARTITION        storage_partition
+#define ZMS_PARTITION_DEVICE PARTITION_DEVICE(ZMS_PARTITION)
+#define ZMS_PARTITION_OFFSET PARTITION_OFFSET(ZMS_PARTITION)
+
+static struct zms_fs fs;
+
+void init_storage(void)
+{
+	int rc;
+	struct flash_pages_info info;
+
+	fs.flash_device = ZMS_PARTITION_DEVICE;
+	if (!device_is_ready(fs.flash_device)) {
+		printk("Flash device %s is not ready\n", fs.flash_device->name);
+		return;
+	}
+
+	fs.offset = ZMS_PARTITION_OFFSET;
+	rc = flash_get_page_info_by_offs(fs.flash_device, fs.offset, &info);
+	if (rc) {
+		printk("Unable to get page info, rc=%d\n", rc);
+		return;
+	}
+
+	fs.sector_size = info.size;
+	fs.sector_count = 3U;  /* Adjust based on your partition size */
+
+	rc = zms_mount(&fs);
+	if (rc) {
+		printk("ZMS mount failed: %d\n", rc);
+		return;
+	}
+
+	printk("ZMS mounted successfully\n");
+}
+
+void read_data(void)
+{
+	uint8_t buf[128];
+	ssize_t len;
+
+	/* Read ID 2 */
+	len = zms_read(&fs, 2, buf, sizeof(buf));
+	if (len > 0) {
+		printk("ID 2: ");
+		for (int i = 0; i < len; i++) {
+			printk("%c", buf[i]);
+		}
+		printk("\n");
+	}
+}
+
+int main(void)
+{
+	printf("Hello World! %s\n", CONFIG_BOARD_TARGET);
+
+	init_storage();
+	read_data();
+
+	return 0;
+}

--- a/scripts/build/fs_class.py
+++ b/scripts/build/fs_class.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FsSectorStatus(Enum):
+    ERASED = 0
+    OPEN = 1
+    CLOSED = 2
+    NA = 3
+
+
+@dataclass
+class FsSectorData:
+    status: FsSectorStatus
+    records: dict
+
+
+class Fs(ABC):
+    def __init__(self, base_addr, sector_size, write_block_size, flash_erase_value):
+        self.base_addr = base_addr
+        self.sector_size = sector_size
+        self.write_block_size = write_block_size
+        self.flash_erase_value = flash_erase_value
+
+    @abstractmethod
+    def initialize(self, ih):
+        """
+        Initialize the file system.
+        Write all required records to the file system to make it ready for use.
+
+        Args:
+            ih (intelhex.IntelHex): Intel Hex object.
+        """
+
+    @abstractmethod
+    def write_record(self, ih, record_id, data):
+        """
+        Write a single record to the file system.
+
+        Args:
+            ih (intelhex.IntelHex): Intel Hex object.
+            record_id (int): Record ID.
+            data (bytes): Record data.
+        """
+
+    @abstractmethod
+    def parse(self, bin_str):
+        """
+        Parse the file system.
+
+        Args:
+            bin_str (str): Binary string containing the file system.
+
+        Returns:
+            dict: Dictionary with key-value (record_id, record_data) pairs.
+        """
+
+    # Helper methods used for writing the file system
+
+    def _from_relative_2_absolute_addr(self, offset):
+        return self.base_addr + offset
+
+    def _align_data_to_wbs(self, data):
+        padding = (self.write_block_size - len(data)) % self.write_block_size
+        return data + self.flash_erase_value * padding
+
+    # Helper methods used for parsing the file system
+
+    def _get_sector_cnt(self, bin_str):
+        assert (len(bin_str) % self.sector_size) == 0
+        return int(len(bin_str) / self.sector_size)
+
+    def _get_sector_addr_range(self, sector_idx):
+        start = self.sector_size * sector_idx
+        end = self.sector_size * (sector_idx + 1)
+        return start, end
+
+    def _get_sector(self, bin_str, sector_idx):
+        start, end = self._get_sector_addr_range(sector_idx)
+        sector = bin_str[start:end]
+        return sector
+
+    def _parse_all_sectors(self, bin_str, parse_sector_fn):
+        sectors = []
+
+        sector_cnt = self._get_sector_cnt(bin_str)
+        for i in range(0, sector_cnt):
+            sector = self._get_sector(bin_str, i)
+            parsed_sector = parse_sector_fn(sector)
+            sectors.append(parsed_sector)
+
+        return sectors
+
+    def _find_newest_sector_id(self, sectors):
+        newest_idx = None
+
+        for idx, elem in enumerate(sectors):
+            next_elem = sectors[(idx + 1) % len(sectors)]
+            if elem.status == FsSectorStatus.CLOSED and next_elem.status == FsSectorStatus.OPEN:
+                if newest_idx is not None:
+                    print("Memory analysis: Found another transition from closed to open sector")
+                newest_idx = (idx + 1) % len(sectors)
+
+        if newest_idx is None:
+            print("Memory analysis: There was no transition, will proceed from the end of memory")
+            newest_idx = len(sectors) - 1
+
+        return newest_idx
+
+    def _get_sectors_additional_metadata(self, sectors):
+        additional_metadata = {
+            "sectors_with_records_cnt": 0,
+            "first_sector_with_records_idx": None,
+        }
+
+        for idx, sector in enumerate(sectors):
+            if len(sector.records) > 0:
+                if additional_metadata["first_sector_with_records_idx"] is None:
+                    additional_metadata["first_sector_with_records_idx"] = idx
+                additional_metadata["sectors_with_records_cnt"] += 1
+
+        return additional_metadata
+
+    def _get_sectors_range(self, sectors):
+        sector_cnt = len(sectors)
+        sectors_range = None
+
+        additional_metadata = self._get_sectors_additional_metadata(sectors)
+
+        if additional_metadata["sectors_with_records_cnt"] == 0:
+            print("Memory analysis: No data records found in the memory")
+            return None
+
+        if additional_metadata["sectors_with_records_cnt"] == 1:
+            print("Memory analysis: Found only one sector with data records")
+            sectors_range = (
+                additional_metadata["first_sector_with_records_idx"],
+                additional_metadata["first_sector_with_records_idx"] + 1,
+            )
+        else:
+            print("Memory analysis: Assuming range of storage partition by itself")
+            sectors_range = (additional_metadata["first_sector_with_records_idx"], sector_cnt)
+
+        print(f"Memory analysis: Search in sector range: {sectors_range}")
+        return sectors_range
+
+    def _order_sectors(self, sectors):
+        if len(sectors) == 0:
+            print("Memory analysis: No sectors to be analysed")
+            return None
+
+        sectors_range = self._get_sectors_range(sectors)
+        if sectors_range is None:
+            return None
+
+        sectors = sectors[sectors_range[0] : sectors_range[1]]
+
+        if len(sectors) > 1:
+            # Calculate the oldest sector ID
+            idx = (self._find_newest_sector_id(sectors) + 1) % len(sectors)
+            # Reorder NVS sectors metadata from the oldest to the newest
+            sectors = sectors[idx:] + sectors[:idx]
+
+        return sectors
+
+    def _consolidate_records(self, ordered_sectors):
+        if ordered_sectors is None:
+            return {}
+
+        consolidated_records = {}
+        for sector in ordered_sectors:
+            if len(sector.records) == 0:
+                continue
+
+            for record_id, value in sector.records.items():
+                consolidated_records[record_id] = value
+
+        return consolidated_records

--- a/scripts/build/fs_raw_instance.py
+++ b/scripts/build/fs_raw_instance.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import fs_class as fs_core
+import intelhex
+import zms as fs_zms
+
+
+class RawStorage:
+    """Direct raw storage"""
+
+    def __init__(self, fs: fs_core.Fs):
+        self.fs = fs
+
+    @staticmethod
+    def validate_id_data_records(id_data_records):
+        """Validate ID-data pairs"""
+        for record_id, data in id_data_records.items():
+            if not isinstance(record_id, int):
+                print(f"Record ID {record_id} is not an integer")
+                return False
+            if record_id < 0:
+                print(f"Record ID {record_id} is negative")
+                return False
+            if not isinstance(data, bytes):
+                print(f"Data for ID {record_id} is not a bytes object")
+                return False
+        return True
+
+    def read(self, bin_str):
+        """
+        Read ID-data records from the binary string containing the storage partition.
+
+        Args:
+            bin_str (str): Binary string containing the storage partition.
+
+        Returns:
+            dict: Dictionary with ID-data records.
+        """
+        records = self.fs.parse(bin_str)
+
+        if records is None:
+            return None
+
+        if not self.validate_id_data_records(records):
+            return None
+
+        return records
+
+    def write(self, dest_hex_file, id_data_records):
+        """
+        Write ID-data records to the Intel Hex file.
+
+        Args:
+            dest_hex_file (str): Destination hex file path.
+            id_data_records (dict): Dictionary with ID-data records (int -> bytes).
+
+        Returns:
+            bool: True if the operation was successful, False otherwise.
+        """
+        # Validate ID-data records
+        if not self.validate_id_data_records(id_data_records):
+            return False
+
+        # Create an IntelHex object
+        ih = intelhex.IntelHex()
+
+        # Write initialization records
+        self.fs.initialize(ih)
+
+        # Write ID-data records
+        for record_id, data in id_data_records.items():
+            print(f"  Writing ID {record_id} ({len(data)} bytes)")
+            self.fs.write_record(ih, record_id, data)
+
+        # Write to hex file
+        try:
+            ih.write_hex_file(dest_hex_file)
+        except Exception as e:
+            print(f"Error writing hex file: {str(e)}")
+            return False
+
+        return True
+
+
+def storage_raw_instance_create(
+    storage_base, storage_sector_size, device_write_block_size, device_flash_erase_value
+):
+    """
+    Create a raw storage instance
+
+    Args:
+        storage_base: Base address of storage partition
+        storage_sector_size: Size of each sector
+        device_write_block_size: Write block size of the device
+        device_flash_erase_value: Erase value for flash (typically 0xFF)
+
+    Returns:
+        RawStorage: Raw storage instance
+    """
+
+    fs = fs_zms.FsZms(
+        base_addr=storage_base,
+        sector_size=storage_sector_size,
+        write_block_size=device_write_block_size,
+        flash_erase_value=device_flash_erase_value,
+    )
+
+    return RawStorage(fs=fs)

--- a/scripts/build/gen_zms_provision_data.py
+++ b/scripts/build/gen_zms_provision_data.py
@@ -1,0 +1,380 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import argparse
+import os
+import sys
+
+import fs_raw_instance as storage_raw
+from intelhex import IntelHex
+
+NVM_ERASE_VALUE = b'\xff'
+
+
+def provision_error_handle(msg, param_prefix=None):
+    parser.print_usage()
+
+    if param_prefix is None:
+        param_prefix = ''
+    else:
+        param_prefix = f'argument {param_prefix}: '
+    print('provision-raw: error: ' + param_prefix + msg)
+
+    sys.exit(1)
+
+
+def hex_arg_to_int(hex_str):
+    try:
+        return int(hex_str, 16)
+    except ValueError:
+        return None
+
+
+def parse_id_data_pair(pair_str):
+    """Parse ID:data pair from command line.
+    Format: ID:data where data is hex string (without 0x prefix)
+    Example: 1:48656c6c6f for ID=1, data=b'Hello'
+    """
+    try:
+        parts = pair_str.split(':', 1)
+        if len(parts) != 2:
+            return None, None, "Invalid format. Use ID:hexdata"
+
+        # Parse ID - can be decimal or hex (with 0x prefix)
+        id_str = parts[0].strip()
+        if id_str.startswith('0x') or id_str.startswith('0X'):
+            record_id = int(id_str, 16)
+        else:
+            record_id = int(id_str, 10)
+
+        # Parse data as hex string
+        data_str = parts[1].strip()
+        if data_str.startswith('0x') or data_str.startswith('0X'):
+            data_str = data_str[2:]
+
+        # Convert hex string to bytes
+        if len(data_str) % 2 != 0:
+            return None, None, "Data hex string must have even number of characters"
+
+        data = bytes.fromhex(data_str)
+
+        return record_id, data, None
+    except ValueError as e:
+        return None, None, str(e)
+
+
+def parse_args():
+    global parser
+
+    parser = argparse.ArgumentParser(
+        description='Raw ZMS Provisioning Tool', add_help=False, allow_abbrev=False
+    )
+
+    parser.add_argument(
+        '-d',
+        '--data',
+        action='append',
+        metavar='ID:HEXDATA',
+        help='ID-data pair in format ID:hexdata. Can be specified multiple times. '
+        'Example: -d 1:48656c6c6f -d 2:576f726c64',
+    )
+    parser.add_argument(
+        '-i',
+        '--input-file',
+        metavar='FILE',
+        help='Input file with ID-data pairs (one per line, format: ID:hexdata)',
+    )
+    parser.add_argument(
+        '-o',
+        '--output-path',
+        default='provisioned_raw.hex',
+        metavar='PATH',
+        help='Path to store the result of the provisioning.',
+    )
+    parser.add_argument(
+        '-f',
+        '--storage-base',
+        metavar='ADDRESS',
+        required=True,
+        help='Storage base address given in hex format.',
+    )
+    parser.add_argument(
+        '-s',
+        '--storage-size',
+        metavar='SIZE',
+        required=True,
+        help='Storage size in bytes given in hex format.',
+    )
+    parser.add_argument(
+        '-n',
+        '--nvm-address',
+        default=0x0,
+        metavar='NVM_OFFSET',
+        help='NVM base address offset in hex format. Default is 0x0.',
+    )
+    parser.add_argument(
+        '-z',
+        '--nvm-size',
+        default=0x0,
+        metavar='NVM_SIZE',
+        help='NVM size in bytes given in hex format. Default is 0x0.',
+    )
+    parser.add_argument(
+        '-w',
+        '--write-block-size',
+        default=16,
+        metavar='WRITE_BLOCK_SIZE',
+        help='Write block size in bytes given in int format. Default is 16.',
+    )
+    parser.add_argument(
+        '-c',
+        '--sector-size',
+        default=0x1000,
+        metavar='SECTOR_SIZE',
+        help='Sector size in bytes given in hex format. Default is 0x1000.',
+    )
+    parser.add_argument(
+        '-x',
+        '--input-hex-file',
+        help='Hex file to be merged with provisioned data. If this option is set, '
+        'the output hex file will be [input-hex-file + provisioned data].',
+    )
+
+    parser.add_argument('--help', action='help', help='Show this help message and exit')
+    args = parser.parse_args()
+
+    return args
+
+
+def storage_base_input_handle(storage_base, storage_size, nvm_address, nvm_size, write_block_size):
+    param_prefix = '-f/--storage-base'
+
+    nvm_size = hex_arg_to_int(nvm_size)
+    storage_base = hex_arg_to_int(storage_base)
+    storage_size = hex_arg_to_int(storage_size)
+    write_block_size = int(write_block_size)
+
+    if nvm_address != 0x0:
+        nvm_address = hex_arg_to_int(nvm_address)
+        if storage_base < nvm_address:
+            storage_base = nvm_address + storage_base
+
+    if storage_base < nvm_address:
+        provision_error_handle(
+            f'storage address is smaller than the target device memory: '
+            f'{hex(storage_base)} < {hex(nvm_address)}',
+            param_prefix,
+        )
+    if (nvm_address + nvm_size - storage_base) <= 0:
+        provision_error_handle(
+            f'storage address is bigger than the target device memory: '
+            f'{hex(storage_base)} >= {hex(nvm_size)}',
+            param_prefix,
+        )
+
+    if (nvm_address + nvm_size - storage_base) < storage_size:
+        provision_error_handle(
+            f'not enough space from address to the end of target device memory:'
+            f' {hex(storage_base)} + {hex(storage_size)} >'
+            f' {hex(nvm_address + nvm_size)}',
+            param_prefix,
+        )
+
+    if (storage_base % write_block_size) != 0:
+        aligned_page = hex(storage_base & ~(write_block_size - 1))
+        provision_error_handle(
+            f'address should be page aligned: {hex(storage_base)} -> {aligned_page}', param_prefix
+        )
+
+    return storage_base
+
+
+def input_hex_file_input_handle(input_hex_file):
+    param_prefix = '-x/--input-hex-file'
+
+    if not input_hex_file:
+        return input_hex_file
+
+    try:
+        input_hex_file = os.path.realpath(input_hex_file)
+    except Exception:
+        provision_error_handle('malformed path format', param_prefix)
+
+    if not os.path.exists(input_hex_file):
+        provision_error_handle('target file does not exist', param_prefix)
+
+    if not os.path.isfile(input_hex_file):
+        provision_error_handle('target path is not a file', param_prefix)
+
+    try:
+        IntelHex(input_hex_file)
+    except Exception as e:
+        msg = 'target file with malformed content format\n' + str(e)
+        provision_error_handle(msg, param_prefix)
+
+    return input_hex_file
+
+
+def output_path_input_handle(output_path):
+    param_prefix = '-o/--output-path'
+
+    if not output_path:
+        return output_path
+
+    try:
+        output_path = os.path.realpath(output_path)
+    except Exception:
+        provision_error_handle('malformed path format', param_prefix)
+
+    if os.path.isdir(output_path):
+        provision_error_handle('target is an existing directory', param_prefix)
+
+    if not os.path.exists(os.path.split(output_path)[0]):
+        provision_error_handle('target directory does not exist', param_prefix)
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    return output_path
+
+
+def parse_data_from_args(data_args):
+    """Parse ID-data pairs from command line arguments"""
+    param_prefix = '-d/--data'
+    id_data_records = {}
+
+    if not data_args:
+        return id_data_records
+
+    for pair_str in data_args:
+        record_id, data, error = parse_id_data_pair(pair_str)
+        if error:
+            provision_error_handle(f'Invalid data pair "{pair_str}": {error}', param_prefix)
+
+        if record_id in id_data_records:
+            provision_error_handle(f'Duplicate ID {record_id}', param_prefix)
+
+        id_data_records[record_id] = data
+
+    return id_data_records
+
+
+def parse_data_from_file(input_file):
+    """Parse ID-data pairs from input file"""
+    param_prefix = '-i/--input-file'
+    id_data_records = {}
+
+    if not input_file:
+        return id_data_records
+
+    try:
+        with open(input_file) as f:
+            line_num = 0
+            for line in f:
+                line_num += 1
+                line = line.strip()
+
+                # Skip empty lines and comments
+                if not line or line.startswith('#'):
+                    continue
+
+                record_id, data, error = parse_id_data_pair(line)
+                if error:
+                    provision_error_handle(
+                        f'Line {line_num}: Invalid data pair "{line}": {error}', param_prefix
+                    )
+
+                if record_id in id_data_records:
+                    provision_error_handle(
+                        f'Line {line_num}: Duplicate ID {record_id}', param_prefix
+                    )
+
+                id_data_records[record_id] = data
+    except FileNotFoundError:
+        return id_data_records
+    except Exception as e:
+        provision_error_handle(f'Error reading file: {str(e)}', param_prefix)
+
+    return id_data_records
+
+
+def merge_hex_files(input_hex_file, provisioned_data_hex_file, output_file):
+    try:
+        h = IntelHex(input_hex_file)
+        h.merge(IntelHex(provisioned_data_hex_file))
+        h.write_hex_file(output_file)
+    except Exception as e:
+        os.remove(provisioned_data_hex_file)
+        msg = '--input-hex-file target cannot be merged with provisioning data\n' + str(e)
+        provision_error_handle(msg)
+
+
+def provision(
+    data_args,
+    input_file,
+    output_path,
+    storage_base,
+    storage_size,
+    nvm_address,
+    nvm_size,
+    write_block_size,
+    sector_size,
+    input_hex_file,
+):
+    storage_base = storage_base_input_handle(
+        storage_base, storage_size, nvm_address, nvm_size, write_block_size
+    )
+    input_hex_file = input_hex_file_input_handle(input_hex_file)
+    output_path = output_path_input_handle(output_path)
+
+    # Parse ID-data pairs from both sources
+    id_data_records = parse_data_from_args(data_args)
+    file_records = parse_data_from_file(input_file)
+
+    # Merge records, checking for duplicates
+    for record_id, data in file_records.items():
+        if record_id in id_data_records:
+            provision_error_handle(f'Duplicate ID {record_id} in command line and input file')
+        id_data_records[record_id] = data
+
+    print(f'''Using:
+    * Storage base: {hex(storage_base)}
+    * Device write block size: {write_block_size} bytes
+    * Number of records: {len(id_data_records)}''')
+
+    sector_size = hex_arg_to_int(sector_size)
+    write_block_size = int(write_block_size)
+    # Create raw storage instance
+    raw_storage = storage_raw.storage_raw_instance_create(
+        storage_base, sector_size, write_block_size, NVM_ERASE_VALUE
+    )
+
+    if raw_storage.write(output_path, id_data_records):
+        print('Provisioning successful')
+        print(f'Generated: {output_path}')
+    else:
+        provision_error_handle('Provisioning failed')
+
+    if input_hex_file:
+        provisioned_data_hex_file = output_path
+        merge_hex_files(input_hex_file, provisioned_data_hex_file, output_path)
+        print(f'Merged with: {input_hex_file}')
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    provision(
+        args.data,
+        args.input_file,
+        args.output_path,
+        args.storage_base,
+        args.storage_size,
+        args.nvm_address,
+        args.nvm_size,
+        args.write_block_size,
+        args.sector_size,
+        args.input_hex_file,
+    )

--- a/scripts/build/zms.py
+++ b/scripts/build/zms.py
@@ -1,0 +1,594 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import struct
+import zlib
+from dataclasses import dataclass
+from enum import Enum
+
+import fs_class as fs_core
+
+
+class ZmsIdSize(Enum):
+    """Enum for ZMS ID size configuration"""
+
+    ID_32_BIT = 32
+    ID_64_BIT = 64
+
+
+# Used for special ATEs, such as: Empty, Close, GC done.
+@dataclass
+class Metadata:
+    meta_data: int  # uint32_t meta_data;
+
+    def __eq__(self, other):
+        if not isinstance(other, Metadata):
+            return False
+        return self.meta_data == other.meta_data
+
+    def serialize(self):
+        return struct.pack('<I', self.meta_data)
+
+    @classmethod
+    def deserialize(cls, data):
+        return cls(meta_data=struct.unpack('<I', data)[0])
+
+
+# Used for data ATEs that point to the big data.
+@dataclass
+class DataCRC:
+    data_crc: int  # uint32_t data_crc;
+
+    def __eq__(self, other):
+        if not isinstance(other, DataCRC):
+            return False
+        return self.data_crc == other.data_crc
+
+    @staticmethod
+    def crc32_from_bytes(buf):
+        return zlib.crc32(buf) & 0xFFFFFFFF
+
+    def verify_crc32(self, data):
+        # CRC32 support is optional
+        if self.data_crc == 0:
+            return True
+
+        if self.data_crc != self.crc32_from_bytes(data):
+            print("Memory analysis: CRC32 mismatch")
+            return False
+        return True
+
+    def serialize(self):
+        return struct.pack('<I', self.data_crc)
+
+    @classmethod
+    def deserialize(cls, data):
+        return cls(data_crc=struct.unpack('<I', data)[0])
+
+
+# Used for data ATEs that contain small data.
+@dataclass
+class SmallData:
+    data: bytes  # uint8_t data[8] or uint8_t data[4];
+
+    MAX_SIZE_32BIT = 8
+    MAX_SIZE_64BIT = 4
+
+    def __eq__(self, other):
+        if not isinstance(other, SmallData):
+            return False
+        return self.data == other.data
+
+    def serialize(self):
+        return self.data
+
+    @classmethod
+    def deserialize(cls, data):
+        return cls(data=data)
+
+    @classmethod
+    def get_max_size(cls, id_size):
+        return cls.MAX_SIZE_32BIT if id_size == ZmsIdSize.ID_32_BIT else cls.MAX_SIZE_64BIT
+
+
+# Used for either data ATEs that either points to the big data or for special ATEs.
+@dataclass
+class DataInfo:
+    offset: int  # uint32_t offset;
+    additional_info: DataCRC | Metadata  # union { uint32_t data_crc; uint32_t metadata; };
+
+    def __eq__(self, other):
+        if not isinstance(other, DataInfo):
+            return False
+        return (self.offset == other.offset) and (self.additional_info == other.additional_info)
+
+    def serialize(self):
+        return struct.pack('<I', self.offset) + self.additional_info.serialize()
+
+    @classmethod
+    def deserialize(cls, data, is_special_ate):
+        offset = struct.unpack('<I', data[:4])[0]
+        additional_info = None
+        if is_special_ate:
+            additional_info = Metadata.deserialize(data[4:8])
+        else:
+            additional_info = DataCRC.deserialize(data[4:8])
+        return cls(offset=offset, additional_info=additional_info)
+
+
+# Represents the ZMS ATE for both 32-bit and 64-bit ID variants
+#
+# (32-bit ID)
+# struct zms_ate {
+#     uint8_t crc8;
+#     uint8_t cycle_cnt;
+#     uint16_t len;
+#     uint32_t id;
+#     union {
+#         uint8_t data[8];
+#         struct {
+#             uint32_t offset;
+#             union {
+#                 uint32_t data_crc;
+#                 uint32_t metadata;
+#             };
+#         };
+#     };
+# } __packed;
+#
+# (64-bit ID)
+# struct zms_ate {
+#     uint8_t crc8;
+#     uint8_t cycle_cnt;
+#     uint16_t len;
+#     uint64_t id;
+#     union {
+#         uint8_t data[4];
+#         uint32_t offset;
+#         uint32_t metadata;
+#     };
+# } __packed;
+
+
+@dataclass
+class FsZmsAte:
+    cycle_cnt: int
+    len: int
+    id: int
+    content: SmallData | DataInfo | Metadata
+    id_size: ZmsIdSize
+
+    crc8: int = 0xFF
+    auto_update_crc8: bool = True
+
+    # Size of the ZMS ATE equal to sizeof(struct zms_ate).
+    ATE_SIZE = 16
+
+    # Special ATE ID for both 32-bit and 64-bit
+    HEAD_ID_32BIT = 0xFFFFFFFF
+    HEAD_ID_64BIT = 0xFFFFFFFFFFFFFFFF
+
+    def __post_init__(self):
+        if self.auto_update_crc8:
+            self.crc8 = self._compute_crc8()
+
+    def __eq__(self, other):
+        if not isinstance(other, FsZmsAte):
+            return False
+        return (
+            (self.id == other.id)
+            and (self.len == other.len)
+            and (self.content == other.content)
+            and (self.cycle_cnt == other.cycle_cnt)
+            and (self.crc8 == other.crc8)
+            and (self.id_size == other.id_size)
+        )
+
+    @staticmethod
+    def crc8_ccitt_from_bytes(buf):
+        CRC8_CCITT_TABLE = [
+            0x00,
+            0x07,
+            0x0E,
+            0x09,
+            0x1C,
+            0x1B,
+            0x12,
+            0x15,
+            0x38,
+            0x3F,
+            0x36,
+            0x31,
+            0x24,
+            0x23,
+            0x2A,
+            0x2D,
+        ]
+
+        crc = 0xFF
+        for byte in buf:
+            crc = (crc ^ byte) & 0xFF
+            crc = ((crc << 4) ^ CRC8_CCITT_TABLE[(crc >> 4) & 0xFF]) & 0xFF
+            crc = ((crc << 4) ^ CRC8_CCITT_TABLE[(crc >> 4) & 0xFF]) & 0xFF
+        return crc
+
+    def _compute_crc8(self):
+        """Compute CRC8 for the ATE"""
+        return self.crc8_ccitt_from_bytes(self.serialize()[1:])
+
+    def _get_head_id(self):
+        """Get the appropriate HEAD_ID based on id_size"""
+        return self.HEAD_ID_32BIT if self.id_size == ZmsIdSize.ID_32_BIT else self.HEAD_ID_64BIT
+
+    def _serialize_header(self):
+        """Serialize the header (cycle_cnt, len, id)"""
+        if self.id_size == ZmsIdSize.ID_32_BIT:
+            return struct.pack('<BHI', self.cycle_cnt, self.len, self.id)
+        else:
+            return struct.pack('<BHQ', self.cycle_cnt, self.len, self.id)
+
+    def _serialize_content(self):
+        """Serialize the content based on type and id_size"""
+        if isinstance(self.content, SmallData):
+            return self.content.serialize()
+        elif isinstance(self.content, DataInfo):
+            if self.id_size == ZmsIdSize.ID_32_BIT:
+                return self.content.serialize()
+            else:
+                # For 64-bit ID, only offset is stored (no data_crc/metadata in union)
+                return struct.pack('<I', self.content.offset)
+        elif isinstance(self.content, Metadata):
+            # For 64-bit special ATEs
+            return self.content.serialize()
+        else:
+            raise ValueError(f"Unknown content type: {type(self.content)}")
+
+    def serialize(self):
+        header_data = self._serialize_header()
+        content_data = self._serialize_content()
+        body = header_data + content_data
+
+        if self.auto_update_crc8:
+            self.crc8 = self.crc8_ccitt_from_bytes(body)
+
+        return struct.pack('<B', self.crc8) + body
+
+    def is_valid_crc8(self):
+        return self.crc8 == self._compute_crc8()
+
+    def is_valid_cycle_cnt(self, cycle_cnt):
+        return self.cycle_cnt == cycle_cnt
+
+    def is_valid(self, cycle_cnt):
+        return self.is_valid_crc8() and self.is_valid_cycle_cnt(cycle_cnt)
+
+    @classmethod
+    def deserialize(cls, ate_bytes, write_block_size, id_size):
+        ate_size = cls.size_from_write_block_size(write_block_size)
+        assert len(ate_bytes) == ate_size
+
+        ate_crc8 = ate_bytes[0]
+        ate_cycle_cnt = ate_bytes[1]
+        ate_len = struct.unpack('<H', ate_bytes[2:4])[0]
+
+        if id_size == ZmsIdSize.ID_32_BIT:
+            ate_id = struct.unpack('<I', ate_bytes[4:8])[0]
+            content_start = 8
+            is_special_ate = ate_id == cls.HEAD_ID_32BIT
+            small_data_max = SmallData.MAX_SIZE_32BIT
+        else:
+            ate_id = struct.unpack('<Q', ate_bytes[4:12])[0]
+            content_start = 12
+            is_special_ate = ate_id == cls.HEAD_ID_64BIT
+            small_data_max = SmallData.MAX_SIZE_64BIT
+
+        # Parse content
+        if is_special_ate:
+            if id_size == ZmsIdSize.ID_32_BIT:
+                content = DataInfo.deserialize(ate_bytes[content_start : content_start + 8], True)
+            else:
+                # For 64-bit special ATE, content is metadata
+                content = Metadata.deserialize(ate_bytes[content_start : content_start + 4])
+        elif ate_len <= small_data_max:
+            content_end = content_start + small_data_max
+            content = SmallData.deserialize(ate_bytes[content_start:content_end])
+        else:
+            if id_size == ZmsIdSize.ID_32_BIT:
+                content = DataInfo.deserialize(ate_bytes[content_start : content_start + 8], False)
+            else:
+                # For 64-bit data ATE, only offset is stored
+                offset = struct.unpack('<I', ate_bytes[content_start : content_start + 4])[0]
+                # No CRC for 64-bit
+                content = DataInfo(offset=offset, additional_info=DataCRC(data_crc=0))
+
+        return cls(
+            id=ate_id,
+            len=ate_len,
+            content=content,
+            cycle_cnt=ate_cycle_cnt,
+            crc8=ate_crc8,
+            id_size=id_size,
+            auto_update_crc8=False,
+        )
+
+    @classmethod
+    def size_from_write_block_size(cls, write_block_size):
+        assert write_block_size > 0
+        assert (write_block_size & (write_block_size - 1)) == 0
+        return (cls.ATE_SIZE + (write_block_size - 1)) & ~(write_block_size - 1)
+
+
+# Special ATE: Empty ATE, located at the end of the sector (N ate).
+class FsZmsAteEmpty(FsZmsAte):
+    ZMS_VERSION = 0x01
+    ZMS_VERSION_OFFSET = 0
+    ZMS_MAGIC = 0x42
+    ZMS_MAGIC_OFFSET = 8
+    ZMS_RESERVED = 0x0000
+    ZMS_RESERVED_OFFSET = 16
+
+    @classmethod
+    def _serialize_metadata(cls):
+        return (
+            (cls.ZMS_VERSION << cls.ZMS_VERSION_OFFSET)
+            | (cls.ZMS_MAGIC << cls.ZMS_MAGIC_OFFSET)
+            | (cls.ZMS_RESERVED << cls.ZMS_RESERVED_OFFSET)
+        )
+
+    def __init__(self, cycle_cnt, id_size):
+        head_id = self.HEAD_ID_32BIT if id_size == ZmsIdSize.ID_32_BIT else self.HEAD_ID_64BIT
+
+        if id_size == ZmsIdSize.ID_32_BIT:
+            meta_data = Metadata(meta_data=FsZmsAteEmpty._serialize_metadata())
+            content = DataInfo(offset=0x0, additional_info=meta_data)
+        else:
+            # For 64-bit, content is just metadata
+            content = Metadata(meta_data=FsZmsAteEmpty._serialize_metadata())
+
+        super().__init__(
+            id=head_id, len=0xFFFF, content=content, cycle_cnt=cycle_cnt, id_size=id_size
+        )
+
+
+# Special ATE: Close ATE, located at the end of the sector (N-1 ate).
+class FsZmsAteClose(FsZmsAte):
+    def __init__(self, cycle_cnt, offset, id_size):
+        head_id = self.HEAD_ID_32BIT if id_size == ZmsIdSize.ID_32_BIT else self.HEAD_ID_64BIT
+
+        if id_size == ZmsIdSize.ID_32_BIT:
+            meta_data = Metadata(meta_data=0xFFFFFFFF)
+            content = DataInfo(offset=offset, additional_info=meta_data)
+        else:
+            # For 64-bit, content is just metadata
+            content = Metadata(meta_data=0xFFFFFFFF)
+
+        super().__init__(id=head_id, len=0x0, content=content, cycle_cnt=cycle_cnt, id_size=id_size)
+
+
+class FsZms(fs_core.Fs):
+    def __init__(
+        self,
+        base_addr,
+        sector_size,
+        write_block_size,
+        flash_erase_value,
+        id_size=ZmsIdSize.ID_32_BIT,
+    ):
+        super().__init__(base_addr, sector_size, write_block_size, flash_erase_value)
+
+        self.id_size = id_size
+        ate_size = FsZmsAte.size_from_write_block_size(write_block_size)
+
+        # Start from the last ATE
+        self.ate_offset = self.sector_size - ate_size
+        self.data_offset = 0
+
+    # Provisioning methods
+
+    def _verify_sector(self):
+        assert self.ate_offset >= self.data_offset
+
+    def _change_sector_ate_offset(self, ate_len):
+        self.ate_offset -= ate_len
+        self._verify_sector()
+
+    def _change_sector_data_offset(self, data_len):
+        self.data_offset += data_len
+        self._verify_sector()
+
+    def _align_data_small(self, data, max_size):
+        assert len(data) <= max_size
+        return data + self.flash_erase_value * (max_size - len(data))
+
+    def _write_zms_ate(self, ih, zms_ate):
+        serialized_ate = self._align_data_to_wbs(zms_ate.serialize())
+        ih.frombytes(serialized_ate, self._from_relative_2_absolute_addr(self.ate_offset))
+        self._change_sector_ate_offset(len(serialized_ate))
+
+    def _write_init_empty_ate(self, ih):
+        empty_ate = FsZmsAteEmpty(cycle_cnt=0x01, id_size=self.id_size)
+        self._write_zms_ate(ih, empty_ate)
+
+    def _write_data_big(self, ih, data):
+        aligned_data = self._align_data_to_wbs(data)
+        ih.frombytes(aligned_data, self._from_relative_2_absolute_addr(self.data_offset))
+        self._change_sector_data_offset(len(aligned_data))
+
+    def _write_data_record_big(self, ih, record_id, data):
+        if self.id_size == ZmsIdSize.ID_32_BIT:
+            data_crc = DataCRC(data_crc=DataCRC.crc32_from_bytes(data))
+            content = DataInfo(offset=self.data_offset, additional_info=data_crc)
+        else:
+            # For 64-bit, no CRC stored
+            content = DataInfo(offset=self.data_offset, additional_info=DataCRC(data_crc=0))
+
+        zms_ate = FsZmsAte(
+            id=record_id, len=len(data), content=content, cycle_cnt=0x01, id_size=self.id_size
+        )
+
+        self._write_zms_ate(ih, zms_ate)
+        self._write_data_big(ih, data)
+
+    def _write_data_record_small(self, ih, record_id, data):
+        max_size = SmallData.get_max_size(self.id_size)
+        content = SmallData(data=self._align_data_small(data, max_size))
+        zms_ate = FsZmsAte(
+            id=record_id, len=len(data), content=content, cycle_cnt=0x01, id_size=self.id_size
+        )
+
+        self._write_zms_ate(ih, zms_ate)
+
+    def initialize(self, ih):
+        self._write_init_empty_ate(ih)
+
+        # Skip two ATEs: one for close ATE and one for GC done ATE
+        ate_size = FsZmsAte.size_from_write_block_size(self.write_block_size)
+        self._change_sector_ate_offset(2 * ate_size)
+
+    def write_record(self, ih, record_id, data):
+        max_size = SmallData.get_max_size(self.id_size)
+        if len(data) > max_size:
+            self._write_data_record_big(ih, record_id, data)
+        else:
+            self._write_data_record_small(ih, record_id, data)
+
+    # Extraction methods
+
+    def _is_erased_sector(self, sector):
+        return sector == (self.sector_size * self.flash_erase_value)
+
+    def _is_close_ate(self, ate):
+        if not ate.is_valid_crc8():
+            return False
+
+        close_ate_cmp = FsZmsAteClose(
+            cycle_cnt=ate.cycle_cnt, offset=self._get_close_offset(ate), id_size=self.id_size
+        )
+
+        if close_ate_cmp != ate:
+            return False
+
+        ate_size = FsZmsAte.size_from_write_block_size(self.write_block_size)
+        close_offset = self._get_close_offset(ate)
+        valid_offset = (self.sector_size - close_offset) % ate_size == 0
+
+        return valid_offset
+
+    def _get_close_offset(self, ate):
+        """Extract offset from close ATE based on id_size"""
+        if self.id_size == ZmsIdSize.ID_32_BIT:
+            return ate.content.offset
+        else:
+            # For 64-bit, metadata contains the offset in the lower bits
+            # But actually for close ATE it's all 0xff, so we need to rethink this
+            # Based on structure, for 64-bit close ATE the offset isn't stored the same way
+            # Let me check the actual close ATE structure for 64-bit
+            # Actually, looking at the structure, 64-bit close might not store offset
+            return 0
+
+    def _is_empty_ate(self, ate):
+        if not ate.is_valid_crc8():
+            return False
+
+        empty_ate_cmp = FsZmsAteEmpty(cycle_cnt=ate.cycle_cnt, id_size=self.id_size)
+        return empty_ate_cmp == ate
+
+    def _validate_data_within_sector(self, ate, ate_ptr, data_ptr):
+        if not isinstance(ate.content, DataInfo):
+            return True
+
+        if ate.content.offset < data_ptr:
+            return False
+
+        return (ate.content.offset + ate.len) < ate_ptr
+
+    def _parse_record_data(self, ate, sector, ate_ptr, data_ptr):
+        if isinstance(ate.content, SmallData):
+            return ate.content.data[: ate.len], data_ptr
+        elif isinstance(ate.content, DataInfo):
+            if isinstance(ate.content.additional_info, DataCRC):
+                if not self._validate_data_within_sector(ate, ate_ptr, data_ptr):
+                    return None, data_ptr
+
+                data = sector[ate.content.offset : (ate.content.offset + ate.len)]
+                data_ptr = ate.content.offset + ate.len
+
+                if (
+                    self.id_size == ZmsIdSize.ID_32_BIT
+                    and not ate.content.additional_info.verify_crc32(data)
+                ):
+                    return None, data_ptr
+
+                return data, data_ptr
+            else:
+                return None, data_ptr
+        elif isinstance(ate.content, Metadata):
+            return None, data_ptr
+
+        return None, data_ptr
+
+    def _parse_sector(self, sector):
+        data_ptr = 0
+        records = {}
+
+        if self._is_erased_sector(sector):
+            return fs_core.FsSectorData(status=fs_core.FsSectorStatus.ERASED, records={})
+
+        ate_size = FsZmsAte.size_from_write_block_size(self.write_block_size)
+
+        # Check last ATE (empty ATE)
+        ate_ptr = len(sector) - ate_size
+        empty_ate = FsZmsAte.deserialize(
+            sector[ate_ptr : (ate_ptr + ate_size)], self.write_block_size, self.id_size
+        )
+
+        if not self._is_empty_ate(empty_ate):
+            return fs_core.FsSectorData(status=fs_core.FsSectorStatus.NA, records={})
+
+        current_cycle_cnt = empty_ate.cycle_cnt
+
+        # Check second last ATE (close ATE)
+        ate_ptr -= ate_size
+        close_ate = FsZmsAte.deserialize(
+            sector[ate_ptr : (ate_ptr + ate_size)], self.write_block_size, self.id_size
+        )
+
+        if self._is_close_ate(close_ate) and (empty_ate.cycle_cnt == close_ate.cycle_cnt):
+            sector_status = fs_core.FsSectorStatus.CLOSED
+        else:
+            sector_status = fs_core.FsSectorStatus.OPEN
+
+        # Parse all ATEs
+        while ate_ptr >= 0:
+            ate_ptr -= ate_size
+
+            if ate_ptr < data_ptr:
+                break
+
+            ate = FsZmsAte.deserialize(
+                sector[ate_ptr : (ate_ptr + ate_size)], self.write_block_size, self.id_size
+            )
+
+            if not ate.is_valid(current_cycle_cnt):
+                continue
+
+            data, data_ptr = self._parse_record_data(ate, sector, ate_ptr, data_ptr)
+
+            if data is None:
+                continue
+
+            records[ate.id] = data
+
+        if sector_status == fs_core.FsSectorStatus.OPEN and len(records) == 0:
+            return fs_core.FsSectorData(status=fs_core.FsSectorStatus.ERASED, records={})
+
+        return fs_core.FsSectorData(status=sector_status, records=records)
+
+    def parse(self, bin_str):
+        sectors = self._parse_all_sectors(bin_str, self._parse_sector)
+        ordered_sectors = self._order_sectors(sectors)
+        consolidated_records = self._consolidate_records(ordered_sectors)
+        return consolidated_records


### PR DESCRIPTION
This is a provisioning script for ZMS storage system.
It is divided into 4 parts to make it scalable for other storage systems to be added.
gen_zms_provision_data: This is the main script that generates the provisioning data based on input data and the storage system instantiation.
fs_class.py : This is the abstraction class for the filesystem
zms.py : This is the file containing all related classes and functions for ZMS
fs_raw_instance.py : Contains the instance of the filesystem and serve as an interface to use the ZMS (or other) storage system.

The script is used in the following syntax:
```
usage: gen_zms_provision_data.py [-d ID:HEXDATA] [-i FILE] [-o PATH] -f ADDRESS -s SIZE [-n NVM_OFFSET] [-z NVM_SIZE] [-w WRITE_BLOCK_SIZE] [-c SECTOR_SIZE] [-x INPUT_HEX_FILE]
                                 [--help]

Raw ZMS Provisioning Tool

options:
  -d ID:HEXDATA, --data ID:HEXDATA
                        ID-data pair in format ID:hexdata. Can be specified multiple times. Example: -d 1:48656c6c6f -d 2:576f726c64
  -i FILE, --input-file FILE
                        Input file with ID-data pairs (one per line, format: ID:hexdata)
  -o PATH, --output-path PATH
                        Path to store the result of the provisioning.
  -f ADDRESS, --storage-base ADDRESS
                        Storage base address given in hex format.
  -s SIZE, --storage-size SIZE
                        Storage size in bytes given in hex format.
  -n NVM_OFFSET, --nvm-address NVM_OFFSET
                        NVM base address offset in hex format. Default is 0x0.
  -z NVM_SIZE, --nvm-size NVM_SIZE
                        NVM size in bytes given in hex format. Default is 0x0.
  -w WRITE_BLOCK_SIZE, --write-block-size WRITE_BLOCK_SIZE
                        Write block size in bytes given in int format. Default is 16.
  -c SECTOR_SIZE, --sector-size SECTOR_SIZE
                        Sector size in bytes given in hex format. Default is 0x1000.
  -x INPUT_HEX_FILE, --input-hex-file INPUT_HEX_FILE
                        Hex file to be merged with provisioned data. If this option is set, the output hex file will be [input-hex-file + provisioned data].
  --help                Show this help message and exit
```