### PR TITLE
net: ethernet: Let ethernet define the API with DEVICE_API

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -249,6 +249,10 @@ New APIs and options
 
 * Networking
 
+  * Ethernet
+
+    * :c:struct:`ethernet_driver_api`
+
   * Wi-Fi
 
     * Add support for Wi-Fi Direct (P2P) mode.

--- a/drivers/ethernet/dsa/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa/dsa_ksz8xxx.c
@@ -1118,10 +1118,12 @@ static enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)
 		ETHERNET_LINK_100BASE;
 }
 
-const struct ethernet_api dsa_eth_api_funcs = {
-	.iface_api.init		= dsa_iface_init,
-	.get_capabilities	= dsa_port_get_capabilities,
-	.send                   = dsa_tx,
+static DEVICE_API(ethernet, dsa_eth_api_funcs) = {
+	.l2 = {
+		.iface_api.init		= dsa_iface_init,
+		.get_capabilities	= dsa_port_get_capabilities,
+		.send               = dsa_tx,
+	},
 };
 
 static struct dsa_api dsa_api_f = {

--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1638,17 +1638,19 @@ static struct net_stats_eth *eth_dwc_xgmac_stats(const struct device *dev)
 }
 #endif
 
-static const struct ethernet_api eth_dwc_xgmac_apis = {
-	.iface_api.init = eth_dwc_xgmac_iface_init,
-	.send = eth_dwc_xgmac_send,
-	.start = eth_dwc_xgmac_start_device,
-	.stop = eth_dwc_xgmac_stop_device,
-	.get_capabilities = eth_dwc_xgmac_get_capabilities,
-	.set_config = eth_dwc_xgmac_set_config,
-	.get_config = eth_dwc_xgmac_get_config,
+static DEVICE_API(ethernet, eth_dwc_xgmac_apis) = {
+	.l2 = {
+		.iface_api.init = eth_dwc_xgmac_iface_init,
+		.send = eth_dwc_xgmac_send,
+		.start = eth_dwc_xgmac_start_device,
+		.stop = eth_dwc_xgmac_stop_device,
+		.get_capabilities = eth_dwc_xgmac_get_capabilities,
+		.set_config = eth_dwc_xgmac_set_config,
+		.get_config = eth_dwc_xgmac_get_config,
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
-	.get_stats = eth_dwc_xgmac_stats,
+		.get_stats = eth_dwc_xgmac_stats,
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
+	},
 };
 
 /* Interrupt configuration function macro */

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -1507,14 +1507,16 @@ static int adin2111_init(const struct device *dev)
 	return ret;
 }
 
-static const struct ethernet_api adin2111_port_api = {
-	.iface_api.init = adin2111_port_iface_init,
-	.get_capabilities = adin2111_port_get_capabilities,
-	.set_config = adin2111_port_set_config,
-	.send = adin2111_port_send,
-#if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = adin2111_port_get_stats,
-#endif /* CONFIG_NET_STATISTICS_ETHERNET */
+static DEVICE_API(ethernet, adin2111_port_api) = {
+	.l2 = {
+		.iface_api.init = adin2111_port_iface_init,
+		.get_capabilities = adin2111_port_get_capabilities,
+		.set_config = adin2111_port_set_config,
+		.send = adin2111_port_send,
+		#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+		.get_stats = adin2111_port_get_stats,
+		#endif /* CONFIG_NET_STATISTICS_ETHERNET */
+	},
 };
 
 #define ADIN2111_STR(x)		#x

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -1137,12 +1137,16 @@ static int eth_cyclonev_stop(const struct device *dev)
 	return 0;
 }
 
-const struct ethernet_api eth_cyclonev_api = {.iface_api.init = eth_cyclonev_iface_init,
-					      .get_capabilities = eth_cyclonev_caps,
-					      .send = eth_cyclonev_send,
-					      .start = eth_cyclonev_start,
-					      .stop = eth_cyclonev_stop,
-					      .set_config = eth_cyclonev_set_config};
+const DEVICE_API(ethernet, eth_cyclonev_api) = {
+	.l2 = {
+		.iface_api.init = eth_cyclonev_iface_init,
+		.get_capabilities = eth_cyclonev_caps,
+		.send = eth_cyclonev_send,
+		.start = eth_cyclonev_start,
+		.stop = eth_cyclonev_stop,
+		.set_config = eth_cyclonev_set_config
+	},
+};
 
 #define CYCLONEV_ETH_INIT(inst) \
 	static struct eth_cyclonev_priv eth_cyclonev_##inst##_data; \

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -616,9 +616,11 @@ int dwmac_probe(const struct device *dev)
 	return 0;
 }
 
-const struct ethernet_api dwmac_api = {
-	.iface_api.init		= dwmac_iface_init,
-	.get_capabilities	= dwmac_caps,
-	.set_config		= dwmac_set_config,
-	.send			= dwmac_send,
+DEVICE_API(ethernet, dwmac_api) = {
+	.l2 = {
+		.iface_api.init		= dwmac_iface_init,
+		.get_capabilities	= dwmac_caps,
+		.set_config		= dwmac_set_config,
+		.send			= dwmac_send,
+	},
 };

--- a/drivers/ethernet/eth_dwmac_priv.h
+++ b/drivers/ethernet/eth_dwmac_priv.h
@@ -84,7 +84,7 @@ int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(struct dwmac_priv *p);
 void dwmac_platform_init(struct dwmac_priv *p);
 void dwmac_isr(const struct device *ddev);
-extern const struct ethernet_api dwmac_api;
+extern const struct ethernet_driver_api dwmac_api;
 
 /*
  * MAC Register Definitions

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -297,16 +297,18 @@ static struct net_stats_eth *get_stats(const struct device *dev)
 }
 #endif
 
-static const struct ethernet_api e1000_api = {
-	.iface_api.init		= e1000_iface_init,
+static DEVICE_API(ethernet, e1000_api) = {
+	.l2 = {
+		.iface_api.init = e1000_iface_init,
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
-	.get_ptp_clock		= e1000_get_ptp_clock,
+		.get_ptp_clock = e1000_get_ptp_clock,
 #endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = get_stats,
+		.get_stats = get_stats,
 #endif
-	.get_capabilities	= e1000_caps,
-	.send			= e1000_send,
+		.get_capabilities = e1000_caps,
+		.send = e1000_send,
+	}
 };
 
 #define E1000_DT_INST_IRQ_FLAGS(inst)					\

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -813,11 +813,13 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 	context->iface_initialized = true;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init		= eth_enc28j60_iface_init,
-	.set_config		= eth_enc28j60_set_config,
-	.get_capabilities	= eth_enc28j60_get_capabilities,
-	.send			= eth_enc28j60_tx,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init		= eth_enc28j60_iface_init,
+		.set_config		= eth_enc28j60_set_config,
+		.get_capabilities	= eth_enc28j60_get_capabilities,
+		.send			= eth_enc28j60_tx,
+	},
 };
 
 static int eth_enc28j60_init(const struct device *dev)

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -625,13 +625,15 @@ static int enc424j600_stop_device(const struct device *dev)
 	return 0;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init		= enc424j600_iface_init,
-	.set_config		= enc424j600_set_config,
-	.get_capabilities	= enc424j600_get_capabilities,
-	.send			= enc424j600_tx,
-	.start			= enc424j600_start_device,
-	.stop			= enc424j600_stop_device,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init		= enc424j600_iface_init,
+		.set_config		= enc424j600_set_config,
+		.get_capabilities	= enc424j600_get_capabilities,
+		.send			= enc424j600_tx,
+		.start			= enc424j600_start_device,
+		.stop			= enc424j600_stop_device,
+	},
 };
 
 static int enc424j600_init(const struct device *dev)

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -343,12 +343,14 @@ static void eth_esp32_iface_init(struct net_if *iface)
 	}
 }
 
-static const struct ethernet_api eth_esp32_api = {
-	.iface_api.init		= eth_esp32_iface_init,
-	.get_capabilities	= eth_esp32_caps,
-	.set_config		= eth_esp32_set_config,
-	.get_phy		= eth_esp32_phy_get,
-	.send			= eth_esp32_send,
+static DEVICE_API(ethernet, eth_esp32_api) = {
+	.l2 = {
+		.iface_api.init		= eth_esp32_iface_init,
+		.get_capabilities	= eth_esp32_caps,
+		.set_config		= eth_esp32_set_config,
+		.get_phy		= eth_esp32_phy_get,
+		.send			= eth_esp32_send,
+	},
 };
 
 /* DMA data must be in DRAM */

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -634,10 +634,12 @@ static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev
 	return (ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE);
 }
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_iface_init,
-	.get_capabilities = eth_gecko_get_capabilities,
-	.send = eth_tx,
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
+		.get_capabilities = eth_gecko_get_capabilities,
+		.send = eth_tx,
+	},
 };
 
 static void eth0_irq_config(void)

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -376,15 +376,17 @@ static void eth_ivshmem_iface_init(struct net_if *iface)
 	k_poll_signal_raise(&dev_data->poll_signal, 0);
 }
 
