### PR TITLE
drivers: flash_mspi_nor: Add support for DMA transfers

### DIFF
--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -79,6 +79,26 @@ config FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE
 	  Other options include the 32K-byte erase size (32768), the sector
 	  size (4096), or any non-zero multiple of the sector size.
 
+config FLASH_MSPI_NOR_DMA_DATA_XFER
+	bool "Use DMA for Flash MSPI NOR data transfers"
+	depends on MSPI_DMA
+	default y
+	help
+	  Transfer mode for MSPI read/write data transactions. Since read/write tends
+	  to involve larger data transfers, it is generally recommended to use MSPI_DMA
+	  to reduce CPU load and improve throughput. Will default to MSPI_DMA if
+	  CONFIG_MSPI_DMA is enabled, otherwise it will default to MSPI_PIO.
+
+config FLASH_MSPI_NOR_DMA_CONTROL_XFER
+	bool "Use DMA for Flash MSPI NOR control transfers"
+	depends on MSPI_DMA
+	default n
+	help
+	  Transfer mode for register reads/writes and command MSPI transactions.
+	  Since these are shorter transfers, it is generally recommended to use MSPI_PIO
+	  (programmed I/O) due to there being less overhead compared to setting up a
+	  DMA transfer.
+
 endif # FLASH_MSPI_NOR
 
 endmenu

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -106,6 +106,8 @@ struct flash_mspi_nor_config {
 	bool multi_io_cmd        : 1;
 	bool single_io_addr      : 1;
 	bool initial_soft_reset  : 1;
+	enum mspi_xfer_mode control_xfer_mode;
+	enum mspi_xfer_mode data_xfer_mode;
 };
 
 struct flash_mspi_nor_data {

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -77,7 +77,7 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	}
 
 	/* Write status and config registers */
-	set_up_xfer(dev, MSPI_TX);
+	set_up_xfer(dev, MSPI_TX, dev_config->control_xfer_mode);
 	dev_data->packet.data_buf  = mxicy_mx25r_hp_payload;
 	dev_data->packet.num_bytes = sizeof(mxicy_mx25r_hp_payload);
 	rc = perform_xfer(dev, SPI_NOR_CMD_WRSR);
@@ -98,7 +98,7 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	}
 
 	/* Verify configuration registers */
-	set_up_xfer(dev, MSPI_RX);
+	set_up_xfer(dev, MSPI_RX, dev_config->control_xfer_mode);
 	dev_data->packet.num_bytes = sizeof(config);
 	dev_data->packet.data_buf  = config;
 	rc = perform_xfer(dev, SPI_NOR_CMD_RDCR);
@@ -154,7 +154,7 @@ static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
 	}
 
 	/* Write config register 2 */
-	set_up_xfer(dev, MSPI_TX);
+	set_up_xfer(dev, MSPI_TX, dev_config->control_xfer_mode);
 	dev_data->xfer.addr_length = 4;
 	dev_data->packet.address   = 0;
 	dev_data->packet.data_buf  = &opi_enable;
@@ -187,7 +187,7 @@ static int mxicy_mx25u_pre_init(const struct device *dev)
 	 */
 
 	/* Read configured number of dummy cycles for memory reading commands. */
-	set_up_xfer(dev, MSPI_RX);
+	set_up_xfer(dev, MSPI_RX, dev_config->control_xfer_mode);
 	dev_data->xfer.addr_length = 4;
 	dev_data->packet.address   = 0x300;
 	dev_data->packet.data_buf  = &cfg_reg;


### PR DESCRIPTION
Added Kconfig options to select use of DMA for MSPI NOR flash transfers to allow user to select between DMA and PIO modes for read/write transfers and control transfers (like sending commands and reading registers). The idea being that control transfers will by default use PIO mode due to this being more effective for small transfers. This will change the setup of the xfer in the flash mspi nor driver.