### PR TITLE
drivers: display: Add AC057TC1 6 Color E-Ink Display

### DIFF
--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CONFIG_SDL_DISPLAY)
 endif()
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_AC057TC1	display_ac057tc1.c)
 zephyr_library_sources_ifdef(CONFIG_CO5300 display_co5300.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_MCUX_DCNANO_LCDIF display_mcux_dcnano_lcdif.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_MCUX_ELCDIF display_mcux_elcdif.c)

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -21,6 +21,7 @@ module-str = display
 source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
+source "drivers/display/Kconfig.ac057tc1"
 source "drivers/display/Kconfig.co5300"
 source "drivers/display/Kconfig.dummy"
 source "drivers/display/Kconfig.gc9x01x"

--- a/drivers/display/Kconfig.ac057tc1
+++ b/drivers/display/Kconfig.ac057tc1
@@ -1,0 +1,10 @@
+# Copyright 2026 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config AC057TC1
+	bool "AC057TC1 display controller"
+	default y
+	depends on DT_HAS_EINK_AC057TC1_ENABLED
+	select MIPI_DBI
+	help
+	  Enable driver for AC057TC1 display controller.

--- a/drivers/display/display_ac057tc1.c
+++ b/drivers/display/display_ac057tc1.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2026 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT eink_ac057tc1
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/drivers/display/ac057tc1.h>
+#include <zephyr/drivers/mipi_dbi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(ac057tc1, CONFIG_DISPLAY_LOG_LEVEL);
+
+/* Timing constants */
+#define AC057TC1_RESET_DELAY      1
+#define AC057TC1_RESET_WAIT       200
+#define AC057TC1_BUSY_TIMEOUT     5000  /* 5 seconds for normal operations */
+#define AC057TC1_REFRESH_TIMEOUT  40000 /* 40 seconds for display refresh */
+#define AC057TC1_POWER_OFF_DELAY  200
+#define AC057TC1_INIT_DELAY       100
+#define AC057TC1_DEEP_SLEEP_DELAY 10
+#define AC057TC1_DEEP_SLEEP_WAIT  100
+
+/* Register definitions */
+#define AC057TC1_CMD_PANEL_SET          0x00
+#define AC057TC1_CMD_POWER_SET          0x01
+#define AC057TC1_CMD_POWER_OFF          0x02
+#define AC057TC1_CMD_POWER_OFF_SEQ      0x03
+#define AC057TC1_CMD_POWER_ON           0x04
+#define AC057TC1_CMD_BOOSTER_SOFTSTART  0x06
+#define AC057TC1_CMD_DEEP_SLEEP         0x07
+#define AC057TC1_CMD_DATA_START_TRANS   0x10
+#define AC057TC1_CMD_DISPLAY_REF        0x12
+#define AC057TC1_CMD_TEMP_SENSOR        0x40
+#define AC057TC1_CMD_TEMP_SENSOR_EN     0x41
+#define AC057TC1_CMD_VCOM_DATA_INTERVAL 0x50
+#define AC057TC1_CMD_TCON               0x60
+#define AC057TC1_CMD_RESOLUTION_SET     0x61
+#define AC057TC1_CMD_E3                 0xE3
+
+/* Deep sleep check byte */
+#define AC057TC1_DEEP_SLEEP_CHECK 0xA5
+
+/* Pixel format: 4 bits per pixel (one nibble per pixel, 2 pixels per byte) */
+#define AC057TC1_PIXELS_PER_BYTE 2
+
+struct ac057tc1_config {
+	const struct device *mipi_dev;
+	struct mipi_dbi_config dbi_config;
+	struct gpio_dt_spec busy_gpio;
+	uint16_t width;
+	uint16_t height;
+};
+
+struct ac057tc1_data {
+	bool blanking_on;
+	struct k_sem busy_sem;
+	struct gpio_callback busy_cb;
+};
+
+static inline int ac057tc1_write_cmd(const struct device *dev, uint8_t cmd, const uint8_t *data,
+				     size_t len)
+{
+	const struct ac057tc1_config *config = dev->config;
+
+	return mipi_dbi_command_write(config->mipi_dev, &config->dbi_config, cmd, data, len);
+}
+
+static inline int ac057tc1_write_cmd_uint8(const struct device *dev, uint8_t cmd, uint8_t data)
+{
+	return ac057tc1_write_cmd(dev, cmd, &data, 1);
+}
+
+static void ac057tc1_busy_cb(const struct device *gpio_dev, struct gpio_callback *cb, uint32_t pins)
+{
+	struct ac057tc1_data *data = CONTAINER_OF(cb, struct ac057tc1_data, busy_cb);
+
+	k_sem_give(&data->busy_sem);
+}
+
+static int ac057tc1_busy_wait(const struct device *dev, uint32_t timeout_ms)
+{
+	const struct ac057tc1_config *config = dev->config;
+	struct ac057tc1_data *data = dev->data;
+	int ret;
+
+	if (config->busy_gpio.port == NULL) {
+		LOG_WRN("Busy GPIO not configured, using fixed delay");
+		k_msleep(timeout_ms);
+		return 0;
+	}
+
+	if (!device_is_ready(config->busy_gpio.port)) {
+		LOG_WRN("Busy GPIO port not ready, using fixed delay");
+		k_msleep(timeout_ms);
+		return 0;
+	}
+
+	if (gpio_pin_get_dt(&config->busy_gpio) != 0) {
+		LOG_DBG("Busy GPIO already ready (HIGH)");
+		return 0;
+	}
+
+	k_sem_reset(&data->busy_sem);
+
+	ret = gpio_pin_interrupt_configure_dt(&config->busy_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure busy GPIO interrupt: %d", ret);
+		return ret;
+	}
+
+	ret = k_sem_take(&data->busy_sem, K_MSEC(timeout_ms));
+
+	gpio_pin_interrupt_configure_dt(&config->busy_gpio, GPIO_INT_DISABLE);
+
+	if (ret < 0) {
+		LOG_ERR("Timeout waiting for busy signal");
+		return -ETIMEDOUT;
+	}
+
+	LOG_DBG("Busy GPIO ready (HIGH)");
+	return 0;
+}
+
+static int ac057tc1_hw_init(const struct device *dev)
+{
+	const struct ac057tc1_config *config = dev->config;
+	int ret;
+
+	ret = mipi_dbi_reset(config->mipi_dev, AC057TC1_RESET_DELAY);
+	if (ret < 0) {
+		LOG_ERR("Failed to reset display: %d", ret);
+		return ret;
+	}
+	k_msleep(AC057TC1_RESET_WAIT);
+
+	ret = ac057tc1_busy_wait(dev, AC057TC1_BUSY_TIMEOUT);
+	if (ret < 0) {
+		LOG_ERR("Display not ready after reset");
+		return ret;
+	}
+
+	uint8_t panel_set[] = {0xEF, 0x08};
+
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_PANEL_SET, panel_set, sizeof(panel_set));
+	if (ret < 0) {
+		return ret;
+	}
+
+	uint8_t power_set[] = {0x37, 0x00, 0x05, 0x05};
+
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_POWER_SET, power_set, sizeof(power_set));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_POWER_OFF_SEQ, 0x00);
+	if (ret < 0) {
+		return ret;
+	}
+
+	uint8_t booster[] = {0xC7, 0xC7, 0x1D};
+
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_BOOSTER_SOFTSTART, booster, sizeof(booster));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_TEMP_SENSOR_EN, 0x00);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_VCOM_DATA_INTERVAL, 0x37);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_TCON, 0x20);
+	if (ret < 0) {
+		return ret;
+	}
+
+	uint8_t res_set[] = {(config->width >> 8) & 0xFF, config->width & 0xFF,
+			     (config->height >> 8) & 0xFF, config->height & 0xFF};
+
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_RESOLUTION_SET, res_set, sizeof(res_set));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_E3, 0xAA);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(AC057TC1_INIT_DELAY);
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_VCOM_DATA_INTERVAL, 0x37);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return mipi_dbi_release(config->mipi_dev, &config->dbi_config);
+}
+
+static int ac057tc1_deep_sleep(const struct device *dev)
+{
+	int ret;
+
+	k_msleep(AC057TC1_DEEP_SLEEP_DELAY);
+
+	ret = ac057tc1_write_cmd_uint8(dev, AC057TC1_CMD_DEEP_SLEEP, AC057TC1_DEEP_SLEEP_CHECK);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(AC057TC1_DEEP_SLEEP_WAIT);
+
+	return 0;
+}
+
+static int ac057tc1_init(const struct device *dev)
+{
+	const struct ac057tc1_config *config = dev->config;
+	struct ac057tc1_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("Initializing AC057TC1 display");
+
+	if (!device_is_ready(config->mipi_dev)) {
+		LOG_ERR("MIPI DBI device not ready");
+		return -ENODEV;
+	}
+
+	if (config->busy_gpio.port != NULL) {
+		if (!gpio_is_ready_dt(&config->busy_gpio)) {
+			LOG_ERR("Busy GPIO not ready");
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->busy_gpio, GPIO_INPUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure busy GPIO: %d", ret);
+			return ret;
+		}
+
+		/* Initialize semaphore for interrupt-driven busy wait */
+		k_sem_init(&data->busy_sem, 0, 1);
+
+		/* Set up GPIO callback for busy pin */
+		gpio_init_callback(&data->busy_cb, ac057tc1_busy_cb, BIT(config->busy_gpio.pin));
+		ret = gpio_add_callback(config->busy_gpio.port, &data->busy_cb);
+		if (ret < 0) {
+			LOG_ERR("Failed to add busy GPIO callback: %d", ret);
+			return ret;
+		}
+	}
+
+	data->blanking_on = true;
+
+	ret = ac057tc1_hw_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Hardware init failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("AC057TC1 display initialized (%ux%u)", config->width, config->height);
+
+	return 0;
+}
+
+static int ac057tc1_write(const struct device *dev, const uint16_t x, const uint16_t y,
+			  const struct display_buffer_descriptor *desc, const void *buf)
+{
+	const struct ac057tc1_config *config = dev->config;
+	struct ac057tc1_data *data = dev->data;
+	int ret;
+	size_t buf_len;
+
+	LOG_DBG("write x=%u y=%u w=%u h=%u pitch=%u", x, y, desc->width, desc->height, desc->pitch);
+
+	/* Validate parameters */
+	if (x != 0 || y != 0 || desc->width != config->width || desc->height != config->height) {
+		LOG_ERR("Partial updates not supported. Full screen writes only.");
+		return -ENOTSUP;
+	}
+
+	/* Calculate buffer length - 4 bits per pixel, 2 pixels per byte */
+	buf_len = (desc->width * desc->height) / AC057TC1_PIXELS_PER_BYTE;
+
+	if (buf == NULL || desc->buf_size < buf_len) {
+		LOG_ERR("Invalid buffer: buf=%p size=%u expected=%u", buf, desc->buf_size, buf_len);
+		return -EINVAL;
+	}
+
+	/* Wake panel from deep sleep if needed */
+	ret = ac057tc1_hw_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to wake panel: %d", ret);
+		return ret;
+	}
+
+	/* Set resolution */
+	uint8_t res_set[] = {(config->width >> 8) & 0xFF, config->width & 0xFF,
+			     (config->height >> 8) & 0xFF, config->height & 0xFF};
+
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_RESOLUTION_SET, res_set, sizeof(res_set));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Send pixel data with DATA_START_TRANS command */
+	ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_DATA_START_TRANS, buf, buf_len);
+	if (ret < 0) {
+		LOG_ERR("Failed to write display data: %d", ret);
+		return ret;
+	}
+
+	if (!data->blanking_on) {
+		ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_POWER_ON, NULL, 0);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Wait for power on */
+		ret = ac057tc1_busy_wait(dev, AC057TC1_BUSY_TIMEOUT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Display refresh */
+		ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_DISPLAY_REF, NULL, 0);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* 7-color e-ink displays take 20-40 seconds to refresh */
+		ret = ac057tc1_busy_wait(dev, AC057TC1_REFRESH_TIMEOUT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Power off after refresh */
+		ret = ac057tc1_write_cmd(dev, AC057TC1_CMD_POWER_OFF, NULL, 0);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Wait for power off - busy goes LOW when done */
+		k_msleep(AC057TC1_POWER_OFF_DELAY);
+
+		/* Put panel to deep sleep */
+		ret = ac057tc1_deep_sleep(dev);
+		if (ret < 0) {
+			LOG_WRN("Failed to enter deep sleep: %d", ret);
+		}
+	}
+
+	return mipi_dbi_release(config->mipi_dev, &config->dbi_config);
+}
+
+static int ac057tc1_blanking_on(const struct device *dev)
+{
+	struct ac057tc1_data *data = dev->data;
+
+	LOG_DBG("Blanking on");
+	data->blanking_on = true;
+
+	return 0;
+}
+
+static int ac057tc1_blanking_off(const struct device *dev)
+{
+	struct ac057tc1_data *data = dev->data;
+
+	LOG_DBG("Blanking off");
+	data->blanking_on = false;
+
+	return 0;
+}
+
+static void ac057tc1_get_capabilities(const struct device *dev, struct display_capabilities *caps)
+{
+	const struct ac057tc1_config *config = dev->config;
+
+	memset(caps, 0, sizeof(struct display_capabilities));
+	caps->x_resolution = config->width;
+	caps->y_resolution = config->height;
+	caps->supported_pixel_formats = PIXEL_FORMAT_L_4;
+	caps->current_pixel_format = PIXEL_FORMAT_L_4;
+	caps->screen_info = SCREEN_INFO_EPD;
+}
+
+static int ac057tc1_set_pixel_format(const struct device *dev, const enum display_pixel_format pf)
+{
+	if (pf == PIXEL_FORMAT_L_4) {
+		return 0;
+	}
+
+	LOG_ERR("Pixel format not supported");
+	return -ENOTSUP;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int ac057tc1_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		ret = ac057tc1_hw_init(dev);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		ret = ac057tc1_deep_sleep(dev);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+static DEVICE_API(display, ac057tc1_api) = {
+	.blanking_on = ac057tc1_blanking_on,
+	.blanking_off = ac057tc1_blanking_off,
+	.write = ac057tc1_write,
+	.get_capabilities = ac057tc1_get_capabilities,
+	.set_pixel_format = ac057tc1_set_pixel_format,
+};
+
+#define AC057TC1_DEFINE(inst)                                                                      \
+	static const struct ac057tc1_config ac057tc1_cfg_##inst = {                                \
+		.mipi_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                   \
+		.dbi_config =                                                                      \
+			{                                                                          \
+				.mode = MIPI_DBI_MODE_SPI_4WIRE,                                   \
+				.config = MIPI_DBI_SPI_CONFIG_DT_INST(                             \
+					inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),            \
+			},                                                                         \
+		.busy_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, busy_gpios, {0}),                      \
+		.width = DT_INST_PROP(inst, width),                                                \
+		.height = DT_INST_PROP(inst, height),                                              \
+	};                                                                                         \
+	static struct ac057tc1_data ac057tc1_data_##inst;                                          \
+	PM_DEVICE_DT_INST_DEFINE(inst, ac057tc1_pm_action);                                        \
+	DEVICE_DT_INST_DEFINE(inst, ac057tc1_init, PM_DEVICE_DT_INST_GET(inst),                    \
+			      &ac057tc1_data_##inst, &ac057tc1_cfg_##inst, POST_KERNEL,            \
+			      CONFIG_DISPLAY_INIT_PRIORITY, &ac057tc1_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AC057TC1_DEFINE)

