### PR TITLE
Bluetooth: GMAP: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -20,7 +20,6 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 
 #include "audio_internal.h"
 
@@ -647,7 +646,7 @@ int bt_gmap_discover(struct bt_conn *conn)
 	struct bt_gmap_client *gmap_cli;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 
 		return -EINVAL;
@@ -685,7 +684,7 @@ int bt_gmap_discover(struct bt_conn *conn)
 
 int bt_gmap_cb_register(const struct bt_gmap_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 
 		return -EINVAL;

--- a/subsys/bluetooth/audio/gmap_server.c
+++ b/subsys/bluetooth/audio/gmap_server.c
@@ -16,7 +16,6 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -346,13 +345,13 @@ int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features)
 {
 	int err;
 
-	CHECKIF(!valid_gmap_role(role)) {
+	if (!valid_gmap_role(role)) {
 		LOG_DBG("Invalid role: %d", role);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!valid_gmap_features(role, features)) {
+	if (!valid_gmap_features(role, features)) {
 		LOG_DBG("Invalid features");
 
 		return -EINVAL;
@@ -383,13 +382,13 @@ int bt_gmap_set_role(enum bt_gmap_role role, struct bt_gmap_feat features)
 		return -ENOEXEC;
 	}
 
-	CHECKIF(!valid_gmap_role(role)) {
+	if (!valid_gmap_role(role)) {
 		LOG_DBG("Invalid role: %d", role);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!valid_gmap_features(role, features)) {
+	if (!valid_gmap_features(role, features)) {
 		LOG_DBG("Invalid features");
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.