### PR TITLE
dts: nxp: rw6xx: update exit-latency-us and min-residency-us for System Power Management

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -353,3 +353,22 @@ zephyr_mipi_dbi_spi: &lcdic {
 nxp_pmod_touch_panel_i2c: &arduino_i2c {
 	status = "okay";
 };
+
+/* power-states properties:
+ * min-residency-us depends on use-case, and set by the board or app
+ * Idle mode maps to Power Mode 1
+ */
+&idle {
+	min-residency-us = <0>;
+};
+
+/* Suspend mode maps to Power Mode 2 */
+&suspend {
+	min-residency-us = <412>;
+};
+
+/* standby mode maps to Sleep/Power Mode 3 */
+&standby {
+	exit-latency-us = <13460>;
+	min-residency-us = <1690>;
+};

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -340,3 +340,21 @@ nxp_8080_touch_panel_i2c: &arduino_i2c {
 	status = "okay";
 	wakeup-source;
 };
+
+/* power-states properties:
+ * min-residency-us depends on use-case, and set by the board or app
+ * Idle mode maps to Power Mode 1
+ */
+&idle {
+	min-residency-us = <0>;
+};
+
+/* Suspend mode maps to Power Mode 2 */
+&suspend {
+	min-residency-us = <412>;
+};
+
+/* standby mode maps to Sleep/Power Mode 3 */
+&standby {
+	min-residency-us = <1690>;
+};

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -39,11 +39,12 @@
 		};
 
 		power-states {
-			/* Idle mode maps to Power Mode 1 */
+			/* exit-latency-us is the wake time of the SOC
+			 * Idle mode maps to Power Mode 1
+			 */
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				min-residency-us = <60>;
 				exit-latency-us = <38>;
 			};
 
@@ -51,7 +52,6 @@
 			suspend: suspend {
 				compatible = "nxp,pdcfg-power", "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-				min-residency-us = <600>;
 				exit-latency-us = <38>;
 				deep-sleep-config = <0x180000>,
 						    <0x0>,
@@ -64,8 +64,7 @@
 			standby: standby {
 				compatible = "nxp,pdcfg-power", "zephyr,power-state";
 				power-state-name = "standby";
-				min-residency-us = <336000>;
-				exit-latency-us = <14000>;
+				exit-latency-us = <4360>;
 				deep-sleep-config = <0x180000>,
 						    <0x0>,
 						    <0x4>,


### PR DESCRIPTION
- exit-latency-us is SOC wake time.  Updated based on measurements
- exit-latency-us increased for PM3 on frdm_rw612 to match measurements on that board.
- min-residency-us depends on use-case, moved to the board DTS, based on measurements