### PR TITLE
modules/hal_rpi_pico: Use toolchain libc when picolibc is not selected

### DIFF
--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -44,9 +44,15 @@ target_include_directories(boot_stage2 PUBLIC
   ${ZEPHYR_BASE}/include
   )
 
+if(CONFIG_PICOLIBC)
+  set(boot_specs "picolibc.specs")
+else()
+  set(boot_specs "nosys.specs")
+endif()
+
 target_link_options(boot_stage2 PRIVATE
   "-nostartfiles"
-  "--specs=picolibc.specs"
+  "--specs=${boot_specs}"
   "-T${boot_stage_dir}/boot_stage2.ld"
   )
 


### PR DESCRIPTION
When the application isn't using picolibc, fall back to previous behavior and use toolchain default along with 'nosys.specs'.

Fixes #103406 