### PR TITLE
Kconfig: net: remove useless default

### DIFF
--- a/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
+++ b/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
@@ -32,9 +32,6 @@ config COAP_INIT_ACK_TIMEOUT_MS
 config NET_IPV6
 	default n
 
-config NET_CONFIG_NEED_IPV6
-	default n
-
 endif # NETWORKING
 
 endif # SHIELD_SPARKFUN_SARA_R4

--- a/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
+++ b/boards/shields/sparkfun_sara_r4/Kconfig.defconfig
@@ -28,10 +28,6 @@ config UART_INTERRUPT_DRIVEN
 config COAP_INIT_ACK_TIMEOUT_MS
 	default 20000
 
-# Hack: disable IPv6 for now
-config NET_IPV6
-	default n
-
 endif # NETWORKING
 
 endif # SHIELD_SPARKFUN_SARA_R4

--- a/boards/shields/wnc_m14a2a/Kconfig.defconfig
+++ b/boards/shields/wnc_m14a2a/Kconfig.defconfig
@@ -25,9 +25,6 @@ config COAP_INIT_ACK_TIMEOUT_MS
 config NET_IPV6
 	default n
 
-config NET_CONFIG_NEED_IPV6
-	default n
-
 endif # NETWORKING
 
 endif # SHIELD_WNC_M14A2A

--- a/boards/shields/wnc_m14a2a/Kconfig.defconfig
+++ b/boards/shields/wnc_m14a2a/Kconfig.defconfig
@@ -21,10 +21,6 @@ config UART_INTERRUPT_DRIVEN
 config COAP_INIT_ACK_TIMEOUT_MS
 	default 20000
 
-# Hack: disable IPv6 for now
-config NET_IPV6
-	default n
-
 endif # NETWORKING
 
 endif # SHIELD_WNC_M14A2A


### PR DESCRIPTION
NET_CONFIG_NEED_IPV6 is by default
already not enabled, so we don't need
to add that default again in a shield.