### PR TITLE
drivers: bluetooth: hci_nxp: move calibration data to zephyr

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -34,6 +34,7 @@ config HCI_NXP_SET_CAL_DATA
 config HCI_NXP_SET_CAL_DATA_ANNEX100
 	bool "Bluetooth Controller calibration data annex 100"
 	default y if BT_NXP_NW612 || BT_NXP_IW416
+	depends on HCI_NXP_SET_CAL_DATA
 	help
 	  If enabled, the Host will send calibration data annex 100 to the Bluetooth Controller during HCI
 	  init.
@@ -60,6 +61,24 @@ config HEAP_MEM_POOL_ADD_SIZE_BT_NXP_RX_THREAD
 	default 768
 
 endif
+
+choice HCI_NXP_ANT_DIVERSITY
+	bool "Antenna diversity configuration"
+	default HCI_NXP_ANT_DIVERSITY_ANT1
+	depends on HCI_NXP_SET_CAL_DATA_ANNEX100
+
+	config HCI_NXP_ANT_DIVERSITY_ANT1
+		bool "ANT1 diversity (shared with annex100)"
+
+	config HCI_NXP_ANT_DIVERSITY_ANT2
+		bool "ANT2 diversity with external FEM (ble only case)"
+
+	config HCI_NXP_ANT_DIVERSITY_ANT3
+		bool "ANT3 diversity (with annex100)"
+
+	config HCI_NXP_ANT_DIVERSITY_ANT4
+		bool "ANT4 diversity (with annex100)"
+endchoice
 
 if BT_NXP
 

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 NXP
+ * Copyright 2023-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -58,14 +58,6 @@ LOG_MODULE_REGISTER(bt_driver);
 #define BD_ADDR_OUI_PART_SIZE                           3U
 #define BD_ADDR_UUID_PART_SIZE                          3U
 
-#if !defined(CONFIG_HCI_NXP_SET_CAL_DATA)
-#define bt_nxp_set_calibration_data() 0
-#endif
-
-#if !defined(CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100)
-#define bt_nxp_set_calibration_data_annex100() 0
-#endif
-
 #if !defined(CONFIG_HCI_NXP_ENABLE_AUTO_SLEEP)
 #define nxp_bt_set_host_sleep_config()       0
 #define nxp_bt_enable_controller_autosleep() 0
@@ -80,9 +72,120 @@ LOG_MODULE_REGISTER(bt_driver);
 #define HCI_NXP_LOCK_STANDBY_BEFORE_SEND
 #endif
 
+#if defined(CONFIG_HCI_NXP_SET_CAL_DATA)
+#if defined(CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100)
+/* For share antenna case or diversty case(ble only case) */
+#define BT_CAL_DATA_ANNEX_FRONT_END_LOSS 0x03U
+#else
+/* For dual ant case */
+#define BT_CAL_DATA_ANNEX_FRONT_END_LOSS 0x02U
+#endif /* CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100 */
+#else
+#define bt_nxp_set_calibration_data() 0
+#endif /* CONFIG_HCI_NXP_SET_CAL_DATA */
+
+#if defined(CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100)
+#if defined(CONFIG_HCI_NXP_ANT_DIVERSITY_ANT1) || defined(CONFIG_HCI_NXP_ANT_DIVERSITY_ANT2)
+/* For share antenna case or ant2 with external FEM(ble only case) */
+#define BT_CAL_DATA_ANNEX_100_EPA_FEM_MASK_LOW_BYTE 0x02U
+#define BT_CAL_DATA_ANNEX_100_LNA_FEM_MASK_LOW_BYTE 0x02U
+#elif defined(CONFIG_HCI_NXP_ANT_DIVERSITY_ANT3)
+/* diversity case(enable ant3) */
+#define BT_CAL_DATA_ANNEX_100_EPA_FEM_MASK_LOW_BYTE 0x0AU
+#define BT_CAL_DATA_ANNEX_100_LNA_FEM_MASK_LOW_BYTE 0x0AU
+#elif defined(CONFIG_HCI_NXP_ANT_DIVERSITY_ANT4)
+/* diversity case(enable ant4) */
+#define BT_CAL_DATA_ANNEX_100_EPA_FEM_MASK_LOW_BYTE 0x06U
+#define BT_CAL_DATA_ANNEX_100_LNA_FEM_MASK_LOW_BYTE 0x06U
+#else
+#error "Missing calibration data for annex100"
+#endif /* HCI_NXP_ANT_DIVERSITY_ANTx */
+#else
+#define bt_nxp_set_calibration_data_annex100() 0
+#endif /* CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100 */
+
 /* -------------------------------------------------------------------------- */
