### PR TITLE
shell: move position of `last_nl` in `struct shell_backend_ctx_flags`

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -931,10 +931,10 @@ BUILD_ASSERT((sizeof(struct shell_backend_config_flags) == sizeof(uint32_t)),
 };
 
 struct shell_backend_ctx_flags {
+	uint32_t last_nl      :8; /*!< Last received new line character */
 	uint32_t processing   :1; /*!< Shell is executing process function */
 	uint32_t tx_rdy       :1;
 	uint32_t history_exit :1; /*!< Request to exit history mode */
-	uint32_t last_nl      :8; /*!< Last received new line character */
 	uint32_t cmd_ctx      :1; /*!< Shell is executing command */
 	uint32_t print_noinit :1; /*!< Print request from not initialized shell */
 	uint32_t sync_mode    :1; /*!< Shell in synchronous mode */


### PR DESCRIPTION
`last_nl` is 8 bits long, put it at the beginning of the packed struct, so it can be read and written with one intruction, as it is now aligned.