### PR TITLE
Bluetooth: CAP: Commander: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -26,7 +26,6 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -46,13 +45,13 @@ static const struct bt_cap_commander_cb *cap_cb;
 
 int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(cap_cb != NULL) {
+	if (cap_cb != NULL) {
 		LOG_DBG("callbacks already registered");
 
 		return -EALREADY;
@@ -65,12 +64,12 @@ int bt_cap_commander_register_cb(const struct bt_cap_commander_cb *cb)
 
 int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(cap_cb != cb) {
+	if (cap_cb != cb) {
 		LOG_DBG("cb is not registered");
 		return -EINVAL;
 	}
@@ -92,7 +91,7 @@ cap_commander_discover_complete(struct bt_conn *conn, int err,
 
 int bt_cap_commander_discover(struct bt_conn *conn)
 {
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -174,23 +173,23 @@ static bool valid_broadcast_reception_start_param(
 {
 	uint32_t total_bis_sync = 0U;
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %zu", param->count);
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
 	}
 
-	CHECKIF(param->param == NULL) {
+	if (param->param == NULL) {
 		LOG_DBG("param->param is NULL");
 		return false;
 	}
@@ -212,34 +211,34 @@ static bool valid_broadcast_reception_start_param(
 			return false;
 		}
 
-		CHECKIF(start_param->addr.type > BT_ADDR_LE_RANDOM) {
+		if (start_param->addr.type > BT_ADDR_LE_RANDOM) {
 			LOG_DBG("Invalid address type %u", start_param->addr.type);
 			return false;
 		}
 
-		CHECKIF(start_param->adv_sid > BT_GAP_SID_MAX) {
+		if (start_param->adv_sid > BT_GAP_SID_MAX) {
 			LOG_DBG("param->param[%zu]->adv_sid is larger than %d", i, BT_GAP_SID_MAX);
 			return false;
 		}
 
-		CHECKIF(!IN_RANGE(start_param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
-				  BT_GAP_PER_ADV_MAX_INTERVAL)) {
+		if (!IN_RANGE(start_param->pa_interval, BT_GAP_PER_ADV_MIN_INTERVAL,
+			      BT_GAP_PER_ADV_MAX_INTERVAL)) {
 			LOG_DBG("param->param[%zu]->pa_interval is out of range", i);
 			return false;
 		}
 
-		CHECKIF(start_param->broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
+		if (start_param->broadcast_id > BT_AUDIO_BROADCAST_ID_MAX) {
 			LOG_DBG("param->param[%zu]->broadcast_id is larger than %u", i,
 				BT_AUDIO_BROADCAST_ID_MAX);
 			return false;
 		}
 
-		CHECKIF(start_param->num_subgroups == 0) {
+		if (start_param->num_subgroups == 0) {
 			LOG_DBG("param->param[%zu]->num_subgroups is 0", i);
 			return false;
 		}
 
-		CHECKIF(start_param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
+		if (start_param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
 			LOG_DBG("Too many subgroups %u/%u", start_param->num_subgroups,
 				CONFIG_BT_BAP_BASS_MAX_SUBGROUPS);
 
@@ -251,14 +250,14 @@ static bool valid_broadcast_reception_start_param(
 			const struct bt_bap_bass_subgroup *param_subgroups =
 				&start_param->subgroups[j];
 
-			CHECKIF(!valid_bis_syncs(param_subgroups->bis_sync)) {
+			if (!valid_bis_syncs(param_subgroups->bis_sync)) {
 				LOG_DBG("param->param[%zu].subgroup[%zu].bis_sync is invalid %u", i,
 					j, param_subgroups->bis_sync);
 
 				return false;
 			}
 
-			CHECKIF((total_bis_sync & param_subgroups->bis_sync) != 0) {
+			if ((total_bis_sync & param_subgroups->bis_sync) != 0) {
 				LOG_DBG("param->param[%zu].subgroup[%zu].bis_sync 0x%08X has "
 					"duplicate bits (0x%08X) ",
 					i, j, param_subgroups->bis_sync, total_bis_sync);
@@ -268,8 +267,8 @@ static bool valid_broadcast_reception_start_param(
 
 			total_bis_sync |= param_subgroups->bis_sync;
 
-			CHECKIF(param_subgroups->metadata_len >
-				CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {
+			if (param_subgroups->metadata_len >
+			    CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {
 				LOG_DBG("param->param[%zu].subgroup[%zu].metadata_len too long "
 					"%u/%u",
 					i, j, param_subgroups->metadata_len,
@@ -278,9 +277,9 @@ static bool valid_broadcast_reception_start_param(
 				return false;
 			}
 #if defined(CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE)
-			CHECKIF(param_subgroups->metadata_len > 0 &&
-				!bt_audio_valid_ltv(param_subgroups->metadata,
-						    param_subgroups->metadata_len)) {
+			if (param_subgroups->metadata_len > 0 &&
+			    !bt_audio_valid_ltv(param_subgroups->metadata,
+						param_subgroups->metadata_len)) {
 				LOG_DBG("param->param[%zu].subgroup[%zu].metadata not valid LTV", i,
 					j);
 			}
@@ -524,23 +523,23 @@ static void cap_commander_broadcast_assistant_mod_src_cb(struct bt_conn *conn, i
 bool bt_cap_commander_valid_broadcast_reception_stop_param(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %zu", param->count);
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
 	}
 
-	CHECKIF(param->param == NULL) {
+	if (param->param == NULL) {
 		LOG_DBG("param->param is NULL");
 		return false;
 	}
@@ -562,12 +561,12 @@ bool bt_cap_commander_valid_broadcast_reception_stop_param(
 			return false;
 		}
 
-		CHECKIF(stop_param->num_subgroups == 0) {
+		if (stop_param->num_subgroups == 0) {
 			LOG_DBG("param->param[%zu]->num_subgroups is 0", i);
 			return false;
 		}
 
-		CHECKIF(stop_param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
+		if (stop_param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
 			LOG_DBG("Too many subgroups %u/%u", stop_param->num_subgroups,
 				CONFIG_BT_BAP_BASS_MAX_SUBGROUPS);
 			return false;
@@ -725,23 +724,23 @@ static void cap_commander_broadcast_assistant_set_broadcast_code_cb(struct bt_co
 static bool valid_distribute_broadcast_code_param(
 	const struct bt_cap_commander_distribute_broadcast_code_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %zu", param->count);
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
 	}
 
-	CHECKIF(param->param == NULL) {
+	if (param->param == NULL) {
 		LOG_DBG("param->param is NULL");
 		return false;
 	}
@@ -1010,22 +1009,22 @@ static int cap_commander_register_vcp_cb(void)
 
 static bool valid_change_volume_param(const struct bt_cap_commander_change_volume_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %u", param->count);
 		return false;
 	}
 
-	CHECKIF(param->members == NULL) {
+	if (param->members == NULL) {
 		LOG_DBG("param->members is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
@@ -1190,22 +1189,22 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 static bool valid_change_volume_mute_state_param(
 	const struct bt_cap_commander_change_volume_mute_state_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %u", param->count);
 		return false;
 	}
 
-	CHECKIF(param->members == NULL) {
+	if (param->members == NULL) {
 		LOG_DBG("param->members is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
@@ -1226,7 +1225,7 @@ static bool valid_change_volume_mute_state_param(
 			return false;
 		}
 
-		CHECKIF(bt_vcp_vol_ctlr_get_by_conn(member_conn) == NULL) {
+		if (bt_vcp_vol_ctlr_get_by_conn(member_conn) == NULL) {
 			LOG_DBG("Volume control not available for param->members[%zu]", i);
 			return false;
 		}
@@ -1234,7 +1233,7 @@ static bool valid_change_volume_mute_state_param(
 		for (size_t j = 0U; j < i; j++) {
 			const union bt_cap_set_member *other = &param->members[j];
 
-			CHECKIF(other == member) {
+			if (other == member) {
 				LOG_DBG("param->members[%zu] (%p) is duplicated by "
 					"param->members[%zu] (%p)",
 					j, other, i, member);
@@ -1381,22 +1380,22 @@ int bt_cap_commander_change_volume_mute_state(
 static bool
 valid_change_offset_param(const struct bt_cap_commander_change_volume_offset_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %u", param->count);
 		return false;
 	}
 
-	CHECKIF(param->param == NULL) {
+	if (param->param == NULL) {
 		LOG_DBG("param->param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
@@ -1630,22 +1629,22 @@ static int cap_commander_register_micp_callbacks(void)
 static bool valid_change_microphone_mute_state_param(
 	const struct bt_cap_commander_change_microphone_mute_state_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %u", param->count);
 		return false;
 	}
 
-	CHECKIF(param->members == NULL) {
+	if (param->members == NULL) {
 		LOG_DBG("param->members is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;
@@ -1666,7 +1665,7 @@ static bool valid_change_microphone_mute_state_param(
 			return false;
 		}
 
-		CHECKIF(bt_micp_mic_ctlr_get_by_conn(member_conn) == NULL) {
+		if (bt_micp_mic_ctlr_get_by_conn(member_conn) == NULL) {
 			LOG_DBG("Microphone control not available for param->members[%zu]", i);
 			return false;
 		}
@@ -1674,7 +1673,7 @@ static bool valid_change_microphone_mute_state_param(
 		for (size_t j = 0U; j < i; j++) {
 			const union bt_cap_set_member *other = &param->members[j];
 
-			CHECKIF(other == member) {
+			if (other == member) {
 				LOG_DBG("param->members[%zu] (%p) is duplicated by "
 					"param->members[%zu] (%p)",
 					j, other, i, member);
@@ -1822,22 +1821,22 @@ int bt_cap_commander_change_microphone_mute_state(
 static bool valid_change_microphone_gain_param(
 	const struct bt_cap_commander_change_microphone_gain_setting_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count == 0) {
+	if (param->count == 0) {
 		LOG_DBG("Invalid param->count: %u", param->count);
 		return false;
 	}
 
-	CHECKIF(param->param == NULL) {
+	if (param->param == NULL) {
 		LOG_DBG("param->param is NULL");
 		return false;
 	}
 
-	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+	if (param->count > CONFIG_BT_MAX_CONN) {
 		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
 			CONFIG_BT_MAX_CONN);
 		return false;

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -246,11 +246,6 @@ static bool valid_broadcast_reception_start_param(
 			return false;
 		}
 
-		CHECKIF(start_param->subgroups == NULL) {
-			LOG_DBG("param->param[%zu]->subgroup is NULL", i);
-			return false;
-		}
-
 		total_bis_sync = 0U;
 		for (size_t j = 0U; j < start_param->num_subgroups; j++) {
 			const struct bt_bap_bass_subgroup *param_subgroups =


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.