### PR TITLE
LoRa: Add native support for STM32WL

### DIFF
--- a/drivers/lora/native/sx126x/CMakeLists.txt
+++ b/drivers/lora/native/sx126x/CMakeLists.txt
@@ -5,6 +5,13 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_LORA_SX126X_NATIVE
   sx126x.c
-  sx126x_hal.c
   sx126x_hal_common.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_LORA_SX126X_NATIVE_STANDALONE
+  sx126x_hal.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_LORA_SX126X_NATIVE_STM32WL
+  sx126x_hal_stm32wl.c
 )

--- a/drivers/lora/native/sx126x/CMakeLists.txt
+++ b/drivers/lora/native/sx126x/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
@@ -5,4 +6,5 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_LORA_SX126X_NATIVE
   sx126x.c
   sx126x_hal.c
+  sx126x_hal_common.c
 )

--- a/drivers/lora/native/sx126x/Kconfig
+++ b/drivers/lora/native/sx126x/Kconfig
@@ -5,10 +5,28 @@ config LORA_SX126X_NATIVE
 	bool "Semtech SX126x native driver (experimental)"
 	default y
 	depends on LORA_MODULE_BACKEND_NATIVE
-	depends on DT_HAS_SEMTECH_SX1262_ENABLED || DT_HAS_SEMTECH_SX1261_ENABLED
+	depends on DT_HAS_SEMTECH_SX1262_ENABLED || DT_HAS_SEMTECH_SX1261_ENABLED || \
+		   DT_HAS_ST_STM32WL_SUBGHZ_RADIO_ENABLED
 	select SPI
 	select GPIO
 	help
-	  Enable native driver for Semtech SX1261/SX1262 LoRa transceivers.
+	  Enable native driver for Semtech SX1261/SX1262 LoRa transceivers,
+	  including the STM32WL integrated sub-GHz radio.
 	  This is an experimental driver that does not depend on loramac-node
 	  or lora-basics-modem external modules.
+
+config LORA_SX126X_NATIVE_STM32WL
+	bool
+	default y
+	depends on LORA_SX126X_NATIVE
+	depends on DT_HAS_ST_STM32WL_SUBGHZ_RADIO_ENABLED
+	help
+	  STM32WL Sub-GHz radio support for the native SX126x driver.
+
+config LORA_SX126X_NATIVE_STANDALONE
+	bool
+	default y
+	depends on LORA_SX126X_NATIVE
+	depends on DT_HAS_SEMTECH_SX1262_ENABLED || DT_HAS_SEMTECH_SX1261_ENABLED
+	help
+	  Standalone SX1261/SX1262 support for the native SX126x driver.

--- a/drivers/lora/native/sx126x/sx126x_hal.h
+++ b/drivers/lora/native/sx126x/sx126x_hal.h
@@ -63,11 +63,16 @@ int sx126x_hal_read_buffer(const struct device *dev, uint8_t offset,
 int sx126x_hal_set_dio1_callback(const struct device *dev,
 				 void (*callback)(const struct device *dev));
 
+void sx126x_hal_dio1_irq_enable(const struct device *dev);
+
 void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable);
 
 void sx126x_hal_set_rf_switch(const struct device *dev, bool tx);
 
 int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
 			      gpio_flags_t flags, const char *name);
+
+int sx126x_hal_configure_tx_params(const struct device *dev, int8_t power,
+				   uint32_t frequency, uint8_t ramp_time);
 
 #endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_HAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x_hal.h
+++ b/drivers/lora/native/sx126x/sx126x_hal.h
@@ -10,17 +10,27 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/gpio.h>
 
