### PR TITLE
drivers: clock_control: stm32: fix LSE|MSIS|MSIK enabled macros

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u3.c
+++ b/drivers/clock_control/clock_stm32_ll_u3.c
@@ -333,9 +333,9 @@ static void enable_epod_booster(void)
 #if STM32_MSIK_PLL_MODE || STM32_MSIS_PLL_MODE
 
 /* Use two asserts for more precise error messages */
-BUILD_ASSERT(STM32_LSE_ENABLED || !STM32_MSIK_PLL_MODE,
+BUILD_ASSERT(IS_ENABLED(STM32_LSE_ENABLED) || !STM32_MSIK_PLL_MODE,
 	"MSIK PLL mode requires LSE clock to be enabled for auto-calibration");
-BUILD_ASSERT(STM32_LSE_ENABLED || !STM32_MSIS_PLL_MODE,
+BUILD_ASSERT(IS_ENABLED(STM32_LSE_ENABLED) || !STM32_MSIS_PLL_MODE,
 	"MSIS PLL mode requires LSE clock to be enabled for auto-calibration");
 
 static void configure_clock_with_calibration(int range)

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -823,9 +823,10 @@ static void set_up_fixed_clock_sources(void)
 
 		LL_RCC_MSIS_SetRange(STM32_MSIS_RANGE << RCC_ICSCR1_MSISRANGE_Pos);
 
+		BUILD_ASSERT(IS_ENABLED(STM32_LSE_ENABLED) || !IS_ENABLED(STM32_MSIS_PLL_MODE),
+			     "MSIS Hardware auto calibration needs LSE clock activation");
+
 		if (IS_ENABLED(STM32_MSIS_PLL_MODE)) {
-			__ASSERT(STM32_LSE_ENABLED,
-				"MSIS Hardware auto calibration needs LSE clock activation");
 			/* Enable MSI hardware auto calibration */
 			LL_RCC_SetMSIPLLMode(LL_RCC_PLLMODE_MSIS);
 			LL_RCC_MSI_EnablePLLMode();
@@ -845,9 +846,10 @@ static void set_up_fixed_clock_sources(void)
 
 		LL_RCC_MSIK_SetRange(STM32_MSIK_RANGE << RCC_ICSCR1_MSIKRANGE_Pos);
 
+		BUILD_ASSERT(IS_ENABLED(STM32_LSE_ENABLED) || !IS_ENABLED(STM32_MSIK_PLL_MODE),
+			     "MSIK Hardware auto calibration needs LSE clock activation");
+
 		if (IS_ENABLED(STM32_MSIK_PLL_MODE)) {
-			__ASSERT(STM32_LSE_ENABLED,
-				"MSIK Hardware auto calibration needs LSE clock activation");
 			/* Enable MSI hardware auto calibration */
 			LL_RCC_SetMSIPLLMode(LL_RCC_PLLMODE_MSIK);
 			LL_RCC_MSI_EnablePLLMode();

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -556,11 +556,11 @@
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msi), st_stm32_msi_clock, okay)
 #define STM32_MSI_ENABLED	1
 #define STM32_MSI_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msi), msi_pll_mode)
-#endif
 
-#if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !defined(STM32_LSE_ENABLED)
-#error "On STM32L4 series, MSI PLL mode requires LSE to be enabled"
-#endif
+# if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !defined(STM32_LSE_ENABLED)
+# error "On STM32L4 series, MSI PLL mode requires LSE to be enabled"
+# endif /* stm32l4 && msi_pll_mode && !STM32_LSE_ENABLED */
+#endif /* st_stm32_msi_clock */
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msis), st_stm32u5_msi_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msis), st_stm32u3_msi_clock, okay)

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -554,7 +554,6 @@
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msi), st_stm32_msi_clock, okay)
-#define STM32_MSI_ENABLED	1
 #define STM32_MSI_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msi), msi_pll_mode)
 
 # if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !defined(STM32_LSE_ENABLED)

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -542,7 +542,6 @@
 #define STM32_LSE_DRIVING	DT_PROP(DT_NODELABEL(clk_lse), driving_capability)
 #define STM32_LSE_BYPASS	DT_PROP(DT_NODELABEL(clk_lse), lse_bypass)
 #else
-#define STM32_LSE_ENABLED	0
 #define STM32_LSE_FREQ		0
 #define STM32_LSE_DRIVING	0
 #define STM32_LSE_BYPASS	0
@@ -559,7 +558,7 @@
 #define STM32_MSI_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msi), msi_pll_mode)
 #endif
 
-#if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !STM32_LSE_ENABLED
+#if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !defined(STM32_LSE_ENABLED)
 #error "On STM32L4 series, MSI PLL mode requires LSE to be enabled"
 #endif
 
@@ -569,7 +568,6 @@
 #define STM32_MSIS_RANGE	DT_PROP(DT_NODELABEL(clk_msis), msi_range)
 #define STM32_MSIS_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msis), msi_pll_mode)
 #else
-#define STM32_MSIS_ENABLED	0
 #define STM32_MSIS_RANGE	0
 #define STM32_MSIS_PLL_MODE	0
 #endif
@@ -580,7 +578,6 @@
 #define STM32_MSIK_RANGE	DT_PROP(DT_NODELABEL(clk_msik), msi_range)
 #define STM32_MSIK_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msik), msi_pll_mode)
 #else
-#define STM32_MSIK_ENABLED	0
 #define STM32_MSIK_RANGE	0
 #define STM32_MSIK_PLL_MODE	0
 #endif


### PR DESCRIPTION
Change STM32_LSE_ENABLED, STM32_MSIS_ENABLED and STM32_MSIK_ENABLED macros to not be defined when the related clock is not enable in Zephyr scope. This is their expected state where used in the implementation (e.g., relying on #ifdef) but at a few places regarding STM32_LSE_ENABLED that are also fixed by this change.

This change makes these macros more consistent with the other main clock enable state macros (STM32_LSI_ENABLED, STM32_HSI_ENABLED, STM32_HSE_ENABLED, etc...).