### PR TITLE
boards: rakwireless: rak5010: add SHTC3 temperature and humidity sensor

### DIFF
--- a/boards/rakwireless/rak5010/rak5010_nrf52840.dts
+++ b/boards/rakwireless/rak5010/rak5010_nrf52840.dts
@@ -37,6 +37,7 @@
 		accel0 = &lis3dh;
 		modem-uart = &uart0;
 		modem = &modem;
+		dht0 = &shtc3;
 	};
 };
 
@@ -104,6 +105,14 @@
 	lps22hb-press@5c {
 		compatible = "st,lps22hb-press";
 		reg = <0x5c>;
+	};
+
+	/* Sensiron SHTCx humidity and temperature sensor*/
+	shtc3: shtc3@70 {
+		compatible = "sensirion,shtc3", "sensirion,shtcx";
+		reg = <0x70>;
+		measure-mode = "normal";
+		clock-stretching;
 	};
 };
 


### PR DESCRIPTION
Add devicetree node for the onboard Sensirion SHTC3 temperature and humidity sensor on the RAK5010.

The change allows applications and sensor samples to access temperature and relative humidity readings through the Zephyr sensor subsystem.

Validation:
- Built and tested on rak5010/nrf52840.
- Used an overlay with the samples/sensor/dht_polling sample to expose the device via: aliases { dht0 = &shtc3; }
- Verified temperature and humidity readings over console output.