### PR TITLE
rtio: SQE cache line sizing adjustments

### DIFF
--- a/subsys/rtio/Kconfig
+++ b/subsys/rtio/Kconfig
@@ -39,6 +39,14 @@ config RTIO_SYS_MEM_BLOCKS
 	  without a pre-allocated memory buffer. Instead the buffer will be taken
 	  from the allocated memory pool associated with the RTIO context.
 
+config RTIO_OP_DELAY
+	bool "Delay Operation"
+	default y
+	help
+	  Enable OP_DELAY which allows for, in chains of operations, delaying using a
+	  kernel timer. Note this makes the size of the submission queue entries
+	  typically larger than a dcache line and may have performance implications.
+
 rsource "Kconfig.workq"
 
 module = RTIO

--- a/subsys/rtio/Kconfig
+++ b/subsys/rtio/Kconfig
@@ -47,6 +47,13 @@ config RTIO_OP_DELAY
 	  kernel timer. Note this makes the size of the submission queue entries
 	  typically larger than a dcache line and may have performance implications.
 
+config RTIO_SQE_CACHELINE_CHECK
+	bool "SQE Cacheline size check"
+	help
+	  At build time check the size of struct rtio_sqe to ensure it is less than a
+	  cache line otherwise the build will fail. This ensures high performance on
+	  systems that are sensitive to data cache effects.
+
 rsource "Kconfig.workq"
 
 module = RTIO

--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -40,9 +40,11 @@ static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe, int last_result)
 		sqe->callback.callback(iodev_sqe->r, sqe, last_result, sqe->callback.arg0);
 		rtio_iodev_sqe_ok(iodev_sqe, 0);
 		break;
+#ifdef CONFIG_RTIO_OP_DELAY
 	case RTIO_OP_DELAY:
 		rtio_sched_alarm(iodev_sqe, sqe->delay.timeout);
 		break;
+#endif /* CONFIG_RTIO_OP_DELAY */
 	case RTIO_OP_AWAIT:
 		rtio_iodev_sqe_await_signal(iodev_sqe, rtio_executor_sqe_signaled, NULL);
 		break;

--- a/subsys/rtio/rtio_sched.c
+++ b/subsys/rtio/rtio_sched.c
@@ -17,6 +17,7 @@
 
 #include "rtio_sched.h"
 
+#ifdef CONFIG_RTIO_OP_DELAY
 static void rtio_sched_alarm_expired(struct _timeout *t)
 {
 	struct rtio_sqe *sqe = CONTAINER_OF(t, struct rtio_sqe, delay.to);
@@ -32,3 +33,4 @@ void rtio_sched_alarm(struct rtio_iodev_sqe *iodev_sqe, k_timeout_t timeout)
 	z_init_timeout(&sqe->delay.to);
 	z_add_timeout(&sqe->delay.to, rtio_sched_alarm_expired, timeout);
 }
+#endif /* CONFIG_RTIO_OP_DELAY */

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -689,6 +689,8 @@ ZTEST(rtio_api, test_rtio_cqe_count_overflow)
 	}
 }
 
+
+#ifdef CONFIG_RTIO_OP_DELAY
 #define RTIO_DELAY_NUM_ELEMS 10
 
 RTIO_DEFINE(r_delay, RTIO_DELAY_NUM_ELEMS, RTIO_DELAY_NUM_ELEMS);
@@ -745,6 +747,7 @@ ZTEST(rtio_api, test_rtio_delay)
 		zassert_is_null(cqe, "There should not be a cqe since next delay has not expired");
 	}
 }
+#endif /* CONFIG_RTIO_OP_DELAY */
 
 #define THROUGHPUT_ITERS 100000
 RTIO_DEFINE(r_throughput, SQE_POOL_SIZE, CQE_POOL_SIZE);

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -47,3 +47,9 @@ tests:
       - userspace
     integration_platforms:
       - qemu_x86
+  rtio.api.no_op_delay:
+    tags: rtio
+    extra_configs:
+      - CONFIG_RTIO_OP_DELAY=n
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
This allows OP_DELAY to be optional (you can opt out, the default is its enabled) as _timeout can be quite large.

Additionally make the cache line size check verify the correct struct size (struct rtio_iodev_sqe) rather than struct rtio_sqe which has been embedded in it for quite some time.

Currently the BUILD_ASSERT always fails, but I have some ideas to fix this. So the check is disabled by default. It can be reenabled, but unless your machines dcache line is large it will likely fail.