### PR TITLE
dts: arm: silabs: Fix clock branch and hwinfo definitions

### DIFF
--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -164,7 +164,7 @@
 	};
 
 	hwinfo: hwinfo {
-		compatible = "silabs,gecko-hwinfo";
+		compatible = "silabs,series2-hwinfo";
 		status = "disabled";
 	};
 

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -242,6 +242,7 @@
 			reg = <0x50030000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_HCLK>;
 			interrupt-names = "msc";
 			interrupts = <51 2>;
 

--- a/dts/arm/silabs/xg26/xg26.dtsi
+++ b/dts/arm/silabs/xg26/xg26.dtsi
@@ -593,7 +593,7 @@
 		usart1: usart@500a4000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x500a4000 0x4000>;
-			clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_INVALID>;
+			clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
 			interrupt-names = "rx", "tx";
 			interrupts = <16 2>, <17 2>;
 			status = "disabled";
@@ -602,7 +602,7 @@
 		usart2: usart@500a8000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x500a8000 0x4000>;
-			clocks = <&cmu CLOCK_USART2 CLOCK_BRANCH_INVALID>;
+			clocks = <&cmu CLOCK_USART2 CLOCK_BRANCH_PCLK>;
 			interrupt-names = "rx", "tx";
 			interrupts = <18 2>, <19 2>;
 			status = "disabled";

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -478,7 +478,7 @@
 		buram: retained-memory@50080000 {
 			compatible = "silabs,buram";
 			reg = <0x50080000 0x80>;
-			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_PCLK>;
+			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -182,7 +182,7 @@
 	};
 
 	hwinfo: hwinfo {
-		compatible = "silabs,gecko-hwinfo";
+		compatible = "silabs,series2-hwinfo";
 		status = "disabled";
 	};
 

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -571,7 +571,7 @@
 			#address-cells = <1>;
 			#io-channel-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_INVALID>;
+			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_VDAC0CLK>;
 			interrupt-names = "vdac0";
 			interrupts = <55 2>;
 			status = "disabled";

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -483,7 +483,7 @@
 		buram: retained-memory@50080000 {
 			compatible = "silabs,buram";
 			reg = <0x50080000 0x80>;
-			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_PCLK>;
+			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
 		};
 

--- a/include/zephyr/dt-bindings/clock/silabs/common-clock.h
+++ b/include/zephyr/dt-bindings/clock/silabs/common-clock.h
@@ -1,4 +1,10 @@
-/*
+/**
+ * @file
+ * @brief Clock branch macros for use on Silicon Labs Series 2 devices.
+ * @ingroup clock_control_silabs
+ */
+
+ /*
  * Copyright (c) 2024 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -6,6 +12,20 @@
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_SILABS_COMMON_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_SILABS_COMMON_CLOCK_H_
+
+/**
+ * @defgroup clock_control_silabs Silicon Labs Series 2 Devicetree helpers
+ * @ingroup clock_control_interface
+ *
+ * @details Devicetree macros for clock enables and clock branches on Silicon Labs Series 2 devices,
+ * for use with the <tt>silabs,series-clock</tt> binding.
+ *
+ * @c CLOCK_BRANCH_* macros represent clock branches, while @c CLOCK_* macros represent clock
+ * enables.
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 /*
  * DT macros for clock branches.
@@ -47,9 +67,16 @@
 #define CLOCK_BRANCH_VDAC1CLK     32
 #define CLOCK_BRANCH_USB0CLK      33
 #define CLOCK_BRANCH_FLPLLREFCLK  34
-#define CLOCK_BRANCH_INVALID      35
+#define CLOCK_BRANCH_PDM0CLK      35
+#define CLOCK_BRANCH_INVALID      36
 
 #define CLOCK_BIT_MASK 0x03FUL
 #define CLOCK_REG_MASK 0x1C0UL
+
+/** @endcond INTERNAL_HIDDEN */
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_SILABS_COMMON_CLOCK_H_ */


### PR DESCRIPTION
Fix clock branch definitions for Series 2 devices to align with 2025.12 HAL.

Consistently make use of `silabs,series2-hwinfo` compatible in Series 2 .dtsi files. The compatible is not directly used to select the hwinfo driver, but align on a single compatible for all Series 2 devices.