### PR TITLE
drivers: usb: udc: max32: Fix MAX32 udc event handling

### DIFF
--- a/drivers/usb/udc/udc_max32.c
+++ b/drivers/usb/udc/udc_max32.c
@@ -566,8 +566,11 @@ static int udc_max32_event_callback(maxusb_event_t event, void *cbdata)
 		break;
 	case MAXUSB_EVENT_DPACT:
 		LOG_DBG("DPACT event occurred");
-		udc_set_suspended(dev, false);
-		udc_submit_sof_event(dev);
+		/* Only submit resume if device is suspended */
+		if (udc_is_suspended(dev)) {
+			udc_set_suspended(dev, false);
+			udc_submit_event(dev, UDC_EVT_RESUME, 0);
+		}
 		break;
 	case MAXUSB_EVENT_BRST:
 		LOG_DBG("BRST event occurred");

--- a/drivers/usb/udc/udc_max32.c
+++ b/drivers/usb/udc/udc_max32.c
@@ -233,6 +233,11 @@ static void udc_event_xfer_in_done(const struct device *dev, struct udc_ep_confi
 	} else {
 		udc_submit_ep_event(dev, buf, 0);
 	}
+
+	/* Start the next transfer if there is another waiting */
+	if (ep_cfg->addr != USB_CONTROL_EP_IN && udc_buf_peek(ep_cfg) != NULL) {
+		udc_event_xfer_in(dev, ep_cfg);
+	}
 }
 
 static void udc_event_xfer_out_done(const struct device *dev, struct udc_ep_config *ep_cfg)
@@ -259,6 +264,11 @@ static void udc_event_xfer_out_done(const struct device *dev, struct udc_ep_conf
 		udc_ctrl_submit_s_out_status(dev, buf);
 	} else {
 		udc_submit_ep_event(dev, buf, 0);
+	}
+
+	/* Start the next transfer if there is another waiting */
+	if (ep_cfg->addr != USB_CONTROL_EP_OUT && udc_buf_peek(ep_cfg) != NULL) {
+		udc_event_xfer_out(dev, ep_cfg);
 	}
 }
 


### PR DESCRIPTION
MAX32 USB had some functions in ISR context allocating memory & acquiring mutexes. This PR fixes this by separating the transfer completion events into ISR-context and thread-context steps using the message queue. Additionally, some apparent swapping of devicetree configuration for in/out endpoints and configuration structs is resolved. Finally, handling of deferred endpoint transfers was added. 

Commit 1:
- Rename UDC_MAX32_EVT_XFER to UDC_MAX32_EVT_START_XFER
- Add MAX32 UDC events for XFER_IN_DONE and XFER_OUT_DONE
- Refactor xfer_in/out callbacks to only submit messages to a message queue
- Provide xfer_in_Done and xfer_out_done to handle transfer completions from UDC thread context.
- Add XFER_IN_DONE and XFER_OUT_DONE events to thread handler
- Fix swapping in devicetree macros of num_of_in_eps / num_of_out_eps and ep_cfg_in / ep_cfg_out

Commit 2: 
- Add guard to only submit resume events when the device was suspended

Commit 3:
- Move xfer_in_done / xfer_out_done to be defined before xfer_in and xfer_out to avoid compiler errors in the next commit

Commit 4:
- Check queue for remaining transfers on transfer completion of a busy endpoint

## Functional Tests

Tested the `cdc_acm` sample and the `mass` sample with the FAT filesystem successfully. 

## Twister Tests

```bash
❯ ./scripts/twister -p apard32690/max32690/m4 -b \
  -T samples/subsys/usb/ \
  -T tests/drivers/udc/
ZEPHYR_BASE unset, using "/home/bjh/workspace/z/zephyr-main/zephyr"
Renaming previous output directory to /home/bjh/workspace/z/zephyr-main/zephyr/twister-out.1
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-6204-g5fb7cb3094d0
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.02 seconds
INFO    - Writing JSON report /home/bjh/workspace/z/zephyr-main/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   20/  20  100%  built (not run):   17, filtered:   28, failed:    0, error:    0
INFO    - 45 test scenarios (45 configurations) selected, 28 configurations filtered (25 by static filter, 3 at runtime).
INFO    - 0 of 17 executed test configurations passed (0.00%), 17 built (not run), 0 failed, 0 errored, with no warnings in 169.26 seconds.
INFO    - 0 test configurations executed on platforms, 17 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/bjh/workspace/z/zephyr-main/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/bjh/workspace/z/zephyr-main/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/bjh/workspace/z/zephyr-main/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```