### PR TITLE
dts: arm: nxp: mcxw72: Use lowercase hex notation

### DIFF
--- a/dts/arm/nxp/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/nxp_mcxw72.dtsi
@@ -20,7 +20,7 @@
 		};
 
 		shmem_rpmsg: memory@220 {
-			reg = <0x220 0xA00>;
+			reg = <0x220 0xa00>;
 		};
 	};
 };


### PR DESCRIPTION
Use lowercase 'a' instead of uppercase 'A' in hexadecimal notation for consistency with coding style conventions.