### PR TITLE
drivers: include: led_strip: use doxygen aliases to document driver ops

### DIFF
--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -60,46 +60,58 @@ struct led_rgb {
 };
 
 /**
- * @typedef led_api_update_rgb
+ * @def_driverbackendgroup{LED Strip,led_strip_interface}
+ * @{
+ */
+
+/**
  * @brief Callback API for updating an RGB LED strip
  *
- * @see led_strip_update_rgb() for argument descriptions.
+ * See @a led_strip_update_rgb() for argument descriptions.
  */
 typedef int (*led_api_update_rgb)(const struct device *dev,
 				  struct led_rgb *pixels,
 				  size_t num_pixels);
 
 /**
- * @typedef led_api_update_channels
  * @brief Callback API for updating channels without an RGB interpretation.
  *
- * @see led_strip_update_channels() for argument descriptions.
+ * See @a led_strip_update_channels() for argument descriptions.
  */
 typedef int (*led_api_update_channels)(const struct device *dev,
 				       uint8_t *channels,
 				       size_t num_channels);
 
 /**
- * @typedef led_api_length
  * @brief Callback API for getting length of an LED strip.
  *
- * @see led_strip_length() for argument descriptions.
+ * See @a led_strip_length() for argument descriptions.
  */
 typedef size_t (*led_api_length)(const struct device *dev);
 
 /**
- * @brief LED strip driver API
+ * @driver_ops{LED Strip}
  */
 __subsystem struct led_strip_driver_api {
-	/* Mandatory callbacks. */
+	/**
+	 * @driver_ops_mandatory @copybrief led_strip_update_rgb
+	 */
 	led_api_update_rgb update_rgb;
+	/**
+	 * @driver_ops_mandatory @copybrief led_strip_length
+	 */
 	led_api_length length;
-	/* Optional callbacks. */
+	/**
+	 * @driver_ops_optional @copybrief led_strip_update_channels
+	 */
 	led_api_update_channels update_channels;
 };
+/**
+ * @}
+ */
 
 /**
- * @brief		Mandatory function to update an LED strip with the given RGB array.
+ * @brief		Update an LED strip with the given RGB array.
  *
  * @param dev		LED strip device.
  * @param pixels	Array of pixel data.
@@ -131,8 +143,8 @@ static inline int led_strip_update_rgb(const struct device *dev,
 }
 
 /**
- * @brief		Optional function to update an LED strip with the given channel array
- *			(each channel byte corresponding to an individually addressable color
+ * @brief		Update an LED strip with the given channel array.
+ *			Each channel byte corresponds to an individually addressable color
  *			channel or LED. Channels are updated linearly in strip order.
  *
  * @param dev		LED strip device.
@@ -160,7 +172,7 @@ static inline int led_strip_update_channels(const struct device *dev,
 }
 
 /**
- * @brief	Mandatory function to get chain length (in pixels) of an LED strip device.
+ * @brief	Get chain length (in pixels) of an LED strip device.
  *
  * @param dev	LED strip device.
  *


### PR DESCRIPTION
Apply the recently introduced driver_ops Doxygen macros to the CAN controller driver API. This standardizes how driver operations are documented, making it easier for developers to distinguish between mandatory and optional operations directly in the public API documentation.

https://builds.zephyrproject.io/zephyr/pr/104085/docs/doxygen/html/group__led__strip__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/104085/docs/doxygen/html/structled__strip__driver__api.html