### PR TITLE
shields: g1120b0mipi: change vendor to NXP

### DIFF
--- a/boards/shields/g1120b0mipi/shield.yml
+++ b/boards/shields/g1120b0mipi/shield.yml
@@ -1,6 +1,7 @@
 shield:
   name: g1120b0mipi
   full_name: G1120B0 MIPI Display Shield
-  vendor: boe
+  vendor: nxp
   supported_features:
     - display
+    - input


### PR DESCRIPTION
BOE manufactures the display panel.  But G1120B0MIPI is an NXP part number, designed specifically for NXP evaluation boards, and sold by NXP.  And the Zephyr shield is supported and maintained by NXP.