### PR TITLE
Bluetooth: TMAP: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/audio/tmap.c
+++ b/subsys/bluetooth/audio/tmap.c
@@ -23,7 +23,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
@@ -217,7 +216,7 @@ int bt_tmap_register(enum bt_tmap_role role)
 {
 	int err;
 
-	CHECKIF(!valid_tmap_role(role)) {
+	if (!valid_tmap_role(role)) {
 		LOG_DBG("Invalid role: %d", role);
 
 		return -EINVAL;


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.