### PR TITLE
twister: Do not clean previous results for listing tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -86,6 +86,9 @@ class Twister:
             self.options.no_clean
             or self.options.only_failed
             or self.options.test_only
+            or self.options.list_tests
+            or self.options.list_tags
+            or self.options.test_tree
             or self.options.report_summary is not None
         ):
             if os.path.exists(self.options.outdir):


### PR DESCRIPTION
When user only wants to list tests or tags twister should not clean previous results.
This change improves also performance for listing tests.