### PR TITLE
west: microchip: Support flashing using MPLAB IPE

### DIFF
--- a/boards/common/mplab_ipe.board.cmake
+++ b/boards/common/mplab_ipe.board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Muhammed Asif P
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(mplab_ipe)
+board_finalize_runner_args(mplab_ipe)

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--device" "32CX1025SG41128" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CX1025SG41128" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/doc/index.rst
@@ -59,6 +59,33 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLab IPE
+=====================
+To flash the board using MPLAB IPE, follow the steps below:
+
+1. Install MPLAB IPE
+
+   - Download the `MPLAB X IDE`_ installer from the Microchip Technology website.
+   - Extract the downloaded package and run the installer script on your system.
+   - During installation, select **MPLAB IPE** from the available components.
+   - Ensure that the ``ipecmd`` executable is available in your system ``PATH``.
+
+2. Connect the Board
+
+   - Connect the **DEBUG USB (J300)** port on the board to your host machine.
+   - This connection powers up the board and provides access to the on-board
+     Debugger (PKoB).
+   - The PKoB enables programming of the target microcontroller through MPLAB IPE.
+
+3.  Flash the Firmware
+
+   - Run the following command from your project directory:
+
+   .. code-block:: console
+
+      west flash
+
+
 Flash Using J-Link
 ==================
 
@@ -93,9 +120,9 @@ To flash the board using the J-Link debugger, follow the steps below:
 
    .. code-block:: console
 
-      west flash
+      west flash -r jlink
 
-   This uses the default ``jlink`` runner to flash the application to the board.
+   This uses the jlink runner to flash the application to the board.
 
 5. Observe the Result
 
@@ -119,3 +146,6 @@ PIC32CX SG41 Curiosity Ultra evaluation kit Page:
 
 .. _J32 Debug Probe:
     https://www.microchip.com/en-us/development-tool/dv164232
+
+.. _MPLAB X IDE:
+    https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -47,6 +47,7 @@ _names = [
     'minichlink',
     'misc',
     'mpcli',
+    'mplab_ipe',
     'native',
     'nrfjprog',
     'nrfutil',

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -331,6 +331,9 @@ class RunnerCaps:
     - skip_load: whether the runner supports the --load/--no-load option, which
       allows skipping the load of image on target before starting a debug session
       (this option only affects the 'debug' command)
+
+    - verify: whether the runner supports an --verify option, which
+      does a verification of the flashed hex after programming.
     '''
 
     commands: set[str] = field(default_factory=lambda: set(_RUNNERCAPS_COMMANDS))
@@ -354,6 +357,7 @@ class RunnerCaps:
                               # 'disconnect', and 'quit' commands (named batch_debug in west),
                               # unlike interactive debug mode (default),
                               # which stops and waits for user input
+    verify: bool = False
 
     def __post_init__(self):
         if self.mult_dev_ids and not self.dev_id:
@@ -691,6 +695,11 @@ class ZephyrBinaryRunner(abc.ABC):
                             help="enable west debug batch mode"
                             if caps.batch_debug else argparse.SUPPRESS)
 
+        parser.add_argument('--verify', action=argparse.BooleanOptionalAction,
+                            help=("verify flash after programming, or don't"
+                                  "Default action depends on each specific runner."
+                                  if caps.verify else argparse.SUPPRESS))
+
         # Runner-specific options.
         cls.do_add_parser(parser)
 
@@ -737,12 +746,16 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--rtt-address')
         if args.dry_run and not caps.dry_run:
             _missing_cap(cls, '--dry-run')
+        if args.verify and not caps.verify:
+            _missing_cap(cls, '--verify')
 
         ret = cls.do_create(cfg, args)
         if args.erase:
             ret.logger.info('mass erase requested')
         if args.reset:
             ret.logger.info('reset after flashing requested')
+        if args.verify:
+            ret.logger.info('verify requested')
         return ret
 
     @classmethod

--- a/scripts/west_commands/runners/mplab_ipe.py
+++ b/scripts/west_commands/runners/mplab_ipe.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+# Copyright (c) 2026 Muhammed Asif P
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import shlex
+
+from runners.core import RunnerCaps, RunnerConfig, ZephyrBinaryRunner
+
+
+class MPLABIPEBinaryRunner(ZephyrBinaryRunner):
+    """Runner for Flashing Application using Microchip MPLAB IPE"""
+
+    def __init__(
+        self, cfg: RunnerConfig, tool: str, device: str, erase: bool = False, verify: bool = False
+    ):
+        super().__init__(cfg)
+        self.tool = tool
+        self.device = device
+        self.erase = erase
+        self.verify = verify
+
+    @classmethod
+    def name(cls):
+        return "mplab_ipe"
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={"flash"}, erase=True, verify=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument("--tool", required=True, help="Programmer tool name, e.g. PKOB4")
+        parser.add_argument(
+            "--device", required=True, help="Target device name, e.g. 32CX1025SG61128"
+        )
+
+    @classmethod
+    def do_create(cls, cfg: RunnerConfig, args):
+        return MPLABIPEBinaryRunner(
+            cfg, tool=args.tool, device=args.device, erase=args.erase, verify=args.verify
+        )
+
+    def do_run(self, command: str, **kwargs):
+        if command == "flash":
+            self.flash()
+
+    def flash(self):
+        hex_file = self.cfg.hex_file
+
+        if not hex_file or not os.path.isfile(hex_file):
+            raise RuntimeError(f"Hex file not found: {hex_file}")
+
+        exe = "ipecmd.exe" if os.name == "nt" else "ipecmd.sh"
+
+        cmd = [
+            exe,
+            f"-TP{self.tool}",
+            f"-P{self.device}",
+            f"-F{hex_file}",
+            "-M",
+            "-OL",
+            "-OK",
+        ]
+
+        if self.erase:
+            cmd.append("-E")
+
+        if self.verify:
+            cmd.append("-V")
+            # cmd.append("-YP")
+
+        self.logger.info("Running: %s", " ".join(shlex.quote(p) for p in cmd))
+        self.check_call(cmd)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -39,6 +39,7 @@ def test_runner_imports():
         'minichlink',
         'misc-flasher',
         'mpcli',
+        'mplab_ipe',
         'native',
         'nrfjprog',
         'nrfutil',


### PR DESCRIPTION
- Adds support for flashing microchip devices using the MPLAB IPE by adding it as a west runner.
- Uses the mplab_ipe runner to flash pic32cx_sg41_cult board.
- Tested on linux machine and used `MPLAB X IPE v6.30`