### PR TITLE
dts: arm: st: h7rs: Enable HSI internal clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -221,33 +221,59 @@ static uint32_t get_pllsrc_frequency(void)
 }
 
 __unused
-static uint32_t get_hclk_frequency(void)
+static uint32_t get_startup_hclk_frequency(void)
 {
 	uint32_t sysclk = 0;
 
-	/* Get the current system clock source */
 	switch (LL_RCC_GetSysClkSource()) {
-	case LL_RCC_SYS_CLKSOURCE_STATUS_HSI:
-		sysclk = STM32_HSI_FREQ/STM32_HSI_DIVISOR;
-		break;
 	case LL_RCC_SYS_CLKSOURCE_STATUS_CSI:
 		sysclk = STM32_CSI_FREQ;
+		break;
+	case LL_RCC_SYS_CLKSOURCE_STATUS_HSI:
+		/* Use HAL define instead of STM32_HSI_FREQ, which can be 0 when node is disabled */
+		sysclk = HSI_VALUE;
 		break;
 	case LL_RCC_SYS_CLKSOURCE_STATUS_HSE:
 		sysclk = STM32_HSE_FREQ;
 		break;
-#if defined(STM32_PLL_ENABLED)
 	case LL_RCC_SYS_CLKSOURCE_STATUS_PLL1:
-		sysclk = get_pllout_frequency(get_pllsrc_frequency(),
-					      STM32_PLL_M_DIVISOR,
-					      STM32_PLL_N_MULTIPLIER,
-					      STM32_PLL_FRACN_VALUE,
-					      STM32_PLL_P_DIVISOR);
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+		/* When using a bootloader, we can't rely on the #define values as the bootloader
+		 * may have configured the clock tree differently. Instead, we must read the actual
+		 * clock configuration from the RCC registers to determine the current HCLK
+		 * frequency.
+		 */
+		return HAL_RCC_GetHCLKFreq();
+#else
+		sysclk = get_pllsrc_frequency();
 		break;
-#endif /* STM32_PLL_ENABLED */
+#endif
+	default:
+		__ASSERT(0, "Unexpected startup freq");
+		return 0;
 	}
 
-	return get_bus_clock(sysclk, STM32_HPRE);
+	return sysclk / STM32_HPRE;
+}
+
+static uint32_t get_sysclk_frequency(void)
+{
+#if defined(STM32_SYSCLK_SRC_PLL)
+	return get_pllout_frequency(get_pllsrc_frequency(),
+				    STM32_PLL_M_DIVISOR,
+				    STM32_PLL_N_MULTIPLIER,
+				    STM32_PLL_FRACN_VALUE,
+				    STM32_PLL_R_DIVISOR);
+#elif defined(STM32_SYSCLK_SRC_CSI)
+	return STM32_CSI_FREQ;
+#elif defined(STM32_SYSCLK_SRC_HSE)
+	return STM32_HSE_FREQ;
+#elif defined(STM32_SYSCLK_SRC_HSI)
+	return STM32_HSI_FREQ;
+#else
+	__ASSERT(0, "No SYSCLK Source configured");
+	return 0;
+#endif
 }
 
 #if !defined(CONFIG_CPU_CORTEX_M4)
@@ -531,7 +557,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		break;
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 	case STM32_SRC_SYSCLK:
-		*rate = get_hclk_frequency();
+		*rate = get_sysclk_frequency();
 		break;
 #if defined(STM32_CKPER_ENABLED)
 	case STM32_SRC_CKPER:
@@ -1109,6 +1135,9 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Configure Voltage scale to comply with the desired system frequency */
 	prepare_regulator_voltage_scale();
 
+	/* Current hclk value */
+	old_hclk_freq = get_startup_hclk_frequency();
+
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
@@ -1116,8 +1145,6 @@ int stm32_clock_control_init(const struct device *dev)
 		return r;
 	}
 
-	/* Current hclk value */
-	old_hclk_freq = get_hclk_frequency();
 	/* AHB is HCLK clock to configure */
 	new_hclk_freq = get_bus_clock(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
 				      STM32_HPRE);
@@ -1129,13 +1156,6 @@ int stm32_clock_control_init(const struct device *dev)
 	if (new_hclk_freq > old_hclk_freq) {
 		LL_SetFlashLatency(new_hclk_freq);
 	}
-#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
-	/*
-	 * The default Flash latency is 3 WS which is not enough,
-	 * set higher and correct later if needed
-	 */
-	LL_FLASH_SetLatency(LL_FLASH_LATENCY_6);
-#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 	/* Preset the prescalers prior to choosing SYSCLK */
 	/* Prevents APB clock to go over limits */

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -77,6 +77,7 @@
 			status = "disabled";
 		};
 
+		/* controller reset default is on */
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
 			compatible = "st,stm32h7-hsi-clock";

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -101,6 +101,7 @@
 			status = "disabled";
 		};
 
+		/* controller reset default is on */
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
 			compatible = "st,stm32h7-hsi-clock";


### PR DESCRIPTION
The HSI is on by default at controller startup, ~~so enable it per default at dts level.~~ Having HSI disabled causes STM32_HSI_FREQ define set to 0.

This fixes [`get_hclk_frequency()`](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/clock_control/clock_stm32_ll_h7.c#L243) returns 0 when called from [`stm32_clock_control_init()`](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/clock_control/clock_stm32_ll_h7.c#L1105). The result was used in the follwing lines: `if (new_hclk_freq > old_hclk_freq)`, with `old_hclk_freq` always set to 0.

Edit [2026-02-26]: Scope changed during discussion. Copy of new commit message:

driver: clock_control: stm32_ll_h7: Fix SYSCLK/HCLK mix and more

Fixes the mix-up of HCLK and SYSCLK in h7 clock driver and also makes sure
to calculate the correct startup frequency:
- Take care of bootloader might already have configured clocks instead of
  relying on #defines/dts).
- Use HAL HSI_VALUE instead of STM32_HSI_FREQ which can be 0 if hsi node
  is disabled in DT (but is default on after reset...)

Also move calculation of old_hclk_freq above set_up_plls() during
stm32_clock_control_init(), which can change the current clock setting and
make it impossible to get the previous clock.

Remove not needed special handling for h7rsx controllers.

Add a comment to the clk_hsi node in the h7x / h7rsx DT stating that the
clock is enabled by default after reset.
