### PR TITLE
drivers: display: sdl: move SDL pixel format configuration to devicetree

### DIFF
--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <posix/posix.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
@@ -196,6 +197,7 @@
 
 	sdl_dc: sdl_dc {
 		compatible = "zephyr,sdl-dc";
+		pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
 		height = <240>;
 		width = <320>;
 	};

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -87,6 +87,14 @@ Digital Microphone
   have been updated. Application code using :c:func:`dmic_configure`, :c:func:`dmic_trigger`, and
   :c:func:`dmic_read` is not impacted.
 
+Display
+=======
+
+* The Kconfig options ``CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_*`` for SDL display pixel-format
+  selection have been removed in favour of setting the pixel-format property directly in devicetree
+  on the SDL pseudo-device node using the PANEL_PIXEL_FORMAT_* macros from
+  :zephyr_file:`include/zephyr/dt-bindings/display/panel.h`. (:github:`104099`)
+
 Ethernet
 ========
 

--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -14,55 +14,6 @@ menuconfig SDL_DISPLAY
 
 if SDL_DISPLAY
 
-choice SDL_DISPLAY_DEFAULT_PIXEL_FORMAT
-	prompt "Default pixel format"
-	default SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
-	help
-	  Default pixel format to be used by the display
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
-		bool "ARGB 8888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_XRGB_8888
-		bool "XRGB 8888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888
-		bool "RGB 888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01
-		bool "Mono Black=0"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10
-		bool "Mono Black=1"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565
-		bool "RGB 565"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565X
-		bool "RGB 565X"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8
-		bool "Grayscale 8bit"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88
-		bool "Grayscale 8bit with Alpha"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888
-		bool "BGR 888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888
-		bool "ABGR 8888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888
-		bool "RGBA 8888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888
-		bool "BGRA 8888"
-
-	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_I_4
-		bool "Indexed 4bit"
-endchoice
-
 config SDL_DISPLAY_ZOOM_PCT
 	int "Default zoom percentage"
 	default 100

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -188,38 +188,6 @@ static int sdl_display_init(const struct device *dev)
 
 	LOG_DBG("Initializing display driver");
 
