### PR TITLE
llext: define global mutex using K_MUTEX_DEFINE

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(llext, CONFIG_LLEXT_LOG_LEVEL);
 
 sys_slist_t llext_list = SYS_SLIST_STATIC_INIT(&llext_list);
 
-struct k_mutex llext_lock = Z_MUTEX_INITIALIZER(llext_lock);
+K_MUTEX_DEFINE(llext_lock);
 
 int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
 			const char *sect_name)


### PR DESCRIPTION
Use the appropriate macro `K_MUTEX_DEFINE` to define the global `llext_lock` mutex instead of declaring it like a regular variable initialized using the internal `Z_MUTEX_INITIALIZER()` helper.