### PR TITLE
eswifi: Return error for unsupported TLS socket options

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -249,9 +249,11 @@ static int eswifi_socket_setsockopt(void *obj, int level, int optname,
 			ret = map_credentials(sd, optval, optlen);
 			break;
 		case ZSOCK_TLS_HOSTNAME:
+			LOG_ERR("eswifi offload does not support TLS_HOSTNAME");
+			return -ENOTSUP;
 		case ZSOCK_TLS_PEER_VERIFY:
-			ret = 0;
-			break;
+			LOG_ERR("eswifi offload does not support TLS_PEER_VERIFY");
+			return -ENOTSUP;
 		default:
 			return -EINVAL;
 		}


### PR DESCRIPTION
The eswifi socket offload driver's setsockopt() handler returns success (0) for TLS_HOSTNAME and TLS_PEER_VERIFY options without implementing them. This causes applications to believe TLS hostname and peer certificate verification is enabled when it may not be, potentially enabling man-in-the-middle attacks. The Inventek eS-WiFi module's default P9 setting (0=None) means no certificate verification occurs unless explicitly configured out-of-band. This fix returns -ENOTSUP instead, making the limitation explicit so applications can detect and handle unsupported TLS options appropriately.

Reported-by: Pavel Kohout, Aisle Research, www.aisle.com