### PR TITLE
Bluetooth: UUID: add string to UUID conversion function

### DIFF
--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -72,6 +72,21 @@ struct bt_uuid_128 {
 	uint8_t val[BT_UUID_SIZE_128];
 };
 
+/** @brief Helper type that can store any UUID size. */
+struct bt_uuid_any {
+	/** Union of all supported UUID sizes. */
+	union {
+		/** Generic UUID view. */
+		struct bt_uuid uuid;
+		/** 16-bit UUID view. */
+		struct bt_uuid_16 u16;
+		/** 32-bit UUID view. */
+		struct bt_uuid_32 u32;
+		/** 128-bit UUID view. */
+		struct bt_uuid_128 u128;
+	};
+};
+
 /** @brief Initialize a 16-bit UUID.
  *
  *  @param value 16-bit UUID value in host endianness.
@@ -5266,6 +5281,35 @@ bool bt_uuid_create(struct bt_uuid *uuid, const uint8_t *data, uint8_t data_len)
  *  @param len length of str
  */
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len);
+
+/** @brief Convert a UUID string to a Bluetooth UUID.
+ *
+ *  Parses a UUID string and stores the result in a @ref bt_uuid_any. The UUID
+ *  type (16/32/128-bit) is determined by the input string length.
+ *
+ *  Accepted formats:
+ *   - 4 hex digits (e.g. "180D") -> BT_UUID_TYPE_16
+ *   - 8 hex digits (e.g. "0000180D") -> BT_UUID_TYPE_32
+ *   - 36-char canonical form (e.g. "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+ *     -> BT_UUID_TYPE_128
+ *
+ *  A full 128-bit UUID string always produces BT_UUID_TYPE_128, even if it
+ *  matches the Bluetooth Base UUID pattern. Use the short forms (4 or 8 hex
+ *  chars) to obtain 16-bit or 32-bit types.
+ *
+ *  Notes:
+ *   - No "0x" prefix.
+ *   - No leading/trailing whitespace.
+ *   - Only hexadecimal characters (case-insensitive).
+ *   - 128-bit UUIDs must include hyphens in the standard positions.
+ *   - 16/32-bit UUIDs must not include separators or hyphens.
+ *
+ *  @param str Pointer to the UUID string.
+ *  @param uuid Pointer to a @ref bt_uuid_any to receive the result.
+ *
+ *  @return 0 on success, or a negative error code on failure.
+ */
+int bt_uuid_from_str(const char *str, struct bt_uuid_any *uuid);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -5311,6 +5311,24 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len);
  */
 int bt_uuid_from_str(const char *str, struct bt_uuid_any *uuid);
 
+/** @brief Compress a 128-bit UUID to 16-bit or 32-bit if it matches the
+ *         Bluetooth Base UUID.
+ *
+ *  If @p src is already 16-bit or 32-bit it is copied as-is.
+ *  A 128-bit UUID whose bytes [4..15] match the Bluetooth Base UUID is
+ *  compressed to 16-bit (when bytes [0..1] of the RFC 9562 form are zero)
+ *  or 32-bit. Non-matching 128-bit UUIDs are not compressed and cause the
+ *  function to return -ENOTSUP without modifying @p dst.
+ *
+ *  @param[in]  src  Source UUID to compress.
+ *  @param[out] dst  Destination to receive the (possibly shorter) UUID.
+ *
+ *  @retval 0        UUID was compressed (or copied for 16/32-bit input).
+ *  @retval -ENOTSUP 128-bit UUID does not match the Bluetooth Base UUID;
+ *                   @p dst is left unmodified.
+ */
+int bt_uuid_compress(const struct bt_uuid *src, struct bt_uuid_any *dst);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -40,6 +40,7 @@ config BT_HCI_HOST
 	bool
 	default y
 	depends on !BT_HCI_RAW
