### PR TITLE
w1: serial: support configurable baud rate for Overdrive mode

### DIFF
--- a/doc/hardware/peripherals/w1.rst
+++ b/doc/hardware/peripherals/w1.rst
@@ -69,6 +69,15 @@ Related configuration options:
 * :kconfig:option:`CONFIG_W1_NET`
 
 
+W1 Serial Driver
+****************
+
+The ``zephyr,w1-serial`` driver implements the 1-Wire interface using a UART
+peripheral. Individual 1-Wire bits are encoded as bytes sent over the UART.
+For standard speed, it uses 115200 Baud for data and 9600 Baud for
+reset/presence detection. For overdrive speed, it uses configurable baud rates
+with a default of 1000000 Baud for data and 115200 Baud for reset/presence.
+
 API Reference
 *************
 

--- a/drivers/w1/w1_zephyr_serial.c
+++ b/drivers/w1/w1_zephyr_serial.c
@@ -27,32 +27,33 @@
 
 LOG_MODULE_REGISTER(w1_serial, CONFIG_W1_LOG_LEVEL);
 
-#define W1_SERIAL_READ_REQ_BYTE   0xFF
-#define W1_SERIAL_BIT_1           0xFF
-#define W1_SERIAL_BIT_0           0x00
+#define W1_SERIAL_READ_REQ_BYTE 0xFF
+#define W1_SERIAL_BIT_1         0xFF
+#define W1_SERIAL_BIT_0         0x00
 
 /* Standard speed signal parameters:
  * RST: t_RSTL=520us; t_slot=1041us
  * DATA: t_low1=8.68us; t_low0=78.1us; t_slot=86.8us
  */
-#define W1_SERIAL_STD_RESET_BYTE   0xF0
-#define W1_SERIAL_STD_RESET_BAUD   9600u
-#define W1_SERIAL_STD_DATA_BAUD    115200u
+#define W1_SERIAL_STD_RESET_BYTE 0xF0
+#define W1_SERIAL_STD_RESET_BAUD 9600u
+#define W1_SERIAL_STD_DATA_BAUD  115200u
 
 /*
  * Overdrive speed signal parameters:
- * RST: t_RSTL=52.1us; t_slot=86.8us
- * DATA: t_low1=1.0us; t_low0=9.0us; t_slot=10.0us
+ * Unlike standard speed, RST and DATA timing defined in Devicetree
  */
