### PR TITLE
drivers: display: Put display drivers into iterable sections

### DIFF
--- a/drivers/display/display_hub12.c
+++ b/drivers/display/display_hub12.c
@@ -284,7 +284,7 @@ static int hub12_set_orientation(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct display_driver_api hub12_api = {
+static DEVICE_API(display, hub12_api) = {
 	.blanking_on = hub12_blanking_on,
 	.blanking_off = hub12_blanking_off,
 	.write = hub12_write,

--- a/drivers/display/display_lpm013m126.c
+++ b/drivers/display/display_lpm013m126.c
@@ -242,7 +242,7 @@ static int lpm_init(const struct device *dev)
 	return 0;
 }
 
-static const struct display_driver_api lpm_api = {
+static DEVICE_API(display, lpm_api) = {
 	.blanking_on = lpm_blanking_on,
 	.blanking_off = lpm_blanking_off,
 	.write = lpm_write,

--- a/drivers/display/display_mcux_lcdifv3.c
+++ b/drivers/display/display_mcux_lcdifv3.c
@@ -281,7 +281,7 @@ static int mcux_lcdifv3_init(const struct device *dev)
 	return 0;
 }
 
-static const struct display_driver_api mcux_lcdifv3_api = {
+static DEVICE_API(display, mcux_lcdifv3_api) = {
 	.write = mcux_lcdifv3_write,
 	.get_framebuffer = mcux_lcdifv3_get_framebuffer,
 	.get_capabilities = mcux_lcdifv3_get_capabilities,


### PR DESCRIPTION
Use the DEVICE_API macro to put the diplay driver APIs into the correct iterable sections.