### PR TITLE
modules: hostap: Remove md5

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -463,10 +463,6 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MSCHAPV2
   EAP_MSCHAPv2
 )
 
-if(CONFIG_EAP_TTLS OR CONFIG_EAP_MSCHAPV2)
-  zephyr_library_sources(${HOSTAP_SRC_BASE}/eap_common/chap.c)
-endif()
-
 zephyr_library_sources_ifdef(CONFIG_EAP_LEAP
   ${HOSTAP_SRC_BASE}/eap_peer/eap_leap.c
 )

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -465,14 +465,6 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MSCHAPV2
   EAP_MSCHAPv2
 )
 
-zephyr_library_sources_ifdef(CONFIG_EAP_LEAP
-  ${HOSTAP_SRC_BASE}/eap_peer/eap_leap.c
-)
-
-zephyr_library_compile_definitions_ifdef(CONFIG_EAP_LEAP
-  EAP_LEAP
-)
-
 zephyr_library_sources_ifdef(CONFIG_EAP_PSK
   ${HOSTAP_SRC_BASE}/eap_peer/eap_psk.c
   ${HOSTAP_SRC_BASE}/eap_common/eap_psk_common.c

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -47,6 +47,8 @@ zephyr_library_compile_definitions(
   CONFIG_CTRL_IFACE_ZEPHYR
   CONFIG_SUITEB192
   CONFIG_SUITEB
+  # Though MbedTLS is not FIPS compliant, we don't want to use broken crypto algorithms
+  CONFIG_FIPS
 )
 
 

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -297,8 +297,6 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
   ${HOSTAP_SRC_BASE}/crypto/aes-internal-enc.c
   ${HOSTAP_SRC_BASE}/crypto/aes-internal-dec.c
   ${HOSTAP_SRC_BASE}/crypto/aes-omac1.c
-  ${HOSTAP_SRC_BASE}/crypto/md5.c
-  ${HOSTAP_SRC_BASE}/crypto/md5-internal.c
   ${HOSTAP_SRC_BASE}/crypto/sha1.c
   ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
   ${HOSTAP_SRC_BASE}/crypto/sha1-pbkdf2.c
@@ -448,14 +446,6 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_PEAP
   EAP_PEAP
 )
 
-zephyr_library_sources_ifdef(CONFIG_EAP_MD5
-  ${HOSTAP_SRC_BASE}/eap_peer/eap_md5.c
-)
-
-zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MD5
-  EAP_MD5
-)
-
 zephyr_library_sources_ifdef(CONFIG_EAP_GTC
   ${HOSTAP_SRC_BASE}/eap_peer/eap_gtc.c
 )
@@ -473,7 +463,7 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_MSCHAPV2
   EAP_MSCHAPv2
 )
 
-if(CONFIG_EAP_TTLS OR CONFIG_EAP_MSCHAPV2 OR CONFIG_EAP_MD5)
+if(CONFIG_EAP_TTLS OR CONFIG_EAP_MSCHAPV2)
   zephyr_library_sources(${HOSTAP_SRC_BASE}/eap_common/chap.c)
 endif()
 
@@ -665,14 +655,6 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_SERVER_TLS
   EAP_SERVER_TLS
 )
 
-zephyr_library_sources_ifdef(CONFIG_EAP_SERVER_MD5
-  ${HOSTAP_SRC_BASE}/eap_server/eap_server_md5.c
-)
-
-zephyr_library_compile_definitions_ifdef(CONFIG_EAP_SERVER_MD5
-  EAP_SERVER_MD5
-)
-
 zephyr_library_sources_ifdef(CONFIG_EAP_SERVER_MSCHAPV2
   ${HOSTAP_SRC_BASE}/eap_server/eap_server_mschapv2.c
 )
@@ -733,7 +715,6 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
   ${HOSTAP_SRC_BASE}/crypto/crypto_module_tests.c
   ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
   ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
-  ${HOSTAP_SRC_BASE}/crypto/sha1-tlsprf.c
 )
 endif()
 

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -177,7 +177,6 @@ config WIFI_NM_WPA_SUPPLICANT_CRYPTO_ALT
 	select MBEDTLS_CIPHER_MODE_CBC_ENABLED
 	select MBEDTLS_CIPHER_AES_ENABLED
 	select MBEDTLS_CIPHER_DES_ENABLED
-	select MBEDTLS_MD5
 	select MBEDTLS_SHA1
 	select MBEDTLS_SHA384
 	select MBEDTLS_ENTROPY_C
@@ -222,7 +221,6 @@ config WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
 	select PSA_WANT_ALG_HMAC
 	select PSA_WANT_ALG_CCM
 	select PSA_WANT_ALG_CTR
-	select PSA_WANT_ALG_MD5
 	select PSA_WANT_ALG_SHA_1
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_ALG_SHA_224
@@ -267,9 +265,6 @@ config EAP_TTLS
 
 config EAP_PEAP
 	bool "EAP-PEAP support"
-
-config EAP_MD5
-	bool "EAP-MD5 support"
 
 config EAP_GTC
 	bool "EAP-GTC support"
@@ -389,9 +384,6 @@ config EAP_SERVER_TLS
 
 config EAP_SERVER_IDENTITY
 	bool "EAP-IDENTITY server support"
-
-config EAP_SERVER_MD5
-	bool "EAP-MD5 server support"
 
 config EAP_SERVER_MSCHAPV2
 	bool "EAP-MSCHAPV2 server support"

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -272,9 +272,6 @@ config EAP_GTC
 config EAP_MSCHAPV2
 	bool "EAP-MSCHAPv2 support"
 
