### PR TITLE
driver: Fix Stale Read in STM32 SPI Half-Duplex Master RX Mode

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -792,6 +792,9 @@ static void spi_stm32_complete(const struct device *dev, int status)
 				ll_func_disable_spi(spi);
 			}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+			if (LL_SPI_HALF_DUPLEX_RX == LL_SPI_GetTransferDirection(spi)) {
+				ll_func_disable_spi(spi);
+			}
 		}
 
 		spi_stm32_cs_control(dev, false);


### PR DESCRIPTION
SPI STM32 Driver: Fix Infinite Loop Hang in Half-Duplex Master RX Mode

In half-duplex SPI transfers on STM32, subsequent transfers read stale.

- The SPI STM32 driver enters an infinite while loop in function spi_stm32_complete() when operating in half-duplex master mode, specifically when receiving (RX).
- The loop waits for the SPI peripheral to be disabled , but in half-duplex master RX transfers, the SPI is not properly disabled, causing the loop condition to remain true indefinitely and the driver to hang.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103725