### PR TITLE
fs: zms: Add manual lookup cache configuration

### DIFF
--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -402,6 +402,8 @@ Version 1
 - Supports multiple ATE formats to satisfy the requirements of different applications
 - Supports forced mount recovery via :c:func:`zms_mount_force` (automatic partition wipe
   and reinitialization on mount failure)
+- Supports a lookup cache to speed up repeated ID lookups with optional per-instance cache
+  configuration to customize the cache size on a per-partition basis
 
 Future features
 ===============
@@ -483,6 +485,27 @@ Cache size
 - If you use ZMS through :ref:`Settings <settings_api>`, you have to take into account that each Settings entry is
   divided into two ZMS entries. The recommendation for the cache size is to make it at least
   twice the number of Settings entries.
+
+Manual per-instance cache
+=========================
+
+When :kconfig:option:`CONFIG_ZMS_LOOKUP_CACHE_MANUAL` is enabled, each :c:struct:`zms_fs`
+instance can provide its own lookup cache buffer instead of using the global
+:kconfig:option:`CONFIG_ZMS_LOOKUP_CACHE_SIZE` setting.
+
+Call :c:func:`zms_set_lookup_cache` before :c:func:`zms_mount` to assign the cache buffer for
+that instance. If no buffer is assigned, the lookup cache remains disabled for that
+:c:struct:`zms_fs` instance.
+
+.. code-block:: c
+
+	static struct zms_fs zms_a;
+	static struct zms_fs zms_b;
+	static uint64_t zms_a_cache[512];
+	static uint64_t zms_b_cache[32];
+
+	zms_set_lookup_cache(&zms_a, zms_a_cache, ARRAY_SIZE(zms_a_cache));
+	zms_set_lookup_cache(&zms_b, zms_b_cache, ARRAY_SIZE(zms_b_cache));
 
 ID size
 =======

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -62,8 +62,15 @@ struct zms_fs {
 	/** Size of an Allocation Table Entry */
 	size_t ate_size;
 #if CONFIG_ZMS_LOOKUP_CACHE
+#if CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+	/** Lookup table used to cache ATE addresses of written IDs */
+	uint64_t *lookup_cache;
+	/** Size of the lookup cache */
+	size_t lookup_cache_size;
+#else
 	/** Lookup table used to cache ATE addresses of written IDs */
 	uint64_t lookup_cache[CONFIG_ZMS_LOOKUP_CACHE_SIZE];
+#endif
 #endif
 };
 
@@ -271,6 +278,24 @@ ssize_t zms_active_sector_free_space(struct zms_fs *fs);
  * @retval -EINVAL if `fs` is NULL.
  */
 int zms_sector_use_next(struct zms_fs *fs);
+
+#if CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+/**
+ * @brief Assign a buffer for the lookup cache for a ZMS instance.
+ *
+ * This must be called before zms_mount(). If not called, the cache
+ * will be disabled for this file system instance.
+ *
+ * @param fs Pointer to the file system.
+ * @param buffer Pointer to the buffer to be used for the cache.
+ * @param size The number of entries in the buffer.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if `fs` or `buffer` are NULL, or `size` is 0.
+ * @retval -EBUSY if ZMS is already mounted.
+ */
+int zms_set_lookup_cache(struct zms_fs *fs, uint64_t *buffer, size_t size);
+#endif
 
 /**
  * @}

--- a/subsys/kvss/zms/Kconfig
+++ b/subsys/kvss/zms/Kconfig
@@ -35,10 +35,17 @@ config ZMS_LOOKUP_CACHE_SIZE
 	int "ZMS lookup cache size"
 	default 128
 	range 1 65536
-	depends on ZMS_LOOKUP_CACHE
+	depends on ZMS_LOOKUP_CACHE && !ZMS_LOOKUP_CACHE_MANUAL
 	help
 	  Number of entries in the ZMS lookup cache.
 	  Every additional entry in cache will use 8 bytes of RAM.
+
+config ZMS_LOOKUP_CACHE_MANUAL
+	bool "ZMS manual lookup cache"
+	depends on ZMS_LOOKUP_CACHE
+	help
+	  Enable manual ZMS cache configuration. This allows to have multiple
+	  ZMS partitions each with its own cache.
 
 config ZMS_DATA_CRC
 	bool "ZMS data CRC"

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -30,7 +30,25 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 
-static inline size_t zms_lookup_cache_pos(zms_id_t id)
+static inline size_t zms_lookup_cache_size(struct zms_fs *fs __unused)
+{
+#if CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+	return fs->lookup_cache_size;
+#else
+	return CONFIG_ZMS_LOOKUP_CACHE_SIZE;
+#endif
+}
+
+static inline bool zms_lookup_cache_available(struct zms_fs *fs __unused)
+{
+#if CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+	return fs->lookup_cache != NULL;
+#else
+	return true;
+#endif
+}
+
+static inline size_t zms_lookup_cache_pos(struct zms_fs *fs __unused, zms_id_t id)
 {
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
 	/*
@@ -79,7 +97,38 @@ static inline size_t zms_lookup_cache_pos(zms_id_t id)
 	hash ^= hash >> 16;
 #endif /* CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS */
 
