### PR TITLE
drivers: gpio: stm32: use device as ISR argument instead of data

### DIFF
--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -75,8 +75,6 @@ struct gpio_stm32_config {
 struct gpio_stm32_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
-	/* device's owner of this data */
-	const struct device *dev;
 	/* user ISR cb */
 	sys_slist_t cb;
 	/* keep track of pins that  are connected and need GPIO clock to be enabled */


### PR DESCRIPTION
The GPIO ISR needs both a pointer to the device object and its data block (because the callback linked list is stored in the data block). Sicne the device object has a built-in pointer to the data block, using that as the ISR's argument allows obtaining all we need "for free" whereas the current approach wastes 4 bytes of RAM per GPIO port instance.

Note that once compiled, the reworked ISR is effectively identical to the old one (only the offset of one `ldr Rt, [Rn, #off]` changes).