### PR TITLE
boards: wiznet: fix flash size and update documentation

### DIFF
--- a/boards/wiznet/w5500_evb_pico/Kconfig
+++ b/boards/wiznet/w5500_evb_pico/Kconfig
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Yonatan Schachter
-# Copyright (c) 2023 Ian Wakely
+# SPDX-FileCopyrightText: Copyright 2021 Yonatan Schachter
+# SPDX-FileCopyrightText: Copyright 2023 Ian Wakely
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_W5500_EVB_PICO

--- a/boards/wiznet/w5500_evb_pico/Kconfig.defconfig
+++ b/boards/wiznet/w5500_evb_pico/Kconfig.defconfig
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Yonatan Schachter
-# Copyright (c) 2023 Ian Wakely
+# SPDX-FileCopyrightText: Copyright 2021 Yonatan Schachter
+# SPDX-FileCopyrightText: Copyright 2023 Ian Wakely
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_W5500_EVB_PICO

--- a/boards/wiznet/w5500_evb_pico/Kconfig.w5500_evb_pico
+++ b/boards/wiznet/w5500_evb_pico/Kconfig.w5500_evb_pico
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Yonatan Schachter
-# Copyright (c) 2023 Ian Wakely
+# SPDX-FileCopyrightText: Copyright 2021 Yonatan Schachter
+# SPDX-FileCopyrightText: Copyright 2023 Ian Wakely
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_W5500_EVB_PICO

--- a/boards/wiznet/w5500_evb_pico/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico/doc/index.rst
@@ -14,7 +14,7 @@ Hardware
 ********
 - Dual core Arm Cortex-M0+ processor running up to 133MHz
 - 264KB on-chip SRAM
-- 16MB on-board QSPI flash with XIP capabilities
+- 2MB on-board QSPI flash with XIP capabilities
 - 26 GPIO pins
 - 3 Analog inputs
 - 2 UART peripherals
@@ -22,7 +22,7 @@ Hardware
 - 2 I2C controllers
 - 16 PWM channels
 - USB 1.1 controller (host/device)
-- 8 Programmable I/O (PIO) for custom peripherals
+- 2 Programmable IO (PIO) blocks, 8 state machines total
 - On-board LED
 - 1 Watchdog timer peripheral
 - Wiznet W5500 Ethernet MAC/PHY
@@ -41,12 +41,13 @@ the datasheet to see the possible routings for each peripheral.
 
 External pin mapping on the W5500_EVB_PICO is identical to the Raspberry Pi
 Pico. Since GPIO 25 is routed to the on-board LED on, similar to the Raspberry
-Pi Pico, the blinky example works as intended. The W5500 is routed to the SPI0
+Pi Pico, the blinky example works as intended. GPIO 29 (ADC_CH3) is connected
+internally to measure VSYS/3.The W5500 is routed to the SPI0
 (P16-P19), with the reset and interrupt signal for the W5500 routed to P20 and
 P21, respectively. All of these are shared with the edge connector on the
 board.
 
-Refer to `W55500 Evaluation Board Documentation`_ for a board schematic and
+Refer to `W5500 Evaluation Board Documentation`_ for a board schematic and
 other certifications.
 
 Default Zephyr Peripheral Mapping:
@@ -77,7 +78,7 @@ Programming and Debugging
 .. zephyr:board-supported-runners::
 
 The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
-See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation.
 
 Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
@@ -95,5 +96,5 @@ Below is an example of building and flashing the :zephyr:code-sample:`blinky` ap
 .. _Getting Started with Raspberry Pi Pico:
   https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
 
