### PR TITLE
boards: nxp: frdm_mcxc444: enable MCUboot

### DIFF
--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -35,6 +35,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {


### PR DESCRIPTION
Adds missing "zephyr,code-partition" required for MCUboot.