### PR TITLE
drivers: ethernet: nxp: Advertise ETHERNET_PROMISC_MODE capability

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -271,6 +271,9 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 		ETHERNET_HW_TX_CHKSUM_OFFLOAD |
 		ETHERNET_HW_RX_CHKSUM_OFFLOAD |
 #endif
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+		ETHERNET_PROMISC_MODE |
+#endif
 		ETHERNET_LINK_100BASE;
 
 	if (COND_CODE_1(IS_ENABLED(CONFIG_ETH_NXP_ENET_1G),
@@ -311,6 +314,9 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 			ENET_LeaveMulticastGroup(data->base,
 						 (uint8_t *)cfg->filter.mac_address.addr);
 		}
+		return 0;
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		/* Promiscuous mode is enabled at eth_nxp_enet_init */
 		return 0;
 	default:
 		break;

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -316,7 +316,12 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 		}
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
-		/* Promiscuous mode is enabled at eth_nxp_enet_init */
+		/* Promiscuous mode is enabled at eth_nxp_enet_init and
+		 * cannot be disabled at runtime
+		 */
+		if (!cfg->promisc_mode) {
+			return -EINVAL;
+		}
 		return 0;
 	default:
 		break;


### PR DESCRIPTION
The NXP Ethernet driver (eth_nxp_enet.c) enables promiscuous mode during initialization when CONFIG_NET_PROMISCUOUS_MODE=y:
```c
if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE)) {
    enet_config.macSpecialConfig |= kENET_ControlPromiscuousEnable;
}
```

This configuration is performed inside eth_nxp_enet_init().
However, the driver does not advertise ETHERNET_PROMISC_MODE in eth_nxp_enet_get_capabilities().
As a result, networking features that require promiscuous capability (for example, Ethernet bridge) do not work correctly because the interface does not report support for promiscuous mode, even though it is already enabled at hardware level.
This creates an inconsistency between actual hardware behavior and reported capabilities.

**Solution**
When CONFIG_NET_PROMISCUOUS_MODE=y, the driver should:
- Advertise ETHERNET_PROMISC_MODE in eth_nxp_enet_get_capabilities()
- Accept ETHERNET_CONFIG_TYPE_PROMISC_MODE in eth_nxp_enet_set_config()

This aligns the reported capability with the existing initialization behavior.

Fixes #103728