### PR TITLE
scripts: dts: python-devicetree: extend special casing to io-channels

### DIFF
--- a/doc/build/dts/phandles.rst
+++ b/doc/build/dts/phandles.rst
@@ -327,11 +327,13 @@ specifier space ``foo``. For example:
 The ``dmas`` property's specifier space is "dma". The ``pwms`` property's
 specifier space is ``pwm``.
 
-Special case: GPIO
-==================
+Special case: GPIOs and IO channels
+====================================
 
-``*-gpios`` properties are special-cased so that e.g. ``foo-gpios`` resolves to
-``#gpio-cells`` rather than ``#foo-gpio-cells``.
+``*-gpios`` and ``*-io-channels`` properties are special-cased so that e.g.
+``foo-gpios`` and ``bar-io-channels`` resolve to ``#gpio-cells`` and
+``#io-channel-cells`` respectively, rather than ``#foo-gpio-cells`` and
+``#bar-io-channel-cells``.
 
 Manually specifying a space
 ===========================

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2052,15 +2052,19 @@ class Node:
         # unspecified.
 
         if not specifier_space:
-            if prop.name.endswith("gpios"):
-                # There's some slight special-casing for *-gpios properties in that
-                # e.g. foo-gpios still maps to #gpio-cells rather than
-                # #foo-gpio-cells
-                specifier_space = "gpio"
-            else:
-                # Strip -s. We've already checked that property names end in -s
-                # if there is no specifier space in _check_prop_by_type().
-                specifier_space = prop.name[:-1]
+            specifier_space_groups = {"gpio", "io-channel"}
+            for group in specifier_space_groups:
+                if prop.name.endswith(group + 's'):
+                    # There's some slight special-casing for some properties in that
+                    # e.g. foo-gpios and bar-io-channels still map to #gpio-cells and
+                    # #io-channels rather than #foo-gpio-cells and bar-io-channels
+                    # respectively.
+                    specifier_space = group
+
+        if not specifier_space:
+            # Strip -s. We've already checked that property names end in -s
+            # if there is no specifier space in _check_prop_by_type().
+            specifier_space = prop.name[:-1]
 
         res: list[Optional[ControllerAndData]] = []
 

--- a/scripts/dts/python-devicetree/tests/test-bindings/phandle-array-controller-2.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/phandle-array-controller-2.yaml
@@ -7,3 +7,6 @@ compatible: "phandle-array-controller-2"
 phandle-array-foo-cells:
   - one
   - two
+
+io-channel-cells:
+  - io-channel-one

--- a/scripts/dts/python-devicetree/tests/test-bindings/props.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/props.yaml
@@ -49,3 +49,6 @@ properties:
 
   path:
     type: path
+
+  bar-io-channels:
+    type: phandle-array

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -425,6 +425,7 @@
 		phandle-array-foos = <&{/ctrl-1} 1 &{/ctrl-2} 2 3>;
 		foo-gpios = <&{/ctrl-1} 1>;
 		path = &{/ctrl-1};
+		bar-io-channels = <&{/ctrl-2} 2>;
 	};
 
 	ctrl-1 {
@@ -436,6 +437,7 @@
 	ctrl-2 {
 		compatible = "phandle-array-controller-2";
 		#phandle-array-foo-cells = <2>;
+		#io-channel-cells = <1>;
 	};
 
 	props-2 {
@@ -580,6 +582,8 @@
 		handle = <&{/ctrl-1}>;
 		phandles = <&{/ctrl-1}>, <&{/ctrl-2}>;
 		phandle-array-foos = <&{/ctrl-2} 1 2>;
+		foo-gpios = <&{/ctrl-1} 1>;
+		bar-io-channels = <&{/ctrl-2} 2>;
 	};
 
 	//

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -764,6 +764,10 @@ def test_props():
                               'foo-gpios',
                               [(ctrl_1, {'gpio-one': 1})])
 
+    verify_phandle_array_prop(props_node,
+                              'bar-io-channels',
+                              [(ctrl_2, {'io-channel-one': 2})])
+
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''
     with from_here():
@@ -891,6 +895,14 @@ def test_binding_inference():
     verify_phandle_array_prop(zephyr_user,
                               'phandle-array-foos',
                               [(edt.get_node('/ctrl-2'), {'one': 1, 'two': 2})])
+
+    verify_phandle_array_prop(zephyr_user,
+                              'foo-gpios',
+                              [(ctrl_1, {'gpio-one': 1})])
+
+    verify_phandle_array_prop(zephyr_user,
+                              'bar-io-channels',
+                              [(ctrl_2, {'io-channel-one': 2})])
 
 def test_multi_bindings():
     '''Test having multiple directories with bindings'''


### PR DESCRIPTION
Extend the special casing of specifer space to include io-channels, making the implementation a bit more easily scalable for the future as well. This allows defining io-channels like gpios, prepending a name like foo-io-channels, which is useful when multiple groups of io-channels need to be defined for a node:

```
  foo {
          bar-io-channels = <&baz 0>, <&baz 1>;
          qiz-io-channels = <&baz 2>, <&baz 3>;
  };
```

This is useful for defining channels to be read in parrallel sequences.

without this addition, io-channels can only be defined in a single sequence, and each entry extracted by name or IDX:
```
io-channels = <&baz 0>, <&baz 1>, <&baz 2>, <&baz 3>;
io-channel-names = "bar_0", "bar_1", "qiz_0", "qiz_1";
```
which then has to be stitched together with macro magic, by name or idx... either that or baz in this case would have to define two different io channels:
```
properties:
  bar-io-channel-cells:
    - id

  qiz-io-channel-cells: 
    - id
```
which does not make sense in this case since baz in this case is not the component defining the sequences, to it an io-channel is an io-channel, like a gpio is a gpio.

See https://github.com/zephyrproject-rtos/zephyr/pull/99787 which could use this addition.

Extending it to pwms maybe could be cool?
```
rgb_led {
        red-pwms = <...>;
        green-pwms = <...>;
        blue-pwms = <...>;
};
```