-static const struct ethernet_api eth_ivshmem_api = {
-	.iface_api.init		= eth_ivshmem_iface_init,
+static DEVICE_API(ethernet, eth_ivshmem_api) = {
+	.l2 = {
+		.iface_api.init		= eth_ivshmem_iface_init,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats		= eth_ivshmem_get_stats,
+		.get_stats		= eth_ivshmem_get_stats,
 #endif
-	.start			= eth_ivshmem_start,
-	.stop			= eth_ivshmem_stop,
-	.get_capabilities	= eth_ivshmem_caps,
-	.send			= eth_ivshmem_send,
+		.start			= eth_ivshmem_start,
+		.stop			= eth_ivshmem_stop,
+		.get_capabilities	= eth_ivshmem_caps,
+		.send			= eth_ivshmem_send,
+	},
 };
 
 #define ETH_IVSHMEM_RANDOM_MAC_ADDR(inst)						\

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -468,12 +468,14 @@ const struct device *lan865x_get_phy(const struct device *dev)
 	return cfg->phy;
 }
 
-static const struct ethernet_api lan865x_api_func = {
-	.iface_api.init = lan865x_iface_init,
-	.get_capabilities = lan865x_port_get_capabilities,
-	.set_config = lan865x_set_config,
-	.send = lan865x_port_send,
-	.get_phy = lan865x_get_phy,
+static DEVICE_API(ethernet, lan865x_api_func) = {
+	.l2 = {
+		.iface_api.init = lan865x_iface_init,
+		.get_capabilities = lan865x_port_get_capabilities,
+		.set_config = lan865x_set_config,
+		.send = lan865x_port_send,
+		.get_phy = lan865x_get_phy,
+	},
 };
 
 #define LAN865X_DEFINE(inst)                                                                       \

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -850,11 +850,13 @@ static int lan9250_set_config(const struct device *dev, enum ethernet_config_typ
 	return -ENOTSUP;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init = lan9250_iface_init,
-	.get_capabilities = lan9250_get_capabilities,
-	.set_config = lan9250_set_config,
-	.send = lan9250_tx,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = lan9250_iface_init,
+		.get_capabilities = lan9250_get_capabilities,
+		.set_config = lan9250_set_config,
+		.send = lan9250_tx,
+	},
 };
 
 static int lan9250_init(const struct device *dev)

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -285,14 +285,16 @@ static enum ethernet_hw_caps eth_caps(const struct device *dev)
 		ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
 }
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_iface_init,
-	.start = eth_start,
-	.stop = eth_stop,
-	.get_capabilities = eth_caps,
-	.set_config = eth_set_config,
-	.get_phy = eth_get_phy,
-	.send = eth_tx
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
+		.start = eth_start,
+		.stop = eth_stop,
+		.get_capabilities = eth_caps,
+		.set_config = eth_set_config,
+		.get_phy = eth_get_phy,
+		.send = eth_tx
+	},
 };
 
 #define ETH_LITEX_SLOT_RX_ADDR(n)                                                                  \

--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -491,22 +491,22 @@ static int vlan_setup(const struct device *dev, struct net_if *iface,
 }
 #endif /* CONFIG_NET_VLAN */
 
-static const struct ethernet_api eth_if_api = {
-	.iface_api.init = eth_iface_init,
-
-	.get_capabilities = eth_native_tap_get_capabilities,
-	.set_config = set_config,
-	.send = eth_send,
-
+static DEVICE_API(ethernet, eth_if_api) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
+		.get_capabilities = eth_native_tap_get_capabilities,
+		.set_config = set_config,
+		.send = eth_send,
 #if defined(CONFIG_NET_VLAN)
-	.vlan_setup = vlan_setup,
+		.vlan_setup = vlan_setup,
 #endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = get_stats,
+		.get_stats = get_stats,
 #endif
 #if defined(CONFIG_ETH_NATIVE_TAP_PTP_CLOCK)
-	.get_ptp_clock = eth_get_ptp_clock,
+		.get_ptp_clock = eth_get_ptp_clock,
 #endif
+	},
 };
 
 #define DEFINE_ETH_DEV_DATA(x, _)					     \

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -553,11 +553,13 @@ static enum ethernet_hw_caps numaker_eth_get_cap(const struct device *dev)
 #endif
 }
 
-static const struct ethernet_api eth_numaker_driver_api = {
-	.iface_api.init = numaker_eth_if_init,
-	.get_capabilities = numaker_eth_get_cap,
-	.set_config = numaker_eth_set_config,
-	.send = numaker_eth_tx,
+static DEVICE_API(ethernet, eth_numaker_driver_api) = {
+	.l2 = {
+		.iface_api.init = numaker_eth_if_init,
+		.get_capabilities = numaker_eth_get_cap,
+		.set_config = numaker_eth_set_config,
+		.send = numaker_eth_tx,
+	},
 };
 
 /* EMAC IRQ Handler */

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -828,16 +828,18 @@ static int eth_nxp_enet_device_pm_action(const struct device *dev, enum pm_devic
 #define NXP_ENET_SEND_FUNC eth_nxp_enet_tx
 #endif /* CONFIG_NET_DSA_DEPRECATED */
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init		= eth_nxp_enet_iface_init,
-	.get_capabilities	= eth_nxp_enet_get_capabilities,
-	.get_phy                = eth_nxp_enet_get_phy,
-	.set_config		= eth_nxp_enet_set_config,
-	.get_config		= eth_nxp_enet_get_config,
-	.send			= NXP_ENET_SEND_FUNC,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init		= eth_nxp_enet_iface_init,
+		.get_capabilities	= eth_nxp_enet_get_capabilities,
+		.get_phy                = eth_nxp_enet_get_phy,
+		.set_config		= eth_nxp_enet_set_config,
+		.get_config		= eth_nxp_enet_get_config,
+		.send			= NXP_ENET_SEND_FUNC,
 #if defined(CONFIG_PTP_CLOCK)
-	.get_ptp_clock		= eth_nxp_enet_get_ptp_clock,
+		.get_ptp_clock		= eth_nxp_enet_get_ptp_clock,
 #endif
+	},
 };
 
 #define NXP_ENET_CONNECT_IRQ(node_id, irq_names, idx)				\

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -823,12 +823,14 @@ static int eth_nxp_enet_qos_set_config(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init = eth_nxp_enet_qos_iface_init,
-	.send = eth_nxp_enet_qos_tx,
-	.get_capabilities = eth_nxp_enet_qos_get_capabilities,
-	.get_phy = eth_nxp_enet_qos_get_phy,
-	.set_config	= eth_nxp_enet_qos_set_config,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_nxp_enet_qos_iface_init,
+		.send = eth_nxp_enet_qos_tx,
+		.get_capabilities = eth_nxp_enet_qos_get_capabilities,
+		.get_phy = eth_nxp_enet_qos_get_phy,
+		.set_config	= eth_nxp_enet_qos_set_config,
+	},
 };
 
 #define NXP_ENET_QOS_NODE_HAS_MAC_ADDR_CHECK(n)                                                    \

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -587,14 +587,16 @@ static void eth_nxp_s32_rx_irq(const struct device *dev)
 	GMAC_RxIRQHandler(cfg->instance, cfg->rx_ring_idx);
 }
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_nxp_s32_iface_init,
-	.get_capabilities = eth_nxp_s32_get_capabilities,
-	.get_phy = eth_nxp_s32_get_phy,
-	.start = eth_nxp_s32_start,
-	.stop = eth_nxp_s32_stop,
-	.send = eth_nxp_s32_tx,
-	.set_config = eth_nxp_s32_set_config,
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_nxp_s32_iface_init,
+		.get_capabilities = eth_nxp_s32_get_capabilities,
+		.get_phy = eth_nxp_s32_get_phy,
+		.start = eth_nxp_s32_start,
+		.stop = eth_nxp_s32_stop,
+		.send = eth_nxp_s32_tx,
+		.set_config = eth_nxp_s32_set_config,
+	},
 };
 
 

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -208,12 +208,14 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	}
 }
 
