### PR TITLE
samples: drivers: espi: Fix reference to SPI driver for TAF sample code

### DIFF
--- a/samples/drivers/espi/boards/mec172xevb_assy6906.overlay
+++ b/samples/drivers/espi/boards/mec172xevb_assy6906.overlay
@@ -43,9 +43,7 @@
 	reset-source = "ESPI_RESET";
 };
 
-&spi0 {
+&qspi0 {
 	status = "okay";
 	clock-frequency = <24000000>;
-	chip-select = <0>;
-	lines = <4>;
 };

--- a/samples/drivers/espi/boards/mec172xmodular_assy6930.overlay
+++ b/samples/drivers/espi/boards/mec172xmodular_assy6930.overlay
@@ -39,11 +39,9 @@
 	reset-source = "ESPI_RESET";
 };
 
-&spi0 {
+&qspi0 {
 	status = "okay";
 	clock-frequency = <24000000>;
-	chip-select = <0>;
-	lines = <4>;
 };
 
 /* Disable unwanted VWs notifications

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -99,7 +99,7 @@ struct saf_addr_info {
 	uintptr_t saf_struct_addr;
 	uintptr_t saf_exp_addr;
 };
-static const struct device *const qspi_dev = DEVICE_DT_GET(DT_NODELABEL(spi0));
+static const struct device *const qspi_dev = DEVICE_DT_GET(DT_NODELABEL(qspi0));
 static const struct device *const espi_saf_dev = DEVICE_DT_GET(DT_NODELABEL(espi_saf0));
 static uint8_t safbuf[SAF_TEST_BUF_SIZE] __aligned(4);
 static uint8_t safbuf2[SAF_TEST_BUF_SIZE] __aligned(4);


### PR DESCRIPTION
spi0 node removed in recently Microchip driver update https://github.com/zephyrproject-rtos/zephyr/pull/102604
Update sample code to fix build error.