### PR TITLE
drivers: i2c: microchip: xec: I2C byte mode version 3 for MEC174x/5x

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -90,6 +90,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91 i2c_b91.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_WCH i2c_wch.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XEC i2c_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XEC_V2 i2c_mchp_xec_v2.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_XEC_V3 i2c_mchp_xec_v3.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XILINX_AXI i2c_xilinx_axi.c)
 # zephyr-keep-sorted-stop
 

--- a/drivers/i2c/Kconfig.xec
+++ b/drivers/i2c/Kconfig.xec
@@ -18,3 +18,11 @@ config I2C_XEC_V2
 	select PINCTRL
 	help
 	  Enable the Microchip XEC I2C V2 driver.
+
+config I2C_XEC_V3
+	bool "XEC Microchip I2C version 3 driver"
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_I2C_V3_ENABLED
+	select PINCTRL
+	help
+	  Enable the Microchip XEC I2C V3 byte mode driver.

--- a/drivers/i2c/i2c_mchp_xec_regs.h
+++ b/drivers/i2c/i2c_mchp_xec_regs.h
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_
+#define ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_
+
+#include <zephyr/sys/util.h>
+
+#define XEC_I2C_SMB0_ID    0
+#define XEC_I2C_SMB1_ID    1
+#define XEC_I2C_SMB2_ID    2
+#define XEC_I2C_SMB3_ID    3
+#define XEC_I2C_SMB4_ID    4
+#define XEC_I2C_SMB_MAX_ID 5
+
+#define XEC_I2C_SMB_GIRQ    13U
+#define XEC_I2C_SMB_WK_GIRQ 26U
+
+#define XEC_I2C_SMB_INST_SIZE 0x400U
+
+#define XEC_I2C_SMB_BASE(base, instance)                                                           \
+	((uint32_t)(base) + ((uint32_t)(instance) * (XEC_I2C_SMB_INST_SIZE)))
+
+/* Hardware only supports 7-bit I2C addressing */
+#define XEC_I2C_TARGET_ADDR_MSK GENMASK(6, 0)
+
+/* Hardware supports two target 7-bit addresses */
+#define XEC_I2C_MAX_TARGETS 2
+
+#define XEC_I2C_CR_OFS     0 /* WO */
+#define XEC_I2C_CR_MSK     0xcfU
+#define XEC_I2C_CR_ACK_POS 0
+#define XEC_I2C_CR_STO_POS 1
+#define XEC_I2C_CR_STA_POS 2
+#define XEC_I2C_CR_ENI_POS 3
+#define XEC_I2C_CR_ESO_POS 6
+#define XEC_I2C_CR_PIN_POS 7
+
+#define XEC_I2C_SR_OFS         0 /* RO */
+#define XEC_I2C_SR_MSK         0xffU
+#define XEC_I2C_SR_NBB_POS     0
+#define XEC_I2C_SR_LAB_POS     1
+#define XEC_I2C_SR_AAT_POS     2
+#define XEC_I2C_SR_LRB_AD0_POS 3
+#define XEC_I2C_SR_BER_POS     4
+#define XEC_I2C_SR_STO_POS     5
+#define XEC_I2C_SR_SAD_POS     6
+#define XEC_I2C_SR_PIN_POS     7
+
+/* XEC I2C hardware can match the following addresses in addition
+ * to the two programmable 7-bit OWN addresses.
+ * I2C general call 7-bit address 0x00. I2C.CONFIG.GC_DIS bit = 0
+ * SMBus Host and Device addresses 0x08 and 0x61. I2C.CONFIG.DSA bit = 1
+ * Detection using I2C.STATUS register.
+ * AAT SAD LRB/AD0 address
+ *  1   1   0      0x08 SMBus Host address
+ *  1   1   1      0x61 SMBus Device address
+ *  1   0   1      0x00 I2C general call address
+ *  1   0   0      One of the two programmable OWN addresses.
+ * The actual address can be viewed without side-effect by reading I2C.SHAD_ADDR
+ * register. It can be read from I2C.DATA with side-effect of clearing AAT, SAD, and LRB/AD0.
+ * In network layer mode the HW stores the address via DMA into the configured memory buffer.
+ */
+#define XEC_I2C_GEN_CALL_ADDR   0u
+#define XEC_I2C_SMB_HOST_ADDR   0x08U
+#define XEC_I2C_SMB_DEVICE_ADDR 0x61U
+
+#define XEC_I2C_SR_ADDR_MATCH_MSK                                                                  \
+	(BIT(XEC_I2C_SR_PIN_POS) | BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_LRB_AD0_POS) |         \
+	 BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_GEN_CALL (BIT(XEC_I2C_SR_LRB_AD0_POS) | BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_SMB_HOST (BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_AAT_POS))
+#define XEC_I2C_SR_ADDR_MATCH_SMB_DEV                                                              \
+	(BIT(XEC_I2C_SR_SAD_POS) | BIT(XEC_I2C_SR_LRB_AD0_POS) | BIT(XEC_I2C_SR_AAT_POS))
+
+#define XEC_I2C_OA_OFS       0x4U /* own(target) address */
+#define XEC_I2C_OA_1_POS     0
+#define XEC_I2C_OA_2_POS     8
+#define XEC_I2C_OA_1_MSK     GENMASK(6, 0)
+#define XEC_I2C_OA_2_MSK     GENMASK(14, 8)
+#define XEC_I2C_OA_1_SET(a)  FIELD_PREP(XEC_I2C_OA_1_MSK, (a))
+#define XEC_I2C_OA_2_SET(a)  FIELD_PREP(XEC_I2C_OA_2_MSK, (a))
+#define XEC_I2C_OA_1_GET(r)  FIELD_GET(XEC_I2C_OA_1_MSK, (r))
+#define XEC_I2C_OA_2_GET(r)  FIELD_GET(XEC_I2C_OA_2_MSK, (r))
+#define XEC_I2C_OA_POS(n)    ((n) * 8U)
+#define XEC_I2C_OA_MSK(n)    (0x7FU << XEC_I2C_OA_POS(n))
+#define XEC_I2C_OA_SET(n, a) (((uint32_t)(a) << XEC_I2C_OA_POS(n)) & XEC_I2C_OA_MSK(n))
+#define XEC_I2C_OA_GET(n, r) (((uint32_t)(r) & XEC_I2C_OA_MSK(n)) >> XEC_I2C_OA_POS(n))
+
+#define XEC_I2C_OA_NUM_TARGETS 2U
+
+#define XEC_I2C_DATA_OFS 0x8U
+#define XEC_I2C_DATA_MSK GENMASK(7, 0)
+
+#define XEC_I2C_HCMD_OFS        0x0cU /* network layer host command */
+#define XEC_I2C_HCMD_RUN_POS    0
+#define XEC_I2C_HCMD_PROC_POS   1
+#define XEC_I2C_HCMD_START0_POS 8
+#define XEC_I2C_HCMD_STARTN_POS 9
+#define XEC_I2C_HCMD_STOP_POS   10
+#define XEC_I2C_HCMD_PEC_TX_POS 11
+#define XEC_I2C_HCMD_RDM_POS    12
+#define XEC_I2C_HCMD_PEC_RD_POS 13
+#define XEC_I2C_HCMD_WCL_POS    16
+#define XEC_I2C_HCMD_WCL_MSK    GENMASK(23, 16)
+#define XEC_I2C_HCMD_WCL_SET(n) FIELD_PREP(XEC_I2C_HCMD_WCL_MSK, (n))
+#define XEC_I2C_HCMD_WCL_GET(r) FIELD_GET(XEC_I2C_HCMD_WCL_MSK, (r))
+#define XEC_I2C_HCMD_RCL_POS    24
+#define XEC_I2C_HCMD_RCL_MSK    GENMASK(31, 24)
+#define XEC_I2C_HCMD_RCL_SET(n) FIELD_PREP(XEC_I2C_HCMD_RCL_MSK, (n))
+#define XEC_I2C_HCMD_RCL_GET(r) FIELD_GET(XEC_I2C_HCMD_RCL_MSK, (r))
+
+#define XEC_I2C_TCMD_OFS        0x10U /* network layer target command */
+#define XEC_I2C_TCMD_RUN_POS    0
+#define XEC_I2C_TCMD_PROC_POS   1
+#define XEC_I2C_TCMD_TX_PEC_POS 2
+#define XEC_I2C_TCMD_WCL_POS    8
+#define XEC_I2C_TCMD_WCL_MSK    GENMASK(15, 8)
+#define XEC_I2C_TCMD_WCL_SET(n) FIELD_PREP(XEC_I2C_TCMD_WCL_MSK, (n))
+#define XEC_I2C_TCMD_WCL_GET(r) FIELD_GET(XEC_I2C_TCMD_WCL_MSK, (r))
+#define XEC_I2C_TCMD_RCL_POS    16
+#define XEC_I2C_TCMD_RCL_MSK    GENMASK(23, 16)
+#define XEC_I2C_TCMD_RCL_SET(n) FIELD_PREP(XEC_I2C_TCMD_RCL_MSK, (n))
+#define XEC_I2C_TCMD_RCL_GET(r) FIELD_GET(XEC_I2C_TCMD_RCL_MSK, (r))
+
+#define XEC_I2C_PEC_OFS 0x14U
+#define XEC_I2C_PEC_MSK GENMASK(7, 0)
+
+#define XEC_I2C_RSHT_OFS 0x18U /* Repeated-START hold time */
+#define XEC_I2C_RSHT_MSK GENMASK(7, 0)
+
+/* Network layer mode extended length. Contains bit[15:8] of write and read counts */
+#define XEC_I2C_ELEN_OFS        0x1cU
+#define XEC_I2C_ELEN_HWR_POS    0
+#define XEC_I2C_ELEN_HWR_MSK    GENMASK(7, 0)
+#define XEC_I2C_ELEN_HWR_SET(n) FIELD_PREP(XEC_I2C_ELEN_HWR_MSK, (n))
+#define XEC_I2C_ELEN_HWR_GET(r) FIELD_GET(XEC_I2C_ELEN_HWR_MSK, (r))
+#define XEC_I2C_ELEN_HRD_POS    8
+#define XEC_I2C_ELEN_HRD_MSK    GENMASK(15, 8)
+#define XEC_I2C_ELEN_HRD_SET(n) FIELD_PREP(XEC_I2C_ELEN_HRD_MSK, (n))
+#define XEC_I2C_ELEN_HRD_GET(r) FIELD_GET(XEC_I2C_ELEN_HRD_MSK, (r))
+#define XEC_I2C_ELEN_TWR_POS    16
+#define XEC_I2C_ELEN_TWR_MSK    GENMASK(23, 16)
+#define XEC_I2C_ELEN_TWR_SET(n) FIELD_PREP(XEC_I2C_ELEN_TWR_MSK, (n))
+#define XEC_I2C_ELEN_TWR_GET(r) FIELD_GET(XEC_I2C_ELEN_TWR_MSK, (r))
+#define XEC_I2C_ELEN_TRD_POS    24
+#define XEC_I2C_ELEN_TRD_MSK    GENMASK(31, 24)
+#define XEC_I2C_ELEN_TRD_SET(n) FIELD_PREP(XEC_I2C_ELEN_TRD_MSK, (n))
+#define XEC_I2C_ELEN_TRD_GET(r) FIELD_GET(XEC_I2C_ELEN_TRD_MSK, (r))
+
+#define XEC_I2C_CMPL_OFS 0x20U /* Completion: R/W1C status and timeout check enables */
+#define XEC_I2C_CMPL_MSK                                                                           \
+	(GENMASK(6, 2) | GENMASK(14, 8) | GENMASK(17, 16) | GENMASK(21, 19) | GENMASK(25, 24) |    \
+	 GENMASK(31, 29))
+#define XEC_I2C_CMPL_RW_MSK GENMASK(5, 2)
+#define XEC_I2C_CMPL_RO_MSK (BIT(6) | BIT(17) | BIT(25))
+#define XEC_I2C_CMPL_RW1C_MSK                                                                      \
+	(GENMASK(14, 8) | BIT(16) | GENMASK(21, 19) | BIT(24) | GENMASK(31, 29))
+#define XEC_I2C_CMPL_DTEN_POS      2
+#define XEC_I2C_CMPL_HCEN_POS      3
+#define XEC_I2C_CMPL_TCEN_POS      4
+#define XEC_I2C_CMPL_BIDEN_POS     5
+#define XEC_I2C_CMPL_TMO_STS_POS   6 /* RO - any of 4 timeouts detected */
+#define XEC_I2C_CMPL_DTS_STS_POS   8
+#define XEC_I2C_CMPL_HCTO_STS_POS  9
+#define XEC_I2C_CMPL_TCTO_STS_POS  10
+#define XEC_I2C_CMPL_CHDL_STS_POS  11
+#define XEC_I2C_CMPL_CHDH_STS_POS  12
+#define XEC_I2C_CMPL_BER_STS_POS   13
+#define XEC_I2C_CMPL_LAB_STS_POS   14
+#define XEC_I2C_CMPL_TNAKR_STS_POS 16
+#define XEC_I2C_CMPL_TTR_POS       17 /* RO */
+#define XEC_I2C_CMPL_TPROT_POS     19
+#define XEC_I2C_CMPL_RPT_RD_POS    20
+#define XEC_I2C_CMPL_RPT_WR_POS    21
+#define XEC_I2C_CMPL_HNAKX_POS     24
+#define XEC_I2C_CMPL_HTR_POS       25 /* RO */
+#define XEC_I2C_CMPL_IDLE_POS      29
+#define XEC_I2C_CMPL_HDONE_POS     30
+#define XEC_I2C_CMPL_TDONE_POS     31
+
+#define XEC_I2C_ISC_OFS         0x24U /* fairness idle time scaling */
+#define XEC_I2C_ISC_FBI_POS     0
+#define XEC_I2C_ISC_FBI_MSK     GENMASK(11, 0)
+#define XEC_I2C_ISC_FBI_SET(n)  FIELD_PREP(XEC_I2C_ISC_FBI_MSK, (n))
+#define XEC_I2C_ISC_FBI_GET(r)  FIELD_GET(XEC_I2C_ISC_FBI_MSK, (r))
+#define XEC_I2C_ISC_FIDD_POS    16
+#define XEC_I2C_ISC_FIDD_MSK    GENMASK(27, 16)
+#define XEC_I2C_ISC_FIDD_SET(n) FIELD_PREP(XEC_I2C_ISC_FIDD_MSK, (n))
+#define XEC_I2C_ISC_FIDD_GET(r) FIELD_GET(XEC_I2C_ISC_FIDD_MSK, (r))
+
+#define XEC_I2C_CFG_OFS            0x28U
+#define XEC_I2C_CFG_PORT_POS       0
+#define XEC_I2C_CFG_PORT_MSK       GENMASK(3, 0)
+#define XEC_I2C_CFG_PORT_SET(p)    FIELD_PREP(XEC_I2C_CFG_PORT_MSK, (p))
+#define XEC_I2C_CFG_PORT_GET(r)    FIELD_GET(XEC_I2C_CFG_PORT_MSK, (r))
+#define XEC_I2C_CFG_TCEN_POS       4
+#define XEC_I2C_CFG_SLOW_CLK_POS   5
+#define XEC_I2C_CFG_PECEN_POS      7
+#define XEC_I2C_CFG_FEN_POS        8
+#define XEC_I2C_CFG_RST_POS        9
+#define XEC_I2C_CFG_ENAB_POS       10
+#define XEC_I2C_CFG_DSA_POS        11
+#define XEC_I2C_CFG_FAIR_POS       12
+#define XEC_I2C_CFG_GC_DIS_POS     14
+#define XEC_I2C_CFG_PROM_EN_POS    15
+#define XEC_I2C_CFG_FTTX_POS       16 /* WO */
+#define XEC_I2C_CFG_FTRX_POS       17 /* WO */
+#define XEC_I2C_CFG_FHTX_POS       18 /* WO */
+#define XEC_I2C_CFG_FHRX_POS       19 /* WO */
+#define XEC_I2C_CFG_STD_IEN_POS    24 /* v3.8 HW only */
+#define XEC_I2C_CFG_STD_NL_IEN_POS 27 /* v3.8 HW only */
+#define XEC_I2C_CFG_AAT_IEN_POS    28
+#define XEC_I2C_CFG_IDLE_IEN_POS   29
+#define XEC_I2C_CFG_HD_IEN_POS     30
+#define XEC_I2C_CFG_TD_IEN_POS     31
+
+#define XEC_I2C_CFG_MAX_PORT 16
+
+#define XEC_I2C_BCLK_OFS        0x2cU /* bus clock */
+#define XEC_I2C_BCLK_LOP_POS    0
+#define XEC_I2C_BCLK_LOP_MSK    GENMASK(7, 0)
+#define XEC_I2C_BCLK_LOP_SET(n) FIELD_PREP(XEC_I2C_BCLK_LOP_MSK, (n))
+#define XEC_I2C_BCLK_LOP_GET(r) FIELD_GET(XEC_I2C_BCLK_LOP_MSK, (r))
+#define XEC_I2C_BCLK_HIP_POS    8
+#define XEC_I2C_BCLK_HIP_MSK    GENMASK(15, 8)
+#define XEC_I2C_BCLK_HIP_SET(n) FIELD_PREP(XEC_I2C_BCLK_HIP_MSK, (n))
+#define XEC_I2C_BCLK_HIP_GET(r) FIELD_GET(XEC_I2C_BCLK_HIP_MSK, (r))
+
+#define XEC_I2C_BLKID_OFS 0x30U /* RO HW block ID */
+#define XEC_I2C_REV_OFS   0x34U /* RO HW revision */
+
+#define XEC_I2C_BBCR_OFS        0x38U /* bit-bang control */
+#define XEC_I2C_BBCR_EN_POS     0     /* MUX SCL/SDA pins from I2C to BB logic */
+#define XEC_I2C_BBCR_CD_POS     1
+#define XEC_I2C_BBCR_DD_POS     2
+#define XEC_I2C_BBCR_SCL_POS    3
+#define XEC_I2C_BBCR_SDA_POS    4
+#define XEC_I2C_BBCR_SCL_IN_POS 5
+#define XEC_I2C_BBCR_SDA_IN_POS 6
+#define XEC_I2C_BBCR_CM_POS     7 /* ver3.8 only */
+
+#define XEC_I2C_MR0_OFS 0x3cU /* MCHP reserved 0 */
+
+#define XEC_I2C_DT_OFS         0x40U /* data timing */
+#define XEC_I2C_DT_DH_POS      0
+#define XEC_I2C_DT_DH_MSK      GENMASK(7, 0)
+#define XEC_I2C_DT_DH_SET(n)   FIELD_PREP(XEC_I2C_DT_DH_MSK, (n))
+#define XEC_I2C_DT_DH_GET(r)   FIELD_GET(XEC_I2C_DT_DH_MSK, (r))
+#define XEC_I2C_DT_RSS_POS     8
+#define XEC_I2C_DT_RSS_MSK     GENMASK(15, 8)
+#define XEC_I2C_DT_RSS_SET(n)  FIELD_PREP(XEC_I2C_DT_RSS_MSK, (n))
+#define XEC_I2C_DT_RSS_GET(r)  FIELD_GET(XEC_I2C_DT_RSS_MSK, (r))
+#define XEC_I2C_DT_STPS_POS    16
+#define XEC_I2C_DT_STPS_MSK    GENMASK(23, 16)
+#define XEC_I2C_DT_STPS_SET(n) FIELD_PREP(XEC_I2C_DT_STPS_MSK, (n))
+#define XEC_I2C_DT_STPS_GET(r) FIELD_GET(XEC_I2C_DT_STPS_MSK, (r))
+#define XEC_I2C_DT_FSH_POS     24
+#define XEC_I2C_DT_FSH_MSK     GENMASK(31, 24)
+#define XEC_I2C_DT_FSH_SET(n)  FIELD_PREP(XEC_I2C_DT_FSH_MSK, (n))
+#define XEC_I2C_DT_FSH_GET(r)  FIELD_GET(XEC_I2C_DT_FSH_MSK, (r))
+
+#define XEC_I2C_TMOUT_SC_OFS         0x44U /* timeout scaling */
+#define XEC_I2C_TMOUT_SC_CHTO_POS    0
+#define XEC_I2C_TMOUT_SC_CHTO_MSK    GENMASK(7, 0)
+#define XEC_I2C_TMOUT_SC_CHTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_CHTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_CHTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_CHTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_TCTO_POS    8
+#define XEC_I2C_TMOUT_SC_TCTO_MSK    GENMASK(15, 8)
+#define XEC_I2C_TMOUT_SC_TCTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_TCTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_TCTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_TCTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_HCTO_POS    16
+#define XEC_I2C_TMOUT_SC_HCTO_MSK    GENMASK(23, 16)
+#define XEC_I2C_TMOUT_SC_HCTO_SET(n) FIELD_PREP(XEC_I2C_TMOUT_SC_HCTO_MSK, (n))
+#define XEC_I2C_TMOUT_SC_HCTO_GET(r) FIELD_GET(XEC_I2C_TMOUT_SC_HCTO_MSK, (r))
+#define XEC_I2C_TMOUT_SC_BIM_POS     24
+#define XEC_I2C_TMOUT_SC_BIM_MSK     GENMASK(31, 24)
+#define XEC_I2C_TMOUT_SC_BIM_SET(n)  FIELD_PREP(XEC_I2C_TMOUT_SC_BIM_MSK, (n))
+#define XEC_I2C_TMOUT_SC_BIM_GET(r)  FIELD_GET(XEC_I2C_TMOUT_SC_BIM_MSK, (r))
+
+/* 8-bit data register for network layer mode */
+#define XEC_I2C_TTX_OFS 0x48U /* network layer mode target transmit */
+#define XEC_I2C_TRX_OFS 0x4cU /* network layer mode target receive */
+#define XEC_I2C_HTX_OFS 0x50U /* network layer mode host transmit */
+#define XEC_I2C_HRX_OFS 0x54U /* network layer mode host receive */
+
+#define XEC_I2C_IFSM_OFS                  0x58U /* RO I2C HW FSM */
+#define XEC_I2C_IFSM_HM_ST_POS            0
+#define XEC_I2C_IFSM_HM_ST_MSK            GENMASK(7, 0)
+#define XEC_I2C_IFSM_HM_ST_IDLE           0
+#define XEC_I2C_IFSM_HM_ST_W4STA          1U
+#define XEC_I2C_IFSM_HM_ST_TXADDR         2U
+#define XEC_I2C_IFSM_HM_ST_CHK_AACK       3U
+#define XEC_I2C_IFSM_HM_ST_RXDATA         4U /* debug I2C0 was here */
+#define XEC_I2C_IFSM_HM_ST_CHK_DACK       5U
+#define XEC_I2C_IFSM_HM_ST_TXDATA         6U
+#define XEC_I2C_IFSM_HM_ST_TXDATA_LD      7U
+#define XEC_I2C_IFSM_HM_ST_W4ACK          8U
+#define XEC_I2C_IFSM_HM_ST_W4STO          9U
+#define XEC_I2C_IFSM_HM_ST_LARB           10U
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA      11U
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA_DLY1 12U
+#define XEC_I2C_IFSM_HM_ST_LARB_RSTA_DLY2 13U
+#define XEC_I2C_IFSM_HM_ST_W4STA_HLD      14U
+#define XEC_I2C_IFSM_HM_ST_GET(r)         FIELD_GET(XEC_I2C_IFSM_HM_ST_MSK, (r))
+
+#define XEC_I2C_IFSM_TM_ST_POS     8
+#define XEC_I2C_IFSM_TM_ST_MSK     GENMASK(15, 8)
+#define XEC_I2C_IFSM_TM_ST_IDLE    0
+#define XEC_I2C_IFSM_TM_ST_HDRACK  1U
+#define XEC_I2C_IFSM_TM_ST_TXDATA  2U
+#define XEC_I2C_IFSM_TM_ST_W4ACK   3U
+#define XEC_I2C_IFSM_TM_ST_RXDATA  4U
+#define XEC_I2C_IFSM_TM_ST_ACKDATA 5U
+#define XEC_I2C_IFSM_TM_ST_GET(r)  FIELD_GET(XEC_I2C_IFSM_TM_ST_MSK, (r))
+
+#define XEC_I2C_IFSM_PHY_POS     16
+#define XEC_I2C_IFSM_PHY_MSK     GENMASK(19, 16)
+#define XEC_I2C_IFSM_PHY_IDLE    0
+#define XEC_I2C_IFSM_PHY_CLKHI   1U
+#define XEC_I2C_IFSM_PHY_STA_STO 2U
+#define XEC_I2C_IFSM_PHY_CLKLO   3U
+#define XEC_I2C_IFSM_PHY_SDATCR  4U
+#define XEC_I2C_IFSM_PHY_ARBLOSS 5U
+#define XEC_I2C_IFSM_PHY_GET(r)  FIELD_GET(XEC_I2C_IFSM_TM_PHY_MSK, (r))
+
+#define XEC_I2C_IFSM_HMCTO_POS    20
+#define XEC_I2C_IFSM_HMCTO_MSK    GENMASK(23, 20)
+#define XEC_I2C_IFSM_HMCTO_IDLE   0
+#define XEC_I2C_IFSM_HMCTO_CNT    1U
+#define XEC_I2C_IFSM_HMCTO_GET(r) FIELD_GET(XEC_I2C_IFSM_HMCTO_MSK, (r))
+
+#define XEC_I2C_IFSM_SMCTO_POS    24
+#define XEC_I2C_IFSM_SMCTO_MSK    GENMASK(27, 24)
+#define XEC_I2C_IFSM_SMCTO_IDLE   0
+#define XEC_I2C_IFSM_SMCTO_CNT    1U
+#define XEC_I2C_IFSM_SMCTO_GET(r) FIELD_GET(XEC_I2C_IFSM_SMCTO_MSK, (r))
+
+#define XEC_I2C_IFSM_TMBI_POS    28
+#define XEC_I2C_IFSM_TMBI_MSK    GENMASK(31, 28)
+#define XEC_I2C_IFSM_TMBI_IDLE   0
+#define XEC_I2C_IFSM_TMBI_CNT    1U
+#define XEC_I2C_IFSM_TMBI_GET(r) FIELD_GET(XEC_I2C_IFSM_TMBI_MSK, (r))
+
+#define XEC_I2C_NFSM_OFS               0x5cu /* RO Network layer mode HW FSM */
+#define XEC_I2C_NFSM_HC_STATE_POS      0
+#define XEC_I2C_NFSM_HC_STATE_MSK      GENMASK(7, 0)
+#define XEC_I2C_NFSM_HC_STATE_IDLE     0
+#define XEC_I2C_NFSM_HC_STATE_SOP      1U
+#define XEC_I2C_NFSM_HC_STATE_STA      2U
+#define XEC_I2C_NFSM_HC_STATE_STA_PIN  3U
+#define XEC_I2C_NFSM_HC_STATE_WDATA    4U
+#define XEC_I2C_NFSM_HC_STATE_WPEC     5U
+#define XEC_I2C_NFSM_HC_STATE_RSTA     6U
+#define XEC_I2C_NFSM_HC_STATE_RSTA_PIN 7U
+#define XEC_I2C_NFSM_HC_STATE_RDN      8U
+#define XEC_I2C_NFSM_HC_STATE_RD_PEC   9U
+#define XEC_I2C_NFSM_HC_STATE_RPEC     10U
+#define XEC_I2C_NFSM_HC_STATE_PAUSE    11U
+#define XEC_I2C_NFSM_HC_STATE_STO      12U
+#define XEC_I2C_NFSM_HC_STATE_EOP      13U
+#define XEC_I2C_NFSM_HC_STATE_GET(r)   FIELD_GET(XEC_I2C_NFSM_HC_STATE_MSK, (r))
+#define XEC_I2C_NFSM_TC_STATE_POS      8
+#define XEC_I2C_NFSM_TC_STATE_MSK      GENMASK(15, 8)
+#define XEC_I2C_NFSM_TC_STATE_IDLE     0
+#define XEC_I2C_NFSM_TC_STATE_ADDR     1U
+#define XEC_I2C_NFSM_TC_STATE_WPIN     2U
+#define XEC_I2C_NFSM_TC_STATE_RPIN     3U
+#define XEC_I2C_NFSM_TC_STATE_WDATA    4U
+#define XEC_I2C_NFSM_TC_STATE_RDATA    5U
+#define XEC_I2C_NFSM_TC_STATE_RBE      6U
+#define XEC_I2C_NFSM_TC_STATE_RPEC     7U
+#define XEC_I2C_NFSM_TC_STATE_RPECRPT  8U
+#define XEC_I2C_NFSM_TC_STATE_GET(r)   FIELD_GET(XEC_I2C_NFSM_TC_STATE_MSK, (r))
+#define XEC_I2C_NFSM_FAIR_POS          16
+#define XEC_I2C_NFSM_FAIR_MSK          GENMASK(23, 16)
+#define XEC_I2C_NFSM_FAIR_IDLE         0
+#define XEC_I2C_NFSM_FAIR_BUSY         1U
+#define XEC_I2C_NFSM_FAIR_WIN          2U
+#define XEC_I2C_NFSM_FAIR_DLY          3U
+#define XEC_I2C_NFSM_FAIR_WAIT         4U
+#define XEC_I2C_NFSM_FAIR_WAIT_DONE    5U
+#define XEC_I2C_NFSM_FAIR_ACTIVE       6U
+
+#define XEC_I2C_WKSR_OFS    0x60U /* wake status */
+#define XEC_I2C_WKSR_SB_POS 0     /* start bit detected R/W1C */
+
+#define XEC_I2C_WKCR_OFS      0x64U /* wake control */
+#define XEC_I2C_WKCR_SBEN_POS 0     /* start bit detection interrupt enable */
+
+#define XEC_I2C_MR1_OFS 0x68U /* MCHP reserved 1 */
+
+#define XEC_I2C_IAS_OFS 0x6cU /* RO I2C address shadow */
+
+#define XEC_I2C_PIS_OFS     0x70U /* I2C promiscuous mode interrupt status */
+/* I2C has captured 8 address bits and is stretching the clock
+ * software sets HW to (n)ACK
+ */
+#define XEC_I2C_PIS_CAP_POS 0
+
+#define XEC_I2C_PIE_OFS     0x74U /* I2C promiscuous mode interrupt enable */
+#define XEC_I2C_PIE_CAP_POS 0
+
+#define XEC_I2C_PCR_OFS     0x78U /* I2C promiscuous mode control */
+#define XEC_I2C_PCR_ACK_POS 0     /* write 1 to ACK the captured address */
+
+#define XEC_I2C_IDS_OFS 0x7cU /* RO I2C data shadow */
+
+#define XEC_I2C_SMB_DATA_TM_100K 0x0C4D5006U
+#define XEC_I2C_SMB_IDLE_SC_100K 0x01FC01EDU
+#define XEC_I2C_SMB_TMO_SC_100K  0x4B9CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_100K 0x4F4FU
+#define XEC_I2C_SMB_RSHT_100K    0x4DU
+
+#define XEC_I2C_SMB_DATA_TM_400K 0x040A0A06U
+#define XEC_I2C_SMB_IDLE_SC_400K 0x01000050U
+#define XEC_I2C_SMB_TMO_SC_400K  0x159CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_400K 0x0F17U
+#define XEC_I2C_SMB_RSHT_400K    0x0AU
+
+#define XEC_I2C_SMB_DATA_TM_1M 0x04060601U
+#define XEC_I2C_SMB_IDLE_SC_1M 0x10000050U
+#define XEC_I2C_SMB_TMO_SC_1M  0x089CC2C7U
+#define XEC_I2C_SMB_BUS_CLK_1M 0x0509U
+#define XEC_I2C_SMB_RSHT_1M    0x06U
+
+#define XEC_I2C_NL_MAX_LEN 0xfff8U
+
+#define XEC_I2C_MAX_PORTS (((XEC_I2C_CFG_PORT_MSK) >> (XEC_I2C_CFG_PORT_POS)) + 1U)
+
+#endif /* ZEPHYR_SOC_MICROCHIP_MEC_COMMON_XEC_I2C_REGS_H_ */

