### PR TITLE
drivers: hwinfo: add wakeup cause API

### DIFF
--- a/doc/hardware/peripherals/hwinfo.rst
+++ b/doc/hardware/peripherals/hwinfo.rst
@@ -7,13 +7,19 @@ Overview
 ********
 
 The HW Info API provides access to hardware information such as device
-identifiers and reset cause flags.
+identifiers, reset cause flags, and wakeup cause flags.
 
 Reset cause flags can be used to determine why the device was reset; for
 example due to a watchdog timeout or due to power cycling. Different devices
 support different subset of flags. Use
 :c:func:`hwinfo_get_supported_reset_cause` to retrieve the flags that are
 supported by that device.
+
+Wakeup cause flags can be used to determine what woke the device from low
+power mode. This is only meaningful when the reset cause includes
+:c:macro:`RESET_LOW_POWER_WAKE`. Use
+:c:func:`hwinfo_get_supported_wakeup_cause` to retrieve the wakeup cause
+flags that are supported by that device.
 
 Configuration Options
 *********************

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -207,6 +207,18 @@ New APIs and options
     * :c:type:`haptics_error_callback_t` to provide function prototype for error callbacks.
     * :c:func:`haptics_register_error_callback` to register an error callback with a driver.
 
+* Hardware Information
+
+  * :c:func:`hwinfo_get_wakeup_cause`
+  * :c:func:`hwinfo_get_supported_wakeup_cause`
+  * :c:macro:`WAKEUP_TIMER`
+  * :c:macro:`WAKEUP_GPIO`
+  * :c:macro:`WAKEUP_COPROCESSOR`
+  * :c:macro:`WAKEUP_TOUCHPAD`
+  * :c:macro:`WAKEUP_UART`
+  * :c:macro:`WAKEUP_WIFI`
+  * :c:macro:`WAKEUP_BT`
+
 * IPM
 
   * IPM callbacks for the mailbox backend now correctly handle signal-only mailbox

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -9,6 +9,7 @@
 #include <soc/reset_reasons.h>
 #include "esp_system.h"
 #include "rtc.h"
+#include <esp_sleep.h>
 
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
@@ -91,6 +92,50 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		break;
 	case ESP_RST_BROWNOUT:
 		*cause = RESET_BROWNOUT;
