### PR TITLE
scripts: sysbuild: improve domain build contexts to be build-root based

### DIFF
--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -81,7 +81,7 @@ class Domains:
         self._flash_order = self.get_domains(data.get('flash_order', []))
 
     @staticmethod
-    def from_file(domains_file):
+    def from_file(domains_file, build_dir):
         '''Load domains from a domains.yaml file.
         '''
         try:
@@ -91,14 +91,17 @@ class Domains:
             logger.critical(f'domains.yaml file not found: {domains_file}')
             exit(1)
 
-        return Domains.from_yaml(domains_yaml)
+        return Domains.from_yaml(domains_yaml, build_dir)
 
     @staticmethod
-    def from_yaml(domains_yaml):
+    def from_yaml(domains_yaml, build_dir):
         '''Load domains from a string with YAML contents.
         '''
         try:
             domains_yaml = yaml.safe_load(domains_yaml)
+            domains_yaml['build_dir'] = build_dir
+            for domain in domains_yaml['domains']:
+                domain['build_dir'] = build_dir + '/' + domain['name']
             return Domains(domains_yaml)
         except yaml.YAMLError as e:
             logger.critical(f'Invalid domains.yaml: {e}')

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -784,7 +784,7 @@ class FilterBuilder(CMake):
         if self.instance.sysbuild and not filter_stages:
             # Load domain yaml to get default domain build directory
             domain_path = os.path.join(self.build_dir, "domains.yaml")
-            domains = Domains.from_file(domain_path)
+            domains = Domains.from_file(domain_path, self.build_dir)
             logger.debug(f"Loaded sysbuild domain data from {domain_path}")
             self.instance.domains = domains
             domain_build = domains.get_default_domain().build_dir

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -167,4 +167,4 @@ def load_domains(path):
         }
         return Domains(default_domains)
 
-    return Domains.from_file(domains_file)
+    return Domains.from_file(domains_file, path)

--- a/share/sysbuild/cmake/domains.cmake
+++ b/share/sysbuild/cmake/domains.cmake
@@ -5,11 +5,9 @@
 sysbuild_images_order(IMAGES_FLASHING_ORDER FLASH IMAGES ${IMAGES})
 
 set(domains_yaml "default: ${DEFAULT_IMAGE}")
-set(domains_yaml "${domains_yaml}\nbuild_dir: ${CMAKE_BINARY_DIR}")
 set(domains_yaml "${domains_yaml}\ndomains:")
 foreach(image ${IMAGES})
   set(domains_yaml "${domains_yaml}\n  - name: ${image}")
-  set(domains_yaml "${domains_yaml}\n    build_dir: $<TARGET_PROPERTY:${image},_EP_BINARY_DIR>")
 endforeach()
 set(domains_yaml "${domains_yaml}\nflash_order:")
 foreach(image ${IMAGES_FLASHING_ORDER})


### PR DESCRIPTION
Currently, the `domains.yml` uses the absolute path directive for each domain. This causes an error when using the --prepare-artifacts-for-testing option on Twister. This occurs when the artifact is moved to testing on another runner.

This commit updates the script to generate the build context for each domain from the root build context folder.