### PR TITLE
drivers: gnss: Add small delay after closing u-blox M8 modem pipe

### DIFF
--- a/drivers/gnss/gnss_u_blox_m8.c
+++ b/drivers/gnss/gnss_u_blox_m8.c
@@ -242,6 +242,7 @@ static inline int reattach_modem(const struct device *dev)
 
 	(void)modem_ubx_release(&data->ubx.inst);
 	(void)modem_pipe_close(data->backend.pipe, K_SECONDS(1));
+	(void)k_sleep(K_MSEC(10));
 
 	err = modem_pipe_open(data->backend.pipe, K_SECONDS(1));
 	if (err != 0) {


### PR DESCRIPTION
The `modem_pipe_close()` doesn't wait for UART_RX_DISABLED event. If `discard_fifo` flag is set, the subsequent `modem_pipe_open()` call will fail with `-EBUSY`.

I am not sure if this is the appropriate way to fix the issue. Probably this should be fixed in the modem pipe drivers. 