### PR TITLE
input: double_tap: replace work handler with timestamp tracking

### DIFF
--- a/dts/bindings/input/zephyr,input-double-tap.yaml
+++ b/dts/bindings/input/zephyr,input-double-tap.yaml
@@ -7,7 +7,7 @@ description: |
   Listens for key events as an input and produces key events as output
   corresponding to double taps.
 
-  Can be optionally be associated to a specific device to listen for events
+  Can optionally be associated to a specific device to listen for events
   only from that device.
 
   Example configuration:


### PR DESCRIPTION
 Eliminate the use of a delayable work handler for double tap detection.
Instead, track the time of the first tap using a timestamp, simplifying the logic / reducing code size.