### PR TITLE
drivers: gnss: Add optional reset support to u-blox M8

### DIFF
--- a/drivers/gnss/Kconfig.u_blox_m8
+++ b/drivers/gnss/Kconfig.u_blox_m8
@@ -28,4 +28,7 @@ config GNSS_U_BLOX_M8_SATELLITES_COUNT
 	  device is actually tracking, just how many of those can be reported
 	  in the satellites callback.
 
+config GNSS_U_BLOX_M8_RESET_ON_INIT
+	bool "Reset GNSS on init using reset pin"
+
 endif

--- a/dts/bindings/gnss/u-blox,m8.yaml
+++ b/dts/bindings/gnss/u-blox,m8.yaml
@@ -26,3 +26,7 @@ properties:
       Initial fix-rate GNSS modem will be operating on. May be adjusted at
       run-time through GNSS APIs. Must be greater than 50-ms.
       Default is power-on setting.
+
+  reset-gpios:
+    type: phandle-array
+    description: GPIOs used to reset the GNSS module


### PR DESCRIPTION
This PR adds an optional way to reset the GNSS module on driver initialization.

If the host resets separately from the GNSS module the driver almost always fails to initialize properly. A software only fix for this is not trivial because you would need to automatically resolve baudrate. This is an interim solution before the driver could be refactored properly. 