### PR TITLE
[Backport v3.7-branch] net: ipv6: Do packet length checks before starting fragment reassembly

### DIFF
--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -492,13 +492,6 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	reass = reassembly_get(id, (struct in6_addr *)hdr->src,
-			       (struct in6_addr *)hdr->dst);
-	if (!reass) {
-		NET_DBG("Cannot get reassembly slot, dropping pkt %p", pkt);
-		goto drop;
-	}
-
 	more = flag & 0x01;
 	net_pkt_set_ipv6_fragment_flags(pkt, flag);
 
@@ -509,6 +502,13 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 		 */
 		net_icmpv6_send_error(pkt, NET_ICMPV6_PARAM_PROBLEM,
 				      NET_ICMPV6_PARAM_PROB_HEADER, NET_IPV6H_LENGTH_OFFSET);
+		goto drop;
+	}
+
+	reass = reassembly_get(id, (struct in6_addr *)hdr->src,
+			       (struct in6_addr *)hdr->dst);
+	if (reass == NULL) {
+		NET_DBG("Cannot get reassembly slot, dropping pkt %p", pkt);
 		goto drop;
 	}
 


### PR DESCRIPTION
Make sure to check packet length check before starting the IPv6 fragmentation reassembly process. This way we can drop the malformed packet without consuming resources.


(cherry picked from commit 66812f66a79883182a0d6a310456e35ff4e0652a)

Backport 66812f66a79883182a0d6a310456e35ff4e0652a from #104044.

Fixes #104208
