### PR TITLE
drivers: *: stm32: don't check if clock device is ready

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1562,16 +1562,10 @@ static int adc_stm32_init(const struct device *dev)
 {
 	struct adc_stm32_data *data = dev->data;
 	const struct adc_stm32_cfg *config = dev->config;
-	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	__maybe_unused ADC_TypeDef *adc = config->base;
 	int err;
 
 	LOG_DBG("Initializing %s", dev->name);
-
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
 
 	data->dev = dev;
 

--- a/drivers/adc/adc_stm32wb0.c
+++ b/drivers/adc/adc_stm32wb0.c
@@ -1074,11 +1074,6 @@ int adc_stm32wb0_init(const struct device *dev)
 	ADC_TypeDef *adc = config->reg;
 	int err;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Turn on ADC digital clock (always on) */
 	err = clock_control_on(clk,
 		(clock_control_subsys_t)&config->dig_clk);

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -575,11 +575,6 @@ static int c2_reset(void)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	err = clock_control_configure(clk, (clock_control_subsys_t) &clk_cfg[1],
 					NULL);
 	if (err < 0) {

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -565,12 +565,12 @@ static int can_stm32_set_timing(const struct device *dev,
 static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	const struct can_stm32_config *cfg = dev->config;
-	const struct device *clock;
+	const struct device *clk;
 	int ret;
 
-	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	ret = clock_control_get_rate(clock,
+	ret = clock_control_get_rate(clk,
 				     (clock_control_subsys_t) &cfg->pclken,
 				     rate);
 	if (ret != 0) {
@@ -598,7 +598,7 @@ static int can_stm32_init(const struct device *dev)
 	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
 	struct can_timing timing = { 0 };
-	const struct device *clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int ret;
 
 	k_mutex_init(&filter_mutex);
@@ -612,7 +612,7 @@ static int can_stm32_init(const struct device *dev)
 		}
 	}
 
-	ret = clock_control_on(clock, (clock_control_subsys_t) &cfg->pclken);
+	ret = clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("HAL_CAN_Init clock control on failed: %d", ret);
 		return -EIO;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -598,7 +598,7 @@ static int can_stm32_init(const struct device *dev)
 	struct can_stm32_data *data = dev->data;
 	CAN_TypeDef *can = cfg->can;
 	struct can_timing timing = { 0 };
-	const struct device *clock;
+	const struct device *clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int ret;
 
 	k_mutex_init(&filter_mutex);
@@ -610,12 +610,6 @@ static int can_stm32_init(const struct device *dev)
 			LOG_ERR("CAN transceiver not ready");
 			return -ENODEV;
 		}
-	}
-
-	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	if (!device_is_ready(clock)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
 	}
 
 	ret = clock_control_on(clock, (clock_control_subsys_t) &cfg->pclken);

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -413,11 +413,6 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	ARG_UNUSED(dev);
-	if (!device_is_ready(clk)) {
-		return -ENODEV;
-	}
-
 	if (IS_ENABLED(STM32_CANFD_DOMAIN_CLOCK_SUPPORT) && (stm32fd_cfg->pclk_len > 1)) {
 		if (clock_control_get_rate(clk,
 			 (clock_control_subsys_t) &stm32fd_cfg->pclken[1],
@@ -449,10 +444,6 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	if (!device_is_ready(clk)) {
-		return -ENODEV;
-	}
 
 	if (IS_ENABLED(STM32_CANFD_DOMAIN_CLOCK_SUPPORT) && (stm32fd_cfg->pclk_len > 1)) {
 		ret = clock_control_configure(clk,

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -89,12 +89,6 @@ static int can_stm32h7_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	uint32_t cdiv;
 
-	ARG_UNUSED(dev);
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (IS_ENABLED(STM32H7_FDCAN_DOMAIN_CLOCK_SUPPORT) && (stm32h7_cfg->pclk_len > 1)) {
 		if (clock_control_get_rate(clk,
 			 (clock_control_subsys_t) &stm32h7_cfg->pclken[1],
@@ -127,11 +121,6 @@ static int can_stm32h7_clock_enable(const struct device *dev)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	uint32_t fdcan_clock = 0xffffffff;
 	int ret;
-
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
 
 	if (IS_ENABLED(STM32H7_FDCAN_DOMAIN_CLOCK_SUPPORT) && (stm32h7_cfg->pclk_len > 1)) {
 		ret = clock_control_configure(clk,

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -16,6 +16,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <stm32_backup_domain.h>
@@ -834,6 +835,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
+		__ASSERT(0, "PLL setup failed");
 		return r;
 	}
 
@@ -864,6 +866,7 @@ int stm32_clock_control_init(const struct device *dev)
 		while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI) {
 		}
 	} else {
+		__ASSERT(0, "Invalid SYSCLK source selected");
 		return -ENOTSUP;
 	}
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -14,6 +14,7 @@
 #include <stm32_ll_utils.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <stm32_backup_domain.h>
@@ -1124,6 +1125,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
+		__ASSERT(0, "PLL setup failed");
 		return r;
 	}
 
@@ -1188,6 +1190,7 @@ int stm32_clock_control_init(const struct device *dev)
 					LL_RCC_SYS_CLKSOURCE_STATUS_CSI) {
 		}
 	} else {
+		__ASSERT(0, "Invalid SYSCLK source selected");
 		return -ENOTSUP;
 	}
 

--- a/drivers/clock_control/clock_stm32_ll_n6.c
+++ b/drivers/clock_control/clock_stm32_ll_n6.c
@@ -940,6 +940,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
+		__ASSERT(0, "PLL setup failed");
 		return r;
 	}
 

--- a/drivers/clock_control/clock_stm32_ll_u3.c
+++ b/drivers/clock_control/clock_stm32_ll_u3.c
@@ -634,6 +634,7 @@ int stm32_clock_control_init(const struct device *dev)
 	while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI16) {
 	}
 #else
+	__ASSERT(0, "Invalid SYSCLK source selected");
 	return -ENOTSUP;
 #endif
 

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -914,6 +914,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
+		__ASSERT(0, "PLL setup failed");
 		return r;
 	}
 
@@ -944,6 +945,7 @@ int stm32_clock_control_init(const struct device *dev)
 		while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_HSI) {
 		}
 	} else {
+		__ASSERT(0, "Invalid SYSCLK source selected");
 		return -ENOTSUP;
 	}
 

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -567,6 +567,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
+		__ASSERT(0, "PLL setup failed");
 		return r;
 	}
 

