### PR TITLE
drivers: sensor: tmag5170: fix SPI word size

### DIFF
--- a/drivers/sensor/ti/tmag5170/tmag5170.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170.c
@@ -20,124 +20,116 @@
 
 #include "tmag5170.h"
 
-#define TMAG5170_REG_DEVICE_CONFIG	0x0U
-#define TMAG5170_REG_SENSOR_CONFIG	0x1U
-#define TMAG5170_REG_SYSTEM_CONFIG	0x2U
-#define TMAG5170_REG_ALERT_CONFIG	0x3U
-#define TMAG5170_REG_X_THRX_CONFIG	0x4U
-#define TMAG5170_REG_Y_THRX_CONFIG	0x5U
-#define TMAG5170_REG_Z_THRX_CONFIG	0x6U
-#define TMAG5170_REG_T_THRX_CONFIG	0x7U
-#define TMAG5170_REG_CONV_STATUS	0x8U
-#define TMAG5170_REG_X_CH_RESULT	0x9U
-#define TMAG5170_REG_Y_CH_RESULT	0xAU
-#define TMAG5170_REG_Z_CH_RESULT	0xBU
-#define TMAG5170_REG_TEMP_RESULT	0xCU
-#define TMAG5170_REG_AFE_STATUS		0xDU
-#define TMAG5170_REG_SYS_STATUS		0xEU
-#define TMAG5170_REG_TEST_CONFIG	0xFU
-#define TMAG5170_REG_OSC_MONITOR	0x10U
-#define TMAG5170_REG_MAG_GAIN_CONFIG	0x11U
-#define TMAG5170_REG_MAG_OFFSET_CONFIG	0x12U
-#define TMAG5170_REG_ANGLE_RESULT	0x13U
-#define TMAG5170_REG_MAGNITUDE_RESULT	0x14U
+#define TMAG5170_REG_DEVICE_CONFIG     0x0U
+#define TMAG5170_REG_SENSOR_CONFIG     0x1U
+#define TMAG5170_REG_SYSTEM_CONFIG     0x2U
+#define TMAG5170_REG_ALERT_CONFIG      0x3U
+#define TMAG5170_REG_X_THRX_CONFIG     0x4U
+#define TMAG5170_REG_Y_THRX_CONFIG     0x5U
+#define TMAG5170_REG_Z_THRX_CONFIG     0x6U
+#define TMAG5170_REG_T_THRX_CONFIG     0x7U
+#define TMAG5170_REG_CONV_STATUS       0x8U
+#define TMAG5170_REG_X_CH_RESULT       0x9U
+#define TMAG5170_REG_Y_CH_RESULT       0xAU
+#define TMAG5170_REG_Z_CH_RESULT       0xBU
+#define TMAG5170_REG_TEMP_RESULT       0xCU
+#define TMAG5170_REG_AFE_STATUS        0xDU
+#define TMAG5170_REG_SYS_STATUS        0xEU
+#define TMAG5170_REG_TEST_CONFIG       0xFU
+#define TMAG5170_REG_OSC_MONITOR       0x10U
+#define TMAG5170_REG_MAG_GAIN_CONFIG   0x11U
+#define TMAG5170_REG_MAG_OFFSET_CONFIG 0x12U
+#define TMAG5170_REG_ANGLE_RESULT      0x13U
+#define TMAG5170_REG_MAGNITUDE_RESULT  0x14U
 
-#define TMAG5170_CONV_AVG_POS		12U
-#define TMAG5170_CONV_AVG_MASK		(BIT_MASK(3U) << TMAG5170_CONV_AVG_POS)
-#define TMAG5170_CONV_AVG_SET(value)	(((value) << TMAG5170_CONV_AVG_POS) &\
-					TMAG5170_CONV_AVG_MASK)
+#define TMAG5170_CONV_AVG_POS        12U
+#define TMAG5170_CONV_AVG_MASK       (BIT_MASK(3U) << TMAG5170_CONV_AVG_POS)
+#define TMAG5170_CONV_AVG_SET(value) (((value) << TMAG5170_CONV_AVG_POS) & TMAG5170_CONV_AVG_MASK)
 
-#define TMAG5170_MAG_TEMPCO_POS		8U
-#define TMAG5170_MAG_TEMPCO_MASK	(BIT_MASK(2U) << TMAG5170_MAG_TEMPCO_POS)
-#define TMAG5170_MAG_TEMPCO_SET(value)	(((value) << TMAG5170_MAG_TEMPCO_POS) &\
-					TMAG5170_MAG_TEMPCO_MASK)
+#define TMAG5170_MAG_TEMPCO_POS  8U
+#define TMAG5170_MAG_TEMPCO_MASK (BIT_MASK(2U) << TMAG5170_MAG_TEMPCO_POS)
+#define TMAG5170_MAG_TEMPCO_SET(value)                                                             \
+	(((value) << TMAG5170_MAG_TEMPCO_POS) & TMAG5170_MAG_TEMPCO_MASK)
 
