### PR TITLE
kconfig: fix load offset when FLASH_CODE_PARTITION_ADDRESS_INVALID + prevent build warning when not applicable

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -122,7 +122,7 @@ config FLASH_LOAD_OFFSET
 	default $(sub_hex, $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)), \
 		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if USE_DT_CODE_PARTITION && \
 		!FLASH_CODE_PARTITION_ADDRESS_INVALID
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) if USE_DT_CODE_PARTITION
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
 	default 0
 	help
 	  This option specifies the byte offset from the beginning of flash that

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -103,6 +103,7 @@ DT_CHOSEN_Z_FLASH := zephyr,flash
 config FLASH_CODE_PARTITION_ADDRESS_INVALID
 	bool
 	default y if XIP && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) < FLASH_BASE_ADDRESS
+	depends on USE_DT_CODE_PARTITION
 	select DEPRECATED
 	help
 	  If this item is selected, it is likely selected because your board/SoC/base DTS files

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -119,10 +119,10 @@ config FLASH_CODE_PARTITION_ADDRESS_INVALID
 config FLASH_LOAD_OFFSET
 	# Only user-configurable when USE_DT_CODE_PARTITION is disabled
 	hex "Kernel load offset" if !USE_DT_CODE_PARTITION
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) \
+		if FLASH_CODE_PARTITION_ADDRESS_INVALID
 	default $(sub_hex, $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)), \
-		$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if USE_DT_CODE_PARTITION && \
-		!FLASH_CODE_PARTITION_ADDRESS_INVALID
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
+			   $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))) if USE_DT_CODE_PARTITION
 	default 0
 	help
 	  This option specifies the byte offset from the beginning of flash that


### PR DESCRIPTION
Commit 2f7d13840f6d introduced `FLASH_CODE_PARTITION_ADDRESS_INVALID` config symbol.
- Prevents it emits a "warning: Deprecated symbol ..." build message when not applicable.
- Fix the load offset value when deprecated offset scheme is used in the DT (when above switch gets enabled).

The issue being fixed is that application code base address is _2 x memory_base_address_ when it's expected to be _memory_base_address+memory_partition_offset_.

The issue currently prevents at least all ST boards from being programmed (no error at build time) when either MCUBoot or TF-M is embedded. Any other board enabling `CONFIG_USE_DT_CODE_PARTITION` and using the now deprecated DT partition offset scheme is likely also impacted.