### PR TITLE
add flexspi nor flash support on imx93_evk for A55

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
+++ b/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
@@ -346,4 +346,19 @@
 			input-enable;
 		};
 	};
+
+	pinmux_flexspi: pinmux_flexspi {
+		group0 {
+			pinmux = <&iomuxc1_sd1_strobe_flexspi_a_dqs_flexspi1_a_dqs>,
+				 <&iomuxc1_sd3_clk_flexspi_a_sclk_flexspi1_a_sclk>,
+				 <&iomuxc1_sd3_cmd_flexspi_a_ss_b_flexspi1_a_ss0_b>,
+				 <&iomuxc1_sd3_data0_flexspi_a_data_flexspi1_a_data00>,
+				 <&iomuxc1_sd3_data1_flexspi_a_data_flexspi1_a_data01>,
+				 <&iomuxc1_sd3_data2_flexspi_a_data_flexspi1_a_data02>,
+				 <&iomuxc1_sd3_data3_flexspi_a_data_flexspi1_a_data03>;
+			bias-pull-down;
+			slew-rate = "fast";
+			drive-strength = "x5";
+		};
+	};
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -260,3 +260,39 @@
 &wdog4 {
 	status = "okay";
 };
+
+&flexspi1 {
+	/*
+	 * For this spi-nor on M.2 card, need first enable the VPCIe_3.3v.
+	 * Note, VPCIe_3.3v need about 1.74ms to change from 0v to 3.3v.
+	 * U-boot already enable VPCIe_3.3v, so in linux, can ignore this
+	 * 1.7ms, if u-boot do not enable VPCIe_3.3v first, then need to
+	 * take care of the 1.74ms delay, better to build the flexspi driver
+	 * as module in driver to avoid spi-nor probe fail.
+	 */
+	pinctrl-0 = <&pinmux_flexspi>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	mt25qu512abb8e12: flash@0 {
+		compatible = "nxp,imx-flexspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(64)>;
+		spi-max-frequency = <66000000>;
+		status = "okay";
+		jedec-id = [9d 70 17];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@100000 {
+				label = "storage";
+				reg = <0x00100000 DT_SIZE_K(128)>;
+			};
+		};
+	};
+};

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -20,6 +20,7 @@ supported:
   - can
   - net
   - watchdog
