### PR TITLE
boards: nrf7120dk: Update UART00 and SPI00 pin mappings

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120-pinctrl.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120-pinctrl.dtsi
@@ -53,16 +53,16 @@
 	/omit-if-no-ref/ spi00_default: spi00_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
-				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+				<NRF_PSEL(SPIM_MOSI, 2, 0)>,
+				<NRF_PSEL(SPIM_MISO, 2, 2)>;
 		};
 	};
 
 	/omit-if-no-ref/ spi00_sleep: spi00_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
-				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
-				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+				<NRF_PSEL(SPIM_MOSI, 2, 0)>,
+				<NRF_PSEL(SPIM_MISO, 2, 2)>;
 			low-power-enable;
 		};
 	};
@@ -82,23 +82,23 @@
 
 	/omit-if-no-ref/ uart00_default: uart00_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 2)>,
+			psels = <NRF_PSEL(UART_TX, 2, 0)>,
 				<NRF_PSEL(UART_RTS, 2, 5)>;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 2, 0)>,
-				<NRF_PSEL(UART_CTS, 2, 4)>;
+			psels = <NRF_PSEL(UART_RX, 2, 4)>,
+				<NRF_PSEL(UART_CTS, 2, 2)>;
 			bias-pull-up;
 		};
 	};
 
 	/omit-if-no-ref/ uart00_sleep: uart00_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 2)>,
-				<NRF_PSEL(UART_RX, 2, 0)>,
+			psels = <NRF_PSEL(UART_TX, 2, 0)>,
+				<NRF_PSEL(UART_RX, 2, 4)>,
 				<NRF_PSEL(UART_RTS, 2, 5)>,
-				<NRF_PSEL(UART_CTS, 2, 4)>;
+				<NRF_PSEL(UART_CTS, 2, 2)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Hardware assignments for UART00 and SPI00 have changed so SPI00 can align with QSPI00.