### PR TITLE
tests: drivers: can: api: pick a platform for the NXP S32 CANXL test

### DIFF
--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -21,4 +21,8 @@ tests:
   drivers.can.api.nxp_s32_canxl.non_rx_fifo:
     extra_configs:
       - CONFIG_CAN_NXP_S32_RX_FIFO=n
-    filter: dt_compat_enabled("nxp,s32-canxl")
+    platform_allow:
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1


### PR DESCRIPTION
Pick a specific platform for the NXP S32 CANXL specific test configuration instead of relying on build-time filtering on all twister invocations.