### PR TITLE
tests: drivers: gpio: Remove fixture requirement and platform restric…

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -4,8 +4,6 @@ common:
     - gpio
   depends_on: gpio
   harness: ztest
-  harness_config:
-    fixture: gpio_loopback
 
 tests:
   drivers.gpio.2pin:


### PR DESCRIPTION
Remove the harness_config fixture (gpio_loopback) requirement from the
common section of gpio_basic_api tests. This fixture requirement was
causing the drivers.gpio.2pin test to be filtered out during test
selection, preventing it from being built and run on hardware platforms
unless the --fixture flag was explicitly specified on the twister
command line.

By removing this requirement, the test can now be properly selected and
executed based on the existing devicetree compatibility filter
(dt_compat_enabled("test-gpio-basic-api")), which is sufficient to
ensure the test runs only on boards that have the appropriate GPIO test
configuration in their devicetree overlay.