### PR TITLE
serial: uart_mchp_xec: fix TX complete status check

### DIFF
--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -632,7 +632,7 @@ static int uart_xec_irq_tx_complete(const struct device *dev)
 	/* TX FIFO holding register empty interrupt enabled OR
 	 * both TX holding and shift registers are empty.
 	 */
-	if (((ier & XEC_UART_IER_ETHREI) != 0) || ((lsr & lsr_msk) == lsr_msk)) {
+	if (((ier & XEC_UART_IER_ETHREI) != 0) || ((lsr & lsr_msk) != lsr_msk)) {
 		ret = 0;
 	} else {
 		ret = 1;


### PR DESCRIPTION
Fix the logic in `uart_xec_irq_tx_complete` when evaluating the UART line status register against the TX-empty mask. The previous condition could report "TX complete" even when the TX path was not fully empty, which can cause flush users to loop or make incorrect progress decisions.

This change corrects the comparison against the TX-empty mask so that the function only reports completion when the hardware indicates the expected empty state.