### PR TITLE
Bluetooth: BAP: codec_cfg fixes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -57,6 +57,12 @@ Bluetooth Audio
   value. Any non-read uses of it will need to be updated with the appropriate operations such as
   :c:func:`bt_bap_stream_config`, :c:func:`bt_bap_stream_reconfig`, :c:func:`bt_bap_stream_enable`
   or :c:func:`bt_bap_stream_metadata`. (:github:`104219`)
+* Almost all API uses of ``struct bt_audio_codec_cfg *`` is now const, which means that once the
+  ``codec_cfg`` has been stored in a parameter struct like
+  :c:struct:`bt_cap_initiator_broadcast_subgroup_param` or
+  :c:struct:`bt_cap_unicast_audio_start_stream_param`, then the parameter's pointer cannot be used
+  to modify the ``codec_cfg``, and the actual definition of the struct should be modified instead.
+  (:github:`104219`)
 
 Networking
 **********

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -50,6 +50,13 @@ Device Drivers and Devicetree
 Bluetooth
 *********
 
+Bluetooth Audio
+===============
+
+* :c:member:`bt_bap_stream.codec_cfg` is now ``const``, to better reflect that it is a read-only
+  value. Any non-read uses of it will need to be updated with the appropriate operations such as
+  :c:func:`bt_bap_stream_config`, :c:func:`bt_bap_stream_reconfig`, :c:func:`bt_bap_stream_enable`
+  or :c:func:`bt_bap_stream_metadata`. (:github:`104219`)
 
 Networking
 **********

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -926,8 +926,12 @@ struct bt_bap_stream {
 	/** Endpoint reference */
 	struct bt_bap_ep *ep;
 
-	/** Codec Configuration */
-	struct bt_audio_codec_cfg *codec_cfg;
+	/**
+	 * @brief Codec Configuration
+	 *
+	 * Only valid if the endpoint for this stream is non-NULL.
+	 */
+	const struct bt_audio_codec_cfg *codec_cfg;
 
 	/** QoS Configuration */
 	struct bt_bap_qos_cfg *qos;

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1146,7 +1146,7 @@ void bt_bap_stream_cb_register(struct bt_bap_stream *stream, struct bt_bap_strea
  * @return Allocated Audio Stream object or NULL in case of error.
  */
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
-			 struct bt_audio_codec_cfg *codec_cfg);
+			 const struct bt_audio_codec_cfg *codec_cfg);
 
 /**
  * @brief Reconfigure Audio Stream
@@ -1161,7 +1161,8 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
  *
  * @return 0 in case of success or negative value in case of error.
  */
-int bt_bap_stream_reconfig(struct bt_bap_stream *stream, struct bt_audio_codec_cfg *codec_cfg);
+int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
+			   const struct bt_audio_codec_cfg *codec_cfg);
 
 /**
  * @brief Configure Audio Stream QoS
@@ -1609,7 +1610,7 @@ int bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func
  * @return 0 in case of success or negative value in case of error.
  */
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
-				     struct bt_audio_codec_cfg *codec_cfg,
+				     const struct bt_audio_codec_cfg *codec_cfg,
 				     const struct bt_bap_qos_cfg_pref *qos_pref);
 
 /** @} */ /* End of group bt_bap_unicast_server */
@@ -2320,7 +2321,7 @@ struct bt_bap_broadcast_source_stream_param {
 	size_t data_len;
 
 	/** BIS Codec Specific Configuration */
-	uint8_t *data;
+	const uint8_t *data;
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 };
 
@@ -2333,7 +2334,7 @@ struct bt_bap_broadcast_source_subgroup_param {
 	struct bt_bap_broadcast_source_stream_param *params;
 
 	/** Subgroup Codec configuration. */
-	struct bt_audio_codec_cfg *codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg;
 };
 
 /** Broadcast Source create parameters */

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -469,7 +469,7 @@ struct bt_cap_unicast_audio_start_stream_param {
 	 * This value is assigned to the @p stream, and shall remain valid while the stream is
 	 * non-idle.
 	 */
-	struct bt_audio_codec_cfg *codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg;
 };
 
 /** Parameters for the bt_cap_initiator_unicast_audio_start() function */
@@ -654,7 +654,7 @@ struct bt_cap_initiator_broadcast_subgroup_param {
 	struct bt_cap_initiator_broadcast_stream_param *stream_params;
 
 	/** Subgroup Codec configuration. */
-	struct bt_audio_codec_cfg *codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg;
 };
 
 /** Parameters for * bt_cap_initiator_broadcast_audio_create() */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -321,7 +321,7 @@ struct bt_iso_chan_path {
 	 *
 	 * Shall not be NULL if bt_iso_chan_path.cc_len is non-zero.
 	 */
-	uint8_t *cc;
+	const uint8_t *cc;
 };
 
 /** ISO packet status flag bits */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1683,7 +1683,7 @@ static int ase_config(struct bt_ascs_ase *ase, const struct bt_ascs_config *cfg)
 
 	ascs_cp_rsp_success(ASE_ID(ase));
 
-	bt_bap_stream_attach(ase->conn, stream, &ase->ep, &ase->ep.codec_cfg);
+	bt_bap_stream_attach(ase->conn, stream, &ase->ep);
 
 	ascs_ep_set_state(&ase->ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 
@@ -1759,7 +1759,7 @@ int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 
 	ep->qos_pref = *qos_pref;
 
-	bt_bap_stream_attach(conn, stream, ep, &ep->codec_cfg);
+	bt_bap_stream_attach(conn, stream, ep);
 
 	err = ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1704,7 +1704,7 @@ static struct bt_bap_ep *ep_lookup_stream(struct bt_conn *conn, struct bt_bap_st
 }
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
-		       struct bt_audio_codec_cfg *codec_cfg,
+		       const struct bt_audio_codec_cfg *codec_cfg,
 		       const struct bt_bap_qos_cfg_pref *qos_pref)
 {
 	const struct bt_audio_codec_cap *codec_cap;

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -355,7 +355,7 @@ int ascs_ep_set_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
 bool bt_ascs_has_ep(const struct bt_bap_ep *ep);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
-		       struct bt_audio_codec_cfg *codec_cfg,
+		       const struct bt_audio_codec_cfg *codec_cfg,
 		       const struct bt_bap_qos_cfg_pref *qos_pref);
 int bt_ascs_disable_ase(struct bt_bap_ep *ep);
 int bt_ascs_release_ase(struct bt_bap_ep *ep);

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -981,7 +981,8 @@ static struct bt_bap_ep *broadcast_sink_new_ep(uint8_t index)
 
 static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink,
 					      struct bt_bap_stream *stream,
