### PR TITLE
samples: drivers: biometrics: Add missing overlay

### DIFF
--- a/samples/drivers/biometrics/fingerprint/boards/native_sim_native_64.overlay
+++ b/samples/drivers/biometrics/fingerprint/boards/native_sim_native_64.overlay
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"


### PR DESCRIPTION
The sample is set to be built and run both for native_sim and native_sim//64, but lacks an overlay for the 64 bit variant, and fails at runtime when it tries to connect to the real sensor defined in app.overlay. Let's add an overlay for it which just refers to the 32bit variant overlay.

There is also the option to remove native_sim/native/64 from the allowed list, but having it there tests the code for 64bit builds which seemed beneficial. Either way, the issue would be fixed.

Note this sample is failing in main in PRs like for example here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21889225383/job/63287709842?pr=103876#step:13:1003
```
uart_1 connected to pseudotty: /dev/pts/1
[00:00:00.510,000] <err> zfm_x0: UART RX timeout
[00:00:00.510,000] <err> zfm_x0: Password verification failed: -110
*** Booting Zephyr OS build v4.3.0-5950-gaadf1e8e3e1d ***
[00:00:00.510,000] <inf> main: Fingerprint Sensor Test
[00:00:00.510,000] <err> main: Sensor not ready
```

The issue has been present since the sample was introduced in 
* https://github.com/zephyrproject-rtos/zephyr/pull/100139