### PR TITLE
drivers: i2c: stm32: rename slave terminology to target

### DIFF
--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -367,7 +367,7 @@ static int i2c_stm32_init(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	/*
 	 * Force i2c reset for STM32F1 series.
-	 * So that they can enter master mode properly.
+	 * So that they can enter controller mode properly.
 	 * Issue described in ES096 2.14.7
 	 */
 	I2C_TypeDef *i2c = cfg->i2c;

--- a/drivers/i2c/i2c_stm32.c
+++ b/drivers/i2c/i2c_stm32.c
@@ -142,7 +142,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 #define OPERATION(msg) (((struct i2c_msg *) msg)->flags & I2C_MSG_RW_MASK)
 
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
-			      uint8_t num_msgs, uint16_t slave)
+			      uint8_t num_msgs, uint16_t target)
 {
 	struct i2c_stm32_data *data = dev->data;
 	struct i2c_msg *current;
@@ -208,7 +208,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 			next = current + 1;
 			next_msg_flags = &(next->flags);
 		}
-		ret = i2c_stm32_transaction(dev, *current, next_msg_flags, slave);
+		ret = i2c_stm32_transaction(dev, *current, next_msg_flags, target);
 		if (ret < 0) {
 			break;
 		}

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -130,7 +130,7 @@ struct i2c_stm32_data {
 #endif /* CONFIG_I2C_RTIO */
 
 #ifdef CONFIG_I2C_TARGET
-	bool master_active;
+	bool controller_active;
 	bool target_attached;
 	struct i2c_target_config *target_cfg;
 #ifdef CONFIG_I2C_STM32_V2

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -83,7 +83,7 @@ struct i2c_stm32_data {
 #ifdef CONFIG_I2C_STM32_V1
 	size_t msg_len;
 	uint8_t is_restart;
-	uint16_t slave_address;
+	uint16_t target_address;
 #else
 	uint8_t burst_flags;
 	uint8_t burst_len;
@@ -99,7 +99,7 @@ struct i2c_stm32_data {
 	struct i2c_config_timing current_timing;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2) */
 #ifdef CONFIG_I2C_STM32_V1
-	uint16_t slave_address;
+	uint16_t target_address;
 #endif /* CONFIG_I2C_STM32_V1 */
 	struct {
 #ifdef CONFIG_I2C_STM32_V1
@@ -131,10 +131,10 @@ struct i2c_stm32_data {
 
 #ifdef CONFIG_I2C_TARGET
 	bool master_active;
-	bool slave_attached;
-	struct i2c_target_config *slave_cfg;
+	bool target_attached;
+	struct i2c_target_config *target_cfg;
 #ifdef CONFIG_I2C_STM32_V2
-	struct i2c_target_config *slave2_cfg;
+	struct i2c_target_config *target2_cfg;
 #endif /* CONFIG_I2C_STM32_V2 */
 #endif /* CONFIG_I2C_TARGET */
 };

--- a/drivers/i2c/i2c_stm32_rtio.c
+++ b/drivers/i2c/i2c_stm32_rtio.c
@@ -252,7 +252,7 @@ static int i2c_stm32_init(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	/*
 	 * Force i2c reset for STM32F1 series.
-	 * So that they can enter master mode properly.
+	 * So that they can enter controller mode properly.
 	 * Issue described in ES096 2.14.7
 	 */
 	I2C_TypeDef *i2c = cfg->i2c;

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -130,7 +130,7 @@ static void i2c_stm32_master_finish(const struct device *dev)
 
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = false;
-	if (!data->slave_attached && !data->smbalert_active) {
+	if (!data->target_attached && !data->smbalert_active) {
 		LL_I2C_Disable(i2c);
 	} else {
 		i2c_stm32_enable_transfer_interrupts(dev);
@@ -144,7 +144,7 @@ static void i2c_stm32_master_finish(const struct device *dev)
 }
 
 static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
-			    uint8_t *next_msg_flags, uint16_t slave,
+			    uint8_t *next_msg_flags, uint16_t target,
 			    uint32_t transfer)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -169,7 +169,7 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = true;
 #endif
-	data->slave_address = slave;
+	data->target_address = target;
 
 	LL_I2C_Enable(i2c);
 
@@ -233,12 +233,12 @@ static inline void handle_sb(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	uint16_t saddr = data->slave_address;
-	uint8_t slave;
+	uint16_t saddr = data->target_address;
+	uint8_t target;
 
 	if (I2C_ADDR_10_BITS & data->dev_config) {
-		slave = (((saddr & 0x0300) >> 7) & 0xFF);
-		uint8_t header = slave | HEADER;
+		target = (((saddr & 0x0300) >> 7) & 0xFF);
+		uint8_t header = target | HEADER;
 
 		if (data->current.is_restart == 0U) {
 			data->current.is_restart = 1U;
@@ -250,11 +250,11 @@ static inline void handle_sb(const struct device *dev)
 
 		return;
 	}
-	slave = (saddr << 1) & 0xFF;
+	target = (saddr << 1) & 0xFF;
 	if (data->current.is_write) {
-		LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_WRITE);
+		LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_WRITE);
 	} else {
-		LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_READ);
+		LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_READ);
 		if (data->current.len == 2) {
 			LL_I2C_EnableBitPOS(i2c);
 		}
@@ -434,24 +434,24 @@ static inline void handle_btf(const struct device *dev)
 
 
 #if defined(CONFIG_I2C_TARGET)
-static void i2c_stm32_slave_event(const struct device *dev)
+static void i2c_stm32_target_event(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
-	const struct i2c_target_callbacks *slave_cb =
-		data->slave_cfg->callbacks;
+	const struct i2c_target_callbacks *target_cb =
+		data->target_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXE(i2c) && LL_I2C_IsActiveFlag_BTF(i2c)) {
 		uint8_t val;
-		slave_cb->read_processed(data->slave_cfg, &val);
+		target_cb->read_processed(data->target_cfg, &val);
 		LL_I2C_TransmitData8(i2c, val);
 		return;
 	}
 
 	if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
 		uint8_t val = LL_I2C_ReceiveData8(i2c);
-		if (slave_cb->write_received(data->slave_cfg, val)) {
+		if (target_cb->write_received(data->target_cfg, val)) {
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 		}
 		return;
@@ -463,7 +463,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_STOP(i2c)) {
 		LL_I2C_ClearFlag_STOP(i2c);
-		slave_cb->stop(data->slave_cfg);
+		target_cb->stop(data->target_cfg);
 		/* Prepare to ACK next transmissions address byte */
 		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
 	}
@@ -471,11 +471,11 @@ static void i2c_stm32_slave_event(const struct device *dev)
 	if (LL_I2C_IsActiveFlag_ADDR(i2c)) {
 		uint32_t dir = LL_I2C_GetTransferDirection(i2c);
 		if (dir == LL_I2C_DIRECTION_READ) {
-			slave_cb->write_requested(data->slave_cfg);
+			target_cb->write_requested(data->target_cfg);
 			LL_I2C_EnableIT_RX(i2c);
 		} else {
 			uint8_t val;
-			slave_cb->read_requested(data->slave_cfg, &val);
+			target_cb->read_requested(data->target_cfg, &val);
 			LL_I2C_TransmitData8(i2c, val);
 			LL_I2C_EnableIT_TX(i2c);
 		}
@@ -484,7 +484,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 	}
 }
 
-/* Attach and start I2C as slave */
+/* Attach and start I2C as target */
 int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config *config)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -497,7 +497,7 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EINVAL;
 	}
 