--- a/drivers/comparator/comparator_stm32_comp.c
+++ b/drivers/comparator/comparator_stm32_comp.c
@@ -223,11 +223,6 @@ static int stm32_comp_init(const struct device *dev)
 	COMP_TypeDef *comp = cfg->comp;
 	int ret = 0;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("%s clock control device not ready", dev->name);
-		return -ENODEV;
-	}
-
 	/* Enable COMP bus clock */
 	ret = clock_control_on(clk, &cfg->pclken[0]);
 	if (ret != 0) {

--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -753,11 +753,6 @@ static int rtc_stm32_init(const struct device *dev)
 
 	data->callback = NULL;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
 		LOG_ERR("clock op failed");

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -520,11 +520,6 @@ static int crypto_stm32_init(const struct device *dev)
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(dev);
 	const struct crypto_stm32_config *cfg = CRYPTO_STM32_CFG(dev);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;

--- a/drivers/crypto/crypto_stm32_hash.c
+++ b/drivers/crypto/crypto_stm32_hash.c
@@ -147,11 +147,6 @@ static int crypto_stm32_hash_init(const struct device *dev)
 	const struct crypto_stm32_hash_config *cfg = CRYPTO_STM32_HASH_CFG(dev);
 	struct crypto_stm32_hash_data *data = CRYPTO_STM32_HASH_DATA(dev);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("Clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_ERR("Clock op failed\n");
 		return -EIO;

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -147,11 +147,6 @@ static int dac_stm32_init(const struct device *dev)
 	/* enable clock for subsystem */
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t) &cfg->pclken) != 0) {
 		return -EIO;

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -933,12 +933,6 @@ static void stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv)
 static int disk_stm32_sdmmc_init(const struct device *dev)
 {
 	struct stm32_sdmmc_priv *priv = dev->data;
-	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
 
 	if (!device_is_ready(priv->reset.dev)) {
 		LOG_ERR("reset control device not ready");

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -409,11 +409,6 @@ static int stm32_ltdc_init(const struct device *dev)
 		}
 	}
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Turn on LTDC peripheral clock */
 	err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				(clock_control_subsys_t) &config->pclken[0]);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -661,11 +661,6 @@ static int dma_stm32_init(const struct device *dev)
 	const struct dma_stm32_config *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk,
 		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -786,11 +786,6 @@ static int bdma_stm32_init(const struct device *dev)
 	const struct bdma_stm32_config *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk,
 		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -251,11 +251,6 @@ static int dmamux_stm32_init(const struct device *dev)
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk,
 		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -831,10 +831,6 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(dev_data->clock)) {
-		return -ENODEV;
-	}
-
 	res = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t)&dev_cfg->pclken[0]);
 	__ASSERT_NO_MSG(res == 0);

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -41,11 +41,6 @@ int dwmac_bus_init(struct dwmac_priv *p)
 
 	p->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(p->clock)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	for (size_t n = 0; n < ARRAY_SIZE(pclken); n++) {
 		ret  = clock_control_on(p->clock, (clock_control_subsys_t)&pclken[n]);
 		if (ret) {

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -117,11 +117,6 @@ static int eth_initialize(const struct device *dev)
 	ETH_HandleTypeDef *heth = &dev_data->heth;
 	int ret = 0;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Enable clocks */
 	for (size_t n = 0; n < cfg->pclken_cnt; n++) {
 		if (n == cfg->kclk_sel_idx) {

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -437,11 +437,6 @@ static int stm32_flash_init(const struct device *dev)
 	}
 #endif
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* enable clock */
 	if (clock_control_on(clk, (clock_control_subsys_t)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2196,11 +2196,6 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	uint32_t prescaler = STM32_OSPI_CLOCK_PRESCALER_MIN;
 	int ret;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 #ifdef CONFIG_STM32_MEMMAP
 	/* If MemoryMapped then configure skip init */
 	if (stm32_ospi_is_memorymap(dev)) {

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2083,11 +2083,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	uint32_t prescaler = STM32_XSPI_CLOCK_PRESCALER_MIN;
 	int ret;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 #if defined(CONFIG_STM32_APP_IN_EXT_FLASH) && defined(CONFIG_XIP)
 	/* If MemoryMapped then configure skip init
 	 * Check clock status first as reading CR register without bus clock doesn't work on N6

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -934,11 +934,6 @@ static int stm32h7_flash_init(const struct device *dev)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* enable clock : enable the RCC_AHB3ENR_FLASHEN bit */
 	if (clock_control_on(clk, (clock_control_subsys_t)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -739,10 +739,6 @@ __maybe_unused static int gpio_stm32_init(const struct device *dev)
 
 	data->dev = dev;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		return -ENODEV;
-	}
-
 #if (defined(PWR_CR2_IOSV) || defined(PWR_SVMCR_IO2SV)) && \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpiog))
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);

--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -347,11 +347,6 @@ static int i2c_stm32_init(const struct device *dev)
 	 */
 	k_sem_init(&data->bus_mutex, 1, 1);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	i2c_stm32_activate(dev);
 
 	if (IS_ENABLED(I2C_STM32_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -232,11 +232,6 @@ static int i2c_stm32_init(const struct device *dev)
 
 	i2c_rtio_init(data->ctx, dev);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	i2c_stm32_activate(dev);
 
 	if (IS_ENABLED(I2C_STM32_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {

--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -76,11 +76,6 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (ret != 0) {
 		LOG_ERR("Could not enable I2S clock");

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -272,12 +272,6 @@ static int stm32_sai_enable_clock(const struct device *dev)
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-	LOG_DBG("Clock Control Device: <OK>");
-
 	/* Turn on SAI peripheral clock */
 	err = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (err != 0) {

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -136,12 +136,6 @@ static int stm32_exti_enable_clocks(void)
 
 #if DT_NODE_HAS_PROP(EXTI_NODE, clocks)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	if (!device_is_ready(clk)) {
-		LOG_ERR("Clock control device not ready");
-		return -ENODEV;
-	}
-
 	const struct stm32_pclken pclken = STM32_CLOCK_INFO(0, EXTI_NODE);
 
 	ret = clock_control_on(clk, (clock_control_subsys_t) &pclken);

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -159,11 +159,6 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 	/* Config transfer semaphore */
 	switch (CONFIG_IPM_STM32_HSEM_CPU) {
 	case HSEM_CPU1:
-		if (!device_is_ready(clk)) {
-			LOG_ERR("clock control device not ready");
-			return -ENODEV;
-		}
-
 		/* Enable clock */
 		if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 			LOG_WRN("Failed to enable clock");

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -249,11 +249,6 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 #if DT_INST_NUM_CLOCKS(0) != 0
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* enable clock */
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t)&cfg->pclken) != 0) {

--- a/drivers/mbox/mbox_stm32_hsem.c
+++ b/drivers/mbox/mbox_stm32_hsem.c
@@ -199,11 +199,6 @@ static int mbox_stm32_clock_init(const struct device *dev)
 	const struct mbox_stm32_hsem_conf *cfg = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("Clock control device not ready.");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_WRN("Failed to enable clock.");
 		return -EIO;

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -54,12 +54,6 @@ static int memc_stm32_init(const struct device *dev)
 
 	/* enable FMC peripheral clock */
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	r = clock_control_on(clk, (clock_control_subsys_t)&config->pclken[0]);
 	if (r < 0) {
 		LOG_ERR("Could not initialize FMC clock (%d)", r);

--- a/drivers/memc/memc_stm32_ospi_psram.c
+++ b/drivers/memc/memc_stm32_ospi_psram.c
@@ -286,11 +286,6 @@ static int memc_stm32_ospi_psram_init(const struct device *dev)
 		return ret;
 	}
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			     (clock_control_subsys_t)&dev_cfg->pclken) != 0) {
 		LOG_ERR("Could not enable OSPI clock");

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -229,11 +229,6 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		return ret;
 	}
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			     (clock_control_subsys_t) &dev_cfg->pclken) != 0) {

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -456,11 +456,6 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 	const struct mipi_dsi_stm32_config *config = dev->config;
 	int ret;
 
-	if (!device_is_ready(config->rcc)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	ret = clock_control_on(config->rcc, (clock_control_subsys_t)&config->dsi_clk);
 	if (ret < 0) {
 		LOG_ERR("Enable DSI peripheral clock failed! (%d)", ret);

--- a/drivers/misc/stm32n6_axisram/stm32n6_axisram.c
+++ b/drivers/misc/stm32n6_axisram/stm32n6_axisram.c
@@ -32,10 +32,6 @@ static int axisram_stm32_init(const struct device *dev)
 	/* enable clock for subsystem */
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken_ramcfg) != 0) {
 		return -EIO;
 	}

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1387,11 +1387,6 @@ static int mspi_stm32_ospi_activate(const struct device *dev)
 	int ret;
 	const struct mspi_stm32_conf *config = (const struct mspi_stm32_conf *)dev->config;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -578,11 +578,6 @@ static int mspi_stm32_qspi_clock_config(const struct mspi_stm32_conf *cfg,
 	uint32_t ahb_clock_freq;
 	uint32_t prescaler;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			     (clock_control_subsys_t)&cfg->pclken[0]) != 0) {

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1458,10 +1458,6 @@ static int mspi_stm32_xspi_activate(const struct device *dev)
 	const struct mspi_stm32_conf *config = (struct mspi_stm32_conf *)dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		return -ENODEV;
-	}
-
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -641,11 +641,6 @@ static int pwm_stm32_init(const struct device *dev)
 	uint32_t tim_clk;
 	int r;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Enable clock and store its speed */
 	r = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (r < 0) {

--- a/drivers/regulator/regulator_stm32_vrefbuf.c
+++ b/drivers/regulator/regulator_stm32_vrefbuf.c
@@ -122,11 +122,6 @@ static int regulator_stm32_vrefbuf_init(const struct device *dev)
 
 	regulator_common_data_init(dev);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("Clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&config->pclken[0]) != 0) {
 		LOG_ERR("Could not enable clock");
 		return -EIO;

--- a/drivers/rtc/rtc_stm32.c
+++ b/drivers/rtc/rtc_stm32.c
@@ -445,11 +445,6 @@ static int rtc_stm32_init(const struct device *dev)
 
 	int err = 0;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/sdhc/sdhc_stm32.c
+++ b/drivers/sdhc/sdhc_stm32.c
@@ -211,10 +211,6 @@ static int sdhc_stm32_activate(const struct device *dev)
 	const struct sdhc_stm32_config *config = (struct sdhc_stm32_config *)dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		return -ENODEV;
-	}
-
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;

--- a/drivers/sensor/st/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/st/qdec_stm32/qdec_stm32.c
@@ -111,11 +111,6 @@ static int qdec_stm32_initialize(const struct device *dev)
 		return retval;
 	}
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("Clock control device not ready");
-		return -ENODEV;
-	}
-
 	retval = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				  (clock_control_subsys_t)&dev_cfg->pclken);
 	if (retval < 0) {

--- a/drivers/sensor/st/stm32_digi_temp/stm32_digi_temp.c
+++ b/drivers/sensor/st/stm32_digi_temp/stm32_digi_temp.c
@@ -171,11 +171,6 @@ static int stm32_digi_temp_init(const struct device *dev)
 	/* enable clock for subsystem */
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("Clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken) != 0) {
 		LOG_ERR("Could not enable DTS clock");
 		return -EIO;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2223,11 +2223,6 @@ static int uart_stm32_clocks_enable(const struct device *dev)
 	const struct uart_stm32_config *config = dev->config;
 	int err;
 
-	if (!device_is_ready(config->clock)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* enable clock */
 	err = clock_control_on(config->clock, (clock_control_subsys_t)&config->pclken[0]);
 	if (err != 0) {

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1707,11 +1707,6 @@ static int spi_stm32_init(const struct device *dev)
 	const struct spi_stm32_config *cfg = dev->config;
 	int err;
 
-	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (IS_ENABLED(STM32_SPI_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
 		err = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 					      (clock_control_subsys_t) &cfg->pclken[1],

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -521,10 +521,6 @@ static int sys_clock_driver_init(void)
 	uint32_t count_per_tick;
 	int err;
 
-	if (!device_is_ready(clk_ctrl)) {
-		return -ENODEV;
-	}
-
 	/* Reset timer to default state using RCC */
 	(void)reset_line_toggle_dt(&lptim_reset);
 

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1290,11 +1290,6 @@ static int udc_stm32_clock_enable(const struct device *dev)
 	const struct udc_stm32_config *cfg = dev->config;
 	int err;
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (cfg->num_clocks > 1) {
 		if (clock_control_configure(clk, &cfg->pclken[1], NULL) != 0) {
 			LOG_ERR("Could not select USB domain clock");

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -191,11 +191,6 @@ static int stm32_dcmi_enable_clock(const struct device *dev)
 	const struct video_stm32_dcmi_config *config = dev->config;
 	const struct device *dcmi_clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(dcmi_clock)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Turn on DCMI peripheral clock */
 	return clock_control_on(dcmi_clock, (clock_control_subsys_t)&config->pclken);
 }

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1680,11 +1680,6 @@ static int stm32_dcmipp_enable_clock(const struct device *dev)
 	const struct device *cc_node = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
 
-	if (!device_is_ready(cc_node)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Turn on DCMIPP peripheral clock */
 	err = clock_control_configure(cc_node, (clock_control_subsys_t)&config->dcmipp_pclken_ker,
 				      NULL);

--- a/drivers/video/video_stm32_jpeg.c
+++ b/drivers/video/video_stm32_jpeg.c
@@ -484,11 +484,6 @@ static int stm32_jpeg_enable_clock(const struct device *dev)
 	const struct stm32_jpeg_config *config = dev->config;
 	const struct device *cc_node = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(cc_node)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	/* Turn on JPEG peripheral clock */
 	return clock_control_on(cc_node, (clock_control_subsys_t)&config->jpeg_hclken);
 }

--- a/drivers/video/video_stm32_venc.c
+++ b/drivers/video/video_stm32_venc.c
@@ -397,11 +397,6 @@ static int stm32_venc_enable_clock(const struct device *dev)
 	const struct stm32_venc_config *config = dev->config;
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&config->pclken) != 0) {
 		return -EIO;
 	}

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -286,11 +286,6 @@ static int wwdg_stm32_init(const struct device *dev)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 
-	if (!device_is_ready(clk)) {
-		LOG_ERR("clock control device not ready");
-		return -ENODEV;
-	}
-
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_ERR("clock control on failed");
 		return -EIO;


### PR DESCRIPTION
If the clock device (i.e., RCC) failed to initialize, we have bigger problems than trying to call `clock_control_{off,on,configure}` on it. Don't bother checking to save some footprint.

Example with `samples/hello_world` on `stm32n6570_dk`:
```
ZEPHYR_BASE (-44)
+++++++++++++++++++++
lib/libc/picolibc/stdio.c/stderr (-4) disappeared.
drivers/interrupt_controller/intc_exti_stm32.c/stm32_exti_init -> -12
drivers/gpio/gpio_stm32.c/gpio_stm32_init -> -20
drivers/serial/uart_stm32.c/uart_stm32_init -> -12
lib/libc/picolibc/stdio.c/stdout (+4) is new.
```