### PR TITLE
soc: silabs: siwx91x: Code/data relocation is required

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -18,6 +18,7 @@ rsource "*/Kconfig"
 config SILABS_SIWX91X_NWP
 	bool "Silabs Network Coprocessor"
 	depends on DT_HAS_SILABS_SIWX91X_NWP_ENABLED
+	select CODE_DATA_RELOCATION_SRAM
 	select CMSIS_RTOS_V2
 	select POLL
 	select DYNAMIC_THREAD


### PR DESCRIPTION
Without this change, the fix introduced in commit 189fa5f4d8e ("modules: silabs: Force sli_mv_m4_app_from_flash_to_ram() to be in RAM") is not active.