### PR TITLE
drivers: gpio: esp32_lp: add pull-up/down and wakeup support

### DIFF
--- a/drivers/gpio/gpio_esp32_lp.c
+++ b/drivers/gpio/gpio_esp32_lp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2025-2026 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,6 +66,18 @@ static int gpio_esp32_lp_configure(const struct device *dev, gpio_pin_t pin, gpi
 		}
 	} else if (flags & GPIO_INPUT) {
 		rtcio_hal_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
+	}
+
+	if (flags & GPIO_PULL_UP) {
+		rtcio_ll_pullup_enable(pin);
+	} else {
+		rtcio_ll_pullup_disable(pin);
+	}
+
+	if (flags & GPIO_PULL_DOWN) {
+		rtcio_ll_pulldown_enable(pin);
+	} else {
+		rtcio_ll_pulldown_disable(pin);
 	}
 
 	return 0;
@@ -159,6 +171,7 @@ static int gpio_esp32_lp_pin_interrupt_configure(const struct device *dev, gpio_
 	ulp_lp_core_intr_enable();
 
 	rtcio_ll_intr_enable(pin, intr_trig_mode);
+	rtcio_ll_wakeup_enable(pin, intr_trig_mode);
 
 	return 0;
 }


### PR DESCRIPTION
Add GPIO_PULL_UP and GPIO_PULL_DOWN handling in pin_configure and enable LP_IO wakeup source in pin_interrupt_configure via rtcio_ll_wakeup_enable(). Both rtcio_ll_intr_enable() and rtcio_ll_wakeup_enable() are required for LP_IO wakeup to function, as clk_en must be set for the interrupt status register to update.