### PR TITLE
net: socket: Add helpers to send all data in a buffer

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -843,6 +843,59 @@ int zsock_getnameinfo(const struct net_sockaddr *addr, net_socklen_t addrlen,
 		      char *serv, net_socklen_t servlen, int flags);
 
 /**
+ * @brief Send data to an arbitrary network address. The function will try
+ *        to send all the data requested, blocking if necessary. User can set
+ *        a limit on the time spent in the function using socket send timeout.
+ *
+ * @details
+ * See POSIX.1-2017 article
+ * http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
+ * for normative description of the parameters. The function differs from
+ * zsock_send() by trying to send all the data requested, blocking
+ * if necessary until all data is sent or timeout occurs.
+ * Note that this is only applicable for stream sockets like TCP.
+ * If the timeout is set to K_NO_WAIT, the function will return after
+ * the first send attempt, possibly sending less data than requested.
+ *
+ * @param sock Socket file descriptor
+ * @param buf Pointer to data buffer to send
+ * @param len Length of data to send
+ * @param flags Socket flags for sending data
+ * @param timeout Maximum time to wait until data is sent
+ * @param sent_len Pointer to variable where to store the actual number of bytes
+ *        sent. Can be set to NULL if the caller does not need this information.
+ * @return 0 on success, -errno on failure
+ */
+int zsock_send_all(int sock, const void *buf, size_t len, int flags,
+		   k_timeout_t timeout, size_t *sent_len);
+
+/**
+ * @brief Send data to an arbitrary network address. The function will try
+ *       to send all the data requested, blocking if necessary. User can set
+ *       a limit on the time spent in the function using socket send timeout.
+ *
+ * @details
+ * See POSIX.1-2017 article
+ * http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
+ * for normative description of the parameters. The function differs from
+ * zsock_sendmsg() by trying to send all the data requested, blocking
+ * if necessary until all data is sent or timeout occurs.
+ * Note that this is only applicable for stream sockets like TCP.
+ * If the timeout is set to K_NO_WAIT, the function will return after
+ * the first send attempt, possibly sending less data than requested.
+ *
+ * @param sock Socket file descriptor
+ * @param msg Pointer to message header describing data to send
+ * @param flags Socket flags for sending data
+ * @param timeout Maximum time to wait until data is sent
+ * @param sent_len Pointer to variable where to store the actual number of bytes
+ *        sent. Can be set to NULL if the caller does not need this information.
+ * @return 0 on success, -errno on failure
+ */
+int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
+		      k_timeout_t timeout, size_t *sent_len);
+
+/**
  * @name Socket level options (ZSOCK_SOL_SOCKET)
  * @{
  */

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1013,3 +1013,141 @@ static inline int z_vrfy_zsock_getsockname(int sock, struct net_sockaddr *addr,
 }
 #include <zephyr/syscalls/zsock_getsockname_mrsh.c>
 #endif /* CONFIG_USERSPACE */
