### PR TITLE
tests: drivers: adc: Microchip: Add adc test support files

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro.conf
+++ b/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC=y
+CONFIG_DAC_BUFFER_NOT_SUPPORTED=y

--- a/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* DAC0 internally connected to ADC channel 30 */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	prescaler = <16>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 4)>;
+		zephyr,input-positive = <MCHP_ADC_DAC0>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&dac {
+	refsel = "vdd_ana";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	dac0: channel@0 {
+		reg = <0>;
+		rate = <100>;
+		data-adj = "right";
+		refresh-period = <30>;
+		sampling-ratio = <1>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro_ref.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/sam_e54_xpro_ref.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect the PA03(EXT2 pin 4) to VCC for the test */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+		reference-mv = <3300>;
+		expected-accuracy = <32>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <MCHP_ADC_AIN1>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <PA3B_ADC0_AIN1>;
+		};
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -38,6 +38,7 @@ tests:
       - fpb_ra4e1
       - ek_ra2a1
       - ek_ra2l1
+      - sam_e54_xpro
   drivers.adc.accuracy.ref_volt:
     extra_configs:
       - CONFIG_REFERENCE_VOLTAGE_TEST=y
@@ -64,8 +65,10 @@ tests:
       - slwrb4180a
       - ek_ra4c1
       - pic32cx_sg41_cult
+      - sam_e54_xpro
     extra_args:
-      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"DTC_OVERLAY_FILE="boards/pic32cx_sg41_cult_ref.overlay"
+      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"DTC_OVERLAY_FILE=boards/pic32cx_sg41_cult_ref.overlay"
+      - platform:sam_e54_xpro/atsame54p20a:"DTC_OVERLAY_FILE=boards/sam_e54_xpro_ref.overlay"
     integration_platforms:
       - frdm_kl25z
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/adc/adc_api/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam_e54_xpro.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCHP_ADC_SCALEDIOVCC>;
+	};
+};

--- a/tests/drivers/adc/adc_error_cases/testcase.yaml
+++ b/tests/drivers/adc/adc_error_cases/testcase.yaml
@@ -22,3 +22,4 @@ tests:
       - bg29_rb4420a
       - slwrb4180a
       - pic32cx_sg41_cult
+      - sam_e54_xpro


### PR DESCRIPTION
Add board overlay files for sam_e54_xpro to enable adc test cases to run on this board.