### PR TITLE
Add native SX126x LoRa driver

### DIFF
--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -5,4 +5,5 @@ zephyr_sources_ifdef(CONFIG_LORA_SHELL shell.c)
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE loramac-node)
 add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM lora-basics-modem)
+add_subdirectory_ifdef(CONFIG_LORA_MODULE_BACKEND_NATIVE native)
 # zephyr-keep-sorted-stop

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -34,6 +34,12 @@ config LORA_MODULE_BACKEND_LORA_BASICS_MODEM
 	help
 	  LoRa API support using the LoRa Basics Modem module.
 
+config LORA_MODULE_BACKEND_NATIVE
+	bool "Native Zephyr backend"
+	help
+	  Use Zephyr's built-in LoRa drivers without external modules.
+	  Currently supports SX1261/SX1262 transceivers.
+
 endchoice
 
 module = LORA
@@ -55,5 +61,6 @@ config LORA_INIT_PRIORITY
 rsource "Kconfig.sx12xx"
 rsource "Kconfig.rylrxxx"
 rsource "lora-basics-modem/Kconfig"
+rsource "native/Kconfig"
 
 endif # LORA

--- a/drivers/lora/native/CMakeLists.txt
+++ b/drivers/lora/native/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(sx126x)

--- a/drivers/lora/native/Kconfig
+++ b/drivers/lora/native/Kconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "sx126x/Kconfig"

--- a/drivers/lora/native/sx126x/CMakeLists.txt
+++ b/drivers/lora/native/sx126x/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_LORA_SX126X_NATIVE
+  sx126x.c
+  sx126x_hal.c
+)

