### PR TITLE
net: ip: Add dependency to NET_NATIVE when reserving FD

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -541,7 +541,8 @@ config NET_MAX_CONTEXTS
 
 config ZVFS_OPEN_ADD_SIZE_NET
 	int "Number of network sockets to allocate"
-	default NET_MAX_CONTEXTS
+	default NET_MAX_CONTEXTS if NET_NATIVE && NET_SOCKETS
+	default 0
 
 config NET_CONTEXT_NET_PKT_POOL
 	bool "Net_buf TX pool / context"


### PR DESCRIPTION
Increasing FD count in the system for the network stack (native sockets) only makes sense if native network stack is enabled. Otherwise, just make it 0. This makes a difference for example when socket offloading is used and the offloaded implementation makes its own reservation.