### PR TITLE
boards: st: simplify build directive when TF-M is embedded

### DIFF
--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -1,15 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  set(TFM_FLASH_BASE_ADDRESS 0x0C000000)
 
+if(CONFIG_BUILD_WITH_TFM)
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${TFM_FLASH_BASE_ADDRESS}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_TFM_FLASH_BASE_ADDRESS})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 endif()
 
 # keep first

--- a/boards/st/nucleo_l552ze_q/board.cmake
+++ b/boards/st/nucleo_l552ze_q/board.cmake
@@ -1,16 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BUILD_WITH_TFM)
-  set(FLASH_BASE_ADDRESS_S 0x0C000000)
-
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_FLASH_BASE_ADDRESS_S})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 endif()
 
 # keep first

--- a/boards/st/nucleo_wba65ri/board.cmake
+++ b/boards/st/nucleo_wba65ri/board.cmake
@@ -2,21 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BUILD_WITH_TFM)
-  set(FLASH_BASE_ADDRESS_S 0x0C000000)
-
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_FLASH_BASE_ADDRESS_S})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 
   # System entry point is TF-M vector, located 1kByte after tfm_fmw_partition in DTS
   dt_nodelabel(tfm_partition_path NODELABEL slot0_secure_partition REQUIRED)
   dt_reg_addr(tfm_partition_offset PATH ${tfm_partition_path} REQUIRED)
-  math(EXPR tfm_fwm_boot_address "${tfm_partition_offset}+${FLASH_BASE_ADDRESS_S}+0x400")
+  math(EXPR tfm_fwm_boot_address "${tfm_partition_offset}+${flash_secure_base_address}+0x400")
 
   board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw"
     "--erase" "--start-address=${tfm_fwm_boot_address}"

--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -1,15 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  set(FLASH_BASE_ADDRESS_S 0x0C000000)
 
+if(CONFIG_BUILD_WITH_TFM)
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_FLASH_BASE_ADDRESS_S})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 endif()
 
 # keep first

--- a/boards/st/stm32l562e_dk/board.cmake
+++ b/boards/st/stm32l562e_dk/board.cmake
@@ -1,15 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_BUILD_WITH_TFM)
-  set(TFM_FLASH_BASE_ADDRESS 0x0C000000)
 
+if(CONFIG_BUILD_WITH_TFM)
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${TFM_FLASH_BASE_ADDRESS}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_TFM_FLASH_BASE_ADDRESS})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 endif()
 
 # keep first

--- a/boards/st/stm32wba65i_dk1/board.cmake
+++ b/boards/st/stm32wba65i_dk1/board.cmake
@@ -2,21 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BUILD_WITH_TFM)
-  set(FLASH_BASE_ADDRESS_S 0x0C000000)
-
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
-    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")
-  else()
-    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_FLASH_BASE_ADDRESS_S})
-  endif()
+  # Flash is set all secure (<build>/tfm/api_ns/regression.sh) before flash programming
+  # hence locate non-secure image from the secure flash base address in HEX file.
+  set(flash_secure_base_address 0x0c000000)
+  math(EXPR TFM_HEX_BASE_ADDRESS_NS "${flash_secure_base_address}+${CONFIG_FLASH_LOAD_OFFSET}")
 
   # System entry point is TF-M vector, located 1kByte after tfm_fmw_partition in DTS
   dt_nodelabel(tfm_partition_path NODELABEL slot0_secure_partition REQUIRED)
   dt_reg_addr(tfm_partition_offset PATH ${tfm_partition_path} REQUIRED)
-  math(EXPR tfm_fwm_boot_address "${tfm_partition_offset}+${FLASH_BASE_ADDRESS_S}+0x400")
+  math(EXPR tfm_fwm_boot_address "${tfm_partition_offset}+${flash_secure_base_address}+0x400")
 
   board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw"
     "--erase" "--start-address=${tfm_fwm_boot_address}"


### PR DESCRIPTION
Originally there was typos in 2 ST board **board.cmake** files when `CONFIG_HAS_FLASH_LOAD_OFFSET` is disabled. These are solved by removing testing of `CONFIG_HAS_FLASH_LOAD_OFFSET` in **board.cmake** files that relate to architectures where this configuration switch is always enabled.

While at it, rename `TFM_FLASH_BASE_ADDRESS` to `flash_secure_base_address` to prevent confusion upon being a variable used in TFM build sequence (`TFM_` prefix since it is not, it is a CMake variable local to these **board.cmake** files.