### PR TITLE
soc: infineon: psoc4100tp: clock and interrupt fixes

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
@@ -47,8 +47,3 @@
 		};
 	};
 };
-
-&clk_wco {
-	status = "okay";
-	clock-frequency = <32000>; /* 32 kHz */
-};

--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
@@ -48,27 +48,6 @@ uart0: &scb0 {
 	clock-div = <11500>;
 };
 
-/*
- * Note : use IFX_PATH_PSOC4_IMO for internal main oscillator as src
- *	  use IFX_PATH_PSOC4_EXT for External clock as src
- */
-&clk_hf {
-	status = "okay";
-	source-path = <IFX_PATH_PSOC4_IMO>;
-};
-
-/*
- * Note : use IFX_PATH_PSOC4_PUMP_GND for No clock, connect to gnd
- *	  use IFX_PATH_PSOC4_PUMP_IMO for main IMO pump output
- *        use IFX_PATH_PSOC4_PUMP_HFCLK for clk_hf pump
- *
- * usage : The pump clock can be used for the analog pump
- */
-&clk_pump {
-	status = "okay";
-	source-path = <IFX_PATH_PSOC4_PUMP_GND>;
-};
-
 &gpio_prt4 {
 	status = "okay";
 };

--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
@@ -75,7 +75,6 @@ uart0: &scb0 {
 
 &gpio_prt5 {
 	status = "okay";
-	interrupts = <4 4>;
 };
 
 &watchdog0 {

--- a/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.dtsi
@@ -29,7 +29,7 @@
 		gpio_prt0: gpio@40040000 {
 			compatible = "infineon,gpio";
 			reg = <0x40040000 0x100>;
-			interrupts = <0 4>;
+			interrupts = <0 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -39,7 +39,7 @@
 		gpio_prt1: gpio@40040100 {
 			compatible = "infineon,gpio";
 			reg = <0x40040100 0x100>;
-			interrupts = <1 4>;
+			interrupts = <1 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -49,7 +49,7 @@
 		gpio_prt2: gpio@40040200 {
 			compatible = "infineon,gpio";
 			reg = <0x40040200 0x100>;
-			interrupts = <2 4>;
+			interrupts = <2 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -59,7 +59,7 @@
 		gpio_prt3: gpio@40040300 {
 			compatible = "infineon,gpio";
 			reg = <0x40040300 0x100>;
-			interrupts = <3 4>;
+			interrupts = <3 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -69,6 +69,7 @@
 		gpio_prt4: gpio@40040400 {
 			compatible = "infineon,gpio";
 			reg = <0x40040400 0x100>;
+			interrupts = <4 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -78,6 +79,7 @@
 		gpio_prt5: gpio@40040500 {
 			compatible = "infineon,gpio";
 			reg = <0x40040500 0x100>;
+			interrupts = <4 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -87,6 +89,7 @@
 		gpio_prt6: gpio@40040600 {
 			compatible = "infineon,gpio";
 			reg = <0x40040600 0x100>;
+			interrupts = <4 3>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";

--- a/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/system_clocks.dtsi
@@ -15,21 +15,21 @@
 
 / {
 	clocks {
-		/* Internal main oscillator (IMO) */
-		clk_imo: clk-imo {
-			#clock-cells = <0>;
-			compatible = "infineon,fixed-clock";
-			clock-frequency = <DT_FREQ_M(24)>;
-			system-clock = <IFX_IMO>;
-			status = "okay";
-		};
-
 		/* Internal low-speed oscillator (ILO) */
 		clk_ilo: clk-ilo {
 			#clock-cells = <0>;
 			compatible = "infineon,fixed-clock";
 			clock-frequency = <DT_FREQ_K(40)>;
 			system-clock = <IFX_ILO>;
+			status = "okay";
+		};
+
+		/* Internal main oscillator (IMO) */
+		clk_imo: clk-imo {
+			#clock-cells = <0>;
+			compatible = "infineon,fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			system-clock = <IFX_IMO>;
 			status = "okay";
 		};
 
@@ -47,6 +47,7 @@
 			#clock-cells = <0>;
 			compatible = "infineon,fixed-clock";
 			system-clock = <IFX_WCO>;
+			clock-frequency = <32768>;
 			status = "okay";
 		};
 
@@ -57,7 +58,7 @@
 			source-path = <IFX_PATH_PSOC4_IMO>;
 			system-clock = <IFX_HF>;
 			instance = <0>;
-			status = "disabled";
+			status = "okay";
 		};
 
 		clk_pump: clk-pump {
@@ -66,7 +67,7 @@
 			system-clock = <IFX_PUMP>;
 			source-path = <IFX_PATH_PSOC4_PUMP_GND>;
 			instance = <0>;
-			status = "disabled";
+			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
Fixes the clock setup to work at 48MHz correctly. Fixes GPIO interrupts in order to be able to build samples and apps on the board.