### PR TITLE
kernel: check if interrupt is disabled in `k_can_yield()`

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1088,7 +1088,11 @@ static inline void z_vrfy_k_reschedule(void)
 
 bool k_can_yield(void)
 {
-	return !(k_is_pre_kernel() || k_is_in_isr() ||
+	unsigned int k = arch_irq_lock();
+	bool irq_locked = !arch_irq_unlocked(k);
+
+	arch_irq_unlock(k);
+	return !(k_is_pre_kernel() || k_is_in_isr() || irq_locked ||
 		 z_is_idle_thread_object(_current));
 }
 


### PR DESCRIPTION
`k_yield()` can't be called when interrupt is disabled, update `k_can_yield()` to reflect that.