### PR TITLE
STM32: misc drivers: replace ll_func_* by ll_*

### DIFF
--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -125,7 +125,7 @@ struct rtc_stm32_data {
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 };
 
-static inline void ll_func_clear_alarm_flag(RTC_TypeDef *rtc)
+static inline void ll_clear_alarm_flag(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_RTC_ClearFlag_ALR(rtc);
@@ -134,7 +134,7 @@ static inline void ll_func_clear_alarm_flag(RTC_TypeDef *rtc)
 #endif
 }
 
-static inline uint32_t ll_func_is_active_alarm(RTC_TypeDef *rtc)
+static inline uint32_t ll_is_active_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	return LL_RTC_IsActiveFlag_ALR(rtc);
@@ -143,7 +143,7 @@ static inline uint32_t ll_func_is_active_alarm(RTC_TypeDef *rtc)
 #endif
 }
 
-static inline void ll_func_enable_interrupt_alarm(RTC_TypeDef *rtc)
+static inline void ll_enable_interrupt_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_RTC_EnableIT_ALR(rtc);
@@ -152,7 +152,7 @@ static inline void ll_func_enable_interrupt_alarm(RTC_TypeDef *rtc)
 #endif
 }
 
-static inline void ll_func_disable_interrupt_alarm(RTC_TypeDef *rtc)
+static inline void ll_disable_interrupt_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_RTC_DisableIT_ALR(rtc);
@@ -162,7 +162,7 @@ static inline void ll_func_disable_interrupt_alarm(RTC_TypeDef *rtc)
 }
 
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
-static inline uint32_t ll_func_isenabled_interrupt_alarm(RTC_TypeDef *rtc)
+static inline uint32_t ll_isenabled_interrupt_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	return LL_RTC_IsEnabledIT_ALR(rtc);
@@ -172,7 +172,7 @@ static inline uint32_t ll_func_isenabled_interrupt_alarm(RTC_TypeDef *rtc)
 }
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 
-static inline void ll_func_enable_alarm(RTC_TypeDef *rtc)
+static inline void ll_enable_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	ARG_UNUSED(rtc);
@@ -181,7 +181,7 @@ static inline void ll_func_enable_alarm(RTC_TypeDef *rtc)
 #endif
 }
 
-static inline void ll_func_disable_alarm(RTC_TypeDef *rtc)
+static inline void ll_disable_alarm(RTC_TypeDef *rtc)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 	ARG_UNUSED(rtc);
@@ -580,7 +580,7 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 #if !defined(COUNTER_NO_DATE)
 	LL_RTC_DisableWriteProtection(RTC);
 
-	ll_func_disable_alarm(RTC);
+	ll_disable_alarm(RTC);
 
 	/* Configure the Alarm registers */
 	LL_RTC_ALMA_DisableWeekday(RTC);
@@ -618,9 +618,9 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 	LL_RTC_ALMA_SetSubSecondMask(RTC, 0);
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 #endif /* HW_SUBSECOND_SUPPORT */
-	ll_func_enable_alarm(RTC);
-	ll_func_clear_alarm_flag(RTC);
-	ll_func_enable_interrupt_alarm(RTC);
+	ll_enable_alarm(RTC);
+	ll_clear_alarm_flag(RTC);
+	ll_enable_interrupt_alarm(RTC);
 	LL_RTC_EnableWriteProtection(RTC);
 
 #if defined(COUNTER_NO_DATE)
@@ -656,9 +656,9 @@ static int rtc_stm32_cancel_alarm(const struct device *dev, uint8_t chan_id)
 
 	stm32_backup_domain_enable_access();
 	LL_RTC_DisableWriteProtection(RTC);
-	ll_func_clear_alarm_flag(RTC);
-	ll_func_disable_interrupt_alarm(RTC);
-	ll_func_disable_alarm(RTC);
+	ll_clear_alarm_flag(RTC);
+	ll_disable_interrupt_alarm(RTC);
+	ll_disable_alarm(RTC);
 	LL_RTC_EnableWriteProtection(RTC);
 	stm32_backup_domain_disable_access();
 
@@ -670,7 +670,7 @@ static int rtc_stm32_cancel_alarm(const struct device *dev, uint8_t chan_id)
 
 static uint32_t rtc_stm32_get_pending_int(const struct device *dev)
 {
-	return ll_func_is_active_alarm(RTC) != 0;
+	return ll_is_active_alarm(RTC) != 0;
 }
 
 
@@ -704,17 +704,17 @@ void rtc_stm32_isr(const struct device *dev)
 
 	uint32_t now = rtc_stm32_read(dev);
 
