### PR TITLE
boards: adi: Add ability to flash code to external flash

### DIFF
--- a/boards/adi/apard32690/Kconfig
+++ b/boards/adi/apard32690/Kconfig
@@ -1,0 +1,13 @@
+# ADI APARD32690 board
+
+# Copyright (c) 2026 Analog Devices, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_APARD32690_ENABLE_QSPI_FLASHING
+	bool "Set up QSPI flash bank within OpenOCD"
+	default y if CODE_DATA_RELOCATION
+	help
+	  When using code relocation to place code into external flash accessed
+	  with the SPIXF peripheral, ensure OpenOCD will initialize the bank
+	  so the code relocated there can be flashed along with the rest of the
+	  code located on internal flash.

--- a/boards/adi/apard32690/board.cmake
+++ b/boards/adi/apard32690/board.cmake
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
+if(CONFIG_BOARD_APARD32690_ENABLE_QSPI_FLASHING)
+  board_runner_args(openocd --cmd-pre-init "set MAX32_QSPI_ENABLE 1")
+endif()
 
 include(${ZEPHYR_BASE}/boards/common/openocd-adi-max32.boards.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
The SPIXF peripheral allows executing code from external flash, so add example configuration to the APARD32690 board that enables the OpenOCD flash bank so code built targetting the flash can be downloaded there.

Note: This depends on some changes to OpenOCD that are actively being submitted upstream now.