### PR TITLE
drivers: flash: stm32_xspi: Remove hard-coded XSPI2 dependency

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2115,9 +2115,16 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
-	LL_PWR_EnableXSPIM2();
 	__HAL_RCC_SBS_CLK_ENABLE();
-	LL_SBS_EnableXSPI2SpeedOptim();
+	if (dev_data->hxspi.Instance == XSPI1) {
+		LL_PWR_EnableXSPIM1();
+		LL_SBS_EnableXSPI1SpeedOptim();
+	} else if (dev_data->hxspi.Instance == XSPI2) {
+		LL_PWR_EnableXSPIM2();
+		LL_SBS_EnableXSPI2SpeedOptim();
+	} else {
+		__ASSERT(0, "Not an XSPI instance?!");
+	}
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 	/* Signals configuration */


### PR DESCRIPTION
Fixes stm32 xspi nor-flash is driver is only supporting xspi2 peripheral.

Check the used XSPIx peripheral before calling the corresponding function instead of hard-coded calling the `LL_PWR_EnableXSPIM2()` and `LL_SBS_EnableXSPI2SpeedOptim()` during [`flash_stm32_xspi_init(...)`](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/flash_stm32_xspi.c#L2118).

### Testing
XiP working from xspi2 (nucleo_h7s3l8) and xspi1 (custom board*).

\* My custom board has xspi nor flash connected to xspi1 and psram to xspi2 (by accident, was planned to be the same as on the eval-boards).