### PR TITLE
boards: remove odd tags from supported board features

### DIFF
--- a/boards/96boards/avenger96/96b_avenger96.yaml
+++ b/boards/96boards/avenger96/96b_avenger96.yaml
@@ -7,7 +7,6 @@ toolchain:
   - gnuarmemb
 supported:
   - gpio
-  - shell
 testing:
   ignore_tags:
     - cmsis_rtos_v2
@@ -16,7 +15,6 @@ testing:
     - crypto
     - aes
     - cmm
-    - LED
     - nfc
 ram: 256
 flash: 64

--- a/boards/96boards/meerkat96/96b_meerkat96_mcimx7d_m4.yaml
+++ b/boards/96boards/meerkat96/96b_meerkat96_mcimx7d_m4.yaml
@@ -15,7 +15,6 @@ toolchain:
   - gnuarmemb
 supported:
   - gpio
-  - shell
 testing:
   ignore_tags:
     - net

--- a/boards/arduino/nicla_sense_me/arduino_nicla_sense_me.yaml
+++ b/boards/arduino/nicla_sense_me/arduino_nicla_sense_me.yaml
@@ -11,7 +11,6 @@ supported:
   - gpio
   - i2c
   - spi
-  - shell
   - counter
   - nvs
   - pwm

--- a/boards/microchip/sam/sam_e54_cult/sam_e54_cult.yaml
+++ b/boards/microchip/sam/sam_e54_cult/sam_e54_cult.yaml
@@ -12,6 +12,5 @@ ram: 256
 supported:
   - gpio
   - pinctrl
-  - shell
   - uart
 vendor: microchip

--- a/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.yaml
+++ b/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.yaml
@@ -26,7 +26,6 @@ supported:
   - pwm
   - reset
   - rtc
-  - shell
   - spi
   - uart
   - watchdog

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -12,6 +12,5 @@ supported:
   - eeprom
   - i2c
   - pinctrl
-  - shell
   - uart
 vendor: microchip

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
@@ -17,6 +17,5 @@ supported:
   - hwinfo
   - pwm
   - sdhc
-  - shell
   - uart
 vendor: microchip

--- a/boards/oct/osd32mp1_brk/osd32mp1_brk.yaml
+++ b/boards/oct/osd32mp1_brk/osd32mp1_brk.yaml
@@ -6,7 +6,6 @@ toolchain:
   - zephyr
 supported:
   - gpio
-  - shell
 testing:
   ignore_tags:
     - cmsis_rtos_v2
@@ -15,7 +14,6 @@ testing:
     - crypto
     - aes
     - cmm
-    - LED
     - nfc
 ram: 256
 flash: 64

--- a/boards/segger/trb_stm32f407/segger_trb_stm32f407.yaml
+++ b/boards/segger/trb_stm32f407/segger_trb_stm32f407.yaml
@@ -14,6 +14,5 @@ supported:
 testing:
   ignore_tags:
     - net
-    - shell
     - console
 vendor: segger

--- a/boards/st/stm32mp135f_dk/twister.yaml
+++ b/boards/st/stm32mp135f_dk/twister.yaml
@@ -8,7 +8,6 @@ toolchain:
 supported:
   - gpio
   - uart
-  - shell
 ram: 262144
 flash: 262144
 vendor: st

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.yaml
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.yaml
@@ -9,7 +9,6 @@ supported:
   - arduino_i2c
   - arduino_gpio
   - gpio
-  - shell
   - i2c
   - spi
 testing:
@@ -20,7 +19,6 @@ testing:
     - crypto
     - aes
     - cmm
-    - LED
     - nfc
 ram: 320
 flash: 64

--- a/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.yaml
+++ b/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.yaml
@@ -6,9 +6,7 @@ toolchain:
   - zephyr
   - gccarmemb
 supported:
-  - LED
   - gpio
-  - shell
   - i2c
   - i3c
   - spi

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
@@ -6,9 +6,7 @@ toolchain:
   - zephyr
   - gccarmemb
 supported:
-  - LED
   - gpio
-  - shell
   - i2c
   - i3c
   - spi


### PR DESCRIPTION
Remove the tags "shell" and "LED" from the lists of supported board features as there are no tests nor samples that depend on these tags.