### PR TITLE
drivers: ethernet: eth_native_tap: set the link address on interface

### DIFF
--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -482,6 +482,9 @@ static int set_config(const struct device *dev,
 
 		memcpy(context->mac_addr, config->mac_address.addr,
 		       sizeof(context->mac_addr));
+		ret = net_if_set_link_addr(context->iface, context->mac_addr,
+					   sizeof(context->mac_addr),
+					   NET_LINK_ETHERNET);
 	}
 
 	return ret;


### PR DESCRIPTION
Calling net_if_set_link_addr() is needed to update the link address information of the interface.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103231