### PR TITLE
maintainers: add James Bennion-Pedley as WCH maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5583,7 +5583,9 @@ VFS:
     - filesystem
 
 WCH Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - BOJIT
   collaborators:
     - nzmichaelh
     - kholia
@@ -6146,6 +6148,7 @@ West:
   maintainers:
     - nzmichaelh
     - kholia
+    - BOJIT
   collaborators:
     - VynDragon
   files:


### PR DESCRIPTION
Adding myself as a maintainer in preparation for a few board PRs that have been requested.

Currently the WCH platform is maintainerless. There are a few efforts to expand peripheral support for various chips in this family that I am now reviewing: https://github.com/zephyrproject-rtos/zephyr/issues?q=state%3Aopen%20label%3A%22platform%3A%20WinChipHead%22

As of last week I now actually have a good selection of boards to test PRs on (can now test `CH32V307`, `CH32V003`, `CH32V305`, `CH32V203`, `CH32V317`).
<img width="375" height="500" alt="image" src="https://github.com/user-attachments/assets/5021edf3-a651-459a-acbf-3b06a79f6861" />

Have okayed this with @VynDragon on [Discord](https://discord.com/channels/720317445772017664/1372248336039411782), who AFAIK is the only other active collaborator at the moment.