### PR TITLE
usb: usbip: make USBIP service port configurable

### DIFF
--- a/subsys/usb/host/Kconfig.usbip
+++ b/subsys/usb/host/Kconfig.usbip
@@ -15,6 +15,11 @@ menuconfig USBIP
 
 if USBIP
 
+config USBIP_SERVICE_PORT
+	int "Port number for USBIP service"
+	range 1 $(UINT16_MAX)
+	default 3240
+
 config USBIP_THREAD_STACK_SIZE
 	int "USBIP thread stack size"
 	default 2048

--- a/subsys/usb/host/usbip.h
+++ b/subsys/usb/host/usbip.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define USBIP_PORT		3240
+#define USBIP_PORT		CONFIG_USBIP_SERVICE_PORT
 #define USBIP_VERSION		0x0111U
 
 /* Retrieve the list of exported devices command code */


### PR DESCRIPTION
Makes it possible to host multiple native_sim's with native networking without port collisions in the USBIP service.