### PR TITLE
dts: arm: st: h7rs: Add RTC support and enable RTC on nucleo_h7s3l8 & stm32h7s78_dk boards

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -129,6 +129,12 @@
 	status = "okay";
 };
 
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -16,4 +16,5 @@ supported:
   - can
   - canfd
   - netif:eth
+  - rtc
 vendor: st

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -170,6 +170,12 @@
 	status = "okay";
 };
 
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
+};
+
 &timers2 {
 	st,prescaler = <10000>;
 	status = "okay";

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -16,4 +16,5 @@ supported:
   - octospi
   - usbd
   - memc
+  - rtc
 vendor: st

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
@@ -18,4 +18,5 @@ supported:
   - usbd
   - memc
   - netif:eth
+  - rtc
 vendor: st

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -413,6 +413,17 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@58004000 {
+			compatible = "st,stm32-rtc";
+			reg = <0x58004000 0x400>;
+			interrupts = <32 0>;
+			clocks = <&rcc STM32_CLOCK(APB4, 16)>;
+			prescaler = <32768>;
+			alarms-count = <2>;
+			alrm-exti-line = <17>;
+			status = "disabled";
+		};
+
 		i2c1: i2c@40005400 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
This pull request adds support for the RTC peripheral on STM32H7RS series devices.

Changes include:

* Add RTC node in the STM32H7RS device tree source (dts)
* Enabling RTC node on the nucleo_h7s3l8 & stm32h7s78_dk boards

### Tested on custom board with h7s7 controller:

prj.conf:
```
CONFIG_RTC=y
CONFIG_RTC_STM32=y
CONFIG_RTC_SHELL=y
```

Uart Shell:
```
zephyr: rtc set rtc 2026-02-04T11:58:00
zephyr: rtc get rtc
2026-02-04T11:58:03.109
[power cycle board]
zephyr: rtc get rtc
2026-02-04T11:58:36.179
```

Note: Not tested on nucleo_h7s3l8 & stm32h7s78_dk boards, but the boards rtc node are the same as on my custom board.