### PR TITLE
drivers: usb: udc: max32: Fix ISR context issues with MAX32 USB

### DIFF
--- a/drivers/usb/udc/udc_max32.c
+++ b/drivers/usb/udc/udc_max32.c
@@ -23,9 +23,13 @@ LOG_MODULE_REGISTER(udc_max32, CONFIG_UDC_DRIVER_LOG_LEVEL);
 
 enum udc_max32_event_type {
 	/* Shim driver event to trigger transfer */
-	UDC_MAX32_EVT_XFER,
+	UDC_MAX32_EVT_START_XFER,
 	/* Setup event */
 	UDC_MAX32_EVT_SETUP,
+	/* Transfer IN complete */
+	UDC_MAX32_EVT_XFER_IN_DONE,
+	/* Transfer OUT complete */
+	UDC_MAX32_EVT_XFER_OUT_DONE,
 };
 
 struct udc_max32_evt {
@@ -82,59 +86,96 @@ static void udc_event_xfer_ctrl_status(const struct device *dev, struct net_buf 
 	udc_ctrl_update_stage(dev, buf);
 }
 
+/*
+ * ISR-context callbacks: These are called from MXC_USB_EventHandler() in
+ * interrupt context.
+ *
+ * They should only push to a message queue and not acquire memory or locks.
+ */
 static void udc_event_xfer_in_callback(void *cbdata)
 {
 	struct req_cb_data *req_cb_data = (struct req_cb_data *)cbdata;
-	struct udc_max32_data *priv = udc_get_private(req_cb_data->dev);
-	MXC_USB_Req_t *ep_request = &priv->ep_request[USB_EP_GET_IDX(req_cb_data->ep)];
-	struct net_buf *buf;
+	struct udc_max32_evt evt = {
+		.type = UDC_MAX32_EVT_XFER_IN_DONE,
+		.ep_cfg = udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep),
+	};
 
-	buf = udc_buf_get(udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep));
-
-	udc_ep_set_busy(udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep), false);
-
-	if (ep_request->error_code) {
-		LOG_ERR("ep 0x%02x error: %x", req_cb_data->ep, ep_request->error_code);
-		udc_submit_ep_event(req_cb_data->dev, buf, ep_request->error_code);
-		return;
-	}
-
-	if (udc_ep_buf_has_zlp(buf)) {
-		udc_ep_buf_clear_zlp(buf);
-	}
-
-	if (req_cb_data->ep == USB_CONTROL_EP_IN) {
-		udc_event_xfer_ctrl_status(req_cb_data->dev, buf);
-	} else {
-		udc_submit_ep_event(req_cb_data->dev, buf, 0);
-	}
+	k_msgq_put(&drv_msgq, &evt, K_NO_WAIT);
 }
 
 static void udc_event_xfer_out_callback(void *cbdata)
 {
 	struct req_cb_data *req_cb_data = (struct req_cb_data *)cbdata;
-	struct udc_max32_data *priv = udc_get_private(req_cb_data->dev);
-	MXC_USB_Req_t *ep_request = &priv->ep_request[USB_EP_GET_IDX(req_cb_data->ep)];
+	struct udc_max32_evt evt = {
+		.type = UDC_MAX32_EVT_XFER_OUT_DONE,
+		.ep_cfg = udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep),
+	};
+
+	k_msgq_put(&drv_msgq, &evt, K_NO_WAIT);
+}
+
+/*
+ * Thread-context (non ISR-safe) handlers for xfer completions.
+ */
+static void udc_event_xfer_in_done(const struct device *dev, struct udc_ep_config *ep_cfg)
+{
+	struct udc_max32_data *priv = udc_get_private(dev);
+	MXC_USB_Req_t *ep_request = &priv->ep_request[USB_EP_GET_IDX(ep_cfg->addr)];
 	struct net_buf *buf;
 
-	buf = udc_buf_get(udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep));
-	net_buf_add(buf, ep_request->actlen);
+	/* Get data from endpoint */
+	buf = udc_buf_get(ep_cfg);
 
-	udc_ep_set_busy(udc_get_ep_cfg(req_cb_data->dev, req_cb_data->ep), false);
+	/* Release the endpoint now that data is acquired */
+	udc_ep_set_busy(ep_cfg, false);
 
+	/* Indicate any USB errors */
 	if (ep_request->error_code) {
-		LOG_ERR("ep 0x%02x error: %x", req_cb_data->ep, ep_request->error_code);
-		udc_submit_ep_event(req_cb_data->dev, buf, ep_request->error_code);
+		LOG_ERR("ep 0x%02x error: %x", ep_cfg->addr, ep_request->error_code);
+		udc_submit_ep_event(dev, buf, ep_request->error_code);
 		return;
 	}
 
