### PR TITLE
twister: Remove redundant DUT storage from classes

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -30,7 +30,6 @@ from packaging import version
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.constants import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
-from twisterlib.hardwaremap import DUT
 from twisterlib.log_helper import setup_logging
 from twisterlib.statuses import TwisterStatus
 
@@ -885,7 +884,6 @@ class ProjectBuilder(FilterBuilder):
         self.filtered_tests = 0
         self.options = env.options
         self.env = env
-        self.duts: list[DUT] = []
 
     @property
     def trace(self) -> bool:
@@ -1756,7 +1754,7 @@ class ProjectBuilder(FilterBuilder):
             instance.status = TwisterStatus.NONE
 
             if instance.handler.type_str == "device":
-                instance.handler.duts = self.duts
+                instance.handler.duts = self.env.hwm.duts
 
             if(self.options.seed is not None and instance.platform.name.startswith("native_")):
                 self.parse_generated()
@@ -1825,7 +1823,6 @@ class TwisterRunner:
         self.env = env
         self.instances: dict[str, TestInstance] = instances
         self.suites: dict[str, TestSuite] = suites
-        self.duts: list[DUT] = []
         self.jobs = 1
         self.results = None
         self.jobserver = None
@@ -2051,7 +2048,6 @@ class TwisterRunner:
                     continue
 
                 pb = ProjectBuilder(instance, self.env, self.jobserver)
-                pb.duts = self.duts
                 pb.process(processing_queue, processing_ready, task, lock, results)
                 if (
                     self.env.options.quit_on_failure

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -202,10 +202,9 @@ class Twister:
             raise SystemExit(0)
         return report
 
-    def execute(self, tplan: TestPlan, env: TwisterEnv, hwm: HardwareMap) -> TwisterRunner:
+    def execute(self, tplan: TestPlan, env: TwisterEnv) -> TwisterRunner:
         """Run twister runner."""
         runner = TwisterRunner(tplan.instances, tplan.testsuites, env)
-        runner.duts = hwm.duts
         runner.run()
         return runner
 
@@ -329,7 +328,7 @@ class Twister:
         if self.options.short_build_path:
             self.tplan.create_build_dir_links()
 
-        self.runner = self.execute(self.tplan, self.env, self.hwm)
+        self.runner = self.execute(self.tplan, self.env)
 
         self.prepare_reports(self.report, previous_results_file)
 

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2256,7 +2256,6 @@ TESTDATA_14 = [
         True,
         True,
         True,
-        True,
         False
     ),
     (
@@ -2267,7 +2266,6 @@ TESTDATA_14 = [
         'not posix',
         {'CONFIG_FAKE_ENTROPY_NATIVE_SIM': 'y'},
         'not pytest',
-        False,
         False,
         False,
         False,
@@ -2286,14 +2284,13 @@ TESTDATA_14 = [
         False,
         False,
         False,
-        False,
         False
     ),
 ]
 
 @pytest.mark.parametrize(
     'ready, type_str, seed, platform_name, platform_arch, defconfig, harness,' \
-    ' expect_duts, expect_parse_generated, expect_seed,' \
+    ' expect_parse_generated, expect_seed,' \
     ' expect_extra_test_args, expect_pytest, expect_handle',
     TESTDATA_14,
     ids=['pytest full', 'not pytest minimal', 'not ready']
@@ -2307,7 +2304,6 @@ def test_projectbuilder_run(
     platform_arch,
     defconfig,
     harness,
-    expect_duts,
     expect_parse_generated,
     expect_seed,
     expect_extra_test_args,
@@ -2328,7 +2324,6 @@ def test_projectbuilder_run(
     instance_mock.handler.seed = 123
     instance_mock.handler.ready = ready
     instance_mock.handler.type_str = type_str
-    instance_mock.handler.duts = [mock.Mock(name='dummy dut')]
     instance_mock.platform.name = platform_name
     instance_mock.platform.arch = platform_arch
     instance_mock.testsuite.harness = harness
@@ -2336,7 +2331,6 @@ def test_projectbuilder_run(
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
     pb.options.extra_test_args = ['dummy_arg1', 'dummy_arg2']
-    pb.duts = ['another dut']
     pb.options.seed = seed
     pb.defconfig = defconfig
     pb.parse_generated = mock.Mock()
@@ -2344,9 +2338,6 @@ def test_projectbuilder_run(
     with mock.patch('twisterlib.runner.HarnessImporter.get_harness',
                     mock_harness):
         pb.run()
-
-    if expect_duts:
-        assert pb.instance.handler.duts == ['another dut']
 
     if expect_parse_generated:
         pb.parse_generated.assert_called_once()


### PR DESCRIPTION
Simplify the design by removing the `detected` attribute from
HardwareMap class and DUT storage from ProjectBuilder class.
Instead of storing detected DUTs as instance attributes, pass
them as method parameters where needed.

This eliminates data duplication since `ProjectBuilder` can access DUTs
directly from the environment object, and `HardwareMap` doesn't need to
maintain its own copy of detected DUTs. The refactoring makes the code
cleaner and reduces the risk of inconsistent state between different
objects storing the same DUT information.

Updated twister unit tests.