### PR TITLE
Bluetooth: CSIP: Coordinator: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -44,7 +44,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/types.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/byteorder.h>
 
 #include "csip_crypto.h"
@@ -1387,13 +1386,13 @@ struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_h
 {
 	const struct bt_csip_set_coordinator_svc_inst *svc_inst;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return NULL;
 	}
 
-	CHECKIF(start_handle == 0) {
+	if (start_handle == 0) {
 		LOG_DBG("start_handle is 0");
 
 		return NULL;
@@ -1417,7 +1416,7 @@ bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn)
 {
 	struct bt_csip_set_coordinator_inst *client;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return NULL;
@@ -1434,7 +1433,7 @@ bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn)
 /*************************** PUBLIC FUNCTIONS ***************************/
 int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 
 		return -EINVAL;
@@ -1450,7 +1449,7 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 	int err;
 	struct bt_csip_set_coordinator_inst *client;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -1505,14 +1504,14 @@ static int verify_members(const struct bt_csip_set_coordinator_set_member **memb
 		struct bt_csip_set_coordinator_svc_inst *svc_inst;
 		struct bt_conn *conn;
 
-		CHECKIF(member == NULL) {
+		if (member == NULL) {
 			LOG_DBG("Invalid member[%d] was NULL", i);
 			return -EINVAL;
 		}
 
 		conn = client_inst->conn;
 
-		CHECKIF(conn == NULL) {
+		if (conn == NULL) {
 			LOG_DBG("Member[%d] conn was NULL", i);
 			return -EINVAL;
 		}
@@ -1704,7 +1703,7 @@ int bt_csip_set_coordinator_lock(
 	struct bt_csip_set_coordinator_svc_inst *svc_inst;
 	int err;
 
-	CHECKIF(active.in_progress) {
+	if (active.in_progress) {
 		LOG_DBG("Procedure in progress");
 		return -EBUSY;
 	}
@@ -1750,7 +1749,7 @@ int bt_csip_set_coordinator_release(const struct bt_csip_set_coordinator_set_mem
 	struct bt_csip_set_coordinator_svc_inst *svc_inst;
 	int err;
 
-	CHECKIF(active.in_progress) {
+	if (active.in_progress) {
 		LOG_DBG("Procedure in progress");
 		return -EBUSY;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.