### PR TITLE
modules: silabs: Force sli_mv_m4_app_from_flash_to_ram() to be in RAM

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -262,6 +262,10 @@ if(CONFIG_SILABS_SIWX91X_NWP)
     ${WISECONNECT}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c
   )
   zephyr_include_directories(.)
+  zephyr_code_relocate(FILES
+    ${WISECONNECT}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
+    LOCATION RAM
+  )
 endif() # CONFIG_SILABS_SIWX91X_NWP
 
 if(CONFIG_SILABS_SISDK_SLEEPTIMER)

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 6bde23d62ffd16347d1696ba15db92b070907828
+      revision: 8a4c8d3572731757a0a8d9c66cda27bb9343b588
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
SiWx917 does not support concurrent read and write on the flash. `sli_mv_m4_app_from_flash_to_ram()` ensure that requirement. Especially, it disable the Zephyr scheduler. However, to guaranty the instruction cache won't access to the flash, this function has to be located in RAM.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103329