### PR TITLE
video: shell: fixes, and tree command

### DIFF
--- a/drivers/video/video_shell.c
+++ b/drivers/video/video_shell.c
@@ -868,7 +868,7 @@ static void complete_video_ctrl_menu_name(size_t idx, struct shell_static_entry 
 	}
 
 }
-LISTIFY(10, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_ctrl_menu_name);
+LISTIFY(20, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_ctrl_menu_name);
 
 static const union shell_cmd_entry *dsub_video_ctrl_menu_name[] = {
 	&dsub_video_ctrl_menu_name0, &dsub_video_ctrl_menu_name1,
@@ -876,6 +876,11 @@ static const union shell_cmd_entry *dsub_video_ctrl_menu_name[] = {
 	&dsub_video_ctrl_menu_name4, &dsub_video_ctrl_menu_name5,
 	&dsub_video_ctrl_menu_name6, &dsub_video_ctrl_menu_name7,
 	&dsub_video_ctrl_menu_name8, &dsub_video_ctrl_menu_name9,
+	&dsub_video_ctrl_menu_name10, &dsub_video_ctrl_menu_name11,
+	&dsub_video_ctrl_menu_name12, &dsub_video_ctrl_menu_name13,
+	&dsub_video_ctrl_menu_name14, &dsub_video_ctrl_menu_name15,
+	&dsub_video_ctrl_menu_name16, &dsub_video_ctrl_menu_name17,
+	&dsub_video_ctrl_menu_name18, &dsub_video_ctrl_menu_name19,
 };
 
 static void complete_video_ctrl_name_dev(size_t idx, struct shell_static_entry *entry, int devn)
@@ -921,7 +926,7 @@ static void complete_video_ctrl_name_dev(size_t idx, struct shell_static_entry *
 		break;
 	}
 }
-LISTIFY(10, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_ctrl_name_dev);
+LISTIFY(20, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_ctrl_name_dev);
 
 static const union shell_cmd_entry *dsub_video_ctrl_name_dev[] = {
 	&dsub_video_ctrl_name_dev0, &dsub_video_ctrl_name_dev1,
@@ -929,6 +934,11 @@ static const union shell_cmd_entry *dsub_video_ctrl_name_dev[] = {
 	&dsub_video_ctrl_name_dev4, &dsub_video_ctrl_name_dev5,
 	&dsub_video_ctrl_name_dev6, &dsub_video_ctrl_name_dev7,
 	&dsub_video_ctrl_name_dev8, &dsub_video_ctrl_name_dev9,
+	&dsub_video_ctrl_name_dev10, &dsub_video_ctrl_name_dev11,
+	&dsub_video_ctrl_name_dev12, &dsub_video_ctrl_name_dev13,
+	&dsub_video_ctrl_name_dev14, &dsub_video_ctrl_name_dev15,
+	&dsub_video_ctrl_name_dev16, &dsub_video_ctrl_name_dev17,
+	&dsub_video_ctrl_name_dev18, &dsub_video_ctrl_name_dev19,
 };
 
 static void complete_video_ctrl_dev(size_t idx, struct shell_static_entry *entry)
@@ -1042,7 +1052,7 @@ static void complete_video_format_dir_dev(size_t idx, struct shell_static_entry 
 		break;
 	}
 }
