### PR TITLE
dts: bindings: gnss: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/gnss/gnss-nmea-generic.yaml
+++ b/dts/bindings/gnss/gnss-nmea-generic.yaml
@@ -6,17 +6,17 @@ description: |
 
   Implement a generic NMEA based GNSS device.
 
-  Example configuration:
-
-  &uart0 {
-          current-speed = <9600>;
-          ...
-          gnss: gnss-nmea-generic {
-                  compatible = "gnss-nmea-generic";
-          };
-  };
-
 compatible: "gnss-nmea-generic"
 
 include:
   - uart-device.yaml
+
+examples:
+  - |
+    &uart0 {
+            current-speed = <9600>;
+            /* ... */
+            gnss: gnss-nmea-generic {
+                    compatible = "gnss-nmea-generic";
+            };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.