### PR TITLE
scripts: fpdiff: don't crash when a duplicate symbol is found

### DIFF
--- a/scripts/footprint/fpdiff.py
+++ b/scripts/footprint/fpdiff.py
@@ -16,7 +16,7 @@
 
 from anytree.importer import DictImporter
 from anytree import PreOrderIter, AnyNode
-from anytree.search  import find
+from anytree.search  import find, CountError
 
 import colorama
 from colorama import Fore
@@ -63,8 +63,13 @@ def main():
         for node in PreOrderIter(root1):
             n1_size = nodesz(node)
 
-            # pylint: disable=undefined-loop-variable
-            n = find(root2, lambda node2: node2.identifier == node.identifier)
+            try:
+                # pylint: disable=undefined-loop-variable
+                n = find(root2, lambda node2: node2.identifier == node.identifier)
+            except CountError:
+                print(f"W: ignored duplicate symbol {node.identifier} (@ {node.address:#08x})")
+                continue
+
             if n:
                 n2_size = nodesz(n)
                 if n2_size != n1_size:
@@ -82,11 +87,15 @@ def main():
                     print(f"{node.identifier} ({Fore.GREEN}-{n1_size}{Fore.RESET}) disappeared.")
 
         for node in PreOrderIter(root2):
-            n = find(root1, lambda node2: node2.identifier == node.identifier)
+            try:
+                n = find(root1, lambda node2: node2.identifier == node.identifier)
+            except CountError:
+                print(f"W: ignored duplicate symbol {node.identifier} (@ {node.address:#08x})")
+                continue
+
             if not n:
                 if not node.children and node.size != 0:
                     print(f"{node.identifier} ({Fore.RED}+{nodesz(node)}{Fore.RESET}) is new.")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The same symbol may be found multiple times when a function is declared in a header, which causes `anytree.search.find()` to throw a `CountError`.

Catch the exception and ignore duplicate symbols instead of crashing.

Example before/after:

<details>

```
(no paths)
+++++++++++++++++++++
:/__aeabi_memcpy4 (-28) disappeared.
:/__aeabi_memcpy8 (+28) is new.
ZEPHYR_BASE
+++++++++++++++++++++
<path/to/>zephyrproject/zephyr -> -8
Traceback (most recent call last):
  File "<path/to/>zephyrproject/zephyr/./scripts/footprint/fpdiff.py", line 92, in <module>
    main()
  File "<path/to/>zephyrproject/zephyr/./scripts/footprint/fpdiff.py", line 67, in main
    n = find(root2, lambda node2: node2.identifier == node.identifier)
  File "<path/to/>zephyrproject/.venv/lib/python3.10/site-packages/anytree/search.py", line 165, in find
    return _find(node, filter_=filter_, stop=stop, maxlevel=maxlevel)
  File "<path/to/>zephyrproject/.venv/lib/python3.10/site-packages/anytree/search.py", line 216, in _find
    items = _findall(node, filter_, stop=stop, maxlevel=maxlevel, maxcount=1)
  File "<path/to/>zephyrproject/.venv/lib/python3.10/site-packages/anytree/search.py", line 228, in _findall
    raise CountError(msg % (maxcount, resultlen), result)
anytree.search.CountError: Expecting 1 elements at maximum, but found 4. (AnyNode(address=134222653, identifier='soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0', loc=['rom'], name='z_stm32_hsem_lock.constprop.0', section='text', size=52), AnyNode(address=134223005, identifier='soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0', loc=['rom'], name='z_stm32_hsem_lock.constprop.0', section='text', size=52), AnyNode(address=134223733, identifier='soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0', loc=['rom'], name='z_stm32_hsem_lock.constprop.0', section='text', size=52), AnyNode(address=134224973, identifier='soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0', loc=['rom'], name='z_stm32_hsem_lock.constprop.0', section='text', size=52))
```

```
(no paths)
+++++++++++++++++++++
:/__aeabi_memcpy4 (-28) disappeared.
:/__aeabi_memcpy8 (+28) is new.
ZEPHYR_BASE
+++++++++++++++++++++
<path/to/>zephyrproject/zephyr -> -8
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x800133d)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x800149d)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x8001775)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x8001c51)
drivers/gpio/gpio_stm32.c/gpio_stm32_pin_interrupt_configure -> -4
drivers/gpio/gpio_stm32.c/gpio_stm32_init -> -4
W: ignored duplicate symbol kernel/include/ksched.h/unpend_thread_no_timeout (@ 0x80045df)
W: ignored duplicate symbol kernel/include/ksched.h/unpend_thread_no_timeout (@ 0x80046bf)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x800133d)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x800149d)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x8001775)
W: ignored duplicate symbol soc/st/stm32/common/stm32_hsem.h/z_stm32_hsem_lock.constprop.0 (@ 0x8001c4d)
W: ignored duplicate symbol kernel/include/ksched.h/unpend_thread_no_timeout (@ 0x80045d7)
W: ignored duplicate symbol kernel/include/ksched.h/unpend_thread_no_timeout (@ 0x80046b7)
OUTPUT_DIR
+++++++++++++++++++++
WORKSPACE
+++++++++++++++++++++
(hidden)
+++++++++++++++++++++
```

</details>