### PR TITLE
net: wifi: shell: Convert the code to use SHELL_HELP macro

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -921,6 +921,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					strlen(params->server_cert_domain_suffix);
 			break;
 		case 'h':
+			shell_help(sh);
 			return -ENOEXEC;
 		default:
 			PR_ERROR("Invalid option %c\n", state->optopt);
@@ -4333,87 +4334,115 @@ static int cmd_wifi_config_params(const struct shell *sh, size_t argc, char *arg
 	return 0;
 }
 
+SHELL_SUBCMD_ADD((wifi), 11k, NULL,
+		 SHELL_HELP("Configure 11k or get 11k status",
+			    "[-i, --iface=<interface index>]\n"
+			    "[enable/disable]"),
+		 cmd_wifi_11k,
+		 1, 3);
+
+SHELL_SUBCMD_ADD((wifi), 11k_neighbor_request, NULL,
+		 SHELL_HELP("Send Neighbor Report Request frame",
+			    "[-i, --iface=<interface index>]\n"
+			    "[ssid <ssid>]"),
+		 cmd_wifi_11k_neighbor_request,
+		 1, 4);
+
+SHELL_SUBCMD_ADD((wifi), 11v_btm_query, NULL,
+		 SHELL_HELP("Setting BTM query reason",
+			    "[-i, --iface=<interface index>]\n"
+			    "<reason code for BSS transition management query>"),
+		 cmd_wifi_btm_query,
+		 2, 2);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	wifi_cmd_ap,
-	SHELL_CMD_ARG(disable, NULL, "Disable Access Point mode.\n"
-		"[-i, --iface=<interface index>] : Interface index.\n",
+	SHELL_CMD_ARG(disable, NULL,
+		      SHELL_HELP("Disable Access Point mode",
+				 "[-i, --iface=<interface index>]"),
 		cmd_wifi_ap_disable, 1, 2),
 	SHELL_CMD_ARG(enable, NULL,
-		      "-s --ssid=<SSID>\n"
-		      "-c --channel=<channel number>\n"
-		      "-p --passphrase=<PSK> (valid only for secure SSIDs)\n"
-		      "-k --key-mgmt=<Security type> (valid only for secure SSIDs)\n"
-		      "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
-		      "7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP\n"
-		      "12: EAP-PEAP-MSCHAPv2, 13: EAP-PEAP-GTC, 14: EAP-TTLS-MSCHAPv2,\n"
-		      "15: EAP-PEAP-TLS, 20: SAE-EXT-KEY\n"
-		      "-w --ieee-80211w=<MFP> (optional: needs security type to be specified)\n"
-		      "0:Disable, 1:Optional, 2:Required\n"
-		      "-b --band=<band> (2 -2.6GHz, 5 - 5Ghz, 6 - 6GHz)\n"
-		      "-m --bssid=<BSSID>\n"
-		      "-g --ignore-broadcast-ssid=<type>. Hide SSID in AP mode.\n"
-		      "0: disabled (default)\n"
-		      "1: send empty (length=0) SSID in beacon and ignore probe request for "
-		      "broadcast SSID.\n"
-		      "2: clear SSID (ASCII 0), but keep the original length and ignore "
-		      "probe requests for broadcast SSID.\n"
-		      "[-B, --bandwidth=<bandwidth>]: 1:20MHz, 2:40MHz, 3:80MHz\n"
-		      "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
-		      "Private key passwd for enterprise mode. Default no password for private key.\n"
-		      "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
-		      "Default 0: Not WPA3 enterprise mode.\n"
-		      "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode.\n"
-		      "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
-		      "[-I, --eap-id1...--eap-id8]: Client Identity. Default no eap identity.\n"
-		      "[-P, --eap-pwd1...--eap-pwd8]: Client Password.\n"
-		      "Default no password for eap user.\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n"
-		      "-h --help (prints help)",
+		      SHELL_HELP("Enable Access Point mode",
+				 "[-i, --iface=<interface index>]\n"
+				 "-s --ssid=<SSID>\n"
+				 "-c --channel=<channel number>\n"
+				 "-p --passphrase=<PSK> (valid only for secure SSIDs)\n"
+				 "-k --key-mgmt=<Security type> (valid only for secure SSIDs)\n"
+				 "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, "
+				 "5:SAE-AUTO, 6:WAPI, 7:EAP-TLS, 8:WEP, 9: WPA-PSK, "
+				 "10:WPA-Auto-Personal, 11:DPP 12:EAP-PEAP-MSCHAPv2, "
+				 "13:EAP-PEAP-GTC, 14:EAP-TTLS-MSCHAPv2, 15:EAP-PEAP-TLS, "
+				 "20:SAE-EXT-KEY\n"
+				 "-w --ieee-80211w=<MFP> (optional: needs security type to "
+				 "be specified)\n"
+				 "0:Disable, 1:Optional, 2:Required\n"
+				 "-b --band=<band> (2 -2.6GHz, 5 - 5Ghz, 6 - 6GHz)\n"
+				 "-m --bssid=<BSSID>\n"
+				 "-g --ignore-broadcast-ssid=<type>. Hide SSID in AP mode.\n"
+				 "0: disabled (default)\n"
+				 "1: send empty (length=0) SSID in beacon and ignore probe "
+				 "request for broadcast SSID\n"
+				 "2: clear SSID (ASCII 0), but keep the original length "
+				 "and ignore probe requests for broadcast SSID\n"
+				 "[-B, --bandwidth=<bandwidth>]: 1:20MHz, 2:40MHz, 3:80MHz\n"
+				 "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
+				 "Private key passwd for enterprise mode. Default is no password "
+				 "for private key\n"
+				 "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
+				 "Default is 0: Not WPA3 enterprise mode\n"
+				 "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode\n"
+				 "[-V, --eap-version]: 0 or 1. Default 1: eap version 1\n"
+				 "[-I, --eap-id1...--eap-id8]: Client Identity. Default no eap identity\n"
+				 "[-P, --eap-pwd1...--eap-pwd8]: Client Password\n"
+				 "Default no password for eap user"),
 		      cmd_wifi_ap_enable, 2, 47),
-	SHELL_CMD_ARG(stations, NULL, "List stations connected to the AP\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+	SHELL_CMD_ARG(stations, NULL,
+		      SHELL_HELP("List stations connected to the AP",
+				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_ap_stations, 1, 2),
 	SHELL_CMD_ARG(disconnect, NULL,
-		      "Disconnect a station from the AP\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n"
-		      "<MAC address of the station>\n",
+		      SHELL_HELP("Disconnect a station from the AP",
+				 "[-i, --iface=<interface index>]\n"
+				 "<MAC address of the station>"),
 		      cmd_wifi_ap_sta_disconnect, 2, 3),
 	SHELL_CMD_ARG(config, NULL,
-		      "Configure AP parameters.\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n"
-		      "-t --max_inactivity=<time duration (in seconds)>\n"
-		      "-s --max_num_sta=<maximum number of stations>\n"
+		      SHELL_HELP("Configure AP parameters",
+				 "[-i, --iface=<interface index>]\n"
+				 "-t --max_inactivity=<time duration (in seconds)>\n"
+				 "-s --max_num_sta=<maximum number of stations>"
 #if defined(CONFIG_WIFI_NM_HOSTAPD_AP)
-		      "Please refer to hostapd.conf to set the following options,\n"
+		      "\nPlease refer to hostapd.conf to set the following options,\n"
 		      "============ IEEE 802.11 related configuration ============\n"
 		      "-n --ht_capab=<HT capabilities (string)>\n"
 		      "(e.g. \"ht_capab=[HT40+]\" is that \"-n [HT40+]\")\n"
 		      "-c --vht_capab=<VHT capabilities (string)>\n"
 		      "(e.g. \"vht_capab=[SU-BEAMFORMEE][BF-ANTENNA-4]\" is that\n"
 		      "\"-c [SU-BEAMFORMEE][BF-ANTENNA-4]\")\n"
-		      "===========================================================\n"
+		      "==========================================================="
 #endif
-		      "-h --help (prints help)",
+		      ),
 		      cmd_wifi_ap_config_params, 3, 12),
 	SHELL_CMD_ARG(wps_pbc, NULL,
-		      "Start AP WPS PBC session.\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Start AP WPS PBC session",
+				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_ap_wps_pbc, 1, 2),
 	SHELL_CMD_ARG(wps_pin, NULL,
-		      "Get or Set AP WPS PIN.\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n"
-		      "[pin] Only applicable for set.\n",
+		      SHELL_HELP("Get or Set AP WPS PIN",
+				 "[-i, --iface=<interface index>]\n"
+				 "[pin] Only applicable for set"),
 		      cmd_wifi_ap_wps_pin, 1, 3),
-	SHELL_CMD_ARG(status, NULL, "Status of Wi-Fi SAP\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+	SHELL_CMD_ARG(status, NULL,
+		      SHELL_HELP("Status of Wi-Fi SAP",
+				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_ap_status, 1, 2),
 	SHELL_CMD_ARG(rts_threshold,
-		  NULL,
-		  "<rts_threshold: rts threshold/off>.\n"
-		  "[-i, --iface=<interface index>] : Interface index.\n",
-		  cmd_wifi_ap_set_rts_threshold,
-		  2,
-		  2),
+		      NULL,
+		      SHELL_HELP("Set RTS value or turn it off",
+				 "[-i, --iface=<interface index>]\n"
+				 "<rts_threshold value> | off"),
+		      cmd_wifi_ap_set_rts_threshold,
+		      2,
+		      2),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_SUBCMD_ADD((wifi), ap, &wifi_cmd_ap,
@@ -4421,147 +4450,191 @@ SHELL_SUBCMD_ADD((wifi), ap, &wifi_cmd_ap,
 		 NULL,
 		 0, 0);
 
-SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
-	SHELL_CMD_ARG(quick_setup, NULL, " Start a TWT flow with defaults:\n"
-		"<twt_wake_interval: 1-262144us> <twt_interval: 1us-2^31us>.\n"
-		"[-i, --iface=<interface index>] : Interface index.\n",
-		cmd_wifi_twt_setup_quick,
-		3, 2),
-	SHELL_CMD_ARG(setup, NULL, " Start a TWT flow:\n"
-		"<-n --negotiation-type>: 0: Individual, 1: Broadcast, 2: Wake TBTT\n"
-		"<-c --setup-cmd>: 0: Request, 1: Suggest, 2: Demand\n"
-		"<-t --dialog-token>: 1-255\n"
-		"<-f --flow-id>: 0-7\n"
-		"<-r --responder>: 0/1\n"
-		"<-T --trigger>: 0/1\n"
-		"<-I --implicit>:0/1\n"
-		"<-a --announce>: 0/1\n"
-		"<-w --wake-interval>: 1-262144us\n"
-		"<-p --interval>: 1us-2^31us\n"
-		"<-D --wake-ahead-duration>: 0us-2^31us\n"
-		"<-d --info-disable>: 0/1\n"
-		"<-e --exponent>: 0-31\n"
-		"<-m --mantissa>: 1-2^16\n"
-		"[-i, --iface=<interface index>] : Interface index.\n"
-		"[-h, --help]: Print out command usage.\n",
-		cmd_wifi_twt_setup,
-		25, 7),
-	SHELL_CMD_ARG(
-		btwt_setup, NULL,
-		" Start a BTWT flow:\n"
-		"<sta_wait> <offset> <twtli> <session_num>: 2-5\n"
-		"<id0> <mantissa0> <exponent0> <nominal_wake0>: 64-255\n"
-		"<id1> <mantissa1> <exponent1> <nominal_wake1>: 64-255\n"
-		"<idx> <mantissax> <exponentx> <nominal_wakex>: 64-255\n"
-		" The total number of '0, 1, ..., x' is session_num\n"
-		"[-i, --iface=<interface index>] : Interface index.\n",
-		cmd_wifi_btwt_setup,
-		13, 12),
-	SHELL_CMD_ARG(teardown, NULL, " Teardown a TWT flow:\n"
-		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
-		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
-		"<dialog_token: 1-255> <flow_id: 0-7>.\n",
-		cmd_wifi_twt_teardown,
-		5, 0),
-	SHELL_CMD_ARG(teardown_all, NULL, " Teardown all TWT flows.\n",
-		cmd_wifi_twt_teardown_all,
-		1, 0),
-	SHELL_SUBCMD_SET_END
-);
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN
+SHELL_SUBCMD_ADD((wifi), bgscan, NULL,
+		 SHELL_HELP("Configure background scanning",
+			    "[-i, --iface=<interface index>]\n"
+			    "<-t, --type simple/learn/none> : The scanning type, "
+			    "use none to disable\n"
+			    "[-s, --short-interval <val>] : Short scan interval (default: 30)\n"
+			    "[-l, --long-interval <val>] : Long scan interval (default: 300)\n"
+			    "[-r, --rssi-threshold <val>] : Signal strength threshold "
+			    "(default: disabled)\n"
+			    "[-b, --btm-queries <val>] : BTM queries before scanning "
+			    "(default: disabled)"),
+		 cmd_wifi_set_bgscan,
+		 2, 6);
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN */
 
-SHELL_SUBCMD_ADD((wifi), twt, &wifi_twt_ops,
-		 "Manage TWT flows.",
-		 NULL,
-		 0, 0);
+SHELL_SUBCMD_ADD((wifi), bss_max_idle_period, NULL,
+		 SHELL_HELP("Set BSS max idle period preference timeout",
+			    "[-i, --iface=<interface index>]\n"
+			    "<timeout(in seconds)>"),
+		 cmd_wifi_set_bss_max_idle_period,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), channel, NULL,
+		 SHELL_HELP("Wifi channel setting",
+			    "This command is used to set the channel when\n"
+			    "monitor or TX-Injection mode is enabled\n"
+			    "Currently 20 MHz is only supported and no BW parameter is provided\n"
+			    "[-i, --iface=<interface index>]\n"
+			    "[-c, --channel <chan>] : Set a specific channel number "
+			    "to the lower layer\n"
+			    "[-g, --get] : Get current set channel number from the lower layer\n"
+			    "Examples:\n"
+			    "Get operation example for interface index 1\n"
+			    "wifi channel -g -i1\n"
+			    "Set operation example for interface index 1 (setting channel 5)\n"
+			    "wifi -i1 -c5"),
+		 cmd_wifi_channel,
+		 2, 6);
+
+SHELL_SUBCMD_ADD((wifi), config, NULL,
+		 SHELL_HELP("Configure STA parameters",
+			    "[-i, --iface=<interface index>]\n"
+			    "-o, --okc=<0/1>: Opportunistic Key Caching. 0: disable, 1: enable"),
+		 cmd_wifi_config_params,
+		 3, 12);
+
+SHELL_SUBCMD_ADD((wifi), connect, NULL,
+		 SHELL_HELP("Connect to a Wi-Fi AP",
+			    "[-i, --iface=<interface index>]\n"
+			    "<-s --ssid \"<SSID>\">: SSID to connect\n"
+			    "[-c --channel]: Channel that needs to be scanned for connection. "
+			    "Value 0 indicates any channel\n"
+			    "[-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz]\n"
+			    "[-p, --passphrase]: Passphrase (valid only for secure SSIDs)\n"
+			    "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
+			    "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, "
+			    "5:SAE-AUTO, 6:WAPI, "
+			    "7:EAP-TLS, 8:WEP, 9:WPA-PSK, 10:WPA-Auto-Personal, 11:DPP, "
+			    "12:EAP-PEAP-MSCHAPv2, 13:EAP-PEAP-GTC, 14:EAP-TTLS-MSCHAPv2, "
+			    "15:EAP-PEAP-TLS, 20:SAE-EXT-KEY\n"
+			    "[-w, --ieee-80211w]: MFP (optional: needs security type to be "
+			    "specified): 0:Disable, 1:Optional, 2:Required\n"
+			    "[-m, --bssid]: MAC address of the AP (BSSID)\n"
+			    "[-t, --timeout]: Timeout for the connection attempt (in seconds)\n"
+			    "[-a, --anon-id]: Anonymous identity for enterprise mode\n"
+			    "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
+			    "Private key passwd for enterprise mode. Default is no password "
+			    "for private key\n"
+			    "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
+			    "Default is 0. 0:No WPA3 enterprise mode, "
+			    "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode\n"
+			    "[-T, --TLS-cipher]: 0:TLS-NONE, 1:TLS-ECC-P384, 2:TLS-RSA-3K\n"
+			    "[-A, --verify-peer-cert]: apply for EAP-PEAP-MSCHAPv2 and "
+			    "EAP-TTLS-MSCHAPv2\n"
+			    "Default is 0. 0:do not use CA to verify peer, "
+			    "1:use CA to verify peer\n"
+			    "[-V, --eap-version]: 0 or 1. Default is 1: use eap version 1\n"
+			    "[-I, --eap-id1]: Client Identity. Default is no eap identity\n"
+			    "[-P, --eap-pwd1]: Client Password. "
+			    "Default is no password for eap user\n"
+			    "[-R, --ieee-80211r]: Use IEEE80211R fast BSS transition connect\n"
+			    "[-e, --server-cert-domain-exact]: Full domain names for "
+			    "server certificate match\n"
+			    "[-x, --server-cert-domain-suffix]: Domain name suffixes for "
+			    "server certificate match"),
+		 cmd_wifi_connect,
+		 2, 46);
+
+SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
+		 SHELL_HELP("Disconnect from the Wi-Fi AP",
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_disconnect,
+		 1, 2);
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	wifi_cmd_dpp,
 	SHELL_CMD_ARG(configurator_add, NULL,
-		      " Add DPP configurator\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Add DPP configurator",
+				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_dpp_configurator_add, 1, 2),
 	SHELL_CMD_ARG(auth_init, NULL,
-		      "DPP start auth request:\n"
-		      "-p --peer <peer_bootstrap_id>\n"
-		      "[-r --role <1/2>]: DPP role default 1. 1: configurator, 2: enrollee\n"
-		      "Optional args for configurator:\n"
-		      "[-c --configurator <configurator_id>]\n"
-		      "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
-		      "[-s --ssid <SSID>]: SSID\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("DPP start auth request",
+				 "[-i, --iface=<interface index>]\n"
+				 "-p --peer <peer_bootstrap_id>\n"
+				 "[-r --role <1/2>]: DPP role default 1: "
+				 "1: configurator, 2: enrollee\n"
+				 "[-c --configurator <configurator_id>]\n"
+				 "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
+				 "[-s --ssid <SSID>]: SSID"),
 		      cmd_wifi_dpp_auth_init, 3, 10),
 	SHELL_CMD_ARG(qr_code, NULL,
-		      " Input QR code:\n"
-		      "<qr_code_string>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Input QR code",
+				 "[-i, --iface=<interface index>]\n"
+				 "<qr_code_string>"),
 		      cmd_wifi_dpp_qr_code, 2, 2),
 	SHELL_CMD_ARG(chirp, NULL,
-		      " DPP chirp:\n"
-		      "-o --own <own_bootstrap_id>\n"
-		      "-f --freq <listen_freq>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("DPP chirp",
+				 "[-i, --iface=<interface index>]\n"
+				 "-o --own <own_bootstrap_id>\n"
+				 "-f --freq <listen_freq>"),
 		      cmd_wifi_dpp_chirp, 5, 2),
 	SHELL_CMD_ARG(listen, NULL,
-		      " DPP listen:\n"
-		      "-f --freq <listen_freq>\n"
-		      "-r --role <1/2>: DPP role. 1: configurator, 2: enrollee\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("DPP listen",
+				 "[-i, --iface=<interface index>]\n"
+				 "-f --freq <listen_freq>\n"
+				 "-r --role <1/2>: DPP role. 1: configurator, 2: enrollee"),
 		      cmd_wifi_dpp_listen, 5, 2),
 	SHELL_CMD_ARG(btstrap_gen, NULL,
-		      " DPP bootstrap generate:\n"
-		      "[-t --type <1/2/3>]: Bootstrap type. 1: qr_code, 2: pkex, 3: nfc."
-		      " Currently only support qr_code\n"
-		      "[-o --opclass <operating_class>]\n"
-		      "[-h --channel <channel>]\n"
-		      "[-a --mac <mac_addr>]\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("DPP bootstrap generate",
+				 "[-i, --iface=<interface index>]\n"
+				 "[-t --type <1/2/3>]\n"
+				 "Bootstrap type. 1: qr_code, 2: pkex, 3: nfc\n"
+				 "Currently only support qr_code\n"
+				 "[-o --opclass <operating_class>]\n"
+				 "[-h --channel <channel>]\n"
+				 "[-a --mac <mac_addr>]"),
 		      cmd_wifi_dpp_btstrap_gen, 1, 10),
 	SHELL_CMD_ARG(btstrap_get_uri, NULL,
-		      " Get DPP bootstrap uri by id:\n"
-		      "<bootstrap_id>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Get DPP bootstrap uri by id",
+				 "[-i, --iface=<interface index>]\n"
+				 "<bootstrap_id>"),
 		      cmd_wifi_dpp_btstrap_get_uri, 2, 2),
 	SHELL_CMD_ARG(configurator_set, NULL,
-		      " Set DPP configurator parameters:\n"
-		      "-c --configurator <configurator_id>\n"
-		      "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
-		      "[-s --ssid <SSID>]: SSID\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Set DPP configurator parameters",
+				 "[-i, --iface=<interface index>]\n"
+				 "-c --configurator <configurator_id>\n"
+				 "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
+				 "[-s --ssid <SSID>]: SSID"),
 		      cmd_wifi_dpp_configurator_set, 3, 6),
 	SHELL_CMD_ARG(resp_timeout_set, NULL,
-		      " Set DPP RX response wait timeout ms:\n"
-		      "<timeout_ms>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Set DPP RX response wait timeout ms",
+				 "[-i, --iface=<interface index>]\n"
+				 "<timeout_ms>"),
 		      cmd_wifi_dpp_resp_timeout_set, 2, 2),
 	SHELL_CMD_ARG(ap_btstrap_gen, NULL,
-		      " AP DPP bootstrap generate:\n"
-		      "[-t --type <1/2/3>]: Bootstrap type. 1: qr_code, 2: pkex, 3: nfc."
-		      " Currently only support qr_code\n"
-		      "[-o --opclass <operating_class>]\n"
-		      "[-h --channel <channel>]\n"
-		      "[-a --mac <mac_addr>]\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("AP DPP bootstrap generate",
+				 "[-i, --iface=<interface index>]\n"
+				 "[-t --type <1/2/3>]\n"
+				 "Bootstrap type. 1: qr_code, 2: pkex, 3: nfc\n"
+				 "Currently only support qr_code\n"
+				 "[-o --opclass <operating_class>]\n"
+				 "[-h --channel <channel>]\n"
+				 "[-a --mac <mac_addr>]"),
 		      cmd_wifi_dpp_ap_btstrap_gen, 1, 10),
 	SHELL_CMD_ARG(ap_btstrap_get_uri, NULL,
-		      " AP get DPP bootstrap uri by id:\n"
-		      "<bootstrap_id>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("AP get DPP bootstrap uri by id",
+				 "[-i, --iface=<interface index>]\n"
+				 "<bootstrap_id>"),
 		      cmd_wifi_dpp_ap_btstrap_get_uri, 2, 2),
 	SHELL_CMD_ARG(ap_qr_code, NULL,
-		      " AP Input QR code:\n"
-		      "<qr_code_string>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("AP Input QR code",
+				 "[-i, --iface=<interface index>]\n"
+				 "<qr_code_string>"),
 		      cmd_wifi_dpp_ap_qr_code, 2, 2),
 	SHELL_CMD_ARG(ap_auth_init, NULL,
-		      "AP DPP start auth request as enrollee:\n"
-		      "-p --peer <peer_bootstrap_id>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("AP DPP start auth request as enrollee",
+				 "[-i, --iface=<interface index>]\n"
+				 "-p --peer <peer_bootstrap_id>"),
 		      cmd_wifi_dpp_ap_auth_init, 3, 2),
 	SHELL_CMD_ARG(reconfig, NULL,
-		      " reconfig network by id:\n"
-		      "<network_id>\n"
-		      "[-i, --iface=<interface index>] : Interface index.\n",
+		      SHELL_HELP("Reconfig network by id",
+				 "[-i, --iface=<interface index>]\n"
+				 "<network_id>"),
 		      cmd_wifi_dpp_reconfig, 2, 2),
 	SHELL_SUBCMD_SET_END
 );
