### PR TITLE
Add I2C driver support for PIC32CM JH family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,13 @@
 		group1 {
 			pinmux = <PB10D_SERCOM4_PAD2>,
 				 <PB11D_SERCOM4_PAD3>;
+		};
+	};
+
+	sercom1_i2c_default: sercom1_i2c_default {
+		group1 {
+			pinmux = <PA16C_SERCOM1_PAD0>,
+				 <PA17C_SERCOM1_PAD1>;
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cm_jh/pic32cm_jh01/pic32cm5164jh01100.dtsi>
 #include "pic32cm_jh01_cpro-pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -139,6 +140,16 @@
 	rxpo = <3>;
 	txpo = <1>;
 	pinctrl-0 = <&sercom4_uart_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&sercom1 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom1_i2c_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -12,6 +12,7 @@ ram: 64
 supported:
   - clock_control
   - gpio
+  - i2c
   - pinctrl
   - reset
   - uart

--- a/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
+++ b/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 title: Microchip SERCOM G1 I2C driver
@@ -7,7 +7,7 @@ description: |
   Microchip SERCOM I2C driver bindings.
 
   Group g1 SERCOM I2C driver supports following hardware peripherals:
-    - module name="SERCOM" id="U2201" version="5.0.0"
+    - module name="SERCOM" id="U2201" version="3.1.1","5.0.0"
 
 compatible: "microchip,sercom-g1-i2c"
 


### PR DESCRIPTION
This PR adds I2C driver support for the PIC32CM JH family of devices and board support for PIC32CM JH01 Curiosity Pro board.