### PR TITLE
boards: cy8ckit_041s_max: Adds pwm support

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_defconfig
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_defconfig
@@ -10,5 +10,8 @@ CONFIG_UART_CONSOLE=y
 # UART driver
 CONFIG_SERIAL=y
 
+#GPIO driver
+CONFIG_GPIO=y
+
 # Clock controller
 CONFIG_CLOCK_CONTROL=y

--- a/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
@@ -229,7 +229,9 @@
 			tcpwm0_0: tcpwm0_0@40200100 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200100 0x40>;
+				interrupts = <17 3>;
 				resolution = <16>;
+				index = <0>;
 				clk-dst = <0x6>;
 				status = "disabled";
 
@@ -248,7 +250,9 @@
 			tcpwm0_1: tcpwm0_1@40200140 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200140 0x40>;
+				interrupts = <18 3>;
 				resolution = <16>;
+				index = <1>;
 				clk-dst = <0x7>;
 				status = "disabled";
 
@@ -267,7 +271,9 @@
 			tcpwm0_2: tcpwm0_2@40200180 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200180 0x40>;
+				interrupts = <19 3>;
 				resolution = <16>;
+				index = <2>;
 				clk-dst = <0x8>;
 				status = "disabled";
 
@@ -286,7 +292,9 @@
 			tcpwm0_3: tcpwm0_3@402001c0 {
 				compatible = "infineon,tcpwm";
 				reg = <0x402001c0 0x40>;
+				interrupts = <20 3>;
 				resolution = <16>;
+				index = <3>;
 				clk-dst = <0x9>;
 				status = "disabled";
 
@@ -305,7 +313,9 @@
 			tcpwm0_4: tcpwm0_4@40200200 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200200 0x40>;
+				interrupts = <21 3>;
 				resolution = <16>;
+				index = <4>;
 				clk-dst = <0xa>;
 				status = "disabled";
 
@@ -324,7 +334,9 @@
 			tcpwm0_5: tcpwm0_5@40200240 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200240 0x40>;
+				interrupts = <22 3>;
 				resolution = <16>;
+				index = <5>;
 				clk-dst = <0xb>;
 				status = "disabled";
 
@@ -343,7 +355,9 @@
 			tcpwm0_6: tcpwm0_6@40200280 {
 				compatible = "infineon,tcpwm";
 				reg = <0x40200280 0x40>;
+				interrupts = <23 3>;
 				resolution = <16>;
+				index = <6>;
 				clk-dst = <0xc>;
 				status = "disabled";
 
@@ -362,7 +376,9 @@
 			tcpwm0_7: tcpwm0_7@402002c0 {
 				compatible = "infineon,tcpwm";
 				reg = <0x402002c0 0x40>;
+				interrupts = <24 3>;
 				resolution = <16>;
+				index = <7>;
 				clk-dst = <0xd>;
 				status = "disabled";
 

--- a/samples/basic/blinky_pwm/boards/cy8ckit_041s_max.overlay
+++ b/samples/basic/blinky_pwm/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led1;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led1: pwm_led1 {
+			label = "PWM LED1";
+			pwms = <&pwm0_1 0 PWM_MSEC(1U) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&tcpwm0_1 {
+	status = "okay";
+
+	pwm0_1 {
+		clocks = <&peri_clk_div3>;
+		compatible = "infineon,tcpwm-pwm";
+		status = "okay";
+		pinctrl-0 = <&p7_3_pwm0_1>;
+		pinctrl-names = "default";
+	};
+};
+
+&p7_3_pwm0_1 {
+	drive-push-pull;
+};
+
+&peri_clk_div3 {
+	status = "okay";
+	resource-channel = <1>;
+};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	zephyr,user {
+		/* PWM out on P2.0, GPIO in on P2.1.
+		 * These pins must be physically connected for the test to pass.
+		 */
+		pwms = <&pwm0_4 0 PWM_MSEC(2) (PWM_POLARITY_NORMAL | PWM_IFX_TCPWM_OUTPUT_HIGHZ)>;
+		gpios = <&gpio_prt2 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tcpwm0_4 {
+	status = "okay";
+
+	pwm0_4: pwm0_4 {
+		compatible = "infineon,tcpwm-pwm";
+		status = "okay";
+		clocks = <&peri_clk_div3>;
+		pinctrl-0 = <&p2_0_pwm0_4>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri_clk_div3 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <4>;
+	clock-div = <24>;
+};
+
+&pinctrl {
+	p2_0_pwm0_4: p2_0_pwm0_4 {
+		drive-push-pull;
+	};
+};
+
+&gpio_prt2 {
+	status = "okay";
+};


### PR DESCRIPTION
Add support for Infineon PSOC4 cy8ckit_041s_max TCPWM driver update.

Closely related to https://github.com/zephyrproject-rtos/zephyr/pull/104572