### PR TITLE
usb: usbip: improve completion handling and replase zsock_send() with zsock_send_all()

### DIFF
--- a/subsys/usb/host/Kconfig.usbip
+++ b/subsys/usb/host/Kconfig.usbip
@@ -28,6 +28,21 @@ config USBIP_SUBMIT_BACKLOG_COUNT
 	help
 	  Number of submit commands that can be stored in the backlog.
 
+config USBIP_BUF_COUNT
+	int "Number of buffers in the USBIP pool"
+	range 16 256
+	default 64
+	help
+	  Number of USBIP request buffers in the pool.
+
+config USBIP_BUF_POOL_SIZE
+	int "Memory available for USBIP buffers"
+	range 4096 $(UINT32_MAX)
+	default 16777216 if BOARD_NATIVE_SIM
+	default 65536
+	help
+	  Total amount of memory available for USBIP buffers.
+
 config USBIP_DEVICES_COUNT
 	int "Number of devices that can be exported"
 	range 1 255

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -27,6 +27,8 @@ NET_BUF_POOL_VAR_DEFINE(usbip_pool,
 			CONFIG_USBIP_BUF_COUNT, CONFIG_USBIP_BUF_POOL_SIZE,
 			0, NULL);
 
+#define USBIP_SUBMIT_REQ_RETRY_COUNT	10
+
 K_THREAD_STACK_DEFINE(usbip_thread_stack, CONFIG_USBIP_THREAD_STACK_SIZE);
 K_THREAD_STACK_ARRAY_DEFINE(dev_thread_stacks, CONFIG_USBIP_DEVICES_COUNT,
 			    CONFIG_USBIP_THREAD_STACK_SIZE);
@@ -209,13 +211,22 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usbip_dev_ctx *const dev_ctx = cmd_nd->ctx;
 	struct usbip_command *const cmd = &cmd_nd->cmd;
 	struct usb_device *const udev = dev_ctx->udev;
+	uint32_t retry = USBIP_SUBMIT_REQ_RETRY_COUNT;
 	struct uhc_transfer *xfer;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
-	if (xfer == NULL) {
-		return -ENOMEM;
-	}
+	/*
+	 * Depending on the server, functions, and client application, we may
+	 * get out of transfers very quickly. To throttle here may allow
+	 * submitted transfers to be finished. Perhaps usbh_xfer_alloc() should
+	 * be reworked to take a timeout argument.
+	 */
+	do {
+		xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
+		if (xfer == NULL) {
+			k_msleep(1);
+		}
+	} while (xfer == NULL && retry--);
 
 	if (setup != NULL) {
 		memcpy(xfer->setup_pkt, setup, sizeof(struct usb_setup_packet));


### PR DESCRIPTION
Improve completion handling and replase zsock_send() with zsock_send_all().

Depends on #103230
Fixes: #102737 (USB/IP part)