### PR TITLE
drivers serial native_pty: Add DT property to connect to stdin/out

### DIFF
--- a/drivers/serial/Kconfig.native_pty
+++ b/drivers/serial/Kconfig.native_pty
@@ -33,14 +33,19 @@ config UART_NATIVE_PTY_0_ON_OWN_PTY
 config UART_NATIVE_PTY_0_ON_STDINOUT
 	bool "Connect the first PTY UART to the invoking shell stdin/stdout"
 	help
-	  Connect this UART to the stdin & stdout of the calling shell/terminal
-	  which invoked the native executable. This is good enough for
-	  automated testing, or when feeding from a file/pipe.
-	  Note that other, non UART messages, will also be printed to the
-	  terminal.
-	  It is strongly discouraged to try to use this option with the new
-	  shell interactively, as the default terminal configuration is NOT
-	  appropriate for interactive use.
+	  Connect the first UART instance to the stdin & stdout of the calling shell/terminal which
+	  invoked the native executable. This is good enough for automated testing, or when feeding from a
+	  file/pipe.
+
+	  NOTE: This applies to whichever PTY instance is instantiated first. If there is more than one,
+	  and you want to control which instance is on stdin/out you should instead use the command line
+	  options, or the corresponding instance DT `on-stdinout` property.
+
+	  Note that other, non UART messages, will also be printed to the terminal.
+
+	  It is discouraged to use this option with the shell interactively: The default terminal
+	  configuration is not appropriate for Zephyr's shell interactive use and several shell functions
+	  like autocomplete or the history search will appear faulty.
 
 endchoice
 

--- a/drivers/serial/uart_native_pty.c
+++ b/drivers/serial/uart_native_pty.c
@@ -34,6 +34,10 @@
  * if set so from command line.
  */
 
+struct native_pty_config {
+	bool on_stdinout; /* Requested on stdin/out from DT */
+};
+
 struct native_pty_status {
 	int out_fd;       /* File descriptor used for output */
 	int in_fd;        /* File descriptor used for input */
@@ -137,10 +141,14 @@ static DEVICE_API(uart, np_uart_driver_api) = {
 };
 
 #define NATIVE_PTY_INSTANCE(inst)                                        \
+	static struct native_pty_config native_pty_##inst##_cfg = {      \
+		.on_stdinout = DT_INST_PROP(inst, on_stdinout),          \
+	};                                                               \
 	static struct native_pty_status native_pty_status_##inst;        \
 								         \
 	DEVICE_DT_INST_DEFINE(inst, np_uart_init, NULL,                  \
-			      (void *)&native_pty_status_##inst, NULL,   \
+			      (void *)&native_pty_status_##inst,         \
+			      &native_pty_##inst##_cfg,                  \
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY, \
 			      &np_uart_driver_api);
 
@@ -158,6 +166,7 @@ static int np_uart_init(const struct device *dev)
 
 	static bool stdinout_used;
 	struct native_pty_status *d;
+	const struct native_pty_config *dt_config = (const struct native_pty_config *)dev->config;
 
 	d = (struct native_pty_status *)dev->data;
 
@@ -170,7 +179,7 @@ static int np_uart_init(const struct device *dev)
 		first_node = false;
 	}
 
-	if (d->cmd_request_stdinout) {
+	if (d->cmd_request_stdinout || dt_config->on_stdinout) {
 		if (stdinout_used) {
 			nsi_print_warning("%s requested to connect to STDIN/OUT, but another UART"
 					  " is already connected to it => ignoring request.\n",

--- a/dts/bindings/serial/zephyr,native-pty-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-pty-uart.yaml
@@ -6,3 +6,17 @@ description: Native PTY UART
 compatible: "zephyr,native-pty-uart"
 
 include: uart-controller.yaml
+
+properties:
+  on-stdinout:
+    type: boolean
+    description: |
+      Connect this PTY UART instance to the stdin & stdout of the calling shell/terminal which
+      invoked the native executable. This is good enough for automated testing, or when feeding
+      from a file/pipe.
+      NOTE: Only one PTY UART can be connected to the stdin/out. If this property is set in several,
+      it will only apply to whichever is instantiated first. Note that if
+      CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT is set this property is effectively ignored.
+      It is discouraged to use this property with the shell interactively: The default terminal
+      configuration is not appropriate for Zephyr's shell interactive use and several shell
+      functions like autocomplete or the history search will appear faulty.


### PR DESCRIPTION
Add a device tree property to request connecting an instance of the native_sim UART PTY driver to stdin/out (on top of the command line options, and the kconfig option).

And clarify that the kconfig option applies to whichever is the first instance in whatever order the DT logic happens to order them.

Fixes #100812