### PR TITLE
llext: remove platform_excludes for fixed #80949

### DIFF
--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -86,11 +86,6 @@ tests:
       - riscv
       - arc
       - x86
-    platform_exclude:
-      - qemu_arc/qemu_arc_hs5x     # See #80949
-      - nsim/nsim_hs5x             # See #80949
-      - nsim/nsim_hs5x/smp         # See #80949
-      - nsim/nsim_hs5x/smp/12cores # See #80949
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
@@ -122,11 +117,6 @@ tests:
       - riscv
       - arc
       - x86
-    platform_exclude:
-      - qemu_arc/qemu_arc_hs5x     # See #80949
-      - nsim/nsim_hs5x             # See #80949
-      - nsim/nsim_hs5x/smp         # See #80949
-      - nsim/nsim_hs5x/smp/12cores # See #80949
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU


### PR DESCRIPTION
Removes platforms excluded for #80949, which has been fixed.