-	if (req_cb_data->ep == USB_CONTROL_EP_OUT) {
-		/* Update to next stage of control transfer */
-		udc_ctrl_update_stage(req_cb_data->dev, buf);
+	/* Check if a zero-length packet is needed */
+	if (udc_ep_buf_has_zlp(buf)) {
+		udc_ep_buf_clear_zlp(buf);
+	}
 
-		udc_ctrl_submit_s_out_status(req_cb_data->dev, buf);
+	/* Submit the received buffer to the UDC stack */
+	if (ep_cfg->addr == USB_CONTROL_EP_IN) {
+		udc_event_xfer_ctrl_status(dev, buf);
 	} else {
-		udc_submit_ep_event(req_cb_data->dev, buf, 0);
+		udc_submit_ep_event(dev, buf, 0);
+	}
+}
+
+static void udc_event_xfer_out_done(const struct device *dev, struct udc_ep_config *ep_cfg)
+{
+	struct udc_max32_data *priv = udc_get_private(dev);
+	MXC_USB_Req_t *ep_request = &priv->ep_request[USB_EP_GET_IDX(ep_cfg->addr)];
+	struct net_buf *buf;
+
+	buf = udc_buf_get(ep_cfg);
+	net_buf_add(buf, ep_request->actlen);
+
+	/* Release the endpoint since transfer is done */
+	udc_ep_set_busy(ep_cfg, false);
+
+	/* Indicate any USB errors */
+	if (ep_request->error_code) {
+		LOG_ERR("ep 0x%02x error: %x", ep_cfg->addr, ep_request->error_code);
+		udc_submit_ep_event(dev, buf, ep_request->error_code);
+		return;
+	}
+
+	/* Indicate transfer done to the UDC stack */
+	if (ep_cfg->addr == USB_CONTROL_EP_OUT) {
+		/* Update to next stage of control transfer */
+		udc_ctrl_update_stage(dev, buf);
+
+		udc_ctrl_submit_s_out_status(dev, buf);
+	} else {
+		udc_submit_ep_event(dev, buf, 0);
 	}
 }
 
@@ -321,7 +362,6 @@ static ALWAYS_INLINE void max32_thread_handler(void *const arg)
 
 	LOG_DBG("Driver %p thread started", dev);
 	while (true) {
-		bool start_xfer = false;
 		struct udc_max32_evt evt;
 
 		k_msgq_get(&drv_msgq, &evt, K_FOREVER);
@@ -330,19 +370,21 @@ static ALWAYS_INLINE void max32_thread_handler(void *const arg)
 		case UDC_MAX32_EVT_SETUP:
 			udc_event_setup(dev);
 			break;
-		case UDC_MAX32_EVT_XFER:
-			start_xfer = true;
-			break;
-		default:
-			break;
-		}
-
-		if (start_xfer) {
+		case UDC_MAX32_EVT_START_XFER:
 			if (USB_EP_DIR_IS_IN(evt.ep_cfg->addr)) {
 				udc_event_xfer_in(dev, evt.ep_cfg);
 			} else {
 				udc_event_xfer_out(dev, evt.ep_cfg);
 			}
+			break;
+		case UDC_MAX32_EVT_XFER_IN_DONE:
+			udc_event_xfer_in_done(dev, evt.ep_cfg);
+			break;
+		case UDC_MAX32_EVT_XFER_OUT_DONE:
+			udc_event_xfer_out_done(dev, evt.ep_cfg);
+			break;
+		default:
+			break;
 		}
 	}
 }
@@ -351,7 +393,7 @@ static int udc_max32_ep_enqueue(const struct device *dev, struct udc_ep_config *
 				struct net_buf *buf)
 {
 	struct udc_max32_evt evt = {
-		.type = UDC_MAX32_EVT_XFER,
+		.type = UDC_MAX32_EVT_START_XFER,
 		.ep_cfg = cfg,
 	};
 
@@ -471,7 +513,7 @@ static int udc_max32_ep_clear_halt(const struct device *dev, struct udc_ep_confi
 	/* If there is a request for this endpoint, enqueue the request. */
 	if (udc_buf_peek(cfg) != NULL) {
 		struct udc_max32_evt evt = {
-			.type = UDC_MAX32_EVT_XFER,
+			.type = UDC_MAX32_EVT_START_XFER,
 			.ep_cfg = cfg,
 		};
 
@@ -817,10 +859,10 @@ static const struct udc_api udc_max32_api = {
                                                                                                    \
 	static const struct udc_max32_config udc_max32_config_##n = {                              \
 		.base = (mxc_usbhs_regs_t *)DT_INST_REG_ADDR(n),                                   \
-		.num_of_in_eps = DT_INST_PROP(n, num_out_endpoints),                               \
-		.num_of_out_eps = DT_INST_PROP(n, num_in_endpoints),                               \
-		.ep_cfg_in = ep_cfg_out_##n,                                                       \
-		.ep_cfg_out = ep_cfg_in_##n,                                                       \
+		.num_of_in_eps = DT_INST_PROP(n, num_in_endpoints),                                \
+		.num_of_out_eps = DT_INST_PROP(n, num_out_endpoints),                              \
+		.ep_cfg_in = ep_cfg_in_##n,                                                        \
+		.ep_cfg_out = ep_cfg_out_##n,                                                      \
 		.make_thread = udc_max32_make_thread_##n,                                          \
 		.speed_idx = DT_ENUM_IDX(DT_DRV_INST(n), maximum_speed),                           \
 		.clock = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                    \


### PR DESCRIPTION
MAX32 USB had some functions in ISR context allocating memory & acquiring mutexes. This commit fixes this by separating the transfer completion events into ISR-context and thread-context steps using the message queue. 

Additionally, some apparent swapping of devicetree configuration for in/out endpoints and configuration structs is resolved.

- Rename UDC_MAX32_EVT_XFER to UDC_MAX32_EVT_START_XFER
- Add MAX32 UDC events for XFER_IN_DONE and XFER_OUT_DONE
- Refactor xfer_in/out callbacks to only submit messages to a message queue
- Provide xfer_in_Done and xfer_out_done to handle transfer completions from UDC thread context.
- Add XFER_IN_DONE and XFER_OUT_DONE events to thread handler
- Fix swapping in devicetree macros of num_of_in_eps / num_of_out_eps and ep_cfg_in / ep_cfg_out

I tested this with the CDC-ACM feature while working on Circuitpython's Zephyr port. I'm happy to run other tests as well but this was enough to get this driver into a working state for this purpose. 