### PR TITLE
dts: bindings: led: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/led/dac-leds.yaml
+++ b/dts/bindings/led/dac-leds.yaml
@@ -7,33 +7,6 @@ title: Group of DAC-controlled LEDs.
 description: |
   Each LED is defined in a child node of the dac-leds node.
 
-  Here is an example which defines an LED in the node /leds:
-
-  / {
-          leds {
-                  compatible = "dac-leds";
-                  led_0 {
-                          dac-dev = <&dac1>;
-                          channel = <0>;
-                          resolution = <12>;
-                  };
-                  led_1 {
-                          dac-dev = <&dac1>;
-                          channel = <1>;
-                          resolution = <12>;
-                          voltage-min-brightness-mv = <1400>;
-                          voltage-max-brightness-mv = <2700>;
-                          voltage-max-dac-mv = <3300>;
-                          output-buffer;
-                  };
-          };
-  };
-
-  Above:
-
-  - led_0 uses dac1 channel 0 with 12 bit resolution.
-  - led_1 uses dac1 channel 1 with 12 bit resolution and setup to supply an LED directly.
-
 compatible: "dac-leds"
 
 child-binding:
@@ -80,3 +53,29 @@ child-binding:
       description: |
         Enable the output buffer of the DAC.
         This is required if it is used to drive an LED directly.
+
+examples:
+  - |
+    / {
+            leds {
+                    compatible = "dac-leds";
+                    /* led_0 uses dac1 channel 0 with 12 bit resolution. */
+                    led_0 {
+                            dac-dev = <&dac1>;
+                            channel = <0>;
+                            resolution = <12>;
+                    };
+                    /* led_1 uses dac1 channel 1 with 12 bit resolution and is setup to supply an
+                     * LED directly.
+                     */
+                    led_1 {
+                            dac-dev = <&dac1>;
+                            channel = <1>;
+                            resolution = <12>;
+                            voltage-min-brightness-mv = <1400>;
+                            voltage-max-brightness-mv = <2700>;
+                            voltage-max-dac-mv = <3300>;
+                            output-buffer;
+                    };
+            };
+    };

--- a/dts/bindings/led/gpio-leds.yaml
+++ b/dts/bindings/led/gpio-leds.yaml
@@ -6,32 +6,6 @@ description: |
 
   Each LED is defined in a child node of the gpio-leds node.
 
-  Here is an example which defines three LEDs in the node /leds:
-
-  / {
-  	leds {
-  		compatible = "gpio-leds";
-  		led_0 {
-  			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-  		};
-  		led_1 {
-  			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-  		};
-  		led_2 {
-  			gpios = <&gpio1 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-  		};
-  	};
-  };
-
-  Above:
-
-  - led_0 is pin 1 on gpio0. The LED is on when the pin is low,
-    and off when the pin is high.
-  - led_1 is pin 2 on gpio0. The LED is on when the pin is high,
-    and off when it is low.
-  - led_2 is pin 15 on gpio1. The LED is on when the pin is low,
-    and the pin's internal pull-up resistor should be enabled.
-
 compatible: "gpio-leds"
 
 child-binding:
@@ -46,3 +20,33 @@ child-binding:
     gpios:
       type: phandle-array
       required: true
+
+examples:
+  - |
+    / {
+      leds {
+        compatible = "gpio-leds";
+        /*
+         * led_0 is pin 1 on gpio0.
+         * The LED is on when the pin is low, and off when the pin is high.
+         */
+        led_0 {
+          gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+        };
+        /*
+         * led_1 is pin 2 on gpio0.
+         * The LED is on when the pin is high, and off when it is low.
+         */
+        led_1 {
+          gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+        };
+        /*
+         * led_2 is pin 15 on gpio1.
+         * The LED is on when the pin is low, and the pin's internal pull-up resistor should be
+         * enabled.
+         */
+        led_2 {
+          gpios = <&gpio1 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+        };
+      };
+    };

