### PR TITLE
drivers: nxp: Allow usage of clocks without subsystem name

### DIFF
--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -683,8 +683,9 @@ static DEVICE_API(i2c, mcux_flexcomm_driver_api) = {
 	static const struct mcux_flexcomm_config mcux_flexcomm_config_##id = {	\
 		.base = (I2C_Type *) DT_INST_REG_ADDR(id),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys =				\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (clock_control_subsys_t)COND_CODE_1(	\
+			DT_PHA_HAS_CELL(DT_DRV_INST(id), clocks, name),	\
+			(DT_INST_CLOCKS_CELL(id, name)), (0U)),		\
 		.irq_config_func = mcux_flexcomm_config_func_##id,	\
 		.bitrate = DT_INST_PROP(id, clock_frequency),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -650,8 +650,9 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 	static const struct mcux_lpi2c_config mcux_lpi2c_config_##n = {	\
 		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.clock_subsys = (clock_control_subsys_t)COND_CODE_1(	\
+			DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),	\
+			(DT_INST_CLOCKS_CELL(n, name)), (0U)),		\
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\

--- a/drivers/pinctrl/pinctrl_nxp_port.c
+++ b/drivers/pinctrl/pinctrl_nxp_port.c
@@ -80,8 +80,10 @@ static int pinctrl_mcux_init(const struct device *dev)
 		 ? 0                                                                               \
 		 : MAKE_MRCC_REGADDR(MRCC_BASE, DT_INST_CLOCKS_CELL(n, mrcc_offset)))
 #else
-#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n) \
-	DT_INST_CLOCKS_CELL(n, name)
+#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)			\
+	COND_CODE_1(						\
+		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),	\
+		(DT_INST_CLOCKS_CELL(n, name)), (0U))
 #endif
 
 #define PINCTRL_MCUX_INIT(n)						\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -1439,8 +1439,9 @@ static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state, uint8_t subs
 static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {		\
 	.base = (USART_Type *)DT_INST_REG_ADDR(n),				\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
-	.clock_subsys =								\
-	(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),			\
+	.clock_subsys = (clock_control_subsys_t)COND_CODE_1(			\
+		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),			\
+		(DT_INST_CLOCKS_CELL(n, name)), (0U)),				\
 	.baud_rate = DT_INST_PROP(n, current_speed),				\
 	.parity = DT_INST_ENUM_IDX(n, parity),					\
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1607,7 +1607,9 @@ static DEVICE_API(uart, mcux_lpuart_driver_api) = {
 static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
 	.base = (LPUART_Type *) DT_INST_REG_ADDR(n),                          \
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                   \
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+	.clock_subsys = (clock_control_subsys_t)COND_CODE_1(                  \
+		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),                \
+		(DT_INST_CLOCKS_CELL(n, name)), (0U)),                        \
 	.baud_rate = DT_INST_PROP(n, current_speed),                          \
 	.flow_ctrl = FLOW_CONTROL(n),                                         \
 	.parity = DT_INST_ENUM_IDX(n, parity),                                \

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -1013,8 +1013,9 @@ static DEVICE_API(spi, spi_mcux_driver_api) = {
 		.base =							\
 		(SPI_Type *)DT_INST_REG_ADDR(id),			\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys =					\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (clock_control_subsys_t)COND_CODE_1(	\
+			DT_PHA_HAS_CELL(DT_DRV_INST(id), clocks, name),	\
+			(DT_INST_CLOCKS_CELL(id, name)), (0U)),		\
 		SPI_MCUX_FLEXCOMM_IRQ_HANDLER_FUNC(id)			\
 		.pre_delay = DT_INST_PROP_OR(id, pre_delay, 0),		\
 		.post_delay = DT_INST_PROP_OR(id, post_delay, 0),		\


### PR DESCRIPTION
Several NXP drivers require clock control subsystem name definition in Devicetree. It prevents usage of clock control without subsystem such as fixed-clock. fixed-clock can be used for early SoC enablement when complete clock controller is not available or not required.
Allow optional usage of clock control without subsystem by using 0 as subsystem name if the name is not defined in devicetree. Add the option for port, i2c, spi and serial drivers.