-	return hash % CONFIG_ZMS_LOOKUP_CACHE_SIZE;
+	return hash % zms_lookup_cache_size(fs);
+}
+
+static inline uint64_t zms_lookup_cache_addr(struct zms_fs *fs, zms_id_t id)
+{
+	if (!zms_lookup_cache_available(fs)) {
+		return fs->ate_wra;
+	}
+
+	return fs->lookup_cache[zms_lookup_cache_pos(fs, id)];
+}
+
+static inline void zms_lookup_cache_update(struct zms_fs *fs, zms_id_t id, uint64_t addr)
+{
+	if (zms_lookup_cache_available(fs)) {
+		fs->lookup_cache[zms_lookup_cache_pos(fs, id)] = addr;
+	}
+}
+
+static void zms_lookup_cache_fill(struct zms_fs *fs, uint64_t addr)
+{
+	uint64_t *cache_entry;
+	uint64_t *cache_end;
+
+	if (!zms_lookup_cache_available(fs)) {
+		return;
+	}
+
+	cache_end = &fs->lookup_cache[zms_lookup_cache_size(fs)];
+	for (cache_entry = fs->lookup_cache; cache_entry < cache_end; ++cache_entry) {
+		*cache_entry = addr;
+	}
 }
 
 static int zms_lookup_cache_rebuild(struct zms_fs *fs)
@@ -92,7 +141,10 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 	uint8_t current_cycle;
 	struct zms_ate ate;
 
-	memset(fs->lookup_cache, 0xff, sizeof(fs->lookup_cache));
+	if (!zms_lookup_cache_available(fs)) {
+		return 0;
+	}
+	memset(fs->lookup_cache, 0xff, zms_lookup_cache_size(fs) * sizeof(uint64_t));
 	addr = fs->ate_wra;
 
 	while (true) {
@@ -104,7 +156,7 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 			return rc;
 		}
 
-		cache_entry = &fs->lookup_cache[zms_lookup_cache_pos(ate.id)];
+		cache_entry = &fs->lookup_cache[zms_lookup_cache_pos(fs, ate.id)];
 
 		if (ate.id != ZMS_HEAD_ID && *cache_entry == ZMS_LOOKUP_CACHE_NO_ADDR) {
 			/* read the ate cycle only when we change the sector
@@ -136,8 +188,14 @@ static int zms_lookup_cache_rebuild(struct zms_fs *fs)
 
 static void zms_lookup_cache_invalidate(struct zms_fs *fs, uint32_t sector)
 {
-	uint64_t *cache_entry = fs->lookup_cache;
-	uint64_t *const cache_end = &fs->lookup_cache[CONFIG_ZMS_LOOKUP_CACHE_SIZE];
+	uint64_t *cache_entry;
+	uint64_t *cache_end;
+
+	if (!zms_lookup_cache_available(fs)) {
+		return;
+	}
+	cache_entry = fs->lookup_cache;
+	cache_end = &fs->lookup_cache[zms_lookup_cache_size(fs)];
 
 	for (; cache_entry < cache_end; ++cache_entry) {
 		if (SECTOR_NUM(*cache_entry) == sector) {
@@ -253,7 +311,7 @@ static int zms_flash_ate_wrt(struct zms_fs *fs, const struct zms_ate *entry)
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	/* ZMS_HEAD_ID is a special-purpose identifier. Exclude it from the cache */
 	if (entry->id != ZMS_HEAD_ID) {
-		fs->lookup_cache[zms_lookup_cache_pos(entry->id)] = fs->ate_wra;
+		zms_lookup_cache_update(fs, entry->id, fs->ate_wra);
 	}
 #endif
 	fs->ate_wra -= zms_al_size(fs, sizeof(struct zms_ate));
@@ -1069,7 +1127,7 @@ static int zms_gc(struct zms_fs *fs)
 		}
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-		wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(gc_ate.id)];
+		wlk_addr = zms_lookup_cache_addr(fs, gc_ate.id);
 
 		if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
 			wlk_addr = fs->ate_wra;
