### PR TITLE
drivers: wifi: infineon: airoc: avoid unhandled values in switch statement

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -756,6 +756,11 @@ static int airoc_mgmt_ap_enable(const struct device *dev, struct wifi_connect_re
 	case WIFI_FREQ_BANDWIDTH_80MHZ:
 		chanspec |= GET_C_VAR(airoc_ap_if->whd_driver, CHANSPEC_BW_80);
 		break;
+	default:
+		chanspec |= GET_C_VAR(airoc_ap_if->whd_driver, CHANSPEC_BW_20);
+		LOG_WRN("Discard of setting unsupported bandwidth: %u (will set 20MHz)",
+			params->bandwidth);
+		break;
 	}
 
 	switch (params->security) {


### PR DESCRIPTION
This fix commit 85d353d as merged by PR #103109.

When build:

  `west build -p -b rpi_pico2/rp2350a/m33/w zephyr/samples/net/wifi/shell`

**Warnings** occur (**leading to errors in Twister runs**):

  ```
  .../drivers/wifi/infineon/airoc_wifi.c:749:9: warning: enumeration value
      '__WIFI_FREQ_BANDWIDTH_AFTER_LAST' not handled in switch [-Wswitch]
  .../drivers/wifi/infineon/airoc_wifi.c:749:9: warning: enumeration value
      'WIFI_FREQ_BANDWIDTH_UNKNOWN' not handled in switch [-Wswitch]
    749 |         switch (params->bandwidth) {
        |         ^~~~~~
  ```