+	select UUID
 
 config BT_HCI_TX_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -217,3 +217,41 @@ int bt_uuid_from_str(const char *str, struct bt_uuid_any *uuid)
 		return -EINVAL;
 	}
 }
+
+int bt_uuid_compress(const struct bt_uuid *src, struct bt_uuid_any *dst)
+{
+	struct uuid u;
+
+	if (src == NULL || dst == NULL) {
+		return -EINVAL;
+	}
+
+	switch (src->type) {
+	case BT_UUID_TYPE_16:
+		dst->uuid.type = BT_UUID_TYPE_16;
+		BT_UUID_16(&dst->uuid)->val = BT_UUID_16(src)->val;
+		return 0;
+	case BT_UUID_TYPE_32:
+		dst->uuid.type = BT_UUID_TYPE_32;
+		BT_UUID_32(&dst->uuid)->val = BT_UUID_32(src)->val;
+		return 0;
+	case BT_UUID_TYPE_128:
+		bt_uuid_to_uuid(src, &u);
+
+		if (!is_bt_base_uuid(&u)) {
+			return -ENOTSUP;
+		}
+
+		dst->uuid.type = bt_base_uuid_type(&u);
+
+		if (dst->uuid.type == BT_UUID_TYPE_16) {
+			BT_UUID_16(&dst->uuid)->val = sys_get_be16(&u.val[2]);
+		} else {
+			BT_UUID_32(&dst->uuid)->val = sys_get_be32(u.val);
+		}
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -18,6 +18,10 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/uuid.h>
 
+#define BT_UUID_STR_LEN_16  4U
+#define BT_UUID_STR_LEN_32  8U
+#define BT_UUID_STR_LEN_128 (UUID_STR_LEN - 1U)
+
 /*
  * Bluetooth Base UUID (big-endian / RFC 9562):
  *   00000000-0000-1000-8000-00805F9B34FB
@@ -48,6 +52,41 @@ static void bt_uuid_to_uuid(const struct bt_uuid *src, struct uuid *dst)
 		sys_memcpy_swap(dst->val, BT_UUID_128(src)->val, UUID_SIZE);
 		return;
 	}
+}
+
+/**
+ * @brief Offset of the Bluetooth Base UUID tail (bytes [4..15]).
+ */
+#define BT_UUID_BASE_TAIL_OFFSET 4U
+
+/**
+ * @brief Check whether a generic UUID matches the Bluetooth Base UUID.
+ *
+ * Compares bytes [4..15] against the Bluetooth Base UUID tail.
+ *
+ * @return true if the UUID matches the Bluetooth Base UUID pattern.
+ */
+static bool is_bt_base_uuid(const struct uuid *u)
+{
+	return memcmp(&u->val[BT_UUID_BASE_TAIL_OFFSET],
+		      &bt_uuid_base.val[BT_UUID_BASE_TAIL_OFFSET],
+		      UUID_SIZE - BT_UUID_BASE_TAIL_OFFSET) == 0;
+}
+
+/**
+ * @brief Determine the compact Bluetooth UUID type for a base-matching UUID.
+ *
+ * @pre is_bt_base_uuid(u) must be true.
+ *
+ * @return BT_UUID_TYPE_16 or BT_UUID_TYPE_32.
+ */
+static uint8_t bt_base_uuid_type(const struct uuid *u)
+{
+	if (u->val[0] == 0 && u->val[1] == 0) {
+		return BT_UUID_TYPE_16;
+	}
+
+	return BT_UUID_TYPE_32;
 }
 
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2)
@@ -119,5 +158,62 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 	default:
 		(void)memset(str, 0, len);
 		return;
+	}
+}
+
+int bt_uuid_from_str(const char *str, struct bt_uuid_any *uuid)
+{
+	struct uuid gen_uuid;
+
+	if (str == NULL || uuid == NULL) {
+		return -EINVAL;
+	}
+
+	switch (strlen(str)) {
+	case BT_UUID_STR_LEN_16: {
+		char full[UUID_STR_LEN];
+
+		if (uuid_to_string(&bt_uuid_base, full) != 0) {
+			return -EINVAL;
+		}
+
+		(void)memcpy(&full[4], str, BT_UUID_STR_LEN_16);
+
+		if (uuid_from_string(full, &gen_uuid) != 0) {
+			return -EINVAL;
+		}
+
+		/* Enforce 16-bit UUID type for 4-hex-digit input strings. */
+		uuid->uuid.type = BT_UUID_TYPE_16;
+		BT_UUID_16(&uuid->uuid)->val = sys_get_be16(&gen_uuid.val[2]);
+		return 0;
+	}
+	case BT_UUID_STR_LEN_32: {
+		char full[UUID_STR_LEN];
+
+		if (uuid_to_string(&bt_uuid_base, full) != 0) {
+			return -EINVAL;
+		}
+
+		(void)memcpy(full, str, BT_UUID_STR_LEN_32);
+		if (uuid_from_string(full, &gen_uuid) != 0) {
+			return -EINVAL;
+		}
+
+		/* Enforce 32-bit UUID type for 8-hex-digit input strings. */
+		uuid->uuid.type = BT_UUID_TYPE_32;
+		BT_UUID_32(&uuid->uuid)->val = sys_get_be32(gen_uuid.val);
+		return 0;
+	}
+	case BT_UUID_STR_LEN_128: /* full string -> always 128-bit */
+		if (uuid_from_string(str, &gen_uuid) != 0) {
+			return -EINVAL;
+		}
+
+		uuid->uuid.type = BT_UUID_TYPE_128;
+		sys_memcpy_swap(BT_UUID_128(&uuid->uuid)->val, gen_uuid.val, UUID_SIZE);
+		return 0;
+	default:
+		return -EINVAL;
 	}
 }

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -1,6 +1,7 @@
 /* uuid.c - Bluetooth UUID handling */
 
 /*
+ * Copyright (c) 2025 Xiaomi Corporation
  * Copyright (c) 2015-2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -12,58 +13,51 @@
 #include <string.h>
 
 #include <zephyr/bluetooth/uuid.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/uuid.h>
 
-#define UUID_16_BASE_OFFSET 12
-
-/* TODO: Decide whether to continue using Bluetooth LE format or switch to RFC 4122 */
-
-/* Base UUID : 0000[0000]-0000-1000-8000-00805F9B34FB
- * 0x2800    : 0000[2800]-0000-1000-8000-00805F9B34FB
- *  little endian 0x2800 : [00 28] -> no swapping required
- *  big endian 0x2800    : [28 00] -> swapping required
+/*
+ * Bluetooth Base UUID (big-endian / RFC 9562):
+ *   00000000-0000-1000-8000-00805F9B34FB
  */
