### PR TITLE
scripts: zephyr_module: Fix optionality of "click-through" for blobs

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -318,6 +318,7 @@ def process_blobs(module, meta):
         blob['abspath'] = blobs_path / Path(blob['path'])
         blob['license-abspath'] = Path(module) / Path(blob['license-path'])
         blob['status'] = get_blob_status(blob['abspath'], blob['sha256'])
+        blob['click-through'] = blob.get('click-through', False)
         blobs.append(blob)
 
     return blobs


### PR DESCRIPTION
When pykwalify was changed to jsonschema in commit 58bf2dc0e631d0598adf6c017c3065056a657a7b the optionality of 'click-through' was lost. Fix this by making sure there's always a value in the dictionary, eliminating the following error when the key is missing:
```
if blob['click-through'] and not args.auto_accept:
   ~~~~^^^^^^^^^^^^^^^^^
KeyError: 'click-through'
```

For reference: https://python-jsonschema.readthedocs.io/en/stable/faq/#why-doesn-t-my-schema-s-default-property-set-the-default-on-my-instance