### PR TITLE
dts: nxp: mcxaxx6: fix duplicate reg base address for lpuart1

### DIFF
--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -175,10 +175,10 @@
 			dma-names = "rx", "tx";
 		};
 
-		lpuart1: lpuart@4009a000 {
+		lpuart1: lpuart@400a0000 {
 			compatible = "nxp,lpuart";
 			status = "disabled";
-			reg = <0x4009a000 0x1000>;
+			reg = <0x400a0000 0x1000>;
 			interrupts = <32 0>;
 			clocks = <&syscon MCUX_LPUART1_CLK>;
 			/* DMA channels 2 and 3 muxed to LPUART1 RX and TX */


### PR DESCRIPTION
Fix incorrect register base mapping in nxp_mcxaxx6_common.dtsi where lpuart1 was erroneously mapped to the lpi2c0 base address (0x4009a000).

Correct the lpuart1 register base to 0x400a0000 to match the MCX A-series reference manual.

The incorrect mapping caused duplicate unit-address warnings between lpuart and i2c nodes and could lead to invalid register access and early HardFault when lpuart1 is enabled.

The issue was not detected on reference boards as lpuart1 is not used there