### PR TITLE
Add lpi2c support on frdm imxrt1186

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -77,6 +77,27 @@
 		};
 	};
 
+	pinmux_lpi2c3: pinmux_lpi2c3 {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_18_lpi2c3_scl>,
+				 <&iomuxc_gpio_ad_19_lpi2c3_sda>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			bias-pull-up;
+			input-enable;
+		};
+	};
+
+	pinmux_lpi2c3_sleep: pinmux_lpi2c3_sleep {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_18_lpi2c3_scl>,
+				 <&iomuxc_gpio_ad_19_lpi2c3_sda>;
+			drive-strength = "high";
+			slew-rate = "fast";
+			bias-pull-up;
+		};
+	};
+
 	/* QSPI Flash on FlexSPI2 - GPIO_AON_22/23/24/25/26/27 */
 	pinmux_flexspi2: pinmux_flexspi2 {
 		group0 {

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -14,6 +14,7 @@
 		led1 = &red_led;
 		led2 = &green_led;
 		sw0 = &user_button;
+		eeprom-0 = &eeprom0;
 	};
 
 	chosen {
@@ -78,6 +79,22 @@
 	pinctrl-0 = <&pinmux_lpuart3>;
 	pinctrl-1 = <&pinmux_lpuart3_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+&lpi2c3 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpi2c3>;
+	pinctrl-1 = <&pinmux_lpi2c3_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <4096>;
+		pagesize = <32>;
+		address-width = <16>;
+		timeout = <5>;
+	};
 };
 
 &gpio1 {

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -23,4 +23,5 @@ supported:
   - uart
   - mbox
   - netif:eth
+  - i2c
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -19,4 +19,5 @@ supported:
   - can
   - uart
   - mbox
+  - i2c
 vendor: nxp

--- a/samples/drivers/eeprom/sample.yaml
+++ b/samples/drivers/eeprom/sample.yaml
@@ -10,6 +10,8 @@ tests:
       - native_sim/native/64
       - adafruit_qt_py_rp2040/rp2040
       - frdm_mcxn947/mcxn947/cpu0
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
     integration_platforms:
       - native_sim/native/64
     extra_args:


### PR DESCRIPTION
add lpi2c feature support:

- LPI2C: enable `eeprom` case using lpi2c3.
- Test passed on my local, log can be checked below:

```
*** Booting Zephyr OS build v4.3.0-8826-gfff193d28b23 ***
Found EEPROM device "eeprom@50"
Using eeprom with size of: 4096.
Device booted 24 times.
Reset the MCU to see the increasing boot counter.

*** Booting Zephyr OS build v4.3.0-8826-gfff193d28b23 ***
Found EEPROM device "eeprom@50"
Using eeprom with size of: 4096.
Device booted 25 times.
Reset the MCU to see the increasing boot counter.

*** Booting Zephyr OS build v4.3.0-8826-gfff193d28b23 ***
Found EEPROM device "eeprom@50"
Using eeprom with size of: 4096.
Device booted 26 times.
Reset the MCU to see the increasing boot counter.
```