### PR TITLE
soc: nordic: nrf71: Add support to enable Wi-Fi debug

### DIFF
--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -25,3 +25,12 @@ config SOC_NRF7120_ENGA_CPUAPP
 
 config SOC_NRF7120_ENGA_CPUFLPR
 	select RISCV_CORE_NORDIC_VPR
+
+if SOC_SERIES_NRF71
+
+config SOC_NRF71_WIFI_DAP
+	bool "nRF71 Wi-Fi Debug access port for debugging"
+	help
+	  This controls the Wi-Fi AHB Debug AP (DAP) for debugging nRF71 Wi-Fi cores.
+
+endif # SOC_SERIES_NRF71

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -137,6 +137,15 @@ static void wifi_mpc_configuration(void)
 	override.endaddr = 0x200E0000;
 	override.index = 0;
 	mpc_configure_override(NRF_MPC03, &override);
+
+	if (IS_ENABLED(CONFIG_SOC_NRF71_WIFI_DAP)) {
+		/* Allow access to Wi-Fi debug interface registers */
+		init_mpc_region_override(&override);
+		override.start_address = 0x48000000;
+		override.endaddr = 0x48100000;
+		override.index = index++;
+		mpc_configure_override(NRF_MPC00, &override);
+	}
 }
 
 static void grtc_configuration(void)


### PR DESCRIPTION
To debug Wi-Fi cores, we need to enable access to Wi-Fi debug registers.