### PR TITLE
firmware: scmi: move polling logic to transport layer

### DIFF
--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/firmware/scmi/transport.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
-#include "mailbox.h"
 
 LOG_MODULE_REGISTER(scmi_core);
 
@@ -87,47 +86,17 @@ static int scmi_core_setup_chan(const struct device *transport,
 	return 0;
 }
 
-static int scmi_interrupt_enable(struct scmi_channel *chan, bool enable)
-{
-	struct scmi_mbox_channel *mbox_chan;
-	struct mbox_dt_spec *tx_reply;
-	bool comp_int;
-
-	mbox_chan = chan->data;
-	comp_int = enable ? SCMI_SHMEM_CHAN_FLAG_IRQ_BIT : 0;
-
-	if (mbox_chan->tx_reply.dev) {
-		tx_reply = &mbox_chan->tx_reply;
-	} else {
-		tx_reply = &mbox_chan->tx;
-	}
-
-	/* re-set completion interrupt */
-	scmi_shmem_update_flags(mbox_chan->shmem, SCMI_SHMEM_CHAN_FLAG_IRQ_BIT, comp_int);
-
-	return mbox_set_enabled_dt(tx_reply, enable);
-}
-
 static int scmi_send_message_polling(struct scmi_protocol *proto,
 					struct scmi_message *msg,
 					struct scmi_message *reply)
 {
 	int ret;
-	int status;
 
 	/* wait for channel to be free */
 	if (!k_is_pre_kernel() && k_mutex_lock(&proto->tx->lock, K_NO_WAIT)) {
 		LOG_ERR("failed to acquire chan lock");
 		return -EBUSY;
 	}
-
-	/*
-	 * SCMI communication interrupt is enabled by default during setup_chan
-	 * to support interrupt-driven communication. When using polling mode
-	 * it must be disabled to avoid unnecessary interrupts and
-	 * ensure proper polling behavior.
-	 */
-	status = scmi_interrupt_enable(proto->tx, false);
 
 	ret = scmi_transport_send_message(proto->transport, proto->tx, msg, true);
 	if (ret < 0) {
@@ -153,11 +122,6 @@ static int scmi_send_message_polling(struct scmi_protocol *proto,
 	}
 
 cleanup:
-	/* restore scmi interrupt enable status when disable it pass */
-	if (status >= 0) {
-		scmi_interrupt_enable(proto->tx, true);
-	}
-
 	if (!k_is_pre_kernel()) {
 		k_mutex_unlock(&proto->tx->lock);
 	}

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -129,7 +129,7 @@ static int scmi_send_message_polling(struct scmi_protocol *proto,
 	 */
 	status = scmi_interrupt_enable(proto->tx, false);
 
-	ret = scmi_transport_send_message(proto->transport, proto->tx, msg);
+	ret = scmi_transport_send_message(proto->transport, proto->tx, msg, true);
 	if (ret < 0) {
 		goto cleanup;
 	}
@@ -182,7 +182,7 @@ static int scmi_send_message_interrupt(struct scmi_protocol *proto,
 		return ret;
 	}
 
-	ret = scmi_transport_send_message(proto->transport, proto->tx, msg);
+	ret = scmi_transport_send_message(proto->transport, proto->tx, msg, false);
 	if (ret < 0) {
 		LOG_ERR("failed to send message");
 		goto out_release_mutex;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -31,7 +31,7 @@ static int scmi_mbox_send_message(const struct device *transport,
 
 	mbox_chan = chan->data;
 
-	ret = scmi_shmem_write_message(mbox_chan->shmem, msg);
+	ret = scmi_shmem_write_message(mbox_chan->shmem, msg, use_polling);
 	if (ret < 0) {
 		LOG_ERR("failed to write message to shmem: %d", ret);
 		return ret;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -23,7 +23,8 @@ static void scmi_mbox_cb(const struct device *mbox,
 
 static int scmi_mbox_send_message(const struct device *transport,
 				  struct scmi_channel *chan,
-				  struct scmi_message *msg)
+				  struct scmi_message *msg,
+				  bool use_polling)
 {
 	struct scmi_mbox_channel *mbox_chan;
 	int ret;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -97,11 +97,6 @@ static int scmi_mbox_setup_chan(const struct device *transport,
 		LOG_ERR("failed to enable tx reply dbell");
 	}
 
-	/* enable interrupt-based communication */
-	scmi_shmem_update_flags(mbox_chan->shmem,
-				SCMI_SHMEM_CHAN_FLAG_IRQ_BIT,
-				SCMI_SHMEM_CHAN_FLAG_IRQ_BIT);
-
 	return 0;
 }
 

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -151,6 +151,8 @@ int scmi_shmem_write_message(const struct device *shmem,
 		return -EINVAL;
 	}
 
+	layout->chan_flags = !use_polling ? SCMI_SHMEM_CHAN_FLAG_IRQ_BIT : 0;
+
 	/* done, mark channel as busy and proceed */
 	layout->chan_status &= ~SCMI_SHMEM_CHAN_STATUS_BUSY_BIT;
 

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -110,7 +110,9 @@ int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg
 	return 0;
 }
 
-int scmi_shmem_write_message(const struct device *shmem, struct scmi_message *msg)
+int scmi_shmem_write_message(const struct device *shmem,
+			     struct scmi_message *msg,
+			     bool use_polling)
 {
 	struct scmi_shmem_layout *layout;
 	struct scmi_shmem_data *data;

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -43,12 +43,14 @@ struct scmi_message;
  *
  * @param shmem pointer to shmem device
  * @param msg message to write
+ * @param use_polling true if polling should be used, false otherwise
  *
  * @retval 0 if successful
  * @retval negative errno if failure
  */
 int scmi_shmem_write_message(const struct device *shmem,
-			     struct scmi_message *msg);
+			     struct scmi_message *msg,
+			     bool use_polling);
 
 /**
  * @brief Read a message from a SHMEM area

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -109,16 +109,22 @@ struct scmi_transport_api {
 	 *
 	 * Used to send a message to the platform over a given TX channel.
 	 *
+	 * @note the transport driver is in no way allowed to overwrite
+	 * the value of the \p use_polling parameter and must comply with
+	 * it.
+	 *
 	 * @param transport transport device
 	 * @param chan channel used to send the message
 	 * @param msg message to send
+	 * @param use_polling true if polling should be enabled, false otherwise
 	 *
 	 * @retval 0 if successful
 	 * @retval <0 negative errno code if failure
 	 */
 	int (*send_message)(const struct device *transport,
 			    struct scmi_channel *chan,
-			    struct scmi_message *msg);
+			    struct scmi_message *msg,
+			    bool use_polling);
 
 	/**
 	 * @brief Prepare a channel for communication
@@ -248,7 +254,8 @@ static inline int scmi_transport_setup_chan(const struct device *transport,
  */
 static inline int scmi_transport_send_message(const struct device *transport,
 					      struct scmi_channel *chan,
-					      struct scmi_message *msg)
+					      struct scmi_message *msg,
+					      bool use_polling)
 {
 	const struct scmi_transport_api *api =
 		(const struct scmi_transport_api *)transport->api;
@@ -257,7 +264,7 @@ static inline int scmi_transport_send_message(const struct device *transport,
 		return -ENOSYS;
 	}
 
-	return api->send_message(transport, chan, msg);
+	return api->send_message(transport, chan, msg, use_polling);
 }
 
 /**


### PR DESCRIPTION
This patch series attempts to fix https://github.com/zephyrproject-rtos/zephyr/issues/102904 by moving the polling logic from the core layer to the transport layer. With this, we can get rid of the core bits of code making use of MBOX/SHMEM APIs. Additionally, the series includes a merge of the polling and interrupt-based send_message() functions.