### PR TITLE
dts: bindings: zfm-x0: add Hi-Link HLK sensors

### DIFF
--- a/dts/bindings/biometrics/zhiantec,zfm-x0.yaml
+++ b/dts/bindings/biometrics/zhiantec,zfm-x0.yaml
@@ -5,8 +5,9 @@ description: |
   ZFM-x0 Series Optical Fingerprint Sensor
 
   This binding supports fingerprint sensor modules using the Zhiantec/Synochip
-  ZFM protocol, including ZFM-20, ZFM-60, ZFM-70, R30x, JM-101, DY-50, FPM10A,
-  and other compatible modules.
+  ZFM protocol, including optical sensors like ZFM-20, ZFM-60, ZFM-70, R30x,
+  JM-101, DY-50, FPM10A, capacitive sensors like Hi-Link HLK-ZW3021, HLK-ZW0623,
+  HLK-ZW0642 and other compatible modules.
 
 compatible: "zhiantec,zfm-x0"
 


### PR DESCRIPTION
Update the zhiantec,zfm-x0 binding description to include support for Hi-Link HLK series capacitive fingerprint sensors (HLK-ZW3021, HLK-ZW0623, HLK-ZW0642), which use the compatible ZFM protocol.