--- a/dts/bindings/led/issi,is31fl3194.yaml
+++ b/dts/bindings/led/issi,is31fl3194.yaml
@@ -10,46 +10,6 @@ description: |
   blue components; the driver takes care of routing to the outputs described
   by the color-mapping property.
 
-  The LED_SHELL application can be used for testing.
-
-  The following defines a single RGB LED in the is31fl3194 DT node:
-
-    is31fl3194@53 {
-      compatible = "issi,is31fl3194";
-      reg = <0x53>;
-
-      led_0 {
-        label = "RGB LED";
-        color-mapping =
-          <LED_COLOR_ID_RED>,
-          <LED_COLOR_ID_GREEN>,
-          <LED_COLOR_ID_BLUE>;
-      };
-    };
-
-  The following example defines three single-channel LEDs in the is31fl3194 DT node:
-
-    is31fl3194@53 {
-      compatible = "issi,is31fl3194";
-      reg = <0x53>;
-
-      led_0 {
-        label = "RED LED";
-        color-mapping = <LED_COLOR_ID_RED>;
-      };
-
-      led_1 {
-        label = "GREEN LED";
-        color-mapping = <LED_COLOR_ID_GREEN>;
-      };
-
-      led_2 {
-        label = "BLUE LED";
-        color-mapping = <LED_COLOR_ID_BLUE>;
-      };
-    };
-
-
 compatible: "issi,is31fl3194"
 
 include: ["i2c-device.yaml", "led-controller.yaml"]
@@ -72,3 +32,40 @@ child-binding:
       required: true
       description: |
         The current limit for the LED in mA.
+
+examples:
+  - |
+    /* Single RGB LED */
+    is31fl3194@53 {
+      compatible = "issi,is31fl3194";
+      reg = <0x53>;
+
+      led_0 {
+        label = "RGB LED";
+        color-mapping =
+          <LED_COLOR_ID_RED>,
+          <LED_COLOR_ID_GREEN>,
+          <LED_COLOR_ID_BLUE>;
+      };
+    };
+  - |
+    /* Three single-channel LEDs */
+    is31fl3194@53 {
+      compatible = "issi,is31fl3194";
+      reg = <0x53>;
+
+      led_0 {
+        label = "RED LED";
+        color-mapping = <LED_COLOR_ID_RED>;
+      };
+
+      led_1 {
+        label = "GREEN LED";
+        color-mapping = <LED_COLOR_ID_GREEN>;
+      };
+
+      led_2 {
+        label = "BLUE LED";
+        color-mapping = <LED_COLOR_ID_BLUE>;
+      };
+    };

--- a/dts/bindings/led/leds-group-multicolor.yaml
+++ b/dts/bindings/led/leds-group-multicolor.yaml
@@ -4,38 +4,8 @@
 title: Combines several monochromatic LEDs into one multi-color LED.
 
 description: |
-  Here is an example that defines an RGB LED with a group of monochromatic
-  PWM LEDs. Note that the pwms property definition handle depends on the PWM
-  controller model. In this example, an STM32 PWM controller is assumed.
-
-  #include <zephyr/dt-bindings/led/led.h>
-
-  / {
-          monochromatic-leds {
-                  compatible = "pwm-leds";
-
-                  red_pwm_led: led-0 {
-                          pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-                  };
-
-                  green_pwm_led: led-1 {
-                          pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-                  };
-
-                  blue_pwm_led: led-2 {
-                          pwms = <&pwm3 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-                  };
-          };
-
-          rgb-led {
-                  compatible = "leds-group-multicolor";
-
-                  leds = <&red_pwm_led>, <&green_pwm_led>, <&blue_pwm_led>;
-                  color-mapping = <LED_COLOR_ID_RED>,
-                                  <LED_COLOR_ID_GREEN>,
-                                  <LED_COLOR_ID_BLUE>;
-          };
-  };
+  Defines an RGB LED with a group of monochromatic PWM LEDs. Note that the
+  pwms property definition handle depends on the PWM controller model.
 
 compatible: "leds-group-multicolor"
 
