### PR TITLE
Exception dump hook

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -98,6 +98,10 @@ if(DEFINED CONFIG_ARCH_SUPPORTS_ROM_OFFSET)
   # Handled in ld.cmake
 endif()
 
+zephyr_library_sources_ifdef(
+  CONFIG_EXCEPTION_DUMP_HOOK
+  exception.c
+)
 
 # isr_tables is a normal CMake library and not a zephyr_library because it
 # should not be --whole-archive'd

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -39,6 +39,13 @@ config EXCEPTION_DUMP_HOOK
 	  Enables hook for configuring an additional method for delivering
 	  exeption prints through similar interface as printk or LOG.
 
+config EXCEPTION_DUMP_HOOK_ONLY
+	bool "Do not send exception prints to logs or printk if hook is set"
+	depends on EXCEPTION_DUMP_HOOK
+	help
+	  Do not send exception prints to logs or printk if the exception
+	  hook is set.
+
 config ARM_MPU
 	bool "ARM MPU Support"
 	select MPU

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -33,6 +33,12 @@ config ARCH_SUPPORTS_ROM_OFFSET
 	  script, which will place a block of 0x0 of size
 	  CONFIG_ROM_START_OFFSET at the start of the ROM region.
 
+config EXCEPTION_DUMP_HOOK
+	bool "Exceptions printing hooks"
+	help
+	  Enables hook for configuring an additional method for delivering
+	  exeption prints through similar interface as printk or LOG.
+
 config ARM_MPU
 	bool "ARM MPU Support"
 	select MPU

--- a/arch/common/exception.c
+++ b/arch/common/exception.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/exception.h>
+
+arch_exception_dump_hook_t arch_exception_dump_hook;
+arch_exception_drain_hook_t arch_exception_drain_hook;

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -36,6 +36,17 @@ config XTENSA_ENABLE_BACKTRACE
 	help
 	  Enable this config option to print backtrace on panic exception
 
+config XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK
+	bool "Send backtrace to exception dump hook"
+	depends on XTENSA_ENABLE_BACKTRACE && EXCEPTION_DUMP_HOOK
+	default y if EXCEPTION_DUMP_HOOK_ONLY
+	help
+	  Enable this option to forward Xtensa panic backtrace output to
+	  exception dump hook.
+
+	  When EXCEPTION_DUMP_HOOK_ONLY is enabled, this defaults to y to
+	  preserve hook-only backtrace output.
+
 config XTENSA_SMALL_VECTOR_TABLE_ENTRY
 	bool "Workaround for small vector table entries"
 	help

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -106,6 +106,9 @@ void xtensa_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK)
+	arch_exception_call_drain_hook(false);
+#endif
 	z_fatal_error(reason, esf);
 }
 

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -743,6 +743,9 @@ skip_checks:
 	}
 #endif /* CONFIG_XTENSA_MMU */
 
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK)
+	arch_exception_call_drain_hook(false);
+#endif
 	return return_to(interrupted_stack);
 
 #if defined(CONFIG_XTENSA_MMU) && defined(CONFIG_USERSPACE)
@@ -751,6 +754,9 @@ return_to_interrupted:
 		XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
 	}
 
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK)
+	arch_exception_call_drain_hook(false);
+#endif
 	return interrupted_stack;
 #endif /* CONFIG_XTENSA_MMU && CONFIG_USERSPACE */
 }

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -242,6 +242,10 @@ static void print_fatal_exception(void *print_stack, bool is_dblexc, uint32_t de
 	 */
 	if (xtensa_is_outside_stack_bounds((uintptr_t)bsa, sizeof(*bsa), UINT32_MAX)) {
 		EXCEPTION_DUMP(" ** VADDR %p Invalid SP %p", (void *)bsa->excvaddr, print_stack);
+		/* Do not waste hook bandwidth on broken records. */
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK)
+		arch_exception_call_drain_hook(true);
+#endif
 		return;
 	}
 

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -7,6 +7,7 @@
 #include "xtensa/corebits.h"
 #include "xtensa_backtrace.h"
 #include <zephyr/sys/printk.h>
+#include <zephyr/arch/exception.h>
 #if defined(CONFIG_SOC_SERIES_ESP32)
 #include <esp_memory_utils.h>
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
@@ -138,11 +139,17 @@ int xtensa_backtrace_print(int depth, int *interrupted_stack)
 	if (cause != EXCCAUSE_INSTR_PROHIBITED) {
 		mask = stk_frame.pc & 0xc0000000;
 	}
+#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
+	arch_exception_call_dump_hook("BT 0x%08x:0x%08x ",
+				      xtensa_cpu_process_stack_pc(stk_frame.pc),
+				      stk_frame.sp);
+#endif
+#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
 	printk("\r\n\r\nBacktrace:");
 	printk("0x%08x:0x%08x ",
 			xtensa_cpu_process_stack_pc(stk_frame.pc),
 			stk_frame.sp);
