### PR TITLE
MAINTAINERS: Remove yonsch as collaborator for RPi Pico

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4443,7 +4443,6 @@ Raspberry Pi Pico Platforms:
   maintainers:
     - soburi
   collaborators:
-    - yonsch
     - threeeights
     - ajf58
   files:
@@ -5912,7 +5911,6 @@ West:
   maintainers:
     - soburi
   collaborators:
-    - yonsch
     - threeeights
     - ajf58
   files:


### PR DESCRIPTION
Continuing the recent trend of tidying up the maintainers.

yonsch is no longer active in maintaining the Raspberry Pi Pico board support either in terms of contributing code or reviewing PRs. I imagine they're getting a lot of noise their notifications.

@yonsch thanks for the work you've done. Please do shout if you'd like to stay as a named collaborator.