### PR TITLE
drivers: timer: stm32wb0: Prevent building for WB06/07 if PM enabled

### DIFF
--- a/drivers/timer/Kconfig.stm32wb0_radio_timer
+++ b/drivers/timer/Kconfig.stm32wb0_radio_timer
@@ -7,6 +7,7 @@ config STM32WB0_RADIO_TIMER
 	bool "STM32 Radio Timer for WB0x"
 	default y if PM || BT
 	depends on SOC_SERIES_STM32WB0X
+	depends on !((SOC_STM32WB06XX || SOC_STM32WB07XX) && PM) # Not supported yet
 	select USE_STM32_HAL_RADIO_TIMER
 	select HAS_STM32LIB
 	select TICKLESS_CAPABLE

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -32,10 +32,6 @@ LOG_MODULE_REGISTER(radio_timer_driver);
 BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_NODELABEL(clk_lsi), disabled),
 	     "LSI is not supported yet");
 
-#if (defined(CONFIG_SOC_STM32WB06XX) || defined(CONFIG_SOC_STM32WB07XX)) && defined(CONFIG_PM)
-#error "PM is not supported yet for WB06/WB07"
-#endif /* (CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB06XX) && CONFIG_PM */
-
 /* This value is only valid for the LSE with a frequency of 32768 Hz.
  * The implementation for the LSI will be done in the future.
  */


### PR DESCRIPTION
Prevents building the driver entirely if the PM symbol is selected instead of erroring out via a compiler pragma.

Fixes issue encountered during weekly CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21325722006/job/61382412132#step:14:2155 