### PR TITLE
dts: gen_dts_cmake.py: Add a to_cmake_list() function

### DIFF
--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -63,6 +63,10 @@ def escape(value):
     return value
 
 
+def to_cmake_list(iter, map=lambda x: x) -> str:
+    return ";".join(str(map(val)) for val in iter)
+
+
 def parse_args():
     # Returns parsed command-line arguments
 
@@ -128,7 +132,7 @@ def main():
                         continue  # phandle-array not supported
                     # Convert array to CMake list
                     if isinstance(node.props[item].val, list):
-                        cmake_value = ';'.join(phandle.path for phandle in node.props[item].val)
+                        cmake_value = to_cmake_list(node.props[item].val, lambda ph: ph.path)
                     else:
                         cmake_value = node.props[item].val.path
 
@@ -140,7 +144,7 @@ def main():
                 else:
                     if "array" in node.props[item].type:
                         # Convert array to CMake list
-                        cmake_value = ';'.join(str(val) for val in node.props[item].val)
+                        cmake_value = to_cmake_list(node.props[item].val)
                     else:
                         cmake_value = node.props[item].val
 
@@ -150,7 +154,7 @@ def main():
                     cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
         elif node.compats:
             # Manually output compatibles for nodes that have no properties
-            cmake_value = ';'.join(node.compats)
+            cmake_value = to_cmake_list(node.compats)
 
             cmake_prop = f'DT_PROP|{node.path}|compatible'
             cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
@@ -176,7 +180,7 @@ def main():
             cmake_props.append(f'"DT_UNIT_ADDR|{node.path}" "{cmake_unit_addr_int}"')
 
     for comp in compatible2paths:
-        cmake_path = ';'.join(compatible2paths[comp])
+        cmake_path = to_cmake_list(compatible2paths[comp])
 
         cmake_comp = f'DT_COMP|{comp}'
         cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')


### PR DESCRIPTION
It conveniently converts an iterator into a CMake list. e.g.: `[1,2,3]` convert to `1;2;3`