+
+int zsock_send_all(int sock, const void *buf, size_t len, int flags, k_timeout_t timeout,
+		   size_t *sent_len)
+{
+	k_timepoint_t end;
+	int ret, opt;
+
+	if (sent_len != NULL) {
+		*sent_len = 0;
+	}
+
+	/* This function is only meaningful for stream sockets. */
+	ret = zsock_getsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_TYPE,
+			       &opt, &(net_socklen_t){ sizeof(opt) });
+	if (ret < 0) {
+		return -errno;
+	}
+
+	if (opt != NET_SOCK_STREAM) {
+		return -EOPNOTSUPP;
+	}
+
+	end = sys_timepoint_calc(timeout);
+
+	while (len > 0) {
+		ssize_t out_len = zsock_send(sock, buf, len, ZSOCK_MSG_DONTWAIT | flags);
+
+		if ((out_len == 0) || (out_len < 0 && errno == EAGAIN)) {
+			k_ticks_t req_timeout_ticks = sys_timepoint_timeout(end).ticks;
+			int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
+			struct zsock_pollfd pfd;
+			int pollres;
+
+			pfd.fd = sock;
+			pfd.events = ZSOCK_POLLOUT;
+
+			pollres = zsock_poll(&pfd, 1, req_timeout_ms);
+			if (pollres == 0) {
+				return -ETIMEDOUT;
+			} else if (pollres > 0) {
+				continue;
+			} else {
+				return -errno;
+			}
+		} else if (out_len < 0) {
+			return -errno;
+		}
+
+		__ASSERT_NO_MSG(out_len <= len);
+
+		buf = (const char *)buf + out_len;
+		len -= out_len;
+
+		if (sent_len != NULL) {
+			*sent_len += out_len;
+		}
+	}
+
+	return 0;
+}
+
+int zsock_sendmsg_all(int sock, const struct net_msghdr *message, int flags,
+		      k_timeout_t timeout, size_t *sent_len)
+{
+	size_t total_len = 0;
+	size_t offset = 0;
+	k_timepoint_t end;
+	int ret, i, opt;
+
+	if (sent_len != NULL) {
+		*sent_len = 0;
+	}
+
+	/* This function is only meaningful for stream sockets. */
+	ret = zsock_getsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_TYPE,
+			       &opt, &(net_socklen_t){ sizeof(opt) });
+	if (ret < 0) {
+		return -errno;
+	}
+
+	if (opt != NET_SOCK_STREAM) {
+		return -EOPNOTSUPP;
+	}
+
+	for (i = 0; i < message->msg_iovlen; i++) {
+		total_len += message->msg_iov[i].iov_len;
+	}
+
+	end = sys_timepoint_calc(timeout);
+
+	while (offset < total_len) {
+		ret = zsock_sendmsg(sock, message, ZSOCK_MSG_DONTWAIT | flags);
+		if ((ret == 0) || (ret < 0 && errno == EAGAIN)) {
+			k_ticks_t req_timeout_ticks = sys_timepoint_timeout(end).ticks;
+			int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
+			struct zsock_pollfd pfd;
+			int pollres;
+
+			pfd.fd = sock;
+			pfd.events = ZSOCK_POLLOUT;
+
+			pollres = zsock_poll(&pfd, 1, req_timeout_ms);
+			if (pollres == 0) {
+				return -ETIMEDOUT;
+			} else if (pollres > 0) {
+				continue;
+			} else {
+				return -errno;
+			}
+		} else if (ret < 0) {
+			return -errno;
+		}
+
+		if (sent_len != NULL) {
+			*sent_len += ret;
+		}
+
+		offset += ret;
+		if (offset >= total_len) {
+			break;
+		}
+
+		/* Update msghdr for the next iteration. */
+		for (i = 0; i < message->msg_iovlen; i++) {
+			if (ret < message->msg_iov[i].iov_len) {
+				message->msg_iov[i].iov_len -= ret;
+				message->msg_iov[i].iov_base =
+					(uint8_t *)message->msg_iov[i].iov_base + ret;
+				break;
+			}
+
+			ret -= message->msg_iov[i].iov_len;
+			message->msg_iov[i].iov_len = 0;
+		}
+	}
+
+	return 0;
+}

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -67,6 +67,22 @@ static void test_send(int sock, const void *buf, size_t len, int flags)
 		      "send failed");
 }
 
