### PR TITLE
drivers: clock_control: introduce shared helpers for NXP MCUX SoCs to fix peripheral clock configuration errors with clock_control_mcux_sim.c

### DIFF
--- a/drivers/counter/counter_mcux_tpm.c
+++ b/drivers/counter/counter_mcux_tpm.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
@@ -30,7 +31,10 @@ struct mcux_tpm_config {
 	DEVICE_MMIO_NAMED_ROM(tpm_mmio);
 
 	const struct device *clock_dev;
+	/* Register clock (gate) token for clock_control_on/off(). */
 	clock_control_subsys_t clock_subsys;
+	/* Function clock (rate) token for clock_control_get_rate(). */
+	clock_control_subsys_t clock_subsys_rate;
 
 	tpm_clock_source_t tpm_clock_source;
 	tpm_clock_prescale_t prescale;
@@ -218,9 +222,30 @@ static uint32_t mcux_tpm_get_top_value(const struct device *dev)
 	return base->MOD;
 }
 
+static int mcux_tpm_calc_freq(const struct device *dev, uint32_t *freq)
+{
+	const struct mcux_tpm_config *config = dev->config;
+	uint32_t input_clock_freq;
+	int err;
+
+	err = clock_control_get_rate(config->clock_dev, config->clock_subsys_rate,
+				   &input_clock_freq);
+	if (err != 0) {
+		return err;
+	}
+
+	*freq = input_clock_freq / (1U << config->prescale);
+	return 0;
+}
+
 static uint32_t mcux_tpm_get_freq(const struct device *dev)
 {
 	struct mcux_tpm_data *data = dev->data;
+	uint32_t freq;
+
+	if (mcux_tpm_calc_freq(dev, &freq) == 0) {
+		data->freq = freq;
+	}
 
 	return data->freq;
 }
@@ -230,7 +255,6 @@ static int mcux_tpm_init(const struct device *dev)
 	const struct mcux_tpm_config *config = dev->config;
 	struct mcux_tpm_data *data = dev->data;
 	tpm_config_t tpmConfig;
-	uint32_t input_clock_freq;
 	TPM_Type *base;
 
 	DEVICE_MMIO_NAMED_MAP(dev, tpm_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
@@ -261,13 +285,11 @@ static int mcux_tpm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
-				   &input_clock_freq)) {
-		LOG_ERR("Could not get clock frequency");
+	err = mcux_tpm_calc_freq(dev, &data->freq);
+	if (err != 0) {
+		LOG_ERR("Could not get clock frequency: %d", err);
 		return -EINVAL;
 	}
-
-	data->freq = input_clock_freq / (1U << config->prescale);
 
 	TPM_GetDefaultConfig(&tpmConfig);
 	tpmConfig.prescale = config->prescale;
@@ -303,8 +325,10 @@ static DEVICE_API(counter, mcux_tpm_driver_api) = {
 	static const struct mcux_tpm_config mcux_tpm_config_ ## n = {		\
 		DEVICE_MMIO_NAMED_ROM_INIT(tpm_mmio, DT_DRV_INST(n)),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-		.clock_subsys =							\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		.clock_subsys =						\
+			NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(n),	\
+		.clock_subsys_rate =					\
+			NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR(n),	\
 		.tpm_clock_source = kTPM_SystemClock,				\
 		.prescale = TO_TPM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),	\
 		.info = {							\

--- a/drivers/counter/counter_nxp_pit.c
+++ b/drivers/counter/counter_nxp_pit.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h>
 #include <zephyr/irq.h>
 #include <fsl_pit.h>
 
@@ -46,7 +47,10 @@ struct nxp_pit_config {
 	void (**irq_config_func)(const struct device *dev);
 #endif
 	const struct device *clock_dev;
+	/* Register clock (gate) token for clock_control_on/off(). */
 	clock_control_subsys_t clock_subsys;
+	/* Function clock (rate) token for clock_control_get_rate(). */
+	clock_control_subsys_t clock_subsys_rate;
 	struct nxp_pit_channel_data *const *data;
 	const struct device *const *channels;
 };
@@ -146,7 +150,7 @@ static uint32_t nxp_pit_get_frequency(const struct device *dev)
 	const struct nxp_pit_config *config = dev->config;
 	uint32_t clock_rate;
 
-	if (clock_control_get_rate(config->clock_dev, config->clock_subsys, &clock_rate)) {
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys_rate, &clock_rate)) {
 		LOG_ERR("Failed to get clock rate");
 		return 0;
 	}
@@ -359,8 +363,8 @@ static DEVICE_API(counter, nxp_pit_driver_api) = {
 		.num_channels = DT_INST_FOREACH_CHILD_SEP_VARGS(				\
 			n, DT_NODE_HAS_COMPAT, (+), nxp_pit_channel),				\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),				\
-		.clock_subsys = (clock_control_subsys_t)					\
-				DT_INST_CLOCKS_CELL(n, name),					\
+		.clock_subsys = NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(n),\
+		.clock_subsys_rate = NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR(n),\
 		.data = nxp_pit_##n##_channel_datas,						\
 		.channels = nxp_pit_##n##_channels,						\
 	};											\

