### PR TITLE
boards: arduino: uno_r4: Add `arduino_serial`

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
@@ -105,3 +105,5 @@
 arduino_i2c: &iic1 {};
 
 arduino_spi: &spi1 {};
+
+arduino_serial: &uart2 {};

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -124,3 +124,5 @@ zephyr_i2c: &iic0 {};
 arduino_i2c: &iic1 {};
 
 arduino_spi: &spi0 {};
+
+arduino_serial: &uart2 {};


### PR DESCRIPTION
Add `arduino_serial` alias for improve compatibility for arduino sheilds.