### PR TITLE
drivers: uart: microchip: sercom g1: Refactor for macro mapping and multi-SoC support

### DIFF
--- a/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh00/soc.h
+++ b/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh00/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +30,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cm_jh.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh01/soc.h
+++ b/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh01/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,6 +34,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cm_jh.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg41/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg41/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cx_sg.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg60/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg60/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cx_sg.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg61/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg61/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cx_sg.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsamd51/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsamd51/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,6 +32,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "samd5xe5x.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame51/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame51/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,6 +28,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "samd5xe5x.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame53/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame53/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +24,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "samd5xe5x.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame54/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame54/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "samd5xe5x.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 14bc95d3885e6c7b2303f93a3bf6a5506bbd943a
+      revision: 10920fe424f320067e95ae9480a30df9bbe63684
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
This pull request improves the SERCOM UART G1 driver to better support multiple Microchip SoCs. It adds mapping files that define common macro names, allowing the driver to work consistently across different SoCs. The driver code is refactored to remove SoC-specific symbols and use standardized macros and register definitions.