-static const struct bt_uuid_128 uuid128_base = {
-	.uuid = { BT_UUID_TYPE_128 },
-	.val = { BT_UUID_128_ENCODE(
-		0x00000000, 0x0000, 0x1000, 0x8000, 0x00805F9B34FB) }
+static const struct uuid bt_uuid_base = {
+	.val = { 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x10U, 0x00U,
+		 0x80U, 0x00U, 0x00U, 0x80U, 0x5fU, 0x9bU, 0x34U, 0xfbU }
 };
 
-static void uuid_to_uuid128(const struct bt_uuid *src, struct bt_uuid_128 *dst)
+/**
+ * @brief Expand a Bluetooth UUID to the generic UUID representation.
+ *
+ * 16-bit and 32-bit short UUIDs are expanded using the Bluetooth Base UUID.
+ * 128-bit UUIDs are byte-swapped from BT wire order (LE) to RFC 9562 order (BE).
+ */
+static void bt_uuid_to_uuid(const struct bt_uuid *src, struct uuid *dst)
 {
 	switch (src->type) {
 	case BT_UUID_TYPE_16:
-		*dst = uuid128_base;
-		sys_put_le16(BT_UUID_16(src)->val,
-			     &dst->val[UUID_16_BASE_OFFSET]);
+		*dst = bt_uuid_base;
+		sys_put_be16(BT_UUID_16(src)->val, &dst->val[2]);
 		return;
 	case BT_UUID_TYPE_32:
-		*dst = uuid128_base;
-		sys_put_le32(BT_UUID_32(src)->val,
-			     &dst->val[UUID_16_BASE_OFFSET]);
+		*dst = bt_uuid_base;
+		sys_put_be32(BT_UUID_32(src)->val, dst->val);
 		return;
 	case BT_UUID_TYPE_128:
-		memcpy(dst, src, sizeof(*dst));
+		sys_memcpy_swap(dst->val, BT_UUID_128(src)->val, UUID_SIZE);
 		return;
 	}
 }
 
-static int uuid128_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2)
-{
-	struct bt_uuid_128 uuid1, uuid2;
-
-	uuid_to_uuid128(u1, &uuid1);
-	uuid_to_uuid128(u2, &uuid2);
-
-	return memcmp(uuid1.val, uuid2.val, 16);
-}
-
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2)
 {
-	/* Convert to 128 bit if types don't match */
 	if (u1->type != u2->type) {
-		return uuid128_cmp(u1, u2);
+		struct uuid uu1, uu2;
+
+		bt_uuid_to_uuid(u1, &uu1);
+		bt_uuid_to_uuid(u2, &uu2);
+		return memcmp(uu1.val, uu2.val, UUID_SIZE);
 	}
 
 	switch (u1->type) {
@@ -102,9 +96,6 @@ bool bt_uuid_create(struct bt_uuid *uuid, const uint8_t *data, uint8_t data_len)
 
 void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 {
-	uint32_t tmp1, tmp5;
-	uint16_t tmp0, tmp2, tmp3, tmp4;
-
 	switch (uuid->type) {
 	case BT_UUID_TYPE_16:
 		snprintk(str, len, "%04x", BT_UUID_16(uuid)->val);
@@ -112,19 +103,19 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 	case BT_UUID_TYPE_32:
 		snprintk(str, len, "%08x", BT_UUID_32(uuid)->val);
 		break;
-	case BT_UUID_TYPE_128:
-		memcpy(&tmp0, &BT_UUID_128(uuid)->val[0], sizeof(tmp0));
-		memcpy(&tmp1, &BT_UUID_128(uuid)->val[2], sizeof(tmp1));
-		memcpy(&tmp2, &BT_UUID_128(uuid)->val[6], sizeof(tmp2));
-		memcpy(&tmp3, &BT_UUID_128(uuid)->val[8], sizeof(tmp3));
-		memcpy(&tmp4, &BT_UUID_128(uuid)->val[10], sizeof(tmp4));
-		memcpy(&tmp5, &BT_UUID_128(uuid)->val[12], sizeof(tmp5));
+	case BT_UUID_TYPE_128: {
+		struct uuid gen_uuid;
+		char full[UUID_STR_LEN];
 
-		snprintk(str, len, "%08x-%04x-%04x-%04x-%08x%04x",
-			 sys_le32_to_cpu(tmp5), sys_le16_to_cpu(tmp4),
-			 sys_le16_to_cpu(tmp3), sys_le16_to_cpu(tmp2),
-			 sys_le32_to_cpu(tmp1), sys_le16_to_cpu(tmp0));
+		bt_uuid_to_uuid(uuid, &gen_uuid);
+		if (uuid_to_string(&gen_uuid, full) != 0) {
+			(void)memset(str, 0, len);
+			return;
+		}
+
+		snprintk(str, len, "%s", full);
 		break;
+	}
 	default:
 		(void)memset(str, 0, len);
 		return;

--- a/tests/bluetooth/audio/ascs/CMakeLists.txt
+++ b/tests/bluetooth/audio/ascs/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(app PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_unicast_server.c
   ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
   ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+  ${ZEPHYR_BASE}/lib/uuid/uuid.c
 
   # Mock files
   ${ZEPHYR_BASE}/tests/bluetooth/audio/mocks/src/bap_stream.c

--- a/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
+++ b/tests/bluetooth/audio/cap_initiator/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(app PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/ccid.c
   ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
   ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+  ${ZEPHYR_BASE}/lib/uuid/uuid.c
 
   # Mock files
   ${ZEPHYR_BASE}/tests/bluetooth/audio/mocks/src/conn.c

--- a/tests/bluetooth/audio/ccp_call_control_server/CMakeLists.txt
+++ b/tests/bluetooth/audio/ccp_call_control_server/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(app PRIVATE
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/tbs.c
   ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
   ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+  ${ZEPHYR_BASE}/lib/uuid/uuid.c
 
   # Mock files
   ${ZEPHYR_BASE}/tests/bluetooth/audio/mocks/src/conn.c

--- a/tests/bluetooth/host/crypto/CMakeLists.txt
+++ b/tests/bluetooth/host/crypto/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(mocks STATIC
             ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
             ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
             ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+            ${ZEPHYR_BASE}/lib/utils/hex.c
+            ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )
 
 target_include_directories(mocks PUBLIC

--- a/tests/bluetooth/host/data/bt_data_parse/CMakeLists.txt
+++ b/tests/bluetooth/host/data/bt_data_parse/CMakeLists.txt
@@ -19,4 +19,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
@@ -31,4 +31,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
@@ -31,4 +31,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
@@ -29,4 +29,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
@@ -31,4 +31,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
@@ -30,4 +30,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
@@ -31,4 +31,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
@@ -32,4 +32,6 @@ target_sources(testbinary
     ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(testbinary
     src/test_suite_full_list_overwrite_oldest.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 
     # Unit under test
     ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c

--- a/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(testbinary
     src/test_suite_get_type_invalid_inputs.c
     ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
     ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/lib/utils/hex.c
+    ${ZEPHYR_BASE}/lib/uuid/uuid.c
 
     # Unit under test
     ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c

--- a/tests/bluetooth/uuid/src/test_bt_uuid_from_str.c
+++ b/tests/bluetooth/uuid/src/test_bt_uuid_from_str.c
@@ -1,0 +1,220 @@
+/* Copyright (c) 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <zephyr/ztest.h>
+#include <zephyr/bluetooth/uuid.h>
+
+ZTEST_SUITE(bt_uuid_from_str, NULL, NULL, NULL, NULL, NULL);
+
+/* Short hex "180d" -> 16-bit UUID */
+ZTEST(bt_uuid_from_str, test_uuid_from_str_16)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("180d", &uuid);
+	zassert_true(ret == 0, "Failed to parse 16-bit UUID");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_16, "Should be 16-bit");
+	zassert_true(bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_16(0x180dU)) == 0,
+		     "Parsed UUID does not match expected 16-bit UUID");
+}
+
+/* Short hex "abcdef12" -> 32-bit UUID */
+ZTEST(bt_uuid_from_str, test_uuid_from_str_32)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("abcdef12", &uuid);
+	zassert_true(ret == 0, "Failed to parse 32-bit UUID");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_32, "Should be 32-bit");
+	zassert_true(bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_32(0xabcdef12U)) == 0,
+		     "Parsed UUID does not match expected 32-bit UUID");
+}
+
+/* 8-hex-digit with leading zeros -> always 32-bit, never auto-compacted to 16-bit */
+ZTEST(bt_uuid_from_str, test_uuid_from_str_32_leading_zeros)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("0000180d", &uuid);
+	zassert_true(ret == 0, "Failed to parse 32-bit UUID with leading zeros");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_32, "Should be 32-bit");
+	zassert_equal(BT_UUID_32(&uuid.uuid)->val, 0x0000180dU, "Value mismatch");
+}
+
+/* Full UUID matching Base UUID -> still 128-bit (no auto-compaction) */
+ZTEST(bt_uuid_from_str, test_uuid_from_str_base_uuid_stays_128)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("0000180d-0000-1000-8000-00805f9b34fb", &uuid);
+	zassert_true(ret == 0, "Failed to parse UUID");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_128, "Full string should stay 128-bit");
+	zassert_true(bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_16(0x180dU)) == 0,
+		     "Value should still compare equal to 16-bit equivalent");
+
+	ret = bt_uuid_from_str("abcdef12-0000-1000-8000-00805f9b34fb", &uuid);
+	zassert_true(ret == 0, "Failed to parse UUID");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_128, "Full string should stay 128-bit");
+	zassert_true(bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_32(0xabcdef12U)) == 0,
+		     "Value should still compare equal to 32-bit equivalent");
+}
+
+/* Full UUID (non-Base) -> 128-bit */
+ZTEST(bt_uuid_from_str, test_uuid_from_str_128)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("6e400001-b5a3-f393-e0a9-e50e24dcca9e", &uuid);
+	zassert_true(ret == 0, "Failed to parse 128-bit UUID");
+	zassert_equal(uuid.uuid.type, BT_UUID_TYPE_128, "Should be 128-bit");
+	const struct bt_uuid *expected =
+		BT_UUID_DECLARE_128(0x9eU, 0xcaU, 0xdcU, 0x24U, 0x0eU, 0xe5U, 0xa9U, 0xe0U,
+				    0x93U, 0xf3U, 0xa3U, 0xb5U, 0x01U, 0x00U, 0x40U, 0x6eU);
+	zassert_true(bt_uuid_cmp(&uuid.uuid, expected) == 0,
+		     "Parsed UUID does not match expected 128-bit UUID");
+}
+
+/* Roundtrip: 16-bit -> to_str -> from_str -> compare */
+ZTEST(bt_uuid_from_str, test_uuid_roundtrip_to_str_and_back_16)
+{
+	struct bt_uuid_16 u1 = BT_UUID_INIT_16(0x180dU);
+	struct bt_uuid_any uuid_tmp = {0};
+	char str[BT_UUID_STR_LEN];
+	int ret;
+
+	bt_uuid_to_str(&u1.uuid, str, sizeof(str));
+	ret = bt_uuid_from_str(str, &uuid_tmp);
+	zassert_true(ret == 0, "bt_uuid_from_str failed for 16-bit");
+	zassert_true(bt_uuid_cmp(&u1.uuid, &uuid_tmp.uuid) == 0,
+		     "Round-trip 16-bit UUID mismatch");
+}
+
+/* Roundtrip: 32-bit -> to_str -> from_str -> compare */
+ZTEST(bt_uuid_from_str, test_uuid_roundtrip_to_str_and_back_32)
+{
+	struct bt_uuid_32 u1 = BT_UUID_INIT_32(0xabcdef12U);
+	struct bt_uuid_any uuid_tmp = {0};
+	char str[BT_UUID_STR_LEN];
+	int ret;
+
+	bt_uuid_to_str(&u1.uuid, str, sizeof(str));
+	ret = bt_uuid_from_str(str, &uuid_tmp);
+	zassert_true(ret == 0, "bt_uuid_from_str failed for 32-bit");
+	zassert_true(bt_uuid_cmp(&u1.uuid, &uuid_tmp.uuid) == 0,
+		     "Round-trip 32-bit UUID mismatch");
+}
+
+/* Roundtrip: 128-bit -> to_str -> from_str -> compare */
+ZTEST(bt_uuid_from_str, test_uuid_roundtrip_to_str_and_back_128)
+{
+	const struct bt_uuid *expected =
+		BT_UUID_DECLARE_128(0x9eU, 0xcaU, 0xdcU, 0x24U, 0x0eU, 0xe5U, 0xa9U, 0xe0U,
+				    0x93U, 0xf3U, 0xa3U, 0xb5U, 0x01U, 0x00U, 0x40U, 0x6eU);
+	struct bt_uuid_any uuid_tmp = {0};
+	char str[BT_UUID_STR_LEN];
+	int ret;
+
+	bt_uuid_to_str(expected, str, sizeof(str));
+	ret = bt_uuid_from_str(str, &uuid_tmp);
+	zassert_true(ret == 0, "bt_uuid_from_str failed for 128-bit");
+	zassert_true(bt_uuid_cmp(expected, &uuid_tmp.uuid) == 0,
+		     "Round-trip 128-bit UUID mismatch");
+}
+
+ZTEST(bt_uuid_from_str, test_uuid_from_str_invalid)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("not-a-uuid", &uuid);
+	zassert_true(ret < 0, "Invalid UUID string should fail");
+
+	ret = bt_uuid_from_str("", &uuid);
+	zassert_true(ret < 0, "Empty string should fail");
+
+	ret = bt_uuid_from_str("123", &uuid);
+	zassert_true(ret < 0, "Too short string should fail");
+
+	ret = bt_uuid_from_str("zzzz", &uuid);
+	zassert_true(ret < 0, "Non-hex 4-char string should fail");
+
+	ret = bt_uuid_from_str("00001101-0000-1000-8000-00805f9b34fb00", &uuid);
+	zassert_true(ret < 0, "Too long 128-bit string should fail");
+}
+
+ZTEST(bt_uuid_from_str, test_uuid_from_str_null_params)
+{
+	struct bt_uuid_any uuid = {0};
+	int ret;
+
+	ret = bt_uuid_from_str("180d", NULL);
+	zassert_true(ret < 0, "NULL uuid pointer should fail");
+
+	ret = bt_uuid_from_str(NULL, &uuid);
+	zassert_true(ret < 0, "NULL string pointer should fail");
+}
+
+/* bt_uuid_compress: 128-bit base UUID with 16-bit value -> 16-bit */
+ZTEST(bt_uuid_from_str, test_uuid_compress_128_to_16)
+{
+	const struct bt_uuid *src =
+		BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(
+			0x0000180dU, 0x0000U, 0x1000U, 0x8000U, 0x00805f9b34fbU));
+	struct bt_uuid_any dst = {0};
+	int ret;
+
+	ret = bt_uuid_compress(src, &dst);
+	zassert_equal(ret, 0, "Compress should succeed");
+	zassert_equal(dst.uuid.type, BT_UUID_TYPE_16, "Should be 16-bit");
+	zassert_equal(BT_UUID_16(&dst.uuid)->val, 0x180dU, "Value mismatch");
+}
+
+/* bt_uuid_compress: 128-bit base UUID with 32-bit value -> 32-bit */
+ZTEST(bt_uuid_from_str, test_uuid_compress_128_to_32)
+{
+	const struct bt_uuid *src =
+		BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(
+			0xabcdef12U, 0x0000U, 0x1000U, 0x8000U, 0x00805f9b34fbU));
+	struct bt_uuid_any dst = {0};
+	int ret;
+
+	ret = bt_uuid_compress(src, &dst);
+	zassert_equal(ret, 0, "Compress should succeed");
+	zassert_equal(dst.uuid.type, BT_UUID_TYPE_32, "Should be 32-bit");
+	zassert_equal(BT_UUID_32(&dst.uuid)->val, 0xabcdef12U, "Value mismatch");
+}
+
+/* bt_uuid_compress: non-base 128-bit UUID -> fails with -ENOTSUP */
+ZTEST(bt_uuid_from_str, test_uuid_compress_non_base_128)
+{
+	const struct bt_uuid *src =
+		BT_UUID_DECLARE_128(0x9eU, 0xcaU, 0xdcU, 0x24U, 0x0eU, 0xe5U, 0xa9U, 0xe0U,
+				    0x93U, 0xf3U, 0xa3U, 0xb5U, 0x01U, 0x00U, 0x40U, 0x6eU);
+	struct bt_uuid_any dst = {0};
+	int ret;
+
+	ret = bt_uuid_compress(src, &dst);
+	zassert_equal(ret, -ENOTSUP, "Non-base UUID should return -ENOTSUP");
+}
+
+/* bt_uuid_compress: 16-bit input -> copied as-is */
+ZTEST(bt_uuid_from_str, test_uuid_compress_passthrough_16)
+{
+	struct bt_uuid_16 src = BT_UUID_INIT_16(0x180dU);
+	struct bt_uuid_any dst = {0};
+	int ret;
+
+	ret = bt_uuid_compress(&src.uuid, &dst);
+	zassert_equal(ret, 0, "Should succeed");
+	zassert_equal(dst.uuid.type, BT_UUID_TYPE_16, "Should stay 16-bit");
+	zassert_equal(BT_UUID_16(&dst.uuid)->val, 0x180dU, "Value mismatch");
+}


