### PR TITLE
soc: renesas: ra: add SB_CONFIG_SOC_RA_START_SECOND_CORE

### DIFF
--- a/boards/renesas/ek_ra8p1/doc/index.rst
+++ b/boards/renesas/ek_ra8p1/doc/index.rst
@@ -147,6 +147,16 @@ see the following message in the terminal:
    ***** Booting Zephyr OS v4.2.0-xxx-xxxxxxxxxxxxx *****
    Hello World! ek_ra8p1/r7ka8p1kflcac/cm85
 
+For the CM33 core, you can use the ``--sysbuild`` flow to build a minimal first-core launcher image that
+starts the CM33 core.
+
+.. zephyr-app-commands::
+   :tool: west
+   :zephyr-app: samples/hello_world
+   :board: ek_ra8p1/r7ka8p1kflcac/cm33
+   :goals: build flash
+   :west-args: --sysbuild
+
 Flashing
 ========
 

--- a/soc/renesas/ra/Kconfig.sysbuild
+++ b/soc/renesas/ra/Kconfig.sysbuild
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config RA_SECOND_CORE_LAUNCHER
+	bool "Start second core launcher"
+	default y
+	depends on HAS_RA_SECOND_CORE_LAUNCHER_IMAGE
+	help
+	  Include a minimal launcher image built for the first core that
+	  enables CONFIG_SOC_RA_ENABLE_START_SECOND_CORE so that the
+	  startup image will start the second core.
+
+config HAS_RA_SECOND_CORE_LAUNCHER_IMAGE
+	bool
+
+if RA_SECOND_CORE_LAUNCHER
+
+config RA_SECOND_CORE_LAUNCHER_NAME
+	string "Launcher core name"
+	help
+	  Specify the core name to use when building the launcher image.
+
+endif # RA_SECOND_CORE_LAUNCHER
+
+rsource "*/Kconfig.sysbuild"

--- a/soc/renesas/ra/ra8p1/Kconfig.sysbuild
+++ b/soc/renesas/ra/ra8p1/Kconfig.sysbuild
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config HAS_RA_SECOND_CORE_LAUNCHER_IMAGE
+	default y if SOC_R7KA8P1KFLCAC_CM33
+
+config RA_SECOND_CORE_LAUNCHER_NAME
+	default "cm85"

--- a/soc/renesas/ra/sysbuild.cmake
+++ b/soc/renesas/ra/sysbuild.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if(SB_CONFIG_RA_SECOND_CORE_LAUNCHER)
+  set(image "second_core_launcher")
+
+  set(qualifiers ${CONFIG_SOC}/${SB_CONFIG_RA_SECOND_CORE_LAUNCHER_NAME})
+
+  ExternalZephyrProject_Add(
+    APPLICATION ${image}
+    SOURCE_DIR ${ZEPHYR_BASE}/samples/basic/minimal
+    BOARD ${BOARD}/${qualifiers}
+  )
+
+  set_config_bool(${image} CONFIG_SOC_RA_ENABLE_START_SECOND_CORE 1)
+endif()


### PR DESCRIPTION
Add SB_CONFIG_SOC_RA_START_SECOND_CORE for Renesas RA8P1 SoC to support building a minimal launcher image that starts the second core on Renesas RA SoCs via sysbuild