### PR TITLE
drivers: serial: nrfx_uarte: Fix compilation with deprecated option

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3296,9 +3296,6 @@ static int uarte_instance_deinit(const struct device *dev)
 				(.uart_config = UARTE_CONFIG(idx),))	       \
 		IF_ENABLED(CONFIG_UART_##idx##_ASYNC,			       \
 			    (.async = &uarte##idx##_async,))		       \
-		IF_ENABLED(CONFIG_UART_##idx##_NRF_HW_ASYNC,		       \
-			    (.timer = NRFX_TIMER_INSTANCE(NRF_TIMER_INST_GET(  \
-				CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER)),))    \
 		IF_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN,	       \
 			    (.int_driven = &uarte##idx##_int_driven,))	       \
 	};								       \


### PR DESCRIPTION
Recent changes deprecated Kconfig configuration for TIMER that is used for bytes counting. In one place code was not cleared correctly which results in compilation failure when deprecated symbol is used.

Cleanup for #100177.