### PR TITLE
drivers: reset: Put reset driver APIs into iterable section

### DIFF
--- a/drivers/reset/reset_ft9001.c
+++ b/drivers/reset/reset_ft9001.c
@@ -98,7 +98,7 @@ static int reset_ft9001_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_ft9001_driver_api = {
+static DEVICE_API(reset, reset_ft9001_driver_api) = {
 	.status = reset_ft9001_status,
 	.line_assert = reset_ft9001_line_assert,
 	.line_deassert = reset_ft9001_line_deassert,

--- a/drivers/reset/reset_rts5817.c
+++ b/drivers/reset/reset_rts5817.c
@@ -52,7 +52,7 @@ static int reset_rts5817_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_rts5817_driver_api = {
+static DEVICE_API(reset, reset_rts5817_driver_api) = {
 	.status = reset_rts5817_status,
 	.line_assert = reset_rts5817_line_assert,
 	.line_deassert = reset_rts5817_line_deassert,


### PR DESCRIPTION
Use the DEVICE_API to put the reset driver APIs into the correct linker section.