### PR DESCRIPTION
# Bluetooth: UUID: add string-to-UUID conversion and compress helpers

## Summary

This PR refactors the Bluetooth UUID module to use the generic UUID library (lib/uuid) and introduces two new public APIs: bt_uuid_from_str() and bt_uuid_compress().

## New APIs

### bt_uuid_from_str(const char *str, struct bt_uuid_any *uuid)
Converts a UUID string into a Bluetooth UUID structure. The UUID type (16/32/128-bit) is automatically determined by the input string length.

- Returns 0 on success, or a negative error code on failure.

### bt_uuid_compress(const struct bt_uuid *src, struct bt_uuid_any *dst)
Compresses a 128-bit UUID to its 16-bit or 32-bit short form when it matches the Bluetooth Base UUID. 16-bit and 32-bit source UUIDs are copied as-is.

- Returns 0 on success, -ENOTSUP if the 128-bit UUID does not match the Bluetooth Base UUID.

### struct bt_uuid_any
A new helper union type that can store any UUID size (16/32/128-bit), used as the output parameter for both new APIs.

## Changes

1. Refactor: Replace internal bt_uuid_128-based base UUID with struct uuid (RFC 9562 order) from lib/uuid, simplifying bt_uuid_to_str() and bt_uuid_cmp().
2. New API: bt_uuid_from_str() — string-to-UUID conversion supporting all three formats.
3. New API: bt_uuid_compress() — 128-bit to short UUID compression.
4. Kconfig: BT_HCI_HOST now selects UUID to provide the generic UUID library dependency.
5. Tests: Comprehensive unit tests for both new APIs.

## Supported String Formats

| Format | Example | Result |
|--------|---------|--------|
| 4 hex digits | "180d" | BT_UUID_TYPE_16 |
| 8 hex digits | "abcdef12" | BT_UUID_TYPE_32 |
| 36-char canonical | "00001800-0000-1000-8000-00805f9b34fb" | BT_UUID_TYPE_128 |

## Usage Example

c
struct bt_uuid_any uuid;

/* String to UUID */
if (bt_uuid_from_str("180d", &uuid) == 0) {
    /* uuid.uuid.type == BT_UUID_TYPE_16 */
    /* BT_UUID_16(&uuid.uuid)->val == 0x180d */
}

/* Compress 128-bit to short form */
struct bt_uuid_any compressed;
if (bt_uuid_compress(&some_128bit_uuid, &compressed) == 0) {
    /* compressed now holds 16-bit or 32-bit UUID */
}


## Testing
- 16-bit, 32-bit, and 128-bit string conversion
- Invalid input cases (malformed strings, empty strings, wrong lengths)
- Compress: base UUID to 16-bit and 32-bit, non-base returns -ENOTSUP, 16-bit passthrough
- Round-trip validation with bt_uuid_to_str()

Reopen from: #98784