### PR TITLE
boards: renesas: ek_ra2l1: added arduino node labels

### DIFF
--- a/boards/renesas/ek_ra2l1/ek_ra2l1.dts
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.dts
@@ -16,6 +16,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include "ek_ra2l1-pinctrl.dtsi"
 
 / {
@@ -102,6 +103,35 @@
 			   <11 0 &ioport4 7 0>;	/* SDA  */
 		/* +5V */
 		/* GND */
+	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &ioport0 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &ioport0 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &ioport0 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &ioport0 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &ioport0 12 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &ioport0 14 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &ioport4 10 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &ioport4 11 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &ioport1 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &ioport4 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &ioport1 7 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &ioport1 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &ioport5 0 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &ioport1 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &ioport1 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &ioport1 12 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &ioport1 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &ioport1 1 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &ioport1 0 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &ioport1 2 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &ioport4 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &ioport4 8 0>;
 	};
 
 	buttons {
@@ -258,3 +288,9 @@ mikrobus_serial: &uart0 {};
 mikrobus_i2c: &iic0 {};
 
 mikrobus_spi: &spi0 {};
+
+arduino_serial: &uart0 {};
+
+arduino_i2c: &iic0 {};
+
+arduino_spi: &spi0 {};


### PR DESCRIPTION
Added arduino_serial, arduino_i2c, arduino_spi and arduino_header node labels to EK-RA2L1 device tree board definition, allowing compatible shield boards to be used.