### PR TITLE
dts: bindings: can: st: fdcan: improve descriptions and add examples

### DIFF
--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -1,4 +1,8 @@
-description: STM32 FDCAN CAN FD controller
+title: STM32 FDCAN CAN FD controller
+
+description: |
+  STM32 Controller Area Network (CAN) controller with Flexible Data (FD) rate and fixed message RAM
+  layout.
 
 compatible: "st,stm32-fdcan"
 
@@ -54,3 +58,17 @@ properties:
       Hardware Constraint: The selected timer must be physically routed to the
       fdcan_ts input in the SoC interconnect. (e.g. TIM3 on STM32G4). The exact timer
       connected to the fdcan_ts input can be found in the reference manual of the specific SoC.
+
+examples:
+  - |
+      fdcan1: can@40006400 {
+        compatible = "st,stm32-fdcan";
+        reg = <0x40006400 0x400>, <0x4000b400 0x350>;
+        reg-names = "m_can", "message_ram";
+        interrupts = <21 0>, <22 0>;
+        interrupt-names = "int0", "int1";
+        clocks = <&rcc STM32_CLOCK(APB1, 12)>,
+                 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
+        bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+        status = okay";
+      };

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -5,6 +5,9 @@ compatible: "st,stm32-fdcan"
 include: ["bosch,m_can-base.yaml", "pinctrl-device.yaml"]
 
 properties:
+  clocks:
+    required: true
+
   reg:
     required: true
 
@@ -12,9 +15,6 @@ properties:
     required: true
 
   interrupt-names:
-    required: true
-
-  clocks:
     required: true
 
   clk-divider:
@@ -36,13 +36,12 @@ properties:
       - 26
       - 28
       - 30
-
     description: |
-      Divides the kernel clock giving the time quanta clock that is fed to the
-      CAN core(FDCAN_CKDIV).
-      Note that the divisor is common to all 'st,stm32-fdcan' instances.
-      Divide by 1 is the peripherals reset value and remains set unless
-      this property is configured.
+      FDCAN kernel/domain clock divider. The resulting clock is fed to the FDCAN time quanta
+      clock. Note that the divisor is common to all 'st,stm32-fdcan' instances.
+
+      The clock divider, which is set via the FDCAN_CKDIV register, defaults to divide by 1 unless
+      this property is provided.
 
   external-timestamp-counter:
     type: phandle

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -1,4 +1,8 @@
-description: STM32H7 series FDCAN CAN FD controller
+title: STM32H7 series (and compatible) FDCAN CAN FD controller
+
+description: |
+  STM32 Controller Area Network (CAN) controller with Flexible Data (FD) rate and Clock Calibration
+  Unit (CCU).
 
 compatible: "st,stm32h7-fdcan"
 
@@ -42,3 +46,17 @@ properties:
 
       The clock divider, which is set via the FDCAN_CCU->CCFG_CDIV register, defaults to divide by 1
       unless this property is provided.
+
+examples:
+  - |
+      fdcan1: can@4000a000 {
+        compatible = "st,stm32h7-fdcan";
+        reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
+        reg-names = "m_can", "message_ram";
+        clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
+                 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+        interrupts = <19 0>, <21 0>, <63 0>;
+        interrupt-names = "int0", "int1", "calib";
+        bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+        status = okay";
+      };

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -37,8 +37,8 @@ properties:
       - 28
       - 30
     description: |
-      Divides the kernel clock giving the time quanta clock that is fed to the FDCAN core
-      (FDCAN_CCU->CCFG CDIV register bits). Note that the divisor is common to all
-      'st,stm32h7-fdcan' instances.
+      FDCAN kernel/domain clock divider. The resulting clock is fed to the FDCAN time quanta
+      clock. Note that the divisor is common to all 'st,stm32h7-fdcan' instances.
 
-      Divide by 1 is the peripherals reset value and remains set unless this property is configured.
+      The clock divider, which is set via the FDCAN_CCU->CCFG_CDIV register, defaults to divide by 1
+      unless this property is provided.


### PR DESCRIPTION
Align devicetree property descriptions between the two STM32 FDCAN variants, improve the descriptions, and add devicetree node examples.