### PR TITLE
samples: video: capture: Add support for VIDEO_PIX_FMT_RGBA32 pixel format

### DIFF
--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -84,6 +84,11 @@ static inline int app_setup_display(const struct device *const display_dev, cons
 			}
 		}
 		break;
+	case VIDEO_PIX_FMT_RGBA32:
+		if (capabilities.current_pixel_format != PIXEL_FORMAT_ABGR_8888) {
+			ret = display_set_pixel_format(display_dev, PIXEL_FORMAT_ABGR_8888);
+		}
+		break;
 	default:
 		LOG_ERR("Display pixel format not supported by this sample");
 		return -ENOTSUP;


### PR DESCRIPTION
Add handling for VIDEO_PIX_FMT_ABGR32 format in the display setup function.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/103797
Is the dependency of https://github.com/zephyrproject-rtos/zephyr/pull/101883/