-					      struct bt_audio_codec_cfg *codec_cfg)
+					      const struct bt_audio_codec_cfg *codec_cfg,
+					      uint8_t id)
 {
 	struct bt_bap_iso *iso;
 	struct bt_bap_ep *ep;
@@ -1006,12 +1007,14 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 	bt_bap_iso_init(iso, &broadcast_sink_iso_ops);
 	bt_bap_iso_bind_ep(iso, ep);
 	stream->iso = &iso->chan;
+	ep->id = id;
 
 	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->rx, &sink->qos_cfg);
+	(void)memcpy(&ep->codec_cfg, codec_cfg, sizeof(*codec_cfg));
 
 	bt_bap_iso_unref(iso);
 
-	bt_bap_stream_attach(NULL, stream, ep, codec_cfg);
+	bt_bap_stream_attach(NULL, stream, ep);
 	stream->qos = &sink->qos_cfg;
 	stream->group = sink;
 
@@ -1347,12 +1350,12 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	sink->stream_count = 0U;
 	for (size_t i = 0; i < stream_count; i++) {
 		struct bt_bap_stream *stream;
-		struct bt_audio_codec_cfg *codec_cfg;
+		const struct bt_audio_codec_cfg *codec_cfg;
 
 		stream = streams[i];
 		codec_cfg = &data.codec_cfgs[i];
 
-		err = bt_bap_broadcast_sink_setup_stream(sink, stream, codec_cfg);
+		err = bt_bap_broadcast_sink_setup_stream(sink, stream, codec_cfg, i);
 		if (err != 0) {
 			LOG_DBG("Failed to setup streams[%zu]: %d", i, err);
 			broadcast_sink_cleanup_streams(sink);

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -930,7 +930,6 @@ static void broadcast_source_reconfig_update_subgroup(
 	struct bt_bap_broadcast_source *source, struct bt_bap_broadcast_subgroup *subgroup,
 	const struct bt_bap_broadcast_source_subgroup_param *subgroup_param)
 {
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_param->codec_cfg;
 	struct bt_bap_stream *stream;
 
 	(void)memcpy(&subgroup->codec_cfg, subgroup_param->codec_cfg, sizeof(subgroup->codec_cfg));
@@ -960,8 +959,8 @@ static void broadcast_source_reconfig_update_subgroup(
 		if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
 			const struct bt_audio_broadcast_stream_data *stream_data =
 				&source->stream_data[stream->ep->id];
+			struct bt_audio_codec_cfg *codec_cfg = &stream->ep->codec_cfg;
 
-			codec_cfg = &stream->ep->codec_cfg;
 			(void)memcpy(codec_cfg, subgroup_param->codec_cfg,
 				     sizeof(struct bt_audio_codec_cfg));
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -43,7 +43,7 @@ struct bt_bap_broadcast_subgroup {
 	sys_slist_t streams;
 
 	/* The codec of the subgroup */
-	struct bt_audio_codec_cfg *codec_cfg;
+	struct bt_audio_codec_cfg codec_cfg;
 
 	/* List node */
 	sys_snode_t _node;
@@ -291,10 +291,64 @@ static struct bt_bap_broadcast_subgroup *broadcast_source_new_subgroup(uint8_t i
 	return NULL;
 }
 
-static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
-					 struct bt_audio_codec_cfg *codec_cfg,
-					 struct bt_bap_qos_cfg *qos,
-					 struct bt_bap_broadcast_source *source)
+static bool merge_bis_and_subgroup_data_cb(struct bt_data *data, void *user_data)
+{
+	struct bt_audio_codec_cfg *codec_cfg = user_data;
+	int err;
+
+	err = bt_audio_codec_cfg_set_val(codec_cfg, data->type, data->data, data->data_len);
+	if (err < 0) {
+		LOG_DBG("Failed to set type %u with len %u in codec_cfg: %d", data->type,
+			data->data_len, err);
+
+		return false;
+	}
+
+	return true;
+}
+
+static void update_codec_cfg_data(struct bt_audio_codec_cfg *codec_cfg, const uint8_t data[],
+				  size_t data_len)
+{
+#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
+	if (data_len > 0) {
+		int err;
+
+		/* Merge subgroup codec configuration with the BIS configuration
+		 * As per the BAP spec, if a value exist at level 2 (subgroup) and 3 (BIS), then it
+		 * is the value at level 3 that shall be used
+		 */
+		if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+			err = bt_audio_data_parse(data, data_len, merge_bis_and_subgroup_data_cb,
+						  codec_cfg);
+		} else {
+			/* If it is not LC3, then we don't know how to merge the subgroup and BIS
+			 * codecs, so we just append them
+			 */
+			if (codec_cfg->data_len + data_len > sizeof(codec_cfg->data)) {
+				LOG_DBG("Could not store BIS and subgroup config in codec_cfg (%u "
+					"> %u)",
+					codec_cfg->data_len + data_len, sizeof(codec_cfg->data));
+
+				err = -ENOMEM;
+			} else {
+				err = 0;
+				(void)memcpy(&codec_cfg->data[codec_cfg->data_len], data, data_len);
+				codec_cfg->data_len += data_len;
+			}
+		}
+
+		__ASSERT(err == 0, "Failed codec merge not guarded by can_merge_codec_cfg_data");
+	}
+#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
+}
+
+static int
+broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
+			      const struct bt_audio_codec_cfg *subgroup_codec_cfg,
+			      const struct bt_bap_broadcast_source_stream_param *stream_param,
+			      struct bt_bap_qos_cfg *qos, struct bt_bap_broadcast_source *source,
+			      uint8_t id)
 {
 	struct bt_bap_iso *iso;
 	struct bt_bap_ep *ep;
@@ -314,8 +368,17 @@ static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *st
 	bt_bap_iso_init(iso, &broadcast_source_iso_ops);
 	bt_bap_iso_bind_ep(iso, ep);
 	stream->iso = &iso->chan;
+	ep->id = id;
 
 	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->tx, qos);
+	(void)memcpy(&ep->codec_cfg, subgroup_codec_cfg, sizeof(*subgroup_codec_cfg));
+
+	/* If there are any BIS specific codec configuration data, update the data to contain both
+	 * the subgroup and BIS specific data
+	 */
+	if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
+		update_codec_cfg_data(&ep->codec_cfg, stream_param->data, stream_param->data_len);
+	}
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	iso->chan.qos->num_subevents = qos->num_subevents;
@@ -323,7 +386,7 @@ static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *st
 
 	bt_bap_iso_unref(iso);
 
-	bt_bap_stream_attach(NULL, stream, ep, codec_cfg);
+	bt_bap_stream_attach(NULL, stream, ep);
 	stream->qos = qos;
 	stream->group = source;
 	ep->broadcast_source = source;
@@ -345,7 +408,7 @@ static bool encode_base_subgroup(struct bt_bap_broadcast_subgroup *subgroup,
 		stream_count++;
 	}
 
-	codec_cfg = subgroup->codec_cfg;
+	codec_cfg = &subgroup->codec_cfg;
 
 	net_buf_simple_add_u8(buf, stream_count);
 	net_buf_simple_add_u8(buf, codec_cfg->id);
@@ -476,22 +539,6 @@ static void broadcast_source_cleanup(struct bt_bap_broadcast_source *source)
 	(void)memset(source, 0, sizeof(*source));
 }
 
