### PR TITLE
west.yml: fix hal unconditional directory inclusion

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: dbbff4a054d5888c3e8a27096335197a1a8186ca
+      revision: 39e192079299363f191ee6ab712ca0d67f49e7e3
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Update west manifest to point to the latest revision of the hal_microchip repository which fixes an issue of unconditional directory inclusion.

Fixes: #102770