### PR TITLE
soc: mcxw: Add Power management support on connectivity apps

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
@@ -76,3 +76,8 @@
 &rtc {
 	reg = <0x4002c000 0x50>;
 };
+
+&nbu {
+	rfmc-xo-cdac = <0x0c>;
+	rfmc-xo-isel = <0x05>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw72.dtsi
@@ -76,3 +76,8 @@
 &rtc {
 	reg = <0x4002c000 0x60>;
 };
+
+&nbu {
+	rfmc-xo-cdac = <0x0a>;
+	rfmc-xo-isel = <0x0b>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -46,13 +46,13 @@
 			sleep: sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				exit-latency-us = <10>;
+				exit-latency-us = <140>;
 			};
 
 			deep_sleep: deep-sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
-				exit-latency-us = <11>;
+				exit-latency-us = <140>;
 			};
 		};
 
@@ -364,6 +364,7 @@
 		compatible = "nxp,nbu";
 		interrupts = <48 2>;
 		interrupt-names = "nbu_rx_int";
+		wakeup-source;
 	};
 
 	hci: hci_ble {

--- a/dts/bindings/arm/nxp,nbu.yaml
+++ b/dts/bindings/arm/nxp,nbu.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP NBU interruption information
@@ -14,3 +14,12 @@ properties:
     default: "NBU NXP"
     type: string
     description: Name of the Narrow Band Unit interruption initialization
+  rfmc-xo-cdac:
+    type: int
+    description: |
+      XTAL CDAC trim value.
+      This value is usually used to fine-tune the 32MHz crystal oscillator frequency.
+  rfmc-xo-isel:
+    type: int
+    description: |
+      XTAL ISEL (Current Selection) value.

--- a/soc/nxp/common/nxp_nbu.c
+++ b/soc/nxp/common/nxp_nbu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,6 +27,15 @@
 #define NBU_WAKE_UP_IRQ_P DT_IRQ_BY_NAME(DT_DRV_INST(0), wakeup_int, priority)
 #endif
 
+/* Check if XTAL properties are set and get values */
+#if DT_INST_NODE_HAS_PROP(0, rfmc_xo_cdac)
+#define NBU_RFMC_XO_CDAC_VALUE DT_INST_PROP(0, rfmc_xo_cdac)
+#endif
+
+#if DT_INST_NODE_HAS_PROP(0, rfmc_xo_isel)
+#define NBU_RFMC_XO_ISEL_VALUE DT_INST_PROP(0, rfmc_xo_isel)
+#endif
+
 /* -------------------------------------------------------------------------- */
 /*                             Private prototypes                             */
 /* -------------------------------------------------------------------------- */
@@ -39,6 +48,24 @@ extern int32_t nbu_wakeup_done_handler(void);
 
 void nxp_nbu_init(void)
 {
+#if defined(NBU_RFMC_XO_CDAC_VALUE) || defined(NBU_RFMC_XO_ISEL_VALUE)
+	uint32_t rfmc_xo;
+
+	rfmc_xo = RFMC->XO_TEST;
+
+#if defined(NBU_RFMC_XO_CDAC_VALUE)
+	/* Apply a Trim value/ Current selection for the crystal oscillator */
+	rfmc_xo &= ~(RFMC_XO_TEST_CDAC_MASK);
+	rfmc_xo |= RFMC_XO_TEST_CDAC(NBU_RFMC_XO_CDAC_VALUE);
+#endif
+
+#if defined(NBU_RFMC_XO_ISEL_VALUE)
+	rfmc_xo &= ~(RFMC_XO_TEST_ISEL_MASK);
+	rfmc_xo |= RFMC_XO_TEST_ISEL(NBU_RFMC_XO_ISEL_VALUE);
+#endif
+
+	RFMC->XO_TEST = rfmc_xo;
+#endif
 	/* NBU interface Interrupt */
 	IRQ_CONNECT(NBU_RX_IRQ_N, NBU_RX_IRQ_P, nbu_handler, 0, 0);
 

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -12,6 +12,13 @@ config NUM_IRQS
 config MCUX_LPTMR_TIMER
 	default y if PM
 
+
+# LPTMR runs from a 32.768 kHz clock when PM is enabled. Using 1024 ticks/sec gives an exact
+# 32-cycle tick period (32768 / 1024), reducing jitter and keeping the timer
+# efficient in low‑power.
+config SYS_CLOCK_TICKS_PER_SEC
+	default 1024 if MCUX_LPTMR_TIMER
+
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
 DT_LPTMR_PATH := $(dt_nodelabel_path,lptmr0)
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -303,8 +303,39 @@ void soc_early_init_hook(void)
 
 	/* restore interrupt state */
 	irq_unlock(oldLevel);
+}
 
+static int soc_nbu_init(void)
+{
 #if defined(CONFIG_NXP_NBU)
 	nxp_nbu_init();
+#else
+	/* Shutdown NBU as not used */
+
+	/* Reset all RFMC registers and put the NBU CM3 in reset */
+	RFMC->CTRL |= RFMC_CTRL_RFMC_RST(0x1U);
+	/* Wait for a few microseconds before releasing the NBU reset,
+	 * without this the system may hang in the loop waiting for FRO clock valid
+	 */
+	k_busy_wait(31U);
+	/* Release NBU reset */
+	RFMC->CTRL &= ~RFMC_CTRL_RFMC_RST_MASK;
+
+	/* NBU was probably in low power before the RFMC reset, so we need to wait for the FRO clock
+	 * to be valid before accessing RF_CMC
+	 */
+	while ((RFMC->RF2P4GHZ_STAT & RFMC_RF2P4GHZ_STAT_FRO_CLK_VLD_STAT_MASK) == 0U) {
+		;
+	}
+
+	/* Force low power entry request to the radio domain */
+	RF_CMC1->RADIO_LP |= RF_CMC1_RADIO_LP_CK(0x2);
+	RFMC->RF2P4GHZ_CTRL |= RFMC_RF2P4GHZ_CTRL_LP_ENTER(0x1U);
 #endif
+	return 0;
 }
+
+/* soc_nbu_init may call k_busy_wait, which requires the system timer to be initialized
+ * (available by early PRE_KERNEL_2).
+ */
+SYS_INIT(soc_nbu_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 NXP
+ * Copyright 2023-2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,8 +14,8 @@
 #define nbu_handler RF_IMU0_IRQHandler
 
 #undef NXP_ENABLE_WAKEUP_SIGNAL
-void mcxw7xx_set_wakeup(int32_t sig);
-#define NXP_ENABLE_WAKEUP_SIGNAL(sig) mcxw7xx_set_wakeup(sig)
+void mcxw7xx_set_wakeup(int32_t irqn);
+#define NXP_ENABLE_WAKEUP_SIGNAL(irqn) mcxw7xx_set_wakeup(irqn)
 
 #if CONFIG_PM
 void nxp_mcxw7x_power_init(void);


### PR DESCRIPTION
- Update low power state exit latency to match SDK
- Enable NBU wakeup source
- Configure 32MHz crystal osc used by NBU
- Shutdown NBU when it's not used