-	disp_data->current_pixel_format =
-#if defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888)
-		PIXEL_FORMAT_RGB_888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01)
-		PIXEL_FORMAT_MONO01
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10)
-		PIXEL_FORMAT_MONO10
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565)
-		PIXEL_FORMAT_RGB_565
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565X)
-		PIXEL_FORMAT_RGB_565X
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8)
-		PIXEL_FORMAT_L_8
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88)
-		PIXEL_FORMAT_AL_88
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_XRGB_8888)
-		PIXEL_FORMAT_XRGB_8888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888)
-		PIXEL_FORMAT_BGR_888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888)
-		PIXEL_FORMAT_ABGR_8888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888)
-		PIXEL_FORMAT_RGBA_8888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888)
-		PIXEL_FORMAT_BGRA_8888
-#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_I_4)
-		PIXEL_FORMAT_I_4
-#else  /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
-		PIXEL_FORMAT_ARGB_8888
-#endif /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
-		;
-
 	k_sem_init(&disp_data->task_sem, 0, 1);
 	k_mutex_init(&disp_data->task_mutex);
 	k_thread_create(&disp_data->sdl_thread, disp_data->sdl_thread_stack,
@@ -1018,7 +986,7 @@ static void sdl_display_read_l8(const uint8_t *read_buf,
 }
 
 static void sdl_display_read_al88(const uint8_t *read_buf,
-				const struct display_buffer_descriptor *desc, void *buf)
+				  const struct display_buffer_descriptor *desc, void *buf)
 {
 	uint8_t *buf8;
 	const uint32_t *pix_ptr;
@@ -1092,7 +1060,7 @@ static void sdl_display_read_i4(const struct device *dev, const uint8_t *read_bu
 #endif /* CONFIG_DISPLAY_COLOR_PALETTE */
 }
 
-	static int sdl_display_read(const struct device *dev, const uint16_t x, const uint16_t y,
+static int sdl_display_read(const struct device *dev, const uint16_t x, const uint16_t y,
 			    const struct display_buffer_descriptor *desc, void *buf)
 {
 	struct sdl_display_data *disp_data = dev->data;
@@ -1289,8 +1257,9 @@ static void sdl_display_get_capabilities(
 		(IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_VTILED) ? SCREEN_INFO_MONO_VTILED : 0) |
 		(IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_MSB_FIRST) ? SCREEN_INFO_MONO_MSB_FIRST : 0);
 }
-	static int sdl_display_set_pixel_format(const struct device *dev,
-		const enum display_pixel_format pixel_format)
+
+static int sdl_display_set_pixel_format(const struct device *dev,
+					const enum display_pixel_format pixel_format)
 {
 	struct sdl_display_data *disp_data = dev->data;
 
@@ -1382,6 +1351,7 @@ static DEVICE_API(display, sdl_display_api) = {
 	static uint8_t sdl_read_buf_##n[4 * DT_INST_PROP(n, height) * DT_INST_PROP(n, width)];     \
 	K_MSGQ_DEFINE(sdl_task_msgq_##n, sizeof(struct sdl_display_task), 1, 4);                   \
 	static struct sdl_display_data sdl_data_##n = {                                            \
+		.current_pixel_format = DT_INST_PROP(n, pixel_format),                             \
 		.buf = sdl_buf_##n,                                                                \
 		.read_buf = sdl_read_buf_##n,                                                      \
 		.task_msgq = &sdl_task_msgq_##n,                                                   \

--- a/dts/bindings/display/zephyr,sdl-dc.yaml
+++ b/dts/bindings/display/zephyr,sdl-dc.yaml
@@ -13,3 +13,34 @@ properties:
     type: string
     description: |
       Name of graphical window
+
+  pixel-format:
+    type: int
+    required: true
+    description: |
+      Initial Pixel format of this controller's output data.
+    enum:
+      - 1 # PANEL_PIXEL_FORMAT_RGB_888
+      - 2 # PANEL_PIXEL_FORMAT_MONO01
+      - 4 # PANEL_PIXEL_FORMAT_MONO10
+      - 8 # PANEL_PIXEL_FORMAT_ARGB_8888
+      - 16 # PANEL_PIXEL_FORMAT_RGB_565
+      - 32 # PANEL_PIXEL_FORMAT_RGB_565X
+      - 64 # PANEL_PIXEL_FORMAT_L_8
+      - 128 # PANEL_PIXEL_FORMAT_AL_88
+      - 256 # PANEL_PIXEL_FORMAT_XRGB_8888
+      - 512 # PANEL_PIXEL_FORMAT_BGR_888
+      - 1024 # PANEL_PIXEL_FORMAT_ABGR_8888
+      - 2048 # PANEL_PIXEL_FORMAT_RGBA_8888
+      - 4096 # PANEL_PIXEL_FORMAT_BGRA_8888
+      - 8192 # PANEL_PIXEL_FORMAT_I_4
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/display/panel.h>
+
+    sdl_dc: sdl_dc {
+      /* ... */
+
+      pixel-format = <PANEL_PIXEL_FORMAT_ABGR_8888>;
+    };

--- a/samples/modules/lvgl/multi_display/boards/native_sim_64.overlay
+++ b/samples/modules/lvgl/multi_display/boards/native_sim_64.overlay
@@ -33,6 +33,7 @@
 	sdl_dc2: sdl-dc2 {
 		compatible = "zephyr,sdl-dc";
 		title = "Zephyr Display 2";
+		pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
 		width = <800>;
 		height = <600>;
 		status = "okay";

--- a/samples/subsys/display/color_palette/boards/native_sim.conf
+++ b/samples/subsys/display/color_palette/boards/native_sim.conf
@@ -1,6 +1,5 @@
 # Copyright (c) 2026 Fabian Blatz <fabianblatz@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_I_4=y
 CONFIG_DISPLAY_COLOR_PALETTE=y
 CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE=16

--- a/samples/subsys/display/color_palette/boards/native_sim.overlay
+++ b/samples/subsys/display/color_palette/boards/native_sim.overlay
@@ -7,6 +7,7 @@
 #include <zephyr/dt-bindings/display/panel.h>
 
 &sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_I_4>;
 	width = <320>;
 	height = <240>;
 

--- a/samples/subsys/display/color_palette/boards/native_sim_64.conf
+++ b/samples/subsys/display/color_palette/boards/native_sim_64.conf
@@ -1,6 +1,5 @@
 # Copyright (c) 2026 Fabian Blatz <fabianblatz@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_I_4=y
 CONFIG_DISPLAY_COLOR_PALETTE=y
 CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE=16

--- a/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
+++ b/tests/cmake/hwm/board_extend/oot_root/boards/native/native_sim_extend/native_sim_native_one.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <posix/posix.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
@@ -179,6 +180,7 @@
 
 	sdl_dc: sdl_dc {
 		compatible = "zephyr,sdl-dc";
+		pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
 		height = <240>;
 		width = <320>;
 	};

--- a/tests/drivers/display/display_read_write/native_sim_abgr_8888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_abgr_8888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_ABGR_8888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_al_88.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_al_88.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_AL_88>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_argb_8888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_argb_8888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_bgr_888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_bgr_888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_BGR_888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_bgra_8888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_bgra_8888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_BGRA_8888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_mono01.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_mono01.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_MONO01>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_mono10.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_mono10.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_MONO10>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_rgb_565.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_rgb_565.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_rgb_565x.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_rgb_565x.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565X>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_rgb_888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_rgb_888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_rgba_8888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_rgba_8888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_RGBA_8888>;
+};

--- a/tests/drivers/display/display_read_write/native_sim_xrgb_8888.overlay
+++ b/tests/drivers/display/display_read_write/native_sim_xrgb_8888.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_XRGB_8888>;
+};

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -14,118 +14,124 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_argb_8888.overlay
   drivers.display.read_write.sdl.xrgb8888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_XRGB_8888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_xrgb_8888.overlay
   drivers.display.read_write.sdl.al88:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_al_88.overlay
   drivers.display.read_write.sdl.rgb888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_rgb_888.overlay
   drivers.display.read_write.sdl.mono01.vtiled.msbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
   drivers.display.read_write.sdl.mono10.vtiled.msbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
   drivers.display.read_write.sdl.mono01.htiled.msbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
   drivers.display.read_write.sdl.mono10.htiled.msbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
   drivers.display.read_write.sdl.mono01.vtiled.lsbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.mono10.vtiled.lsbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.mono01.htiled.lsbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.mono10.htiled.lsbfirst:
     platform_allow:
       - native_sim
       - native_sim/native/64
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.rgb565:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_rgb_565.overlay
   drivers.display.read_write.sdl.rgb565x:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565X=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_rgb_565x.overlay
   drivers.display.read_write.sdl.bgr888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_bgr_888.overlay
   drivers.display.read_write.sdl.abgr8888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ABGR_8888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_abgr_8888.overlay
   drivers.display.read_write.sdl.rgba8888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGBA_8888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_rgba_8888.overlay
   drivers.display.read_write.sdl.bgra8888:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGRA_8888=y
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_bgra_8888.overlay
   drivers.display.read_write.ili9340:
     tags:
       - shield

--- a/tests/subsys/display/cfb/basic/native_sim_mono01.overlay
+++ b/tests/subsys/display/cfb/basic/native_sim_mono01.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_MONO01>;
+};

--- a/tests/subsys/display/cfb/basic/native_sim_mono10.overlay
+++ b/tests/subsys/display/cfb/basic/native_sim_mono10.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_MONO10>;
+};

--- a/tests/subsys/display/cfb/basic/testcase.yaml
+++ b/tests/subsys/display/cfb/basic/testcase.yaml
@@ -14,50 +14,58 @@ common:
     - native_sim/native/64
 tests:
   display.cfb.basic.mono01.vtiled.msbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=y
   display.cfb.basic.mono01.vtiled.lsbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   display.cfb.basic.mono01.htiled.msbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=y
   display.cfb.basic.mono01.htiled.lsbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono01.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   display.cfb.basic.mono10.vtiled.msbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=y
   display.cfb.basic.mono10.vtiled.lsbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   display.cfb.basic.mono10.htiled.msbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=y
   display.cfb.basic.mono10.htiled.lsbfirst:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n

--- a/tests/subsys/display/cfb/fonts/native_sim_mono10.overlay
+++ b/tests/subsys/display/cfb/fonts/native_sim_mono10.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/display/panel.h>
+
+&sdl_dc {
+	pixel-format = <PANEL_PIXEL_FORMAT_MONO10>;
+};

--- a/tests/subsys/display/cfb/fonts/testcase.yaml
+++ b/tests/subsys/display/cfb/fonts/testcase.yaml
@@ -14,26 +14,30 @@ common:
     - native_sim/native/64
 tests:
   display.cfb.fonts.vtiled.msbfirst_font:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_TEST_MSB_FIRST_FONT=y
   display.cfb.fonts.vtiled.lsbfirst_font:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_VTILED=y
       - CONFIG_TEST_MSB_FIRST_FONT=n
   display.cfb.fonts.htiled.msbfirst_font:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_TEST_MSB_FIRST_FONT=y
   display.cfb.fonts.htiled.lsbfirst_font:
+    extra_args:
+      - DTC_OVERLAY_FILE=native_sim_mono10.overlay
     extra_configs:
-      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
       - CONFIG_SDL_DISPLAY_MONO_VTILED=n
       - CONFIG_TEST_MSB_FIRST_FONT=n


### PR DESCRIPTION
Replace the SDL display driver's default pixel format Kconfig selection with a devicetree property and initialize the display using the DT-provided format.

## Testing
Tested with `samples/subsys/display/lvgl/`

<img width="320" height="280" alt="image" src="https://github.com/user-attachments/assets/71f39ba2-cb14-4d8e-9e6e-5096d76c1525" />
