### PR TITLE
dts: bindings: mtd: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -17,8 +17,13 @@ description: |
   these can list the specific EEPROM vendor and model along with the vendor EEPROM family as long as
   the least-specific compatible entry is "atmel,at24".
 
-  Example devicetree node describing a ST M24M01 EEPROM on the i2c0 bus:
+compatible: "atmel,at24"
 
+include: ["atmel,at2x-base.yaml", i2c-device.yaml]
+
+examples:
+  - |
+    /* Example node for an ST M24M01 EEPROM on the i2c0 bus */
     &i2c0 {
       status = "okay";
       clock-frequency = <I2C_BITRATE_FAST>;
@@ -30,9 +35,5 @@ description: |
         pagesize = <256>;
         address-width = <16>;
         timeout = <5>;
-     };
-   };
-
-compatible: "atmel,at24"
-
-include: ["atmel,at2x-base.yaml", i2c-device.yaml]
+      };
+    };

--- a/dts/bindings/mtd/atmel,at25.yaml
+++ b/dts/bindings/mtd/atmel,at25.yaml
@@ -16,8 +16,13 @@ description: |
   these can list the specific EEPROM vendor and model along with the vendor EEPROM family as long as
   the least-specific compatible entry is "atmel,at25".
 
-  Example devicetree node describing a ST M95256 EEPROM on the spi0 bus:
+compatible: "atmel,at25"
 
+include: ["atmel,at2x-base.yaml", spi-device.yaml]
+
+examples:
+  - |
+    /* Example node for an ST M95256 EEPROM on the spi0 bus */
     &spi0 {
       status = "okay";
 
@@ -30,8 +35,4 @@ description: |
         spi-max-frequency = <DT_FREQ_M(20)>;
         timeout = <5>;
       };
-   };
-
-compatible: "atmel,at25"
-
-include: ["atmel,at2x-base.yaml", spi-device.yaml]
+    };

--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -1,43 +1,6 @@
 description: |
   Fixed partitions of a flash (or other non-volatile storage) memory.
 
-  Here is an example:
-
-    &flash0 {
-            partitions {
-                    compatible = "fixed-partitions";
-                    #address-cells = <1>;
-                    #size-cells = <1>;
-
-                    boot_partition: partition@0 {
-                            label = "mcuboot";
-                            reg = <0x00000000 0x0000C000>;
-                    };
-                    slot0_partition: partition@c000 {
-                            label = "image-0";
-                            reg = <0x0000C000 0x00076000>;
-                    };
-                    slot1_partition: partition@82000 {
-                            label = "image-1";
-                            reg = <0x00082000 0x00076000>;
-                    };
-
-                    /*
-                     * The flash starting at 0x000f8000 and ending at
-                     * 0x000fffff is reserved for use by the application.
-                     */
-
-                    /*
-                     * Storage partition will be used by FCB/LittleFS/NVS
-                     * if enabled.
-                     */
-                    storage_partition: partition@f8000 {
-                            label = "storage";
-                            reg = <0x000f8000 0x00008000>;
-                    };
-            };
-    };
-
   Note that the usual name for this node is 'partitions'.
   The fixed-partitions node should be a child of the flash
   memory node. Note also that the flash memory node is usually
@@ -94,3 +57,40 @@ child-binding:
         address of the parent memory, and SIZE is the size of
         the partition in bytes.
       required: true
+
+examples:
+  - |
+    &flash0 {
+            partitions {
+                    compatible = "fixed-partitions";
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+
+                    boot_partition: partition@0 {
+                            label = "mcuboot";
+                            reg = <0x00000000 0x0000C000>;
+                    };
+                    slot0_partition: partition@c000 {
+                            label = "image-0";
+                            reg = <0x0000C000 0x00076000>;
+                    };
+                    slot1_partition: partition@82000 {
+                            label = "image-1";
+                            reg = <0x00082000 0x00076000>;
+                    };
+
+                    /*
+                     * The flash starting at 0x000f8000 and ending at
+                     * 0x000fffff is reserved for use by the application.
+                     */
+
+                    /*
+                     * Storage partition will be used by FCB/LittleFS/NVS
+                     * if enabled.
+                     */
+                    storage_partition: partition@f8000 {
+                            label = "storage";
+                            reg = <0x000f8000 0x00008000>;
+                    };
+            };
+    };

--- a/dts/bindings/mtd/fixed-subpartitions.yaml
+++ b/dts/bindings/mtd/fixed-subpartitions.yaml
@@ -1,35 +1,6 @@
 description: |
   Fixed subpartitions of a flash (or other nonvolatile storage) memory.
 
-  Here is an example:
-
-    &flash0 {
-            partitions {
-                    compatible = "fixed-partitions";
-                    #address-cells = <1>;
-                    #size-cells = <1>;
-
-                    slot0_partition: partition@10000 {
-                            compatible = "fixed-subpartitions";
-                            label = "image-0";
-                            reg = <0x00010000 0x70000>;
-                            ranges = <0x0 0x10000 0x70000>;
-                            #address-cells = <1>;
-                            #size-cells = <1>;
-
-                            slot0_s_partition: partition@0 {
-                                    label = "image-0-secure";
-                                    reg = <0x00000000 0x40000>;
-                            };
-
-                            slot0_ns_partition: partition@40000 {
-                                    label = "image-0-nonsecure";
-                                    reg = <0x00040000 0x30000>;
-                            };
-                    };
-            };
-    };
-
 compatible: "fixed-subpartitions"
 
 properties:
@@ -87,3 +58,32 @@ child-binding:
         address of the parent memory, and SIZE is the size of
         the partition in bytes.
       required: true
+
+examples:
+  - |
+    &flash0 {
+            partitions {
+                    compatible = "fixed-partitions";
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+
+                    slot0_partition: partition@10000 {
+                            compatible = "fixed-subpartitions";
+                            label = "image-0";
+                            reg = <0x00010000 0x70000>;
+                            ranges = <0x0 0x10000 0x70000>;
+                            #address-cells = <1>;
+                            #size-cells = <1>;
+
+                            slot0_s_partition: partition@0 {
+                                    label = "image-0-secure";
+                                    reg = <0x00000000 0x40000>;
+                            };
+
+                            slot0_ns_partition: partition@40000 {
+                                    label = "image-0-nonsecure";
+                                    reg = <0x00040000 0x30000>;
+                            };
+                    };
+            };
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.

<img width="1436" height="944" alt="image" src="https://github.com/user-attachments/assets/6f5de4bb-6b77-41ca-800d-32d4cb215f05" />