--- a/dts/bindings/display/eink,ac057tc1.yaml
+++ b/dts/bindings/display/eink,ac057tc1.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+title: E-Ink AC057TC1 Display Controller
+
+description: |
+  Controller of E-Ink AC057TC1 (or (AB1024-EGA) 5.7-inch seven-color electrophoretic display.
+
+compatible: "eink,ac057tc1"
+
+include:
+  - display-controller.yaml
+  - name: mipi-dbi-spi-device.yaml
+    property-blocklist:
+      - te-delay
+
+properties:
+  busy-gpios:
+    type: phandle-array
+    description: Busy/status GPIO

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -208,6 +208,7 @@ eeti	eGalax_eMPIA Technology Inc
 efinix	Efinix Inc
 egis	Egis Technology Inc
 einfochips	Einfochips
+eink	E Ink Corporation
 elan	Elan Microelectronic Corp.
 electronut	Electronut Labs
 element14	Element14 (A Premier Farnell Company)

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -143,6 +143,12 @@ enum display_pixel_format {
 	 * @endcode
 	 */
 	PIXEL_FORMAT_AL_88		= BIT(7), /**< 8-bit Grayscale/Luminance with alpha */
+
+	/**
+	 * This and higher values are display specific.
+	 * Refer to the display header file.
+	 */
+	PIXEL_FORMAT_PRIV_START = (PIXEL_FORMAT_AL_88 << 1),
 };
 
 /**
@@ -150,7 +156,8 @@ enum display_pixel_format {
  *
  * This macro expands to the number of bits required for a given display
  * format. It can be used to allocate a framebuffer based on a given
- * display format type
+ * display format type. This does not work with any private
+ * pixel formats.
  */
 #define DISPLAY_BITS_PER_PIXEL(fmt)						\
 	((((fmt & PIXEL_FORMAT_RGB_888) >> 0) * 24U) +				\

--- a/include/zephyr/drivers/display/ac057tc1.h
+++ b/include/zephyr/drivers/display/ac057tc1.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup display_interface
+ * @brief Public API for AC057TC1 7-color e-ink display
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DISPLAY_AC057TC1_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DISPLAY_AC057TC1_H_
+
+/**
+ * @brief AC057TC1 7-color e-ink display controller device-specific API extension
+ * @defgroup ac057tc1_display_interface AC057TC1 display controller
+ * @since 4.4.0
+ * @version 0.1.0
+ * @ingroup display_interface
+ * @{
+ */
+
+#include <zephyr/drivers/display.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief AC057TC1 private pixel format
+ *
+ * 4 bits per pixel, 2 pixels per byte (high nibble first).
+ * Supports 7 colors indexed 0-6 (3-bit color palette).
+ */
+#define PIXEL_FORMAT_L_4 (PIXEL_FORMAT_PRIV_START << 0)
+
+/**
+ * @brief Bits per pixel for AC057TC1 format
+ */
+#define AC057TC1_BITS_PER_PIXEL 4
+
+/**
+ * @name AC057TC1 Color Definitions
+ * @{
+ */
+#define AC057TC1_COLOR_BLACK  0x00 /**< Black color index */
+#define AC057TC1_COLOR_WHITE  0x01 /**< White color index */
+#define AC057TC1_COLOR_GREEN  0x02 /**< Green color index */
+#define AC057TC1_COLOR_BLUE   0x03 /**< Blue color index */
+#define AC057TC1_COLOR_RED    0x04 /**< Red color index */
+#define AC057TC1_COLOR_YELLOW 0x05 /**< Yellow color index */
+#define AC057TC1_COLOR_ORANGE 0x06 /**< Orange color index */
+/** @} */
+
+/**
+ * @brief Pack two AC057TC1 pixels into a single byte
+ *
+ * @param pixel1 First pixel (high nibble, left pixel)
+ * @param pixel2 Second pixel (low nibble, right pixel)
+ * @return Packed byte containing both pixels
+ */
+#define AC057TC1_PACK_PIXELS(pixel1, pixel2) (((pixel1) << 4) | ((pixel2) & 0x0F))
+
+/**
+ * @brief Calculate buffer size needed for AC057TC1 framebuffer
+ *
+ * @param width Display width in pixels
+ * @param height Display height in pixels
+ * @return Size in bytes needed for framebuffer
+ */
+#define AC057TC1_BUFFER_SIZE(width, height) (((width) * (height)) / 2)
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DISPLAY_AC057TC1_H_ */

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -389,6 +389,15 @@
 				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 				grayscale-table = [02 02 02 02 02 02 02 02 03 04 05 06 07 07 07];
 			};
+
+			ac057tc1: ac057tc1@22 {
+				compatible = "eink,ac057tc1";
+				reg = <22>;
+				mipi-max-frequency = <2000000>;
+				width = <600>;
+				height = <448>;
+				busy-gpios = <&test_gpio 0 0>;
+			};
 		};
 
 		test_mipi_dbi_xfr_16bit_write_only {


### PR DESCRIPTION
Adds a PIXEL_FORMAT_PRIV_START value to the display header. This allows displays with unusual color format to still report sensible information in their display_capabilites via extension of the enumeration.

While working on a display with a non common pixel format (6 Color) I encountered the issue that I like the capabilities to still return a value for the supported pixel formats. Therefore I added a private `PIXEL_FORMAT_PRIV_START` member to the enum that allows for device specific expansion similar to how it is done for sensor channels and attributes.