### PR TITLE
drivers: display: Add pixel formats to align with video formats

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -1,6 +1,7 @@
 # SDL based emulated display configuration options
 
 # Copyright (c) 2018 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+# Copyright (c) 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SDL_DISPLAY
@@ -45,6 +46,18 @@ choice SDL_DISPLAY_DEFAULT_PIXEL_FORMAT
 
 	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88
 		bool "Grayscale 8bit with Alpha"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888
+		bool "BGR 888"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888
+		bool "ABGR 8888"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888
+		bool "RGBA 8888"
+
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888
+		bool "BGRA 8888"
 
 endchoice
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Jan Van Winkel <jan.van_winkel@dxplore.eu>
  * Copyright (c) 2021 Nordic Semiconductor
+ * Copyright (c) 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -201,6 +202,14 @@ static int sdl_display_init(const struct device *dev)
 		PIXEL_FORMAT_AL_88
 #elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_XRGB_8888)
 		PIXEL_FORMAT_XRGB_8888
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888)
+		PIXEL_FORMAT_BGR_888
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888)
+		PIXEL_FORMAT_ABGR_8888
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888)
+		PIXEL_FORMAT_RGBA_8888
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888)
+		PIXEL_FORMAT_BGRA_8888
 #else  /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
 		PIXEL_FORMAT_ARGB_8888
 #endif /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
@@ -227,7 +236,7 @@ static int sdl_display_init(const struct device *dev)
  *
  * Hence, simple copy is enough
  */
