### PR TITLE
sensors: bmi270: Added bmi270 node for CY8CKIT-062S2-AI

### DIFF
--- a/boards/infineon/cy8ckit_062s2_ai/cy8ckit_062s2_ai.dts
+++ b/boards/infineon/cy8ckit_062s2_ai/cy8ckit_062s2_ai.dts
@@ -25,6 +25,7 @@
 		sw0 = &user_bt;
 		watchdog0 = &watchdog0;
 		pressure-sensor = &dps368;
+		accel0 = &bmi270;
 	};
 
 	leds {
@@ -122,6 +123,12 @@ i2c0: &scb0 {
 		compatible = "infineon,dps368", "infineon,dps310";
 		status = "okay";
 		reg = <0x77>;
+	};
+
+	bmi270: bmi270@68 {
+		compatible = "bosch,bmi270";
+		status = "okay";
+		reg = <0x68>;
 	};
 };
 


### PR DESCRIPTION
Enable BMI270 in DTS for Infineon CY8CKIT-062S2-AI kit.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103782