### PR TITLE
doc: css: update Google Programmable Search stylesheet

### DIFF
--- a/doc/_static/css/gcs.css
+++ b/doc/_static/css/gcs.css
@@ -14,6 +14,10 @@
   color: var(--body-color) !important;
 }
 
+.gsc-above-wrapper-area, .gsc-wrapper {
+  max-width: none !important;
+}
+
 .gsc-control-cse {
   width: 100%;
   padding: 0 !important;
@@ -22,6 +26,10 @@
   background-color: inherit !important;
   border: none !important;
   font-size: inherit !important;
+}
+
+.gsc-refinementsArea {
+  background-color: inherit !important;
 }
 
 .gsc-completion-container {
@@ -45,7 +53,6 @@
 
 .gs-result .gs-image, .gs-result .gs-promotion-image {
   border: none !important;
-  padding-right: .5em;
 }
 
 .gsc-table-result {
@@ -70,6 +77,12 @@
   padding: .5em 0;
   border: none !important;
   border-bottom: 1px solid var(--hr-color) !important;
+}
+
+.gs-webResult .gs-visibleUrl {
+  color: var(--body-color) !important;
+  font-weight: 100;
+  font-size: 0.9em;
 }
 
 .gs-webResult div.gs-per-result-labels {


### PR DESCRIPTION
Google apparently just changed ever so slightly the html and default css for Programmable Search result page. This fixes the few things that were looking pretty wrong due to this change, in particular in dark mode where some text would actually be invisible.

| | Dark Theme | Light Theme |
|---|---|---|
| **Before** | ![image](https://github.com/user-attachments/assets/aab1a5af-2a32-495b-920e-6db3514004c8) | ![image](https://github.com/user-attachments/assets/82f6e3ca-42d4-4afd-b5d7-94eb5e629396) |
| **After** | ![image](https://github.com/user-attachments/assets/a0039eac-f36c-4a32-8743-4892cf99589e) | ![image](https://github.com/user-attachments/assets/3e4aaa59-4c51-4055-a2ba-b9c7c963dd23) |
