### PR TITLE
fs: reduce usages of `strlen()`

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -142,8 +142,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 	int rc = -EINVAL;
 	bool truncate_file = false;
 
-	if ((file_name == NULL) ||
-			(strlen(file_name) <= 1) || (file_name[0] != '/')) {
+	if ((file_name == NULL) || (file_name[0] != '/') || (file_name[1] == '\0')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -353,8 +352,7 @@ int fs_opendir(struct fs_dir_t *zdp, const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) < 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (abs_path[0] != '/')) {
 		LOG_ERR("invalid directory name!!");
 		return -EINVAL;
 	}
@@ -505,8 +503,7 @@ int fs_mkdir(const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (abs_path[0] != '/') || (abs_path[1] == '\0')) {
 		LOG_ERR("invalid directory name!!");
 		return -EINVAL;
 	}
@@ -538,8 +535,7 @@ int fs_unlink(const char *abs_path)
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (abs_path[0] != '/') || (abs_path[1] == '\0')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -572,8 +568,8 @@ int fs_rename(const char *from, const char *to)
 	size_t match_len;
 	int rc = -EINVAL;
 
-	if ((from == NULL) || (strlen(from) <= 1) || (from[0] != '/') ||
-			(to == NULL) || (strlen(to) <= 1) || (to[0] != '/')) {
+	if ((from == NULL) || (from[0] != '/') || (from[1] == '\0') ||
+			(to == NULL) || (to[0] != '/') || (to[1] == '\0')) {
 		LOG_ERR("invalid file name!!");
 		return -EINVAL;
 	}
@@ -655,8 +651,7 @@ int fs_statvfs(const char *abs_path, struct fs_statvfs *stat)
 	struct fs_mount_t *mp;
 	int rc;
 
-	if ((abs_path == NULL) ||
-			(strlen(abs_path) <= 1) || (abs_path[0] != '/')) {
+	if ((abs_path == NULL) || (abs_path[0] != '/') || (abs_path[1] == '\0')) {
 		LOG_ERR("invalid file or dir name!!");
 		return -EINVAL;
 	}


### PR DESCRIPTION
for checking the first two chars of a string
we don't need to get the full lenght, we can simply just check the 2 chars, especially as we already check the first one already.

in `fs_opendir` we only need to check the first char.