### PR TITLE
soc: sifli: sf32lb52x: default FLASH_LOAD_OFFSET to code partition

### DIFF
--- a/boards/coredevices/pt2/pt2.dts
+++ b/boards/coredevices/pt2/pt2.dts
@@ -88,14 +88,18 @@
 
 	gd25q256e: flash@0 {
 		compatible = "gd,gd25q256e", "jedec,qspi-nor";
-		reg = <0x0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0x0 DT_SIZE_M(32)>;
 		size = <DT_SIZE_M(256)>;
 		quad-enable-requirements = "S2B1v6";
+		ranges = <0x0 0x0 DT_SIZE_M(32)>;
 
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			ptable: partition@0 {
 				label = "ptable";

--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -111,14 +111,18 @@
 
 	py25q128ha: flash@0 {
 		compatible = "puya,py25q128ha", "jedec,qspi-nor";
-		reg = <0x0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0x0 DT_SIZE_M(16)>;
 		size = <DT_SIZE_M(128)>;
 		quad-enable-requirements = "S2B1v1";
+		ranges = <0x0 0x0 DT_SIZE_M(16)>;
 
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			ptable: partition@0 {
 				label = "ptable";

--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -149,7 +149,8 @@
 			reg-names = "ctrl", "nor";
 			clocks = <&rcc_clk SF32LB52X_CLOCK_MPI1>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
+			ranges = <0x0 0x10000000 DT_SIZE_M(32)>;
 			status = "disabled";
 		};
 
@@ -161,7 +162,8 @@
 			reg = <0x50042000 0x1000>, <0x12000000 DT_SIZE_M(224)>;
 			reg-names = "ctrl", "nor";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
+			ranges = <0x0 0x12000000 DT_SIZE_M(224)>;
 			clocks = <&rcc_clk SF32LB52X_CLOCK_MPI2>;
 			status = "disabled";
 		};

--- a/dts/bindings/mtd/sifli,sf32lb-mpi-qspi-nor.yaml
+++ b/dts/bindings/mtd/sifli,sf32lb-mpi-qspi-nor.yaml
@@ -28,7 +28,7 @@ properties:
 
   "#size-cells":
     required: true
-    const: 0
+    const: 1
 
   sifli,lines:
     type: int

--- a/soc/sifli/sf32/gen_ftab.py
+++ b/soc/sifli/sf32/gen_ftab.py
@@ -44,6 +44,13 @@ def _partition_bounds(node) -> tuple[int, int]:
     return reg.addr, reg.size
 
 
+def _partition_address(flash_base: int, partition_start: int) -> int:
+    if partition_start < flash_base:
+        return flash_base + partition_start
+
+    return partition_start
+
+
 def _flash_base_address(flash_node) -> int:
     controller = flash_node.parent
     if controller is None:
@@ -172,10 +179,10 @@ def main() -> None:
     except KeyError as exc:
         raise SystemExit("Unable to locate 'ptable' labeled partition in devicetree") from exc
 
-    code_offset, code_size = _partition_bounds(code_node)
-    code_start = flash_base + code_offset
-    ptable_offset, _ = _partition_bounds(ptable_node)
-    ptable_addr = flash_base + ptable_offset
+    code_reg_addr, code_size = _partition_bounds(code_node)
+    code_start = _partition_address(flash_base, code_reg_addr)
+    ptable_reg_addr, _ = _partition_bounds(ptable_node)
+    ptable_addr = _partition_address(flash_base, ptable_reg_addr)
     sec_image_desc_index = (
         PartitionIndex.SECONDARY_BOOTLOADER.value - PartitionIndex.LCPU_IMAGE_PING.value
     )


### PR DESCRIPTION
After the FLASH_LOAD_OFFSET Kconfig logic update, sf32lb52x can fall
back to a 0x0 load offset when FLASH_CODE_PARTITION_ADDRESS_INVALID is
selected. This links Zephyr at 0x12000000 and overlaps the ftab image,
instead of using the code partition offset at 0x12010000.

Define DT_CHOSEN_Z_CODE_PARTITION for this SoC and set
FLASH_LOAD_OFFSET from the chosen code partition address when
USE_DT_CODE_PARTITION is enabled.

This restores the expected image layout:
- ftab at 0x12000000
- zephyr image at 0x12010000

Fixes: 2f7d13840f6

Signed-off-by: Haoran Jiang <halfsweet@halfsweet.cn>
