### PR TITLE
boards: adi: Add display support to MAX32666EKVIT

### DIFF
--- a/boards/adi/max32666evkit/Kconfig.defconfig
+++ b/boards/adi/max32666evkit/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# MAX32666EVKIT boards configuration defaults
+
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32666EVKIT
+
+if DISPLAY
+
+if LVGL
+
+config LV_Z_VDB_SIZE
+	default 16
+
+config LV_DPI_DEF
+	default 150
+
+config LV_Z_BITS_PER_PIXEL
+	default 1
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32666EVKIT

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram4;
 		zephyr,flash = &flash0;
+		zephyr,display = &ls0xx_ls013b7dh03;
 	};
 
 	leds {
@@ -61,6 +62,25 @@
 		sw0 = &pb1;
 		sw1 = &pb2;
 		watchdog0 = &wdt0;
+	};
+
+	spibb0: spibb0 {
+		compatible = "zephyr,spi-bitbang";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clk-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		mosi-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		cs-gpios = <&gpio1 8 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+
+		ls0xx_ls013b7dh03: ls0xx@0 {
+			compatible = "sharp,ls0xx";
+			spi-max-frequency = <2000000>;
+			reg = <0>;
+			width = <128>;
+			height = <128>;
+			disp-en-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		};
 	};
 };
 

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
@@ -10,6 +10,7 @@ supported:
   - dma
   - i2c
   - gpio
+  - display
   - serial
   - trng
   - watchdog


### PR DESCRIPTION
Enable the sharp MIP display present on the MAX32666EVKIT, using the bitbang SPI driver, since the hardware SPI peripheral does not support LSB transfers used by the LS0XX driver.