### PR TITLE
Bluetooth: CAP: Stream: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -19,7 +19,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -337,7 +336,7 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream,
 #if defined(CONFIG_BT_AUDIO_TX)
 int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num)
 {
-	CHECKIF(stream == NULL) {
+	if (stream == NULL) {
 		LOG_DBG("stream is NULL");
 
 		return -EINVAL;
@@ -349,7 +348,7 @@ int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16
 int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts)
 {
-	CHECKIF(stream == NULL) {
+	if (stream == NULL) {
 		LOG_DBG("stream is NULL");
 
 		return -EINVAL;
@@ -360,7 +359,7 @@ int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uin
 
 int bt_cap_stream_get_tx_sync(struct bt_cap_stream *stream, struct bt_iso_tx_info *info)
 {
-	CHECKIF(stream == NULL) {
+	if (stream == NULL) {
 		LOG_DBG("stream is NULL");
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.