### PR TITLE
drivers: sensor: bmi270: fix I2C write to use single transaction

### DIFF
--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -19,11 +19,6 @@
 
 LOG_MODULE_REGISTER(bmi270, CONFIG_SENSOR_LOG_LEVEL);
 
-#define BMI270_WR_LEN                           256
-#define BMI270_CONFIG_FILE_RETRIES              15
-#define BMI270_CONFIG_FILE_POLL_PERIOD_US       10000
-#define BMI270_INTER_WRITE_DELAY_US             1000
-
 static inline int bmi270_bus_check(const struct device *dev)
 {
 	const struct bmi270_config *cfg = dev->config;

--- a/drivers/sensor/bosch/bmi270/bmi270.h
+++ b/drivers/sensor/bosch/bmi270/bmi270.h
@@ -19,6 +19,11 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 
+#define BMI270_WR_LEN                           32
+#define BMI270_CONFIG_FILE_RETRIES              15
+#define BMI270_CONFIG_FILE_POLL_PERIOD_US       10000
+#define BMI270_INTER_WRITE_DELAY_US             1000
+
 #define BMI270_REG_CHIP_ID         0x00
 #define BMI270_REG_ERROR           0x02
 #define BMI270_REG_STATUS          0x03

--- a/drivers/sensor/bosch/bmi270/bmi270_i2c.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_i2c.c
@@ -8,6 +8,7 @@
  * Bus-specific functionality for BMI270s accessed via I2C.
  */
 
+#include <string.h>
 #include "bmi270.h"
 
 static int bmi270_bus_check_i2c(const union bmi270_bus *bus)
@@ -24,7 +25,23 @@ static int bmi270_reg_read_i2c(const union bmi270_bus *bus,
 static int bmi270_reg_write_i2c(const union bmi270_bus *bus, uint8_t start,
 				const uint8_t *data, uint16_t len)
 {
-	return i2c_burst_write_dt(&bus->i2c, start, data, len);
+	/* Combine register address and data into a single buffer and
+	 * use i2c_write_dt() instead of i2c_burst_write_dt() which
+	 * may not be supported on all I2C devices.
+	 * Maximum write length is BMI270_WR_LEN + 1 byte for address.
+	 */
+	uint8_t buf[1 + BMI270_WR_LEN];
+
+	if (len > BMI270_WR_LEN) {
+		return -EINVAL;
+	}
+
+	buf[0] = start;
+	if (len > 0) {
+		memcpy(&buf[1], data, len);
+	}
+
+	return i2c_write_dt(&bus->i2c, buf, 1 + len);
 }
 
 static int bmi270_bus_init_i2c(const union bmi270_bus *bus)


### PR DESCRIPTION
Combine register address and data in one buffer and use i2c_write_dt() instead of i2c_burst_write_dt() so the transfer is a single I2C transaction. Some I2C controllers (e.g. Infineon) split burst write into two transactions with a STOP in between, which causes failure.
<img width="1468" height="843" alt="burst_write" src="https://github.com/user-attachments/assets/ef735032-166b-47b9-bba4-79d54b075a4f" />
<img width="1468" height="843" alt="write" src="https://github.com/user-attachments/assets/758e0d9f-29f6-410b-a66c-c68979235a1a" />
