### PR TITLE
tests: net: udp: fix invalid NULL check in test callback

### DIFF
--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -139,17 +139,7 @@ static enum net_verdict test_ok(struct net_conn *conn,
 				union net_proto_header *proto_hdr,
 				void *user_data)
 {
-	struct ud *ud = (struct ud *)user_data;
-
 	k_sem_give(&recv_lock);
-
-	if (!ud) {
-		fail = true;
-
-		DBG("Test %s failed.", ud->test);
-
-		return NET_DROP;
-	}
 
 	fail = false;
 


### PR DESCRIPTION
The UDP test callback test_ok() contains a NULL check for user_data, but this pointer is always valid for successful registrations.

The current code also dereferences the pointer inside the NULL branch.

Remove the redundant check to make the test logic explicit.