### PR TITLE
sysbuild: Enable board-specific configuration and overlay discovery

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2741,6 +2741,11 @@ endfunction()
 #                                    For example:
 #                                    SUFFIX fish, will look for <file>_fish.conf and use
 #                                    if found but will use <file>.conf if not found
+#                     PREFIX <name>: Prefix name to check for instead of the default name
+#                                    but with a fallback to the default name if not found.
+#                                    For example:
+#                                    PREFIX mcuboot, will look for mcuboot_<file>.conf and use
+#                                    if found but will use <file>.conf if not found
 #                     REQUIRED:      Option to indicate that the <list> specified by DTS or KCONF
 #                                    must contain at least one element, else an error will be raised.
 #
@@ -2755,7 +2760,7 @@ Please provide one of following: APPLICATION_ROOT, CONF_FILES")
     set(single_args APPLICATION_ROOT BASE_DIR)
   elseif(${ARGV0} STREQUAL CONF_FILES)
     set(options QUALIFIERS REQUIRED)
-    set(single_args BOARD BOARD_REVISION BOARD_QUALIFIERS DTS KCONF DEFCONFIG SUFFIX)
+    set(single_args BOARD BOARD_REVISION BOARD_QUALIFIERS DTS KCONF DEFCONFIG SUFFIX PREFIX)
     set(multi_args CONF_FILES NAMES)
   endif()
 
@@ -3069,6 +3074,64 @@ function(zephyr_file_suffix filename)
     # Use the filename with the suffix if it exists, if not then fall back to the default
     if(EXISTS "${new_filename}")
       list(APPEND tmp_new_list ${new_filename})
+    else()
+      list(APPEND tmp_new_list ${file})
+    endif()
+  endforeach()
+
+  # Update supplied variable if it differs
+  if(NOT "${${filename}}" STREQUAL "${tmp_new_list}")
+    set(${filename} "${tmp_new_list}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Usage:
+#   zephyr_file_prefix(<filename> PREFIX <prefix>)
+#
+# Zephyr file add prefix extension.
+# This function will check the provided filename or list of filenames to see if they have a
+# `<prefix>_` prefix to them and if so, updates the supplied variable/list with the new
+# path/paths.
+#
+# <filename>: Variable (singular or list) of absolute path filename(s) which should be checked
+#             and updated if there is a filename which has the <prefix> present.
+# <prefix>: The prefix to test for and prepend to the provided filename.
+#
+# Returns an updated variable of absolute path(s)
+#
+function(zephyr_file_prefix filename)
+  set(single_args PREFIX)
+  cmake_parse_arguments(PFILE "" "${single_args}" "" ${ARGN})
+
+  if(NOT DEFINED PFILE_PREFIX OR NOT DEFINED ${filename})
+    # If the file prefix variable is not known then there is nothing to do, return early
+    return()
+  endif()
+
+  set(tmp_new_list)
+
+  foreach(file ${${filename}})
+    if("${file}" STREQUAL "")
+      # Skip checking empty variables
+      continue()
+    endif()
+
+    # Get the file path components
+    cmake_path(GET file PARENT_PATH file_dir)
+    cmake_path(GET file FILENAME file_name)
+
+    # Create new filename with prefix
+    set(new_filename "${PFILE_PREFIX}_${file_name}")
+
+    if(file_dir)
+      cmake_path(APPEND file_dir ${new_filename} OUTPUT_VARIABLE new_file_path)
+    else()
+      set(new_file_path ${new_filename})
+    endif()
+
+    # Use the filename with the prefix if it exists, if not then fall back to the default
+    if(EXISTS "${new_file_path}")
+      list(APPEND tmp_new_list ${new_file_path})
     else()
       list(APPEND tmp_new_list ${file})
     endif()

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -659,7 +659,12 @@ In the folder of the main application, create a Kconfig fragment or a devicetree
 overlay under a sysbuild folder, where the name of the file is
 :file:`<image>.conf` or :file:`<image>.overlay`, for example if your main
 application includes ``my_sample`` then create a :file:`sysbuild/my_sample.conf`
-file or a devicetree overlay :file:`sysbuild/my_sample.overlay`.
+file or a devicetree overlay :file:`sysbuild/my_sample.overlay`. Board-specific
+configuration files and overlays can also be created using the naming patterns
+:file:`<image>_<board>.conf` and :file:`<image>_<board>.overlay`, such as
+:file:`sysbuild/my_sample_nrf54h20dk_nrf54h20_cpuapp.conf` or
+:file:`sysbuild/my_sample_nrf54h20dk_nrf54h20_cpuapp.overlay`, which will be
+automatically discovered and applied when building for the corresponding board.
 
 A Kconfig fragment could look as:
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -182,6 +182,12 @@ New APIs and options
       generating slot 1 images automatically in sysbuild projects when using MCUboot in
       direct-xip mode.
 
+    * Enhanced image-specific configuration file discovery to support board-specific
+      Kconfig fragments and devicetree overlays using :file:`<image>_<board>.conf`
+      and :file:`<image>_<board>.overlay` naming patterns in the application's
+      sysbuild directory. This aligns with the existing base image configuration
+      discovery and provides consistent file naming conventions.
+
 * CPUFreq
 
   * :kconfig:option:`CONFIG_CPU_FREQ_POLICY_PRESSURE`

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -277,6 +277,11 @@ function(ExternalZephyrProject_Add)
                 NAMES ${ZBUILD_APPLICATION}.conf SUFFIX ${FILE_SUFFIX}
     )
 
