### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -329,7 +329,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 9eac8cb5f4fedb3500986c5877277ef80606c4b0
+      revision: cf5810201c84d6e266aeda2abdab80854066ac08
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
west.yml: MCUboot synchronization from upstream
    
Update Zephyr fork of MCUboot to revision:
  cf5810201c84d6e266aeda2abdab80854066ac08
    
Brings following Zephyr relevant fixes:
    
  - cf581020 boot: zephyr: use MBEDTLS_VERSION_4_x to select crypto Mbed TLS legacy support
  - 8a1109bb Revert "boot: zephyr: kconfig: fix detection of Mbed TLS 4"
  - e9c87d96 boot: zephyr: separate Espressif do_boot from Xtensa path

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.