### PR TITLE
net: coap: Use dedicated pointer for resource metadata 

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -807,6 +807,11 @@ Networking
   to automatically enable all the dependencies of a given ciphersuite, and more can be added as
   needed following the same pattern.
 
+* Resource-related metadata for CoAP ``.well-known/core`` responses is now configured with a dedicated
+  :c:member:`coap_resource.metadata` pointer instead of :c:member:`coap_resource.user_data`, which
+  should remain for the application to use exclusively. Applications implementing CoAP
+  ``.well-known/core`` handling should be updated to use the new pointer.
+
 Modem
 *****
 

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -287,6 +287,8 @@ struct coap_resource {
 	const char * const *path;
 	/** User specific opaque data */
 	void *user_data;
+	/** Resource metadata for '.well-known/core' responses */
+	struct coap_core_metadata *metadata;
 	/** List of resource observers */
 	sys_slist_t observers;
 	/** Resource age */

--- a/include/zephyr/net/coap_link_format.h
+++ b/include/zephyr/net/coap_link_format.h
@@ -66,7 +66,7 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
 
 /**
  * In case you want to add attributes to the resources included in the
- * 'well-known/core' "virtual" resource, the 'user_data' field should point
+ * 'well-known/core' "virtual" resource, the 'metadata' field should point
  * to a valid coap_core_metadata structure.
  */
 struct coap_core_metadata {

--- a/samples/net/sockets/coap_server/src/core.c
+++ b/samples/net/sockets/coap_server/src/core.c
@@ -60,7 +60,7 @@ COAP_RESOURCE_DEFINE(core_1, coap_server,
 {
 	.get = core_get,
 	.path = core_1_path,
-	.user_data = &((struct coap_core_metadata) {
+	.metadata = &((struct coap_core_metadata) {
 		.attributes = core_1_attributes,
 	}),
 });
@@ -75,7 +75,7 @@ COAP_RESOURCE_DEFINE(core_2, coap_server,
 {
 	.get = core_get,
 	.path = core_2_path,
-	.user_data = &((struct coap_core_metadata) {
+	.metadata = &((struct coap_core_metadata) {
 		.attributes = core_2_attributes,
 	}),
 });

--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -143,7 +143,7 @@ static bool match_queries_resource(const struct coap_resource *resource,
 				   const struct coap_option *query,
 				   int num_queries)
 {
-	struct coap_core_metadata *meta = resource->user_data;
+	struct coap_core_metadata *meta = resource->metadata;
 	const char * const *attributes = NULL;
 	const int href_len = strlen("href");
 
@@ -151,11 +151,11 @@ static bool match_queries_resource(const struct coap_resource *resource,
 		return true;
 	}
 
-	if (meta && meta->attributes) {
+	if (meta != NULL && meta->attributes != NULL) {
 		attributes = meta->attributes;
 	}
 
-	if (!attributes) {
+	if (attributes == NULL) {
 		return false;
 	}
 
@@ -354,7 +354,7 @@ static int format_resource(const struct coap_resource *resource,
 			   uint16_t *remaining, size_t *offset,
 			   size_t current, bool *more)
 {
-	struct coap_core_metadata *meta = resource->user_data;
+	struct coap_core_metadata *meta = resource->metadata;
 	const char * const *attributes = NULL;
 	int r;
 
@@ -369,7 +369,7 @@ static int format_resource(const struct coap_resource *resource,
 		return 0;
 	}
 
-	if (meta && meta->attributes) {
+	if (meta != NULL && meta->attributes != NULL) {
 		attributes = meta->attributes;
 	}
 
@@ -602,7 +602,7 @@ static int format_attributes(const char * const *attributes,
 static int format_resource(const struct coap_resource *resource,
 			   struct coap_packet *response)
 {
-	struct coap_core_metadata *meta = resource->user_data;
+	struct coap_core_metadata *meta = resource->metadata;
 	const char * const *attributes = NULL;
 	int r;
 
@@ -611,7 +611,7 @@ static int format_resource(const struct coap_resource *resource,
 		return r;
 	}
 
-	if (meta && meta->attributes) {
+	if (meta != NULL && meta->attributes != NULL) {
 		attributes = meta->attributes;
 	}
 


### PR DESCRIPTION
CoAP .well-known/core handling routine assumed that the "user_data"
pointer in struct coap_resource will be set to a valid struct
coap_core_metadata pointer, or left NULL. This approach is error
prone (application cannot use "user_data" field freely) and renders the
"user_data" field useless for other cases.

Therefore, introduce a separate "metadata" pointer within the struct
coap_resource specifically to configure the resource-related metadata,
and leave "user_data" for the applications to use freely.

Fixes #102980