### PR TITLE
debug: thread_analyzer: default `THREAD_RUNTIME_STATS`

### DIFF
--- a/subsys/debug/thread_analyzer/Kconfig
+++ b/subsys/debug/thread_analyzer/Kconfig
@@ -9,7 +9,6 @@ menuconfig THREAD_ANALYZER
 	select INIT_STACKS
 	select THREAD_MONITOR
 	select THREAD_STACK_INFO
-	select THREAD_RUNTIME_STATS
 	help
 	  Enable thread analyzer functionality and all the required modules.
 	  This module may be used to debug thread configuration issues, e.g.
@@ -20,6 +19,9 @@ if THREAD_ANALYZER
 module = THREAD_ANALYZER
 module-str = thread analyzer
 source "subsys/logging/Kconfig.template.log_config"
+
+configdefault THREAD_RUNTIME_STATS
+	default y
 
 choice
 	prompt "Thread analysis print mode"

--- a/subsys/debug/thread_analyzer/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer/thread_analyzer.c
@@ -157,7 +157,6 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	size_t size = thread->stack_info.size;
 	struct ta_cb_user_data *ud = user_data;
 	thread_analyzer_cb cb = ud->cb;
-	unsigned int cpu = ud->cpu;
 	struct thread_analyzer_info info;
 	char hexname[PTR_STR_MAXLEN + 1];
 	const char *name;
@@ -211,7 +210,7 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	}
 
 	if (IS_ENABLED(CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES)) {
-		if (k_thread_runtime_stats_cpu_get(cpu, &rt_stats_all) != 0) {
+		if (k_thread_runtime_stats_cpu_get(ud->cpu, &rt_stats_all) != 0) {
 			ret++;
 		}
 	} else {


### PR DESCRIPTION
`THREAD_RUNTIME_STATS` is not a requirement for the thread analyzer to operate, merely useful. Switch the control to `configdefault` to leave it enabled by default, while allowing both applications to disable the option with `CONFIG_THREAD_RUNTIME_STATS=n` and for alternate defaults to be specified elsewhere.