### PR TITLE
dts: bindings: i3c: fix typos in bindings

### DIFF
--- a/dts/bindings/i3c/cdns,i3c.yaml
+++ b/dts/bindings/i3c/cdns,i3c.yaml
@@ -23,4 +23,4 @@ properties:
   ibid-thr:
     type: int
     default: 1
-    description: IBI Data Fifo Threashold Value
+    description: IBI Data FIFO Threshold Value

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -45,7 +45,7 @@ properties:
     description: |
       Minimum high clock pulse length (ns) in Open-Drain mode for pure bus.
       The default value is from Section 4.3.11.2 & Table 49 of the I3C
-      Basic Specifiction v1.2 (16-Dec-2024).
+      Basic Specification v1.2 (16-Dec-2024).
 
   od-tlow-min-ns:
     type: int
@@ -53,5 +53,4 @@ properties:
     description: |
       Minimum low clock pulse length (ns) in Open-Drain mode.
       The default value is from Section 4.3.11.2 & Table 49 of the I3C
-      Basic Specifiction v1.2 (16-Dec-2024).
-      Specifiction.
+      Basic Specification v1.2 (16-Dec-2024).

--- a/dts/bindings/i3c/ite,it51xxx-i3cm.yaml
+++ b/dts/bindings/i3c/ite,it51xxx-i3cm.yaml
@@ -19,7 +19,7 @@ properties:
     type: int
     enum: [0, 1, 2, 3]
     description: |
-      The it51xxx chip features four i3c io channels and two i3c cotroller
+      The it51xxx chip features four i3c io channels and two i3c controller
       (i3cm) engines. This property allows the i3cm engine to select the
       desired i3c io channel. To ensure proper i3c functionality, make sure
       that multiple controllers (including the i3cm controller and i3cs

--- a/dts/bindings/i3c/nuvoton,npcx-i3c.yaml
+++ b/dts/bindings/i3c/nuvoton,npcx-i3c.yaml
@@ -75,7 +75,7 @@ properties:
     description: |
       Target 48-bit Provisioned ID.
       array[0]: PID[47:33] MIPI manufacturer ID.
-                PID[32] ID type selector (i'b1 ramdom value, 1'b0 vendor fixed).
+                PID[32] ID type selector (i'b1 random value, 1'b0 vendor fixed).
       array[1]: PID[31:0] Random value or vendor fixed value.
 
   bcr:


### PR DESCRIPTION
Fix multiple spelling errors in I3C dts bindings descriptions.

No functional changes.