### PR TITLE
bluetooth: has: Enable HAS preset sync feature for synchronized preset tests

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_has.c
+++ b/tests/bluetooth/tester/src/audio/btp_has.c
@@ -171,7 +171,7 @@ uint8_t tester_init_has(void)
 
 	struct bt_has_features_param params = {
 		.type = BT_HAS_HEARING_AID_TYPE_BINAURAL,
-		.preset_sync_support = false,
+		.preset_sync_support = true,
 		.independent_presets = IS_ENABLED(CONFIG_BT_HAS_PRESET_SUPPORT)
 	};
 	int err = bt_has_register(&params);


### PR DESCRIPTION
Description
Enable HAS preset sync feature for synchronized preset tests

This change enables the following PTS cases to pass:
 HAS/SR/CP/BV-06-C (Active Preset – Synced Locally)
 HAS/SR/CP/BV-08-C (Next Preset – Synced Locally)
 HAS/SR/CP/BV-10-C (Previous Preset – Synced Locally)
 HAS/SR/FEAT/BV-01  (Preset Sync Feature)

Testing
nRF5340 Audio DK
nRF54L15 DK