--- a/drivers/i2c/i2c_mchp_xec_v3.c
+++ b/drivers/i2c/i2c_mchp_xec_v3.c
@@ -1,0 +1,1940 @@
+/*
+ * Copyright (c) 2026 Microchip Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_xec_i2c_v3
+
+#include <soc.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(i2c_xec_v3, CONFIG_I2C_LOG_LEVEL);
+
+#include "i2c-priv.h"
+#include "i2c_mchp_xec_regs.h"
+
+/* Microchip MEC I2C controller using byte mode.
+ * This driver is for HW version 3.8 and above.
+ */
+
+#define RESET_WAIT_US 20
+
+/* I2C timeout is  10 ms (WAIT_INTERVAL * WAIT_COUNT) */
+#define WAIT_INTERVAL   50
+#define WAIT_COUNT      200
+#define STOP_WAIT_COUNT 500
+#define PIN_CFG_WAIT    50
+
+/* I2C recover SCL low retries */
+#define I2C_XEC_RECOVER_SCL_LOW_RETRIES 10
+/* I2C recover SDA low retries */
+#define I2C_XEC_RECOVER_SDA_LOW_RETRIES 3
+/* I2C recovery bit bang delay */
+#define I2C_XEC_RECOVER_BB_DELAY_US     5
+/* I2C recovery SCL sample delay */
+#define I2C_XEC_RECOVER_SCL_DELAY_US    50
+
+#define I2C_XEC_CTRL_WR_DLY 8
+
+/* get_lines bit positions */
+#define XEC_I2C_SCL_LINE_POS 0
+#define XEC_I2C_SDA_LINE_POS 1
+#define XEC_I2C_LINES_MSK    (BIT(XEC_I2C_SCL_LINE_POS) | BIT(XEC_I2C_SDA_LINE_POS))
+
+#define XEC_I2C_CR_PIN_ESO_ACK                                                                     \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ACK_POS))
+
+#define XEC_I2C_CR_PIN_ESO_ENI_ACK (XEC_I2C_CR_PIN_ESO_ACK | BIT(XEC_I2C_CR_ENI_POS))
+
+#define XEC_I2C_CR_START                                                                           \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STA_POS) |             \
+	 BIT(XEC_I2C_CR_ACK_POS))
+
+#define XEC_I2C_CR_START_ENI (XEC_I2C_CR_START | BIT(XEC_I2C_CR_ENI_POS))
+
+#define XEC_I2C_CR_RPT_START                                                                       \
+	(BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STA_POS) | BIT(XEC_I2C_CR_ACK_POS))
+
+#define XEC_I2C_CR_RPT_START_ENI (XEC_I2C_CR_RPT_START | BIT(XEC_I2C_CR_ENI_POS))
+
+#define XEC_I2C_CR_STOP                                                                            \
+	(BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_STO_POS) |             \
+	 BIT(XEC_I2C_CR_ACK_POS))
+
+#define XEC_I2C_TM_HOST_READ_IGNORE_VAL 0xffu
+
+#define XEC_I2C_TM_REGISTER_WAIT_MS 1000u
+
+#define XEC_I2C_TM_SHAD_ADDR_ANOMALY
+#define XEC_I2C_TM_SHAD_ADDR_ANOMALY_WAIT_US 20
+
+#define XEC_I2C_GIRQ_DIS 0
+#define XEC_I2C_GIRQ_EN  1U
+
+/* I2C controller bit position in wake GIRQ is offset by 1 */
+#define XEC_I2C_GIRQ_WK_BIT_OFS 1U
+
+/* I2C idle interrupt timeout in milliseconds */
+#define XEC_I2C_IDLE_TIMEOUT_MS 100U
+
+/* I2C transfer timeout in milliseconds */
+#define XEC_I2C_XFR_TIMEOUT_MS 100U
+
+enum xec_i2c_state {
+	XEC_I2C_STATE_CLOSED = 0,
+	XEC_I2C_STATE_OPEN,
+};
+
+enum xec_i2c_error {
+	XEC_I2C_ERR_NONE = 0,
+	XEC_I2C_ERR_BUS,
+	XEC_I2C_ERR_LOST_ARB,
+	XEC_I2C_ERR_TIMEOUT,
+};
+
+enum xec_i2c_direction {
+	XEC_I2C_DIR_NONE = 0,
+	XEC_I2C_DIR_WR,
+	XEC_I2C_DIR_RD,
+};
+
+enum xec_i2c_start {
+	XEC_I2C_START_NONE = 0,
+	XEC_I2C_START_NORM,
+	XEC_I2C_START_RPT,
+};
+
+enum i2c_xec_isr_state {
+	I2C_XEC_ISR_STATE_GEN_START = 0,
+	I2C_XEC_ISR_STATE_CHK_ACK,
+	I2C_XEC_ISR_STATE_WR_DATA,
+	I2C_XEC_ISR_STATE_RD_DATA,
+	I2C_XEC_ISR_STATE_GEN_STOP,
+	I2C_XEC_ISR_STATE_EV_IDLE,
+	I2C_XEC_ISR_STATE_NEXT_MSG,
+	I2C_XEC_ISR_STATE_EXIT_1,
+#ifdef CONFIG_I2C_TARGET
+	I2C_XEC_ISR_STATE_TM_HOST_RD,
+	I2C_XEC_ISR_STATE_TM_HOST_WR,
+	I2C_XEC_ISR_STATE_TM_EV_STOP,
+#endif
+	I2C_XEC_ISR_STATE_MAX
+};
+
+enum i2c_xec_std_freq {
+	XEC_I2C_STD_FREQ_100K = 0,
+	XEC_I2C_STD_FREQ_400K,
+	XEC_I2C_STD_FREQ_1M,
+	XEC_I2C_STD_FREQ_MAX,
+};
+
+struct xec_i2c_timing {
+	uint32_t freq_hz;
+	uint32_t data_tm;    /* data timing  */
+	uint32_t idle_sc;    /* idle scaling */
+	uint32_t timeout_sc; /* timeout scaling */
+	uint32_t bus_clock;  /* bus clock hi/lo pulse widths */
+	uint8_t rpt_sta_htm; /* repeated start hold time */
+};
+
+struct i2c_xec_v3_config {
+	mem_addr_t base;
+	uint32_t clock_freq;
+	struct gpio_dt_spec sda_gpio;
+	struct gpio_dt_spec scl_gpio;
+	const struct pinctrl_dev_config *pcfg;
+	void (*irq_config_func)(void);
+	uint8_t girq;
+	uint8_t girq_pos;
+	uint8_t enc_pcr;
+	uint8_t port;
+#ifdef CONFIG_I2C_TARGET
+	uint8_t wakeup_source;
+#endif
+};
+
+#define I2C_XEC_XFR_FLAG_START_REQ 0x01
+#define I2C_XEC_XFR_FLAG_STOP_REQ  0x02
+
+#define I2C_XEC_XFR_STS_NACK 0x01
+#define I2C_MEC5_XFR_STS_BER 0x02
+#define I2C_MEC5_XFR_STS_LAB 0x04
+
+struct i2c_xec_cm_xfr {
+	volatile uint8_t *mbuf;
+	volatile size_t mlen;
+	volatile uint8_t xfr_sts;
+	uint8_t mdir;
+	uint8_t target_addr;
+	uint8_t mflags;
+};
+
+#define I2C_XEC_TARG_PROG0_IDX    0
+#define I2C_XEC_TARG_PROG1_IDX    1
+#define I2C_XEC_TARG_SMB_HA_IDX   2
+#define I2C_XEC_TARG_SMB_DA_IDX   3
+#define I2C_XEC_TARG_GEN_CALL_IDX 4
+#define I2C_XEC_TARG_ADDR_MAX     5
+
+#define I2C_XEC_TARG_BITMAP_MSK 0x1fu
+
+struct i2c_xec_target {
+	uint16_t targ_addr;
+	uint8_t targ_data;
+	uint8_t targ_ignore;
+	uint8_t targ_active;
+	uint8_t targ_bitmap;
+	uint8_t *targ_buf_ptr;
+	uint32_t targ_buf_len;
+	struct i2c_target_config *curr_target;
+	struct i2c_target_config *tcfgs[I2C_XEC_TARG_ADDR_MAX];
+};
+
+struct i2c_xec_v3_data {
+	struct k_work kworkq;
+	const struct device *dev;
+	struct k_mutex lock_mut;
+	struct k_sem sync_sem;
+	uint32_t i2c_config;
+	uint32_t clock_freq;
+	uint32_t i2c_compl;
+	uint8_t i2c_cr_shadow;
+	uint8_t i2c_sr;
+	uint8_t port_sel;
+	uint8_t wraddr;
+	uint8_t state;
+	uint8_t cm_dir;
+	uint8_t msg_idx;
+	uint8_t num_msgs;
+	struct i2c_msg *msgs;
+	struct i2c_xec_cm_xfr cm_xfr;
+	volatile uint8_t mdone;
+#ifdef CONFIG_I2C_TARGET
+	struct i2c_xec_target tg;
+#endif
+};
+
+static const struct xec_i2c_timing xec_i2c_timing_tbl[] = {
+	{KHZ(100), XEC_I2C_SMB_DATA_TM_100K, XEC_I2C_SMB_IDLE_SC_100K, XEC_I2C_SMB_TMO_SC_100K,
+	 XEC_I2C_SMB_BUS_CLK_100K, XEC_I2C_SMB_RSHT_100K},
+	{KHZ(400), XEC_I2C_SMB_DATA_TM_400K, XEC_I2C_SMB_IDLE_SC_400K, XEC_I2C_SMB_TMO_SC_400K,
+	 XEC_I2C_SMB_BUS_CLK_400K, XEC_I2C_SMB_RSHT_400K},
+	{MHZ(1), XEC_I2C_SMB_DATA_TM_1M, XEC_I2C_SMB_IDLE_SC_1M, XEC_I2C_SMB_TMO_SC_1M,
+	 XEC_I2C_SMB_BUS_CLK_1M, XEC_I2C_SMB_RSHT_1M},
+};
+
+static int xec_i2c_prog_standard_timing(const struct device *dev, uint32_t freq_hz)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	for (size_t n = 0; n < ARRAY_SIZE(xec_i2c_timing_tbl); n++) {
+		const struct xec_i2c_timing *p = &xec_i2c_timing_tbl[n];
+
+		if (freq_hz == p->freq_hz) {
+			sys_write32(p->data_tm, rb + XEC_I2C_DT_OFS);
+			sys_write32(p->idle_sc, rb + XEC_I2C_ISC_OFS);
+			sys_write32(p->timeout_sc, rb + XEC_I2C_TMOUT_SC_OFS);
+			sys_write16(p->bus_clock, rb + XEC_I2C_BCLK_OFS);
+			sys_write8(p->rpt_sta_htm, rb + XEC_I2C_RSHT_OFS);
+
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static void xec_i2c_cr_write(const struct device *dev, uint8_t ctrl_val)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+
+	data->i2c_cr_shadow = ctrl_val;
+	sys_write8(ctrl_val, devcfg->base + XEC_I2C_CR_OFS);
+}
+
+#ifdef CONFIG_I2C_TARGET
+static void xec_i2c_cr_write_mask(const struct device *dev, uint8_t clr_msk, uint8_t set_msk)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+
+	data->i2c_cr_shadow = (data->i2c_cr_shadow & (uint8_t)~clr_msk) | set_msk;
+	sys_write8(data->i2c_cr_shadow, devcfg->base + XEC_I2C_CR_OFS);
+}
+#endif
+
+static int wait_bus_free(const struct device *dev, uint32_t nwait)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	uint32_t count = nwait;
+	uint8_t sts = 0;
+
+	while (count--) {
+		sts = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_sr = sts;
+
+		if ((sts & BIT(XEC_I2C_SR_NBB_POS)) != 0) {
+			break; /* bus is free */
+		}
+
+		k_busy_wait(WAIT_INTERVAL);
+	}
+
+	/* check for bus error, lost arbitration or external stop */
+	if (sts == (BIT(XEC_I2C_SR_NBB_POS) | BIT(XEC_I2C_SR_PIN_POS))) {
+		return 0;
+	}
+
+	/* Bus error: caller must reset controller and if need a bus recovery */
+	if ((sts & BIT(XEC_I2C_SR_BER_POS)) != 0) {
+		return -EIO;
+	}
+
+	/* Lost arbitration: this controller attempted to generate START when
+	 * its NBB=0 indicating the bus is busy (SCL/SDA are not idle) then LAB
+	 * is set in I2C.STATUS. Return value indicates our HW stopped the transaction
+	 * to prevent contention.
+	 */
+	if ((sts & BIT(XEC_I2C_SR_LAB_POS)) != 0) {
+		return -ECONNABORTED;
+	}
+
+	return -ETIMEDOUT;
+}
+
+/* return 0 if SCL and SDA are both high else return -EIO */
+#if defined(CONFIG_SOC_SERIES_MEC172X)
+static int check_lines(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	gpio_port_value_t sda = 0, scl = 0;
+
+	gpio_port_get_raw(devcfg->sda_gpio.port, &sda);
+	scl = sda;
+	if (devcfg->sda_gpio.port != devcfg->scl_gpio.port) {
+		gpio_port_get_raw(devcfg->scl_gpio.port, &scl);
+	}
+
+	if ((sda & BIT(devcfg->sda_gpio.pin)) && (scl & BIT(devcfg->scl_gpio.pin))) {
+		return 0;
+	}
+
+	return -EIO;
+}
+
+/* returns uint8_t with bit[0] = SCL and bit[1] = SDA */
+static uint8_t get_lines(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	gpio_port_value_t sda = 0, scl = 0;
+	uint8_t lines = 0;
+
+	gpio_port_get_raw(devcfg->scl_gpio.port, &scl);
+	gpio_port_get_raw(devcfg->sda_gpio.port, &sda);
+
+	if ((sda & BIT(devcfg->scl_gpio.pin)) != 0) {
+		lines |= BIT(XEC_I2C_SCL_LINE_POS);
+	}
+
+	if ((sda & BIT(devcfg->sda_gpio.pin)) != 0) {
+		lines |= BIT(XEC_I2C_SDA_LINE_POS);
+	}
+
+	return lines;
+}
+#else
+static int check_lines(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	uint8_t himsk = BIT(XEC_I2C_BBCR_SCL_IN_POS) | BIT(XEC_I2C_BBCR_SDA_IN_POS);
+	uint8_t bbcr = 0;
+
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+	bbcr = sys_read8(rb + XEC_I2C_BBCR_OFS);
+
+	if ((bbcr & himsk) == himsk) {
+		return 0;
+	}
+
+	return -EIO;
+}
+
+/* returns uint8_t with bit[0] = SCL and bit[1] = SDA */
+static uint8_t get_lines(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	uint8_t bbcr = 0;
+	uint8_t lines = 0;
+
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+	bbcr = sys_read8(rb + XEC_I2C_BBCR_OFS);
+
+	if ((bbcr & BIT(XEC_I2C_BBCR_SCL_IN_POS)) != 0) {
+		lines |= BIT(XEC_I2C_SCL_LINE_POS);
+	}
+
+	if ((bbcr & BIT(XEC_I2C_BBCR_SDA_IN_POS)) != 0) {
+		lines |= BIT(XEC_I2C_SDA_LINE_POS);
+	}
+
+	return lines;
+}
+#endif
+
+#ifdef CONFIG_I2C_TARGET
+/* NOTE: index values are assigned.
+ * 0 = programmable address 0, 1 = programmable address 1
+ * 2 = I2C general call at target address 0
+ * 3 = SMBus host address at 0x08
+ * 4 = SMBus device address at 0x61
+ */
+static void prog_target_addresses(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mem_addr_t rb = devcfg->base;
+	uint32_t t = 0;
+
+	for (uint32_t n = 0; n < I2C_XEC_TARG_ADDR_MAX; n++) {
+		struct i2c_target_config *tcfg = ptg->tcfgs[n];
+
+		if (tcfg == NULL) {
+			continue;
+		}
+
+		if (tcfg->address == XEC_I2C_GEN_CALL_ADDR) {
+			sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+		} else if ((tcfg->address == XEC_I2C_SMB_HOST_ADDR) ||
+			   (tcfg->address == XEC_I2C_SMB_DEVICE_ADDR)) {
+			sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+		} else { /* Handle the two programmable target addresses */
+			t = XEC_I2C_OA_SET(n, tcfg->address);
+		}
+	}
+
+	if (t != 0) {
+		sys_write32(t, rb + XEC_I2C_OA_OFS);
+	}
+}
+#endif /* CONFIG_I2C_TARGET */
+
+static int i2c_xec_reset_config(const struct device *dev, uint32_t config, uint8_t port)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	uint32_t val = 0;
+	uint8_t crval = 0;
+
+	data->i2c_config = config;
+	data->port_sel = port;
+	data->i2c_cr_shadow = 0;
+
+	data->state = XEC_I2C_STATE_CLOSED;
+	data->i2c_cr_shadow = 0;
+	data->i2c_sr = 0;
+	data->i2c_compl = 0;
+	data->mdone = 0;
+	data->port_sel = port;
+
+	soc_xec_pcr_sleep_en_clear(devcfg->enc_pcr);
+	/* reset I2C controller using PCR reset feature */
+	soc_xec_pcr_reset_en(devcfg->enc_pcr);
+
+	/* make sure general call and SMBus target address decodes disabled */
+	sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+	sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+
+	crval = BIT(XEC_I2C_CR_PIN_POS);
+	xec_i2c_cr_write(dev, crval);
+
+#ifdef CONFIG_I2C_TARGET
+	prog_target_addresses(dev);
+#endif
+
+	/* timing registers */
+	xec_i2c_prog_standard_timing(dev, data->clock_freq);
+
+	/* enable output driver and ACK logic */
+	crval = XEC_I2C_CR_PIN_ESO_ENI_ACK;
+	xec_i2c_cr_write(dev, crval);
+
+	/* port and filter enable */
+	val = XEC_I2C_CFG_PORT_SET((uint32_t)port);
+	val |= BIT(XEC_I2C_CFG_FEN_POS);
+	sys_set_bits(rb + XEC_I2C_CFG_OFS, val);
+
+	/* Enable live monitoring of SDA and SCL. No effect on MEC15xx and MEC172x */
+	sys_write8(BIT(XEC_I2C_BBCR_CM_POS), rb + XEC_I2C_BBCR_OFS);
+
+	/* enable */
+	sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
+
+	/* wait for NBB=1, BER, LAB, or timeout */
+	return wait_bus_free(dev, WAIT_COUNT);
+}
+
+static int i2c_xec_bb_recover(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int ret = 0;
+	uint32_t cnt = I2C_XEC_RECOVER_SCL_LOW_RETRIES;
+	uint8_t bbcr = 0;
+	uint8_t lines = 0u;
+
+	i2c_xec_reset_config(dev, data->i2c_config, data->port_sel);
+
+	lines = get_lines(dev);
+	if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) {
+		return 0;
+	}
+
+	/* Disconnect SDL and SDA from I2C logic and connect to bit-bang logic */
+	bbcr = BIT(XEC_I2C_BBCR_EN_POS) | BIT(XEC_I2C_BBCR_CM_POS);
+	sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+
+	lines = get_lines(dev);
+
+	/* If SCL is low continue sampling hoping it will go high on its own */
+	while (!(lines & BIT(XEC_I2C_SCL_LINE_POS))) {
+		if (cnt) {
+			cnt--;
+		} else {
+			break;
+		}
+		k_busy_wait(I2C_XEC_RECOVER_SCL_DELAY_US);
+		lines = get_lines(dev);
+	}
+
+	lines = get_lines(dev);
+	if ((lines & BIT(XEC_I2C_SCL_LINE_POS)) == 0) {
+		ret = -EBUSY;
+		goto disable_bb_exit;
+	}
+
+	/* SCL is high, check SDA */
+	if ((lines & BIT(XEC_I2C_SDA_LINE_POS)) != 0) {
+		ret = 0; /* both high */
+		goto disable_bb_exit;
+	}
+
+	/* SCL is high and SDA is low. Loop generating 9 clocks until
+	 * we observe SDA high or loop terminates
+	 */
+	ret = -EBUSY;
+	for (int i = 0; i < I2C_XEC_RECOVER_SDA_LOW_RETRIES; i++) {
+		/* tri-state SCL & inputs */
+		bbcr = BIT(XEC_I2C_BBCR_CM_POS) | BIT(XEC_I2C_BBCR_EN_POS);
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+
+		/* 9 clocks */
+		for (int j = 0; j < 9; j++) {
+			/* drive SCL low  by SCL output drive low, SDA tri-state input */
+			bbcr = (BIT(XEC_I2C_BBCR_CM_POS) | BIT(XEC_I2C_BBCR_CD_POS) |
+				BIT(XEC_I2C_BBCR_EN_POS));
+			sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+			k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+			/* SCL & SDA tri-state inputs, external pull-up should pull signals high */
+			bbcr = BIT(XEC_I2C_BBCR_CM_POS) | BIT(XEC_I2C_BBCR_EN_POS);
+			sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+			k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+		}
+
+		lines = get_lines(dev);
+		if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) { /* Both high? */
+			ret = 0;
+			goto disable_bb_exit;
+		}
+
+		/* generate I2C STOP.  While SCL is high SDA transitions low to high */
+		/* SCL tri-state input (high), drive SDA low */
+		bbcr = (BIT(XEC_I2C_BBCR_CM_POS) | BIT(XEC_I2C_BBCR_DD_POS) |
+			BIT(XEC_I2C_BBCR_EN_POS));
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+		k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+		/* SCL and SDA tri-state inputs. */
+		bbcr = BIT(XEC_I2C_BBCR_CM_POS) | BIT(XEC_I2C_BBCR_EN_POS);
+		sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+		k_busy_wait(I2C_XEC_RECOVER_BB_DELAY_US);
+
+		lines = get_lines(dev);
+		if ((lines & XEC_I2C_LINES_MSK) == XEC_I2C_LINES_MSK) { /* Both high? */
+			ret = 0;
+			goto disable_bb_exit;
+		}
+	}
+
+disable_bb_exit:
+	bbcr = BIT(XEC_I2C_BBCR_CM_POS);
+	sys_write8(bbcr, rb + XEC_I2C_BBCR_OFS);
+
+	return ret;
+}
+
+static int i2c_xec_recover_bus(const struct device *dev)
+{
+	struct i2c_xec_v3_data *const data = dev->data;
+	int ret = 0;
+
+	LOG_ERR("I2C attempt bus recovery\n");
+
+	/* Try controller reset first */
+	ret = i2c_xec_reset_config(dev, data->i2c_config, data->port_sel);
+	if (ret == 0) {
+		return 0; /* controller reset cleared the error */
+	}
+
+	/* controller reporting error after reset, try bus recovery */
+	ret = i2c_xec_bb_recover(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return wait_bus_free(dev, WAIT_COUNT);
+}
+
+/* Configure I2C controller for speed and hardware port if parameters are support */
+static int i2c_xec_cfg(const struct device *dev, uint32_t dev_config_raw, uint8_t port)
+{
+	struct i2c_xec_v3_data *const data = dev->data;
+
+	if (port >= XEC_I2C_MAX_PORTS) {
+		return -EINVAL;
+	}
+
+	switch (I2C_SPEED_GET(dev_config_raw)) {
+	case I2C_SPEED_STANDARD:
+		data->clock_freq = KHZ(100);
+		break;
+	case I2C_SPEED_FAST:
+		data->clock_freq = KHZ(400);
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		data->clock_freq = MHZ(1);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return i2c_xec_reset_config(dev, dev_config_raw, port);
+}
+
+/* i2c_configure API */
+static int i2c_xec_configure(const struct device *dev, uint32_t dev_config_raw)
+{
+	struct i2c_xec_v3_data *const data = dev->data;
+	int rc = 0;
+
+	if (!(dev_config_raw & I2C_MODE_CONTROLLER)) {
+		return -ENOTSUP;
+	}
+
+	rc = k_mutex_lock(&data->lock_mut, K_NO_WAIT);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = i2c_xec_cfg(dev, dev_config_raw, data->port_sel);
+
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
+}
+
+/* MCHP XEC v3 specific APIs */
+int i2c_xec_v3_get_port(const struct device *dev, uint8_t *port)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+
+	if ((dev == NULL) || (port == NULL)) {
+		return -EINVAL;
+	}
+
+	if (k_mutex_lock(&data->lock_mut, K_NO_WAIT) != 0) {
+		return -EBUSY;
+	}
+
+	*port = (uint8_t)XEC_I2C_CFG_PORT_GET(sys_read32(rb + XEC_I2C_CFG_OFS));
+
+	k_mutex_unlock(&data->lock_mut);
+
+	return 0;
+}
+
+int i2c_xec_v3_configure(const struct device *dev, uint32_t config, uint8_t port)
+{
+	struct i2c_xec_v3_data *const data = dev->data;
+
+	if (dev == NULL) {
+		return -EINVAL;
+	}
+
+	if (k_mutex_lock(&data->lock_mut, K_NO_WAIT) != 0) {
+		return -EBUSY;
+	}
+
+	return i2c_xec_cfg(dev, config, port);
+}
+
+/* i2c_get_config API */
+static int i2c_xec_get_config(const struct device *dev, uint32_t *dev_config)
+{
+	struct i2c_xec_v3_data *const data = dev->data;
+	uint32_t dcfg = 0u;
+
+	if (dev_config == NULL) {
+		return -EINVAL;
+	}
+
+	dcfg = data->i2c_config;
+
+#ifdef CONFIG_I2C_TARGET
+	if (data->tg.targ_bitmap == 0) {
+		dcfg |= I2C_MODE_CONTROLLER;
+	} else {
+		dcfg &= ~I2C_MODE_CONTROLLER;
+	}
+#else
+	dcfg |= I2C_MODE_CONTROLLER;
+#endif
+	*dev_config = dcfg;
+
+	return 0;
+}
+
+/* XEC I2C controller support 7-bit addressing only.
+ * Format 7-bit address for as it appears on the bus as an 8-bit
+ * value with R/W bit at bit[0], 0(write), 1(read).
+ */
+static inline uint8_t i2c_xec_fmt_addr(uint16_t addr, uint8_t read)
+{
+	uint8_t fmt_addr = (uint8_t)((addr & XEC_I2C_TARGET_ADDR_MSK) << 1);
+
+	if (read != 0) {
+		fmt_addr |= BIT(0);
+	}
+
+	return fmt_addr;
+}
+
+/* I2C STOP only if controller owns the bus otherwise
+ * clear driver state and re-arm controller for next
+ * controller-mode or target-mode transaction.
+ * Reason for ugly code sequence:
+ * Brain-dead I2C controller has write-only control register
+ * containing enable interrupt bit. This is the enable for ACK/NACK,
+ * bus error and lost arbitration.
+ * NOTE: IDLE interrupt has issues. If it is enabled it can fire if the bus
+ * goes IDLE before we perform an action such as generate the STOP.
+ */
+static int i2c_xec_stop(const struct device *dev, uint32_t flags)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+	uint8_t ctrl = 0, sts = 0;
+
+	/* Is the bus busy? */
+	sts = sys_read8(rb + XEC_I2C_SR_OFS);
+	if ((sts & BIT(XEC_I2C_SR_NBB_POS)) == 0) {
+		data->mdone = 0;
+		ctrl = (BIT(XEC_I2C_CR_PIN_POS) | BIT(XEC_I2C_CR_ESO_POS) |
+			BIT(XEC_I2C_CR_STO_POS) | BIT(XEC_I2C_CR_ACK_POS));
+
+		/* disable IDLE interrupt in config register */
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+		/* clear IDLE R/W1C status in completion register */
+		sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+		/* clear GIRQ status */
+		soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+		/* generate STOP */
+		xec_i2c_cr_write(dev, ctrl);
+
+		if (flags & BIT(0)) { /* detect STOP completion with interrupt */
+			/* enable IDLE interrupt in config register */
+			sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+			rc = k_sem_take(&data->sync_sem, K_MSEC(XEC_I2C_IDLE_TIMEOUT_MS));
+		} else {
+			rc = wait_bus_free(dev, WAIT_COUNT);
+		}
+	}
+
+	data->cm_dir = XEC_I2C_DIR_NONE;
+	data->state = XEC_I2C_STATE_CLOSED;
+
+	return rc;
+}
+
+static int check_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	for (uint8_t n = 0u; n < num_msgs; n++) {
+		struct i2c_msg *m = &msgs[n];
+
+		if ((m->flags & I2C_MSG_ADDR_10_BITS) != 0) {
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int i2c_xec_xfr_begin(const struct device *dev, uint16_t addr)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	struct i2c_msg *m = data->msgs;
+	mem_addr_t rb = devcfg->base;
+	uint8_t target_addr = 0;
+	uint8_t ctrl = XEC_I2C_CR_START_ENI;
+	uint8_t start = XEC_I2C_START_NORM;
+
+	target_addr = i2c_xec_fmt_addr(addr, 0);
+	data->wraddr = target_addr;
+
+	if ((data->msgs[0].flags & I2C_MSG_READ) != 0) {
+		target_addr |= BIT(0);
+		xfr->mdir = XEC_I2C_DIR_RD;
+	} else {
+		xfr->mdir = XEC_I2C_DIR_WR;
+	}
+
+	data->mdone = 0;
+	xfr->mbuf = m->buf;
+	xfr->mlen = m->len;
+	xfr->xfr_sts = 0;
+	xfr->target_addr = target_addr;
+	xfr->mflags = I2C_XEC_XFR_FLAG_START_REQ;
+
+	if (((sys_read8(rb + XEC_I2C_SR_OFS) & BIT(XEC_I2C_SR_NBB_POS)) == 0) &&
+	    ((data->cm_dir != xfr->mdir) || (m->flags & I2C_MSG_RESTART))) {
+		start = XEC_I2C_START_RPT;
+		ctrl = XEC_I2C_CR_RPT_START_ENI;
+	}
+
+	data->cm_dir = xfr->mdir;
+	if (m->flags & I2C_MSG_STOP) {
+		xfr->mflags |= I2C_XEC_XFR_FLAG_STOP_REQ;
+	}
+
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	/* Generate (RPT)-START and transmit address for write or read */
+	if (ctrl == XEC_I2C_CR_START_ENI) { /* START? */
+		sys_write8(target_addr, rb + XEC_I2C_DATA_OFS);
+		xec_i2c_cr_write(dev, ctrl);
+	} else { /* RPT-START */
+		xec_i2c_cr_write(dev, ctrl);
+		sys_write8(target_addr, rb + XEC_I2C_DATA_OFS);
+	}
+
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_EN);
+
+	if (k_sem_take(&data->sync_sem, K_MSEC(XEC_I2C_XFR_TIMEOUT_MS)) != 0) {
+		return -ETIMEDOUT;
+	}
+
+	if (xfr->xfr_sts) { /* error */
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* i2c_transfer API - Synchronous using interrupts
+ * The call wrapper in i2c.h returns if num_msgs is 0.
+ * It does not check for msgs being a NULL pointer and accesses msgs.
+ * NOTE 1: Zephyr I2C documentation states an I2C driver can be switched
+ * between Host and Target modes by registering and unregistering targets.
+ * NOTE 2:
+ * XEC I2C controller supports up to 5 target addresses:
+ * Two address match registers.
+ * I2C general call (address 0). UNTESTED!
+ * Two SMBus fixed addresses defined in the SMBus spec. UNTESTED!
+ * We many need to remove general call and the two SMBus fixed address code logic!
+ */
+static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			    uint16_t addr)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *const data = dev->data;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+
+	k_mutex_lock(&data->lock_mut, K_FOREVER);
+#ifdef CONFIG_I2C_TARGET
+	if (data->tg.targ_bitmap != 0) {
+		k_mutex_unlock(&data->lock_mut);
+		return -EBUSY;
+	}
+#endif
+	pm_device_busy_set(dev);
+	k_sem_reset(&data->sync_sem);
+
+	memset(&data->cm_xfr, 0, sizeof(struct i2c_xec_cm_xfr));
+
+	rc = check_msgs(msgs, num_msgs);
+	if (rc != 0) {
+		goto xec_unlock;
+	}
+
+	if (data->state != XEC_I2C_STATE_OPEN) {
+		rc = check_lines(dev);
+		data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+
+		if (rc || (data->i2c_sr & BIT(XEC_I2C_SR_BER_POS))) {
+			rc = i2c_xec_recover_bus(dev);
+		}
+	}
+
+	if (rc) {
+		data->state = XEC_I2C_STATE_CLOSED;
+		goto xec_unlock;
+	}
+
+	data->state = XEC_I2C_STATE_OPEN;
+
+	data->msg_idx = 0;
+	data->num_msgs = num_msgs;
+	data->msgs = msgs;
+
+	rc = i2c_xec_xfr_begin(dev, addr);
+	if (rc) { /* if error issue STOP if bus is still owned by controller */
+		i2c_xec_stop(dev, 0);
+	}
+
+xec_unlock:
+	if ((sys_read8(rb + XEC_I2C_SR_OFS) & BIT(XEC_I2C_SR_NBB_POS)) == 0) {
+		data->cm_dir = XEC_I2C_DIR_NONE;
+		data->state = XEC_I2C_STATE_CLOSED;
+	}
+
+	pm_device_busy_clear(dev);
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
+}
+
+#ifdef CONFIG_I2C_TARGET
+static struct i2c_target_config *find_target(struct i2c_xec_v3_data *data, uint16_t i2c_addr)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+
+	if (i2c_addr == ptg->tcfgs[I2C_XEC_TARG_PROG0_IDX]->address) {
+		return ptg->tcfgs[I2C_XEC_TARG_PROG0_IDX];
+	}
+
+	if (i2c_addr == ptg->tcfgs[I2C_XEC_TARG_PROG1_IDX]->address) {
+		return ptg->tcfgs[I2C_XEC_TARG_PROG1_IDX];
+	}
+
+	if (i2c_addr == XEC_I2C_GEN_CALL_ADDR) {
+		return ptg->tcfgs[I2C_XEC_TARG_GEN_CALL_IDX];
+	}
+
+	if (i2c_addr == XEC_I2C_SMB_HOST_ADDR) {
+		return ptg->tcfgs[I2C_XEC_TARG_SMB_HA_IDX];
+	}
+
+	if (i2c_addr == XEC_I2C_SMB_DEVICE_ADDR) {
+		return ptg->tcfgs[I2C_XEC_TARG_SMB_DA_IDX];
+	}
+
+	return NULL;
+}
+
+/* I2C can respond to 3 fixed address and 2 configurable
+ * address 0x00 if GC_DIS == 0 in configuration register
+ * addresses 0x08 and 0x61 if DSA == 1 in configuration register
+ * Own addresses 1 and 2 which are programmable.
+ * NOTE: Zephyr uses target_register to enable target mode and
+ * target_unregister to disable target mode. The app will use
+ * these for switching between host and target modes.
+ * Since our HW supports multiple target, the app must unregister all
+ * targets before Host mode is allowed.
+ */
+static int check_targ_config(struct i2c_target_config *cfg)
+{
+	if (cfg == NULL) {
+		return -EINVAL;
+	}
+
+	if (((cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0) ||
+	    (cfg->address > XEC_I2C_TARGET_ADDR_MSK)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int target_i2c_gen_call(const struct device *dev, struct i2c_target_config *cfg,
+			       uint8_t enable)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mem_addr_t rb = devcfg->base;
+
+	if (enable != 0) {
+		if (ptg->tcfgs[I2C_XEC_TARG_GEN_CALL_IDX] != NULL) {
+			return -EEXIST;
+		}
+
+		ptg->tcfgs[I2C_XEC_TARG_GEN_CALL_IDX] = cfg;
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+		ptg->targ_bitmap |= BIT(I2C_XEC_TARG_GEN_CALL_IDX);
+	} else {
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_GC_DIS_POS);
+		ptg->tcfgs[I2C_XEC_TARG_GEN_CALL_IDX] = NULL;
+		ptg->targ_bitmap &= ~BIT(I2C_XEC_TARG_GEN_CALL_IDX);
+	}
+
+	return 0;
+}
+
+static int target_smb_hd(const struct device *dev, struct i2c_target_config *cfg, uint8_t enable,
+			 uint8_t targ_idx)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mem_addr_t rb = devcfg->base;
+
+	if (enable != 0) {
+		if (ptg->tcfgs[targ_idx] != NULL) {
+			return -EEXIST;
+		}
+
+		ptg->targ_bitmap |= BIT(targ_idx);
+		ptg->tcfgs[targ_idx] = cfg;
+
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+	} else {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_DSA_POS);
+		ptg->tcfgs[targ_idx] = NULL;
+		ptg->targ_bitmap &= ~BIT(targ_idx);
+	}
+
+	return 0;
+}
+
+/* MEC I2C controller own address register implements two 7-bit addresses located at
+ * bits[6:0] and bits[14:8].
+ */
+static int target_prog_addr(const struct device *dev, struct i2c_target_config *cfg, uint8_t en)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mem_addr_t rb = devcfg->base;
+	uint32_t oar = sys_read32(rb + XEC_I2C_OA_OFS);
+	uint32_t msk = XEC_I2C_TARGET_ADDR_MSK;
+	int rc = -EEXIST;
+	uint16_t oaddr = 0;
+	uint8_t pos = 0;
+
+	for (uint32_t n = 0; n < XEC_I2C_OA_NUM_TARGETS; n++) {
+		oaddr = (oar & msk) >> pos;
+		if (oaddr == 0) { /* address disabled? */
+			if (en != 0) {
+				ptg->tcfgs[n + I2C_XEC_TARG_PROG0_IDX] = cfg;
+				ptg->targ_bitmap |= BIT(I2C_XEC_TARG_PROG0_IDX + n);
+				soc_mmcr_mask_set(rb + XEC_I2C_OA_OFS, cfg->address, msk);
+				rc = 0;
+				break;
+			}
+		} else {
+			if ((oaddr == cfg->address) && (en == 0)) {
+				soc_mmcr_mask_set(rb + XEC_I2C_OA_OFS, 0, msk);
+				ptg->tcfgs[n + I2C_XEC_TARG_PROG0_IDX] = NULL;
+				ptg->targ_bitmap &= ~BIT(I2C_XEC_TARG_PROG0_IDX + n);
+				rc = 0;
+				break;
+			}
+		}
+
+		msk <<= 8;
+		pos += 8u;
+	}
+
+	return rc;
+}
+
+static int config_target_address(const struct device *dev, struct i2c_target_config *cfg,
+				 uint8_t enable)
+{
+	int rc = 0;
+
+	switch (cfg->address) {
+	case XEC_I2C_GEN_CALL_ADDR:
+		rc = target_i2c_gen_call(dev, cfg, enable);
+		break;
+	case XEC_I2C_SMB_HOST_ADDR:
+		rc = target_smb_hd(dev, cfg, enable, I2C_XEC_TARG_SMB_HA_IDX);
+		break;
+	case XEC_I2C_SMB_DEVICE_ADDR:
+		rc = target_smb_hd(dev, cfg, enable, I2C_XEC_TARG_SMB_DA_IDX);
+		break;
+	default:
+		rc = target_prog_addr(dev, cfg, enable);
+	}
+
+	return rc;
+}
+
+#if defined(CONFIG_PM_DEVICE)
+static void i2c_xec_target_arm_wake(const struct device *dev, bool arm_wake)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	if (arm_wake == true) {
+		sys_write32(BIT(XEC_I2C_WKSR_SB_POS), rb + XEC_I2C_WKSR_OFS); /* R/W1C */
+		sys_set_bit(rb + XEC_I2C_WKCR_OFS, XEC_I2C_WKCR_SBEN_POS);
+		soc_ecia_girq_status_clear(XEC_I2C_SMB_WK_GIRQ,
+					   devcfg->girq_pos + XEC_I2C_GIRQ_WK_BIT_OFS);
+		soc_ecia_girq_ctrl(XEC_I2C_SMB_WK_GIRQ, devcfg->girq_pos + XEC_I2C_GIRQ_WK_BIT_OFS,
+				   XEC_I2C_GIRQ_EN);
+	} else { /* disarm, resume path */
+		sys_clear_bit(rb + XEC_I2C_WKCR_OFS, XEC_I2C_WKCR_SBEN_POS);
+		sys_write32(BIT(XEC_I2C_WKSR_SB_POS), rb + XEC_I2C_WKSR_OFS);
+		soc_ecia_girq_ctrl(XEC_I2C_SMB_WK_GIRQ, devcfg->girq_pos + XEC_I2C_GIRQ_WK_BIT_OFS,
+				   XEC_I2C_GIRQ_DIS);
+		soc_ecia_girq_status_clear(XEC_I2C_SMB_WK_GIRQ,
+					   devcfg->girq_pos + XEC_I2C_GIRQ_WK_BIT_OFS);
+	}
+}
+#endif
+
+/* Register target specified by struct i2c_target_config
+ * Hardware supports two 7-bit target addresses and three fixed addresses.
+ * I2C general call address 0 controlled by enable bit in configuration registers
+ * SMBus Host address 0x08 and device address 0x61 controlled by one enable bit in the
+ * configuration register.
+ * 1. Check if i2c_target_config is valid. If valid take lock.
+ * 2. Check if struct i2c_target_config is currently registers, if so return 0.
+ * 3. Check if address is one of the fixed address if yes turn on the fixed address
+ * 4. Check if one of the two programmable addresses is available (0), if yes configure it
+ *    else return no address available (-ENOSPC).
+ * PM notes:
+ * PM and PM_DEVICE are mutually exclusive. If PM is enabled we must configure wake
+ * when registering a target because the kernel does inform drivers of PM state entry/exit.
+ * If PM_DEVICE is enabled we enable/disable wake in the PM callback registered with the kernel.
+ */
+static int i2c_xec_target_register(const struct device *dev, struct i2c_target_config *cfg)
+{
+	const struct i2c_xec_v3_config *drvcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mm_reg_t rb = drvcfg->base;
+	int rc = 0;
+
+	rc = check_targ_config(cfg);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = k_mutex_lock(&data->lock_mut, K_MSEC(XEC_I2C_TM_REGISTER_WAIT_MS));
+	if (rc != 0) {
+		return -EBUSY;
+	}
+
+	rc = config_target_address(dev, cfg, 1u);
+
+	if (ptg->targ_bitmap != 0) {
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_AAT_IEN_POS);
+		soc_ecia_girq_ctrl(drvcfg->girq, drvcfg->girq_pos, XEC_I2C_GIRQ_EN);
+	} else {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_AAT_IEN_POS);
+		soc_ecia_girq_ctrl(drvcfg->girq, drvcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+	}
+
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
+}
+
+static int i2c_xec_target_unregister(const struct device *dev, struct i2c_target_config *cfg)
+{
+	const struct i2c_xec_v3_config *drvcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	struct i2c_xec_target *ptg = &data->tg;
+	mm_reg_t rb = drvcfg->base;
+	int rc = 0;
+
+	rc = check_targ_config(cfg);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = k_mutex_lock(&data->lock_mut, K_MSEC(XEC_I2C_TM_REGISTER_WAIT_MS));
+	if (rc != 0) {
+		return -EBUSY;
+	}
+
+	rc = config_target_address(dev, cfg, 0);
+
+	if (ptg->targ_bitmap == 0) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_AAT_IEN_POS);
+		soc_ecia_girq_ctrl(drvcfg->girq, drvcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+	}
+
+	k_mutex_unlock(&data->lock_mut);
+
+	return rc;
+}
+#endif /* CONFIG_I2C_TARGET */
+
+/* ISR helpers and state handlers */
+static int i2c_xec_is_ber_lab(struct i2c_xec_v3_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+
+	if ((data->i2c_sr & (BIT(XEC_I2C_SR_BER_POS) | BIT(XEC_I2C_SR_LAB_POS))) != 0) {
+		if (data->i2c_sr & BIT(XEC_I2C_SR_BER_POS)) {
+			xfr->xfr_sts |= XEC_I2C_ERR_BUS;
+		} else {
+			xfr->xfr_sts |= XEC_I2C_ERR_LOST_ARB;
+		}
+
+		soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+		data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+		data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+		data->mdone = 0x51;
+
+		return 1;
+	}
+
+	return 0;
+}
+
+static int i2c_xec_next_msg(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	struct i2c_msg *m = NULL;
+	uint32_t idx = (uint32_t)data->msg_idx;
+
+	if (++idx >= (uint32_t)data->num_msgs) {
+		xfr->mbuf = NULL;
+		xfr->mlen = 0;
+		xfr->mflags = 0;
+		xfr->mdir = XEC_I2C_DIR_NONE;
+		return 0;
+	}
+
+	data->msg_idx = (uint8_t)(idx & 0xffu);
+	m = &data->msgs[idx];
+
+	xfr->mbuf = m->buf;
+	xfr->mlen = m->len;
+	xfr->mdir = XEC_I2C_DIR_WR;
+	xfr->mflags = 0;
+	xfr->target_addr = data->wraddr;
+
+	if ((m->flags & I2C_MSG_READ) != 0) {
+		xfr->mdir = XEC_I2C_DIR_RD;
+		xfr->target_addr |= BIT(0);
+	}
+
+	if ((m->flags & I2C_MSG_STOP) != 0) {
+		xfr->mflags = I2C_XEC_XFR_FLAG_STOP_REQ;
+	}
+
+	if (((m->flags & I2C_MSG_RESTART) != 0) || (data->cm_dir != xfr->mdir)) {
+		xfr->mflags |= I2C_XEC_XFR_FLAG_START_REQ;
+	}
+
+	data->cm_dir = xfr->mdir;
+
+	return 1;
+}
+
+#ifdef CONFIG_I2C_TARGET
+/* When address as a target, I2C hardware sets bits based on the matched target address.
+ * I2C.STATUS.AAT = 1
+ *   The received address  matches I2C general call or one of the two own addresses.
+ *   I2C.STATUS.LRB/AD0 = 0(own address match), 1(I2C general call)
+ *   If DSA is enable then we must check the actual received address value to determine
+ *   if it matches SMBus Host or Device address.
+ */
+
+static void xec_i2c_tm_host_rd_req(struct i2c_xec_v3_data *data,
+				   const struct i2c_target_callbacks *tcbs)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	if (((tcbs != NULL) && (tcbs->read_requested != NULL)) &&
+	    (tcbs->read_requested(ptg->curr_target, &ptg->targ_data) == 0)) {
+		ptg->targ_ignore = 0;
+	}
+
+	/* read & discard target address clears I2C.SR.AAT */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+	/* as target transmitter writing I2C.DATA releases clock stretching */
+	sys_write8(ptg->targ_data, rb + XEC_I2C_DATA_OFS);
+}
+
+static void xec_i2c_tm_host_wr_req(struct i2c_xec_v3_data *data,
+				   const struct i2c_target_callbacks *tcbs)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	if (((tcbs != NULL) && (tcbs->write_requested != NULL)) &&
+	    (tcbs->write_requested(ptg->curr_target) == 0)) {
+		ptg->targ_ignore = 0u;
+	}
+
+	if (ptg->targ_ignore != 0) {
+		xec_i2c_cr_write_mask(dev, BIT(XEC_I2C_CR_ACK_POS), 0);
+	}
+
+	/* as target receiver reading I2C.DATA releases clock stretching
+	 * and clears I2C.SR.AAT.
+	 */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+}
+
+static int state_check_ack_tm(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	const struct i2c_target_callbacks *tcbs = NULL;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+	uint16_t i2c_addr = 0;
+
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_AAT_POS)) != 0) {
+		/* enable STOP detect and IDLE interrupts */
+		sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+		sys_set_bits(rb + XEC_I2C_CFG_OFS,
+			     (BIT(XEC_I2C_CFG_IDLE_IEN_POS) | BIT(XEC_I2C_CFG_STD_IEN_POS)));
+
+#ifdef XEC_I2C_TM_SHAD_ADDR_ANOMALY
+		k_busy_wait(XEC_I2C_TM_SHAD_ADDR_ANOMALY_WAIT_US);
+#endif
+
+		ptg->targ_active = 1u;
+		ptg->targ_ignore = 1u;
+		ptg->targ_data = XEC_I2C_TM_HOST_READ_IGNORE_VAL;
+
+		ptg->targ_addr = sys_read8(rb + XEC_I2C_IAS_OFS);
+
+		/* extract I2C address from bus value */
+		i2c_addr = (ptg->targ_addr >> 1); /* bits[7:1]=address, bit[0]=R/nW */
+		ptg->curr_target = find_target(data, i2c_addr);
+		if (ptg->curr_target != NULL) {
+			tcbs = ptg->curr_target->callbacks;
+		}
+
+		if ((ptg->targ_addr & BIT(0)) != 0) { /* Host requesting read from target */
+			xec_i2c_tm_host_rd_req(data, tcbs);
+		} else { /* Host requesting write to target */
+			xec_i2c_tm_host_wr_req(data, tcbs);
+		}
+
+		next_state = I2C_XEC_ISR_STATE_EXIT_1;
+	} else {
+		if (ptg->targ_active != 0) {
+			next_state = I2C_XEC_ISR_STATE_TM_HOST_WR;
+			if ((ptg->targ_addr & BIT(0)) != 0) {
+				next_state = I2C_XEC_ISR_STATE_TM_HOST_RD;
+			}
+		}
+	}
+
+	return next_state;
+}
+#endif /* CONFIG_I2C_TARGET */
+
+static int state_check_ack(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+
+#ifdef CONFIG_I2C_TARGET
+	next_state = state_check_ack_tm(data);
+	if (next_state != I2C_XEC_ISR_STATE_MAX) {
+		return next_state;
+	}
+#endif
+
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_LRB_AD0_POS)) == 0) { /* ACK? */
+		next_state = I2C_XEC_ISR_STATE_WR_DATA;
+
+		if (xfr->mdir == XEC_I2C_DIR_RD) {
+			next_state = I2C_XEC_ISR_STATE_RD_DATA;
+		}
+	} else {
+		next_state = I2C_XEC_ISR_STATE_GEN_STOP;
+		xfr->xfr_sts |= I2C_XEC_XFR_STS_NACK;
+	}
+
+	return next_state;
+}
+
+static int state_data_wr(struct i2c_xec_v3_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_EXIT_1;
+
+	if (xfr->mlen > 0) {
+		sys_write8(*xfr->mbuf, rb + XEC_I2C_DATA_OFS);
+		xfr->mbuf++;
+		xfr->mlen--;
+	} else {
+		if (xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) {
+			next_state = I2C_XEC_ISR_STATE_GEN_STOP;
+		} else {
+			next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+		}
+	}
+
+	return next_state;
+}
+
+/* NOTE: Reading I2C controller Data register causes HW to
+ * generate clocks for the next data byte plus (n)ACK bit.
+ * In addition the Controller will always ACK received data
+ * unless the I2C.CTRL auto-ACK bit is cleared.
+ * If the message has I2C_MSG_STOP flag set:
+ * Reading the next to last byte generates clocks for the last byte.
+ * Therefore we must clear the auto-ACK bit in I2C.CTRL before
+ * reading the next to last byte from I2C.Data register.
+ * Before reading the last byte we must write I2C.CTRL to begin
+ * generating the I2C STOP sequence. We can then read the
+ * last byte from the I2C.Data register without causing clocks
+ * to be generated. We hope the Controller HW does not have a
+ * race condition between STOP generation and the read of I2C.Data.
+ */
+static int state_data_rd(struct i2c_xec_v3_data *data)
+{
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	mem_addr_t rb = devcfg->base;
+	int next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+	uint8_t ctrl = 0;
+
+	if (xfr->mlen > 0) {
+		next_state = I2C_XEC_ISR_STATE_EXIT_1;
+		if ((xfr->mflags & I2C_XEC_XFR_FLAG_START_REQ) != 0) {
+			/* HW clocks in address it transmits. Read and discard.
+			 * HW generates clocks for first data byte.
+			 */
+			xfr->mflags &= ~(I2C_XEC_XFR_FLAG_START_REQ);
+			if ((xfr->mlen == 1) && ((xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) != 0)) {
+				/* disable auto-ACK and make sure ENI=1 */
+				ctrl = BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ENI_POS);
+				xec_i2c_cr_write(dev, ctrl);
+			}
+			/* read byte currently in HW buffer and generate clocks for next byte */
+			sys_write8(sys_read8(rb + XEC_I2C_DATA_OFS), rb + XEC_I2C_BLKID_OFS);
+		} else if ((xfr->mflags & I2C_XEC_XFR_FLAG_STOP_REQ) != 0) {
+			if (xfr->mlen != 1) {
+				if (xfr->mlen == 2) {
+					ctrl = BIT(XEC_I2C_CR_ESO_POS) | BIT(XEC_I2C_CR_ENI_POS);
+					xec_i2c_cr_write(dev, ctrl);
+				}
+
+				*xfr->mbuf = sys_read8(rb + XEC_I2C_DATA_OFS);
+				xfr->mbuf++;
+				xfr->mlen--;
+			} else { /* Begin STOP generation and read last byte */
+				xfr->mflags &= ~(I2C_XEC_XFR_FLAG_STOP_REQ);
+				sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+				xec_i2c_cr_write(dev, XEC_I2C_CR_STOP);
+				/* read triggers STOP generation */
+				*xfr->mbuf = sys_read8(rb + XEC_I2C_DATA_OFS);
+				xfr->mlen = 0;
+			}
+		} else { /* No START or STOP flags */
+			*xfr->mbuf = sys_read8(rb + XEC_I2C_DATA_OFS);
+			xfr->mbuf++;
+			xfr->mlen--;
+		}
+	}
+
+	return next_state;
+}
+
+static int state_next_msg(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+	int ret = i2c_xec_next_msg(data);
+
+	if (ret) {
+		if (xfr->mflags & I2C_XEC_XFR_FLAG_START_REQ) {
+			next_state = I2C_XEC_ISR_STATE_GEN_START;
+		} else {
+			next_state = I2C_XEC_ISR_STATE_WR_DATA;
+			if (xfr->mdir == XEC_I2C_DIR_RD) {
+				next_state = I2C_XEC_ISR_STATE_RD_DATA;
+			}
+		}
+	} else { /* no more messages */
+		data->mdone = 1;
+	}
+
+	return next_state;
+}
+
+#ifdef CONFIG_I2C_TARGET
+/* state I2C_XEC_ISR_STATE_TM_HOST_RD (external Host I2 Read data phase)
+ * external Host I2C Read. Application callback returned error code.
+ * We "ignore" remaining protocol until STOP.
+ * This I2C controller clock stretches on target address match and
+ * on each ACK of data bytes we write from the external Host.
+ * We must write a value to the I2C.DATA register to cause this controller
+ * to release SCL allowing the external Host to generate clocks on SCL.
+ */
+static int state_tm_host_read(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = ptg->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+
+	if ((tcbs == NULL) || (tcbs->read_processed == NULL)) {
+		ptg->targ_ignore = 1u;
+	}
+
+	if (ptg->targ_ignore == 0) {
+		rc = tcbs->read_processed(tcfg, &ptg->targ_data);
+		if (rc != 0) {
+			ptg->targ_ignore = 1;
+			ptg->targ_data = XEC_I2C_TM_HOST_READ_IGNORE_VAL;
+		}
+	}
+
+	sys_write8(ptg->targ_data, rb + XEC_I2C_DATA_OFS);
+
+	return I2C_XEC_ISR_STATE_EXIT_1;
+}
+
+/* state I2C_XEC_ISR_STATE_TM_HOST_WR (external Host I2C Write data phase)
+ * external Host generated START and target write address matching this I2C target.
+ * We invoked application write requested callback which returned an error code.
+ * This means we must "ignore" I2C bus activity until the external Host generates STOP.
+ * When the external Host generates clocks and data this controller will clock stretch
+ * after the 9th clock if auto-ACK is enabled. We must read and discard the data byte
+ * from I2C.DATA.
+ */
+static int state_tm_host_write(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = ptg->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+
+	/* read shadow data register. No side-effects */
+	ptg->targ_data = sys_read8(rb + XEC_I2C_IDS_OFS);
+
+	if (ptg->targ_ignore == 0) {
+		rc = tcbs->write_received(tcfg, ptg->targ_data);
+		if (rc != 0) {
+			ptg->targ_ignore = 1u;
+			/* clear HW auto-ACK. We NAK future received bytes */
+			xec_i2c_cr_write_mask(dev, BIT(XEC_I2C_CR_ACK_POS), 0);
+		}
+	}
+
+	/* must read I2C.DATA to release SCL */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+
+	return I2C_XEC_ISR_STATE_EXIT_1;
+}
+
+static int state_tm_stop_event(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_target_config *tcfg = ptg->curr_target;
+	const struct i2c_target_callbacks *tcbs = tcfg->callbacks;
+	mem_addr_t rb = devcfg->base;
+
+	if ((tcbs != NULL) && (tcbs->stop != NULL)) {
+		tcbs->stop(tcfg);
+	}
+
+	/* Race condition:
+	 * Docs state: "After the function(stop callback) returns the controller
+	 * shall enter a state where it is ready to react to new start conditions"
+	 */
+	ptg->targ_active = 0;
+	ptg->targ_ignore = 0;
+	ptg->curr_target = NULL;
+	/* HW requires a read and discard of I2C.DATA register to clear the read-only
+	 * STOP detect status in I2C.SR.
+	 */
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+	xec_i2c_cr_write(dev, XEC_I2C_CR_PIN_ESO_ENI_ACK);
+
+	return I2C_XEC_ISR_STATE_EXIT_1;
+}
+
+static void tm_cleanup(struct i2c_xec_v3_data *data)
+{
+	struct i2c_xec_target *ptg = &data->tg;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+
+	ptg->targ_active = 0;
+	ptg->targ_ignore = 0;
+	ptg->curr_target = NULL;
+
+	sys_read8(rb + XEC_I2C_DATA_OFS);
+	/* re-arm I2C to detect external Host activity */
+	xec_i2c_cr_write(dev, XEC_I2C_CR_PIN_ESO_ENI_ACK);
+}
+#endif /* CONFIG_I2C_TARGET */
+
+/* SonarQube does not like GNU extensions required for CONTAINER_OF macro.
+ * We work around this by placing struct k_work as the first member of struct i2c_xec_v3_data.
+ * Therefore the pointer to struct k_work passed to xec_i2c_kwork_thread is also the address
+ * of this instance's struct i2c_xec_v3_data.
+ */
+BUILD_ASSERT(offsetof(struct i2c_xec_v3_data, kworkq) == 0,
+	     "Member kworkq must be located as the first memory of struct i2c_xec_v3_data");
+
+static void xec_i2c_kwork_thread(struct k_work *work)
+{
+	struct i2c_xec_v3_data *data = (struct i2c_xec_v3_data *)work;
+	const struct device *dev = data->dev;
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	struct i2c_xec_cm_xfr *xfr = &data->cm_xfr;
+	uint32_t i2c_cfg = 0;
+	bool run_sm = true;
+	int state = I2C_XEC_ISR_STATE_CHK_ACK;
+	int next_state = I2C_XEC_ISR_STATE_MAX;
+
+	i2c_cfg = sys_read32(rb + XEC_I2C_CFG_OFS);
+	data->i2c_compl = sys_read32(rb + XEC_I2C_CMPL_OFS);
+	data->i2c_sr = sys_read8(rb + XEC_I2C_SR_OFS);
+	if (((i2c_cfg & BIT(XEC_I2C_CFG_IDLE_IEN_POS)) != 0) &&
+	    ((data->i2c_sr & BIT(XEC_I2C_SR_NBB_POS)) != 0)) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+		state = I2C_XEC_ISR_STATE_EV_IDLE;
+	}
+
+#ifdef CONFIG_I2C_TARGET
+	if ((data->i2c_sr & BIT(XEC_I2C_SR_STO_POS)) != 0) {
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_STD_IEN_POS);
+		state = I2C_XEC_ISR_STATE_TM_EV_STOP;
+	}
+#endif
+
+	sys_write32(XEC_I2C_CMPL_RW1C_MSK, rb + XEC_I2C_CMPL_OFS);
+	sys_write32(BIT(XEC_I2C_WKSR_SB_POS), rb + XEC_I2C_WKSR_OFS);
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	/* Lost Arbitration or Bus Error? */
+	if (i2c_xec_is_ber_lab(data)) {
+		run_sm = false;
+#ifdef CONFIG_I2C_TARGET
+		tm_cleanup(data);
+#endif
+	}
+
+	while (run_sm) {
+		switch (state) {
+		case I2C_XEC_ISR_STATE_GEN_START:
+			if ((data->i2c_sr & BIT(XEC_I2C_SR_NBB_POS)) != 0) { /* START? */
+				sys_write8(xfr->target_addr, rb + XEC_I2C_DATA_OFS);
+				xec_i2c_cr_write(dev, XEC_I2C_CR_START_ENI);
+			} else { /* RPT-START */
+				xec_i2c_cr_write(dev, XEC_I2C_CR_RPT_START_ENI);
+				sys_write8(xfr->target_addr, rb + XEC_I2C_DATA_OFS);
+			}
+			run_sm = false;
+			break;
+		case I2C_XEC_ISR_STATE_CHK_ACK:
+			next_state = state_check_ack(data);
+			break;
+		case I2C_XEC_ISR_STATE_WR_DATA:
+			next_state = state_data_wr(data);
+			break;
+		case I2C_XEC_ISR_STATE_RD_DATA:
+			next_state = state_data_rd(data);
+			break;
+		case I2C_XEC_ISR_STATE_GEN_STOP:
+			sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_IDLE_IEN_POS);
+			xec_i2c_cr_write(dev, XEC_I2C_CR_STOP);
+			data->cm_dir = XEC_I2C_DIR_NONE;
+			run_sm = false;
+			break;
+		case I2C_XEC_ISR_STATE_EV_IDLE:
+			sys_set_bit(rb + XEC_I2C_CMPL_OFS, XEC_I2C_CMPL_IDLE_POS);
+			data->cm_dir = XEC_I2C_DIR_NONE;
+			next_state = I2C_XEC_ISR_STATE_NEXT_MSG;
+			if (xfr->xfr_sts != 0) {
+				data->mdone = 0x13;
+				run_sm = false;
+			}
+#ifdef CONFIG_I2C_TARGET
+			tm_cleanup(data);
+#endif
+			break;
+		case I2C_XEC_ISR_STATE_NEXT_MSG:
+			next_state = state_next_msg(data);
+			break;
+		case I2C_XEC_ISR_STATE_EXIT_1:
+			data->mdone = 0;
+			run_sm = false;
+			break;
+#ifdef CONFIG_I2C_TARGET
+		case I2C_XEC_ISR_STATE_TM_HOST_RD:
+			next_state = state_tm_host_read(data);
+			break;
+		case I2C_XEC_ISR_STATE_TM_HOST_WR:
+			next_state = state_tm_host_write(data);
+			break;
+		case I2C_XEC_ISR_STATE_TM_EV_STOP:
+			next_state = state_tm_stop_event(data);
+			data->mdone = 0;
+			run_sm = false;
+			break;
+#endif /* CONFIG_I2C_TARGET */
+		default:
+			sys_write32(XEC_I2C_CMPL_RW1C_MSK, rb + XEC_I2C_CMPL_OFS);
+			soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+			if (!data->mdone) {
+				data->mdone = 0x66;
+			}
+			run_sm = false;
+			break;
+		}
+
+		state = next_state;
+	}
+
+	/* ISR common exit path */
+	soc_ecia_girq_status_clear(devcfg->girq, devcfg->girq_pos);
+
+	if (data->mdone == 0) {
+		soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_EN);
+	} else {
+		k_sem_give(&data->sync_sem);
+	}
+} /* xec_i2c_kwork_thread */
+
+/* Controller Mode ISR
+ * We need to disable interrupt before exiting ISR.
+ */
+static void i2c_xec_isr(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+
+	/* clears I2C controller's GIRQ enable causing GIRQ result
+	 * signal to clear. GIRQ result is the input to the NVIC.
+	 */
+	soc_ecia_girq_ctrl(devcfg->girq, devcfg->girq_pos, XEC_I2C_GIRQ_DIS);
+
+	k_work_submit(&data->kworkq);
+}
+
+#ifdef CONFIG_PM_DEVICE
+/* If target mode enabled, we must enable wake on externally generated START.
+ * For deep sleep this requires enabling GIRQ22 wake clocks feature.
+ * Check if targets are registered and controller was designated a wakeup source in
+ * device tree.
+ */
+static bool i2c_xec_is_wakeup_source(const struct device *dev)
+{
+#ifdef CONFIG_I2C_TARGET
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+
+	if ((devcfg->wakeup_source != 0) && (data->tg.targ_bitmap != 0)) {
+		return true;
+	}
+#endif
+	return false;
+}
+
+static int i2c_xec_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct i2c_xec_v3_config *devcfg = dev->config;
+	mem_addr_t rb = devcfg->base;
+	int rc = 0;
+	bool target_wake_enable = i2c_xec_is_wakeup_source(dev);
+
+	LOG_DBG("PM action: %d", (int)action);
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		if (target_wake_enable == true) {
+			i2c_xec_target_arm_wake(dev, true);
+		} else {
+			rc = pinctrl_apply_state(devcfg->pcfg, PINCTRL_STATE_SLEEP);
+			if ((rc != 0) && (rc != -ENOENT)) {
+				LOG_ERR("PM suspend pinctrl default error (%d)", rc);
+			}
+		}
+
+		sys_clear_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		if (target_wake_enable == true) {
+			i2c_xec_target_arm_wake(dev, false);
+		} else {
+			rc = pinctrl_apply_state(devcfg->pcfg, PINCTRL_STATE_DEFAULT);
+			if ((rc != 0) && (rc != -ENOENT)) {
+				LOG_ERR("PM resume pinctrl default error (%d)", rc);
+			}
+		}
+
+		sys_set_bit(rb + XEC_I2C_CFG_OFS, XEC_I2C_CFG_ENAB_POS);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif
+
+static int i2c_xec_init(const struct device *dev)
+{
+	const struct i2c_xec_v3_config *cfg = dev->config;
+	struct i2c_xec_v3_data *data = dev->data;
+	int rc = 0;
+	uint32_t i2c_config = 0;
+
+	data->dev = dev;
+	data->state = XEC_I2C_STATE_CLOSED;
+	data->i2c_compl = 0;
+	data->i2c_cr_shadow = 0;
+	data->i2c_sr = 0;
+	data->mdone = 0;
+	data->port_sel = cfg->port;
+
+	rc = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (rc != 0) {
+		LOG_ERR("pinctrl setup failed (%d)", rc);
+		return rc;
+	}
+
+	i2c_config = i2c_map_dt_bitrate(cfg->clock_freq);
+	if (i2c_config == 0) {
+		return -EINVAL;
+	}
+
+	i2c_config |= I2C_MODE_CONTROLLER;
+
+	/* Default configuration */
+	rc = i2c_xec_configure(dev, i2c_config);
+	if (rc != 0) {
+		return rc;
+	}
+
+	k_work_init(&data->kworkq, &xec_i2c_kwork_thread);
+	k_mutex_init(&data->lock_mut);
+	k_sem_init(&data->sync_sem, 0, 1);
+
+	if (cfg->irq_config_func) {
+		cfg->irq_config_func();
+	}
+
+	return 0;
+}
+
+static DEVICE_API(i2c, i2c_xec_driver_api) = {
+	.configure = i2c_xec_configure,
+	.get_config = i2c_xec_get_config,
+	.transfer = i2c_xec_transfer,
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_xec_target_register,
+	.target_unregister = i2c_xec_target_unregister,
+#else
+	.target_register = NULL,
+	.target_unregister = NULL,
+#endif
+#ifdef CONFIG_I2C_RTIO
+	.iodev_submit = i2c_iodev_submit_fallback,
+#endif
+	.recover_bus = i2c_xec_recover_bus,
+};
+
+#define XEC_I2C_GIRQ_DT(inst)     MCHP_XEC_ECIA_GIRQ(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+#define XEC_I2C_GIRQ_POS_DT(inst) MCHP_XEC_ECIA_GIRQ_POS(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+
+#define I2C_XEC_DEVICE(i)                                                                          \
+	PINCTRL_DT_INST_DEFINE(i);                                                                 \
+	static void i2c_xec_irq_config_func_##i(void)                                              \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(i), DT_INST_IRQ(i, priority), i2c_xec_isr,                \
+			    DEVICE_DT_INST_GET(i), 0);                                             \
+		irq_enable(DT_INST_IRQN(i));                                                       \
+	}                                                                                          \
+	static struct i2c_xec_v3_data i2c_xec_v3_data_##i = {.port_sel =                           \
+								     DT_INST_PROP(i, port_sel)};   \
+	static const struct i2c_xec_v3_config i2c_xec_v3_cfg_##i = {                               \
+		.base = (mem_addr_t)DT_INST_REG_ADDR(i),                                           \
+		.clock_freq = DT_INST_PROP(i, clock_frequency),                                    \
+		.sda_gpio = GPIO_DT_SPEC_INST_GET(i, sda_gpios),                                   \
+		.scl_gpio = GPIO_DT_SPEC_INST_GET(i, scl_gpios),                                   \
+		.irq_config_func = i2c_xec_irq_config_func_##i,                                    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),                                         \
+		.girq = (uint8_t)XEC_I2C_GIRQ_DT(i),                                               \
+		.girq_pos = (uint8_t)XEC_I2C_GIRQ_POS_DT(i),                                       \
+		.enc_pcr = (uint8_t)DT_INST_PROP(i, pcr_scr),                                      \
+		.port = (uint8_t)DT_INST_PROP(i, port_sel),                                        \
+		IF_ENABLED(CONFIG_I2C_TARGET,                                                      \
+			(.wakeup_source = DT_INST_PROP_OR(i, wakeup_source, 0))) };               \
+	PM_DEVICE_DT_INST_DEFINE(i, i2c_xec_pm_action);                                            \
+	I2C_DEVICE_DT_INST_DEFINE(i, i2c_xec_init, PM_DEVICE_DT_INST_GET(i), &i2c_xec_v3_data_##i, \
+				  &i2c_xec_v3_cfg_##i, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,      \
+				  &i2c_xec_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(I2C_XEC_DEVICE)

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -417,9 +417,10 @@
 
 		i2c_smb_0: i2c@40004000 {
 			reg = <0x40004000 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <20 2>;
-			girqs = <13 0>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 0)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 1)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 10)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -427,9 +428,10 @@
 
 		i2c_smb_1: i2c@40004400 {
 			reg = <0x40004400 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <21 2>;
-			girqs = <13 1>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 1)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 2)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 13)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -437,9 +439,10 @@
 
 		i2c_smb_2: i2c@40004800 {
 			reg = <0x40004800 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <22 2>;
-			girqs = <13 2>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 2)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 3)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 14)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -449,7 +452,9 @@
 			reg = <0x40004c00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <23 2>;
