### PR TITLE
boards: adafruit: power lcd controller at init

### DIFF
--- a/boards/adafruit/feather_esp32s3_tft/board.c
+++ b/boards/adafruit/feather_esp32s3_tft/board.c
@@ -15,6 +15,7 @@
 
 #if DT_NODE_HAS_STATUS(DISPLAY_NODE, okay)
 static const struct gpio_dt_spec backlight = GPIO_DT_SPEC_GET(DT_ALIAS(backlight), gpios);
+static const struct gpio_dt_spec i2c_reg = GPIO_DT_SPEC_GET(DT_NODELABEL(i2c_reg), enable_gpios);
 #endif
 
 void board_late_init_hook(void)
@@ -22,6 +23,10 @@ void board_late_init_hook(void)
 #if DT_NODE_HAS_STATUS(DISPLAY_NODE, okay)
 	if (gpio_is_ready_dt(&backlight)) {
 		gpio_pin_configure_dt(&backlight, GPIO_OUTPUT_ACTIVE);
+	}
+
+	if (gpio_is_ready_dt(&i2c_reg)) {
+		gpio_pin_configure_dt(&i2c_reg, GPIO_OUTPUT_ACTIVE);
 	}
 #endif
 }


### PR DESCRIPTION
Power LCD controller at init just as the
board already does for the backlight.
Without power, LCD controller fails silently.

Signed-off-by: Peter Hoddie <peter@moddable.com>