+/* STM32WL PA output selection */
+#define SX126X_PA_OUTPUT_RFO_LP 0
+#define SX126X_PA_OUTPUT_RFO_HP 1
+
 struct sx126x_hal_config {
 	struct spi_dt_spec spi;
+#ifdef CONFIG_LORA_SX126X_NATIVE_STANDALONE
 	struct gpio_dt_spec reset;
 	struct gpio_dt_spec busy;
 	struct gpio_dt_spec dio1;
+	bool is_sx1261;
+#elif CONFIG_LORA_SX126X_NATIVE_STM32WL
+	uint8_t pa_output;
+	int8_t rfo_lp_max_power;
+	int8_t rfo_hp_max_power;
+#endif /* CONFIG_LORA_SX126X_NATIVE_STM32WL */
 	struct gpio_dt_spec antenna_enable;
 	struct gpio_dt_spec tx_enable;
 	struct gpio_dt_spec rx_enable;
 	uint16_t tcxo_startup_delay_ms;
 	uint8_t dio3_tcxo_voltage;
-	bool is_sx1261;
 	bool dio2_tx_enable;
 	bool dio3_tcxo_enable;
 	bool rx_boosted;

--- a/drivers/lora/native/sx126x/sx126x_hal_common.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_common.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "sx126x.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sx126x_hal_common, CONFIG_LORA_LOG_LEVEL);
+
+#define SX126X_BUSY_DEFAULT_TIMEOUT 1000
+
+static int spi_transfer(const struct spi_dt_spec *spi,
+			const uint8_t *hdr, size_t hdr_len,
+			uint8_t *data, size_t data_len, bool read)
+{
+	uint8_t rx_hdr[4];
+
+	__ASSERT_NO_MSG(hdr_len <= sizeof(rx_hdr));
+
+	struct spi_buf tx_bufs[] = {
+		{ .buf = (uint8_t *)hdr, .len = hdr_len },
+		{ .buf = data, .len = data_len },
+	};
+	struct spi_buf rx_bufs[] = {
+		{ .buf = rx_hdr, .len = hdr_len },
+		{ .buf = data, .len = data_len },
+	};
+	struct spi_buf_set tx_set = {
+		.buffers = tx_bufs,
+		.count = (read || (data_len == 0)) ? 1 : 2,
+	};
+	struct spi_buf_set rx_set = {
+		.buffers = rx_bufs,
+		.count = read ? 2 : 1,
+	};
+
+	return spi_transceive_dt(spi, &tx_set, &rx_set);
+}
+
+int sx126x_hal_wait_busy(const struct device *dev, uint32_t timeout_ms)
+{
+	if (!WAIT_FOR(!sx126x_hal_is_busy(dev),
+		      timeout_ms * 1000,
+		      k_msleep(1))) {
+		LOG_WRN("Busy timeout after %u ms", timeout_ms);
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	if (config->antenna_enable.port != NULL) {
+		gpio_pin_set_dt(&config->antenna_enable, enable);
+	}
+}
+
+void sx126x_hal_set_rf_switch(const struct device *dev, bool tx)
+{
+	const struct sx126x_hal_config *config = dev->config;
+
+	if (config->tx_enable.port != NULL) {
+		gpio_pin_set_dt(&config->tx_enable, tx);
+	}
+
+	if (config->rx_enable.port != NULL) {
+		gpio_pin_set_dt(&config->rx_enable, !tx);
+	}
+}
+
+int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
+			      gpio_flags_t flags, const char *name)
+{
+	int ret;
+
+	if (gpio->port == NULL) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(gpio)) {
+		LOG_ERR("%s GPIO not ready", name);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(gpio, flags);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure %s: %d", name, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_cmd(const struct device *dev, uint8_t opcode,
+			 const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[1] = { opcode };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write failed: %d", ret);
+		return ret;
+	}
+
+	if (opcode != SX126X_CMD_SET_SLEEP) {
+		ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	}
+
+	return ret;
+}
+
+int sx126x_hal_read_cmd(const struct device *dev, uint8_t opcode,
+			uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[2] = { opcode, 0x00 };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI transceive failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_regs(const struct device *dev, uint16_t address,
+			  const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[3];
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hdr[0] = SX126X_CMD_WRITE_REGISTER;
+	sys_put_be16(address, &hdr[1]);
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write regs failed: %d", ret);
+		return ret;
+	}
+
+	return sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+}
+
+int sx126x_hal_read_regs(const struct device *dev, uint16_t address,
+			 uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[4];
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hdr[0] = SX126X_CMD_READ_REGISTER;
+	sys_put_be16(address, &hdr[1]);
+	hdr[3] = 0x00;
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI read regs failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int sx126x_hal_write_buffer(const struct device *dev, uint8_t offset,
+			    const uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[2] = { SX126X_CMD_WRITE_BUFFER, offset };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), (uint8_t *)data, len, false);
+	if (ret < 0) {
+		LOG_ERR("SPI write buffer failed: %d", ret);
+		return ret;
+	}
+
+	return sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+}
+
+int sx126x_hal_read_buffer(const struct device *dev, uint8_t offset,
+			   uint8_t *data, size_t len)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t hdr[3] = { SX126X_CMD_READ_BUFFER, offset, 0x00 };
+	int ret;
+
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = spi_transfer(&config->spi, hdr, sizeof(hdr), data, len, true);
+	if (ret < 0) {
+		LOG_ERR("SPI read buffer failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}

--- a/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
+
+#include <stm32_ll_exti.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+
+#include "sx126x.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sx126x_hal_stm32wl, CONFIG_LORA_LOG_LEVEL);
+
+#define SX126X_RESET_PULSE_MS       20
+#define SX126X_RESET_WAIT_MS        10
+#define SX126X_BUSY_DEFAULT_TIMEOUT 1000
+
+#define SX126X_OCP_60MA             0x18
+#define SX126X_OCP_140MA            0x38
+
+#define DT_DRV_COMPAT st_stm32wl_subghz_radio
+
+static inline struct sx126x_hal_data *get_hal_data(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+
+	return &data->hal;
+}
+
+static int sx126x_hal_wakeup(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t tx_buf[2] = { SX126X_CMD_GET_STATUS, 0x00 };
+
+	struct spi_buf tx_spi_buf = {
+		.buf = tx_buf,
+		.len = sizeof(tx_buf),
+	};
+	struct spi_buf_set tx_set = {
+		.buffers = &tx_spi_buf,
+		.count = 1,
+	};
+
+	return spi_write_dt(&config->spi, &tx_set);
+}
+
+int sx126x_hal_reset(const struct device *dev)
+{
+	int ret;
+
+	/* Use RCC to reset the radio subsystem */
+	LL_RCC_RF_EnableReset();
+	k_msleep(SX126X_RESET_PULSE_MS);
+
+	LL_RCC_RF_DisableReset();
+	k_msleep(SX126X_RESET_WAIT_MS);
+
+	/*
+	 * After RCC reset, the radio is in sleep mode. Send a wakeup command
+	 * to allow the busy flag to be properly checked.
+	 */
+	ret = sx126x_hal_wakeup(dev);
+	if (ret < 0) {
+		LOG_ERR("Wakeup failed: %d", ret);
+		return ret;
+	}
+
+	/* Wait for chip to be ready */
+	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_DBG("Reset complete");
+	return 0;
+}
+
+bool sx126x_hal_is_busy(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return LL_PWR_IsActiveFlag_RFBUSYS() != 0;
+}
+
+static void radio_isr(const struct device *dev)
+{
+	struct sx126x_hal_data *data = get_hal_data(dev);
+
+	irq_disable(DT_INST_IRQN(0));
+
+	if (data->dio1_callback != NULL) {
+		data->dio1_callback(data->dev);
+	}
+}
+
+int sx126x_hal_set_dio1_callback(const struct device *dev,
+				 void (*callback)(const struct device *dev))
+{
+	struct sx126x_hal_data *data = get_hal_data(dev);
+
+	data->dio1_callback = callback;
+
+	if (callback != NULL) {
+		NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+		irq_enable(DT_INST_IRQN(0));
+	} else {
+		irq_disable(DT_INST_IRQN(0));
+	}
+
+	return 0;
+}
+
+void sx126x_hal_dio1_irq_enable(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	irq_enable(DT_INST_IRQN(0));
+}
+
+static int sx126x_hal_set_pa_config(const struct device *dev, uint8_t pa_duty_cycle,
+				    uint8_t hp_max, uint8_t device_sel, uint8_t pa_lut)
+{
+	uint8_t buf[4] = { pa_duty_cycle, hp_max, device_sel, pa_lut };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_PA_CONFIG, buf, 4);
+}
+
+int sx126x_hal_configure_tx_params(const struct device *dev, int8_t power,
+				   uint32_t frequency, uint8_t ramp_time)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	int8_t tx_power = power;
+	uint8_t ocp_value;
+	int ret;
+
+	ARG_UNUSED(frequency);
+
+	if (config->pa_output == SX126X_PA_OUTPUT_RFO_LP) {
+		/* RFO_LP (Low Power) output */
+		const int8_t max_power = config->rfo_lp_max_power;
+
+		if (tx_power > max_power) {
+			tx_power = max_power;
+		}
+
+		if (max_power == 15) {
+			ret = sx126x_hal_set_pa_config(dev, 0x07, 0x00, 0x01, 0x01);
+			tx_power = 14 - (max_power - tx_power);
+		} else if (max_power == 10) {
+			ret = sx126x_hal_set_pa_config(dev, 0x01, 0x00, 0x01, 0x01);
+			tx_power = 13 - (max_power - tx_power);
+		} else {
+			/* Default: +14 dBm */
+			ret = sx126x_hal_set_pa_config(dev, 0x04, 0x00, 0x01, 0x01);
+			tx_power = 14 - (max_power - tx_power);
+		}
+
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (tx_power < -17) {
+			tx_power = -17;
+		}
+
+		/* PA overcurrent protection limit 60 mA for RFO_LP */
+		ocp_value = SX126X_OCP_60MA;
+	} else {
+		/* RFO_HP (High Power) output */
+		const int8_t max_power = config->rfo_hp_max_power;
+		uint8_t reg_val;
+
+		if (tx_power > max_power) {
+			tx_power = max_power;
+		}
+
+		ret = sx126x_hal_read_regs(dev, SX126X_REG_TX_CLAMP_CFG, &reg_val, 1);
+		if (ret < 0) {
+			return ret;
+		}
+		reg_val |= (0x0F << 1);
+		ret = sx126x_hal_write_regs(dev, SX126X_REG_TX_CLAMP_CFG, &reg_val, 1);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (max_power == 20) {
+			ret = sx126x_hal_set_pa_config(dev, 0x03, 0x05, 0x00, 0x01);
+			tx_power = 22 - (max_power - tx_power);
+		} else if (max_power == 17) {
+			ret = sx126x_hal_set_pa_config(dev, 0x02, 0x03, 0x00, 0x01);
+			tx_power = 22 - (max_power - tx_power);
+		} else if (max_power == 14) {
+			ret = sx126x_hal_set_pa_config(dev, 0x02, 0x02, 0x00, 0x01);
+			tx_power = 14 - (max_power - tx_power);
+		} else {
+			/* Default: +22 dBm */
+			ret = sx126x_hal_set_pa_config(dev, 0x04, 0x07, 0x00, 0x01);
+			tx_power = 22 - (max_power - tx_power);
+		}
+
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (tx_power < -9) {
+			tx_power = -9;
+		}
+
+		/* PA overcurrent protection limit 140 mA for RFO_HP */
+		ocp_value = SX126X_OCP_140MA;
+	}
+
+	/* Set OCP value */
+	ret = sx126x_hal_write_regs(dev, SX126X_REG_OCP, &ocp_value, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set TX params */
+	uint8_t buf[2] = { (uint8_t)tx_power, ramp_time };
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_TX_PARAMS, buf, 2);
+}
+
+int sx126x_hal_init(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	struct sx126x_hal_data *data = get_hal_data(dev);
+	int ret;
+
+	data->dev = dev;
+	data->dio1_callback = NULL;
+
+	if (!spi_is_ready_dt(&config->spi)) {
+		LOG_ERR("SPI bus not ready");
+		return -ENODEV;
+	}
+
+	/* Setup radio IRQ (EXTI line 44) */
+	IRQ_CONNECT(DT_INST_IRQN(0),
+		    DT_INST_IRQ(0, priority),
+		    radio_isr, DEVICE_DT_INST_GET(0), 0);
+	LL_EXTI_EnableIT_32_63(LL_EXTI_LINE_44);
+
+	/* Configure optional GPIOs */
+	ret = sx126x_hal_configure_gpio(&config->antenna_enable, GPIO_OUTPUT_INACTIVE,
+					"antenna enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sx126x_hal_configure_gpio(&config->tx_enable, GPIO_OUTPUT_INACTIVE,
+					"TX enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = sx126x_hal_configure_gpio(&config->rx_enable, GPIO_OUTPUT_INACTIVE,
+					"RX enable");
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_DBG("STM32WL HAL initialized");
+	return 0;
+}

