### PR TITLE
dts: bindings: led_strip: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/led_strip/ti,tlc5971.yaml
+++ b/dts/bindings/led_strip/ti,tlc5971.yaml
@@ -12,8 +12,13 @@ description: |
   The color order of the TLC5971 is BGR. Applications can provide custom mappings
   using the color-mapping property.
 
-  Example device tree node w. 24 pixels (6 TLC5971 devices):
+compatible: "ti,tlc5971"
 
+include: [spi-device.yaml, led-strip.yaml]
+
+examples:
+  - |
+    /* Example Devicetree node with 24 pixels (6 daisy-chained TLC5971 devices):
     &spi1 {
       led_controller: led_controller@0 {
         status = "okay";
@@ -26,7 +31,3 @@ description: |
                         <LED_COLOR_ID_RED>;
       };
     };
-
-compatible: "ti,tlc5971"
-
-include: [spi-device.yaml, led-strip.yaml]

--- a/dts/bindings/led_strip/worldsemi,ws2812-gpio.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-gpio.yaml
@@ -30,46 +30,6 @@ description: |
      |               |         |
   ---+               +---------+
 
-
-  Example dts file:
-  / {
-        cpus {
-            cpu@0 {
-                clock-frequency = <64000000>;
-            };
-        };
-
-        rgb_led: ws2812 {
-            compatible = "worldsemi,ws2812-gpio";
-            chain-length = <1>;
-            color-mapping = <LED_COLOR_ID_GREEN
-                             LED_COLOR_ID_RED
-                             LED_COLOR_ID_BLUE>;
-            gpios = <&gpio0 16 0>;
-        };
-  };
-
-  Example dts file:
-  / {
-        chosen {
-            zephyr,led-strip = &rgb_led;
-        };
-
-        rgb_led: ws2812 {
-            compatible = "worldsemi,ws2812-gpio";
-            chain-length = <1>;
-            color-mapping = <LED_COLOR_ID_GREEN
-                             LED_COLOR_ID_RED
-                             LED_COLOR_ID_BLUE>;
-            reset-delay = <50>;
-            gpios = <&gpio0 16 0>;
-            delay-t1h = <48>;
-            delay-t1l = <32>;
-            delay-t0h = <16>;
-            delay-t0l = <32>;
-        };
-  };
-
 compatible: "worldsemi,ws2812-gpio"
 
 include: [base.yaml, ws2812-gpio.yaml]
@@ -98,3 +58,43 @@ properties:
     description: |
       Number of NOP assembly operations to create a delay for a 0 bit, low
       voltage period (default 800 nsec)
+
+examples:
+  - |
+    / {
+          cpus {
+              cpu@0 {
+                  clock-frequency = <64000000>;
+              };
+          };
+
+          rgb_led: ws2812 {
+              compatible = "worldsemi,ws2812-gpio";
+              chain-length = <1>;
+              color-mapping = <LED_COLOR_ID_GREEN
+                               LED_COLOR_ID_RED
+                               LED_COLOR_ID_BLUE>;
+              gpios = <&gpio0 16 0>;
+          };
+    };n
+
+  - |
+    / {
+          chosen {
+              zephyr,led-strip = &rgb_led;
+          };
+
+          rgb_led: ws2812 {
+              compatible = "worldsemi,ws2812-gpio";
+              chain-length = <1>;
+              color-mapping = <LED_COLOR_ID_GREEN
+                               LED_COLOR_ID_RED
+                               LED_COLOR_ID_BLUE>;
+              reset-delay = <50>;
+              gpios = <&gpio0 16 0>;
+              delay-t1h = <48>;
+              delay-t1l = <32>;
+              delay-t0h = <16>;
+              delay-t0l = <32>;
+          };
+    };

--- a/dts/bindings/led_strip/worldsemi,ws2812-uart.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-uart.yaml
@@ -40,37 +40,6 @@ description: |
   each bit of pixel data, the driver generates a symbol of N bits (where N
   is the value of `bits-per-symbol`), which are then packed into the buffer.
 
-  An example of an overlay:
-
-  &uart1 {
-      status = "okay";
-      /* Target baudrate is 800kHz * 3 = 2.4MHz. 2.5MHz is a close value. */
-      current-speed = <2500000>;
-      /* Frame constraint: (1 start + 7 data + 1 stop) = 9 bits total. */
-      data-bits = <7>;
-      /* tx-invert is required to create an idle-low signal. */
-      tx-invert;
-
-      led_strip: ws2812-strip {
-          compatible = "worldsemi,ws2812-uart";
-          status = "okay";
-
-          /* Timing based on 2.5MHz baudrate (400ns per bit):
-           * T1H for '1' bit (2 high bits) = 2 * 400ns = 800ns.
-           * T0H for '0' bit (1 high bit) = 1 * 400ns = 400ns.
-           */
-          one-symbol = <6>;   /* 0b110 */
-          zero-symbol = <4>;  /* 0b100 */
-          bits-per-symbol = <3>;
-
-          chain-length = <8>;
-          reset-delay = <50>;
-          color-mapping = <LED_COLOR_ID_GREEN
-                           LED_COLOR_ID_RED
-                           LED_COLOR_ID_BLUE>;
-      };
-  };
-
 compatible: "worldsemi,ws2812-uart"
 
 include: [ws2812.yaml, uart-device.yaml]
@@ -102,3 +71,34 @@ properties:
     description: |
       The number of UART bits used to represent a single WS2812 data bit.
       The value must be between 3 and 10, inclusive.
+
+examples:
+  - |
+    &uart1 {
+        status = "okay";
+        /* Target baudrate is 800kHz * 3 = 2.4MHz. 2.5MHz is a close value. */
+        current-speed = <2500000>;
+        /* Frame constraint: (1 start + 7 data + 1 stop) = 9 bits total. */
+        data-bits = <7>;
+        /* tx-invert is required to create an idle-low signal. */
+        tx-invert;
+
+        led_strip: ws2812-strip {
+            compatible = "worldsemi,ws2812-uart";
+            status = "okay";
+
+            /* Timing based on 2.5MHz baudrate (400ns per bit):
+             * T1H for '1' bit (2 high bits) = 2 * 400ns = 800ns.
+             * T0H for '0' bit (1 high bit) = 1 * 400ns = 400ns.
+             */
+            one-symbol = <6>;   /* 0b110 */
+            zero-symbol = <4>;  /* 0b100 */
+            bits-per-symbol = <3>;
+
+            chain-length = <8>;
+            reset-delay = <50>;
+            color-mapping = <LED_COLOR_ID_GREEN
+                             LED_COLOR_ID_RED
+                             LED_COLOR_ID_BLUE>;
+        };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.