### PR TITLE
twister: move ZEPHYR_BASE to constants to reduce dependencies

### DIFF
--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -4,6 +4,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+if not ZEPHYR_BASE:
+    sys.exit("$ZEPHYR_BASE environment variable undefined")
+
+# Use this for internal comparisons; that's what canonicalization is
+# for. Don't use it when invoking other components of the build system
+# to avoid confusing and hard to trace inconsistencies in error messages
+# and logs, generated Makefiles, etc. compared to when users invoke these
+# components directly.
+# Note "normalization" is different from canonicalization, see os.path.
+canonical_zephyr_base = os.path.realpath(ZEPHYR_BASE)
+
 SUPPORTED_SIMS = [
     "mdb-nsim",
     "nsim",

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -22,23 +22,11 @@ from pathlib import Path
 from typing import Any
 
 import zephyr_module
-from twisterlib.constants import SUPPORTED_SIMS
+from twisterlib.constants import SUPPORTED_SIMS, ZEPHYR_BASE
 from twisterlib.coverage import supported_coverage_formats
 from twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')
-
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    sys.exit("$ZEPHYR_BASE environment variable undefined")
-
-# Use this for internal comparisons; that's what canonicalization is
-# for. Don't use it when invoking other components of the build system
-# to avoid confusing and hard to trace inconsistencies in error messages
-# and logs, generated Makefiles, etc. compared to when users invoke these
-# components directly.
-# Note "normalization" is different from canonicalization, see os.path.
-canonical_zephyr_base = os.path.realpath(ZEPHYR_BASE)
 
 
 def _get_installed_packages() -> Generator[str, None, None]:

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -28,7 +28,8 @@ from queue import Empty, Queue
 
 import psutil
 from serial.tools import list_ports
-from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
+from twisterlib.constants import ZEPHYR_BASE
+from twisterlib.environment import strip_ansi_sequences
 from twisterlib.error import TwisterException
 from twisterlib.hardwaremap import DUT
 from twisterlib.platform import Platform

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -17,7 +17,7 @@ from typing import Any
 import scl
 import yaml
 from natsort import natsorted
-from twisterlib.environment import ZEPHYR_BASE
+from twisterlib.constants import ZEPHYR_BASE
 
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -14,8 +14,7 @@ from itertools import groupby
 
 import list_boards
 import scl
-from twisterlib.constants import SUPPORTED_SIMS
-from twisterlib.environment import ZEPHYR_BASE
+from twisterlib.constants import SUPPORTED_SIMS, ZEPHYR_BASE
 
 logger = logging.getLogger('twister')
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -28,7 +28,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 from packaging import version
 from twisterlib.cmakecache import CMakeCache
-from twisterlib.environment import canonical_zephyr_base
+from twisterlib.constants import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
 from twisterlib.hardwaremap import DUT
 from twisterlib.log_helper import setup_logging
@@ -41,7 +41,7 @@ if version.parse(elftools.__version__) < version.parse('0.24'):
 if sys.platform == 'linux':
     from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
 
-from twisterlib.environment import ZEPHYR_BASE
+from twisterlib.constants import ZEPHYR_BASE
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 from domains import Domains

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -12,7 +12,7 @@ import re
 from enum import Enum
 from pathlib import Path
 
-from twisterlib.environment import canonical_zephyr_base
+from twisterlib.constants import canonical_zephyr_base
 from twisterlib.error import StatusAttributeError, TwisterException, TwisterRuntimeError
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.statuses import TwisterStatus


### PR DESCRIPTION
Moving ZEPHYR_BASE from environment.py to constants.py allows importing classes like HardwareMap in
pytest-twister-harness module without pulling in unnecessary dependencies from environment.py.

This refactoring improves module independence and makes selective imports cleaner across the twister Python package structure.