### PR TITLE
soc: ti: introduce ti,control-module for MMR partition unlocking

### DIFF
--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -65,10 +65,19 @@
 		#mbox-cells = <1>;
 	};
 
-	pinctrl: pinctrl@4084000 {
-		compatible = "ti,k3-pinctrl";
-		reg = <0x04084000 0x88>;
-		status = "okay";
+	mcu_padcfg0: syscon@4080000 {
+		compatible = "ti,control-module";
+		reg = <0x4080000 DT_SIZE_K(32)>;
+		ranges = <0x00 0x4080000 DT_SIZE_K(32)>;
+		ti,unlock-offsets = <0x1008 0x5008>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		pinctrl: pinctrl@4000 {
+			compatible = "ti,k3-pinctrl";
+			reg = <0x4000 0x88>;
+			status = "okay";
+		};
 	};
 
 	uart0: serial@4a00000 {

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -60,10 +60,19 @@
 		status = "okay";
 	};
 
-	pinctrl: pinctrl@f4000 {
-		compatible = "ti,k3-pinctrl";
-		reg = <0x000f4000 0x2ac>;
-		status = "okay";
+	main_padcfg0: syscon@f0000 {
+		compatible = "ti,control-module";
+		reg = <0xf0000 DT_SIZE_K(32)>;
+		ranges = <0x00 0xf0000 DT_SIZE_K(32)>;
+		ti,unlock-offsets = <0x1008 0x5008>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		pinctrl: pinctrl@4000 {
+			compatible = "ti,k3-pinctrl";
+			reg = <0x4000 0x2ac>;
+			status = "okay";
+		};
 	};
 
 	mbox0: mailbox0@29000000 {

--- a/dts/bindings/syscon/ti,control-module.yaml
+++ b/dts/bindings/syscon/ti,control-module.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI-K3 device level control register module
+
+compatible: "ti,control-module"
+
+include: syscon.yaml
+
+properties:
+  ti,unlock-offsets:
+    type: array
+    description: |
+      Unlock configuration consisting of offsets to the KICK0 registers for
+      the partitions that require unlocking. Two 32-bit magic numbers will
+      be written at this location to unlock the partition.
+
+      Example:
+        ti,unlock-offsets = <0x1008   /* Partition 1  */
+                             0x5008>; /* Partition 2 */

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -27,10 +27,19 @@
 		status = "disabled";
 	};
 
-	main_pinctrl: pinctrl@f4000 {
-		compatible = "ti,k3-pinctrl";
-		reg = <0xf4000 0x2ac>;
-		status = "disabled";
+	main_padcfg0: syscon@f0000 {
+		compatible = "ti,control-module";
+		reg = <0xf0000 DT_SIZE_K(32)>;
+		ranges = <0x00 0xf0000 DT_SIZE_K(32)>;
+		ti,unlock-offsets = <0x1008 0x5008>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		main_pinctrl: pinctrl@4000 {
+			compatible = "ti,k3-pinctrl";
+			reg = <0x4000 0x2ac>;
+			status = "disabled";
+		};
 	};
 
 	main_timer0: timer@2400000 {

--- a/dts/vendor/ti/am64x_mcu.dtsi
+++ b/dts/vendor/ti/am64x_mcu.dtsi
@@ -11,10 +11,19 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	mcu_pinctrl: pinctrl@4084000 {
-		compatible = "ti,k3-pinctrl";
-		reg = <0x04084000 0x88>;
-		status = "disabled";
+	mcu_padcfg0: syscon@4080000 {
+		compatible = "ti,control-module";
+		reg = <0x4080000 DT_SIZE_K(32)>;
+		ranges = <0x00 0x4080000 DT_SIZE_K(32)>;
+		ti,unlock-offsets = <0x1008 0x5008>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		mcu_pinctrl: pinctrl@4000 {
+			compatible = "ti,k3-pinctrl";
+			reg = <0x4000 0x88>;
+			status = "disabled";
+		};
 	};
 
 	mcu_uart0: serial@4a00000 {

--- a/soc/ti/k3/am6x/CMakeLists.txt
+++ b/soc/ti/k3/am6x/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_sources(common/ctrl_partitions.c)
 
 if(CONFIG_SOC_AM6234_A53 OR CONFIG_SOC_AM6232_A53 OR CONFIG_SOC_AM6254_A53 OR CONFIG_SOC_AM62L3_A53)
   zephyr_sources_ifdef(CONFIG_ARM_MMU a53/mmu_regions.c)
+  zephyr_sources(a53/soc.c)
 
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")
 elseif(CONFIG_SOC_SERIES_AM6X_M4)

--- a/soc/ti/k3/am6x/Kconfig
+++ b/soc/ti/k3/am6x/Kconfig
@@ -5,6 +5,7 @@ config SOC_SERIES_AM6X_A53
 	select ARM64
 	select CPU_CORTEX_A53
 	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
+	select SOC_EARLY_INIT_HOOK
 
 config SOC_SERIES_AM6X_M4
 	select ARM

--- a/soc/ti/k3/am6x/a53/soc.c
+++ b/soc/ti/k3/am6x/a53/soc.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <common/ctrl_partitions.h>
+
+void soc_early_init_hook(void)
+{
+	k3_unlock_all_ctrl_partitions();
+}

--- a/soc/ti/k3/am6x/common/ctrl_partitions.c
+++ b/soc/ti/k3/am6x/common/ctrl_partitions.c
@@ -4,53 +4,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/arch/common/sys_io.h>
 
-#define KICK0_OFFSET     (0x1008)
-#define KICK1_OFFSET     (0x100C)
 #define KICK0_UNLOCK_VAL (0x68EF3490U)
 #define KICK1_UNLOCK_VAL (0xD172BC5AU)
-#define KICK_LOCK_VAL    (0x0U)
 
-#define CTRL_PARTITION_SIZE        (0x4000)
-#define CTRL_PARTITION(base, part) ((base) + (part) * CTRL_PARTITION_SIZE)
+#define K3_UNLOCK_CONTROL_MODULE_(node_id)                                                         \
+	const uint32_t conf_##node_id[] = DT_PROP(node_id, ti_unlock_offsets);                     \
+	base = DT_REG_ADDR(node_id);                                                               \
+	device_map(&base, base, DT_REG_SIZE(node_id), K_MEM_CACHE_NONE);                           \
+	ARRAY_FOR_EACH(conf_##node_id, i) {                                                        \
+		k3_unlock_partition(conf_##node_id[i] + base);                                     \
+	}                                                                                          \
+	IF_ENABLED(CONFIG_MMU, (k_mem_unmap_phys_bare((uint8_t *)base, DT_REG_SIZE(node_id));))
 
-#if defined CONFIG_SOC_AM6442_M4 || defined CONFIG_SOC_AM2434_M4
-#define MCU_PADCFG_BASE (0x4080000)
-#elif defined CONFIG_SOC_AM6234_M4 | defined CONFIG_SOC_AM6232_M4 | defined CONFIG_SOC_AM6254_M4
-#define WKUP_PADCFG_BASE (0x4080000)
-#elif defined CONFIG_SOC_AM2434_R5F0_0
-#define MCU_PADCFG_BASE  (0x4080000)
-#define MAIN_PADCFG_BASE (0xf0000)
+#define K3_UNLOCK_CONTROL_MODULE(node_id)                                                          \
+	IF_ENABLED(DT_NODE_HAS_PROP(node_id, ti_unlock_offsets),                                   \
+		   (K3_UNLOCK_CONTROL_MODULE_(node_id)))
+
+#if DT_HAS_COMPAT_STATUS_OKAY(ti_control_module)
+static void k3_unlock_partition(mem_addr_t kick0_address)
+{
+	sys_write32(KICK0_UNLOCK_VAL, kick0_address);
+	sys_write32(KICK1_UNLOCK_VAL, kick0_address + 4);
+}
 #endif
-
-static const uintptr_t ctrl_partitions[] = {
-#if defined CONFIG_SOC_AM6442_M4 || defined CONFIG_SOC_AM2434_M4
-	CTRL_PARTITION(MCU_PADCFG_BASE, 0),
-	CTRL_PARTITION(MCU_PADCFG_BASE, 1),
-#elif defined CONFIG_SOC_AM6234_M4 | defined CONFIG_SOC_AM6232_M4 | defined CONFIG_SOC_AM6254_M4
-	CTRL_PARTITION(WKUP_PADCFG_BASE, 0),
-	CTRL_PARTITION(WKUP_PADCFG_BASE, 1),
-#elif defined CONFIG_SOC_AM2434_R5F0_0
-	CTRL_PARTITION(MAIN_PADCFG_BASE, 0),
-	CTRL_PARTITION(MAIN_PADCFG_BASE, 1),
-	CTRL_PARTITION(MCU_PADCFG_BASE, 0),
-	CTRL_PARTITION(MCU_PADCFG_BASE, 1),
-#endif
-};
 
 void k3_unlock_all_ctrl_partitions(void)
 {
-	ARRAY_FOR_EACH(ctrl_partitions, i) {
-		mm_reg_t base_addr = ctrl_partitions[i];
+#if DT_HAS_COMPAT_STATUS_OKAY(ti_control_module)
+	uintptr_t base;
 
-#ifdef DEVICE_MMIO_IS_IN_RAM
-		device_map(&base_addr, base_addr, sizeof(base_addr), K_MEM_CACHE_NONE);
+	DT_FOREACH_STATUS_OKAY(ti_control_module, K3_UNLOCK_CONTROL_MODULE)
 #endif
-
-		sys_write32(KICK0_UNLOCK_VAL, base_addr + KICK0_OFFSET);
-		sys_write32(KICK1_UNLOCK_VAL, base_addr + KICK1_OFFSET);
-	}
 }


### PR DESCRIPTION
This binding is for TI devices that use control modules for configuring
registers and information related to control MMRs, power, reset and
clocking.

These control modules consist of regions that require writing specific
values to specific kick registers to unlock that region. This is provided
as ti,unlock-offsets property.

Currently we maintain addresses and values as static configurations using
static configurations and macros in ctrl_partitions.c. Instead use the
new ti,control-module binding to get these values from the device tree and
unlock the partitions during early init.

### Rationale behind driver-less DT binding
I am aware that this is not a preferred thing in the codebase, however writing a driver separately for doing a couple of I/O operations makes little sense in this case. It would pretty much just be the same as the generic syscon driver with a different `init()` API.

### Usecases
One usecase is already addressed in this PR which is unlocking of pinctrl/pinmux regions. 

There are several more usecases for other MMR regions that are not currently in the DT. These involve having something like `compatible = "ti,control-module", "syscon";` to enable the syscon driver as well.
- Can use syscon API for setting DMTimer parent. (Related: https://github.com/zephyrproject-rtos/zephyr/pull/101283)
- Can select TB clock for when EPWM driver is added. (Related: https://github.com/zephyrproject-rtos/zephyr/pull/88757)
- USB subsystem configuration for when USB driver is added.

In general, it would be used as a generic syscon driver for many peripheral configurations (or in case of pinctrl, syscon-less for reduced complexity) in addition to the unlocking mechanism in early init hook.

### Testing

Built for
- AM62-SK A53 and M4 cores
- AM243x-EVM R5F and M4 cores

Ran on
- AM62-SK A53 core
- AM243x-EVM R5F core