### PR TITLE
i2c: dw: Allow implementations to block suspend to idle

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -35,3 +35,9 @@ config I2C_DW_EXTENDED_SUPPORT
 	help
 	  This option enables support for the SCL/SDA timeout registers and some
 	  additional features of the DW I2C controller.
+
+config I2C_DW_PM_POLICY_STATE_LOCK
+	bool "Lock power managemnet policy during I2C transfers"
+	help
+	  Enable this option to block power management policy state changes
+	  during I2C transfers.

--- a/drivers/i2c/Kconfig.rts5912
+++ b/drivers/i2c/Kconfig.rts5912
@@ -7,6 +7,7 @@ menuconfig I2C_RTS5912
 	depends on DT_HAS_REALTEK_RTS5912_I2C_ENABLED
 	select I2C_ALLOW_NO_STOP_TRANSACTIONS
 	select I2C_DW_EXTENDED_SUPPORT
+	select I2C_DW_PM_POLICY_STATE_LOCK
 	help
 	  Enable the Realtek RTS5912 I2C driver
 


### PR DESCRIPTION
Some implementations of the DesginWare I2C controller do not support the system suspending to idle during an I2C transaction. Add a Kconfig option to allow locking of the power management policy state during I2C transactions.