### PR TITLE
drivers: net: Increase loopback interface MTU to 1500

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -200,7 +200,7 @@ config NET_LOOPBACK_SIMULATE_PACKET_DROP
 
 config NET_LOOPBACK_MTU
 	int "MTU for loopback interface"
-	default 576
+	default 1500
 	help
 	  This option sets the MTU for loopback interface.
 


### PR DESCRIPTION
No need to have such a low MTU 576 bytes as it prevents sending larger packets for loopback interface. If one have low MTU setting and one tries to send for example larger UDP packets, then one can get this rather confusing error message

Available payload buffer (548) is not enough for requested DGRAM (1197)