### PR TITLE
drivers: uart: kb106x: Fix RX data loss and TX IRQ triggering

### DIFF
--- a/drivers/serial/uart_ene_kb106x.c
+++ b/drivers/serial/uart_ene_kb106x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 ENE Technology Inc.
+ * Copyright (c) 2025-2026 ENE Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,7 +9,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/ring_buffer.h>
 #include <reg/ser.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(uart_ene_kb106x, CONFIG_UART_LOG_LEVEL);
 
 struct kb106x_uart_config {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -19,14 +23,18 @@ struct kb106x_uart_config {
 	const struct pinctrl_dev_config *pcfg;
 };
 
+#define RX_BUF_SIZE 16
+
 struct kb106x_uart_data {
 	uart_irq_callback_user_data_t callback;
 	struct uart_config current_config;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void *callback_data;
-	uint8_t pending_flag_data;
+	struct k_timer tx_timer;
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+	struct k_spinlock lock;
 };
 
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int kb106x_uart_configure(const struct device *dev, const struct uart_config *cfg)
 {
 	uint16_t reg_baudrate = 0;
@@ -34,7 +42,7 @@ static int kb106x_uart_configure(const struct device *dev, const struct uart_con
 	const struct kb106x_uart_config *config = dev->config;
 	struct kb106x_uart_data *data = dev->data;
 
-	reg_baudrate = (DIVIDER_BASE_CLK / cfg->baudrate) - 1;
+	reg_baudrate = ((DIVIDER_BASE_CLK + (cfg->baudrate / 2)) / cfg->baudrate) - 1;
 
 	switch (cfg->parity) {
 	case UART_CFG_PARITY_NONE:
@@ -80,12 +88,13 @@ static int kb106x_uart_configure(const struct device *dev, const struct uart_con
 		ret = -ENOTSUP;
 		break;
 	}
-	config->ser->SERCFG = (reg_baudrate << 16) | 0x04 | SERIE_TX_ENABLE;
+	config->ser->SERCFG = (reg_baudrate << 16) | 0x04 | SERCFG_TX_ENABLE | SERCFG_RX_ENABLE;
 	config->ser->SERCTRL = SERCTRL_MODE1;
 	data->current_config = *cfg;
 	return ret;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int kb106x_uart_config_get(const struct device *dev, struct uart_config *cfg)
 {
 	struct kb106x_uart_data *data = dev->data;
@@ -96,60 +105,127 @@ static int kb106x_uart_config_get(const struct device *dev, struct uart_config *
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void tx_irq_trigger(struct k_timer *timer)
+{
+	const struct device *dev = k_timer_user_data_get(timer);
+	const struct kb106x_uart_config *config = dev->config;
+	struct kb106x_uart_data *data = dev->data;
+	uint8_t pending_flag_data = 0;
+
+	if (config->ser->SERIE & SERIE_TX_ENABLE) {
+		config->ser->SERPF = SERPF_TX_EMPTY;
+		pending_flag_data |= SERPF_TX_EMPTY;
+	}
+	if (data->callback && pending_flag_data) {
+		data->callback(dev, data->callback_data);
+	}
+}
+
 static int kb106x_uart_fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)
 {
 	const struct kb106x_uart_config *config = dev->config;
+	struct kb106x_uart_data *data = dev->data;
 	uint16_t tx_bytes = 0U;
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	while ((size - tx_bytes) > 0) {
-		/* Check Tx FIFO not Full*/
-		while (config->ser->SERSTS & SERSTS_TX_FULL) {
-		}
+	while (((size - tx_bytes) > 0) && (!(config->ser->SERSTS & SERSTS_TX_FULL))) {
 		/* Put a character into	Tx FIFO	*/
-		config->ser->SERTBUF = tx_data[tx_bytes];
-		tx_bytes++;
+		config->ser->SERTBUF = tx_data[tx_bytes++];
 	}
+	k_spin_unlock(&data->lock, key);
+
 	return tx_bytes;
 }
 
 static void kb106x_uart_irq_tx_enable(const struct device *dev)
 {
 	const struct kb106x_uart_config *config = dev->config;
+	struct kb106x_uart_data *data = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	config->ser->SERPF = SERPF_TX_EMPTY;
 	config->ser->SERIE |= SERIE_TX_ENABLE;
+	if (!(config->ser->SERSTS & SERSTS_TX_BUSY)) {
+		k_timer_start(&data->tx_timer, K_NO_WAIT, K_FOREVER);
+	}
+	k_spin_unlock(&data->lock, key);
 }
 
 static void kb106x_uart_irq_tx_disable(const struct device *dev)
 {
 	const struct kb106x_uart_config *config = dev->config;
+	struct kb106x_uart_data *data = dev->data;
 
+	k_timer_stop(&data->tx_timer);
 	config->ser->SERIE &= ~SERIE_TX_ENABLE;
 	config->ser->SERPF = SERPF_TX_EMPTY;
 }
 
+static int kb106x_uart_irq_tx_complete(const struct device *dev)
+{
+	const struct kb106x_uart_config *config = dev->config;
+
+	return (config->ser->SERSTS & SERSTS_TX_BUSY) ? 0 : 1;
+}
+
 static int kb106x_uart_irq_tx_ready(const struct device *dev)
 {
-	struct kb106x_uart_data *data = dev->data;
+	const struct kb106x_uart_config *config = dev->config;
 
-	return (data->pending_flag_data & SERPF_TX_EMPTY) ? 1 : 0;
+	if ((config->ser->SERIE & SERIE_TX_ENABLE) && !(config->ser->SERSTS & SERSTS_TX_FULL)) {
+		return 1;
+	}
+	return 0;
+}
+
+static int kb106x_uart_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
+{
+	const struct kb106x_uart_config *config = dev->config;
+	int read_len = 0;
+
+	while (config->ser->SERPF & SERPF_RX_CNT_FULL) {
+		*rx_data++ = (uint8_t)config->ser->SERRBUF;
+		config->ser->SERPF = SERPF_RX_CNT_FULL;
+		if (++read_len >= size) {
+			break;
+		}
+	}
+
+	return read_len;
+}
+
+static void kb106x_uart_irq_rx_enable(const struct device *dev)
+{
+	const struct kb106x_uart_config *config = dev->config;
+
+	config->ser->SERIE |= SERIE_RX_ENABLE;
+}
+
+static void kb106x_uart_irq_rx_disable(const struct device *dev)
+{
+	const struct kb106x_uart_config *config = dev->config;
+
+	config->ser->SERIE &= ~SERIE_RX_ENABLE;
+}
+
+static int kb106x_uart_irq_rx_ready(const struct device *dev)
+{
+	const struct kb106x_uart_config *config = dev->config;
+
+	if (config->ser->SERPF & SERPF_RX_CNT_FULL) {
+		return 1;
+	}
+	return 0;
 }
 
 static int kb106x_uart_irq_is_pending(const struct device *dev)
 {
-	struct kb106x_uart_data *data = dev->data;
-
-	return (data->pending_flag_data) ? 1 : 0;
+	return kb106x_uart_irq_tx_ready(dev) || kb106x_uart_irq_rx_ready(dev);
 }
 
 static void kb106x_uart_irq_update(const struct device *dev)
 {
-	struct kb106x_uart_data *data = dev->data;
-	const struct kb106x_uart_config *config = dev->config;
-
-	data->pending_flag_data = (config->ser->SERPF) & (config->ser->SERIE);
-	/*clear	pending	flag*/
-	config->ser->SERPF = data->pending_flag_data;
+	ARG_UNUSED(dev);
 }
 
 static void kb106x_uart_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
@@ -163,10 +239,24 @@ static void kb106x_uart_irq_callback_set(const struct device *dev, uart_irq_call
 
 static void kb106x_uart_irq_handler(const struct device *dev)
 {
+	const struct kb106x_uart_config *config = dev->config;
 	struct kb106x_uart_data *data = dev->data;
+	uint8_t pending_flag_data = 0;
 
-	if (data->callback) {
+	if (config->ser->SERPF & SERPF_RX_CNT_FULL) {
+		pending_flag_data |= SERPF_RX_CNT_FULL;
+	}
+	if ((config->ser->SERPF & SERPF_TX_EMPTY) && (config->ser->SERIE & SERIE_TX_ENABLE)) {
+		config->ser->SERPF = SERPF_TX_EMPTY;
+		pending_flag_data |= SERPF_TX_EMPTY;
+	}
+	if (data->callback && pending_flag_data) {
 		data->callback(dev, data->callback_data);
+		pending_flag_data = 0;
+	}
+	if ((config->ser->SERPF & SERPF_RX_CNT_FULL) && pending_flag_data) {
+		config->ser->SERPF = SERPF_RX_CNT_FULL;
+		LOG_WRN("UART %s: RX FIFO not empty after ISR.", dev->name);
 	}
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -175,28 +265,29 @@ static int kb106x_uart_poll_in(const struct device *dev, unsigned char *c)
 {
 	const struct kb106x_uart_config *config = dev->config;
 
-	/* Check Rx FIFO not Empty*/
-	if (config->ser->SERSTS & SERSTS_RX_BUSY) {
-		return -1;
+	if (config->ser->SERPF & SERPF_RX_CNT_FULL) {
+		*c = config->ser->SERRBUF;
+		config->ser->SERPF = SERPF_RX_CNT_FULL;
+		return 0;
 	}
-	/* Put a character into Tx FIFO */
-	*c = config->ser->SERRBUF;
-	return 0;
+
+	return -1;
 }
 
 static void kb106x_uart_poll_out(const struct device *dev, unsigned char c)
 {
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	kb106x_uart_fifo_fill(dev, &c, 1);
-#else
 	const struct kb106x_uart_config *config = dev->config;
+	int try_count = 500;
 
-	/* Wait	Tx FIFO	not Full*/
-	while (config->ser->SERSTS & SERSTS_TX_FULL) {
+	while (try_count > 0) {
+		if (config->ser->SERSTS & SERSTS_TX_FULL) {
+			try_count--;
+			continue;
+		}
+		/* Put a character into	Tx FIFO */
+		config->ser->SERTBUF = c;
+		break;
 	}
-	/* Put a character into	Tx FIFO */
-	config->ser->SERTBUF = c;
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 }
 
 static DEVICE_API(uart, kb106x_uart_api) = {
@@ -208,9 +299,14 @@ static DEVICE_API(uart, kb106x_uart_api) = {
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = kb106x_uart_fifo_fill,
+	.fifo_read = kb106x_uart_fifo_read,
 	.irq_tx_enable = kb106x_uart_irq_tx_enable,
 	.irq_tx_disable = kb106x_uart_irq_tx_disable,
 	.irq_tx_ready = kb106x_uart_irq_tx_ready,
+	.irq_tx_complete = kb106x_uart_irq_tx_complete,
+	.irq_rx_enable = kb106x_uart_irq_rx_enable,
+	.irq_rx_disable = kb106x_uart_irq_rx_disable,
+	.irq_rx_ready = kb106x_uart_irq_rx_ready,
 	.irq_is_pending = kb106x_uart_irq_is_pending,
 	.irq_update = kb106x_uart_irq_update,
 	.irq_callback_set = kb106x_uart_irq_callback_set,
@@ -218,8 +314,7 @@ static DEVICE_API(uart, kb106x_uart_api) = {
 };
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-
-/* GPIO module instances */
+/* UART module instances */
 #define KB106X_UART_DEV(inst) DEVICE_DT_INST_GET(inst),
 static const struct device *const uart_devices[] = {DT_INST_FOREACH_STATUS_OKAY(KB106X_UART_DEV)};
 static void kb106x_uart_isr_wrap(const struct device *dev)
@@ -228,7 +323,10 @@ static void kb106x_uart_isr_wrap(const struct device *dev)
 		const struct device *dev_ = uart_devices[i];
 		const struct kb106x_uart_config *config = dev_->config;
 
-		if (config->ser->SERIE & config->ser->SERPF) {
+		if (((config->ser->SERIE & SERIE_RX_ENABLE) &&
+		     (config->ser->SERPF & SERPF_RX_CNT_FULL)) ||
+		    ((config->ser->SERIE & SERIE_TX_ENABLE) &&
+		     (config->ser->SERPF & SERPF_TX_EMPTY))) {
 			kb106x_uart_irq_handler(dev_);
 		}
 	}
@@ -249,15 +347,18 @@ static int kb106x_uart_init(const struct device *dev)
 	kb106x_uart_configure(dev, &data->current_config);
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	config->irq_cfg_func();
+	k_timer_init(&data->tx_timer, tx_irq_trigger, NULL);
+	k_timer_user_data_set(&data->tx_timer, (void *)dev);
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
 	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-static bool init_irq = true;
 static void kb106x_uart_irq_init(void)
 {
+	static bool init_irq = true;
+
 	if (init_irq) {
 		init_irq = false;
 		IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), kb106x_uart_isr_wrap, NULL,
@@ -270,7 +371,8 @@ static void kb106x_uart_irq_init(void)
 #define KB106X_UART_INIT(n)                                                                        \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static struct kb106x_uart_data kb106x_uart_data_##n = {                                    \
-		.current_config = {                                                                \
+		.current_config =                                                                  \
+			{                                                                          \
 				.baudrate = DT_INST_PROP(n, current_speed),                        \
 				.parity = UART_CFG_PARITY_NONE,                                    \
 				.stop_bits = UART_CFG_STOP_BITS_1,                                 \


### PR DESCRIPTION
- Add an RX queue to prevent data loss since kb106x lacks a hardware RX buffer.
- Manually trigger TX IRQ when the buffer is empty to work around the hardware limitation where the IRQ is not automatically generated.