### PR TITLE
drivers: counter: Put counter driver API into iterable section

### DIFF
--- a/drivers/counter/counter_mcux_rtc_jdp.c
+++ b/drivers/counter/counter_mcux_rtc_jdp.c
@@ -398,7 +398,7 @@ static int mcux_rtc_jdp_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api mcux_rtc_jdp_driver_api = {
+static DEVICE_API(counter, mcux_rtc_jdp_driver_api) = {
 	.start = mcux_rtc_jdp_start,
 	.stop = mcux_rtc_jdp_stop,
 	.get_value = mcux_rtc_jdp_get_value,

--- a/drivers/counter/counter_npcx_lct.c
+++ b/drivers/counter/counter_npcx_lct.c
@@ -330,7 +330,7 @@ static uint32_t counter_npcx_get_pending_int(const struct device *dev)
 	return reg_base->LCTSTAT & NPCX_LCT_STAT_EV_MASK;
 }
 
-static const struct counter_driver_api counter_npcx_lct_api = {
+static DEVICE_API(counter, counter_npcx_lct_api) = {
 	.start = counter_npcx_lct_start,
 	.stop = counter_npcx_lct_stop,
 	.get_value = counter_npcx_lct_get_value,


### PR DESCRIPTION
Use DEVICE_API macro to put the API into the correct iterable section.