### PR TITLE
modules: mbedtls: imply legacy RSA Kconfigs from ciphersuites

### DIFF
--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -60,6 +60,23 @@ config MBEDTLS_GENPRIME_ENABLED
 
 endif # MBEDTLS_RSA_C
 
+config MBEDTLS_RSA_ENABLE_LEGACY_APIS
+	bool
+	imply MBEDTLS_RSA_C
+	imply MBEDTLS_PKCS1_V15
+	default y if MBEDTLS_CIPHERSUITE_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 || \
+		     MBEDTLS_CIPHERSUITE_TLS_RSA_WITH_AES_256_CBC_SHA256
+	help
+	  Promptless Kconfig to automatically enable legacy RSA crypto support
+	  when RSA based ciphersuites are enabled.
+	  This is required because TLS/X.509 code still relies on these legacy
+	  symbols to guard parts of the code.
+	  In theory this fix is only necessary when TF-M is enabled, because
+	  otherwise when Mbed TLS uses its own implementation of PSA Crypto
+	  it automatically does this internally. On the other hand it doesn't hurt to
+	  always enable it.
+	  This fix is very likely to be removed with Mbed TLS 4.x.
+
 config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
 	bool "All available ciphersuite modes"
 	select MBEDTLS_MD_C


### PR DESCRIPTION
There should be no direct select of those Kconfigs anymore in Zephyr codebase, but we still need them available because Mbed TLS checks for legacy RSA build symbols when key exchanges are enabled.
Therefore instead of removing the Kconfigs we make them promptless and enabled by corresponding PSA_WANT and only when the build has TF-M enabled.
When TF-M is disabled there is no need for this trick because Mbed TLS automatically enables legacy support internally.

Resolves #103468