### PR TITLE
drivers: rtc: pcf8563: Fix year offset conversion

### DIFF
--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -136,7 +136,7 @@ static int pcf8563_set_time(const struct device *dev, const struct rtc_time *tim
 	raw_time[6] = bin2bcd(timeptr->tm_mon);
 
 	/* Set year */
-	raw_time[7] = bin2bcd(timeptr->tm_year);
+	raw_time[7] = bin2bcd(timeptr->tm_year % 100);
 
 	/* Write to device */
 	ret = i2c_write_dt(&config->i2c, raw_time, sizeof(raw_time));
@@ -190,6 +190,7 @@ static int pcf8563_get_time(const struct device *dev, struct rtc_time *timeptr)
 
 	/* Get year */
 	timeptr->tm_year = bcd2bin(raw_time[6]);
+	timeptr->tm_year = timeptr->tm_year + 100;
 
 	/* Day number not used */
 	timeptr->tm_yday = -1;


### PR DESCRIPTION
The PCF8563 stores years as 2-digit BCD (00-99 for years 2000-2099) as specified in the datasheet (Table 17, section 8.4.7): https://www.nxp.com/docs/en/data-sheet/PCF8563.pdf

However, struct rtc_time uses tm_year as years since 1900 (100-199 for years 2000-2099).

The driver was incorrectly passing tm_year directly to bin2bcd() without conversion, causing:
1. Invalid BCD values to be written (e.g., 0x7E for year 2026)
2. 100-year offset when reading back (year 2026 read as 1926)

Fix by:
- SET: Use modulo 100 to convert tm_year to chip format
- GET: Add 100 to convert chip value back to tm_year

This follows the same pattern as the DS1307 driver (drivers/rtc/rtc_ds1307.c).

Tested in Renode simulation with custom PCF8563 peripheral. All test years (2000, 2026, 2050, 2099) pass with valid BCD values.

Fixes #103971