### PR TITLE
MAINTAINERS: remove aronlander-pe as percepio maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6249,7 +6249,6 @@ West:
   status: maintained
   maintainers:
     - eriktamlin
-    - aronlander-pe
   files:
     - modules/percepio/
   labels:


### PR DESCRIPTION
Remove aronlander-pe from maintainer for percepio.

Signed-off-by: Erik Tamlin [erik.tamlin@percepio.com](mailto:erik.tamlin@percepio.com)