### PR TITLE
openthread: Kconfig: Remove experimental tag for Zephyr Border Router

### DIFF
--- a/modules/openthread/Kconfig
+++ b/modules/openthread/Kconfig
@@ -408,8 +408,7 @@ config OPENTHREAD_PLATFORM_USEC_TIMER
 menu "OpenThread Border Router"
 
 config OPENTHREAD_ZEPHYR_BORDER_ROUTER
-	bool "Adds support for Border Router functionality [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Adds support for Border Router functionality"
 	select NET_ROUTING
 	help
 	  Enable support for Border Router using Openthread's implementation.


### PR DESCRIPTION
Remove experimental symbol for Zephyr Border Router application.