### PR TITLE
drivers: kconfig: unify menuconfig title strings

### DIFF
--- a/drivers/auxdisplay/Kconfig
+++ b/drivers/auxdisplay/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig AUXDISPLAY
-	bool "Auxiliary (textual) Display Drivers"
+	bool "Auxiliary (textual) display drivers"
 	help
 	  Enable auxiliary/textual display drivers (e.g. alphanumerical displays)
 

--- a/drivers/biometrics/Kconfig
+++ b/drivers/biometrics/Kconfig
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Siratul Islam
 
 menuconfig BIOMETRICS
-	bool "Biometrics Drivers"
+	bool "Biometrics drivers"
 	help
 	  Enable biometric sensor driver support.
 

--- a/drivers/crc/Kconfig
+++ b/drivers/crc/Kconfig
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CRC_DRIVER
-	bool "CRC device drivers"
+	bool "Cyclic Redundancy Check (CRC) drivers"
 	help
 	  Enable support for CRC device driver.
 

--- a/drivers/dp/Kconfig
+++ b/drivers/dp/Kconfig
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig DP_DRIVER
-	bool "Debug Port interface driver [EXPERIMENTAL]"
+	bool "Debug Port (DP) drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enable Debug Port interface driver

--- a/drivers/gnss/Kconfig
+++ b/drivers/gnss/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig GNSS
-	bool "GNSS drivers"
+	bool "Global Navigation Satellite System (GNSS) drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enable GNSS drivers and configuration.

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig HWINFO
-	bool "Hardware Information drivers"
+	bool "Hardware information drivers"
 	help
 	  Enable hwinfo driver.
 

--- a/drivers/hwspinlock/Kconfig
+++ b/drivers/hwspinlock/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig HWSPINLOCK
-	bool "HW spinlock Support"
+	bool "Hardware spinlock drivers"
 	help
 	  Include support for HW spinlock.
 

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-menu "Miscellaneous Drivers"
+menu "Miscellaneous drivers"
 
 # zephyr-keep-sorted-start
 source "drivers/misc/devmux/Kconfig"

--- a/drivers/mm/Kconfig
+++ b/drivers/mm/Kconfig
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MM_DRV
-	bool "Memory Management drivers [EXPERIMENTAL]"
+	bool "Memory management drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select KERNEL_VM_SUPPORT
 	help

--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -7,7 +7,7 @@
 # Reset Controller options
 #
 menuconfig RESET
-	bool "Reset Controller drivers"
+	bool "Reset controller drivers"
 	help
 	  Reset Controller drivers. Reset node represents a region containing
 	  information about reset controller device. The typical use-case is
@@ -17,7 +17,7 @@ menuconfig RESET
 if RESET
 
 config RESET_INIT_PRIORITY
-	int "Reset Controller driver init priority"
+	int "Reset controller driver init priority"
 	default 35
 	help
 	  This option controls the priority of the reset controller device
@@ -25,7 +25,7 @@ config RESET_INIT_PRIORITY
 	  initialized earlier in the startup cycle. If unsure, leave at default
 	  value
 
-comment "Reset Controller Drivers"
+comment "Reset controller Drivers"
 
 # zephyr-keep-sorted-start
 rsource "Kconfig.aspeed"

--- a/drivers/sent/Kconfig
+++ b/drivers/sent/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SENT
-	bool "SENT Single Edge Nibble Transmission (SENT)"
+	bool "Single Edge Nibble Transmission (SENT) drivers"
 	help
 	  Enable SENT Driver Configuration
 

--- a/drivers/stepper/Kconfig
+++ b/drivers/stepper/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig STEPPER
-	bool "Stepper Controller"
+	bool "Stepper controller drivers"
 	help
 	  Enable stepper controller
 


### PR DESCRIPTION
Unify the drivers/*/Kconfig menuconfig title strings to the format "<class> [(acronym)] [bus] drivers".

Including both the full name of the driver class and an acronym makes menuconfig more user friendly as some of the acronyms are less well-known than others. It also improves Kconfig search, both via menuconfig and via the generated Kconfig documentation.

This is a follow-up to commit c41dd36de242830b45ca64a6abd1d8a148a13ad3, bringing new additions in line with the established prompt format.