### PR TITLE
soc: mcxw: Fix PM Kconfig dependency on MCXW23

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "*/Kconfig"
@@ -18,4 +18,3 @@ config SOC_FAMILY_MCXW
 	select SOC_EARLY_INIT_HOOK
 	select CLOCK_CONTROL
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
-	select HAS_PM if SOC_MCXW716C || SOC_MCXW727C

--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_MCXW2XX
+	select HAS_PM
 	select HAS_POWEROFF
 	select NXP_SNPS_BLE_CTRL if BT

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
@@ -10,10 +10,12 @@ config MCUX_CORE_SUFFIX
 config SOC_MCXW716C
 	bool
 	select NXP_MULTICORE if NXP_NBU
+	select HAS_PM
 
 config SOC_MCXW727C
 	bool
 	select NXP_MULTICORE if NXP_NBU
+	select HAS_PM
 
 config SOC_MCXW70AC
 	bool


### PR DESCRIPTION
This is a regression. We are no longer able to enable CONFIG_PM on MCXW23.
This Kconfig depends on HAS_PM, which is no longer selected by the SoC.