### PR TITLE
Bluetooth: TBS: Rename features to optional opcodes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -161,6 +161,12 @@ Bluetooth Audio
     ``BT_TBS_TECHNOLOGY`` to ``BT_BEARER_TECH``. Additionally the values are now defined in
     :zephyr_file:`include/zephyr/bluetooth/assigned_numbers.h` instead of
     :zephyr_file:`include/zephyr/bluetooth/audio/tbs.h`. (:github:`102430`)
+  * ``bt_tbs_register_param.supported_features`` has been renamed to
+    :c:member:`bt_tbs_register_param.optional_opcodes`. Applications can do a simple
+    search-and-replace for ``supported_features`` to ``optional_opcodes``.
+    Additionally the ``BT_TBS_FEATURE_*`` macros have been changed to ``BT_TBS_OPTIONAL_OPCODE_*``.
+    Applications can do a simple search-and-replace for ``BT_TBS_FEATURE_`` to
+    ``BT_TBS_OPTIONAL_OPCODE_``. (:github:`103350`)
 
 * CSIP
 

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -122,18 +122,18 @@ extern "C" {
 /** @} */
 
 /**
- * @name Optional feature bits
+ * @name Optional opcodes bits
  *
- * Optional features that can be supported. See bt_tbs_client_read_optional_opcodes() on how to
+ * Optional opcodes that can be supported. See bt_tbs_client_read_optional_opcodes() on how to
  * read these from a remote device
  * @{
  */
 /** Local Hold and Local Retrieve Call Control Point Opcodes supported */
-#define BT_TBS_FEATURE_HOLD BIT(0)
+#define BT_TBS_OPTIONAL_OPCODE_HOLD BIT(0)
 /** Join Call Control Point Opcode supported */
-#define BT_TBS_FEATURE_JOIN BIT(1)
+#define BT_TBS_OPTIONAL_OPCODE_JOIN BIT(1)
 /** All Control Point Opcodes supported */
-#define BT_TBS_FEATURE_ALL  (BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN)
+#define BT_TBS_OPTIONAL_OPCODE_ALL  (BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN)
 /** @} */
 
 /**
@@ -491,11 +491,11 @@ struct bt_tbs_register_param {
 	bool authorization_required;
 
 	/**
-	 * @brief The optional supported features of the bearer
+	 * @brief The optional supported opcodes of the bearer
 	 *
-	 * See the BT_TBS_FEATURE_* values.
+	 * See the BT_TBS_OPTIONAL_OPCODE_* values.
 	 */
-	uint8_t supported_features;
+	uint16_t optional_opcodes;
 };
 
 /**

--- a/samples/bluetooth/ccp_call_control_server/src/main.c
+++ b/samples/bluetooth/ccp_call_control_server/src/main.c
@@ -158,7 +158,7 @@ static int init_ccp_call_control_server(void)
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD,
 	};
 	int err;
 
@@ -190,7 +190,7 @@ static int init_ccp_call_control_server(void)
 			.authorization_required = false,
 			/* Set different technologies per bearer */
 			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
-			.supported_features = BT_TBS_FEATURE_HOLD,
+			.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD,
 		};
 
 		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);

--- a/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
+++ b/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
@@ -53,7 +53,7 @@ int ccp_call_control_server_init(void)
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 	};
 
 	err = bt_tbs_register_bearer(&gtbs_param);

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -38,7 +38,7 @@ static int cmd_ccp_call_control_server_init(const struct shell *sh, size_t argc,
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 	};
 	int err;
 
@@ -61,7 +61,8 @@ static int cmd_ccp_call_control_server_init(const struct shell *sh, size_t argc,
 			.authorization_required = false,
 			/* Set different technologies per bearer */
 			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
-			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+			.optional_opcodes =
+				BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 		};
 
 		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -73,7 +73,7 @@ static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 	};
 	int err;
 
@@ -96,7 +96,8 @@ static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 			.authorization_required = false,
 			/* Set different technologies per bearer */
 			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
