### PR TITLE
devicetree: add macros for reg property iteration

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -38,6 +38,10 @@ node-macro =/ %s"DT_N" path-id %s"_REG_IDX_" DIGIT
 node-macro =/ %s"DT_N" path-id %s"_REG_NAME_" dt-name
               %s"_VAL_" ( %s"ADDRESS" / %s"SIZE")
 node-macro =/ %s"DT_N" path-id %s"_REG_NAME_" dt-name "_EXISTS"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_REG"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_REG_SEP"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_REG_VARGS"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_REG_SEP_VARGS"
 ; The interrupts property is also special.
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NUM"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_LEVEL"

--- a/dts/bindings/test/vnd,test-foreach-reg-unique.yaml
+++ b/dts/bindings/test/vnd,test-foreach-reg-unique.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 EPAM Systems
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test inst foreach region node
+
+compatible: "vnd,test-foreach-reg-unique"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/test/vnd,test-foreach-reg.yaml
+++ b/dts/bindings/test/vnd,test-foreach-reg.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 EPAM Systems
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test foreach region node
+
+compatible: "vnd,test-foreach-reg"
+
+include: [base.yaml]

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2588,6 +2588,143 @@
 
 
 /**
+ * @brief Invokes @p fn for each entry of @p node_id reg property
+ *
+ * The macro @p fn takes two parameters, @p node_id which will be the node
+ * identifier of the node with the reg property and @p idx the index of
+ * the reg array.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n: node@0 {
+ *             #address-cells = <0x2>;
+ *             #size-cells = <0x2>;
+ *             reg = <0x0 0x0 0x0 0x1000>,
+ *                   <0x0 0x1000 0x0 0x1000>,
+ *                   <0x0 0x2000 0x0 0x1000>;
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define REG_ADDR(node_id, idx) DT_REG_ADDR_BY_IDX(node_id, idx),
+ *     #define REG_SIZE(node_id, idx) DT_REG_SIZE_BY_IDX(node_id, idx),
+ *
+ *     const uint64_t reg_addrs[] = {
+ *             DT_FOREACH_REG(DT_NODELABEL(n), REG_ADDR),
+ *     };
+ *     const uint64_t reg_sizes[] = {
+ *             DT_FOREACH_REG(DT_NODELABEL(n), REG_SIZE),
+ *     };
+ * @endcode
+ *
+ * This expands to:
+ *
+ * @code{.c}
+ *     const uint64_t reg_addrs[] = {
+ *         0x0, 0x1000, 0x2000,
+ *     };
+ *     const uint64_t reg_sizes[] = {
+ *         0x1000, 0x1000, 0x1000,
+ *     };
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_REG(node_id, fn) \
+	DT_CAT(node_id, _FOREACH_REG)(fn)
+
+/**
+ * @brief Invokes @p fn for each entry of @p node_id reg property with separator
+ *
+ * The macro @p fn takes two parameters, @p node_id which will be the node
+ * identifier of the node with the reg property and @p idx the index of
+ * the reg array.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n: node@0 {
+ *             #address-cells = <0x2>;
+ *             #size-cells = <0x2>;
+ *             reg = <0x0 0x0 0x0 0x1000>,
+ *                   <0x0 0x1000 0x0 0x1000>,
+ *                   <0x0 0x2000 0x0 0x1000>;
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     const uint64_t reg_addrs[] = {
+ *             DT_FOREACH_REG_SEP(DT_NODELABEL(n), DT_REG_ADDR_BY_IDX, (,))
+ *     };
+ *     const uint64_t reg_sizes[] = {
+ *             DT_FOREACH_REG_SEP(DT_NODELABEL(n), DT_REG_SIZE_BY_IDX, (,))
+ *     };
+ * @endcode
+ *
+ * This expands to:
+ *
+ * @code{.c}
+ *     const uint64_t reg_addrs[] = {
+ *         0x0, 0x1000, 0x2000
+ *     };
+ *     const uint64_t reg_sizes[] = {
+ *         0x1000, 0x1000, 0x1000
+ *     };
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_REG
+ */
+#define DT_FOREACH_REG_SEP(node_id, fn, sep) \
+	DT_CAT(node_id, _FOREACH_REG_SEP)(fn, sep)
+
+/**
+ * @brief Invokes @p fn for each entry of @p node_id reg property with multiple arguments.
+ *
+ * The macro @p fn takes multiple arguments. The first one @p node_id will be the node
+ * identifier of the node with the reg property and @p idx the index of the reg array.
+ * The remaining are passed-in by the caller.
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_REG
+ */
+
+#define DT_FOREACH_REG_VARGS(node_id, fn, ...) \
+	DT_CAT(node_id, _FOREACH_REG_VARGS)(fn, __VA_ARGS__)
+
+/**
+ * @brief Invokes @p fn for each entry of @p node_id reg property with separator and
+ * multiple arguments.
+ *
+ * The macro @p fn takes multiple arguments. The first one @p node_id will be the node
+ * identifier of the node with the reg property and @p idx the index of the reg array.
+ * The remaining are passed-in by the caller.
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_REG
+ */
+#define DT_FOREACH_REG_SEP_VARGS(node_id, fn, sep, ...) \
+	DT_CAT(node_id, _FOREACH_REG_SEP_VARGS)(fn, sep, __VA_ARGS__)
+
+/**
  * @}
  */
 