-	if (data->slave_attached) {
+	if (data->target_attached) {
 		return -EBUSY;
 	}
 
@@ -513,15 +513,15 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return ret;
 	}
 
-	data->slave_cfg = config;
+	data->target_cfg = config;
 
 	LL_I2C_Enable(i2c);
 
-	if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+	if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 		return -ENOTSUP;
 	}
 	LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
-	data->slave_attached = true;
+	data->target_attached = true;
 
 	LOG_DBG("i2c: target registered");
 
@@ -537,7 +537,7 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return -EINVAL;
 	}
 
@@ -555,9 +555,9 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 		LL_I2C_Disable(i2c);
 	}
 
-	data->slave_attached = false;
+	data->target_attached = false;
 
-	LOG_DBG("i2c: slave unregistered");
+	LOG_DBG("i2c: target unregistered");
 
 	return 0;
 }
@@ -570,8 +570,8 @@ void i2c_stm32_event(const struct device *dev)
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
-		i2c_stm32_slave_event(dev);
+	if (data->target_attached && !data->master_active) {
+		i2c_stm32_target_event(dev);
 		return;
 	}
 #endif
@@ -579,7 +579,7 @@ void i2c_stm32_event(const struct device *dev)
 	if (LL_I2C_IsActiveFlag_SB(i2c)) {
 		handle_sb(dev);
 	} else if (LL_I2C_IsActiveFlag_ADD10(i2c)) {
-		LL_I2C_TransmitData8(i2c, data->slave_address);
+		LL_I2C_TransmitData8(i2c, data->target_address);
 	} else if (LL_I2C_IsActiveFlag_ADDR(i2c)) {
 		handle_addr(dev);
 	} else if (LL_I2C_IsActiveFlag_BTF(i2c)) {
@@ -600,9 +600,9 @@ int i2c_stm32_error(const struct device *dev)
 #if defined(CONFIG_I2C_TARGET)
 	i2c_target_error_cb_t error_cb = NULL;
 
-	if (data->slave_attached && !data->master_active &&
-	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
-		error_cb = data->slave_cfg->callbacks->error;
+	if (data->target_attached && !data->master_active &&
+	    data->target_cfg != NULL && data->target_cfg->callbacks != NULL) {
+		error_cb = data->target_cfg->callbacks->error;
 	}
 #endif
 
@@ -612,7 +612,7 @@ int i2c_stm32_error(const struct device *dev)
 		data->current.is_nack = 1U;
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto end;
@@ -622,7 +622,7 @@ int i2c_stm32_error(const struct device *dev)
 		data->current.is_arlo = 1U;
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+			error_cb(data->target_cfg, I2C_ERROR_ARBITRATION);
 		}
 #endif
 		goto end;
@@ -633,7 +633,7 @@ int i2c_stm32_error(const struct device *dev)
 		data->current.is_err = 1U;
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto end;
@@ -643,7 +643,7 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_ClearFlag_OVR(i2c);
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto end;
@@ -661,7 +661,7 @@ int i2c_stm32_error(const struct device *dev)
 	return 0;
 end:
 #if defined(CONFIG_I2C_TARGET)
-	if (!data->slave_attached || data->master_active) {
+	if (!data->target_attached || data->master_active) {
 		i2c_stm32_master_mode_end(dev);
 	}
 #else
@@ -787,8 +787,8 @@ static int32_t i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg
 		}
 
 		if (I2C_ADDR_10_BITS & data->dev_config) {
-			uint8_t slave = (((saddr & 0x0300) >> 7) & 0xFF);
-			uint8_t header = slave | HEADER;
+			uint8_t target = (((saddr & 0x0300) >> 7) & 0xFF);
+			uint8_t header = target | HEADER;
 
 			LL_I2C_TransmitData8(i2c, header);
 			timeout = I2C_STM32_TIMEOUT_USEC;
@@ -800,12 +800,12 @@ static int32_t i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg
 				}
 			}
 
