### PR TITLE
scripts: checkpatch: warn on sizeof(char constant)

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -6183,6 +6183,13 @@ sub process {
 			     "sizeof(& should be avoided\n" . $herecurr);
 		}
 
+# check for sizeof(character literal)
+		if ($line =~ /\bsizeof\s*\(\s*'/ &&
+			$line !~ /\bsizeof\s*\(\s*\(\s*[^)]+\s*\)\s*'/) {
+			WARN("SIZEOF_CHAR_LITERAL",
+     			"sizeof(character constant) is sizeof(int) in C; use sizeof((char)'x') (or +1) instead\n" . $herecurr);
+		}
+
 # check for sizeof without parenthesis
 		if ($line =~ /\bsizeof\s+((?:\*\s*|)$Lval|$Type(?:\s+$Lval|))/) {
 			if (WARN("SIZEOF_PARENTHESIS",


### PR DESCRIPTION
Character constants like 'a' have type int in C, so sizeof('a') is typically sizeof(int).
Add a checkpatch warning to catch sizeof('...') and suggest casting to char (or using +1 for buffer sizing).

This change adds a checkpatch warning for sizeof('...') and suggests using sizeof((char)'x') or +1 instead.