### PR TITLE
drivers: gpio: nxp: pca_series: reorder reset register writes to avoid driving outputs

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -705,11 +705,11 @@ static inline int gpio_pca_series_reset_write_reg(const struct device *dev)
 	/**
 	 * write reset value to registers
 	 */
-	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_OUTPUT_PORT, reset_value_1);
+	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_CONFIGURATION, reset_value_1);
 	if (ret) {
 		return ret;
 	}
-	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_CONFIGURATION, reset_value_1);
+	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_OUTPUT_PORT, reset_value_1);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
Fixes #103168 

Set pin direction before setting pin levels. Initial pin direction is configured to be inputs. In the case where pin direction requires a reset, this prevents activating outputs.

Backport can be found at https://github.com/sgfeniex/zephyr/pull/3