-config EAP_LEAP
-	bool "EAP-LEAP support"
-
 config EAP_PSK
 	bool "EAP-PSK support"
 

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -690,6 +690,9 @@ config NW_SEL_RELIABILITY
 	default y
 	depends on WIFI_NM_WPA_SUPPLICANT_NW_SEL_RELIABILITY
 
+config FIPS
+	bool
+
 choice WIFI_NM_WPA_SUPPLICANT_NW_SEL
 	prompt "WPA supplicant Network selection criterion"
 	default WIFI_NM_WPA_SUPPLICANT_NW_SEL_THROUGHPUT

--- a/modules/hostap/src/supp_main.h
+++ b/modules/hostap/src/supp_main.h
@@ -11,7 +11,7 @@
 #if !defined(CONFIG_EAP_TLS) && !defined(CONFIG_EAP_TTLS) && \
 	!defined(CONFIG_EAP_PEAP) && !defined(CONFIG_EAP_FAST) && \
 	!defined(CONFIG_EAP_SIM) && !defined(CONFIG_EAP_AKA) && \
-	!defined(CONFIG_EAP_MD5) && !defined(CONFIG_EAP_MSCHAPV2) && \
+	!defined(CONFIG_EAP_MSCHAPV2) && \
 	!defined(CONFIG_EAP_PSK) && !defined(CONFIG_EAP_PAX) && \
 	!defined(CONFIG_EAP_SAKE) && !defined(CONFIG_EAP_GPSK) && \
 	!defined(CONFIG_EAP_PWD) && !defined(CONFIG_EAP_EKE) && \
@@ -21,7 +21,6 @@
 	CONFIG_EAP_TLS    \
 	CONFIG_EAP_TTLS   \
 	CONFIG_EAP_PEAP   \
-	CONFIG_EAP_MD5        \
 	CONFIG_EAP_MSCHAPV2    \
 	CONFIG_EAP_LEAP    \
 	CONFIG_EAP_PSK   \

--- a/modules/hostap/src/supp_main.h
+++ b/modules/hostap/src/supp_main.h
@@ -15,14 +15,12 @@
 	!defined(CONFIG_EAP_PSK) && !defined(CONFIG_EAP_PAX) && \
 	!defined(CONFIG_EAP_SAKE) && !defined(CONFIG_EAP_GPSK) && \
 	!defined(CONFIG_EAP_PWD) && !defined(CONFIG_EAP_EKE) && \
-	!defined(CONFIG_EAP_IKEV2) && !defined(CONFIG_EAP_GTC) && \
-	!defined(CONFIG_EAP_LEAP)
+	!defined(CONFIG_EAP_IKEV2) && !defined(CONFIG_EAP_GTC)
 #error "At least one of the following EAP methods need to be defined    \
 	CONFIG_EAP_TLS    \
 	CONFIG_EAP_TTLS   \
 	CONFIG_EAP_PEAP   \
 	CONFIG_EAP_MSCHAPV2    \
-	CONFIG_EAP_LEAP    \
 	CONFIG_EAP_PSK   \
 	CONFIG_EAP_PAX   \
 	CONFIG_EAP_SAKE   \

--- a/tests/boards/nrf/nrf70/ent_security/testcase.yaml
+++ b/tests/boards/nrf/nrf70/ent_security/testcase.yaml
@@ -21,9 +21,6 @@ tests:
   wifi.build.crypto_enterprise_peap:
     extra_configs:
       - CONFIG_EAP_PEAP=y
-  wifi.build.crypto_enterprise_md5:
-    extra_configs:
-      - CONFIG_EAP_MD5=y
   wifi.build.crypto_enterprise_mschapv2:
     extra_configs:
       - CONFIG_EAP_MSCHAPV2=y

--- a/tests/boards/nrf/nrf70/ent_security/testcase.yaml
+++ b/tests/boards/nrf/nrf70/ent_security/testcase.yaml
@@ -24,9 +24,6 @@ tests:
   wifi.build.crypto_enterprise_mschapv2:
     extra_configs:
       - CONFIG_EAP_MSCHAPV2=y
-  wifi.build.crypto_enterprise_leap:
-    extra_configs:
-      - CONFIG_EAP_LEAP=y
   wifi.build.crypto_enterprise_psk:
     extra_configs:
       - CONFIG_EAP_PSK=y

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -25,7 +25,6 @@ tests:
       - CONFIG_EAP_TLS=y
       - CONFIG_EAP_TTLS=y
       - CONFIG_EAP_PEAP=y
-      - CONFIG_EAP_MD5=y
       - CONFIG_EAP_MSCHAPV2=y
       - CONFIG_EAP_LEAP=y
       - CONFIG_EAP_PSK=y

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -26,7 +26,6 @@ tests:
       - CONFIG_EAP_TTLS=y
       - CONFIG_EAP_PEAP=y
       - CONFIG_EAP_MSCHAPV2=y
-      - CONFIG_EAP_LEAP=y
       - CONFIG_EAP_PSK=y
       - CONFIG_EAP_PAX=y
       - CONFIG_EAP_SAKE=y

--- a/west.yml
+++ b/west.yml
@@ -291,7 +291,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: f5708c522793b0de59f467080a33caac769cd525
+      revision: 8fa6fe8b1df12a727e86048f587161b241590ca0
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
MD5 is deprecated and the security methods that use are not officially supported in Zephyr (EAP-MD5, TLSv1 etc), so, remove the code related to MD5 and disable it in hostap.