### PR TITLE
dts: arm: st: fix some stm32f1 and f4 adc compatibles

### DIFF
--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -144,7 +144,7 @@
 		};
 
 		adc2: adc@40012800 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f1-adc", "st,stm32-adc";
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			clock-names = "adcx";
@@ -160,7 +160,7 @@
 		};
 
 		adc3: adc@40013c00 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f1-adc", "st,stm32-adc";
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 15)>;
 			clock-names = "adcx";

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -258,7 +258,7 @@
 		};
 
 		adc2: adc@40012100 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012100 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			clock-names = "adcx";
@@ -274,7 +274,7 @@
 		};
 
 		adc3: adc@40012200 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012200 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			clock-names = "adcx";

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -117,7 +117,7 @@
 		};
 
 		adc2: adc@40012100 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012100 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			clock-names = "adcx";
@@ -133,7 +133,7 @@
 		};
 
 		adc3: adc@40012200 {
-			compatible = "st,stm32-adc";
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012200 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			clock-names = "adcx";


### PR DESCRIPTION
Some ADC instances of STM32F1 and F4 didn't use the correct compatible.