-static void sdl_display_write_argb8888(void *disp_buf,
+static void sdl_display_write_argb8888(uint8_t *disp_buf,
 		const struct display_buffer_descriptor *desc, const void *buf)
 {
 	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
@@ -264,27 +273,137 @@ static void sdl_display_write_xrgb8888(uint8_t *disp_buf,
  *				7......0 15.....8 23....16 31....24
  * PIXEL_FORMAT_RGB_888		Bbbbbbbb Gggggggg Rrrrrrrr Bbbbbbbb
  * into
- * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Ffffffff
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr 11111111
  */
 static void sdl_display_write_rgb888(uint8_t *disp_buf,
 		const struct display_buffer_descriptor *desc, const void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint32_t pixel;
 	const uint8_t *byte_ptr;
 
 	__ASSERT((desc->pitch * 3U * desc->height) <= desc->buf_size,
 			"Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			byte_ptr = (const uint8_t *)buf +
 				((h_idx * desc->pitch) + w_idx) * 3U;
 			pixel = *(byte_ptr + 2) << 16;		/* R */
 			pixel |= *(byte_ptr + 1) << 8;		/* G */
 			pixel |= *byte_ptr;			/* B */
 			*((uint32_t *)disp_buf) = sys_cpu_to_le32(pixel | 0xFF000000);
+			disp_buf += 4;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * PIXEL_FORMAT_BGR_888		Rrrrrrrr Gggggggg Bbbbbbbb Rrrrrrrr
+ * into
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr 11111111
+ */
+static void sdl_display_write_bgr888(uint8_t *disp_buf,
+		const struct display_buffer_descriptor *desc, const void *buf)
+{
+	uint32_t pixel;
+	const uint8_t *byte_ptr;
+
+	__ASSERT((desc->pitch * 3U * desc->height) <= desc->buf_size,
+			"Input buffer too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			byte_ptr = (const uint8_t *)buf +
+				((h_idx * desc->pitch) + w_idx) * 3U;
+			pixel = *byte_ptr << 16;		/* R */
+			pixel |= *(byte_ptr + 1) << 8;		/* G */
+			pixel |= *(byte_ptr + 2);		/* B */
+			*((uint32_t *)disp_buf) = sys_cpu_to_le32(pixel | 0xFF000000);
+			disp_buf += 4;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * PIXEL_FORMAT_ABGR_8888	Rrrrrrrr Gggggggg Bbbbbbbb Aaaaaaaa
+ * into
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ */
+static void sdl_display_write_abgr8888(uint8_t *disp_buf,
+		const struct display_buffer_descriptor *desc, const void *buf)
+{
+	uint32_t pixel;
+	const uint8_t *byte_ptr;
+
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
+			"Input buffer too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			byte_ptr = (const uint8_t *)buf +
+				((h_idx * desc->pitch) + w_idx) * 4U;
+			pixel = *(byte_ptr + 3) << 24;	/* A */
+			pixel |= *(byte_ptr + 0) << 16;	/* R */
+			pixel |= *(byte_ptr + 1) << 8;	/* G */
+			pixel |= *(byte_ptr + 2);	/* B */
+			*((uint32_t *)disp_buf) = sys_cpu_to_le32(pixel);
+			disp_buf += 4;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * PIXEL_FORMAT_RGBA_8888	Aaaaaaaa Bbbbbbbb Gggggggg Rrrrrrrr
+ * into
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ */
+static void sdl_display_write_rgba8888(uint8_t *disp_buf,
+		const struct display_buffer_descriptor *desc, const void *buf)
+{
+	uint32_t pixel;
+	const uint8_t *byte_ptr;
+
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
+			"Input buffer too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			byte_ptr = (const uint8_t *)buf +
+				((h_idx * desc->pitch) + w_idx) * 4U;
+			pixel = *(byte_ptr + 0) << 24;	/* A */
+			pixel |= *(byte_ptr + 3) << 16;	/* R */
+			pixel |= *(byte_ptr + 2) << 8;	/* G */
+			pixel |= *(byte_ptr + 1);	/* B */
+			*((uint32_t *)disp_buf) = sys_cpu_to_le32(pixel);
+			disp_buf += 4;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * PIXEL_FORMAT_BGRA_8888	Aaaaaaaa Rrrrrrrr Gggggggg Bbbbbbbb
+ * into
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ */
+static void sdl_display_write_bgra8888(uint8_t *disp_buf,
+		const struct display_buffer_descriptor *desc, const void *buf)
+{
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size,
+			"Input buffer too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		const uint32_t *src = (const uint32_t *)buf + h_idx * desc->pitch;
+
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			*(uint32_t *)disp_buf = BSWAP_32(src[w_idx]);
 			disp_buf += 4;
 		}
 	}
@@ -302,16 +421,14 @@ static void sdl_display_write_rgb888(uint8_t *disp_buf,
 static void sdl_display_write_al88(uint8_t *disp_buf,
 		const struct display_buffer_descriptor *desc, const void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint32_t pixel;
 	const uint8_t *byte_ptr;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
 			"Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			byte_ptr = (const uint8_t *)buf +
 				((h_idx * desc->pitch) + w_idx) * 2U;
 			pixel = *(byte_ptr + 1) << 24;	/* A */
@@ -334,8 +451,6 @@ static void sdl_display_write_al88(uint8_t *disp_buf,
 static void sdl_display_write_rgb565(uint8_t *disp_buf,
 		const struct display_buffer_descriptor *desc, const void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint32_t pixel;
 	const uint16_t *pix_ptr;
 	uint16_t rgb565;
@@ -343,8 +458,8 @@ static void sdl_display_write_rgb565(uint8_t *disp_buf,
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
 			"Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint16_t *)buf +
 				((h_idx * desc->pitch) + w_idx);
 			rgb565 = sys_le16_to_cpu(*pix_ptr);
@@ -367,8 +482,6 @@ static void sdl_display_write_rgb565(uint8_t *disp_buf,
 static void sdl_display_write_rgb565x(uint8_t *disp_buf,
 				      const struct display_buffer_descriptor *desc, const void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint32_t pixel;
 	const uint16_t *pix_ptr;
 	uint16_t rgb565;
@@ -376,8 +489,8 @@ static void sdl_display_write_rgb565x(uint8_t *disp_buf,
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
 			"Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint16_t *)buf +
 				((h_idx * desc->pitch) + w_idx);
 			/*
@@ -405,15 +518,13 @@ static void sdl_display_write_mono(uint8_t *disp_buf, const struct display_buffe
 				   const void *buf, const bool one_is_black)
 {
 	const uint32_t pixel_on = one_is_black ? 0U : 0x00FFFFFF;
-	uint32_t w_idx;
-	uint32_t h_idx;
 	bool pixel;
 	const uint8_t *byte_ptr;
 
 	__ASSERT((desc->pitch * desc->height) <= (desc->buf_size * 8U), "Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			byte_ptr = buf;
 
 			if (IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_VTILED)) {
@@ -443,15 +554,13 @@ static void sdl_display_write_mono(uint8_t *disp_buf, const struct display_buffe
 static void sdl_display_write_l8(uint8_t *disp_buf, const struct display_buffer_descriptor *desc,
 				 const void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint32_t pixel;
 	const uint8_t *byte_ptr;
 
 	__ASSERT((desc->pitch * desc->height) <= desc->buf_size, "Input buffer too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			byte_ptr = (const uint8_t *)buf + ((h_idx * desc->pitch) + w_idx);
 			pixel = *byte_ptr << 16;	/* R */
 			pixel |= *byte_ptr << 8;	/* G */
@@ -504,6 +613,14 @@ static int sdl_display_write(const struct device *dev, const uint16_t x,
 		sdl_display_write_xrgb8888(disp_data->buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_RGB_888) {
 		sdl_display_write_rgb888(disp_data->buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_BGR_888) {
+		sdl_display_write_bgr888(disp_data->buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_ABGR_8888) {
+		sdl_display_write_abgr8888(disp_data->buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_RGBA_8888) {
+		sdl_display_write_rgba8888(disp_data->buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_BGRA_8888) {
+		sdl_display_write_bgra8888(disp_data->buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_MONO10) {
 		sdl_display_write_mono(disp_data->buf, desc, buf, true);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_MONO01) {
@@ -580,17 +697,15 @@ static void sdl_display_read_xrgb8888(const uint8_t *read_buf,
 static void sdl_display_read_rgb888(const uint8_t *read_buf,
 				    const struct display_buffer_descriptor *desc, void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint8_t *buf8;
 	const uint32_t *pix_ptr;
 
 	__ASSERT((desc->pitch * 3U * desc->height) <= desc->buf_size, "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		buf8 = ((uint8_t *)buf) + desc->pitch * 3U * h_idx;
 
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
 			pix_ptr = sys_le32_to_cpu(pix_ptr);
 			*buf8 = (*pix_ptr & 0xFF);		/* B */
@@ -608,23 +723,140 @@ static void sdl_display_read_rgb888(const uint8_t *read_buf,
  *				7......0 15.....8 23....16 31....24
  * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Ffffffff
  * into
+ * PIXEL_FORMAT_BGR_888		Rrrrrrrr Gggggggg Bbbbbbbb Rrrrrrrr
+ */
+static void sdl_display_read_bgr888(const uint8_t *read_buf,
+				    const struct display_buffer_descriptor *desc, void *buf)
+{
+	uint8_t *buf8;
+	const uint32_t *pix_ptr;
+
+	__ASSERT((desc->pitch * 3U * desc->height) <= desc->buf_size, "Read buffer is too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		buf8 = ((uint8_t *)buf) + desc->pitch * 3U * h_idx;
+
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
+			pix_ptr = sys_le32_to_cpu(pix_ptr);
+			*buf8 = (*pix_ptr & 0xFF0000) >> 16;	/* R */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x00FF00) >> 8;	/* G */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x0000FF);		/* B */
+			buf8 += 1;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ * into
+ * PIXEL_FORMAT_ABGR_8888	Rrrrrrrr Gggggggg Bbbbbbbb Aaaaaaaa
+ */
+static void sdl_display_read_abgr8888(const uint8_t *read_buf,
+				      const struct display_buffer_descriptor *desc, void *buf)
+{
+	uint8_t *buf8;
+	const uint32_t *pix_ptr;
+
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size, "Read buffer is too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		buf8 = ((uint8_t *)buf) + desc->pitch * 4U * h_idx;
+
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
+			pix_ptr = sys_le32_to_cpu(pix_ptr);
+			*buf8 = (*pix_ptr & 0xFF0000) >> 16;		/* R */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x00FF00) >> 8;		/* G */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x0000FF);			/* B */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0xFF000000) >> 24;		/* A */
+			buf8 += 1;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ * into
+ * PIXEL_FORMAT_RGBA_8888	Aaaaaaaa Bbbbbbbb Gggggggg Rrrrrrrr
+ */
+static void sdl_display_read_rgba8888(const uint8_t *read_buf,
+				      const struct display_buffer_descriptor *desc, void *buf)
+{
+	uint8_t *buf8;
+	const uint32_t *pix_ptr;
+
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size, "Read buffer is too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		buf8 = ((uint8_t *)buf) + desc->pitch * 4U * h_idx;
+
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
+			pix_ptr = sys_le32_to_cpu(pix_ptr);
+			*buf8 = (*pix_ptr & 0xFF000000) >> 24;		/* A */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x0000FF);			/* B */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0x00FF00) >> 8;		/* G */
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0xFF0000) >> 16;		/* R */
+			buf8 += 1;
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa
+ * into
+ * PIXEL_FORMAT_BGRA_8888	Aaaaaaaa Rrrrrrrr Gggggggg Bbbbbbbb
+ */
+static void sdl_display_read_bgra8888(const uint8_t *read_buf,
+				      const struct display_buffer_descriptor *desc, void *buf)
+{
+	__ASSERT((desc->pitch * 4U * desc->height) <= desc->buf_size, "Read buffer is too small");
+
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		uint32_t *dst = (uint32_t *)buf + h_idx * desc->pitch;
+		const uint32_t *src = (const uint32_t *)read_buf + h_idx * desc->pitch;
+
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			dst[w_idx] = BSWAP_32(src[w_idx]);
+		}
+	}
+}
+
+/*
+ * Convert from			Byte 0   Byte 1   Byte 2   Byte 3
+ *				7......0 15.....8 23....16 31....24
+ * SDL_PIXELFORMAT_BGRA32	Bbbbbbbb Gggggggg Rrrrrrrr Ffffffff
+ * into
  * PIXEL_FORMAT_RGB_565		gggBbbbb RrrrrGgg gggBbbbb RrrrrGgg
  */
 static void sdl_display_read_rgb565(const uint8_t *read_buf,
 				    const struct display_buffer_descriptor *desc, void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint16_t pixel;
 	uint16_t *buf16;
 	const uint32_t *pix_ptr;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size, "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		buf16 = (void *)(((uint8_t *)buf) + desc->pitch * 2U * h_idx);
 
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
 			pix_ptr = sys_le32_to_cpu(pix_ptr);
 			pixel = (*pix_ptr & 0xF80000) >> 8;	/* R */
@@ -646,18 +878,16 @@ static void sdl_display_read_rgb565(const uint8_t *read_buf,
 static void sdl_display_read_rgb565x(const uint8_t *read_buf,
 				     const struct display_buffer_descriptor *desc, void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint16_t pixel;
 	uint16_t *buf16;
 	const uint32_t *pix_ptr;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size, "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		buf16 = (void *)(((uint8_t *)buf) + desc->pitch * 2U * h_idx);
 
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
 			pix_ptr = sys_le32_to_cpu(pix_ptr);
 			pixel = (*pix_ptr & 0xF80000) >> 8;	/* R */
@@ -685,16 +915,14 @@ static void sdl_display_read_mono(const uint8_t *read_buf,
 				  const bool one_is_black)
 {
 	const uint32_t pixel_on = one_is_black ? 0xFF000000 : 0xFFFFFFFF;
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint8_t bits;
 	const uint32_t *pix_ptr;
 	uint8_t *buf8;
 
 	__ASSERT((desc->pitch * desc->height) <= (desc->buf_size * 8U), "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + h_idx * desc->pitch + w_idx;
 			pix_ptr = sys_cpu_to_le32(pix_ptr);
 			buf8 = buf;
@@ -728,17 +956,15 @@ static void sdl_display_read_mono(const uint8_t *read_buf,
 static void sdl_display_read_l8(const uint8_t *read_buf,
 				const struct display_buffer_descriptor *desc, void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint8_t *buf8;
 	const uint32_t *pix_ptr;
 
 	__ASSERT((desc->pitch * desc->height) <= desc->buf_size, "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		buf8 = ((uint8_t *)buf) + desc->pitch * h_idx;
 
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
 			pix_ptr = sys_le32_to_cpu(pix_ptr);
 			*buf8 = *pix_ptr & 0xFF;
@@ -750,17 +976,15 @@ static void sdl_display_read_l8(const uint8_t *read_buf,
 static void sdl_display_read_al88(const uint8_t *read_buf,
 				const struct display_buffer_descriptor *desc, void *buf)
 {
-	uint32_t w_idx;
-	uint32_t h_idx;
 	uint8_t *buf8;
 	const uint32_t *pix_ptr;
 
 	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size, "Read buffer is too small");
 
-	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+	for (uint32_t h_idx = 0U; h_idx < desc->height; ++h_idx) {
 		buf8 = ((uint8_t *)buf) + desc->pitch * 2U * h_idx;
 
-		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+		for (uint32_t w_idx = 0U; w_idx < desc->width; ++w_idx) {
 			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
 			pix_ptr = sys_le32_to_cpu(pix_ptr);
 			*buf8 = (*pix_ptr & 0xFF);
@@ -811,6 +1035,14 @@ static void sdl_display_read_al88(const uint8_t *read_buf,
 		sdl_display_read_xrgb8888(disp_data->read_buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_RGB_888) {
 		sdl_display_read_rgb888(disp_data->read_buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_BGR_888) {
+		sdl_display_read_bgr888(disp_data->read_buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_ABGR_8888) {
+		sdl_display_read_abgr8888(disp_data->read_buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_RGBA_8888) {
+		sdl_display_read_rgba8888(disp_data->read_buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_BGRA_8888) {
+		sdl_display_read_bgra8888(disp_data->read_buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_MONO10) {
 		sdl_display_read_mono(disp_data->read_buf, desc, buf, true);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_MONO01) {
@@ -840,9 +1072,13 @@ static int sdl_display_clear(const struct device *dev)
 	switch (disp_data->current_pixel_format) {
 	case PIXEL_FORMAT_ARGB_8888:
 	case PIXEL_FORMAT_XRGB_8888:
+	case PIXEL_FORMAT_ABGR_8888:
+	case PIXEL_FORMAT_RGBA_8888:
+	case PIXEL_FORMAT_BGRA_8888:
 		size = config->width * config->height * 4U;
 		break;
 	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
 		size = config->width * config->height * 3U;
 		break;
 	case PIXEL_FORMAT_MONO10:
@@ -931,6 +1167,10 @@ static void sdl_display_get_capabilities(
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_ARGB_8888 |
 		PIXEL_FORMAT_XRGB_8888 |
 		PIXEL_FORMAT_RGB_888 |
+		PIXEL_FORMAT_BGR_888 |
+		PIXEL_FORMAT_ABGR_8888 |
+		PIXEL_FORMAT_RGBA_8888 |
+		PIXEL_FORMAT_BGRA_8888 |
 		PIXEL_FORMAT_MONO01 |
 		PIXEL_FORMAT_MONO10 |
 		PIXEL_FORMAT_RGB_565 |
@@ -951,6 +1191,10 @@ static void sdl_display_get_capabilities(
 	case PIXEL_FORMAT_ARGB_8888:
 	case PIXEL_FORMAT_XRGB_8888:
 	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
+	case PIXEL_FORMAT_ABGR_8888:
+	case PIXEL_FORMAT_RGBA_8888:
+	case PIXEL_FORMAT_BGRA_8888:
 	case PIXEL_FORMAT_MONO01:
 	case PIXEL_FORMAT_MONO10:
 	case PIXEL_FORMAT_RGB_565:

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 enum display_pixel_format {
 	/**
-	 * 24-bit RGB format with 8 bits per component.
+	 * @brief 24-bit RGB format with 8 bits per component.
 	 *
 	 * Below shows how data are organized in memory.
 	 *
@@ -62,7 +62,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_RGB_888		= BIT(0), /**< 24-bit RGB */
 
 	/**
-	 * 1-bit monochrome format with 1 bit per pixel, thus each byte represent 8 pixels
+	 * @brief 1-bit monochrome format with 1 bit per pixel, thus each byte represent 8 pixels
 	 * Two variants, with black being either represented by 0 or 1
 	 *
 	 * Below shows how data are organized in memory.
@@ -78,7 +78,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_MONO10		= BIT(2), /**< Monochrome (1=Black 0=White) */
 
 	/**
-	 * 32-bit RGB format with 8 bits per component and 8 bits for alpha.
+	 * @brief 32-bit RGB format with 8 bits per component and 8 bits for alpha.
 	 *
 	 * Below shows how data are organized in memory.
 	 *
@@ -92,7 +92,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_ARGB_8888		= BIT(3), /**< 32-bit ARGB */
 
 	/**
-	 * 16-bit RGB format packed into two bytes: 5 red bits [15:11], 6
+	 * @brief 16-bit RGB format packed into two bytes: 5 red bits [15:11], 6
 	 * green bits [10:5], 5 blue bits [4:0].
 	 *
 	 * Below shows how data are organized in memory.
@@ -107,7 +107,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_RGB_565		= BIT(4),
 
 	/**
-	 * 16-bit RGB format packed into two bytes. Byte swapped version of
+	 * @brief 16-bit RGB format packed into two bytes. Byte swapped version of
 	 * the PIXEL_FORMAT_RGB_565 format.
 	 *
 	 * @code{.unparsed}
@@ -119,7 +119,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_RGB_565X		= BIT(5),
 
 	/**
-	 * 8-bit Greyscale format
+	 * @brief 8-bit Greyscale format
 	 *
 	 * Below shows how data are organized in memory.
 	 *
@@ -133,7 +133,7 @@ enum display_pixel_format {
 						  /**< GRAY, GREY, GRAY8, Y8, R8, etc...        */
 
 	/**
-	 * 16-bit Greyscale format with 8-bit luminance and 8-bit for alpha
+	 * @brief 16-bit Greyscale format with 8-bit luminance and 8-bit for alpha
 	 *
 	 * Below shows how data are organized in memory.
 	 *
@@ -146,7 +146,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_AL_88		= BIT(7), /**< 8-bit Grayscale/Luminance with alpha */
 
 	/**
-	 * 32-bit RGB format with 8 bits per component and 8 bits unused.
+	 * @brief 32-bit RGB format with 8 bits per component and 8 bits unused.
 	 *
 	 * Below shows how data are organized in memory.
 	 *
@@ -160,10 +160,66 @@ enum display_pixel_format {
 	PIXEL_FORMAT_XRGB_8888 = BIT(8), /**< 32-bit XRGB */
 
 	/**
+	 * @brief 24-bit BGR format with 8 bits per component.
+	 *
+	 * Below shows how data are organized in memory.
+	 *
+	 * @code{.unparsed}
+	 *   Byte 0   Byte 1   Byte 2
+	 *   7......0 15.....8 23....16
+	 * | Rrrrrrrr Gggggggg Bbbbbbbb | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_BGR_888 = BIT(9), /**< 24-bit BGR */
+
+	/**
+	 * @brief 32-bit BGR format with 8 bits per component and 8 bits for alpha.
+	 *
+	 * Below shows how data are organized in memory.
+	 *
+	 * @code{.unparsed}
+	 *   Byte 0   Byte 1   Byte 2   Byte 3
+	 *   7......0 15.....8 23....16 31....24
+	 * | Rrrrrrrr Gggggggg Bbbbbbbb Aaaaaaaa | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_ABGR_8888 = BIT(10), /**< 32-bit ABGR */
+
+	/**
+	 * @brief 32-bit RGB format with 8 bits per component and 8 bits for alpha.
+	 *
+	 * Below shows how data are organized in memory.
+	 *
+	 * @code{.unparsed}
+	 *   Byte 0   Byte 1   Byte 2   Byte 3
+	 *   7......0 15.....8 23....16 31....24
+	 * | Aaaaaaaa Bbbbbbbb Gggggggg Rrrrrrrr | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_RGBA_8888 = BIT(11), /**< 32-bit RGBA */
+
+	/**
+	 * @brief 32-bit BGR format with 8 bits per component and 8 bits for alpha.
+	 *
+	 * Below shows how data are organized in memory.
+	 *
+	 * @code{.unparsed}
+	 *   Byte 0   Byte 1   Byte 2   Byte 3
+	 *   7......0 15.....8 23....16 31....24
+	 * | Aaaaaaaa Rrrrrrrr Gggggggg Bbbbbbbb | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_BGRA_8888 = BIT(12), /**< 32-bit BGRA */
+
+	/**
 	 * This and higher values are display specific.
 	 * Refer to the display header file.
 	 */
-	PIXEL_FORMAT_PRIV_START = (PIXEL_FORMAT_XRGB_8888 << 1),
+	PIXEL_FORMAT_PRIV_START = (PIXEL_FORMAT_BGRA_8888 << 1),
 };
 
 /**
@@ -183,8 +239,11 @@ enum display_pixel_format {
 	(((fmt & PIXEL_FORMAT_RGB_565X) >> 5) * 16U) +				\
 	(((fmt & PIXEL_FORMAT_L_8) >> 6) * 8U) +				\
 	(((fmt & PIXEL_FORMAT_AL_88) >> 7) * 16U) +				\
-	(((fmt & PIXEL_FORMAT_XRGB_8888) >> 8) * 32U))
-
+	(((fmt & PIXEL_FORMAT_XRGB_8888) >> 8) * 32U) +				\
+	(((fmt & PIXEL_FORMAT_BGR_888) >> 9) * 24U) +				\
+	(((fmt & PIXEL_FORMAT_ABGR_8888) >> 10) * 32U) +			\
+	(((fmt & PIXEL_FORMAT_RGBA_8888) >> 11) * 32U) +			\
+	(((fmt & PIXEL_FORMAT_BGRA_8888) >> 12) * 32U))
 /**
  * @brief Display screen information
  */

--- a/samples/drivers/display/src/display.c
+++ b/samples/drivers/display/src/display.c
@@ -4,6 +4,8 @@
  * Based on ST7789V sample:
  * Copyright (c) 2019 Marc Reilly
  *
+ * Copyright (c) 2026 NXP
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,26 +31,44 @@ enum corner {
 };
 
 typedef void (*fill_buffer)(enum corner corner, uint8_t grey, uint8_t *buf,
-			    size_t buf_size);
+			    size_t buf_size, enum display_pixel_format fmt);
 
 
 static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
-				 size_t buf_size)
+				 size_t buf_size, enum display_pixel_format fmt)
 {
-	uint32_t color = 0;
+	uint8_t r = 0, g = 0, b = 0;
+	uint8_t a = 0xFFu;
+	uint32_t color;
 
 	switch (corner) {
 	case TOP_LEFT:
-		color = 0xFFFF0000u;
+		r = 0xFF;
 		break;
 	case TOP_RIGHT:
-		color = 0xFF00FF00u;
+		g = 0xFF;
 		break;
 	case BOTTOM_RIGHT:
-		color = 0xFF0000FFu;
+		b = 0xFF;
 		break;
 	case BOTTOM_LEFT:
-		color = 0xFF000000u | grey << 16 | grey << 8 | grey;
+	default:
+		r = grey; g = grey; b = grey;
+		break;
+	}
+
+	switch (fmt) {
+	case PIXEL_FORMAT_ABGR_8888:
+		color = (uint32_t)a << 24 | (uint32_t)b << 16 | (uint32_t)g << 8 | r;
+		break;
+	case PIXEL_FORMAT_RGBA_8888:
+		color = (uint32_t)r << 24 | (uint32_t)g << 16 | (uint32_t)b << 8 | a;
+		break;
+	case PIXEL_FORMAT_BGRA_8888:
+		color = (uint32_t)b << 24 | (uint32_t)g << 16 | (uint32_t)r << 8 | a;
+		break;
+	default: /* PIXEL_FORMAT_ARGB_8888 / PIXEL_FORMAT_XRGB_8888 */
+		color = (uint32_t)a << 24 | (uint32_t)r << 16 | (uint32_t)g << 8 | b;
 		break;
 	}
 
@@ -58,29 +78,37 @@ static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
 }
 
 static void fill_buffer_rgb888(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       size_t buf_size, enum display_pixel_format fmt)
 {
-	uint32_t color = 0;
+	uint8_t r = 0, g = 0, b = 0;
+	uint8_t byte0, byte1, byte2;
 
 	switch (corner) {
 	case TOP_LEFT:
-		color = 0x00FF0000u;
+		r = 0xFF;
 		break;
 	case TOP_RIGHT:
-		color = 0x0000FF00u;
+		g = 0xFF;
 		break;
 	case BOTTOM_RIGHT:
-		color = 0x000000FFu;
+		b = 0xFF;
 		break;
 	case BOTTOM_LEFT:
-		color = grey << 16 | grey << 8 | grey;
+	default:
+		r = grey; g = grey; b = grey;
 		break;
 	}
 
+	if (fmt == PIXEL_FORMAT_BGR_888) {
+		byte0 = r; byte1 = g; byte2 = b;
+	} else {
+		byte0 = b; byte1 = g; byte2 = r;
+	}
+
 	for (size_t idx = 0; idx < buf_size; idx += 3) {
-		*(buf + idx + 0) = (color >> 0) & 0xFFu;
-		*(buf + idx + 1) = (color >> 8) & 0xFFu;
-		*(buf + idx + 2) = (color >> 16) & 0xFFu;
+		*(buf + idx + 0) = byte0;
+		*(buf + idx + 1) = byte1;
+		*(buf + idx + 2) = byte2;
 	}
 }
 
@@ -109,7 +137,7 @@ static uint16_t get_rgb565_color(enum corner corner, uint8_t grey)
 }
 
 static void fill_buffer_rgb565x(enum corner corner, uint8_t grey, uint8_t *buf,
-				size_t buf_size)
+				size_t buf_size, enum display_pixel_format fmt)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
@@ -120,7 +148,7 @@ static void fill_buffer_rgb565x(enum corner corner, uint8_t grey, uint8_t *buf,
 }
 
 static void fill_buffer_rgb565(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       size_t buf_size, enum display_pixel_format fmt)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
@@ -147,7 +175,8 @@ static void fill_buffer_mono(enum corner corner, uint8_t grey,
 	memset(buf, color, buf_size);
 }
 
-static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *buf, size_t buf_size)
+static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *buf,
+				    size_t buf_size, enum display_pixel_format fmt)
 {
 	uint8_t color;
 
@@ -176,7 +205,7 @@ static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *bu
 }
 
 static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
-				 size_t buf_size)
+			      size_t buf_size, enum display_pixel_format fmt)
 {
 	uint16_t color;
 
@@ -204,13 +233,15 @@ static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
 }
 
 static inline void fill_buffer_mono01(enum corner corner, uint8_t grey,
-				      uint8_t *buf, size_t buf_size)
+				      uint8_t *buf, size_t buf_size,
+				      enum display_pixel_format fmt)
 {
 	fill_buffer_mono(corner, grey, 0x00u, 0xFFu, buf, buf_size);
 }
 
 static inline void fill_buffer_mono10(enum corner corner, uint8_t grey,
-				      uint8_t *buf, size_t buf_size)
+				      uint8_t *buf, size_t buf_size,
+				      enum display_pixel_format fmt)
 {
 	fill_buffer_mono(corner, grey, 0xFFu, 0x00u, buf, buf_size);
 }
@@ -289,10 +320,14 @@ int sample_display_draw(void)
 	switch (capabilities.current_pixel_format) {
 	case PIXEL_FORMAT_XRGB_8888:
 	case PIXEL_FORMAT_ARGB_8888:
+	case PIXEL_FORMAT_ABGR_8888:
+	case PIXEL_FORMAT_RGBA_8888:
+	case PIXEL_FORMAT_BGRA_8888:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_argb8888;
 		break;
 	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_rgb888;
 		break;
@@ -375,7 +410,7 @@ int sample_display_draw(void)
 	buf_desc.width = rect_w;
 	buf_desc.height = rect_h;
 
-	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size);
+	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = 0;
 	y = 0;
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
@@ -384,7 +419,7 @@ int sample_display_draw(void)
 		goto end;
 	}
 
-	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size);
+	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = 0;
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
@@ -400,7 +435,7 @@ int sample_display_draw(void)
 	 */
 	buf_desc.frame_incomplete = false;
 
-	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size);
+	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size, capabilities.current_pixel_format);
 	x = capabilities.x_resolution - rect_w;
 	y = capabilities.y_resolution - rect_h;
 	ret = display_write(display_dev, x, y, &buf_desc, buf);
@@ -421,7 +456,8 @@ int sample_display_draw(void)
 
 	LOG_INF("Display starts");
 	while (1) {
-		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size);
+		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size,
+			capabilities.current_pixel_format);
 		ret = display_write(display_dev, x, y, &buf_desc, buf);
 		if (ret < 0) {
 			LOG_ERR("Failed to write to display (error %d)", ret);

--- a/tests/drivers/display/display_read_write/src/main.c
+++ b/tests/drivers/display/display_read_write/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 (c) TOKITA Hiroshi
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -39,8 +40,13 @@ static inline uint8_t bytes_per_pixel(enum display_pixel_format pixel_format)
 {
 	switch (pixel_format) {
 	case PIXEL_FORMAT_ARGB_8888:
+	case PIXEL_FORMAT_XRGB_8888:
+	case PIXEL_FORMAT_ABGR_8888:
+	case PIXEL_FORMAT_RGBA_8888:
+	case PIXEL_FORMAT_BGRA_8888:
 		return 4;
 	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
 		return 3;
 	case PIXEL_FORMAT_RGB_565:
 	case PIXEL_FORMAT_RGB_565X:

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -1,4 +1,5 @@
 # Copyright 2024 (c) TOKITA Hiroshi
+# Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 common:
@@ -101,6 +102,30 @@ tests:
       - native_sim/native/64
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565X=y
+  drivers.display.read_write.sdl.bgr888:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888=y
+  drivers.display.read_write.sdl.abgr8888:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888=y
+  drivers.display.read_write.sdl.rgba8888:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888=y
+  drivers.display.read_write.sdl.bgra8888:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888=y
   drivers.display.read_write.ili9340:
     tags:
       - shield


### PR DESCRIPTION
Add support for additional pixel formats, so that the display pixel formats are aligned with the video pixel formats:
- PIXEL_FORMAT_BGR_888: 24-bit BGR format with 8 bits per component
- PIXEL_FORMAT_XRGB_8888: 32-bit RGB with 8 bits padding
- PIXEL_FORMAT_ABGR_8888: 32-bit ABGR with alpha channel
- PIXEL_FORMAT_RGBA_8888: 32-bit RGBA with alpha channel
- PIXEL_FORMAT_BGRA_8888: 32-bit BGRA with alpha channel

In many use cases the display driver uses the the frame generated by video driver directly, so their format shall be aligned.
This PR is the dependency for https://github.com/zephyrproject-rtos/zephyr/pull/101883