### PR TITLE
lib: heap: Fix runtime stats for un-init heaps

### DIFF
--- a/lib/heap/heap_stats.c
+++ b/lib/heap/heap_stats.c
@@ -11,7 +11,7 @@
 int sys_heap_runtime_stats_get(struct sys_heap *heap,
 		struct sys_memory_stats *stats)
 {
-	if ((heap == NULL) || (stats == NULL)) {
+	if ((heap == NULL) || (stats == NULL) || (heap->heap == NULL)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Calling sys_heap_runtime_stats_get on a valid but uninitialized heap results in a NULL pointer access. Add an additional check in this function that the heap is valid and has also been initialized.