### PR TITLE
usb: host: Correct function prototype

### DIFF
--- a/subsys/usb/host/usbh_desc.h
+++ b/subsys/usb/host/usbh_desc.h
@@ -89,8 +89,7 @@ int usbh_desc_fill_filter(const struct usb_desc_header *desc,
  * @return true if the descriptor size and type are correct
  * @return false if the descriptor size or type is wrong
  */
-const bool usbh_desc_is_valid(const void *const desc,
-			      const size_t size, const uint8_t type);
+bool usbh_desc_is_valid(const void *const desc, const size_t size, const uint8_t type);
 
 /**
  * @brief Checks that the pointed descriptor is an interface descriptor.


### PR DESCRIPTION
Correct function prototype which causes a compiler warning and builds to fail due to it.

Failure can be seen for ex. here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21712843364/job/62620678223#step:12:329
with clang