-			girqs = <13 3>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 3)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 4)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 15)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -457,9 +462,10 @@
 
 		i2c_smb_4: i2c@40005000 {
 			reg = <0x40005000 0x80>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <158 2>;
-			girqs = <13 4>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 4)>, <MCHP_XEC_ECIA_GIRQ_ENC(22, 5)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 20)>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/bindings/i2c/microchip,xec-i2c-v3.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v3.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip XEC I2C-SMB V3 controller byte mode driver
+
+compatible: "microchip,xec-i2c-v3"
+
+include: [i2c-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  port-sel:
+    type: int
+    required: true
+    description: |
+      XEC I2C controller has a hardware MUX to select among
+      multiple I2C ports. I2C pins must be set to their I2C
+      mode using PINCTRL. The driver can then select the pins
+      by programming the port select register field in the
+      controller's configuration register.
+
+  girqs:
+    type: array
+    required: true
+    description: array of GIRQ numbers [8:26] and bit positions [0:31]
+
+  pcr-scr:
+    type: int
+    required: true
+    description: |
+      I2C controller PCR register index and bit position encoded
+      in an integer.
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      I2C controller versions older than v3.8 do not make pin
+      state monitoring visible in the bit-bang register without
+      switching the pins from I2C control to bit-bang control.
+      This can cause disruption of an open I2C session. For older
+      hardware use access pin state using the GPIO driver.
+
+  scl-gpios:
+    type: phandle-array
+    description: |
+      Refer to the description of sda-gpios.
+
+  target-buf-write-req-buffer-size:
+    type: int
+    default: 8
+    description: |
+      The property allows each instance of the driver to have
+      a unique target buffer write request buffer size in bytes.
+      This property is only used if the driver is built with
+      I2C target buffer mode enabled.

--- a/soc/microchip/mec/common/soc_common.h
+++ b/soc/microchip/mec/common/soc_common.h
@@ -30,6 +30,7 @@
 #include <soc_ecia.h>
 #include <soc_espi_channels.h>
 #include <soc_gpio.h>
+#include <soc_i2c.h>
 #include <soc_misc.h>
 #include <soc_mmcr.h>
 #include <soc_pcr.h>

--- a/soc/microchip/mec/common/soc_i2c.h
+++ b/soc/microchip/mec/common/soc_i2c.h
@@ -11,40 +11,67 @@
 #ifndef _MICROCHIP_MEC_SOC_I2C_H_
 #define _MICROCHIP_MEC_SOC_I2C_H_
 
+#include <zephyr/device.h>
+
 /* 144-pin package I2C port masks */
 #if defined(CONFIG_SOC_MEC172X_NSZ)
-#define MEC_I2C_PORT_MASK	0xFEFFU
+#define MEC_I2C_PORT_MASK 0xFEFFU
 #elif defined(CONFIG_SOC_MEC1501_HSZ)
-#define MEC_I2C_PORT_MASK	0xFEFFU
+#define MEC_I2C_PORT_MASK 0xFEFFU
+#else
+#define MEC_I2C_PORT_MASK 0xFFFFU
 #endif
 
-#define MCHP_I2C_PORT_0		0
-#define MCHP_I2C_PORT_1		1
-#define MCHP_I2C_PORT_2		2
-#define MCHP_I2C_PORT_3		3
-#define MCHP_I2C_PORT_4		4
-#define MCHP_I2C_PORT_5		5
-#define MCHP_I2C_PORT_6		6
-#define MCHP_I2C_PORT_7		7
-#define MCHP_I2C_PORT_8		8
-#define MCHP_I2C_PORT_9		9
-#define MCHP_I2C_PORT_10	10
-#define MCHP_I2C_PORT_11	11
-#define MCHP_I2C_PORT_12	12
-#define MCHP_I2C_PORT_13	13
-#define MCHP_I2C_PORT_14	14
-#define MCHP_I2C_PORT_15	15
-#define MCHP_I2C_PORT_MAX	16
+#define MCHP_I2C_PORT_0   0
+#define MCHP_I2C_PORT_1   1
+#define MCHP_I2C_PORT_2   2
+#define MCHP_I2C_PORT_3   3
+#define MCHP_I2C_PORT_4   4
+#define MCHP_I2C_PORT_5   5
+#define MCHP_I2C_PORT_6   6
+#define MCHP_I2C_PORT_7   7
+#define MCHP_I2C_PORT_8   8
+#define MCHP_I2C_PORT_9   9
+#define MCHP_I2C_PORT_10  10
+#define MCHP_I2C_PORT_11  11
+#define MCHP_I2C_PORT_12  12
+#define MCHP_I2C_PORT_13  13
+#define MCHP_I2C_PORT_14  14
+#define MCHP_I2C_PORT_15  15
+#define MCHP_I2C_PORT_MAX 16
 
+#ifdef CONFIG_SOC_SERIES_MEC172X
 /*
  * Read pin states of specified I2C port.
  * We GPIO control register always active RO pad input bit.
  * lines b[0]=SCL pin state at pad, b[1]=SDA pin state at pad
  * Returns 0 success or -EINVAL if port is not support or lines is NULL.
  */
-#define SOC_I2C_SCL_POS		0
-#define SOC_I2C_SDA_POS		1
+#define SOC_I2C_SCL_POS 0
+#define SOC_I2C_SDA_POS 1
 
 int soc_i2c_port_lines_get(uint8_t port, uint32_t *lines);
+#endif /* CONFIG_SOC_SERIES_MEC172X */
+
+#ifdef CONFIG_I2C_XEC_V3
+/** @brief Get I2C controller's port configuration
+ *
+ * @param dev Pointer to I2C controller's device structure
+ * @param port Pointer to port variable to fill in with port number
+ *
+ * @retval Return on success or negative error code
+ */
+int i2c_xec_v3_get_port(const struct device *dev, uint8_t *port);
+
+/** @brief Configure I2C controller for specified port and frequency
+ *
+ * @param dev pointer to I2C controller's device structure
+ * @param config I2C configuration 32-bit word containing encoded frequency
+ * @param port I2C hardware port number
+ *
+ * @retval Return on success or negative error code
+ */
+int i2c_xec_v3_config(const struct device *dev, uint32_t config, uint8_t port);
+#endif /* CONFIG_I2C_XEC_V3 */
 
 #endif /* _MICROCHIP_MEC_SOC_I2C_H_ */

--- a/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec_assy6941_mec1753_qlj.overlay
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* We configure i2c_smb_0 to use HW port 0 pins
+ * and i2c_smb_1 to use HW port 4 pins.
+ * MEC I2C controllers have a HW mux allowing each controller to
+ * access any of the port pin pairs.
+ * For this test we need to connect both controllers together.
+ * We set port-sel of both controllers to port 0 connecting the
+ * the two controller to port 0 pins
+ */
+&i2c_smb_0 {
+	compatible = "microchip,xec-i2c-v3";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_003 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_004 0>;
+	pinctrl-0 = <&i2c00_sda_gpio003 &i2c00_scl_gpio004>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+&i2c_smb_1 {
+	compatible = "microchip,xec-i2c-v3";
+	port-sel = <0>;
+	sda-gpios = <MCHP_GPIO_DECODE_143 0>;
+	scl-gpios = <MCHP_GPIO_DECODE_144 0>;
+	pinctrl-0 = <&i2c04_sda_gpio143 &i2c04_scl_gpio144>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+/* I2C Port 0 */
+&i2c00_sda_gpio003 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c00_scl_gpio004 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+/* I2C Port 4 */
+&i2c04_sda_gpio143 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};
+
+&i2c04_scl_gpio144 {
+	drive-open-drain;
+	output-enable;
+	output-high;
+	drive-strength = <1>;
+};


### PR DESCRIPTION
Zephyr I2C driver for Microchip XEC I2C HW version 3.8 in MEC174x, MEC175x, and MEC165xB parts.
This driver implements byte mode control of I2C using controller per byte interrupts.  The Zephyr kernel work queue is used to offload I2C protocol handling from the ISR.  XEC I2C hardware implements a MUX allowing any of the up to 16 I2C ports (SCL/SDA pin pairs) to be connected to any of the XEC I2C controller instances.  We implemented two driver specific APIs to read the current port from the HW MUX and to configure the HW MUX.  The controller requires a reset when switching ports. The API to select a new port also accepts the 32-bit I2C configuration word.  The application can switch the port and set a new frequency in one call.