### PR TITLE
dts: bindings: regulator: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/regulator/cirrus,cp9314.yaml
+++ b/dts/bindings/regulator/cirrus,cp9314.yaml
@@ -4,12 +4,6 @@
 description: |
   Cirrus CP9314 Buck Switched Cap DC/DC Converter
 
-  converter@72 {
-    compatible = "cirrus,cp9314";
-    reg = <0x72>;
-
-    cirrus,initial-switched-capacitor-mode = "2:1";
-  };
 compatible: "cirrus,cp9314"
 
 include:
@@ -44,3 +38,12 @@ properties:
     description: |
       Indicate if the hardware write lock was enabled via the resistor value applied to
       PGPIO2.
+
+examples:
+  - |
+    converter@72 {
+      compatible = "cirrus,cp9314";
+      reg = <0x72>;
+
+      cirrus,initial-switched-capacitor-mode = "2:1";
+    };

--- a/dts/bindings/regulator/regulator-gpio.yaml
+++ b/dts/bindings/regulator/regulator-gpio.yaml
@@ -4,25 +4,6 @@
 description: |
   GPIO-controlled voltage of regulators
 
-  Example of dts node:
-    vccq_sd0: regulator-vccq-sd0 {
-      compatible = "regulator-gpio";
-
-      regulator-name = "SD0 VccQ";
-      regulator-min-microvolt = <1800000>;
-      regulator-max-microvolt = <3300000>;
-
-      enable-gpios = <&gpio5 3 GPIO_ACTIVE_HIGH>;
-
-      gpios = <&gpio5 1 GPIO_ACTIVE_HIGH>, <&gpio5 2 GPIO_ACTIVE_HIGH>;
-      states = <3300000 2>, <2700000 1>, <1800000 0>;
-
-      regulator-boot-on;
-    };
-  In the above example, three GPIO pins are used for controlling the regulator:
-    * two of them for controlling voltage;
-    * third for enabling/disabling the regulator.
-
 include:
   - name: base.yaml
   - name: regulator.yaml
@@ -70,3 +51,25 @@ properties:
 
       Example:
         enable-gpios = <&gpio5 2 GPIO_ACTIVE_HIGH>;
+
+examples:
+  - |
+    /*
+     * In the below example, three GPIO pins are used for controlling the regulator:
+     * - two of them for controlling voltage;
+     * - third one for enabling/disabling the regulator.
+     */
+    vccq_sd0: regulator-vccq-sd0 {
+      compatible = "regulator-gpio";
+
+      regulator-name = "SD0 VccQ";
+      regulator-min-microvolt = <1800000>;
+      regulator-max-microvolt = <3300000>;
+
+      enable-gpios = <&gpio5 3 GPIO_ACTIVE_HIGH>;
+
+      gpios = <&gpio5 1 GPIO_ACTIVE_HIGH>, <&gpio5 2 GPIO_ACTIVE_HIGH>;
+      states = <3300000 2>, <2700000 1>, <1800000 0>;
+
+      regulator-boot-on;
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.
<img width="917" height="789" alt="image" src="https://github.com/user-attachments/assets/b90a9d54-20d6-45ba-98d1-0ccfa6ede3b2" />
