### PR TITLE
drivers: sdhc: renesas_ra: remove dead error check

### DIFF
--- a/drivers/sdhc/sdhc_renesas_ra.c
+++ b/drivers/sdhc/sdhc_renesas_ra.c
@@ -193,10 +193,6 @@ static int sdhc_ra_request(const struct device *dev, struct sdhc_command *cmd,
 	/* Reset semaphore */
 	k_sem_reset(&priv->sdmmc_event.transfer_sem);
 	k_sem_take(&priv->thread_lock, K_FOREVER);
-	if (ret < 0) {
-		LOG_ERR("Can not take sem!");
-		goto end;
-	}
 
 	/*
 	 * Handle opcode with RA specifics


### PR DESCRIPTION
Remove a dead error check which check ret but ret wasn't even assigned before the test.

Remove the useless condition to make the intent explicit and clean up the code.