### PR TITLE
Bluetooth: MICP: CTLR: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -27,7 +27,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
@@ -534,7 +533,7 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 	 * 5) When everything above have been discovered, the callback is called
 	 */
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -605,7 +604,7 @@ int bt_micp_mic_ctlr_cb_register(struct bt_micp_mic_ctlr_cb *cb)
 {
 	struct bt_micp_mic_ctlr_cb *tmp;
 
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -625,12 +624,12 @@ int bt_micp_mic_ctlr_cb_register(struct bt_micp_mic_ctlr_cb *cb)
 int bt_micp_mic_ctlr_included_get(struct bt_micp_mic_ctlr *mic_ctlr,
 				  struct bt_micp_included *included)
 {
-	CHECKIF(mic_ctlr == NULL) {
+	if (mic_ctlr == NULL) {
 		LOG_DBG("NULL mic_ctlr");
 		return -EINVAL;
 	}
 
-	CHECKIF(included == NULL) {
+	if (included == NULL) {
 		return -EINVAL;
 	}
 
@@ -645,7 +644,7 @@ struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn
 {
 	struct bt_micp_mic_ctlr *mic_ctlr;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("NULL conn pointer");
 		return NULL;
 	}
@@ -662,7 +661,7 @@ struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn
 
 int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr, struct bt_conn **conn)
 {
-	CHECKIF(mic_ctlr == NULL) {
+	if (mic_ctlr == NULL) {
 		LOG_DBG("NULL mic_ctlr pointer");
 		return -EINVAL;
 	}
@@ -681,7 +680,7 @@ int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr)
 {
 	int err;
 
-	CHECKIF(mic_ctlr == NULL) {
+	if (mic_ctlr == NULL) {
 		LOG_DBG("NULL mic_ctlr");
 		return -EINVAL;
 	}
@@ -712,7 +711,7 @@ static int bt_micp_mic_ctlr_write_mute(struct bt_micp_mic_ctlr *mic_ctlr, bool m
 {
 	int err;
 
-	CHECKIF(mic_ctlr == NULL) {
+	if (mic_ctlr == NULL) {
 		LOG_DBG("NULL mic_ctlr");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.