### PR TITLE
Improvements to samples boards nordic nrf sys event

### DIFF
--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_common.dtsi
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_common.dtsi
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-sample_counter: &timer20 {
-	status = "okay";
-};

--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nrf54l15dk_nrf54l15_common.dtsi"
+sample_counter: &timer20 {
+	status = "okay";
+};

--- a/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/boards/nordic/nrf_sys_event/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
@@ -1,6 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include "nrf54l15dk_nrf54l15_common.dtsi"

--- a/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
+++ b/samples/boards/nordic/nrf_sys_event/pytest/test_reg_event.py
@@ -16,7 +16,7 @@ def test_rramc_wakeup(dut: DeviceAdapter):
     - sample.boards.nordic.nrf_sys_event.rramc_wakeup.ppi.
     Parse logs from serial port. If the Register Event API was used correctly,
     code execution shall be faster by ~14 us when event was registered.
-    If the API works correctly, RRAMC is woken up just before event occures.
+    If the API works correctly, RRAMC is woken up just before event occurs.
     Thus, there is no delay resulting from RRAMC getting ready.
     """
 

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -62,5 +62,6 @@ tests:
       - CONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/boards/nordic/nrf_sys_event/src/main.c
+++ b/samples/boards/nordic/nrf_sys_event/src/main.c
@@ -97,9 +97,7 @@ static void sys_event_irq_latency_run(enum rramc_mode mode)
 static void sys_event_irq_latency(void)
 {
 	sys_event_irq_latency_run(RRAMC_DEFAULT);
-#if !defined(CONFIG_SOC_NRF54LM20A)
 	sys_event_irq_latency_run(RRAMC_POWER_MODE);
-#endif
 	sys_event_irq_latency_run(RRAMC_PPI_WAKEUP);
 }
 #endif /* CONFIG_NRF_SYS_EVENT_IRQ_LATENCY */


### PR DESCRIPTION
samples: boards: nordic: nrf_sys_event: Enable Twister on nrf54lm20dk

Add nrf54lm20dk/nrf54lm20a/cpuapp to platform_allow list.
Overlay for this target is already there.

Remove skipping of RRAMC_POWER_MODE on nrf54lm20dk because PyTest always expects result from this configuration.

//--
samples: boards: nordic: nrf_sys_event: Remove unused overlays

Remove overlay for nrf54l15dk/nrf54l15/cpuflpr/xip target as it is no longer supported.