### PR TITLE
MAINTAINER: Add jsbatch as PWM and ADC collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1309,6 +1309,7 @@ Documentation Infrastructure:
   collaborators:
     - anangl
     - ZhaoxiangJin
+    - jsbatch
   files:
     - drivers/adc/
     - include/zephyr/drivers/adc.h
@@ -2287,6 +2288,7 @@ Documentation Infrastructure:
     - anangl
     - henrikbrixandersen
     - FelixWang47831
+    - jsbatch
   files:
     - drivers/pwm/
     - dts/bindings/pwm/


### PR DESCRIPTION
Add jsbatch as a collaborator for the ADC and PWM drivers.

Supporting PRs:

https://github.com/zephyrproject-rtos/zephyr/pull/97823
https://github.com/zephyrproject-rtos/zephyr/pull/96877
https://github.com/zephyrproject-rtos/zephyr/pull/88874
https://github.com/zephyrproject-rtos/zephyr/pull/94831 (changes included as part of a different Infineon PR)
