### PR TITLE
drivers: can: use DEVICE_API_GET() for obtaining the can_driver_api struct

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -34,7 +34,7 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 		    k_timeout_t timeout, can_tx_callback_t callback,
 		    void *user_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
 	uint32_t id_mask;
 
 	CHECKIF(frame == NULL) {
@@ -77,7 +77,6 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 		      void *user_data, const struct can_filter *filter)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 	uint32_t id_mask;
 
 	CHECKIF(callback == NULL || filter == NULL) {
@@ -99,7 +98,7 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 		return -EINVAL;
 	}
 
-	return api->add_rx_filter(dev, callback, user_data, filter);
+	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, callback, user_data, filter);
 }
 
 static void can_msgq_put(const struct device *dev, struct can_frame *frame, void *user_data)
@@ -120,9 +119,8 @@ static void can_msgq_put(const struct device *dev, struct can_frame *frame, void
 int z_impl_can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
 				  const struct can_filter *filter)
 {
-	const struct can_driver_api *api = dev->api;
 
-	return api->add_rx_filter(dev, can_msgq_put, msgq, filter);
+	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, can_msgq_put, msgq, filter);
 }
 
 /**
@@ -368,7 +366,6 @@ static int check_timing_in_range(const struct can_timing *timing,
 int z_impl_can_set_timing(const struct device *dev,
 			  const struct can_timing *timing)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 	const struct can_timing *min = can_get_timing_min(dev);
 	const struct can_timing *max = can_get_timing_max(dev);
 	int err;
@@ -378,7 +375,7 @@ int z_impl_can_set_timing(const struct device *dev,
 		return err;
 	}
 
-	return api->set_timing(dev, timing);
+	return DEVICE_API_GET(can, dev)->set_timing(dev, timing);
 }
 
 int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
@@ -410,7 +407,7 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 int z_impl_can_set_timing_data(const struct device *dev,
 			       const struct can_timing *timing_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
 	const struct can_timing *min = can_get_timing_data_min(dev);
 	const struct can_timing *max = can_get_timing_data_max(dev);
 	int err;

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -823,9 +823,7 @@ __syscall int can_get_core_clock(const struct device *dev, uint32_t *rate);
 
 static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *rate)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_core_clock(dev, rate);
+	return DEVICE_API_GET(can, dev)->get_core_clock(dev, rate);
 }
 
 /**
@@ -889,9 +887,7 @@ __syscall const struct can_timing *can_get_timing_min(const struct device *dev);
 
 static inline const struct can_timing *z_impl_can_get_timing_min(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_min;
+	return &DEVICE_API_GET(can, dev)->timing_min;
 }
 
 /**
@@ -905,9 +901,7 @@ __syscall const struct can_timing *can_get_timing_max(const struct device *dev);
 
 static inline const struct can_timing *z_impl_can_get_timing_max(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_max;
+	return &DEVICE_API_GET(can, dev)->timing_max;
 }
 
 /**
@@ -957,9 +951,7 @@ __syscall const struct can_timing *can_get_timing_data_min(const struct device *
 #ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_data_min;
+	return &DEVICE_API_GET(can, dev)->timing_data_min;
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
@@ -981,9 +973,7 @@ __syscall const struct can_timing *can_get_timing_data_max(const struct device *
 #ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_data_max;
+	return &DEVICE_API_GET(can, dev)->timing_data_max;
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
@@ -1093,9 +1083,7 @@ __syscall int can_get_capabilities(const struct device *dev, can_mode_t *cap);
 
 static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode_t *cap)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_capabilities(dev, cap);
+	return DEVICE_API_GET(can, dev)->get_capabilities(dev, cap);
 }
 
 /**
@@ -1137,9 +1125,7 @@ __syscall int can_start(const struct device *dev);
 
 static inline int z_impl_can_start(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->start(dev);
+	return DEVICE_API_GET(can, dev)->start(dev);
 }
 
 /**
@@ -1161,9 +1147,7 @@ __syscall int can_stop(const struct device *dev);
 
 static inline int z_impl_can_stop(const struct device *dev)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->stop(dev);
+	return DEVICE_API_GET(can, dev)->stop(dev);
 }
 
 /**
@@ -1180,9 +1164,7 @@ __syscall int can_set_mode(const struct device *dev, can_mode_t mode);
 
 static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->set_mode(dev, mode);
+	return DEVICE_API_GET(can, dev)->set_mode(dev, mode);
 }
 
 /**
@@ -1376,9 +1358,7 @@ __syscall void can_remove_rx_filter(const struct device *dev, int filter_id);
 
 static inline void z_impl_can_remove_rx_filter(const struct device *dev, int filter_id)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	api->remove_rx_filter(dev, filter_id);
+	DEVICE_API_GET(can, dev)->remove_rx_filter(dev, filter_id);
 }
 
 /**
@@ -1398,7 +1378,7 @@ __syscall int can_get_max_filters(const struct device *dev, bool ide);
 
 static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
 
 	if (api->get_max_filters == NULL) {
 		return -ENOSYS;
@@ -1434,9 +1414,7 @@ __syscall int can_get_state(const struct device *dev, enum can_state *state,
 static inline int z_impl_can_get_state(const struct device *dev, enum can_state *state,
 				       struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_state(dev, state, err_cnt);
+	return DEVICE_API_GET(can, dev)->get_state(dev, state, err_cnt);
 }
 
 /**
@@ -1462,7 +1440,7 @@ __syscall int can_recover(const struct device *dev, k_timeout_t timeout);
 #ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	const struct can_driver_api *api = DEVICE_API_GET(can, dev);
 
 	if (api->recover == NULL) {
 		return -ENOSYS;
@@ -1489,9 +1467,7 @@ static inline void can_set_state_change_callback(const struct device *dev,
 						 can_state_change_callback_t callback,
 						 void *user_data)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	api->set_state_change_callback(dev, callback, user_data);
+	DEVICE_API_GET(can, dev)->set_state_change_callback(dev, callback, user_data);
 }
 
 /** @} */


### PR DESCRIPTION
Use the `DEVICE_API_GET()` macro for obtaining a pointer to the `can_driver_api` struct from the `device` struct.