### PR TITLE
usb: device_next: validate CDC ECM/NCM remote-mac-address format

### DIFF
--- a/dts/bindings/ethernet/zephyr,cdc-ecm-ethernet.yaml
+++ b/dts/bindings/ethernet/zephyr,cdc-ecm-ethernet.yaml
@@ -12,5 +12,19 @@ properties:
     type: string
     required: true
     description: |
-      Remote MAC address of the virtual Ethernet connection.
-      Should not be the same as local-mac-address property.
+      Remote MAC address of the virtual Ethernet connection encoded as
+      a string of 12 uppercase hexadecimal characters. Do not use
+      colons, dashes, or other separators. Per the USB CDC ECM
+      specification (section 5.4), this string is sent as-is in the
+      string descriptor referenced by the iMACAddress descriptor index
+      to the USB host. Should not be the same as local-mac-address
+      property.
+
+examples:
+  - |
+    / {
+      cdc-ecm {
+        compatible = "zephyr,cdc-ecm-ethernet";
+        remote-mac-address = "00005E005301";
+      };
+    };

--- a/dts/bindings/ethernet/zephyr,cdc-ncm-ethernet.yaml
+++ b/dts/bindings/ethernet/zephyr,cdc-ncm-ethernet.yaml
@@ -12,5 +12,19 @@ properties:
     type: string
     required: true
     description: |
-      Remote MAC address of the virtual Ethernet connection.
-      Should not be the same as local-mac-address property.
+      Remote MAC address of the virtual Ethernet connection encoded as
+      a string of 12 uppercase hexadecimal characters. Do not use
+      colons, dashes, or other separators. Per the USB CDC ECM
+      specification (section 5.4), this string is sent as-is in the
+      string descriptor referenced by the iMACAddress descriptor index
+      to the USB host. Should not be the same as local-mac-address
+      property.
+
+examples:
+  - |
+    / {
+      cdc-ncm {
+        compatible = "zephyr,cdc-ncm-ethernet";
+        remote-mac-address = "00005E005301";
+      };
+    };

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -101,6 +101,17 @@ extern "C" {
  */
 #define IS_BIT_SET(value, bit) ((((value) >> (bit)) & (0x1)) != 0)
 
+/**
+ * @brief Check if @p c is an uppercase hexadecimal character.
+ *
+ * Evaluates to true if @p c is in the range '0'-'9' or 'A'-'F'.
+ * Does not match lowercase 'a'-'f'.
+ *
+ * @param c Character to check
+ */
+#define IS_UPPERCASE_HEX(c) \
+	(((c) >= '0' && (c) <= '9') || ((c) >= 'A' && (c) <= 'F'))
+
 /** @brief Extract the Least Significant Bit from @p value. */
 #define LSB_GET(value) ((value) & -(value))
 

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -814,7 +814,21 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 		(struct usb_desc_header *) &cdc_ecm_desc_##n.nil_desc,		\
 	}
 
+#define BUILD_ASSERT_IMAC(str)							\
+	BUILD_ASSERT(sizeof(str) == 13,						\
+		     "remote-mac-address must be exactly 12 hex characters"	\
+		     " (e.g. \"00005E005301\"), without colons or separators");	\
+	BUILD_ASSERT(								\
+		IS_UPPERCASE_HEX((str)[0])  && IS_UPPERCASE_HEX((str)[1])  &&	\
+		IS_UPPERCASE_HEX((str)[2])  && IS_UPPERCASE_HEX((str)[3])  &&	\
+		IS_UPPERCASE_HEX((str)[4])  && IS_UPPERCASE_HEX((str)[5])  &&	\
+		IS_UPPERCASE_HEX((str)[6])  && IS_UPPERCASE_HEX((str)[7])  &&	\
+		IS_UPPERCASE_HEX((str)[8])  && IS_UPPERCASE_HEX((str)[9])  &&	\
+		IS_UPPERCASE_HEX((str)[10]) && IS_UPPERCASE_HEX((str)[11]),	\
+		"remote-mac-address must contain only hex characters (0-9, A-F)")
+
 #define USBD_CDC_ECM_DT_DEVICE_DEFINE(n)					\
