### PR TITLE
drivers: sensor: adi: Add ADE7978 polyphase energy metering IC driver

### DIFF
--- a/drivers/sensor/adi/CMakeLists.txt
+++ b/drivers/sensor/adi/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_AD2S1210 ad2s1210)
+add_subdirectory_ifdef(CONFIG_ADE7978 ade7978)
 add_subdirectory_ifdef(CONFIG_ADLTC2990 adltc2990)
 add_subdirectory_ifdef(CONFIG_ADT7310 adt7310)
 add_subdirectory_ifdef(CONFIG_ADT7420 adt7420)

--- a/drivers/sensor/adi/Kconfig
+++ b/drivers/sensor/adi/Kconfig
@@ -3,6 +3,7 @@
 
 # zephyr-keep-sorted-start
 source "drivers/sensor/adi/ad2s1210/Kconfig"
+source "drivers/sensor/adi/ade7978/Kconfig"
 source "drivers/sensor/adi/adltc2990/Kconfig"
 source "drivers/sensor/adi/adt7310/Kconfig"
 source "drivers/sensor/adi/adt7420/Kconfig"

--- a/drivers/sensor/adi/ade7978/CMakeLists.txt
+++ b/drivers/sensor/adi/ade7978/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(ade7978.c)

--- a/drivers/sensor/adi/ade7978/Kconfig
+++ b/drivers/sensor/adi/ade7978/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config ADE7978
+	bool "ADE7978 Isolated energy metering chipset for polyphase shunt meters"
+	default y
+	depends on DT_HAS_ADI_ADE7978_ENABLED
+	select SPI
+	help
+		Enable the driver for Analog Devices ADE7978 isolated energy chipset
+		for polyphase shunt meters.
+
+config ADE7978_SHUNT_RESISTOR
+	int "Shunt resistor value"
+	default 200
+	help
+		Value of shunt resistor in uOhms
+
+config ADE7978_VOLTAGE_DIVIDER
+	int "Voltage divider ratio"
+	default 1131
+	help
+		Voltage divider factor

