### PR TITLE
libc: common: implement raise()

### DIFF
--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -12,6 +12,8 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_CTIME source/time/ctime.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_TIME source/time/time.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_MALLOC source/stdlib/malloc.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_STRNLEN source/string/strnlen.c)
+zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_SIGNAL source/signal/signal.c)
+zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_RAISE  source/signal/raise.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_THRD
     source/thrd/cnd.c
     source/thrd/mtx.c

--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -104,6 +104,20 @@ config COMMON_LIBC_STRNLEN
 	help
 	  common implementation of strnlen().
 
+config COMMON_LIBC_SIGNAL
+	bool "Common C library signal"
+	depends on MINIMAL_LIBC
+	default y
+	help
+	  Provide libc signal().
+
+config COMMON_LIBC_RAISE
+	bool "Common C library raise"
+	depends on MINIMAL_LIBC
+	default y
+	help
+	  Provide libc raise().
+
 config COMMON_LIBC_THRD
 	bool "C11 <threads.h> API support"
 	depends on DYNAMIC_THREAD

--- a/lib/libc/common/source/signal/raise.c
+++ b/lib/libc/common/source/signal/raise.c
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+*/
+
+#include <errno.h>
+#include <signal.h>
+
+int raise(int sig)
+{
+	(void)sig;      
+	errno = EINVAL;
+	return -1;
+}


### PR DESCRIPTION
# Pull Request: libc: common: implement raise()

## Summary

Implement the missing C89 `raise()` function for Zephyr’s common libc when building with `CONFIG_MINIMAL_LIBC=y`.

Zephyr’s current `signal()` implementation in this area is a stub; this change adds a matching stub `raise()` implementation (returns `-1` and sets `errno = EINVAL`) to provide the symbol and consistent behavior.

Fixes: #66926

## Details

- Added: `lib/libc/common/source/signal/raise.c`
- Build wiring:
  - `lib/libc/common/CMakeLists.txt`: compile `raise.c` behind `CONFIG_COMMON_LIBC_RAISE`
- Kconfig wiring:
  - `lib/libc/common/Kconfig`: added `COMMON_LIBC_RAISE` (gated by `MINIMAL_LIBC`)

## Testing

Built `hello_world` for QEMU Cortex-M3 with minimal libc enabled:

```sh
cat > /tmp/minlibc.conf <<'EOF'
CONFIG_MINIMAL_LIBC=y
EOF

ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb \
GNUARMEMB_TOOLCHAIN_PATH=/usr \
west build -d ~/zephyr-build-qemu-m3-minlibc -b qemu_cortex_m3 -p always \
  zephyr/samples/hello_world -- -DOVERLAY_CONFIG=/tmp/minlibc.conf
