### PR TITLE
[RFC] Early stage of a video common structure allowing to have more & more common framework code

### DIFF
--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1220,6 +1220,7 @@ static int gc2145_set_stream(const struct device *dev, bool enable, enum video_b
 
 static int gc2145_get_caps(const struct device *dev, struct video_caps *caps)
 {
+	caps->type = VIDEO_BUF_TYPE_OUTPUT;
 	caps->format_caps = fmts;
 	return 0;
 }
@@ -1319,6 +1320,7 @@ static int gc2145_init(const struct device *dev)
 {
 	/* set default/init format VGA RGB565 */
 	struct video_format fmt = {
+		.type = VIDEO_BUF_TYPE_OUTPUT,
 		.pixelformat = VIDEO_PIX_FMT_RGB565,
 		.width = RESOLUTION_VGA_W,
 		.height = RESOLUTION_VGA_H,

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -768,6 +768,7 @@ struct gc2145_ctrls {
 };
 
 struct gc2145_data {
+	struct video_device_context dctx;
 	struct gc2145_ctrls ctrls;
 	struct video_format fmt;
 	struct video_rect crop;
@@ -1349,6 +1350,11 @@ static int gc2145_init(const struct device *dev)
 	int ret;
 	const struct gc2145_config *cfg = dev->config;
 	(void) cfg;
+
+	ret = video_init_context_dev(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
 		LOG_ERR("Bus device is not ready");

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1262,10 +1262,6 @@ static int gc2145_set_ctrl(const struct device *dev, uint32_t id)
 
 static int gc2145_set_selection(const struct device *dev, struct video_selection *sel)
 {
-	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
-		return -EINVAL;
-	}
-
 	if (sel->target != VIDEO_SEL_TGT_CROP) {
 		return -EINVAL;
 	}
@@ -1276,10 +1272,6 @@ static int gc2145_set_selection(const struct device *dev, struct video_selection
 static int gc2145_get_selection(const struct device *dev, struct video_selection *sel)
 {
 	struct gc2145_data *drv_data = dev->data;
-
-	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
-		return -EINVAL;
-	}
 
 	switch (sel->target) {
 	case VIDEO_SEL_TGT_CROP:
@@ -1351,7 +1343,7 @@ static int gc2145_init(const struct device *dev)
 	const struct gc2145_config *cfg = dev->config;
 	(void) cfg;
 
-	ret = video_init_context_dev(dev);
+	ret = video_init_context_dev(dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -770,7 +770,6 @@ struct gc2145_ctrls {
 struct gc2145_data {
 	struct video_device_context dctx;
 	struct gc2145_ctrls ctrls;
-	struct video_format fmt;
 	struct video_rect crop;
 	uint16_t format_width;
 	uint16_t format_height;
@@ -1043,8 +1042,8 @@ static int gc2145_set_crop(const struct device *dev, struct video_selection *sel
 	drv_data->crop = sel->rect;
 
 	/* enqueue/dequeue depend on this being set as well as the crop */
-	drv_data->fmt.width = drv_data->crop.width;
-	drv_data->fmt.height = drv_data->crop.height;
+	drv_data->dctx.fmt.width = drv_data->crop.width;
+	drv_data->dctx.fmt.height = drv_data->crop.height;
 
 	return 0;
 }
@@ -1145,11 +1144,6 @@ static int gc2145_set_fmt(const struct device *dev, struct video_format *fmt)
 	size_t idx;
 	int ret;
 
-	if (memcmp(&drv_data->fmt, fmt, sizeof(drv_data->fmt)) == 0) {
-		/* nothing to do */
-		return 0;
-	}
-
 	/* Check if camera is capable of handling given format */
 	ret = video_format_caps_index(fmts, fmt, &idx);
 	if (ret < 0) {
@@ -1180,16 +1174,7 @@ static int gc2145_set_fmt(const struct device *dev, struct video_format *fmt)
 		}
 	}
 
-	drv_data->fmt = *fmt;
-
-	return 0;
-}
-
-static int gc2145_get_fmt(const struct device *dev, struct video_format *fmt)
-{
-	struct gc2145_data *drv_data = dev->data;
-
-	*fmt = drv_data->fmt;
+	drv_data->dctx.fmt = *fmt;
 
 	return 0;
 }
@@ -1293,7 +1278,6 @@ static int gc2145_get_selection(const struct device *dev, struct video_selection
 
 static DEVICE_API(video, gc2145_driver_api) = {
 	.set_format = gc2145_set_fmt,
-	.get_format = gc2145_get_fmt,
 	.get_caps = gc2145_get_caps,
 	.set_stream = gc2145_set_stream,
 	.set_ctrl = gc2145_set_ctrl,

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -755,7 +755,7 @@ static int imx335_init(const struct device *dev)
 	struct imx335_data *drv_data = dev->data;
 	int ret;
 
-	ret = video_init_context_dev(dev);
+	ret = video_init_context_dev(dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -371,6 +371,7 @@ static const uint32_t imx335_framerates[] = {
 
 static int imx335_get_caps(const struct device *dev, struct video_caps *caps)
 {
+	caps->type = VIDEO_BUF_TYPE_OUTPUT;
 	caps->format_caps = imx335_fmts;
 	return 0;
 }
@@ -815,6 +816,7 @@ static int imx335_init(const struct device *dev)
 #define IMX335_INIT(n)										\
 	static struct imx335_data imx335_data_##n = {						\
 		.dctx.fmt = {									\
+			.type = VIDEO_BUF_TYPE_OUTPUT,						\
 			.pixelformat = VIDEO_PIX_FMT_SRGGB10P,					\
 			.width = IMX335_NATIVE_WIDTH,						\
 			.height = IMX335_NATIVE_HEIGHT,						\

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -57,6 +57,7 @@ struct imx335_ctrls {
 };
 
 struct imx335_data {
+	struct video_device_context dctx;
 	struct imx335_ctrls ctrls;
 	struct video_format fmt;
 	uint32_t frame_rate;
@@ -753,6 +754,11 @@ static int imx335_init(const struct device *dev)
 	const struct imx335_config *cfg = dev->config;
 	struct imx335_data *drv_data = dev->data;
 	int ret;
+
+	ret = video_init_context_dev(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (!device_is_ready(cfg->i2c.bus)) {
 		LOG_ERR("Bus device is not ready");

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -61,7 +61,6 @@ struct imx335_data {
 	struct imx335_ctrls ctrls;
 	struct video_format fmt;
 	uint32_t frame_rate;
-	bool enabled;
 };
 
 #define IMX335_REG8(addr)  ((addr) | VIDEO_REG_ADDR16_DATA8)
@@ -389,7 +388,6 @@ static int imx335_get_caps(const struct device *dev, struct video_caps *caps)
 static int imx335_set_stream(const struct device *dev, bool enable, enum video_buf_type type)
 {
 	const struct imx335_config *cfg = dev->config;
-	struct imx335_data *drv_data = dev->data;
 	int ret;
 
 	ret = video_write_cci_reg(&cfg->i2c, IMX335_STANDBY,
@@ -398,8 +396,6 @@ static int imx335_set_stream(const struct device *dev, bool enable, enum video_b
 		LOG_ERR("Failed to set standby register\n");
 		return ret;
 	}
-
-	drv_data->enabled = enable;
 
 	k_sleep(K_USEC(20));
 
@@ -554,11 +550,6 @@ static int imx335_set_fmt(const struct device *dev, struct video_format *fmt)
 	struct imx335_ctrls *ctrls = &drv_data->ctrls;
 	int ret;
 	size_t fmt_idx;
-
-	if (drv_data->enabled) {
-		LOG_ERR("Cannot set format while the stream is running");
-		return -EBUSY;
-	}
 
 	ret = video_format_caps_index(imx335_fmts, fmt, &fmt_idx);
 	if (ret < 0) {
@@ -840,7 +831,6 @@ static int imx335_init(const struct device *dev)
 			.height = IMX335_NATIVE_HEIGHT,						\
 		},										\
 		.frame_rate = 30,								\
-		.enabled = false,								\
 	};											\
 	static const struct imx335_config imx335_cfg_##n = {					\
 		.i2c = I2C_DT_SPEC_INST_GET(n),							\

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -59,7 +59,6 @@ struct imx335_ctrls {
 struct imx335_data {
 	struct video_device_context dctx;
 	struct imx335_ctrls ctrls;
-	struct video_format fmt;
 	uint32_t frame_rate;
 };
 
@@ -370,15 +369,6 @@ static const uint32_t imx335_framerates[] = {
 	[IMX335_60_FPS] = 60,
 };
 
-static int imx335_get_fmt(const struct device *dev, struct video_format *fmt)
-{
-	struct imx335_data *drv_data = dev->data;
-
-	*fmt = drv_data->fmt;
-
-	return 0;
-}
-
 static int imx335_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	caps->format_caps = imx335_fmts;
@@ -491,7 +481,7 @@ static int imx335_set_frmival(const struct device *dev, struct video_frmival *fr
 	int ret;
 
 	struct video_frmival_enum match = {
-		.format = &drv_data->fmt,
+		.format = &drv_data->dctx.fmt,
 		.type = VIDEO_FRMIVAL_TYPE_DISCRETE,
 		.discrete = *frmival,
 	};
@@ -504,8 +494,8 @@ static int imx335_set_frmival(const struct device *dev, struct video_frmival *fr
 
 	switch (match.index) {
 	case IMX335_25_FPS:
-		hmax = (drv_data->fmt.width == IMX335_BIN_2X2_WIDTH
-				&& drv_data->fmt.height == IMX335_BIN_2X2_HEIGHT) ? 0x0280 : 0x0294;
+		hmax = (drv_data->dctx.fmt.width == IMX335_BIN_2X2_WIDTH &&
+			drv_data->dctx.fmt.height == IMX335_BIN_2X2_HEIGHT) ? 0x0280 : 0x0294;
 		break;
 	case IMX335_30_FPS:
 		hmax = 0x0226;
@@ -592,8 +582,8 @@ static int imx335_set_fmt(const struct device *dev, struct video_format *fmt)
 		}
 	}
 
-	drv_data->fmt.width = fmt->width;
-	drv_data->fmt.height = fmt->height;
+	drv_data->dctx.fmt.width = fmt->width;
+	drv_data->dctx.fmt.height = fmt->height;
 	/* update framerate, since the timing and allowed framerates may have changed */
 	struct video_frmival frmival = {
 		.numerator = 1,
@@ -637,7 +627,6 @@ static int imx335_enum_frmival(const struct device *dev, struct video_frmival_en
 
 static DEVICE_API(video, imx335_driver_api) = {
 	.set_format = imx335_set_fmt,
-	.get_format = imx335_get_fmt,
 	.get_caps = imx335_get_caps,
 	.set_stream = imx335_set_stream,
 	.set_ctrl = imx335_set_ctrl,
@@ -794,7 +783,7 @@ static int imx335_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = imx335_set_fmt(dev, &drv_data->fmt);
+	ret = imx335_set_fmt(dev, &drv_data->dctx.fmt);
 	if (ret < 0) {
 		LOG_ERR("Unable to apply format");
 		return ret;
@@ -825,7 +814,7 @@ static int imx335_init(const struct device *dev)
 
 #define IMX335_INIT(n)										\
 	static struct imx335_data imx335_data_##n = {						\
-		.fmt = {									\
+		.dctx.fmt = {									\
 			.pixelformat = VIDEO_PIX_FMT_SRGGB10P,					\
 			.width = IMX335_NATIVE_WIDTH,						\
 			.height = IMX335_NATIVE_HEIGHT,						\

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -620,5 +620,23 @@ static int video_init_context(const struct device *dev, uint8_t buf_type)
 
 int video_init_context_dev(const struct device *dev, enum video_buf_type buf_type)
 {
-	return video_init_context(dev, buf_type);
+	struct video_context *vctx;
+	struct video_device_context *dctx;
+	int ret;
+
+	ret = video_init_context(dev, buf_type);
+	if (ret < 0) {
+		return ret;
+	}
+
+	vctx = (struct video_context *)dev->data;
+	dctx = (struct video_device_context *)dev->data;
+
+	if (buf_type == VIDEO_BUF_TYPE_INPUT) {
+		vctx->is_streaming_in = &dctx->is_streaming;
+	} else {
+		vctx->is_streaming_out = &dctx->is_streaming;
+	}
+
+	return 0;
 }

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -593,3 +593,24 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
 
 	return video_enqueue(sink, buf);
 }
+
+static int video_init_context(const struct device *dev)
+{
+	struct video_context *vctx;
+
+	if (dev == NULL || dev->data == NULL) {
+		return -EINVAL;
+	}
+
+	vctx = (struct video_context *)dev->data;
+
+	vctx->dev = dev;
+	k_mutex_init(&vctx->lock);
+
+	return 0;
+}
+
+int video_init_context_dev(const struct device *dev)
+{
+	return video_init_context(dev);
+}

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -156,15 +156,22 @@ int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx)
 int video_enqueue(const struct device *dev, struct video_buffer *buf)
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	struct video_context *ctx;
 
-	if (dev == NULL || buf == NULL || buf->index >= CONFIG_VIDEO_BUFFER_POOL_NUM_MAX ||
-	    (buf->type != VIDEO_BUF_TYPE_INPUT && buf->type != VIDEO_BUF_TYPE_OUTPUT)) {
+	if (dev == NULL || dev->data == NULL || buf == NULL ||
+	    buf->index >= CONFIG_VIDEO_BUFFER_POOL_NUM_MAX) {
 		return -EINVAL;
 	}
 
 	api = (const struct video_driver_api *)dev->api;
 	if (api->enqueue == NULL) {
 		return -ENOSYS;
+	}
+
+	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, buf->type)) {
+		return -EINVAL;
 	}
 
 	video_buf[buf->index].type = buf->type;
@@ -594,7 +601,7 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
 	return video_enqueue(sink, buf);
 }
 
-static int video_init_context(const struct device *dev)
+static int video_init_context(const struct device *dev, uint8_t buf_type)
 {
 	struct video_context *vctx;
 
@@ -606,11 +613,12 @@ static int video_init_context(const struct device *dev)
 
 	vctx->dev = dev;
 	k_mutex_init(&vctx->lock);
+	vctx->supported_buf_type = buf_type;
 
 	return 0;
 }
 
-int video_init_context_dev(const struct device *dev)
+int video_init_context_dev(const struct device *dev, enum video_buf_type buf_type)
 {
-	return video_init_context(dev);
+	return video_init_context(dev, buf_type);
 }

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -634,8 +634,10 @@ int video_init_context_dev(const struct device *dev, enum video_buf_type buf_typ
 
 	if (buf_type == VIDEO_BUF_TYPE_INPUT) {
 		vctx->is_streaming_in = &dctx->is_streaming;
+		vctx->fmt_in = &dctx->fmt;
 	} else {
 		vctx->is_streaming_out = &dctx->is_streaming;
+		vctx->fmt_out = &dctx->fmt;
 	}
 
 	return 0;

--- a/drivers/video/video_st_mipid02.c
+++ b/drivers/video/video_st_mipid02.c
@@ -34,7 +34,6 @@ struct mipid02_config {
 
 struct mipid02_data {
 	struct video_device_context dctx;
-	struct video_format fmt;
 	const struct mipid02_format_desc *desc;
 	struct video_format_cap *caps;
 };
@@ -170,7 +169,7 @@ static int mipid02_set_fmt(const struct device *dev, struct video_format *fmt)
 		return ret;
 	}
 
-	drv_data->fmt = *fmt;
+	drv_data->dctx.fmt = *fmt;
 	drv_data->desc = desc;
 
 	return 0;
@@ -198,11 +197,11 @@ static int mipid02_get_fmt(const struct device *dev, struct video_format *fmt)
 		/* Override the pixelformat */
 		fmt->pixelformat = desc->pixelformat;
 
-		drv_data->fmt = *fmt;
+		drv_data->dctx.fmt = *fmt;
 		drv_data->desc = desc;
 	}
 
-	*fmt = drv_data->fmt;
+	*fmt = drv_data->dctx.fmt;
 
 	return 0;
 }
@@ -292,7 +291,7 @@ static int mipid02_set_stream(const struct device *dev, bool enable, enum video_
 		return 0;
 	}
 
-	desc = mipid02_get_format_desc(drv_data->fmt.pixelformat);
+	desc = mipid02_get_format_desc(drv_data->dctx.fmt.pixelformat);
 	if (!desc) {
 		LOG_ERR("No valid format desc available, should get/set_fmt prior to set_stream");
 		return -EIO;

--- a/drivers/video/video_st_mipid02.c
+++ b/drivers/video/video_st_mipid02.c
@@ -33,6 +33,7 @@ struct mipid02_config {
 };
 
 struct mipid02_data {
+	struct video_device_context dctx;
 	struct video_format fmt;
 	const struct mipid02_format_desc *desc;
 	struct video_format_cap *caps;
@@ -366,6 +367,11 @@ static int mipid02_init(const struct device *dev)
 {
 	const struct mipid02_config *cfg = dev->config;
 	int ret;
+
+	ret = video_init_context_dev(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (!device_is_ready(cfg->i2c.bus)) {
 		LOG_ERR("Bus device is not ready");

--- a/drivers/video/video_st_mipid02.c
+++ b/drivers/video/video_st_mipid02.c
@@ -368,7 +368,7 @@ static int mipid02_init(const struct device *dev)
 	const struct mipid02_config *cfg = dev->config;
 	int ret;
 
-	ret = video_init_context_dev(dev);
+	ret = video_init_context_dev(dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -77,10 +77,9 @@ enum stm32_dcmipp_state {
 #define STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR (STM32_DCMIPP_MAX_PIPE_DEC_FACTOR * \
 					    STM32_DCMIPP_MAX_PIPE_DSIZE_FACTOR)
 struct stm32_dcmipp_pipe_data {
-	const struct device *dev;
+	struct video_device_context dctx;
 	uint32_t id;
 	struct stm32_dcmipp_data *dcmipp;
-	struct k_mutex lock;
 	struct video_format fmt;
 	struct video_rect crop;
 	struct video_rect compose;
@@ -586,8 +585,6 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 
 	stm32_dcmipp_compute_fmt_pitch(pipe->id, fmt);
 
-	k_mutex_lock(&pipe->lock, K_FOREVER);
-
 	if (pipe->is_streaming) {
 		ret = -EBUSY;
 		goto out;
@@ -616,8 +613,6 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 	pipe->fmt = *fmt;
 
 out:
-	k_mutex_unlock(&pipe->lock);
-
 	return ret;
 }
 
@@ -980,8 +975,6 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 	HAL_StatusTypeDef hal_ret;
 	int ret;
 
-	k_mutex_lock(&pipe->lock, K_FOREVER);
-
 	if (pipe->is_streaming) {
 		ret = -EALREADY;
 		goto out;
@@ -1201,8 +1194,6 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 	dcmipp->enabled_pipe++;
 
 out:
-	k_mutex_unlock(&pipe->lock);
-
 	return ret;
 }
 
@@ -1213,8 +1204,6 @@ static int stm32_dcmipp_stream_disable(const struct device *dev)
 	const struct stm32_dcmipp_config *config = dev->config;
 	struct video_buffer *vbuf;
 	int ret;
-
-	k_mutex_lock(&pipe->lock, K_FOREVER);
 
 	if (!pipe->is_streaming) {
 		ret = -EINVAL;
@@ -1283,8 +1272,6 @@ static int stm32_dcmipp_stream_disable(const struct device *dev)
 	dcmipp->enabled_pipe--;
 
 out:
-	k_mutex_unlock(&pipe->lock);
-
 	return ret;
 }
 
@@ -1297,8 +1284,6 @@ static int stm32_dcmipp_enqueue(const struct device *dev, struct video_buffer *v
 {
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
-
-	k_mutex_lock(&pipe->lock, K_FOREVER);
 
 	if (pipe->fmt.pitch * pipe->fmt.height > vbuf->size) {
 		return -EINVAL;
@@ -1325,8 +1310,6 @@ static int stm32_dcmipp_enqueue(const struct device *dev, struct video_buffer *v
 	} else {
 		k_fifo_put(&pipe->fifo_in, vbuf);
 	}
-
-	k_mutex_unlock(&pipe->lock);
 
 	return 0;
 }
@@ -1534,14 +1517,12 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 			sel->rect.width = ROUND_DOWN(sel->rect.width, h_pixel_align);
 		}
 
-		k_mutex_lock(&pipe->lock, K_FOREVER);
 		pipe->crop = sel->rect;
 		pipe->compose.width = sel->rect.width;
 		pipe->compose.height = sel->rect.height;
 		pipe->fmt.width = sel->rect.width;
 		pipe->fmt.height = sel->rect.height;
 		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->fmt);
-		k_mutex_unlock(&pipe->lock);
 		break;
 	case VIDEO_SEL_TGT_COMPOSE:
 		/* Compose not available on Pipe0 */
@@ -1569,12 +1550,10 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 			sel->rect.height = pipe->crop.height / STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR;
 		}
 
-		k_mutex_lock(&pipe->lock, K_FOREVER);
 		pipe->compose = sel->rect;
 		pipe->fmt.width = sel->rect.width;
 		pipe->fmt.height = sel->rect.height;
 		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->fmt);
-		k_mutex_unlock(&pipe->lock);
 		break;
 	default:
 		return -EINVAL;
@@ -1762,8 +1741,13 @@ static int stm32_dcmipp_pipe_init(const struct device *dev)
 {
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
+	int ret;
 
-	k_mutex_init(&pipe->lock);
+	ret = video_init_context_dev(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	k_fifo_init(&pipe->fifo_in);
 	k_fifo_init(&pipe->fifo_out);
 

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1386,6 +1386,7 @@ static int stm32_dcmipp_get_caps(const struct device *dev, struct video_caps *ca
 		CODE_UNREACHABLE;
 	}
 
+	caps->type = VIDEO_BUF_TYPE_OUTPUT;
 	caps->min_vbuf_count = 1;
 	caps->buf_align = 16;
 
@@ -1812,6 +1813,7 @@ static void stm32_dcmipp_csi_isr(const struct device *dev)
 			.Instance = (DCMIPP_TypeDef *)DT_INST_REG_ADDR(inst),			\
 		},										\
 		.source_fmt = {									\
+			.type = VIDEO_BUF_TYPE_OUTPUT,						\
 			.pixelformat =								\
 				VIDEO_FOURCC_FROM_STR(						\
 						CONFIG_VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT),	\

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1476,10 +1476,6 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 	uint32_t frame_width = dcmipp->source_fmt.width;
 	uint32_t frame_height = dcmipp->source_fmt.height;
 
-	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
-		return -EINVAL;
-	}
-
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
 	if (pipe->id == DCMIPP_PIPE1 || pipe->id == DCMIPP_PIPE2) {
 		frame_width /= dcmipp->isp_dec_hratio;
@@ -1567,10 +1563,6 @@ static int stm32_dcmipp_get_selection(const struct device *dev, struct video_sel
 {
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
-
-	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
-		return -EINVAL;
-	}
 
 	switch (sel->target) {
 	case VIDEO_SEL_TGT_CROP:
@@ -1743,7 +1735,7 @@ static int stm32_dcmipp_pipe_init(const struct device *dev)
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 	int ret;
 
-	ret = video_init_context_dev(dev);
+	ret = video_init_context_dev(dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -80,7 +80,6 @@ struct stm32_dcmipp_pipe_data {
 	struct video_device_context dctx;
 	uint32_t id;
 	struct stm32_dcmipp_data *dcmipp;
-	struct video_format fmt;
 	struct video_rect crop;
 	struct video_rect compose;
 	struct k_fifo fifo_in;
@@ -146,7 +145,7 @@ static void stm32_dcmipp_set_next_buffer_addr(struct stm32_dcmipp_pipe_data *pip
 {
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
-	struct video_format *fmt = &pipe->fmt;
+	struct video_format *fmt = &pipe->dctx.fmt;
 #endif
 	uint8_t *plane = pipe->next->buffer;
 
@@ -204,7 +203,7 @@ void HAL_DCMIPP_PIPE_FrameEventCallback(DCMIPP_HandleTypeDef *hdcmipp, uint32_t 
 			pipe->active->bytesused = bytesused;
 		}
 	} else {
-		pipe->active->bytesused = pipe->fmt.height * pipe->fmt.pitch;
+		pipe->active->bytesused = pipe->dctx.fmt.height * pipe->dctx.fmt.pitch;
 	}
 
 	pipe->active->timestamp = k_uptime_get_32();
@@ -602,7 +601,7 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 	}
 #endif
 
-	pipe->fmt = *fmt;
+	pipe->dctx.fmt = *fmt;
 
 	return 0;
 }
@@ -624,15 +623,6 @@ static void stm32_dcmipp_get_isp_decimation(struct stm32_dcmipp_data *dcmipp)
 	}
 }
 #endif
-
-static int stm32_dcmipp_get_fmt(const struct device *dev, struct video_format *fmt)
-{
-	struct stm32_dcmipp_pipe_data *pipe = dev->data;
-
-	*fmt = pipe->fmt;
-
-	return 0;
-}
 
 static int stm32_dcmipp_set_crop(struct stm32_dcmipp_pipe_data *pipe)
 {
@@ -668,7 +658,7 @@ static int stm32_dcmipp_set_crop(struct stm32_dcmipp_pipe_data *pipe)
 	 * set_selection ensure that value leads to a multiple of 32bit word
 	 */
 	if (pipe->id == DCMIPP_PIPE0) {
-		unsigned int bpp = video_bits_per_pixel(pipe->fmt.pixelformat);
+		unsigned int bpp = video_bits_per_pixel(pipe->dctx.fmt.pixelformat);
 
 		crop_cfg.HStart = pipe->crop.left * bpp / 32;
 		crop_cfg.HSize = pipe->crop.width * bpp / 32;
@@ -867,7 +857,7 @@ static int stm32_dcmipp_start_pipeline(const struct device *dev,
 	const struct stm32_dcmipp_config *config = dev->config;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
-	struct video_format *fmt = &pipe->fmt;
+	struct video_format *fmt = &pipe->dctx.fmt;
 #endif
 	HAL_StatusTypeDef hal_ret;
 
@@ -956,7 +946,7 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 	const struct stm32_dcmipp_config *config = dev->config;
-	struct video_format *fmt = &pipe->fmt;
+	struct video_format *fmt = &pipe->dctx.fmt;
 	const struct stm32_dcmipp_mapping *mapping;
 	const struct stm32_dcmipp_input_fmt *input_fmt;
 #if defined(STM32_DCMIPP_HAS_CSI)
@@ -1264,7 +1254,7 @@ static int stm32_dcmipp_enqueue(const struct device *dev, struct video_buffer *v
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 
-	if (pipe->fmt.pitch * pipe->fmt.height > vbuf->size) {
+	if (pipe->dctx.fmt.pitch * pipe->dctx.fmt.height > vbuf->size) {
 		return -EINVAL;
 	}
 
@@ -1481,7 +1471,8 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 		 */
 		if (pipe->id == DCMIPP_PIPE0 &&
 		    !(sel->rect.left == 0 || sel->rect.width == frame_width)) {
-			int h_pixel_align = stm32_dcmipp_pipe0_pixel_align(pipe->fmt.pixelformat);
+			int h_pixel_align =
+				stm32_dcmipp_pipe0_pixel_align(pipe->dctx.fmt.pixelformat);
 
 			if (h_pixel_align == 0) {
 				LOG_ERR("Cannot figure out required pixel alignment");
@@ -1495,9 +1486,9 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 		pipe->crop = sel->rect;
 		pipe->compose.width = sel->rect.width;
 		pipe->compose.height = sel->rect.height;
-		pipe->fmt.width = sel->rect.width;
-		pipe->fmt.height = sel->rect.height;
-		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->fmt);
+		pipe->dctx.fmt.width = sel->rect.width;
+		pipe->dctx.fmt.height = sel->rect.height;
+		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->dctx.fmt);
 		break;
 	case VIDEO_SEL_TGT_COMPOSE:
 		/* Compose not available on Pipe0 */
@@ -1526,9 +1517,9 @@ static int stm32_dcmipp_set_selection(const struct device *dev, struct video_sel
 		}
 
 		pipe->compose = sel->rect;
-		pipe->fmt.width = sel->rect.width;
-		pipe->fmt.height = sel->rect.height;
-		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->fmt);
+		pipe->dctx.fmt.width = sel->rect.width;
+		pipe->dctx.fmt.height = sel->rect.height;
+		stm32_dcmipp_compute_fmt_pitch(pipe->id, &pipe->dctx.fmt);
 		break;
 	default:
 		return -EINVAL;
@@ -1580,7 +1571,6 @@ static int stm32_dcmipp_get_selection(const struct device *dev, struct video_sel
 
 static DEVICE_API(video, stm32_dcmipp_driver_api) = {
 	.set_format = stm32_dcmipp_set_fmt,
-	.get_format = stm32_dcmipp_get_fmt,
 	.set_stream = stm32_dcmipp_set_stream,
 	.enqueue = stm32_dcmipp_enqueue,
 	.dequeue = stm32_dcmipp_dequeue,
@@ -1723,14 +1713,14 @@ static int stm32_dcmipp_pipe_init(const struct device *dev)
 	k_fifo_init(&pipe->fifo_out);
 
 	/* Initialize format/crop/compose */
-	pipe->fmt.type = VIDEO_BUF_TYPE_OUTPUT;
-	pipe->fmt.width = dcmipp->source_fmt.width;
-	pipe->fmt.height = dcmipp->source_fmt.height;
-	pipe->fmt.pixelformat = dcmipp->source_fmt.pixelformat;
+	pipe->dctx.fmt.type = VIDEO_BUF_TYPE_OUTPUT;
+	pipe->dctx.fmt.width = dcmipp->source_fmt.width;
+	pipe->dctx.fmt.height = dcmipp->source_fmt.height;
+	pipe->dctx.fmt.pixelformat = dcmipp->source_fmt.pixelformat;
 	pipe->crop.top = 0;
 	pipe->crop.left = 0;
-	pipe->crop.width = pipe->fmt.width;
-	pipe->crop.height = pipe->fmt.height;
+	pipe->crop.width = pipe->dctx.fmt.width;
+	pipe->crop.height = pipe->dctx.fmt.height;
 	pipe->compose = pipe->crop;
 
 	/* Store the pipe data pointer into dcmipp data structure */

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -88,7 +88,6 @@ struct stm32_dcmipp_pipe_data {
 	struct video_buffer *next;
 	struct video_buffer *active;
 	enum stm32_dcmipp_state state;
-	bool is_streaming;
 };
 
 struct stm32_dcmipp_data {
@@ -551,7 +550,6 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 	struct stm32_dcmipp_data *dcmipp = pipe->dcmipp;
 	const struct stm32_dcmipp_mapping *mapping;
-	int ret = 0;
 
 	/* Sanitize format given */
 	mapping = stm32_dcmipp_get_mapping(fmt->pixelformat, pipe->id);
@@ -585,11 +583,6 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 
 	stm32_dcmipp_compute_fmt_pitch(pipe->id, fmt);
 
-	if (pipe->is_streaming) {
-		ret = -EBUSY;
-		goto out;
-	}
-
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
 	if (pipe->id == DCMIPP_PIPE1 || pipe->id == DCMIPP_PIPE2) {
 		uint32_t post_isp_decimate_width = dcmipp->source_fmt.width /
@@ -604,16 +597,14 @@ static int stm32_dcmipp_set_fmt(const struct device *dev, struct video_format *f
 			      post_isp_decimate_height / STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR,
 			      post_isp_decimate_height)) {
 			LOG_ERR("Requested resolution cannot be achieved");
-			ret = -EINVAL;
-			goto out;
+			return -EINVAL;
 		}
 	}
 #endif
 
 	pipe->fmt = *fmt;
 
-out:
-	return ret;
+	return 0;
 }
 
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
@@ -975,11 +966,6 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 	HAL_StatusTypeDef hal_ret;
 	int ret;
 
-	if (pipe->is_streaming) {
-		ret = -EALREADY;
-		goto out;
-	}
-
 	input_fmt = stm32_dcmipp_get_input_info(dcmipp->source_fmt.pixelformat);
 	if (input_fmt == NULL) {
 		LOG_ERR("Unsupported input format");
@@ -1190,7 +1176,6 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 #endif
 
 	pipe->state = STM32_DCMIPP_RUNNING;
-	pipe->is_streaming = true;
 	dcmipp->enabled_pipe++;
 
 out:
@@ -1204,11 +1189,6 @@ static int stm32_dcmipp_stream_disable(const struct device *dev)
 	const struct stm32_dcmipp_config *config = dev->config;
 	struct video_buffer *vbuf;
 	int ret;
-
-	if (!pipe->is_streaming) {
-		ret = -EINVAL;
-		goto out;
-	}
 
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
 	/* Stop the external ISP handling */
@@ -1268,7 +1248,6 @@ static int stm32_dcmipp_stream_disable(const struct device *dev)
 	}
 
 	pipe->state = STM32_DCMIPP_STOPPED;
-	pipe->is_streaming = false;
 	dcmipp->enabled_pipe--;
 
 out:

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -60,7 +60,7 @@ static uint8_t png_frame_buffer_hflip[] = {
 };
 
 struct video_sw_generator_data {
-	const struct device *dev;
+	struct video_device_context dctx;
 	struct sw_ctrls ctrls;
 	struct video_format fmt;
 	struct k_fifo fifo_in;
@@ -468,7 +468,7 @@ static void video_sw_generator_worker(struct k_work *work)
 
 	switch (data->pattern) {
 	case VIDEO_PATTERN_COLOR_BAR:
-		video_sw_generator_fill(data->dev, vbuf);
+		video_sw_generator_fill(data->dctx.vctx.dev, vbuf);
 		break;
 	}
 
@@ -631,8 +631,13 @@ static int video_sw_generator_init_controls(const struct device *dev)
 static int video_sw_generator_init(const struct device *dev)
 {
 	struct video_sw_generator_data *data = dev->data;
+	int ret;
 
-	data->dev = dev;
+	ret = video_init_context_dev(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	k_fifo_init(&data->fifo_in);
 	k_fifo_init(&data->fifo_out);
 	k_work_init_delayable(&data->work, video_sw_generator_worker);

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -633,7 +633,7 @@ static int video_sw_generator_init(const struct device *dev)
 	struct video_sw_generator_data *data = dev->data;
 	int ret;
 
-	ret = video_init_context_dev(dev);
+	ret = video_init_context_dev(dev, VIDEO_BUF_TYPE_OUTPUT);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -517,6 +517,7 @@ static int video_sw_generator_flush(const struct device *dev, bool cancel)
 
 static int video_sw_generator_get_caps(const struct device *dev, struct video_caps *caps)
 {
+	caps->type = VIDEO_BUF_TYPE_OUTPUT;
 	caps->format_caps = fmts;
 	caps->min_vbuf_count = 1;
 
@@ -636,6 +637,7 @@ static int video_sw_generator_init(const struct device *dev)
 
 #define VIDEO_SW_GENERATOR_DEFINE(n)                                                               \
 	static struct video_sw_generator_data video_sw_generator_data_##n = {                      \
+		.dctx.fmt.type = VIDEO_BUF_TYPE_OUTPUT,                                            \
 		.dctx.fmt.width = DEFAULT_FRAME_WIDTH,                                             \
 		.dctx.fmt.height = DEFAULT_FRAME_HEIGHT,                                           \
 		.dctx.fmt.pitch = DEFAULT_FRAME_WIDTH * 2,                                         \

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -62,7 +62,6 @@ static uint8_t png_frame_buffer_hflip[] = {
 struct video_sw_generator_data {
 	struct video_device_context dctx;
 	struct sw_ctrls ctrls;
-	struct video_format fmt;
 	struct k_fifo fifo_in;
 	struct k_fifo fifo_out;
 	struct k_work_delayable work;
@@ -145,16 +144,7 @@ static int video_sw_generator_set_fmt(const struct device *dev, struct video_for
 		fmt->size = MAX(sizeof(png_frame_buffer), sizeof(png_frame_buffer_hflip));
 	}
 
-	data->fmt = *fmt;
-	return 0;
-}
-
-static int video_sw_generator_get_fmt(const struct device *dev, struct video_format *fmt)
-{
-	struct video_sw_generator_data *data = dev->data;
-
-	*fmt = data->fmt;
-
+	data->dctx.fmt = *fmt;
 	return 0;
 }
 
@@ -368,15 +358,15 @@ static uint16_t video_sw_generator_fill_grey(uint8_t *buffer, uint16_t width, bo
 static int video_sw_generator_fill(const struct device *const dev, struct video_buffer *vbuf)
 {
 	struct video_sw_generator_data *data = dev->data;
-	struct video_format *fmt = &data->fmt;
+	struct video_format *fmt = &data->dctx.fmt;
 	size_t pitch = fmt->width * video_bits_per_pixel(fmt->pixelformat) / BITS_PER_BYTE;
 	bool hflip = data->ctrls.hflip.val;
 	uint16_t lines = 0;
 
 	/* Handle JPEG and PNG formats specially */
-	if ((data->fmt.pixelformat == VIDEO_PIX_FMT_JPEG) ||
-	    (data->fmt.pixelformat == VIDEO_PIX_FMT_PNG)) {
-		return video_sw_generator_fill_compressed(vbuf, hflip, data->fmt.pixelformat);
+	if ((data->dctx.fmt.pixelformat == VIDEO_PIX_FMT_JPEG) ||
+	    (data->dctx.fmt.pixelformat == VIDEO_PIX_FMT_PNG)) {
+		return video_sw_generator_fill_compressed(vbuf, hflip, data->dctx.fmt.pixelformat);
 	}
 
 	if (vbuf->size < pitch * 2) {
@@ -385,7 +375,7 @@ static int video_sw_generator_fill(const struct device *const dev, struct video_
 	}
 
 	/* Fill the first row of the emulated framebuffer */
-	switch (data->fmt.pixelformat) {
+	switch (data->dctx.fmt.pixelformat) {
 	case VIDEO_PIX_FMT_YUYV:
 		lines = video_sw_generator_fill_yuyv(vbuf->buffer, fmt->width, hflip);
 		break;
@@ -433,10 +423,10 @@ static int video_sw_generator_fill(const struct device *const dev, struct video_
 	}
 
 	/* How much was filled in so far */
-	vbuf->bytesused = data->fmt.pitch * lines;
+	vbuf->bytesused = data->dctx.fmt.pitch * lines;
 
 	/* Duplicate the first line(s) all over the buffer */
-	for (int h = lines; h < data->fmt.height; h += lines) {
+	for (int h = lines; h < data->dctx.fmt.height; h += lines) {
 		if (vbuf->size < vbuf->bytesused + pitch * lines) {
 			LOG_WRN("Generation stopped early: buffer too small");
 			break;
@@ -599,7 +589,6 @@ static int video_sw_generator_enum_frmival(const struct device *dev, struct vide
 
 static DEVICE_API(video, video_sw_generator_driver_api) = {
 	.set_format = video_sw_generator_set_fmt,
-	.get_format = video_sw_generator_get_fmt,
 	.set_stream = video_sw_generator_set_stream,
 	.flush = video_sw_generator_flush,
 	.enqueue = video_sw_generator_enqueue,
@@ -647,11 +636,11 @@ static int video_sw_generator_init(const struct device *dev)
 
 #define VIDEO_SW_GENERATOR_DEFINE(n)                                                               \
 	static struct video_sw_generator_data video_sw_generator_data_##n = {                      \
-		.fmt.width = DEFAULT_FRAME_WIDTH,                                                  \
-		.fmt.height = DEFAULT_FRAME_HEIGHT,                                                \
-		.fmt.pitch = DEFAULT_FRAME_WIDTH * 2,                                              \
-		.fmt.pixelformat = VIDEO_PIX_FMT_RGB565,                                           \
-		.fmt.size = DEFAULT_FRAME_WIDTH * 2 * DEFAULT_FRAME_HEIGHT,                        \
+		.dctx.fmt.width = DEFAULT_FRAME_WIDTH,                                             \
+		.dctx.fmt.height = DEFAULT_FRAME_HEIGHT,                                           \
+		.dctx.fmt.pitch = DEFAULT_FRAME_WIDTH * 2,                                         \
+		.dctx.fmt.pixelformat = VIDEO_PIX_FMT_RGB565,                                      \
+		.dctx.fmt.size = DEFAULT_FRAME_WIDTH * 2 * DEFAULT_FRAME_HEIGHT,                   \
 		.frame_rate = DEFAULT_FRAME_RATE,                                                  \
 	};                                                                                         \
                                                                                                    \

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -302,6 +302,9 @@ struct video_context {
 	/** pointers to the streaming status */
 	bool *is_streaming_in;
 	bool *is_streaming_out;
+	/** pointers to the video_formats */
+	struct video_format *fmt_in;
+	struct video_format *fmt_out;
 };
 
 /**
@@ -315,6 +318,8 @@ struct video_device_context {
 	struct video_context vctx;
 	/** streaming boolean */
 	bool is_streaming;
+	/** video_format */
+	struct video_format fmt;
 };
 
 /**
@@ -509,11 +514,6 @@ static inline int video_set_format(const struct device *dev, struct video_format
 		return -EINVAL;
 	}
 
-	api = DEVICE_API_GET(video, dev);
-	if (api->set_format == NULL) {
-		return -ENOSYS;
-	}
-
 	ctx = dev->data;
 
 	if (!is_video_type_valid(ctx, fmt->type)) {
@@ -526,6 +526,14 @@ static inline int video_set_format(const struct device *dev, struct video_format
 	if ((fmt->type == VIDEO_BUF_TYPE_INPUT && *ctx->is_streaming_in) ||
 	    (fmt->type == VIDEO_BUF_TYPE_OUTPUT && *ctx->is_streaming_out)) {
 		ret = -EBUSY;
+		goto out;
+	}
+
+	/* Check if the new format is different from the currently set format */
+	ret = memcmp(fmt->type == VIDEO_BUF_TYPE_INPUT ? ctx->fmt_in : ctx->fmt_out,
+		     fmt, sizeof(struct video_format));
+	if (ret	== 0) {
+		/* Nothing to do */
 		goto out;
 	}
 
@@ -556,15 +564,10 @@ static inline int video_get_format(const struct device *dev, struct video_format
 {
 	const struct video_driver_api *api;
 	struct video_context *ctx;
-	int ret;
+	int ret = 0;
 
 	if (dev == NULL || dev->data == NULL || fmt == NULL) {
 		return -EINVAL;
-	}
-
-	api = DEVICE_API_GET(video, dev);
-	if (api->get_format == NULL) {
-		return -ENOSYS;
 	}
 
 	ctx = dev->data;
@@ -573,8 +576,19 @@ static inline int video_get_format(const struct device *dev, struct video_format
 		return -EINVAL;
 	}
 
+	api = DEVICE_API_GET(video, dev);
+	if (api->get_format == NULL) {
+		return -ENOSYS;
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
-	ret = api->get_format(dev, fmt);
+
+	if (api->get_format != NULL) {
+		ret = api->get_format(dev, fmt);
+	} else {
+		*fmt = (fmt->type == VIDEO_BUF_TYPE_INPUT ? *ctx->fmt_in : *ctx->fmt_out);
+	}
+
 	k_mutex_unlock(&ctx->lock);
 
 	return ret;

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -299,6 +299,9 @@ struct video_context {
 	struct k_mutex lock;
 	/** supported type bitfield - considering enum video_buf_type as bit */
 	uint8_t supported_buf_type;
+	/** pointers to the streaming status */
+	bool *is_streaming_in;
+	bool *is_streaming_out;
 };
 
 /**
@@ -310,6 +313,8 @@ struct video_context {
 struct video_device_context {
 	/** struct video_context */
 	struct video_context vctx;
+	/** streaming boolean */
+	bool is_streaming;
 };
 
 /**
@@ -516,7 +521,22 @@ static inline int video_set_format(const struct device *dev, struct video_format
 	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
+
+	/* Format cannot be set if the device is already streaming */
+	if ((fmt->type == VIDEO_BUF_TYPE_INPUT && *ctx->is_streaming_in) ||
+	    (fmt->type == VIDEO_BUF_TYPE_OUTPUT && *ctx->is_streaming_out)) {
+		ret = -EBUSY;
+		goto out;
+	}
+
+	api = DEVICE_API_GET(video, dev);
+	if (api->set_format == NULL) {
+		ret = -ENOSYS;
+		goto out;
+	}
+
 	ret = api->set_format(dev, fmt);
+out:
 	k_mutex_unlock(&ctx->lock);
 
 	return ret;
@@ -801,6 +821,7 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
 {
 	const struct video_driver_api *api;
 	struct video_context *ctx;
+	bool *is_streaming;
 	int ret;
 
 	if (dev == NULL || dev->data == NULL) {
@@ -818,8 +839,18 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
 		return -EINVAL;
 	}
 
+	is_streaming = (type == VIDEO_BUF_TYPE_INPUT ? ctx->is_streaming_in :
+			ctx->is_streaming_out);
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
+	if (*is_streaming) {
+		k_mutex_unlock(&ctx->lock);
+		return -EALREADY;
+	}
 	ret = api->set_stream(dev, true, type);
+	if (ret == 0) {
+		*is_streaming = true;
+	}
 	k_mutex_unlock(&ctx->lock);
 
 	return ret;
@@ -842,6 +873,7 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 {
 	const struct video_driver_api *api;
 	struct video_context *ctx;
+	bool *is_streaming;
 	int ret;
 
 	if (dev == NULL || dev->data == NULL) {
@@ -859,11 +891,20 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 		return -EINVAL;
 	}
 
+	is_streaming = (type == VIDEO_BUF_TYPE_INPUT ? ctx->is_streaming_in :
+			ctx->is_streaming_out);
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
+	if (!*is_streaming) {
+		k_mutex_unlock(&ctx->lock);
+		return -EALREADY;
+	}
 	ret = api->set_stream(dev, false, type);
 	if (ret < 0) {
 		k_mutex_unlock(&ctx->lock);
 		return ret;
+	} else if (ret == 0) {
+		*is_streaming = false;
 	}
 	ret = api->flush(dev, true);
 	k_mutex_unlock(&ctx->lock);

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -287,6 +287,30 @@ struct video_selection {
 };
 
 /**
+ * @brief Video framework context structure
+ *
+ * Struct meant to be added as first element of other video type specific
+ * context structures
+ */
+struct video_context {
+	/** device unique struct device pointer */
+	const struct device *dev;
+	/** device lock, used to serialize all video calls */
+	struct k_mutex lock;
+};
+
+/**
+ * @brief Video framework device context structure
+ *
+ * Struct meant to be added as first element of other video type specific
+ * context structures
+ */
+struct video_device_context {
+	/** struct video_context */
+	struct video_context vctx;
+};
+
+/**
  * @def_driverbackendgroup{Video,video_interface}
  * @{
  */
@@ -466,8 +490,10 @@ __subsystem struct video_driver_api {
 static inline int video_set_format(const struct device *dev, struct video_format *fmt)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || fmt == NULL) {
+	if (dev == NULL || dev->data == NULL || fmt == NULL) {
 		return -EINVAL;
 	}
 
@@ -476,7 +502,13 @@ static inline int video_set_format(const struct device *dev, struct video_format
 		return -ENOSYS;
 	}
 
-	return api->set_format(dev, fmt);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->set_format(dev, fmt);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -492,8 +524,10 @@ static inline int video_set_format(const struct device *dev, struct video_format
 static inline int video_get_format(const struct device *dev, struct video_format *fmt)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || fmt == NULL) {
+	if (dev == NULL || dev->data == NULL || fmt == NULL) {
 		return -EINVAL;
 	}
 
@@ -502,7 +536,13 @@ static inline int video_get_format(const struct device *dev, struct video_format
 		return -ENOSYS;
 	}
 
-	return api->get_format(dev, fmt);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->get_format(dev, fmt);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -524,8 +564,10 @@ static inline int video_get_format(const struct device *dev, struct video_format
 static inline int video_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || frmival == NULL) {
+	if (dev == NULL || dev->data == NULL || frmival == NULL) {
 		return -EINVAL;
 	}
 
@@ -538,7 +580,13 @@ static inline int video_set_frmival(const struct device *dev, struct video_frmiv
 		return -ENOSYS;
 	}
 
-	return api->set_frmival(dev, frmival);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->set_frmival(dev, frmival);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -557,8 +605,10 @@ static inline int video_set_frmival(const struct device *dev, struct video_frmiv
 static inline int video_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || frmival == NULL) {
+	if (dev == NULL || dev->data == NULL || frmival == NULL) {
 		return -EINVAL;
 	}
 
@@ -567,7 +617,13 @@ static inline int video_get_frmival(const struct device *dev, struct video_frmiv
 		return -ENOSYS;
 	}
 
-	return api->get_frmival(dev, frmival);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->get_frmival(dev, frmival);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -590,8 +646,10 @@ static inline int video_get_frmival(const struct device *dev, struct video_frmiv
 static inline int video_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || fie == NULL || fie->format == NULL) {
+	if (dev == NULL || dev->data == NULL || fie == NULL || fie->format == NULL) {
 		return -EINVAL;
 	}
 
@@ -600,7 +658,13 @@ static inline int video_enum_frmival(const struct device *dev, struct video_frmi
 		return -ENOSYS;
 	}
 
-	return api->enum_frmival(dev, fie);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->enum_frmival(dev, fie);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -636,8 +700,10 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
 				k_timeout_t timeout)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || buf == NULL) {
+	if (dev == NULL || dev->data == NULL || buf == NULL) {
 		return -EINVAL;
 	}
 
@@ -646,7 +712,13 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
 		return -ENOSYS;
 	}
 
-	return api->dequeue(dev, buf, timeout);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->dequeue(dev, buf, timeout);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -665,8 +737,10 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
 static inline int video_flush(const struct device *dev, bool cancel)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL) {
+	if (dev == NULL || dev->data == NULL) {
 		return -EINVAL;
 	}
 
@@ -675,7 +749,13 @@ static inline int video_flush(const struct device *dev, bool cancel)
 		return -ENOSYS;
 	}
 
-	return api->flush(dev, cancel);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->flush(dev, cancel);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -697,8 +777,10 @@ static inline int video_flush(const struct device *dev, bool cancel)
 static inline int video_stream_start(const struct device *dev, enum video_buf_type type)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL) {
+	if (dev == NULL || dev->data == NULL) {
 		return -EINVAL;
 	}
 
@@ -707,7 +789,13 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
 		return -ENOSYS;
 	}
 
-	return api->set_stream(dev, true, type);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->set_stream(dev, true, type);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -726,9 +814,10 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
 static inline int video_stream_stop(const struct device *dev, enum video_buf_type type)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
 	int ret;
 
-	if (dev == NULL) {
+	if (dev == NULL || dev->data == NULL) {
 		return -EINVAL;
 	}
 
@@ -737,8 +826,16 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 		return -ENOSYS;
 	}
 
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->set_stream(dev, false, type);
-	video_flush(dev, true);
+	if (ret < 0) {
+		k_mutex_unlock(&ctx->lock);
+		return ret;
+	}
+	ret = api->flush(dev, true);
+	k_mutex_unlock(&ctx->lock);
 
 	return ret;
 }
@@ -754,8 +851,10 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 static inline int video_get_caps(const struct device *dev, struct video_caps *caps)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || caps == NULL ||
+	if (dev == NULL || dev->data == NULL || caps == NULL ||
 	    (caps->type != VIDEO_BUF_TYPE_INPUT && caps->type != VIDEO_BUF_TYPE_OUTPUT)) {
 		return -EINVAL;
 	}
@@ -765,7 +864,13 @@ static inline int video_get_caps(const struct device *dev, struct video_caps *ca
 		return -ENOSYS;
 	}
 
-	return api->get_caps(dev, caps);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->get_caps(dev, caps);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -808,8 +913,10 @@ static inline int video_transform_cap(const struct device *const dev,
 				      enum video_buf_type type, uint16_t ind)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || cap == NULL || res_cap == NULL ||
+	if (dev == NULL || dev->data == NULL || cap == NULL || res_cap == NULL ||
 	    (type != VIDEO_BUF_TYPE_INPUT && type != VIDEO_BUF_TYPE_OUTPUT)) {
 		return -EINVAL;
 	}
@@ -819,7 +926,13 @@ static inline int video_transform_cap(const struct device *const dev,
 		return -ENOSYS;
 	}
 
-	return api->transform_cap(dev, cap, res_cap, type, ind);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->transform_cap(dev, cap, res_cap, type, ind);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -902,8 +1015,10 @@ void video_print_ctrl(const struct video_ctrl_query *const cq);
 static inline int video_set_signal(const struct device *dev, struct k_poll_signal *sig)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || sig == NULL) {
+	if (dev == NULL || dev->data == NULL || sig == NULL) {
 		return -EINVAL;
 	}
 
@@ -912,7 +1027,13 @@ static inline int video_set_signal(const struct device *dev, struct k_poll_signa
 		return -ENOSYS;
 	}
 
-	return api->set_signal(dev, sig);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->set_signal(dev, sig);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -937,8 +1058,10 @@ static inline int video_set_signal(const struct device *dev, struct k_poll_signa
 static inline int video_set_selection(const struct device *dev, struct video_selection *sel)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || sel == NULL) {
+	if (dev == NULL || dev->data == NULL || sel == NULL) {
 		return -EINVAL;
 	}
 
@@ -947,7 +1070,13 @@ static inline int video_set_selection(const struct device *dev, struct video_sel
 		return -ENOSYS;
 	}
 
-	return api->set_selection(dev, sel);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->set_selection(dev, sel);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -970,8 +1099,10 @@ static inline int video_set_selection(const struct device *dev, struct video_sel
 static inline int video_get_selection(const struct device *dev, struct video_selection *sel)
 {
 	const struct video_driver_api *api;
+	struct video_context *ctx;
+	int ret;
 
-	if (dev == NULL || sel == NULL) {
+	if (dev == NULL || dev->data == NULL || sel == NULL) {
 		return -EINVAL;
 	}
 
@@ -980,7 +1111,13 @@ static inline int video_get_selection(const struct device *dev, struct video_sel
 		return -ENOSYS;
 	}
 
-	return api->get_selection(dev, sel);
+	ctx = dev->data;
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+	ret = api->get_selection(dev, sel);
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 /**
@@ -1143,6 +1280,8 @@ int video_set_compose_format(const struct device *dev, struct video_format *fmt)
 int video_transfer_buffer(const struct device *src, const struct device *sink,
 			  enum video_buf_type src_type, enum video_buf_type sink_type,
 			  k_timeout_t timeout);
+
+int video_init_context_dev(const struct device *dev);
 
 /**
  * @defgroup video_pixel_formats Video pixel formats

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -297,6 +297,8 @@ struct video_context {
 	const struct device *dev;
 	/** device lock, used to serialize all video calls */
 	struct k_mutex lock;
+	/** supported type bitfield - considering enum video_buf_type as bit */
+	uint8_t supported_buf_type;
 };
 
 /**
@@ -474,6 +476,11 @@ __subsystem struct video_driver_api {
  * @}
  */
 
+static inline bool is_video_type_valid(struct video_context *ctx, enum video_buf_type type)
+{
+	return !!(ctx->supported_buf_type & type);
+}
+
 /**
  * @brief Set video format.
  *
@@ -503,6 +510,10 @@ static inline int video_set_format(const struct device *dev, struct video_format
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, fmt->type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->set_format(dev, fmt);
@@ -537,6 +548,10 @@ static inline int video_get_format(const struct device *dev, struct video_format
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, fmt->type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->get_format(dev, fmt);
@@ -660,6 +675,10 @@ static inline int video_enum_frmival(const struct device *dev, struct video_frmi
 
 	ctx = dev->data;
 
+	if (!is_video_type_valid(ctx, fie->format->type)) {
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->enum_frmival(dev, fie);
 	k_mutex_unlock(&ctx->lock);
@@ -713,6 +732,10 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, (*buf)->type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->dequeue(dev, buf, timeout);
@@ -791,6 +814,10 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
 
 	ctx = dev->data;
 
+	if (!is_video_type_valid(ctx, type)) {
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->set_stream(dev, true, type);
 	k_mutex_unlock(&ctx->lock);
@@ -828,6 +855,10 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
 
 	ctx = dev->data;
 
+	if (!is_video_type_valid(ctx, type)) {
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->set_stream(dev, false, type);
 	if (ret < 0) {
@@ -854,8 +885,7 @@ static inline int video_get_caps(const struct device *dev, struct video_caps *ca
 	struct video_context *ctx;
 	int ret;
 
-	if (dev == NULL || dev->data == NULL || caps == NULL ||
-	    (caps->type != VIDEO_BUF_TYPE_INPUT && caps->type != VIDEO_BUF_TYPE_OUTPUT)) {
+	if (dev == NULL || dev->data == NULL || caps == NULL) {
 		return -EINVAL;
 	}
 
@@ -865,6 +895,10 @@ static inline int video_get_caps(const struct device *dev, struct video_caps *ca
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, caps->type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->get_caps(dev, caps);
@@ -916,8 +950,7 @@ static inline int video_transform_cap(const struct device *const dev,
 	struct video_context *ctx;
 	int ret;
 
-	if (dev == NULL || dev->data == NULL || cap == NULL || res_cap == NULL ||
-	    (type != VIDEO_BUF_TYPE_INPUT && type != VIDEO_BUF_TYPE_OUTPUT)) {
+	if (dev == NULL || dev->data == NULL || cap == NULL || res_cap == NULL) {
 		return -EINVAL;
 	}
 
@@ -927,6 +960,10 @@ static inline int video_transform_cap(const struct device *const dev,
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->transform_cap(dev, cap, res_cap, type, ind);
@@ -1072,6 +1109,10 @@ static inline int video_set_selection(const struct device *dev, struct video_sel
 
 	ctx = dev->data;
 
+	if (!is_video_type_valid(ctx, sel->type)) {
+		return -EINVAL;
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->set_selection(dev, sel);
 	k_mutex_unlock(&ctx->lock);
@@ -1112,6 +1153,10 @@ static inline int video_get_selection(const struct device *dev, struct video_sel
 	}
 
 	ctx = dev->data;
+
+	if (!is_video_type_valid(ctx, sel->type)) {
+		return -EINVAL;
+	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 	ret = api->get_selection(dev, sel);
@@ -1281,7 +1326,7 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
 			  enum video_buf_type src_type, enum video_buf_type sink_type,
 			  k_timeout_t timeout);
 
-int video_init_context_dev(const struct device *dev);
+int video_init_context_dev(const struct device *dev, enum video_buf_type buf_type);
 
 /**
  * @defgroup video_pixel_formats Video pixel formats


### PR DESCRIPTION
This PR is an RFC of a proposal to introduce a common video header structure to be hold by all Zephyr video driver in order to let a video framework part do more heavy lifting job instead of letting drivers do all the checks and implement stuff that are not HW specific.

In this PR, only mutex  / streaming status / get_format handling is done, however there are still plenty of stuff that can be added such as queue handling for example (similarly to what is done within the stm32 JPEG driver for queue for example which should also be abstracted into a common structure).

Goal here is to have the framework provide a first level of check (just an example, do not allow to change a format while the device is already streaming), as well as provide mutex protection between api entry points (to be then used also, if appropriate, by the driver itself to protect concurrent access between API entry points and IRQ handler for example).

Just to illustrate this, I've added the related code into the video-sw-generator driver.

If such framework is meaningful and atomic introduction in all video driver is diffiult, we would have to think about a way to make the two kind (with usage of common header or not) of driver cohabite.