### PR TITLE
wifi: fix SAE password validation and add shell support for SAE passwords

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -412,7 +412,8 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 	}
 
 	if (params->sae_password_length &&
-	    (params->sae_password_length < 8 || params->sae_password_length > 64)) {
+	    (params->sae_password_length < 8 ||
+	     params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -933,6 +933,19 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		}
 	}
 
+	/* For SAE types, use -p passphrase as SAE password and clear PSK. */
+	if (params->psk != NULL &&
+	    (params->security == WIFI_SECURITY_TYPE_SAE_HNP ||
+	     params->security == WIFI_SECURITY_TYPE_SAE_H2E ||
+	     params->security == WIFI_SECURITY_TYPE_SAE_AUTO ||
+	     params->security == WIFI_SECURITY_TYPE_FT_SAE ||
+	     params->security == WIFI_SECURITY_TYPE_SAE_EXT_KEY)) {
+		params->sae_password = params->psk;
+		params->sae_password_length = params->psk_length;
+		params->psk = NULL;
+		params->psk_length = 0;
+	}
+
 	if (params->psk && !secure_connection) {
 		PR_WARNING("Passphrase provided without security configuration\n");
 	}


### PR DESCRIPTION
Summary
Fix SAE password length validation and add support in the Wi-Fi shell command to pass SAE passwords separately, enabling proper WPA3 connection handling.

Details
wifi_connect(....) incorrectly limited SAE password length to 64 bytes despite WIFI_SAE_PSWD_MAX_LEN allowing up to 128 bytes, causing connection failures with valid SAE passwords. This change updates the validation logic to use the correct limit.

Additionally, the Wi-Fi shell command previously stored all passwords as PSK, preventing SAE authentication paths from being used. Shell support is added to allow setting SAE passwords separately so WPA3 connections can be exercised correctly.

Fixes : #103126 
