### PR TITLE
boards: st: stm32n6570_dk: enable OTP if ETH_STM32_HAL && NVMEM

### DIFF
--- a/boards/st/stm32n6570_dk/Kconfig.defconfig
+++ b/boards/st/stm32n6570_dk/Kconfig.defconfig
@@ -9,7 +9,7 @@ configdefault NET_L2_ETHERNET
 	default y
 
 configdefault OTP
-	default y if NET_L2_ETHERNET && NVMEM
+	default y if ETH_STM32_HAL && NVMEM
 
 if DISPLAY || VIDEO
 # MEMC needs to be enabled in order to store


### PR DESCRIPTION
Using the NET_L2_ETHERNET to enable OTP can create a build error if we compile the ST Ethernet driver while setting NET_L2_ETHERNET to n. In fact the MAC node points to the BSEC node that won't be instantiated by the OTP driver resulting in a build fail.

Checking ETH_STM32_HAL instead of NET_L2_ETHERNET
will ensure that the OTP driver will be built when the ST Ethernet driver is.

This error can be reproduced with :
`west build -p -b stm32n6570_dk/stm32n657xx/sb tests/drivers/build_all/ethernet -T net.ethernet.build.default -- -DZEPHYR_SCA_VARIANT=dtdoctor`

and gives the following output:

> zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/drivers/ethernet/libdrivers__ethernet.a(eth_stm32_hal_common.c.obj):(.rodata.eth0_config+0x18): undefined reference to `__device_dts_ord_131'
collect2: error: ld returned 1 exit status
+--------------------------------------------------------------------------------------+
| DT Doctor                                                                            |
+======================================================================================+
| 'bsec: /soc/efuse@56009000' is enabled but no driver appears to be available for it. |
|                                                                                      |
| Try enabling these Kconfig options:                                                  |
|                                                                                      |
|  - CONFIG_OTP=y                                                                      |
+--------------------------------------------------------------------------------------+
ninja: build stopped: subcommand failed.