-/*                              Public prototypes                             */
+/*                               Private memory                               */
 /* -------------------------------------------------------------------------- */
+#if defined(CONFIG_HCI_NXP_SET_CAL_DATA)
+/* clang-format off */
+static const uint8_t hci_cal_data_params[] = {
+	0x00U,                            /*  Sequence Number : 0x00 */
+	0x00U,                            /*  Action : 0x00 */
+	0x01U,                            /*  Type : Not use CheckSum */
+	0x1CU,                            /*  File Length : 0x1C */
+	0x37U,                            /*  BT Annex Type : BT CFG */
+	0x71U,                            /*  Checksum : 0x71 */
+	0x1CU,                            /*  Annex Length LSB: 0x001C */
+	0x00U,                            /*  Annex Length MSB: 0x001C */
+	0xFFU,                            /*  Pointer For Next Annex[0] : 0xFFFFFFFF */
+	0xFFU,                            /*  Pointer For Next Annex[1] : 0xFFFFFFFF */
+	0xFFU,                            /*  Pointer For Next Annex[2] : 0xFFFFFFFF */
+	0xFFU,                            /*  Pointer For Next Annex[3] : 0xFFFFFFFF */
+	0x01U,                            /*  Annex Version : 0x01 */
+	0x7CU,                            /*  External Xtal Calibration Value : 0x7C */
+	0x04U,                            /*  Initial TX Power : 0x04 */
+	BT_CAL_DATA_ANNEX_FRONT_END_LOSS, /*  Front End Loss : 0x02 or 0x03 */
+	/*
+	 * BT Options :
+	 * BIT[0]] Force Class 2 operation = 0
+	 * BIT[1]] Disable Pwr Control for class 2= 0
+	 * BIT[2]] MiscFlag(to indicagte external XTAL) = 0
+	 * BIT[3] Used Internal Sleep Clock = 1
+	 * BIT[4] BT AOA localtion support = 0
+	 * BIT[5] Force Class 1 mode = 1
+	 * BIT[7:6] Reserved
+	 */
+	0x28U,
+	0x00U, /*  AOANumberOfAntennas: 0x00 */
+	0x00U, /*  RSSI Golden Low : 0 */
+	0x00U, /*  RSSI Golden High : 0 */
+	0xC0U, /*  UART Baud Rate[0] : 0x002DC6C0(3000000) */
+	0xC6U, /*  UART Baud Rate[1] : 0x002DC6C0(3000000) */
+	0x2DU, /*  UART Baud Rate[2] : 0x002DC6C0(3000000) */
+	0x00U, /*  UART Baud Rate[3] : 0x002DC6C0(3000000) */
+	0x00U, /*  BdAddress[0] : 0x000000000000 */
+	0x00U, /*  BdAddress[1] : 0x000000000000 */
+	0x00U, /*  BdAddress[2] : 0x000000000000 */
+	0x00U, /*  BdAddress[3] : 0x000000000000 */
+	0x00U, /*  BdAddress[4] : 0x000000000000 */
+	0x00U, /*  BdAddress[5] : 0x000000000000 */
+	/*
+	 * Encr_Key_Len[3:0]: MinEncrKeyLen = 0x0
+	 * Encr_Key_Len[7:4]: MaxEncrKeyLen = 0xF
+	 */
+	0xF0U,
+	0x00U, /*  RegionCode : 0x00 */
+};
+/* clang-format on */
+
+#if defined(CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100)
+/*
+ * a.The following parameters are used in three cases,
+ *    1.For share antenna case or ant2 with external FEM(ble only case).
+ *    2.diversity case(enable ant3)
+ *    3.diversity case(enable ant4)
+ */
+static const uint8_t hci_cal_data_annex100_params[] = {
+	0x64U, /*  Annex Type : 0x64 */
+	0x00U, /*  CheckSum: Annex100 ignores checksum */
+	0x10U, /*  Length-In-Byte : 0x0010 */
+	0x00U, /*  Length-In-Byte : 0x0010 */
+	0xFFU, /* Pointer for next annex structure : 0xFFFFFFFF */
+	0xFFU, /* Pointer for next annex structure : 0xFFFFFFFF */
+	0xFFU, /* Pointer for next annex structure : 0xFFFFFFFF */
+	0xFFU, /* Pointer for next annex structure : 0xFFFFFFFF */
+	0x01U, /* Ext_PA Gain : Bit[7:1]   Ext_PA Present : Bit[0] */
+	0x00U, /* Ext_Ant Gain : Bit[4:1]   Ext_Ant Present : Bit[0] */
+	BT_CAL_DATA_ANNEX_100_EPA_FEM_MASK_LOW_BYTE, /* BT_HW_INFO_EPA_FEM_Mask */
+	0x00U,                                       /* BT_HW_INFO_EPA_FEM_Mask */
+	0x01U, /* Ext_LNA Present : Bit[0]   Ext_LNA Gain : Bit[7:1] */
+	0x00U, /* multipurpose mask */
+	BT_CAL_DATA_ANNEX_100_LNA_FEM_MASK_LOW_BYTE, /* BT / LE ext LNA FEM BITMASK */
+	0x00U,                                       /* BT / LE ext LNA FEM BITMASK */
+};
+#endif /* CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100 */
+#endif /* CONFIG_HCI_NXP_SET_CAL_DATA */
 
 /* -------------------------------------------------------------------------- */
 /*                             Private functions                              */
