### PR TITLE
boards: renesas: Correct MRAM and SRAM info for Renesas ek_ra8p1

### DIFF
--- a/boards/renesas/ek_ra8p1/doc/index.rst
+++ b/boards/renesas/ek_ra8p1/doc/index.rst
@@ -105,16 +105,16 @@ starting the CM33 core.
 Memory Usage
 ============
 
-By default, Flash (MRAM) and SRAM are split evenly between the two cores.
-Users can manually change the address and size for Flash and SRAM as follows node:
+By default, MRAM (Flash) and SRAM are split evenly between the two cores.
+Users can manually change the address and size for MRAM (Flash) and SRAM as follows node:
 
-   - CPU0: &flash0, &sram0
-   - CPU1: &flash1, &sram1
+   - CPU0: &code_mram_cm85, &sram0
+   - CPU1: &code_mram_cm33, &sram1
 
 .. note::
 
-   - Flash usable range: 0x0200_0000 ... 0x0290_0000
-   - SRAM usable range: 0x2200_0000 ... 0x221D_4000
+   - MRAM usable range: 0x0200_0000 ... 0x0210_0000 (1 MB)
+   - SRAM usable range: 0x2200_0000 ... 0x221A_0000 (1664 KB)
 
 Dual Core Flashing
 ==================

--- a/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
@@ -27,14 +27,14 @@
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
-			reg = <0x22000000 DT_SIZE_K(1404)>;
+			reg = <0x22000000 DT_SIZE_M(1)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
 
