### PR TITLE
riscv: pmp: add option to unlock ROM region for debugging

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -421,6 +421,16 @@ config PMP_NO_LOCK_GLOBAL
 	  features. This allows application to dynamically reconfigure PMP
 	  entries without requiring hard reset.
 
+config PMP_UNLOCK_ROM_FOR_DEBUG
+	bool "Unlock ROM region for debugger access"
+	default n
+	help
+	  When enabled, the ROM region PMP entry is configured without
+	  the lock bit (L=0), allowing debuggers running in machine mode
+	  to set breakpoints and read instructions. NULL pointer guards
+	  and stack guards remain locked to catch critical bugs during
+	  development. Only enable for debug builds.
+
 endif #RISCV_PMP
 
 config PMP_STACK_GUARD

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -612,7 +612,9 @@ void z_riscv_pmp_init(void)
 
 	/* The read-only area is always there for every mode */
 	set_pmp_entry(&index,
-		      PMP_R | PMP_X | COND_CODE_1(CONFIG_PMP_NO_LOCK_GLOBAL, (0x0), (PMP_L)),
+		      PMP_R | PMP_X | COND_CODE_1(CONFIG_PMP_NO_LOCK_GLOBAL, (0x0),
+		      (COND_CODE_1(CONFIG_PMP_UNLOCK_ROM_FOR_DEBUG, (0x0),
+		      (PMP_L)))),
 		      (uintptr_t)__rom_region_start,
 		      (size_t)__rom_region_size,
 		      pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));


### PR DESCRIPTION
Add CONFIG_PMP_UNLOCK_ROM_FOR_DEBUG option to selectively unlock the ROM region PMP entry for hardware debugger access while preserving NULL pointer and stack guard protections.

When PMP lock bits are set, they restrict access even in machine mode, causing debugger connection failures. This provides a targeted solution for RISC-V debugging with PMP enabled.

Fixes #103423