### PR TITLE
tests: fs: posix: stat: fix test

### DIFF
--- a/tests/posix/fs/src/test_fs_stat.c
+++ b/tests/posix/fs/src/test_fs_stat.c
@@ -102,8 +102,7 @@ ZTEST(posix_fs_stat_test, test_fs_stat_dir)
 	zassert_equal(0, buf.st_size);
 	zassert_equal(S_IFDIR, buf.st_mode);
 
-	/* note: for posix compatibility should should actually work */
-	zassert_not_equal(0, stat(TEST_ROOT, &buf));
+	zassert_equal(0, stat(TEST_ROOT, &buf));
 }
 
 /**


### PR DESCRIPTION
Due to 35835ed695ad84155dc9e22ce678e48a75a179fa
doing `stat()` on the mount point works now works, as it should. Change the test to reflect that.