-static bool merge_bis_and_subgroup_data_cb(struct bt_data *data, void *user_data)
-{
-	struct bt_audio_codec_cfg *codec_cfg = user_data;
-	int err;
-
-	err = bt_audio_codec_cfg_set_val(codec_cfg, data->type, data->data, data->data_len);
-	if (err < 0) {
-		LOG_DBG("Failed to set type %u with len %u in codec_cfg: %d", data->type,
-			data->data_len, err);
-
-		return false;
-	}
-
-	return true;
-}
-
 static bool
 can_merge_codec_cfg_data(const struct bt_audio_codec_cfg *subgroup_codec_cfg,
 			 const struct bt_bap_broadcast_source_stream_param *stream_param)
@@ -537,45 +584,6 @@ can_merge_codec_cfg_data(const struct bt_audio_codec_cfg *subgroup_codec_cfg,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 	return true;
-}
-
-static void update_codec_cfg_data(struct bt_audio_codec_cfg *codec_cfg,
-				  const struct bt_bap_broadcast_source_stream_param *stream_param)
-{
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
-	if (stream_param->data_len > 0) {
-		int err;
-
-		/* Merge subgroup codec configuration with the BIS configuration
-		 * As per the BAP spec, if a value exist at level 2 (subgroup) and 3 (BIS), then it
-		 * is the value at level 3 that shall be used
-		 */
-		if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-			err = bt_audio_data_parse(stream_param->data, stream_param->data_len,
-						  merge_bis_and_subgroup_data_cb, codec_cfg);
-		} else {
-			/* If it is not LC3, then we don't know how to merge the subgroup and BIS
-			 * codecs, so we just append them
-			 */
-			if (codec_cfg->data_len + stream_param->data_len >
-			    sizeof(codec_cfg->data)) {
-				LOG_DBG("Could not store BIS and subgroup config in codec_cfg (%u "
-					"> %u)",
-					codec_cfg->data_len + stream_param->data_len,
-					sizeof(codec_cfg->data));
-
-				err = ENOMEM;
-			} else {
-				err = 0;
-				(void)memcpy(&codec_cfg->data[codec_cfg->data_len],
-					     stream_param->data, stream_param->data_len);
-				codec_cfg->data_len += stream_param->data_len;
-			}
-		}
-
-		__ASSERT(err == 0, "Failed codec merge not guarded by can_merge_codec_cfg_data");
-	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 }
 
 static bool valid_broadcast_source_subgroup_param(
@@ -741,7 +749,6 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 	struct bt_bap_qos_cfg *qos;
 	size_t stream_count;
 	uint8_t index;
-	uint8_t bis_count;
 	int err;
 
 	if (out_source == NULL) {
@@ -771,7 +778,6 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 	}
 
 	stream_count = 0U;
-	bis_count = 0U;
 	qos = param->qos;
 	/* Go through all subgroups and streams and setup each setup with an
 	 * endpoint
@@ -789,7 +795,8 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 			return -ENOMEM;
 		}
 
-		subgroup->codec_cfg = subgroup_param->codec_cfg;
+		(void)memcpy(&subgroup->codec_cfg, subgroup_param->codec_cfg,
+			     sizeof(subgroup->codec_cfg));
 		sys_slist_append(&source->subgroups, &subgroup->_node);
 
 		/* Check that we are not above the maximum BIS count */
@@ -801,26 +808,15 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 		}
 
 		for (size_t j = 0U; j < subgroup_param->params_count; j++) {
-			const struct bt_bap_broadcast_source_stream_param *stream_param;
-			struct bt_bap_stream *stream;
-			struct bt_audio_codec_cfg *codec_cfg;
+			const struct bt_bap_broadcast_source_stream_param *stream_param =
+				&subgroup_param->params[j];
+			const struct bt_audio_codec_cfg *subgroup_codec_cfg =
+				subgroup_param->codec_cfg;
+			struct bt_bap_stream *stream = stream_param->stream;
 
-			codec_cfg = subgroup_param->codec_cfg;
-			stream_param = &subgroup_param->params[j];
-			stream = stream_param->stream;
-
-			if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
-				codec_cfg = &source->codec_cfg[bis_count];
-				memcpy(codec_cfg, subgroup_param->codec_cfg,
-				       sizeof(struct bt_audio_codec_cfg));
-
-				update_codec_cfg_data(codec_cfg, stream_param);
-			}
-
-			bis_count++;
-			__ASSERT_NO_MSG(bis_count <= BROADCAST_STREAM_CNT);
-
-			err = broadcast_source_setup_stream(index, stream, codec_cfg, qos, source);
+			err = broadcast_source_setup_stream(index, stream, subgroup_codec_cfg,
+							    stream_param, qos, source,
+							    stream_count);
 			if (err != 0) {
 				LOG_DBG("Failed to setup streams[%zu]: %d", i, err);
 				broadcast_source_cleanup(source);
@@ -936,44 +932,23 @@ static void broadcast_source_reconfig_update_subgroup(
 {
 	struct bt_audio_codec_cfg *codec_cfg = subgroup_param->codec_cfg;
 	struct bt_bap_stream *stream;
-	uint8_t bis_count = 0U;
 
-	subgroup->codec_cfg = codec_cfg;
+	(void)memcpy(&subgroup->codec_cfg, subgroup_param->codec_cfg, sizeof(subgroup->codec_cfg));
 
-	for (size_t j = 0U; j < subgroup_param->params_count; j++) {
-		const struct bt_bap_broadcast_source_stream_param *stream_param;
+	/* Store data from subgroup_param */
+	for (size_t i = 0U; i < subgroup_param->params_count; i++) {
+		const struct bt_bap_broadcast_source_stream_param *stream_param =
+			&subgroup_param->params[i];
 		struct bt_audio_broadcast_stream_data *stream_data;
-		struct bt_bap_stream *subgroup_stream;
-		size_t stream_idx;
 
-		stream_param = &subgroup_param->params[j];
 		stream = stream_param->stream;
-		if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
-			codec_cfg = &source->codec_cfg[bis_count];
-			memcpy(codec_cfg, subgroup_param->codec_cfg,
-			       sizeof(struct bt_audio_codec_cfg));
-
-			update_codec_cfg_data(codec_cfg, stream_param);
-		}
-
-		bis_count++;
-		__ASSERT_NO_MSG(bis_count <= BROADCAST_STREAM_CNT);
-
-		stream_idx = 0U;
-		SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, subgroup_stream, _node) {
-			if (subgroup_stream == stream) {
-				break;
-			}
-
-			stream_idx++;
-		}
 
 		/* Store the BIS specific codec configuration data in the broadcast source.
 		 * It is stored in the broadcast* source, instead of the stream object,
 		 * as this is only relevant for the broadcast source, and not used
 		 * for unicast or broadcast sink.
 		 */
-		stream_data = &source->stream_data[stream_idx];
+		stream_data = &source->stream_data[stream->ep->id];
 		(void)memcpy(stream_data->data, stream_param->data, stream_param->data_len);
 		stream_data->data_len = stream_param->data_len;
 	}
@@ -982,7 +957,16 @@ static void broadcast_source_reconfig_update_subgroup(
 	 * params
 	 */
 	SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, stream, _node) {
-		bt_bap_stream_attach(NULL, stream, stream->ep, codec_cfg);
+		if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
+			const struct bt_audio_broadcast_stream_data *stream_data =
+				&source->stream_data[stream->ep->id];
+
+			codec_cfg = &stream->ep->codec_cfg;
+			(void)memcpy(codec_cfg, subgroup_param->codec_cfg,
+				     sizeof(struct bt_audio_codec_cfg));
+
+			update_codec_cfg_data(codec_cfg, stream_data->data, stream_data->data_len);
+		}
 	}
 }
 
