### PR TITLE
Support dma continuous transfer

### DIFF
--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -508,7 +508,7 @@ static int dma_mcux_edma_configure_hardware(const struct device *dev, uint32_t c
 
 	dma_mcux_edma_configure_muxes(dev, channel, config);
 
-#if defined(CONFIG_DMA_MCUX_EDMA_V3) && \
+#if (defined(CONFIG_DMA_MCUX_EDMA_V3) || defined(CONFIG_DMA_MCUX_EDMA_V4)) && \
 	(!defined(FSL_FEATURE_SOC_DMAMUX_COUNT) || (FSL_FEATURE_SOC_DMAMUX_COUNT == 0))
 	if (transfer_type == kEDMA_MemoryToMemory && (sg_mode || config->block_count > 1)) {
 		LOG_WRN("mem2mem xfer scatter gather not supported");
@@ -613,13 +613,13 @@ static inline void dma_mcux_edma_set_xfer_settings(const struct device *dev, uin
 	struct dma_mcux_channel_transfer_edma_settings *xfer_settings = &data->transfer_settings;
 
 	xfer_settings->source_burst_length = config->source_burst_length;
-#if defined(CONFIG_DMA_MCUX_EDMA_V3) && \
+#if (defined(CONFIG_DMA_MCUX_EDMA_V3) || defined(CONFIG_DMA_MCUX_EDMA_V4)) && \
 	(!defined(FSL_FEATURE_SOC_DMAMUX_COUNT) || (FSL_FEATURE_SOC_DMAMUX_COUNT == 0))
 	struct dma_block_config *block_config = config->head_block;
 
-	if (xfer_settings->transfer_type == kEDMA_MemoryToMemory) {
+	if (xfer_settings->transfer_type == kEDMA_MemoryToMemory &&
+	    !config->source_chaining_en) {
 		xfer_settings->source_burst_length = block_config->block_size;
-
 	}
 #endif
 	xfer_settings->source_data_size = config->source_data_size;
@@ -741,7 +741,7 @@ static int dma_mcux_edma_suspend(const struct device *dev, uint32_t channel)
 {
 	struct call_back *data = DEV_CHANNEL_DATA(dev, channel);
 
-#if defined(CONFIG_DMA_MCUX_EDMA_V3) && \
+#if (defined(CONFIG_DMA_MCUX_EDMA_V3) || defined(CONFIG_DMA_MCUX_EDMA_V4)) && \
 	(!defined(FSL_FEATURE_SOC_DMAMUX_COUNT) || (FSL_FEATURE_SOC_DMAMUX_COUNT == 0))
 	struct dma_mcux_channel_transfer_edma_settings *xfer_settings = &data->transfer_settings;
 

--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_mcxa153.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_mcxa153.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/frdm_mcxa153.conf
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_mcxa153.conf
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_LOOP_TRANSFER_SIZE=1024

--- a/tests/drivers/dma/loop_transfer/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_mcxa153.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma0 {};


### PR DESCRIPTION
- Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99596#issue-3638751756
- When dma_mcux_edma_start is executed, the DMA initiates a persistent trigger to ensure the DMA major loop completes transmission and generates the interrupt.
- Supporting DMA demo for frdmmcxa153
/
<details><summary>Loop transfer run results</summary>
<p>

*** Booting Zephyr OS build v4.3.0-6021-g53a986431a90 ***

Running TESTSUITE dma_m2m_loop

===================================================================

START - test_tst_dma0_m2m_loop

DMA memory to memory transfer started

Preparing DMA Controller: dma-controller@40080000

Starting the transfer on channel 0 and waiting for 1 second

Each RX buffer should contain the full TX buffer string.

RX data Loop 0

RX data Loop 1

RX data Loop 2

RX data Loop 3

Finished DMA: dma-controller@40080000

 PASS - test_tst_dma0_m2m_loop in 0.282 seconds

===================================================================

START - test_tst_dma0_m2m_loop_repeated_start_stop

DMA memory to memory transfer started

Preparing DMA Controller

Starting the transfer on channel 0 and waiting for 1 second

Each RX buffer should contain the full TX buffer string.

RX data Loop 0

RX data Loop 1

RX data Loop 2

RX data Loop 3

Finished: DMA

 PASS - test_tst_dma0_m2m_loop_repeated_start_stop in 0.277 seconds

===================================================================

START - test_tst_dma0_m2m_loop_suspend_resume

DMA memory to memory transfer started

Preparing DMA Controller: dma-controller@40080000

Starting the transfer on channel 0 and waiting for 1 second

suspend not supported

 SKIP - test_tst_dma0_m2m_loop_suspend_resume in 0.020 seconds

===================================================================

TESTSUITE dma_m2m_loop succeeded



------ TESTSUITE SUMMARY START ------



SUITE PASS - 100.00% [dma_m2m_loop]: pass = 2, fail = 0, skip = 1, total = 3 duration = 0.579 seconds

 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop] duration = 0.282 seconds

 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_repeated_start_stop] duration = 0.277 seconds

 - SKIP - [dma_m2m_loop.test_tst_dma0_m2m_loop_suspend_resume] duration = 0.020 seconds



------ TESTSUITE SUMMARY END ------



===================================================================

PROJECT EXECUTION SUCCESSFUL


</p>
</details> 
/
<details><summary>chan link run results</summary>
<p>

*** Booting Zephyr OS build v4.3.0-6021-g53a986431a90 ***

Running TESTSUITE dma_m2m_loop

===================================================================

START - test_tst_dma0_m2m_loop

DMA memory to memory transfer started

Preparing DMA Controller: dma-controller@40080000

Starting the transfer on channel 0 and waiting for 1 second

*** Booting Zephyr OS build v4.3.0-6021-g53a986431a90 ***

Running TESTSUITE dma_m2m_link

===================================================================

START - test_dma_m2m_chan0_1_major_link

Preparing DMA Controller: Chan_ID=1, BURST_LEN=1

Starting the transfer

DMA transfer done ch 0

It is harder to be kind than to be wise........

It is harder to 

 PASS - test_dma_m2m_chan0_1_major_link in 2.015 seconds

===================================================================

START - test_dma_m2m_chan0_1_minor_link

Preparing DMA Controller: Chan_ID=1, BURST_LEN=1

Starting the transfer

DMA transfer done ch 0

It is harder to be kind than to be wise........

It is harder to be kind than to 

 PASS - test_dma_m2m_chan0_1_minor_link in 2.016 seconds

===================================================================

START - test_dma_m2m_chan0_1_minor_major_link

Preparing DMA Controller: Chan_ID=1, BURST_LEN=1

Starting the transfer

DMA transfer done ch 0

DMA transfer done ch 1

It is harder to be kind than to be wise........

It is harder to be kind than to be wise........

 PASS - test_dma_m2m_chan0_1_minor_major_link in 2.019 seconds

===================================================================

TESTSUITE dma_m2m_link succeeded



------ TESTSUITE SUMMARY START ------



SUITE PASS - 100.00% [dma_m2m_link]: pass = 3, fail = 0, skip = 0, total = 3 duration = 6.050 seconds

 - PASS - [dma_m2m_link.test_dma_m2m_chan0_1_major_link] duration = 2.015 seconds

 - PASS - [dma_m2m_link.test_dma_m2m_chan0_1_minor_link] duration = 2.016 seconds

 - PASS - [dma_m2m_link.test_dma_m2m_chan0_1_minor_major_link] duration = 2.019 seconds



------ TESTSUITE SUMMARY END ------



===================================================================

PROJECT EXECUTION SUCCESSFUL


</p>
</details> 
/
<details><summary>chan blen run results</summary>
<p>

*** Booting Zephyr OS build v4.3.0-6021-g53a986431a90 ***

Running TESTSUITE dma_m2m_link

===================================================================

START - test_dma_m2m_chan0_1_major_link

Preparing DMA Controller: Chan_ID=1, BURST_LEN=1

Starting the transfer

DMA transfer done ch 0

*** Booting Zephyr OS build v4.3.0-6021-g53a986431a90 ***

Running TESTSUITE dma_m2m

===================================================================

START - test_tst_dma0_m2m_chan0_burst16

Preparing DMA Controller: Name=dma-controller@40080000, Chan_ID=0, BURST_LEN=2

Starting the transfer

DMA transfer done

It is harder to be kind than to be wise........

 PASS - test_tst_dma0_m2m_chan0_burst16 in 2.015 seconds

===================================================================

START - test_tst_dma0_m2m_chan0_burst8

Preparing DMA Controller: Name=dma-controller@40080000, Chan_ID=0, BURST_LEN=1

Starting the transfer

DMA transfer done

It is harder to be kind than to be wise........

 PASS - test_tst_dma0_m2m_chan0_burst8 in 2.015 seconds

===================================================================

START - test_tst_dma0_m2m_chan1_burst16

Preparing DMA Controller: Name=dma-controller@40080000, Chan_ID=1, BURST_LEN=2

Starting the transfer

DMA transfer done

It is harder to be kind than to be wise........

 PASS - test_tst_dma0_m2m_chan1_burst16 in 2.015 seconds

===================================================================

START - test_tst_dma0_m2m_chan1_burst8

Preparing DMA Controller: Name=dma-controller@40080000, Chan_ID=1, BURST_LEN=1

Starting the transfer

DMA transfer done

It is harder to be kind than to be wise........

 PASS - test_tst_dma0_m2m_chan1_burst8 in 2.015 seconds

===================================================================

TESTSUITE dma_m2m succeeded



------ TESTSUITE SUMMARY START ------



SUITE PASS - 100.00% [dma_m2m]: pass = 4, fail = 0, skip = 0, total = 4 duration = 8.060 seconds

 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst16] duration = 2.015 seconds

 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst8] duration = 2.015 seconds

 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst16] duration = 2.015 seconds

 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst8] duration = 2.015 seconds



------ TESTSUITE SUMMARY END ------



===================================================================

PROJECT EXECUTION SUCCESSFUL


</p>
</details> 