### PR TITLE
boards: u-blox: ubx_bmd345eval: Add gain numbers for FEM

### DIFF
--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
@@ -132,6 +132,8 @@
 		ctx-settle-time-us = <1>;
 		crx-gpios = <&gpio1 6 0>;
 		crx-settle-time-us = <1>;
+		tx-gain-db = <24>;
+		rx-gain-db = <10>;
 	};
 
 	/* These aliases are provided for compatibility with samples */


### PR DESCRIPTION
Missing tx-gain and rx-gain values added.

The missing gain values causes bild errors when building for ubx_bmd345eval in nRF Connect SDK.