### PR TITLE
tests: boot: test_mcuboot: refine STM32H5/H7 support

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -54,9 +54,7 @@ tests:
       - esp32c3_devkitm
       - esp32c6_devkitc/esp32c6/hpcore
       - esp8684_devkitm
-      - stm32h750b_dk/stm32h750xx/ext_flash_app
       - stm32h573i_dk
-      - stm32h573i_dk/stm32h573xx/ext_flash_app
       - sam_e54_xpro
       - pic32cx_sg41_cult
       - nucleo_c071rb
@@ -79,8 +77,7 @@ tests:
       - nrf52840dk/nrf52840
   bootloader.mcuboot.assert:
     platform_allow:
-      - stm32h750b_dk/stm32h750xx/ext_flash_app
-      - stm32h573i_dk/stm32h573xx/ext_flash_app
+      - stm32h573i_dk
     extra_configs:
       - CONFIG_ASSERT=y
   bootloader.mcuboot.swap_using_move:
@@ -88,8 +85,6 @@ tests:
       - frdm_k64f
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
-      - stm32h750b_dk/stm32h750xx/ext_flash_app
-      - stm32h573i_dk/stm32h573xx/ext_flash_app
     integration_platforms:
       - frdm_k64f
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Remove **ext_flash_app** variant of **stm32h573i_dk** and **stm32h750b_dk** boards from the platform_allow list of **test_mcuboot**. These configuration variants do not allow to run these tests where the zephyr application executes in place from an external flash while it is expected to write to that same flash. The current implementation does not support that.

Add **stm32h573i_dk** (normal variant) for testcase **bootloader.mcuboot.assert** which is applicable.