### PR TITLE
dts: bindings: charger: maxim: max20335: fix typos in bindings

### DIFF
--- a/dts/bindings/charger/maxim,max20335-charger.yaml
+++ b/dts/bindings/charger/maxim,max20335-charger.yaml
@@ -33,7 +33,7 @@ properties:
       - 500000
       - 1000000
     description: |
-      CHGIN to SYS path current limitter configuration.
+      CHGIN to SYS path current limiter configuration.
       Refer to ILimCntl register description for details.
 
   system-voltage-min-threshold-microvolt:


### PR DESCRIPTION
Fix spelling errors in maxim max20335-charger dts bindings descriptions.

No functional changes.