### PR TITLE
modules: hal_nordic: ironside: Prerequisites for PERIPHCONF load

### DIFF
--- a/modules/hal_nordic/ironside/se/Kconfig
+++ b/modules/hal_nordic/ironside/se/Kconfig
@@ -50,12 +50,26 @@ endif # IRONSIDE_SE_DVFS
 menuconfig NRF_PERIPHCONF_SECTION
 	bool "Global peripheral initialization section"
 	depends on LINKER_DEVNULL_SUPPORT
-	imply LINKER_DEVNULL_MEMORY
 	help
 	  Include static global domain peripheral initialization values from the
-	  build in a dedicated section in the devnull region.
+	  build in a dedicated section. The section is either stripped from the
+	  firmware binary or kept as constant data, depending on how it will be
+	  loaded at runtime.
 
 if NRF_PERIPHCONF_SECTION
+
+config NRF_PERIPHCONF_SECTION_STRIP
+	bool "Strip the section from the binary"
+	default y if !NRF_PERIPHCONF_SECTION_KEEP_BY_DEFAULT
+	imply LINKER_DEVNULL_MEMORY
+	help
+	  Strip the PERIPHCONF section from the firmware binary.
+	  If the UICR generator image is enabled, it will include the stripped section
+	  in the generated UICR PERIPHCONF blob.
+
+	  When this is disabled, the PERIPHCONF section will remain as data in the binary,
+	  and will not included in the UICR PERIPHCONF blob. Instead, it is expected that
+	  it will be loaded via the ironside_se_periphconf_write() API.
 
 config NRF_PERIPHCONF_GENERATE_ENTRIES
 	bool "Generate PERIPHCONF entries source file"
@@ -73,5 +87,12 @@ config NRF_PERIPHCONF_GENERATE_ENTRIES_LOCK
 	  Disable this to allow the registers to be reconfigured after boot.
 
 endif # NRF_PERIPHCONF_SECTION
+
+config NRF_PERIPHCONF_SECTION_KEEP_BY_DEFAULT
+	bool "Keep the PERIPHCONF section by default (set by build system)"
+	help
+	  This is set from Sysbuild to change the default behavior for the image so that
+	  CONFIG_NRF_PERIPHCONF_SECTION_STRIP=n unless explicitly configured otherwise.
+	  To override this behavior, set CONFIG_NRF_PERIPHCONF_SECTION_STRIP=y directly.
 
 endmenu # IronSide SE

--- a/modules/hal_nordic/ironside/se/uicr.ld
+++ b/modules/hal_nordic/ironside/se/uicr.ld
@@ -5,7 +5,15 @@
 
 #include <zephyr/linker/iterable_sections.h>
 
+#if defined(CONFIG_NRF_PERIPHCONF_SECTION_STRIP)
+
 SECTION_PROLOGUE(periphconf_entry,(COPY),SUBALIGN(Z_LINK_ITERABLE_SUBALIGN))
 {
 	Z_LINK_ITERABLE(periphconf_entry);
 } GROUP_ROM_LINK_IN(DEVNULL_REGION, DEVNULL_REGION)
+
+#else
+
+ITERABLE_SECTION_ROM(periphconf_entry, Z_LINK_ITERABLE_SUBALIGN)
+
+#endif

--- a/soc/nordic/common/uicr/Kconfig.gen_uicr
+++ b/soc/nordic/common/uicr/Kconfig.gen_uicr
@@ -285,4 +285,35 @@ config GEN_UICR_SECONDARY_PROTECTEDMEM_SIZE_BYTES
 
 endif # GEN_UICR_SECONDARY
 
