### PR TITLE
tests: subsys: fat-fs: sdmmc enhance

### DIFF
--- a/tests/subsys/fs/fat_fs_api/prj_sdmmc.conf
+++ b/tests/subsys/fs/fat_fs_api/prj_sdmmc.conf
@@ -1,6 +1,22 @@
 CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_MKFS=y
 CONFIG_LOG=y
 CONFIG_FAT_FILESYSTEM_ELM=y
+
+# Use the SD card partition table (MBR) instead of super-floppy formatting.
+#
+# - Enable FatFS multi-partition support and provide VolToPart[] mapping in the test.
+# - Disable Zephyr's "format on mount" path for FatFS (it uses FM_SFD, ignoring MBR).
+CONFIG_FS_FATFS_MULTI_PARTITION=y
+CONFIG_FS_FATFS_MOUNT_MKFS=n
+
+# Make sure FatFS drive 0 maps to the SD disk string "SD" on all platforms.
+CONFIG_FS_FATFS_CUSTOM_MOUNT_POINT_COUNT=1
+CONFIG_FS_FATFS_CUSTOM_MOUNT_POINTS="SD"
+
+# Align FATFS internal window buffer and SDHC IO buffers.
+CONFIG_FS_FATFS_WINDOW_ALIGNMENT=32
+
 CONFIG_ZTEST=y
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_ZTEST_STACK_SIZE=2048

--- a/tests/subsys/fs/fat_fs_api/src/common.c
+++ b/tests/subsys/fs/fat_fs_api/src/common.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2023 Husqvarna AB
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,12 +11,26 @@
 #include <zephyr/storage/flash_map.h>
 #else
 #include <zephyr/storage/disk_access.h>
+#include <zephyr/sys/byteorder.h>
 #endif
 
 /* FatFs work area */
 FATFS fat_fs;
 struct fs_file_t filep;
 const char test_str[] = "hello world!";
+
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+/*
+ * FatFS multi-partition mapping.
+ *
+ * Map logical drive 0 ("SD:") -> physical disk 0, MBR partition #1.
+ * This allows formatting/mounting within the partition rather than using
+ * super-floppy formatting on the whole card.
+ */
+PARTITION VolToPart[] = {
+	{0, 1},
+};
+#endif
 
 /* For large disks, we only send 1024 erase requests
  * This assumption relies on the fact that any filesystem headers will be
@@ -44,8 +59,7 @@ int wipe_partition(void)
 	int rc = flash_area_open(id, &pfa);
 
 	if (rc < 0) {
-		TC_PRINT("Error accessing flash area %u [%d]\n",
-			 id, rc);
+		TC_PRINT("Error accessing flash area %u [%d]\n", id, rc);
 		return TC_FAIL;
 	}
 
@@ -54,15 +68,14 @@ int wipe_partition(void)
 	(void)flash_area_close(pfa);
 
 	if (rc < 0) {
-		TC_PRINT("Error wiping flash area %u [%d]\n",
-			 id, rc);
+		TC_PRINT("Error wiping flash area %u [%d]\n", id, rc);
 		return TC_FAIL;
 	}
 
 	return TC_PASS;
 }
 #else
-static uint8_t erase_buffer[4096] = { 0 };
+static uint8_t erase_buffer[4096] __aligned(32) = {0};
 
 int wipe_partition(void)
 {
@@ -71,16 +84,49 @@ int wipe_partition(void)
 	uint32_t sector_wr_jmp;
 	uint32_t sector_wr_size;
 
+	/*
+	 * When using FatFS multi-partition, preserve the partition table (MBR) and
+	 * only wipe the beginning of the first partition.
+	 */
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+	static uint8_t mbr[512] __aligned(32);
+	uint32_t part_lba;
+	uint32_t part_sectors;
+#endif
+
 	if (disk_access_init(DISK_NAME)) {
-		TC_PRINT("Failed to init disk "DISK_NAME"\n");
+		TC_PRINT("Failed to init disk " DISK_NAME "\n");
 		return TC_FAIL;
 	}
