### PR TITLE
drivers: adc: add adc emul shell

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -241,6 +241,13 @@ File-System
 - :kconfig:option:`CONFIG_FILE_SYSTEM`
 - :kconfig:option:`CONFIG_FILE_SYSTEM_SHELL`
 
+ADC
+---
+
+- :kconfig:option:`CONFIG_ADC`
+- :kconfig:option:`CONFIG_ADC_SHELL`
+- :kconfig:option:`CONFIG_ADC_EMUL_SHELL` (requires :kconfig:option:`CONFIG_ADC_EMUL`)
+
 Creating commands
 =================
 

--- a/drivers/adc/CMakeLists.txt
+++ b/drivers/adc/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_ADC adc_common.c)
 zephyr_library_sources_ifdef(CONFIG_ADC_SHELL adc_shell.c)
+zephyr_library_sources_ifdef(CONFIG_ADC_EMUL_SHELL adc_emul_shell.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE adc_handlers.c)
 
 # zephyr-keep-sorted-start

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -21,6 +21,13 @@ config ADC_SHELL
 	help
 	  Enable ADC Shell for testing.
 
+config ADC_EMUL_SHELL
+	bool "ADC emulator shell"
+	depends on SHELL
+	depends on ADC_EMUL
+	help
+	  Enable ADC emulator (zephyr,adc-emul) shell commands.
+
 # By selecting or not this option particular ADC drivers indicate if it is
 # required to explicitly specify analog inputs when configuring channels or
 # just the channel identifier is sufficient.

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -298,8 +298,7 @@ static int adc_emul_channel_setup(const struct device *dev,
 	}
 
 	if (channel_cfg->differential) {
-		LOG_ERR("unsupported differential mode");
-		return -ENOTSUP;
+		LOG_WRN("differential mode requested; samples are provided as raw codes");
 	}
 
 	emul_chan_cfg = &data->chan_cfg[channel_cfg->channel_id];

