### PR TITLE
kernel: Disable k_mutex priority inheritance

### DIFF
--- a/doc/kernel/services/synchronization/mutexes.rst
+++ b/doc/kernel/services/synchronization/mutexes.rst
@@ -73,7 +73,9 @@ that mutex.
 .. note::
     The :kconfig:option:`CONFIG_PRIORITY_CEILING` configuration option limits
     how high the kernel can raise a thread's priority due to priority
-    inheritance. The default value of 0 permits unlimited elevation.
+    inheritance. The default value of -128 permits unlimited. Setting this
+    to a priority level that is at or lower than the priority of the idle
+    thread disables it.
 
 The owning thread's base priority is saved in the mutex when it obtains the
 lock. Each time a higher priority thread waits on a mutex, the kernel adjusts

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -83,11 +83,14 @@ config PREEMPT_ENABLED
 
 config PRIORITY_CEILING
 	int "Priority inheritance ceiling"
-	default -127
+	default -128
+	range -128 127
 	help
-	  This defines the minimum priority value (i.e. the logically
-	  highest priority) that a thread will acquire as part of
-	  k_mutex priority inheritance.
+	  This defines the minimum priority value (i.e. the logically highest
+	  priority) that a thread will acquire as part of the k_mutex priority
+	  inheritance. Setting this to a priority level at or lower than the
+	  the idle thread's priority level disables the k_mutex priority
+	  inheritance algorithm.
 
 config NUM_METAIRQ_PRIORITIES
 	int "Number of very-high priority 'preemptor' threads"


### PR DESCRIPTION
There were a few loose ends centered around CONFIG_PRIORITY_CEILING.
1. Lowers the default value to -128 from -127 and correctly documents this. This streamlines the priority inheritance algorithm slightly.
2. Adds a Kconfig range to CONFIG_PRIORITY_CEILING. This helps ensure configuration consistency.
3. Disable k_mutex priority inheritance when CONFIG_PRIORITY_CEILING is set to too low of a priority.

Fixes #103240