### PR TITLE
MAINTAINERS: add mbittan as collaborator for NXP LPC11U6x

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3760,6 +3760,7 @@ NXP Platforms (MCU):
     - name: NXP MCU LPC11U6x
       collaborators:
         - simonguinot
+        - mbittan
       files:
         - boards/nxp/lpcxpresso11u68/
         - soc/nxp/lpc/lpc11u6x/


### PR DESCRIPTION
Adds @mbittan as collaborator who contributed the LPC11U6x SOC support and lpcxpresso11u68 board in https://github.com/zephyrproject-rtos/zephyr/pull/25837, so they can help maintain this platform support. Collaborator role requested at https://github.com/zephyrproject-rtos/zephyr/pull/103689#issuecomment-3881137566.