### PR TITLE
dts: arm: nxp: imx95_m7: misc. DT fixes

### DIFF
--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -114,13 +114,13 @@
 
 		disp_mix: power-domain@d {
 			compatible = "arm,scmi-power-domain";
-			reg = <13>;
+			reg = <0xd>;
 			#power-domain-cells = <0>;
 		};
 
 		netc_mix: power-domain@12 {
 			compatible = "arm,scmi-power-domain";
-			reg = <18>;
+			reg = <0x12>;
 			#power-domain-cells = <0>;
 		};
 	};

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -112,13 +112,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		disp_mix: power-domain@13 {
+		disp_mix: power-domain@d {
 			compatible = "arm,scmi-power-domain";
 			reg = <13>;
 			#power-domain-cells = <0>;
 		};
 
-		netc_mix: power-domain@18 {
+		netc_mix: power-domain@12 {
 			compatible = "arm,scmi-power-domain";
 			reg = <18>;
 			#power-domain-cells = <0>;


### PR DESCRIPTION
Fix reg vs unit address mismatch for PD nodes and switch to using hex to avoid similar mistakes in the future