### PR TITLE
drivers: dma: stm32u5: check stream busyness in dma_suspend

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -649,6 +649,7 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	const struct dma_stm32_stream *stream = &config->streams[id];
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
@@ -659,7 +660,8 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 	/* It's not enough to wait for the SUSPF bit with LL_DMA_IsActiveFlag_SUSP */
 	do {
 		k_busy_wait(800); /* A delay is needed (800us is valid) */
-	} while (LL_DMA_IsActiveFlag_SUSP(dma, dma_stm32_id_to_stream(id)) != 1);
+	} while (LL_DMA_IsActiveFlag_SUSP(dma, dma_stm32_id_to_stream(id)) != 1 &&
+			stream->busy == true);
 
 	/* Do not Reset the channel to allow resuming later */
 	return 0;


### PR DESCRIPTION
Add additional business check to waiting SUSPF to be set so
that the loop cannot be executed forever when the dma stream
is idle.

When the stream is not busy, then there is nothing to suspend.
However, if suspend was attempted for an idle stream, then the
changed loop waited forever SUSPF to be set. This could have
happened at least when serial api tx_abort() is called with
stm32u5 and tx dma transfer becoming ready about the same time
the tx_abort() API is called.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103042