### PR TITLE
boards: nxp: frdm_mcxwxx: fix partition ranges

### DIFF
--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -213,6 +213,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -173,6 +173,7 @@ arduino_i2c: &lpi2c1 {};
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -129,6 +129,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		code_partition: partition@0 {
 			reg = <0x0 DT_SIZE_K(2024)>;

--- a/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
@@ -126,7 +126,10 @@
 		status = "okay";
 
 		flash0: flash@0 {
+			#address-cells = <1>;
+			#size-cells = <1>;
 			compatible = "soc-nv-flash";
+			ranges = <0x0 0x0 DT_SIZE_K(1016)>;
 			reg = <0x0 DT_SIZE_K(1016)>;
 			erase-block-size = <DT_SIZE_K(8)>;
 			write-block-size = <16>;

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -73,9 +73,12 @@
 			status = "disabled";
 
 			flash: flash@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
 				compatible = "soc-nv-flash";
 				write-block-size = <16>;
 				erase-block-size = <DT_SIZE_K(8)>;
+				ranges = <>;
 			};
 		};
 


### PR DESCRIPTION
As per 4.4 migration guide, a `ranges <>;` property should be used by the flash nodes to specify the base address and size for child nodes, and `fixed-partitions` nodes must have a `ranges;` property to pass the parent's ranges on to child nodes.
Fixes `CONFIG_FLASH_CODE_PARTITION_ADDRESS_INVALID` being selected when building with MCUboot.
This caused MCUboot builds to link to RAM instead of FLASH, causing all sorts of problems.