### PR TITLE
dts: broadcom: bcm2711: add rng device node

### DIFF
--- a/boards/raspberrypi/rpi_4b/rpi_4b.dts
+++ b/boards/raspberrypi/rpi_4b/rpi_4b.dts
@@ -26,6 +26,7 @@
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
+		zephyr,entropy = &rng;
 	};
 
 	leds {

--- a/dts/arm64/broadcom/bcm2711.dtsi
+++ b/dts/arm64/broadcom/bcm2711.dtsi
@@ -61,6 +61,12 @@
 			status = "okay";
 		};
 
+		rng: rng@fe104000 {
+			compatible = "brcm,iproc-rng200";
+			reg = <0xfe104000 0x28>;
+			status = "okay";
+		};
+
 		pinctrl: pin-controller@fe200000 {
 			compatible = "brcm,bcm2711-pinctrl";
 			reg = <0xfe200000 0xf4>;


### PR DESCRIPTION
Add device tree node for the Broadcom iProc RNG200 hardware random number generator found on BCM2711 SoC