### PR TITLE
AFL++ support for native simulator platform

### DIFF
--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -34,6 +34,13 @@ config NATIVE_SIM_REBOOT
 	help
 	  Enables the reboot implementation for the native sim executable.
 
+config ARCH_POSIX_AFLPLUSPLUS
+	bool "Enable AFL++ support"
+	default n
+	help
+	  When selected, the AFL++ instrumentation will be enabled for the native 
+	  simulator.
+
 source "boards/native/common/sdl/Kconfig"
 source "boards/native/common/extra_args/Kconfig"
 

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -15,8 +15,13 @@ if(DEFINED TOOLCHAIN_HOME)
   set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 endif()
 
-find_program(CMAKE_C_COMPILER   clang   ${find_program_clang_args})
-find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
+if(CONFIG_ARCH_POSIX_AFLPLUSPLUS)
+  find_program(CMAKE_C_COMPILER   afl-clang-fast   ${find_program_clang_args})
+  find_program(CMAKE_CXX_COMPILER afl-clang-fast++ ${find_program_clang_args})
+else()
+  find_program(CMAKE_C_COMPILER   clang   ${find_program_clang_args})
+  find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
+endif()
 
 if(SYSROOT_DIR)
   # The toolchain has specified a sysroot dir, pass it to the compiler


### PR DESCRIPTION
Adding support for AFL++ instrumentation in the native simulator platform. This change expects that the AFL++ compiler is installed and available in the system PATH.

More information on setting up AFL toolchain can be found here - https://aflplus.plus/building/

Build application using the following command:
`west -v build -b native_sim/native/64 samples/hello_world -p -- -DZEPHYR_TOOLCHAIN_VARIANT=llvm -DCONFIG_ARCH_POSIX_AFLPLUSPLUS=y`