### PR TITLE
samples: blinky_pwm: fix pwm pin for esp32c3_supermini

### DIFF
--- a/samples/basic/blinky_pwm/boards/esp32c3_supermini.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32c3_supermini.overlay
@@ -26,7 +26,7 @@
 &pinctrl {
 	ledc0_default: ledc0-default {
 		group1 {
-			pinmux = <LEDC_CH0_GPIO2>;
+			pinmux = <LEDC_CH0_GPIO8>;
 			output-enable;
 		};
 	};


### PR DESCRIPTION
Change LEDC channel 0 pinmux from GPIO2 to GPIO8 to match the onboard LED location on the ESP32-C3 SuperMini board.