### PR TITLE
tests: spi: Fixed an issue with a missing definition for a SPI test.

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/README.txt
+++ b/tests/drivers/spi/spi_controller_peripheral/README.txt
@@ -1,4 +1,4 @@
-In this test suite two instances of the SPI peripheral are connected together.
+In this test suite, two instances of the SPI peripheral are connected together on the same device (i.e. loopback mode).
 One SPI instance works as a controller, second one is configured as a peripheral.
 In each test, both instances get identical configuration (CPOL, CPHA, bitrate, etc.).
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -78,4 +78,5 @@ dut_spis: &spi21 {
 	pinctrl-names = "default", "sleep";
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;
+	zephyr,pm-device-runtime-auto;
 };


### PR DESCRIPTION
This fixes an issue that causes all SPI tests run natively on the nRF54LM20-DK to fail. Furthermore, this adds a clarification in the README.txt so that this test intention is clear about being run on only one device, and not two.