-#define TMAG5170_OPERATING_MODE_POS		4U
-#define TMAG5170_OPERATING_MODE_MASK		(BIT_MASK(3U) << TMAG5170_OPERATING_MODE_POS)
-#define TMAG5170_OPERATING_MODE_SET(value)	(((value) << TMAG5170_OPERATING_MODE_POS) &\
-						TMAG5170_OPERATING_MODE_MASK)
+#define TMAG5170_OPERATING_MODE_POS  4U
+#define TMAG5170_OPERATING_MODE_MASK (BIT_MASK(3U) << TMAG5170_OPERATING_MODE_POS)
+#define TMAG5170_OPERATING_MODE_SET(value)                                                         \
+	(((value) << TMAG5170_OPERATING_MODE_POS) & TMAG5170_OPERATING_MODE_MASK)
 
-#define TMAG5170_T_CH_EN_POS		3U
-#define TMAG5170_T_CH_EN_MASK		(BIT_MASK(1U) << TMAG5170_T_CH_EN_POS)
-#define TMAG5170_T_CH_EN_SET(value)	(((value) << TMAG5170_T_CH_EN_POS) &\
-					TMAG5170_T_CH_EN_MASK)
+#define TMAG5170_T_CH_EN_POS        3U
+#define TMAG5170_T_CH_EN_MASK       (BIT_MASK(1U) << TMAG5170_T_CH_EN_POS)
+#define TMAG5170_T_CH_EN_SET(value) (((value) << TMAG5170_T_CH_EN_POS) & TMAG5170_T_CH_EN_MASK)
 
-#define TMAG5170_T_RATE_POS		2U
-#define TMAG5170_T_RATE_MASK		(BIT_MASK(1U) << TMAG5170_T_RATE_POS)
-#define TMAG5170_T_RATE_SET(value)	(((value) << TMAG5170_T_RATE_POS) &\
-					TMAG5170_T_RATE_MASK)
+#define TMAG5170_T_RATE_POS        2U
+#define TMAG5170_T_RATE_MASK       (BIT_MASK(1U) << TMAG5170_T_RATE_POS)
+#define TMAG5170_T_RATE_SET(value) (((value) << TMAG5170_T_RATE_POS) & TMAG5170_T_RATE_MASK)
 
-#define TMAG5170_ANGLE_EN_POS		14U
-#define TMAG5170_ANGLE_EN_MASK		(BIT_MASK(2U) << TMAG5170_ANGLE_EN_POS)
-#define TMAG5170_ANGLE_EN_SET(value)	(((value) << TMAG5170_ANGLE_EN_POS) &\
-					TMAG5170_ANGLE_EN_MASK)
+#define TMAG5170_ANGLE_EN_POS        14U
+#define TMAG5170_ANGLE_EN_MASK       (BIT_MASK(2U) << TMAG5170_ANGLE_EN_POS)
+#define TMAG5170_ANGLE_EN_SET(value) (((value) << TMAG5170_ANGLE_EN_POS) & TMAG5170_ANGLE_EN_MASK)
 
-#define TMAG5170_SLEEPTIME_POS	10U
-#define TMAG5170_SLEEPTIME_MASK		(BIT_MASK(4U) << TMAG5170_SLEEPTIME_POS)
-#define TMAG5170_SLEEPTIME_SET(value)	(((value) << TMAG5170_SLEEPTIME_POS) &\
-					TMAG5170_SLEEPTIME_MASK)
+#define TMAG5170_SLEEPTIME_POS  10U
+#define TMAG5170_SLEEPTIME_MASK (BIT_MASK(4U) << TMAG5170_SLEEPTIME_POS)
+#define TMAG5170_SLEEPTIME_SET(value)                                                              \
+	(((value) << TMAG5170_SLEEPTIME_POS) & TMAG5170_SLEEPTIME_MASK)
 
-#define TMAG5170_MAG_CH_EN_POS	6U
-#define TMAG5170_MAG_CH_EN_MASK		(BIT_MASK(4U) << TMAG5170_MAG_CH_EN_POS)
-#define TMAG5170_MAG_CH_EN_SET(value)	(((value) << TMAG5170_MAG_CH_EN_POS) &\
-					TMAG5170_MAG_CH_EN_MASK)
+#define TMAG5170_MAG_CH_EN_POS  6U
+#define TMAG5170_MAG_CH_EN_MASK (BIT_MASK(4U) << TMAG5170_MAG_CH_EN_POS)
+#define TMAG5170_MAG_CH_EN_SET(value)                                                              \
+	(((value) << TMAG5170_MAG_CH_EN_POS) & TMAG5170_MAG_CH_EN_MASK)
 
-#define TMAG5170_Z_RANGE_POS		4U
-#define TMAG5170_Z_RANGE_MASK		(BIT_MASK(2U) << TMAG5170_Z_RANGE_POS)
-#define TMAG5170_Z_RANGE_SET(value)	(((value) << TMAG5170_Z_RANGE_POS) &\
-					TMAG5170_Z_RANGE_MASK)
+#define TMAG5170_Z_RANGE_POS        4U
+#define TMAG5170_Z_RANGE_MASK       (BIT_MASK(2U) << TMAG5170_Z_RANGE_POS)
+#define TMAG5170_Z_RANGE_SET(value) (((value) << TMAG5170_Z_RANGE_POS) & TMAG5170_Z_RANGE_MASK)
 
