### PR TITLE
bindings: pic32cz-ca-dpll: drop compatible from child

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -86,8 +86,6 @@
 		compatible = "microchip,pic32cz-ca-dpll";
 
 		dpll0: dpll0 {
-			compatible = "microchip,pic32cz-ca-dpllchild";
-
 			subsystem = <CLOCK_MCHP_DPLL_ID_DPLL0>;
 			dpll-bandwidth-sel = "4mhz-10mhz";
 			dpll-ref-division-factor = <2>;

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
@@ -60,12 +60,10 @@
 				compatible = "microchip,pic32cz-ca-dpll";
 
 				dpll0: dpll0 {
-					compatible = "microchip,pic32cz-ca-dpllchild";
 					subsystem = <CLOCK_MCHP_DPLL_ID_DPLL0>;
 				};
 
 				dpll1: dpll1 {
-					compatible = "microchip,pic32cz-ca-dpllchild";
 					subsystem = <CLOCK_MCHP_DPLL_ID_DPLL1>;
 				};
 			};

--- a/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-dpll.yaml
+++ b/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-dpll.yaml
@@ -12,7 +12,6 @@ include: [base.yaml]
 compatible: "microchip,pic32cz-ca-dpll"
 
 child-binding:
-  compatible: "microchip,pic32cz-ca-dpllchild"
   properties:
     subsystem:
       type: int


### PR DESCRIPTION
The child node does not need a compatible, the child properties are inferred from the partent binding, plus this compatible is confusing the documentation, which is failing with:

/__w/zephyr/zephyr/doc/_build/src/boards/microchip/pic32c/pic32cz_ca80_cult/doc/index.rst:36: WARNING: 'dtcompatible' reference target not found: microchip,pic32cz-ca-dpllchild [ref.dtcompatible]
1417
