### PR TITLE
shell: add configurable bypass buffer size

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -372,6 +372,20 @@ config SHELL_TX_TIMEOUT_MS
 	  When using the shell log backend, the timeout should be longer to avoid
 	  timeouts due to log processing. A value of 0 means no timeout.
 
+config SHELL_BYPASS_READ_BUF_SIZE
+	int "Bypass read buffer size"
+	range 1 $(UINT16_MAX)
+	default SEGGER_RTT_BUFFER_SIZE_DOWN if SHELL_BACKEND_RTT
+	default 16
+	help
+	  Size of buffer used for reading data in bypass mode.
+	  This buffer is allocated on stack. The bypass reads data
+	  in a loop, so a small buffer is sufficient.
+	  Must be smaller than SHELL_STACK_SIZE.
+
+	  When using RTT backend, this defaults to SEGGER_RTT_BUFFER_SIZE_DOWN
+	  for backward compatibility.
+
 source "subsys/shell/modules/Kconfig"
 
 endif # SHELL

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -46,6 +46,9 @@ BUILD_ASSERT(SHELL_THREAD_PRIORITY >=
 		&& SHELL_THREAD_PRIORITY <= K_LOWEST_APPLICATION_THREAD_PRIO,
 		  "Invalid range for thread priority");
 
+BUILD_ASSERT(CONFIG_SHELL_BYPASS_READ_BUF_SIZE < CONFIG_SHELL_STACK_SIZE,
+		  "Bypass buffer size must be smaller than shell stack size");
+
 static inline void receive_state_change(const struct shell *sh,
 					enum shell_receive_state state)
 {
@@ -990,11 +993,7 @@ static void state_collect(const struct shell *sh)
 		void *bypass_user_data = sh->ctx->bypass_user_data;
 
 		if (bypass) {
-#if defined(CONFIG_SHELL_BACKEND_RTT) && defined(CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN)
-			uint8_t buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN];
-#else
-			uint8_t buf[16];
-#endif
+			uint8_t buf[CONFIG_SHELL_BYPASS_READ_BUF_SIZE];
 
 			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);


### PR DESCRIPTION
The bypass mode in shell.c transfers data in a loop and doesn't need a large buffer. The previous code conditionally used `CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN` which unnecessarily tied the bypass buffer size to RTT configuration and could increase stack usage when RTT buffer is configured larger.

This adds `CONFIG_SHELL_BYPASS_BUF_SIZE` with a default of 16 bytes, which is sufficient for the iterative read loop. A build-time assert ensures the buffer doesn't exceed `SHELL_STACK_SIZE`.

Fixes: db9dccdc8a6a4355dcbc618af7e3a8f762b426a4
