### PR TITLE
drivers: can: tcan4x5x: various power management related changes

### DIFF
--- a/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
+++ b/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
@@ -23,6 +23,7 @@
 		reset-gpios = <&mikrobus_header 1 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
+		ti,nwkrq-voltage-vio;
 
 		can-transceiver {
 			max-bitrate = <8000000>;

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -30,6 +30,7 @@
 		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
+		ti,nwkrq-voltage-vio;
 		status = "okay";
 
 		can-transceiver {

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -24,7 +24,8 @@
 		spi-max-frequency = <2000000>;
 		status = "okay";
 		clock-frequency = <40000000>;
-		device-state-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		device-state-gpios = <&arduino_header ARDUINO_HEADER_R3_D6
+				      (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 		device-wake-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -225,6 +225,10 @@ Controller Area Network (CAN)
   :kconfig:option:`CONFIG_CAN_NXP_LPC_MCAN` as this driver is not based on the NXP MCUXpresso HAL
   (:github:`103679`).
 
+* Added devicetree property ``ti,nwkrq-voltage-vio`` to :dtcompatible:`ti,tcan4x5x` to allow
+  configuring the voltage rail used for the ``nWKRQ`` pin. To maintain previous driver default of
+  using VIO, this property must be set (:github:`104182`).
+
 Counter
 =======
 

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -236,6 +236,7 @@ struct tcan4x5x_config {
 #endif /* TCAN4X5X_WAKE_GPIO_SUPPORT */
 	struct gpio_dt_spec int_gpio;
 	uint32_t clk_freq;
+	bool nwkrq_voltage_vio;
 };
 
 struct tcan4x5x_data {
@@ -639,8 +640,13 @@ static int tcan4x5x_init_normal_mode(const struct device *dev)
 		reg |= CAN_TCAN4X5X_MODE_CONFIG_CLK_REF;
 	}
 
-	/* Set nWKRQ voltage to VIO */
-	reg |= CAN_TCAN4X5X_MODE_CONFIG_NWKRQ_VOLTAGE;
+	if (tcan_config->nwkrq_voltage_vio) {
+		/* Set nWKRQ voltage to VIO, open-drain */
+		reg |= CAN_TCAN4X5X_MODE_CONFIG_NWKRQ_VOLTAGE;
+	} else {
+		/* Set nWKRQ voltage to use internal voltage rail, push-pull */
+		reg &= ~(CAN_TCAN4X5X_MODE_CONFIG_NWKRQ_VOLTAGE);
+	}
 
 	/* Write remaining configuration to the device */
 	err = tcan4x5x_write_tcan_reg(dev, CAN_TCAN4X5X_MODE_CONFIG, reg);
@@ -897,6 +903,7 @@ static const struct can_mcan_ops tcan4x5x_ops = {
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.int_gpio = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                                \
 		.clk_freq = DT_INST_PROP(inst, clock_frequency),                                   \
+		.nwkrq_voltage_vio = DT_INST_PROP(inst, ti_nwkrq_voltage_vio),                     \
 		TCAN4X5X_RST_GPIO_INIT(inst)                                                       \
 		TCAN4X5X_NWKRQ_GPIO_INIT(inst)                                                     \
 		TCAN4X5X_WAKE_GPIO_INIT(inst)                                                      \

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -206,13 +206,14 @@ LOG_MODULE_REGISTER(can_tcan4x5x, CONFIG_CAN_LOG_LEVEL);
 #define CAN_TCAN4X5X_READ_B_FL  0x41
 
 /* TCAN4x5x timing requirements */
-#define CAN_TCAN4X5X_T_MODE_STBY_NOM_US 70
-#define CAN_TCAN4X5X_T_MODE_NOM_SLP_US  200
-#define CAN_TCAN4X5X_T_MODE_NOM_STBY_US 200
-#define CAN_TCAN4X5X_T_MODE_SLP_STBY_US 200
-#define CAN_TCAN4X5X_T_WAKE_US          50
-#define CAN_TCAN4X5X_T_PULSE_WIDTH_US   30
-#define CAN_TCAN4X5X_T_RESET_US         1000
+#define CAN_TCAN4X5X_T_MODE_STBY_NOM_US           70
+#define CAN_TCAN4X5X_T_MODE_NOM_SLP_US            200
+#define CAN_TCAN4X5X_T_MODE_NOM_STBY_US           200
+#define CAN_TCAN4X5X_T_MODE_SLP_STBY_US           200
+#define CAN_TCAN4X5X_T_MODE_SLP_STBY_VCCOUT_ON_US 1500
+#define CAN_TCAN4X5X_T_WAKE_US                    50
+#define CAN_TCAN4X5X_T_PULSE_WIDTH_US             30
+#define CAN_TCAN4X5X_T_RESET_US                   1000
 
 /*
  * Only compile in support for the optional GPIOs if at least one enabled tcan4x5x device tree node
@@ -509,6 +510,8 @@ static int tcan4x5x_wake(const struct device *dev)
 			LOG_ERR("failed to deassert WAKE GPIO (err %d)", err);
 			return err;
 		}
+
+		k_usleep(CAN_TCAN4X5X_T_MODE_SLP_STBY_VCCOUT_ON_US);
 	}
 #endif /* TCAN4X5X_WAKE_GPIO_SUPPORT*/
 

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -555,7 +555,7 @@ static int tcan4x5x_reset(const struct device *dev)
 	}
 #endif /* TCAN4X5X_RST_GPIO_SUPPORT */
 
-	k_busy_wait(CAN_TCAN4X5X_T_RESET_US);
+	k_usleep(CAN_TCAN4X5X_T_RESET_US);
 
 	return 0;
 }

--- a/dts/bindings/can/ti,tcan4x5x.yaml
+++ b/dts/bindings/can/ti,tcan4x5x.yaml
@@ -39,6 +39,17 @@ properties:
     description: |
       GPIO connected to the TCAN4x5x nINT interrupt output. This signal is open-drain, active low.
 
+  ti,nwkrq-voltage-vio:
+    type: boolean
+    description: |
+      nWKRQ pin GPO buffer voltage rail configuration.
+
+      If set, the nWKRQ pin GPO buffer is configured as open-drain, requiring an external pull-up
+      resistor to the VIO rail.
+
+      If unset, the nWKRQ pin GPO buffer is configured as push-pull based off an internal voltage
+      rail.
+
 examples:
   - |
     &spi0 {
@@ -52,6 +63,7 @@ examples:
         reset-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
         int-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
         bosch,mram-cfg = <0x0 15 15 5 5 0 10 10>;
+        ti,nwkrq-voltage-vio;
         status = "okay";
 
         can-transceiver {


### PR DESCRIPTION
- boards: shields: tcan4550evm: enable internal pull-up on nWKRQ
- drivers: can: tcan4x5x: do no busy wait for an entire millisecond
- drivers: can: tcan4x5x: allow for VCCOUT to stabilize on local wake-up
- dts: bindings: can: ti: tcan4x5x: add property for the nWKRQ voltage
- boards: shields: mikroe_can_fd_6_click: configure nWKRQ pin for VIO
- boards: shields: tcan4550evm: configure nWKRQ pin for VIO
- drivers: can: tcan4x5x: add support for configuring nWKRQ pin voltage rail
- doc: releases: migration-guide: 4.4: mention new ti,tcan4x5x property