### PR TITLE
tests: net: socket: Initialize test variable to pacify compiler

### DIFF
--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -2794,7 +2794,7 @@ static void test_zsock_send_all_data(int method)
 	struct net_msghdr msg;
 	ssize_t recved;
 	int i, send_len, recv_len, remaining, split_point;
-	size_t sent_len;
+	size_t sent_len = 0;
 
 	prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr);
 	prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr);


### PR DESCRIPTION
clang complains that this variable may be used un-itialized if neither of the if's below are true. Let's just preset it to 0.

Can be seen failing in main here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21646762742/job/62400652954#step:12:1035

Issue introduced in 299f0f1cac4dbe1e7372c1145f0f5996668d0d62