### PR TITLE
doc: include: drop funcprops Doxygen alias

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -292,7 +292,6 @@ ALIASES                = "kconfig{1}=\c \1" \
                          "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
                          "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
                          "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \
-                         "funcprops=\par \"Function properties (list may not be complete)\"" \
                          "reschedule=\qualifier reschedule" \
                          "sleep=\qualifier sleep" \
                          "no_wait=\qualifier no-wait" \

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -201,7 +201,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
  * callee must not perform any action that makes the current thread unready. When called from ISR
  * context, the callback runs without scheduler lock.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param type_mask A bit mask of buffer types that have been freed.
  */
@@ -211,7 +211,7 @@ typedef void (*bt_buf_rx_freed_cb_t)(enum bt_buf_type type_mask);
  *
  * It's safe to call this inside the callback itself.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param cb Callback to notify about freed buffer in the incoming data pool. If NULL, the callback
  *           is disabled.

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -446,7 +446,7 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  * Start is allowed on channels that have already been started and must report
  * success.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer will
@@ -472,7 +472,7 @@ static inline int dma_start(const struct device *dev, uint32_t channel)
  * Stop is allowed on channels that have already been stopped and must report
  * success.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer was
@@ -489,14 +489,13 @@ static inline int dma_stop(const struct device *dev, uint32_t channel)
 	return api->stop(dev, channel);
 }
 
-
 /**
  * @brief Suspend a DMA channel transfer
  *
  * Implementations must check the validity of the channel state and ID passed
  * in and return -EINVAL if either are invalid.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to suspend
@@ -522,7 +521,7 @@ static inline int dma_suspend(const struct device *dev, uint32_t channel)
  * Implementations must check the validity of the channel state and ID passed
  * in and return -EINVAL if either are invalid.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to resume
@@ -649,7 +648,7 @@ static inline int dma_chan_filter(const struct device *dev, int channel, void *f
  * Implementations must check the validity of the channel ID passed in and
  * return -EINVAL if it is invalid or -ENOSYS if not supported.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer was
@@ -680,7 +679,7 @@ static inline int dma_get_status(const struct device *dev, uint32_t channel,
  * Implementations must check the validity of the type passed in and
  * return -EINVAL if it is invalid or -ENOSYS if not supported.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param type    Numeric identification of the attribute

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -864,7 +864,7 @@ static inline bool gpio_is_ready_dt(const struct gpio_dt_spec *spec)
  *       not controlled directly by the GPIO module. That is, pins which are
  *       routed to other modules such as I2C, SPI, UART.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param port Pointer to device structure for the driver instance.
  * @param pin Pin number.
@@ -955,7 +955,7 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 /**
  * @brief Configure pin interrupts from a @p gpio_dt_spec.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * This is equivalent to:
  *

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -896,7 +896,7 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
  * to another I2C device asynchronously with a callback completion.
  *
  * @see i2c_transfer()
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev Pointer to the device structure for an I2C controller
  *            driver configured in controller mode.
@@ -1047,7 +1047,7 @@ void z_i2c_transfer_signal_cb(const struct device *dev, int result, void *userda
  * to another I2C device asynchronously with a k_poll_signal completion.
  *
  * @see i2c_transfer_cb()
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dev Pointer to the device structure for an I2C controller
  *            driver configured in controller mode.

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -833,7 +833,7 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
  * CONTAINER_OF to retrieve a context pointer when the trigger is embedded in a
  * larger struct and requires that the trigger is not allocated on the stack.
  *
- * @funcprops \supervisor
+ * @supervisor
  *
  * @param dev Pointer to the sensor device
  * @param trig The trigger to activate

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -795,7 +795,7 @@ __syscall k_tid_t k_sched_current_thread_query(void);
  * This routine allows the caller to customize its actions, depending on
  * whether it being invoked before the kernel is fully active.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @return true if invoked before post-kernel initialization
  * @return false if invoked during/after post-kernel initialization
@@ -1390,7 +1390,7 @@ void k_thread_time_slice_set(struct k_thread *th, int32_t slice_ticks,
  * This routine allows the caller to customize its actions, depending on
  * whether it is a thread or an ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @return false if invoked by a thread.
  * @return true if invoked by an ISR.
@@ -1408,7 +1408,7 @@ bool k_is_in_isr(void);
  * - The thread's priority is in the preemptible range.
  * - The thread has not locked the scheduler.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @return 0 if invoked by an ISR or by a cooperative thread.
  * @return Non-zero if invoked by a preemptible thread.
@@ -1985,7 +1985,7 @@ __syscall void k_timer_start(struct k_timer *timer,
  * @note The stop handler has to be callable from ISRs if @a k_timer_stop is to
  * be called from ISRs.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param timer     Address of timer.
  */
