### PR TITLE
scripts: dts: gen_driver_kconfig_dts: optimize compatible extraction

### DIFF
--- a/scripts/dts/gen_driver_kconfig_dts.py
+++ b/scripts/dts/gen_driver_kconfig_dts.py
@@ -59,30 +59,59 @@ def parse_args():
     return parser.parse_args()
 
 
+def extract_compatible(filepath):
+    # Extract top-level 'compatible' scalar from a binding YAML file.
+    #
+    # Uses a byte-level pre-filter to skip files that cannot contain a compatible key, then streams
+    # YAML events via yaml.parse() and exits as soon as the compatible value is found to avoid
+    # construction of the full representation.
+
+    with open(filepath, "rb") as f:
+        raw = f.read()
+
+    # Pre-filter: skip files that can't possibly have a compatible key.
+    if b"compatible" not in raw:
+        return None
+
+    depth = 0
+    expect_value = False
+    for event in yaml.parse(raw, Loader=SafeLoader):
+        if isinstance(event, (yaml.MappingStartEvent, yaml.SequenceStartEvent)):
+            depth += 1
+        elif isinstance(event, (yaml.MappingEndEvent, yaml.SequenceEndEvent)):
+            depth -= 1
+            if depth == 0:
+                return None  # Top-level mapping ended, compatible not found
+        elif isinstance(event, yaml.ScalarEvent) and depth == 1:
+            if expect_value:
+                return event.value  # Found it, early exit
+            expect_value = event.value == "compatible"
+        else:
+            expect_value = False
+
+    return None
+
+
 def main():
     args = parse_args()
 
     compats = set()
 
     for binding_path in binding_paths(args.bindings_dirs):
-        with open(binding_path, encoding="utf-8") as f:
-            try:
-                # Parsed PyYAML representation graph. For our purpose,
-                # we don't need the whole file converted into a dict.
-                root = yaml.compose(f, Loader=SafeLoader)
-            except yaml.YAMLError as e:
-                print(
-                    f"WARNING: '{binding_path}' appears in binding "
-                    f"directories but isn't valid YAML: {e}"
-                )
-                continue
-
-        if not isinstance(root, yaml.MappingNode):
+        try:
+            compat = extract_compatible(binding_path)
+        except OSError as e:
+            print(f"WARNING: couldn't read '{binding_path}': {e}")
             continue
-        for key, node in root.value:
-            if key.value == "compatible" and isinstance(node, yaml.ScalarNode):
-                compats.add(node.value)
-                break
+        except yaml.YAMLError as e:
+            print(
+                f"WARNING: '{binding_path}' appears in binding "
+                f"directories but isn't valid YAML: {e}"
+            )
+            continue
+
+        if compat is not None:
+            compats.add(compat)
 
     with open(args.kconfig_out, "w", encoding="utf-8") as kconfig_file:
         print(HEADER, file=kconfig_file)


### PR DESCRIPTION
Use yaml.parse() to stream YAML events and exit as soon as the compatible scalar is found, avoiding construction of the full representation graph.
This makes the script almost 2x faster on the 3000+ bindings currently in-tree, i.e. saves about 100ms on my machine.


main:

```
hyperfine './scripts/dts/gen_driver_kconfig_dts.py --kconfig-out /tmp/bla --bindings-dirs ./dts/bindings' -m 50
Benchmark 1: ./scripts/dts/gen_driver_kconfig_dts.py --kconfig-out /tmp/bla --bindings-dirs ./dts/bindings
  Time (mean ± σ):     256.2 ms ±   6.0 ms    [User: 184.0 ms, System: 68.8 ms]
  Range (min … max):   248.7 ms … 279.7 ms    50 runs
```

This PR:

```
hyperfine './scripts/dts/gen_driver_kconfig_dts.py --kconfig-out /tmp/bla --bindings-dirs ./dts/bindings' -m 50
Benchmark 1: ./scripts/dts/gen_driver_kconfig_dts.py --kconfig-out /tmp/bla --bindings-dirs ./dts/bindings
  Time (mean ± σ):     149.8 ms ±   4.2 ms    [User: 82.9 ms, System: 64.1 ms]
  Range (min … max):   144.2 ms … 160.5 ms    50 runs
```