@@ -144,11 +247,9 @@ static int nxp_bt_set_host_sleep_config(void)
 static int bt_nxp_set_calibration_data(void)
 {
 	uint16_t opcode = BT_OP(BT_OGF_VS, HCI_CMD_STORE_BT_CAL_DATA_OCF);
-	extern const uint8_t hci_cal_data_params[HCI_CMD_STORE_BT_CAL_DATA_PARAM_LENGTH];
 
 	/* Send the command */
-	return nxp_bt_send_vs_command(opcode, hci_cal_data_params,
-				      HCI_CMD_STORE_BT_CAL_DATA_PARAM_LENGTH);
+	return nxp_bt_send_vs_command(opcode, hci_cal_data_params, sizeof(hci_cal_data_params));
 }
 
 #if defined(CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100)
@@ -156,12 +257,9 @@ static int bt_nxp_set_calibration_data_annex100(void)
 {
 	uint16_t opcode = BT_OP(BT_OGF_VS, HCI_CMD_STORE_BT_CAL_DATA_ANNEX100_OCF);
 
-	extern const uint8_t
-		hci_cal_data_annex100_params[HCI_CMD_STORE_BT_CAL_DATA_PARAM_ANNEX100_LENGTH];
-
 	/* Send the command */
 	return nxp_bt_send_vs_command(opcode, hci_cal_data_annex100_params,
-				      HCI_CMD_STORE_BT_CAL_DATA_PARAM_ANNEX100_LENGTH);
+				      sizeof(hci_cal_data_annex100_params));
 }
 #endif /* CONFIG_HCI_NXP_SET_CAL_DATA_ANNEX100 */
 

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -67,7 +67,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #define bt_nxp_set_mac_address(public_addr) 0
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(standby), okay) && defined(CONFIG_PM) &&\
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(standby), okay) && defined(CONFIG_PM) &&                       \
 	defined(CONFIG_HCI_NXP_ENABLE_AUTO_SLEEP)
 #define HCI_NXP_LOCK_STANDBY_BEFORE_SEND
 #endif
