### PR TITLE
tests: modem: fix typos in comments and assert

### DIFF
--- a/tests/subsys/modem/backends/uart/src/main.c
+++ b/tests/subsys/modem/backends/uart/src/main.c
@@ -9,7 +9,7 @@
  * RX and TX pins wired together to provide loopback functionality. A large number of bytes
  * containing a sequence of pseudo random numbers are then transmitted, received, and validated.
  *
- * The test suite repeats three times, opening and clsoing the modem_pipe attached to the
+ * The test suite repeats three times, opening and closing the modem_pipe attached to the
  * modem_backend_uart instance before and after the tests respectively.
  */
 

--- a/tests/subsys/modem/mock/modem_backend_mock.h
+++ b/tests/subsys/modem/mock/modem_backend_mock.h
@@ -38,7 +38,7 @@ struct modem_backend_mock {
 
 	/* Max allowed read/write size */
 	size_t limit;
-	/* Mock Brige pair */
+	/* Mock Bridge pair */
 	struct modem_backend_mock *bridge;
 };
 

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -341,7 +341,7 @@ ZTEST(modem_ppp, test_ppp_frame_receive)
 	net_pkt_read(pkt, buffer, pkt_len);
 
 	zassert_true(memcmp(buffer, ppp_frame_unwrapped, pkt_len) == 0,
-		     "Recevied net pkt data incorrect");
+		     "Received net pkt data incorrect");
 }
 
 ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)
@@ -368,7 +368,7 @@ ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)
 	net_pkt_cursor_init(pkt);
 	net_pkt_read(pkt, buffer, pkt_len);
 	zassert_true(memcmp(buffer, ppp_frame_unwrapped, pkt_len) == 0,
-		     "Recevied net pkt data incorrect");
+		     "Received net pkt data incorrect");
 }
 
 ZTEST(modem_ppp, test_ppp_frame_send)
@@ -486,7 +486,7 @@ ZTEST(modem_ppp, test_ip_frame_receive)
 	net_pkt_cursor_init(pkt);
 	net_pkt_read(pkt, buffer, pkt_len);
 	zassert_true(memcmp(buffer, ip_frame_unwrapped_with_protocol, pkt_len) == 0,
-		     "Recevied net pkt data incorrect");
+		     "Received net pkt data incorrect");
 }
 
 ZTEST(modem_ppp, test_ip_frame_send)

--- a/tests/subsys/modem/modem_ubx/src/main.c
+++ b/tests/subsys/modem/modem_ubx/src/main.c
@@ -433,7 +433,7 @@ ZTEST(modem_ubx, test_rsp_filters_out_non_matches)
 	uint8_t buf[256];
 	size_t buf_len = 0;
 
-	/** We're passing a valid packet, but not what we're expecing. We
+	/** We're passing a valid packet, but not what we're expecting. We
 	 * should not get an event out of this one.
 	 */
 	memcpy(buf, &test_rsp_non_match, UBX_FRAME_SZ(test_rsp_non_match.payload_size));
@@ -481,7 +481,7 @@ ZTEST(modem_ubx, test_rsp_match_with_payload)
 	uint8_t buf[256];
 	size_t buf_len = 0;
 
-	/** We're passing a valid packet, but not what we're expecing. We
+	/** We're passing a valid packet, but not what we're expecting. We
 	 * should not get an event out of this one.
 	 */
 	memcpy(buf, &test_rsp_non_match, UBX_FRAME_SZ(test_rsp_non_match.payload_size));


### PR DESCRIPTION
Fix spelling and wording issues in comments and assert across tests modem files.

No functional change.