### PR TITLE
Bluetooth: Shell: Fix BAP USB Audio on windows

### DIFF
--- a/tests/bluetooth/shell/usb_audio.overlay
+++ b/tests/bluetooth/shell/usb_audio.overlay
@@ -12,7 +12,7 @@
 		status = "okay";
 		full-speed;
 		high-speed;
-		audio-function = <AUDIO_FUNCTION_SUBCLASS_UNDEFINED>;
+		audio-function = <AUDIO_FUNCTION_HEADSET>;
 
 		/* Clock supporting 48KHz
 		 *
@@ -65,7 +65,7 @@
 			compatible = "zephyr,uac2-output-terminal";
 			data-source = <&out_terminal>;
 			clock-source = <&uac_aclk>;
-			terminal-type = <BIDIRECTIONAL_TERMINAL_UNDEFINED>;
+			terminal-type = <BIDIRECTIONAL_TERMINAL_HEADSET>;
 			assoc-terminal = <&bt_input>;
 		};
 
@@ -73,7 +73,7 @@
 		bt_input: microphone {
 			compatible = "zephyr,uac2-input-terminal";
 			clock-source = <&uac_aclk>;
-			terminal-type = <BIDIRECTIONAL_TERMINAL_UNDEFINED>;
+			terminal-type = <BIDIRECTIONAL_TERMINAL_HEADSET>;
 			/* Circular reference, macros will figure it out and
 			 * provide correct associated terminal ID because the
 			 * terminals associations are always 1-to-1.


### PR DESCRIPTION
On Windows, using the UNDEFINED device class
and terminal types in the devicetree resulted
in the USB Audio device not being selectable as
input/output sound device.

Changing to HEADSET makes it work.