### PR TITLE
samples: subsystem: usb: udc: Add multi-instance initialization

### DIFF
--- a/dts/bindings/usb/zephyr,udc.yaml
+++ b/dts/bindings/usb/zephyr,udc.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Leica Geosystems AG
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Generic USB Device Controller (UDC) marker.
+
+  This compatible can be added as a secondary compatible to any USB device
+  controller to enable auto-discovery via DT_FOREACH_STATUS_OKAY(zephyr_udc, fn).
+
+  Example usage in devicetree:
+    zephyr_udc0: &usbotg_hs {
+      compatible = "st,stm32-otghs", "zephyr,udc";
+      ...
+    };
+
+  Example iteration in C code:
+    #define UDC_DEVICE_GET(node_id) DEVICE_DT_GET(node_id),
+    static const struct device *const all_udc_devices[] = {
+      DT_FOREACH_STATUS_OKAY(zephyr_udc, UDC_DEVICE_GET)
+    };
+
+compatible: "zephyr,udc"
+
+include: base.yaml

--- a/samples/subsys/usb/common/sample_usbd.h
+++ b/samples/subsys/usb/common/sample_usbd.h
@@ -36,4 +36,22 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb);
  */
 struct usbd_context *sample_usbd_setup_device(usbd_msg_cb_t msg_cb);
 
+/*
+ * Get the number of UDC devices discovered via zephyr,udc compatible.
+ * This enables auto-discovery of all UDC devices in the system.
+ */
+size_t sample_usbd_get_device_count(void);
+
+/*
+ * Get a USBD context by index.
+ * Returns NULL if index is out of range.
+ */
+struct usbd_context *sample_usbd_get_context(size_t idx);
+
+/*
+ * Initialize all UDC devices discovered via zephyr,udc compatible.
+ * Returns the number of successfully initialized devices.
+ */
+int sample_usbd_init_all_devices(usbd_msg_cb_t msg_cb);
+
 #endif /* ZEPHYR_SAMPLES_SUBSYS_USB_COMMON_SAMPLE_USBD_H */


### PR DESCRIPTION
This introduces a generic mechanism to instantiate multiple USB interfaces and enable/assign the classes automatically.

Problem:

Assuming that the hardware have multiple USB interfaces how we can select only the UDC instances?

Proposal:

Add a generic binding to be added in the interfaces to allow for use of FOR_EACH macros based in that bind. This allows us to use multi-vendor interfaces and group then together at build time.

Description:

This demonstrate how to use the binding in the CDC-ACM example.

The below snip add the binding in the two UDC interfaces. After that, the application can initialize looking all the `zephyr,udc` defined and active.

```c
    zephyr_udc0: &usbotg_hs {
      compatible = "st,stm32-otghs", "zephyr,udc";
      ...
    };
    zephyr_udc1: &udp {
      compatible = "atmel,udc-sam-udp", "zephyr,udc";
      ...
    };
```

The classes now should be added as child of the respective interfaces.

```c
&usbotg_hs {
	cdc_ncm_eth0: cdc_ncm_eth0 {
		compatible = "zephyr,cdc-ncm-ethernet";
	};
};

&udp {
	cdc_acm_uart0 {
		compatible = "zephyr,cdc-acm-uart";
	};
};
```

Using this approach, the user can control which interface is active and what is exposed on that interface.

The example demonstrate that no changes in the core stack are necessary to allow the binding to happen. Assuming that the USB-CORE can handle multiple instances per interface this could automate the initialization. The code was made to keep the compatibility with the `zephyr_udc0` interface name and avoid double instantiation.

Notes:
- Tested using #103840
- Bug found: #103836
