### PR TITLE
drivers: flash: stm32wba65ri : Add byte-write emulation to handle unaligned flash writes on STM32WBA65

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -104,4 +104,18 @@ config USE_MICROCHIP_QSPI_FLASH_WITH_STM32
 	  Set to use Microchip QSPI flash memories which use the PP_1_1_4 opcode
 	  (32H) for the PP_1_4_4 operation (usually 38H).
 
+config FLASH_STM32_ACCEPT_UNALIGNED_WRITES
+	bool "Extended operation for STM32 SoCs to handle unaligned offsets and lengths."
+	depends on SOC_STM32WBA65XX
+	help
+		Enable support for flash_write() calls when unaligned offsets and lengths are passed.
+		DO NOT ENABLE THIS OPTION WITHOUT UNDERSTANDING THE TARGET'S FLASH HARDWARE IMPLEMENTATION
+		DETAILS AND LIMITATIONS.
+
+		When this option is enabled, unaligned writes will be handled by writing to all blocks in range
+		[offset; offset + length]. Blocks for which only part of the contents are provided are padded with
+		the flash's erase value before writing. THIS IS NOT A READ-MODIFY-WRITE type operation! The flash
+		addresses being written to are expected to be erased before writing to them. Contens of the flash
+		after unaligned writes depend on the flash hardware details. The operation may fault.
+
 endif # SOC_FLASH_STM32

--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -108,14 +108,14 @@ config FLASH_STM32_ACCEPT_UNALIGNED_WRITES
 	bool "Extended operation for STM32 SoCs to handle unaligned offsets and lengths."
 	depends on SOC_STM32WBA65XX
 	help
-		Enable support for flash_write() calls when unaligned offsets and lengths are passed.
-		DO NOT ENABLE THIS OPTION WITHOUT UNDERSTANDING THE TARGET'S FLASH HARDWARE IMPLEMENTATION
-		DETAILS AND LIMITATIONS.
+	  Enable support for flash_write() calls when unaligned offsets and lengths are passed.
+	  DO NOT ENABLE THIS OPTION WITHOUT UNDERSTANDING THE TARGET'S FLASH HARDWARE IMPLEMENTATION
+	  DETAILS AND LIMITATIONS.
 
