### PR TITLE
doc: contribute: style: kconfig: Add sample/test/boards naming style

### DIFF
--- a/doc/contribute/style/kconfig.rst
+++ b/doc/contribute/style/kconfig.rst
@@ -84,6 +84,12 @@ The specific formats by subtree:
   creating new symbols, check if similar ones already exist in other
   architectures.
 
+* **Samples (/samples)**: Use ``SAMPLE_`` for symbols, this is to prevent conflicts with external
+  modules.
+
+* **Tests (/tests)**: Use ``TEST_`` for symbols, this is to prevent conflicts with external
+  modules.
+
 Examples
 ========
 
@@ -100,6 +106,18 @@ Examples
 **Sensor Examples:**
 
 .. literalinclude:: kconfig_example_sensor.txt
+   :language: kconfig
+   :start-after: start-after-here
+
+**Sample examples:**
+
+.. literalinclude:: kconfig_example_sample.txt
+   :language: kconfig
+   :start-after: start-after-here
+
+**Test examples:**
+
+.. literalinclude:: kconfig_example_test.txt
    :language: kconfig
    :start-after: start-after-here
 

--- a/doc/contribute/style/kconfig.rst
+++ b/doc/contribute/style/kconfig.rst
@@ -90,6 +90,8 @@ The specific formats by subtree:
 * **Tests (/tests)**: Use ``TEST_`` for symbols, this is to prevent conflicts with external
   modules.
 
+* **Boards (/boards)**: Use ``BOARD_`` for symbols.
+
 Examples
 ========
 

--- a/doc/contribute/style/kconfig_example_sample.txt
+++ b/doc/contribute/style/kconfig_example_sample.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Examples of Kconfig symbols for samples
+
+# start-after-here
+
+config SAMPLE_LOCK
+	bool "Locking feature"
+
+config SAMPLE_TEMPERATURE_READINGS
+	bool "Fetch readings from temperature sensor"

--- a/doc/contribute/style/kconfig_example_test.txt
+++ b/doc/contribute/style/kconfig_example_test.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Examples of Kconfig symbols for tests
+
+# start-after-here
+
+config TEST_ITERATIONS
+	int "Number of times test should run"
+	default 3


### PR DESCRIPTION
Adds a naming system for samples and tests, this is picked to avoid conflicts with external modules, e.g. a sample using ``LOCK`` might conflict with a Kconfig that an external module has with the same name, whereas ``SAMPLE_LOCK`` clearly separates it into being for an application