--- a/drivers/adc/adc_emul_shell.c
+++ b/drivers/adc/adc_emul_shell.c
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/adc/adc_emul.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/util.h>
+
+#define ADC_EMUL_HDL_LIST_ENTRY(node_id) { .dev = DEVICE_DT_GET(node_id) },
+
+static const struct {
+	const struct device *dev;
+} adc_emul_list[] = {
+	DT_FOREACH_STATUS_OKAY(zephyr_adc_emul, ADC_EMUL_HDL_LIST_ENTRY)
+};
+
+static const struct device *get_adc_emul(const char *device_name)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(adc_emul_list); i++) {
+		if (!strcmp(device_name, adc_emul_list[i].dev->name)) {
+			return adc_emul_list[i].dev;
+		}
+	}
+
+	/* The device name is provided by shell dynamic command completion. */
+	__ASSERT_NO_MSG(false);
+	return NULL;
+}
+
+static int cmd_adc_emul_raw(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	const struct device *dev = get_adc_emul(argv[-1]);
+	char *endptr;
+	unsigned long chan_ul;
+	unsigned long raw_ul;
+	int ret;
+
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "ADC emulator device not ready");
+		return -ENODEV;
+	}
+
+	endptr = NULL;
+	chan_ul = strtoul(argv[1], &endptr, 0);
+	if ((endptr == argv[1]) || (*endptr != '\0')) {
+		shell_error(sh, "<channel> must be a number");
+		return -EINVAL;
+	}
+
+	endptr = NULL;
+	raw_ul = strtoul(argv[2], &endptr, 0);
+	if ((endptr == argv[2]) || (*endptr != '\0') || (raw_ul > 0xFFFFUL)) {
+		shell_error(sh, "<raw> must be 0..0xFFFF (supports 0x prefix)");
+		return -EINVAL;
+	}
+
+	ret = adc_emul_const_raw_value_set(dev, (unsigned int)chan_ul, (uint32_t)raw_ul);
+	if (ret != 0) {
+		shell_error(sh, "adc_emul_const_raw_value_set failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "%s: ch%lu raw=0x%04lX (%lu)", dev->name, chan_ul, raw_ul, raw_ul);
+	return 0;
+}
+
+static int cmd_adc_emul_mv(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	const struct device *dev = get_adc_emul(argv[-1]);
+	char *endptr;
+	unsigned long chan_ul;
+	unsigned long mv_ul;
+	int ret;
+
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "ADC emulator device not ready");
+		return -ENODEV;
+	}
+
+	endptr = NULL;
+	chan_ul = strtoul(argv[1], &endptr, 0);
+	if ((endptr == argv[1]) || (*endptr != '\0')) {
+		shell_error(sh, "<channel> must be a number");
+		return -EINVAL;
+	}
+
+	endptr = NULL;
+	mv_ul = strtoul(argv[2], &endptr, 0);
+	if ((endptr == argv[2]) || (*endptr != '\0')) {
+		shell_error(sh, "<mv> must be a number");
+		return -EINVAL;
+	}
+
+	ret = adc_emul_const_value_set(dev, (unsigned int)chan_ul, (uint32_t)mv_ul);
+	if (ret != 0) {
+		shell_error(sh, "adc_emul_const_value_set failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "%s: ch%lu mv=%lu", dev->name, chan_ul, mv_ul);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_emul_cmds,
+	SHELL_CMD_ARG(raw, NULL,
+		"Set constant RAW code: raw <channel> <value> (decimal or 0x....)",
+		cmd_adc_emul_raw, 3, 0),
+	SHELL_CMD_ARG(mv, NULL,
+		"Set constant input voltage in mV: mv <channel> <mv>",
+		cmd_adc_emul_mv, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
+static void cmd_adc_emul_dev_get(size_t idx, struct shell_static_entry *entry)
+{
+	if (idx < ARRAY_SIZE(adc_emul_list)) {
+		entry->syntax = adc_emul_list[idx].dev->name;
+		entry->handler = NULL;
+		entry->subcmd = &sub_adc_emul_cmds;
+		entry->help = "Select subcommand for ADC emulator device.";
+	} else {
+		entry->syntax = NULL;
+	}
+}
+
+SHELL_DYNAMIC_CMD_CREATE(sub_adc_emul_dev, cmd_adc_emul_dev_get);
+
+SHELL_CMD_REGISTER(adc_emul, &sub_adc_emul_dev, "ADC emulator commands", NULL);


### PR DESCRIPTION
Overview
=============

When using the ADC emulator `zephyr,adc-emul`, it is often useful to control the emulated input at runtime while testing ADC client code. Enabling `CONFIG_ADC_EMUL_SHELL registers an ``adc_emul`` shell command group which can set a constant raw ADC code or a constant input voltage (in millivolts) for a channel. This is intended for test and debug, it is not used by production applications.

Configuration
=============

Enable the following options:

- `CONFIG_ADC`
- `CONFIG_SHELL`
- `CONFIG_ADC_EMUL`
- `CONFIG_ADC_EMUL_SHELL`

You also need at least one enabled ADC emulator node in devicetree.

Example devicetree overlay
-------------------------

```
   / {
     test_adc_emul: adc-emul {
       compatible = "zephyr,adc-emul";
       status = "okay";
       nchannels = <2>;
       ref-internal-mv = <3300>;
       #io-channel-cells = <1>;
     };
   };
```

Usage
=====

List available emulated ADC devices (device names are board/build dependent):

   `uart:~$ adc_emul <TAB>`

Set constant raw code (16-bit, accepts decimal or ``0x`` hex):

   `uart:~$ adc_emul adc-emul raw 0 0x8000`

Set constant input voltage (mV):

   `uart:~$ adc_emul adc-emul mv 0 1650`

Combine with the generic ADC shell to read values:

   `uart:~$ adc adc-emul resolution 16`
   `uart:~$ adc adc-emul read 0`

Notes
=====

- The ADC emulator supports up to 16-bit resolution.
- Channel numbers are validated by the emulator based on the ``nchannels`` devicetree property.
