### PR TITLE
dts: arm: microchip: mec: Fix MEC1653B flash0 node

### DIFF
--- a/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
@@ -9,7 +9,7 @@
 #include "mec5.dtsi"
 
 / {
-	flash0: flash@b0000 {
+	flash0: flash@c0000 {
 		reg = <0x000c0000 0x58000>;
 	};
 


### PR DESCRIPTION
The flash0 physical address in the node name did not match the starting address in the reg property. This part implements 352KB code SRAM starting at 0xC0000.