### PR TITLE
drivers: serial: nrfx_uarte: Fix wrong endif use

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -767,8 +767,8 @@ static void uarte_periph_enable(const struct device *dev)
 				nrf_timer_task_trigger(config->timer_regs, NRF_TIMER_TASK_COUNT);
 			}
 		}
-		return;
 #endif
+		return;
 	}
 #endif
 


### PR DESCRIPTION
Preprocess endif should be before return so that uarte_periph_enable returns always when asynchronous API is used. It leads to faulty behavior in certain configurations.