-			slave = data->slave_address & 0xFF;
-			LL_I2C_TransmitData8(i2c, slave);
+			target = data->target_address & 0xFF;
+			LL_I2C_TransmitData8(i2c, target);
 		} else {
-			uint8_t slave = (saddr << 1) & 0xFF;
+			uint8_t target = (saddr << 1) & 0xFF;
 
-			LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_WRITE);
+			LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_WRITE);
 		}
 
 		timeout = I2C_STM32_TIMEOUT_USEC;
@@ -885,8 +885,8 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 		}
 
 		if (I2C_ADDR_10_BITS & data->dev_config) {
-			uint8_t slave = (((saddr & 0x0300) >> 7) & 0xFF);
-			uint8_t header = slave | HEADER;
+			uint8_t target = (((saddr & 0x0300) >> 7) & 0xFF);
+			uint8_t header = target | HEADER;
 
 			LL_I2C_TransmitData8(i2c, header);
 			timeout = I2C_STM32_TIMEOUT_USEC;
@@ -898,8 +898,8 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 				}
 			}
 
-			slave = saddr & 0xFF;
-			LL_I2C_TransmitData8(i2c, slave);
+			target = saddr & 0xFF;
+			LL_I2C_TransmitData8(i2c, target);
 			timeout = I2C_STM32_TIMEOUT_USEC;
 			while (!LL_I2C_IsActiveFlag_ADDR(i2c)) {
 				if (i2c_stm32_wait_timeout(&timeout)) {
@@ -923,9 +923,9 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 			header |= I2C_REQUEST_READ;
 			LL_I2C_TransmitData8(i2c, header);
 		} else {
-			uint8_t slave = ((saddr) << 1) & 0xFF;
+			uint8_t target = ((saddr) << 1) & 0xFF;
 
-			LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_READ);
+			LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_READ);
 		}
 
 		timeout = I2C_STM32_TIMEOUT_USEC;
@@ -938,7 +938,7 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 			}
 		}
 		/* ADDR must be cleared before NACK generation. Either in 2 byte reception
-		 * byte 1 will be NACK'ed and slave won't sent the last byte
+		 * byte 1 will be NACK'ed and target won't sent the last byte
 		 */
 		LL_I2C_ClearFlag_ADDR(i2c);
 		if (len == 1U) {

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -75,7 +75,7 @@ static void i2c_stm32_master_mode_end(const struct device *dev, int status)
 
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = false;
-	if (data->slave_attached) {
+	if (data->target_attached) {
 		i2c_stm32_enable_transfer_interrupts(dev);
 		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
 		return;
@@ -94,29 +94,29 @@ static void handle_sb(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	uint16_t saddr = data->slave_address;
-	uint8_t slave;
+	uint16_t saddr = data->target_address;
+	uint8_t target;
 
 	if ((data->xfer_flags & I2C_MSG_ADDR_10_BITS) != 0) {
-		slave = ((saddr & 0x0300) >> 7) & 0xFF;
-		slave |= HEADER;
+		target = ((saddr & 0x0300) >> 7) & 0xFF;
+		target |= HEADER;
 
 		if (data->is_restart == 0U) {
 			data->is_restart = 1U;
 		} else {
-			slave |= I2C_REQUEST_READ;
+			target |= I2C_REQUEST_READ;
 			data->is_restart = 0U;
 		}
-		LL_I2C_TransmitData8(i2c, slave);
+		LL_I2C_TransmitData8(i2c, target);
 	} else {
-		slave = (saddr << 1) & 0xFF;
+		target = (saddr << 1) & 0xFF;
 		if ((data->xfer_flags & I2C_MSG_READ) != 0) {
-			LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_READ);
+			LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_READ);
 			if (data->xfer_len == 2) {
 				LL_I2C_EnableBitPOS(i2c);
 			}
 		} else {
-			LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_WRITE);
+			LL_I2C_TransmitData8(i2c, target | I2C_REQUEST_WRITE);
 		}
 	}
 }
