### PR TITLE
drivers: interrupt_controller: intc_gpio_stm32: Assert against invalid exti lines

### DIFF
--- a/drivers/interrupt_controller/intc_gpio_stm32.c
+++ b/drivers/interrupt_controller/intc_gpio_stm32.c
@@ -89,6 +89,9 @@ static inline uint32_t stm32_exti_linenum_to_src_cfg_line(gpio_pin_t linenum)
  */
 static inline gpio_pin_t ll_exti_line_to_linenum(stm32_gpio_irq_line_t line)
 {
+	__ASSERT(IS_POWER_OF_TWO(line), "Invalid/corrupted LL_EXTI_LINE_n value");
+	__ASSERT_NO_MSG(LOG2(line) < NUM_EXTI_LINES);
+
 	return LOG2(line);
 }
 
@@ -190,8 +193,6 @@ void stm32_gpio_intc_enable_line(stm32_gpio_irq_line_t line)
 {
 	unsigned int irqnum;
 	uint32_t line_num = ll_exti_line_to_linenum(line);
-
-	__ASSERT_NO_MSG(line_num < NUM_EXTI_LINES);
 
 	/* Get matching exti irq provided line thanks to irq_table */
 	irqnum = exti_irq_table[line_num];


### PR DESCRIPTION
Unchecked indexing into intc_gpio_data.cb could lead to overflow in the following functions:

- stm32_gpio_intc_set_irq_callback
- stm32_gpio_intc_remove_irq_callback

Fixes zephyrproject-rtos/zephyr#103573