### PR TITLE
samples: boards: nordic: nrf_sys_event: Clean up

### DIFF
--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_common.dtsi
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_common.dtsi
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-sample_counter: &timer20 {
-	status = "okay";
-};

--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nrf54l15dk_nrf54l15_common.dtsi"
+sample_counter: &timer20 {
+	status = "okay";
+};

--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
@@ -1,6 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include "nrf54l15dk_nrf54l15_common.dtsi"


### PR DESCRIPTION
Remove overlay for nrf54l15dk/nrf54l15/cpuflpr/xip as sample is intended to be run only on the cpuapp. Overlay for cpuflpr was added but it was never added to sample.yaml configuration.