### PR TITLE
lib: heap: tiered hardening with canary-based corruption detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1048,6 +1048,8 @@ target_include_directories(${OFFSETS_LIB} PRIVATE
 # Make sure that LTO will never be enabled when compiling offsets.c
 set_source_files_properties(${OFFSETS_C_PATH} PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
 
+target_sources(${OFFSETS_LIB} PRIVATE ${ZEPHYR_BASE}/lib/heap/heap_constants.c)
+
 target_link_libraries(${OFFSETS_LIB} zephyr_interface)
 add_dependencies(zephyr_interface
   ${SYSCALL_LIST_H_TARGET}
@@ -1061,6 +1063,7 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/gen_offset_header.py
   -i $<TARGET_OBJECTS:${OFFSETS_LIB}>
   -o ${OFFSETS_H_PATH}
+  COMMAND_EXPAND_LISTS
   DEPENDS
   ${OFFSETS_LIB}
   $<TARGET_OBJECTS:${OFFSETS_LIB}>

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6121,9 +6121,10 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 	ROUND_UP(___z_heap_struct_SIZEOF + \
 		 (nb) * ___z_heap_bucket_SIZEOF, ___z_heap_chunk_unit_SIZEOF)
 
-/* Allocation chunk size in bytes */
+/* Allocation chunk size in bytes (header + data rounded up, plus trailer) */
 #define _Z_HEAP_AC(ab) \
-	ROUND_UP(___z_heap_hdr_SIZEOF + (ab), ___z_heap_chunk_unit_SIZEOF)
+	(ROUND_UP(___z_heap_hdr_SIZEOF + (ab), ___z_heap_chunk_unit_SIZEOF) + \
+	 ___z_heap_trailer_SIZEOF)
 
 /* Total heap size in chunk units */
 #define _Z_HEAP_SZ(nb, ab) \

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6116,10 +6116,11 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 #include <zephyr/offsets.h>
 #endif
 
-/* chunk0 size in bytes for nb buckets */
+/* chunk0 size in bytes for nb buckets (includes trailer metadata) */
 #define _Z_HEAP_C0(nb) \
-	ROUND_UP(___z_heap_struct_SIZEOF + \
-		 (nb) * ___z_heap_bucket_SIZEOF, ___z_heap_chunk_unit_SIZEOF)
+	(ROUND_UP(___z_heap_struct_SIZEOF + \
+		  (nb) * ___z_heap_bucket_SIZEOF, ___z_heap_chunk_unit_SIZEOF) + \
+	 ___z_heap_trailer_SIZEOF)
 
 /* Allocation chunk size in bytes (header + data rounded up, plus trailer) */
 #define _Z_HEAP_AC(ab) \

--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -6,7 +6,6 @@ menu "Heap and Memory Allocation"
 
 config SYS_HEAP_VALIDATE
 	bool "Internal heap validity checking"
-	depends on ASSERT
 	help
 	  The sys_heap implementation is instrumented for extensive
 	  internal validation.  Leave this off by default, unless
@@ -78,18 +77,85 @@ config HEAP_LISTENER
 	  listeners of certain events related to a heap usage,
 	  such as the heap resize.
 
-config SYS_HEAP_CANARIES
-	bool "Heap canaries for corruption detection"
+choice SYS_HEAP_HARDENING
+	prompt "Heap hardening level"
+	default SYS_HEAP_HARDENING_MODERATE if ASSERT
+	default SYS_HEAP_HARDENING_BASIC
 	help
-	  Enable canary values at the end of each heap allocation to detect
-	  memory corruption. The canary is validated when memory is freed,
-	  catching buffer overflows (writing past allocation) and double-free
-	  errors.
+	  Controls the level of runtime validation performed by the
+	  sys_heap allocator. Higher levels detect more classes of
+	  heap corruption but add increasing overhead. Each level
+	  includes all checks from lower levels.
 
-	  This adds 8 bytes of memory overhead per allocation and a
-	  canary computation on alloc and validation on free. It is
-	  useful for hardening against memory corruption as well as
-	  for chasing bugs during development.
+config SYS_HEAP_HARDENING_NONE
+	bool "None"
+	help
+	  Disable all heap validation checks for maximum performance.
+	  Use this for production builds where heap usage is well
+	  tested and every cycle counts.
+
+config SYS_HEAP_HARDENING_BASIC
+	bool "Basic"
+	help
+	  Cheap double-free and buffer overflow detection in
+	  sys_heap_free(). This adds a few field reads on the free
+	  path with negligible runtime cost. Suitable for production
+	  builds that want a safety net.
+
+config SYS_HEAP_HARDENING_MODERATE
+	bool "Moderate"
+	help
+	  In addition to basic checks, validate free list pointer
+	  consistency in free list operations and bidirectional
+	  neighbor size consistency in sys_heap_free(). This adds
+	  a few more field reads on the alloc and free paths. This
+	  is quite effective at detecting most accidental corruptions
+	  and is a good default for development and production
+	  systems that need extra robustness.
+
+config SYS_HEAP_HARDENING_FULL
+	bool "Full"
+	select SYS_HEAP_CANARIES
+	help
+	  In addition to moderate checks, enable per-chunk trailer
+	  canaries. The canary is validated on free, realloc, and
+	  size queries. This adds 8 bytes of memory overhead per
+	  allocation and a canary computation on alloc and free.
+	  Useful for hardening against deliberate memory corruption
+	  attacks as well as for chasing bugs during development.
+
+config SYS_HEAP_HARDENING_EXTREME
+	bool "Extreme"
+	select SYS_HEAP_CANARIES
+	select SYS_HEAP_VALIDATE
+	help
+	  In addition to full checks, run a complete heap structure
+	  validation after every allocation and free operation.
+	  This walks every chunk on each operation, making it
+	  extremely expensive (linear in the number of allocations).
+	  Detects external corruption of the heap before the allocator
+	  acts on it.
+
+	  The overhead of this level is disproportionate to the
+	  protection it provides over "Full". It is unsuitable for
+	  production use and intended solely for debugging.
+
+endchoice
+
+config SYS_HEAP_HARDENING_LEVEL
+	int
+	default 0 if SYS_HEAP_HARDENING_NONE
+	default 1 if SYS_HEAP_HARDENING_BASIC
+	default 2 if SYS_HEAP_HARDENING_MODERATE
+	default 3 if SYS_HEAP_HARDENING_FULL
+	default 4 if SYS_HEAP_HARDENING_EXTREME
+
+config SYS_HEAP_CANARIES
+	bool
+
+module = SYS_HEAP
+module-str = sys_heap
+source "subsys/logging/Kconfig.template.log_config"
 
 choice
 	prompt "Supported heap sizes"

--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -78,6 +78,19 @@ config HEAP_LISTENER
 	  listeners of certain events related to a heap usage,
 	  such as the heap resize.
 
+config SYS_HEAP_CANARIES
+	bool "Heap canaries for corruption detection"
+	help
+	  Enable canary values at the end of each heap allocation to detect
+	  memory corruption. The canary is validated when memory is freed,
+	  catching buffer overflows (writing past allocation) and double-free
+	  errors.
+
+	  This adds 8 bytes of memory overhead per allocation and a
+	  canary computation on alloc and validation on free. It is
+	  useful for hardening against memory corruption as well as
+	  for chasing bugs during development.
+
 choice
 	prompt "Supported heap sizes"
 	depends on !64BIT

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -13,8 +13,6 @@
 #include <sanitizer/msan_interface.h>
 #endif
 
-/* Validate the `kernel.h` macro */
-BUILD_ASSERT(_Z_HEAP_SIZE == sizeof(struct z_heap), "Incorrect _Z_HEAP_SIZE value");
 
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -60,7 +60,7 @@ static void free_list_remove_bidx(struct z_heap *h, chunkid_t c, int bidx)
 
 static void free_list_remove(struct z_heap *h, chunkid_t c)
 {
-	if (!solo_free_header(h, c)) {
+	if (!undersized_chunk(h, c)) {
 		int bidx = bucket_idx(h, chunk_size(h, c));
 		free_list_remove_bidx(h, c, bidx);
 	}
@@ -98,7 +98,7 @@ static void free_list_add_bidx(struct z_heap *h, chunkid_t c, int bidx)
 
 static void free_list_add(struct z_heap *h, chunkid_t c)
 {
-	if (!solo_free_header(h, c)) {
+	if (!undersized_chunk(h, c)) {
 		int bidx = bucket_idx(h, chunk_size(h, c));
 		free_list_add_bidx(h, c, bidx);
 	}

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -20,6 +20,15 @@
 #define CHECK(x) /**/
 #endif
 
+/* Heap hardening level predicates.  Each is true when the configured
+ * hardening level is at or above the named level.  The compiler
+ * eliminates dead code at lower levels.
+ */
+#define SYS_HEAP_HARDENING_BASIC    (CONFIG_SYS_HEAP_HARDENING_LEVEL >= 1)
+#define SYS_HEAP_HARDENING_MODERATE (CONFIG_SYS_HEAP_HARDENING_LEVEL >= 2)
+#define SYS_HEAP_HARDENING_FULL     (CONFIG_SYS_HEAP_HARDENING_LEVEL >= 3)
+#define SYS_HEAP_HARDENING_EXTREME (CONFIG_SYS_HEAP_HARDENING_LEVEL >= 4)
+
 /* Chunks are identified by their offset in 8 byte units from the
  * first address in the buffer (a zero-valued chunkid_t is used as a
  * null; that chunk would always point into the metadata at the start

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -328,4 +328,14 @@ static inline struct z_heap_chunk_trailer *chunk_trailer(struct z_heap *h,
 
 #endif /* CONFIG_SYS_HEAP_CANARIES */
 
+#ifdef CONFIG_SYS_HEAP_VALIDATE
+bool z_heap_full_check(struct z_heap *h);
+#else
+static inline bool z_heap_full_check(struct z_heap *h)
+{
+	ARG_UNUSED(h);
+	return true;
+}
+#endif
+
 #endif /* ZEPHYR_INCLUDE_LIB_OS_HEAP_H_ */

--- a/lib/heap/heap_constants.c
+++ b/lib/heap/heap_constants.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Build-time computation of heap constants from actual struct layouts.
+ * Compiled as part of the offsets library so that the generated offsets.h
+ * header provides heap sizing values derived from real structure sizes,
+ * eliminating manual synchronization of magic numbers in kernel.h.
+ *
+ * The heap layout for a single allocation looks like:
+ *
+ *   [     chunk0: struct z_heap + buckets     ]  [  alloc chunk  ]  [ftr]
+ *                                                 |              |
+ *                                                hdr    data   (trailer)
+ *
+ * Each region is sized as follows:
+ *
+ *   chunk0  = ROUND_UP(sizeof(struct z_heap) + nb * bucket_size, CHUNK_UNIT)
+ *   alloc   = ROUND_UP(chunk_header_bytes + alloc_bytes, CHUNK_UNIT)
+ *   ftr     = heap_footer_bytes  (end marker, not chunk-aligned)
+ *
+ * The number of buckets (nb) depends on the total heap size in chunk
+ * units, creating a circular dependency that is resolved by iterating
+ * from 1 bucket until convergence (3 rounds always suffice).
+ *
+ * The individual component sizes are emitted as symbols so that
+ * kernel.h can compute exact heap sizes without any magic numbers.
+ */
+
+#include <gen_offset.h>
+#include <zephyr/kernel.h>
+#include "heap.h"
+
+/*
+ * Determine whether the heap uses big (8-byte) or small (4-byte) chunk
+ * headers and footers.  This mirrors big_heap_chunks() in heap.h: for
+ * the minimum-size computation the heap is always tiny, so the runtime
+ * size threshold never triggers — only Kconfig and pointer width matter.
+ */
+#ifdef CONFIG_SYS_HEAP_SMALL_ONLY
+#define _IS_BIG 0
+#elif defined(CONFIG_SYS_HEAP_BIG_ONLY)
+#define _IS_BIG 1
+#else
+#define _IS_BIG (sizeof(void *) > 4)
+#endif
+
+#define _HDR (_IS_BIG ? 8 : 4)	/* chunk_header_bytes */
+#define _FTR (_IS_BIG ? 8 : 4)	/* heap_footer_bytes  */
+
+/* Round up to chunk units (compile-time version of chunksz()) */
+#define _CHUNKSZ(n) (((n) + CHUNK_UNIT - 1U) / CHUNK_UNIT)
+
+/* min_chunk_size: smallest allocatable chunk (in chunk units) */
+#define _MINC  _CHUNKSZ(_HDR + 1)
+
+/* --- emit symbols into offsets.h --- */
+
+GEN_ABS_SYM_BEGIN(_HeapConstantAbsSyms)
+
+GEN_ABSOLUTE_SYM(___z_heap_struct_SIZEOF, sizeof(struct z_heap));
+
+GEN_ABSOLUTE_SYM(___z_heap_bucket_SIZEOF,
+	sizeof(struct z_heap_bucket));
+
+GEN_ABSOLUTE_SYM(___z_heap_chunk_unit_SIZEOF, CHUNK_UNIT);
+
+GEN_ABSOLUTE_SYM(___z_heap_hdr_SIZEOF, (unsigned int)_HDR);
+
+GEN_ABSOLUTE_SYM(___z_heap_ftr_SIZEOF, (unsigned int)_FTR);
+
+GEN_ABSOLUTE_SYM(___z_heap_min_chunk_SIZEOF, (unsigned int)_MINC);
+
+GEN_ABS_SYM_END

--- a/lib/heap/heap_constants.c
+++ b/lib/heap/heap_constants.c
@@ -53,7 +53,7 @@
 #define _CHUNKSZ(n) (((n) + CHUNK_UNIT - 1U) / CHUNK_UNIT)
 
 /* min_chunk_size: smallest allocatable chunk (in chunk units) */
-#define _MINC  _CHUNKSZ(_HDR + 1)
+#define _MINC  (_CHUNKSZ(_HDR + 1) + CHUNK_TRAILER_SIZE)
 
 /* --- emit symbols into offsets.h --- */
 
@@ -69,6 +69,9 @@ GEN_ABSOLUTE_SYM(___z_heap_chunk_unit_SIZEOF, CHUNK_UNIT);
 GEN_ABSOLUTE_SYM(___z_heap_hdr_SIZEOF, (unsigned int)_HDR);
 
 GEN_ABSOLUTE_SYM(___z_heap_ftr_SIZEOF, (unsigned int)_FTR);
+
+GEN_ABSOLUTE_SYM(___z_heap_trailer_SIZEOF,
+	(unsigned int)(CHUNK_TRAILER_SIZE * CHUNK_UNIT));
 
 GEN_ABSOLUTE_SYM(___z_heap_min_chunk_SIZEOF, (unsigned int)_MINC);
 

--- a/lib/heap/heap_info.c
+++ b/lib/heap/heap_info.c
@@ -39,7 +39,7 @@ static void heap_print_info(struct z_heap *h, bool dump_chunks)
 		if (count) {
 			printk("%9d %12d %12d %12d %12zd\n",
 			       i, (1 << i) - 1 + min_chunk_size(h), count,
-			       largest, chunksz_to_bytes(h, largest));
+			       largest, (size_t)largest * CHUNK_UNIT);
 		}
 	}
 

--- a/lib/heap/heap_info.c
+++ b/lib/heap/heap_info.c
@@ -49,7 +49,7 @@ static void heap_print_info(struct z_heap *h, bool dump_chunks)
 			printk("chunk %4d: [%c] size=%-4d left=%-4d right=%d\n",
 			       c,
 			       chunk_used(h, c) ? '*'
-			       : solo_free_header(h, c) ? '.'
+			       : undersized_chunk(h, c) ? '.'
 			       : '-',
 			       chunk_size(h, c),
 			       left_chunk(h, c),

--- a/samples/basic/sys_heap/sample.yaml
+++ b/samples/basic/sys_heap/sample.yaml
@@ -9,7 +9,7 @@ common:
     type: multi_line
     ordered: true
     regex:
-      - ".*allocated 16.,.*"
+      - ".*allocated 15.,.*"
       - ".*allocated 1..,.*"
       - ".*allocated 0, free ..., max allocated ..., heap size 256.*"
 tests:

--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj_ram_load.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj_ram_load.conf
@@ -40,6 +40,14 @@ CONFIG_MCUBOOT_UTIL_LOG_LEVEL_WRN=y
 # Disable debug logging
 CONFIG_LOG_MAX_LEVEL=3
 
+# The nrf52840dk ram_load variant is very tight on RAM. The MCUboot
+# RAM_LOAD padding section rounds the image up to the next power-of-2
+# boundary, so even a small increase in code size can double the
+# padding and overflow RAM. Disable heap hardening (this build has
+# CONFIG_ASSERT=n so previous __ASSERT-gated checks were inactive
+# anyway) to stay under the 128KB boundary.
+CONFIG_SYS_HEAP_HARDENING_NONE=y
+
 # Enable retained memory and retention
 CONFIG_RETAINED_MEM=y
 CONFIG_RETENTION=y

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -408,7 +408,7 @@ void cmd_alloc_free_call(unsigned long a0, unsigned long a1, unsigned long a2, u
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(1);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
@@ -523,7 +523,7 @@ void cmd_rpc_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(2);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
@@ -666,7 +666,7 @@ void cmd_shm_alloc_appl(unsigned long a0, unsigned long a1, unsigned long a2, un
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(1);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
@@ -835,7 +835,7 @@ void cmd_gettime_call(unsigned long a0, unsigned long a1, unsigned long a2, unsi
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(1);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
@@ -935,7 +935,7 @@ void cmd_suspend_call(unsigned long a0, unsigned long a1, unsigned long a2, unsi
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(1);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
@@ -1024,7 +1024,7 @@ void cmd_notify_alloc_call(unsigned long a0, unsigned long a1, unsigned long a2,
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = 1;
+		res->a1 = OPTEE_MSG_GET_ARG_SIZE(1);
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);

--- a/tests/lib/heap/src/main.c
+++ b/tests/lib/heap/src/main.c
@@ -41,15 +41,6 @@
 #define BIG_HEAP_SZ MIN(256 * 1024, MEMSZ / 3)
 #define SMALL_HEAP_SZ MIN(BIG_HEAP_SZ, 2048)
 
-/* With enabling SYS_HEAP_RUNTIME_STATS, the size of struct z_heap
- * will increase 16 bytes on 64 bit CPU.
- */
-#ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
-#define SOLO_FREE_HEADER_HEAP_SZ (80)
-#else
-#define SOLO_FREE_HEADER_HEAP_SZ (64)
-#endif
-
 #define SCRATCH_SZ (sizeof(heapmem) / 2)
 
 /* The test memory.  Make them pointer arrays for robust alignment
@@ -238,36 +229,6 @@ ZTEST(lib_heap, test_big_heap)
 			100, &result);
 
 	log_result(BIG_HEAP_SZ, &result);
-}
-
-/* Test a heap with a solo free header.  A solo free header can exist
- * only on a heap with 64 bit CPU (or chunk_header_bytes() == 8).
- * With 64 bytes heap and 1 byte allocation on a big heap, we get:
- *
- *   0   1   2   3   4   5   6   7
- * | h | h | b | b | c | 1 | s | f |
- *
- * where
- * - h: chunk0 header
- * - b: buckets in chunk0
- * - c: chunk header for the first allocation
- * - 1: chunk mem
- * - s: solo free header
- * - f: end marker / footer
- */
-ZTEST(lib_heap, test_solo_free_header)
-{
-	struct sys_heap heap;
-
-	TC_PRINT("Testing solo free header in a heap\n");
-
-	sys_heap_init(&heap, heapmem, SOLO_FREE_HEADER_HEAP_SZ);
-	if (sizeof(void *) > 4U) {
-		sys_heap_alloc(&heap, 1);
-		zassert_true(sys_heap_validate(&heap), "");
-	} else {
-		ztest_test_skip();
-	}
 }
 
 /* Simple clobber detection */

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -18,6 +18,9 @@ common:
     - qemu_x86
 tests:
   libraries.heap: {}
-  libraries.heap.canaries:
+  libraries.heap.hardening_none:
     extra_configs:
-      - CONFIG_SYS_HEAP_CANARIES=y
+      - CONFIG_SYS_HEAP_HARDENING_NONE=y
+  libraries.heap.hardening_full:
+    extra_configs:
+      - CONFIG_SYS_HEAP_HARDENING_FULL=y

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -5,15 +5,19 @@
 # coverage of the RISC-V architectures via qemu platforms already.
 # Excludes qemu_xtensa/dc233c due to pathological runtimes which cannot be
 # reproduced on real hardware.
+common:
+  tags: heap
+  platform_exclude:
+    - m2gl025_miv
+    - qemu_xtensa/dc233c
+    - esp32s2_saola
+    - esp32s2_lolin_mini
+  timeout: 480
+  integration_platforms:
+    - native_sim
+    - qemu_x86
 tests:
-  libraries.heap:
-    tags: heap
-    platform_exclude:
-      - m2gl025_miv
-      - qemu_xtensa/dc233c
-      - esp32s2_saola
-      - esp32s2_lolin_mini
-    timeout: 480
-    integration_platforms:
-      - native_sim
-      - qemu_x86
+  libraries.heap: {}
+  libraries.heap.canaries:
+    extra_configs:
+      - CONFIG_SYS_HEAP_CANARIES=y

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -1,8 +1,12 @@
+common:
+  tags:
+    - heap
+    - heap_align
+  integration_platforms:
+    - native_sim
+    - mps2/an521/cpu0
 tests:
-  libraries.heap_align:
-    tags:
-      - heap
-      - heap_align
-    integration_platforms:
-      - native_sim
-      - mps2/an521/cpu0
+  libraries.heap_align: {}
+  libraries.heap_align.canaries:
+    extra_configs:
+      - CONFIG_SYS_HEAP_CANARIES=y

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -7,6 +7,6 @@ common:
     - mps2/an521/cpu0
 tests:
   libraries.heap_align: {}
-  libraries.heap_align.canaries:
+  libraries.heap_align.hardening_full:
     extra_configs:
-      - CONFIG_SYS_HEAP_CANARIES=y
+      - CONFIG_SYS_HEAP_HARDENING_FULL=y

--- a/tests/lib/heap_min/testcase.yaml
+++ b/tests/lib/heap_min/testcase.yaml
@@ -8,3 +8,6 @@ tests:
   libraries.heap_min.runtime_stats:
     extra_configs:
       - CONFIG_SYS_HEAP_RUNTIME_STATS=y
+  libraries.heap_min.canaries:
+    extra_configs:
+      - CONFIG_SYS_HEAP_CANARIES=y

--- a/tests/lib/heap_min/testcase.yaml
+++ b/tests/lib/heap_min/testcase.yaml
@@ -8,6 +8,6 @@ tests:
   libraries.heap_min.runtime_stats:
     extra_configs:
       - CONFIG_SYS_HEAP_RUNTIME_STATS=y
-  libraries.heap_min.canaries:
+  libraries.heap_min.hardening_full:
     extra_configs:
-      - CONFIG_SYS_HEAP_CANARIES=y
+      - CONFIG_SYS_HEAP_HARDENING_FULL=y


### PR DESCRIPTION
This series introduces tiered runtime hardening for the sys_heap allocator,
ranging from near-zero-cost structural checks to per-allocation canary
protection. It also replaces the fragile hardcoded `Z_HEAP_MIN_SIZE`
constants with build-time computation from actual struct layouts.

The MODERATE level already caught a real bug: the OP-TEE test driver was
requesting 1-byte RPC buffers then writing full struct optee_msg_arg
structures into them, silently corrupting adjacent heap metadata. The fix
is included in this series.

## Hardening levels

The new `SYS_HEAP_HARDENING` Kconfig choice offers five levels, each
including all checks from lower levels:

| Level | Cost | Description |
|-------|------|-------------|
| **NONE** (0) | Zero | No checks, maximum performance |
| **BASIC** (1) | Negligible | Double-free and buffer overflow detection on free/realloc |
| **MODERATE** (2) | Low | Free list and neighbor consistency; catches most accidental corruptions |
| **FULL** (3) | 8 bytes/alloc + canary computation | Per-chunk trailer canaries; helps harden against deliberate corruption |
| **EXTREME** (4) | O(n) per operation | Full heap walk on every alloc/free; unsuitable for production, debugging only |

Default is MODERATE when `CONFIG_ASSERT` is enabled, BASIC otherwise.
Checks use `LOG_ERR` + `k_panic()` independently of `CONFIG_ASSERT`.

## Design notes

**Trailer canaries** are placed at the end of each allocated chunk rather
than in the header. This avoids complicating the aligned allocation logic
which relies on the header size to locate chunks from user pointers.
A buffer overflow must corrupt the trailer before reaching the next chunk's
header, so checking the trailer at `free()` time catches the overflow at its
source. Free chunks don't need their own canaries: since adjacent free
chunks are always merged, every free chunk is bounded by used chunks whose
trailers act as tripwires. For extra safety at FULL level, the left
neighbor's canary is validated before trusting a free chunk's metadata
during merge operations.

**Build-time constants** (`Z_HEAP_MIN_SIZE`, `Z_HEAP_MIN_SIZE_FOR`) are now
computed from actual C struct layouts via the gen_offset mechanism,
eliminating a growing tower of `#ifdef` combinations in `kernel.h`. Adding
new per-allocation metadata (like the canary trailer) no longer requires
manually updating sizing constants.