### PR TITLE
MAINTAINERS: Update ADI Platforms area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -161,8 +161,7 @@ ADI Platforms:
     - ozersa
     - ttmut
     - yasinustunerg
-    - galak
-    - microbuilder
+    - petejohanson-adi
   files:
     - boards/adi/
     - boards/common/*adi*

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -165,6 +165,7 @@ ADI Platforms:
     - microbuilder
   files:
     - boards/adi/
+    - boards/common/*adi*
     - boards/shields/eval*ardz/
     - boards/shields/pmod_acl/
     - drivers/*/*max*
@@ -175,6 +176,7 @@ ADI Platforms:
     - drivers/mdio/mdio_adin*
     - drivers/sensor/adi/
     - drivers/stepper/adi_tmc/
+    - drivers/usb/udc/*max*
     - dts/arm/adi/
     - dts/bindings/*/adi,*
     - dts/bindings/*/lltc,*


### PR DESCRIPTION
Updates the ADI Platforms area to:
- Add the max32 usb driver and openocd board runner cmake. These were missed in #104103 and #102899.
- Remove inactive collaborators (@galak and @microbuilder) and add a new active collaborator (@petejohanson-adi)