### PR TITLE
soc: espressif: fix bootloader memory layout for all SoCs

### DIFF
--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
 /* SRAM0 (192kB)  instruction cache+memory */
 #define SRAM0_IRAM_START    DT_REG_ADDR(DT_NODELABEL(sram0))
 #define SRAM0_CACHE_SIZE    0x10000
@@ -62,16 +64,19 @@
 #define SRAM1_DRAM_IRAM_CALC(addr_dram) (SRAM1_SIZE - (addr_dram - SRAM1_DRAM_START) + \
 					SRAM1_IRAM_START)
 
-/* Set bootloader segments size */
-#define BOOTLOADER_DRAM_SEG_LEN        0x8000
-#define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x4000
-#define BOOTLOADER_IRAM_SEG_LEN        0xa000
-
-/* Start of the lower region is determined by region size and the end of the higher region */
-#define BOOTLOADER_DRAM_SEG_START  0x3ffe8000
-#define BOOTLOADER_DRAM_SEG_END    (BOOTLOADER_DRAM_SEG_START + BOOTLOADER_DRAM_SEG_LEN)
+/* Bootloader segment start addresses (fixed by physical bank layout) */
+#define BOOTLOADER_DRAM_SEG_START        0x3ffe8000
 #define BOOTLOADER_IRAM_LOADER_SEG_START 0x40078000
