### PR TITLE
Versal2 APU enable TF-A and SMP board variant 

### DIFF
--- a/boards/amd/versal2_apu/board.cmake
+++ b/boards/amd/versal2_apu/board.cmake
@@ -1,7 +1,20 @@
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+if(CONFIG_BUILD_WITH_TFA)
+  set(TFA_PLAT "versal2")
+  # Add Versal Gen 2 specific TF-A build parameters
+  set(TFA_EXTRA_ARGS "RESET_TO_BL31=1;PRELOADED_BL33_BASE=${CONFIG_SRAM_BASE_ADDRESS};TFA_NO_PM=1;")
+  if(CONFIG_TFA_MAKE_BUILD_TYPE_DEBUG)
+    set(BUILD_FOLDER "debug")
+  else()
+    set(BUILD_FOLDER "release")
+  endif()
+  set(XSDB_BL31_PATH ${PROJECT_BINARY_DIR}/../tfa/versal2/${BUILD_FOLDER}/bl31/bl31.elf)
+  board_runner_args(xsdb "--bl31=${XSDB_BL31_PATH}")
+endif()
 
 include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)

--- a/boards/amd/versal2_apu/board.yml
+++ b/boards/amd/versal2_apu/board.yml
@@ -7,3 +7,5 @@ board:
   vendor: amd
   socs:
   - name: amd_versal2_apu
+    variants:
+    - name: smp

--- a/boards/amd/versal2_apu/support/xsdb.cfg
+++ b/boards/amd/versal2_apu/support/xsdb.cfg
@@ -73,7 +73,6 @@ proc load_image args  {
 	set elf_file [lindex $args 0]
 	set pdi_file [lindex $args 1]
 	set bl31_file [lindex $args 2]
-	set dtb_file [lindex $args 3]
 
 	if { [info exists ::env(HW_SERVER_URL)] } {
 		connect -url $::env(HW_SERVER_URL)
@@ -98,7 +97,6 @@ proc load_image args  {
 	after 100
 	cluster0_core0_rst
 	after 100
-	dow -data -force $dtb_file 0x1000000
 	dow -force $elf_file
 	dow -force $bl31_file
 	con

--- a/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.dts
+++ b/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.dts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "versal2_apu.dts"

--- a/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.yaml
+++ b/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.yaml
@@ -1,0 +1,11 @@
+identifier: versal2_apu/amd_versal2_apu/smp
+name: AMD Development board for Versal Gen 2 APU
+arch: arm
+toolchain:
+  - zephyr
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+    - fpu
+vendor: amd

--- a/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp_defconfig
+++ b/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp_defconfig
@@ -1,0 +1,35 @@
+# The Zephyr build from this defconfig is expected to boot from
+# Xilinx Arm Trusted Firmware (ATF).
+# Boot Flow is: Boot PDI -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
+
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_PL011=y
+
+# This should be commented in order to test at EL1 S (EL1 Secure)
+CONFIG_ARMV8_A_NS=y
+
+# Enable Clock Manager
+CONFIG_CLOCK_CONTROL=y
+
+# Reset Manager
+CONFIG_RESET=y
+
+# PSCI support Enable
+CONFIG_PM_CPU_OPS=y
+CONFIG_PM_CPU_OPS_PSCI=y
+
+# Enable SMP support
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=2

--- a/boards/amd/versal2_apu/versal2_apu_defconfig
+++ b/boards/amd/versal2_apu/versal2_apu_defconfig
@@ -1,5 +1,6 @@
 # Xilinx Arm Trusted Firmware (ATF).
 # Boot Flow is: Boot PDI -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
 
 CONFIG_ARM64_VA_BITS_40=y
 CONFIG_ARM64_PA_BITS_40=y


### PR DESCRIPTION
This pull request does the below
1) Enable TF-A by default
2) Add SMP board variant 