### PR TITLE
drivers: led: lp3943: fix unsigned integer underflow Coverity error

### DIFF
--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -57,42 +57,15 @@ struct lp3943_config {
 
 static int lp3943_get_led_reg(uint32_t *led, uint8_t *reg)
 {
-	switch (*led) {
-	case 0:
-	case 1:
-	case 2:
-		__fallthrough;
-	case 3:
-		*reg = LP3943_LS0;
-		break;
-	case 4:
-	case 5:
-	case 6:
-		__fallthrough;
-	case 7:
-		*reg = LP3943_LS1;
-		*led -= 4U;
-		break;
-	case 8:
-	case 9:
-	case 10:
-		__fallthrough;
-	case 11:
-		*reg = LP3943_LS2;
-		*led -= 8U;
-		break;
-	case 12:
-	case 13:
-	case 14:
-		__fallthrough;
-	case 15:
-		*reg = LP3943_LS3;
-		*led -= 12U;
-		break;
-	default:
+	static const uint8_t regs[] = {LP3943_LS0, LP3943_LS1, LP3943_LS2, LP3943_LS3};
+
+	if (*led >= ARRAY_SIZE(regs) * 4U) {
 		LOG_ERR("Invalid LED specified");
 		return -EINVAL;
 	}
+
+	*reg = regs[*led / 4U];
+	*led %= 4U;
 
 	return 0;
 }


### PR DESCRIPTION
Replace the switch statement with an array-based register lookup and a modulo operation to resolve a Coverity "integer handling" issue and make the code simpler.

The original subtractions (`*led -= 4U/8U/12U`) were guarded by switch cases making underflow impossible in practice, but the pattern was flagged nevertheless. The new array-based approach is semantically equivalent and  more readable (and 4 less bytes in code size!). 

Fixes zephyrproject-rtos/zephyr#84770
Fixes Coverity CID 487606