### PR TITLE
drivers: auxdisplay: tm1637: Put API into iterable section

### DIFF
--- a/drivers/auxdisplay/auxdisplay_tm1637.c
+++ b/drivers/auxdisplay/auxdisplay_tm1637.c
@@ -329,7 +329,7 @@ static int tm1637_initialize(const struct device *dev)
 	return tm1637_auxdisplay_clear(dev);
 }
 
-static const struct auxdisplay_driver_api tm1637_auxdisplay_api = {
+static DEVICE_API(auxdisplay, tm1637_auxdisplay_api) = {
 	.write = tm1637_auxdisplay_write,
 	.clear = tm1637_auxdisplay_clear,
 	.brightness_set = tm1637_auxdisplay_set_brightness,


### PR DESCRIPTION
Use the DEVICE_API macro to make sure the device API is in the respective API linker section.