### PR TITLE
script: west_commands: jlink: Add --reset-type parameter

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -298,6 +298,19 @@ class RunnerCaps:
     - reset: whether the runner supports a --reset option, which
       resets the device after a flash operation is complete.
 
+    - reset_types: whether the runner supports a --reset-type=x option,
+      which specifies a runner specific value for selecting a specific type
+      of reset to use when resetting the device.
+
+    - reset_types_supported: a list of values allowed to be passed with the
+      --reset-type option. If the list of supported reset types is
+      dynamic/device specific, this should be omitted, allowing any value to
+      be set and passed directly to the underlying tool. In addition to these,
+      each runner implementation must always be ready to accept `None` in a
+      runner-specific fashion. For user-friendliness, it is recommended to
+      place first in the list the value which has the behavior identical or
+      most similar to `None`.
+
     - extload: whether the runner supports a --extload option, which
       must be given one time and is passed on to the underlying tool
       that the runner wraps.
@@ -326,6 +339,8 @@ class RunnerCaps:
     flash_addr: bool = False
     erase: bool = False
     reset: bool = False
+    reset_types: bool = False
+    reset_types_supported: list[str] | None = None
     extload: bool = False
     tool_opt: bool = False
     file: bool = False
@@ -639,6 +654,11 @@ class ZephyrBinaryRunner(abc.ABC):
                             help=("reset device after flashing, or don't. "
                                   "Default action depends on each specific runner."
                                   if caps.reset else argparse.SUPPRESS))
+
+        parser.add_argument('--reset-type', dest="reset_type", choices=caps.reset_types_supported,
+                            help=("reset type to use for resetting the device. "
+                                    "Default type depends on each specific runner and target."
+                                    if caps.reset_types else argparse.SUPPRESS))
 
         parser.add_argument('--extload', dest='extload',
                             help=(cls.extload_help() if caps.extload

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -48,9 +48,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, device, dev_id=None,
                  commander=DEFAULT_JLINK_EXE,
-                 dt_flash=True, erase=True, reset=False,
-                 iface='swd', speed='auto', flash_script = None,
-                 loader=None, flash_sram=False,
+                 dt_flash=True, erase=True, reset=False, reset_type=None,
+                 iface='swd', speed='auto',
+                 flash_script = None, loader=None, flash_sram=False,
                  gdbserver='JLinkGDBServer',
                  gdb_host='',
                  gdb_port=DEFAULT_JLINK_GDB_PORT,
@@ -72,6 +72,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.flash_sram = flash_sram
         self.erase = erase
         self.reset = reset
+        self.reset_type = reset_type
         self.gdbserver = gdbserver
         self.iface = iface
         self.speed = speed
@@ -120,7 +121,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt', 'reset'},
-                          dev_id=True, flash_addr=True, erase=True, reset=True,
+                          dev_id=True, flash_addr=True, erase=True, reset=True, reset_types=True,
                           tool_opt=True, file=True, rtt=True, batch_debug=True)
 
     @classmethod
@@ -215,6 +216,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  erase=args.erase,
                                  reset=args.reset,
                                  iface=args.iface, speed=args.speed,
+                                 reset_type=args.reset_type,
                                  flash_script=args.flash_script,
                                  gdbserver=args.gdbserver,
                                  loader=args.loader,
@@ -437,6 +439,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             'r',  # Reset and halt the target
             'BE' if self.build_conf.getboolean('CONFIG_BIG_ENDIAN') else 'LE'
         ]
+
+        if self.reset_type:
+            lines.insert(0, f"RSetType {self.reset_type}")
 
         if self.erase:
             lines.append('erase') # Erase all flash sectors

--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -148,7 +148,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={"flash"}, dev_id=True, erase=True, extload=True, tool_opt=True)
+        return RunnerCaps(commands={"flash"}, dev_id=True, erase=True, extload=True, tool_opt=True,
+                          reset_types=True, reset_types_supported=
+                                         list(STM32CubeProgrammerBinaryRunner._RESET_MODES.keys())
+                          )
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -168,9 +171,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument(
             "--reset-mode",
             type=str,
+            dest="reset_type",
             required=False,
-            choices=["sw", "hw", "core"],
-            help="Reset mode",
+            choices=list(STM32CubeProgrammerBinaryRunner._RESET_MODES.keys()),
+            help="Obsolete synonym for --reset-type",
         )
         parser.add_argument(
             "--download-address",
@@ -234,7 +238,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             port=args.port,
             dev_id=args.dev_id,
             frequency=args.frequency,
-            reset_mode=args.reset_mode,
+            reset_mode=args.reset_type,
             download_address=args.download_address,
             download_modifiers=args.download_modifiers,
             start_address=args.start_address,


### PR DESCRIPTION
For some devices, the default JLink reset type may not work properly, so allow overriding the reset type by passing, e.g. --reset-type=12 when flashing.

Will be adding a follow up PR for MAX32 targets that leverages this, to ensure `reset halt` properly works as expected there. This helps ensure twister hardware tests don't need to bump `BOOT_DELAY` to avoid spurious ztest messages from a test starting to run before the JLink halts it manually after the reset.