@@ -1444,9 +1502,7 @@ static int zms_init(struct zms_fs *fs)
 		 * So, temporarily, we set the lookup cache to the end of the fs.
 		 * The cache will be rebuilt afterwards
 		 **/
-		for (i = 0; i < CONFIG_ZMS_LOOKUP_CACHE_SIZE; i++) {
-			fs->lookup_cache[i] = fs->ate_wra;
-		}
+		zms_lookup_cache_fill(fs, fs->ate_wra);
 #endif
 		rc = zms_gc(fs);
 		goto end;
@@ -1468,6 +1524,23 @@ end:
 
 	return rc;
 }
+
+#if CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+int zms_set_lookup_cache(struct zms_fs *fs, uint64_t *buffer, size_t size)
+{
+	if (!fs || !buffer || !size) {
+		return -EINVAL;
+	}
+	if (fs->ready) {
+		return -EBUSY;
+	}
+
+	fs->lookup_cache = buffer;
+	fs->lookup_cache_size = size;
+
+	return 0;
+}
+#endif
 
 static int zms_mount_internal(struct zms_fs *fs, bool wipe_on_failure)
 {
@@ -1526,7 +1599,6 @@ static int zms_mount_internal(struct zms_fs *fs, bool wipe_on_failure)
 		LOG_ERR("Configuration error - sector count below minimum requirement (2)");
 		return -EINVAL;
 	}
