### PR TITLE
logging: Add CONFIG_LOG_RUNTIME_DEFAULT_LEVEL for startup filter control

### DIFF
--- a/subsys/logging/Kconfig.filtering
+++ b/subsys/logging/Kconfig.filtering
@@ -10,6 +10,30 @@ config LOG_RUNTIME_FILTERING
 	  Allow runtime configuration of maximal, independent severity
 	  level for instance.
 
+if LOG_RUNTIME_FILTERING
+
+config LOG_RUNTIME_DEFAULT_LEVEL
+	int "Default runtime log level at startup"
+	default LOG_DEFAULT_LEVEL
+	range 0 4
+	help
+	  Sets the initial runtime filter level for all modules at system startup.
+	  This level is applied before any backend or application-specific filtering
+	  is configured. Useful for controlling logging verbosity at boot before
+	  dynamic reconfiguration via IPC or other mechanisms.
+
+	  Levels are:
+	  - 0 OFF, no logs at startup
+	  - 1 ERROR, only errors shown at startup
+	  - 2 WARNING, errors and warnings at startup
+	  - 3 INFO, info level and above at startup
+	  - 4 DEBUG, all logs including debug at startup
+
+	  Note: This affects runtime filtering only. Compile-time log levels
+	  are controlled by CONFIG_LOG_MAX_LEVEL and per-module settings.
+
+endif # LOG_RUNTIME_FILTERING
+
 config LOG_DEFAULT_LEVEL
 	int "Default log level"
 	default 3

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -311,10 +311,13 @@ static uint32_t activate_foreach_backend(uint32_t mask)
 
 		mask_cpy &= ~BIT(i);
 		if (backend->autostart && (log_backend_is_ready(backend) == 0)) {
+			uint32_t level = CONFIG_LOG_MAX_LEVEL;
+
+#if defined(CONFIG_LOG_RUNTIME_FILTERING) && defined(CONFIG_LOG_RUNTIME_DEFAULT_LEVEL)
+			level = CONFIG_LOG_RUNTIME_DEFAULT_LEVEL;
+#endif
 			mask &= ~BIT(i);
-			log_backend_enable(backend,
-					   backend->cb->ctx,
-					   CONFIG_LOG_MAX_LEVEL);
+			log_backend_enable(backend, backend->cb->ctx, level);
 		}
 	}
 
@@ -344,15 +347,18 @@ static uint32_t z_log_init(bool blocking, bool can_sleep)
 	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		/* Activate autostart backends */
 		if (backend->autostart) {
+			uint32_t level = CONFIG_LOG_MAX_LEVEL;
+
+#if defined(CONFIG_LOG_RUNTIME_FILTERING) && defined(CONFIG_LOG_RUNTIME_DEFAULT_LEVEL)
+			level = CONFIG_LOG_RUNTIME_DEFAULT_LEVEL;
+#endif
 			log_backend_init(backend);
 
 			/* If backend has activation function then backend is
 			 * not ready until activated.
 			 */
 			if (log_backend_is_ready(backend) == 0) {
-				log_backend_enable(backend,
-						   backend->cb->ctx,
-						   CONFIG_LOG_MAX_LEVEL);
+				log_backend_enable(backend, backend->cb->ctx, level);
 			} else {
 				mask |= BIT(backend_index);
 			}

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -354,8 +354,15 @@ void z_log_runtime_filters_init(void)
 	 */
 	for (int i = 0; i < z_log_sources_count(); i++) {
 		uint32_t *filters = z_log_dynamic_filters_get(i);
-		uint8_t level = log_compiled_level_get(Z_LOG_LOCAL_DOMAIN_ID, i);
+		uint8_t level;
 
+#ifdef CONFIG_LOG_RUNTIME_DEFAULT_LEVEL
+		/* Use configured runtime default level for initial filter */
+		level = CONFIG_LOG_RUNTIME_DEFAULT_LEVEL;
+#else
+		/* Fall back to compile-time level */
+		level = log_compiled_level_get(Z_LOG_LOCAL_DOMAIN_ID, i);
+#endif
 		level = MAX(level, CONFIG_LOG_OVERRIDE_LEVEL);
 		LOG_FILTER_SLOT_SET(filters,
 				    LOG_FILTER_AGGR_SLOT_IDX,


### PR DESCRIPTION
Add a new Kconfig option CONFIG_LOG_RUNTIME_DEFAULT_LEVEL that allows setting the initial runtime filter level at system startup, independent of compile-time log levels.

This enables a common use case where firmware needs to:
1. Compile with DEBUG level (to include all log macros)
2. Boot with minimal logging (e.g., ERROR only for quiet startup)
3. Allow dynamic runtime increases via IPC or other mechanisms

Previously, autostart backends were always initialized with CONFIG_LOG_MAX_LEVEL, which meant compile-time and initial runtime levels were coupled. This change decouples them when runtime filtering is enabled.

Changes:
- Add CONFIG_LOG_RUNTIME_DEFAULT_LEVEL Kconfig option under LOG_RUNTIME_FILTERING, defaulting to LOG_DEFAULT_LEVEL
- Update z_log_runtime_filters_init() to use the new config for initial aggregated filter levels
- Update autostart backend initialization in z_log_init() and activate_foreach_backend() to use CONFIG_LOG_RUNTIME_DEFAULT_LEVEL instead of CONFIG_LOG_MAX_LEVEL when runtime filtering is enabled

This allows firmware to start with ERROR-level logging while keeping full DEBUG compile-time capability, then dynamically increase verbosity as needed without recompilation.