### PR TITLE
samples: boards: nrf_sys_event: add pytest and nrf54lm20 support

### DIFF
--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+sample_counter: &timer20 {
+	status = "okay";
+};

--- a/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
+++ b/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import re
+
+from twister_harness import DeviceAdapter
+
+
+def test_rramc_wakeup(dut: DeviceAdapter):
+    """
+    PyTest code for samples/boards/nordic/nrf_sys_event, sample configurations:
+    - sample.boards.nordic.nrf_sys_event.rramc_wakeup,
+    - sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi.
+    Parse logs from serial port. If the Register Event API was used correctly,
+    code execution shall be faster by ~14 us when event was registered.
+    If the API works correctly, RRAMC is woken up just before event occures.
+    Thus, there is no delay resulting from RRAMC getting ready.
+    """
+
+    TIMEOUT = 5
+    MIN_DIFF = 10  # Minimal difference to pass the check
+
+    # Get output from serial port
+    output = "\n".join(
+        dut.readlines_until(
+            regex="All done",
+            print_output=True,
+            timeout=TIMEOUT,
+        )
+    )
+
+    # Get execution times
+    t_not_registered_str = re.search(
+        r"Alarm set for 1000 us, execution took:(.+) \(no event registered\)", output
+    ).group(1)
+    assert t_not_registered_str is not None, "Timing for no event registered was NOT found"
+    t_not_registered = int(t_not_registered_str)
+
+    t_registered_str = re.search(
+        r"Alarm set for 1000 us, execution took:(.+) \(event registered\)", output
+    ).group(1)
+    assert t_registered_str is not None, "Timing for event registered was NOT found"
+    t_registered = int(t_registered_str)
+
+    # Check if registering event results in faster code execution
+    assert t_not_registered > t_registered + MIN_DIFF, (
+        f"{t_not_registered} is NOT larger than {t_registered} + {MIN_DIFF}"
+    )

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -56,6 +56,10 @@ tests:
     extra_configs:
       - CONFIG_SOC_NRF_FORCE_CONSTLAT=y
   sample.boards.nordic.nrf_sys_event.rramc_wakeup:
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_reg_event.py::test_rramc_wakeup"
     extra_configs:
       - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
       - CONFIG_NRF_SYS_EVENT_GRTC_CHAN_CNT=0
@@ -65,6 +69,10 @@ tests:
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
   sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi:
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_reg_event.py::test_rramc_wakeup"
     extra_configs:
       - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
     platform_allow:

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -20,6 +20,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -42,6 +43,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -59,6 +61,7 @@ tests:
       - CONFIG_NRF_SYS_EVENT_GRTC_CHAN_CNT=0
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
   sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi:
@@ -67,5 +70,6 @@ tests:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuflpr/xip
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/boards/nordic/nrf_sys_event/src/main.c
+++ b/samples/boards/nordic/nrf_sys_event/src/main.c
@@ -82,7 +82,7 @@ static void sys_event_irq_latency(void)
 	}
 
 	cyc /= rpt;
-	printf("Alarm set for %d us, execution took:%d\n", delay, cyc);
+	printf("Alarm set for %d us, execution took:%d (event registered)\n", delay, cyc);
 }
 #endif /* CONFIG_NRF_SYS_EVENT_IRQ_LATENCY */
 
@@ -119,6 +119,8 @@ int main(void)
 
 #ifdef CONFIG_NRF_SYS_EVENT_IRQ_LATENCY
 	sys_event_irq_latency();
+
+	printf("All done\n");
 #endif
 	return 0;
 }


### PR DESCRIPTION
Extend sample configuration with check that confirms correct use of register event API.
Use PyTes to validate that code executes faster when event is registered.

Also, enable sample on nrf54lm20dk.