### PR TITLE
flash: npcx: add lock and unlock control register functions

### DIFF
--- a/drivers/flash/flash_npcx_fiu_nor.c
+++ b/drivers/flash/flash_npcx_fiu_nor.c
@@ -672,6 +672,28 @@ static int flash_npcx_nor_ex_op(const struct device *dev, uint16_t code,
 
 	return ret;
 }
+
+void npcx_lock_flash_control_register(const struct device *dev)
+{
+	struct npcx_ex_ops_uma_in op_in = {
+		.opcode = SPI_NOR_CMD_WRDI,
+		.tx_count = 0,
+		.addr_count = 0,
+	};
+
+	flash_npcx_nor_ex_op(dev, FLASH_NPCX_EX_OP_EXEC_UMA, (uintptr_t)&op_in, NULL);
+}
+
+void npcx_unlock_flash_control_register(const struct device *dev)
+{
+	struct npcx_ex_ops_uma_in op_in = {
+		.opcode = SPI_NOR_CMD_WREN,
+		.tx_count = 0,
+		.addr_count = 0,
+	};
+
+	flash_npcx_nor_ex_op(dev, FLASH_NPCX_EX_OP_EXEC_UMA, (uintptr_t)&op_in, NULL);
+}
 #endif
 
 static DEVICE_API(flash, flash_npcx_nor_driver_api) = {

--- a/include/zephyr/drivers/flash/npcx_flash_api_ex.h
+++ b/include/zephyr/drivers/flash/npcx_flash_api_ex.h
@@ -129,6 +129,28 @@ struct npcx_ex_ops_gdma_in {
 #define NPCX_EX_OP_INT_FLASH_WP BIT(1) /**< Issue write protection of internal flash */
 /** @} */
 
+/**
+ * Lock the flash control register.
+ *
+ * If the flash control register has been disabled since the last reset when
+ * this function is called, a bus fault will be generated.
+ *
+ * @kconfig_dep{CONFIG_FLASH_EX_OP_ENABLED}
+ *
+ */
+void npcx_lock_flash_control_register(const struct device *dev);
+
+/**
+ * Unlock the flash control register using the unlock sequence.
+ *
+ * If the flash control register has been disabled since the last reset when
+ * this function is called, a bus fault will be generated.
+ *
+ * @kconfig_dep{CONFIG_FLASH_EX_OP_ENABLED}
+ *
+ */
+void npcx_unlock_flash_control_register(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add `npcx_lock_flash_control_register` and `npcx_unlock_flash_control_register` functions to the NPCX FIU NOR driver. These helpers utilize the UMA (User Mode Access) operation to send `SPI_NOR_CMD_WRDI` and `SPI_NOR_CMD_WREN` commands respectively.

This allows for explicit control over the flash write-enable latch state via the driver's extended operations.