-			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+			.optional_opcodes =
+				BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 		};
 
 		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1719,7 +1719,7 @@ static uint8_t tbs_hold_call(struct tbs_inst *inst, const struct bt_tbs_call_cp_
 {
 	struct bt_tbs_call *call = lookup_call_in_inst(inst, ccp->call_index);
 
-	if ((inst->optional_opcodes & BT_TBS_FEATURE_HOLD) == 0) {
+	if ((inst->optional_opcodes & BT_TBS_OPTIONAL_OPCODE_HOLD) == 0) {
 		return BT_TBS_RESULT_CODE_OPCODE_NOT_SUPPORTED;
 	}
 
@@ -1744,7 +1744,7 @@ static uint8_t retrieve_call(struct tbs_inst *inst, const struct bt_tbs_call_cp_
 {
 	struct bt_tbs_call *call = lookup_call_in_inst(inst, ccp->call_index);
 
-	if ((inst->optional_opcodes & BT_TBS_FEATURE_HOLD) == 0) {
+	if ((inst->optional_opcodes & BT_TBS_OPTIONAL_OPCODE_HOLD) == 0) {
 		return BT_TBS_RESULT_CODE_OPCODE_NOT_SUPPORTED;
 	}
 
@@ -1802,7 +1802,7 @@ static uint8_t join_calls(struct tbs_inst *inst, const struct bt_tbs_call_cp_joi
 	struct bt_tbs_call *joined_calls[CONFIG_BT_TBS_MAX_CALLS];
 	uint8_t call_state;
 
-	if ((inst->optional_opcodes & BT_TBS_FEATURE_JOIN) == 0) {
+	if ((inst->optional_opcodes & BT_TBS_OPTIONAL_OPCODE_JOIN) == 0) {
 		return BT_TBS_RESULT_CODE_OPERATION_NOT_POSSIBLE;
 	}
 
@@ -2485,7 +2485,7 @@ static int tbs_inst_init_and_register(struct tbs_inst *inst, struct bt_gatt_serv
 	(void)utf8_lcpy(inst->uci, param->uci, sizeof(inst->uci));
 	(void)utf8_lcpy(inst->uri_scheme_list, param->uri_schemes_supported,
 			sizeof(inst->uri_scheme_list));
-	inst->optional_opcodes = param->supported_features;
+	inst->optional_opcodes = param->optional_opcodes;
 	inst->technology = param->technology;
 	inst->attrs = svc->attrs;
 	inst->attr_count = svc->attr_count;
@@ -2566,8 +2566,8 @@ static bool valid_register_param(const struct bt_tbs_register_param *param)
 		return false;
 	}
 
-	if (param->supported_features > BT_TBS_FEATURE_ALL) {
-		LOG_DBG("Invalid supported_features: %u", param->supported_features);
+	if (param->optional_opcodes > BT_TBS_OPTIONAL_OPCODE_ALL) {
+		LOG_DBG("Invalid optional_opcodes: %u", param->optional_opcodes);
 
 		return false;
 	}

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -90,7 +90,7 @@ static void register_default_bearer(struct ccp_call_control_server_test_suite_fi
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = 0,
+		.optional_opcodes = 0,
 	};
 	int err;
 
@@ -120,7 +120,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 			.gtbs = false,
 			.authorization_required = false,
 			.technology = BT_BEARER_TECH_3G,
-			.supported_features = 0,
+			.optional_opcodes = 0,
 		};
 		int err;
 
@@ -149,7 +149,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = 0,
+		.optional_opcodes = 0,
 	};
 	int err;
 
@@ -167,7 +167,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.gtbs = false,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = 0,
+		.optional_opcodes = 0,
 	};
 	int err;
 
@@ -185,7 +185,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = 0,
+		.optional_opcodes = 0,
 	};
 	int err;
 
@@ -209,7 +209,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 		.gtbs = false,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = 0,
+		.optional_opcodes = 0,
 	};
 	int err;
 

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -1219,7 +1219,7 @@ static uint8_t tbs_register_bearer(const void *cmd, uint16_t cmd_len, void *rsp,
 		.uri_schemes_supported = uri_scheme_list,
 		.gtbs = cp->gtbs == 1U ? true : false,
 		.technology = cp->technology,
-		.supported_features  = sys_le16_to_cpu(cp->optional_opcodes),
+		.optional_opcodes = sys_le16_to_cpu(cp->optional_opcodes),
 	};
 
 	int index = bt_tbs_register_bearer(&param);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -183,7 +183,8 @@ static void init(void)
 			.gtbs = true,
 			.authorization_required = false,
 			.technology = BT_BEARER_TECH_3G,
-			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+			.optional_opcodes =
+				BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 		};
 
 		err = bt_tbs_register_bearer(&gtbs_param);

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
@@ -56,7 +56,7 @@ static void init(void)
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 	};
 	int err;
 
@@ -102,7 +102,8 @@ static void init(void)
 			.authorization_required = false,
 			/* Set different technologies per bearer */
 			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
-			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+			.optional_opcodes =
+				BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 		};
 
 		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -334,7 +334,7 @@ static void init(void)
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_BEARER_TECH_3G,
-		.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+		.optional_opcodes = BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 	};
 	int err;
 
@@ -382,7 +382,8 @@ static void init(void)
 			.authorization_required = false,
 			/* Set different technologies per bearer */
 			.technology = (i % BT_BEARER_TECH_WCDMA) + 1,
-			.supported_features = BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN,
+			.optional_opcodes =
+				BT_TBS_OPTIONAL_OPCODE_HOLD | BT_TBS_OPTIONAL_OPCODE_JOIN,
 		};
 
 		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2025-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,10 +34,10 @@ static void test_ccp_peripheral(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_core_register(BTP_SERVICE_ID_TBS);
 
-	bsim_btp_tbs_register_bearer(true, BT_BEARER_TECH_3G, BT_TBS_FEATURE_ALL, "GTBS Provider",
-				     "un000", "tel");
-	bsim_btp_tbs_register_bearer(false, BT_BEARER_TECH_3G, BT_TBS_FEATURE_ALL, "TBS Provider",
-				     "un000", "tel");
+	bsim_btp_tbs_register_bearer(true, BT_BEARER_TECH_3G, BT_TBS_OPTIONAL_OPCODE_ALL,
+				     "GTBS Provider", "un000", "tel");
+	bsim_btp_tbs_register_bearer(false, BT_BEARER_TECH_3G, BT_TBS_OPTIONAL_OPCODE_ALL,
+				     "TBS Provider", "un000", "tel");
 
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);


### PR DESCRIPTION
The characteristic name and definitions in the TBS spec for
the values are "optional opcodes" instead of "support features".

Additionally, the field is 16-bit, instead of the current 8-bit
in the register parameters.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/102666
