### PR TITLE
shields: nxp: discontinued shields and replacements

### DIFF
--- a/boards/shields/frdm_stbc_agm01/doc/index.rst
+++ b/boards/shields/frdm_stbc_agm01/doc/index.rst
@@ -6,6 +6,8 @@ NXP FRDM-STBC-AGM01
 Overview
 ********
 
+The FRDM-STBC-AGM01 product is no longer manufactured (discontinued).
+
 The FRDM-STBC-AGM01 is an NXP Freedom development board with
 FXOS8700 and FXAS21002. This 9-axis solution (FXAS21002C Gyroscope,
 + FXOS8700CQ E-compass sensor) is compatible with any board that

--- a/boards/shields/rk043fn02h_ct/doc/index.rst
+++ b/boards/shields/rk043fn02h_ct/doc/index.rst
@@ -6,6 +6,9 @@ NXP RK043FN02H-CT Parallel Display
 Overview
 ********
 
+This display panel is no longer manufactured. The replacement for this LCD is
+the :ref:`rk043fn66hs_ctg` 4.3-inch LCD shield.
+
 RK043FN02H-CT is a 4.3 inch TFT 480*272 pixels with LED backlight and
 capacitive touch panel from Rocktech. This LCD panel can work with several i.MX
 RT EVKs and LPC MCUs for evaluation of applications with display.

--- a/boards/shields/rk055hdmipi4m/doc/index.rst
+++ b/boards/shields/rk055hdmipi4m/doc/index.rst
@@ -6,6 +6,9 @@ NXP RK055HDMIPI4M MIPI Display
 Overview
 ********
 
+This product is not recommended for new designs. The replacement for this
+LCD is the :ref:`rk055hdmipi4ma0` 5.5-inch LCD Panel.
+
 The Rocktech RK055HDMIPI4M MIPI Display is a 5.5 inch TFT 720x1280 pixels
 panel with LED backlighting, full viewing angle, MIPI interface and
 capacitive touch panel from Rocktech.


### PR DESCRIPTION
* rk055hdmipi4m: not recommended for new designs, and replaced by rk055hdmipi4ma0
* rk043fn02h_ct: no longer manufactured, and replaced by rk043fn66hs_ctg
* frdm_stbc_agm01: discontinued