### PR TITLE
drivers: adc: mcux_lpadc: Fix adc 12-bit measurement

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -705,8 +705,8 @@ static void mcux_lpadc_isr(const struct device *dev)
 				result -= 0x1000;
 			}
 		}
-		*data->buffer++ = result;
 #endif
+		*data->buffer++ = result;
 	} else {
 		*data->buffer++ = conv_result.convValue;
 	}


### PR DESCRIPTION
drivers: adc: mcux_lpadc: Fix of invalid adc measurement when using 12-bit resolution.

When adc resolution is set to 12bit (lpadc provides 12bit or 16bit) and the FSL_FEATURE_LPADC_HAS_B_SIDE_CHANNELS is not enabled, the function mcux_lpadc_isr saves the measured value to variable result but this value is not used after that, (unless the FSL_FEATURE_LPADC_HAS_B_SIDE_CHANNELS is enabled). This change fixed the issue.

Signed-off-by: Martin Martincek <martin.martincek@nxp.com>