### PR TITLE
dts: bindings: mbox: move DTS examples to `examples:` section

### DIFF
--- a/dts/bindings/mbox/nordic,nrf-bellboard-rx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-bellboard-rx.yaml
@@ -9,18 +9,6 @@ description: |
   communication (IPC) framework. When used in the rx mode, the BELLBOARD
   instance is used to receive events triggered by other remote cores.
 
-  Example definition:
-
-    bellboard: mailbox@deadbeef {
-      compatible = "nordic,nrf-bellboard-rx";
-      reg = <0xdeadbeef 0x1000>;
-      interrupts = <98 NRF_DEFAULT_IRQ_PRIORITY>,
-                   <99 NRF_DEFAULT_IRQ_PRIORITY>;
-      interrupt-names = "irq2", "irq3";
-      nordic,interrupt-mapping = <0x0000000f 2>, <0x000000f0 3>;
-      #mbox-cells = <1>;
-    };
-
 compatible: "nordic,nrf-bellboard-rx"
 
 include: "nordic,nrf-bellboard-common.yaml"
@@ -41,3 +29,15 @@ properties:
       possible events are mapped to the given interrupt. For example, given
       <0x0000000f 2>, the first four events are mapped to interrupt 2
       (irq2).
+
+examples:
+  - |
+    bellboard: mailbox@deadbeef {
+      compatible = "nordic,nrf-bellboard-rx";
+      reg = <0xdeadbeef 0x1000>;
+      interrupts = <98 NRF_DEFAULT_IRQ_PRIORITY>,
+                   <99 NRF_DEFAULT_IRQ_PRIORITY>;
+      interrupt-names = "irq2", "irq3";
+      nordic,interrupt-mapping = <0x0000000f 2>, <0x000000f0 3>;
+      #mbox-cells = <1>;
+    };

--- a/dts/bindings/mbox/nordic,nrf-bellboard-tx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-bellboard-tx.yaml
@@ -9,14 +9,14 @@ description: |
   communication (IPC) framework. When used in the tx mode, the BELLBOARD
   instance is used to trigger events to another core.
 
-  Example definition:
+compatible: "nordic,nrf-bellboard-tx"
 
+include: "nordic,nrf-bellboard-common.yaml"
+
+examples:
+  - |
     bellboard: mailbox@deadbeef {
       compatible = "nordic,nrf-bellboard-tx";
       reg = <0xdeadbeef 0x1000>;
       #mbox-cells = <1>;
     };
-
-compatible: "nordic,nrf-bellboard-tx"
-
-include: "nordic,nrf-bellboard-common.yaml"

--- a/dts/bindings/mbox/nordic,nrf-vevif-event-rx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-vevif-event-rx.yaml
@@ -9,20 +9,6 @@ description: |
   When used in the event rx mode, the VEVIF events are used to receive IRQs that are
   triggered by the VPR core.
 
-  Example definition:
-
-    cpuppr_vpr: vpr@deadbeef {
-      ...
-      cpuflpr_vevif_event_rx: mailbox@0 {
-        compatible = "nordic,nrf-vevif-event-rx";
-        reg = <0x0 0x1000>;
-        interrupts = <76 NRF_DEFAULT_IRQ_PRIORITY>;
-        #mbox-cells = <1>;
-        nordic,events = <1>;
-        nordic,events-mask = <0x00008000>;
-      };
-    };
-
 compatible: "nordic,nrf-vevif-event-rx"
 
 include: [base.yaml, mailbox-controller.yaml]
@@ -46,3 +32,17 @@ properties:
 
 mbox-cells:
   - channel
+
+examples:
+  - |
+    cpuppr_vpr: vpr@deadbeef {
+      /* ... */
+      cpuflpr_vevif_event_rx: mailbox@0 {
+        compatible = "nordic,nrf-vevif-event-rx";
+        reg = <0x0 0x1000>;
+        interrupts = <76 NRF_DEFAULT_IRQ_PRIORITY>;
+        #mbox-cells = <1>;
+        nordic,events = <1>;
+        nordic,events-mask = <0x00008000>;
+      };
+    };

