### PR TITLE
bluetooth: cap: Fixed Broadcast Adv Stop handling

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -849,21 +849,23 @@ static uint8_t btp_cap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len,
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
 
 	if (source == NULL) {
-		return BTP_STATUS_FAILED;
+		/* Treat missing source as success (already stopped) per PTS expectations */
+		return BTP_STATUS_SUCCESS;
 	}
 
 	err = tester_gap_padv_stop(source->ext_adv);
-	if (err == -ESRCH) {
-		/* Ext adv hasn't been created yet */
-		return BTP_STATUS_SUCCESS;
-	} else if (err != 0) {
+	if (err != 0 && err != -ESRCH) {
 		LOG_DBG("Failed to stop periodic adv, err: %d", err);
 		return BTP_STATUS_FAILED;
 	}
 
 	err = tester_gap_stop_ext_adv(source->ext_adv);
+	if (err != 0 && err != -ESRCH) {
+		LOG_DBG("Failed to stop ext adv, err: %d", err);
+		return BTP_STATUS_FAILED;
+	}
 
-	return BTP_STATUS_VAL(err);
+	return BTP_STATUS_SUCCESS;
 }
 
 static uint8_t btp_cap_broadcast_source_start(const void *cmd, uint16_t cmd_len,


### PR DESCRIPTION
Description
This makes CAP Broadcast Adv Stop behave correctly when the broadcast
source is missing or advertising was already stopped, returning success in
these cases aligns with the expected CAP teardown flow. Only treat GAP
stop errors as failures when they are not -ESRCH. These adjustments ensure
the behavior aligns with the expectations of the TMAP BMS procedures,
allowing the TMAP/BMS/CTXT/BV-01-C test to complete successfully.

Testing
nRF5340 Audio DK
nRF54L15 DK
