### PR TITLE
drivers: serial: stm32: avoid C23 extension for declaration after label

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1282,6 +1282,7 @@ static void uart_stm32_dma_rx_flush(const struct device *dev, int status)
 	struct dma_status stat;
 	struct uart_stm32_data *data = dev->data;
 	size_t rx_rcv_len = 0;
+	uint32_t half_pos;
 
 	switch (status) {
 	case DMA_STATUS_COMPLETE:
@@ -1297,7 +1298,7 @@ static void uart_stm32_dma_rx_flush(const struct device *dev, int status)
 		break;
 	case DMA_STATUS_BLOCK:
 		/* half complete */
-		uint32_t half_pos = data->dma_rx.buffer_length / 2;
+		half_pos = data->dma_rx.buffer_length / 2;
 
 		/* Already handled by timeout path has already dealt with this data.
 		 * Return immediately.


### PR DESCRIPTION
Move the declaration of half_pos out of the switch case to avoid
relying on C23 extensions. In C standards prior to C23, a declaration
cannot immediately follow a label, which causes build failures in 
environments enforcing strict standard compliance.

Signed-off-by: Rob Barnes <robbarnes@google.com>
