### PR TITLE
boards: nordic: nrf54l15tag: Fix missing ranges

### DIFF
--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
@@ -31,6 +31,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr_xip.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr_xip.dts
@@ -18,6 +18,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";


### PR DESCRIPTION
Fixes an issue with a missing ranges in the flpr dts files