### PR TITLE
subsys: pmci: resolve some mctp_i3c issues

### DIFF
--- a/subsys/pmci/mctp/mctp_i3c_controller.c
+++ b/subsys/pmci/mctp/mctp_i3c_controller.c
@@ -114,6 +114,7 @@ int mctp_i3c_controller_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt
 	struct i3c_msg msg = {
 		.buf = &pkt->data[pkt->start],
 		.len = pktsize,
+		.flags = I3C_MSG_WRITE | I3C_MSG_STOP,
 	};
 
 	int rc = i3c_transfer(b->endpoint_i3c_devs[endpoint_idx], &msg, 1);

--- a/subsys/pmci/mctp/mctp_i3c_target.c
+++ b/subsys/pmci/mctp/mctp_i3c_target.c
@@ -80,7 +80,7 @@ int mctp_i3c_target_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 
 	/* Some I3C IP need to have data at TX fifo before raising IBI */
 	ret = i3c_target_tx_write(b->i3c, pkt->data + pkt->start, pkt->end - pkt->start, 0);
-	if (ret != 0) {
+	if (ret < 0) {
 		LOG_ERR("i3c_target_tx_write failed: %d", ret);
 		goto out;
 	}


### PR DESCRIPTION
This pr resolves some mctp_i3c subsys and sample issues.
- subsys: pmci: mctp_i3c_target: fix incorrect return code check
- subsys: pmci: mctp_i3c_controller: fix missing STOP flag for i3c write msg
- sample: subsys: pmci: i3c_bus_endpoint: moves rx msg handler to sys workq