### PR TITLE
drivers: wifi: esp-hosted: Add support for the latest firmware.

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_proto.options
+++ b/drivers/wifi/esp_hosted/esp_hosted_proto.options
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
 *.ssid max_size:32 max_length:31
 *.bssid max_size:17
 *.mac max_size:17

--- a/drivers/wifi/esp_hosted/esp_hosted_proto.pb
+++ b/drivers/wifi/esp_hosted/esp_hosted_proto.pb
@@ -35,9 +35,10 @@ enum Ctrl_WifiBw {
 }
 
 enum Ctrl_WifiPowerSave {
-    PS_Invalid = 0;
+    NO_PS = 0;
     MIN_MODEM = 1;
     MAX_MODEM = 2;
+    PS_Invalid = 3;
 }
 
 enum Ctrl_WifiSecProt {
@@ -103,9 +104,14 @@ enum CtrlMsgId {
     Req_GetWifiCurrTxPower = 120;
 
     Req_ConfigHeartbeat = 121;
+    Req_EnableDisable = 122;
+    Req_GetFwVersion = 123;
+    Req_SetCountryCode = 124;
+    Req_GetCountryCode = 125;
+    Req_Custom_RPC_Unserialised_Msg = 126;
     /* Add new control path command response before Req_Max
      * and update Req_Max */
-    Req_Max = 122;
+    Req_Max = 127;
 
     /** Response Msgs **/
     Resp_Base = 200;
@@ -137,9 +143,14 @@ enum CtrlMsgId {
     Resp_GetWifiCurrTxPower = 220;
 
     Resp_ConfigHeartbeat = 221;
+    Resp_EnableDisable = 222;
+    Resp_GetFwVersion = 223;
+    Resp_SetCountryCode = 224;
+    Resp_GetCountryCode = 225;
+    Resp_Custom_RPC_Unserialised_Msg = 226;
     /* Add new control path command response before Resp_Max
      * and update Resp_Max */
-    Resp_Max = 222;
+    Resp_Max = 227;
 
     /** Event Msgs **/
     Event_Base = 300;
@@ -147,9 +158,19 @@ enum CtrlMsgId {
     Event_Heartbeat = 302;
     Event_StationDisconnectFromAP = 303;
     Event_StationDisconnectFromESPSoftAP = 304;
+    Event_StationConnectedToAP = 305;
+    Event_StationConnectedToESPSoftAP = 306;
+    Event_Custom_RPC_Unserialised_Msg = 307;
     /* Add new control path command notification before Event_Max
      * and update Event_Max */
-    Event_Max = 305;
+    Event_Max = 308;
+}
+
+enum HostedFeature {
+    Hosted_InvalidFeature = 0;
+    Hosted_Wifi = 1;
+    Hosted_Bluetooth = 2;
+    /* Add your new features here and re-build prot using build_proto.sh */
 }
 
 /* internal supporting structures for CtrlMsg */
@@ -220,6 +241,7 @@ message CtrlMsg_Resp_GetAPConfig {
     int32 chnl = 4;
     Ctrl_WifiSecProt sec_prot = 5;
     int32 resp = 6;
+    int32 band_mode = 7;
 }
 
 message CtrlMsg_Req_ConnectAP {
@@ -228,11 +250,13 @@ message CtrlMsg_Req_ConnectAP {
     bytes bssid = 3;
     bool is_wpa3_supported = 4;
     int32 listen_interval = 5;
+    int32 band_mode = 6;
 }
 
 message  CtrlMsg_Resp_ConnectAP {
     int32 resp = 1;
     bytes mac = 2;
+    int32 band_mode = 3;
 }
 
 message CtrlMsg_Req_GetSoftAPConfig {
@@ -247,6 +271,7 @@ message CtrlMsg_Resp_GetSoftAPConfig {
     bool ssid_hidden = 6;
     int32 bw = 7;
     int32 resp = 8;
+    int32 band_mode = 9;
 }
 
 message CtrlMsg_Req_StartSoftAP {
@@ -257,11 +282,13 @@ message CtrlMsg_Req_StartSoftAP {
     int32 max_conn = 5;
     bool ssid_hidden = 6;
     int32 bw = 7;
+    int32 band_mode = 8;
 }
 
 message CtrlMsg_Resp_StartSoftAP {
     int32 resp = 1;
     bytes mac = 2;
+    int32 band_mode = 3;
 }
 
 message CtrlMsg_Req_ScanResult {
@@ -348,6 +375,45 @@ message CtrlMsg_Resp_ConfigHeartbeat {
     int32 resp = 1;
 }
 
+message CtrlMsg_Req_EnableDisable {
+    uint32 feature = 1;
+    bool enable = 2;
+}
+
+message CtrlMsg_Resp_EnableDisable {
+    int32 resp = 1;
+}
+
+message CtrlMsg_Req_GetFwVersion {
+}
+
+message CtrlMsg_Resp_GetFwVersion {
+    int32 resp = 1;
+    string name = 2;
+    uint32 major1 = 3;
+    uint32 major2 = 4;
+    uint32 minor = 5;
+    uint32 rev_patch1 = 6;
+    uint32 rev_patch2 = 7;
+}
+
+message CtrlMsg_Req_SetCountryCode {
+    bytes country = 1;
+    bool ieee80211d_enabled = 2;
+}
+
+message CtrlMsg_Resp_SetCountryCode {
+    int32 resp = 1;
+}
+
+message CtrlMsg_Req_GetCountryCode {
+}
+
+message CtrlMsg_Resp_GetCountryCode {
+    int32 resp = 1;
+    bytes country = 2;
+}
+
 /** Event structure **/
 message CtrlMsg_Event_ESPInit {
     bytes init_data = 1;
@@ -359,11 +425,55 @@ message CtrlMsg_Event_Heartbeat {
 
 message CtrlMsg_Event_StationDisconnectFromAP {
     int32 resp = 1;
+    bytes ssid = 2;
+    uint32 ssid_len = 3;
+    bytes bssid = 4;
+    uint32 reason = 5;
+    int32 rssi = 6;
 }
+
+message CtrlMsg_Event_StationConnectedToAP {
+    int32 resp = 1;
+    bytes ssid = 2;
+    uint32 ssid_len = 3;
+    bytes bssid = 4;
+    uint32 channel = 5;
+    int32 authmode = 6;
+    int32 aid = 7;
+}
+
 
 message CtrlMsg_Event_StationDisconnectFromESPSoftAP {
     int32 resp = 1;
     bytes mac = 2;
+    uint32 aid = 3;
+    bool is_mesh_child = 4;
+    uint32 reason = 5;
+}
+
+message CtrlMsg_Event_StationConnectedToESPSoftAP {
+    int32 resp = 1;
+    bytes mac = 2;
+    uint32 aid = 3;
+    bool is_mesh_child = 4;
+}
+
+/* Add Custom RPC message structures after existing message structures to make it easily notice */
+message CtrlMsg_Req_CustomRpcUnserialisedMsg {
+    uint32 custom_msg_id = 1;
+    bytes data = 2;
+}
+
+message CtrlMsg_Resp_CustomRpcUnserialisedMsg {
+    int32 resp = 1;
+    uint32 custom_msg_id = 2;
+    bytes data = 3;
+}
+
+message CtrlMsg_Event_CustomRpcUnserialisedMsg {
+    int32 resp = 1;
+    uint32 custom_evt_id = 2;
+    bytes data = 3;
 }
 
 message CtrlMsg {
@@ -372,6 +482,12 @@ message CtrlMsg {
 
     /* msg id */
     CtrlMsgId msg_id = 2;
+
+    /* UID of message */
+    int32 uid = 3;
+
+    /* Request/response type: sync or async */
+    uint32 req_resp_type = 4;
 
     /* union of all msg ids */
     oneof payload {
@@ -402,6 +518,11 @@ message CtrlMsg {
         CtrlMsg_Req_SetWifiMaxTxPower req_set_wifi_max_tx_power = 119;
         CtrlMsg_Req_GetWifiCurrTxPower req_get_wifi_curr_tx_power = 120;
         CtrlMsg_Req_ConfigHeartbeat req_config_heartbeat = 121;
+        CtrlMsg_Req_EnableDisable req_enable_disable_feat = 122;
+        CtrlMsg_Req_GetFwVersion req_get_fw_version = 123;
+        CtrlMsg_Req_SetCountryCode req_set_country_code = 124;
+        CtrlMsg_Req_GetCountryCode req_get_country_code = 125;
+        CtrlMsg_Req_CustomRpcUnserialisedMsg req_custom_rpc_unserialised_msg = 126;
 
         /** Responses **/
         CtrlMsg_Resp_GetMacAddress resp_get_mac_address = 201;
@@ -429,11 +550,19 @@ message CtrlMsg {
         CtrlMsg_Resp_SetWifiMaxTxPower resp_set_wifi_max_tx_power = 219;
         CtrlMsg_Resp_GetWifiCurrTxPower resp_get_wifi_curr_tx_power = 220;
         CtrlMsg_Resp_ConfigHeartbeat resp_config_heartbeat = 221;
+        CtrlMsg_Resp_EnableDisable resp_enable_disable_feat = 222;
+        CtrlMsg_Resp_GetFwVersion resp_get_fw_version = 223;
+        CtrlMsg_Resp_SetCountryCode resp_set_country_code = 224;
+        CtrlMsg_Resp_GetCountryCode resp_get_country_code = 225;
+        CtrlMsg_Resp_CustomRpcUnserialisedMsg resp_custom_rpc_unserialised_msg = 226;
 
         /** Notifications **/
         CtrlMsg_Event_ESPInit event_esp_init = 301;
         CtrlMsg_Event_Heartbeat event_heartbeat = 302;
         CtrlMsg_Event_StationDisconnectFromAP event_station_disconnect_from_AP = 303;
         CtrlMsg_Event_StationDisconnectFromESPSoftAP event_station_disconnect_from_ESP_SoftAP = 304;
+        CtrlMsg_Event_StationConnectedToAP event_station_connected_to_AP = 305;
+        CtrlMsg_Event_StationConnectedToESPSoftAP event_station_connected_to_ESP_SoftAP = 306;
+        CtrlMsg_Event_CustomRpcUnserialisedMsg event_custom_rpc_unserialised_msg = 307;
     }
 }

--- a/drivers/wifi/esp_hosted/esp_hosted_util.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_util.h
@@ -132,12 +132,22 @@ static inline int esp_hosted_ctrl_response(CtrlMsg *ctrl_msg)
 		return ctrl_msg->resp_get_wifi_curr_tx_power.resp;
 	case CtrlMsgId_Resp_ConfigHeartbeat:
 		return ctrl_msg->resp_config_heartbeat.resp;
+	case CtrlMsgId_Resp_EnableDisable:
+		return ctrl_msg->resp_enable_disable_feat.resp;
+	case CtrlMsgId_Resp_GetFwVersion:
+		return ctrl_msg->resp_get_fw_version.resp;
+	case CtrlMsgId_Resp_SetCountryCode:
+		return ctrl_msg->resp_set_country_code.resp;
+	case CtrlMsgId_Resp_GetCountryCode:
+		return ctrl_msg->resp_get_country_code.resp;
+	case CtrlMsgId_Resp_Custom_RPC_Unserialised_Msg:
+		return ctrl_msg->resp_custom_rpc_unserialised_msg.resp;
 	default:
 		return -1;
 	}
 }
 
-#if CONFIG_WIFI_ESP_HOSTED_DEBUG
+#if defined(CONFIG_WIFI_ESP_HOSTED_DEBUG)
 static void esp_hosted_frame_dump(esp_frame_t *frame)
 {
 	static const char *const if_strs[] = {"STA", "AP", "SERIAL", "HCI", "PRIV", "TEST"};

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -204,7 +204,7 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 			continue;
 		}
 
-#if CONFIG_WIFI_ESP_HOSTED_DEBUG
+#if defined(CONFIG_WIFI_ESP_HOSTED_DEBUG)
 		esp_hosted_frame_dump(&frame);
 #endif
 
@@ -220,6 +220,12 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 		case CtrlMsgId_Event_Heartbeat:
 			data->last_hb_ms = k_uptime_get();
 			continue;
+		case CtrlMsgId_Event_StationConnectedToAP: {
+			data->state[ESP_HOSTED_STA_IF] = WIFI_STATE_COMPLETED;
+			net_if_dormant_off(data->iface[ESP_HOSTED_STA_IF]);
+			wifi_mgmt_raise_connect_result_event(data->iface[ESP_HOSTED_STA_IF], 0);
+			continue;
+		}
 		case CtrlMsgId_Event_StationDisconnectFromAP:
 			data->state[ESP_HOSTED_STA_IF] = WIFI_STATE_DISCONNECTED;
 			net_if_dormant_on(data->iface[ESP_HOSTED_STA_IF]);
@@ -236,16 +242,6 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 				sta_info.mac);
 			wifi_mgmt_raise_ap_sta_disconnected_event(data->iface[ESP_HOSTED_SAP_IF],
 								  &sta_info);
-			continue;
-		}
-		case CtrlMsgId_Resp_ConnectAP: {
-			int ret = esp_hosted_ctrl_response(&ctrl_msg);
-
-			if (!ret) {
-				data->state[ESP_HOSTED_STA_IF] = WIFI_STATE_COMPLETED;
-				net_if_dormant_off(data->iface[ESP_HOSTED_STA_IF]);
-			}
-			wifi_mgmt_raise_connect_result_event(data->iface[ESP_HOSTED_STA_IF], ret);
 			continue;
 		}
 		default: /* Unhandled events/responses will be queued. */
@@ -289,6 +285,7 @@ static void esp_hosted_init(struct net_if *iface)
 
 static int esp_hosted_connect(const struct device *dev, struct wifi_connect_req_params *params)
 {
+	esp_hosted_data_t *data = dev->data;
 	CtrlMsg ctrl_msg = CtrlMsg_init_zero;
 
 	ctrl_msg.req_connect_ap.listen_interval = 0;
@@ -298,9 +295,17 @@ static int esp_hosted_connect(const struct device *dev, struct wifi_connect_req_
 	strncpy(ctrl_msg.req_connect_ap.ssid, params->ssid, ESP_HOSTED_MAX_SSID_LEN);
 	esp_hosted_mac_to_str(params->bssid, ctrl_msg.req_connect_ap.bssid.bytes);
 
-	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_ConnectAP, &ctrl_msg, 0)) {
+	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_ConnectAP, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
 		return -EAGAIN;
 	}
+
+	/* Legacy connect response is synchronous */
+	if (data->fw_version.major1 < 1) {
+		data->state[ESP_HOSTED_STA_IF] = WIFI_STATE_COMPLETED;
+		net_if_dormant_off(data->iface[ESP_HOSTED_STA_IF]);
+		wifi_mgmt_raise_connect_result_event(data->iface[ESP_HOSTED_STA_IF], 0);
+	}
+
 	return 0;
 }
 
@@ -601,6 +606,23 @@ static int esp_hosted_dev_init(const struct device *dev)
 	if (esp_hosted_ctrl(dev, CtrlMsgId_Event_ESPInit, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
 		return -EIO;
 	}
+
+	/* Read firmware version */
+	ctrl_msg = (CtrlMsg)CtrlMsg_init_zero;
+	CtrlMsg_Resp_GetFwVersion *fw = &ctrl_msg.resp_get_fw_version;
+
+	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_GetFwVersion, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
+		LOG_INF("legacy firmware detected\n");
+	} else {
+		data->fw_version.major1 = fw->major1;
+		data->fw_version.major2 = fw->major2;
+		data->fw_version.minor = fw->minor;
+		data->fw_version.rev_patch1 = fw->rev_patch1;
+		data->fw_version.rev_patch2 = fw->rev_patch2;
+	}
+
+	LOG_INF("firmware version: v%u.%u.%u.%u.%u", fw->major1, fw->major2, fw->minor,
+		fw->rev_patch1, fw->rev_patch2);
 
 	/* Set MAC addresses. */
 	for (size_t i = 0; i < 2; i++) {

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.h
@@ -56,6 +56,13 @@ typedef struct {
 	struct net_stats_wifi stats;
 #endif
 	enum wifi_iface_state state[2];
+	struct {
+		uint32_t major1;
+		uint32_t major2;
+		uint32_t minor;
+		uint32_t rev_patch1;
+		uint32_t rev_patch2;
+	} fw_version;
 } esp_hosted_data_t;
 
 #define TLV_HEADER_SIZE      (14)


### PR DESCRIPTION
The latest stable ESP-hosted firmware (v1.0.0.0.0) is no longer backward compatible with Zephyr's host driver. The main breaking change is the `ConnectAP` response changing from a synchronous response to an asynchronous event. This is a good change and it's in line with other requests, but it breaks backward compatibility.

This PR adds support for the latest firmware while maintaining support for the legacy firmware (v0.0.5) shipped with some boards. Moving forward, if ESP ever releases an update, the host driver in Zephyr should by default support the latest firmware.

Note: The latest firmware also introduces new features, such as set/get country code, band argument in requests and responses, uid for frames and some additional events. This PR does not attempt to support every new feature, but just the base functionality.