### PR TITLE
soc: intel_adsp: clear BSS on core #0 at boot

### DIFF
--- a/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
+++ b/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
@@ -340,10 +340,6 @@ SECTIONS {
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
-    _bss_table_start = .;
-    LONG(_bss_start)
-    LONG(_bss_end)
-    _bss_table_end = .;
     MMU_PAGE_ALIGN
   } >ram
 
@@ -465,7 +461,7 @@ SECTIONS {
 
   .bss SEGSTART_UNCACHED (NOLOAD) :
   {
-    _bss_start = .;
+    __bss_start = .;
 
 #if defined(CONFIG_ZTEST) && defined(CONFIG_SIMULATOR_XTENSA)
     /* For some weird unknown reasons, the simulator really do not
@@ -499,7 +495,7 @@ SECTIONS {
     *(COMMON)
     . = ALIGN(8);
     MMU_PAGE_ALIGN
-    _bss_end = .;
+    __bss_end = .;
   } >ucram
 
   . = SEGSTART_UNCACHED;

--- a/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -307,10 +307,6 @@ SECTIONS {
     *(.dynamic)
     *(.gnu.version_d)
     _image_ram_start = .;
-    _bss_table_start = .;
-    LONG(_bss_start)
-    LONG(_bss_end)
-    _bss_table_end = .;
     __rodata_region_end = .;
   } >RAM
 
@@ -405,7 +401,7 @@ SECTIONS {
 
   .bss SEGSTART_UNCACHED (NOLOAD) :
   {
-    _bss_start = .;
+    __bss_start = .;
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -423,7 +419,7 @@ SECTIONS {
 #include <linker_sram_bss_relocate.ld>
 #endif
     . = ALIGN(8);
-    _bss_end = .;
+    __bss_end = .;
   } >ucram
 
   /* Heap start and end markers.  Mostly unused, though newlib likes them */

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -9,6 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/arch/common/init.h>
 #include <soc_util.h>
 #include <zephyr/cache.h>
 #include <adsp_shim.h>
@@ -158,6 +159,9 @@ __imr void boot_core0(void)
 	hp_sram_init(L2_SRAM_SIZE);
 	lp_sram_init();
 	parse_manifest();
+
+	arch_bss_zero();
+
 	sys_cache_data_flush_all();
 
 	xtensa_vecbase_lock();


### PR DESCRIPTION
Since the audio DSP is not using the architecture boot path, the BSS is not cleared/zeroed at boot. So we need to manually zero out the BSS via arch_bss_zero().

Also, the _bss_table_start/_end symbols are no longer needed since we are not using the arch boot code. Saves a few bytes.