### PR TITLE
arm64: cnthctl_el2: Set EL1PCTEN/EL1PCEN for cntp in EL1

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -201,7 +201,8 @@ void z_arm64_el2_init(void)
 #endif
 
 	zero_cntvoff_el2();		/* Set 64-bit virtual timer offset to 0 */
-	zero_cnthctl_el2();
+	reg = CNTHCTL_EL2_EL1PCEN | CNTHCTL_EL2_EL1PCTEN;
+	write_cnthctl_el2(reg);
 #ifdef CONFIG_CPU_AARCH64_CORTEX_R
 	zero_cnthps_ctl_el2();
 #else

--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -277,9 +277,9 @@ void z_arm64_el1_init(void)
 	barrier_isync_fence_full();
 
 	write_cntv_cval_el0(~(uint64_t)0);
+	write_cntp_cval_el0(~(uint64_t)0);
 	/*
-	 * Enable these if/when we use the corresponding timers.
-	 * write_cntp_cval_el0(~(uint64_t)0);
+	 * Enable secure cntps if/when we use the corresponding timer.
 	 * write_cntps_cval_el1(~(uint64_t)0);
 	 */
 

--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -168,6 +168,10 @@
 #define HCR_APK_BIT		BIT(40)	/* Trap pointer authentication key registers */
 #define HCR_API_BIT		BIT(41)	/* Trap pointer authentication instructions */
 
+/* CNTHCTL_EL2: Counter-timer Hypervisor Control register */
+#define CNTHCTL_EL2_EL1PCTEN	BIT(0)	/* Enable EL1 access to physical counter timer */
+#define CNTHCTL_EL2_EL1PCEN	BIT(1)	/* Enable EL1 access to physical counter */
+
 /* PAC Key Registers - System register encodings */
 #define APIAKeyLo_EL1		S3_0_C2_C1_0
 #define APIAKeyHi_EL1		S3_0_C2_C1_1

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -12,6 +12,8 @@
 #include <zephyr/arch/arm64/cpu.h>
 #include <stdint.h>
 
+/** @cond INTERNAL_HIDDEN */
+
 /* All the macros need a memory clobber */
 
 #define read_sysreg(reg)						\
@@ -62,6 +64,7 @@ MAKE_REG_HELPER(cnthp_ctl_el2);
 MAKE_REG_HELPER(cnthps_ctl_el2);
 MAKE_REG_HELPER(cntv_ctl_el0)
 MAKE_REG_HELPER(cntv_cval_el0)
+MAKE_REG_HELPER(cntp_cval_el0)
 MAKE_REG_HELPER(cntvct_el0);
 MAKE_REG_HELPER(cntvoff_el2);
 MAKE_REG_HELPER(currentel);
@@ -222,6 +225,8 @@ MAKE_REG_HELPER(apdbkeyhi_el1);
 MAKE_REG_HELPER(apgakeylo_el1);
 MAKE_REG_HELPER(apgakeyhi_el1);
 #endif /* CONFIG_ARM_PAC */
+
+/** @endcond */
 
 #endif /* !_ASMLANGUAGE */
 


### PR DESCRIPTION
zeroing CNTHCTL_EL2 traps physical timer/counter access from EL1 to EL2, but Zephyr has no hypervisor to handle those traps. Enabling access is the standard EL2→EL1 drop behavior. 