### PR TITLE
kernel: Add NONZERO_SPINLOCK_SIZE Kconfig option

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -432,6 +432,13 @@ config CURRENT_THREAD_USE_TLS
 	  Use thread local storage to store the current thread. This avoids a
 	  syscall if userspace is enabled.
 
+config NONZERO_SPINLOCK_SIZE
+	bool "Force spinlock to have non-zero size"
+	help
+	  This option indicates that the spinlock structure must have a
+	  non-zero size (such as if used in an array). It is automatically
+	  selected when using C++.
+
 endmenu
 
 menu "Kernel Debugging and Metrics"

--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -7,6 +7,7 @@ menu "C++ Language Support"
 
 config CPP
 	bool "C++ support for the application"
+	select NONZERO_SPINLOCK_SIZE
 	help
 	  This option enables the use of applications built with C++.
 

--- a/lib/posix/options/Kconfig.spinlock
+++ b/lib/posix/options/Kconfig.spinlock
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_SPIN_LOCKS
 	bool "POSIX spin locks"
+	select NONZERO_SPINLOCK_SIZE
 	help
 	  Select 'y' here to enable POSIX spin locks.
 

--- a/lib/posix/options/spinlock.c
+++ b/lib/posix/options/spinlock.c
@@ -11,17 +11,7 @@
 #include <zephyr/posix/pthread.h>
 #include <zephyr/sys/bitarray.h>
 
-union _spinlock_storage {
-	struct k_spinlock lock;
-	uint8_t byte;
-};
-#if !defined(CONFIG_CPP) && !defined(CONFIG_SMP) && !defined(CONFIG_SPIN_VALIDATE)
-BUILD_ASSERT(sizeof(struct k_spinlock) == 0,
-	     "please remove the _spinlock_storage workaround if, at some point, k_spinlock is no "
-	     "longer zero bytes when CONFIG_SMP=n && CONFIG_SPIN_VALIDATE=n");
-#endif
-
-static union _spinlock_storage posix_spinlock_pool[CONFIG_MAX_PTHREAD_SPINLOCK_COUNT];
+static struct k_spinlock posix_spinlock_pool[CONFIG_MAX_PTHREAD_SPINLOCK_COUNT];
 static k_spinlock_key_t posix_spinlock_key[CONFIG_MAX_PTHREAD_SPINLOCK_COUNT];
 SYS_BITARRAY_DEFINE_STATIC(posix_spinlock_bitarray, CONFIG_MAX_PTHREAD_SPINLOCK_COUNT);
 
@@ -35,7 +25,7 @@ BUILD_ASSERT(CONFIG_MAX_PTHREAD_SPINLOCK_COUNT < PTHREAD_OBJ_MASK_INIT,
 
 static inline size_t posix_spinlock_to_offset(struct k_spinlock *l)
 {
-	return (union _spinlock_storage *)l - posix_spinlock_pool;
+	return l - posix_spinlock_pool;
 }
 
 static inline size_t to_posix_spinlock_idx(pthread_spinlock_t lock)


### PR DESCRIPTION
Embeds both an anonymous union and an anonymous structure within the
k_spinlock structure to ensure that the structure can easily have a
non-zero size.
    
This new option provides a cleaner way to specify that the
spinlock structure must have a non-zero size. A non-zero size
is necessary when C++ support is enabled, or when a library
or application wants to create an array of spinlocks.

Fixes #59922