### PR TITLE
device: Add asserts to DEVICE_API_GET

### DIFF
--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -87,6 +87,10 @@ applications.
 
 :c:macro:`DEVICE_API()`
    Wrap a driver API declaration to assign it to its respective linker section.
+   Use of this macro is mandatory for any driver implementing an upstream driver
+   class, as :c:macro:`DEVICE_API_GET` and :c:macro:`DEVICE_API_IS` rely on API
+   instances being placed in their class linker section to validate the device's
+   API class at runtime.
 
 .. _device_struct:
 
@@ -127,8 +131,10 @@ Most drivers will be implementing a device-independent subsystem API.
 Applications can simply program to that generic API, and application
 code is not specific to any particular driver implementation.
 
-If all driver API instances are assigned to their respective API linker section
-use :c:macro:`DEVICE_API_IS()` to verify the API's type.
+Driver API instances must be declared with :c:macro:`DEVICE_API()` so that they
+are assigned to their respective API linker section. This is required for
+:c:macro:`DEVICE_API_GET` and :c:macro:`DEVICE_API_IS` to validate at runtime
+that a device's API belongs to the expected class.
 
 A subsystem API definition typically looks like this:
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -42,6 +42,14 @@ Device Drivers and Devicetree
 ..
 .. ...
 
+* The :c:macro:`DEVICE_API` macro is now mandatory for declaring device driver API instances of any
+  upstream driver class, including in out-of-tree drivers. :c:macro:`DEVICE_API_GET` now asserts
+  that the API belongs to the requested class, which requires the instance to live in the class's
+  iterable section. Out-of-tree driver classes that embed an upstream API as their first member
+  must also declare the relationship with :c:macro:`DEVICE_API_EXTENDS`, so that
+  :c:macro:`DEVICE_API_GET` for the parent class succeeds on devices implementing the child API.
+  See :ref:`device_driver_api` for details.
+
 .. zephyr-keep-sorted-start re(^\w) ignorecase
 
 Clock Control

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -212,7 +212,7 @@ int espi_emul_register(const struct device *dev, struct espi_emul *emul)
 }
 
 /* Device instantiation */
