### PR TITLE
drivers: flash: flexspi_nor: Update page program LUT for 4-byte addressing

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020,2023-2025 NXP
+ * Copyright 2020,2023-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1021,6 +1021,12 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
 					SPI_NOR_CMD_BE, kFLEXSPI_Command_RADDR_SDR,
 					kFLEXSPI_1PAD, addr_width);
+			/* Update LUT for page program to use 32 bit addr and 4byte page program
+			 * command.
+			 */
+			flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
+				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_PP_4B,
+				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, addr_width);
 		}
 	}
 	/* Extract the read command.
@@ -1055,6 +1061,25 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 			flexspi_lut[READ][2] =
 				FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_SDR, kFLEXSPI_8PAD, 0x04,
 						kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
+
+			if (addr_width == 32) {
+				/* Update LUT for page program with 1S-8S-8S command */
+				flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+					SPI_NOR_CMD_PP_1_8_8_4B, kFLEXSPI_Command_RADDR_SDR,
+					kFLEXSPI_8PAD, addr_width);
+				flexspi_lut[PAGE_PROGRAM][1] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_8PAD, 0x4,
+					kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
+			} else {
+				/* Update LUT for page program with 1S-8S-8S command */
+				flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_PP_1_8_8,
+					kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_8PAD, addr_width);
+				flexspi_lut[PAGE_PROGRAM][1] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_8PAD, 0x4,
+					kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
+			}
 			return 0;
 		}
 	}

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -43,6 +43,8 @@
 #define SPI_NOR_CMD_PP_1_1_2    0xA2    /* Dual Page program (1-1-2) */
 #define SPI_NOR_CMD_PP_1_1_4    0x32    /* Quad Page program (1-1-4) */
 #define SPI_NOR_CMD_PP_1_4_4    0x38    /* Quad Page program (1-4-4) */
+#define SPI_NOR_CMD_PP_1_1_8    0x82    /* Octal Page program (1-1-8) */
+#define SPI_NOR_CMD_PP_1_8_8    0xC2    /* Extended Octal Page program (1-8-8) */
 #define SPI_NOR_CMD_RDCR        0x15    /* Read control register */
 #define SPI_NOR_CMD_SE          0x20    /* Sector erase */
 #define SPI_NOR_CMD_SE_4B       0x21    /* Sector erase 4 byte address*/
@@ -70,6 +72,8 @@
 #define SPI_NOR_CMD_PP_4B        0x12  /* Page Program 4 Byte Address */
 #define SPI_NOR_CMD_PP_1_1_4_4B  0x34  /* Quad Page program (1-1-4) 4 Byte Address */
 #define SPI_NOR_CMD_PP_1_4_4_4B  0x3e  /* Quad Page program (1-4-4) 4 Byte Address */
+#define SPI_NOR_CMD_PP_1_1_8_4B  0x84  /* Octal Page program (1-1-8) 4 Byte Address */
+#define SPI_NOR_CMD_PP_1_8_8_4B  0x8E  /* Extended Octal Page program (1-8-8) 4 Byte Address */
 #define SPI_NOR_CMD_RDFLSR       0x70  /* Read Flag Status Register */
 #define SPI_NOR_CMD_CLRFLSR      0x50  /* Clear Flag Status Register */
 #define SPI_NOR_CMD_WR_VCFGREG   0x81  /* Octal Write volatile configuration Register */


### PR DESCRIPTION
Fixes: #102155

# Root Cause
When 4-byte addressing mode is enabled on the flash device, there is an inconsistency in how address widths are handled between read and write operations:

Current behavior:

The read command correctly updates its addr_width to 32 bits when 4-byte mode is enabled
The program (write) command does NOT update its addr_width and remains at the default width
Impact: This mismatch causes the program command to send addresses with incorrect width (likely 24 bits instead of 32 bits) when the device is in 4-byte addressing mode. As a result:

Writes may target incorrect memory addresses
Data corruption or write failures can occur
The device behavior becomes unpredictable when accessing addresses beyond the 24-bit range (>16MB)

# Resulution
When 4-byte addressing is enabled, update the page program LUT entry to use the appropriate 4-byte page program command (SPI_NOR_CMD_PP_4B).

For octal mode (1S-8S-8S), select the correct page program command based on address width:
- Use SPI_NOR_CMD_PP_1_8_8_4B for 32-bit addressing
- Use SPI_NOR_CMD_PP_1_8_8 for 24-bit addressing

This ensures the flash controller uses the correct command sequence for page programming operations in both standard and octal modes with extended addressing.

Signed-off-by: Albort Xue <yao.xue@nxp.com>