### PR TITLE
cmake: compiler: add -Wint-in-bool-context flag to compiler warnings

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -54,6 +54,7 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_1
                             -Wmissing-prototypes
                             -Wmissing-include-dirs
                             -Wunused-but-set-variable
+                            -Wint-in-bool-context
                             -Wno-missing-field-initializers
 )
 

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -49,6 +49,7 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_1
                             -Wmissing-prototypes
                             -Wmissing-include-dirs
                             -Wunused-but-set-variable
+                            -Wint-in-bool-context
                             -Wno-missing-field-initializers
 )
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -61,6 +61,7 @@ set_compiler_property(PROPERTY warning_dw_1
 )
 check_set_compiler_property(APPEND PROPERTY warning_dw_1
                             -Wlogical-op
+                            -Wint-in-bool-context
                             -Wno-missing-field-initializers
 )
 


### PR DESCRIPTION
Add -Wint-in-bool-context to warning_dw_1 for gcc, clang, and arcmwdt toolchains.
This warning catches suspicious integer expressions used in boolean context:

> Warn for suspicious use of integer values where boolean values are expected, such as conditional expressions (?:) using non-boolean integer constants in boolean context, like if (a <= b ? 2 : 3). Or left shifting of signed integers in boolean context, like for (a = 0; 1 << a; a++);. Likewise for all kinds of multiplications regardless of the data type.


https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wint-in-bool-context