### PR TITLE
retention: change init priority level

### DIFF
--- a/drivers/retained_mem/retained_mem_nrf_gpregret.c
+++ b/drivers/retained_mem/retained_mem_nrf_gpregret.c
@@ -129,7 +129,7 @@ static DEVICE_API(retained_mem, nrf_gpregret_api) = {
 					  (&nrf_gpregret_data_##inst), (NULL)	\
 			      ),						\
 			      &nrf_gpregret_config_##inst,			\
-			      POST_KERNEL,					\
+			      PRE_KERNEL_1,					\
 			      CONFIG_RETAINED_MEM_INIT_PRIORITY,		\
 			      &nrf_gpregret_api);
 

--- a/drivers/retained_mem/retained_mem_silabs_buram.c
+++ b/drivers/retained_mem/retained_mem_silabs_buram.c
@@ -132,6 +132,9 @@ static DEVICE_API(retained_mem, silabs_buram_api) = {
 	.write = silabs_buram_write,
 	.clear = silabs_buram_clear,
 };
+BUILD_ASSERT(
+	CONFIG_RETAINED_MEM_INIT_PRIORITY > CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+	"CONFIG_RETAINED_MEM_INIT_PRIORITY must be higher than CONFIG_CLOCK_CONTROL_INIT_PRIORITY");
 
 #define SILABS_BURAM_DEVICE(inst)                                                                  \
 	static struct silabs_buram_data silabs_buram_data_##inst;                                  \
@@ -146,7 +149,7 @@ static DEVICE_API(retained_mem, silabs_buram_api) = {
 					 ({0})),                                                   \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &silabs_buram_init, NULL, &silabs_buram_data_##inst,           \
-			      &silabs_buram_config_##inst, POST_KERNEL,                            \
+			      &silabs_buram_config_##inst, PRE_KERNEL_1,                           \
 			      CONFIG_RETAINED_MEM_INIT_PRIORITY, &silabs_buram_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SILABS_BURAM_DEVICE)

--- a/drivers/retained_mem/retained_mem_zephyr_ram.c
+++ b/drivers/retained_mem/retained_mem_zephyr_ram.c
@@ -143,7 +143,7 @@ static DEVICE_API(retained_mem, zephyr_retained_mem_ram_api) = {
 					  (&zephyr_retained_mem_ram_data_##inst), (NULL)	\
 			      ),								\
 			      &zephyr_retained_mem_ram_config_##inst,				\
-			      POST_KERNEL,							\
+			      PRE_KERNEL_1,							\
 			      CONFIG_RETAINED_MEM_INIT_PRIORITY,				\
 			      &zephyr_retained_mem_ram_api);
 

--- a/drivers/retained_mem/retained_mem_zephyr_reg.c
+++ b/drivers/retained_mem/retained_mem_zephyr_reg.c
@@ -128,7 +128,7 @@ static DEVICE_API(retained_mem, zephyr_retained_mem_reg_api) = {
 			      NULL,								\
 			      &zephyr_retained_mem_reg_data_##inst,				\
 			      &zephyr_retained_mem_reg_config_##inst,				\
-			      POST_KERNEL,							\
+			      PRE_KERNEL_1,							\
 			      CONFIG_RETAINED_MEM_INIT_PRIORITY,				\
 			      &zephyr_retained_mem_reg_api);
 

--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -415,7 +415,7 @@ finish:
 			      NULL,								\
 			      &retention_data_##inst,						\
 			      &retention_config_##inst,						\
-			      POST_KERNEL,							\
+			      PRE_KERNEL_1,							\
 			      CONFIG_RETENTION_INIT_PRIORITY,					\
 			      NULL);
 


### PR DESCRIPTION
Change the initialization priotity level from POST_KERNEL to PRE_KERNEL_1 for the retention subsystem and all retained_mem drivers.

Such change is requried for applications that require the information from the retention system very eraly during boot e.g. some data passed by bootloader.