### PR TITLE
 Add support for polymorphic JSON fields

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -615,6 +615,22 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
  * (2) no UTF-8 validation is performed; and
  * (3) only integer numbers are supported (no strtod() in the minimal libc).
  *
+ * @note Polymorphic decoding: Multiple descriptors may share the same field
+ * name to handle fields that can contain different JSON types. This is
+ * primarily intended for scalar types, such as JSON-RPC style "id" fields
+ * that may be either a string or a number.
+ *
+ * When decoding fails for a descriptor, the behavior depends on the actual
+ * JSON token type:
+ *
+ * - Scalar tokens (strings, numbers, booleans): The parser continues to try
+ *   alternate descriptors, since no parsing occurred and the lexer state
+ *   remains valid.
+ *
+ * - Complex tokens (objects, arrays): The parser returns the error immediately,
+ *   since partial parsing may have corrupted the lexer state, making it unsafe
+ *   to continue with other descriptors.
+ *
  * @param json Pointer to JSON-encoded value to be parsed
  * @param len Length of JSON-encoded value
  * @param descr Pointer to the descriptor array

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -1165,6 +1165,9 @@ static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *desc
 	int ret;
 
 	while (!obj_next(obj, &kv)) {
+		bool any_descriptor_matched_name = false;
+		bool field_decoded = false;
+
 		if (kv.value.type == JSON_TOK_OBJECT_END) {
 			return decoded_fields;
 		}
@@ -1187,15 +1190,55 @@ static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *desc
 				continue;
 			}
 
+			any_descriptor_matched_name = true;
+
 			/* Store the decoded value */
 			ret = decode_value(obj, &descr[i], &kv.value,
 					   decode_field, val);
 			if (ret < 0) {
-				return ret;
+				/*
+				 * When decode fails, we must distinguish between two cases:
+				 *
+				 * 1. Type mismatch: The JSON token type didn't match what the
+				 *    descriptor expected (e.g., token is STRING but descriptor
+				 *    expects ARRAY). In this case, equivalent_types() returned
+				 *    false and decode_value() exited early - no parsing occurred
+				 *    and the lexer state is still valid. Safe to continue and
+				 *    try alternate descriptors.
+				 *
+				 * 2. Parse failure: The token type matched but parsing the
+				 *    complex structure (object/array) failed internally. The
+				 *    lexer has advanced through partial content and its state
+				 *    may be corrupted. Must return error immediately.
+				 *
+				 * We check the actual token type (kv.value.type) rather than
+				 * the descriptor type to determine if complex parsing was
+				 * actually attempted.
+				 */
+				if (kv.value.type == JSON_TOK_OBJECT_START ||
+				    kv.value.type == JSON_TOK_ARRAY_START) {
+					return ret;
+				}
+				continue;
 			}
 
 			decoded_fields |= (int64_t)1<<i;
+			field_decoded = true;
 			break;
+		}
+
+		/*
+		 * If the field name matched at least one descriptor but all decode
+		 * attempts failed, propagate an error.
+		 *
+		 * Note: 'ret' contains the error code from the last failed
+		 * decode_value() attempt. When multiple descriptors share the same
+		 * field name (for example, in polymorphic decoding scenarios), the
+		 * specific error code returned here is implementation-defined and may
+		 * depend on descriptor ordering.
+		 */
+		if (any_descriptor_matched_name && !field_decoded) {
+			return ret;
 		}
 
 		/* Skip field, if no descriptor was found */

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -420,6 +420,20 @@ static const struct json_mixed_arr_descr test_mixed_arr_null_descr[] = {
 	JSON_MIXED_ARR_DESCR_PRIM(struct test_mixed_arr, status_buf, JSON_TOK_STRING_BUF, count),
 };
 
