### PR TITLE
remove CONSOLE dependency for LOG_BACKEND_UART

### DIFF
--- a/subsys/logging/backends/Kconfig.uart
+++ b/subsys/logging/backends/Kconfig.uart
@@ -3,7 +3,6 @@
 
 config LOG_BACKEND_UART
 	bool "UART backend"
-	depends on UART_CONSOLE
 	default y if !SHELL_BACKEND_SERIAL
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help


### PR DESCRIPTION
use case: zephyr,log-uart doesn't require console