### PR TITLE
drivers: modem: cellular: Allow defining reset GPIO behavior

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -3459,7 +3459,7 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
 						  (gnss_pipe, 3))                                  \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 0, 0, false,                                  \
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 5000, 0, false,                               \
 				       NULL,                                                       \
 				       &nordic_nrf91_slm_init_chat_script,                         \
 				       &nordic_nrf91_slm_dial_chat_script,                         \

--- a/dts/bindings/modem/nordic,nrf91-slm.yaml
+++ b/dts/bindings/modem/nordic,nrf91-slm.yaml
@@ -17,3 +17,6 @@ properties:
     description: |
       Modem automatically configures and connects the default PDP context (cid=0) when
       registered to the network. This is used by default in Serial Modem application.
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/nordic,nrf91-slm.yaml
+++ b/dts/bindings/modem/nordic,nrf91-slm.yaml
@@ -2,21 +2,11 @@ description: Nordic nRF91 series running the Serial LTE Modem application
 
 compatible: "nordic,nrf91-slm"
 
-include:
-  - name: zephyr,cellular-modem-device.yaml
-    property-blocklist:
-      - zephyr,use-default-pdp-ctx
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   zephyr,use-default-pdp-ctx:
-    type: int
-    enum:
-      - 0
-      - 1
     default: 1
-    description: |
-      Modem automatically configures and connects the default PDP context (cid=0) when
-      registered to the network. This is used by default in Serial Modem application.
 
   zephyr,mdm-reset-behavior:
     default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/quectel,bg95.yaml
+++ b/dts/bindings/modem/quectel,bg95.yaml
@@ -18,3 +18,6 @@ properties:
       automatically when supply voltage is applied—that is, the modem
       asserts PWRKEY internally and does not require an external PWRKEY
       pulse.
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/quectel,bg96.yaml
+++ b/dts/bindings/modem/quectel,bg96.yaml
@@ -5,7 +5,7 @@ description: quectel BG96 modem
 
 compatible: "quectel,bg96"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:
@@ -21,3 +21,6 @@ properties:
       automatically when supply voltage is applied—that is, the modem
       asserts PWRKEY internally and does not require an external PWRKEY
       pulse.
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/quectel,eg25-g.yaml
+++ b/dts/bindings/modem/quectel,eg25-g.yaml
@@ -14,3 +14,6 @@ properties:
 
   mdm-wdisable-gpios:
     type: phandle-array
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/quectel,eg800q.yaml
+++ b/dts/bindings/modem/quectel,eg800q.yaml
@@ -8,3 +8,6 @@ properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/sqn,gm02s.yaml
+++ b/dts/bindings/modem/sqn,gm02s.yaml
@@ -11,3 +11,6 @@ properties:
   mdm-reset-gpios:
     type: phandle-array
     required: true
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_resume", "toggle_on_recovery"]

--- a/dts/bindings/modem/swir,hl7800.yaml
+++ b/dts/bindings/modem/swir,hl7800.yaml
@@ -45,3 +45,6 @@ properties:
   mdm-gpio6-gpios:
     type: phandle-array
     required: true
+
+  zephyr,mdm-reset-behavior:
+    default: ["hold_on_suspend", "toggle_on_resume", "toggle_on_recovery"]

--- a/dts/bindings/modem/u-blox,lara-r6.yaml
+++ b/dts/bindings/modem/u-blox,lara-r6.yaml
@@ -11,3 +11,6 @@ properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/u-blox,sara-r4.yaml
+++ b/dts/bindings/modem/u-blox,sara-r4.yaml
@@ -14,3 +14,6 @@ properties:
 
   mdm-vint-gpios:
     type: phandle-array
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/u-blox,sara-r5.yaml
+++ b/dts/bindings/modem/u-blox,sara-r5.yaml
@@ -6,3 +6,7 @@ description: u-blox SARA-R5 modem
 compatible: "u-blox,sara-r5"
 
 include: zephyr,cellular-modem-device.yaml
+
+properties:
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -31,3 +31,6 @@ properties:
   mdm-send-ok-gpios:
     type: phandle-array
     description: UART RTS pin if no HW flow control (set to always enabled)
+
+  zephyr,mdm-reset-behavior:
+    default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/zephyr,cellular-modem-device.yaml
+++ b/dts/bindings/modem/zephyr,cellular-modem-device.yaml
@@ -14,6 +14,22 @@ properties:
     type: phandle-array
     description: GPIO for modem reset
 
+  zephyr,mdm-reset-behavior:
+    type: string-array
+    enum:
+      - "hold_on_suspend"
+      - "toggle_on_resume"
+      - "toggle_on_recovery"
+    description: |
+      Behavior of modem reset GPIOs. Supported values are:
+      - hold_on_suspend: Hold the reset GPIOs asserted (logical high) when the modem is suspended.
+                         Release the reset GPIOs (logical low) when the modem is resumed from idle.
+      - toggle_on_resume: Toggle the modem reset GPIOs during resume from suspend.
+      - toggle_on_recovery: Toggle the modem reset GPIOs when a modem recovery is triggered,
+                            for example when modem fails to respond to initialization AT commands.
+
+      Multiple behaviors can be specified as a string array.
+
   mdm-wake-gpios:
     type: phandle-array
     description: GPIO for modem wake

--- a/dts/bindings/modem/zephyr,cellular-modem-device.yaml
+++ b/dts/bindings/modem/zephyr,cellular-modem-device.yaml
@@ -70,7 +70,6 @@ properties:
     enum:
       - 0
       - 1
-    default: 0
     description: |
       Modem automatically configures and connects the default PDP context (cid=0) when
       registered to the network.
@@ -84,7 +83,6 @@ properties:
     enum:
       - 0
       - 1
-    default: 0
     description: |
       Modem automatically configures the APN name when registering to the network.
       If this is set to 1, the modem driver will supply empty string as APN name when


### PR DESCRIPTION
Some modems enter a power-up sequence if reset line is held active, so we need a way to alter the GPIO behavior.

Define a "zephyr,mdm-reset-behavior" enum in device tree to allow choosing one, or all of the supported behavior

* hold_on_suspend
* toggle_on_resume
* toggle_on_recovery

By default, all of the behaviors are enabled, so it matches the previous implementation.