@@ -294,12 +294,12 @@ static void i2c_stm32_target_event(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_target_callbacks *target_cb =
-		data->slave_cfg->callbacks;
+		data->target_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXE(i2c) && LL_I2C_IsActiveFlag_BTF(i2c)) {
 		uint8_t val;
 
-		target_cb->read_processed(data->slave_cfg, &val);
+		target_cb->read_processed(data->target_cfg, &val);
 		LL_I2C_TransmitData8(i2c, val);
 		return;
 	}
@@ -307,7 +307,7 @@ static void i2c_stm32_target_event(const struct device *dev)
 	if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
 		uint8_t val = LL_I2C_ReceiveData8(i2c);
 
-		if (target_cb->write_received(data->slave_cfg, val)) {
+		if (target_cb->write_received(data->target_cfg, val)) {
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 		}
 		return;
@@ -319,7 +319,7 @@ static void i2c_stm32_target_event(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_STOP(i2c)) {
 		LL_I2C_ClearFlag_STOP(i2c);
-		target_cb->stop(data->slave_cfg);
+		target_cb->stop(data->target_cfg);
 		/* Prepare to ACK next transmissions address byte */
 		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
 	}
@@ -328,12 +328,12 @@ static void i2c_stm32_target_event(const struct device *dev)
 		uint32_t dir = LL_I2C_GetTransferDirection(i2c);
 
 		if (dir == LL_I2C_DIRECTION_READ) {
-			target_cb->write_requested(data->slave_cfg);
+			target_cb->write_requested(data->target_cfg);
 			LL_I2C_EnableIT_RX(i2c);
 		} else {
 			uint8_t val;
 
-			target_cb->read_requested(data->slave_cfg, &val);
+			target_cb->read_requested(data->target_cfg, &val);
 			LL_I2C_TransmitData8(i2c, val);
 			LL_I2C_EnableIT_TX(i2c);
 		}
@@ -355,7 +355,7 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return -EINVAL;
 	}
 
-	if (data->slave_attached) {
+	if (data->target_attached) {
 		return -EBUSY;
 	}
 
@@ -371,15 +371,15 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 		return ret;
 	}
 
-	data->slave_cfg = config;
+	data->target_cfg = config;
 
 	LL_I2C_Enable(i2c);
 
-	if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+	if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 		return -ENOTSUP;
 	}
 	LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
-	data->slave_attached = true;
+	data->target_attached = true;
 
 	LOG_DBG("i2c: target registered");
 
@@ -395,7 +395,7 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return -EINVAL;
 	}
 
@@ -410,7 +410,7 @@ int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_conf
 	LL_I2C_ClearFlag_ADDR(i2c);
 	LL_I2C_Disable(i2c);
 
-	data->slave_attached = false;
+	data->target_attached = false;
 
 	LOG_DBG("i2c: target unregistered");
 
@@ -425,7 +425,7 @@ void i2c_stm32_event(const struct device *dev)
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
+	if (data->target_attached && !data->master_active) {
 		i2c_stm32_target_event(dev);
 		return;
 	}
