### PR TITLE
[Backport v4.3-branch] Fix PM on SiWx91x SoC

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -13,6 +13,8 @@ LOG_MODULE_REGISTER(bt_hci_driver_siwg917);
 
 #include "rsi_ble.h"
 #include "rsi_ble_common_config.h"
+#include "siwx91x_nwp.h"
+
 #define BLE_RF_POWER_INDEX     0x0006
 #define BT_OP_VS_RF_POWER_MODE BT_OP(BT_OGF_VS, BLE_RF_POWER_INDEX)
 #define BT_LE_MODE             2
@@ -76,12 +78,20 @@ static int siwx91x_bt_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int siwx91x_bt_setup(const struct device *dev, const struct bt_hci_setup_params *params)
 {
+	const struct hci_config *hci_config = dev->config;
 	int err = rsi_bt_driver_send_tx_pwr_vs_cmd(dev, BT_LE_MODE, RSI_BLE_PWR_INX);
 
 	if (err < 0) {
 		LOG_ERR("Failed to send RF power config command: %d", err);
 		return err;
 	}
+
+	err = siwx91x_nwp_apply_power_profile(hci_config->nwp_dev);
+	if (err < 0) {
+		LOG_ERR("Failed to set power profile: %d", err);
+		return err;
+	}
+
 	return 0;
 }
 

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -669,6 +669,7 @@ static void siwx91x_dma_isr(const struct device *dev)
 	}
 
 	if (data->chan_info[channel].Cnt == data->chan_info[channel].Size) {
+		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
 		if (data->zephyr_channel_info[channel].channel_active) {
 			pm_device_runtime_put_async(dev, K_NO_WAIT);
 			data->zephyr_channel_info[channel].channel_active = false;
@@ -678,7 +679,6 @@ static void siwx91x_dma_isr(const struct device *dev)
 			data->zephyr_channel_info[channel].dma_callback(
 				dev, data->zephyr_channel_info[channel].cb_data, channel, 0);
 		}
-		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
 	} else {
 		/* Call UDMA ROM IRQ handler. */
 		ROMAPI_UDMA_WRAPPER_API->uDMAx_IRQHandler(&udma_resources, udma_resources.desc,

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/policy.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/types.h>
 #include "rsi_rom_udma.h"
 #include "rsi_rom_udma_wrapper.h"
@@ -62,16 +62,6 @@ struct dma_siwx91x_data {
 					      * related information
 					      */
 };
-
-static void siwx91x_dma_pm_policy_state_lock_get(void)
-{
-	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-}
-
-static void siwx91x_dma_pm_policy_state_lock_put(void)
-{
-	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-}
 
 static enum dma_xfer_dir siwx91x_transfer_direction(uint32_t dir)
 {
@@ -495,15 +485,14 @@ static int siwx91x_dma_start(const struct device *dev, uint32_t channel)
 		return -EINVAL;
 	}
 
-	/* Get the power management policy state lock */
 	if (!data->zephyr_channel_info[channel].channel_active) {
-		siwx91x_dma_pm_policy_state_lock_get();
+		pm_device_runtime_get(dev);
 		data->zephyr_channel_info[channel].channel_active = true;
 	}
 
 	if (RSI_UDMA_ChannelEnable(udma_handle, channel) != 0) {
 		if (data->zephyr_channel_info[channel].channel_active) {
-			siwx91x_dma_pm_policy_state_lock_put();
+			pm_device_runtime_put(dev);
 			data->zephyr_channel_info[channel].channel_active = false;
 		}
 		return -EINVAL;
@@ -534,7 +523,7 @@ static int siwx91x_dma_stop(const struct device *dev, uint32_t channel)
 	}
 
 	if (data->zephyr_channel_info[channel].channel_active) {
-		siwx91x_dma_pm_policy_state_lock_put();
+		pm_device_runtime_put(dev);
 		data->zephyr_channel_info[channel].channel_active = false;
 	}
 
@@ -680,16 +669,16 @@ static void siwx91x_dma_isr(const struct device *dev)
 	}
 
 	if (data->chan_info[channel].Cnt == data->chan_info[channel].Size) {
+		if (data->zephyr_channel_info[channel].channel_active) {
+			pm_device_runtime_put_async(dev, K_NO_WAIT);
+			data->zephyr_channel_info[channel].channel_active = false;
+		}
 		if (data->zephyr_channel_info[channel].dma_callback) {
 			/* Transfer complete, call user callback */
 			data->zephyr_channel_info[channel].dma_callback(
 				dev, data->zephyr_channel_info[channel].cb_data, channel, 0);
 		}
 		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
-		if (data->zephyr_channel_info[channel].channel_active) {
-			siwx91x_dma_pm_policy_state_lock_put();
-			data->zephyr_channel_info[channel].channel_active = false;
-		}
 	} else {
 		/* Call UDMA ROM IRQ handler. */
 		ROMAPI_UDMA_WRAPPER_API->uDMAx_IRQHandler(&udma_resources, udma_resources.desc,

--- a/drivers/i2s/i2s_silabs_siwx91x.c
+++ b/drivers/i2s/i2s_silabs_siwx91x.c
@@ -442,9 +442,7 @@ static void i2s_siwx91x_dma_rx_callback(const struct device *dma_dev, void *user
 
 rx_disable:
 	i2s_siwx91x_stream_disable(stream, dma_dev);
-	if (stream->state == I2S_STATE_READY && stream->last_block) {
-		pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
-	}
+	pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
 }
 
 static void i2s_siwx91x_dma_tx_callback(const struct device *dma_dev, void *user_data,
@@ -511,9 +509,7 @@ static void i2s_siwx91x_dma_tx_callback(const struct device *dma_dev, void *user
 
 tx_disable:
 	i2s_siwx91x_stream_disable(stream, dma_dev);
-	if (stream->state == I2S_STATE_READY && stream->last_block) {
-		pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
-	}
+	pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
 }
 
 static int i2s_siwx91x_param_config(const struct device *dev, enum i2s_dir dir)

--- a/drivers/power_domain/power_domain_silabs_siwx91x.c
+++ b/drivers/power_domain/power_domain_silabs_siwx91x.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/policy.h>
 
 #define DT_DRV_COMPAT silabs_siwx91x_power_domain
 
@@ -13,10 +13,12 @@ static int siwx91x_pd_pm_action(const struct device *dev, enum pm_device_action 
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		pm_policy_device_power_lock_get(dev);
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_ON, NULL);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_OFF, NULL);
+		pm_policy_device_power_lock_put(dev);
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		break;

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -555,6 +555,7 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 		ret = gspi_siwx91x_config(dev, config, cb, userdata);
 		if (ret) {
 			spi_context_release(&data->ctx, ret);
+			pm_device_runtime_put(dev);
 			return ret;
 		}
 	}
@@ -566,6 +567,9 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 	if (spi_siwx91x_is_dma_enabled_instance(dev)) {
 		/* Perform DMA transceive */
 		ret = gspi_siwx91x_transceive_dma(dev, config);
+		if (ret < 0) {
+			pm_device_runtime_put(dev);
+		}
 		spi_context_release(&data->ctx, ret);
 	} else {
 		/* Perform synchronous polling transceive */

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -134,6 +134,7 @@
 		siwx91x_soc_pd: siwx91x-soc-pd {
 			compatible = "silabs,siwx91x-power-domain";
 			#power-domain-cells = <0>;
+			zephyr,disabling-power-states = <&pstate_ps4_sleep>;
 			zephyr,pm-device-runtime-auto;
 			status = "okay";
 		};

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -76,7 +76,6 @@
 
 	nwp: nwp {
 		compatible = "silabs,siwx91x-nwp";
-		power-profile = "deep-sleep-with-ram-retention";
 		stack-size = <10240>;
 		interrupt-parent = <&nvic>;
 		interrupts = <30 0>, <74 0>;

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -20,14 +20,3 @@ properties:
     type: int
     description: Stack size for the NWP in bytes
     required: true
-
-  power-profile:
-    type: string
-    description: Power/performance profile
-    enum:
-      - high-performance
-      - associated-power-save
-      - associated-power-save-low-latency
-      - deep-sleep-without-ram-retention
-      - deep-sleep-with-ram-retention
-    required: true

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -27,6 +27,9 @@ configdefault PM_DEVICE_RUNTIME
 configdefault POWER_DOMAIN
 	default y
 
+configdefault PM_POLICY_DEVICE_CONSTRAINTS
+	default y
+
 endif # PM_DEVICE
 
 if SILABS_SIWX91X_NWP

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -42,7 +42,6 @@ struct siwx91x_nwp_data {
 struct siwx91x_nwp_config {
 	void (*config_irq)(const struct device *dev);
 	uint32_t stack_size;
-	uint8_t power_profile;
 };
 
 typedef struct {
@@ -395,9 +394,9 @@ static int siwx91x_nwp_init(const struct device *dev)
 {
 	const struct siwx91x_nwp_config *config = dev->config;
 	__maybe_unused sl_wifi_performance_profile_t performance_profile = {
-		.profile = config->power_profile};
+		.profile = DEEP_SLEEP_WITH_RAM_RETENTION};
 	__maybe_unused sl_bt_performance_profile_t bt_performance_profile = {
-		.profile = config->power_profile};
+		.profile = DEEP_SLEEP_WITH_RAM_RETENTION};
 	sl_wifi_device_configuration_t network_config;
 	int ret;
 
@@ -466,7 +465,6 @@ BUILD_ASSERT(CONFIG_SIWX91X_NWP_INIT_PRIORITY < CONFIG_KERNEL_INIT_PRIORITY_DEFA
                                                                                                    \
 	static const struct siwx91x_nwp_config siwx91x_nwp_config_##inst = {                       \
 		.config_irq = silabs_siwx91x_nwp_irq_configure_##inst,                             \
-		.power_profile = DT_ENUM_IDX(DT_DRV_INST(inst), power_profile),                    \
 		.stack_size = DT_INST_PROP(inst, stack_size)                                       \
 	};                                                                                         \
                                                                                                    \

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
@@ -28,6 +28,17 @@
 int siwx91x_nwp_mode_switch(const struct device *dev, uint8_t oper_mode, bool hidden_ssid,
 			    uint8_t max_num_sta);
 
+/*
+ * @brief Apply the power profile for the NWP.
+ *
+ * This function applies the power profile for the NWP.
+ *
+ * @param[in] dev           NWP device.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int siwx91x_nwp_apply_power_profile(const struct device *dev);
+
 /**
  * @brief Map an ISO/IEC 3166-1 alpha-2 country code to a Wi-Fi region code.
  *


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/b78fe9f1aae101287e1679e7d500e91e0124b7f8 ~3..https://github.com/zephyrproject-rtos/zephyr/commit/d02cdc734e6e4ad83960a7b97787729509c848b2 from https://github.com/zephyrproject-rtos/zephyr/pull/100116
Backport https://github.com/zephyrproject-rtos/zephyr/commit/e866da994fbfc8e84b90518145b41a268ead91d8 and https://github.com/zephyrproject-rtos/zephyr/commit/be4723c213541ea01241a9ed27014f57e42e64a3 from https://github.com/zephyrproject-rtos/zephyr/pull/100913

Some driver modifications may not look like bug fixes, but they are necessary to correct the power_domain ↔ CPU state relationships. Basically, this change switches the driver’s power-management code from using pm_state lock functions to the pm_device_runtime mechanism, which makes power management work correctly.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103339