### PR TITLE
tests: retained_mem: Fix overlay for nRF54H20dk

### DIFF
--- a/tests/drivers/retained_mem/api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/retained_mem/api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -15,8 +15,3 @@
 		retainedmemtestdevice = &retainedmem0;
 	};
 };
-
-&cpuapp_ram0 {
-	reg = <0x22000000 DT_SIZE_K(16)>;
-	ranges = <0x0 0x22000000 0x4000>;
-};

--- a/tests/drivers/retained_mem/api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/retained_mem/api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -15,8 +15,3 @@
 		retainedmemtestdevice = &retainedmem0;
 	};
 };
-
-&cpurad_ram0 {
-	reg = <0x23000000 DT_SIZE_K(176)>;
-	ranges = <0x0 0x23000000 0x2c000>;
-};


### PR DESCRIPTION
Remove `cpux_ram0` node from overlay file as it is already defined in DTS.