### PR TITLE
subsys: dfu: refactor flash_img to isolate MCUboot specific code

### DIFF
--- a/subsys/dfu/CMakeLists.txt
+++ b/subsys/dfu/CMakeLists.txt
@@ -1,4 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(boot)
-add_subdirectory(img_util)
+zephyr_library()
+
+if(CONFIG_MCUBOOT_IMG_MANAGER)
+    zephyr_library_sources(
+        boot/mcuboot.c
+        img_util/flash_img.c
+    )
+    zephyr_library_sources_ifdef(CONFIG_MCUBOOT_SHELL boot/mcuboot_shell.c)
+    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+endif()

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -32,6 +32,32 @@ config MCUBOOT_IMG_MANAGER
 
 endchoice
 
+config IMG_BLOCK_BUF_SIZE
+	int "Image writer buffer size"
+	default 512
+	help
+	  Size (in Bytes) of buffer for image writer. Must be a multiple of
+	  the access alignment required by used flash driver.
+
+config IMG_ERASE_PROGRESSIVELY
+	bool "Erase flash progressively when receiving new firmware"
+	select STREAM_FLASH_ERASE if FLASH_HAS_EXPLICIT_ERASE
+	help
+	  If enabled, flash is erased as necessary when receiving new firmware,
+	  instead of erasing the whole image slot at once. This is necessary
+	  on some hardware that has long erase times, to prevent long wait
+	  times at the beginning of the DFU process.
+
+config IMG_ENABLE_IMAGE_CHECK
+	bool "Image check functions"
+	select FLASH_AREA_CHECK_INTEGRITY
+	help
+	  If enabled, there will be available the function to check flash
+	  integrity.  It can be used to verify flash integrity after received
+	  a new firmware.  This is useful to avoid firmware reboot and test.
+	  Another use is to ensure that firmware upgrade routines from internet
+	  server to flash slot are performing properly.
+
 if MCUBOOT_IMG_MANAGER
 
 config MCUBOOT_SHELL
@@ -59,32 +85,6 @@ config MCUBOOT_UPDATE_FOOTER_SIZE
 	  Estimated size of update image data, which is used to prevent loading of firmware updates
 	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
 	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
-
-config IMG_BLOCK_BUF_SIZE
-	int "Image writer buffer size"
-	default 512
-	help
-	  Size (in Bytes) of buffer for image writer. Must be a multiple of
-	  the access alignment required by used flash driver.
-
-config IMG_ERASE_PROGRESSIVELY
-	bool "Erase flash progressively when receiving new firmware"
-	select STREAM_FLASH_ERASE if FLASH_HAS_EXPLICIT_ERASE
-	help
-	  If enabled, flash is erased as necessary when receiving new firmware,
-	  instead of erasing the whole image slot at once. This is necessary
-	  on some hardware that has long erase times, to prevent long wait
-	  times at the beginning of the DFU process.
-
-config IMG_ENABLE_IMAGE_CHECK
-	bool "Image check functions"
-	select FLASH_AREA_CHECK_INTEGRITY
-	help
-	  If enabled, there will be available the function to check flash
-	  integrity.  It can be used to verify flash integrity after received
-	  a new firmware.  This is useful to avoid firmware reboot and test.
-	  Another use is to ensure that firmware upgrade routines from internet
-	  server to flash slot are performing properly.
 
 endif # MCUBOOT_IMG_MANAGER
 

--- a/subsys/dfu/boot/CMakeLists.txt
+++ b/subsys/dfu/boot/CMakeLists.txt
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-if(CONFIG_MCUBOOT_IMG_MANAGER)
-  zephyr_library()
-  zephyr_library_sources(mcuboot.c)
-  zephyr_library_sources_ifdef(CONFIG_MCUBOOT_SHELL mcuboot_shell.c)
-  zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
-endif()

--- a/subsys/dfu/img_util/CMakeLists.txt
+++ b/subsys/dfu/img_util/CMakeLists.txt
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-zephyr_sources_ifdef(CONFIG_MCUBOOT_IMG_MANAGER flash_img.c)
-
-zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)


### PR DESCRIPTION
This commit refactors the flash_img module to separate MCUboot-specific functionality from generic flash image handling code.

Relates to #103999 RFC.