### PR TITLE
drivers: pwm: mcux_ctimer: add capture mode feature

### DIFF
--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -9,43 +9,76 @@
 
 #include <errno.h>
 #include <fsl_ctimer.h>
+#include <fsl_inputmux.h>
 #include <fsl_clock.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/irq.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pwm_mcux_ctimer, CONFIG_PWM_LOG_LEVEL);
 
-#define CHANNEL_COUNT kCTIMER_Match_3 + 1
+#define MAX_MATCH_CHANNEL_COUNT (kCTIMER_Match_3 + 1)
+#define MAX_CAPTURE_CHANNEL_COUNT (kCTIMER_Capture_3 + 1)
 
 enum pwm_ctimer_channel_role {
 	PWM_CTIMER_CHANNEL_ROLE_NONE = 0,
 	PWM_CTIMER_CHANNEL_ROLE_PULSE,
 	PWM_CTIMER_CHANNEL_ROLE_PERIOD,
+	PWM_CTIMER_CHANNEL_ROLE_CAPTURE,
 };
 
-struct pwm_ctimer_channel_state {
+typedef struct pwm_ctimer_channel_state {
 	enum pwm_ctimer_channel_role role;
 	uint32_t cycles;
-};
+} pwm_ctimer_channel_state;
 
 struct pwm_mcux_ctimer_data {
-	struct pwm_ctimer_channel_state channel_states[CHANNEL_COUNT];
+	uint8_t is_period_channel_set :1;
+
+	uint8_t num_active_pulse_chans;
 	ctimer_match_t current_period_channel;
-	bool is_period_channel_set;
-	uint32_t num_active_pulse_chans;
+	pwm_ctimer_channel_state channel_states[MAX_MATCH_CHANNEL_COUNT];
+
+#ifdef CONFIG_PWM_CAPTURE
+	ctimer_capture_channel_t operate_channel;
+	ctimer_status_flags_t capture_status_flags;
+	ctimer_interrupt_enable_t capture_interrupt_enable;
+
+	void *user_data;
+	inputmux_connection_t inputmux_connection[MAX_CAPTURE_CHANNEL_COUNT];
+
+	pwm_capture_callback_handler_t capture_callback;
+#endif /* CONFIG_PWM_CAPTURE */
 };
 
 struct pwm_mcux_ctimer_config {
 	CTIMER_Type *base;
-	uint32_t prescale;
-	uint32_t period_channel;
-	const struct device *clock_control;
-	clock_control_subsys_t clock_id;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	const struct pinctrl_dev_config *pincfg;
+
+	uint8_t period_channel;
+	ctimer_timer_mode_t mode;
+	uint32_t prescale;
+
+#ifdef CONFIG_PWM_CAPTURE
+	uint8_t capture_channel_enable :1;
+	uint8_t inputmux;
+	ctimer_capture_channel_t channel;
+    ctimer_capture_edge_t capture_edge;
+	void (*irq_config_func)(const struct device *dev);
+#endif /* CONFIG_PWM_CAPTURE */
 };
+
+#ifdef CONFIG_PWM_CAPTURE
+typedef struct user_data_t {
+    /* uint8_t capture_channel_enable :1; */
+	uint32_t unused;
+} user_data_t;
+#endif /* CONFIG_PWM_CAPTURE */
 
 /*
  * All pwm signals generated from the same ctimer must have same period. To avoid this, we check
@@ -112,14 +145,14 @@ static int mcux_ctimer_pwm_select_period_channel(struct pwm_mcux_ctimer_data *da
 
 	/* we need to find an unused channel to use as period_channel */
 	*ret_period_channel = new_pulse_channel + 1;
-	*ret_period_channel %= CHANNEL_COUNT;
+	*ret_period_channel %= MAX_MATCH_CHANNEL_COUNT;
 	while (data->channel_states[*ret_period_channel].role != PWM_CTIMER_CHANNEL_ROLE_NONE) {
 		if (new_pulse_channel == *ret_period_channel) {
 			LOG_ERR("no available channel for period counter");
 			return -EBUSY;
 		}
 		(*ret_period_channel)++;
-		*ret_period_channel %= CHANNEL_COUNT;
+		*ret_period_channel %= MAX_MATCH_CHANNEL_COUNT;
 	}
 
 	return 0;
