### PR TITLE
Add lpspi support on frdm imxrt1186

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -7,6 +7,28 @@
 #include <nxp/nxp_imx/rt/mimxrt1186cvj8c-pinctrl.dtsi>
 
 &pinctrl {
+	pinmux_lpspi2: pinmux_lpspi2 {
+		group0 {
+			pinmux = <&iomuxc_aon_gpio_aon_16_lpspi2_pcs0>,
+				 <&iomuxc_aon_gpio_aon_17_lpspi2_sin>,
+				 <&iomuxc_aon_gpio_aon_18_lpspi2_sout>,
+				 <&iomuxc_aon_gpio_aon_19_lpspi2_sck>;
+			drive-strength = "high";
+			slew-rate = "fast";
+		};
+	};
+
+	pinmux_lpspi2_sleep: pinmux_lpspi2_sleep {
+		group0 {
+			pinmux = <&iomuxc_aon_gpio_aon_16_lpspi2_pcs0>,
+				 <&iomuxc_aon_gpio_aon_17_lpspi2_sin>,
+				 <&iomuxc_aon_gpio_aon_18_lpspi2_sout>,
+				 <&iomuxc_aon_gpio_aon_19_lpspi2_sck>;
+			drive-strength = "high";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_lpuart1: pinmux_lpuart1 {
 		group0 {
 			pinmux = <&iomuxc_aon_gpio_aon_09_lpuart1_rxd>,

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -51,6 +51,21 @@
 	};
 };
 
+&edma3 {
+	status = "okay";
+};
+
+&edma4 {
+	status = "okay";
+};
+
+&lpspi2 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi2>;
+	pinctrl-1 = <&pinmux_lpspi2_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &lpuart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart1>;

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -15,6 +15,7 @@ toolchain:
 ram: 8192
 flash: 16384
 supported:
+  - spi
   - adc
   - gpio
   - can

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 256
 flash: 256
 supported:
+  - spi
   - adc
   - gpio
   - can

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect J3-14 (LPSPI2_SOUT) <-> J3-16 (LPSPI2_SIN) */
+
+&lpspi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
+};

--- a/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect J3-14 (LPSPI2_SOUT) <-> J3-16 (LPSPI2_SIN) */
+
+&lpspi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
+};


### PR DESCRIPTION
add lpspi2 instance support on frdm-imxrt1186

- add lpspi2 instance support
- test spi_loopback passed on my local (connect J3-14 (LPSPI2_SOUT) <-> J3-16 (LPSPI2_SIN))