### PR TITLE
scripts: kconfig: Add support for `-DKCONFIG_WARNING_AS_ERROR=1`

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -870,7 +870,6 @@ exclude = [
     "./scripts/github_helpers.py",
     "./scripts/gitlint/zephyr_commit_rules.py",
     "./scripts/kconfig/guiconfig.py",
-    "./scripts/kconfig/kconfig.py",
     "./scripts/kconfig/kconfigfunctions.py",
     "./scripts/kconfig/kconfiglib.py",
     "./scripts/kconfig/lint.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -768,7 +768,6 @@ exclude = [
     "./scripts/github_helpers.py",
     "./scripts/gitlint/zephyr_commit_rules.py",
     "./scripts/kconfig/guiconfig.py",
-    "./scripts/kconfig/kconfig.py",
     "./scripts/kconfig/kconfigfunctions.py",
     "./scripts/kconfig/kconfiglib.py",
     "./scripts/kconfig/lint.py",

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -405,12 +405,18 @@ if(NOT EXISTS ${autoconf_h_path})
   file(MAKE_DIRECTORY ${autoconf_h_path})
 endif()
 
+zephyr_get(KCONFIG_WARNING_AS_ERROR)
+if(KCONFIG_WARNING_AS_ERROR)
+  set(kconfig_py_flags --warning-as-error)
+endif()
+
 execute_process(
   COMMAND ${CMAKE_COMMAND} -E env
   ${COMMON_KCONFIG_ENV_SETTINGS}
   SHIELD_AS_LIST=${SHIELD_AS_LIST_ESCAPED_COMMAND}
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/kconfig/kconfig.py
+  ${kconfig_py_flags}
   --zephyr-base=${ZEPHYR_BASE}
   ${input_configs_flags}
   ${KCONFIG_ROOT}

--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -191,6 +191,29 @@ configuration that gets modified when making changes in the :ref:`interactive
 configuration interfaces <menuconfig>`.
 
 
+.. _kconfig_warning_as_error:
+
+Treating Kconfig warnings as errors
+***********************************
+
+Some Kconfig warnings abort the build by default, for example assignments to
+undefined symbols. Others are only printed, for example when a symbol is set
+more than once, or when an assignment is ignored because the dependencies of
+the symbol are not satisfied.
+
+Set the :makevar:`KCONFIG_WARNING_AS_ERROR` CMake variable to treat *every*
+Kconfig warning as an error:
+
+.. code-block:: console
+
+   west build -b <board> <app> -- -DKCONFIG_WARNING_AS_ERROR=y
+
+This is useful in CI, where a silently ignored configuration setting is likely
+to be a mistake. It is read with ``zephyr_get()``, so it can also be given as
+an :ref:`environment variable <env_vars>` or through a
+:ref:`cmake_build_config_package`.
+
+
 Tracking Kconfig symbols
 ************************
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -449,6 +449,10 @@ should know about.
   fragments and devicetree overlays (if these files exists, otherwise will fallback to
   the name without the prefix). See :ref:`application-file-suffixes` for details.
 
+* :makevar:`KCONFIG_WARNING_AS_ERROR`: Treat every Kconfig warning as an error,
+  including the ones which are only printed by default. See
+  :ref:`kconfig_warning_as_error` for details.
+
 .. note::
 
    You can use a :ref:`cmake_build_config_package` to share common settings for

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -47,8 +47,7 @@ def main():
         os.environ['ZEPHYR_BASE'] = args.zephyr_base
 
     print("Parsing " + args.kconfig_file)
-    kconf = Kconfig(args.kconfig_file, warn_to_stderr=False,
-                    suppress_traceback=True)
+    kconf = Kconfig(args.kconfig_file, warn_to_stderr=False, suppress_traceback=True)
 
     if args.handwritten_input_configs:
         # Warn for assignments to undefined symbols, but only for handwritten
@@ -152,10 +151,13 @@ def check_no_promptless_assign(kconf):
 
     for sym in kconf.unique_defined_syms:
         if sym.user_value is not None and promptless(sym):
-            err(f"""\
+            err(
+                f"""\
 {sym.name_and_loc} is assigned in a configuration file, but is not directly
 user-configurable (has no prompt). It gets its value indirectly from other
-symbols. """ + SYM_INFO_HINT.format(sym))
+symbols. """
+                + SYM_INFO_HINT.format(sym)
+            )
 
 
 def check_assigned_sym_values(kconf):
@@ -177,8 +179,10 @@ def check_assigned_sym_values(kconf):
             user_value = TRI_TO_STR[user_value]
 
         if user_value != sym.str_value:
-            msg = f"{sym.name_and_loc} was assigned the value '{user_value}'" \
-                  f" but got the value '{sym.str_value}'. "
+            msg = (
+                f"{sym.name_and_loc} was assigned the value '{user_value}'"
+                f" but got the value '{sym.str_value}'. "
+            )
 
             # List any unsatisfied 'depends on' dependencies in the warning
             mdeps = missing_deps(sym)
@@ -191,11 +195,9 @@ def check_assigned_sym_values(kconf):
                         # Gives '(FOO || BAR) (=n)' instead of
                         # 'FOO || BAR (=n)', which might be clearer.
                         estr = f"({estr})"
-                    expr_strs.append(f"{estr} "
-                                     f"(={TRI_TO_STR[expr_value(expr)]})")
+                    expr_strs.append(f"{estr} (={TRI_TO_STR[expr_value(expr)]})")
 
-                msg += "Check these unsatisfied dependencies: " + \
-                    ", ".join(expr_strs) + ". "
+                msg += "Check these unsatisfied dependencies: " + ", ".join(expr_strs) + ". "
 
             warn(msg + SYM_INFO_HINT.format(sym))
 
@@ -239,13 +241,14 @@ def check_assigned_choice_values(kconf):
     # y ended up as n, and print a spurious warning.
 
     for choice in kconf.unique_choices:
-        if choice.user_selection and \
-           choice.user_selection is not choice.selection:
-
-            warn(f"""\
+        if choice.user_selection and choice.user_selection is not choice.selection:
+            warn(
+                f"""\
 The choice symbol {choice.user_selection.name_and_loc} was selected (set =y),
 but {choice.selection.name_and_loc if choice.selection else "no symbol"} ended
-up as the choice selection. """ + SYM_INFO_HINT.format(choice.user_selection))
+up as the choice selection. """
+                + SYM_INFO_HINT.format(choice.user_selection)
+            )
 
 
 # Hint on where to find symbol information. Used like
@@ -278,6 +281,7 @@ def check_experimental(kconf):
         for selector in selectors:
             selector_name = split_expr(selector, AND)[0].name
             warn(f'Experimental symbol {selector_name} is enabled.')
+
 
 def check_not_secure(kconf):
     not_secure = kconf.syms.get('NOT_SECURE')
@@ -328,8 +332,7 @@ def collect_trace_data(kconf):
         kind, loc = origin
         value = None if kind == "unset" else item.str_value
 
-        trace_entry = (name, TRI_TO_STR[item.visibility],
-                       TYPE_TO_STR[item.type], value, kind, loc)
+        trace_entry = (name, TRI_TO_STR[item.visibility], TYPE_TO_STR[item.type], value, kind, loc)
         trace_data.append(trace_entry)
 
     return trace_data
@@ -342,42 +345,44 @@ def write_kconfig_filenames(kconf, kconfig_list_path):
     # needs to be deterministic.
 
     with open(kconfig_list_path, 'w') as out:
-        for path in sorted({os.path.realpath(os.path.join(kconf.srctree, path))
-                            for path in set(kconf.kconfig_filenames)}):
+        for path in sorted(
+            {
+                os.path.realpath(os.path.join(kconf.srctree, path))
+                for path in set(kconf.kconfig_filenames)
+            }
+        ):
             print(path, file=out)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
-    parser.add_argument("--handwritten-input-configs",
-                        action="store_true",
-                        help="Assume the input configuration fragments are "
-                             "handwritten fragments and do additional checks "
-                             "on them, like no promptless symbols being "
-                             "assigned")
-    parser.add_argument("--forced-input-configs",
-                        action="store_true",
-                        help="Indicate the input configuration files are "
-                             "followed by an forced configuration file."
-                             "The forced configuration is used to forcefully "
-                             "set specific configuration settings to a "
-                             "pre-defined value and thereby remove any user "
-                             " adjustments.")
-    parser.add_argument("--zephyr-base",
-                        help="Path to current Zephyr installation")
-    parser.add_argument("kconfig_file",
-                        help="Top-level Kconfig file")
-    parser.add_argument("config_out",
-                        help="Output configuration file")
-    parser.add_argument("header_out",
-                        help="Output header file")
-    parser.add_argument("kconfig_list_out",
-                        help="Output file for list of parsed Kconfig files")
-    parser.add_argument("configs_in",
-                        nargs="+",
-                        help="Input configuration fragments. Will be merged "
-                             "together.")
+    parser.add_argument(
+        "--handwritten-input-configs",
+        action="store_true",
+        help="Assume the input configuration fragments are "
+        "handwritten fragments and do additional checks "
+        "on them, like no promptless symbols being "
+        "assigned",
+    )
+    parser.add_argument(
+        "--forced-input-configs",
+        action="store_true",
+        help="Indicate the input configuration files are "
+        "followed by an forced configuration file."
+        "The forced configuration is used to forcefully "
+        "set specific configuration settings to a "
+        "pre-defined value and thereby remove any user "
+        " adjustments.",
+    )
+    parser.add_argument("--zephyr-base", help="Path to current Zephyr installation")
+    parser.add_argument("kconfig_file", help="Top-level Kconfig file")
+    parser.add_argument("config_out", help="Output configuration file")
+    parser.add_argument("header_out", help="Output header file")
+    parser.add_argument("kconfig_list_out", help="Output file for list of parsed Kconfig files")
+    parser.add_argument(
+        "configs_in", nargs="+", help="Input configuration fragments. Will be merged together."
+    )
 
     return parser.parse_args()
 

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -39,6 +39,9 @@ from kconfiglib import (
     split_expr,
 )
 
+# store warnings separately from kconf.warnings
+warnings = []
+
 
 def main():
     args = parse_args()
@@ -106,13 +109,11 @@ def main():
     # fast.
     kconf.write_config(os.devnull)
 
-    warn_only = r"warning:.*set more than once."
+    warn_only = [r"warning:.*set more than once."]
+    error_out = False
 
     if kconf.warnings:
-        if args.forced_input_configs:
-            error_out = False
-        else:
-            error_out = True
+        error_out = not args.forced_input_configs
 
         # Put a blank line between warnings to make them easier to read
         for warning in kconf.warnings:
@@ -130,6 +131,12 @@ def main():
         # warning for now.
         if error_out:
             err("Aborting due to Kconfig warnings")
+
+    # if args.werror is enabled error out in case of any warning
+    if args.werror and (warnings or kconf.warnings):
+        for warning in warnings + kconf.warnings:
+            print("\n" + warning, file=sys.stderr)
+        err("Aborting due to Kconfig warnings (--warning-as-error)")
 
     # Write the merged configuration and the C header
     print(kconf.write_config(args.config_out))
@@ -375,6 +382,12 @@ def parse_args():
         "pre-defined value and thereby remove any user "
         " adjustments.",
     )
+    parser.add_argument(
+        "--warning-as-error",
+        action=argparse.BooleanOptionalAction,
+        dest='werror',
+        help="Turn Kconfig warnings into errors",
+    )
     parser.add_argument("--zephyr-base", help="Path to current Zephyr installation")
     parser.add_argument("kconfig_file", help="Top-level Kconfig file")
     parser.add_argument("config_out", help="Output configuration file")
@@ -392,7 +405,13 @@ def warn(msg):
     # reference link, and add some extra newlines to set the message off from
     # surrounding text (this usually gets printed as part of spammy CMake
     # output)
-    print("\n" + textwrap.fill("warning: " + msg, 100) + "\n", file=sys.stderr)
+    warning = "warning: " + msg
+
+    # store the warning without linebreaks for easier parsing later
+    warnings.append(warning)
+
+    # Put a blank line between warnings when printed to make them easier to read
+    print("\n\n" + textwrap.fill(warning, 100) + "\n", file=sys.stderr)
 
 
 def err(msg):

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -39,6 +39,9 @@ from kconfiglib import (
     split_expr,
 )
 
+# store warnings separately from kconf.warnings
+warnings = []
+
 
 def main():
     args = parse_args()
@@ -109,10 +112,7 @@ def main():
     warn_only = r"warning:.*set more than once."
 
     if kconf.warnings:
-        if args.forced_input_configs:
-            error_out = False
-        else:
-            error_out = True
+        error_out = not args.forced_input_configs
 
         # Put a blank line between warnings to make them easier to read
         for warning in kconf.warnings:
@@ -130,6 +130,12 @@ def main():
         # warning for now.
         if error_out:
             err("Aborting due to Kconfig warnings")
+
+    # All warnings have already been printed above, either by warn() or by the
+    # kconf.warnings loop. With --warning-as-error, any of them is fatal, also
+    # the ones which are tolerated by default.
+    if args.werror and (warnings or kconf.warnings):
+        err("Aborting due to Kconfig warnings (--warning-as-error)")
 
     # Write the merged configuration and the C header
     print(kconf.write_config(args.config_out))
@@ -375,6 +381,12 @@ def parse_args():
         "pre-defined value and thereby remove any user "
         " adjustments.",
     )
