### PR TITLE
ztest: fix recursive panic when fatal error occurs pre-kernel

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <zephyr/ztest.h>
 
 
@@ -48,7 +49,10 @@ __weak void ztest_post_fatal_error_hook(unsigned int reason,
 
 void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 {
-	k_tid_t curr_tid = k_current_get();
+	/* Use _current directly if pre-kernel to avoid k_current_get() assertion
+	 * failure, but use k_current_get() otherwise for proper userspace/TLS support.
+	 */
+	k_tid_t curr_tid = k_is_pre_kernel() ? _current : k_current_get();
 	bool valid_fault = (curr_tid == valid_fault_tid) || fault_in_isr;
 
 	printk("Caught system error -- reason %d %d\n", reason, valid_fault);
@@ -123,7 +127,12 @@ void assert_post_action(const char *file, unsigned int line)
 
 	printk("Caught assert failed\n");
 
-	if ((k_current_get() == valid_assert_tid) || assert_in_isr) {
+	/* Use _current directly if pre-kernel to avoid k_current_get() assertion
+	 * failure, but use k_current_get() otherwise for proper userspace/TLS support.
+	 */
+	k_tid_t curr_tid = k_is_pre_kernel() ? _current : k_current_get();
+
+	if ((curr_tid == valid_assert_tid) || assert_in_isr) {
 		printk("Assert error expected as part of test case.\n");
 
 		/* reset back to normal */


### PR DESCRIPTION
When a fatal error occurs before the kernel is fully initialized
(e.g., during early boot), the ztest fatal error handler would call
`k_current_get()` which now contains an assertion that fails if called
pre-kernel (added in commit 5ce408b6472d6faf ("kernel: assert if
k_current_get is called pre-kernel")). This assertion failure
triggers another panic, creating an infinite recursion that floods
the console with nonsensical values.

