### PR TITLE
dts: riscv: nordic: add definitions for vevif_rx for nRF7120

### DIFF
--- a/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
@@ -32,6 +32,24 @@ clic: &cpuflpr_clic {};
 	};
 };
 
+&cpuflpr {
+	cpuflpr_vevif_rx: mailbox {
+		compatible = "nordic,nrf-vevif-task-rx";
+		status = "disabled";
+		interrupt-parent = <&cpuflpr_clic>;
+		interrupts = <16 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <17 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <18 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <19 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <20 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <21 NRF_DEFAULT_IRQ_PRIORITY>,
+			     <22 NRF_DEFAULT_IRQ_PRIORITY>;
+		#mbox-cells = <1>;
+		nordic,tasks = <7>;
+		nordic,tasks-mask = <0x007f0000>;
+	};
+};
+
 &cpuflpr_vpr {
 	cpuflpr_vevif_tx: mailbox {
 		compatible = "nordic,nrf-vevif-event-tx";


### PR DESCRIPTION
Add cpuflpr_vevif_rx for mailbox for nRF7120.
sdk-zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/3742