### PR TITLE
[usbd]: add default NET_TC_TX_COUNT=1 for USBD_CDC_ECM_CLASS and USBD_CDC_NCM_CLASS

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -198,6 +198,7 @@ config NET_IPV4_MAPPING_TO_IPV6
 config NET_TC_TX_COUNT
 	int "How many Tx traffic classes to have for each network device"
 	default 1 if USERSPACE || USB_DEVICE_NETWORK || \
+		     USBD_CDC_ECM_CLASS || USBD_CDC_NCM_CLASS || \
 		     NET_SHELL_REQUIRE_TX_THREAD
 	default 0
 	range 1 NET_TC_NUM_PRIORITIES if NET_TC_NUM_PRIORITIES<=8 && \


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#103442
Origin: Original

Adds a separate TX traffic class for CDC-ECM and CDC-NCM in USBD_Next to prevent a TX deadlock during interface provisioning.

Tested with a custom nRF53-app firmware which combines CDC-ECM / CDC-NCM (both tested) with mDNS with USB hosts MacOS, iPadOS, and Alpine Linux.