### PR TITLE
boards: rpi_pico: Add ranges prop. to flash node

### DIFF
--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -63,11 +63,13 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {


### PR DESCRIPTION
This commit adds ranges property to flash node for raspberry pi pico (rpi_pico) board. This is required for 4.4 release. Without this change, flashing to rpi_pico with `west flash` does not work.

PR #103222 added this property for all other boards except rpi_pico board.