### PR TITLE
wifi: esp_at: validate IPv4 family before sin_addr access

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -292,6 +292,12 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 		dst = sock->dst;
 		k_mutex_unlock(&sock->lock);
 
+		/* ESP-AT supports IPv4 only */
+		if (dst.sa_family != NET_AF_INET) {
+			ret = -EAFNOSUPPORT;
+			goto out;
+		}
+
 		net_addr_ntop(dst.sa_family,
 			      &net_sin(&dst)->sin_addr,
 			      addr_str, sizeof(addr_str));


### PR DESCRIPTION
Coverity reported a potential out-of-bounds access in drivers/wifi/esp_at/esp_offload.c when accessing sin_addr without validating the sockaddr family.

ESP-AT offload supports IPv4 only, so add an explicit AF_INET check before dereferencing the IPv4-specific structure to prevent invalid memory access.

Fixes: #100001