### PR TITLE
cmake: ensure CMake 3.20 support

### DIFF
--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -58,8 +58,10 @@ set_property(TARGET linker PROPERTY lto_arguments_st)
 # front-end for ld.
 set_compiler_property(PROPERTY specs)
 
-define_property(TARGET PROPERTY no_optimization INHERITED FULL_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_debug INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_speed INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_size INHERITED BRIEF_DOCS "INHERIT")
-define_property(TARGET PROPERTY optimization_size_aggressive INHERITED BRIEF_DOCS "INHERIT")
+# The optimization properties are used for controlling inheritance for linker settings.
+set(linker_property_docs BRIEF_DOCS "INHERIT" FULL_DOCS "Linker property with inheritance")
+define_property(TARGET PROPERTY no_optimization INHERITED ${linker_property_docs})
+define_property(TARGET PROPERTY optimization_debug INHERITED ${linker_property_docs})
+define_property(TARGET PROPERTY optimization_speed INHERITED ${linker_property_docs})
+define_property(TARGET PROPERTY optimization_size INHERITED ${linker_property_docs})
+define_property(TARGET PROPERTY optimization_size_aggressive INHERITED ${linker_property_docs})

--- a/cmake/modules/hwm_v2.cmake
+++ b/cmake/modules/hwm_v2.cmake
@@ -30,7 +30,7 @@ function(kconfig_gen bin_dir file dirs comment)
   endforeach()
 
   file(WRITE ${kconfig_file}.tmp "${kconfig_output}")
-  file(COPY_FILE ${kconfig_file}.tmp ${kconfig_file} ONLY_IF_DIFFERENT)
+  zephyr_file_copy(${kconfig_file}.tmp ${kconfig_file} ONLY_IF_DIFFERENT)
 endfunction()
 
 # 'SOC_ROOT' and 'ARCH_ROOT' are prioritized lists of directories where their


### PR DESCRIPTION
Fixes #103317

Zephyr supports CMake 3.20, which doesn't support
`file(COPY ... ONLY_IF_DIFFERENT)` and requires `BRIEF_DOCS` and `FULL_DOCS` when defining properties.

This commit ensures the build system is CMake 3.20 compliant.