### PR TITLE
drivers: i2c: rts5912: set pin as open drain in i2c_rts5912_recover_bus

### DIFF
--- a/drivers/i2c/i2c_realtek_rts5912.c
+++ b/drivers/i2c/i2c_realtek_rts5912.c
@@ -133,7 +133,7 @@ static int i2c_rts5912_recover_bus(const struct device *dev)
 	gpio_pin_get_dt(&config->scl_gpios);
 
 	/* Output type selection */
-	flags = GPIO_OUTPUT_HIGH | RTS5912_GPIO_SCHEN;
+	flags = GPIO_OUTPUT_HIGH | RTS5912_GPIO_SCHEN | GPIO_OPEN_DRAIN;
 	/* Set SCL of I2C as GPIO pin */
 	gpio_pin_configure_dt(&config->scl_gpios, flags);
 	/* Set SDA of I2C as GPIO pin */


### PR DESCRIPTION
The i2c_rts5912_recover_bus kicks in after an i2c transfer error to recover the bus and uses the i2c pins in gpio mode. This MCU allows using pins in a 3.3V domain at 1.8V by setting compatible input thresholds, the problem though is that then if the pin is set to push-pull output it's going to drive back up to 3.3V.

Avoid that by setting the pin as open drain before setting it as output.

Before

<img width="800" height="480" alt="image24587" src="https://github.com/user-attachments/assets/e720abf8-81b1-4c0d-bc7f-fb359cf0d1fc" />

after

<img width="800" height="480" alt="image10569" src="https://github.com/user-attachments/assets/e0dbd11f-5be9-4061-bc06-3604fcf8aacd" />
