### PR TITLE
drivers: pinctrl: mci_io_mux: correct CTIMER macro name

### DIFF
--- a/drivers/pinctrl/pinctrl_mci_io_mux.c
+++ b/drivers/pinctrl/pinctrl_mci_io_mux.c
@@ -89,7 +89,7 @@ static void select_gpio_mode(uint8_t gpio_idx)
 	/* Clear fsel settings */
 	mci_iomux->FSEL &= ~IOMUX_GET_FSEL_CLR_MASK(gpio_setting);
 	/* Clear CTimer in/out, if required */
-	if (IOMUX_GET_SCTIMER_IN_CLR_ENABLE(gpio_setting)) {
+	if (IOMUX_GET_CTIMER_CLR_ENABLE(gpio_setting)) {
 		mci_iomux->C_TIMER_IN &=
 			~(0x1 << IOMUX_GET_CTIMER_CLR_OFFSET(gpio_setting));
 		mci_iomux->C_TIMER_OUT &=


### PR DESCRIPTION
Fix inconsistent macro name from IOMUX_GET_SCTIMER_IN_CLR_ENABLE to IOMUX_GET_CTIMER_CLR_ENABLE to align with the actual CTimer functionality and related macro naming convention.