### PR TITLE
Add MCUboot variant for nucleo n6

### DIFF
--- a/boards/st/nucleo_n657x0_q/Kconfig.sysbuild
+++ b/boards/st/nucleo_n657x0_q/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Gaiaochos
+
+if BOARD_NUCLEO_N657X0_Q_STM32N657XX
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+endif

--- a/boards/st/nucleo_n657x0_q/board.cmake
+++ b/boards/st/nucleo_n657x0_q/board.cmake
@@ -10,7 +10,6 @@ else()
   board_runner_args(stm32cubeprogrammer "--no-reset")
   board_runner_args(stm32cubeprogrammer "--tool-opt= mode=HOTPLUG ap=1")
   board_runner_args(stm32cubeprogrammer "--extload=MX25UM51245G_STM32N6570-NUCLEO.stldr")
-  board_runner_args(stm32cubeprogrammer "--download-address=0x70000000")
 endif()
 
 board_runner_args(stlink_gdbserver "--apid=1")

--- a/boards/st/nucleo_n657x0_q/board.yml
+++ b/boards/st/nucleo_n657x0_q/board.yml
@@ -6,3 +6,4 @@ board:
     - name: stm32n657xx
       variants:
         - name: sb
+        - name: fsbl

--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -215,14 +215,25 @@ First, connect the NUCLEO-N657X0-Q to your host computer using the ST-Link USB p
 
    .. tabs::
 
-      .. group-tab:: ST-Link
+      .. group-tab:: Application Image
 
-         Build and flash an application using ``nucleo_n657x0_q`` target.
+         Build and flash an application loaded by MCUBoot
 
          .. zephyr-app-commands::
             :zephyr-app: samples/hello_world
             :board: nucleo_n657x0_q
+            :west-args: --sysbuild
             :goals: build flash
+
+         .. note::
+             By default, application runs in XIP mode. To use RAMLOAD mode, build
+	     using the following command instead:
+
+                      .. zephyr-app-commands::
+                         :zephyr-app: samples/hello_world
+                         :board: nucleo_n657x0_q
+                         :west-args: --sysbuild -- -DCONFIG_XIP=n -DSB_CONFIG_MCUBOOT_MODE_RAM_LOAD=y
+                         :goals: build flash
 
          .. note::
             For flashing, before powering the board, set the boot pins in the following configuration:
@@ -279,19 +290,65 @@ Debugging
 =========
 
 You can debug an application in the usual way using the :ref:`ST-LINK GDB Server <runner_stlink_gdbserver>`.
-Here is an example for the :zephyr:code-sample:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: nucleo_n657x0_q
-   :maybe-skip-config:
-   :goals: debug
 
 .. note::
    To enable debugging, before powering on the board, set the boot pins in the following configuration:
 
    * BOOT0: 0
    * BOOT1: 1
+
+.. tabs::
+
+      .. group-tab:: Application image
+
+         To debug a multi-stage application (application loaded by a bootloader such as MCUboot), follow these steps:
+
+         First, flash your application, it is required so that MCUboot can find it in external memory (see indications above).
+
+         Then, launch debug session using the bootloader domain:
+
+         .. code-block:: console
+
+            west debug --domain mcuboot
+
+         At this step, you're able to debug the bootloader. To debug the chainloaded application, now run the following gdb commands:
+
+         .. code-block:: console
+
+            (gdb) b do_boot
+            (gdb) c
+            # Once stopped in do_boot, add chainloaded application symbols
+            (gdb) add-symbol-file ./build/hello_world/zephyr/zephyr.elf
+            # Place breakpoint on 'main' in chainloaded application
+            (gdb) b main
+            (gdb) c
+
+         Don't forget to systematically power reset the board before each debug session.
+         This can be done using :zephyr_file:`the following script:<boards/st/common/scripts/board_power_reset.sh>`
+
+         .. code-block:: console
+
+            ./boards/st/common/scripts/board_power_reset.sh
+
+      .. group-tab:: FSBL - ST-Link
+
+         Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+         .. zephyr-app-commands::
+            :zephyr-app: samples/hello_world
+            :board: nucleo_n657x0_q/fsbl
+            :maybe-skip-config:
+            :goals: debug
+
+      .. group-tab:: FSBL - Serial Boot Loader (USB)
+
+         Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+         .. zephyr-app-commands::
+            :zephyr-app: samples/hello_world
+            :board: nucleo_n657x0_q/stm32n657xx/sb
+            :maybe-skip-config:
+            :goals: debug
 
 Another solution for debugging is to use STM32CubeIDE:
 

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -17,7 +17,10 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &axisram2;
 		zephyr,canbus = &fdcan1;