@@ -2300,7 +2300,7 @@ __syscall void k_queue_init(struct k_queue *queue);
  * -EINTR and K_POLL_STATE_CANCELLED state (and per above, subsequent
  * k_queue_get() will return NULL).
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  */
@@ -2313,7 +2313,7 @@ __syscall void k_queue_cancel_wait(struct k_queue *queue);
  * aligned on a word boundary, and the first word of the item is reserved
  * for the kernel's use.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2328,7 +2328,7 @@ void k_queue_append(struct k_queue *queue, void *data);
  * the calling thread's resource pool, which is automatically freed when the
  * item is removed. The data itself is not copied.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2345,7 +2345,7 @@ __syscall int32_t k_queue_alloc_append(struct k_queue *queue, void *data);
  * aligned on a word boundary, and the first word of the item is reserved
  * for the kernel's use.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2360,7 +2360,7 @@ void k_queue_prepend(struct k_queue *queue, void *data);
  * the calling thread's resource pool, which is automatically freed when the
  * item is removed. The data itself is not copied.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2377,7 +2377,7 @@ __syscall int32_t k_queue_alloc_prepend(struct k_queue *queue, void *data);
  * data item must be aligned on a word boundary, and the first word of
  * the item is reserved for the kernel's use.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param prev Address of the previous data item.
@@ -2393,7 +2393,7 @@ void k_queue_insert(struct k_queue *queue, void *prev, void *data);
  * in each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param head Pointer to first node in singly-linked list.
@@ -2412,7 +2412,7 @@ int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
  * The data items must be in a singly-linked list implemented using a
  * sys_slist_t object. Upon completion, the original list is empty.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param list Pointer to sys_slist_t object.
@@ -2430,7 +2430,7 @@ int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param timeout Waiting period to obtain a data item, or one of the special
@@ -2450,7 +2450,7 @@ __syscall void *k_queue_get(struct k_queue *queue, k_timeout_t timeout);
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2466,7 +2466,7 @@ bool k_queue_remove(struct k_queue *queue, void *data);
  * item is reserved for the kernel's use. Appending elements to k_queue
  * relies on sys_slist_is_node_in_list which is not a constant time operation.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  * @param data Address of the data item.
@@ -2481,7 +2481,7 @@ bool k_queue_unique_append(struct k_queue *queue, void *data);
  * Note that the data might be already gone by the time this function returns
  * if other threads are also trying to read from the queue.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue Address of the queue.
  *
@@ -2680,7 +2680,7 @@ __syscall void k_event_init(struct k_event *event);
  * Posting differs from setting in that posted events are merged together with
  * the current set of events tracked by the event object.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param event Address of the event object
  * @param events Set of events to post to @a event
@@ -2699,7 +2699,7 @@ __syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
  * Setting differs from posting in that set events replace the current set of
  * events tracked by the event object.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param event Address of the event object
  * @param events Set of events to set in @a event
@@ -2716,7 +2716,7 @@ __syscall uint32_t k_event_set(struct k_event *event, uint32_t events);
  * become met by this immediately unpend. Unlike @ref k_event_set, this routine
  * allows specific event bits to be set and cleared as determined by the mask.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param event Address of the event object
  * @param events Set of events to set/clear in @a event
