### PR TITLE
sys: list_gen: fix thread safety in list length calculation

### DIFF
--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -261,10 +261,10 @@
 	}
 
 #define Z_GENLIST_LEN(__lname, __nname)                                                            \
-	static inline size_t sys_##__lname##_len(const sys_##__lname##_t * list)                   \
+	static inline size_t sys_##__lname##_len(const sys_##__lname##_t *list)                    \
 	{                                                                                          \
 		size_t len = 0;                                                                    \
-		static sys_##__nname##_t * node;                                                   \
+		sys_##__nname##_t *node;                                                           \
 		Z_GENLIST_FOR_EACH_NODE(__lname, list, node) {                                     \
 			len++;                                                                     \
 		}                                                                                  \


### PR DESCRIPTION
The `Z_GENLIST_LEN` macro declared the loop iterator `node` as `static`. This causes the variable to be stored in the data segment, shared across all invocations of the generated `sys_*_len` function.

This makes the function non-reentrant and unsafe in multi-threaded environments. If an ISR or another thread calls the function concurrently, the shared iterator state gets corrupted, leading to incorrect results or infinite loops.

Removing the `static` keyword ensures `node` is allocated on the stack, making the function thread-safe.