### PR TITLE
Fix bugs in NXP DCnano DBI driver

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -93,7 +93,7 @@ static int mcux_dcnano_lcdif_dbi_configure(const struct device *dev,
 	const struct mcux_dcnano_lcdif_dbi_config *config = dev->config;
 	struct mcux_dcnano_lcdif_dbi_data *lcdif_data = dev->data;
 	uint8_t bus_type = dbi_config->mode & 0xFU;
-	uint8_t color_coding = dbi_config->mode & 0xF0U;
+	uint8_t color_coding = dbi_config->color_coding & 0xF0U;
 	lcdif_dbi_config_t lcdif_dbi_config = config->dbi_config;
 	status_t status;
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1095,6 +1095,8 @@
 		reg = <0x480000 0x1000>;
 		interrupts = <56 0>;
 		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <0>;
 	};
 
 	mipi_dsi: dsi@417000 {

--- a/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
+++ b/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025,2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -17,7 +17,7 @@ description: |
 
 compatible: "nxp,mipi-dbi-dcnano-lcdif"
 
-include: [base.yaml]
+include: ["mipi-dbi-controller.yaml", "pinctrl-device.yaml"]
 
 properties:
   clock-frequency:


### PR DESCRIPTION
1. Get the color_coding value from in mipi_dbi_config properly
2. Update device tree binding to include pinctrl support and declare mipi-dbi bus compatibility.