### PR TITLE
treewide: use proper essential type in boolean variables assignments

### DIFF
--- a/drivers/adc/adc_max32.c
+++ b/drivers/adc/adc_max32.c
@@ -231,7 +231,7 @@ static int start_read_stream(const struct device *dev, const struct adc_sequence
 		return -EINVAL;
 	}
 
-	data->ctx.asynchronous = 1;
+	data->ctx.asynchronous = true;
 	data->sample_channels = seq->channels;
 
 	/* Here we use regular cb that does nothing, it should be

--- a/drivers/adc/adc_xmc4xxx.c
+++ b/drivers/adc/adc_xmc4xxx.c
@@ -274,7 +274,7 @@ static int adc_xmc4xxx_init(const struct device *dev)
 		/* global bound register is unused */
 		adc_global_ptr->GLOBBOUND = 0;
 
-		adc_global_init = 1;
+		adc_global_init = true;
 	}
 
 	adc_group->ARBCFG = 0;

--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -641,7 +641,7 @@ out_disable_bkup_access:
 	 */
 	now = rtc_stm32_read(dev);
 	if ((ticks - now < 2) || (now > ticks)) {
-		data->irq_on_late = 1;
+		data->irq_on_late = true;
 		rtc_stm32_set_int_pending();
 	}
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
@@ -718,7 +718,7 @@ void rtc_stm32_isr(const struct device *dev)
 		LL_RTC_EnableWriteProtection(RTC);
 		stm32_backup_domain_disable_access();
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
-		data->irq_on_late = 0;
+		data->irq_on_late = false;
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 
 		if (alarm_callback != NULL) {

--- a/drivers/crypto/crypto_intel_sha.c
+++ b/drivers/crypto/crypto_intel_sha.c
@@ -305,7 +305,7 @@ static int intel_sha_device_free(const struct device *dev, struct hash_ctx *ctx)
 	(void)memset((void *)self->dfsha, 0, sizeof(struct sha_hw_regs));
 	(void)memset(&session->sha_ctx, 0, sizeof(struct sha_context));
 	(void)memset(&session->state, 0, sizeof(union sha_state));
-	session->in_use = 0;
+	session->in_use = false;
 	session->algo = 0;
 	return 0;
 }

--- a/drivers/crypto/crypto_it8xxx2_sha_v2.c
+++ b/drivers/crypto/crypto_it8xxx2_sha_v2.c
@@ -120,7 +120,7 @@ static int it8xxx2_sha256_module_calculation(void)
 		gctrl_regs->GCTRL_WNCKR = IT8XXX2_GCTRL_WN65K;
 
 		if ((sys_read8(IT8XXX2_SHA_REGS_BASE + IT8XXX2_REG_SHASR) & IT8XXX2_SHAIS)) {
-			timeout = 0;
+			timeout = false;
 			break;
 		}
 	}
