### PR TITLE
scripts: tests: speed up `test_output_levels`

### DIFF
--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -166,7 +166,7 @@ class TestOutput:
     )
     def test_output_levels(self, capfd, out_path, flags):
         test_path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic')
-        args = ['--outdir', out_path, '-T', test_path, *flags]
+        args = ['--outdir', out_path, '-T', test_path, '-p', 'qemu_x86', *flags]
 
         with mock.patch.object(sys, 'argv', [sys.argv[0]] + args), \
             pytest.raises(SystemExit) as sys_exit:


### PR DESCRIPTION
Assign a platform to the test so Twister doesn't pick up multiple platforms.

This reduces the test time by ~2 minutes.

Before: 9 passed in 265.88s (0:04:25)
After: 9 passed in 140.24s (0:02:20)