### PR TITLE
drivers: modem: HL7800: TCP socket fixes

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3982,6 +3982,11 @@ static bool on_cmd_sock_notif(struct net_buf **buf, uint16_t len)
 		err = true;
 		sock->error = -ENOTCONN;
 		break;
+	case HL7800_TCP_CONN:
+		/* Connection failed/refused on this socket; do NOT drop network. */
+		err = true;
+		sock->error = -ECONNREFUSED;
+		break;
 	default:
 		iface_ctx.network_dropped = true;
 		err = true;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -5854,11 +5854,6 @@ static int configure_TCP_socket(struct hl7800_socket *sock)
 	char cmd_cfg[sizeof("AT+KTCPCFG=#,#,\"" IPV6_ADDR_FORMAT "\",#####,,,,#,,#")];
 	int dst_port = -1;
 	int af;
-	bool restore_on_boot = false;
-
-#ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
-	restore_on_boot = true;
-#endif
 
 	if (sock->dst.sa_family == NET_AF_INET6) {
 		af = MDM_HL7800_SOCKET_AF_IPV6;
@@ -5872,8 +5867,8 @@ static int configure_TCP_socket(struct hl7800_socket *sock)
 
 	sock->socket_id = MDM_CREATE_SOCKET_ID;
 
-	snprintk(cmd_cfg, sizeof(cmd_cfg), "AT+KTCPCFG=%d,%d,\"%s\",%u,,,,%d,,%d", 1, 0,
-		 hl7800_sprint_ip_addr(&sock->dst), dst_port, af, restore_on_boot);
+	snprintk(cmd_cfg, sizeof(cmd_cfg), "AT+KTCPCFG=%d,%d,\"%s\",%u,,,,%d,,0", 1, 0,
+		 hl7800_sprint_ip_addr(&sock->dst), dst_port, af);
 	ret = send_at_cmd(sock, cmd_cfg, MDM_CMD_SEND_TIMEOUT, 0, false);
 	if (ret < 0) {
 		LOG_ERR("AT+KTCPCFG ret:%d", ret);
@@ -5890,11 +5885,6 @@ static int configure_UDP_socket(struct hl7800_socket *sock)
 	int ret = 0;
 	char cmd[sizeof("AT+KUDPCFG=1,0,,,,,0,#")];
 	int af;
-	bool restore_on_boot = false;
-
-#ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
-	restore_on_boot = true;
-#endif
 
 	sock->socket_id = MDM_CREATE_SOCKET_ID;
 
@@ -5906,7 +5896,7 @@ static int configure_UDP_socket(struct hl7800_socket *sock)
 		return -EINVAL;
 	}
 
-	snprintk(cmd, sizeof(cmd), "AT+KUDPCFG=1,0,,,,,%d,%d", af, restore_on_boot);
+	snprintk(cmd, sizeof(cmd), "AT+KUDPCFG=1,0,,,,,%d,0", af);
 	ret = send_at_cmd(sock, cmd, MDM_CMD_SEND_TIMEOUT, 0, false);
 	if (ret < 0) {
 		LOG_ERR("AT+KUDPCFG ret:%d", ret);

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -3425,6 +3425,8 @@ static void iface_status_work_cb(struct k_work *work)
 	if ((iface_ctx.iface && !net_if_is_up(iface_ctx.iface)) ||
 	    (iface_ctx.low_power_mode == HL7800_LPM_PSM && state == HL7800_OUT_OF_COVERAGE)) {
 		hl7800_stop_rssi_work();
+		/* Avoid deadlock: closing sockets can re-enter hl7800. */
+		hl7800_unlock();
 		notify_all_tcp_sockets_closed();
 	} else if (iface_ctx.iface && net_if_is_up(iface_ctx.iface)) {
 		hl7800_start_rssi_work();


### PR DESCRIPTION
# treat TCP_CONN notif as per-socket error

TCP connect refused triggers +K**P_NOTIF ,5.
The current handler falls through to default, marks network_dropped,
and later closes all sockets, taking down unrelated
connections (e.g., MQTT).

# unlock before closing all sockets

iface_status_work_cb() calls notify_all_tcp_sockets_closed() while
holding hl7800_lock(). The close-all path can re-enter hl7800 via
socket callbacks, causing a lock inversion deadlock.

# do not restore sockets on boot

HL7800 only supports restoring 1 socket on boot. This means,
only the first socket created can be restored.
This isn't very useful, so never restore sockets on boot.
The driver already handles recreating sockets when
low power modes are used.