-		sram1: memory@2215f000 {
+		sram1: memory@22100000 {
 			compatible = "mmio-sram";
-			reg = <0x2215f000 DT_SIZE_K(468)>;
+			reg = <0x22100000 DT_SIZE_K(640)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -1,10 +1,7 @@
 /*
- * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright (c) 2025-2026 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/delete-node/ &sram0;
-/delete-node/ &sram1;
 
 / {
 	ipc {
@@ -20,30 +17,25 @@
 	};
 
 	soc {
-		/* Redefine sram regions for CPU0 */
-		sram0: memory@22000000 {
-			reg = <0x22000000 0xe9800>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: memory@220e9800 {
-			reg = <0x220e9800 0xe9800>;
-		};
-
 		/* Define shared memory regions for IPC */
 		reserved-memory {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_rx: memory@221d3000 {
-				reg = <0x221d3000 0x800>;
+			sram_rx: memory@2219f000 {
+				reg = <0x2219f000 0x800>;
 			};
 
-			sram_tx: memory@221d3800 {
-				reg = <0x221d3800 0x800>;
+			sram_tx: memory@2219f800 {
+				reg = <0x2219f800 0x800>;
 			};
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(636)>;
 };
 
 &mbox0 {

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -1,10 +1,7 @@
 /*
- * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright (c) 2025-2026 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-
-/delete-node/ &sram0;
-/delete-node/ &sram1;
 
 / {
 	ipc {
@@ -20,30 +17,25 @@
 	};
 
 	soc {
-		/* Redefine sram regions for CPU0 */
-		sram0: memory@22000000 {
-			reg = <0x22000000 0xe9800>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: memory@220e9800 {
-			reg = <0x220e9800 0xe9800>;
-		};
-
 		/* Define shared memory regions for IPC */
 		reserved-memory {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_tx: memory@221d3000 {
-				reg = <0x221d3000 0x800>;
+			sram_tx: memory@2219f000 {
+				reg = <0x2219f000 0x800>;
 			};
 
-			sram_rx: memory@221d3800 {
-				reg = <0x221d3800 0x800>;
+			sram_rx: memory@2219f800 {
+				reg = <0x2219f800 0x800>;
 			};
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(636)>;
 };
 
 &mbox0 {

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -1,12 +1,9 @@
 /*
- * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright (c) 2025-2026 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
-/delete-node/ &sram0;
-/delete-node/ &sram1;
 
 / {
 	ipc {
@@ -32,30 +29,25 @@
 	};
 
 	soc {
-		/* Redefine sram regions for CPU0 */
-		sram0: memory@22000000 {
-			reg = <0x22000000 0xe2000>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: memory@220e2000 {
-			reg = <0x220e2000 0xe2000>;
-		};
-
 		/* Define shared memory regions for IPC */
 		reserved-memory {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_ipc0: memory@221c4000 {
-				reg = <0x221c4000 0x8000>;
+			sram_ipc0: memory@22190000 {
+				reg = <0x22190000 0x8000>;
 			};
 
-			sram_ipc1: memory@221cc000 {
-				reg = <0x221cc000 0x8000>;
+			sram_ipc1: memory@22198000 {
+				reg = <0x22198000 0x8000>;
 			};
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(576)>;
 };
 
 &mbox0 {

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -1,12 +1,9 @@
 /*
- * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright (c) 2025-2026 Renesas Electronics Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
-/delete-node/ &sram0;
-/delete-node/ &sram1;
 
 / {
 	ipc {
@@ -32,30 +29,25 @@
 	};
 
 	soc {
-		/* Redefine sram regions for CPU0 */
-		sram0: memory@22000000 {
-			reg = <0x22000000 0xe2000>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: memory@220e2000 {
-			reg = <0x220e2000 0xe2000>;
-		};
-
 		/* Define shared memory regions for IPC */
 		reserved-memory {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			sram_ipc0: memory@221c4000 {
-				reg = <0x221c4000 0x8000>;
+			sram_ipc0: memory@22190000 {
+				reg = <0x22190000 0x8000>;
 			};
 
-			sram_ipc1: memory@221cc000 {
-				reg = <0x221cc000 0x8000>;
+			sram_ipc1: memory@22198000 {
+				reg = <0x22198000 0x8000>;
 			};
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(576)>;
 };
 
 &mbox0 {

--- a/samples/subsys/ipc/openamp/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/samples/subsys/ipc/openamp/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &sram0;
-/delete-node/ &sram1;
-
 / {
 	chosen {
 		/*
@@ -24,21 +21,16 @@
 			status = "okay";
 		};
 
-		/* Redefine sram regions for CPU0 */
-		sram0: sram@22000000 {
-			reg = <0x22000000 0xe6000>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: sram@220e6000 {
-			reg = <0x220e6000 0xe6000>;
-		};
-
 		/* Define shared memory regions for IPC */
-		sram_shm: sram@221cc000 {
-			reg = <0x221cc000 0x8000>;
+		sram_shm: sram@22198000 {
+			reg = <0x22198000 0x8000>;
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(608)>;
 };
 
 &mbox0 {

--- a/samples/subsys/ipc/openamp/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &sram0;
-/delete-node/ &sram1;
-
 / {
 	chosen {
 		/*
@@ -24,21 +21,16 @@
 			status = "okay";
 		};
 
-		/* Redefine sram regions for CPU0 */
-		sram0: sram@22000000 {
-			reg = <0x22000000 0xe6000>;
-		};
-
-		/* Redefine sram regions for CPU1 */
-		sram1: sram@220e6000 {
-			reg = <0x220e6000 0xe6000>;
-		};
-
 		/* Define shared memory regions for IPC */
-		sram_shm: sram@221cc000 {
-			reg = <0x221cc000 0x8000>;
+		sram_shm: sram@22198000 {
+			reg = <0x22198000 0x8000>;
 		};
 	};
+};
+
+/* Redefine sram size for CPU1 */
+&sram1 {
+	reg = <0x22100000 DT_SIZE_K(608)>;
 };
 
 &mbox0 {


### PR DESCRIPTION
- Correct the SRAM size for `ek_ra8p1` CM85 and CM33 since the previous values of `sram0` and `sram1` exceeded the maximum SRAM size
- Correct MRAM and SRAM info for Renesas `ek_ra8p1` board document
- Update SRAM size for `ek_ra8p1` overlay in `samples/subsys/ipc`