### PR TITLE
Bluetooth: TBS: Add bt_tbs_client_get_by_index 

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -164,6 +164,7 @@ New APIs and options
     * :c:member:`bt_ccp_call_control_client_cb.user_data`
     * :kconfig:option:`CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH`
     * :c:member:`bt_cap_handover_cb.unicast_to_broadcast_created`
+    * :c:func:`bt_tbs_client_get_by_index`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -1128,6 +1128,16 @@ int bt_tbs_client_register_cb(struct bt_tbs_client_cb *cbs);
 struct bt_tbs_instance *bt_tbs_client_get_by_ccid(const struct bt_conn *conn,
 						  uint8_t ccid);
 
+/**
+ * @brief Look up Telephone Bearer Service instance by index
+ *
+ * @param conn The connection to the TBS server.
+ * @param index The index to lookup a service instance for.
+ *
+ * @return Pointer to a Telephone Bearer Service instance if found else NULL.
+ */
+struct bt_tbs_instance *bt_tbs_client_get_by_index(const struct bt_conn *conn, uint8_t index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -102,7 +102,7 @@ static struct bt_tbs_instance *tbs_instance_find(struct bt_tbs_server_inst *serv
 	return NULL;
 }
 
-static struct bt_tbs_instance *tbs_inst_by_index(struct bt_conn *conn, uint8_t index)
+static struct bt_tbs_instance *tbs_inst_by_index(const struct bt_conn *conn, uint8_t index)
 {
 	struct bt_tbs_server_inst *server;
 
@@ -2518,5 +2518,16 @@ struct bt_tbs_instance *bt_tbs_client_get_by_ccid(const struct bt_conn *conn,
 	server = &srv_insts[bt_conn_index(conn)];
 
 	return tbs_instance_find(server, tbs_instance_ccid_is_eq, UINT_TO_POINTER(ccid));
+}
+
+struct bt_tbs_instance *bt_tbs_client_get_by_index(const struct bt_conn *conn, uint8_t index)
+
+{
+	if (conn == NULL) {
+		LOG_DBG("conn was NULL");
+		return NULL;
+	}
+
+	return tbs_inst_by_index(conn, index);
 }
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -19,6 +19,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "../../subsys/bluetooth/audio/tbs_internal.h"
 #include "btp/btp.h"
@@ -26,11 +27,7 @@
 #define LOG_MODULE_NAME bttester_ccp
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
-struct btp_ccp_chrc_handles_ev tbs_handles;
-struct bt_tbs_instance *tbs_inst;
 static uint8_t call_index;
-static uint8_t inst_ccid;
-static bool send_ev;
 static uint8_t tbs_register_bearer(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len);
 
 static uint8_t ccp_supported_commands(const void *cmd, uint16_t cmd_len,
@@ -55,26 +52,31 @@ static void tbs_client_discovered_ev(int err, uint8_t tbs_count, bool gtbs_found
 	tester_event(BTP_SERVICE_ID_CCP, BTP_CCP_EV_DISCOVERED, &ev, sizeof(ev));
 }
 
-static void tbs_chrc_handles_ev(struct btp_ccp_chrc_handles_ev *tbs_handles)
+static void tbs_chrc_handles_ev(const struct bt_tbs_instance *tbs_inst)
 {
 	struct btp_ccp_chrc_handles_ev ev;
 
-	ev.provider_name = sys_cpu_to_le16(tbs_handles->provider_name);
-	ev.bearer_uci = sys_cpu_to_le16(tbs_handles->bearer_uci);
-	ev.bearer_technology = sys_cpu_to_le16(tbs_handles->bearer_technology);
-	ev.uri_list = sys_cpu_to_le16(tbs_handles->uri_list);
-	ev.signal_strength = sys_cpu_to_le16(tbs_handles->signal_strength);
-	ev.signal_interval = sys_cpu_to_le16(tbs_handles->signal_interval);
-	ev.current_calls = sys_cpu_to_le16(tbs_handles->current_calls);
-	ev.ccid = sys_cpu_to_le16(tbs_handles->ccid);
-	ev.status_flags = sys_cpu_to_le16(tbs_handles->status_flags);
-	ev.bearer_uri = sys_cpu_to_le16(tbs_handles->bearer_uri);
-	ev.call_state = sys_cpu_to_le16(tbs_handles->call_state);
-	ev.control_point = sys_cpu_to_le16(tbs_handles->control_point);
-	ev.optional_opcodes = sys_cpu_to_le16(tbs_handles->optional_opcodes);
-	ev.termination_reason = sys_cpu_to_le16(tbs_handles->termination_reason);
-	ev.incoming_call = sys_cpu_to_le16(tbs_handles->incoming_call);
-	ev.friendly_name = sys_cpu_to_le16(tbs_handles->friendly_name);
+	if (tbs_inst == NULL) {
+		LOG_ERR("Could not generate event for NULL TBS inst");
+		return;
+	}
+
+	ev.provider_name = sys_cpu_to_le16(tbs_inst->name_sub_params.value_handle);
+	ev.bearer_uci = sys_cpu_to_le16(tbs_inst->bearer_uci_handle);
+	ev.bearer_technology = sys_cpu_to_le16(tbs_inst->technology_sub_params.value_handle);
+	ev.uri_list = sys_cpu_to_le16(tbs_inst->uri_list_handle);
+	ev.signal_strength = sys_cpu_to_le16(tbs_inst->signal_strength_sub_params.value_handle);
+	ev.signal_interval = sys_cpu_to_le16(tbs_inst->signal_interval_handle);
+	ev.current_calls = sys_cpu_to_le16(tbs_inst->current_calls_sub_params.value_handle);
+	ev.ccid = sys_cpu_to_le16(tbs_inst->ccid_handle);
+	ev.status_flags = sys_cpu_to_le16(tbs_inst->status_flags_sub_params.value_handle);
+	ev.bearer_uri = sys_cpu_to_le16(tbs_inst->in_target_uri_sub_params.value_handle);
+	ev.call_state = sys_cpu_to_le16(tbs_inst->call_state_sub_params.value_handle);
+	ev.control_point = sys_cpu_to_le16(tbs_inst->call_cp_sub_params.value_handle);
+	ev.optional_opcodes = sys_cpu_to_le16(tbs_inst->optional_opcodes_handle);
+	ev.termination_reason = sys_cpu_to_le16(tbs_inst->termination_reason_handle);
+	ev.incoming_call = sys_cpu_to_le16(tbs_inst->incoming_call_sub_params.value_handle);
+	ev.friendly_name = sys_cpu_to_le16(tbs_inst->friendly_name_sub_params.value_handle);
 
 	tester_event(BTP_SERVICE_ID_CCP, BTP_CCP_EV_CHRC_HANDLES, &ev, sizeof(ev));
 }
@@ -144,11 +146,17 @@ static void tbs_client_discover_cb(struct bt_conn *conn, int err, uint8_t tbs_co
 
 	LOG_DBG("Discovered TBS - err (%u) GTBS (%u)", err, gtbs_found);
 
-	bt_tbs_client_read_ccid(conn, 0xFF);
-
 	tbs_client_discovered_ev(err, tbs_count, gtbs_found);
 
-	send_ev = true;
+	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT_GTBS) && gtbs_found) {
+		tbs_chrc_handles_ev(bt_tbs_client_get_by_index(conn, BT_TBS_GTBS_INDEX));
+	}
+
+	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT_TBS)) {
+		for (uint8_t i = 0U; i < tbs_count; i++) {
+			tbs_chrc_handles_ev(bt_tbs_client_get_by_index(conn, i));
+		}
+	}
 }
 
 typedef struct bt_tbs_client_call_state bt_tbs_client_call_state_t;
