### PR TITLE
logging: Replace NULL equality check with is_null_no_warn()

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -330,7 +330,7 @@ do { \
 	int _plen; \
 	uint32_t _options = Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
 			  CBPRINTF_PACKAGE_ADD_RW_STR_POS; \
-	if (GET_ARG_N(1, __VA_ARGS__) == NULL) { \
+	if (is_null_no_warn((void *)GET_ARG_N(1, __VA_ARGS__))) { \
 		_plen = 0; \
 	} else { \
 		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, _options, \


### PR DESCRIPTION
This change solves the problem with `the comparison will always evaluate as 'false' for the address of '_fmt' will never be NULL` warning. It appears when `CONFIG_COMPILER_SAVE_TEMPS=y` and this case is mentioned in documentation for this function https://docs.zephyrproject.org/latest/doxygen/html/group__sys-util.html#ga611e5bb95e5b4d490a33b9025791d366

Fixes zephyrproject-rtos/zephyr#104158