### PR TITLE
MAINTAINERS: Update maintained files from Microchip

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4310,6 +4310,8 @@ Peregrine Platforms:
     - nandojve
   files:
     - boards/peregrine/
+    - boards/shields/atmel_rf2xx/
+    - drivers/ieee802154/*rf2xx*
   labels:
     - "platform: Peregrine"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3402,6 +3402,7 @@ Microchip MEC Platforms:
     - albertofloyd
   files:
     - boards/microchip/mec*/
+    - boards/microchip/ev11l78a/
     - dts/arm/microchip/
     - soc/microchip/mec/
     - tests/boards/mec15xxevb_assy6853/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3407,6 +3407,7 @@ Microchip MEC Platforms:
     - soc/microchip/mec/
     - drivers/*/*xec*
     - drivers/sensor/microchip/mchp_tach_xec/
+    - include/zephyr/*/*/*xec*
     - tests/boards/mec15xxevb_assy6853/
     - tests/boards/mec172xevb_assy6906/
     - dts/bindings/*/microchip,mec*
@@ -3459,6 +3460,7 @@ Microchip RISC-V Platforms:
     - drivers/*/*mchp*mss*
     - dts/bindings/*/microchip,mpfs*
     - dts/bindings/*/microchip,coreuart*
+    - include/zephyr/dt-bindings/reset/mchp_mss*
   labels:
     - "platform: Microchip RISC-V"
 
@@ -3476,6 +3478,8 @@ Microchip SAM Platforms:
     - soc/microchip/sam/sama*/
     - drivers/*/*sam*
     - dts/bindings/*/atmel,*
+    - include/zephyr/*/*/*sam*
+    - include/zephyr/*/*/*atmel*
   labels:
     - "platform: Microchip SAM"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3411,6 +3411,7 @@ Microchip MEC Platforms:
     - tests/boards/mec172xevb_assy6906/
     - dts/bindings/*/microchip,mec*
     - dts/bindings/*/microchip,xec*
+    - dts/bindings/*/microchip,dmec*
     - samples/boards/microchip/mec*
   labels:
     - "platform: Microchip MEC"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3456,6 +3456,8 @@ Microchip RISC-V Platforms:
     - soc/microchip/miv/
     - soc/microchip/pic64/
     - drivers/*/*mchp*mss*
+    - dts/bindings/*/microchip,mpfs*
+    - dts/bindings/*/microchip,coreuart*
   labels:
     - "platform: Microchip RISC-V"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3410,10 +3410,11 @@ Microchip MEC Platforms:
     - include/zephyr/*/*/*xec*
     - tests/boards/mec15xxevb_assy6853/
     - tests/boards/mec172xevb_assy6906/
+    - tests/**/boards/*mec*
     - dts/bindings/*/microchip,mec*
     - dts/bindings/*/microchip,xec*
     - dts/bindings/*/microchip,dmec*
-    - samples/boards/microchip/mec*
+    - samples/**/boards/mec*
   labels:
     - "platform: Microchip MEC"
 
@@ -3437,8 +3438,11 @@ Microchip PIC32 Platforms:
     - dts/bindings/*/microchip,*-g*
     - drivers/*/*mchp*
     - include/zephyr/**/mchp*
+    - samples/**/boards/sam_*
     - soc/microchip/pic32*/
     - tests/**/boards/pic32*
+    - tests/**/boards/sam_*
+    - tests/**/microchip/
   labels:
     - "platform: Microchip PIC32"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3413,6 +3413,29 @@ Microchip MEC Platforms:
   labels:
     - "platform: Microchip MEC"
 
+Microchip PIC32 Platforms:
+  status: maintained
+  maintainers:
+    - ArunMCHP
+    - NhMchp
+  collaborators:
+    - fabin-mchp
+    - Farsin-Nasar-Microchip
+    - mchp-asif
+    - sunil-abraham
+    - AzharMCHP
+    - nandojve
+  files:
+    - boards/microchip/pic32*/
+    - dts/bindings/*/microchip/pic32*/
+    - dts/arm/microchip/pic32*/
+    - drivers/*/*mchp*
+    - include/zephyr/**/mchp*
+    - soc/microchip/pic32*/
+    - tests/**/boards/pic32*
+  labels:
+    - "platform: Microchip PIC32"
+
 Microchip RISC-V Platforms:
   status: maintained
   maintainers:
@@ -3440,11 +3463,9 @@ Microchip SAM Platforms:
     - stephanosio
   files:
     - boards/atmel/
-    - boards/microchip/sam/
     - dts/arm/atmel/
