### PR TITLE
drivers: crypto: ataes132a: fix error propagation

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -655,6 +655,7 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	/* Ensure buf_len + 3 fits within a uint8_t and the destination buffer */
 	if (buf_len > (UINT8_MAX - 3) || (buf_len + 3) > sizeof(param_buffer)) {
 		LOG_ERR("Encrypt buffer length %d is too large", buf_len);
+		k_sem_give(&data->device_sem);
 		return -EINVAL;
 	}
 

--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -205,7 +205,7 @@ int ataes132a_aes_ccm_decrypt(const struct device *dev,
 	struct ataes132a_device_data *data = dev->data;
 	uint8_t out_len;
 	uint8_t in_buf_len;
-	uint8_t return_code;
+	int return_code;
 	uint8_t expected_out_len;
 	uint8_t param_buffer[52];
 
@@ -284,11 +284,11 @@ int ataes132a_aes_ccm_decrypt(const struct device *dev,
 						     0x0, param_buffer, 16,
 						     param_buffer, &out_len);
 
-		if (return_code != 0U) {
+		if (return_code < 0) {
 			LOG_ERR("nonce command ended with code %d",
 				    return_code);
 			k_sem_give(&data->device_sem);
-			return -EINVAL;
+			return return_code;
 		}
 
 		if (param_buffer[0] != 0U) {
@@ -359,10 +359,10 @@ int ataes132a_aes_ccm_decrypt(const struct device *dev,
 					     in_buf_len + 4, param_buffer,
 					     &out_len);
 
-	if (return_code != 0U) {
+	if (return_code < 0) {
 		LOG_ERR("decrypt command ended with code %d", return_code);
 		k_sem_give(&data->device_sem);
-		return -EINVAL;
+		return return_code;
 	}
 
 	if (!IN_RANGE(out_len, 2, 33)) {
@@ -405,7 +405,7 @@ int ataes132a_aes_ccm_encrypt(const struct device *dev,
 	struct ataes132a_device_data *data = dev->data;
 	uint8_t buf_len;
 	uint8_t out_len;
-	uint8_t return_code;
+	int return_code;
 
 	const uint8_t key_id_len = 1;
 	const uint8_t buf_len_len = 1;
@@ -482,11 +482,11 @@ int ataes132a_aes_ccm_encrypt(const struct device *dev,
 						     0x0, param_buffer, 16,
 						     param_buffer, &out_len);
 
-		if (return_code != 0U) {
+		if (return_code < 0) {
 			LOG_ERR("nonce command ended with code %d",
 				    return_code);
 			k_sem_give(&data->device_sem);
-			return -EINVAL;
+			return return_code;
 		}
 
 		if (param_buffer[0] != 0U) {
@@ -544,10 +544,10 @@ int ataes132a_aes_ccm_encrypt(const struct device *dev,
 					     buf_len + 2, param_buffer,
 					     &out_len);
 
-	if (return_code != 0U) {
+	if (return_code < 0) {
 		LOG_ERR("encrypt command ended with code %d", return_code);
 		k_sem_give(&data->device_sem);
-		return -EINVAL;
+		return return_code;
 	}
 
 	if (!IN_RANGE(out_len, 33, 49)) {
@@ -603,7 +603,7 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	struct ataes132a_device_data *data = dev->data;
 	uint8_t buf_len;
 	uint8_t out_len;
-	uint8_t return_code;
+	int return_code;
 	uint8_t param_buffer[19];
 
 	if (!pkt) {
@@ -671,10 +671,10 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 					     param_buffer, buf_len + 3,
 					     param_buffer, &out_len);
 
-	if (return_code != 0U) {
+	if (return_code < 0) {
 		LOG_ERR("legacy command ended with code %d", return_code);
 		k_sem_give(&data->device_sem);
-		return -EINVAL;
+		return return_code;
 	}
 
 	if (out_len != 17U) {


### PR DESCRIPTION
This PR have 2 commits.

Commit 1 :

Use int return type for command results to avoid truncating negative errno values and ensure proper error propagation.

Commit 2 :

In ataes132a_aes_ecb_block(), error paths could return after k_sem_take() without releasing device_sem, leading to a potential deadlock on subsequent calls.

Ensure k_sem_give() is called on all early-return paths after the semaphore is taken.