### PR TITLE
logging: Add missing compiler barrier after k_is_user_context

### DIFF
--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -111,6 +111,7 @@ void xtensa_arch_kernel_oops(int reason_p, void *ssf);
 		arch_syscall_invoke1(reason_p, \
 			K_SYSCALL_XTENSA_USER_FAULT); \
 	} else { \
+		compiler_barrier(); \
 		xtensa_arch_except(reason_p); \
 	} \
 	CODE_UNREACHABLE; \

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -531,9 +531,10 @@ do { \
 			( \
 			bool can_simple = LOG_MSG_SIMPLE_CHECK(__VA_ARGS__); \
 			if (can_simple && ((_dlen) == 0) && !k_is_user_context()) { \
-				LOG_MSG_DBG("create fast message\n");\
+				compiler_barrier(); \
+				LOG_MSG_DBG("create fast message\n"); \
 				Z_LOG_MSG_SIMPLE_ARGS_CREATE(_domain_id, _source, _level, \
-						     Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
+							     Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
 				_mode = Z_LOG_MSG_MODE_SIMPLE; \
 				break; \
 			} \

--- a/include/zephyr/syscall.h
+++ b/include/zephyr/syscall.h
@@ -110,6 +110,12 @@ static ALWAYS_INLINE bool z_syscall_trap(void)
  * Indicate whether the CPU is currently in user mode
  *
  * @return true if the CPU is currently running with user permissions
+ *
+ * CAUTION!
+ * If you branch on k_is_user_context() and then perform a kernel-only operation, you must insert
+ * a memory barrier before the privileged operation. Both the compiler and the CPU may reorder
+ * memory operations around the branch. Without a barrier, memory accesses related to the privileged
+ * path may move before the context check or be speculated.
  */
 __pinned_func
 static inline bool k_is_user_context(void)

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -124,6 +124,7 @@ void vprintk(const char *fmt, va_list ap)
 			buf_flush(&ctx);
 		}
 	} else {
+		compiler_barrier();
 #ifdef CONFIG_PRINTK_SYNC
 		k_spinlock_key_t key = k_spin_lock(&lock);
 #endif

--- a/subsys/logging/frontends/stmesp/zephyr_custom_log.h
+++ b/subsys/logging/frontends/stmesp/zephyr_custom_log.h
@@ -40,9 +40,7 @@ extern "C" {
  */
 #define Z_LOG_STMESP_0(_level, _source, ...)                                                       \
 	do {                                                                                       \
-		if (!Z_LOG_LEVEL_ALL_CHECK(_level, __log_current_const_data, _source)) {           \
-			break;                                                                     \
-		}                                                                                  \
+		Z_LOG_LEVEL_ALL_CHECK_BREAK(_level, __log_current_const_data, _source)             \
 		LOG_FRONTEND_STMESP_LOG0(_source, STRINGIFY(_level) __VA_ARGS__);                  \
 	} while (0)
 
@@ -72,9 +70,7 @@ extern "C" {
 				(Z_LOG(_level, __VA_ARGS__)));                                     \
 			break;                                                                     \
 		}                                                                                  \
-		if (!Z_LOG_LEVEL_ALL_CHECK(_level, __log_current_const_data, _source)) {           \
-			break;                                                                     \
-		}                                                                                  \
+		Z_LOG_LEVEL_ALL_CHECK_BREAK(_level, __log_current_const_data, _source)             \
 		LOG_FRONTEND_STMESP_LOG1(_source, STRINGIFY(_level) __VA_ARGS__, dummy);           \
 	} while (0)
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -372,7 +372,7 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 	struct log_msg_desc desc =
 		Z_LOG_MSG_DESC_INITIALIZER(domain_id, level, plen, dlen);
 
-	if (IS_ENABLED(CONFIG_USERSPACE) && k_is_user_context()) {
+	if (k_is_user_context()) {
 		pkg = alloca(plen);
 		msg = NULL;
 	} else if (IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) && BACKENDS_IN_USE()) {
@@ -392,7 +392,7 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		__ASSERT_NO_MSG(plen >= 0);
 	}
 
-	if (IS_ENABLED(CONFIG_USERSPACE) && k_is_user_context()) {
+	if (k_is_user_context()) {
 		z_log_msg_static_create(source, desc, pkg, data);
 	} else {
 		if (IS_ENABLED(CONFIG_LOG_FRONTEND) &&

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -376,6 +376,7 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		pkg = alloca(plen);
 		msg = NULL;
 	} else if (IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) && BACKENDS_IN_USE()) {
+		compiler_barrier();
 		msg = z_log_msg_alloc(msg_wlen);
 		if (IS_ENABLED(CONFIG_LOG_FRONTEND) && msg == NULL) {
 			pkg = alloca(plen);
@@ -383,6 +384,7 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 			pkg = msg ? msg->data : NULL;
 		}
 	} else {
+		compiler_barrier();
 		msg = alloca(msg_wlen * sizeof(int));
 		pkg = msg->data;
 	}
@@ -395,6 +397,7 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 	if (k_is_user_context()) {
 		z_log_msg_static_create(source, desc, pkg, data);
 	} else {
+		compiler_barrier();
 		if (IS_ENABLED(CONFIG_LOG_FRONTEND) &&
 		    frontend_runtime_filtering(source, desc.level)) {
 			log_frontend_msg(source, desc, pkg, data);

--- a/subsys/sensing/dispatch.c
+++ b/subsys/sensing/dispatch.c
@@ -86,6 +86,7 @@ static void dispatch_task(void *a, void *b, void *c)
 	ARG_UNUSED(c);
 
 	if (IS_ENABLED(CONFIG_USERSPACE) && !k_is_user_context()) {
+		compiler_barrier();
 		rtio_access_grant(&sensing_rtio_ctx, k_current_get());
 		k_thread_user_mode_enter(dispatch_task, a, b, c);
 	}

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -651,7 +651,7 @@ static void test_cb(void *a, void *b, void *c)
 	struct ztest_unit_test *test = b;
 	const bool config_user_mode = FIELD_GET(K_USER, test->thread_options) != 0;
 
-	if (!IS_ENABLED(CONFIG_USERSPACE) || !k_is_user_context()) {
+	if (!k_is_user_context()) {
 		__ztest_set_test_result(ZTEST_RESULT_PENDING);
 		run_test_rules(/*is_before=*/true, test, /*data=*/c);
 		if (suite->before) {

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -211,6 +211,7 @@ static void counter_setup_instance(const struct device *dev)
 {
 	k_sem_reset(&alarm_cnt_sem);
 	if (!k_is_user_context()) {
+		compiler_barrier();
 		alarm_cnt = 0;
 	}
 }

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1847,6 +1847,7 @@ static void run_ancillary_recvmsg_test(int client_sock,
 	}
 
 	if (!k_is_user_context()) {
+		compiler_barrier();
 		iface = net_if_get_default();
 		zassert_equal(ifindex, net_if_get_by_iface(iface));
 	}


### PR DESCRIPTION
Add missing memory barriers after branching on `k_is_user_context()` to prevent reordering of privileged memory access. 

Xtensa compiler optimizations can occasionally reorder code in a way that generates an access to privileged memory before the conditional branch that checks the value returned by `k_is_user_context`.

```
<ZEPHYR_BASE>/include/zephyr/arch/xtensa/syscall.h:
221             __asm__ volatile(
   0xa003991d <+45>:    rur.threadptr   a3

<ZEPHYR_BASE>/tests/subsys/logging/log_core_additional/src/log_test_user.c:
32              LOG_INF("log from user %d", d);
   0xa0039920 <+48>:    l32i.n  a2, a2, 0                                       <----- access to privileged memory
   0xa0039922 <+50>:    bnez.n  a3, 0xa003992a <_test_log_core_additional_test_log_from_user_wrapper+58>
```

This PR adds explicit barriers between the context check and the privileged memory access to enforce correct ordering. Memory barriers are already used with `k_is_user_context context`. For example, the `ARCH_EXCEPT` macro on RISC-V, and `k_is_pre_kernel` use barriers to enforce ordering. The `gen_syscalls.py` script also inserts a barrier after `z_syscall_trap` (which calls `arch_is_user_context`).

Remove the `k_is_user_context` call from the `Z_LOG_LEVEL_ALL_CHECK` macro. Add the `Z_LOG_LEVEL_ALL_CHECK_BREAK` macro, which safely checks whether logging is performed in user context before checking the dynamic log level that requires access to kernel structure.

Remove the unnecessary `CONFIG_USERSPACE` checks around `k_is_user_context` calls. This function is inline and already performs the config check internally.