### PR TITLE
hifive_unmatched: configure the OpenOCD runner

### DIFF
--- a/boards/sifive/hifive_unmatched/board.cmake
+++ b/boards/sifive/hifive_unmatched/board.cmake
@@ -7,5 +7,6 @@ set(RENODE_UART sysbus.uart0)
 set(OPENOCD_USE_LOAD_IMAGE NO)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_hifive_unmatched.cfg")
+board_runner_args(openocd "--file-type=elf")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/sifive/hifive_unmatched/doc/index.rst
+++ b/boards/sifive/hifive_unmatched/doc/index.rst
@@ -41,13 +41,21 @@ Current version has not yet supported flashing binary to onboard Flash ROM.
 This board has USB-JTAG interface and this can be used with OpenOCD.
 Load applications on DDR and run as follows:
 
-.. code-block:: console
+.. tabs::
 
-   openocd -c 'bindto 0.0.0.0' \
-           -f boards/riscv/hifive_unmatched/support/openocd_hifive_unmatched.cfg
-   riscv64-zephyr-elf-gdb build/zephyr/zephyr.elf
-   (gdb) target remote :3333
-   (gdb) c
+   .. group-tab:: S7
+
+      .. zephyr-app-commands::
+         :zephyr-app: samples/hello_world
+         :board: hifive_unleashed//s7
+         :goals: flash
+
+   .. group-tab:: U74
+
+      .. zephyr-app-commands::
+         :zephyr-app: samples/hello_world
+         :board: hifive_unmatched///u74
+         :goals: flash
 
 Debugging
 =========

--- a/boards/sifive/hifive_unmatched/support/openocd_hifive_unmatched.cfg
+++ b/boards/sifive/hifive_unmatched/support/openocd_hifive_unmatched.cfg
@@ -1,11 +1,11 @@
 adapter speed 10000
 
 adapter driver ftdi
-ftdi_device_desc "Dual RS232-HS"
-ftdi_vid_pid 0x0403 0x6010
+ftdi device_desc "Dual RS232-HS"
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_layout_init 0x0008 0x001b
-ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+ftdi layout_init 0x0008 0x001b
+ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x20000913


### PR DESCRIPTION
This PR:
* includes a fix to the OpenOCD runner, configuring it to use the ELF file format
* removes deprecated commands in OpenOCD configuration
* points the user to the `west flash` command in the board documentation