### PR TITLE
net: mqtt_sn: make client_radius a uint8_t

### DIFF
--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -326,7 +326,7 @@ struct mqtt_sn_client {
 	int64_t ts_gwinfo;
 
 	/** Radius of the next GWINFO transmission */
-	int64_t radius_gwinfo;
+	uint8_t radius_gwinfo;
 
 	/** State for will topic updates */
 	struct mqtt_sn_will_update will_topic_update;


### PR DESCRIPTION
There is no need for it to have a different type than the packet data. The variable is never checked for negativity and is only used when ts_gwinfo is non zero, in which case client_radius must have been set as well.