### PR TITLE
shell: backends: uart: disable RX on async_uninit

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -332,6 +332,9 @@ static void irq_uninit(struct shell_uart_int_driven *sh_uart)
 
 static void async_uninit(struct shell_uart_async *sh_uart)
 {
+	const struct device *dev = sh_uart->common.dev;
+
+	(void)uart_rx_disable(dev);
 }
 
 static void polling_uninit(struct shell_uart_polling *sh_uart)


### PR DESCRIPTION
async_uninit() was a no-op, so when the shell UART transport was uninitialized, UART RX stayed enabled and the device remained active. Call uart_rx_disable() in async_uninit to match async_init's rx_enable(), so the UART is fully disabled on uninit.

If the underlying UART driver (implementing device runtime PM) acquires the device as part of rx_enable(), repeated initialization and deinitialization of the backend could result in unbalanced get/put calls.