### PR TITLE
counter: ace_v1x_rtc: fix unused function warning

### DIFF
--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -21,6 +21,7 @@ static int counter_ace_v1x_rtc_get_value_32(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 static int counter_ace_v1x_rtc_get_value(const struct device *dev,
 		uint64_t *value)
 {
@@ -37,6 +38,7 @@ static int counter_ace_v1x_rtc_get_value(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 int counter_ace_v1x_rtc_init(const struct device *dev)
 {


### PR DESCRIPTION
The 64-bit counter getter function is defined regardless whether it is being used by the API struct. This results in toolchain complaining about unused function. So guard the getter function under the same kconfig.