### PR TITLE
modules: hostap: hapd_api: fix potential null pointer dereference

### DIFF
--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -375,17 +375,21 @@ int hostapd_ap_reg_domain(const struct device *dev,
 	if (iface == NULL) {
 		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		ret = -ENODEV;
+		goto out;
 	}
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
 		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
 		ret = -EACCES;
+		goto out;
 	}
 
 	if (!hostapd_cli_cmd_v("set country_code %s", reg_domain->country_code)) {
 		ret = -ENOTSUP;
+		goto out;
 	}
 
+out:
 	return ret;
 }
 


### PR DESCRIPTION
Prevent a possible NULL pointer dereference in
hostapd_ap_reg_domain() when get_hostapd_handle() returns NULL.

Previously, the function continued execution after detecting a NULL interface pointer, which could lead to dereferencing iface->state.

Return early via a common exit path when errors are detected to ensure safe execution.