@@ -4572,343 +4645,105 @@ SHELL_SUBCMD_ADD((wifi), dpp, &wifi_cmd_dpp,
 		 0, 0);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
-SHELL_SUBCMD_SET_CREATE(wifi_commands, (wifi));
-
-SHELL_SUBCMD_ADD((wifi), 11k, NULL,
-		 "Configure 11k or get 11k status.\n"
-		 "[enable/disable]\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_11k,
-		 1, 3);
-
-SHELL_SUBCMD_ADD((wifi), 11k_neighbor_request, NULL,
-		 "Send Neighbor Report Request frame.\n"
-		 "[ssid <ssid>]\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_11k_neighbor_request,
-		 1, 4);
-
-SHELL_SUBCMD_ADD((wifi), 11v_btm_query, NULL,
-		 "<query_reason: The reason code for a BSS transition management query>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_btm_query,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), channel, NULL,
-		 "wifi channel setting\n"
-		 "This command is used to set the channel when\n"
-		 "monitor or TX-Injection mode is enabled\n"
-		 "Currently 20 MHz is only supported and no BW parameter is provided\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n"
-		 "[-c, --channel <chan>] : Set a specific channel number to the lower layer\n"
-		 "[-g, --get] : Get current set channel number from the lower layer\n"
-		 "[-h, --help] : Help\n"
-		 "Usage: Get operation example for interface index 1\n"
-		 "wifi channel -g -i1\n"
-		 "Set operation example for interface index 1 (setting channel 5)\n"
-		 "wifi -i1 -c5.\n",
-		 cmd_wifi_channel,
-		 2, 6);
-
-SHELL_SUBCMD_ADD((wifi), connect, NULL,
-		 "Connect to a Wi-Fi AP\n"
-		 "<-s --ssid \"<SSID>\">: SSID.\n"
-		 "[-c --channel]: Channel that needs to be scanned for connection. "
-		 "0:any channel.\n"
-		 "[-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz]\n"
-		 "[-p, --passphrase]: Passphrase (valid only for secure SSIDs)\n"
-		 "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
-		 "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE-HNP, 4:SAE-H2E, 5:SAE-AUTO, 6:WAPI,"
-		 "7:EAP-TLS, 8:WEP, 9: WPA-PSK, 10: WPA-Auto-Personal, 11: DPP\n"
-		 "12: EAP-PEAP-MSCHAPv2, 13: EAP-PEAP-GTC, 14: EAP-TTLS-MSCHAPv2,\n"
-		 "15: EAP-PEAP-TLS, 20: SAE-EXT-KEY\n"
-		 "[-w, --ieee-80211w]: MFP (optional: needs security type to be specified)\n"
-		 ": 0:Disable, 1:Optional, 2:Required.\n"
-		 "[-m, --bssid]: MAC address of the AP (BSSID).\n"
-		 "[-t, --timeout]: Timeout for the connection attempt (in seconds).\n"
-		 "[-a, --anon-id]: Anonymous identity for enterprise mode.\n"
-		 "[-K, --key1-pwd for eap phase1 or --key2-pwd for eap phase2]:\n"
-		 "Private key passwd for enterprise mode. Default no password for private key.\n"
-		 "[-S, --wpa3-enterprise]: WPA3 enterprise mode:\n"
-		 "Default 0: Not WPA3 enterprise mode.\n"
-		 "1:Suite-b mode, 2:Suite-b-192-bit mode, 3:WPA3-enterprise-only mode.\n"
-		 "[-T, --TLS-cipher]: 0:TLS-NONE, 1:TLS-ECC-P384, 2:TLS-RSA-3K.\n"
-		 "[-A, --verify-peer-cert]: apply for EAP-PEAP-MSCHAPv2 and EAP-TTLS-MSCHAPv2\n"
-		 "Default 0. 0:not use CA to verify peer, 1:use CA to verify peer.\n"
-		 "[-V, --eap-version]: 0 or 1. Default 1: eap version 1.\n"
-		 "[-I, --eap-id1]: Client Identity. Default no eap identity.\n"
-		 "[-P, --eap-pwd1]: Client Password.\n"
-		 "Default no password for eap user.\n"
-		 "[-R, --ieee-80211r]: Use IEEE80211R fast BSS transition connect."
-		 "[-e, --server-cert-domain-exact]: Full domain names for server certificate match.\n"
-		 "[-x, --server-cert-domain-suffix]: Domain name suffixes for server certificate match.\n"
-		 "[-h, --help]: Print out the help for the connect command.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_connect,
-		 2, 46);
-
-SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
-		 "Disconnect from the Wi-Fi AP.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_disconnect,
-		 1, 2);
-
 SHELL_SUBCMD_ADD((wifi), mode, NULL,
-		 "mode operational setting\n"
-		 "This command may be used to set the Wi-Fi device into a specific "
-		 "mode of operation\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n"
-		 "[-s, --sta] : Station mode\n"
-		 "[-m, --monitor] : Monitor mode\n"
-		 "[-a, --ap] : AP mode\n"
-		 "[-k, --softap] : Softap mode\n"
-		 "[-h, --help] : Help\n"
-		 "Usage: Get operation example for interface index 1\n"
-		 "wifi mode -i1\n"
-		 "Set operation example for interface index 1 - set station+promiscuous\n"
-		 "wifi mode -i1 -sp.\n",
+		 SHELL_HELP("Mode operational setting",
+			    "This command may be used to set the Wi-Fi device into a specific "
+			    "mode of operation\n"
+			    "[-i, --iface=<interface index>]\n"
+			    "[-s, --sta] : Station mode\n"
+			    "[-m, --monitor] : Monitor mode\n"
+			    "[-a, --ap] : AP mode\n"
+			    "[-k, --softap] : Softap mode\n"
+			    "[-h, --help] : Help\n"
+			    "Examples:\n"
+			    "Get operation example for interface index 1\n"
+			    "wifi mode -i1\n"
+			    "Set operation example for interface index 1 - "
+			    "set station+promiscuous\n"
+			    "wifi mode -i1 -sp"),
 		 cmd_wifi_mode,
 		 1, 11);
