### PR TITLE
soc: silabs: siwx91x: Fix corrupted firmware

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -124,6 +124,8 @@
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <4096>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/silabs/siwg917m111mgtba.dtsi
+++ b/dts/arm/silabs/siwg917m111mgtba.dtsi
@@ -17,11 +17,11 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_M(8)>;
+	ranges = <0 0x08000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
+		ranges;
 
 		/* See AN1416: SiWx917 SoC Memory Map, 3.1.4 Memory Map (8 MB) */
 		mbr_nwp_partition: partition@0 {


### PR DESCRIPTION
Since, commit 2f7d138 ("kconfig: Fix CONFIG_FLASH_LOAD_OFFSET for non-0
starting addresses"), the way to compute offsets in the flash memory has
changed.

With this change, the arguments passed to siwx91x_isp_prepare.py were not
correct anymore and "west flash" ended up with:

    ERROR: Waiting for flashloader failed: 108 - Checksum error