### PR TITLE
drivers: modem: cellular: Fix BG95/BG96 shutdown script

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -712,6 +712,10 @@ MODEM_CHAT_MATCHES_DEFINE(dial_abort_matches,
 MODEM_CHAT_MATCH_DEFINE(connect_match, "CONNECT", "", NULL);
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(quectel_bg95) || DT_HAS_COMPAT_STATUS_OKAY(quectel_bg96)
+MODEM_CHAT_MATCH_DEFINE(powerdown_match, "POWERED DOWN", "", NULL);
+#endif
+
 
 static int append_apn_cmd(struct modem_cellular_data *data, uint8_t *steps, const char *fmt,
 			  const char *apn_value)
@@ -2544,11 +2548,11 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_periodic_chat_script,
 			 modem_cellular_chat_callback_handler, 4);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_shutdown_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QPOWD=1", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QPOWD=1", powerdown_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_shutdown_chat_script,
 			 quectel_bg9x_shutdown_chat_script_cmds, abort_matches,
-			 modem_cellular_chat_callback_handler, 10);
+			 modem_cellular_chat_callback_handler, 1);
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(quectel_eg25_g)
@@ -3202,7 +3206,7 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 1000, 5000, 2000, false,                         \
 				       NULL,                                                       \
 				       &quectel_bg9x_init_chat_script,                             \
 				       &quectel_bg9x_dial_chat_script,                             \


### PR DESCRIPTION
According to the manual, device should wait:
  AT+QPOWD=1
  OK
  POWERED DOWN
before shutting down. This should take about 300 ms.

Correct the timing to match BG96 manual, where power_key pulse is 500ms (on a shut down, it say 650ms).

The start-up time of UART is described as >=4900ms so start_ms is now set to 5s. It does not require 10s.

We require more than 100ms to reset from CMUX to AT mode UART, 500ms seems to be enough. Manual does not describe this delay.

Shutdown time is described as 2s, but we don't typically use that as the shutdown script receives the POWERED DOWN message and is now faster.