### PR TITLE
boards: weact: mini_stm32h7b0: correct slot0 partition size

### DIFF
--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
@@ -164,7 +164,7 @@ zephyr_udc0: &usbotg_hs {
 			#size-cells = <1>;
 
 			slot0_partition: partition@0 {
-				reg = <0x00000000 DT_SIZE_M(64)>;
+				reg = <0x00000000 DT_SIZE_M(8)>;
 			};
 		};
 	};


### PR DESCRIPTION
MiniSTM32H7B0 external NOR flash is 64Mbits large hence 8MBytes. Correct slot0_parition size from 64MByte to 8Mbyte.