### PR TITLE
drivers: counter: stm32: remove duplicate reset implementation

### DIFF
--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -464,16 +464,6 @@ static uint32_t counter_stm32_get_freq(const struct device *dev)
 	return data->freq;
 }
 
-static int counter_stm32_reset_timer(const struct device *dev)
-{
-	const struct counter_stm32_config *config = dev->config;
-	TIM_TypeDef *timer = config->timer;
-
-	LL_TIM_SetCounter(timer, 0);
-
-	return 0;
-}
-
 static int counter_stm32_set_value(const struct device *dev, uint32_t ticks)
 {
 	const struct counter_stm32_config *config = dev->config;
@@ -530,7 +520,6 @@ static DEVICE_API(counter, counter_stm32_driver_api) = {
 	.get_guard_period = counter_stm32_get_guard_period,
 	.set_guard_period = counter_stm32_set_guard_period,
 	.get_freq = counter_stm32_get_freq,
-	.reset = counter_stm32_reset_timer,
 	.set_value = counter_stm32_set_value,
 };
 


### PR DESCRIPTION
Drop `counter_stm32_reset_timer`, introduced in PR #94189 (01a00d5), as it duplicates the existing `counter_stm32_reset` functionality.