### PR TITLE
boards: st: stm32mp257f_ev1: use correct tag for denoting CAN support

### DIFF
--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
@@ -12,7 +12,7 @@ supported:
   - i2c
   - i3c
   - spi
-  - fdcan
+  - can
 testing:
   ignore_tags:
     - cmsis_rtos_v2


### PR DESCRIPTION
Use the correct tag ("can") to denote CAN support for the ST STM32MP257F-EV1. The wrong tag was introduced in https://github.com/zephyrproject-rtos/zephyr/pull/102888