### PR TITLE
fs: fatfs: enable automount by default if activated in dt

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -457,6 +457,13 @@ Ethernet
   reworked to be used as active low, you may have to set the pin as
   ``GPIO_ACTIVE_LOW`` in devicetree (:github:`100751`).
 
+File System
+===========
+
+* :kconfig:option:`CONFIG_FS_FATFS_FSTAB_AUTOMOUNT` is now enabled by default, if any enabled
+  :dtcompatible:`zephyr,fstab,fatfs` with the ``automount`` property are present in the devicetree.
+  Applications that do not want this behavior need to explicitly disable this option.
+
 GPIO
 ====
 

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -301,7 +301,8 @@ config FS_FATFS_CUSTOM_MOUNT_POINTS
 
 config FS_FATFS_FSTAB_AUTOMOUNT
 	bool "Support for fstab auto-mounting"
-	depends on $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_FSTAB_FATFS))
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_FSTAB_FATFS),automount,True)
+	default y
 	help
 	  This option enables fatfs support for the devicetree fstab auto-mounting
 	  functionality.

--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -132,4 +132,12 @@ config FS_LITTLEFS_DISK_VERSION_NUMBER
 	help
 	  Set to 0 to use the latest littlefs disk version (LFS_DISK_VERSION).
 
+config FS_LITTLEFS_FSTAB_AUTOMOUNT
+	bool "Support for fstab auto-mounting"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_FSTAB_LITTLEFS),automount,True)
+	default y
+	help
+	  This option enables littlefs support for the devicetree fstab auto-mounting
+	  functionality.
+
 endif # FILE_SYSTEM_LITTLEFS

--- a/subsys/fs/ext2/Kconfig
+++ b/subsys/fs/ext2/Kconfig
@@ -55,7 +55,7 @@ config EXT2_SUPERBLOCK_ALIGNMENT
 
 config EXT2_FSTAB_AUTOMOUNT
 	bool "Support for fstab auto-mounting"
-	depends on $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_FSTAB_EXT2))
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_FSTAB_EXT2),automount,True)
 	default y
 	help
 	  Enable automatic mounting of Ext2 file system at boot time.

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -660,19 +660,21 @@ static const struct fs_file_system_t ext2_fs = {
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_FS);
 
 #ifdef CONFIG_EXT2_FSTAB_AUTOMOUNT
-#define REFERENCE_MOUNT(inst) (&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),
+#define REFERENCE_MOUNT(inst)                                                                      \
+	IF_ENABLED(DT_INST_PROP(inst, automount), ((&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),))
 
 static void automount_if_enabled(struct fs_mount_t *mountp)
 {
-	int ret = 0;
+	int ret;
 
-	if ((mountp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0) {
-		ret = fs_mount(mountp);
-		if (ret < 0) {
-			LOG_ERR("Error mounting filesystem: at %s: %d", mountp->mnt_point, ret);
-		} else {
-			LOG_DBG("EXT2 Filesystem \"%s\" initialized", mountp->mnt_point);
-		}
+	/* We already filter it during build. */
+	__ASSERT_NO_MSG((mountp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0);
+
+	ret = fs_mount(mountp);
+	if (ret < 0) {
+		LOG_ERR("Error mounting filesystem: at %s: %d", mountp->mnt_point, ret);
+	} else {
+		LOG_DBG("EXT2 Filesystem \"%s\" initialized", mountp->mnt_point);
 	}
 }
 #endif /* CONFIG_EXT2_FSTAB_AUTOMOUNT */

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -577,19 +577,21 @@ static const struct fs_file_system_t fatfs_fs = {
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_FS);
 
 #ifdef CONFIG_FS_FATFS_FSTAB_AUTOMOUNT
-#define REFERENCE_MOUNT(inst) (&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),
+#define REFERENCE_MOUNT(inst)                                                                      \
+	IF_ENABLED(DT_INST_PROP(inst, automount), ((&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),))
 
 static void automount_if_enabled(struct fs_mount_t *mountp)
 {
-	int ret = 0;
+	int ret;
 
-	if ((mountp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0) {
-		ret = fs_mount(mountp);
-		if (ret < 0) {
-			LOG_ERR("Error mounting filesystem: at %s: %d", mountp->mnt_point, ret);
-		} else {
-			LOG_DBG("FATFS Filesystem \"%s\" initialized", mountp->mnt_point);
-		}
+	/* We already filter it during build. */
+	__ASSERT_NO_MSG((mountp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0);
+
+	ret = fs_mount(mountp);
+	if (ret < 0) {
+		LOG_ERR("Error mounting filesystem: at %s: %d", mountp->mnt_point, ret);
+	} else {
+		LOG_DBG("FATFS Filesystem \"%s\" initialized", mountp->mnt_point);
 	}
 }
 #endif /* CONFIG_FS_FATFS_FSTAB_AUTOMOUNT */

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -1139,40 +1139,41 @@ struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = { \
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_FS)
 
-#define REFERENCE_MOUNT(inst) (&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),
+#ifdef CONFIG_FS_LITTLEFS_FSTAB_AUTOMOUNT
+#define REFERENCE_MOUNT(inst)                                                                      \
+	IF_ENABLED(DT_INST_PROP(inst, automount), ((&FS_FSTAB_ENTRY(DT_DRV_INST(inst))),))
 
-static void mount_init(struct fs_mount_t *mp)
+static void automount_if_enabled(struct fs_mount_t *mountp)
 {
+	int ret;
 
-	LOG_INF("littlefs partition at %s", mp->mnt_point);
-	if ((mp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0) {
-		int rc = fs_mount(mp);
+	/* We already filter it during build. */
+	__ASSERT_NO_MSG((mountp->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0);
 
-		if (rc < 0) {
-			LOG_ERR("Automount %s failed: %d",
-				mp->mnt_point, rc);
-		} else {
-			LOG_INF("Automount %s succeeded",
-				mp->mnt_point);
-		}
+	ret = fs_mount(mountp);
+	if (ret < 0) {
+		LOG_ERR("Error mounting filesystem: at %s: %d", mountp->mnt_point, ret);
+	} else {
+		LOG_DBG("LITTLEFS Filesystem \"%s\" initialized", mountp->mnt_point);
 	}
 }
+#endif /* CONFIG_FS_LITTLEFS_FSTAB_AUTOMOUNT */
 
 static int littlefs_init(void)
 {
-	static struct fs_mount_t *partitions[] = {
-		DT_INST_FOREACH_STATUS_OKAY(REFERENCE_MOUNT)
-	};
-
 	int rc = fs_register(FS_LITTLEFS, &littlefs_fs);
 
+#ifdef CONFIG_FS_LITTLEFS_FSTAB_AUTOMOUNT
 	if (rc == 0) {
-		struct fs_mount_t **mpi = partitions;
+		struct fs_mount_t *partitions[] = {DT_INST_FOREACH_STATUS_OKAY(REFERENCE_MOUNT)};
 
-		while (mpi < (partitions + ARRAY_SIZE(partitions))) {
-			mount_init(*mpi++);
+		for (size_t i = 0; i < ARRAY_SIZE(partitions); i++) {
+			struct fs_mount_t *mpi = partitions[i];
+
+			automount_if_enabled(mpi);
 		}
 	}
+#endif /* CONFIG_FS_LITTLEFS_FSTAB_AUTOMOUNT */
 
 	return rc;
 }


### PR DESCRIPTION
If automount is enabled in the devicetree for
a fatfs, then enable the Kconfig option by default.

Feels off having to enable it in the dt and also the Kconfig.