### PR TITLE
boards: st: stm32h573i_dk: fix external flash address mapping

### DIFF
--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -76,14 +76,6 @@
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
 	};
-
-	ext_flash_mem: memory@90000000 {
-		compatible = "zephyr,memory-region";
-		reg = <0x90000000 DT_SIZE_M(64)>;
-		zephyr,memory-region = "EXT_FLASH";
-		/* DT_MEM_ARM_MPU_EXTMEM and DT_MEM_ARM_MPU_FLASH cause MPU issues */
-		zephyr,memory-attr = <DT_MEM_ARM_MPU_IO>;
-	};
 };
 
 &fmc {


### PR DESCRIPTION
Remove the explicit mapping of the external flash address range. It is not needed (driver use the privileged background map) and the attribute set was set (DT_MEM_ARM_MPU_IO) causes troubles. The issue appeared since commit fec8b10a09c3 that defines the mapping attribute for Armv8M. Before that commit, attribute was not defined hence was this node ignored.

