### PR TITLE
samples: button: fix build issue when led0 is defined but disabled

### DIFF
--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -9,7 +9,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-static const struct led_dt_spec led0 = LED_DT_SPEC_GET_OR(DT_ALIAS(led0), {0});
+#define LED0_NODE DT_ALIAS(led0)
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_PARENT(LED0_NODE))
+static const struct led_dt_spec led0 = LED_DT_SPEC_GET(LED0_NODE);
+#else
+static const struct led_dt_spec led0;
+#endif
 
 static void button_input_cb(struct input_event *evt, void *user_data)
 {


### PR DESCRIPTION
Seems like some boards have an LED that is mounted but not connected to the gpio by default and needs a jumper or solder bridge to work, and in that case the led0 node is defined with status = "disabled".

Rework the led_dt_spec led0 initialization to handle that and just build with no led support.