### PR TITLE
scripts: ci: doxygen_coverage_diff: warn-only for C headers

### DIFF
--- a/.github/workflows/doxygen-coverage-delta.yml
+++ b/.github/workflows/doxygen-coverage-delta.yml
@@ -97,4 +97,5 @@ jobs:
             --strip-comparison-prefix "$PR_ROOT" \
             --warn-paths "include/zephyr/dt-bindings" \
             --warn-paths "include/zephyr/posix" \
+            --warn-paths "lib/libc" \
             --summary-file "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
False positives were being reported for the `doxygen-coverage-delta.yml` workflow, so make C library headers warning-only for now.

Workaround for #103523