### PR TITLE
samples: drivers: mspi: mspi_flash: enable CI testing on available STM32 platforms and apply several fixes and improvements to the MSPI Flash driver

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1328,11 +1328,11 @@ BUILD_ASSERT((CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE % 4096) == 0,
 #define FLASH_PAGE_LAYOUT_DEFINE(inst) \
 	.layout = { \
 		.pages_size = CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE, \
-		.pages_count = FLASH_SIZE(inst) \
+		.pages_count = FLASH_SIZE_INST(inst) \
 			     / CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE, \
 	},
 #define FLASH_PAGE_LAYOUT_CHECK(inst) \
-BUILD_ASSERT((FLASH_SIZE(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
+BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
 	"MSPI_NOR_FLASH_LAYOUT_PAGE_SIZE incompatible with flash size, instance " #inst);
 #else
 #define FLASH_PAGE_LAYOUT_DEFINE(inst)
@@ -1351,7 +1351,7 @@ BUILD_ASSERT((FLASH_SIZE(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
 
 #define FLASH_MSPI_NOR_INST(inst)						\
 	BUILD_ASSERT(!PACKET_DATA_LIMIT(inst) ||				\
-		     FLASH_PAGE_SIZE(inst) <= PACKET_DATA_LIMIT(inst),		\
+		     FLASH_PAGE_SIZE_INST(inst) <= PACKET_DATA_LIMIT(inst),		\
 		"Page size for " DT_NODE_FULL_NAME(DT_DRV_INST(inst))		\
 		" exceeds controller packet data limit");			\
 	SFDP_BUILD_ASSERTS(inst);						\
@@ -1362,8 +1362,8 @@ BUILD_ASSERT((FLASH_SIZE(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),			\
 		.packet_data_limit = DT_PROP_OR(DT_INST_BUS(inst),		\
 						packet_data_limit, 0),		\
-		.flash_size = FLASH_SIZE(inst),					\
-		.page_size = FLASH_PAGE_SIZE(inst),				\
+		.flash_size = FLASH_SIZE_INST(inst),					\
+		.page_size = FLASH_PAGE_SIZE_INST(inst),				\
 		.mspi_id = MSPI_DEVICE_ID_DT_INST(inst),			\
 		.mspi_nor_cfg = MSPI_DEVICE_CONFIG_DT_INST(inst),		\
 		.mspi_control_cfg = FLASH_CONTROL_CMD_CONFIG(inst),		\

--- a/drivers/flash/flash_mspi_nor_sfdp.h
+++ b/drivers/flash/flash_mspi_nor_sfdp.h
@@ -320,14 +320,14 @@
 	 ? BIT(MIN(31, (dw2 & BIT_MASK(31)) - 3)) \
 	 : dw2 / 8)
 
-#define FLASH_SIZE(inst) \
+#define FLASH_SIZE_INST(inst) \
 	(DT_INST_NODE_HAS_PROP(inst, size) \
 	 ? DT_INST_PROP(inst, size) / 8 \
 	 : BFP_FLASH_SIZE(SFDP_DW(inst, sfdp_bfp, 2)))
 
 #define BFP_FLASH_PAGE_EXP(inst) SFDP_FIELD(inst, sfdp_bfp, 11, GENMASK(7, 4))
 
-#define FLASH_PAGE_SIZE(inst) \
+#define FLASH_PAGE_SIZE_INST(inst) \
 	(BFP_FLASH_PAGE_EXP(inst) \
 	 ? BIT(BFP_FLASH_PAGE_EXP(inst)) \
 	 : SPI_NOR_PAGE_SIZE)
@@ -412,9 +412,9 @@
 	.octal_enable_req = OCTAL_ENABLE_REQ_NONE, \
 	.enter_4byte_addr = ENTER_4BYTE_ADDR_NONE }
 
-#define FLASH_SIZE(inst) (DT_INST_PROP(inst, size) / 8)
+#define FLASH_SIZE_INST(inst) (DT_INST_PROP(inst, size) / 8)
 
-#define FLASH_PAGE_SIZE(inst) SPI_NOR_PAGE_SIZE
+#define FLASH_PAGE_SIZE_INST(inst) SPI_NOR_PAGE_SIZE
 
 #define SFDP_BUILD_ASSERTS(inst)
 

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -296,7 +296,8 @@ static int mspi_stm32_xspi_abort_memmap_if_enabled(const struct device *dev)
  * @brief Reads/Writes in memory mapped mode.
  *
  */
-static int read_write_in_memory_map_mode(const struct device *dev, struct mspi_xfer_packet *packet)
+static int read_write_in_memory_map_mode(const struct device *dev,
+					 const struct mspi_xfer_packet *packet)
 {
 	int ret;
 	struct mspi_stm32_data *dev_data = dev->data;
@@ -339,7 +340,7 @@ static int read_write_in_memory_map_mode(const struct device *dev, struct mspi_x
 }
 
 static HAL_StatusTypeDef read_write_in_indirect_mode(const struct device *dev,
-						     struct mspi_xfer_packet *packet,
+						     const struct mspi_xfer_packet *packet,
 						     uint8_t access_mode)
 {
 	HAL_StatusTypeDef hal_ret;
@@ -422,7 +423,7 @@ end:
  * @brief Sends a Command to the NOR and Receive/Transceive data if relevant in IT or DMA mode.
  *
  */
-static int mspi_stm32_xspi_access(const struct device *dev, struct mspi_xfer_packet *packet,
+static int mspi_stm32_xspi_access(const struct device *dev, const struct mspi_xfer_packet *packet,
 				  uint8_t access_mode)
 {
 	HAL_StatusTypeDef hal_ret;
@@ -1277,7 +1278,7 @@ static int mspi_stm32_xspi_pio_dma_transceive(const struct device *controller,
 	uint32_t packet_idx;
 	struct mspi_stm32_data *dev_data = controller->data;
 	struct mspi_stm32_context *ctx = &dev_data->ctx;
-	struct mspi_xfer_packet *packet;
+	const struct mspi_xfer_packet *packet;
 
 	if (xfer->num_packet == 0 || xfer->packets == NULL ||
 	    xfer->timeout > CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE) {
@@ -1293,7 +1294,7 @@ static int mspi_stm32_xspi_pio_dma_transceive(const struct device *controller,
 
 	while (ctx->packets_left > 0) {
 		packet_idx = ctx->xfer.num_packet - ctx->packets_left;
-		packet = (const struct mspi_xfer_packet *)&ctx->xfer.packets[packet_idx];
+		packet = &ctx->xfer.packets[packet_idx];
 #ifdef CONFIG_MSPI_DMA
 		const struct mspi_stm32_conf *dev_cfg = controller->config;
 

--- a/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
@@ -18,6 +18,7 @@
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 8)>,
 				 <&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
+			clock-frequency = <DT_FREQ_M(50)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			op-mode = "MSPI_OP_MODE_CONTROLLER";
@@ -41,9 +42,9 @@
 				mspi-io-mode = "MSPI_IO_MODE_OCTAL";
 				mspi-data-rate = "MSPI_DATA_RATE_DUAL"; /* as first step */
 				mspi-hardware-ce-num = <0>;
-				read-command = <0xEE11>;                /* ReaD 4Bytes */
+				read-command = <0xee11>;                /* ReaD 4Bytes */
 				command-length = "INSTR_2_BYTE";
-				write-command = <0x12ED>; /* WRite 4Bytes */
+				write-command = <0x12ed>; /* WRite 4Bytes */
 				rx-dummy = <20>;
 				jedec-id = [c2 85 3a];
 				status = "okay";

--- a/samples/drivers/mspi/mspi_flash/sample.yaml
+++ b/samples/drivers/mspi/mspi_flash/sample.yaml
@@ -10,6 +10,15 @@ tests:
     platform_exclude:
       - hifive_unmatched/fu740/s7
       - hifive_unmatched/fu740/u74
+    platform_allow:
+      - apollo3p_evb
+      - apollo510_evb
+      - arduino_giga_r1/stm32h747xx/m7
+      - b_u585i_iot02a
+      - stm32h573i_dk
+      - stm32h735g_disco
+      - stm32l496g_disco
+      - stm32l562e_dk
     harness: console
     harness_config:
       type: multi_line
@@ -20,7 +29,6 @@ tests:
         - "Test 2: Flash write"
         - "Attempting to write 4 bytes"
         - "Data read matches data written. Good!!"
-    depends_on: mspi
     integration_platforms:
       - apollo3p_evb
       - apollo510_evb


### PR DESCRIPTION
This PR introduces several fixes and improvements across the MSPI Flash driver, STM32 XSPI implementation, and enables CI testing on available STM32 boards using the zephyr/samples/drivers/mspi/mspi_flash sample.

**1. Avoid HAL macro conflicts in MSPI flash driver**

   STM32 HAL headers define FLASH_SIZE and FLASH_PAGE_SIZE macros, which conflict with similarly named macros in 
  flash_mspi_nor_sfdp.h.
  https://github.com/zephyrproject-rtos/hal_stm32/blob/b66bb5c3743ddccc501712d84638eb1df1ebbb04/stm32cube/stm32l5xx/soc/stm32l562xx.h#L1772  
  (`FLASH_SIZE`)
    https://github.com/zephyrproject-rtos/hal_stm32/blob/b66bb5c3743ddccc501712d84638eb1df1ebbb04/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_flash.h#L940  (`FLASH_PAGE_SIZE`)
    
   To prevent redefinition warnings and ensure compatibility across STM32 HAL variants, the macros are renamed:

   `FLASH_SIZE(inst) → FLASH_SIZE_INST(inst)
`  
` FLASH_PAGE_SIZE(inst) → FLASH_PAGE_SIZE_INST(inst)`

   This resolves build warnings and avoids name collisions with existing HAL definitions.
   
```
   zephyrproject/zephyr/drivers/flash/flash_mspi_nor_sfdp.h:415: warning: "FLASH_SIZE" redefined 

  415 | #define FLASH_SIZE(inst) (DT_INST_PROP(inst, size) / 8) 

      |  [...]
zephyrproject/modules/hal/stm32/stm32cube/stm32l5xx/soc/stm32l562xx.h:1772: note: this is the location of the previous definition 

1772 | #define FLASH_SIZE            ((((*((uint16_t *)FLASHSIZE_BASE)) == 0xFFFFU)) ? 0x80000U : \ 

      |  
      
      zephyrproject/zephyr/drivers/flash/flash_mspi_nor_sfdp.h:417: warning: "FLASH_PAGE_SIZE" redefined 

  417 | #define FLASH_PAGE_SIZE(inst) SPI_NOR_PAGE_SIZE 

      |  [...]
   zephyrproject/modules/hal/stm32/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_flash.h:940: note: this is the location of the previous definition 

  940 | #define FLASH_PAGE_SIZE          0x00000800U 
```
 
 To reproduce :  west build -p -b stm32l562e_dk samples/drivers/mspi/mspi_flash/ 

**2. Fix discarded const qualifier in STM32 XSPI driver**

The MSPI API defines xfer.packets as a pointer to const struct mspi_xfer_packet, but the driver stored it in a non‑const pointer, causing a -Wdiscarded-qualifiers warning.
The XSPI driver now uses a const pointer, restoring const‑correctness without functional changes.

```
In function 'mspi_stm32_xspi_pio_dma_transceive': 

zephyrproject/zephyr/drivers/mspi/mspi_stm32_xspi.c:1296:24: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers] 

1296 |                 packet = (const struct mspi_xfer_packet *)&ctx->xfer.packets[packet_idx]; 
```

To reproduce :  west build -p -b stm32h573i_dk samples/drivers/mspi/mspi_flash/

**3. Add STM32‑specific test scenario for MSPI Flash sample**

The mspi_flash sample is extended with a new test scenario targeting STM32 platforms using jedec,mspi-nor compatible devices.
This enables automated validation of erase, write, and read operations on STM32 MSPI-capable boards.

Note: MSPI remains experimental, so no depend_on: mspi is added until board support is finalized.

