### PR TITLE
subsys: usb: host: fix usbh_bus_thread name setting

### DIFF
--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -219,7 +219,7 @@ static int uhs_pre_init(void)
 			NULL, NULL, NULL,
 			K_PRIO_COOP(9), 0, K_NO_WAIT);
 
-	k_thread_name_set(&usbh_thread_data, "usbh_bus");
+	k_thread_name_set(&usbh_bus_thread_data, "usbh_bus");
 
 	return 0;
 }


### PR DESCRIPTION
Use correct thread data pointer when setting bus thread name.