### PR TITLE
samples: boards: nordic: coresight_stm: Minor fixes

### DIFF
--- a/samples/boards/nordic/coresight_stm/pytest/test_stm.py
+++ b/samples/boards/nordic/coresight_stm/pytest/test_stm.py
@@ -172,7 +172,7 @@ def nrfutil_dictionary_from_serial(
     decoded_file_name: str = "output.txt",
     collect_time: float = 60.0,
 ) -> None:
-    UART_PATH = dut.device_config.serial
+    UART_PATH = dut.device_config.serial_configs[0].port
     dut.close()
 
     logger.debug(f"Using serial: {UART_PATH}")

--- a/samples/boards/nordic/coresight_stm/sample.yaml
+++ b/samples/boards/nordic/coresight_stm/sample.yaml
@@ -23,6 +23,9 @@ tests:
       - SB_CONFIG_APP_CPUFLPR_RUN=y
 
   sample.boards.nrf.coresight_stm.tpiu.dict:
+    harness: console
+    harness_config:
+      fixture: jlink_trace_pro
     required_snippets:
       - nordic-log-stm-tpiu-dict
     extra_args:
@@ -42,6 +45,11 @@ tests:
       - SB_CONFIG_APP_CPUFLPR_RUN=y
 
   sample.boards.nrf.coresight_stm.rtt:
+    harness: pytest
+    harness_config:
+      pytest_dut_scope: session
+      pytest_root:
+        - "pytest/test_stm.py::test_sample_STM_decoded"
     required_snippets:
       - nordic-log-stm
     extra_configs:


### PR DESCRIPTION
Limit execution of sample.boards.nrf.coresight_stm.tpiu.dict to test setups with jlink_trace_pro fixture as JLink Pro is required to use TPIU.

Define harness for sample.boards.nrf.coresight_stm.rtt. Otherwise, Twister is unable to derive test result.

Aling serial port use to the lates changes in the DeviceAdapter.