### PR TITLE
boards: ite: it51xxx_evb_it51526aw: include it51526aw.dtsi

### DIFF
--- a/boards/ite/it51xxx_evb/it51xxx_evb_it51526aw.dts
+++ b/boards/ite/it51xxx_evb/it51xxx_evb_it51526aw.dts
@@ -8,6 +8,7 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <ite/it51xxx.dtsi>
+#include <ite/it51526aw.dtsi>
 #include <ite/it51xxx-pinctrl-map.dtsi>
 
 / {


### PR DESCRIPTION
Include it51526aw.dtsi for it51xxx_evb/it51526aw.