### PR TITLE
tests: drivers: spi: spi_loopback: add nRF9151 board overlay

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf9151dk_nrf9151.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf9151dk_nrf9151.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/nrf9151dk_nrf9151.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf9151dk_nrf9151.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};


### PR DESCRIPTION
Add board overlay for nRF9151DK board.
Tested on nRF9151DK hardware.