### PR TITLE
boards: st:  add missing usb supported tag in board yaml file

### DIFF
--- a/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
@@ -6,26 +6,27 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
-  - i2c
+  - ble
+  - counter
+  - dac
+  - dma
+  - gpio
   - hts221
+  - i2c
   - lps22hb
   - lsm6dsl
-  - pwm
-  - counter
-  - gpio
-  - ble
-  - spi
   - nvs
+  - pwm
+  - qspi
+  - rtc
+  - spi
+  - usb_device
+  - usbd
   - vl53l0x
   - watchdog
-  - adc
-  - dac
-  - qspi
-  - dma
-  - rtc
-  - usbd
 ram: 96
 flash: 1024
 vendor: st

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.yaml
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.yaml
@@ -8,22 +8,23 @@ toolchain:
 ram: 256
 flash: 1024
 supported:
-  - arduino_i2c
-  - arduino_gpio
-  - arduino_spi
-  - uart
-  - gpio
-  - netif:eth
-  - usb_device
-  - i2c
-  - pwm
-  - spi
-  - watchdog
-  - counter
-  - can
   - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi
+  - backup_sram
+  - can
+  - counter
   - dac
   - dma
-  - backup_sram
+  - gpio
+  - i2c
+  - netif:eth
+  - pwm
   - rtc
+  - spi
+  - uart
+  - usb_device
+  - usbd
+  - watchdog
 vendor: st

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
@@ -8,19 +8,20 @@ toolchain:
 ram: 512
 flash: 2048
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
-  - dma
-  - uart
-  - gpio
-  - counter
-  - i2c
-  - pwm
-  - adc
-  - netif:eth
-  - spi
-  - rtc
-  - usb_device
   - can
+  - counter
+  - dma
+  - gpio
+  - i2c
+  - netif:eth
+  - pwm
+  - rtc
+  - spi
+  - uart
+  - usb_device
+  - usbd
   - watchdog
 vendor: st

--- a/boards/st/stm32f3_disco/stm32f3_disco_B.yaml
+++ b/boards/st/stm32f3_disco/stm32f3_disco_B.yaml
@@ -8,18 +8,19 @@ toolchain:
 ram: 40
 flash: 256
 supported:
-  - gpio
-  - i2c
-  - counter
-  - spi
-  - watchdog
-  - usb_device
-  - lsm303dlhc
-  - nvs
-  - can
-  - pwm
   - adc
+  - can
+  - counter
   - dac
   - dma
+  - gpio
+  - i2c
+  - lsm303dlhc
+  - nvs
+  - pwm
   - rtc
+  - spi
+  - usb_device
+  - usbd
+  - watchdog
 vendor: st

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -7,24 +7,25 @@ toolchain:
 ram: 256
 flash: 2048
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
   - arduino_spi
-  - gpio
-  - uart
-  - watchdog
-  - entropy
-  - dma
-  - adc
-  - dac
-  - netif:eth
-  - pwm
-  - counter
-  - spi
-  - octospi
   - can
+  - counter
+  - dac
+  - dma
+  - entropy
+  - gpio
   - i2c
+  - netif:eth
+  - octospi
+  - pwm
   - rtc
+  - spi
+  - uart
+  - usb_device
   - usbd
+  - watchdog
 vendor: st

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -7,14 +7,15 @@ toolchain:
 ram: 456
 flash: 64
 supported:
-  - arduino_gpio
-  - gpio
-  - uart
-  - watchdog
-  - entropy
   - adc
-  - octospi
-  - usbd
+  - arduino_gpio
+  - entropy
+  - gpio
   - memc
+  - octospi
   - rtc
+  - uart
+  - usb_device
+  - usbd
+  - watchdog
 vendor: st

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
@@ -14,7 +14,9 @@ supported:
   - gpio
   - i2c
   - pwm
-  - usart
   - tsc
+  - usart
+  - usb_device
+  - usbd
 ram: 32
 flash: 256


### PR DESCRIPTION

- `usbd` is required by examples to run some samples in zephyr/samples/subsys/usb

- `usb_device` is required by examples to run some tests in zephyr/tests/subsys/usb

Related boards :  
- disco_l475_iot1
- nucleo_f746zg
- nucleo_h753zi
- stm32f3_disco/stm32f3_disco_B
- stm32h573i_dk
- stm32h7s78_dk
- stm32u083c_dk