### PR TITLE
cmake: snippets: skip snippets.py when SNIPPET is unset

### DIFF
--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -71,6 +71,11 @@ function(zephyr_process_snippets)
   list(REMOVE_DUPLICATES SNIPPET_ROOT)
   set(SNIPPET_ROOT "${SNIPPET_ROOT}" PARENT_SCOPE)
 
+  # Skip parsing and validating snippet files if none are requested
+  if(NOT DEFINED SNIPPET)
+    return()
+  endif()
+
   # Generate and include snippets_generated.cmake.
   # The Python script is responsible for checking for unknown
   # snippets.


### PR DESCRIPTION
When SNIPPET is not set, no snippets are applied but snippets.py still runs. Skip invoking it to avoid Python import overhead (~140 ms on my end).

Just an idea to speed up build configuration time. My understanding is that if `SNIPPET` is not defined, then no snippets are required for the build. https://docs.zephyrproject.org/latest/build/snippets/using.html

Tested using: `west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky  --cmake -- --profiling-format=google-trace --profiling-output=cmake-configure-trace.json`

Before (141.6ms):

<img width="1444" height="847" alt="image" src="https://github.com/user-attachments/assets/6a00ba6d-009a-4ff8-a8b7-558472a213c3" />


After(1.1ms):

<img width="1444" height="847" alt="image" src="https://github.com/user-attachments/assets/55267193-d6ce-435c-8b46-68356cdb8bb0" />