--- a/drivers/sensor/adi/ade7978/ade7978.c
+++ b/drivers/sensor/adi/ade7978/ade7978.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_ade7978
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+
+#include "ade7978.h"
+
+LOG_MODULE_REGISTER(ADE7978, CONFIG_SENSOR_LOG_LEVEL);
+
+static inline int ade7978_read_reg8(const struct device *dev, uint16_t addr, uint8_t *value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[4] = {ADE7978_CMD_READ, (addr >> 8) & 0xFF, addr & 0xFF, ADE7978_DUMMY};
+	uint8_t rx_buf[4];
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+	const struct spi_buf rx = {.buf = rx_buf, .len = sizeof(rx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+	const struct spi_buf_set rx_set = {.buffers = &rx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	*value = rx_buf[3];
+
+	return 0;
+}
+
+static inline int __maybe_unused ade7978_read_reg16(const struct device *dev, uint16_t addr,
+						    uint16_t *value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[5] = {ADE7978_CMD_READ, (addr >> 8) & 0xFF, addr & 0xFF, ADE7978_DUMMY,
+			     ADE7978_DUMMY};
+	uint8_t rx_buf[5];
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+	const struct spi_buf rx = {.buf = rx_buf, .len = sizeof(rx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+	const struct spi_buf_set rx_set = {.buffers = &rx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	*value = ((uint16_t)rx_buf[3] << 8) | rx_buf[4];
+
+	return 0;
+}
+
+static inline int ade7978_read_reg32(const struct device *dev, uint16_t addr, uint32_t *value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[7] = {ADE7978_CMD_READ, (addr >> 8) & 0xFF, addr & 0xFF,  ADE7978_DUMMY,
+			     ADE7978_DUMMY,    ADE7978_DUMMY,      ADE7978_DUMMY};
+	uint8_t rx_buf[7];
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+	const struct spi_buf rx = {.buf = rx_buf, .len = sizeof(rx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+	const struct spi_buf_set rx_set = {.buffers = &rx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, &rx_set);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	*value = ((uint32_t)rx_buf[3] << 24) | ((uint32_t)rx_buf[4] << 16) |
+		 ((uint32_t)rx_buf[5] << 8) | ((uint32_t)rx_buf[6]);
+
+	return 0;
+}
+
+static inline int __maybe_unused ade7978_write_reg8(const struct device *dev, uint16_t addr,
+						    uint8_t value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[4] = {ADE7978_CMD_WRITE, (addr >> 8) & 0xFF, addr & 0xFF, value};
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, NULL);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static inline int ade7978_write_reg16(const struct device *dev, uint16_t addr, uint16_t value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[5] = {ADE7978_CMD_WRITE, (addr >> 8) & 0xFF, addr & 0xFF,
+			     (value >> 8) & 0xFF, value & 0xFF};
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, NULL);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static inline int __maybe_unused ade7978_write_reg32(const struct device *dev, uint16_t addr,
+						     uint32_t value)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t tx_buf[7] = {ADE7978_CMD_WRITE,    (addr >> 8) & 0xFF,   addr & 0xFF,
+			     (value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF,
+			     value & 0xFF};
+
+	const struct spi_buf tx = {.buf = tx_buf, .len = sizeof(tx_buf)};
+
+	const struct spi_buf_set tx_set = {.buffers = &tx, .count = 1};
+
+	int ret = spi_transceive_dt(&cfg->spi, &tx_set, NULL);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static inline int32_t ade7978_sign_extend_24(uint32_t value)
+{
+	value = value & ADE7978_24BIT_MASK;
+
+	if (value & ADE7978_24BIT_SIGN) {
+		/* Negative number - extend */
+		return (int32_t)(value | ADE7978_24BIT_EXTEND);
+	}
+
+	/* Positive number */
+	return (int32_t)value;
+}
+
+static int ade7978_init(const struct device *dev)
+{
+	const struct ade7978_config *cfg = dev->config;
+	uint8_t version;
+	int ret;
+
+	if (!spi_is_ready_dt(&cfg->spi)) {
+		LOG_ERR("SPI bus not ready!");
+		return -ENODEV;
+	}
+
+	ret = ade7978_read_reg8(dev, ADE7978_REG_VERSION, &version);
+	if (ret < 0) {
+		LOG_ERR("Failed to read VERSION register");
+		return ret;
+	}
+
+	LOG_INF("ADE7978 version: 0x%02X", version);
+
+	ret = ade7978_write_reg16(dev, ADE7978_REG_RUN, 0x01);
+	if (ret < 0) {
+		LOG_ERR("Failed to start DSP");
+		return ret;
+	}
+
+	LOG_INF("ADE7978 initialized successfully!");
+	return 0;
+}
+
+static int ade7978_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct ade7978_data *data = dev->data;
+	uint32_t raw_airms, raw_avrms;
+	int ret;
+
+	switch (chan) {
+	case SENSOR_CHAN_ALL:
+		ret = ade7978_read_reg32(dev, ADE7978_REG_AIRMS, &raw_airms);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = ade7978_read_reg32(dev, ADE7978_REG_AVRMS, &raw_avrms);
+		if (ret < 0) {
+			return ret;
+		}
+		data->airms = ade7978_sign_extend_24(raw_airms);
+		data->avrms = ade7978_sign_extend_24(raw_avrms);
+		break;
+	case SENSOR_CHAN_CURRENT:
+		ret = ade7978_read_reg32(dev, ADE7978_REG_AIRMS, &raw_airms);
+		if (ret < 0) {
+			return ret;
+		}
+		data->airms = ade7978_sign_extend_24(raw_airms);
+		break;
+	case SENSOR_CHAN_VOLTAGE:
+		ret = ade7978_read_reg32(dev, ADE7978_REG_AVRMS, &raw_avrms);
+		if (ret < 0) {
+			return ret;
+		}
+		data->avrms = ade7978_sign_extend_24(raw_avrms);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int ade7978_channel_get(const struct device *dev, enum sensor_channel chan,
+			       struct sensor_value *val)
+{
+	struct ade7978_data *data = dev->data;
+	int ret;
+
+	switch (chan) {
+	case SENSOR_CHAN_CURRENT:
+		ret = sensor_value_from_double(val, (double)data->airms / ADE7978_IRATIO);
+		break;
+	case SENSOR_CHAN_VOLTAGE:
+		ret = sensor_value_from_double(val, (double)data->avrms / ADE7978_VRATIO);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+	return ret;
+}
+
+static DEVICE_API(sensor, ade7978_api) = {
+	.sample_fetch = ade7978_sample_fetch,
+	.channel_get = ade7978_channel_get,
+};
+
+#define ADE7978_DEFINE(inst)                                                                       \
+	static struct ade7978_data ade7978_data_##inst;                                            \
+                                                                                                   \
+	static const struct ade7978_config ade7978_config_##inst = {                               \
+		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |          \
+							  SPI_WORD_SET(8))};                       \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ade7978_init, NULL, &ade7978_data_##inst,               \
+				     &ade7978_config_##inst, POST_KERNEL,                          \
+				     CONFIG_SENSOR_INIT_PRIORITY, &ade7978_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ADE7978_DEFINE)

--- a/drivers/sensor/adi/ade7978/ade7978.h
+++ b/drivers/sensor/adi/ade7978/ade7978.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ADE7978_H_
+#define ZEPHYR_DRIVERS_SENSOR_ADE7978_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/sensor.h>
+
+#define ADE7978_ADC_FULL_SCALE_OUTPUT  5320000.0
+#define ADE7978_MAX_DIFF_CURRENT_INPUT 0.03125 /* 31.25 mV */
+#define ADE7978_MAX_DIFF_VOLTAGE_INPUT 0.5     /* 0.5 V */
+
+#define ADE7978_SHUNT_RESISTOR  (((double)CONFIG_ADE7978_SHUNT_RESISTOR) / 1e6)
+#define ADE7978_VOLTAGE_DIVIDER (((double)CONFIG_ADE7978_VOLTAGE_DIVIDER))
+
+#define ADE7978_IRATIO                                                                             \
+	(ADE7978_ADC_FULL_SCALE_OUTPUT * ADE7978_SHUNT_RESISTOR / ADE7978_MAX_DIFF_CURRENT_INPUT)
+#define ADE7978_VRATIO                                                                             \
+	(ADE7978_ADC_FULL_SCALE_OUTPUT / ADE7978_VOLTAGE_DIVIDER / ADE7978_MAX_DIFF_VOLTAGE_INPUT)
+
+/* ADE7978 register map */
+
+/* System Control Registers */
+#define ADE7978_REG_VERSION 0xE707 /* 8-bit  - Chip version */
+#define ADE7978_REG_RUN     0xE228 /* 16-bit - Start/stop DSP */
+#define ADE7978_REG_CONFIG  0xE618 /* 16-bit - Configuration */
+
+/* Status and Interrupt Registers */
+#define ADE7978_REG_STATUS0 0xE502 /* 32-bit - Interrupt status 0 */
+#define ADE7978_REG_STATUS1 0xE503 /* 32-bit - Interrupt status 1 */
+#define ADE7978_REG_MASK0   0xE50A /* 32-bit - Interrupt enable 0 */
+#define ADE7978_REG_MASK1   0xE50B /* 32-bit - Interrupt enable 1 */
+
+/* RMS Measurement Registers (24-bit data in 32-bit registers) */
+#define ADE7978_REG_AIRMS 0x43C0 /* Phase A current RMS */
+#define ADE7978_REG_BIRMS 0x43C3 /* Phase B current RMS */
+#define ADE7978_REG_CIRMS 0x43C6 /* Phase C current RMS */
+#define ADE7978_REG_NIRMS 0x43C9 /* Neutral current RMS */
+
+#define ADE7978_REG_AVRMS 0x43C1 /* Phase A voltage RMS */
+#define ADE7978_REG_BVRMS 0x43C4 /* Phase B voltage RMS */
+#define ADE7978_REG_CVRMS 0x43C7 /* Phase C voltage RMS */
+#define ADE7978_REG_NVRMS 0xE530 /* Neutral voltage RMS */
+
+/* Instantaneous Power Registers (24-bit data) */
+#define ADE7978_REG_AWATT 0xE518 /* Phase A active power */
+#define ADE7978_REG_BWATT 0xE519 /* Phase B active power */
+#define ADE7978_REG_CWATT 0xE51A /* Phase C active power */
+
+#define ADE7978_REG_AVAR 0xE51B /* Phase A reactive power */
+#define ADE7978_REG_BVAR 0xE51C /* Phase B reactive power */
+#define ADE7978_REG_CVAR 0xE51D /* Phase C reactive power */
+
+/* SPI Command bytes */
+#define ADE7978_CMD_READ  0x01 /* SPI read command */
+#define ADE7978_CMD_WRITE 0x00 /* SPI write command */
+#define ADE7978_DUMMY     0xFF /* SPI dummy byte */
+
+/* Helper macros for 24-bit sign extension */
+#define ADE7978_24BIT_MASK   0x00FFFFFF
+#define ADE7978_24BIT_SIGN   0x00800000
+#define ADE7978_24BIT_EXTEND 0xFF000000
+
+struct ade7978_config {
+	struct spi_dt_spec spi;
+};
+
+struct ade7978_data {
+	int32_t airms; /* Cached Phase A current RMS */
+	int32_t avrms; /* Cached Phase A voltage RMS */
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ADE7978_H_ */

--- a/dts/bindings/sensor/adi,ade7978.yaml
+++ b/dts/bindings/sensor/adi,ade7978.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Filip Stojanovic
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADE7978 Isolated energy metering chipset for polyphase shunt meters
+
+compatible: "adi,ade7978"
+
+include: [sensor-device.yaml, spi-device.yaml]

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -157,7 +157,9 @@
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>;	/* 0x3A */
+				   <&test_gpio 0 0>,	/* 0x3A */
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;	/* 0x3C */
 			#include "spi.dtsi"
 		};
 

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -495,3 +495,9 @@ test_spi_as5048: as5048@3b {
 	reg = <0x3b>;
 	spi-max-frequency = <0>;
 };
+
+test_spi_ade7978: ade7978@3c {
+	compatible = "adi,ade7978";
+	reg = <0x3c>;
+	spi-max-frequency = <0>;
+};


### PR DESCRIPTION
Add driver for ADE7978 polyphase energy metering IC with isolated shunt sensors. Initial implementation supports Phase A current and voltage RMS measurements via SPI interface.

This is a proof-of-concept implementation demonstrating the minimal working driver. The driver has been successfully built and tested with ESP32-S3 DevKitC board.

Future enhancements will include:
- Multi-phase support (Phases A, B, C, and Neutral)
- Active/reactive power measurement
- Interrupt support
- Calibration API