### PR TITLE
pm: device: Refactor power domain add/remove logic

### DIFF
--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -306,5 +306,31 @@ ZTEST(power_domain_1cpu, test_on_power_domain)
 	zassert_false(pm_device_on_power_domain(devc), "devc in the power domain.");
 }
 
+ZTEST(power_domain_1cpu, test_power_domain_add_remove_duplicate)
+{
+	int ret;
+
+	devc = DEVICE_GET(devc);
+	zassert_true(device_is_ready(devc), "Device is not ready!");
+
+	ret = pm_device_power_domain_remove(devc, domain);
+	zassert_equal(ret, -ENOENT);
+
+	ret = pm_device_power_domain_add(devc, domain);
+	zassert_equal(ret, 0);
+	zassert_true(pm_device_on_power_domain(devc), "devc is not in the power domain.");
+
+	ret = pm_device_power_domain_add(devc, domain);
+	zassert_equal(ret, -EALREADY);
+	zassert_true(pm_device_on_power_domain(devc), "devc is not in the power domain.");
+
+	ret = pm_device_power_domain_remove(devc, domain);
+	zassert_equal(ret, 0);
+	zassert_false(pm_device_on_power_domain(devc), "devc in the power domain.");
+
+	ret = pm_device_power_domain_remove(devc, domain);
+	zassert_equal(ret, -ENOENT);
+}
+
 ZTEST_SUITE(power_domain_1cpu, NULL, NULL, ztest_simple_1cpu_before,
 			ztest_simple_1cpu_after, NULL);

--- a/tests/subsys/pm/power_domain/testcase.yaml
+++ b/tests/subsys/pm/power_domain/testcase.yaml
@@ -5,7 +5,7 @@ tests:
     integration_platforms:
       - native_sim
     tags: pm
-  pm.power_doamin.isr_safe:
+  pm.power_domain.isr_safe:
     platform_allow:
       - native_sim
     integration_platforms:


### PR DESCRIPTION
It turns out that `power_domain_add_or_remove()` when `add==true` only looks for `DEVICE_HANDLE_NULL` empty slots to write to, and never checks "whether this `dev_handle` is already in the supported handles or not". The result is: repeated adds may insert duplicate entries; or when there are no empty slots, even though it's "already in the domain", it returns `-ENOSPC` (which conflicts with the documented semantics).

This commit adds a check: when `add==true` and `rv[i] == dev_handle` is found, it returns `-EALREADY` and avoids duplicate insertion.