### PR TITLE
usb: host: add macros for device connection state

### DIFF
--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -26,6 +26,11 @@
 extern "C" {
 #endif
 
+/** USB device connected signal value */
+#define USBH_DEVICE_CONNECTED			1
+/** USB device disconnected signal value */
+#define USBH_DEVICE_DISCONNECTED		2
+
 /**
  * @brief USB HOST Core Layer API
  * @defgroup usb_host_core_api USB Host Core API


### PR DESCRIPTION
Introduce USBH_DEVICE_CONNECTED and USBH_DEVICE_DISCONNECTED macros to report USB device connection status.

USB host application needs to know the current device's connection status. For the usage, refer to [ usb: host: class: support for usb host video class #94085](https://github.com/zephyrproject-rtos/zephyr/pull/94085)