-		When this option is enabled, unaligned writes will be handled by writing to all blocks in range
-		[offset; offset + length]. Blocks for which only part of the contents are provided are padded with
-		the flash's erase value before writing. THIS IS NOT A READ-MODIFY-WRITE type operation! The flash
-		addresses being written to are expected to be erased before writing to them. Contens of the flash
-		after unaligned writes depend on the flash hardware details. The operation may fault.
+	  When this option is enabled, unaligned writes will be handled by writing to all blocks in range
+	  [offset; offset + length]. Blocks for which only part of the contents are provided are padded with
+	  the flash's erase value before writing. THIS IS NOT A READ-MODIFY-WRITE type operation! The flash
+	  addresses being written to are expected to be erased before writing to them. Contens of the flash
+	  after unaligned writes depend on the flash hardware details. The operation may fault.
 
 endif # SOC_FLASH_STM32

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -40,8 +40,7 @@ LOG_MODULE_REGISTER(flash_stm32, CONFIG_FLASH_LOG_LEVEL);
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */
-#define STM32_FLASH_TIMEOUT	\
-	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
+#define STM32_FLASH_TIMEOUT (2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
 static const struct flash_parameters flash_stm32_parameters = {
 	.write_block_size = FLASH_STM32_WRITE_BLOCK_SIZE,
@@ -54,8 +53,8 @@ static const struct flash_parameters flash_stm32_parameters = {
 #endif
 };
 
-bool __weak flash_stm32_valid_range(const struct device *dev, off_t offset,
-				    uint32_t len, bool write)
+bool __weak flash_stm32_valid_range(const struct device *dev, off_t offset, uint32_t len,
+				    bool write)
 {
 	if (write && !flash_stm32_valid_write(offset, len)) {
 		return false;
@@ -68,18 +67,16 @@ int __weak flash_stm32_check_configuration(void)
 	return 0;
 }
 
-
 #if !defined(CONFIG_SOC_SERIES_STM32WBX)
 static int flash_stm32_check_status(const struct device *dev)
 {
 
 	if (FLASH_STM32_REGS(dev)->FLASH_STM32_SR & FLASH_STM32_SR_ERRORS) {
-		LOG_DBG("Status: 0x%08lx",
-			(unsigned long)FLASH_STM32_REGS(dev)->FLASH_STM32_SR &
-							FLASH_STM32_SR_ERRORS);
+		LOG_DBG("Status: 0x%08lx", (unsigned long)FLASH_STM32_REGS(dev)->FLASH_STM32_SR &
+						   FLASH_STM32_SR_ERRORS);
 		/* Clear errors to unblock usage of the flash */
-		FLASH_STM32_REGS(dev)->FLASH_STM32_CCR = FLASH_STM32_REGS(dev)->FLASH_STM32_SR &
-							 FLASH_STM32_SR_ERRORS;
+		FLASH_STM32_REGS(dev)->FLASH_STM32_CCR =
+			FLASH_STM32_REGS(dev)->FLASH_STM32_SR & FLASH_STM32_SR_ERRORS;
 		return -EIO;
 	}
 
@@ -122,20 +119,17 @@ int flash_stm32_wait_flash_idle(const struct device *dev)
 	return 0;
 }
 
-static void flash_stm32_flush_caches(const struct device *dev,
-				     off_t offset, size_t len)
+static void flash_stm32_flush_caches(const struct device *dev, off_t offset, size_t len)
 {
-#if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32G0X) || defined(CONFIG_SOC_SERIES_STM32L5X) || \
-	defined(CONFIG_SOC_SERIES_STM32U3X) || defined(CONFIG_SOC_SERIES_STM32U5X) || \
+#if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F3X) ||                  \
+	defined(CONFIG_SOC_SERIES_STM32G0X) || defined(CONFIG_SOC_SERIES_STM32L5X) ||              \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || defined(CONFIG_SOC_SERIES_STM32U5X) ||              \
 	defined(CONFIG_SOC_SERIES_STM32H5X)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(offset);
 	ARG_UNUSED(len);
-#elif defined(CONFIG_SOC_SERIES_STM32F4X) || \
-	defined(CONFIG_SOC_SERIES_STM32L4X) || \
-	defined(CONFIG_SOC_SERIES_STM32WBX) || \
-	defined(CONFIG_SOC_SERIES_STM32G4X)
+#elif defined(CONFIG_SOC_SERIES_STM32F4X) || defined(CONFIG_SOC_SERIES_STM32L4X) ||                \
+	defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32G4X)
 	ARG_UNUSED(offset);
 	ARG_UNUSED(len);
 
@@ -148,18 +142,14 @@ static void flash_stm32_flush_caches(const struct device *dev,
 		regs->ACR |= FLASH_ACR_DCEN;
 	}
 #elif defined(CONFIG_SOC_SERIES_STM32F7X)
-	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS
-						  + offset), len);
+	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset), len);
 #endif
 }
 
-static int flash_stm32_read(const struct device *dev, off_t offset,
-			    void *data,
-			    size_t len)
+static int flash_stm32_read(const struct device *dev, off_t offset, void *data, size_t len)
 {
 	if (!flash_stm32_valid_range(dev, offset, len, false)) {
-		LOG_ERR("Read range invalid. Offset: %ld, len: %zu",
-			(long int) offset, len);
+		LOG_ERR("Read range invalid. Offset: %ld, len: %zu", (long)offset, len);
 		return -EINVAL;
 	}
 
@@ -167,21 +157,19 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 		return 0;
 	}
 
-	LOG_DBG("Read offset: %ld, len: %zu", (long int) offset, len);
+	LOG_DBG("Read offset: %ld, len: %zu", (long)offset, len);
 
