### PR TITLE
doc: contribute: style: kconfig: Add SoC naming scheme

### DIFF
--- a/doc/contribute/style/kconfig.rst
+++ b/doc/contribute/style/kconfig.rst
@@ -92,6 +92,12 @@ The specific formats by subtree:
 
 * **Boards (/boards)**: Use ``BOARD_`` for symbols.
 
+* **SoCs (/soc)**: Use the most appropriate base for symbols: ``SOC_FAMILY_{SoC family}_`` if it
+  relates to a whole SoC family, ``SOC_SERIES_{SoC series}_`` if it relates to a whole SoC series,
+  or ``SOC_{SoC}_`` if it relates to a specific SoC - see :ref:`soc_porting_guide` for details on
+  these terms and where they must originate from. This is to prevent conflicts with other vendors
+  and external modules.
+
 Examples
 ========
 
@@ -120,6 +126,12 @@ Examples
 **Test examples:**
 
 .. literalinclude:: kconfig_example_test.txt
+   :language: kconfig
+   :start-after: start-after-here
+
+**SoC examples:**
+
+.. literalinclude:: kconfig_example_soc.txt
    :language: kconfig
    :start-after: start-after-here
 

--- a/doc/contribute/style/kconfig_example_soc.txt
+++ b/doc/contribute/style/kconfig_example_soc.txt
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Examples of Kconfig symbols for SoCs
+
+# start-after-here
+
+# This assumes the following soc.yml file:
+# family:
+#   - name: alpha
+#     series:
+#       - name: foxtrot
+#         socs:
+#           - name: charlie
+
+config SOC_FAMILY_ALPHA_JTAG_LOCK
+	bool "Lock JTAG access"
+
+config SOC_SERIES_FOXTROT_EMULATE_POWER_OFF
+	bool "Emulate power off mode"
+
+config SOC_CHARLIE_IMAGE_HEADER
+	bool "Include image header"


### PR DESCRIPTION
Adds a naming scheme for SoC Kconfig symbols with examples