@@ -152,8 +185,8 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 	int ret = 0;
 	status_t status;
 
-	if (pulse_channel >= CHANNEL_COUNT) {
-		LOG_ERR("Invalid channel %u. muse be less than %u", pulse_channel, CHANNEL_COUNT);
+	if (pulse_channel >= MAX_MATCH_CHANNEL_COUNT) {
+		LOG_ERR("Invalid channel %u. muse be less than %u", pulse_channel, MAX_MATCH_CHANNEL_COUNT);
 		return -EINVAL;
 	}
 
@@ -191,6 +224,201 @@ static int mcux_ctimer_pwm_set_cycles(const struct device *dev, uint32_t pulse_c
 	return 0;
 }
 
+#ifdef CONFIG_PWM_CAPTURE
+static void mcux_ctimer_capture_isr(const struct device *dev)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	uint32_t period = 0;	/* ARG_UNUSED */
+	uint32_t pulse = 0;		/* ARG_UNUSED */
+	int err = 0;
+	uint8_t interrupt_flag = 0;
+
+	if (CTIMER_GetStatusFlags(config->base) & kCTIMER_Capture0Flag) {
+		interrupt_flag = 1;
+		data->operate_channel = kCTIMER_Capture_0;
+		data->capture_status_flags = kCTIMER_Capture0Flag;
+	} else if (CTIMER_GetStatusFlags(config->base) & kCTIMER_Capture1Flag) {
+		interrupt_flag = 1;
+		data->operate_channel = kCTIMER_Capture_1;
+		data->capture_status_flags = kCTIMER_Capture1Flag;
+	} else if (CTIMER_GetStatusFlags(config->base) & kCTIMER_Capture2Flag) {
+		interrupt_flag = 1;
+		data->operate_channel = kCTIMER_Capture_2;
+		data->capture_status_flags = kCTIMER_Capture2Flag;
+	} else if (CTIMER_GetStatusFlags(config->base) & kCTIMER_Capture3Flag) {
+		interrupt_flag = 1;
+		data->operate_channel = kCTIMER_Capture_3;
+		data->capture_status_flags = kCTIMER_Capture3Flag;
+	}
+
+	if (interrupt_flag) {
+		interrupt_flag = 0;
+		if (data->capture_callback != NULL) {
+			data->capture_callback(dev, data->operate_channel,
+										period, pulse, err,
+										data->user_data);
+		}
+
+		/* Clear Capture Interrupt Flag */
+		CTIMER_ClearStatusFlags(config->base, data->capture_status_flags);
+	}
+}
+
+static int mcux_ctimer_configure_capture(const struct device *dev,
+										 uint32_t channel, pwm_flags_t flags,
+										 pwm_capture_callback_handler_t cb,
+										 void *user_data)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+	uint32_t timer_captsel_base;
+
+	/* flags represent PWM_POLARITY_NORMAL and PWM_POLARITY_INVERTED */
+	/* Future used for calculate duty cycle */
+	ARG_UNUSED(flags);
+
+	if (channel >= MAX_CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("Invalid channel %u. must be less than %u", channel, MAX_CAPTURE_CHANNEL_COUNT);
+		return -EINVAL;
+	}
+
+	data->channel_states[channel].role = PWM_CTIMER_CHANNEL_ROLE_CAPTURE;
+
+	/* INPUT MUX Initialization */
+	INPUTMUX_Init(INPUTMUX); /* Enable INPUTMUX Clock */
+	/* INPUTMUX0->CTIMER0CAP0 = INPUTMUX_CTIMER0CAP0_INP(0); */
+	/* CTIMERiCAPj => index equals to channel of CTIMERi => equals to j */
+	/* inputmux_connection_t connection = kINPUTMUX_CtimerInp0ToTimer0Captsel */
+
+	/* LOG_DBG("device name %s", dev->name); */
+	/* Compare base address with CTIMER0, CTIMER1, CTIMER2, CTIMER3, CTIMER4 */
+	timer_captsel_base = TIMER0CAPTSEL0;
+	if (config->base == CTIMER0) {
+		/* LOG_DBG("Detect CTIMER0"); */
+		timer_captsel_base = TIMER0CAPTSEL0;
+	} else if (config->base == CTIMER1) {
+		/* LOG_DBG("Detect CTIMER1"); */
+		timer_captsel_base = TIMER1CAPTSEL0;
+	} else if (config->base == CTIMER2) {
+		/* LOG_DBG("Detect CTIMER2"); */
+		timer_captsel_base = TIMER2CAPTSEL0;
+	} else if (config->base == CTIMER3) {
+		/* LOG_DBG("Detect CTIMER3"); */
+		timer_captsel_base = TIMER3CAPTSEL0;
+	} else if (config->base == CTIMER4) {
+		/* LOG_DBG("Detect CTIMER4"); */
+		timer_captsel_base = TIMER4CAPTSEL0;
+	}
+
+	switch (channel)
+	{
+	case 0:
+		data->capture_interrupt_enable = kCTIMER_Capture0InterruptEnable;
+		break;
+	case 1:
+		data->capture_interrupt_enable = kCTIMER_Capture1InterruptEnable;
+		break;
+	case 2:
+		data->capture_interrupt_enable = kCTIMER_Capture2InterruptEnable;
+		break;
+	case 3:
+		data->capture_interrupt_enable = kCTIMER_Capture3InterruptEnable;
+		break;
+	default:
+		LOG_ERR("Invalid capture channel %u. must be less than %u", channel,
+																	MAX_CAPTURE_CHANNEL_COUNT);
+		return -EINVAL;
+	}
+
+	data->inputmux_connection[channel] = (uint32_t)config->inputmux +
+													(timer_captsel_base << PMUX_SHIFT);
+	INPUTMUX_AttachSignal(INPUTMUX, channel, data->inputmux_connection[channel]);
+
+	/* Setup ctimer CCR register for capture */
+	CTIMER_SetupCapture(config->base, channel, config->capture_edge, true);
+	config->base->CTCR &= ~CTIMER_CTCR_ENCC(1);	   /* Clear Capture Channel Enable */
+	config->base->CTCR &= ~CTIMER_CTCR_SELCC_MASK; /* clear SELCC in CTCR register */
+
+	data->capture_callback = cb;
+	data->user_data = user_data;
+
+	return 0;
+}
+
+static int mcux_ctimer_enable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+
+	if (channel >= MAX_CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("Invalid channel %u. must be less than %u", channel, MAX_CAPTURE_CHANNEL_COUNT);
+		return -EINVAL;
+	}
+
+	if (data->channel_states[channel].role != PWM_CTIMER_CHANNEL_ROLE_CAPTURE) {
+		LOG_ERR("Channel %u is not configured for capture", channel);
+		return -EINVAL;
+	}
+
+	/* Writing 1 to this field enables clearing of the timer and the prescaler */
+	/* when the capture-edge event specified in SELCC occurs */
+	if (config->capture_channel_enable) {
+		config->base->CTCR |= CTIMER_CTCR_ENCC(1);	/* enable */
+	}
+	else {
+		config->base->CTCR &= ~CTIMER_CTCR_ENCC(1);	/* disable */
+	}
+
+	/* SELCC take effect only when ENCC is 1 */
+	/* Setup CTCR count control register */
+	switch (config->capture_edge)
+	{
+	case kCTIMER_Capture_RiseEdge:
+		/* clear TC/PR on rising edge */
+		config->base->CTCR |= CTIMER_CTCR_SELCC((channel << 1));
+		/* Enable edge capture with CCR register */
+		CTIMER_EnableRisingEdgeCapture(config->base, channel, true);
+		break;
+	case kCTIMER_Capture_FallEdge:
+		/* clear TC/PR on falling edge */
+		config->base->CTCR |= CTIMER_CTCR_SELCC((channel << 1) | 1);
+		/* Enable edge capture with CCR register */
+		CTIMER_EnableFallingEdgeCapture(config->base, channel, true);
+		break;
+	default:
+		LOG_ERR("Invalid capture edge %d", config->capture_edge);
+		return -EINVAL;
+	}
+
+	CTIMER_EnableInterrupts(config->base, data->capture_interrupt_enable);
+	CTIMER_StartTimer(config->base);
+
+	return 0;
+}
+
+static int mcux_ctimer_disable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_ctimer_config *config = dev->config;
+	struct pwm_mcux_ctimer_data *data = dev->data;
+
+	if (channel >= MAX_CAPTURE_CHANNEL_COUNT) {
+		LOG_ERR("Invalid channel %u. must be less than %u", channel, MAX_CAPTURE_CHANNEL_COUNT);
+		return -EINVAL;
+	}
+
+	if (data->channel_states[channel].role != PWM_CTIMER_CHANNEL_ROLE_CAPTURE) {
+		LOG_ERR("Channel %u is not configured for capture", channel);
+		return -EINVAL;
+	}
+
+	CTIMER_DisableInterrupts(config->base, data->capture_interrupt_enable);
+	CTIMER_StopTimer(config->base);
+
+	return 0;
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
 static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 					      uint64_t *cycles)
 {
@@ -201,7 +429,8 @@ static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t
 	/* clean up upper word of return parameter */
 	*cycles &= 0xFFFFFFFF;
 
-	err = clock_control_get_rate(config->clock_control, config->clock_id, (uint32_t *)cycles);
+	err = clock_control_get_rate(config->clock_dev, config->clock_subsys, (uint32_t *)cycles);
+
 	if (err != 0) {
 		LOG_ERR("could not get clock rate");
 		return err;
@@ -217,7 +446,7 @@ static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t
 static int mcux_ctimer_pwm_init(const struct device *dev)
 {
 	const struct pwm_mcux_ctimer_config *config = dev->config;
-	ctimer_config_t pwm_config;
+	ctimer_config_t ctimer_config;
 	int err;
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
@@ -225,53 +454,122 @@ static int mcux_ctimer_pwm_init(const struct device *dev)
 		return err;
 	}
 
-	if (config->period_channel >= CHANNEL_COUNT) {
+	if (config->period_channel >= MAX_MATCH_CHANNEL_COUNT) {
 		LOG_ERR("invalid period_channel: %d. must be less than %d", config->period_channel,
-			CHANNEL_COUNT);
+				MAX_MATCH_CHANNEL_COUNT);
 		return -EINVAL;
 	}
 
-	CTIMER_GetDefaultConfig(&pwm_config);
-	pwm_config.prescale = config->prescale;
+	CTIMER_GetDefaultConfig(&ctimer_config);
+	ctimer_config.prescale = config->prescale;
 
-	CTIMER_Init(config->base, &pwm_config);
+	#ifdef CONFIG_PWM_CAPTURE
+	ctimer_config.mode = config->mode;
+	ctimer_config.input = config->channel;
+#endif /* CONFIG_PWM_CAPTURE */
+
+	/* ctimer_config.input is useless when config->mode is 0 */
+	CTIMER_Init(config->base, &ctimer_config);
+
+#ifdef CONFIG_PWM_CAPTURE
+	config->irq_config_func(dev);
+#endif /* CONFIG_PWM_CAPTURE */
+
 	return 0;
 }
 
 static DEVICE_API(pwm, pwm_mcux_ctimer_driver_api) = {
 	.set_cycles = mcux_ctimer_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_ctimer_pwm_get_cycles_per_sec,
+#ifdef CONFIG_PWM_CAPTURE
+	.configure_capture = mcux_ctimer_configure_capture,
+	.enable_capture = mcux_ctimer_enable_capture,
+	.disable_capture = mcux_ctimer_disable_capture,
+#endif /* CONFIG_PWM_CAPTURE */
 };
 
-#define PWM_MCUX_CTIMER_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define PWM_MCUX_CTIMER_PINCTRL_INIT(n)   .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
+#ifdef CONFIG_PWM_CAPTURE
 
-#define PWM_MCUX_CTIMER_DEVICE_INIT_MCUX(n)                                                        \
-	static struct pwm_mcux_ctimer_data pwm_mcux_ctimer_data_##n = {                            \
-		.channel_states =                                                                  \
-			{                                                                          \
-				[kCTIMER_Match_0] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,         \
-						     .cycles = 0},                                 \
-				[kCTIMER_Match_1] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,         \
-						     .cycles = 0},                                 \
-				[kCTIMER_Match_2] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,         \
-						     .cycles = 0},                                 \
-				[kCTIMER_Match_3] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,         \
-						     .cycles = 0},                                 \
-			},                                                                         \
-		.current_period_channel = kCTIMER_Match_0,                                         \
-		.is_period_channel_set = false,                                                    \
-	};                                                                                         \
-	PWM_MCUX_CTIMER_PINCTRL_DEFINE(n)                                                          \
-	static const struct pwm_mcux_ctimer_config pwm_mcux_ctimer_config_##n = {                  \
-		.base = (CTIMER_Type *)DT_INST_REG_ADDR(n),                                        \
-		.prescale = DT_INST_PROP(n, prescaler),                                            \
-		.clock_control = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                            \
-		.clock_id = (clock_control_subsys_t)(DT_INST_CLOCKS_CELL(n, name)),                \
-		PWM_MCUX_CTIMER_PINCTRL_INIT(n)};                                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(n, mcux_ctimer_pwm_init, NULL, &pwm_mcux_ctimer_data_##n,            \
-			      &pwm_mcux_ctimer_config_##n, POST_KERNEL,                            \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_mcux_ctimer_driver_api);
+#define PWM_MCUX_CTIMER_DEVICE_INIT_MCUX(n)                                                 \
+	static void mcux_ctimer_irq_config_func_##n(const struct device *dev);                  \
+                                                                                            \
+	PINCTRL_DT_INST_DEFINE(n);                                                              \
+                                                                                            \
+	static struct pwm_mcux_ctimer_data pwm_mcux_ctimer_data_##n = {                         \
+		.channel_states =                                                                   \
+			{                                                                               \
+				[0] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[1] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[2] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[3] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+			},                                                                         		\
+		.current_period_channel = kCTIMER_Match_0,                                          \
+		.is_period_channel_set = false,                                                     \
+	};                                                                                      \
+	static const struct pwm_mcux_ctimer_config pwm_mcux_ctimer_config_##n = {               \
+		.base = (CTIMER_Type *)DT_INST_REG_ADDR(n),                                         \
+		.mode = DT_INST_PROP(n, mode),                                                      \
+		.channel = DT_INST_PROP(n, channel),                                                \
+		.capture_channel_enable = DT_INST_PROP(n, capture_channel_enable),                  \
+		.capture_edge = DT_INST_PROP(n, capture_edge),                                      \
+		.inputmux = DT_INST_PROP(n, inputmux),                                              \
+		.prescale = DT_INST_PROP(n, prescale),                                              \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                 \
+		.clock_subsys = (clock_control_subsys_t)(DT_INST_CLOCKS_CELL(n, name)),             \
+		.irq_config_func = mcux_ctimer_irq_config_func_##n,                                 \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                        \
+	};                                                                                      \
+                                                                                            \
+	DEVICE_DT_INST_DEFINE(n, mcux_ctimer_pwm_init, NULL, &pwm_mcux_ctimer_data_##n,         \
+			      &pwm_mcux_ctimer_config_##n, POST_KERNEL,                            		\
+						  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_mcux_ctimer_driver_api); \
+                                                                                            \
+	static void mcux_ctimer_irq_config_func_##n(const struct device *dev)                   \
+	{                                                                                       \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),                              \
+					mcux_ctimer_capture_isr, DEVICE_DT_INST_GET(n), 0);                     \
+		irq_enable(DT_INST_IRQN(n));                                                        \
+	}
+
+#else /* !CONFIG_PWM_CAPTURE */
+
+#define PWM_MCUX_CTIMER_DEVICE_INIT_MCUX(n)                                                 \
+                                                                                            \
+	PINCTRL_DT_INST_DEFINE(n);                                                              \
+                                                                                            \
+	static struct pwm_mcux_ctimer_data pwm_mcux_ctimer_data_##n = {                         \
+		.channel_states =                                                                   \
+			{                                                                               \
+				[0] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[1] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[2] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+				[3] = {.role = PWM_CTIMER_CHANNEL_ROLE_NONE,                                \
+						     .cycles = 0},                                 					\
+			},                                                                         		\
+		.current_period_channel = kCTIMER_Match_0,                                          \
+		.is_period_channel_set = false,                                                     \
+	};                                                                                      \
+	static const struct pwm_mcux_ctimer_config pwm_mcux_ctimer_config_##n = {               \
+		.base = (CTIMER_Type *)DT_INST_REG_ADDR(n),                                         \
+		.prescale = DT_INST_PROP(n, prescale),                                              \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                 \
+		.clock_subsys = (clock_control_subsys_t)(DT_INST_CLOCKS_CELL(n, name)),             \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                        \
+	};                                                                                      \
+                                                                                            \
+	DEVICE_DT_INST_DEFINE(n, mcux_ctimer_pwm_init, NULL, &pwm_mcux_ctimer_data_##n,         \
+			      &pwm_mcux_ctimer_config_##n, POST_KERNEL,                            		\
+						  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_mcux_ctimer_driver_api); \
+                                                                                            \
+
+#endif /* CONFIG_PWM_CAPTURE */
+
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_MCUX_CTIMER_DEVICE_INIT_MCUX)

