### PR TITLE
dts: vendor: nordic: Add missing hfpll clock source to peripherals

### DIFF
--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -145,6 +145,7 @@
 				#size-cells = <0>;
 				reg = <0x4a000 0x1000>;
 				interrupts = <74 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				max-frequency = <DT_FREQ_M(32)>;
 				easydma-maxcnt-bits = <16>;
 				rx-delay-supported;

--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -196,6 +196,7 @@
 				#size-cells = <0>;
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				max-frequency = <DT_FREQ_M(32)>;
 				easydma-maxcnt-bits = <16>;
 				rx-delay-supported;

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -244,6 +244,7 @@
 				compatible = "nordic,nrf-spim";
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				max-frequency = <DT_FREQ_M(32)>;
@@ -257,6 +258,7 @@
 				compatible = "nordic,nrf-uarte";
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hfpll>;
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;


### PR DESCRIPTION
Add missing clock property to spi00 nodes. Add missing clock property to uart00 node in nrf7120.