### PR TITLE
Bluetooth: ISO: Improve validate_send for conn state

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -905,12 +905,13 @@ static int validate_send(const struct bt_iso_chan *chan, const struct net_buf *b
 
 	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
 
-	if (chan->state != BT_ISO_STATE_CONNECTED) {
+	iso_conn = chan->iso;
+	if (iso_conn == NULL || iso_conn->state != BT_CONN_CONNECTED ||
+	    chan->state != BT_ISO_STATE_CONNECTED) {
 		LOG_DBG("Channel %p not connected", chan);
 		return -ENOTCONN;
 	}
 
-	iso_conn = chan->iso;
 	if (!iso_conn->iso.info.can_send) {
 		LOG_DBG("Channel %p not able to send", chan);
 		return -EINVAL;


### PR DESCRIPTION
ISO connections basically have 2 connection states: 1 for the `bt_iso_chan`, and one for the underlying `bt_conn`. Due to how hci_disconn_complete_prio works, these may be out of sync while disconnecting, and
bt_iso_chan_send could return 0 after we have received a disconnect event from the controller. In this case the number of pending SDUs in the host for the ISO channel could be non-0, which could cause issues.