### PR TITLE
net: dns: resolve: Take lock before calling dns_resolve_init_locked

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -916,9 +916,11 @@ int dns_resolve_init_with_svc(struct dns_resolve_context *ctx, const char *serve
 		ctx->state = DNS_RESOLVE_CONTEXT_INACTIVE;
 	}
 
+	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = dns_resolve_init_locked(ctx, servers, servers_sa, svc, port,
 				      interfaces, true, DNS_SOURCE_UNKNOWN);
 
+	k_mutex_unlock(&ctx->lock);
 	k_mutex_unlock(&lock);
 
 	return ret;


### PR DESCRIPTION
The mutex should be held when calling `dns_resolve_init_locked` as mentioned in a comment above the function.