### PR TITLE
scripts: dts: python-devicetree: Fix failing test with uppercase address

### DIFF
--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -126,7 +126,7 @@ def test_interrupts():
         edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
     ]
 
-    node = edt.get_node("/interrupt-map-bitops-test/node@70000000E")
+    node = edt.get_node("/interrupt-map-bitops-test/node@70000000e")
     assert node.interrupts == [
         edtlib.ControllerAndData(node=node, controller=edt.get_node('/interrupt-map-bitops-test/controller'), data={'one': 3, 'two': 2}, name=None, basename=None)
     ]


### PR DESCRIPTION
Commit f55358bcbfcfc4e7bd7d5c00bf6a16a13f01e8f6 changed all hex values to use lowercase characters. Update the test accordingly.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103638
