### PR TITLE
drivers: xen: add XEN_EVENTS Kconfig option

### DIFF
--- a/arch/arm64/core/xen/CMakeLists.txt
+++ b/arch/arm64/core/xen/CMakeLists.txt
@@ -5,4 +5,4 @@
 zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:-D__ASSEMBLY__>)
 
 zephyr_library_sources(hypercall.S)
-zephyr_library_sources(enlighten.c)
+zephyr_library_sources_ifdef(CONFIG_XEN_EVENTS enlighten.c)

--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -11,6 +11,7 @@ config UART_XEN_HVC
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on XEN && !XEN_DOM0 && !XEN_DOM0LESS
+	select XEN_EVENTS if UART_INTERRUPT_DRIVEN
 	help
 	  Enable Xen ring buffer based hypervisor console driver. Used
 	  for Zephyr as unprivileged domain.

--- a/drivers/xen/CMakeLists.txt
+++ b/drivers/xen/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2021-2025 EPAM Systems
 
 zephyr_sources(hvm.c)
-zephyr_sources(events.c)
+zephyr_sources_ifdef(CONFIG_XEN_EVENTS events.c)
 zephyr_sources_ifdef(CONFIG_XEN_GRANT_TABLE gnttab.c)
 zephyr_sources(memory.c)
 zephyr_sources_ifdef(CONFIG_XEN_DMOP dmop.c)

--- a/drivers/xen/Kconfig
+++ b/drivers/xen/Kconfig
@@ -35,6 +35,12 @@ config NR_GRANT_FRAMES
 	  grant table driver in runtime. This value should be <= max_grant_frames
 	  configured for domain in Xen hypervisor.
 
+config XEN_EVENTS
+	bool "Xen events driver"
+	default y
+	help
+	  Xen event channels driver.
+
 endmenu
 
 endif # XEN


### PR DESCRIPTION
The Xen events channel driver consume 72K of RAM, but may not be required in all use cases.

Added a XEN_EVENTS Kconfig option so that Xen events can be gracefully disabled if not required. Updated the relevant CMakeLists.txt and Kconfig files to guard the inclusion of the Xen events driver and its source files by this option.