### PR TITLE
dts: remove 0x and ull from node addresses

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -136,7 +136,7 @@
 		regulator-boot-on;
 	};
 
-	psram: memory@0x38000000 {
+	psram: memory@38000000 {
 		compatible = "zephyr,memory-region";
 		device_type = "memory";
 		reg = <0x38000000 0x8000000>;


### PR DESCRIPTION
0x is node addresses as these are always hexadecimal values.

CC @yishai1999 

This was discussed in https://github.com/zephyrproject-rtos/zephyr/pull/100388#pullrequestreview-3750130954 and also https://github.com/zephyrproject-rtos/zephyr/pull/103535#issuecomment-3864865324