+    # Check for board-specific conf files with image name prefix
+    zephyr_file(CONF_FILES ${sysbuild_image_conf_dir} KCONF sysbuild_image_conf_fragment
+                SUFFIX ${FILE_SUFFIX} PREFIX ${ZBUILD_APPLICATION}
+    )
+
     if(NOT (${ZBUILD_APPLICATION}_OVERLAY_CONFIG OR ${ZBUILD_APPLICATION}_EXTRA_CONF_FILE)
         AND EXISTS ${sysbuild_image_conf_fragment}
     )
@@ -286,22 +291,23 @@ function(ExternalZephyrProject_Add)
     endif()
 
     if(NOT ${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE)
-      # Check for overlay named <ZBUILD_APPLICATION>.overlay.
-      set(sysbuild_image_dts_overlay_files ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}.overlay)
+      # Check for overlay named <ZBUILD_APPLICATION>.overlay with optional FILE_SUFFIX.
+      zephyr_file(CONF_FILES ${sysbuild_image_conf_dir} DTS sysbuild_image_dts_overlay
+                  NAMES ${ZBUILD_APPLICATION}.overlay SUFFIX ${FILE_SUFFIX}
+      )
 
-      # Check for overlay named <ZBUILD_APPLICATION>_<FILE_SUFFIX>.overlay.
-      if(FILE_SUFFIX)
-        list(PREPEND sysbuild_image_dts_overlay_files ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}_${FILE_SUFFIX}.overlay)
+      # Check for board-specific overlay files with image name prefix
+      if(NOT EXISTS ${sysbuild_image_dts_overlay})
+        zephyr_file(CONF_FILES ${sysbuild_image_conf_dir} DTS sysbuild_image_dts_overlay
+                    SUFFIX ${FILE_SUFFIX} PREFIX ${ZBUILD_APPLICATION}
+        )
       endif()
 
-      foreach(overlay_file ${sysbuild_image_dts_overlay_files})
-        if(EXISTS ${overlay_file})
-          set(${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE ${overlay_file}
+      if(EXISTS ${sysbuild_image_dts_overlay})
+        set(${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE ${sysbuild_image_dts_overlay}
             CACHE INTERNAL "devicetree overlay file defined by main application"
-          )
-          break()
-        endif()
-      endforeach()
+        )
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
Add support for automatic discovery of board-specific Kconfig fragments and devicetree overlays in sysbuild using `<image>_<board>` naming pattern.

In addition to currently supported:
- `sysbuild/<image>.conf`
- `sysbuild/<image>.overlay`

Sysbuild can now automatically locate and apply board-specific files:
- `sysbuild/<image>_<board>.conf` for Kconfig configuration
- `sysbuild/<image>_<board>.overlay` for devicetree overlays

This allows different board targets to have customized configurations for sysbuild-managed images (e.g., MCUboot, secondary applications) without requiring explicit CMakeLists.txt modifications or command-line arguments.