### PR TITLE
tests: drivers: flash: common: Fix overlay for xg24_rb4187c

### DIFF
--- a/tests/drivers/flash/common/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/flash/common/boards/xg24_rb4187c.overlay
@@ -10,3 +10,13 @@
 &msc {
 	dmas = <&dma0 DMA_REQSEL_MSCWDATA>;
 };
+
+/* Disable jedec spi nor flash to test internal flash */
+
+/ {
+	aliases {
+		/delete-property/ spi-flash0;
+	};
+};
+
+/delete-node/ &mx25r80;


### PR DESCRIPTION
xg24_rb4187c has an external SPI NOR flash in addition to the internal flash. Disable the NOR flash to make the test run on the internal flash.