### PR TITLE
soc: nxp: mcxw7xx: refactor shared memory layout

### DIFF
--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 NXP
+ * Copyright 2023-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,12 +10,17 @@
 	smu2: smu2@1c0000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "SMU2";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		reg = <0x1c0000 DT_SIZE_K(40)>;
 
-		rpmsgmem: memory@8800 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x8800 DT_SIZE_K(6)>;
-			zephyr,memory-region = "rpmsg_sh_mem";
-			zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		shmem_fwk: memory@78 {
+			reg = <0x78 0x8>;
+		};
+
+		shmem_rpmsg: memory@8800 {
+			reg = <0x8800 0x1100>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/nxp_mcxw72.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,12 +10,17 @@
 	smu2: smu2@1c0000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "SMU2";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		reg = <0x1c0000 DT_SIZE_K(64)>;
 
-		rpmsgmem: memory@220 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x220 0x1100>;
-			zephyr,memory-region = "rpmsg_sh_mem";
-			zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		shmem_fwk: memory@200 {
+			reg = <0x200 0x20>;
+		};
+
+		shmem_rpmsg: memory@220 {
+			reg = <0x220 0xA00>;
 		};
 	};
 };

--- a/soc/nxp/mcx/mcxw/mcxw7xx/linker.ld
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/linker.ld
@@ -1,19 +1,10 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/devicetree.h>
-
-m_sector_size                       = 0x2000;
-m_flash_end                         = 0x000FFFFF;
-
-
-m_fsl_prodInfo_size                 = m_sector_size;
-m_fsl_prodInfo_start                = m_flash_end - m_fsl_prodInfo_size + 1;
-m_fsl_prodInfo_end                  = m_flash_end;
-PROD_DATA_BASE_ADDR                 = m_fsl_prodInfo_start;
 
 /*
  * We perform all custom placement before including the generic linker file. This

--- a/soc/nxp/mcx/mcxw/mcxw7xx/sections.ld
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/sections.ld
@@ -1,18 +1,18 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* NOINIT section for rpmsg_sh_mem */
-.noinit_rpmsg_sh_mem (NOLOAD) : ALIGN(4)
+/* NOINIT section for shared memory SMU2 */
+.noinit_smu2 (NOLOAD) : ALIGN(4)
 {
-   __RPMSG_SH_MEM_START__ = .;
-PROVIDE(rpmsg_sh_mem_start = __RPMSG_SH_MEM_START__);
-
-   *(.noinit.$rpmsg_sh_mem*)
-   . = ALIGN(4) ;
-   __RPMSG_SH_MEM_END__ = .;
-PROVIDE(rpmsg_sh_mem_end = __RPMSG_SH_MEM_END__);
-
-} > rpmsg_sh_mem
+    . = DT_REG_ADDR(DT_NODELABEL(shmem_fwk)) - DT_REG_ADDR(DT_NODELABEL(smu2));
+    PROVIDE(m_lowpower_flag_start = . + 0x4);
+    . = DT_REG_ADDR(DT_NODELABEL(shmem_rpmsg)) - DT_REG_ADDR(DT_NODELABEL(smu2));
+    PROVIDE(rpmsg_sh_mem_start = .);
+    *(.noinit.$rpmsg_sh_mem*)
+    . = ALIGN(4) ;
+    PROVIDE(rpmsg_sh_mem_end = .);
+    . = DT_REG_SIZE(DT_NODELABEL(smu2));
+} > SMU2


### PR DESCRIPTION
- Define the entire SMU2 as a single memory region so it represents only one entry in the MPU.
- Clean up linker.ld and sections.ld to remove obsolete/unused symbols
- Declare the "shmem_fwk" section in SMU2 used by connectivity framework
- Rearrange the rpmsg shared memory relatively to the entire SMU2 range
- Provide necessary symbols for the connectivity framework to locate its shared memory section within SMU2

This is preparatory work for upcoming connectivity framework integration and mcxw70 ble enablement.