### PR TITLE
dts: nordic: Fix missing ranges properties

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -98,11 +98,30 @@ config USE_DT_CODE_PARTITION
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_CODE_PARTITION_ADDRESS_INVALID
+	bool
+	default y if XIP && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) < FLASH_BASE_ADDRESS
+	select DEPRECATED
+	help
+	  If this item is selected, it is likely selected because your board/SoC/base DTS files
+	  are wrong and have a flash memory that does not start at absolute address 0x0 and:
+	    * Do not have a ``ranges <>;`` property in the flash node passing down the address
+	      and size to child nodes
+	    * Do not have a ``ranges;`` property in the partitions node passing down the previous
+	      ranges to child nodes
+
+	  Support for this will be removed and required that your files be updated correctly for
+	  a future release, check the Zephyr 4.4 migration notes.
 
 config FLASH_LOAD_OFFSET
 	# Only user-configurable when USE_DT_CODE_PARTITION is disabled
 	hex "Kernel load offset" if !USE_DT_CODE_PARTITION
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
+	default $(sub_hex, $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)), \
+		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if USE_DT_CODE_PARTITION && \
+		!FLASH_CODE_PARTITION_ADDRESS_INVALID
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) if USE_DT_CODE_PARTITION
 	default 0
 	help
 	  This option specifies the byte offset from the beginning of flash that

--- a/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
+++ b/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
@@ -71,11 +71,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
+++ b/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
@@ -71,11 +71,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
+++ b/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
@@ -71,11 +71,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
+++ b/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
@@ -71,11 +71,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
@@ -50,11 +50,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
+++ b/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
@@ -70,11 +70,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
+++ b/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
@@ -60,11 +60,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -132,11 +132,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
+++ b/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
@@ -60,11 +60,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -40,11 +40,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
+++ b/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
@@ -70,11 +70,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
+++ b/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
@@ -81,11 +81,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
+++ b/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
@@ -62,11 +62,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
+++ b/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
@@ -48,11 +48,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_common.dtsi
@@ -39,6 +39,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* 48K */
 		boot_partition: partition@0 {

--- a/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -83,6 +83,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		code_partition: partition@0 {
 			reg = <0x0 0x80000>;

--- a/boards/longan/canbed_rp2040/canbed_rp2040.dts
+++ b/boards/longan/canbed_rp2040/canbed_rp2040.dts
@@ -57,11 +57,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
@@ -55,11 +55,13 @@
 
 &flash1 {
 	reg = <0x01000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x01000000 DT_SIZE_K(256)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@0 {
 			label = "storage";

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet.dts
@@ -61,6 +61,7 @@ arduino_spi: &spi0 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet.dts
@@ -80,6 +80,7 @@ arduino_spi: &spi0 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/nordic/nrf54h20dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54h20dk/Kconfig.defconfig
@@ -17,10 +17,13 @@ config ROM_START_OFFSET
 
 if !USE_DT_CODE_PARTITION
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 # Application core firmware must start at this offset when not using MCUboot.
 # However, the default 'zephyr,code-partition' in DT is set for MCUboot.
 config FLASH_LOAD_OFFSET
-	default $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition)
+	default $(sub_hex, $(dt_nodelabel_reg_addr_hex,cpuapp_boot_partition), \
+		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))
 
 # This is meant to span 'cpuapp_boot_partition' and 'cpuapp_slot0_partition'
 # in the default memory map.

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -130,6 +130,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuapp_boot_partition: partition@30000 {
 			reg = <0x30000 DT_SIZE_K(64)>;

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -154,6 +154,7 @@ arduino_spi: &spi0 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
@@ -34,6 +34,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
@@ -189,6 +189,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		cpuapp_boot_partition: partition@312000 {
 			reg = <0x312000 DT_SIZE_K(64)>;

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
@@ -145,6 +145,7 @@ fem_spi: &spi0 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -263,6 +263,7 @@ arduino_serial: &flexcomm2_lpuart2 {};
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.dts
@@ -54,6 +54,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * All partition sizes must be aligned to the flash memory sector size (8 KB).

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
@@ -28,6 +28,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
@@ -185,6 +185,7 @@ arduino_spi: &spi0 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpunet.dts
+++ b/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpunet.dts
@@ -125,6 +125,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_common.dts
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_common.dts
@@ -35,6 +35,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_common.dts
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_common.dts
@@ -35,6 +35,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/seeed/xiao_rp2040/xiao_rp2040.dts
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.dts
@@ -74,11 +74,13 @@
 	 * 2MB of flash minus the 0x100 used for the second stage bootloader
 	 */
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -32,11 +32,13 @@
 	 * the second stage bootloader
 	 */
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -89,11 +89,13 @@
 	 * the second stage bootloader
 	 */
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -148,6 +148,17 @@ Boards
 
 * ITE ``it515xx_evb`` is renamed to ``it51xxx_evb``.
 
+* Boards that have NVM devices must now correctly have their addresses set or inheritied when they
+  do not start at address 0x0. In previous zephyr releases, a ``partitions`` entry in DTS was
+  wrongly interpreted as starting in the flash device's address range even though the DTS file
+  does not describe this and instead describes flash partitions starting at absolute addresses
+  e.g. 0x0. If you build and get the deprecated Kconfig
+  :kconfig:option:`CONFIG_FLASH_CODE_PARTITION_ADDRESS_INVALID` being set then this means your
+  board, SoC or DTS files are wrong and need updating, a ``ranges <>;`` property should be used
+  by the flash nodes to specify the base address and size for child nodes, and
+  ``fixed-partitions``/``fixed-subpartitions`` nodes must have a ``ranges;`` property to pass the
+  parent's ranges on to child nodes.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -79,11 +79,6 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	return 0;
 }
 
-/* obtain VPR address either from memory or partition */
-#define VPR_ADDR(node_id)                                                                          \
-	(DT_REG_ADDR(node_id) +                                                                    \
-	 COND_CODE_0(DT_FIXED_PARTITION_EXISTS(node_id), (0), (DT_REG_ADDR(DT_GPARENT(node_id)))))
-
 #define NEEDS_COPYING(inst) UTIL_AND(DT_INST_NODE_HAS_PROP(inst, execution_memory),                \
 				     DT_INST_NODE_HAS_PROP(inst, source_memory))
 
@@ -96,11 +91,11 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
-			   (.exec_addr = VPR_ADDR(DT_INST_PHANDLE(inst, execution_memory)),))      \
+			   (.exec_addr = DT_REG_ADDR(DT_INST_PHANDLE(inst, execution_memory)),))   \
 		.enable_secure = DT_INST_PROP(inst, enable_secure),                                \
 		.enable_dma_secure = DT_INST_PROP(inst, enable_dma_secure),                        \
 		IF_ENABLED(NEEDS_COPYING(inst),                                                    \
-			   (.src_addr = VPR_ADDR(DT_INST_PHANDLE(inst, source_memory)),            \
+			   (.src_addr = DT_REG_ADDR(DT_INST_PHANDLE(inst, source_memory)),         \
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))};      \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \

