### PR TITLE
usb: host: Add dynamic configuration matching of supported class

### DIFF
--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
- * SPDX-FileCopyrightText: Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -139,6 +139,8 @@ struct usbh_class_data {
 enum usbh_class_state {
 	/** The class is available to be associated to an USB device function. */
 	USBH_CLASS_STATE_IDLE,
+	/** The class is tentatively reserved during configuration matching. */
+	USBH_CLASS_STATE_RESERVED,
 	/** The class got bound to an USB function of a particular device on the bus. */
 	USBH_CLASS_STATE_BOUND,
 	/** The class failed to initialize and cannot be used. */

--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
- * SPDX-FileCopyrightText: Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -141,6 +141,8 @@ struct usbh_class_data {
 enum usbh_class_state {
 	/** The class is available to be associated to an USB device function. */
 	USBH_CLASS_STATE_IDLE,
+	/** The class is tentatively reserved during configuration matching. */
+	USBH_CLASS_STATE_RESERVED,
 	/** The class got bound to an USB function of a particular device on the bus. */
 	USBH_CLASS_STATE_BOUND,
 	/** The class failed to initialize and cannot be used. */

--- a/subsys/usb/host/usbh_class.c
+++ b/subsys/usb/host/usbh_class.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
- * SPDX-FileCopyrightText: Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -49,6 +49,12 @@ void usbh_class_remove_all(struct usb_device *const udev)
 			continue;
 		}
 
+		if (c_node->state == USBH_CLASS_STATE_RESERVED) {
+			c_node->state = USBH_CLASS_STATE_IDLE;
+			c_data->udev = NULL;
+			continue;
+		}
+
 		ret = usbh_class_removed(c_data);
 		if (ret != 0) {
 			LOG_ERR("Failed to handle device removal for each class (%d)", ret);
@@ -65,39 +71,55 @@ void usbh_class_remove_all(struct usb_device *const udev)
 	k_mutex_unlock(&udev->mutex);
 }
 
-/*
- * Probe an USB device function against each host class instantiated.
- *
- * Try to match a class from the global list of all system classes, using their
- * filter rules and return status to tell if a class matches or not.
- *
- * The first match will stop the loop, and the status will be updated
- * so that classes only match one function at a time.
- *
- * USB functions will have at most one class matching, and calling
- * usbh_class_probe_function() multiple times consequently has no effect.
- */
-static void usbh_class_probe_function(struct usb_device *const udev,
-				      struct usbh_class_filter *const filter_data,
-				      const uint8_t iface)
+void usbh_class_probe_device(struct usb_device *const udev)
 {
-	int ret;
+	int err;
 
-	/* Assumes that udev->mutex is locked */
-
-	/* First check if any interface is already bound to this */
 	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
 		struct usbh_class_data *const c_data = c_node->c_data;
 
-		if (c_node->state == USBH_CLASS_STATE_BOUND &&
-		    c_data->udev == udev && c_data->iface == iface) {
-			LOG_DBG("Interface %u bound to '%s', skipping",
-				iface, c_data->name);
-			return;
+		if (c_node->state != USBH_CLASS_STATE_RESERVED) {
+			continue;
+		}
+
+		if (c_data->udev != udev) {
+			continue;
+		}
+
+		err = usbh_class_probe(c_data, udev, c_data->iface);
+		if (err != 0) {
+			LOG_WRN("Failed to probe class %s for interface %u",
+				c_data->name, c_data->iface);
+
+			c_node->state = USBH_CLASS_STATE_IDLE;
+			c_data->udev = NULL;
+			c_data->iface = 0;
+		} else {
+			c_node->state = USBH_CLASS_STATE_BOUND;
+
+			LOG_INF("Class '%s' matches interface %u", c_data->name, c_data->iface);
 		}
 	}
+}
 
-	/* Then try to match this function against all interfaces */
+/*
+ * Match the first idle class instance matching a USB device function.
+ *
+ * Iterate through all registered class nodes and find the first one that
+ * is in USBH_CLASS_STATE_IDLE state and whose filter rules match the
+ * given filter data. On match, the class node transitions to
+ * USBH_CLASS_STATE_RESERVED and records the interface number.
+ *
+ * This is used during configuration matching to simulate driver allocation
+ * without actually binding. The reservation can later be:
+ *   - Promoted to BOUND by usbh_class_probe_device()
+ *   - Rolled back to IDLE by usbh_class_probe_device() if class probes failed
+ */
+static struct usbh_class_node *
+usbh_class_match_function(struct usb_device *const udev,
+			  struct usbh_class_filter *const filter_data,
+			  const uint8_t iface)
+{
 	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
 		struct usbh_class_data *const c_data = c_node->c_data;
 
@@ -113,55 +135,54 @@ static void usbh_class_probe_function(struct usb_device *const udev,
 			continue;
 		}
 
-		ret = usbh_class_probe(c_data, udev, iface);
-		if (ret == -ENOTSUP) {
-			LOG_DBG("Class %s not supporting this function, skipping",
-				c_data->name);
-			continue;
-		}
-
-		LOG_INF("Class '%s' matches interface %u", c_data->name, iface);
-		c_node->state = USBH_CLASS_STATE_BOUND;
+		c_node->state = USBH_CLASS_STATE_RESERVED;
 		c_data->udev = udev;
 		c_data->iface = iface;
-		break;
+		return c_node;
 	}
+
+	return NULL;
 }
 
-void usbh_class_probe_device(struct usb_device *const udev)
+bool usbh_class_match_device(struct usb_device *const udev, const void *cfg_desc)
 {
-	const struct usb_desc_header *desc = udev->cfg_desc;
+	const struct usb_desc_header *desc = cfg_desc;
+	struct usbh_class_node *c_node;
 	struct usbh_class_filter filter_data;
+	bool match = false;
 	uint8_t iface;
-	int ret;
 
 	/* To support single-function devices, match against the entire device */
-
 	filter_data.vid = udev->dev_desc.idVendor;
 	filter_data.pid = udev->dev_desc.idProduct;
 	filter_data.class = udev->dev_desc.bDeviceClass;
 	filter_data.sub = udev->dev_desc.bDeviceSubClass;
 	filter_data.proto = udev->dev_desc.bDeviceProtocol;
-
-	usbh_class_probe_function(udev, &filter_data, USBH_CLASS_IFNUM_DEVICE);
+	c_node = usbh_class_match_function(udev, &filter_data, USBH_CLASS_IFNUM_DEVICE);
+	if (c_node != NULL) {
+		return true;
+	}
 
 	/* To support multi-function devices, match against each function */
-
 	while (true) {
 		desc = usbh_desc_get_next_function(desc);
 		if (desc == NULL) {
 			break;
 		}
 
-		ret = usbh_desc_fill_filter(desc, &filter_data, &iface);
-		if (ret != 0) {
+		if (usbh_desc_fill_filter(desc, &filter_data, &iface) != 0) {
 			LOG_ERR("Failed to collect class codes for matching interface %u",
 				iface);
 			continue;
 		}
 
-		usbh_class_probe_function(udev, &filter_data, iface);
+		c_node = usbh_class_match_function(udev, &filter_data, iface);
+		if (c_node != NULL) {
+			match = true;
+		}
 	}
+
+	return match;
 }
 
 bool usbh_class_is_matching(const struct usbh_class_filter *const filter_rules,

--- a/subsys/usb/host/usbh_class.h
+++ b/subsys/usb/host/usbh_class.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
- * SPDX-FileCopyrightText: Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,12 +40,24 @@ bool usbh_class_is_matching(const struct usbh_class_filter *const filter_rules,
 void usbh_class_init_all(void);
 
 /**
- * @brief Probe an USB device function against all available host class instances.
+ * Reserve class instances for all functions of a given configuration.
  *
- * Try to match a class from the global list of all system classes using their filter rules
- * and return status to update the state of each matched class.
+ * Match device-level and interface-level functions against registered
+ * class drivers, marking matched class nodes as RESERVED for
+ * subsequent usbh_class_probe_device() to bind.
  *
- * The first matching host class driver is going to stop the scanning, and become the one in use.
+ * @param[in] udev USB device to match against
+ * @param[in] cfg_desc Configuration descriptor pointer
+ *
+ * @retval true  At least one class instance was reserved
+ * @retval false No match found
+ */
+bool usbh_class_match_device(struct usb_device *const udev, const void *cfg_desc);
+
+/**
+ * @brief Probe all matched USB classes of current USB device.
+ *
+ * Try to probe all class instances that matched, which are identified by usbh_class_match_device().
  *
  * @param[in] udev USB device to probe.
  */

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -172,7 +173,7 @@ static int device_interface_modify(struct usb_device *const udev,
 	int err;
 
 	dhp = udev->ifaces[iface].dhp;
-	desc_end = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->wTotalLength);
+	desc_end = (void *)((uint8_t *)cfg_desc + cfg_desc->wTotalLength);
 
 	while (dhp != NULL && (void *)dhp < desc_end) {
 		if (dhp->bDescriptorType == USB_DESC_INTERFACE) {
@@ -283,8 +284,8 @@ static int parse_configuration_descriptor(struct usb_device *const udev)
 	uint8_t tmp_nif = 0;
 	void *desc_end;
 
-	dhp = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->bLength);
-	desc_end = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->wTotalLength);
+	dhp = (void *)((uint8_t *)cfg_desc + cfg_desc->bLength);
+	desc_end = (void *)((uint8_t *)cfg_desc + cfg_desc->wTotalLength);
 
 	while ((void *)dhp < desc_end) {
 		if ((uint8_t *)dhp + sizeof(struct usb_desc_header) > (uint8_t *)desc_end ||
@@ -356,37 +357,25 @@ static void reset_configuration(struct usb_device *const udev)
 	udev->state = USB_STATE_ADDRESSED;
 }
 
-int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t num)
+static int device_get_configuration(struct usb_device *const udev, const uint8_t num,
+				    void **const desc)
 {
 	struct usb_cfg_descriptor cfg_desc;
-	uint8_t idx;
 	int err;
 
 	err = k_mutex_lock(&udev->mutex, K_NO_WAIT);
-	if (err) {
+	if (err != 0) {
 		LOG_ERR("Failed to lock USB device");
 		return err;
 	}
 
-	if (udev->actual_cfg == num) {
-		LOG_INF("Already active device configuration");
-		goto error;
-	}
-
 	if (num == 0) {
-		reset_configuration(udev);
-		err = usbh_req_set_cfg(udev, num);
-		if (err) {
-			LOG_ERR("Set Configuration %u request failed", num);
-		}
-
+		err = -EINVAL;
 		goto error;
 	}
 
-	idx = num - 1;
-
-	err = usbh_req_desc_cfg(udev, idx, sizeof(cfg_desc), &cfg_desc);
-	if (err) {
+	err = usbh_req_desc_cfg(udev, num - 1, sizeof(struct usb_cfg_descriptor), &cfg_desc);
+	if (err != 0) {
 		LOG_ERR("Failed to read configuration %u descriptor", num);
 		goto error;
 	}
@@ -409,48 +398,94 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 		goto error;
 	}
 
-	udev->cfg_desc = k_heap_alloc(&usb_device_heap,
-				      cfg_desc.wTotalLength + sizeof(struct usb_desc_header),
-				      K_NO_WAIT);
-	if (udev->cfg_desc == NULL) {
+	*desc = k_heap_alloc(&usb_device_heap,
+			     cfg_desc.wTotalLength + sizeof(struct usb_desc_header),
+			     K_NO_WAIT);
+	if (*desc == NULL) {
 		LOG_ERR("Failed to allocate memory for configuration descriptor");
 		err = -ENOMEM;
 		goto error;
 	}
 
-	err = usbh_req_set_cfg(udev, num);
+	memset(*desc, 0, cfg_desc.wTotalLength + sizeof(struct usb_desc_header));
+
+	err = usbh_req_desc_cfg(udev, num - 1, cfg_desc.wTotalLength, *desc);
 	if (err) {
+		LOG_ERR("Failed to read configuration descriptor of %u bytes: %d",
+			cfg_desc.wTotalLength, err);
+		k_heap_free(&usb_device_heap, *desc);
+		goto error;
+	}
+
+	if (memcmp(*desc, &cfg_desc, sizeof(struct usb_cfg_descriptor))) {
+		LOG_ERR("Configuration descriptor read mismatch");
+		k_heap_free(&usb_device_heap, *desc);
+		err = -EINVAL;
+		goto error;
+	}
+
+error:
+	k_mutex_unlock(&udev->mutex);
+
+	return err;
+}
+
+static int device_set_configuration(struct usb_device *const udev, const uint8_t num, void *desc)
+{
+	struct usb_cfg_descriptor *const new_cfg_desc = desc;
+	void *const old_cfg_desc = udev->cfg_desc;
+	int err;
+
+	err = k_mutex_lock(&udev->mutex, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("Failed to lock USB device");
+		return err;
+	}
+
+	if (new_cfg_desc == NULL && num != 0) {
+		LOG_ERR("Invalid configuration %u to set", num);
+		err = -EINVAL;
+		goto error;
+	}
+
+	if (udev->actual_cfg == num) {
+		LOG_INF("Already active device configuration");
+		err = -EALREADY;
+		goto error;
+	}
+
+	if (num == 0) {
+		reset_configuration(udev);
+		err = usbh_req_set_cfg(udev, num);
+		if (err) {
+			LOG_ERR("Set Configuration %u request failed", num);
+		}
+
+		goto error;
+	}
+
+	err = usbh_req_set_cfg(udev, num);
+	if (err != 0) {
 		LOG_ERR("Set Configuration %u request failed", num);
 		goto error;
 	}
 
-	memset(udev->cfg_desc, 0, cfg_desc.wTotalLength + sizeof(struct usb_desc_header));
 	if (udev->state == USB_STATE_CONFIGURED) {
 		reset_configuration(udev);
 	}
 
-	err = usbh_req_desc_cfg(udev, idx, cfg_desc.wTotalLength, udev->cfg_desc);
-	if (err) {
-		LOG_ERR("Failed to read configuration descriptor of %u bytes: %d",
-			cfg_desc.wTotalLength, err);
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
-		goto error;
-	}
-
-	if (memcmp(udev->cfg_desc, &cfg_desc, sizeof(cfg_desc))) {
-		LOG_ERR("Configuration descriptor read mismatch");
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
-		goto error;
-	}
+	udev->cfg_desc = new_cfg_desc;
 
 	LOG_INF("Configuration %u bNumInterfaces %u",
-		cfg_desc.bConfigurationValue, cfg_desc.bNumInterfaces);
+		new_cfg_desc->bConfigurationValue, new_cfg_desc->bNumInterfaces);
 
 	err = parse_configuration_descriptor(udev);
-	if (err) {
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
+	if (err != 0) {
+		udev->cfg_desc = old_cfg_desc;
 		goto error;
 	}
+
+	k_heap_free(&usb_device_heap, old_cfg_desc);
 
 	udev->actual_cfg = num;
 	udev->state = USB_STATE_CONFIGURED;
@@ -459,6 +494,47 @@ error:
 	k_mutex_unlock(&udev->mutex);
 
 	return err;
+}
+
+static int choose_configuration(struct usb_device *const udev, uint8_t *const num,
+				void **const desc)
+{
+	void *cfg1_desc = NULL;
+
+	for (unsigned int i = 0; i < udev->dev_desc.bNumConfigurations; i++) {
+		void *cfg_desc = NULL;
+
+		if (device_get_configuration(udev, i + 1, &cfg_desc) != 0) {
+			LOG_ERR("Failed to get configuration %u of new device with address %u",
+				i + 1, udev->addr);
+			continue;
+		}
+
+		if (usbh_class_match_device(udev, cfg_desc)) {
+			/* Matched, discard the fallback */
+			k_heap_free(&usb_device_heap, cfg1_desc);
+			*desc = cfg_desc;
+			*num = i + 1;
+			return 0;
+		}
+
+		if (i == 0) {
+			/* Keep config 1 as fallback */
+			cfg1_desc = cfg_desc;
+		} else {
+			/* Discard unmatched config */
+			k_heap_free(&usb_device_heap, cfg_desc);
+		}
+	}
+
+	if (cfg1_desc == NULL) {
+		return -EINVAL;
+	}
+
+	/* No match found, fall back to config 1 */
+	*desc = cfg1_desc;
+	*num = 1;
+	return 0;
 }
 
 int usbh_device_set_address(struct usb_device *const udev, const uint8_t new_addr)
@@ -490,6 +566,8 @@ struct usb_device *usbh_device_get_root(struct usbh_context *const ctx)
 void usbh_device_connect(struct usbh_context *const ctx,
 			 struct usb_device *const udev)
 {
+	uint8_t cfg_num;
+	void *cfg_desc;
 	int err;
 
 	LOG_DBG("Device connected event");
@@ -503,15 +581,34 @@ void usbh_device_connect(struct usbh_context *const ctx,
 	err = usbh_device_init(udev);
 	if (err != 0) {
 		LOG_ERR("Failed to init new USB device");
-		if (usbh_device_is_root(ctx, udev)) {
-			ctx->root = NULL;
-		}
+		goto error;
+	}
 
-		usbh_device_free(udev);
-		return;
+	err = choose_configuration(udev, &cfg_num, &cfg_desc);
+	if (err != 0) {
+		goto error;
+	}
+
+	err = device_set_configuration(udev, cfg_num, cfg_desc);
+	if (err != 0) {
+		LOG_ERR("Failed to configure (index %u) new device with address %u",
+			cfg_num, udev->addr);
+		k_heap_free(&usb_device_heap, cfg_desc);
+		goto error;
 	}
 
 	usbh_class_probe_device(udev);
+
+	return;
+
+error:
+	usbh_class_remove_all(udev);
+
+	if (usbh_device_is_root(ctx, udev)) {
+		ctx->root = NULL;
+	}
+
+	usbh_device_free(udev);
 }
 
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
@@ -592,11 +689,6 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
-
-	err = usbh_device_set_configuration(udev, 1);
-	if (err) {
-		LOG_ERR("Failed to configure new device with address %u", udev->addr);
-	}
 
 error:
 	k_mutex_unlock(&udev->mutex);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -173,7 +174,7 @@ static int device_interface_modify(struct usb_device *const udev,
 	int err;
 
 	dhp = udev->ifaces[iface].dhp;
-	desc_end = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->wTotalLength);
+	desc_end = (void *)((uint8_t *)cfg_desc + cfg_desc->wTotalLength);
 
 	while (dhp != NULL && (void *)dhp < desc_end) {
 		if (dhp->bDescriptorType == USB_DESC_INTERFACE) {
@@ -284,8 +285,8 @@ static int parse_configuration_descriptor(struct usb_device *const udev)
 	uint8_t tmp_nif = 0;
 	void *desc_end;
 
-	dhp = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->bLength);
-	desc_end = (void *)((uint8_t *)udev->cfg_desc + cfg_desc->wTotalLength);
+	dhp = (void *)((uint8_t *)cfg_desc + cfg_desc->bLength);
+	desc_end = (void *)((uint8_t *)cfg_desc + cfg_desc->wTotalLength);
 
 	while ((void *)dhp < desc_end) {
 		if ((uint8_t *)dhp + sizeof(struct usb_desc_header) > (uint8_t *)desc_end ||
@@ -357,37 +358,25 @@ static void reset_configuration(struct usb_device *const udev)
 	udev->state = USB_STATE_ADDRESSED;
 }
 
-int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t num)
+static int device_get_configuration(struct usb_device *const udev, const uint8_t num,
+				    void **const desc)
 {
 	struct usb_cfg_descriptor cfg_desc;
-	uint8_t idx;
 	int err;
 
 	err = k_mutex_lock(&udev->mutex, K_NO_WAIT);
-	if (err) {
+	if (err != 0) {
 		LOG_ERR("Failed to lock USB device");
 		return err;
 	}
 
-	if (udev->actual_cfg == num) {
-		LOG_INF("Already active device configuration");
-		goto error;
-	}
-
 	if (num == 0) {
-		reset_configuration(udev);
-		err = usbh_req_set_cfg(udev, num);
-		if (err) {
-			LOG_ERR("Set Configuration %u request failed", num);
-		}
-
+		err = -EINVAL;
 		goto error;
 	}
 
-	idx = num - 1;
-
-	err = usbh_req_desc_cfg(udev, idx, sizeof(cfg_desc), &cfg_desc);
-	if (err) {
+	err = usbh_req_desc_cfg(udev, num - 1, sizeof(struct usb_cfg_descriptor), &cfg_desc);
+	if (err != 0) {
 		LOG_ERR("Failed to read configuration %u descriptor", num);
 		goto error;
 	}
@@ -410,51 +399,94 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 		goto error;
 	}
 
-	udev->cfg_desc = k_heap_alloc(&usb_device_heap,
-				      cfg_desc.wTotalLength + sizeof(struct usb_desc_header),
-				      K_NO_WAIT);
-	if (udev->cfg_desc == NULL) {
+	*desc = k_heap_alloc(&usb_device_heap,
+			     cfg_desc.wTotalLength + sizeof(struct usb_desc_header),
+			     K_NO_WAIT);
+	if (*desc == NULL) {
 		LOG_ERR("Failed to allocate memory for configuration descriptor");
 		err = -ENOMEM;
 		goto error;
 	}
 
-	err = usbh_req_set_cfg(udev, num);
+	memset(*desc, 0, cfg_desc.wTotalLength + sizeof(struct usb_desc_header));
+
+	err = usbh_req_desc_cfg(udev, num - 1, cfg_desc.wTotalLength, *desc);
 	if (err) {
+		LOG_ERR("Failed to read configuration descriptor of %u bytes: %d",
+			cfg_desc.wTotalLength, err);
+		k_heap_free(&usb_device_heap, *desc);
+		goto error;
+	}
+
+	if (memcmp(*desc, &cfg_desc, sizeof(struct usb_cfg_descriptor))) {
+		LOG_ERR("Configuration descriptor read mismatch");
+		k_heap_free(&usb_device_heap, *desc);
+		err = -EINVAL;
+		goto error;
+	}
+
+error:
+	k_mutex_unlock(&udev->mutex);
+
+	return err;
+}
+
+static int device_set_configuration(struct usb_device *const udev, const uint8_t num, void *desc)
+{
+	struct usb_cfg_descriptor *const new_cfg_desc = desc;
+	void *const old_cfg_desc = udev->cfg_desc;
+	int err;
+
+	err = k_mutex_lock(&udev->mutex, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("Failed to lock USB device");
+		return err;
+	}
+
+	if (new_cfg_desc == NULL && num != 0) {
+		LOG_ERR("Invalid configuration %u to set", num);
+		err = -EINVAL;
+		goto error;
+	}
+
+	if (udev->actual_cfg == num) {
+		LOG_INF("Already active device configuration");
+		err = -EALREADY;
+		goto error;
+	}
+
+	if (num == 0) {
+		reset_configuration(udev);
+		err = usbh_req_set_cfg(udev, num);
+		if (err) {
+			LOG_ERR("Set Configuration %u request failed", num);
+		}
+
+		goto error;
+	}
+
+	err = usbh_req_set_cfg(udev, num);
+	if (err != 0) {
 		LOG_ERR("Set Configuration %u request failed", num);
 		goto error;
 	}
 
-	memset(udev->cfg_desc, 0, cfg_desc.wTotalLength + sizeof(struct usb_desc_header));
 	if (udev->state == USB_STATE_CONFIGURED) {
 		reset_configuration(udev);
 	}
 
-	err = usbh_req_desc_cfg(udev, idx, cfg_desc.wTotalLength, udev->cfg_desc);
-	if (err) {
-		LOG_ERR("Failed to read configuration descriptor of %u bytes: %d",
-			cfg_desc.wTotalLength, err);
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
-		udev->cfg_desc = NULL;
-		goto error;
-	}
-
-	if (memcmp(udev->cfg_desc, &cfg_desc, sizeof(cfg_desc))) {
-		LOG_ERR("Configuration descriptor read mismatch");
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
-		udev->cfg_desc = NULL;
-		goto error;
-	}
+	udev->cfg_desc = new_cfg_desc;
 
 	LOG_INF("Configuration %u bNumInterfaces %u",
-		cfg_desc.bConfigurationValue, cfg_desc.bNumInterfaces);
+		new_cfg_desc->bConfigurationValue, new_cfg_desc->bNumInterfaces);
 
 	err = parse_configuration_descriptor(udev);
-	if (err) {
-		k_heap_free(&usb_device_heap, udev->cfg_desc);
-		udev->cfg_desc = NULL;
+	if (err != 0) {
+		udev->cfg_desc = old_cfg_desc;
 		goto error;
 	}
+
+	k_heap_free(&usb_device_heap, old_cfg_desc);
 
 	udev->actual_cfg = num;
 	udev->state = USB_STATE_CONFIGURED;
@@ -463,6 +495,47 @@ error:
 	k_mutex_unlock(&udev->mutex);
 
 	return err;
+}
+
+static int choose_configuration(struct usb_device *const udev, uint8_t *const num,
+				void **const desc)
+{
+	void *cfg1_desc = NULL;
+
+	for (unsigned int i = 0; i < udev->dev_desc.bNumConfigurations; i++) {
+		void *cfg_desc = NULL;
+
+		if (device_get_configuration(udev, i + 1, &cfg_desc) != 0) {
+			LOG_ERR("Failed to get configuration %u of new device with address %u",
+				i + 1, udev->addr);
+			continue;
+		}
+
+		if (usbh_class_match_device(udev, cfg_desc)) {
+			/* Matched, discard the fallback */
+			k_heap_free(&usb_device_heap, cfg1_desc);
+			*desc = cfg_desc;
+			*num = i + 1;
+			return 0;
+		}
+
+		if (i == 0) {
+			/* Keep config 1 as fallback */
+			cfg1_desc = cfg_desc;
+		} else {
+			/* Discard unmatched config */
+			k_heap_free(&usb_device_heap, cfg_desc);
+		}
+	}
+
+	if (cfg1_desc == NULL) {
+		return -EINVAL;
+	}
+
+	/* No match found, fall back to config 1 */
+	*desc = cfg1_desc;
+	*num = 1;
+	return 0;
 }
 
 int usbh_device_set_address(struct usb_device *const udev, const uint8_t new_addr)
@@ -494,6 +567,8 @@ struct usb_device *usbh_device_get_root(struct usbh_context *const ctx)
 void usbh_device_connect(struct usbh_context *const ctx,
 			 struct usb_device *const udev)
 {
+	uint8_t cfg_num;
+	void *cfg_desc;
 	int err;
 
 	LOG_DBG("Device connected event");
@@ -507,15 +582,34 @@ void usbh_device_connect(struct usbh_context *const ctx,
 	err = usbh_device_init(udev);
 	if (err != 0) {
 		LOG_ERR("Failed to init new USB device");
-		if (usbh_device_is_root(ctx, udev)) {
-			ctx->root = NULL;
-		}
+		goto error;
+	}
 
-		usbh_device_free(udev);
-		return;
+	err = choose_configuration(udev, &cfg_num, &cfg_desc);
+	if (err != 0) {
+		goto error;
+	}
+
+	err = device_set_configuration(udev, cfg_num, cfg_desc);
+	if (err != 0) {
+		LOG_ERR("Failed to configure (index %u) new device with address %u",
+			cfg_num, udev->addr);
+		k_heap_free(&usb_device_heap, cfg_desc);
+		goto error;
 	}
 
 	usbh_class_probe_device(udev);
+
+	return;
+
+error:
+	usbh_class_remove_all(udev);
+
+	if (usbh_device_is_root(ctx, udev)) {
+		ctx->root = NULL;
+	}
+
+	usbh_device_free(udev);
 }
 
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
@@ -596,11 +690,6 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
-
-	err = usbh_device_set_configuration(udev, 1);
-	if (err) {
-		LOG_ERR("Failed to configure new device with address %u", udev->addr);
-	}
 
 error:
 	k_mutex_unlock(&udev->mutex);


### PR DESCRIPTION
Modify device initialization to iterate through all available device configurations and probe for supported classes, stopping at the first configuration that has a matching class driver.