### PR TITLE
boards: blackpill_u585ci: fix button and LED GPIO configuration

### DIFF
--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -37,7 +37,7 @@
 		compatible = "gpio-leds";
 
 		led_0: led0 {
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 			label = "User LED";
 		};
 	};
@@ -47,7 +47,7 @@
 
 		button_0: button0 {
 			label = "User Button";
-			gpios = <&gpioa 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+			gpios = <&gpioa 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
GPIO polarity and pull configuration were incorrect for the hardware. Button shorts to ground and requires pull-up with active-low logic. LED is active-low per schematic. These changes allow the button sample to work correctly on this board.

Fixes zephyrproject-rtos/zephyr#103342