### PR TITLE
dts: vendor: nordic: nrf7120_enga: Rename DTS node

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -101,7 +101,7 @@
 			zephyr,memory-region = "NRF_KMU_CRACEN_EXCHANGE";
 		};
 
-		nrf_mpc_region: memory@50041000 {
+		nrf_mpc: memory@50041000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			compatible = "nordic,nrf-mpc";


### PR DESCRIPTION
Fixes a name mismatch with nrf54l devices