### PR TITLE
dts: arm: st: add stm32h562xi and stm32h563xg

### DIFF
--- a/dts/arm/st/h5/stm32h562Xi.dtsi
+++ b/dts/arm/st/h5/stm32h562Xi.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Siemens
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <st/h5/stm32h562.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/h5/stm32h563Xg.dtsi
+++ b/dts/arm/st/h5/stm32h563Xg.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Siemens
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <st/h5/stm32h563.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(1)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The STM32H56XXX family is available in 1 and 2 MB versions,
where

``` 
STM32H563 V I XXX
        | | |
        | | +- I: 2 MB flash
        | | +- G: 1 MB flash
        | |
        | +- Pin count
        |
        +-- H562: without Ethernet
        +-- H563: with Ethernet
```

All four options are available, but currently we only have
device trees for two of them.

Introduce two new device tree includes for the other
two combinations:
- `stm32h562Xi.dtsi`
- `stm32h563Xg.dtsi`