### PR TITLE
drivers: clock_control: nrf: K32SRC_RC_CALIBRATION depend on HFXO

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -66,6 +66,7 @@ endchoice
 config CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 	bool "LF clock calibration"
 	depends on !SOC_SERIES_NRF91 && CLOCK_CONTROL_NRF_K32SRC_RC
+	depends on $(dt_nodelabel_enabled,hfxo)
 	default y if !SOC_NRF53_CPUNET_ENABLE
 	select NRFX_CLOCK_LF_CAL_ENABLED if !CLOCK_CONTROL_NRF_FORCE_ALT
 	help


### PR DESCRIPTION
The CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION calibration feature uses HFCLK (hfxo in devicetree) as reference to calibrate the internal RC. If the hfxo is not present, calibration is not possible, and if the driver attempts to do it anyway, HFCLK will be requested wasting power, and the calibration will never complete.