### PR TITLE
arch: riscv: csr: lock IRQs around indirect CSR (micsr) access

### DIFF
--- a/drivers/interrupt_controller/intc_riscv_imsic.c
+++ b/drivers/interrupt_controller/intc_riscv_imsic.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/interrupt_controller/riscv_imsic.h>
-#include <zephyr/arch/riscv/csr.h>
+#include <zephyr/arch/riscv/icsr.h>
 #include <zephyr/arch/riscv/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -270,46 +270,6 @@
 	__swv;							\
 })
 
-#ifdef CONFIG_RISCV_ISA_EXT_SMCSRIND
-
-static inline unsigned long micsr_read(unsigned int index)
-{
-	csr_write(MISELECT, index);
-	return csr_read(MIREG);
-}
-
-static inline void micsr_write(unsigned int index, unsigned long value)
-{
-	csr_write(MISELECT, index);
-	csr_write(MIREG, value);
-}
-
-static inline void micsr_set(unsigned int index, unsigned long mask)
-{
-	csr_write(MISELECT, index);
-	csr_set(MIREG, mask);
-}
-
-static inline void micsr_clear(unsigned int index, unsigned long mask)
-{
-	csr_write(MISELECT, index);
-	csr_clear(MIREG, mask);
-}
-
-static inline unsigned long micsr_read_set(unsigned int index, unsigned long mask)
-{
-	csr_write(MISELECT, index);
-	return csr_read_set(MIREG, mask);
-}
-
-static inline unsigned long micsr_read_clear(unsigned int index, unsigned long mask)
-{
-	csr_write(MISELECT, index);
-	return csr_read_clear(MIREG, mask);
-}
-
-#endif /* CONFIG_RISCV_ISA_EXT_SMCSRIND */
-
 #endif /* !_ASMLANGUAGE */
 
 #endif /* CSR_H_ */

--- a/include/zephyr/arch/riscv/icsr.h
+++ b/include/zephyr/arch/riscv/icsr.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief RISC-V indirect CSR (iCSR) access helpers with IRQ locking
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_ICSR_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_ICSR_H_
+
+#include <zephyr/arch/riscv/csr.h>
+#include <zephyr/irq.h>
+
+#ifdef CONFIG_RISCV_ISA_EXT_SMCSRIND
+
+static inline unsigned long micsr_read(unsigned int index)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	unsigned long val = csr_read(MIREG);
+
+	irq_unlock(key);
+	return val;
+}
+
+static inline void micsr_write(unsigned int index, unsigned long value)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	csr_write(MIREG, value);
+
+	irq_unlock(key);
+}
+
+static inline void micsr_set(unsigned int index, unsigned long mask)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	csr_set(MIREG, mask);
+
+	irq_unlock(key);
+}
+
+static inline void micsr_clear(unsigned int index, unsigned long mask)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	csr_clear(MIREG, mask);
+
+	irq_unlock(key);
+}
+
+static inline unsigned long micsr_read_set(unsigned int index, unsigned long mask)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	unsigned long val = csr_read_set(MIREG, mask);
+
+	irq_unlock(key);
+	return val;
+}
+
+static inline unsigned long micsr_read_clear(unsigned int index, unsigned long mask)
+{
+	unsigned int key = irq_lock();
+
+	csr_write(MISELECT, index);
+	unsigned long val = csr_read_clear(MIREG, mask);
+
+	irq_unlock(key);
+	return val;
+}
+
+#endif /* CONFIG_RISCV_ISA_EXT_SMCSRIND */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_ICSR_H_ */


### PR DESCRIPTION
The micsr_* helpers use a two-step MISELECT+MIREG sequence that is not
atomic. If an interrupt fires between writing MISELECT and accessing
MIREG, the handler could modify MISELECT, causing the MIREG operation
to target the wrong indirect register.

Wrap the MISELECT+MIREG sequence in each micsr_* helper with
irq_lock/irq_unlock to prevent preemption during the two-step access.
This ensures all callers are automatically protected without needing
to add locking at each call site.

Signed-off-by: Afonso Oliveira <afonso.oliveira707@gmail.com>