### PR TITLE
samples: bluetooth: peripheral: Add NXP board to support list

### DIFF
--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -33,4 +33,6 @@ tests:
       - xg24_rb4187c/efr32mg24b220f1536im48
       - xg27_dk2602a/efr32bg27c140f768im40
       - xg29_rb4412a/efr32mg29b140f1024im40
+      - frdm_mcxw71
+      - frdm_mcxw72
     build_only: true


### PR DESCRIPTION
Adding the platforms here helps maintain build coverage for the Bluetooth subsystem on our
architecture and helps catch integration or configuration regressions early.