### PR TITLE
Update AMP documentation on serial console usage

### DIFF
--- a/boards/espressif/common/board-variants.rst
+++ b/boards/espressif/common/board-variants.rst
@@ -44,7 +44,7 @@ To apply a board variant, use the ``-S`` flag with west build:
 
 .. note::
 
-   These snippets are applicable to boards with compatible hardware support for the selected flash/PSRAM configuration.
+   These snippets are only applicable to boards with compatible hardware support for the selected flash/PSRAM configuration.
 
    - If no FLASH snippet is used, the board default flash size will be used.
    - If no PSRAM snippet is used, the board default psram size will be used.

--- a/boards/espressif/common/soc-esp32-features.rst
+++ b/boards/espressif/common/soc-esp32-features.rst
@@ -34,8 +34,21 @@ ESP32 Features
 Asymmetric Multiprocessing (AMP)
 ================================
 
-ESP32 allows 2 different applications to be executed in ESP32 SoC. Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
+Boards featuring the ESP32 and ESP32-S3 SoC allows 2 different applications to be executed.
+Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :zephyr:code-sample-category:`ipc` folder as code reference.
+
+.. note::
+
+   ** AMP and serial output support **
+
+   In the current Zephyr ESP32 implementation, access to Zephyr-managed serial
+   drivers (such as ``printk()``, logging, or the console UART) is not yet
+   implemented for applications running on the APPCPU. As a result, serial
+   output APIs provided by Zephyr are only available on the PROCPU.
+
+   As a mitigation, applications running on the APPCPU may use ESP32 ROM
+   functions such as ``ets_printf()`` to emit diagnostic or debug output.
 
 For more information, check the `ESP32 Datasheet`_ or the `ESP32 Technical Reference Manual`_.
 

--- a/boards/espressif/common/soc-esp32s3-features.rst
+++ b/boards/espressif/common/soc-esp32s3-features.rst
@@ -66,9 +66,21 @@ Security:
 Asymmetric Multiprocessing (AMP)
 ================================
 
-Boards featuring the ESP32-S3 SoC allows 2 different applications to be executed. Due to its dual-core
-architecture, each core can be enabled to execute customized tasks in stand-alone mode
+Boards featuring the ESP32 and ESP32-S3 SoC allows 2 different applications to be executed.
+Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :zephyr:code-sample-category:`ipc` folder as code reference.
+
+.. note::
+
+   ** AMP and serial output support **
+
+   In the current Zephyr ESP32 implementation, access to Zephyr-managed serial
+   drivers (such as ``printk()``, logging, or the console UART) is not yet
+   implemented for applications running on the APPCPU. As a result, serial
+   output APIs provided by Zephyr are only available on the PROCPU.
+
+   As a mitigation, applications running on the APPCPU may use ESP32 ROM
+   functions such as ``ets_printf()`` to emit diagnostic or debug output.
 
 For more information, check the `ESP32-S3 Datasheet`_ or the `ESP32-S3 Technical Reference Manual`_.
 


### PR DESCRIPTION
Update the documentation describing the appcpu console when AMP is used on Xtensa dual-core.