### PR TITLE
tests: drivers: spi: loopback: Update overlay for xg24_rb4187c

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
@@ -15,7 +15,7 @@
 		};
 
 		group1 {
-			pins = <EUSART1_RX_PC2>;
+			pins = <EUSART1_RX_PA5>;
 			input-enable;
 		};
 	};


### PR DESCRIPTION
Change the spi_loopback fixture to connect EXP4 to EXP7 instead of EXP6 to be consistent with other loopback fixtures for this board.