### PR TITLE
tests: kernel: timer: Fix timer_behavior test for ARC boards

### DIFF
--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -15,6 +15,24 @@ tests:
         as_json: ['metrics']
     platform_exclude:
       - nrf54h20dk/nrf54h20/cpuppr
+    arch_exclude:
+      - arc
+  kernel.timer.timer_arc:
+    tags:
+      - kernel
+      - timer
+    min_ram: 16
+    platform_type:
+      - mcu
+    harness_config:
+      record:
+        regex:
+          - "RECORD:(?P<metrics>.*)"
+        as_json: ['metrics']
+    arch_allow:
+      - arc
+    extra_configs:
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
   kernel.timer.timer_behavior_external:
     tags:
       - kernel


### PR DESCRIPTION
The kernel.timer.timer test fails on ARC hardware boards because they set CONFIG_SYS_CLOCK_TICKS_PER_SEC=100 (10 ms tick period), which is larger than the test's default 1 ms timer period. The kernel rounds up to the next tick boundary, causing the test to fail.

This adds a separate kernel.timer.timer_arc test scenario that overrides the tick rate to 10 kHz for ARC boards, so the test runs at its expected resolution without changing any board defaults.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103076