-    - dts/arm/microchip/sam/
     - soc/atmel/
-    - soc/microchip/sam/
+    - soc/microchip/sam/sama*/
     - drivers/*/*sam*.c
     - dts/bindings/*/atmel,*
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3403,13 +3403,14 @@ Microchip MEC Platforms:
   files:
     - boards/microchip/mec*/
     - boards/microchip/ev11l78a/
-    - dts/arm/microchip/
+    - dts/arm/microchip/mec/
     - soc/microchip/mec/
+    - drivers/*/*xec*
     - tests/boards/mec15xxevb_assy6853/
     - tests/boards/mec172xevb_assy6906/
     - dts/bindings/*/microchip,mec*
     - dts/bindings/*/microchip,xec*
-    - samples/boards/microchip/
+    - samples/boards/microchip/mec*
   labels:
     - "platform: Microchip MEC"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3406,6 +3406,7 @@ Microchip MEC Platforms:
     - dts/arm/microchip/mec/
     - soc/microchip/mec/
     - drivers/*/*xec*
+    - drivers/sensor/microchip/mchp_tach_xec/
     - tests/boards/mec15xxevb_assy6853/
     - tests/boards/mec172xevb_assy6906/
     - dts/bindings/*/microchip,mec*

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3429,8 +3429,10 @@ Microchip PIC32 Platforms:
     - nandojve
   files:
     - boards/microchip/pic32*/
-    - dts/bindings/*/microchip/pic32*/
     - dts/arm/microchip/pic32*/
+    - dts/bindings/*/microchip/pic32*/
+    - dts/bindings/*/microchip,sam*
+    - dts/bindings/*/microchip,*-g*
     - drivers/*/*mchp*
     - include/zephyr/**/mchp*
     - soc/microchip/pic32*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3404,7 +3404,6 @@ Microchip MEC Platforms:
     - boards/microchip/mec*/
     - dts/arm/microchip/
     - soc/microchip/mec/
-    - drivers/*/*mchp*.c
     - tests/boards/mec15xxevb_assy6853/
     - tests/boards/mec172xevb_assy6906/
     - dts/bindings/*/microchip,mec*

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3466,7 +3466,7 @@ Microchip SAM Platforms:
     - dts/arm/atmel/
     - soc/atmel/
     - soc/microchip/sam/sama*/
-    - drivers/*/*sam*.c
+    - drivers/*/*sam*
     - dts/bindings/*/atmel,*
   labels:
     - "platform: Microchip SAM"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3452,6 +3452,7 @@ Microchip RISC-V Platforms:
     - dts/riscv/microchip/
     - soc/microchip/miv/
     - soc/microchip/pic64/
+    - drivers/*/*mchp*mss*
   labels:
     - "platform: Microchip RISC-V"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3490,6 +3490,14 @@ Microchip Standalone Devices:
     - drivers/sensor/microchip/mcp970x/
     - drivers/sensor/microchip/mtch9010/
     - drivers/sensor/microchip/tcn75a/
+    - dts/bindings/*/microchip,cap*
+    - dts/bindings/*/microchip,enc*
+    - dts/bindings/*/microchip,mcp*
+    - dts/bindings/*/microchip,tcn*
+    - dts/bindings/**/microchip,ksz*
+    - dts/bindings/**/microchip,lan*
+    - dts/bindings/**/microchip,t1s*
+    - dts/bindings/**/microchip,vsc*
   labels:
     - "platform: Microchip"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3474,6 +3474,20 @@ Microchip SAM Platforms:
   labels:
     - "platform: Microchip SAM"
 
+Microchip Standalone Devices:
+  status: maintained
+  maintainers:
+    - NhMchp
+  files:
+    - drivers/bbram/*microchip*
+    - drivers/ethernet/phy/*microchip*
+    - drivers/sensor/microchip/mcp9600/
+    - drivers/sensor/microchip/mcp970x/
+    - drivers/sensor/microchip/mtch9010/
+    - drivers/sensor/microchip/tcn75a/
+  labels:
+    - "platform: Microchip"
+
 Modbus:
   status: maintained
   maintainers:


### PR DESCRIPTION
This is a scan in the zephyr tree to identify spots not covered in the maintainers.yml file related to Microchip.
In this proposal many areas where identified and it is not clear which division should take care.

I believe that generic patterns like Kconfig.mchp or Kconfig.microchip in future will be in a generic session covering the commons and shared content together with the new generic drivers. At moment, I bring to Platform SAM those because seems to be the more active contributions at moment.

This is the best I can suggest without a clear pattern to follow.
Let me know if any adjust is necessary.