### PR TITLE
scripts: zephyr_module.py: Optional jsonschema dependency

### DIFF
--- a/scripts/west_commands/packages.py
+++ b/scripts/west_commands/packages.py
@@ -116,7 +116,9 @@ class Packages(WestCommand):
             )
 
         # Store the zephyr modules for easier access
-        self.zephyr_modules = zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest)
+        self.zephyr_modules = zephyr_module.parse_modules(
+            ZEPHYR_BASE, self.manifest, require_yaml_validation=False
+        )
 
         if args.modules:
             # Check for unknown module names


### PR DESCRIPTION
Commit 58bf2dc0e631d0598adf6c017c3065056a657a7b replaced pykwalify with jsonschema for Zephyr module.yml files. However the west 'packages' extension uses this module to list Python dependencies for Zephyr and active Zephyr modules.

Make YAML validation optional using a new argument.