### PR TITLE
tests: Bluetooth: ASCS: Fix link with CONFIG_NO_OPTIMIZATIONS

### DIFF
--- a/tests/bluetooth/audio/ascs/CMakeLists.txt
+++ b/tests/bluetooth/audio/ascs/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(app PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_iso.c
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_stream.c
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_unicast_server.c
+  ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
   ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
 
   # Mock files


### PR DESCRIPTION
When this test is built with CONFIG_NO_OPTIMIZATIONS (which is the case when building with CONFIG_COVERAGE) or when building with debug logging, it fails to link due to lacking `bt_uuid_str()`.
Let's include the corresponding file in the build so it can link.

Failure can be seen for example in
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21623307913/job/62317166683#step:13:2434