-	if (ll_func_is_active_alarm(RTC) != 0
+	if (ll_is_active_alarm(RTC) != 0
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
-	    || (data->irq_on_late && ll_func_isenabled_interrupt_alarm(RTC))
+	    || (data->irq_on_late && ll_isenabled_interrupt_alarm(RTC))
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 	) {
 
 		stm32_backup_domain_enable_access();
 		LL_RTC_DisableWriteProtection(RTC);
-		ll_func_clear_alarm_flag(RTC);
-		ll_func_disable_interrupt_alarm(RTC);
-		ll_func_disable_alarm(RTC);
+		ll_clear_alarm_flag(RTC);
+		ll_disable_interrupt_alarm(RTC);
+		ll_disable_alarm(RTC);
 		LL_RTC_EnableWriteProtection(RTC);
 		stm32_backup_domain_disable_access();
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS

--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -351,7 +351,7 @@ static int i2s_stm32_trigger(const struct device *dev, enum i2s_dir dir,
 			return -EIO;
 		}
 do_trigger_stop:
-		if (ll_func_i2s_dma_busy(cfg->i2s)) {
+		if (ll_i2s_dma_busy(cfg->i2s)) {
 			stream->state = I2S_STATE_STOPPING;
 			/*
 			 * Indicate that the transition to I2S_STATE_STOPPING
@@ -376,7 +376,7 @@ do_trigger_stop:
 
 		if (dir == I2S_DIR_TX) {
 			if ((queue_is_empty(stream->msgq) == false) ||
-						(ll_func_i2s_dma_busy(cfg->i2s))) {
+						(ll_i2s_dma_busy(cfg->i2s))) {
 				stream->state = I2S_STATE_STOPPING;
 				/*
 				 * Indicate that the transition to I2S_STATE_STOPPING

--- a/drivers/i2s/i2s_stm32.h
+++ b/drivers/i2s/i2s_stm32.h
@@ -51,7 +51,7 @@ struct i2s_stm32_data {
 };
 
 /* checks that DMA Tx packet is fully transmitted over the I2S */
-static inline uint32_t ll_func_i2s_dma_busy(SPI_TypeDef *i2s)
+static inline uint32_t ll_i2s_dma_busy(SPI_TypeDef *i2s)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_i2s)
 	return LL_SPI_IsActiveFlag_TXC(i2s) == 0;

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -251,7 +251,7 @@ static int spi_stm32_dma_tx_load(const struct device *dev, const uint8_t *buf, s
 		}
 	}
 
-	blk_cfg->dest_address = ll_func_dma_get_reg_addr(cfg->spi, SPI_STM32_DMA_TX);
+	blk_cfg->dest_address = ll_dma_get_reg_addr(cfg->spi, SPI_STM32_DMA_TX);
 	/* fifo mode NOT USED there */
 	if (data->dma_tx.dst_addr_increment) {
 		blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
@@ -308,7 +308,7 @@ static int spi_stm32_dma_rx_load(const struct device *dev, uint8_t *buf, size_t 
 		}
 	}
 
-	blk_cfg->source_address = ll_func_dma_get_reg_addr(cfg->spi, SPI_STM32_DMA_RX);
+	blk_cfg->source_address = ll_dma_get_reg_addr(cfg->spi, SPI_STM32_DMA_RX);
 	if (data->dma_rx.src_addr_increment) {
 		blk_cfg->source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 	} else {
@@ -463,12 +463,12 @@ static void spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 	uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
 
 	if (transfer_dir != LL_SPI_HALF_DUPLEX_TX &&
-		ll_func_rx_is_not_empty(spi)) {
+		ll_rx_is_not_empty(spi)) {
 		spi_stm32_read_next_frame(spi, data);
 	}
 
 	if (transfer_dir != LL_SPI_HALF_DUPLEX_RX &&
-		ll_func_tx_is_not_full(spi)) {
+		ll_tx_is_not_full(spi)) {
 		spi_stm32_send_next_frame(spi, data);
 	}
 }
@@ -482,7 +482,7 @@ static void spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm
 		uint32_t transfer_dir = LL_SPI_GetTransferDirection(cfg->spi);
 
 		if (transfer_dir != LL_SPI_HALF_DUPLEX_RX) {
-			while (!ll_func_tx_is_not_full(cfg->spi)) {
+			while (!ll_tx_is_not_full(cfg->spi)) {
 				/* NOP */
 			}
 
@@ -490,7 +490,7 @@ static void spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm
 		}
 
 		if (transfer_dir != LL_SPI_HALF_DUPLEX_TX) {
-			while (!ll_func_rx_is_not_empty(cfg->spi)) {
+			while (!ll_rx_is_not_empty(cfg->spi)) {
 				/* NOP */
 			}
 
@@ -502,13 +502,13 @@ static void spi_stm32_shift_m(const struct spi_stm32_config *cfg, struct spi_stm
 /* Shift a SPI frame as slave. */
 static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	if (ll_func_tx_is_not_full(spi) && spi_context_tx_on(&data->ctx)) {
+	if (ll_tx_is_not_full(spi) && spi_context_tx_on(&data->ctx)) {
 		spi_stm32_send_next_frame(spi, data);
 	} else {
-		ll_func_disable_int_tx_empty(spi);
+		ll_disable_int_tx_empty(spi);
 	}
 
-	if (ll_func_rx_is_not_empty(spi) && spi_context_rx_buf_on(&data->ctx)) {
+	if (ll_rx_is_not_empty(spi) && spi_context_rx_buf_on(&data->ctx)) {
 		spi_stm32_read_next_frame(spi, data);
 	}
 }
@@ -594,13 +594,13 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 		LL_SPI_EnableIT_EOT(spi);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	ll_func_enable_int_errors(spi);
+	ll_enable_int_errors(spi);
 
 	if (!is_rx_empty) {
-		ll_func_enable_int_rx_not_empty(spi);
+		ll_enable_int_rx_not_empty(spi);
 	}
 
-	ll_func_enable_int_tx_empty(spi);
+	ll_enable_int_tx_empty(spi);
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	irq_enable(cfg->irq_line);
@@ -647,7 +647,7 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 	if (cfg->fifo_enabled && SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 		if (LL_SPI_IsEnabled(spi)) {
 			/* SPI needs to be disabled to set the transfer size */
-			ll_func_disable_spi(spi);
+			ll_disable_spi(spi);
 		}
 		LL_SPI_SetTransferSize(spi, size);
 	}
@@ -760,9 +760,9 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #endif /* CONFIG_SPI_RTIO */
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
-	ll_func_disable_int_tx_empty(spi);
-	ll_func_disable_int_rx_not_empty(spi);
-	ll_func_disable_int_errors(spi);
+	ll_disable_int_tx_empty(spi);
+	ll_disable_int_rx_not_empty(spi);
+	ll_disable_int_errors(spi);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (cfg->fifo_enabled) {
@@ -775,13 +775,13 @@ static void spi_stm32_complete(const struct device *dev, int status)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
-	while (ll_func_rx_is_not_empty(spi)) {
+	while (ll_rx_is_not_empty(spi)) {
 		(void) LL_SPI_ReceiveData8(spi);
 	}
 #endif /* compat st_stm32_spi_fifo*/
 
 	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-		while (ll_func_spi_is_busy(spi) && LL_SPI_IsEnabled(spi)) {
+		while (ll_spi_is_busy(spi) && LL_SPI_IsEnabled(spi)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 			uint32_t width = SPI_WORD_SIZE_GET(data->ctx.config->operation);
 			/* In non-FIFO mode, the TXC flag is not raised at the end of 9, 17 or 25
@@ -789,7 +789,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 			 */
 			if (!cfg->fifo_enabled &&
 			    ((width == 9U) || (width == 17U) || (width == 25U))) {
-				ll_func_disable_spi(spi);
+				ll_disable_spi(spi);
 			}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		}
@@ -816,7 +816,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 	if (!(data->ctx.config->operation & SPI_HOLD_ON_CS)) {
-		ll_func_disable_spi(spi);
+		ll_disable_spi(spi);
 #if defined(CONFIG_SPI_STM32_INTERRUPT) && defined(CONFIG_SOC_SERIES_STM32H7X)
 	} else {
 		/* On H7, with SPI still enabled, the ISR is always called, even if the interrupt
@@ -844,7 +844,7 @@ static void spi_stm32_isr(const struct device *dev)
 	/* With RTIO, an interrupt can occur even though they
 	 * are all previously disabled. Ignore it then.
 	 */
-	if (ll_func_are_int_disabled(spi)) {
+	if (ll_are_int_disabled(spi)) {
 		return;
 	}
 #endif /* CONFIG_SPI_RTIO */
@@ -1048,7 +1048,7 @@ static int spi_stm32_configure(const struct device *dev,
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
-	ll_func_set_fifo_threshold_8bit(spi);
+	ll_set_fifo_threshold_8bit(spi);
 #endif
 
 	/* At this point, it's mandatory to set this on the context! */
@@ -1070,7 +1070,7 @@ static int spi_stm32_release(const struct device *dev, const struct spi_config *
 	const struct spi_stm32_config *cfg = dev->config;
 
 	spi_context_unlock_unconditionally(&data->ctx);
-	ll_func_disable_spi(cfg->spi);
+	ll_disable_spi(cfg->spi);
 
 	return 0;
 }
@@ -1158,7 +1158,7 @@ static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config
 
 	if (!spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx)) {
 #ifndef CONFIG_SPI_STM32_INTERRUPT
-		while (ll_func_spi_is_busy(spi)) {
+		while (ll_spi_is_busy(spi)) {
 			/* NOP */
 		}
 		LL_SPI_Disable(spi);
@@ -1219,8 +1219,8 @@ static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config
 		}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-		ll_func_enable_int_errors(spi);
-		ll_func_enable_int_rx_not_empty(spi);
+		ll_enable_int_errors(spi);
+		ll_enable_int_rx_not_empty(spi);
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 	}
 
@@ -1499,10 +1499,10 @@ static int transceive_dma(const struct device *dev,
 #endif /* SPI_SR_FTLVL */
 
 #ifdef CONFIG_SPI_STM32_ERRATA_BUSY
-		WAIT_FOR(!ll_func_spi_dma_busy(spi), CONFIG_SPI_STM32_BUSY_FLAG_TIMEOUT, k_yield());
+		WAIT_FOR(!ll_spi_dma_busy(spi), CONFIG_SPI_STM32_BUSY_FLAG_TIMEOUT, k_yield());
 #else
 		/* wait until spi is no more busy (spi TX fifo is really empty) */
-		while (ll_func_spi_dma_busy(spi) && LL_SPI_IsEnabled(spi)) {
+		while (ll_spi_dma_busy(spi) && LL_SPI_IsEnabled(spi)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 			uint32_t width = SPI_WORD_SIZE_GET(data->ctx.config->operation);
 			/* The TXC flag is not raised at the end of 9, 17 or 25
@@ -1510,7 +1510,7 @@ static int transceive_dma(const struct device *dev,
 			 */
 			if ((width == 9U) || (width == 17U) || (width == 25U)) {
 				k_usleep(1000);
-				ll_func_disable_spi(spi);
+				ll_disable_spi(spi);
 			}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		}

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -81,7 +81,7 @@ struct spi_stm32_data {
 };
 
 #ifdef CONFIG_SPI_STM32_DMA
-static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t location)
+static inline uint32_t ll_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t location)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (location == SPI_STM32_DMA_TX) {
@@ -95,7 +95,7 @@ static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t locat
 }
 
 /* checks that DMA Tx packet is fully transmitted over the SPI */
-static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
+static inline uint32_t ll_spi_dma_busy(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (LL_SPI_GetTransferSize(spi) == 0) {
@@ -111,7 +111,7 @@ static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
 }
 #endif /* st_stm32h7_spi */
 
-static inline uint32_t ll_func_tx_is_not_full(SPI_TypeDef *spi)
+static inline uint32_t ll_tx_is_not_full(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_TXP(spi);
@@ -120,7 +120,7 @@ static inline uint32_t ll_func_tx_is_not_full(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
+static inline uint32_t ll_rx_is_not_empty(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_RXP(spi);
@@ -129,7 +129,7 @@ static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
+static inline void ll_enable_int_tx_empty(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_TXP(spi);
@@ -138,7 +138,7 @@ static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
+static inline void ll_enable_int_rx_not_empty(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_RXP(spi);
@@ -147,7 +147,7 @@ static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
+static inline void ll_enable_int_errors(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_UDR(spi);
@@ -160,7 +160,7 @@ static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
+static inline void ll_disable_int_tx_empty(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_TXP(spi);
@@ -169,7 +169,7 @@ static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
+static inline void ll_disable_int_rx_not_empty(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_RXP(spi);
@@ -178,7 +178,7 @@ static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
+static inline void ll_disable_int_errors(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_UDR(spi);
@@ -191,7 +191,7 @@ static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline bool ll_func_are_int_disabled(SPI_TypeDef *spi)
+static inline bool ll_are_int_disabled(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return (spi->IER == 0U);
@@ -202,7 +202,7 @@ static inline bool ll_func_are_int_disabled(SPI_TypeDef *spi)
 #endif
 }
 
-static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
+static inline uint32_t ll_spi_is_busy(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (LL_SPI_GetTransferSize(spi) == 0) {
@@ -219,7 +219,7 @@ static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
  * non-existing LL FIFO functions for SoC without SPI FIFO
  */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
-static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
+static inline void ll_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_01DATA);
@@ -228,7 +228,7 @@ static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 #endif /* st_stm32h7_spi */
 }
 
-static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
+static inline void ll_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_02DATA);
@@ -238,11 +238,11 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 }
 #endif /* st_stm32_spi_fifo */
 
-static inline void ll_func_disable_spi(SPI_TypeDef *spi)
+static inline void ll_disable_spi(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
-	while (ll_func_rx_is_not_empty(spi)) {
+	while (ll_rx_is_not_empty(spi)) {
 		(void) LL_SPI_ReceiveData8(spi);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo) */


### PR DESCRIPTION
Some drivers need to redefine LL functions because the name can be different between different series. A common name pattern for these functions starts with `ll_func_`.
This PR renames these functions by removing the `_func` that doesn't bring anything of value.
It shortens the name, and improves consistency with some other drivers that don't use this prefix.