-
+#endif
 	/* Check if first frame is valid */
 	bool corrupted = !(xtensa_stack_ptr_is_sane(stk_frame.sp) &&
 				(xtensa_ptr_executable((void *)
@@ -155,12 +162,29 @@ int xtensa_backtrace_print(int depth, int *interrupted_stack)
 		if (!xtensa_backtrace_get_next_frame(&stk_frame)) {
 			corrupted = true;
 		}
+#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
+		arch_exception_call_dump_hook("0x%08x:0x%08x ",
+					      xtensa_cpu_process_stack_pc(stk_frame.pc),
+					      stk_frame.sp);
+#endif
+#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
 		printk("0x%08x:0x%08x ", xtensa_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
+#endif
 	}
 
 	/* Print backtrace termination marker */
 	int ret = 0;
 
+#if defined(CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK)
+	if (corrupted) {
+		arch_exception_call_dump_hook("CORRUPTED");
+		ret = -1;
+	} else if (stk_frame.next_pc != 0) {    /* Backtrace continues */
+		arch_exception_call_dump_hook("CONTINUES");
+	}
+	arch_exception_call_dump_hook("\n");
+#endif
+#if !defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
 	if (corrupted) {
 		printk(" |<-CORRUPTED");
 		ret =  -1;
@@ -168,5 +192,6 @@ int xtensa_backtrace_print(int depth, int *interrupted_stack)
 		printk(" |<-CONTINUES");
 	}
 	printk("\r\n\r\n");
+#endif
 	return ret;
 }

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -87,7 +87,9 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 	}
 }
 
-#if defined(CONFIG_LOG)
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK_ONLY)
+#define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__)
+#elif defined(CONFIG_LOG)
 #define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__); \
 	LOG_ERR(format, ##__VA_ARGS__)
 #else

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -8,10 +8,100 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_EXCEPTION_H_
 #define ZEPHYR_INCLUDE_ARCH_EXCEPTION_H_
 
+#if defined(CONFIG_EXCEPTION_DUMP_HOOK)
+
+#include <stdbool.h>
+#include <stdarg.h>
+
+/**
+ * @typedef exception_dump_hook_t
+ * @brief Exception dump output callback.
+ *
+ * Called for each exception dump print with printf-style format and
+ * argument list.
+ *
+ * @param format Printf-style format string.
+ * @param args Variable argument list for @p format.
+ */
+typedef void (*arch_exception_dump_hook_t)(const char *format, va_list args);
+
+/**
+ * @typedef exception_drain_hook_t
+ * @brief Exception dump flush callback.
+ *
+ * Called when exception dump output should be drained or reset.
+ *
+ * @param flush True to flush/reset buffered state, false to emit pending output.
+ */
+typedef void (*arch_exception_drain_hook_t)(bool flush);
+
+extern arch_exception_dump_hook_t arch_exception_dump_hook;
+extern arch_exception_drain_hook_t arch_exception_drain_hook;
+
+/**
+ * @brief Set exception dump callbacks.
+ *
+ * Registers callback handlers used by exception dump helpers.
+ *
+ * @param dump Callback for formatted exception dump output.
+ * @param drain Callback to flush or reset buffered output state.
+ */
+static inline void arch_exception_set_dump_hook(arch_exception_dump_hook_t dump,
+						arch_exception_drain_hook_t drain)
+{
+	arch_exception_dump_hook = dump;
+	arch_exception_drain_hook = drain;
+}
+
+/**
+ * @brief Call the registered exception drain callback.
+ *
+ * Calls the drain callback if one is registered.
+ *
+ * @param flush True to flush/reset buffered state, false to emit pending output.
+ */
+static inline void arch_exception_call_drain_hook(bool flush)
+{
+	if (arch_exception_drain_hook) {
+		arch_exception_drain_hook(flush);
+	}
+}
+
+/**
+ * @brief Call the registered exception dump callback.
+ *
+ * Forwards a printf-style format string and arguments to the registered
+ * exception dump callback, if present.
+ *
+ * @param format Printf-style format string.
+ * @param ... Arguments for @p format.
+ */
+static inline void arch_exception_call_dump_hook(const char *format, ...)
+{
+	va_list args;
+
+	if (arch_exception_dump_hook) {
+		va_start(args, format);
+		arch_exception_dump_hook(format, args);
+		va_end(args);
+	}
+}
+
+#if defined(CONFIG_LOG)
+#define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__); \
+	LOG_ERR(format, ##__VA_ARGS__)
+#else
+#define EXCEPTION_DUMP(format, ...) arch_exception_call_dump_hook(format "\n",  ##__VA_ARGS__); \
+	printk(format "\n", ##__VA_ARGS__)
+#endif
+
+#else
+
 #if defined(CONFIG_LOG)
 #define EXCEPTION_DUMP(...) LOG_ERR(__VA_ARGS__)
 #else
 #define EXCEPTION_DUMP(format, ...) printk(format "\n", ##__VA_ARGS__)
+#endif
 #endif
 
 #if defined(CONFIG_X86_64)


### PR DESCRIPTION
The exception dump hooks now work reliably with SOF and https://github.com/thesofproject/sof/pull/10517 .