### PR TITLE
usb: use correct subclass for cdc-ecm data interface

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -739,7 +739,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 		.bAlternateSetting = 1,						\
 		.bNumEndpoints = 2,						\
 		.bInterfaceClass = USB_BCC_CDC_DATA,				\
-		.bInterfaceSubClass = ECM_SUBCLASS,				\
+		.bInterfaceSubClass = 0,					\
 		.bInterfaceProtocol = 0,					\
 		.iInterface = 0,						\
 	},									\


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#103447
Origin: Original

The CDC-ECM data interface (alternate setting 1) incorrectly used ECM_SUBCLASS (0x06) for bInterfaceSubClass. Per USB CDC-ECM spec section 3.4, the Data Class interface should use bInterfaceSubClass=0.

From USB CDC 1.2 specification, section 4.5 "Data Class Interface":
  "The Data Class defines a general-purpose mechanism that can be
   used to enable bulk or isochronic transfer on the Universal
   Serial Bus when the data does not meet the requirements for any
   other class."

  Table 6 - Data Class Interface Protocol Codes:
  - bInterfaceClass: 0x0A (Data Interface Class)
  - bInterfaceSubClass: 0x00 (unused)
  - bInterfaceProtocol: 0x00 (no class-specific protocol)

The ECM subclass (0x06) is only valid for the Communications Class control interface, not the Data Class interface. The Linux cdc_ether driver validates this and rejects devices with the wrong subclass, returning -EINVAL during probe.

This fix enables CDC-ECM to work on Linux hosts. macOS and iPadOS are more permissive and work with either value.