### PR TITLE
Bluetooth: ISO: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2020 Intel Corporation
- * Copyright (c) 2021-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,7 +28,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -249,20 +248,19 @@ static int validate_iso_setup_data_path_parms(const struct bt_iso_chan *chan, ui
 {
 	struct bt_conn *iso;
 
-	CHECKIF(chan == NULL) {
+	if (chan == NULL) {
 		LOG_DBG("chan is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(path == NULL) {
+	if (path == NULL) {
 		LOG_DBG("path is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(dir != BT_HCI_DATAPATH_DIR_HOST_TO_CTLR &&
-		dir != BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
+	if (dir != BT_HCI_DATAPATH_DIR_HOST_TO_CTLR && dir != BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		LOG_DBG("Invalid dir: %u", dir);
 
 		return -EINVAL;
@@ -287,27 +285,26 @@ static int validate_iso_setup_data_path_parms(const struct bt_iso_chan *chan, ui
 		return -EINVAL;
 	}
 
-	CHECKIF(path->pid != BT_ISO_DATA_PATH_HCI &&
-		!IN_RANGE(path->pid, BT_ISO_DATA_PATH_VS_ID_MIN, BT_ISO_DATA_PATH_VS_ID_MAX)) {
+	if (path->pid != BT_ISO_DATA_PATH_HCI &&
+	    !IN_RANGE(path->pid, BT_ISO_DATA_PATH_VS_ID_MIN, BT_ISO_DATA_PATH_VS_ID_MAX)) {
 		LOG_DBG("Invalid pid %u", path->pid);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(path->format > BT_HCI_CODING_FORMAT_G729A &&
-		path->format != BT_HCI_CODING_FORMAT_VS) {
+	if (path->format > BT_HCI_CODING_FORMAT_G729A && path->format != BT_HCI_CODING_FORMAT_VS) {
 		LOG_DBG("Invalid format %u", path->format);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(path->delay > BT_ISO_CONTROLLER_DELAY_MAX) {
+	if (path->delay > BT_ISO_CONTROLLER_DELAY_MAX) {
 		LOG_DBG("Invalid delay: %u", path->delay);
 
 		return -EINVAL;
 	}
 
-	CHECKIF(path->cc_len > 0U && path->cc == NULL) {
+	if (path->cc_len > 0U && path->cc == NULL) {
 		LOG_DBG("No CC provided for CC length %u", path->cc_len);
 
 		return -EINVAL;
@@ -383,14 +380,13 @@ static int validate_iso_remove_data_path(const struct bt_iso_chan *chan, uint8_t
 {
 	struct bt_conn *iso;
 
-	CHECKIF(chan == NULL) {
+	if (chan == NULL) {
 		LOG_DBG("chan is NULL");
 
 		return -EINVAL;
 	}
 
-	CHECKIF(dir != BT_HCI_DATAPATH_DIR_HOST_TO_CTLR &&
-		dir != BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
+	if (dir != BT_HCI_DATAPATH_DIR_HOST_TO_CTLR && dir != BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		LOG_DBG("Invalid dir: %u", dir);
 
 		return -EINVAL;
@@ -613,17 +609,17 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, enum bt_iso_state state)
 
 int bt_iso_chan_get_info(const struct bt_iso_chan *chan, struct bt_iso_info *info)
 {
-	CHECKIF(chan == NULL) {
+	if (chan == NULL) {
 		LOG_DBG("chan is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(chan->iso == NULL) {
+	if (chan->iso == NULL) {
 		LOG_DBG("chan->iso is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(info == NULL) {
+	if (info == NULL) {
 		LOG_DBG("info is NULL");
 		return -EINVAL;
 	}
@@ -906,7 +902,7 @@ static int validate_send(const struct bt_iso_chan *chan, const struct net_buf *b
 	const struct bt_conn *iso_conn;
 	uint16_t max_data_len;
 
-	CHECKIF(!chan || !buf) {
+	if (!chan || !buf) {
 		LOG_DBG("Invalid parameters: chan %p buf %p", chan, buf);
 		return -EINVAL;
 	}
@@ -1055,22 +1051,22 @@ int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_inf
 	struct net_buf *rsp = NULL;
 	int err;
 
-	CHECKIF(chan == NULL) {
+	if (chan == NULL) {
 		LOG_DBG("chan is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(chan->iso == NULL) {
+	if (chan->iso == NULL) {
 		LOG_DBG("chan->iso is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(info == NULL) {
+	if (info == NULL) {
 		LOG_DBG("info is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(chan->state != BT_ISO_STATE_CONNECTED) {
+	if (chan->state != BT_ISO_STATE_CONNECTED) {
 		return -ENOTCONN;
 	}
 
@@ -1108,12 +1104,12 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 {
 	int err;
 
-	CHECKIF(!chan) {
+	if (!chan) {
 		LOG_DBG("Invalid parameter: chan %p", chan);
 		return -EINVAL;
 	}
 
-	CHECKIF(chan->iso == NULL) {
+	if (chan->iso == NULL) {
 		LOG_DBG("Channel has not been initialized in a CIG");
 		return -EINVAL;
 	}
@@ -1417,7 +1413,7 @@ void hci_le_cis_established_v2(struct net_buf *buf)
 #if defined(CONFIG_BT_ISO_PERIPHERAL)
 int bt_iso_server_register(struct bt_iso_server *server)
 {
-	CHECKIF(!server) {
+	if (!server) {
 		LOG_DBG("Invalid parameter: server %p", server);
 		return -EINVAL;
 	}
@@ -1453,7 +1449,7 @@ int bt_iso_server_register(struct bt_iso_server *server)
 
 int bt_iso_server_unregister(struct bt_iso_server *server)
 {
-	CHECKIF(!server) {
+	if (!server) {
 		LOG_DBG("Invalid parameter: server %p", server);
 		return -EINVAL;
 	}
@@ -1473,7 +1469,7 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 	struct bt_iso_chan *chan;
 	int err;
 
-	CHECKIF(!iso || iso->type != BT_CONN_TYPE_ISO) {
+	if (!iso || iso->type != BT_CONN_TYPE_ISO) {
 		LOG_DBG("Invalid parameters: iso %p iso->type %u", iso, iso ? iso->type : 0);
 		return -EINVAL;
 	}
@@ -2139,12 +2135,12 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
 	bool advanced = false;
 	int i;
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(out_cig == NULL) {
+	if (out_cig == NULL) {
 		LOG_DBG("out_cig is NULL");
 		return -EINVAL;
 	}
@@ -2157,12 +2153,12 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
 	}
 
 	/* TBD: Should we allow creating empty CIGs? */
-	CHECKIF(param->cis_channels == NULL) {
+	if (param->cis_channels == NULL) {
 		LOG_DBG("NULL CIS channels");
 		return -EINVAL;
 	}
 
-	CHECKIF(param->num_cis == 0) {
+	if (param->num_cis == 0) {
 		LOG_DBG("Invalid number of CIS %u", param->num_cis);
 		return -EINVAL;
 	}
@@ -2171,7 +2167,7 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
 	advanced = is_advanced_cig_param(param);
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 
-	CHECKIF(!valid_cig_param(param, advanced, NULL)) {
+	if (!valid_cig_param(param, advanced, NULL)) {
 		LOG_DBG("Invalid CIG params");
 		return -EINVAL;
 	}
@@ -2256,12 +2252,12 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig, const struct bt_iso_cig_param
 	struct net_buf *rsp = NULL;
 	int err;
 
-	CHECKIF(cig == NULL) {
+	if (cig == NULL) {
 		LOG_DBG("cig is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}
@@ -2275,7 +2271,7 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig, const struct bt_iso_cig_param
 	advanced = is_advanced_cig_param(param);
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 
-	CHECKIF(!valid_cig_param(param, advanced, cig)) {
+	if (!valid_cig_param(param, advanced, cig)) {
 		LOG_DBG("Invalid CIG params");
 		return -EINVAL;
 	}
@@ -2342,7 +2338,7 @@ int bt_iso_cig_terminate(struct bt_iso_cig *cig)
 {
 	int err;
 
-	CHECKIF(cig == NULL) {
+	if (cig == NULL) {
 		LOG_DBG("cig is NULL");
 		return -EINVAL;
 	}
@@ -2570,33 +2566,33 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 {
 	int err;
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(count == 0) {
+	if (count == 0) {
 		LOG_DBG("Invalid count %zu", count);
 		return -EINVAL;
 	}
 
-	CHECKIF(count > CONFIG_BT_ISO_MAX_CHAN) {
+	if (count > CONFIG_BT_ISO_MAX_CHAN) {
 		return -EINVAL;
 	}
 
 	/* Validate input */
 	for (size_t i = 0; i < count; i++) {
-		CHECKIF(param[i].iso_chan == NULL) {
+		if (param[i].iso_chan == NULL) {
 			LOG_DBG("[%zu]: Invalid iso (%p)", i, param[i].iso_chan);
 			return -EINVAL;
 		}
 
-		CHECKIF(param[i].acl == NULL) {
+		if (param[i].acl == NULL) {
 			LOG_DBG("[%zu]: Invalid acl (%p)", i, param[i].acl);
 			return -EINVAL;
 		}
 
-		CHECKIF((param[i].acl->type & BT_CONN_TYPE_LE) == 0) {
+		if ((param[i].acl->type & BT_CONN_TYPE_LE) == 0) {
 			LOG_DBG("[%zu]: acl type (%u) shall be an LE connection", i,
 				param[i].acl->type);
 			return -EINVAL;
@@ -2785,7 +2781,7 @@ static int big_init_bis(struct bt_iso_big *big, struct bt_iso_chan *bis, uint8_t
 
 int bt_iso_big_register_cb(struct bt_iso_big_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		LOG_DBG("cb is NULL");
 
 		return -EINVAL;
@@ -2955,13 +2951,13 @@ static bool is_advanced_big_param(const struct bt_iso_big_create_param *param)
 
 static bool valid_big_param(const struct bt_iso_big_create_param *param, bool advanced)
 {
-	CHECKIF(!param->bis_channels) {
+	if (!param->bis_channels) {
 		LOG_DBG("NULL BIS channels");
 
 		return false;
 	}
 
-	CHECKIF(!param->num_bis) {
+	if (!param->num_bis) {
 		LOG_DBG("Invalid number of BIS %u", param->num_bis);
 
 		return false;
@@ -2970,7 +2966,7 @@ static bool valid_big_param(const struct bt_iso_big_create_param *param, bool ad
 	for (uint8_t i = 0; i < param->num_bis; i++) {
 		struct bt_iso_chan *bis = param->bis_channels[i];
 
-		CHECKIF(bis == NULL) {
+		if (bis == NULL) {
 			LOG_DBG("bis_channels[%u]: NULL channel", i);
 
 			return false;
@@ -2982,49 +2978,48 @@ static bool valid_big_param(const struct bt_iso_big_create_param *param, bool ad
 			return false;
 		}
 
-		CHECKIF(bis->qos == NULL) {
+		if (bis->qos == NULL) {
 			LOG_DBG("bis_channels[%u]: qos is NULL", i);
 
 			return false;
 		}
 
-		CHECKIF(bis->qos->tx == NULL ||
-			!valid_chan_io_qos(bis->qos->tx, true, true, advanced)) {
+		if (bis->qos->tx == NULL ||
+		    !valid_chan_io_qos(bis->qos->tx, true, true, advanced)) {
 			LOG_DBG("bis_channels[%u]: Invalid QOS", i);
 
 			return false;
 		}
 	}
 
-	CHECKIF(param->framing != BT_ISO_FRAMING_UNFRAMED &&
-		param->framing != BT_ISO_FRAMING_FRAMED) {
+	if (param->framing != BT_ISO_FRAMING_UNFRAMED && param->framing != BT_ISO_FRAMING_FRAMED) {
 		LOG_DBG("Invalid framing parameter: %u", param->framing);
 
 		return false;
 	}
 
-	CHECKIF(param->packing != BT_ISO_PACKING_SEQUENTIAL &&
-		param->packing != BT_ISO_PACKING_INTERLEAVED) {
+	if (param->packing != BT_ISO_PACKING_SEQUENTIAL &&
+	    param->packing != BT_ISO_PACKING_INTERLEAVED) {
 		LOG_DBG("Invalid packing parameter: %u", param->packing);
 
 		return false;
 	}
 
-	CHECKIF(param->num_bis > BT_ISO_MAX_GROUP_ISO_COUNT ||
-		param->num_bis > CONFIG_BT_ISO_MAX_CHAN) {
+	if (param->num_bis > BT_ISO_MAX_GROUP_ISO_COUNT ||
+	    param->num_bis > CONFIG_BT_ISO_MAX_CHAN) {
 		LOG_DBG("num_bis (%u) shall be lower than: %u", param->num_bis,
 			MAX(CONFIG_BT_ISO_MAX_CHAN, BT_ISO_MAX_GROUP_ISO_COUNT));
 
 		return false;
 	}
 
-	CHECKIF(!IN_RANGE(param->interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
+	if (!IN_RANGE(param->interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
 		LOG_DBG("Invalid interval: %u", param->interval);
 
 		return false;
 	}
 
-	CHECKIF(!advanced && !IN_RANGE(param->latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
+	if (!advanced && !IN_RANGE(param->latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
 		LOG_DBG("Invalid latency: %u", param->latency);
 
 		return false;
@@ -3032,20 +3027,20 @@ static bool valid_big_param(const struct bt_iso_big_create_param *param, bool ad
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	if (advanced) {
-		CHECKIF(!IN_RANGE(param->irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX)) {
+		if (!IN_RANGE(param->irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX)) {
 			LOG_DBG("Invalid IRC %u", param->irc);
 
 			return false;
 		}
 
-		CHECKIF(!IN_RANGE(param->pto, BT_ISO_PTO_MIN, BT_ISO_PTO_MAX)) {
+		if (!IN_RANGE(param->pto, BT_ISO_PTO_MIN, BT_ISO_PTO_MAX)) {
 			LOG_DBG("Invalid PTO %u", param->pto);
 
 			return false;
 		}
 
-		CHECKIF(!IN_RANGE(param->iso_interval, BT_ISO_ISO_INTERVAL_MIN,
-				  BT_ISO_ISO_INTERVAL_MAX)) {
+		if (!IN_RANGE(param->iso_interval, BT_ISO_ISO_INTERVAL_MIN,
+			      BT_ISO_ISO_INTERVAL_MAX)) {
 			LOG_DBG("Invalid ISO interval %u", param->iso_interval);
 
 			return false;
@@ -3064,17 +3059,17 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 	struct bt_iso_big *big;
 	bool advanced = false;
 
-	CHECKIF(padv == NULL) {
+	if (padv == NULL) {
 		LOG_DBG("padv is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(out_big == NULL) {
+	if (out_big == NULL) {
 		LOG_DBG("out_big is NULL");
 		return -EINVAL;
 	}
@@ -3287,7 +3282,7 @@ int bt_iso_big_terminate(struct bt_iso_big *big)
 	struct bt_iso_chan *bis;
 	int err;
 
-	CHECKIF(big == NULL) {
+	if (big == NULL) {
 		LOG_DBG("big is NULL");
 		return -EINVAL;
 	}
@@ -3490,17 +3485,17 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 	struct bt_iso_big *big;
 	uint32_t bitfield_copy;
 
-	CHECKIF(sync == NULL) {
+	if (sync == NULL) {
 		LOG_DBG("sync is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(out_big == NULL) {
+	if (out_big == NULL) {
 		LOG_DBG("out_big is NULL");
 		return -EINVAL;
 	}
@@ -3510,28 +3505,28 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 		return -EINVAL;
 	}
 
-	CHECKIF(param->mse > BT_ISO_SYNC_MSE_MAX) {
+	if (param->mse > BT_ISO_SYNC_MSE_MAX) {
 		LOG_DBG("Invalid MSE 0x%02x", param->mse);
 		return -EINVAL;
 	}
 
-	CHECKIF(param->sync_timeout < BT_ISO_SYNC_TIMEOUT_MIN ||
-		param->sync_timeout > BT_ISO_SYNC_TIMEOUT_MAX) {
+	if (param->sync_timeout < BT_ISO_SYNC_TIMEOUT_MIN ||
+	    param->sync_timeout > BT_ISO_SYNC_TIMEOUT_MAX) {
 		LOG_DBG("Invalid sync timeout 0x%04x", param->sync_timeout);
 		return -EINVAL;
 	}
 
-	CHECKIF(!BT_ISO_VALID_BIS_BITFIELD(param->bis_bitfield)) {
+	if (!BT_ISO_VALID_BIS_BITFIELD(param->bis_bitfield)) {
 		LOG_DBG("Invalid BIS bitfield 0x%08x", param->bis_bitfield);
 		return -EINVAL;
 	}
 
-	CHECKIF(!param->bis_channels) {
+	if (!param->bis_channels) {
 		LOG_DBG("NULL BIS channels");
 		return -EINVAL;
 	}
 
-	CHECKIF(!param->num_bis) {
+	if (!param->num_bis) {
 		LOG_DBG("Invalid number of BIS %u", param->num_bis);
 		return -EINVAL;
 	}
@@ -3539,7 +3534,7 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 	for (uint8_t i = 0; i < param->num_bis; i++) {
 		struct bt_iso_chan *param_bis = param->bis_channels[i];
 
-		CHECKIF(param_bis == NULL) {
+		if (param_bis == NULL) {
 			LOG_DBG("bis_channels[%u]: NULL channel", i);
 			return -EINVAL;
 		}
@@ -3549,12 +3544,12 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 			return -EALREADY;
 		}
 
-		CHECKIF(param_bis->qos == NULL) {
+		if (param_bis->qos == NULL) {
 			LOG_DBG("bis_channels[%u]: qos is NULL", i);
 			return -EINVAL;
 		}
 
-		CHECKIF(param_bis->qos->rx == NULL) {
+		if (param_bis->qos->rx == NULL) {
 			LOG_DBG("bis_channels[%u]: qos->rx is NULL", i);
 			return -EINVAL;
 		}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.