-#define BOOTLOADER_IRAM_SEG_START  0x400a0000
+#define BOOTLOADER_IRAM_SEG_START        ALIGN_UP(SRAM1_IRAM_START, 0x400)
+
+/* Bootloader segment sizes (computed from bank boundaries) */
+#define BOOTLOADER_DRAM_SEG_LEN \
+	(SRAM1_DRAM_END - BOOTLOADER_DRAM_SEG_START)
+#define BOOTLOADER_DRAM_SEG_END \
+	(BOOTLOADER_DRAM_SEG_START + BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_LOADER_SEG_LEN \
+	((SRAM0_IRAM_START + SRAM0_CACHE_SIZE) - BOOTLOADER_IRAM_LOADER_SEG_START)
+#define BOOTLOADER_IRAM_SEG_LEN         SRAM1_SIZE
 
 /* The `USER_IRAM_END` represents the end of staticaly allocated memory.
  * This address is where 2nd stage bootloader starts allocating memory.

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -15,7 +15,7 @@
  * If no bootloader is used, we can extend it to gain more user ram.
  */
 #ifdef CONFIG_ESP_SIMPLE_BOOT
-user_iram_end = (DRAM_BUFFERS_START + IRAM_DRAM_OFFSET);
+user_iram_end = (DRAM_SHARED_BUFFERS_END + IRAM_DRAM_OFFSET);
 #else
 user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
@@ -86,7 +86,7 @@ _rom_store_table = 0;
 _iram_dram_offset = IRAM_DRAM_OFFSET;
 
 /* Heap size calculations */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -15,7 +15,7 @@
  * If no bootloader is used, we can extend it to gain more user ram.
  */
 #ifdef CONFIG_ESP_SIMPLE_BOOT
-user_iram_end = (DRAM_BUFFERS_START + IRAM_DRAM_OFFSET);
+user_iram_end = (DRAM_SHARED_BUFFERS_END + IRAM_DRAM_OFFSET);
 #else
 user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
@@ -103,7 +103,7 @@ _rom_store_table = 0;
 _iram_dram_offset = IRAM_DRAM_OFFSET;
 
 /* Heap size calculations */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/soc/espressif/esp32c3/memory.h
+++ b/soc/espressif/esp32c3/memory.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
 /* SRAM0 (16kB) memory */
 #define SRAM0_IRAM_START   DT_REG_ADDR(DT_NODELABEL(sram0))
 #define SRAM0_SIZE         DT_REG_SIZE(DT_NODELABEL(sram0))
@@ -33,35 +35,44 @@
  * Used to convert between 0x403xxxxx and 0x3fcxxxxx addresses.
  */
 #define IRAM_DRAM_OFFSET         0x700000
-#define DRAM_BUFFERS_START       0x3fccae00
-#define DRAM_BUFFERS_END         0x3fccc000
-#define DRAM_STACK_START         0x3fcdc710
+#define DRAM_SHARED_BUFFERS_START       0x3fccae00
+#define DRAM_SHARED_BUFFERS_END         0x3fcdc710
+#define DRAM_STACK_START         DRAM_SHARED_BUFFERS_END
 #define DRAM_ROM_BSS_DATA_START  0x3fcde710
 
-/* Set the limit for the application runtime dynamic allocations */
-#define DRAM_RESERVED_START      DRAM_BUFFERS_END
+/* Upper boundary of user-usable SRAM */
+#define DRAM_USER_END      DRAM_SHARED_BUFFERS_END
 
-/* Base address used for calculating memory layout
- * counted from Dbus backwards and back to the Ibus
- */
-#define BOOTLOADER_USER_DRAM_END DRAM_BUFFERS_START
+/* Upper limit of SRAM available for MCUboot bootloader segments */
+/* Safety margin between MCUboot segments and ROM stack */
+#define BOOTLOADER_STACK_OVERHEAD      0x2000
 
-/* For safety margin between bootloader data section and startup stacks */
-#define BOOTLOADER_STACK_OVERHEAD      0x0
-/* These lengths can be adjusted, if necessary: */
-#define BOOTLOADER_DRAM_SEG_LEN        0x9800
-#define BOOTLOADER_IRAM_SEG_LEN        0x9C00
+#define BOOTLOADER_USER_DRAM_END (DRAM_SHARED_BUFFERS_END - BOOTLOADER_STACK_OVERHEAD)
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x1400
 
-/* Start of the lower region is determined by region size and the end of the higher region */
 #define BOOTLOADER_IRAM_LOADER_SEG_END \
-		(BOOTLOADER_USER_DRAM_END + BOOTLOADER_STACK_OVERHEAD + IRAM_DRAM_OFFSET)
+		(BOOTLOADER_USER_DRAM_END + IRAM_DRAM_OFFSET)
 #define BOOTLOADER_IRAM_LOADER_SEG_START \
 		(BOOTLOADER_IRAM_LOADER_SEG_END - BOOTLOADER_IRAM_LOADER_SEG_LEN)
+
+/* MCUboot iram/dram segments: stacked in upper SRAM, below iram_loader_seg.
+ * On split-bus SoCs, iram_seg and dram_seg MUST occupy separate physical
+ * SRAM regions (IRAM and DRAM buses map to the same physical memory).
+ * Layout (in physical/DRAM space, top-down):
+ *   iram_loader_seg  (IRAM bus)
+ *   iram_seg         (IRAM bus, 256-byte aligned start)
+ *   dram_seg         (DRAM bus)
+ */
+#define BOOTLOADER_IRAM_SEG_TARGET_LEN \
+	((BOOTLOADER_IRAM_LOADER_SEG_START - IRAM_DRAM_OFFSET - \
+	  (SRAM1_DRAM_START + ICACHE_SIZE)) / 4)
 #define BOOTLOADER_IRAM_SEG_START \
-		(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
+	ALIGN_UP(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_TARGET_LEN, 0x100)
+#define BOOTLOADER_IRAM_SEG_LEN \
+	(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_START)
+#define BOOTLOADER_DRAM_SEG_LEN   BOOTLOADER_IRAM_SEG_LEN
 #define BOOTLOADER_DRAM_SEG_START \
-		(BOOTLOADER_IRAM_SEG_START - IRAM_DRAM_OFFSET - BOOTLOADER_DRAM_SEG_LEN)
+	(BOOTLOADER_IRAM_SEG_START - IRAM_DRAM_OFFSET - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
 #ifdef CONFIG_FLASH_SIZE

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -16,7 +16,7 @@
  * If no bootloader is used, we can extend it to gain more user ram.
  */
 #ifdef CONFIG_ESP_SIMPLE_BOOT
-user_sram_end = DRAM_BUFFERS_START;
+user_sram_end = DRAM_SHARED_BUFFERS_END;
 #else
 user_sram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
@@ -122,7 +122,7 @@ REGION_ALIAS("rtc_data_location", rtc_iram_seg );
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 /* Heap size calculations */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -16,7 +16,7 @@
  * If no bootloader is used, we can extend it to gain more user ram.
  */
 #ifdef CONFIG_ESP_SIMPLE_BOOT
-user_sram_end = DRAM_BUFFERS_START;
+user_sram_end = DRAM_SHARED_BUFFERS_END;
 #else
 user_sram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
@@ -102,7 +102,7 @@ REGION_ALIAS("rtc_data_location", rtc_iram_seg );
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 /* Heap size calculations */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/soc/espressif/esp32h2/memory.h
+++ b/soc/espressif/esp32h2/memory.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
 /* LP-SRAM (4kB) memory */
 #define LPSRAM_IRAM_START DT_REG_ADDR(DT_NODELABEL(sramlp))
 #define LPSRAM_SIZE       DT_REG_SIZE(DT_NODELABEL(sramlp))
@@ -29,30 +31,36 @@
  *  buffers area (0x4084d380).
  */
 
-#define DRAM_BUFFERS_START      0x4083ba78
-#define DRAM_BUFFERS_END        0x4084d380
-#define DRAM_STACK_START        DRAM_BUFFERS_END
+#define DRAM_SHARED_BUFFERS_START      0x4083ba78
+#define DRAM_SHARED_BUFFERS_END        0x4084d380
+#define DRAM_STACK_START        DRAM_SHARED_BUFFERS_END
 #define DRAM_ROM_BSS_DATA_START 0x4084f380
 
-/* Set the limit for the application runtime dynamic allocations */
-#define DRAM_RESERVED_START DRAM_BUFFERS_END
+/* Upper boundary of user-usable SRAM */
+#define DRAM_USER_END DRAM_SHARED_BUFFERS_END
 
-/* For safety margin between bootloader data section and startup stacks */
-#define BOOTLOADER_STACK_OVERHEAD      0x0
-/* These lengths can be adjusted, if necessary: FIXME: optimize ram usage */
-#define BOOTLOADER_DRAM_SEG_LEN        0xA000
+/* Safety margin between MCUboot segments and ROM stack */
+#define BOOTLOADER_STACK_OVERHEAD      0x2000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x3000
-#define BOOTLOADER_IRAM_SEG_LEN        0xC000
 
-/* Base address used for calculating memory layout
- * counted from Dbus backwards and back to the Ibus
+/* Upper limit of SRAM available for MCUboot bootloader segments */
+#define BOOTLOADER_USER_DRAM_END (DRAM_SHARED_BUFFERS_END - BOOTLOADER_STACK_OVERHEAD)
+
+#define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_USER_DRAM_END - BOOTLOADER_IRAM_LOADER_SEG_LEN)
+
+/* MCUboot iram/dram segments: placed in upper half of SRAM, below iram_loader_seg.
+ * On unified-address SoCs (C6, H2) these are the same physical memory.
+ * The lower half is reserved for the application image.
  */
-#define BOOTLOADER_USER_SRAM_END (DRAM_BUFFERS_START - BOOTLOADER_STACK_OVERHEAD)
-
-/* Start of the lower region is determined by region size and the end of the higher region */
-#define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_USER_SRAM_END - BOOTLOADER_IRAM_LOADER_SEG_LEN)
-#define BOOTLOADER_IRAM_SEG_START       (BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
-#define BOOTLOADER_DRAM_SEG_START        (BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_SEG_TARGET_LEN \
+	((BOOTLOADER_IRAM_LOADER_SEG_START - (HPSRAM_START + ICACHE_SIZE)) / 4)
+#define BOOTLOADER_IRAM_SEG_START \
+	ALIGN_UP(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_TARGET_LEN, 0x100)
+#define BOOTLOADER_IRAM_SEG_LEN \
+	(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_START)
+#define BOOTLOADER_DRAM_SEG_LEN   BOOTLOADER_IRAM_SEG_LEN
+#define BOOTLOADER_DRAM_SEG_START \
+	(BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Flash */
 #ifdef CONFIG_FLASH_SIZE

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -17,7 +17,7 @@
  * If no bootloader is used, we can extend it to gain more user ram.
  */
 #ifdef CONFIG_ESP_SIMPLE_BOOT
-user_iram_end = (BOOTLOADER_USER_DRAM_END + IRAM_DRAM_OFFSET);
+user_iram_end = (DRAM_SHARED_BUFFERS_END + IRAM_DRAM_OFFSET);
 #else
 user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
@@ -122,7 +122,7 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 _rom_store_table = 0;
 
 /* Used as a pointer to the heap end */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/soc/espressif/esp32s2/memory.h
+++ b/soc/espressif/esp32s2/memory.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
 /* SRAM0 (32k) with adjacted SRAM1 (288k)
  * Ibus and Dbus address space
  */
@@ -29,38 +31,49 @@
  *  - 0x3fffe710 - 0x40000000: ROM .bss and .data (not easily reclaimable)
  *
  *  The 2nd stage bootloader can take space up to the end of ROM shared
- *  buffers area (0x3fffc410). For alignment purpose we shall use value (0x3fce9700).
+ *  buffers area (0x3fffc410).
  */
 
 /* The offset between Dbus and Ibus.
  * Used to convert between 0x4002xxxx and 0x3ffbxxxx addresses.
  */
 #define IRAM_DRAM_OFFSET         0x70000
-#define DRAM_BUFFERS_START       0x3ffea400
-#define DRAM_BUFFERS_END         0x3fffc410
-#define DRAM_ROM_CPU_STACK_START 0x3fffc410
+#define DRAM_SHARED_BUFFERS_START       0x3ffea400
+#define DRAM_SHARED_BUFFERS_END         0x3fffc410
+#define DRAM_STACK_START 0x3fffc410
 #define DRAM_ROM_BSS_DATA_START  0x3fffe710
 
-/* For safety margin between bootloader data section and startup stacks */
-#define BOOTLOADER_STACK_OVERHEAD      0x0
-#define BOOTLOADER_DRAM_SEG_LEN        0x8000
+/* Safety margin between MCUboot segments and ROM stack */
+#define BOOTLOADER_STACK_OVERHEAD      0x2000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x3000
-#define BOOTLOADER_IRAM_SEG_LEN        0xa000
 
-/* Set the limit for the application runtime dynamic allocations */
-#define DRAM_RESERVED_START      DRAM_BUFFERS_END
+/* Upper boundary of user-usable SRAM */
+#define DRAM_USER_END      DRAM_SHARED_BUFFERS_END
 
-/* Base address used for calculating memory layout
- * counted from Dbus backwards and back to the Ibus
- */
-#define BOOTLOADER_USER_DRAM_END (DRAM_BUFFERS_START - BOOTLOADER_STACK_OVERHEAD)
+/* Upper limit of SRAM available for MCUboot bootloader segments */
+#define BOOTLOADER_USER_DRAM_END (DRAM_SHARED_BUFFERS_END - BOOTLOADER_STACK_OVERHEAD)
 
-/* Start of the lower region is determined by region size and the end of the higher region */
 #define BOOTLOADER_IRAM_LOADER_SEG_START \
 	(BOOTLOADER_USER_DRAM_END - BOOTLOADER_IRAM_LOADER_SEG_LEN + IRAM_DRAM_OFFSET)
-#define BOOTLOADER_IRAM_SEG_START (BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
+
+/* MCUboot iram/dram segments: stacked in upper SRAM, below iram_loader_seg.
+ * On Xtensa split-bus SoCs, iram_seg and dram_seg MUST occupy separate physical
+ * SRAM regions (IRAM and DRAM buses map to the same physical memory).
+ * Layout (in physical/DRAM space, top-down):
+ *   iram_loader_seg  (IRAM bus)
+ *   iram_seg         (IRAM bus, 1024-byte aligned start for Xtensa VECBASE)
+ *   dram_seg         (DRAM bus)
+ */
+#define BOOTLOADER_IRAM_SEG_TARGET_LEN \
+	((BOOTLOADER_IRAM_LOADER_SEG_START - IRAM_DRAM_OFFSET - \
+	  (SRAM_DRAM_START + SRAM_CACHE_SIZE)) / 4)
+#define BOOTLOADER_IRAM_SEG_START \
+	ALIGN_UP(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_TARGET_LEN, 0x400)
+#define BOOTLOADER_IRAM_SEG_LEN \
+	(BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_START)
+#define BOOTLOADER_DRAM_SEG_LEN   BOOTLOADER_IRAM_SEG_LEN
 #define BOOTLOADER_DRAM_SEG_START \
-	(BOOTLOADER_IRAM_SEG_START - BOOTLOADER_DRAM_SEG_LEN - IRAM_DRAM_OFFSET)
+	(BOOTLOADER_IRAM_SEG_START - IRAM_DRAM_OFFSET - BOOTLOADER_DRAM_SEG_LEN)
 
 /* Cached memories */
 #define ICACHE0_START DT_REG_ADDR(DT_NODELABEL(icache0))

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -130,7 +130,7 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 #ifdef CONFIG_SOC_ENABLE_APPCPU
 _heap_sentry = procpu_dram_end;
 #else
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 #endif
 
 _libc_heap_size = _heap_sentry - _end;
@@ -243,7 +243,7 @@ SECTIONS
     *(.rtc.force_fast .rtc.force_fast.*)
     . = ALIGN(4);
     _rtc_force_fast_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.

--- a/soc/espressif/esp32s3/default_appcpu.ld
+++ b/soc/espressif/esp32s3/default_appcpu.ld
@@ -78,7 +78,7 @@ MEMORY
 ENTRY(__appcpu_start)
 
 /* Heap size calculations for APPCPU */
-_heap_sentry = DRAM_RESERVED_START;
+_heap_sentry = DRAM_USER_END;
 _libc_heap_size = _heap_sentry - _end;
 
 SECTIONS

--- a/tests/boards/espressif/memory_layout/CMakeLists.txt
+++ b/tests/boards/espressif/memory_layout/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(memory_layout_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/boards/espressif/memory_layout/prj.conf
+++ b/tests/boards/espressif/memory_layout/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/boards/espressif/memory_layout/src/main.c
+++ b/tests/boards/espressif/memory_layout/src/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+extern char _image_ram_start[];
+extern char _end[];
+extern char _heap_sentry[];
+
+ZTEST(memory_layout, test_sram_region_size)
+{
+	size_t total_sram = (size_t)_heap_sentry - (size_t)_image_ram_start;
+	size_t heap_size = (size_t)_heap_sentry - (size_t)_end;
+
+	TC_PRINT("_image_ram_start=%p, _end=%p, _heap_sentry=%p\n",
+		 (void *)_image_ram_start, (void *)_end,
+		 (void *)_heap_sentry);
+	TC_PRINT("total SRAM region: %zu bytes (%zu KB)\n",
+		 total_sram, total_sram / 1024);
+	TC_PRINT("libc heap region: %zu bytes (%zu KB)\n",
+		 heap_size, heap_size / 1024);
+
+	zassert_true(total_sram > 0, "SRAM region is empty");
+	zassert_true(heap_size > 1024, "heap too small: %zu bytes", heap_size);
+}
+
+ZTEST(memory_layout, test_heap_boundary)
+{
+	volatile uint8_t *start = (volatile uint8_t *)_end;
+	volatile uint8_t *end = (volatile uint8_t *)_heap_sentry;
+	size_t region_size = end - start;
+	size_t errors = 0;
+
+	TC_PRINT("testing %zu bytes (%zu KB) from %p to %p\n",
+		 region_size, region_size / 1024,
+		 (void *)start, (void *)end);
+
+	for (volatile uint8_t *p = start; p < end; p += 4) {
+		*p = (uint8_t)(((uintptr_t)p >> 2) ^ 0xA5);
+	}
+
+	for (volatile uint8_t *p = start; p < end; p += 4) {
+		uint8_t expected = (uint8_t)(((uintptr_t)p >> 2) ^ 0xA5);
+
+		if (*p != expected) {
+			if (errors == 0) {
+				TC_PRINT("FIRST mismatch at %p: "
+					 "got 0x%02x, expected 0x%02x\n",
+					 (void *)p, *p, expected);
+			}
+			errors++;
+		}
+	}
+
+	zassert_equal(errors, 0,
+		      "pattern check: %zu errors in %zu bytes",
+		      errors, region_size);
+
+	TC_PRINT("libc heap boundary: %zu KB verified up to %p\n",
+		 region_size / 1024, (void *)end);
+}
+
+ZTEST_SUITE(memory_layout, NULL, NULL, NULL, NULL, NULL);

--- a/tests/boards/espressif/memory_layout/testcase.yaml
+++ b/tests/boards/espressif/memory_layout/testcase.yaml
@@ -1,0 +1,14 @@
+common:
+  tags: memory
+  filter: CONFIG_SOC_FAMILY_ESPRESSIF_ESP32
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "total SRAM region: (.*) bytes"
+      - "heap boundary: (.*) KB verified"
+      - "PASS"
+tests:
+  boards.espressif.memory_layout.simple_boot: {}
+  boards.espressif.memory_layout.mcuboot:
+    sysbuild: true


### PR DESCRIPTION
Fix the bootloader segment base address calculation to use
DRAM_BUFFERS_END instead of DRAM_BUFFERS_START, matching the
IDF bootloader approach. The shared buffers region is only used
during ROM download mode and is available for bootloader use.

This change reclaims significant RAM for application builds:

| SoC  | Simple Boot | MCUboot App |
|------|:-----------:|:-----------:|
| C6   | +69.5 KB    | +61.7 KB    |
| H2   | +70 KB      | +62 KB      |
| C3   | +70 KB      | +62 KB      |
| C2   | +70 KB      | +62 KB      |
| S3   | +70 KB      | +62 KB      |
| S2   | +57 KB      | +49 KB      |

Fixes #103955