### PR TITLE
boards: nordic: nrf54l15dk: Fix missing flash runner groups

### DIFF
--- a/boards/nordic/nrf54l15dk/board.yml
+++ b/boards/nordic/nrf54l15dk/board.yml
@@ -23,6 +23,9 @@ runners:
         run: first
         groups:
           - boards:
+              - nrf54l15dk/nrf54l05/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuapp
               - nrf54l15dk/nrf54l15/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuflpr
@@ -35,6 +38,9 @@ runners:
         run: first
         groups:
           - boards:
+              - nrf54l15dk/nrf54l05/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuapp
               - nrf54l15dk/nrf54l15/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuflpr
@@ -47,6 +53,9 @@ runners:
         run: last
         groups:
           - boards:
+              - nrf54l15dk/nrf54l05/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp
+              - nrf54l15dk/nrf54l10/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuapp
               - nrf54l15dk/nrf54l15/cpuapp/ns
               - nrf54l15dk/nrf54l15/cpuflpr


### PR DESCRIPTION
Fixes missing groups for the nrf54l05 and nrf54l10 emulated board targets