### PR TITLE
subsys: modem: backends: uart async close fix

### DIFF
--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -288,7 +288,6 @@ static int modem_backend_uart_async_close(void *data)
 		LOG_ERR("Failed to power off UART: %d", ret);
 		return ret;
 	}
-	modem_pipe_notify_closed(&backend->pipe);
 	return 0;
 }
 

--- a/tests/subsys/modem/backends/uart/src/main.c
+++ b/tests/subsys/modem/backends/uart/src/main.c
@@ -222,5 +222,17 @@ ZTEST(modem_backend_uart_suite, test_transmit_receive)
 	}
 }
 
+ZTEST(modem_backend_uart_suite, test_close_open)
+{
+	zassert_ok(modem_pipe_close(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_open(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_close(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_open(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_close(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_open(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_close(pipe, K_SECONDS(1)));
+	zassert_ok(modem_pipe_open(pipe, K_SECONDS(1)));
+}
+
 ZTEST_SUITE(modem_backend_uart_suite, NULL, test_modem_backend_uart_setup,
 	    test_modem_backend_uart_before, test_modem_backend_uart_after, NULL);


### PR DESCRIPTION
This fixes an issue where the modem pipe is declared closed before it actually is closed, leading to issues when you try to re-open quickly.

@bjarki-andreasen 