### PR TITLE
dts: bindings: adc: fix naming of ADI ADC controllers

### DIFF
--- a/dts/bindings/adc/adi,ad4050-adc.yaml
+++ b/dts/bindings/adc/adi,ad4050-adc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ADL4050 ADC Controller
+description: ADI AD4050 ADC Controller
 
 compatible: "adi,ad4050-adc"
 

--- a/dts/bindings/adc/adi,ad4052-adc.yaml
+++ b/dts/bindings/adc/adi,ad4052-adc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ADL4052 ADC Controller
+description: ADI AD4052 ADC Controller
 
 compatible: "adi,ad4052-adc"
 

--- a/dts/bindings/adc/adi,ad405x-adc-base.yaml
+++ b/dts/bindings/adc/adi,ad405x-adc-base.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ADL4050 ADC Controller
+description: ADI AD4050 ADC Controller
 
 compatible: "adi,ad4050-adc"
 

--- a/dts/bindings/adc/adi,ad4114-adc.yaml
+++ b/dts/bindings/adc/adi,ad4114-adc.yaml
@@ -2,7 +2,7 @@ include: [adc-controller.yaml, spi-device.yaml]
 
 compatible: "adi,ad4114-adc"
 
-description: Binding for the ADI AD4114 ADC.
+description: ADI AD4114 ADC Controller
 
 properties:
   map-inputs:

--- a/dts/bindings/adc/adi,ad4130-adc.yaml
+++ b/dts/bindings/adc/adi,ad4130-adc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Bindings for the ADI AD4130 Analog-to-Digital Converter.
+  ADI AD4130 ADC Controller.
 
   This device is controlled over SPI and exposes one or more ADC input channels.
   Each child node corresponds to a channel and supports standard ADC properties

--- a/dts/bindings/adc/adi,ad4170-adc.yaml
+++ b/dts/bindings/adc/adi,ad4170-adc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Bindings for the ADI AD4170 Analog-to-Digital Converter.
+  ADI AD4170 ADC Controller.
 
   This device is controlled over SPI and exposes one or more ADC input channels.
   Each child node corresponds to a channel and supports standard ADC properties

--- a/dts/bindings/adc/adi,ad4190-adc.yaml
+++ b/dts/bindings/adc/adi,ad4190-adc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Bindings for the ADI AD4190 Analog-to-Digital Converter.
+  ADI AD4190 ADC Controller.
 
 compatible: "adi,ad4190-adc"
 

--- a/dts/bindings/adc/adi,ad4195-adc.yaml
+++ b/dts/bindings/adc/adi,ad4195-adc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Bindings for the ADI AD4195 Analog-to-Digital Converter.
+  ADI AD4195 ADC Controller.
 
 compatible: "adi,ad4195-adc"
 

--- a/dts/bindings/adc/adi,ad559x-adc.yaml
+++ b/dts/bindings/adc/adi,ad559x-adc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Grinn
 # SPDX-License-Identifier: Apache-2.0
 
-description: AD559x ADC Controller
+description: ADI AD559x ADC Controller
 
 compatible: "adi,ad559x-adc"
 

--- a/dts/bindings/adc/adi,ad7124-adc.yaml
+++ b/dts/bindings/adc/adi,ad7124-adc.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Bindings for the ADI AD7124 Analog-to-Digital Converter.
+  ADI AD7124 ADC Controller.
 
 compatible: "adi,ad7124-adc"
 


### PR DESCRIPTION
fixes a bunch of errors (eg ADL1234 instead of AD1234) and inconsistencies in the naming of the Analog Devices ADC bindings.