### PR TITLE
soc: intel_adsp/ace: Fix MMU mapping for shared heap

### DIFF
--- a/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
+++ b/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
@@ -631,4 +631,6 @@ SECTIONS {
 	MEM_MAP_SYM_PROVIDE(__rodata_region_end)
 	MEM_MAP_SYM_PROVIDE(__text_region_start)
 	MEM_MAP_SYM_PROVIDE(__text_region_end)
+	MEM_MAP_SYM_PROVIDE(_shared_heap_start)
+	MEM_MAP_SYM_PROVIDE(_shared_heap_end)
 }

--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -63,6 +63,8 @@ MEM_MAP_SYM_DECLARE(__cold_end);
 MEM_MAP_SYM_DECLARE(__coldrodata_start);
 MEM_MAP_SYM_DECLARE(_heap_start);
 MEM_MAP_SYM_DECLARE(_heap_end);
+MEM_MAP_SYM_DECLARE(_shared_heap_start);
+MEM_MAP_SYM_DECLARE(_shared_heap_end);
 MEM_MAP_SYM_DECLARE(_image_ram_start);
 MEM_MAP_SYM_DECLARE(_image_ram_end);
 MEM_MAP_SYM_DECLARE(__imr_data_start);
@@ -74,7 +76,6 @@ MEM_MAP_SYM_DECLARE(__rodata_region_start);
 MEM_MAP_SYM_DECLARE(__rodata_region_end);
 MEM_MAP_SYM_DECLARE(__text_region_start);
 MEM_MAP_SYM_DECLARE(__text_region_end);
-
 
 const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	MEM_MAP_SYM_REGION(
@@ -250,12 +251,13 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 		"lpsram"
 	)
 
-	{
-		.start = (uint32_t)_shared_heap_start,
-		.end   = (uint32_t)_shared_heap_end,
-		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB | XTENSA_MMU_MAP_SHARED,
-		.name = "shared heap",
-	},
+	MEM_MAP_SYM_REGION(
+		_shared_heap_start,
+		_shared_heap_end,
+		XTENSA_MMU_PERM_W | XTENSA_MMU_MAP_SHARED,
+		"shared heap"
+	)
+
 	{
 		.start = (uint32_t)(ADSP_L1CC_ADDR),
 		.end   = (uint32_t)(ADSP_L1CC_ADDR + CONFIG_MMU_PAGE_SIZE),

--- a/soc/intel/intel_adsp/ace/mmu_ace40.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace40.c
@@ -63,6 +63,8 @@ MEM_MAP_SYM_DECLARE(__cold_end);
 MEM_MAP_SYM_DECLARE(__coldrodata_start);
 MEM_MAP_SYM_DECLARE(_heap_start);
 MEM_MAP_SYM_DECLARE(_heap_end);
+MEM_MAP_SYM_DECLARE(_shared_heap_start);
+MEM_MAP_SYM_DECLARE(_shared_heap_end);
 MEM_MAP_SYM_DECLARE(_image_ram_start);
 MEM_MAP_SYM_DECLARE(_image_ram_end);
 MEM_MAP_SYM_DECLARE(__imr_data_start);
@@ -74,7 +76,6 @@ MEM_MAP_SYM_DECLARE(__rodata_region_start);
 MEM_MAP_SYM_DECLARE(__rodata_region_end);
 MEM_MAP_SYM_DECLARE(__text_region_start);
 MEM_MAP_SYM_DECLARE(__text_region_end);
-
 
 const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	MEM_MAP_SYM_REGION(
@@ -236,12 +237,13 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 		"lpsram"
 	)
 
-	{
-		.start = (uint32_t)_shared_heap_start,
-		.end   = (uint32_t)_shared_heap_end,
-		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB | XTENSA_MMU_MAP_SHARED,
-		.name = "shared heap",
-	},
+	MEM_MAP_SYM_REGION(
+		_shared_heap_start,
+		_shared_heap_end,
+		XTENSA_MMU_PERM_W | XTENSA_MMU_MAP_SHARED,
+		"shared heap"
+	)
+
 	{
 		.start = (uint32_t)(ADSP_L1CC_ADDR),
 		.end = (uint32_t)(ADSP_L1CC_ADDR + CONFIG_MMU_PAGE_SIZE),


### PR DESCRIPTION
Update shared heap entry in the SoC MMU map to match the new mirrored-memory model.