### PR TITLE
tests: Bluetooth: tester: Fix missing NULL check in PBP BTP

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_pbp.c
+++ b/tests/bluetooth/tester/src/audio/btp_pbp.c
@@ -179,6 +179,14 @@ static int pbp_broadcast_source_adv_setup(void)
 	struct btp_bap_broadcast_local_source *source;
 
 	source = btp_bap_broadcast_local_source_from_src_id_get(0);
+	if (source == NULL) {
+		/* use dummy broadcast ID, it is updated later on anyway */
+		source = btp_bap_broadcast_local_source_allocate(0);
+		if (source == NULL) {
+			LOG_DBG("Could not allocate source");
+			return -ENOMEM;
+		}
+	}
 
 	if (source->ext_adv == NULL) {
 		err = tester_gap_create_adv_instance(&param, BTP_GAP_ADDR_TYPE_IDENTITY, ext_ad,
@@ -198,7 +206,6 @@ static int pbp_broadcast_source_adv_setup(void)
 	}
 
 	source->broadcast_id = broadcast_id;
-	source->allocated = true;
 
 	return 0;
 }


### PR DESCRIPTION
btp_bap_broadcast_local_source_from_src_id_get() may return NULL.