### PR TITLE
sensing: sensor_mgmt: Fix polling in sensing subsys.

### DIFF
--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -60,6 +60,7 @@ struct sensing_sensor_register_info {
  */
 enum {
 	EVENT_CONFIG_READY, /**< Configuration is ready. */
+	EVENT_SENSOR_POLL,  /**< Sensor polling requested by timer. */
 };
 
 /**
@@ -69,6 +70,7 @@ enum {
  */
 enum {
 	SENSOR_LATER_CFG_BIT, /**< Indicates if there is a configuration request pending. */
+	SENSOR_POLL_BIT,      /**< Indicates sensor needs to be polled. */
 };
 
 /**


### PR DESCRIPTION
The sensing subsystem currently calls fetch and get from a timer ISR context. A TODO had been previously added to move this to the runtime thread context, which has been done in this fix.