-	memcpy(data, (uint8_t *) FLASH_STM32_BASE_ADDRESS + offset, len);
+	memcpy(data, (uint8_t *)FLASH_STM32_BASE_ADDRESS + offset, len);
 
 	return 0;
 }
 
-static int flash_stm32_erase(const struct device *dev, off_t offset,
-			     size_t len)
+static int flash_stm32_erase(const struct device *dev, off_t offset, size_t len)
 {
 	int rc;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Erase range invalid. Offset: %ld, len: %zu",
-			(long int) offset, len);
+		LOG_ERR("Erase range invalid. Offset: %ld, len: %zu", (long)offset, len);
 		return -EINVAL;
 	}
 
@@ -191,7 +179,7 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Erase offset: %ld, len: %zu", (long int) offset, len);
+	LOG_DBG("Erase offset: %ld, len: %zu", (long)offset, len);
 
 	rc = flash_stm32_cr_lock(dev, false);
 	if (rc == 0) {
@@ -211,14 +199,12 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_stm32_write(const struct device *dev, off_t offset,
-			     const void *data, size_t len)
+static int flash_stm32_write(const struct device *dev, off_t offset, const void *data, size_t len)
 {
 	int rc;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Write range invalid. Offset: %ld, len: %zu",
-			(long int) offset, len);
+		LOG_ERR("Write range invalid. Offset: %ld, len: %zu", (long)offset, len);
 		return -EINVAL;
 	}
 
@@ -228,7 +214,7 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Write offset: %ld, len: %zu", (long int) offset, len);
+	LOG_DBG("Write offset: %ld, len: %zu", (long)offset, len);
 
 	rc = flash_stm32_cr_lock(dev, false);
 	if (rc == 0) {
@@ -247,8 +233,7 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 }
 
 #ifdef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
