### PR TITLE
[soc][st] enable DMA2D acceleration on stm32f4 series with LVGL

### DIFF
--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig
@@ -35,4 +35,11 @@ config IDLE_STACK_SIZE
 
 endif # PM
 
+if LVGL
+
+config LV_DRAW_DMA2D_HAL_INCLUDE
+	default "stm32f4xx.h"
+
+endif # LVGL
+
 endif # SOC_SERIES_STM32F4X


### PR DESCRIPTION
This PR enables DMA2D acceleration with LVGL on stm32f4xx series 
Tested ok on stm32f469i_disco board