-static const struct ethernet_api nxp_s32_eth_api = {
-	.iface_api.init = nxp_s32_eth_iface_init,
-	.get_capabilities = nxp_s32_eth_get_capabilities,
-	.get_phy = nxp_s32_eth_get_phy,
-	.set_config = nxp_s32_eth_set_config,
-	.send = nxp_s32_eth_tx
+static DEVICE_API(ethernet, nxp_s32_eth_api) = {
+	.l2 = {
+		.iface_api.init = nxp_s32_eth_iface_init,
+		.get_capabilities = nxp_s32_eth_get_capabilities,
+		.get_phy = nxp_s32_eth_get_phy,
+		.set_config = nxp_s32_eth_set_config,
+		.send = nxp_s32_eth_tx
+	},
 };
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_psi) == 1, "Only one PSI enabled supported");

--- a/drivers/ethernet/eth_nxp_s32_netc_vsi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_vsi.c
@@ -70,11 +70,13 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	}
 }
 
-static const struct ethernet_api nxp_s32_eth_api = {
-	.iface_api.init = nxp_s32_eth_iface_init,
-	.get_capabilities = nxp_s32_eth_get_capabilities,
-	.set_config = nxp_s32_eth_set_config,
-	.send = nxp_s32_eth_tx
+static DEVICE_API(ethernet, nxp_s32_eth_api) = {
+	.l2 = {
+		.iface_api.init = nxp_s32_eth_iface_init,
+		.get_capabilities = nxp_s32_eth_get_capabilities,
+		.set_config = nxp_s32_eth_set_config,
+		.send = nxp_s32_eth_tx
+	},
 };
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_vsi) == 1, "Only one VSI enabled supported");

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -316,11 +316,13 @@ static const struct device *renesas_ra_eth_get_phy(const struct device *dev)
 	return config->phy_dev;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init = renesas_ra_eth_initialize,
-	.get_capabilities = renesas_ra_eth_get_capabilities,
-	.get_phy = renesas_ra_eth_get_phy,
-	.send = renesas_ra_eth_tx,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = renesas_ra_eth_initialize,
+		.get_capabilities = renesas_ra_eth_get_capabilities,
+		.get_phy = renesas_ra_eth_get_phy,
+		.send = renesas_ra_eth_tx,
+	},
 };
 
 static void renesas_ra_eth_isr(const struct device *dev)

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2024,18 +2024,18 @@ static const struct device *eth_sam_gmac_get_ptp_clock(const struct device *dev)
 }
 #endif
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_iface_init,
-
-	.get_capabilities = eth_sam_gmac_get_capabilities,
-	.set_config = eth_sam_gmac_set_config,
-	.get_config = eth_sam_gmac_get_config,
-	.get_phy = eth_sam_gmac_get_phy,
-	.send = eth_tx,
-
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
+		.get_capabilities = eth_sam_gmac_get_capabilities,
+		.set_config = eth_sam_gmac_set_config,
+		.get_config = eth_sam_gmac_get_config,
+		.get_phy = eth_sam_gmac_get_phy,
+		.send = eth_tx,
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
-	.get_ptp_clock = eth_sam_gmac_get_ptp_clock,
+		get_ptp_clock = eth_sam_gmac_get_ptp_clock,
 #endif
+	},
 };
 
 #define DEFN_IRQ_CONFIG(n, x, name)							\

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -537,14 +537,16 @@ static void sy1xx_mac_rx_thread_entry(void *p1, void *p2, void *p3)
 	}
 }
 
-const struct ethernet_api sy1xx_mac_driver_api = {
-	.start = sy1xx_mac_start,
-	.stop = sy1xx_mac_stop,
-	.iface_api.init = sy1xx_mac_iface_init,
-	.get_capabilities = sy1xx_mac_get_caps,
-	.set_config = sy1xx_mac_set_config,
-	.send = sy1xx_mac_send,
-	.get_phy = sy1xx_mac_get_phy,
+static DEVICE_API(ethernet, sy1xx_mac_driver_api) = {
+	.l2 = {
+		.start = sy1xx_mac_start,
+		.stop = sy1xx_mac_stop,
+		.iface_api.init = sy1xx_mac_iface_init,
+		.get_capabilities = sy1xx_mac_get_caps,
+		.set_config = sy1xx_mac_set_config,
+		.send = sy1xx_mac_send,
+		.get_phy = sy1xx_mac_get_phy,
+	},
 };
 
 #define SY1XX_MAC_INIT(n)                                                                          \

--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -52,12 +52,13 @@ static int eth_slip_tap_set_config(const struct device *dev, enum ethernet_confi
 	return -ENOTSUP;
 }
 
-static const struct ethernet_api slip_if_api = {
-	.iface_api.init = slip_iface_init,
-
-	.get_capabilities = eth_capabilities,
-	.send = slip_send,
-	.set_config = eth_slip_tap_set_config,
+static DEVICE_API(ethernet, slip_if_api) = {
+	.l2 = {
+		.iface_api.init = slip_iface_init,
+		.get_capabilities = eth_capabilities,
+		.send = slip_send,
+		.set_config = eth_slip_tap_set_config,
+	},
 };
 
 #define _SLIP_L2_LAYER    ETHERNET_L2

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -506,14 +506,16 @@ error:
 	return -1;
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init = eth_initialize,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_initialize,
 
-	.get_capabilities = eth_smsc911x_get_capabilities,
-	.send = eth_tx,
+		.get_capabilities = eth_smsc911x_get_capabilities,
+		.send = eth_tx,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = get_stats,
+		.get_stats = get_stats,
 #endif
+	},
 };
 
 static void smsc_discard_pkt(void)

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -774,12 +774,14 @@ static void eth_initialize(struct net_if *iface)
 	}
 }
 