@@ -2732,7 +2732,7 @@ __syscall uint32_t k_event_set_masked(struct k_event *event, uint32_t events,
  *
  * This routine clears (resets) the specified events stored in an event object.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param event Address of the event object
  * @param events Set of events to clear in @a event
@@ -2839,12 +2839,10 @@ __syscall uint32_t k_event_wait_safe(struct k_event *event, uint32_t events,
 __syscall uint32_t k_event_wait_all_safe(struct k_event *event, uint32_t events,
 					 bool reset, k_timeout_t timeout);
 
-
-
 /**
  * @brief Test the events currently tracked in the event object
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param event Address of the event object
  * @param events_mask Set of desired events to test
@@ -2919,7 +2917,7 @@ struct k_fifo {
  * return from k_fifo_get() call with NULL value (as if timeout
  * expired).
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO queue.
  */
@@ -2937,7 +2935,7 @@ struct k_fifo {
  * aligned on a word boundary, and the first word of the item is reserved
  * for the kernel's use.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO.
  * @param data Address of the data item.
@@ -2958,7 +2956,7 @@ struct k_fifo {
  * the calling thread's resource pool, which is automatically freed when the
  * item is removed. The data itself is not copied.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO.
  * @param data Address of the data item.
@@ -2983,7 +2981,7 @@ struct k_fifo {
  * each data item pointing to the next data item; the list must be
  * NULL-terminated.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO queue.
  * @param head Pointer to first node in singly-linked list.
@@ -3004,7 +3002,7 @@ struct k_fifo {
  * sys_slist_t object. Upon completion, the sys_slist_t object is invalid
  * and must be re-initialized via sys_slist_init().
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO queue.
  * @param list Pointer to sys_slist_t object.
@@ -3024,7 +3022,7 @@ struct k_fifo {
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO queue.
  * @param timeout Waiting period to obtain a data item,
@@ -3047,7 +3045,7 @@ struct k_fifo {
  * Note that the data might be already gone by the time this function returns
  * if other threads is also trying to read from the FIFO.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param fifo Address of the FIFO queue.
  *
@@ -3161,7 +3159,7 @@ struct k_lifo {
  * aligned on a word boundary, and the first word of the item is
  * reserved for the kernel's use.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param lifo Address of the LIFO queue.
  * @param data Address of the data item.
@@ -3182,7 +3180,7 @@ struct k_lifo {
  * the calling thread's resource pool, which is automatically freed when the
  * item is removed. The data itself is not copied.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param lifo Address of the LIFO.
  * @param data Address of the data item.
@@ -3207,7 +3205,7 @@ struct k_lifo {
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param lifo Address of the LIFO queue.
  * @param timeout Waiting period to obtain a data item,
@@ -3326,7 +3324,7 @@ int k_stack_cleanup(struct k_stack *stack);
  *
  * This routine adds a stack_data_t value @a data to @a stack.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param stack Address of the stack.
  * @param data Value to push onto the stack.
@@ -3344,7 +3342,7 @@ __syscall int k_stack_push(struct k_stack *stack, stack_data_t data);
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param stack Address of the stack.
  * @param data Address of area to hold the value popped from the stack.
@@ -3675,7 +3673,7 @@ __syscall int k_sem_init(struct k_sem *sem, unsigned int initial_count,
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param sem Address of the semaphore.
  * @param timeout Waiting period to take the semaphore,
@@ -3694,7 +3692,7 @@ __syscall int k_sem_take(struct k_sem *sem, k_timeout_t timeout);
  * This routine gives @a sem, unless the semaphore is already at its maximum
  * permitted count.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param sem Address of the semaphore.
  */
@@ -3879,7 +3877,7 @@ typedef void (*k_work_handler_t)(struct k_work *work);
  * re-invoked to change the associated handler, but this must be done when the
  * work item is idle.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work the work structure to be initialized.
  *
@@ -3895,7 +3893,7 @@ void k_work_init(struct k_work *work,
  * @note This is a live snapshot of state, which may change before the result
  * is checked.  Use locks where appropriate.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work pointer to the work item.
  *
@@ -3911,7 +3909,7 @@ int k_work_busy_get(const struct k_work *work);
  * @note This is a live snapshot of state, which may change before the result
  * is checked.  Use locks where appropriate.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work pointer to the work item.
  *
@@ -3924,7 +3922,7 @@ static inline bool k_work_is_pending(const struct k_work *work);
  * @param queue pointer to the work queue on which the item should run.  If
  * NULL the queue from the most recent submission will be used.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work pointer to the work item.
  *
@@ -3944,7 +3942,7 @@ int k_work_submit_to_queue(struct k_work_q *queue,
 
 /** @brief Submit a work item to the system queue.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work pointer to the work item.
  *
@@ -3991,7 +3989,7 @@ bool k_work_flush(struct k_work *work,
  *
  * See also k_work_cancel_sync().
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work pointer to the work item.
  *
@@ -4037,7 +4035,7 @@ bool k_work_cancel_sync(struct k_work *work, struct k_work_sync *sync);
  * This must be invoked before starting a work queue structure for the first time.
  * It need not be invoked again on the same work queue structure.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue the queue structure to be initialized.
  */
@@ -4120,7 +4118,7 @@ int k_work_queue_drain(struct k_work_q *queue, bool plug);
  * is invoked with the @p plug option enabled.  If this is invoked before the
  * drain completes new items may be submitted as soon as the drain completes.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue pointer to the queue structure.
  *
@@ -4153,7 +4151,7 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout);
  * can be re-invoked to change the associated handler, but this must be done
  * when the work item is idle.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dwork the delayable work structure to be initialized.
  *
@@ -4178,7 +4176,7 @@ k_work_delayable_from_work(struct k_work *work);
 
 /** @brief Busy state flags from the delayable work item.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @note This is a live snapshot of state, which may change before the result
  * can be inspected.  Use locks where appropriate.
@@ -4198,7 +4196,7 @@ int k_work_delayable_busy_get(const struct k_work_delayable *dwork);
  * @note This is a live snapshot of state, which may change before the result
  * can be inspected.  Use locks where appropriate.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dwork pointer to the delayable work item.
  *
@@ -4214,7 +4212,7 @@ static inline bool k_work_delayable_is_pending(
  * @note This is a live snapshot of state, which may change before the result
  * can be inspected.  Use locks where appropriate.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dwork pointer to the delayable work item.
  *
@@ -4230,7 +4228,7 @@ static inline k_ticks_t k_work_delayable_expires_get(
  * @note This is a live snapshot of state, which may change before the result
  * can be inspected.  Use locks where appropriate.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dwork pointer to the delayable work item.
  *
@@ -4245,7 +4243,7 @@ static inline k_ticks_t k_work_delayable_remaining_get(
  * Unlike k_work_reschedule_for_queue() this is a no-op if the work item is
  * already scheduled or submitted, even if @p delay is @c K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue the queue on which the work item should be submitted after the
  * delay.
@@ -4294,7 +4292,7 @@ int k_work_schedule(struct k_work_delayable *dwork,
  * (e.g. is idle, submitted, or running).  This function does not affect
  * ("unsubmit") a work item that has been submitted to a queue.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param queue the queue on which the work item should be submitted after the
  * delay.
@@ -4381,7 +4379,7 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
  * @note Canceling delayable work does not prevent rescheduling it.  It does
  * prevent submitting it until the cancellation completes.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param dwork pointer to the delayable work item.
  *
@@ -4825,7 +4823,7 @@ static inline void k_work_user_init(struct k_work_user *work,
  *       work will still be pending when this information is used. It is up to
  *       the caller to make sure that this information is used in a safe manner.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work Address of work item.
  *
@@ -4845,7 +4843,7 @@ static inline bool k_work_user_is_pending(struct k_work_user *work)
  * thread must have memory access to the k_work item being submitted. The caller
  * must have permission granted on the work_q parameter's queue object.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work_q Address of workqueue.
  * @param work Address of work item.
@@ -4981,7 +4979,7 @@ void k_work_poll_init(struct k_work_poll *work,
  * to race conditions with the pre-existing triggered work item and work queue,
  * so care must be taken to synchronize such resubmissions externally.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @warning
  * Provided array of events as well as a triggered work item must be placed
@@ -5021,7 +5019,7 @@ int k_work_poll_submit_to_queue(struct k_work_q *work_q,
  * to race conditions with the pre-existing triggered work item and work queue,
  * so care must be taken to synchronize such resubmissions externally.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @warning
  * Provided array of events as well as a triggered work item must not be
@@ -5049,7 +5047,7 @@ int k_work_poll_submit(struct k_work_poll *work,
  * A triggered work item can only be canceled if no event triggered work
  * submission.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param work Address of delayed work item.
  *
@@ -5225,7 +5223,7 @@ int k_msgq_cleanup(struct k_msgq *msgq);
  * pointer is not retained, so the message content will not be modified
  * by this function.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Pointer to the message.
@@ -5254,7 +5252,7 @@ __syscall int k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t time
  *
  * @note k_msgq_put_front() does not block.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Pointer to the message.
@@ -5272,7 +5270,7 @@ __syscall int k_msgq_put_front(struct k_msgq *msgq, const void *data);
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Address of area to hold the received message.
@@ -5292,7 +5290,7 @@ __syscall int k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout);
  * This routine reads a message from message queue @a q in a "first in,
  * first out" manner and leaves the message in the queue.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Address of area to hold the message read from the queue.
@@ -5309,7 +5307,7 @@ __syscall int k_msgq_peek(struct k_msgq *msgq, void *data);
  * and leaves the message in the queue.
  * k_msgq_peek_at(msgq, data, 0) is equivalent to k_msgq_peek(msgq, data)
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Address of area to hold the message read from the queue.
@@ -5852,7 +5850,7 @@ int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab.
  * @param mem Pointer to block address area.
@@ -5875,7 +5873,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
  * This routine releases a previously allocated memory block back to its
  * associated memory slab.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab.
  * @param mem Pointer to the memory block (as returned by k_mem_slab_alloc()).
@@ -5888,7 +5886,7 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem);
  * This routine gets the number of memory blocks that are currently
  * allocated in @a slab.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab.
  *
@@ -5905,7 +5903,7 @@ static inline uint32_t k_mem_slab_num_used_get(struct k_mem_slab *slab)
  * This routine gets the maximum number of memory blocks that were
  * allocated in @a slab.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab.
  *
@@ -5927,7 +5925,7 @@ static inline uint32_t k_mem_slab_max_used_get(struct k_mem_slab *slab)
  * This routine gets the number of memory blocks that are currently
  * unallocated in @a slab.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab.
  *
@@ -5943,7 +5941,7 @@ static inline uint32_t k_mem_slab_num_free_get(struct k_mem_slab *slab)
  *
  * This routine gets the runtime memory usage stats for the slab @a slab.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab
  * @param stats Pointer to memory into which to copy memory usage statistics
@@ -5960,7 +5958,7 @@ int k_mem_slab_runtime_stats_get(struct k_mem_slab *slab, struct sys_memory_stat
  * This routine resets the maximum memory usage for the slab @a slab to its
  * current usage.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param slab Address of the memory slab
  *
@@ -6012,7 +6010,7 @@ void k_heap_init(struct k_heap *h, void *mem,
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param h Heap from which to allocate
  * @param align Alignment in bytes, must be a power of two
@@ -6037,7 +6035,7 @@ void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param h Heap from which to allocate
  * @param bytes Desired size of block to allocate
@@ -6061,7 +6059,7 @@ void *k_heap_alloc(struct k_heap *h, size_t bytes,
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param h Heap from which to allocate
  * @param num Number of objects to allocate
@@ -6086,7 +6084,7 @@ void *k_heap_calloc(struct k_heap *h, size_t num, size_t size, k_timeout_t timeo
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
  *
- * @funcprops \isr_ok
+ * @isr_ok
  *
  * @param h Heap from which to allocate
  * @param ptr Original pointer returned from a previous allocation

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -43,7 +43,7 @@ int pm_device_runtime_auto_enable(const struct device *dev);
  * This function will enable runtime PM on the given device. If the device is
  * in #PM_DEVICE_STATE_ACTIVE state, the device will be suspended.
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  *
@@ -61,7 +61,7 @@ int pm_device_runtime_enable(const struct device *dev);
  *
  * If the device is currently suspended it will be resumed.
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  *
@@ -85,7 +85,7 @@ int pm_device_runtime_disable(const struct device *dev);
  * @note It is safe to use this function in contexts where blocking is not
  * allowed, e.g. ISR, provided the device PM implementation does not block.
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  *
@@ -104,7 +104,7 @@ int pm_device_runtime_get(const struct device *dev);
  * state will be left unchanged. In all other cases, usage count will be
  * decremented (down to 0).
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  *
@@ -129,7 +129,7 @@ int pm_device_runtime_put(const struct device *dev);
  * this case, the function will be blocking (equivalent to
  * pm_device_runtime_put()).
  *
- * @funcprops \pre_kernel_ok, \async, \isr_ok
+ * @pre_kernel_ok @async @isr_ok
  *
  * @param dev Device instance.
  * @param delay Minimum amount of time before triggering the action.
@@ -147,7 +147,7 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay);
 /**
  * @brief Check if device runtime is enabled for a given device.
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  *

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -40,7 +40,7 @@ static struct k_work_q pm_device_runtime_wq;
  * this case, the async flag will be always forced to be false, and so the
  * function will be blocking.
  *
- * @funcprops \pre_kernel_ok
+ * @pre_kernel_ok
  *
  * @param dev Device instance.
  * @param async Perform operation asynchronously.


### PR DESCRIPTION
The "@funcprops" Doxygen alias was originally introduced to list all the function properties that apply to a given function (e.g. isr_ok, etc.) in the form of a bullet list. However, since commit a258ab32d1 that is no longer the case and all the properties are rendered as qualifiers (https://www.doxygen.nl/manual/commands.html#cmdqualifier) and therefore no longer need to be grouped in a separate list.

This commit also ensure all aliases for the actual qualifiers use `@qualifier` notation instead of `\qualifier` to be consistent with our Doxygen guidelines.

- https://builds.zephyrproject.io/zephyr/pr/103900/docs/doxygen/html/group__event__apis.html#ga81e66be0959e8cb0414d9772056a6264
- https://builds.zephyrproject.io/zephyr/pr/103900/docs/doxygen/html/group__subsys__pm__device__runtime.html#ga9e90089b0ab78f365905418646e196c6