### PR TITLE
boards: cy8cproto_041tp: Extend configuration for onboard components

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.dts
@@ -23,25 +23,43 @@
 	};
 
 	aliases {
-		led0 = &led;
-		sw0 = &user_btn;
+		led0 = &user_led2;
+		led1 = &user_led3;
+		led2 = &user_led5;
+		led3 = &user_led6;
+		sw0 = &user_sw4;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 		status = "okay";
 
-		led: led {
-			label = "LED_0";
+		user_led2: red_led: led_0 {
+			label = "LED2 Red";
 			gpios = <&gpio_prt5 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		user_led3: green_led: led_1 {
+			label = "LED3 Green";
+			gpios = <&gpio_prt5 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		user_led5: blue_led: led_2 {
+			label = "LED5 Blue";
+			gpios = <&gpio_prt6 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		user_led6: orange_led: led_3 {
+			label = "LED6 Orange";
+			gpios = <&gpio_prt6 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
 
-		user_btn: button {
-			label = "SW_0";
+		user_sw4: user_btn: button {
+			label = "SW4";
 			gpios = <&gpio_prt5 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};

--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
@@ -56,6 +56,10 @@ uart0: &scb0 {
 	status = "okay";
 };
 
+&gpio_prt6 {
+	status = "okay";
+};
+
 &watchdog0 {
 	status = "okay";
 };


### PR DESCRIPTION
Extending default board configuration to include additional LEDs (x4) and updated
labeling for leds and pushbutton to match schematic / silkscreen.