### PR TITLE
drivers: stepper: adi_tmc: tmc50xx: Remove redundant pointer check

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper.c
@@ -74,9 +74,9 @@ static int read_vactual(const struct device *dev, int32_t *actual_velocity)
 	}
 
 	*actual_velocity = sign_extend(*actual_velocity, TMC_RAMP_VACTUAL_SHIFT);
-	if (actual_velocity) {
-		LOG_DBG("actual velocity: %d", *actual_velocity);
-	}
+
+	LOG_DBG("actual velocity: %d", *actual_velocity);
+
 	return 0;
 }
 


### PR DESCRIPTION
The actual_velocity pointer is dereferenced unconditionally before the NULL check, making the conditional LOG_DBG() guard ineffective.

Since actual_velocity must be valid to reach this point, the conditional check is redundant and misleading.

Remove it and log the value unconditionally to reflect the actual control flow.