--- a/dts/bindings/pwm/nxp,ctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,ctimer-pwm.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  prescaler:
+  prescale:
     type: int
     default: 1
     description: |
@@ -22,6 +22,54 @@ properties:
     type: int
     required: true
     description: clock to use
+
+  mode:
+    type: int
+    description: |
+      required when CONFIG_PWM_CAPTURE enabled
+      timer mode
+    default: 0
+    enum:
+      - 0 # kCTIMER_TimerMode: TC increments on every rising APB bus clock edge.
+      - 1 # kCTIMER_IncreaseOnRiseEdge: TC increments on rising edge of input signal.
+      - 2 # kCTIMER_IncreaseOnFallEdge: TC increments on falling edge of input signal.
+
+  channel:
+    type: int
+    description: |
+      required when CONFIG_PWM_CAPTURE enabled
+      input channel number
+    default: 0
+    enum:
+      - 0 # kCTIMER_Capture_0
+      - 1 # kCTIMER_Capture_1
+      - 2 # kCTIMER_Capture_2
+      - 3 # kCTIMER_Capture_3
+
+  capture-channel-enable:
+    type: boolean
+    description: |
+      required when CONFIG_PWM_CAPTURE enabled
+      whether to use capture channel register
+      if Set to true, the capture channel will be enabled,
+      timer and prescaler will be cleared when capture-edge event occurs.
+
+  capture-edge:
+    type: int
+    description: |
+      required when CONFIG_PWM_CAPTURE enabled
+      capture event when edge occurs
+    default: 0
+    enum:
+      - 1 # kCTIMER_Capture_RiseEdge
+      - 2 # kCTIMER_Capture_FallEdge
+
+  inputmux:
+    type: int
+    description: |
+      required when CONFIG_PWM_CAPTURE enabled
+      inputmux routing
+      inp0 ~ inp19
 
   "#pwm-cells":
     const: 3


### PR DESCRIPTION
Implement capture mode in ctimer driver and renamed several macros and variables to be more intuitive.