### PR TITLE
drivers: pwm: Put driver APIs into iterable section

### DIFF
--- a/drivers/pwm/pwm_cc23x0_timer.c
+++ b/drivers/pwm/pwm_cc23x0_timer.c
@@ -111,7 +111,7 @@ static int pwm_cc23x0_get_cycles_per_sec(const struct device *dev, uint32_t chan
 	return 0;
 }
 
-static const struct pwm_driver_api pwm_cc23x0_driver_api = {
+static DEVICE_API(pwm, pwm_cc23x0_driver_api) = {
 	.set_cycles = pwm_cc23x0_set_cycles,
 	.get_cycles_per_sec = pwm_cc23x0_get_cycles_per_sec,
 };

--- a/drivers/pwm/pwm_sf32lb_atim.c
+++ b/drivers/pwm/pwm_sf32lb_atim.c
@@ -122,7 +122,7 @@ static int pwm_sf32lb_atim_get_cycles_per_sec(const struct device *dev, uint32_t
 	return 0;
 }
 
-static const struct pwm_driver_api pwm_sf32lb_atim_api = {
+static DEVICE_API(pwm, pwm_sf32lb_atim_api) = {
 	.set_cycles = pwm_sf32lb_atim_set_cycles,
 	.get_cycles_per_sec = pwm_sf32lb_atim_get_cycles_per_sec,
 };


### PR DESCRIPTION
Use the DEVICE_API macro to put the PWM driver APIs into the correct iterable section.