### PR TITLE
samples: drivers: opamp: fix console harness regex to match actual output (fractional gain)

### DIFF
--- a/samples/drivers/opamp/output_measure/README.rst
+++ b/samples/drivers/opamp/output_measure/README.rst
@@ -40,11 +40,10 @@ Hardware connection (OPAMP0 in differential mode):
 Sample output
 =============
 
-You will see the inverting and non-inverting gain and the output of the opamp
-in the terminal. Users can calculate the theoretical output value of the opamp
-according to the formula and compare it with the ADC measurement value.
+The application configures the OPAMP gain (if programmable gain is supported)
+and measures the OPAMP output using the ADC.
 
-The following output is printed:
+For each configured gain, the measured output voltage is printed in millivolts:
 
 .. code-block:: console
 

--- a/samples/drivers/opamp/output_measure/sample.yaml
+++ b/samples/drivers/opamp/output_measure/sample.yaml
@@ -11,9 +11,7 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "Set opamp inverting gain to: -?\\d+"
-        - "Set opamp non-inverting gain to: -?\\d+"
-        - "OPAMP output is: -?\\d+(mv)"
+        - "OPAMP output \\(@gain: (?:\\d+|\\d+/\\d+)\\) is: -?\\d+\\(mv\\)"
     platform_allow:
       - frdm_mcxa156
       - frdm_mcxa346


### PR DESCRIPTION
This PR updates the harness regex to match the actual output format.

The current console harness for the OPAMP output measurement sample expects the following lines:
- Set opamp inverting gain to: -?\d+
- Set opamp non-inverting gain to: -?\d+
- OPAMP output is: -?\d+(mv)

However, the sample does not set or print separate inverting/non-inverting gains. Instead, it configures a single PGA gain with opamp_set_gain() and prints the output in the format:

`OPAMP output (@gain: <string>) is: <mv>(mv)`

where <string> can be fractional (e.g., 1/7, 5/3, 13/3, etc.).

Update sample.yaml harness to:

- Use a regex that matches: OPAMP output (@ gain: (int|fraction)) is: -?\d+(mv)
- Drop the two lines related to inverting/non-inverting gains, which the sample does not print.