-
-SHELL_SUBCMD_ADD((wifi), packet_filter, NULL,
-		 "mode filter setting\n"
-		 "This command is used to set packet filter setting when\n"
-		 "monitor, TX-Injection and promiscuous mode is enabled\n"
-		 "The different packet filter modes are control, management, "
-		 "data and enable all filters\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n"
-		 "[-a, --all] : Enable all packet filter modes\n"
-		 "[-m, --mgmt] : Enable management packets to allowed up the stack\n"
-		 "[-c, --ctrl] : Enable control packets to be allowed up the stack\n"
-		 "[-d, --data] : Enable Data packets to be allowed up the stack\n"
-		 "[-g, --get] : Get current filter settings for a specific interface index\n"
-		 "[-b, --capture-len <len>] : Capture length buffer size for each packet "
-		 "to be captured\n"
-		 "[-h, --help] : Help\n"
-		 "Usage: Get operation example for interface index 1\n"
-		 "wifi packet_filter -g -i1\n"
-		 "Set operation example for interface index 1 - set data+management frame filter\n"
-		 "wifi packet_filter -i1 -md.\n",
-		 cmd_wifi_packet_filter,
-		 2, 10);
-
-SHELL_SUBCMD_ADD((wifi), pmksa_flush, NULL,
-		 "Flush PMKSA cache entries.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_pmksa_flush,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), ps, NULL,
-		 "Configure or display Wi-Fi power save state.\n[on/off]\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_ps,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), ps_listen_interval, NULL,
-		 "<val> - Listen interval in the range of <0-65535>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_listen_interval,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), ps_mode, NULL,
-		 "<mode: legacy/WMM>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_ps_mode,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), ps_timeout, NULL,
-		 "<val> - PS inactivity timer(in ms).\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_ps_timeout,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), ps_wakeup_mode, NULL,
-		 "<wakeup_mode: DTIM/Listen Interval>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_ps_wakeup_mode,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), reg_domain, NULL,
-		 "Set or Get Wi-Fi regulatory domain\n"
-		 "[ISO/IEC 3166-1 alpha2]: Regulatory domain\n"
-		 "[-f]: Force to use this regulatory hint over any other regulatory hints\n"
-		 "Note1: The behavior of this command is dependent on the Wi-Fi driver/chipset implementation\n"
-		 "Note2: This may cause regulatory compliance issues, use it at your own risk.\n"
-		 "[-v]: Verbose, display the per-channel regulatory information\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_reg_domain,
-		 1, 5);
-
-SHELL_SUBCMD_ADD((wifi), rts_threshold, NULL,
-	"<rts_threshold: rts threshold/off>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_set_rts_threshold,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), scan, NULL,
-		 "Scan for Wi-Fi APs\n"
-		 "[-t, --type <active/passive>] : Preferred mode of scan. "
-		 "The actual mode of scan can depend on factors such as the Wi-Fi chip "
-		 "implementation, regulatory domain restrictions. Default type is active\n"
-		 "[-b, --bands <Comma separated list of band values (2/5/6)>] : "
-		 "Bands to be scanned where 2: 2.4 GHz, 5: 5 GHz, 6: 6 GHz\n"
-		 "[-a, --dwell_time_active <val_in_ms>] : "
-		 "Active scan dwell time (in ms) on a channel. Range 5 ms to 1000 ms\n"
-		 "[-p, --dwell_time_passive <val_in_ms>] : "
-		 "Passive scan dwell time (in ms) on a channel. Range 10 ms to 1000 ms\n"
-		 "[-s, --ssid] : SSID to scan for. Can be provided multiple times\n"
-		 "[-m, --max_bss <val>] : Maximum BSSes to scan for. Range 1 - 65535\n"
-		 "[-c, --chans <Comma separated list of channel ranges>] : "
-		 "Channels to be scanned. The channels must be specified in the form "
-		 "band1:chan1,chan2_band2:chan3,..etc. band1, band2 must be valid band "
-		 "values and chan1, chan2, chan3 must be specified as a list of comma "
-		 "separated values where each value is either a single channel or a "
-		 "channel range specified as chan_start-chan_end. Each band channel "
-		 "set has to be separated by a _. For example, a valid channel "
-		 "specification can be 2:1,6_5:36 or 2:1,6-11,14_5:36,163-177,52. "
-		 "Care should be taken to ensure that configured channels don't exceed "
-		 "CONFIG_WIFI_MGMT_SCAN_CHAN_MAX_MANUAL\n"
-		 "[-h, --help] : Print out the help for the scan command.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_scan,
-		 1, 10);
-
-SHELL_SUBCMD_ADD((wifi), statistics, NULL,
-		 "Wi-Fi interface statistics.\n"
-		 "[reset] : Reset Wi-Fi interface statistics\n"
-		 "[help] :  Print out the help for the statistics command.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_stats,
-		 1, 3);
-
-SHELL_SUBCMD_ADD((wifi), status, NULL,
-		 "Status of the Wi-Fi interface.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_status,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), version, NULL,
-		 "Print Wi-Fi Driver and Firmware versions\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_version,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), wps_pbc, NULL,
-		 "Start a WPS PBC connection.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_wps_pbc,
-		 1, 2);
-
-SHELL_SUBCMD_ADD((wifi), wps_pin, NULL,
-		 "Set and get WPS pin.\n"
-		 "[pin] Only applicable for set.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_wps_pin,
-		 1, 3);
-
-SHELL_SUBCMD_ADD((wifi), ps_exit_strategy, NULL,
-		 "<tim> : Set PS exit strategy to Every TIM\n"
-		 "<custom> : Set PS exit strategy to Custom\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_ps_exit_strategy,
-		 2, 2);
-
-SHELL_SUBCMD_ADD((wifi), bss_max_idle_period, NULL,
-		 "<BSS max idle period preference: timeout(in seconds)>.\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_set_bss_max_idle_period,
-		 2, 2);
-
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN
-SHELL_SUBCMD_ADD((wifi), bgscan, NULL,
-		 "Configure background scanning.\n"
-		 "<-t, --type simple/learn/none> : The scanning type, use none to disable.\n"
-		 "[-s, --short-interval <val>] : Short scan interval (default: 30).\n"
-		 "[-l, --long-interval <val>] : Long scan interval (default: 300).\n"
-		 "[-r, --rssi-threshold <val>] : Signal strength threshold (default: disabled).\n"
-		 "[-b, --btm-queries <val>] : BTM queries before scanning (default: disabled).\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_set_bgscan,
-		 2, 6);
-#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN */
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	wifi_cmd_p2p,
 	SHELL_CMD_ARG(find, NULL,
-		      "Start P2P device discovery\n"
-		      "[-t, --timeout=<timeout in seconds>]: Discovery timeout\n"
-		      "[-T, --type=<0|1|2>]: Discovery type\n"
-		      "  0: Social channels only (1, 6, 11)\n"
-		      "  1: Progressive scan (all channels)\n"
-		      "  2: Full scan first, then social (default)\n"
-		      "[-i, --iface=<interface index>]: Interface index\n"
-		      "[-h, --help]: Show help\n",
+		      SHELL_HELP("Start P2P device discovery",
+				 "[-i, --iface=<interface index>]\n"
+				 "[-t, --timeout=<timeout in seconds>]: Discovery timeout\n"
+				 "[-T, --type=<0|1|2>]: Discovery type\n"
+				 "0: Social channels only (1, 6, 11)\n"
+				 "1: Progressive scan (all channels)\n"
+				 "2: Full scan first, then social (default)"),
 		      cmd_wifi_p2p_find, 1, 6),
 	SHELL_CMD_ARG(stop_find, NULL,
-		      "Stop P2P device discovery\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Stop P2P device discovery",
+				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_p2p_stop_find, 1, 2),
 	SHELL_CMD_ARG(peer, NULL,
-		      "Show information about P2P peers\n"
-		      "Usage: peer [<MAC address>]\n"
-		      "<MAC address>: Show detailed info for specific peer (format: XX:XX:XX:XX:XX:XX)\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Show information about P2P peers",
+				 "[-i, --iface=<interface index>]\n"
+				 "<MAC address>: Show detailed info for specific peer "
+				 "(format: XX:XX:XX:XX:XX:XX)"),
 		      cmd_wifi_p2p_peer, 1, 3),
 	SHELL_CMD_ARG(connect, NULL,
-		      "Connect to a P2P peer\n"
-		      "Usage: connect <MAC address> <pbc|pin> [PIN] [options]\n"
-		      "<MAC address>: Peer device MAC address (format: XX:XX:XX:XX:XX:XX)\n"
-		      "<pbc>: Use Push Button Configuration\n"
-		      "<pin>: Use PIN method\n"
-		      "  - Without PIN: Device displays generated PIN for peer to enter\n"
-		      "  - With PIN: Device uses provided PIN to connect\n"
-		      "[PIN]: 8-digit PIN (optional, generates if omitted)\n"
-		      "[-g, --go-intent=<0-15>]: GO intent (0=client, 15=GO, default: 0)\n"
-		      "[-f, --freq=<frequency>]: Frequency in MHz (default: 2462)\n"
-		      "[-j, --join]: Join an existing group (as a client) instead of starting GO negotiation\n"
-		      "[-i, --iface=<interface index>]: Interface index\n"
-		      "[-h, --help]: Show help\n"
-		      "Examples:\n"
-		      "  wifi p2p connect 9c:b1:50:e3:81:96 pin -g 0  (displays PIN)\n"
-		      "  wifi p2p connect 9c:b1:50:e3:81:96 pin 12345670 -g 0  (uses PIN)\n"
-		      "  wifi p2p connect f4:ce:36:01:00:38 pbc --join  (join existing group)\n",
+		      SHELL_HELP("Connect to a P2P peer",
+				 "[-i, --iface=<interface index>]\n"
+				 "<MAC address>: Peer device MAC address "
+				 "(format: XX:XX:XX:XX:XX:XX)\n"
+				 "<pbc>: Use Push Button Configuration\n"
+				 "<pin>: Use PIN method\n"
+				 "- Without PIN: Device displays generated PIN for peer to enter\n"
+				 "- With PIN: Device uses provided PIN to connect\n"
+				 "[PIN]: 8-digit PIN (optional, generates if omitted)\n"
+				 "[-g, --go-intent=<0-15>]: GO intent "
+				 "(0=client, 15=GO, default: 0)\n"
+				 "[-f, --freq=<frequency>]: Frequency in MHz (default: 2462)\n"
+				 "[-j, --join]: Join an existing group (as a client) "
+				 "instead of starting GO negotiation\n"
+				 "Examples:\n"
+				 "wifi p2p connect 9c:b1:50:e3:81:96 pin -g 0  (displays PIN)\n"
+				 "wifi p2p connect 9c:b1:50:e3:81:96 pin 12345670 -g 0  "
+				 "(uses PIN)\n"
+				 "wifi p2p connect f4:ce:36:01:00:38 pbc --join  "
+				 "(join existing group)"),
 		      cmd_wifi_p2p_connect, 3, 6),
 	SHELL_CMD_ARG(group_add, NULL,
-		      "Add a P2P group (start as GO)\n"
-		      "Usage: group_add [options]\n"
-		      "[-f, --freq=<MHz>]: Frequency in MHz (0 = auto)\n"
-		      "[-p, --persistent=<id>]: Persistent group ID (-1 = not persistent)\n"
-		      "[-h, --ht40]: Enable HT40\n"
-		      "[-v, --vht]: Enable VHT (also enables HT40)\n"
-		      "[-H, --he]: Enable HE\n"
-		      "[-e, --edmg]: Enable EDMG\n"
-		      "[-b, --go-bssid=<MAC>]: GO BSSID (format: XX:XX:XX:XX:XX:XX)\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Add a P2P group (start as GO)",
+				 "[-i, --iface=<interface index>]\n"
+				 "[-f, --freq=<MHz>]: Frequency in MHz (0 = auto)\n"
+				 "[-p, --persistent=<id>]: Persistent group ID "
+				 "(-1 = not persistent)\n"
+				 "[-h, --ht40]: Enable HT40\n"
+				 "[-v, --vht]: Enable VHT (also enables HT40)\n"
+				 "[-H, --he]: Enable HE\n"
+				 "[-e, --edmg]: Enable EDMG\n"
+				 "[-b, --go-bssid=<MAC>]: GO BSSID (format: XX:XX:XX:XX:XX:XX)"),
 		      cmd_wifi_p2p_group_add, 1, 10),
 	SHELL_CMD_ARG(group_remove, NULL,
-		      "Remove a P2P group\n"
-		      "Usage: group_remove <ifname>\n"
-		      "<ifname>: Interface name (e.g., wlan0)\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Remove a P2P group",
+				 "[-i, --iface=<interface index>]\n"
+				 "<ifname>: Interface name (e.g., wlan0)"),
 		      cmd_wifi_p2p_group_remove, 2, 3),
 	SHELL_CMD_ARG(invite, NULL,
-		      "Invite a peer to a P2P group\n"
-		      "Usage: invite --persistent=<id> <peer MAC> OR\n"
-		      "       invite --group=<ifname> --peer=<MAC> [options]\n"
-		      "[-p, --persistent=<id>]: Persistent group ID\n"
-		      "[-g, --group=<ifname>]: Group interface name\n"
-		      "[-P, --peer=<MAC>]: Peer MAC address (format: XX:XX:XX:XX:XX:XX)\n"
-		      "[-f, --freq=<MHz>]: Frequency in MHz (0 = auto)\n"
-		      "[-d, --go-dev-addr=<MAC>]: GO device address (for group type)\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Invite a peer to a P2P group",
+				 "[-i, --iface=<interface index>]\n"
+				 "[-p, --persistent=<id>]: Persistent group ID\n"
+				 "[-g, --group=<ifname>]: Group interface name\n"
+				 "[-P, --peer=<MAC>]: Peer MAC address "
+				 "(format: XX:XX:XX:XX:XX:XX)\n"
+				 "[-f, --freq=<MHz>]: Frequency in MHz (0 = auto)\n"
+				 "[-d, --go-dev-addr=<MAC>]: GO device address (for group type)\n"
+				 "Examples:\n"
+				 "wifi p2p invite --persistent=<id> <peer MAC>\n"
+				 "wifi p2p invite --group=<ifname> --peer=<MAC> [options]"),
 		      cmd_wifi_p2p_invite, 2, 8),
 	SHELL_CMD_ARG(power_save, NULL,
-		      "Set P2P power save mode\n"
-		      "Usage: power_save <on|off>\n"
-		      "<on>: Enable P2P power save\n"
-		      "<off>: Disable P2P power save\n"
-		      "[-i, --iface=<interface index>]: Interface index\n",
+		      SHELL_HELP("Set P2P power save mode",
+				 "[-i, --iface=<interface index>]\n"
+				 "<on|off>\n"
+				 "<on>: Enable P2P power save\n"
+				 "<off>: Disable P2P power save"),
 		      cmd_wifi_p2p_power_save, 2, 3),
 	SHELL_SUBCMD_SET_END
 );
