### PR TITLE
tracing: ctf: fixes missing end_call event in ctf metadata

### DIFF
--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -162,6 +162,11 @@ event {
 };
 
 event {
+    name = end_call;
+    id = 0x20;
+};
+
+event {
 	name = semaphore_init;
 	id = 0x21;
 	fields := struct {


### PR DESCRIPTION
When converting a ctf trace (which was recorded in-memory and dumped via gdb) with babeltrace2, the process ends with an error message stating that event-class-id 32 could not be found.

This event class is implemented in ctf_top.h and therefore being recorded, but the metadata file does not contain an according event definition.

The same is true for event class 31, but up until now no error regarding this event class appeared, so this one remains untouched.

I don't have much experience with Zephyr's tracing subsystem, the ctf format and babeltrace2, so I assume that this fix is incomplete. Happily accepting any input or suggestions!