### PR TITLE
PR preventing breaking change in movement of nvs.h and zms.h under kvss

### DIFF
--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_FS_NVS_H_
+#define ZEPHYR_INCLUDE_FS_NVS_H_
+
+/**
+ * @file
+ * @brief Legacy interface header for NVS API.
+ * @deprecated Please use @ref zephyr/kvss/nvs.h instead.
+ * @ingroup nvs
+ */
+#include <zephyr/kvss/nvs.h>
+
+__WARN("This header file is deprecated, please use zephyr/kvss/nvs.h instead.")
+
+#endif /* ZEPHYR_INCLUDE_FS_NVS_H_ */

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+#ifndef ZEPHYR_INCLUDE_FS_ZMS_H_
+#define ZEPHYR_INCLUDE_FS_ZMS_H_
+
+/**
+ * @file
+ * @brief Legacy interface header for ZMS API.
+ * @deprecated Please use @ref zephyr/kvss/zms.h instead.
+ * @ingroup zms
+ */
+#include <zephyr/kvss/zms.h>
+
+__WARN("This header file is deprecated, please use zephyr/kvss/zms.h instead.")
+
+#endif /* ZEPHYR_INCLUDE_FS_ZMS_H_ */

--- a/include/zephyr/kvss/nvs.h
+++ b/include/zephyr/kvss/nvs.h
@@ -4,8 +4,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_FS_NVS_H_
-#define ZEPHYR_INCLUDE_FS_NVS_H_
+#ifndef ZEPHYR_INCLUDE_KVSS_NVS_H_
+#define ZEPHYR_INCLUDE_KVSS_NVS_H_
 
 #include <sys/types.h>
 #include <zephyr/kernel.h>
@@ -196,4 +196,4 @@ int nvs_sector_use_next(struct nvs_fs *fs);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_FS_NVS_H_ */
+#endif /* ZEPHYR_INCLUDE_KVSS_NVS_H_ */

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -5,8 +5,8 @@
  *
  * ZMS: Zephyr Memory Storage
  */
-#ifndef ZEPHYR_INCLUDE_FS_ZMS_H_
-#define ZEPHYR_INCLUDE_FS_ZMS_H_
+#ifndef ZEPHYR_INCLUDE_KVSS_ZMS_H_
+#define ZEPHYR_INCLUDE_KVSS_ZMS_H_
 
 #include <sys/types.h>
 #include <zephyr/drivers/flash.h>
@@ -265,4 +265,4 @@ int zms_sector_use_next(struct zms_fs *fs);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_FS_ZMS_H_ */
+#endif /* ZEPHYR_INCLUDE_KVSS_ZMS_H_ */


### PR DESCRIPTION
PR adds redirecting headers under fs, to avoid breaking user code.
Fixes header guards.