### PR TITLE
tests: posix: net + barriers: mitigate sonarcloud issues

### DIFF
--- a/tests/posix/barriers/src/main.c
+++ b/tests/posix/barriers/src/main.c
@@ -29,6 +29,7 @@ ZTEST(posix_barriers, test_barrier)
 	zassert_equal(ret, 0, "pthread_barrierattr_setpshared failed");
 
 	ret = pthread_barrierattr_getpshared(&attr, &pshared);
+	zassert_equal(ret, 0, "pthread_barrierattr_getpshared failed");
 	zassert_equal(pshared, PTHREAD_PROCESS_PUBLIC, "pshared attribute not retrieved correctly");
 
 	ret = pthread_barrierattr_setpshared(&attr, 42);

--- a/tests/posix/net/src/inet_addr.c
+++ b/tests/posix/net/src/inet_addr.c
@@ -39,7 +39,7 @@ ZTEST(net, test_inet_addr)
 		{"1.2.3.4", htonl(0x01020304)},
 		{"1.2.3.4    ", htonl(0x01020304)},
 		{"0.0.0.123 a", htonl(0x0000007b)},
-		{"255.255.255.255", htonl(0xffffffff)},
+		{"255.255.255.255", htonl(0xffffffffU)},
 	};
 
 	ARRAY_FOR_EACH_PTR(parms, p) {

--- a/tests/posix/net/src/inet_ntoa.c
+++ b/tests/posix/net/src/inet_ntoa.c
@@ -19,6 +19,6 @@ ZTEST(net, test_inet_ntoa)
 	in.s_addr = htonl(0);
 	zassert_mem_equal(inet_ntoa(in), "0.0.0.0", strlen("0.0.0.0") + 1);
 
-	in.s_addr = htonl(0xffffffff);
+	in.s_addr = htonl(0xffffffffU);
 	zassert_mem_equal(inet_ntoa(in), "255.255.255.255", strlen("255.255.255.255") + 1);
 }


### PR DESCRIPTION
This change mitigates some SonarCloud issues.

1. explicit 'U' after 0xffffffff

> A cast shall not remove any const or volatile qualification from the
> type of a pointer or reference c:S859

2. check return value from call to `pthread_barrierattr_getpshared()`

> Unused assignments should be removed c:S1854