### PR TITLE
MAINTAINERS: add iia as collaborator for NXP K32L

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3712,6 +3712,13 @@ NXP Platforms (MCU):
         - boards/nxp/vmu*/
         - boards/nxp/rddrone_fmuk66/
         - tests/boards/vmu_rt1170/
+    - name: NXP MCU k32l
+      collaborators:
+        - iia
+      files:
+        - boards/nxp/frdm_k32l2b3/
+        - dts/arm/nxp/nxp_k32l2b3.dtsi
+        - soc/nxp/kinetis/k32lx/
   labels:
     - "platform: NXP MCU"
     - "platform: NXP"


### PR DESCRIPTION
Adds @iia as collaborator who contributed the K32L SOC support and frdm_k32l2b3 board so they can help maintain this platform support.  Contributions include https://github.com/zephyrproject-rtos/zephyr/pull/91932/  and https://github.com/zephyrproject-rtos/zephyr/pull/92368 .