### PR TITLE
nvmem: Make struct fields private

### DIFF
--- a/include/zephyr/nvmem.h
+++ b/include/zephyr/nvmem.h
@@ -34,6 +34,8 @@ extern "C" {
  * @brief Non-Volatile Memory cell representation.
  */
 struct nvmem_cell {
+	/* @cond INTERNAL_HIDDEN */
+
 	/** NVMEM parent controller device instance. */
 	const struct device *dev;
 	/** Offset of the NVMEM cell relative to the parent controller's base address */
@@ -42,6 +44,8 @@ struct nvmem_cell {
 	size_t size;
 	/** Indicator if the NVMEM cell is read-write or read-only */
 	bool read_only;
+
+	/* @endcond */
 };
 
 /**
@@ -358,6 +362,18 @@ int nvmem_cell_write(const struct nvmem_cell *cell, const void *data, off_t off,
 static inline bool nvmem_cell_is_ready(const struct nvmem_cell *cell)
 {
 	return cell != NULL && device_is_ready(cell->dev);
+}
+
+/**
+ * @brief Check if an NVMEM cell is read-only.
+ *
+ * @param cell NVMEM cell to check. Can't be NULL.
+ *
+ * @return True if the NVMEM cell is read-only and false otherwise.
+ */
+static inline bool nvmem_cell_is_read_only(const struct nvmem_cell *cell)
+{
+	return cell->read_only;
 }
 
 #ifdef __cplusplus

--- a/tests/subsys/nvmem/api/src/main.c
+++ b/tests/subsys/nvmem/api/src/main.c
@@ -20,12 +20,12 @@ ZTEST(nvmem_api, test_nvmem_api)
 	zexpect_equal_ptr(cell0.dev, DEVICE_DT_GET(nvmem0));
 	zexpect_equal(cell0.offset, 0);
 	zexpect_equal(cell0.size, 0x10);
-	zexpect_false(cell0.read_only);
+	zexpect_false(nvmem_cell_is_read_only(&cell0));
 
 	zexpect_equal_ptr(cell10.dev, DEVICE_DT_GET(nvmem0));
 	zexpect_equal(cell10.offset, 0x10);
 	zexpect_equal(cell10.size, 0x10);
-	zexpect_true(cell10.read_only);
+	zexpect_true(nvmem_cell_is_read_only(&cell10));
 
 	for (size_t i = 0; i < sizeof(buf); ++i) {
 		buf[i] = 2 * i;


### PR DESCRIPTION
The internals of an NVMEM cell should be kept private, and needs to be interacted with using an API.