-#define W1_SERIAL_OD_RESET_BYTE    0xE0
-#define W1_SERIAL_OD_RESET_BAUD    115200u
-#define W1_SERIAL_OD_DATA_BAUD     1000000u
+#define W1_SERIAL_OD_RESET_BYTE 0xE0
 
 struct w1_serial_config {
 	/** w1 master config, common to all drivers */
 	struct w1_master_config master_config;
 	/** UART device used for 1-Wire communication */
 	const struct device *uart_dev;
+	/** Baud rate for overdrive speed data communication */
+	uint32_t od_data_baud;
+	/** Baud rate for overdrive speed reset/presence detection */
+	uint32_t od_reset_baud;
 };
 
 struct w1_serial_data {
@@ -66,8 +67,8 @@ struct w1_serial_data {
  * Concurrently transmits and receives one 1-Wire bit
  * by sending and receiving one uart byte
  */
-static int serial_tx_rx(const struct device *dev, const uint8_t *tx_data,
-			uint8_t *rx_data, size_t len, uint32_t timeout)
+static int serial_tx_rx(const struct device *dev, const uint8_t *tx_data, uint8_t *rx_data,
+			size_t len, uint32_t timeout)
 {
 	const struct w1_serial_config *cfg = dev->config;
 	k_timepoint_t end;
@@ -94,24 +95,23 @@ static int serial_tx_rx(const struct device *dev, const uint8_t *tx_data,
 }
 
 /* Concurretly tranmits and receives one 1-Wire byte */
-static int serial_tx_rx_byte(const struct device *dev, uint8_t tx_byte,
-			     uint8_t *rx_byte)
+static int serial_tx_rx_byte(const struct device *dev, uint8_t tx_byte, uint8_t *rx_byte)
 {
 	__ASSERT_NO_MSG(rx_byte != NULL);
 	uint8_t byte_representation[8];
 
 	for (int i = 0; i < 8; ++i) {
 		/*
-		 * Transmitting 0xFF the uart start bit pulls the line low to
-		 * indicate either write Bit 1, or read low time.
-		 * Write Bit 0 is represented as 0x00
+		 * The uart start bit pulls the line low to indicate either
+		 * write Bit 1, or read low time.
+		 * Bit representations vary by speed mode.
 		 */
 		byte_representation[i] =
 			((tx_byte & (1 << i)) != 0) ? W1_SERIAL_BIT_1 : W1_SERIAL_BIT_0;
 	}
 
-	if (serial_tx_rx(dev, &byte_representation[0], &byte_representation[0],
-			 8, CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) < 0) {
+	if (serial_tx_rx(dev, &byte_representation[0], &byte_representation[0], 8,
+			 CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) < 0) {
 		return -EIO;
 	}
 
@@ -139,8 +139,8 @@ static int w1_serial_reset_bus(const struct device *dev)
 	 */
 	const uint32_t reset_timeout = CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT * 12;
 
-	data->uart_cfg.baudrate = data->overdrive_active ?
-			W1_SERIAL_OD_RESET_BAUD : W1_SERIAL_STD_RESET_BAUD;
+	data->uart_cfg.baudrate =
+		data->overdrive_active ? cfg->od_reset_baud : W1_SERIAL_STD_RESET_BAUD;
 	if (uart_configure(cfg->uart_dev, &data->uart_cfg) != 0) {
 		LOG_ERR("Failed set baud rate for reset pulse");
 		return -EIO;
@@ -151,8 +151,8 @@ static int w1_serial_reset_bus(const struct device *dev)
 		return -EIO;
 	}
 
-	data->uart_cfg.baudrate = data->overdrive_active ?
-			W1_SERIAL_OD_DATA_BAUD : W1_SERIAL_STD_DATA_BAUD;
+	data->uart_cfg.baudrate =
+		data->overdrive_active ? cfg->od_data_baud : W1_SERIAL_STD_DATA_BAUD;
 	if (uart_configure(cfg->uart_dev, &data->uart_cfg) != 0) {
 		LOG_ERR("Failed set baud rate for data transfer");
 		return -EIO;
@@ -170,8 +170,7 @@ static int w1_serial_read_bit(const struct device *dev)
 	uint8_t tx_bit = W1_SERIAL_READ_REQ_BYTE;
 	uint8_t rx_bit;
 
-	if (serial_tx_rx(dev, &tx_bit, &rx_bit, 1,
-			 CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) != 0) {
+	if (serial_tx_rx(dev, &tx_bit, &rx_bit, 1, CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) != 0) {
 		return -EIO;
 	};
 
@@ -184,8 +183,8 @@ static int w1_serial_write_bit(const struct device *dev, const bool bit)
 	uint8_t rx_bit;
 
 	tx_bit = bit ? W1_SERIAL_BIT_1 : W1_SERIAL_BIT_0;
-	if (serial_tx_rx(dev, &tx_bit, &rx_bit, 1,
-			 CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) != 0) {
+
+	if (serial_tx_rx(dev, &tx_bit, &rx_bit, 1, CONFIG_W1_ZEPHYR_SERIAL_BIT_TIMEOUT) != 0) {
 		return -EIO;
 	}
 	return 0;
@@ -210,8 +209,7 @@ static int w1_serial_write_byte(const struct device *dev, const uint8_t byte)
 	return serial_tx_rx_byte(dev, byte, &rx_byte);
 }
 
-static int w1_serial_configure(const struct device *dev,
-			       enum w1_settings_type type, uint32_t value)
+static int w1_serial_configure(const struct device *dev, enum w1_settings_type type, uint32_t value)
 {
 	const struct w1_serial_config *cfg = dev->config;
 	struct w1_serial_data *data = dev->data;
@@ -226,8 +224,8 @@ static int w1_serial_configure(const struct device *dev,
 		}
 
 		data->overdrive_active = temp;
-		data->uart_cfg.baudrate = data->overdrive_active ?
-				W1_SERIAL_OD_DATA_BAUD : W1_SERIAL_STD_DATA_BAUD;
+		data->uart_cfg.baudrate =
+			data->overdrive_active ? cfg->od_data_baud : W1_SERIAL_STD_DATA_BAUD;
 		if (uart_configure(cfg->uart_dev, &data->uart_cfg) != 0) {
 			LOG_ERR("Failed set baud rate for data transfer");
 			ret = -EIO;
@@ -262,8 +260,7 @@ static int w1_serial_init(const struct device *dev)
 
 	data->overdrive_active = false;
 
-	LOG_DBG("w1-serial initialized, with %d slave devices",
-		cfg->master_config.slave_count);
+	LOG_DBG("w1-serial initialized, with %d slave devices", cfg->master_config.slave_count);
 	return 0;
 }
 
@@ -276,14 +273,16 @@ static DEVICE_API(w1, w1_serial_driver_api) = {
 	.configure = w1_serial_configure,
 };
 
-#define W1_ZEPHYR_SERIAL_INIT(inst)					   \
-static const struct w1_serial_config w1_serial_cfg_##inst = {		   \
-	.uart_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),			   \
-	.master_config.slave_count = W1_INST_SLAVE_COUNT(inst)		   \
-};									   \
-static struct w1_serial_data w1_serial_data_##inst = {};		   \
-DEVICE_DT_INST_DEFINE(inst, &w1_serial_init, NULL, &w1_serial_data_##inst, \
-		      &w1_serial_cfg_##inst, POST_KERNEL,		   \
-		      CONFIG_W1_INIT_PRIORITY, &w1_serial_driver_api);	   \
+#define W1_ZEPHYR_SERIAL_INIT(inst)                                                                \
+	static const struct w1_serial_config w1_serial_cfg_##inst = {                              \
+		.uart_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),                                      \
+		.master_config.slave_count = W1_INST_SLAVE_COUNT(inst),                            \
+		.od_data_baud = DT_INST_PROP(inst, overdrive_data_baud),                           \
+		.od_reset_baud = DT_INST_PROP(inst, overdrive_reset_baud),                         \
+	};                                                                                         \
+	static struct w1_serial_data w1_serial_data_##inst = {};                                   \
+	DEVICE_DT_INST_DEFINE(inst, &w1_serial_init, NULL, &w1_serial_data_##inst,                 \
+			      &w1_serial_cfg_##inst, POST_KERNEL, CONFIG_W1_INIT_PRIORITY,         \
+			      &w1_serial_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(W1_ZEPHYR_SERIAL_INIT)

--- a/dts/bindings/w1/zephyr,w1-serial.yaml
+++ b/dts/bindings/w1/zephyr,w1-serial.yaml
@@ -13,3 +13,44 @@ description: 1-Wire master over Zephyr uart
 compatible: "zephyr,w1-serial"
 
 include: [uart-device.yaml, w1-master.yaml]
+
+properties:
+  overdrive-data-baud:
+    type: int
+    default: 1000000
+    description: |
+      Baud rate for overdrive speed data communication. The default value of
+      1000000 provides timing of t_low1=1.0us, t_low0=9.0us, t_slot=10.0us.
+
+  overdrive-reset-baud:
+    type: int
+    default: 115200
+    description: |
+      Baud rate for overdrive speed reset/presence detection. The default value
+      of 115200 provides timing of t_RSTL=52.1us, t_slot=86.8us.
+
+examples:
+  - |
+    /* Basic Example */
+    &uart1 {
+        status = "okay";
+        current-speed = <115200>;
+
+        w1_bus: w1-bus {
+            compatible = "zephyr,w1-serial";
+            status = "okay";
+        };
+    };
+  - |
+    /* Custom Overdrive settings Example */
+    &uart1 {
+        status = "okay";
+        current-speed = <115200>;
+
+        w1_bus: w1-bus {
+            compatible = "zephyr,w1-serial";
+            status = "okay";
+            overdrive-data-baud = <921600>;
+            overdrive-reset-baud = <115200>;
+        };
+    };


### PR DESCRIPTION
Modifies 1-wire serial driver to accept configurable baud rates for Overdrive mode.

In testing with DS2488, which are Overdrive-only, it was found that both the baud rate and zero bit pattern needed to be adjusted for stability. This commit allows the user to define their own baud rates for OD mode, and modifies the zero bit in OD mode.

It is assumed that most testing has been done with standard-speed devices, so the timings and bit patterns have not been changed or made user-modifiable for Standard speed.