### PR TITLE
drivers: can: mcux: flexcan: allow configuring max filters from 0 to 128

### DIFF
--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -29,14 +29,15 @@ config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
 	  freeze mode.
 
 config CAN_MCUX_FLEXCAN_MAX_FILTERS
-	int "Maximum number of concurrent active RX filters"
+	int "Maximum number of concurrently active RX filters"
+	range 0 128
 	default 5 if CAN_MCUX_FLEXCAN_FD
 	default 13
 	help
-	  Defines maximum number of concurrent active RX filters
-	  The maximum value depends on the number of available message
-	  buffers for each FlexCAN instance. CAN FD mode uses larger
-	  message buffers, resulting in fewer available filters.
+	  Defines maximum number of concurrently active RX filters. The maximum value depends on the
+	  number of available message buffers for each FlexCAN instance.
+
+	  CAN FD mode uses larger message buffers, resulting in fewer available filters.
 
 endif # CAN_MCUX_FLEXCAN
 

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -34,8 +34,11 @@ config CAN_MCUX_FLEXCAN_MAX_FILTERS
 	default 5 if CAN_MCUX_FLEXCAN_FD
 	default 13
 	help
-	  Defines maximum number of concurrently active RX filters. The maximum value depends on the
+	  Default maximum number of concurrently active RX filters. The maximum value depends on the
 	  number of available message buffers for each FlexCAN instance.
+
+	  This default can be overridden on a per-instance basis via the "max-filters" devicetree
+	  property.
 
 	  CAN FD mode uses larger message buffers, resulting in fewer available filters.
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -68,6 +68,7 @@ struct mcux_flexcan_config {
 	uint32_t number_of_mb;
 	uint32_t rx_mb;
 	uint32_t tx_mb;
+	uint8_t max_filters;
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	bool flexcan_fd;
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -133,9 +134,11 @@ static int mcux_flexcan_get_core_clock(const struct device *dev, uint32_t *rate)
 
 static int mcux_flexcan_get_max_filters(const struct device *dev, bool ide)
 {
+	const struct mcux_flexcan_config *config = dev->config;
+
 	ARG_UNUSED(ide);
 
-	return CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS;
+	return config->max_filters;
 }
 
 static int mcux_flexcan_set_timing(const struct device *dev,
@@ -1509,7 +1512,9 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
  * RX message buffers (filters) will take up the first N message
  * buffers. The rest are available for TX use.
  */
-#define FLEXCAN_INST_RX_MB(id) (CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS + RX_START_IDX)
+#define FLEXCAN_INST_MAX_FILTERS(id) \
+	DT_INST_PROP_OR(id, max_filters, CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS)
+#define FLEXCAN_INST_RX_MB(id) (FLEXCAN_INST_MAX_FILTERS(id) + RX_START_IDX)
 #define FLEXCAN_INST_TX_MB(id) (FLEXCAN_INST_NUMBER_OF_MB(id) - FLEXCAN_INST_RX_MB(id))
 
 #define FLEXCAN_CLK_SOURCE(id) DT_INST_PROP(id, clk_source)
@@ -1569,6 +1574,7 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 		.number_of_mb = FLEXCAN_INST_NUMBER_OF_MB(id),		\
 		.rx_mb = FLEXCAN_INST_RX_MB(id),			\
 		.tx_mb = FLEXCAN_INST_TX_MB(id),			\
+		.max_filters = FLEXCAN_INST_MAX_FILTERS(id),		\
 		IF_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD, (		\
 			.flexcan_fd = DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT), \
 		))							\

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1555,10 +1555,10 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 	static void mcux_flexcan_irq_disable_##id(void); \
 									\
 	static struct mcux_flexcan_rx_callback flexcan_rx_cbs_##id	\
-			[FLEXCAN_INST_RX_MB(id)] = {0};			\
+			[FLEXCAN_INST_RX_MB(id)];			\
 									\
 	static struct mcux_flexcan_tx_callback flexcan_tx_cbs_##id	\
-			[FLEXCAN_INST_TX_MB(id)] = {0};			\
+			[FLEXCAN_INST_TX_MB(id)];			\
 									\
 	static ATOMIC_DEFINE(flexcan_rx_allocs_##id, FLEXCAN_INST_RX_MB(id));	\
 									\

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1537,8 +1537,6 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 			"FlexCAN instance " STRINGIFY(id) " clk-source without named clock")))
 
 #define FLEXCAN_CHECK_MAX_FILTER(id)						\
-	BUILD_ASSERT(CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS > 0,			\
-		"Maximum number of RX filters should greater than 0");		\
 	BUILD_ASSERT(FLEXCAN_INST_NUMBER_OF_MB(id) > FLEXCAN_INST_RX_MB(id),	\
 		     "FlexCAN instance " STRINGIFY(id) " number-of-mb ("	\
 		     STRINGIFY(FLEXCAN_INST_NUMBER_OF_MB(id))			\

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -51,6 +51,15 @@ properties:
       Number of 8-byte sized message buffers (MBs) supported by this FlexCAN instance. CAN FD mode,
       if supported, uses 64-byte sized MBs, resulting in fewer available MBs.
 
+  max-filters:
+    type: int
+    description: |
+      Maximum number of concurrently active RX filters. The allowed range value depends on the
+      number of available message buffers for the FlexCAN instance.
+
+      If this property is not set, the default maximum number of RX filters set via Kconfig will be
+      used instead.
+
 examples:
   - |
     flexcan0: can@40024000 {

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -48,7 +48,8 @@ properties:
       - 128
     required: true
     description: |
-      Number of 8-byte sized message buffers supported by this FlexCAN instance.
+      Number of 8-byte sized message buffers (MBs) supported by this FlexCAN instance. CAN FD mode,
+      if supported, uses 64-byte sized MBs, resulting in fewer available MBs.
 
 examples:
   - |


### PR DESCRIPTION
The maximum number of RX filters is limited by the number of message buffers, which cannot exceed 128. Add a range to the Kconfig option imposing this.
    
Remove artificial build-time check on CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS being larger than zero, as transmit-only configuration is otherwise fully supported.

Add devicetree property for overriding the maximum number of hardware message buffers used for RX filters on a per-instance basis.

These limitations were discovered during implementation of an alternative, Zephyr-native FlexCAN driver.