### PR TITLE
tests: drivers: dma: check rx buf overflow

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -12,4 +12,4 @@
 
 __aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] =
 	"It is harder to be kind than to be wise........";
-__aligned(DMA_DATA_ALIGNMENT) char rx_data[TEST_BUF_SIZE] = {0};
+__aligned(DMA_DATA_ALIGNMENT) char rx_data[TEST_BUF_SIZE + GUARD_BUF_SIZE] = {0};

--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.h
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.h
@@ -6,7 +6,8 @@
 
 #include <stdint.h>
 
+#define GUARD_BUF_SIZE (16)
 #define TEST_BUF_SIZE (48)
 
 extern char tx_data[TEST_BUF_SIZE];
-extern char rx_data[TEST_BUF_SIZE];
+extern char rx_data[TEST_BUF_SIZE + GUARD_BUF_SIZE];


### PR DESCRIPTION
Check the DMA transfer to ensure it doesn't write past the RX buffer.

I didn't add any overflow checks for the `loop transfer` and `scatter gather` tests as those implicitly check for overflows.

Fixes #103097 