### PR TITLE
tests: llext: update min_ram sizes for writable test cases

### DIFF
--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -76,6 +76,7 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    min_ram: 300
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
@@ -94,6 +95,7 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    min_ram: 300
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
@@ -111,6 +113,7 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    min_ram: 300
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
@@ -130,6 +133,7 @@ tests:
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
+    min_ram: 300
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y


### PR DESCRIPTION
The writable test cases require about 70% more RAM than the readonly test cases, but the common min_ram limit does not reflect that, leading to RAM overflows as we are building for targets which are too small. Update the min_ram for writable tests to 300k, which is about 40k more than the actual size when building for an arm cortex-m, specifically nrf54l15.