### PR TITLE
drivers: serial: silabs: Fix async race condition

### DIFF
--- a/tests/drivers/uart/uart_async_dual/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/uart/uart_async_dual/boards/xg24_rb4187c.overlay
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2025, Silicon Laboratories Inc.
+ * Copyright (c) 2026, Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /*
- * Need to connect PC1 and PA5 of the Expension Pin header
+ * Connect EXP[4,6,8,10] with EXP[7,9,11,13] on the Expension Pin header
  */
 / {
 	chosen {
@@ -18,13 +18,27 @@
 &pinctrl {
 	usart0_default: usart0_default {
 		group0 {
-			pins = <USART0_TX_PC1>;
+			pins = <USART0_TX_PC1>, <USART0_RTS_PC3>;
 			drive-push-pull;
 			output-high;
 		};
 
 		group1 {
-			pins = <USART0_RX_PA5>;
+			pins = <USART0_RX_PC2>, <USART0_CTS_PC0>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
+	eusart1_default: eusart1_default {
+		group0 {
+			pins = <EUSART1_TX_PD2>, <EUSART1_RTS_PA7>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <EUSART1_RX_PA5>, <EUSART1_CTS_PA6>;
 			input-enable;
 			silabs,input-filter;
 		};
@@ -51,6 +65,19 @@ dut: &usart0 {
 	dma-names = "tx", "rx";
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
+};
+
+dut_aux: &eusart1 {
+	compatible = "silabs,eusart-uart";
+	current-speed = <115200>;
+	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
+	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	/delete-property/ cs-gpios;
 };
 
 &eusart0 {

--- a/tests/drivers/uart/uart_async_dual/testcase.yaml
+++ b/tests/drivers/uart/uart_async_dual/testcase.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuppr
       - nrf9160dk/nrf9160
       - nrf52_bsim
+      - xg24_rb4187c
   drivers.uart.async_dual.busy_sim:
     harness: ztest
     harness_config:

--- a/tests/drivers/uart/uart_elementary/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/xg24_rb4187c.overlay
@@ -13,7 +13,7 @@
 };
 
 /*
- * Connect EXP4 (PC1) and EXP6 (PC2) of the Expansion Pin header
+ * Connect EXP4 (PC1) and EXP7 (PA5) of the Expansion Pin header
  */
 
 &pinctrl {
@@ -39,7 +39,7 @@
 		};
 
 		group1 {
-			pins = <USART0_RX_PC2>; /* WPK EXP6 (PC2) */
+			pins = <USART0_RX_PA5>; /* WPK EXP7 (PA5) */
 			input-enable;
 			silabs,input-filter;
 		};


### PR DESCRIPTION
When an async transfer finished quickly, the internal state of the driver could come out of sync with the hardware. The tx/rx
enabled flag and PM lock was taken after starting the DMA transaction, which caused issues if the DMA complete callback
was called before the flags were updated. Set the flag and take the PM lock prior to starting the DMA transaction to avoid this.

Also release the PM rx lock upon successful completion of a transfer. The lock was previously only released when the user manually called `uart_rx_disable()`.

Enable two-uart test for xg24_rb4187c. Modify the pinout for the uart_loopback fixture to support two complete UARTs including flow control by connecting pins EXP[4,6,8,10] with EXP[7,9,11,13] on the expansion header.

Edit by Martinhoff-maker:

fix: https://github.com/zephyrproject-rtos/zephyr/issues/103239