### PR TITLE
i2c: add a generic CONFIG_I2C_TRANSFER_TIMEOUT_MS option

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -30,6 +30,25 @@ config I2C_SHELL_BUFFER_SIZE
 	  maximum size for read/write operations. Note that this is allocated
 	  on the stack.
 
+config I2C_TRANSFER_TIMEOUT_SUPPORTED
+	bool
+	help
+	  Selected by drivers that supports setting an i2c transaction timeout
+	  using the I2C_TRANSFER_TIMEOUT_MS Kconfig option.
+
+config I2C_TRANSFER_TIMEOUT_MS
+	int "Transfer timeout in milliseconds"
+	default 500
+	depends on I2C_TRANSFER_TIMEOUT_SUPPORTED
+	help
+	  Timeout in milliseconds used for each I2C transfer.
+	  In some drivers 0 means that the driver should use the K_FOREVER
+	  value, i.e. it should wait as long as necessary.
+
+	  I2C controllers that program a timeout directly into a register do
+	  not support setting this option to 0 and guard against an infinite
+	  timeout using the BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT() check.
+
 config I2C_STATS
 	bool "I2C device Stats"
 	depends on STATS

--- a/drivers/i2c/Kconfig.npcx
+++ b/drivers/i2c/Kconfig.npcx
@@ -8,6 +8,7 @@ config I2C_NPCX
 	default y
 	depends on DT_HAS_NUVOTON_NPCX_I2C_PORT_ENABLED
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  This option enables the I2C driver for NPCX family of
 	  processors.

--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -9,6 +9,7 @@ menuconfig I2C_NRFX
 	depends on SOC_FAMILY_NORDIC_NRF
 	depends on MULTITHREADING
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  Enable support for nrfx TWI drivers for nRF MCU series.
 
@@ -23,14 +24,6 @@ config I2C_NRFX_TWIM
 	def_bool y
 	depends on DT_HAS_NORDIC_NRF_TWIM_ENABLED
 	select NRFX_TWIM
-
-config I2C_NRFX_TRANSFER_TIMEOUT
-	int "Transfer timeout [ms]"
-	default 500
-	help
-	  Timeout in milliseconds used for each I2C transfer.
-	  0 means that the driver should use the K_FOREVER value,
-	  i.e. it should wait as long as necessary.
 
 config I2C_NRFX_TWIS
 	def_bool y

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -6,6 +6,7 @@ menuconfig I2C_STM32
 	default y
 	depends on DT_HAS_ST_STM32_I2C_V1_ENABLED || DT_HAS_ST_STM32_I2C_V2_ENABLED
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  Enable I2C support on the STM32 SoCs
 
@@ -65,14 +66,6 @@ config I2C_STM32_V2_DMA
 	select EXPERIMENTAL
 	help
 	  Enable DMA support for the STM32 I2C driver.
-
-config I2C_STM32_TRANSFER_TIMEOUT_MSEC
-	int "STM32 I2C transfer timeout (ms)"
-	range 1 $(UINT32_MAX)
-	default 500
-	help
-	  Time in milliseconds to wait for an I2C transfer to complete before
-	  considering it timed out.
 
 config I2C_STM32_WAIT_BUS_IDLE_TIMEOUT_USEC
 	int "STM32 I2C bus wait timeout (us)"

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -88,9 +88,6 @@ LOG_MODULE_REGISTER(i2c_npcx, CONFIG_I2C_LOG_LEVEL);
 /* Timeout for SCL held to low by slave device . (SMBus spec. unit:ms). */
 #define I2C_MIN_TIMEOUT 25
 
-/* Default maximum time we allow for an I2C transfer (unit:ms) */
-#define I2C_TRANS_TIMEOUT K_MSEC(100)
-
 /* Valid bit fields in SMBST register */
 #define NPCX_VALID_SMBST_MASK ~(BIT(NPCX_SMBST_XMIT) | BIT(NPCX_SMBST_MASTER))
 
