### PR TITLE
soc: stm32: fix pm_s2ram linker warning

### DIFF
--- a/soc/st/stm32/stm32wb0x/s2ram_marking.S
+++ b/soc/st/stm32/stm32wb0x/s2ram_marking.S
@@ -12,6 +12,7 @@
 #include <offsets_short.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/common/pm_s2ram.h>
+#include <zephyr/linker/sections.h>
 
 /* Read RCC and PWRC base from Device Tree */
 #include <zephyr/devicetree.h>


### PR DESCRIPTION
Below warning is reported in Zephyr upstream weekly CI after 34985a73b836b7f44b3314854fc760270e38fb26 was merged:
```
ld.bfd: warning: orphan section .TEXT.pm_s2ram_mark_check_and_clear'
from zephyr/libzephyr.a(s2ram_marking.S.obj)' being placed in section
`.TEXT.pm_s2ram_mark_check_and_clear'
```

Fix the warning by adding the appropriate headers.