### PR TITLE
tests: boot: mcuboot_direct_xip: Fix changed string for test

### DIFF
--- a/tests/boot/mcuboot_direct_xip/testcase.yaml
+++ b/tests/boot/mcuboot_direct_xip/testcase.yaml
@@ -35,7 +35,7 @@ tests:
       type: multi_line
       regex:
         - "Starting Direct-XIP bootloader"
-        - "Image 0 Primary slot: Image not found"
+        - "Image 0 primary slot: image not found"
         - "Secondary slot: version=0.0.0\\+0"
         - "Image 0 loaded from the secondary slot"
         - "Bootloader chainload address offset"

--- a/west.yml
+++ b/west.yml
@@ -326,7 +326,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: cb6e4ceaacd4dfe1e3cdeb92c7f5680f62967837
+      revision: d9c2ba153128efd7c16db9f36dea4ee69f63c7f5
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Fixes a test and fixes an issue caused with the recent MCUboot synchronisation that meant the MCUboot version was not put into shared data