### PR TITLE
Bluetooth: Classic: HFP AG: skip callback if AG is disconnected

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -871,15 +871,17 @@ static void bt_ag_notify_work(struct k_work *work)
 
 	bt_ag_tx_free(tx);
 
+	state = ag->state;
+
 	if (err < 0) {
-		state = ag->state;
 		if ((state != BT_HFP_DISCONNECTED) && (state != BT_HFP_DISCONNECTING)) {
 			bt_hfp_ag_set_state(ag, BT_HFP_DISCONNECTING);
 			bt_rfcomm_dlc_disconnect(&ag->rfcomm_dlc);
 		}
 	}
 
-	if (cb != NULL) {
+	/* If the AG connection has been disconnected, ignore the callback of tx node. */
+	if ((state != BT_HFP_DISCONNECTED) && (cb != NULL)) {
 		cb(ag, user_data);
 	}
 


### PR DESCRIPTION
Move state retrieval before error handling to ensure it's always available for subsequent checks. Add a check to prevent executing the callback when the AG connection is in a disconnected state.

This prevents potential use-after-free or invalid state access when the callback is invoked after the AG has been disconnected, improving the robustness of the notification work handler.

