### PR TITLE
drivers: spi: stm32: replace ll_func_* by ll_*

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -793,7 +793,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 			}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 			if (LL_SPI_HALF_DUPLEX_RX == LL_SPI_GetTransferDirection(spi)) {
-				ll_func_disable_spi(spi);
+				ll_disable_spi(spi);
 			}
 		}
 


### PR DESCRIPTION
Replace remaining ll_func_* by ll_* for LL function redefinitions in the STM32 SPI driver.

Fixes: 938fe74aae81c888c9cda6265ce18ff2650d8fae

Breakage seen on `main`: https://github.com/zephyrproject-rtos/zephyr/actions/runs/21960404732