--- a/dts/bindings/mbox/nordic,nrf-vevif-event-tx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-vevif-event-tx.yaml
@@ -9,18 +9,6 @@ description: |
   When used in the event tx mode, the VEVIF events are used to trigger IRQs from VPR
   to a remote core.
 
-  Example definition:
-
-    cpuppr_vpr: vpr@deadbeef{
-      ...
-      cpuflpr_vevif_event_tx: mailbox {
-        compatible = "nordic,nrf-vevif-event-tx";
-        #mbox-cells = <1>;
-        nordic,events = <1>;
-        nordic,events-mask = <0x00008000>;
-      };
-    };
-
 compatible: "nordic,nrf-vevif-event-tx"
 
 include: [base.yaml, mailbox-controller.yaml]
@@ -38,3 +26,15 @@ properties:
 
 mbox-cells:
   - channel
+
+examples:
+  - |
+    cpuppr_vpr: vpr@deadbeef{
+      /* ... */
+      cpuflpr_vevif_event_tx: mailbox {
+        compatible = "nordic,nrf-vevif-event-tx";
+        #mbox-cells = <1>;
+        nordic,events = <1>;
+        nordic,events-mask = <0x00008000>;
+      };
+    };

--- a/dts/bindings/mbox/nordic,nrf-vevif-task-rx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-vevif-task-rx.yaml
@@ -11,22 +11,6 @@ description: |
   intended for signaling within an interprocessor communication (IPC) framework.
   When used in task rx mode, the VEVIF tasks are used to receive events triggered by other core.
 
-  Example definition:
-
-    cpuppr: cpu@d {
-      ...
-      cpuppr_vevif_task_rx: mailbox {
-        compatible = "nordic,nrf-vevif-task-rx";
-        interrupts = <0 NRF_DEFAULT_IRQ_PRIORITY>,
-                     <1 NRF_DEFAULT_IRQ_PRIORITY>,
-                     ...
-                     <N NRF_DEFAULT_IRQ_PRIORITY>;
-        #mbox-cells = <1>;
-        nordic,tasks = <16>;
-        nordic,tasks-mask = <0xfffffff0>;
-      };
-    };
-
 compatible: "nordic,nrf-vevif-task-rx"
 
 include: [base.yaml, mailbox-controller.yaml]
@@ -47,3 +31,19 @@ properties:
 
 mbox-cells:
   - channel
+
+examples:
+  - |
+    cpuppr: cpu@d {
+      /* ... */
+      cpuppr_vevif_task_rx: mailbox {
+        compatible = "nordic,nrf-vevif-task-rx";
+        interrupts = <0 NRF_DEFAULT_IRQ_PRIORITY>,
+                     <1 NRF_DEFAULT_IRQ_PRIORITY>,
+                     ...
+                     <N NRF_DEFAULT_IRQ_PRIORITY>;
+        #mbox-cells = <1>;
+        nordic,tasks = <16>;
+        nordic,tasks-mask = <0xfffffff0>;
+      };
+    };

--- a/dts/bindings/mbox/nordic,nrf-vevif-task-tx.yaml
+++ b/dts/bindings/mbox/nordic,nrf-vevif-task-tx.yaml
@@ -11,19 +11,6 @@ description: |
   intended for signaling within an interprocessor communication (IPC) framework.
   When used in task tx mode, the VEVIF tasks are used to trigger IRQs on VPR core.
 
-  Example definition:
-
-    cpuppr_vpr: vpr@deadbeef{
-      ...
-      cpuppr_vevif_task_tx: mailbox@0 {
-        compatible = "nordic,nrf-vevif-task-tx";
-        reg = <0x0 0x1000>;
-        #mbox-cells = <1>;
-        nordic,tasks = <16>;
-        nordic,tasks-mask = <0xfffffff0>;
-      };
-    };
-
 compatible: "nordic,nrf-vevif-task-tx"
 
 include: [base.yaml, mailbox-controller.yaml]
@@ -44,3 +31,16 @@ properties:
 
 mbox-cells:
   - channel
