### PR TITLE
imx93_evk and frdm_imx93: a55: add pwm support

### DIFF
--- a/boards/nxp/frdm_imx93/doc/index.rst
+++ b/boards/nxp/frdm_imx93/doc/index.rst
@@ -119,6 +119,18 @@ Run following command to test user buttons connected to FRDM-IMX93 GPIO:
 Note: The overlay only supports ``mimx9352/a55``, but can be extended to support
 ``mimx9352/m33`` if I2C and PCAL6524 is enabled.
 
+PWM(TPM)
+--------
+
+For A55 Core, TPM3 is enabled for :zephyr:code-sample:`pwm-blinky` application,
+the GREEN Colored LED in RGB LED LED1 on the board will blink with different frequency.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky_pwm
+   :host-os: unix
+   :board: frdm_imx93/mimx9352/a55
+   :goals: build
+
 Programming and Debugging (A55)
 *******************************
 

--- a/boards/nxp/frdm_imx93/frdm_imx93-pinctrl.dtsi
+++ b/boards/nxp/frdm_imx93/frdm_imx93-pinctrl.dtsi
@@ -337,4 +337,15 @@
 			bias-pull-up;
 		};
 	};
+
+	tpm3_default: tpm3_default {
+		group0 {
+			pinmux = <&iomuxc1_gpio_io04_tpm_ch_tpm3_ch0>,
+				 <&iomuxc1_gpio_io20_tpm_ch_tpm3_ch1>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
@@ -231,3 +231,9 @@ display_i2c: &lpi2c1 {};
 zephyr_udc0: &usb1 {
 	status = "okay";
 };
+
+&pwm3 {
+	pinctrl-0 = <&tpm3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
@@ -22,6 +22,7 @@ supported:
   - net
   - watchdog
   - usbd
+  - pwm
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -48,12 +48,20 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-TPM
----
+PWM(TPM)
+--------
 
-TPM2 is enabled for PWM for M33 core. Signals can be observerd with
-oscilloscope or logic analyzer.
-Connect J1005-3 and J1005-7(GND) to Oscilloscope or logic analyzer
+For M33 Core, TPM2 is enabled. Signals can be observerd with
+oscilloscope or logic analyzer. Connect J1005-3 and J1005-7(GND) to Oscilloscope or logic analyzer
+
+For A55 Core, TPM3 is enabled for :zephyr:code-sample:`pwm-blinky` application,
+the Green Colored LED in RGB LED D1001 on the board will blink with different frequency.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky_pwm
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
 
 ADC
 ---

--- a/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
+++ b/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
@@ -346,4 +346,15 @@
 			input-enable;
 		};
 	};
+
+	tpm3_default: tpm3_default {
+		group0 {
+			pinmux = <&iomuxc1_gpio_io04_tpm_ch_tpm3_ch0>,
+				 <&iomuxc1_gpio_io20_tpm_ch_tpm3_ch1>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -260,3 +260,9 @@
 &wdog4 {
 	status = "okay";
 };
+
+&pwm3 {
+	pinctrl-0 = <&tpm3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -20,6 +20,7 @@ supported:
   - can
   - net
   - watchdog
+  - pwm
 testing:
   ignore_tags:
     - bluetooth

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -624,6 +624,78 @@
 		status = "disabled";
 	};
 
+	pwm1: pwm@44310000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x44310000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM1_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm2: pwm@44320000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x44320000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM2_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm3: pwm@424e0000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x424e0000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 75 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM3_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm4: pwm@424f0000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x424f0000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 76 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM4_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm5: pwm@42500000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x42500000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 77 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM5_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
+	pwm6: pwm@42510000 {
+		compatible = "nxp,kinetis-tpm";
+		reg = <0x42510000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 78 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_TPM6_CLK 0 0>;
+		prescaler = <1>;
+		#pwm-cells = <3>;
+		status = "disabled";
+	};
+
 	usb1: usbd@4c100000 {
 		compatible = "nxp,ehci";
 		reg = <0x4c100000 DT_SIZE_K(4)>;

--- a/samples/basic/blinky_pwm/boards/frdm_imx93_mimx9352_a55.overlay
+++ b/samples/basic/blinky_pwm/boards/frdm_imx93_mimx9352_a55.overlay
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm3 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};

--- a/samples/basic/blinky_pwm/boards/imx93_evk_mimx9352_a55.overlay
+++ b/samples/basic/blinky_pwm/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm3 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};


### PR DESCRIPTION
Add PWM support on imx93_evk and frdm_imx93 A55 platform.