### PR TITLE
samples: uart: async_api: Add NUCLEO_L4R5ZI board support

### DIFF
--- a/samples/drivers/uart/async_api/boards/nucleo_l4r5zi.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Waqar Ahmed
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpuart1 {
+	status = "okay";
+	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+
+	dmas = <&dmamux1 5 34 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 35 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add support of NUCLEO_L4R5ZI in async API sample with DMA-enabled LPUART1 devicetree overlay.

Configuration:
- DMA1 channel 5 for TX (DMAMUX slot 34)
- DMA1 channel 4 for RX (DMAMUX slot 35)
- LPUART1 on pins PG7 (TX) and PG8 (RX)
- Baud rate: 115200

Tested on hardware with loopback configuration.