### PR TITLE
scripts: coredump: fix Python exception

### DIFF
--- a/scripts/coredump/coredump_parser/elf_parser.py
+++ b/scripts/coredump/coredump_parser/elf_parser.py
@@ -144,7 +144,7 @@ class CoredumpElfFile:
                 mem_region = {"start": sec_start, "end": sec_end, "data": section.data()}
                 logger.info(
                     f'ELF Section: 0x{mem_region["start"]:x} to 0x{mem_region["end"]:x} '
-                    f'of size {mem_region["data"]:d} ({sect_desc:s})'
+                    f'of size {len(mem_region["data"]):d} ({sect_desc:s})'
                 )
 
                 self.memory_regions.append(mem_region)


### PR DESCRIPTION
The coredump parsing script raises an exception as it tries to format bytes objects as integer (":d").

This is a regression from a recent PR fxing ruff warnings.