-static const struct ethernet_api api_funcs = {
-	.iface_api.init   = eth_initialize,
-	.get_capabilities = eth_smsc_get_caps,
-	.get_phy          = eth_get_phy,
-	.set_config       = eth_smsc_set_config,
-	.send             = eth_tx,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init   = eth_initialize,
+		.get_capabilities = eth_smsc_get_caps,
+		.get_phy          = eth_get_phy,
+		.set_config       = eth_smsc_set_config,
+		.send             = eth_tx,
+	},
 };
 
 static void eth_smsc_isr(const struct device *dev)

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -355,12 +355,14 @@ struct eth_stellaris_runtime eth_data = {
 	.tx_pos = 0,
 };
 
-static const struct ethernet_api eth_stellaris_apis = {
-	.iface_api.init	= eth_stellaris_init,
-	.send =  eth_stellaris_send,
+static DEVICE_API(ethernet, eth_stellaris_apis) = {
+	.l2 = {
+		.iface_api.init	= eth_stellaris_init,
+		.send =  eth_stellaris_send,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = eth_stellaris_stats,
+		.get_stats = eth_stellaris_stats,
 #endif
+	},
 };
 
 NET_DEVICE_DT_INST_DEFINE(0,

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -354,22 +354,24 @@ static struct net_stats_eth *eth_stm32_hal_get_stats(const struct device *dev)
 }
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	.get_ptp_clock = eth_stm32_get_ptp_clock,
+		.get_ptp_clock = eth_stm32_get_ptp_clock,
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
-	.get_capabilities = eth_stm32_hal_get_capabilities,
-	.set_config = eth_stm32_hal_set_config,
-	.get_phy = eth_stm32_hal_get_phy,
+		.get_capabilities = eth_stm32_hal_get_capabilities,
+		.set_config = eth_stm32_hal_set_config,
+		.get_phy = eth_stm32_hal_get_phy,
 #if defined(CONFIG_NET_DSA_DEPRECATED)
-	.send = dsa_tx,
+		.send = dsa_tx,
 #else
-	.send = eth_stm32_tx,
+		.send = eth_stm32_tx,
 #endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = eth_stm32_hal_get_stats,
+		.get_stats = eth_stm32_hal_get_stats,
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
+	},
 };
 
 static void eth0_irq_config(void)

--- a/drivers/ethernet/eth_test.c
+++ b/drivers/ethernet/eth_test.c
@@ -117,25 +117,27 @@ static int vnd_ethernet_init(const struct device *dev)
 	return 0;
 }
 
