### PR TITLE
drivers: gpio: max149x6: Fix GPIO API compliance and CRC issues

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -232,7 +232,7 @@ static int gpio_max14906_port_clear_bits_raw(const struct device *dev, gpio_port
 	uint32_t reg_val = 0;
 
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
-	reg_val = ret & (0xf0 & ~pins);
+	reg_val = ret & ~(pins & 0x0f);
 
 	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
 }

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -237,6 +237,19 @@ static int gpio_max14906_port_clear_bits_raw(const struct device *dev, gpio_port
 	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
 }
 
+static int gpio_max14906_port_set_masked_raw(const struct device *dev,
+					     gpio_port_pins_t mask,
+					     gpio_port_value_t value)
+{
+	int ret;
+	uint32_t reg_val;
+
+	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
+	reg_val = (ret & ~(mask & 0x0f)) | (value & mask & 0x0f);
+
+	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+}
+
 static int gpio_max14906_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	int err = 0;
@@ -451,6 +464,7 @@ static int gpio_max14906_init(const struct device *dev)
 static DEVICE_API(gpio, gpio_max14906_api) = {
 	.pin_configure = gpio_max14906_config,
 	.port_get_raw = gpio_max14906_port_get_raw,
+	.port_set_masked_raw = gpio_max14906_port_set_masked_raw,
 	.port_set_bits_raw = gpio_max14906_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_max14906_port_clear_bits_raw,
 	.port_toggle_bits = gpio_max14906_port_toggle_bits,

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -304,16 +304,12 @@ static int gpio_max14906_port_get_raw(const struct device *dev, gpio_port_value_
 static int gpio_max14906_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
 {
 	int ret;
-	uint32_t reg_val, direction, state, new_reg_val;
+	uint32_t reg_val;
 
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
+	reg_val = ret ^ (pins & 0x0f);
 
-	direction = ret & 0xf0;
-	state = ret & 0x0f;
-	reg_val = state ^ pins;
-	new_reg_val = direction | (0x0f & state);
-
-	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, new_reg_val);
+	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
 }
 
 static int gpio_max14906_clean_on_power(const struct device *dev)

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -276,6 +276,11 @@ static int gpio_max14906_config(const struct device *dev, gpio_pin_t pin, gpio_f
 		LOG_DBG("SETUP AS INPUT %d", pin);
 		break;
 	case GPIO_OUTPUT:
+		if (flags & GPIO_OUTPUT_INIT_HIGH) {
+			gpio_max14906_port_set_bits_raw(dev, BIT(pin));
+		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+			gpio_max14906_port_clear_bits_raw(dev, BIT(pin));
+		}
 		max14906_ch_func(dev, (uint32_t)pin, MAX14906_OUT);
 		LOG_DBG("SETUP AS OUTPUT %d", pin);
 		break;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -178,6 +178,19 @@ static int gpio_max14916_port_clear_bits_raw(const struct device *dev, gpio_port
 	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
 }
 
+static int gpio_max14916_port_set_masked_raw(const struct device *dev,
+					     gpio_port_pins_t mask,
+					     gpio_port_value_t value)
+{
+	int ret;
+	uint32_t reg_val;
+
+	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	reg_val = (ret & ~mask) | (value & mask);
+
+	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+}
+
 static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	int err = 0;
@@ -360,6 +373,7 @@ static int gpio_max14916_init(const struct device *dev)
 static DEVICE_API(gpio, gpio_max14916_api) = {
 	.pin_configure = gpio_max14916_config,
 	.port_get_raw = gpio_max14916_port_get_raw,
+	.port_set_masked_raw = gpio_max14916_port_set_masked_raw,
 	.port_set_bits_raw = gpio_max14916_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_max14916_port_clear_bits_raw,
 	.port_toggle_bits = gpio_max14916_port_toggle_bits,

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -213,6 +213,11 @@ static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_f
 
 	switch (flags & GPIO_DIR_MASK) {
 	case GPIO_OUTPUT:
+		if (flags & GPIO_OUTPUT_INIT_HIGH) {
+			gpio_max14916_port_set_bits_raw(dev, BIT(pin));
+		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+			gpio_max14916_port_clear_bits_raw(dev, BIT(pin));
+		}
 		break;
 	case GPIO_INPUT:
 	default:


### PR DESCRIPTION
Whilst testing the MAX14906 driver on a custom board I have encountered a few problems with the driver. See commit message and body for exact details. The headlines of the commits:

- drivers: gpio: max149x6: Handle check_byte in CRC function
- drivers: gpio: max14906: Make non-essential ports optional
- drivers: gpio: max14906: Fix clear_bits_raw to erase correct output bits
- drivers: gpio: max149x6: Add missing port_set_masked_raw GPIO API
- drivers: gpio: max14906: Apply new value in toggle_bits
- drivers: gpio: max149x6: Handle GPIO_OUTPUT_INIT_HIGH/LOW flags

These commits fix broken GPIO API implementations and improve datasheet compliance for MAX14906, but since MAX14916 shares common code with ‘906, I fixed these problems for both drivers as the problems mentioned above are rather simple.

One significant problem that is not addressed in this PR:

- The driver does not handle most read/write SPI-errors. There are occasions where the result of a SPI read is directly written to register, even though a negative return value can lead to erroneous flipping of output/input mode of ports (see max14906_reg_update). I think this is best fixed by implementing register caching (for writes) and adding some checks for reads. I have opened an issue to discuss this separately: #104034.

### Test setup

Custom board with 4x MAX14906. OR connected SPI lines + EN + FAULT + SYNCH (READY pulled low, per datasheet – if not used) to a STM32G0B1CET6 MCU. 