### PR TITLE
fs: fs_stat: allow using it on root dir

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -614,14 +614,18 @@ int fs_stat(const char *abs_path, struct fs_dirent *entry)
 	size_t path_len;
 
 	if ((abs_path == NULL) || (abs_path[0] != '/')) {
-		path_len = 0;
-	} else {
-		path_len = strlen(abs_path);
-	}
-
-	if (path_len <= 1) {
 		LOG_ERR("invalid file or dir name!!");
 		return -EINVAL;
+	}
+
+	path_len = strlen(abs_path);
+	if (path_len == 1) {
+		/* Stat on the root directory */
+		entry->type = FS_DIR_ENTRY_DIR;
+		entry->name[0] = '/';
+		entry->name[1] = '\0';
+		entry->size = 0;
+		return 0;
 	}
 
 	rc = fs_get_mnt_point(&mp, abs_path, &mp_len);

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -991,7 +991,7 @@ ZTEST(fs_api_dir_file, test_file_stat)
 	zassert_not_equal(ret, 0, "Stat a dir without entry");
 
 	ret = fs_stat("/", &entry);
-	zassert_not_equal(ret, 0, "dir path name is too short");
+	zassert_equal(ret, 0, "Fail to stat root dir");
 
 	ret = fs_stat("SDCARD", &entry);
 	zassert_not_equal(ret, 0, "Stat a dir path without /");


### PR DESCRIPTION
We already allow using `fs_opendir` on the
root dir, so `fs_stat` should also work with it.