### PR TITLE
manifest: update hal_nordic revision and IronSide SE support code

### DIFF
--- a/modules/hal_nordic/ironside/se/CMakeLists.txt
+++ b/modules/hal_nordic/ironside/se/CMakeLists.txt
@@ -18,6 +18,7 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 zephyr_library_sources_ifdef(CONFIG_IRONSIDE_SE_CALL
   ${IRONSIDE_SUPPORT_DIR}/se/src/ironside_se_api.c
   call.c
+  glue.c
 )
 zephyr_library_sources_ifdef(CONFIG_IRONSIDE_SE_DVFS dvfs.c)
 
@@ -26,6 +27,12 @@ if(CONFIG_NRF_PERIPHCONF_SECTION)
 endif()
 
 if(CONFIG_NRF_PERIPHCONF_GENERATE_ENTRIES)
+  set(optional_args)
+  if(CONFIG_NRF_PERIPHCONF_GENERATE_ENTRIES_LOCK)
+    list(APPEND optional_args --lock)
+  else()
+    list(APPEND optional_args --no-lock)
+  endif()
   set(periphconf_entries_c_file ${PROJECT_BINARY_DIR}/periphconf_entries_generated.c)
   execute_process(
     COMMAND
@@ -34,6 +41,7 @@ if(CONFIG_NRF_PERIPHCONF_GENERATE_ENTRIES)
       --soc ${CONFIG_SOC}
       --in-edt-pickle ${EDT_PICKLE}
       --out-periphconf-source ${periphconf_entries_c_file}
+      ${optional_args}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     COMMAND_ERROR_IS_FATAL ANY
   )

--- a/modules/hal_nordic/ironside/se/Kconfig
+++ b/modules/hal_nordic/ironside/se/Kconfig
@@ -55,12 +55,23 @@ menuconfig NRF_PERIPHCONF_SECTION
 	  Include static global domain peripheral initialization values from the
 	  build in a dedicated section in the devnull region.
 
+if NRF_PERIPHCONF_SECTION
+
 config NRF_PERIPHCONF_GENERATE_ENTRIES
 	bool "Generate PERIPHCONF entries source file"
 	default y
-	depends on NRF_PERIPHCONF_SECTION
 	help
 	  Generate a C file containing PERIPHCONF entries based on the
 	  device configuration in the devicetree.
+
+config NRF_PERIPHCONF_GENERATE_ENTRIES_LOCK
+	bool "Lock registers in PERIPHCONF"
+	default y
+	depends on NRF_PERIPHCONF_GENERATE_ENTRIES
+	help
+	  Set the lock bit in registers that support it.
+	  Disable this to allow the registers to be reconfigured after boot.
+
+endif # NRF_PERIPHCONF_SECTION
 
 endmenu # IronSide SE

--- a/modules/hal_nordic/ironside/se/glue.c
+++ b/modules/hal_nordic/ironside/se/glue.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ironside/se/glue.h>
+#include <zephyr/cache.h>
+
+void ironside_se_data_cache_writeback(void *addr, size_t size)
+{
+	sys_cache_data_flush_range(addr, size);
+}
+
+void ironside_se_data_cache_invalidate(void *addr, size_t size)
+{
+	sys_cache_data_invd_range(addr, size);
+}
+
+void ironside_se_data_cache_writeback_invalidate(void *addr, size_t size)
+{
+	sys_cache_data_flush_and_invd_range(addr, size);
+}

--- a/modules/hal_nordic/ironside/se/scripts/gen_periphconf_entries.py
+++ b/modules/hal_nordic/ironside/se/scripts/gen_periphconf_entries.py
@@ -127,6 +127,12 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--lock",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Value to set for the lock bit in registers that support it.",
+    )
+    parser.add_argument(
         "--in-edt-pickle",
         type=argparse.FileType("rb"),
         required=True,
@@ -146,7 +152,7 @@ def main() -> None:
     dt = pickle.load(args.in_edt_pickle)
     processor = dt_processor_id(dt)
     lookup_tables = lookup_tables_get(Soc.soc(args.soc), Family.family(args.soc))
-    builder = PeriphconfBuilder(dt, lookup_tables)
+    builder = PeriphconfBuilder(dt, lookup_tables, lock_value=args.lock)
 
     # Application local peripherals
     if processor == ProcessorId.APPLICATION:

--- a/modules/hal_nordic/ironside/se/scripts/periphconf/builder.py
+++ b/modules/hal_nordic/ironside/se/scripts/periphconf/builder.py
@@ -98,17 +98,20 @@ class PeriphconfBuilder:
         self,
         dt: EDT,
         lookup_tables: SocLookupTables,
+        lock_value: bool = True,
     ) -> None:
         """Builder class used to generate a PERIPHCONF C source file based on the devicetree.
 
         :param dt: Devicetree object.
         :param lookup_tables: Lookup table object containing soc-specific information.
+        :param lock_value: Lock bit value to set in the registers that support it.
         """
 
         self._dt = dt
         self._hw_tables = lookup_tables
         self._processor_id = dt_processor_id(dt)
         self._owner_id = self._processor_id.default_owner_id
