### PR TITLE
dts: allow refering childs with `phy-handle`

### DIFF
--- a/boards/kws/pico2_spe/pico2_spe.dtsi
+++ b/boards/kws/pico2_spe/pico2_spe.dtsi
@@ -88,13 +88,15 @@
 
 		local-mac-address = [ca 2f b7 10 23 79];
 
+		phy-handle = <&lan865x_phy>;
+
 		lan865x_mdio: lan865x_mdio {
 			compatible = "microchip,lan865x-mdio";
 			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			ethernet-phy@0 {
+			lan865x_phy: ethernet-phy@0 {
 				compatible = "microchip,t1s-phy";
 				reg = <0x0>;
 				plca-enable;

--- a/boards/kws/pico_spe/pico_spe.dts
+++ b/boards/kws/pico_spe/pico_spe.dts
@@ -153,6 +153,7 @@
 		rst-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		local-mac-address = [ca 2f b7 10 23 78];
+		phy-handle = <&lan865x_phy>;
 
 		lan865x_mdio: lan865x_mdio {
 			compatible = "microchip,lan865x-mdio";
@@ -160,7 +161,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			ethernet-phy@0 {
+			lan865x_phy: ethernet-phy@0 {
 				compatible = "microchip,t1s-phy";
 				reg = <0x0>;
 				plca-enable;

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -514,6 +514,8 @@ Ethernet
   :kconfig:option:`CONFIG_PTP_CLOCK_INIT_PRIORITY`,  but only if :kconfig:option:`CONFIG_ETH_DRIVER`
   is enabled. This way the priority is based on the dependencies in the devicetree.
 
+* The ``phy-handle`` property of :dtcompatible:`microchip,lan865x` must now be set to the phy node.
+
 File System
 ===========
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -481,8 +481,7 @@ static const struct ethernet_api lan865x_api_func = {
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.reset = GPIO_DT_SPEC_INST_GET(inst, rst_gpios),                                   \
-		.phy = DEVICE_DT_GET(                                                              \
-			DT_CHILD(DT_INST_CHILD(inst, lan865x_mdio), ethernet_phy_##inst)),         \
+		.phy = DEVICE_DT_GET(DT_INST_PHANDLE(inst, phy_handle)),                           \
 		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(inst),                                  \
 	};                                                                                         \
                                                                                                    \

--- a/samples/net/sockets/echo_server/boards/nucleo_g474re.overlay
+++ b/samples/net/sockets/echo_server/boards/nucleo_g474re.overlay
@@ -21,6 +21,8 @@
 
 		local-mac-address = [00 19 05 00 00 01];
 
+		phy-handle = <&lan865x_phy>;
+
 		spi-max-frequency = <25000000>;
 
 		lan865x_mdio: lan865x_mdio {

--- a/samples/net/zperf/boards/nucleo_g474re.overlay
+++ b/samples/net/zperf/boards/nucleo_g474re.overlay
@@ -21,6 +21,8 @@
 
 		local-mac-address = [00 19 05 00 00 01];
 
+		phy-handle = <&lan865x_phy>;
+
 		spi-max-frequency = <25000000>;
 
 		lan865x_mdio: lan865x_mdio {
@@ -29,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			ethernet-phy@0 {
+			lan865x_phy: ethernet-phy@0 {
 				compatible = "microchip,t1s-phy";
 				reg = <0x0>;
 				plca-enable;

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2384,6 +2384,22 @@ class EDT:
         # 'phandles', or 'phandle-array' property values.
         for prop in props_node.props.values():
             if prop.type == 'phandle':
+                # According to the DT spec, a property named 'phy-handle' is required when
+                # the Ethernet device is connected a physical layer device (PHY).
+                # But the 'phy-handle' property can point to a child node of the Ethernet device,
+                # so we need to check for that and not add a dependency in that case, otherwise
+                # we'll get a cycle in the graph.
+                if prop.name == "phy-handle":
+                    def _is_child(parent_node: Node, child_node: Optional[Node]) -> bool:
+                        if child_node is None:
+                            return False
+                        if parent_node is child_node:
+                            return True
+                        return _is_child(parent_node, child_node.parent)
+                    if TYPE_CHECKING:
+                        assert isinstance(prop.val, Node)
+                    if _is_child(props_node, prop.val):
+                        continue
                 self._graph.add_edge(root_node, prop.val)
             elif prop.type == 'phandles':
                 if TYPE_CHECKING:

--- a/tests/drivers/build_all/ethernet/spi_devices.overlay
+++ b/tests/drivers/build_all/ethernet/spi_devices.overlay
@@ -132,6 +132,7 @@
 				int-gpios = <&test_gpio 0 0>;
 				rst-gpios = <&test_gpio 0 0>;
 				local-mac-address = [00 00 00 01 02 03];
+				phy-handle = <&lan865x_phy>;
 
 				lan865x_mdio: lan865x_mdio {
 					compatible = "microchip,lan865x-mdio";
@@ -139,7 +140,7 @@
 					#address-cells = <1>;
 					#size-cells = <0>;
 
-					ethernet-phy@0 {
+					lan865x_phy: ethernet-phy@0 {
 						compatible = "microchip,t1s-phy";
 						reg = <0x0>;
 						plca-enable;


### PR DESCRIPTION
According to the DT spec the 'phy-handle' phandle prop
is required, when a phy is used. As this phy could be
a child, we have to filter it out to not get a cycle in the graph.

This allows the phy to be a child of the eternet controller,
when using the  'phy-handle' dt prop.

An alternative would be that instead of just handling it for 'phy-handle',
would be to add a option to the property, so that it could be set in the dt bindings yaml.