### PR TITLE
net: shell: dns: Add browse command

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1411,13 +1411,18 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 
 		invoke_query_callback(DNS_EAI_INPROGRESS, &info, &ctx->queries[*query_idx]);
 
-		if (dns_msg->response_type == DNS_RESPONSE_IP ||
-		    dns_msg->response_type == DNS_RESPONSE_SRV) {
+		switch (dns_msg->response_type) {
+		case DNS_RESPONSE_IP:
+		case DNS_RESPONSE_SRV:
+		case DNS_RESPONSE_DATA:
 #ifdef CONFIG_DNS_RESOLVER_CACHE
 			dns_cache_add(&dns_cache,
 				ctx->queries[*query_idx].query, &info, ttl);
 #endif /* CONFIG_DNS_RESOLVER_CACHE */
 			items++;
+			break;
+		default:
+			break;
 		}
 	}
 

--- a/subsys/net/lib/shell/Kconfig
+++ b/subsys/net/lib/shell/Kconfig
@@ -50,6 +50,11 @@ config NET_SHELL_DNS_RESOLVER_SUPPORTED
 	default y
 	depends on NET_SHELL_SHOW_DISABLED_COMMANDS || DNS_RESOLVER
 
+config NET_SHELL_DNS_RESOLVER_QUEUE_SIZE
+	int "DNS resolver info queue size"
+	default 3
+	depends on NET_SHELL_DNS_RESOLVER_SUPPORTED
+
 config NET_SHELL_EVENT_MONITOR_SUPPORTED
 	bool "Network management event monitoring configuration"
 	default y

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -319,8 +319,8 @@ static int cmd_net_dns_query(const struct shell *sh, size_t argc, char *argv[])
 		PR("Query for '%s' sent.\n", host);
 	}
 #else
-	PR_INFO("DNS resolver not supported. Set CONFIG_DNS_RESOLVER to "
-		"enable it.\n");
+	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_RESOLVER",
+		"DNS resolver");
 #endif
 
 	return 0;
@@ -348,8 +348,8 @@ static int cmd_net_dns(const struct shell *sh, size_t argc, char *argv[])
 
 	print_dns_info(sh, ctx);
 #else
-	PR_INFO("DNS resolver not supported. Set CONFIG_DNS_RESOLVER to "
-		"enable it.\n");
+	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_RESOLVER",
+		"DNS resolver");
 #endif
 
 	return 0;
@@ -394,8 +394,8 @@ static int cmd_net_dns_list(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 #else
-	PR_INFO("DNS service discovery not supported. Set CONFIG_DNS_SD to "
-		"enable it.\n");
+	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_RESOLVER",
+		"DNS service discovery");
 #endif
 
 	return 0;
@@ -578,8 +578,8 @@ static int cmd_net_dns_service(const struct shell *sh, size_t argc, char *argv[]
 		}
 	}
 #else
-	PR_INFO("DNS resolver not supported. Set CONFIG_DNS_RESOLVER to "
-		"enable it.\n");
+	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_RESOLVER",
+		"DNS resolver");
 #endif
 
 	return 0;

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -97,7 +97,7 @@ static void dns_result_cb(enum dns_resolve_status status,
 	PR_WARNING("dns: Unhandled status %d received (errno %d)\n", status, errno);
 }
 
-K_MSGQ_DEFINE(dns_infoq, sizeof(struct dns_addrinfo), 3, 1);
+K_MSGQ_DEFINE(dns_infoq, sizeof(struct dns_addrinfo), CONFIG_NET_SHELL_DNS_RESOLVER_QUEUE_SIZE, 1);
 
 static void dns_service_cb(enum dns_resolve_status status,
 			   struct dns_addrinfo *info,


### PR DESCRIPTION
Add the 'net dns browse <service>' command to resolve multiple hosts of a certain service type.

```shell
uart:~$ net dns browse
Browsing for '_services._dns-sd._udp.local'...
  _airplay._tcp.local
  _ssh._tcp.local
Found 2 service(s).

uart:~$ net dns browse _ssh._tcp.local
Browsing for '_ssh._tcp.local'...
  MacBook Air._ssh._tcp.local
Found 1 service(s).
```
