### PR TITLE
drivers: wifi: nxp: fix WPA3 connection failure

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -629,21 +629,21 @@ static int nxp_wifi_start_ap(const struct device *dev, struct wifi_connect_req_p
 			strncpy(nxp_wlan_uap_network.security.psk, params->psk, params->psk_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE) {
 			nxp_wlan_uap_network.security.type = WLAN_SECURITY_WPA3_SAE;
-			nxp_wlan_uap_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_uap_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_uap_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_uap_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE_H2E) {
 			nxp_wlan_uap_network.security.type = WLAN_SECURITY_WPA3_SAE;
 			nxp_wlan_uap_network.security.pwe_derivation = 1;
-			nxp_wlan_uap_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_uap_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_uap_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_uap_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE_AUTO) {
 			nxp_wlan_uap_network.security.type = WLAN_SECURITY_WPA3_SAE;
 			nxp_wlan_uap_network.security.pwe_derivation = 2;
-			nxp_wlan_uap_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_uap_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_uap_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_uap_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
 			nxp_wlan_uap_network.security.type = WLAN_SECURITY_WPA2_WPA3_SAE_MIXED;
 			nxp_wlan_uap_network.security.psk_len = params->psk_length;
@@ -1060,21 +1060,21 @@ static int nxp_wifi_connect(const struct device *dev, struct wifi_connect_req_pa
 			strncpy(nxp_wlan_network.security.psk, params->psk, params->psk_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE) {
 			nxp_wlan_network.security.type = WLAN_SECURITY_WPA3_SAE;
-			nxp_wlan_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE_H2E) {
 			nxp_wlan_network.security.type = WLAN_SECURITY_WPA3_SAE;
 			nxp_wlan_network.security.pwe_derivation = 1;
-			nxp_wlan_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_SAE_AUTO) {
 			nxp_wlan_network.security.type = WLAN_SECURITY_WPA3_SAE;
 			nxp_wlan_network.security.pwe_derivation = 2;
-			nxp_wlan_network.security.password_len = params->psk_length;
-			strncpy(nxp_wlan_network.security.password, params->psk,
-				params->psk_length);
+			nxp_wlan_network.security.password_len = params->sae_password_length;
+			strncpy(nxp_wlan_network.security.password, params->sae_password,
+				params->sae_password_length);
 		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
 			nxp_wlan_network.security.type = WLAN_SECURITY_WPA2_WPA3_SAE_MIXED;
 			nxp_wlan_network.security.psk_len = params->psk_length;


### PR DESCRIPTION
For wifi embedded supplicant, use params->sae_password and params->sae_password_length for SAE/SAE-H2E/SAE-AUTO in nxp_wifi_connect and nxp_wifi_start_ap, as psk is NUll and psk_length is 0. This resolves WPA3-SAE auth failures.
Issue introduced by this PR: https://github.com/zephyrproject-rtos/zephyr/pull/103313