@@ -216,32 +224,6 @@ static void tbs_client_read_val_cb(struct bt_conn *conn, int err, uint8_t inst_i
 
 	tbs_client_chrc_val_ev(conn, err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS, inst_index,
 			       value);
-
-	if (send_ev == true) {
-		inst_ccid = value;
-
-		tbs_inst = bt_tbs_client_get_by_ccid(conn, inst_ccid);
-
-		tbs_handles.provider_name = tbs_inst->name_sub_params.value_handle;
-		tbs_handles.bearer_uci = tbs_inst->bearer_uci_handle;
-		tbs_handles.bearer_technology = tbs_inst->technology_sub_params.value_handle;
-		tbs_handles.uri_list = tbs_inst->uri_list_handle;
-		tbs_handles.signal_strength = tbs_inst->signal_strength_sub_params.value_handle;
-		tbs_handles.signal_interval = tbs_inst->signal_interval_handle;
-		tbs_handles.current_calls = tbs_inst->current_calls_sub_params.value_handle;
-		tbs_handles.ccid = tbs_inst->ccid_handle;
-		tbs_handles.status_flags = tbs_inst->status_flags_sub_params.value_handle;
-		tbs_handles.bearer_uri = tbs_inst->in_target_uri_sub_params.value_handle;
-		tbs_handles.call_state = tbs_inst->call_state_sub_params.value_handle;
-		tbs_handles.control_point = tbs_inst->call_cp_sub_params.value_handle;
-		tbs_handles.optional_opcodes = tbs_inst->optional_opcodes_handle;
-		tbs_handles.termination_reason = tbs_inst->termination_reason_handle;
-		tbs_handles.incoming_call = tbs_inst->incoming_call_sub_params.value_handle;
-		tbs_handles.friendly_name = tbs_inst->friendly_name_sub_params.value_handle;
-
-		tbs_chrc_handles_ev(&tbs_handles);
-		send_ev = false;
-	}
 }
 
 static void tbs_client_current_calls_cb(struct bt_conn *conn, int err, uint8_t inst_index,


### PR DESCRIPTION
Add function to get an instance pointer by index.
This works the same as bt_tbs_client_get_by_ccid except that
it uses the index instead of the CCID.