### PR TITLE
modem: backends: uart_async: Prevent closing twice

### DIFF
--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -277,7 +277,10 @@ static int modem_backend_uart_async_close(void *data)
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	int ret;
 
-	atomic_clear_bit(&backend->async.common.state, MODEM_BACKEND_UART_ASYNC_STATE_OPEN_BIT);
+	if (!atomic_test_and_clear_bit(&backend->async.common.state,
+				       MODEM_BACKEND_UART_ASYNC_STATE_OPEN_BIT)) {
+		return 0;
+	}
 	uart_tx_abort(backend->uart);
 	uart_rx_disable(backend->uart);
 	if (backend->dtr_gpio) {

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -360,7 +360,10 @@ static int modem_backend_uart_async_hwfc_close(void *data)
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	int ret;
 
-	atomic_clear_bit(&backend->async.common.state, MODEM_BACKEND_UART_ASYNC_STATE_OPEN_BIT);
+	if (!atomic_test_and_clear_bit(&backend->async.common.state,
+				       MODEM_BACKEND_UART_ASYNC_STATE_OPEN_BIT)) {
+		return 0;
+	}
 	uart_tx_abort(backend->uart);
 
 	if (!atomic_test_and_clear_bit(&backend->async.common.state,
@@ -377,7 +380,6 @@ static int modem_backend_uart_async_hwfc_close(void *data)
 		LOG_ERR("Failed to power off UART: %d", ret);
 		return ret;
 	}
-	modem_pipe_notify_closed(&backend->pipe);
 
 	return 0;
 }


### PR DESCRIPTION
When modem_pipe_notify_closed() is removed from pipe->close() call, we rely on the UART callback to notify when the UART is closed.

If we call uart_rx_disable() twice, we might lose the callback, and the pipe status stays open.

This happens when modem_cellular_run_shutdown_script_event_handler() calls modem_pipe_close_async() followed by modem_cellular_enter_state(IDLE) which also calls modem_pipe_close_async().

Prevent side-effects of calling the close twice, by checking the already existing atomic bit.

This issue is a regression from https://github.com/zephyrproject-rtos/zephyr/pull/103599
Also, that PR removed `modem_pipe_notify_closed()` only from one of the async drivers.
Remove the same from the HWFC version as well.

Please review @vytvir
