### PR TITLE
drivers: clock_control: stm32u3: enable MSIx PLL mode only if requested

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u3.c
+++ b/drivers/clock_control/clock_stm32_ll_u3.c
@@ -330,6 +330,14 @@ static void enable_epod_booster(void)
 	}
 }
 
+#if STM32_MSIK_PLL_MODE || STM32_MSIS_PLL_MODE
+
+/* Use two asserts for more precise error messages */
+BUILD_ASSERT(STM32_LSE_ENABLED || !STM32_MSIK_PLL_MODE,
+	"MSIK PLL mode requires LSE clock to be enabled for auto-calibration");
+BUILD_ASSERT(STM32_LSE_ENABLED || !STM32_MSIS_PLL_MODE,
+	"MSIS PLL mode requires LSE clock to be enabled for auto-calibration");
+
 static void configure_clock_with_calibration(int range)
 {
 	LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_MSIS);
@@ -343,10 +351,6 @@ static void configure_clock_with_calibration(int range)
 	LL_RCC_SetAPB2Prescaler(LL_RCC_APB2_HCLK_DIV_1);
 	LL_RCC_SetAPB3Prescaler(LL_RCC_APB3_HCLK_DIV_1);
 
-	BUILD_ASSERT(STM32_LSE_ENABLED || !IS_ENABLED(STM32_MSIK_ENABLED),
-		"MSIK requires LSE clock to be enabled for auto-calibration");
-	BUILD_ASSERT(STM32_LSE_ENABLED || !IS_ENABLED(STM32_MSIS_ENABLED),
-		"MSIS requires LSE clock to be enabled for auto-calibration");
 	if (IN_RANGE(range, 0, 3)) {
 		/*
 		 * LSE or HSE must be enabled and ready before selecting
@@ -375,6 +379,7 @@ static void configure_clock_with_calibration(int range)
 		}
 	}
 }
+#endif /* STM32_MSIK_PLL_MODE || STM32_MSIS_PLL_MODE */
 
 static void set_up_fixed_clock_sources(void)
 {
@@ -495,7 +500,9 @@ static void set_up_fixed_clock_sources(void)
 		while (LL_RCC_MSIS_IsReady() == 0U) {
 		}
 
+#if STM32_MSIS_PLL_MODE
 		configure_clock_with_calibration(STM32_MSIS_RANGE);
+#endif /* STM32_MSIS_PLL_MODE */
 	}
 
 	if (IS_ENABLED(STM32_MSIK_ENABLED)) {
@@ -561,7 +568,9 @@ static void set_up_fixed_clock_sources(void)
 		while (LL_RCC_MSIK_IsReady() == 0U) {
 		}
 
+#if STM32_MSIK_PLL_MODE
 		configure_clock_with_calibration(STM32_MSIK_RANGE);
+#endif /* STM32_MSIK_PLL_MODE */
 	}
 
 	if (IS_ENABLED(STM32_LSI_ENABLED)) {


### PR DESCRIPTION
PLL mode on MSIK/MSIS should be enabled only if property `msi-pll-mode` is present on the generator's DT node. However, the STM32U3 clock driver did not check this property and unconditionally enabled PLL mode. This is an issue because PLL mode requires an LSE generator to be provided, which was asserted at build time, preventing usage of MSIS/MSIK without an LSE even if the target application did not need the accuracy provided by PLL mode.

Fix by enabling PLL mode for each MSIx generator only if the `msi-pll-mode` property is enabled on the corresponding DT node.