### PR TITLE
scripts: twister: minor speedup in `apply_filters`

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -889,6 +889,10 @@ class TestPlan:
             for itoolchain, plat in itertools.product(
                 ts.integration_toolchains or [None], platform_scope
             ):
+                if (plat.arch == "unit") != (ts.type == "unit"):
+                    # Discard silently
+                    continue
+
                 if itoolchain:
                     toolchain = itoolchain
                 elif plat.arch in ['posix', 'unit']:
@@ -908,10 +912,6 @@ class TestPlan:
 
                 if not force_platform and self.check_platform(plat,exclude_platform):
                     instance.add_filter("Platform is excluded on command line.", Filters.CMD_LINE)
-
-                if (plat.arch == "unit") != (ts.type == "unit"):
-                    # Discard silently
-                    continue
 
                 if ts.modules and self.modules and not set(ts.modules).issubset(set(self.modules)):
                     instance.add_filter(


### PR DESCRIPTION
Move a check to run earlier in a for-loop to minimize doing unnecessary work like creating `TestInstance` class instances.

This is a very minor optimization when the number of testsuites are low. But starts to count when there are a lot of testsuites.

I've been using this command to measure the performance of Twister configuration when it involves thousands of tests.
```
west twister -c -e test_framework -e kernel -e test_framework -e kernel -e cmsis_dsp -e posix -e wifi -e net -e mcumgr -e bluetooth --dry-run
```

The number of function calls reduces from 24878497 to  24042599 or 835k function calls. And `apply_filters` function runs about 300ms faster.

Test Method
====

In `TestPlan`'s `load` method:
```python
            import cProfile, pstats, io
            from pstats import SortKey
            pr = cProfile.Profile()
            pr.enable()

            self.apply_filters()

            pr.disable()
            s = io.StringIO()
            sortby = SortKey.CUMULATIVE
            ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
            ps.print_stats(50)
            print(s.getvalue())
```

Before
====

```
INFO    - Built testsuite list in 11.34 seconds
         24878497 function calls (24833051 primitive calls) in 11.341 seconds

   Ordered by: cumulative time
   List reduced from 262 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    1.715    1.715   11.341   11.341 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:757(apply_filters)
   159620    0.309    0.000    3.205    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:52(__init__)
    18787    0.027    0.000    2.347    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:103(setup_run_id)
    18787    0.077    0.000    2.320    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:149(_get_run_id)
   159620    0.207    0.000    1.598    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:145(init_cases)
45582/26120    0.047    0.000    1.494    0.000 <frozen os>:200(makedirs)
  1042015    1.112    0.000    1.391    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:196(add_testcase)
   366863    0.869    0.000    1.365    0.000 <frozen posixpath>:71(join)
    45582    1.121    0.000    1.121    0.000 {built-in method posix.mkdir}
    83414    0.255    0.000    0.857    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:168(add_missing_case_status)
    26456    0.690    0.000    0.709    0.000 {built-in method _io.open}
   159620    0.207    0.000    0.685    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:282(check_runnable)
    18787    0.050    0.000    0.650    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:341(create_overlay)
   558750    0.239    0.000    0.527    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:391(status)
   306653    0.419    0.000    0.488    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/platform.py:186(simulator_by_name)
   234701    0.138    0.000    0.459    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:138(add_filter)
    65221    0.034    0.000    0.374    0.000 <frozen genericpath>:16(exists)
    66245    0.347    0.000    0.362    0.000 {built-in method posix.stat}
    26456    0.313    0.000    0.313    0.000 {method '__exit__' of '_io._IOBase' objects}
   234701    0.135    0.000    0.292    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:129(status)
  3242228    0.267    0.000    0.267    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:876(<lambda>)
   793451    0.174    0.000    0.248    0.000 /usr/lib/python3.12/enum.py:202(__get__)
        8    0.000    0.000    0.218    0.027 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:276(find_snippets_in_roots)
       16    0.002    0.000    0.218    0.014 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:292(process_snippets_in)
  2764828    0.213    0.000    0.213    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:843(<lambda>)
  1276907    0.192    0.000    0.194    0.000 {built-in method builtins.isinstance}
  1480174    0.184    0.000    0.184    0.000 {method 'append' of 'list' objects}
  1007751    0.170    0.000    0.170    0.000 {method 'startswith' of 'str' objects}
  1005863    0.161    0.000    0.161    0.000 {method 'endswith' of 'str' objects}
   159620    0.076    0.000    0.160    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:754(check_platform)
  1042015    0.155    0.000    0.155    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:379(__init__)
      336    0.002    0.000    0.151    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:317(load_snippet_yml)
   412525    0.085    0.000    0.146    0.000 <frozen posixpath>:41(_get_sep)
    45653    0.061    0.000    0.105    0.000 <frozen posixpath>:100(split)
   164967    0.054    0.000    0.091    0.000 {built-in method builtins.any}
  1213960    0.091    0.000    0.091    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:880(<lambda>)
      336    0.001    0.000    0.088    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/validators.py:350(iter_errors)
 1848/336    0.003    0.000    0.083    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:290(properties)
 3880/760    0.010    0.000    0.082    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/validators.py:397(descend)
   793451    0.076    0.000    0.076    0.000 /usr/lib/python3.12/enum.py:810(__getitem__)
   793451    0.075    0.000    0.075    0.000 /usr/lib/python3.12/enum.py:1287(name)
  1117500    0.074    0.000    0.074    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:387(status)
30745/11049    0.033    0.000    0.074    0.000 /usr/lib/python3.12/copy.py:118(deepcopy)
   135885    0.051    0.000    0.069    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:218(testsuite_runnable)
   185282    0.067    0.000    0.067    0.000 {method 'intersection' of 'set' objects}
      144    0.001    0.000    0.055    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:16(patternProperties)
      896    0.001    0.000    0.052    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:274(ref)
      336    0.001    0.000    0.049    0.000 /home/gudni/.venv/lib/python3.12/site-packages/yaml/__init__.py:74(load)
      336    0.012    0.000    0.047    0.000 /home/gudni/.venv/lib/python3.12/site-packages/yaml/constructor.py:47(get_single_data)
      336    0.003    0.000    0.042    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:57(process_data)
```

After
====

```
INFO    - Built testsuite list in 11.04 seconds
         24042599 function calls (23997153 primitive calls) in 11.040 seconds

   Ordered by: cumulative time
   List reduced from 262 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    1.679    1.679   11.040   11.040 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:757(apply_filters)
   146976    0.287    0.000    3.119    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:52(__init__)
    18787    0.028    0.000    2.371    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:103(setup_run_id)
    18787    0.078    0.000    2.344    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:149(_get_run_id)
   341575    1.113    0.000    1.571    0.000 <frozen posixpath>:71(join)
45582/26120    0.048    0.000    1.507    0.000 <frozen os>:200(makedirs)
   146976    0.181    0.000    1.333    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:145(init_cases)
   897887    0.908    0.000    1.152    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:196(add_testcase)
    45582    1.126    0.000    1.126    0.000 {built-in method posix.mkdir}
    83414    0.241    0.000    0.826    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:168(add_missing_case_status)
    26456    0.708    0.000    0.729    0.000 {built-in method _io.open}
    18787    0.050    0.000    0.665    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:341(create_overlay)
   146976    0.194    0.000    0.525    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:282(check_runnable)
   558750    0.232    0.000    0.515    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:391(status)
   234701    0.137    0.000    0.458    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:138(add_filter)
    65221    0.035    0.000    0.379    0.000 <frozen genericpath>:16(exists)
    66245    0.351    0.000    0.366    0.000 {built-in method posix.stat}
   294009    0.278    0.000    0.346    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/platform.py:186(simulator_by_name)
    26456    0.313    0.000    0.313    0.000 {method '__exit__' of '_io._IOBase' objects}
   234701    0.133    0.000    0.291    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:129(status)
  3242228    0.264    0.000    0.264    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:876(<lambda>)
   793451    0.170    0.000    0.243    0.000 /usr/lib/python3.12/enum.py:202(__get__)
        8    0.000    0.000    0.216    0.027 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:276(find_snippets_in_roots)
       16    0.002    0.000    0.216    0.013 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:292(process_snippets_in)
  2764828    0.208    0.000    0.208    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:843(<lambda>)
  1251619    0.194    0.000    0.197    0.000 {built-in method builtins.isinstance}
  1336046    0.167    0.000    0.167    0.000 {method 'append' of 'list' objects}
   931887    0.156    0.000    0.156    0.000 {method 'startswith' of 'str' objects}
   146976    0.071    0.000    0.151    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:754(check_platform)
      336    0.002    0.000    0.150    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:317(load_snippet_yml)
   929999    0.148    0.000    0.148    0.000 {method 'endswith' of 'str' objects}
   897887    0.138    0.000    0.138    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:379(__init__)
   387237    0.079    0.000    0.138    0.000 <frozen posixpath>:41(_get_sep)
    45653    0.063    0.000    0.107    0.000 <frozen posixpath>:100(split)
  1213960    0.090    0.000    0.090    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testplan.py:880(<lambda>)
   152323    0.051    0.000    0.088    0.000 {built-in method builtins.any}
      336    0.001    0.000    0.088    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/validators.py:350(iter_errors)
 1848/336    0.003    0.000    0.083    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:290(properties)
 3880/760    0.010    0.000    0.082    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/validators.py:397(descend)
30745/11049    0.033    0.000    0.074    0.000 /usr/lib/python3.12/copy.py:118(deepcopy)
   793451    0.074    0.000    0.074    0.000 /usr/lib/python3.12/enum.py:810(__getitem__)
   793451    0.073    0.000    0.073    0.000 /usr/lib/python3.12/enum.py:1287(name)
  1117500    0.069    0.000    0.069    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testsuite.py:387(status)
   185282    0.066    0.000    0.066    0.000 {method 'intersection' of 'set' objects}
   123716    0.047    0.000    0.064    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/pylib/twister/twisterlib/testinstance.py:218(testsuite_runnable)
      144    0.001    0.000    0.054    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:16(patternProperties)
      896    0.001    0.000    0.052    0.000 /home/gudni/.venv/lib/python3.12/site-packages/jsonschema/_keywords.py:274(ref)
      336    0.001    0.000    0.049    0.000 /home/gudni/.venv/lib/python3.12/site-packages/yaml/__init__.py:74(load)
      336    0.012    0.000    0.046    0.000 /home/gudni/.venv/lib/python3.12/site-packages/yaml/constructor.py:47(get_single_data)
      336    0.003    0.000    0.041    0.000 /home/gudni/Desktop/my-workspace/zephyr/scripts/snippets.py:57(process_data)

```