--- a/drivers/lora/native/sx126x/Kconfig
+++ b/drivers/lora/native/sx126x/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config LORA_SX126X_NATIVE
+	bool "Semtech SX126x native driver (experimental)"
+	default y
+	depends on LORA_MODULE_BACKEND_NATIVE
+	depends on DT_HAS_SEMTECH_SX1262_ENABLED || DT_HAS_SEMTECH_SX1261_ENABLED
+	select SPI
+	select GPIO
+	help
+	  Enable native driver for Semtech SX1261/SX1262 LoRa transceivers.
+	  This is an experimental driver that does not depend on loramac-node
+	  or lora-basics-modem external modules.

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1,0 +1,1064 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/lora.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "sx126x.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sx126x, CONFIG_LORA_LOG_LEVEL);
+
+static uint8_t bandwidth_to_reg(enum lora_signal_bandwidth bw)
+{
+	switch (bw) {
+	case BW_7_KHZ:
+		return SX126X_LORA_BW_7_8;
+	case BW_10_KHZ:
+		return SX126X_LORA_BW_10_4;
+	case BW_15_KHZ:
+		return SX126X_LORA_BW_15_6;
+	case BW_20_KHZ:
+		return SX126X_LORA_BW_20_8;
+	case BW_31_KHZ:
+		return SX126X_LORA_BW_31_25;
+	case BW_41_KHZ:
+		return SX126X_LORA_BW_41_7;
+	case BW_62_KHZ:
+		return SX126X_LORA_BW_62_5;
+	case BW_125_KHZ:
+		return SX126X_LORA_BW_125;
+	case BW_250_KHZ:
+		return SX126X_LORA_BW_250;
+	case BW_500_KHZ:
+		return SX126X_LORA_BW_500;
+	default:
+		return SX126X_LORA_BW_125;
+	}
+}
+
+static uint32_t bandwidth_to_hz(enum lora_signal_bandwidth bw)
+{
+	switch (bw) {
+	case BW_7_KHZ:
+		return 7810;
+	case BW_10_KHZ:
+		return 10420;
+	case BW_15_KHZ:
+		return 15630;
+	case BW_20_KHZ:
+		return 20830;
+	case BW_31_KHZ:
+		return 31250;
+	case BW_41_KHZ:
+		return 41670;
+	case BW_62_KHZ:
+		return 62500;
+	case BW_125_KHZ:
+		return 125000;
+	case BW_250_KHZ:
+		return 250000;
+	case BW_500_KHZ:
+		return 500000;
+	default:
+		return 125000;
+	}
+}
+
+static bool should_enable_ldro(enum lora_datarate sf, enum lora_signal_bandwidth bw,
+			       const struct sx126x_hal_config *config)
+{
+	if (config->force_ldro) {
+		return true;
+	}
+
+	uint32_t bw_hz = bandwidth_to_hz(bw);
+	/* Symbol time = 2^SF / BW (in seconds) */
+	/* 16.38 ms = 16380 us */
+	/* 2^SF / BW > 0.01638 => 2^SF * 1000000 / BW > 16380 */
+	uint32_t symbol_time_us = ((1 << sf) * 1000000UL) / bw_hz;
+
+	return symbol_time_us > 16380;
+}
+
+static int sx126x_set_standby(const struct device *dev, uint8_t mode)
+{
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_STANDBY, &mode, 1);
+}
+
+static int sx126x_set_regulator_mode(const struct device *dev, uint8_t mode)
+{
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_REGULATOR_MODE, &mode, 1);
+}
+
+static int sx126x_set_buffer_base_address(const struct device *dev,
+					  uint8_t tx_base, uint8_t rx_base)
+{
+	uint8_t buf[2] = { tx_base, rx_base };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_BUFFER_BASE_ADDRESS, buf, 2);
+}
+
+static int sx126x_set_packet_type(const struct device *dev, uint8_t type)
+{
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_PACKET_TYPE, &type, 1);
+}
+
+static int sx126x_set_dio_irq_params(const struct device *dev,
+				     uint16_t irq_mask, uint16_t dio1_mask,
+				     uint16_t dio2_mask, uint16_t dio3_mask)
+{
+	uint8_t buf[8];
+
+	sys_put_be16(irq_mask, &buf[0]);
+	sys_put_be16(dio1_mask, &buf[2]);
+	sys_put_be16(dio2_mask, &buf[4]);
+	sys_put_be16(dio3_mask, &buf[6]);
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_DIO_IRQ_PARAMS, buf, 8);
+}
+
+static int sx126x_clear_irq_status(const struct device *dev, uint16_t mask)
+{
+	uint8_t buf[2];
+
+	sys_put_be16(mask, buf);
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_CLR_IRQ_STATUS, buf, 2);
+}
+
+static int sx126x_get_irq_status(const struct device *dev, uint16_t *status)
+{
+	uint8_t buf[2];
+	int ret;
+
+	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_IRQ_STATUS, buf, 2);
+	if (ret == 0) {
+		*status = ((uint16_t)buf[0] << 8) | buf[1];
+	}
+
+	return ret;
+}
+
+static int sx126x_set_dio2_as_rf_switch(const struct device *dev, bool enable)
+{
+	uint8_t val = enable;
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_DIO2_AS_RF_SWITCH, &val, 1);
+}
+
+static int sx126x_set_dio3_as_tcxo_ctrl(const struct device *dev,
+					uint8_t voltage, uint32_t timeout_ms)
+{
+	/* Timeout in units of 15.625 us */
+	uint32_t timeout = SX126X_MS_TO_TIMEOUT(timeout_ms);
+	uint8_t buf[4];
+
+	buf[0] = voltage;
+	sys_put_be24(timeout, &buf[1]);
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_DIO3_AS_TCXO_CTRL, buf, 4);
+}
+
+static int sx126x_calibrate(const struct device *dev, uint8_t mask)
+{
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_CALIBRATE, &mask, 1);
+}
+
+static int sx126x_calibrate_image(const struct device *dev, uint32_t freq)
+{
+	uint8_t buf[2];
+
+	if (freq > 900000000) {
+		buf[0] = 0xE1;
+		buf[1] = 0xE9;
+	} else if (freq > 850000000) {
+		buf[0] = 0xD7;
+		buf[1] = 0xDB;
+	} else if (freq > 770000000) {
+		buf[0] = 0xC1;
+		buf[1] = 0xC5;
+	} else if (freq > 460000000) {
+		buf[0] = 0x75;
+		buf[1] = 0x81;
+	} else {
+		buf[0] = 0x6B;
+		buf[1] = 0x6F;
+	}
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_CALIBRATE_IMAGE, buf, 2);
+}
+
+static int sx126x_set_rf_frequency(const struct device *dev, uint32_t freq)
+{
+	uint32_t freq_reg = SX126X_FREQ_TO_REG(freq);
+	uint8_t buf[4];
+
+	sys_put_be32(freq_reg, buf);
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_RF_FREQUENCY, buf, 4);
+}
+
+static int sx126x_set_pa_config(const struct device *dev, uint8_t pa_duty_cycle,
+				uint8_t hp_max, uint8_t device_sel, uint8_t pa_lut)
+{
+	uint8_t buf[4] = { pa_duty_cycle, hp_max, device_sel, pa_lut };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_PA_CONFIG, buf, 4);
+}
+
+static int sx126x_configure_pa_and_tx_params(const struct device *dev,
+					     int8_t power, uint32_t frequency,
+					     uint8_t ramp_time)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t pa_duty_cycle;
+	int8_t tx_power;
+	int ret;
+
+	if (config->is_sx1261) {
+		/*
+		 * SX1261: Low power PA, up to +15 dBm
+		 * For +15 dBm at >400 MHz, use higher paDutyCycle.
+		 * For lower power, use lower paDutyCycle for efficiency.
+		 */
+		pa_duty_cycle = (power >= SX1261_MAX_POWER && frequency >= 400000000)
+				? SX1261_PA_DUTY_CYCLE_HIGH
+				: SX1261_PA_DUTY_CYCLE_LOW;
+		ret = sx126x_set_pa_config(dev, pa_duty_cycle, SX1261_HP_MAX,
+					   SX126X_DEVICE_SEL_SX1261,
+					   SX126X_PA_LUT);
+		if (ret < 0) {
+			return ret;
+		}
+		tx_power = CLAMP(power, SX1261_MIN_POWER, SX1261_MAX_POWER_TX_PARAM);
+	} else {
+		/* SX1262: High power PA, up to +22 dBm */
+		ret = sx126x_set_pa_config(dev, SX1262_PA_DUTY_CYCLE,
+					   SX1262_HP_MAX,
+					   SX126X_DEVICE_SEL_SX1262,
+					   SX126X_PA_LUT);
+		if (ret < 0) {
+			return ret;
+		}
+		tx_power = CLAMP(power, SX1262_MIN_POWER, SX1262_MAX_POWER);
+	}
+
+	uint8_t buf[2] = { (uint8_t)tx_power, ramp_time };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_TX_PARAMS, buf, 2);
+}
+
+static int sx126x_set_modulation_params(const struct device *dev,
+					uint8_t sf, uint8_t bw, uint8_t cr,
+					bool ldro)
+{
+	uint8_t buf[4] = { sf, bw, cr, ldro };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_MODULATION_PARAMS, buf, 4);
+}
+
+static int sx126x_set_packet_params(const struct device *dev,
+				    uint16_t preamble_len, uint8_t header_type,
+				    uint8_t payload_len, uint8_t crc_mode,
+				    uint8_t invert_iq)
+{
+	uint8_t buf[6];
+
+	sys_put_be16(preamble_len, &buf[0]);
+	buf[2] = header_type;
+	buf[3] = payload_len;
+	buf[4] = crc_mode;
+	buf[5] = invert_iq;
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_PACKET_PARAMS, buf, 6);
+}
+
+static int sx126x_set_sync_word(const struct device *dev, bool public_network)
+{
+	uint16_t sync_word = public_network ?
+			     SX126X_LORA_SYNC_WORD_PUBLIC :
+			     SX126X_LORA_SYNC_WORD_PRIVATE;
+	uint8_t buf[2];
+
+	sys_put_be16(sync_word, buf);
+	return sx126x_hal_write_regs(dev, SX126X_REG_LORA_SYNC_WORD_MSB, buf, 2);
+}
+
+static int sx126x_set_rx_gain(const struct device *dev, bool boosted)
+{
+	uint8_t val = boosted ? SX126X_RX_GAIN_BOOSTED : SX126X_RX_GAIN_POWER_SAVING;
+
+	return sx126x_hal_write_regs(dev, SX126X_REG_RX_GAIN, &val, 1);
+}
+
+static int sx126x_set_tx(const struct device *dev, uint32_t timeout_ms)
+{
+	uint32_t timeout = SX126X_MS_TO_TIMEOUT(timeout_ms);
+	uint8_t buf[3];
+
+	sys_put_be24(timeout, buf);
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_TX, buf, 3);
+}
+
+static int sx126x_set_rx(const struct device *dev, uint32_t timeout_ms)
+{
+	uint32_t timeout;
+
+	if (timeout_ms == 0) {
+		timeout = SX126X_RX_TIMEOUT_CONTINUOUS;
+	} else {
+		timeout = SX126X_MS_TO_TIMEOUT(timeout_ms);
+	}
+
+	uint8_t buf[3];
+
+	sys_put_be24(timeout, buf);
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_RX, buf, 3);
+}
+
+static int sx126x_get_rx_buffer_status(const struct device *dev,
+				       uint8_t *payload_len, uint8_t *offset)
+{
+	uint8_t buf[2];
+	int ret;
+
+	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_RX_BUFFER_STATUS, buf, 2);
+	if (ret == 0) {
+		*payload_len = buf[0];
+		*offset = buf[1];
+	}
+
+	return ret;
+}
+
+static int sx126x_get_packet_status(const struct device *dev,
+				    int16_t *rssi, int8_t *snr)
+{
+	uint8_t buf[3];
+	int ret;
+
+	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_PACKET_STATUS, buf, 2);
+	if (ret == 0) {
+		/* RSSI is -value/2 dBm */
+		*rssi = -((int16_t)buf[0] >> 1);
+		/* SNR is value/4 dB (signed) */
+		*snr = ((int8_t)buf[1]) >> 2;
+	}
+
+	return ret;
+}
+
+static int sx126x_chip_init(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	int ret;
+
+	/* Hardware reset */
+	ret = sx126x_hal_reset(dev);
+	if (ret < 0) {
+		LOG_ERR("Reset failed: %d", ret);
+		return ret;
+	}
+
+	/* Set standby mode */
+	ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	if (ret < 0) {
+		LOG_ERR("Set standby failed: %d", ret);
+		return ret;
+	}
+
+	/* Configure TCXO if enabled */
+	if (config->dio3_tcxo_enable) {
+		ret = sx126x_set_dio3_as_tcxo_ctrl(dev, config->dio3_tcxo_voltage,
+						   config->tcxo_startup_delay_ms);
+		if (ret < 0) {
+			LOG_ERR("Set TCXO failed: %d", ret);
+			return ret;
+		}
+
+		/* Run full calibration after TCXO setup */
+		ret = sx126x_calibrate(dev, SX126X_CALIBRATE_ALL);
+		if (ret < 0) {
+			LOG_ERR("Calibration failed: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Configure DIO2 as RF switch if enabled */
+	if (config->dio2_tx_enable) {
+		ret = sx126x_set_dio2_as_rf_switch(dev, true);
+		if (ret < 0) {
+			LOG_ERR("Set DIO2 RF switch failed: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Set regulator mode */
+	ret = sx126x_set_regulator_mode(dev, config->regulator_ldo ?
+					SX126X_REGULATOR_LDO : SX126X_REGULATOR_DCDC);
+	if (ret < 0) {
+		LOG_ERR("Set regulator failed: %d", ret);
+		return ret;
+	}
+
+	/* Set buffer base addresses */
+	ret = sx126x_set_buffer_base_address(dev, 0x00, 0x00);
+	if (ret < 0) {
+		LOG_ERR("Set buffer base failed: %d", ret);
+		return ret;
+	}
+
+	/* Set packet type to LoRa */
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_LORA);
+	if (ret < 0) {
+		LOG_ERR("Set packet type failed: %d", ret);
+		return ret;
+	}
+
+	/* Configure IRQs on DIO1: TX done, RX done, timeout */
+	uint16_t irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_DONE |
+			    SX126X_IRQ_RX_TX_TIMEOUT | SX126X_IRQ_CRC_ERR;
+	ret = sx126x_set_dio_irq_params(dev, irq_mask, irq_mask, 0, 0);
+	if (ret < 0) {
+		LOG_ERR("Set IRQ params failed: %d", ret);
+		return ret;
+	}
+
+	/* Clear any pending IRQs */
+	ret = sx126x_clear_irq_status(dev, SX126X_IRQ_ALL);
+	if (ret < 0) {
+		LOG_ERR("Clear IRQ failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("SX126x initialized");
+	return 0;
+}
+
+static void sx126x_dio1_callback(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+
+	k_work_submit(&data->irq_work);
+}
+
+static void sx126x_set_rf_path(const struct device *dev, bool enable, bool tx)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	sx126x_hal_set_antenna_enable(dev, enable);
+	if (!config->dio2_tx_enable) {
+		sx126x_hal_set_rf_switch(dev, enable && tx);
+	}
+}
+
+static void sx126x_handle_irq_tx_done(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_tx_result result = { .status = 0 };
+
+	LOG_DBG("TX done");
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	sx126x_set_rf_path(dev, false, false);
+
+	if (data->tx_async_signal != NULL) {
+		k_poll_signal_raise(data->tx_async_signal, 0);
+		data->tx_async_signal = NULL;
+	}
+	k_msgq_put(&data->tx_msgq, &result, K_NO_WAIT);
+}
+
+static void sx126x_handle_irq_rx_done(const struct device *dev, uint16_t irq_status)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_rx_result result = { 0 };
+	uint8_t payload_len = 0, offset = 0;
+	int ret;
+
+	/* Get received packet info */
+	ret = sx126x_get_rx_buffer_status(dev, &payload_len, &offset);
+	if (ret < 0) {
+		LOG_ERR("Failed to get RX buffer status");
+		result.status = ret;
+	} else {
+		/* Get signal quality */
+		sx126x_get_packet_status(dev, &result.rssi, &result.snr);
+
+		/* Check for CRC error */
+		if (irq_status & SX126X_IRQ_CRC_ERR) {
+			LOG_WRN("CRC error");
+			result.status = -EIO;
+		} else {
+			/* Read payload into shared buffer */
+			result.len = MIN(payload_len, sizeof(data->rx_buf));
+			ret = sx126x_hal_read_buffer(dev, offset,
+						     data->rx_buf, result.len);
+			if (ret < 0) {
+				LOG_ERR("Failed to read RX buffer");
+				result.status = ret;
+			} else {
+				result.status = result.len;
+				LOG_DBG("RX done: %d bytes, RSSI=%d, SNR=%d",
+					result.len, result.rssi, result.snr);
+			}
+		}
+	}
+
+	/* Handle async callback or signal sync receiver */
+	if (data->rx_cb != NULL) {
+		/* Async mode - call callback and restart RX */
+		data->rx_cb(dev, data->rx_buf, result.len,
+			    result.rssi, result.snr,
+			    data->rx_cb_user_data);
+		/* Restart RX for continuous reception */
+		sx126x_set_rx(dev, 0);
+	} else {
+		/* Sync mode */
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_rf_path(dev, false, false);
+		k_msgq_put(&data->rx_msgq, &result, K_NO_WAIT);
+	}
+}
+
+static void sx126x_handle_irq_timeout(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+
+	LOG_DBG("Timeout");
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	sx126x_set_rf_path(dev, false, false);
+
+	if (data->tx_async_signal != NULL) {
+		struct sx126x_tx_result result = { .status = -ETIMEDOUT };
+
+		k_poll_signal_raise(data->tx_async_signal, -ETIMEDOUT);
+		data->tx_async_signal = NULL;
+		k_msgq_put(&data->tx_msgq, &result, K_NO_WAIT);
+	} else if (data->rx_cb == NULL) {
+		/* Sync RX timeout */
+		struct sx126x_rx_result result = { .status = -EAGAIN };
+
+		k_msgq_put(&data->rx_msgq, &result, K_NO_WAIT);
+	}
+}
+
+static void sx126x_irq_work_handler(struct k_work *work)
+{
+	struct sx126x_data *data = CONTAINER_OF(work, struct sx126x_data, irq_work);
+	const struct device *dev = data->dev;
+	uint16_t irq_status = 0;
+	int ret;
+
+	ret = sx126x_get_irq_status(dev, &irq_status);
+	if (ret < 0) {
+		LOG_ERR("Failed to get IRQ status");
+		return;
+	}
+
+	LOG_DBG("IRQ status: 0x%04x", irq_status);
+
+	/* Clear handled IRQs */
+	sx126x_clear_irq_status(dev, irq_status);
+
+	if (irq_status & SX126X_IRQ_TX_DONE) {
+		sx126x_handle_irq_tx_done(dev);
+	}
+
+	if (irq_status & SX126X_IRQ_RX_DONE) {
+		sx126x_handle_irq_rx_done(dev, irq_status);
+	}
+
+	if (irq_status & SX126X_IRQ_RX_TX_TIMEOUT) {
+		sx126x_handle_irq_timeout(dev);
+	}
+}
+
+static int sx126x_lora_config(const struct device *dev,
+			      struct lora_modem_config *config)
+{
+	struct sx126x_data *data = dev->data;
+	const struct sx126x_hal_config *hal_config = dev->config;
+	bool ldro;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	/* Store configuration */
+	memcpy(&data->config, config, sizeof(*config));
+
+	/* Run image calibration for frequency band */
+	ret = sx126x_calibrate_image(dev, config->frequency);
+	if (ret < 0) {
+		goto out;
+	}
+
+	/* Set RF frequency */
+	ret = sx126x_set_rf_frequency(dev, config->frequency);
+	if (ret < 0) {
+		goto out;
+	}
+
+	/* Configure PA and TX power based on chip variant and frequency */
+	ret = sx126x_configure_pa_and_tx_params(dev, config->tx_power,
+						config->frequency,
+						SX126X_RAMP_200_US);
+	if (ret < 0) {
+		goto out;
+	}
+
+	/* Set modulation parameters */
+	ldro = should_enable_ldro(config->datarate, config->bandwidth, hal_config);
+	ret = sx126x_set_modulation_params(dev,
+					   config->datarate,
+					   bandwidth_to_reg(config->bandwidth),
+					   config->coding_rate,
+					   ldro);
+	if (ret < 0) {
+		goto out;
+	}
+
+	/* Set sync word */
+	ret = sx126x_set_sync_word(dev, config->public_network);
+	if (ret < 0) {
+		goto out;
+	}
+
+	/* Set RX gain */
+	ret = sx126x_set_rx_gain(dev, hal_config->rx_boosted);
+	if (ret < 0) {
+		goto out;
+	}
+
+	data->config_valid = true;
+	LOG_DBG("Config: freq=%u, SF=%d, BW=%d, CR=%d, power=%d",
+		config->frequency, config->datarate, config->bandwidth,
+		config->coding_rate, config->tx_power);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int sx126x_lora_send_async(const struct device *dev,
+				  uint8_t *data_buf, uint32_t data_len,
+				  struct k_poll_signal *async)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	if (!data->config_valid) {
+		LOG_ERR("Not configured");
+		return -EINVAL;
+	}
+
+	if (data_len > SX126X_MAX_PAYLOAD_LEN) {
+		LOG_ERR("Payload too long: %u", data_len);
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_TX)) {
+		LOG_ERR("Busy");
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	data->tx_async_signal = async;
+	k_msgq_purge(&data->tx_msgq);
+
+	/* Set packet parameters */
+	ret = sx126x_set_packet_params(dev,
+				       data->config.preamble_len,
+				       SX126X_LORA_HEADER_EXPLICIT,
+				       data_len,
+				       data->config.packet_crc_disable ?
+				       SX126X_LORA_CRC_OFF : SX126X_LORA_CRC_ON,
+				       data->config.iq_inverted ?
+				       SX126X_LORA_IQ_INVERTED : SX126X_LORA_IQ_STANDARD);
+	if (ret < 0) {
+		goto out_error;
+	}
+
+	/* Write payload to buffer */
+	ret = sx126x_hal_write_buffer(dev, 0x00, data_buf, data_len);
+	if (ret < 0) {
+		goto out_error;
+	}
+
+	/* Enable antenna and set TX path */
+	sx126x_set_rf_path(dev, true, true);
+
+	/* Start transmission with 10 second timeout */
+	ret = sx126x_set_tx(dev, 10000);
+	if (ret < 0) {
+		goto out_error;
+	}
+
+	k_mutex_unlock(&data->lock);
+	return 0;
+
+out_error:
+	data->tx_async_signal = NULL;
+	k_mutex_unlock(&data->lock);
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	return ret;
+}
+
+static int sx126x_lora_send(const struct device *dev,
+			    uint8_t *data_buf, uint32_t data_len)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_tx_result result;
+	int ret;
+
+	ret = sx126x_lora_send_async(dev, data_buf, data_len, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Wait for TX completion */
+	ret = k_msgq_get(&data->tx_msgq, &result, K_SECONDS(15));
+	if (ret < 0) {
+		LOG_ERR("TX timeout");
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return -ETIMEDOUT;
+	}
+
+	return result.status;
+}
+
+static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
+			    uint8_t size, k_timeout_t timeout,
+			    int16_t *rssi, int8_t *snr)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_rx_result result;
+	uint32_t timeout_ms;
+	int ret;
+
+	if (!data->config_valid) {
+		LOG_ERR("Not configured");
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+		LOG_ERR("Busy");
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	data->rx_cb = NULL;
+	k_msgq_purge(&data->rx_msgq);
+
+	/* Set packet parameters for variable length reception */
+	ret = sx126x_set_packet_params(dev,
+				       data->config.preamble_len,
+				       SX126X_LORA_HEADER_EXPLICIT,
+				       SX126X_MAX_PAYLOAD_LEN,
+				       data->config.packet_crc_disable ?
+				       SX126X_LORA_CRC_OFF : SX126X_LORA_CRC_ON,
+				       data->config.iq_inverted ?
+				       SX126X_LORA_IQ_INVERTED : SX126X_LORA_IQ_STANDARD);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return ret;
+	}
+
+	/* Enable antenna and set RX path */
+	sx126x_set_rf_path(dev, true, false);
+
+	/* Start reception (0 = continuous for K_FOREVER) */
+	timeout_ms = K_TIMEOUT_EQ(timeout, K_FOREVER)
+		     ? 0 : k_ticks_to_ms_ceil32(timeout.ticks);
+	ret = sx126x_set_rx(dev, timeout_ms);
+	if (ret < 0) {
+		sx126x_set_rf_path(dev, false, false);
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return ret;
+	}
+
+	k_mutex_unlock(&data->lock);
+
+	/* Wait for RX completion */
+	ret = k_msgq_get(&data->rx_msgq, &result, timeout);
+	if (ret < 0) {
+		LOG_DBG("RX timeout");
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_rf_path(dev, false, false);
+		return -EAGAIN;
+	}
+
+	/* Copy received data from shared buffer */
+	if (result.status > 0) {
+		int copy_len = MIN(result.status, size);
+
+		memcpy(data_buf, data->rx_buf, copy_len);
+		if (rssi != NULL) {
+			*rssi = result.rssi;
+		}
+		if (snr != NULL) {
+			*snr = result.snr;
+		}
+		return copy_len;
+	}
+
+	return result.status;
+}
+
+static int sx126x_lora_recv_async(const struct device *dev,
+				  lora_recv_cb cb, void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (cb == NULL) {
+		/* Stop async reception */
+		data->rx_cb = NULL;
+		data->rx_cb_user_data = NULL;
+		if (atomic_cas(&data->state, SX126X_STATE_RX, SX126X_STATE_IDLE)) {
+			sx126x_set_standby(dev, SX126X_STANDBY_RC);
+			sx126x_set_rf_path(dev, false, false);
+		}
+		k_mutex_unlock(&data->lock);
+		return 0;
+	}
+
+	if (!data->config_valid) {
+		LOG_ERR("Not configured");
+		k_mutex_unlock(&data->lock);
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+		LOG_ERR("Busy");
+		k_mutex_unlock(&data->lock);
+		return -EBUSY;
+	}
+
+	data->rx_cb = cb;
+	data->rx_cb_user_data = user_data;
+
+	/* Set packet parameters */
+	ret = sx126x_set_packet_params(dev,
+				       data->config.preamble_len,
+				       SX126X_LORA_HEADER_EXPLICIT,
+				       SX126X_MAX_PAYLOAD_LEN,
+				       data->config.packet_crc_disable ?
+				       SX126X_LORA_CRC_OFF : SX126X_LORA_CRC_ON,
+				       data->config.iq_inverted ?
+				       SX126X_LORA_IQ_INVERTED : SX126X_LORA_IQ_STANDARD);
+	if (ret < 0) {
+		data->rx_cb = NULL;
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return ret;
+	}
+
+	/* Enable antenna and set RX path */
+	sx126x_set_rf_path(dev, true, false);
+
+	/* Start continuous reception */
+	ret = sx126x_set_rx(dev, 0);
+	if (ret < 0) {
+		data->rx_cb = NULL;
+		sx126x_set_rf_path(dev, false, false);
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return ret;
+	}
+
+	k_mutex_unlock(&data->lock);
+	return 0;
+}
+
+static uint32_t sx126x_lora_airtime(const struct device *dev, uint32_t data_len)
+{
+	struct sx126x_data *data = dev->data;
+	uint32_t t_preamble_us, t_payload_us, t_sym_us, n_payload, bw_hz;
+	uint8_t sf, cr;
+	int32_t tmp;
+	bool de, crc;
+
+	if (!data->config_valid) {
+		return 0;
+	}
+
+	/* Calculate symbol time in microseconds */
+	bw_hz = bandwidth_to_hz(data->config.bandwidth);
+	sf = data->config.datarate;
+
+	/* Symbol time = 2^SF / BW (seconds) */
+	/* In microseconds: (2^SF * 1000000) / BW */
+	t_sym_us = ((1UL << sf) * 1000000UL) / bw_hz;
+
+	/* Preamble time (4.25 extra symbols) */
+	t_preamble_us = (data->config.preamble_len + 4) * t_sym_us +
+			(t_sym_us / 4);
+
+	/* Payload symbol count calculation (from LoRa modem designer's guide) */
+	de = should_enable_ldro(sf, data->config.bandwidth, dev->config);
+	crc = !data->config.packet_crc_disable;
+	cr = data->config.coding_rate;
+
+	/* ih (implicit header) = false for explicit header mode */
+	tmp = 8 * data_len - 4 * sf + 28 + 16 * crc;
+	if (tmp < 0) {
+		tmp = 0;
+	}
+
+	n_payload = 8 + (((tmp + 4 * (sf - 2 * de) - 1) /
+			  (4 * (sf - 2 * de))) * (cr + 4));
+	t_payload_us = n_payload * t_sym_us;
+
+	/* Total airtime in milliseconds */
+	return (t_preamble_us + t_payload_us + 500) / 1000;
+}
+
+static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
+			       int8_t tx_power, uint16_t duration)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	if (atomic_get(&data->state) != SX126X_STATE_IDLE) {
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	/* Set frequency */
+	ret = sx126x_set_rf_frequency(dev, frequency);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		return ret;
+	}
+
+	/* Set PA config and TX power */
+	ret = sx126x_configure_pa_and_tx_params(dev, tx_power, frequency,
+						SX126X_RAMP_200_US);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		return ret;
+	}
+
+	/* Enable antenna and TX path */
+	sx126x_set_rf_path(dev, true, true);
+
+	/* Start CW transmission */
+	ret = sx126x_hal_write_cmd(dev, SX126X_CMD_SET_TX_CONTINUOUS_WAVE, NULL, 0);
+	if (ret < 0) {
+		sx126x_set_rf_path(dev, false, false);
+		k_mutex_unlock(&data->lock);
+		return ret;
+	}
+
+	k_mutex_unlock(&data->lock);
+
+	/* Wait for duration */
+	k_sleep(K_SECONDS(duration));
+
+	/* Stop CW */
+	k_mutex_lock(&data->lock, K_FOREVER);
+	sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	sx126x_set_rf_path(dev, false, false);
+	k_mutex_unlock(&data->lock);
+
+	return 0;
+}
+
+static const struct lora_driver_api sx126x_lora_api = {
+	.config = sx126x_lora_config,
+	.send = sx126x_lora_send,
+	.send_async = sx126x_lora_send_async,
+	.recv = sx126x_lora_recv,
+	.recv_async = sx126x_lora_recv_async,
+	.airtime = sx126x_lora_airtime,
+	.test_cw = sx126x_lora_test_cw,
+};
+
+static int sx126x_init(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	/* Initialize data structures */
+	k_mutex_init(&data->lock);
+	k_msgq_init(&data->tx_msgq, (char *)&data->tx_result,
+		    sizeof(struct sx126x_tx_result), 1);
+	k_msgq_init(&data->rx_msgq, (char *)&data->rx_result,
+		    sizeof(struct sx126x_rx_result), 1);
+	k_work_init(&data->irq_work, sx126x_irq_work_handler);
+	data->dev = dev;
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	data->config_valid = false;
+
+	/* Initialize HAL */
+	ret = sx126x_hal_init(dev);
+	if (ret < 0) {
+		LOG_ERR("HAL init failed: %d", ret);
+		return ret;
+	}
+
+	/* Setup DIO1 interrupt callback */
+	ret = sx126x_hal_set_dio1_callback(dev, sx126x_dio1_callback);
+	if (ret < 0) {
+		LOG_ERR("DIO1 callback setup failed: %d", ret);
+		return ret;
+	}
+
+	/* Initialize chip */
+	ret = sx126x_chip_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Chip init failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+#define SX126X_INIT(inst, is_1261)						\
+	static struct sx126x_data sx126x_data_##inst;				\
+										\
+	static const struct sx126x_hal_config sx126x_config_##inst = {		\
+		.spi = SPI_DT_SPEC_INST_GET(inst,				\
+					    SPI_WORD_SET(8) | SPI_TRANSFER_MSB), \
+		.reset = GPIO_DT_SPEC_INST_GET(inst, reset_gpios),		\
+		.busy = GPIO_DT_SPEC_INST_GET(inst, busy_gpios),		\
+		.dio1 = GPIO_DT_SPEC_INST_GET(inst, dio1_gpios),		\
+		.antenna_enable = GPIO_DT_SPEC_INST_GET_OR(inst,		\
+							   antenna_enable_gpios, \
+							   {0}),		\
+		.tx_enable = GPIO_DT_SPEC_INST_GET_OR(inst, tx_enable_gpios,	\
+						      {0}),			\
+		.rx_enable = GPIO_DT_SPEC_INST_GET_OR(inst, rx_enable_gpios,	\
+						      {0}),			\
+		.is_sx1261 = is_1261,						\
+		.dio2_tx_enable = DT_INST_PROP(inst, dio2_tx_enable),		\
+		.dio3_tcxo_enable = DT_INST_NODE_HAS_PROP(inst, dio3_tcxo_voltage), \
+		.dio3_tcxo_voltage = DT_INST_PROP_OR(inst, dio3_tcxo_voltage, 0), \
+		.tcxo_startup_delay_ms = DT_INST_PROP_OR(inst,			\
+						tcxo_power_startup_delay_ms, 10), \
+		.rx_boosted = DT_INST_PROP(inst, rx_boosted),			\
+		.regulator_ldo = DT_INST_PROP(inst, regulator_ldo),		\
+		.force_ldro = DT_INST_PROP(inst, force_ldro),			\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(inst, sx126x_init, NULL,				\
+			      &sx126x_data_##inst, &sx126x_config_##inst,	\
+			      POST_KERNEL, CONFIG_LORA_INIT_PRIORITY,		\
+			      &sx126x_lora_api);
+
+#define DT_DRV_COMPAT semtech_sx1262
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SX126X_INIT, false)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT semtech_sx1261
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SX126X_INIT, true)

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_LORA_SX126X_SX126X_INTERNAL_H_
+#define ZEPHYR_DRIVERS_LORA_SX126X_SX126X_INTERNAL_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/lora.h>
+#include <zephyr/sys/atomic.h>
+
+#include "sx126x_hal.h"
+#include "sx126x_regs.h"
+
+#define SX126X_STATE_IDLE 0
+#define SX126X_STATE_TX   1
+#define SX126X_STATE_RX   2
+
+struct sx126x_tx_result {
+	int status;
+};
+
+struct sx126x_rx_result {
+	int16_t rssi;
+	int8_t snr;
+	uint8_t len;
+	int status;
+};
+
+struct sx126x_data {
+	struct sx126x_hal_data hal;
+
+	/* Current state (atomic for lock-free state transitions) */
+	atomic_t state;
+	struct k_mutex lock;
+
+	/* Current configuration */
+	struct lora_modem_config config;
+	bool config_valid;
+
+	/* TX completion via message queue */
+	struct k_msgq tx_msgq;
+	struct sx126x_tx_result tx_result;
+
+	/* RX completion via message queue */
+	struct k_msgq rx_msgq;
+	struct sx126x_rx_result rx_result;
+
+	/* RX data buffer (shared between IRQ handler and recv) */
+	uint8_t rx_buf[SX126X_MAX_PAYLOAD_LEN];
+
+	/* Async RX callback */
+	lora_recv_cb rx_cb;
+	void *rx_cb_user_data;
+
+	/* Async TX signal */
+	struct k_poll_signal *tx_async_signal;
+
+	/* Deferred work for interrupt handling */
+	struct k_work irq_work;
+	const struct device *dev;
+};
+
+#endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_INTERNAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x_hal.c
+++ b/drivers/lora/native/sx126x/sx126x_hal.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "sx126x.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sx126x_hal, CONFIG_LORA_LOG_LEVEL);
+
+/* Timing constants */
+#define SX126X_RESET_PULSE_MS       5
+#define SX126X_RESET_WAIT_MS        5
+#define SX126X_BUSY_DEFAULT_TIMEOUT 1000
+
+static inline struct sx126x_hal_data *get_hal_data(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+
+	return &data->hal;
+}
+
+static int spi_transfer(const struct spi_dt_spec *spi,
+			const uint8_t *hdr, size_t hdr_len,
+			uint8_t *data, size_t data_len, bool read)
+{
+	uint8_t rx_hdr[4];
+
+	__ASSERT_NO_MSG(hdr_len <= sizeof(rx_hdr));
+
+	struct spi_buf tx_bufs[] = {
+		{ .buf = (uint8_t *)hdr, .len = hdr_len },
+		{ .buf = data, .len = data_len },
+	};
+	struct spi_buf rx_bufs[] = {
+		{ .buf = rx_hdr, .len = hdr_len },
+		{ .buf = data, .len = data_len },
+	};
+	struct spi_buf_set tx_set = {
+		.buffers = tx_bufs,
+		.count = (read || (data_len == 0)) ? 1 : 2,
+	};
+	struct spi_buf_set rx_set = {
+		.buffers = rx_bufs,
+		.count = read ? 2 : 1,
+	};
+
+	return spi_transceive_dt(spi, &tx_set, &rx_set);
+}
+
+int sx126x_hal_reset(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	int ret;
+
+	if (!gpio_is_ready_dt(&config->reset)) {
+		LOG_ERR("Reset GPIO not ready");
+		return -ENODEV;
+	}
+
+	/* Pull reset low */
+	ret = gpio_pin_set_dt(&config->reset, 1);
+	if (ret < 0) {
+		LOG_ERR("Failed to assert reset: %d", ret);
+		return ret;
+	}
+
+	k_msleep(SX126X_RESET_PULSE_MS);
+
+	/* Release reset */
+	ret = gpio_pin_set_dt(&config->reset, 0);
+	if (ret < 0) {
+		LOG_ERR("Failed to release reset: %d", ret);
+		return ret;
+	}
+
+	k_msleep(SX126X_RESET_WAIT_MS);
+
+	/* Wait for chip to be ready */
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_DBG("Reset complete");
+	return 0;
+}
+
+bool sx126x_hal_is_busy(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	return gpio_pin_get_dt(&config->busy) != 0;
+}
+
+int sx126x_hal_wait_busy(const struct device *dev, uint32_t timeout_ms)
+{
+	if (!WAIT_FOR(!sx126x_hal_is_busy(dev),
+		      timeout_ms * 1000,
+		      k_msleep(1))) {
+		LOG_WRN("Busy timeout after %u ms", timeout_ms);
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+static void dio1_isr(const struct device *gpio, struct gpio_callback *cb,
+		     uint32_t pins)
+{
+	struct sx126x_hal_data *data = CONTAINER_OF(cb, struct sx126x_hal_data, dio1_cb);
+
+	if (data->dio1_callback != NULL) {
+		data->dio1_callback(data->dev);
+	}
+}
+
+int sx126x_hal_set_dio1_callback(const struct device *dev,
+				 void (*callback)(const struct device *dev))
+{
+	const struct sx126x_hal_config *config = dev->config;
+	struct sx126x_hal_data *data = get_hal_data(dev);
+	int ret;
+
+	data->dio1_callback = callback;
+
+	if (callback != NULL) {
+		ret = gpio_pin_interrupt_configure_dt(&config->dio1,
+						      GPIO_INT_EDGE_TO_ACTIVE);
+	} else {
+		ret = gpio_pin_interrupt_configure_dt(&config->dio1,
+						      GPIO_INT_DISABLE);
+	}
+
+	return ret;
+}
+
+void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	if (config->antenna_enable.port != NULL) {
+		gpio_pin_set_dt(&config->antenna_enable, enable);
+	}
+}
+
+void sx126x_hal_set_rf_switch(const struct device *dev, bool tx)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	if (config->tx_enable.port != NULL) {
+		gpio_pin_set_dt(&config->tx_enable, tx);
+	}
+
+	if (config->rx_enable.port != NULL) {
+		gpio_pin_set_dt(&config->rx_enable, !tx);
+	}
+}
+
+int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
+			      gpio_flags_t flags, const char *name)
+{
+	int ret;
+
+	if (gpio->port == NULL) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(gpio)) {
+		LOG_ERR("%s GPIO not ready", name);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(gpio, flags);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure %s: %d", name, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_cmd(const struct device *dev, uint8_t opcode,
+			 const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[1] = { opcode };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write failed: %d", ret);
+		return ret;
+	}
+
+	if (opcode != SX126X_CMD_SET_SLEEP) {
+		ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	}
+
+	return ret;
+}
+
+int sx126x_hal_read_cmd(const struct device *dev, uint8_t opcode,
+			uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[2] = { opcode, 0x00 };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI transceive failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_regs(const struct device *dev, uint16_t address,
+			  const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[3];
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hdr[0] = SX126X_CMD_WRITE_REGISTER;
+	sys_put_be16(address, &hdr[1]);
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write regs failed: %d", ret);
+		return ret;
+	}
+
+	return sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+}
+
+int sx126x_hal_read_regs(const struct device *dev, uint16_t address,
+			 uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[4];
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hdr[0] = SX126X_CMD_READ_REGISTER;
+	sys_put_be16(address, &hdr[1]);
+	hdr[3] = 0x00;
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI read regs failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_buffer(const struct device *dev, uint8_t offset,
+			    const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[2] = { SX126X_CMD_WRITE_BUFFER, offset };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write buffer failed: %d", ret);
+		return ret;
+	}
+
+	return sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+}
+
+int sx126x_hal_read_buffer(const struct device *dev, uint8_t offset,
+			   uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[3] = { SX126X_CMD_READ_BUFFER, offset, 0x00 };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI read buffer failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_init(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	struct sx126x_hal_data *data = get_hal_data(dev);
+	int ret;
+
+	/* Store device reference for callbacks */
+	data->dev = dev;
+	data->dio1_callback = NULL;
+
+	/* Check SPI bus */
+	if (!spi_is_ready_dt(&config->spi)) {
+		LOG_ERR("SPI bus not ready");
+		return -ENODEV;
+	}
+
+	/* Configure reset GPIO */
+	if (!gpio_is_ready_dt(&config->reset)) {
+		LOG_ERR("Reset GPIO not ready");
+		return -ENODEV;
+	}
+	ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure reset GPIO: %d", ret);
+		return ret;
+	}
+
+	/* Configure busy GPIO */
+	if (!gpio_is_ready_dt(&config->busy)) {
+		LOG_ERR("Busy GPIO not ready");
+		return -ENODEV;
+	}
+	ret = gpio_pin_configure_dt(&config->busy, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure busy GPIO: %d", ret);
+		return ret;
+	}
+
+	/* Configure DIO1 GPIO with interrupt */
+	if (!gpio_is_ready_dt(&config->dio1)) {
+		LOG_ERR("DIO1 GPIO not ready");
+		return -ENODEV;
+	}
+	ret = gpio_pin_configure_dt(&config->dio1, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure DIO1 GPIO: %d", ret);
+		return ret;
+	}
+
+	/* Setup DIO1 interrupt callback */
+	gpio_init_callback(&data->dio1_cb, dio1_isr, BIT(config->dio1.pin));
+	ret = gpio_add_callback(config->dio1.port, &data->dio1_cb);
+	if (ret < 0) {
+		LOG_ERR("Failed to add DIO1 callback: %d", ret);
+		return ret;
+	}
+
+	/* Configure optional GPIOs */
+	ret = sx126x_hal_configure_gpio(&config->antenna_enable, GPIO_OUTPUT_INACTIVE,
+					"antenna enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sx126x_hal_configure_gpio(&config->tx_enable, GPIO_OUTPUT_INACTIVE,
+					"TX enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sx126x_hal_configure_gpio(&config->rx_enable, GPIO_OUTPUT_INACTIVE,
+					"RX enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_DBG("HAL initialized");
+	return 0;
+}

--- a/drivers/lora/native/sx126x/sx126x_hal.h
+++ b/drivers/lora/native/sx126x/sx126x_hal.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_LORA_SX126X_SX126X_HAL_H_
+#define ZEPHYR_DRIVERS_LORA_SX126X_SX126X_HAL_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+
+struct sx126x_hal_config {
+	struct spi_dt_spec spi;
+	struct gpio_dt_spec reset;
+	struct gpio_dt_spec busy;
+	struct gpio_dt_spec dio1;
+	struct gpio_dt_spec antenna_enable;
+	struct gpio_dt_spec tx_enable;
+	struct gpio_dt_spec rx_enable;
+	uint16_t tcxo_startup_delay_ms;
+	uint8_t dio3_tcxo_voltage;
+	bool is_sx1261;
+	bool dio2_tx_enable;
+	bool dio3_tcxo_enable;
+	bool rx_boosted;
+	bool regulator_ldo;
+	bool force_ldro;
+};
+
+struct sx126x_hal_data {
+	struct gpio_callback dio1_cb;
+	void (*dio1_callback)(const struct device *dev);
+	const struct device *dev;
+};
+
+int sx126x_hal_init(const struct device *dev);
+
+int sx126x_hal_reset(const struct device *dev);
+
+int sx126x_hal_wait_busy(const struct device *dev, uint32_t timeout_ms);
+
+bool sx126x_hal_is_busy(const struct device *dev);
+
+int sx126x_hal_write_cmd(const struct device *dev, uint8_t opcode,
+			 const uint8_t *data, size_t len);
+
+int sx126x_hal_read_cmd(const struct device *dev, uint8_t opcode,
+			uint8_t *data, size_t len);
+
+int sx126x_hal_write_regs(const struct device *dev, uint16_t address,
+			  const uint8_t *data, size_t len);
+
+int sx126x_hal_read_regs(const struct device *dev, uint16_t address,
+			 uint8_t *data, size_t len);
+
+int sx126x_hal_write_buffer(const struct device *dev, uint8_t offset,
+			    const uint8_t *data, size_t len);
+
+int sx126x_hal_read_buffer(const struct device *dev, uint8_t offset,
+			   uint8_t *data, size_t len);
+
+int sx126x_hal_set_dio1_callback(const struct device *dev,
+				 void (*callback)(const struct device *dev));
+
+void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable);
+
+void sx126x_hal_set_rf_switch(const struct device *dev, bool tx);
+
+int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
+			      gpio_flags_t flags, const char *name);
+
+#endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_HAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x_regs.h
+++ b/drivers/lora/native/sx126x/sx126x_regs.h
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_LORA_SX126X_SX126X_REGS_H_
+#define ZEPHYR_DRIVERS_LORA_SX126X_SX126X_REGS_H_
+
+#include <stdint.h>
+#include <zephyr/sys/util.h>
+
+/* SPI Command Opcodes */
+
+/* Operational Modes Commands */
+#define SX126X_CMD_SET_SLEEP                0x84
+#define SX126X_CMD_SET_STANDBY              0x80
+#define SX126X_CMD_SET_FS                   0xC1
+#define SX126X_CMD_SET_TX                   0x83
+#define SX126X_CMD_SET_RX                   0x82
+#define SX126X_CMD_STOP_TIMER_ON_PREAMBLE   0x9F
+#define SX126X_CMD_SET_RX_DUTY_CYCLE        0x94
+#define SX126X_CMD_SET_CAD                  0xC5
+#define SX126X_CMD_SET_TX_CONTINUOUS_WAVE   0xD1
+#define SX126X_CMD_SET_TX_INFINITE_PREAMBLE 0xD2
+#define SX126X_CMD_SET_REGULATOR_MODE       0x96
+#define SX126X_CMD_CALIBRATE                0x89
+#define SX126X_CMD_CALIBRATE_IMAGE          0x98
+#define SX126X_CMD_SET_PA_CONFIG            0x95
+#define SX126X_CMD_SET_RX_TX_FALLBACK_MODE  0x93
+
+/* Register and Buffer Access Commands */
+#define SX126X_CMD_WRITE_REGISTER           0x0D
+#define SX126X_CMD_READ_REGISTER            0x1D
+#define SX126X_CMD_WRITE_BUFFER             0x0E
+#define SX126X_CMD_READ_BUFFER              0x1E
+
+/* DIO and IRQ Control Commands */
+#define SX126X_CMD_SET_DIO_IRQ_PARAMS       0x08
+#define SX126X_CMD_GET_IRQ_STATUS           0x12
+#define SX126X_CMD_CLR_IRQ_STATUS           0x02
+#define SX126X_CMD_SET_DIO2_AS_RF_SWITCH    0x9D
+#define SX126X_CMD_SET_DIO3_AS_TCXO_CTRL    0x97
+
+/* RF, Modulation and Packet Commands */
+#define SX126X_CMD_SET_RF_FREQUENCY         0x86
+#define SX126X_CMD_SET_PACKET_TYPE          0x8A
+#define SX126X_CMD_GET_PACKET_TYPE          0x11
+#define SX126X_CMD_SET_TX_PARAMS            0x8E
+#define SX126X_CMD_SET_MODULATION_PARAMS    0x8B
+#define SX126X_CMD_SET_PACKET_PARAMS        0x8C
+#define SX126X_CMD_SET_CAD_PARAMS           0x88
+#define SX126X_CMD_SET_BUFFER_BASE_ADDRESS  0x8F
+#define SX126X_CMD_SET_LORA_SYMB_NUM_TIMEOUT 0xA0
+
+/* Status Commands */
+#define SX126X_CMD_GET_STATUS               0xC0
+#define SX126X_CMD_GET_RSSI_INST            0x15
+#define SX126X_CMD_GET_RX_BUFFER_STATUS     0x13
+#define SX126X_CMD_GET_PACKET_STATUS        0x14
+#define SX126X_CMD_GET_DEVICE_ERRORS        0x17
+#define SX126X_CMD_CLR_DEVICE_ERRORS        0x07
+#define SX126X_CMD_GET_STATS                0x10
+#define SX126X_CMD_RESET_STATS              0x00
+
+/* IRQ Flags (16-bit mask) */
+#define SX126X_IRQ_TX_DONE                  BIT(0)
+#define SX126X_IRQ_RX_DONE                  BIT(1)
+#define SX126X_IRQ_PREAMBLE_DETECTED        BIT(2)
+#define SX126X_IRQ_SYNC_WORD_VALID          BIT(3)
+#define SX126X_IRQ_HEADER_VALID             BIT(4)
+#define SX126X_IRQ_HEADER_ERR               BIT(5)
+#define SX126X_IRQ_CRC_ERR                  BIT(6)
+#define SX126X_IRQ_CAD_DONE                 BIT(7)
+#define SX126X_IRQ_CAD_ACTIVITY_DETECTED    BIT(8)
+#define SX126X_IRQ_RX_TX_TIMEOUT            BIT(9)
+
+#define SX126X_IRQ_ALL                      0x03FF
+
+/* Packet Types */
+#define SX126X_PACKET_TYPE_GFSK             0x00
+#define SX126X_PACKET_TYPE_LORA             0x01
+
+/* Standby Modes */
+#define SX126X_STANDBY_RC                   0x00
+#define SX126X_STANDBY_XOSC                 0x01
+
+/* Regulator Modes */
+#define SX126X_REGULATOR_LDO                0x00
+#define SX126X_REGULATOR_DCDC               0x01
+
+/* Sleep Configuration */
+#define SX126X_SLEEP_COLD_START             0x00
+#define SX126X_SLEEP_WARM_START             0x04
+
+/* Calibration Mask */
+#define SX126X_CALIBRATE_RC64K              BIT(0)
+#define SX126X_CALIBRATE_RC13M              BIT(1)
+#define SX126X_CALIBRATE_PLL                BIT(2)
+#define SX126X_CALIBRATE_ADC_PULSE          BIT(3)
+#define SX126X_CALIBRATE_ADC_BULK_N         BIT(4)
+#define SX126X_CALIBRATE_ADC_BULK_P         BIT(5)
+#define SX126X_CALIBRATE_IMAGE              BIT(6)
+#define SX126X_CALIBRATE_ALL                0x7F
+
+/* LoRa Bandwidth values (for SET_MODULATION_PARAMS) */
+#define SX126X_LORA_BW_7_8                  0x00
+#define SX126X_LORA_BW_10_4                 0x08
+#define SX126X_LORA_BW_15_6                 0x01
+#define SX126X_LORA_BW_20_8                 0x09
+#define SX126X_LORA_BW_31_25                0x02
+#define SX126X_LORA_BW_41_7                 0x0A
+#define SX126X_LORA_BW_62_5                 0x03
+#define SX126X_LORA_BW_125                  0x04
+#define SX126X_LORA_BW_250                  0x05
+#define SX126X_LORA_BW_500                  0x06
+
+/* LoRa Coding Rate values (for SET_MODULATION_PARAMS) */
+#define SX126X_LORA_CR_4_5                  0x01
+#define SX126X_LORA_CR_4_6                  0x02
+#define SX126X_LORA_CR_4_7                  0x03
+#define SX126X_LORA_CR_4_8                  0x04
+
+/* LoRa Header Type (for SET_PACKET_PARAMS) */
+#define SX126X_LORA_HEADER_EXPLICIT         0x00
+#define SX126X_LORA_HEADER_IMPLICIT         0x01
+
+/* LoRa CRC Mode (for SET_PACKET_PARAMS) */
+#define SX126X_LORA_CRC_OFF                 0x00
+#define SX126X_LORA_CRC_ON                  0x01
+
+/* LoRa IQ Mode (for SET_PACKET_PARAMS) */
+#define SX126X_LORA_IQ_STANDARD             0x00
+#define SX126X_LORA_IQ_INVERTED             0x01
+
+/* TX Power Ramp Time (for SET_TX_PARAMS) */
+#define SX126X_RAMP_10_US                   0x00
+#define SX126X_RAMP_20_US                   0x01
+#define SX126X_RAMP_40_US                   0x02
+#define SX126X_RAMP_80_US                   0x03
+#define SX126X_RAMP_200_US                  0x04
+#define SX126X_RAMP_800_US                  0x05
+#define SX126X_RAMP_1700_US                 0x06
+#define SX126X_RAMP_3400_US                 0x07
+
+/* Device Selection (for SET_PA_CONFIG) */
+#define SX126X_DEVICE_SEL_SX1262            0x00
+#define SX126X_DEVICE_SEL_SX1261            0x01
+
+/* PA Configuration per chip variant (from datasheet Table 13-21) */
+
+/* SX1261: Low power PA, up to +15 dBm */
+#define SX1261_MAX_POWER                    15
+#define SX1261_MAX_POWER_TX_PARAM           14
+#define SX1261_MIN_POWER                    (-17)
+#define SX1261_PA_DUTY_CYCLE_HIGH           0x06  /* For +15 dBm at >400 MHz */
+#define SX1261_PA_DUTY_CYCLE_LOW            0x04  /* For lower power / <400 MHz */
+#define SX1261_HP_MAX                       0x00  /* Not used on SX1261 */
+
+/* SX1262: High power PA, up to +22 dBm */
+#define SX1262_MAX_POWER                    22
+#define SX1262_MIN_POWER                    (-9)
+#define SX1262_PA_DUTY_CYCLE                0x04
+#define SX1262_HP_MAX                       0x07
+
+/* PA LUT (always 0x01) */
+#define SX126X_PA_LUT                       0x01
+
+/* Register Addresses */
+
+/* LoRa Sync Word */
+#define SX126X_REG_LORA_SYNC_WORD_MSB       0x0740
+#define SX126X_REG_LORA_SYNC_WORD_LSB       0x0741
+
+/* Sync Word Values */
+#define SX126X_LORA_SYNC_WORD_PUBLIC        0x3444
+#define SX126X_LORA_SYNC_WORD_PRIVATE       0x1424
+
+/* RX Gain */
+#define SX126X_REG_RX_GAIN                  0x08AC
+#define SX126X_RX_GAIN_POWER_SAVING         0x94
+#define SX126X_RX_GAIN_BOOSTED              0x96
+
+/* TX Clamp Config (workaround for SX1262) */
+#define SX126X_REG_TX_CLAMP_CFG             0x08D8
+
+/* IQ Polarity (workaround) */
+#define SX126X_REG_IQ_POLARITY              0x0736
+
+/* TX Modulation (workaround for 500kHz BW) */
+#define SX126X_REG_TX_MODULATION            0x0889
+
+/* Random Number Generator */
+#define SX126X_REG_RANDOM_NUMBER_GEN        0x0819
+
+/* Status Byte Decoding */
+#define SX126X_STATUS_CHIP_MODE_MASK        0xE0
+#define SX126X_STATUS_CHIP_MODE_SHIFT       5
+#define SX126X_STATUS_CMD_STATUS_MASK       0x1E
+#define SX126X_STATUS_CMD_STATUS_SHIFT      1
+
+/* Chip Modes */
+#define SX126X_CHIP_MODE_UNUSED             0x00
+#define SX126X_CHIP_MODE_RFU                0x01
+#define SX126X_CHIP_MODE_STBY_RC            0x02
+#define SX126X_CHIP_MODE_STBY_XOSC          0x03
+#define SX126X_CHIP_MODE_FS                 0x04
+#define SX126X_CHIP_MODE_RX                 0x05
+#define SX126X_CHIP_MODE_TX                 0x06
+
+/* Command Status */
+#define SX126X_CMD_STATUS_RESERVED          0x00
+#define SX126X_CMD_STATUS_RFU               0x01
+#define SX126X_CMD_STATUS_DATA_AVAILABLE    0x02
+#define SX126X_CMD_STATUS_CMD_TIMEOUT       0x03
+#define SX126X_CMD_STATUS_CMD_PROC_ERROR    0x04
+#define SX126X_CMD_STATUS_EXEC_FAILURE      0x05
+#define SX126X_CMD_STATUS_CMD_TX_DONE       0x06
+
+/* Timeout Special Values (in units of 15.625 us) */
+#define SX126X_RX_TIMEOUT_CONTINUOUS        0x000000
+#define SX126X_RX_TIMEOUT_SINGLE            0xFFFFFF
+#define SX126X_TX_TIMEOUT_NONE              0x000000
+
+/* Convert milliseconds to timeout ticks */
+#define SX126X_MS_TO_TIMEOUT(ms)            ((uint32_t)((ms) * 64))
+
+/* Crystal Frequency */
+#define SX126X_XTAL_FREQ                    32000000UL
+
+/* Frequency calculation: freq_reg = (frequency * 2^25) / XTAL_FREQ */
+#define SX126X_FREQ_TO_REG(freq) \
+	((uint32_t)(((uint64_t)(freq) << 25) / SX126X_XTAL_FREQ))
+
+/* Maximum payload size */
+#define SX126X_MAX_PAYLOAD_LEN              255
+
+/* Buffer size */
+#define SX126X_BUFFER_SIZE                  256
+
+#endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_REGS_H_ */