--- a/drivers/pinctrl/pinctrl_nxp_port.c
+++ b/drivers/pinctrl/pinctrl_nxp_port.c
@@ -8,9 +8,9 @@
 #define DT_DRV_COMPAT nxp_port_pinmux
 
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
-#include <fsl_clock.h>
 
 LOG_MODULE_REGISTER(pinctrl_nxp_port, CONFIG_PINCTRL_LOG_LEVEL);
 
@@ -71,26 +71,10 @@ static int pinctrl_mcux_init(const struct device *dev)
 	return 0;
 }
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_kinetis_sim))
-#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)                                                       \
-	CLK_GATE_DEFINE(DT_INST_CLOCKS_CELL(n, offset), DT_INST_CLOCKS_CELL(n, bits))
-#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_scg_k4)
-#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)                                                       \
-	(DT_INST_CLOCKS_CELL(n, mrcc_offset) == 0                                                  \
-		 ? 0                                                                               \
-		 : MAKE_MRCC_REGADDR(MRCC_BASE, DT_INST_CLOCKS_CELL(n, mrcc_offset)))
-#else
-#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)			\
-	COND_CODE_1(						\
-		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),	\
-		(DT_INST_CLOCKS_CELL(n, name)), (0U))
-#endif
-
 #define PINCTRL_MCUX_INIT(n)						\
 	static const struct pinctrl_mcux_config pinctrl_mcux_##n##_config = {\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys = (clock_control_subsys_t)		\
