### PR TITLE
drivers: gpio: silabs: Set port_pin_mask from Devicetree

### DIFF
--- a/drivers/gpio/gpio_silabs.c
+++ b/drivers/gpio/gpio_silabs.c
@@ -471,7 +471,7 @@ static int gpio_silabs_common_init(const struct device *dev)
 
 #define GPIO_PORT_INIT(n)                                                                          \
 	static const struct gpio_silabs_port_config gpio_silabs_port_config_##n = {                \
-		.common.port_pin_mask = (gpio_port_pins_t)(-1),                                    \
+		.common.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_NODE(n),                        \
 		.gpio_index = GET_SILABS_GPIO_INDEX(n),                                            \
 		.common_dev = DEVICE_DT_GET(DT_PARENT(n)),                                         \
 		.em4wu_pin_count = DT_PROP_LEN(n, silabs_wakeup_ints),                             \

--- a/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
+++ b/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <2>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <5>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -26,6 +26,23 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	gpio-reserved-ranges = <0 2>;
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
@@ -18,6 +18,23 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	gpio-reserved-ranges = <0 1>;
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
@@ -20,6 +20,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <7>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-cte-tx-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-cte-tx-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-cte-tx-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;

--- a/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x08000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <7>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Yishai Jaffe
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,22 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+};
+
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240pa32vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa32vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240pa32vnn.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa32vnn.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb32vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240pb32vnn.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb32vnn.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
@@ -25,6 +25,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24a020f1024im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a020f1024im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24a020f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a020f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24b220f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b220f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b020f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1024im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Steven Lemaire
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,22 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/efr32mg24b020f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1536im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b120f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b120f1536im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Steven Lemaire
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,22 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Fr. Sauter AG
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,22 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Steven Lemaire
+ * Copyright (c) 2026 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,22 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240pa32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa32vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240pa32vnn.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa32vnn.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
@@ -24,6 +24,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240pb32vnn.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vnn.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
@@ -23,6 +23,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
@@ -24,6 +24,22 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	ctune = <140>;
 	precision = <50>;

--- a/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/bgm260pb32vna.dtsi
+++ b/dts/arm/silabs/xg26/bgm260pb32vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/efm32pg26b101f512il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b101f512il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b101f512im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b101f512im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(512)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <12>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b301f1024il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f1024il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b301f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f1024im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <12>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b301f2048il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f2048il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b301f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f2048im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <12>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <12>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <12>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b321f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f1024im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b321f2048im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f2048im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b321f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f2048im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b420f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b420f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b421f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b421f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b221f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b221f2048im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(2048)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b221f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b221f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b420f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b420f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b420f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b420f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b421f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b421f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b421f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b421f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <14>;
+};
+
+&gpiob {
+	ngpios = <10>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <16>;
+};
+
+&gpiob {
+	ngpios = <16>;
+};
+
+&gpioc {
+	ngpios = <16>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b520f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b520f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b520f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b520f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b521f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b521f3200im48.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <4>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b521f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b521f3200im68.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <11>;
+};
+
+&gpiob {
+	ngpios = <9>;
+};
+
+&gpioc {
+	ngpios = <14>;
+};
+
+&gpiod {
+	ngpios = <11>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/mgm260pb32vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb32vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/mgm260pb32vnn.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb32vnn.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/mgm260pd32vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd32vna.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg26/mgm260pd32vnn.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd32vnn.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(3200)>;
 };
 
+&gpioa {
+	ngpios = <10>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <10>;
+};
+
+&gpiod {
+	ngpios = <6>;
+};
+
 &hfxo {
 	clock-frequency = <DT_FREQ_M(40)>;
 	ctune = <140>;

--- a/dts/arm/silabs/xg27/efr32bg27c140f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c140f768im32.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c140f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c140f768im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <5>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <3>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <7>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <7>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c140f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c140f768im32.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c140f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c140f768im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <5>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <6>;
+};
+
+&gpiod {
+	ngpios = <3>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(768)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <15>;
+};
+
+&gpiob {
+	ngpios = <8>;
+};
+
+&gpioc {
+	ngpios = <12>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
@@ -19,6 +19,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <15>;
+};
+
+&gpiob {
+	ngpios = <6>;
+};
+
+&gpioc {
+	ngpios = <12>;
+};
+
+&gpiod {
+	ngpios = <16>;
+};
+
 &radio {
 	ble-2mbps-supported;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <7>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <7>;
+};
+
+&gpiob {
+	ngpios = <3>;
+};
+
+&gpioc {
+	ngpios = <7>;
+};
+
+&gpiod {
+	ngpios = <2>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(192)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
@@ -18,6 +18,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <9>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
@@ -26,6 +26,22 @@
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
+&gpioa {
+	ngpios = <8>;
+};
+
+&gpiob {
+	ngpios = <5>;
+};
+
+&gpioc {
+	ngpios = <8>;
+};
+
+&gpiod {
+	ngpios = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };


### PR DESCRIPTION
Declare `ngpios` and `gpio-reserved-ranges` in Devicetree for Series 2 devices.

Set `port_pin_mask` in the GPIO driver for Silicon Labs Series 2 based on Devicetree `ngpios` and `gpio-reserved-ranges`. This mask is used to validate that the pin numbers passed to the GPIO API are valid on a given device when assertions are enabled.