### PR TITLE
samples: ipm: esp32: fix board qualifier separator in sysbuild

### DIFF
--- a/samples/boards/espressif/flash_ipm/sysbuild.cmake
+++ b/samples/boards/espressif/flash_ipm/sysbuild.cmake
@@ -4,7 +4,7 @@
 
 # Prepare the full board name to be used for the remote target
 string(REPLACE "procpu" "appcpu" REMOTE_CPU "${BOARD_QUALIFIERS}")
-string(CONFIGURE "${BOARD}${REMOTE_CPU}" IPM_REMOTE_BOARD)
+string(CONFIGURE "${BOARD}/${REMOTE_CPU}" IPM_REMOTE_BOARD)
 
 if(${REMOTE_CPU} STREQUAL ${BOARD_QUALIFIERS})
   # Make sure the remote build is using different target than host CPU

--- a/samples/drivers/ipm/ipm_esp32/sysbuild.cmake
+++ b/samples/drivers/ipm/ipm_esp32/sysbuild.cmake
@@ -4,7 +4,7 @@
 
 # Prepare the full board name to be used for the remote target
 string(REPLACE "procpu" "appcpu" REMOTE_CPU "${BOARD_QUALIFIERS}")
-string(CONFIGURE "${BOARD}${REMOTE_CPU}" IPM_REMOTE_BOARD)
+string(CONFIGURE "${BOARD}/${REMOTE_CPU}" IPM_REMOTE_BOARD)
 
 if(${REMOTE_CPU} STREQUAL ${BOARD_QUALIFIERS})
   # Make sure the remote build is using different target than host CPU


### PR DESCRIPTION
Follow-up to PR https://github.com/zephyrproject-rtos/zephyr/pull/102385.

After the BOARD_QUALIFIERS alignment between CMake and Kconfig, the CMake variable no longer has a leading '/'. Add the separator explicitly when constructing IPM_REMOTE_BOARD.

