### PR TITLE
drivers: usb: udc: stm32: disable MSC double buffering

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -18,6 +18,12 @@ config UDC_STM32
 
 if UDC_STM32
 
+# Temporary workaround for an incompatibility between
+# the STM32 UDC driver and MSC in double buffered mode.
+# The core issue should be fixed and this quirk dropped!
+configdefault USBD_MSC_DOUBLE_BUFFERING
+	default n
+
 config UDC_STM32_STACK_SIZE
 	int "UDC controller driver internal thread stack size"
 	default 512


### PR DESCRIPTION
When combined with the STM32 UDC driver, MSC in double buffered mode is broken (see #102889).
To avoid an out-of-the-box-broken experience for users, add a ***temporary*** quirk in the driver's Kconfig to disable MSC double buffering.