### PR TITLE
Revert pykwalify to jsonschema

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -318,7 +318,6 @@ def process_blobs(module, meta):
         blob['abspath'] = blobs_path / Path(blob['path'])
         blob['license-abspath'] = Path(module) / Path(blob['license-path'])
         blob['status'] = get_blob_status(blob['abspath'], blob['sha256'])
-        blob['click-through'] = blob.get('click-through', False)
         blobs.append(blob)
 
     return blobs


### PR DESCRIPTION
Recent commits moving from pykwalify to jsonschema have resulted in the west tool and zephyr being out of sync, see https://github.com/zephyrproject-rtos/west/pull/904#issuecomment-3860898555 

Following the getting started guide now will result in
```
Traceback (most recent call last):
  File "/home/nordic/Documents/zephyr-2/.venv/lib/python3.11/site-packages/west/commands.py", line 565, in __call__
    mod = _commands_module_from_file(self.py_file)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nordic/Documents/zephyr-2/.venv/lib/python3.11/site-packages/west/commands.py", line 718, in _commands_module_from_file
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/nordic/Documents/zephyr-2/zephyr/scripts/west_commands/packages.py", line 20, in <module>
    import zephyr_module
  File "/home/nordic/Documents/zephyr-2/zephyr/scripts/zephyr_module.py", line 27, in <module>
    import jsonschema
ModuleNotFoundError: No module named 'jsonschema'
```
as west packages pip --install is called

therefore revert the changes until this issue is fixed as it is imperative that the getting started guide works.