--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -23,3 +23,11 @@ tests:
       - rak11720
     extra_configs:
       - CONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM=y
+  sample.driver.lora.receive.native:
+    build_only: true
+    extra_args:
+      - SHIELD=semtech_sx1261mb2bas
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    platform_allow:
+      - nrf52840dk/nrf52840

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -23,3 +23,11 @@ tests:
       - rak11720
     extra_configs:
       - CONFIG_LORA_MODULE_BACKEND_LORA_BASICS_MODEM=y
+  sample.driver.lora.send.native:
+    build_only: true
+    extra_args:
+      - SHIELD=semtech_sx1261mb2bas
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    platform_allow:
+      - nrf52840dk/nrf52840

--- a/tests/drivers/build_all/lora/testcase.yaml
+++ b/tests/drivers/build_all/lora/testcase.yaml
@@ -19,6 +19,15 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+  sample.driver.lora.build.sx1262.native:
+    build_only: true
+    extra_args: DTC_OVERLAY_FILE="sx1262.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
   sample.driver.lora.build.sx1272:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="sx1272.overlay"


### PR DESCRIPTION
I decided to embark on a crusade to free Zephyr from the tyranny of the semtech drivers and modules. This is the first tiny step in that direction: a semtech-free LoRa driver for the SX126x transceiver. 