### PR TITLE
docs(example): improve README with latest Wi-Fi shell command usage 

### DIFF
--- a/samples/net/wifi/shell/README.rst
+++ b/samples/net/wifi/shell/README.rst
@@ -12,6 +12,7 @@ enabling the Wi-Fi shell module that provides a set of commands:
 scan, connect, and disconnect.  It also enables the net_shell module
 to verify net_if settings.
 
+
 Building and Running
 ********************
 
@@ -28,6 +29,14 @@ For instance you can use Nordic's nrf7002dk by selecting the nrf7002dk/nrf5340/c
 Sample console interaction
 ==========================
 
+For in-depth description of each shell command, you can run ``wifi --help`` on the shell.
+
+In this shell example, we will scan for available access points and connect to one of them.
+``--key-mgmt`` indicates the security type, where 0 is open, 1 is WPA/WPA2 Personal.
+
+More information can be obtained by running ``wifi connect --help``.
+
+
 .. code-block:: console
 
    shell> wifi scan
@@ -41,7 +50,7 @@ Sample console interaction
    ----------
    Scan request done
 
-   shell> wifi connect "gksu" 4 SecretStuff
+   shell> wifi connect --ssid "gksu" --key-mgmt 1 --passphrase SecretStuff
    Connection requested
    shell>
    Connected


### PR DESCRIPTION
The documentation on the wifi shell is not updated, and it seems would help future users if the shell example are updated.