@@ -4304,6 +4441,82 @@
  */
 #define DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(inst, fn, sep, ...) \
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
+
+/**
+ * @brief Call @p fn on all node reg property for a given `DT_DRV_COMPAT` instance.
+ *
+ * The macro @p fn takes two parameters, @p node_id which will be the node
+ * identifier of the node with the reg property and @p idx the index of
+ * the reg array.
+ *
+ * Equivalent to DT_FOREACH_REG(DT_DRV_INST(inst), fn).
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each reg property
+ *
+ * @see DT_FOREACH_REG
+ */
+#define DT_INST_FOREACH_REG(inst, fn) \
+	DT_FOREACH_REG(DT_DRV_INST(inst), fn)
+
+/**
+ * @brief Call @p fn on all node reg property for a given `DT_DRV_COMPAT` instance with separator.
+ *
+ * The macro @p fn takes two parameters, @p node_id which will be the node
+ * identifier of the node with the reg property and @p idx the index of
+ * the reg array.
+ *
+ * Equivalent to DT_FOREACH_REG_SEP(DT_DRV_INST(inst), fn, sep).
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each reg property
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_REG_SEP
+ */
+#define DT_INST_FOREACH_REG_SEP(inst, fn, sep) \
+	DT_FOREACH_REG_SEP(DT_DRV_INST(inst), fn, sep)
+
+/**
+ * @brief Call @p fn on all node reg property for a given `DT_DRV_COMPAT` instance
+ * with multiple arguments.
+ *
+ * The macro @p fn takes multiple arguments. The first one @p node_id will be the node
+ * identifier of the node with the reg property and @p idx the index of the reg array.
+ * The remaining are passed-in by the caller.
+ *
+ * Equivalent to DT_FOREACH_REG_VARGS(DT_DRV_INST(inst), fn, __VA_ARGS__).
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each reg property
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_REG_VARGS
+ */
+#define DT_INST_FOREACH_REG_VARGS(inst, fn, ...) \
+	DT_FOREACH_REG_VARGS(DT_DRV_INST(inst), fn, __VA_ARGS__)
+
+/**
+ * @brief Call @p fn on all node reg property for a given `DT_DRV_COMPAT` instance
+ * with separator and multiple arguments.
+ *
+ * The macro @p fn takes multiple arguments. The first one @p node_id will be the node
+ * identifier of the node with the reg property and @p idx the index of the reg array.
+ * The remaining are passed-in by the caller.
+ *
+ * Equivalent to DT_FOREACH_REG_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__).
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each reg property
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_REG_SEP_VARGS
+ */
+#define DT_INST_FOREACH_REG_SEP_VARGS(inst, fn, sep, ...) \
+	DT_FOREACH_REG_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
 
 /**
  * @brief Get a `DT_DRV_COMPAT` property array value's index into its enumeration values

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -371,6 +371,21 @@ def write_regs(node: edtlib.Node) -> None:
     for macro, val in name_vals:
         out_dt_define(macro, val)
 
+    out_dt_define(f"{path_id}_FOREACH_REG(fn)",
+                  " ".join(f"fn(DT_{path_id}, {i})" for i,reg in enumerate(node.regs)))
+
+    out_dt_define(f"{path_id}_FOREACH_REG_SEP(fn, sep)",
+                  " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{path_id}, {i})"
+                  for i,reg in enumerate(node.regs)))
+
+    out_dt_define(f"{path_id}_FOREACH_REG_VARGS(fn, ...)",
+                  " ".join(f"fn(DT_{path_id}, {i}, __VA_ARGS__)"
+                  for i,reg in enumerate(node.regs)))
+
+    out_dt_define(f"{path_id}_FOREACH_REG_SEP_VARGS(fn, sep, ...)",
+                  " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{path_id}, {i}, __VA_ARGS__)"
+                  for i,reg in enumerate(node.regs)))
+
 
 def write_interrupts(node: edtlib.Node) -> None:
     # interrupts property: we have some hard-coded logic for interrupt

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -768,6 +768,28 @@
 			};
 		};
 
+		test-regs {
+			#address-cells = <2>;
+			#size-cells = <1>;
+
+			/* there should only be one of these */
+			test_regs_test_node: testnode@2000000 {
+				compatible = "vnd,test-foreach-reg-unique";
+				reg = <0x00 0x2000000 0x40000>,
+				      <0x00 0x2200000 0x5c00000>,
+				      <0x00 0x8400000 0x7a00000>;
+			};
+
+			test_regs_other: other@107fff9000 {
+				compatible = "vnd,test-foreach-reg";
+				reg = <0x10 0x7fff9000 0x1000>;
+			};
+
+			test_regs_empty: empty {
+				compatible = "vnd,test-foreach-reg";
+			};
+		};
+
 		device-with-props-0 {
 			compatible = "vnd,device-with-props";
 			status = "okay";

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -100,6 +100,10 @@
 #define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
 #define TEST_RANGES_EMPTY DT_NODELABEL(test_ranges_empty)
 
+#define TEST_REGS_TEST_NODE   DT_NODELABEL(test_regs_test_node)
+#define TEST_REGS_OTHER       DT_NODELABEL(test_regs_other)
+#define TEST_REGS_EMPTY       DT_NODELABEL(test_regs_empty)
+
 #define TEST_MTD_0 DT_PATH(test, test_mtd_ffeeddcc)
 #define TEST_MTD_1 DT_PATH(test, test_mtd_33221100)
 #define TEST_MTD_2 DT_PATH(test_mtd_12830)
@@ -2944,6 +2948,255 @@ ZTEST(devicetree_api, test_ranges_empty)
 #define FAIL(node_id, idx) ztest_test_fail();
 
 	DT_FOREACH_RANGE(TEST_RANGES_EMPTY, FAIL);
+
+#undef FAIL
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_test_foreach_reg_unique
+
+ZTEST(devicetree_api, test_foreach_reg)
+{
+#define REG_ADDR(node_id, idx) \
+	DT_REG_ADDR_BY_IDX(node_id, idx),
+#define REG_SIZE(node_id, idx) \
+	DT_REG_SIZE_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_REGS(TEST_REGS_TEST_NODE);
+
+	const uint64_t regs_addr[] = {
+		DT_FOREACH_REG(TEST_REGS_TEST_NODE, REG_ADDR)
+	};
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG(TEST_REGS_TEST_NODE, REG_SIZE)
+	};
+
+	zassert_equal(count, 3, "");
+
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_TEST_NODE, 0), 1, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_TEST_NODE, 1), 1, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_TEST_NODE, 2), 1, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_TEST_NODE, 3), 0, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_TEST_NODE, 4), 0, "");
+
+	zassert_equal(regs_addr[0], 0x2000000, "");
+	zassert_equal(regs_addr[1], 0x2200000, "");
+	zassert_equal(regs_addr[2], 0x8400000, "");
+	zassert_equal(regs_size[0], 0x0040000, "");
+	zassert_equal(regs_size[1], 0x5C00000, "");
+	zassert_equal(regs_size[2], 0x7A00000, "");
+
+#undef REG_ADDR
+#undef REG_SIZE
+}
+
+ZTEST(devicetree_api, test_foreach_reg_sep)
+{
+	const uint64_t regs_addr[] = {
+		DT_FOREACH_REG_SEP(TEST_REGS_TEST_NODE, DT_REG_ADDR_BY_IDX, (,))
+	};
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG_SEP(TEST_REGS_TEST_NODE, DT_REG_SIZE_BY_IDX, (,))
+	};
+
+	zassert_equal(regs_addr[0], 0x2000000, "");
+	zassert_equal(regs_addr[1], 0x2200000, "");
+	zassert_equal(regs_addr[2], 0x8400000, "");
+	zassert_equal(regs_size[0], 0x0040000, "");
+	zassert_equal(regs_size[1], 0x5C00000, "");
+	zassert_equal(regs_size[2], 0x7A00000, "");
+}
+
+ZTEST(devicetree_api, test_foreach_reg_sep_vargs)
+{
+/* Returns the size in pages */
+#define REG_SIZE_PAGES(node_id, idx, page_size) \
+	DT_REG_SIZE_BY_IDX(node_id, idx) / page_size
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG_SEP_VARGS(TEST_REGS_TEST_NODE, REG_SIZE_PAGES, (,), 0x1000)
+	};
+
+	zassert_equal(regs_size[0], 0x40, "");
+	zassert_equal(regs_size[1], 0x5C00, "");
+	zassert_equal(regs_size[2], 0x7A00, "");
+#undef REG_SIZE_PAGES
+}
+
+ZTEST(devicetree_api, test_foreach_reg_vargs)
+{
+/* Returns the size in pages with a coma at the end */
+#define REG_SIZE_PAGES(node_id, idx, page_size) \
+	DT_REG_SIZE_BY_IDX(node_id, idx) / page_size,
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG_VARGS(TEST_REGS_TEST_NODE, REG_SIZE_PAGES, 0x1000)
+	};
+
+	zassert_equal(regs_size[0], 0x40, "");
+	zassert_equal(regs_size[1], 0x5C00, "");
+	zassert_equal(regs_size[2], 0x7A00, "");
+#undef REG_SIZE_PAGES
+}
+
+ZTEST(devicetree_api, test_inst_foreach_reg)
+{
+#define REG_ADDR(node_id, idx) \
+	DT_REG_ADDR_BY_IDX(node_id, idx),
+#define REG_SIZE(node_id, idx) \
+	DT_REG_SIZE_BY_IDX(node_id, idx),
+
+	/* Because dt has only one node with such compatible, the result node of DT_INST(),
+	 * and the parsed reg values as well are axiomatic and can be tested
+	 */
+	const uint64_t regs_addr[] = {
+		DT_INST_FOREACH_REG(0, REG_ADDR)
+	};
+
+	const uint64_t regs_size[] = {
+		DT_INST_FOREACH_REG(0, REG_SIZE)
+	};
+
+	zassert_equal(DT_INST_REG_HAS_IDX(0, 0), 1, "");
+	zassert_equal(DT_INST_REG_HAS_IDX(0, 1), 1, "");
+	zassert_equal(DT_INST_REG_HAS_IDX(0, 2), 1, "");
+	zassert_equal(DT_INST_REG_HAS_IDX(0, 3), 0, "");
+	zassert_equal(DT_INST_REG_HAS_IDX(0, 4), 0, "");
+
+	zassert_equal(regs_addr[0], 0x2000000, "");
+	zassert_equal(regs_addr[1], 0x2200000, "");
+	zassert_equal(regs_addr[2], 0x8400000, "");
+	zassert_equal(regs_size[0], 0x0040000, "");
+	zassert_equal(regs_size[1], 0x5C00000, "");
+	zassert_equal(regs_size[2], 0x7A00000, "");
+#undef REG_ADDR
+#undef REG_SIZE
+}
+
+ZTEST(devicetree_api, test_inst_foreach_reg_vargs)
+{
+/* Returns the size in pages */
+#define REG_SIZE_PAGES(node_id, idx, page_size) \
+	DT_REG_SIZE_BY_IDX(node_id, idx) / page_size,
+
+	/* Because dt has only one node with such compatible, the result node of DT_INST(),
+	 * and the parsed size value as well are axiomatic and can be tested
+	 */
+	const uint64_t regs_size[] = {
+		DT_INST_FOREACH_REG_VARGS(0, REG_SIZE_PAGES, 0x1000)
+	};
+
+	zassert_equal(regs_size[0], 0x40, "");
+	zassert_equal(regs_size[1], 0x5C00, "");
+	zassert_equal(regs_size[2], 0x7A00, "");
+#undef REG_SIZE_PAGES
+}
+
+ZTEST(devicetree_api, test_inst_foreach_reg_sep_vargs)
+{
+/* Returns the size in pages */
+#define REG_SIZE_PAGES(node_id, idx, page_size) \
+	DT_REG_SIZE_BY_IDX(node_id, idx) / page_size
+
+	/* Because dt has only one node with such compatible, the result node of DT_INST(),
+	 * and the parsed size value as well are axiomatic and can be tested
+	 */
+	const uint64_t regs_inst_size[] = {
+		DT_INST_FOREACH_REG_SEP_VARGS(0, REG_SIZE_PAGES, (,), 0x1000)
+	};
+
+	zassert_equal(regs_inst_size[0], 0x40, "");
+	zassert_equal(regs_inst_size[1], 0x5C00, "");
+	zassert_equal(regs_inst_size[2], 0x7A00, "");
+
+#undef REG_SIZE_PAGES
+}
+
+ZTEST(devicetree_api, test_inst_foreach_reg_sep)
+{
+	/* Because dt has only one node with such compatible, the result node of DT_INST(),
+	 * and the parsed reg values as well are axiomatic and can be tested
+	 */
+	const uint64_t regs_inst_addr[] = {
+		DT_INST_FOREACH_REG_SEP(0, DT_REG_ADDR_BY_IDX, (,))
+	};
+
+	const uint64_t regs_inst_size[] = {
+		DT_INST_FOREACH_REG_SEP(0, DT_REG_SIZE_BY_IDX, (,))
+	};
+
+	zassert_equal(regs_inst_addr[0], 0x2000000, "");
+	zassert_equal(regs_inst_addr[1], 0x2200000, "");
+	zassert_equal(regs_inst_addr[2], 0x8400000, "");
+	zassert_equal(regs_inst_size[0], 0x0040000, "");
+	zassert_equal(regs_inst_size[1], 0x5C00000, "");
+	zassert_equal(regs_inst_size[2], 0x7A00000, "");
+}
+#undef DT_DRV_COMPAT
+
+ZTEST(devicetree_api, test_foreach_reg_other)
+{
+#define REG_ADDR(node_id, idx) \
+	DT_REG_ADDR_BY_IDX(node_id, idx),
+#define REG_SIZE(node_id, idx) \
+	DT_REG_SIZE_BY_IDX(node_id, idx),
+
+	unsigned int count = DT_NUM_REGS(TEST_REGS_OTHER);
+
+	const uint64_t regs_addr[] = {
+		DT_FOREACH_REG(TEST_REGS_OTHER, REG_ADDR)
+	};
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG(TEST_REGS_OTHER, REG_SIZE)
+	};
+
+	zassert_equal(count, 1, "");
+
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 0), 1, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 1), 0, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 2), 0, "");
+
+	zassert_equal(regs_addr[0], 0x107fff9000, "");
+	zassert_equal(regs_size[0], 0x1000, "");
+
+#undef REG_ADDR
+#undef REG_SIZE
+}
+
+ZTEST(devicetree_api, test_foreach_reg_vargs_other)
+{
+/* Returns the size in pages with a coma at the end */
+#define REG_SIZE_PAGES(node_id, idx, page_size) \
+	DT_REG_SIZE_BY_IDX(node_id, idx) / page_size,
+
+	const uint64_t regs_size[] = {
+		DT_FOREACH_REG_VARGS(TEST_REGS_OTHER, REG_SIZE_PAGES, 0x1000)
+	};
+
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 0), 1, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 1), 0, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_OTHER, 2), 0, "");
+
+	zassert_equal(regs_size[0], 1, "");
+
+#undef REG_SIZE_PAGES
+}
+
+ZTEST(devicetree_api, test_foreach_reg_empty)
+{
+	zassert_equal(DT_NODE_HAS_PROP(TEST_REGS_EMPTY, reg), 0, "");
+
+	zassert_equal(DT_NUM_REGS(TEST_REGS_EMPTY), 0, "");
+
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_EMPTY, 0), 0, "");
+	zassert_equal(DT_REG_HAS_IDX(TEST_REGS_EMPTY, 1), 0, "");
+
+#define FAIL(node_id, idx) ztest_test_fail();
+
+	DT_FOREACH_REG(TEST_REGS_EMPTY, FAIL);
 
 #undef FAIL
 }


### PR DESCRIPTION
Introduce DT_FOREACH_REG and DT_INST_FOREACH_REG macros to enable iteration over reg entries in devicetree nodes. These macros allow invocation of user-supplied functions or macros for each reg array element. The DT_FOREACH_REG macro mirrors the behavior of the ranges property, making it easier to handle allocations for each provided register.

Update devicetree macro generation logic and the docs section contained an Augmented Backus-Naur Form grammar for generated macros.

Expand test coverage with new overlay nodes and dedicated tests to verify macro correctness and behavior.