### PR TITLE
doc: harmonize main() return value documentation in C language support

### DIFF
--- a/doc/develop/languages/cpp/index.rst
+++ b/doc/develop/languages/cpp/index.rst
@@ -33,8 +33,8 @@ or a **cxx** suffix are compiled using the C++ compiler. For example,
 The C++ standard requires the ``main()`` function to have the return type of
 ``int``. Your ``main()`` must be defined as ``int main(void)`` or
 ``int main(int, char **)``. To use main with arguments the ``CONFIG_BOOTARGS`` option
-has to be selected. Zephyr ignores the return value from main, so applications
-should not return status information and should, instead, return zero.
+has to be selected. Zephyr ignores the return value from main. However, Applications
+must return zero (0). All non-zero return values are reserved.
 
 .. note::
     Do not use C++ for kernel, driver, or system initialization code.


### PR DESCRIPTION
The C language support documentation currently states that applications
must return zero from main(), while the C++ language documentation indicates
that Zephyr ignores the return value and applications should return zero.

This change updates the C documentation to clarify that Zephyr ignores the
return value of main(), aligning the wording with the C++ documentation and
resolving the inconsistency between the two pages.

Fixes #103135 