### PR TITLE
drivers: display: mcux_dcnano_lcdif: Add support for more pixel formats

### DIFF
--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -141,19 +141,57 @@ static void mcux_dcnano_lcdif_get_capabilities(const struct device *dev,
 
 	capabilities->y_resolution = config->dpi_config.panelHeight;
 	capabilities->x_resolution = config->dpi_config.panelWidth;
+#if DT_INST_ENUM_HAS_VALUE(0, version, dc8000)
+	capabilities->supported_pixel_formats = (PIXEL_FORMAT_RGB_565 | PIXEL_FORMAT_ARGB_8888 |
+		PIXEL_FORMAT_RGB_888 | PIXEL_FORMAT_BGR_888 | PIXEL_FORMAT_ABGR_8888 |
+		PIXEL_FORMAT_RGBA_8888 | PIXEL_FORMAT_BGRA_8888);
+#else
 	capabilities->supported_pixel_formats = (PIXEL_FORMAT_RGB_565 | PIXEL_FORMAT_ARGB_8888);
+#endif
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+
 	switch (data->fb_config.format) {
 	case kLCDIF_PixelFormatRGB565:
 		capabilities->current_pixel_format = PIXEL_FORMAT_RGB_565;
 		break;
 #if DT_INST_ENUM_HAS_VALUE(0, version, dc8000)
+	case kLCDIF_PixelFormatRGB888:
+		switch (data->fb_config.inOrder) {
+		case kLCDIF_PixelInputOrderARGB:
+			capabilities->current_pixel_format = PIXEL_FORMAT_RGB_888;
+			break;
+		case kLCDIF_PixelInputOrderABGR:
+			capabilities->current_pixel_format = PIXEL_FORMAT_BGR_888;
+			break;
+		default:
+			/* Other LCDIF formats don't have a Zephyr enum yet */
+			break;
+		}
+		break;
 	case kLCDIF_PixelFormatARGB8888:
+		switch (data->fb_config.inOrder) {
+		case kLCDIF_PixelInputOrderARGB:
+			capabilities->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
+			break;
+		case kLCDIF_PixelInputOrderABGR:
+			capabilities->current_pixel_format = PIXEL_FORMAT_ABGR_8888;
+			break;
+		case kLCDIF_PixelInputOrderRGBA:
+			capabilities->current_pixel_format = PIXEL_FORMAT_RGBA_8888;
+			break;
+		case kLCDIF_PixelInputOrderBGRA:
+			capabilities->current_pixel_format = PIXEL_FORMAT_BGRA_8888;
+			break;
+		default:
+			/* Other LCDIF formats don't have a Zephyr enum yet */
+			break;
+		}
+		break;
 #else
 	case kLCDIF_PixelFormatXRGB8888:
-#endif
 		capabilities->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
 		break;
+#endif
 	default:
 		/* Other LCDIF formats don't have a Zephyr enum yet */
 		return;
@@ -196,11 +234,39 @@ static int mcux_dcnano_lcdif_set_pixel_format(const struct device *dev,
 	case PIXEL_FORMAT_ARGB_8888:
 #if DT_INST_ENUM_HAS_VALUE(0, version, dc8000)
 		data->fb_config.format = kLCDIF_PixelFormatARGB8888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderARGB;
 #else
 		data->fb_config.format = kLCDIF_PixelFormatXRGB8888;
 #endif
 		data->pixel_bytes = 4;
 		break;
+#if DT_INST_ENUM_HAS_VALUE(0, version, dc8000)
+	case PIXEL_FORMAT_RGB_888:
+		data->fb_config.format = kLCDIF_PixelFormatRGB888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderARGB;
+		data->pixel_bytes = 3;
+		break;
+	case PIXEL_FORMAT_BGR_888:
+		data->fb_config.format = kLCDIF_PixelFormatRGB888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderABGR;
+		data->pixel_bytes = 3;
+		break;
+	case PIXEL_FORMAT_ABGR_8888:
+		data->fb_config.format = kLCDIF_PixelFormatARGB8888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderABGR;
+		data->pixel_bytes = 4;
+		break;
+	case PIXEL_FORMAT_RGBA_8888:
+		data->fb_config.format = kLCDIF_PixelFormatARGB8888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderRGBA;
+		data->pixel_bytes = 4;
+		break;
+	case PIXEL_FORMAT_BGRA_8888:
+		data->fb_config.format = kLCDIF_PixelFormatARGB8888;
+		data->fb_config.inOrder = kLCDIF_PixelInputOrderBGRA;
+		data->pixel_bytes = 4;
+		break;
+#endif
 	default:
 		return -ENOTSUP;
 	}
@@ -212,6 +278,16 @@ static int mcux_dcnano_lcdif_set_pixel_format(const struct device *dev,
 	data->pitch_bytes = ROUND_UP((config->dpi_config.panelWidth * data->pixel_bytes),
 						MCUX_DCNANO_LCDIF_FB_PITCH_ALIGN);
 	data->fb_bytes = data->pitch_bytes * config->dpi_config.panelHeight;
+
+	/* Update frame buffer pointer. */
+	for (int i = 0; i < CONFIG_MCUX_DCNANO_LCDIF_FB_NUM; i++) {
+		/* Record pointers to each driver framebuffer */
+		data->fb[i] = config->fb_ptr + (data->fb_bytes * i);
+	}
+	data->active_fb = config->fb_ptr;
+
+	/* Clear the framebuffer since the frame size may be larger. */
+	memset(config->fb_ptr, 0, data->fb_bytes * CONFIG_MCUX_DCNANO_LCDIF_FB_NUM);
 
 	return 0;
 }
@@ -296,9 +372,9 @@ static DEVICE_API(display, mcux_dcnano_lcdif_api) = {
 	DT_INST_PROP(n, height)
 
 /* Place the frame buffer in secondary RAM if specified, otherwise use default RAM */
-#define MCUX_DCNANO_LCDIF_FB_PLACEMENT(n)					\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, ext_ram),				\
-	(Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_INST_PHANDLE(n, ext_ram)))), \
+#define MCUX_DCNANO_LCDIF_FB_PLACEMENT(n)						\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, ext_ram),					\
+	(Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_INST_PHANDLE(n, ext_ram)))),	\
 	())
 
 /* Use 4 Bpp to calculate the largest possible framebuffer size. */


### PR DESCRIPTION
Add support for more pixel formats that are supported by the DCNano on mimxrt700_evk:
- PIXEL_FORMAT_RGB_888: 24-bit RGB format with 8 bits per component
- PIXEL_FORMAT_BGR_888: 24-bit BGR format with 8 bits per component
- PIXEL_FORMAT_ABGR_8888: 32-bit ABGR with alpha channel
- PIXEL_FORMAT_RGBA_8888: 32-bit RGBA with alpha channel
- PIXEL_FORMAT_BGRA_8888: 32-bit BGRA with alpha channel

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/103797 and https://github.com/zephyrproject-rtos/zephyr/pull/106370
Is the dependency of https://github.com/zephyrproject-rtos/zephyr/pull/101883