### PR TITLE
Fix nrf-auxpll frequency Calculation

### DIFF
--- a/dts/bindings/clock/nordic,nrf-auxpll.yaml
+++ b/dts/bindings/clock/nordic,nrf-auxpll.yaml
@@ -48,14 +48,14 @@ properties:
   nordic,out-div:
     type: int
     enum:
-      - 1 # Division of 1
-      - 2 # Division of 2
-      - 3 # Division of 3
-      - 4 # Division of 4
-      - 5 # Division of 6
-      - 6 # Division of 8
-      - 7 # Division of 12
-      - 8 # Division of 16
+      - 1
+      - 2
+      - 3
+      - 4
+      - 6
+      - 8
+      - 12
+      - 16
     description: PLL output divider. Valid values shown in dt-bindings/clock/nrf-auxpll.h.
 
   nordic,out-drive:

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -681,7 +681,7 @@
 				#clock-cells = <0>;
 				nordic,ficrs = <&ficr NRF_FICR_TRIM_GLOBAL_CANPLL_TRIM_CTUNE>;
 				nordic,frequency = <NRF_AUXPLL_FREQ_DIV_MIN>;
-				nordic,out-div = <NRF_AUXPLL_OUT_DIV_2>;
+				nordic,out-div = <2>;
 				nordic,out-drive = <0>;
 				nordic,current-tune = <6>;
 				nordic,sdm-disable;

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -883,7 +883,7 @@
 				 * not defined yet
 				 */
 				nordic,ficrs = <&ficr 0>;
-				nordic,out-div = <NRF_AUXPLL_OUT_DIV_12>;
+				nordic,out-div = <12>;
 				nordic,out-drive = <0>;
 				nordic,current-tune = <9>;
 				nordic,sdm-disable;

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -447,7 +447,7 @@
 				#clock-cells = <0>;
 				nordic,ficrs = <&ficr NRF_FICR_TRIM_GLOBAL_CANPLL_TRIM_CTUNE>;
 				nordic,frequency = <NRF_AUXPLL_FREQ_DIV_MIN>;
-				nordic,out-div = <NRF_AUXPLL_OUT_DIV_2>;
+				nordic,out-div = <2>;
 				nordic,out-drive = <0>;
 				nordic,current-tune = <6>;
 				nordic,sdm-disable;

--- a/include/zephyr/dt-bindings/clock/nrf-auxpll.h
+++ b/include/zephyr/dt-bindings/clock/nrf-auxpll.h
@@ -13,14 +13,4 @@
 #define NRF_AUXPLL_FREQ_DIV_AUDIO_48K  39845
 #define NRF_AUXPLL_FREQ_DIV_MAX        65535
 
-#define NRF_AUXPLL_OUT_DIV_DISABLED 0
-#define NRF_AUXPLL_OUT_DIV_1        1
-#define NRF_AUXPLL_OUT_DIV_2        2
-#define NRF_AUXPLL_OUT_DIV_3        3
-#define NRF_AUXPLL_OUT_DIV_4        4
-#define NRF_AUXPLL_OUT_DIV_6        5
-#define NRF_AUXPLL_OUT_DIV_8        6
-#define NRF_AUXPLL_OUT_DIV_12       7
-#define NRF_AUXPLL_OUT_DIV_16       8
-
 #endif /* #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_NRF_AUXPLL_H_ */


### PR DESCRIPTION
The out_div dts setting differs to the register setting causing the frequency calculation to be incorrect. This was originally intended to be fixed in NRFX (see NRFX PR 1074 for more details) but this requires further investigation on how to approach translation of literal values to enums (Jira ticket NRFX-8181). This PR adds a helper function for the conversion for now and changes the devicetree bindings to align with the literal value.