### PR TITLE
tests: kernel/semaphore: fix multiple threads wait test

### DIFF
--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -875,9 +875,9 @@ ZTEST(semaphore, test_sem_multiple_threads_wait)
 		expect_k_sem_count_get_nomsg(&simple_sem, 0U);
 		expect_k_sem_count_get_nomsg(&multiple_thread_sem, 0U);
 
-	}
-	for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
-		k_thread_join(&multiple_tid[i], K_FOREVER);
+		for (int i = 0; i < TOTAL_THREADS_WAITING; i++) {
+			k_thread_join(&multiple_tid[i], K_FOREVER);
+		}
 	}
 }
 


### PR DESCRIPTION
The test_sem_multiple_threads_wait test spawns multiple threads to wait on one semaphore. The test itself loops twice, and in each iteration it calls k_thread_create() to create new threads but without joining the threads at the end of the loop. With SMP, it is possible for the threads to still be running on other CPUs when k_thread_create() is called on the second iteraion. This overwrites the data inside the thread object. When other CPUs finishes with those threads and try to clean up the threads, they now have incorrect data (e.g. stack pointer) which may result in CPU exception. So we need to make sure all running threads have stopped running before starting the second iteration.