+	BUILD_ASSERT_IMAC(DT_INST_PROP(n, remote_mac_address));			\
 	CDC_ECM_DEFINE_DESCRIPTOR(n);						\
 	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
 				DT_INST_PROP(n, remote_mac_address),		\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1374,7 +1374,21 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 	(struct usb_desc_header *) &cdc_ncm_desc_##n.nil_desc,			\
 }
 
+#define BUILD_ASSERT_IMAC(str)							\
+	BUILD_ASSERT(sizeof(str) == 13,						\
+		     "remote-mac-address must be exactly 12 hex characters"	\
+		     " (e.g. \"00005E005301\"), without colons or separators");	\
+	BUILD_ASSERT(								\
+		IS_UPPERCASE_HEX((str)[0])  && IS_UPPERCASE_HEX((str)[1])  &&	\
+		IS_UPPERCASE_HEX((str)[2])  && IS_UPPERCASE_HEX((str)[3])  &&	\
+		IS_UPPERCASE_HEX((str)[4])  && IS_UPPERCASE_HEX((str)[5])  &&	\
+		IS_UPPERCASE_HEX((str)[6])  && IS_UPPERCASE_HEX((str)[7])  &&	\
+		IS_UPPERCASE_HEX((str)[8])  && IS_UPPERCASE_HEX((str)[9])  &&	\
+		IS_UPPERCASE_HEX((str)[10]) && IS_UPPERCASE_HEX((str)[11]),	\
+		"remote-mac-address must contain only hex characters (0-9, A-F)")
+
 #define USBD_CDC_NCM_DT_DEVICE_DEFINE(n)					\
+	BUILD_ASSERT_IMAC(DT_INST_PROP(n, remote_mac_address));			\
 	CDC_NCM_DEFINE_DESCRIPTOR(n);						\
 	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
 				DT_INST_PROP(n, remote_mac_address),		\


### PR DESCRIPTION
While developing a Zephyr CDC-ECM application, I ran into strange reliability/negotiation failures with MacOS and traced it down (in part) to the fact that I had used colon delimited format for remote-mac-address which seemed intuitive to me at the time. This caused weird and difficult to debug negotiation failures between my Zephyr app and MacOS.

This PR is created to update documentation and add compile-time validation so that others don't suffer my fate.

Please review and if this looks acceptable, I will run the test pass and then update the status of this PR with any changes needed and test pass completion.

## Summary

- Add compile-time `BUILD_ASSERT` to catch `remote-mac-address` strings that aren't exactly 12 characters (e.g. colon-separated `"00:00:5E:00:53:01"` has `sizeof == 19`)
- Add compile-time hex-digit validation via `IS_HEX` / `BUILD_ASSERT_IMAC` macros — catches non-hex characters and lowercase at build time
- Update DTS binding descriptions to document the required format

## Context

The `iMACAddress` string descriptor in the USB CDC ECM specification (section 5.4) must be exactly 12 uppercase hexadecimal characters. The `remote-mac-address` DTS property value is passed as-is into this descriptor, but there was no validation — a colon-separated MAC like `"00:00:5E:00:53:01"` compiled without error but silently causes host enumeration failures on macOS and Linux.

## Compliance

`check_compliance.py` was run against this commit. All ClangFormat warnings on changed lines of code were addressed. Remaining ClangFormat warnings are in pre-existing macro formatting (tab-aligned `\` continuations vs space-aligned) that predates this change and were not modified.

## Test plan

- [ ] Build a CDC ECM sample with the correct format (`"00005E005301"`) — compiles cleanly
- [ ] Change overlay to `"00:00:5E:00:53:01"` — sizeof `BUILD_ASSERT` fires at compile time
- [ ] Change overlay to `"00005e005301"` — hex character `BUILD_ASSERT` fires at compile time
- [ ] Change overlay to `"ZZZZZZZZZZZZ"` — hex character `BUILD_ASSERT` fires at compile time
- [ ] `tests/subsys/usb/device_next/` build_all test still passes