### PR TITLE
debug: coredump: arm: add callee-saved offset for thread debugging

### DIFF
--- a/arch/arm/core/cortex_m/coredump.c
+++ b/arch/arm/core/cortex_m/coredump.c
@@ -8,7 +8,7 @@
 #include <zephyr/debug/coredump.h>
 #include <zephyr/kernel/thread.h>
 
-#define ARCH_HDR_VER 2
+#define ARCH_HDR_VER 3
 
 uint32_t z_arm_coredump_fault_sp;
 
@@ -34,6 +34,10 @@ struct arm_arch_block {
 		uint32_t r10;
 		uint32_t r11;
 	} r;
+	struct {
+		uint32_t	callee_saved_valid;   /* non-zero if offset is valid */
+		uint32_t	callee_saved_offset;  /* offsetof(k_thread, callee_saved) */
+	} callee;
 } __packed;
 
 /*
@@ -74,6 +78,7 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 	arch_blk.r.xpsr = esf->basic.xpsr;
 
 	arch_blk.r.sp = z_arm_coredump_fault_sp;
+	arch_blk.callee.callee_saved_valid = 0;
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	if (esf->extra_info.callee) {
@@ -85,6 +90,9 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 		arch_blk.r.r9 = esf->extra_info.callee->v6;
 		arch_blk.r.r10 = esf->extra_info.callee->v7;
 		arch_blk.r.r11 = esf->extra_info.callee->v8;
+
+		arch_blk.callee.callee_saved_valid = 1;
+		arch_blk.callee.callee_saved_offset = offsetof(struct k_thread, callee_saved);
 	}
 #endif
 

--- a/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
+++ b/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
@@ -38,6 +38,7 @@ class RegNum:
 class GdbStub_ARM_CortexM(GdbStub):
     ARCH_DATA_BLK_STRUCT = "<IIIIIIIII"
     ARCH_DATA_BLK_STRUCT_V2 = "<IIIIIIIIIIIIIIIII"
+    ARCH_DATA_BLK_STRUCT_V3 = "<IIIIIIIIIIIIIIIIIII"
 
     GDB_SIGNAL_DEFAULT = 7
 
@@ -47,6 +48,7 @@ class GdbStub_ARM_CortexM(GdbStub):
         super().__init__(logfile=logfile, elffile=elffile)
         self.registers = None
         self.gdb_signal = self.GDB_SIGNAL_DEFAULT
+        self.callee_saved_offset = None
 
         self.parse_arch_data_block()
 
@@ -58,6 +60,8 @@ class GdbStub_ARM_CortexM(GdbStub):
             tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT, arch_data_blk)
         elif arch_data_ver == 2:
             tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT_V2, arch_data_blk)
+        elif arch_data_ver == 3:
+            tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT_V3, arch_data_blk)
 
         self.registers = dict()
 
@@ -80,6 +84,11 @@ class GdbStub_ARM_CortexM(GdbStub):
             self.registers[RegNum.R9] = tu[14]
             self.registers[RegNum.R10] = tu[15]
             self.registers[RegNum.R11] = tu[16]
+
+        if arch_data_ver > 2:
+            callee_saved_valid = tu[17]
+            if callee_saved_valid:
+                self.callee_saved_offset = tu[18]
 
     def send_registers_packet(self, registers):
         reg_fmt = "<I"
@@ -186,5 +195,21 @@ class GdbStub_ARM_CortexM(GdbStub):
 
                     # Set R7 to match the stack pointer in case the frame pointer is not omitted
                     thread_registers[RegNum.R7] = thread_registers[RegNum.SP]
+
+                # Read callee-saved registers (r4-r11) from _callee_saved struct.
+                if self.callee_saved_offset is not None:
+                    callee_saved_bytes = self.get_memory(
+                        thread_ptr + self.callee_saved_offset, size_t_size * 8
+                    )
+                    if callee_saved_bytes is not None:
+                        callee_regs = struct.unpack("<IIIIIIII", callee_saved_bytes)
+                        thread_registers[RegNum.R4] = callee_regs[0]
+                        thread_registers[RegNum.R5] = callee_regs[1]
+                        thread_registers[RegNum.R6] = callee_regs[2]
+                        thread_registers[RegNum.R7] = callee_regs[3]
+                        thread_registers[RegNum.R8] = callee_regs[4]
+                        thread_registers[RegNum.R9] = callee_regs[5]
+                        thread_registers[RegNum.R10] = callee_regs[6]
+                        thread_registers[RegNum.R11] = callee_regs[7]
 
             self.send_registers_packet(thread_registers)


### PR DESCRIPTION
Extend the ARM Cortex-M coredump arch block to version 3 with metadata that provides the offset to the callee_saved struct within k_thread. This enables the coredump GDB stub to accurately retrieve callee-saved registers (r4-r11) for non-faulting threads during multi-thread debugging.