### PR TITLE
soc: bflb: Fix EM zone clobbering occupation of WRAM

### DIFF
--- a/soc/bflb/bl61x/Kconfig
+++ b/soc/bflb/bl61x/Kconfig
@@ -12,6 +12,7 @@ config SOC_SERIES_BL61X
 	select REGULATOR
 	select RISCV
 	select SOC_EARLY_INIT_HOOK
+	select SOC_PREP_HOOK
 	select SYSCON
 	select XIP
 	select CPU_XUANTIE_E907

--- a/soc/bflb/bl61x/soc.c
+++ b/soc/bflb/bl61x/soc.c
@@ -191,7 +191,15 @@ void soc_early_init_hook(void)
 	tmp &= ~HBN_REG_EN_AON_CTRL_GPIO_MSK;
 	sys_write32(tmp, HBN_BASE + HBN_PAD_CTRL_0_OFFSET);
 
-	/* TODO: 'em' config for ble goes here */
-
 	irq_unlock(key);
+}
+
+void soc_prep_hook(void)
+{
+	uint32_t tmp;
+
+	/* Disable default EM zone before data relocation happens */
+	tmp = sys_read32(GLB_BASE + GLB_SRAM_CFG3_OFFSET);
+	tmp &= GLB_EM_SEL_UMSK;
+	sys_write32(tmp, GLB_BASE + GLB_SRAM_CFG3_OFFSET);
 }


### PR DESCRIPTION
EM occupates the last 32KB of WRAM by default,
we cannot use it for now, disable EM