### PR TITLE
bluetooth: mesh: Reset in-memory cdb node state on deletion

### DIFF
--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -1053,8 +1053,12 @@ void bt_mesh_cdb_node_del(struct bt_mesh_cdb_node *node, bool store)
 	}
 
 	node->addr = BT_MESH_ADDR_UNASSIGNED;
+	node->num_elem = 0;
+	node->net_idx = 0;
+	memset(node->uuid, 0, sizeof(node->uuid));
 	bt_mesh_key_destroy(&node->dev_key);
 	memset(&node->dev_key, 0, sizeof(node->dev_key));
+	atomic_clear(node->flags);
 }
 
 void bt_mesh_cdb_node_update(struct bt_mesh_cdb_node *node, uint16_t addr,


### PR DESCRIPTION
Stale in-memory node data caused me problems today (uuid).

This PR makes `bt_mesh_cdb_node_del` clear all node metadata (`num_elem`, `net_idx`, `uuid`, `flags`) in addition to `addr` and `dev_key`, to prevent stale in-memory data after node deletion.

As far as I can tell, the freed node isn't used again until `bt_mesh_cdb_node_alloc` is called and the node is next in line.
So resetting everything should be fine.
