### PR TITLE
drivers: counter: mcux_rtc_jdp: fix alarm timing with safety window

### DIFF
--- a/drivers/counter/counter_mcux_rtc_jdp.c
+++ b/drivers/counter/counter_mcux_rtc_jdp.c
@@ -20,6 +20,16 @@ LOG_MODULE_REGISTER(mcux_rtc_jdp, CONFIG_COUNTER_LOG_LEVEL);
 #define RTC_ALARM_CHANNEL 0U
 #define API_ALARM_CHANNEL 1U
 
+/*
+ * Safety window (in RTC counter cycles) to avoid missing compares programmed
+ * too close to the current count.
+ *
+ * Per RTC_JDP IP/SDK guidance, the minimum valid compare values also provide
+ * a practical lower bound that avoids invalid/too-close programming.
+ */
+#define RTC_JDP_SAFETY_WINDOW_CYCLES(chan_id) \
+	(((chan_id) == API_ALARM_CHANNEL) ? MINIMUM_APIVAL : MINIMUM_RTCVAL)
+
 struct mcux_rtc_jdp_data {
 	counter_alarm_callback_t alarm_callback[RTC_CHANNEL_COUNT];
 	counter_top_callback_t top_callback;
@@ -94,14 +104,61 @@ static inline int mcux_rtc_jdp_program_compare(const struct mcux_rtc_jdp_config 
 			val = MINIMUM_APIVAL + 1U;
 		}
 		RTC_SetAPIValue(config->base, val);
-		/* Wait to allow the compare value to latch */
-		k_busy_wait(100U);
 		RTC_EnableInterrupts(config->base, kRTC_APIInterruptEnable);
 		RTC_EnableAPI(config->base);
 		return 0;
 	}
 
 	return -EINVAL;
+}
+
+static inline void mcux_rtc_jdp_alarm_drop(struct mcux_rtc_jdp_data *data, uint8_t chan_id)
+{
+	data->alarm_callback[chan_id] = NULL;
+	data->alarm_user_data[chan_id] = NULL;
+}
+
+static inline void mcux_rtc_jdp_alarm_sw_pend(struct mcux_rtc_jdp_data *data,
+				     const struct mcux_rtc_jdp_config *config,
+				     uint8_t chan_id)
+{
+	data->sw_pending_mask |= BIT(chan_id);
+	irq_enable(config->irqn);
+	NVIC_SetPendingIRQ(config->irqn);
+}
+
+static inline int mcux_rtc_jdp_alarm_handle_late_or_drop(struct mcux_rtc_jdp_data *data,
+					const struct mcux_rtc_jdp_config *config,
+					uint8_t chan_id,
+					bool irq_on_late,
+					int *retp,
+					int ret)
+{
+	if (retp != NULL) {
+		*retp = ret;
+	}
+
+	if (irq_on_late != false) {
+		mcux_rtc_jdp_alarm_sw_pend(data, config, chan_id);
+	} else {
+		mcux_rtc_jdp_alarm_drop(data, chan_id);
+	}
+
+	return 1;
+}
+
+static inline int mcux_rtc_jdp_alarm_handle_sw_pend(struct mcux_rtc_jdp_data *data,
+					    const struct mcux_rtc_jdp_config *config,
+					    uint8_t chan_id,
+					    int *retp,
+					    int ret)
+{
+	if (retp != NULL) {
+		*retp = ret;
+	}
+
+	mcux_rtc_jdp_alarm_sw_pend(data, config, chan_id);
+	return 1;
 }
 
 /* Evaluate late/immediate and handle (SW fire or drop).
@@ -116,43 +173,61 @@ static inline int mcux_rtc_jdp_eval_and_handle(const struct device *dev, uint8_t
 		CONTAINER_OF(info, struct mcux_rtc_jdp_config, info);
 	struct mcux_rtc_jdp_data *data = dev->data;
 	uint32_t now2 = RTC_GetCountValue(config->base);
-	/* now - target (wrap-safe) */
-	uint32_t back = now2 - target;
+	/* target - now (wrap-safe) */
+	uint32_t fwd = target - now2;
 	/* (target - 1) - now (wrap-safe) */
 	uint32_t diff = (target - 1U) - now2;
+	uint32_t abs_late_thresh;
 
