### PR TITLE
drivers: clock_control: Put API into iterable section

### DIFF
--- a/drivers/clock_control/clock_control_ft9001.c
+++ b/drivers/clock_control/clock_control_ft9001.c
@@ -88,7 +88,7 @@ static enum clock_control_status clock_control_ft9001_get_status(const struct de
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static const struct clock_control_driver_api clock_control_ft9001_api = {
+static DEVICE_API(clock_control, clock_control_ft9001_api) = {
 	.on = clock_control_ft9001_on,
 	.off = clock_control_ft9001_off,
 	.get_status = clock_control_ft9001_get_status,

--- a/drivers/clock_control/clock_control_rts5817.c
+++ b/drivers/clock_control/clock_control_rts5817.c
@@ -970,7 +970,7 @@ static int rts_fp_clk_set_rate(const struct device *dev, clock_control_subsys_t 
 	return clk->ops->set_rate(dev, clk, (uint32_t)rate);
 }
 
-static const struct clock_control_driver_api rts_fp_clk_api = {
+static DEVICE_API(clock_control, rts_fp_clk_api) = {
 	.on = rts_fp_clk_on,
 	.off = rts_fp_clk_off,
 	.get_status = rts_fp_clk_get_status,


### PR DESCRIPTION
Update the driver to use DEVICE_API to put it into the correct iterable section.