--- a/dts/arm/infineon/cat3/xmc/xmc4500_F100x1024.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4500_F100x1024.dtsi
@@ -27,6 +27,9 @@
 
 &flash0 {
 	reg = <0x8000000 DT_SIZE_M(1)>;
+	ranges = <0x0 0x8000000 DT_SIZE_M(1)>;
+	#address-cells = <1>;
+	#size-cells = <1>;
 
 	pages_layout: pages_layout {
 		pages_layout_16k: pages_layout_16k {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -317,6 +317,8 @@
 				compatible = "soc-nv-flash";
 				erase-block-size = <2048>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -9,6 +9,7 @@
 
 &flash1 {
 	reg = <0x01000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x01000000 DT_SIZE_K(256)>;
 };
 
 &sram0 {

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -41,6 +41,7 @@
 		peripheral@50000000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x50000000 0x10000000>;
 			ranges = <0x0 0x50000000 0x10000000>;
 
 			/* Common nRF91 peripherals description. */

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -205,6 +205,8 @@
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <DT_SIZE_K(4)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -271,8 +271,11 @@
 		mram1x: mram@e000000 {
 			compatible = "nordic,mram";
 			reg = <0xe000000 DT_SIZE_K(2048)>;
+			ranges = <0x0 0xe000000 DT_SIZE_K(2048)>;
 			erase-block-size = <4096>;
 			write-block-size = <16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		uicr: uicr@fff8000 {

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -51,6 +51,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* This static layout needs to be the same with the upstream TF-M layout in the
 		 * header flash_layout.h of the relevant platform. Any updates in the layout

--- a/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
@@ -16,6 +16,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -934,8 +934,11 @@
 			cpuapp_mram: mram@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(4084)>;
+				ranges = <0x0 0 DT_SIZE_K(4084)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -114,8 +114,11 @@
 		mram1x: mram@e000000 {
 			compatible = "nordic,mram";
 			reg = <0xe000000 DT_SIZE_K(8192)>;
+			ranges = <0x0 0xe000000 DT_SIZE_K(8192)>;
 			erase-block-size = <4096>;
 			write-block-size = <16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		uicr: uicr@fff8000 {

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -373,11 +373,20 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 /**
  * Get fixed-partition or fixed-subpartition offset from DTS node label
  *
+ * Note: This only works from a top level ``fixed-partitions`` node, top level
+ * ``fixed-subpartitions`` node or ``fixed-partitions`` node inside of 1 layer of a
+ * ``fixed-subpartitions`` node, it will not work for multiple layers of ``fixed-subpartitions``
+ * nodes.
+ *
  * @param label DTS node label of a partition
  *
  * @return fixed-partition offset, as defined for the partition in DTS.
  */
-#define FIXED_PARTITION_OFFSET(label) DT_REG_ADDR(DT_NODELABEL(label))
+#define FIXED_PARTITION_OFFSET(label) \
+	COND_CODE_1(DT_FIXED_SUBPARTITION_EXISTS(DT_NODELABEL(label)), \
+		(DT_PROP_BY_IDX(DT_PARENT(DT_NODELABEL(label)), reg, 0) + \
+		 DT_PROP_BY_IDX(DT_NODELABEL(label), reg, 0)), \
+		(DT_PROP_BY_IDX(DT_NODELABEL(label), reg, 0)))
 
 /**
  * Get fixed-partition or fixed-subpartition address from DTS node label
@@ -386,10 +395,7 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  *
  * @return fixed-partition address, as defined for the partition in DTS.
  */
-#define FIXED_PARTITION_ADDRESS(label) \
-	(COND_CODE_1(DT_FIXED_SUBPARTITION_EXISTS(DT_NODELABEL(label)), \
-		(DT_FIXED_SUBPARTITION_ADDR(DT_NODELABEL(label))), \
-		(DT_FIXED_PARTITION_ADDR(DT_NODELABEL(label)))))
+#define FIXED_PARTITION_ADDRESS(label) DT_REG_ADDR(DT_NODELABEL(label))
 
 /**
  * Get fixed-partition or fixed-subpartition address from DTS node
@@ -398,19 +404,24 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  *
  * @return fixed-partition address, as defined for the partition in DTS.
  */
-#define FIXED_PARTITION_NODE_ADDRESS(node) \
-	(COND_CODE_1(DT_FIXED_SUBPARTITION_EXISTS(node), \
-		(DT_FIXED_SUBPARTITION_ADDR(node)), \
-		(DT_FIXED_PARTITION_ADDR(node))))
+#define FIXED_PARTITION_NODE_ADDRESS(node) DT_REG_ADDR(node)
 
 /**
  * Get fixed-partition offset from DTS node
+ *
+ * Note: This only works from a top level ``fixed-partitions`` node, top level
+ * ``fixed-subpartitions`` node or ``fixed-partitions`` node inside of 1 layer of a
+ * ``fixed-subpartitions`` node, it will not work for multiple layers of ``fixed-subpartitions``
+ * nodes.
  *
  * @param node DTS node of a partition
  *
  * @return fixed-partition offset, as defined for the partition in DTS.
  */
-#define FIXED_PARTITION_NODE_OFFSET(node) DT_REG_ADDR(node)
+#define FIXED_PARTITION_NODE_OFFSET(node) \
+	COND_CODE_1(DT_FIXED_SUBPARTITION_EXISTS(node), \
+		(DT_PROP_BY_IDX(DT_PARENT(node), reg, 0) + DT_PROP_BY_IDX(node, reg, 0)), \
+		(DT_PROP_BY_IDX(node, reg, 0)))
 
 /**
  * Get fixed-partition size for DTS node label

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -41,11 +41,8 @@ endfunction()
 # Function to compute partition absolute address and size from devicetree
 function(compute_partition_address_and_size partition_nodelabel output_address_var output_size_var)
   dt_nodelabel(partition_path NODELABEL ${partition_nodelabel} REQUIRED)
-  dt_reg_addr(partition_offset PATH ${partition_path} REQUIRED)
+  dt_reg_addr(partition_address PATH ${partition_path} REQUIRED)
   dt_reg_size(partition_size PATH ${partition_path} REQUIRED)
-
-  # Calculate absolute partition address
-  math(EXPR partition_address "${CONFIG_FLASH_BASE_ADDRESS} + ${partition_offset}" OUTPUT_FORMAT HEXADECIMAL)
 
   # Set output variables in parent scope
   set(${output_address_var} ${partition_address} PARENT_SCOPE)

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -25,9 +25,10 @@ LOG_MODULE_REGISTER(flash_img, CONFIG_IMG_MANAGER_LOG_LEVEL);
 
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
 	DT_SAME_NODE(FIXED_PARTITION_NODE_MTD(DT_CHOSEN(zephyr_code_partition)),                   \
-		FIXED_PARTITION_MTD(label)) &&                                                     \
-	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
-	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
+		FIXED_PARTITION_MTD(label)) && (FIXED_PARTITION_ADDRESS(label) <=                  \
+				(CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET) &&          \
+			FIXED_PARTITION_ADDRESS(label) + FIXED_PARTITION_SIZE(label) >             \
+				(CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET))
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && (CONFIG_TFM_MCUBOOT_IMAGE_NUMBER == 2)
 #define UPLOAD_FLASH_AREA_LABEL slot1_ns_partition

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -50,9 +50,10 @@
 
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
 	DT_SAME_NODE(FIXED_PARTITION_NODE_MTD(DT_CHOSEN(zephyr_code_partition)),                   \
-		FIXED_PARTITION_MTD(label)) &&                                                     \
-	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
-	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
+		FIXED_PARTITION_MTD(label)) && (FIXED_PARTITION_ADDRESS(label) <=                  \
+			(CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET) &&                  \
+		FIXED_PARTITION_ADDRESS(label) + FIXED_PARTITION_SIZE(label) >                     \
+			(CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET))
 
 BUILD_ASSERT(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
 	     "struct image_header not required size");

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -13,14 +13,14 @@
 #if CONFIG_FLASH_MAP_LABELS
 #define FLASH_AREA_FOO(part, mtd_from_partition)				\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
-	 .fa_off = DT_REG_ADDR(part),						\
+	 .fa_off = FIXED_PARTITION_NODE_OFFSET(part),				\
 	 .fa_dev = DEVICE_DT_GET(mtd_from_partition(part)),		        \
 	 .fa_size = DT_REG_SIZE(part),						\
 	 .fa_label = DT_PROP_OR(part, label, NULL),	},
 #else
 #define FLASH_AREA_FOO(part, mtd_from_partition)				\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
-	 .fa_off = DT_REG_ADDR(part),						\
+	 .fa_off = FIXED_PARTITION_NODE_OFFSET(part),				\
 	 .fa_dev = DEVICE_DT_GET(mtd_from_partition(part)),		        \
 	 .fa_size = DT_REG_SIZE(part), },
 #endif
@@ -56,7 +56,7 @@ const struct flash_area *flash_map = default_flash_map;
 #define DEFINE_PARTITION_0(part, ord)								\
 	const struct flash_area DT_CAT(global_fixed_partition_ORD_, ord) = {			\
 		.fa_id = DT_FIXED_PARTITION_ID(part),						\
-		.fa_off = DT_REG_ADDR(part),							\
+		.fa_off = FIXED_PARTITION_NODE_OFFSET(part),					\
 		.fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),			\
 		.fa_size = DT_REG_SIZE(part),							\
 	};
@@ -71,7 +71,7 @@ DT_FOREACH_STATUS_OKAY(fixed_partitions, FOR_EACH_PARTITION_TABLE)
 #define DEFINE_SUBPARTITION_0(part, ord)							\
 	const struct flash_area DT_CAT(global_fixed_subpartition_ORD_, ord) = {			\
 		.fa_id = DT_FIXED_PARTITION_ID(part),						\
-		.fa_off = DT_REG_ADDR(part),							\
+		.fa_off = FIXED_PARTITION_NODE_OFFSET(part),					\
 		.fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_SUBPARTITION(part)),			\
 		.fa_size = DT_REG_SIZE(part),							\
 	};

--- a/tests/subsys/storage/flash_map/app.overlay
+++ b/tests/subsys/storage/flash_map/app.overlay
@@ -8,13 +8,17 @@
  */
 
 / {
-	disabled_flash@0 {
+	disabled_flash@4000 {
 		compatible = "vnd,flash";
-		reg = <0x00 0x1000>;
+		reg = <0x4000 0x1000>;
+		ranges = <0x0 0x4000 0x1000>;
 		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 


### PR DESCRIPTION
    dts: nordic: Fix missing ranges properties
    
    Adds these properties which are missing


Also fixes a missing nrf91 reg property