### PR TITLE
tests: bluetooth: controller: mock_ctrl: ll_assert: fix printf format

### DIFF
--- a/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ll_assert.c
@@ -7,9 +7,10 @@
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 void bt_ctlr_assert_handle(char *file, uint32_t line)
 {
-	printf("Assertion failed in %s:%d\n", file, line);
+	printf("Assertion failed in %s:%" PRIu32 "\n", file, line);
 	exit(-1);
 }


### PR DESCRIPTION
Use the correct unsigned format specifier to match the uint32_t line argument.