### PR TITLE
Nrf7120 hfxo startup time support

### DIFF
--- a/dts/bindings/clock/nordic,nrf71-hfxo.yaml
+++ b/dts/bindings/clock/nordic,nrf71-hfxo.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic nRF high-frequency crystal oscillator (nRF71 series)
+
+compatible: "nordic,nrf71-hfxo"
+
+include: fixed-clock.yaml
+
+properties:
+  clock-frequency:
+    const: 64000000
+
+  startup-time-us:
+    type: int
+    required: true
+    description: |
+      Startup time in microseconds.
+
+      The value can be obtained by first measuring the time between
+      TASKS_XOSTART and EVENTS_STARTED. Then multiply the value by 2 to
+      account for temperature and supply variations.
+
+      Note that the startup time will be longer than usual on the first
+      power-up and as such should not be used to determine
+      startup-time-us.

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -63,10 +63,14 @@
 			clock-frequency = <32768>;
 		};
 
-		hfxo64m: hfxo64m {
-			compatible = "fixed-clock";
+		hfxo: hfxo {
+			compatible = "nordic,nrf71-hfxo";
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(64)>;
+			/* TODO: Estimated based on fixed delays in IP, will update once we can
+			 * measure with the real SOC
+			 */
+			startup-time-us = <1210>;
 		};
 
 		hfpll: hfpll {


### PR DESCRIPTION
Adding nRF7120 HFXO startup-time-us variable in the devicetree. This value has been estimated based on fixed wait time and chirpTime, xtallSettleTime, biasSearch defined in the IP. This will be updated once we have a Si SOC and can measure it.