### PR TITLE
soc: nordic: uicr: use IRONSIDE_SUPPORT_DIR for the script location

### DIFF
--- a/modules/hal_nordic/ironside/se/CMakeLists.txt
+++ b/modules/hal_nordic/ironside/se/CMakeLists.txt
@@ -1,14 +1,7 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# The IronSide source directory can be overridden by setting
-# IRONSIDE_SUPPORT_DIR before invoking the build system.
-zephyr_get(IRONSIDE_SUPPORT_DIR SYSBUILD GLOBAL)
-if(NOT DEFINED IRONSIDE_SUPPORT_DIR)
-  set(IRONSIDE_SUPPORT_DIR
-    ${ZEPHYR_CURRENT_MODULE_DIR}/ironside CACHE PATH "IronSide Support Directory"
-  )
-endif()
+include(./ironside_support_dir.cmake)
 
 zephyr_include_directories(include)
 zephyr_include_directories(${IRONSIDE_SUPPORT_DIR}/se/include)

--- a/modules/hal_nordic/ironside/se/ironside_support_dir.cmake
+++ b/modules/hal_nordic/ironside/se/ironside_support_dir.cmake
@@ -1,0 +1,8 @@
+# The IronSide source directory can be overridden by setting
+# IRONSIDE_SUPPORT_DIR before invoking the build system.
+zephyr_get(IRONSIDE_SUPPORT_DIR SYSBUILD GLOBAL)
+if(NOT DEFINED IRONSIDE_SUPPORT_DIR)
+  set(IRONSIDE_SUPPORT_DIR
+    ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/ironside CACHE PATH "IronSide Support Directory"
+  )
+endif()

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -17,6 +17,9 @@ find_package(Zephyr
   REQUIRED HINTS $ENV{ZEPHYR_BASE}
   )
 
+# Needed since the CMakeLists.txt that would normally set this is not run in this image.
+include(${ZEPHYR_BASE}/modules/hal_nordic/ironside/se/ironside_support_dir.cmake)
+
 project(uicr)
 
 # Function to parse a Kconfig value from a .config file
@@ -261,7 +264,7 @@ endif()
 # Generate hex files (merged, uicr-only, periphconf-only, and secondary-periphconf-only)
 add_custom_command(
   OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file}
-  COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/ironside/se/tool/ironside/__main__.py
+  COMMAND ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
           gen-uicr
           --uicr-address ${UICR_ADDRESS}
           --out-merged-hex ${merged_hex_file}


### PR DESCRIPTION
Use the IRONSIDE_SUPPORT_DIR cmake variable to determine the location of the UICR generator script location, to allow overriding the location if needed.

Since the CMake that would normally set this variable in modules/hal_nordic/ironside/se/CMakeLists.txt is not actually run in the gen_uicr image, refactor the logic for setting the variable so that it can be included in the gen_uicr image directly.