### PR TITLE
dts: raspberrypi: rpi_pico2: Fix missing partition ranges

### DIFF
--- a/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
+++ b/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -76,6 +77,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(2)>;
+			read-only;
+		};
+	};
 };
 
 &gpio0 {

--- a/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
+++ b/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -41,6 +42,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(2)>;
+			read-only;
+		};
+	};
 };
 
 &gpio0 {

--- a/boards/kws/pico2_spe/pico2_spe.dtsi
+++ b/boards/kws/pico2_spe/pico2_spe.dtsi
@@ -16,6 +16,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -58,6 +59,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(4)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/boards/kws/pico2_spe/pico2_spe.dtsi
+++ b/boards/kws/pico2_spe/pico2_spe.dtsi
@@ -62,12 +62,12 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(4)>;
 			read-only;

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -95,12 +95,12 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(16)>;
 			read-only;

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -91,6 +92,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(16)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -64,12 +64,12 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(4)>;
 			read-only;

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash-controller = &qmi;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -60,6 +61,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(4)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
@@ -23,6 +23,10 @@
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.
  */
+&flash0 {
+	/delete-node/ partitions;
+};
+
 #include <raspberrypi/partitions_4M_sysbuild.dtsi>
 
 / {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
@@ -80,6 +80,10 @@
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.
  */
+&flash0 {
+	/delete-node/ partitions;
+};
+
 #include <raspberrypi/partitions_4M_sysbuild.dtsi>
 
 / {

--- a/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
+++ b/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
@@ -103,6 +103,7 @@
 &flash0 {
 	status = "okay";
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 };
 
 &storage_partition {

--- a/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
+++ b/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
@@ -66,12 +66,12 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(4)>;
 			read-only;

--- a/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
+++ b/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -62,6 +63,20 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(4)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -85,12 +85,12 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(16)>;
 			read-only;

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	pico_header: connector {
@@ -80,10 +81,21 @@
 };
 
 &flash0 {
-	/* 16MB of flash minus the 0x100 used for
-	 * the second stage bootloader
-	 */
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x0 DT_SIZE_M(16)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
@@ -5,7 +5,7 @@
  */
 
 &flash0 {
-	status = "okay";
+	/delete-node/ partitions;
 
 	partitions {
 		compatible = "fixed-partitions";

--- a/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
@@ -5,12 +5,13 @@
  */
 
 &flash0 {
-	status = "okay";
+	/delete-node/ partitions;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
+		ranges;
 
 		second_stage_bootloader: partition@0 {
 			label = "second_stage_bootloader";

--- a/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
@@ -5,12 +5,13 @@
  */
 
 &flash0 {
-	status = "okay";
+	/delete-node/ partitions;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
+		ranges;
 
 		code_partition: partition@0 {
 			label = "code";

--- a/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
@@ -5,21 +5,20 @@
  */
 
 &flash0 {
-	/delete-node/ partitions;
-
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(1)>;
 			read-only;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x100000 DT_SIZE_M(3)>;
 		};

--- a/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
@@ -5,12 +5,13 @@
  */
 
 &flash0 {
-	status = "okay";
+	/delete-node/ partitions;
 
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
@@ -5,30 +5,31 @@
  */
 
 &flash0 {
-	/delete-node/ partitions;
-
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x10000>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 0xd0000>;
 		};
 
 		slot1_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xe0000 0xd0000>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 0x250000>;
 		};

--- a/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
@@ -205,6 +205,8 @@
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <DT_SIZE_K(4)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 


### PR DESCRIPTION
After PR #103222 , building for rp2350-based boards generates incorrect binaries and warns with:

`warning: Deprecated symbol FLASH_CODE_PARTITION_ADDRESS_INVALID ...`

Fixed by adding ranges properties to flash and partitions, and zephyr,code-parition to chosen node in same manner as PR #103222 . Built samples/hello_world for each board and did not get warning.

Fixes #103694 