### PR TITLE
Infineon: PSE84: Remove duplicate entries in the CMakeLists.txt

### DIFF
--- a/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
@@ -90,11 +90,8 @@ zephyr_library_sources(${pdl_drv_dir}/source/cy_ppc.c)
 zephyr_library_sources(${pdl_drv_dir}/source/cy_syspm_pdcm.c)
 zephyr_library_sources(${pdl_drv_dir}/source/cy_syspm_ppu.c)
 zephyr_library_sources(${pdl_drv_dir}/source/ppu_v1.c)
-zephyr_library_sources(${pdl_drv_dir}/source/cy_smif.c)
 
 zephyr_library_sources(${pdl_drv_dir}/source/cy_trigmux.c)
-zephyr_library_sources(${pdl_drv_dir}/source/cy_wdt.c)
-zephyr_library_sources(${pdl_drv_dir}/source/cy_tcpwm_pwm.c)
 
 zephyr_include_directories(${hal_dir}/include)
 zephyr_library_sources(${hal_dir}/source/mtb_hal_clock.c)

--- a/soc/infineon/edge/pse84/security_config/pse84_s_mpc.c
+++ b/soc/infineon/edge/pse84/security_config/pse84_s_mpc.c
@@ -9,13 +9,6 @@
 #include "pse84_s_protection.h"
 #include <string.h>
 
-#if (SMIF_0_MPC_0_REGION_COUNT > 0U) || (SMIF_1_MPC_0_REGION_COUNT > 0U)
-#include "cy_smif.h"
-
-#define SMIF_DESELECT_DELAY (7U)
-#define TIMEOUT_1_MS        (1000U)
-#endif /* (SMIF_0_MPC_0_REGION_COUNT > 0U)|| (SMIF_1_MPC_0_REGION_COUNT > 0U) */
-
 /* Value generated through device-configurator settings */
 #define CY_MPC_PC_LAST (8)
 
@@ -45,31 +38,6 @@ cy_rslt_t cy_mpc_init(void)
 	cy_rslt_t return_result = CY_RSLT_SUCCESS;
 	/* Will track the current iteration for errors */
 	cy_rslt_t current_result = CY_RSLT_SUCCESS;
-
-	/* When executing from RRAM, the SMIF must be initialized and enabled to
-	 * hold onto any MPC configurations performed on the SMIF memory regions.
-	 * We can disable them after performing the MPC configurations.
-	 */
-#if (SMIF_0_MPC_0_REGION_COUNT > 0U)
-	bool is_smif0_uninit = false;
-
-	if (!Cy_SMIF_IsEnabled(SMIF0_CORE)) {
-		is_smif0_uninit = true;
-
-		cy_stc_smif_context_t smif_core0_context;
-
-		static const cy_stc_smif_config_t smif_0_core0_config = {
-			.mode = (uint32_t)CY_SMIF_NORMAL,
-			.deselectDelay = SMIF_DESELECT_DELAY,
-			.blockEvent = (uint32_t)CY_SMIF_BUS_ERROR,
-			.enable_internal_dll = false};
-
-		/* Enable IP with default configuration */
-		(void)Cy_SMIF_Init(SMIF0_CORE, &smif_0_core0_config, TIMEOUT_1_MS,
-				   &smif_core0_context);
-		Cy_SMIF_Enable(SMIF0_CORE, &smif_core0_context);
-	}
-#endif /* (SMIF_0_MPC_0_REGION_COUNT > 0U) */
 
 #if (SOCMEM_0_MPC_0_REGION_COUNT > 0U)
 	/* Enable SOCMEM */
@@ -101,13 +69,6 @@ cy_rslt_t cy_mpc_init(void)
 			}
 		}
 	}
-
-#if (SMIF_0_MPC_0_REGION_COUNT > 0U)
-	if (is_smif0_uninit) {
-		/* Disable IP as MPC configuration is complete*/
-		Cy_SMIF_Disable(SMIF0_CORE);
-	}
-#endif /* (SMIF_0_MPC_0_REGION_COUNT > 0U) */
 
 	return return_result;
 }


### PR DESCRIPTION
This change removes unused code from soc/infineon/edge/pse84/security_config/pse84_s_mpc.c and removes duplicate source inclusion entries from modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt.

The removal of the unguarded cy_smif.c inclusion would cause build failures in pse84_s_mpc.c. Because the code path in pse84_s_mpc.c that depended on cy_smif.c was not being used, it was removed.