### PR TITLE
manifest: update cmsis-nn

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -125,7 +125,7 @@ manifest:
       revision: 97512610ec92058f0119450b9e743eeb7e95b5c8
       path: modules/lib/cmsis-dsp
     - name: cmsis-nn
-      revision: e9328d612ea3ea7d0d210d3ac16ea8667c01abdd
+      revision: d20117c9e88cf9018d6fa06744dddac700c3e3a1
       path: modules/lib/cmsis-nn
     - name: cmsis_6
       repo-path: CMSIS_6


### PR DESCRIPTION
Update `cmsis-nn` with cherry picked commit from upstream to fix pointer arithmetic warning.

Fixing root cause of #103678