### PR TITLE
net: mdns_responder: Avoid linking to not available code

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -385,9 +385,9 @@ static int create_answer(struct net_buf *query, enum dns_rr_type qtype,
 		return ret;
 	}
 
-	if (qtype == DNS_RR_TYPE_A) {
+	if ((qtype == DNS_RR_TYPE_A) && IS_ENABLED(CONFIG_NET_IPV4)) {
 		net_if_ipv4_addr_foreach(iface, answer_addr_cb, &ctx);
-	} else if (qtype == DNS_RR_TYPE_AAAA) {
+	} else if ((qtype == DNS_RR_TYPE_AAAA) && IS_ENABLED(CONFIG_NET_IPV6)) {
 		net_if_ipv6_addr_foreach(iface, answer_addr_cb, &ctx);
 	} else {
 		return -EINVAL;


### PR DESCRIPTION
When building with CONFIG_NO_OPTIMIZATIONS the compiler will not optimize create_answer() based on the caller, and will try to call ipv4/6 code even if not built.
Let's add an extra check in the if before those possibly unavailable calls to ensure those branches are dropped in this case.

Can be seen failing in https://github.com/zephyrproject-rtos/zephyr/actions/runs/21623307913/job/62317166683#step:13:1042