### PR TITLE
Update documentation references to AM62L-specific resources

### DIFF
--- a/boards/ti/am62l_evm/doc/index.rst
+++ b/boards/ti/am62l_evm/doc/index.rst
@@ -94,13 +94,13 @@ References
 https://www.ti.com/tool/TMDS62LEVM
 
 .. _AM62L EVM TRM:
-   https://www.ti.com/lit/pdf/SPRUJG8
+   https://www.ti.com/lit/pdf/sprujb4
 
 .. _TI AM62L Product Page:
    https://www.ti.com/product/AM62L
 
 .. _WIC:
-   https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-PvdSyIiioq/10.01.10.04/tisdk-default-image-am62xx-evm-10.01.10.04.rootfs.wic.xz
+   https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-YjEeNKJJjt/11.02.08.02/tisdk-default-image-am62lxx-evm-11.02.08.02.rootfs.wic.xz
 
 .. _EVM User's Guide:
    https://www.ti.com/lit/pdf/SPRUJG8


### PR DESCRIPTION
Update AM62L EVM documentation references to point to correct technical resources:

- Update TRM link (correct AM62L SoC TRM)
- Update correct link to linux SDK WIC image for am62l_evm

