### PR TITLE
modules: lvgl: input: Demote ignored event log print

### DIFF
--- a/modules/lvgl/input/lvgl_keypad_input.c
+++ b/modules/lvgl/input/lvgl_keypad_input.c
@@ -36,7 +36,7 @@ static void lvgl_keypad_process_event(struct input_event *evt, void *user_data)
 	}
 
 	if (i == cfg->num_codes) {
-		LOG_WRN("Ignored input event: %u", evt->code);
+		LOG_DBG("Ignored input event: %u", evt->code);
 		return;
 	}
 


### PR DESCRIPTION
An unknown event key can occur a lot if only a subset of the keys are used in lvgl. Demote level from warning to debug.