### PR TITLE
west.yml: fix st_hal unconditional directory inclusion

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -250,7 +250,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 6d963459acecfd2f9748ab506385a3188d8768f0
+      revision: 7a792882847223c72944791e0c48eed6101e6569
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Update hal_st revision to fix unconditional directory inclusion of ST HAL.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/102504
(see https://github.com/zephyrproject-rtos/hal_st/pull/31)
