### PR TITLE
treewide: use proper essential type for boolean variables

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -154,7 +154,7 @@ static int counter_esp32_set_alarm_64(const struct device *dev, uint8_t chan_id,
 	uint64_t target;
 	uint64_t diff;
 	int err = 0;
-	bool irq_on_late = 0;
+	bool irq_on_late = false;
 
 	if (ticks > data->top_data.ticks) {
 		return -EINVAL;

--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -115,7 +115,7 @@ static int set_cc(const struct device *dev, uint8_t id, uint32_t val, uint32_t f
 	uint32_t now;
 	uint32_t diff;
 	uint32_t max_rel_val = top;
-	bool irq_on_late = 0;
+	bool irq_on_late = false;
 
 	now = MXC_TMR_GetCount(regs);
 	MXC_TMR_ClearFlags(regs);

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -40,7 +40,7 @@ void i2c_dump_msgs_rw(const struct device *dev, const struct i2c_msg *msgs, uint
 		      uint16_t addr, bool dump_read)
 {
 #ifdef CONFIG_I2C_DUMP_MESSAGES_ALLOWLIST
-	bool found_dev = 0;
+	bool found_dev = false;
 
 	for (int a = 0; a < ARRAY_SIZE(messages_allowlist); a++) {
 		struct i2c_dt_spec *allowed = &messages_allowlist[a];
@@ -48,7 +48,7 @@ void i2c_dump_msgs_rw(const struct device *dev, const struct i2c_msg *msgs, uint
 		if (dev != allowed->bus || addr != allowed->addr) {
 			continue;
 		} else {
-			found_dev = 1;
+			found_dev = true;
 			break;
 		}
 	}

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -823,7 +823,7 @@ int IRAM_ATTR esp_intr_disable(intr_handle_t handle)
 	}
 	unsigned int key = irq_lock();
 	int source;
-	bool disabled = 1;
+	bool disabled = true;
 
 	if (handle->shared_vector_desc) {
 		handle->shared_vector_desc->disabled = 1;
@@ -834,7 +834,7 @@ int IRAM_ATTR esp_intr_disable(intr_handle_t handle)
 		assert(svd != NULL);
 		while (svd) {
 			if (svd->source == source && svd->disabled == 0) {
-				disabled = 0;
+				disabled = false;
 				break;
 			}
 			svd = svd->next;

--- a/drivers/memc/memc_smartbond_nor_psram.c
+++ b/drivers/memc/memc_smartbond_nor_psram.c
@@ -126,7 +126,7 @@ static void memc_automode_configure(void)
 static bool memc_jedec_read_and_verify_id(QSPIC_TYPE qspi_id)
 {
 	uint16_t device_density;
-	bool ret = 0;
+	bool ret = false;
 	qspi_memory_id_t memory_id;
 
 	da1469x_qspi_memory_jedec_read_id(qspi_id, &memory_id);

--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -50,7 +50,7 @@ void iis3dwb_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	const struct iis3dwb_config *config = dev->config;
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
 	struct trigger_config trig_cfg = {0};
-	bool cfg_changed = 0;
+	bool cfg_changed = false;
 
 	gpio_pin_interrupt_configure_dt(iis3dwb->drdy_gpio, GPIO_INT_DISABLE);
 
@@ -79,13 +79,13 @@ void iis3dwb_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 
 		/* enable/disable the FIFO */
 		iis3dwb_config_fifo(dev, trig_cfg);
-		cfg_changed = 1;
+		cfg_changed = true;
 	}
 
 	/* if any change in trig_cfg for DRDY triggers */
 	if (trig_cfg.int_drdy != iis3dwb->trig_cfg.int_drdy) {
 		iis3dwb->trig_cfg.int_drdy = trig_cfg.int_drdy;
-		cfg_changed = 1;
+		cfg_changed = true;
 	}
 
 	if (!cfg_changed) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -712,7 +712,7 @@ TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
 #endif
 bool z_thread_prio_set(struct k_thread *thread, int prio)
 {
-	bool need_sched = 0;
+	bool need_sched = false;
 	int old_prio = thread->base.prio;
 
 	K_SPINLOCK(&_sched_spinlock) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -213,7 +213,7 @@ static void isr_rx(void *param)
 
 #if defined(CONFIG_BT_CTLR_DF_CTE_RX)
 	bool cte_ready;
-	bool cte_ok = 0;
+	bool cte_ok = false;
 #endif /* CONFIG_BT_CTLR_DF_CTE_RX */
 
 	/* Read radio status and events */

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3226,14 +3226,14 @@ static int cmd_set_power_report_enable(const struct shell *sh, size_t argc, char
 {
 	if (argc < 4) {
 		int err = 0;
-		bool local_enable = 0;
-		bool remote_enable = 0;
+		bool local_enable = false;
+		bool remote_enable = false;
 
 		if (*argv[1] == '1') {
-			local_enable = 1;
+			local_enable = true;
 		}
 		if (*argv[2] == '1') {
-			remote_enable = 1;
+			remote_enable = true;
 		}
 		if (default_conn == NULL) {
 			shell_error(sh, "Conn handle error, at least one connection is required.");

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -373,7 +373,7 @@ void z_impl_test_arm_user_interrupt_syscall(void)
 	zassert_false(__get_PRIMASK(), "PRIMASK is set\n");
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 
-	static bool first_call = 1;
+	static bool first_call = true;
 
 	if (first_call == 1) {
 

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
@@ -42,7 +42,7 @@ static volatile uint8_t g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
-static volatile bool g_aics_active = 1;
+static volatile bool g_aics_active = true;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
 

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -51,7 +51,7 @@ static volatile uint8_t g_aics_input_type;
 static volatile uint8_t g_aics_units;
 static volatile uint8_t g_aics_gain_max;
 static volatile uint8_t g_aics_gain_min;
-static volatile bool g_aics_active = 1;
+static volatile bool g_aics_active = true;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
 


### PR DESCRIPTION
As per Zephyr [coding guideline #59](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#:~:text=Operands%20shall%20not%20be%20of%20an%20inappropriate%20essential%20type), "operands shall not be of an inappropriate essential type". This makes sure boolean variables are initialized and used with proper essential type (true/false).

I am sure there are still many offenders but this should at least take care of all variables that add bad initilization code (and might have later been used with inappropriate type too, which I should have also fixed)