### PR TITLE
Add HFCLK24M support for TDM and PDM

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -471,11 +471,12 @@ static void init_clock_manager(const struct device *dev)
 #elif CONFIG_CLOCK_CONTROL_NRF
 	clock_control_subsys_t subsys;
 	struct dmic_nrfx_pdm_drv_data *drv_data = dev->data;
-#if NRF_CLOCK_HAS_HFCLKAUDIO
+#if NRF_CLOCK_HAS_HFCLKAUDIO || NRF_CLOCK_HAS_HFCLK24M
 	const struct dmic_nrfx_pdm_drv_cfg *drv_cfg = dev->config;
 
 	if (drv_cfg->clk_src == ACLK) {
-		subsys = CLOCK_CONTROL_NRF_SUBSYS_HFAUDIO;
+		IF_ENABLED(NRF_CLOCK_HAS_HFCLKAUDIO, (subsys = CLOCK_CONTROL_NRF_SUBSYS_HFAUDIO;))
+		IF_ENABLED(NRF_CLOCK_HAS_HFCLK24M, (subsys = CLOCK_CONTROL_NRF_SUBSYS_HF24M;))
 	} else
 #endif
 	{


### PR DESCRIPTION
This PR adds support for 24 MHz PCLK for TDM and PDM peripherals.