### PR TITLE
MAINTAINERS: Add esp_hosted wifi driver to be Espressif maintained

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2782,6 +2782,10 @@ Espressif Platforms:
     - samples/boards/espressif/
     - tests/boards/espressif/
     - drivers/*/*esp32*/
+  file-groups:
+    - name: Espressif hosted Wi-Fi driver
+      files:
+        - drivers/wifi/esp_hosted
   labels:
     - "platform: ESP32"
 


### PR DESCRIPTION
The esp_hosted wifi driver is added as a sub-group to Espressif platform.