+  - flash
 testing:
   ignore_tags:
     - bluetooth

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -50,6 +50,13 @@ static int mcux_ccm_on(const struct device *dev,
 		return 0;
 #endif
 #endif
+#ifdef CONFIG_MEMC_MCUX_FLEXSPI
+#ifdef CONFIG_SOC_MIMX9352
+	case IMX_CCM_FLEXSPI_CLK:
+		CLOCK_EnableClock(kCLOCK_Flexspi1);
+		return 0;
+#endif
+#endif
 	default:
 		(void)instance;
 		return 0;
@@ -393,7 +400,8 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 	case IMX_CCM_FLEXSPI_CLK:
 		__fallthrough;
 	case IMX_CCM_FLEXSPI2_CLK:
-#if (defined(CONFIG_SOC_SERIES_IMXRT11XX) || defined(CONFIG_SOC_SERIES_IMXRT118X)) \
+#if (defined(CONFIG_SOC_SERIES_IMXRT11XX) || defined(CONFIG_SOC_SERIES_IMXRT118X) \
+		|| defined(CONFIG_SOC_MIMX9352)) \
 		&& defined(CONFIG_MEMC_MCUX_FLEXSPI)
 		/* The SOC is using the FlexSPI for XIP. Therefore,
 		 * the FlexSPI itself must be managed within the function,

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -304,7 +304,7 @@ static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %zu bytes to 0x%08zx", len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
@@ -434,7 +434,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_InvalidateByRange((uint32_t) dst, size);
+	DCACHE_InvalidateByRange((uintptr_t)dst, size);
 #endif
 
 	return 0;
@@ -527,7 +527,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_InvalidateByRange((uint32_t) dst, size);
+	DCACHE_InvalidateByRange((uintptr_t)dst, size);
 #endif
 
 	return 0;

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -156,6 +156,7 @@
 		flexspi: spi@425e0000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <48 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
@@ -103,7 +103,9 @@
 
 		flexspi: spi@400a0000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400a0000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400a0000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <26 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
@@ -41,6 +41,7 @@
 &flexspi {
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;
+	reg-names = "reg_base", "ahb";
 
 	/* 32 megabit internal flash present on chip */
 	w25q32jvwj0: w25q32jvwj@0 {

--- a/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
@@ -14,6 +14,7 @@
 &flexspi2 {
 	status = "okay";
 	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
+	reg-names = "reg_base", "ahb";
 	rx-clock-source = <1>;
 
 	/* WINBOND */

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -131,7 +131,9 @@
 
 		flexspi: spi@402a8000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a8000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x402a8000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <108 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -143,7 +145,9 @@
 
 		flexspi2: spi@402a4000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a4000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x402a4000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <107 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm33.dtsi
@@ -46,10 +46,12 @@
 
 		flexspi: spi@525e0000 {
 			reg = <0x525e0000 0x4000>, <0x38000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@545e0000 {
 			reg = <0x545e0000 0x4000>, <0x14000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm33_ns.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm33_ns.dtsi
@@ -40,10 +40,12 @@
 
 		flexspi: spi@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm7.dtsi
@@ -33,10 +33,12 @@
 
 		flexspi: spi@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -77,7 +77,9 @@
 
 		flexspi: spi@400cc000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400cc000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400cc000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <130 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -87,7 +89,9 @@
 
 		flexspi2: spi@400d0000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400d0000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400d0000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <131 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -120,10 +120,12 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	flexspi2: spi@13c000 {
 		reg = <0x13c000 0x1000>, <0x38000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -130,6 +130,7 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@50020000 {
 			reg = <0x50020000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_ns.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@40020000 {
 			reg = <0x40020000 0x1000>, <0x80000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn54x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn54x.dtsi
@@ -23,6 +23,7 @@
 
 		flexspi: spi@500c8000 {
 			reg = <0x500c8000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn94x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x.dtsi
@@ -23,6 +23,7 @@
 
 		flexspi: spi@500c8000 {
 			reg = <0x500c8000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@400c8000 {
 			reg = <0x400c8000 0x1000>, <0x80000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -148,6 +148,7 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/phytec/phycore_rt1170_common.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_common.dtsi
@@ -94,6 +94,7 @@
 	ahb-read-addr-opt;
 	rx-clock-source = <1>;
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(16)>;
+	reg-names = "reg_base", "ahb";
 
 	mx25u12832f: mx25u12832f@0 {
 		compatible = "nxp,imx-flexspi-nor";

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -165,6 +165,20 @@
 		status = "disabled";
 	};
 
+	flexspi1: spi@425e0000 {
+		compatible = "nxp,imx-flexspi";
+		reg = <0x425e0000 0x10000>, <0x28000000 DT_SIZE_M(64)>;
+		reg-names = "reg_base", "ahb";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		ahb-bufferable;
+		ahb-cacheable;
+		clocks = <&ccm IMX_CCM_FLEXSPI_CLK 0x0 0x0>;
+		status = "disabled";
+	};
+
 	gpio1: gpio@47400000 {
 		compatible = "nxp,imx-rgpio";
 		reg = <0x47400000 DT_SIZE_K(64)>;

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -11,6 +11,12 @@ properties:
   reg:
     required: true
 
+  reg-names:
+    required: true
+    description: |
+      Identifiers for register spaces with "reg_base" for control
+      and "ahb" for ahb space
+
   interrupts:
     required: true
 

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -55,6 +55,8 @@
 #define SPI_FLASH_COMPAT st_stm32_xspi_nor
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_qspi_nor)
 #define SPI_FLASH_COMPAT nordic_qspi_nor
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_flexspi_nor)
+#define SPI_FLASH_COMPAT nxp_imx_flexspi_nor
 #elif DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_ospi_b_nor)
 #define SPI_FLASH_COMPAT renesas_ra_ospi_b_nor
 #elif DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_qspi_nor)

--- a/soc/nxp/imx/imx9/imx93/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx93/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CONFIG_SOC_MIMX9352_A55)
   zephyr_include_directories(a55)
 
   zephyr_sources_ifdef(CONFIG_ARM_MMU a55/mmu_regions.c)
+  zephyr_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI a55/flexspi.c)
 
   zephyr_sources(common_clock_set.c)
   zephyr_sources(a55/soc.c)

--- a/soc/nxp/imx/imx9/imx93/a55/flexspi.c
+++ b/soc/nxp/imx/imx9/imx93/a55/flexspi.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fsl_clock.h>
+#include <fsl_flexspi.h>
+#include <soc.h>
+#include <errno.h>
+#include <zephyr/irq.h>
+#include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
+
+#define MCR0_SERCLKDIV_MASK  0x700
+#define MCR0_SERCLKDIV_SHIFT 8
+
+uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
+{
+	uint32_t root_rate;
+	FLEXSPI_Type *flexspi;
+	clock_root_t flexspi_clk;
+	clock_ip_name_t clk_gate;
+	uint32_t divider;
+
+	switch (clock_name) {
+	case IMX_CCM_FLEXSPI_CLK:
+		flexspi_clk = kCLOCK_Root_Flexspi1;
+		flexspi = (FLEXSPI_Type *)DT_REG_ADDR(DT_NODELABEL(flexspi1));
+		clk_gate = kCLOCK_Flexspi1;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	/* Get clock root frequency */
+	root_rate = CLOCK_GetIpFreq(flexspi_clk);
+
+	/* Select a divider based on root clock frequency. We round the
+	 * divider up, so that the resulting clock frequency is lower than
+	 * requested when we can't output the exact requested frequency
+	 */
+	divider = ((root_rate + (rate - 1)) / rate);
+	/* Cap divider to max value */
+	divider = MIN(divider, 7U);
+
+	while (FLEXSPI_GetBusIdleStatus(flexspi) == false) {
+		/* Spin */
+	}
+
+	FLEXSPI_Enable(flexspi, false);
+
+	flexspi->MCR0 &= ~MCR0_SERCLKDIV_MASK;
+	flexspi->MCR0 |= divider << MCR0_SERCLKDIV_SHIFT;
+
+	FLEXSPI_Enable(flexspi, true);
+
+	FLEXSPI_SoftwareReset(flexspi);
+
+	return 0;
+}

--- a/soc/nxp/imx/imx9/imx93/a55/soc.h
+++ b/soc/nxp/imx/imx9/imx93/a55/soc.h
@@ -10,5 +10,6 @@
 #include <stdint.h>
 
 uint32_t common_clock_set_freq(uint32_t clock_name, uint32_t rate);
+uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate);
 
 #endif /* _SOC_NXP_IMX_IMX93_A55_SOC_H_ */

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 125d3a401db81445db940f502991cb45d3c4a9e3
+      revision: pull/666/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
1. Updated flexspi memc driver: add reg-names dts property,  add MMIO mapping support, update all platforms dts which using flexspi memc driver.
2. Add flexspi nor flash support on imx93_evk for A55