### PR TITLE
dts: bindings: sensor: fix ilps22qs typo

### DIFF
--- a/dts/bindings/sensor/st,ilps22qs-i2c.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-i2c.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LPS22DF pressure and temperature sensor connected to I2C
+    STMicroelectronics ILPS22QS pressure and temperature sensor connected to I2C
     bus
 
 compatible: "st,ilps22qs"

--- a/dts/bindings/sensor/st,ilps22qs-i3c.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-i3c.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LPS22DF pressure and temperature sensor connected to I3C
+    STMicroelectronics ILPS22QS pressure and temperature sensor connected to I3C
     bus
 
 compatible: "st,ilps22qs"

--- a/dts/bindings/sensor/st,ilps22qs-spi.yaml
+++ b/dts/bindings/sensor/st,ilps22qs-spi.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LPS22DF pressure and temperature sensor connected to SPI
+    STMicroelectronics ILPS22QS pressure and temperature sensor connected to SPI
     bus
 
 compatible: "st,ilps22qs"


### PR DESCRIPTION
Fix mistyped sensor name in ILPS22QS sensor dts bindings descriptions.

No functional changes.

Fixes #103478