### PR TITLE
drivers: led_strip: Put driver APIs into iterable sections

### DIFF
--- a/drivers/led_strip/ws2812_uart.c
+++ b/drivers/led_strip/ws2812_uart.c
@@ -277,7 +277,7 @@ static int ws2812_uart_init(const struct device *dev)
 	return 0;
 }
 
-static const struct led_strip_driver_api ws2812_uart_api = {
+static DEVICE_API(led_strip, ws2812_uart_api) = {
 	.update_rgb = ws2812_strip_update_rgb,
 	.length = ws2812_strip_length,
 };


### PR DESCRIPTION
Update led_strip drivers with DEVICE_API to put the API into the correct iterable section.