### PR TITLE
drivers: dma: Put driver APIs into iterable sections

### DIFF
--- a/drivers/dma/dma_andes_atcdmacx00.c
+++ b/drivers/dma/dma_andes_atcdmacx00.c
@@ -600,7 +600,7 @@ static int dma_atcdmacx00_get_status(const struct device *dev,
 	return 0;
 }
 
-static const struct dma_driver_api dma_atcdmacx00_api = {
+static DEVICE_API(dma, dma_atcdmacx00_api) = {
 	.config = dma_atcdmacx00_config,
 	.reload = dma_atcdmacx00_reload,
 	.start = dma_atcdmacx00_transfer_start,

--- a/drivers/dma/dma_npcx_gdma.c
+++ b/drivers/dma/dma_npcx_gdma.c
@@ -397,7 +397,7 @@ static int dma_npcx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct dma_driver_api npcx_driver_api = {
+static DEVICE_API(dma, npcx_driver_api) = {
 		.config = dma_npcx_configure,
 		.start = dma_npcx_start,
 		.stop = dma_npcx_stop,


### PR DESCRIPTION
Make sure all DMA drivers are located in their linker sections.