### PR TITLE
boards:rp2040: fix missing ranges for RP2040-based boards

### DIFF
--- a/boards/adafruit/kb2040/adafruit_kb2040.dts
+++ b/boards/adafruit/kb2040/adafruit_kb2040.dts
@@ -31,11 +31,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
+++ b/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
@@ -67,11 +67,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
+++ b/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
@@ -46,11 +46,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(1)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(1)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
+++ b/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
@@ -49,11 +49,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(1)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(1)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/kws/pico_spe/pico_spe.dts
+++ b/boards/kws/pico_spe/pico_spe.dts
@@ -86,11 +86,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/pimoroni/tiny2040/tiny2040.dts
+++ b/boards/pimoroni/tiny2040/tiny2040.dts
@@ -71,11 +71,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(8)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
+++ b/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
@@ -64,11 +64,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -63,11 +63,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/sparkfun/rp2040_mikrobus/sparkfun_rp2040_mikrobus-flash.dtsi
+++ b/boards/sparkfun/rp2040_mikrobus/sparkfun_rp2040_mikrobus-flash.dtsi
@@ -18,6 +18,7 @@
 &flash0 {
 	status = "okay";
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 };
 
 &storage_partition {

--- a/boards/vicharak/shrike_lite/shrike_lite.dts
+++ b/boards/vicharak/shrike_lite/shrike_lite.dts
@@ -46,11 +46,13 @@
 	 * the second stage bootloader
 	 */
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/waveshare/rp2040_geek/rp2040_geek.dts
+++ b/boards/waveshare/rp2040_geek/rp2040_geek.dts
@@ -74,11 +74,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
+++ b/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
@@ -63,11 +63,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
+++ b/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
@@ -49,11 +49,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/waveshare/rp2040_plus/rp2040_plus.dts
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.dts
@@ -90,11 +90,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -30,11 +30,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {

--- a/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
@@ -11,6 +11,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Usable flash. Starts at 0x100, after the bootloader. The partition


### PR DESCRIPTION
Add the `ranges` property to the flash node on RP2040-based boards to correctly specify the base address and size for child nodes. This aligns the board device trees with expected Zephyr DT conventions and ensures proper address translation for flash partitions and other child nodes.