### PR TITLE
soc: mimxrt1180_m7: enahance mimxrt1180_m7 settings

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt118x/CMakeLists.txt
@@ -6,6 +6,10 @@
 
 zephyr_sources(soc.c)
 
+# Only provide a SoC-specific mpu_config for CM7 builds (CM33 uses the generic
+# ARM MPU regions).
+zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M7 mpu_regions.c)
+
 zephyr_include_directories(.)
 
 if(CONFIG_MEMC_MCUX_FLEXSPI)

--- a/soc/nxp/imxrt/imxrt118x/mpu_regions.c
+++ b/soc/nxp/imxrt/imxrt118x/mpu_regions.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * i.MXRT118x (CM7) selects CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS.
+ * Some boards provide their own mpu_config via board sources, but for
+ * build-only virtual boards we still need a definition.
+ *
+ * Keep this minimal: define basic Flash + SRAM regions using generic MPU
+ * helpers.
+ */
+
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
+#include <zephyr/toolchain.h>
+
+static const struct arm_mpu_region mpu_regions[] = {
+	/* Region 0: Flash */
+	MPU_REGION_ENTRY("FLASH_0", CONFIG_FLASH_BASE_ADDRESS,
+			 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
+
+	/* Region 1: SRAM */
+	MPU_REGION_ENTRY("SRAM_0", CONFIG_SRAM_BASE_ADDRESS, REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+};
+
+__weak const struct arm_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+};


### PR DESCRIPTION
enhance mimxrt1180_m7 core settings, with mpu_regions defined for M7 core

RT118x CM7 selects CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS, so a mpu_region.c need be provided