### PR TITLE
hal_rpi_pico: Pass CONFIG_PICOLIBC to bootloader. Fix compile_options

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -38,6 +38,7 @@ if(CONFIG_HAS_RPI_PICO)
         -DFLASH_TYPE=${flash_type}
         -DPYTHON_EXECUTABLE=${Python3_EXECUTABLE}
         -DRP2_BOOTLOADER_BYPRODUCT=${rp2_bootloader_asm}
+        -DCONFIG_PICOLIBC=${CONFIG_PICOLIBC}
       INSTALL_COMMAND "" # No installation needed
       BUILD_BYPRODUCTS ${rp2_bootloader_asm}
       BUILD_ALWAYS TRUE

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -45,14 +45,14 @@ target_include_directories(boot_stage2 PUBLIC
   )
 
 if(CONFIG_PICOLIBC)
-  set(boot_specs "picolibc.specs")
+  target_compile_options(boot_stage2 PRIVATE "--specs=picolibc.specs")
+  target_link_options(boot_stage2 PRIVATE "--specs=picolibc.specs")
 else()
-  set(boot_specs "nosys.specs")
+  target_link_options(boot_stage2 PRIVATE "--specs=nosys.specs")
 endif()
 
 target_link_options(boot_stage2 PRIVATE
   "-nostartfiles"
-  "--specs=${boot_specs}"
   "-T${boot_stage_dir}/boot_stage2.ld"
   )
 


### PR DESCRIPTION
Oops. #103436 tried to make the bootloader select the correct specs file using CONFIG_PICOLIBC, but that variable wasn't set while configuring the bootloader. Pass that from the Zephyr build into the bootloader build.

This also uncovered a gap in the target_compile_options setting when picolibc is not the default C library -- the bootloader was getting linked with --specs=picolibc.specs but it wasn't getting compiled with that flag, so compilation was happening using the default C library headers.

Without this fix, the bootloader is still compiled with --specs=nosys.specs and fails to link with SDK 1.0.