### PR TITLE
clock_control: bflb: Improve PLL power consumption and reliability

### DIFF
--- a/drivers/clock_control/clock_control_bl61x.c
+++ b/drivers/clock_control/clock_control_bl61x.c
@@ -622,6 +622,7 @@ static void clock_control_bl61x_init_wifipll_setup(const bl61x_pll_config *const
 	tmp = sys_read32(GLB_BASE + GLB_WIFI_PLL_CFG5_OFFSET);
 	tmp = (tmp & GLB_WIFIPLL_VCO_SPEED_UMSK)
 		| (config->pllVcoSpeed << GLB_WIFIPLL_VCO_SPEED_POS);
+	tmp &= GLB_WIFIPLL_VCO_DIV2_EN_UMSK;
 	sys_write32(tmp, GLB_BASE + GLB_WIFI_PLL_CFG5_OFFSET);
 
 	tmp = sys_read32(GLB_BASE + GLB_WIFI_PLL_CFG6_OFFSET);


### PR DESCRIPTION
Increases performance, reduces clock cross-domain errors, Shaves up to 20mA off the power consumption somehow.

640 OC: 87 mA -> 67 mA
480 OC: 64 mA -> 56 mA
Normal: 52 mA -> 40 mA

No adverse effects observed.