### PR TITLE
soc: xlnx: zynq7000: Fix SoC Kconfig naming for HWMv2 compliance

### DIFF
--- a/boards/digilent/zybo/Kconfig.zybo
+++ b/boards/digilent/zybo/Kconfig.zybo
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ZYBO
-	select SOC_XILINX_XC7Z010
+	select SOC_XC7Z010

--- a/boards/qemu/cortex_a9/Kconfig.qemu_cortex_a9
+++ b/boards/qemu/cortex_a9/Kconfig.qemu_cortex_a9
@@ -6,4 +6,4 @@
 #
 
 config BOARD_QEMU_CORTEX_A9
-	select SOC_XILINX_XC7Z007S
+	select SOC_XC7Z007S

--- a/soc/xlnx/zynq7000/xc7zxxx/Kconfig.soc
+++ b/soc/xlnx/zynq7000/xc7zxxx/Kconfig.soc
@@ -13,14 +13,14 @@ config SOC_SERIES_XC7ZXXX
 	  Enable support for the Xilinx Zynq-7000 (XC7Zxxx)
 	  SoC series (dual core ARM Cortex-A9).
 
-config SOC_XILINX_XC7Z010
+config SOC_XC7Z010
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 866 MHz, Artix-7 programmable logic,
 	  28k logic cells, 2.1Mb block RAM, 800 DSP slices, up to 100 I/O pins.
 
-config SOC_XILINX_XC7Z015
+config SOC_XC7Z015
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
@@ -28,14 +28,14 @@ config SOC_XILINX_XC7Z015
 	  74k logic cells, 3.3Mb block RAM, 160 DSP slices, up to 150 I/O pins,
 	  up to 4 transceivers.
 
-config SOC_XILINX_XC7Z020
+config SOC_XC7Z020
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 866 MHz, Artix-7 programmable logic,
 	  85k logic cells, 4.9Mb block RAM, 220 DSP slices, up to 200 I/O pins.
 
-config SOC_XILINX_XC7Z030
+config SOC_XC7Z030
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
@@ -43,7 +43,7 @@ config SOC_XILINX_XC7Z030
 	  125k logic cells, 9.3Mb block RAM, 400 DSP slices, up to 250 I/O pins,
 	  up to 4 transceivers.
 
-config SOC_XILINX_XC7Z035
+config SOC_XC7Z035
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
@@ -51,7 +51,7 @@ config SOC_XILINX_XC7Z035
 	  275k logic cells, 17.6Mb block RAM, 900 DSP slices, up to 362 I/O pins,
 	  up to 16 transceivers.
 
-config SOC_XILINX_XC7Z045
+config SOC_XC7Z045
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
@@ -59,7 +59,7 @@ config SOC_XILINX_XC7Z045
 	  350k logic cells, 19.1Mb block RAM, 900 DSP slices, up to 362 I/O pins,
 	  up to 16 transceivers.
 
-config SOC_XILINX_XC7Z100
+config SOC_XC7Z100
 	bool
 	select SOC_SERIES_XC7ZXXX
 	help
@@ -71,10 +71,10 @@ config SOC_SERIES
 	default "xc7zxxx" if SOC_SERIES_XC7ZXXX
 
 config SOC
-	default "xc7z010" if SOC_XILINX_XC7Z010
-	default "xc7z015" if SOC_XILINX_XC7Z015
-	default "xc7z020" if SOC_XILINX_XC7Z020
-	default "xc7z030" if SOC_XILINX_XC7Z030
-	default "xc7z035" if SOC_XILINX_XC7Z035
-	default "xc7z045" if SOC_XILINX_XC7Z045
-	default "xc7z100" if SOC_XILINX_XC7Z100
+	default "xc7z010" if SOC_XC7Z010
+	default "xc7z015" if SOC_XC7Z015
+	default "xc7z020" if SOC_XC7Z020
+	default "xc7z030" if SOC_XC7Z030
+	default "xc7z035" if SOC_XC7Z035
+	default "xc7z045" if SOC_XC7Z045
+	default "xc7z100" if SOC_XC7Z100

--- a/soc/xlnx/zynq7000/xc7zxxxs/Kconfig.soc
+++ b/soc/xlnx/zynq7000/xc7zxxxs/Kconfig.soc
@@ -13,14 +13,14 @@ config SOC_SERIES_XC7ZXXXS
 	  Enable support for the Xilinx Zynq-7000S (XC7ZxxxS)
 	  SoC series (single core ARM Cortex-A9).
 
-config SOC_XILINX_XC7Z007S
+config SOC_XC7Z007S
 	bool
 	select SOC_SERIES_XC7ZXXXS
 	help
 	  1 ARM Cortex-A9 core up to 766 MHz, Artix-7 programmable logic,
 	  23k logic cells, 1.8 Mb block RAM, 60 DSP slices, up to 100 I/O pins.
 
-config SOC_XILINX_XC7Z012S
+config SOC_XC7Z012S
 	bool
 	select SOC_SERIES_XC7ZXXXS
 	help
@@ -28,7 +28,7 @@ config SOC_XILINX_XC7Z012S
 	  55k logic cells, 2.5Mb block RAM, 120 DSP slices, up to 150 I/O pins,
 	  up to 4 transceivers.
 
-config SOC_XILINX_XC7Z014S
+config SOC_XC7Z014S
 	bool
 	select SOC_SERIES_XC7ZXXXS
 	help
@@ -39,6 +39,6 @@ config SOC_SERIES
 	default "xc7zxxxs" if SOC_SERIES_XC7ZXXXS
 
 config SOC
-	default "xc7z007s" if SOC_XILINX_XC7Z007S
-	default "xc7z012s" if SOC_XILINX_XC7Z012S
-	default "xc7z014s" if SOC_XILINX_XC7Z014S
+	default "xc7z007s" if SOC_XC7Z007S
+	default "xc7z012s" if SOC_XC7Z012S
+	default "xc7z014s" if SOC_XC7Z014S


### PR DESCRIPTION
Rename SOC_XILINX_XC7Z* Kconfig symbols to SOC_XC7Z* to align with HWMv2 guidelines. The SOC Kconfig symbol name must match the uppercase version of the SOC name defined in soc.yml.

Before: config SOC_XILINX_XC7Z010 with default "xc7z010"
After:  config SOC_XC7Z010 with default "xc7z010"

This allows CI checks to detect typos and enables future auto-generation of SOC_* symbols from soc.yml files.

Updated files:
- soc/xlnx/zynq7000/xc7zxxx/Kconfig.soc
- soc/xlnx/zynq7000/xc7zxxxs/Kconfig.soc
- boards/digilent/zybo/Kconfig.zybo
- boards/qemu/cortex_a9/Kconfig.qemu_cortex_a9

Fixes: #69317