### PR TITLE
drivers: usb: udc: stm32: dequeue OUT packets before submission

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -501,8 +501,13 @@ static void handle_msg_data_out(struct udc_stm32_data *priv, uint8_t epnum, uint
 		 *  - receive Status OUT ZLP during s-in-(status)
 		 */
 		if (udc_ctrl_stage_is_status_out(dev)) {
-			/* s-in-status completed */
+			/*
+			 * s-in-status completed (ZLP)
+			 *
+			 * Dequeue packet and submit it to stack.
+			 */
 			__ASSERT_NO_MSG(rx_count == 0);
+			buf = udc_buf_get(ep_cfg);
 			udc_ctrl_update_stage(dev, buf);
 			udc_ctrl_submit_status(dev, buf);
 		} else {
@@ -526,18 +531,19 @@ static void handle_msg_data_out(struct udc_stm32_data *priv, uint8_t epnum, uint
 			 * Data stage is complete: update to next step
 			 * which should be Status IN, then submit the
 			 * Setup+Data phase buffers to UDC stack and
-			 * let it handle the next stage.
+			 * let it handle the next stage. Don't forget
+			 * to dequeue packet before submitting it.
 			 */
+			buf = udc_buf_get(ep_cfg);
 			udc_ctrl_update_stage(dev, buf);
 			__ASSERT_NO_MSG(udc_ctrl_stage_is_status_in(dev));
 			udc_ctrl_submit_s_out_status(dev, buf);
 		}
 	} else {
+		/* All data received - dequeue packet and submit it to stack */
+		buf = udc_buf_get(ep_cfg);
 		udc_submit_ep_event(dev, buf, 0);
 	}
-
-	/* Buffer was filled and submitted - remove it from queue */
-	(void)udc_buf_get(ep_cfg);
 
 	/* Endpoint is no longer busy */
 	udc_ep_set_busy(ep_cfg, false);


### PR DESCRIPTION
The `udc_submit_ep_event()` does not document this requirement, but the `net_buf` provided to it must have been removed from the driver's internal queue before submission. This wasn't noticed because the list node member of `net_buf` was untouched, but is now causing list corruption due to 5137439a47685e04b584eff973bc2090f48e7946 when multiple packets are enqueued.

Fix by always dequeuing buffers before submitting them to the UDC stack.

Fixes #102889 