### PR TITLE
cmake: mcuboot: allow extending imgtool args with property

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -117,6 +117,11 @@ function(zephyr_mcuboot_tasks)
     set(imgtool_args)
   endif()
 
+  get_property(extra_imgtool_args_prop GLOBAL PROPERTY mcuboot_extra_imgtool_args)
+  if(extra_imgtool_args_prop)
+    list(APPEND imgtool_args ${extra_imgtool_args_prop})
+  endif()
+
   if(NOT "${keyfile}" STREQUAL "")
     set(imgtool_args --key "${keyfile}" ${imgtool_args})
   endif()


### PR DESCRIPTION
Allow additional imgtool arguments to be added by setting the global 'mcuboot_extra_imgtool_args' property, for example:

set_property(GLOBAL APPEND PROPERTY mcuboot_extra_imgtool_args
  --custom-tlv 0xA1 01234567
)

This works in a similar way to the
CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS option but gives a bit more flexibility in how/where it is specified.

The motivating use case for this change is to be able to add custom vendor specific TLVs as inputs to the imgtool signing command by adding --custom-tlv arguments. As these TLVs might be generated by the build system, the existing kconfig interface did not seem a good fit for this use case.