### PR TITLE
MAINTAINERS: add RtkFP as maintainer for Realtek fingerprint SoC

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4652,6 +4652,19 @@ Realtek EC Platforms:
   labels:
     - "platform: Realtek EC"
 
+Realtek Fingerprint Platforms:
+  status: maintained
+  maintainers:
+    - RtkFP
+  files:
+    - boards/realtek/rts5817_maa_evb/
+    - drivers/*/*rts5817*
+    - dts/bindings/*/*rts5817*
+    - dts/arm/realtek/fingerprint/
+    - soc/realtek/fingerprint/
+  labels:
+    - "platform: Realtek Fingerprint"
+
 Release:
   status: maintained
   maintainers:


### PR DESCRIPTION
This commit adds maintainer of Realtek fingerprint SoC to maintainers.yml

Support resource: #91486