### PR TITLE
.gitignore: Add CMakeStyle.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ tags
 .idea
 
 # from check_compliance.py
-# zephyr-keep-sorted-start
+# zephyr-keep-sorted-start ignorecase
 BinaryFiles.txt
 BoardYml.txt
 Checkpatch.txt

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ BinaryFiles.txt
 BoardYml.txt
 Checkpatch.txt
 ClangFormat.txt
+CMakeStyle.txt
 DevicetreeBindings.txt
 DevicetreeLinting.txt
 GitDiffCheck.txt


### PR DESCRIPTION
CMakeStyle.txt is sometimes generated when running checkpatch.pl, and should never be pushed to the repo.