@@ -1084,12 +1068,12 @@ int bt_bap_broadcast_source_update_metadata(struct bt_bap_broadcast_source *sour
 	 * for each subgroup individually
 	 */
 	SYS_SLIST_FOR_EACH_CONTAINER(&source->subgroups, subgroup, _node) {
-		memset(subgroup->codec_cfg->meta, 0, sizeof(subgroup->codec_cfg->meta));
+		(void)memset(subgroup->codec_cfg.meta, 0, sizeof(subgroup->codec_cfg.meta));
 
 		if (meta != NULL) {
-			(void)memcpy(subgroup->codec_cfg->meta, meta, meta_len);
+			(void)memcpy(subgroup->codec_cfg.meta, meta, meta_len);
 		}
-		subgroup->codec_cfg->meta_len = meta_len; /* may be 0 */
+		subgroup->codec_cfg.meta_len = meta_len; /* may be 0 */
 	}
 
 	return 0;

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -972,7 +972,7 @@ static void broadcast_source_reconfig_update_subgroup(
 int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 				     struct bt_bap_broadcast_source_param *param)
 {
-	struct bt_bap_broadcast_subgroup *subgroup;
+	struct bt_bap_broadcast_subgroup *subgroup = NULL;
 	enum bt_bap_ep_state broadcast_state;
 	struct bt_bap_qos_cfg *qos;
 
@@ -1005,6 +1005,10 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 			subgroup =
 				SYS_SLIST_PEEK_HEAD_CONTAINER(&source->subgroups, subgroup, _node);
 		} else {
+			/* Number of subgroups in `source` are verified in
+			 * valid_broadcast_source_reconfig_param so this should never happen
+			 */
+			__ASSERT_NO_MSG(subgroup != NULL);
 			subgroup = SYS_SLIST_PEEK_NEXT_CONTAINER(subgroup, _node);
 		}
 

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -45,7 +45,7 @@ struct bt_bap_ep {
 	uint8_t dir;
 	uint8_t cig_id;
 	uint8_t cis_id;
-	uint8_t id;
+	uint8_t id; /* ASE ID or BIS ID (BIS index - 1) */
 	enum bt_bap_ep_state state;
 	struct bt_bap_stream *stream;
 	struct bt_audio_codec_cfg codec_cfg;
@@ -130,11 +130,6 @@ struct bt_bap_broadcast_source {
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
-	/* The complete codec specific configured data for each stream in the subgroup.
-	 * This contains both the subgroup and the BIS-specific data for each stream.
-	 */
-	struct bt_audio_codec_cfg codec_cfg[BROADCAST_STREAM_CNT];
-
 	/* The subgroups containing the streams used to create the broadcast source */
 	sys_slist_t subgroups;
 };
@@ -169,7 +164,6 @@ struct bt_bap_broadcast_sink_subgroup {
 struct bt_bap_broadcast_sink_bis {
 	uint8_t index;
 	struct bt_iso_chan *chan;
-	struct bt_audio_codec_cfg codec_cfg;
 };
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)

--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -174,7 +174,7 @@ static struct bt_bap_iso_dir *bap_iso_get_iso_dir(bool unicast_client, struct bt
 
 void bt_bap_setup_iso_data_path(struct bt_bap_stream *stream)
 {
-	struct bt_audio_codec_cfg *codec_cfg = stream->codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg = stream->codec_cfg;
 	struct bt_bap_ep *ep = stream->ep;
 	struct bt_bap_iso *bap_iso = ep->iso;
 	const bool is_unicast_client =

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -76,10 +76,9 @@ void bt_bap_stream_init(struct bt_bap_stream *stream)
 	stream->user_data = user_data;
 }
 
-void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
-			  struct bt_audio_codec_cfg *codec_cfg)
+void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep)
 {
-	LOG_DBG("conn %p stream %p ep %p codec_cfg %p", (void *)conn, stream, ep, codec_cfg);
+	LOG_DBG("conn %p stream %p ep %p", (void *)conn, stream, ep);
 
 	if (conn != NULL) {
 		__ASSERT(stream->conn == NULL || stream->conn == conn,
@@ -88,7 +87,7 @@ void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, st
 			stream->conn = bt_conn_ref(conn);
 		}
 	}
-	stream->codec_cfg = codec_cfg;
+	stream->codec_cfg = &ep->codec_cfg;
 	stream->ep = ep;
 	ep->stream = stream;
 }
@@ -655,7 +654,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 	}
 	__ASSERT(ep->iso == NULL, "endpoint %p already bound to iso %p", ep, ep->iso);
 
