### PR TITLE
drivers: usb: udc: stm32: enable SOF support

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -742,6 +742,7 @@ int udc_stm32_init(const struct device *dev)
 	priv->pcd.Init.ep0_mps = UDC_STM32_EP0_MAX_PACKET_SIZE;
 	priv->pcd.Init.phy_itface = cfg->selected_phy;
 	priv->pcd.Init.speed = cfg->selected_speed;
+	priv->pcd.Init.Sof_enable = IS_ENABLED(CONFIG_UDC_ENABLE_SOF);
 
 	status = HAL_PCD_Init(&priv->pcd);
 	if (status != HAL_OK) {


### PR DESCRIPTION
For some reason, the driver was not requesting the HAL to enable SOF even if SOF was enabled at stack level.

Fix by requesting SOF to be enabled based on stack configuration. ~~While at it, `#ifdef`-gate a function definition to reduce footprint when SOF is not enabled.~~ dropped due to @jfischer-no request