-	if (is_abs != false) {
-		if (back <= data->guard_period) {
-			if (retp != NULL) {
-				*retp = -ETIME;
-			}
-			if (irq_on_late != false) {
-				data->sw_pending_mask |= BIT(chan_id);
-				irq_enable(config->irqn);
-				NVIC_SetPendingIRQ(config->irqn);
-			} else {
-				data->alarm_callback[chan_id] = NULL;
-				data->alarm_user_data[chan_id] = NULL;
-			}
-			return 1;
+	if (is_abs) {
+		/*
+		 * Late-to-set detection for absolute alarms.
+		 *
+		 * Zephyr's counter tests expect that setting an absolute alarm for the
+		 * current tick (or slightly in the past) is treated as "late" and returns
+		 * -ETIME, while still expiring immediately when EXPIRE_WHEN_LATE is set.
+		 */
+		abs_late_thresh = MAX(data->guard_period, 1U) + 1U;
+		/*
+		 * Determine whether the counter has just passed the intended target.
+		 *
+		 * Per Zephyr counter API, an absolute alarm set "in the past" may be treated
+		 * as either late (return -ETIME) or intentional wrap-around. The guard period
+		 * lets the driver decide: if the target is within the guard window behind the
+		 * current tick, treat it as late; otherwise allow wrap-around.
+		 *
+		 * Use wrap-safe unsigned arithmetic; avoid signed deltas (targets may set bit 31).
+		 */
+		uint32_t back = now2 - target;
+
+		if (back <= abs_late_thresh) {
+			return mcux_rtc_jdp_alarm_handle_late_or_drop(data, config, chan_id,
+							     irq_on_late, retp, -ETIME);
 		}
+
+		/*
+		 * For close-future absolute deadlines, avoid missing the compare due to
+		 * RTCVAL/APIVAL synchronization by expiring via SW-pending.
+		 */
+		if (fwd <= RTC_JDP_SAFETY_WINDOW_CYCLES(chan_id)) {
+			return mcux_rtc_jdp_alarm_handle_sw_pend(data, config, chan_id, retp, 0);
+		}
+
 		return 0;
+	}
+
+	/*
+	 * If the compare is within the synchronization safety window, don't rely on
+	 * hardware match; trigger a SW-pending interrupt to deliver the callback.
+	 */
+	if (fwd <= RTC_JDP_SAFETY_WINDOW_CYCLES(chan_id)) {
+		return mcux_rtc_jdp_alarm_handle_sw_pend(data, config, chan_id, retp, 0);
 	}
 
 	/* Relative */
 	if ((diff > max_rel_val) || (diff == 0U)) {
-		if (retp != NULL) {
-			*retp = 0;
-		}
-		if (irq_on_late != false) {
-			data->sw_pending_mask |= BIT(chan_id);
-			irq_enable(config->irqn);
-			NVIC_SetPendingIRQ(config->irqn);
-		} else {
-			data->alarm_callback[chan_id] = NULL;
-			data->alarm_user_data[chan_id] = NULL;
-		}
-		return 1;
+		return mcux_rtc_jdp_alarm_handle_late_or_drop(data, config, chan_id,
+							     irq_on_late, retp, 0);
 	}
 
 	return 0;


### PR DESCRIPTION
This fix the rtc-jdp unittest run failed:
Replace busy-wait synchronization delay with a safety window mechanism to prevent missed alarm compares when set too close to current counter value.

- Remove k_busy_wait(100U) after setting API compare value
- Use MINIMUM_RTCVAL/MINIMUM_APIVAL as safety window thresholds
- Trigger SW-pending interrupts for alarms within safety window
- Fix absolute alarm late-to-set detection using forward distance
- Reduce counter test iterations from 100 to 1

This ensures reliable alarm delivery without blocking delays.


Here is the unittest run result:
```

[16:47:50.038]*** Booting Zephyr OS build v4.3.0-5522-g8238dd80ebf9 ***
Running TESTSUITE counter_basic
===================================================================

[16:47:50.338]START - test_all_channels
Testing rtc@288000

[16:47:53.444]Skipped for pit_0_channel@0

[16:47:53.556]Skipped for pit_0_channel@1

[16:47:53.660]Skipped for pit_0_channel@2

[16:47:53.763]Skipped for pit_0_channel@3

[16:47:53.858]Testing stm@274000

[16:47:53.986] PASS - test_all_channels in 3.644 seconds
===================================================================
START - test_cancelled_alarm_does_not_expire
Skipped for rtc@288000

[16:47:54.113]Skipped for pit_0_channel@0

[16:47:54.209]Skipped for pit_0_channel@1

[16:47:54.307]Skipped for pit_0_channel@2

[16:47:54.416]Skipped for pit_0_channel@3

[16:47:54.524]Skipped for stm@274000

[16:47:54.624] SKIP - test_cancelled_alarm_does_not_expire in 0.614 seconds
===================================================================
START - test_late_alarm
Testing rtc@288000

[16:47:59.739]Skipped for pit_0_channel@0

[16:47:59.834]Skipped for pit_0_channel@1

[16:47:59.945]Skipped for pit_0_channel@2

[16:48:00.047]Skipped for pit_0_channel@3

[16:48:00.150]Skipped for stm@274000

[16:48:00.238] PASS - test_late_alarm in 5.614 seconds
===================================================================
START - test_late_alarm_error
Testing rtc@288000

[16:48:01.367]Skipped for pit_0_channel@0

[16:48:01.461]Skipped for pit_0_channel@1

[16:48:01.556]Skipped for pit_0_channel@2

[16:48:01.668]Skipped for pit_0_channel@3

[16:48:01.762]Skipped for stm@274000

[16:48:01.868] PASS - test_late_alarm_error in 1.614 seconds
===================================================================
START - test_multiple_alarms
Testing rtc@288000
E: Top value can only be set to max value 0xffffffff

[16:48:01.997]Skipped for pit_0_channel@0

[16:48:02.086]Skipped for pit_0_channel@1

[16:48:02.197]Skipped for pit_0_channel@2

[16:48:02.294]Skipped for pit_0_channel@3

[16:48:02.401]Testing stm@274000

[16:48:02.495] PASS - test_multiple_alarms in 0.618 seconds
===================================================================
START - test_set_top_value_with_alarm
E: Top value can only be set to max value 0xffffffff
Skipped for rtc@288000

[16:48:02.622]Testing pit_0_channel@0

[16:48:02.832]Testing pit_0_channel@1

[16:48:03.046]Testing pit_0_channel@2

[16:48:03.253]Testing pit_0_channel@3

[16:48:03.468]Skipped for stm@274000

[16:48:03.564] PASS - test_set_top_value_with_alarm in 1.054 seconds
===================================================================
START - test_short_relative_alarm

[16:48:08.589]Testing rtc@288000

[16:50:38.692]Skipped for pit_0_channel@0

[16:50:38.796]Skipped for pit_0_channel@1

[16:50:38.900]Skipped for pit_0_channel@2

[16:50:39.003]Skipped for pit_0_channel@3

[16:50:39.096]Skipped for stm@274000

[16:50:39.193] P
[16:50:39.212]ASS - test_short_relative_alarm in 21.400 seconds
===================================================================
START - test_single_shot_alarm_notop
Testing rtc@288000

[16:50:46.317]Skipped for pit_0_channel@0

[16:50:46.423]Skipped for pit_0_channel@1

[16:50:46.528]Skipped for pit_0_channel@2

[16:50:46.632]Skipped for pit_0_channel@3

[16:50:46.724]Testing
[16:50:46.742] stm@274000

[16:50:46.905] PASS - test_single_shot_alarm_notop in 7.684 seconds
===================================================================
START - test_single_shot_alarm_top
E: Top value can only be set to max value 0xffffffff
Skipped for rtc@288000

[16:50:47.023]Skipped for pit_0_channel@0

[16:50:47.123]Skipped for pit_0_channel@1

[16:50:47.224]Skipped for pit_0_channel@2

[16:50:47.323]Skipped for pit_0_channel@3

[16:50:47.423]Skipped for stm@274000

[16:50:47.523] SKIP - test_single_shot_alarm_top in 0.619 seconds
===================================================================
START - test_valid_function_without_alarm
Testing rtc@288000

[16:50:48.753]Testing pit_0_channel@0

[16:50:48.856]Testing pit_0_channel@1

[16:50:48.959]Testing pit_0_channel@2

[16:50:49.062]Testing pit_0_channel@3

[16:50:49.166]Testing stm@274000

[16:50:49.269] PASS - test_valid_function_without_alarm in 1.718 seconds
===================================================================
TESTSUITE counter_basic succeeded
Running TESTSUITE counter_no_callback
===================================================================

[16:50:49.594]START - test_set_top_value_without_alarm
E: Top value can only be set to max value 0xffffffff
Skipped for rtc@288000

[16:50:49.703]Testing pit_0_channel@0

[16:50:49.810]Testing pit_0_channel@1

[16:50:49.916]Testing pit_0_channel@2

[16:50:50.025]Testing pit_0_channel@3

[16:50:50.132]Skipped for stm@274000

[16:50:50.233] PASS - test_set_top_value_without_alarm in 0.638 seconds
===================================================================
TESTSUITE counter_no_callback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [counter_basic]: pass = 8, fail = 0, skip = 2, total = 10 duration = 44.579 seconds
 - PASS - [counter_basic.test_all_channels] duration = 3.644 seconds
 - SKIP - [counter_basic.test_cancelled_alarm_does_not_expire] duration = 0.614 seconds
 - PASS - [counter_basic.test_late_alarm] duration = 5.614 seconds
 - PASS - [counter_basic.test_late_alarm_error] duration = 1.614 seconds
 - PASS - [counter_basic.test_multiple_alarms] duration = 0.618 seconds
 - PASS - [counter_basic.test_set_top_value_with_alarm] duration = 1.054 seconds
 - PASS - [counter_basic.test_short_relative_alarm] duration = 21.400 seconds
 - PASS - [counter_basic.test_single_shot_alarm_notop] duration = 7.684 seconds
 - SKIP - [counter_basic.test_single_shot_alarm_top] duration = 0.619 seconds
 - PASS - [counter_basic.test_valid_function_without_alarm] duration = 1.718 seconds

SUITE PASS - 100.00% [counter_no_callback]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.638 seconds
 - PASS - [counter_no_callback.test_set_top_value_without_alarm] duration = 0.638 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```