-static struct emul_espi_driver_api emul_espi_driver_api = {
+static DEVICE_API(emul_espi, emul_driver_api) = {
 	.espi_api = {
 		.config = espi_emul_config,
 		.get_channel_status = espi_emul_get_channel_status,
@@ -240,6 +240,6 @@ static struct emul_espi_driver_api emul_espi_driver_api = {
 	};                                                                                         \
 	static struct espi_emul_data espi_emul_data_##n;                                           \
 	DEVICE_DT_INST_DEFINE(n, &espi_emul_init, NULL, &espi_emul_data_##n, &espi_emul_cfg_##n,   \
-			      POST_KERNEL, CONFIG_ESPI_INIT_PRIORITY, &emul_espi_driver_api);
+			      POST_KERNEL, CONFIG_ESPI_INIT_PRIORITY, &emul_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESPI_EMUL_INIT)

--- a/drivers/mspi/mspi_emul.c
+++ b/drivers/mspi/mspi_emul.c
@@ -842,7 +842,7 @@ int mspi_emul_register(const struct device *dev, struct mspi_emul *emul)
 }
 
 /* Device instantiation */
-static struct emul_mspi_driver_api emul_mspi_driver_api = {
+static DEVICE_API(emul_mspi, emul_driver_api) = {
 	.mspi_api = {
 			.config                = mspi_emul_config,
 			.dev_config            = mspi_emul_dev_config,
@@ -904,6 +904,6 @@ static struct emul_mspi_driver_api emul_mspi_driver_api = {
 			      &mspi_emul_cfg_##n,                                                 \
 			      POST_KERNEL,                                                        \
 			      CONFIG_MSPI_INIT_PRIORITY,                                          \
-			      &emul_mspi_driver_api);
+			      &emul_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MSPI_EMUL_INIT)

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1422,7 +1422,12 @@ DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
  *
  * @return the pointer to the device API.
  */
-#define DEVICE_API_GET(_class, _dev) Z_DEVICE_API_GET(_class, _dev)
+#define DEVICE_API_GET(_class, _dev)                                                               \
+	({                                                                                         \
+		__ASSERT(_dev != NULL, "device is NULL");                                          \
+		__ASSERT(DEVICE_API_IS(_class, _dev), "device API is not %s", STRINGIFY(_class));  \
+		Z_DEVICE_API_GET(_class, _dev);                                                    \
+	})
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -120,7 +120,7 @@ struct espi_emul {
 };
 
 /** Definition of the eSPI controller emulator API */
-struct emul_espi_driver_api {
+__subsystem struct emul_espi_driver_api {
 	/* The struct espi_driver_api has to be first in
 	 * struct emul_espi_driver_api to make pointer casting working
 	 */
@@ -129,6 +129,10 @@ struct emul_espi_driver_api {
 	emul_trigger_event trigger_event;
 	emul_find_emul find_emul;
 };
+
+/** @cond INTERNAL_HIDDEN */
+DEVICE_API_EXTENDS(emul_espi, espi, espi_api);
+/** @endcond */
 
 /**
  * Register an emulated device on the controller

--- a/include/zephyr/drivers/mspi_emul.h
+++ b/include/zephyr/drivers/mspi_emul.h
@@ -96,7 +96,7 @@ struct mspi_emul {
 };
 
 /** Definition of the MSPI controller emulator API */
-struct emul_mspi_driver_api {
+__subsystem struct emul_mspi_driver_api {
 	/* The struct mspi_driver_api has to be first in
 	 * struct emul_mspi_driver_api to make pointer casting working
 	 */
@@ -105,6 +105,10 @@ struct emul_mspi_driver_api {
 	mspi_emul_trigger_event      trigger_event;
 	mspi_emul_find_emul          find_emul;
 };
+
+/** @cond INTERNAL_HIDDEN */
+DEVICE_API_EXTENDS(emul_mspi, mspi, mspi_api);
+/** @endcond */
 
 /**
  * Register an emulated device on the controller

--- a/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
+++ b/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
@@ -529,6 +529,40 @@ ZTEST(flash_sim_api, test_flash_fill)
 	}
 }
 
+#if !defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
+/* Forwarding flash API instance with erase intentionally set to NULL, used by
+ * test_flash_flatten to verify the flash_flatten() fallback to flash_fill()
+ * when the driver's erase callback is unimplemented. The instance must live
+ * in the flash driver API iterable section (declared via DEVICE_API) so that
+ * DEVICE_API_GET passes its class assertion at runtime.
+ */
+static int no_erase_api_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	ARG_UNUSED(dev);
+	return flash_read(flash_dev, offset, data, len);
+}
+
+static int no_erase_api_write(const struct device *dev, off_t offset, const void *data,
+			      size_t len)
+{
+	ARG_UNUSED(dev);
+	return flash_write(flash_dev, offset, data, len);
+}
+
+static const struct flash_parameters *no_erase_api_get_parameters(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return flash_get_parameters(flash_dev);
+}
+
+static DEVICE_API(flash, no_erase_api) = {
+	.read = no_erase_api_read,
+	.write = no_erase_api_write,
+	.erase = NULL,
+	.get_parameters = no_erase_api_get_parameters,
+};
+#endif
+
 ZTEST(flash_sim_api, test_flash_flatten)
 {
 	int rc;
@@ -559,12 +593,9 @@ ZTEST(flash_sim_api, test_flash_flatten)
 	 * with erase_value.
 	 */
 	struct device other;
-	struct flash_driver_api api;
 
 	memcpy(&other, flash_dev, sizeof(other));
-	other.api = &api;
-	memcpy(&api, flash_dev->api, sizeof(api));
-	api.erase = NULL;
+	other.api = &no_erase_api;
 
 	/* Now fill the device with anything */
 	rc = flash_fill(flash_dev, 0xaa,

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -344,6 +344,54 @@ static int bad_write(const struct device *dev, off_t off, const void *data, size
 	return -EINVAL;
 }
 
+/* Forwarders that delegate to the real flash driver API for callbacks not under test.
+ */
+static int forward_erase(const struct device *dev, off_t off, size_t len)
+{
+	ARG_UNUSED(dev);
+	return api->erase(fdev, off, len);
+}
+
+static const struct flash_parameters *forward_get_parameters(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return api->get_parameters(fdev);
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void forward_page_layout(const struct device *dev,
+				const struct flash_pages_layout **lay,
+				size_t *lay_size)
+{
+	ARG_UNUSED(dev);
+	api->page_layout(fdev, lay, lay_size);
+}
+#endif
+
+/* Fake flash APIs used by test_stream_flash_buffered_write_callback. The instances must live in
+ * the flash driver API iterable section (declared via DEVICE_API) so that DEVICE_API_GET passes
+ * its class assertion when the test routes flash_* calls through a fake device.
+ */
+static DEVICE_API(flash, fake_api_fake_write) = {
+	.read = bad_read,
+	.write = fake_write,
+	.erase = forward_erase,
+	.get_parameters = forward_get_parameters,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = forward_page_layout,
+#endif
+};
+
+static DEVICE_API(flash, fake_api_bad_write) = {
+	.read = bad_read,
+	.write = bad_write,
+	.erase = forward_erase,
+	.get_parameters = forward_get_parameters,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = forward_page_layout,
+#endif
+};
+
 ZTEST(lib_stream_flash, test_stream_flash_buffered_write_callback)
 {
 	int rc;
@@ -384,16 +432,13 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_callback)
 	zassert_equal(ctx.buf_bytes, BUF_LEN, "Expected bytes to be left in buffer");
 
 	struct device fake_dev = *ctx.fdev;
-	struct flash_driver_api fake_api = *(struct flash_driver_api *)ctx.fdev->api;
 	struct stream_flash_ctx bad_ctx = ctx;
 	struct stream_flash_ctx cmp_ctx;
 
-	fake_api.read = bad_read;
 	/* Using fake write here because after previous write, with faked callback failure,
 	 * the flash is already written and real flash_write would cause failure.
 	 */
-	fake_api.write = fake_write;
-	fake_dev.api = &fake_api;
+	fake_dev.api = &fake_api_fake_write;
 	bad_ctx.fdev = &fake_dev;
 	/* Trigger erase attempt */
 	cmp_ctx = bad_ctx;
@@ -405,7 +450,7 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_callback)
 	/* Pretend flashed context and attempt write write block - 1 bytes to trigger unaligned
 	 * write; the write needs to fail so that we could check that context does not get modified.
 	 */
-	fake_api.write = bad_write;
+	fake_dev.api = &fake_api_bad_write;
 	bad_ctx.callback = NULL;
 	bad_ctx.buf_bytes = 0;
 	cmp_ctx = bad_ctx;


### PR DESCRIPTION
Update the `DEVICE_API_GET` macro to trigger an assert on NULL devices and incorrect device driver API class.

Needed for this PR IMO:
- https://github.com/zephyrproject-rtos/zephyr/pull/106371

Related PR:
- https://github.com/zephyrproject-rtos/zephyr/pull/106295

Done:
- https://github.com/zephyrproject-rtos/zephyr/pull/106617