### PR TITLE
drivers: mbox: ti_secproxy: drop redundant NULL check on dev pointer

### DIFF
--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -214,7 +214,7 @@ static int secproxy_mailbox_send(const struct device *dev, uint32_t channel,
 	mem_addr_t data_reg;
 	k_spinlock_key_t key;
 
-	if (!dev || !msg || !msg->data) {
+	if (msg == NULL || msg->data == NULL) {
 		LOG_ERR("Invalid parameters");
 		return -EINVAL;
 	}

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2025 Texas Instruments Incorporated.
  *
  * TI Secureproxy Mailbox driver for Zephyr's MBOX model.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/spinlock.h>


### PR DESCRIPTION
The mailbox send callback is always invoked with a valid device pointer.

Remove the redundant NULL check.