### PR TITLE
drivers: uart: ns16550: clear TX and RX FIFOs when initial

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -855,6 +855,7 @@ static int uart_ns16550_init(const struct device *dev)
 	__maybe_unused struct uart_ns16550_dev_data *data = dev->data;
 	const struct uart_ns16550_dev_config *dev_cfg = dev->config;
 	__maybe_unused int ret;
+	uint8_t c;
 
 	ARG_UNUSED(dev_cfg);
 
@@ -934,6 +935,10 @@ static int uart_ns16550_init(const struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	dev_cfg->irq_config_func(dev);
 #endif
+
+	/* clear the port */
+	(void)ns16550_read_char(dev, &c);
+	ns16550_outbyte(dev_cfg, FCR(dev), (FCR_RCVRCLR | FCR_XMITCLR));
 
 	return pm_device_driver_init(dev, uart_ns16550_pm_action);
 }


### PR DESCRIPTION
Clear the TX and RX FIFOs to ensure a clean state. Without this reset, residual data or incomplete
characters from a previous session or the bootloader could remain in the hardware buffers.