### PR TITLE
usb: host: refine connect/disconnect handling

### DIFF
--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -12,7 +12,6 @@
 #include <zephyr/usb/usbh.h>
 
 #include "usbh_class.h"
-#include "usbh_class_api.h"
 #include "usbh_device.h"
 #include "usbh_internal.h"
 
@@ -48,41 +47,35 @@ static int usbh_event_carrier(const struct device *dev,
 static void dev_connected_handler(struct usbh_context *const ctx,
 				  const struct uhc_event *const event)
 {
-	LOG_DBG("Device connected event");
-	if (ctx->root != NULL) {
-		LOG_ERR("Device already connected");
-		usbh_device_free(ctx->root);
-		ctx->root = NULL;
-	}
+	struct usb_device *udev;
 
-	ctx->root = usbh_device_alloc(ctx);
-	if (ctx->root == NULL) {
+	udev = usbh_device_alloc(ctx);
+
+	if (udev == NULL) {
 		LOG_ERR("Failed allocate new device");
 		return;
 	}
 
-	ctx->root->state = USB_STATE_DEFAULT;
-
 	if (event->type == UHC_EVT_DEV_CONNECTED_HS) {
-		ctx->root->speed = USB_SPEED_SPEED_HS;
+		udev->speed = USB_SPEED_SPEED_HS;
 	} else {
-		ctx->root->speed = USB_SPEED_SPEED_FS;
+		udev->speed = USB_SPEED_SPEED_FS;
 	}
 
-	if (usbh_device_init(ctx->root)) {
-		LOG_ERR("Failed to reset new USB device");
+	if (ctx->root == NULL) {
+		ctx->root = udev;
 	}
 
-	usbh_class_probe_device(ctx->root);
+	usbh_device_connect(ctx, udev);
 }
 
 static void dev_removed_handler(struct usbh_context *const ctx)
 {
-	if (ctx->root != NULL) {
-		usbh_class_remove_all(ctx->root);
-		usbh_device_free(ctx->root);
-		ctx->root = NULL;
-		LOG_DBG("Device removed");
+	struct usb_device *udev = NULL;
+
+	udev = usbh_device_get_root(ctx);
+	if (udev != NULL) {
+		usbh_device_disconnect(ctx, udev);
 	} else {
 		LOG_DBG("Spurious device removed event");
 	}

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -8,6 +8,8 @@
 
 #include "usbh_device.h"
 #include "usbh_ch9.h"
+#include "usbh_class.h"
+#include "usbh_class_api.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbh_dev, CONFIG_USBH_LOG_LEVEL);
@@ -480,6 +482,39 @@ int usbh_device_set_address(struct usb_device *const udev, const uint8_t new_add
 	return 0;
 }
 
+struct usb_device *usbh_device_get_root(struct usbh_context *const ctx)
+{
+	return ctx->root;
+}
+
+void usbh_device_connect(struct usbh_context *const ctx,
+			 struct usb_device *const udev)
+{
+	int err;
+
+	LOG_DBG("Device connected event");
+
+	udev->state = USB_STATE_DEFAULT;
+
+	err = usbh_device_init(udev);
+	if (err != 0) {
+		LOG_ERR("Failed to init new USB device");
+		usbh_device_free(udev);
+		return;
+	}
+
+	usbh_class_probe_device(udev);
+}
+
+void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
+{
+	usbh_class_remove_all(udev);
+
+	usbh_device_free(udev);
+
+	LOG_DBG("Device removed");
+}
+
 int usbh_device_init(struct usb_device *const udev)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
@@ -497,11 +532,12 @@ int usbh_device_init(struct usb_device *const udev)
 		return err;
 	}
 
-	/* FIXME: The port to which the device is connected should be reset. */
-	err = uhc_bus_reset(uhs_ctx->dev);
-	if (err) {
-		LOG_ERR("Failed to signal bus reset");
-		return err;
+	if (usbh_device_is_root(uhs_ctx, udev)) {
+		err = uhc_bus_reset(uhs_ctx->dev);
+		if (err) {
+			LOG_ERR("Failed to signal bus reset");
+			return err;
+		}
 	}
 
 	/*

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -38,6 +38,22 @@ int usbh_device_interface_set(struct usb_device *const udev,
 /* Set USB device address */
 int usbh_device_set_address(struct usb_device *const udev, const uint8_t num);
 
+/* Get root USB device */
+struct usb_device *usbh_device_get_root(struct usbh_context *const ctx);
+
+/* Check if USB device is root */
+static inline bool usbh_device_is_root(struct usbh_context *const ctx,
+				       struct usb_device *const udev)
+{
+	return usbh_device_get_root(ctx) == udev;
+}
+
+/* Connect a new USB device */
+void usbh_device_connect(struct usbh_context *const ctx, struct usb_device *const udev);
+
+/* Disconnect USB device */
+void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
+
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,


### PR DESCRIPTION
1. Remove the root member from usbh_context and add two functions: usbh_device_get_root() and usbh_device_is_root() to check the root device.
2. Add two functions for device connection and disconnection: usbh_connect_device() for device connection and
usbh_disconnect_device() for device disconnection. These functions centralize the logic for device attach/detach, including class probe and remove handling. They can be invoked by the hub class as well as dev_connected_handler and dev_removed_handler, improving code clarity and reuse.