### PR TITLE
drivers: crypto: Put device API into iterable section

### DIFF
--- a/drivers/crypto/crypto_esp32_aes.c
+++ b/drivers/crypto/crypto_esp32_aes.c
@@ -458,7 +458,7 @@ static int aes_init(const struct device *dev)
 	return 0;
 }
 
-static const struct crypto_driver_api aes_crypto_api = {
+static DEVICE_API(crypto, aes_crypto_api) = {
 	.query_hw_caps = aes_query_hw_caps,
 	.cipher_begin_session = aes_cipher_begin_session,
 	.cipher_free_session = aes_cipher_free_session,

--- a/drivers/crypto/crypto_esp32_sha.c
+++ b/drivers/crypto/crypto_esp32_sha.c
@@ -538,7 +538,7 @@ static int sha_init(const struct device *dev)
 	return 0;
 }
 
-static const struct crypto_driver_api sha_crypto_api = {
+static DEVICE_API(crypto, sha_crypto_api) = {
 	.query_hw_caps = sha_query_hw_caps,
 	.hash_begin_session = sha_begin_session,
 	.hash_free_session = sha_free_session,


### PR DESCRIPTION
Update some crypto drivers to use the DEVICE_API macro.