### PR TITLE
cmake: snippets: detect app-local snippets in sysbuild

### DIFF
--- a/doc/build/snippets/index.rst
+++ b/doc/build/snippets/index.rst
@@ -4,7 +4,7 @@ Snippets
 ########
 
 Snippets are a way to save build system settings in one place, and then use
-those settings when you build any Zephyr application. This lets you save common
+those settings when you build a Zephyr application. This lets you save common
 configuration separately when it applies to multiple different applications.
 
 Some example use cases for snippets are:
@@ -13,6 +13,17 @@ Some example use cases for snippets are:
 - enabling frequently-used debugging options
 - applying interrelated configuration settings to your "main" CPU and a
   co-processor core on an AMP SoC
+
+Application-local snippets
+**************************
+
+In addition to snippets defined in Zephyr, modules, and directories specified
+by :makevar:`SNIPPET_ROOT`, you can also define snippets in your application's
+source directory. When using :ref:`sysbuild <sysbuild>` to build multiple images application-local
+snippets require special handling. Application-local snippets are only available to the
+application that defines them. To use application-local snippets with sysbuild, you must use the
+image-specific snippet variable by prefixing the variable with the image name.
+See :ref:`application-local-snippets` for more details.
 
 The following pages document this feature.
 

--- a/doc/build/snippets/using.rst
+++ b/doc/build/snippets/using.rst
@@ -51,3 +51,55 @@ can be added to that application's ``CMakeLists.txt`` file. For example:
    endif()
 
    find_package(Zephyr ....)
+
+.. _application-local-snippets:
+
+Application-local snippets
+**************************
+
+You can define snippets directly in your application's source directory by
+creating a :file:`snippets/` subdirectory. These application-local snippets
+are used the same way as any other snippet:
+
+.. code-block:: console
+
+   west build -S my-app-snippet app
+
+Or with CMake:
+
+.. code-block:: console
+
+   cmake -Sapp -Bbuild -DSNIPPET="my-app-snippet" [...]
+
+With sysbuild
+=============
+
+When using :ref:`sysbuild <sysbuild>` to build multiple images, application-local
+snippets require the image-specific snippet variable. This is because app-local
+snippets are only visible to the application that defines them, not to other
+images in the build (such as a bootloader).
+
+Use the image name as a prefix for the ``SNIPPET`` variable using west:
+
+.. code-block:: console
+
+   west build -b <board> --sysbuild app -- -Dapp_SNIPPET=my-app-snippet
+
+Or with CMake:
+
+.. code-block:: console
+
+   cmake -Sapp -Bbuild -Dapp_SNIPPET="my-app-snippet" [...]
+
+For example, if your application directory is ``my_app`` and you have a snippet
+called ``debug-console`` in :file:`my_app/snippets/debug-console/snippet.yml`:
+
+.. code-block:: console
+
+   west build -b nrf52840dk/nrf52840 --sysbuild my_app -- -Dmy_app_SNIPPET=debug-console
+
+.. note::
+
+   Using the global ``-S`` or ``-DSNIPPET=`` syntax with application-local
+   snippets in a sysbuild configuration will result in a build error, as the
+   build system will attempt to apply the snippet to all images.

--- a/doc/build/snippets/writing.rst
+++ b/doc/build/snippets/writing.rst
@@ -104,6 +104,32 @@ The build system looks for snippets in these places:
    automatically be discovered by the build system, just as if
    the path to ``baz`` had appeared in :makevar:`SNIPPET_ROOT`.
 
+Application-local snippets
+==========================
+
+You can define snippets specific to your application by placing them in a
+:file:`snippets/` subdirectory of your application source directory:
+
+.. code-block:: none
+
+   <app>/
+   ├── CMakeLists.txt
+   ├── prj.conf
+   ├── src/
+   │   └── main.c
+   └── snippets/
+       └── my-snippet/
+           ├── snippet.yml
+           └── my-snippet.conf
+
+These application-local snippets are automatically discovered and can be used
+like any other snippet. See :ref:`using-snippets` for usage examples.
+
+When using :ref:`sysbuild <sysbuild>` to build multiple images (for example,
+an application with a bootloader), application-local snippets are only
+available to the application that defines them. Other images in the build
+cannot access the application's :file:`snippets/` directory.
+
 Processing order
 ****************
 