+
+examples:
+  - |
+    cpuppr_vpr: vpr@deadbeef{
+      /* ... */
+      cpuppr_vevif_task_tx: mailbox@0 {
+        compatible = "nordic,nrf-vevif-task-tx";
+        reg = <0x0 0x1000>;
+        #mbox-cells = <1>;
+        nordic,tasks = <16>;
+        nordic,tasks-mask = <0xfffffff0>;
+      };
+    };

--- a/dts/bindings/mbox/xlnx,mbox-versal-ipi-mailbox.yaml
+++ b/dts/bindings/mbox/xlnx,mbox-versal-ipi-mailbox.yaml
@@ -8,45 +8,6 @@ description: |
   It manages messaging and interrupt handling between two IPI agents (processors).
   Each IPI agent owns registers used for notification and may include buffers for message.
 
-  Example definition:
-
-    mailbox@ff300000 {
-      compatible = "xlnx,versal-ipi-mailbox";
-      interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL_HIGH>;
-      reg = <0x0 0xff300000 0x0 0x1000>,
-            <0x0 0xff990000 0x0 0x1ff>;
-      reg-names = "ctrl", "msg";
-      xlnx,ipi-id = <0>;
-      #address-cells = <2>;
-      #size-cells = <2>;
-
-      /* buffered IPI */
-      child_1: mailbox@ff340000 {
-        compatible = "xlnx,versal-ipi-dest-mailbox";
-        reg = <0x0 0xff340000 0x0 0x1000>,
-              <0x0 0xff990400 0x0 0x1ff>;
-        reg-names = "ctrl", "msg";
-        xlnx,ipi-id = <4>;
-        #mbox-cells = <1>;
-      };
-
-      /* bufferless IPI */
-      child_2: mailbox@ff370000 {
-        compatible = "xlnx,versal-ipi-dest-mailbox";
-        reg = <0x0 0xff370000 0x0 0x1000>;
-        reg-names = "ctrl";
-        xlnx,ipi-id = <7>;
-        #mbox-cells = <1>;
-      };
-    };
-
-  Example usage:
-    mbox-consumer {
-      compatible = "vnd,mbox-consumer";
-      mboxes = <&child_1 0>, <&child_1 1>;
-      mbox-names = "tx", "rx";
-    };
-
 compatible: "xlnx,mbox-versal-ipi-mailbox"
 
 include: [base.yaml]
@@ -93,3 +54,45 @@ child-binding:
 
   mbox-cells:
     - channel
+
+examples:
+  - |
+    /* Example definition */
+
+    mailbox@ff300000 {
+      compatible = "xlnx,versal-ipi-mailbox";
+      interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL_HIGH>;
+      reg = <0x0 0xff300000 0x0 0x1000>,
+            <0x0 0xff990000 0x0 0x1ff>;
+      reg-names = "ctrl", "msg";
+      xlnx,ipi-id = <0>;
+      #address-cells = <2>;
+      #size-cells = <2>;
+
+      /* buffered IPI */
+      child_1: mailbox@ff340000 {
+        compatible = "xlnx,versal-ipi-dest-mailbox";
+        reg = <0x0 0xff340000 0x0 0x1000>,
+              <0x0 0xff990400 0x0 0x1ff>;
+        reg-names = "ctrl", "msg";
+        xlnx,ipi-id = <4>;
+        #mbox-cells = <1>;
+      };
+
+      /* bufferless IPI */
+      child_2: mailbox@ff370000 {
+        compatible = "xlnx,versal-ipi-dest-mailbox";
+        reg = <0x0 0xff370000 0x0 0x1000>;
+        reg-names = "ctrl";
+        xlnx,ipi-id = <7>;
+        #mbox-cells = <1>;
+      };
+    };
+  - |
+    /* Example usage */
+
+    mbox-consumer {
+      compatible = "vnd,mbox-consumer";
+      mboxes = <&child_1 0>, <&child_1 1>;
+      mbox-names = "tx", "rx";
+    };


### PR DESCRIPTION
Use the new `examples` property to provide example usage in a more structured way.

<img width="1209" height="730" alt="image" src="https://github.com/user-attachments/assets/37e19461-fd50-4721-85e6-45a5996d6f54" />