+static void test_send_all(int sock, const void *buf, size_t len, int flags,
+			  k_timeout_t timeout, size_t *sent_bytes)
+{
+	zassert_equal(zsock_send_all(sock, buf, len, flags, timeout, sent_bytes),
+		      0,
+		      "send_all failed");
+}
+
+static void test_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
+			     k_timeout_t timeout, size_t *sent_bytes)
+{
+	zassert_equal(zsock_sendmsg_all(sock, msg, flags, timeout, sent_bytes),
+		      0,
+		      "sendmsg_all failed");
+}
+
 static void test_sendto(int sock, const void *buf, size_t len, int flags,
 			const struct net_sockaddr *addr, net_socklen_t addrlen)
 {
@@ -2681,6 +2697,159 @@ ZTEST(net_socket_tcp, test_v6_listen_backlog)
 	test_common_listen_backlog(NET_AF_INET6, 0);
 	test_common_listen_backlog(NET_AF_INET6, 1);
 	test_common_listen_backlog(NET_AF_INET6, TEST_BACKLOG_MAX);
+}
+
+enum {
+	SEND_DATA_USING_SEND_ALL = 1,
+	SEND_DATA_USING_SENDMSG_ALL,
+};
+
+static void test_zsock_send_all_data(int method)
+{
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct net_sockaddr_in c_saddr;
+	struct net_sockaddr_in s_saddr;
+	struct net_sockaddr addr;
+	net_socklen_t addrlen = sizeof(addr);
+#define SENDALL_MAX_BUF_LEN 2048
+	static char send_buf[SENDALL_MAX_BUF_LEN];
+	static char recv_buf[SENDALL_MAX_BUF_LEN];
+	struct net_iovec io_vector[3];
+	struct net_msghdr msg;
+	ssize_t recved;
+	int i, send_len, recv_len, remaining, split_point;
+	size_t sent_len;
+
+	prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr);
+	prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr);
+
+	/* Set smaller receive buffer to force TCP to split the data
+	 * into multiple segments.
+	 */
+	zsock_setsockopt(s_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVBUF,
+			 &(int){ SENDALL_MAX_BUF_LEN / 2 }, sizeof(int));
+
+	test_bind(s_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_listen(s_sock);
+
+	test_connect(c_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
+
+	for (i = 0; i < sizeof(send_buf); i++) {
+		send_buf[i] = TEST_STR_LONG[i % (sizeof(TEST_STR_LONG) - 1)];
+	}
+
+	if (method == SEND_DATA_USING_SEND_ALL) {
+		test_send_all(c_sock, send_buf, sizeof(send_buf), 0,
+			      K_MSEC(1000), &sent_len);
+	} else if (method == SEND_DATA_USING_SENDMSG_ALL) {
+		/* Send data using sendmsg_all */
+		io_vector[0].iov_base = send_buf;
+		io_vector[0].iov_len = sizeof(send_buf);
+
+		memset(&msg, 0, sizeof(msg));
+		msg.msg_iov = io_vector;
+		msg.msg_iovlen = 1;
+
+		test_sendmsg_all(c_sock, &msg, 0, K_MSEC(1000), &sent_len);
+	} else {
+		zassert_true(false, "invalid send method");
+	}
+
+	zassert_equal(sent_len, sizeof(send_buf), "invalid length sent");
+
+	test_accept(s_sock, &new_sock, &addr, &addrlen);
+	zassert_equal(addrlen, sizeof(struct net_sockaddr_in), "wrong addrlen");
+
+	/* Read data in two chunks */
+	io_vector[0].iov_base = recv_buf;
+	io_vector[0].iov_len = sizeof(recv_buf) / 2;
+
+	split_point = io_vector[0].iov_len;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_name = &addr;
+	msg.msg_namelen = addrlen;
+
+	for (i = 0, send_len = 0; i < msg.msg_iovlen; i++) {
+		send_len += msg.msg_iov[i].iov_len;
+	}
+
+	remaining = send_len;
+	while (remaining > 0) {
+		recved = zsock_recvmsg(new_sock, &msg, 0);
+		if (recved < 0) {
+			break;
+		}
+
+		if (recved > 0) {
+			remaining -= recved;
+		}
+
+		/* There should be two rounds of recv. Adjust the iov_base pointer
+		 * so that the recv_buf is filled correctly.
+		 */
+		io_vector[0].iov_base = recv_buf + split_point;
+		io_vector[0].iov_len = sizeof(recv_buf) - split_point;
+	}
+
+	for (i = 0, recv_len = 0; i < msg.msg_iovlen; i++) {
+		recv_len += msg.msg_iov[i].iov_len;
+	}
+
+	zassert_equal(send_len, recv_len, "invalid length received");
+	zassert_mem_equal(recv_buf, send_buf, recv_len, "invalid data received");
+
+	test_close(new_sock);
+	test_close(s_sock);
+	test_close(c_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+}
+
+ZTEST(net_socket_tcp, test_zsock_send_all_data)
+{
+	test_zsock_send_all_data(SEND_DATA_USING_SEND_ALL);
+}
+
+ZTEST(net_socket_tcp, test_zsock_sendmsg_all_data)
+{
+	test_zsock_send_all_data(SEND_DATA_USING_SENDMSG_ALL);
+}
+
+ZTEST(net_socket_tcp, test_zsock_sendmsg_all_failure)
+{
+	int sock, ret;
+	size_t sent_len = 1; /* set to non-zero value to verify it is reset */
+	struct net_sockaddr_in addr;
+	struct net_msghdr msg = { 0 };
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &sock,
+			    (struct net_sockaddr_in *)&addr);
+
+	ret = zsock_sendmsg_all(sock, &msg, 0, K_FOREVER, &sent_len);
+	zassert_equal(sent_len, 0, "sendmsg_all should not have sent data");
+	zassert_equal(ret, -EOPNOTSUPP, "sendmsg_all should have failed, ret %d", ret);
+	test_close(sock);
+}
+
+ZTEST(net_socket_tcp, test_zsock_send_all_failure)
+{
+	int sock, ret;
+	size_t sent_len = 1; /* set to non-zero value to verify it is reset */
+	struct net_sockaddr_in addr;
+	const char *buf = TEST_STR_SMALL;
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &sock,
+			    (struct net_sockaddr_in *)&addr);
+
+	ret = zsock_send_all(sock, buf, strlen(buf), 0, K_FOREVER, &sent_len);
+	zassert_equal(sent_len, 0, "send_all should not have sent data");
+	zassert_equal(ret, -EOPNOTSUPP, "send_all should have failed, ret %d", ret);
+	test_close(sock);
 }
 
 static void after(void *arg)


### PR DESCRIPTION
It is a common use case to send data to peer using a TCP socket. As the `send()` or `sendmsg()` might return early before all data is sent, we might need to call sending function multiple times to make sure all the data is sent.
Create a helpers for this so that we do not need to have the users to do that individually (perhaps even introducing errors in the process).

We can change in-tree users to use these helpers if this is accepted and merged.
