### PR TITLE
tests: drivers: gpio: Update/add overlay for PSOC6 boards

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_062_4343w.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_062_4343w.overlay
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio_prt9 4 0>;
+		in-gpios = <&gpio_prt9 2 0>;
+	};
+};
+
+&gpio_prt9 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cy8cproto_063_ble.overlay
@@ -13,6 +13,6 @@
 	};
 };
 
-&gpio_prt9 {
+&gpio_prt12 {
 	status = "okay";
 };


### PR DESCRIPTION
For BLE board, update the present overlay to use the right port info to mark as okay.
For 062 board add overlay to run 2 pins tests successfully.