### PR TITLE
Bluetooth: CAP: Acceptor: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/cap_acceptor.c
+++ b/subsys/bluetooth/audio/cap_acceptor.c
@@ -16,7 +16,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util_macro.h>
 
 #include "cap_internal.h"
@@ -36,12 +35,12 @@ int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *par
 	static struct bt_gatt_service cas;
 	int err;
 
-	CHECKIF(param->set_size == 0U) {
+	if (param->set_size == 0U) {
 		LOG_DBG("param->set_size shall be non-zero");
 		return -EINVAL;
 	}
 
-	CHECKIF(param->rank == 0U) {
+	if (param->rank == 0U) {
 		LOG_DBG("param->rank shall be non-zero");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.