### PR TITLE
drivers: modem: cellular: Don't redial when net_if_down()

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1525,8 +1525,10 @@ static void modem_cellular_carrier_on_event_handler(struct modem_cellular_data *
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_DORMANT);
 		break;
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_DORMANT);
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		if (net_if_is_admin_up(modem_ppp_get_iface(data->ppp))) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_DORMANT);
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:


### PR DESCRIPTION
When net_if_down() is called, the PPP_DEAD event is handled in state machine before the modem_ppp_ppp_api_stop() requests the driver to suspend.

Prevent non-wanted re-dial script by checking the admin state (UP/DOWN) of the PPP interface, before dealing with lost connection.