### PR TITLE
xtensa: cleanup exception handling and rework TLB multi-hit exception handling

### DIFF
--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -704,23 +704,6 @@ skip_checks:
 		break;
 	}
 
-#ifdef CONFIG_XTENSA_MMU
-	switch (cause) {
-	case EXCCAUSE_LEVEL1_INTERRUPT:
-#ifndef CONFIG_USERSPACE
-	case EXCCAUSE_SYSCALL:
-#endif /* !CONFIG_USERSPACE */
-#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
-	case EXCCAUSE_CP_DISABLED(XCHAL_CP_ID_AUDIOENGINELX):
-#endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
-		is_fatal_error = false;
-		break;
-	default:
-		is_fatal_error = true;
-		break;
-	}
-#endif /* CONFIG_XTENSA_MMU */
-
 	if (is_dblexc || is_fatal_error) {
 		uint32_t ignore;
 

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -632,7 +632,7 @@ void *xtensa_excint1_c(void *esf)
 #endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
 #if defined(CONFIG_XTENSA_MMU) && defined(CONFIG_USERSPACE)
 	case EXCCAUSE_DTLB_MULTIHIT:
-		xtensa_exc_dtlb_multihit_handle();
+		xtensa_exc_dtlb_multihit_handle((void *)bsa->excvaddr);
 		goto return_to_interrupted;
 		break;
 	case EXCCAUSE_LOAD_STORE_RING:

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -631,6 +631,9 @@ void *xtensa_excint1_c(void *esf)
 		break;
 #endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
 #if defined(CONFIG_XTENSA_MMU) && defined(CONFIG_USERSPACE)
+	case EXCCAUSE_ITLB_MULTIHIT:
+		xtensa_exc_itlb_multihit_handle((void *)bsa->excvaddr);
+		goto return_to_interrupted;
 	case EXCCAUSE_DTLB_MULTIHIT:
 		xtensa_exc_dtlb_multihit_handle((void *)bsa->excvaddr);
 		goto return_to_interrupted;

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -633,10 +633,11 @@ void *xtensa_excint1_c(void *esf)
 #if defined(CONFIG_XTENSA_MMU) && defined(CONFIG_USERSPACE)
 	case EXCCAUSE_DTLB_MULTIHIT:
 		xtensa_exc_dtlb_multihit_handle();
+		goto return_to_interrupted;
 		break;
 	case EXCCAUSE_LOAD_STORE_RING:
 		if (!xtensa_exc_load_store_ring_error_check(bsa)) {
-			break;
+			goto return_to_interrupted;
 		}
 		__fallthrough;
 #endif /* CONFIG_XTENSA_MMU && CONFIG_USERSPACE */
@@ -740,6 +741,15 @@ skip_checks:
 #endif /* CONFIG_XTENSA_MMU */
 
 	return return_to(interrupted_stack);
+
+#if defined(CONFIG_XTENSA_MMU) && defined(CONFIG_USERSPACE)
+return_to_interrupted:
+	if (is_dblexc) {
+		XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
+	}
+
+	return interrupted_stack;
+#endif /* CONFIG_XTENSA_MMU && CONFIG_USERSPACE */
 }
 
 #if defined(CONFIG_GDBSTUB)

--- a/arch/xtensa/include/xtensa_internal.h
+++ b/arch/xtensa/include/xtensa_internal.h
@@ -85,6 +85,16 @@ bool xtensa_mem_kernel_has_access(const void *addr, size_t size, int write);
 void xtensa_exc_dtlb_multihit_handle(void *vaddr);
 
 /**
+ * @brief Handle ITLB multihit exception.
+ *
+ * Handle ITLB multihit exception by invalidating all auto-refilled ITLBs of
+ * a particular memory page.
+ *
+ * @param[in] vaddr Virtual address of ITLB to be invalidated.
+ */
+void xtensa_exc_itlb_multihit_handle(void *vaddr);
+
+/**
  * @brief Check if it is a true load/store ring exception.
  *
  * When a page can be accessed by both kernel and user threads, the autofill DTLB

--- a/arch/xtensa/include/xtensa_internal.h
+++ b/arch/xtensa/include/xtensa_internal.h
@@ -77,10 +77,12 @@ bool xtensa_mem_kernel_has_access(const void *addr, size_t size, int write);
 /**
  * @brief Handle DTLB multihit exception.
  *
- * Handle DTLB multihit exception by invalidating all auto-refilled DTLBs of
+ * Handle DTLB multihit exception by invalidating auto-refilled DTLBs of
  * a particular memory page.
+ *
+ * @param[in] vaddr Virtual address of data TLB to be invalidated.
  */
-void xtensa_exc_dtlb_multihit_handle(void);
+void xtensa_exc_dtlb_multihit_handle(void *vaddr);
 
 /**
  * @brief Check if it is a true load/store ring exception.

--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -323,6 +323,28 @@ static inline void xtensa_dtlb_autorefill_invalidate(void)
 }
 
 /**
+ * @brief Invalidate all autorefill ITLB entries.
+ *
+ * This should be used carefully since all refill entries in
+ * the instruction TLBs are affected.
+ */
+static inline void xtensa_itlb_autorefill_invalidate(void)
+{
+	uint8_t way, i, entries;
+
+	entries = BIT(XCHAL_ITLB_ARF_ENTRIES_LOG2);
+
+	for (way = 0; way < XTENSA_MMU_NUM_TLB_AUTOREFILL_WAYS; way++) {
+		for (i = 0; i < entries; i++) {
+			uint32_t entry = way + (i << XTENSA_MMU_PTE_PPN_SHIFT);
+
+			xtensa_itlb_entry_invalidate(entry);
+		}
+	}
+	__asm__ volatile("isync");
+}
+
+/**
  * @brief Set the page tables.
  *
  * The page tables is set writing ptevaddr address.


### PR DESCRIPTION
* Removes an unnecessary part of exception handling of setting the variable `is_fatal_error`.
* After handling DTLB multi-hit exception, return directly to the exception raising site to continue execution to minimize the chance of hitting DTLB multi-hit again.
* Changed DTLB multi-hit handling to only invalidate the TLB entries corresponding to the exception address.
* Added ITLB multi-hit handling.