### PR TITLE
drivers/i2c: it8xxx2: Fix incorrect target address register

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1509,7 +1509,7 @@ static int i2c_enhance_target_register(const struct device *dev,
 		 * DMA read target address register
 		 * for high order byte
 		 */
-		IT8XXX2_I2C_CMD_ADDH2(base) = out_data_addr >> 16;
+		IT8XXX2_I2C_WM_ADDRH2(base) = out_data_addr >> 16;
 		IT8XXX2_I2C_RAMHA2(base) = out_data_addr >> 8;
 		IT8XXX2_I2C_RAMLA2(base) = out_data_addr;
 

--- a/soc/ite/ec/it8xxx2/chip_chipregs.h
+++ b/soc/ite/ec/it8xxx2/chip_chipregs.h
@@ -1370,6 +1370,7 @@ enum chip_pll_mode {
 #define IT8XXX2_I2C_CMD_ADDL(base)   ECREG(base + 0x26)
 #define IT8XXX2_I2C_RAMH2A(base)     ECREG(base + 0x50)
 #define IT8XXX2_I2C_CMD_ADDH2(base)  ECREG(base + 0x52)
+#define IT8XXX2_I2C_WM_ADDRH2(base)  ECREG(base + 0x56)
 
 /* SMBus/I2C register fields */
 /* 0x09-0xB: SMCLK Timing Setting */


### PR DESCRIPTION
The base address was written to an incorrect register, which caused incorrect data to be read from the I2C target. This has been fixed by writing to the correct register.