@@ -4919,12 +4754,220 @@ SHELL_SUBCMD_ADD((wifi), p2p, &wifi_cmd_p2p,
 		 0, 0);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 
-SHELL_SUBCMD_ADD((wifi), config, NULL,
-		 "Configure STA parameters.\n"
-		 "-o, --okc=<0/1>: Opportunistic Key Caching. 0: disable, 1: enable\n"
-		 "[-i, --iface=<interface index>] : Interface index.\n",
-		 cmd_wifi_config_params,
-		 3, 12);
+SHELL_SUBCMD_ADD((wifi), packet_filter, NULL,
+		 SHELL_HELP("Mode filter setting",
+			    "This command is used to set packet filter setting when "
+			    "monitor, TX-Injection and promiscuous mode is enabled. "
+			    "The different packet filter modes are control, management, "
+			    "data and enable all filters\n"
+			    "[-i, --iface=<interface index>]\n"
+			    "[-a, --all] : Enable all packet filter modes\n"
+			    "[-m, --mgmt] : Enable management packets to allowed up the stack\n"
+			    "[-c, --ctrl] : Enable control packets to be allowed up the stack\n"
+			    "[-d, --data] : Enable Data packets to be allowed up the stack\n"
+			    "[-g, --get] : Get current filter settings for a specific "
+			    "interface index\n"
+			    "[-b, --capture-len <len>] : Capture length buffer size for each "
+			    "packet to be captured\n"
+			    "Examples:\n"
+			    "Get operation example for interface index 1\n"
+			    "wifi packet_filter -g -i1\n"
+			    "Set operation example for interface index 1 - set data+management "
+			    "frame filter\n"
+			    "wifi packet_filter -i1 -md"),
+		 cmd_wifi_packet_filter,
+		 2, 10);
+
+SHELL_SUBCMD_ADD((wifi), pmksa_flush, NULL,
+		 SHELL_HELP("Flush PMKSA cache entries",
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_pmksa_flush,
+		 1, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps, NULL,
+		 SHELL_HELP("Configure or display Wi-Fi power save state",
+			    "[-i, --iface=<interface index>]\n"
+			    "[on/off]"),
+		 cmd_wifi_ps,
+		 1, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps_exit_strategy, NULL,
+		 SHELL_HELP("Set PS exit strategy",
+			    "[-i, --iface=<interface index>]\n"
+			    "tim | custom\n"
+			    "tim : Set PS exit strategy to Every TIM\n"
+			    "custom : Set PS exit strategy to Custom"),
+		 cmd_wifi_ps_exit_strategy,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps_listen_interval, NULL,
+		 SHELL_HELP("Set PS listen interval",
+			    "[-i, --iface=<interface index>]\n"
+			    "<val> - Listen interval in the range of <0-65535>"),
+		 cmd_wifi_listen_interval,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps_mode, NULL,
+		 SHELL_HELP("Set PS mode",
+			    "[-i, --iface=<interface index>]\n"
+			    "<mode: legacy/WMM>"),
+		 cmd_wifi_ps_mode,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps_timeout, NULL,
+		 SHELL_HELP("Set PS inactivity timer value",
+			    "[-i, --iface=<interface index>]\n"
+			    "<val> - PS inactivity timer(in ms)"),
+		 cmd_wifi_ps_timeout,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), ps_wakeup_mode, NULL,
+		 SHELL_HELP("Set PS wakeup mode interval",
+			    "[-i, --iface=<interface index>]\n"
+			    "<wakeup_mode: DTIM/Listen Interval>"),
+		 cmd_wifi_ps_wakeup_mode,
+		 2, 2);
+
+SHELL_SUBCMD_ADD((wifi), reg_domain, NULL,
+		 SHELL_HELP("Set or Get Wi-Fi regulatory domain",
+			    "[-i, --iface=<interface index>]\n"
+			    "[ISO/IEC 3166-1 alpha2]: Regulatory domain\n"
+			    "[-f]: Force to use this regulatory hint over any other "
+			    "regulatory hints\n"
+			    "Note1: The behavior of this command is dependent on the "
+			    "Wi-Fi driver/chipset implementation\n"
+			    "Note2: This may cause regulatory compliance issues, "
+			    "use it at your own risk.\n"
+			    "[-v]: Verbose, display the per-channel regulatory information"),
+		 cmd_wifi_reg_domain,
+		 1, 5);
+
+SHELL_SUBCMD_ADD((wifi), rts_threshold, NULL,
+		 SHELL_HELP("Set RTS value or turn it off",
+			    "[-i, --iface=<interface index>]\n"
+			    "<rts_threshold value> | off"),
+		 cmd_wifi_set_rts_threshold,
+		 1, 2);
+
+SHELL_SUBCMD_ADD((wifi), scan, NULL,
+		 SHELL_HELP("Scan for Wi-Fi APs",
+			    "[-i, --iface=<interface index>]\n"
+			    "[-t, --type <active/passive>] : Preferred mode of scan. "
+			    "The actual mode of scan can depend on factors such as the Wi-Fi chip "
+			    "implementation, regulatory domain restrictions. "
+			    "Default type is active\n"
+			    "[-b, --bands <Comma separated list of band values (2/5/6)>] : "
+			    "Bands to be scanned where 2: 2.4 GHz, 5: 5 GHz, 6: 6 GHz\n"
+			    "[-a, --dwell_time_active <val_in_ms>] : "
+			    "Active scan dwell time (in ms) on a channel. Range 5 ms to 1000 ms\n"
+			    "[-p, --dwell_time_passive <val_in_ms>] : "
+			    "Passive scan dwell time (in ms) on a channel. "
+			    "Range 10 ms to 1000 ms\n"
+			    "[-s, --ssid] : SSID to scan for. Can be provided multiple times\n"
+			    "[-m, --max_bss <val>] : Maximum BSSes to scan for. Range 1 - 65535\n"
+			    "[-c, --chans <Comma separated list of channel ranges>] : "
+			    "Channels to be scanned. The channels must be specified in the form "
+			    "band1:chan1,chan2_band2:chan3,..etc. band1, band2 must be valid band "
+			    "values and chan1, chan2, chan3 must be specified as a list of comma "
+			    "separated values where each value is either a single channel or a "
+			    "channel range specified as chan_start-chan_end. Each band channel "
+			    "set has to be separated by a _. For example, a valid channel "
+			    "specification can be 2:1,6_5:36 or 2:1,6-11,14_5:36,163-177,52. "
+			    "Care should be taken to ensure that configured channels don't exceed "
+			    "CONFIG_WIFI_MGMT_SCAN_CHAN_MAX_MANUAL"),
+		 cmd_wifi_scan,
+		 1, 10);
+
+SHELL_SUBCMD_ADD((wifi), statistics, NULL,
+		 SHELL_HELP("Show Wi-Fi interface statistics",
+			    "[-i, --iface=<interface index>]\n"
+			    "[reset] : Reset Wi-Fi interface statistics"),
+		 cmd_wifi_stats,
+		 1, 3);
+
+SHELL_SUBCMD_ADD((wifi), status, NULL,
+		 SHELL_HELP("Status of the Wi-Fi interface",
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_status,
+		 1, 2);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
+	SHELL_CMD_ARG(quick_setup, NULL,
+		      SHELL_HELP("Start a TWT flow with defaults",
+				 "[-i, --iface=<interface index>]\n"
+				 "<twt_wake_interval: 1-262144us>\n"
+				 "<twt_interval: 1us-2^31us>"),
+		      cmd_wifi_twt_setup_quick,
+		      3, 2),
+	SHELL_CMD_ARG(setup, NULL,
+		      SHELL_HELP("Start a TWT flow",
+				 "[-i, --iface=<interface index>]\n"
+				 "<-n --negotiation-type>: 0: Individual, "
+				 "1: Broadcast, 2: Wake TBTT\n"
+				 "<-c --setup-cmd>: 0: Request, 1: Suggest, 2: Demand\n"
+				 "<-t --dialog-token>: 1-255\n"
+				 "<-f --flow-id>: 0-7\n"
+				 "<-r --responder>: 0/1\n"
+				 "<-T --trigger>: 0/1\n"
+				 "<-I --implicit>:0/1\n"
+				 "<-a --announce>: 0/1\n"
+				 "<-w --wake-interval>: 1-262144us\n"
+				 "<-p --interval>: 1us-2^31us\n"
+				 "<-D --wake-ahead-duration>: 0us-2^31us\n"
+				 "<-d --info-disable>: 0/1\n"
+				 "<-e --exponent>: 0-31\n"
+				 "<-m --mantissa>: 1-2^16"),
+		      cmd_wifi_twt_setup,
+		      25, 7),
+	SHELL_CMD_ARG(btwt_setup, NULL,
+		      SHELL_HELP("Start a BTWT flow",
+				 "[-i, --iface=<interface index>]\n"
+				 "<sta_wait> <offset> <twtli> <session_num>: 2-5\n"
+				 "<id0> <mantissa0> <exponent0> <nominal_wake0>: 64-255\n"
+				 "<id1> <mantissa1> <exponent1> <nominal_wake1>: 64-255\n"
+				 "<idx> <mantissax> <exponentx> <nominal_wakex>: 64-255\n"
+				 " The total number of '0, 1, ..., x' is session_num"),
+		      cmd_wifi_btwt_setup,
+		      13, 12),
+	SHELL_CMD_ARG(teardown, NULL,
+		      SHELL_HELP("Teardown a TWT flow",
+				 "<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
+				 "<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
+				 "<dialog_token: 1-255> <flow_id: 0-7>"),
+		      cmd_wifi_twt_teardown,
+		      5, 0),
+	SHELL_CMD_ARG(teardown_all, NULL,
+		      SHELL_HELP("Teardown all TWT flows", ""),
+		      cmd_wifi_twt_teardown_all,
+		      1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_SUBCMD_ADD((wifi), twt, &wifi_twt_ops,
+		 "Manage TWT flows.",
+		 NULL,
+		 0, 0);
+
+SHELL_SUBCMD_ADD((wifi), version, NULL,
+		 SHELL_HELP("Print Wi-Fi Driver and Firmware versions",
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_version,
+		 1, 2);
+
+SHELL_SUBCMD_ADD((wifi), wps_pbc, NULL,
+		 SHELL_HELP("Start a WPS PBC connection",
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_wps_pbc,
+		 1, 2);
+
+SHELL_SUBCMD_ADD((wifi), wps_pin, NULL,
+		 SHELL_HELP("Set and get WPS pin",
+			    "[-i, --iface=<interface index>]\n"
+			    "[pin] Only applicable for set"),
+		 cmd_wifi_wps_pin,
+		 1, 3);
+
+SHELL_SUBCMD_SET_CREATE(wifi_commands, (wifi));
 
 SHELL_CMD_REGISTER(wifi, &wifi_commands, "Wi-Fi commands", NULL);
 


### PR DESCRIPTION
This will save flash memory by 1489 bytes and make usage help look uniform in different commands.

Re-order the shell commands to alphabetical order. This has been done before but has bitrotted over time.