### PR TITLE
usb: host: desc: Fix function descriptor iteration logic

### DIFF
--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -184,6 +184,8 @@ const void *usbh_desc_get_next_function(const void *const desc)
 	/* Skip all interfaces the Association descriptor contains */
 	if (usbh_desc_is_valid_association(head)) {
 		skip_num = ass_d->bInterfaceCount;
+	} else if (usbh_desc_is_valid_interface(head)) {
+		skip_num = 1;
 	}
 
 	/* Skip the interface if the head is interface */


### PR DESCRIPTION
This prevents incorrectly skipping descriptors when the current descriptor is neither an association nor an interface descriptor.