### PR TITLE
soc: espressif: use ZSR_CPU_STR macro for cpu pointer register

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -26,6 +26,9 @@
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/arch/common/init.h>
+#ifdef CONFIG_XTENSA
+#include <zephyr/zsr.h>
+#endif
 
 #if CONFIG_SOC_SERIES_ESP32C6
 #include <soc/hp_apm_reg.h>
@@ -307,10 +310,10 @@ void __start(void)
 	__asm__ __volatile__("wsr %0, PS" : : "r"(PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE));
 
 	/* Initialize the architecture CPU pointer.  Some of the
-	 * initialization code wants a valid arch_current_thread() before
+	 * initialization code wants a valid arch_curr_cpu() before
 	 * arch_kernel_init() is invoked.
 	 */
-	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
+	__asm__ __volatile__("wsr %0, " ZSR_CPU_STR "; rsync" : : "r"(&_kernel.cpus[0]));
 
 #endif /* CONFIG_RISCV_GP */
 

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -18,6 +18,7 @@
 
 #include "esp_mcuboot_image.h"
 #include "esp_memory_utils.h"
+#include <zephyr/zsr.h>
 
 #ifdef CONFIG_SMP
 
@@ -94,7 +95,7 @@ static void appcpu_entry2(void)
 	 */
 	_cpu_t *cpu = &_kernel.cpus[1];
 
-	__asm__ volatile("wsr.MISC0 %0" : : "r"(cpu));
+	__asm__ volatile("wsr %0, " ZSR_CPU_STR : : "r"(cpu));
 
 	smp_log("ESP32: APPCPU running");
 

--- a/soc/espressif/esp32/soc_appcpu.c
+++ b/soc/espressif/esp32/soc_appcpu.c
@@ -18,6 +18,7 @@
 #include <zephyr/types.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/arch/common/init.h>
+#include <zephyr/zsr.h>
 
 #include <esp_private/system_internal.h>
 #include <esp32s3/rom/cache.h>
@@ -83,7 +84,7 @@ void IRAM_ATTR __appcpu_start(void)
 	 * initialization code wants a valid _current before
 	 * z_prep_c() is invoked.
 	 */
-	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[1]));
+	__asm__ __volatile__("wsr %0, " ZSR_CPU_STR "; rsync" : : "r"(&_kernel.cpus[1]));
 
 	core_intr_matrix_clear();
 

--- a/soc/espressif/esp32s3/soc_appcpu.c
+++ b/soc/espressif/esp32s3/soc_appcpu.c
@@ -18,6 +18,7 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/arch/common/init.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/zsr.h>
 
 #include <esp_private/system_internal.h>
 #include <esp32s3/rom/cache.h>
@@ -68,7 +69,7 @@ void IRAM_ATTR __appcpu_start(void)
 	 * initialization code wants a valid _current before
 	 * arch_kernel_init() is invoked.
 	 */
-	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[1]));
+	__asm__ __volatile__("wsr %0, " ZSR_CPU_STR "; rsync" : : "r"(&_kernel.cpus[1]));
 
 	core_intr_matrix_clear();
 


### PR DESCRIPTION
Replace hardcoded wsr.MISC0 with the build-generated ZSR_CPU_STR macro to write the correct Xtensa special register for the CPU pointer.