### PR TITLE
net: http-server: handle OPTIONS for dynamic resources

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -402,8 +402,8 @@ static int http1_dynamic_response(struct http_client_ctx *client, struct http_re
 	return 0;
 }
 
-static int dynamic_get_del_req(struct http_resource_detail_dynamic *dynamic_detail,
-			       struct http_client_ctx *client)
+static int dynamic_get_del_opts_req(struct http_resource_detail_dynamic *dynamic_detail,
+				    struct http_client_ctx *client)
 {
 	int ret, len;
 	char *ptr;
@@ -713,11 +713,12 @@ static int handle_http1_dynamic_resource(
 
 	case HTTP_GET:
 	case HTTP_DELETE:
-		/* For GET/DELETE request, we do not pass any data to the app
+	case HTTP_OPTIONS:
+		/* For GET/DELETE/OPTIONS request, we do not pass any data to the app
 		 * but let the app send data to the peer.
 		 */
 		if (user_method & BIT(client->method)) {
-			return dynamic_get_del_req(dynamic_detail, client);
+			return dynamic_get_del_opts_req(dynamic_detail, client);
 		}
 
 		goto not_supported;

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -617,8 +617,8 @@ static int http2_dynamic_response(struct http_client_ctx *client, struct http2_f
 	return 0;
 }
 
-static int dynamic_get_del_req_v2(struct http_resource_detail_dynamic *dynamic_detail,
-				  struct http_client_ctx *client)
+static int dynamic_get_del_opts_req_v2(struct http_resource_detail_dynamic *dynamic_detail,
+				       struct http_client_ctx *client)
 {
 	int ret, len;
 	char *ptr;
@@ -818,8 +818,9 @@ static int handle_http2_dynamic_resource(
 	switch (client->method) {
 	case HTTP_GET:
 	case HTTP_DELETE:
+	case HTTP_OPTIONS:
 		if (user_method & BIT(client->method)) {
-			return dynamic_get_del_req_v2(dynamic_detail, client);
+			return dynamic_get_del_opts_req_v2(dynamic_detail, client);
 		}
 
 		goto not_supported;


### PR DESCRIPTION
Allow applications to respond to HTTP OPTIONS requests (e.g. CORS pre- flight) by routing OPTIONS through the same dynamic handler path as GET/DELETE.

This enables OPTIONS handling for both HTTP/1.1 and HTTP/2.