### PR TITLE
stm32: tests:  drivers: watchdog : wdt_basic_api:  fix regressions on some STM32 platforms and 

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -82,7 +82,7 @@ LOG_MODULE_REGISTER(wdt_wwdg_stm32);
 #define ABS_DIFF_UINT(a, b)  ((a) > (b) ? (a) - (b) : (b) - (a))
 #define WWDG_TIMEOUT_ERROR_MARGIN(__TIMEOUT__)   (__TIMEOUT__ / 10)
 #define IS_WWDG_TIMEOUT(__TIMEOUT_GOLDEN__, __TIMEOUT__)  \
-	(__TIMEOUT__ - __TIMEOUT_GOLDEN__) < \
+	ABS_DIFF_UINT(__TIMEOUT__, __TIMEOUT_GOLDEN__) < \
 	WWDG_TIMEOUT_ERROR_MARGIN(__TIMEOUT_GOLDEN__)
 
 static void wwdg_stm32_irq_config(const struct device *dev);

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -167,7 +167,11 @@ static struct wdt_timeout_cfg m_cfg_wdt1;
 #define DATATYPE uint32_t
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
+/*
+ * Exclude all STM32 SoCs from using the DTCM noinit section,
+ * as it may break WDT state retention.
+ */
+#if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm)) && !defined(CONFIG_SOC_FAMILY_STM32)
 #define NOINIT_SECTION ".dtcm_noinit.test_wdt"
 #else
 #define NOINIT_SECTION ".noinit.test_wdt"

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -72,7 +72,11 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
 #define WDT_NODE            DT_INST(0, st_stm32_window_watchdog)
 #define TIMEOUTS            0
+#if defined(CONFIG_SOC_SERIES_STM32F7X)
+#define WDT_TEST_MAX_WINDOW 170
+#else
 #define WDT_TEST_MAX_WINDOW 200
+#endif
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)
 #define TIMEOUTS 0

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -72,6 +72,8 @@ tests:
   drivers.watchdog.stm32wwdg_h7:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg_h7.overlay"
+    extra_configs:
+      - CONFIG_DCACHE=n
     platform_allow:
       - nucleo_h7s3l8
       - stm32h7s78_dk


### PR DESCRIPTION
Following the relevant changes made to the watchdog in https://github.com/zephyrproject-rtos/zephyr/pull/98148, we are now able to run the watchdog test successfully without side effects such as interference with subsequent tests.

There are some changes that need to be applied for this test to work properly:

- Keep noinit variables out of DTCM on all STM32 boards in general, and this is particularly required for STM32H7.
- Decrease the window watchdog timeout from 200 ms to 170 ms on STM32F7 due to hardware limitations.