### PR TITLE
tests: bsim: bluetooth: host: Add missing license to id_addr_update test

### DIFF
--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.h
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.h
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 


### PR DESCRIPTION
Restore missing license in these 2 files based on license from their .c counterparts.