### PR TITLE
fs: fs_stat: handle if it is on a mount point

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -127,6 +127,14 @@ static int fs_get_mnt_point(struct fs_mount_t **mnt_pntp,
 	return 0;
 }
 
+static inline void fs_copy_mnt_point_to_entry(struct fs_mount_t *mnt, struct fs_dirent *entry)
+{
+	entry->type = FS_DIR_ENTRY_DIR;
+	memcpy(entry->name, &mnt->mnt_point[1], min(sizeof(entry->name) - 1, mnt->mountp_len));
+	entry->name[sizeof(entry->name) - 1] = 0;
+	entry->size = 0;
+}
+
 /* File operations */
 int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 {
@@ -445,11 +453,7 @@ int fs_readdir(struct fs_dir_t *zdp, struct fs_dirent *entry)
 
 			mnt = CONTAINER_OF(node, struct fs_mount_t, node);
 
-			entry->type = FS_DIR_ENTRY_DIR;
-			strncpy(entry->name, mnt->mnt_point + 1,
-				sizeof(entry->name) - 1);
-			entry->name[sizeof(entry->name) - 1] = 0;
-			entry->size = 0;
+			fs_copy_mnt_point_to_entry(mnt, entry);
 
 			/* Save pointer to the next one, for later */
 			next = sys_dlist_peek_next(&fs_mnt_list, node);
@@ -606,17 +610,31 @@ int fs_stat(const char *abs_path, struct fs_dirent *entry)
 {
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
+	size_t mp_len;
+	size_t path_len;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (abs_path[0] != '/')) {
+		path_len = 0;
+	} else {
+		path_len = strlen(abs_path);
+	}
+
+	if (path_len <= 1) {
 		LOG_ERR("invalid file or dir name!!");
 		return -EINVAL;
 	}
 
-	rc = fs_get_mnt_point(&mp, abs_path, NULL);
+	rc = fs_get_mnt_point(&mp, abs_path, &mp_len);
 	if (rc < 0) {
 		LOG_ERR("mount point not found!!");
 		return rc;
+	}
+
+	/* abs_path can have a / at the end, unlike mnt_point. */
+	if (path_len - mp_len <= 1U) {
+		/* Stat on the mount point itself */
+		fs_copy_mnt_point_to_entry(mp, entry);
+		return 0;
 	}
 
 	CHECKIF(mp->fs->stat == NULL) {

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -1000,7 +1000,7 @@ ZTEST(fs_api_dir_file, test_file_stat)
 	zassert_not_equal(ret, 0, "Stat a not existing dir");
 
 	ret = fs_stat(NOOP_MNTP, &entry);
-	zassert_not_equal(ret, 0, "filesystem has no stat functionality");
+	zassert_equal(ret, 0, "Fail to stat a mount point");
 
 	ret = fs_stat(TEST_DIR, &entry);
 	zassert_equal(ret, 0, "Fail to stat a dir");


### PR DESCRIPTION
If fs_stat() is done on a mount point treat it like it is a directory, instead of leaving it to the implementation of the filesystem.

The fatfs for example will fail. That is also the reason `fs cd` from the fs shell fails, when trying it on a mointpoint with fatfs.

Also brings `fs_stat()` inline with `fs_readdir()` as both use `struct fs_dirent` to return the infos about the dir/file.