### PR TITLE
MAINTAINERS: adds collaborators for NXP boards and shields

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3607,6 +3607,7 @@ NXP Platform Wireless:
       collaborators:
         - MaochenWang1
       files:
+        - boards/shields/nxp_m2_wifi_bt/
         - drivers/wifi/
         - samples/net/
     - name: NXP IEEE802.15.4
@@ -3726,6 +3727,28 @@ NXP Platforms (MCU):
         - boards/nxp/vmu*/
         - boards/nxp/rddrone_fmuk66/
         - tests/boards/vmu_rt1170/
+    - name: NXP Camera Shields
+      collaborators:
+        - ngphibang
+      files:
+        - boards/shields/nxp_btb44_ov5640/
+    - name: NXP Display Shields
+      collaborators:
+        - KATE-WANG-NXP
+      files:
+        - boards/shields/g1120b0mipi/
+        - boards/shields/lcd_par_s035/
+        - boards/shields/rk043fn02h_ct/
+        - boards/shields/rk043fn66hs_ctg/
+        - boards/shields/rk055hdmipi4m
+        - boards/shields/rk055hdmipi4ma0/
+        - boards/shields/zc143ac72mipi/
+    - name: NXP I3C Test Shields
+      collaborators:
+        - hakehuang
+      files:
+        - boards/shields/p3t1755dp_ard_i2c/
+        - boards/shields/p3t1755dp_ard_i3c/
     - name: NXP MCU k32l
       collaborators:
         - iia

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3749,6 +3749,14 @@ NXP Platforms (MCU):
       files:
         - boards/shields/p3t1755dp_ard_i2c/
         - boards/shields/p3t1755dp_ard_i3c/
+    - name: NXP MCU LPC11U6x
+      collaborators:
+        - simonguinot
+      files:
+        - boards/nxp/lpcxpresso11u68/
+        - soc/nxp/lpc/lpc11u6x/
+      files-regex:
+        - .*lpc11u6.*
     - name: NXP MCU KE1xF
       collaborators:
         - henrikbrixandersen

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3749,6 +3749,14 @@ NXP Platforms (MCU):
       files:
         - boards/shields/p3t1755dp_ard_i2c/
         - boards/shields/p3t1755dp_ard_i3c/
+    - name: NXP MCU KE1xF
+      collaborators:
+        - henrikbrixandersen
+      files:
+        - boards/nxp/twr_ke18f/
+        - soc/nxp/kinetis/ke1xf/
+      files-regex:
+        - .*ke1*f.*
     - name: NXP MCU k32l
       collaborators:
         - iia


### PR DESCRIPTION
Adds shields maintained by NXP with NXP collaborators.  And adds the following collaborators who contributed boards:
- @henrikbrixandersen contributed the [twr_ke18f](https://docs.zephyrproject.org/latest/boards/nxp/twr_ke18f/doc/index.html)  in https://github.com/zephyrproject-rtos/zephyr/pull/16049