### PR TITLE
fs: nvs: fix data loss after power loss during close ATE programming

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -42,8 +42,25 @@ config FLASH_HAS_EXPLICIT_ERASE
 	  optimized-out by compiler in case where there is no such device in
 	  a system.
 
+config FLASH_HAS_SAFE_INPLACE_WRITE
+	bool
+	help
+	  Indicates that this flash device can safely perform in-place writes
+	  to a location that has already been programmed, without requiring
+	  a full erase.
+
+	  On devices without this capability, rewriting a partially programmed
+	  location (e.g., a close ATE in NVS) may fail or result in undefined
+	  behavior. NVS and other layers should guard such operations with
+	  this flag to avoid mount failures or data corruption.
+
+	  Drivers for devices that allow safe in-place updates should select
+	  this option. Platforms where rewrites are unsafe should leave it
+	  disabled.
+
 config FLASH_HAS_NO_EXPLICIT_ERASE
 	bool
+	select FLASH_HAS_SAFE_INPLACE_WRITE
 	help
 	  Device does not require explicit erase before programming
 	  a new random value at any location that has been previously

--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -49,6 +49,7 @@ config FLASH_SIMULATOR_RAMLIKE
 
 config FLASH_SIMULATOR_DOUBLE_WRITES
 	bool "Allow program units to be programmed more than once"
+	select FLASH_HAS_SAFE_INPLACE_WRITE
 	help
 	 If selected, writing to a non-erased program unit will succeed, otherwise, it will return an error.
 	 Keep in mind that write operations can only change value of a bit from erase-value to the

