### PR TITLE
scripts: west_commands: add west reset command to reboot board

### DIFF
--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -49,6 +49,9 @@ west-commands:
       - name: rtt
         class: Rtt
         help: open an rtt shell
+      - name: reset
+        class: Reset
+        help: reset the board to reboot
   - file: scripts/west_commands/export.py
     commands:
       - name: zephyr-export

--- a/scripts/west_commands/debug.py
+++ b/scripts/west_commands/debug.py
@@ -92,3 +92,23 @@ class Rtt(WestCommand):
 
     def do_run(self, my_args, runner_args):
         do_run_common(self, my_args, runner_args)
+
+
+class Reset(WestCommand):
+
+    def __init__(self):
+        super().__init__(
+            'reset',
+            # Keep this in sync with the string in west-commands.yml.
+            'reset the board to reboot',
+            "",
+            accepts_unknown_args=True)
+        self.runner_key = 'debug-runner'  # in runners.yaml
+
+    def do_add_parser(self, parser_adder):
+        parser = add_parser_common(self, parser_adder)
+        parser.set_defaults(rebuild=False)
+        return parser
+
+    def do_run(self, my_args, runner_args):
+        do_run_common(self, my_args, runner_args)

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -249,7 +249,17 @@ class MissingProgram(FileNotFoundError):
         super().__init__(errno.ENOENT, os.strerror(errno.ENOENT), program)
 
 
-_RUNNERCAPS_COMMANDS = {'flash', 'debug', 'debugserver', 'attach', 'simulate', 'robot', 'rtt'}
+_RUNNERCAPS_COMMANDS = {
+    "flash",
+    "debug",
+    "debugserver",
+    "attach",
+    "simulate",
+    "robot",
+    "rtt",
+    "reset",
+}
+
 
 @dataclass
 class RunnerCaps:

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -119,7 +119,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt', 'reset'},
                           dev_id=True, flash_addr=True, erase=True, reset=True,
                           tool_opt=True, file=True, rtt=True, batch_debug=True)
 
@@ -414,6 +414,15 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                     client_cmd += ['-ex', 'monitor go', '-ex', 'disconnect', '-ex', 'quit']
                 elif self.reset:
                     client_cmd += ['-ex', 'monitor reset']
+            if command == 'reset':
+                client_cmd += [
+                    '-ex', 'monitor halt',
+                    '-ex', 'monitor reset',
+                    '-ex', 'set confirm off',
+                    '-ex', 'monitor go',
+                    '-ex', 'disconnect',
+                    '-ex', 'quit',
+                ]
 
             if not self.gdb_host:
                 self.require(self.gdbserver)


### PR DESCRIPTION
add west reset command with gdb reset for jlink runner

this is to address issue https://github.com/zephyrproject-rtos/zephyr/issues/102544
it will be possible to reset board in test scripts with common APIs.

`
west reset -r jlink
`
will add more runners/debugger tools and reset types support in the next PRs.
