### PR TITLE
soc: nxp: mcxe24x: Add LPTMR system timer and power management support

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_pcc.h>
 #include <zephyr/dt-bindings/clock/kinetis_scg.h>
@@ -28,6 +29,40 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&idle &pstop2 &pstop1 &stop>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <10>;
+				exit-latency-us = <100>;
+			};
+
+			stop: stop {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <0>;
+				min-residency-us = <2>;
+				exit-latency-us = <500>;
+			};
+
+			pstop1: pstop1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <2>;
+				exit-latency-us = <300>;
+			};
+
+			pstop2: pstop2 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <2>;
+				min-residency-us = <2>;
+				exit-latency-us = <200>;
+			};
 		};
 	};
 
@@ -560,7 +595,7 @@
 			compatible = "nxp,lptmr";
 			reg = <0x40040000 0x1000>;
 			interrupts = <58 0>;
-			clock-frequency = <1000>;
+			clock-frequency = <DT_FREQ_K(1)>;
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <16>;

--- a/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
@@ -7,6 +7,8 @@ zephyr_include_directories(.)
 
 zephyr_sources(soc.c)
 
+zephyr_sources_ifdef(CONFIG_PM power.c)
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 zephyr_linker_sources_ifdef(CONFIG_MCXE_FLASH_CONFIG

--- a/soc/nxp/mcx/mcxe/mcxe24x/Kconfig
+++ b/soc/nxp/mcx/mcxe/mcxe24x/Kconfig
@@ -7,6 +7,7 @@ config SOC_SERIES_MCXE24X
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
 	select HAS_MCUX
+	select HAS_PM
 	select CLOCK_CONTROL
 	select SOC_RESET_HOOK
 	select CPU_HAS_ICACHE

--- a/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig
@@ -3,20 +3,26 @@
 
 if SOC_SERIES_MCXE24X
 
-config CORTEX_M_SYSTICK
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
+
+configdefault CORTEX_M_SYSTICK
 	default n if MCUX_LPTMR_TIMER
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
+configdefault SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
-	default $(dt_node_int_prop_int,/soc/lptmr@40040000,clock-frequency) if MCUX_LPTMR_TIMER
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),clock-frequency) if MCUX_LPTMR_TIMER
 
-config NUM_IRQS
+configdefault SYS_CLOCK_TICKS_PER_SEC
+	default 1000 if MCUX_LPTMR_TIMER
+
+configdefault NUM_IRQS
 	default 146
 
-config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
+configdefault CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	default y
 
-config GPIO
+configdefault GPIO
 	default y
 
 # Enable cache management features
@@ -27,7 +33,7 @@ choice CACHE_TYPE
 	default EXTERNAL_CACHE
 endchoice
 
-config WDT_DISABLE_AT_BOOT
+configdefault WDT_DISABLE_AT_BOOT
 	default y
 
 endif # SOC_SERIES_MCXE24X

