### PR TITLE
drivers: counter: esp32: fix relative alarm diff calculation

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -144,8 +144,12 @@ static int counter_esp32_get_value_64(const struct device *dev, uint64_t *ticks)
 static int counter_esp32_set_alarm_64(const struct device *dev, uint8_t chan_id,
 				      const struct counter_alarm_cfg_64 *alarm_cfg)
 {
-	ARG_UNUSED(chan_id);
 	struct counter_esp32_data *data = dev->data;
+
+	if (chan_id > 0) {
+		return -ENOTSUP;
+	}
+
 	bool absolute = alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE;
 	uint64_t ticks = alarm_cfg->ticks;
 	uint64_t top = data->top_data.ticks;
@@ -178,7 +182,7 @@ static int counter_esp32_set_alarm_64(const struct device *dev, uint8_t chan_id,
 
 	timer_ll_set_alarm_value(data->hal_ctx.dev, data->hal_ctx.timer_id, target);
 
-	diff = (alarm_cfg->ticks - now);
+	diff = absolute ? (target - now) : ticks;
 	if (diff > max_rel_val) {
 		if (absolute) {
 			err = -ETIME;


### PR DESCRIPTION
Fix incorrect diff calculation for relative alarms that caused alarm callbacks to never fire. The original code calculated diff as (alarm_cfg->ticks - now), which caused unsigned underflow when now > alarm_cfg->ticks, resulting in a huge diff value that incorrectly triggered the late alarm path and set callback to NULL.

For relative alarms, the diff should simply be the ticks value since it already represents the delay from the current time.

Also add channel validation to return -ENOTSUP for chan_id > 0 since ESP32 timer hardware only supports one alarm comparator per timer.