### PR TITLE
drivers: can: can_stm32_bxcan: Fix TDTxR config

### DIFF
--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -849,8 +849,7 @@ static int can_stm32_send(const struct device *dev, const struct can_frame *fram
 		mailbox->TDHR = frame->data_32[1];
 	}
 
-	mailbox->TDTR = (mailbox->TDTR & ~CAN_TDT1R_DLC) |
-			((frame->dlc & 0xF) << CAN_TDT1R_DLC_Pos);
+	mailbox->TDTR = ((frame->dlc & 0xF) << CAN_TDT1R_DLC_Pos);
 
 	mailbox->TIR |= CAN_TI0R_TXRQ;
 	k_mutex_unlock(&data->inst_mutex);


### PR DESCRIPTION
As the TDTxR registers reset value is undefined they must be fully
initialized when used.

Without full initialization, the TGT bit might be inadvertently set, causing
the 16-bit timestamp to be sent as the last two data bytes when
CONFIG_CAN_RX_TIMESTAMP is enabled.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/98768

Signed-off-by: Giuseppe Iellamo <giellamo@gmail.com>