+struct polymorphic_request {
+	const char *method;
+	const char *id_string;
+	int64_t id_number;
+	int params;
+};
+
+static const struct json_obj_descr polymorphic_descr[] = {
+	JSON_OBJ_DESCR_PRIM(struct polymorphic_request, method, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct polymorphic_request, "id", id_string, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct polymorphic_request, "id", id_number, JSON_TOK_INT64),
+	JSON_OBJ_DESCR_PRIM(struct polymorphic_request, params, JSON_TOK_NUMBER),
+};
+
 ZTEST(lib_json_test, test_json_encoding)
 {
 	struct test_struct ts = {
@@ -3039,6 +3053,98 @@ ZTEST(lib_json_test, test_debug_string_types)
 
 	zassert_str_equal(decoded.string_value, "test\nvalue", "string_value not unescaped");
 	zassert_str_equal(decoded.string_buf, "buffer\ttab", "string_buf not unescaped");
+}
+
+ZTEST(lib_json_test, test_json_polymorphic_id_as_string)
+{
+	char encoded[] = "{\"method\":\"initialize\",\"id\":\"request123\",\"params\":42}";
+	struct polymorphic_request req = {0};
+	int ret;
+
+	ret = json_obj_parse(encoded, strlen(encoded), polymorphic_descr,
+			     ARRAY_SIZE(polymorphic_descr), &req);
+
+	zassert_equal(ret, (1 << 0) | (1 << 1) | (1 << 3),
+		      "Expected method, id_string, and params to be decoded, got %d", ret);
+	zassert_str_equal(req.method, "initialize", "Method not decoded correctly");
+	zassert_str_equal(req.id_string, "request123", "String ID not decoded correctly");
+	zassert_equal(req.id_number, 0, "Numeric ID should remain zero");
+	zassert_equal(req.params, 42, "Params not decoded correctly");
+}
+
+ZTEST(lib_json_test, test_json_polymorphic_id_as_number)
+{
+	char encoded[] = "{\"method\":\"shutdown\",\"id\":999,\"params\":0}";
+	struct polymorphic_request req = {0};
+	int ret;
+
+	ret = json_obj_parse(encoded, strlen(encoded), polymorphic_descr,
+			     ARRAY_SIZE(polymorphic_descr), &req);
+
+	zassert_equal(ret, (1 << 0) | (1 << 2) | (1 << 3),
+		      "Expected method, id_number, and params to be decoded, got %d", ret);
+	zassert_str_equal(req.method, "shutdown", "Method not decoded correctly");
+	zassert_is_null(req.id_string, "String ID should remain null");
+	zassert_equal(req.id_number, 999, "Numeric ID not decoded correctly");
+	zassert_equal(req.params, 0, "Params not decoded correctly");
+}
+
+ZTEST(lib_json_test, test_json_polymorphic_id_invalid_type)
+{
+	/* Boolean 'id' should fail to decode as both string and number */
+	char encoded[] = "{\"method\":\"test\",\"id\":true,\"params\":0}";
+	struct polymorphic_request req = {0};
+	int ret;
+
+	ret = json_obj_parse(encoded, strlen(encoded), polymorphic_descr,
+			     ARRAY_SIZE(polymorphic_descr), &req);
+	zassert_true(ret < 0, "Parsing should fail for boolean id, got %d", ret);
+}
+
+/*
+ * Test to verify safety behavior: when a complex type (object/array) token
+ * is encountered and parsing fails, the error is returned immediately rather
+ * than attempting fallback to other descriptors. This prevents undefined
+ * behavior from corrupted lexer state.
+ *
+ * Note: Polymorphic decoding is primarily intended for scalar types
+ * (string vs number). This test verifies correct error handling, not
+ * a typical use case.
+ */
+ZTEST(lib_json_test, test_json_polymorphic_complex_type_error_handling)
+{
+	struct nested_data {
+		int value;
+	};
+
+	struct complex_polymorphic {
+		struct nested_data data_obj;
+		const char *data_string;
+	};
+
+	static const struct json_obj_descr nested_data_descr[] = {
+		JSON_OBJ_DESCR_PRIM(struct nested_data, value, JSON_TOK_NUMBER),
+	};
+
+	static const struct json_obj_descr complex_descr[] = {
+		JSON_OBJ_DESCR_OBJECT_NAMED(struct complex_polymorphic, "data", data_obj,
+					    nested_data_descr),
+		JSON_OBJ_DESCR_PRIM_NAMED(struct complex_polymorphic, "data", data_string,
+					  JSON_TOK_STRING),
+	};
+
+	/*
+	 * JSON has object token with invalid nested content. Parser must
+	 * return error immediately, not attempt fallback to string descriptor.
+	 */
+	char encoded[] = "{\"data\":{\"value\":\"not_a_number\"}}";
+	struct complex_polymorphic req = {0};
+	int ret;
+
+	ret = json_obj_parse(encoded, strlen(encoded), complex_descr, ARRAY_SIZE(complex_descr),
+			     &req);
+
+	zassert_true(ret < 0, "Parsing should fail immediately for invalid object, got %d", ret);
 }
 
 ZTEST_SUITE(lib_json_test, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This PR enables parsing of polymorphic JSON fields where the same field name can accept multiple types such as the MCP JSON-RPC specification where "id" can be either a string or an integer. Added test suites for polymorphic fields while verifying existing tests still pass.