-		spi-flash0 = &mx25um51245g;
+		spi-flash0 = &ospi_nor_flash;
+		zephyr,flash-controller = &ospi_nor_flash;
+		zephyr,flash = &ext_flash;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -307,7 +310,7 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	status = "okay";
 
-	mx25um51245g: ospi-nor-flash@0 {
+	ospi_nor_flash: ospi-nor-flash@0 {
 		compatible = "st,stm32-xspi-nor";
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -21,6 +21,7 @@
 		zephyr,flash-controller = &ospi_nor_flash;
 		zephyr,flash = &ext_flash;
 		zephyr,code-partition = &slot0_partition;
+		mcuboot,image-ram = &axisram1;
 	};
 
 	leds: leds {
@@ -295,11 +296,6 @@ zephyr_udc0: &usbotg_hs1 {
 		compatible = "ethernet-phy";
 		reg = <0x0>;
 	};
-};
-
-&xspim {
-	/* To be moved to sb/fsbl target once sysbuild added to the board */
-	status = "okay";
 };
 
 &xspi2 {

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -316,21 +316,48 @@ zephyr_udc0: &usbotg_hs1 {
 		data-rate = <XSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
+		ranges = <0x0 0x70000000 DT_SIZE_M(64)>;
 
-		partitions {
-			compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
+			ranges = <0x0 0x70000000 DT_SIZE_M(64)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			storage_partition: partition@3ff0000 {
-				label = "storage";
-				/*
-				 * Prevent access to the last 32bytes of the memory-mapped device
-				 * Issue described in the STM32N6xxxx errata sheet ES0620 Rev 1:
-				 * 2.4.5 Deadlock or data corruption when DQS is enabled and the
-				 * wrap request includes the last address of the memory
-				 */
-				reg = <0x3ff0000 (DT_SIZE_K(64) - 32)>;
+			partitions {
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(64)>;
+				};
+
+				slot0_partition: partition@10000 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-0";
+					reg = <0x10000 DT_SIZE_K(1536)>;
+				};
+
+				slot1_partition: partition@210000 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-1";
+					reg = <0x210000 DT_SIZE_K(1536)>;
+				};
+
+				storage_partition: partition@410000 {
+					compatible = "zephyr,mapped-partition";
+					label = "storage";
+					reg = <0x410000 DT_SIZE_K(64)>;
+				};
 			};
 		};
 	};

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_defconfig
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_defconfig
@@ -17,8 +17,5 @@ CONFIG_ARM_MPU=y
 # Enable HW stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# No internal Flash
-CONFIG_XIP=n
-
 # HAL needs TRUSTED_EXECUTION_SECURE explicitly enabled
 CONFIG_TRUSTED_EXECUTION_SECURE=y

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl.dts
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2026 Gaiaochos
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,9 +9,5 @@
 
 / {
 	model = "STMicroelectronics STM32N657X0-Q-NUCLEO board";
-	compatible = "st,stm32n657x0-q-nucleo";
-
-	chosen {
-		zephyr,sram = &axisram1;
-	};
+	compatible = "st,stm32n657x0-q-nucleo-fsbl";
 };

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl.dts
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl.dts
@@ -11,3 +11,7 @@
 	model = "STMicroelectronics STM32N657X0-Q-NUCLEO board";
 	compatible = "st,stm32n657x0-q-nucleo-fsbl";
 };
+
+&xspim {
+	status = "okay";
+};

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl_defconfig
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_fsbl_defconfig
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Gaiaochos
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable Hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Don't place text and such in ROM
+CONFIG_XIP=n
+
+# HAL needs TRUSTED_EXECUTION_SECURE explicitly enabled
+CONFIG_TRUSTED_EXECUTION_SECURE=y

--- a/boards/st/nucleo_n657x0_q/sysbuild.cmake
+++ b/boards/st/nucleo_n657x0_q/sysbuild.cmake
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026  Gaiaochos
+
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  set_target_properties(mcuboot PROPERTIES BOARD nucleo_n657x0_q/stm32n657xx/fsbl)
+endif()

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -22,6 +22,8 @@ vendor: st
 variants:
   nucleo_n657x0_q/stm32n657xx:
     twister: false
+  nucleo_n657x0_q/stm32n657xx/fsbl:
+    twister: false
   nucleo_n657x0_q/stm32n657xx/sb:
     toolchain:
       - zephyr


### PR DESCRIPTION
This work adds a fsbl variant so we can use XIP on the nucleo n6 board. Most thankful to @erwango  for  a PR of the same sort on the N6 DK that I used as a hit



depends on #108786