### PR TITLE
doc: _extensions: put board status abbr into a paragraph

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -299,14 +299,15 @@ class ConvertBoardNode(SphinxTransform):
             field_list = nodes.field_list()
             sidebar += field_list
 
+            status_para = nodes.paragraph()
             if node.get("maintained", False):
-                status_text = nodes.abbreviation(
+                status_para += nodes.abbreviation(
                     "Maintained",
                     "Maintained",
                     explanation="At least one active maintainer is looking after this board",
                 )
             else:
-                status_text = nodes.abbreviation(
+                status_para += nodes.abbreviation(
                     "Not actively maintained",
                     "Not actively maintained",
                     explanation="No active maintainer on file, but contributions are welcome",
@@ -315,7 +316,7 @@ class ConvertBoardNode(SphinxTransform):
             details = [
                 ("Name", nodes.literal(text=node["id"])),
                 ("Vendor", node["vendor"]),
-                ("Status", status_text),
+                ("Status", status_para),
                 ("Architecture", ", ".join(node["archs"])),
                 ("SoC", ", ".join(node["socs"])),
             ]


### PR DESCRIPTION
Commit 7449b51688fefd216c878bce55ac2eb0d6819d9c introduced a new "Status" field for indicatting whether a board is actively maintained or not but the field was added as an abbr node directly to the field list which causes it to render with an ever so slightly larger font size than the other fields. Put it into a paragraph to fix this.

See

https://docs.zephyrproject.org/latest/boards/holyiot/holyiot_21014/doc/index.html

vs. 

https://builds.zephyrproject.io/zephyr/pr/104062/docs/boards/holyiot/holyiot_21014/doc/index.html