### PR TITLE
drivers: ethernet: e1000: Fix TX buffer overflow

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -128,6 +128,10 @@ static int e1000_send(const struct device *ddev, struct net_pkt *pkt)
 	struct e1000_dev *dev = ddev->data;
 	size_t len = net_pkt_get_len(pkt);
 
+	if (len > sizeof(dev->txb[dev->next_tx_desc])) {
+		return -EMSGSIZE;
+	}
+
 	if (net_pkt_read(pkt, dev->txb[dev->next_tx_desc], len)) {
 		return -EIO;
 	}

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -98,8 +98,8 @@ struct e1000_dev {
 	 */
 	struct net_if *iface;
 	uint8_t mac[ETH_ALEN];
-	uint8_t txb[CONFIG_ETH_E1000_TX_QUEUE_SIZE][NET_ETH_MTU];
-	uint8_t rxb[CONFIG_ETH_E1000_RX_QUEUE_SIZE][NET_ETH_MTU];
+	uint8_t txb[CONFIG_ETH_E1000_TX_QUEUE_SIZE][NET_ETH_MAX_FRAME_SIZE];
+	uint8_t rxb[CONFIG_ETH_E1000_RX_QUEUE_SIZE][NET_ETH_MAX_FRAME_SIZE];
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
 	const struct device *ptp_clock;
 #endif


### PR DESCRIPTION
The e1000 Ethernet driver TX staging buffer is sized to NET_ETH_MTU (1500 bytes), but the Ethernet L2 layer prepends headers (14 bytes standard, 18 bytes with VLAN) before calling the driver's send function. When transmitting MTU-sized packets, net_pkt_get_len() returns the full L2 frame size (up to 1514+ bytes), causing a 14-18 byte out-of-bounds write into adjacent RX buffers. This is remotely triggerable by inducing large TX responses such as ICMP echo replies. Fix by sizing the TX buffer to NET_ETH_MAX_FRAME_SIZE and adding a defensive bounds check.

Reported-by: Pavel Kohout, Aisle Research, www.aisle.com"