### PR TITLE
samples: drivers: memc:  use log function instead of printk for debug 

### DIFF
--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(main);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_flexspi)
 /* Use memc API to get AHB base address for the device */
@@ -107,7 +109,7 @@ int main(void)
 			dump_memory(memc_read_buffer, BUF_SIZE);
 			return 0;
 		}
-		printk("Check (%i/%i) passed!\n", j, (MEMC_SIZE / BUF_SIZE) - 1);
+		LOG_INF("Check (%i/%i) passed!", j, (MEMC_SIZE / BUF_SIZE) - 1);
 	}
 	/* Copy any remaining space bytewise */
 	for (; i < MEMC_SIZE; i++) {


### PR DESCRIPTION



Changed printk() to LOG_INF() to reduce execution time. This optimization is necessary when using large buffers, such as on the STM32H7S_DK with 32 MB of PSRAM. Otherwise, in CI, the test will fail due to a timeout (60s by default) occurring before the test completes its execution and misses printing the required regex word for the test to be successful.

This behaviour was detected after addition  https://github.com/zephyrproject-rtos/zephyr/pull/102166/commits/5739862435280c9ef51dc7dc08ae0f927bf4ac9c

For comparison STM32H7S_DK:

With printk :  
```
"reason":"Unknown Error", 
"execution_time":"60.53", 
"build_time":"13.42", 
Without LOG in prj 
```
 
With LOG
```
"status":"passed", 
"execution_time":"8.36", 
"build_time":"13.44", 

```