### PR TITLE
[Backport v4.3-branch] modules: silabs: Force sli_mv_m4_app_from_flash_to_ram() to be in RAM

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -199,6 +199,10 @@ if(CONFIG_SILABS_SIWX91X_NWP)
     ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c
   )
   zephyr_include_directories(.)
+  zephyr_code_relocate(FILES
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
+    LOCATION RAM
+  )
 endif() # CONFIG_SILABS_SIWX91X_NWP
 
 if(CONFIG_SILABS_SISDK_SLEEPTIMER)

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -18,6 +18,7 @@ rsource "*/Kconfig"
 config SILABS_SIWX91X_NWP
 	bool "Silabs Network Coprocessor"
 	depends on DT_HAS_SILABS_SIWX91X_NWP_ENABLED
+	select CODE_DATA_RELOCATION_SRAM
 	select CMSIS_RTOS_V2
 	select POLL
 	select DYNAMIC_THREAD

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 5d75cba8a1b0e9a747ae387d9ffbb1bf7cd8c529
+      revision: b1510f2c86b918163070f3a540e51cac8160302d
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/de64c007c2227386787728e561e1699ddd499581 from https://github.com/zephyrproject-rtos/zephyr/pull/103084.
Backport https://github.com/zephyrproject-rtos/zephyr/commit/df01f03c0c85d64d48d55f52a1552bc0605254ab from https://github.com/zephyrproject-rtos/zephyr/pull/103414

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103329