### PR TITLE
drivers: otp: Remove MCUX from NXP OCOTP

### DIFF
--- a/drivers/otp/Kconfig.mcux_ocotp
+++ b/drivers/otp/Kconfig.mcux_ocotp
@@ -4,7 +4,7 @@
 config OTP_MCUX_OCOTP
 	bool "MCUX OCOTP driver"
 	default y
-	depends on DT_HAS_NXP_MCUX_OCOTP_ENABLED
-	select CLOCK_CONTROL if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_MCUX_OCOTP),clocks)
+	depends on DT_HAS_NXP_OCOTP_ENABLED
+	select CLOCK_CONTROL if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_OCOTP),clocks)
 	help
 	  Enable support for MCUX OCOTP driver.

--- a/drivers/otp/otp_mcux_ocotp.c
+++ b/drivers/otp/otp_mcux_ocotp.c
@@ -10,7 +10,7 @@
 
 #include "fsl_ocotp.h"
 
-#define DT_DRV_COMPAT nxp_mcux_ocotp
+#define DT_DRV_COMPAT nxp_ocotp
 
 LOG_MODULE_REGISTER(mcux_ocotp, CONFIG_OTP_LOG_LEVEL);
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -1227,7 +1227,7 @@
 		};
 
 		ocotp: ocotp@401f4000 {
-			compatible = "nxp,mcux-ocotp";
+			compatible = "nxp,ocotp";
 			reg = <0x401f4000 0x4000>;
 			status = "disabled";
 			clocks = <&ccm IMX_CCM_OCOTP_CLK 0 0>;

--- a/dts/bindings/otp/nxp,ocotp.yaml
+++ b/dts/bindings/otp/nxp,ocotp.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2026 Basalte bv
 # SPDX-License-Identifier: Apache-2.0
 
-title: NXP MCUX OCOTP driver
+title: NXP OCOTP
 
 description: |
-  NXP MCUX On-Chip OTP (One-Time Programmable) controller driver.
+  NXP On-Chip OTP (One-Time Programmable) controller.
 
   This binding represents the OCOTP peripheral found on NXP i.MX RT series
   and similar SoCs. The OCOTP module provides access to on-chip fuse memory
@@ -20,14 +20,14 @@ description: |
   child nodes, use byte offsets. The driver handles the conversion between byte
   addresses and register indices internally.
 
-compatible: "nxp,mcux-ocotp"
+compatible: "nxp,ocotp"
 
 include: base.yaml
 
 examples:
   - |
     ocotp: ocotp@401f4000 {
-            compatible = "nxp,mcux-ocotp";
+            compatible = "nxp,ocotp";
             reg = <0x401f4000 0x4000>;
             status = "okay";
             clocks = <&ccm IMX_CCM_OCOTP_CLK 0 0>;


### PR DESCRIPTION
MCUX should not be used as part of the compatible, update the names, files, etc.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/103087