+    parser.add_argument(
+        "--warning-as-error",
+        action=argparse.BooleanOptionalAction,
+        dest='werror',
+        help="Turn Kconfig warnings into errors",
+    )
     parser.add_argument("--zephyr-base", help="Path to current Zephyr installation")
     parser.add_argument("kconfig_file", help="Top-level Kconfig file")
     parser.add_argument("config_out", help="Output configuration file")
@@ -392,7 +404,13 @@ def warn(msg):
     # reference link, and add some extra newlines to set the message off from
     # surrounding text (this usually gets printed as part of spammy CMake
     # output)
-    print("\n" + textwrap.fill("warning: " + msg, 100) + "\n", file=sys.stderr)
+    warning = "warning: " + msg
+
+    # store the warning unwrapped, so that --warning-as-error can tell whether
+    # any warning was emitted at all
+    warnings.append(warning)
+
+    print("\n" + textwrap.fill(warning, 100) + "\n", file=sys.stderr)
 
 
 def err(msg):


### PR DESCRIPTION
Ref: #77530

Support for `-DKCONFIG_WARNING_AS_ERROR=1` is added, which can be used to control that cmake stops in case of any kconfig warning. `.

**Potential for Improvement in a follow-up PR:**
In a next step `-DKCONFIG_WARNING_AS_ERROR_CONFIG=<path>` could be supported to specify a config file, that defines if a specific pattern is treated as warning or as error.


