### PR TITLE
Bluetooth: HAS: Client: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -20,7 +20,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
@@ -815,11 +814,11 @@ static int features_discover(struct bt_has_client *inst)
 
 int bt_has_client_cb_register(const struct bt_has_client_cb *cb)
 {
-	CHECKIF(!cb) {
+	if (!cb) {
 		return -EINVAL;
 	}
 
-	CHECKIF(client_cb) {
+	if (client_cb) {
 		return -EALREADY;
 	}
 
@@ -843,7 +842,7 @@ int bt_has_client_discover(struct bt_conn *conn)
 
 	LOG_DBG("conn %p", (void *)conn);
 
-	CHECKIF(!conn || !client_cb || !client_cb->discover) {
+	if (!conn || !client_cb || !client_cb->discover) {
 		return -EINVAL;
 	}
 
@@ -893,11 +892,11 @@ int bt_has_client_presets_read(struct bt_has *has, uint8_t start_index, uint8_t 
 		return -EBUSY;
 	}
 
-	CHECKIF(start_index == BT_HAS_PRESET_INDEX_NONE) {
+	if (start_index == BT_HAS_PRESET_INDEX_NONE) {
 		return -EINVAL;
 	}
 
-	CHECKIF(count == 0u) {
+	if (count == 0u) {
 		return -EINVAL;
 	}
 
@@ -920,7 +919,7 @@ int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync)
 		return -ENOTCONN;
 	}
 
-	CHECKIF(index == BT_HAS_PRESET_INDEX_NONE) {
+	if (index == BT_HAS_PRESET_INDEX_NONE) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.