### PR TITLE
drivers: flash: npcx: fix parameter name in qspi_npcx_fiu_uma_block docs

### DIFF
--- a/drivers/flash/flash_npcx_fiu_qspi.h
+++ b/drivers/flash/flash_npcx_fiu_qspi.h
@@ -142,7 +142,7 @@ void qspi_npcx_fiu_set_spi_size(const struct device *dev, const struct npcx_qspi
  * @brief Block FIU master to generate flash transactions.
  *
  * @param dev Pointer to the device structure for qspi bus controller instance.
- * @param lock Block or unblock FIU master transactions.
+ * @param lock_en Block or unblock FIU master transactions.
  * @retval 0 on success, otherwise a negative error code.
  */
 int qspi_npcx_fiu_uma_block(const struct device *dev, bool lock_en);


### PR DESCRIPTION
Update the @param documentation for `qspi_npcx_fiu_uma_block` to match the actual function signature, changing lock to lock_en.