### PR TITLE
tests: clock_control: onoff: Fix test when RC is used

### DIFF
--- a/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
+++ b/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
@@ -29,6 +29,11 @@ static void clock_off(void)
 {
 	struct onoff_manager *mgr = get_mgr();
 
+#if defined(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC)
+	while (z_nrf_clock_calibration_is_in_progress()) {
+		/* empty */
+	}
+#endif
 	do {
 		(void)onoff_release(mgr);
 


### PR DESCRIPTION
Add wait for the calibration process to complete when releasing the clock if an RC oscillator is used.