### PR TITLE
soc: mcxw70: add image length at vector table offset 0x20

### DIFF
--- a/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
@@ -11,6 +11,9 @@ zephyr_sources_ifdef(CONFIG_PM power.c)
 
 zephyr_include_directories(./)
 
+zephyr_linker_sources_ifdef(CONFIG_NXP_MCXW7XX_BOOT_HEADER
+  ROM_START SORT_KEY 0 boot_header.ld)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 
 if(CONFIG_NXP_NBU)

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,3 +14,14 @@ config SOC_MCXW716C
 config SOC_MCXW727C
 	bool
 	select NXP_MULTICORE if NXP_NBU
+
+config SOC_MCXW70AC
+	bool
+	select NXP_MCXW7XX_BOOT_HEADER if !BOOTLOADER_MCUBOOT
+
+config NXP_MCXW7XX_BOOT_HEADER
+	bool "Create boot header"
+	depends on !BOOTLOADER_MCUBOOT
+	help
+	  Create data structures required by the boot ROM to boot the
+	  application from flash.

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -69,4 +69,11 @@ config NXP_RF_IMU
 
 endif # IEEE802154
 
+if NXP_MCXW7XX_BOOT_HEADER
+
+config ROM_START_OFFSET
+	default 0x40 if SOC_MCXW70AC
+
+endif # NXP_MCXW7XX_BOOT_HEADER
+
 endif

--- a/soc/nxp/mcx/mcxw/mcxw7xx/boot_header.ld
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/boot_header.ld
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP(*(.boot_hdr.ivt))

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -19,6 +19,51 @@
 extern uint32_t SystemCoreClock;
 extern void nxp_nbu_init(void);
 
+#ifdef CONFIG_NXP_MCXW7XX_BOOT_HEADER
+extern char z_main_stack[];
+extern char _flash_used[];
+
+extern void z_arm_reset(void);
+extern void z_arm_nmi(void);
+extern void z_arm_hard_fault(void);
+extern void z_arm_mpu_fault(void);
+extern void z_arm_bus_fault(void);
+extern void z_arm_usage_fault(void);
+extern void z_arm_secure_fault(void);
+extern void z_arm_svc(void);
+extern void z_arm_debug_monitor(void);
+extern void z_arm_pendsv(void);
+extern void sys_clock_isr(void);
+extern void z_arm_exc_spurious(void);
+
+__imx_boot_ivt_section void (*const image_vector_table[])(void) = {
+	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE), /* 0x00 */
+	z_arm_reset,                                         /* 0x04 */
+	z_arm_nmi,                                           /* 0x08 */
+	z_arm_hard_fault,                                    /* 0x0C */
+	z_arm_mpu_fault,                                     /* 0x10 */
+	z_arm_bus_fault,                                     /* 0x14 */
+	z_arm_usage_fault,                                   /* 0x18 */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	z_arm_secure_fault, /* 0x1C */
+#else
+	z_arm_exc_spurious,
+#endif                                               /* CONFIG_ARM_SECURE_FIRMWARE */
+	(void (*)())((uintptr_t)_flash_used),        /* 0x20, imageLength. */
+	0,                                           /* 0x24, imageType (Plain Image) */
+	0,                                           /* 0x28, authBlockOffset/crcChecksum */
+	z_arm_svc,                                   /* 0x2C */
+	z_arm_debug_monitor,                         /* 0x30 */
+	(void (*)())((uintptr_t)image_vector_table), /* 0x34, imageLoadAddress. */
+	z_arm_pendsv,                                /* 0x38 */
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
+	sys_clock_isr, /* 0x3C */
+#else
+	z_arm_exc_spurious,
+#endif
+};
+#endif /* CONFIG_NXP_MCXW7XX_BOOT_HEADER */
+
 __weak void clock_init(void)
 {
 #if !defined(FPGA_TARGET) || (FPGA_TARGET == 0)


### PR DESCRIPTION
Add image length field at vector table offset 0x20.
Boot ROM will check the application image length at application image offset 0x20 and configure the flash permissions through TRDC.
This feature applys to MCXW70AC only.