### PR TITLE
MAINTAINERS: add ACE counter drivers to Intel Xtensa Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3080,6 +3080,8 @@ Intel Platforms (Xtensa):
     - samples/boards/intel/adsp/
     - dts/bindings/*/intel,adsp*
     - scripts/west_commands/runners/intel_adsp.py
+    - drivers/counter/counter_ace_v1x*
+    - drivers/counter/Kconfig.ace
   labels:
     - "platform: Intel ADSP"
 


### PR DESCRIPTION
This adds the ACE counter drivers and Kconfig to the file list under Intel Audio DSP platform (aka Intel Xtensa platforms).