### PR TITLE
doc: fix incorrect default value of CONFIG_PRIORITY_CEILING

### DIFF
--- a/doc/kernel/services/synchronization/mutexes.rst
+++ b/doc/kernel/services/synchronization/mutexes.rst
@@ -73,7 +73,7 @@ that mutex.
 .. note::
     The :kconfig:option:`CONFIG_PRIORITY_CEILING` configuration option limits
     how high the kernel can raise a thread's priority due to priority
-    inheritance. The default value of 0 permits unlimited elevation.
+    inheritance. The default value of -127 permits unlimited elevation.
 
 The owning thread's base priority is saved in the mutex when it obtains the
 lock. Each time a higher priority thread waits on a mutex, the kernel adjusts


### PR DESCRIPTION
Fixes :  #103240

Summary:
The mutex documentation incorrectly states that CONFIG_PRIORITY_CEILING defaults to 0 , changed it to the actual default defined in Kconfig is -127 .
