### PR TITLE
cmake: add missing BRIEF_DOCS and FULL_DOCS property defines

### DIFF
--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -58,8 +58,18 @@ set_property(TARGET linker PROPERTY lto_arguments_st)
 # front-end for ld.
 set_compiler_property(PROPERTY specs)
 
-define_property(TARGET PROPERTY no_optimization INHERITED FULL_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_debug INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_speed INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_size INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_size_aggressive INHERITED BRIEF_DOCS "INHERIT")
+define_property(TARGET PROPERTY no_optimization INHERITED
+    BRIEF_DOCS "Target property for no optimization level"
+    FULL_DOCS "Target property for no optimization level")
+define_property(TARGET PROPERTY optimization_debug INHERITED
+    BRIEF_DOCS "Target property for debug optimization level"
+    FULL_DOCS "Target property for debug optimization level")
+define_property(TARGET PROPERTY optimization_speed INHERITED
+    BRIEF_DOCS "Target property for speed optimization level"
+    FULL_DOCS "Target property for speed optimization level")
+define_property(TARGET PROPERTY optimization_size INHERITED
+    BRIEF_DOCS "Target property for size optimization level"
+    FULL_DOCS "Target property for size optimization level")
+define_property(TARGET PROPERTY optimization_size_aggressive INHERITED
+    BRIEF_DOCS "Target property for aggressive size optimization level"
+    FULL_DOCS "Target property for aggressive size optimization level")


### PR DESCRIPTION
After commit 0fa0e41, I started getting cmake error in my builds regarding define_property not given a BRIEF_DOCS <brief-doc> argument.

This PR adds the missing arguments enable cmake builds again.

This fixes #103317