### PR TITLE
manifest: update hal_nordic to have nrfx_nfct RXERROR fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: daad38f2e9f6c641849010d74fe02ea736d4d921
+      revision: d7dc801ab175e286205fd6229b0c05ec7886e2ac
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Updated nrfx_nfct contains a fix to poll RXERROR event register on RXFRAMEEND instead of handling it as a separate interrupt. This fixes a race condition where parity errors
were not propagated to the NFC stack due to the RXERROR event being cleared before RXFRAMEEND was processed.