### PR TITLE
scripts: coccinelle: add MISRA 10.1 boolean essential type check

### DIFF
--- a/scripts/ci/guideline_check.py
+++ b/scripts/ci/guideline_check.py
@@ -17,6 +17,8 @@ RESERVED_NAMES_SCRIPT = "/scripts/coccinelle/reserved_names.cocci"
 coccinelle_scripts = [
     RESERVED_NAMES_SCRIPT,
     "/scripts/coccinelle/same_identifier.cocci",
+    "/scripts/coccinelle/boolean_strict_init.cocci",
+    # "/scripts/coccinelle/boolean.cocci",  # Rule 14.4 - disabled (timeout)
     # "/scripts/coccinelle/identifier_length.cocci",
 ]
 

--- a/scripts/coccinelle/boolean.cocci
+++ b/scripts/coccinelle/boolean.cocci
@@ -1,5 +1,15 @@
-// Check violations for rule 14.4
+// Check violations for MISRA C:2012 Rule 14.4
 // https://gitlab.com/MISRA/MISRA-C/MISRA-C-2012/Example-Suite/-/blob/master/R_14_04.c
+//
+// Rule 14.4: Controlling expression shall have essentially Boolean type
+//
+// NOTE: This script is NOT enabled in CI (guideline_check.py) because it
+// causes timeouts on large files due to expensive type resolution needed
+// to check if variables in if/while conditions are boolean-typed.
+// See: https://github.com/zephyrproject-rtos/zephyr/pull/34773
+//
+// For Rule 10.1 (bool = 0/1), use boolean_strict_init.cocci instead,
+// which uses simple pattern matching and is fast enough for CI.
 //
 // Confidence: Moderate
 // Copyright: (C) 2021 Intel Corporation

--- a/scripts/coccinelle/boolean_strict_init.cocci
+++ b/scripts/coccinelle/boolean_strict_init.cocci
@@ -1,0 +1,63 @@
+// Check violations for MISRA C:2012 Rule 10.1 (boolean essential type)
+// https://gitlab.com/MISRA/MISRA-C/MISRA-C-2012/Example-Suite/-/blob/master/R_10_01.c
+//
+// Rule 10.1: Operands shall not be of an inappropriate essential type
+//            (boolean variables shall use true/false, not 0/1)
+//
+// This enforces Zephyr coding guideline #59 which requires boolean
+// variables to be initialized and assigned with true/false literals.
+//
+// Confidence: High
+// Copyright: (C) 2026 Espressif Systems (Shanghai) Co., Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+virtual report
+
+// Rule 10.1: Boolean initialization with integer literal
+// Detect: bool var = 0; or bool var = 1;
+// Note: Coccinelle matches type regardless of storage class specifiers
+@rule1_init@
+identifier v;
+position p;
+@@
+(
+bool v@p = 0;
+|
+bool v@p = 1;
+)
+
+@ script:python @
+p << rule1_init.p;
+@@
+
+msg = "WARNING: Violation to rule 10.1 (Boolean variable initialized with integer literal, use true/false)"
+coccilib.report.print_report(p[0], msg)
+
+// Rule 10.1: Boolean assignment with integer literal
+// Detect: bool_var = 0; or bool_var = 1;
+@rule2_assign_base@
+identifier v;
+@@
+(
+bool v;
+|
+bool v = ...;
+)
+
+@rule2_assign@
+identifier rule2_assign_base.v;
+position p;
+@@
+(
+v@p = 0;
+|
+v@p = 1;
+)
+
+@ script:python @
+p << rule2_assign.p;
+@@
+
+msg = "WARNING: Violation to rule 10.1 (Boolean variable assigned integer literal, use true/false)"
+coccilib.report.print_report(p[0], msg)


### PR DESCRIPTION
## Summary

Add `boolean_strict_init.cocci` to detect improper boolean initialization and assignment using integer literals (0/1) instead of true/false.

This enforces Zephyr coding guideline (MISRA C:2012 Rule 10.1) which states that operands shall not be of an inappropriate essential type.

### Changes

- Add new `boolean_strict_init.cocci` with rules for detecting:
  - `bool var = 0/1` initialization
  - `bool_var = 0/1` assignment
- Enable `boolean_strict_init.cocci` in `guideline_check.py` so CI runs this check on changed files
- Keep original `boolean.cocci` (Rule 14.4) disabled due to performance issues causing CI timeouts on large files (see #34773)

### Fixes issues like

```c
bool foo = 0;      /* should be: bool foo = false; */
bool bar = 1;      /* should be: bool bar = true;  */

foo = 0;           /* should be: foo = false; */
bar = 1;           /* should be: bar = true;  */
```

CI output:
```
Error: scripts/coccinelle/test_boolean.c:11:WARNING: Violation to rule 10.1 (Boolean variable initialized with integer literal, use true/false)
scripts/coccinelle/test_boolean.c:12:WARNING: Violation to rule 10.1 (Boolean variable initialized with integer literal, use true/false)
scripts/coccinelle/test_boolean.c:15:WARNING: Violation to rule 10.1 (Boolean variable assigned integer literal, use true/false)
scripts/coccinelle/test_boolean.c:16:WARNING: Violation to rule 10.1 (Boolean variable assigned integer literal, use true/false)
Error: Process completed with exit code 1.
```

Why a separate file?
The original boolean.cocci contains Rule 14.4 checks (controlling expressions must be boolean type) which require expensive type resolution and cause CI timeouts on large files. The new Rule 10.1 checks use simple pattern matching and are fast enough for CI.