### PR TITLE
dts: Fix nRF71 Wi-Fi bindings

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2674,7 +2674,7 @@ Documentation Infrastructure:
     - dts/bindings/wifi/nordic,nrf7000-spi.yaml
     - dts/bindings/wifi/nordic,nrf7001-qspi.yaml
     - dts/bindings/wifi/nordic,nrf7001-spi.yaml
-    - dts/bindings/wifi/nordic,nrf71-wifi.yaml
+    - dts/bindings/wifi/nordic,nrf7120-wifi.yaml
     - boards/shields/nrf7002ek/
   labels:
     - "area: Wi-Fi"

--- a/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: >
-  This is a representation of the Wi-Fi parts of the nRF71 Series Wi-Fi and
-  Bluetooth chip SoC.
+  Wi-Fi domain of nRF7120 Wi-Fi and
+  Bluetooth combo SoC.
 
-compatible: "nordic,nrf71-wifi"
+compatible: "nordic,nrf7120-wifi"
 
 include:
   - "wifi-tx-power-2g.yaml"


### PR DESCRIPTION
Match to the DTS entry and use the specific chip instead of the series.