### PR TITLE
dts: remove 0x and ull from node addresses

### DIFF
--- a/boards/amd/versal2_rpu/versal2_rpu-qemu.dts
+++ b/boards/amd/versal2_rpu/versal2_rpu-qemu.dts
@@ -960,7 +960,7 @@
 				phandle = <0x10f>;
 			};
 
-			loader_write_cpu0_0x1@0xf1110880 {
+			loader_write_cpu0_0x1@f1110880 {
 				compatible = "loader";
 				addr = <0xf1110880>;
 				data = <0x01>;
@@ -972,7 +972,7 @@
 				phandle = <0x110>;
 			};
 
-			loader_write_cpu0_0x5@0xfd1a0050 {
+			loader_write_cpu0_0x5@fd1a0050 {
 				compatible = "loader";
 				addr = <0xfd1a0050>;
 				data = <0x05>;
@@ -984,7 +984,7 @@
 				phandle = <0x111>;
 			};
 
-			loader_write_cpu0_0xFF@0xf111010c {
+			loader_write_cpu0_0xFF@f111010c {
 				compatible = "loader";
 				addr = <0xf111010c>;
 				data = <0xff>;
@@ -1031,7 +1031,7 @@
 				phandle = <0x44>;
 			};
 
-			loader_write_cpu0_0x80C@0xf12b0100 {
+			loader_write_cpu0_0x80C@f12b0100 {
 				compatible = "loader";
 				addr = <0xf12b0100>;
 				data = <0x80c>;
@@ -1043,7 +1043,7 @@
 				phandle = <0x113>;
 			};
 
-			loader_write_cpu0_0x77@0xf1260320 {
+			loader_write_cpu0_0x77@f1260320 {
 				compatible = "loader";
 				addr = <0xf1260320>;
 				data = <0x77>;
@@ -1098,7 +1098,7 @@
 				reg = <0x00 0x00 0xffffffff 0xffffffff 0xffffffff>;
 			};
 
-			xppu_lpd@0xeb990000 {
+			xppu_lpd@eb990000 {
 				compatible = "xlnx,versal-xppu";
 				reg-extended = <0x0a 0x00 0xeb990000 0x00 0x10000 0x00
 						0x16 0x00 0xeb000000 0x00 0x1000000 0x02
@@ -1108,7 +1108,7 @@
 				phandle = <0x117>;
 			};
 
-			ethernet@0xf1a60000 {
+			ethernet@f1a60000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				#priority-cells = <0x00>;
@@ -1125,7 +1125,7 @@
 				phandle = <0x118>;
 			};
 
-			ethernet@0xf1a70000 {
+			ethernet@f1a70000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				#priority-cells = <0x00>;
@@ -1142,7 +1142,7 @@
 				phandle = <0x119>;
 			};
 
-			serial@0xf1920000 {
+			serial@f1920000 {
 				compatible = "pl011";
 				interrupts = <0x19>;
 				reg = <0x00 0xf1920000 0x00 0x10000 0x00>;
@@ -1151,7 +1151,7 @@
 				phandle = <0x11a>;
 			};
 
-			serial@0xf1930000 {
+			serial@f1930000 {
 				compatible = "pl011";
 				interrupts = <0x1a>;
 				reg = <0x00 0xf1930000 0x00 0x10000 0x00>;
@@ -1165,7 +1165,7 @@
 				phandle = <0x1f>;
 			};
 
-			can@0xf19e0000 {
+			can@f19e0000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -1177,7 +1177,7 @@
 				phandle = <0x11c>;
 			};
 
-			can@0xf19f0000 {
+			can@f19f0000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -1189,7 +1189,7 @@
 				phandle = <0x11d>;
 			};
 
-			crl@0xeb5e0000 {
+			crl@eb5e0000 {
 				compatible = "xlnx,psxc_crl";
 				reg = <0x00 0xeb5e0000 0x00 0x300000 0x00>;
 				gpio-controller;
@@ -1197,13 +1197,13 @@
 				phandle = <0x1a>;
 			};
 
-			slcr@0xf1a20000 {
+			slcr@f1a20000 {
 				compatible = "xlnx,versal-lpd-iou-slcr";
 				reg = <0x00 0xf1a20000 0x00 0x20000 0x00>;
 				phandle = <0x11e>;
 			};
 
-			ipi@0xeb300000 {
+			ipi@eb300000 {
 				compatible = "xlnx,versal-ipi";
 				reg = <0x00 0xeb300000 0x00 0x100000 0x00>;
 				interrupts = <0xfbc 0xbd4 0x39 0x3a 0x3b 0x3c 0x3d 0x3e 0x3f 0xbd5
@@ -1213,7 +1213,7 @@
 				phandle = <0x11f>;
 			};
 
-			spi@0xf19c0000 {
+			spi@f19c0000 {
 				compatible = "cdns,spi-r1p6";
 				interrupts = <0x17>;
 				num-ss-bits = <0x04>;
@@ -1235,14 +1235,14 @@
 					blockdev-node-name = "spi0_flash0";
 					phandle = <0x121>;
 
-					spi0_flash0@0x00000000 {
+					spi0_flash0@00000000 {
 						label = "spi0_flash0";
 						reg = <0x00 0x100000>;
 					};
 				};
 			};
 
-			spi@0xf19d0000 {
+			spi@f19d0000 {
 				compatible = "cdns,spi-r1p6";
 				interrupts = <0x18>;
 				num-ss-bits = <0x04>;
@@ -1264,7 +1264,7 @@
 					blockdev-node-name = "spi1_flash0";
 					phandle = <0x123>;
 
-					spi1_flash0@0x00000000 {
+					spi1_flash0@00000000 {
 						label = "spi1_flash0";
 						reg = <0x00 0x100000>;
 					};
@@ -1284,7 +1284,7 @@
 				phandle = <0x124>;
 			};
 
-			timer@0xf1e60000 {
+			timer@f1e60000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2b 0x2b 0x2b>;
 				reg = <0x00 0xf1e60000 0x00 0x10000 0x00>;
@@ -1293,7 +1293,7 @@
 				phandle = <0x125>;
 			};
 
-			timer@0xf1e70000 {
+			timer@f1e70000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2c 0x2c 0x2c>;
 				reg = <0x00 0xf1e70000 0x00 0x10000 0x00>;
@@ -1302,7 +1302,7 @@
 				phandle = <0x126>;
 			};
 
-			timer@0xf1e80000 {
+			timer@f1e80000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2d 0x2d 0x2d>;
 				reg = <0x00 0xf1e80000 0x00 0x10000 0x00>;
@@ -1311,7 +1311,7 @@
 				phandle = <0x127>;
 			};
 
-			timer@0xf1e90000 {
+			timer@f1e90000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2e 0x2e 0x2e>;
 				reg = <0x00 0xf1e90000 0x00 0x10000 0x00>;
@@ -1326,7 +1326,7 @@
 				phandle = <0x21>;
 			};
 
-			dma-controller@0xebd00000 {
+			dma-controller@ebd00000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd00000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1348,7 +1348,7 @@
 				phandle = <0x23>;
 			};
 
-			dma-controller@0xebd10000 {
+			dma-controller@ebd10000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd10000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1370,7 +1370,7 @@
 				phandle = <0x24>;
 			};
 
-			dma-controller@0xebd20000 {
+			dma-controller@ebd20000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd20000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1392,7 +1392,7 @@
 				phandle = <0x25>;
 			};
 
-			dma-controller@0xebd30000 {
+			dma-controller@ebd30000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd30000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1414,7 +1414,7 @@
 				phandle = <0x26>;
 			};
 
-			dma-controller@0xebd40000 {
+			dma-controller@ebd40000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd40000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1436,7 +1436,7 @@
 				phandle = <0x27>;
 			};
 
-			dma-controller@0xebd50000 {
+			dma-controller@ebd50000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd50000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1458,7 +1458,7 @@
 				phandle = <0x28>;
 			};
 
-			dma-controller@0xebd60000 {
+			dma-controller@ebd60000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd60000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1480,7 +1480,7 @@
 				phandle = <0x29>;
 			};
 
-			dma-controller@0xebd70000 {
+			dma-controller@ebd70000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd70000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1496,13 +1496,13 @@
 				phandle = <0x130>;
 			};
 
-			afi_fm@0xeb9b0000 {
+			afi_fm@eb9b0000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xeb9b0000 0x00 0x10000 0x00>;
 			};
 
 			lpd_i2c_wrapper {
-				ps_i2c@0xf1940000 {
+				ps_i2c@f1940000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1512,7 +1512,7 @@
 					phandle = <0x131>;
 				};
 
-				ps_i2c@0xf1950000 {
+				ps_i2c@f1950000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1522,7 +1522,7 @@
 					phandle = <0x132>;
 				};
 
-				ps_i2c@0xf1960000 {
+				ps_i2c@f1960000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1532,7 +1532,7 @@
 					phandle = <0x133>;
 				};
 
-				ps_i2c@0xf1970000 {
+				ps_i2c@f1970000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1542,7 +1542,7 @@
 					phandle = <0x134>;
 				};
 
-				ps_i2c@0xf1980000 {
+				ps_i2c@f1980000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1552,7 +1552,7 @@
 					phandle = <0x135>;
 				};
 
-				ps_i2c@0xf1990000 {
+				ps_i2c@f1990000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1562,7 +1562,7 @@
 					phandle = <0x136>;
 				};
 
-				ps_i2c@0xf19a0000 {
+				ps_i2c@f19a0000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1572,7 +1572,7 @@
 					phandle = <0x137>;
 				};
 
-				ps_i2c@0xf19b0000 {
+				ps_i2c@f19b0000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1592,7 +1592,7 @@
 				phandle = <0x139>;
 			};
 
-			lpd_slcr@0xeb410000 {
+			lpd_slcr@eb410000 {
 				compatible = "xlnx.psxc-lpx-slcr";
 				reg = <0x00 0xeb410000 0x00 0x100000 0x00>;
 				interrupt-parent = <0x08>;
@@ -1613,7 +1613,7 @@
 				phandle = <0x1b>;
 			};
 
-			lpd_slcr_secure@0xeb510000 {
+			lpd_slcr_secure@eb510000 {
 				compatible = "xlnx.versal2-psxc-lpx-slcr-secure";
 				reg = <0x00 0xeb510000 0x00 0x40000 0x00>;
 				gpio-controller;
@@ -1621,7 +1621,7 @@
 				phandle = <0x22>;
 			};
 
-			lpd_iou_slcr_secure@0xf1a40000 {
+			lpd_iou_slcr_secure@f1a40000 {
 				compatible = "xlnx,versal-lpd-iou-slcr-secure";
 				reg = <0x00 0xf1a40000 0x00 0x10000 0x00>;
 				memattr-gem0 = <0x18>;
@@ -1631,7 +1631,7 @@
 				phandle = <0x13a>;
 			};
 
-			wwdt@0xeb000000 {
+			wwdt@eb000000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xeb000000 0x00 0x10000 0x00>;
 				interrupts = <0xec 0xed 0xee 0xef>;
@@ -1640,7 +1640,7 @@
 				phandle = <0x13b>;
 			};
 
-			lpd_gpio@0xf1a50000 {
+			lpd_gpio@f1a50000 {
 				#gpio-cells = <0x01>;
 				compatible = "xlnx,zynqmp-gpio";
 				gpio-controller;
@@ -1704,7 +1704,7 @@
 				phandle = <0x13d>;
 			};
 
-			rpu_cluster@0xeb580000 {
+			rpu_cluster@eb580000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb580000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1713,7 +1713,7 @@
 				phandle = <0x36>;
 			};
 
-			rpu_ctrl_a0@0xeb588000 {
+			rpu_ctrl_a0@eb588000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb588000 0x00 0x4000 0x00>;
@@ -1725,7 +1725,7 @@
 				phandle = <0xe5>;
 			};
 
-			rpu_ctrl_a1@0xeb58c000 {
+			rpu_ctrl_a1@eb58c000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb58c000 0x00 0x4000 0x00>;
@@ -1737,7 +1737,7 @@
 				phandle = <0xe8>;
 			};
 
-			rpu_cluster@0xeb590000 {
+			rpu_cluster@eb590000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb590000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1746,7 +1746,7 @@
 				phandle = <0x3a>;
 			};
 
-			rpu_ctrl_b0@0xeb598000 {
+			rpu_ctrl_b0@eb598000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb598000 0x00 0x4000 0x00>;
@@ -1758,7 +1758,7 @@
 				phandle = <0xeb>;
 			};
 
-			rpu_ctrl_b1@0xeb59c000 {
+			rpu_ctrl_b1@eb59c000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb59c000 0x00 0x4000 0x00>;
@@ -1770,7 +1770,7 @@
 				phandle = <0xee>;
 			};
 
-			rpu_cluster@0xeb5a0000 {
+			rpu_cluster@eb5a0000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb5a0000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1779,7 +1779,7 @@
 				phandle = <0x3e>;
 			};
 
-			rpu_ctrl_c0@0xeb5a8000 {
+			rpu_ctrl_c0@eb5a8000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5a8000 0x00 0x4000 0x00>;
@@ -1791,7 +1791,7 @@
 				phandle = <0xf1>;
 			};
 
-			rpu_ctrl_c1@0xeb5ac000 {
+			rpu_ctrl_c1@eb5ac000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5ac000 0x00 0x4000 0x00>;
@@ -1803,7 +1803,7 @@
 				phandle = <0xf4>;
 			};
 
-			rpu_cluster@0xeb5b0000 {
+			rpu_cluster@eb5b0000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb5b0000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1812,7 +1812,7 @@
 				phandle = <0x42>;
 			};
 
-			rpu_ctrl_d0@0xeb5b8000 {
+			rpu_ctrl_d0@eb5b8000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5b8000 0x00 0x4000 0x00>;
@@ -1824,7 +1824,7 @@
 				phandle = <0xf7>;
 			};
 
-			rpu_ctrl_d1@0xeb5bc000 {
+			rpu_ctrl_d1@eb5bc000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5bc000 0x00 0x4000 0x00>;
@@ -1836,7 +1836,7 @@
 				phandle = <0xfa>;
 			};
 
-			rpu_cluster@0xeb5c0000 {
+			rpu_cluster@eb5c0000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb5c0000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1845,7 +1845,7 @@
 				phandle = <0x46>;
 			};
 
-			rpu_ctrl_e0@0xeb5c8000 {
+			rpu_ctrl_e0@eb5c8000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5c8000 0x00 0x4000 0x00>;
@@ -1857,7 +1857,7 @@
 				phandle = <0xfd>;
 			};
 
-			rpu_ctrl_e1@0xeb5cc000 {
+			rpu_ctrl_e1@eb5cc000 {
 				compatible = "xlnx,psxc-rpu-cluster-core";
 				version = <0x01>;
 				reg = <0x00 0xeb5cc000 0x00 0x4000 0x00>;
@@ -1882,7 +1882,7 @@
 				phandle = <0x13e>;
 			};
 
-			i3c0@0xf1940000 {
+			i3c0@f1940000 {
 				compatible = "dwc.i3c";
 				reg = <0x00 0xf1948000 0x00 0x10000 0x00>;
 				num-devices = <0x0b>;
@@ -1890,7 +1890,7 @@
 				phandle = <0x13f>;
 			};
 
-			i3c1@0xf1950000 {
+			i3c1@f1950000 {
 				compatible = "dwc.i3c";
 				reg = <0x00 0xf1958000 0x00 0x10000 0x00>;
 				slave-static-addr-en = <0x01>;
@@ -1899,7 +1899,7 @@
 				phandle = <0x140>;
 			};
 
-			ocm_ctrl@0xeb960000 {
+			ocm_ctrl@eb960000 {
 				compatible = "xlnx,zynqmp-ocmc";
 				interrupts = <0x11>;
 				memsize = <0x80000>;
@@ -1908,7 +1908,7 @@
 				phandle = <0x141>;
 			};
 
-			ocm_ctrl@0xeb9d0000 {
+			ocm_ctrl@eb9d0000 {
 				compatible = "xlnx,zynqmp-ocmc";
 				interrupts = <0x0e>;
 				memsize = <0x80000>;
@@ -1917,7 +1917,7 @@
 				phandle = <0x142>;
 			};
 
-			ocm_ctrl@0xeaa00000 {
+			ocm_ctrl@eaa00000 {
 				compatible = "xlnx,zynqmp-ocmc";
 				interrupts = <0x0f>;
 				memsize = <0x80000>;
@@ -1926,7 +1926,7 @@
 				phandle = <0x143>;
 			};
 
-			can@0xf1a00000 {
+			can@f1a00000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -1938,7 +1938,7 @@
 				phandle = <0x144>;
 			};
 
-			can@0xf1a10000 {
+			can@f1a10000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -1950,7 +1950,7 @@
 				phandle = <0x145>;
 			};
 
-			timer@0xf1ea0000 {
+			timer@f1ea0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2f 0x2f 0x2f>;
 				reg = <0x00 0xf1ea0000 0x00 0x10000 0x00>;
@@ -1959,7 +1959,7 @@
 				phandle = <0x146>;
 			};
 
-			timer@0xf1eb0000 {
+			timer@f1eb0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x30 0x30 0x30>;
 				reg = <0x00 0xf1eb0000 0x00 0x10000 0x00>;
@@ -1968,7 +1968,7 @@
 				phandle = <0x147>;
 			};
 
-			timer@0xf1ec0000 {
+			timer@f1ec0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x31 0x31 0x31>;
 				reg = <0x00 0xf1ec0000 0x00 0x10000 0x00>;
@@ -1977,7 +1977,7 @@
 				phandle = <0x148>;
 			};
 
-			timer@0xf1ed0000 {
+			timer@f1ed0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x32 0x32 0x32>;
 				reg = <0x00 0xf1ed0000 0x00 0x10000 0x00>;
@@ -1992,7 +1992,7 @@
 				phandle = <0x49>;
 			};
 
-			dma-controller@0xebd80000 {
+			dma-controller@ebd80000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd80000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2014,7 +2014,7 @@
 				phandle = <0x4a>;
 			};
 
-			dma-controller@0xebd90000 {
+			dma-controller@ebd90000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd90000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2036,7 +2036,7 @@
 				phandle = <0x4b>;
 			};
 
-			dma-controller@0xebda0000 {
+			dma-controller@ebda0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebda0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2058,7 +2058,7 @@
 				phandle = <0x4c>;
 			};
 
-			dma-controller@0xebdb0000 {
+			dma-controller@ebdb0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebdb0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2080,7 +2080,7 @@
 				phandle = <0x4d>;
 			};
 
-			dma-controller@0xebdc0000 {
+			dma-controller@ebdc0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebdc0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2102,7 +2102,7 @@
 				phandle = <0x4e>;
 			};
 
-			dma-controller@0xebdd0000 {
+			dma-controller@ebdd0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebdd0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2124,7 +2124,7 @@
 				phandle = <0x4f>;
 			};
 
-			dma-controller@0xebde0000 {
+			dma-controller@ebde0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebde0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2146,7 +2146,7 @@
 				phandle = <0x50>;
 			};
 
-			dma-controller@0xebdf0000 {
+			dma-controller@ebdf0000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebdf0000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -2162,7 +2162,7 @@
 				phandle = <0x151>;
 			};
 
-			wwdt@0xeb010000 {
+			wwdt@eb010000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xeb010000 0x00 0x10000 0x00>;
 				interrupts = <0xf0 0xf1 0xf2 0xf3>;
@@ -2171,7 +2171,7 @@
 				phandle = <0x152>;
 			};
 
-			lpd_afi_fs@0xeb560000 {
+			lpd_afi_fs@eb560000 {
 				compatible = "xlnx.psxc_afi_fs";
 				reg = <0x00 0xeb560000 0x00 0x8000 0x00>;
 				phandle = <0x153>;
@@ -2192,44 +2192,44 @@
 			ranges;
 			phandle = <0x0b>;
 
-			afi_fm@0xec880000 {
+			afi_fm@ec880000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xec880000 0x00 0x10000 0x00>;
 			};
 
-			afi_fm@0xec8a0000 {
+			afi_fm@ec8a0000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xec8a0000 0x00 0x10000 0x00>;
 			};
 
-			cpm_crcpm@0xfca00000 {
+			cpm_crcpm@fca00000 {
 				compatible = "xlnx,versal_cpm_crcpm";
 				reg = <0x00 0xfca00000 0x00 0x10000 0x00>;
 			};
 
-			cpm_pcsr@0xfcff0000 {
+			cpm_pcsr@fcff0000 {
 				compatible = "xlnx,versal_cpm_pcsr";
 				reg = <0x00 0xfcff0000 0x00 0x10000 0x00>;
 			};
 
-			cpm_slcr_secure@0xfca20000 {
+			cpm_slcr_secure@fca20000 {
 				compatible = "xlnx.cpm_slcr_secure";
 				reg = <0x00 0xfca20000 0x00 0x10000 0x00>;
 			};
 
-			fpd_slcr@0xec8c0000 {
+			fpd_slcr@ec8c0000 {
 				compatible = "xlnx,versal-fpd-slcr";
 				interrupts = <0x8c>;
 				reg = <0x00 0xec8c0000 0x00 0x10000 0x00>;
 			};
 
-			fpd_slcr_secure@0xec8c0000 {
+			fpd_slcr_secure@ec8c0000 {
 				compatible = "xlnx,versal-fpd-slcr-secure";
 				interrupts = <0x8c>;
 				reg = <0x00 0xec8e0000 0x00 0x10000 0x00>;
 			};
 
-			watchdog@0xecc10000 {
+			watchdog@ecc10000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xecc10000 0x00 0x10000 0x00>;
 				interrupts = <0xec 0xed 0xee 0xef>;
@@ -2238,7 +2238,7 @@
 				phandle = <0x154>;
 			};
 
-			apu_cluster@0xecc00000 {
+			apu_cluster@ecc00000 {
 				#gpio-cells = <0x01>;
 				gpio-controller;
 				compatible = "xlnx,versal-apu-ctrl";
@@ -2251,7 +2251,7 @@
 				phandle = <0x155>;
 			};
 
-			apu_cluster@0xecd00000 {
+			apu_cluster@ecd00000 {
 				#gpio-cells = <0x01>;
 				gpio-controller;
 				compatible = "xlnx,versal-apu-ctrl";
@@ -2264,7 +2264,7 @@
 				phandle = <0x156>;
 			};
 
-			apu_cluster@0xece00000 {
+			apu_cluster@ece00000 {
 				#gpio-cells = <0x01>;
 				gpio-controller;
 				compatible = "xlnx,versal-apu-ctrl";
@@ -2277,7 +2277,7 @@
 				phandle = <0x157>;
 			};
 
-			apu_cluster@0xecf00000 {
+			apu_cluster@ecf00000 {
 				#gpio-cells = <0x01>;
 				gpio-controller;
 				compatible = "xlnx,versal-apu-ctrl";
@@ -2290,7 +2290,7 @@
 				phandle = <0x158>;
 			};
 
-			cmn600ae@0xa0000000 {
+			cmn600ae@a0000000 {
 				compatible = "arm,cmn600ae";
 				reg = <0x00 0xa0000000 0x00 0x3000000 0x00>;
 			};
@@ -2329,12 +2329,12 @@
 				phandle = <0x159>;
 			};
 
-			dummy_pcie@0x6_0000_0000 {
+			dummy_pcie@6_0000_0000 {
 				compatible = "PCI";
 				phandle = <0x68>;
 			};
 
-			apu_pcil@0xecb10000 {
+			apu_pcil@ecb10000 {
 				compatible = "xlnx.apu_pcil";
 				reg = <0x00 0xecb10000 0x00 0x10000 0x00>;
 				core-mask = <0x3333>;
@@ -2355,7 +2355,7 @@
 				phandle = <0x15a>;
 			};
 
-			lpd_afi_fs@0xec860000 {
+			lpd_afi_fs@ec860000 {
 				compatible = "xlnx.psxc_afi_fs";
 				reg = <0x00 0xec860000 0x00 0x8000 0x00>;
 				phandle = <0x15b>;
@@ -2400,7 +2400,7 @@
 					};
 				};
 
-				ethernet@0xed920000 {
+				ethernet@ed920000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					#priority-cells = <0x00>;
@@ -2415,7 +2415,7 @@
 					phandle = <0x15d>;
 				};
 
-				usb_drd@0xedec0000 {
+				usb_drd@edec0000 {
 					compatible = "usb_dwc3";
 					reg = <0x00 0xedec0000 0x00 0x10000 0x00>;
 					interrupts = <0xbf 0xc0>;
@@ -2426,13 +2426,13 @@
 					phandle = <0x15e>;
 				};
 
-				mmi_crs@0xedc00000 {
+				mmi_crs@edc00000 {
 					compatible = "xlnx.mmi_crx";
 					reg = <0x00 0xedc00000 0x00 0x10000 0x00>;
 					phandle = <0x15f>;
 				};
 
-				mmi_pcsr@0xeb2f0000 {
+				mmi_pcsr@eb2f0000 {
 					compatible = "xlnx,noc-npi-dev";
 					reg = <0x00 0xeb2f0000 0x00 0x10000 0x01>;
 					map-size = <0x10000>;
@@ -2441,7 +2441,7 @@
 					phandle = <0x160>;
 				};
 
-				mmi_gtyp@0xed900000 {
+				mmi_gtyp@ed900000 {
 					compatible = "xlnx,noc-npi-dev";
 					reg = <0x00 0xed900000 0x00 0x20000 0x01>;
 					map-size = <0xed900000>;
@@ -2458,7 +2458,7 @@
 					phandle = <0x162>;
 				};
 
-				trng@0xede80000 {
+				trng@ede80000 {
 					doc-status = "complete";
 					compatible = "xlnx,versal-trng";
 					reg = <0x00 0xede80000 0x00 0x10000 0x00>;
@@ -2467,14 +2467,14 @@
 					phandle = <0x6c>;
 				};
 
-				udh_slcr@0xedea0000 {
+				udh_slcr@edea0000 {
 					compatible = "xlnx.mmi_udh_slcr";
 					reg = <0x00 0xedea0000 0x00 0x8000 0x00>;
 					gpios = <0x6c 0x00>;
 					phandle = <0x163>;
 				};
 
-				udh_pll@0xede90000 {
+				udh_pll@ede90000 {
 					compatible = "xlnx.mmi_udh_pll";
 					reg = <0x00 0xede90000 0x00 0x10000 0x00>;
 					phandle = <0x164>;
@@ -2488,7 +2488,7 @@
 					phandle = <0x165>;
 				};
 
-				loader_write_cpu0_0x1@0xedc30440 {
+				loader_write_cpu0_0x1@edc30440 {
 					compatible = "loader";
 					addr = <0xedc30440>;
 					data = <0x01>;
@@ -2500,7 +2500,7 @@
 					phandle = <0x166>;
 				};
 
-				loader_write_cpu0_0x7F@0xedc30444 {
+				loader_write_cpu0_0x7F@edc30444 {
 					compatible = "loader";
 					addr = <0xedc30444>;
 					data = <0x7f>;
@@ -2512,7 +2512,7 @@
 					phandle = <0x167>;
 				};
 
-				loader_write_cpu0_0x1@0xedc3044c {
+				loader_write_cpu0_0x1@edc3044c {
 					compatible = "loader";
 					addr = <0xedc3044c>;
 					data = <0x01>;
@@ -2524,7 +2524,7 @@
 					phandle = <0x168>;
 				};
 
-				loader_write_cpu0_0x1@0xedc30450 {
+				loader_write_cpu0_0x1@edc30450 {
 					compatible = "loader";
 					addr = <0xedc30450>;
 					data = <0x01>;
@@ -2536,7 +2536,7 @@
 					phandle = <0x169>;
 				};
 
-				loader_write_cpu0_0x1@0xedc30460 {
+				loader_write_cpu0_0x1@edc30460 {
 					compatible = "loader";
 					addr = <0xedc30460>;
 					data = <0x01>;
@@ -2548,7 +2548,7 @@
 					phandle = <0x16a>;
 				};
 
-				loader_write_cpu0_0x7f@0xedc30464 {
+				loader_write_cpu0_0x7f@edc30464 {
 					compatible = "loader";
 					addr = <0xedc30464>;
 					data = <0x7f>;
@@ -2560,7 +2560,7 @@
 					phandle = <0x16b>;
 				};
 
-				loader_write_cpu0_0x1@0xedc3046c {
+				loader_write_cpu0_0x1@edc3046c {
 					compatible = "loader";
 					addr = <0xedc3046c>;
 					data = <0x01>;
@@ -2572,7 +2572,7 @@
 					phandle = <0x16c>;
 				};
 
-				loader_write_cpu0_0x1@0xedc30470 {
+				loader_write_cpu0_0x1@edc30470 {
 					compatible = "loader";
 					addr = <0xedc30470>;
 					data = <0x01>;
@@ -2584,7 +2584,7 @@
 					phandle = <0x16d>;
 				};
 
-				loader_write_cpu0_0x3@0xed0a0098 {
+				loader_write_cpu0_0x3@ed0a0098 {
 					compatible = "loader";
 					addr = <0xed0a0098>;
 					data = <0x03>;
@@ -2660,7 +2660,7 @@
 				phandle = <0x16f>;
 			};
 
-			xppu_pmc_npi@0xf1300000 {
+			xppu_pmc_npi@f1300000 {
 				compatible = "xlnx,versal-xppu";
 				reg-extended = <0x0c 0x00 0xf1300000 0x00 0x10000 0x00 0x0c 0x00
 						0xf6000000 0x00 0x1000000 0x02 0x0c
@@ -2670,7 +2670,7 @@
 				phandle = <0x170>;
 			};
 
-			xppu_pmc@0xf1310000 {
+			xppu_pmc@f1310000 {
 				compatible = "xlnx,versal-xppu";
 				reg-extended = <0x0c 0x00 0xf1310000 0x00 0x10000 0x00
 						0x0d 0x00 0xf1000000 0x00 0x1000000 0x02
@@ -2702,7 +2702,7 @@
 				reg = <0x00 0x00 0xffffffff 0xffffffff 0xffffffff>;
 			};
 
-			xmpu_pmc_cfu@0xf1340000 {
+			xmpu_pmc_cfu@f1340000 {
 				compatible = "xlnx,versal-xmpu";
 				reg-extended = <0x74 0x00 0xf1340000 0x00 0x10000 0x00
 						0x71 0x00 0xf12b0000 0x00 0x11000 0x02
@@ -2713,7 +2713,7 @@
 				phandle = <0x172>;
 			};
 
-			pmx_err_mng@0xf1110000 {
+			pmx_err_mng@f1110000 {
 				compatible = "xlnx,pmxc-err-mng";
 				reg = <0x00 0xf1130000 0x00 0x10000 0x01>;
 				gpios = <0x76 0x03 0x1b 0x2e 0x1b 0x2f 0x1b 0x30 0x1b 0x31>;
@@ -2721,7 +2721,7 @@
 				phandle = <0x173>;
 			};
 
-			intpmxc_config@0xf1400000 {
+			intpmxc_config@f1400000 {
 				compatible = "xlnx.pmxc_intpmx_config";
 				reg = <0x00 0xf1400000 0x00 0x300000 0x00>;
 				phandle = <0x174>;
@@ -2738,7 +2738,7 @@
 			doc-status = "partial";
 			phandle = <0x16>;
 
-			pmc_iou_slcr@0xf1060000 {
+			pmc_iou_slcr@f1060000 {
 				doc-status = "partial";
 				compatible = "xlnx,versal-pmx-iou-slcr";
 				reg = <0x00 0xf1060000 0x00 0x1000 0x00>;
@@ -2748,7 +2748,7 @@
 				phandle = <0x85>;
 			};
 
-			pmc_iou_slcr_secure@0xf1070000 {
+			pmc_iou_slcr_secure@f1070000 {
 				compatible = "xlnx,versal-pmc-iou-slcr-secure";
 				reg = <0x00 0xf1070000 0x00 0x10000 0x00>;
 				interrupts = <0xbca>;
@@ -2775,7 +2775,7 @@
 				phandle = <0x7f>;
 			};
 
-			pmc_qspi@0xf1030000 {
+			pmc_qspi@f1030000 {
 				doc-status = "complete";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
@@ -2805,7 +2805,7 @@
 					drive-index = <0x00>;
 					phandle = <0x177>;
 
-					qspi_flash_lcs_lb@0x00000000 {
+					qspi_flash_lcs_lb@00000000 {
 						label = "qspi_flash_lcs_lb";
 						reg = <0x00 0x2000000>;
 					};
@@ -2822,7 +2822,7 @@
 					drive-index = <0x01>;
 					phandle = <0x178>;
 
-					qspi_flash_lcs_ub@0x00000000 {
+					qspi_flash_lcs_ub@00000000 {
 						label = "qspi_flash_lcs_ub";
 						reg = <0x00 0x2000000>;
 					};
@@ -2839,7 +2839,7 @@
 					drive-index = <0x02>;
 					phandle = <0x179>;
 
-					qspi_flash_ucs_lb@0x00000000 {
+					qspi_flash_ucs_lb@00000000 {
 						label = "qspi_flash_ucs_lb";
 						reg = <0x00 0x2000000>;
 					};
@@ -2856,7 +2856,7 @@
 					drive-index = <0x03>;
 					phandle = <0x17a>;
 
-					qspi_flash_ucs_ub@0x00000000 {
+					qspi_flash_ucs_ub@00000000 {
 						label = "qspi_flash_ucs_ub";
 						reg = <0x00 0x2000000>;
 					};
@@ -2889,7 +2889,7 @@
 				phandle = <0x84>;
 			};
 
-			spi@0xf1010000 {
+			spi@f1010000 {
 				doc-status = "complete";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
@@ -2914,7 +2914,7 @@
 					drive-index = <0x04>;
 					phandle = <0x17c>;
 
-					ospi_flash_lcs_lb@0x00000000 {
+					ospi_flash_lcs_lb@00000000 {
 						label = "ospi_flash_lcs_lb";
 						reg = <0x00 0x2000000>;
 					};
@@ -2931,7 +2931,7 @@
 					drive-index = <0x05>;
 					phandle = <0x17d>;
 
-					ospi_flash_lcs_ub@0x00000000 {
+					ospi_flash_lcs_ub@00000000 {
 						label = "ospi_flash_lcs_ub";
 						reg = <0x00 0x2000000>;
 					};
@@ -2948,7 +2948,7 @@
 					drive-index = <0x06>;
 					phandle = <0x17e>;
 
-					ospi_flash_ucs_lb@0x00000000 {
+					ospi_flash_ucs_lb@00000000 {
 						label = "ospi_flash_ucs_lb";
 						reg = <0x00 0x2000000>;
 					};
@@ -2965,14 +2965,14 @@
 					drive-index = <0x07>;
 					phandle = <0x17f>;
 
-					ospi_flash_ucs_ub@0x00000000 {
+					ospi_flash_ucs_ub@00000000 {
 						label = "ospi_flash_ucs_ub";
 						reg = <0x00 0x2000000>;
 					};
 				};
 			};
 
-			gpio_mr_mux@0xc0000000 {
+			gpio_mr_mux@c0000000 {
 				doc-status = "complete";
 				compatible = "gpio-mr-mux";
 				reg = <0x00 0xc0000000 0x00 0x20000000 0x00>;
@@ -2985,7 +2985,7 @@
 				phandle = <0x180>;
 			};
 
-			pmc_gpio@0xf1020000 {
+			pmc_gpio@f1020000 {
 				#gpio-cells = <0x01>;
 				compatible = "xlnx,zynqmp-gpio";
 				gpio-controller;
@@ -2995,7 +2995,7 @@
 				phandle = <0x181>;
 			};
 
-			mmc@0xf1040000 {
+			mmc@f1040000 {
 				doc-status = "complete";
 				compatible = "xilinx,zynqmp-sdhci\0generic-sdhci";
 				drive-index = <0x00>;
@@ -3015,7 +3015,7 @@
 				phandle = <0x182>;
 			};
 
-			mmc@0xf1050000 {
+			mmc@f1050000 {
 				doc-status = "complete";
 				compatible = "xlnx,versalnet-emmc";
 				drive-index = <0x01>;
@@ -3036,7 +3036,7 @@
 				phandle = <0x183>;
 			};
 
-			pmc_tap@0xf11a0000 {
+			pmc_tap@f11a0000 {
 				doc-status = "complete";
 				doc-comments = "Just a stub.";
 				compatible = "xlnx,pmc-tap";
@@ -3049,7 +3049,7 @@
 			};
 
 			pmc_i2c_wrapper {
-				pmc_i2c@0xf1000000 {
+				pmc_i2c@f1000000 {
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
 					interrupts = <0xcb>;
 					reg-extended = <0x16 0x00 0xf1000000 0x00 0x10000 0x00>;
@@ -3060,14 +3060,14 @@
 				};
 			};
 
-			wwdt@0xf03f0000 {
+			wwdt@f03f0000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xf03f0000 0x00 0x10000 0x00>;
 				pclk = <0x5f5e100>;
 				phandle = <0x186>;
 			};
 
-			pmc_ufshc@0xf10b0000 {
+			pmc_ufshc@f10b0000 {
 				compatible = "ufshc-sysbus";
 				reg = <0x00 0xf10b0000 0x00 0x10000 0x00>;
 				interrupts = <0xea>;
@@ -3090,7 +3090,7 @@
 				phandle = <0x87>;
 			};
 
-			ufs_reg@0xf1060000 {
+			ufs_reg@f1060000 {
 				compatible = "dwc.ufs_reg";
 				reg = <0x00 0xf1061000 0x00 0x100 0x01>;
 				gpios = <0x88 0x00>;
@@ -3110,7 +3110,7 @@
 Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x6f>;
 
-			trng@0xf1230000 {
+			trng@f1230000 {
 				doc-status = "complete";
 				compatible = "xlnx,versal-trng";
 				reg = <0x00 0xf1230000 0x00 0x1000 0x00>;
@@ -3186,7 +3186,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x8a>;
 			};
 
-			pmc_sha@0xf1210000 {
+			pmc_sha@f1210000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu_sha3";
 				reg = <0x00 0xf1210000 0x00 0x100 0x00>;
@@ -3194,7 +3194,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x90>;
 			};
 
-			pmc_aes@0xf11e0000 {
+			pmc_aes@f11e0000 {
 				doc-status = "in-progress";
 				#gpio-cells = <0x01>;
 				gpio-controller;
@@ -3218,7 +3218,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				};
 			};
 
-			pmc_rsa@0xf1200000 {
+			pmc_rsa@f1200000 {
 				doc-status = "complete";
 				compatible = "xlnx,versal-ecdsa-rsa";
 				reg = <0x00 0xf1200000 0x00 0x6c 0x00>;
@@ -3227,7 +3227,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x18a>;
 			};
 
-			xlnx_pmc_efuse_cache@0xf1250000 {
+			xlnx_pmc_efuse_cache@f1250000 {
 				doc-status = "complete";
 				compatible = "xlnx,pmx_efuse_cache";
 				reg = <0x00 0xf1250000 0x00 0x10000 0x00>;
@@ -3245,7 +3245,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x97>;
 			};
 
-			pmc_efuse@0xf1240000 {
+			pmc_efuse@f1240000 {
 				doc-status = "complete";
 				compatible = "xlnx,pmx_efuse_ctrl";
 				#gpio-cells = <0x02>;
@@ -3267,7 +3267,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				};
 			};
 
-			pmc_bbram@0xf11f0000 {
+			pmc_bbram@f11f0000 {
 				doc-status = "partial";
 				doc-limitations = "Missing AES key connections.";
 				compatible = "xlnx,bbram-ctrl";
@@ -3278,7 +3278,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x98>;
 			};
 
-			pmc_sbi@0xf1220000 {
+			pmc_sbi@f1220000 {
 				doc-status = "complete";
 				compatible = "pmc,slave-boot";
 				reg = <0x00 0xf1220000 0x00 0x10000 0x00 0x00 0xf2100000
@@ -3289,7 +3289,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x91>;
 			};
 
-			pmc_sha1@0xf1800000 {
+			pmc_sha1@f1800000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu_sha2";
 				reg = <0x00 0xf1800000 0x00 0x10000 0x00>;
@@ -3328,7 +3328,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x70>;
 
-			pmc_clk_rst@0xf1260000 {
+			pmc_clk_rst@f1260000 {
 				doc-status = "partial";
 				compatible = "xlnx,pmx_crp";
 				reg = <0x00 0xf1260000 0x00 0x80000 0x00>;
@@ -3338,7 +3338,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x7e>;
 			};
 
-			pmc_int@0xf1400000 {
+			pmc_int@f1400000 {
 				doc-status = "partial";
 				compatible = "xlnx,versal-pmc-int";
 				reg = <0x00 0xf1400000 0x00 0x300000 0x00>;
@@ -3351,7 +3351,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				gpios = <0x7e 0x02>;
 			};
 
-			pmc_global@0xf1110000 {
+			pmc_global@f1110000 {
 				doc-status = "partial";
 				#gpio-cells = <0x01>;
 				gpio-controller;
@@ -3375,7 +3375,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x18d>;
 			};
 
-			pmc_analog@0xf1160000 {
+			pmc_analog@f1160000 {
 				compatible = "xlnx,pmxc_anlg";
 				reg = <0x00 0xf1160000 0x00 0x40000 0x00>;
 				interrupts-extended = <0x07 0x00 0x13 0x00>;
@@ -3383,7 +3383,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x18e>;
 			};
 
-			pmc_sysmon@0xf1270000 {
+			pmc_sysmon@f1270000 {
 				compatible = "xlnx,pmc-sysmon";
 				reg = <0x00 0xf1270000 0x00 0x30000 0x00>;
 				interrupts = <0x12 0x79>;
@@ -3454,13 +3454,13 @@ Cannot continue.\nTry installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x71>;
 
-			noc_npi_nir@0xf6000000 {
+			noc_npi_nir@f6000000 {
 				compatible = "xlnx.npi-nir";
 				reg = <0x00 0xf6000000 0x00 0x10000 0x01>;
 				phandle = <0x191>;
 			};
 
-			npi_ddrmc_ub0@0xf62c0000 {
+			npi_ddrmc_ub0@f62c0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf62c0000 0x00 0x40000 0x01>;
@@ -3470,7 +3470,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x192>;
 			};
 
-			npi_ddrmc_main0@0xf6290000 {
+			npi_ddrmc_main0@f6290000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6290000 0x00 0x10000 0x01>;
@@ -3478,7 +3478,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xcf>;
 			};
 
-			npi_ddrmc_noc0@0xf62a0000 {
+			npi_ddrmc_noc0@f62a0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf62a0000 0x00 0x20000 0xffffffff>;
@@ -3486,7 +3486,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x193>;
 			};
 
-			npi_ddrmc_ub1@0xf63b0000 {
+			npi_ddrmc_ub1@f63b0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf63b0000 0x00 0x40000 0x01>;
@@ -3496,7 +3496,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x194>;
 			};
 
-			npi_ddrmc_main1@0xf6380000 {
+			npi_ddrmc_main1@f6380000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6380000 0x00 0x10000 0x01>;
@@ -3504,7 +3504,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x195>;
 			};
 
-			npi_ddrmc_noc1@0xf6390000 {
+			npi_ddrmc_noc1@f6390000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6390000 0x00 0x20000 0xffffffff>;
@@ -3512,7 +3512,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x196>;
 			};
 
-			npi_ddrmc_ub2@0xf6940000 {
+			npi_ddrmc_ub2@f6940000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf6940000 0x00 0x40000 0x01>;
@@ -3522,7 +3522,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x197>;
 			};
 
-			npi_ddrmc_main2@0xf6910000 {
+			npi_ddrmc_main2@f6910000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6910000 0x00 0x10000 0x01>;
@@ -3530,7 +3530,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x198>;
 			};
 
-			npi_ddrmc_noc2@0xf6920000 {
+			npi_ddrmc_noc2@f6920000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6920000 0x00 0x20000 0xffffffff>;
@@ -3538,7 +3538,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x199>;
 			};
 
-			npi_ddrmc_ub3@0xf6a20000 {
+			npi_ddrmc_ub3@f6a20000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf6a20000 0x00 0x40000 0x01>;
@@ -3548,7 +3548,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x19a>;
 			};
 
-			npi_ddrmc_main3@0xf69f0000 {
+			npi_ddrmc_main3@f69f0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf69f0000 0x00 0x10000 0x01>;
@@ -3556,7 +3556,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x19b>;
 			};
 
-			npi_ddrmc_noc3@0xf6a00000 {
+			npi_ddrmc_noc3@f6a00000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6a00000 0x00 0x20000 0xffffffff>;
@@ -3564,7 +3564,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x19c>;
 			};
 
-			npi_ddrmc_xmpu0@0xf62a0000 {
+			npi_ddrmc_xmpu0@f62a0000 {
 				compatible = "xlnx,versal-ddrmc-xmpu";
 				reg-extended = <0x71 0x00 0xf62b2000 0x00 0x10000 0x01 0x0d 0x00
 						0x00 0x00 0x80000000 0x00>;
@@ -3574,7 +3574,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x19d>;
 			};
 
-			npi_me@0xf6540000 {
+			npi_me@f6540000 {
 				compatible = "xlnx.aie2p_s_npi";
 				reg = <0x00 0xf6540000 0x00 0x10000 0x01>;
 				reset-gpios = <0x7e 0x0f>;
@@ -3587,20 +3587,20 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x19f>;
 			};
 
-			cfu_fdro@0xf12c2000 {
+			cfu_fdro@f12c2000 {
 				compatible = "xlnx,versal-cfu-fdro";
 				reg = <0x00 0xf12c2000 0x00 0x1000 0x00>;
 				phandle = <0xa4>;
 			};
 
-			cfu_sfr@0xf12c1000 {
+			cfu_sfr@f12c1000 {
 				compatible = "xlnx,versal-cfu-sfr";
 				reg = <0x00 0xf12c1000 0x00 0x1000 0x00>;
 				cfu = <0xa3>;
 				phandle = <0x1a0>;
 			};
 
-			cframe0_reg@0xf12d0000 {
+			cframe0_reg@f12d0000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d0000 0x00 0x1000 0x00 0x00 0xf12d1000
 				       0x00 0x1000 0x00>;
@@ -3616,7 +3616,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xa5>;
 			};
 
-			cframe1_reg@0xf12d2000 {
+			cframe1_reg@f12d2000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d2000 0x00 0x1000 0x00 0x00 0xf12d3000
 				       0x00 0x1000 0x00>;
@@ -3632,7 +3632,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xa6>;
 			};
 
-			cframe2_reg@0xf12d4000 {
+			cframe2_reg@f12d4000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d4000 0x00 0x1000 0x00 0x00 0xf12d5000
 				       0x00 0x1000 0x00>;
@@ -3648,7 +3648,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xa7>;
 			};
 
-			cframe3_reg@0xf12d6000 {
+			cframe3_reg@f12d6000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d6000 0x00 0x1000 0x00 0x00 0xf12d7000
 				       0x00 0x1000 0x00>;
@@ -3664,7 +3664,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xa8>;
 			};
 
-			cframe4_reg@0xf12d8000 {
+			cframe4_reg@f12d8000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d8000 0x00 0x1000 0x00 0x00 0xf12d9000
 				       0x00 0x1000 0x00>;
@@ -3673,7 +3673,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xa9>;
 			};
 
-			cframe5_reg@0xf12da000 {
+			cframe5_reg@f12da000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12da000 0x00 0x1000 0x00 0x00 0xf12db000
 				       0x00 0x1000 0x00>;
@@ -3682,7 +3682,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xaa>;
 			};
 
-			cframe6_reg@0xf12dc000 {
+			cframe6_reg@f12dc000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12dc000 0x00 0x1000 0x00 0x00 0xf12dd000
 				       0x00 0x1000 0x00>;
@@ -3691,7 +3691,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xab>;
 			};
 
-			cframe7_reg@0xf12de000 {
+			cframe7_reg@f12de000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12de000 0x00 0x1000 0x00 0x00 0xf12df000
 				       0x00 0x1000 0x00>;
@@ -3700,7 +3700,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xac>;
 			};
 
-			cframe8_reg@0xf12e0000 {
+			cframe8_reg@f12e0000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e0000 0x00 0x1000 0x00 0x00 0xf12e1000
 				       0x00 0x1000 0x00>;
@@ -3709,7 +3709,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xad>;
 			};
 
-			cframe9_reg@0xf12e2000 {
+			cframe9_reg@f12e2000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e2000 0x00 0x1000 0x00 0x00 0xf12e3000
 				       0x00 0x1000 0x00>;
@@ -3718,7 +3718,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xae>;
 			};
 
-			cframe10_reg@0xf12e4000 {
+			cframe10_reg@f12e4000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e4000 0x00 0x1000 0x00 0x00 0xf12e5000
 				       0x00 0x1000 0x00>;
@@ -3727,7 +3727,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xaf>;
 			};
 
-			cframe11_reg@0xf12e6000 {
+			cframe11_reg@f12e6000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e6000 0x00 0x1000 0x00 0x00 0xf12e7000
 				       0x00 0x1000 0x00>;
@@ -3736,7 +3736,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xb0>;
 			};
 
-			cframe12_reg@0xf12e8000 {
+			cframe12_reg@f12e8000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e8000 0x00 0x1000 0x00 0x00 0xf12e9000
 				       0x00 0x1000 0x00>;
@@ -3745,7 +3745,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xb1>;
 			};
 
-			cframe13_reg@0xf12ea000 {
+			cframe13_reg@f12ea000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12ea000 0x00 0x1000 0x00 0x00 0xf12eb000
 				       0x00 0x1000 0x00>;
@@ -3754,7 +3754,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xb2>;
 			};
 
-			cframe14_reg@0xf12ec000 {
+			cframe14_reg@f12ec000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12ec000 0x00 0x1000 0x00 0x00 0xf12ed000
 				       0x00 0x1000 0x00>;
@@ -3763,7 +3763,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xb3>;
 			};
 
-			cframe_bcast_reg@0xf12ee000 {
+			cframe_bcast_reg@f12ee000 {
 				compatible = "xlnx.cframe-bcast-reg";
 				reg = <0x00 0xf12ee000 0x00 0x1000 0x00 0x00 0xf12ef000
 				       0x00 0x1000 0x00>;
@@ -3785,26 +3785,26 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1a1>;
 			};
 
-			gtyp_npi_slave_0@0xf65a0000 {
+			gtyp_npi_slave_0@f65a0000 {
 				compatible = "xlnx,xlnx,gtyp_npi_slave";
 				reg = <0x00 0xf65a0000 0x00 0x20000 0x00>;
 			};
 
-			gtyp_npi_slave_1@0xf66c0000 {
+			gtyp_npi_slave_1@f66c0000 {
 				compatible = "xlnx,xlnx,gtyp_npi_slave";
 				reg = <0x00 0xf66c0000 0x00 0x20000 0x00>;
 			};
 
-			gtyp_npi_slave_2@0xf6720000 {
+			gtyp_npi_slave_2@f6720000 {
 				compatible = "xlnx,xlnx,gtyp_npi_slave";
 				reg = <0x00 0xf6720000 0x00 0x20000 0x00>;
 			};
 
-			dummy_cfu_mem@0xf12b0000 {
+			dummy_cfu_mem@f12b0000 {
 				compatible = "qemu:memory-region";
 				phandle = <0x75>;
 
-				cfu@0x0 {
+				cfu@0 {
 					doc-status = "partial";
 					doc-comments = "Stub";
 					doc-limitations = "No way to extract CFRAME data.";
@@ -3828,7 +3828,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x72>;
 
-			rtc@0xf12a0000 {
+			rtc@f12a0000 {
 				doc-status = "complete";
 				doc-comments = "Versal PMC RTC";
 				compatible = "xlnx,zynqmp-rtc";
@@ -3885,7 +3885,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			};
 		};
 
-		crf@0xec200000 {
+		crf@ec200000 {
 			compatible = "xlnx,versal-psx-crf";
 			reg-extended = <0x0b 0x00 0xec200000 0x00 0x100000 0x00>;
 			gpio-controller;
@@ -3917,7 +3917,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			ranges;
 			phandle = <0x51>;
 
-			asu_instr_ram@0xebe00000 {
+			asu_instr_ram@ebe00000 {
 				compatible = "qemu:memory-region";
 				device_type = "memory";
 				qemu,ram = <0x01>;
@@ -3925,7 +3925,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1a3>;
 			};
 
-			io-module@0xebe80000 {
+			io-module@ebe80000 {
 				#address-cells = <0x02>;
 				#size-cells = <0x01>;
 				#priority-cells = <0x00>;
@@ -4062,33 +4062,33 @@ Cannot continue.\nTry installing libgcrypt.";
 				};
 			};
 
-			asu_mdm_uart@0xebef0000 {
+			asu_mdm_uart@ebef0000 {
 				compatible = "xlnx,xps-uartlite";
 				reg = <0x00 0xebef0000 0x00 0x10 0x01>;
 				chardev = "serial4";
 				phandle = <0x1a9>;
 			};
 
-			asu_global@0xebf80000 {
+			asu_global@ebf80000 {
 				compatible = "xlnx,asu_global";
 				reg = <0x00 0xebf80000 0x00 0x20000 0x00>;
 				gpios = <0xb9 0x00>;
 				phandle = <0x1aa>;
 			};
 
-			asu_global_pmc@0xebf80000 {
+			asu_global_pmc@ebf80000 {
 				compatible = "xlnx,asu_global_pmc";
 				reg = <0x00 0xebf90000 0x00 0x20000 0x00>;
 				phandle = <0x1ab>;
 			};
 
-			asu_local@0xebe8e000 {
+			asu_local@ebe8e000 {
 				compatible = "xlnx,asu_local_reg";
 				reg = <0x00 0xebe8e000 0x00 0x2000 0x00>;
 				phandle = <0x1ac>;
 			};
 
-			asu_sss@0xebe8e000 {
+			asu_sss@ebe8e000 {
 				compatible = "asu-sss";
 				reg = <0x00 0xebe8e000 0x00 0x08 0x01>;
 				stream-connected-dma0 = <0xba>;
@@ -4099,7 +4099,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xbe>;
 			};
 
-			asu_dma_src@0xebe8c000 {
+			asu_dma_src@ebe8c000 {
 				compatible = "zynqmp,csu-dma";
 				reg = <0x00 0xebe8c000 0x00 0x800 0x00>;
 				interrupts = <0x13>;
@@ -4111,7 +4111,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1ad>;
 			};
 
-			asu_dma_dst@0xebe8c000 {
+			asu_dma_dst@ebe8c000 {
 				compatible = "zynqmp,csu-dma";
 				reg = <0x00 0xebe8c800 0x00 0x800 0x00>;
 				interrupts = <0x13>;
@@ -4123,7 +4123,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xba>;
 			};
 
-			asu_dma1_src@0xebe8d000 {
+			asu_dma1_src@ebe8d000 {
 				compatible = "zynqmp,csu-dma";
 				reg = <0x00 0xebe8d000 0x00 0x800 0x00>;
 				interrupts = <0x13>;
@@ -4135,7 +4135,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1ae>;
 			};
 
-			asu_dma1_dst@0xebe8d000 {
+			asu_dma1_dst@ebe8d000 {
 				compatible = "zynqmp,csu-dma";
 				reg = <0x00 0xebe8d800 0x00 0x800 0x00>;
 				interrupts = <0x14>;
@@ -4147,7 +4147,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xbd>;
 			};
 
-			asu_xmpu@0xebf60000 {
+			asu_xmpu@ebf60000 {
 				compatible = "xlnx,versal-xmpu";
 				reg-extended = <0x51 0x00 0xebf60000 0x00 0x10000 0x00 0x51 0x00
 						0xebe40000 0x00 0x20000 0x02>;
@@ -4157,7 +4157,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1af>;
 			};
 
-			asu_aes@0xebe88000 {
+			asu_aes@ebe88000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu-aes";
 				reg = <0x00 0xebe88000 0x00 0x2000 0x00>;
@@ -4169,7 +4169,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xb9>;
 			};
 
-			asu_kv@0xebe8a000 {
+			asu_kv@ebe8a000 {
 				compatible = "xlnx,asu-kv";
 				reg = <0x00 0xebe8a000 0x00 0x2000 0x00>;
 				pmxc-aes = <0x8f>;
@@ -4177,7 +4177,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x94>;
 			};
 
-			asu_sha3@0xebf40000 {
+			asu_sha3@ebf40000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu_sha3";
 				reg = <0x00 0xebf40000 0x00 0x10000 0x00>;
@@ -4185,14 +4185,14 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0xbc>;
 			};
 
-			asu_sha2@0xebf30000 {
+			asu_sha2@ebf30000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu_sha2";
 				reg = <0x00 0xebf30000 0x00 0x10000 0x00>;
 				phandle = <0xbb>;
 			};
 
-			pmc_rsa@0xebf50000 {
+			pmc_rsa@ebf50000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu-ecdsa-rsa";
 				reg = <0x00 0xebf50000 0x00 0x10000 0x00>;
@@ -4200,7 +4200,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1b0>;
 			};
 
-			trng@0xebf20000 {
+			trng@ebf20000 {
 				doc-status = "complete";
 				compatible = "xlnx-asu-trng";
 				reg = <0x00 0xebf10000 0x00 0x20000 0x00>;
@@ -4208,7 +4208,7 @@ Cannot continue.\nTry installing libgcrypt.";
 				phandle = <0x1b1>;
 			};
 
-			asu_ecc@0xebf00000 {
+			asu_ecc@ebf00000 {
 				doc-status = "complete";
 				compatible = "xlnx,asu_ecc";
 				reg = <0x00 0xebf00000 0x00 0x10000 0x00>;
@@ -4234,7 +4234,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			reg = <0x00 0x00 0xffffffff 0xffffffff 0x00>;
 		};
 
-		pmc_rom@0xf0000000 {
+		pmc_rom@f0000000 {
 			reg = <0x00 0xf0000000 0x00 0x40000 0x01>;
 			compatible = "qemu:memory-region";
 			container = <0xa1>;
@@ -4243,7 +4243,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1b3>;
 		};
 
-		ppu0_ram@0xf0060000 {
+		ppu0_ram@f0060000 {
 			reg = <0x00 0xf0060000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			container = <0xa1>;
@@ -4699,21 +4699,21 @@ Cannot continue.\nTry installing libgcrypt.";
 		doc-status = "partial";
 		phandle = <0xc9>;
 
-		ddrmc0_ram_data@0x1c000 {
+		ddrmc0_ram_data@1c000 {
 			reg = <0x00 0x1c000 0x00 0x4000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x1ca>;
 		};
 
-		ddrmc0_ram_instr@0x20000 {
+		ddrmc0_ram_instr@20000 {
 			reg = <0x00 0x20000 0x00 0x20000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x1cb>;
 		};
 
-		ddrmc0_ram_exchange@0x08000 {
+		ddrmc0_ram_exchange@08000 {
 			reg = <0x00 0x8000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
@@ -4850,21 +4850,21 @@ Cannot continue.\nTry installing libgcrypt.";
 		ranges;
 		phandle = <0x1d1>;
 
-		ddrmc1_ram_data@0x1c000 {
+		ddrmc1_ram_data@1c000 {
 			reg = <0x00 0x1c000 0x00 0x4000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x1d2>;
 		};
 
-		ddrmc1_ram_instr@0x20000 {
+		ddrmc1_ram_instr@20000 {
 			reg = <0x00 0x20000 0x00 0x20000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x1d3>;
 		};
 
-		ddrmc1_ram_exchange@0x08000 {
+		ddrmc1_ram_exchange@08000 {
 			reg = <0x00 0x8000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
@@ -5062,7 +5062,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x103>;
 	};
 
-	memory@0x50000000000ull {
+	memory@50000000000 {
 		compatible = "qemu:memory-region";
 		device_type = "memory";
 		container = <0x0d>;
@@ -5101,7 +5101,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1d9>;
 	};
 
-	xram_mem@0xbbe00000 {
+	xram_mem@bbe00000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x1da>;
 	};
@@ -5115,12 +5115,12 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1db>;
 	};
 
-	pmc_ram@0xf2000000 {
+	pmc_ram@f2000000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x73>;
 	};
 
-	pmc_ram_bank_0@0x0 {
+	pmc_ram_bank_0@0 {
 		compatible = "qemu:memory-region";
 		container = <0x73>;
 		qemu,ram = <0x01>;
@@ -5128,7 +5128,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1dc>;
 	};
 
-	pmc_ppu1_ram@0xf0200000 {
+	pmc_ppu1_ram@f0200000 {
 		compatible = "qemu:memory-region";
 		container = <0x0d>;
 		qemu,ram = <0x01>;
@@ -5136,7 +5136,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1dd>;
 	};
 
-	pmc_ppu1_ram@0xf0280000 {
+	pmc_ppu1_ram@f0280000 {
 		compatible = "qemu:memory-region";
 		container = <0x0d>;
 		qemu,ram = <0x01>;
@@ -5144,14 +5144,14 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1de>;
 	};
 
-	ppu0_mdm_uart@0xf0110000 {
+	ppu0_mdm_uart@f0110000 {
 		doc-status = "complete";
 		compatible = "xlnx,xps-uartlite";
 		reg-extended = <0xa1 0x00 0xf0110000 0x00 0x10 0x01>;
 		chardev = "serial0";
 	};
 
-	ppu1_mdm_uart@0xf0310000 {
+	ppu1_mdm_uart@f0310000 {
 		doc-status = "complete";
 		compatible = "xlnx,xps-uartlite";
 		reg-extended = <0xc4 0x00 0xf0310000 0x00 0x10 0x01>;
@@ -5707,7 +5707,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		priority = <0xffffffff>;
 		phandle = <0x1e5>;
 
-		interrupt-controller@0xe2000000 {
+		interrupt-controller@e2000000 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -5734,7 +5734,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x01>;
 		};
 
-		git_its@0xe2040000 {
+		git_its@e2040000 {
 			compatible = "arm-gicv3-its";
 			reg = <0x00 0xe2040000 0x00 0x20000 0x00>;
 			parent-gicv3 = <0x01>;
@@ -5789,7 +5789,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0x1e7>;
 	};
 
-	ddr@0x00000000 {
+	ddr@00000000 {
 		compatible = "qemu:memory-region";
 		container = <0x102>;
 		qemu,ram = <0x01>;
@@ -5797,7 +5797,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		phandle = <0xa2>;
 	};
 
-	ddr_2@0x800000000ull {
+	ddr_2@800000000 {
 		compatible = "qemu:memory-region-spec";
 		container = <0x103>;
 		qemu,ram = <0x01>;
@@ -5892,7 +5892,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0xd1>;
 
-		rpu_gic_a@0x0 {
+		rpu_gic_a@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -5919,7 +5919,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0x104>;
 
-		rpu_gic_b@0x0 {
+		rpu_gic_b@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -5946,7 +5946,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0x105>;
 
-		rpu_gic_c@0x0 {
+		rpu_gic_c@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -5973,7 +5973,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0x106>;
 
-		rpu_gic_d@0x0 {
+		rpu_gic_d@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -6000,7 +6000,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0x107>;
 
-		rpu_gic_e@0x0 {
+		rpu_gic_e@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -6027,7 +6027,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x35>;
 
-		atcm_rpu_core0@0x00000 {
+		atcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x35>;
 			qemu,ram = <0x01>;
@@ -6035,7 +6035,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1eb>;
 		};
 
-		btcm_rpu_core0@0x00000 {
+		btcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x35>;
 			qemu,ram = <0x01>;
@@ -6043,7 +6043,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1ec>;
 		};
 
-		ctcm_rpu_core0@0x00000 {
+		ctcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x35>;
 			qemu,ram = <0x01>;
@@ -6059,7 +6059,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x37>;
 
-		atcm_rpu_core1@0x00000 {
+		atcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x37>;
 			qemu,ram = <0x01>;
@@ -6067,7 +6067,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1ee>;
 		};
 
-		btcm_rpu_core1@0x00000 {
+		btcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x37>;
 			qemu,ram = <0x01>;
@@ -6075,7 +6075,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1ef>;
 		};
 
-		ctcm_rpu_core1@0x00000 {
+		ctcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x37>;
 			qemu,ram = <0x01>;
@@ -6091,7 +6091,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x39>;
 
-		atcm_rpu_core2@0x00000 {
+		atcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x39>;
 			qemu,ram = <0x01>;
@@ -6099,7 +6099,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f1>;
 		};
 
-		btcm_rpu_core2@0x00000 {
+		btcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x39>;
 			qemu,ram = <0x01>;
@@ -6107,7 +6107,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f2>;
 		};
 
-		ctcm_rpu_core2@0x00000 {
+		ctcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x39>;
 			qemu,ram = <0x01>;
@@ -6123,7 +6123,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x3b>;
 
-		atcm_rpu_core3@0x00000 {
+		atcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3b>;
 			qemu,ram = <0x01>;
@@ -6131,7 +6131,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f4>;
 		};
 
-		btcm_rpu_core3@0x00000 {
+		btcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3b>;
 			qemu,ram = <0x01>;
@@ -6139,7 +6139,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f5>;
 		};
 
-		ctcm_rpu_core3@0x00000 {
+		ctcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3b>;
 			qemu,ram = <0x01>;
@@ -6155,7 +6155,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x3d>;
 
-		atcm_rpu_core4@0x00000 {
+		atcm_rpu_core4@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3d>;
 			qemu,ram = <0x01>;
@@ -6163,7 +6163,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f7>;
 		};
 
-		btcm_rpu_core4@0x00000 {
+		btcm_rpu_core4@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3d>;
 			qemu,ram = <0x01>;
@@ -6171,7 +6171,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1f8>;
 		};
 
-		ctcm_rpu_core4@0x00000 {
+		ctcm_rpu_core4@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3d>;
 			qemu,ram = <0x01>;
@@ -6187,7 +6187,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x3f>;
 
-		atcm_rpu_core5@0x00000 {
+		atcm_rpu_core5@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3f>;
 			qemu,ram = <0x01>;
@@ -6195,7 +6195,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1fa>;
 		};
 
-		btcm_rpu_core5@0x00000 {
+		btcm_rpu_core5@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3f>;
 			qemu,ram = <0x01>;
@@ -6203,7 +6203,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1fb>;
 		};
 
-		ctcm_rpu_core5@0x00000 {
+		ctcm_rpu_core5@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x3f>;
 			qemu,ram = <0x01>;
@@ -6219,7 +6219,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x41>;
 
-		atcm_rpu_core6@0x00000 {
+		atcm_rpu_core6@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x41>;
 			qemu,ram = <0x01>;
@@ -6227,7 +6227,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1fd>;
 		};
 
-		btcm_rpu_core6@0x00000 {
+		btcm_rpu_core6@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x41>;
 			qemu,ram = <0x01>;
@@ -6235,7 +6235,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x1fe>;
 		};
 
-		ctcm_rpu_core6@0x00000 {
+		ctcm_rpu_core6@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x41>;
 			qemu,ram = <0x01>;
@@ -6251,7 +6251,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x43>;
 
-		atcm_rpu_core7@0x00000 {
+		atcm_rpu_core7@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x43>;
 			qemu,ram = <0x01>;
@@ -6259,7 +6259,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x200>;
 		};
 
-		btcm_rpu_core7@0x00000 {
+		btcm_rpu_core7@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x43>;
 			qemu,ram = <0x01>;
@@ -6267,7 +6267,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x201>;
 		};
 
-		ctcm_rpu_core7@0x00000 {
+		ctcm_rpu_core7@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x43>;
 			qemu,ram = <0x01>;
@@ -6283,7 +6283,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x45>;
 
-		atcm_rpu_core8@0x00000 {
+		atcm_rpu_core8@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x45>;
 			qemu,ram = <0x01>;
@@ -6291,7 +6291,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x203>;
 		};
 
-		btcm_rpu_core8@0x00000 {
+		btcm_rpu_core8@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x45>;
 			qemu,ram = <0x01>;
@@ -6299,7 +6299,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x204>;
 		};
 
-		ctcm_rpu_core8@0x00000 {
+		ctcm_rpu_core8@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x45>;
 			qemu,ram = <0x01>;
@@ -6315,7 +6315,7 @@ Cannot continue.\nTry installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0x47>;
 
-		atcm_rpu_core9@0x00000 {
+		atcm_rpu_core9@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x47>;
 			qemu,ram = <0x01>;
@@ -6323,7 +6323,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x206>;
 		};
 
-		btcm_rpu_core9@0x00000 {
+		btcm_rpu_core9@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x47>;
 			qemu,ram = <0x01>;
@@ -6331,7 +6331,7 @@ Cannot continue.\nTry installing libgcrypt.";
 			phandle = <0x207>;
 		};
 
-		ctcm_rpu_core9@0x00000 {
+		ctcm_rpu_core9@00000 {
 			compatible = "qemu:memory-region";
 			container = <0x47>;
 			qemu,ram = <0x01>;
@@ -7231,12 +7231,12 @@ Cannot continue.\nTry installing libgcrypt.";
 		};
 	};
 
-	ocm_mem@0xbbe00000 {
+	ocm_mem@bbe00000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x0e>;
 	};
 
-	asu_data_ram_wrapper@0xebe40000 {
+	asu_data_ram_wrapper@ebe40000 {
 		compatible = "qemu:memory-region";
 		phandle = <0xbf>;
 
@@ -7290,228 +7290,228 @@ Cannot continue.\nTry installing libgcrypt.";
 		amba = "/amba_root@0/amba@0";
 		xmpu_ocm = "/amba_root@0/amba@0/xmpu_ocm@0";
 		xmpu_ocm2 = "/amba_root@0/amba@0/xmpu_ocm2@0";
-		loader_write_0xF1110880 = "/amba_root@0/amba@0/loader_write_cpu0_0x1@0xF1110880";
-		loader_write_0xFD1A0050 = "/amba_root@0/amba@0/loader_write_cpu0_0x5@0xFD1A0050";
-		loader_write_0xF111010C = "/amba_root@0/amba@0/loader_write_cpu0_0xFF@0xF111010C";
+		loader_write_0xF1110880 = "/amba_root@0/amba@0/loader_write_cpu0_0x1@F1110880";
+		loader_write_0xFD1A0050 = "/amba_root@0/amba@0/loader_write_cpu0_0x5@FD1A0050";
+		loader_write_0xF111010C = "/amba_root@0/amba@0/loader_write_cpu0_0xFF@F111010C";
 		s_axi_tcm_a = "/amba_root@0/amba@0/s_axi_tcm_a@0";
 		s_axi_tcm_b = "/amba_root@0/amba@0/s_axi_tcm_b@0";
 		s_axi_tcm_c = "/amba_root@0/amba@0/s_axi_tcm_c@0";
 		s_axi_tcm_d = "/amba_root@0/amba@0/s_axi_tcm_d@0";
 		s_axi_tcm_e = "/amba_root@0/amba@0/s_axi_tcm_e@0";
-		loader_write_0xF12B0100 = "/amba_root@0/amba@0/loader_write_cpu0_0x80C@0xF12B0100";
-		loader_write_0xF1260320 = "/amba_root@0/amba@0/loader_write_cpu0_0x77@0xF1260320";
+		loader_write_0xF12B0100 = "/amba_root@0/amba@0/loader_write_cpu0_0x80C@F12B0100";
+		loader_write_0xF1260320 = "/amba_root@0/amba@0/loader_write_cpu0_0x77@F1260320";
 		xmpu_ocm1 = "/amba_root@0/amba@0/xmpu_ocm1@0";
 		xmpu_ocm3 = "/amba_root@0/amba@0/xmpu_ocm3@0";
 		amba_lpd = "/amba_root@0/amba_lpd@0";
-		xppu_lpd = "/amba_root@0/amba_lpd@0/xppu_lpd@0xeb990000";
-		gem0 = "/amba_root@0/amba_lpd@0/ethernet@0xf1a60000";
-		gem1 = "/amba_root@0/amba_lpd@0/ethernet@0xf1a70000";
-		serial0 = "/amba_root@0/amba_lpd@0/serial@0xf1920000";
-		serial1 = "/amba_root@0/amba_lpd@0/serial@0xf1930000";
+		xppu_lpd = "/amba_root@0/amba_lpd@0/xppu_lpd@eb990000";
+		gem0 = "/amba_root@0/amba_lpd@0/ethernet@f1a60000";
+		gem1 = "/amba_root@0/amba_lpd@0/ethernet@f1a70000";
+		serial0 = "/amba_root@0/amba_lpd@0/serial@f1920000";
+		serial1 = "/amba_root@0/amba_lpd@0/serial@f1930000";
 		canfdbus0 = "/amba_root@0/amba_lpd@0/canfdbus@0";
-		can0 = "/amba_root@0/amba_lpd@0/can@0xf19e0000";
-		can1 = "/amba_root@0/amba_lpd@0/can@0xf19f0000";
-		crl = "/amba_root@0/amba_lpd@0/crl@0xeb5e0000";
-		lpd_iou_slcr = "/amba_root@0/amba_lpd@0/slcr@0xf1a20000";
-		ipi = "/amba_root@0/amba_lpd@0/ipi@0xeb300000";
-		spi0 = "/amba_root@0/amba_lpd@0/spi@0xf19c0000";
-		spi0_flash0 = "/amba_root@0/amba_lpd@0/spi@0xf19c0000/spi0_flash0@0";
-		spi1 = "/amba_root@0/amba_lpd@0/spi@0xf19d0000";
-		spi1_flash0 = "/amba_root@0/amba_lpd@0/spi@0xf19d0000/spi1_flash0@0";
+		can0 = "/amba_root@0/amba_lpd@0/can@f19e0000";
+		can1 = "/amba_root@0/amba_lpd@0/can@f19f0000";
+		crl = "/amba_root@0/amba_lpd@0/crl@eb5e0000";
+		lpd_iou_slcr = "/amba_root@0/amba_lpd@0/slcr@f1a20000";
+		ipi = "/amba_root@0/amba_lpd@0/ipi@eb300000";
+		spi0 = "/amba_root@0/amba_lpd@0/spi@f19c0000";
+		spi0_flash0 = "/amba_root@0/amba_lpd@0/spi@f19c0000/spi0_flash0@0";
+		spi1 = "/amba_root@0/amba_lpd@0/spi@f19d0000";
+		spi1_flash0 = "/amba_root@0/amba_lpd@0/spi@f19d0000/spi1_flash0@0";
 		dwc3_0 = "/amba_root@0/amba_lpd@0/usb2@USB2_0_XHCI";
-		ttc0 = "/amba_root@0/amba_lpd@0/timer@0xf1e60000";
-		ttc1 = "/amba_root@0/amba_lpd@0/timer@0xf1e70000";
-		ttc2 = "/amba_root@0/amba_lpd@0/timer@0xf1e80000";
-		ttc3 = "/amba_root@0/amba_lpd@0/timer@0xf1e90000";
+		ttc0 = "/amba_root@0/amba_lpd@0/timer@f1e60000";
+		ttc1 = "/amba_root@0/amba_lpd@0/timer@f1e70000";
+		ttc2 = "/amba_root@0/amba_lpd@0/timer@f1e80000";
+		ttc3 = "/amba_root@0/amba_lpd@0/timer@f1e90000";
 		adma0_mattr = "/amba_root@0/amba_lpd@0/adma0mattr";
-		adma0 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd00000";
+		adma0 = "/amba_root@0/amba_lpd@0/dma-controller@ebd00000";
 		adma1_mattr = "/amba_root@0/amba_lpd@0/adma1mattr";
-		adma1 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd10000";
+		adma1 = "/amba_root@0/amba_lpd@0/dma-controller@ebd10000";
 		adma2_mattr = "/amba_root@0/amba_lpd@0/adma2mattr";
-		adma2 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd20000";
+		adma2 = "/amba_root@0/amba_lpd@0/dma-controller@ebd20000";
 		adma3_mattr = "/amba_root@0/amba_lpd@0/adma3mattr";
-		adma3 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd30000";
+		adma3 = "/amba_root@0/amba_lpd@0/dma-controller@ebd30000";
 		adma4_mattr = "/amba_root@0/amba_lpd@0/adma4mattr";
-		adma4 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd40000";
+		adma4 = "/amba_root@0/amba_lpd@0/dma-controller@ebd40000";
 		adma5_mattr = "/amba_root@0/amba_lpd@0/adma5mattr";
-		adma5 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd50000";
+		adma5 = "/amba_root@0/amba_lpd@0/dma-controller@ebd50000";
 		adma6_mattr = "/amba_root@0/amba_lpd@0/adma6mattr";
-		adma6 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd60000";
+		adma6 = "/amba_root@0/amba_lpd@0/dma-controller@ebd60000";
 		adma7_mattr = "/amba_root@0/amba_lpd@0/adma7mattr";
-		adma7 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd70000";
-		ps_i2c0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1940000";
-		ps_i2c1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1950000";
-		ps_i2c2 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1960000";
-		ps_i2c3 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1970000";
-		ps_i2c4 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1980000";
-		ps_i2c5 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf1990000";
-		ps_i2c6 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf19a0000";
-		ps_i2c7 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@0xf19b0000";
+		adma7 = "/amba_root@0/amba_lpd@0/dma-controller@ebd70000";
+		ps_i2c0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1940000";
+		ps_i2c1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1950000";
+		ps_i2c2 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1960000";
+		ps_i2c3 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1970000";
+		ps_i2c4 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1980000";
+		ps_i2c5 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f1990000";
+		ps_i2c6 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f19a0000";
+		ps_i2c7 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c@f19b0000";
 		ocm_ctrl0 = "/amba_root@0/amba_lpd@0/ocm_ctrl@OCM";
-		lpd_slcr = "/amba_root@0/amba_lpd@0/lpd_slcr@0xeb410000";
-		lpd_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_slcr_secure@0xeb510000";
-		lpd_iou_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_iou_slcr_secure@0xf1a40000";
-		lpd_wwdt0 = "/amba_root@0/amba_lpd@0/wwdt@0xeb000000";
-		lpd_gpio = "/amba_root@0/amba_lpd@0/lpd_gpio@0xf1a50000";
+		lpd_slcr = "/amba_root@0/amba_lpd@0/lpd_slcr@eb410000";
+		lpd_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_slcr_secure@eb510000";
+		lpd_iou_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_iou_slcr_secure@f1a40000";
+		lpd_wwdt0 = "/amba_root@0/amba_lpd@0/wwdt@eb000000";
+		lpd_gpio = "/amba_root@0/amba_lpd@0/lpd_gpio@f1a50000";
 		rpu_ctrl = "/amba_root@0/amba_lpd@0/rpu_ctrl@0";
-		rpu_ctrl_a = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb580000";
-		rpu_ctrl_a0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a0@0xeb588000";
-		rpu_ctrl_a1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a1@0xeb58c000";
-		rpu_ctrl_b = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb590000";
-		rpu_ctrl_b0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b0@0xeb598000";
-		rpu_ctrl_b1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b1@0xeb59c000";
-		rpu_ctrl_c = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb5a0000";
-		rpu_ctrl_c0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_c0@0xeb5a8000";
-		rpu_ctrl_c1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_c1@0xeb5ac000";
-		rpu_ctrl_d = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb5b0000";
-		rpu_ctrl_d0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_d0@0xeb5b8000";
-		rpu_ctrl_d1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_d1@0xeb5bc000";
-		rpu_ctrl_e = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb5c0000";
-		rpu_ctrl_e0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_e0@0xeb5c8000";
-		rpu_ctrl_e1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_e1@0xeb5cc000";
+		rpu_ctrl_a = "/amba_root@0/amba_lpd@0/rpu_cluster@eb580000";
+		rpu_ctrl_a0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a0@eb588000";
+		rpu_ctrl_a1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a1@eb58c000";
+		rpu_ctrl_b = "/amba_root@0/amba_lpd@0/rpu_cluster@eb590000";
+		rpu_ctrl_b0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b0@eb598000";
+		rpu_ctrl_b1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b1@eb59c000";
+		rpu_ctrl_c = "/amba_root@0/amba_lpd@0/rpu_cluster@eb5a0000";
+		rpu_ctrl_c0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_c0@eb5a8000";
+		rpu_ctrl_c1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_c1@eb5ac000";
+		rpu_ctrl_d = "/amba_root@0/amba_lpd@0/rpu_cluster@eb5b0000";
+		rpu_ctrl_d0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_d0@eb5b8000";
+		rpu_ctrl_d1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_d1@eb5bc000";
+		rpu_ctrl_e = "/amba_root@0/amba_lpd@0/rpu_cluster@eb5c0000";
+		rpu_ctrl_e0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_e0@eb5c8000";
+		rpu_ctrl_e1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_e1@eb5cc000";
 		dwc3_1 = "/amba_root@0/amba_lpd@0/usb2@USB2_0_XHCI1";
-		psx_i3c0 = "/amba_root@0/amba_lpd@0/i3c0@0xf1940000";
-		psx_i3c1 = "/amba_root@0/amba_lpd@0/i3c1@0xf1950000";
-		ocm_ctrl1 = "/amba_root@0/amba_lpd@0/ocm_ctrl@0xeb960000";
-		ocm_ctrl2 = "/amba_root@0/amba_lpd@0/ocm_ctrl@0xeb9d0000";
-		ocm_ctrl3 = "/amba_root@0/amba_lpd@0/ocm_ctrl@0xeaa00000";
-		can2 = "/amba_root@0/amba_lpd@0/can@0xf1a00000";
-		can3 = "/amba_root@0/amba_lpd@0/can@0xf1a10000";
-		ttc4 = "/amba_root@0/amba_lpd@0/timer@0xf1ea0000";
-		ttc5 = "/amba_root@0/amba_lpd@0/timer@0xf1eb0000";
-		ttc6 = "/amba_root@0/amba_lpd@0/timer@0xf1ec0000";
-		ttc7 = "/amba_root@0/amba_lpd@0/timer@0xf1ed0000";
+		psx_i3c0 = "/amba_root@0/amba_lpd@0/i3c0@f1940000";
+		psx_i3c1 = "/amba_root@0/amba_lpd@0/i3c1@f1950000";
+		ocm_ctrl1 = "/amba_root@0/amba_lpd@0/ocm_ctrl@eb960000";
+		ocm_ctrl2 = "/amba_root@0/amba_lpd@0/ocm_ctrl@eb9d0000";
+		ocm_ctrl3 = "/amba_root@0/amba_lpd@0/ocm_ctrl@eaa00000";
+		can2 = "/amba_root@0/amba_lpd@0/can@f1a00000";
+		can3 = "/amba_root@0/amba_lpd@0/can@f1a10000";
+		ttc4 = "/amba_root@0/amba_lpd@0/timer@f1ea0000";
+		ttc5 = "/amba_root@0/amba_lpd@0/timer@f1eb0000";
+		ttc6 = "/amba_root@0/amba_lpd@0/timer@f1ec0000";
+		ttc7 = "/amba_root@0/amba_lpd@0/timer@f1ed0000";
 		sdma0_mattr = "/amba_root@0/amba_lpd@0/sdma0mattr";
-		sdma0 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd80000";
+		sdma0 = "/amba_root@0/amba_lpd@0/dma-controller@ebd80000";
 		sdma1_mattr = "/amba_root@0/amba_lpd@0/sdma1mattr";
-		sdma1 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd90000";
+		sdma1 = "/amba_root@0/amba_lpd@0/dma-controller@ebd90000";
 		sdma2_mattr = "/amba_root@0/amba_lpd@0/sdma2mattr";
-		sdma2 = "/amba_root@0/amba_lpd@0/dma-controller@0xebda0000";
+		sdma2 = "/amba_root@0/amba_lpd@0/dma-controller@ebda0000";
 		sdma3_mattr = "/amba_root@0/amba_lpd@0/sdma3mattr";
-		sdma3 = "/amba_root@0/amba_lpd@0/dma-controller@0xebdb0000";
+		sdma3 = "/amba_root@0/amba_lpd@0/dma-controller@ebdb0000";
 		sdma4_mattr = "/amba_root@0/amba_lpd@0/sdma4mattr";
-		sdma4 = "/amba_root@0/amba_lpd@0/dma-controller@0xebdc0000";
+		sdma4 = "/amba_root@0/amba_lpd@0/dma-controller@ebdc0000";
 		sdma5_mattr = "/amba_root@0/amba_lpd@0/sdma5mattr";
-		sdma5 = "/amba_root@0/amba_lpd@0/dma-controller@0xebdd0000";
+		sdma5 = "/amba_root@0/amba_lpd@0/dma-controller@ebdd0000";
 		sdma6_mattr = "/amba_root@0/amba_lpd@0/sdma6mattr";
-		sdma6 = "/amba_root@0/amba_lpd@0/dma-controller@0xebde0000";
+		sdma6 = "/amba_root@0/amba_lpd@0/dma-controller@ebde0000";
 		sdma7_mattr = "/amba_root@0/amba_lpd@0/sdma7mattr";
-		sdma7 = "/amba_root@0/amba_lpd@0/dma-controller@0xebdf0000";
-		lpd_wwdt1 = "/amba_root@0/amba_lpd@0/wwdt@0xeb010000";
-		lpd_afi_fs = "/amba_root@0/amba_lpd@0/lpd_afi_fs@0xeb560000";
+		sdma7 = "/amba_root@0/amba_lpd@0/dma-controller@ebdf0000";
+		lpd_wwdt1 = "/amba_root@0/amba_lpd@0/wwdt@eb010000";
+		lpd_afi_fs = "/amba_root@0/amba_lpd@0/lpd_afi_fs@eb560000";
 		amba_fpd = "/amba_root@0/amba_fpd@0";
-		wwdt0 = "/amba_root@0/amba_fpd@0/watchdog@0xecc10000";
-		apu_cluster0 = "/amba_root@0/amba_fpd@0/apu_cluster@0xecc00000";
-		apu_cluster1 = "/amba_root@0/amba_fpd@0/apu_cluster@0xecd00000";
-		apu_cluster2 = "/amba_root@0/amba_fpd@0/apu_cluster@0xece00000";
-		apu_cluster3 = "/amba_root@0/amba_fpd@0/apu_cluster@0xecf00000";
+		wwdt0 = "/amba_root@0/amba_fpd@0/watchdog@ecc10000";
+		apu_cluster0 = "/amba_root@0/amba_fpd@0/apu_cluster@ecc00000";
+		apu_cluster1 = "/amba_root@0/amba_fpd@0/apu_cluster@ecd00000";
+		apu_cluster2 = "/amba_root@0/amba_fpd@0/apu_cluster@ece00000";
+		apu_cluster3 = "/amba_root@0/amba_fpd@0/apu_cluster@ecf00000";
 		smmu = "/amba_root@0/amba_fpd@0/smmuv3@MM_FPD_SMMU";
-		pcie = "/amba_root@0/amba_fpd@0/dummy_pcie@0x6_0000_0000";
-		apu_pcil = "/amba_root@0/amba_fpd@0/apu_pcil@0xecb10000";
-		fpd_afi_fs = "/amba_root@0/amba_fpd@0/lpd_afi_fs@0xec860000";
+		pcie = "/amba_root@0/amba_fpd@0/dummy_pcie@6_0000_0000";
+		apu_pcil = "/amba_root@0/amba_fpd@0/apu_pcil@ecb10000";
+		fpd_afi_fs = "/amba_root@0/amba_fpd@0/lpd_afi_fs@ec860000";
 		mmi_gem_memattr = "/amba_root@0/amba_fpd@0/mmi_gem_ma";
 		mmi_usb_memattr = "/amba_root@0/amba_fpd@0/mmi_usb_ma";
 		amba_mmi = "/amba_root@0/amba_fpd@0/amba_mmi@0";
 		mdio_10gbe = "/amba_root@0/amba_fpd@0/amba_mmi@0/mdio_10gbe@0";
 		phy_10gbe = "/amba_root@0/amba_fpd@0/amba_mmi@0/mdio_10gbe@0/phy@1";
-		mmi_10gbe = "/amba_root@0/amba_fpd@0/amba_mmi@0/ethernet@0xed920000";
-		mmi_usb_drd = "/amba_root@0/amba_fpd@0/amba_mmi@0/usb_drd@0xedec0000";
-		mmi_crx = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_crs@0xedc00000";
-		mmi_pcsr = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_pcsr@0xeb2f0000";
-		mmi_gtyp = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_gtyp@0xed900000";
+		mmi_10gbe = "/amba_root@0/amba_fpd@0/amba_mmi@0/ethernet@ed920000";
+		mmi_usb_drd = "/amba_root@0/amba_fpd@0/amba_mmi@0/usb_drd@edec0000";
+		mmi_crx = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_crs@edc00000";
+		mmi_pcsr = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_pcsr@eb2f0000";
+		mmi_gtyp = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_gtyp@ed900000";
 		mmi_slcr_secure = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_slcr_sec@0";
-		mmi_trng = "/amba_root@0/amba_fpd@0/amba_mmi@0/trng@0xede80000";
-		mmi_udh_slcr = "/amba_root@0/amba_fpd@0/amba_mmi@0/udh_slcr@0xedea0000";
-		mmi_udh_pll = "/amba_root@0/amba_fpd@0/amba_mmi@0/udh_pll@0xede90000";
+		mmi_trng = "/amba_root@0/amba_fpd@0/amba_mmi@0/trng@ede80000";
+		mmi_udh_slcr = "/amba_root@0/amba_fpd@0/amba_mmi@0/udh_slcr@edea0000";
+		mmi_udh_pll = "/amba_root@0/amba_fpd@0/amba_mmi@0/udh_pll@ede90000";
 		mmi_gpu_a = "/amba_root@0/amba_fpd@0/amba_mmi@0/mmi_gpu_a@0";
 		loader_write_0xEDC30440 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC30440";
+loader_write_cpu0_0x1@EDC30440";
 		loader_write_0xEDC30444 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x7F@0xEDC30444";
+loader_write_cpu0_0x7F@EDC30444";
 		loader_write_0xEDC3044c = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC3044c";
+loader_write_cpu0_0x1@EDC3044c";
 		loader_write_0xEDC30450 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC30450";
+loader_write_cpu0_0x1@EDC30450";
 		loader_write_0xEDC30460 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC30460";
+loader_write_cpu0_0x1@EDC30460";
 		loader_write_0xEDC30464 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x7f@0xEDC30464";
+loader_write_cpu0_0x7f@EDC30464";
 		loader_write_0xEDC3046c = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC3046c";
+loader_write_cpu0_0x1@EDC3046c";
 		loader_write_0xEDC30470 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x1@0xEDC30470";
+loader_write_cpu0_0x1@EDC30470";
 		loader_write_0xED0A0098 = "/amba_root@0/amba_fpd@0/amba_mmi@0/
-loader_write_cpu0_0x3@0xED0A0098";
+loader_write_cpu0_0x3@ED0A0098";
 		amba_pmc_internal = "/amba_root@0/amba_pmc_internal@0";
 		xmpu_pmc = "/amba_root@0/amba_pmc_internal@0/xmpu_pmc@0";
-		xppu_pmc_npi = "/amba_root@0/amba_pmc_internal@0/xppu_pmc_npi@0xf1300000";
-		xppu_pmc = "/amba_root@0/amba_pmc_internal@0/xppu_pmc@0xf1310000";
+		xppu_pmc_npi = "/amba_root@0/amba_pmc_internal@0/xppu_pmc_npi@f1300000";
+		xppu_pmc = "/amba_root@0/amba_pmc_internal@0/xppu_pmc@f1310000";
 		amba_pmc = "/amba_root@0/amba_pmc@0";
-		xmpu_pmc_cfu = "/amba_root@0/amba_pmc@0/xmpu_pmc_cfu@0xf1340000";
-		pmx_err_mng = "/amba_root@0/amba_pmc@0/pmx_err_mng@0xf1110000";
-		intpmxc_config = "/amba_root@0/amba_pmc@0/intpmxc_config@0xf1400000";
+		xmpu_pmc_cfu = "/amba_root@0/amba_pmc@0/xmpu_pmc_cfu@f1340000";
+		pmx_err_mng = "/amba_root@0/amba_pmc@0/pmx_err_mng@f1110000";
+		intpmxc_config = "/amba_root@0/amba_pmc@0/intpmxc_config@f1400000";
 		amba_pmc_iou = "/amba_root@0/amba_pmc_iou@0";
-		pmc_iou_slcr = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr@0xf1060000";
-		pmc_iou_slcr_secure = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr_secure@0xf1070000";
+		pmc_iou_slcr = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr@f1060000";
+		pmc_iou_slcr_secure = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr_secure@f1070000";
 		pmc_qspi_dma_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi_dma@QSPI_DMA";
-		pmc_qspi_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000";
-		qspi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		pmc_qspi_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000";
+		qspi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_lcs_lb@0";
-		qspi_flash_lcs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		qspi_flash_lcs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_lcs_ub@0";
-		qspi_flash_ucs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		qspi_flash_ucs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_ucs_lb@0";
-		qspi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		qspi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_ucs_ub@0";
 		ospi_dma_dst = "/amba_root@0/amba_pmc_iou@0/ospi_dst_dma@0";
 		ospi_dma_src = "/amba_root@0/amba_pmc_iou@0/ospi_src_dma@0";
-		ospi = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000";
-		ospi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000/
+		ospi = "/amba_root@0/amba_pmc_iou@0/spi@f1010000";
+		ospi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/spi@f1010000/
 ospi_flash_lcs_lb@0";
-		ospi_flash_lcs_ub = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000/
+		ospi_flash_lcs_ub = "/amba_root@0/amba_pmc_iou@0/spi@f1010000/
 ospi_flash_lcs_ub@0";
-		ospi_flash_ucs_lb = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000/
+		ospi_flash_ucs_lb = "/amba_root@0/amba_pmc_iou@0/spi@f1010000/
 ospi_flash_ucs_lb@0";
-		ospi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000/
+		ospi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/spi@f1010000/
 ospi_flash_ucs_ub@0";
-		gpio_mr_mux = "/amba_root@0/amba_pmc_iou@0/gpio_mr_mux@0xc0000000";
-		pmc_gpio = "/amba_root@0/amba_pmc_iou@0/pmc_gpio@0xf1020000";
-		sdhci0 = "/amba_root@0/amba_pmc_iou@0/mmc@0xf1040000";
-		sdhci1 = "/amba_root@0/amba_pmc_iou@0/mmc@0xf1050000";
-		pmc_tap = "/amba_root@0/amba_pmc_iou@0/pmc_tap@0xf11a0000";
-		pmc_i2c = "/amba_root@0/amba_pmc_iou@0/pmc_i2c_wrapper/pmc_i2c@0xf1000000";
-		pmx_wwdt = "/amba_root@0/amba_pmc_iou@0/wwdt@0xf03f0000";
-		pmc_ufshc = "/amba_root@0/amba_pmc_iou@0/pmc_ufshc@0xf10b0000";
+		gpio_mr_mux = "/amba_root@0/amba_pmc_iou@0/gpio_mr_mux@c0000000";
+		pmc_gpio = "/amba_root@0/amba_pmc_iou@0/pmc_gpio@f1020000";
+		sdhci0 = "/amba_root@0/amba_pmc_iou@0/mmc@f1040000";
+		sdhci1 = "/amba_root@0/amba_pmc_iou@0/mmc@f1050000";
+		pmc_tap = "/amba_root@0/amba_pmc_iou@0/pmc_tap@f11a0000";
+		pmc_i2c = "/amba_root@0/amba_pmc_iou@0/pmc_i2c_wrapper/pmc_i2c@f1000000";
+		pmx_wwdt = "/amba_root@0/amba_pmc_iou@0/wwdt@f03f0000";
+		pmc_ufshc = "/amba_root@0/amba_pmc_iou@0/pmc_ufshc@f10b0000";
 		unipro = "/amba_root@0/amba_pmc_iou@0/unipro@0";
 		ufs_dev = "/amba_root@0/amba_pmc_iou@0/ufs_dev@0";
-		ufs_reg = "/amba_root@0/amba_pmc_iou@0/ufs_reg@0xf1060000";
+		ufs_reg = "/amba_root@0/amba_pmc_iou@0/ufs_reg@f1060000";
 		amba_pmc_sec = "/amba_root@0/amba_pmc_sec@0";
 		pmc_dma0_src = "/amba_root@0/amba_pmc_sec@0/pmc_dma0_src@0";
 		pmc_dma0_dst = "/amba_root@0/amba_pmc_sec@0/pmc_dma0_dst@0";
 		pmc_dma1_src = "/amba_root@0/amba_pmc_sec@0/pmc_dma1_src@0";
 		pmc_dma1_dst = "/amba_root@0/amba_pmc_sec@0/pmc_dma1_dst@0";
 		pmc_stream_switch = "/amba_root@0/amba_pmc_sec@0/pmc_stream_switch@0";
-		pmc_sha3 = "/amba_root@0/amba_pmc_sec@0/pmc_sha@0xf1210000";
-		pmc_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@0xf11e0000";
-		xlnx_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@0xf11e0000/xlnx_aes@0";
-		pmc_rsa = "/amba_root@0/amba_pmc_sec@0/pmc_rsa@0xf1200000";
+		pmc_sha3 = "/amba_root@0/amba_pmc_sec@0/pmc_sha@f1210000";
+		pmc_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@f11e0000";
+		xlnx_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@f11e0000/xlnx_aes@0";
+		pmc_rsa = "/amba_root@0/amba_pmc_sec@0/pmc_rsa@f1200000";
 		xlnx_pmc_efuse_cache = "/amba_root@0/amba_pmc_sec@0/
-xlnx_pmc_efuse_cache@0xf1250000";
+xlnx_pmc_efuse_cache@f1250000";
 		pmc_puf_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_puf_ctrl@0";
-		pmc_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@0xf1240000";
-		xlnx_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@0xf1240000/xlnx_efuse@0";
-		pmc_bbram_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_bbram@0xf11f0000";
-		pmc_sbi = "/amba_root@0/amba_pmc_sec@0/pmc_sbi@0xf1220000";
-		pmc_sha3_1 = "/amba_root@0/amba_pmc_sec@0/pmc_sha1@0xF1800000";
+		pmc_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@f1240000";
+		xlnx_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@f1240000/xlnx_efuse@0";
+		pmc_bbram_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_bbram@f11f0000";
+		pmc_sbi = "/amba_root@0/amba_pmc_sec@0/pmc_sbi@f1220000";
+		pmc_sha3_1 = "/amba_root@0/amba_pmc_sec@0/pmc_sha1@F1800000";
 		amba_pmc_ppu = "/amba_root@0/amba_pmc_ppu@0";
 		pmc_gic_proxy = "/amba_root@0/amba_pmc_ppu@0/pmc_gic_proxy@0";
 		amba_pmc_sys = "/amba_root@0/amba_pmc_sys@0";
-		pmc_clk_rst = "/amba_root@0/amba_pmc_sys@0/pmc_clk_rst@0xf1260000";
-		pmc_int = "/amba_root@0/amba_pmc_sys@0/pmc_int@0xf1400000";
-		pmc_global = "/amba_root@0/amba_pmc_sys@0/pmc_global@0xf1110000";
+		pmc_clk_rst = "/amba_root@0/amba_pmc_sys@0/pmc_clk_rst@f1260000";
+		pmc_int = "/amba_root@0/amba_pmc_sys@0/pmc_int@f1400000";
+		pmc_global = "/amba_root@0/amba_pmc_sys@0/pmc_global@f1110000";
 		pmc_stream_zero = "/amba_root@0/amba_pmc_sys@0/pmc_stream_zero@";
-		pmx_analog = "/amba_root@0/amba_pmc_sys@0/pmc_analog@0xf1160000";
-		pmc_sysmon = "/amba_root@0/amba_pmc_sys@0/pmc_sysmon@0xf1270000";
+		pmx_analog = "/amba_root@0/amba_pmc_sys@0/pmc_analog@f1160000";
+		pmc_sysmon = "/amba_root@0/amba_pmc_sys@0/pmc_sysmon@f1270000";
 		pmc_ams_sat0 = "/amba_root@0/amba_pmc_sys@0/pmc_ams_sat@0";
 		pmc_ams_sat1 = "/amba_root@0/amba_pmc_sys@0/pmc_ams_sat@1";
 		pmc_global_tamper = "/amba_root@0/amba_pmc_sys@0/versal_pmc_tamper@";
@@ -7521,80 +7521,80 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		fpd_sysmon_sat2 = "/amba_root@0/amba_pmc_sys@0/fpd_ams_sat@2";
 		fpd_sysmon_sat3 = "/amba_root@0/amba_pmc_sys@0/fpd_ams_sat@3";
 		amba_pmc_pl = "/amba_root@0/amba_pmc_pl@0";
-		noc_npi_nir = "/amba_root@0/amba_pmc_pl@0/noc_npi_nir@0xf6000000";
-		npi_ddrmc_ub0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub0@0xf62c0000";
-		npi_ddrmc_main0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main0@0xf6290000";
-		npi_ddrmc_noc0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc0@0xf62a0000";
-		npi_ddrmc_ub1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub1@0xf63b0000";
-		npi_ddrmc_main1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main1@0xf6380000";
-		npi_ddrmc_noc1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc1@0xf6390000";
-		npi_ddrmc_ub2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub2@0xf6940000";
-		npi_ddrmc_main2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main2@0xf6910000";
-		npi_ddrmc_noc2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc2@0xf6920000";
-		npi_ddrmc_ub3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub3@0xf6a20000";
-		npi_ddrmc_main3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main3@0xf69f0000";
-		npi_ddrmc_noc3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc3@0xf6a00000";
-		npi_ddrmc_xmpu0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_xmpu0@0xf62a0000";
-		npi_me = "/amba_root@0/amba_pmc_pl@0/npi_me@0xf6540000";
-		npi_me0 = "/amba_root@0/amba_pmc_pl@0/npi_me@0xf6540000";
+		noc_npi_nir = "/amba_root@0/amba_pmc_pl@0/noc_npi_nir@f6000000";
+		npi_ddrmc_ub0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub0@f62c0000";
+		npi_ddrmc_main0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main0@f6290000";
+		npi_ddrmc_noc0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc0@f62a0000";
+		npi_ddrmc_ub1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub1@f63b0000";
+		npi_ddrmc_main1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main1@f6380000";
+		npi_ddrmc_noc1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc1@f6390000";
+		npi_ddrmc_ub2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub2@f6940000";
+		npi_ddrmc_main2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main2@f6910000";
+		npi_ddrmc_noc2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc2@f6920000";
+		npi_ddrmc_ub3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub3@f6a20000";
+		npi_ddrmc_main3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main3@f69f0000";
+		npi_ddrmc_noc3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc3@f6a00000";
+		npi_ddrmc_xmpu0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_xmpu0@f62a0000";
+		npi_me = "/amba_root@0/amba_pmc_pl@0/npi_me@f6540000";
+		npi_me0 = "/amba_root@0/amba_pmc_pl@0/npi_me@f6540000";
 		noc_npi_devs = "/amba_root@0/amba_pmc_pl@0/noc_npi_devs@0";
-		cfu_fdro = "/amba_root@0/amba_pmc_pl@0/cfu_fdro@0xf12c2000";
-		cfu_sfr = "/amba_root@0/amba_pmc_pl@0/cfu_sfr@0xf12c1000";
-		cframe0_reg = "/amba_root@0/amba_pmc_pl@0/cframe0_reg@0xf12d0000";
-		cframe1_reg = "/amba_root@0/amba_pmc_pl@0/cframe1_reg@0xf12d2000";
-		cframe2_reg = "/amba_root@0/amba_pmc_pl@0/cframe2_reg@0xf12d4000";
-		cframe3_reg = "/amba_root@0/amba_pmc_pl@0/cframe3_reg@0xf12d6000";
-		cframe4_reg = "/amba_root@0/amba_pmc_pl@0/cframe4_reg@0xf12d8000";
-		cframe5_reg = "/amba_root@0/amba_pmc_pl@0/cframe5_reg@0xf12da000";
-		cframe6_reg = "/amba_root@0/amba_pmc_pl@0/cframe6_reg@0xf12dc000";
-		cframe7_reg = "/amba_root@0/amba_pmc_pl@0/cframe7_reg@0xf12de000";
-		cframe8_reg = "/amba_root@0/amba_pmc_pl@0/cframe8_reg@0xf12e0000";
-		cframe9_reg = "/amba_root@0/amba_pmc_pl@0/cframe9_reg@0xf12e2000";
-		cframe10_reg = "/amba_root@0/amba_pmc_pl@0/cframe10_reg@0xf12e4000";
-		cframe11_reg = "/amba_root@0/amba_pmc_pl@0/cframe11_reg@0xf12e6000";
-		cframe12_reg = "/amba_root@0/amba_pmc_pl@0/cframe12_reg@0xf12e8000";
-		cframe13_reg = "/amba_root@0/amba_pmc_pl@0/cframe13_reg@0xf12ea000";
-		cframe14_reg = "/amba_root@0/amba_pmc_pl@0/cframe14_reg@0xf12ec000";
-		cframe_bcast_reg = "/amba_root@0/amba_pmc_pl@0/cframe_bcast_reg@0xf12ee000";
-		dummy_cfu_mem = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@0xf12b0000";
-		cfu = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@0xf12b0000/cfu@0x0";
+		cfu_fdro = "/amba_root@0/amba_pmc_pl@0/cfu_fdro@f12c2000";
+		cfu_sfr = "/amba_root@0/amba_pmc_pl@0/cfu_sfr@f12c1000";
+		cframe0_reg = "/amba_root@0/amba_pmc_pl@0/cframe0_reg@f12d0000";
+		cframe1_reg = "/amba_root@0/amba_pmc_pl@0/cframe1_reg@f12d2000";
+		cframe2_reg = "/amba_root@0/amba_pmc_pl@0/cframe2_reg@f12d4000";
+		cframe3_reg = "/amba_root@0/amba_pmc_pl@0/cframe3_reg@f12d6000";
+		cframe4_reg = "/amba_root@0/amba_pmc_pl@0/cframe4_reg@f12d8000";
+		cframe5_reg = "/amba_root@0/amba_pmc_pl@0/cframe5_reg@f12da000";
+		cframe6_reg = "/amba_root@0/amba_pmc_pl@0/cframe6_reg@f12dc000";
+		cframe7_reg = "/amba_root@0/amba_pmc_pl@0/cframe7_reg@f12de000";
+		cframe8_reg = "/amba_root@0/amba_pmc_pl@0/cframe8_reg@f12e0000";
+		cframe9_reg = "/amba_root@0/amba_pmc_pl@0/cframe9_reg@f12e2000";
+		cframe10_reg = "/amba_root@0/amba_pmc_pl@0/cframe10_reg@f12e4000";
+		cframe11_reg = "/amba_root@0/amba_pmc_pl@0/cframe11_reg@f12e6000";
+		cframe12_reg = "/amba_root@0/amba_pmc_pl@0/cframe12_reg@f12e8000";
+		cframe13_reg = "/amba_root@0/amba_pmc_pl@0/cframe13_reg@f12ea000";
+		cframe14_reg = "/amba_root@0/amba_pmc_pl@0/cframe14_reg@f12ec000";
+		cframe_bcast_reg = "/amba_root@0/amba_pmc_pl@0/cframe_bcast_reg@f12ee000";
+		dummy_cfu_mem = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@f12b0000";
+		cfu = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@f12b0000/cfu@0";
 		amba_pmc_bat = "/amba_root@0/amba_pmc_bat@0";
-		rtc = "/amba_root@0/amba_pmc_bat@0/rtc@0xf12a0000";
+		rtc = "/amba_root@0/amba_pmc_bat@0/rtc@f12a0000";
 		amba_psm = "/amba_root@0/amba_psm@0";
 		amba_xram = "/amba_root@0/amba_xram@0";
-		crf = "/amba_root@0/crf@0xec200000";
+		crf = "/amba_root@0/crf@ec200000";
 		amba_asu_cpu = "/amba_root@0/amba_asu_cpu@0";
 		amba_asu = "/amba_root@0/amba_asu@0";
-		asu_iram = "/amba_root@0/amba_asu@0/asu_instr_ram@0xebe00000";
-		asu_io_module = "/amba_root@0/amba_asu@0/io-module@0xebe80000";
-		asu_io_intc = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_io_intc@0C";
-		asu_io_gpi1 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_gpi@20";
-		asu_io_gpo1 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_gpo@10";
-		asu_io_gpo2 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_gpo@14";
-		asu_io_pit1 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_pit@40";
-		asu_io_pit2 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_pit@50";
-		asu_io_pit3 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_pit@60";
-		asu_io_pit4 = "/amba_root@0/amba_asu@0/io-module@0xebe80000/asu_pit@70";
-		asu_mdm_uart = "/amba_root@0/amba_asu@0/asu_mdm_uart@0xebef0000";
-		asu_global = "/amba_root@0/amba_asu@0/asu_global@0xebf80000";
-		asu_global_pmc = "/amba_root@0/amba_asu@0/asu_global_pmc@0xebf80000";
-		asu_local = "/amba_root@0/amba_asu@0/asu_local@0xebe8e000";
-		asu_sss = "/amba_root@0/amba_asu@0/asu_sss@0xebe8e000";
-		asu_dma_src = "/amba_root@0/amba_asu@0/asu_dma_src@0xebe8c000";
-		asu_dma_dst = "/amba_root@0/amba_asu@0/asu_dma_dst@0xebe8c000";
-		asu_dma1_src = "/amba_root@0/amba_asu@0/asu_dma1_src@0xebe8d000";
-		asu_dma1_dst = "/amba_root@0/amba_asu@0/asu_dma1_dst@0xebe8d000";
-		asu_xmpu = "/amba_root@0/amba_asu@0/asu_xmpu@0xebf60000";
-		asu_aes = "/amba_root@0/amba_asu@0/asu_aes@0xebe88000";
-		asu_kv = "/amba_root@0/amba_asu@0/asu_kv@0xebe8a000";
-		asu_sha3 = "/amba_root@0/amba_asu@0/asu_sha3@0xebf40000";
-		asu_sha2 = "/amba_root@0/amba_asu@0/asu_sha2@0xebf30000";
-		asu_rsa = "/amba_root@0/amba_asu@0/pmc_rsa@0xebf50000";
-		asu_trng = "/amba_root@0/amba_asu@0/trng@0xebf20000";
-		asu_ecc = "/amba_root@0/amba_asu@0/asu_ecc@0xebf00000";
+		asu_iram = "/amba_root@0/amba_asu@0/asu_instr_ram@ebe00000";
+		asu_io_module = "/amba_root@0/amba_asu@0/io-module@ebe80000";
+		asu_io_intc = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_io_intc@0C";
+		asu_io_gpi1 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_gpi@20";
+		asu_io_gpo1 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_gpo@10";
+		asu_io_gpo2 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_gpo@14";
+		asu_io_pit1 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_pit@40";
+		asu_io_pit2 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_pit@50";
+		asu_io_pit3 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_pit@60";
+		asu_io_pit4 = "/amba_root@0/amba_asu@0/io-module@ebe80000/asu_pit@70";
+		asu_mdm_uart = "/amba_root@0/amba_asu@0/asu_mdm_uart@ebef0000";
+		asu_global = "/amba_root@0/amba_asu@0/asu_global@ebf80000";
+		asu_global_pmc = "/amba_root@0/amba_asu@0/asu_global_pmc@ebf80000";
+		asu_local = "/amba_root@0/amba_asu@0/asu_local@ebe8e000";
+		asu_sss = "/amba_root@0/amba_asu@0/asu_sss@ebe8e000";
+		asu_dma_src = "/amba_root@0/amba_asu@0/asu_dma_src@ebe8c000";
+		asu_dma_dst = "/amba_root@0/amba_asu@0/asu_dma_dst@ebe8c000";
+		asu_dma1_src = "/amba_root@0/amba_asu@0/asu_dma1_src@ebe8d000";
+		asu_dma1_dst = "/amba_root@0/amba_asu@0/asu_dma1_dst@ebe8d000";
+		asu_xmpu = "/amba_root@0/amba_asu@0/asu_xmpu@ebf60000";
+		asu_aes = "/amba_root@0/amba_asu@0/asu_aes@ebe88000";
+		asu_kv = "/amba_root@0/amba_asu@0/asu_kv@ebe8a000";
+		asu_sha3 = "/amba_root@0/amba_asu@0/asu_sha3@ebf40000";
+		asu_sha2 = "/amba_root@0/amba_asu@0/asu_sha2@ebf30000";
+		asu_rsa = "/amba_root@0/amba_asu@0/pmc_rsa@ebf50000";
+		asu_trng = "/amba_root@0/amba_asu@0/trng@ebf20000";
+		asu_ecc = "/amba_root@0/amba_asu@0/asu_ecc@ebf00000";
 		lmb_pmc_ppu0 = "/lmb_pmc_ppu0@0";
-		pmc_rom = "/lmb_pmc_ppu0@0/pmc_rom@0xf0000000";
-		pmc_ppu0_ram = "/lmb_pmc_ppu0@0/ppu0_ram@0xf0060000";
+		pmc_rom = "/lmb_pmc_ppu0@0/pmc_rom@f0000000";
+		pmc_ppu0_ram = "/lmb_pmc_ppu0@0/ppu0_ram@f0060000";
 		pmc_ppu0_io_module = "/lmb_pmc_ppu0@0/io-module@00";
 		pmc_ppu0_io_intc = "/lmb_pmc_ppu0@0/io-module@00/pmc_ppu0_intc@0C";
 		pmc_ppu0_io_gpi1 = "/lmb_pmc_ppu0@0/io-module@00/pmc_ppu0_gpi@20";
@@ -7626,9 +7626,9 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		pmc_ppu1_io_pit4 = "/lmb_pmc_ppu1@0/io-module@00/pmc_ppu1_pit@70";
 		lmb_psm = "/lmb_psm@0";
 		lmb_ddrmc0 = "/lmb_ddrmc@0";
-		ddrmc0_ram_data = "/lmb_ddrmc@0/ddrmc0_ram_data@0x1c000";
-		ddrmc0_ram_instr = "/lmb_ddrmc@0/ddrmc0_ram_instr@0x20000";
-		ddrmc0_ram_exchange = "/lmb_ddrmc@0/ddrmc0_ram_exchange@0x08000";
+		ddrmc0_ram_data = "/lmb_ddrmc@0/ddrmc0_ram_data@1c000";
+		ddrmc0_ram_instr = "/lmb_ddrmc@0/ddrmc0_ram_instr@20000";
+		ddrmc0_ram_exchange = "/lmb_ddrmc@0/ddrmc0_ram_exchange@08000";
 		ddrmc_0_io_module = "/lmb_ddrmc@0/io-module@00";
 		ddrmc0_io_intc = "/lmb_ddrmc@0/io-module@00/ddrmc0_intc@0C";
 		ddrmc0_io_gpo1 = "/lmb_ddrmc@0/io-module@00/ddrmc0_gpo@10";
@@ -7638,9 +7638,9 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		ddrmc0_io_pit4 = "/lmb_ddrmc@0/io-module@00/ddrmc0_pit@70";
 		ddrmc_uart0 = "/lmb_ddrmc@0/ddrmc_uart0@0";
 		lmb_ddrmc1 = "/lmb_ddrmc@1";
-		ddrmc1_ram_data = "/lmb_ddrmc@1/ddrmc1_ram_data@0x1c000";
-		ddrmc1_ram_instr = "/lmb_ddrmc@1/ddrmc1_ram_instr@0x20000";
-		ddrmc1_ram_exchange = "/lmb_ddrmc@1/ddrmc1_ram_exchange@0x08000";
+		ddrmc1_ram_data = "/lmb_ddrmc@1/ddrmc1_ram_data@1c000";
+		ddrmc1_ram_instr = "/lmb_ddrmc@1/ddrmc1_ram_instr@20000";
+		ddrmc1_ram_exchange = "/lmb_ddrmc@1/ddrmc1_ram_exchange@08000";
 		amba_rpu = "/amba_rpu@0";
 		amba_r5_0 = "/amba_r5@0";
 		amba_r5_1 = "/amba_r5@1";
@@ -7654,17 +7654,17 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		smmu_tbu6 = "/tbu6_slave@0";
 		ddr_mem = "/memory@00000000";
 		ddr_2_mem = "/memory@8_0000_0000";
-		ddr_3_mem = "/memory@0x50000000000ULL";
+		ddr_3_mem = "/memory@50000000000";
 		ocm_mem_bank_0 = "/ocm_mem_bank_0@";
 		ocm_mem_bank_1 = "/ocm_mem_bank_1@";
 		ocm_mem_bank_2 = "/ocm_mem_bank_2@";
 		ocm_mem_bank_3 = "/ocm_mem_bank_3@";
-		xram_mem = "/xram_mem@0xbbe00000";
+		xram_mem = "/xram_mem@bbe00000";
 		ipi_msgbuf = "/ipi_msgbuf@0";
-		pmc_ram = "/pmc_ram@0xf2000000";
-		pmc_ram_bank_0 = "/pmc_ram_bank_0@0x0";
-		pmc_ppu1_insn_ram = "/pmc_ppu1_ram@0xf0200000";
-		pmc_ppu1_data_ram = "/pmc_ppu1_ram@0xf0280000";
+		pmc_ram = "/pmc_ram@f2000000";
+		pmc_ram_bank_0 = "/pmc_ram_bank_0@0";
+		pmc_ppu1_insn_ram = "/pmc_ppu1_ram@f0200000";
+		pmc_ppu1_data_ram = "/pmc_ppu1_ram@f0280000";
 		lqspi_mr = "/lqspi_mr@0";
 		lospi_mr = "/lospi_mr@0";
 		cpu0 = "/cpus/apu_cpu@0";
@@ -7693,7 +7693,7 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		amba_apu = "/amba_apu@0";
 		timer = "/amba_apu@0/timer";
 		amba_apu_gic = "/amba_apu_gic@0";
-		gic = "/amba_apu_gic@0/interrupt-controller@0xe2000000";
+		gic = "/amba_apu_gic@0/interrupt-controller@e2000000";
 		amba_alias = "/amba_alias@0";
 		qemu_sysmem = "/qemu_sysmem@0";
 		psm0 = "/dummy_ppu0@0";
@@ -7701,8 +7701,8 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		pmc_ppu1 = "/dummy_ppu1@0";
 		ddrmc_ub0 = "/dummy_ddrmc0@0";
 		ddrmc_ub1 = "/dummy_ddrmc1@0";
-		ddr = "/ddr@0x00000000";
-		ddr_2 = "/ddr_2@0x800000000ULL";
+		ddr = "/ddr@00000000";
+		ddr_2 = "/ddr_2@800000000";
 		mdio0 = "/mdio";
 		phy0 = "/mdio/phy@1";
 		phy1 = "/mdio/phy@2";
@@ -7714,55 +7714,55 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		smmu_tbu11 = "/tbu11_slave@0";
 		smmu_tbu12 = "/tbu12_slave@0";
 		mr_rpu_gic_a = "/mr_rpu_gic_a@0";
-		rpu_gic_a = "/mr_rpu_gic_a@0/rpu_gic_a@0x0";
+		rpu_gic_a = "/mr_rpu_gic_a@0/rpu_gic_a@0";
 		mr_rpu_gic_b = "/mr_rpu_gic_b@0";
-		rpu_gic_b = "/mr_rpu_gic_b@0/rpu_gic_b@0x0";
+		rpu_gic_b = "/mr_rpu_gic_b@0/rpu_gic_b@0";
 		mr_rpu_gic_c = "/mr_rpu_gic_c@0";
-		rpu_gic_c = "/mr_rpu_gic_c@0/rpu_gic_c@0x0";
+		rpu_gic_c = "/mr_rpu_gic_c@0/rpu_gic_c@0";
 		mr_rpu_gic_d = "/mr_rpu_gic_d@0";
-		rpu_gic_d = "/mr_rpu_gic_d@0/rpu_gic_d@0x0";
+		rpu_gic_d = "/mr_rpu_gic_d@0/rpu_gic_d@0";
 		mr_rpu_gic_e = "/mr_rpu_gic_e@0";
-		rpu_gic_e = "/mr_rpu_gic_e@0/rpu_gic_e@0x0";
+		rpu_gic_e = "/mr_rpu_gic_e@0/rpu_gic_e@0";
 		tcm_core0 = "/tcm_core@0";
-		atcm_rpu_core0 = "/tcm_core@0/atcm_rpu_core0@0x00000";
-		btcm_rpu_core0 = "/tcm_core@0/btcm_rpu_core0@0x00000";
-		ctcm_rpu_core0 = "/tcm_core@0/ctcm_rpu_core0@0x00000";
+		atcm_rpu_core0 = "/tcm_core@0/atcm_rpu_core0@00000";
+		btcm_rpu_core0 = "/tcm_core@0/btcm_rpu_core0@00000";
+		ctcm_rpu_core0 = "/tcm_core@0/ctcm_rpu_core0@00000";
 		tcm_core1 = "/tcm_core@1";
-		atcm_rpu_core1 = "/tcm_core@1/atcm_rpu_core1@0x00000";
-		btcm_rpu_core1 = "/tcm_core@1/btcm_rpu_core1@0x00000";
-		ctcm_rpu_core1 = "/tcm_core@1/ctcm_rpu_core1@0x00000";
+		atcm_rpu_core1 = "/tcm_core@1/atcm_rpu_core1@00000";
+		btcm_rpu_core1 = "/tcm_core@1/btcm_rpu_core1@00000";
+		ctcm_rpu_core1 = "/tcm_core@1/ctcm_rpu_core1@00000";
 		tcm_core2 = "/tcm_core@2";
-		atcm_rpu_core2 = "/tcm_core@2/atcm_rpu_core2@0x00000";
-		btcm_rpu_core2 = "/tcm_core@2/btcm_rpu_core2@0x00000";
-		ctcm_rpu_core2 = "/tcm_core@2/ctcm_rpu_core2@0x00000";
+		atcm_rpu_core2 = "/tcm_core@2/atcm_rpu_core2@00000";
+		btcm_rpu_core2 = "/tcm_core@2/btcm_rpu_core2@00000";
+		ctcm_rpu_core2 = "/tcm_core@2/ctcm_rpu_core2@00000";
 		tcm_core3 = "/tcm_core@3";
-		atcm_rpu_core3 = "/tcm_core@3/atcm_rpu_core3@0x00000";
-		btcm_rpu_core3 = "/tcm_core@3/btcm_rpu_core3@0x00000";
-		ctcm_rpu_core3 = "/tcm_core@3/ctcm_rpu_core3@0x00000";
+		atcm_rpu_core3 = "/tcm_core@3/atcm_rpu_core3@00000";
+		btcm_rpu_core3 = "/tcm_core@3/btcm_rpu_core3@00000";
+		ctcm_rpu_core3 = "/tcm_core@3/ctcm_rpu_core3@00000";
 		tcm_core4 = "/tcm_core@4";
-		atcm_rpu_core4 = "/tcm_core@4/atcm_rpu_core4@0x00000";
-		btcm_rpu_core4 = "/tcm_core@4/btcm_rpu_core4@0x00000";
-		ctcm_rpu_core4 = "/tcm_core@4/ctcm_rpu_core4@0x00000";
+		atcm_rpu_core4 = "/tcm_core@4/atcm_rpu_core4@00000";
+		btcm_rpu_core4 = "/tcm_core@4/btcm_rpu_core4@00000";
+		ctcm_rpu_core4 = "/tcm_core@4/ctcm_rpu_core4@00000";
 		tcm_core5 = "/tcm_core@5";
-		atcm_rpu_core5 = "/tcm_core@5/atcm_rpu_core5@0x00000";
-		btcm_rpu_core5 = "/tcm_core@5/btcm_rpu_core5@0x00000";
-		ctcm_rpu_core5 = "/tcm_core@5/ctcm_rpu_core5@0x00000";
+		atcm_rpu_core5 = "/tcm_core@5/atcm_rpu_core5@00000";
+		btcm_rpu_core5 = "/tcm_core@5/btcm_rpu_core5@00000";
+		ctcm_rpu_core5 = "/tcm_core@5/ctcm_rpu_core5@00000";
 		tcm_core6 = "/tcm_core@6";
-		atcm_rpu_core6 = "/tcm_core@6/atcm_rpu_core6@0x00000";
-		btcm_rpu_core6 = "/tcm_core@6/btcm_rpu_core6@0x00000";
-		ctcm_rpu_core6 = "/tcm_core@6/ctcm_rpu_core6@0x00000";
+		atcm_rpu_core6 = "/tcm_core@6/atcm_rpu_core6@00000";
+		btcm_rpu_core6 = "/tcm_core@6/btcm_rpu_core6@00000";
+		ctcm_rpu_core6 = "/tcm_core@6/ctcm_rpu_core6@00000";
 		tcm_core7 = "/tcm_core@7";
-		atcm_rpu_core7 = "/tcm_core@7/atcm_rpu_core7@0x00000";
-		btcm_rpu_core7 = "/tcm_core@7/btcm_rpu_core7@0x00000";
-		ctcm_rpu_core7 = "/tcm_core@7/ctcm_rpu_core7@0x00000";
+		atcm_rpu_core7 = "/tcm_core@7/atcm_rpu_core7@00000";
+		btcm_rpu_core7 = "/tcm_core@7/btcm_rpu_core7@00000";
+		ctcm_rpu_core7 = "/tcm_core@7/ctcm_rpu_core7@00000";
 		tcm_core8 = "/tcm_core@8";
-		atcm_rpu_core8 = "/tcm_core@8/atcm_rpu_core8@0x00000";
-		btcm_rpu_core8 = "/tcm_core@8/btcm_rpu_core8@0x00000";
-		ctcm_rpu_core8 = "/tcm_core@8/ctcm_rpu_core8@0x00000";
+		atcm_rpu_core8 = "/tcm_core@8/atcm_rpu_core8@00000";
+		btcm_rpu_core8 = "/tcm_core@8/btcm_rpu_core8@00000";
+		ctcm_rpu_core8 = "/tcm_core@8/ctcm_rpu_core8@00000";
 		tcm_core9 = "/tcm_core@9";
-		atcm_rpu_core9 = "/tcm_core@9/atcm_rpu_core9@0x00000";
-		btcm_rpu_core9 = "/tcm_core@9/btcm_rpu_core9@0x00000";
-		ctcm_rpu_core9 = "/tcm_core@9/ctcm_rpu_core9@0x00000";
+		atcm_rpu_core9 = "/tcm_core@9/atcm_rpu_core9@00000";
+		btcm_rpu_core9 = "/tcm_core@9/btcm_rpu_core9@00000";
+		ctcm_rpu_core9 = "/tcm_core@9/ctcm_rpu_core9@00000";
 		tcm_cluster_a = "/tcm_cluster_a@0";
 		tcm_cluster_b = "/tcm_cluster_b@0";
 		tcm_cluster_c = "/tcm_cluster_c@0";
@@ -7847,8 +7847,8 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		apu31_ns_memattr = "/apu31_ns_ma";
 		asu_cpu_memattr = "/asu_cpu_ma";
 		lmb_amba_asu = "/lmb_amba_asu@0";
-		ocm_mem = "/ocm_mem@0xbbe00000";
-		asu_dram = "/asu_data_ram_wrapper@0xebe40000";
+		ocm_mem = "/ocm_mem@bbe00000";
+		asu_dram = "/asu_data_ram_wrapper@ebe40000";
 		psm_gic_proxy = "/psm_gic_proxy@0";
 		asu_cpu = "/asu_cpu@0";
 	};

--- a/boards/amd/versalnet_apu/versalnet_apu-qemu.dts
+++ b/boards/amd/versalnet_apu/versalnet_apu-qemu.dts
@@ -694,7 +694,7 @@
 				phandle = <0xc9>;
 			};
 
-			loader_write_cpu0_0x1@0xf1110880 {
+			loader_write_cpu0_0x1@f1110880 {
 				compatible = "loader";
 				addr = <0xf1110880>;
 				data = <0x01>;
@@ -706,7 +706,7 @@
 				phandle = <0xca>;
 			};
 
-			loader_write_cpu0_0x5@0xfd1a0050 {
+			loader_write_cpu0_0x5@fd1a0050 {
 				compatible = "loader";
 				addr = <0xfd1a0050>;
 				data = <0x05>;
@@ -718,7 +718,7 @@
 				phandle = <0xcb>;
 			};
 
-			loader_write_cpu0_0xFF@0xf111010c {
+			loader_write_cpu0_0xFF@f111010c {
 				compatible = "loader";
 				addr = <0xf111010c>;
 				data = <0xff>;
@@ -744,7 +744,7 @@
 				phandle = <0x2c>;
 			};
 
-			loader_write_cpu0_0x80C@0xf12b0100 {
+			loader_write_cpu0_0x80C@f12b0100 {
 				compatible = "loader";
 				addr = <0xf12b0100>;
 				data = <0x80c>;
@@ -777,7 +777,7 @@
 				reg = <0x00 0x00 0xffffffff 0xffffffff 0xffffffff>;
 			};
 
-			xppu_lpd@0xeb990000 {
+			xppu_lpd@eb990000 {
 				compatible = "xlnx,versal-xppu";
 				/* dts-format off */
 				reg-extended = <0x08 0x00 0xeb990000 0x00 0x10000 0x00 0x12
@@ -790,7 +790,7 @@
 				phandle = <0xce>;
 			};
 
-			ethernet@0xf19e0000 {
+			ethernet@f19e0000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				#priority-cells = <0x00>;
@@ -807,7 +807,7 @@
 				phandle = <0xcf>;
 			};
 
-			ethernet@0xf19f0000 {
+			ethernet@f19f0000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				#priority-cells = <0x00>;
@@ -824,7 +824,7 @@
 				phandle = <0xd0>;
 			};
 
-			serial@0xf1920000 {
+			serial@f1920000 {
 				compatible = "pl011";
 				interrupts = <0x19>;
 				reg = <0x00 0xf1920000 0x00 0x10000 0x00>;
@@ -833,7 +833,7 @@
 				phandle = <0xd1>;
 			};
 
-			serial@0xf1930000 {
+			serial@f1930000 {
 				compatible = "pl011";
 				interrupts = <0x1a>;
 				reg = <0x00 0xf1930000 0x00 0x10000 0x00>;
@@ -847,7 +847,7 @@
 				phandle = <0x1b>;
 			};
 
-			can@0xf1980000 {
+			can@f1980000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -859,7 +859,7 @@
 				phandle = <0xd3>;
 			};
 
-			can@0xf1990000 {
+			can@f1990000 {
 				compatible = "xlnx,versal-canfd";
 				rx-fifo0 = <0x40>;
 				rx-fifo1 = <0x40>;
@@ -871,7 +871,7 @@
 				phandle = <0xd4>;
 			};
 
-			crl@0xeb5e0000 {
+			crl@eb5e0000 {
 				compatible = "xlnx,psx_crl";
 				reg = <0x00 0xeb5e0000 0x00 0x300000 0x00>;
 				gpio-controller;
@@ -879,13 +879,13 @@
 				phandle = <0x16>;
 			};
 
-			slcr@0xf19a0000 {
+			slcr@f19a0000 {
 				compatible = "xlnx,versal-lpd-iou-slcr";
 				reg = <0x00 0xf19a0000 0x00 0x20000 0x00>;
 				phandle = <0xd5>;
 			};
 
-			ipi@0xeb300000 {
+			ipi@eb300000 {
 				compatible = "xlnx,versal-ipi";
 				reg = <0x00 0xeb300000 0x00 0x100000 0x00>;
 				interrupts = <0xfb2 0xbd4 0x39 0x3a 0x3b 0x3c 0x3d 0x3e
@@ -895,7 +895,7 @@
 				phandle = <0xd6>;
 			};
 
-			spi@0xf1960000 {
+			spi@f1960000 {
 				compatible = "cdns,spi-r1p6";
 				interrupts = <0x17>;
 				num-ss-bits = <0x04>;
@@ -917,14 +917,14 @@
 					blockdev-node-name = "spi0_flash0";
 					phandle = <0xd8>;
 
-					spi0_flash0@0x00000000 {
+					spi0_flash0@00000000 {
 						label = "spi0_flash0";
 						reg = <0x00 0x100000>;
 					};
 				};
 			};
 
-			spi@0xf1970000 {
+			spi@f1970000 {
 				compatible = "cdns,spi-r1p6";
 				interrupts = <0x18>;
 				num-ss-bits = <0x04>;
@@ -946,7 +946,7 @@
 					blockdev-node-name = "spi1_flash0";
 					phandle = <0xda>;
 
-					spi1_flash0@0x00000000 {
+					spi1_flash0@00000000 {
 						label = "spi1_flash0";
 						reg = <0x00 0x100000>;
 					};
@@ -966,7 +966,7 @@
 				phandle = <0xdb>;
 			};
 
-			timer@0xf1dc0000 {
+			timer@f1dc0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2b 0x2c 0x2d>;
 				reg = <0x00 0xf1dc0000 0x00 0x10000 0x00>;
@@ -975,7 +975,7 @@
 				phandle = <0xdc>;
 			};
 
-			timer@0xf1dd0000 {
+			timer@f1dd0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x2e 0x2f 0x30>;
 				reg = <0x00 0xf1dd0000 0x00 0x10000 0x00>;
@@ -984,7 +984,7 @@
 				phandle = <0xdd>;
 			};
 
-			timer@0xf1de0000 {
+			timer@f1de0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x31 0x32 0x33>;
 				reg = <0x00 0xf1de0000 0x00 0x10000 0x00>;
@@ -993,7 +993,7 @@
 				phandle = <0xde>;
 			};
 
-			timer@0xf1df0000 {
+			timer@f1df0000 {
 				compatible = "xlnx,ps7-ttc-1.00.a";
 				interrupts = <0x34 0x35 0x36>;
 				reg = <0x00 0xf1df0000 0x00 0x10000 0x00>;
@@ -1008,7 +1008,7 @@
 				phandle = <0x1d>;
 			};
 
-			dma-controller@0xebd00000 {
+			dma-controller@ebd00000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd00000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1030,7 +1030,7 @@
 				phandle = <0x1f>;
 			};
 
-			dma-controller@0xebd10000 {
+			dma-controller@ebd10000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd10000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1052,7 +1052,7 @@
 				phandle = <0x20>;
 			};
 
-			dma-controller@0xebd20000 {
+			dma-controller@ebd20000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd20000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1074,7 +1074,7 @@
 				phandle = <0x21>;
 			};
 
-			dma-controller@0xebd30000 {
+			dma-controller@ebd30000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd30000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1096,7 +1096,7 @@
 				phandle = <0x22>;
 			};
 
-			dma-controller@0xebd40000 {
+			dma-controller@ebd40000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd40000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1118,7 +1118,7 @@
 				phandle = <0x23>;
 			};
 
-			dma-controller@0xebd50000 {
+			dma-controller@ebd50000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd50000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1140,7 +1140,7 @@
 				phandle = <0x24>;
 			};
 
-			dma-controller@0xebd60000 {
+			dma-controller@ebd60000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd60000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1162,7 +1162,7 @@
 				phandle = <0x25>;
 			};
 
-			dma-controller@0xebd70000 {
+			dma-controller@ebd70000 {
 				compatible = "xlnx,zdma";
 				reg = <0x00 0xebd70000 0x00 0x10000 0x00>;
 				bus-width = <0x80>;
@@ -1178,13 +1178,13 @@
 				phandle = <0xe7>;
 			};
 
-			afi_fm@0xeb9b0000 {
+			afi_fm@eb9b0000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xeb9b0000 0x00 0x10000 0x00>;
 			};
 
 			lpd_i2c_wrapper {
-				ps_i2c0@0xf1940000 {
+				ps_i2c0@f1940000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1200,7 +1200,7 @@
 					};
 				};
 
-				ps_i2c0@0xf1950000 {
+				ps_i2c0@f1950000 {
 					#address-cells = <0x01>;
 					#size-cells = <0x00>;
 					compatible = "xlnx,ps7-i2c-1.00.a\0cdns,i2c-r1p10";
@@ -1242,12 +1242,12 @@
 				phandle = <0xec>;
 			};
 
-			lpd_slcr@0xeb410000 {
+			lpd_slcr@eb410000 {
 				compatible = "xlnx,versal-lpd-slcr";
 				reg = <0x00 0xeb410000 0x00 0x100000 0x00>;
 			};
 
-			lpd_slcr_secure@0xeb510000 {
+			lpd_slcr_secure@eb510000 {
 				compatible = "xlnx,versal-lpd-slcr-secure";
 				reg = <0x00 0xeb510000 0x00 0x40000 0x00>;
 				gpio-controller;
@@ -1255,7 +1255,7 @@
 				phandle = <0x1e>;
 			};
 
-			lpd_iou_slcr_secure@0xf19c0000 {
+			lpd_iou_slcr_secure@f19c0000 {
 				compatible = "xlnx,versal-lpd-iou-slcr-secure";
 				reg = <0x00 0xf19c0000 0x00 0x10000 0x00>;
 				memattr-gem0 = <0x14>;
@@ -1265,7 +1265,7 @@
 				phandle = <0xed>;
 			};
 
-			lpd_gpio@0xf19d0000 {
+			lpd_gpio@f19d0000 {
 				#gpio-cells = <0x01>;
 				compatible = "xlnx,zynqmp-gpio";
 				gpio-controller;
@@ -1275,7 +1275,7 @@
 				phandle = <0xee>;
 			};
 
-			intlpd@0xea600000 {
+			intlpd@ea600000 {
 				compatible = "xlnx-intlpd-config";
 				reg = <0x00 0xea600000 0x00 0x200000 0x00>;
 				interrupts = <0x50>;
@@ -1336,7 +1336,7 @@
 				phandle = <0xf0>;
 			};
 
-			rpu_cluster@0xeb580000 {
+			rpu_cluster@eb580000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb580000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1345,7 +1345,7 @@
 				phandle = <0x2a>;
 			};
 
-			rpu_ctrl_a0@0xeb588000 {
+			rpu_ctrl_a0@eb588000 {
 				compatible = "xlnx,psx_rpu_cluster_core0";
 				reg = <0x00 0xeb588000 0x00 0x4000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1355,7 +1355,7 @@
 				phandle = <0xae>;
 			};
 
-			rpu_ctrl_a1@0xeb58c000 {
+			rpu_ctrl_a1@eb58c000 {
 				compatible = "xlnx,psx_rpu_cluster_core1";
 				reg = <0x00 0xeb58c000 0x00 0x4000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1365,7 +1365,7 @@
 				phandle = <0xb1>;
 			};
 
-			rpu_cluster@0xeb590000 {
+			rpu_cluster@eb590000 {
 				compatible = "xlnx,psx_rpu_cluster_2.0";
 				reg = <0x00 0xeb590000 0x00 0x8000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1374,7 +1374,7 @@
 				phandle = <0x2e>;
 			};
 
-			rpu_ctrl_b0@0xeb598000 {
+			rpu_ctrl_b0@eb598000 {
 				compatible = "xlnx,psx_rpu_cluster_core0";
 				reg = <0x00 0xeb598000 0x00 0x4000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1384,7 +1384,7 @@
 				phandle = <0xb4>;
 			};
 
-			rpu_ctrl_b1@0xeb59c000 {
+			rpu_ctrl_b1@eb59c000 {
 				compatible = "xlnx,psx_rpu_cluster_core1";
 				reg = <0x00 0xeb59c000 0x00 0x4000 0x00>;
 				#gpio-cells = <0x01>;
@@ -1394,7 +1394,7 @@
 				phandle = <0xb7>;
 			};
 
-			rpu_pcil@0xeb420000 {
+			rpu_pcil@eb420000 {
 				compatible = "xlnx,rpu_pcil";
 				reg = <0x00 0xeb420000 0x00 0x10000 0x00>;
 				gpio-controller;
@@ -1424,39 +1424,39 @@
 			ranges;
 			phandle = <0x09>;
 
-			afi_fm@0xec880000 {
+			afi_fm@ec880000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xec880000 0x00 0x10000 0x00>;
 			};
 
-			afi_fm@0xec8a0000 {
+			afi_fm@ec8a0000 {
 				compatible = "xlnx,versal-afi-fm";
 				reg = <0x00 0xec8a0000 0x00 0x10000 0x00>;
 			};
 
-			cpm_crcpm@0xfca00000 {
+			cpm_crcpm@fca00000 {
 				compatible = "xlnx,versal_cpm_crcpm";
 				reg = <0x00 0xfca00000 0x00 0x10000 0x00>;
 			};
 
-			cpm_pcsr@0xfcff0000 {
+			cpm_pcsr@fcff0000 {
 				compatible = "xlnx,versal_cpm_pcsr";
 				reg = <0x00 0xfcff0000 0x00 0x10000 0x00>;
 			};
 
-			fpd_slcr@0xec8c0000 {
+			fpd_slcr@ec8c0000 {
 				compatible = "xlnx,versal-fpd-slcr";
 				interrupts = <0xa3>;
 				reg = <0x00 0xec8c0000 0x00 0x10000 0x00>;
 			};
 
-			fpd_slcr_secure@0xec8c0000 {
+			fpd_slcr_secure@ec8c0000 {
 				compatible = "xlnx,versal-fpd-slcr-secure";
 				interrupts = <0xa3>;
 				reg = <0x00 0xec8e0000 0x00 0x10000 0x00>;
 			};
 
-			watchdog@0xecc10000 {
+			watchdog@ecc10000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xecc10000 0x00 0x10000 0x00>;
 				interrupts = <0x8b 0x8c 0x8d 0x8e>;
@@ -1465,7 +1465,7 @@
 				phandle = <0xf2>;
 			};
 
-			intfpd@0xec400000 {
+			intfpd@ec400000 {
 				compatible = "xlnx-intfpd-config";
 				reg = <0x00 0xec400000 0x00 0x400000 0x00>;
 				interrupts = <0xa3>;
@@ -1524,7 +1524,7 @@
 				phandle = <0xf7>;
 			};
 
-			cmn600ae@0xa0000000 {
+			cmn600ae@a0000000 {
 				compatible = "arm,cmn600ae";
 				reg = <0x00 0xa0000000 0x00 0x3000000 0x00>;
 			};
@@ -1559,51 +1559,51 @@
 				phandle = <0xf8>;
 			};
 
-			dummy_pcie@0x6_0000_0000 {
+			dummy_pcie@6_0000_0000 {
 				compatible = "PCI";
 				phandle = <0x4e>;
 			};
 
-			pki_rng@0x20400040000ull {
+			pki_rng@20400040000 {
 				compatible = "xlnx,psx-pki-rng";
 				reg = <0x204 0x40000 0x00 0x20000 0x00>;
 				interrupts = <0x9c>;
 				phandle = <0xf9>;
 			};
 
-			apu_pcil@0xecb10000 {
+			apu_pcil@ecb10000 {
 				compatible = "xlnx.apu_pcil";
 				reg = <0x00 0xecb10000 0x00 0x10000 0x00>;
 				phandle = <0xfa>;
 			};
 
-			cpm5_crx@0xdc0000 {
+			cpm5_crx@dc0000 {
 				compatible = "xlnx,cpm5_crx";
 				reg = <0x00 0xe4dc0000 0x00 0x10000 0x00>;
 				phandle = <0xfb>;
 			};
 
-			cpm5_slcr_secure@0xde0000 {
+			cpm5_slcr_secure@de0000 {
 				compatible = "xlnx,cpm5_slcr_secure";
 				reg = <0x00 0xe4de0000 0x00 0x10000 0x00>;
 			};
 
-			cpm5_gtyp_cfg@0xd00000 {
+			cpm5_gtyp_cfg@d00000 {
 				compatible = "xlnx,gtyp_npi_slave";
 				reg = <0x00 0xe4d00000 0x00 0x20000 0x00>;
 			};
 
-			cpm5_gtyp_cfg@0xd20000 {
+			cpm5_gtyp_cfg@d20000 {
 				compatible = "xlnx,gtyp_npi_slave";
 				reg = <0x00 0xe4d20000 0x00 0x20000 0x00>;
 			};
 
-			cpm5_gtyp_cfg@0xd40000 {
+			cpm5_gtyp_cfg@d40000 {
 				compatible = "xlnx,gtyp_npi_slave";
 				reg = <0x00 0xe4d40000 0x00 0x20000 0x00>;
 			};
 
-			cpm5_gtyp_cfg@0xd60000 {
+			cpm5_gtyp_cfg@d60000 {
 				compatible = "xlnx,gtyp_npi_slave";
 				reg = <0x00 0xe4d60000 0x00 0x20000 0x00>;
 			};
@@ -1665,7 +1665,7 @@
 				phandle = <0xfc>;
 			};
 
-			xppu_pmc_npi@0xf1300000 {
+			xppu_pmc_npi@f1300000 {
 				compatible = "xlnx,versal-xppu";
 				reg-extended = <0x0a 0x00 0xf1300000 0x00 0x10000
 						0x00 0x0a 0x00 0xf6000000 0x00 0x1000000
@@ -1676,7 +1676,7 @@
 				phandle = <0xfd>;
 			};
 
-			xppu_pmc@0xf1310000 {
+			xppu_pmc@f1310000 {
 				compatible = "xlnx,versal-xppu";
 				reg-extended = <0x0a 0x00 0xf1310000 0x00 0x10000 0x00 0x0b
 						0x00 0xf1000000 0x00 0x1000000 0x02 0x0b 0x00
@@ -1709,7 +1709,7 @@
 				reg = <0x00 0x00 0xffffffff 0xffffffff 0xffffffff>;
 			};
 
-			xmpu_pmc_cfu@0xf1340000 {
+			xmpu_pmc_cfu@f1340000 {
 				compatible = "xlnx,versal-xmpu";
 				reg-extended = <0x55 0x00 0xf1340000 0x00 0x10000 0x00 0x52
 						0x00 0xf12b0000 0x00 0x11000 0x02 0x52
@@ -1720,7 +1720,7 @@
 				phandle = <0xff>;
 			};
 
-			pmx_err_mng@0xf1110000 {
+			pmx_err_mng@f1110000 {
 				compatible = "xlnx,pmx-err-mng";
 				reg = <0x00 0xf1130000 0x00 0x10000 0x01>;
 				phandle = <0x100>;
@@ -1737,7 +1737,7 @@
 			doc-status = "partial";
 			phandle = <0x12>;
 
-			pmc_iou_slcr@0xf1060000 {
+			pmc_iou_slcr@f1060000 {
 				doc-status = "partial";
 				compatible = "xlnx,versal-pmx-iou-slcr";
 				reg = <0x00 0xf1060000 0x00 0x1000 0x00>;
@@ -1747,7 +1747,7 @@
 				phandle = <0x65>;
 			};
 
-			pmc_iou_slcr_secure@0xf1070000 {
+			pmc_iou_slcr_secure@f1070000 {
 				compatible = "xlnx,versal-pmc-iou-slcr-secure";
 				reg = <0x00 0xf1070000 0x00 0x10000 0x00>;
 				interrupts = <0xbca>;
@@ -1774,7 +1774,7 @@
 				phandle = <0x5f>;
 			};
 
-			pmc_qspi@0xf1030000 {
+			pmc_qspi@f1030000 {
 				doc-status = "complete";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
@@ -1804,7 +1804,7 @@
 					drive-index = <0x00>;
 					phandle = <0x103>;
 
-					qspi_flash_lcs_lb@0x00000000 {
+					qspi_flash_lcs_lb@00000000 {
 						label = "qspi_flash_lcs_lb";
 						reg = <0x00 0x2000000>;
 					};
@@ -1821,7 +1821,7 @@
 					drive-index = <0x03>;
 					phandle = <0x104>;
 
-					qspi_flash_ucs_ub@0x00000000 {
+					qspi_flash_ucs_ub@00000000 {
 						label = "qspi_flash_ucs_ub";
 						reg = <0x00 0x2000000>;
 					};
@@ -1854,7 +1854,7 @@
 				phandle = <0x64>;
 			};
 
-			spi@0xf1010000 {
+			spi@f1010000 {
 				doc-status = "complete";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
@@ -1869,7 +1869,7 @@
 				phandle = <0x105>;
 			};
 
-			gpio_mr_mux@0xc0000000 {
+			gpio_mr_mux@c0000000 {
 				doc-status = "complete";
 				compatible = "gpio-mr-mux";
 				reg = <0x00 0xc0000000 0x00 0x20000000 0x00>;
@@ -1882,7 +1882,7 @@
 				phandle = <0x106>;
 			};
 
-			pmc_gpio@0xf1020000 {
+			pmc_gpio@f1020000 {
 				#gpio-cells = <0x01>;
 				compatible = "xlnx,zynqmp-gpio";
 				gpio-controller;
@@ -1892,7 +1892,7 @@
 				phandle = <0x107>;
 			};
 
-			mmc@0xf1040000 {
+			mmc@f1040000 {
 				doc-status = "complete";
 				compatible = "xilinx,zynqmp-sdhci\0generic-sdhci";
 				drive-index = <0x00>;
@@ -1912,7 +1912,7 @@
 				phandle = <0x108>;
 			};
 
-			mmc@0xf1050000 {
+			mmc@f1050000 {
 				doc-status = "complete";
 				compatible = "xlnx,versalnet-emmc";
 				drive-index = <0x01>;
@@ -1933,7 +1933,7 @@
 				phandle = <0x109>;
 			};
 
-			pmc_tap@0xf11a0000 {
+			pmc_tap@f11a0000 {
 				doc-status = "complete";
 				doc-comments = "Just a stub.";
 				compatible = "xlnx,pmc-tap";
@@ -1947,7 +1947,7 @@
 
 			pmc_i2c_wrapper {};
 
-			wwdt@0xf03f0000 {
+			wwdt@f03f0000 {
 				compatible = "xlnx,versal-wwdt";
 				reg = <0x00 0xf03f0000 0x00 0x10000 0x00>;
 				pclk = <0x5f5e100>;
@@ -1967,7 +1967,7 @@
 Cannot continue.Try installing libgcrypt.";
 			phandle = <0x50>;
 
-			trng@0xf1230000 {
+			trng@f1230000 {
 				doc-status = "complete";
 				compatible = "xlnx,versal-trng";
 				reg = <0x00 0xf1230000 0x00 0x1000 0x00>;
@@ -2043,7 +2043,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x67>;
 			};
 
-			pmc_sha@0xf1210000 {
+			pmc_sha@f1210000 {
 				doc-status = "complete";
 				compatible = "zynqmp,csu-sha3";
 				reg = <0x00 0xf1210000 0x00 0x100 0x00>;
@@ -2051,7 +2051,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x6d>;
 			};
 
-			pmc_aes@0xf11e0000 {
+			pmc_aes@f11e0000 {
 				doc-status = "in-progress";
 				#gpio-cells = <0x01>;
 				gpio-controller;
@@ -2073,7 +2073,7 @@ Cannot continue.Try installing libgcrypt.";
 				};
 			};
 
-			pmc_rsa@0xf1200000 {
+			pmc_rsa@f1200000 {
 				doc-status = "complete";
 				reg = <0x00 0xf1200000 0x00 0x6c 0x00>;
 				interrupts = <0xc3>;
@@ -2081,7 +2081,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x10e>;
 			};
 
-			xlnx_pmc_efuse_cache@0xf1250000 {
+			xlnx_pmc_efuse_cache@f1250000 {
 				doc-status = "complete";
 				compatible = "xlnx,pmx_efuse_cache";
 				reg = <0x00 0xf1250000 0x00 0x10000 0x00>;
@@ -2099,7 +2099,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x73>;
 			};
 
-			pmc_efuse@0xf1240000 {
+			pmc_efuse@f1240000 {
 				doc-status = "complete";
 				compatible = "xlnx,pmx_efuse_ctrl";
 				#gpio-cells = <0x02>;
@@ -2121,7 +2121,7 @@ Cannot continue.Try installing libgcrypt.";
 				};
 			};
 
-			pmc_bbram@0xf11f0000 {
+			pmc_bbram@f11f0000 {
 				doc-status = "partial";
 				doc-limitations = "Missing AES key connections.";
 				compatible = "xlnx,bbram-ctrl";
@@ -2132,7 +2132,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x74>;
 			};
 
-			pmc_sbi@0xf1220000 {
+			pmc_sbi@f1220000 {
 				doc-status = "complete";
 				compatible = "pmc,slave-boot";
 				reg = <0x00 0xf1220000 0x00 0x10000 0x00
@@ -2143,7 +2143,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x6e>;
 			};
 
-			pmc_sha1@0xf1800000 {
+			pmc_sha1@f1800000 {
 				doc-status = "complete";
 				compatible = "zynqmp,csu-sha3";
 				reg = <0x00 0xf1800000 0x00 0x10000 0x00>;
@@ -2182,7 +2182,7 @@ Cannot continue.Try installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x51>;
 
-			pmc_clk_rst@0xf1260000 {
+			pmc_clk_rst@f1260000 {
 				doc-status = "partial";
 				compatible = "xlnx,pmx_crp";
 				reg = <0x00 0xf1260000 0x00 0x80000 0x00>;
@@ -2192,7 +2192,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x5e>;
 			};
 
-			pmc_int@0xf1400000 {
+			pmc_int@f1400000 {
 				doc-status = "partial";
 				compatible = "xlnx,versal-pmc-int";
 				reg = <0x00 0xf1400000 0x00 0x300000 0x00>;
@@ -2205,7 +2205,7 @@ Cannot continue.Try installing libgcrypt.";
 				gpios = <0x5e 0x02>;
 			};
 
-			pmc_global@0xf1110000 {
+			pmc_global@f1110000 {
 				doc-status = "partial";
 				#gpio-cells = <0x01>;
 				gpio-controller;
@@ -2224,7 +2224,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x76>;
 			};
 
-			pmc_err_mng@0xf1130000 {
+			pmc_err_mng@f1130000 {
 				compatible = "xlnx,PmcErrMngmnt";
 				reg = <0x00 0xf1130000 0x00 0x10000 0x00>;
 				interrupts = <0xbca>;
@@ -2238,14 +2238,14 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x112>;
 			};
 
-			pmc_analog@0xf1160000 {
+			pmc_analog@f1160000 {
 				compatible = "xlnx,pmx_anlg";
 				reg = <0x00 0xf1160000 0x00 0x40000 0x00>;
 				interrupts-extended = <0x04 0x00 0xdd 0x00>;
 				tamper-sink = <0x76>;
 			};
 
-			pmc_sysmon@0xf1270000 {
+			pmc_sysmon@f1270000 {
 				compatible = "xlnx,pmc-sysmon";
 				reg = <0x00 0xf1270000 0x00 0x30000 0x00>;
 				interrupts = <0xca 0xcb>;
@@ -2316,13 +2316,13 @@ Cannot continue.Try installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x52>;
 
-			noc_npi_nir@0xf6000000 {
+			noc_npi_nir@f6000000 {
 				compatible = "xlnx.npi-nir";
 				reg = <0x00 0xf6000000 0x00 0x10000 0x01>;
 				phandle = <0x115>;
 			};
 
-			npi_ddrmc_ub0@0xf67c0000 {
+			npi_ddrmc_ub0@f67c0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf67c0000 0x00 0x40000 0x01>;
@@ -2332,7 +2332,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x116>;
 			};
 
-			npi_ddrmc_main0@0xf6790000 {
+			npi_ddrmc_main0@f6790000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6790000 0x00 0x10000 0x01>;
@@ -2340,7 +2340,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0xa5>;
 			};
 
-			npi_ddrmc_noc0@0xf67a0000 {
+			npi_ddrmc_noc0@f67a0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf67a0000 0x00 0x20000 0xffffffff>;
@@ -2348,7 +2348,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x117>;
 			};
 
-			npi_ddrmc_ub1@0xf68b0000 {
+			npi_ddrmc_ub1@f68b0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf68b0000 0x00 0x40000 0x01>;
@@ -2358,7 +2358,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x118>;
 			};
 
-			npi_ddrmc_main1@0xf6880000 {
+			npi_ddrmc_main1@f6880000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6880000 0x00 0x10000 0x01>;
@@ -2366,7 +2366,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x119>;
 			};
 
-			npi_ddrmc_noc1@0xf6890000 {
+			npi_ddrmc_noc1@f6890000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6890000 0x00 0x20000 0xffffffff>;
@@ -2374,7 +2374,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11a>;
 			};
 
-			npi_ddrmc_ub2@0xf6dc0000 {
+			npi_ddrmc_ub2@f6dc0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf6dc0000 0x00 0x40000 0x01>;
@@ -2384,7 +2384,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11b>;
 			};
 
-			npi_ddrmc_main2@0xf6d90000 {
+			npi_ddrmc_main2@f6d90000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6d90000 0x00 0x10000 0x01>;
@@ -2392,7 +2392,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11c>;
 			};
 
-			npi_ddrmc_noc2@0xf6da0000 {
+			npi_ddrmc_noc2@f6da0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6da0000 0x00 0x20000 0xffffffff>;
@@ -2400,7 +2400,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11d>;
 			};
 
-			npi_ddrmc_ub3@0xf6eb0000 {
+			npi_ddrmc_ub3@f6eb0000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf6eb0000 0x00 0x40000 0x01>;
@@ -2410,7 +2410,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11e>;
 			};
 
-			npi_ddrmc_main3@0xf6e80000 {
+			npi_ddrmc_main3@f6e80000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6e80000 0x00 0x10000 0x01>;
@@ -2418,7 +2418,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x11f>;
 			};
 
-			npi_ddrmc_noc3@0xf6e90000 {
+			npi_ddrmc_noc3@f6e90000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6e90000 0x00 0x20000 0xffffffff>;
@@ -2426,7 +2426,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x120>;
 			};
 
-			npi_ddrmc_ub4@0xf6f70000 {
+			npi_ddrmc_ub4@f6f70000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf6f70000 0x00 0x40000 0x01>;
@@ -2436,7 +2436,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x121>;
 			};
 
-			npi_ddrmc_main4@0xf6f40000 {
+			npi_ddrmc_main4@f6f40000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf6f40000 0x00 0x10000 0x01>;
@@ -2444,7 +2444,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x122>;
 			};
 
-			npi_ddrmc_noc4@0xf6f50000 {
+			npi_ddrmc_noc4@f6f50000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf6f50000 0x00 0x20000 0xffffffff>;
@@ -2452,7 +2452,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x123>;
 			};
 
-			npi_ddrmc_ub5@0xf7060000 {
+			npi_ddrmc_ub5@f7060000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf7060000 0x00 0x40000 0x01>;
@@ -2462,7 +2462,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x124>;
 			};
 
-			npi_ddrmc_main5@0xf7030000 {
+			npi_ddrmc_main5@f7030000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf7030000 0x00 0x10000 0x01>;
@@ -2470,7 +2470,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x125>;
 			};
 
-			npi_ddrmc_noc5@0xf7040000 {
+			npi_ddrmc_noc5@f7040000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf7040000 0x00 0x20000 0xffffffff>;
@@ -2478,7 +2478,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x126>;
 			};
 
-			npi_ddrmc_ub6@0xf7320000 {
+			npi_ddrmc_ub6@f7320000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf7320000 0x00 0x40000 0x01>;
@@ -2488,7 +2488,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x127>;
 			};
 
-			npi_ddrmc_main6@0xf72f0000 {
+			npi_ddrmc_main6@f72f0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf72f0000 0x00 0x10000 0x01>;
@@ -2496,7 +2496,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x128>;
 			};
 
-			npi_ddrmc_noc6@0xf7300000 {
+			npi_ddrmc_noc6@f7300000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf7300000 0x00 0x20000 0xffffffff>;
@@ -2504,7 +2504,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x129>;
 			};
 
-			npi_ddrmc_ub7@0xf7400000 {
+			npi_ddrmc_ub7@f7400000 {
 				doc-limitations = "Only the uB rst is supported";
 				compatible = "xlnx,ddrmc5_ub";
 				reg = <0x00 0xf7400000 0x00 0x40000 0x01>;
@@ -2514,7 +2514,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x12a>;
 			};
 
-			npi_ddrmc_main7@0xf73d0000 {
+			npi_ddrmc_main7@f73d0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-main";
 				reg = <0x00 0xf73d0000 0x00 0x10000 0x01>;
@@ -2522,7 +2522,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x12b>;
 			};
 
-			npi_ddrmc_noc7@0xf73e0000 {
+			npi_ddrmc_noc7@f73e0000 {
 				doc-limitations = "Just a stub";
 				compatible = "xlnx,versal-ddrmc-noc";
 				reg = <0x00 0xf73e0000 0x00 0x20000 0xffffffff>;
@@ -2530,7 +2530,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x12c>;
 			};
 
-			npi_ddrmc_xmpu0@0xf67a0000 {
+			npi_ddrmc_xmpu0@f67a0000 {
 				compatible = "xlnx,versal-ddrmc-xmpu";
 				reg-extended = <0x52 0x00 0xf67b0000 0x00 0x10000 0x01 0x0b
 						0x00 0x00 0x00 0x80000000 0x00>;
@@ -2546,20 +2546,20 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x12e>;
 			};
 
-			cfu_fdro@0xf12c2000 {
+			cfu_fdro@f12c2000 {
 				compatible = "xlnx,versal-cfu-fdro";
 				reg = <0x00 0xf12c2000 0x00 0x1000 0x00>;
 				phandle = <0x81>;
 			};
 
-			cfu_sfr@0xf12c1000 {
+			cfu_sfr@f12c1000 {
 				compatible = "xlnx,versal-cfu-sfr";
 				reg = <0x00 0xf12c1000 0x00 0x1000 0x00>;
 				cfu = <0x80>;
 				phandle = <0x12f>;
 			};
 
-			cframe0_reg@0xf12d0000 {
+			cframe0_reg@f12d0000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d0000 0x00 0x1000 0x00
 				       0x00 0xf12d1000 0x00 0x1000 0x00>;
@@ -2575,7 +2575,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x82>;
 			};
 
-			cframe1_reg@0xf12d2000 {
+			cframe1_reg@f12d2000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d2000 0x00 0x1000 0x00
 				       0x00 0xf12d3000 0x00 0x1000 0x00>;
@@ -2591,7 +2591,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x83>;
 			};
 
-			cframe2_reg@0xf12d4000 {
+			cframe2_reg@f12d4000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d4000 0x00 0x1000 0x00
 				       0x00 0xf12d5000 0x00 0x1000 0x00>;
@@ -2607,7 +2607,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x84>;
 			};
 
-			cframe3_reg@0xf12d6000 {
+			cframe3_reg@f12d6000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d6000 0x00 0x1000 0x00
 				       0x00 0xf12d7000 0x00 0x1000 0x00>;
@@ -2623,7 +2623,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x85>;
 			};
 
-			cframe4_reg@0xf12d8000 {
+			cframe4_reg@f12d8000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12d8000 0x00 0x1000 0x00
 				       0x00 0xf12d9000 0x00 0x1000 0x00>;
@@ -2632,7 +2632,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x86>;
 			};
 
-			cframe5_reg@0xf12da000 {
+			cframe5_reg@f12da000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12da000 0x00 0x1000 0x00
 				       0x00 0xf12db000 0x00 0x1000 0x00>;
@@ -2641,7 +2641,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x87>;
 			};
 
-			cframe6_reg@0xf12dc000 {
+			cframe6_reg@f12dc000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12dc000 0x00 0x1000 0x00
 				       0x00 0xf12dd000 0x00 0x1000 0x00>;
@@ -2650,7 +2650,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x88>;
 			};
 
-			cframe7_reg@0xf12de000 {
+			cframe7_reg@f12de000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12de000 0x00 0x1000 0x00
 				       0x00 0xf12df000 0x00 0x1000 0x00>;
@@ -2659,7 +2659,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x89>;
 			};
 
-			cframe8_reg@0xf12e0000 {
+			cframe8_reg@f12e0000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e0000 0x00 0x1000 0x00
 				       0x00 0xf12e1000 0x00 0x1000 0x00>;
@@ -2668,7 +2668,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8a>;
 			};
 
-			cframe9_reg@0xf12e2000 {
+			cframe9_reg@f12e2000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e2000 0x00 0x1000 0x00
 				       0x00 0xf12e3000 0x00 0x1000 0x00>;
@@ -2677,7 +2677,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8b>;
 			};
 
-			cframe10_reg@0xf12e4000 {
+			cframe10_reg@f12e4000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e4000 0x00 0x1000 0x00
 				       0x00 0xf12e5000 0x00 0x1000 0x00>;
@@ -2686,7 +2686,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8c>;
 			};
 
-			cframe11_reg@0xf12e6000 {
+			cframe11_reg@f12e6000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e6000 0x00 0x1000 0x00
 				       0x00 0xf12e7000 0x00 0x1000 0x00>;
@@ -2695,7 +2695,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8d>;
 			};
 
-			cframe12_reg@0xf12e8000 {
+			cframe12_reg@f12e8000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12e8000 0x00 0x1000 0x00 0x00
 				       0xf12e9000 0x00 0x1000 0x00>;
@@ -2704,7 +2704,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8e>;
 			};
 
-			cframe13_reg@0xf12ea000 {
+			cframe13_reg@f12ea000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12ea000 0x00 0x1000 0x00 0x00
 				       0xf12eb000 0x00 0x1000 0x00>;
@@ -2713,7 +2713,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x8f>;
 			};
 
-			cframe14_reg@0xf12ec000 {
+			cframe14_reg@f12ec000 {
 				compatible = "xlnx.cframe_reg";
 				reg = <0x00 0xf12ec000 0x00 0x1000 0x00 0x00
 				       0xf12ed000 0x00 0x1000 0x00>;
@@ -2722,7 +2722,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x90>;
 			};
 
-			cframe_bcast_reg@0xf12ee000 {
+			cframe_bcast_reg@f12ee000 {
 				compatible = "xlnx.cframe-bcast-reg";
 				reg = <0x00 0xf12ee000 0x00 0x1000 0x00
 				       0x00 0xf12ef000 0x00 0x1000 0x00>;
@@ -2744,24 +2744,24 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x130>;
 			};
 
-			gtm_npi_slave_0@0xf6ca0000 {
+			gtm_npi_slave_0@f6ca0000 {
 				compatible = "xlnx,xlnx,gtyp_npi_slave";
 				reg = <0x00 0xf6ca0000 0x00 0x20000 0x00>;
 			};
 
-			gtm_npi_slave_1@0xf6d10000 {
+			gtm_npi_slave_1@f6d10000 {
 				compatible = "xlnx,xlnx,gtyp_npi_slave";
 				reg = <0x00 0xf6d10000 0x00 0x20000 0x00>;
 			};
 
-			hnicx_npi_0@0xf6af0000 {
+			hnicx_npi_0@f6af0000 {
 				compatible = "xlnx,hnicx_npi";
 				reg = <0x00 0xf6af0000 0x00 0x20000 0x01>;
 				doc-limitations = "Just a stub";
 				phandle = <0x131>;
 			};
 
-			hnicx_pllpor_0@0xf6b30000 {
+			hnicx_pllpor_0@f6b30000 {
 				compatible = "xlnx,noc-npi-dev";
 				reg = <0x00 0xf6b30000 0x00 0x10000 0x01>;
 				custom = <0x01>;
@@ -2769,11 +2769,11 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x132>;
 			};
 
-			dummy_cfu_mem@0xf12b0000 {
+			dummy_cfu_mem@f12b0000 {
 				compatible = "qemu:memory-region";
 				phandle = <0x56>;
 
-				cfu@0x0 {
+				cfu@0 {
 					doc-status = "partial";
 					doc-comments = "Stub";
 					doc-limitations = "No way to extract CFRAME data.";
@@ -2797,7 +2797,7 @@ Cannot continue.Try installing libgcrypt.";
 			doc-status = "partial";
 			phandle = <0x53>;
 
-			rtc@0xf12a0000 {
+			rtc@f12a0000 {
 				doc-status = "complete";
 				doc-comments = "Versal PMC RTC";
 				compatible = "xlnx,zynqmp-rtc";
@@ -2816,7 +2816,7 @@ Cannot continue.Try installing libgcrypt.";
 			ranges;
 			phandle = <0x11>;
 
-			psm_ram_instr@0xebc00000 {
+			psm_ram_instr@ebc00000 {
 				device_type = "memory";
 				compatible = "qemu:memory-region";
 				qemu,ram = <0x01>;
@@ -2824,7 +2824,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x134>;
 			};
 
-			psm_ram_data@0xebc20000 {
+			psm_ram_data@ebc20000 {
 				device_type = "memory";
 				compatible = "qemu:memory-region";
 				qemu,ram = <0x01>;
@@ -2844,7 +2844,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0x05>;
 			};
 
-			psm_global_reg@0xebc90000 {
+			psm_global_reg@ebc90000 {
 				compatible = "xlnx,psmx_global_reg";
 				reg = <0x00 0xebc90000 0x00 0xf000 0x00>;
 				interrupt-parent = <0x07>;
@@ -2865,7 +2865,7 @@ Cannot continue.Try installing libgcrypt.";
 				phandle = <0xab>;
 			};
 
-			psm_err_mng@0xebc90000 {
+			psm_err_mng@ebc90000 {
 				compatible = "xlnx.psmx_err_reg";
 				reg = <0x00 0xebc91000 0x00 0x100 0x00>;
 				phandle = <0x136>;
@@ -2916,7 +2916,7 @@ Cannot continue.Try installing libgcrypt.";
 			};
 		};
 
-		crf@0xec200000 {
+		crf@ec200000 {
 			compatible = "xlnx,versal-psx-crf";
 			reg-extended = <0x09 0x00 0xec200000 0x00 0x100000 0x00>;
 			gpio-controller;
@@ -2941,7 +2941,7 @@ Cannot continue.Try installing libgcrypt.";
 			reg = <0x00 0x00 0xffffffff 0xffffffff 0x00>;
 		};
 
-		pmc_rom@0xf0000000 {
+		pmc_rom@f0000000 {
 			reg = <0x00 0xf0000000 0x00 0x40000 0x01>;
 			compatible = "qemu:memory-region";
 			container = <0x7e>;
@@ -2950,7 +2950,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x137>;
 		};
 
-		ppu0_ram@0xf0060000 {
+		ppu0_ram@f0060000 {
 			reg = <0x00 0xf0060000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			container = <0x7e>;
@@ -3504,7 +3504,7 @@ Cannot continue.Try installing libgcrypt.";
 			};
 		};
 
-		psm_local_reg@0xebc88000 {
+		psm_local_reg@ebc88000 {
 			gpio-controller;
 			#gpio-cells = <0x01>;
 			compatible = "xlnx,psmx_local_reg";
@@ -3523,21 +3523,21 @@ Cannot continue.Try installing libgcrypt.";
 		doc-status = "partial";
 		phandle = <0x9f>;
 
-		ddrmc0_ram_data@0x1c000 {
+		ddrmc0_ram_data@1c000 {
 			reg = <0x00 0x1c000 0x00 0x4000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x150>;
 		};
 
-		ddrmc0_ram_instr@0x20000 {
+		ddrmc0_ram_instr@20000 {
 			reg = <0x00 0x20000 0x00 0x20000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x151>;
 		};
 
-		ddrmc0_ram_exchange@0x08000 {
+		ddrmc0_ram_exchange@08000 {
 			reg = <0x00 0x8000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
@@ -3674,21 +3674,21 @@ Cannot continue.Try installing libgcrypt.";
 		ranges;
 		phandle = <0x157>;
 
-		ddrmc1_ram_data@0x1c000 {
+		ddrmc1_ram_data@1c000 {
 			reg = <0x00 0x1c000 0x00 0x4000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x158>;
 		};
 
-		ddrmc1_ram_instr@0x20000 {
+		ddrmc1_ram_instr@20000 {
 			reg = <0x00 0x20000 0x00 0x20000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
 			phandle = <0x159>;
 		};
 
-		ddrmc1_ram_exchange@0x08000 {
+		ddrmc1_ram_exchange@08000 {
 			reg = <0x00 0x8000 0x00 0x8000 0x01>;
 			compatible = "qemu:memory-region";
 			qemu,ram = <0x01>;
@@ -3865,14 +3865,14 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0xba>;
 	};
 
-	memory@0x50000000000ull {
+	memory@50000000000 {
 		compatible = "qemu:memory-region";
 		device_type = "memory";
 		container = <0x0b>;
 		phandle = <0x15b>;
 	};
 
-	ocm_mem@0xbbf00000 {
+	ocm_mem@bbf00000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x0c>;
 	};
@@ -3909,12 +3909,12 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x15f>;
 	};
 
-	xram_mem@0xea800000 {
+	xram_mem@ea800000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x0e>;
 	};
 
-	xram_mem_bank_0@0x0 {
+	xram_mem_bank_0@0 {
 		compatible = "qemu:memory-region";
 		container = <0x0e>;
 		qemu,ram = <0x01>;
@@ -3922,7 +3922,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x160>;
 	};
 
-	xram_mem_bank_1@0x200000 {
+	xram_mem_bank_1@200000 {
 		compatible = "qemu:memory-region";
 		container = <0x0e>;
 		qemu,ram = <0x01>;
@@ -3930,7 +3930,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x161>;
 	};
 
-	xram_mem_bank_2@0x400000 {
+	xram_mem_bank_2@400000 {
 		compatible = "qemu:memory-region";
 		container = <0x0e>;
 		qemu,ram = <0x01>;
@@ -3938,7 +3938,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x162>;
 	};
 
-	xram_mem_bank_3@0x600000 {
+	xram_mem_bank_3@600000 {
 		compatible = "qemu:memory-region";
 		container = <0x0e>;
 		qemu,ram = <0x01>;
@@ -3955,12 +3955,12 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x164>;
 	};
 
-	pmc_ram@0xf2000000 {
+	pmc_ram@f2000000 {
 		compatible = "qemu:memory-region";
 		phandle = <0x54>;
 	};
 
-	pmc_ram_bank_0@0x0 {
+	pmc_ram_bank_0@0 {
 		compatible = "qemu:memory-region";
 		container = <0x54>;
 		qemu,ram = <0x01>;
@@ -3968,7 +3968,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x165>;
 	};
 
-	pmc_ppu1_ram@0xf0200000 {
+	pmc_ppu1_ram@f0200000 {
 		compatible = "qemu:memory-region";
 		container = <0x0b>;
 		qemu,ram = <0x01>;
@@ -3976,7 +3976,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x166>;
 	};
 
-	pmc_ppu1_ram@0xf0280000 {
+	pmc_ppu1_ram@f0280000 {
 		compatible = "qemu:memory-region";
 		container = <0x0b>;
 		qemu,ram = <0x01>;
@@ -3984,14 +3984,14 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x167>;
 	};
 
-	ppu0_mdm_uart@0xf0110000 {
+	ppu0_mdm_uart@f0110000 {
 		doc-status = "complete";
 		compatible = "xlnx,xps-uartlite";
 		reg-extended = <0x7e 0x00 0xf0110000 0x00 0x10 0x01>;
 		chardev = "serial0";
 	};
 
-	ppu1_mdm_uart@0xf0310000 {
+	ppu1_mdm_uart@f0310000 {
 		doc-status = "complete";
 		compatible = "xlnx,xps-uartlite";
 		reg-extended = <0x97 0x00 0xf0310000 0x00 0x10 0x01>;
@@ -4574,7 +4574,7 @@ Cannot continue.Try installing libgcrypt.";
 		priority = <0xffffffff>;
 		phandle = <0x16b>;
 
-		interrupt-controller@0xe2000000 {
+		interrupt-controller@e2000000 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -4605,7 +4605,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x01>;
 		};
 
-		git_its@0xe2040000 {
+		git_its@e2040000 {
 			compatible = "arm-gicv3-its";
 			reg = <0x00 0xe2040000 0x00 0x20000 0x00>;
 			parent-gicv3 = <0x01>;
@@ -4660,7 +4660,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x16d>;
 	};
 
-	ddr@0x00000000 {
+	ddr@00000000 {
 		compatible = "qemu:memory-region";
 		container = <0xb9>;
 		qemu,ram = <0x01>;
@@ -4668,7 +4668,7 @@ Cannot continue.Try installing libgcrypt.";
 		phandle = <0x7f>;
 	};
 
-	ddr_2@0x800000000ull {
+	ddr_2@800000000 {
 		compatible = "qemu:memory-region-spec";
 		container = <0xba>;
 		qemu,ram = <0x01>;
@@ -4756,7 +4756,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0xa8>;
 
-		rpu_gic_a@0x0 {
+		rpu_gic_a@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -4783,7 +4783,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "simple-bus";
 		phandle = <0xbd>;
 
-		rpu_gic_b@0x0 {
+		rpu_gic_b@0 {
 			#address-cells = <0x00>;
 			#size-cells = <0x00>;
 			#interrupt-cells = <0x03>;
@@ -4810,7 +4810,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0xa7>;
 
-		atcm_rpu_core0@0x00000 {
+		atcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa7>;
 			qemu,ram = <0x01>;
@@ -4818,7 +4818,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x171>;
 		};
 
-		btcm_rpu_core0@0x00000 {
+		btcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa7>;
 			qemu,ram = <0x01>;
@@ -4826,7 +4826,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x172>;
 		};
 
-		ctcm_rpu_core0@0x00000 {
+		ctcm_rpu_core0@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa7>;
 			qemu,ram = <0x01>;
@@ -4842,7 +4842,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0xa9>;
 
-		atcm_rpu_core1@0x00000 {
+		atcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa9>;
 			qemu,ram = <0x01>;
@@ -4850,7 +4850,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x174>;
 		};
 
-		btcm_rpu_core1@0x00000 {
+		btcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa9>;
 			qemu,ram = <0x01>;
@@ -4858,7 +4858,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x175>;
 		};
 
-		ctcm_rpu_core1@0x00000 {
+		ctcm_rpu_core1@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xa9>;
 			qemu,ram = <0x01>;
@@ -4874,7 +4874,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0xbb>;
 
-		atcm_rpu_core2@0x00000 {
+		atcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbb>;
 			qemu,ram = <0x01>;
@@ -4882,7 +4882,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x177>;
 		};
 
-		btcm_rpu_core2@0x00000 {
+		btcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbb>;
 			qemu,ram = <0x01>;
@@ -4890,7 +4890,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x178>;
 		};
 
-		ctcm_rpu_core2@0x00000 {
+		ctcm_rpu_core2@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbb>;
 			qemu,ram = <0x01>;
@@ -4906,7 +4906,7 @@ Cannot continue.Try installing libgcrypt.";
 		compatible = "qemu:memory-region";
 		phandle = <0xbc>;
 
-		atcm_rpu_core3@0x00000 {
+		atcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbc>;
 			qemu,ram = <0x01>;
@@ -4914,7 +4914,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x17a>;
 		};
 
-		btcm_rpu_core3@0x00000 {
+		btcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbc>;
 			qemu,ram = <0x01>;
@@ -4922,7 +4922,7 @@ Cannot continue.Try installing libgcrypt.";
 			phandle = <0x17b>;
 		};
 
-		ctcm_rpu_core3@0x00000 {
+		ctcm_rpu_core3@00000 {
 			compatible = "qemu:memory-region";
 			container = <0xbc>;
 			qemu,ram = <0x01>;
@@ -5080,135 +5080,135 @@ Cannot continue.Try installing libgcrypt.";
 		amba = "/amba_root@0/amba@0";
 		xmpu_ocm = "/amba_root@0/amba@0/xmpu_ocm@0";
 		xmpu_ocm2 = "/amba_root@0/amba@0/xmpu_ocm2@0";
-		loader_write_0xF1110880 = "/amba_root@0/amba@0/loader_write_cpu0_0x1@0xF1110880";
-		loader_write_0xFD1A0050 = "/amba_root@0/amba@0/loader_write_cpu0_0x5@0xFD1A0050";
-		loader_write_0xF111010C = "/amba_root@0/amba@0/loader_write_cpu0_0xFF@0xF111010C";
+		loader_write_0xF1110880 = "/amba_root@0/amba@0/loader_write_cpu0_0x1@F1110880";
+		loader_write_0xFD1A0050 = "/amba_root@0/amba@0/loader_write_cpu0_0x5@FD1A0050";
+		loader_write_0xF111010C = "/amba_root@0/amba@0/loader_write_cpu0_0xFF@F111010C";
 		s_axi_tcm_a = "/amba_root@0/amba@0/s_axi_tcm_a@0";
 		s_axi_tcm_b = "/amba_root@0/amba@0/s_axi_tcm_b@0";
-		loader_write_0xF12B0100 = "/amba_root@0/amba@0/loader_write_cpu0_0x80C@0xF12B0100";
+		loader_write_0xF12B0100 = "/amba_root@0/amba@0/loader_write_cpu0_0x80C@F12B0100";
 		amba_lpd = "/amba_root@0/amba_lpd@0";
-		xppu_lpd = "/amba_root@0/amba_lpd@0/xppu_lpd@0xeb990000";
-		gem0 = "/amba_root@0/amba_lpd@0/ethernet@0xf19e0000";
-		gem1 = "/amba_root@0/amba_lpd@0/ethernet@0xf19f0000";
-		serial0 = "/amba_root@0/amba_lpd@0/serial@0xf1920000";
-		serial1 = "/amba_root@0/amba_lpd@0/serial@0xf1930000";
+		xppu_lpd = "/amba_root@0/amba_lpd@0/xppu_lpd@eb990000";
+		gem0 = "/amba_root@0/amba_lpd@0/ethernet@f19e0000";
+		gem1 = "/amba_root@0/amba_lpd@0/ethernet@f19f0000";
+		serial0 = "/amba_root@0/amba_lpd@0/serial@f1920000";
+		serial1 = "/amba_root@0/amba_lpd@0/serial@f1930000";
 		canfdbus0 = "/amba_root@0/amba_lpd@0/canfdbus@0";
-		can0 = "/amba_root@0/amba_lpd@0/can@0xf1980000";
-		can1 = "/amba_root@0/amba_lpd@0/can@0xf1990000";
-		crl = "/amba_root@0/amba_lpd@0/crl@0xeb5e0000";
-		lpd_iou_slcr = "/amba_root@0/amba_lpd@0/slcr@0xf19a0000";
-		ipi = "/amba_root@0/amba_lpd@0/ipi@0xeb300000";
-		spi0 = "/amba_root@0/amba_lpd@0/spi@0xf1960000";
-		spi0_flash0 = "/amba_root@0/amba_lpd@0/spi@0xf1960000/spi0_flash0@0";
-		spi1 = "/amba_root@0/amba_lpd@0/spi@0xf1970000";
-		spi1_flash0 = "/amba_root@0/amba_lpd@0/spi@0xf1970000/spi1_flash0@0";
+		can0 = "/amba_root@0/amba_lpd@0/can@f1980000";
+		can1 = "/amba_root@0/amba_lpd@0/can@f1990000";
+		crl = "/amba_root@0/amba_lpd@0/crl@eb5e0000";
+		lpd_iou_slcr = "/amba_root@0/amba_lpd@0/slcr@f19a0000";
+		ipi = "/amba_root@0/amba_lpd@0/ipi@eb300000";
+		spi0 = "/amba_root@0/amba_lpd@0/spi@f1960000";
+		spi0_flash0 = "/amba_root@0/amba_lpd@0/spi@f1960000/spi0_flash0@0";
+		spi1 = "/amba_root@0/amba_lpd@0/spi@f1970000";
+		spi1_flash0 = "/amba_root@0/amba_lpd@0/spi@f1970000/spi1_flash0@0";
 		dwc3_0 = "/amba_root@0/amba_lpd@0/usb2@USB2_0_XHCI";
-		ttc0 = "/amba_root@0/amba_lpd@0/timer@0xf1dc0000";
-		ttc1 = "/amba_root@0/amba_lpd@0/timer@0xf1dd0000";
-		ttc2 = "/amba_root@0/amba_lpd@0/timer@0xf1de0000";
-		ttc3 = "/amba_root@0/amba_lpd@0/timer@0xf1df0000";
+		ttc0 = "/amba_root@0/amba_lpd@0/timer@f1dc0000";
+		ttc1 = "/amba_root@0/amba_lpd@0/timer@f1dd0000";
+		ttc2 = "/amba_root@0/amba_lpd@0/timer@f1de0000";
+		ttc3 = "/amba_root@0/amba_lpd@0/timer@f1df0000";
 		adma0_mattr = "/amba_root@0/amba_lpd@0/adma0mattr";
-		adma0 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd00000";
+		adma0 = "/amba_root@0/amba_lpd@0/dma-controller@ebd00000";
 		adma1_mattr = "/amba_root@0/amba_lpd@0/adma1mattr";
-		adma1 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd10000";
+		adma1 = "/amba_root@0/amba_lpd@0/dma-controller@ebd10000";
 		adma2_mattr = "/amba_root@0/amba_lpd@0/adma2mattr";
-		adma2 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd20000";
+		adma2 = "/amba_root@0/amba_lpd@0/dma-controller@ebd20000";
 		adma3_mattr = "/amba_root@0/amba_lpd@0/adma3mattr";
-		adma3 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd30000";
+		adma3 = "/amba_root@0/amba_lpd@0/dma-controller@ebd30000";
 		adma4_mattr = "/amba_root@0/amba_lpd@0/adma4mattr";
-		adma4 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd40000";
+		adma4 = "/amba_root@0/amba_lpd@0/dma-controller@ebd40000";
 		adma5_mattr = "/amba_root@0/amba_lpd@0/adma5mattr";
-		adma5 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd50000";
+		adma5 = "/amba_root@0/amba_lpd@0/dma-controller@ebd50000";
 		adma6_mattr = "/amba_root@0/amba_lpd@0/adma6mattr";
-		adma6 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd60000";
+		adma6 = "/amba_root@0/amba_lpd@0/dma-controller@ebd60000";
 		adma7_mattr = "/amba_root@0/amba_lpd@0/adma7mattr";
-		adma7 = "/amba_root@0/amba_lpd@0/dma-controller@0xebd70000";
-		ps_i2c0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1940000";
-		i2c0_bridge = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1940000/
+		adma7 = "/amba_root@0/amba_lpd@0/dma-controller@ebd70000";
+		ps_i2c0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1940000";
+		i2c0_bridge = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1940000/
 i2c0_bridge@0";
-		ps_i2c1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1950000";
-		eeprom0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1950000/eeprom@54";
-		eeprom1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1950000/eeprom@51";
-		i2c1_bridge = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@0xf1950000/
+		ps_i2c1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1950000";
+		eeprom0 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1950000/eeprom@54";
+		eeprom1 = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1950000/eeprom@51";
+		i2c1_bridge = "/amba_root@0/amba_lpd@0/lpd_i2c_wrapper/ps_i2c0@f1950000/
 i2c1_bridge@0";
 		ocm_ctrl0 = "/amba_root@0/amba_lpd@0/ocm_ctrl@OCM";
-		lpd_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_slcr_secure@0xeb510000";
-		lpd_iou_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_iou_slcr_secure@0xf19c0000";
-		lpd_gpio = "/amba_root@0/amba_lpd@0/lpd_gpio@0xf19d0000";
-		intlpd = "/amba_root@0/amba_lpd@0/intlpd@0xea600000";
+		lpd_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_slcr_secure@eb510000";
+		lpd_iou_slcr_secure = "/amba_root@0/amba_lpd@0/lpd_iou_slcr_secure@f19c0000";
+		lpd_gpio = "/amba_root@0/amba_lpd@0/lpd_gpio@f19d0000";
+		intlpd = "/amba_root@0/amba_lpd@0/intlpd@ea600000";
 		rpu_ctrl = "/amba_root@0/amba_lpd@0/rpu_ctrl@0";
-		rpu_ctrl_a = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb580000";
-		rpu_ctrl_a0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a0@0xeb588000";
-		rpu_ctrl_a1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a1@0xeb58c000";
-		rpu_ctrl_b = "/amba_root@0/amba_lpd@0/rpu_cluster@0xeb590000";
-		rpu_ctrl_b0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b0@0xeb598000";
-		rpu_ctrl_b1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b1@0xeb59c000";
-		rpu_pcil = "/amba_root@0/amba_lpd@0/rpu_pcil@0xEB420000";
+		rpu_ctrl_a = "/amba_root@0/amba_lpd@0/rpu_cluster@eb580000";
+		rpu_ctrl_a0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a0@eb588000";
+		rpu_ctrl_a1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_a1@eb58c000";
+		rpu_ctrl_b = "/amba_root@0/amba_lpd@0/rpu_cluster@eb590000";
+		rpu_ctrl_b0 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b0@eb598000";
+		rpu_ctrl_b1 = "/amba_root@0/amba_lpd@0/rpu_ctrl_b1@eb59c000";
+		rpu_pcil = "/amba_root@0/amba_lpd@0/rpu_pcil@EB420000";
 		dwc3_1 = "/amba_root@0/amba_lpd@0/usb2@USB2_0_XHCI1";
 		amba_fpd = "/amba_root@0/amba_fpd@0";
-		wwdt0 = "/amba_root@0/amba_fpd@0/watchdog@0xecc10000";
-		intfpd = "/amba_root@0/amba_fpd@0/intfpd@0xec400000";
+		wwdt0 = "/amba_root@0/amba_fpd@0/watchdog@ecc10000";
+		intfpd = "/amba_root@0/amba_fpd@0/intfpd@ec400000";
 		apu_cluster0 = "/amba_root@0/amba_fpd@0/apu_cluster@MM_FPD_FPD_APU_CLUSTER0";
 		apu_cluster1 = "/amba_root@0/amba_fpd@0/apu_cluster@MM_FPD_FPD_APU_CLUSTER1";
 		apu_cluster2 = "/amba_root@0/amba_fpd@0/apu_cluster@MM_FPD_FPD_APU_CLUSTER2";
 		apu_cluster3 = "/amba_root@0/amba_fpd@0/apu_cluster@MM_FPD_FPD_APU_CLUSTER3";
 		smmu = "/amba_root@0/amba_fpd@0/smmuv3@MM_FPD_SMMU";
-		pcie = "/amba_root@0/amba_fpd@0/dummy_pcie@0x6_0000_0000";
-		pki_rng = "/amba_root@0/amba_fpd@0/pki_rng@0x20400040000ULL";
-		apu_pcil = "/amba_root@0/amba_fpd@0/apu_pcil@0xecb10000";
-		cpm5_crx = "/amba_root@0/amba_fpd@0/cpm5_crx@0xdc0000";
+		pcie = "/amba_root@0/amba_fpd@0/dummy_pcie@6_0000_0000";
+		pki_rng = "/amba_root@0/amba_fpd@0/pki_rng@20400040000";
+		apu_pcil = "/amba_root@0/amba_fpd@0/apu_pcil@ecb10000";
+		cpm5_crx = "/amba_root@0/amba_fpd@0/cpm5_crx@dc0000";
 		amba_pmc_internal = "/amba_root@0/amba_pmc_internal@0";
 		xmpu_pmc = "/amba_root@0/amba_pmc_internal@0/xmpu_pmc@0";
-		xppu_pmc_npi = "/amba_root@0/amba_pmc_internal@0/xppu_pmc_npi@0xf1300000";
-		xppu_pmc = "/amba_root@0/amba_pmc_internal@0/xppu_pmc@0xf1310000";
+		xppu_pmc_npi = "/amba_root@0/amba_pmc_internal@0/xppu_pmc_npi@f1300000";
+		xppu_pmc = "/amba_root@0/amba_pmc_internal@0/xppu_pmc@f1310000";
 		amba_pmc = "/amba_root@0/amba_pmc@0";
-		xmpu_pmc_cfu = "/amba_root@0/amba_pmc@0/xmpu_pmc_cfu@0xf1340000";
-		pmx_err_mng = "/amba_root@0/amba_pmc@0/pmx_err_mng@0xf1110000";
+		xmpu_pmc_cfu = "/amba_root@0/amba_pmc@0/xmpu_pmc_cfu@f1340000";
+		pmx_err_mng = "/amba_root@0/amba_pmc@0/pmx_err_mng@f1110000";
 		amba_pmc_iou = "/amba_root@0/amba_pmc_iou@0";
-		pmc_iou_slcr = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr@0xf1060000";
-		pmc_iou_slcr_secure = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr_secure@0xf1070000";
+		pmc_iou_slcr = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr@f1060000";
+		pmc_iou_slcr_secure = "/amba_root@0/amba_pmc_iou@0/pmc_iou_slcr_secure@f1070000";
 		pmc_qspi_dma_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi_dma@QSPI_DMA";
-		pmc_qspi_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000";
-		qspi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		pmc_qspi_0 = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000";
+		qspi_flash_lcs_lb = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_lcs_lb@0";
-		qspi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@0xf1030000/
+		qspi_flash_ucs_ub = "/amba_root@0/amba_pmc_iou@0/pmc_qspi@f1030000/
 qspi_flash_ucs_ub@0";
 		ospi_dma_dst = "/amba_root@0/amba_pmc_iou@0/ospi_dst_dma@0";
 		ospi_dma_src = "/amba_root@0/amba_pmc_iou@0/ospi_src_dma@0";
-		ospi = "/amba_root@0/amba_pmc_iou@0/spi@0xf1010000";
-		gpio_mr_mux = "/amba_root@0/amba_pmc_iou@0/gpio_mr_mux@0xc0000000";
-		pmc_gpio = "/amba_root@0/amba_pmc_iou@0/pmc_gpio@0xf1020000";
-		sdhci0 = "/amba_root@0/amba_pmc_iou@0/mmc@0xf1040000";
-		sdhci1 = "/amba_root@0/amba_pmc_iou@0/mmc@0xf1050000";
-		pmc_tap = "/amba_root@0/amba_pmc_iou@0/pmc_tap@0xf11a0000";
-		pmx_wwdt = "/amba_root@0/amba_pmc_iou@0/wwdt@0xf03f0000";
+		ospi = "/amba_root@0/amba_pmc_iou@0/spi@f1010000";
+		gpio_mr_mux = "/amba_root@0/amba_pmc_iou@0/gpio_mr_mux@c0000000";
+		pmc_gpio = "/amba_root@0/amba_pmc_iou@0/pmc_gpio@f1020000";
+		sdhci0 = "/amba_root@0/amba_pmc_iou@0/mmc@f1040000";
+		sdhci1 = "/amba_root@0/amba_pmc_iou@0/mmc@f1050000";
+		pmc_tap = "/amba_root@0/amba_pmc_iou@0/pmc_tap@f11a0000";
+		pmx_wwdt = "/amba_root@0/amba_pmc_iou@0/wwdt@f03f0000";
 		amba_pmc_sec = "/amba_root@0/amba_pmc_sec@0";
 		pmc_dma0_src = "/amba_root@0/amba_pmc_sec@0/pmc_dma0_src@0";
 		pmc_dma0_dst = "/amba_root@0/amba_pmc_sec@0/pmc_dma0_dst@0";
 		pmc_dma1_src = "/amba_root@0/amba_pmc_sec@0/pmc_dma1_src@0";
 		pmc_dma1_dst = "/amba_root@0/amba_pmc_sec@0/pmc_dma1_dst@0";
 		pmc_stream_switch = "/amba_root@0/amba_pmc_sec@0/pmc_stream_switch@0";
-		pmc_sha3 = "/amba_root@0/amba_pmc_sec@0/pmc_sha@0xf1210000";
-		pmc_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@0xf11e0000";
-		xlnx_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@0xf11e0000/xlnx_aes@0";
-		pmc_rsa = "/amba_root@0/amba_pmc_sec@0/pmc_rsa@0xf1200000";
+		pmc_sha3 = "/amba_root@0/amba_pmc_sec@0/pmc_sha@f1210000";
+		pmc_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@f11e0000";
+		xlnx_aes = "/amba_root@0/amba_pmc_sec@0/pmc_aes@f11e0000/xlnx_aes@0";
+		pmc_rsa = "/amba_root@0/amba_pmc_sec@0/pmc_rsa@f1200000";
 		xlnx_pmc_efuse_cache = "/amba_root@0/amba_pmc_sec@0/
-xlnx_pmc_efuse_cache@0xf1250000";
+xlnx_pmc_efuse_cache@f1250000";
 		pmc_puf_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_puf_ctrl@0";
-		pmc_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@0xf1240000";
-		xlnx_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@0xf1240000/xlnx_efuse@0";
-		pmc_bbram_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_bbram@0xf11f0000";
-		pmc_sbi = "/amba_root@0/amba_pmc_sec@0/pmc_sbi@0xf1220000";
-		pmc_sha3_1 = "/amba_root@0/amba_pmc_sec@0/pmc_sha1@0xF1800000";
+		pmc_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@f1240000";
+		xlnx_efuse = "/amba_root@0/amba_pmc_sec@0/pmc_efuse@f1240000/xlnx_efuse@0";
+		pmc_bbram_ctrl = "/amba_root@0/amba_pmc_sec@0/pmc_bbram@f11f0000";
+		pmc_sbi = "/amba_root@0/amba_pmc_sec@0/pmc_sbi@f1220000";
+		pmc_sha3_1 = "/amba_root@0/amba_pmc_sec@0/pmc_sha1@F1800000";
 		amba_pmc_ppu = "/amba_root@0/amba_pmc_ppu@0";
 		pmc_gic_proxy = "/amba_root@0/amba_pmc_ppu@0/pmc_gic_proxy@0";
 		amba_pmc_sys = "/amba_root@0/amba_pmc_sys@0";
-		pmc_clk_rst = "/amba_root@0/amba_pmc_sys@0/pmc_clk_rst@0xf1260000";
-		pmc_int = "/amba_root@0/amba_pmc_sys@0/pmc_int@0xf1400000";
-		pmc_global = "/amba_root@0/amba_pmc_sys@0/pmc_global@0xf1110000";
-		pmc_err_mng = "/amba_root@0/amba_pmc_sys@0/pmc_err_mng@0xF1130000";
+		pmc_clk_rst = "/amba_root@0/amba_pmc_sys@0/pmc_clk_rst@f1260000";
+		pmc_int = "/amba_root@0/amba_pmc_sys@0/pmc_int@f1400000";
+		pmc_global = "/amba_root@0/amba_pmc_sys@0/pmc_global@f1110000";
+		pmc_err_mng = "/amba_root@0/amba_pmc_sys@0/pmc_err_mng@F1130000";
 		pmc_stream_zero = "/amba_root@0/amba_pmc_sys@0/pmc_stream_zero@";
-		pmc_sysmon = "/amba_root@0/amba_pmc_sys@0/pmc_sysmon@0xf1270000";
+		pmc_sysmon = "/amba_root@0/amba_pmc_sys@0/pmc_sysmon@f1270000";
 		pmc_ams_sat0 = "/amba_root@0/amba_pmc_sys@0/pmc_ams_sat@0";
 		pmc_ams_sat1 = "/amba_root@0/amba_pmc_sys@0/pmc_ams_sat@1";
 		pmc_global_tamper = "/amba_root@0/amba_pmc_sys@0/versal_pmc_tamper@";
@@ -5218,68 +5218,68 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		fpd_sysmon_sat2 = "/amba_root@0/amba_pmc_sys@0/fpd_ams_sat@2";
 		fpd_sysmon_sat3 = "/amba_root@0/amba_pmc_sys@0/fpd_ams_sat@3";
 		amba_pmc_pl = "/amba_root@0/amba_pmc_pl@0";
-		noc_npi_nir = "/amba_root@0/amba_pmc_pl@0/noc_npi_nir@0xf6000000";
-		npi_ddrmc_ub0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub0@0xf67c0000";
-		npi_ddrmc_main0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main0@0xf6790000";
-		npi_ddrmc_noc0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc0@0xf67a0000";
-		npi_ddrmc_ub1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub1@0xf68b0000";
-		npi_ddrmc_main1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main1@0xf6880000";
-		npi_ddrmc_noc1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc1@0xf6890000";
-		npi_ddrmc_ub2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub2@0xf6dc0000";
-		npi_ddrmc_main2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main2@0xf6d90000";
-		npi_ddrmc_noc2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc2@0xf6da0000";
-		npi_ddrmc_ub3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub3@0xf6eb0000";
-		npi_ddrmc_main3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main3@0xf6e80000";
-		npi_ddrmc_noc3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc3@0xf6e90000";
-		npi_ddrmc_ub4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub4@0xf6f70000";
-		npi_ddrmc_main4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main4@0xf6f40000";
-		npi_ddrmc_noc4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc4@0xf6f50000";
-		npi_ddrmc_ub5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub5@0xf7060000";
-		npi_ddrmc_main5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main5@0xf7030000";
-		npi_ddrmc_noc5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc5@0xf7040000";
-		npi_ddrmc_ub6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub6@0xf7320000";
-		npi_ddrmc_main6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main6@0xf72f0000";
-		npi_ddrmc_noc6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc6@0xf7300000";
-		npi_ddrmc_ub7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub7@0xf7400000";
-		npi_ddrmc_main7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main7@0xf73d0000";
-		npi_ddrmc_noc7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc7@0xf73e0000";
-		npi_ddrmc_xmpu0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_xmpu0@0xf67a0000";
+		noc_npi_nir = "/amba_root@0/amba_pmc_pl@0/noc_npi_nir@f6000000";
+		npi_ddrmc_ub0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub0@f67c0000";
+		npi_ddrmc_main0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main0@f6790000";
+		npi_ddrmc_noc0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc0@f67a0000";
+		npi_ddrmc_ub1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub1@f68b0000";
+		npi_ddrmc_main1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main1@f6880000";
+		npi_ddrmc_noc1 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc1@f6890000";
+		npi_ddrmc_ub2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub2@f6dc0000";
+		npi_ddrmc_main2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main2@f6d90000";
+		npi_ddrmc_noc2 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc2@f6da0000";
+		npi_ddrmc_ub3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub3@f6eb0000";
+		npi_ddrmc_main3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main3@f6e80000";
+		npi_ddrmc_noc3 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc3@f6e90000";
+		npi_ddrmc_ub4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub4@f6f70000";
+		npi_ddrmc_main4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main4@f6f40000";
+		npi_ddrmc_noc4 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc4@f6f50000";
+		npi_ddrmc_ub5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub5@f7060000";
+		npi_ddrmc_main5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main5@f7030000";
+		npi_ddrmc_noc5 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc5@f7040000";
+		npi_ddrmc_ub6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub6@f7320000";
+		npi_ddrmc_main6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main6@f72f0000";
+		npi_ddrmc_noc6 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc6@f7300000";
+		npi_ddrmc_ub7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_ub7@f7400000";
+		npi_ddrmc_main7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_main7@f73d0000";
+		npi_ddrmc_noc7 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_noc7@f73e0000";
+		npi_ddrmc_xmpu0 = "/amba_root@0/amba_pmc_pl@0/npi_ddrmc_xmpu0@f67a0000";
 		noc_npi_devs = "/amba_root@0/amba_pmc_pl@0/noc_npi_devs@0";
-		cfu_fdro = "/amba_root@0/amba_pmc_pl@0/cfu_fdro@0xf12c2000";
-		cfu_sfr = "/amba_root@0/amba_pmc_pl@0/cfu_sfr@0xf12c1000";
-		cframe0_reg = "/amba_root@0/amba_pmc_pl@0/cframe0_reg@0xf12d0000";
-		cframe1_reg = "/amba_root@0/amba_pmc_pl@0/cframe1_reg@0xf12d2000";
-		cframe2_reg = "/amba_root@0/amba_pmc_pl@0/cframe2_reg@0xf12d4000";
-		cframe3_reg = "/amba_root@0/amba_pmc_pl@0/cframe3_reg@0xf12d6000";
-		cframe4_reg = "/amba_root@0/amba_pmc_pl@0/cframe4_reg@0xf12d8000";
-		cframe5_reg = "/amba_root@0/amba_pmc_pl@0/cframe5_reg@0xf12da000";
-		cframe6_reg = "/amba_root@0/amba_pmc_pl@0/cframe6_reg@0xf12dc000";
-		cframe7_reg = "/amba_root@0/amba_pmc_pl@0/cframe7_reg@0xf12de000";
-		cframe8_reg = "/amba_root@0/amba_pmc_pl@0/cframe8_reg@0xf12e0000";
-		cframe9_reg = "/amba_root@0/amba_pmc_pl@0/cframe9_reg@0xf12e2000";
-		cframe10_reg = "/amba_root@0/amba_pmc_pl@0/cframe10_reg@0xf12e4000";
-		cframe11_reg = "/amba_root@0/amba_pmc_pl@0/cframe11_reg@0xf12e6000";
-		cframe12_reg = "/amba_root@0/amba_pmc_pl@0/cframe12_reg@0xf12e8000";
-		cframe13_reg = "/amba_root@0/amba_pmc_pl@0/cframe13_reg@0xf12ea000";
-		cframe14_reg = "/amba_root@0/amba_pmc_pl@0/cframe14_reg@0xf12ec000";
-		cframe_bcast_reg = "/amba_root@0/amba_pmc_pl@0/cframe_bcast_reg@0xf12ee000";
-		hnicx_npi_0 = "/amba_root@0/amba_pmc_pl@0/hnicx_npi_0@0xf6af0000";
-		hnicx_pllpor_0 = "/amba_root@0/amba_pmc_pl@0/hnicx_pllpor_0@0xf6b30000";
-		dummy_cfu_mem = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@0xf12b0000";
-		cfu = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@0xf12b0000/cfu@0x0";
+		cfu_fdro = "/amba_root@0/amba_pmc_pl@0/cfu_fdro@f12c2000";
+		cfu_sfr = "/amba_root@0/amba_pmc_pl@0/cfu_sfr@f12c1000";
+		cframe0_reg = "/amba_root@0/amba_pmc_pl@0/cframe0_reg@f12d0000";
+		cframe1_reg = "/amba_root@0/amba_pmc_pl@0/cframe1_reg@f12d2000";
+		cframe2_reg = "/amba_root@0/amba_pmc_pl@0/cframe2_reg@f12d4000";
+		cframe3_reg = "/amba_root@0/amba_pmc_pl@0/cframe3_reg@f12d6000";
+		cframe4_reg = "/amba_root@0/amba_pmc_pl@0/cframe4_reg@f12d8000";
+		cframe5_reg = "/amba_root@0/amba_pmc_pl@0/cframe5_reg@f12da000";
+		cframe6_reg = "/amba_root@0/amba_pmc_pl@0/cframe6_reg@f12dc000";
+		cframe7_reg = "/amba_root@0/amba_pmc_pl@0/cframe7_reg@f12de000";
+		cframe8_reg = "/amba_root@0/amba_pmc_pl@0/cframe8_reg@f12e0000";
+		cframe9_reg = "/amba_root@0/amba_pmc_pl@0/cframe9_reg@f12e2000";
+		cframe10_reg = "/amba_root@0/amba_pmc_pl@0/cframe10_reg@f12e4000";
+		cframe11_reg = "/amba_root@0/amba_pmc_pl@0/cframe11_reg@f12e6000";
+		cframe12_reg = "/amba_root@0/amba_pmc_pl@0/cframe12_reg@f12e8000";
+		cframe13_reg = "/amba_root@0/amba_pmc_pl@0/cframe13_reg@f12ea000";
+		cframe14_reg = "/amba_root@0/amba_pmc_pl@0/cframe14_reg@f12ec000";
+		cframe_bcast_reg = "/amba_root@0/amba_pmc_pl@0/cframe_bcast_reg@f12ee000";
+		hnicx_npi_0 = "/amba_root@0/amba_pmc_pl@0/hnicx_npi_0@f6af0000";
+		hnicx_pllpor_0 = "/amba_root@0/amba_pmc_pl@0/hnicx_pllpor_0@f6b30000";
+		dummy_cfu_mem = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@f12b0000";
+		cfu = "/amba_root@0/amba_pmc_pl@0/dummy_cfu_mem@f12b0000/cfu@0";
 		amba_pmc_bat = "/amba_root@0/amba_pmc_bat@0";
-		rtc = "/amba_root@0/amba_pmc_bat@0/rtc@0xf12a0000";
+		rtc = "/amba_root@0/amba_pmc_bat@0/rtc@f12a0000";
 		amba_psm = "/amba_root@0/amba_psm@0";
-		psm_ram_instr = "/amba_root@0/amba_psm@0/psm_ram_instr@0xebc00000";
-		psm_ram_data = "/amba_root@0/amba_psm@0/psm_ram_data@0xebc20000";
+		psm_ram_instr = "/amba_root@0/amba_psm@0/psm_ram_instr@ebc00000";
+		psm_ram_data = "/amba_root@0/amba_psm@0/psm_ram_data@ebc20000";
 		psm_gic_proxy = "/amba_root@0/amba_psm@0/psm_gic_proxy@0";
-		psm_global = "/amba_root@0/amba_psm@0/psm_global_reg@0xebc90000";
-		psm_err_mng = "/amba_root@0/amba_psm@0/psm_err_mng@0xebc90000";
+		psm_global = "/amba_root@0/amba_psm@0/psm_global_reg@ebc90000";
+		psm_err_mng = "/amba_root@0/amba_psm@0/psm_err_mng@ebc90000";
 		amba_xram = "/amba_root@0/amba_xram@0";
-		crf = "/amba_root@0/crf@0xec200000";
+		crf = "/amba_root@0/crf@ec200000";
 		lmb_pmc_ppu0 = "/lmb_pmc_ppu0@0";
-		pmc_rom = "/lmb_pmc_ppu0@0/pmc_rom@0xf0000000";
-		pmc_ppu0_ram = "/lmb_pmc_ppu0@0/ppu0_ram@0xf0060000";
+		pmc_rom = "/lmb_pmc_ppu0@0/pmc_rom@f0000000";
+		pmc_ppu0_ram = "/lmb_pmc_ppu0@0/ppu0_ram@f0060000";
 		pmc_ppu0_io_module = "/lmb_pmc_ppu0@0/io-module@00";
 		pmc_ppu0_io_intc = "/lmb_pmc_ppu0@0/io-module@00/pmc_ppu0_intc@0C";
 		pmc_ppu0_io_gpi1 = "/lmb_pmc_ppu0@0/io-module@00/pmc_ppu0_gpi@20";
@@ -5317,11 +5317,11 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		psm0_io_pit2 = "/lmb_psm@0/io-module@00/psm0_pit@50";
 		psm0_io_pit3 = "/lmb_psm@0/io-module@00/psm0_pit@60";
 		psm0_io_pit4 = "/lmb_psm@0/io-module@00/psm0_pit@70";
-		psm_local = "/lmb_psm@0/psm_local_reg@0xebc88000";
+		psm_local = "/lmb_psm@0/psm_local_reg@ebc88000";
 		lmb_ddrmc0 = "/lmb_ddrmc@0";
-		ddrmc0_ram_data = "/lmb_ddrmc@0/ddrmc0_ram_data@0x1c000";
-		ddrmc0_ram_instr = "/lmb_ddrmc@0/ddrmc0_ram_instr@0x20000";
-		ddrmc0_ram_exchange = "/lmb_ddrmc@0/ddrmc0_ram_exchange@0x08000";
+		ddrmc0_ram_data = "/lmb_ddrmc@0/ddrmc0_ram_data@1c000";
+		ddrmc0_ram_instr = "/lmb_ddrmc@0/ddrmc0_ram_instr@20000";
+		ddrmc0_ram_exchange = "/lmb_ddrmc@0/ddrmc0_ram_exchange@08000";
 		ddrmc_0_io_module = "/lmb_ddrmc@0/io-module@00";
 		ddrmc0_io_intc = "/lmb_ddrmc@0/io-module@00/ddrmc0_intc@0C";
 		ddrmc0_io_gpo1 = "/lmb_ddrmc@0/io-module@00/ddrmc0_gpo@10";
@@ -5331,9 +5331,9 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		ddrmc0_io_pit4 = "/lmb_ddrmc@0/io-module@00/ddrmc0_pit@70";
 		ddrmc_uart0 = "/lmb_ddrmc@0/ddrmc_uart0@0";
 		lmb_ddrmc1 = "/lmb_ddrmc@1";
-		ddrmc1_ram_data = "/lmb_ddrmc@1/ddrmc1_ram_data@0x1c000";
-		ddrmc1_ram_instr = "/lmb_ddrmc@1/ddrmc1_ram_instr@0x20000";
-		ddrmc1_ram_exchange = "/lmb_ddrmc@1/ddrmc1_ram_exchange@0x08000";
+		ddrmc1_ram_data = "/lmb_ddrmc@1/ddrmc1_ram_data@1c000";
+		ddrmc1_ram_instr = "/lmb_ddrmc@1/ddrmc1_ram_instr@20000";
+		ddrmc1_ram_exchange = "/lmb_ddrmc@1/ddrmc1_ram_exchange@08000";
 		amba_rpu = "/amba_rpu@0";
 		amba_r5_0 = "/amba_r5@0";
 		amba_r5_1 = "/amba_r5@1";
@@ -5347,22 +5347,22 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		smmu_tbu6 = "/tbu6_slave@0";
 		ddr_mem = "/memory@00000000";
 		ddr_2_mem = "/memory@8_0000_0000";
-		ddr_3_mem = "/memory@0x50000000000ULL";
-		ocm_mem = "/ocm_mem@0xbbf00000";
+		ddr_3_mem = "/memory@50000000000";
+		ocm_mem = "/ocm_mem@bbf00000";
 		ocm_mem_bank_0 = "/ocm_mem_bank_0@";
 		ocm_mem_bank_1 = "/ocm_mem_bank_1@";
 		ocm_mem_bank_2 = "/ocm_mem_bank_2@";
 		ocm_mem_bank_3 = "/ocm_mem_bank_3@";
-		xram_mem = "/xram_mem@0xea800000";
-		xram_mem_bank_0 = "/xram_mem_bank_0@0x0";
-		xram_mem_bank_1 = "/xram_mem_bank_1@0x200000";
-		xram_mem_bank_2 = "/xram_mem_bank_2@0x400000";
-		xram_mem_bank_3 = "/xram_mem_bank_3@0x600000";
+		xram_mem = "/xram_mem@ea800000";
+		xram_mem_bank_0 = "/xram_mem_bank_0@0";
+		xram_mem_bank_1 = "/xram_mem_bank_1@200000";
+		xram_mem_bank_2 = "/xram_mem_bank_2@400000";
+		xram_mem_bank_3 = "/xram_mem_bank_3@600000";
 		ipi_msgbuf = "/ipi_msgbuf@0";
-		pmc_ram = "/pmc_ram@0xf2000000";
-		pmc_ram_bank_0 = "/pmc_ram_bank_0@0x0";
-		pmc_ppu1_insn_ram = "/pmc_ppu1_ram@0xf0200000";
-		pmc_ppu1_data_ram = "/pmc_ppu1_ram@0xf0280000";
+		pmc_ram = "/pmc_ram@f2000000";
+		pmc_ram_bank_0 = "/pmc_ram_bank_0@0";
+		pmc_ppu1_insn_ram = "/pmc_ppu1_ram@f0200000";
+		pmc_ppu1_data_ram = "/pmc_ppu1_ram@f0280000";
 		lqspi_mr = "/lqspi_mr@0";
 		lospi_mr = "/lospi_mr@0";
 		cpu0 = "/cpus/apu_cpu@0";
@@ -5390,7 +5390,7 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		amba_apu = "/amba_apu@0";
 		timer = "/amba_apu@0/timer";
 		amba_apu_gic = "/amba_apu_gic@0";
-		gic = "/amba_apu_gic@0/interrupt-controller@0xe2000000";
+		gic = "/amba_apu_gic@0/interrupt-controller@e2000000";
 		amba_alias = "/amba_alias@0";
 		qemu_sysmem = "/qemu_sysmem@0";
 		psm0 = "/dummy_ppu0@0";
@@ -5398,8 +5398,8 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		pmc_ppu1 = "/dummy_ppu1@0";
 		ddrmc_ub0 = "/dummy_ddrmc0@0";
 		ddrmc_ub1 = "/dummy_ddrmc1@0";
-		ddr = "/ddr@0x00000000";
-		ddr_2 = "/ddr_2@0x800000000ULL";
+		ddr = "/ddr@00000000";
+		ddr_2 = "/ddr_2@800000000";
 		mdio0 = "/mdio";
 		phy0 = "/mdio/phy@1";
 		cpunone = "/cpu_dummy";
@@ -5410,25 +5410,25 @@ xlnx_pmc_efuse_cache@0xf1250000";
 		smmu_tbu11 = "/tbu11_slave@0";
 		smmu_tbu12 = "/tbu12_slave@0";
 		mr_rpu_gic_a = "/mr_rpu_gic_a@0";
-		rpu_gic_a = "/mr_rpu_gic_a@0/rpu_gic_a@0x0";
+		rpu_gic_a = "/mr_rpu_gic_a@0/rpu_gic_a@0";
 		mr_rpu_gic_b = "/mr_rpu_gic_b@0";
-		rpu_gic_b = "/mr_rpu_gic_b@0/rpu_gic_b@0x0";
+		rpu_gic_b = "/mr_rpu_gic_b@0/rpu_gic_b@0";
 		tcm_core0 = "/tcm_core@0";
-		atcm_rpu_core0 = "/tcm_core@0/atcm_rpu_core0@0x00000";
-		btcm_rpu_core0 = "/tcm_core@0/btcm_rpu_core0@0x00000";
-		ctcm_rpu_core0 = "/tcm_core@0/ctcm_rpu_core0@0x00000";
+		atcm_rpu_core0 = "/tcm_core@0/atcm_rpu_core0@00000";
+		btcm_rpu_core0 = "/tcm_core@0/btcm_rpu_core0@00000";
+		ctcm_rpu_core0 = "/tcm_core@0/ctcm_rpu_core0@00000";
 		tcm_core1 = "/tcm_core@1";
-		atcm_rpu_core1 = "/tcm_core@1/atcm_rpu_core1@0x00000";
-		btcm_rpu_core1 = "/tcm_core@1/btcm_rpu_core1@0x00000";
-		ctcm_rpu_core1 = "/tcm_core@1/ctcm_rpu_core1@0x00000";
+		atcm_rpu_core1 = "/tcm_core@1/atcm_rpu_core1@00000";
+		btcm_rpu_core1 = "/tcm_core@1/btcm_rpu_core1@00000";
+		ctcm_rpu_core1 = "/tcm_core@1/ctcm_rpu_core1@00000";
 		tcm_core2 = "/tcm_core@2";
-		atcm_rpu_core2 = "/tcm_core@2/atcm_rpu_core2@0x00000";
-		btcm_rpu_core2 = "/tcm_core@2/btcm_rpu_core2@0x00000";
-		ctcm_rpu_core2 = "/tcm_core@2/ctcm_rpu_core2@0x00000";
+		atcm_rpu_core2 = "/tcm_core@2/atcm_rpu_core2@00000";
+		btcm_rpu_core2 = "/tcm_core@2/btcm_rpu_core2@00000";
+		ctcm_rpu_core2 = "/tcm_core@2/ctcm_rpu_core2@00000";
 		tcm_core3 = "/tcm_core@3";
-		atcm_rpu_core3 = "/tcm_core@3/atcm_rpu_core3@0x00000";
-		btcm_rpu_core3 = "/tcm_core@3/btcm_rpu_core3@0x00000";
-		ctcm_rpu_core3 = "/tcm_core@3/ctcm_rpu_core3@0x00000";
+		atcm_rpu_core3 = "/tcm_core@3/atcm_rpu_core3@00000";
+		btcm_rpu_core3 = "/tcm_core@3/btcm_rpu_core3@00000";
+		ctcm_rpu_core3 = "/tcm_core@3/ctcm_rpu_core3@00000";
 		tcm_cluster_a = "/tcm_cluster_a@0";
 		tcm_cluster_b = "/tcm_cluster_b@0";
 		amba_r5_2 = "/amba_r5@2";

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -136,7 +136,7 @@
 		regulator-boot-on;
 	};
 
-	psram: memory@0x38000000 {
+	psram: memory@38000000 {
 		compatible = "zephyr,memory-region";
 		device_type = "memory";
 		reg = <0x38000000 0x8000000>;


### PR DESCRIPTION
0x is node addresses as these are always hexadecimal values.

ull or ULL is also redundant as the address size is defined by the @size-cells property.

CC @de-nordic  @nordicjm 

This was discussed in https://github.com/zephyrproject-rtos/zephyr/pull/100388#pullrequestreview-3750130954