--- a/subsys/kvss/nvs/nvs.c
+++ b/subsys/kvss/nvs/nvs.c
@@ -749,13 +749,14 @@ gc_done:
 static int nvs_startup(struct nvs_fs *fs)
 {
 	int rc;
-	struct nvs_ate last_ate;
+	struct nvs_ate last_ate, close_ate;
 	size_t ate_size, empty_len;
 	/* Initialize addr to 0 for the case fs->sector_count == 0. This
 	 * should never happen as this is verified in nvs_mount() but both
 	 * Coverity and GCC believe the contrary.
 	 */
 	uint32_t addr = 0U;
+	uint32_t close_addr = 0U;
 	uint16_t i, closed_sectors = 0;
 	uint8_t erase_value = fs->flash_parameters->erase_value;
 
@@ -768,11 +769,18 @@ static int nvs_startup(struct nvs_fs *fs)
 	for (i = 0; i < fs->sector_count; i++) {
 		addr = (i << ADDR_SECT_SHIFT) +
 		       (uint16_t)(fs->sector_size - ate_size);
-		rc = nvs_flash_cmp_const(fs, addr, erase_value,
-					 sizeof(struct nvs_ate));
+
+		rc = nvs_flash_ate_rd(fs, addr, &close_ate);
+		if (rc) {
+			goto end;
+		}
+
+		rc = nvs_ate_cmp_const(&close_ate, erase_value);
 		if (rc) {
 			/* closed sector */
 			closed_sectors++;
+
+			close_addr = addr;
 			nvs_sector_advance(fs, &addr);
 			rc = nvs_flash_cmp_const(fs, addr, erase_value,
 						 sizeof(struct nvs_ate));
@@ -867,6 +875,49 @@ static int nvs_startup(struct nvs_fs *fs)
 
 		fs->ate_wra -= ate_size;
 	}
+
+#ifdef CONFIG_FLASH_HAS_SAFE_INPLACE_WRITE
+	/*
+	 * Recovery for power loss during close ATE programming.
+	 *
+	 * When the newly selected sector is empty, the sector layout indicates
+	 * that a close ATE should exist in the previously used sector. If such
+	 * a close ATE is present but invalid, this most likely means that power
+	 * was lost while programming the close ATE.
+	 *
+	 * Although the previous closed sector can still be correctly identified
+	 * during this startup, the flash contents of the invalid close ATE are
+	 * not stable. Due to flash charge characteristics, subsequent reads
+	 * may incorrectly return an erased (all erase_value) pattern, causing
+	 * the sector to be misidentified as open and the most recently moved
+	 * data to be treated as obsolete.
+	 *
+	 * To prevent this potential data loss, explicitly reconstruct and
+	 * rewrite a valid close ATE based on the last valid data ATE found in
+	 * the sector.
+	 */
+	if (((fs->ate_wra & ADDR_OFFS_MASK) == (fs->sector_size - 2 * ate_size)) &&
+	    (close_addr != 0U) && !nvs_close_ate_valid(fs, &close_ate)) {
+		addr = close_addr;
+		rc = nvs_recover_last_ate(fs, &addr);
+		if (rc) {
+			goto end;
+		}
+
+		close_ate.id = 0xFFFF;
+		close_ate.len = 0U;
+		close_ate.offset = (uint16_t)(addr & ADDR_OFFS_MASK);
+		close_ate.part = 0xff;
+
+		nvs_ate_crc8_update(&close_ate);
+
+		rc = nvs_flash_al_wrt(fs, close_addr, &close_ate,
+				      sizeof(struct nvs_ate));
+		if (rc) {
+			goto end;
+		}
+	}
+#endif
 
 	/* if the sector after the write sector is not empty gc was interrupted
 	 * we might need to restart gc if it has not yet finished. Otherwise

--- a/tests/subsys/kvss/nvs/src/main.c
+++ b/tests/subsys/kvss/nvs/src/main.c
@@ -877,6 +877,84 @@ ZTEST_F(nvs, test_nvs_startup_full_sector_after_ate_power_loss)
 	zassert_equal((fixture->fs.ate_wra & ADDR_SECT_MASK) >> ADDR_SECT_SHIFT,
 		      1, "nvs_gc() not trigger");
 }
+#if CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES
+/*
+ * Test recovery when a close ATE was interrupted by power loss and later
+ * misread as erased. Although the close ATE appears erased, the sector
+ * layout indicates that a close ATE is expected. A valid data ATE is still
+ * present earlier in the sector and must be recovered to prevent data loss.
+ */
+ZTEST_F(nvs, test_nvs_startup_missing_close_ate)
+{
+	struct nvs_ate ate, close_ate;
+	uint32_t data;
+	int err;
+#ifdef CONFIG_NVS_DATA_CRC
+	uint32_t data_crc;
+#endif
+
+	/* Simulate erased close ATE (all erase_value) */
+	memset(&close_ate, fixture->fs.flash_parameters->erase_value,
+	       sizeof(close_ate));
+
+	/* Valid data ATE located before the close ATE */
+	ate.id = 0x1;
+	ate.offset = 0;
+	ate.len = sizeof(data);
+#ifdef CONFIG_NVS_DATA_CRC
+	ate.len += sizeof(data_crc);
+#endif
+	ate.part = 0xff;
+	ate.crc8 = crc8_ccitt(0xff, &ate,
+			      offsetof(struct nvs_ate, crc8));
+
+	/* Write valid data ATE at -2 */
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset + fixture->fs.sector_size -
+			  sizeof(struct nvs_ate) * 2,
+			  &ate, sizeof(ate));
+	zassert_true(err == 0, "flash_write failed: %d", err);
+
+	/* Write data referenced by the valid ATE */
+	data = 0xdeadbeefU;
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset, &data, sizeof(data));
+	zassert_true(err == 0, "flash_write failed: %d", err);
+#ifdef CONFIG_NVS_DATA_CRC
+	data_crc = crc32_ieee((const uint8_t *)&data, sizeof(data));
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset + sizeof(data),
+			  &data_crc, sizeof(data_crc));
+	zassert_true(err == 0, "flash_write for data CRC failed: %d", err);
+#endif
+
+	/* Write a nearly-erased (almost erase_value) invalid close ATE at the end of sector 0 */
+	close_ate.crc8 = ~close_ate.crc8;
+	err = flash_write(fixture->fs.flash_device,
+			  fixture->fs.offset + fixture->fs.sector_size -
+			  sizeof(struct nvs_ate),
+			  &close_ate, sizeof(close_ate));
+	zassert_true(err == 0, "flash_write failed: %d", err);
+
+	fixture->fs.sector_count = 3;
+
+	err = nvs_mount(&fixture->fs);
+	zassert_true(err == 0, "nvs_mount call failure: %d", err);
+
+	zassert_equal((fixture->fs.ate_wra & ADDR_SECT_MASK) >> ADDR_SECT_SHIFT, 1,
+		      "unexpected ate_wra value: %x", fixture->fs.ate_wra);
+
+	err = flash_read(fixture->fs.flash_device,
+			 fixture->fs.offset + fixture->fs.sector_size -
+			 sizeof(struct nvs_ate),
+			 &close_ate, sizeof(close_ate));
+	zassert_true(err == 0, "flash_read failed: %d", err);
+
+	zassert_equal(close_ate.offset,
+		      fixture->fs.sector_size - 2 * sizeof(struct nvs_ate),
+		      "unexpected close ATE offset: %x", close_ate.offset);
+}
+#endif /* CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES */
 #endif /* CONFIG_TEST_NVS_SIMULATOR */
 
 #ifdef CONFIG_NVS_LOOKUP_CACHE

--- a/tests/subsys/kvss/nvs/testcase.yaml
+++ b/tests/subsys/kvss/nvs/testcase.yaml
@@ -31,3 +31,7 @@ tests:
   keyvalstorage.nvs.64kb_erase_block:
     extra_args: DTC_OVERLAY_FILE=boards/native_sim_64kb_erase_block.overlay
     platform_allow: native_sim
+  filesystem.nvs.close_ate_recovery:
+    extra_args:
+      - CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
+    platform_allow: native_sim


### PR DESCRIPTION
Fix a potential data loss issue when power is lost while programming the close ATE. An invalid close ATE may later be read as erased due to flash instability, causing a previously closed sector to be misidentified as open and moved data to be discarded. Reconstruct and rewrite the close ATE during startup when required to ensure stable sector state recovery.