### PR TITLE
xtensa: clear LCOUNT special register after saving it

### DIFF
--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -173,7 +173,8 @@
 	s32i \SCRATCH_REG, \BSA_PTR, ___xtensa_irq_bsa_t_lbeg_OFFSET
 	rsr.lend \SCRATCH_REG
 	s32i \SCRATCH_REG, \BSA_PTR, ___xtensa_irq_bsa_t_lend_OFFSET
-	rsr.lcount \SCRATCH_REG
+	movi \SCRATCH_REG, 0
+	xsr.lcount \SCRATCH_REG
 	s32i \SCRATCH_REG, \BSA_PTR, ___xtensa_irq_bsa_t_lcount_OFFSET
 #endif
 	rsr.exccause \SCRATCH_REG


### PR DESCRIPTION
When handling an ISR (which does not have a context from which to restore its own value of LCOUNT), we must clear LCOUNT to prevents incorrect zero-overhead execution if calling a function such as memmove() which could be implemented using zero-overhead loop.

A function such as memmove() implemented using zero-overhead loop assumes LCOUNT to have properly been setup before being called; but an ISR calling memmove() in assembly, will likely not know that.