### PR TITLE
driver: intc: hazard3: fix interrupt being enabled too early

### DIFF
--- a/drivers/interrupt_controller/intc_hazard3.c
+++ b/drivers/interrupt_controller/intc_hazard3.c
@@ -44,8 +44,6 @@ static int hazard3_irq_init(const struct device *dev)
 	/* Global external IRQ enable. */
 	csr_write(mie, RVCSR_MIE_MEIE_BITS);
 
-	csr_set(mstatus, MSTATUS_IEN);
-
 	return 0;
 }
 


### PR DESCRIPTION
`hazard3_irq_init` enables `mstatus:MSTATUS_IEN` too early, which allows ISRs, specifically machine timer ISR, to run before `_kernel.cpus[0].irq_stack` is initialized in `prepare_multithreading()` / `z_init_cpu()`.

This can result in interrupt being handled with uninitialized IRQ stack, causing system to crash.

Fixes #103766