### PR TITLE
drivers: i2c: sbcon: fix init when pinctrl applies successfully

### DIFF
--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -132,10 +132,10 @@ static int i2c_sbcon_init(const struct device *dev)
 	int ret;
 	ret = pinctrl_apply_state(config->pctrl, PINCTRL_STATE_DEFAULT);
 
-	/* some pins are not available externally so,
-	 * ignore if there is no entry for them
+	/* Some pins are not available externally so,
+	 * ignore if there is no pinctrl entry for them.
 	 */
-	if (ret != -ENOENT) {
+	if (ret < 0 && ret != -ENOENT) {
 		return ret;
 	}
 	i2c_bitbang_init(&context->bitbang, &io_fns, config->sbcon);


### PR DESCRIPTION
When pinctrl_apply_state() returns 0 (success), the previous condition (ret != -ENOENT) caused an early return, so i2c_bitbang_init() and i2c_bitbang_configure() were never run. Only -ENOENT (no pinctrl entry) should be ignored; real errors should still abort init.

Fix by returning only when ret < 0 && ret != -ENOENT.