### PR TITLE
doc: doxygen: intc: Add interrupt controller devices group

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -36,6 +36,12 @@
 @{
 @}
 
+@brief Interfaces for interrupt controller devices.
+@defgroup intc_interfaces Interrupt Controller Devices
+@ingroup io_interfaces
+@{
+@}
+
 @brief Testing
 @defgroup testing Testing
 @{


### PR DESCRIPTION
Currently the interrupt controller drivers in folder include/zephyr/drivers/interrupt_controller are not added in any doxygen group, and there is not a common
interrupt controller header file to add such group.

Add a new Doxygen group for interrupt controller device interfaces under the I/O interfaces category.

This group is needed to add intc drivers, like: https://github.com/zephyrproject-rtos/zephyr/pull/100240