### PR TITLE
net: openthread: Add missing CMake linkage to mbed TLS

### DIFF
--- a/modules/openthread/platform/CMakeLists.txt
+++ b/modules/openthread/platform/CMakeLists.txt
@@ -44,3 +44,5 @@ if(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
   zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/l2/openthread)
   zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/dns)
 endif()
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)


### PR DESCRIPTION
OpenThread platform lib (psa_crypto.c specifically) needs access to mbed TLS headers, therefore add explicit linkage in the library to avoid build issues.

Fixes #104096