### PR TITLE
drivers: fix clock path bug in infineon clock drivers

### DIFF
--- a/drivers/clock_control/clock_control_infineon_fixed_factor_clock.c
+++ b/drivers/clock_control/clock_control_infineon_fixed_factor_clock.c
@@ -89,9 +89,7 @@ static int fixed_factor_clk_init(const struct device *dev)
 		 */
 		Cy_SysClk_ClkHfSetDivider(IFX_PSOC4_HFCLK_DIV(config->divider));
 #else
-		uint32_t source_instance = 0;
-
-		err = Cy_SysClk_ClkHfSetSource(config->instance, source_instance);
+		err = Cy_SysClk_ClkHfSetSource(config->instance, config->source_path);
 		if (err != CY_SYSCLK_SUCCESS) {
 			return -EIO;
 		}


### PR DESCRIPTION
- fix automatic set to path 0 in infineon clock driver