-	bt_bap_stream_attach(conn, stream, ep, codec_cfg);
+	bt_bap_stream_attach(conn, stream, ep);
 
 	/* If a stream has been added to a group at this point, then it has a reference to a CIS.
 	 * and we can bind the ep to the CIS

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -608,7 +608,7 @@ static uint8_t conn_get_role(const struct bt_conn *conn)
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
-			 struct bt_audio_codec_cfg *codec_cfg)
+			 const struct bt_audio_codec_cfg *codec_cfg)
 {
 	uint8_t role;
 	int err;
@@ -785,8 +785,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 
-int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
-			     struct bt_audio_codec_cfg *codec_cfg)
+int bt_bap_stream_reconfig(struct bt_bap_stream *stream, const struct bt_audio_codec_cfg *codec_cfg)
 {
 	enum bt_bap_ep_state state;
 	uint8_t role;

--- a/subsys/bluetooth/audio/bap_stream.h
+++ b/subsys/bluetooth/audio/bap_stream.h
@@ -21,8 +21,7 @@ int bt_bap_stream_disconnect(struct bt_bap_stream *stream);
 
 void bt_bap_stream_reset(struct bt_bap_stream *stream);
 
-void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
-			  struct bt_audio_codec_cfg *codec_cfg);
+void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep);
 
 void bt_bap_qos_cfg_to_iso_qos(struct bt_iso_chan_io_qos *io, const struct bt_bap_qos_cfg *qos_cfg);
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -143,12 +143,10 @@ static struct unicast_client {
 static sys_slist_t unicast_client_cbs = SYS_SLIST_STATIC_INIT(&unicast_client_cbs);
 
 /* TODO: Move the functions to avoid these prototypes */
-static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint8_t len,
-					  struct bt_audio_codec_cfg *codec_cfg);
+static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint8_t len);
 
 static int unicast_client_ep_set_codec_cfg(struct bt_bap_ep *ep, uint8_t id, uint16_t cid,
-					   uint16_t vid, void *data, uint8_t len,
-					   struct bt_audio_codec_cfg *codec_cfg);
+					   uint16_t vid, void *data, uint8_t len);
 static int unicast_client_ep_start(struct bt_bap_ep *ep, struct net_buf_simple *buf);
 
 static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_handle);
