### PR TITLE
Add flexcan support on frdm imxrt1186

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -78,4 +78,14 @@
 			slew-rate = "fast";
 		};
 	};
+
+	pinmux_flexcan1: pinmux_flexcan1 {
+		group0 {
+			pinmux = <&iomuxc_aon_gpio_aon_06_flexcan1_tx>,
+				 <&iomuxc_aon_gpio_aon_07_flexcan1_rx>;
+			slew-rate = "fast";
+			drive-strength = "normal";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -16,6 +16,10 @@
 		sw0 = &user_button;
 	};
 
+	chosen {
+		zephyr,canbus = &flexcan1;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -83,6 +87,12 @@
 
 &gpio6 {
 	status = "okay";
+};
+
+&flexcan1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_flexcan1>;
+	pinctrl-names = "default";
 };
 
 &systick {

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -17,5 +17,6 @@ flash: 16384
 supported:
   - adc
   - gpio
+  - can
   - uart
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -14,5 +14,6 @@ flash: 256
 supported:
   - adc
   - gpio
+  - can
   - uart
 vendor: nxp


### PR DESCRIPTION
enable flexcan1 instance on frdm-imxrt1186

- enable flexcan1 instance
- test can cases: timing/shell/api
- ensure used flexcan1 clock source is 80MHz