### PR TITLE
dts: bindings: video: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/video/himax,hm01b0.yaml
+++ b/dts/bindings/video/himax,hm01b0.yaml
@@ -7,23 +7,6 @@
 description: |
     Himax HM01B0 video sensor.
 
-    Example of node configuration:
-
-    &i2c0 {
-      status = "okay";
-      hm01b0: hm01b0@24 {
-        compatible = "himax,hm01b0";
-        reg = <0x24>;
-        status = "okay";
-        data-bits = <0x4>;
-        port {
-          hm01b0_ep_out: endpoint {
-            remote-endpoint-label = "video_pio_dma_ep_in";
-          };
-        };
-      };
-    };
-
 compatible: "himax,hm01b0"
 properties:
   data-bits:
@@ -39,3 +22,20 @@ include: i2c-device.yaml
 child-binding:
   child-binding:
     include: video-interfaces.yaml
+
+examples:
+  - |
+    &i2c0 {
+      status = "okay";
+      hm01b0: hm01b0@24 {
+        compatible = "himax,hm01b0";
+        reg = <0x24>;
+        status = "okay";
+        data-bits = <0x4>;
+        port {
+          hm01b0_ep_out: endpoint {
+            remote-endpoint-label = "video_pio_dma_ep_in";
+          };
+        };
+      };
+    };

--- a/dts/bindings/video/himax,hm0360.yaml
+++ b/dts/bindings/video/himax,hm0360.yaml
@@ -7,25 +7,6 @@
 description: |
   HM0360 CMOS video sensor.
 
-  Example of node configuration:
-
-  &i2c4
-  {
-    status = "okay";
-    hm0360: hm0360@24{
-      compatible = "himax,hm0360";
-      reg = <0x24>;
-      status = "okay";
-      reset-gpios = <&gpiod 4 GPIO_ACTIVE_LOW>;
-      pwdn-gpios = <&gpioa 1 GPIO_ACTIVE_LOW>;
-      port {
-        hm0360_ep_out: endpoint {
-          remote-endpoint-label = "video_pio_dma_ep_in";
-        };
-      };
-    };
-  };
-
 compatible: "himax,hm0360"
 
 include: i2c-device.yaml
@@ -45,3 +26,22 @@ properties:
 child-binding:
   child-binding:
     include: video-interfaces.yaml
+
+examples:
+  - |
+    &i2c4
+    {
+      status = "okay";
+      hm0360: hm0360@24{
+        compatible = "himax,hm0360";
+        reg = <0x24>;
+        status = "okay";
+        reset-gpios = <&gpiod 4 GPIO_ACTIVE_LOW>;
+        pwdn-gpios = <&gpioa 1 GPIO_ACTIVE_LOW>;
+        port {
+          hm0360_ep_out: endpoint {
+            remote-endpoint-label = "video_pio_dma_ep_in";
+          };
+        };
+      };
+    };

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -10,26 +10,6 @@ description: |
     The STM32 DCMI (Digital Camera Memory Interface) allows
     capturing data via a parallel interface (DVP).
 
-    Example of node configuration at board level:
-
-    &dcmi {
-      status = "okay";
-      pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pb7
-                  &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
-                  &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;
-      pinctrl-names = "default";
-
-      port {
-        dcmi_ep_in: endpoint {
-          remote-endpoint-label = "ov2640_ep_out";
-          bus-width = <8>;
-          hsync-active = <0>;
-          vsync-active = <0>;
-          pclk-sample = <1>;
-        };
-      };
-    };
-
 compatible: "st,stm32-dcmi"
 
 include: [base.yaml, pinctrl-device.yaml]
@@ -52,3 +32,23 @@ properties:
 child-binding:
   child-binding:
     include: video-interfaces.yaml
+
+examples:
+  - |
+    &dcmi {
+      status = "okay";
+      pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pb7
+                   &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
+                   &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;
+      pinctrl-names = "default";
+
+      port {
+        dcmi_ep_in: endpoint {
+          remote-endpoint-label = "ov2640_ep_out";
+          bus-width = <8>;
+          hsync-active = <0>;
+          vsync-active = <0>;
+          pclk-sample = <1>;
+        };
+      };
+    };

--- a/dts/bindings/video/st,stm32-dcmipp.yaml
+++ b/dts/bindings/video/st,stm32-dcmipp.yaml
@@ -13,25 +13,6 @@ description: |
     performing frame operations, including one pipeline with ISP functionality
     enabled.
 
-    Example of node configuration at board level:
-
-    &dcmipp {
-      status = "okay";
-
-      ports {
-        #address-cells = <1>;
-        #size-cells = <0>;
-
-        port@0 {
-          reg = <0>;
-          dcmipp_ep_in: endpoint {
-            remote-endpoint-label = "imx335_ep_out";
-            data-lanes = <1 2>;
-          };
-        };
-      };
-    };
-
 compatible: "st,stm32-dcmipp"
 
 include: [base.yaml, pinctrl-device.yaml, reset-device.yaml]
@@ -59,3 +40,22 @@ child-binding:
     properties:
       bus-type:
         required: true
+
+examples:
+  - |
+    &dcmipp {
+      status = "okay";
+
+      ports {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        port@0 {
+          reg = <0>;
+          dcmipp_ep_in: endpoint {
+            remote-endpoint-label = "imx335_ep_out";
+            data-lanes = <1 2>;
+          };
+        };
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.

<img width="1209" height="855" alt="image" src="https://github.com/user-attachments/assets/ac276db4-4317-4667-9192-04310daf05d4" />