### PR TITLE
boards: st: stm32n6570_dk: correct red led number and add alias

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -29,6 +29,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		led1 = &red_led_2;
 		sw0 = &user_button;
 	};
 
@@ -53,7 +54,7 @@
 			label = "User LD1";
 		};
 
-		red_led_1: led_2 {
+		red_led_2: led_2 {
 			gpios = <&gpiog 10 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};

--- a/tests/drivers/gpio/gpio_api_1pin/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -5,6 +5,6 @@
 
 / {
 	aliases {
-		led0 = &red_led_1;
+		led0 = &red_led_2;
 	};
 };


### PR DESCRIPTION
The user red led on the stm32n6570_dk is LD2 hence rename the as red_led_2 instead of red_led_1. Moreover add an alias led1 pointing to this led, since this is a USER LED, allowing to use samples requiring two leds.