### PR TITLE
subsys: usb: cdc_ncm/ecm: Clear data iface in suspend

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -412,6 +412,7 @@ static void usbd_cdc_ecm_suspended(struct usbd_class_data *const c_data)
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_ecm_eth_data *data = dev->data;
 
+	atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
 	atomic_set_bit(&data->state, CDC_ECM_CLASS_SUSPENDED);
 }
 

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -876,6 +876,7 @@ static void usbd_cdc_ncm_suspended(struct usbd_class_data *const c_data)
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct cdc_ncm_eth_data *data = dev->data;
 
+	atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
 	atomic_set_bit(&data->state, CDC_NCM_CLASS_SUSPENDED);
 }
 


### PR DESCRIPTION
Using the CDC-NCM/ECM with VBUS detection leads to problems when device is suspended. Clearing the data iface state solved the issue.