### PR TITLE
drivers: video: add link up/down signal events

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -220,6 +220,8 @@ enum video_signal_result {
 	VIDEO_BUF_DONE,    /**< Buffer is done */
 	VIDEO_BUF_ABORTED, /**< Buffer is aborted */
 	VIDEO_BUF_ERROR,   /**< Buffer is in error */
+	VIDEO_LINK_UP,     /**< Video link up */
+	VIDEO_LINK_DOWN,   /**< Video link down */
 };
 
 /**


### PR DESCRIPTION
Add VIDEO_LINK_UP and VIDEO_LINK_DOWN signals for
video link status notification.

The application needs to know the current video link status. For one usage case, refer to[ usb: host: class: support for usb host video class#94085](https://github.com/zephyrproject-rtos/zephyr/pull/94085)
