### PR TITLE
Enable dma and dma loop_transfer test for frdm_mcxc242

### DIFF
--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -211,3 +211,7 @@ zephyr_udc0: &usb {
 &vref {
 	status = "okay";
 };
+
+&dma {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -23,6 +23,7 @@ supported:
   - uart
   - usb_device
   - usbd
+  - dma
 testing:
   ignore_tags:
     - net

--- a/tests/drivers/dma/loop_transfer/boards/frdm_mcxc242.conf
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_mcxc242.conf
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_LOOP_TRANSFER_SIZE=1024

--- a/tests/drivers/dma/loop_transfer/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_mcxc242.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma {};


### PR DESCRIPTION
Dma and dma test is not enabled for frdm_mcxc242. Enable it.