### PR TITLE
Revert "drivers: rtc: check PORF flag before clearing alarm flags at init"

### DIFF
--- a/drivers/rtc/rtc_rv3028.c
+++ b/drivers/rtc/rtc_rv3028.c
@@ -868,7 +868,6 @@ static int rv3028_init(const struct device *dev)
 	uint8_t regs[3];
 	uint8_t val;
 	int err;
-	uint8_t status;
 
 	k_sem_init(&data->lock, 1, 1);
 
@@ -961,21 +960,13 @@ static int rv3028_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	err = rv3028_read_reg8(dev, RV3028_REG_STATUS, &status);
+	/* Disable the alarms */
+	err = rv3028_update_reg8(dev,
+				 RV3028_REG_CONTROL2,
+				 RV3028_CONTROL2_AIE | RV3028_CONTROL2_UIE,
+				 0);
 	if (err) {
 		return -ENODEV;
-	}
-	if (status & RV3028_STATUS_PORF) {
-		/* Disable the alarms */
-		err = rv3028_update_reg8(dev, RV3028_REG_CONTROL2,
-					 RV3028_CONTROL2_AIE | RV3028_CONTROL2_UIE, 0);
-		if (err) {
-			return -ENODEV;
-		}
-		err = rv3028_update_reg8(dev, RV3028_REG_STATUS, RV3028_STATUS_PORF, 0);
-		if (err) {
-			return -ENODEV;
-		}
 	}
 
 	err = rv3028_read_regs(dev, RV3028_REG_ALARM_MINUTES, regs, sizeof(regs));


### PR DESCRIPTION
This reverts commit e55a505

The reverted commit clears the PORF flag during init, which prevents it from being used to check if the time is valid.

Additionally, `AIE` and `UIE` are not alarm flags. They are interrupt enable bits. The driver should always disable the interrupt signals during init, as there are no callbacks registered to handle them.