### PR TITLE
OpenThread Border Router - split service initialization between IPV6 and IPV4 services

### DIFF
--- a/modules/openthread/Kconfig
+++ b/modules/openthread/Kconfig
@@ -489,6 +489,14 @@ config OPENTHREAD_ZEPHYR_BORDER_ROUTER_MDNS_BUFFER_THRESHOLD
 	  number of available OT message buffers will drop under a certain
 	  threshold if the mDNS packet is accepted and processed.
 
+config OPENTHREAD_ZEPHYR_BORDER_ROUTER_IPV4
+	bool "Border Router has IPV4 capabilities"
+	default y
+	select NET_DHCPV4
+	depends on NET_IPV4 && NET_UDP
+	help
+	  This configuration enables IPV4 communication.
+
 config OPENTHREAD_ZEPHYR_BORDER_ROUTER_NAT64_TRANSLATOR
 	bool "Border Router NAT64 translator"
 	default y
@@ -496,7 +504,7 @@ config OPENTHREAD_ZEPHYR_BORDER_ROUTER_NAT64_TRANSLATOR
 	select OPENTHREAD_NAT64_BORDER_ROUTING
 	select NET_PKT_FILTER
 	select NET_PKT_FILTER_IPV4_HOOK
-	depends on NET_IPV4
+	depends on OPENTHREAD_ZEPHYR_BORDER_ROUTER_IPV4
 	help
 	  This configuration enables NAT64 translator from OpenThread.
 

--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -135,6 +135,7 @@ otError dhcpv6_pd_client_init(otInstance *ot_instance, uint32_t ail_iface_index)
 otError dns_upstream_resolver_init(otInstance *ot_instance);
 void openthread_border_router_set_nat64_translator_enabled(bool enable);
 otError infra_if_nat64_init(void);
+otError infra_if_nat64_deinit(void);
 otError infra_if_send_raw_message(uint8_t *buf, uint16_t len);
 #endif /* CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER */
 

--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -49,10 +49,6 @@ otError udp_plat_init(otInstance *ot_instance, struct net_if *ail_iface, struct 
 	ot_iface_index = (uint32_t)net_if_get_by_iface(ot_iface);
 	ail_iface_index = (uint32_t)net_if_get_by_iface(ail_iface);
 
-	for (uint8_t i = 0; i < CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MAX_UDP_SERVICES; i++) {
-		sockfd_udp[i].fd = -1;
-	}
-
 	return OT_ERROR_NONE;
 }
 
@@ -82,13 +78,14 @@ otError otPlatUdpSocket(otUdpSocket *aUdpSocket)
 	sock = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	VerifyOrExit(sock >= 0, error = OT_ERROR_FAILED);
 
-#if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
-	int off = 0;
+	if (IS_ENABLED(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_IPV4) &&
+	    IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6)) {
+		int off = 0;
 
-	VerifyOrExit(zsock_setsockopt(sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_V6ONLY,
-				      &off, sizeof(off)) == 0,
-		     error = OT_ERROR_FAILED);
-#endif
+		VerifyOrExit(zsock_setsockopt(sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_V6ONLY,
+					      &off, sizeof(off)) == 0,
+			     error = OT_ERROR_FAILED);
+	}
 
 	aUdpSocket->mHandle = INT_TO_POINTER(sock);
 

--- a/subsys/net/l2/openthread/openthread_border_router.h
+++ b/subsys/net/l2/openthread/openthread_border_router.h
@@ -140,6 +140,11 @@ void openthread_border_router_post_message(struct otbr_msg_ctx *msg_context);
  */
 bool openthread_border_router_check_packet_forwarding_rules(struct net_pkt *pkt);
 
+/**
+ * @brief Returns if OpenThread Border Router has IPV4 connectivity established.
+ */
+bool openthread_border_router_has_ipv4_connectivity(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
There are cases in which a DHCPv4 server is not present in the network setup, and therefore, there is no reason to wait for an IPV4 address before starting the border router. In this case, only IPV6 functionalities would be exposed.

A bug related to IPV4 packet filtering required for OT NAT64 module has been identified and fixed. Packet filtering rules were not removed when IPV4 related services were stopped. If a start-stop-start sequence was performed, rules were duplicated.