### PR TITLE
drivers: bluetooth: hci_nxp: Wi-Fi and Bluetooth coexistence for M.2 modules

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1230,9 +1230,9 @@ static int bt_nxp_ctlr_init(void)
 #if defined(CONFIG_WIFI_NXP) && (defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610))
 	/* We must skip Bluetooth firmware uploading here, since Wi-Fi driver is enabled
 	   and already loaded `sduart` firmware for both Wi-Fi and Bluetooth parts of the modules. */
-#else /* defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610) */
+#else /* defined(CONFIG_WIFI_NXP) && (defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610)) */
 	err = fw_uploading(bt_fw_bin, bt_fw_bin_len);
-#endif /* defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610) */
+#endif /* defined(CONFIG_WIFI_NXP) && (defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610)) */
 
 	if (err) {
 		LOG_ERR("Fail to upload firmware");

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1227,7 +1227,12 @@ static int bt_nxp_ctlr_init(void)
 
 	uart_irq_rx_enable(uart_dev);
 
+#if defined(CONFIG_WIFI_NXP) && (defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610))
+	/* We must skip Bluetooth firmware uploading here, since Wi-Fi driver is enabled
+	   and already loaded `sduart` firmware for both Wi-Fi and Bluetooth parts of the modules. */
+#else /* defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610) */
 	err = fw_uploading(bt_fw_bin, bt_fw_bin_len);
+#endif /* defined(CONFIG_NXP_IW61X) || defined(CONFIG_NXP_IW416) || defined(CONFIG_NXP_IW610) */
 
 	if (err) {
 		LOG_ERR("Fail to upload firmware");


### PR DESCRIPTION
For M.2 Wi-Fi / BT modules (2EL, 2LL, 1XK) Bluetooth firmware uploading must be skipped when Wi-Fi driver is enabled, otherwise Bluetooth initialization hangs. Wi-Fi driver already uploads `sduart` firmware for both Wi-Fi and Bluetooth parts of the modules.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103408