### PR TITLE
Bluetooth: Controller: LLL: Use chosen entropy device

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -60,10 +60,7 @@ static struct {
 
 /* Entropy device */
 #if defined(CONFIG_ENTROPY_HAS_DRIVER)
-/* FIXME: This could probably use a chosen entropy device instead on relying on
- * the nodelabel being the same as for the old nrf rng.
- */
-static const struct device *const dev_entropy = DEVICE_DT_GET(DT_NODELABEL(rng));
+static const struct device *const dev_entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 #endif /* CONFIG_ENTROPY_HAS_DRIVER */
 
 static int init_reset(void);


### PR DESCRIPTION
Uses the chosen entropy node as the LLL entropy device instead of a presumed node label which does not hold true