@@ -262,7 +262,7 @@ static int it8xxx2_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt,
 
 			if ((sys_read8(IT8XXX2_SHA_REGS_BASE + IT8XXX2_REG_SHASR)
 			      & IT8XXX2_SHAIS)) {
-				timeout = 0;
+				timeout = false;
 				break;
 			}
 		}

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -208,7 +208,7 @@ static void nxp_edma_callback(edma_handle_t *handle, void *param, bool transferD
 	if (data->transfer_settings.cyclic) {
 		data->transfer_settings.empty_tcds++;
 		/*In loop mode, DMA is always busy*/
-		data->busy = 1;
+		data->busy = true;
 		ret = DMA_STATUS_COMPLETE;
 	} else if (transferDone) {
 		/* DMA is no longer busy when there are no remaining TCDs to transfer */

--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -613,12 +613,12 @@ void hl78xx_on_kselacq(struct modem_chat *chat, char **argv, uint16_t argc, void
 		return;
 	}
 	if (argc > 3) {
-		data->kselacq_data.mode = 0;
+		data->kselacq_data.mode = false;
 		data->kselacq_data.rat1 = ATOI(argv[1], 0, "rat1");
 		data->kselacq_data.rat2 = ATOI(argv[2], 0, "rat2");
 		data->kselacq_data.rat3 = ATOI(argv[3], 0, "rat3");
 	} else {
-		data->kselacq_data.mode = 0;
+		data->kselacq_data.mode = false;
 		data->kselacq_data.rat1 = 0;
 		data->kselacq_data.rat2 = 0;
 		data->kselacq_data.rat3 = 0;

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -358,7 +358,7 @@ static int pwm_suspend(const struct device *dev)
 	data->period_cycles = 0;
 	data->pwm_needed = 0;
 	data->prescaler = 0;
-	data->stop_requested = 0;
+	data->stop_requested = false;
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 
 	return 0;

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -577,7 +577,7 @@ static int regulator_cp9314_init(const struct device *dev)
 			return ret;
 		}
 	} else {
-		data->allow_hw_i2c_lock = 0;
+		data->allow_hw_i2c_lock = false;
 	}
 
 	ret = cp9314_do_soft_reset(dev);

--- a/drivers/rtc/rtc_max31331.c
+++ b/drivers/rtc/rtc_max31331.c
@@ -435,9 +435,9 @@ static int enable_alarm_interrupt(const struct device *dev, uint16_t id, uint16_
 	bool enable;
 
 	if (mask != 0) {
-		enable = 1;
+		enable = true;
 	} else {
-		enable = 0;
+		enable = false;
 	}
 
 	if (id == 1) {

--- a/drivers/rtc/rtc_smartbond.c
+++ b/drivers/rtc/rtc_smartbond.c
@@ -514,7 +514,7 @@ static int rtc_smartbond_alarm_is_pending(const struct device *dev, uint16_t id)
 	key = DA1469X_IRQ_DISABLE();
 	status = data->is_alarm_pending;
 	/* After reading, the alarm status should be cleared. */
-	data->is_alarm_pending = 0;
+	data->is_alarm_pending = false;
 	DA1469X_IRQ_ENABLE(key);
 
 	return status;

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.c
@@ -331,8 +331,8 @@ int pat9136_encode(const struct device *dev,
 	int err;
 
 	edata->header.channels = 0;
-	edata->header.events.drdy = 0;
-	edata->header.events.motion = 0;
+	edata->header.events.drdy = false;
+	edata->header.events.motion = false;
 
 	for (size_t i = 0 ; i < num_channels; i++) {
 		edata->header.channels |= pat9136_encode_channel(channels[i].chan_type);

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -477,7 +477,7 @@ static int uart_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 		return -EBUSY;
 	}
 
-	uart0_cb.rx_enabled = 1;
+	uart0_cb.rx_enabled = true;
 	uart0_cb.rx_buffer = buf;
 	uart0_cb.rx_buffer_length = len;
 	uart0_cb.rx_counter = 0;
@@ -522,7 +522,7 @@ static int uart_nrfx_rx_disable(const struct device *dev)
 		return -EFAULT;
 	}
 
-	uart0_cb.rx_enabled = 0;
+	uart0_cb.rx_enabled = false;
 	if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
 		k_timer_stop(&uart0_cb.rx_timeout_timer);
 	}
@@ -570,7 +570,7 @@ static void rx_reset_state(void)
 			     NRF_UART_INT_MASK_ERROR |
 			     NRF_UART_INT_MASK_RXTO);
 	uart0_cb.rx_buffer_length = 0;
-	uart0_cb.rx_enabled = 0;
+	uart0_cb.rx_enabled = false;
 	uart0_cb.rx_counter = 0;
 	uart0_cb.rx_offset = 0;
 	uart0_cb.rx_secondary_buffer_length = 0;
@@ -612,7 +612,7 @@ static void rx_isr(const struct device *dev)
 		unsigned int key = irq_lock();
 
 		if (uart0_cb.rx_secondary_buffer_length == 0) {
-			uart0_cb.rx_enabled = 0;
+			uart0_cb.rx_enabled = false;
 		}
 		irq_unlock(key);
 

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -236,7 +236,7 @@ int usb_dc_attach(void)
 	 */
 	usb_dc_reset();
 
-	dev_data.attached = 1;
+	dev_data.attached = true;
 	LOG_DBG("attached");
 
 	/* non-OTG device mode, enable DP Pullup */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -281,9 +281,9 @@ static int wpa_supp_band_chan_compat(struct wpa_supplicant *wpa_s, uint8_t band,
 static inline void wpa_supp_restart_status_work(void)
 {
 	/* Terminate synchronously */
-	wpas_api_ctrl.terminate = 1;
+	wpas_api_ctrl.terminate = true;
 	k_work_flush_delayable(&wpa_supp_status_work, &wpas_api_ctrl.sync);
-	wpas_api_ctrl.terminate = 0;
+	wpas_api_ctrl.terminate = false;
 
 	/* Start afresh */
 	k_work_reschedule_for_queue(get_workq(), &wpa_supp_status_work, K_MSEC(10));

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -81,7 +81,7 @@ static int validate_addr_blk(uint32_t start_addr,
 	if (((start_addr >= block_map[0]) && (start_addr <= block_map[1])) &&
 	    ((end_addr >= block_map[0]) && (end_addr <= block_map[1]))) {
 		if (block_no == PKTRAM) {
-			*hl_flag = 0;
+			*hl_flag = false;
 		}
 		*selected_blk = block_no;
 		return 0;
@@ -98,7 +98,7 @@ static int rpu_validate_addr(uint32_t start_addr, uint32_t len, bool *hl_flag)
 
 	end_addr = start_addr + len - 1;
 
-	*hl_flag = 1;
+	*hl_flag = true;
 
 	for (i = 0; i < NUM_MEM_BLOCKS; i++) {
 		ret = validate_addr_blk(start_addr, end_addr, i, hl_flag, &selected_blk);

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -1297,7 +1297,7 @@ static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid
 
 	if ((rsp_code == BT_AVRCP_RSP_INTERIM) && (ct->ct_notify[event_id].interim_received == 0)) {
 		/* Mark as interim_received flag on interim response */
-		ct->ct_notify[event_id].interim_received = 1;
+		ct->ct_notify[event_id].interim_received = true;
 		avrcp_ct_cb->notification(get_avrcp_ct(avrcp), tid, BT_AVRCP_STATUS_SUCCESS,
 					  event_id, (struct bt_avrcp_event_data *)event_data);
 		return BT_AVRCP_STATUS_OPERATION_COMPLETED;
@@ -1305,7 +1305,7 @@ static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid
 	}
 
 	if ((ct->ct_notify[event_id].interim_received == 1) && (rsp_code == BT_AVRCP_RSP_CHANGED)) {
-		ct->ct_notify[event_id].interim_received = 0;
+		ct->ct_notify[event_id].interim_received = false;
 		if (ct->ct_notify[event_id].cb != NULL) {
 			bt_avrcp_notify_changed_cb_t cb;
 
@@ -1323,7 +1323,7 @@ notify_callback:
 		if (ct->ct_notify[i].tid == tid && ct->ct_notify[i].cb != NULL) {
 			failed_evt = i;
 			ct->ct_notify[i].cb = NULL;
-			ct->ct_notify[i].interim_received = 0;
+			ct->ct_notify[i].interim_received = false;
 			found = true;
 			break;
 		}
@@ -3276,7 +3276,7 @@ int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8
 	}
 
 	ct->ct_notify[event_id].cb = cb;
-	ct->ct_notify[event_id].interim_received = 0;
+	ct->ct_notify[event_id].interim_received = false;
 	ct->ct_notify[event_id].tid = tid;
 
 	return 0;

--- a/subsys/bluetooth/mesh/brg_cfg.c
+++ b/subsys/bluetooth/mesh/brg_cfg.c
@@ -57,7 +57,7 @@ static int brg_en_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	}
 
 	if (len_rd == 0) {
-		brg_enabled = 0;
+		brg_enabled = false;
 		LOG_DBG("Cleared bridge enable state");
 		return 0;
 	}

--- a/subsys/instrumentation/common/instr_common.c
+++ b/subsys/instrumentation/common/instr_common.c
@@ -114,7 +114,7 @@ int instr_init(void)
 	 * infinite recursion in the handler since instr_initialized() will return 0 and
 	 * instr_init() will be called again.
 	 */
-	_instr_initialized = 1;
+	_instr_initialized = true;
 
 	if (retention_is_valid(instrumentation_triggers)) {
 		/* Retained mem is already initialized, load trigger and stopper addresses */
@@ -345,7 +345,7 @@ void push_callee_timestamp(void *callee)
 	/* Find callee in the discovered function array */
 	for (curr_func = 0; curr_func < num_disco_func; curr_func++) {
 		if (disco_func[curr_func].addr == callee) {
-			found = 1;
+			found = true;
 			break;
 		}
 	}
@@ -570,7 +570,7 @@ void instr_event_handler(enum instr_event_types type, void *callee, void *caller
 
 		if (!IS_ENABLED(CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE) &&
 				instr_buffer_space_get() < sizeof(struct instr_record)) {
-			_instr_tracing_disabled = 1;
+			_instr_tracing_disabled = true;
 			return;
 		}
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -139,7 +139,7 @@ static struct lwm2m_engine_obj_inst *security_create(uint16_t obj_inst_id)
 	/* default values */
 	security_uri[index][0] = '\0';
 	client_identity[index][0] = '\0';
-	bootstrap_flag[index] = 0;
+	bootstrap_flag[index] = false;
 	security_mode[index] = 0U;
 	short_server_id[index] = 0U;
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -163,7 +163,7 @@ static int put_basename(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 
 	record->record_bn.record_bn.value = basename;
 	record->record_bn.record_bn.len = len;
-	record->record_bn_present = 1;
+	record->record_bn_present = true;
 
 	if ((len < sizeof("/0/0") - 1) || (len >= SENML_MAX_NAME_SIZE)) {
 		__ASSERT_NO_MSG(false);
@@ -260,7 +260,7 @@ static int put_begin_r(struct lwm2m_output_context *out, struct lwm2m_obj_path *
 
 	record->record_n.record_n.value = name;
 	record->record_n.record_n.len = len;
-	record->record_n_present = 1;
+	record->record_n_present = true;
 
 	/* Makes possible to use same slot for storing r/ri name combination.
 	 * No need to increase the name count if an existing name has been used
@@ -288,11 +288,11 @@ static int put_data_timestamp(struct lwm2m_output_context *out, time_t value)
 
 	if (fd->basetime) {
 		out_record->record_t.record_t = value - fd->basetime;
-		out_record->record_t_present = 1;
+		out_record->record_t_present = true;
 	} else {
 		fd->basetime = value;
 		out_record->record_bt.record_bt = value;
-		out_record->record_bt_present = 1;
+		out_record->record_bt_present = true;
 	}
 
 	return 0;
@@ -334,7 +334,7 @@ static int put_begin_ri(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 	/* Tell CBOR encoder where to find the name */
 	record->record_n.record_n.value = name;
 	record->record_n.record_n.len = len;
-	record->record_n_present = 1;
+	record->record_n_present = true;
 
 	/* No need to increase the name count if an existing name has been used */
 	if (name == GET_CBOR_FD_NAME(fd)) {
@@ -379,7 +379,7 @@ static int put_value(struct lwm2m_output_context *out, struct lwm2m_obj_path *pa
 	/* Write the value */
 	record->record_union.record_union_choice = union_vi_c;
 	record->record_union.union_vi = value;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -417,7 +417,7 @@ static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *pat
 	/* Write the value */
 	record->record_union.record_union_choice = union_vi_c;
 	record->record_union.union_vi = (int64_t)value;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -435,7 +435,7 @@ static int put_float(struct lwm2m_output_context *out, struct lwm2m_obj_path *pa
 	/* Write the value */
 	record->record_union.record_union_choice = union_vf_c;
 	record->record_union.union_vf = *value;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -455,7 +455,7 @@ static int put_string(struct lwm2m_output_context *out, struct lwm2m_obj_path *p
 	record->record_union.record_union_choice = union_vs_c;
 	record->record_union.union_vs.value = buf;
 	record->record_union.union_vs.len = buflen;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -473,7 +473,7 @@ static int put_bool(struct lwm2m_output_context *out, struct lwm2m_obj_path *pat
 	/* Write the value */
 	record->record_union.record_union_choice = union_vb_c;
 	record->record_union.union_vb = value;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -493,7 +493,7 @@ static int put_opaque(struct lwm2m_output_context *out, struct lwm2m_obj_path *p
 	record->record_union.record_union_choice = union_vd_c;
 	record->record_union.union_vd.value = buf;
 	record->record_union.union_vd.len = buflen;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	return 0;
 }
@@ -530,7 +530,7 @@ static int put_objlnk(struct lwm2m_output_context *out, struct lwm2m_obj_path *p
 	record->record_union.record_union_choice = union_vlo_c;
 	record->record_union.union_vlo.value = objlink_buf;
 	record->record_union.union_vlo.len = objlnk_len;
-	record->record_union_present = 1;
+	record->record_union_present = true;
 
 	fd->objlnk_cnt++;
 

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -83,7 +83,7 @@ ZTEST_BMEM volatile k_tid_t valid_assert_tid;
 static inline void reset_stored_assert_status(void)
 {
 	valid_assert_tid = NULL;
-	assert_in_isr = 0;
+	assert_in_isr = false;
 }
 
 void z_impl_ztest_set_assert_valid(bool valid)

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -378,7 +378,7 @@ void z_impl_test_arm_user_interrupt_syscall(void)
 	if (first_call == 1) {
 
 		/* First time the syscall is invoked */
-		first_call = 0;
+		first_call = false;
 
 		/* Lock IRQs in supervisor mode */
 		unsigned int key = irq_lock();

--- a/tests/drivers/usb/bc12/src/pd_mode.c
+++ b/tests/drivers/usb/bc12/src/pd_mode.c
@@ -173,7 +173,7 @@ static void bc12_before(void *data)
 	struct bc12_pd_mode_fixture *fixture = data;
 
 	fixture->callback_count = 0;
-	fixture->disconnect_detected = 0;
+	fixture->disconnect_detected = false;
 	memset(&fixture->partner_state, 0, sizeof(struct bc12_partner_state));
 
 	bc12_set_result_cb(fixture->bc12_dev, &bc12_test_result_cb, fixture);

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2183,7 +2183,7 @@ static int test_gpio_init(const struct device *dev)
 {
 	struct test_gpio_data *data = dev->data;
 
-	data->init_called = 1;
+	data->init_called = true;
 	return 0;
 }
 


### PR DESCRIPTION
As per Zephyr coding guideline #59, "operands shall not be of an inappropriate essential type". This makes sure boolean variables are assigned true/false values, not 1/0.

Patching was done with https://github.com/zephyrproject-rtos/zephyr/pull/103527