### PR TITLE
usb: uac2: kconfig override for feedback endpoint size

### DIFF
--- a/samples/subsys/usb/uac2_explicit_feedback/README.rst
+++ b/samples/subsys/usb/uac2_explicit_feedback/README.rst
@@ -20,6 +20,8 @@ Asynchronous USB Audio 2 class device supporting 48 kHz 16-bit 2-channel
    release 1703 expects Full-Speed explicit feedback endpoint wMaxPacketSize to
    be equal 4, which violates the USB 2.0 Specification.
    See https://aka.ms/AArvnax for Windows Feedback Hub report.
+   For Windows-only use wMaxPacketSize can be overridden with
+   :kconfig:option:`CONFIG_USBD_UAC2_FS_WINDOWS_WORKAROUND`
 
 Explicit Feedback
 *****************

--- a/subsys/usb/device_next/class/Kconfig.uac2
+++ b/subsys/usb/device_next/class/Kconfig.uac2
@@ -10,6 +10,12 @@ config USBD_AUDIO2_CLASS
 
 if USBD_AUDIO2_CLASS
 
+config USBD_UAC2_FS_WINDOWS_WORKAROUND
+	bool "Workaround Windows Full-Speed wMaxPacketSize bug"
+	help
+	  Sets the feedback endpoint size for UAC2 on Full-Speed USB link to be 4 bytes.
+	  USB2.0 specification mandates length of 3, non-compliant Windows UAC2 driver expects 4.
+
 module = USBD_UAC2
 module-str = usbd uac2
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -432,7 +432,12 @@ static void write_explicit_feedback(struct usbd_class_data *const c_data,
 	fb_value = ctx->ops->feedback_cb(dev, terminal, ctx->user_data);
 
 	if (usbd_bus_speed(uds_ctx) == USBD_SPEED_FS) {
-		net_buf_add_le24(buf, fb_value);
+		if (IS_ENABLED(CONFIG_USBD_UAC2_FS_WINDOWS_WORKAROUND)) {
+			/* Convert Q10.14 to Q16.16 */
+			net_buf_add_le32(buf, fb_value << 2);
+		} else {
+			net_buf_add_le24(buf, fb_value);
+		}
 	} else {
 		net_buf_add_le32(buf, fb_value);
 	}

--- a/subsys/usb/device_next/class/usbd_uac2_macros.h
+++ b/subsys/usb/device_next/class/usbd_uac2_macros.h
@@ -802,13 +802,21 @@
 	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_std_data_ep, node),	\
 	(struct usb_desc_header *) &DESCRIPTOR_NAME(cs_data_ep, node),
 
-#define AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR(node)			\
-	0x07,						/* bLength */		\
-	USB_DESC_ENDPOINT,				/* bDescriptorType */	\
-	AS_NEXT_IN_EP_ADDR(node),			/* bEndpointAddress */	\
-	0x11,						/* bmAttributes */	\
-	U16_LE(0x03),					/* wMaxPacketSize */	\
-	0x01, /* TODO: adjust to P 5.12.4.2 Feedback */	/* bInterval */
+#if defined(CONFIG_USBD_UAC2_FS_WINDOWS_WORKAROUND)
+#warning "CONFIG_USBD_UAC2_FS_WINDOWS_WORKAROUND violates USB standard. \
+Apply only for working with non-compliant Windows UAC2 driver"
+#define EXPLICIT_FEEDBACK_ENDPOINT_FS_FEEDBACK_LEN (0x04)
+#else
+#define EXPLICIT_FEEDBACK_ENDPOINT_FS_FEEDBACK_LEN (0x03)
+#endif
+
+#define AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR(node)				\
+	0x07,							/* bLength */		\
+	USB_DESC_ENDPOINT,					/* bDescriptorType */	\
+	AS_NEXT_IN_EP_ADDR(node),				/* bEndpointAddress */	\
+	0x11,							/* bmAttributes */	\
+	U16_LE(EXPLICIT_FEEDBACK_ENDPOINT_FS_FEEDBACK_LEN),	/* wMaxPacketSize */	\
+	0x01, /* TODO: adjust to P 5.12.4.2 Feedback */		/* bInterval */
 
 #define AS_EXPLICIT_FEEDBACK_FS_DESCRIPTOR_ARRAY(node)				\
 	static uint8_t DESCRIPTOR_NAME(fs_feedback_ep, node)[] = {		\


### PR DESCRIPTION
Adds compile-time option for overriding UAC2 Feedback endpoint to allow usage with non-class-compliant Windows UAC2 driver.

This issue has been known about for a while: see previous mentions in https://github.com/zephyrproject-rtos/zephyr/issues/77212, https://github.com/zephyrproject-rtos/zephyr/pull/86660.

This is noted in the docs: for a USB UAC2 device to work with windows it has to set its feedback endpoint to be 4 bytes in size, rather than the 3 specified in the USB 2.0 standard (section 5.12.4.2)
<img width="837" height="159" alt="image" src="https://github.com/user-attachments/assets/73773f8f-b424-4be7-9947-98401b5024c1" />

This PR adds a KConfig parameter for overriding the feedback endpoint size to allow windows interoperability for full-speed devices. The default value is the standard-compliant one.

Obviously the ideal solution would be that Windows would fix their driver, but according to the guy who wrote it, that's unlikely to happen any time soon.
https://github.com/zephyrproject-rtos/zephyr/issues/77212#issuecomment-2309423077

Note that this fix is compile-time only, so the device can't simultaneously work with both windows / non-windows UAC2 drivers. However, for devices that are windows-only (e.g. internal laptop USB devices), this is an adequate fix.