-				PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n),	\
+		.clock_subsys = NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(n),\
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -11,6 +11,7 @@
 #define DT_DRV_COMPAT nxp_kinetis_tpm
 
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h>
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/irq.h>
@@ -49,7 +50,10 @@ LOG_MODULE_REGISTER(pwm_mcux_tpm, CONFIG_PWM_LOG_LEVEL);
 struct mcux_tpm_config {
 	DEVICE_MMIO_NAMED_ROM(base);
 	const struct device *clock_dev;
+	/* Register clock (gate) token for clock_control_on/off(). */
 	clock_control_subsys_t clock_subsys;
+	/* Function clock (rate) token for clock_control_get_rate()/configure(). */
+	clock_control_subsys_t clock_subsys_rate;
 	tpm_clock_source_t tpm_clock_source;
 	tpm_clock_prescale_t prescale;
 	uint8_t channel_count;
@@ -542,7 +546,7 @@ static int mcux_tpm_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	err = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	err = clock_control_configure(config->clock_dev, config->clock_subsys_rate, NULL);
 	if (err != 0) {
 		/* Check if error is due to lack of support */
 		if (err != -ENOSYS) {
@@ -565,7 +569,7 @@ static int mcux_tpm_init(const struct device *dev)
 	}
 #endif
 
-	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys_rate,
 				   &data->clock_freq)) {
 		LOG_ERR("Could not get clock frequency");
 		return -EINVAL;
@@ -649,8 +653,10 @@ static void mcux_tpm_config_func_##n(const struct device *dev) \
 	static const struct mcux_tpm_config mcux_tpm_config_##n = { \
 		DEVICE_MMIO_NAMED_ROM_INIT(base, DT_DRV_INST(n)), \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
-		.clock_subsys = (clock_control_subsys_t) \
-			DT_INST_CLOCKS_CELL(n, name), \
+		.clock_subsys = \
+			NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(n), \
+		.clock_subsys_rate = \
+			NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR(n), \
 		.tpm_clock_source = kTPM_SystemClock, \
 		.prescale = TO_TPM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)), \
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
@@ -63,7 +64,10 @@ struct mcux_lpuart_config {
 	LPUART_Type *base;
 	const struct device *clock_dev;
 	const struct pinctrl_dev_config *pincfg;
+	/* Register clock (gate) token for clock_control_on/off(). */
 	clock_control_subsys_t clock_subsys;
+	/* Function clock (rate) token for clock_control_get_rate()/configure(). */
+	clock_control_subsys_t clock_subsys_rate;
 	uint32_t baud_rate;
 	uint8_t flow_ctrl;
 	uint8_t parity;
@@ -1226,7 +1230,7 @@ static int mcux_lpuart_configure_init(const struct device *dev, const struct uar
 		return -ENODEV;
 	}
 
-	ret = clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
+	ret = clock_control_configure(config->clock_dev, config->clock_subsys_rate, NULL);
 	if (ret != 0) {
 		/* Check if error is due to lack of support */
 		if (ret != -ENOSYS) {
@@ -1248,7 +1252,7 @@ static int mcux_lpuart_configure_init(const struct device *dev, const struct uar
 		return ret;
 	}
 
-	ret = clock_control_get_rate(config->clock_dev, config->clock_subsys,
+	ret = clock_control_get_rate(config->clock_dev, config->clock_subsys_rate,
 								&clock_freq);
 	if (ret) {
 		LOG_ERR("Failed to get clock rate: %d", ret);
@@ -1607,9 +1611,8 @@ static DEVICE_API(uart, mcux_lpuart_driver_api) = {
 static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
 	.base = (LPUART_Type *) DT_INST_REG_ADDR(n),                          \
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                   \
-	.clock_subsys = (clock_control_subsys_t)COND_CODE_1(                  \
-		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),                \
-		(DT_INST_CLOCKS_CELL(n, name)), (0U)),                        \
+	.clock_subsys = NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(n), \
+	.clock_subsys_rate = NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR(n), \
 	.baud_rate = DT_INST_PROP(n, current_speed),                          \
 	.flow_ctrl = FLOW_CONTROL(n),                                         \
 	.parity = DT_INST_ENUM_IDX(n, parity),                                \

--- a/include/zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h
+++ b/include/zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h
@@ -1,0 +1,356 @@
+/**
+ * @file
+ * @brief NXP MCUX clock_control devicetree subsystem helpers.
+ */
+
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_MCUX_CLOCK_SUBSYS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_MCUX_CLOCK_SUBSYS_H_
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <fsl_clock.h>
+
+/**
+ * @brief Helpers for MCUX clock_control devicetree consumers.
+ *
+ * Some NXP SoCs use the MCUX SIM as a clock controller with @c \#clock-cells = 3:
+ *
+ * @code
+ * <name offset bits>
+ * @endcode
+ *
+ * Some NXP SoCs use the SCG K4 clock controller with @c \#clock-cells = 2:
+ *
+ * @code
+ * <name mrcc_offset>
+ * @endcode
+ *
+ * - Enabling/disabling a peripheral clock may require a provider-specific
+ *   gate token derived from (offset, bits) via CLK_GATE_DEFINE() (SIM) or
+ *   MRCC register address encoding from `mrcc_offset` (SCG K4).
+ * - Retrieving a clock rate may require a provider-specific selector such as
+ *   the `name` cell, suitable for CLOCK_GetFreq().
+ *
+ * Some controllers (notably Kinetis SIM) require different devicetree cells
+ * for gate control vs rate queries. Use the `*_GATE_*` macros for
+ * `clock_control_on/off()` and the `*_RATE_*` macros for
+ * `clock_control_get_rate()`. Drivers may therefore store both a gate subsys
+ * token and a rate subsys token.
+ *
+ * In the common "register clock" / "function clock" model:
+ *
+ * - The register clock is the clock used to access the peripheral registers
+ *   and is typically controlled via `clock_control_on/off()`.
+ * - The function clock is the clock that drives the peripheral function and
+ *   is typically queried via `clock_control_get_rate()`.
+ *
+ * These helpers map each API usage to the controller-specific
+ * `clock_control_subsys_t` token expected by the underlying clock controller
+ * implementation. Some controllers use the same token for both concepts,
+ * while others (e.g. SIM) use different devicetree cells/tokens for register
+ * clock gating vs function clock rate.
+ */
+
+/**
+ * @brief True if the clock specifier has a `name` cell.
+ *
+ * Some clock controllers (e.g. fixed-clock) use @c \#clock-cells = 0 and thus
+ * do not provide a subsystem selector cell.
+ */
+#define NXP_MCUX_DT_CLOCK_HAS_NAME_CELL_BY_IDX(node_id, idx) \
+	DT_PHA_HAS_CELL_AT_IDX(node_id, clocks, idx, name)
+
+/**
+ * @brief True if the instance clock specifier has a `name` cell.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_HAS_NAME_CELL_BY_IDX(inst, idx) \
+	DT_PHA_HAS_CELL_AT_IDX(DT_DRV_INST(inst), clocks, idx, name)
+
+/**
+ * @brief True if the clock controller for a DT node is a Kinetis SIM.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param idx Clock specifier index within the node's `clocks` property.
+ *
+ * @return 1 if the clock controller is compatible with a Kinetis SIM, else 0.
+ */
+#define NXP_MCUX_DT_CLOCK_CTLR_IS_SIM_BY_IDX(node_id, idx) \
+	UTIL_OR(DT_NODE_HAS_COMPAT(DT_CLOCKS_CTLR_BY_IDX(node_id, idx), nxp_kinetis_sim), \
+		DT_NODE_HAS_COMPAT(DT_CLOCKS_CTLR_BY_IDX(node_id, idx), nxp_kinetis_ke1xf_sim))
+
+/**
+ * @brief True if the clock controller for a DT node is SCG K4.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param idx Clock specifier index within the node's `clocks` property.
+ *
+ * @return 1 if the clock controller is compatible with SCG K4, else 0.
+ */
+#define NXP_MCUX_DT_CLOCK_CTLR_IS_SCG_K4_BY_IDX(node_id, idx) \
+	DT_NODE_HAS_COMPAT(DT_CLOCKS_CTLR_BY_IDX(node_id, idx), nxp_scg_k4)
+
+/**
+ * @brief True if the clock controller for a devicetree instance is a Kinetis SIM.
+ *
+ * @param inst Devicetree instance number.
+ * @param idx Clock specifier index within the instance's `clocks` property.
+ *
+ * @return 1 if the clock controller is compatible with a Kinetis SIM, else 0.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SIM_BY_IDX(inst, idx) \
+	UTIL_OR(DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR_BY_IDX(inst, idx), nxp_kinetis_sim), \
+		DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR_BY_IDX(inst, idx), nxp_kinetis_ke1xf_sim))
+
+/**
+ * @brief True if the instance clock controller is SCG K4.
+ *
+ * @param inst Devicetree instance number.
+ * @param idx Clock specifier index within the instance's `clocks` property.
+ *
+ * @return 1 if the clock controller is compatible with SCG K4, else 0.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SCG_K4_BY_IDX(inst, idx) \
+	DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR_BY_IDX(inst, idx), nxp_scg_k4)
+
+/**
+ * @brief True if the instance clock controller is a Kinetis SIM.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SIM_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return 1 if the clock controller is compatible with a Kinetis SIM, else 0.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SIM(inst) \
+	NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SIM_BY_IDX(inst, 0)
+
+/**
+ * @brief Clock subsys token for enabling/disabling the node clock (by index).
+ */
+#define NXP_MCUX_DT_CLOCK_GATE_SUBSYS_BY_IDX(node_id, idx) \
+	COND_CODE_1(NXP_MCUX_DT_CLOCK_CTLR_IS_SIM_BY_IDX(node_id, idx), \
+		(CLK_GATE_DEFINE(DT_CLOCKS_CELL_BY_IDX(node_id, idx, offset), \
+				DT_CLOCKS_CELL_BY_IDX(node_id, idx, bits))), \
+		(COND_CODE_1(NXP_MCUX_DT_CLOCK_CTLR_IS_SCG_K4_BY_IDX(node_id, idx), \
+			((DT_CLOCKS_CELL_BY_IDX(node_id, idx, mrcc_offset) == 0) \
+				? 0U \
+				: MAKE_MRCC_REGADDR(MRCC_BASE, \
+					DT_CLOCKS_CELL_BY_IDX(node_id, idx, mrcc_offset))), \
+			(COND_CODE_1(NXP_MCUX_DT_CLOCK_HAS_NAME_CELL_BY_IDX(node_id, idx), \
+				(DT_CLOCKS_CELL_BY_IDX(node_id, idx, name)), \
+				(0U))))))
+
+/**
+ * @brief Clock subsys token for enabling/disabling the node clock.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_GATE_SUBSYS_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_CLOCK_GATE_SUBSYS(node_id) \
+	NXP_MCUX_DT_CLOCK_GATE_SUBSYS_BY_IDX(node_id, 0)
+
+/**
+ * @brief Pointer-form clock subsys token for enabling/disabling
+ * the node clock.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_GATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_CLOCK_GATE_SUBSYS_PTR_BY_IDX(node_id, idx) \
+	UINT_TO_POINTER(NXP_MCUX_DT_CLOCK_GATE_SUBSYS_BY_IDX(node_id, idx))
+
+/**
+ * @brief Pointer-form clock subsys token for enabling/disabling
+ * the node clock.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_GATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_CLOCK_GATE_SUBSYS_PTR(node_id) \
+	NXP_MCUX_DT_CLOCK_GATE_SUBSYS_PTR_BY_IDX(node_id, 0)
+
+/**
+ * @brief Clock subsys token for enabling/disabling the instance clock.
+ *
+ * If the instance clock controller is a Kinetis SIM, returns a packed gate
+ * token derived from the `offset` and `bits` clock cells. If the instance
+ * clock controller is SCG K4, returns an MRCC register address token derived
+ * from `mrcc_offset` (`0` means no gate). Otherwise, returns the
+ * controller-specific `name` clock cell.
+ *
+ * @param inst Devicetree instance number.
+ * @param idx Clock specifier index within the instance's `clocks` property.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_BY_IDX(inst, idx) \
+	COND_CODE_1(NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SIM_BY_IDX(inst, idx), \
+		(CLK_GATE_DEFINE(DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, offset), \
+				DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, bits))), \
+		(COND_CODE_1(NXP_MCUX_DT_INST_CLOCK_CTLR_IS_SCG_K4_BY_IDX(inst, idx), \
+			((DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, mrcc_offset) == 0) \
+				? 0U \
+				: MAKE_MRCC_REGADDR(MRCC_BASE, \
+					DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, mrcc_offset))), \
+			(COND_CODE_1(NXP_MCUX_DT_INST_CLOCK_HAS_NAME_CELL_BY_IDX(inst, idx), \
+				(DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, name)), \
+				(0U))))))
+
+/**
+ * @brief Clock subsys token for enabling/disabling the instance clock.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS(inst) \
+	NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_BY_IDX(inst, 0)
+
+/**
+ * @brief Pointer-form clock subsys token for enabling/disabling
+ * the instance clock.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR_BY_IDX(inst, idx) \
+	UINT_TO_POINTER(NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_BY_IDX(inst, idx))
+
+/**
+ * @brief Pointer-form clock subsys token for enabling/disabling
+ * the instance clock.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_on/off()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR(inst) \
+	NXP_MCUX_DT_INST_CLOCK_GATE_SUBSYS_PTR_BY_IDX(inst, 0)
+
+/**
+ * @brief Clock subsys token for retrieving the node clock rate.
+ */
+#define NXP_MCUX_DT_CLOCK_RATE_SUBSYS_BY_IDX(node_id, idx) \
+	COND_CODE_1(NXP_MCUX_DT_CLOCK_HAS_NAME_CELL_BY_IDX(node_id, idx), \
+		(DT_CLOCKS_CELL_BY_IDX(node_id, idx, name)), (0U))
+
+/**
+ * @brief Clock subsys token for retrieving the node clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_RATE_SUBSYS_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_CLOCK_RATE_SUBSYS(node_id) \
+	NXP_MCUX_DT_CLOCK_RATE_SUBSYS_BY_IDX(node_id, 0)
+
+/**
+ * @brief Pointer-form clock subsys token for retrieving
+ * the node clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_RATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_CLOCK_RATE_SUBSYS_PTR_BY_IDX(node_id, idx) \
+	UINT_TO_POINTER(NXP_MCUX_DT_CLOCK_RATE_SUBSYS_BY_IDX(node_id, idx))
+
+/**
+ * @brief Pointer-form clock subsys token for retrieving
+ * the node clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_CLOCK_RATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param node_id Devicetree node identifier.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_CLOCK_RATE_SUBSYS_PTR(node_id) \
+	NXP_MCUX_DT_CLOCK_RATE_SUBSYS_PTR_BY_IDX(node_id, 0)
+
+/**
+ * @brief Clock subsys token for retrieving the instance clock rate.
+ *
+ * @param inst Devicetree instance number.
+ * @param idx Clock specifier index within the instance's `clocks` property.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_BY_IDX(inst, idx) \
+	COND_CODE_1(NXP_MCUX_DT_INST_CLOCK_HAS_NAME_CELL_BY_IDX(inst, idx), \
+		(DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, name)), (0U))
+
+/**
+ * @brief Clock subsys token for retrieving the instance clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A token usable as `clock_control_subsys_t` for `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS(inst) \
+	NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_BY_IDX(inst, 0)
+
+/**
+ * @brief Pointer-form clock subsys token for retrieving
+ * the instance clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR_BY_IDX(inst, idx) \
+	UINT_TO_POINTER(NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_BY_IDX(inst, idx))
+
+/**
+ * @brief Pointer-form clock subsys token for retrieving
+ * the instance clock rate.
+ *
+ * Convenience form of NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR_BY_IDX() for index 0.
+ *
+ * @param inst Devicetree instance number.
+ *
+ * @return A pointer-form token usable as `clock_control_subsys_t` for
+ * `clock_control_get_rate()`.
+ */
+#define NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR(inst) \
+	NXP_MCUX_DT_INST_CLOCK_RATE_SUBSYS_PTR_BY_IDX(inst, 0)
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NXP_MCUX_CLOCK_SUBSYS_H_ */


### PR DESCRIPTION
## Overview

This PR introduces shared clock control infrastructure for NXP MCUX-based SoCs and converts existing drivers to use it.

## Motivation

Fix the the peripheral clock configuration error with with clock_control_mcux_sim.c.

Some NXP SoCs use the MCUX SIM as a clock controller with `#clock-cells = 3` format: `<name offset bits>`, where:
- Enabling/disabling a peripheral clock requires a packed gate token derived from `(offset, bits)`
- Retrieving a clock rate requires the `name` cell for `CLOCK_GetFreq()`
Previously, some driver mistakenly only get `name` argument from device tree and send them into sim clock APIs which is wrong.

## Changes

### 1. New shared infrastructure (Patch 1/6)
- Add `include/zephyr/drivers/clock_control/nxp_mcux_clock_subsys.h`
- Provides helper macros to detect Kinetis SIM clock controllers
- Generates appropriate clock gate and rate subsystem tokens

### 2. Driver conversions (Patches 2-6)
Convert the following drivers to use the new shared helpers:
- `drivers/counter/counter_mcux_tpm.c`
- `drivers/counter/counter_nxp_pit.c`
- `drivers/pwm/pwm_mcux_tpm.c`
- `drivers/serial/uart_mcux_lpuart.c`
- `drivers/pinctrl/pinctrl_nxp_port.c`

Each driver now separates:
- `clock_subsys` - for clock gating operations
- `clock_subsys_rate` - for clock rate queries