### PR TITLE
dts: bindings: input: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/input/futaba,sbus.yaml
+++ b/dts/bindings/input/futaba,sbus.yaml
@@ -13,40 +13,6 @@ description: |
   Each channel can be configured to generate either absolute position events
   (for joysticks) or key events (for switches).
 
-  The following example shows how to configure 2 joysticks and a button using 5 channels:
-
-  &lpuart6 {
-    status = "okay";
-
-    sbus {
-        compatible = "futaba,sbus";
-        right_stick_x {
-            channel = <1>;
-            type = <INPUT_EV_ABS>;
-            zephyr,code = <INPUT_ABS_RX>;
-        };
-        right_stick_y {
-            channel = <2>;
-            type = <INPUT_EV_ABS>;
-            zephyr,code = <INPUT_ABS_RY>;
-        };
-        left_stick_x {
-            channel = <3>;
-            type = <INPUT_EV_ABS>;
-            zephyr,code = <INPUT_ABS_X>;
-        };
-        left_stick_y {
-            channel = <4>;
-            type = <INPUT_EV_ABS>;
-            zephyr,code = <INPUT_ABS_Y>;
-        };
-        kill_switch {
-            channel = <5>;
-            type = <INPUT_EV_KEY>;
-            zephyr,code = <INPUT_KEY_0>;
-        };
-    };
-  };
 
 compatible: "futaba,sbus"
 
@@ -72,3 +38,44 @@ child-binding:
       type: int
       required: true
       description: Code to emit.
+
+examples:
+  - |
+    /* Example configuration for 2 joysticks and a button using 5 channels */
+    &lpuart6 {
+      status = "okay";
+
+      sbus {
+          compatible = "futaba,sbus";
+
+          right_stick_x {
+              channel = <1>;
+              type = <INPUT_EV_ABS>;
+              zephyr,code = <INPUT_ABS_RX>;
+          };
+
+          right_stick_y {
+              channel = <2>;
+              type = <INPUT_EV_ABS>;
+              zephyr,code = <INPUT_ABS_RY>;
+          };
+
+          left_stick_x {
+              channel = <3>;
+              type = <INPUT_EV_ABS>;
+              zephyr,code = <INPUT_ABS_X>;
+          };
+
+          left_stick_y {
+              channel = <4>;
+              type = <INPUT_EV_ABS>;
+              zephyr,code = <INPUT_ABS_Y>;
+          };
+
+          kill_switch {
+              channel = <5>;
+              type = <INPUT_EV_KEY>;
+              zephyr,code = <INPUT_KEY_0>;
+          };
+      };
+    };

--- a/dts/bindings/input/wch,ch9350l.yaml
+++ b/dts/bindings/input/wch,ch9350l.yaml
@@ -5,27 +5,6 @@ description: |
   WinChipHead CH9350L USB HID to UART control chip.
   This supports State 0.
 
-
-  &uart0 {
-    status = "okay";
-
-      usb_kb {
-        compatible = "wch,ch9350l";
-        status = "okay";
-
-        kb-codemap = <
-          4 INPUT_KEY_Q
-          5 INPUT_KEY_B
-          6 INPUT_KEY_C
-        >;
-        mouse-codemap = <
-          1 INPUT_BTN_LEFT
-          2 INPUT_BTN_RIGHT
-          4 INPUT_BTN_MIDDLE
-        >;
-      };
-  };
-
 compatible: "wch,ch9350l"
 
 include: [base.yaml, uart-device.yaml]
@@ -40,3 +19,21 @@ properties:
     type: array
     description: |
       Maps a mouse button code to a input code by pair of 2 when needed.
+
+examples:
+  - |
+    &uart0 {
+      status = "okay";
+
+        usb_kb {
+          compatible = "wch,ch9350l";
+          status = "okay";
+
+          kb-codemap = <4 INPUT_KEY_Q
+                        5 INPUT_KEY_B
+                        6 INPUT_KEY_C>;
+          mouse-codemap = <1 INPUT_BTN_LEFT
+                           2 INPUT_BTN_RIGHT
+                           4 INPUT_BTN_MIDDLE>;
+        };
+    };


### PR DESCRIPTION
This has to be take 3 by now.... 🫣  I guess I only realized just now that searching for `"compatible ="` in the dts bindings was the best way to spot example snippets (as opposed to searching for variations of "example", "sample", ...)

Use the new `examples` property to provide example usage in a more structured way.