-
 	rc = zms_init(fs);
 
 	if (rc && wipe_on_failure) {
@@ -1594,7 +1666,7 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 
 	/* find latest entry with same id */
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
+	wlk_addr = zms_lookup_cache_addr(fs, id);
 
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
 		if (len > 0) {
@@ -1742,7 +1814,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
 	cnt_his = 0U;
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
+	wlk_addr = zms_lookup_cache_addr(fs, id);
 
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
 		rc = -ENOENT;

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -22,6 +22,11 @@
 #define TEST_ZMS_AREA_DEV    DEVICE_DT_GET(DT_MTD_FROM_PARTITION(DT_NODELABEL(TEST_ZMS_AREA)))
 #define TEST_DATA_ID         1
 #define TEST_SECTOR_COUNT    5U
+#if defined(CONFIG_ZMS_LOOKUP_CACHE_MANUAL)
+#define TEST_ZMS_LOOKUP_CACHE_SIZE 64
+#elif defined(CONFIG_ZMS_LOOKUP_CACHE)
+#define TEST_ZMS_LOOKUP_CACHE_SIZE CONFIG_ZMS_LOOKUP_CACHE_SIZE
+#endif
 
 static const struct device *const flash_dev = TEST_ZMS_AREA_DEV;
 
@@ -693,8 +698,15 @@ static size_t num_matching_cache_entries(uint64_t addr, bool compare_sector_only
 {
 	size_t num = 0;
 	uint64_t mask = compare_sector_only ? ADDR_SECT_MASK : UINT64_MAX;
+	size_t cache_size;
 
-	for (int i = 0; i < CONFIG_ZMS_LOOKUP_CACHE_SIZE; i++) {
+#if defined(CONFIG_ZMS_LOOKUP_CACHE_MANUAL)
+	cache_size = fs->lookup_cache_size;
+#else
+	cache_size = TEST_ZMS_LOOKUP_CACHE_SIZE;
+#endif
+
+	for (size_t i = 0; i < cache_size; i++) {
 		if ((fs->lookup_cache[i] & mask) == addr) {
 			num++;
 		}
@@ -705,26 +717,49 @@ static size_t num_matching_cache_entries(uint64_t addr, bool compare_sector_only
 
 static size_t num_occupied_cache_entries(struct zms_fs *fs)
 {
-	return CONFIG_ZMS_LOOKUP_CACHE_SIZE -
+#if defined(CONFIG_ZMS_LOOKUP_CACHE_MANUAL)
+	return fs->lookup_cache_size -
 	       num_matching_cache_entries(ZMS_LOOKUP_CACHE_NO_ADDR, false, fs);
+#else
+	return TEST_ZMS_LOOKUP_CACHE_SIZE -
+	       num_matching_cache_entries(ZMS_LOOKUP_CACHE_NO_ADDR, false, fs);
+#endif
+}
+#endif
+
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+static int setup_lookup_cache(struct zms_fs *fs)
+{
+#if defined(CONFIG_ZMS_LOOKUP_CACHE_MANUAL)
+	static uint64_t cache_buffer[TEST_ZMS_LOOKUP_CACHE_SIZE];
+
+	return zms_set_lookup_cache(fs, cache_buffer, ARRAY_SIZE(cache_buffer));
+#else
+	return 0;
+#endif
 }
 #endif
 
 /*
- * Test that ZMS lookup cache is properly rebuilt on zms_mount(), or initialized
- * to ZMS_LOOKUP_CACHE_NO_ADDR if the store is empty.
+ * Test that manual lookup cache is properly initialized when a buffer is provided,
+ * updated after writes, and rebuilt on zms_mount() when the store is non-empty.
  */
-ZTEST_F(zms, test_zms_cache_init)
+ZTEST_F(zms, test_zms_manual_cache)
 {
-#ifdef CONFIG_ZMS_LOOKUP_CACHE
+#ifdef CONFIG_ZMS_LOOKUP_CACHE_MANUAL
 	int err;
 	size_t num;
 	uint64_t ate_addr;
 	uint8_t data = 0;
+	static uint64_t cache_buffer[TEST_ZMS_LOOKUP_CACHE_SIZE];
 
 	/* Test cache initialization when the store is empty */
 
 	fixture->fs.sector_count = 3;
+
+	err = zms_set_lookup_cache(&fixture->fs, cache_buffer, ARRAY_SIZE(cache_buffer));
+	zassert_true(err == 0, "zms_set_lookup_cache call failure: %d", err);
+
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
@@ -745,7 +780,91 @@ ZTEST_F(zms, test_zms_cache_init)
 
 	/* Test cache initialization when the store is non-empty */
 
-	memset(fixture->fs.lookup_cache, 0xAA, sizeof(fixture->fs.lookup_cache));
+	memset(fixture->fs.lookup_cache, 0xAA,
+	       TEST_ZMS_LOOKUP_CACHE_SIZE * sizeof(uint64_t));
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	num = num_occupied_cache_entries(&fixture->fs);
+	zassert_equal(num, 1, "uninitialized cache after restart");
+
+	num = num_matching_cache_entries(ate_addr, false, &fixture->fs);
+	zassert_equal(num, 1, "invalid cache entry after restart");
+
+	err = zms_set_lookup_cache(&fixture->fs, cache_buffer, ARRAY_SIZE(cache_buffer));
+	zassert_equal(err, -EBUSY, "zms_set_lookup_cache should fail after mount: %d", err);
+#else
+	ztest_test_skip();
+#endif
+}
+
+/*
+ * Test that manual lookup cache is disabled when zms_set_lookup_cache() is not called.
+ * The cache pointer should remain NULL and operations should still work correctly.
+ */
+ZTEST_F(zms, test_zms_manual_cache_disabled)
+{
+#ifdef CONFIG_ZMS_LOOKUP_CACHE_MANUAL
+	int err;
+	uint8_t data = 0;
+
+	fixture->fs.sector_count = 3;
+	fixture->fs.lookup_cache = NULL;
+	fixture->fs.lookup_cache_size = 0;
+
+	/* Do not call zms_set_lookup_cache() - cache should be disabled */
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	err = zms_write(&fixture->fs, 1, &data, sizeof(data));
+	zassert_equal(err, sizeof(data), "zms_write call failure: %d", err);
+
+	zassert_true(fixture->fs.lookup_cache == NULL, "cache should be disabled");
+#else
+	ztest_test_skip();
+#endif
+}
+
+/*
+ * Test that ZMS lookup cache is properly rebuilt on zms_mount(), or initialized
+ * to ZMS_LOOKUP_CACHE_NO_ADDR if the store is empty.
+ */
+ZTEST_F(zms, test_zms_cache_init)
+{
+#ifdef CONFIG_ZMS_LOOKUP_CACHE
+	int err;
+	size_t num;
+	uint64_t ate_addr;
+	uint8_t data = 0;
+
+	/* Test cache initialization when the store is empty */
+
+	fixture->fs.sector_count = 3;
+	err = setup_lookup_cache(&fixture->fs);
+	zassert_true(err == 0, "setup_lookup_cache call failure: %d", err);
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	num = num_occupied_cache_entries(&fixture->fs);
+	zassert_equal(num, 0, "uninitialized cache");
+
+	/* Test cache update after zms_write() */
+
+	ate_addr = fixture->fs.ate_wra;
+	err = zms_write(&fixture->fs, 1, &data, sizeof(data));
+	zassert_equal(err, sizeof(data), "zms_write call failure: %d", err);
+
+	num = num_occupied_cache_entries(&fixture->fs);
+	zassert_equal(num, 1, "cache not updated after write");
+
+	num = num_matching_cache_entries(ate_addr, false, &fixture->fs);
+	zassert_equal(num, 1, "invalid cache entry after write");
+
+	/* Test cache initialization when the store is non-empty */
+
+	memset(fixture->fs.lookup_cache, 0xAA,
+	       TEST_ZMS_LOOKUP_CACHE_SIZE * sizeof(uint64_t));
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
@@ -770,27 +889,29 @@ ZTEST_F(zms, test_zms_cache_collision)
 	uint16_t data;
 
 	fixture->fs.sector_count = 4;
+	err = setup_lookup_cache(&fixture->fs);
+	zassert_true(err == 0, "setup_lookup_cache call failure: %d", err);
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
-	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+	for (int id = 0; id < TEST_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
 		data = id;
 		err = zms_write(&fixture->fs, id, &data, sizeof(data));
 		zassert_equal(err, sizeof(data), "zms_write call failure: %d", err);
 	}
 
-	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+	for (int id = 0; id < TEST_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
 		err = zms_read(&fixture->fs, id, &data, sizeof(data));
 		zassert_equal(err, sizeof(data), "zms_read call failure: %d", err);
 		zassert_equal(data, id, "incorrect data read");
 	}
 
-	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+	for (int id = 0; id < TEST_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
 		err = zms_delete(&fixture->fs, id);
 		zassert_equal(0, err, "zms_delete failed: %d", err);
 	}
 
-	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+	for (int id = 0; id < TEST_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
 		err = zms_read(&fixture->fs, id, &data, sizeof(data));
 		zassert_equal(-ENOENT, err, "zms_delete failed: %d", err);
 	}
@@ -810,6 +931,8 @@ ZTEST_F(zms, test_zms_cache_gc)
 	uint16_t data = 0;
 
 	fixture->fs.sector_count = 3;
+	err = setup_lookup_cache(&fixture->fs);
+	zassert_true(err == 0, "setup_lookup_cache call failure: %d", err);
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
@@ -856,18 +979,20 @@ ZTEST_F(zms, test_zms_cache_gc)
 ZTEST_F(zms, test_zms_cache_hash_quality)
 {
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	const size_t MIN_CACHE_OCCUPANCY = CONFIG_ZMS_LOOKUP_CACHE_SIZE * 6 / 10;
+	const size_t MIN_CACHE_OCCUPANCY = TEST_ZMS_LOOKUP_CACHE_SIZE * 6 / 10;
 	int err;
 	size_t num;
 	uint32_t id;
 	uint16_t data;
 
+	err = setup_lookup_cache(&fixture->fs);
+	zassert_true(err == 0, "setup_lookup_cache call failure: %d", err);
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
-	/* Write ZMS IDs from 0 to CONFIG_ZMS_LOOKUP_CACHE_SIZE - 1 */
+	/* Write ZMS IDs from 0 to TEST_ZMS_LOOKUP_CACHE_SIZE - 1 */
 
-	for (int i = 0; i < CONFIG_ZMS_LOOKUP_CACHE_SIZE; i++) {
+	for (int i = 0; i < TEST_ZMS_LOOKUP_CACHE_SIZE; i++) {
 		id = i;
 		data = 0;
 
@@ -879,7 +1004,7 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 
 	num = num_occupied_cache_entries(&fixture->fs);
 	TC_PRINT("Cache occupancy: %u\n", (unsigned int)num);
-	zassert_between_inclusive(num, MIN_CACHE_OCCUPANCY, CONFIG_ZMS_LOOKUP_CACHE_SIZE,
+	zassert_between_inclusive(num, MIN_CACHE_OCCUPANCY, TEST_ZMS_LOOKUP_CACHE_SIZE,
 				  "too low cache occupancy - poor hash quality");
 
 	err = zms_clear(&fixture->fs);
@@ -888,9 +1013,9 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 	err = zms_mount(&fixture->fs);
 	zassert_true(err == 0, "zms_mount call failure: %d", err);
 
-	/* Write CONFIG_ZMS_LOOKUP_CACHE_SIZE ZMS IDs that form the following series: 0, 4, 8... */
+	/* Write TEST_ZMS_LOOKUP_CACHE_SIZE ZMS IDs that form the following series: 0, 4, 8... */
 
-	for (int i = 0; i < CONFIG_ZMS_LOOKUP_CACHE_SIZE; i++) {
+	for (int i = 0; i < TEST_ZMS_LOOKUP_CACHE_SIZE; i++) {
 		id = i * 4;
 		data = 0;
 
@@ -902,7 +1027,7 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 
 	num = num_occupied_cache_entries(&fixture->fs);
 	TC_PRINT("Cache occupancy: %u\n", (unsigned int)num);
-	zassert_between_inclusive(num, MIN_CACHE_OCCUPANCY, CONFIG_ZMS_LOOKUP_CACHE_SIZE,
+	zassert_between_inclusive(num, MIN_CACHE_OCCUPANCY, TEST_ZMS_LOOKUP_CACHE_SIZE,
 				  "too low cache occupancy - poor hash quality");
 #else
 	ztest_test_skip();

--- a/tests/subsys/kvss/zms/testcase.yaml
+++ b/tests/subsys/kvss/zms/testcase.yaml
@@ -21,6 +21,11 @@ tests:
       - CONFIG_ZMS_LOOKUP_CACHE=y
       - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
+  keyvalstorage.zms.cache.manual:
+    extra_configs:
+      - CONFIG_ZMS_LOOKUP_CACHE=y
+      - CONFIG_ZMS_LOOKUP_CACHE_MANUAL=y
+    platform_allow: native_sim
   keyvalstorage.zms.data_crc:
     extra_configs:
       - CONFIG_ZMS_DATA_CRC=y


### PR DESCRIPTION
### **Summary**

This pull request introduces manual configuration for the ZMS lookup cache to allow for more efficient memory usage across multiple file system partitions.

### **Problem**

Currently, all ZMS file system instances share a single, statically configured cache size. This is inefficient when multiple partitions with different needs are present, as smaller partitions are forced to allocate an unnecessarily large cache, leading to wasted RAM.

### **Solution**

A new Kconfig option, `CONFIG_ZMS_LOOKUP_CACHE_MANUAL`, is introduced to enable per-instance cache configuration. When this option is active, a new function `zms_set_lookup_cache()` can be used to provide a custom-sized cache buffer for each ZMS instance. This allows developers to optimize memory usage by right-sizing the cache for each partition. To maintain backward compatibility, the existing behavior of a single, statically allocated cache is preserved when the new Kconfig option is not enabled.

### **Key Changes**

*   **Kconfig:** Added `CONFIG_ZMS_LOOKUP_CACHE_MANUAL` to toggle the manual cache feature.
*   **API:** Introduced `zms_set_lookup_cache()` to assign a cache buffer to a file system instance.
*   **Core Logic:** Updated `zms.c` to handle both manual and static cache allocation strategies.
*   **Testing:** Added dedicated tests for the new manual cache functionality.