### PR TITLE
esp_hosted: add protocol events 305-307 for esp_hosted_fg

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_proto.pb
+++ b/drivers/wifi/esp_hosted/esp_hosted_proto.pb
@@ -147,9 +147,12 @@ enum CtrlMsgId {
     Event_Heartbeat = 302;
     Event_StationDisconnectFromAP = 303;
     Event_StationDisconnectFromESPSoftAP = 304;
+    Event_StationConnectedToAP = 305;
+    Event_StationConnectedToESPSoftAP = 306;
+    Event_CustomRPCUnserialisedMsg = 307;
     /* Add new control path command notification before Event_Max
      * and update Event_Max */
-    Event_Max = 305;
+    Event_Max = 308;
 }
 
 /* internal supporting structures for CtrlMsg */
@@ -359,11 +362,42 @@ message CtrlMsg_Event_Heartbeat {
 
 message CtrlMsg_Event_StationDisconnectFromAP {
     int32 resp = 1;
+    bytes ssid = 2;
+    uint32 ssid_len = 3;
+    bytes bssid = 4;
+    uint32 reason = 5;
+    int32 rssi = 6;
+}
+
+message CtrlMsg_Event_StationConnectedToAP {
+    int32 resp = 1;
+    bytes ssid = 2;
+    uint32 ssid_len = 3;
+    bytes bssid = 4;
+    uint32 channel = 5;
+    int32 authmode = 6;
+    int32 aid = 7;
 }
 
 message CtrlMsg_Event_StationDisconnectFromESPSoftAP {
     int32 resp = 1;
     bytes mac = 2;
+    uint32 aid = 3;
+    bool is_mesh_child = 4;
+    uint32 reason = 5;
+}
+
+message CtrlMsg_Event_StationConnectedToESPSoftAP {
+    int32 resp = 1;
+    bytes mac = 2;
+    uint32 aid = 3;
+    bool is_mesh_child = 4;
+}
+
+message CtrlMsg_Event_CustomRpcUnserialisedMsg {
+    int32 resp = 1;
+    uint32 custom_evt_id = 2;
+    bytes data = 3;
 }
 
 message CtrlMsg {
@@ -435,5 +469,8 @@ message CtrlMsg {
         CtrlMsg_Event_Heartbeat event_heartbeat = 302;
         CtrlMsg_Event_StationDisconnectFromAP event_station_disconnect_from_AP = 303;
         CtrlMsg_Event_StationDisconnectFromESPSoftAP event_station_disconnect_from_ESP_SoftAP = 304;
+        CtrlMsg_Event_StationConnectedToAP event_station_connected_to_AP = 305;
+        CtrlMsg_Event_StationConnectedToESPSoftAP event_station_connected_to_ESP_SoftAP = 306;
+        CtrlMsg_Event_CustomRpcUnserialisedMsg event_custom_rpc_unserialised_msg = 307;
     }
 }

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -248,6 +248,26 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 			wifi_mgmt_raise_connect_result_event(data->iface[ESP_HOSTED_STA_IF], ret);
 			continue;
 		}
+		case CtrlMsgId_Event_StationConnectedToAP:
+			/* Connection is handled via Resp_ConnectAP above */
+			LOG_DBG("Station connected to AP event received");
+			continue;
+		case CtrlMsgId_Event_StationConnectedToESPSoftAP: {
+			struct wifi_ap_sta_info sta_info = {0};
+
+			sta_info.link_mode = WIFI_LINK_MODE_UNKNOWN;
+			sta_info.twt_capable = false;
+			sta_info.mac_length = WIFI_MAC_ADDR_LEN;
+			esp_hosted_str_to_mac(
+				ctrl_msg.event_station_connected_to_ESP_SoftAP.mac.bytes,
+				sta_info.mac);
+			wifi_mgmt_raise_ap_sta_connected_event(data->iface[ESP_HOSTED_SAP_IF],
+							       &sta_info);
+			continue;
+		}
+		case CtrlMsgId_Event_CustomRPCUnserialisedMsg:
+			LOG_DBG("Custom RPC unserialised msg event received");
+			continue;
 		default: /* Unhandled events/responses will be queued. */
 			break;
 		}


### PR DESCRIPTION
## Summary

* Add support for newer ESP-Hosted-FG protocol events (305, 306, 307) that firmware FG-1.0.0.0.0 sends but the Zephyr driver did not handle
* Fix protocol mismatch error expected id 207 got id 305 that caused WiFi connection to fail
Implement ap_sta_connected event notification for SoftAP mode