-LISTIFY(10, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_format_dir_dev);
+LISTIFY(20, VIDEO_SHELL_COMPLETE_DEFINE, (;), video_format_dir_dev);
 
 static const union shell_cmd_entry *dsub_video_format_dir_dev[] = {
 	&dsub_video_format_dir_dev0, &dsub_video_format_dir_dev1,
@@ -1050,6 +1060,11 @@ static const union shell_cmd_entry *dsub_video_format_dir_dev[] = {
 	&dsub_video_format_dir_dev4, &dsub_video_format_dir_dev5,
 	&dsub_video_format_dir_dev6, &dsub_video_format_dir_dev7,
 	&dsub_video_format_dir_dev8, &dsub_video_format_dir_dev9,
+	&dsub_video_format_dir_dev10, &dsub_video_format_dir_dev11,
+	&dsub_video_format_dir_dev12, &dsub_video_format_dir_dev13,
+	&dsub_video_format_dir_dev14, &dsub_video_format_dir_dev15,
+	&dsub_video_format_dir_dev16, &dsub_video_format_dir_dev17,
+	&dsub_video_format_dir_dev18, &dsub_video_format_dir_dev19,
 };
 
 static void complete_video_format_dev(size_t idx, struct shell_static_entry *entry)

--- a/drivers/video/video_shell.c
+++ b/drivers/video/video_shell.c
@@ -855,14 +855,12 @@ static void complete_video_ctrl_name_dev(size_t idx, struct shell_static_entry *
 	struct video_ctrl_query *cq = &video_shell_cq;
 	int ret;
 
-
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = NULL;
 	entry->syntax = NULL;
 
 	/* Check which device was selected */
-
 	dev = video_shell_dev = video_shell_get_dev_by_num(devn);
 	if (!device_is_ready(dev)) {
 		return;
@@ -1171,6 +1169,80 @@ static int cmd_video_selection(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static void complete_video_selection_target(size_t idx, struct shell_static_entry *entry)
+{
+	entry->syntax = NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+	video_shell_dev = NULL;
+
+	switch (idx) {
+	case 0:
+		entry->syntax = "crop";
+		break;
+	case 1:
+		entry->syntax = "crop_bound";
+		break;
+	case 2:
+		entry->syntax = "native_size";
+		break;
+	case 3:
+		entry->syntax = "compose";
+		break;
+	case 4:
+		entry->syntax = "compose_bound";
+		break;
+	default:
+		entry->syntax = NULL;
+		break;
+	}
+}
+SHELL_DYNAMIC_CMD_CREATE(dsub_video_selection_target, complete_video_selection_target);
+
+static void complete_video_selection_dir(size_t idx, struct shell_static_entry *entry)
+{
+	entry->syntax = NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+	video_shell_dev = NULL;
+
+	switch (idx) {
+	case 0:
+		entry->subcmd = &dsub_video_selection_target;
+		entry->syntax = "in";
+		break;
+	case 1:
+		entry->subcmd = &dsub_video_selection_target;
+		entry->syntax = "out";
+		break;
+	default:
+		entry->syntax = NULL;
+		break;
+	}
+}
+SHELL_DYNAMIC_CMD_CREATE(dsub_video_selection_dir, complete_video_selection_dir);
+
+static void complete_video_selection_dev(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev;
+
+	entry->syntax = NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+
+	dev = video_shell_get_dev_by_num(idx);
+	if (idx >= ARRAY_SIZE(dsub_video_format_dir_dev)) {
+		return;
+	}
+
+	entry->syntax = dev->name;
+	entry->subcmd = &dsub_video_selection_dir;
+}
+SHELL_DYNAMIC_CMD_CREATE(dsub_video_selection_dev, complete_video_selection_dev);
+
 /* Video shell commands declaration */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_video_cmds,
@@ -1196,7 +1268,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_video_cmds,
 		SHELL_HELP("Query or set video controls of a device",
 			   "<device> [<ctrl> <value>]"),
 		cmd_video_ctrl, 2, 2),
-	SHELL_CMD_ARG(selection, &dsub_video_format_dev,
+	SHELL_CMD_ARG(selection, &dsub_video_selection_dev,
 		SHELL_HELP("Query or set the video selection of a device",
 			   "<device> <dir> <target> [<left> <top> <width>x<height>]"),
 		cmd_video_selection, 4, 3),

--- a/drivers/video/video_shell.c
+++ b/drivers/video/video_shell.c
@@ -73,7 +73,7 @@ static const struct device *video_shell_get_dev_by_num(int num)
 	size_t n = z_device_get_all_static(&dev_list);
 
 	for (size_t i = 0; i < n; i++) {
-		if (!DEVICE_API_IS(video, (&dev_list[i]))) {
+		if (!device_is_video_and_ready(&dev_list[i])) {
 			continue;
 		}
 		if (num == 0) {
@@ -862,7 +862,7 @@ static void complete_video_ctrl_name_dev(size_t idx, struct shell_static_entry *
 
 	/* Check which device was selected */
 	dev = video_shell_dev = video_shell_get_dev_by_num(devn);
-	if (!device_is_ready(dev)) {
+	if (dev == NULL) {
 		return;
 	}
 
@@ -911,8 +911,12 @@ static void complete_video_ctrl_dev(size_t idx, struct shell_static_entry *entry
 	entry->help = NULL;
 	entry->subcmd = NULL;
 
+	if (idx >= ARRAY_SIZE(dsub_video_ctrl_name_dev)) {
+		return;
+	}
+
 	dev = video_shell_get_dev_by_num(idx);
-	if (!device_is_ready(dev) || idx >= ARRAY_SIZE(dsub_video_ctrl_name_dev)) {
+	if (dev == NULL) {
 		return;
 	}
 
@@ -989,7 +993,7 @@ static void complete_video_format_dir_dev(size_t idx, struct shell_static_entry 
 	/* Check which device was selected */
 
 	dev = video_shell_dev = video_shell_get_dev_by_num(devn);
-	if (!device_is_ready(dev)) {
+	if (dev == NULL) {
 		return;
 	}
 
@@ -1028,8 +1032,12 @@ static void complete_video_format_dev(size_t idx, struct shell_static_entry *ent
 	entry->help = NULL;
 	entry->subcmd = NULL;
 
+	if (idx >= ARRAY_SIZE(dsub_video_format_dir_dev)) {
+		return;
+	}
+
 	dev = video_shell_get_dev_by_num(idx);
-	if (!device_is_ready(dev) || idx >= ARRAY_SIZE(dsub_video_format_dir_dev)) {
+	if (dev == NULL) {
 		return;
 	}
 
@@ -1233,8 +1241,12 @@ static void complete_video_selection_dev(size_t idx, struct shell_static_entry *
 	entry->help = NULL;
 	entry->subcmd = NULL;
 
-	dev = video_shell_get_dev_by_num(idx);
 	if (idx >= ARRAY_SIZE(dsub_video_format_dir_dev)) {
+		return;
+	}
+
+	dev = video_shell_get_dev_by_num(idx);
+	if (dev == NULL) {
 		return;
 	}
 


### PR DESCRIPTION
This adds multiple small improvements to the shell:

- fixes tab completion for `video selection ...` command
- fixes tab completion when there are failed devices
- adds an extra debug command to inspect the tree/chain of video source devices

I can also split it in smaller PRs if this helps.