### PR TITLE
kernel: msgq: Fix __ASSERT_NO_MSG() checks

### DIFF
--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -153,8 +153,9 @@ static inline int put_msg_in_queue(struct k_msgq *msgq, const void *data,
 			arch_thread_return_value_set(pending_thread, 0);
 			z_ready_thread(pending_thread);
 		} else {
-			__ASSERT_NO_MSG(msgq->write_ptr >= msgq->buffer_start &&
-					msgq->write_ptr < msgq->buffer_end);
+			__ASSERT_NO_MSG((msgq->write_ptr >= msgq->buffer_start) &&
+					(msgq->write_ptr <= (msgq->buffer_end - 1)));
+
 			if (put_at_back) {
 				/*
 				 * to write a message to the back of the queue,
@@ -299,8 +300,8 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 			SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_msgq, get, msgq, timeout);
 
 			/* add thread's message to queue */
-			__ASSERT_NO_MSG(msgq->write_ptr >= msgq->buffer_start &&
-					msgq->write_ptr < msgq->buffer_end);
+			__ASSERT_NO_MSG((msgq->write_ptr >= msgq->buffer_start) &&
+					(msgq->write_ptr <= (msgq->buffer_end - 1)));
 			(void)memcpy(msgq->write_ptr, (char *)pending_thread->base.swap_data,
 			       msgq->msg_size);
 			msgq->write_ptr += msgq->msg_size;


### PR DESCRIPTION
The message queue 'buffer_end' field points to the next address AFTER the end of the buffer. When the buffer goes to the last addressable byte, the next byte is 0x0. To ensure proper evaluation of the bounds the __ASSERT_NO_MSG() checks must not use "< buffer_end", but "<= buffer_end - 1".