### PR TITLE
pm: policy_events: Fix variable scope

### DIFF
--- a/subsys/pm/policy/policy_events.c
+++ b/subsys/pm/policy/policy_events.c
@@ -18,7 +18,7 @@ static struct k_spinlock events_lock;
 /** List of events. */
 static sys_slist_t events_list;
 /** Pointer to Next Event. */
-struct pm_policy_event *next_event;
+static struct pm_policy_event *next_event;
 
 static void update_next_event(void)
 {


### PR DESCRIPTION
next_event should not be global. This can cause
linkage conflicts if another file defines a symbol with the same name.