### PR TITLE
include: zephyr: Add doxygen coverage for Renesas header files

### DIFF
--- a/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
@@ -3,94 +3,153 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Renesas RA Clock Generator Circuit (CGC) header file
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RA_CGC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RA_CGC_H_
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
+/**
+ * @name Clock source and divider helpers for Renesas RA devices.
+ *
+ * @{
+ */
+
+/**
+ * @brief Conditional property getter based on devicetree status.
+ *
+ * Returns the value of a devicetree property if the node is marked as `okay`.
+ * Otherwise, the provided default value is used.
+ */
 #define RA_CGC_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                               \
-	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value))
+	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), \
+		(DT_PROP(node_id, prop)), (default_value))
 
+/**
+ * @brief Helper to get clock source form device tree.
+ *
+ * Expands to a BSP_CLOCKS_SOURCE_* constant when the node is enabled, or
+ * BSP_CLOCKS_CLOCK_DISABLED otherwise.
+ */
 #define RA_CGC_CLK_SRC(node_id)                                                                    \
-	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),                                             \
-		    (UTIL_CAT(BSP_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))),        \
-		    (BSP_CLOCKS_CLOCK_DISABLED))
+	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), \
+		(UTIL_CAT(BSP_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))), \
+		(BSP_CLOCKS_CLOCK_DISABLED))
 
+/**
+ * @brief Helper to compute a clock divider.
+ *
+ * This macro expands to a RA_CGC_DIV_* prefix combined with a devicetree value.
+ */
 #define RA_CGC_CLK_DIV(clk, prop, default_value)                                                   \
 	UTIL_CAT(RA_CGC_DIV_, DT_NODE_FULL_NAME_UPPER_TOKEN(clk))                                  \
 	(RA_CGC_PROP_HAS_STATUS_OKAY_OR(clk, prop, default_value))
 
-#define RA_CGC_DIV_BCLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_CANFDCLK(n)   UTIL_CAT(BSP_CLOCKS_CANFD_CLOCK_DIV_, n)
-#define RA_CGC_DIV_CECCLK(n)     UTIL_CAT(BSP_CLOCKS_CEC_CLOCK_DIV_, n)
-#define RA_CGC_DIV_CLKOUT(n)     UTIL_CAT(BSP_CLOCKS_CLKOUT_DIV_, n)
-#define RA_CGC_DIV_CPUCLK0(n)    UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_CPUCLK1(n)    UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_MRPCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_CPUCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_FCLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_I3CCLK(n)     UTIL_CAT(BSP_CLOCKS_I3C_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ICLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_LCDCLK(n)     UTIL_CAT(BSP_CLOCKS_LCD_CLOCK_DIV_, n)
-#define RA_CGC_DIV_OCTASPICLK(n) UTIL_CAT(BSP_CLOCKS_OCTA_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PCLKA(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PCLKB(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PCLKC(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PCLKD(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PCLKE(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_PLL(n)        UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLLP(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLLQ(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLLR(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLL2(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLL2P(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLL2Q(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_PLL2R(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)
-#define RA_CGC_DIV_SCICLK(n)     UTIL_CAT(BSP_CLOCKS_SCI_CLOCK_DIV_, n)
-#define RA_CGC_DIV_SPICLK(n)     UTIL_CAT(BSP_CLOCKS_SPI_CLOCK_DIV_, n)
-#define RA_CGC_DIV_U60CLK(n)     UTIL_CAT(BSP_CLOCKS_USB60_CLOCK_DIV_, n)
-#define RA_CGC_DIV_UCLK(n)       UTIL_CAT(BSP_CLOCKS_USB_CLOCK_DIV_, n)
-#define RA_CGC_DIV_SCISPICLK(n)  UTIL_CAT(BSP_CLOCKS_SCISPI_CLOCK_DIV_, n)
-#define RA_CGC_DIV_GPTCLK(n)     UTIL_CAT(BSP_CLOCKS_GPT_CLOCK_DIV_, n)
-#define RA_CGC_DIV_IICCLK(n)     UTIL_CAT(BSP_CLOCKS_IIC_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ADCCLK(n)     UTIL_CAT(BSP_CLOCKS_ADC_CLOCK_DIV_, n)
-#define RA_CGC_DIV_MRICLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_NPUCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)
-#define RA_CGC_DIV_BCLKA(n)      UTIL_CAT(BSP_CLOCKS_BCLKA_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ESWCLK(n)     UTIL_CAT(BSP_CLOCKS_ESW_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ESWPHYCLK(n)  UTIL_CAT(BSP_CLOCKS_ESWPHY_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ETHPHYCLK(n)  UTIL_CAT(BSP_CLOCKS_ETHPHY_CLOCK_DIV_, n)
-#define RA_CGC_DIV_ESCCLK(n)     UTIL_CAT(BSP_CLOCKS_ESC_CLOCK_DIV_, n)
-#define RA_CGC_DIV_DSMIFCLK(n)   UTIL_CAT(BSP_CLOCKS_DSMIF_CLOCK_DIV_, n)
+/**
+ * @defgroup ra_cgc_div Renesas RA Clock Divider Generators
+ * @brief Divider generator macros for multiple clock domains.
+ * @{
+ */
 
-#define BSP_CLOCKS_SOURCE_PLL  BSP_CLOCKS_SOURCE_CLOCK_PLL
-#define BSP_CLOCKS_SOURCE_PLLP BSP_CLOCKS_SOURCE_CLOCK_PLL
-#define BSP_CLOCKS_SOURCE_PLLQ BSP_CLOCKS_SOURCE_CLOCK_PLL1Q
-#define BSP_CLOCKS_SOURCE_PLLR BSP_CLOCKS_SOURCE_CLOCK_PLL1R
+#define RA_CGC_DIV_BCLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< BCLK divider. */
+#define RA_CGC_DIV_CANFDCLK(n)   UTIL_CAT(BSP_CLOCKS_CANFD_CLOCK_DIV_, n)  /**< CANFD divider. */
+#define RA_CGC_DIV_CECCLK(n)     UTIL_CAT(BSP_CLOCKS_CEC_CLOCK_DIV_, n)    /**< CEC divider. */
+#define RA_CGC_DIV_CLKOUT(n)     UTIL_CAT(BSP_CLOCKS_CLKOUT_DIV_, n)       /**< CLKOUT divider. */
+#define RA_CGC_DIV_CPUCLK0(n)    UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< CPUCLK0 divider. */
+#define RA_CGC_DIV_CPUCLK1(n)    UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< CPUCLK1 divider. */
+#define RA_CGC_DIV_MRPCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< MRPCLK divider. */
+#define RA_CGC_DIV_CPUCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< CPUCLK divider. */
+#define RA_CGC_DIV_FCLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< FCLK divider. */
+#define RA_CGC_DIV_I3CCLK(n)     UTIL_CAT(BSP_CLOCKS_I3C_CLOCK_DIV_, n)    /**< I3C divider. */
+#define RA_CGC_DIV_ICLK(n)       UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< ICLK divider. */
+#define RA_CGC_DIV_LCDCLK(n)     UTIL_CAT(BSP_CLOCKS_LCD_CLOCK_DIV_, n)    /**< LCDCLK divider. */
+#define RA_CGC_DIV_OCTASPICLK(n) UTIL_CAT(BSP_CLOCKS_OCTA_CLOCK_DIV_, n)   /**< OCTASPI divider. */
+#define RA_CGC_DIV_PCLKA(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< PCLKA divider. */
+#define RA_CGC_DIV_PCLKB(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< PCLKB divider. */
+#define RA_CGC_DIV_PCLKC(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< PCLKC divider. */
+#define RA_CGC_DIV_PCLKD(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< PCLKD divider. */
+#define RA_CGC_DIV_PCLKE(n)      UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< PCLKE divider. */
+#define RA_CGC_DIV_PLL(n)        UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLL divider. */
+#define RA_CGC_DIV_PLLP(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLLP divider. */
+#define RA_CGC_DIV_PLLQ(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLLQ divider. */
+#define RA_CGC_DIV_PLLR(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLLR divider. */
+#define RA_CGC_DIV_PLL2(n)       UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLL2 divider. */
+#define RA_CGC_DIV_PLL2P(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLL2P divider. */
+#define RA_CGC_DIV_PLL2Q(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLL2Q divider. */
+#define RA_CGC_DIV_PLL2R(n)      UTIL_CAT(BSP_CLOCKS_PLL_DIV_, n)          /**< PLL2R divider. */
+#define RA_CGC_DIV_SCICLK(n)     UTIL_CAT(BSP_CLOCKS_SCI_CLOCK_DIV_, n)    /**< SCICLK divider. */
+#define RA_CGC_DIV_SPICLK(n)     UTIL_CAT(BSP_CLOCKS_SPI_CLOCK_DIV_, n)    /**< SPICLK divider. */
+#define RA_CGC_DIV_U60CLK(n)     UTIL_CAT(BSP_CLOCKS_USB60_CLOCK_DIV_, n)  /**< U60CLK divider. */
+#define RA_CGC_DIV_UCLK(n)       UTIL_CAT(BSP_CLOCKS_USB_CLOCK_DIV_, n)    /**< UCLK divider. */
+#define RA_CGC_DIV_SCISPICLK(n)  UTIL_CAT(BSP_CLOCKS_SCISPI_CLOCK_DIV_, n) /**< SCISPI divider. */
+#define RA_CGC_DIV_GPTCLK(n)     UTIL_CAT(BSP_CLOCKS_GPT_CLOCK_DIV_, n)    /**< GPTCLK divider. */
+#define RA_CGC_DIV_IICCLK(n)     UTIL_CAT(BSP_CLOCKS_IIC_CLOCK_DIV_, n)    /**< IICCLK divider. */
+#define RA_CGC_DIV_ADCCLK(n)     UTIL_CAT(BSP_CLOCKS_ADC_CLOCK_DIV_, n)    /**< ADCCLK divider. */
+#define RA_CGC_DIV_MRICLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< MRICLK divider. */
+#define RA_CGC_DIV_NPUCLK(n)     UTIL_CAT(BSP_CLOCKS_SYS_CLOCK_DIV_, n)    /**< NPUCLK divider. */
+#define RA_CGC_DIV_BCLKA(n)      UTIL_CAT(BSP_CLOCKS_BCLKA_CLOCK_DIV_, n)  /**< BCLKA divider. */
+#define RA_CGC_DIV_ESWCLK(n)     UTIL_CAT(BSP_CLOCKS_ESW_CLOCK_DIV_, n)    /**< ESWCLK divider. */
+#define RA_CGC_DIV_ESWPHYCLK(n)                                                                    \
+	UTIL_CAT(BSP_CLOCKS_ESWPHY_CLOCK_DIV_, n) /**< ESWPHYCLK divider.  */
+#define RA_CGC_DIV_ETHPHYCLK(n) UTIL_CAT(BSP_CLOCKS_ETHPHY_CLOCK_DIV_, n) /**< ETHPHY divider. */
+#define RA_CGC_DIV_ESCCLK(n)    UTIL_CAT(BSP_CLOCKS_ESC_CLOCK_DIV_, n)    /**< ESCCLK divider. */
+#define RA_CGC_DIV_DSMIFCLK(n)  UTIL_CAT(BSP_CLOCKS_DSMIF_CLOCK_DIV_, n)  /**< DSMIFCLK divider. */
+/** @} end of ra_cgc_div group */
 
-#define BSP_CLOCKS_SOURCE_PLL2  BSP_CLOCKS_SOURCE_CLOCK_PLL2
-#define BSP_CLOCKS_SOURCE_PLL2P BSP_CLOCKS_SOURCE_CLOCK_PLL2
-#define BSP_CLOCKS_SOURCE_PLL2Q BSP_CLOCKS_SOURCE_CLOCK_PLL2Q
-#define BSP_CLOCKS_SOURCE_PLL2R BSP_CLOCKS_SOURCE_CLOCK_PLL2R
+/**
+ *  @defgroup bsp_clock_source Renesas RA BSP Clock Source Constants
+ *  @brief Renesas RA BSP clock source constants.
+ *  @{
+ */
 
-#define BSP_CLOCKS_CLKOUT_DIV_1   (0)
-#define BSP_CLOCKS_CLKOUT_DIV_2   (1)
-#define BSP_CLOCKS_CLKOUT_DIV_4   (2)
-#define BSP_CLOCKS_CLKOUT_DIV_8   (3)
-#define BSP_CLOCKS_CLKOUT_DIV_16  (4)
-#define BSP_CLOCKS_CLKOUT_DIV_32  (5)
-#define BSP_CLOCKS_CLKOUT_DIV_64  (6)
-#define BSP_CLOCKS_CLKOUT_DIV_128 (7)
+#define BSP_CLOCKS_SOURCE_PLL   BSP_CLOCKS_SOURCE_CLOCK_PLL   /**< PLL clock source. */
+#define BSP_CLOCKS_SOURCE_PLLP  BSP_CLOCKS_SOURCE_CLOCK_PLL   /**< PLLP clock source. */
+#define BSP_CLOCKS_SOURCE_PLLQ  BSP_CLOCKS_SOURCE_CLOCK_PLL1Q /**< PLLQ clock source. */
+#define BSP_CLOCKS_SOURCE_PLLR  BSP_CLOCKS_SOURCE_CLOCK_PLL1R /**< PLLR clock source. */
+#define BSP_CLOCKS_SOURCE_PLL2  BSP_CLOCKS_SOURCE_CLOCK_PLL2  /**< PLL2 clock source. */
+#define BSP_CLOCKS_SOURCE_PLL2P BSP_CLOCKS_SOURCE_CLOCK_PLL2  /**< PLL2P clock source. */
+#define BSP_CLOCKS_SOURCE_PLL2Q BSP_CLOCKS_SOURCE_CLOCK_PLL2Q /**< PLL2Q clock source. */
+#define BSP_CLOCKS_SOURCE_PLL2R BSP_CLOCKS_SOURCE_CLOCK_PLL2R /**< PLL2R clock source. */
+/** @} end of bsp_clock_source group */
 
+/**
+ *  @defgroup bsp_clock_clkout Renesas RA BSP Clock Clkout Divider Constants
+ *  @brief Renesas RA BSP clock clkout divider constants.
+ *  @{
+ */
+
+#define BSP_CLOCKS_CLKOUT_DIV_1   (0) /**< Clkout div 1. */
+#define BSP_CLOCKS_CLKOUT_DIV_2   (1) /**< Clkout div 2. */
+#define BSP_CLOCKS_CLKOUT_DIV_4   (2) /**< Clkout div 4. */
+#define BSP_CLOCKS_CLKOUT_DIV_8   (3) /**< Clkout div 8. */
+#define BSP_CLOCKS_CLKOUT_DIV_16  (4) /**< Clkout div 16. */
+#define BSP_CLOCKS_CLKOUT_DIV_32  (5) /**< Clkout div 32. */
+#define BSP_CLOCKS_CLKOUT_DIV_64  (6) /**< Clkout div 64. */
+#define BSP_CLOCKS_CLKOUT_DIV_128 (7) /**< Clkout div 128. */
+/** @} end of bsp_clock_clkout group */
+
+/**
+ * @brief Peripheral clock configuration.
+ */
 struct clock_control_ra_pclk_cfg {
-	uint32_t clk_src;
-	uint32_t clk_div;
+	uint32_t clk_src; /**< Clock source selection. */
+	uint32_t clk_div; /**< Clock divider value. */
 };
 
+/**
+ * @brief Subsystem clock control configuration.
+ */
 struct clock_control_ra_subsys_cfg {
-	uint32_t mstp;
-	uint32_t stop_bit;
+	uint32_t mstp;     /**< MSTP register index. */
+	uint32_t stop_bit; /**< Clock stop bit. */
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RA_CGC_H_ */

--- a/include/zephyr/drivers/clock_control/renesas_rx_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_rx_cgc.h
@@ -3,56 +3,114 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Renesas RX Clock Generator Circuit (CGC) header file
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RX_CGC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RX_CGC_H_
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/rx_clock.h>
 
+/**
+ * @name Clock source and divider helpers for Renesas RX devices.
+ * @{
+ */
+
+/**
+ * @brief Conditional property getter based on devicetree status.
+ *
+ * Returns the value of a devicetree property if the node is marked as `okay`.
+ * Otherwise, the provided default value is used.
+ */
 #define RX_CGC_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                               \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value))
 
+/**
+ * @brief Helper to get clock source form device tree.
+ *
+ * Expands to a RX_CLOCKS_SOURCE_* constant when the node is enabled, or
+ * RX_CLOCKS_CLOCK_DISABLED otherwise.
+ */
 #define RX_CGC_CLK_SRC(node_id)                                                                    \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),                                             \
 		    (UTIL_CAT(RX_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))),        \
 		    (RX_CLOCKS_CLOCK_DISABLED))
 
+/**
+ * @brief Helper to get IF clock source form device tree.
+ *
+ * Expands to a RX_IF_CLOCKS_SOURCE_* constant when the node is enabled, or
+ * RX_CLOCKS_CLOCK_DISABLED otherwise.
+ */
 #define RX_IF_CLK_SRC(node_id)                                                                     \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),\
 			(UTIL_CAT(RX_IF_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))),\
 			(RX_CLOCKS_CLOCK_DISABLED))
 
+/**
+ * @brief Helper to get LPT clock source form device tree.
+ *
+ * Expands to a RX_LPT_CLOCKS_SOURCE_* constant when the node is enabled, or
+ * RX_LPT_CLOCKS_NON_USE otherwise.
+ */
 #define RX_LPT_CLK_SRC(node_id)                                                                    \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),\
 			(UTIL_CAT(RX_LPT_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))),\
 			(RX_LPT_CLOCKS_NON_USE))
 
+/**
+ * @brief Helper to get PLL clock source form device tree.
+ *
+ * Expands to a RX_PLL_CLOCKS_SOURCE_* constant when the node is enabled, or
+ * RX_CLOCKS_CLOCK_DISABLED otherwise.
+ */
 #define RX_CGC_PLL_CLK_SRC(node_id)                                                                \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),                                             \
 		(UTIL_CAT(RX_PLL_CLOCKS_SOURCE_, DT_NODE_FULL_NAME_UPPER_TOKEN(node_id))),        \
 		    (RX_CLOCKS_CLOCK_DISABLED))
 
+/**
+ * @brief Peripheral clock configuration (PCLK).
+ */
 struct clock_control_rx_pclk_cfg {
-	const struct device *clock_src_dev;
-	uint32_t clk_div;
+	const struct device *clock_src_dev; /**< Clock source. */
+	uint32_t clk_div;                   /**< Divider configuration. */
 };
 
+/**
+ * @brief Subsystem clock control configuration.
+ */
 struct clock_control_rx_subsys_cfg {
-	uint32_t mstp;
-	uint32_t stop_bit;
+	uint32_t mstp;     /**< MSTP register index. */
+	uint32_t stop_bit; /**< Clock stop bit. */
 };
 
+/**
+ * @brief PLL configuration structure.
+ */
 struct clock_control_rx_pll_cfg {
-	const struct device *clock_dev;
+	const struct device *clock_dev; /**< Device providing PLL source. */
 };
 
+/**
+ * @brief PLL control parameters.
+ */
 struct clock_control_rx_pll_data {
-	uint32_t pll_div;
-	uint32_t pll_mul;
+	uint32_t pll_div; /**< PLL divider. */
+	uint32_t pll_mul; /**< PLL multiplier. */
 };
 
+/**
+ * @brief Root clock configuration.
+ */
 struct clock_control_rx_root_cfg {
-	uint32_t rate;
+	uint32_t rate; /**< Target clock rate in Hz. */
 };
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RX_CGC_H_ */

--- a/include/zephyr/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.h
+++ b/include/zephyr/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.h
@@ -4,21 +4,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Interfaces for Renesas RA external interrupt.
+ * @{
+ */
 #ifndef ZEPHYR_DRIVERS_MISC_RENESAS_RA_EXTERNAL_INTERRUPT_H_
 #define ZEPHYR_DRIVERS_MISC_RENESAS_RA_EXTERNAL_INTERRUPT_H_
 
 #include <zephyr/drivers/gpio.h>
 
+/**
+ * @brief Callback configuration for an external RA GPIO interrupt.
+ *
+ */
 struct gpio_ra_callback {
-	struct device *port;
-	uint8_t port_num;
-	uint8_t pin;
-	enum gpio_int_trig trigger;
-	enum gpio_int_mode mode;
-	void (*isr)(const struct device *dev, gpio_pin_t pin);
+	struct device *port;                                   /**< GPIO port device. */
+	uint8_t port_num;                                      /**< Port index number. */
+	uint8_t pin;                                           /**< Pin number. */
+	enum gpio_int_trig trigger;                            /**< Trigger condition. */
+	enum gpio_int_mode mode;                               /**< Interrupt mode configuration. */
+	void (*isr)(const struct device *dev, gpio_pin_t pin); /**< ISR handler. */
 };
 
+/**
+ * @brief Configure and enable RA external interrupt.
+ *
+ * @param dev       RA external interrupt device instance.
+ * @param callback  Pointer to callback configuration.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
 int gpio_ra_interrupt_set(const struct device *dev, struct gpio_ra_callback *callback);
+
+/**
+ * @brief Disable RA external interrupt.
+ *
+ * @param dev       RA external interrupt device instance.
+ * @param port_num  Port index.
+ * @param pin       Pin number.
+ */
 void gpio_ra_interrupt_unset(const struct device *dev, uint8_t port_num, uint8_t pin);
+
+/** @} */
 
 #endif /* ZEPHYR_DRIVERS_MISC_RENESAS_RA_EXTERNAL_INTERRUPT_H_ */

--- a/include/zephyr/drivers/misc/renesas_rx_dtc/renesas_rx_dtc.h
+++ b/include/zephyr/drivers/misc/renesas_rx_dtc/renesas_rx_dtc.h
@@ -4,116 +4,140 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RX DTC Driver Header File
+ */
+
 #ifndef ZEPHYR_DRIVERS_MISC_RENESAS_RX_DTC_H_
 #define ZEPHYR_DRIVERS_MISC_RENESAS_RX_DTC_H_
 
 #include <zephyr/drivers/gpio.h>
-#define DTC_PLACE_IN_SECTION(x) __attribute__((section(x))) __attribute__((__used__))
-#define DTC_ALIGN_VARIABLE(x)   __aligned(x)
-#define DTC_SECTION_ATTRIBUTE   DTC_PLACE_IN_SECTION(".dtc_vector_table")
 
-#define DTC_VECTOR_TABLE_ENTRIES       (CONFIG_NUM_IRQS)
-#define DTC_PRV_ACT_BIT_MASK           (1 << 15) /* DTC Active flag (DTCSTS.ACT) bit mask */
-#define DTC_PRV_VECT_NR_MASK           (0x00FF)  /* DTC-Activating Vector Number bits mask */
-/* Counter Register A Lower Byte Mask */
-#define DTC_PRV_MASK_CRAL              (0xFFU)
-/* Counter Register A Upper Byte Offset */
-#define DTC_PRV_OFFSET_CRAH            (8U)
-/* Max configurable number of transfers in NORMAL MODE */
-#define DTC_MAX_NORMAL_TRANSFER_LENGTH (0x10000)
-/* Max number of transfers per repeat for REPEAT MODE */
-#define DTC_MAX_REPEAT_TRANSFER_LENGTH (0x100)
-/* Max number of transfers per block in BLOCK MODE */
-#define DTC_MAX_BLOCK_TRANSFER_LENGTH  (0x100)
-/* Max configurable number of blocks to transfer in BLOCK MODE */
-#define DTC_MAX_BLOCK_COUNT            (0x10000)
+/**
+ * @name Renesas RX DTC driver definitions.
+ * @{
+ */
+#define DTC_PLACE_IN_SECTION(x)                                                                    \
+	__attribute__((section(x)))                                                                \
+	__attribute__((__used__)) /**< Attribute to place variable in a specific section. */
+#define DTC_ALIGN_VARIABLE(x) __aligned(x) /**< Attribute to align variable. */
+#define DTC_SECTION_ATTRIBUTE                                                                      \
+	DTC_PLACE_IN_SECTION(".dtc_vector_table") /**< DTC vector table section attribute. */
 
+#define DTC_VECTOR_TABLE_ENTRIES (CONFIG_NUM_IRQS) /**< Number of DTC vector entries. */
+#define DTC_PRV_ACT_BIT_MASK     (1 << 15)         /**< DTC Active flag (DTCSTS.ACT) bit mask */
+#define DTC_PRV_VECT_NR_MASK     (0x00FF)          /**< DTC-Activating Vector Number bits mask */
+#define DTC_PRV_MASK_CRAL        (0xFFU)           /**< Counter Register A Lower Byte Mask */
+#define DTC_PRV_OFFSET_CRAH      (8U)              /**< Counter Register A Upper Byte Offset */
+
+#define DTC_MAX_NORMAL_TRANSFER_LENGTH                                                             \
+	(0x10000) /**< Max configurable number of transfers in NORMAL MODE */
+/**< Max number of transfers per repeat for REPEAT MODE */
+#define DTC_MAX_REPEAT_TRANSFER_LENGTH                                                             \
+	(0x100) /**< Max number of transfers per repeat for REPEAT MODE */
+/**< Max number of transfers per block in BLOCK MODE */
+#define DTC_MAX_BLOCK_TRANSFER_LENGTH                                                              \
+	(0x100) /**< Max number of transfers per block in BLOCK MODE */
+#define DTC_MAX_BLOCK_COUNT                                                                        \
+	(0x10000) /**< Max configurable number of blocks to transfer in BLOCK MODE */
+
+/** @} */
+
+/** @brief Transfer address mode. */
 typedef enum e_transfer_addr_mode {
-	TRANSFER_ADDR_MODE_FIXED = 0,
-	TRANSFER_ADDR_MODE_OFFSET = 1,
-	TRANSFER_ADDR_MODE_INCREMENTED = 2,
-	TRANSFER_ADDR_MODE_DECREMENTED = 3
+	TRANSFER_ADDR_MODE_FIXED = 0,       /**< Mode fixed. */
+	TRANSFER_ADDR_MODE_OFFSET = 1,      /**< Mode offset. */
+	TRANSFER_ADDR_MODE_INCREMENTED = 2, /**< Mode incremented. */
+	TRANSFER_ADDR_MODE_DECREMENTED = 3  /**< Mode decremented. */
 } transfer_addr_mode_t;
 
+/** @brief Area that repeats during repeat transfer mode. */
 typedef enum e_transfer_repeat_area {
-	TRANSFER_REPEAT_AREA_DESTINATION = 0,
-	TRANSFER_REPEAT_AREA_SOURCE = 1
+	TRANSFER_REPEAT_AREA_DESTINATION = 0, /**< Destination repeats. */
+	TRANSFER_REPEAT_AREA_SOURCE = 1       /**< Source repeats. */
 } transfer_repeat_area_t;
 
+/** @brief Transfer interrupt type. */
 typedef enum e_transfer_irq {
-	TRANSFER_IRQ_END = 0,
-	TRANSFER_IRQ_EACH = 1
+	TRANSFER_IRQ_END = 0, /**< Interrupt at end of transfer. */
+	TRANSFER_IRQ_EACH = 1 /**< Interrupt on each transfer. */
 } transfer_irq_t;
 
+/**< Interrupt on each transfer. */
 typedef enum e_transfer_chain_mode {
-	TRANSFER_CHAIN_MODE_DISABLED = 0,
-	TRANSFER_CHAIN_MODE_EACH = 2,
-	TRANSFER_CHAIN_MODE_END = 3
+	TRANSFER_CHAIN_MODE_DISABLED = 0, /**< Chaining disabled. */
+	TRANSFER_CHAIN_MODE_EACH = 2,     /**< Chaining disabled. */
+	TRANSFER_CHAIN_MODE_END = 3       /**< Chain at end. */
 } transfer_chain_mode_t;
 
+/** @brief Transfer data size. */
 typedef enum e_transfer_size {
-	TRANSFER_SIZE_1_BYTE = 0,
-	TRANSFER_SIZE_2_BYTE = 1,
-	TRANSFER_SIZE_4_BYTE = 2
+	TRANSFER_SIZE_1_BYTE = 0, /**< 1-byte transfer. */
+	TRANSFER_SIZE_2_BYTE = 1, /**< 2-byte transfer. */
+	TRANSFER_SIZE_4_BYTE = 2  /**< 4-byte transfer. */
 } transfer_size_t;
 
+/** @brief Transfer mode. */
 typedef enum e_transfer_mode {
-	TRANSFER_MODE_NORMAL = 0,
-	TRANSFER_MODE_REPEAT = 1,
-	TRANSFER_MODE_BLOCK = 2,
-	TRANSFER_MODE_REPEAT_BLOCK = 3
+	TRANSFER_MODE_NORMAL = 0,      /**< Normal transfer mode. */
+	TRANSFER_MODE_REPEAT = 1,      /**< Repeat transfer mode. */
+	TRANSFER_MODE_BLOCK = 2,       /**< Block transfer mode. */
+	TRANSFER_MODE_REPEAT_BLOCK = 3 /**< Repeat block transfer mode. */
 } transfer_mode_t;
 
+/** @brief DTC activation status. */
 typedef enum e_dtc_act_status {
-	DTC_ACT_IDLE = 0,
-	DTC_ACT_CONFIGURED = 1,
-	DTC_ACT_IN_PROGRESS = 2,
+	DTC_ACT_IDLE = 0,        /**< Idle state. */
+	DTC_ACT_CONFIGURED = 1,  /**< Configured state. */
+	DTC_ACT_IN_PROGRESS = 2, /**< In-progress state. */
 } dtc_act_status_t;
 
+/** @brief Transfer information structure. */
 typedef struct st_transfer_info {
 	union {
 		struct {
 			unsigned int: 16;
 			unsigned int: 2;
 
-			transfer_addr_mode_t dest_addr_mode: 2;
+			transfer_addr_mode_t dest_addr_mode: 2; /**< Destination address mode. */
 
-			transfer_repeat_area_t repeat_area: 1;
+			transfer_repeat_area_t repeat_area: 1; /**< Destination address mode. */
 
-			transfer_irq_t irq: 1;
+			transfer_irq_t irq: 1; /**< IRQ type. */
 
-			transfer_chain_mode_t chain_mode: 2;
+			transfer_chain_mode_t chain_mode: 2; /**< Chain mode. */
 
 			unsigned int: 2;
 
-			transfer_addr_mode_t src_addr_mode: 2;
+			transfer_addr_mode_t src_addr_mode: 2; /**< Source address mode. */
 
-			transfer_size_t size: 2;
+			transfer_size_t size: 2; /**< Transfer data size. */
 
-			transfer_mode_t mode: 2;
+			transfer_mode_t mode: 2; /**< Transfer mode. */
 		} transfer_settings_word_b;
 
-		uint32_t transfer_settings_word;
+		uint32_t transfer_settings_word; /**< Raw settings. */
 	};
 
-	void const *volatile p_src;
-	void *volatile p_dest;
-
-	volatile uint16_t num_blocks;
-
-	volatile uint16_t length;
+	void const *volatile p_src;   /**< Source address. */
+	void *volatile p_dest;        /**< Destination address. */
+	volatile uint16_t num_blocks; /**< Number of blocks. */
+	volatile uint16_t length;     /**< Transfer length. */
 } transfer_info_t;
 
+/** @brief Detailed transfer properties. */
 typedef struct st_transfer_properties {
-	uint32_t block_count_max;           /* Maximum number of blocks */
-	uint32_t block_count_remaining;     /* Number of blocks remaining */
-	uint32_t transfer_length_max;       /* Maximum number of transfers */
-	uint32_t transfer_length_remaining; /* Number of transfers remaining */
+	uint32_t block_count_max;           /**< Maximum number of blocks */
+	uint32_t block_count_remaining;     /**< Number of blocks remaining */
+	uint32_t transfer_length_max;       /**< Maximum number of transfers */
+	uint32_t transfer_length_remaining; /**< Number of transfers remaining */
 } transfer_properties_t;
 
+/** @brief DTC transfer status. */
 struct dtc_transfer_status {
-	uint8_t activation_irq;
-	bool in_progress;
+	uint8_t activation_irq; /**< Activation IRQ number. */
+	bool in_progress;       /**< Transfer in progress flag. */
 };
 
 /**
@@ -224,7 +248,7 @@ void dtc_renesas_rx_get_transfer_status(const struct device *dev,
  * @retval -EINVAL  If activation source is invalid.
  */
 int dtc_renesas_rx_info_get(const struct device *dev, uint8_t activation_irq,
-			   transfer_properties_t *const p_properties);
+			    transfer_properties_t *const p_properties);
 
 static ALWAYS_INLINE bool is_valid_activation_irq(uint8_t activation_irq)
 {

--- a/include/zephyr/drivers/misc/renesas_rx_external_interrupt/renesas_rx_external_interrupt.h
+++ b/include/zephyr/drivers/misc/renesas_rx_external_interrupt/renesas_rx_external_interrupt.h
@@ -4,21 +4,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Interfaces for Renesas RX external interrupt.
+ * @{
+ */
+
 #ifndef ZEPHYR_DRIVERS_MISC_RENESAS_RX_EXTERNAL_INTERRUPT_H_
 #define ZEPHYR_DRIVERS_MISC_RENESAS_RX_EXTERNAL_INTERRUPT_H_
 
 #include <zephyr/drivers/gpio.h>
 
+/**
+ * @brief Callback configuration for external RX GPIO interrupt.
+ *
+ */
 struct gpio_rx_callback {
-	struct device *port;
-	uint8_t port_num;
-	uint8_t pin;
-	enum gpio_int_trig trigger;
-	enum gpio_int_mode mode;
-	void (*isr)(const struct device *dev, gpio_pin_t pin);
+	struct device *port;                                   /**< GPIO port device. */
+	uint8_t port_num;                                      /**< Port index number. */
+	uint8_t pin;                                           /**< Pin number. */
+	enum gpio_int_trig trigger;                            /**< Trigger condition. */
+	enum gpio_int_mode mode;                               /**< Interrupt mode configuration. */
+	void (*isr)(const struct device *dev, gpio_pin_t pin); /**< ISR handler. */
 };
 
+/**
+ * @brief Configure and enable an RX external interrupt.
+ *
+ * @param dev       RX external interrupt device instance.
+ * @param callback  Pointer to callback configuration.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
 int gpio_rx_interrupt_set(const struct device *dev, struct gpio_rx_callback *callback);
+
+/**
+ * @brief Disable RX external interrupt.
+ *
+ * @param dev       RX external interrupt device instance.
+ * @param port_num  Port index.
+ * @param pin       Pin number.
+ */
 void gpio_rx_interrupt_unset(const struct device *dev, uint8_t port_num, uint8_t pin);
+
+/** @} */
 
 #endif /* ZEPHYR_DRIVERS_MISC_RENESAS_RX_EXTERNAL_INTERRUPT_H_ */

--- a/include/zephyr/dt-bindings/clock/ra_clock.h
+++ b/include/zephyr/dt-bindings/clock/ra_clock.h
@@ -4,13 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA Clock Generator Circuit (CGC) definitions for Zephyr.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RA_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RA_CLOCK_H_
 
-#define MSTPA 0
-#define MSTPB 1
-#define MSTPC 2
-#define MSTPD 3
-#define MSTPE 4
+/**
+ * @name Renesas RA Module Stop Control Register (MSTP) definitions
+ * @{
+ */
+#define MSTPA 0 /**< Module stop control register A */
+#define MSTPB 1 /**< Module stop control register B */
+#define MSTPC 2 /**< Module stop control register C */
+#define MSTPD 3 /**< Module stop control register D */
+#define MSTPE 4 /**< Module stop control register E */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RA_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/rx_clock.h
+++ b/include/zephyr/dt-bindings/clock/rx_clock.h
@@ -4,86 +4,132 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RX Clock Generator Circuit (CGC) definitions for Zephyr.
+ * This header provides macro constants for clock source selections
+ * and multipliers/dividers for Renesas RX SoCs. These values are used by the
+ * DeviceTree clock control subsystem to describe clock configurations.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RX_H_
 
-#define RX_CLOCKS_SOURCE_CLOCK_LOCO     0
-#define RX_CLOCKS_SOURCE_CLOCK_HOCO     1
-#define RX_CLOCKS_SOURCE_CLOCK_MAIN_OSC 2
-#define RX_CLOCKS_SOURCE_CLOCK_SUBCLOCK 3
-#define RX_CLOCKS_SOURCE_PLL            4
-#define RX_CLOCKS_SOURCE_CLOCK_DISABLE  0xff
+/**
+ * @name Renesas RX clock source selection definitions
+ * @{
+ */
 
-#define RX_IF_CLOCKS_SOURCE_CLOCK_HOCO 0
-#define RX_IF_CLOCKS_SOURCE_CLOCK_LOCO 2
-#define RX_IF_CLOCKS_SOURCE_PLL        5
-#define RX_IF_CLOCKS_SOURCE_PLL2       6
+#define RX_CLOCKS_SOURCE_CLOCK_LOCO     0    /**< LOCO clock source */
+#define RX_CLOCKS_SOURCE_CLOCK_HOCO     1    /**< HOCO clock source */
+#define RX_CLOCKS_SOURCE_CLOCK_MAIN_OSC 2    /**< Main oscillator */
+#define RX_CLOCKS_SOURCE_CLOCK_SUBCLOCK 3    /**< Sub-clock oscillator */
+#define RX_CLOCKS_SOURCE_PLL            4    /**< PLL clock source */
+#define RX_CLOCKS_SOURCE_CLOCK_DISABLE  0xff /**< Clock source disabled. */
 
-#define RX_LPT_CLOCKS_SOURCE_CLOCK_SUBCLOCK       0
-#define RX_LPT_CLOCKS_SOURCE_CLOCK_IWDT_LOW_SPEED 1
-#define RX_LPT_CLOCKS_NON_USE                     2
-#define RX_LPT_CLOCKS_SOURCE_CLOCK_LOCO           3
+/** @} */
 
+/**
+ * @name Renesas RX clock source definitions for some peripherals selections
+ * @brief Encoded clock source values used by certain peripherals.
+ * @{
+ */
+#define RX_IF_CLOCKS_SOURCE_CLOCK_HOCO 0 /**< HOCO clock source */
+#define RX_IF_CLOCKS_SOURCE_CLOCK_LOCO 2 /**< LOCO clock source */
+#define RX_IF_CLOCKS_SOURCE_PLL        5 /**< PLL clock source */
+#define RX_IF_CLOCKS_SOURCE_PLL2       6 /**< PLL2 clock source */
+
+/** @} */
+
+/**
+ * @name Renesas RX clock source selection for Low-power-timer (LPT) definitions
+ * @{
+ */
+#define RX_LPT_CLOCKS_SOURCE_CLOCK_SUBCLOCK       0 /**< Sub-clock oscillator. */
+#define RX_LPT_CLOCKS_SOURCE_CLOCK_IWDT_LOW_SPEED 1 /**< IWDT low spped. */
+#define RX_LPT_CLOCKS_NON_USE                     2 /**< Not use. */
+#define RX_LPT_CLOCKS_SOURCE_CLOCK_LOCO           3 /**< LOCO clock source. */
+
+/** @} */
+
+/**
+ * @name Renesas RX PLL clock source selection (RX26T series only)
+ * @{
+ */
 #ifdef CONFIG_SOC_SERIES_RX26T
-#define RX_PLL_CLOCKS_SOURCE_CLOCK_MAIN_OSC 0
-#define RX_PLL_CLOCKS_SOURCE_CLOCK_HOCO     1
+#define RX_PLL_CLOCKS_SOURCE_CLOCK_MAIN_OSC 0 /**< Main oscillator. */
+#define RX_PLL_CLOCKS_SOURCE_CLOCK_HOCO     1 /**< HOCO clock source. */
 #endif /* CONFIG_SOC_SERIES_RX26T */
 
-#define RX_PLL_MUL_4   7
-#define RX_PLL_MUL_4_5 8
-#define RX_PLL_MUL_5   9
-#define RX_PLL_MUL_5_5 10
-#define RX_PLL_MUL_6   11
-#define RX_PLL_MUL_6_5 12
-#define RX_PLL_MUL_7   13
-#define RX_PLL_MUL_7_5 14
-#define RX_PLL_MUL_8   15
+/** @} */
 
-#define RX_PLL_MUL_10   19
-#define RX_PLL_MUL_10_5 20
-#define RX_PLL_MUL_11   21
-#define RX_PLL_MUL_11_5 22
-#define RX_PLL_MUL_12   23
-#define RX_PLL_MUL_12_5 24
-#define RX_PLL_MUL_13   25
-#define RX_PLL_MUL_13_5 26
-#define RX_PLL_MUL_14   27
-#define RX_PLL_MUL_14_5 28
-#define RX_PLL_MUL_15   29
-#define RX_PLL_MUL_15_5 30
-#define RX_PLL_MUL_16   31
-#define RX_PLL_MUL_16_5 32
-#define RX_PLL_MUL_17   33
-#define RX_PLL_MUL_17_5 34
-#define RX_PLL_MUL_18   35
-#define RX_PLL_MUL_18_5 36
-#define RX_PLL_MUL_19   37
-#define RX_PLL_MUL_19_5 38
-#define RX_PLL_MUL_20   39
-#define RX_PLL_MUL_20_5 40
-#define RX_PLL_MUL_21   41
-#define RX_PLL_MUL_21_5 42
-#define RX_PLL_MUL_22   43
-#define RX_PLL_MUL_22_5 44
-#define RX_PLL_MUL_23   45
-#define RX_PLL_MUL_23_5 46
-#define RX_PLL_MUL_24   47
-#define RX_PLL_MUL_24_5 48
-#define RX_PLL_MUL_25   49
-#define RX_PLL_MUL_25_5 50
-#define RX_PLL_MUL_26   51
-#define RX_PLL_MUL_26_5 52
-#define RX_PLL_MUL_27   53
-#define RX_PLL_MUL_27_5 54
-#define RX_PLL_MUL_28   55
-#define RX_PLL_MUL_28_5 56
-#define RX_PLL_MUL_29   57
-#define RX_PLL_MUL_29_5 58
-#define RX_PLL_MUL_30   59
+/**
+ * @name Renesas RX PLL multiplier definitions
+ * @{
+ */
+#define RX_PLL_MUL_4   7  /**< PLL multiplier ×4 */
+#define RX_PLL_MUL_4_5 8  /**< PLL multiplier ×4.5 */
+#define RX_PLL_MUL_5   9  /**< PLL multiplier ×5 */
+#define RX_PLL_MUL_5_5 10 /**< PLL multiplier ×5.5 */
+#define RX_PLL_MUL_6   11 /**< PLL multiplier ×6 */
+#define RX_PLL_MUL_6_5 12 /**< PLL multiplier ×6.5 */
+#define RX_PLL_MUL_7   13 /**< PLL multiplier ×7 */
+#define RX_PLL_MUL_7_5 14 /**< PLL multiplier ×7.5 */
+#define RX_PLL_MUL_8   15 /**< PLL multiplier ×7 */
 
-#define MSTPA 0
-#define MSTPB 1
-#define MSTPC 2
-#define MSTPD 3
+#define RX_PLL_MUL_10   19 /**< PLL multiplier ×10 */
+#define RX_PLL_MUL_10_5 20 /**< PLL multiplier ×10.5 */
+#define RX_PLL_MUL_11   21 /**< PLL multiplier ×11 */
+#define RX_PLL_MUL_11_5 22 /**< PLL multiplier ×11.5 */
+#define RX_PLL_MUL_12   23 /**< PLL multiplier ×12 */
+#define RX_PLL_MUL_12_5 24 /**< PLL multiplier ×12.5 */
+#define RX_PLL_MUL_13   25 /**< PLL multiplier ×13 */
+#define RX_PLL_MUL_13_5 26 /**< PLL multiplier ×13.5 */
+#define RX_PLL_MUL_14   27 /**< PLL multiplier ×14 */
+#define RX_PLL_MUL_14_5 28 /**< PLL multiplier ×14.5 */
+#define RX_PLL_MUL_15   29 /**< PLL multiplier ×15 */
+#define RX_PLL_MUL_15_5 30 /**< PLL multiplier ×15.5 */
+#define RX_PLL_MUL_16   31 /**< PLL multiplier ×16 */
+#define RX_PLL_MUL_16_5 32 /**< PLL multiplier ×16.5 */
+#define RX_PLL_MUL_17   33 /**< PLL multiplier ×17 */
+#define RX_PLL_MUL_17_5 34 /**< PLL multiplier ×17.5 */
+#define RX_PLL_MUL_18   35 /**< PLL multiplier ×18 */
+#define RX_PLL_MUL_18_5 36 /**< PLL multiplier ×18.5 */
+#define RX_PLL_MUL_19   37 /**< PLL multiplier ×19 */
+#define RX_PLL_MUL_19_5 38 /**< PLL multiplier ×19.5 */
+#define RX_PLL_MUL_20   39 /**< PLL multiplier ×20 */
+#define RX_PLL_MUL_20_5 40 /**< PLL multiplier ×20.5 */
+#define RX_PLL_MUL_21   41 /**< PLL multiplier ×21 */
+#define RX_PLL_MUL_21_5 42 /**< PLL multiplier ×21.5 */
+#define RX_PLL_MUL_22   43 /**< PLL multiplier ×22 */
+#define RX_PLL_MUL_22_5 44 /**< PLL multiplier ×22.5 */
+#define RX_PLL_MUL_23   45 /**< PLL multiplier ×23 */
+#define RX_PLL_MUL_23_5 46 /**< PLL multiplier ×23.5 */
+#define RX_PLL_MUL_24   47 /**< PLL multiplier ×24 */
+#define RX_PLL_MUL_24_5 48 /**< PLL multiplier ×24.5 */
+#define RX_PLL_MUL_25   49 /**< PLL multiplier ×25 */
+#define RX_PLL_MUL_25_5 50 /**< PLL multiplier ×25.5 */
+#define RX_PLL_MUL_26   51 /**< PLL multiplier ×26 */
+#define RX_PLL_MUL_26_5 52 /**< PLL multiplier ×26.5 */
+#define RX_PLL_MUL_27   53 /**< PLL multiplier ×27 */
+#define RX_PLL_MUL_27_5 54 /**< PLL multiplier ×27.5 */
+#define RX_PLL_MUL_28   55 /**< PLL multiplier ×28 */
+#define RX_PLL_MUL_28_5 56 /**< PLL multiplier ×28.5 */
+#define RX_PLL_MUL_29   57 /**< PLL multiplier ×29 */
+#define RX_PLL_MUL_29_5 58 /**< PLL multiplier ×29.5 */
+#define RX_PLL_MUL_30   59 /**< PLL multiplier ×30 */
+
+/** @} */
+
+/**
+ * @name Renesas RX Module Stop Control Register (MSTP) definitions
+ * @{
+ */
+#define MSTPA 0 /**< Module stop control register A */
+#define MSTPB 1 /**< Module stop control register B */
+#define MSTPC 2 /**< Module stop control register C */
+#define MSTPD 3 /**< Module stop control register D */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RX_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2a1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2a1-elc.h
@@ -4,166 +4,181 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA2A1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2A1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2A1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_DTC_COMPLETE           0x009
-#define RA_ELC_EVENT_DTC_END                0x00A
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x00B
-#define RA_ELC_EVENT_FCU_FRDYI              0x00C
-#define RA_ELC_EVENT_LVD_LVD1               0x00D
-#define RA_ELC_EVENT_LVD_LVD2               0x00E
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x00F
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x010
-#define RA_ELC_EVENT_AGT0_INT               0x011
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x012
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x013
-#define RA_ELC_EVENT_AGT1_INT               0x014
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x015
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x016
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x017
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x018
-#define RA_ELC_EVENT_RTC_ALARM              0x019
-#define RA_ELC_EVENT_RTC_PERIOD             0x01A
-#define RA_ELC_EVENT_RTC_CARRY              0x01B
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x01C
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x01D
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x01E
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x01F
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x020
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x021
-#define RA_ELC_EVENT_ACMPHS0_INT            0x022
-#define RA_ELC_EVENT_ACMPLP0_INT            0x023
-#define RA_ELC_EVENT_ACMPLP1_INT            0x024
-#define RA_ELC_EVENT_USBFS_INT              0x025
-#define RA_ELC_EVENT_USBFS_RESUME           0x026
-#define RA_ELC_EVENT_IIC0_RXI               0x027
-#define RA_ELC_EVENT_IIC0_TXI               0x028
-#define RA_ELC_EVENT_IIC0_TEI               0x029
-#define RA_ELC_EVENT_IIC0_ERI               0x02A
-#define RA_ELC_EVENT_IIC0_WUI               0x02B
-#define RA_ELC_EVENT_IIC1_RXI               0x02C
-#define RA_ELC_EVENT_IIC1_TXI               0x02D
-#define RA_ELC_EVENT_IIC1_TEI               0x02E
-#define RA_ELC_EVENT_IIC1_ERI               0x02F
-#define RA_ELC_EVENT_CTSU_WRITE             0x030
-#define RA_ELC_EVENT_CTSU_READ              0x031
-#define RA_ELC_EVENT_CTSU_END               0x032
-#define RA_ELC_EVENT_KEY_INT                0x033
-#define RA_ELC_EVENT_DOC_INT                0x034
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x035
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x036
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x037
-#define RA_ELC_EVENT_CAN0_ERROR             0x038
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x039
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x03A
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x03B
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x03C
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x03D
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x03E
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x03F
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x040
-#define RA_ELC_EVENT_POEG0_EVENT            0x041
-#define RA_ELC_EVENT_POEG1_EVENT            0x042
-#define RA_ELC_EVENT_SDADC0_ADI             0x043
-#define RA_ELC_EVENT_SDADC0_SCANEND         0x044
-#define RA_ELC_EVENT_SDADC0_CALIEND         0x045
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x046
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x047
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x048
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x049
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x04A
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x04B
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x04C
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x04D
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x04E
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x04F
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x050
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x051
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x052
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x053
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x054
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x055
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x056
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x057
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x058
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x059
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x05A
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x05B
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x05C
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x05D
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x05E
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x05F
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x060
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x061
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x062
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x063
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x064
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x065
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x066
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x067
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x068
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x069
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x06A
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x06B
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x06C
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x06D
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x06E
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x06F
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x070
-#define RA_ELC_EVENT_SCI0_RXI               0x071
-#define RA_ELC_EVENT_SCI0_TXI               0x072
-#define RA_ELC_EVENT_SCI0_TEI               0x073
-#define RA_ELC_EVENT_SCI0_ERI               0x074
-#define RA_ELC_EVENT_SCI0_AM                0x075
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x076
-#define RA_ELC_EVENT_SCI1_RXI               0x077
-#define RA_ELC_EVENT_SCI1_TXI               0x078
-#define RA_ELC_EVENT_SCI1_TEI               0x079
-#define RA_ELC_EVENT_SCI1_ERI               0x07A
-#define RA_ELC_EVENT_SCI1_AM                0x07B
-#define RA_ELC_EVENT_SCI9_RXI               0x07C
-#define RA_ELC_EVENT_SCI9_TXI               0x07D
-#define RA_ELC_EVENT_SCI9_TEI               0x07E
-#define RA_ELC_EVENT_SCI9_ERI               0x07F
-#define RA_ELC_EVENT_SCI9_AM                0x080
-#define RA_ELC_EVENT_SPI0_RXI               0x081
-#define RA_ELC_EVENT_SPI0_TXI               0x082
-#define RA_ELC_EVENT_SPI0_IDLE              0x083
-#define RA_ELC_EVENT_SPI0_ERI               0x084
-#define RA_ELC_EVENT_SPI0_TEI               0x085
-#define RA_ELC_EVENT_SPI1_RXI               0x086
-#define RA_ELC_EVENT_SPI1_TXI               0x087
-#define RA_ELC_EVENT_SPI1_IDLE              0x088
-#define RA_ELC_EVENT_SPI1_ERI               0x089
-#define RA_ELC_EVENT_SPI1_TEI               0x08A
-#define RA_ELC_EVENT_AES_WRREQ              0x08B
-#define RA_ELC_EVENT_AES_RDREQ              0x08C
-#define RA_ELC_EVENT_TRNG_RDREQ             0x08D
+/**
+ * @name Event codes for Renesas RA2A1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x009 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x00A /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x00B /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x00C /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x00D /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x00E /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x00F /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x010 /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x011 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x012 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x013 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x014 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x015 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x016 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x017 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x018 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x019 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x01A /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x01B /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x01C /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x01D /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x01E /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x01F /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x020 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x021 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPHS0_INT            0x022 /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPLP0_INT            0x023 /**< Low Power analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPLP1_INT            0x024 /**< Low Power analog comparator channel 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x025 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x026 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x027 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x028 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x029 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x02A /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x02B /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x02C /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x02D /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x02E /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x02F /**< Transfer error. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x030 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x031 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x032 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                0x033 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x034 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x035 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x036 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x037 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x038 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x039 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x03A /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x03B /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x03C /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x03D /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x03E /**< Port 2 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x03F /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x040 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x041 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x042 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_SDADC0_ADI             0x043 /**< End of SD A/D conversion (type 1) */
+#define RA_ELC_EVENT_SDADC0_SCANEND         0x044 /**< End of SD A/D scan. */
+#define RA_ELC_EVENT_SDADC0_CALIEND         0x045 /**< End of SD A/D A/D calibration. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x046 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x047 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x048 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x049 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x04A /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x04B /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x04C /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x04D /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x04E /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x04F /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x050 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x051 /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x052 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x053 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x054 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x055 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x056 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x057 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x058 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x059 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x05A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x05B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x05C /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x05D /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x05E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x05F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x060 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x061 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x062 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x063 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x064 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x065 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x066 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x067 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x068 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x069 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x06A /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x06B /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x06C /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x06D /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x06E /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x06F /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x070 /**< UVW edge event. */
+#define RA_ELC_EVENT_SCI0_RXI               0x071 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x072 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x073 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x074 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x075 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x076 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x077 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x078 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x079 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x07A /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                0x07B /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x07C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x07D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x07E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x07F /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x080 /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x081 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x082 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x083 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x084 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x085 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x086 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x087 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x088 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x089 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x08A /**< Transmission complete event. */
+#define RA_ELC_EVENT_AES_WRREQ              0x08B /**< AES Write Request. */
+#define RA_ELC_EVENT_AES_RDREQ              0x08C /**< AES Read Request. */
+#define RA_ELC_EVENT_TRNG_RDREQ             0x08D /**< TRNG Read Request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_CTSU    18
-#define RA_ELC_PERIPHERAL_DA8_0   19
-#define RA_ELC_PERIPHERAL_DA8_1   20
-#define RA_ELC_PERIPHERAL_SDADC0  22
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+#define RA_ELC_PERIPHERAL_DA8_0   19 /**< DA8_0 */
+#define RA_ELC_PERIPHERAL_DA8_1   20 /**< DA8_1 */
+#define RA_ELC_PERIPHERAL_SDADC0  22 /**< SDADC0 */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2A1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra2l1-elc.h
@@ -4,185 +4,200 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA2L1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2L1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2L1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_DTC_COMPLETE           0x009
-#define RA_ELC_EVENT_DTC_END                0x00A
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x00B
-#define RA_ELC_EVENT_FCU_FRDYI              0x00C
-#define RA_ELC_EVENT_LVD_LVD1               0x00D
-#define RA_ELC_EVENT_LVD_LVD2               0x00E
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x00F
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x010
-#define RA_ELC_EVENT_AGT0_INT               0x011
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x012
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x013
-#define RA_ELC_EVENT_AGT1_INT               0x014
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x015
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x016
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x017
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x018
-#define RA_ELC_EVENT_RTC_ALARM              0x019
-#define RA_ELC_EVENT_RTC_PERIOD             0x01A
-#define RA_ELC_EVENT_RTC_CARRY              0x01B
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x01C
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x01D
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x01E
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x01F
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x020
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x021
-#define RA_ELC_EVENT_ACMPLP0_INT            0x023
-#define RA_ELC_EVENT_ACMPLP1_INT            0x024
-#define RA_ELC_EVENT_IIC0_RXI               0x027
-#define RA_ELC_EVENT_IIC0_TXI               0x028
-#define RA_ELC_EVENT_IIC0_TEI               0x029
-#define RA_ELC_EVENT_IIC0_ERI               0x02A
-#define RA_ELC_EVENT_IIC0_WUI               0x02B
-#define RA_ELC_EVENT_IIC1_RXI               0x02C
-#define RA_ELC_EVENT_IIC1_TXI               0x02D
-#define RA_ELC_EVENT_IIC1_TEI               0x02E
-#define RA_ELC_EVENT_IIC1_ERI               0x02F
-#define RA_ELC_EVENT_CTSU_WRITE             0x030
-#define RA_ELC_EVENT_CTSU_READ              0x031
-#define RA_ELC_EVENT_CTSU_END               0x032
-#define RA_ELC_EVENT_KEY_INT                0x033
-#define RA_ELC_EVENT_DOC_INT                0x034
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x035
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x036
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x037
-#define RA_ELC_EVENT_CAN0_ERROR             0x038
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x039
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x03A
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x03B
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x03C
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x03D
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x03E
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x03F
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x040
-#define RA_ELC_EVENT_POEG0_EVENT            0x041
-#define RA_ELC_EVENT_POEG1_EVENT            0x042
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x046
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x047
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x048
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x049
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x04A
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x04B
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x04C
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x04D
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x04E
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x04F
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x050
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x051
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x052
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x053
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x054
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x055
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x056
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x057
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x058
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x059
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x05A
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x05B
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x05C
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x05D
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x05E
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x05F
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x060
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x061
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x062
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x063
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x064
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x065
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x066
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x067
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x068
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x069
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x06A
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x06B
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x06C
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x06D
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x06E
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x06F
-#define RA_ELC_EVENT_GPT_UVWEDGE            0x070
-#define RA_ELC_EVENT_SCI0_RXI               0x071
-#define RA_ELC_EVENT_SCI0_TXI               0x072
-#define RA_ELC_EVENT_SCI0_TEI               0x073
-#define RA_ELC_EVENT_SCI0_ERI               0x074
-#define RA_ELC_EVENT_SCI0_AM                0x075
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x076
-#define RA_ELC_EVENT_SCI1_RXI               0x077
-#define RA_ELC_EVENT_SCI1_TXI               0x078
-#define RA_ELC_EVENT_SCI1_TEI               0x079
-#define RA_ELC_EVENT_SCI1_ERI               0x07A
-#define RA_ELC_EVENT_SCI1_AM                0x07B
-#define RA_ELC_EVENT_SCI9_RXI               0x07C
-#define RA_ELC_EVENT_SCI9_TXI               0x07D
-#define RA_ELC_EVENT_SCI9_TEI               0x07E
-#define RA_ELC_EVENT_SCI9_ERI               0x07F
-#define RA_ELC_EVENT_SCI9_AM                0x080
-#define RA_ELC_EVENT_SPI0_RXI               0x081
-#define RA_ELC_EVENT_SPI0_TXI               0x082
-#define RA_ELC_EVENT_SPI0_IDLE              0x083
-#define RA_ELC_EVENT_SPI0_ERI               0x084
-#define RA_ELC_EVENT_SPI0_TEI               0x085
-#define RA_ELC_EVENT_SPI1_RXI               0x086
-#define RA_ELC_EVENT_SPI1_TXI               0x087
-#define RA_ELC_EVENT_SPI1_IDLE              0x088
-#define RA_ELC_EVENT_SPI1_ERI               0x089
-#define RA_ELC_EVENT_SPI1_TEI               0x08A
-#define RA_ELC_EVENT_AES_WRREQ              0x08B
-#define RA_ELC_EVENT_AES_RDREQ              0x08C
-#define RA_ELC_EVENT_TRNG_RDREQ             0x08D
-#define RA_ELC_EVENT_SCI2_RXI               0x08E
-#define RA_ELC_EVENT_SCI2_TXI               0x08F
-#define RA_ELC_EVENT_SCI2_TEI               0x090
-#define RA_ELC_EVENT_SCI2_ERI               0x091
-#define RA_ELC_EVENT_SCI2_AM                0x092
-#define RA_ELC_EVENT_SCI3_RXI               0x093
-#define RA_ELC_EVENT_SCI3_TXI               0x094
-#define RA_ELC_EVENT_SCI3_TEI               0x095
-#define RA_ELC_EVENT_SCI3_ERI               0x096
-#define RA_ELC_EVENT_SCI3_AM                0x097
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x098
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x099
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x09A
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x09B
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x09C
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x09D
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x09E
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x09F
-#define RA_ELC_EVENT_GPT8_COMPARE_C         0x0A0
-#define RA_ELC_EVENT_GPT8_COMPARE_D         0x0A1
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x0A2
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x0A3
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x0A4
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x0A5
-#define RA_ELC_EVENT_GPT9_COMPARE_C         0x0A6
-#define RA_ELC_EVENT_GPT9_COMPARE_D         0x0A7
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x0A8
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x0A9
+/**
+ * @name Event codes for Renesas RA2L1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x009 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x00A /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x00B /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x00C /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x00D /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x00E /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x00F /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x010 /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x011 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x012 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x013 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x014 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x015 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x016 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x017 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x018 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x019 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x01A /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x01B /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x01C /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x01D /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x01E /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x01F /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x020 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x021 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPLP0_INT            0x023 /**< Low Power Comparator channel 0 interrupt. */
+#define RA_ELC_EVENT_ACMPLP1_INT            0x024 /**< Low Power Comparator channel 1 interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x027 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x028 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x029 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x02A /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x02B /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x02C /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x02D /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x02E /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x02F /**< Transfer error. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x030 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x031 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x032 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                0x033 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x034 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x035 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x036 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x037 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x038 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x039 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x03A /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x03B /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x03C /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x03D /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x03E /**< Port 2 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x03F /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x040 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x041 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x042 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x046 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x047 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x048 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x049 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x04A /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x04B /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x04C /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x04D /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x04E /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x04F /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x050 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x051 /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x052 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x053 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x054 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x055 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x056 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x057 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x058 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x059 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x05A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x05B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x05C /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x05D /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x05E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x05F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x060 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x061 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x062 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x063 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x064 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x065 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x066 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x067 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x068 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x069 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x06A /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x06B /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x06C /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x06D /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x06E /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x06F /**< Underflow. */
+#define RA_ELC_EVENT_GPT_UVWEDGE            0x070 /**< UVW edge event. */
+#define RA_ELC_EVENT_SCI0_RXI               0x071 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x072 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x073 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x074 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x075 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x076 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x077 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x078 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x079 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x07A /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                0x07B /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x07C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x07D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x07E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x07F /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x080 /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x081 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x082 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x083 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x084 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x085 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x086 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x087 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x088 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x089 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x08A /**< Transmission complete event. */
+#define RA_ELC_EVENT_AES_WRREQ              0x08B /**< AES Write Request. */
+#define RA_ELC_EVENT_AES_RDREQ              0x08C /**< AES Read Request. */
+#define RA_ELC_EVENT_TRNG_RDREQ             0x08D /**< TRNG Read Request. */
+#define RA_ELC_EVENT_SCI2_RXI               0x08E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x08F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x090 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x091 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                0x092 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI               0x093 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x094 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x095 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x096 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x097 /**< Address match event. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x098 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x099 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x09A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x09B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x09C /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x09D /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x09E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x09F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C         0x0A0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D         0x0A1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x0A2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x0A3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x0A4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x0A5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C         0x0A6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D         0x0A7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x0A8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x0A9 /**< Underflow. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA2L1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e1-elc.h
@@ -4,172 +4,186 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4E1 Event Link Controller (ELC) definitions
+ */
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CAN0_ERROR             0x0A1
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA4E1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x0A1 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4e2-elc.h
@@ -4,197 +4,212 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4E2 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E2_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_CAN_RXF                0x059
-#define RA_ELC_EVENT_CAN_GLERR              0x05A
-#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B
-#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C
-#define RA_ELC_EVENT_CAN0_TX                0x063
-#define RA_ELC_EVENT_CAN0_CHERR             0x064
-#define RA_ELC_EVENT_CAN0_COMFRX            0x065
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066
-#define RA_ELC_EVENT_CAN0_RXMB              0x067
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CEC_INTDA              0x0AB
-#define RA_ELC_EVENT_CEC_INTCE              0x0AC
-#define RA_ELC_EVENT_CEC_INTERR             0x0AD
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2
-#define RA_ELC_EVENT_GPT1_PC                0x0D3
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3
-#define RA_ELC_EVENT_GPT4_PC                0x0F4
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE
-#define RA_ELC_EVENT_GPT5_PC                0x0FF
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0
-#define RA_ELC_EVENT_DOC_INT                0x1DB
-#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC
-#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD
-#define RA_ELC_EVENT_I3C0_IBI               0x1DE
-#define RA_ELC_EVENT_I3C0_RX                0x1DF
-#define RA_ELC_EVENT_IICB0_RXI              0x1DF
-#define RA_ELC_EVENT_I3C0_TX                0x1E0
-#define RA_ELC_EVENT_IICB0_TXI              0x1E0
-#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1
-#define RA_ELC_EVENT_I3C0_HRESP             0x1E2
-#define RA_ELC_EVENT_I3C0_HCMD              0x1E3
-#define RA_ELC_EVENT_I3C0_HRX               0x1E4
-#define RA_ELC_EVENT_I3C0_HTX               0x1E5
-#define RA_ELC_EVENT_I3C0_TEND              0x1E6
-#define RA_ELC_EVENT_IICB0_TEI              0x1E6
-#define RA_ELC_EVENT_I3C0_EEI               0x1E7
-#define RA_ELC_EVENT_IICB0_ERI              0x1E7
-#define RA_ELC_EVENT_I3C0_STEV              0x1E8
-#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9
-#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA
-#define RA_ELC_EVENT_I3C0_AMEV              0x1EB
-#define RA_ELC_EVENT_I3C0_WU                0x1EC
-#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3
+/**
+ * @name Event codes for Renesas RA4E2 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_CAN_RXF                0x059 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR              0x05A /**< Global error. */
+#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                0x063 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR             0x064 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX            0x065 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB              0x067 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CEC_INTDA              0x0AB /**< Data interrupt. */
+#define RA_ELC_EVENT_CEC_INTCE              0x0AC /**< Communication complete interrupt. */
+#define RA_ELC_EVENT_CEC_INTERR             0x0AD /**< Error interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D3 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0F4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0FF /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0 /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI               0x1DE /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                0x1DF /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI              0x1DF /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI              0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP             0x1E2 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD              0x1E3 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX               0x1E4 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX               0x1E5 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI               0x1E7 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI              0x1E7 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV              0x1E8 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9 /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV              0x1EB /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     23
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4E2_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4l1-elc.h
@@ -4,239 +4,256 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4L1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4L1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4L1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_CGC_SOSC_STOP          0x03D
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_CAN_RXF                0x059
-#define RA_ELC_EVENT_CAN_GLERR              0x05A
-#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B
-#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C
-#define RA_ELC_EVENT_CAN0_TX                0x063
-#define RA_ELC_EVENT_CAN0_CHERR             0x064
-#define RA_ELC_EVENT_CAN0_COMFRX            0x065
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066
-#define RA_ELC_EVENT_CAN0_RXMB              0x067
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_UARTA0_TXI             0x08E
-#define RA_ELC_EVENT_UARTA0_RXI             0x08F
-#define RA_ELC_EVENT_UARTA0_ERRI            0x090
-#define RA_ELC_EVENT_UARTA1_TXI             0x091
-#define RA_ELC_EVENT_UARTA1_RXI             0x092
-#define RA_ELC_EVENT_UARTA1_ERRI            0x093
-#define RA_ELC_EVENT_ACMPLP0_INT            0x094
-#define RA_ELC_EVENT_ACMPLP1_INT            0x095
-#define RA_ELC_EVENT_CTSU_WRITE             0x09A
-#define RA_ELC_EVENT_CTSU_READ              0x09B
-#define RA_ELC_EVENT_CTSU_END               0x09C
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT2_PC                0x0DA
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2
-#define RA_ELC_EVENT_GPT3_PC                0x0E3
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI5_RXI               0x19E
-#define RA_ELC_EVENT_SCI5_TXI               0x19F
-#define RA_ELC_EVENT_SCI5_TEI               0x1A0
-#define RA_ELC_EVENT_SCI5_ERI               0x1A1
-#define RA_ELC_EVENT_SCI5_AM                0x1A2
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC
-#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC
-#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD
-#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD
-#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE
-#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE
-#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF
-#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
-#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC
-#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD
-#define RA_ELC_EVENT_I3C0_IBI               0x1DE
-#define RA_ELC_EVENT_I3C0_RX                0x1DF
-#define RA_ELC_EVENT_IICB0_RXI              0x1DF
-#define RA_ELC_EVENT_I3C0_TX                0x1E0
-#define RA_ELC_EVENT_IICB0_TXI              0x1E0
-#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1
-#define RA_ELC_EVENT_I3C0_TEND              0x1E6
-#define RA_ELC_EVENT_IICB0_TEI              0x1E6
-#define RA_ELC_EVENT_I3C0_EEI               0x1E7
-#define RA_ELC_EVENT_IICB0_ERI              0x1E7
-#define RA_ELC_EVENT_I3C0_WU                0x1EC
-#define RA_ELC_EVENT_RSIP_TADI              0x1EE
+/**
+ * @name Event codes for Renesas RA4L1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE               0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0           0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1           0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2           0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3           0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4           0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5           0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6           0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7           0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8           0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9           0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10          0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11          0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12          0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13          0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14          0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15          0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT          0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT          0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT          0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT          0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT          0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT          0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT          0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT          0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE       0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END            0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR       0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL  0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR         0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI          0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1           0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2           0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP      0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST 0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_CGC_SOSC_STOP      0x03D /**< Sub oscillation stop. */
+#define RA_ELC_EVENT_AGT0_INT           0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A     0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B     0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT           0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A     0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B     0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW     0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW      0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM          0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD         0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY          0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_CAN_RXF            0x059 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR          0x05A /**< Global error. */
+#define RA_ELC_EVENT_CAN_DMAREQ0        0x05B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN_DMAREQ1        0x05C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX            0x063 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR         0x064 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX        0x065 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ     0x066 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB          0x067 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0       0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1       0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT          0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME       0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI           0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI           0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI           0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI           0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI           0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_SSI0_TXI           0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI           0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT           0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_UARTA0_TXI                                                                    \
+	0x08E /**< UARTA0 transmission transfer end or buffer empty interrupt. */
+#define RA_ELC_EVENT_UARTA0_RXI  0x08F /**< UARTA0 reception transfer end. */
+#define RA_ELC_EVENT_UARTA0_ERRI 0x090 /**< UARTA0 reception communication error occurrence. */
+#define RA_ELC_EVENT_UARTA1_TXI                                                                    \
+	0x091 /**< UARTA1 transmission transfer end or buffer empty interrupt. */
+#define RA_ELC_EVENT_UARTA1_RXI             0x092 /**< UARTA1 reception transfer end. */
+#define RA_ELC_EVENT_UARTA1_ERRI            0x093 /**< UARTA1 reception error occurrence. */
+#define RA_ELC_EVENT_ACMPLP0_INT            0x094 /**< Low Power Comparator channel 0 interrupt. */
+#define RA_ELC_EVENT_ACMPLP1_INT            0x095 /**< Low Power Comparator channel 1 interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x09A /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x09B /**< Measurement data request interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x09C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_PC                0x0DA /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_PC                0x0E3 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI5_RXI               0x19E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI5_TXI               0x19F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI5_TEI               0x1A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI5_ERI               0x1A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI5_AM                0x1A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0 /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI               0x1DE /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                0x1DF /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI              0x1DF /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI              0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_TEND              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI               0x1E7 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI              0x1E7 /**< Error. */
+#define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_RSIP_TADI              0x1EE /**< RSIP Tamper Detection. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4L1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m1-elc.h
@@ -4,208 +4,223 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4M1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x011
-#define RA_ELC_EVENT_DMAC1_INT              0x012
-#define RA_ELC_EVENT_DMAC2_INT              0x013
-#define RA_ELC_EVENT_DMAC3_INT              0x014
-#define RA_ELC_EVENT_DTC_COMPLETE           0x015
-#define RA_ELC_EVENT_DTC_END                0x016
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x017
-#define RA_ELC_EVENT_FCU_FRDYI              0x018
-#define RA_ELC_EVENT_LVD_LVD1               0x019
-#define RA_ELC_EVENT_LVD_LVD2               0x01A
-#define RA_ELC_EVENT_LVD_VBATT              0x01B
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x01C
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x01D
-#define RA_ELC_EVENT_AGT0_INT               0x01E
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x01F
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x020
-#define RA_ELC_EVENT_AGT1_INT               0x021
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x022
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x023
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x024
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x025
-#define RA_ELC_EVENT_RTC_ALARM              0x026
-#define RA_ELC_EVENT_RTC_PERIOD             0x027
-#define RA_ELC_EVENT_RTC_CARRY              0x028
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x029
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x02A
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x02B
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x02C
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x02D
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x02E
-#define RA_ELC_EVENT_ACMPLP0_INT            0x02F
-#define RA_ELC_EVENT_ACMPLP1_INT            0x030
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x031
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x032
-#define RA_ELC_EVENT_USBFS_INT              0x033
-#define RA_ELC_EVENT_USBFS_RESUME           0x034
-#define RA_ELC_EVENT_IIC0_RXI               0x035
-#define RA_ELC_EVENT_IIC0_TXI               0x036
-#define RA_ELC_EVENT_IIC0_TEI               0x037
-#define RA_ELC_EVENT_IIC0_ERI               0x038
-#define RA_ELC_EVENT_IIC0_WUI               0x039
-#define RA_ELC_EVENT_IIC1_RXI               0x03A
-#define RA_ELC_EVENT_IIC1_TXI               0x03B
-#define RA_ELC_EVENT_IIC1_TEI               0x03C
-#define RA_ELC_EVENT_IIC1_ERI               0x03D
-#define RA_ELC_EVENT_SSI0_TXI               0x03E
-#define RA_ELC_EVENT_SSI0_RXI               0x03F
-#define RA_ELC_EVENT_SSI0_INT               0x041
-#define RA_ELC_EVENT_CTSU_WRITE             0x042
-#define RA_ELC_EVENT_CTSU_READ              0x043
-#define RA_ELC_EVENT_CTSU_END               0x044
-#define RA_ELC_EVENT_KEY_INT                0x045
-#define RA_ELC_EVENT_DOC_INT                0x046
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x047
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x048
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x049
-#define RA_ELC_EVENT_CAN0_ERROR             0x04A
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x04B
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x04C
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x04D
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x04E
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x04F
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x050
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x051
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x052
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x053
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x054
-#define RA_ELC_EVENT_POEG0_EVENT            0x055
-#define RA_ELC_EVENT_POEG1_EVENT            0x056
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x057
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x058
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x059
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x05A
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x05B
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x05C
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x05D
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x05E
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x05F
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x060
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x061
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x062
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x063
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x064
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x065
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x066
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x067
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x068
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x069
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x06A
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x06B
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x06C
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x06D
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x06E
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x06F
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x070
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x071
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x072
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x073
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x074
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x075
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x076
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x077
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x078
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x079
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x07A
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x07B
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x07C
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x07D
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x07E
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x07F
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x080
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x081
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x082
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x083
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x084
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x085
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x086
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x087
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x088
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x089
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x08A
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x08B
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x08C
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x08D
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x08E
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x08F
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x090
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x091
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x092
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x093
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x094
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x095
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x096
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x097
-#define RA_ELC_EVENT_SCI0_RXI               0x098
-#define RA_ELC_EVENT_SCI0_TXI               0x099
-#define RA_ELC_EVENT_SCI0_TEI               0x09A
-#define RA_ELC_EVENT_SCI0_ERI               0x09B
-#define RA_ELC_EVENT_SCI0_AM                0x09C
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x09D
-#define RA_ELC_EVENT_SCI1_RXI               0x09E
-#define RA_ELC_EVENT_SCI1_TXI               0x09F
-#define RA_ELC_EVENT_SCI1_TEI               0x0A0
-#define RA_ELC_EVENT_SCI1_ERI               0x0A1
-#define RA_ELC_EVENT_SCI1_AM                0x0A2
-#define RA_ELC_EVENT_SCI2_RXI               0x0A3
-#define RA_ELC_EVENT_SCI2_TXI               0x0A4
-#define RA_ELC_EVENT_SCI2_TEI               0x0A5
-#define RA_ELC_EVENT_SCI2_ERI               0x0A6
-#define RA_ELC_EVENT_SCI2_AM                0x0A7
-#define RA_ELC_EVENT_SCI9_RXI               0x0A8
-#define RA_ELC_EVENT_SCI9_TXI               0x0A9
-#define RA_ELC_EVENT_SCI9_TEI               0x0AA
-#define RA_ELC_EVENT_SCI9_ERI               0x0AB
-#define RA_ELC_EVENT_SCI9_AM                0x0AC
-#define RA_ELC_EVENT_SPI0_RXI               0x0AD
-#define RA_ELC_EVENT_SPI0_TXI               0x0AE
-#define RA_ELC_EVENT_SPI0_IDLE              0x0AF
-#define RA_ELC_EVENT_SPI0_ERI               0x0B0
-#define RA_ELC_EVENT_SPI0_TEI               0x0B1
-#define RA_ELC_EVENT_SPI1_RXI               0x0B2
-#define RA_ELC_EVENT_SPI1_TXI               0x0B3
-#define RA_ELC_EVENT_SPI1_IDLE              0x0B4
-#define RA_ELC_EVENT_SPI1_ERI               0x0B5
-#define RA_ELC_EVENT_SPI1_TEI               0x0B6
+/**
+ * @name Event codes for Renesas RA4M1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x011 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x012 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x013 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x014 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x015 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x016 /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x017 /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x018 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x019 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x01A /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_LVD_VBATT              0x01B /**< VBATT low voltage detect. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x01C /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x01D /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x01E /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x01F /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x020 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x021 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x022 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x023 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x024 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x025 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x026 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x027 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x028 /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x029 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x02A /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x02B /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x02C /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x02D /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x02E /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPLP0_INT            0x02F /**< Low Power Comparator channel 0 interrupt. */
+#define RA_ELC_EVENT_ACMPLP1_INT            0x030 /**< Low Power Comparator channel 1 interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x031 /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x032 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x033 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x034 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x035 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x036 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x037 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x038 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x039 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x03A /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x03B /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x03C /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x03D /**< Transfer error. */
+#define RA_ELC_EVENT_SSI0_TXI               0x03E /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x03F /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x041 /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x042 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x043 /**< Measurement data request interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x044 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                0x045 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x046 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x047 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x048 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x049 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x04A /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x04B /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x04C /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x04D /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x04E /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x04F /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x050 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x051 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x052 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x053 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x054 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x055 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x056 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x057 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x058 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x059 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x05A /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x05B /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x05C /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x05D /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x05E /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x05F /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x060 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x061 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x062 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x063 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x064 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x065 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x066 /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x067 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x068 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x069 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x06A /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x06B /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x06C /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x06D /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x06E /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x06F /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x070 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x071 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x072 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x073 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x074 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x075 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x076 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x077 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x078 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x079 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x07A /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x07B /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x07C /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x07D /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x07E /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x07F /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x080 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x081 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x082 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x083 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x084 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x085 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x086 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x087 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x088 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x089 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x08A /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x08B /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x08C /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x08D /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x08E /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x08F /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x090 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x091 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x092 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x093 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x094 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x095 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x096 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x097 /**< UVW edge event. */
+#define RA_ELC_EVENT_SCI0_RXI               0x098 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x099 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x09A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x09B /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x09C /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x09D /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x09E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x09F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x0A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x0A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                0x0A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI               0x0A3 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x0A4 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x0A5 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x0A6 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                0x0A7 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x0A8 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x0A9 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x0AA /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x0AB /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x0AC /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x0AD /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x0AE /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x0AF /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x0B0 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x0B1 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x0B2 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x0B3 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x0B4 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x0B5 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x0B6 /**< Transmission complete event. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m2-elc.h
@@ -4,255 +4,270 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4M2 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M2_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT4_INT               0x04C
-#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D
-#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_IIC1_RXI               0x078
-#define RA_ELC_EVENT_IIC1_TXI               0x079
-#define RA_ELC_EVENT_IIC1_TEI               0x07A
-#define RA_ELC_EVENT_IIC1_ERI               0x07B
-#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082
-#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083
-#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CTSU_WRITE             0x09A
-#define RA_ELC_EVENT_CTSU_READ              0x09B
-#define RA_ELC_EVENT_CTSU_END               0x09C
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CAN0_ERROR             0x0A1
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD
-#define RA_ELC_EVENT_GPT6_PC                0x0FE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI2_RXI               0x18C
-#define RA_ELC_EVENT_SCI2_TXI               0x18D
-#define RA_ELC_EVENT_SCI2_TEI               0x18E
-#define RA_ELC_EVENT_SCI2_ERI               0x18F
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC
-#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC
-#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD
-#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD
-#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE
-#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE
-#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF
-#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF
-#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0
-#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0
-#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1
-#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1
-#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2
-#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2
-#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3
-#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA4M2 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT4_INT               0x04C /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D /**< Compare match A. */
+#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x078 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x079 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x07A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x07B /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x09A /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x09B /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x09C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x0A1 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_PC                0x0FE /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_RXI               0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M2_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m3-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4m3-elc.h
@@ -4,268 +4,283 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4M3 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M3_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M3_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT4_INT               0x04C
-#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D
-#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_IIC1_RXI               0x078
-#define RA_ELC_EVENT_IIC1_TXI               0x079
-#define RA_ELC_EVENT_IIC1_TEI               0x07A
-#define RA_ELC_EVENT_IIC1_ERI               0x07B
-#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082
-#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083
-#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CTSU_WRITE             0x09A
-#define RA_ELC_EVENT_CTSU_READ              0x09B
-#define RA_ELC_EVENT_CTSU_END               0x09C
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CAN0_ERROR             0x0A1
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5
-#define RA_ELC_EVENT_CAN1_ERROR             0x0A6
-#define RA_ELC_EVENT_CAN1_FIFO_RX           0x0A7
-#define RA_ELC_EVENT_CAN1_FIFO_TX           0x0A8
-#define RA_ELC_EVENT_CAN1_MAILBOX_RX        0x0A9
-#define RA_ELC_EVENT_CAN1_MAILBOX_TX        0x0AA
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD
-#define RA_ELC_EVENT_GPT6_PC                0x0FE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_ADC1_SCAN_END          0x166
-#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167
-#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168
-#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI2_RXI               0x18C
-#define RA_ELC_EVENT_SCI2_TXI               0x18D
-#define RA_ELC_EVENT_SCI2_TEI               0x18E
-#define RA_ELC_EVENT_SCI2_ERI               0x18F
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC
-#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC
-#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD
-#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD
-#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE
-#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE
-#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF
-#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF
-#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0
-#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0
-#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1
-#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1
-#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2
-#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2
-#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3
-#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA4M3 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT4_INT               0x04C /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D /**< Compare match A. */
+#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x078 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x079 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x07A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x07B /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x09A /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x09B /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x09C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x0A1 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_CAN1_ERROR             0x0A6 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_RX           0x0A7 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_TX           0x0A8 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_RX        0x0A9 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_TX        0x0AA /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_PC                0x0FE /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END          0x166 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_RXI               0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4M3_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4t1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4t1-elc.h
@@ -4,210 +4,225 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4T1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4T1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4T1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_CAN_RXF                0x059
-#define RA_ELC_EVENT_CAN_GLERR              0x05A
-#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B
-#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C
-#define RA_ELC_EVENT_CAN0_TX                0x063
-#define RA_ELC_EVENT_CAN0_CHERR             0x064
-#define RA_ELC_EVENT_CAN0_COMFRX            0x065
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066
-#define RA_ELC_EVENT_CAN0_RXMB              0x067
-#define RA_ELC_EVENT_ACMPHS0_INT            0x08E
-#define RA_ELC_EVENT_ACMPHS1_INT            0x08F
-#define RA_ELC_EVENT_ACMPHS2_INT            0x090
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2
-#define RA_ELC_EVENT_GPT1_PC                0x0D3
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D6
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D7
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D8
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D9
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0DA
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0DB
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0DC
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0DD
-#define RA_ELC_EVENT_GPT2_AD_TRIG_A         0x0DF
-#define RA_ELC_EVENT_GPT2_AD_TRIG_B         0x0E0
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0E1
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0E2
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0E3
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0E4
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0E5
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E6
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E7
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E8
-#define RA_ELC_EVENT_GPT3_AD_TRIG_A         0x0EA
-#define RA_ELC_EVENT_GPT3_AD_TRIG_B         0x0EB
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3
-#define RA_ELC_EVENT_GPT4_PC                0x0F4
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE
-#define RA_ELC_EVENT_GPT5_PC                0x0FF
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0
-#define RA_ELC_EVENT_DOC_INT                0x1DB
-#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC
-#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD
-#define RA_ELC_EVENT_I3C0_IBI               0x1DE
-#define RA_ELC_EVENT_I3C0_RX                0x1DF
-#define RA_ELC_EVENT_IICB0_RXI              0x1DF
-#define RA_ELC_EVENT_I3C0_TX                0x1E0
-#define RA_ELC_EVENT_IICB0_TXI              0x1E0
-#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1
-#define RA_ELC_EVENT_I3C0_HRESP             0x1E2
-#define RA_ELC_EVENT_I3C0_HCMD              0x1E3
-#define RA_ELC_EVENT_I3C0_HRX               0x1E4
-#define RA_ELC_EVENT_I3C0_HTX               0x1E5
-#define RA_ELC_EVENT_I3C0_TEND              0x1E6
-#define RA_ELC_EVENT_IICB0_TEI              0x1E6
-#define RA_ELC_EVENT_I3C0_EEI               0x1E7
-#define RA_ELC_EVENT_IICB0_ERI              0x1E7
-#define RA_ELC_EVENT_I3C0_STEV              0x1E8
-#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9
-#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA
-#define RA_ELC_EVENT_I3C0_AMEV              0x1EB
-#define RA_ELC_EVENT_I3C0_WU                0x1EC
-#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3
+/**
+ * @name Event codes for Renesas RA4T1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_CAN_RXF                0x059 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR              0x05A /**< Global error. */
+#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                0x063 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR             0x064 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX            0x065 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB              0x067 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_ACMPHS0_INT            0x08E /**< High Speed Comparator channel 0 interrupt. */
+#define RA_ELC_EVENT_ACMPHS1_INT            0x08F /**< High Speed Comparator channel 1 interrupt. */
+#define RA_ELC_EVENT_ACMPHS2_INT            0x090 /**< High Speed Comparator channel 2 interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D3 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0DA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0DB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0DC /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0DD /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_A         0x0DF /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_B         0x0E0 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0E1 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0E2 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0E3 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0E4 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0E5 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E6 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E7 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E8 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_A         0x0EA /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_B         0x0EB /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0F4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0FF /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0 /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI               0x1DE /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                0x1DF /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI              0x1DF /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI              0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP             0x1E2 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD              0x1E3 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX               0x1E4 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX               0x1E5 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI               0x1E7 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI              0x1E7 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV              0x1E8 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9 /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV              0x1EB /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     23
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4T1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4w1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra4w1-elc.h
@@ -4,193 +4,208 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA4W1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4W1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4W1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x011
-#define RA_ELC_EVENT_DMAC1_INT              0x012
-#define RA_ELC_EVENT_DMAC2_INT              0x013
-#define RA_ELC_EVENT_DMAC3_INT              0x014
-#define RA_ELC_EVENT_DTC_COMPLETE           0x015
-#define RA_ELC_EVENT_DTC_END                0x016
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x017
-#define RA_ELC_EVENT_FCU_FRDYI              0x018
-#define RA_ELC_EVENT_LVD_LVD1               0x019
-#define RA_ELC_EVENT_LVD_VBATT              0x01B
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x01C
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x01D
-#define RA_ELC_EVENT_AGT0_INT               0x01E
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x01F
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x020
-#define RA_ELC_EVENT_AGT1_INT               0x021
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x022
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x023
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x024
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x025
-#define RA_ELC_EVENT_RTC_ALARM              0x026
-#define RA_ELC_EVENT_RTC_PERIOD             0x027
-#define RA_ELC_EVENT_RTC_CARRY              0x028
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x029
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x02A
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x02B
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x02C
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x02D
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x02E
-#define RA_ELC_EVENT_ACMPLP0_INT            0x02F
-#define RA_ELC_EVENT_ACMPLP1_INT            0x030
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x031
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x032
-#define RA_ELC_EVENT_USBFS_INT              0x033
-#define RA_ELC_EVENT_USBFS_RESUME           0x034
-#define RA_ELC_EVENT_IIC0_RXI               0x035
-#define RA_ELC_EVENT_IIC0_TXI               0x036
-#define RA_ELC_EVENT_IIC0_TEI               0x037
-#define RA_ELC_EVENT_IIC0_ERI               0x038
-#define RA_ELC_EVENT_IIC0_WUI               0x039
-#define RA_ELC_EVENT_IIC1_RXI               0x03A
-#define RA_ELC_EVENT_IIC1_TXI               0x03B
-#define RA_ELC_EVENT_IIC1_TEI               0x03C
-#define RA_ELC_EVENT_IIC1_ERI               0x03D
-#define RA_ELC_EVENT_CTSU_WRITE             0x046
-#define RA_ELC_EVENT_CTSU_READ              0x047
-#define RA_ELC_EVENT_CTSU_END               0x048
-#define RA_ELC_EVENT_KEY_INT                0x049
-#define RA_ELC_EVENT_DOC_INT                0x04A
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x04B
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x04C
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x04D
-#define RA_ELC_EVENT_CAN0_ERROR             0x04E
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x04F
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x050
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x051
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x052
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x053
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x054
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x055
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x056
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x057
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x058
-#define RA_ELC_EVENT_POEG0_EVENT            0x059
-#define RA_ELC_EVENT_POEG1_EVENT            0x05A
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x05B
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x05C
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x05D
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x05E
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x05F
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x060
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x061
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x062
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x063
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x064
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x065
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x066
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x067
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x068
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x069
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x06A
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x06B
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x06C
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x06D
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x06E
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x06F
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x070
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x071
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x072
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x073
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x074
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x075
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x076
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x077
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x078
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x079
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x07A
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x07B
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x07C
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x07D
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x07E
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x07F
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x080
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x081
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x082
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x083
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x084
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x085
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x086
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x087
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x088
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x089
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x08A
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x09B
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x09C
-#define RA_ELC_EVENT_GPT8_COMPARE_C         0x09D
-#define RA_ELC_EVENT_GPT8_COMPARE_D         0x09E
-#define RA_ELC_EVENT_GPT8_COMPARE_E         0x09F
-#define RA_ELC_EVENT_GPT8_COMPARE_F         0x0A0
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x0A1
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x0A2
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x0AB
-#define RA_ELC_EVENT_SCI0_RXI               0x0AC
-#define RA_ELC_EVENT_SCI0_TXI               0x0AD
-#define RA_ELC_EVENT_SCI0_TEI               0x0AE
-#define RA_ELC_EVENT_SCI0_ERI               0x0AF
-#define RA_ELC_EVENT_SCI0_AM                0x0B0
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x0B1
-#define RA_ELC_EVENT_SCI1_RXI               0x0B2
-#define RA_ELC_EVENT_SCI1_TXI               0x0B3
-#define RA_ELC_EVENT_SCI1_TEI               0x0B4
-#define RA_ELC_EVENT_SCI1_ERI               0x0B5
-#define RA_ELC_EVENT_SCI1_AM                0x0B6
-#define RA_ELC_EVENT_SCI4_RXI               0x0C1
-#define RA_ELC_EVENT_SCI4_TXI               0x0C2
-#define RA_ELC_EVENT_SCI4_TEI               0x0C3
-#define RA_ELC_EVENT_SCI4_ERI               0x0C4
-#define RA_ELC_EVENT_SCI4_AM                0x0C5
-#define RA_ELC_EVENT_SCI9_RXI               0x0C6
-#define RA_ELC_EVENT_SCI9_TXI               0x0C7
-#define RA_ELC_EVENT_SCI9_TEI               0x0C8
-#define RA_ELC_EVENT_SCI9_ERI               0x0C9
-#define RA_ELC_EVENT_SCI9_AM                0x0CA
-#define RA_ELC_EVENT_SPI0_RXI               0x0CB
-#define RA_ELC_EVENT_SPI0_TXI               0x0CC
-#define RA_ELC_EVENT_SPI0_IDLE              0x0CD
-#define RA_ELC_EVENT_SPI0_ERI               0x0CE
-#define RA_ELC_EVENT_SPI0_TEI               0x0CF
-#define RA_ELC_EVENT_SPI1_RXI               0x0D0
-#define RA_ELC_EVENT_SPI1_TXI               0x0D1
-#define RA_ELC_EVENT_SPI1_IDLE              0x0D2
-#define RA_ELC_EVENT_SPI1_ERI               0x0D3
-#define RA_ELC_EVENT_SPI1_TEI               0x0D4
+/**
+ * @name Event codes for Renesas RA4W1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x011 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x012 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x013 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x014 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x015 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x016 /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x017 /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x018 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x019 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_VBATT              0x01B /**< VBATT low voltage detect. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x01C /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x01D /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x01E /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x01F /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x020 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x021 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x022 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x023 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x024 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x025 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x026 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x027 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x028 /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x029 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x02A /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x02B /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x02C /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x02D /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x02E /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPLP0_INT            0x02F /**< Low Power Comparator channel 0 interrupt. */
+#define RA_ELC_EVENT_ACMPLP1_INT            0x030 /**< Low Power Comparator channel 1 interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x031 /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x032 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x033 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x034 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x035 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x036 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x037 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x038 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x039 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x03A /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x03B /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x03C /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x03D /**< Transfer error. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x046 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x047 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x048 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                0x049 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x04A /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x04B /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x04C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x04D /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x04E /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x04F /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x050 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x051 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x052 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x053 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x054 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x055 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x056 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x057 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x058 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x059 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x05A /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x05B /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x05C /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x05D /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x05E /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x05F /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x060 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x061 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x062 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x063 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x064 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x065 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x066 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x067 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x068 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x069 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x06A /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x06B /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x06C /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x06D /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x06E /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x06F /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x070 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x071 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x072 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x073 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x074 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x075 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x076 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x077 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x078 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x079 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x07A /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x07B /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x07C /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x07D /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x07E /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x07F /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x080 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x081 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x082 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x083 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x084 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x085 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x086 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x087 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x088 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x089 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x08A /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x09B /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x09C /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C         0x09D /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D         0x09E /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E         0x09F /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F         0x0A0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x0A1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x0A2 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x0AB /**< UVW edge event. */
+#define RA_ELC_EVENT_SCI0_RXI               0x0AC /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x0AD /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x0AE /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x0AF /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x0B0 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x0B1 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x0B2 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x0B3 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x0B4 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x0B5 /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                0x0B6 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x0C1 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x0C2 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x0C3 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x0C4 /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x0C5 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x0C6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x0C7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x0C8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x0C9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x0CA /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x0CB /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x0CC /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x0CD /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x0CE /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x0CF /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x0D0 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x0D1 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x0D2 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x0D3 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x0D4 /**< Transmission complete event. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA4W1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e1-elc.h
@@ -4,230 +4,245 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6E1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT4_INT               0x04C
-#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D
-#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_IIC1_RXI               0x078
-#define RA_ELC_EVENT_IIC1_TXI               0x079
-#define RA_ELC_EVENT_IIC1_TEI               0x07A
-#define RA_ELC_EVENT_IIC1_ERI               0x07B
-#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082
-#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083
-#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CAN0_ERROR             0x0A1
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD
-#define RA_ELC_EVENT_GPT6_PC                0x0FE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_EDMAC0_EINT            0x16F
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI2_RXI               0x18C
-#define RA_ELC_EVENT_SCI2_TXI               0x18D
-#define RA_ELC_EVENT_SCI2_TEI               0x18E
-#define RA_ELC_EVENT_SCI2_ERI               0x18F
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0
-#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0
-#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1
-#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1
-#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2
-#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2
-#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3
-#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA6E1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT4_INT               0x04C /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D /**< Compare match A. */
+#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x078 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x079 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x07A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x07B /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x0A1 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_PC                0x0FE /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106 /**< Underflow. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_EDMAC0_EINT            0x16F /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_RXI               0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6e2-elc.h
@@ -4,219 +4,234 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6E2 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E2_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_CAN_RXF                0x059
-#define RA_ELC_EVENT_CAN_GLERR              0x05A
-#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B
-#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C
-#define RA_ELC_EVENT_CAN0_TX                0x063
-#define RA_ELC_EVENT_CAN0_CHERR             0x064
-#define RA_ELC_EVENT_CAN0_COMFRX            0x065
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066
-#define RA_ELC_EVENT_CAN0_RXMB              0x067
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CEC_INTDA              0x0AB
-#define RA_ELC_EVENT_CEC_INTCE              0x0AC
-#define RA_ELC_EVENT_CEC_INTERR             0x0AD
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2
-#define RA_ELC_EVENT_GPT1_PC                0x0D3
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D6
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D7
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D8
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D9
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0DA
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0DB
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0DC
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0DD
-#define RA_ELC_EVENT_GPT2_AD_TRIG_A         0x0DF
-#define RA_ELC_EVENT_GPT2_AD_TRIG_B         0x0E0
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0E1
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0E2
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0E3
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0E4
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0E5
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E6
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E7
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E8
-#define RA_ELC_EVENT_GPT3_AD_TRIG_A         0x0EA
-#define RA_ELC_EVENT_GPT3_AD_TRIG_B         0x0EB
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3
-#define RA_ELC_EVENT_GPT4_PC                0x0F4
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE
-#define RA_ELC_EVENT_GPT5_PC                0x0FF
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
-#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC
-#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD
-#define RA_ELC_EVENT_I3C0_IBI               0x1DE
-#define RA_ELC_EVENT_I3C0_RX                0x1DF
-#define RA_ELC_EVENT_IICB0_RXI              0x1DF
-#define RA_ELC_EVENT_I3C0_TX                0x1E0
-#define RA_ELC_EVENT_IICB0_TXI              0x1E0
-#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1
-#define RA_ELC_EVENT_I3C0_HRESP             0x1E2
-#define RA_ELC_EVENT_I3C0_HCMD              0x1E3
-#define RA_ELC_EVENT_I3C0_HRX               0x1E4
-#define RA_ELC_EVENT_I3C0_HTX               0x1E5
-#define RA_ELC_EVENT_I3C0_TEND              0x1E6
-#define RA_ELC_EVENT_IICB0_TEI              0x1E6
-#define RA_ELC_EVENT_I3C0_EEI               0x1E7
-#define RA_ELC_EVENT_IICB0_ERI              0x1E7
-#define RA_ELC_EVENT_I3C0_STEV              0x1E8
-#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9
-#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA
-#define RA_ELC_EVENT_I3C0_AMEV              0x1EB
-#define RA_ELC_EVENT_I3C0_WU                0x1EC
-#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3
+/**
+ * @name Event codes for Renesas RA6E2 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_CAN_RXF                0x059 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR              0x05A /**< Global error. */
+#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                0x063 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR             0x064 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX            0x065 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB              0x067 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CEC_INTDA              0x0AB /**< Data interrupt. */
+#define RA_ELC_EVENT_CEC_INTCE              0x0AC /**< Communication complete interrupt. */
+#define RA_ELC_EVENT_CEC_INTERR             0x0AD /**< Error interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A         0x0C9 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B         0x0CA /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0CB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0D0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0D1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D3 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A         0x0D4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B         0x0D5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0DA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0DB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0DC /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0DD /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_A         0x0DF /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_B         0x0E0 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0E1 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0E2 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0E3 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0E4 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0E5 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E6 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E7 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E8 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_A         0x0EA /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_B         0x0EB /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0F4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A         0x0F5 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B         0x0F6 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0F7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0F8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0F9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0FA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0FB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0FC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0FD /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0FE /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0FF /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A         0x100 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B         0x101 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x15C /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0 /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_I3C0_RESPONSE          0x1DC /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND           0x1DD /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI               0x1DE /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                0x1DF /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI              0x1DF /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI              0x1E0 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS        0x1E1 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP             0x1E2 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD              0x1E3 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX               0x1E4 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX               0x1E5 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI              0x1E6 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI               0x1E7 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI              0x1E7 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV              0x1E8 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF           0x1E9 /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT           0x1EA /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV              0x1EB /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                0x1EC /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_TRNG_RDREQ             0x1F3 /**< TRNG Read Request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     23
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     23 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6E2_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m1-elc.h
@@ -4,316 +4,331 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6M1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                      0x0
-#define RA_ELC_EVENT_ICU_IRQ0                  0x001
-#define RA_ELC_EVENT_ICU_IRQ1                  0x002
-#define RA_ELC_EVENT_ICU_IRQ2                  0x003
-#define RA_ELC_EVENT_ICU_IRQ3                  0x004
-#define RA_ELC_EVENT_ICU_IRQ4                  0x005
-#define RA_ELC_EVENT_ICU_IRQ5                  0x006
-#define RA_ELC_EVENT_ICU_IRQ6                  0x007
-#define RA_ELC_EVENT_ICU_IRQ7                  0x008
-#define RA_ELC_EVENT_ICU_IRQ8                  0x009
-#define RA_ELC_EVENT_ICU_IRQ9                  0x00A
-#define RA_ELC_EVENT_ICU_IRQ10                 0x00B
-#define RA_ELC_EVENT_ICU_IRQ11                 0x00C
-#define RA_ELC_EVENT_ICU_IRQ12                 0x00D
-#define RA_ELC_EVENT_ICU_IRQ13                 0x00E
-#define RA_ELC_EVENT_DMAC0_INT                 0x020
-#define RA_ELC_EVENT_DMAC1_INT                 0x021
-#define RA_ELC_EVENT_DMAC2_INT                 0x022
-#define RA_ELC_EVENT_DMAC3_INT                 0x023
-#define RA_ELC_EVENT_DMAC4_INT                 0x024
-#define RA_ELC_EVENT_DMAC5_INT                 0x025
-#define RA_ELC_EVENT_DMAC6_INT                 0x026
-#define RA_ELC_EVENT_DMAC7_INT                 0x027
-#define RA_ELC_EVENT_DTC_COMPLETE              0x029
-#define RA_ELC_EVENT_DTC_END                   0x02A
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D
-#define RA_ELC_EVENT_FCU_FIFERR                0x030
-#define RA_ELC_EVENT_FCU_FRDYI                 0x031
-#define RA_ELC_EVENT_LVD_LVD1                  0x038
-#define RA_ELC_EVENT_LVD_LVD2                  0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C
-#define RA_ELC_EVENT_AGT0_INT                  0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042
-#define RA_ELC_EVENT_AGT1_INT                  0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046
-#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047
-#define RA_ELC_EVENT_RTC_ALARM                 0x048
-#define RA_ELC_EVENT_RTC_PERIOD                0x049
-#define RA_ELC_EVENT_RTC_CARRY                 0x04A
-#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B
-#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C
-#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D
-#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050
-#define RA_ELC_EVENT_ADC1_SCAN_END             0x051
-#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052
-#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053
-#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056
-#define RA_ELC_EVENT_ACMPHS0_INT               0x057
-#define RA_ELC_EVENT_ACMPHS1_INT               0x058
-#define RA_ELC_EVENT_ACMPHS2_INT               0x059
-#define RA_ELC_EVENT_ACMPHS3_INT               0x05A
-#define RA_ELC_EVENT_ACMPHS4_INT               0x05B
-#define RA_ELC_EVENT_ACMPHS5_INT               0x05C
-#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F
-#define RA_ELC_EVENT_USBFS_FIFO_1              0x060
-#define RA_ELC_EVENT_USBFS_INT                 0x061
-#define RA_ELC_EVENT_USBFS_RESUME              0x062
-#define RA_ELC_EVENT_IIC0_RXI                  0x063
-#define RA_ELC_EVENT_IIC0_TXI                  0x064
-#define RA_ELC_EVENT_IIC0_TEI                  0x065
-#define RA_ELC_EVENT_IIC0_ERI                  0x066
-#define RA_ELC_EVENT_IIC0_WUI                  0x067
-#define RA_ELC_EVENT_IIC1_RXI                  0x068
-#define RA_ELC_EVENT_IIC1_TXI                  0x069
-#define RA_ELC_EVENT_IIC1_TEI                  0x06A
-#define RA_ELC_EVENT_IIC1_ERI                  0x06B
-#define RA_ELC_EVENT_SSI0_TXI                  0x072
-#define RA_ELC_EVENT_SSI0_RXI                  0x073
-#define RA_ELC_EVENT_SSI0_INT                  0x075
-#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D
-#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E
-#define RA_ELC_EVENT_CTSU_WRITE                0x082
-#define RA_ELC_EVENT_CTSU_READ                 0x083
-#define RA_ELC_EVENT_CTSU_END                  0x084
-#define RA_ELC_EVENT_KEY_INT                   0x085
-#define RA_ELC_EVENT_DOC_INT                   0x086
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088
-#define RA_ELC_EVENT_CAC_OVERFLOW              0x089
-#define RA_ELC_EVENT_CAN0_ERROR                0x08A
-#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B
-#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E
-#define RA_ELC_EVENT_CAN1_ERROR                0x08F
-#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090
-#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091
-#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092
-#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093
-#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094
-#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095
-#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096
-#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099
-#define RA_ELC_EVENT_POEG0_EVENT               0x09A
-#define RA_ELC_EVENT_POEG1_EVENT               0x09B
-#define RA_ELC_EVENT_POEG2_EVENT               0x09C
-#define RA_ELC_EVENT_POEG3_EVENT               0x09D
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1
-#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2
-#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3
-#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4
-#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB
-#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC
-#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD
-#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE
-#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5
-#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6
-#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7
-#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8
-#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB
-#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC
-#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF
-#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0
-#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1
-#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2
-#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5
-#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6
-#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9
-#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA
-#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB
-#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC
-#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3
-#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4
-#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5
-#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6
-#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED
-#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE
-#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF
-#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0
-#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3
-#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4
-#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7
-#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8
-#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9
-#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA
-#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD
-#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE
-#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101
-#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102
-#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103
-#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104
-#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B
-#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C
-#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D
-#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E
-#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115
-#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116
-#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117
-#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118
-#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F
-#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120
-#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121
-#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122
-#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129
-#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A
-#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B
-#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C
-#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F
-#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150
-#define RA_ELC_EVENT_SCI0_RXI                  0x174
-#define RA_ELC_EVENT_SCI0_TXI                  0x175
-#define RA_ELC_EVENT_SCI0_TEI                  0x176
-#define RA_ELC_EVENT_SCI0_ERI                  0x177
-#define RA_ELC_EVENT_SCI0_AM                   0x178
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179
-#define RA_ELC_EVENT_SCI1_RXI                  0x17A
-#define RA_ELC_EVENT_SCI1_TXI                  0x17B
-#define RA_ELC_EVENT_SCI1_TEI                  0x17C
-#define RA_ELC_EVENT_SCI1_ERI                  0x17D
-#define RA_ELC_EVENT_SCI1_AM                   0x17E
-#define RA_ELC_EVENT_SCI2_RXI                  0x180
-#define RA_ELC_EVENT_SCI2_TXI                  0x181
-#define RA_ELC_EVENT_SCI2_TEI                  0x182
-#define RA_ELC_EVENT_SCI2_ERI                  0x183
-#define RA_ELC_EVENT_SCI2_AM                   0x184
-#define RA_ELC_EVENT_SCI3_RXI                  0x186
-#define RA_ELC_EVENT_SCI3_TXI                  0x187
-#define RA_ELC_EVENT_SCI3_TEI                  0x188
-#define RA_ELC_EVENT_SCI3_ERI                  0x189
-#define RA_ELC_EVENT_SCI3_AM                   0x18A
-#define RA_ELC_EVENT_SCI4_RXI                  0x18C
-#define RA_ELC_EVENT_SCI4_TXI                  0x18D
-#define RA_ELC_EVENT_SCI4_TEI                  0x18E
-#define RA_ELC_EVENT_SCI4_ERI                  0x18F
-#define RA_ELC_EVENT_SCI4_AM                   0x190
-#define RA_ELC_EVENT_SCI8_RXI                  0x1A4
-#define RA_ELC_EVENT_SCI8_TXI                  0x1A5
-#define RA_ELC_EVENT_SCI8_TEI                  0x1A6
-#define RA_ELC_EVENT_SCI8_ERI                  0x1A7
-#define RA_ELC_EVENT_SCI8_AM                   0x1A8
-#define RA_ELC_EVENT_SCI9_RXI                  0x1AA
-#define RA_ELC_EVENT_SCI9_TXI                  0x1AB
-#define RA_ELC_EVENT_SCI9_TEI                  0x1AC
-#define RA_ELC_EVENT_SCI9_ERI                  0x1AD
-#define RA_ELC_EVENT_SCI9_AM                   0x1AE
-#define RA_ELC_EVENT_SPI0_RXI                  0x1BC
-#define RA_ELC_EVENT_SPI0_TXI                  0x1BD
-#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE
-#define RA_ELC_EVENT_SPI0_ERI                  0x1BF
-#define RA_ELC_EVENT_SPI0_TEI                  0x1C0
-#define RA_ELC_EVENT_SPI1_RXI                  0x1C1
-#define RA_ELC_EVENT_SPI1_TXI                  0x1C2
-#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3
-#define RA_ELC_EVENT_SPI1_ERI                  0x1C4
-#define RA_ELC_EVENT_SPI1_TEI                  0x1C5
-#define RA_ELC_EVENT_QSPI_INT                  0x1C6
-#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7
-#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8
-#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA
-#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB
-#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC
-#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE
+/**
+ * @name Event codes for Renesas RA6M1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                  0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                  0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                  0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                  0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                  0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                  0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                  0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                  0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10                 0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11                 0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12                 0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13                 0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_DMAC0_INT                 0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT                 0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT                 0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT                 0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT                 0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT                 0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT                 0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT                 0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE              0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                   0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR                0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI                 0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1                  0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2                  0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT                  0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                  0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM                 0x048 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD                0x049 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY                 0x04A /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END             0x051 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPHS0_INT               0x057 /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT               0x058 /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ACMPHS2_INT               0x059 /**< High Speed analog comparator channel 2. */
+#define RA_ELC_EVENT_ACMPHS3_INT               0x05A /**< High Speed analog comparator channel 3. */
+#define RA_ELC_EVENT_ACMPHS4_INT               0x05B /**< High Speed analog comparator channel 4. */
+#define RA_ELC_EVENT_ACMPHS5_INT               0x05C /**< High Speed analog comparator channel 5. */
+#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1              0x060 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT                 0x061 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME              0x062 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI                  0x063 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                  0x064 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                  0x065 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                  0x066 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                  0x067 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                  0x068 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                  0x069 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                  0x06A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                  0x06B /**< Transfer error. */
+#define RA_ELC_EVENT_SSI0_TXI                  0x072 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI                  0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT                  0x075 /**< Error interrupt. */
+#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A /**< Input FIFO empty. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B /**< Output FIFO full. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C /**< Output FIFO overflow. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D /**< Output FIFO underflow. */
+#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E /**< Conversion end. */
+#define RA_ELC_EVENT_CTSU_WRITE                0x082 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ                 0x083 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END                  0x084 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                   0x085 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                   0x086 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW              0x089 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR                0x08A /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_CAN1_ERROR                0x08F /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT               0x09A /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT               0x09B /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT               0x09C /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT               0x09D /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106 /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B /**< Underflow. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124 /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125 /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_SCI0_RXI                  0x174 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                  0x175 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                  0x176 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                  0x177 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                   0x178 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI                  0x17A /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                  0x17B /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                  0x17C /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                  0x17D /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                   0x17E /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                  0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                  0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                  0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                  0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                   0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                  0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                  0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                  0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                  0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                   0x18A /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                  0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                  0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                  0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                  0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                   0x190 /**< Address match event. */
+#define RA_ELC_EVENT_SCI8_RXI                  0x1A4 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI8_TXI                  0x1A5 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI8_TEI                  0x1A6 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI8_ERI                  0x1A7 /**< Receive error. */
+#define RA_ELC_EVENT_SCI8_AM                   0x1A8 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                  0x1AA /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                  0x1AB /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                  0x1AC /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                  0x1AD /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                   0x1AE /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                  0x1BC /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                  0x1BD /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                  0x1BF /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                  0x1C0 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                  0x1C1 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                  0x1C2 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                  0x1C4 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                  0x1C5 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT                  0x1C6 /**< QSPI interrupt. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE /**< DMA transfer request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m2-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m2-elc.h
@@ -4,349 +4,364 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6M2 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M2_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M2_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                      0x0
-#define RA_ELC_EVENT_ICU_IRQ0                  0x001
-#define RA_ELC_EVENT_ICU_IRQ1                  0x002
-#define RA_ELC_EVENT_ICU_IRQ2                  0x003
-#define RA_ELC_EVENT_ICU_IRQ3                  0x004
-#define RA_ELC_EVENT_ICU_IRQ4                  0x005
-#define RA_ELC_EVENT_ICU_IRQ5                  0x006
-#define RA_ELC_EVENT_ICU_IRQ6                  0x007
-#define RA_ELC_EVENT_ICU_IRQ7                  0x008
-#define RA_ELC_EVENT_ICU_IRQ8                  0x009
-#define RA_ELC_EVENT_ICU_IRQ9                  0x00A
-#define RA_ELC_EVENT_ICU_IRQ10                 0x00B
-#define RA_ELC_EVENT_ICU_IRQ11                 0x00C
-#define RA_ELC_EVENT_ICU_IRQ12                 0x00D
-#define RA_ELC_EVENT_ICU_IRQ13                 0x00E
-#define RA_ELC_EVENT_ICU_IRQ14                 0x00F
-#define RA_ELC_EVENT_ICU_IRQ15                 0x010
-#define RA_ELC_EVENT_DMAC0_INT                 0x020
-#define RA_ELC_EVENT_DMAC1_INT                 0x021
-#define RA_ELC_EVENT_DMAC2_INT                 0x022
-#define RA_ELC_EVENT_DMAC3_INT                 0x023
-#define RA_ELC_EVENT_DMAC4_INT                 0x024
-#define RA_ELC_EVENT_DMAC5_INT                 0x025
-#define RA_ELC_EVENT_DMAC6_INT                 0x026
-#define RA_ELC_EVENT_DMAC7_INT                 0x027
-#define RA_ELC_EVENT_DTC_COMPLETE              0x029
-#define RA_ELC_EVENT_DTC_END                   0x02A
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D
-#define RA_ELC_EVENT_FCU_FIFERR                0x030
-#define RA_ELC_EVENT_FCU_FRDYI                 0x031
-#define RA_ELC_EVENT_LVD_LVD1                  0x038
-#define RA_ELC_EVENT_LVD_LVD2                  0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C
-#define RA_ELC_EVENT_AGT0_INT                  0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042
-#define RA_ELC_EVENT_AGT1_INT                  0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046
-#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047
-#define RA_ELC_EVENT_RTC_ALARM                 0x048
-#define RA_ELC_EVENT_RTC_PERIOD                0x049
-#define RA_ELC_EVENT_RTC_CARRY                 0x04A
-#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B
-#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C
-#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D
-#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050
-#define RA_ELC_EVENT_ADC1_SCAN_END             0x051
-#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052
-#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053
-#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056
-#define RA_ELC_EVENT_ACMPHS0_INT               0x057
-#define RA_ELC_EVENT_ACMPHS1_INT               0x058
-#define RA_ELC_EVENT_ACMPHS2_INT               0x059
-#define RA_ELC_EVENT_ACMPHS3_INT               0x05A
-#define RA_ELC_EVENT_ACMPHS4_INT               0x05B
-#define RA_ELC_EVENT_ACMPHS5_INT               0x05C
-#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F
-#define RA_ELC_EVENT_USBFS_FIFO_1              0x060
-#define RA_ELC_EVENT_USBFS_INT                 0x061
-#define RA_ELC_EVENT_USBFS_RESUME              0x062
-#define RA_ELC_EVENT_IIC0_RXI                  0x063
-#define RA_ELC_EVENT_IIC0_TXI                  0x064
-#define RA_ELC_EVENT_IIC0_TEI                  0x065
-#define RA_ELC_EVENT_IIC0_ERI                  0x066
-#define RA_ELC_EVENT_IIC0_WUI                  0x067
-#define RA_ELC_EVENT_IIC1_RXI                  0x068
-#define RA_ELC_EVENT_IIC1_TXI                  0x069
-#define RA_ELC_EVENT_IIC1_TEI                  0x06A
-#define RA_ELC_EVENT_IIC1_ERI                  0x06B
-#define RA_ELC_EVENT_IIC2_RXI                  0x06D
-#define RA_ELC_EVENT_IIC2_TXI                  0x06E
-#define RA_ELC_EVENT_IIC2_TEI                  0x06F
-#define RA_ELC_EVENT_IIC2_ERI                  0x070
-#define RA_ELC_EVENT_SSI0_TXI                  0x072
-#define RA_ELC_EVENT_SSI0_RXI                  0x073
-#define RA_ELC_EVENT_SSI0_INT                  0x075
-#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D
-#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E
-#define RA_ELC_EVENT_PDC_RECEIVE_DATA_READY    0x07F
-#define RA_ELC_EVENT_PDC_FRAME_END             0x080
-#define RA_ELC_EVENT_PDC_INT                   0x081
-#define RA_ELC_EVENT_CTSU_WRITE                0x082
-#define RA_ELC_EVENT_CTSU_READ                 0x083
-#define RA_ELC_EVENT_CTSU_END                  0x084
-#define RA_ELC_EVENT_KEY_INT                   0x085
-#define RA_ELC_EVENT_DOC_INT                   0x086
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088
-#define RA_ELC_EVENT_CAC_OVERFLOW              0x089
-#define RA_ELC_EVENT_CAN0_ERROR                0x08A
-#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B
-#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E
-#define RA_ELC_EVENT_CAN1_ERROR                0x08F
-#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090
-#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091
-#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092
-#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093
-#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094
-#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095
-#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096
-#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099
-#define RA_ELC_EVENT_POEG0_EVENT               0x09A
-#define RA_ELC_EVENT_POEG1_EVENT               0x09B
-#define RA_ELC_EVENT_POEG2_EVENT               0x09C
-#define RA_ELC_EVENT_POEG3_EVENT               0x09D
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1
-#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2
-#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3
-#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4
-#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB
-#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC
-#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD
-#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE
-#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5
-#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6
-#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7
-#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8
-#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB
-#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC
-#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF
-#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0
-#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1
-#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2
-#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5
-#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6
-#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9
-#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA
-#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB
-#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC
-#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3
-#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4
-#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5
-#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6
-#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED
-#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE
-#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF
-#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0
-#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3
-#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4
-#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7
-#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8
-#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9
-#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA
-#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD
-#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE
-#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101
-#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102
-#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103
-#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104
-#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B
-#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C
-#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D
-#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E
-#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115
-#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116
-#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117
-#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118
-#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F
-#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120
-#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121
-#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122
-#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129
-#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A
-#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B
-#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C
-#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A   0x132
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B   0x133
-#define RA_ELC_EVENT_GPT13_COMPARE_C           0x134
-#define RA_ELC_EVENT_GPT13_COMPARE_D           0x135
-#define RA_ELC_EVENT_GPT13_COMPARE_E           0x136
-#define RA_ELC_EVENT_GPT13_COMPARE_F           0x137
-#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW    0x138
-#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW   0x139
-#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150
-#define RA_ELC_EVENT_EDMAC0_EINT               0x163
-#define RA_ELC_EVENT_SCI0_RXI                  0x174
-#define RA_ELC_EVENT_SCI0_TXI                  0x175
-#define RA_ELC_EVENT_SCI0_TEI                  0x176
-#define RA_ELC_EVENT_SCI0_ERI                  0x177
-#define RA_ELC_EVENT_SCI0_AM                   0x178
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179
-#define RA_ELC_EVENT_SCI1_RXI                  0x17A
-#define RA_ELC_EVENT_SCI1_TXI                  0x17B
-#define RA_ELC_EVENT_SCI1_TEI                  0x17C
-#define RA_ELC_EVENT_SCI1_ERI                  0x17D
-#define RA_ELC_EVENT_SCI1_AM                   0x17E
-#define RA_ELC_EVENT_SCI2_RXI                  0x180
-#define RA_ELC_EVENT_SCI2_TXI                  0x181
-#define RA_ELC_EVENT_SCI2_TEI                  0x182
-#define RA_ELC_EVENT_SCI2_ERI                  0x183
-#define RA_ELC_EVENT_SCI2_AM                   0x184
-#define RA_ELC_EVENT_SCI3_RXI                  0x186
-#define RA_ELC_EVENT_SCI3_TXI                  0x187
-#define RA_ELC_EVENT_SCI3_TEI                  0x188
-#define RA_ELC_EVENT_SCI3_ERI                  0x189
-#define RA_ELC_EVENT_SCI3_AM                   0x18A
-#define RA_ELC_EVENT_SCI4_RXI                  0x18C
-#define RA_ELC_EVENT_SCI4_TXI                  0x18D
-#define RA_ELC_EVENT_SCI4_TEI                  0x18E
-#define RA_ELC_EVENT_SCI4_ERI                  0x18F
-#define RA_ELC_EVENT_SCI4_AM                   0x190
-#define RA_ELC_EVENT_SCI5_RXI                  0x192
-#define RA_ELC_EVENT_SCI5_TXI                  0x193
-#define RA_ELC_EVENT_SCI5_TEI                  0x194
-#define RA_ELC_EVENT_SCI5_ERI                  0x195
-#define RA_ELC_EVENT_SCI5_AM                   0x196
-#define RA_ELC_EVENT_SCI6_RXI                  0x198
-#define RA_ELC_EVENT_SCI6_TXI                  0x199
-#define RA_ELC_EVENT_SCI6_TEI                  0x19A
-#define RA_ELC_EVENT_SCI6_ERI                  0x19B
-#define RA_ELC_EVENT_SCI6_AM                   0x19C
-#define RA_ELC_EVENT_SCI7_RXI                  0x19E
-#define RA_ELC_EVENT_SCI7_TXI                  0x19F
-#define RA_ELC_EVENT_SCI7_TEI                  0x1A0
-#define RA_ELC_EVENT_SCI7_ERI                  0x1A1
-#define RA_ELC_EVENT_SCI7_AM                   0x1A2
-#define RA_ELC_EVENT_SCI8_RXI                  0x1A4
-#define RA_ELC_EVENT_SCI8_TXI                  0x1A5
-#define RA_ELC_EVENT_SCI8_TEI                  0x1A6
-#define RA_ELC_EVENT_SCI8_ERI                  0x1A7
-#define RA_ELC_EVENT_SCI8_AM                   0x1A8
-#define RA_ELC_EVENT_SCI9_RXI                  0x1AA
-#define RA_ELC_EVENT_SCI9_TXI                  0x1AB
-#define RA_ELC_EVENT_SCI9_TEI                  0x1AC
-#define RA_ELC_EVENT_SCI9_ERI                  0x1AD
-#define RA_ELC_EVENT_SCI9_AM                   0x1AE
-#define RA_ELC_EVENT_SPI0_RXI                  0x1BC
-#define RA_ELC_EVENT_SPI0_TXI                  0x1BD
-#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE
-#define RA_ELC_EVENT_SPI0_ERI                  0x1BF
-#define RA_ELC_EVENT_SPI0_TEI                  0x1C0
-#define RA_ELC_EVENT_SPI1_RXI                  0x1C1
-#define RA_ELC_EVENT_SPI1_TXI                  0x1C2
-#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3
-#define RA_ELC_EVENT_SPI1_ERI                  0x1C4
-#define RA_ELC_EVENT_SPI1_TEI                  0x1C5
-#define RA_ELC_EVENT_QSPI_INT                  0x1C6
-#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7
-#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8
-#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA
-#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB
-#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC
-#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE
+/**
+ * @name Event codes for Renesas RA6M2 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                  0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                  0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                  0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                  0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                  0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                  0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                  0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                  0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10                 0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11                 0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12                 0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13                 0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14                 0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15                 0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT                 0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT                 0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT                 0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT                 0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT                 0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT                 0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT                 0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT                 0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE              0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                   0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR                0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI                 0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1                  0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2                  0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT                  0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                  0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM                 0x048 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD                0x049 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY                 0x04A /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END             0x051 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPHS0_INT               0x057 /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT               0x058 /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ACMPHS2_INT               0x059 /**< High Speed analog comparator channel 2. */
+#define RA_ELC_EVENT_ACMPHS3_INT               0x05A /**< High Speed analog comparator channel 3. */
+#define RA_ELC_EVENT_ACMPHS4_INT               0x05B /**< High Speed analog comparator channel 4. */
+#define RA_ELC_EVENT_ACMPHS5_INT               0x05C /**< High Speed analog comparator channel 5. */
+#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1              0x060 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT                 0x061 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME              0x062 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI                  0x063 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                  0x064 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                  0x065 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                  0x066 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                  0x067 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                  0x068 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                  0x069 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                  0x06A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                  0x06B /**< Transfer error. */
+#define RA_ELC_EVENT_IIC2_RXI                  0x06D /**< Receive data full. */
+#define RA_ELC_EVENT_IIC2_TXI                  0x06E /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC2_TEI                  0x06F /**< Transmit end. */
+#define RA_ELC_EVENT_IIC2_ERI                  0x070 /**< Transfer error. */
+#define RA_ELC_EVENT_SSI0_TXI                  0x072 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI                  0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT                  0x075 /**< Error interrupt. */
+#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A /**< Input FIFO empty. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B /**< Output FIFO full. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C /**< Output FIFO overflow. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D /**< Output FIFO underflow. */
+#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E /**< Conversion end. */
+#define RA_ELC_EVENT_PDC_RECEIVE_DATA_READY    0x07F /**< Receive data ready interrupt. */
+#define RA_ELC_EVENT_PDC_FRAME_END             0x080 /**< Frame end interrupt. */
+#define RA_ELC_EVENT_PDC_INT                   0x081 /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE                0x082 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ                 0x083 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END                  0x084 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                   0x085 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                   0x086 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW              0x089 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR                0x08A /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_CAN1_ERROR                0x08F /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT               0x09A /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT               0x09B /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT               0x09C /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT               0x09D /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106 /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B /**< Underflow. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124 /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125 /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F /**< Underflow. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A   0x132 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B   0x133 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT13_COMPARE_C           0x134 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT13_COMPARE_D           0x135 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT13_COMPARE_E           0x136 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT13_COMPARE_F           0x137 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW    0x138 /**< Overflow. */
+#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW   0x139 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_EDMAC0_EINT               0x163 /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI                  0x174 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                  0x175 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                  0x176 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                  0x177 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                   0x178 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI                  0x17A /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                  0x17B /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                  0x17C /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                  0x17D /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                   0x17E /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                  0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                  0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                  0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                  0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                   0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                  0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                  0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                  0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                  0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                   0x18A /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                  0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                  0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                  0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                  0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                   0x190 /**< Address match event. */
+#define RA_ELC_EVENT_SCI5_RXI                  0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI5_TXI                  0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI5_TEI                  0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI5_ERI                  0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI5_AM                   0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI6_RXI                  0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI6_TXI                  0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI6_TEI                  0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI6_ERI                  0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI6_AM                   0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI7_RXI                  0x19E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI7_TXI                  0x19F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI7_TEI                  0x1A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI7_ERI                  0x1A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI7_AM                   0x1A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI8_RXI                  0x1A4 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI8_TXI                  0x1A5 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI8_TEI                  0x1A6 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI8_ERI                  0x1A7 /**< Receive error. */
+#define RA_ELC_EVENT_SCI8_AM                   0x1A8 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                  0x1AA /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                  0x1AB /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                  0x1AC /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                  0x1AD /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                   0x1AE /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                  0x1BC /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                  0x1BD /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                  0x1BF /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                  0x1C0 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                  0x1C1 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                  0x1C2 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                  0x1C4 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                  0x1C5 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT                  0x1C6 /**< QSPI interrupt. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE /**< DMA transfer request. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M2_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m3-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m3-elc.h
@@ -4,377 +4,392 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6M3 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M3_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M3_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                      0x0
-#define RA_ELC_EVENT_ICU_IRQ0                  0x001
-#define RA_ELC_EVENT_ICU_IRQ1                  0x002
-#define RA_ELC_EVENT_ICU_IRQ2                  0x003
-#define RA_ELC_EVENT_ICU_IRQ3                  0x004
-#define RA_ELC_EVENT_ICU_IRQ4                  0x005
-#define RA_ELC_EVENT_ICU_IRQ5                  0x006
-#define RA_ELC_EVENT_ICU_IRQ6                  0x007
-#define RA_ELC_EVENT_ICU_IRQ7                  0x008
-#define RA_ELC_EVENT_ICU_IRQ8                  0x009
-#define RA_ELC_EVENT_ICU_IRQ9                  0x00A
-#define RA_ELC_EVENT_ICU_IRQ10                 0x00B
-#define RA_ELC_EVENT_ICU_IRQ11                 0x00C
-#define RA_ELC_EVENT_ICU_IRQ12                 0x00D
-#define RA_ELC_EVENT_ICU_IRQ13                 0x00E
-#define RA_ELC_EVENT_ICU_IRQ14                 0x00F
-#define RA_ELC_EVENT_ICU_IRQ15                 0x010
-#define RA_ELC_EVENT_DMAC0_INT                 0x020
-#define RA_ELC_EVENT_DMAC1_INT                 0x021
-#define RA_ELC_EVENT_DMAC2_INT                 0x022
-#define RA_ELC_EVENT_DMAC3_INT                 0x023
-#define RA_ELC_EVENT_DMAC4_INT                 0x024
-#define RA_ELC_EVENT_DMAC5_INT                 0x025
-#define RA_ELC_EVENT_DMAC6_INT                 0x026
-#define RA_ELC_EVENT_DMAC7_INT                 0x027
-#define RA_ELC_EVENT_DTC_COMPLETE              0x029
-#define RA_ELC_EVENT_DTC_END                   0x02A
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D
-#define RA_ELC_EVENT_FCU_FIFERR                0x030
-#define RA_ELC_EVENT_FCU_FRDYI                 0x031
-#define RA_ELC_EVENT_LVD_LVD1                  0x038
-#define RA_ELC_EVENT_LVD_LVD2                  0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C
-#define RA_ELC_EVENT_AGT0_INT                  0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042
-#define RA_ELC_EVENT_AGT1_INT                  0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045
-#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046
-#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047
-#define RA_ELC_EVENT_RTC_ALARM                 0x048
-#define RA_ELC_EVENT_RTC_PERIOD                0x049
-#define RA_ELC_EVENT_RTC_CARRY                 0x04A
-#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B
-#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C
-#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D
-#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050
-#define RA_ELC_EVENT_ADC1_SCAN_END             0x051
-#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052
-#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053
-#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056
-#define RA_ELC_EVENT_ACMPHS0_INT               0x057
-#define RA_ELC_EVENT_ACMPHS1_INT               0x058
-#define RA_ELC_EVENT_ACMPHS2_INT               0x059
-#define RA_ELC_EVENT_ACMPHS3_INT               0x05A
-#define RA_ELC_EVENT_ACMPHS4_INT               0x05B
-#define RA_ELC_EVENT_ACMPHS5_INT               0x05C
-#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F
-#define RA_ELC_EVENT_USBFS_FIFO_1              0x060
-#define RA_ELC_EVENT_USBFS_INT                 0x061
-#define RA_ELC_EVENT_USBFS_RESUME              0x062
-#define RA_ELC_EVENT_IIC0_RXI                  0x063
-#define RA_ELC_EVENT_IIC0_TXI                  0x064
-#define RA_ELC_EVENT_IIC0_TEI                  0x065
-#define RA_ELC_EVENT_IIC0_ERI                  0x066
-#define RA_ELC_EVENT_IIC0_WUI                  0x067
-#define RA_ELC_EVENT_IIC1_RXI                  0x068
-#define RA_ELC_EVENT_IIC1_TXI                  0x069
-#define RA_ELC_EVENT_IIC1_TEI                  0x06A
-#define RA_ELC_EVENT_IIC1_ERI                  0x06B
-#define RA_ELC_EVENT_IIC2_RXI                  0x06D
-#define RA_ELC_EVENT_IIC2_TXI                  0x06E
-#define RA_ELC_EVENT_IIC2_TEI                  0x06F
-#define RA_ELC_EVENT_IIC2_ERI                  0x070
-#define RA_ELC_EVENT_SSI0_TXI                  0x072
-#define RA_ELC_EVENT_SSI0_RXI                  0x073
-#define RA_ELC_EVENT_SSI0_INT                  0x075
+/**
+ * @name Event codes for Renesas RA6M3 Event Link Controller.
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                      0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                  0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                  0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                  0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                  0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                  0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                  0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                  0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                  0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                  0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                  0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10                 0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11                 0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12                 0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13                 0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14                 0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15                 0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT                 0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT                 0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT                 0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT                 0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT                 0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT                 0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT                 0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT                 0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE              0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                   0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL         0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR                0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI                 0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1                  0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2                  0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP             0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST        0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT                  0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A            0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B            0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                  0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A            0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B            0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW            0x046 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW             0x047 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM                 0x048 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD                0x049 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY                 0x04A /**< Carry interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END             0x04B /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B           0x04C /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A             0x04D /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B             0x04E /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH        0x04F /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH     0x050 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END             0x051 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B           0x052 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A             0x053 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B             0x054 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH        0x055 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH     0x056 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ACMPHS0_INT               0x057 /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT               0x058 /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ACMPHS2_INT               0x059 /**< High Speed analog comparator channel 2. */
+#define RA_ELC_EVENT_ACMPHS3_INT               0x05A /**< High Speed analog comparator channel 3. */
+#define RA_ELC_EVENT_ACMPHS4_INT               0x05B /**< High Speed analog comparator channel 4. */
+#define RA_ELC_EVENT_ACMPHS5_INT               0x05C /**< High Speed analog comparator channel 5. */
+#define RA_ELC_EVENT_USBFS_FIFO_0              0x05F /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1              0x060 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT                 0x061 /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME              0x062 /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI                  0x063 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                  0x064 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                  0x065 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                  0x066 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                  0x067 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                  0x068 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                  0x069 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                  0x06A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                  0x06B /**< Transfer error. */
+#define RA_ELC_EVENT_IIC2_RXI                  0x06D /**< Receive data full. */
+#define RA_ELC_EVENT_IIC2_TXI                  0x06E /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC2_TEI                  0x06F /**< Transmit end. */
+#define RA_ELC_EVENT_IIC2_ERI                  0x070 /**< Transfer error. */
+#define RA_ELC_EVENT_SSI0_TXI                  0x072 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI                  0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT                  0x075 /**< Error interrupt. */
 #define RA_ELC_EVENT_SSI1_TXI_RXI              0x078
-#define RA_ELC_EVENT_SSI1_TXI                  0x078
-#define RA_ELC_EVENT_SSI1_RXI                  0x078
-#define RA_ELC_EVENT_SSI1_INT                  0x079
-#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C
-#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D
-#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E
-#define RA_ELC_EVENT_PDC_RECEIVE_DATA_READY    0x07F
-#define RA_ELC_EVENT_PDC_FRAME_END             0x080
-#define RA_ELC_EVENT_PDC_INT                   0x081
-#define RA_ELC_EVENT_CTSU_WRITE                0x082
-#define RA_ELC_EVENT_CTSU_READ                 0x083
-#define RA_ELC_EVENT_CTSU_END                  0x084
-#define RA_ELC_EVENT_KEY_INT                   0x085
-#define RA_ELC_EVENT_DOC_INT                   0x086
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088
-#define RA_ELC_EVENT_CAC_OVERFLOW              0x089
-#define RA_ELC_EVENT_CAN0_ERROR                0x08A
-#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B
-#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E
-#define RA_ELC_EVENT_CAN1_ERROR                0x08F
-#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090
-#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091
-#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092
-#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093
-#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094
-#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095
-#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096
-#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099
-#define RA_ELC_EVENT_POEG0_EVENT               0x09A
-#define RA_ELC_EVENT_POEG1_EVENT               0x09B
-#define RA_ELC_EVENT_POEG2_EVENT               0x09C
-#define RA_ELC_EVENT_POEG3_EVENT               0x09D
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1
-#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2
-#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3
-#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4
-#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7
-#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8
-#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB
-#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC
-#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD
-#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE
-#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1
-#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2
-#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5
-#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6
-#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7
-#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8
-#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB
-#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC
-#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF
-#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0
-#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1
-#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2
-#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5
-#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6
-#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9
-#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA
-#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB
-#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC
-#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF
-#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0
-#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3
-#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4
-#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5
-#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6
-#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9
-#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA
-#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED
-#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE
-#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF
-#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0
-#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3
-#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4
-#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7
-#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8
-#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9
-#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA
-#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD
-#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE
-#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101
-#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102
-#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103
-#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104
-#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B
-#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C
-#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D
-#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E
-#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115
-#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116
-#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117
-#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118
-#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F
-#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120
-#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121
-#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122
-#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129
-#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A
-#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B
-#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C
-#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A   0x132
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B   0x133
-#define RA_ELC_EVENT_GPT13_COMPARE_C           0x134
-#define RA_ELC_EVENT_GPT13_COMPARE_D           0x135
-#define RA_ELC_EVENT_GPT13_COMPARE_E           0x136
-#define RA_ELC_EVENT_GPT13_COMPARE_F           0x137
-#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW    0x138
-#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW   0x139
-#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150
-#define RA_ELC_EVENT_EPTPC_IPLS                0x160
-#define RA_ELC_EVENT_EPTPC_MINT                0x161
-#define RA_ELC_EVENT_EPTPC_PINT                0x162
-#define RA_ELC_EVENT_EDMAC0_EINT               0x163
-#define RA_ELC_EVENT_EPTPC_TIMER0_RISE         0x165
-#define RA_ELC_EVENT_EPTPC_TIMER1_RISE         0x166
-#define RA_ELC_EVENT_EPTPC_TIMER2_RISE         0x167
-#define RA_ELC_EVENT_EPTPC_TIMER3_RISE         0x168
-#define RA_ELC_EVENT_EPTPC_TIMER4_RISE         0x169
-#define RA_ELC_EVENT_EPTPC_TIMER5_RISE         0x16A
-#define RA_ELC_EVENT_EPTPC_TIMER0_FALL         0x16B
-#define RA_ELC_EVENT_EPTPC_TIMER1_FALL         0x16C
-#define RA_ELC_EVENT_EPTPC_TIMER2_FALL         0x16D
-#define RA_ELC_EVENT_EPTPC_TIMER3_FALL         0x16E
-#define RA_ELC_EVENT_EPTPC_TIMER4_FALL         0x16F
-#define RA_ELC_EVENT_EPTPC_TIMER5_FALL         0x170
-#define RA_ELC_EVENT_USBHS_FIFO_0              0x171
-#define RA_ELC_EVENT_USBHS_FIFO_1              0x172
-#define RA_ELC_EVENT_USBHS_USB_INT_RESUME      0x173
-#define RA_ELC_EVENT_SCI0_RXI                  0x174
-#define RA_ELC_EVENT_SCI0_TXI                  0x175
-#define RA_ELC_EVENT_SCI0_TEI                  0x176
-#define RA_ELC_EVENT_SCI0_ERI                  0x177
-#define RA_ELC_EVENT_SCI0_AM                   0x178
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179
-#define RA_ELC_EVENT_SCI1_RXI                  0x17A
-#define RA_ELC_EVENT_SCI1_TXI                  0x17B
-#define RA_ELC_EVENT_SCI1_TEI                  0x17C
-#define RA_ELC_EVENT_SCI1_ERI                  0x17D
-#define RA_ELC_EVENT_SCI1_AM                   0x17E
-#define RA_ELC_EVENT_SCI2_RXI                  0x180
-#define RA_ELC_EVENT_SCI2_TXI                  0x181
-#define RA_ELC_EVENT_SCI2_TEI                  0x182
-#define RA_ELC_EVENT_SCI2_ERI                  0x183
-#define RA_ELC_EVENT_SCI2_AM                   0x184
-#define RA_ELC_EVENT_SCI3_RXI                  0x186
-#define RA_ELC_EVENT_SCI3_TXI                  0x187
-#define RA_ELC_EVENT_SCI3_TEI                  0x188
-#define RA_ELC_EVENT_SCI3_ERI                  0x189
-#define RA_ELC_EVENT_SCI3_AM                   0x18A
-#define RA_ELC_EVENT_SCI4_RXI                  0x18C
-#define RA_ELC_EVENT_SCI4_TXI                  0x18D
-#define RA_ELC_EVENT_SCI4_TEI                  0x18E
-#define RA_ELC_EVENT_SCI4_ERI                  0x18F
-#define RA_ELC_EVENT_SCI4_AM                   0x190
-#define RA_ELC_EVENT_SCI5_RXI                  0x192
-#define RA_ELC_EVENT_SCI5_TXI                  0x193
-#define RA_ELC_EVENT_SCI5_TEI                  0x194
-#define RA_ELC_EVENT_SCI5_ERI                  0x195
-#define RA_ELC_EVENT_SCI5_AM                   0x196
-#define RA_ELC_EVENT_SCI6_RXI                  0x198
-#define RA_ELC_EVENT_SCI6_TXI                  0x199
-#define RA_ELC_EVENT_SCI6_TEI                  0x19A
-#define RA_ELC_EVENT_SCI6_ERI                  0x19B
-#define RA_ELC_EVENT_SCI6_AM                   0x19C
-#define RA_ELC_EVENT_SCI7_RXI                  0x19E
-#define RA_ELC_EVENT_SCI7_TXI                  0x19F
-#define RA_ELC_EVENT_SCI7_TEI                  0x1A0
-#define RA_ELC_EVENT_SCI7_ERI                  0x1A1
-#define RA_ELC_EVENT_SCI7_AM                   0x1A2
-#define RA_ELC_EVENT_SCI8_RXI                  0x1A4
-#define RA_ELC_EVENT_SCI8_TXI                  0x1A5
-#define RA_ELC_EVENT_SCI8_TEI                  0x1A6
-#define RA_ELC_EVENT_SCI8_ERI                  0x1A7
-#define RA_ELC_EVENT_SCI8_AM                   0x1A8
-#define RA_ELC_EVENT_SCI9_RXI                  0x1AA
-#define RA_ELC_EVENT_SCI9_TXI                  0x1AB
-#define RA_ELC_EVENT_SCI9_TEI                  0x1AC
-#define RA_ELC_EVENT_SCI9_ERI                  0x1AD
-#define RA_ELC_EVENT_SCI9_AM                   0x1AE
-#define RA_ELC_EVENT_SPI0_RXI                  0x1BC
-#define RA_ELC_EVENT_SPI0_TXI                  0x1BD
-#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE
-#define RA_ELC_EVENT_SPI0_ERI                  0x1BF
-#define RA_ELC_EVENT_SPI0_TEI                  0x1C0
-#define RA_ELC_EVENT_SPI1_RXI                  0x1C1
-#define RA_ELC_EVENT_SPI1_TXI                  0x1C2
-#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3
-#define RA_ELC_EVENT_SPI1_ERI                  0x1C4
-#define RA_ELC_EVENT_SPI1_TEI                  0x1C5
-#define RA_ELC_EVENT_QSPI_INT                  0x1C6
-#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7
-#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8
-#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA
-#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB
-#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC
-#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE
-#define RA_ELC_EVENT_GLCDC_LINE_DETECT         0x1FA
-#define RA_ELC_EVENT_GLCDC_UNDERFLOW_1         0x1FB
-#define RA_ELC_EVENT_GLCDC_UNDERFLOW_2         0x1FC
-#define RA_ELC_EVENT_DRW_INT                   0x1FD
-#define RA_ELC_EVENT_JPEG_JEDI                 0x1FE
-#define RA_ELC_EVENT_JPEG_JDTI                 0x1FF
+#define RA_ELC_EVENT_SSI1_TXI                  0x078 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_RXI                  0x078 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_INT                  0x079 /**< Error interrupt. */
+#define RA_ELC_EVENT_SRC_INPUT_FIFO_EMPTY      0x07A /**< Input FIFO empty. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_FULL      0x07B /**< Output FIFO full. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_OVERFLOW  0x07C /**< Output FIFO overflow. */
+#define RA_ELC_EVENT_SRC_OUTPUT_FIFO_UNDERFLOW 0x07D /**< Output FIFO underflow. */
+#define RA_ELC_EVENT_SRC_CONVERSION_END        0x07E /**< Conversion end. */
+#define RA_ELC_EVENT_PDC_RECEIVE_DATA_READY    0x07F /**< Receive data ready interrupt. */
+#define RA_ELC_EVENT_PDC_FRAME_END             0x080 /**< Frame end interrupt. */
+#define RA_ELC_EVENT_PDC_INT                   0x081 /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE                0x082 /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ                 0x083 /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END                  0x084 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_KEY_INT                   0x085 /**< Key interrupt. */
+#define RA_ELC_EVENT_DOC_INT                   0x086 /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR       0x087 /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END       0x088 /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW              0x089 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR                0x08A /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX              0x08B /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX              0x08C /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX           0x08D /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX           0x08E /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_CAN1_ERROR                0x08F /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_RX              0x090 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_TX              0x091 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_RX           0x092 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_TX           0x093 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1            0x094 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2            0x095 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3            0x096 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4            0x097 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0      0x098 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1      0x099 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT               0x09A /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT               0x09B /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT               0x09C /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT               0x09D /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A    0x0B0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B    0x0B1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C            0x0B2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D            0x0B3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E            0x0B4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F            0x0B5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW     0x0B6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW    0x0B7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_A            0x0B8 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT0_AD_TRIG_B            0x0B9 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A    0x0BA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B    0x0BB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C            0x0BC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D            0x0BD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E            0x0BE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F            0x0BF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW     0x0C0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW    0x0C1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_A            0x0C2 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT1_AD_TRIG_B            0x0C3 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A    0x0C4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B    0x0C5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C            0x0C6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D            0x0C7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E            0x0C8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F            0x0C9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW     0x0CA /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW    0x0CB /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_A            0x0CC /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT2_AD_TRIG_B            0x0CD /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A    0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B    0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C            0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D            0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E            0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F            0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW     0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW    0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_A            0x0D6 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT3_AD_TRIG_B            0x0D7 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A    0x0D8 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B    0x0D9 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C            0x0DA /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D            0x0DB /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E            0x0DC /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F            0x0DD /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW     0x0DE /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW    0x0DF /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_A            0x0E0 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT4_AD_TRIG_B            0x0E1 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A    0x0E2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B    0x0E3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C            0x0E4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D            0x0E5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E            0x0E6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F            0x0E7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW     0x0E8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW    0x0E9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_A            0x0EA /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT5_AD_TRIG_B            0x0EB /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A    0x0EC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B    0x0ED /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C            0x0EE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D            0x0EF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E            0x0F0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F            0x0F1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW     0x0F2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW    0x0F3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_A            0x0F4 /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT6_AD_TRIG_B            0x0F5 /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A    0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B    0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C            0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D            0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E            0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F            0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW     0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW    0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_A            0x0FE /**< A/D converter start request A. */
+#define RA_ELC_EVENT_GPT7_AD_TRIG_B            0x0FF /**< A/D converter start request B. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A    0x100 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B    0x101 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C            0x102 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D            0x103 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E            0x104 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F            0x105 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW     0x106 /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW    0x107 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A    0x10A /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B    0x10B /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C            0x10C /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D            0x10D /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E            0x10E /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F            0x10F /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW     0x110 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW    0x111 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A   0x114 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B   0x115 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C           0x116 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D           0x117 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E           0x118 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F           0x119 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW    0x11A /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW   0x11B /**< Underflow. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A   0x11E /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B   0x11F /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C           0x120 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D           0x121 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E           0x122 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F           0x123 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW    0x124 /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW   0x125 /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A   0x128 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B   0x129 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C           0x12A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D           0x12B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E           0x12C /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F           0x12D /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW    0x12E /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW   0x12F /**< Underflow. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A   0x132 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B   0x133 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT13_COMPARE_C           0x134 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT13_COMPARE_D           0x135 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT13_COMPARE_E           0x136 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT13_COMPARE_F           0x137 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW    0x138 /**< Overflow. */
+#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW   0x139 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE              0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_EPTPC_IPLS                0x160 /**< STCA interrupt. */
+#define RA_ELC_EVENT_EPTPC_MINT                0x161 /**< SYNFP0/1 interrupt. */
+#define RA_ELC_EVENT_EPTPC_PINT                0x162 /**< PTPEDMAC interrupt. */
+#define RA_ELC_EVENT_EDMAC0_EINT               0x163 /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_EPTPC_TIMER0_RISE         0x165 /**< Pulse output timer 0 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER1_RISE         0x166 /**< Pulse output timer 1 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER2_RISE         0x167 /**< Pulse output timer 2 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER3_RISE         0x168 /**< Pulse output timer 3 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER4_RISE         0x169 /**< Pulse output timer 4 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER5_RISE         0x16A /**< Pulse output timer 5 rising detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER0_FALL         0x16B /**< Pulse output timer 0 falling detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER1_FALL         0x16C /**< Pulse output timer 1 falling detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER2_FALL         0x16D /**< Pulse output timer 2 falling detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER3_FALL         0x16E /**< Pulse output timer 3 falling detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER4_FALL         0x16F /**< Pulse output timer 4 falling detection. */
+#define RA_ELC_EVENT_EPTPC_TIMER5_FALL         0x170 /**< Pulse output timer 5 falling detection. */
+#define RA_ELC_EVENT_USBHS_FIFO_0              0x171 /**< DMA transfer request 0. */
+#define RA_ELC_EVENT_USBHS_FIFO_1              0x172 /**< DMA transfer request 1. */
+#define RA_ELC_EVENT_USBHS_USB_INT_RESUME      0x173 /**< USBHS interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI                  0x174 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                  0x175 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                  0x176 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                  0x177 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                   0x178 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI           0x179 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI                  0x17A /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                  0x17B /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                  0x17C /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                  0x17D /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AM                   0x17E /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                  0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                  0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                  0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                  0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                   0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                  0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                  0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                  0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                  0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                   0x18A /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                  0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                  0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                  0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                  0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                   0x190 /**< Address match event. */
+#define RA_ELC_EVENT_SCI5_RXI                  0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI5_TXI                  0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI5_TEI                  0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI5_ERI                  0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI5_AM                   0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI6_RXI                  0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI6_TXI                  0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI6_TEI                  0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI6_ERI                  0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI6_AM                   0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI7_RXI                  0x19E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI7_TXI                  0x19F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI7_TEI                  0x1A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI7_ERI                  0x1A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI7_AM                   0x1A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI8_RXI                  0x1A4 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI8_TXI                  0x1A5 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI8_TEI                  0x1A6 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI8_ERI                  0x1A7 /**< Receive error. */
+#define RA_ELC_EVENT_SCI8_AM                   0x1A8 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                  0x1AA /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                  0x1AB /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                  0x1AC /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                  0x1AD /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                   0x1AE /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                  0x1BC /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                  0x1BD /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE                 0x1BE /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                  0x1BF /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                  0x1C0 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                  0x1C1 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                  0x1C2 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE                 0x1C3 /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                  0x1C4 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                  0x1C5 /**< Transmission complete event. */
+#define RA_ELC_EVENT_QSPI_INT                  0x1C6 /**< QSPI interrupt. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS             0x1C7 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO             0x1C8 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD             0x1C9 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ          0x1CA /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS             0x1CB /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO             0x1CC /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD             0x1CD /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ          0x1CE /**< DMA transfer request. */
+#define RA_ELC_EVENT_GLCDC_LINE_DETECT         0x1FA /**< Specified line. */
+#define RA_ELC_EVENT_GLCDC_UNDERFLOW_1         0x1FB /**< Graphic 1 underflow. */
+#define RA_ELC_EVENT_GLCDC_UNDERFLOW_2         0x1FC /**< Graphic 2 underflow. */
+#define RA_ELC_EVENT_DRW_INT                   0x1FD /**< DRW interrupt. */
+#define RA_ELC_EVENT_JPEG_JEDI                 0x1FE /**< Compression/decompression interrupt. */
+#define RA_ELC_EVENT_JPEG_JDTI                 0x1FF /**< Data transfer interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M3_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m4-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m4-elc.h
@@ -4,311 +4,326 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6M4 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M4_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M4_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT4_INT               0x04C
-#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D
-#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_IIC1_RXI               0x078
-#define RA_ELC_EVENT_IIC1_TXI               0x079
-#define RA_ELC_EVENT_IIC1_TEI               0x07A
-#define RA_ELC_EVENT_IIC1_ERI               0x07B
-#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082
-#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083
-#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CTSU_WRITE             0x09A
-#define RA_ELC_EVENT_CTSU_READ              0x09B
-#define RA_ELC_EVENT_CTSU_END               0x09C
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CAN0_ERROR             0x0A1
-#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2
-#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3
-#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4
-#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5
-#define RA_ELC_EVENT_CAN1_ERROR             0x0A6
-#define RA_ELC_EVENT_CAN1_FIFO_RX           0x0A7
-#define RA_ELC_EVENT_CAN1_FIFO_TX           0x0A8
-#define RA_ELC_EVENT_CAN1_MAILBOX_RX        0x0A9
-#define RA_ELC_EVENT_CAN1_MAILBOX_TX        0x0AA
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD
-#define RA_ELC_EVENT_GPT6_PC                0x0FE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x108
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x109
-#define RA_ELC_EVENT_GPT8_COMPARE_C         0x10A
-#define RA_ELC_EVENT_GPT8_COMPARE_D         0x10B
-#define RA_ELC_EVENT_GPT8_COMPARE_E         0x10C
-#define RA_ELC_EVENT_GPT8_COMPARE_F         0x10D
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x10E
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x10F
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x111
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x112
-#define RA_ELC_EVENT_GPT9_COMPARE_C         0x113
-#define RA_ELC_EVENT_GPT9_COMPARE_D         0x114
-#define RA_ELC_EVENT_GPT9_COMPARE_E         0x115
-#define RA_ELC_EVENT_GPT9_COMPARE_F         0x116
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x117
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x118
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_ADC1_SCAN_END          0x166
-#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167
-#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168
-#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B
-#define RA_ELC_EVENT_EDMAC0_EINT            0x16F
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI2_RXI               0x18C
-#define RA_ELC_EVENT_SCI2_TXI               0x18D
-#define RA_ELC_EVENT_SCI2_TEI               0x18E
-#define RA_ELC_EVENT_SCI2_ERI               0x18F
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI5_RXI               0x19E
-#define RA_ELC_EVENT_SCI5_TXI               0x19F
-#define RA_ELC_EVENT_SCI5_TEI               0x1A0
-#define RA_ELC_EVENT_SCI5_ERI               0x1A1
-#define RA_ELC_EVENT_SCI5_AM                0x1A2
-#define RA_ELC_EVENT_SCI6_RXI               0x1A4
-#define RA_ELC_EVENT_SCI6_TXI               0x1A5
-#define RA_ELC_EVENT_SCI6_TEI               0x1A6
-#define RA_ELC_EVENT_SCI6_ERI               0x1A7
-#define RA_ELC_EVENT_SCI6_AM                0x1A8
-#define RA_ELC_EVENT_SCI7_RXI               0x1AA
-#define RA_ELC_EVENT_SCI7_TXI               0x1AB
-#define RA_ELC_EVENT_SCI7_TEI               0x1AC
-#define RA_ELC_EVENT_SCI7_ERI               0x1AD
-#define RA_ELC_EVENT_SCI7_AM                0x1AE
-#define RA_ELC_EVENT_SCI8_RXI               0x1B0
-#define RA_ELC_EVENT_SCI8_TXI               0x1B1
-#define RA_ELC_EVENT_SCI8_TEI               0x1B2
-#define RA_ELC_EVENT_SCI8_ERI               0x1B3
-#define RA_ELC_EVENT_SCI8_AM                0x1B4
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC
-#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC
-#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD
-#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD
-#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE
-#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE
-#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF
-#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF
-#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0
-#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0
-#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1
-#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1
-#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2
-#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2
-#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3
-#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_OSPI_INT               0x1D9
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA6M4 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT4_INT               0x04C /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D /**< Compare match A. */
+#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x078 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x079 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x07A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x07B /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x09A /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x09B /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x09C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CAN0_ERROR             0x0A1 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_RX           0x0A2 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_FIFO_TX           0x0A3 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_RX        0x0A4 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN0_MAILBOX_TX        0x0A5 /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_CAN1_ERROR             0x0A6 /**< Error interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_RX           0x0A7 /**< Receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_FIFO_TX           0x0A8 /**< Transmit FIFO interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_RX        0x0A9 /**< Reception complete interrupt. */
+#define RA_ELC_EVENT_CAN1_MAILBOX_TX        0x0AA /**< Transmission complete interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_PC                0x0FE /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x108 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x109 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C         0x10A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D         0x10B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E         0x10C /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F         0x10D /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x10E /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x10F /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x111 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x112 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C         0x113 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D         0x114 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E         0x115 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F         0x116 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x117 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x118 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END          0x166 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B /**< Compare mismatch. */
+#define RA_ELC_EVENT_EDMAC0_EINT            0x16F /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_RXI               0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI5_RXI               0x19E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI5_TXI               0x19F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI5_TEI               0x1A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI5_ERI               0x1A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI5_AM                0x1A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI6_RXI               0x1A4 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI6_TXI               0x1A5 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI6_TEI               0x1A6 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI6_ERI               0x1A7 /**< Receive error. */
+#define RA_ELC_EVENT_SCI6_AM                0x1A8 /**< Address match event. */
+#define RA_ELC_EVENT_SCI7_RXI               0x1AA /**< Receive data full. */
+#define RA_ELC_EVENT_SCI7_TXI               0x1AB /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI7_TEI               0x1AC /**< Transmit end. */
+#define RA_ELC_EVENT_SCI7_ERI               0x1AD /**< Receive error. */
+#define RA_ELC_EVENT_SCI7_AM                0x1AE /**< Address match event. */
+#define RA_ELC_EVENT_SCI8_RXI               0x1B0 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI8_TXI               0x1B1 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI8_TEI               0x1B2 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI8_ERI               0x1B3 /**< Receive error. */
+#define RA_ELC_EVENT_SCI8_AM                0x1B4 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_OSPI_INT               0x1D9 /**< OSPI interrupt. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M4_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m5-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra6m5-elc.h
@@ -4,332 +4,347 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA6M5 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M5_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M5_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                   0x0
-#define RA_ELC_EVENT_ICU_IRQ0               0x001
-#define RA_ELC_EVENT_ICU_IRQ1               0x002
-#define RA_ELC_EVENT_ICU_IRQ2               0x003
-#define RA_ELC_EVENT_ICU_IRQ3               0x004
-#define RA_ELC_EVENT_ICU_IRQ4               0x005
-#define RA_ELC_EVENT_ICU_IRQ5               0x006
-#define RA_ELC_EVENT_ICU_IRQ6               0x007
-#define RA_ELC_EVENT_ICU_IRQ7               0x008
-#define RA_ELC_EVENT_ICU_IRQ8               0x009
-#define RA_ELC_EVENT_ICU_IRQ9               0x00A
-#define RA_ELC_EVENT_ICU_IRQ10              0x00B
-#define RA_ELC_EVENT_ICU_IRQ11              0x00C
-#define RA_ELC_EVENT_ICU_IRQ12              0x00D
-#define RA_ELC_EVENT_ICU_IRQ13              0x00E
-#define RA_ELC_EVENT_ICU_IRQ14              0x00F
-#define RA_ELC_EVENT_ICU_IRQ15              0x010
-#define RA_ELC_EVENT_DMAC0_INT              0x020
-#define RA_ELC_EVENT_DMAC1_INT              0x021
-#define RA_ELC_EVENT_DMAC2_INT              0x022
-#define RA_ELC_EVENT_DMAC3_INT              0x023
-#define RA_ELC_EVENT_DMAC4_INT              0x024
-#define RA_ELC_EVENT_DMAC5_INT              0x025
-#define RA_ELC_EVENT_DMAC6_INT              0x026
-#define RA_ELC_EVENT_DMAC7_INT              0x027
-#define RA_ELC_EVENT_DTC_COMPLETE           0x029
-#define RA_ELC_EVENT_DTC_END                0x02A
-#define RA_ELC_EVENT_DMA_TRANSERR           0x02B
-#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D
-#define RA_ELC_EVENT_FCU_FIFERR             0x030
-#define RA_ELC_EVENT_FCU_FRDYI              0x031
-#define RA_ELC_EVENT_LVD_LVD1               0x038
-#define RA_ELC_EVENT_LVD_LVD2               0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B
-#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C
-#define RA_ELC_EVENT_AGT0_INT               0x040
-#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_AGT1_INT               0x043
-#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT2_INT               0x046
-#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047
-#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048
-#define RA_ELC_EVENT_AGT3_INT               0x049
-#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A
-#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B
-#define RA_ELC_EVENT_AGT4_INT               0x04C
-#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D
-#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E
-#define RA_ELC_EVENT_AGT5_INT               0x04F
-#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050
-#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051
-#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052
-#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM              0x054
-#define RA_ELC_EVENT_RTC_PERIOD             0x055
-#define RA_ELC_EVENT_RTC_CARRY              0x056
-#define RA_ELC_EVENT_CAN_RXF                0x059
-#define RA_ELC_EVENT_CAN_GLERR              0x05A
-#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B
-#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C
-#define RA_ELC_EVENT_CAN_DMAREQ2            0x05D
-#define RA_ELC_EVENT_CAN_DMAREQ3            0x05E
-#define RA_ELC_EVENT_CAN_DMAREQ4            0x05F
-#define RA_ELC_EVENT_CAN_DMAREQ5            0x060
-#define RA_ELC_EVENT_CAN_DMAREQ6            0x061
-#define RA_ELC_EVENT_CAN_DMAREQ7            0x062
-#define RA_ELC_EVENT_CAN0_TX                0x063
-#define RA_ELC_EVENT_CAN0_CHERR             0x064
-#define RA_ELC_EVENT_CAN0_COMFRX            0x065
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066
-#define RA_ELC_EVENT_CAN1_TX                0x067
-#define RA_ELC_EVENT_CAN1_CHERR             0x068
-#define RA_ELC_EVENT_CAN1_COMFRX            0x069
-#define RA_ELC_EVENT_CAN1_CF_DMAREQ         0x06A
-#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B
-#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C
-#define RA_ELC_EVENT_USBFS_INT              0x06D
-#define RA_ELC_EVENT_USBFS_RESUME           0x06E
-#define RA_ELC_EVENT_IIC0_RXI               0x073
-#define RA_ELC_EVENT_IIC0_TXI               0x074
-#define RA_ELC_EVENT_IIC0_TEI               0x075
-#define RA_ELC_EVENT_IIC0_ERI               0x076
-#define RA_ELC_EVENT_IIC0_WUI               0x077
-#define RA_ELC_EVENT_IIC1_RXI               0x078
-#define RA_ELC_EVENT_IIC1_TXI               0x079
-#define RA_ELC_EVENT_IIC1_TEI               0x07A
-#define RA_ELC_EVENT_IIC1_ERI               0x07B
-#define RA_ELC_EVENT_IIC2_RXI               0x07D
-#define RA_ELC_EVENT_IIC2_TXI               0x07E
-#define RA_ELC_EVENT_IIC2_TEI               0x07F
-#define RA_ELC_EVENT_IIC2_ERI               0x080
-#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082
-#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083
-#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085
-#define RA_ELC_EVENT_SSI0_TXI               0x08A
-#define RA_ELC_EVENT_SSI0_RXI               0x08B
-#define RA_ELC_EVENT_SSI0_INT               0x08D
-#define RA_ELC_EVENT_CTSU_WRITE             0x09A
-#define RA_ELC_EVENT_CTSU_READ              0x09B
-#define RA_ELC_EVENT_CTSU_END               0x09C
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F
-#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0
-#define RA_ELC_EVENT_CEC_INTDA              0x0AB
-#define RA_ELC_EVENT_CEC_INTCE              0x0AC
-#define RA_ELC_EVENT_CEC_INTERR             0x0AD
-#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1
-#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2
-#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3
-#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6
-#define RA_ELC_EVENT_POEG0_EVENT            0x0B7
-#define RA_ELC_EVENT_POEG1_EVENT            0x0B8
-#define RA_ELC_EVENT_POEG2_EVENT            0x0B9
-#define RA_ELC_EVENT_POEG3_EVENT            0x0BA
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1
-#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2
-#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3
-#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4
-#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7
-#define RA_ELC_EVENT_GPT0_PC                0x0C8
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA
-#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB
-#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC
-#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD
-#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0
-#define RA_ELC_EVENT_GPT1_PC                0x0D1
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3
-#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4
-#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5
-#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6
-#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC
-#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD
-#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE
-#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF
-#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5
-#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6
-#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7
-#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8
-#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB
-#define RA_ELC_EVENT_GPT4_PC                0x0EC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE
-#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF
-#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0
-#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1
-#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4
-#define RA_ELC_EVENT_GPT5_PC                0x0F5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7
-#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8
-#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9
-#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA
-#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD
-#define RA_ELC_EVENT_GPT6_PC                0x0FE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100
-#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101
-#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102
-#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103
-#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x108
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x109
-#define RA_ELC_EVENT_GPT8_COMPARE_C         0x10A
-#define RA_ELC_EVENT_GPT8_COMPARE_D         0x10B
-#define RA_ELC_EVENT_GPT8_COMPARE_E         0x10C
-#define RA_ELC_EVENT_GPT8_COMPARE_F         0x10D
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x10E
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x10F
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x111
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x112
-#define RA_ELC_EVENT_GPT9_COMPARE_C         0x113
-#define RA_ELC_EVENT_GPT9_COMPARE_D         0x114
-#define RA_ELC_EVENT_GPT9_COMPARE_E         0x115
-#define RA_ELC_EVENT_GPT9_COMPARE_F         0x116
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x117
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x118
-#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150
-#define RA_ELC_EVENT_ADC0_SCAN_END          0x160
-#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161
-#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162
-#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165
-#define RA_ELC_EVENT_ADC1_SCAN_END          0x166
-#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167
-#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168
-#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B
-#define RA_ELC_EVENT_EDMAC0_EINT            0x16F
-#define RA_ELC_EVENT_USBHS_FIFO_0           0x17D
-#define RA_ELC_EVENT_USBHS_FIFO_1           0x17E
-#define RA_ELC_EVENT_USBHS_USB_INT_RESUME   0x17F
-#define RA_ELC_EVENT_SCI0_RXI               0x180
-#define RA_ELC_EVENT_SCI0_TXI               0x181
-#define RA_ELC_EVENT_SCI0_TEI               0x182
-#define RA_ELC_EVENT_SCI0_ERI               0x183
-#define RA_ELC_EVENT_SCI0_AM                0x184
-#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185
-#define RA_ELC_EVENT_SCI1_RXI               0x186
-#define RA_ELC_EVENT_SCI1_TXI               0x187
-#define RA_ELC_EVENT_SCI1_TEI               0x188
-#define RA_ELC_EVENT_SCI1_ERI               0x189
-#define RA_ELC_EVENT_SCI2_RXI               0x18C
-#define RA_ELC_EVENT_SCI2_TXI               0x18D
-#define RA_ELC_EVENT_SCI2_TEI               0x18E
-#define RA_ELC_EVENT_SCI2_ERI               0x18F
-#define RA_ELC_EVENT_SCI3_RXI               0x192
-#define RA_ELC_EVENT_SCI3_TXI               0x193
-#define RA_ELC_EVENT_SCI3_TEI               0x194
-#define RA_ELC_EVENT_SCI3_ERI               0x195
-#define RA_ELC_EVENT_SCI3_AM                0x196
-#define RA_ELC_EVENT_SCI4_RXI               0x198
-#define RA_ELC_EVENT_SCI4_TXI               0x199
-#define RA_ELC_EVENT_SCI4_TEI               0x19A
-#define RA_ELC_EVENT_SCI4_ERI               0x19B
-#define RA_ELC_EVENT_SCI4_AM                0x19C
-#define RA_ELC_EVENT_SCI5_RXI               0x19E
-#define RA_ELC_EVENT_SCI5_TXI               0x19F
-#define RA_ELC_EVENT_SCI5_TEI               0x1A0
-#define RA_ELC_EVENT_SCI5_ERI               0x1A1
-#define RA_ELC_EVENT_SCI5_AM                0x1A2
-#define RA_ELC_EVENT_SCI6_RXI               0x1A4
-#define RA_ELC_EVENT_SCI6_TXI               0x1A5
-#define RA_ELC_EVENT_SCI6_TEI               0x1A6
-#define RA_ELC_EVENT_SCI6_ERI               0x1A7
-#define RA_ELC_EVENT_SCI6_AM                0x1A8
-#define RA_ELC_EVENT_SCI7_RXI               0x1AA
-#define RA_ELC_EVENT_SCI7_TXI               0x1AB
-#define RA_ELC_EVENT_SCI7_TEI               0x1AC
-#define RA_ELC_EVENT_SCI7_ERI               0x1AD
-#define RA_ELC_EVENT_SCI7_AM                0x1AE
-#define RA_ELC_EVENT_SCI8_RXI               0x1B0
-#define RA_ELC_EVENT_SCI8_TXI               0x1B1
-#define RA_ELC_EVENT_SCI8_TEI               0x1B2
-#define RA_ELC_EVENT_SCI8_ERI               0x1B3
-#define RA_ELC_EVENT_SCI8_AM                0x1B4
-#define RA_ELC_EVENT_SCI9_RXI               0x1B6
-#define RA_ELC_EVENT_SCI9_TXI               0x1B7
-#define RA_ELC_EVENT_SCI9_TEI               0x1B8
-#define RA_ELC_EVENT_SCI9_ERI               0x1B9
-#define RA_ELC_EVENT_SCI9_AM                0x1BA
-#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC
-#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC
-#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD
-#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD
-#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE
-#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE
-#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF
-#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF
-#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0
-#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0
-#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1
-#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1
-#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2
-#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2
-#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3
-#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3
-#define RA_ELC_EVENT_SPI0_RXI               0x1C4
-#define RA_ELC_EVENT_SPI0_TXI               0x1C5
-#define RA_ELC_EVENT_SPI0_IDLE              0x1C6
-#define RA_ELC_EVENT_SPI0_ERI               0x1C7
-#define RA_ELC_EVENT_SPI0_TEI               0x1C8
-#define RA_ELC_EVENT_SPI1_RXI               0x1C9
-#define RA_ELC_EVENT_SPI1_TXI               0x1CA
-#define RA_ELC_EVENT_SPI1_IDLE              0x1CB
-#define RA_ELC_EVENT_SPI1_ERI               0x1CC
-#define RA_ELC_EVENT_SPI1_TEI               0x1CD
-#define RA_ELC_EVENT_CAN_AFLRAM0_ERI        0x1CE
-#define RA_ELC_EVENT_CAN_AFLRAM1_ERI        0x1CF
-#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0
-#define RA_ELC_EVENT_OSPI_INT               0x1D9
-#define RA_ELC_EVENT_QSPI_INT               0x1DA
-#define RA_ELC_EVENT_DOC_INT                0x1DB
+/**
+ * @name Event codes for Renesas RA6M5 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                   0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0               0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1               0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2               0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3               0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4               0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5               0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6               0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7               0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8               0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9               0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10              0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11              0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12              0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13              0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14              0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15              0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT              0x020 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT              0x021 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT              0x022 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT              0x023 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT              0x024 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT              0x025 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT              0x026 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT              0x027 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE           0x029 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DTC_END                0x02A /**< DTC transfer end. */
+#define RA_ELC_EVENT_DMA_TRANSERR           0x02B /**< DMA/DTC transfer error. */
+#define RA_ELC_EVENT_ICU_SNOOZE_CANCEL      0x02D /**< Canceling from Snooze mode. */
+#define RA_ELC_EVENT_FCU_FIFERR             0x030 /**< Flash access error interrupt. */
+#define RA_ELC_EVENT_FCU_FRDYI              0x031 /**< Flash ready interrupt. */
+#define RA_ELC_EVENT_LVD_LVD1               0x038 /**< Voltage monitor 1 interrupt. */
+#define RA_ELC_EVENT_LVD_LVD2               0x039 /**< Voltage monitor 2 interrupt. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP          0x03B /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_LPM_SNOOZE_REQUEST     0x03C /**< Snooze entry. */
+#define RA_ELC_EVENT_AGT0_INT               0x040 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A         0x041 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B         0x042 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT               0x043 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A         0x044 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B         0x045 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT2_INT               0x046 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT2_COMPARE_A         0x047 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT2_COMPARE_B         0x048 /**< Compare match B. */
+#define RA_ELC_EVENT_AGT3_INT               0x049 /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT3_COMPARE_A         0x04A /**< Compare match A. */
+#define RA_ELC_EVENT_AGT3_COMPARE_B         0x04B /**< Compare match B. */
+#define RA_ELC_EVENT_AGT4_INT               0x04C /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT4_COMPARE_A         0x04D /**< Compare match A. */
+#define RA_ELC_EVENT_AGT4_COMPARE_B         0x04E /**< Compare match B. */
+#define RA_ELC_EVENT_AGT5_INT               0x04F /**< AGT interrupt. */
+#define RA_ELC_EVENT_AGT5_COMPARE_A         0x050 /**< Compare match A. */
+#define RA_ELC_EVENT_AGT5_COMPARE_B         0x051 /**< Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW         0x052 /**< IWDT underflow. */
+#define RA_ELC_EVENT_WDT_UNDERFLOW          0x053 /**< WDT underflow. */
+#define RA_ELC_EVENT_RTC_ALARM              0x054 /**< Alarm interrupt. */
+#define RA_ELC_EVENT_RTC_PERIOD             0x055 /**< Periodic interrupt. */
+#define RA_ELC_EVENT_RTC_CARRY              0x056 /**< Carry interrupt. */
+#define RA_ELC_EVENT_CAN_RXF                0x059 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR              0x05A /**< Global error. */
+#define RA_ELC_EVENT_CAN_DMAREQ0            0x05B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN_DMAREQ1            0x05C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN_DMAREQ2            0x05D /**< RX fifo DMA request 2. */
+#define RA_ELC_EVENT_CAN_DMAREQ3            0x05E /**< RX fifo DMA request 3. */
+#define RA_ELC_EVENT_CAN_DMAREQ4            0x05F /**< RX fifo DMA request 4. */
+#define RA_ELC_EVENT_CAN_DMAREQ5            0x060 /**< RX fifo DMA request 5. */
+#define RA_ELC_EVENT_CAN_DMAREQ6            0x061 /**< RX fifo DMA request 6. */
+#define RA_ELC_EVENT_CAN_DMAREQ7            0x062 /**< RX fifo DMA request 7. */
+#define RA_ELC_EVENT_CAN0_TX                0x063 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR             0x064 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX            0x065 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ         0x066 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN1_TX                0x067 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN1_CHERR             0x068 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN1_COMFRX            0x069 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN1_CF_DMAREQ         0x06A /**< Channel  DMA request. */
+#define RA_ELC_EVENT_USBFS_FIFO_0           0x06B /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1           0x06C /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT              0x06D /**< USBFS interrupt. */
+#define RA_ELC_EVENT_USBFS_RESUME           0x06E /**< USBFS resume interrupt. */
+#define RA_ELC_EVENT_IIC0_RXI               0x073 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI               0x074 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI               0x075 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI               0x076 /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI               0x077 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI               0x078 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI               0x079 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI               0x07A /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI               0x07B /**< Transfer error. */
+#define RA_ELC_EVENT_IIC2_RXI               0x07D /**< Receive data full. */
+#define RA_ELC_EVENT_IIC2_TXI               0x07E /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC2_TEI               0x07F /**< Transmit end. */
+#define RA_ELC_EVENT_IIC2_ERI               0x080 /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS          0x082 /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO          0x083 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD          0x084 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ       0x085 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI               0x08A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI               0x08B /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT               0x08D /**< Error interrupt. */
+#define RA_ELC_EVENT_CTSU_WRITE             0x09A /**< Write request interrupt. */
+#define RA_ELC_EVENT_CTSU_READ              0x09B /**< Measurement data transfer interrupt. */
+#define RA_ELC_EVENT_CTSU_END               0x09C /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR    0x09E /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END    0x09F /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW           0x0A0 /**< Overflow interrupt. */
+#define RA_ELC_EVENT_CEC_INTDA              0x0AB /**< Data interrupt. */
+#define RA_ELC_EVENT_CEC_INTCE              0x0AC /**< Communication complete interrupt. */
+#define RA_ELC_EVENT_CEC_INTERR             0x0AD /**< Error interrupt. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1         0x0B1 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2         0x0B2 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3         0x0B3 /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4         0x0B4 /**< Port 4 event. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0   0x0B5 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1   0x0B6 /**< Software event 1. */
+#define RA_ELC_EVENT_POEG0_EVENT            0x0B7 /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT            0x0B8 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT            0x0B9 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT            0x0BA /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A 0x0C0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B 0x0C1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C         0x0C2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D         0x0C3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E         0x0C4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F         0x0C5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW  0x0C6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW 0x0C7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                0x0C8 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A 0x0C9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B 0x0CA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C         0x0CB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D         0x0CC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E         0x0CD /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F         0x0CE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW  0x0CF /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW 0x0D0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                0x0D1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A 0x0D2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B 0x0D3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C         0x0D4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D         0x0D5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E         0x0D6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F         0x0D7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW  0x0D8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW 0x0D9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A 0x0DB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B 0x0DC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C         0x0DD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D         0x0DE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E         0x0DF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F         0x0E0 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW  0x0E1 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW 0x0E2 /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A 0x0E4 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B 0x0E5 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C         0x0E6 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D         0x0E7 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E         0x0E8 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F         0x0E9 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW  0x0EA /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW 0x0EB /**< Underflow. */
+#define RA_ELC_EVENT_GPT4_PC                0x0EC /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A 0x0ED /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B 0x0EE /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C         0x0EF /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D         0x0F0 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E         0x0F1 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F         0x0F2 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW  0x0F3 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW 0x0F4 /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_PC                0x0F5 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A 0x0F6 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B 0x0F7 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C         0x0F8 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D         0x0F9 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E         0x0FA /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F         0x0FB /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW  0x0FC /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW 0x0FD /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_PC                0x0FE /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A 0x0FF /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B 0x100 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C         0x101 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D         0x102 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E         0x103 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F         0x104 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW  0x105 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW 0x106 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A 0x108 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B 0x109 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C         0x10A /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D         0x10B /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E         0x10C /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F         0x10D /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW  0x10E /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW 0x10F /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A 0x111 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B 0x112 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C         0x113 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D         0x114 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E         0x115 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F         0x116 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW  0x117 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW 0x118 /**< Underflow. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE           0x150 /**< UVW edge event. */
+#define RA_ELC_EVENT_ADC0_SCAN_END          0x160 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B        0x161 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A          0x162 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B          0x163 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH     0x164 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH  0x165 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END          0x166 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B        0x167 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A          0x168 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B          0x169 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH     0x16A /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH  0x16B /**< Compare mismatch. */
+#define RA_ELC_EVENT_EDMAC0_EINT            0x16F /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_USBHS_FIFO_0           0x17D /**< DMA transfer request 0. */
+#define RA_ELC_EVENT_USBHS_FIFO_1           0x17E /**< DMA transfer request 1. */
+#define RA_ELC_EVENT_USBHS_USB_INT_RESUME   0x17F /**< USBHS interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI               0x180 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI               0x181 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI               0x182 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI               0x183 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AM                0x184 /**< Address match event. */
+#define RA_ELC_EVENT_SCI0_RXI_OR_ERI        0x185 /**< Receive data full/Receive error. */
+#define RA_ELC_EVENT_SCI1_RXI               0x186 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI               0x187 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI               0x188 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI               0x189 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_RXI               0x18C /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI               0x18D /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI               0x18E /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI               0x18F /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_RXI               0x192 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI               0x193 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI               0x194 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI               0x195 /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                0x196 /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI               0x198 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI               0x199 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI               0x19A /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI               0x19B /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                0x19C /**< Address match event. */
+#define RA_ELC_EVENT_SCI5_RXI               0x19E /**< Receive data full. */
+#define RA_ELC_EVENT_SCI5_TXI               0x19F /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI5_TEI               0x1A0 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI5_ERI               0x1A1 /**< Receive error. */
+#define RA_ELC_EVENT_SCI5_AM                0x1A2 /**< Address match event. */
+#define RA_ELC_EVENT_SCI6_RXI               0x1A4 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI6_TXI               0x1A5 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI6_TEI               0x1A6 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI6_ERI               0x1A7 /**< Receive error. */
+#define RA_ELC_EVENT_SCI6_AM                0x1A8 /**< Address match event. */
+#define RA_ELC_EVENT_SCI7_RXI               0x1AA /**< Receive data full. */
+#define RA_ELC_EVENT_SCI7_TXI               0x1AB /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI7_TEI               0x1AC /**< Transmit end. */
+#define RA_ELC_EVENT_SCI7_ERI               0x1AD /**< Receive error. */
+#define RA_ELC_EVENT_SCI7_AM                0x1AE /**< Address match event. */
+#define RA_ELC_EVENT_SCI8_RXI               0x1B0 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI8_TXI               0x1B1 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI8_TEI               0x1B2 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI8_ERI               0x1B3 /**< Receive error. */
+#define RA_ELC_EVENT_SCI8_AM                0x1B4 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI               0x1B6 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI               0x1B7 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI               0x1B8 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI               0x1B9 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                0x1BA /**< Address match event. */
+#define RA_ELC_EVENT_SCIX0_SCIX0            0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI1_SCIX0             0x1BC /**< SCI0 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX0_SCIX1            0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI1_SCIX1             0x1BD /**< SCI0 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX0_SCIX2            0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI1_SCIX2             0x1BE /**< SCI0 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX0_SCIX3            0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI1_SCIX3             0x1BF /**< SCI0 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCIX1_SCIX0            0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCI2_SCIX0             0x1C0 /**< SCI1 extended serial mode event 0. */
+#define RA_ELC_EVENT_SCIX1_SCIX1            0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCI2_SCIX1             0x1C1 /**< SCI1 extended serial mode event 1. */
+#define RA_ELC_EVENT_SCIX1_SCIX2            0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCI2_SCIX2             0x1C2 /**< SCI1 extended serial mode event 2. */
+#define RA_ELC_EVENT_SCIX1_SCIX3            0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SCI2_SCIX3             0x1C3 /**< SCI1 extended serial mode event 3. */
+#define RA_ELC_EVENT_SPI0_RXI               0x1C4 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI               0x1C5 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE              0x1C6 /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI               0x1C7 /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI               0x1C8 /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI               0x1C9 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI               0x1CA /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE              0x1CB /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI               0x1CC /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI               0x1CD /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN_AFLRAM0_ERI        0x1CE /**< ECC error. */
+#define RA_ELC_EVENT_CAN_AFLRAM1_ERI        0x1CF /**< ECC error. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI          0x1D0 /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_OSPI_INT               0x1D9 /**< OSPI interrupt. */
+#define RA_ELC_EVENT_QSPI_INT               0x1DA /**< QSPI interrupt. */
+#define RA_ELC_EVENT_DOC_INT                0x1DB /**< Data operation circuit interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_CTSU    18
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_CTSU    18 /**< CTSU */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA6M5_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8d1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8d1-elc.h
@@ -4,361 +4,376 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA8D1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8D1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8D1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                    0x0
-#define RA_ELC_EVENT_ICU_IRQ0                0x001
-#define RA_ELC_EVENT_ICU_IRQ1                0x002
-#define RA_ELC_EVENT_ICU_IRQ2                0x003
-#define RA_ELC_EVENT_ICU_IRQ3                0x004
-#define RA_ELC_EVENT_ICU_IRQ4                0x005
-#define RA_ELC_EVENT_ICU_IRQ5                0x006
-#define RA_ELC_EVENT_ICU_IRQ6                0x007
-#define RA_ELC_EVENT_ICU_IRQ7                0x008
-#define RA_ELC_EVENT_ICU_IRQ8                0x009
-#define RA_ELC_EVENT_ICU_IRQ9                0x00A
-#define RA_ELC_EVENT_ICU_IRQ10               0x00B
-#define RA_ELC_EVENT_ICU_IRQ11               0x00C
-#define RA_ELC_EVENT_ICU_IRQ12               0x00D
-#define RA_ELC_EVENT_ICU_IRQ13               0x00E
-#define RA_ELC_EVENT_ICU_IRQ14               0x00F
-#define RA_ELC_EVENT_ICU_IRQ15               0x010
-#define RA_ELC_EVENT_DMAC0_INT               0x011
-#define RA_ELC_EVENT_DMAC1_INT               0x012
-#define RA_ELC_EVENT_DMAC2_INT               0x013
-#define RA_ELC_EVENT_DMAC3_INT               0x014
-#define RA_ELC_EVENT_DMAC4_INT               0x015
-#define RA_ELC_EVENT_DMAC5_INT               0x016
-#define RA_ELC_EVENT_DMAC6_INT               0x017
-#define RA_ELC_EVENT_DMAC7_INT               0x018
-#define RA_ELC_EVENT_DTC_END                 0x021
-#define RA_ELC_EVENT_DTC_COMPLETE            0x022
-#define RA_ELC_EVENT_DMA_TRANSERR            0x027
-#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029
-#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A
-#define RA_ELC_EVENT_DBG_JBRXI               0x02B
-#define RA_ELC_EVENT_FCU_FIFERR              0x030
-#define RA_ELC_EVENT_FCU_FRDYI               0x031
-#define RA_ELC_EVENT_LVD_LVD1                0x038
-#define RA_ELC_EVENT_LVD_LVD2                0x039
-#define RA_ELC_EVENT_VBATT_TADI              0x03D
-#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E
-#define RA_ELC_EVENT_ULPT0_INT               0x040
-#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_ULPT1_INT               0x043
-#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT0_INT                0x046
-#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047
-#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048
-#define RA_ELC_EVENT_AGT1_INT                0x049
-#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A
-#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B
-#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052
-#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM               0x055
-#define RA_ELC_EVENT_RTC_PERIOD              0x056
-#define RA_ELC_EVENT_RTC_CARRY               0x057
-#define RA_ELC_EVENT_USBFS_FIFO_0            0x058
-#define RA_ELC_EVENT_USBFS_FIFO_1            0x059
-#define RA_ELC_EVENT_USBFS_INT               0x05A
-#define RA_ELC_EVENT_USBFS_RESUME            0x05B
-#define RA_ELC_EVENT_IIC0_RXI                0x05C
-#define RA_ELC_EVENT_IIC0_TXI                0x05D
-#define RA_ELC_EVENT_IIC0_TEI                0x05E
-#define RA_ELC_EVENT_IIC0_ERI                0x05F
-#define RA_ELC_EVENT_IIC0_WUI                0x060
-#define RA_ELC_EVENT_IIC1_RXI                0x061
-#define RA_ELC_EVENT_IIC1_TXI                0x062
-#define RA_ELC_EVENT_IIC1_TEI                0x063
-#define RA_ELC_EVENT_IIC1_ERI                0x064
-#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B
-#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C
-#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E
-#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F
-#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070
-#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072
-#define RA_ELC_EVENT_SSI0_TXI                0x073
-#define RA_ELC_EVENT_SSI0_RXI                0x074
-#define RA_ELC_EVENT_SSI0_INT                0x076
-#define RA_ELC_EVENT_SSI1_TXI_RXI            0x079
-#define RA_ELC_EVENT_SSI1_TXI                0x079
-#define RA_ELC_EVENT_SSI1_RXI                0x079
-#define RA_ELC_EVENT_SSI1_INT                0x07A
-#define RA_ELC_EVENT_ACMPHS0_INT             0x07B
-#define RA_ELC_EVENT_ACMPHS1_INT             0x07C
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084
-#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088
-#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089
-#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A
-#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D
-#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E
-#define RA_ELC_EVENT_POEG0_EVENT             0x08F
-#define RA_ELC_EVENT_POEG1_EVENT             0x090
-#define RA_ELC_EVENT_POEG2_EVENT             0x091
-#define RA_ELC_EVENT_POEG3_EVENT             0x092
-#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2
-#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3
-#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4
-#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5
-#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8
-#define RA_ELC_EVENT_GPT0_PC                 0x0A9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB
-#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC
-#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD
-#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE
-#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1
-#define RA_ELC_EVENT_GPT1_PC                 0x0B2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4
-#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5
-#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6
-#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7
-#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA
-#define RA_ELC_EVENT_GPT2_PC                 0x0BB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD
-#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE
-#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF
-#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0
-#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3
-#define RA_ELC_EVENT_GPT3_PC                 0x0C4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6
-#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7
-#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8
-#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9
-#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF
-#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0
-#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1
-#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2
-#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8
-#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9
-#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA
-#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB
-#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1
-#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2
-#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3
-#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4
-#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA
-#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB
-#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC
-#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED
-#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0
-#define RA_ELC_EVENT_GPT8_PC                 0x0F1
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3
-#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4
-#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5
-#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6
-#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9
-#define RA_ELC_EVENT_GPT9_PC                 0x0FA
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC
-#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD
-#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE
-#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF
-#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102
-#define RA_ELC_EVENT_GPT10_PC                0x103
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105
-#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106
-#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107
-#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108
-#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E
-#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F
-#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110
-#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111
-#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117
-#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118
-#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119
-#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A
-#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B
-#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C
-#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D
-#define RA_ELC_EVENT_EDMAC0_EINT             0x120
-#define RA_ELC_EVENT_USBHS_FIFO_0            0x121
-#define RA_ELC_EVENT_USBHS_FIFO_1            0x122
-#define RA_ELC_EVENT_USBHS_USB_INT_RESUME    0x123
-#define RA_ELC_EVENT_SCI0_RXI                0x124
-#define RA_ELC_EVENT_SCI0_TXI                0x125
-#define RA_ELC_EVENT_SCI0_TEI                0x126
-#define RA_ELC_EVENT_SCI0_ERI                0x127
-#define RA_ELC_EVENT_SCI0_AED                0x128
-#define RA_ELC_EVENT_SCI0_BFD                0x129
-#define RA_ELC_EVENT_SCI0_AM                 0x12A
-#define RA_ELC_EVENT_SCI1_RXI                0x12B
-#define RA_ELC_EVENT_SCI1_TXI                0x12C
-#define RA_ELC_EVENT_SCI1_TEI                0x12D
-#define RA_ELC_EVENT_SCI1_ERI                0x12E
-#define RA_ELC_EVENT_SCI1_AED                0x12F
-#define RA_ELC_EVENT_SCI1_BFD                0x130
-#define RA_ELC_EVENT_SCI1_AM                 0x131
-#define RA_ELC_EVENT_SCI2_RXI                0x132
-#define RA_ELC_EVENT_SCI2_TXI                0x133
-#define RA_ELC_EVENT_SCI2_TEI                0x134
-#define RA_ELC_EVENT_SCI2_ERI                0x135
-#define RA_ELC_EVENT_SCI2_AM                 0x138
-#define RA_ELC_EVENT_SCI3_RXI                0x139
-#define RA_ELC_EVENT_SCI3_TXI                0x13A
-#define RA_ELC_EVENT_SCI3_TEI                0x13B
-#define RA_ELC_EVENT_SCI3_ERI                0x13C
-#define RA_ELC_EVENT_SCI3_AM                 0x13F
-#define RA_ELC_EVENT_SCI4_RXI                0x140
-#define RA_ELC_EVENT_SCI4_TXI                0x141
-#define RA_ELC_EVENT_SCI4_TEI                0x142
-#define RA_ELC_EVENT_SCI4_ERI                0x143
-#define RA_ELC_EVENT_SCI4_AM                 0x146
-#define RA_ELC_EVENT_SCI9_RXI                0x163
-#define RA_ELC_EVENT_SCI9_TXI                0x164
-#define RA_ELC_EVENT_SCI9_TEI                0x165
-#define RA_ELC_EVENT_SCI9_ERI                0x166
-#define RA_ELC_EVENT_SCI9_AM                 0x169
-#define RA_ELC_EVENT_SPI0_RXI                0x178
-#define RA_ELC_EVENT_SPI0_TXI                0x179
-#define RA_ELC_EVENT_SPI0_IDLE               0x17A
-#define RA_ELC_EVENT_SPI0_ERI                0x17B
-#define RA_ELC_EVENT_SPI0_TEI                0x17C
-#define RA_ELC_EVENT_SPI1_RXI                0x17D
-#define RA_ELC_EVENT_SPI1_TXI                0x17E
-#define RA_ELC_EVENT_SPI1_IDLE               0x17F
-#define RA_ELC_EVENT_SPI1_ERI                0x180
-#define RA_ELC_EVENT_SPI1_TEI                0x181
-#define RA_ELC_EVENT_XSPI_ERR                0x182
-#define RA_ELC_EVENT_XSPI_CMP                0x183
-#define RA_ELC_EVENT_CAN_RXF                 0x185
-#define RA_ELC_EVENT_CAN_GLERR               0x186
-#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187
-#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188
-#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B
-#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C
-#define RA_ELC_EVENT_CAN0_TX                 0x18F
-#define RA_ELC_EVENT_CAN0_CHERR              0x190
-#define RA_ELC_EVENT_CAN0_COMFRX             0x191
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192
-#define RA_ELC_EVENT_CAN0_RXMB               0x193
-#define RA_ELC_EVENT_CAN1_TX                 0x194
-#define RA_ELC_EVENT_CAN1_CHERR              0x195
-#define RA_ELC_EVENT_CAN1_COMFRX             0x196
-#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197
-#define RA_ELC_EVENT_CAN1_RXMB               0x198
-#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B
-#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C
-#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D
-#define RA_ELC_EVENT_I3C0_COMMAND            0x19E
-#define RA_ELC_EVENT_I3C0_IBI                0x19F
-#define RA_ELC_EVENT_I3C0_RX                 0x1A0
-#define RA_ELC_EVENT_IICB0_RXI               0x1A0
-#define RA_ELC_EVENT_I3C0_TX                 0x1A1
-#define RA_ELC_EVENT_IICB0_TXI               0x1A1
-#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2
-#define RA_ELC_EVENT_I3C0_HRESP              0x1A3
-#define RA_ELC_EVENT_I3C0_HCMD               0x1A4
-#define RA_ELC_EVENT_I3C0_HRX                0x1A5
-#define RA_ELC_EVENT_I3C0_HTX                0x1A6
-#define RA_ELC_EVENT_I3C0_TEND               0x1A7
-#define RA_ELC_EVENT_IICB0_TEI               0x1A7
-#define RA_ELC_EVENT_I3C0_EEI                0x1A8
-#define RA_ELC_EVENT_IICB0_ERI               0x1A8
-#define RA_ELC_EVENT_I3C0_STEV               0x1A9
-#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA
-#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB
-#define RA_ELC_EVENT_I3C0_AMEV               0x1AC
-#define RA_ELC_EVENT_I3C0_WU                 0x1AD
-#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE
-#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF
-#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0
-#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3
-#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4
-#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5
-#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6
-#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9
-#define RA_ELC_EVENT_DOC_INT                 0x1BA
-#define RA_ELC_EVENT_RSIP_TADI               0x1BC
-#define RA_ELC_EVENT_GLCDC_LINE_DETECT       0x1CD
-#define RA_ELC_EVENT_GLCDC_UNDERFLOW_1       0x1CE
-#define RA_ELC_EVENT_GLCDC_UNDERFLOW_2       0x1CF
-#define RA_ELC_EVENT_DRW_INT                 0x1D0
-#define RA_ELC_EVENT_MIPIDSI_SEQ0            0x1D3
-#define RA_ELC_EVENT_MIPIDSI_SEQ1            0x1D4
-#define RA_ELC_EVENT_MIPIDSI_VIN1            0x1D5
-#define RA_ELC_EVENT_MIPIDSI_RCV             0x1D6
-#define RA_ELC_EVENT_MIPIDSI_FERR            0x1D7
-#define RA_ELC_EVENT_MIPIDSI_PPI             0x1D8
-#define RA_ELC_EVENT_CEU_CEUI                0x1DA
+/**
+ * @name Event codes for Renesas RA8D1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10               0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11               0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12               0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13               0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14               0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15               0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT               0x011 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT               0x012 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT               0x013 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT               0x014 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT               0x015 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT               0x016 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT               0x017 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT               0x018 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_END                 0x021 /**< DTC transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE            0x022 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR            0x027 /**< DMA transfer error. */
+#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029 /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_JBRXI               0x02B /**< JB RXI. */
+#define RA_ELC_EVENT_FCU_FIFERR              0x030 /**< Flash access error. */
+#define RA_ELC_EVENT_FCU_FRDYI               0x031 /**< Flash ready. */
+#define RA_ELC_EVENT_LVD_LVD1                0x038 /**< Voltage monitor 1. */
+#define RA_ELC_EVENT_LVD_LVD2                0x039 /**< Voltage monitor 2. */
+#define RA_ELC_EVENT_VBATT_TADI              0x03D /**< VBATT Tamper detection. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_ULPT0_INT               0x040 /**< ULPT0 Underflow. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041 /**< ULPT0 Compare match A. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042 /**< ULPT0 Compare match B. */
+#define RA_ELC_EVENT_ULPT1_INT               0x043 /**< ULPT1 Underflow. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044 /**< ULPT1 Compare match A. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045 /**< ULPT1 Compare match B. */
+#define RA_ELC_EVENT_AGT0_INT                0x046 /**< AGT0 interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047 /**< AGT0 Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048 /**< AGT0 Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                0x049 /**< AGT1 interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A /**< AGT1 Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B /**< AGT1 Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052 /**< Independent watchdog underflow. */
+#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053 /**< Watchdog 0 underflow. */
+#define RA_ELC_EVENT_RTC_ALARM               0x055 /**< RTC alarm. */
+#define RA_ELC_EVENT_RTC_PERIOD              0x056 /**< RTC periodic. */
+#define RA_ELC_EVENT_RTC_CARRY               0x057 /**< RTC carry. */
+#define RA_ELC_EVENT_USBFS_FIFO_0            0x058 /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1            0x059 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT               0x05A /**< USBFS INT. */
+#define RA_ELC_EVENT_USBFS_RESUME            0x05B /**< USBFS RESUME. */
+#define RA_ELC_EVENT_IIC0_RXI                0x05C /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                0x05D /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                0x05E /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                0x05F /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                0x060 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                0x061 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                0x062 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                0x063 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                0x064 /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI                0x073 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI                0x074 /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT                0x076 /**< Error interrupt. */
+#define RA_ELC_EVENT_SSI1_TXI_RXI            0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_TXI                0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_RXI                0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_INT                0x07A /**< Error interrupt. */
+#define RA_ELC_EVENT_ACMPHS0_INT             0x07B /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT             0x07C /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084 /**< Software event 1. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B /**< Port 4 event. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E /**< Overflow interrupt. */
+#define RA_ELC_EVENT_POEG0_EVENT             0x08F /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT             0x090 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT             0x091 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT             0x092 /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0 /**< UVW edge event. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                 0x0A9 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                 0x0B2 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_PC                 0x0BB /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_PC                 0x0C4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_PC                 0x0F1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_PC                 0x0FA /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101 /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_PC                0x103 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113 /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114 /**< Underflow. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A /**< Compare match E. */
+#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B /**< Compare match F. */
+#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C /**< Overflow. */
+#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D /**< Underflow. */
+#define RA_ELC_EVENT_EDMAC0_EINT             0x120 /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_USBHS_FIFO_0            0x121 /**< DMA transfer request 0. */
+#define RA_ELC_EVENT_USBHS_FIFO_1            0x122 /**< DMA transfer request 1. */
+#define RA_ELC_EVENT_USBHS_USB_INT_RESUME    0x123 /**< USBHS interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI                0x124 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                0x125 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                0x126 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                0x127 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AED                0x128 /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI0_BFD                0x129 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI0_AM                 0x12A /**< Address match event. */
+#define RA_ELC_EVENT_SCI1_RXI                0x12B /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                0x12C /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                0x12D /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                0x12E /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AED                0x12F /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI1_BFD                0x130 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI1_AM                 0x131 /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                0x132 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                0x133 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                0x134 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                0x135 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                 0x138 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                0x139 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                0x13A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                0x13B /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                0x13C /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                 0x13F /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                0x140 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                0x141 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                0x142 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                0x143 /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                 0x146 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                0x163 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                0x164 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                0x165 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                0x166 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                 0x169 /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                0x178 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                0x179 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE               0x17A /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                0x17B /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                0x17C /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                0x17D /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                0x17E /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE               0x17F /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                0x180 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                0x181 /**< Transmission complete event. */
+#define RA_ELC_EVENT_XSPI_ERR                0x182 /**< xSPI Error. */
+#define RA_ELC_EVENT_XSPI_CMP                0x183 /**< xSPI Complete. */
+#define RA_ELC_EVENT_CAN_RXF                 0x185 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR               0x186 /**< Global error. */
+#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187 /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188 /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                 0x18F /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR              0x190 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX             0x191 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB               0x193 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN1_TX                 0x194 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN1_CHERR              0x195 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN1_COMFRX             0x196 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN1_RXMB               0x198 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C /**< CANFD1 ECC error. */
+#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND            0x19E /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI                0x19F /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                 0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI               0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                 0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI               0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP              0x1A3 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD               0x1A4 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX                0x1A5 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX                0x1A6 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI                0x1A8 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI               0x1A8 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV               0x1A9 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV               0x1AC /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                 0x1AD /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9 /**< Compare mismatch. */
+#define RA_ELC_EVENT_DOC_INT                 0x1BA /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
+#define RA_ELC_EVENT_GLCDC_LINE_DETECT       0x1CD /**< GLCDC line detect interrupt. */
+#define RA_ELC_EVENT_GLCDC_UNDERFLOW_1       0x1CE /**< GLCDC underflow interrupt 1. */
+#define RA_ELC_EVENT_GLCDC_UNDERFLOW_2       0x1CF /**< GLCDC underflow interrupt 2. */
+#define RA_ELC_EVENT_DRW_INT                 0x1D0 /**< DRW interrupt. */
+#define RA_ELC_EVENT_MIPIDSI_SEQ0            0x1D3 /**< MIPI DSI Sequence 0. */
+#define RA_ELC_EVENT_MIPIDSI_SEQ1            0x1D4 /**< MIPI DSI Sequence 1. */
+#define RA_ELC_EVENT_MIPIDSI_VIN1            0x1D5 /**< MIPI DSI Video Input 1. */
+#define RA_ELC_EVENT_MIPIDSI_RCV             0x1D6 /**< MIPI DSI Receive. */
+#define RA_ELC_EVENT_MIPIDSI_FERR            0x1D7 /**< MIPI DSI Frame Error. */
+#define RA_ELC_EVENT_MIPIDSI_PPI             0x1D8 /**< MIPI DSI PPI. */
+#define RA_ELC_EVENT_CEU_CEUI                0x1DA /**< CEU interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     30
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8D1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8m1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8m1-elc.h
@@ -4,351 +4,366 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA8M1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8M1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8M1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                    0x0
-#define RA_ELC_EVENT_ICU_IRQ0                0x001
-#define RA_ELC_EVENT_ICU_IRQ1                0x002
-#define RA_ELC_EVENT_ICU_IRQ2                0x003
-#define RA_ELC_EVENT_ICU_IRQ3                0x004
-#define RA_ELC_EVENT_ICU_IRQ4                0x005
-#define RA_ELC_EVENT_ICU_IRQ5                0x006
-#define RA_ELC_EVENT_ICU_IRQ6                0x007
-#define RA_ELC_EVENT_ICU_IRQ7                0x008
-#define RA_ELC_EVENT_ICU_IRQ8                0x009
-#define RA_ELC_EVENT_ICU_IRQ9                0x00A
-#define RA_ELC_EVENT_ICU_IRQ10               0x00B
-#define RA_ELC_EVENT_ICU_IRQ11               0x00C
-#define RA_ELC_EVENT_ICU_IRQ12               0x00D
-#define RA_ELC_EVENT_ICU_IRQ13               0x00E
-#define RA_ELC_EVENT_ICU_IRQ14               0x00F
-#define RA_ELC_EVENT_ICU_IRQ15               0x010
-#define RA_ELC_EVENT_DMAC0_INT               0x011
-#define RA_ELC_EVENT_DMAC1_INT               0x012
-#define RA_ELC_EVENT_DMAC2_INT               0x013
-#define RA_ELC_EVENT_DMAC3_INT               0x014
-#define RA_ELC_EVENT_DMAC4_INT               0x015
-#define RA_ELC_EVENT_DMAC5_INT               0x016
-#define RA_ELC_EVENT_DMAC6_INT               0x017
-#define RA_ELC_EVENT_DMAC7_INT               0x018
-#define RA_ELC_EVENT_DTC_END                 0x021
-#define RA_ELC_EVENT_DTC_COMPLETE            0x022
-#define RA_ELC_EVENT_DMA_TRANSERR            0x027
-#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029
-#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A
-#define RA_ELC_EVENT_DBG_JBRXI               0x02B
-#define RA_ELC_EVENT_FCU_FIFERR              0x030
-#define RA_ELC_EVENT_FCU_FRDYI               0x031
-#define RA_ELC_EVENT_LVD_LVD1                0x038
-#define RA_ELC_EVENT_LVD_LVD2                0x039
-#define RA_ELC_EVENT_VBATT_TADI              0x03D
-#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E
-#define RA_ELC_EVENT_ULPT0_INT               0x040
-#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_ULPT1_INT               0x043
-#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT0_INT                0x046
-#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047
-#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048
-#define RA_ELC_EVENT_AGT1_INT                0x049
-#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A
-#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B
-#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052
-#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053
-#define RA_ELC_EVENT_RTC_ALARM               0x055
-#define RA_ELC_EVENT_RTC_PERIOD              0x056
-#define RA_ELC_EVENT_RTC_CARRY               0x057
-#define RA_ELC_EVENT_USBFS_FIFO_0            0x058
-#define RA_ELC_EVENT_USBFS_FIFO_1            0x059
-#define RA_ELC_EVENT_USBFS_INT               0x05A
-#define RA_ELC_EVENT_USBFS_RESUME            0x05B
-#define RA_ELC_EVENT_IIC0_RXI                0x05C
-#define RA_ELC_EVENT_IIC0_TXI                0x05D
-#define RA_ELC_EVENT_IIC0_TEI                0x05E
-#define RA_ELC_EVENT_IIC0_ERI                0x05F
-#define RA_ELC_EVENT_IIC0_WUI                0x060
-#define RA_ELC_EVENT_IIC1_RXI                0x061
-#define RA_ELC_EVENT_IIC1_TXI                0x062
-#define RA_ELC_EVENT_IIC1_TEI                0x063
-#define RA_ELC_EVENT_IIC1_ERI                0x064
-#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B
-#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C
-#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E
-#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F
-#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070
-#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072
-#define RA_ELC_EVENT_SSI0_TXI                0x073
-#define RA_ELC_EVENT_SSI0_RXI                0x074
-#define RA_ELC_EVENT_SSI0_INT                0x076
-#define RA_ELC_EVENT_SSI1_TXI_RXI            0x079
-#define RA_ELC_EVENT_SSI1_TXI                0x079
-#define RA_ELC_EVENT_SSI1_RXI                0x079
-#define RA_ELC_EVENT_SSI1_INT                0x07A
-#define RA_ELC_EVENT_ACMPHS0_INT             0x07B
-#define RA_ELC_EVENT_ACMPHS1_INT             0x07C
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084
-#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088
-#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089
-#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A
-#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D
-#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E
-#define RA_ELC_EVENT_POEG0_EVENT             0x08F
-#define RA_ELC_EVENT_POEG1_EVENT             0x090
-#define RA_ELC_EVENT_POEG2_EVENT             0x091
-#define RA_ELC_EVENT_POEG3_EVENT             0x092
-#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2
-#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3
-#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4
-#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5
-#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8
-#define RA_ELC_EVENT_GPT0_PC                 0x0A9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB
-#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC
-#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD
-#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE
-#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1
-#define RA_ELC_EVENT_GPT1_PC                 0x0B2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4
-#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5
-#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6
-#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7
-#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA
-#define RA_ELC_EVENT_GPT2_PC                 0x0BB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD
-#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE
-#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF
-#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0
-#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3
-#define RA_ELC_EVENT_GPT3_PC                 0x0C4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6
-#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7
-#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8
-#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9
-#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF
-#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0
-#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1
-#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2
-#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8
-#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9
-#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA
-#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB
-#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1
-#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2
-#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3
-#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4
-#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA
-#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB
-#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC
-#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED
-#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0
-#define RA_ELC_EVENT_GPT8_PC                 0x0F1
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3
-#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4
-#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5
-#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6
-#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9
-#define RA_ELC_EVENT_GPT9_PC                 0x0FA
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC
-#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD
-#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE
-#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF
-#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102
-#define RA_ELC_EVENT_GPT10_PC                0x103
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105
-#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106
-#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107
-#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108
-#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E
-#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F
-#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110
-#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111
-#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117
-#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118
-#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119
-#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A
-#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B
-#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C
-#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D
-#define RA_ELC_EVENT_EDMAC0_EINT             0x120
-#define RA_ELC_EVENT_USBHS_FIFO_0            0x121
-#define RA_ELC_EVENT_USBHS_FIFO_1            0x122
-#define RA_ELC_EVENT_USBHS_USB_INT_RESUME    0x123
-#define RA_ELC_EVENT_SCI0_RXI                0x124
-#define RA_ELC_EVENT_SCI0_TXI                0x125
-#define RA_ELC_EVENT_SCI0_TEI                0x126
-#define RA_ELC_EVENT_SCI0_ERI                0x127
-#define RA_ELC_EVENT_SCI0_AED                0x128
-#define RA_ELC_EVENT_SCI0_BFD                0x129
-#define RA_ELC_EVENT_SCI0_AM                 0x12A
-#define RA_ELC_EVENT_SCI1_RXI                0x12B
-#define RA_ELC_EVENT_SCI1_TXI                0x12C
-#define RA_ELC_EVENT_SCI1_TEI                0x12D
-#define RA_ELC_EVENT_SCI1_ERI                0x12E
-#define RA_ELC_EVENT_SCI1_AED                0x12F
-#define RA_ELC_EVENT_SCI1_BFD                0x130
-#define RA_ELC_EVENT_SCI1_AM                 0x131
-#define RA_ELC_EVENT_SCI2_RXI                0x132
-#define RA_ELC_EVENT_SCI2_TXI                0x133
-#define RA_ELC_EVENT_SCI2_TEI                0x134
-#define RA_ELC_EVENT_SCI2_ERI                0x135
-#define RA_ELC_EVENT_SCI2_AM                 0x138
-#define RA_ELC_EVENT_SCI3_RXI                0x139
-#define RA_ELC_EVENT_SCI3_TXI                0x13A
-#define RA_ELC_EVENT_SCI3_TEI                0x13B
-#define RA_ELC_EVENT_SCI3_ERI                0x13C
-#define RA_ELC_EVENT_SCI3_AM                 0x13F
-#define RA_ELC_EVENT_SCI4_RXI                0x140
-#define RA_ELC_EVENT_SCI4_TXI                0x141
-#define RA_ELC_EVENT_SCI4_TEI                0x142
-#define RA_ELC_EVENT_SCI4_ERI                0x143
-#define RA_ELC_EVENT_SCI4_AM                 0x146
-#define RA_ELC_EVENT_SCI9_RXI                0x163
-#define RA_ELC_EVENT_SCI9_TXI                0x164
-#define RA_ELC_EVENT_SCI9_TEI                0x165
-#define RA_ELC_EVENT_SCI9_ERI                0x166
-#define RA_ELC_EVENT_SCI9_AM                 0x169
-#define RA_ELC_EVENT_SPI0_RXI                0x178
-#define RA_ELC_EVENT_SPI0_TXI                0x179
-#define RA_ELC_EVENT_SPI0_IDLE               0x17A
-#define RA_ELC_EVENT_SPI0_ERI                0x17B
-#define RA_ELC_EVENT_SPI0_TEI                0x17C
-#define RA_ELC_EVENT_SPI1_RXI                0x17D
-#define RA_ELC_EVENT_SPI1_TXI                0x17E
-#define RA_ELC_EVENT_SPI1_IDLE               0x17F
-#define RA_ELC_EVENT_SPI1_ERI                0x180
-#define RA_ELC_EVENT_SPI1_TEI                0x181
-#define RA_ELC_EVENT_XSPI_ERR                0x182
-#define RA_ELC_EVENT_XSPI_CMP                0x183
-#define RA_ELC_EVENT_CAN_RXF                 0x185
-#define RA_ELC_EVENT_CAN_GLERR               0x186
-#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187
-#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188
-#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B
-#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C
-#define RA_ELC_EVENT_CAN0_TX                 0x18F
-#define RA_ELC_EVENT_CAN0_CHERR              0x190
-#define RA_ELC_EVENT_CAN0_COMFRX             0x191
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192
-#define RA_ELC_EVENT_CAN0_RXMB               0x193
-#define RA_ELC_EVENT_CAN1_TX                 0x194
-#define RA_ELC_EVENT_CAN1_CHERR              0x195
-#define RA_ELC_EVENT_CAN1_COMFRX             0x196
-#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197
-#define RA_ELC_EVENT_CAN1_RXMB               0x198
-#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B
-#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C
-#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D
-#define RA_ELC_EVENT_I3C0_COMMAND            0x19E
-#define RA_ELC_EVENT_I3C0_IBI                0x19F
-#define RA_ELC_EVENT_I3C0_RX                 0x1A0
-#define RA_ELC_EVENT_IICB0_RXI               0x1A0
-#define RA_ELC_EVENT_I3C0_TX                 0x1A1
-#define RA_ELC_EVENT_IICB0_TXI               0x1A1
-#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2
-#define RA_ELC_EVENT_I3C0_HRESP              0x1A3
-#define RA_ELC_EVENT_I3C0_HCMD               0x1A4
-#define RA_ELC_EVENT_I3C0_HRX                0x1A5
-#define RA_ELC_EVENT_I3C0_HTX                0x1A6
-#define RA_ELC_EVENT_I3C0_TEND               0x1A7
-#define RA_ELC_EVENT_IICB0_TEI               0x1A7
-#define RA_ELC_EVENT_I3C0_EEI                0x1A8
-#define RA_ELC_EVENT_IICB0_ERI               0x1A8
-#define RA_ELC_EVENT_I3C0_STEV               0x1A9
-#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA
-#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB
-#define RA_ELC_EVENT_I3C0_AMEV               0x1AC
-#define RA_ELC_EVENT_I3C0_WU                 0x1AD
-#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE
-#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF
-#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0
-#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3
-#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4
-#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5
-#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6
-#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9
-#define RA_ELC_EVENT_DOC_INT                 0x1BA
-#define RA_ELC_EVENT_RSIP_TADI               0x1BC
-#define RA_ELC_EVENT_CEU_CEUI                0x1DA
+/**
+ * @name Event codes for Renesas RA8M1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10               0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11               0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12               0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13               0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14               0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15               0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT               0x011 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT               0x012 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT               0x013 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT               0x014 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT               0x015 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT               0x016 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT               0x017 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT               0x018 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_END                 0x021 /**< DTC transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE            0x022 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR            0x027 /**< DMA transfer error. */
+#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029 /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_JBRXI               0x02B /**< JB RXI. */
+#define RA_ELC_EVENT_FCU_FIFERR              0x030 /**< Flash access error. */
+#define RA_ELC_EVENT_FCU_FRDYI               0x031 /**< Flash ready. */
+#define RA_ELC_EVENT_LVD_LVD1                0x038 /**< Voltage monitor 1. */
+#define RA_ELC_EVENT_LVD_LVD2                0x039 /**< Voltage monitor 2. */
+#define RA_ELC_EVENT_VBATT_TADI              0x03D /**< VBATT Tamper detection. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_ULPT0_INT               0x040 /**< ULPT0 Underflow. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041 /**< ULPT0 Compare match A. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042 /**< ULPT0 Compare match B. */
+#define RA_ELC_EVENT_ULPT1_INT               0x043 /**< ULPT1 Underflow. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044 /**< ULPT1 Compare match A. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045 /**< ULPT1 Compare match B. */
+#define RA_ELC_EVENT_AGT0_INT                0x046 /**< AGT0 interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047 /**< AGT0 Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048 /**< AGT0 Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                0x049 /**< AGT1 interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A /**< AGT1 Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B /**< AGT1 Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052 /**< Independent watchdog underflow. */
+#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053 /**< Watchdog 0 underflow. */
+#define RA_ELC_EVENT_RTC_ALARM               0x055 /**< RTC alarm. */
+#define RA_ELC_EVENT_RTC_PERIOD              0x056 /**< RTC periodic. */
+#define RA_ELC_EVENT_RTC_CARRY               0x057 /**< RTC carry. */
+#define RA_ELC_EVENT_USBFS_FIFO_0            0x058 /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1            0x059 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT               0x05A /**< USBFS INT. */
+#define RA_ELC_EVENT_USBFS_RESUME            0x05B /**< USBFS RESUME. */
+#define RA_ELC_EVENT_IIC0_RXI                0x05C /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                0x05D /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                0x05E /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                0x05F /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                0x060 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                0x061 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                0x062 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                0x063 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                0x064 /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072 /**< DMA transfer request. */
+#define RA_ELC_EVENT_SSI0_TXI                0x073 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SSI0_RXI                0x074 /**< Receive data full. */
+#define RA_ELC_EVENT_SSI0_INT                0x076 /**< Error interrupt. */
+#define RA_ELC_EVENT_SSI1_TXI_RXI            0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_TXI                0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_RXI                0x079 /**< Receive data full/Transmit data empty. */
+#define RA_ELC_EVENT_SSI1_INT                0x07A /**< Error interrupt. */
+#define RA_ELC_EVENT_ACMPHS0_INT             0x07B /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT             0x07C /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084 /**< Software event 1. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B /**< Port 4 event. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E /**< Overflow interrupt. */
+#define RA_ELC_EVENT_POEG0_EVENT             0x08F /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT             0x090 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT             0x091 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT             0x092 /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0 /**< UVW edge event. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                 0x0A9 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                 0x0B2 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_PC                 0x0BB /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_PC                 0x0C4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_PC                 0x0F1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_PC                 0x0FA /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101 /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_PC                0x103 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113 /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114 /**< Underflow. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A /**< Compare match E. */
+#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B /**< Compare match F. */
+#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C /**< Overflow. */
+#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D /**< Underflow. */
+#define RA_ELC_EVENT_EDMAC0_EINT             0x120 /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_USBHS_FIFO_0            0x121 /**< DMA transfer request 0. */
+#define RA_ELC_EVENT_USBHS_FIFO_1            0x122 /**< DMA transfer request 1. */
+#define RA_ELC_EVENT_USBHS_USB_INT_RESUME    0x123 /**< USBHS interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI                0x124 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                0x125 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                0x126 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                0x127 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AED                0x128 /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI0_BFD                0x129 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI0_AM                 0x12A /**< Address match event. */
+#define RA_ELC_EVENT_SCI1_RXI                0x12B /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                0x12C /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                0x12D /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                0x12E /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AED                0x12F /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI1_BFD                0x130 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI1_AM                 0x131 /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                0x132 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                0x133 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                0x134 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                0x135 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                 0x138 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                0x139 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                0x13A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                0x13B /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                0x13C /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                 0x13F /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                0x140 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                0x141 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                0x142 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                0x143 /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                 0x146 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                0x163 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                0x164 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                0x165 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                0x166 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                 0x169 /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                0x178 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                0x179 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE               0x17A /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                0x17B /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                0x17C /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                0x17D /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                0x17E /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE               0x17F /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                0x180 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                0x181 /**< Transmission complete event. */
+#define RA_ELC_EVENT_XSPI_ERR                0x182 /**< xSPI Error. */
+#define RA_ELC_EVENT_XSPI_CMP                0x183 /**< xSPI Complete. */
+#define RA_ELC_EVENT_CAN_RXF                 0x185 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR               0x186 /**< Global error. */
+#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187 /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188 /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                 0x18F /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR              0x190 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX             0x191 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB               0x193 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN1_TX                 0x194 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN1_CHERR              0x195 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN1_COMFRX             0x196 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN1_RXMB               0x198 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C /**< CANFD1 ECC error. */
+#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND            0x19E /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI                0x19F /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                 0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI               0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                 0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI               0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP              0x1A3 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD               0x1A4 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX                0x1A5 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX                0x1A6 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI                0x1A8 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI               0x1A8 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV               0x1A9 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV               0x1AC /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                 0x1AD /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9 /**< Compare mismatch. */
+#define RA_ELC_EVENT_DOC_INT                 0x1BA /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
+#define RA_ELC_EVENT_CEU_CEUI                0x1DA /**< CEU interrupt. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     30
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8M1_ELC_H_ */

--- a/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8t1-elc.h
+++ b/include/zephyr/dt-bindings/misc/renesas/ra-elc/ra8t1-elc.h
@@ -4,334 +4,349 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA8T1 Event Link Controller (ELC) definitions
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8T1_ELC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8T1_ELC_H_
 
-/* Sources of event signals to be linked to other peripherals or the CPU */
-#define RA_ELC_EVENT_NONE                    0x0
-#define RA_ELC_EVENT_ICU_IRQ0                0x001
-#define RA_ELC_EVENT_ICU_IRQ1                0x002
-#define RA_ELC_EVENT_ICU_IRQ2                0x003
-#define RA_ELC_EVENT_ICU_IRQ3                0x004
-#define RA_ELC_EVENT_ICU_IRQ4                0x005
-#define RA_ELC_EVENT_ICU_IRQ5                0x006
-#define RA_ELC_EVENT_ICU_IRQ6                0x007
-#define RA_ELC_EVENT_ICU_IRQ7                0x008
-#define RA_ELC_EVENT_ICU_IRQ8                0x009
-#define RA_ELC_EVENT_ICU_IRQ9                0x00A
-#define RA_ELC_EVENT_ICU_IRQ10               0x00B
-#define RA_ELC_EVENT_ICU_IRQ11               0x00C
-#define RA_ELC_EVENT_ICU_IRQ12               0x00D
-#define RA_ELC_EVENT_ICU_IRQ13               0x00E
-#define RA_ELC_EVENT_ICU_IRQ14               0x00F
-#define RA_ELC_EVENT_ICU_IRQ15               0x010
-#define RA_ELC_EVENT_DMAC0_INT               0x011
-#define RA_ELC_EVENT_DMAC1_INT               0x012
-#define RA_ELC_EVENT_DMAC2_INT               0x013
-#define RA_ELC_EVENT_DMAC3_INT               0x014
-#define RA_ELC_EVENT_DMAC4_INT               0x015
-#define RA_ELC_EVENT_DMAC5_INT               0x016
-#define RA_ELC_EVENT_DMAC6_INT               0x017
-#define RA_ELC_EVENT_DMAC7_INT               0x018
-#define RA_ELC_EVENT_DTC_END                 0x021
-#define RA_ELC_EVENT_DTC_COMPLETE            0x022
-#define RA_ELC_EVENT_DMA_TRANSERR            0x027
-#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029
-#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A
-#define RA_ELC_EVENT_DBG_JBRXI               0x02B
-#define RA_ELC_EVENT_FCU_FIFERR              0x030
-#define RA_ELC_EVENT_FCU_FRDYI               0x031
-#define RA_ELC_EVENT_LVD_LVD1                0x038
-#define RA_ELC_EVENT_LVD_LVD2                0x039
-#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E
-#define RA_ELC_EVENT_ULPT0_INT               0x040
-#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041
-#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042
-#define RA_ELC_EVENT_ULPT1_INT               0x043
-#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044
-#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045
-#define RA_ELC_EVENT_AGT0_INT                0x046
-#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047
-#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048
-#define RA_ELC_EVENT_AGT1_INT                0x049
-#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A
-#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B
-#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052
-#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053
-#define RA_ELC_EVENT_USBFS_FIFO_0            0x058
-#define RA_ELC_EVENT_USBFS_FIFO_1            0x059
-#define RA_ELC_EVENT_USBFS_INT               0x05A
-#define RA_ELC_EVENT_USBFS_RESUME            0x05B
-#define RA_ELC_EVENT_IIC0_RXI                0x05C
-#define RA_ELC_EVENT_IIC0_TXI                0x05D
-#define RA_ELC_EVENT_IIC0_TEI                0x05E
-#define RA_ELC_EVENT_IIC0_ERI                0x05F
-#define RA_ELC_EVENT_IIC0_WUI                0x060
-#define RA_ELC_EVENT_IIC1_RXI                0x061
-#define RA_ELC_EVENT_IIC1_TXI                0x062
-#define RA_ELC_EVENT_IIC1_TEI                0x063
-#define RA_ELC_EVENT_IIC1_ERI                0x064
-#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B
-#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C
-#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D
-#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E
-#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F
-#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070
-#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071
-#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072
-#define RA_ELC_EVENT_ACMPHS0_INT             0x07B
-#define RA_ELC_EVENT_ACMPHS1_INT             0x07C
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083
-#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084
-#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088
-#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089
-#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A
-#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B
-#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C
-#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D
-#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E
-#define RA_ELC_EVENT_POEG0_EVENT             0x08F
-#define RA_ELC_EVENT_POEG1_EVENT             0x090
-#define RA_ELC_EVENT_POEG2_EVENT             0x091
-#define RA_ELC_EVENT_POEG3_EVENT             0x092
-#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1
-#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2
-#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3
-#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4
-#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5
-#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6
-#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7
-#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8
-#define RA_ELC_EVENT_GPT0_PC                 0x0A9
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA
-#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB
-#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC
-#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD
-#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE
-#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF
-#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0
-#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1
-#define RA_ELC_EVENT_GPT1_PC                 0x0B2
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3
-#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4
-#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5
-#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6
-#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7
-#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8
-#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9
-#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA
-#define RA_ELC_EVENT_GPT2_PC                 0x0BB
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC
-#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD
-#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE
-#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF
-#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0
-#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1
-#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2
-#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3
-#define RA_ELC_EVENT_GPT3_PC                 0x0C4
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5
-#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6
-#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7
-#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8
-#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9
-#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA
-#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB
-#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE
-#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF
-#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0
-#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1
-#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2
-#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3
-#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4
-#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7
-#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8
-#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9
-#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA
-#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB
-#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC
-#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD
-#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0
-#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1
-#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2
-#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3
-#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4
-#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5
-#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6
-#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9
-#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA
-#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB
-#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC
-#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED
-#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE
-#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF
-#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0
-#define RA_ELC_EVENT_GPT8_PC                 0x0F1
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2
-#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3
-#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4
-#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5
-#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6
-#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7
-#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8
-#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9
-#define RA_ELC_EVENT_GPT9_PC                 0x0FA
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB
-#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC
-#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD
-#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE
-#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF
-#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100
-#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101
-#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102
-#define RA_ELC_EVENT_GPT10_PC                0x103
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104
-#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105
-#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106
-#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107
-#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108
-#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109
-#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A
-#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D
-#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E
-#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F
-#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110
-#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111
-#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112
-#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113
-#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116
-#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117
-#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118
-#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119
-#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A
-#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B
-#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C
-#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D
-#define RA_ELC_EVENT_EDMAC0_EINT             0x120
-#define RA_ELC_EVENT_SCI0_RXI                0x124
-#define RA_ELC_EVENT_SCI0_TXI                0x125
-#define RA_ELC_EVENT_SCI0_TEI                0x126
-#define RA_ELC_EVENT_SCI0_ERI                0x127
-#define RA_ELC_EVENT_SCI0_AED                0x128
-#define RA_ELC_EVENT_SCI0_BFD                0x129
-#define RA_ELC_EVENT_SCI0_AM                 0x12A
-#define RA_ELC_EVENT_SCI1_RXI                0x12B
-#define RA_ELC_EVENT_SCI1_TXI                0x12C
-#define RA_ELC_EVENT_SCI1_TEI                0x12D
-#define RA_ELC_EVENT_SCI1_ERI                0x12E
-#define RA_ELC_EVENT_SCI1_AED                0x12F
-#define RA_ELC_EVENT_SCI1_BFD                0x130
-#define RA_ELC_EVENT_SCI1_AM                 0x131
-#define RA_ELC_EVENT_SCI2_RXI                0x132
-#define RA_ELC_EVENT_SCI2_TXI                0x133
-#define RA_ELC_EVENT_SCI2_TEI                0x134
-#define RA_ELC_EVENT_SCI2_ERI                0x135
-#define RA_ELC_EVENT_SCI2_AM                 0x138
-#define RA_ELC_EVENT_SCI3_RXI                0x139
-#define RA_ELC_EVENT_SCI3_TXI                0x13A
-#define RA_ELC_EVENT_SCI3_TEI                0x13B
-#define RA_ELC_EVENT_SCI3_ERI                0x13C
-#define RA_ELC_EVENT_SCI3_AM                 0x13F
-#define RA_ELC_EVENT_SCI4_RXI                0x140
-#define RA_ELC_EVENT_SCI4_TXI                0x141
-#define RA_ELC_EVENT_SCI4_TEI                0x142
-#define RA_ELC_EVENT_SCI4_ERI                0x143
-#define RA_ELC_EVENT_SCI4_AM                 0x146
-#define RA_ELC_EVENT_SCI9_RXI                0x163
-#define RA_ELC_EVENT_SCI9_TXI                0x164
-#define RA_ELC_EVENT_SCI9_TEI                0x165
-#define RA_ELC_EVENT_SCI9_ERI                0x166
-#define RA_ELC_EVENT_SCI9_AM                 0x169
-#define RA_ELC_EVENT_SPI0_RXI                0x178
-#define RA_ELC_EVENT_SPI0_TXI                0x179
-#define RA_ELC_EVENT_SPI0_IDLE               0x17A
-#define RA_ELC_EVENT_SPI0_ERI                0x17B
-#define RA_ELC_EVENT_SPI0_TEI                0x17C
-#define RA_ELC_EVENT_SPI1_RXI                0x17D
-#define RA_ELC_EVENT_SPI1_TXI                0x17E
-#define RA_ELC_EVENT_SPI1_IDLE               0x17F
-#define RA_ELC_EVENT_SPI1_ERI                0x180
-#define RA_ELC_EVENT_SPI1_TEI                0x181
-#define RA_ELC_EVENT_CAN_RXF                 0x185
-#define RA_ELC_EVENT_CAN_GLERR               0x186
-#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187
-#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188
-#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B
-#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C
-#define RA_ELC_EVENT_CAN0_TX                 0x18F
-#define RA_ELC_EVENT_CAN0_CHERR              0x190
-#define RA_ELC_EVENT_CAN0_COMFRX             0x191
-#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192
-#define RA_ELC_EVENT_CAN0_RXMB               0x193
-#define RA_ELC_EVENT_CAN1_TX                 0x194
-#define RA_ELC_EVENT_CAN1_CHERR              0x195
-#define RA_ELC_EVENT_CAN1_COMFRX             0x196
-#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197
-#define RA_ELC_EVENT_CAN1_RXMB               0x198
-#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B
-#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C
-#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D
-#define RA_ELC_EVENT_I3C0_COMMAND            0x19E
-#define RA_ELC_EVENT_I3C0_IBI                0x19F
-#define RA_ELC_EVENT_I3C0_RX                 0x1A0
-#define RA_ELC_EVENT_IICB0_RXI               0x1A0
-#define RA_ELC_EVENT_I3C0_TX                 0x1A1
-#define RA_ELC_EVENT_IICB0_TXI               0x1A1
-#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2
-#define RA_ELC_EVENT_I3C0_HRESP              0x1A3
-#define RA_ELC_EVENT_I3C0_HCMD               0x1A4
-#define RA_ELC_EVENT_I3C0_HRX                0x1A5
-#define RA_ELC_EVENT_I3C0_HTX                0x1A6
-#define RA_ELC_EVENT_I3C0_TEND               0x1A7
-#define RA_ELC_EVENT_IICB0_TEI               0x1A7
-#define RA_ELC_EVENT_I3C0_EEI                0x1A8
-#define RA_ELC_EVENT_IICB0_ERI               0x1A8
-#define RA_ELC_EVENT_I3C0_STEV               0x1A9
-#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA
-#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB
-#define RA_ELC_EVENT_I3C0_AMEV               0x1AC
-#define RA_ELC_EVENT_I3C0_WU                 0x1AD
-#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE
-#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF
-#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0
-#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1
-#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2
-#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3
-#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4
-#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5
-#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6
-#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7
-#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8
-#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9
-#define RA_ELC_EVENT_DOC_INT                 0x1BA
-#define RA_ELC_EVENT_RSIP_TADI               0x1BC
+/**
+ * @name Event codes for Renesas RA8T1 Event Link Controller (ELC).
+ * @{
+ */
+#define RA_ELC_EVENT_NONE                    0x0   /**< Link disabled. */
+#define RA_ELC_EVENT_ICU_IRQ0                0x001 /**< External pin interrupt 0. */
+#define RA_ELC_EVENT_ICU_IRQ1                0x002 /**< External pin interrupt 1. */
+#define RA_ELC_EVENT_ICU_IRQ2                0x003 /**< External pin interrupt 2. */
+#define RA_ELC_EVENT_ICU_IRQ3                0x004 /**< External pin interrupt 3. */
+#define RA_ELC_EVENT_ICU_IRQ4                0x005 /**< External pin interrupt 4. */
+#define RA_ELC_EVENT_ICU_IRQ5                0x006 /**< External pin interrupt 5. */
+#define RA_ELC_EVENT_ICU_IRQ6                0x007 /**< External pin interrupt 6. */
+#define RA_ELC_EVENT_ICU_IRQ7                0x008 /**< External pin interrupt 7. */
+#define RA_ELC_EVENT_ICU_IRQ8                0x009 /**< External pin interrupt 8. */
+#define RA_ELC_EVENT_ICU_IRQ9                0x00A /**< External pin interrupt 9. */
+#define RA_ELC_EVENT_ICU_IRQ10               0x00B /**< External pin interrupt 10. */
+#define RA_ELC_EVENT_ICU_IRQ11               0x00C /**< External pin interrupt 11. */
+#define RA_ELC_EVENT_ICU_IRQ12               0x00D /**< External pin interrupt 12. */
+#define RA_ELC_EVENT_ICU_IRQ13               0x00E /**< External pin interrupt 13. */
+#define RA_ELC_EVENT_ICU_IRQ14               0x00F /**< External pin interrupt 14. */
+#define RA_ELC_EVENT_ICU_IRQ15               0x010 /**< External pin interrupt 15. */
+#define RA_ELC_EVENT_DMAC0_INT               0x011 /**< DMAC0 transfer end. */
+#define RA_ELC_EVENT_DMAC1_INT               0x012 /**< DMAC1 transfer end. */
+#define RA_ELC_EVENT_DMAC2_INT               0x013 /**< DMAC2 transfer end. */
+#define RA_ELC_EVENT_DMAC3_INT               0x014 /**< DMAC3 transfer end. */
+#define RA_ELC_EVENT_DMAC4_INT               0x015 /**< DMAC4 transfer end. */
+#define RA_ELC_EVENT_DMAC5_INT               0x016 /**< DMAC5 transfer end. */
+#define RA_ELC_EVENT_DMAC6_INT               0x017 /**< DMAC6 transfer end. */
+#define RA_ELC_EVENT_DMAC7_INT               0x018 /**< DMAC7 transfer end. */
+#define RA_ELC_EVENT_DTC_END                 0x021 /**< DTC transfer end. */
+#define RA_ELC_EVENT_DTC_COMPLETE            0x022 /**< DTC transfer complete. */
+#define RA_ELC_EVENT_DMA_TRANSERR            0x027 /**< DMA transfer error. */
+#define RA_ELC_EVENT_DBG_CTIIRQ0             0x029 /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_CTIIRQ1             0x02A /**< Coresight Crosstrigger. */
+#define RA_ELC_EVENT_DBG_JBRXI               0x02B /**< JB RXI. */
+#define RA_ELC_EVENT_FCU_FIFERR              0x030 /**< Flash access error. */
+#define RA_ELC_EVENT_FCU_FRDYI               0x031 /**< Flash ready. */
+#define RA_ELC_EVENT_LVD_LVD1                0x038 /**< Voltage monitor 1. */
+#define RA_ELC_EVENT_LVD_LVD2                0x039 /**< Voltage monitor 2. */
+#define RA_ELC_EVENT_CGC_MOSC_STOP           0x03E /**< Main Clock oscillation stop. */
+#define RA_ELC_EVENT_ULPT0_INT               0x040 /**< ULPT0 Underflow. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_A         0x041 /**< ULPT0 Compare match A. */
+#define RA_ELC_EVENT_ULPT0_COMPARE_B         0x042 /**< ULPT0 Compare match B. */
+#define RA_ELC_EVENT_ULPT1_INT               0x043 /**< ULPT1 Underflow. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_A         0x044 /**< ULPT1 Compare match A. */
+#define RA_ELC_EVENT_ULPT1_COMPARE_B         0x045 /**< ULPT1 Compare match B. */
+#define RA_ELC_EVENT_AGT0_INT                0x046 /**< AGT0 interrupt. */
+#define RA_ELC_EVENT_AGT0_COMPARE_A          0x047 /**< AGT0 Compare match A. */
+#define RA_ELC_EVENT_AGT0_COMPARE_B          0x048 /**< AGT0 Compare match B. */
+#define RA_ELC_EVENT_AGT1_INT                0x049 /**< AGT1 interrupt. */
+#define RA_ELC_EVENT_AGT1_COMPARE_A          0x04A /**< AGT1 Compare match A. */
+#define RA_ELC_EVENT_AGT1_COMPARE_B          0x04B /**< AGT1 Compare match B. */
+#define RA_ELC_EVENT_IWDT_UNDERFLOW          0x052 /**< Independent watchdog underflow. */
+#define RA_ELC_EVENT_WDT0_UNDERFLOW          0x053 /**< Watchdog 0 underflow. */
+#define RA_ELC_EVENT_USBFS_FIFO_0            0x058 /**< DMA/DTC transfer request 0. */
+#define RA_ELC_EVENT_USBFS_FIFO_1            0x059 /**< DMA/DTC transfer request 1. */
+#define RA_ELC_EVENT_USBFS_INT               0x05A /**< USBFS INT. */
+#define RA_ELC_EVENT_USBFS_RESUME            0x05B /**< USBFS RESUME. */
+#define RA_ELC_EVENT_IIC0_RXI                0x05C /**< Receive data full. */
+#define RA_ELC_EVENT_IIC0_TXI                0x05D /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC0_TEI                0x05E /**< Transmit end. */
+#define RA_ELC_EVENT_IIC0_ERI                0x05F /**< Transfer error. */
+#define RA_ELC_EVENT_IIC0_WUI                0x060 /**< Wakeup interrupt. */
+#define RA_ELC_EVENT_IIC1_RXI                0x061 /**< Receive data full. */
+#define RA_ELC_EVENT_IIC1_TXI                0x062 /**< Transmit data empty. */
+#define RA_ELC_EVENT_IIC1_TEI                0x063 /**< Transmit end. */
+#define RA_ELC_EVENT_IIC1_ERI                0x064 /**< Transfer error. */
+#define RA_ELC_EVENT_SDHIMMC0_ACCS           0x06B /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC0_SDIO           0x06C /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC0_CARD           0x06D /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC0_DMA_REQ        0x06E /**< DMA transfer request. */
+#define RA_ELC_EVENT_SDHIMMC1_ACCS           0x06F /**< Card access. */
+#define RA_ELC_EVENT_SDHIMMC1_SDIO           0x070 /**< SDIO access. */
+#define RA_ELC_EVENT_SDHIMMC1_CARD           0x071 /**< Card detect. */
+#define RA_ELC_EVENT_SDHIMMC1_DMA_REQ        0x072 /**< DMA transfer request. */
+#define RA_ELC_EVENT_ACMPHS0_INT             0x07B /**< High Speed analog comparator channel 0. */
+#define RA_ELC_EVENT_ACMPHS1_INT             0x07C /**< High Speed analog comparator channel 1. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_0    0x083 /**< Software event 0. */
+#define RA_ELC_EVENT_ELC_SOFTWARE_EVENT_1    0x084 /**< Software event 1. */
+#define RA_ELC_EVENT_IOPORT_EVENT_1          0x088 /**< Port 1 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_2          0x089 /**< Port 2 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_3          0x08A /**< Port 3 event. */
+#define RA_ELC_EVENT_IOPORT_EVENT_4          0x08B /**< Port 4 event. */
+#define RA_ELC_EVENT_CAC_FREQUENCY_ERROR     0x08C /**< Frequency error interrupt. */
+#define RA_ELC_EVENT_CAC_MEASUREMENT_END     0x08D /**< Measurement end interrupt. */
+#define RA_ELC_EVENT_CAC_OVERFLOW            0x08E /**< Overflow interrupt. */
+#define RA_ELC_EVENT_POEG0_EVENT             0x08F /**< Port Output disable 0 interrupt. */
+#define RA_ELC_EVENT_POEG1_EVENT             0x090 /**< Port Output disable 1 interrupt. */
+#define RA_ELC_EVENT_POEG2_EVENT             0x091 /**< Port Output disable 2 interrupt. */
+#define RA_ELC_EVENT_POEG3_EVENT             0x092 /**< Port Output disable 3 interrupt. */
+#define RA_ELC_EVENT_OPS_UVW_EDGE            0x0A0 /**< UVW edge event. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_A  0x0A1 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT0_CAPTURE_COMPARE_B  0x0A2 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT0_COMPARE_C          0x0A3 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT0_COMPARE_D          0x0A4 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT0_COMPARE_E          0x0A5 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT0_COMPARE_F          0x0A6 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT0_COUNTER_OVERFLOW   0x0A7 /**< Overflow. */
+#define RA_ELC_EVENT_GPT0_COUNTER_UNDERFLOW  0x0A8 /**< Underflow. */
+#define RA_ELC_EVENT_GPT0_PC                 0x0A9 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_A  0x0AA /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT1_CAPTURE_COMPARE_B  0x0AB /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT1_COMPARE_C          0x0AC /**< Compare match C. */
+#define RA_ELC_EVENT_GPT1_COMPARE_D          0x0AD /**< Compare match D. */
+#define RA_ELC_EVENT_GPT1_COMPARE_E          0x0AE /**< Compare match E. */
+#define RA_ELC_EVENT_GPT1_COMPARE_F          0x0AF /**< Compare match F. */
+#define RA_ELC_EVENT_GPT1_COUNTER_OVERFLOW   0x0B0 /**< Overflow. */
+#define RA_ELC_EVENT_GPT1_COUNTER_UNDERFLOW  0x0B1 /**< Underflow. */
+#define RA_ELC_EVENT_GPT1_PC                 0x0B2 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_A  0x0B3 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT2_CAPTURE_COMPARE_B  0x0B4 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT2_COMPARE_C          0x0B5 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT2_COMPARE_D          0x0B6 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT2_COMPARE_E          0x0B7 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT2_COMPARE_F          0x0B8 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT2_COUNTER_OVERFLOW   0x0B9 /**< Overflow. */
+#define RA_ELC_EVENT_GPT2_COUNTER_UNDERFLOW  0x0BA /**< Underflow. */
+#define RA_ELC_EVENT_GPT2_PC                 0x0BB /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_A  0x0BC /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT3_CAPTURE_COMPARE_B  0x0BD /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT3_COMPARE_C          0x0BE /**< Compare match C. */
+#define RA_ELC_EVENT_GPT3_COMPARE_D          0x0BF /**< Compare match D. */
+#define RA_ELC_EVENT_GPT3_COMPARE_E          0x0C0 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT3_COMPARE_F          0x0C1 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT3_COUNTER_OVERFLOW   0x0C2 /**< Overflow. */
+#define RA_ELC_EVENT_GPT3_COUNTER_UNDERFLOW  0x0C3 /**< Underflow. */
+#define RA_ELC_EVENT_GPT3_PC                 0x0C4 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_A  0x0C5 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT4_CAPTURE_COMPARE_B  0x0C6 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT4_COMPARE_C          0x0C7 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT4_COMPARE_D          0x0C8 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT4_COMPARE_E          0x0C9 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT4_COMPARE_F          0x0CA /**< Compare match F. */
+#define RA_ELC_EVENT_GPT4_COUNTER_OVERFLOW   0x0CB /**< Overflow. */
+#define RA_ELC_EVENT_GPT4_COUNTER_UNDERFLOW  0x0CC /**< Underflow. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_A  0x0CE /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT5_CAPTURE_COMPARE_B  0x0CF /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT5_COMPARE_C          0x0D0 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT5_COMPARE_D          0x0D1 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT5_COMPARE_E          0x0D2 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT5_COMPARE_F          0x0D3 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT5_COUNTER_OVERFLOW   0x0D4 /**< Overflow. */
+#define RA_ELC_EVENT_GPT5_COUNTER_UNDERFLOW  0x0D5 /**< Underflow. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_A  0x0D7 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT6_CAPTURE_COMPARE_B  0x0D8 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT6_COMPARE_C          0x0D9 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT6_COMPARE_D          0x0DA /**< Compare match D. */
+#define RA_ELC_EVENT_GPT6_COMPARE_E          0x0DB /**< Compare match E. */
+#define RA_ELC_EVENT_GPT6_COMPARE_F          0x0DC /**< Compare match F. */
+#define RA_ELC_EVENT_GPT6_COUNTER_OVERFLOW   0x0DD /**< Overflow. */
+#define RA_ELC_EVENT_GPT6_COUNTER_UNDERFLOW  0x0DE /**< Underflow. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_A  0x0E0 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT7_CAPTURE_COMPARE_B  0x0E1 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT7_COMPARE_C          0x0E2 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT7_COMPARE_D          0x0E3 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT7_COMPARE_E          0x0E4 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT7_COMPARE_F          0x0E5 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT7_COUNTER_OVERFLOW   0x0E6 /**< Overflow. */
+#define RA_ELC_EVENT_GPT7_COUNTER_UNDERFLOW  0x0E7 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_A  0x0E9 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT8_CAPTURE_COMPARE_B  0x0EA /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT8_COMPARE_C          0x0EB /**< Compare match C. */
+#define RA_ELC_EVENT_GPT8_COMPARE_D          0x0EC /**< Compare match D. */
+#define RA_ELC_EVENT_GPT8_COMPARE_E          0x0ED /**< Compare match E. */
+#define RA_ELC_EVENT_GPT8_COMPARE_F          0x0EE /**< Compare match F. */
+#define RA_ELC_EVENT_GPT8_COUNTER_OVERFLOW   0x0EF /**< Overflow. */
+#define RA_ELC_EVENT_GPT8_COUNTER_UNDERFLOW  0x0F0 /**< Underflow. */
+#define RA_ELC_EVENT_GPT8_PC                 0x0F1 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_A  0x0F2 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT9_CAPTURE_COMPARE_B  0x0F3 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT9_COMPARE_C          0x0F4 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT9_COMPARE_D          0x0F5 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT9_COMPARE_E          0x0F6 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT9_COMPARE_F          0x0F7 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT9_COUNTER_OVERFLOW   0x0F8 /**< Overflow. */
+#define RA_ELC_EVENT_GPT9_COUNTER_UNDERFLOW  0x0F9 /**< Underflow. */
+#define RA_ELC_EVENT_GPT9_PC                 0x0FA /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_A 0x0FB /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT10_CAPTURE_COMPARE_B 0x0FC /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT10_COMPARE_C         0x0FD /**< Compare match C. */
+#define RA_ELC_EVENT_GPT10_COMPARE_D         0x0FE /**< Compare match D. */
+#define RA_ELC_EVENT_GPT10_COMPARE_E         0x0FF /**< Compare match E. */
+#define RA_ELC_EVENT_GPT10_COMPARE_F         0x100 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT10_COUNTER_OVERFLOW  0x101 /**< Overflow. */
+#define RA_ELC_EVENT_GPT10_COUNTER_UNDERFLOW 0x102 /**< Underflow. */
+#define RA_ELC_EVENT_GPT10_PC                0x103 /**< Period count function finish. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_A 0x104 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT11_CAPTURE_COMPARE_B 0x105 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT11_COMPARE_C         0x106 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT11_COMPARE_D         0x107 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT11_COMPARE_E         0x108 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT11_COMPARE_F         0x109 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT11_COUNTER_OVERFLOW  0x10A /**< Overflow. */
+#define RA_ELC_EVENT_GPT11_COUNTER_UNDERFLOW 0x10B /**< Underflow. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_A 0x10D /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT12_CAPTURE_COMPARE_B 0x10E /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT12_COMPARE_C         0x10F /**< Compare match C. */
+#define RA_ELC_EVENT_GPT12_COMPARE_D         0x110 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT12_COMPARE_E         0x111 /**< Compare match E. */
+#define RA_ELC_EVENT_GPT12_COMPARE_F         0x112 /**< Compare match F. */
+#define RA_ELC_EVENT_GPT12_COUNTER_OVERFLOW  0x113 /**< Overflow. */
+#define RA_ELC_EVENT_GPT12_COUNTER_UNDERFLOW 0x114 /**< Underflow. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_A 0x116 /**< Capture/Compare match A. */
+#define RA_ELC_EVENT_GPT13_CAPTURE_COMPARE_B 0x117 /**< Capture/Compare match B. */
+#define RA_ELC_EVENT_GPT13_COMPARE_C         0x118 /**< Compare match C. */
+#define RA_ELC_EVENT_GPT13_COMPARE_D         0x119 /**< Compare match D. */
+#define RA_ELC_EVENT_GPT13_COMPARE_E         0x11A /**< Compare match E. */
+#define RA_ELC_EVENT_GPT13_COMPARE_F         0x11B /**< Compare match F. */
+#define RA_ELC_EVENT_GPT13_COUNTER_OVERFLOW  0x11C /**< Overflow. */
+#define RA_ELC_EVENT_GPT13_COUNTER_UNDERFLOW 0x11D /**< Underflow. */
+#define RA_ELC_EVENT_EDMAC0_EINT             0x120 /**< EDMAC 0 interrupt. */
+#define RA_ELC_EVENT_SCI0_RXI                0x124 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI0_TXI                0x125 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI0_TEI                0x126 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI0_ERI                0x127 /**< Receive error. */
+#define RA_ELC_EVENT_SCI0_AED                0x128 /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI0_BFD                0x129 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI0_AM                 0x12A /**< Address match event. */
+#define RA_ELC_EVENT_SCI1_RXI                0x12B /**< Receive data full. */
+#define RA_ELC_EVENT_SCI1_TXI                0x12C /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI1_TEI                0x12D /**< Transmit end. */
+#define RA_ELC_EVENT_SCI1_ERI                0x12E /**< Receive error. */
+#define RA_ELC_EVENT_SCI1_AED                0x12F /**< Active edge detection. */
+#define RA_ELC_EVENT_SCI1_BFD                0x130 /**< Break field detection. */
+#define RA_ELC_EVENT_SCI1_AM                 0x131 /**< Address match event. */
+#define RA_ELC_EVENT_SCI2_RXI                0x132 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI2_TXI                0x133 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI2_TEI                0x134 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI2_ERI                0x135 /**< Receive error. */
+#define RA_ELC_EVENT_SCI2_AM                 0x138 /**< Address match event. */
+#define RA_ELC_EVENT_SCI3_RXI                0x139 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI3_TXI                0x13A /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI3_TEI                0x13B /**< Transmit end. */
+#define RA_ELC_EVENT_SCI3_ERI                0x13C /**< Receive error. */
+#define RA_ELC_EVENT_SCI3_AM                 0x13F /**< Address match event. */
+#define RA_ELC_EVENT_SCI4_RXI                0x140 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI4_TXI                0x141 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI4_TEI                0x142 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI4_ERI                0x143 /**< Receive error. */
+#define RA_ELC_EVENT_SCI4_AM                 0x146 /**< Address match event. */
+#define RA_ELC_EVENT_SCI9_RXI                0x163 /**< Receive data full. */
+#define RA_ELC_EVENT_SCI9_TXI                0x164 /**< Transmit data empty. */
+#define RA_ELC_EVENT_SCI9_TEI                0x165 /**< Transmit end. */
+#define RA_ELC_EVENT_SCI9_ERI                0x166 /**< Receive error. */
+#define RA_ELC_EVENT_SCI9_AM                 0x169 /**< Address match event. */
+#define RA_ELC_EVENT_SPI0_RXI                0x178 /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI0_TXI                0x179 /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI0_IDLE               0x17A /**< Idle. */
+#define RA_ELC_EVENT_SPI0_ERI                0x17B /**< Error. */
+#define RA_ELC_EVENT_SPI0_TEI                0x17C /**< Transmission complete event. */
+#define RA_ELC_EVENT_SPI1_RXI                0x17D /**< Receive buffer full. */
+#define RA_ELC_EVENT_SPI1_TXI                0x17E /**< Transmit buffer empty. */
+#define RA_ELC_EVENT_SPI1_IDLE               0x17F /**< Idle. */
+#define RA_ELC_EVENT_SPI1_ERI                0x180 /**< Error. */
+#define RA_ELC_EVENT_SPI1_TEI                0x181 /**< Transmission complete event. */
+#define RA_ELC_EVENT_CAN_RXF                 0x185 /**< Global receive FIFO interrupt. */
+#define RA_ELC_EVENT_CAN_GLERR               0x186 /**< Global error. */
+#define RA_ELC_EVENT_CAN0_DMAREQ0            0x187 /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN0_DMAREQ1            0x188 /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN1_DMAREQ0            0x18B /**< RX fifo DMA request 0. */
+#define RA_ELC_EVENT_CAN1_DMAREQ1            0x18C /**< RX fifo DMA request 1. */
+#define RA_ELC_EVENT_CAN0_TX                 0x18F /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN0_CHERR              0x190 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN0_COMFRX             0x191 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN0_CF_DMAREQ          0x192 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN0_RXMB               0x193 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN1_TX                 0x194 /**< Transmit interrupt. */
+#define RA_ELC_EVENT_CAN1_CHERR              0x195 /**< Channel  error. */
+#define RA_ELC_EVENT_CAN1_COMFRX             0x196 /**< Common FIFO receive interrupt. */
+#define RA_ELC_EVENT_CAN1_CF_DMAREQ          0x197 /**< Channel  DMA request. */
+#define RA_ELC_EVENT_CAN1_RXMB               0x198 /**< Receive message buffer interrupt. */
+#define RA_ELC_EVENT_CAN0_MRAM_ERI           0x19B /**< CANFD0 ECC error. */
+#define RA_ELC_EVENT_CAN1_MRAM_ERI           0x19C /**< CANFD1 ECC error. */
+#define RA_ELC_EVENT_I3C0_RESPONSE           0x19D /**< Response status buffer full. */
+#define RA_ELC_EVENT_I3C0_COMMAND            0x19E /**< Command buffer empty. */
+#define RA_ELC_EVENT_I3C0_IBI                0x19F /**< IBI status buffer full. */
+#define RA_ELC_EVENT_I3C0_RX                 0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_IICB0_RXI               0x1A0 /**< Receive. */
+#define RA_ELC_EVENT_I3C0_TX                 0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_IICB0_TXI               0x1A1 /**< Transmit. */
+#define RA_ELC_EVENT_I3C0_RCV_STATUS         0x1A2 /**< Receive status buffer full. */
+#define RA_ELC_EVENT_I3C0_HRESP              0x1A3 /**< High priority response queue full. */
+#define RA_ELC_EVENT_I3C0_HCMD               0x1A4 /**< High priority command queue empty. */
+#define RA_ELC_EVENT_I3C0_HRX                0x1A5 /**< High priority rx data buffer full. */
+#define RA_ELC_EVENT_I3C0_HTX                0x1A6 /**< High priority tx data buffer empty. */
+#define RA_ELC_EVENT_I3C0_TEND               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_IICB0_TEI               0x1A7 /**< Transmit end. */
+#define RA_ELC_EVENT_I3C0_EEI                0x1A8 /**< Error. */
+#define RA_ELC_EVENT_IICB0_ERI               0x1A8 /**< Error. */
+#define RA_ELC_EVENT_I3C0_STEV               0x1A9 /**< Synchronous timing. */
+#define RA_ELC_EVENT_I3C0_MREFOVF            0x1AA /**< MREF counter overflow. */
+#define RA_ELC_EVENT_I3C0_MREFCPT            0x1AB /**< MREF capture. */
+#define RA_ELC_EVENT_I3C0_AMEV               0x1AC /**< Additional master-initiated bus event. */
+#define RA_ELC_EVENT_I3C0_WU                 0x1AD /**< Wake-up Condition Detection interrupt. */
+#define RA_ELC_EVENT_ADC0_SCAN_END           0x1AE /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC0_SCAN_END_B         0x1AF /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC0_WINDOW_A           0x1B0 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_WINDOW_B           0x1B1 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MATCH      0x1B2 /**< Compare match. */
+#define RA_ELC_EVENT_ADC0_COMPARE_MISMATCH   0x1B3 /**< Compare mismatch. */
+#define RA_ELC_EVENT_ADC1_SCAN_END           0x1B4 /**< End of A/D scanning operation. */
+#define RA_ELC_EVENT_ADC1_SCAN_END_B         0x1B5 /**< A/D scan end interrupt for group B. */
+#define RA_ELC_EVENT_ADC1_WINDOW_A           0x1B6 /**< Window A Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_WINDOW_B           0x1B7 /**< Window B Compare match interrupt. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MATCH      0x1B8 /**< Compare match. */
+#define RA_ELC_EVENT_ADC1_COMPARE_MISMATCH   0x1B9 /**< Compare mismatch. */
+#define RA_ELC_EVENT_DOC_INT                 0x1BA /**< Data operation circuit interrupt. */
+#define RA_ELC_EVENT_RSIP_TADI               0x1BC /**< RSIP Tamper Detection. */
 
-/* Possible peripherals to be linked to event signals */
-#define RA_ELC_PERIPHERAL_GPT_A   0
-#define RA_ELC_PERIPHERAL_GPT_B   1
-#define RA_ELC_PERIPHERAL_GPT_C   2
-#define RA_ELC_PERIPHERAL_GPT_D   3
-#define RA_ELC_PERIPHERAL_GPT_E   4
-#define RA_ELC_PERIPHERAL_GPT_F   5
-#define RA_ELC_PERIPHERAL_GPT_G   6
-#define RA_ELC_PERIPHERAL_GPT_H   7
-#define RA_ELC_PERIPHERAL_ADC0    8
-#define RA_ELC_PERIPHERAL_ADC0_B  9
-#define RA_ELC_PERIPHERAL_ADC1    10
-#define RA_ELC_PERIPHERAL_ADC1_B  11
-#define RA_ELC_PERIPHERAL_DAC0    12
-#define RA_ELC_PERIPHERAL_DAC1    13
-#define RA_ELC_PERIPHERAL_IOPORT1 14
-#define RA_ELC_PERIPHERAL_IOPORT2 15
-#define RA_ELC_PERIPHERAL_IOPORT3 16
-#define RA_ELC_PERIPHERAL_IOPORT4 17
-#define RA_ELC_PERIPHERAL_I3C     30
+/** @} */
+
+/**
+ * @name Renesas RA ELC possible peripherals to be linked to event signals
+ * @{
+ */
+#define RA_ELC_PERIPHERAL_GPT_A   0  /**< General PWM Timer A */
+#define RA_ELC_PERIPHERAL_GPT_B   1  /**< General PWM Timer B */
+#define RA_ELC_PERIPHERAL_GPT_C   2  /**< General PWM Timer C */
+#define RA_ELC_PERIPHERAL_GPT_D   3  /**< General PWM Timer D */
+#define RA_ELC_PERIPHERAL_GPT_E   4  /**< General PWM Timer E */
+#define RA_ELC_PERIPHERAL_GPT_F   5  /**< General PWM Timer F */
+#define RA_ELC_PERIPHERAL_GPT_G   6  /**< General PWM Timer G */
+#define RA_ELC_PERIPHERAL_GPT_H   7  /**< General PWM Timer H */
+#define RA_ELC_PERIPHERAL_ADC0    8  /**< ADC0 */
+#define RA_ELC_PERIPHERAL_ADC0_B  9  /**< ADC0 Group B */
+#define RA_ELC_PERIPHERAL_ADC1    10 /**< ADC1 */
+#define RA_ELC_PERIPHERAL_ADC1_B  11 /**< ADC1 Group B */
+#define RA_ELC_PERIPHERAL_DAC0    12 /**< DAC0 */
+#define RA_ELC_PERIPHERAL_DAC1    13 /**< DAC1 */
+#define RA_ELC_PERIPHERAL_IOPORT1 14 /**< IOPORT1 */
+#define RA_ELC_PERIPHERAL_IOPORT2 15 /**< IOPORT2 */
+#define RA_ELC_PERIPHERAL_IOPORT3 16 /**< IOPORT3 */
+#define RA_ELC_PERIPHERAL_IOPORT4 17 /**< IOPORT4 */
+#define RA_ELC_PERIPHERAL_I3C     30 /**< I3C */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MISC_RENESAS_RA_ELC_RA8T1_ELC_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h
@@ -4,61 +4,107 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RA pin control (pinctrl) definitions for Zephyr.
+ *
+ * This header provides macro constants for encoding pin function selections
+ * and pin indices for Renesas RA SoCs. These values are used by the DeviceTree
+ * pinctrl subsystem to describe peripheral pin mappings.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA_H__
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA_H__
 
-#define RA_PORT_NUM_POS  0
-#define RA_PORT_NUM_MASK 0xf
+/**
+ * @name Renesas RA Pinctrl Definitions.
+ * @{
+ */
 
-#define RA_PIN_NUM_POS  4
-#define RA_PIN_NUM_MASK 0xf
+/** @brief Bit position of the port number field. */
+#define RA_PORT_NUM_POS  0 /**< Port number position. */
+/** @brief Mask for the port number field. */
+#define RA_PORT_NUM_MASK 0xf /**< Port number mask. */
 
-#define RA_PSEL_HIZ_JTAG_SWD 0x0
-#define RA_PSEL_ADC          0x0
-#define RA_PSEL_DAC          0x0
-#define RA_PSEL_ACMPHS       0x0
-#define RA_PSEL_AGT          0x1
-#define RA_PSEL_GPT0         0x2
-#define RA_PSEL_GPT1         0x3
-#define RA_PSEL_SCI_0        0x4
-#define RA_PSEL_SCI_2        0x4
-#define RA_PSEL_SCI_4        0x4
-#define RA_PSEL_SCI_6        0x4
-#define RA_PSEL_SCI_8        0x4
-#define RA_PSEL_SCI_1        0x5
-#define RA_PSEL_SCI_3        0x5
-#define RA_PSEL_SCI_5        0x5
-#define RA_PSEL_SCI_7        0x5
-#define RA_PSEL_SCI_9        0x5
-#define RA_PSEL_SPI          0x6
-#define RA_PSEL_I2C          0x7
-#define RA_PSEL_I3C          0x7
-#define RA_PSEL_CLKOUT_RTC   0x9
-#define RA_PSEL_ACMPHS_VCOUT 0x9
-#define RA_PSEL_CAC_ADC      0xa
-#define RA_PSEL_CAC_DAC      0xa
-#define RA_PSEL_BUS          0xb
-#define RA_PSEL_CANFD        0x10
-#define RA_PSEL_QSPI         0x11
-#define RA_PSEL_SSIE         0x12
-#define RA_PSEL_USBFS        0x13
-#define RA_PSEL_USBHS        0x14
-#define RA_PSEL_SDHI         0x15
-#define RA_PSEL_ETH_MII      0x16
-#define RA_PSEL_ETH_RMII     0x17
-#define RA_PSEL_GLCDC        0x19
-#define RA_PSEL_OSPI         0x1c
-#define RA_PSEL_CTSU         0x0c
-#define RA_PSEL_CEU          0xf
+/** @brief Bit position of the pin number field. */
+#define RA_PIN_NUM_POS  4 /**< Pin number position. */
+/** @brief Mask for the pin number field. */
+#define RA_PIN_NUM_MASK 0xf /**< Pin number mask. */
 
-#define RA_PSEL_POS  8
-#define RA_PSEL_MASK 0x1f
+/**
+ * @name  Renesas RA Peripheral Selection (PSEL) Pins
+ * @{
+ */
 
-#define RA_MODE_POS  13
-#define RA_MODE_MASK 0x1
+#define RA_PSEL_HIZ_JTAG_SWD 0x0  /**< High-impedance / JTAG / SWD. */
+#define RA_PSEL_ADC          0x0  /**< ADC function. */
+#define RA_PSEL_DAC          0x0  /**< DAC function. */
+#define RA_PSEL_ACMPHS       0x0  /**< ACMPHS function. */
+#define RA_PSEL_AGT          0x1  /**< AGT function. */
+#define RA_PSEL_GPT0         0x2  /**< GPT0 function. */
+#define RA_PSEL_GPT1         0x3  /**< GPT1 function. */
+#define RA_PSEL_SCI_0        0x4  /**< SCI0 function. */
+#define RA_PSEL_SCI_2        0x4  /**< SCI2 function. */
+#define RA_PSEL_SCI_4        0x4  /**< SCI4 function. */
+#define RA_PSEL_SCI_6        0x4  /**< SCI6 function. */
+#define RA_PSEL_SCI_8        0x4  /**< SCI8 function. */
+#define RA_PSEL_SCI_1        0x5  /**< SCI1 function. */
+#define RA_PSEL_SCI_3        0x5  /**< SCI3 function. */
+#define RA_PSEL_SCI_5        0x5  /**< SCI5 function. */
+#define RA_PSEL_SCI_7        0x5  /**< SCI7 function. */
+#define RA_PSEL_SCI_9        0x5  /**< SCI9 function. */
+#define RA_PSEL_SPI          0x6  /**< SPI function. */
+#define RA_PSEL_I2C          0x7  /**< I2C function. */
+#define RA_PSEL_I3C          0x7  /**< I3C function. */
+#define RA_PSEL_CLKOUT_RTC   0x9  /**< CLKOUT / RTC function. */
+#define RA_PSEL_ACMPHS_VCOUT 0x9  /**< ACMPHS VCOUT function. */
+#define RA_PSEL_CAC_ADC      0xa  /**< CAC / ADC function. */
+#define RA_PSEL_CAC_DAC      0xa  /**< CAC / DAC function. */
+#define RA_PSEL_BUS          0xb  /**< Bus function. */
+#define RA_PSEL_CANFD        0x10 /** CANFD function. */
+#define RA_PSEL_QSPI         0x11 /** QSPI function. */
+#define RA_PSEL_SSIE         0x12 /** SSIE function. */
+#define RA_PSEL_USBFS        0x13 /** USBFS function. */
+#define RA_PSEL_USBHS        0x14 /** USBHS function. */
+#define RA_PSEL_SDHI         0x15 /** SDHI function. */
+#define RA_PSEL_ETH_MII      0x16 /** ETH MII function. */
+#define RA_PSEL_ETH_RMII     0x17 /** ETH RMII function. */
+#define RA_PSEL_GLCDC        0x19 /** GLCDC function. */
+#define RA_PSEL_OSPI         0x1c /** OSPI function. */
+#define RA_PSEL_CTSU         0x0c /** CTSU function. */
+#define RA_PSEL_CEU          0xf  /** CEU function. */
 
+/** @} */
+
+/** @brief Bit position of the Peripheral Select (PSEL) field. */
+#define RA_PSEL_POS 8 /** PSEL field position. */
+
+/** @brief Bit mask for the Peripheral Select (PSEL) field (5-bit width). */
+#define RA_PSEL_MASK 0x1f /** PSEL field mask. */
+
+/** @brief Bit position of the RA mode field. */
+#define RA_MODE_POS 13 /** Mode field position. */
+
+/** @brief Bit mask for the RA mode field (1-bit width). */
+#define RA_MODE_MASK 0x1 /** Mode field mask. */
+
+/**
+ * @brief Macro to encode a pin configuration for Renesas RA SoCs.
+ *
+ * This macro encodes the mode, peripheral selection (PSEL), port number,
+ * and pin number into a single 32-bit value suitable for use in DeviceTree
+ * pinctrl configurations.
+ *
+ * @param psel       Peripheral selection value (use RA_PSEL_* macros).
+ * @param port_num   Port number.
+ * @param pin_num    Pin number within the port.
+ *
+ * @return Encoded pin configuration value.
+ */
 #define RA_PSEL(psel, port_num, pin_num)                                                           \
 	(1 << RA_MODE_POS | psel << RA_PSEL_POS | port_num << RA_PORT_NUM_POS |                    \
 	 pin_num << RA_PIN_NUM_POS)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RA_H__ */

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rx.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rx.h
@@ -4,400 +4,503 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RX pin control (pinctrl) definitions for Zephyr.
+ *
+ * This header provides macro constants for encoding pin function selections
+ * and pin indices for Renesas RX SoCs. These values are used by the DeviceTree
+ * pinctrl subsystem to describe peripheral pin mappings.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_PINCTRL_RX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_PINCTRL_RX_H_
 
-#define RX_PORT_NUM_POS  0
-#define RX_PORT_NUM_MASK 0x1f
+/**
+ * @name Multi-Function Pin Controller (MPC) Definitions for Renesas RX SoCs.
+ * @{
+ */
 
-#define RX_PIN_NUM_POS  5
-#define RX_PIN_NUM_MASK 0xf
+/** @brief Bit position of the port number field. */
+#define RX_PORT_NUM_POS  0 /**< Port number position. */
+/** @brief Mask for the port number field. */
+#define RX_PORT_NUM_MASK 0x1f /**< Port number mask. */
 
-#define RX_PSEL_MASK 0x1f
-#define RX_PSEL_POS  9
+/** @brief Bit position of the pin number field. */
+#define RX_PIN_NUM_POS  5 /**< Pin number position. */
+/** @brief Mask for the pin number field. */
+#define RX_PIN_NUM_MASK 0xf /**< Pin number mask. */
 
-#define RX_PSEL_RSCI      0xA
-#define RX_PSEL_RSCI_TXDB 0xC
-#define RX_PSEL_SCI_1     0xA
-#define RX_PSEL_SCI_5     0xA
-#define RX_PSEL_SCI_6     0xB
-#define RX_PSEL_SCI_12    0xC
-#define RX_PSEL_TMR       0x5
-#define RX_PSEL_POE       0x7
-#define RX_PSEL_ADC       0x0
-#define RX_PSEL_LVD       0x0
+/** @brief Bit position of the Peripheral Select (PSEL) field. */
+#define RX_PSEL_MASK 0x1f /**< PSEL mask. */
+/** @brief Mask for the Peripheral Select (PSEL) field. */
+#define RX_PSEL_POS  9 /**< PSEL position. */
 
-/* P0nPFS */
+/**
+ * @name Renesas RX Peripheral Selection (PSEL) Pins
+ * @{
+ */
+
+#define RX_PSEL_RSCI      0xA /**< RSCI function. */
+#define RX_PSEL_RSCI_TXDB 0xC /**< RSCI TXD/B function. */
+#define RX_PSEL_SCI_1     0xA /**< SCI1 function. */
+#define RX_PSEL_SCI_5     0xA /**< SCI5 function. */
+#define RX_PSEL_SCI_6     0xB /**< SCI6 function. */
+#define RX_PSEL_SCI_12    0xC /**< SCI12 function. */
+#define RX_PSEL_TMR       0x5 /**< TMR function. */
+#define RX_PSEL_POE       0x7 /**< POE function. */
+#define RX_PSEL_ADC       0x0 /**< ADC function. */
+#define RX_PSEL_LVD       0x0 /**< LVD function. */
+
+/** @} */
+
+/**
+ * @name Renesas RX MPC Port 0 Pin Function Select codes (PSEL values)
+ * @{
+ */
 #define RX_PSEL_P0nPFS_HIZ    0x0
 #define RX_PSEL_P0nPFS_ADTRG0 0x1
 
-/* P1nPFS */
-#define RX_PSEL_P1nPFS_MTIOC0B 0x01
-#define RX_PSEL_P1nPFS_MTIOC3A 0x01
-#define RX_PSEL_P1nPFS_MTIOC3C 0x01
-
-#define RX_PSEL_P1nPFS_MTCLKA  0x02
-#define RX_PSEL_P1nPFS_MTCLKB  0x02
-#define RX_PSEL_P1nPFS_MTIOC3B 0x02
-#define RX_PSEL_P1nPFS_MTIOC3D 0x02
-
-#define RX_PSEL_P1nPFS_TMCI1 0x5
-#define RX_PSEL_P1nPFS_TMO1  0x5
-#define RX_PSEL_P1nPFS_TMCI2 0x5
-#define RX_PSEL_P1nPFS_TMO2  0x5
-#define RX_PSEL_P1nPFS_TMRI2 0x5
-#define RX_PSEL_P1nPFS_TMO3  0x5
-
-#define RX_PSEL_P1nPFS_RTCOUT 0x7
-#define RX_PSEL_P1nPFS_POE8   0x7
-
-#define RX_PSEL_P1nPFS_ADTRG0 0x9
-
-#define RX_PSEL_P1nPFS_RXD1   0xA
-#define RX_PSEL_P1nPFS_SMISO1 0xA
-#define RX_PSEL_P1nPFS_SSCL1  0xA
-#define RX_PSEL_P1nPFS_TXD1   0xA
-#define RX_PSEL_P1nPFS_SMOSI1 0xA
-#define RX_PSEL_P1nPFS_SSDA1  0xA
-
-#define RX_PSEL_P1nPFS_CTS1 0xB
-#define RX_PSEL_P1nPFS_RTS1 0xB
-#define RX_PSEL_P1nPFS_SS1  0xB
-
-#define RX_PSEL_P1nPFS_MOSIA 0xD
-#define RX_PSEL_P1nPFS_MISOA 0xD
-
-#define RX_PSEL_P1nPFS_SCL 0xF
-#define RX_PSEL_P1nPFS_SDA 0xF
-
-#define RX_PSEL_P1nPFS_TS5 0x19
-#define RX_PSEL_P1nPFS_TS6 0x19
-
-/* P2nPFS */
-#define RX_PSEL_P2nPFS_MTIOC1A 0x01
-#define RX_PSEL_P2nPFS_MTIOC1B 0x01
-#define RX_PSEL_P2nPFS_MTIOC2A 0x01
-#define RX_PSEL_P2nPFS_MTIOC2B 0x01
-#define RX_PSEL_P2nPFS_MTIOC3B 0x01
-#define RX_PSEL_P2nPFS_MTIOC3D 0x01
-#define RX_PSEL_P2nPFS_MTIOC4A 0x01
-#define RX_PSEL_P2nPFS_MTIOC4C 0x01
-
-#define RX_PSEL_P2nPFS_MTCLKA 0x02
-#define RX_PSEL_P2nPFS_MTCLKB 0x02
-#define RX_PSEL_P2nPFS_MTCLKC 0x02
-#define RX_PSEL_P2nPFS_MTCLKD 0x02
-
-#define RX_PSEL_P2nPFS_TMCI0 0x5
-#define RX_PSEL_P2nPFS_TMO0  0x5
-#define RX_PSEL_P2nPFS_TMRI0 0x5
-#define RX_PSEL_P2nPFS_TMO1  0x5
-#define RX_PSEL_P2nPFS_TMRI1 0x5
-#define RX_PSEL_P2nPFS_TMCI3 0x5
-
-#define RX_PSEL_P2nPFS_ADTRG0 0x9
-
-#define RX_PSEL_P2nPFS_RXD0   0xA
-#define RX_PSEL_P2nPFS_SMISO0 0xA
-#define RX_PSEL_P2nPFS_SSCL0  0xA
-#define RX_PSEL_P2nPFS_TXD0   0xA
-#define RX_PSEL_P2nPFS_SMOSI0 0xA
-#define RX_PSEL_P2nPFS_SSDA0  0xA
-#define RX_PSEL_P2nPFS_SCK0   0xA
-#define RX_PSEL_P2nPFS_TXD1   0xA
-#define RX_PSEL_P2nPFS_SMOSI1 0xA
-#define RX_PSEL_P2nPFS_SSDA1  0xA
-#define RX_PSEL_P2nPFS_SCK1   0xA
-
-#define RX_PSEL_P2nPFS_CTS0 0xB
-#define RX_PSEL_P2nPFS_RTS0 0xB
-#define RX_PSEL_P2nPFS_SS0  0xB
-
-#define RX_PSEL_P2nPFS_TS3 0x19
-#define RX_PSEL_P2nPFS_TS4 0x19
-
-/* P3nPFS */
-#define RX_PSEL_P3nPFS_MTIOC0A 0x01
-#define RX_PSEL_P3nPFS_MTIOC0C 0x01
-#define RX_PSEL_P3nPFS_MTIOC0D 0x01
-#define RX_PSEL_P3nPFS_MTIOC4B 0x01
-#define RX_PSEL_P3nPFS_MTIOC4D 0x01
-
-#define RX_PSEL_P3nPFS_TMCI2 0x5
-#define RX_PSEL_P3nPFS_TMO3  0x5
-#define RX_PSEL_P3nPFS_TMRI3 0x5
-#define RX_PSEL_P3nPFS_TMCI3 0x5
-
-#define RX_PSEL_P3nPFS_RTCOUT 0x7
-#define RX_PSEL_P3nPFS_POE2   0x7
-#define RX_PSEL_P3nPFS_POE3   0x7
-#define RX_PSEL_P3nPFS_POE8   0x7
-
-#define RX_PSEL_P3nPFS_RXD1   0xA
-#define RX_PSEL_P3nPFS_SMISO1 0xA
-#define RX_PSEL_P3nPFS_SSCL1  0xA
-
-#define RX_PSEL_P3nPFS_CTS1   0xB
-#define RX_PSEL_P3nPFS_RTS1   0xB
-#define RX_PSEL_P3nPFS_SS1    0xB
-#define RX_PSEL_P3nPFS_RXD6   0xB
-#define RX_PSEL_P3nPFS_SMISO6 0xB
-#define RX_PSEL_P3nPFS_SSCL6  0xB
-#define RX_PSEL_P3nPFS_TXD6   0xB
-#define RX_PSEL_P3nPFS_SMOSI6 0xB
-#define RX_PSEL_P3nPFS_SSDA6  0xB
-#define RX_PSEL_P3nPFS_SCK6   0xB
-
-#define RX_PSEL_P3nPFS_TS0 0x19
-#define RX_PSEL_P3nPFS_TS1 0x19
-#define RX_PSEL_P3nPFS_TS2 0x19
-
-/* P5nPFS */
-#define RX_PSEL_P5nPFS_MTIOC4B 0x01
-#define RX_PSEL_P5nPFS_MTIOC4D 0x01
-
-#define RX_PSEL_P5nPFS_TMCI1 0x5
-#define RX_PSEL_P5nPFS_TMO3  0x5
-
-#define RX_PSEL_P5nPFS_TS11 0x19
-#define RX_PSEL_P5nPFS_TS12 0x19
-
-#define RX_PSEL_P5nPFS_PMC0 0x19
-#define RX_PSEL_P5nPFS_PMC1 0x19
-
-/* PAnPFS */
-#define RX_PSEL_PAnPFS_MTIOC4A 0x01
-#define RX_PSEL_PAnPFS_MTIOC0B 0x01
-#define RX_PSEL_PAnPFS_MTIOC0D 0x01
-#define RX_PSEL_PAnPFS_MTIOC5U 0x01
-#define RX_PSEL_PAnPFS_MTIOC5V 0x01
-
-#define RX_PSEL_PAnPFS_MTCLKA 0x02
-#define RX_PSEL_PAnPFS_MTCLKB 0x02
-#define RX_PSEL_PAnPFS_MTCLKC 0x02
-#define RX_PSEL_PAnPFS_MTCLKD 0x02
-
-#define RX_PSEL_PAnPFS_TMRI0 0x5
-#define RX_PSEL_PAnPFS_TMCI3 0x5
-
-#define RX_PSEL_PAnPFS_POE2   0x7
-#define RX_PSEL_PAnPFS_CACREF 0x7
-
-#define RX_PSEL_PAnPFS_RXD5   0xA
-#define RX_PSEL_PAnPFS_SMISO5 0xA
-#define RX_PSEL_PAnPFS_SSCL5  0xA
-#define RX_PSEL_PAnPFS_TXD5   0xA
-#define RX_PSEL_PAnPFS_SMOSI5 0xA
-#define RX_PSEL_PAnPFS_SSDA5  0xA
-#define RX_PSEL_PAnPFS_SCK5   0xA
-
-#define RX_PSEL_PAnPFS_CTS5 0xB
-#define RX_PSEL_PAnPFS_RTS5 0xB
-#define RX_PSEL_PAnPFS_SS5  0xB
-
-#define RX_PSEL_PAnPFS_SSLA0  0xD
-#define RX_PSEL_PAnPFS_SSLA1  0xD
-#define RX_PSEL_PAnPFS_SSLA2  0xD
-#define RX_PSEL_PAnPFS_SSLA3  0xD
-#define RX_PSEL_PAnPFS_RSPCKA 0xD
-#define RX_PSEL_PAnPFS_MOSIA  0xD
-#define RX_PSEL_PAnPFS_MISOA  0xD
-
-#define RX_PSEL_PAnPFS_TS26 0x19
-#define RX_PSEL_PAnPFS_TS27 0x19
-#define RX_PSEL_PAnPFS_TS28 0x19
-#define RX_PSEL_PAnPFS_TS29 0x19
-#define RX_PSEL_PAnPFS_TS30 0x19
-#define RX_PSEL_PAnPFS_TS31 0x19
-#define RX_PSEL_PAnPFS_TS32 0x19
-
-/* PBnPFS */
-#define RX_PSEL_PBnPFS_MTIOC0A 0x01
-#define RX_PSEL_PBnPFS_MTIOC0C 0x01
-#define RX_PSEL_PBnPFS_MTIOC2A 0x01
-#define RX_PSEL_PBnPFS_MTIOC3B 0x01
-#define RX_PSEL_PBnPFS_MTIOC3D 0x01
-#define RX_PSEL_PBnPFS_MTIOC5W 0x01
-
-#define RX_PSEL_PBnPFS_MTIOC1B 0x02
-#define RX_PSEL_PBnPFS_MTIOC4A 0x02
-#define RX_PSEL_PBnPFS_MTIOC4C 0x02
-
-#define RX_PSEL_PBnPFS_TMO0  0x5
-#define RX_PSEL_PBnPFS_TMRI1 0x5
-#define RX_PSEL_PBnPFS_TMCI0 0x5
-
-#define RX_PSEL_PBnPFS_POE1 0x7
-#define RX_PSEL_PBnPFS_POE3 0x7
-
-#define RX_PSEL_PBnPFS_RXD9   0xA
-#define RX_PSEL_PBnPFS_SMISO9 0xA
-#define RX_PSEL_PBnPFS_SSCL9  0xA
-#define RX_PSEL_PBnPFS_TXD9   0xA
-#define RX_PSEL_PBnPFS_SMOSI9 0xA
-#define RX_PSEL_PBnPFS_SSDA9  0xA
-#define RX_PSEL_PBnPFS_SCK9   0xA
-
-#define RX_PSEL_PBnPFS_CTS6   0xB
-#define RX_PSEL_PBnPFS_RTS6   0xB
-#define RX_PSEL_PBnPFS_SS6    0xB
-#define RX_PSEL_PBnPFS_CTS9   0xB
-#define RX_PSEL_PBnPFS_RTS9   0xB
-#define RX_PSEL_PBnPFS_SS9    0xB
-#define RX_PSEL_PBnPFS_RXD6   0xB
-#define RX_PSEL_PBnPFS_SMISO6 0xB
-#define RX_PSEL_PBnPFS_SSCL6  0xB
-#define RX_PSEL_PBnPFS_TXD6   0xB
-#define RX_PSEL_PBnPFS_SMOSI6 0xB
-#define RX_PSEL_PBnPFS_SSDA6  0xB
-#define RX_PSEL_PBnPFS_SCK6   0xB
-
-#define RX_PSEL_PBnPFS_RSPCKA 0xD
-
-#define RX_PSEL_PBnPFS_CMPOB1 0x10
-
-#define RX_PSEL_PBnPFS_TS18 0x19
-#define RX_PSEL_PBnPFS_TS19 0x19
-#define RX_PSEL_PBnPFS_TS20 0x19
-#define RX_PSEL_PBnPFS_TS21 0x19
-#define RX_PSEL_PBnPFS_TS22 0x19
-#define RX_PSEL_PBnPFS_TS23 0x19
-#define RX_PSEL_PBnPFS_TS24 0x19
-#define RX_PSEL_PBnPFS_TS25 0x19
-
-/* PCnPFS */
-#define RX_PSEL_PCnPFS_MTIOC3A 0x01
-#define RX_PSEL_PCnPFS_MTIOC3B 0x01
-#define RX_PSEL_PCnPFS_MTIOC3C 0x01
-#define RX_PSEL_PCnPFS_MTIOC3D 0x01
-#define RX_PSEL_PCnPFS_MTIOC4B 0x01
-#define RX_PSEL_PCnPFS_MTIOC4D 0x01
-
-#define RX_PSEL_PCnPFS_MTCLKA 0x02
-#define RX_PSEL_PCnPFS_MTCLKB 0x02
-#define RX_PSEL_PCnPFS_MTCLKC 0x02
-#define RX_PSEL_PCnPFS_MTCLKD 0x02
-
-#define RX_PSEL_PCnPFS_TMCI1 0x5
-#define RX_PSEL_PCnPFS_TMO2  0x5
-#define RX_PSEL_PCnPFS_TMRI2 0x5
-#define RX_PSEL_PCnPFS_TMCI2 0x5
-
-#define RX_PSEL_PCnPFS_POE0   0x7
-#define RX_PSEL_PCnPFS_CACREF 0x7
-
-#define RX_PSEL_PCnPFS_RXD5   0xA
-#define RX_PSEL_PCnPFS_SMISO5 0xA
-#define RX_PSEL_PCnPFS_SSCL5  0xA
-#define RX_PSEL_PCnPFS_TXD5   0xA
-#define RX_PSEL_PCnPFS_SMOSI5 0xA
-#define RX_PSEL_PCnPFS_SSDA5  0xA
-#define RX_PSEL_PCnPFS_SCK5   0xA
-#define RX_PSEL_PCnPFS_RXD8   0xA
-#define RX_PSEL_PCnPFS_SMISO8 0xA
-#define RX_PSEL_PCnPFS_SSCL8  0xA
-#define RX_PSEL_PCnPFS_TXD8   0xA
-#define RX_PSEL_PCnPFS_SMOSI8 0xA
-#define RX_PSEL_PCnPFS_SSDA8  0xA
-#define RX_PSEL_PCnPFS_SCK8   0xA
-
-#define RX_PSEL_PCnPFS_CTS5 0xB
-#define RX_PSEL_PCnPFS_RTS5 0xB
-#define RX_PSEL_PCnPFS_SS5  0xB
-#define RX_PSEL_PCnPFS_CTS8 0xB
-#define RX_PSEL_PCnPFS_RTS8 0xB
-#define RX_PSEL_PCnPFS_SS8  0xB
-
-#define RX_PSEL_PCnPFS_SSLA0  0xD
-#define RX_PSEL_PCnPFS_SSLA1  0xD
-#define RX_PSEL_PCnPFS_SSLA2  0xD
-#define RX_PSEL_PCnPFS_SSLA3  0xD
-#define RX_PSEL_PCnPFS_RSPCKA 0xD
-#define RX_PSEL_PCnPFS_MOSIA  0xD
-#define RX_PSEL_PCnPFS_MISOA  0xD
-
-#define RX_PSEL_PCnPFS_TS13  0x19
-#define RX_PSEL_PCnPFS_TS14  0x19
-#define RX_PSEL_PCnPFS_TS15  0x19
-#define RX_PSEL_PCnPFS_TS16  0x19
-#define RX_PSEL_PCnPFS_TS17  0x19
-#define RX_PSEL_PCnPFS_TSCAP 0x19
-
-/* PDnPFS */
-#define RX_PSEL_PDnPFS_MTIOC4B 0x01
-#define RX_PSEL_PDnPFS_MTIOC4D 0x01
-#define RX_PSEL_PDnPFS_MTIOC5W 0x01
-#define RX_PSEL_PDnPFS_MTIOC5V 0x01
-#define RX_PSEL_PDnPFS_MTIOC5U 0x01
-
-#define RX_PSEL_PDnPFS_POE0 0x7
-#define RX_PSEL_PDnPFS_POE1 0x7
-#define RX_PSEL_PDnPFS_POE2 0x7
-#define RX_PSEL_PDnPFS_POE3 0x7
-#define RX_PSEL_PDnPFS_POE8 0x7
-
-#define RX_PSEL_PDnPFS_RXD6   0xB
-#define RX_PSEL_PDnPFS_SMISO6 0xB
-#define RX_PSEL_PDnPFS_SSCL6  0xB
-#define RX_PSEL_PDnPFS_TXD6   0xB
-#define RX_PSEL_PDnPFS_SMOSI6 0xB
-#define RX_PSEL_PDnPFS_SSDA6  0xB
-#define RX_PSEL_PDnPFS_SCK6   0xB
-
-/* PEnPFS */
-#define RX_PSEL_PEnPFS_MTIOC4A 0x01
-#define RX_PSEL_PEnPFS_MTIOC4B 0x01
-#define RX_PSEL_PEnPFS_MTIOC4C 0x01
-#define RX_PSEL_PEnPFS_MTIOC4D 0x01
-
-#define RX_PSEL_PEnPFS_MTIOC1A 0x02
-#define RX_PSEL_PEnPFS_MTIOC2B 0x02
-
-#define RX_PSEL_PEnPFS_POE8 0x7
-
-#define RX_PSEL_PEnPFS_CLKOUT 0x9
-
-#define RX_PSEL_PEnPFS_RXD12   0xC
-#define RX_PSEL_PEnPFS_SMISO12 0xC
-#define RX_PSEL_PEnPFS_SSCL12  0xC
-#define RX_PSEL_PEnPFS_TXD12   0xC
-#define RX_PSEL_PEnPFS_SMOSI12 0xC
-#define RX_PSEL_PEnPFS_SSDA12  0xC
-#define RX_PSEL_PEnPFS_SCK12   0xC
-#define RX_PSEL_PEnPFS_TXDX12  0xC
-#define RX_PSEL_PEnPFS_RXDX12  0xC
-#define RX_PSEL_PEnPFS_SIOX12  0xC
-#define RX_PSEL_PEnPFS_CTS12   0xC
-#define RX_PSEL_PEnPFS_RTS12   0xC
-#define RX_PSEL_PEnPFS_SS12    0xC
-
-#define RX_PSEL_PEnPFS_CMPOB0 0X10
-
-#define RX_PSEL_PEnPFS_TS33 0X19
-#define RX_PSEL_PEnPFS_TS34 0x19
-#define RX_PSEL_PEnPFS_TS35 0x19
-
-/* PHnPFS */
-#define RX_PSEL_PHnPFS_TMO0  0x05
-#define RX_PSEL_PHnPFS_TMRI0 0x05
-#define RX_PSEL_PHnPFS_TMCI0 0x05
-
-#define RX_PSEL_PHnPFS_CACREF 0x7
-
-#define RX_PSEL_PHnPFS_TS7  0x19
-#define RX_PSEL_PHnPFS_TS8  0x19
-#define RX_PSEL_PHnPFS_TS9  0x19
-#define RX_PSEL_PHnPFS_TS10 0x19
-
-/* PJnPFS */
-#define RX_PSEL_PJnPFS_MTIOC3A 0x01
-#define RX_PSEL_PJnPFS_MTIOC3C 0x01
-
-#define RX_PSEL_PJnPFS_CTS6 0xB
-#define RX_PSEL_PJnPFS_TTS6 0xB
-#define RX_PSEL_PJnPFS_SS6  0xB
-
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port 1 Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_P1nPFS_MTIOC0B 0x01 /**< Multi-function timer channel 0B. */
+#define RX_PSEL_P1nPFS_MTIOC3A 0x01 /**< Multi-function timer channel 3A. */
+#define RX_PSEL_P1nPFS_MTIOC3C 0x01 /**< Multi-function timer channel 3C. */
+
+#define RX_PSEL_P1nPFS_MTCLKA  0x02 /**< Multi-Timer Clock A function. */
+#define RX_PSEL_P1nPFS_MTCLKB  0x02 /**< Multi-Timer Clock B function. */
+#define RX_PSEL_P1nPFS_MTIOC3B 0x02 /**< Multi-function timer channel 3B. */
+#define RX_PSEL_P1nPFS_MTIOC3D 0x02 /**< Multi-function timer channel 3D. */
+
+#define RX_PSEL_P1nPFS_TMCI1 0x5 /**< Timer input capture channel 1. */
+#define RX_PSEL_P1nPFS_TMO1  0x5 /**< Timer output compare channel 1. */
+#define RX_PSEL_P1nPFS_TMCI2 0x5 /**< Timer input capture channel 2. */
+#define RX_PSEL_P1nPFS_TMO2  0x5 /**< Timer output compare channel 2. */
+#define RX_PSEL_P1nPFS_TMRI2 0x5 /**< Timer read input channel 2. */
+#define RX_PSEL_P1nPFS_TMO3  0x5 /**< Timer output compare channel 3. */
+
+#define RX_PSEL_P1nPFS_RTCOUT 0x7 /**< Realtime clock. */
+#define RX_PSEL_P1nPFS_POE8   0x7 /**< Port output enable 8. */
+
+#define RX_PSEL_P1nPFS_ADTRG0 0x9 /**< ADC trigger input 0. */
+
+#define RX_PSEL_P1nPFS_RXD1   0xA /**< Serial communication interface RXD1. */
+#define RX_PSEL_P1nPFS_SMISO1 0xA /**< SPI MISO channel 1. */
+#define RX_PSEL_P1nPFS_SSCL1  0xA /**< I2C SSCL channel 1. */
+#define RX_PSEL_P1nPFS_TXD1   0xA /**< Serial communication interface TXD1. */
+#define RX_PSEL_P1nPFS_SMOSI1 0xA /**< SPI MOSI channel 1. */
+#define RX_PSEL_P1nPFS_SSDA1  0xA /**< I2C SSDA channel 1. */
+
+#define RX_PSEL_P1nPFS_CTS1 0xB /**< Serial communication interface CTS1. */
+#define RX_PSEL_P1nPFS_RTS1 0xB /**< Serial communication interface RTS1. */
+#define RX_PSEL_P1nPFS_SS1  0xB /**< SPI slave select channel 1. */
+
+#define RX_PSEL_P1nPFS_MOSIA 0xD /**< SPI MOSI. */
+#define RX_PSEL_P1nPFS_MISOA 0xD /**< SPI MISO. */
+
+#define RX_PSEL_P1nPFS_SCL 0xF /**< I2C SCL. */
+#define RX_PSEL_P1nPFS_SDA 0xF /**< I2C SDA. */
+
+#define RX_PSEL_P1nPFS_TS5 0x19 /**< Touch sensor input 5. */
+#define RX_PSEL_P1nPFS_TS6 0x19 /**< Touch sensor input 6. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port 1 Pin Function Select codes (PSEL values)
+ * @{
+ */
+
+#define RX_PSEL_P2nPFS_MTIOC1A 0x01 /**< Multi-function timer channel 1A. */
+#define RX_PSEL_P2nPFS_MTIOC1B 0x01 /**< Multi-function timer channel 1B. */
+#define RX_PSEL_P2nPFS_MTIOC2A 0x01 /**< Multi-function timer channel 2A. */
+#define RX_PSEL_P2nPFS_MTIOC2B 0x01 /**< Multi-function timer channel 2B. */
+#define RX_PSEL_P2nPFS_MTIOC3B 0x01 /**< Multi-function timer channel 3B. */
+#define RX_PSEL_P2nPFS_MTIOC3D 0x01 /**< Multi-function timer channel 3D. */
+#define RX_PSEL_P2nPFS_MTIOC4A 0x01 /**< Multi-function timer channel 4A. */
+#define RX_PSEL_P2nPFS_MTIOC4C 0x01 /**< Multi-function timer channel 4C. */
+
+#define RX_PSEL_P2nPFS_MTCLKA 0x02 /**< Multi-Timer external clock A. */
+#define RX_PSEL_P2nPFS_MTCLKB 0x02 /**< Multi-Timer external clock B. */
+#define RX_PSEL_P2nPFS_MTCLKC 0x02 /**< Multi-Timer external clock C. */
+#define RX_PSEL_P2nPFS_MTCLKD 0x02 /**< Multi-Timer external clock D. */
+
+#define RX_PSEL_P2nPFS_TMCI0 0x5 /**< Timer input capture channel 0. */
+#define RX_PSEL_P2nPFS_TMO0  0x5 /**< Timer output compare channel 0. */
+#define RX_PSEL_P2nPFS_TMRI0 0x5 /**< Timer read input channel 0. */
+#define RX_PSEL_P2nPFS_TMO1  0x5 /**< Timer output compare channel 1. */
+#define RX_PSEL_P2nPFS_TMRI1 0x5 /**< Timer read input channel 1. */
+#define RX_PSEL_P2nPFS_TMCI3 0x5 /**< Timer input capture channel 3. */
+
+#define RX_PSEL_P2nPFS_ADTRG0 0x9 /**< ADC trigger input 0. */
+
+#define RX_PSEL_P2nPFS_RXD0   0xA /**< Serial communication interface RXD0. */
+#define RX_PSEL_P2nPFS_SMISO0 0xA /**< SPI MISO channel 0. */
+#define RX_PSEL_P2nPFS_SSCL0  0xA /**< I2C SSCL channel 0. */
+#define RX_PSEL_P2nPFS_TXD0   0xA /**< Serial communication interface TXD0. */
+#define RX_PSEL_P2nPFS_SMOSI0 0xA /**< SPI MOSI channel 0. */
+#define RX_PSEL_P2nPFS_SSDA0  0xA /**< I2C SSDA channel 0. */
+#define RX_PSEL_P2nPFS_SCK0   0xA /**< SPI SCK channel 0. */
+#define RX_PSEL_P2nPFS_TXD1   0xA /**< Serial communication interface TXD1. */
+#define RX_PSEL_P2nPFS_SMOSI1 0xA /**< SPI MOSI channel 1. */
+#define RX_PSEL_P2nPFS_SSDA1  0xA /**< I2C SSDA channel 1. */
+#define RX_PSEL_P2nPFS_SCK1   0xA /**< SPI SCK channel 1. */
+
+#define RX_PSEL_P2nPFS_CTS0 0xB /**< Serial communication interface CTS0. */
+#define RX_PSEL_P2nPFS_RTS0 0xB /**< Serial communication interface RTS0. */
+#define RX_PSEL_P2nPFS_SS0  0xB /**< SPI slave select channel 0. */
+
+#define RX_PSEL_P2nPFS_TS3 0x19 /**< Touch sensor input 3. */
+#define RX_PSEL_P2nPFS_TS4 0x19 /**< Touch sensor input 4. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port 3 Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_P3nPFS_MTIOC0A 0x01 /**< Multi-function timer channel 0A. */
+#define RX_PSEL_P3nPFS_MTIOC0C 0x01 /**< Multi-function timer channel 0C. */
+#define RX_PSEL_P3nPFS_MTIOC0D 0x01 /**< Multi-function timer channel 0D. */
+#define RX_PSEL_P3nPFS_MTIOC4B 0x01 /**< Multi-function timer channel 4B. */
+#define RX_PSEL_P3nPFS_MTIOC4D 0x01 /**< Multi-function timer channel 4D. */
+
+#define RX_PSEL_P3nPFS_TMCI2 0x5 /**< Timer input capture channel 2. */
+#define RX_PSEL_P3nPFS_TMO3  0x5 /**< Timer output compare channel 3. */
+#define RX_PSEL_P3nPFS_TMRI3 0x5 /**< Timer read input channel 3. */
+#define RX_PSEL_P3nPFS_TMCI3 0x5 /**< Timer input capture channel 3. */
+
+#define RX_PSEL_P3nPFS_RTCOUT 0x7 /**< Realtime clock output. */
+#define RX_PSEL_P3nPFS_POE2   0x7 /**< Port output enable 2. */
+#define RX_PSEL_P3nPFS_POE3   0x7 /**< Port output enable 3. */
+#define RX_PSEL_P3nPFS_POE8   0x7 /**< Port output enable 8. */
+
+#define RX_PSEL_P3nPFS_RXD1   0xA /**< Serial communication interface RXD1. */
+#define RX_PSEL_P3nPFS_SMISO1 0xA /**< SPI MISO channel 1. */
+#define RX_PSEL_P3nPFS_SSCL1  0xA /**< I2C SSCL channel 1. */
+
+#define RX_PSEL_P3nPFS_CTS1   0xB /**< Serial communication interface CTS1. */
+#define RX_PSEL_P3nPFS_RTS1   0xB /**< Serial communication interface RTS1. */
+#define RX_PSEL_P3nPFS_SS1    0xB /**< SPI slave select channel 1. */
+#define RX_PSEL_P3nPFS_RXD6   0xB /**< Serial communication interface RXD6. */
+#define RX_PSEL_P3nPFS_SMISO6 0xB /**< SPI MISO channel 6. */
+#define RX_PSEL_P3nPFS_SSCL6  0xB /**< I2C SSCL channel 6. */
+#define RX_PSEL_P3nPFS_TXD6   0xB /**< Serial communication interface TXD6. */
+#define RX_PSEL_P3nPFS_SMOSI6 0xB /**< SPI MOSI channel 6. */
+#define RX_PSEL_P3nPFS_SSDA6  0xB /**< I2C SSDA channel 6. */
+#define RX_PSEL_P3nPFS_SCK6   0xB /**< SPI SCK channel 6. */
+
+#define RX_PSEL_P3nPFS_TS0 0x19 /**< Touch sensor input 0. */
+#define RX_PSEL_P3nPFS_TS1 0x19 /**< Touch sensor input 1. */
+#define RX_PSEL_P3nPFS_TS2 0x19 /**< Touch sensor input 2. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port 5 Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_P5nPFS_MTIOC4B 0x01 /**< Multi-function timer channel 4B. */
+#define RX_PSEL_P5nPFS_MTIOC4D 0x01 /**< Multi-function timer channel 4D. */
+
+#define RX_PSEL_P5nPFS_TMCI1 0x5 /**< Timer input capture channel 1. */
+#define RX_PSEL_P5nPFS_TMO3  0x5 /**< Timer output compare channel 3. */
+
+#define RX_PSEL_P5nPFS_TS11 0x19 /** Touch sensor input 11. */
+#define RX_PSEL_P5nPFS_TS12 0x19 /** Touch sensor input 12. */
+
+#define RX_PSEL_P5nPFS_PMC0 0x19 /** PMC0 function. */
+#define RX_PSEL_P5nPFS_PMC1 0x19 /** PMC1 function. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port A Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PAnPFS_MTIOC4A 0x01 /**< Multi-function timer channel 4A. */
+#define RX_PSEL_PAnPFS_MTIOC0B 0x01 /**< Multi-function timer channel 0B. */
+#define RX_PSEL_PAnPFS_MTIOC0D 0x01 /**< Multi-function timer channel 0D. */
+#define RX_PSEL_PAnPFS_MTIOC5U 0x01 /**< Multi-function timer channel 5U. */
+#define RX_PSEL_PAnPFS_MTIOC5V 0x01 /**< Multi-function timer channel 5V. */
+
+#define RX_PSEL_PAnPFS_MTCLKA 0x02 /**< Multi-function timer clock channel A. */
+#define RX_PSEL_PAnPFS_MTCLKB 0x02 /**< Multi-function timer clock channel B. */
+#define RX_PSEL_PAnPFS_MTCLKC 0x02 /**< Multi-function timer clock channel C. */
+#define RX_PSEL_PAnPFS_MTCLKD 0x02 /**< Multi-function timer clock channel D. */
+
+#define RX_PSEL_PAnPFS_TMRI0 0x5 /**< Timer read input channel 0. */
+#define RX_PSEL_PAnPFS_TMCI3 0x5 /**< Timer input capture channel 3.*/
+
+#define RX_PSEL_PAnPFS_POE2   0x7 /**< Port output enable 2. */
+#define RX_PSEL_PAnPFS_CACREF 0x7 /**< CAC reference voltage output. */
+
+#define RX_PSEL_PAnPFS_RXD5   0xA /**< Serial communication interface RXD5. */
+#define RX_PSEL_PAnPFS_SMISO5 0xA /**< SPI MISO channel 5. */
+#define RX_PSEL_PAnPFS_SSCL5  0xA /**< I2C SSCL channel 5. */
+#define RX_PSEL_PAnPFS_TXD5   0xA /**< Serial communication interface TXD5. */
+#define RX_PSEL_PAnPFS_SMOSI5 0xA /**< SPI MOSI channel 5. */
+#define RX_PSEL_PAnPFS_SSDA5  0xA /**< I2C SSDA channel 5. */
+#define RX_PSEL_PAnPFS_SCK5   0xA /**< SPI SCK channel 5. */
+
+#define RX_PSEL_PAnPFS_CTS5 0xB /**< Serial communication interface CTS5. */
+#define RX_PSEL_PAnPFS_RTS5 0xB /**< Serial communication interface RTS5. */
+#define RX_PSEL_PAnPFS_SS5  0xB /**< SPI slave select channel 5. */
+
+#define RX_PSEL_PAnPFS_SSLA0  0xD /**< SPI slave select A0. */
+#define RX_PSEL_PAnPFS_SSLA1  0xD /**< SPI slave select A1. */
+#define RX_PSEL_PAnPFS_SSLA2  0xD /**< SPI slave select A2. */
+#define RX_PSEL_PAnPFS_SSLA3  0xD /**< SPI slave select A3. */
+#define RX_PSEL_PAnPFS_RSPCKA 0xD /**< SPI RSPCK A. */
+#define RX_PSEL_PAnPFS_MOSIA  0xD /**< SPI MOSI A. */
+#define RX_PSEL_PAnPFS_MISOA  0xD /**< SPI MISO A. */
+
+#define RX_PSEL_PAnPFS_TS26 0x19 /**< Touch sensor input 26. */
+#define RX_PSEL_PAnPFS_TS27 0x19 /**< Touch sensor input 27. */
+#define RX_PSEL_PAnPFS_TS28 0x19 /**< Touch sensor input 28. */
+#define RX_PSEL_PAnPFS_TS29 0x19 /**< Touch sensor input 29. */
+#define RX_PSEL_PAnPFS_TS30 0x19 /**< Touch sensor input 30. */
+#define RX_PSEL_PAnPFS_TS31 0x19 /**< Touch sensor input 31. */
+#define RX_PSEL_PAnPFS_TS32 0x19 /**< Touch sensor input 32. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port B Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PBnPFS_MTIOC0A 0x01 /**< Multi-function timer channel 0A. */
+#define RX_PSEL_PBnPFS_MTIOC0C 0x01 /**< Multi-function timer channel 0C. */
+#define RX_PSEL_PBnPFS_MTIOC2A 0x01 /**< Multi-function timer channel 2A. */
+#define RX_PSEL_PBnPFS_MTIOC3B 0x01 /**< Multi-function timer channel 3B. */
+#define RX_PSEL_PBnPFS_MTIOC3D 0x01 /**< Multi-function timer channel 3D. */
+#define RX_PSEL_PBnPFS_MTIOC5W 0x01 /**< Multi-function timer channel 5W. */
+
+#define RX_PSEL_PBnPFS_MTIOC1B 0x02 /**< Multi-function timer channel 1B. */
+#define RX_PSEL_PBnPFS_MTIOC4A 0x02 /**< Multi-function timer channel 4A. */
+#define RX_PSEL_PBnPFS_MTIOC4C 0x02 /**< Multi-function timer channel 4C. */
+
+#define RX_PSEL_PBnPFS_TMO0  0x5 /**< Timer output compare channel 0. */
+#define RX_PSEL_PBnPFS_TMRI1 0x5 /**< Timer read input channel 1. */
+#define RX_PSEL_PBnPFS_TMCI0 0x5 /**< Timer input capture channel 0. */
+
+#define RX_PSEL_PBnPFS_POE1 0x7 /**< Port output enable 1. */
+#define RX_PSEL_PBnPFS_POE3 0x7 /**< Port output enable 3. */
+
+#define RX_PSEL_PBnPFS_RXD9   0xA /**< Serial communication interface RXD9. */
+#define RX_PSEL_PBnPFS_SMISO9 0xA /**< SPI MISO channel 9. */
+#define RX_PSEL_PBnPFS_SSCL9  0xA /**< I2C SSCL channel 9. */
+#define RX_PSEL_PBnPFS_TXD9   0xA /**< Serial communication interface TXD9. */
+#define RX_PSEL_PBnPFS_SMOSI9 0xA /**< SPI MOSI channel 9. */
+#define RX_PSEL_PBnPFS_SSDA9  0xA /**< I2C SSDA channel 9. */
+#define RX_PSEL_PBnPFS_SCK9   0xA /**< SPI SCK channel 9. */
+
+#define RX_PSEL_PBnPFS_CTS6   0xB /**< Serial communication interface CTS6. */
+#define RX_PSEL_PBnPFS_RTS6   0xB /**< Serial communication interface RTS6. */
+#define RX_PSEL_PBnPFS_SS6    0xB /**< SPI slave select channel 6. */
+#define RX_PSEL_PBnPFS_CTS9   0xB /**< Serial communication interface CTS9. */
+#define RX_PSEL_PBnPFS_RTS9   0xB /**< Serial communication interface RTS9. */
+#define RX_PSEL_PBnPFS_SS9    0xB /**< SPI slave select channel 9. */
+#define RX_PSEL_PBnPFS_RXD6   0xB /**< Serial communication interface RXD6. */
+#define RX_PSEL_PBnPFS_SMISO6 0xB /**< SPI MISO channel 6. */
+#define RX_PSEL_PBnPFS_SSCL6  0xB /**< I2C SSCL channel 6. */
+#define RX_PSEL_PBnPFS_TXD6   0xB /**< Serial communication interface TXD6. */
+#define RX_PSEL_PBnPFS_SMOSI6 0xB /**< SPI MOSI channel 6. */
+#define RX_PSEL_PBnPFS_SSDA6  0xB /**< I2C SSDA channel 6. */
+#define RX_PSEL_PBnPFS_SCK6   0xB /**< SPI SCK channel 6. */
+
+#define RX_PSEL_PBnPFS_RSPCKA 0xD /**< SPI RSPCK A. */
+
+#define RX_PSEL_PBnPFS_CMPOB1 0x10 /**< Comparator output B1. */
+
+#define RX_PSEL_PBnPFS_TS18 0x19 /**< Touch sensor input 18. */
+#define RX_PSEL_PBnPFS_TS19 0x19 /**< Touch sensor input 19. */
+#define RX_PSEL_PBnPFS_TS20 0x19 /**< Touch sensor input 20. */
+#define RX_PSEL_PBnPFS_TS21 0x19 /**< Touch sensor input 21. */
+#define RX_PSEL_PBnPFS_TS22 0x19 /**< Touch sensor input 22. */
+#define RX_PSEL_PBnPFS_TS23 0x19 /**< Touch sensor input 23. */
+#define RX_PSEL_PBnPFS_TS24 0x19 /**< Touch sensor input 24. */
+#define RX_PSEL_PBnPFS_TS25 0x19 /**< Touch sensor input 25. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port C Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PCnPFS_MTIOC3A 0x01 /**< Multi-function timer channel 3A. */
+#define RX_PSEL_PCnPFS_MTIOC3B 0x01 /**< Multi-function timer channel 3B. */
+#define RX_PSEL_PCnPFS_MTIOC3C 0x01 /**< Multi-function timer channel 3C. */
+#define RX_PSEL_PCnPFS_MTIOC3D 0x01 /**< Multi-function timer channel 3D. */
+#define RX_PSEL_PCnPFS_MTIOC4B 0x01 /**< Multi-function timer channel 4B. */
+#define RX_PSEL_PCnPFS_MTIOC4D 0x01 /**< Multi-function timer channel 4D. */
+
+#define RX_PSEL_PCnPFS_MTCLKA 0x02 /**< Multi-Timer Clock A function. */
+#define RX_PSEL_PCnPFS_MTCLKB 0x02 /**< Multi-Timer Clock B function. */
+#define RX_PSEL_PCnPFS_MTCLKC 0x02 /**< Multi-Timer Clock C function. */
+#define RX_PSEL_PCnPFS_MTCLKD 0x02 /**< Multi-Timer Clock D function. */
+
+#define RX_PSEL_PCnPFS_TMCI1 0x5 /**< Timer input capture channel 1. */
+#define RX_PSEL_PCnPFS_TMO2  0x5 /**< Timer output compare channel 2. */
+#define RX_PSEL_PCnPFS_TMRI2 0x5 /**< Timer read input channel 2. */
+#define RX_PSEL_PCnPFS_TMCI2 0x5 /**< Timer input capture channel 2. */
+
+#define RX_PSEL_PCnPFS_POE0   0x7 /**< Port output enable 0. */
+#define RX_PSEL_PCnPFS_CACREF 0x7 /**< CAC reference voltage output. */
+
+#define RX_PSEL_PCnPFS_RXD5   0xA /**< Serial communication interface RXD5. */
+#define RX_PSEL_PCnPFS_SMISO5 0xA /**< SPI MISO channel 5. */
+#define RX_PSEL_PCnPFS_SSCL5  0xA /**< I2C SSCL channel 5. */
+#define RX_PSEL_PCnPFS_TXD5   0xA /**< Serial communication interface TXD5. */
+#define RX_PSEL_PCnPFS_SMOSI5 0xA /**< SPI MOSI channel 5. */
+#define RX_PSEL_PCnPFS_SSDA5  0xA /**< I2C SSDA channel 5. */
+#define RX_PSEL_PCnPFS_SCK5   0xA /**< SPI SCK channel 5. */
+#define RX_PSEL_PCnPFS_RXD8   0xA /**< Serial communication interface RXD8. */
+#define RX_PSEL_PCnPFS_SMISO8 0xA /**< SPI MISO channel 8. */
+#define RX_PSEL_PCnPFS_SSCL8  0xA /**< I2C SSCL channel 8. */
+#define RX_PSEL_PCnPFS_TXD8   0xA /**< Serial communication interface TXD8. */
+#define RX_PSEL_PCnPFS_SMOSI8 0xA /**< SPI MOSI channel 8. */
+#define RX_PSEL_PCnPFS_SSDA8  0xA /**< I2C SSDA channel 8. */
+#define RX_PSEL_PCnPFS_SCK8   0xA /**< SPI SCK channel 8. */
+
+#define RX_PSEL_PCnPFS_CTS5 0xB /**< Serial communication interface CTS5. */
+#define RX_PSEL_PCnPFS_RTS5 0xB /**< Serial communication interface RTS5. */
+#define RX_PSEL_PCnPFS_SS5  0xB /**< SPI slave select channel 5. */
+#define RX_PSEL_PCnPFS_CTS8 0xB /**< Serial communication interface CTS8. */
+#define RX_PSEL_PCnPFS_RTS8 0xB /**< Serial communication interface RTS8. */
+#define RX_PSEL_PCnPFS_SS8  0xB /**< SPI slave select channel 8. */
+
+#define RX_PSEL_PCnPFS_SSLA0  0xD /**< SPI slave select A0. */
+#define RX_PSEL_PCnPFS_SSLA1  0xD /**< SPI slave select A1. */
+#define RX_PSEL_PCnPFS_SSLA2  0xD /**< SPI slave select A2. */
+#define RX_PSEL_PCnPFS_SSLA3  0xD /**< SPI slave select A3. */
+#define RX_PSEL_PCnPFS_RSPCKA 0xD /**< SPI RSPCK A. */
+#define RX_PSEL_PCnPFS_MOSIA  0xD /**< SPI MOSI A. */
+#define RX_PSEL_PCnPFS_MISOA  0xD /**< SPI MISO A. */
+
+#define RX_PSEL_PCnPFS_TS13  0x19 /**< Touch sensor input 13. */
+#define RX_PSEL_PCnPFS_TS14  0x19 /**< Touch sensor input 14. */
+#define RX_PSEL_PCnPFS_TS15  0x19 /**< Touch sensor input 15. */
+#define RX_PSEL_PCnPFS_TS16  0x19 /**< Touch sensor input 16. */
+#define RX_PSEL_PCnPFS_TS17  0x19 /**< Touch sensor input 17. */
+#define RX_PSEL_PCnPFS_TSCAP 0x19 /**< Touch sensor capacitor connection. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port D Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PDnPFS_MTIOC4B 0x01 /**< Multi-function timer channel 4B. */
+#define RX_PSEL_PDnPFS_MTIOC4D 0x01 /**< Multi-function timer channel 4D. */
+#define RX_PSEL_PDnPFS_MTIOC5W 0x01 /**< Multi-function timer channel 5W. */
+#define RX_PSEL_PDnPFS_MTIOC5V 0x01 /**< Multi-function timer channel 5V. */
+#define RX_PSEL_PDnPFS_MTIOC5U 0x01 /**< Multi-function timer channel 5U. */
+
+#define RX_PSEL_PDnPFS_POE0 0x7 /**< Port output enable 0. */
+#define RX_PSEL_PDnPFS_POE1 0x7 /**< Port output enable 1. */
+#define RX_PSEL_PDnPFS_POE2 0x7 /**< Port output enable 2. */
+#define RX_PSEL_PDnPFS_POE3 0x7 /**< Port output enable 3. */
+#define RX_PSEL_PDnPFS_POE8 0x7 /**< Port output enable 8. */
+
+#define RX_PSEL_PDnPFS_RXD6   0xB /**< Serial communication interface RXD6. */
+#define RX_PSEL_PDnPFS_SMISO6 0xB /**< SPI MISO channel 6. */
+#define RX_PSEL_PDnPFS_SSCL6  0xB /**< I2C SSCL channel 6. */
+#define RX_PSEL_PDnPFS_TXD6   0xB /**< Serial communication interface TXD6. */
+#define RX_PSEL_PDnPFS_SMOSI6 0xB /**< SPI MOSI channel 6. */
+#define RX_PSEL_PDnPFS_SSDA6  0xB /**< I2C SSDA channel 6. */
+#define RX_PSEL_PDnPFS_SCK6   0xB /**< SPI SCK channel 6. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port E Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PEnPFS_MTIOC4A 0x01 /**< Multi-function timer channel 4A. */
+#define RX_PSEL_PEnPFS_MTIOC4B 0x01 /**< Multi-function timer channel 4B. */
+#define RX_PSEL_PEnPFS_MTIOC4C 0x01 /**< Multi-function timer channel 4C. */
+#define RX_PSEL_PEnPFS_MTIOC4D 0x01 /**< Multi-function timer channel 4D. */
+
+#define RX_PSEL_PEnPFS_MTIOC1A 0x02 /**< Multi-function timer channel 1A. */
+#define RX_PSEL_PEnPFS_MTIOC2B 0x02 /**< Multi-function timer channel 2B. */
+
+#define RX_PSEL_PEnPFS_POE8 0x7 /**< Port output enable 8. */
+
+#define RX_PSEL_PEnPFS_CLKOUT 0x9 /**< Clock output function. */
+
+#define RX_PSEL_PEnPFS_RXD12   0xC /**< Serial communication interface RXD12. */
+#define RX_PSEL_PEnPFS_SMISO12 0xC /**< SPI MISO channel 12. */
+#define RX_PSEL_PEnPFS_SSCL12  0xC /**< I2C SSCL channel 12. */
+#define RX_PSEL_PEnPFS_TXD12   0xC /**< Serial communication interface TXD12. */
+#define RX_PSEL_PEnPFS_SMOSI12 0xC /**< SPI MOSI channel 12. */
+#define RX_PSEL_PEnPFS_SSDA12  0xC /**< I2C SSDA channel 12. */
+#define RX_PSEL_PEnPFS_SCK12   0xC /**< SPI SCK channel 12. */
+#define RX_PSEL_PEnPFS_TXDX12  0xC /**< RSCI TXD/X function. */
+#define RX_PSEL_PEnPFS_RXDX12  0xC /**< RSCI RXD/X function. */
+#define RX_PSEL_PEnPFS_SIOX12  0xC /**< RSCI SIO/X function. */
+#define RX_PSEL_PEnPFS_CTS12   0xC /**< Serial communication interface CTS12. */
+#define RX_PSEL_PEnPFS_RTS12   0xC /**< Serial communication interface RTS12. */
+#define RX_PSEL_PEnPFS_SS12    0xC /**< SPI slave select channel 12. */
+
+#define RX_PSEL_PEnPFS_CMPOB0 0X10 /**< Comparator output B0. */
+
+#define RX_PSEL_PEnPFS_TS33 0X19 /**< Touch sensor input 33. */
+#define RX_PSEL_PEnPFS_TS34 0x19 /**< Touch sensor input 34. */
+#define RX_PSEL_PEnPFS_TS35 0x19 /**< Touch sensor input 35. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port H Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PHnPFS_TMO0  0x05 /**< Timer output compare channel 0. */
+#define RX_PSEL_PHnPFS_TMRI0 0x05 /**< Timer read input channel 0. */
+#define RX_PSEL_PHnPFS_TMCI0 0x05 /**< Timer input capture channel 0. */
+
+#define RX_PSEL_PHnPFS_CACREF 0x7 /**< CAC reference voltage output. */
+
+#define RX_PSEL_PHnPFS_TS7  0x19 /**< Touch sensor input 7. */
+#define RX_PSEL_PHnPFS_TS8  0x19 /**< Touch sensor input 8. */
+#define RX_PSEL_PHnPFS_TS9  0x19 /**< Touch sensor input 9. */
+#define RX_PSEL_PHnPFS_TS10 0x19 /**< Touch sensor input 10. */
+
+/** @} */
+
+/**
+ * @name  Renesas RX MPC Port H Pin Function Select codes (PSEL values)
+ * @{
+ */
+#define RX_PSEL_PJnPFS_MTIOC3A 0x01 /**< Multi-function timer channel 3A. */
+#define RX_PSEL_PJnPFS_MTIOC3C 0x01 /**< Multi-function timer channel 3C. */
+
+#define RX_PSEL_PJnPFS_CTS6 0xB /**< Serial communication interface CTS6. */
+#define RX_PSEL_PJnPFS_TTS6 0xB /**< Serial communication interface TTS6. */
+#define RX_PSEL_PJnPFS_SS6  0xB /**< SPI slave select channel 6. */
+
+/** @} */
+
+/**
+ * @brief Macro to encode a pin configuration for Renesas RX SoCs.
+ *
+ * This macro encodes the mode, peripheral selection (PSEL), port number,
+ * and pin number into a single 32-bit value suitable for use in DeviceTree
+ * pinctrl configurations.
+ *
+ * @param psel       Peripheral selection value (use RX_PSEL_* macros).
+ * @param port_num   Port number.
+ * @param pin_num    Pin number within the port.
+ *
+ * @return Encoded pin configuration value.
+ */
 #define RX_PSEL(psel, port_num, pin_num)                                                           \
 	(psel << RX_PSEL_POS | pin_num << RX_PIN_NUM_POS | port_num << RX_PORT_NUM_POS)
 
-#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_SOC_RX_COMMON_H_ */
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_PINCTRL_RX_H_ */


### PR DESCRIPTION
This PR adds Doxygen coverage for the Renesas header files to improve documentation readability and provide better guidance for users.