### PR TITLE
bindings: pic32cz-ca-dpll: drop compatible from child child

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -94,7 +94,6 @@
 			dpll-en = <1>;
 
 			dpll0out0: dpll0out0 {
-				compatible = "microchip,pic32cz-ca-dpllout";
 				subsystem = <CLOCK_MCHP_DPLL0_ID_OUT0>;
 				dpll-output-division-factor = <4>;
 				dpll-output-en = <1>;

--- a/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-dpll.yaml
+++ b/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-dpll.yaml
@@ -109,7 +109,6 @@ child-binding:
         FPFD = FCKR / REFDIV (i.e., FPFD must always be between 4 MHz to 48 MHz.
 
   child-binding:
-    compatible: "microchip,pic32cz-ca-dpllout"
     properties:
       subsystem:
         type: int


### PR DESCRIPTION
Same as 17a91d84e40 but for the child of the child, missed it on the first patch.