-#define TMAG5170_Y_RANGE_POS		2U
-#define TMAG5170_Y_RANGE_MASK		(BIT_MASK(2U) << TMAG5170_Y_RANGE_POS)
-#define TMAG5170_Y_RANGE_SET(value)	(((value) << TMAG5170_Y_RANGE_POS) &\
-					TMAG5170_Y_RANGE_MASK)
+#define TMAG5170_Y_RANGE_POS        2U
+#define TMAG5170_Y_RANGE_MASK       (BIT_MASK(2U) << TMAG5170_Y_RANGE_POS)
+#define TMAG5170_Y_RANGE_SET(value) (((value) << TMAG5170_Y_RANGE_POS) & TMAG5170_Y_RANGE_MASK)
 
-#define TMAG5170_X_RANGE_POS		0U
-#define TMAG5170_X_RANGE_MASK		(BIT_MASK(2U) << TMAG5170_X_RANGE_POS)
-#define TMAG5170_X_RANGE_SET(value)	(((value) << TMAG5170_X_RANGE_POS) &\
-					TMAG5170_X_RANGE_MASK)
+#define TMAG5170_X_RANGE_POS        0U
+#define TMAG5170_X_RANGE_MASK       (BIT_MASK(2U) << TMAG5170_X_RANGE_POS)
+#define TMAG5170_X_RANGE_SET(value) (((value) << TMAG5170_X_RANGE_POS) & TMAG5170_X_RANGE_MASK)
 
-#define TMAG5170_RSLT_ALRT_POS		8U
-#define TMAG5170_RSLT_ALRT_MASK		(BIT_MASK(1U) << TMAG5170_RSLT_ALRT_POS)
-#define TMAG5170_RSLT_ALRT_SET(value)	(((value) << TMAG5170_RSLT_ALRT_POS) &\
-					TMAG5170_RSLT_ALRT_MASK)
+#define TMAG5170_RSLT_ALRT_POS  8U
+#define TMAG5170_RSLT_ALRT_MASK (BIT_MASK(1U) << TMAG5170_RSLT_ALRT_POS)
+#define TMAG5170_RSLT_ALRT_SET(value)                                                              \
+	(((value) << TMAG5170_RSLT_ALRT_POS) & TMAG5170_RSLT_ALRT_MASK)
 
-#define TMAG5170_VER_POS	4U
-#define TMAG5170_VER_MASK	(BIT_MASK(2U) << TMAG5170_VER_POS)
-#define TMAG5170_VER_GET(value)	(((value) & TMAG5170_VER_MASK) >> TMAG5170_VER_POS)
+#define TMAG5170_VER_POS        4U
+#define TMAG5170_VER_MASK       (BIT_MASK(2U) << TMAG5170_VER_POS)
+#define TMAG5170_VER_GET(value) (((value) & TMAG5170_VER_MASK) >> TMAG5170_VER_POS)
 
-#define TMAG5170_A1_REV				0x0U
-#define TMAG5170_A2_REV				0x1U
+#define TMAG5170_A1_REV 0x0U
+#define TMAG5170_A2_REV 0x1U
 
-#define TMAG5170_MAX_RANGE_50MT_IDX		0x0U
-#define TMAG5170_MAX_RANGE_25MT_IDX		0x1U
-#define TMAG5170_MAX_RANGE_100MT_IDX		0x2U
-#define TMAG5170_MAX_RANGE_EXTEND_FACTOR	0x3U
+#define TMAG5170_MAX_RANGE_50MT_IDX      0x0U
+#define TMAG5170_MAX_RANGE_25MT_IDX      0x1U
+#define TMAG5170_MAX_RANGE_100MT_IDX     0x2U
+#define TMAG5170_MAX_RANGE_EXTEND_FACTOR 0x3U
 
-#define TMAG5170_CONFIGURATION_MODE		0x0U
-#define TMAG5170_STAND_BY_MODE			0x1U
-#define TMAG5170_ACTIVE_TRIGGER_MODE		0x3U
-#define TMAG5170_SLEEP_MODE			0x5U
-#define TMAG5170_DEEP_SLEEP_MODE		0x6U
+#define TMAG5170_CONFIGURATION_MODE  0x0U
+#define TMAG5170_STAND_BY_MODE       0x1U
+#define TMAG5170_ACTIVE_TRIGGER_MODE 0x3U
+#define TMAG5170_SLEEP_MODE          0x5U
+#define TMAG5170_DEEP_SLEEP_MODE     0x6U
 
