### PR TITLE
drivers: fuelgauge: add support for SOH property

### DIFF
--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -193,6 +193,10 @@ static int bq27z746_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = bq27z746_read16(dev, BQ27Z746_DESIGNCAPACITY, &tmp_val);
 		val->design_cap = tmp_val;
 		break;
+	case FUEL_GAUGE_STATE_OF_HEALTH:
+		rc = bq27z746_read16(dev, BQ27Z746_STATEOFHEALTH, &tmp_val);
+		val->state_of_health = tmp_val;
+		break;
 	default:
 		rc = -ENOTSUP;
 	}

--- a/drivers/fuel_gauge/bq40z50/bq40z50.c
+++ b/drivers/fuel_gauge/bq40z50/bq40z50.c
@@ -377,6 +377,12 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->sbs_remaining_time_alarm = tmp_val;
 		break;
 
+	case FUEL_GAUGE_STATE_OF_HEALTH:
+		ret = bq40z50_i2c_read(dev, BQ40Z50_STATEOFHEALTH, (uint8_t *)&tmp_val,
+				       BQ40Z50_LEN_BYTE);
+		val->state_of_health = tmp_val;
+		break;
+
 	default:
 		ret = -ENOTSUP;
 		break;

--- a/drivers/fuel_gauge/bq40z50/bq40z50.h
+++ b/drivers/fuel_gauge/bq40z50/bq40z50.h
@@ -44,6 +44,7 @@ enum bq40z50_regs {
 	BQ40Z50_MANUFACTURERBLOCKACCESS = 0x44, /* R/W */
 	BQ40Z50_BTPDISCHARGE = 0x4A,            /* R/W, Unit: mAh, Range: 150..65535 */
 	BQ40Z50_BTPCHARGE = 0x4B,               /* R/W, Unit: mAh, Range: 175..65535 */
+	BQ40Z50_STATEOFHEALTH = 0x4F,           /* R/O, Unit: percent, Range: 0..100 */
 	BQ40Z50_PFSTATUS = 0x53,                /* Cannot read in Sealed Mode */
 	BQ40Z50_OPERATIONSTATUS = 0x54,         /* Cannot read in Sealed Mode */
 	BQ40Z50_CHARGINGSTATUS = 0x55,          /* Cannot read in Sealed Mode */

--- a/drivers/fuel_gauge/bq40z50/emul_bq40z50.c
+++ b/drivers/fuel_gauge/bq40z50/emul_bq40z50.c
@@ -119,6 +119,7 @@ static int emul_bq40z50_reg_read(const struct emul *target, int reg, uint16_t *v
 		break;
 	case BQ40Z50_RELATIVESTATEOFCHARGE:
 	case BQ40Z50_ABSOLUTESTATEOFCHARGE:
+	case BQ40Z50_STATEOFHEALTH:
 		*val = 100;
 		break;
 	case BQ40Z50_CHARGINGVOLTAGE:

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -2,6 +2,7 @@
  * Copyright 2022 Google LLC
  * Copyright 2023 Microsoft Corporation
  * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -131,6 +132,8 @@ enum fuel_gauge_prop_type {
 	FUEL_GAUGE_ADC_MODE,
 	/** Coulomb Counter Config (flags)*/
 	FUEL_GAUGE_CC_CONFIG,
+	/** State of Health (SoH) (percent, 0-100)*/
+	FUEL_GAUGE_STATE_OF_HEALTH,
 
 	/** Reserved to demark end of common fuel gauge properties */
 	FUEL_GAUGE_COMMON_COUNT,
@@ -235,6 +238,8 @@ union fuel_gauge_prop_val {
 	uint8_t adc_mode;
 	/** FUEL_GAUGE_CC_CONFIG */
 	uint8_t cc_config;
+	/** FUEL_GAUGE_STATE_OF_HEALTH */
+	uint8_t state_of_health;
 };
 
 /**

--- a/samples/drivers/fuel_gauge/src/main.c
+++ b/samples/drivers/fuel_gauge/src/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023 Alvaro Garcia Gomez <maxpowel@gmail.com>
  * Copyright (c) 2025 Philipp Steiner <philipp.steiner1987@gmail.com>
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -149,6 +150,7 @@ int main(void)
 			FUEL_GAUGE_CURRENT_DIRECTION,
 			FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
 			FUEL_GAUGE_LOW_VOLTAGE_ALARM,
+			FUEL_GAUGE_STATE_OF_HEALTH,
 		};
 
 		union fuel_gauge_prop_val test_vals[ARRAY_SIZE(test_props)];
@@ -338,6 +340,11 @@ int main(void)
 					case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
 						LOG_INF("  Low voltage alarm: %" PRIu32,
 							test_vals[i].low_voltage_alarm);
+
+					case FUEL_GAUGE_STATE_OF_HEALTH:
+						LOG_INF(" State of Health (SOH): %" PRIu32,
+							test_vals[i].state_of_health);
+
 						break;
 					}
 				}

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -101,23 +101,24 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t props[] = {
-			FUEL_GAUGE_AVG_CURRENT,
-			FUEL_GAUGE_CYCLE_COUNT,
-			FUEL_GAUGE_CURRENT,
-			FUEL_GAUGE_FULL_CHARGE_CAPACITY,
-			FUEL_GAUGE_REMAINING_CAPACITY,
-			FUEL_GAUGE_RUNTIME_TO_EMPTY,
-			FUEL_GAUGE_RUNTIME_TO_FULL,
-			FUEL_GAUGE_SBS_MFR_ACCESS,
-			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-			FUEL_GAUGE_TEMPERATURE,
-			FUEL_GAUGE_VOLTAGE,
-			FUEL_GAUGE_SBS_ATRATE,
-			FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
-			FUEL_GAUGE_CHARGE_VOLTAGE,
-			FUEL_GAUGE_CHARGE_CURRENT,
-			FUEL_GAUGE_STATUS,
-			FUEL_GAUGE_DESIGN_CAPACITY,
+		FUEL_GAUGE_AVG_CURRENT,
+		FUEL_GAUGE_CYCLE_COUNT,
+		FUEL_GAUGE_CURRENT,
+		FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+		FUEL_GAUGE_REMAINING_CAPACITY,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY,
+		FUEL_GAUGE_RUNTIME_TO_FULL,
+		FUEL_GAUGE_SBS_MFR_ACCESS,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+		FUEL_GAUGE_TEMPERATURE,
+		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_SBS_ATRATE,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+		FUEL_GAUGE_CHARGE_VOLTAGE,
+		FUEL_GAUGE_CHARGE_CURRENT,
+		FUEL_GAUGE_STATUS,
+		FUEL_GAUGE_DESIGN_CAPACITY,
+		FUEL_GAUGE_STATE_OF_HEALTH,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
@@ -143,6 +144,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	zassert_equal(vals[14].chg_current, 1000);
 	zassert_equal(vals[15].fg_status, 1);
 	zassert_equal(vals[16].design_cap, 1);
+	zassert_equal(vals[17].state_of_health, 1);
 #else
 	/* When having a real device, check for the valid ranges */
 	zassert_between_inclusive(props[0].avg_current, -32768 * 1000, 32767 * 1000);
@@ -162,6 +164,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	zassert_between_inclusive(props[14].chg_current, 0, 32767);
 	/* Not testing props[15]. This property is the status and only has only status bits */
 	zassert_between_inclusive(props[16].design_cap, 0, 32767);
+	zassert_between_inclusive(props[17].state_of_health, 0, 100);
 #endif
 }
 

--- a/tests/drivers/fuel_gauge/bq40z50/src/test_bq40z50.c
+++ b/tests/drivers/fuel_gauge/bq40z50/src/test_bq40z50.c
@@ -123,8 +123,9 @@ ZTEST_USER_F(bq40z50, test_get_props__returns_ok)
 		FUEL_GAUGE_SBS_ATRATE_OK,
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
 		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-
+		FUEL_GAUGE_STATE_OF_HEALTH,
 	};
+
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
 	zassert_ok(fuel_gauge_get_props(fixture->dev, props, vals, ARRAY_SIZE(props)));
@@ -154,6 +155,7 @@ ZTEST_USER_F(bq40z50, test_get_props__returns_ok)
 	zassert_equal(vals[21].sbs_at_rate_ok, 0);
 	zassert_equal(vals[22].sbs_remaining_capacity_alarm, 300);
 	zassert_equal(vals[23].sbs_remaining_time_alarm, 10);
+	zassert_equal(vals[24].state_of_health, 100);
 #else
 	/* When having a real device, check for the valid ranges */
 	zassert_between_inclusive(vals[0].avg_current, -32767 * 1000, 32768 * 1000);
@@ -180,6 +182,7 @@ ZTEST_USER_F(bq40z50, test_get_props__returns_ok)
 	/* Not testing props[21]. This is the sbs_at_rate_ok property and has a boolean.*/
 	zassert_between_inclusive(vals[22].sbs_remaining_capacity_alarm, 0, 1000);
 	zassert_between_inclusive(vals[23].sbs_remaining_time_alarm, 0, 30);
+	zassert_between_inclusive(vals[24].state_of_health, 0, 100);
 #endif
 }
 


### PR DESCRIPTION
This commit adds support for State-of-Health (SOH) property in the fuel_gauge subsystem.