@@ -932,11 +930,6 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 	if (stream->codec_cfg == NULL) {
 		LOG_ERR("Stream %p does not have a codec configured", stream);
 		return;
-	} else if (stream->codec_cfg->id != cfg->codec.id) {
-		LOG_ERR("Codec configuration mismatched: %u, %u", stream->codec_cfg->id,
-			cfg->codec.id);
-		/* TODO: Release the stream? */
-		return;
 	}
 
 	if (buf->len < cfg->cc_len) {
@@ -976,7 +969,7 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 	}
 
 	unicast_client_ep_set_codec_cfg(ep, cfg->codec.id, sys_le16_to_cpu(cfg->codec.cid),
-					sys_le16_to_cpu(cfg->codec.vid), cc, cfg->cc_len, NULL);
+					sys_le16_to_cpu(cfg->codec.vid), cc, cfg->cc_len);
 
 	/* Every time a stream enters the codec configured state, there is a chance that all streams
 	 * in that direction has exited the QoS configured state, and we need to update the stored
@@ -1142,7 +1135,7 @@ static void unicast_client_ep_enabling_state(struct bt_bap_ep *ep, struct net_bu
 
 	LOG_DBG("dir %s cig 0x%02x cis 0x%02x", bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id);
 
-	unicast_client_ep_set_metadata(ep, metadata, enable->metadata_len, NULL);
+	unicast_client_ep_set_metadata(ep, metadata, enable->metadata_len);
 
 	/* Notify upper layer
 	 *
@@ -1168,6 +1161,7 @@ static void unicast_client_ep_streaming_state(struct bt_bap_ep *ep, struct net_b
 {
 	struct bt_ascs_ase_status_stream *stream_status;
 	struct bt_bap_stream *stream;
+	void *metadata;
 
 	if (buf->len < sizeof(*stream_status)) {
 		LOG_ERR("Streaming status too short");
@@ -1182,11 +1176,21 @@ static void unicast_client_ep_streaming_state(struct bt_bap_ep *ep, struct net_b
 
 	stream_status = net_buf_simple_pull_mem(buf, sizeof(*stream_status));
 
+	if (buf->len < stream_status->metadata_len) {
+		LOG_ERR("Malformed PDU: remaining len %u expected %u", buf->len,
+			stream_status->metadata_len);
+		return;
+	}
+
+	metadata = net_buf_simple_pull_mem(buf, stream_status->metadata_len);
+
 	LOG_DBG("dir %s cig 0x%02x cis 0x%02x", bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id);
 
-	/* If there is a state change (i.e. going from non-streaming to streaming) we setup the data
-	 * path and notify the upper layers with the started callback, and if there is no state
-	 * change then that indicates that it is just a metadata update
+	unicast_client_ep_set_metadata(ep, metadata, stream_status->metadata_len);
+
+	/* Notify upper layer
+	 *
+	 * If the state did not change then only the metadata was changed
 	 */
 	if (state_changed) {
 		/* Setup the ISO data path when the stream is started. We could do it earlier when
@@ -1476,31 +1480,28 @@ static bool valid_ltv_cb(struct bt_data *data, void *user_data)
 }
 
 static int unicast_client_ep_set_codec_cfg(struct bt_bap_ep *ep, uint8_t id, uint16_t cid,
-					   uint16_t vid, void *data, uint8_t len,
-					   struct bt_audio_codec_cfg *codec_cfg)
+					   uint16_t vid, void *data, uint8_t len)
 {
-	if (!ep && !codec_cfg) {
+	if (ep == NULL) {
 		return -EINVAL;
 	}
 
 	LOG_DBG("ep %p codec id 0x%02x cid 0x%04x vid 0x%04x len %u", ep, id, cid, vid, len);
 
-	if (!codec_cfg) {
-		codec_cfg = &ep->codec_cfg;
+	if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
+		if (len > sizeof(ep->codec_cfg.data)) {
+			LOG_DBG("Cannot store %u octets of codec data", len);
+
+			return -ENOMEM;
+		}
+
+		ep->codec_cfg.data_len = len;
+		(void)memcpy(ep->codec_cfg.data, data, len);
 	}
 
-	if (len > sizeof(codec_cfg->data)) {
-		LOG_DBG("Cannot store %u octets of codec data", len);
-
-		return -ENOMEM;
-	}
-
-	codec_cfg->id = id;
-	codec_cfg->cid = cid;
-	codec_cfg->vid = vid;
-
-	codec_cfg->data_len = len;
-	memcpy(codec_cfg->data, data, len);
+	ep->codec_cfg.id = id;
+	ep->codec_cfg.cid = cid;
+	ep->codec_cfg.vid = vid;
 
 	return 0;
 }
@@ -1570,28 +1571,24 @@ static int unicast_client_set_codec_cap(uint8_t id, uint16_t cid, uint16_t vid, 
 	return 0;
 }
 
-static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint8_t len,
-					  struct bt_audio_codec_cfg *codec_cfg)
+static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint8_t len)
 {
-	if (!ep && !codec_cfg) {
+	if (ep == NULL) {
 		return -EINVAL;
 	}
 
-	LOG_DBG("ep %p len %u codec_cfg %p", ep, len, codec_cfg);
+	LOG_DBG("ep %p len %u", ep, len);
 
-	if (!codec_cfg) {
-		codec_cfg = &ep->codec_cfg;
+	if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0) {
+		if (len > sizeof(ep->codec_cfg.meta)) {
+			LOG_DBG("Cannot store %u octets of metadata", len);
+
+			return -ENOMEM;
+		}
+
+		ep->codec_cfg.meta_len = len;
+		(void)memcpy(ep->codec_cfg.meta, data, len);
 	}
-
-	if (len > sizeof(codec_cfg->meta)) {
-		LOG_DBG("Cannot store %u octets of metadata", len);
-
-		return -ENOMEM;
-	}
-
-	/* Reset current metadata */
-	codec_cfg->meta_len = len;
-	(void)memcpy(codec_cfg->meta, data, len);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -211,7 +211,7 @@ int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 }
 
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
-				     struct bt_audio_codec_cfg *codec_cfg,
+				     const struct bt_audio_codec_cfg *codec_cfg,
 				     const struct bt_bap_qos_cfg_pref *qos_pref)
 {
 	return bt_ascs_config_ase(conn, stream, codec_cfg, qos_pref);

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1341,7 +1341,7 @@ cap_initiator_unicast_audio_configure(struct bt_cap_common_proc *active_proc,
 				      const struct bt_cap_unicast_audio_start_param *param)
 {
 	struct bt_cap_initiator_proc_param *proc_param;
-	struct bt_audio_codec_cfg *codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg;
 	struct bt_bap_stream *bap_stream;
 	struct bt_bap_ep *ep;
 	struct bt_conn *conn;
@@ -1504,9 +1504,9 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 	}
 
 	if (!bt_cap_common_proc_is_done()) {
+		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *next_bap_stream;
-		struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_conn *conn;
 		struct bt_bap_ep *ep;
 		int err;

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1662,6 +1662,7 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_type(BT_CAP_COMMON_PROC_TYPE_START)) {
 		struct bt_cap_initiator_proc_param *proc_param;
+		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *bap_stream;
 		int err;
@@ -1691,8 +1692,9 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
 
-		err = bt_bap_stream_enable(bap_stream, bap_stream->codec_cfg->meta,
-					   bap_stream->codec_cfg->meta_len);
+		codec_cfg = proc_param->start.codec_cfg;
+
+		err = bt_bap_stream_enable(bap_stream, codec_cfg->meta, codec_cfg->meta_len);
 		if (err != 0) {
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 
@@ -1766,6 +1768,7 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 	}
 
 	if (!bt_cap_common_proc_is_done()) {
+		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *next_bap_stream;
 
@@ -1775,10 +1778,11 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 
 		active_proc->proc_initiated_cnt++;
-		proc_param->in_progress = true;
 
-		err = bt_bap_stream_enable(next_bap_stream, next_bap_stream->codec_cfg->meta,
-					   next_bap_stream->codec_cfg->meta_len);
+		proc_param->in_progress = true;
+		codec_cfg = proc_param->start.codec_cfg;
+
+		err = bt_bap_stream_enable(next_bap_stream, codec_cfg->meta, codec_cfg->meta_len);
 		if (err != 0) {
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -97,7 +97,7 @@ struct bt_cap_initiator_proc_param {
 		struct {
 			struct bt_conn *conn;
 			struct bt_bap_ep *ep;
-			struct bt_audio_codec_cfg *codec_cfg;
+			const struct bt_audio_codec_cfg *codec_cfg;
 			bool connected;
 		} start;
 		struct {

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -772,7 +772,7 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 };
 #endif /* CONFIG_BT_BAP_UNICAST_SERVER */
 
-static uint16_t strmeta(const char *name)
+static enum bt_audio_context strmeta(const char *name)
 {
 	if (strcmp(name, "Unspecified") == 0) {
 		return BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
@@ -800,22 +800,7 @@ static uint16_t strmeta(const char *name)
 		return BT_AUDIO_CONTEXT_TYPE_EMERGENCY_ALARM;
 	}
 
-	return 0u;
-}
-
-static int set_metadata(struct bt_audio_codec_cfg *codec_cfg, const char *meta_str)
-{
-	uint16_t context;
-
-	context = strmeta(meta_str);
-	if (context == 0) {
-		return -ENOEXEC;
-	}
-
-	/* TODO: Check the type and only overwrite the streaming context */
-	sys_put_le16(context, codec_cfg->meta);
-
-	return 0;
+	return BT_AUDIO_CONTEXT_TYPE_NONE;
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
@@ -1528,7 +1513,7 @@ static int cmd_qos(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_audio_codec_cfg *codec_cfg;
+	struct shell_stream *uni_stream;
 	int err;
 
 	if (default_stream == NULL) {
@@ -1536,17 +1521,37 @@ static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	codec_cfg = default_stream->codec_cfg;
+	if (default_stream->ep == NULL || default_stream->codec_cfg == NULL) {
+		shell_error(sh, "Selected stream is not yet configured");
+		return -ENOEXEC;
+	}
+
+	if (default_stream->conn == NULL) {
+		shell_error(sh, "Selected stream is not unicast");
+		return -ENOEXEC;
+	}
+
+	uni_stream = shell_stream_from_bap_stream(default_stream);
 
 	if (argc > 1) {
-		err = set_metadata(codec_cfg, argv[1]);
+		enum bt_audio_context context;
+
+		context = strmeta(argv[1]);
+		if (context == BT_AUDIO_CONTEXT_TYPE_NONE) {
+			shell_error(sh, "Invalid metadata: %s", argv[1]);
+
+			return -ENOEXEC;
+		}
+
+		err = bt_audio_codec_cfg_meta_set_stream_context(&uni_stream->codec_cfg, context);
 		if (err != 0) {
 			shell_error(sh, "Unable to handle metadata update: %d", err);
-			return err;
+			return -ENOEXEC;
 		}
 	}
 
-	err = bt_bap_stream_enable(default_stream, codec_cfg->meta, codec_cfg->meta_len);
+	err = bt_bap_stream_enable(default_stream, uni_stream->codec_cfg.meta,
+				   uni_stream->codec_cfg.meta_len);
 	if (err) {
 		shell_error(sh, "Unable to enable Channel");
 		return -ENOEXEC;
@@ -1594,7 +1599,7 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_metadata(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_audio_codec_cfg *codec_cfg;
+	struct shell_stream *uni_stream;
 	int err;
 
 	if (default_stream == NULL) {
@@ -1602,17 +1607,37 @@ static int cmd_metadata(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	codec_cfg = default_stream->codec_cfg;
+	if (default_stream->ep == NULL || default_stream->codec_cfg == NULL) {
+		shell_error(sh, "Selected stream is not yet configured");
+		return -ENOEXEC;
+	}
+
+	if (default_stream->conn == NULL) {
+		shell_error(sh, "Selected stream is not unicast");
+		return -ENOEXEC;
+	}
+
+	uni_stream = shell_stream_from_bap_stream(default_stream);
 
 	if (argc > 1) {
-		err = set_metadata(codec_cfg, argv[1]);
+		enum bt_audio_context context;
+
+		context = strmeta(argv[1]);
+		if (context == BT_AUDIO_CONTEXT_TYPE_NONE) {
+			shell_error(sh, "Invalid metadata: %s", argv[1]);
+
+			return -ENOEXEC;
+		}
+
+		err = bt_audio_codec_cfg_meta_set_stream_context(&uni_stream->codec_cfg, context);
 		if (err != 0) {
 			shell_error(sh, "Unable to handle metadata update: %d", err);
-			return err;
+			return -ENOEXEC;
 		}
 	}
 
-	err = bt_bap_stream_metadata(default_stream, codec_cfg->meta, codec_cfg->meta_len);
+	err = bt_bap_stream_metadata(default_stream, uni_stream->codec_cfg.meta,
+				     uni_stream->codec_cfg.meta_len);
 	if (err) {
 		shell_error(sh, "Unable to set Channel metadata");
 		return -ENOEXEC;

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -254,7 +254,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_start_send
 
 			/* verify bap stream started cb stream parameter */
 			zassert_equal(mock_bap_stream_started_cb_fake.arg0_history[i], bap_stream);
-			struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
+			const struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
 			enum bt_audio_location chan_allocation;
 			/* verify subgroup codec data */
 			zassert_equal(bt_audio_codec_cfg_get_freq(codec_cfg),

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -49,6 +49,8 @@ ZTEST_RULE(mock_rule, mock_init_rule_before, mock_destroy_rule_after);
 
 struct bap_broadcast_source_test_suite_fixture {
 	struct bt_bap_broadcast_source_param *param;
+	struct bt_audio_codec_cfg *codec_cfg;
+	uint8_t *bis_data;
 	size_t stream_cnt;
 	struct bt_bap_broadcast_source *source;
 };
@@ -67,14 +69,12 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	const enum bt_audio_location loc = BT_AUDIO_LOCATION_FRONT_LEFT;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_param;
 	struct bt_bap_broadcast_source_stream_param *stream_params;
-	struct bt_audio_codec_cfg *codec_cfg;
 	struct bt_bap_qos_cfg *qos_cfg;
 	struct bt_bap_stream *streams;
 	const uint16_t latency = 10U; /* ms*/
 	const uint32_t pd = 40000U;   /* us */
 	const uint16_t sdu = 40U;     /* octets */
 	const uint8_t rtn = 2U;
-	uint8_t *bis_data;
 
 	zassert_true(streams_per_subgroup > 0U);
 	zassert_true(sizeof(bis_cfg_data) <= CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
@@ -87,14 +87,14 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	stream_params = malloc(sizeof(struct bt_bap_broadcast_source_stream_param) *
 			       CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
 	zassert_not_null(stream_params);
-	codec_cfg = malloc(sizeof(struct bt_audio_codec_cfg));
-	zassert_not_null(codec_cfg);
+	fixture->codec_cfg = malloc(sizeof(struct bt_audio_codec_cfg));
+	zassert_not_null(fixture->codec_cfg);
 	qos_cfg = malloc(sizeof(struct bt_bap_qos_cfg));
 	zassert_not_null(qos_cfg);
 	streams = malloc(sizeof(struct bt_bap_stream) * CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
 	zassert_not_null(streams);
-	bis_data = malloc(CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
-	zassert_not_null(bis_data);
+	fixture->bis_data = malloc(CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
+	zassert_not_null(fixture->bis_data);
 
 	/* Memset everything to 0 */
 	memset(fixture->param, 0, sizeof(*fixture->param));
@@ -104,26 +104,26 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	memset(stream_params, 0,
 	       sizeof(struct bt_bap_broadcast_source_stream_param) *
 		       CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
-	memset(codec_cfg, 0, sizeof(struct bt_audio_codec_cfg));
+	memset(fixture->codec_cfg, 0, sizeof(struct bt_audio_codec_cfg));
 	memset(qos_cfg, 0, sizeof(struct bt_bap_qos_cfg));
 	memset(streams, 0, sizeof(struct bt_bap_stream) * CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
-	memset(bis_data, 0, CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
+	memset(fixture->bis_data, 0, CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
 
 	/* Initialize default values*/
-	*codec_cfg = BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CFG_FREQ_16KHZ,
-					       BT_AUDIO_CODEC_CFG_DURATION_10, loc, 40U, 1, ctx);
+	*fixture->codec_cfg = BT_AUDIO_CODEC_LC3_CONFIG(
+		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10, loc, 40U, 1, ctx);
 	*qos_cfg = BT_BAP_QOS_CFG_UNFRAMED(10000u, sdu, rtn, latency, pd);
-	memcpy(bis_data, bis_cfg_data, sizeof(bis_cfg_data));
+	memcpy(fixture->bis_data, bis_cfg_data, sizeof(bis_cfg_data));
 
 	for (size_t i = 0U; i < CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT; i++) {
 		subgroup_param[i].params_count = streams_per_subgroup;
 		subgroup_param[i].params = stream_params + i * streams_per_subgroup;
-		subgroup_param[i].codec_cfg = codec_cfg;
+		subgroup_param[i].codec_cfg = fixture->codec_cfg;
 	}
 
 	for (size_t i = 0U; i < CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT; i++) {
 		stream_params[i].stream = &streams[i];
-		stream_params[i].data = bis_data;
+		stream_params[i].data = fixture->bis_data;
 		stream_params[i].data_len = sizeof(bis_cfg_data);
 		bt_bap_stream_cb_register(stream_params[i].stream, &mock_bap_stream_ops);
 	}
@@ -176,10 +176,10 @@ static void bap_broadcast_source_test_suite_after(void *f)
 
 	param = fixture->param;
 
-	free(param->params[0].params[0].data);
 	free(param->params[0].params[0].stream);
 	free(param->params[0].params);
-	free(param->params[0].codec_cfg);
+	free(fixture->codec_cfg);
+	free(fixture->bis_data);
 	free(param->params);
 	free(param->qos);
 	free(param);
@@ -411,7 +411,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
 	int err;
 
 	subgroup_params->codec_cfg = NULL;
@@ -425,8 +425,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_create_inval_subgroup_params_codec_cfg_data_len)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	codec_cfg->data_len = CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE + 1;
@@ -438,8 +437,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_create_inval_subgroup_params_codec_cfg_meta_len)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	codec_cfg->meta_len = CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE + 1;
@@ -451,8 +449,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_create_inval_subgroup_params_codec_cfg_cid)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	codec_cfg->id = BT_HCI_CODING_FORMAT_LC3;
@@ -465,8 +462,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_create_inval_subgroup_params_codec_cfg_vid)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	codec_cfg->id = BT_HCI_CODING_FORMAT_LC3;
@@ -496,7 +492,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_inval_stre
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &create_param->params[0];
 	struct bt_bap_broadcast_source_stream_param *stream_params = &subgroup_params->params[0];
-	uint8_t *data = stream_params->data;
+	const uint8_t *data = stream_params->data;
 	int err;
 
 	stream_params->data = NULL;
@@ -900,7 +896,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -924,8 +920,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_reconfigure_inval_subgroup_params_codec_cfg_data_len)
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -947,8 +942,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_reconfigure_inval_subgroup_params_codec_cfg_meta_len)
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -970,8 +964,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_reconfigure_inval_subgroup_params_codec_cfg_cid)
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -994,8 +987,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	test_broadcast_source_reconfigure_inval_subgroup_params_codec_cfg_vid)
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
-	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
-	struct bt_audio_codec_cfg *codec_cfg = subgroup_params->codec_cfg;
+	struct bt_audio_codec_cfg *codec_cfg = fixture->codec_cfg;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -1046,7 +1038,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	struct bt_bap_broadcast_source_param *param = fixture->param;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_params = &param->params[0];
 	struct bt_bap_broadcast_source_stream_param *stream_params = &subgroup_params->params[0];
-	uint8_t *data = stream_params->data;
+	const uint8_t *data = stream_params->data;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -374,9 +374,8 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 	int err;
 
 	/* CAP requires stream context - Let's remove it */
-	(void)memset(fixture->audio_start_stream_params[0].codec_cfg->meta, 0,
-		     sizeof(fixture->audio_start_stream_params[0].codec_cfg->meta));
-	fixture->audio_start_stream_params[0].codec_cfg->meta_len = 0U;
+	(void)memset(&fixture->preset.codec_cfg, 0, sizeof(fixture->preset.codec_cfg));
+	fixture->preset.codec_cfg.meta_len = 0U;
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -584,9 +584,8 @@ static uint8_t btp_cap_broadcast_source_setup_subgroup(const void *cmd, uint16_t
 	struct bt_cap_initiator_broadcast_subgroup_param *subgroup_param =
 		&cap_broadcast_params[cp->source_id].cap_subgroup_params[cp->subgroup_id];
 
-	subgroup_param->codec_cfg = &source->subgroup_codec_cfg[cp->subgroup_id];
-
-	codec_cfg = subgroup_param->codec_cfg;
+	codec_cfg = &source->subgroup_codec_cfg[cp->subgroup_id];
+	subgroup_param->codec_cfg = codec_cfg;
 
 	memset(codec_cfg, 0, sizeof(*codec_cfg));
 	codec_cfg->id = cp->coding_format;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -456,7 +456,7 @@ static struct bt_bap_scan_delegator_cb scan_delegator_cbs = {
 
 static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 {
-	struct bt_audio_codec_cfg *codec_cfg = stream->codec_cfg;
+	const struct bt_audio_codec_cfg *codec_cfg = stream->codec_cfg;
 	enum bt_audio_location chan_allocation;
 	uint8_t frames_blocks_per_sdu;
 	size_t min_sdu_size_required;

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -1274,9 +1274,10 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
 			struct bt_cap_unicast_audio_start_stream_param *stream_param =
 				&stream_params[stream_cnt];
+			struct bt_audio_codec_cfg *codec_cfg = snk_codec_cfgs[snk_stream_cnt];
 
 			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
+			stream_param->codec_cfg = codec_cfg;
 			stream_param->ep = snk_eps[snk_stream_cnt];
 			stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
@@ -1288,7 +1289,7 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 			 */
 			if (param->conn_cnt > 1U || param->snk_cnt[i] > 1U) {
 				const int err = bt_audio_codec_cfg_set_chan_allocation(
-					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
+					codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {
 					FAIL("Failed to set channel allocation: %d\n", err);
@@ -1300,9 +1301,10 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
 			struct bt_cap_unicast_audio_start_stream_param *stream_param =
 				&stream_params[stream_cnt];
+			struct bt_audio_codec_cfg *codec_cfg = src_codec_cfgs[src_stream_cnt];
 
 			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
+			stream_param->codec_cfg = codec_cfg;
 			stream_param->ep = src_eps[src_stream_cnt];
 			stream_param->stream = src_cap_streams[src_stream_cnt];
 
@@ -1314,7 +1316,7 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 			 */
 			if (param->conn_cnt > 1U || param->src_cnt[i] > 1U) {
 				const int err = bt_audio_codec_cfg_set_chan_allocation(
-					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
+					codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {
 					FAIL("Failed to set channel allocation: %d\n", err);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -771,9 +771,10 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
 			struct bt_cap_unicast_audio_start_stream_param *stream_param =
 				&stream_params[stream_cnt];
+			struct bt_audio_codec_cfg *codec_cfg = snk_codec_cfgs[snk_stream_cnt];
 
 			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
+			stream_param->codec_cfg = codec_cfg;
 			stream_param->ep = snk_eps[snk_stream_cnt];
 			stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
@@ -785,7 +786,7 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 			 */
 			if (param->conn_cnt > 1U || param->snk_cnt[i] > 1U) {
 				err = bt_audio_codec_cfg_set_chan_allocation(
-					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
+					codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {
 					FAIL("Failed to set channel allocation: %d\n", err);
@@ -797,9 +798,10 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 		for (size_t j = 0U; j < param->src_cnt[i]; j++) {
 			struct bt_cap_unicast_audio_start_stream_param *stream_param =
 				&stream_params[stream_cnt];
+			struct bt_audio_codec_cfg *codec_cfg = src_codec_cfgs[src_stream_cnt];
 
 			stream_param->member.member = connected_conns[i];
-			stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
+			stream_param->codec_cfg = codec_cfg;
 			stream_param->ep = src_eps[src_stream_cnt];
 			stream_param->stream = src_cap_streams[src_stream_cnt];
 
@@ -811,7 +813,7 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 			 */
 			if (param->conn_cnt > 1U || param->src_cnt[i] > 1U) {
 				err = bt_audio_codec_cfg_set_chan_allocation(
-					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
+					codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {
 					FAIL("Failed to set channel allocation: %d\n", err);


### PR DESCRIPTION
Changes ensure that `stream->codec_cfg` always points to the `stream->ep.codec_cfg`, and making it const makes it easier to understand that this is a read-only value. 