### PR TITLE
Add ADC driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -33,4 +33,25 @@
 			pinmux = <PC21F_TCC0_WO5>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <PB8B_ADC0_AIN2>,	/* EXT1 pin 3 and EXT2 pin 3 */
+				 <PB9B_ADC0_AIN3>,	/* EXT1 pin 4 and EXT2 pin 4 */
+				 <PA3B_ADC0_AIN1>,	/* J501 pin 1 */
+				 <PA4B_ADC0_AIN4>,	/* J501 pin 4 */
+				 <PB2B_ADC0_AIN14>,	/* J501 pin 5 */
+				 <PB3B_ADC0_AIN15>;	/* J501 pin 6 */
+		};
+	};
+
+	adc1_default: adc1_default {
+		group1 {
+			pinmux = <PB8B_ADC1_AIN0>,	/* EXT1 pin 3 and EXT2 pin 3 */
+				 <PB9B_ADC1_AIN1>,	/* EXT1 pin 4 and EXT2 pin 4 */
+				 <PB6B_ADC1_AIN8>,	/* J501 pin 2 */
+				 <PB7B_ADC1_AIN9>,	/* J501 pin 3 */
+				 <PC3B_ADC1_AIN5>;	/* J900 pin 8 - AN */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -9,6 +9,8 @@
 #include "pic32cx_sg41_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mchp_sam_d5x_e5x_adc.h>
 
 / {
 	model = "PIC32CX SG41 Curiosity Ultra";
@@ -158,11 +160,31 @@
 			gclkgen-src = "fdpll0";
 			gclkgen-en = <1>;
 		};
+
+		gclkgen1 {
+			subsystem = <CLOCK_MCHP_GCLKGEN_ID_GEN1>;
+			gclkgen-div-factor = <2>;
+			gclkgen-src = "fdpll0";
+			gclkgen-run-in-standby-en = <1>;
+			gclkgen-en = <1>;
+		};
 	};
 
 	gclkperiph: gclkperiph {
 		compatible = "microchip,sam-d5x-e5x-gclkperiph";
 		#clock-cells = <1>;
+
+		adc0 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_ADC0>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
+
+		adc1 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_ADC1>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
 	};
 
 	mclkperiph: mclkperiph {
@@ -231,5 +253,21 @@
 	pinctrl-names = "default";
 	max-bit-width = <16>;
 	prescaler = <64>;
+	status = "okay";
+};
+
+&adc0 {
+	/* ADC clock = GCLK / prescaler (60 MHz / 4 = 15 MHz) */
+	prescaler = <4>;
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&adc1 {
+	/* ADC clock = GCLK / prescaler (60 MHz / 4 = 15 MHz) */
+	prescaler = <4>;
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -10,6 +10,7 @@ toolchain:
 flash: 1024
 ram: 256
 supported:
+  - adc
   - clock_control
   - comparator
   - dma

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -33,4 +33,25 @@
 			pinmux = <PC21F_TCC0_WO5>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <PB8B_ADC0_AIN2>,	/* EXT1 pin 3 and EXT2 pin 3 */
+				 <PB9B_ADC0_AIN3>,	/* EXT1 pin 4 and EXT2 pin 4 */
+				 <PA3B_ADC0_AIN1>,	/* J501 pin 1 */
+				 <PA4B_ADC0_AIN4>,	/* J501 pin 4 */
+				 <PB2B_ADC0_AIN14>,	/* J501 pin 5 */
+				 <PB3B_ADC0_AIN15>;	/* J501 pin 6 */
+		};
+	};
+
+	adc1_default: adc1_default {
+		group1 {
+			pinmux = <PB8B_ADC1_AIN0>,	/* EXT1 pin 3 and EXT2 pin 3 */
+				 <PB9B_ADC1_AIN1>,	/* EXT1 pin 4 and EXT2 pin 4 */
+				 <PB6B_ADC1_AIN8>,	/* J501 pin 2 */
+				 <PB7B_ADC1_AIN9>,	/* J501 pin 3 */
+				 <PC3B_ADC1_AIN5>;	/* J900 pin 8 - AN */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -9,6 +9,8 @@
 #include "pic32cx_sg61_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mchp_sam_d5x_e5x_adc.h>
 
 / {
 	model = "PIC32CX SG61 Curiosity Ultra";
@@ -152,11 +154,31 @@
 			gclkgen-src = "fdpll0";
 			gclkgen-en = <1>;
 		};
+
+		gclkgen1 {
+			subsystem = <CLOCK_MCHP_GCLKGEN_ID_GEN1>;
+			gclkgen-div-factor = <2>;
+			gclkgen-src = "fdpll0";
+			gclkgen-run-in-standby-en = <1>;
+			gclkgen-en = <1>;
+		};
 	};
 
 	gclkperiph: gclkperiph {
 		compatible = "microchip,sam-d5x-e5x-gclkperiph";
 		#clock-cells = <1>;
+
+		adc0 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_ADC0>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
+
+		adc1 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_ADC1>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
 	};
 
 	mclkperiph: mclkperiph {
@@ -225,5 +247,21 @@
 	pinctrl-names = "default";
 	max-bit-width = <16>;
 	prescaler = <64>;
+	status = "okay";
+};
+
+&adc0 {
+	/* ADC clock = GCLK / prescaler (60 MHz / 4 = 15 MHz) */
+	prescaler = <4>;
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&adc1 {
+	/* ADC clock = GCLK / prescaler (60 MHz / 4 = 15 MHz) */
+	prescaler = <4>;
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -10,6 +10,7 @@ toolchain:
 flash: 1024
 ram: 256
 supported:
+  - adc
   - clock_control
   - comparator
   - dma

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -205,6 +205,10 @@
 				write-block-size = <8>;
 				erase-block-size = <512>;
 			};
+
+			nvm_sw_calib_area: nvm_sw_calib_area@800080 {
+				reg = <0x00800080 0x8>;
+			};
 		};
 
 		pinctrl: pinctrl@41008000 {
@@ -395,6 +399,42 @@
 			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM5>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM5_CORE>;
 			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		adc0: adc@43001c00 {
+			compatible = "microchip,adc-g1";
+			reg = <0x43001c00 0x4a>;
+			interrupts = <118 0>, <119 0>;
+			interrupt-names = "overrun", "resrdy";
+			num-channels = <23>;
+			#io-channel-cells = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_ADC0>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_ADC0>;
+			clock-names = "mclk", "gclk";
+			nvm-calib = <&nvm_sw_calib_area>;
+			calib-mapping = <0 0x2 0x7>,
+					<4 0x8 0x7>,
+					<8 0x5 0x7>;
+			calib-mapping-names = "BIASCOMP", "BIASR2R", "BIASREFBUF";
+			status = "disabled";
+		};
+
+		adc1: adc@43002000 {
+			compatible = "microchip,adc-g1";
+			reg = <0x43002000 0x4a>;
+			interrupts = <120 0>, <121 0>;
+			interrupt-names = "overrun", "resrdy";
+			num-channels = <23>;
+			#io-channel-cells = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_ADC1>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_ADC1>;
+			clock-names = "mclk", "gclk";
+			nvm-calib = <&nvm_sw_calib_area>;
+			calib-mapping = <0 0x10 0x7>,
+					<4 0x16 0x7>,
+					<8 0x13 0x7>;
+			calib-mapping-names = "BIASCOMP", "BIASR2R", "BIASREFBUF";
 			status = "disabled";
 		};
 

--- a/samples/drivers/adc/adc_sequence/boards/pic32cx_sg41_cult.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	/* ADC clock = GCLK / prescaler (60 MHz / 16 = 3.75 MHz) */
+	prescaler = <16>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <MCHP_ADC_AIN1>; /* J501 Pin - 1 (ADC+) */
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/boards/pic32cx_sg61_cult.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	/* ADC clock = GCLK / prescaler (60 MHz / 16 = 3.75 MHz) */
+	prescaler = <16>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <MCHP_ADC_AIN1>; /* J501 Pin - 1 (ADC+) */
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/pic32cx_sg41_cult_ref.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/pic32cx_sg41_cult_ref.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* connect the PA03(J501 pin 1) to VCC(J500 pin 4) for the test */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 1>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <1>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <PA3B_ADC0_AIN1>;
+		};
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -63,6 +63,9 @@ tests:
       - bg29_rb4420a
       - slwrb4180a
       - ek_ra4c1
+      - pic32cx_sg41_cult
+    extra_args:
+      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"DTC_OVERLAY_FILE="boards/pic32cx_sg41_cult_ref.overlay"
     integration_platforms:
       - frdm_kl25z
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/adc/adc_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/adc/adc_api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCHP_ADC_SCALEDIOVCC>;
+	};
+};

--- a/tests/drivers/adc/adc_error_cases/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc = &adc0;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	/* ADC clock = GCLK / prescaler (60 MHz / 16 = 3.75 MHz) */
+	prescaler = <16>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <MCHP_ADC_AIN1>; /* J501 Pin - 1 (ADC+) */
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <2400>;
+	};
+};

--- a/tests/drivers/adc/adc_error_cases/testcase.yaml
+++ b/tests/drivers/adc/adc_error_cases/testcase.yaml
@@ -21,3 +21,4 @@ tests:
       - xg29_rb4412a
       - bg29_rb4420a
       - slwrb4180a
+      - pic32cx_sg41_cult


### PR DESCRIPTION
- Add device tree nodes and associated header file for PIC32CX_SG.
- Update ADC G1 driver implementation to support PIC32CX_SG.
- Add ADC0 and ADC1 pinctrl definitions. 
- update the board metadata to list ADC as a supported feature on the pic32cx_sg41_cult and sg61 board.
- Add a devicetree overlay to run the adc_sequence sample on pic32cx_sg.
- Add board overlay file for pic32cx_sg41_cult to enable adc test cases to run on this boards.