### PR TITLE
bluetooth: avrcp: Fix AVRCP notification failure

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -513,14 +513,19 @@ static void avrcp_connected(struct bt_avctp *session)
 static void avrcp_disconnected(struct bt_avctp *session)
 {
 	struct bt_avrcp *avrcp = AVRCP_AVCTP(session);
+	struct bt_avrcp_ct *ct = get_avrcp_ct(avrcp);
+	struct bt_avrcp_tg *tg = get_avrcp_tg(avrcp);
 
 	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->disconnected != NULL)) {
-		avrcp_ct_cb->disconnected(get_avrcp_ct(avrcp));
+		avrcp_ct_cb->disconnected(ct);
 	}
 
 	if ((avrcp_tg_cb != NULL) && (avrcp_tg_cb->disconnected != NULL)) {
-		avrcp_tg_cb->disconnected(get_avrcp_tg(avrcp));
+		avrcp_tg_cb->disconnected(tg);
 	}
+
+	memset(&ct->ct_notify, 0, sizeof(ct->ct_notify));
+	memset(&tg->tg_notify, 0, sizeof(tg->tg_notify));
 
 	if (avrcp->acl_conn != NULL) {
 		bt_conn_unref(avrcp->acl_conn);


### PR DESCRIPTION
When calling bt_avrcp_ct_register_notification,
it sets ct->ct_notify[event_id].cb = cb.
In process_register_notification_rsp, it clears the callback by setting ct->ct_notify[event_id].cb = NULL. However, when the connection is disconnected, the callback
ct->ct_notify[event_id].cb is not set to NULL , causing subsequent notification registrations to fail immediately with an error because the callback pointer is still active.