@@ -397,7 +394,7 @@ static int i2c_ctrl_wait_completion(const struct device *dev)
 {
 	struct i2c_ctrl_data *const data = dev->data;
 
-	if (k_sem_take(&data->sync_sem, I2C_TRANS_TIMEOUT) == 0) {
+	if (k_sem_take(&data->sync_sem, I2C_TRANSFER_TIMEOUT) == 0) {
 		return data->trans_err;
 	} else {
 		return -ETIMEDOUT;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -19,12 +19,6 @@ LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_twi
 
-#if CONFIG_I2C_NRFX_TRANSFER_TIMEOUT
-#define I2C_TRANSFER_TIMEOUT_MSEC K_MSEC(CONFIG_I2C_NRFX_TRANSFER_TIMEOUT)
-#else
-#define I2C_TRANSFER_TIMEOUT_MSEC K_FOREVER
-#endif
-
 struct i2c_nrfx_twi_data {
 	nrfx_twi_t twi;
 	uint32_t dev_config;
@@ -67,8 +61,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			break;
 		}
 
-		ret = k_sem_take(&data->completion_sync,
-				 I2C_TRANSFER_TIMEOUT_MSEC);
+		ret = k_sem_take(&data->completion_sync, I2C_TRANSFER_TIMEOUT);
 		if (ret != 0) {
 			/* Whatever the frequency, completion_sync should have
 			 * been given by the event handler.

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -23,12 +23,6 @@
 
 LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
-#if CONFIG_I2C_NRFX_TRANSFER_TIMEOUT
-#define I2C_TRANSFER_TIMEOUT_MSEC K_MSEC(CONFIG_I2C_NRFX_TRANSFER_TIMEOUT)
-#else
-#define I2C_TRANSFER_TIMEOUT_MSEC K_FOREVER
-#endif
-
 struct i2c_nrfx_twim_data {
 	nrfx_twim_t twim;
 	struct k_sem transfer_sync;
@@ -158,8 +152,7 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 			break;
 		}
 
-		ret = k_sem_take(&dev_data->completion_sync,
-				 I2C_TRANSFER_TIMEOUT_MSEC);
+		ret = k_sem_take(&dev_data->completion_sync, I2C_TRANSFER_TIMEOUT);
 		if (ret != 0) {
 			/* Whatever the frequency, completion_sync should have
 			 * been given by the event handler.

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -699,8 +699,7 @@ static int32_t i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg
 
 	i2c_stm32_enable_transfer_interrupts(dev);
 
-	if (k_sem_take(&data->device_sync_sem,
-		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+	if (k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT) != 0) {
 		LOG_DBG("%s: WRITE timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;
@@ -721,8 +720,7 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	i2c_stm32_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_RX(i2c);
 
-	if (k_sem_take(&data->device_sync_sem,
-		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+	if (k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT) != 0) {
 		LOG_DBG("%s: READ timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -33,6 +33,8 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
 
+BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT();
+
 #if CONFIG_STM32_HAL2
 #define STM32_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period) \
 	LL_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period)
@@ -800,7 +802,7 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	int ret;
 
 	/* Wait for IRQ to complete or timeout */
-	ret = k_sem_take(&data->device_sync_sem, K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC));
+	ret = k_sem_take(&data->device_sync_sem, K_MSEC(CONFIG_I2C_TRANSFER_TIMEOUT_MS));
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
 	/* Stop DMA and invalidate cache if needed */
@@ -1128,7 +1130,7 @@ static inline int msg_done(const struct device *dev,
 			return -EIO;
 		}
 		if ((k_uptime_get() - start_time) >
-		    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+		    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
 			return -ETIMEDOUT;
 		}
 	}
@@ -1137,7 +1139,7 @@ static inline int msg_done(const struct device *dev,
 		LL_I2C_GenerateStopCondition(i2c);
 		while (!LL_I2C_IsActiveFlag_STOP(i2c)) {
 			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -1172,7 +1174,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 			}
 
 			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -1203,7 +1205,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 				return -EIO;
 			}
 			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
 				return -ETIMEDOUT;
 			}
 		}

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -29,6 +29,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,6 +69,22 @@ extern "C" {
 
 /** Peripheral to act as Controller. */
 #define I2C_MODE_CONTROLLER		BIT(4)
+
+#if CONFIG_I2C_TRANSFER_TIMEOUT_SUPPORTED
+
+/** Helper macro for CONFIG_I2C_TRANSFER_TIMEOUT_MS */
+#if CONFIG_I2C_TRANSFER_TIMEOUT_MS
+#define I2C_TRANSFER_TIMEOUT K_MSEC(CONFIG_I2C_TRANSFER_TIMEOUT_MS)
+#else
+#define I2C_TRANSFER_TIMEOUT K_FOREVER
+#endif
+
+/** Helper macro drivers that do not support infinite timeout */
+#define BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT() \
+	BUILD_ASSERT(CONFIG_I2C_TRANSFER_TIMEOUT_MS != 0, \
+		     "infinite i2c transfer timeout not unsupported")
+
+#endif /* CONFIG_I2C_TRANSFER_TIMEOUT_SUPPORTED */
 
 /**
  * @brief Complete I2C DT information


### PR DESCRIPTION
Hi, currently every i2c driver defines transfer or clock stretch timeout in its own way, making it impossible to set a timeout in a portable way for an application.

Define a single timeout config option at subsystem level and use it in the driver instead of the custom ones. Drivers have to select whether the option is supported or not for that to be available.