### PR TITLE
drivers: ethernet: nxp: Advertise ETHERNET_PROMISC_MODE capability

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -271,6 +271,9 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 		ETHERNET_HW_TX_CHKSUM_OFFLOAD |
 		ETHERNET_HW_RX_CHKSUM_OFFLOAD |
 #endif
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+		ETHERNET_PROMISC_MODE |
+#endif
 		ETHERNET_LINK_100BASE;
 
 	if (COND_CODE_1(IS_ENABLED(CONFIG_ETH_NXP_ENET_1G),
@@ -311,6 +314,9 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 			ENET_LeaveMulticastGroup(data->base,
 						 (uint8_t *)cfg->filter.mac_address.addr);
 		}
+		return 0;
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		/* Promiscuous mode is enabled at eth_nxp_enet_init */
 		return 0;
 	default:
 		break;


### PR DESCRIPTION
ETHERNET_PROMISC_MODE is not advertised in
eth_nxp_enet_get_capabilities() even though promiscuous mode is enabled during initialization when
CONFIG_NET_PROMISCUOUS_MODE=y.

Advertise ETHERNET_PROMISC_MODE in
eth_nxp_enet_get_capabilities() and accept
ETHERNET_CONFIG_TYPE_PROMISC_MODE in
eth_nxp_enet_set_config().

Fixes #103728