### PR TITLE
MAINTAINERS: do not include the dts/ folder in the Boards/SoCs category

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -732,7 +732,6 @@ Boards/SoCs:
   files:
     - boards/
     - soc/
-    - dts/
   labels:
     - "area: Boards/SoCs"
   description: >-


### PR DESCRIPTION
Remove the `dts/` folder from the "area: Boards/SoCs" category. I always get confused why this label is added to PRs neither touching `boards/` nor `soc/`.