### PR TITLE
kvss: nvs: fix NVS recovery to handle trailing delete ATEs

### DIFF
--- a/subsys/kvss/nvs/nvs.c
+++ b/subsys/kvss/nvs/nvs.c
@@ -495,7 +495,7 @@ static int nvs_recover_last_ate(struct nvs_fs *fs, uint32_t *addr)
 	*addr -= ate_size;
 	ate_end_addr = *addr;
 	data_end_addr = *addr & ADDR_SECT_MASK;
-	while (ate_end_addr > data_end_addr) {
+	while ((ate_end_addr >= data_end_addr) && (ate_end_addr & ADDR_OFFS_MASK) != 0U) {
 		rc = nvs_flash_ate_rd(fs, ate_end_addr, &end_ate);
 		if (rc) {
 			return rc;


### PR DESCRIPTION
Use ate_end_addr >= data_end_addr instead of > to ensure the last delete ATE is scanned and recovered correctly.