### PR TITLE
soc: renesas: rz: Fix incorrect value for LMA address

### DIFF
--- a/boards/renesas/rza2m_evk/rza2m_evk.dts
+++ b/boards/renesas/rza2m_evk/rza2m_evk.dts
@@ -40,11 +40,15 @@
 	flash0: flash@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_M(64)>;
+		ranges = <0x0 0x20000000 DT_SIZE_M(64)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			loader_program: partition@0 {
 				label = "loader-program";

--- a/boards/renesas/rza3ul_smarc/Kconfig.defconfig
+++ b/boards/renesas/rza3ul_smarc/Kconfig.defconfig
@@ -1,5 +1,0 @@
-# Copyright (c) 2025 Renesas Electronics Corporation
-# SPDX-License-Identifier: Apache-2.0
-
-config FLASH_LOAD_OFFSET
-	default $(dt_nodelabel_reg_addr_hex,header)

--- a/boards/renesas/rza3ul_smarc/rza3ul_smarc.dts
+++ b/boards/renesas/rza3ul_smarc/rza3ul_smarc.dts
@@ -74,14 +74,18 @@
 	at25ql128a: qspi-nor-flash@20000000 {
 		compatible = "renesas,rz-qspi-spibsc";
 		reg = <0x20000000 DT_SIZE_M(16)>; /* 128 Mbits */
+		ranges = <0x0 0x20000000 DT_SIZE_M(16)>;
 		write-block-size = <1>;
 		erase-block-size = <4096>;
 		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			reserved: partition@0 {
 				reg = <0x00000000 0x20000>;

--- a/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
+++ b/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
@@ -79,11 +79,15 @@
 		xspi0_cs0: memory@60000000 {
 			compatible = "mmio-sram";
 			reg = <0x60000000 DT_SIZE_M(64)>;
+			ranges = <0x0 0x60000000 DT_SIZE_M(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			partitions {
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				loader_param: partition@0 {
 					label = "loader-param";

--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -70,11 +70,15 @@
 		xspi1_cs0: memory@68000000 {
 			compatible = "mmio-sram";
 			reg = <0x68000000 DT_SIZE_M(16)>;
+			ranges = <0 0x68000000 DT_SIZE_M(16)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			partitions {
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				loader_param: partition@0 {
 					label = "loader-param";

--- a/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
@@ -87,11 +87,15 @@
 		xspi0_cs0: memory@60000000 {
 			compatible = "mmio-sram";
 			reg = <0x60000000 DT_SIZE_M(64)>;
+			ranges = <0 0x60000000 DT_SIZE_M(64)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			partitions {
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				loader_param: partition@0 {
 					label = "loader-param";

--- a/soc/renesas/rz/common/loader_program.S
+++ b/soc/renesas/rz/common/loader_program.S
@@ -8,7 +8,7 @@
 #include <zephyr/linker/sections.h>
 
 /* Require CONFIG_XIP=n */
-#define ROM_START	(CONFIG_FLASH_BASE_ADDRESS + DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)))
+#define ROM_START	DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition))
 #define RAM_START	CONFIG_SRAM_BASE_ADDRESS
 #define APP_SIZE	_flash_used
 

--- a/soc/renesas/rz/rza3ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig.defconfig
@@ -18,6 +18,10 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+config FLASH_LOAD_OFFSET
+	default $(sub_hex, $(dt_nodelabel_reg_addr_hex,header), \
+		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))
+
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 DT_CHOSEN_SRAM_ZEPHYR = zephyr,sram
 

--- a/soc/renesas/rz/rzn2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2l/Kconfig.defconfig
@@ -21,8 +21,8 @@ config FLASH_BASE_ADDRESS
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) + \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))"
+	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rzn2l/sections.ld
+++ b/soc/renesas/rz/rzn2l/sections.ld
@@ -10,7 +10,7 @@ SECTION_PROLOGUE(.loader, CONFIG_FLASH_BASE_ADDRESS,)
 	__loader_param_start = .;
 	KEEP(*(.loader_param))
 	__loader_param_end = .;
-	. = DT_REG_ADDR(DT_NODELABEL(loader_program));
+	. = DT_REG_ADDR(DT_NODELABEL(loader_program)) - CONFIG_FLASH_BASE_ADDRESS;
 	__loader_program_start = .;
 	KEEP(*(.loader_text.*))
 	__loader_program_end = .;

--- a/soc/renesas/rz/rzt2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2l/Kconfig.defconfig
@@ -21,8 +21,8 @@ config FLASH_BASE_ADDRESS
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) + \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))"
+	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rzt2l/sections.ld
+++ b/soc/renesas/rz/rzt2l/sections.ld
@@ -10,7 +10,7 @@ SECTION_PROLOGUE(.loader, CONFIG_FLASH_BASE_ADDRESS,)
 	__loader_param_start = .;
 	KEEP(*(.loader_param))
 	__loader_param_end = .;
-	. = DT_REG_ADDR(DT_NODELABEL(loader_program));
+	. = DT_REG_ADDR(DT_NODELABEL(loader_program)) - CONFIG_FLASH_BASE_ADDRESS;
 	__loader_program_start = .;
 	KEEP(*(.loader_text.*))
 	__loader_program_end = .;

--- a/soc/renesas/rz/rzt2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2m/Kconfig.defconfig
@@ -22,8 +22,8 @@ config FLASH_BASE_ADDRESS
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) + \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))"
+	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rzt2m/sections.ld
+++ b/soc/renesas/rz/rzt2m/sections.ld
@@ -10,7 +10,7 @@ SECTION_PROLOGUE(.loader, CONFIG_FLASH_BASE_ADDRESS,)
 	__loader_param_start = .;
 	KEEP(*(.loader_param))
 	__loader_param_end = .;
-	. = DT_REG_ADDR(DT_NODELABEL(loader_program));
+	. = DT_REG_ADDR(DT_NODELABEL(loader_program)) - CONFIG_FLASH_BASE_ADDRESS;
 	__loader_program_start = .;
 	KEEP(*(.loader_text.*))
 	__loader_program_end = .;


### PR DESCRIPTION
The current code is getting the relative address incorrectly for BUILD_OUTPUT_ADJUST_LMA. This update switches to using the addition of two absolute addresses to ensure accuracy.
