### PR TITLE
boards: shields: x_nucleo_iks02a1: boards: remove plli2s Q output 

### DIFF
--- a/boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.overlay
+++ b/boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.overlay
@@ -8,7 +8,6 @@
 	div-m = <8>;
 	mul-n = <192>;
 	div-r = <3>;
-	div-q = <4>;
 	clocks = <&clk_hse>;
 	status = "okay"; /* 48MHz on PLLI2SQ */
 };


### PR DESCRIPTION
This commit https://github.com/zephyrproject-rtos/zephyr/commit/5960c2d5a1f347979c147f603bec08be0b3df8f0 enforces checks on PLL and PLLI2S outputs and generates build errors accordingly.

According to  STM32F411xC/E refman(RM0383) and the clock tree, there is no PLLI2SQ output.

Remove the div-q property to fix/skip build error.


To reproduce : 

- ` west build -p -b nucleo_f411re/stm32f411xe samples/shields/x_nucleo_iks02a1/sensorhub -T sample.shields.x_nucleo_iks02a1.sensorhub`