### PR TITLE
kernel: events: stash no_wake_on_timeout in event_options of k_thread

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -277,10 +277,14 @@ struct k_thread {
 	struct k_thread *next_event_link;
 
 	uint32_t   events; /* dual purpose - wait on and then received */
-	uint32_t   event_options;
 
-	/** true if timeout should not wake the thread */
-	bool no_wake_on_timeout;
+	/**
+	 * k_event_wait() options, and flags for the scheduler
+	 *
+	 * See K_EVENT_FLAG_NO_WAKE_ON_TIMEOUT in kernel_internal.h
+	 * and K_EVENT_* defines in events.c for more details.
+	 */
+	uint32_t   evt_opts_and_flags;
 #endif /* CONFIG_EVENTS */
 
 #if defined(CONFIG_THREAD_MONITOR)

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -110,7 +110,7 @@ static int event_walk_op(struct k_thread *thread, void *data)
 	unsigned int wait_condition;
 	struct event_walk_data *event_data = data;
 
-	wait_condition = thread->event_options & K_EVENT_WAIT_MASK;
+	wait_condition = thread->evt_opts_and_flags & K_EVENT_WAIT_MASK;
 
 	match = are_wait_conditions_met(thread->events, event_data->events,
 					wait_condition);
@@ -123,7 +123,7 @@ static int event_walk_op(struct k_thread *thread, void *data)
 		 * NOTE: thread event options can consume an event
 		 */
 		thread->events = match;
-		if (thread->event_options & K_EVENT_OPTION_CLEAR) {
+		if (thread->evt_opts_and_flags & K_EVENT_OPTION_CLEAR) {
 			event_data->clear_events |= match;
 		}
 		thread->next_event_link = event_data->head;
@@ -135,7 +135,7 @@ static int event_walk_op(struct k_thread *thread, void *data)
 		 * will be woken up by k_event_post_internal once they
 		 * have been processed.
 		 */
-		thread->no_wake_on_timeout = true;
+		thread->evt_opts_and_flags |= K_EVENT_FLAG_NO_WAKE_ON_TIMEOUT;
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 		z_abort_timeout(&thread->base.timeout);
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
@@ -306,7 +306,7 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 	 */
 
 	thread->events = events;
-	thread->event_options = options;
+	thread->evt_opts_and_flags = options;
 
 	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_event, wait, event, events,
 					   options, timeout);

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -25,6 +25,14 @@
 extern "C" {
 #endif
 
+/*
+ * Special flag stashed in k_thread.evt_opts_and_flags
+ * indicating that a k_event_wait() for the thread is
+ * undergoing completion, meaning the thread must not
+ * be awakened if its timeout elapses.
+ */
+#define K_EVENT_FLAG_NO_WAKE_ON_TIMEOUT BIT(31)
+
 /* Initialize per-CPU kernel data */
 void z_init_cpu(int id);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -629,9 +629,10 @@ void z_sched_wake_thread(struct k_thread *thread, bool is_timeout)
 				(_THREAD_DEAD | _THREAD_ABORTING));
 
 #ifdef CONFIG_EVENTS
-		bool do_nothing = thread->no_wake_on_timeout && is_timeout;
+		bool do_nothing = is_timeout &&
+			(thread->evt_opts_and_flags & K_EVENT_FLAG_NO_WAKE_ON_TIMEOUT);
 
-		thread->no_wake_on_timeout = false;
+		thread->evt_opts_and_flags &= ~K_EVENT_FLAG_NO_WAKE_ON_TIMEOUT;
 
 		if (do_nothing) {
 			continue;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -654,7 +654,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	new_thread->custom_data = NULL;
 #endif /* CONFIG_THREAD_CUSTOM_DATA */
 #ifdef CONFIG_EVENTS
-	new_thread->no_wake_on_timeout = false;
+	new_thread->evt_opts_and_flags = 0U;
 #endif /* CONFIG_EVENTS */
 #ifdef CONFIG_THREAD_MONITOR
 	new_thread->entry.pEntry = entry;


### PR DESCRIPTION
Instead of adding a dedicated bool variable, use empty space in the `event_options` field (renamed `evt_opts_and_flags` to reflect this) to store the flag in a specific bit. This saves 4/8 bytes of RAM for each created thread depending on platform being 32-/64-bit.