## Problem

The ESP-Hosted firmware FG-1.0.0.0.0 sends three events not present in the Zephyr driver. When connecting to an AP, the ESP sends event 305 before the expected response 207 (Resp_ConnectAP), causing wifi connect to fail with:

```bash
[err] esp_hosted: expected id 207 got id 305
Error (-11): WiFi connect request failed
```

The driver's protobuf definition and event handler were out of sync with the ESP-Hosted FG protocol. According to the ESP-Hosted FG documentation (section [5.9.3 Events](https://github.com/espressif/esp-hosted/blob/master/esp_hosted_fg/docs/common/ctrl_apis.md) Events), the complete event list is:

```
5.9.3 Events
- CTRL_EVENT_BASE                                = 300
- CTRL_EVENT_ESP_INIT                            = 301
- CTRL_EVENT_HEARTBEAT                           = 302
- CTRL_EVENT_STATION_DISCONNECT_FROM_AP          = 303
- CTRL_EVENT_STATION_DISCONNECT_FROM_ESP_SOFTAP  = 304
- CTRL_EVENT_STATION_CONNECTED_TO_AP             = 305  (missing)
- CTRL_EVENT_STATION_CONNECTED_TO_ESP_SOFTAP     = 306  (missing)
- CTRL_EVENT_CUSTOM_RPC_UNSERIALISED_MSG         = 307  (missing)
- CTRL_EVENT_MAX                                 = 308
```

The Zephyr driver only supported events up to 304 (Event_Max = 305).

## Changes

**esp_hosted_proto.pb:**

* Added enum entries 305, 306, 307 and updated Event_Max to 308
* Added message definitions with fields matching the ESP-Hosted FG protocol
* Updated existing messages StationDisconnectFromAP and StationDisconnectFromESPSoftAP with missing fields
* Added new events to CtrlMsg oneof payload

**esp_hosted_wifi.c:**

* Event 305 (StationConnectedToAP): handled with continue (connection logic already handled by Resp_ConnectAP)
* Event 306 (StationConnectedToESPSoftAP): extracts station MAC and calls wifi_mgmt_raise_ap_sta_connected_event(), mirroring the existing event 304 disconnection handler
* Event 307 (CustomRPCUnserialisedMsg): handled with continue

## Testing

Tested on MiniSTM32H743 (host) + ESP32-C3 (co-processor, FG-1.0.0.0.0) via SPI.

```bash
uart:~$ wifi scan
Num  | SSID                             (len) | Chan (Band)   | RSSI | Security
1    | @MYWIFI                          5     | 6    (2.4GHz) | -41  | WPA2-PSK
2    | Dunder Mifflin Paper Co          23    | 6    (2.4GHz) | -57  | WPA2-PSK
Scan request done
 WiFi connect + DHCP

uart:~$ wifi connect -s "@MYWIFI" -p "87654321" -k 10
Connection requested
Connected
[00:03:32.961,000] <inf> net_dhcpv4: Received: 192.168.15.2
uart:~$ wifi status
State: COMPLETED | SSID: @MYWIFI | Channel: 6 | RSSI: -38 | Security: WPA2-PSK
 WiFi disconnect

uart:~$ wifi disconnect
Disconnection request done (0)
uart:~$ wifi status
State: DISCONNECTED
 SoftAP enable + station connect/disconnect events

uart:~$ wifi ap enable -s "ESP_AP" -p "12345678" -k 1 -c 6
AP enabled
Station connected: FF:FF:FF:FF:AF:FF
Station disconnected: FF:FF:FF:FF:AF:FF
Station connected: FF:FF:FF:FF:AF:FF
uart:~$ wifi ap disable
AP disabled
```

Log esp32-c3

