### PR TITLE
boards: arm: blackpill_u585ci: add flash partitions

### DIFF
--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Michal Piekos
+ * Copyright (c) 2026 Jordano Iqbal Darmawan
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +23,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {
@@ -54,6 +56,34 @@
 
 	zephyr,user {
 		io-channels = <&adc1 16>, <&adc4 18>;
+	};
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(928)>;
+		};
+
+		slot1_partition: partition@f8000 {
+			label = "image-1";
+			reg = <0x000f8000 DT_SIZE_K(928)>;
+		};
+
+		scratch_partition: partition@1e0000 {
+			label = "image-scratch";
+			reg = <0x001e0000 DT_SIZE_K(128)>;
+		};
 	};
 };
 


### PR DESCRIPTION
Define the fixed-partitions layout for the WeAct Blackpill U585CI to enable MCUboot.

**Testing**
* **Hardware:** WeAct Blackpill STM32U585CI
* **Verification:** Confirmed the partition table is correctly parsed by MCUboot. Verified that the primary image is identified at the correct offset (0x10000) and the application boots successfully.

**Console Log Evidence:**
```
*** Booting MCUboot v2.3.0-33-gd9c2ba153128 ***
*** Using Zephyr OS build v4.3.0-6216-gac63d0e0a8de ***
I: Starting bootloader
I: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Boot source: primary slot
I: Image index: 0, Swap type: none
I: Bootloader chainload address offset: 0x10000
I: Image version: v0.0.0
*** Booting Zephyr OS build v4.3.0-6216-gac63d0e0a8de ***
LED toggled 1 times
LED toggled 2 times
LED toggled 3 times
```