### PR TITLE
boards: adafruit: macropad_rp2040: add missing license identifier

### DIFF
--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040-pinctrl.dtsi
@@ -1,3 +1,8 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -1,3 +1,8 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>


### PR DESCRIPTION
Add missing SPDX-License-Identifier