### PR TITLE
drivers: counter: ACE: fix warning and enable 64b by default

### DIFF
--- a/drivers/counter/Kconfig.ace
+++ b/drivers/counter/Kconfig.ace
@@ -6,6 +6,7 @@ config ACE_V1X_ART_COUNTER
 	bool "DSP ART Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_ART_COUNTER_ENABLED
 	select COUNTER_SUPPORTS_64BITS_TICKS
+	select COUNTER_64BITS_TICKS
 	default y
 	help
 	  DSP ART Wall Clock used by ACE V1X.
@@ -14,6 +15,7 @@ config ACE_V1X_RTC_COUNTER
 	bool "DSP RTC Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_RTC_COUNTER_ENABLED
 	select COUNTER_SUPPORTS_64BITS_TICKS
+	select COUNTER_64BITS_TICKS
 	default y
 	help
 	  DSP RTC Wall Clock used by ACE V1X.

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -21,6 +21,7 @@ static int counter_ace_v1x_rtc_get_value_32(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 static int counter_ace_v1x_rtc_get_value(const struct device *dev,
 		uint64_t *value)
 {
@@ -37,6 +38,7 @@ static int counter_ace_v1x_rtc_get_value(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 int counter_ace_v1x_rtc_init(const struct device *dev)
 {


### PR DESCRIPTION
Fixes build warning from PR #94189 and restores default state for ACE counters.