-.. _W55500 Evaluation Board Documentation:
-  https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico
+.. _W5500 Evaluation Board Documentation:
+  https://docs.wiznet.io/Product/Chip/Ethernet/W5500/w5500-evb-pico

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico-pinctrl.dtsi
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Yonatan Schachter
+ * SPDX-FileCopyrightText: Copyright 2021, Yonatan Schachter
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 Yonatan Schachter
- * Copyright (c) 2023 Ian Wakely
+ * SPDX-FileCopyrightText: Copyright 2021 Yonatan Schachter
+ * SPDX-FileCopyrightText: Copyright 2023 Ian Wakely
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -85,19 +85,17 @@
 };
 
 &flash0 {
-	/* 16MB of flash minus the 0x100 used for
-	 * the second stage bootloader
-	 */
-	reg = <0x10000000 DT_SIZE_M(16)>;
-	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
+	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -105,11 +103,12 @@
 
 		/*
 		 * Usable flash. Starts at 0x100, after the bootloader. The partition
-		 * size is 16MB minus the 0x100 bytes taken by the bootloader.
+		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
+			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;
 		};
 	};

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.yaml
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.yaml
@@ -2,7 +2,7 @@ identifier: w5500_evb_pico
 name: Wiznet W5500 Evaluation Board
 type: mcu
 arch: arm
-flash: 16384
+flash: 2048
 ram: 264
 toolchain:
   - zephyr

--- a/boards/wiznet/w5500_evb_pico2/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico2/doc/index.rst
@@ -13,7 +13,7 @@ their SWD interface, using an external adapter.
 Hardware
 ********
 
-- Dual core Arm Cortex-M33 or Hazard3 processor running up to 133MHz
+- Dual core Arm Cortex-M33 or Hazard3 processor running up to 150MHz
 - 520KB on-chip SRAM
 - 16MB on-board QSPI flash with XIP capabilities
 - 26 GPIO pins
@@ -21,11 +21,12 @@ Hardware
 - 2 UART peripherals
 - 2 SPI controllers
 - 2 I2C controllers
-- 16 PWM channels
+- 24 PWM channels
 - USB 1.1 controller (host/device)
-- 3 Programmable I/O (PIO) for custom peripherals
+- 3 Programmable IO (PIO) blocks, 12 state machines total
 - On-board LED
 - 1 Watchdog timer peripheral
+- 1 HSTX pheripheral
 - Wiznet W5500 Ethernet MAC/PHY
 
 Supported Features
@@ -42,12 +43,13 @@ the datasheet to see the possible routings for each peripheral.
 
 External pin mapping on the W5500_EVB_PICO2 is identical to the Raspberry Pi
 Pico2. Since GPIO 25 is routed to the on-board LED on, similar to the Raspberry
-Pi Pico, the blinky example works as intended. The W5500 is routed to the SPI0
+Pi Pico, the blinky example works as intended. GPIO 29 (ADC_CH3) is connected
+internally to measure VSYS/3. The W5500 is routed to the SPI0
 (P16-P19), with the reset and interrupt signal for the W5500 routed to P20 and
 P21, respectively. All of these are shared with the edge connector on the
 board.
 
-Refer to `W55500 Evaluation Board Pico2 Documentation`_ for a board schematic and
+Refer to `W5500 Evaluation Board Pico2 Documentation`_ for a board schematic and
 other certifications.
 
 Default Zephyr Peripheral Mapping:
@@ -77,9 +79,14 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
-See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
+.. note::
 
+   The OpenOCD version bundled with Zephyr SDK does not currently support the
+   RP2350. To debug this board, use the Raspberry Pi OpenOCD fork or an external
+   debug probe such as Segger J-Link.
+
+The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation.
 Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -96,5 +103,5 @@ Below is an example of building and flashing the :zephyr:code-sample:`blinky` ap
 .. _Getting Started with Raspberry Pi Pico:
   https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
 
-.. _W55500 Evaluation Board Pico2 Documentation:
-  https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2
+.. _W5500 Evaluation Board Pico2 Documentation:
+  https://docs.wiznet.io/Product/Chip/Ethernet/W5500/w5500-evb-pico2

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	pico_header: connector {
@@ -80,10 +81,35 @@
 };
 
 &flash0 {
-	/* 16MB of flash minus the 0x100 used for
-	 * the second stage bootloader
-	 */
-	reg = <0x10000000 DT_SIZE_M(16)>;
+	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Reserved memory for the second stage bootloader */
+		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "second_stage_bootloader";
+			reg = <0x00000000 0x100>;
+			read-only;
+		};
+
+		/*
+		 * Usable flash. Starts at 0x100, after the bootloader. The partition
+		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
+		 */
+		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
+			label = "code-partition";
+			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
+			read-only;
+		};
+	};
 };
 
 &uart0 {

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2_rp2350a_m33.yaml
@@ -2,7 +2,7 @@ identifier: w5500_evb_pico2/rp2350a/m33
 name: Wiznet W5500 Evaluation Board with RP2350
 type: mcu
 arch: arm
-flash: 16384
+flash: 2048
 ram: 520
 toolchain:
   - zephyr


### PR DESCRIPTION
Summary of changes:
    1. Fixed the flash size setting to 2MB. The flash memory uses in [w5500-evb-pico](https://docs.wiznet.io/assets/images/w5500_evb_pico_schematic-69ae2bc3858a5c48bc88c17b04f30967.png) and [w5500-evb-pico2](https://docs.wiznet.io/assets/images/sch-w5500-evb-pico2-v100-789bda353040ebd9198df2f3b19770e6.png) is [W25Q16JV](https://www.winbond.com/hq/product/code-storage-flash-memory/serial-nor-flash/?__locale=en&partNo=W25Q16JV) which has 16M-bit, 2M-byte capacity.
    2. Added a note clarifying that the RPI-PICO has 4 ADCs, one of which is internally connected.
    3. Updated documentation to indicate that OpenOCD 0.12 now supports the RPI-PICO.
    4. Corrected the number of PIO blocks according to the official datasheet.
    5. Standardized the copyright style.
    6. Updated broken/outdated documentation links.
    7. Fixed the maximum CPU frequency for Pico 2 (changed from incorrect 133MHz to 150MHz).
    8. Corrected the PWM channel count for RP2350A to 24.