### PR TITLE
boards: nrf54h20: Move extemem config

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
@@ -14,3 +14,40 @@
 
 /* Get a node label for wi-fi spi to use in shield files */
 wifi_spi: &spi130 {};
+
+&exmif {
+	pinctrl-0 = <&exmif_default>;
+	pinctrl-1 = <&exmif_sleep>;
+	pinctrl-names = "default", "sleep";
+	status = "disabled";
+
+	mx25uw63: mx25uw6345g@0 {
+		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		status = "disabled";
+		reg = <0>;
+		jedec-id = [c2 84 37];
+		sfdp-bfp = [e5 20 8a ff ff ff ff 03 00 ff 00 ff 00 ff 00 ff
+			    ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 10 d8
+			    00 ff 00 ff 87 79 01 00 84 12 00 c4 cc 04 67 46
+			    30 b0 30 b0 f4 bd d5 5c 00 00 00 ff 10 10 00 20
+			    00 00 00 00 00 00 7c 23 48 00 00 00 00 00 88 88];
+		sfdp-ff05 = [00 ee c0 69 72 72 71 71 00 d8 f7 f6 00 0a 00 00
+			     14 45 98 80];
+		sfdp-ff84 = [43 06 0f 00 21 dc ff ff];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <30000>;
+		reset-gpios = <&gpio6 12 GPIO_ACTIVE_LOW>;
+		t-reset-pulse = <10000>;
+		t-reset-recovery = <35000>;
+
+		mspi-max-frequency = <DT_FREQ_M(50)>;
+		mspi-io-mode = "MSPI_IO_MODE_OCTAL";
+		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
+		mspi-hardware-ce-num = <1>;
+		mspi-cpp-mode = "MSPI_CPP_MODE_0";
+		mspi-endian = "MSPI_BIG_ENDIAN";
+		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
+	};
+};

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -268,43 +268,6 @@ slot3_partition: &cpurad_slot1_partition {
 	status = "disabled";
 };
 
-&exmif {
-	pinctrl-0 = <&exmif_default>;
-	pinctrl-1 = <&exmif_sleep>;
-	pinctrl-names = "default", "sleep";
-	status = "disabled";
-
-	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
-		status = "disabled";
-		reg = <0>;
-		jedec-id = [c2 84 37];
-		sfdp-bfp = [e5 20 8a ff ff ff ff 03 00 ff 00 ff 00 ff 00 ff
-			    ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 10 d8
-			    00 ff 00 ff 87 79 01 00 84 12 00 c4 cc 04 67 46
-			    30 b0 30 b0 f4 bd d5 5c 00 00 00 ff 10 10 00 20
-			    00 00 00 00 00 00 7c 23 48 00 00 00 00 00 88 88];
-		sfdp-ff05 = [00 ee c0 69 72 72 71 71 00 d8 f7 f6 00 0a 00 00
-			     14 45 98 80];
-		sfdp-ff84 = [43 06 0f 00 21 dc ff ff];
-		size = <67108864>;
-		has-dpd;
-		t-enter-dpd = <10000>;
-		t-exit-dpd = <30000>;
-		reset-gpios = <&gpio6 12 GPIO_ACTIVE_LOW>;
-		t-reset-pulse = <10000>;
-		t-reset-recovery = <35000>;
-
-		mspi-max-frequency = <DT_FREQ_M(50)>;
-		mspi-io-mode = "MSPI_IO_MODE_OCTAL";
-		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
-		mspi-hardware-ce-num = <1>;
-		mspi-cpp-mode = "MSPI_CPP_MODE_0";
-		mspi-endian = "MSPI_BIG_ENDIAN";
-		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
-	};
-};
-
 &cpuapp_ieee802154 {
 	status = "okay";
 };


### PR DESCRIPTION
Move the external memory chip definition from the CPUAPP-specific to the common DTS.
The existence of the external chip is not APP-specific, but a characteristic of the DK itself.