+        self._lock_value = lock_value
 
         self._macros = []
         self._ipcmap_idx = 0
@@ -277,6 +280,7 @@ class PeriphconfBuilder:
                     secure,
                     dma_secure,
                     self._owner_id.c_enum,
+                    self._lock_value,
                 ],
                 comment=f"{spu_name}: {periph_label} permissions",
             )
@@ -346,6 +350,7 @@ class PeriphconfBuilder:
                         num,
                         secure,
                         self._owner_id.c_enum,
+                        self._lock_value,
                     ],
                     comment=f"{spu_name}: {instance_name} ch. {num} permissions",
                 )
@@ -376,6 +381,7 @@ class PeriphconfBuilder:
                         num,
                         secure,
                         self._owner_id.c_enum,
+                        self._lock_value,
                     ],
                     comment=f"{spu_name}: {instance_name} ch. {num} permissions",
                 )
@@ -390,6 +396,7 @@ class PeriphconfBuilder:
                         num,
                         secure,
                         self._owner_id.c_enum,
+                        self._lock_value,
                     ],
                     comment=f"{spu_name}: {instance_name} ch. group {num} permissions",
                 )
@@ -439,6 +446,7 @@ class PeriphconfBuilder:
                 [
                     Address(sub_ppib_addr),
                     sub_ppib_ch,
+                    True,
                 ],
                 comment=(
                     f"SUB: {sub_ppib_name} ch. {sub_ppib_ch} => {pub_ppib_name} ch. {pub_ppib_ch}"
@@ -451,6 +459,7 @@ class PeriphconfBuilder:
                 [
                     Address(pub_ppib_addr),
                     pub_ppib_ch,
+                    True,
                 ],
                 comment=(
                     f"PUB: {sub_ppib_name} ch. {sub_ppib_ch} => {pub_ppib_name} ch. {pub_ppib_ch}"
@@ -476,6 +485,7 @@ class PeriphconfBuilder:
                         num,
                         secure,
                         self._owner_id.c_enum,
+                        self._lock_value,
                     ],
                     comment=f"{spu_name}: {instance_name} ch. {num} permissions",
                 )
@@ -537,7 +547,7 @@ class PeriphconfBuilder:
         self._macros.append(
             MacroCall(
                 "PERIPHCONF_IPCMAP_CHANNEL_SOURCE",
-                [self._ipcmap_idx, source_domain.c_enum, source_ch],
+                [self._ipcmap_idx, source_domain.c_enum, source_ch, True],
                 comment=(
                     f"{source_domain.name} IPCT ch. {source_ch} => "
                     f"{sink_domain.name} IPCT ch. {sink_ch}"
@@ -573,6 +583,7 @@ class PeriphconfBuilder:
                         num,
                         secure,
                         self._owner_id.c_enum,
+                        self._lock_value,
                     ],
                     comment=f"{spu_name}: GRTC CC{num} permissions",
                 )
@@ -696,6 +707,7 @@ class PeriphconfBuilder:
                     num,
                     secure,
                     self._owner_id.c_enum,
+                    self._lock_value,
                 ],
                 comment=f"{spu_name}: P{gpio_port}.{num} permissions",
             )

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 63f2083ff9bc9c39b39f0a874becc7cf8e011a2a
+      revision: 5c1df3fe9bc144e558b3506cef6cf33652bb2539
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Pull in updated IronSide SE supporting code and adapt the Zephyr integration layers:

* Implement the glue function interfaces for doing data cache operations, which are needed for some of the IronSide SE APIs.

* Add an option to the PERIPHCONF entry generator for not locking SPU registers. This will be used to enable reconfiguration of the SPU registers using an IPC call after their initial configuration at boot.