+
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+	if (disk_access_read(DISK_NAME, mbr, 0, 1)) {
+		TC_PRINT("Failed to read MBR from disk " DISK_NAME "\n");
+		return TC_FAIL;
+	}
+
+	/* Verify MBR signature 0x55AA */
+	if (mbr[510] != 0x55 || mbr[511] != 0xAA) {
+		TC_PRINT("Invalid MBR signature on disk " DISK_NAME "\n");
+		return TC_FAIL;
+	}
+
+	/* First partition entry starts at offset 446. Start LBA is at +8, size at +12 */
+	part_lba = sys_get_le32(&mbr[446 + 8]);
+	part_sectors = sys_get_le32(&mbr[446 + 12]);
+
+	if (part_lba == 0U || part_sectors == 0U) {
+		TC_PRINT("MBR partition #1 not found/invalid on disk " DISK_NAME "\n");
+		return TC_FAIL;
+	}
+#endif
+
 	if (disk_access_ioctl(DISK_NAME, DISK_IOCTL_GET_SECTOR_COUNT, &sector_count)) {
-		TC_PRINT("Failed to get disk "DISK_NAME" sector count\n");
+		TC_PRINT("Failed to get disk " DISK_NAME " sector count\n");
 		return TC_FAIL;
 	}
 	if (disk_access_ioctl(DISK_NAME, DISK_IOCTL_GET_SECTOR_SIZE, &sector_size)) {
-		TC_PRINT("Failed to get disk "DISK_NAME" sector size\n");
+		TC_PRINT("Failed to get disk " DISK_NAME " sector size\n");
 		return TC_FAIL;
 	}
 
@@ -89,19 +135,30 @@ int wipe_partition(void)
 		return TC_FAIL;
 	}
 
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+	/* Wipe only within the first partition (cap to 64 sectors for speed) */
+	sector_count = MIN(part_sectors, 64U);
+#else
 	if (sector_count > 64) {
 		/* partition only in first 32k */
 		sector_count = 64;
 	}
+#endif
 	sector_wr_size = MIN(sector_size, ARRAY_SIZE(erase_buffer));
 	sector_wr_jmp = sector_wr_size / sector_wr_size;
-	TC_PRINT("For "DISK_NAME" using sector write size %"PRIu32" to write %"PRIu32" at once\n",
+	TC_PRINT("For " DISK_NAME " using sector write size %" PRIu32 " to write %" PRIu32
+		 " at once\n",
 		 sector_wr_size, sector_wr_jmp);
 
 	for (uint32_t sector_idx = 0; sector_idx < sector_count; sector_idx += sector_wr_jmp) {
-		if (disk_access_write(DISK_NAME, erase_buffer, sector_idx, 1)) {
-			TC_PRINT("Failed to \"erase\" sector %"PRIu32" to "DISK_NAME"\n",
-				 sector_idx);
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+		uint32_t phys_sector = part_lba + sector_idx;
+#else
+		uint32_t phys_sector = sector_idx;
+#endif
+		if (disk_access_write(DISK_NAME, erase_buffer, phys_sector, 1)) {
+			TC_PRINT("Failed to \"erase\" sector %" PRIu32 " to " DISK_NAME "\n",
+				 phys_sector);
 			return TC_FAIL;
 		}
 	}

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -9,7 +9,7 @@
 
 #include "test_fat.h"
 void test_fs_open_flags(void);
-const char *test_fs_open_flags_file_path =  FATFS_MNTP"/the_file.txt";
+const char *test_fs_open_flags_file_path = FATFS_MNTP "/the_file.txt";
 
 /* Time integration for filesystem */
 DWORD get_fattime(void)


### PR DESCRIPTION
1. modern SD card usually very large > 4G, which makes the
test out of memory for most of MCU boards, so limited to
a small partition for testing(16M) recommend.
2. add alignment to io buffers for fat_fs.c
