### PR TITLE
Bluetooth: CSIP: Member: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -36,7 +36,6 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 
 #include "../host/conn_internal.h"
 #include "../host/keys.h"
@@ -1039,12 +1038,12 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
 	struct bt_csip_set_member_svc_inst *inst;
 	int err;
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("NULL param");
 		return -EINVAL;
 	}
 
-	CHECKIF(!valid_register_param(param)) {
+	if (!valid_register_param(param)) {
 		LOG_DBG("Invalid parameters");
 		return -EINVAL;
 	}
@@ -1125,7 +1124,7 @@ int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst)
 {
 	int err;
 
-	CHECKIF(svc_inst == NULL) {
+	if (svc_inst == NULL) {
 		LOG_DBG("NULL svc_inst");
 		return -EINVAL;
 	}
@@ -1160,12 +1159,12 @@ int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst)
 int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
 			    const uint8_t sirk[BT_CSIP_SIRK_SIZE])
 {
-	CHECKIF(svc_inst == NULL) {
+	if (svc_inst == NULL) {
 		LOG_DBG("NULL svc_inst");
 		return -EINVAL;
 	}
 
-	CHECKIF(sirk == NULL) {
+	if (sirk == NULL) {
 		LOG_DBG("NULL SIRK");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.