### PR TITLE
west.yml: update hal_stm32 revision (for SPI pinctrl slew-rate)

### DIFF
--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -198,8 +198,6 @@ stm32_lp_tick_source: &lptim1 {
 zephyr_udc0: &usbotg_hs {
 	clocks = <&rcc STM32_CLOCK(AHB2, 14)>,
 		 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
-	pinctrl-0 = <&usb_otg_hs_dm_pd7 &usb_otg_hs_dp_pd6>;
-	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1006,7 +1006,7 @@
 		compatible = "swj-connector";
 		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
 			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
-			     &debug_jtrst_pb4>;
+			     &debug_njtrst_pb4>;
 		pinctrl-1 = <&analog_pa13 &analog_pa14 &analog_pa15
 			     &analog_pb3 &analog_pb4>;
 		pinctrl-names = "default", "sleep";

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -581,8 +581,7 @@
 		compatible = "swj-connector";
 		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
 			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
-			     /* temp fix to cover current wba5 pin naming */
-			     &debug_jtrst_pb4>;
+			     &debug_njtrst_pb4>;
 		pinctrl-1 = <&analog_pa13 &analog_pa14 &analog_pa15
 			     &analog_pb3 &analog_pb4>;
 		pinctrl-names = "default", "sleep";

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -108,7 +108,7 @@
 		};
 
 		usbotg_hs: usb@42040000 {
-			compatible = "st,stm32-otghs";
+			compatible = "st,stm32n6-otghs", "st,stm32-otghs";
 			reg = <0x42040000 DT_SIZE_K(128)>;
 			interrupts = <76 0>;
 			interrupt-names = "otghs";
@@ -125,16 +125,6 @@
 		clocks = <&rcc STM32_CLOCK(AHB2, 15)>;
 		#phy-cells = <0>;
 		status = "disabled";
-	};
-
-	/*
-	 * Temporary revert of pinctrl-0 definition for stm3wba65
-	 * to fix issue on stm32wba5x based boards
-	 */
-	swj_port: swj_port {
-		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
-			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
-			     &debug_njtrst_pb4>;
 	};
 
 	die_temp: dietemp {

--- a/dts/bindings/usb/st,stm32n6-otghs.yaml
+++ b/dts/bindings/usb/st,stm32n6-otghs.yaml
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  STM32N6 OTGHS controller
+  STM32 OTGHS controller without pinmux
 
-  In the STM32N6 series, the `pinctrl-0` and `pinctrl-names` properties are not required
-  for the USB OTG HS peripheral configuration. This is because the pin multiplexing
-  for the USB OTG HS peripheral are handled automatically by the hardware.
+  On series such as STM32N6, the `pinctrl-0` and `pinctrl-names` properties
+  are not needed as dedicated pins are reserved for USB communication.
 
 compatible: "st,stm32n6-otghs"
 

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: e05bb4707857ecf4344c29a9407aaa4227407546
+      revision: b66bb5c3743ddccc501712d84638eb1df1ebbb04
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 revision so that SPI pinctrl are configured with a very-high-speed slew rate by default.