```bash
I (24) boot: ESP-IDF v5.5.1-dirty 2nd stage bootloader
I (24) boot: compile time Jan 29 2026 22:58:23
I (24) boot: chip revision: v1.1
I (24) boot: efuse block revision: v1.3
I (28) qio_mode: Enabling default flash chip QIO
I (32) boot.esp32c3: SPI Speed      : 80MHz
I (36) boot.esp32c3: SPI Mode       : QIO
I (40) boot.esp32c3: SPI Flash Size : 4MB
I (44) boot: Enabling RNG early entropy source...
I (48) boot: Partition Table:
I (51) boot: ## Label            Usage          Type ST Offset   Length
I (57) boot:  0 nvs              WiFi data        01 02 00009000 00004000
I (64) boot:  1 otadata          OTA data         01 00 0000d000 00002000
I (70) boot:  2 phy_init         RF data          01 01 0000f000 00001000
I (77) boot:  3 ota_0            OTA app          00 10 00010000 00180000
I (83) boot:  4 ota_1            OTA app          00 11 00190000 00180000
I (90) boot: End of partition table
I (93) esp_image: segment 0: paddr=00010020 vaddr=3c0b0020 size=25594h (152980) map
I (122) esp_image: segment 1: paddr=000355bc vaddr=3fc97200 size=037c4h ( 14276) load
I (125) esp_image: segment 2: paddr=00038d88 vaddr=40380000 size=07290h ( 29328) load
I (131) esp_image: segment 3: paddr=00040020 vaddr=42000020 size=a8b64h (691044) map
I (230) esp_image: segment 4: paddr=000e8b8c vaddr=40387290 size=0fe80h ( 65152) load
I (241) esp_image: segment 5: paddr=000f8a14 vaddr=50000000 size=00020h (    32) load
I (248) boot: Loaded app from partition at offset 0x10000
I (248) boot: Disabling RNG early entropy source...
I (259) cpu_start: Unicore app
I (267) cpu_start: Pro cpu start user code
I (267) cpu_start: cpu freq: 160000000 Hz
I (267) app_init: Application information:
I (270) app_init: Project name:     network_adapter
I (275) app_init: App version:      FG-1.0.0.0.0
I (281) app_init: Compile time:     Jan 30 2026 09:43:49
I (287) app_init: ELF file SHA256:  c98785e9d...
I (292) app_init: ESP-IDF:          v5.5.1-dirty
I (297) efuse_init: Min chip rev:     v0.3
I (302) efuse_init: Max chip rev:     v1.99 
I (307) efuse_init: Chip rev:         v1.1
I (312) heap_init: Initializing. RAM available for dynamic allocation:
I (319) heap_init: At 3FC9F870 len 00020790 (129 KiB): RAM
I (325) heap_init: At 3FCC0000 len 0001C710 (113 KiB): Retention RAM
I (332) heap_init: At 3FCDC710 len 0000294C (10 KiB): Retention RAM
I (339) heap_init: At 50000020 len 00001FC8 (7 KiB): RTCRAM
I (346) spi_flash: detected chip: generic
I (350) spi_flash: flash io: qio
I (354) sleep_gpio: Configure to isolate all GPIO pins in sleep state
I (361) sleep_gpio: Enable automatic switching of GPIO sleep configuration
I (369) coexist: coex firmware version: b0bcc39
I (374) coexist: coexist rom version 74f9620
I (379) main_task: Started on CPU0
I (382) main_task: Calling app_main()
I (395) fg_slave: *********************************************************************
I (395) fg_slave:                 ESP-Hosted Firmware version :: FG-1.0.0.0.0
I (403) fg_slave:                 Transport used :: SPI only                      
I (411) fg_slave: *********************************************************************
I (420) fg_slave: Using GPIO [7] as slave reset pin
I (426) h_bt: ESP Bluetooth MAC addr: FF:FF:FF:FF:FF:FF
I (432) BLE_INIT: BT controller compile version [2edb0b0]
I (438) BLE_INIT: Using main XTAL as clock source
I (443) BLE_INIT: Feature Config, ADV:1, BLE_50:1, DTM:1, SCAN:1, CCA:0, SMP:1, CONNECT:1
I (452) BLE_INIT: Bluetooth MAC: FF:FF:FF:FF:FF:FF
I (458) phy_init: phy_version 1201,bae5dd99,Mar  3 2025,15:36:21
I (495) SPI_DRIVER: Using SPI interface
I (496) SPI_DRIVER: SPI Ctrl:1 mode: 3, Freq:ConfigAtHost
GPIOs: MOSI: 1, MISO: 2, CS: 4, CLK: 3 HS: 5 DR: 6

I (499) SPI_DRIVER: TX Queues:20
I (503) SPI_DRIVER: RX Queues:20
E (508) gpio: gpio_install_isr_service(526): GPIO isr service already installed
I (518) pp: pp rom version: 74f9620
I (520) net80211: net80211 rom version: 74f9620
I (527) wifi:wifi driver task: 3fcbd924, prio:23, stack:6656, core=0
I (538) wifi:wifi firmware version: 14da9b7
I (538) wifi:wifi certification version: v7.0
I (539) wifi:config NVS flash: enabled
I (543) wifi:config nano formatting: disabled
I (547) wifi:Init data frame dynamic rx buffer num: 32
I (552) wifi:Init static rx mgmt buffer num: 5
I (556) wifi:Init management short buffer num: 32
I (560) wifi:Init dynamic tx buffer num: 32
I (564) wifi:Init static tx FG buffer num: 2
I (568) wifi:Init static rx buffer size: 1600
I (573) wifi:Init static rx buffer num: 10
I (576) wifi:Init dynamic rx buffer num: 32
I (581) wifi_init: rx ba win: 16
I (584) wifi_init: accept mbox: 6
I (588) wifi_init: tcpip mbox: 32
I (592) wifi_init: udp mbox: 16
I (596) wifi_init: tcp mbox: 16
I (600) wifi_init: tcp tx win: 11520
I (604) wifi_init: tcp rx win: 11520
I (608) wifi_init: tcp mss: 1440
I (612) wifi_init: WiFi IRAM OP enabled
I (617) wifi_init: WiFi RX IRAM OP enabled
I (622) fg_slave: SSID: @MYWIFI
I (625) fg_slave: Wifi provisioned
I (629) wifi:Set ps type: 0, coexist: 0

I (634) wifi:mode : sta (FF:FF:FF:FF:FF:FF)
I (637) wifi:enable tsf
I (640) fg_slave: bus tx locked on slave boot-up
I (644) fg_slave: bus tx unlocked
I (647) wifi:new:<6,0>, old:<1,0>, ap:<255,255>, sta:<6,0>, prof:6, snd_ch_cfg:0x0
I (656) wifi:state: init -> auth (0xb0)
I (660) fg_slave: host reset handler task started
I (665) fg_slave: Supported features are:
I (669) fg_slave: - WLAN over SPI
I (673) h_bt: - BT/BLE
I (676) h_bt:    - HCI Over SPI
I (679) wifi:state: auth -> assoc (0x0)
I (684) h_bt:    - BLE only
I (687) fg_slave: capabilities: 0xe8
I (691) fg_slave: Send slave up event
I (694) wifi:state: assoc -> run (0x10)
I (700) SPI_DRIVER: Slave chip Id[2]
I (704) slave_ctrl: event ESPInit
I (708) slave_ctrl: Registering handler 0x42009f0e for custom packed RPC request
I (716) main_task: Returned from app_main()
I (749) slave_ctrl: Get station mac address
I (749) slave_ctrl: mac [FF:FF:FF:FF:FF:FF] 
I (793) wifi:connected with @MYWIFI, aid = 2, channel 6, BW20, bssid = FF:FF:FF:FF:FF:FF
I (794) wifi:security: WPA2-PSK, phy: bgn, rssi: -40
I (796) wifi:pm start, type: 0

I (798) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
I (806) wifi:set rx beacon pti, rx_bcn_pti: 14, bcn_timeout: 25000, mt_pti: 14, mt_time: 10000
I (815) slave_ctrl: Get softap mac address
I (819) slave_ctrl: mac [FF:FF:FF:FF:FF:FF] 
I (824) slave_ctrl: --- Station connected @MYWIFI ---
I (840) wifi:AP's beacon interval = 102400 us, DTIM period = 3
I (1390) slave_ctrl: mac [FF:FF:FF:FF:FF:FF] 
I (1390) slave_ctrl: SSID: @MYWIFI
I (1390) slave_ctrl: Wifi provisioned
I (1392) slave_ctrl: WiFi config unchanged, keeping current connection
I (1400) slave_ctrl: No change in Wi-Fi config. Send connected event to host
I (2605) wifi:<ba-add>idx:0 (ifx:0, FF:FF:FF:FF:FF:FF), tid:0, ssn:3, winSize:64
I (30517) stats: STA: flw_ctrl(on[0] off[0]) H2S(in[2] out[2] fail[0]) S2H(in[134] out[139]) Ctrl: (in[4] rsp[7] evt[0])
I (60517) stats: STA: flw_ctrl(on[0] off[0]) H2S(in[3] out[3] fail[0]) S2H(in[270] out[278]) Ctrl: (in[4] rsp[7] evt[0])

```