### PR TITLE
drivers: clock_control: mcux: fix RW6xx syscon clock rates

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -473,21 +473,26 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetCTimerClkFreq(7);
 		break;
 #endif
-
-#if defined(CONFIG_COUNTER_NXP_MRT)
+#if defined(CONFIG_COUNTER_NXP_MRT) || defined(CONFIG_SOC_SERIES_RW6XX) \
+		|| defined(CONFIG_PWM_MCUX_SCTIMER)
+	#if defined(CONFIG_COUNTER_NXP_MRT)
 	case MCUX_MRT_CLK:
-#if defined(CONFIG_SOC_SERIES_RW6XX)
+	#endif /* CONFIG_COUNTER_NXP_MRT */
+	#if defined(CONFIG_SOC_SERIES_RW6XX)
 	case MCUX_FREEMRT_CLK:
-#endif /* RW */
-#endif /* MRT */
-#if defined(CONFIG_PWM_MCUX_SCTIMER)
+	#endif /* CONFIG_SOC_SERIES_RW6XX */
+	#if defined(CONFIG_PWM_MCUX_SCTIMER)
 	case MCUX_SCTIMER_CLK:
-#endif
-#ifdef CONFIG_SOC_SERIES_RW6XX
-		/* RW6XX uses core clock for SCTimer, not bus clock */
+	#endif /* CONFIG_PWM_MCUX_SCTIMER */
+	#ifdef CONFIG_SOC_SERIES_RW6XX
+		/* RW6XX uses core clock for SCTimer/MRT, not bus clock */
 		*rate = CLOCK_GetCoreSysClkFreq();
+	#else
+		*rate = CLOCK_GetFreq(kCLOCK_BusClk);
+	#endif
 		break;
-#else
+#endif
+#ifndef CONFIG_SOC_SERIES_RW6XX
 	case MCUX_BUS_CLK:
 		*rate = CLOCK_GetFreq(kCLOCK_BusClk);
 		break;
@@ -511,7 +516,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetI3cClkFreq();
 #endif
 		break;
-#endif
+#endif /* (FSL_FEATURE_SOC_I3C_COUNT == 2) */
 
 #endif /* CONFIG_I3C_MCUX */
 
@@ -529,7 +534,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetDcPixelClkFreq();
 #endif
 		break;
-#endif
+#endif /* defined(CONFIG_MIPI_DSI_MCUX_2L)  */
 #if defined(CONFIG_AUDIO_DMIC_MCUX)
 	case MCUX_DMIC_CLK:
 		*rate = CLOCK_GetDmicClkFreq();


### PR DESCRIPTION
RW6xx syscon clock rates fixes.
In the old structure, the “RW6xx uses core clock …” block sat after a set of conditional case labels. That worked only when the relevant case labels were compiled in.

The key improvement is that MCUX_FREEMRT_CLK is now available for RW6xx even if CONFIG_COUNTER_NXP_MRT is not enabled, because the outer #if now includes CONFIG_SOC_SERIES_RW6XX. Previously, MCUX_FREEMRT_CLK was nested inside the MRT config guard and could disappear unexpectedly.