### PR TITLE
drivers: modem: Improve error handling when losing PPP connection

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1355,7 +1355,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
-		LOG_INF("RING received!");
+		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
 		break;
 	default:
@@ -1413,7 +1413,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
-		LOG_INF("RING received!");
+		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
 		break;
 	default:
@@ -1482,7 +1482,7 @@ static void modem_cellular_carrier_on_event_handler(struct modem_cellular_data *
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
-		LOG_INF("RING received!");
+		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
 		break;
 	default:
@@ -1508,10 +1508,12 @@ static void modem_cellular_dormant_event_handler(struct modem_cellular_data *dat
 						 enum modem_cellular_event evt)
 {
 	switch (evt) {
+	case MODEM_CELLULAR_EVENT_RING:
+		LOG_DBG("RING received!");
+		modem_pipe_open_async(data->uart_pipe);
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
 		break;
-
 	default:
 		break;
 	}

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1470,6 +1470,10 @@ static void modem_cellular_carrier_on_event_handler(struct modem_cellular_data *
 	case MODEM_CELLULAR_EVENT_DEREGISTERED:
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_DORMANT);
 		break;
+	case MODEM_CELLULAR_EVENT_PPP_DEAD:
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_DORMANT);
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
 		net_if_carrier_off(modem_ppp_get_iface(data->ppp));


### PR DESCRIPTION
This PR does two changes to modem driver

## Re-open idling CMUX in DORMANT state as well

If we stay in DORMANT state long enough, the CMUX channel might enter
power saving mode which will then block URC messages unless we deal
with RING event.

Also, change RING log level to DBG. It is too verbose otherwise.

## Handle PPP disconnect event while connected

If we receive PPP_DEAD event before receiving the DEREGISTERED, we
could directly try to recover connection without waiting in the
dormant state.

If we would stay in the DORMANT state, the PPP_DEAD event is not
going to happen againt, and it would deadblock.

Depends on the modem, which is received first.
There is no guarantee of ordering.
