### PR TITLE
stm32n6: enabling of DMA2D support via LVGL

### DIFF
--- a/boards/shields/nxp_mx8_dsi_oled1a/Kconfig.defconfig
+++ b/boards/shields/nxp_mx8_dsi_oled1a/Kconfig.defconfig
@@ -16,9 +16,6 @@ if DISPLAY
 
 if LVGL
 
-config LV_Z_VDB_SIZE
-	default 100
-
 config LV_Z_DOUBLE_VDB
 	default y
 

--- a/boards/shields/rk043fn02h_ct/Kconfig.defconfig
+++ b/boards/shields/rk043fn02h_ct/Kconfig.defconfig
@@ -8,10 +8,6 @@ if LVGL
 config INPUT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
+++ b/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
@@ -11,10 +11,6 @@ config INPUT
 config INPUT_GT911_INTERRUPT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rk055hdmipi4m/Kconfig.defconfig
+++ b/boards/shields/rk055hdmipi4m/Kconfig.defconfig
@@ -20,10 +20,6 @@ config INPUT
 config INPUT_GT911_INTERRUPT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
+++ b/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
@@ -22,10 +22,6 @@ config INPUT
 config INPUT_GT911_INTERRUPT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rtk7eka6m3b00001bu/Kconfig.defconfig
+++ b/boards/shields/rtk7eka6m3b00001bu/Kconfig.defconfig
@@ -10,10 +10,6 @@ if LVGL
 config INPUT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rtklcdpar1s00001be/Kconfig.defconfig
+++ b/boards/shields/rtklcdpar1s00001be/Kconfig.defconfig
@@ -10,10 +10,6 @@ if LVGL
 config INPUT
 	default y
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/rtkmipilcdb00000be/Kconfig.defconfig
+++ b/boards/shields/rtkmipilcdb00000be/Kconfig.defconfig
@@ -19,10 +19,6 @@ config INPUT
 config INPUT_INIT_PRIORITY
 	default 89
 
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/waveshare_dsi_lcd/Kconfig.defconfig
+++ b/boards/shields/waveshare_dsi_lcd/Kconfig.defconfig
@@ -10,9 +10,6 @@ if DISPLAY
 
 if LVGL
 
-config LV_Z_VDB_SIZE
-	default 100
-
 config LV_Z_DOUBLE_VDB
 	default y
 

--- a/boards/st/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7b3i_dk/Kconfig.defconfig
@@ -19,9 +19,6 @@ config LV_USE_DRAW_DMA2D
 config STM32_LTDC_FB_NUM
 	default 2
 
-config LV_Z_VDB_SIZE
-	default 100
-
 config LV_Z_DOUBLE_VDB
 	default y
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -578,6 +578,10 @@ zephyr_jpegenc: &jpeg {
 	status = "okay";
 };
 
+&dma2d {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1583,6 +1583,13 @@
 				status = "disabled";
 			};
 		};
+
+		dma2d: dma@58021000 {
+			compatible = "st,stm32-dma2d";
+			reg = <0x58021000 0x1000>;
+			interrupts = <60 0>;
+			status = "disabled";
+		};
 	};
 
 	iocell: iocell {

--- a/dts/bindings/display/st,stm32-dma2d.yaml
+++ b/dts/bindings/display/st,stm32-dma2d.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2026 STMicroelectronics.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: STM32 Chrom-ART Accelerator (DMA2D)
+
+description: |
+    The Chrom-ART Accelerator (DMA2D) is a specialized DMA dedicated to
+    image manipulation such as fill, copy, format conversion, blending.
+
+compatible: "st,stm32-dma2d"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -190,6 +190,9 @@ endif # LV_Z_RUN_LVGL_ON_WORKQUEUE
 config LV_USE_DRAW_DMA2D
 	bool
 
+config LV_USE_DRAW_DMA2D_INTERRUPT
+	bool
+
 config LV_DRAW_DMA2D_HAL_INCLUDE
 	string
 	help

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -173,6 +173,46 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_32 if STM32_LTDC_ARGB8888
 endchoice
 
+# In case of using DMA2D, buffer alignment must be ensured
+# for both cache handling as well as DMA2D address registers
+# constraints
+# Keep it simple and always align on cache lines
+if DT_HAS_ST_STM32_DMA2D_ENABLED
+# Align buffer provided to DMA2D on 32 bytes boundaries
+config LV_ATTRIBUTE_MEM_ALIGN_SIZE
+	default 32
+
+# Align area width on cache line (32 bytes), depends on format
+config LV_Z_AREA_X_ALIGNMENT_WIDTH
+	default 16 if STM32_LTDC_RGB565
+	default 96 if STM32_LTDC_RGB888
+	default 8 if STM32_LTDC_ARGB8888
+
+config LV_Z_VDB_ALIGN
+	default 32
+
+config LV_DRAW_BUF_ALIGN
+	default 32
+
+# Necessary for the LV_Z_USE_OSAL
+config DYNAMIC_THREAD
+	default y
+config DYNAMIC_THREAD_POOL_SIZE
+	default 1
+config DYNAMIC_THREAD_STACK_SIZE
+	default 8192
+
+config LV_Z_USE_OSAL
+	default y
+
+config LV_USE_DRAW_DMA2D
+	default y
+
+config LV_USE_DRAW_DMA2D_INTERRUPT
+	default y
+
+endif # DT_HAS_ST_STM32_DMA2D_ENABLED
+
 endif # STM32_LTDC && LVGL
 
 endif # SOC_FAMILY_STM32

--- a/soc/st/stm32/stm32n6x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig.defconfig
@@ -38,4 +38,12 @@ configdefault NVMEM
 
 endif # STM32_IOCELL
 
+# Add LVGL HAL include file for SOC supporting DMA2D
+if LVGL && DT_HAS_ST_STM32_DMA2D_ENABLED
+
+config LV_DRAW_DMA2D_HAL_INCLUDE
+	default "stm32n6xx.h"
+
+endif # LVGL
+
 endif # SOC_SERIES_STM32N6X


### PR DESCRIPTION
This PR add LVGL DMA2D support for the STM32N6.

It depends on the LVGL PR https://github.com/lvgl/lvgl/pull/9642 which include improvements / fixes in the DMA2D support within LVGL.

In order to allow LVGL get access to the DMA2D IRQs, a dma2d node & bindings is introduced within the Zephyr DT. It is planned to also introduce a full Zephyr based DMA2D driver in order to let Zephyr application & other devices benefit from the DMA2D capabilities, in which case that node will be used to enable the DMA2D.