### PR TITLE
net: ppp: always set FSM name in ppp_fsm_name_set

### DIFF
--- a/subsys/net/l2/ppp/misc.c
+++ b/subsys/net/l2/ppp/misc.c
@@ -366,10 +366,8 @@ const char *ppp_option2str(enum ppp_protocol_type protocol,
 
 void ppp_fsm_name_set(struct ppp_fsm *fsm, const char *name)
 {
-#if CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG
-	fsm->name = name;
-#else
-	ARG_UNUSED(fsm);
-	ARG_UNUSED(name);
-#endif
+	/* Always set name: NET_ERR/NET_WRN in ipv6cp/ipcp/lcp use fsm->name
+	 * regardless of CONFIG_NET_L2_PPP_LOG_LEVEL.
+	 */
+	fsm->name = (name != NULL) ? name : "";
 }


### PR DESCRIPTION
Previously the name was only set when CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG. NET_ERR/NET_WRN in ipv6cp (and others) use fsm->name as %s at any log level, which could pass NULL into the logger and crash in cbprintf/strlen. Always assign the name so logging is safe.