-struct ethernet_api vnd_ethernet_api = {
-	.iface_api.init = vnd_ethernet_iface_init,
+static DEVICE_API(ethernet, vnd_ethernet_api) = {
+	.l2 = {
+		.iface_api.init = vnd_ethernet_iface_init,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = vnd_ethernet_get_stats,
+		.get_stats = vnd_ethernet_get_stats,
 #endif
-	.start = vnd_ethernet_start,
-	.stop = vnd_ethernet_stop,
-	.get_capabilities = vnd_ethernet_get_capabilities,
-	.set_config = vnd_ethernet_set_config,
-	.get_config = vnd_ethernet_get_config,
+		.start = vnd_ethernet_start,
+		.stop = vnd_ethernet_stop,
+		.get_capabilities = vnd_ethernet_get_capabilities,
+		.set_config = vnd_ethernet_set_config,
+		.get_config = vnd_ethernet_get_config,
 #if defined(CONFIG_NET_VLAN)
-	.vlan_setup = vnd_ethernet_vlan_setup,
+		.vlan_setup = vnd_ethernet_vlan_setup,
 #endif /* CONFIG_NET_VLAN */
 
 #if defined(CONFIG_PTP_CLOCK)
-	.get_ptp_clock = vnd_ethernet_get_ptp_clock,
+		.get_ptp_clock = vnd_ethernet_get_ptp_clock,
 #endif /* CONFIG_PTP_CLOCK */
-	.get_phy = vnd_ethernet_get_phy,
-	.send = vnd_ethernet_send,
+		.get_phy = vnd_ethernet_get_phy,
+		.send = vnd_ethernet_send,
+	},
 };
 
 #define VND_ETHERNET_INIT(n)                                                                       \

--- a/drivers/ethernet/eth_virtio_net.c
+++ b/drivers/ethernet/eth_virtio_net.c
@@ -228,10 +228,12 @@ static int virtnet_dev_init(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api virtnet_api = {
-	.iface_api.init = virtnet_if_init,
-	.get_capabilities = virtnet_get_capabilities,
-	.send = virtnet_send,
+static DEVICE_API(ethernet, virtnet_api) = {
+	.l2 = {
+		.iface_api.init = virtnet_if_init,
+		.get_capabilities = virtnet_get_capabilities,
+		.send = virtnet_send,
+	},
 };
 
 #define VIRTIO_NET_DEFINE(inst)                                                                    \

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -482,14 +482,16 @@ static const struct device *w5500_get_phy(const struct device *dev)
 	return config->phy_dev;
 }
 
-static const struct ethernet_api w5500_api_funcs = {
-	.iface_api.init = w5500_iface_init,
-	.get_capabilities = w5500_get_capabilities,
-	.set_config = w5500_set_config,
-	.start = w5500_hw_start,
-	.stop = w5500_hw_stop,
-	.get_phy = w5500_get_phy,
-	.send = w5500_tx,
+static DEVICE_API(ethernet, w5500_api_funcs) = {
+	.l2 = {
+		.iface_api.init = w5500_iface_init,
+		.get_capabilities = w5500_get_capabilities,
+		.set_config = w5500_set_config,
+		.start = w5500_hw_start,
+		.stop = w5500_hw_stop,
+		.get_phy = w5500_get_phy,
+		.send = w5500_tx,	
+	},
 };
 
 static int w5500_get_link_state(const struct device *dev,

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -323,12 +323,14 @@ static int axi_eth_lite_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static const struct ethernet_api axi_eth_lite_api = {
-	.get_phy = axi_eth_lite_get_phy,
-	.get_capabilities = axi_eth_lite_get_caps,
-	.iface_api.init = axi_eth_lite_iface_init,
-	.set_config = axi_eth_lite_set_config,
-	.send = axi_eth_lite_send,
+static DEVICE_API(ethernet, axi_eth_lite_api) = {
+	.l2 = {
+		.get_phy = axi_eth_lite_get_phy,
+		.get_capabilities = axi_eth_lite_get_caps,
+		.iface_api.init = axi_eth_lite_iface_init,
+		.set_config = axi_eth_lite_set_config,
+		.send = axi_eth_lite_send,
+	},
 };
 
 static inline int axi_eth_lite_read_to_pkt(const struct axi_eth_lite_config *config,

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -565,13 +565,15 @@ static int xilinx_axienet_probe(const struct device *dev)
 }
 
 /* TODO PTP, VLAN not supported yet */
-static const struct ethernet_api xilinx_axienet_api = {
-	.iface_api.init = xilinx_axienet_iface_init,
-	.get_capabilities = xilinx_axienet_caps,
-	.get_config = xilinx_axienet_get_config,
-	.set_config = xilinx_axienet_set_config,
-	.get_phy = xilinx_axienet_get_phy,
-	.send = xilinx_axienet_send,
+static DEVICE_API(ethernet, xilinx_axienet_api) = {
+	.l2 = {
+		.iface_api.init = xilinx_axienet_iface_init,
+		.get_capabilities = xilinx_axienet_caps,
+		.get_config = xilinx_axienet_get_config,
+		.set_config = xilinx_axienet_set_config,
+		.get_phy = xilinx_axienet_get_phy,
+		.send = xilinx_axienet_send,
+	},
 };
 
 #define SETUP_IRQS(inst)                                                                           \

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -71,17 +71,19 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev);
 static void eth_xlnx_gem_tx_done_work(struct k_work *item);
 static void eth_xlnx_gem_handle_tx_done(const struct device *dev);
 
-static const struct ethernet_api eth_xlnx_gem_apis = {
-	.iface_api.init   = eth_xlnx_gem_iface_init,
-	.get_capabilities = eth_xlnx_gem_get_capabilities,
-	.send		  = eth_xlnx_gem_send,
-	.start		  = eth_xlnx_gem_start_device,
-	.stop		  = eth_xlnx_gem_stop_device,
-	.get_config	  = eth_xlnx_gem_get_config,
-	.set_config	  = eth_xlnx_gem_set_config,
+static DEVICE_API(ethernet, eth_xlnx_gem_apis) = {
+	.l2 = {
+		.iface_api.init   = eth_xlnx_gem_iface_init,
+		.get_capabilities = eth_xlnx_gem_get_capabilities,
+		.send		  = eth_xlnx_gem_send,
+		.start		  = eth_xlnx_gem_start_device,
+		.stop		  = eth_xlnx_gem_stop_device,
+		.get_config	  = eth_xlnx_gem_get_config,
+		.set_config	  = eth_xlnx_gem_set_config,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats	  = eth_xlnx_gem_stats,
+		.get_stats	  = eth_xlnx_gem_stats,
 #endif
+	},
 };
 
 /*

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1053,21 +1053,23 @@ int eth_xmc4xxx_vlan_setup(const struct device *dev, struct net_if *iface, uint1
 }
 #endif
 
-static const struct ethernet_api eth_xmc4xxx_api = {
-	.iface_api.init = eth_xmc4xxx_iface_init,
-	.send = eth_xmc4xxx_send,
-	.set_config = eth_xmc4xxx_set_config,
-	.get_phy = eth_xmc4xxx_get_phy,
-	.get_capabilities = eth_xmc4xxx_capabilities,
+static DEVICE_API(ethernet, eth_xmc4xxx_api) = {
+	.l2 = {
+		.iface_api.init = eth_xmc4xxx_iface_init,
+		.send = eth_xmc4xxx_send,
+		.set_config = eth_xmc4xxx_set_config,
+		.get_phy = eth_xmc4xxx_get_phy,
+		.get_capabilities = eth_xmc4xxx_capabilities,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = eth_xmc4xxx_stats,
+		.get_stats = eth_xmc4xxx_stats,
 #endif
 #if defined(CONFIG_PTP_CLOCK_XMC4XXX)
-	.get_ptp_clock = eth_xmc4xxx_get_ptp_clock,
+		.get_ptp_clock = eth_xmc4xxx_get_ptp_clock,
 #endif
 #if defined(CONFIG_ETH_XMC4XXX_VLAN_HW_FILTER)
-	.vlan_setup = eth_xmc4xxx_vlan_setup,
+		.vlan_setup = eth_xmc4xxx_vlan_setup,
 #endif
+	},
 };
 
 PINCTRL_DT_INST_DEFINE(0);

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -1200,15 +1200,17 @@ static int eth_intel_igc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct ethernet_api eth_api = {
-	.iface_api.init = eth_intel_igc_iface_init,
-	.get_capabilities = eth_intel_igc_get_caps,
-	.set_config = eth_intel_igc_set_config,
-	.send = eth_intel_igc_tx_data,
-	.get_phy = eth_intel_igc_get_phy,
+static DEVICE_API(ethernet, eth_api) = {
+	.l2 = {
+		.iface_api.init = eth_intel_igc_iface_init,
+		.get_capabilities = eth_intel_igc_get_caps,
+		.set_config = eth_intel_igc_set_config,
+		.send = eth_intel_igc_tx_data,
+		.get_phy = eth_intel_igc_get_phy,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = eth_intel_igc_get_stats,
+		.get_stats = eth_intel_igc_get_stats,
 #endif
+	},
 };
 
 #define NUM_QUEUES(n)  DT_INST_PROP(n, num_queues)

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -130,14 +130,18 @@ static const struct device *netc_eth_get_phy(const struct device *dev)
 	return cfg->phy_dev;
 }
 
-static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_iface_init,
-						 .get_capabilities = netc_eth_get_capabilities,
-						 .get_phy = netc_eth_get_phy,
-						 .set_config = netc_eth_set_config,
+static DEVICE_API(ethernet, netc_eth_api) = {
+	.l2 = {
+		.iface_api.init = netc_eth_iface_init,
+		.get_capabilities = netc_eth_get_capabilities,
+		.get_phy = netc_eth_get_phy,
+		.set_config = netc_eth_set_config,
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
-						 .get_ptp_clock = netc_eth_get_ptp_clock,
+		.get_ptp_clock = netc_eth_get_ptp_clock,
 #endif
-						 .send = netc_eth_tx};
+		.send = netc_eth_tx
+	},
+};
 
 #define NETC_PSI_INSTANCE_DEFINE(n)                                                                \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -604,6 +604,16 @@ struct ethernet_api {
 	int (*send)(const struct device *dev, struct net_pkt *pkt);
 };
 
+/* Ethernet L2 layer API */
+__subsystem struct ethernet_driver_api {
+	/** Ethernet L2 operations */
+	struct ethernet_api l2;
+#if defined(CONFIG_ETH_DRIVER_WITH_MDIO) || defined(__DOXYGEN__)
+	/** MDIO controller interface */
+	const struct mdio_driver_api *mdio; 
+#endif
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 /* Make sure that the network interface API is properly setup inside
@@ -946,7 +956,7 @@ static inline
 enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = (struct ethernet_api *)dev->api;
+	const struct ethernet_driver_api *api = DEVICE_API_GET(ethernet, dev);
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 #if defined(CONFIG_NET_DSA) && !defined(CONFIG_NET_DSA_DEPRECATED)
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
@@ -957,11 +967,11 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 		caps |= ETHERNET_DSA_USER_PORT;
 	}
 #endif
-	if (api == NULL || api->get_capabilities == NULL) {
+	if (api == NULL || api->l2.get_capabilities == NULL) {
 		return caps;
 	}
 
-	return (enum ethernet_hw_caps)(caps | api->get_capabilities(dev));
+	return (enum ethernet_hw_caps)(caps | api->l2.get_capabilities(dev));
 }
 
 /**
@@ -977,14 +987,14 @@ static inline
 int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 			 struct ethernet_config *config)
 {
-	const struct ethernet_api *eth =
-		(struct ethernet_api *)net_if_get_device(iface)->api;
+	const struct ethernet_driver_api *eth =
+		(struct ethernet_driver_api *)net_if_get_device(iface)->api;
 
-	if (!eth->get_config) {
+	if (!eth->l2.get_config) {
 		return -ENOTSUP;
 	}
 
-	return eth->get_config(net_if_get_device(iface), type, config);
+	return eth->l2.get_config(net_if_get_device(iface), type, config);
 }
 
 

--- a/samples/net/qos/ethernet/src/main.c
+++ b/samples/net/qos/ethernet/src/main.c
@@ -159,9 +159,11 @@ static int net_if_fake_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static const struct ethernet_api net_if_api = {
-	.iface_api.init = net_iface_init,
-	.send = net_if_fake_send,
+static DEVICE_API(ethernet, net_if_api) = {
+	.l2 = {
+		.iface_api.init = net_iface_init,
+		.send = net_if_fake_send,
+	},
 };
 
 static struct net_if_fake_data context;

--- a/subsys/net/l2/ethernet/dsa/dsa_core.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_core.c
@@ -26,7 +26,7 @@ int dsa_xmit(const struct device *dev, struct net_pkt *pkt)
 	struct net_if *iface = net_if_lookup_by_dev(dev);
 	struct net_if *iface_conduit = dsa_switch_ctx->iface_conduit;
 	const struct device *dev_conduit = net_if_get_device(iface_conduit);
-	const struct ethernet_api *eth_api_conduit = dev_conduit->api;
+	const struct ethernet_driver_api *eth_api_conduit = dev_conduit->api;
 	struct net_pkt *dsa_pkt;
 	struct net_pkt *clone;
 	int ret;
@@ -57,7 +57,7 @@ int dsa_xmit(const struct device *dev, struct net_pkt *pkt)
 	dsa_pkt = dsa_tag_xmit(iface, clone);
 
 	/* Transmit from conduit port */
-	ret = eth_api_conduit->send(dev_conduit, dsa_pkt);
+	ret = eth_api_conduit->l2.send(dev_conduit, dsa_pkt);
 
 	/* Release the cloned pkt */
 	net_pkt_unref(clone);

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -176,14 +176,16 @@ static int dsa_get_config(const struct device *dev, enum ethernet_config_type ty
 	return dsa_switch_ctx->dapi->get_config(dev, type, config);
 }
 
-const struct ethernet_api dsa_eth_api = {
-	.iface_api.init = dsa_port_iface_init,
-	.get_phy = dsa_port_get_phy,
-	.send = dsa_xmit,
+DEVICE_API(ethernet, dsa_eth_api) = {
+	.l2 = {
+		.iface_api.init = dsa_port_iface_init,
+		.get_phy = dsa_port_get_phy,
+		.send = dsa_xmit,
 #ifdef CONFIG_NET_L2_PTP
-	.get_ptp_clock = dsa_port_get_ptp_clock,
+		.get_ptp_clock = dsa_port_get_ptp_clock,
 #endif
-	.get_capabilities = dsa_port_get_capabilities,
-	.set_config = dsa_set_config,
-	.get_config = dsa_get_config,
+		.get_capabilities = dsa_port_get_capabilities,
+		.set_config = dsa_set_config,
+		.get_config = dsa_get_config,
+	},
 };

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -220,7 +220,7 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 	};
 
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = DEVICE_API_GET(ethernet, dev);
 
 	/* Make sure we're an ethernet device */
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
@@ -821,12 +821,12 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 	if (!state) {
 		net_arp_clear_cache(iface);
 
-		if (eth->stop) {
-			ret = eth->stop(net_if_get_device(iface));
+		if (eth->l2.stop) {
+			ret = eth->l2.stop(net_if_get_device(iface));
 		}
 	} else {
-		if (eth->start) {
-			ret = eth->start(net_if_get_device(iface));
+		if (eth->l2.start) {
+			ret = eth->l2.start(net_if_get_device(iface));
 		}
 	}
 
@@ -914,7 +914,7 @@ void net_eth_carrier_off(struct net_if *iface)
 const struct device *net_eth_get_phy(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = DEVICE_API_GET(ethernet, dev);
 
 	if (!api) {
 		return NULL;
@@ -935,7 +935,7 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = DEVICE_API_GET(ethernet, dev);
 
 	if (!api) {
 		return NULL;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -231,7 +231,7 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 		return;
 	}
 
-	if (!api || !api->set_config) {
+	if (!api || !api->l2.set_config) {
 		return;
 	}
 
@@ -250,7 +250,7 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 		return;
 	}
 
-	api->set_config(dev, ETHERNET_CONFIG_TYPE_FILTER, &cfg);
+	api->l2.set_config(dev, ETHERNET_CONFIG_TYPE_FILTER, &cfg);
 }
 #endif
 
@@ -681,7 +681,7 @@ static void ethernet_update_tx_stats(struct net_if *iface, struct net_pkt *pkt)
 
 static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct ethernet_api *api = net_if_get_device(iface)->api;
+	const struct ethernet_driver_api *api = net_if_get_device(iface)->api;
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	uint16_t ptype = net_htons(net_pkt_ll_proto_type(pkt));
 	struct net_pkt *orig_pkt = pkt;
@@ -692,7 +692,7 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 		goto error;
 	}
 
-	if (!api->send) {
+	if (!api->l2.send) {
 		ret = -ENOTSUP;
 		goto error;
 	}
@@ -776,7 +776,7 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	net_pkt_cursor_init(pkt);
 
 send:
-	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
+	ret = net_l2_send(api->l2.send, net_if_get_device(iface), iface, pkt);
 	if (ret != 0) {
 		eth_stats_update_errors_tx(iface);
 		goto arp_error;
@@ -811,7 +811,7 @@ arp_error:
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
 	int ret = 0;
-	const struct ethernet_api *eth =
+	const struct ethernet_driver_api *eth =
 		net_if_get_device(iface)->api;
 
 	if (!eth) {
@@ -924,11 +924,11 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 		return NULL;
 	}
 
-	if (!api->get_phy) {
+	if (!api->l2.get_phy) {
 		return NULL;
 	}
 
-	return api->get_phy(net_if_get_device(iface));
+	return api->l2.get_phy(net_if_get_device(iface));
 }
 
 #if defined(CONFIG_PTP_CLOCK)
@@ -949,11 +949,11 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
-	if (!api->get_ptp_clock) {
+	if (!api->l2.get_ptp_clock) {
 		return NULL;
 	}
 
-	return api->get_ptp_clock(net_if_get_device(iface));
+	return api->l2.get_ptp_clock(net_if_get_device(iface));
 }
 #endif /* CONFIG_PTP_CLOCK */
 

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -16,13 +16,13 @@ LOG_MODULE_REGISTER(net_ethernet_mgmt, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 static inline bool is_hw_caps_supported(const struct device *dev,
 					enum ethernet_hw_caps caps)
 {
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 
-	if (!api || !api->get_capabilities) {
+	if (!api || !api->l2.get_capabilities) {
 		return false;
 	}
 
-	return ((api->get_capabilities(dev) & caps) != 0);
+	return ((api->l2.get_capabilities(dev) & caps) != 0);
 }
 
 static int ethernet_set_config(uint64_t mgmt_request,
@@ -31,7 +31,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 	struct ethernet_config config = { 0 };
 	enum ethernet_config_type type;
 
@@ -39,7 +39,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		return -ENOENT;
 	}
 
-	if (!api->set_config) {
+	if (!api->l2.set_config) {
 		return -ENOTSUP;
 	}
 
@@ -177,7 +177,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		return -EINVAL;
 	}
 
-	return api->set_config(net_if_get_device(iface), type, &config);
+	return api->l2.set_config(net_if_get_device(iface), type, &config);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS,
@@ -213,7 +213,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 	struct ethernet_config config = { 0 };
 	int ret = 0;
 	enum ethernet_config_type type;
@@ -222,7 +222,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 		return -ENOENT;
 	}
 
-	if (!api->get_config) {
+	if (!api->l2.get_config) {
 		return -ENOTSUP;
 	}
 
@@ -237,7 +237,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_PRIORITY_QUEUES_NUM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -253,7 +253,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QAV_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -283,7 +283,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_PORTS_NUM) {
 		type = ETHERNET_CONFIG_TYPE_PORTS_NUM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -307,7 +307,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QBV_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -347,7 +347,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QBU_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -389,7 +389,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_TXTIME_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -407,7 +407,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_TXINJECTION_MODE;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->l2.get_config(dev, type, &config);
 		if (ret) {
 			return ret;
 		}

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -22,7 +22,7 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 {
 	size_t len_chk = 0;
 	void *src = NULL;
-	const struct ethernet_api *eth;
+	const struct ethernet_driver_api *eth;
 
 	switch (NET_MGMT_GET_COMMAND(mgmt_request)) {
 	case NET_REQUEST_STATS_CMD_GET_ETHERNET:
@@ -32,16 +32,16 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 
 		eth = net_if_get_device(iface)->api;
 		if (eth == NULL ||
-		    (eth->get_stats == NULL && eth->get_stats_type == NULL)) {
+		    (eth->l2.get_stats == NULL && eth->l2.get_stats_type == NULL)) {
 			return -ENOENT;
 		}
 
 		len_chk = sizeof(struct net_stats_eth);
-		if (eth->get_stats_type != NULL) {
-			src = eth->get_stats_type(net_if_get_device(iface),
+		if (eth->l2.get_stats_type != NULL) {
+			src = eth->l2.get_stats_type(net_if_get_device(iface),
 						  ETHERNET_STATS_TYPE_ALL);
 		} else {
-			src = eth->get_stats(net_if_get_device(iface));
+			src = eth->l2.get_stats(net_if_get_device(iface));
 		}
 		break;
 	}

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -385,7 +385,7 @@ static void setup_link_address(struct vlan_context *ctx)
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	const struct ethernet_api *eth = net_if_get_device(iface)->api;
+	const struct ethernet_driver_api *eth = net_if_get_device(iface)->api;
 	struct vlan_context *vlan;
 	int ret;
 
@@ -449,8 +449,8 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 		 */
 		setup_link_address(vlan);
 
-		if (eth->vlan_setup) {
-			eth->vlan_setup(net_if_get_device(iface),
+		if (eth->l2.vlan_setup) {
+			eth->l2.vlan_setup(net_if_get_device(iface),
 					iface, vlan->tag, true);
 		}
 
@@ -467,7 +467,7 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 {
-	const struct ethernet_api *eth;
+	const struct ethernet_driver_api *eth;
 	struct vlan_context *vlan;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET) &&
@@ -494,8 +494,8 @@ int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 
 	vlan->tag = NET_VLAN_TAG_UNSPEC;
 
-	if (eth->vlan_setup) {
-		eth->vlan_setup(net_if_get_device(vlan->attached_to),
+	if (eth->l2.vlan_setup) {
+		eth->l2.vlan_setup(net_if_get_device(vlan->attached_to),
 				vlan->attached_to, tag, false);
 	}
 

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -638,7 +638,7 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 #if defined(CONFIG_NET_STATISTICS_ETHERNET) && \
 					defined(CONFIG_NET_STATISTICS_USER_API)
 	if (iface && net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *eth_api;
+		const struct ethernet_driver_api *eth_api;
 		struct net_stats_eth *eth_data = NULL;
 		uint32_t type = ETHERNET_STATS_TYPE_ALL;
 
@@ -651,11 +651,11 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 		eth_api = net_if_get_device(iface)->api;
 		if (eth_api != NULL) {
 			/* Use get_stats_type if available for type filtering */
-			if (eth_api->get_stats_type != NULL) {
-				eth_data = eth_api->get_stats_type(
+			if (eth_api->l2.get_stats_type != NULL) {
+				eth_data = eth_api->l2.get_stats_type(
 					net_if_get_device(iface), type);
-			} else if (eth_api->get_stats != NULL) {
-				eth_data = eth_api->get_stats(
+			} else if (eth_api->l2.get_stats != NULL) {
+				eth_data = eth_api->l2.get_stats(
 					net_if_get_device(iface));
 			}
 		}

--- a/subsys/usb/device/class/netusb/netusb.c
+++ b/subsys/usb/device/class/netusb/netusb.c
@@ -137,11 +137,13 @@ static void netusb_init(struct net_if *iface)
 	LOG_INF("netusb initialized");
 }
 
-static const struct ethernet_api netusb_api_funcs = {
-	.iface_api.init = netusb_init,
+static DEVICE_API(ethernet, netusb_api_funcs) = {
+	.l2 = {
+		.iface_api.init = netusb_init,
 
-	.get_capabilities = NULL,
-	.send = netusb_send,
+		.get_capabilities = NULL,
+		.send = netusb_send,
+	},
 };
 
 static int netusb_init_dev(const struct device *dev)

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -645,13 +645,15 @@ static struct usbd_class_api usbd_cdc_ecm_api = {
 	.get_desc = usbd_cdc_ecm_get_desc,
 };
 
-static const struct ethernet_api cdc_ecm_eth_api = {
-	.iface_api.init = cdc_ecm_iface_init,
-	.set_config = cdc_ecm_set_config,
-	.get_capabilities = cdc_ecm_get_capabilities,
-	.send = cdc_ecm_send,
-	.start = cdc_ecm_iface_start,
-	.stop = cdc_ecm_iface_stop,
+static DEVICE_API(ethernet, cdc_ecm_eth_api) = {
+	.l2 = {
+		.iface_api.init = cdc_ecm_iface_init,
+		.set_config = cdc_ecm_set_config,
+		.get_capabilities = cdc_ecm_get_capabilities,
+		.send = cdc_ecm_send,
+		.start = cdc_ecm_iface_start,
+		.stop = cdc_ecm_iface_stop,
+	},
 };
 
 #define CDC_ECM_DEFINE_DESCRIPTOR(n)						\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1195,13 +1195,15 @@ static struct usbd_class_api usbd_cdc_ncm_api = {
 	.get_desc = usbd_cdc_ncm_get_desc,
 };
 
-static const struct ethernet_api cdc_ncm_eth_api = {
-	.iface_api.init = cdc_ncm_iface_init,
-	.set_config = cdc_ncm_set_config,
-	.get_capabilities = cdc_ncm_get_capabilities,
-	.send = cdc_ncm_send,
-	.start = cdc_ncm_iface_start,
-	.stop = cdc_ncm_iface_stop,
+static DEVICE_API(ethernet, cdc_ncm_eth_api) = {
+	.l2 = {
+		.iface_api.init = cdc_ncm_iface_init,
+		.set_config = cdc_ncm_set_config,
+		.get_capabilities = cdc_ncm_get_capabilities,
+		.send = cdc_ncm_send,
+		.start = cdc_ncm_iface_start,
+		.stop = cdc_ncm_iface_stop,
+	},
 };
 
 #define CDC_NCM_DEFINE_DESCRIPTOR(n)						\

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -267,9 +267,11 @@ static void setup_eth_header(struct net_if *iface, struct net_pkt *pkt,
 struct net_arp_context net_arp_context_data;
 
 #if defined(CONFIG_NET_ARP) && defined(CONFIG_NET_L2_ETHERNET)
-static const struct ethernet_api net_arp_if_api = {
-	.iface_api.init = net_arp_iface_init,
-	.send = tester_send,
+static DEVICE_API(ethernet, net_arp_if_api) = {
+	.l2 = {
+		.iface_api.init = net_arp_iface_init,
+		.send = tester_send,
+	},
 };
 
 #define _ETH_L2_LAYER ETHERNET_L2

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -120,11 +120,13 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static const struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
-	.get_capabilities = eth_fake_get_capabilities,
-	.set_config = eth_fake_set_config,
-	.send = eth_fake_send,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
+		.get_capabilities = eth_fake_get_capabilities,
+		.set_config = eth_fake_set_config,
+		.send = eth_fake_send,
+	},
 };
 
 static int eth_fake_init(const struct device *dev)
@@ -166,7 +168,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	DBG("Interface %p [%d]\n", iface, net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/*

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -424,18 +424,22 @@ static enum ethernet_hw_caps eth_offloading_disabled(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs_offloading_disabled = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, api_funcs_offloading_disabled) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_offloading_disabled,
-	.send = eth_tx_offloading_disabled,
+		.get_capabilities = eth_offloading_disabled,
+		.send = eth_tx_offloading_disabled,
+	},
 };
 
-static struct ethernet_api api_funcs_offloading_enabled = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, api_funcs_offloading_enabled) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_offloading_enabled,
-	.send = eth_tx_offloading_enabled,
+		.get_capabilities = eth_offloading_enabled,
+		.send = eth_tx_offloading_enabled,
+	},
 };
 
 static void generate_mac(uint8_t *mac_addr)

--- a/tests/net/conn_mgr_monitor/src/test_ifaces.c
+++ b/tests/net/conn_mgr_monitor/src/test_ifaces.c
@@ -42,8 +42,10 @@ static struct dummy_api test_iface_api = {
 	.send = test_iface_send,
 };
 
-static struct ethernet_api dummy_eth_api = {
-	.iface_api.init = test_iface_init,
+static DEVICE_API(ethernet, dummy_eth_api) = {
+	.l2 = {
+		.iface_api.init = test_iface_init,
+	},
 };
 
 NET_DEVICE_INIT(test_if_simple_a,

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -454,13 +454,15 @@ static int eth_fake_get_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
 
-	.get_capabilities = eth_fake_get_capabilities,
-	.set_config = eth_fake_set_config,
-	.get_config = eth_fake_get_config,
-	.send = eth_fake_send,
+		.get_capabilities = eth_fake_get_capabilities,
+		.set_config = eth_fake_set_config,
+		.get_config = eth_fake_get_config,
+		.send = eth_fake_send,
+	},
 };
 
 static int eth_fake_init(const struct device *dev)

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -131,9 +131,11 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 
 struct net_if_test net_iface1_data;
 
-static struct ethernet_api net_iface_api = {
-	.iface_api.init = net_iface_init,
-	.send = sender_iface,
+static DEVICE_API(ethernet, net_iface_api) = {
+	.l2 = {
+		.iface_api.init = net_iface_init,
+		.send = sender_iface,
+	},
 };
 
 #define _ETH_L2_LAYER ETHERNET_L2
@@ -191,7 +193,7 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
 	.iface_api.init = eth_fake_iface_init,
 	.send = eth_fake_send,
 };

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -256,12 +256,14 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
 
-	.get_capabilities = eth_fake_get_capabilities,
-	.set_config = eth_fake_set_config,
-	.send = eth_fake_send,
+		.get_capabilities = eth_fake_get_capabilities,
+		.set_config = eth_fake_set_config,
+		.send = eth_fake_send,
+	},
 };
 
 static int eth_fake_init(const struct device *dev)
@@ -300,7 +302,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/* As native_sim board will introduce another ethernet

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -384,9 +384,11 @@ out:
 /* Ethernet interface (interface under test) */
 struct net_test_ipv6 net_test_data;
 
-static const struct ethernet_api net_test_if_api = {
-	.iface_api.init = net_test_iface_init,
-	.send = tester_send,
+static DEVICE_API(ethernet, net_test_if_api) = {
+	.l2 = {
+		.iface_api.init = net_test_iface_init,
+		.send = tester_send,
+	},
 };
 
 #define _ETH_L2_LAYER ETHERNET_L2

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -56,9 +56,11 @@ int fake_dev_init(const struct device *dev)
 }
 
 #if defined(CONFIG_NET_L2_ETHERNET)
-static const struct ethernet_api fake_dev_api = {
-	.iface_api.init = fake_dev_iface_init,
-	.send = fake_dev_send,
+static DEVICE_API(ethernet, fake_dev_api) = {
+	.l2 = {
+		.iface_api.init = fake_dev_iface_init,
+		.send = fake_dev_send,
+	},
 };
 
 #define _ETH_L2_LAYER ETHERNET_L2

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -125,12 +125,14 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
 
-	.get_capabilities = eth_fake_get_capabilities,
-	.set_config = eth_fake_set_config,
-	.send = eth_fake_send,
+		.get_capabilities = eth_fake_get_capabilities,
+		.set_config = eth_fake_set_config,
+		.send = eth_fake_send,
+	},
 };
 
 static int eth_fake_init(const struct device *dev)
@@ -175,7 +177,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/* As native_sim board will introduce another ethernet

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -131,12 +131,14 @@ static const struct device *eth_get_ptp_clock(const struct device *dev)
 	return context->ptp_clock;
 }
 
-static struct ethernet_api api_funcs = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_capabilities,
-	.get_ptp_clock = eth_get_ptp_clock,
-	.send = eth_tx,
+		.get_capabilities = eth_capabilities,
+		.get_ptp_clock = eth_get_ptp_clock,
+		.send = eth_tx,
+	},
 };
 
 static void generate_mac(uint8_t *mac_addr)

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -171,9 +171,11 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
-	.send = eth_fake_send,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
+		.send = eth_fake_send,
+	};
 };
 
 ETH_NET_DEVICE_INIT(eth_fake1, "eth_fake1", NULL, NULL, &eth_fake_data1, NULL,

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -227,13 +227,15 @@ static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
 	       ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
 
-	.get_capabilities = eth_fake_get_capabilities,
-	.set_config = eth_fake_set_config,
-	.get_config = eth_fake_get_config,
-	.send = eth_fake_send,
+		.get_capabilities = eth_fake_get_capabilities,
+		.set_config = eth_fake_set_config,
+		.get_config = eth_fake_get_config,
+		.send = eth_fake_send,
+	},
 };
 
 static int eth_fake_init(const struct device *dev)

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1000,9 +1000,11 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
-	.iface_api.init = eth_fake_iface_init,
-	.send = eth_fake_send,
+static DEVICE_API(ethernet, eth_fake_api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_fake_iface_init,
+		.send = eth_fake_send,
+	},
 };
 
 ETH_NET_DEVICE_INIT(eth_fake, "eth_fake", NULL, NULL, &eth_fake_data, NULL,

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -126,11 +126,13 @@ static enum ethernet_hw_caps eth_get_capabilities(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_get_capabilities,
-	.send = eth_tx,
+		.get_capabilities = eth_get_capabilities,
+		.send = eth_tx,
+	},
 };
 
 static void generate_mac(uint8_t *mac_addr)

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -160,11 +160,13 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs = {
-	.iface_api.init = eth_iface_init,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_capabilities,
-	.send = eth_tx,
+		.get_capabilities = eth_capabilities,
+		.send = eth_tx,
+	},
 };
 
 static void generate_mac(uint8_t *mac_addr)

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -240,11 +240,13 @@ static enum ethernet_hw_caps eth_vlan_capabilities(const struct device *dev)
 	return ETHERNET_HW_VLAN;
 }
 
-static struct ethernet_api api_funcs = {
-	.iface_api.init = eth_vlan_iface_init,
+static DEVICE_API(ethernet, api_funcs) = {
+	.l2 = {
+		.iface_api.init = eth_vlan_iface_init,
 
-	.get_capabilities = eth_vlan_capabilities,
-	.send = eth_tx,
+		.get_capabilities = eth_vlan_capabilities,
+		.send = eth_tx,
+	},
 };
 
 static void generate_mac(uint8_t *mac_addr)
@@ -305,7 +307,7 @@ static enum ethernet_hw_caps eth_vlan_embed_ll_hdr_capabilities(const struct dev
 	return ETHERNET_HW_VLAN;
 }
 
-static struct ethernet_api api_vlan_embed_ll_hdr_funcs = {
+static DEVICE_API(ethernet, api_vlan_embed_ll_hdr_funcs) = {
 	.iface_api.init = eth_vlan_iface_init,
 
 	.get_capabilities = eth_vlan_embed_ll_hdr_capabilities,


### PR DESCRIPTION
Allow the Ethernet controller to define its implementation using `DEVICE_API`, and add the implementation to the system iterable section.