### PR TITLE
usb: host: add missing const qualifier

### DIFF
--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -13,8 +13,8 @@
 
 LOG_MODULE_REGISTER(usbh_desc, CONFIG_USBH_LOG_LEVEL);
 
-bool usbh_desc_is_valid(const void *const desc,
-			const size_t size, const uint8_t type)
+const bool usbh_desc_is_valid(const void *const desc,
+			      const size_t size, const uint8_t type)
 {
 	const struct usb_desc_header *const head = desc;
 


### PR DESCRIPTION
Add missing const qualifier, fix build issue found when building with clang:

$ export ZEPHYR_TOOLCHAIN_VARIANT=llvm
$ west build -p -b native_sim/native tests/subsys/usb/device_next ...
zephyrproject/zephyr/subsys/usb/host/usbh_desc.c:16:6: error: conflicting types for 'usbh_desc_is_valid'
   16 | bool usbh_desc_is_valid(const void *const desc,
      |      ^
/home/fabiobaltieri/zephyrproject/zephyr/subsys/usb/host/usbh_desc.h:92:12:
note: previous declaration is here
   92 | const bool usbh_desc_is_valid(const void *const desc,
      |            ^