--- a/share/sysbuild/cmake/modules/sysbuild_snippets.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_snippets.cmake
@@ -6,6 +6,59 @@ zephyr_get(SB_SNIPPET)
 if(NOT SB_SNIPPET AND SNIPPET)
   set_ifndef(SB_SNIPPET ${SNIPPET})
 endif()
+
+# Check for app-local snippets used with global SNIPPET variable.
+# App-local snippets are only available to the specific image that defines them, so using
+# them via global SNIPPET will cause other images to fail.
+# We check this early at sysbuild level to provide a clear error message.
+if(SNIPPET)
+  set(app_snippets_dir "${APP_DIR}/snippets")
+  if(EXISTS "${app_snippets_dir}")
+    # Find all snippet.yml files in the app's snippets directory
+    file(GLOB_RECURSE app_snippet_files "${app_snippets_dir}/*/snippet.yml"
+                                        "${app_snippets_dir}/snippet.yml")
+
+    # Extract snippet names from app-local snippet.yml files
+    set(app_local_snippet_names)
+    foreach(snippet_file IN LISTS app_snippet_files)
+      file(STRINGS "${snippet_file}" snippet_lines)
+      foreach(line IN LISTS snippet_lines)
+        string(FIND "${line}" "name:" name_pos)
+        if(name_pos EQUAL 0)
+          string(SUBSTRING "${line}" 5 -1 snippet_name)
+          string(STRIP "${snippet_name}" snippet_name)
+          list(APPEND app_local_snippet_names "${snippet_name}")
+          break()
+        endif()
+      endforeach()
+    endforeach()
+
+    # Check if any globally requested snippets are app-local
+    string(REPLACE " " ";" snippet_list "${SNIPPET}")
+    set(app_local_snippets_in_use)
+    foreach(requested_snippet IN LISTS snippet_list)
+      if("${requested_snippet}" IN_LIST app_local_snippet_names)
+        list(APPEND app_local_snippets_in_use "${requested_snippet}")
+      endif()
+    endforeach()
+
+    # If app-local snippets are used with global SNIPPET, emit fatal error
+    if(app_local_snippets_in_use)
+      cmake_path(GET APP_DIR FILENAME app_name)
+      list(JOIN app_local_snippets_in_use ", " app_local_snippets_str)
+      message(FATAL_ERROR
+        "The following used snippet(s) are defined in the application's local "
+        "snippets directory:\n"
+        "    ${app_local_snippets_str}\n"
+        "When using sysbuild, application-local snippets are only available to "
+        "the main application. Using global SNIPPET variable will cause other images "
+        "(e.g., bootloader) to fail.\n"
+        "To fix this, use the image-specific snippet variable:\n"
+        "    -D${app_name}_SNIPPET=${app_local_snippets_str}\n")
+    endif()
+  endif()
+endif()
+
 set(SNIPPET_NAMESPACE SB_SNIPPET)
 set(SNIPPET_PYTHON_EXTRA_ARGS --sysbuild)
 set(SNIPPET_APP_DIR ${APP_DIR})


### PR DESCRIPTION
Problem:

When using sysbuild to build multiple images (e.g., application + bootloader), snippets defined in the application's local snippets/directory are only accessible to that specific application. If a user specifies such a snippet using the global SNIPPET variable (-DSNIPPET=my-snippet or -S my-snippet), the build system attempts to apply it to ALL images.

This causes other images like MCUboot to fail with a confusing "snippet not found" error, since they don't have access to the main application's snippets directory.

Solution:

Add early detection in sysbuild_snippets.cmake that runs before any image builds start. The check:

1. Scans the main application's snippets/ directory for snippet.yml files
2. Extracts snippet names from those files
3. Compares against the globally requested SNIPPET list
4. If any match is found, emits a clear fatal error explaining the issue and suggesting the correct syntax: `-D<app>_SNIPPET=<snippet>`

This provides users with an actionable error message instead of the cryptic "snippet not found" error that previously occurred when building secondary images.

Additionally, this commit updates the snippets documentation to:

- Document application-local snippets as a supported feature
- Explain the sysbuild limitation and required image-specific syntax
- Provide usage examples for both regular builds and sysbuild