### PR TITLE
doc: bluetooth: l2cap: clarify dynamic channel accept setup

### DIFF
--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -65,6 +65,17 @@ listen to, the required security level ``sec_level``, and the callback
 ``accept`` which is called to authorize incoming connection requests and
 allocate channel instances.
 
+For dynamic L2CAP channels, the application must provide a channel
+instance from within the ``accept`` callback.
+
+The application typically keeps a :c:struct:`bt_l2cap_le_chan`
+instance (either static or allocated per connection). Inside the
+``accept`` callback, this channel object must be initialized,
+its callback table (``chan.ops``) assigned, and any required
+parameters such as the receive MTU (``rx.mtu``) configured.
+The pointer returned via ``*chan`` must reference the
+``bt_l2cap_chan`` member of this object.
+
 Client channels can be initiated with use of :c:func:`bt_l2cap_chan_connect`
 API and can be disconnected with the :c:func:`bt_l2cap_chan_disconnect` API.
 Note that the later can also disconnect channel instances created by servers.


### PR DESCRIPTION
Add clarification describing how a bt_l2cap_le_chan instance
must be initialized and returned from the server accept
callback when registering dynamic L2CAP channels.

This clarifies how channel instances are allocated and
configured, which was previously unclear.

Fixes #96494
