### PR TITLE
dts: bindings: gpio: adi: fix typos in bindings

### DIFF
--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -23,7 +23,7 @@ properties:
   fault-gpios:
     description: |
       Fault pin indicates when there is Fault state in either FAULT1 or FAULT2
-      bothe of which are cleaned on read once problem is not persistent.
+      both of which are cleaned on read once problem is not persistent.
     type: phandle-array
   sync-gpios:
     description: |

--- a/dts/bindings/gpio/adi,max14916-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14916-gpio.yaml
@@ -23,7 +23,7 @@ properties:
   fault-gpios:
     description: |
       Fault pin indicates when there is Fault state in either FAULT1 or FAULT2
-      bothe of which are cleaned on read once problem is not persistent
+      both of which are cleaned on read once problem is not persistent
     type: phandle-array
   sync-gpios:
     description: |

--- a/dts/bindings/gpio/adi,max22190-gpio.yaml
+++ b/dts/bindings/gpio/adi,max22190-gpio.yaml
@@ -4,9 +4,9 @@
 
 description: |
   ADI MAX22190 octal industrial Input with advanced diagnostic
-  capabilities like Wire break and over/under volatage.
-  Fiter configuration could be done on per channel bases, which
-  mean WB functionality and filters could be set. Reffering to:
+  capabilities like Wire break and over/under voltage.
+  Filter configuration could be done on per channel bases, which
+  mean WB functionality and filters could be set. Referring to:
   filter-wbes = <CH0 CH1 CH2 ... CH7 >  for wire break
   To enable wire break set 1 else 0. Same principle is followed for:
   filter-fbps and filter-delays.
@@ -49,7 +49,7 @@ properties:
       Wire break is disabled in all channels.
       WBE bit in all Filter registers stand for wire break enable on each
       channel, so to enable WB functionality set 1.
-      If WB on specific channel is disabled , FAULT will not be rised in case
+      If WB on specific channel is disabled , FAULT will not be raised in case
       wire is cut.
       - 1 wire break enable
       - 0 wire break disable

--- a/dts/bindings/gpio/adi,max2219x-base-gpio.yaml
+++ b/dts/bindings/gpio/adi,max2219x-base-gpio.yaml
@@ -18,7 +18,7 @@ properties:
   fault-gpios:
     description: |
       Fault pin indicates when there is Fault state in either FAULT1 or FAULT2
-      bothe of which are cleaned on read once problem is not persistent
+      both of which are cleaned on read once problem is not persistent
     type: phandle-array
   latch-gpios:
     description: |
@@ -51,7 +51,7 @@ properties:
       Wire break is disabled in all channels.
       WBE bit in all Filter registers stand for wire break enable on each
       channel, so to enable WB functionality set 1.
-      If WB on specific channel is disabled , FAULT will not be rised in case
+      If WB on specific channel is disabled , FAULT will not be raised in case
       wire is cut.
       - 1 wire break enable
       - 0 wire break disable


### PR DESCRIPTION
Fix multiple spelling errors in GPIO ADI dts bindings descriptions.

No functional changes.