### PR TITLE
scripts: ci: compliance_check: ignore external module documentation

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1419,6 +1419,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             regex,
             "--",
             ":!/doc/releases",
+            ":!/doc/develop/manifest/external",
             ":!/doc/security/vulnerabilities.rst",
             cwd=GIT_TOP,
         )


### PR DESCRIPTION
The undefined Kconfig compliance check may report symbols as undefined when the corresponding external module is not present.

This results in false positives, since such symbols are provided only when the module is included in the workspace.

Exclude doc/develop/manifest/external from the grep search used by the undefined Kconfig check.

This avoids extending UNDEF_KCONFIG_ALLOWLIST for optional external modules while keeping the check strict for core Zephyr symbols.