### PR TITLE
Bluetooth: Host: Use HCI VS command to set public addr on bt_enable

### DIFF
--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -38,6 +38,9 @@ extern "C" {
 
 #define BT_VS_CMD_SUP_FEAT(cmd)                 BT_LE_FEAT_TEST(cmd, \
 						BT_VS_CMD_BIT_SUP_FEAT)
+/** Check if HCI VS command BT_VS_CMD_BIT_WRITE_BDADDR is supported */
+#define BT_VS_CMD_WRITE_BD_ADDR(cmd)            BT_LE_FEAT_TEST(cmd, \
+						BT_VS_CMD_BIT_WRITE_BDADDR)
 #define BT_VS_CMD_READ_STATIC_ADDRS(cmd)        BT_LE_FEAT_TEST(cmd, \
 						BT_VS_CMD_BIT_READ_STATIC_ADDRS)
 #define BT_VS_CMD_READ_KEY_ROOTS(cmd)           BT_LE_FEAT_TEST(cmd, \

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1365,7 +1365,8 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 			return -EALREADY;
 		}
 
-		if (addr->type == BT_ADDR_LE_PUBLIC && IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR)) {
+		if (addr->type == BT_ADDR_LE_PUBLIC &&
+		    (IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR) || IS_ENABLED(CONFIG_BT_HCI_VS))) {
 			/* set the single public address */
 			if (bt_dev.id_count != 0) {
 				return -EALREADY;

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
@@ -93,7 +93,7 @@ ZTEST(bt_id_create_invalid_inputs, test_public_address)
 {
 	int err;
 
-	if (IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR)) {
+	if (IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR) || IS_ENABLED(CONFIG_BT_HCI_VS)) {
 		ztest_test_skip();
 	}
 


### PR DESCRIPTION
The current way of setting the public address using `bt_hci_driver_api::setup` does not work well in split builds where host and controller runs on different cores/socs/boards. This approach requires each HCI driver and each `hci_<transport>` application to implement the setup and pass the information on to the next layer.

Zephyr already defines a vendor-specific command that can be used to set the public address (`bt_hci_cp_vs_write_bd_addr`). Use this in `bt_enable` after opening the HCI transport and before initializing the id module. This makes the setup independent of hci transport and only depends on a controller that implements the Zephyr HCI VS commands.