### PR TITLE
net: coap: Remove invalid 2.00 response code

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -818,10 +818,17 @@ Networking
   to automatically enable all the dependencies of a given ciphersuite, and more can be added as
   needed following the same pattern.
 
+CoAP
+====
+
 * Resource-related metadata for CoAP ``.well-known/core`` responses is now configured with a dedicated
   :c:member:`coap_resource.metadata` pointer instead of :c:member:`coap_resource.user_data`, which
   should remain for the application to use exclusively. Applications implementing CoAP
   ``.well-known/core`` handling should be updated to use the new pointer.
+
+* ``COAP_RESPONSE_CODE_OK`` 2.00 response code definition has been removed as it's not a valid
+  response code - it's not defined in :rfc:`7252` and is not assigned in the IANA registry
+  (https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#response-codes).
 
 Modem
 *****

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -138,10 +138,10 @@ enum coap_msgtype {
  * @brief Set of response codes available for a response packet.
  *
  * To be used when creating a response.
+ *
+ * Refer to RFC 7252, section 12.1.2 for more information.
  */
 enum coap_response_code {
-	/** 2.00 - OK */
-	COAP_RESPONSE_CODE_OK = COAP_MAKE_RESPONSE_CODE(2, 0),
 	/** 2.01 - Created */
 	COAP_RESPONSE_CODE_CREATED = COAP_MAKE_RESPONSE_CODE(2, 1),
 	/** 2.02 - Deleted */

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1024,7 +1024,6 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt)
 	case COAP_METHOD_IPATCH:
 
 	/* All the defined response codes */
-	case COAP_RESPONSE_CODE_OK:
 	case COAP_RESPONSE_CODE_CREATED:
 	case COAP_RESPONSE_CODE_DELETED:
 	case COAP_RESPONSE_CODE_VALID:

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -880,7 +880,7 @@ static int server_resource_1_get(struct coap_resource *resource,
 
 	r = coap_packet_init(&response, data, COAP_BUF_SIZE,
 			     COAP_VERSION_1, COAP_TYPE_ACK, tkl, token,
-			     COAP_RESPONSE_CODE_OK, id);
+			     COAP_RESPONSE_CODE_CONTENT, id);
 	zassert_equal(r, 0, "Unable to initialize packet");
 
 	r = coap_append_option_int(&response, COAP_OPTION_OBSERVE,

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -124,7 +124,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake(int sock, void *buf, size_t max
 	uint16_t last_message_id = 0;
 
 	LOG_INF("Recvfrom");
-	uint8_t ack_data[] = {0x68, 0x40, 0x00, 0x00, 0x00, 0x00,
+	uint8_t ack_data[] = {0x68, 0x45, 0x00, 0x00, 0x00, 0x00,
 			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 	last_message_id = get_next_pending_message_id();
@@ -273,7 +273,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_response(int sock, void *buf, s
 {
 	uint16_t last_message_id = 0;
 
-	static uint8_t ack_data[] = {0x48, 0x40, 0x00, 0x00, 0x00, 0x00,
+	static uint8_t ack_data[] = {0x48, 0x45, 0x00, 0x00, 0x00, 0x00,
 				     0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 	last_message_id = get_next_pending_message_id();
@@ -350,7 +350,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_unmatching(int sock, void *buf,
 {
 	uint16_t last_message_id = 0;
 
-	static uint8_t ack_data[] = {0x68, 0x40, 0x00, 0x00, 0x00, 0x00,
+	static uint8_t ack_data[] = {0x68, 0x45, 0x00, 0x00, 0x00, 0x00,
 				     0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
 	last_message_id = get_next_pending_message_id();
@@ -400,7 +400,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_echo_next_req(int sock, void *b
 	uint16_t last_message_id = 0;
 
 	LOG_INF("Recvfrom");
-	uint8_t ack_data[] = {0x68, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	uint8_t ack_data[] = {0x68, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			      0x00, 0x00, 0x00, 0x00, 0xda, 0xef, 'e',  'c',
 			      'h',  'o',  '_',  'v',  'a',  'l',  'u',  'e'};
 
@@ -525,7 +525,7 @@ ZTEST(coap_client, test_get_request)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_request_block)
@@ -551,7 +551,7 @@ ZTEST(coap_client, test_resend_request)
 	k_sleep(K_MSEC(MORE_THAN_ACK_TIMEOUT_MS));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 	zassert_equal(z_impl_zsock_sendto_fake.call_count, 3);
 }
 
@@ -562,7 +562,7 @@ ZTEST(coap_client, test_echo_option)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_echo_option_next_req)
@@ -574,7 +574,7 @@ ZTEST(coap_client, test_echo_option_next_req)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 
 	char *payload = "echo testing";
 
@@ -586,7 +586,7 @@ ZTEST(coap_client, test_echo_option_next_req)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_get_no_path)
@@ -602,7 +602,7 @@ ZTEST(coap_client, test_send_large_data)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &long_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_no_response)
@@ -629,7 +629,7 @@ ZTEST(coap_client, test_separate_response)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_separate_response_lost)
@@ -683,12 +683,12 @@ ZTEST(coap_client, test_multiple_requests)
 
 	set_socket_events(client.fd, ZSOCK_POLLIN);
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 
 	last_response_code = 0;
 	set_socket_events(client.fd, ZSOCK_POLLIN);
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 ZTEST(coap_client, test_unmatching_tokens)
@@ -722,7 +722,7 @@ ZTEST(coap_client, test_multiple_clients)
 	/* ensure we got both responses */
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 }
 
 
@@ -745,7 +745,7 @@ ZTEST(coap_client, test_poll_err_after_response)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 
 	set_socket_events(client.fd, ZSOCK_POLLERR);
 	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
@@ -770,7 +770,7 @@ ZTEST(coap_client, test_poll_err_on_another_sock)
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, -EIO, "");
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "");
 }
 
 ZTEST(coap_client, test_duplicate_response)
@@ -781,7 +781,7 @@ ZTEST(coap_client, test_duplicate_response)
 	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "Unexpected response");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
 
 	zassert_equal(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)), -EAGAIN, "");
 }
@@ -855,7 +855,7 @@ ZTEST(coap_client, test_cancel)
 	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	set_socket_events(client.fd, ZSOCK_POLLIN);
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_OK, "");
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "");
 }
 
 ZTEST(coap_client, test_cancel_match)


### PR DESCRIPTION
CoAP response code 2.00 is not defined anywhere in the spec nor assigned in the IANA registry, therefore it should not be defined in Zephyr either. Remove the invalid response code and its usage in tests.

Fixes #103491