### PR TITLE
drivers: flash: Allow configuring dummy byte count for RDID request

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -338,7 +338,7 @@ pmod_spi: &spi4 {
 		compatible = "adi,max32-spixf-nor";
 		reg = <0x08000000 DT_SIZE_M(8)>; /* 64 Mbits */
 		qspi-max-frequency = <60000000>;
-		jedec-id = [c2 37 25];
+		jedec-id = [c2 25 37];
 		sfdp-bfp = [e5 20 f1 ff ff ff ff 03 44 eb 08 6b 08 3b 04 bb
 			    fe ff ff ff ff ff 00 ff ff ff 44 eb 0c 20 0f 52
 			    10 d8 00 ff d3 49 c9 00 83 a6 04 c4 44 03 17 38

--- a/drivers/flash/flash_max32_spixf_nor.c
+++ b/drivers/flash/flash_max32_spixf_nor.c
@@ -298,9 +298,10 @@ static int qspi_write_status_register(const struct device *dev, uint8_t reg_num,
 
 static int qspi_read_jedec_id_priv(const struct device *dev, uint8_t *id)
 {
+	uint32_t dummy_cycles = DT_INST_PROP(0, read_id_dummy_cycles);
 	int ret;
 
-	ret = qspi_read_access(dev, JESD216_CMD_READ_ID, id, JESD216_READ_ID_LEN, 8);
+	ret = qspi_read_access(dev, JESD216_CMD_READ_ID, id, JESD216_READ_ID_LEN, dummy_cycles);
 	if (ret < 0) {
 		LOG_ERR("Failed to read ID (%d)", ret);
 		return ret;

--- a/dts/bindings/flash_controller/adi,max32-spixf-nor.yaml
+++ b/dts/bindings/flash_controller/adi,max32-spixf-nor.yaml
@@ -71,3 +71,11 @@ properties:
     description: |
       Force 4 I/O lines for addressing even when using PP_1_1_4 writes.
       This is mostly useful for Microchip NOR flash which require this quirk.
+
+  read-id-dummy-cycles:
+    type: int
+    default: 0
+    description: |
+      The number of dummy-cycles required when reading jedec id. Default value is zero, which
+      matches most parts, but this can be set for parts that require any dummy bytes before the
+      response is sent.


### PR DESCRIPTION
Different flash parts have different requirements on the number of dummy
bytes to send when issued a RDID request, so allow configuring the read ID
dummy byte count in devicetree for the MAX32 SPIXF flash driver.

This is a proper fix that supersedes #103018 by sending the correct number of dummy bytes to the flash on the APARD32690 board so it sends the manufacturer and device IDs in the correct order.