### PR TITLE
lib: os: do not include posix sys/types.h header

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -15,7 +15,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <zephyr/toolchain.h>
-#include <sys/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/cbprintf.h>
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -22,7 +22,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/llext/symbol.h>
-#include <sys/types.h>
 
 /* Option present only when CONFIG_USERSPACE enabled. */
 #ifndef CONFIG_PRINTK_BUFFER_SIZE


### PR DESCRIPTION
There is no need to pull in POSIX types into these files, so remove the `<sys/types.h>` include.