-#define TMAG5170_MT_TO_GAUSS_RATIO		10U
-#define TMAG5170_T_SENS_T0			25U
-#define TMAG5170_T_ADC_T0			17522U
-#define TMAG5170_T_ADC_RES			60U
+#define TMAG5170_MT_TO_GAUSS_RATIO 10U
+#define TMAG5170_T_SENS_T0         25U
+#define TMAG5170_T_ADC_T0          17522U
+#define TMAG5170_T_ADC_RES         60U
 
-#define TMAG5170_CMD_TRIGGER_CONVERSION		BIT(0U)
+#define TMAG5170_CMD_TRIGGER_CONVERSION BIT(0U)
 
-#define TMAG5170_CRC_SEED			0xFU
-#define TMAG5170_CRC_POLY			0x3U
-#define TMAG5170_SPI_BUFFER_LEN			4U
-#define TMAG5170_SET_CRC(buf, crc)		((uint8_t *)(buf))[3] |= (crc & 0x0F)
-#define TMAG5170_ZERO_CRC(buf)			((uint8_t *)(buf))[3] &= 0xF0
-#define TMAG5170_GET_CRC(buf)			((uint8_t *)(buf))[3] & 0x0F
+#define TMAG5170_CRC_SEED          0xFU
+#define TMAG5170_CRC_POLY          0x3U
+#define TMAG5170_SPI_BUFFER_LEN    4U
+#define TMAG5170_SET_CRC(buf, crc) ((uint8_t *)(buf))[3] |= (crc & 0x0F)
+#define TMAG5170_ZERO_CRC(buf)     ((uint8_t *)(buf))[3] &= 0xF0
+#define TMAG5170_GET_CRC(buf)      ((uint8_t *)(buf))[3] & 0x0F
 
 LOG_MODULE_REGISTER(TMAG5170, CONFIG_SENSOR_LOG_LEVEL);
 