+choice GEN_UICR_POLICY_PERIPHCONF_STAGE
+	bool "UICR.POLICY_PERIPHCONFSTAGE"
+	default GEN_UICR_POLICY_PERIPHCONF_STAGE_NORMAL
+	help
+	  Sets the behavior of the IronSide SE PERIPHCONF service APIs at boot.
+
+config GEN_UICR_POLICY_PERIPHCONF_STAGE_NORMAL
+	bool "Normal operation stage"
+	help
+	  The API starts in the normal operation stage, meaning that no explicit
+	  API call is needed to finish initialization.
+
+config GEN_UICR_POLICY_PERIPHCONF_STAGE_INIT
+	bool "Initialization stage"
+	help
+	  The API starts in the initialization stage, which gives permission
+	  to write any register supported by the UICR PERIPHCONF blob without CPU based
+	  restrictions. To finish initialization, the application must notify IronSide SE
+	  via the ironside_se_periphconf_finish_init() API.
+
+	  Enabling this policy option causes the generated UICR format version to be set
+	  to >= 2.1, which requires IronSide SE v23.3.0+26 or higher to be installed.
+
+endchoice
+
+config GEN_UICR_POLICY_PERIPHCONF_STAGE_VALUE
+	hex
+	default 0xBD2328A8 if GEN_UICR_POLICY_PERIPHCONF_STAGE_INIT
+	default 0x1730C77F if GEN_UICR_POLICY_PERIPHCONF_STAGE_NORMAL
+	default 0
+
 endmenu

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -79,6 +79,7 @@ set(protectedmem_args)
 set(periphconf_args)
 set(wdtstart_args)
 set(periphconf_elfs)
+set(policy_args)
 set(merged_hex_file ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.hex)
 set(secondary_periphconf_elfs)
 set(uicr_hex_file ${APPLICATION_BINARY_DIR}/zephyr/uicr.hex)
@@ -264,6 +265,10 @@ if(CONFIG_GEN_UICR_SECONDARY)
   endif()
 endif()
 
+if(CONFIG_GEN_UICR_POLICY_PERIPHCONF_STAGE_INIT OR CONFIG_GEN_UICR_POLICY_PERIPHCONF_STAGE_NORMAL)
+  list(APPEND policy_args --policy-periphconf-stage ${CONFIG_GEN_UICR_POLICY_PERIPHCONF_STAGE_VALUE})
+endif()
+
 # Generate hex files (merged, uicr-only, periphconf-only, and secondary-periphconf-only)
 add_custom_command(
   OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file}
@@ -282,6 +287,7 @@ add_custom_command(
           ${securestorage_args}
           ${protectedmem_args}
           ${secondary_args}
+          ${policy_args}
   DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Using gen_uicr.py to generate ${merged_hex_file}, ${uicr_hex_file}, ${periphconf_hex_file}, and ${secondary_periphconf_hex_file} from ${periphconf_elfs} ${secondary_periphconf_elfs}"

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -166,6 +166,12 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
     endif()
 
     if(EXISTS ${_dir}/zephyr/zephyr.dts)
+      # If the PERIPHCONF is configured to remain in the firmware, do not include it here.
+      parse_kconfig_value(${_dir}/zephyr/.config CONFIG_NRF_PERIPHCONF_SECTION_STRIP strip_periphconf)
+      if(NOT (strip_periphconf STREQUAL "y"))
+        continue()
+      endif()
+
       # Read CONFIG_KERNEL_BIN_NAME from the sibling's .config file
       parse_kconfig_value(${_dir}/zephyr/.config CONFIG_KERNEL_BIN_NAME kernel_bin_name)
       set(kernel_elf_path ${_dir}/zephyr/${kernel_bin_name}.elf)


### PR DESCRIPTION
Additional support for the features pulled in with the IronSide support package in #103775.
Together these are prerequisite changes for supporting loading the PERPIHCONF entries in the image via ironside_se_periphconf_write() either instead of or combined with the static blob pointed to by UICR.PERIPHCONF.
Support is added for:

* Configuring the UICR.POLICY_PERIPHCONFSTAGE field through Kconfig in the gen_uicr image (it must be set to INIT to allow writing certain registers).
* Keeping the PERIPHCONF section entries in the firmware itself as data, instead of stripping it and including it in the UICR PERIPHCONF blob.
