### PR TITLE
cmake: mcuboot: Use relative path for signed files

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -13,6 +13,7 @@
 function(zephyr_runner_file type path)
   # Property magic which makes west flash choose the signed build
   # output of a given type.
+  string(REPLACE "${ZEPHYR_BINARY_DIR}/" "" path ${path})
   set_target_properties(runners_yaml_props_target PROPERTIES "${type}_file" "${path}")
 endfunction()
 


### PR DESCRIPTION
Uses relative paths for the signed images, instead of absolute paths, to allow transferring test files to other machines