### PR TITLE
kernel: timeout: public APIs for timeout_list and its lock

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2116,6 +2116,20 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 	return timer->user_data;
 }
 
+/**
+ * @brief Get first/next timeout in expiry order.
+ *
+ * This routine returns the next timeout in the timeout_list. To get
+ * the first timeout pass NULL, pass a previously returned pointer to
+ * get the next. Returns NULL if none. The list may change between calls.
+ * Read-only: do not modify returned nodes.
+ *
+ * @param to Previous timeout or NULL for first.
+ *
+ * @return Next timeout or NULL.
+ */
+struct _timeout *k_get_next_timeout(struct _timeout *to);
+
 /** @} */
 
 /**

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -361,3 +361,18 @@ void z_vrfy_sys_clock_tick_set(uint64_t tick)
 	z_impl_sys_clock_tick_set(tick);
 }
 #endif /* CONFIG_ZTEST */
+
+struct _timeout *k_get_next_timeout(struct _timeout *to)
+{
+	struct _timeout *t = NULL;
+
+	K_SPINLOCK(&timeout_lock) {
+		if (to == NULL) {
+			t = first();
+		} else {
+			t = sys_dnode_is_linked(&to->node) ? next(to) : NULL;
+		}
+	}
+
+	return t;
+}

--- a/tests/kernel/timer/timeout_get/CMakeLists.txt
+++ b/tests/kernel/timer/timeout_get/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(timeout_get)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/timer/timeout_get/prj.conf
+++ b/tests/kernel/timer/timeout_get/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kernel/timer/timeout_get/src/main.c
+++ b/tests/kernel/timer/timeout_get/src/main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Qualcomm Technologies, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util_macro.h>
+
+static struct k_timer t1;
+static struct k_timer t2;
+
+uint32_t t1_count;
+uint32_t t2_count;
+
+static void t1_expiry_cb(struct k_timer *timer)
+{
+	t1_count++;
+}
+
+static void t2_expiry_cb(struct k_timer *timer)
+{
+	t2_count++;
+}
+
+ZTEST(timeout_get, test_timeout_get)
+{
+	bool found_t1_timeout = false;
+	struct _timeout *iter = NULL;
+
+	/* Initialize the timers */
+	k_timer_init(&t1, t1_expiry_cb, NULL);
+	k_timer_init(&t2, t2_expiry_cb, NULL);
+
+	/* Start timers */
+	k_timer_start(&t1, K_SECONDS(2), K_NO_WAIT);
+	k_timer_start(&t2, K_SECONDS(3), K_NO_WAIT);
+
+	k_sleep(K_SECONDS(1));
+
+	while (1) {
+		struct _timeout *t = k_get_next_timeout(iter);
+
+		if (t == NULL) {
+			break;
+		}
+
+		if (t == &t1.timeout) {
+			found_t1_timeout = true;
+			k_timer_stop(&t1);
+			break;
+		}
+
+		iter = t;
+	}
+
+	zassert_true(found_t1_timeout, "Did not find t1's timeout via iteration");
+
+	k_timer_stop(&t2);
+}
+
+ZTEST_SUITE(timeout_get, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/timer/timeout_get/testcase.yaml
+++ b/tests/kernel/timer/timeout_get/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  kernel.timer.timeout_get:
+    tags:
+      - kernel
+      - timer


### PR DESCRIPTION
This change introduces two APIs, k_timeout_list_get() and k_timeout_lock_get(). These accessors provide visibility into the kernel timeout list and its associated lock. These APIs facilitate the inspection of the timeout list, making it possible to identify and handle timeouts associated with specific events.