+		break;
+	default:
+		*cause = 0;
+		break;
+	}
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_supported_wakeup_cause(uint32_t *supported)
+{
+	*supported = (WAKEUP_TIMER | WAKEUP_GPIO | WAKEUP_COPROCESSOR | WAKEUP_TOUCHPAD |
+		      WAKEUP_UART | WAKEUP_WIFI | WAKEUP_BT);
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_wakeup_cause(uint32_t *cause)
+{
+	esp_sleep_wakeup_cause_t src = esp_sleep_get_wakeup_cause();
+
+	switch (src) {
+	case ESP_SLEEP_WAKEUP_TIMER:
+		*cause = WAKEUP_TIMER;
+		break;
+	case ESP_SLEEP_WAKEUP_GPIO:
+	case ESP_SLEEP_WAKEUP_EXT0:
+	case ESP_SLEEP_WAKEUP_EXT1:
+		*cause = WAKEUP_GPIO;
+		break;
+	case ESP_SLEEP_WAKEUP_ULP:
+		*cause = WAKEUP_COPROCESSOR;
+		break;
+	case ESP_SLEEP_WAKEUP_TOUCHPAD:
+		*cause = WAKEUP_TOUCHPAD;
+		break;
+	case ESP_SLEEP_WAKEUP_UART:
+		*cause = WAKEUP_UART;
+		break;
+	case ESP_SLEEP_WAKEUP_WIFI:
+		*cause = WAKEUP_WIFI;
+		break;
+	case ESP_SLEEP_WAKEUP_BT:
+		*cause = WAKEUP_BT;
 		break;
 	default:
 		*cause = 0;

--- a/drivers/hwinfo/hwinfo_handlers.c
+++ b/drivers/hwinfo/hwinfo_handlers.c
@@ -53,3 +53,27 @@ int z_vrfy_hwinfo_get_supported_reset_cause(uint32_t *supported)
 	return ret;
 }
 #include <zephyr/syscalls/hwinfo_get_supported_reset_cause_mrsh.c>
+
+int z_vrfy_hwinfo_get_wakeup_cause(uint32_t *cause)
+{
+	int ret;
+	uint32_t cause_copy;
+
+	ret = z_impl_hwinfo_get_wakeup_cause(&cause_copy);
+	K_OOPS(k_usermode_to_copy(cause, &cause_copy, sizeof(uint32_t)));
+
+	return ret;
+}
+#include <zephyr/syscalls/hwinfo_get_wakeup_cause_mrsh.c>
+
+int z_vrfy_hwinfo_get_supported_wakeup_cause(uint32_t *supported)
+{
+	int ret;
+	uint32_t supported_copy;
+
+	ret = z_impl_hwinfo_get_supported_wakeup_cause(&supported_copy);
+	K_OOPS(k_usermode_to_copy(supported, &supported_copy, sizeof(uint32_t)));
+
+	return ret;
+}
+#include <zephyr/syscalls/hwinfo_get_supported_wakeup_cause_mrsh.c>

--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -202,6 +202,97 @@ static int cmd_supported_reset_cause(const struct shell *sh, size_t argc,
 	return 0;
 }
 
+static inline const char *wakeup_cause_to_string(uint32_t cause)
+{
+	switch (cause) {
+	case WAKEUP_TIMER:
+		return "timer";
+
+	case WAKEUP_GPIO:
+		return "GPIO";
+
+	case WAKEUP_COPROCESSOR:
+		return "coprocessor";
+
+	case WAKEUP_TOUCHPAD:
+		return "touchpad";
+
+	case WAKEUP_UART:
+		return "UART";
+
+	case WAKEUP_WIFI:
+		return "Wi-Fi";
+
+	case WAKEUP_BT:
+		return "Bluetooth";
+
+	default:
+		return "unknown";
+	}
+}
+
+static void print_all_wakeup_causes(const struct shell *sh, uint32_t cause)
+{
+	for (uint32_t cause_mask = 1; cause_mask; cause_mask <<= 1) {
+		if (cause & cause_mask) {
+			shell_print(sh, "- %s", wakeup_cause_to_string(cause & cause_mask));
+		}
+	}
+}
+
+static int cmd_show_wakeup_cause(const struct shell *sh, size_t argc, char **argv)
+{
+	int res;
+	uint32_t cause;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	res = hwinfo_get_wakeup_cause(&cause);
+	if (res == -ENOSYS) {
+		shell_error(sh, "Not supported by hardware");
+		return res;
+	} else if (res != 0) {
+		shell_error(sh, "Error reading the wakeup cause [%d]", res);
+		return res;
+	}
+
+	if (cause != 0) {
+		shell_print(sh, "wakeup caused by:");
+		print_all_wakeup_causes(sh, cause);
+	} else {
+		shell_print(sh, "No wakeup cause set");
+	}
+
+	return 0;
+}
+
+static int cmd_supported_wakeup_cause(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t cause;
+	int res;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	res = hwinfo_get_supported_wakeup_cause(&cause);
+	if (res == -ENOSYS) {
+		shell_error(sh, "Not supported by hardware");
+	} else if (res != 0) {
+		shell_error(sh, "Could not get the supported wakeup causes [%d]", res);
+		return res;
+	}
+
+	if (cause != 0) {
+		shell_print(sh, "supported wakeup causes:");
+		print_all_wakeup_causes(sh, cause);
+	} else {
+		shell_print(sh, "No wakeup causes supported");
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_reset_cause,
 	SHELL_CMD_ARG(show, NULL, "Show persistent reset causes",
 		      cmd_show_reset_cause, 1, 0),
@@ -213,11 +304,22 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_reset_cause,
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_hwinfo,
-	SHELL_CMD_ARG(devid, NULL, "Show device id", cmd_get_device_id, 1, 0),
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_wakeup_cause,
+			       SHELL_CMD_ARG(show, NULL, "Show wakeup cause", cmd_show_wakeup_cause,
+					     1, 0),
+			       SHELL_CMD_ARG(supported, NULL,
+					     "Get a list of all supported wakeup causes",
+					     cmd_supported_wakeup_cause, 1, 0),
+			       SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_hwinfo, SHELL_CMD_ARG(devid, NULL, "Show device id", cmd_get_device_id, 1, 0),
 	SHELL_CMD_ARG(deveui64, NULL, "Show device eui64", cmd_get_device_eui64, 1, 0),
-	SHELL_CMD_ARG(reset_cause, &sub_reset_cause, "Reset cause commands",
-		      cmd_show_reset_cause, 1, 0),
+	SHELL_CMD_ARG(reset_cause, &sub_reset_cause, "Reset cause commands", cmd_show_reset_cause,
+		      1, 0),
+	SHELL_CMD_ARG(wakeup_cause, &sub_wakeup_cause, "Wakeup cause commands",
+		      cmd_show_wakeup_cause, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/hwinfo/hwinfo_weak_impl.c
+++ b/drivers/hwinfo/hwinfo_weak_impl.c
@@ -30,3 +30,13 @@ int __weak z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 {
 	return -ENOSYS;
 }
+
+int __weak z_impl_hwinfo_get_wakeup_cause(uint32_t *cause)
+{
+	return -ENOSYS;
+}
+
+int __weak z_impl_hwinfo_get_supported_wakeup_cause(uint32_t *supported)
+{
+	return -ENOSYS;
+}

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -76,6 +76,29 @@ extern "C" {
  */
 
 /**
+ * @name Wakeup cause flags
+ * @anchor wakeup_cause
+ * @{
+ */
+/** Timer wakeup */
+#define WAKEUP_TIMER       BIT(0)
+/** GPIO wakeup */
+#define WAKEUP_GPIO        BIT(1)
+/** Coprocessor wakeup */
+#define WAKEUP_COPROCESSOR BIT(2)
+/** Touchpad wakeup */
+#define WAKEUP_TOUCHPAD    BIT(3)
+/** UART wakeup */
+#define WAKEUP_UART        BIT(4)
+/** Wi-Fi wakeup */
+#define WAKEUP_WIFI        BIT(5)
+/** Bluetooth wakeup */
+#define WAKEUP_BT          BIT(6)
+/**
+ * @}
+ */
+
+/**
  * @brief Copy the device id to a buffer
  *
  * This routine copies "length" number of bytes of the device ID to the buffer.
@@ -166,6 +189,38 @@ int z_impl_hwinfo_clear_reset_cause(void);
 __syscall int hwinfo_get_supported_reset_cause(uint32_t *supported);
 
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported);
+
+/**
+ * @brief      Retrieve cause of wakeup from low power mode.
+ *
+ * @param      cause  OR'd @ref wakeup_cause "wakeup cause" flags
+ *
+ * This routine retrieves the flags that indicate what woke the device
+ * from low power mode. Only meaningful when the reset cause includes
+ * @ref RESET_LOW_POWER_WAKE.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOSYS if there is no implementation for the particular device.
+ * @retval <0 any negative value on driver specific errors.
+ */
+__syscall int hwinfo_get_wakeup_cause(uint32_t *cause);
+
+int z_impl_hwinfo_get_wakeup_cause(uint32_t *cause);
+
+/**
+ * @brief      Get supported wakeup cause flags
+ *
+ * @param      supported  OR'd @ref wakeup_cause "wakeup cause" flags that are supported
+ *
+ * Retrieves all `wakeup_cause` flags that are supported by this device.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOSYS if there is no implementation for the particular device.
+ * @retval <0 any negative value on driver specific errors.
+ */
+__syscall int hwinfo_get_supported_wakeup_cause(uint32_t *supported);
+
+int z_impl_hwinfo_get_supported_wakeup_cause(uint32_t *supported);
 
 /**
  * @}

--- a/tests/drivers/hwinfo/api/src/main.c
+++ b/tests/drivers/hwinfo/api/src/main.c
@@ -194,5 +194,40 @@ ZTEST(hwinfo_device_id_api, test_get_supported_reset_cause)
 					"Supported reset cause not written.");
 }
 
+ZTEST(hwinfo_device_id_api, test_get_wakeup_cause)
+{
+	uint32_t cause;
+	ssize_t ret;
+
+	cause = 0xDEADBEEF;
+
+	ret = hwinfo_get_wakeup_cause(&cause);
+	if (ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
+
+	zassert_false((ret < 0), "Unexpected negative return value: %zd", ret);
+
+	zassert_not_equal(cause, 0xDEADBEEF, "Wakeup cause not written.");
+}
+
+ZTEST(hwinfo_device_id_api, test_get_supported_wakeup_cause)
+{
+	uint32_t supported;
+	ssize_t ret;
+
+	supported = 0xDEADBEEF;
+
+	ret = hwinfo_get_supported_wakeup_cause(&supported);
+	if (ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
+
+	zassert_false((ret < 0), "Unexpected negative return value: %zd", ret);
+
+	zassert_not_equal(supported, 0xDEADBEEF, "Supported wakeup cause not written.");
+}
 
 ZTEST_SUITE(hwinfo_device_id_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Applications using LP core coprocessors (e.g., ESP32-C6 ULP)
cannot distinguish ULP wakeup from other deep sleep wakeup
sources (timer, GPIO) using the existing hwinfo API. The only
available flag is `RESET_LOW_POWER_WAKE`, which is generic.

- Add wakeup cause detection API to hwinfo subsystem with 7 flags: timer, GPIO, coprocessor, touchpad, UART, Wi-Fi, and Bluetooth

- Add hwinfo_get_wakeup_cause() and hwinfo_get_supported_wakeup_cause() syscalls, weak stubs, and handlers
- Add shell commands for querying wakeup cause
- Add test cases for the new API functions
- Implement ESP32 wakeup cause detection using esp_sleep_get_wakeup_cause()

RFC: #103872