-static int write_unaligned(const struct device *dev, off_t offset,
-				       const uint8_t *data, size_t len)
+static int write_unaligned(const struct device *dev, off_t offset, const uint8_t *data, size_t len)
 {
 	uint8_t temp_data[FLASH_STM32_WRITE_BLOCK_SIZE];
 	off_t cur_offset_addr;
@@ -269,8 +254,8 @@ static int write_unaligned(const struct device *dev, off_t offset,
 	return flash_stm32_write(dev, cur_offset_addr, temp_data, FLASH_STM32_WRITE_BLOCK_SIZE);
 }
 
-static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
-			     const void *data, size_t len)
+static int flash_stm32_no_align_write(const struct device *dev, off_t offset, const void *data,
+				      size_t len)
 {
 	const uint8_t *data_ptr = data;
 	size_t chunk_size, local_offset;
@@ -315,9 +300,9 @@ static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
 			remaining -= chunk_size;
 		} else {
 			/* Workaround for some SOCs (H7, U3 etc.) which requires word-aligned
-			* input buffer. This should not be necessary once this bug is fixed in
-			* the flash driver.
-			*/
+			 * input buffer. This should not be necessary once this bug is fixed in
+			 * the flash driver.
+			 */
 			size_t temp_chunk_size = chunk_size;
 
 			while (temp_chunk_size > 0) {
@@ -467,8 +452,7 @@ int flash_stm32_option_bytes_disable(const struct device *dev)
 }
 #endif /* CONFIG_FLASH_STM32_BLOCK_REGISTERS */
 
-static const struct flash_parameters *
-flash_stm32_get_parameters(const struct device *dev)
+static const struct flash_parameters *flash_stm32_get_parameters(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -503,10 +487,10 @@ static int flash_stm32_get_size(const struct device *dev, uint64_t *size)
 }
 
 static struct flash_stm32_priv flash_data = {
-	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
-	/* Getting clocks information from device tree description depending
-	 * on the presence of 'clocks' property.
-	 */
+	.regs = (FLASH_TypeDef *)DT_INST_REG_ADDR(0),
+/* Getting clocks information from device tree description depending
+ * on the presence of 'clocks' property.
+ */
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	.pclken = STM32_DT_INST_CLOCK_INFO(0),
 #endif
@@ -544,10 +528,8 @@ static int stm32_flash_init(const struct device *dev)
 	 * On STM32 F0, F1, F3 & L1 series, flash interface clock source is
 	 * always HSI, so statically enable HSI here.
 	 */
-#if defined(CONFIG_SOC_SERIES_STM32F0X) || \
-	defined(CONFIG_SOC_SERIES_STM32F1X) || \
-	defined(CONFIG_SOC_SERIES_STM32F3X) || \
-	defined(CONFIG_SOC_SERIES_STM32L1X)
+#if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F1X) ||                  \
+	defined(CONFIG_SOC_SERIES_STM32F3X) || defined(CONFIG_SOC_SERIES_STM32L1X)
 	LL_RCC_HSI_Enable();
 
 	while (!LL_RCC_HSI_IsReady()) {
@@ -567,8 +549,7 @@ static int stm32_flash_init(const struct device *dev)
 
 	flash_stm32_sem_init(dev);
 
-	LOG_DBG("Flash @0x%x initialized. BS: %zu",
-		FLASH_STM32_BASE_ADDRESS,
+	LOG_DBG("Flash @0x%x initialized. BS: %zu", FLASH_STM32_BASE_ADDRESS,
 		flash_stm32_parameters.write_block_size);
 
 	/* Check Flash configuration */
@@ -583,14 +564,13 @@ static int stm32_flash_init(const struct device *dev)
 
 	flash_stm32_page_layout(dev, &layout, &layout_size);
 	for (size_t i = 0; i < layout_size; i++) {
-		LOG_DBG("Block %zu: bs: %zu count: %zu", i,
-			layout[i].pages_size, layout[i].pages_count);
+		LOG_DBG("Block %zu: bs: %zu count: %zu", i, layout[i].pages_size,
+			layout[i].pages_count);
 	}
 #endif
 
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL,
-		    &flash_data, NULL, POST_KERNEL,
-		    CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -246,6 +246,107 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 	return rc;
 }
 
+#ifdef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
+static int write_unaligned(const struct device *dev, off_t offset,
+				       const uint8_t *data, size_t len)
+{
+	uint8_t temp_data[FLASH_STM32_WRITE_BLOCK_SIZE];
+	off_t cur_offset_addr;
+	size_t local_offset;
+
+	BUILD_ASSERT(FLASH_STM32_WRITE_BLOCK_SIZE <= 128, "Write block size is above the limit.");
+	__ASSERT(len <= FLASH_STM32_WRITE_BLOCK_SIZE, "Length too big.");
+
+	memset(temp_data, flash_stm32_parameters.erase_value, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+	cur_offset_addr = ROUND_DOWN(offset, FLASH_STM32_WRITE_BLOCK_SIZE);
+	local_offset = offset - cur_offset_addr;
+
+	__ASSERT(len == (FLASH_STM32_WRITE_BLOCK_SIZE - local_offset), "Length error.");
+
+	memcpy(temp_data + local_offset, data, len);
+
+	return flash_stm32_write(dev, cur_offset_addr, temp_data, FLASH_STM32_WRITE_BLOCK_SIZE);
+}
+
+static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
+			     const void *data, size_t len)
+{
+	const uint8_t *data_ptr = data;
+	size_t chunk_size, local_offset;
+	off_t off = offset;
+	size_t remaining = len;
+	int rc;
+
+	BUILD_ASSERT(FLASH_STM32_WRITE_BLOCK_SIZE >= 4, "Invalid write size.");
+
+	if (!remaining) {
+		return 0;
+	}
+
+	if (!flash_stm32_range_exists(dev, off, remaining)) {
+		return -EINVAL;
+	}
+
+	if (off % FLASH_STM32_WRITE_BLOCK_SIZE != 0) {
+		local_offset = off % FLASH_STM32_WRITE_BLOCK_SIZE;
+		chunk_size = MIN(remaining, FLASH_STM32_WRITE_BLOCK_SIZE - local_offset);
+
+		rc = write_unaligned(dev, off, data, chunk_size);
+		if (rc != 0) {
+			return rc;
+		}
+
+		remaining -= chunk_size;
+		off += chunk_size;
+		data_ptr += chunk_size;
+	}
+
+	chunk_size = ROUND_DOWN(remaining, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+	if (chunk_size != 0) {
+		if (IS_ALIGNED(data_ptr, 4)) {
+			rc = flash_stm32_write(dev, off, data_ptr, chunk_size);
+			if (rc != 0) {
+				return rc;
+			}
+			off += chunk_size;
+			data_ptr += chunk_size;
+			remaining -= chunk_size;
+		} else {
+			/* Workaround for some SOCs (H7, U3 etc.) which requires word-aligned
+			* input buffer. This should not be necessary once this bug is fixed in
+			* the flash driver.
+			*/
+			size_t temp_chunk_size = chunk_size;
+
+			while (temp_chunk_size > 0) {
+				size_t step = MIN(temp_chunk_size, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+				rc = write_unaligned(dev, off, data_ptr, step);
+				if (rc != 0) {
+					return rc;
+				}
+
+				data_ptr += step;
+				off += step;
+				temp_chunk_size -= step;
+			}
+			remaining -= chunk_size;
+		}
+	}
+
+	/* Write tail for any leftover bytes. */
+	if (remaining > 0) {
+		rc = write_unaligned(dev, off, data_ptr, remaining);
+		if (rc != 0) {
+			return rc;
+		}
+	}
+	return 0;
+}
+#endif /* CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES */
+
 int flash_stm32_cr_lock(const struct device *dev, bool enable)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
@@ -413,7 +514,11 @@ static struct flash_stm32_priv flash_data = {
 
 static DEVICE_API(flash, flash_stm32_api) = {
 	.erase = flash_stm32_erase,
+#ifndef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
 	.write = flash_stm32_write,
+#else
+	.write = flash_stm32_no_align_write,
+#endif
 	.read = flash_stm32_read,
 	.get_parameters = flash_stm32_get_parameters,
 	.get_size = flash_stm32_get_size,

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -159,6 +159,106 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 
 	return rc;
 }
+#ifdef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
+static int write_unaligned(const struct device *dev, off_t offset,
+				       const uint8_t *data, size_t len)
+{
+	uint8_t temp_data[FLASH_STM32_WRITE_BLOCK_SIZE];
+	off_t cur_offset_addr;
+	size_t local_offset;
+
+	BUILD_ASSERT(FLASH_STM32_WRITE_BLOCK_SIZE <= 128, "Write block size is above the limit.");
+	__ASSERT(len <= FLASH_STM32_WRITE_BLOCK_SIZE, "Length too big.");
+
+	memset(temp_data, flash_stm32_parameters.erase_value, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+	cur_offset_addr = ROUND_DOWN(offset, FLASH_STM32_WRITE_BLOCK_SIZE);
+	local_offset = offset - cur_offset_addr;
+
+	__ASSERT(len == (FLASH_STM32_WRITE_BLOCK_SIZE - local_offset), "Length error.");
+
+	memcpy(temp_data + local_offset, data, len);
+
+	return flash_stm32_write(dev, cur_offset_addr, temp_data, FLASH_STM32_WRITE_BLOCK_SIZE);
+}
+
+static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
+			     const void *data, size_t len)
+{
+	const uint8_t *data_ptr = data;
+	size_t chunk_size, local_offset;
+	off_t off = offset;
+	size_t remaining = len;
+	int rc;
+
+	BUILD_ASSERT(FLASH_STM32_WRITE_BLOCK_SIZE >= 4, "Invalid write size.");
+
+	if (!remaining) {
+		return 0;
+	}
+
+	if (!flash_stm32_range_exists(dev, off, remaining)) {
+		return -EINVAL;
+	}
+
+	if (off % FLASH_STM32_WRITE_BLOCK_SIZE != 0) {
+		local_offset = off % FLASH_STM32_WRITE_BLOCK_SIZE;
+		chunk_size = MIN(remaining, FLASH_STM32_WRITE_BLOCK_SIZE - local_offset);
+
+		rc = write_unaligned(dev, off, data, chunk_size);
+		if (rc != 0) {
+			return rc;
+		}
+
+		remaining -= chunk_size;
+		off += chunk_size;
+		data_ptr += chunk_size;
+	}
+
+	chunk_size = ROUND_DOWN(remaining, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+	if (chunk_size != 0) {
+		if (IS_ALIGNED(data_ptr, 4)) {
+			rc = flash_stm32_write(dev, off, data_ptr, chunk_size);
+			if (rc != 0) {
+				return rc;
+			}
+			off += chunk_size;
+			data_ptr += chunk_size;
+			remaining -= chunk_size;
+		} else {
+			/* Workaround quirk in FM-based flash driver which requires word-aligned
+			* input buffer. This should not be necessary once this bug is fixed in
+			* the flash driver.
+			*/
+			size_t temp_chunk_size = chunk_size;
+
+			while (temp_chunk_size > 0) {
+				size_t step = MIN(temp_chunk_size, FLASH_STM32_WRITE_BLOCK_SIZE);
+
+				rc = write_unaligned(dev, off, data_ptr, step);
+				if (rc != 0) {
+					return rc;
+				}
+
+				data_ptr += step;
+				off += step;
+				temp_chunk_size -= step;
+			}
+			remaining -= chunk_size;
+		}
+	}
+
+	/* Write tail for any leftover bytes. */
+	if (remaining > 0) {
+		rc = write_unaligned(dev, off, data_ptr, remaining);
+		if (rc != 0) {
+			return rc;
+		}
+	}
+	return 0;
+}
+#endif /* CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES */
 
 static const struct flash_parameters *
 			flash_stm32_get_parameters(const struct device *dev)
@@ -204,7 +304,11 @@ void flash_stm32wba_page_layout(const struct device *dev,
 
 static DEVICE_API(flash, flash_stm32_api) = {
 	.erase = flash_stm32_erase,
+#ifndef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
 	.write = flash_stm32_write,
+#else
+	.write = flash_stm32_no_align_write,
+#endif
 	.read = flash_stm32_read,
 	.get_parameters = flash_stm32_get_parameters,
 	.get_size = flash_stm32wba_get_size,

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -23,8 +23,7 @@ LOG_MODULE_REGISTER(flash_stm32wba, CONFIG_FLASH_LOG_LEVEL);
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */
-#define STM32_FLASH_TIMEOUT	\
-	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
+#define STM32_FLASH_TIMEOUT (2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
 extern struct k_work_q ble_ctrl_work_q;
 struct k_work fm_work;
@@ -43,9 +42,7 @@ static void flash_callback(FM_FlashOp_Status_t status)
 	k_sem_give(&flash_busy);
 }
 
-struct FM_CallbackNode cb_ptr = {
-	.Callback = flash_callback
-};
+struct FM_CallbackNode cb_ptr = {.Callback = flash_callback};
 
 void FM_ProcessRequest(void)
 {
@@ -59,8 +56,7 @@ void FM_BackgroundProcess_Entry(struct k_work *work)
 	FM_BackgroundProcess();
 }
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-				    uint32_t len, bool write)
+bool flash_stm32_valid_range(const struct device *dev, off_t offset, uint32_t len, bool write)
 {
 	if (write && !flash_stm32_valid_write(offset, len)) {
 		return false;
@@ -68,13 +64,10 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	return flash_stm32_range_exists(dev, offset, len);
 }
 
-static int flash_stm32_read(const struct device *dev, off_t offset,
-			    void *data,
-			    size_t len)
+static int flash_stm32_read(const struct device *dev, off_t offset, void *data, size_t len)
 {
 	if (!flash_stm32_valid_range(dev, offset, len, false)) {
-		LOG_ERR("Read range invalid. Offset: %p, len: %zu",
-			(void *) offset, len);
+		LOG_ERR("Read range invalid. Offset: %p, len: %zu", (void *)offset, len);
 		return -EINVAL;
 	}
 
@@ -84,22 +77,20 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	memcpy(data, (uint8_t *) FLASH_STM32_BASE_ADDRESS + offset, len);
+	memcpy(data, (uint8_t *)FLASH_STM32_BASE_ADDRESS + offset, len);
 
 	flash_stm32_sem_give(dev);
 
 	return 0;
 }
 
-static int flash_stm32_erase(const struct device *dev, off_t offset,
-			     size_t len)
+static int flash_stm32_erase(const struct device *dev, off_t offset, size_t len)
 {
 	int rc;
 	int sect_num;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Erase range invalid. Offset: %p, len: %zu",
-			(void *)offset, len);
+		LOG_ERR("Erase range invalid. Offset: %p, len: %zu", (void *)offset, len);
 		return -EINVAL;
 	}
 
@@ -112,8 +103,8 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Erase offset: %p, page: %ld, len: %zu, sect num: %d",
-		(void *)offset, offset / FLASH_PAGE_SIZE, len, sect_num);
+	LOG_DBG("Erase offset: %p, page: %ld, len: %zu, sect num: %d", (void *)offset,
+		offset / FLASH_PAGE_SIZE, len, sect_num);
 
 	rc = FM_Erase(offset / FLASH_PAGE_SIZE, sect_num, &cb_ptr);
 	if (rc == 0) {
@@ -127,14 +118,12 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_stm32_write(const struct device *dev, off_t offset,
-			     const void *data, size_t len)
+static int flash_stm32_write(const struct device *dev, off_t offset, const void *data, size_t len)
 {
 	int rc;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
-		LOG_ERR("Write range invalid. Offset: %p, len: %zu",
-			(void *)offset, len);
+		LOG_ERR("Write range invalid. Offset: %p, len: %zu", (void *)offset, len);
 		return -EINVAL;
 	}
 
@@ -146,9 +135,8 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 
 	LOG_DBG("Write offset: %p, len: %zu", (void *)offset, len);
 
-	rc = FM_Write((uint32_t *)data,
-		      (uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset),
-		      (int32_t)len/4, &cb_ptr);
+	rc = FM_Write((uint32_t *)data, (uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset),
+		      (int32_t)len / 4, &cb_ptr);
 	if (rc == 0) {
 		k_sem_take(&flash_busy, K_FOREVER);
 	} else {
@@ -160,8 +148,7 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 	return rc;
 }
 #ifdef CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES
-static int write_unaligned(const struct device *dev, off_t offset,
-				       const uint8_t *data, size_t len)
+static int write_unaligned(const struct device *dev, off_t offset, const uint8_t *data, size_t len)
 {
 	uint8_t temp_data[FLASH_STM32_WRITE_BLOCK_SIZE];
 	off_t cur_offset_addr;
@@ -182,8 +169,8 @@ static int write_unaligned(const struct device *dev, off_t offset,
 	return flash_stm32_write(dev, cur_offset_addr, temp_data, FLASH_STM32_WRITE_BLOCK_SIZE);
 }
 
-static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
-			     const void *data, size_t len)
+static int flash_stm32_no_align_write(const struct device *dev, off_t offset, const void *data,
+				      size_t len)
 {
 	const uint8_t *data_ptr = data;
 	size_t chunk_size, local_offset;
@@ -228,9 +215,9 @@ static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
 			remaining -= chunk_size;
 		} else {
 			/* Workaround quirk in FM-based flash driver which requires word-aligned
-			* input buffer. This should not be necessary once this bug is fixed in
-			* the flash driver.
-			*/
+			 * input buffer. This should not be necessary once this bug is fixed in
+			 * the flash driver.
+			 */
 			size_t temp_chunk_size = chunk_size;
 
 			while (temp_chunk_size > 0) {
@@ -260,8 +247,7 @@ static int flash_stm32_no_align_write(const struct device *dev, off_t offset,
 }
 #endif /* CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES */
 
-static const struct flash_parameters *
-			flash_stm32_get_parameters(const struct device *dev)
+static const struct flash_parameters *flash_stm32_get_parameters(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
@@ -279,11 +265,10 @@ static int flash_stm32wba_get_size(const struct device *dev, uint64_t *size)
 }
 
 static struct flash_stm32_priv flash_data = {
-	.regs = (FLASH_TypeDef *) DT_INST_REG_ADDR(0),
+	.regs = (FLASH_TypeDef *)DT_INST_REG_ADDR(0),
 };
 
-void flash_stm32wba_page_layout(const struct device *dev,
-				const struct flash_pages_layout **layout,
+void flash_stm32wba_page_layout(const struct device *dev, const struct flash_pages_layout **layout,
 				size_t *layout_size)
 {
 	static struct flash_pages_layout stm32wba_flash_layout = {
@@ -321,8 +306,7 @@ static int stm32_flash_init(const struct device *dev)
 {
 	k_sem_init(&FLASH_STM32_PRIV(dev)->sem, 1, 1);
 
-	LOG_DBG("Flash initialized. BS: %zu",
-		flash_stm32_parameters.write_block_size);
+	LOG_DBG("Flash initialized. BS: %zu", flash_stm32_parameters.write_block_size);
 
 	k_work_init(&fm_work, &FM_BackgroundProcess_Entry);
 
@@ -340,14 +324,13 @@ static int stm32_flash_init(const struct device *dev)
 
 	flash_stm32wba_page_layout(dev, &layout, &layout_size);
 	for (size_t i = 0; i < layout_size; i++) {
-		LOG_DBG("Block %zu: bs: %zu count: %zu", i,
-			layout[i].pages_size, layout[i].pages_count);
+		LOG_DBG("Block %zu: bs: %zu count: %zu", i, layout[i].pages_size,
+			layout[i].pages_count);
 	}
 #endif
 
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL,
-		    &flash_data, NULL, POST_KERNEL,
-		    CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);


### PR DESCRIPTION
The flash_stm32.c and flash_stm32wba_fm.c have no mechanism in the flash_stm32_write() APIs to accept and handle address offsets and lengths that are not aligned with the write block size of the flash hardware. 
This PR provides an alternate path to handle these unaligned flash writes through Kconfig option - CONFIG_FLASH_STM32_ACCEPT_UNALIGNED_WRITES. When enabled in user application, this corner-case tested driver option provides a path where partial writes are allowed, and any address or length is accepted by the flash_stm32_write API, while still respecting the flash hardware restriction and implementation. 
THIS IS NOT A READ-MODIFY-WRITE OPERATION! This implementation assumes that the flash was erased before writing to it. Partial writes are padded with the flash's erase value to write to the flash hardware with the write block length that it accepts. This is useful for users that want to write partial writes into the flash, but do not want to use a Filesystem, EEPROM emulation or other such solutions due to the overhead involved in their application. 
Note that while the logic supports any STM32 flash hardware (which does not already have a write block size of 1 or 2 bytes), Kconfig enforces specifically for SOC_STM32WBA65XX. This can be supported for any STM32 SoC by adding the Kconfig option for that SoC in the Kconfig.stm32 file by modifying - depends on SOC_STM32WBA65XX. For example, to support this for U5 series, change to depends on SOC_STM32WBA65XX | SOC_SERIES_STM32U5X. Note that this should be done at user's risk - the operation may fault!

FYI: @Chastillon, @vtardy-st, @msmttchr, @FrancescoCiminoST , @Leadman100