### PR TITLE
cy8cproto_041tp:drivers: gpio: Use shared interrupts for PSOC4

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_defconfig
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_defconfig
@@ -10,5 +10,8 @@ CONFIG_UART_CONSOLE=y
 # UART driver
 CONFIG_SERIAL=y
 
+#GPIO driver
+CONFIG_GPIO=y
+
 # Clock controller
 CONFIG_CLOCK_CONTROL=y

--- a/drivers/gpio/gpio_infineon.c
+++ b/drivers/gpio/gpio_infineon.c
@@ -34,7 +34,6 @@ struct gpio_cat1_config {
 #if (!CONFIG_SOC_FAMILY_INFINEON_CAT1C)
 	uint8_t intr_priority;
 #endif
-	int irq;
 };
 
 /* Data structure */
@@ -48,19 +47,6 @@ struct gpio_cat1_data {
 	/* callbacks list */
 	sys_slist_t callbacks;
 };
-
-#if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-typedef struct {
-	int irq;
-	uint8_t priority;
-	uint8_t num_devs;
-	const struct device *devs[DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT)];
-} gpio_psoc4_irq_group_t;
-
-static struct k_spinlock gpio_psoc4_irq_lock;
-static gpio_psoc4_irq_group_t gpio_psoc4_irq_groups[DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT)];
-static uint8_t gpio_psoc4_irq_group_count;
-#endif
 
 static inline uint32_t gpio_cat1_valid_mask(uint8_t ngpios)
 {
@@ -299,77 +285,14 @@ static DEVICE_API(gpio, gpio_cat1_api) = {
 	.get_pending_int = gpio_cat1_get_pending_int,
 };
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-static void gpio_psoc4_shared_isr(const void *arg)
-{
-	const gpio_psoc4_irq_group_t *group = arg;
-
-	for (uint8_t i = 0U; i < group->num_devs; i++) {
-		gpio_cat1_isr(group->devs[i]);
-	}
-}
-
-static void gpio_psoc4_register_irq(const struct device *dev)
-{
-	const struct gpio_cat1_config *const cfg = dev->config;
-
-	if (cfg->irq < 0) {
-		return;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&gpio_psoc4_irq_lock);
-	gpio_psoc4_irq_group_t *group = NULL;
-
-	if (gpio_psoc4_irq_group_count >= ARRAY_SIZE(gpio_psoc4_irq_groups)) {
-		k_spin_unlock(&gpio_psoc4_irq_lock, key);
-		return;
-	}
-
-	if (gpio_psoc4_irq_group_count > 0U) {
-		for (uint8_t i = 0U; i < gpio_psoc4_irq_group_count; i++) {
-			if (gpio_psoc4_irq_groups[i].irq == cfg->irq) {
-				group = &gpio_psoc4_irq_groups[i];
-				break;
-			}
-		}
-	}
-
-	if (group == NULL) {
-		__ASSERT(gpio_psoc4_irq_group_count < ARRAY_SIZE(gpio_psoc4_irq_groups),
-			 "Too many GPIO IRQ groups");
-		group = &gpio_psoc4_irq_groups[gpio_psoc4_irq_group_count++];
-		group->irq = cfg->irq;
-		group->priority = cfg->intr_priority;
-		group->num_devs = 0U;
-
-		irq_connect_dynamic(cfg->irq, cfg->intr_priority, gpio_psoc4_shared_isr, group, 0);
-		irq_enable(cfg->irq);
-	}
-
-	group->devs[group->num_devs++] = dev;
-
-	k_spin_unlock(&gpio_psoc4_irq_lock, key);
-}
-#endif
-
 #if defined(CONFIG_SOC_FAMILY_INFINEON_CAT1C)
 
 #define INTR_PRIORITY(n)
 #define ENABLE_INT(n)
 
-#elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-
-#define INTR_PRIORITY(n)                                                                           \
-	COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, 0),                                                     \
-	(.irq = DT_INST_IRQN(n),                                                           \
-	.intr_priority = DT_INST_IRQ(n, priority)),                                       \
-	(.irq = -1, .intr_priority = 0))
-#define ENABLE_INT(n)
-
 #else
 
 #define INTR_PRIORITY(n) .intr_priority = DT_INST_IRQ_BY_IDX(n, 0, priority),
-
 #define ENABLE_INT(n)                                                                              \
 	IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), gpio_cat1_isr,                      \
 		    DEVICE_DT_INST_GET(n), 0);                                                     \