--- a/drivers/lora/native/sx126x/sx126x_regs.h
+++ b/drivers/lora/native/sx126x/sx126x_regs.h
@@ -183,6 +183,9 @@
 /* TX Clamp Config (workaround for SX1262) */
 #define SX126X_REG_TX_CLAMP_CFG             0x08D8
 
+/* Over Current Protection */
+#define SX126X_REG_OCP                      0x08E7
+
 /* IQ Polarity (workaround) */
 #define SX126X_REG_IQ_POLARITY              0x0736
 

--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -31,3 +31,9 @@ tests:
       - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
     platform_allow:
       - nrf52840dk/nrf52840
+  sample.driver.lora.receive.native.stm32wl:
+    build_only: true
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    integration_platforms:
+      - nucleo_wl55jc

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -31,3 +31,9 @@ tests:
       - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
     platform_allow:
       - nrf52840dk/nrf52840
+  sample.driver.lora.send.native.stm32wl:
+    build_only: true
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    integration_platforms:
+      - nucleo_wl55jc

--- a/tests/drivers/build_all/lora/testcase.yaml
+++ b/tests/drivers/build_all/lora/testcase.yaml
@@ -36,3 +36,12 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+  sample.driver.lora.build.stm32wl.native:
+    tags:
+      - lora
+      - drivers
+    build_only: true
+    extra_configs:
+      - CONFIG_LORA_MODULE_BACKEND_NATIVE=y
+    platform_allow:
+      - nucleo_wl55jc


### PR DESCRIPTION
Add the native radio driver for the STM32WL, based on the previous work done for the SX126x.