### PR TITLE
spi: litex: litespi: move spi_context_update_tx

### DIFF
--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -167,8 +167,6 @@ static void spi_litex_spi_do_tx(const struct device *dev)
 
 	LOG_DBG("txd: 0x%x", txd);
 	litex_write32(txd, dev_config->master_rxtx_addr);
-
-	spi_context_update_tx(ctx, 1U, len);
 }
 
 static void spi_litex_spi_do_rx(const struct device *dev)
@@ -185,6 +183,7 @@ static void spi_litex_spi_do_rx(const struct device *dev)
 		litex_spi_rx_put(data->len, &rxd, ctx->rx_buf);
 	}
 
+	spi_context_update_tx(ctx, 1U, data->len);
 	spi_context_update_rx(ctx, 1U, data->len);
 }
 


### PR DESCRIPTION
With writing to `master_rxtx_addr` the transfer starts and with that ihe interrupt for rx can also come at any time after it. If that interrupt happens durring spi_context_update_tx, it can lead to some undefined behavior. In my case I got a `Load access fault` due to some later code then wanting to read a write only area. Probably `tx_count` in `struct spi_context` being decremented one to many, so it would be the max value of size_t.

Also we don't want to do `spi_context_update_tx` before `spi_context_wait_for_completion()`. As it contains `spi_context_total_tx_len()` and that needs the not incremented `current_tx`.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>