### PR TITLE
drivers: crypto: ataes132a: fix multiple Coverity defects

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -110,8 +110,10 @@ static int ataes132a_send_command(const struct device *dev, uint8_t opcode,
 	burst_read_i2c(&cfg->i2c, ATAES_COMMAND_MEM_ADDR, data->command_buffer, 64);
 
 	count = data->command_buffer[0];
-	/* validate count: at least 3 bytes (1 for count, 2 for CRC) */
-	if (count < 3) {
+	/* Validate count: must be at least 3 (1 for count, 2 for CRC)
+	 * AND must not exceed the actual buffer size to prevent memory corruption.
+	 */
+	if (count < 3 || count > sizeof(data->command_buffer)) {
 		LOG_ERR("invalid packet received: count=%d"
 			" , expects count>=3", count);
 		return -EINVAL;
@@ -529,6 +531,12 @@ int ataes132a_aes_ccm_encrypt(const struct device *dev,
 
 	param_buffer[0] = key_id;
 	param_buffer[1] = buf_len;
+	/* Ensure buf_len + 2 does not overflow uint8_t and fits in param_buffer */
+	if (buf_len > (UINT8_MAX - 2) || (buf_len + 2) > sizeof(param_buffer)) {
+		LOG_ERR("Encrypt buffer length %d is too large", buf_len);
+		return -EINVAL;
+	}
+
 	memcpy(param_buffer + 2, aead_op->pkt->in_buf, buf_len);
 
 	return_code = ataes132a_send_command(dev, ATAES_ENCRYPT_OP,
@@ -643,6 +651,13 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	param_buffer[0] = 0x0;
 	param_buffer[1] = key_id;
 	param_buffer[2] = 0x0;
+
+	/* Ensure buf_len + 3 fits within a uint8_t and the destination buffer */
+	if (buf_len > (UINT8_MAX - 3) || (buf_len + 3) > sizeof(param_buffer)) {
+		LOG_ERR("Encrypt buffer length %d is too large", buf_len);
+		return -EINVAL;
+	}
+
 	memcpy(param_buffer + 3, pkt->in_buf, buf_len);
 	/* skip memset() if buf_len==16.
 	 * Indeed, calling memset(&param_buffer[19], 0x0, 0)
@@ -652,7 +667,6 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	if (buf_len < 16) {
 		(void)memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
 	}
-
 	return_code = ataes132a_send_command(dev, ATAES_LEGACY_OP, 0x00,
 					     param_buffer, buf_len + 3,
 					     param_buffer, &out_len);


### PR DESCRIPTION
Addressed stability and security issues identified by Coverity in the ataes132a crypto driver:

- CID 434625: Added range validation for 'count' to prevent tainted scalar
 usage and buffer underflow in response processing.

- CID 487700 & 487763: Implemented overflow guards for 'buf_len' to 
prevent integer overflow and type truncation when 
calling ataes132a_send_command.

- CID 487746: Applied explicit type casting to CRC calculations 
to satisfy static analysis regarding integer promotion.