### PR TITLE
scripts: footprint: fpdiff: read proper value for symbol sizes

### DIFF
--- a/scripts/footprint/fpdiff.py
+++ b/scripts/footprint/fpdiff.py
@@ -33,6 +33,14 @@ def parse_args():
 
     return parser.parse_args()
 
+def nodesz(n: AnyNode) -> int:
+    # The AnyNode `size` property hides the `size` key
+    # stored in the node's __dict__, which contains the
+    # actual value for the 'size' key in the JSON file.
+    #
+    # Access the dictionary directly as a workaround.
+    return n.__dict__.get("size")
+
 def main():
     colorama.init()
 
@@ -53,11 +61,14 @@ def main():
         print(f"{root1.name}\n+++++++++++++++++++++")
 
         for node in PreOrderIter(root1):
+            n1_size = nodesz(node)
+
             # pylint: disable=undefined-loop-variable
             n = find(root2, lambda node2: node2.identifier == node.identifier)
             if n:
-                if n.size != node.size:
-                    diff = n.size - node.size
+                n2_size = nodesz(n)
+                if n2_size != n1_size:
+                    diff = n2_size - n1_size
                     if diff == 0:
                         continue
                     if not n.children or not n.parent:
@@ -68,13 +79,13 @@ def main():
 
             else:
                 if not node.children:
-                    print(f"{node.identifier} ({Fore.GREEN}-{node.size}{Fore.RESET}) disappeared.")
+                    print(f"{node.identifier} ({Fore.GREEN}-{n1_size}{Fore.RESET}) disappeared.")
 
         for node in PreOrderIter(root2):
             n = find(root1, lambda node2: node2.identifier == node.identifier)
             if not n:
                 if not node.children and node.size != 0:
-                    print(f"{node.identifier} ({Fore.RED}+{node.size}{Fore.RESET}) is new.")
+                    print(f"{node.identifier} ({Fore.RED}+{nodesz(node)}{Fore.RESET}) is new.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The AnyNode class (more specifically, its `NodeMixin` ancestor) [has a `size` property](https://github.com/c0fec0de/anytree/blob/2e0a1b956172654d75aff93277ce3d883355e0bf/src/anytree/node/nodemixin.py#L524-L548) which hides the value sourced from JSON key 'size', resulting in the script displaying nonsense. Consume the proper value by directly accessing the __dict__ which holds it instead of relying on the dot operator.

This fixes some things straight up not appearing in the diff, and also size values just being wrong overall.

Example before/after:
```
(no paths)
+++++++++++++++++++++
:/__aeabi_llsr (-1) disappeared.
:/__aeabi_memcpy4 (-1) disappeared.
:/__muldi3 (-1) disappeared.
:/__aeabi_lmul (+1) is new.
:/__lshrdi3 (+1) is new.
:/__aeabi_memcpy8 (+1) is new.
ZEPHYR_BASE
+++++++++++++++++++++
OUTPUT_DIR
+++++++++++++++++++++
WORKSPACE
+++++++++++++++++++++
(hidden)
+++++++++++++++++++++
```

```
(no paths)
+++++++++++++++++++++
:/__aeabi_llsr (-24) disappeared.
:/__aeabi_memcpy4 (-18) disappeared.
:/__muldi3 (-68) disappeared.
:/__aeabi_lmul (+68) is new.
:/__lshrdi3 (+24) is new.
:/__aeabi_memcpy8 (+18) is new.
ZEPHYR_BASE
+++++++++++++++++++++
<path to ZEPHYR_BASE> -> -4
drivers/adc/adc_stm32.c/adc_stm32_calibrate.isra.0 -> -4
drivers/adc/adc_stm32.c/adc_stm32_init -> -4
drivers/adc/adc_stm32.c/adc_stm32_cfg_0 -> +4
OUTPUT_DIR
+++++++++++++++++++++
WORKSPACE
+++++++++++++++++++++
(hidden)
+++++++++++++++++++++
```

Remark: there remains one issue in the script (it doesn't attempt to match the roots it diffs, so it could diff two unrelated trees) but this one is more difficult to fix, and only appears in specific circumstances so it is left as an exercise for someone else, or future me if I find bandwidth... I think the most sensible solution would be to build a "merged" tree for each matching root then walk that, but it's quite a rework