### PR TITLE
MAINTAINERS: remove tomi-font from GNSS collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1776,7 +1776,6 @@ Documentation Infrastructure:
   maintainers:
     - bjarki-andreasen
   collaborators:
-    - tomi-font
     - fabiobaltieri
     - ubieda
   files:


### PR DESCRIPTION
I'm not active anymore in this area.