### PR TITLE
drivers: modem: cellular: Allow chat match callback to set result

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -471,6 +471,11 @@ static void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **a
 	modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_MODEM_READY);
 }
 
+static void modem_cellular_chat_on_connect(struct modem_chat *chat, char **argv, uint16_t argc,
+					void *user_data)
+{
+	modem_chat_script_stop(chat, MODEM_CHAT_SCRIPT_RESULT_SUCCESS);
+}
 
 static void modem_cellular_chat_on_imei(struct modem_chat *chat, char **argv, uint16_t argc,
 					void *user_data)
@@ -694,7 +699,8 @@ MODEM_CHAT_MATCHES_DEFINE(unsol_matches,
 			  MODEM_CHAT_MATCH("+CEREG: ", ",", modem_cellular_chat_on_cxreg),
 			  MODEM_CHAT_MATCH("+CGREG: ", ",", modem_cellular_chat_on_cxreg),
 			  MODEM_CHAT_MATCH("+CGEV: ", ",", modem_cellular_chat_on_cgev),
-			  MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready));
+			  MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready),
+			  MODEM_CHAT_MATCH("CONNECT", "", modem_cellular_chat_on_connect));
 
 MODEM_CHAT_MATCHES_DEFINE(abort_matches, MODEM_CHAT_MATCH("ERROR", "", NULL));
 

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -542,6 +542,19 @@ void modem_chat_script_set_callback(struct modem_chat_script *script,
 void modem_chat_script_set_timeout(struct modem_chat_script *script, uint32_t timeout_s);
 
 /**
+ * @brief Stop currently executing chat script.
+ *
+ * This function can be called from a script match callback to stop the currently executing script.
+ *
+ * @note This is only safe to call from a script match callback,
+ *       and may cause undefined behavior if called from any other context.
+ *
+ * @param chat Modem chat instance
+ * @param result Result to set when stopping the script
+ */
+void modem_chat_script_stop(struct modem_chat *chat, enum modem_chat_script_result result);
+
+/**
  * @}
  */
 

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -67,7 +67,7 @@ static void modem_chat_log_received_command(struct modem_chat *chat)
 
 #endif
 
-static void modem_chat_script_stop(struct modem_chat *chat, enum modem_chat_script_result result)
+void modem_chat_script_stop(struct modem_chat *chat, enum modem_chat_script_result result)
 {
 	if ((chat == NULL) || (chat->script == NULL)) {
 		return;


### PR DESCRIPTION
Allow chat-script's match callback to stop executing the script and set  the valid result.
This can be used to put the "CONNECT" handler into list of URC message handlers. That allows us to handle all init and dial scripts with generic macros that only use the "ok_match" function.