### PR TITLE
drivers: audio: tlv320dac310x

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -409,8 +409,8 @@ static void codec_configure_output(const struct device *dev)
 	codec_read_reg(dev, HP_OUT_POP_RM_ADDR, &val);
 	codec_write_reg(dev, HP_OUT_POP_RM_ADDR, val | HP_OUT_POP_RM_ENABLE);
 
-	/* route DAC output to Headphone */
-	val = OUTPUT_ROUTING_HPL | OUTPUT_ROUTING_HPR;
+	/* route DAC output to Mixer Amplifier -> so that volume control has effect */
+	val = OUTPUT_ROUTING_MIXERL | OUTPUT_ROUTING_MIXERR;
 	codec_write_reg(dev, OUTPUT_ROUTING_ADDR, val);
 
 	/* enable volume control on Headphone out */

--- a/drivers/audio/tlv320dac310x.h
+++ b/drivers/audio/tlv320dac310x.h
@@ -97,8 +97,10 @@ extern "C" {
 #define HP_OUT_POP_RM_ENABLE	(BIT(7))
 
 #define OUTPUT_ROUTING_ADDR	(struct reg_addr){1, 35}
-#define OUTPUT_ROUTING_HPL	(2 << 6)
-#define OUTPUT_ROUTING_HPR	(2 << 2)
+#define OUTPUT_ROUTING_HPL	  (2 << 6)
+#define OUTPUT_ROUTING_MIXERL (1 << 6)
+#define OUTPUT_ROUTING_HPR	  (2 << 2)
+#define OUTPUT_ROUTING_MIXERR (1 << 2)
 
 #define HPL_ANA_VOL_CTRL_ADDR	(struct reg_addr){1, 36}
 #define HPR_ANA_VOL_CTRL_ADDR	(struct reg_addr){1, 37}


### PR DESCRIPTION
I have been trying to change the volume on the headphone outputs with the current initialization. I was not able to control the volume by calling audio_codec_set_property()  which changes the content of registers "Left Analog Volume to HPL" (0x24 on page 1) and "Right Analog Volume to HPR" (0x25 on page 1).

I finally figured out that the DAC outputs have to be routed to the mixer amplifier instead of to the HP driver to let audio_codec_set_property() change the volume on the headphone outputs.