@@ -47,3 +17,35 @@ properties:
     type: phandles
     description: |
       References to monochromatic LED nodes.
+
+examples:
+  - |
+    /* Example where PWM controller is STM32 */
+    #include <zephyr/dt-bindings/led/led.h>
+
+    / {
+            monochromatic-leds {
+                    compatible = "pwm-leds";
+
+                    red_pwm_led: led-0 {
+                            pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+                    };
+
+                    green_pwm_led: led-1 {
+                            pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+                    };
+
+                    blue_pwm_led: led-2 {
+                            pwms = <&pwm3 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+                    };
+            };
+
+            rgb-led {
+                    compatible = "leds-group-multicolor";
+
+                    leds = <&red_pwm_led>, <&green_pwm_led>, <&blue_pwm_led>;
+                    color-mapping = <LED_COLOR_ID_RED>,
+                                    <LED_COLOR_ID_GREEN>,
+                                    <LED_COLOR_ID_BLUE>;
+            };
+    };

--- a/dts/bindings/led/onnn,ncp5623.yaml
+++ b/dts/bindings/led/onnn,ncp5623.yaml
@@ -5,53 +5,6 @@
 description: |
   NCP5623 Triple Output I2C Controlled RGB LED driver
 
-  The LED_SHELL application can be used for testing
-
-  The following example defines a single RGB LED in the ncp5623 DT node
-
-  ncp5623c@39 {
-    compatible = "onnn,ncp5623";
-    reg = <0x39>;
-
-    led_0 {
-      label = "RGB LED";
-      index = <0>;
-      color-mapping =
-        <LED_COLOR_ID_RED>,
-        <LED_COLOR_ID_GREEN>,
-        <LED_COLOR_ID_BLUE>;
-    };
-  };
-
-  The following example defines three single-channel LEDs in the ncp5623 DT node
-
-  ncp5623c@39 {
-    compatible = "onnn,ncp5623";
-    reg = <0x39>;
-
-    led_0 {
-      label = "RED LED";
-      index = <0>;
-      color-mapping =
-        <LED_COLOR_ID_RED>;
-    };
-
-    led_1 {
-      label = "GREEN LED";
-      index = <1>;
-      color-mapping =
-        <LED_COLOR_ID_GREEN>;
-    };
-
-    led_2 {
-      label = "BLUE LED";
-      index = <2>;
-      color-mapping =
-        <LED_COLOR_ID_BLUE>;
-    };
-  };
-
-
 compatible: "onnn,ncp5623"
 
 include: ["i2c-device.yaml", "led-controller.yaml"]
@@ -66,3 +19,47 @@ child-binding:
 
     color-mapping:
       required: true
+
+examples:
+  - |
+    /* Single RGB LED */
+    ncp5623c@39 {
+      compatible = "onnn,ncp5623";
+      reg = <0x39>;
+
+      led_0 {
+        label = "RGB LED";
+        index = <0>;
+        color-mapping =
+          <LED_COLOR_ID_RED>,
+          <LED_COLOR_ID_GREEN>,
+          <LED_COLOR_ID_BLUE>;
+      };
+    };
+  - |
+    /* Three single-channel LEDs */
+    ncp5623c@39 {
+      compatible = "onnn,ncp5623";
+      reg = <0x39>;
+
+      led_0 {
+        label = "RED LED";
+        index = <0>;
+        color-mapping =
+          <LED_COLOR_ID_RED>;
+      };
+
+      led_1 {
+        label = "GREEN LED";
+        index = <1>;
+        color-mapping =
+          <LED_COLOR_ID_GREEN>;
+      };
+
+      led_2 {
+        label = "BLUE LED";
+        index = <2>;
+        color-mapping =
+          <LED_COLOR_ID_BLUE>;
+      };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.

<img width="887" height="943" alt="image" src="https://github.com/user-attachments/assets/fb5877a7-a2eb-4cea-b72e-b0f567c1a2b3" />