### PR TITLE
drivers: ethernet: phy: remove redundant default condition

### DIFF
--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig ETH_PHY_DRIVER
 	bool "Ethernet PHY drivers"
-	default y if NET_L2_ETHERNET || ETH_DRIVER
+	default y
 
 if ETH_PHY_DRIVER
 


### PR DESCRIPTION
menuconfig ETH_PHY_DRIVER is already inside a
`if ETH_DRIVER`, meaning it already depends on it,
therefore the condition for the default y is not needed.