### PR TITLE
dts: arm: st: Fix invalid flash mapping

### DIFF
--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.dts
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.dts
@@ -19,6 +19,8 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,uart-mcumgr = &lpuart1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {
@@ -29,4 +31,33 @@
 
 &rng {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x0000c000>;
+		};
+
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000c000 0x00014000>;
+		};
+
+		slot1_partition: partition@20000 {
+			label = "image-1";
+			reg = <0x00020000 0x00014000>;
+		};
+
+		storage_partition: partition@34000 {
+			label = "storage";
+			reg = <0x00034000 0x00008000>;
+		};
+	};
 };

--- a/dts/arm/st/l5/stm32l552Xe.dtsi
+++ b/dts/arm/st/l5/stm32l552Xe.dtsi
@@ -14,6 +14,9 @@
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				reg = <0x08000000 DT_SIZE_K(512)>;
+				ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};


### PR DESCRIPTION
Fixes the flash device not being described correctly in devicetree. The sizes are just random but this shows how to fix devices so that the flash mapping is correctly described (has been tested and working with MCUboot updates and tests from the other PR)

FAO @etienne-lms 