@@ -377,21 +300,12 @@ static void gpio_psoc4_register_irq(const struct device *dev)
 
 #endif
 
-#if (CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-#define GPIO_CAT1_INIT_FUNC(n)                                                                     \
-	static int gpio_ifx##n##_init(const struct device *dev)                                    \
-	{                                                                                          \
-		gpio_psoc4_register_irq(dev);                                                      \
-		return 0;                                                                          \
-	}
-#else
 #define GPIO_CAT1_INIT_FUNC(n)                                                                     \
 	static int gpio_ifx##n##_init(const struct device *dev)                                    \
 	{                                                                                          \
 		ENABLE_INT(n)                                                                      \
 		return 0;                                                                          \
 	}
-#endif
 #define GPIO_CAT1_INIT(n)                                                                          \
 	static const struct gpio_cat1_config gpio_cat1_config_##n = {                              \
 		.common =                                                                          \

--- a/soc/infineon/psoc4/Kconfig.defconfig
+++ b/soc/infineon/psoc4/Kconfig.defconfig
@@ -3,8 +3,54 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_FAMILY_INFINEON_PSOC4
+if SOC_SERIES_PSOC4100TP
 
 rsource "*/Kconfig.defconfig"
 
-endif # SOC_FAMILY_INFINEON_PSOC4
+configdefault SHARED_IRQ_MAX_NUM_CLIENTS
+	# All 3 GPIO ports enabled
+	default 3 if $(dt_nodelabel_enabled,gpio_prt4) && \
+		$(dt_nodelabel_enabled,gpio_prt5) && \
+		$(dt_nodelabel_enabled,gpio_prt6)
+
+	# Any 2 GPIO ports enabled
+	default 2 if $(dt_nodelabel_enabled,gpio_prt4) && $(dt_nodelabel_enabled,gpio_prt5)
+	default 2 if $(dt_nodelabel_enabled,gpio_prt4) && $(dt_nodelabel_enabled,gpio_prt6)
+	default 2 if $(dt_nodelabel_enabled,gpio_prt5) && $(dt_nodelabel_enabled,gpio_prt6)
+
+configdefault SHARED_INTERRUPTS
+	default y if (($(dt_nodelabel_enabled,gpio_prt4) && \
+		($(dt_nodelabel_enabled,gpio_prt5) || $(dt_nodelabel_enabled,gpio_prt6))) || \
+		($(dt_nodelabel_enabled,gpio_prt5) && $(dt_nodelabel_enabled,gpio_prt6)))
+
+endif # SOC_SERIES_PSOC4100TP
+
+if SOC_SERIES_PSOC4100SMAX
+
+rsource "*/Kconfig.defconfig"
+
+configdefault SHARED_IRQ_MAX_NUM_CLIENTS
+	default 9 if \
+		$(dt_nodelabel_enabled,gpio_prt4) || \
+		$(dt_nodelabel_enabled,gpio_prt5) || \
+		$(dt_nodelabel_enabled,gpio_prt6) || \
+		$(dt_nodelabel_enabled,gpio_prt7) || \
+		$(dt_nodelabel_enabled,gpio_prt8) || \
+		$(dt_nodelabel_enabled,gpio_prt9) || \
+		$(dt_nodelabel_enabled,gpio_prt10) || \
+		$(dt_nodelabel_enabled,gpio_prt11) || \
+		$(dt_nodelabel_enabled,gpio_prt12)
+
+configdefault SHARED_INTERRUPTS
+	default y if \
+		$(dt_nodelabel_enabled,gpio_prt4) || \
+		$(dt_nodelabel_enabled,gpio_prt5) || \
+		$(dt_nodelabel_enabled,gpio_prt6) || \
+		$(dt_nodelabel_enabled,gpio_prt7) || \
+		$(dt_nodelabel_enabled,gpio_prt8) || \
+		$(dt_nodelabel_enabled,gpio_prt9) || \
+		$(dt_nodelabel_enabled,gpio_prt10) || \
+		$(dt_nodelabel_enabled,gpio_prt11) || \
+		$(dt_nodelabel_enabled,gpio_prt12)
+
+endif # SOC_SERIES_PSOC4100SMAX


### PR DESCRIPTION
Enable CONFIG_SHARED_INTERRUPTS to allow multiple devices to register handlers on the same IRQ line.

Replace irq_connect_dynamic() with IRQ_CONNECT() to configure interrupts at build time, eliminating runtime setup overhead.