### PR TITLE
tests: subsys: crc clarify CRC8 reflected polynomial comment

### DIFF
--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -70,7 +70,7 @@ extern "C" {
 /** CRC8 polynomial */
 #define CRC8_POLY 0x07
 
-/** CRC8_CCITT polynomial */
+/** CRC8_REFLECT polynomial */
 #define CRC8_REFLECT_POLY 0xE0
 
 /** CRC8_ROHC polynomial */


### PR DESCRIPTION
While reviewing the CRC8 tests, I noticed that CRC8_REFLECT_POLY is documented as a CCITT polynomial, which can be misleading in this context. The value 0xE0 actually represents the bit-reflected form of the standard CRC-8 polynomial 0x07, used when the CRC algorithm processes bits in reversed order.

This PR updates the comment to clearly describe CRC8_REFLECT_POLY as the reflected CRC-8 polynomial, improving clarity and avoiding confusion .

No functional changes are introduced; this change only improves documentation clarity.

Fixes: #103419 