### PR TITLE
testsuite: coverage: Increase gcov heap size to 64KiB for x86 and MPS2

### DIFF
--- a/subsys/testsuite/Kconfig.coverage
+++ b/subsys/testsuite/Kconfig.coverage
@@ -54,7 +54,7 @@ endchoice
 config COVERAGE_GCOV_HEAP_SIZE
 	int "Size of heap allocated for gcov coverage data dump"
 	depends on COVERAGE_GCOV
-	default 32768 if X86 || SOC_SERIES_MPS2
+	default 65536 if X86 || SOC_SERIES_MPS2
 	default 16384
 	help
 	  This option configures the heap size allocated for gcov coverage


### PR DESCRIPTION
On qemu_x86, the size of a coverage report entry for certain testcases can exceed 32KiB, resulting in the "No memory available to continue dump" error message in the gcov data output and the subsequent twister error in parsing the data:

  ERROR   - General exception: non-hexadecimal number found in fromhex()
  arg at position 0

This commit increases the gcov heap size to 64KiB to work around the above issue.

---

This is a hotfix for "Code Coverage with codecov" failures for main.