@@ -191,7 +191,7 @@ static const uint8_t hci_cal_data_annex100_params[] = {
 /*                             Private functions                              */
 /* -------------------------------------------------------------------------- */
 
-#if defined(CONFIG_HCI_NXP_ENABLE_AUTO_SLEEP) || defined(CONFIG_HCI_NXP_SET_CAL_DATA) ||\
+#if defined(CONFIG_HCI_NXP_ENABLE_AUTO_SLEEP) || defined(CONFIG_HCI_NXP_SET_CAL_DATA) ||           \
 	defined(CONFIG_BT_HCI_SET_PUBLIC_ADDR)
 static int nxp_bt_send_vs_command(uint16_t opcode, const uint8_t *params, uint8_t params_len)
 {
@@ -279,10 +279,7 @@ static int bt_nxp_set_mac_address(const bt_addr_t *public_addr)
 	uint8_t uid[16] = {0};
 	uint8_t uuidLen;
 	uint32_t unique_val_crc = 0;
-	uint8_t params[HCI_CMD_BT_HOST_SET_MAC_ADDR_PARAM_LENGTH] = {
-		BT_USER_BD,
-		0x06U
-	};
+	uint8_t params[HCI_CMD_BT_HOST_SET_MAC_ADDR_PARAM_LENGTH] = {BT_USER_BD, 0x06U};
 
 	/* If no public address is provided by the user, use a unique address made
 	 * from the device's UID (unique ID)
@@ -297,7 +294,7 @@ static int bt_nxp_set_mac_address(const bt_addr_t *public_addr)
 			unique_val_crc = crc32_ieee_update(HCI_BT_MAC_ADDR_CRC_SEED, uid, uuidLen);
 			/* Copy the lower 3 bytes (24 bits) of the CRC result */
 			memcpy((void *)bleDeviceAddress, (const void *)&unique_val_crc,
-					BD_ADDR_UUID_PART_SIZE);
+			       BD_ADDR_UUID_PART_SIZE);
 		} else {
 			LOG_ERR("UUID is empty, cannot generate address.");
 			return -EFAULT;
@@ -311,11 +308,10 @@ static int bt_nxp_set_mac_address(const bt_addr_t *public_addr)
 	}
 
 	memcpy(&params[2], (const void *)bleDeviceAddress,
-		BD_ADDR_UUID_PART_SIZE + BD_ADDR_OUI_PART_SIZE);
+	       BD_ADDR_UUID_PART_SIZE + BD_ADDR_OUI_PART_SIZE);
 
 	/* Send the command */
-	return nxp_bt_send_vs_command(opcode, params,
-					HCI_CMD_BT_HOST_SET_MAC_ADDR_PARAM_LENGTH);
+	return nxp_bt_send_vs_command(opcode, params, HCI_CMD_BT_HOST_SET_MAC_ADDR_PARAM_LENGTH);
 }
 #endif /* CONFIG_BT_HCI_SET_PUBLIC_ADDR */
 
@@ -333,14 +329,13 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 			ret = true;
 			break;
 #if defined(CONFIG_BT_EXT_ADV)
-		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
-		{
+		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT: {
 			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
 				(void *)&evt_data[3];
 
 			return (ext_adv->num_reports == 1) &&
-				   ((ext_adv->adv_info[0].evt_type &
-					 BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+			       ((ext_adv->adv_info[0].evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) !=
+				0);
 		}
 #endif
 		default:
@@ -661,11 +656,10 @@ static int bt_nxp_init(const struct device *dev)
 	return ret;
 }
 
-#define HCI_DEVICE_INIT(inst) \
-	static struct bt_nxp_data hci_data_##inst = { \
-	}; \
-	DEVICE_DT_INST_DEFINE(inst, bt_nxp_init, NULL, &hci_data_##inst, NULL, \
-			      POST_KERNEL, CONFIG_BT_HCI_INIT_PRIORITY, &drv)
+#define HCI_DEVICE_INIT(inst)                                                                      \
+	static struct bt_nxp_data hci_data_##inst = {};                                            \
+	DEVICE_DT_INST_DEFINE(inst, bt_nxp_init, NULL, &hci_data_##inst, NULL, POST_KERNEL,        \
+			      CONFIG_BT_HCI_INIT_PRIORITY, &drv)
 
 /* Only one instance supported right now */
 HCI_DEVICE_INIT(0)


### PR DESCRIPTION
This commit moves NXP Bluetooth HCI calibration data handling from the HAL to Zephyr hci_nxp driver.
Added Kconfig choice to select antenna diversity.