--- a/soc/nxp/mcx/mcxe/mcxe24x/power.c
+++ b/soc/nxp/mcx/mcxe/mcxe24x/power.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
+
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
+
+#ifdef CONFIG_XIP
+__ramfunc static void wait_for_flash_prefetch_and_wfi(void)
+{
+	for (uint32_t i = 0; i < 8; i++) {
+		arch_nop();
+	}
+
+	/*
+	 * Must execute WFI directly from RAM when XIP is enabled.
+	 * Calling k_cpu_idle() may jump back into flash.
+	 */
+	__DSB();
+	__ISB();
+	__WFI();
+}
+#endif /* CONFIG_XIP */
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	__disable_irq();
+	__set_BASEPRI(0);
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		/* Cortex-M sleep: WFI with SLEEPDEEP cleared. */
+		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+		__DSB();
+		__ISB();
+		__WFI();
+		break;
+
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* Substates align to KE-like STOP options: 0=STOP, 1=PSTOP1, 2=PSTOP2. */
+		if (substate_id > 2U) {
+			LOG_WRN("Unsupported substate-id %u, using 0", substate_id);
+			substate_id = 0U;
+		}
+
+		/* Ensure STOPM is set to normal STOP (not VLPS/VLLS families), if present. */
+		SMC->PMCTRL &= ~SMC_PMCTRL_STOPM_MASK;
+
+#if (defined(FSL_FEATURE_SMC_HAS_PSTOPO) && FSL_FEATURE_SMC_HAS_PSTOPO)
+		SMC->STOPCTRL = (SMC->STOPCTRL & (uint8_t)~SMC_STOPCTRL_PSTOPO_MASK) |
+				SMC_STOPCTRL_PSTOPO(substate_id);
+#endif
+
+		SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+		/* readback to complete bus writes */
+		(void)SMC->PMCTRL;
+		__DSB();
+		__ISB();
+
+#ifdef CONFIG_XIP
+		wait_for_flash_prefetch_and_wfi();
+#else
+		__WFI();
+#endif
+
+		if (SMC->PMCTRL & SMC_PMCTRL_STOPA_MASK) {
+			LOG_DBG("stop aborted");
+		}
+
+		break;
+
+	default:
+		LOG_WRN("Unsupported power state %u", state);
+		break;
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	if ((SCB->SCR & SCB_SCR_SLEEPDEEP_Msk) == SCB_SCR_SLEEPDEEP_Msk) {
+		SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+	}
+
+	__enable_irq();
+	__ISB();
+}

--- a/tests/subsys/pm/power_mgmt_soc/boards/frdm_mcxe247.conf
+++ b/tests/subsys/pm/power_mgmt_soc/boards/frdm_mcxe247.conf
@@ -1,0 +1,6 @@
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_PM_PREWAKEUP_CONV_MODE_CEIL=y
+CONFIG_MCUX_LPTMR_TIMER=y

--- a/tests/subsys/pm/power_mgmt_soc/boards/frdm_mcxe247.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/frdm_mcxe247.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,system-timer = &lptmr0;
+	};
+};
+
+&lptmr0 {
+	status = "okay";
+	clock-frequency = <DT_FREQ_K(32)>;
+	prescale-glitch-filter-bypass;
+	clk-source = <2>;
+};

--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -34,6 +34,7 @@ tests:
       - mcxw23_evk
       - frdm_mcxw23
       - frdm_mcxa153
+      - frdm_mcxe247
       - frdm_mcxa156
       - frdm_mcxa266
       - frdm_mcxa346


### PR DESCRIPTION
## Overview

This PR adds LPTMR-based system timer and power management support for the NXP MCXE24x SoC series.

## Changes

### LPTMR System Timer (Commit 1)
- Migrate LPTMR from legacy driver to hardware timer driver (`nxp,lptmr-hw-timer`)
- Configure LPTMR to use RTC32K clock source at 32kHz for better power efficiency
- Set LPTMR as default system timer, replacing Cortex-M SysTick
- Enable LPTMR on frdm_mcxe247 board

### Power Management (Commit 2)
- Add PM support with 4 power states:
  - **Runtime idle**: Cortex-M WFI with SLEEPDEEP cleared
  - **PSTOP2**: Partial stop mode with 200us exit latency
  - **PSTOP1**: Partial stop mode with 300us exit latency  
  - **STOP**: Full stop mode with 500us exit latency
- Implement `pm_state_set()` and `pm_state_exit_post_ops()` callbacks
- Add XIP-safe low power entry handling for external flash execution
- Enable HAS_PM capability for MCXE24x series

## Benefits

- Lower power consumption using LPTMR with RTC32K instead of high-frequency SysTick
- Flexible power management with multiple stop modes for different latency/power trade-offs
- LPTMR continues running in stop modes, enabling wake-up and timekeeping


- [ ] https://github.com/zephyrproject-rtos/zephyr/pull/95143
