### PR TITLE
boards: arm: fvp_base_revc_2xaem: fix FVP reference link

### DIFF
--- a/boards/arm/fvp_base_revc_2xaem/doc/index.rst
+++ b/boards/arm/fvp_base_revc_2xaem/doc/index.rst
@@ -169,4 +169,4 @@ References
 **********
 
 - `Arm Architecture Reference Manual - Armv8 <https://developer.arm.com/documentation/ddi0487/latest>`_
-- `Fixed Virtual Platforms <https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms>`_
+- `Fixed Virtual Platforms <https://developer.arm.com/Tools%20and%20Software/Fixed%20Virtual%20Platforms/Arm%20Architecture%20FVPs>`_


### PR DESCRIPTION
Update the Fixed Virtual Platforms reference URL to point to the
Arm Architecture FVPs download page instead of the general product
overview page.
