### PR TITLE
west.yml: espressif: fix BLE clock fallback

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 2e6348fd9534226fc0829915e0c15d780855a012
+      revision: 70420fe01f24147e4aaf25a84b3c72a6236ff9b1
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Update HAL to fix a missing fallback when BLE clock reference is configured to use internal RC oscillator.