### PR TITLE
drivers: modem: cellular: Allow registration even during dial-up

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1278,6 +1278,13 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
 		break;
+	case MODEM_CELLULAR_EVENT_REGISTERED:
+		/* Restart immediately, if we are waiting to retry the dial-script */
+		if (!modem_chat_is_running(&data->chat)) {
+			modem_cellular_stop_timer(data);
+			modem_chat_run_script_async(&data->chat, config->dial_chat_script);
+		}
+		break;
 	default:
 		break;
 	}
@@ -1293,6 +1300,11 @@ static int modem_cellular_on_await_registered_state_enter(struct modem_cellular_
 {
 	if (modem_ppp_attach(data->ppp, data->dlci1_pipe) < 0) {
 		return -EAGAIN;
+	}
+
+	/* Check if we are already registered during the dial-script */
+	if (modem_cellular_is_registered(data)) {
+		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
 	}
 
 	modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);


### PR DESCRIPTION
Some modem's reply "NO CARRIER" on the ATD command, until we are connected to the network. This causes first dial-up attempt to fail.

When waiting for retry-timer, we might receive "+CEREG:" or "+CGEV:" events, indicating that we are connected.
We should re-trigger the dial-up script immediately, instead of waiting for timer.

When the dial up script succeed, we don't anymore receive "+CEREG" so that should be handled in await_registered state.