### PR TITLE
soc: infineon: psoc4100smax: clock fixes

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
@@ -42,27 +42,6 @@ uart2: &scb2 {
 	clock-div = <11500>;
 };
 
-/*
- * Note : use IFX_PATH_PSOC4_IMO for internal main oscillator as src
- *	  use IFX_PATH_PSOC4_EXT for External clock as src
- */
-&clk_hf {
-	status = "okay";
-	source-path = <IFX_PATH_PSOC4_IMO>;
-};
-
-/*
- * Note : use IFX_PATH_PSOC4_PUMP_GND for No clock, connect to gnd
- *	  use IFX_PATH_PSOC4_PUMP_IMO for main IMO pump output
- *        use IFX_PATH_PSOC4_PUMP_HFCLK for clk_hf pump
- *
- * usage : The pump clock can be used for the analog pump
- */
-&clk_pump {
-	status = "okay";
-	source-path = <IFX_PATH_PSOC4_PUMP_GND>;
-};
-
 &gpio_prt7 {
 	status = "okay";
 };

--- a/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/system_clocks.dtsi
@@ -15,21 +15,21 @@
 
 / {
 	clocks {
-		/* Internal main oscillator (IMO) */
-		clk_imo: clk-imo {
-			#clock-cells = <0>;
-			compatible = "infineon,fixed-clock";
-			clock-frequency = <DT_FREQ_M(24)>;
-			system-clock = <IFX_IMO>;
-			status = "okay";
-		};
-
 		/* Internal low-speed oscillator (ILO) */
 		clk_ilo: clk-ilo {
 			#clock-cells = <0>;
 			compatible = "infineon,fixed-clock";
 			clock-frequency = <DT_FREQ_K(40)>;
 			system-clock = <IFX_ILO>;
+			status = "okay";
+		};
+
+		/* Internal main oscillator (IMO) */
+		clk_imo: clk-imo {
+			#clock-cells = <0>;
+			compatible = "infineon,fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			system-clock = <IFX_IMO>;
 			status = "okay";
 		};
 
@@ -46,8 +46,8 @@
 		clk_wco: clk-wco {
 			#clock-cells = <0>;
 			compatible = "infineon,fixed-clock";
-			clock-frequency = <0>;
 			system-clock = <IFX_WCO>;
+			clock-frequency = <32768>;
 			status = "okay";
 		};
 
@@ -58,7 +58,7 @@
 			source-path = <IFX_PATH_PSOC4_IMO>;
 			system-clock = <IFX_HF>;
 			instance = <0>;
-			status = "disabled";
+			status = "okay";
 		};
 
 		clk_pump: clk-pump {
@@ -67,7 +67,7 @@
 			system-clock = <IFX_PUMP>;
 			source-path = <IFX_PATH_PSOC4_PUMP_GND>;
 			instance = <0>;
-			status = "disabled";
+			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
Fixes the clock setup to work at 48MHz correctly.

Relates to https://github.com/zephyrproject-rtos/zephyr/pull/103513