### PR TITLE
bluetooth: audio: bap_stream: Fix possible NULL dereference

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1027,7 +1027,7 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 	LOG_DBG("stream %p", stream);
 
 	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
-		LOG_DBG("Invalid stream (ep %p, conn %p)", stream->ep, (void *)stream->conn);
+		LOG_DBG("Invalid stream");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Avoid dereferencing `stream` in the debug log message when checking for invalid input parameters.

The previous log printed `stream->ep` and `stream->conn` inside a combined NULL check, which could trigger static analysis warnings about a possible NULL pointer dereference.

Align the implementation with the existing pattern used in the file by logging a generic "Invalid stream" message instead.

No functional change.