-static int tmag5170_transmit_raw(const struct tmag5170_dev_config *config,
-				 uint8_t *buffer_tx,
+static int tmag5170_transmit_raw(const struct tmag5170_dev_config *config, uint8_t *buffer_tx,
 				 uint8_t *buffer_rx)
 {
 	const struct spi_buf tx_buf = {
@@ -145,20 +137,14 @@ static int tmag5170_transmit_raw(const struct tmag5170_dev_config *config,
 		.len = TMAG5170_SPI_BUFFER_LEN,
 	};
 
-	const struct spi_buf_set tx = {
-		.buffers = &tx_buf,
-		.count = 1
-	};
+	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = 1};
 
 	const struct spi_buf rx_buf = {
 		.buf = buffer_rx,
 		.len = TMAG5170_SPI_BUFFER_LEN,
 	};
 
-	const struct spi_buf_set rx = {
-		.buffers = &rx_buf,
-		.count = 1
-	};
+	const struct spi_buf_set rx = {.buffers = &rx_buf, .count = 1};
 
 	int ret = spi_transceive_dt(&config->bus, &tx, &rx);
 
@@ -191,18 +177,16 @@ static int tmag5170_transmit(const struct device *dev, uint8_t *buffer_tx, uint8
 
 static int tmag5170_write_register(const struct device *dev, uint32_t reg, uint16_t data)
 {
-	uint8_t buffer_tx[4] = { reg, (data >> 8) & 0xFF, data & 0xFF, 0x00U };
+	uint8_t buffer_tx[4] = {reg, (data >> 8) & 0xFF, data & 0xFF, 0x00U};
 
 	return tmag5170_transmit(dev, buffer_tx, NULL);
 }
 
-static int tmag5170_read_register(const struct device *dev,
-				  uint32_t reg,
-				  uint16_t *output,
+static int tmag5170_read_register(const struct device *dev, uint32_t reg, uint16_t *output,
 				  uint8_t cmd)
 {
-	uint8_t buffer_tx[4] = { BIT(7) | reg, 0x00U, 0x00U, (cmd & BIT_MASK(4U)) << 4U };
-	uint8_t buffer_rx[4] = { 0x00U };
+	uint8_t buffer_tx[4] = {BIT(7) | reg, 0x00U, 0x00U, (cmd & BIT_MASK(4U)) << 4U};
+	uint8_t buffer_rx[4] = {0x00U};
 
 	int ret = tmag5170_transmit(dev, buffer_tx, buffer_rx);
 
@@ -212,8 +196,7 @@ static int tmag5170_read_register(const struct device *dev,
 }
 
 static int tmag5170_convert_magn_reading_to_gauss(struct sensor_value *output,
-						  uint16_t chan_reading,
-						  uint8_t chan_range,
+						  uint16_t chan_reading, uint8_t chan_range,
 						  uint8_t chip_revision)
 {
 	uint16_t max_range_mt = 0U;
@@ -267,7 +250,7 @@ static void tmag5170_convert_temp_reading_to_celsius(struct sensor_value *output
 }
 
 static void tmag5170_convert_angle_reading_to_degrees(struct sensor_value *output,
-						     uint16_t chan_reading)
+						      uint16_t chan_reading)
 {
 	/* 12 MSBs store the integer part of the result,
 	 * 4 LSBs store the fractional part of the result
@@ -276,8 +259,7 @@ static void tmag5170_convert_angle_reading_to_degrees(struct sensor_value *outpu
 	output->val2 = ((chan_reading & 0xF) * 1000000) / 16;
 }
 
-static int tmag5170_sample_fetch(const struct device *dev,
-				 enum sensor_channel chan)
+static int tmag5170_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	const struct tmag5170_dev_config *cfg = dev->config;
 	struct tmag5170_data *drv_data = dev->data;
@@ -287,9 +269,7 @@ static int tmag5170_sample_fetch(const struct device *dev,
 	    cfg->operating_mode == TMAG5170_ACTIVE_TRIGGER_MODE) {
 		uint16_t read_status;
 
-		tmag5170_read_register(dev,
-				       TMAG5170_REG_SYS_STATUS,
-				       &read_status,
+		tmag5170_read_register(dev, TMAG5170_REG_SYS_STATUS, &read_status,
 				       TMAG5170_CMD_TRIGGER_CONVERSION);
 
 		/* Wait for the measurement to be ready.
@@ -312,61 +292,42 @@ static int tmag5170_sample_fetch(const struct device *dev,
 		ret = tmag5170_read_register(dev, TMAG5170_REG_X_CH_RESULT, &drv_data->x, 0U);
 
 		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_Y_CH_RESULT,
-						     &drv_data->y,
+			ret = tmag5170_read_register(dev, TMAG5170_REG_Y_CH_RESULT, &drv_data->y,
 						     0U);
 		}
 		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_Z_CH_RESULT,
-						     &drv_data->z,
+			ret = tmag5170_read_register(dev, TMAG5170_REG_Z_CH_RESULT, &drv_data->z,
 						     0U);
 		}
 		break;
 	case SENSOR_CHAN_ROTATION:
-		ret = tmag5170_read_register(dev,
-					     TMAG5170_REG_ANGLE_RESULT,
-					     &drv_data->angle,
-					     0U);
+		ret = tmag5170_read_register(dev, TMAG5170_REG_ANGLE_RESULT, &drv_data->angle, 0U);
 		break;
 	case SENSOR_CHAN_AMBIENT_TEMP:
-		ret = tmag5170_read_register(dev,
-					TMAG5170_REG_TEMP_RESULT,
-					&drv_data->temperature,
-					0U);
+		ret = tmag5170_read_register(dev, TMAG5170_REG_TEMP_RESULT, &drv_data->temperature,
+					     0U);
 		break;
 	case SENSOR_CHAN_ALL:
-		ret = tmag5170_read_register(dev,
-					     TMAG5170_REG_TEMP_RESULT,
-					     &drv_data->temperature,
+		ret = tmag5170_read_register(dev, TMAG5170_REG_TEMP_RESULT, &drv_data->temperature,
 					     0U);
 
 		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_ANGLE_RESULT,
-						     &drv_data->angle,
+			ret = tmag5170_read_register(dev, TMAG5170_REG_ANGLE_RESULT,
+						     &drv_data->angle, 0U);
+		}
+
+		if (ret == 0) {
+			ret = tmag5170_read_register(dev, TMAG5170_REG_X_CH_RESULT, &drv_data->x,
 						     0U);
 		}
 
 		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_X_CH_RESULT,
-						     &drv_data->x,
+			ret = tmag5170_read_register(dev, TMAG5170_REG_Y_CH_RESULT, &drv_data->y,
 						     0U);
 		}
 
 		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_Y_CH_RESULT,
-						     &drv_data->y,
-						     0U);
-		}
-
-		if (ret == 0) {
-			ret = tmag5170_read_register(dev,
-						     TMAG5170_REG_Z_CH_RESULT,
-						     &drv_data->z,
+			ret = tmag5170_read_register(dev, TMAG5170_REG_Z_CH_RESULT, &drv_data->z,
 						     0U);
 		}
 
@@ -379,8 +340,7 @@ static int tmag5170_sample_fetch(const struct device *dev,
 	return ret;
 }
 
-static int tmag5170_channel_get(const struct device *dev,
-				enum sensor_channel chan,
+static int tmag5170_channel_get(const struct device *dev, enum sensor_channel chan,
 				struct sensor_value *val)
 {
 	const struct tmag5170_dev_config *cfg = dev->config;
@@ -389,41 +349,29 @@ static int tmag5170_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_XYZ:
-		ret = tmag5170_convert_magn_reading_to_gauss(val,
-							     drv_data->x,
-							     cfg->x_range,
+		ret = tmag5170_convert_magn_reading_to_gauss(val, drv_data->x, cfg->x_range,
 							     drv_data->chip_revision);
 
 		if (ret == 0) {
-			ret = tmag5170_convert_magn_reading_to_gauss(val + 1,
-								     drv_data->y,
-								     cfg->y_range,
-								     drv_data->chip_revision);
+			ret = tmag5170_convert_magn_reading_to_gauss(
+				val + 1, drv_data->y, cfg->y_range, drv_data->chip_revision);
 		}
 
 		if (ret == 0) {
-			ret = tmag5170_convert_magn_reading_to_gauss(val + 2,
-								     drv_data->z,
-								     cfg->z_range,
-								     drv_data->chip_revision);
+			ret = tmag5170_convert_magn_reading_to_gauss(
+				val + 2, drv_data->z, cfg->z_range, drv_data->chip_revision);
 		}
 		break;
 	case SENSOR_CHAN_MAGN_X:
-		ret = tmag5170_convert_magn_reading_to_gauss(val,
-							     drv_data->x,
-							     cfg->x_range,
+		ret = tmag5170_convert_magn_reading_to_gauss(val, drv_data->x, cfg->x_range,
 							     drv_data->chip_revision);
 		break;
 	case SENSOR_CHAN_MAGN_Y:
-		ret = tmag5170_convert_magn_reading_to_gauss(val,
-							     drv_data->y,
-							     cfg->y_range,
+		ret = tmag5170_convert_magn_reading_to_gauss(val, drv_data->y, cfg->y_range,
 							     drv_data->chip_revision);
 		break;
 	case SENSOR_CHAN_MAGN_Z:
-		ret = tmag5170_convert_magn_reading_to_gauss(val,
-							     drv_data->z,
-							     cfg->z_range,
+		ret = tmag5170_convert_magn_reading_to_gauss(val, drv_data->z, cfg->z_range,
 							     drv_data->chip_revision);
 		break;
 	case SENSOR_CHAN_ROTATION:
@@ -448,7 +396,7 @@ static int tmag5170_init_registers(const struct device *dev)
 	int ret = 0;
 
 #if !defined(CONFIG_TMAG5170_CRC)
-	const uint8_t disable_crc_packet[4] = { 0x0FU, 0x0U, 0x04U, 0x07U };
+	const uint8_t disable_crc_packet[4] = {0x0FU, 0x0U, 0x04U, 0x07U};
 
 	ret = tmag5170_transmit_raw(cfg, disable_crc_packet, NULL);
 #endif
@@ -459,9 +407,9 @@ static int tmag5170_init_registers(const struct device *dev)
 	if (ret == 0) {
 		drv_data->chip_revision = TMAG5170_VER_GET(test_cfg_reg);
 
-		ret = tmag5170_write_register(dev,
-				TMAG5170_REG_SENSOR_CONFIG,
-				TMAG5170_ANGLE_EN_SET(cfg->angle_measurement) |
+		ret = tmag5170_write_register(
+			dev, TMAG5170_REG_SENSOR_CONFIG,
+			TMAG5170_ANGLE_EN_SET(cfg->angle_measurement) |
 				TMAG5170_SLEEPTIME_SET(cfg->sleep_time) |
 				TMAG5170_MAG_CH_EN_SET(cfg->magnetic_channels) |
 				TMAG5170_Z_RANGE_SET(cfg->z_range) |
@@ -471,15 +419,14 @@ static int tmag5170_init_registers(const struct device *dev)
 
 #if defined(CONFIG_TMAG5170_TRIGGER)
 	if (ret == 0) {
-		ret = tmag5170_write_register(dev,
-				TMAG5170_REG_ALERT_CONFIG,
-				TMAG5170_RSLT_ALRT_SET(1U));
+		ret = tmag5170_write_register(dev, TMAG5170_REG_ALERT_CONFIG,
+					      TMAG5170_RSLT_ALRT_SET(1U));
 	}
 #endif
 	if (ret == 0) {
-		ret = tmag5170_write_register(dev,
-				TMAG5170_REG_DEVICE_CONFIG,
-				TMAG5170_OPERATING_MODE_SET(cfg->operating_mode) |
+		ret = tmag5170_write_register(
+			dev, TMAG5170_REG_DEVICE_CONFIG,
+			TMAG5170_OPERATING_MODE_SET(cfg->operating_mode) |
 				TMAG5170_CONV_AVG_SET(cfg->oversampling) |
 				TMAG5170_MAG_TEMPCO_SET(cfg->magnet_type) |
 				TMAG5170_T_CH_EN_SET(cfg->temperature_measurement) |
@@ -490,24 +437,22 @@ static int tmag5170_init_registers(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int tmag5170_pm_action(const struct device *dev,
-			      enum pm_device_action action)
+static int tmag5170_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret_val = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		tmag5170_write_register(dev,
-					TMAG5170_REG_DEVICE_CONFIG,
+		tmag5170_write_register(dev, TMAG5170_REG_DEVICE_CONFIG,
 					TMAG5170_OPERATING_MODE_SET(TMAG5170_CONFIGURATION_MODE));
 		/* As per datasheet, waking up from deep-sleep can take up to 500us */
 		k_sleep(K_USEC(500));
 		ret_val = tmag5170_init_registers(dev);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		ret_val = tmag5170_write_register(dev,
-					TMAG5170_REG_DEVICE_CONFIG,
-					TMAG5170_OPERATING_MODE_SET(TMAG5170_DEEP_SLEEP_MODE));
+		ret_val = tmag5170_write_register(
+			dev, TMAG5170_REG_DEVICE_CONFIG,
+			TMAG5170_OPERATING_MODE_SET(TMAG5170_DEEP_SLEEP_MODE));
 		break;
 	default:
 		ret_val = -ENOTSUP;
@@ -517,11 +462,10 @@ static int tmag5170_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static DEVICE_API(sensor, tmag5170_driver_api) = {
-	.sample_fetch = tmag5170_sample_fetch,
-	.channel_get = tmag5170_channel_get,
+static DEVICE_API(sensor, tmag5170_driver_api) = {.sample_fetch = tmag5170_sample_fetch,
+						  .channel_get = tmag5170_channel_get,
 #if defined(CONFIG_TMAG5170_TRIGGER)
-	.trigger_set = tmag5170_trigger_set
+						  .trigger_set = tmag5170_trigger_set
 #endif
 };
 
@@ -549,37 +493,29 @@ static int tmag5170_init(const struct device *dev)
 	return ret;
 }
 
-#define DEFINE_TMAG5170(_num)								   \
-	static struct tmag5170_data tmag5170_data_##_num;				   \
-	static const struct tmag5170_dev_config tmag5170_config_##_num = {		   \
-		.bus = SPI_DT_SPEC_INST_GET(_num,					   \
-					   SPI_OP_MODE_MASTER |				   \
-					   SPI_TRANSFER_MSB |				   \
-					   SPI_WORD_SET(32)),				   \
-		.magnetic_channels = DT_INST_ENUM_IDX(_num, magnetic_channels),		   \
-		.x_range = DT_INST_ENUM_IDX(_num, x_range),				   \
-		.y_range = DT_INST_ENUM_IDX(_num, y_range),				   \
-		.z_range = DT_INST_ENUM_IDX(_num, z_range),				   \
-		.operating_mode = DT_INST_PROP(_num, operating_mode),			   \
-		.oversampling = DT_INST_ENUM_IDX(_num, oversampling),			   \
-		.temperature_measurement = DT_INST_PROP(_num, enable_temperature_channel), \
-		.magnet_type = DT_INST_ENUM_IDX(_num, magnet_type),			   \
-		.angle_measurement = DT_INST_ENUM_IDX(_num, angle_measurement),		   \
-		.disable_temperature_oversampling = DT_INST_PROP(_num,			   \
-							disable_temperature_oversampling), \
-		.sleep_time = DT_INST_ENUM_IDX(_num, sleep_time),			   \
-		IF_ENABLED(CONFIG_TMAG5170_TRIGGER,					   \
-			(.int_gpio = GPIO_DT_SPEC_INST_GET_OR(_num, int_gpios, { 0 }),))   \
-	};										   \
-	PM_DEVICE_DT_INST_DEFINE(_num, tmag5170_pm_action);				   \
-											   \
-	SENSOR_DEVICE_DT_INST_DEFINE(_num,						   \
-				tmag5170_init,						   \
-				PM_DEVICE_DT_INST_GET(_num),				   \
-				&tmag5170_data_##_num,					   \
-				&tmag5170_config_##_num,				   \
-				POST_KERNEL,						   \
-				CONFIG_SENSOR_INIT_PRIORITY,				   \
-				&tmag5170_driver_api);
+#define DEFINE_TMAG5170(_num)                                                                      \
+	static struct tmag5170_data tmag5170_data_##_num;                                          \
+	static const struct tmag5170_dev_config tmag5170_config_##_num = {                         \
+		.bus = SPI_DT_SPEC_INST_GET(_num, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |          \
+							  SPI_WORD_SET(32)),                       \
+		.magnetic_channels = DT_INST_ENUM_IDX(_num, magnetic_channels),                    \
+		.x_range = DT_INST_ENUM_IDX(_num, x_range),                                        \
+		.y_range = DT_INST_ENUM_IDX(_num, y_range),                                        \
+		.z_range = DT_INST_ENUM_IDX(_num, z_range),                                        \
+		.operating_mode = DT_INST_PROP(_num, operating_mode),                              \
+		.oversampling = DT_INST_ENUM_IDX(_num, oversampling),                              \
+		.temperature_measurement = DT_INST_PROP(_num, enable_temperature_channel),         \
+		.magnet_type = DT_INST_ENUM_IDX(_num, magnet_type),                                \
+		.angle_measurement = DT_INST_ENUM_IDX(_num, angle_measurement),                    \
+		.disable_temperature_oversampling =                                                \
+			DT_INST_PROP(_num, disable_temperature_oversampling),                      \
+		.sleep_time = DT_INST_ENUM_IDX(_num, sleep_time),                                  \
+		IF_ENABLED(CONFIG_TMAG5170_TRIGGER, (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(_num,    \
+								int_gpios, { 0 }),)) };           \
+	PM_DEVICE_DT_INST_DEFINE(_num, tmag5170_pm_action);                                        \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(_num, tmag5170_init, PM_DEVICE_DT_INST_GET(_num),             \
+				     &tmag5170_data_##_num, &tmag5170_config_##_num, POST_KERNEL,  \
+				     CONFIG_SENSOR_INIT_PRIORITY, &tmag5170_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_TMAG5170)

--- a/drivers/sensor/ti/tmag5170/tmag5170.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170.c
@@ -497,7 +497,7 @@ static int tmag5170_init(const struct device *dev)
 	static struct tmag5170_data tmag5170_data_##_num;                                          \
 	static const struct tmag5170_dev_config tmag5170_config_##_num = {                         \
 		.bus = SPI_DT_SPEC_INST_GET(_num, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |          \
-							  SPI_WORD_SET(32)),                       \
+							  SPI_WORD_SET(8)),                        \
 		.magnetic_channels = DT_INST_ENUM_IDX(_num, magnetic_channels),                    \
 		.x_range = DT_INST_ENUM_IDX(_num, x_range),                                        \
 		.y_range = DT_INST_ENUM_IDX(_num, y_range),                                        \

--- a/drivers/sensor/ti/tmag5170/tmag5170.h
+++ b/drivers/sensor/ti/tmag5170/tmag5170.h
@@ -48,16 +48,14 @@ struct tmag5170_data {
 	struct k_sem sem;
 	struct k_thread thread;
 
-	K_KERNEL_STACK_MEMBER(thread_stack,
-			      CONFIG_TMAG5170_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_TMAG5170_THREAD_STACK_SIZE);
 #elif defined(CONFIG_TMAG5170_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;
 #endif
 };
 
 #if defined(CONFIG_TMAG5170_TRIGGER)
-int tmag5170_trigger_set(const struct device *dev,
-			 const struct sensor_trigger *trig,
+int tmag5170_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			 sensor_trigger_handler_t handler);
 
 int tmag5170_trigger_init(const struct device *dev);

--- a/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
@@ -44,21 +44,16 @@ static void tmag5170_thread_main(void *arg1, void *unused1, void *unused2)
 #if defined(CONFIG_TMAG5170_TRIGGER_GLOBAL_THREAD)
 static void tmag5170_work_handler(struct k_work *work)
 {
-	struct tmag5170_data *data = CONTAINER_OF(work,
-						  struct tmag5170_data,
-						  work);
+	struct tmag5170_data *data = CONTAINER_OF(work, struct tmag5170_data, work);
 
 	tmag5170_handle_interrupts(data->dev);
 }
 #endif
 
-static void tmag5170_gpio_callback(const struct device *port,
-				   struct gpio_callback *cb,
+static void tmag5170_gpio_callback(const struct device *port, struct gpio_callback *cb,
 				   uint32_t pin)
 {
-	struct tmag5170_data *data = CONTAINER_OF(cb,
-						  struct tmag5170_data,
-						  gpio_cb);
+	struct tmag5170_data *data = CONTAINER_OF(cb, struct tmag5170_data, gpio_cb);
 
 	ARG_UNUSED(port);
 	ARG_UNUSED(pin);
@@ -72,10 +67,8 @@ static void tmag5170_gpio_callback(const struct device *port,
 #endif
 }
 
-int tmag5170_trigger_set(
-	const struct device *dev,
-	const struct sensor_trigger *trig,
-	sensor_trigger_handler_t handler)
+int tmag5170_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			 sensor_trigger_handler_t handler)
 {
 	struct tmag5170_data *data = dev->data;
 
@@ -104,17 +97,9 @@ int tmag5170_trigger_init(const struct device *dev)
 
 #if defined(CONFIG_TMAG5170_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->sem, 0, 1);
-	k_thread_create(
-		&data->thread,
-		data->thread_stack,
-		CONFIG_TMAG5170_THREAD_STACK_SIZE,
-		tmag5170_thread_main,
-		(void *)dev,
-		NULL,
-		NULL,
-		K_PRIO_COOP(CONFIG_TMAG5170_THREAD_PRIORITY),
-		0,
-		K_NO_WAIT);
+	k_thread_create(&data->thread, data->thread_stack, CONFIG_TMAG5170_THREAD_STACK_SIZE,
+			tmag5170_thread_main, (void *)dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_TMAG5170_THREAD_PRIORITY), 0, K_NO_WAIT);
 #elif defined(CONFIG_TMAG5170_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = tmag5170_work_handler;
 #endif


### PR DESCRIPTION
This PR fixes the TMAG5170 sensor driver by configuring the SPI bus to use an 8-bit word size, matching the device’s SPI protocol requirements.

### Problem
As reported in #103615, the driver configures an incorrect SPI word size. On SPI controllers that strictly enforce the configured word size, this can lead to malformed transfers and the device not responding as expected.
### Solution
Update the TMAG5170 driver SPI configuration to use 8-bit words for register access and transfers.
### Scope / Impact
Files changed: drivers/sensor/ti/tmag5170/tmag5170.c
Behavioral change: SPI transfers now match the TMAG5170 protocol; no intended changes outside of fixing the transfer framing.
### References
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/103615