### PR TITLE
scripts: twister: add skip option to testsuite

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -660,6 +660,12 @@ class TestPlan:
                 instance_list = []
                 for ts in jtp.get("testsuites", []):
                     logger.debug(f"loading {ts['name']}...")
+
+                    # Skip testsuites marked with "skip":true
+                    if ts.get("skip", False):
+                        logger.debug(f"Skipping {ts['name']}: marked as skip in testlist")
+                        continue
+
                     testsuite = ts["name"]
                     toolchain = ts["toolchain"]
 


### PR DESCRIPTION
When using the --load-tests option with the twister script, I would like to be able to skip a testsuite.  Given that json doesn't allow comments, this seems like the best alternative.