### PR TITLE
drivers: video: shell: fix incorrect endptr usage in strtoll

### DIFF
--- a/drivers/video/video_shell.c
+++ b/drivers/video/video_shell.c
@@ -723,7 +723,7 @@ static int video_shell_set_ctrl(const struct shell *sh, const struct device *dev
 		}
 		break;
 	case VIDEO_CTRL_TYPE_INTEGER64:
-		ctrl.val64 = strtoll(arg_value, &arg_value, 10);
+		ctrl.val64 = strtoll(arg_value, &end_value, 10);
 		if (*end_value != '\0') {
 			shell_error(sh, "Invalid integer '%s' for this type", arg_value);
 			return -EINVAL;


### PR DESCRIPTION
The current implementation of video_shell_set_ctrl() incorrectly passes &arg_value as the endptr to strtoll(), while attempting to validate the result using an uninitialized end_value pointer. This causes the check (*end_value != '\0') to always trigger shell_error.

Update the code to pass the address of end_value to strtoll() correctly, ensuring it points to the first invalid character within the input string for proper validation.