### PR TITLE
soc: nxp: mcx: Add flash runner configuration

### DIFF
--- a/soc/nxp/mcx/soc.yml
+++ b/soc/nxp/mcx/soc.yml
@@ -62,6 +62,9 @@ runners:
         - mcxn947/cpu0
         - mcxn947/cpu1
       - qualifiers:
+        - mcxn547/cpu0
+        - mcxn547/cpu1
+      - qualifiers:
         - mcxn236
       - qualifiers:
         - mcxc141
@@ -71,6 +74,20 @@ runners:
         - mcxc242
       - qualifiers:
         - mcxc444
+      - qualifiers:
+        - mcxe245
+      - qualifiers:
+        - mcxe246
+      - qualifiers:
+        - mcxe247
+      - qualifiers:
+        - mcxe315
+      - qualifiers:
+        - mcxe316
+      - qualifiers:
+        - mcxe317
+      - qualifiers:
+        - mcxe31b
       - qualifiers:
         - mcxa153
       - qualifiers:
@@ -86,9 +103,17 @@ runners:
       - qualifiers:
         - mcxw716c
       - qualifiers:
+        - mcxw235
+      - qualifiers:
         - mcxw236
       - qualifiers:
         - mcxa344
+      - qualifiers:
+        - mcxw70ac
+      - qualifiers:
+        - mcxw716c
+      - qualifiers:
+        - mcxw727c
     '--reset':
     - run: last
       runners:
@@ -98,6 +123,9 @@ runners:
         - mcxn947/cpu0
         - mcxn947/cpu1
       - qualifiers:
+        - mcxn547/cpu0
+        - mcxn547/cpu1
+      - qualifiers:
         - mcxn236
       - qualifiers:
         - mcxc141
@@ -107,6 +135,20 @@ runners:
         - mcxc242
       - qualifiers:
         - mcxc444
+      - qualifiers:
+        - mcxe245
+      - qualifiers:
+        - mcxe246
+      - qualifiers:
+        - mcxe247
+      - qualifiers:
+        - mcxe315
+      - qualifiers:
+        - mcxe316
+      - qualifiers:
+        - mcxe317
+      - qualifiers:
+        - mcxe31b
       - qualifiers:
         - mcxa153
       - qualifiers:
@@ -122,6 +164,14 @@ runners:
       - qualifiers:
         - mcxw716c
       - qualifiers:
+        - mcxw235
+      - qualifiers:
         - mcxw236
       - qualifiers:
         - mcxa344
+      - qualifiers:
+        - mcxw70ac
+      - qualifiers:
+        - mcxw716c
+      - qualifiers:
+        - mcxw727c


### PR DESCRIPTION
- Adds missing flash runner configuration for mcxn/e/w used for sysbuild multi-image projects.
- Avoids sysbuild multiple resets and mass erases.