### PR TITLE
Bluetooth: MCC: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -31,7 +31,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/types.h>
@@ -2095,7 +2094,7 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
@@ -2143,7 +2142,7 @@ int bt_mcc_read_player_name(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2182,7 +2181,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2222,7 +2221,7 @@ int bt_mcc_read_icon_url(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2262,7 +2261,7 @@ int bt_mcc_read_track_title(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2302,7 +2301,7 @@ int bt_mcc_read_track_duration(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2342,7 +2341,7 @@ int bt_mcc_read_track_position(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2382,7 +2381,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2427,7 +2426,7 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2467,7 +2466,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2512,7 +2511,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2552,7 +2551,7 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2590,7 +2589,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2628,13 +2627,13 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!BT_MCS_VALID_OBJ_ID(obj_id)) {
+	if (!BT_MCS_VALID_OBJ_ID(obj_id)) {
 		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
@@ -2675,7 +2674,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2713,13 +2712,13 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!BT_MCS_VALID_OBJ_ID(obj_id)) {
+	if (!BT_MCS_VALID_OBJ_ID(obj_id)) {
 		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
@@ -2760,7 +2759,7 @@ int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2798,7 +2797,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2836,13 +2835,13 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!BT_MCS_VALID_OBJ_ID(obj_id)) {
+	if (!BT_MCS_VALID_OBJ_ID(obj_id)) {
 		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
@@ -2885,7 +2884,7 @@ int bt_mcc_read_playing_order(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -2925,14 +2924,14 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!IN_RANGE(order, BT_MCS_PLAYING_ORDER_SINGLE_ONCE,
-			  BT_MCS_PLAYING_ORDER_SHUFFLE_REPEAT)) {
+	if (!IN_RANGE(order, BT_MCS_PLAYING_ORDER_SINGLE_ONCE,
+		      BT_MCS_PLAYING_ORDER_SHUFFLE_REPEAT)) {
 		LOG_DBG("Invalid playing order 0x%02X", order);
 
 		return -EINVAL;
@@ -2977,7 +2976,7 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3017,7 +3016,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3058,19 +3057,19 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 	size_t length;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(cmd == NULL) {
+	if (cmd == NULL) {
 		LOG_DBG("cmd is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!BT_MCS_VALID_OP(cmd->opcode)) {
+	if (!BT_MCS_VALID_OP(cmd->opcode)) {
 		LOG_DBG("Opcode 0x%02X is invalid", cmd->opcode);
 
 		return -EINVAL;
@@ -3121,7 +3120,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3161,19 +3160,19 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(search == NULL) {
+	if (search == NULL) {
 		LOG_DBG("search is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(!IN_RANGE(search->len, SEARCH_LEN_MIN, SEARCH_LEN_MAX)) {
+	if (!IN_RANGE(search->len, SEARCH_LEN_MIN, SEARCH_LEN_MAX)) {
 		LOG_DBG("Invalid search->len: %u", search->len);
 
 		return -EINVAL;
@@ -3216,7 +3215,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3256,7 +3255,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3695,7 +3694,7 @@ int bt_mcc_otc_read_object_metadata(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3728,7 +3727,7 @@ int bt_mcc_otc_read_icon_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3761,7 +3760,7 @@ int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3795,7 +3794,7 @@ int bt_mcc_otc_read_current_track_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3829,7 +3828,7 @@ int bt_mcc_otc_read_next_track_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3863,7 +3862,7 @@ int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;
@@ -3899,7 +3898,7 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn)
 	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.