### PR TITLE
Bluetooth: CAP: Add missing NULL checks in acceptor_register

### DIFF
--- a/subsys/bluetooth/audio/cap_acceptor.c
+++ b/subsys/bluetooth/audio/cap_acceptor.c
@@ -35,6 +35,12 @@ int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *par
 	static struct bt_gatt_service cas;
 	int err;
 
+	if (param == NULL) {
+		LOG_DBG("param is NULL");
+
+		return -EINVAL;
+	}
+
 	if (param->set_size == 0U) {
 		LOG_DBG("param->set_size shall be non-zero");
 		return -EINVAL;
@@ -42,6 +48,12 @@ int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *par
 
 	if (param->rank == 0U) {
 		LOG_DBG("param->rank shall be non-zero");
+		return -EINVAL;
+	}
+
+	if (svc_inst == NULL) {
+		LOG_DBG("svc_inst is NULL");
+
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add missing NULL check for `param` and `svc_inst`