@@ -434,7 +434,7 @@ void i2c_stm32_event(const struct device *dev)
 	if (LL_I2C_IsActiveFlag_SB(i2c)) {
 		handle_sb(dev);
 	} else if (LL_I2C_IsActiveFlag_ADD10(i2c)) {
-		LL_I2C_TransmitData8(i2c, data->slave_address);
+		LL_I2C_TransmitData8(i2c, data->target_address);
 	} else if (LL_I2C_IsActiveFlag_ADDR(i2c)) {
 		handle_addr(dev);
 	} else if (LL_I2C_IsActiveFlag_BTF(i2c)) {
@@ -455,9 +455,9 @@ int i2c_stm32_error(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	i2c_target_error_cb_t error_cb = NULL;
 
-	if (data->slave_attached && !data->master_active &&
-	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
-		error_cb = data->slave_cfg->callbacks->error;
+	if (data->target_attached && !data->master_active &&
+	    data->target_cfg != NULL && data->target_cfg->callbacks != NULL) {
+		error_cb = data->target_cfg->callbacks->error;
 	}
 #endif
 
@@ -466,7 +466,7 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_GenerateStopCondition(i2c);
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto error;
@@ -475,7 +475,7 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_ClearFlag_ARLO(i2c);
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+			error_cb(data->target_cfg, I2C_ERROR_ARBITRATION);
 		}
 #endif
 		goto error;
@@ -485,7 +485,7 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_ClearFlag_BERR(i2c);
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto error;
@@ -494,7 +494,7 @@ int i2c_stm32_error(const struct device *dev)
 	return 0;
 error:
 #if defined(CONFIG_I2C_TARGET)
-	if (!data->slave_attached || data->master_active) {
+	if (!data->target_attached || data->master_active) {
 		i2c_stm32_master_mode_end(dev, -EIO);
 	}
 #else
@@ -516,7 +516,7 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 	data->xfer_flags = flags;
 	data->msg_len = buf_len;
 	data->is_restart = 0;
-	data->slave_address = i2c_addr;
+	data->target_address = i2c_addr;
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = true;
 #endif

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -229,57 +229,57 @@ static void i2c_stm32_disable_transfer_interrupts(const struct device *dev)
 }
 
 #if defined(CONFIG_I2C_TARGET)
-static void i2c_stm32_slave_event(const struct device *dev)
+static void i2c_stm32_target_event(const struct device *dev)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
-	const struct i2c_target_callbacks *slave_cb;
-	struct i2c_target_config *slave_cfg = NULL;
+	const struct i2c_target_callbacks *target_cb;
+	struct i2c_target_config *target_cfg = NULL;
 
-	if (data->slave_cfg != NULL) {
+	if (data->target_cfg != NULL) {
 		/**
-		 * Slave1 is configured and could be in 7- or 10-bit mode.
-		 * If 10-bit mode is enabled, Slave2 cannot be in use because
+		 * Target1 is configured and could be in 7- or 10-bit mode.
+		 * If 10-bit mode is enabled, Target2 cannot be in use because
 		 * it only supports 7-bit mode, so we know which cfg is matched.
 		 * If 7-bit mode is enabled, find the correct cfg based on
 		 * the I2C address sent by bus master.
 		 */
-		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
-			slave_cfg = data->slave_cfg;
+		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+			target_cfg = data->target_cfg;
 		} else {
-			uint8_t slave_address;
+			uint8_t target_address;
 
 			/* Choose the right target from the address match code */
-			slave_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
-			if (slave_address == data->slave_cfg->address) {
-				slave_cfg = data->slave_cfg;
-			} else if (data->slave2_cfg != NULL &&
-				   slave_address == data->slave2_cfg->address) {
-				slave_cfg = data->slave2_cfg;
+			target_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
+			if (target_address == data->target_cfg->address) {
+				target_cfg = data->target_cfg;
+			} else if (data->target2_cfg != NULL &&
+				   target_address == data->target2_cfg->address) {
+				target_cfg = data->target2_cfg;
 			}
 		}
 	} else {
 		/**
-		 * If we received an event but Slave1 is not configured,
-		 * then Slave2 should be the target for the event.
+		 * If we received an event but Target1 is not configured,
+		 * then Target2 should be the target for the event.
 		 */
-		slave_cfg = data->slave2_cfg;
+		target_cfg = data->target2_cfg;
 	}
 
-	if (slave_cfg == NULL) {
+	if (target_cfg == NULL) {
 		__ASSERT_NO_MSG(0);
 		return;
 	}
 
-	slave_cb = slave_cfg->callbacks;
+	target_cb = target_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
 		uint8_t val = 0x00;
-		int ret = slave_cb->read_processed(slave_cfg, &val);
+		int ret = target_cb->read_processed(target_cfg, &val);
 
 		/* We should transmit the data before logging because logging could
-		 * lead the i2c slave to stretch the clock if the data are not
+		 * lead the i2c target to stretch the clock if the data are not
 		 * transmitted fast enough.
 		 */
 		LL_I2C_TransmitData8(i2c, val);
@@ -293,7 +293,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 	if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
 		uint8_t val = LL_I2C_ReceiveData8(i2c);
 
-		if (slave_cb->write_received(slave_cfg, val)) {
+		if (target_cb->write_received(target_cfg, val)) {
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 		}
 		return;
@@ -311,7 +311,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 
 		LL_I2C_ClearFlag_STOP(i2c);
 
-		slave_cb->stop(slave_cfg);
+		target_cb->stop(target_cfg);
 
 		/* Prepare to ACK next transmissions address byte */
 		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
@@ -324,7 +324,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 
 		dir = LL_I2C_GetTransferDirection(i2c);
 		if (dir == LL_I2C_DIRECTION_WRITE) {
-			if (slave_cb->write_requested(slave_cfg) < 0) {
+			if (target_cb->write_requested(target_cfg) < 0) {
 				LOG_ERR("Error initiating writing");
 			} else {
 				LL_I2C_EnableIT_RX(i2c);
@@ -332,7 +332,7 @@ static void i2c_stm32_slave_event(const struct device *dev)
 		} else {
 			uint8_t val;
 
-			if (slave_cb->read_requested(slave_cfg, &val) < 0) {
+			if (target_cb->read_requested(target_cfg, &val) < 0) {
 				LOG_ERR("Error initiating reading");
 			} else {
 				LL_I2C_TransmitData8(i2c, val);
@@ -361,7 +361,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (data->slave_cfg && data->slave2_cfg) {
+	if (data->target_cfg && data->target2_cfg) {
 		return -EBUSY;
 	}
 
@@ -390,9 +390,9 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	LL_I2C_Enable(i2c);
 
-	if (!data->slave_cfg) {
-		data->slave_cfg = config;
-		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+	if (!data->target_cfg) {
+		data->target_cfg = config;
+		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
 			LOG_DBG("i2c: target #1 registered with 10-bit address");
 		} else {
@@ -404,9 +404,9 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		data->slave2_cfg = config;
+		data->target2_cfg = config;
 
-		if (data->slave2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 			return -EINVAL;
 		}
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
@@ -415,7 +415,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: target #2 registered");
 	}
 
-	data->slave_attached = true;
+	data->target_attached = true;
 
 	LL_I2C_EnableIT_ADDR(i2c);
 
@@ -429,7 +429,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return -EINVAL;
 	}
 
@@ -437,23 +437,23 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		return -EBUSY;
 	}
 
-	if (config == data->slave_cfg) {
+	if (config == data->target_cfg) {
 		LL_I2C_DisableOwnAddress1(i2c);
-		data->slave_cfg = NULL;
+		data->target_cfg = NULL;
 
-		LOG_DBG("i2c: slave #1 unregistered");
-	} else if (config == data->slave2_cfg) {
+		LOG_DBG("i2c: target #1 unregistered");
+	} else if (config == data->target2_cfg) {
 		LL_I2C_DisableOwnAddress2(i2c);
-		data->slave2_cfg = NULL;
+		data->target2_cfg = NULL;
 
-		LOG_DBG("i2c: slave #2 unregistered");
+		LOG_DBG("i2c: target #2 unregistered");
 	} else {
 		return -EINVAL;
 	}
 
-	/* Return if there is a slave remaining */
-	if (data->slave_cfg || data->slave2_cfg) {
-		LOG_DBG("i2c: target#%c still registered", data->slave_cfg?'1':'2');
+	/* Return if there is a target remaining */
+	if (data->target_cfg || data->target2_cfg) {
+		LOG_DBG("i2c: target#%c still registered", data->target_cfg?'1':'2');
 		return 0;
 	}
 
@@ -480,7 +480,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	/* Release the device */
 	(void)pm_device_runtime_put(dev);
 
-	data->slave_attached = false;
+	data->target_attached = false;
 
 	return 0;
 }
@@ -494,8 +494,8 @@ void i2c_stm32_event(const struct device *dev)
 	uint32_t isr = stm32_reg_read(&regs->ISR);
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
-		i2c_stm32_slave_event(dev);
+	if (data->target_attached && !data->master_active) {
+		i2c_stm32_target_event(dev);
 		return;
 	}
 #endif
@@ -611,9 +611,9 @@ int i2c_stm32_error(const struct device *dev)
 #if defined(CONFIG_I2C_TARGET)
 	i2c_target_error_cb_t error_cb = NULL;
 
-	if (data->slave_attached && !data->master_active &&
-	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
-		error_cb = data->slave_cfg->callbacks->error;
+	if (data->target_attached && !data->master_active &&
+	    data->target_cfg != NULL && data->target_cfg->callbacks != NULL) {
+		error_cb = data->target_cfg->callbacks->error;
 	}
 #endif
 
@@ -622,7 +622,7 @@ int i2c_stm32_error(const struct device *dev)
 		data->current.is_arlo = 1U;
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+			error_cb(data->target_cfg, I2C_ERROR_ARBITRATION);
 		}
 #endif
 		goto end;
@@ -638,7 +638,7 @@ int i2c_stm32_error(const struct device *dev)
 		data->current.is_err = 1U;
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
 #endif
 		goto end;
@@ -657,7 +657,7 @@ int i2c_stm32_error(const struct device *dev)
 	return 0;
 end:
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
+	if (data->target_attached && !data->master_active) {
 		return -EIO;
 	}
 #endif
@@ -707,8 +707,8 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	if (!keep_enabled || (ret != 0)) {
 		data->master_active = false;
 	}
-	/* Don't disable I2C if a slave is attached */
-	if (data->slave_attached) {
+	/* Don't disable I2C if a target is attached */
+	if (data->target_attached) {
 		keep_enabled = true;
 	}
 #endif
@@ -727,7 +727,7 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 }
 
 static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
-			      uint8_t *next_msg_flags, uint16_t slave)
+			      uint8_t *next_msg_flags, uint16_t target)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
@@ -765,9 +765,9 @@ static int stm32_i2c_irq_xfer(const struct device *dev, struct i2c_msg *msg,
 		I2C_CR2_ADD10);
 
 	if ((I2C_ADDR_10_BITS & data->dev_config) != 0U) {
-		cr2 |= (uint32_t)slave | I2C_CR2_ADD10;
+		cr2 |= (uint32_t)target | I2C_CR2_ADD10;
 	} else {
-		cr2 |= (uint32_t)slave << 1;
+		cr2 |= (uint32_t)target << 1;
 	}
 
 	/* If this is not a stop message and more messages follow without change of direction,
@@ -894,7 +894,7 @@ error:
 }
 
 static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
-			    uint8_t *next_msg_flags, uint16_t slave,
+			    uint8_t *next_msg_flags, uint16_t target,
 			    uint32_t transfer)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -907,11 +907,11 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 		if (I2C_ADDR_10_BITS & data->dev_config) {
 			LL_I2C_SetMasterAddressingMode(i2c,
 					LL_I2C_ADDRESSING_MODE_10BIT);
-			LL_I2C_SetSlaveAddr(i2c, (uint32_t) slave);
+			LL_I2C_SetSlaveAddr(i2c, (uint32_t) target);
 		} else {
 			LL_I2C_SetMasterAddressingMode(i2c,
 				LL_I2C_ADDRESSING_MODE_7BIT);
-			LL_I2C_SetSlaveAddr(i2c, (uint32_t) slave << 1);
+			LL_I2C_SetSlaveAddr(i2c, (uint32_t) target << 1);
 		}
 
 		if (!(msg->flags & I2C_MSG_STOP) && next_msg_flags &&
@@ -968,7 +968,7 @@ static inline int msg_done(const struct device *dev,
 }
 
 static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
-			       uint8_t *next_msg_flags, uint16_t slave)
+			       uint8_t *next_msg_flags, uint16_t target)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
@@ -976,7 +976,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 	uint8_t *buf = msg->buf;
 	int64_t start_time = k_uptime_get();
 
-	msg_init(dev, msg, next_msg_flags, slave, LL_I2C_REQUEST_WRITE);
+	msg_init(dev, msg, next_msg_flags, target, LL_I2C_REQUEST_WRITE);
 
 	len = msg->len;
 	while (len) {
@@ -1004,7 +1004,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 }
 
 static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
-			      uint8_t *next_msg_flags, uint16_t slave)
+			      uint8_t *next_msg_flags, uint16_t target)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
@@ -1012,7 +1012,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	uint8_t *buf = msg->buf;
 	int64_t start_time = k_uptime_get();
 
-	msg_init(dev, msg, next_msg_flags, slave, LL_I2C_REQUEST_READ);
+	msg_init(dev, msg, next_msg_flags, target, LL_I2C_REQUEST_READ);
 
 	len = msg->len;
 	while (len) {
@@ -1407,7 +1407,7 @@ int i2c_stm32_transaction(const struct device *dev,
 		}
 #if defined(CONFIG_I2C_TARGET)
 		data->master_active = false;
-		if (!data->slave_attached && !data->smbalert_active) {
+		if (!data->target_attached && !data->smbalert_active) {
 			LL_I2C_Disable(i2c);
 		}
 #else

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -66,7 +66,7 @@ static void i2c_stm32_master_mode_end(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 
 	data->master_active = false;
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		LL_I2C_Disable(i2c);
 	}
 #else
@@ -84,35 +84,35 @@ static void i2c_stm32_target_event(const struct device *dev)
 	const struct i2c_target_callbacks *target_cb;
 	struct i2c_target_config *target_cfg = NULL;
 
-	if (data->slave_cfg != NULL) {
+	if (data->target_cfg != NULL) {
 		/**
-		 * Slave1 is configured and could be in 7- or 10-bit mode.
-		 * If 10-bit mode is enabled, Slave2 cannot be in use because
+		 * Target1 is configured and could be in 7- or 10-bit mode.
+		 * If 10-bit mode is enabled, Target2 cannot be in use because
 		 * it only supports 7-bit mode, so we know which cfg is matched.
 		 * If 7-bit mode is enabled, find the correct cfg based on
 		 * the I2C address sent by bus master.
 		 */
-		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
-			target_cfg = data->slave_cfg;
+		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS) {
+			target_cfg = data->target_cfg;
 		} else {
 			uint8_t target_address;
 
 			/* Choose the right target from the address match code */
 			target_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
-			if (target_address == data->slave_cfg->address) {
-				target_cfg = data->slave_cfg;
-			} else if (data->slave2_cfg != NULL &&
-				   target_address == data->slave2_cfg->address) {
-				target_cfg = data->slave2_cfg;
+			if (target_address == data->target_cfg->address) {
+				target_cfg = data->target_cfg;
+			} else if (data->target2_cfg != NULL &&
+				   target_address == data->target2_cfg->address) {
+				target_cfg = data->target2_cfg;
 			}
 		}
 
 	} else {
 		/**
-		 * If we received an event but Slave1 is not configured,
-		 * then Slave2 should be the target for the event.
+		 * If we received an event but Target1 is not configured,
+		 * then Target2 should be the target for the event.
 		 */
-		target_cfg = data->slave2_cfg;
+		target_cfg = data->target2_cfg;
 	}
 
 	if (target_cfg == NULL) {
@@ -206,7 +206,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (data->slave_cfg && data->slave2_cfg) {
+	if (data->target_cfg && data->target2_cfg) {
 		return -EBUSY;
 	}
 
@@ -235,9 +235,9 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	LL_I2C_Enable(i2c);
 
-	if (!data->slave_cfg) {
-		data->slave_cfg = config;
-		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+	if (!data->target_cfg) {
+		data->target_cfg = config;
+		if (data->target_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
 			LOG_DBG("i2c: target #1 registered with 10-bit address");
 		} else {
@@ -249,9 +249,9 @@ int i2c_stm32_target_register(const struct device *dev,
 
 		LOG_DBG("i2c: target #1 registered");
 	} else {
-		data->slave2_cfg = config;
+		data->target2_cfg = config;
 
-		if (data->slave2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+		if (data->target2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
 			return -EINVAL;
 		}
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
@@ -260,7 +260,7 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: target #2 registered");
 	}
 
-	data->slave_attached = true;
+	data->target_attached = true;
 
 	LL_I2C_EnableIT_ADDR(i2c);
 
@@ -274,7 +274,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (!data->slave_attached) {
+	if (!data->target_attached) {
 		return -EINVAL;
 	}
 
@@ -282,14 +282,14 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		return -EBUSY;
 	}
 
-	if (config == data->slave_cfg) {
+	if (config == data->target_cfg) {
 		LL_I2C_DisableOwnAddress1(i2c);
-		data->slave_cfg = NULL;
+		data->target_cfg = NULL;
 
 		LOG_DBG("i2c: target #1 unregistered");
-	} else if (config == data->slave2_cfg) {
+	} else if (config == data->target2_cfg) {
 		LL_I2C_DisableOwnAddress2(i2c);
-		data->slave2_cfg = NULL;
+		data->target2_cfg = NULL;
 
 		LOG_DBG("i2c: target #2 unregistered");
 	} else {
@@ -297,8 +297,8 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	}
 
 	/* Return if there is a target remaining */
-	if (data->slave_cfg || data->slave2_cfg) {
-		LOG_DBG("i2c: target#%c still registered", data->slave_cfg?'1':'2');
+	if (data->target_cfg || data->target2_cfg) {
+		LOG_DBG("i2c: target#%c still registered", data->target_cfg?'1':'2');
 		return 0;
 	}
 
@@ -323,7 +323,7 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	/* Release the device */
 	(void)pm_device_runtime_put(dev);
 
-	data->slave_attached = false;
+	data->target_attached = false;
 
 	return 0;
 }
@@ -366,7 +366,7 @@ void i2c_stm32_event(const struct device *dev)
 	int ret = 0;
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
+	if (data->target_attached && !data->master_active) {
 		i2c_stm32_target_event(dev);
 		return;
 	}
@@ -443,9 +443,9 @@ int i2c_stm32_error(const struct device *dev)
 #if defined(CONFIG_I2C_TARGET)
 	i2c_target_error_cb_t error_cb = NULL;
 
-	if (data->slave_attached && !data->master_active &&
-	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
-		error_cb = data->slave_cfg->callbacks->error;
+	if (data->target_attached && !data->master_active &&
+	    data->target_cfg != NULL && data->target_cfg->callbacks != NULL) {
+		error_cb = data->target_cfg->callbacks->error;
 	}
 #endif
 
@@ -453,14 +453,14 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_ClearFlag_ARLO(i2c);
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
-			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+			error_cb(data->target_cfg, I2C_ERROR_ARBITRATION);
 		}
 #endif
 		ret = -EIO;
 	}
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
+	if (data->target_attached && !data->master_active) {
 		return ret;
 	}
 #endif


### PR DESCRIPTION
This PR have 2 commits : 

Commit 1 : Rename internal variables, helpers and logs from "slave" to "target" in STM32 I2C drivers.
Commit 2 : Rename internal variables, helpers and logs from "master" to "controller" in STM32 I2C drivers.

No functional changes are intended.