### PR TITLE
firmware: scmi: replace k_is_pre_kernel() with hardcoded value

### DIFF
--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -39,7 +39,6 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 	struct scmi_message msg, reply;
 	int ret;
 	struct scmi_clock_rate_set_reply reply_buffer;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !rate) {
@@ -59,9 +58,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -79,7 +76,6 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 {
 	struct scmi_message msg, reply;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -103,9 +99,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -118,7 +112,6 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	struct scmi_message msg, reply;
 	int ret;
 	struct scmi_clock_parent_get_reply reply_buffer;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !parent_id) {
@@ -138,9 +131,7 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -159,7 +150,6 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	struct scmi_clock_parent_config cfg = {.clk_id = clk_id, .parent_id = parent_id};
 	struct scmi_message msg, reply;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto) {
@@ -179,9 +169,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -194,7 +182,6 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 {
 	struct scmi_message msg, reply;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -229,9 +216,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -244,7 +229,6 @@ int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attrib
 	struct scmi_message msg, reply;
 	struct scmi_clock_attributes_reply reply_buffer;
 	int ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !attributes) {
@@ -265,9 +249,7 @@ int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attrib
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -65,7 +65,7 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -94,7 +94,7 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -153,7 +153,7 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -16,7 +16,6 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 	struct scmi_message msg, reply;
 	uint32_t config_num;
 	int32_t status, ret;
-	bool use_polling;
 
 	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PINCTRL);
 
@@ -53,9 +52,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -22,7 +22,6 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 	struct scmi_power_state_get_reply reply_buffer;
 	struct scmi_message msg, reply;
 	int ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !power_state) {
@@ -42,9 +41,7 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}
@@ -63,7 +60,6 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -88,9 +84,7 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -45,7 +45,6 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 	struct scmi_message msg, reply;
 	int32_t status;
 	int ret;
-	bool use_polling;
 
 	/* input validation */
 	if (!proto || !cfg) {
@@ -65,9 +64,7 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	use_polling = k_is_pre_kernel();
-
-	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	ret = scmi_send_message(proto, &msg, &reply, false);
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
Replace all occurrences of `k_is_pre_kernel()` with a hardcoded `false`. No functional change.
This is a follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/103060.