### PR TITLE
Add units to Fuel Gauge property fields for enums/structs

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -23,6 +23,7 @@ using :c:func:`fuel_gauge_get_buffer_prop`.
 Properties are set by the client one at a time using :c:func:`fuel_gauge_set_prop`, or set in a
 batch using :c:func:`fuel_gauge_set_props`.
 
+
 Battery Cutoff
 ==============
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -213,6 +213,15 @@ Flash
   of each plane in the flash device. For devices with a single plane, this should be set to the
   same value as ``size-bytes``.
 
+Fuel Gauge
+==========
+
+* Various fuel gauge property enums and union fields have been deprecated in
+  favor of new versions with explicit unit suffixes. Applications and drivers
+  should migrate to the unit-suffixed names. For example,
+  ``FUEL_GAUGE_CURRENT`` (``val.current``) is replaced by
+  ``FUEL_GAUGE_CURRENT_UA`` (``val.current_ua``).
+
 GPIO
 ====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -88,6 +88,11 @@ Deprecated APIs and options
   * The :c:struct:`_dmic_ops` struct has been deprecated. DMIC drivers are now expected to use the
     :c:macro:`DEVICE_API` macro to declare their driver API.
 
+* Fuel Gauge
+
+  * Deprecated various fuel gauge property enums and union fields in favor of
+    new versions with explicit unit suffixes.
+
 * LoRa
 
   * Renamed :c:func:`lora_recv_duty_cycle` to :c:func:`lora_recv_duty_cycle_async`

--- a/drivers/fuel_gauge/adp5360/fuel_gauge_adp5360.c
+++ b/drivers/fuel_gauge/adp5360/fuel_gauge_adp5360.c
@@ -166,8 +166,8 @@ static int fuel_gauge_adp5360_get_vbat(const struct device *dev, union fuel_gaug
 	/* Register Voltage readout is in millivolts,
 	 * multiply by 1000 to get it in terms of microvolts
 	 */
-	val->voltage = (sys_be16_to_cpu(buf) >> FUEL_GAUGE_ADP5360_VBAT_SHIFT) *
-		       FUEL_GAUGE_ADP5360_MV_TO_UV;
+	val->voltage_uv = (sys_be16_to_cpu(buf) >> FUEL_GAUGE_ADP5360_VBAT_SHIFT) *
+			  FUEL_GAUGE_ADP5360_MV_TO_UV;
 
 	return 0;
 }
@@ -228,7 +228,7 @@ static int fuel_gauge_adp5360_get_bat_soc(const struct device *dev, union fuel_g
 		buf = FUEL_GAUGE_ADP5360_SOC_FULL;
 	}
 
-	val->absolute_state_of_charge = buf;
+	val->absolute_state_of_charge_pct = buf;
 
 	return 0;
 }
@@ -254,16 +254,16 @@ static int fuel_gauge_adp5360_get_soc_alarm(const struct device *dev,
 
 	switch (soc_low_th_setting) {
 	case 0:
-		val->state_of_charge_alarm = FUEL_GAUGE_ADP5360_SOC_ALARM_6PCT;
+		val->state_of_charge_alarm_pct = FUEL_GAUGE_ADP5360_SOC_ALARM_6PCT;
 		break;
 	case 1:
-		val->state_of_charge_alarm = FUEL_GAUGE_ADP5360_SOC_ALARM_11PCT;
+		val->state_of_charge_alarm_pct = FUEL_GAUGE_ADP5360_SOC_ALARM_11PCT;
 		break;
 	case 2:
-		val->state_of_charge_alarm = FUEL_GAUGE_ADP5360_SOC_ALARM_21PCT;
+		val->state_of_charge_alarm_pct = FUEL_GAUGE_ADP5360_SOC_ALARM_21PCT;
 		break;
 	case 3:
-		val->state_of_charge_alarm = FUEL_GAUGE_ADP5360_SOC_ALARM_31PCT;
+		val->state_of_charge_alarm_pct = FUEL_GAUGE_ADP5360_SOC_ALARM_31PCT;
 		break;
 	default:
 		LOG_ERR("Invalid state of charge alarm setting read from ADP5360 MFD: %d",
@@ -302,15 +302,15 @@ static int fuel_gauge_adp5360_get_prop(const struct device *dev, fuel_gauge_prop
 	switch (prop) {
 	case FUEL_GAUGE_CYCLE_COUNT:
 		return fuel_gauge_adp5360_get_cycle_count(dev, val);
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		return fuel_gauge_adp5360_get_vbat(dev, val);
 	case FUEL_GAUGE_STATUS:
 		return fuel_gauge_adp5360_get_status(dev, val);
 	case FUEL_GAUGE_DESIGN_CAPACITY:
 		return fuel_gauge_adp5360_get_capacity(dev, val);
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
 		return fuel_gauge_adp5360_get_bat_soc(dev, val);
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
 		return fuel_gauge_adp5360_get_soc_alarm(dev, val);
 	case FUEL_GAUGE_THERM_VOLTAGE_UV:
 		return fuel_gauge_adp5360_get_thr_uv(dev, val);
@@ -326,7 +326,7 @@ static int fuel_gauge_adp5360_set_soc_alarm(const struct device *dev, union fuel
 	int ret;
 	uint8_t buf;
 
-	switch (val.state_of_charge_alarm) {
+	switch (val.state_of_charge_alarm_pct) {
 	case 6:
 		buf = 0;
 		break;
@@ -340,7 +340,7 @@ static int fuel_gauge_adp5360_set_soc_alarm(const struct device *dev, union fuel
 		buf = 3;
 		break;
 	default:
-		LOG_ERR("Invalid state of charge alarm value: %d", val.state_of_charge_alarm);
+		LOG_ERR("Invalid state of charge alarm value: %d", val.state_of_charge_alarm_pct);
 		LOG_ERR("Valid values are: 6, 11, 21, 31");
 		return -EINVAL;
 	}
@@ -621,7 +621,7 @@ static int fuel_gauge_adp5360_set_prop(const struct device *dev, fuel_gauge_prop
 				       union fuel_gauge_prop_val val)
 {
 	switch (prop) {
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
 		return fuel_gauge_adp5360_set_soc_alarm(dev, val);
 	case FUEL_GAUGE_DESIGN_CAPACITY:
 		return fuel_gauge_adp5360_set_bat_cap(dev, val);

--- a/drivers/fuel_gauge/axp2101/fuel_gauge_axp2101.c
+++ b/drivers/fuel_gauge/axp2101/fuel_gauge_axp2101.c
@@ -112,7 +112,7 @@ static int get_battery_percent(const struct device *dev, union fuel_gauge_prop_v
 		return ret;
 	}
 
-	val->relative_state_of_charge = tmp;
+	val->relative_state_of_charge_pct = tmp;
 	return 0;
 }
 
@@ -137,7 +137,7 @@ static int get_bat_voltage(const struct device *dev, union fuel_gauge_prop_val *
 		return ret;
 	}
 
-	val->voltage = (((h5 & GAUGE_VBAT_H_MASK) << 8) | l8) * 1000;
+	val->voltage_uv = (((h5 & GAUGE_VBAT_H_MASK) << 8) | l8) * 1000;
 	return 0;
 }
 
@@ -148,10 +148,10 @@ static int axp2101_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	case FUEL_GAUGE_PRESENT_STATE:
 	case FUEL_GAUGE_CONNECT_STATE:
 		return is_battery_connect(dev, val);
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		return get_bat_voltage(dev, val);
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		return get_battery_percent(dev, val);
 	default:
 		return -ENOTSUP;

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -125,65 +125,65 @@ static int bq27z746_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	 */
 
 	switch (prop) {
-	case FUEL_GAUGE_AVG_CURRENT:
+	case FUEL_GAUGE_AVG_CURRENT_UA:
 		rc = bq27z746_read16(dev, BQ27Z746_AVERAGECURRENT, &tmp_val);
-		val->avg_current = (int16_t)tmp_val * 1000;
+		val->avg_current_ua = (int16_t)tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
 		rc = bq27z746_read16(dev, BQ27Z746_CYCLECOUNT, &tmp_val);
 		val->cycle_count = tmp_val * 100;
 		break;
-	case FUEL_GAUGE_CURRENT:
+	case FUEL_GAUGE_CURRENT_UA:
 		rc = bq27z746_read16(dev, BQ27Z746_CURRENT, &tmp_val);
-		val->current = (int16_t)tmp_val * 1000;
+		val->current_ua = (int16_t)tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 		rc = bq27z746_read16(dev, BQ27Z746_FULLCHARGECAPACITY, &tmp_val);
-		val->full_charge_capacity = tmp_val * 1000;
+		val->full_charge_capacity_uah = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
 		rc = bq27z746_read16(dev, BQ27Z746_REMAININGCAPACITY, &tmp_val);
-		val->remaining_capacity = tmp_val * 1000;
+		val->remaining_capacity_uah = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
 		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOEMPTY, &tmp_val);
-		val->runtime_to_empty = tmp_val;
+		val->runtime_to_empty_mins = tmp_val;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_FULL:
+	case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
 		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOFULL, &tmp_val);
-		val->runtime_to_full = tmp_val;
+		val->runtime_to_full_mins = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = bq27z746_read16(dev, BQ27Z746_MANUFACTURERACCESS, &tmp_val);
 		val->sbs_mfr_access_word = tmp_val;
 		break;
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		rc = bq27z746_read16(dev, BQ27Z746_RELATIVESTATEOFCHARGE, &tmp_val);
-		val->relative_state_of_charge = tmp_val;
+		val->relative_state_of_charge_pct = tmp_val;
 		break;
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		rc = bq27z746_read16(dev, BQ27Z746_TEMPERATURE, &tmp_val);
-		val->temperature = tmp_val;
+		val->temperature_dk = tmp_val;
 		break;
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		rc = bq27z746_read16(dev, BQ27Z746_VOLTAGE, &tmp_val);
-		val->voltage = tmp_val * 1000;
+		val->voltage_uv = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
 		rc = bq27z746_read16(dev, BQ27Z746_ATRATE, &tmp_val);
 		val->sbs_at_rate = (int16_t)tmp_val;
 		break;
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS:
 		rc = bq27z746_read16(dev, BQ27Z746_ATRATETIMETOEMPTY, &tmp_val);
-		val->sbs_at_rate_time_to_empty = tmp_val;
+		val->sbs_at_rate_time_to_empty_mins = tmp_val;
 		break;
-	case FUEL_GAUGE_CHARGE_VOLTAGE:
+	case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
 		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGVOLTAGE, &tmp_val);
-		val->chg_voltage = tmp_val * 1000;
+		val->chg_voltage_uv = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_CHARGE_CURRENT:
+	case FUEL_GAUGE_CHARGE_CURRENT_UA:
 		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGCURRENT, &tmp_val);
-		val->chg_current = tmp_val * 1000;
+		val->chg_current_ua = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_STATUS:
 		rc = bq27z746_read16(dev, BQ27Z746_BATTERYSTATUS, &tmp_val);

--- a/drivers/fuel_gauge/bq40z50/bq40z50.c
+++ b/drivers/fuel_gauge/bq40z50/bq40z50.c
@@ -189,10 +189,10 @@ static int bq40z50_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 					sizeof(val.sbs_remaining_capacity_alarm));
 		break;
 
-	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
 		ret = bq40z50_i2c_write(dev, BQ40Z50_REMAININGTIMEALARM,
-					(uint8_t *)&val.sbs_remaining_time_alarm,
-					sizeof(val.sbs_remaining_time_alarm));
+					(uint8_t *)&val.sbs_remaining_time_alarm_mins,
+					sizeof(val.sbs_remaining_time_alarm_mins));
 		break;
 
 	case FUEL_GAUGE_SBS_MODE:
@@ -225,18 +225,18 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	uint16_t tmp_val = 0;
 
 	switch (prop) {
-	case FUEL_GAUGE_AVG_CURRENT:
+	case FUEL_GAUGE_AVG_CURRENT_UA:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_AVERAGECURRENT, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* convert mA to uA */
-		val->avg_current = (int16_t)tmp_val * 1000;
+		val->avg_current_ua = (int16_t)tmp_val * 1000;
 		break;
 
-	case FUEL_GAUGE_CURRENT:
+	case FUEL_GAUGE_CURRENT_UA:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_CURRENT, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* convert mA to uA */
-		val->current = (int16_t)tmp_val * 1000;
+		val->current_ua = (int16_t)tmp_val * 1000;
 		break;
 
 	case FUEL_GAUGE_CHARGE_CUTOFF:
@@ -251,24 +251,24 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->cycle_count = tmp_val;
 		break;
 
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_FULLCHARGECAPACITY, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* convert mAh to uAh */
-		val->full_charge_capacity = tmp_val * 1000;
+		val->full_charge_capacity_uah = tmp_val * 1000;
 		break;
 
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_REMAININGCAPACITY, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* convert mAh to uAh */
-		val->remaining_capacity = tmp_val * 1000;
+		val->remaining_capacity_uah = tmp_val * 1000;
 		break;
 
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_RUNTIMETOEMPTY, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->runtime_to_empty = tmp_val;
+		val->runtime_to_empty_mins = tmp_val;
 		break;
 
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
@@ -277,29 +277,29 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->sbs_mfr_access_word = tmp_val;
 		break;
 
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_ABSOLUTESTATEOFCHARGE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_BYTE);
-		val->absolute_state_of_charge = tmp_val;
+		val->absolute_state_of_charge_pct = tmp_val;
 		break;
 
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_RELATIVESTATEOFCHARGE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_BYTE);
-		val->relative_state_of_charge = tmp_val;
+		val->relative_state_of_charge_pct = tmp_val;
 		break;
 
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_TEMPERATURE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->temperature = tmp_val;
+		val->temperature_dk = tmp_val;
 		break;
 
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_VOLTAGE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* change mV to uV */
-		val->voltage = tmp_val * 1000;
+		val->voltage_uv = tmp_val * 1000;
 		break;
 
 	case FUEL_GAUGE_SBS_MODE:
@@ -308,18 +308,18 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->sbs_mode = tmp_val;
 		break;
 
-	case FUEL_GAUGE_CHARGE_CURRENT:
+	case FUEL_GAUGE_CHARGE_CURRENT_UA:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_CHARGINGCURRENT, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* change mA to uA */
-		val->chg_current = (int16_t)tmp_val * 1000;
+		val->chg_current_ua = (int16_t)tmp_val * 1000;
 		break;
 
-	case FUEL_GAUGE_CHARGE_VOLTAGE:
+	case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_CHARGINGVOLTAGE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		/* change mV to uV */
-		val->chg_voltage = tmp_val * 1000;
+		val->chg_voltage_uv = tmp_val * 1000;
 		break;
 
 	case FUEL_GAUGE_STATUS:
@@ -335,10 +335,10 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->design_cap = tmp_val;
 		break;
 
-	case FUEL_GAUGE_DESIGN_VOLTAGE:
+	case FUEL_GAUGE_DESIGN_VOLTAGE_MV:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_DESIGNVOLTAGE, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->design_volt = tmp_val;
+		val->design_volt_mv = tmp_val;
 		break;
 
 	case FUEL_GAUGE_SBS_ATRATE:
@@ -347,16 +347,16 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->sbs_at_rate = (int16_t)tmp_val;
 		break;
 
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_ATRATETIMETOFULL, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->sbs_at_rate_time_to_full = tmp_val;
+		val->sbs_at_rate_time_to_full_mins = tmp_val;
 		break;
 
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_ATRATETIMETOEMPTY, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->sbs_at_rate_time_to_empty = tmp_val;
+		val->sbs_at_rate_time_to_empty_mins = tmp_val;
 		break;
 
 	case FUEL_GAUGE_SBS_ATRATE_OK:
@@ -371,10 +371,10 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->sbs_remaining_capacity_alarm = tmp_val;
 		break;
 
-	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
 		ret = bq40z50_i2c_read(dev, BQ40Z50_REMAININGTIMEALARM, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
-		val->sbs_remaining_time_alarm = tmp_val;
+		val->sbs_remaining_time_alarm_mins = tmp_val;
 		break;
 
 	case FUEL_GAUGE_STATE_OF_HEALTH:

--- a/drivers/fuel_gauge/composite/fuel_gauge_composite.c
+++ b/drivers/fuel_gauge/composite/fuel_gauge_composite.c
@@ -68,13 +68,13 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	int rc = 0;
 
 	/* Validate at build time that equivalent channel output fields still match */
-	BUILD_ASSERT(sizeof(val->absolute_state_of_charge) ==
-		     sizeof(val->relative_state_of_charge));
-	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, absolute_state_of_charge) ==
-		     offsetof(union fuel_gauge_prop_val, relative_state_of_charge));
-	BUILD_ASSERT(sizeof(val->current) == sizeof(val->avg_current));
-	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, current) ==
-		     offsetof(union fuel_gauge_prop_val, avg_current));
+	BUILD_ASSERT(sizeof(val->absolute_state_of_charge_pct) ==
+		     sizeof(val->relative_state_of_charge_pct));
+	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, absolute_state_of_charge_pct) ==
+		     offsetof(union fuel_gauge_prop_val, relative_state_of_charge_pct));
+	BUILD_ASSERT(sizeof(val->current_ua) == sizeof(val->avg_current_ua));
+	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, current_ua) ==
+		     offsetof(union fuel_gauge_prop_val, avg_current_ua));
 
 	if (now >= data->next_reading) {
 		/* Trigger a sample on the input devices */
@@ -91,13 +91,13 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	}
 
 	switch (prop) {
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 		rc = composite_channel_get(dev, SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY, &sensor_val);
 		if (rc == -ENOTSUP) {
 			if (config->charge_capacity_microamp_hours == 0) {
 				return -ENOTSUP;
 			}
-			val->full_charge_capacity = config->charge_capacity_microamp_hours;
+			val->full_charge_capacity_uah = config->charge_capacity_microamp_hours;
 			rc = 0;
 		}
 		break;
@@ -112,16 +112,16 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 			rc = 0;
 		}
 		break;
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		sensor_chan = config->fg_channels ? SENSOR_CHAN_GAUGE_VOLTAGE : SENSOR_CHAN_VOLTAGE;
 		rc = composite_channel_get(dev, sensor_chan, &sensor_val);
-		val->voltage = sensor_value_to_micro(&sensor_val);
+		val->voltage_uv = sensor_value_to_micro(&sensor_val);
 		break;
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		rc = composite_channel_get(dev, SENSOR_CHAN_GAUGE_STATE_OF_CHARGE, &sensor_val);
 		if (rc == 0) {
-			val->absolute_state_of_charge = sensor_val.val1;
+			val->absolute_state_of_charge_pct = sensor_val.val1;
 		} else if (rc == -ENOTSUP) {
 			if (config->ocv_lookup_table[0] == -1) {
 				return -ENOTSUP;
@@ -133,24 +133,24 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 			voltage = sensor_value_to_micro(&sensor_val);
 			if (rc == 0) {
 				/* Convert voltage to state of charge */
-				val->relative_state_of_charge =
+				val->relative_state_of_charge_pct =
 					battery_soc_lookup(config->ocv_lookup_table, voltage) /
 					1000;
 			}
 		}
 		break;
-	case FUEL_GAUGE_CURRENT:
-	case FUEL_GAUGE_AVG_CURRENT:
+	case FUEL_GAUGE_CURRENT_UA:
+	case FUEL_GAUGE_AVG_CURRENT_UA:
 		sensor_chan =
 			config->fg_channels ? SENSOR_CHAN_GAUGE_AVG_CURRENT : SENSOR_CHAN_CURRENT;
 		rc = composite_channel_get(dev, sensor_chan, &sensor_val);
-		val->current = sensor_value_to_micro(&sensor_val);
+		val->current_ua = sensor_value_to_micro(&sensor_val);
 		break;
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		sensor_chan = config->fg_channels ? SENSOR_CHAN_GAUGE_TEMP : SENSOR_CHAN_DIE_TEMP;
 		rc = composite_channel_get(dev, sensor_chan, &sensor_val);
 		/* Output unit = 0.1K (10x increase + 273.0) */
-		val->temperature = sensor_value_to_deci(&sensor_val) + 2730;
+		val->temperature_dk = sensor_value_to_deci(&sensor_val) + 2730;
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/fuel_gauge/hy4245/hy4245.c
+++ b/drivers/fuel_gauge/hy4245/hy4245.c
@@ -60,53 +60,53 @@ static int hy4245_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	uint16_t raw;
 
 	switch (prop) {
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		ret = hy4245_read16(dev, HY4245_CMD_TEMPERATURE, &raw);
-		val->temperature = raw;
+		val->temperature_dk = raw;
 		break;
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		ret = hy4245_read16(dev, HY4245_CMD_VOLTAGE, &raw);
-		val->voltage = raw * 1000;
+		val->voltage_uv = raw * 1000;
 		break;
-	case FUEL_GAUGE_CURRENT:
+	case FUEL_GAUGE_CURRENT_UA:
 		ret = hy4245_read16(dev, HY4245_CMD_CURRENT, &raw);
-		val->current = (int16_t)raw * 1000;
+		val->current_ua = (int16_t)raw * 1000;
 		break;
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
 		ret = hy4245_read16(dev, HY4245_CMD_CAPACITY_REM, &raw);
-		val->remaining_capacity = raw * 1000;
+		val->remaining_capacity_uah = raw * 1000;
 		break;
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 		ret = hy4245_read16(dev, HY4245_CMD_CAPACITY_FULL, &raw);
-		val->full_charge_capacity = raw * 1000;
+		val->full_charge_capacity_uah = raw * 1000;
 		break;
-	case FUEL_GAUGE_AVG_CURRENT:
+	case FUEL_GAUGE_AVG_CURRENT_UA:
 		ret = hy4245_read16(dev, HY4245_CMD_AVG_CURRENT, &raw);
-		val->avg_current = (int16_t)raw * 1000;
+		val->avg_current_ua = (int16_t)raw * 1000;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
 		ret = hy4245_read16(dev, HY4245_CMD_TIME_TO_EMPTY, &raw);
-		val->runtime_to_empty = raw;
+		val->runtime_to_empty_mins = raw;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_FULL:
+	case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
 		ret = hy4245_read16(dev, HY4245_CMD_TIME_TO_FULL, &raw);
-		val->runtime_to_full = raw;
+		val->runtime_to_full_mins = raw;
 		break;
-	case FUEL_GAUGE_CHARGE_VOLTAGE:
+	case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
 		ret = hy4245_read16(dev, HY4245_CMD_CHRG_VOLTAGE, &raw);
-		val->chg_voltage = raw * 1000;
+		val->chg_voltage_uv = raw * 1000;
 		break;
-	case FUEL_GAUGE_CHARGE_CURRENT:
+	case FUEL_GAUGE_CHARGE_CURRENT_UA:
 		ret = hy4245_read16(dev, HY4245_CMD_CHRG_CURRENT, &raw);
-		val->chg_current = raw * 1000;
+		val->chg_current_ua = raw * 1000;
 		break;
 	case FUEL_GAUGE_DESIGN_CAPACITY:
 		ret = hy4245_read16(dev, HY4245_CMD_CAPACITY_FULL_AVAIL, &raw);
 		val->design_cap = raw;
 		break;
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		ret = hy4245_read16(dev, HY4245_CMD_RELATIVE_STATE_OF_CHRG, &raw);
-		val->relative_state_of_charge = raw;
+		val->relative_state_of_charge_pct = raw;
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/drivers/fuel_gauge/lc709203f/lc709203f.c
+++ b/drivers/fuel_gauge/lc709203f/lc709203f.c
@@ -516,19 +516,19 @@ static int lc709203f_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	const struct lc709203f_config *config = dev->config;
 
 	switch (prop) {
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		rc = lc709203f_get_rsoc(dev, &val->relative_state_of_charge);
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
+		rc = lc709203f_get_rsoc(dev, &val->relative_state_of_charge_pct);
 		break;
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		if (!config->thermistor) {
 			LOG_ERR("Thermistor not enabled");
 			return -ENOTSUP;
 		}
-		rc = lc709203f_get_cell_temperature(dev, &val->temperature);
+		rc = lc709203f_get_cell_temperature(dev, &val->temperature_dk);
 		break;
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		rc = lc709203f_get_cell_voltage(dev, &tmp_val);
-		val->voltage = tmp_val * 1000;
+		val->voltage_uv = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
 		rc = lc709203f_get_power_mode(dev, (enum lc709203f_power_mode *)&val->sbs_mode);
@@ -567,12 +567,12 @@ static int lc709203f_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = lc709203f_get_current_direction(
 			dev, (enum lc709203f_current_direction *)&val->current_direction);
 		break;
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
-		rc = lc709203f_get_alarm_low_rsoc(dev, &val->state_of_charge_alarm);
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
+		rc = lc709203f_get_alarm_low_rsoc(dev, &val->state_of_charge_alarm_pct);
 		break;
-	case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
+	case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
 		rc = lc709203f_get_alarm_low_voltage(dev, &tmp_val);
-		val->low_voltage_alarm = tmp_val * 1000;
+		val->low_voltage_alarm_uv = tmp_val * 1000;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -595,11 +595,11 @@ static int lc709203f_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = lc709203f_set_current_direction(
 			dev, lc709203f_num_to_current_direction(val.current_direction));
 		break;
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
-		rc = lc709203f_set_alarm_low_rsoc(dev, val.state_of_charge_alarm);
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
+		rc = lc709203f_set_alarm_low_rsoc(dev, val.state_of_charge_alarm_pct);
 		break;
-	case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
-		rc = lc709203f_set_alarm_low_voltage(dev, val.low_voltage_alarm / 1000);
+	case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
+		rc = lc709203f_set_alarm_low_voltage(dev, val.low_voltage_alarm_uv / 1000);
 		break;
 	default:
 		rc = -ENOTSUP;

--- a/drivers/fuel_gauge/ltc2959/ltc2959.c
+++ b/drivers/fuel_gauge/ltc2959/ltc2959.c
@@ -478,7 +478,7 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 
 		break;
 	}
-	case FUEL_GAUGE_VOLTAGE: {
+	case FUEL_GAUGE_VOLTAGE_UV: {
 		uint16_t raw_voltage;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_VOLTAGE_MSB, &raw_voltage);
@@ -491,11 +491,11 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		 * Zephyr's API expects this value in microvolts
 		 * https://docs.zephyrproject.org/latest/doxygen/html/group__fuel__gauge__interface.html
 		 */
-		val->voltage = raw_voltage * LTC2959_VOLT_UV_SF;
+		val->voltage_uv = raw_voltage * LTC2959_VOLT_UV_SF;
 
 		return 0;
 	}
-	case FUEL_GAUGE_CURRENT: {
+	case FUEL_GAUGE_CURRENT_UA: {
 		uint16_t raw_current;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_CURRENT_MSB, &raw_current);
@@ -507,11 +507,11 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		/* Signed 16-bit value from ADC */
 		int16_t current_raw = (int16_t)raw_current;
 
-		val->current = current_raw * cfg->current_lsb_ua;
+		val->current_ua = current_raw * cfg->current_lsb_ua;
 
 		break;
 	}
-	case FUEL_GAUGE_TEMPERATURE: {
+	case FUEL_GAUGE_TEMPERATURE_DK: {
 		uint16_t raw_temp;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_TEMP_MSB, &raw_temp);
@@ -527,10 +527,10 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		 * T(dK) = 8250 * (raw / 65536)
 		 * 65536 = 2 ^ 16, so we can avoid division altogether.
 		 */
-		val->temperature = ((uint32_t)raw_temp * LTC2959_TEMP_K_SF) >> 16;
+		val->temperature_dk = ((uint32_t)raw_temp * LTC2959_TEMP_K_SF) >> 16;
 		break;
 	}
-	case FUEL_GAUGE_REMAINING_CAPACITY: {
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH: {
 		uint32_t acr;
 
 		ret = ltc2959_read_acr(dev, &acr);
@@ -539,47 +539,47 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 			return ret;
 		}
 
-		val->remaining_capacity = ltc2959_counts_to_uah(acr, cfg);
+		val->remaining_capacity_uah = ltc2959_counts_to_uah(acr, cfg);
 		break;
 	}
 	case FUEL_GAUGE_ADC_MODE:
 		ret = ltc2959_get_adc_mode(dev, &val->adc_mode);
 		break;
 
-	case FUEL_GAUGE_HIGH_VOLTAGE_ALARM:
-		ret = ltc2959_get_voltage_threshold_uv(dev, true, &val->high_voltage_alarm);
+	case FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV:
+		ret = ltc2959_get_voltage_threshold_uv(dev, true, &val->high_voltage_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
-		ret = ltc2959_get_voltage_threshold_uv(dev, false, &val->low_voltage_alarm);
+	case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
+		ret = ltc2959_get_voltage_threshold_uv(dev, false, &val->low_voltage_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_HIGH_CURRENT_ALARM:
-		ret = ltc2959_get_current_threshold_ua(dev, true, &val->high_current_alarm);
+	case FUEL_GAUGE_HIGH_CURRENT_ALARM_UA:
+		ret = ltc2959_get_current_threshold_ua(dev, true, &val->high_current_alarm_ua);
 		break;
 
-	case FUEL_GAUGE_LOW_CURRENT_ALARM:
-		ret = ltc2959_get_current_threshold_ua(dev, false, &val->low_current_alarm);
+	case FUEL_GAUGE_LOW_CURRENT_ALARM_UA:
+		ret = ltc2959_get_current_threshold_ua(dev, false, &val->low_current_alarm_ua);
 		break;
 
-	case FUEL_GAUGE_HIGH_TEMPERATURE_ALARM:
-		ret = ltc2959_get_temp_threshold_dK(dev, true, &val->high_temperature_alarm);
+	case FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK:
+		ret = ltc2959_get_temp_threshold_dK(dev, true, &val->high_temperature_alarm_dk);
 		break;
 
-	case FUEL_GAUGE_LOW_TEMPERATURE_ALARM:
-		ret = ltc2959_get_temp_threshold_dK(dev, false, &val->low_temperature_alarm);
+	case FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK:
+		ret = ltc2959_get_temp_threshold_dK(dev, false, &val->low_temperature_alarm_dk);
 		break;
 
-	case FUEL_GAUGE_GPIO_VOLTAGE:
-		ret = ltc2959_get_gpio_voltage_uv(dev, &val->gpio_voltage);
+	case FUEL_GAUGE_GPIO_VOLTAGE_UV:
+		ret = ltc2959_get_gpio_voltage_uv(dev, &val->gpio_voltage_uv);
 		break;
 
-	case FUEL_GAUGE_HIGH_GPIO_ALARM:
-		ret = ltc2959_get_gpio_threshold_uv(dev, true, &val->high_gpio_alarm);
+	case FUEL_GAUGE_HIGH_GPIO_ALARM_UV:
+		ret = ltc2959_get_gpio_threshold_uv(dev, true, &val->high_gpio_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_LOW_GPIO_ALARM:
-		ret = ltc2959_get_gpio_threshold_uv(dev, false, &val->low_gpio_alarm);
+	case FUEL_GAUGE_LOW_GPIO_ALARM_UV:
+		ret = ltc2959_get_gpio_threshold_uv(dev, false, &val->low_gpio_alarm_uv);
 		break;
 
 	case FUEL_GAUGE_CC_CONFIG:
@@ -603,36 +603,36 @@ static int ltc2959_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		ret = ltc2959_set_adc_mode(dev, val.adc_mode);
 		break;
 
-	case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
-		ret = ltc2959_set_voltage_threshold_uv(dev, false, val.low_voltage_alarm);
+	case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
+		ret = ltc2959_set_voltage_threshold_uv(dev, false, val.low_voltage_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_HIGH_VOLTAGE_ALARM:
-		ret = ltc2959_set_voltage_threshold_uv(dev, true, val.high_voltage_alarm);
+	case FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV:
+		ret = ltc2959_set_voltage_threshold_uv(dev, true, val.high_voltage_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_LOW_CURRENT_ALARM:
-		ret = ltc2959_set_current_threshold_ua(dev, false, val.low_current_alarm);
+	case FUEL_GAUGE_LOW_CURRENT_ALARM_UA:
+		ret = ltc2959_set_current_threshold_ua(dev, false, val.low_current_alarm_ua);
 		break;
 
-	case FUEL_GAUGE_HIGH_CURRENT_ALARM:
-		ret = ltc2959_set_current_threshold_ua(dev, true, val.high_current_alarm);
+	case FUEL_GAUGE_HIGH_CURRENT_ALARM_UA:
+		ret = ltc2959_set_current_threshold_ua(dev, true, val.high_current_alarm_ua);
 		break;
 
-	case FUEL_GAUGE_LOW_TEMPERATURE_ALARM:
-		ret = ltc2959_set_temp_threshold_dK(dev, false, val.low_temperature_alarm);
+	case FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK:
+		ret = ltc2959_set_temp_threshold_dK(dev, false, val.low_temperature_alarm_dk);
 		break;
 
-	case FUEL_GAUGE_HIGH_TEMPERATURE_ALARM:
-		ret = ltc2959_set_temp_threshold_dK(dev, true, val.high_temperature_alarm);
+	case FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK:
+		ret = ltc2959_set_temp_threshold_dK(dev, true, val.high_temperature_alarm_dk);
 		break;
 
-	case FUEL_GAUGE_LOW_GPIO_ALARM:
-		ret = ltc2959_set_gpio_threshold_uv(dev, false, val.low_gpio_alarm);
+	case FUEL_GAUGE_LOW_GPIO_ALARM_UV:
+		ret = ltc2959_set_gpio_threshold_uv(dev, false, val.low_gpio_alarm_uv);
 		break;
 
-	case FUEL_GAUGE_HIGH_GPIO_ALARM:
-		ret = ltc2959_set_gpio_threshold_uv(dev, true, val.high_gpio_alarm);
+	case FUEL_GAUGE_HIGH_GPIO_ALARM_UV:
+		ret = ltc2959_set_gpio_threshold_uv(dev, true, val.high_gpio_alarm_uv);
 		break;
 
 	case FUEL_GAUGE_CC_CONFIG:
@@ -640,8 +640,8 @@ static int ltc2959_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		ret = ltc2959_set_cc_config(dev, val.cc_config);
 		break;
 
-	case FUEL_GAUGE_REMAINING_CAPACITY: {
-		uint32_t counts = ltc2959_uah_to_counts(val.remaining_capacity, cfg);
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH: {
+		uint32_t counts = ltc2959_uah_to_counts(val.remaining_capacity_uah, cfg);
 
 		if (counts == LTC2959_ACR_CLR) {
 			counts = LTC2959_ACR_CLR - 1;

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -189,17 +189,17 @@ static int max17048_get_single_prop_impl(const struct device *dev, fuel_gauge_pr
 	int rc = 0;
 
 	switch (prop) {
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
-		val->runtime_to_empty = data->time_to_empty;
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
+		val->runtime_to_empty_mins = data->time_to_empty;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_FULL:
-		val->runtime_to_full = data->time_to_full;
+	case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
+		val->runtime_to_full_mins = data->time_to_full;
 		break;
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		val->relative_state_of_charge = data->charge;
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
+		val->relative_state_of_charge_pct = data->charge;
 		break;
-	case FUEL_GAUGE_VOLTAGE:
-		val->voltage = data->voltage;
+	case FUEL_GAUGE_VOLTAGE_UV:
+		val->voltage_uv = data->voltage;
 		break;
 	default:
 		rc = -ENOTSUP;

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -90,65 +90,65 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	uint16_t tmp_val = 0;
 
 	switch (prop) {
-	case FUEL_GAUGE_AVG_CURRENT:
+	case FUEL_GAUGE_AVG_CURRENT_UA:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_CURRENT, &tmp_val);
-		val->avg_current = tmp_val * 1000;
+		val->avg_current_ua = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CYCLE_COUNT, &tmp_val);
 		val->cycle_count = tmp_val;
 		break;
-	case FUEL_GAUGE_CURRENT:
+	case FUEL_GAUGE_CURRENT_UA:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CURRENT, &tmp_val);
-		val->current = (int16_t)tmp_val * 1000;
+		val->current_ua = (int16_t)tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FULL_CAPACITY, &tmp_val);
-		val->full_charge_capacity = tmp_val * 1000;
+		val->full_charge_capacity_uah = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY, &tmp_val);
-		val->remaining_capacity = tmp_val * 1000;
+		val->remaining_capacity_uah = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RUNTIME2EMPTY, &tmp_val);
-		val->runtime_to_empty = tmp_val;
+		val->runtime_to_empty_mins = tmp_val;
 		break;
-	case FUEL_GAUGE_RUNTIME_TO_FULL:
+	case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_TIME2FULL, &tmp_val);
-		val->runtime_to_full = tmp_val;
+		val->runtime_to_full_mins = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &tmp_val);
 		val->sbs_mfr_access_word = tmp_val;
 		break;
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &tmp_val);
-		val->absolute_state_of_charge = tmp_val;
+		val->absolute_state_of_charge_pct = tmp_val;
 		break;
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RSOC, &tmp_val);
-		val->relative_state_of_charge = tmp_val;
+		val->relative_state_of_charge_pct = tmp_val;
 		break;
-	case FUEL_GAUGE_TEMPERATURE:
+	case FUEL_GAUGE_TEMPERATURE_DK:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_TEMP, &tmp_val);
-		val->temperature = tmp_val;
+		val->temperature_dk = tmp_val;
 		break;
-	case FUEL_GAUGE_VOLTAGE:
+	case FUEL_GAUGE_VOLTAGE_UV:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_VOLTAGE, &tmp_val);
-		val->voltage = tmp_val * 1000;
+		val->voltage_uv = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_BATTERY_MODE, &tmp_val);
 		val->sbs_mode = tmp_val;
 		break;
-	case FUEL_GAUGE_CHARGE_CURRENT:
+	case FUEL_GAUGE_CHARGE_CURRENT_UA:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &tmp_val);
-		val->chg_current = tmp_val * 1000;
+		val->chg_current_ua = tmp_val * 1000;
 		break;
-	case FUEL_GAUGE_CHARGE_VOLTAGE:
+	case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_VOLTAGE, &tmp_val);
-		val->chg_voltage = tmp_val * 1000;
+		val->chg_voltage_uv = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_STATUS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FLAGS, &tmp_val);
@@ -158,21 +158,21 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_NOM_CAPACITY, &tmp_val);
 		val->design_cap = tmp_val;
 		break;
-	case FUEL_GAUGE_DESIGN_VOLTAGE:
+	case FUEL_GAUGE_DESIGN_VOLTAGE_MV:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_DESIGN_VOLTAGE, &tmp_val);
-		val->design_volt = tmp_val;
+		val->design_volt_mv = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &tmp_val);
 		val->sbs_at_rate = tmp_val;
 		break;
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &tmp_val);
-		val->sbs_at_rate_time_to_full = tmp_val;
+		val->sbs_at_rate_time_to_full_mins = tmp_val;
 		break;
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &tmp_val);
-		val->sbs_at_rate_time_to_empty = tmp_val;
+		val->sbs_at_rate_time_to_empty_mins = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_OK:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &tmp_val);
@@ -182,9 +182,9 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM, &tmp_val);
 		val->sbs_remaining_capacity_alarm = tmp_val;
 		break;
-	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_TIME_ALARM, &tmp_val);
-		val->sbs_remaining_time_alarm = tmp_val;
+		val->sbs_remaining_time_alarm_mins = tmp_val;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -227,9 +227,9 @@ static int sbs_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM,
 				       val.sbs_remaining_capacity_alarm);
 		break;
-	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_TIME_ALARM,
-				       val.sbs_remaining_time_alarm);
+				       val.sbs_remaining_time_alarm_mins);
 		break;
 	case FUEL_GAUGE_SBS_MODE:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, val.sbs_mode);

--- a/drivers/fuel_gauge/sy24561/sy24561.c
+++ b/drivers/fuel_gauge/sy24561/sy24561.c
@@ -281,10 +281,10 @@ int sy24561_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		     union fuel_gauge_prop_val *val)
 {
 	switch (prop) {
-	case FUEL_GAUGE_VOLTAGE:
-		return sy24561_get_voltage(dev, &val->voltage);
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		return sy24561_get_soc(dev, &val->relative_state_of_charge);
+	case FUEL_GAUGE_VOLTAGE_UV:
+		return sy24561_get_voltage(dev, &val->voltage_uv);
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
+		return sy24561_get_soc(dev, &val->relative_state_of_charge_pct);
 	case FUEL_GAUGE_STATUS:
 		return sy24561_get_status(dev, &val->fg_status);
 	case FUEL_GAUGE_CURRENT_DIRECTION:
@@ -302,10 +302,10 @@ static int sy24561_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	int ret = 0;
 
 	switch (prop) {
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
-		return sy24561_set_alarm_threshold(dev, val.state_of_charge_alarm);
-	case FUEL_GAUGE_TEMPERATURE:
-		return sy24561_set_temperature(dev, val.temperature);
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
+		return sy24561_set_alarm_threshold(dev, val.state_of_charge_alarm_pct);
+	case FUEL_GAUGE_TEMPERATURE_DK:
+		return sy24561_set_temperature(dev, val.temperature_dk);
 	case FUEL_GAUGE_STATUS:
 		return sy24561_set_status(dev, val.fg_status);
 	default:

--- a/dts/bindings/fuel-gauge/sbs,default-sbs-gauge.yaml
+++ b/dts/bindings/fuel-gauge/sbs,default-sbs-gauge.yaml
@@ -16,7 +16,7 @@ description: |
 
 properties:
   battery-cutoff-reg-addr:
-    # For SBS compliant fuel gauges this is usually "ManufactuerAccess"
+    # For SBS compliant fuel gauges this is usually "ManufacturerAccess"
     default: 0x0
   battery-cutoff-payload:
     default: [0x0010, 0x0010]

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -21,7 +21,7 @@
  * @brief Interfaces for fuel gauges.
  * @defgroup fuel_gauge_interface Fuel Gauge
  * @since 3.3
- * @version 0.8.0
+ * @version 0.9.0
  * @ingroup io_interfaces
  * @{
  */
@@ -45,10 +45,14 @@ enum fuel_gauge_prop_type {
 	 * See driver instance header for details on implementation and
 	 * how the average is calculated. Units in uA negative=discharging
 	 */
-	FUEL_GAUGE_AVG_CURRENT = 0,
+	FUEL_GAUGE_AVG_CURRENT_UA = 0,
+	/** @deprecated Use FUEL_GAUGE_AVG_CURRENT_UA instead. */
+	FUEL_GAUGE_AVG_CURRENT __deprecated = FUEL_GAUGE_AVG_CURRENT_UA,
 
 	/** Battery current (uA); negative=discharging */
-	FUEL_GAUGE_CURRENT,
+	FUEL_GAUGE_CURRENT_UA,
+	/** @deprecated Use FUEL_GAUGE_CURRENT_UA instead. */
+	FUEL_GAUGE_CURRENT __deprecated = FUEL_GAUGE_CURRENT_UA,
 	/** Whether the battery underlying the fuel-gauge is cut off from charge */
 	FUEL_GAUGE_CHARGE_CUTOFF,
 	/** Cycle count in 1/100ths (number of charge/discharge cycles) */
@@ -58,49 +62,77 @@ enum fuel_gauge_prop_type {
 	/** General Error/Runtime Flags */
 	FUEL_GAUGE_FLAGS,
 	/** Full Charge Capacity in uAh (might change in some implementations to determine wear) */
-	FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+	FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
+	/** @deprecated Use FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH instead. */
+	FUEL_GAUGE_FULL_CHARGE_CAPACITY __deprecated = FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
 	/** Is the battery physically present */
 	FUEL_GAUGE_PRESENT_STATE,
 	/** Remaining capacity in uAh */
-	FUEL_GAUGE_REMAINING_CAPACITY,
+	FUEL_GAUGE_REMAINING_CAPACITY_UAH,
+	/** @deprecated Use FUEL_GAUGE_REMAINING_CAPACITY_UAH instead. */
+	FUEL_GAUGE_REMAINING_CAPACITY __deprecated = FUEL_GAUGE_REMAINING_CAPACITY_UAH,
 	/** Remaining battery life time in minutes */
-	FUEL_GAUGE_RUNTIME_TO_EMPTY,
+	FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+	/** @deprecated Use FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS instead. */
+	FUEL_GAUGE_RUNTIME_TO_EMPTY __deprecated = FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
 	/** Remaining time in minutes until battery reaches full charge */
-	FUEL_GAUGE_RUNTIME_TO_FULL,
-	/** Retrieve word from SBS1.1 ManufactuerAccess */
+	FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
+	/** @deprecated Use FUEL_GAUGE_RUNTIME_TO_FULL_MINS instead. */
+	FUEL_GAUGE_RUNTIME_TO_FULL __deprecated = FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
+	/** Retrieve word from SBS1.1 ManufacturerAccess */
 	FUEL_GAUGE_SBS_MFR_ACCESS,
 	/** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
-	FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
+	FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT,
+	/** @deprecated Use FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT instead. */
+	FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE __deprecated = FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT,
 	/** Relative state of charge (percent, 0-100) - expressed as % of full charge capacity */
-	FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+	FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+	/** @deprecated Use FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT instead. */
+	FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE __deprecated = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
 	/** Temperature in 0.1 K */
-	FUEL_GAUGE_TEMPERATURE,
+	FUEL_GAUGE_TEMPERATURE_DK,
+	/** @deprecated Use FUEL_GAUGE_TEMPERATURE_DK instead. */
+	FUEL_GAUGE_TEMPERATURE __deprecated = FUEL_GAUGE_TEMPERATURE_DK,
 	/** Battery voltage (uV) */
-	FUEL_GAUGE_VOLTAGE,
+	FUEL_GAUGE_VOLTAGE_UV,
+	/** @deprecated Use FUEL_GAUGE_VOLTAGE_UV instead. */
+	FUEL_GAUGE_VOLTAGE __deprecated = FUEL_GAUGE_VOLTAGE_UV,
 	/** Battery Mode (flags) */
 	FUEL_GAUGE_SBS_MODE,
 	/** Battery desired Max Charging Current (uA) */
-	FUEL_GAUGE_CHARGE_CURRENT,
+	FUEL_GAUGE_CHARGE_CURRENT_UA,
+	/** @deprecated Use FUEL_GAUGE_CHARGE_CURRENT_UA instead. */
+	FUEL_GAUGE_CHARGE_CURRENT __deprecated = FUEL_GAUGE_CHARGE_CURRENT_UA,
 	/** Battery desired Max Charging Voltage (uV) */
-	FUEL_GAUGE_CHARGE_VOLTAGE,
+	FUEL_GAUGE_CHARGE_VOLTAGE_UV,
+	/** @deprecated Use FUEL_GAUGE_CHARGE_VOLTAGE_UV instead. */
+	FUEL_GAUGE_CHARGE_VOLTAGE __deprecated = FUEL_GAUGE_CHARGE_VOLTAGE_UV,
 	/** Alarm, Status and Error codes (flags) */
 	FUEL_GAUGE_STATUS,
 	/** Design Capacity (mAh or 10mWh) */
 	FUEL_GAUGE_DESIGN_CAPACITY,
 	/** Design Voltage (mV) */
-	FUEL_GAUGE_DESIGN_VOLTAGE,
+	FUEL_GAUGE_DESIGN_VOLTAGE_MV,
+	/** @deprecated Use FUEL_GAUGE_DESIGN_VOLTAGE_MV instead. */
+	FUEL_GAUGE_DESIGN_VOLTAGE __deprecated = FUEL_GAUGE_DESIGN_VOLTAGE_MV,
 	/** AtRate (mA or 10 mW) */
 	FUEL_GAUGE_SBS_ATRATE,
 	/** AtRateTimeToFull (minutes) */
-	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS,
+	/** @deprecated Use FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS instead. */
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL __deprecated = FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS,
 	/** AtRateTimeToEmpty (minutes) */
-	FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
+	/** @deprecated Use FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS instead. */
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY __deprecated = FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
 	/** AtRateOK (boolean) */
 	FUEL_GAUGE_SBS_ATRATE_OK,
 	/** Remaining Capacity Alarm (mAh or 10mWh) */
 	FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
 	/** Remaining Time Alarm (minutes) */
-	FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+	FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
+	/** @deprecated Use FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS instead. */
+	FUEL_GAUGE_SBS_REMAINING_TIME_ALARM __deprecated = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 	/** Manufacturer of pack (1 byte length + 20 bytes data) */
 	FUEL_GAUGE_MANUFACTURER_NAME,
 	/** Name of pack (1 byte length + 20 bytes data) */
@@ -110,25 +142,45 @@ enum fuel_gauge_prop_type {
 	/** Battery current direction (flags)*/
 	FUEL_GAUGE_CURRENT_DIRECTION,
 	/** Remaining state of charge alarm (percent, 0-100) */
-	FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
-	/** Low Cell Voltage Alarm (uV)*/
-	FUEL_GAUGE_LOW_VOLTAGE_ALARM,
-	/** High Cell Voltage Alarm (uV)*/
-	FUEL_GAUGE_HIGH_VOLTAGE_ALARM,
-	/** Low Cell Current Alarm (uA)*/
-	FUEL_GAUGE_LOW_CURRENT_ALARM,
-	/** High Cell Current Alarm (uA)*/
-	FUEL_GAUGE_HIGH_CURRENT_ALARM,
-	/** Low Cell Temperature Alarm (dK)*/
-	FUEL_GAUGE_LOW_TEMPERATURE_ALARM,
-	/** High Cell Temperature Alarm (dK)*/
-	FUEL_GAUGE_HIGH_TEMPERATURE_ALARM,
-	/** Low GPIO Voltage Alarm (uV)*/
-	FUEL_GAUGE_LOW_GPIO_ALARM,
-	/** High GPIO Voltage Alarm (uV)*/
-	FUEL_GAUGE_HIGH_GPIO_ALARM,
-	/** GPIO Voltage (uV)*/
-	FUEL_GAUGE_GPIO_VOLTAGE,
+	FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
+	/** @deprecated Use FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT instead. */
+	FUEL_GAUGE_STATE_OF_CHARGE_ALARM __deprecated = FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
+	/** Low Cell Voltage Alarm (uV) */
+	FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
+	/** @deprecated Use FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV instead. */
+	FUEL_GAUGE_LOW_VOLTAGE_ALARM __deprecated = FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
+	/** High Cell Voltage Alarm (uV) */
+	FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV,
+	/** @deprecated Use FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV instead. */
+	FUEL_GAUGE_HIGH_VOLTAGE_ALARM __deprecated = FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV,
+	/** Low Cell Current Alarm (uA) */
+	FUEL_GAUGE_LOW_CURRENT_ALARM_UA,
+	/** @deprecated Use FUEL_GAUGE_LOW_CURRENT_ALARM_UA instead. */
+	FUEL_GAUGE_LOW_CURRENT_ALARM __deprecated = FUEL_GAUGE_LOW_CURRENT_ALARM_UA,
+	/** High Cell Current Alarm (uA) */
+	FUEL_GAUGE_HIGH_CURRENT_ALARM_UA,
+	/** @deprecated Use FUEL_GAUGE_HIGH_CURRENT_ALARM_UA instead. */
+	FUEL_GAUGE_HIGH_CURRENT_ALARM __deprecated = FUEL_GAUGE_HIGH_CURRENT_ALARM_UA,
+	/** Low Cell Temperature Alarm (dK) */
+	FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK,
+	/** @deprecated Use FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK instead. */
+	FUEL_GAUGE_LOW_TEMPERATURE_ALARM __deprecated = FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK,
+	/** High Cell Temperature Alarm (dK) */
+	FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK,
+	/** @deprecated Use FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK instead. */
+	FUEL_GAUGE_HIGH_TEMPERATURE_ALARM __deprecated = FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK,
+	/** Low GPIO Voltage Alarm (uV) */
+	FUEL_GAUGE_LOW_GPIO_ALARM_UV,
+	/** @deprecated Use FUEL_GAUGE_LOW_GPIO_ALARM_UV instead. */
+	FUEL_GAUGE_LOW_GPIO_ALARM __deprecated = FUEL_GAUGE_LOW_GPIO_ALARM_UV,
+	/** High GPIO Voltage Alarm (uV) */
+	FUEL_GAUGE_HIGH_GPIO_ALARM_UV,
+	/** @deprecated Use FUEL_GAUGE_HIGH_GPIO_ALARM_UV instead. */
+	FUEL_GAUGE_HIGH_GPIO_ALARM __deprecated = FUEL_GAUGE_HIGH_GPIO_ALARM_UV,
+	/** GPIO Voltage (uV) */
+	FUEL_GAUGE_GPIO_VOLTAGE_UV,
+	/** @deprecated Use FUEL_GAUGE_GPIO_VOLTAGE_UV instead. */
+	FUEL_GAUGE_GPIO_VOLTAGE __deprecated = FUEL_GAUGE_GPIO_VOLTAGE_UV,
 	/** ADC Mode (flags) */
 	FUEL_GAUGE_ADC_MODE,
 	/** Coulomb Counter Config (flags)*/
@@ -159,84 +211,214 @@ union fuel_gauge_prop_val {
 	/* type property_field; */
 
 	/* Dynamic Battery Info */
-	/** FUEL_GAUGE_AVG_CURRENT */
-	int avg_current;
+	/**
+	 * FUEL_GAUGE_AVG_CURRENT
+	 * @deprecated Use @ref fuel_gauge_prop_val.avg_current_ua instead
+	 */
+	__deprecated int avg_current;
+	/** FUEL_GAUGE_AVG_CURRENT_UA */
+	int32_t avg_current_ua;
 	/** FUEL_GAUGE_CHARGE_CUTOFF */
 	bool cutoff;
-	/** FUEL_GAUGE_CURRENT */
-	int current;
+	/**
+	 * FUEL_GAUGE_CURRENT
+	 * @deprecated Use @ref fuel_gauge_prop_val.current_ua instead
+	 */
+	__deprecated int current;
+	/** FUEL_GAUGE_CURRENT_UA */
+	int32_t current_ua;
 	/** FUEL_GAUGE_CYCLE_COUNT */
 	uint32_t cycle_count;
 	/** FUEL_GAUGE_CONNECT_STATE */
 	uint32_t connect_state;
 	/** FUEL_GAUGE_FLAGS */
 	uint32_t flags;
-	/** FUEL_GAUGE_FULL_CHARGE_CAPACITY */
-	uint32_t full_charge_capacity;
+	/**
+	 * FUEL_GAUGE_FULL_CHARGE_CAPACITY
+	 * @deprecated Use @ref fuel_gauge_prop_val.full_charge_capacity_uah instead
+	 */
+	__deprecated uint32_t full_charge_capacity;
+	/** FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH */
+	uint32_t full_charge_capacity_uah;
 	/** FUEL_GAUGE_PRESENT_STATE */
 	bool present_state;
-	/** FUEL_GAUGE_REMAINING_CAPACITY */
-	uint32_t remaining_capacity;
-	/** FUEL_GAUGE_RUNTIME_TO_EMPTY */
-	uint32_t runtime_to_empty;
-	/** FUEL_GAUGE_RUNTIME_TO_FULL */
-	uint32_t runtime_to_full;
+	/**
+	 * FUEL_GAUGE_REMAINING_CAPACITY
+	 * @deprecated Use @ref fuel_gauge_prop_val.remaining_capacity_uah instead
+	 */
+	__deprecated uint32_t remaining_capacity;
+	/** FUEL_GAUGE_REMAINING_CAPACITY_UAH */
+	uint32_t remaining_capacity_uah;
+	/**
+	 * FUEL_GAUGE_RUNTIME_TO_EMPTY
+	 * @deprecated Use @ref fuel_gauge_prop_val.runtime_to_empty_mins instead
+	 */
+	__deprecated uint32_t runtime_to_empty;
+	/** FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS */
+	uint32_t runtime_to_empty_mins;
+	/**
+	 * FUEL_GAUGE_RUNTIME_TO_FULL
+	 * @deprecated Use @ref fuel_gauge_prop_val.runtime_to_full_mins instead
+	 */
+	__deprecated uint32_t runtime_to_full;
+	/** FUEL_GAUGE_RUNTIME_TO_FULL_MINS */
+	uint32_t runtime_to_full_mins;
 	/** FUEL_GAUGE_SBS_MFR_ACCESS */
 	uint16_t sbs_mfr_access_word;
-	/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE */
-	uint8_t absolute_state_of_charge;
-	/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE */
-	uint8_t relative_state_of_charge;
-	/** FUEL_GAUGE_TEMPERATURE */
-	uint16_t temperature;
-	/** FUEL_GAUGE_VOLTAGE */
-	int voltage;
+	/**
+	 * FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.absolute_state_of_charge_pct instead
+	 */
+	__deprecated uint8_t absolute_state_of_charge;
+	/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT */
+	uint8_t absolute_state_of_charge_pct;
+	/**
+	 * FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.relative_state_of_charge_pct instead
+	 */
+	__deprecated uint8_t relative_state_of_charge;
+	/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT */
+	uint8_t relative_state_of_charge_pct;
+	/**
+	 * FUEL_GAUGE_TEMPERATURE
+	 * @deprecated Use @ref fuel_gauge_prop_val.temperature_dk instead
+	 */
+	__deprecated uint16_t temperature;
+	/** FUEL_GAUGE_TEMPERATURE_DK */
+	uint16_t temperature_dk;
+	/**
+	 * FUEL_GAUGE_VOLTAGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.voltage_uv instead
+	 */
+	__deprecated int voltage;
+	/** FUEL_GAUGE_VOLTAGE_UV */
+	int32_t voltage_uv;
 	/** FUEL_GAUGE_SBS_MODE */
 	uint16_t sbs_mode;
-	/** FUEL_GAUGE_CHARGE_CURRENT */
-	uint32_t chg_current;
-	/** FUEL_GAUGE_CHARGE_VOLTAGE */
-	uint32_t chg_voltage;
+	/**
+	 * FUEL_GAUGE_CHARGE_CURRENT
+	 * @deprecated Use @ref fuel_gauge_prop_val.chg_current_ua instead
+	 */
+	__deprecated uint32_t chg_current;
+	/** FUEL_GAUGE_CHARGE_CURRENT_UA */
+	uint32_t chg_current_ua;
+	/**
+	 * FUEL_GAUGE_CHARGE_VOLTAGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.chg_voltage_uv instead
+	 */
+	__deprecated uint32_t chg_voltage;
+	/** FUEL_GAUGE_CHARGE_VOLTAGE_UV */
+	uint32_t chg_voltage_uv;
 	/** FUEL_GAUGE_STATUS */
 	uint16_t fg_status;
 	/** FUEL_GAUGE_DESIGN_CAPACITY */
 	uint16_t design_cap;
-	/** FUEL_GAUGE_DESIGN_VOLTAGE */
-	uint16_t design_volt;
+	/**
+	 * FUEL_GAUGE_DESIGN_VOLTAGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.design_volt_mv instead
+	 */
+	__deprecated uint16_t design_volt;
+	/** FUEL_GAUGE_DESIGN_VOLTAGE_MV */
+	uint16_t design_volt_mv;
 	/** FUEL_GAUGE_SBS_ATRATE */
 	int16_t sbs_at_rate;
-	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL */
-	uint16_t sbs_at_rate_time_to_full;
-	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	*/
-	uint16_t sbs_at_rate_time_to_empty;
+	/**
+	 * FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL
+	 * @deprecated Use @ref fuel_gauge_prop_val.sbs_at_rate_time_to_full_mins instead
+	 */
+	__deprecated uint16_t sbs_at_rate_time_to_full;
+	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS */
+	uint16_t sbs_at_rate_time_to_full_mins;
+	/**
+	 * FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY
+	 * @deprecated Use @ref fuel_gauge_prop_val.sbs_at_rate_time_to_empty_mins instead
+	 */
+	__deprecated uint16_t sbs_at_rate_time_to_empty;
+	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS */
+	uint16_t sbs_at_rate_time_to_empty_mins;
 	/** FUEL_GAUGE_SBS_ATRATE_OK */
 	bool sbs_at_rate_ok;
 	/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
 	uint16_t sbs_remaining_capacity_alarm;
-	/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
-	uint16_t sbs_remaining_time_alarm;
+	/**
+	 * FUEL_GAUGE_SBS_REMAINING_TIME_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.sbs_remaining_time_alarm_mins instead
+	 */
+	__deprecated uint16_t sbs_remaining_time_alarm;
+	/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS */
+	uint16_t sbs_remaining_time_alarm_mins;
 	/** FUEL_GAUGE_CURRENT_DIRECTION */
 	uint16_t current_direction;
-	/** FUEL_GAUGE_STATE_OF_CHARGE_ALARM */
-	uint8_t state_of_charge_alarm;
-	/** FUEL_GAUGE_LOW_VOLTAGE_ALARM */
-	uint32_t low_voltage_alarm;
-	/** FUEL_GAUGE_HIGH_VOLTAGE_ALARM */
-	uint32_t high_voltage_alarm;
-	/** FUEL_GAUGE_LOW_CURRENT_ALARM */
-	int32_t low_current_alarm;
-	/** FUEL_GAUGE_HIGH_CURRENT_ALARM */
-	int32_t high_current_alarm;
-	/** FUEL_GAUGE_LOW_TEMPERATURE_ALARM */
-	uint16_t low_temperature_alarm;
-	/** FUEL_GAUGE_HIGH_TEMPERATURE_ALARM */
-	uint16_t high_temperature_alarm;
-	/** FUEL_GAUGE_GPIO_VOLTAGE*/
-	int32_t gpio_voltage;
-	/** FUEL_GAUGE_LOW_GPIO_ALARM */
-	int32_t low_gpio_alarm;
-	/** FUEL_GAUGE_HIGH_GPIO_ALARM */
-	int32_t high_gpio_alarm;
+	/**
+	 * FUEL_GAUGE_STATE_OF_CHARGE_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.state_of_charge_alarm_pct instead
+	 */
+	__deprecated uint8_t state_of_charge_alarm;
+	/** FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT */
+	uint8_t state_of_charge_alarm_pct;
+	/**
+	 * FUEL_GAUGE_LOW_VOLTAGE_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.low_voltage_alarm_uv instead
+	 */
+	__deprecated uint32_t low_voltage_alarm;
+	/** FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV */
+	uint32_t low_voltage_alarm_uv;
+	/**
+	 * FUEL_GAUGE_HIGH_VOLTAGE_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.high_voltage_alarm_uv instead
+	 */
+	__deprecated uint32_t high_voltage_alarm;
+	/** FUEL_GAUGE_HIGH_VOLTAGE_ALARM_UV */
+	uint32_t high_voltage_alarm_uv;
+	/**
+	 * FUEL_GAUGE_LOW_CURRENT_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.low_current_alarm_ua instead
+	 */
+	__deprecated int32_t low_current_alarm;
+	/** FUEL_GAUGE_LOW_CURRENT_ALARM_UA */
+	int32_t low_current_alarm_ua;
+	/**
+	 * FUEL_GAUGE_HIGH_CURRENT_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.high_current_alarm_ua instead
+	 */
+	__deprecated int32_t high_current_alarm;
+	/** FUEL_GAUGE_HIGH_CURRENT_ALARM_UA */
+	int32_t high_current_alarm_ua;
+	/**
+	 * FUEL_GAUGE_LOW_TEMPERATURE_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.low_temperature_alarm_dk instead
+	 */
+	__deprecated uint16_t low_temperature_alarm;
+	/** FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK */
+	uint16_t low_temperature_alarm_dk;
+	/**
+	 * FUEL_GAUGE_HIGH_TEMPERATURE_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.high_temperature_alarm_dk instead
+	 */
+	__deprecated uint16_t high_temperature_alarm;
+	/** FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK */
+	uint16_t high_temperature_alarm_dk;
+	/**
+	 * FUEL_GAUGE_GPIO_VOLTAGE
+	 * @deprecated Use @ref fuel_gauge_prop_val.gpio_voltage_uv instead
+	 */
+	__deprecated int32_t gpio_voltage;
+	/** FUEL_GAUGE_GPIO_VOLTAGE_UV*/
+	int32_t gpio_voltage_uv;
+	/**
+	 * FUEL_GAUGE_LOW_GPIO_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.low_gpio_alarm_uv instead
+	 */
+	__deprecated int32_t low_gpio_alarm;
+	/** FUEL_GAUGE_LOW_GPIO_ALARM_UV */
+	int32_t low_gpio_alarm_uv;
+	/**
+	 * FUEL_GAUGE_HIGH_GPIO_ALARM
+	 * @deprecated Use @ref fuel_gauge_prop_val.high_gpio_alarm_uv instead
+	 */
+	__deprecated int32_t high_gpio_alarm;
+	/** FUEL_GAUGE_HIGH_GPIO_ALARM_UV */
+	int32_t high_gpio_alarm_uv;
 	/** FUEL_GAUGE_ADC_MODE */
 	uint8_t adc_mode;
 	/** FUEL_GAUGE_CC_CONFIG */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -14,8 +14,8 @@
  * @brief Main header file for fuel gauge driver API.
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
-#define ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_H_
 
 /**
  * @brief Interfaces for fuel gauges.
@@ -604,7 +604,7 @@ static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gaug
  * the fuel gauge device. The vals array is not permuted.
  * @param len number of properties in props array
  *
- * @return return=0 if successful. Otherwise, return array index of failing property.
+ * @return 0 if successful, negative errno code of first failing property.
  */
 __syscall int fuel_gauge_set_props(const struct device *dev, const fuel_gauge_prop_t *props,
 				   const union fuel_gauge_prop_val *vals, size_t len);
@@ -682,4 +682,4 @@ static inline int z_impl_fuel_gauge_battery_cutoff(const struct device *dev)
 
 #include <zephyr/syscalls/fuel_gauge.h>
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_H_ */

--- a/samples/drivers/fuel_gauge/README.rst
+++ b/samples/drivers/fuel_gauge/README.rst
@@ -11,7 +11,7 @@ This sample shows how to use the Zephyr :ref:`fuel_gauge_api` API driver for.
 First, the sample tries to read all public fuel gauge properties to verify which are supported by
 the used fuel gauge driver.
 Second, the sample then reads the battery percentage and voltage proper periodically using the
-``FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE`` and ``FUEL_GAUGE_VOLTAGE`` properties.
+``FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT`` and ``FUEL_GAUGE_VOLTAGE_UV`` properties.
 
 .. note::
    The sample does not set/write any properties to avoid misconfiguration the IC.
@@ -38,49 +38,49 @@ Sample output
    [00:00:00.116,000] <inf> app: Found device "lc709203f@0b"
    [00:00:00.116,000] <inf> app: Test-Read generic fuel gauge properties to verify which are supported
    [00:00:00.116,000] <inf> app: Info: not all properties are supported by all fuel gauges!
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_AVG_CURRENT" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_CURRENT" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_AVG_CURRENT_UA" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_CURRENT_UA" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_CHARGE_CUTOFF" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_CYCLE_COUNT" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_CONNECT_STATE" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_FLAGS" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_FULL_CHARGE_CAPACITY" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_PRESENT_STATE" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_REMAINING_CAPACITY" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_RUNTIME_TO_EMPTY" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_RUNTIME_TO_FULL" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_REMAINING_CAPACITY_UAH" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS" is not supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_RUNTIME_TO_FULL_MINS" is not supported
    [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_SBS_MFR_ACCESS" is not supported
-   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE" is not supported
-   [00:00:00.122,000] <inf> app: Property "FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE" is supported
+   [00:00:00.116,000] <inf> app: Property "FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT" is not supported
+   [00:00:00.122,000] <inf> app: Property "FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT" is supported
    [00:00:00.122,000] <inf> app:   Relative state of charge: 100
    [00:00:00.122,000] <err> lc709203f: Thermistor not enabled
-   [00:00:00.122,000] <inf> app: Property "FUEL_GAUGE_TEMPERATURE" is not supported
-   [00:00:00.123,000] <inf> app: Property "FUEL_GAUGE_VOLTAGE" is supported
+   [00:00:00.122,000] <inf> app: Property "FUEL_GAUGE_TEMPERATURE_DK" is not supported
+   [00:00:00.123,000] <inf> app: Property "FUEL_GAUGE_VOLTAGE_UV" is supported
    [00:00:00.123,000] <inf> app:   Voltage: 4190000
    [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_MODE" is supported
    [00:00:00.124,000] <inf> app:   SBS mode: 1
-   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_CHARGE_CURRENT" is not supported
-   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_CHARGE_VOLTAGE" is not supported
+   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_CHARGE_CURRENT_UA" is not supported
+   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_CHARGE_VOLTAGE_UV" is not supported
    [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_STATUS" is not supported
    [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_DESIGN_CAPACITY" is supported
    [00:00:00.124,000] <inf> app:   Design capacity: 500
-   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_DESIGN_VOLTAGE" is not supported
+   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_DESIGN_VOLTAGE_MV" is not supported
    [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE" is not supported
-   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL" is not supported
-   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY" is not supported
+   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS" is not supported
+   [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS" is not supported
    [00:00:00.124,000] <inf> app: Property "FUEL_GAUGE_SBS_ATRATE_OK" is not supported
    [00:00:00.125,000] <inf> app: Property "FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM" is not supported
-   [00:00:00.125,000] <inf> app: Property "FUEL_GAUGE_SBS_REMAINING_TIME_ALARM" is not supported
+   [00:00:00.125,000] <inf> app: Property "FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS" is not supported
    [00:00:00.125,000] <err> app: Error: cannot get property "FUEL_GAUGE_MANUFACTURER_NAME": -88
    [00:00:00.125,000] <err> app: Error: cannot get property "FUEL_GAUGE_DEVICE_NAME": -88
    [00:00:00.125,000] <err> app: Error: cannot get property "FUEL_GAUGE_DEVICE_CHEMISTRY": -88
    [00:00:00.125,000] <inf> app: Property "FUEL_GAUGE_CURRENT_DIRECTION" is supported
    [00:00:00.125,000] <inf> app:   Current direction: 0
-   [00:00:00.126,000] <inf> app: Property "FUEL_GAUGE_STATE_OF_CHARGE_ALARM" is supported
+   [00:00:00.126,000] <inf> app: Property "FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT" is supported
    [00:00:00.126,000] <inf> app:   State of charge alarm: 8
-   [00:00:00.127,000] <inf> app: Property "FUEL_GAUGE_LOW_VOLTAGE_ALARM" is supported
+   [00:00:00.127,000] <inf> app: Property "FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV" is supported
    [00:00:00.127,000] <inf> app:   Low voltage alarm: 0
-   [00:00:00.127,000] <inf> app: Polling fuel gauge data 'FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE' & 'FUEL_GAUGE_VOLTAGE'
+   [00:00:00.127,000] <inf> app: Polling fuel gauge data 'FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT' & 'FUEL_GAUGE_VOLTAGE_UV'
    [00:00:00.128,000] <inf> app: Fuel gauge data: Charge: 100%, Voltage: 4190mV
    [00:00:05.130,000] <inf> app: Fuel gauge data: Charge: 100%, Voltage: 4190mV
    [00:00:10.131,000] <inf> app: Fuel gauge data: Charge: 100%, Voltage: 4190mV

--- a/samples/drivers/fuel_gauge/src/main.c
+++ b/samples/drivers/fuel_gauge/src/main.c
@@ -20,10 +20,10 @@ LOG_MODULE_REGISTER(app);
 const char *fuel_gauge_prop_to_str(enum fuel_gauge_prop_type prop)
 {
 	switch (prop) {
-	case FUEL_GAUGE_AVG_CURRENT:
-		return "FUEL_GAUGE_AVG_CURRENT";
-	case FUEL_GAUGE_CURRENT:
-		return "FUEL_GAUGE_CURRENT";
+	case FUEL_GAUGE_AVG_CURRENT_UA:
+		return "FUEL_GAUGE_AVG_CURRENT_UA";
+	case FUEL_GAUGE_CURRENT_UA:
+		return "FUEL_GAUGE_CURRENT_UA";
 	case FUEL_GAUGE_CHARGE_CUTOFF:
 		return "FUEL_GAUGE_CHARGE_CUTOFF";
 	case FUEL_GAUGE_CYCLE_COUNT:
@@ -32,50 +32,50 @@ const char *fuel_gauge_prop_to_str(enum fuel_gauge_prop_type prop)
 		return "FUEL_GAUGE_CONNECT_STATE";
 	case FUEL_GAUGE_FLAGS:
 		return "FUEL_GAUGE_FLAGS";
-	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
-		return "FUEL_GAUGE_FULL_CHARGE_CAPACITY";
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
+		return "FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH";
 	case FUEL_GAUGE_PRESENT_STATE:
 		return "FUEL_GAUGE_PRESENT_STATE";
-	case FUEL_GAUGE_REMAINING_CAPACITY:
-		return "FUEL_GAUGE_REMAINING_CAPACITY";
-	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
-		return "FUEL_GAUGE_RUNTIME_TO_EMPTY";
-	case FUEL_GAUGE_RUNTIME_TO_FULL:
-		return "FUEL_GAUGE_RUNTIME_TO_FULL";
+	case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
+		return "FUEL_GAUGE_REMAINING_CAPACITY_UAH";
+	case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
+		return "FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS";
+	case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
+		return "FUEL_GAUGE_RUNTIME_TO_FULL_MINS";
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		return "FUEL_GAUGE_SBS_MFR_ACCESS";
-	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
-		return "FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE";
-	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		return "FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE";
-	case FUEL_GAUGE_TEMPERATURE:
-		return "FUEL_GAUGE_TEMPERATURE";
-	case FUEL_GAUGE_VOLTAGE:
-		return "FUEL_GAUGE_VOLTAGE";
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
+		return "FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT";
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
+		return "FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT";
+	case FUEL_GAUGE_TEMPERATURE_DK:
+		return "FUEL_GAUGE_TEMPERATURE_DK";
+	case FUEL_GAUGE_VOLTAGE_UV:
+		return "FUEL_GAUGE_VOLTAGE_UV";
 	case FUEL_GAUGE_SBS_MODE:
 		return "FUEL_GAUGE_SBS_MODE";
-	case FUEL_GAUGE_CHARGE_CURRENT:
-		return "FUEL_GAUGE_CHARGE_CURRENT";
-	case FUEL_GAUGE_CHARGE_VOLTAGE:
-		return "FUEL_GAUGE_CHARGE_VOLTAGE";
+	case FUEL_GAUGE_CHARGE_CURRENT_UA:
+		return "FUEL_GAUGE_CHARGE_CURRENT_UA";
+	case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
+		return "FUEL_GAUGE_CHARGE_VOLTAGE_UV";
 	case FUEL_GAUGE_STATUS:
 		return "FUEL_GAUGE_STATUS";
 	case FUEL_GAUGE_DESIGN_CAPACITY:
 		return "FUEL_GAUGE_DESIGN_CAPACITY";
-	case FUEL_GAUGE_DESIGN_VOLTAGE:
-		return "FUEL_GAUGE_DESIGN_VOLTAGE";
+	case FUEL_GAUGE_DESIGN_VOLTAGE_MV:
+		return "FUEL_GAUGE_DESIGN_VOLTAGE_MV";
 	case FUEL_GAUGE_SBS_ATRATE:
 		return "FUEL_GAUGE_SBS_ATRATE";
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
-		return "FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL";
-	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
-		return "FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY";
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS:
+		return "FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS";
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS:
+		return "FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS";
 	case FUEL_GAUGE_SBS_ATRATE_OK:
 		return "FUEL_GAUGE_SBS_ATRATE_OK";
 	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
 		return "FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM";
-	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
-		return "FUEL_GAUGE_SBS_REMAINING_TIME_ALARM";
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
+		return "FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS";
 	case FUEL_GAUGE_MANUFACTURER_NAME:
 		return "FUEL_GAUGE_MANUFACTURER_NAME";
 	case FUEL_GAUGE_DEVICE_NAME:
@@ -84,10 +84,10 @@ const char *fuel_gauge_prop_to_str(enum fuel_gauge_prop_type prop)
 		return "FUEL_GAUGE_DEVICE_CHEMISTRY";
 	case FUEL_GAUGE_CURRENT_DIRECTION:
 		return "FUEL_GAUGE_CURRENT_DIRECTION";
-	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
-		return "FUEL_GAUGE_STATE_OF_CHARGE_ALARM";
-	case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
-		return "FUEL_GAUGE_LOW_VOLTAGE_ALARM";
+	case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
+		return "FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT";
+	case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
+		return "FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV";
 	case FUEL_GAUGE_THERM_VOLTAGE_UV:
 		return "FUEL_GAUGE_THERM_VOLTAGE_UV";
 	default:
@@ -119,40 +119,40 @@ int main(void)
 		LOG_INF("Info: not all properties are supported by all fuel gauges!");
 
 		fuel_gauge_prop_t test_props[] = {
-			FUEL_GAUGE_AVG_CURRENT,
-			FUEL_GAUGE_CURRENT,
+			FUEL_GAUGE_AVG_CURRENT_UA,
+			FUEL_GAUGE_CURRENT_UA,
 			FUEL_GAUGE_CHARGE_CUTOFF,
 			FUEL_GAUGE_CYCLE_COUNT,
 			FUEL_GAUGE_CONNECT_STATE,
 			FUEL_GAUGE_FLAGS,
-			FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+			FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
 			FUEL_GAUGE_PRESENT_STATE,
-			FUEL_GAUGE_REMAINING_CAPACITY,
-			FUEL_GAUGE_RUNTIME_TO_EMPTY,
-			FUEL_GAUGE_RUNTIME_TO_FULL,
+			FUEL_GAUGE_REMAINING_CAPACITY_UAH,
+			FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+			FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
 			FUEL_GAUGE_SBS_MFR_ACCESS,
-			FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
-			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-			FUEL_GAUGE_TEMPERATURE,
-			FUEL_GAUGE_VOLTAGE,
+			FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT,
+			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+			FUEL_GAUGE_TEMPERATURE_DK,
+			FUEL_GAUGE_VOLTAGE_UV,
 			FUEL_GAUGE_SBS_MODE,
-			FUEL_GAUGE_CHARGE_CURRENT,
-			FUEL_GAUGE_CHARGE_VOLTAGE,
+			FUEL_GAUGE_CHARGE_CURRENT_UA,
+			FUEL_GAUGE_CHARGE_VOLTAGE_UV,
 			FUEL_GAUGE_STATUS,
 			FUEL_GAUGE_DESIGN_CAPACITY,
-			FUEL_GAUGE_DESIGN_VOLTAGE,
+			FUEL_GAUGE_DESIGN_VOLTAGE_MV,
 			FUEL_GAUGE_SBS_ATRATE,
-			FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
-			FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+			FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS,
+			FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
 			FUEL_GAUGE_SBS_ATRATE_OK,
 			FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-			FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+			FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 			FUEL_GAUGE_MANUFACTURER_NAME,
 			FUEL_GAUGE_DEVICE_NAME,
 			FUEL_GAUGE_DEVICE_CHEMISTRY,
 			FUEL_GAUGE_CURRENT_DIRECTION,
-			FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
-			FUEL_GAUGE_LOW_VOLTAGE_ALARM,
+			FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
+			FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
 			FUEL_GAUGE_STATE_OF_HEALTH,
 			FUEL_GAUGE_THERM_VOLTAGE_UV,
 		};
@@ -228,12 +228,12 @@ int main(void)
 						fuel_gauge_prop_to_str(test_props[i]));
 
 					switch (test_props[i]) {
-					case FUEL_GAUGE_AVG_CURRENT:
+					case FUEL_GAUGE_AVG_CURRENT_UA:
 						LOG_INF("  Avg current: %d",
-							test_vals[i].avg_current);
+							test_vals[i].avg_current_ua);
 						break;
-					case FUEL_GAUGE_CURRENT:
-						LOG_INF("  Current: %d", test_vals[i].current);
+					case FUEL_GAUGE_CURRENT_UA:
+						LOG_INF("  Current: %d", test_vals[i].current_ua);
 						break;
 					case FUEL_GAUGE_CYCLE_COUNT:
 						LOG_INF("  Cycle count: %" PRIu32,
@@ -246,56 +246,56 @@ int main(void)
 					case FUEL_GAUGE_FLAGS:
 						LOG_INF("  Flags: 0x%" PRIx32, test_vals[i].flags);
 						break;
-					case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+					case FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH:
 						LOG_INF("  Full charge capacity: %" PRIu32,
-							test_vals[i].full_charge_capacity);
+							test_vals[i].full_charge_capacity_uah);
 						break;
 					case FUEL_GAUGE_PRESENT_STATE:
 						LOG_INF("  Present state: %d",
 							test_vals[i].present_state);
 						break;
-					case FUEL_GAUGE_REMAINING_CAPACITY:
+					case FUEL_GAUGE_REMAINING_CAPACITY_UAH:
 						LOG_INF("  Remaining capacity: %" PRIu32,
-							test_vals[i].remaining_capacity);
+							test_vals[i].remaining_capacity_uah);
 						break;
-					case FUEL_GAUGE_RUNTIME_TO_EMPTY:
+					case FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS:
 						LOG_INF("  Runtime to empty: %" PRIu32,
-							test_vals[i].runtime_to_empty);
+							test_vals[i].runtime_to_empty_mins);
 						break;
-					case FUEL_GAUGE_RUNTIME_TO_FULL:
+					case FUEL_GAUGE_RUNTIME_TO_FULL_MINS:
 						LOG_INF("  Runtime to full: %" PRIu32,
-							test_vals[i].runtime_to_full);
+							test_vals[i].runtime_to_full_mins);
 						break;
 					case FUEL_GAUGE_SBS_MFR_ACCESS:
 						LOG_INF("  SBS MFR access: %" PRIu16,
 							test_vals[i].sbs_mfr_access_word);
 						break;
-					case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
+					case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT:
 						LOG_INF("  Absolute state of charge: %" PRIu8,
-							test_vals[i].absolute_state_of_charge);
+							test_vals[i].absolute_state_of_charge_pct);
 						break;
-					case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+					case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT:
 						LOG_INF("  Relative state of charge: %" PRIu8,
-							test_vals[i].relative_state_of_charge);
+							test_vals[i].relative_state_of_charge_pct);
 						break;
-					case FUEL_GAUGE_TEMPERATURE:
+					case FUEL_GAUGE_TEMPERATURE_DK:
 						LOG_INF("  Temperature: %" PRIu16,
-							test_vals[i].temperature);
+							test_vals[i].temperature_dk);
 						break;
-					case FUEL_GAUGE_VOLTAGE:
-						LOG_INF("  Voltage: %d", test_vals[i].voltage);
+					case FUEL_GAUGE_VOLTAGE_UV:
+						LOG_INF("  Voltage: %d", test_vals[i].voltage_uv);
 						break;
 					case FUEL_GAUGE_SBS_MODE:
 						LOG_INF("  SBS mode: %" PRIu16,
 							test_vals[i].sbs_mode);
 						break;
-					case FUEL_GAUGE_CHARGE_CURRENT:
+					case FUEL_GAUGE_CHARGE_CURRENT_UA:
 						LOG_INF("  Charge current: %" PRIu32,
-							test_vals[i].chg_current);
+							test_vals[i].chg_current_ua);
 						break;
-					case FUEL_GAUGE_CHARGE_VOLTAGE:
+					case FUEL_GAUGE_CHARGE_VOLTAGE_UV:
 						LOG_INF("  Charge voltage: %" PRIu32,
-							test_vals[i].chg_voltage);
+							test_vals[i].chg_voltage_uv);
 						break;
 					case FUEL_GAUGE_STATUS:
 						LOG_INF("  Status: 0x%" PRIx16,
@@ -305,21 +305,22 @@ int main(void)
 						LOG_INF("  Design capacity: %" PRIu16,
 							test_vals[i].design_cap);
 						break;
-					case FUEL_GAUGE_DESIGN_VOLTAGE:
+					case FUEL_GAUGE_DESIGN_VOLTAGE_MV:
 						LOG_INF("  Design voltage: %" PRIx16,
-							test_vals[i].design_volt);
+							test_vals[i].design_volt_mv);
 						break;
 					case FUEL_GAUGE_SBS_ATRATE:
 						LOG_INF("  SBS at rate: %" PRIi16,
 							test_vals[i].sbs_at_rate);
 						break;
-					case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
+					case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS:
 						LOG_INF("  SBS at rate time to full: %" PRIu16,
-							test_vals[i].sbs_at_rate_time_to_full);
+							test_vals[i].sbs_at_rate_time_to_full_mins);
 						break;
-					case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
+					case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS:
 						LOG_INF("  SBS at rate time to empty: %" PRIu16,
-							test_vals[i].sbs_at_rate_time_to_empty);
+							test_vals[i]
+								.sbs_at_rate_time_to_empty_mins);
 						break;
 					case FUEL_GAUGE_SBS_ATRATE_OK:
 						LOG_INF("  SBS at rate ok: %d",
@@ -329,21 +330,21 @@ int main(void)
 						LOG_INF("  SBS remaining capacity alarm: %" PRIu16,
 							test_vals[i].sbs_remaining_capacity_alarm);
 						break;
-					case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+					case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS:
 						LOG_INF("  SBS remaining time alarm: %" PRIu16,
-							test_vals[i].sbs_remaining_time_alarm);
+							test_vals[i].sbs_remaining_time_alarm_mins);
 						break;
 					case FUEL_GAUGE_CURRENT_DIRECTION:
 						LOG_INF("  Current direction: %" PRIu16,
 							test_vals[i].current_direction);
 						break;
-					case FUEL_GAUGE_STATE_OF_CHARGE_ALARM:
+					case FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT:
 						LOG_INF("  State of charge alarm: %" PRIu8,
-							test_vals[i].state_of_charge_alarm);
+							test_vals[i].state_of_charge_alarm_pct);
 						break;
-					case FUEL_GAUGE_LOW_VOLTAGE_ALARM:
+					case FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV:
 						LOG_INF("  Low voltage alarm: %" PRIu32,
-							test_vals[i].low_voltage_alarm);
+							test_vals[i].low_voltage_alarm_uv);
 						break;
 					case FUEL_GAUGE_STATE_OF_HEALTH:
 						LOG_INF(" State of Health (SOH): %" PRIu32,
@@ -359,13 +360,13 @@ int main(void)
 		}
 	}
 
-	LOG_INF("Polling fuel gauge data 'FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE' & "
-		"'FUEL_GAUGE_VOLTAGE'");
+	LOG_INF("Polling fuel gauge data 'FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT' & "
+		"'FUEL_GAUGE_VOLTAGE_UV'");
 
 	while (1) {
 		fuel_gauge_prop_t poll_props[] = {
-			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-			FUEL_GAUGE_VOLTAGE,
+			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+			FUEL_GAUGE_VOLTAGE_UV,
 		};
 
 		union fuel_gauge_prop_val poll_vals[ARRAY_SIZE(poll_props)];
@@ -376,7 +377,8 @@ int main(void)
 			LOG_ERR("Error: cannot get properties");
 		} else {
 			LOG_INF("Fuel gauge data: Charge: %d%%, Voltage: %dmV",
-				poll_vals[0].relative_state_of_charge, poll_vals[1].voltage / 1000);
+				poll_vals[0].relative_state_of_charge_pct,
+				poll_vals[1].voltage_uv / 1000);
 		}
 
 		k_sleep(K_MSEC(5000));

--- a/samples/drivers/mfd_charger/src/main.c
+++ b/samples/drivers/mfd_charger/src/main.c
@@ -279,14 +279,14 @@ static int monitor_fuel_gauge_status(const struct device *flgdev)
 	union fuel_gauge_prop_val fuel_gauge_val;
 	int ret;
 
-	ret = fuel_gauge_get_prop(flgdev, FUEL_GAUGE_VOLTAGE, &fuel_gauge_val);
+	ret = fuel_gauge_get_prop(flgdev, FUEL_GAUGE_VOLTAGE_UV, &fuel_gauge_val);
 	if (ret) {
 		printk("[%s]: Error getting Fuel Gauge Voltage on device! ret %d\n", now_str(),
 		       ret);
 		return -1;
 	}
 
-	printk("[%s]: Fuel gauge Voltage: %d\n", now_str(), fuel_gauge_val.voltage);
+	printk("[%s]: Fuel gauge Voltage: %d\n", now_str(), fuel_gauge_val.voltage_uv);
 
 	ret = fuel_gauge_get_prop(flgdev, FUEL_GAUGE_STATUS, &fuel_gauge_val);
 	if (ret) {
@@ -296,14 +296,15 @@ static int monitor_fuel_gauge_status(const struct device *flgdev)
 
 	printk("[%s]: Fuel gauge Status 0x%X\n", now_str(), fuel_gauge_val.fg_status);
 
-	ret = fuel_gauge_get_prop(flgdev, FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE, &fuel_gauge_val);
+	ret = fuel_gauge_get_prop(flgdev, FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT, &fuel_gauge_val);
 	if (ret) {
 		printk("[%s]: Error getting Fuel Gauge State of charge on device! ret %d\n",
 		       now_str(), ret);
 		return -1;
 	}
 
-	printk("[%s]: Fuel gauge SoC: %d\n", now_str(), fuel_gauge_val.absolute_state_of_charge);
+	printk("[%s]: Fuel gauge SoC: %d\n", now_str(),
+	       fuel_gauge_val.absolute_state_of_charge_pct);
 
 	return 0;
 }

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -39,7 +39,7 @@ ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
@@ -101,21 +101,21 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t props[] = {
-		FUEL_GAUGE_AVG_CURRENT,
+		FUEL_GAUGE_AVG_CURRENT_UA,
 		FUEL_GAUGE_CYCLE_COUNT,
-		FUEL_GAUGE_CURRENT,
-		FUEL_GAUGE_FULL_CHARGE_CAPACITY,
-		FUEL_GAUGE_REMAINING_CAPACITY,
-		FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		FUEL_GAUGE_RUNTIME_TO_FULL,
+		FUEL_GAUGE_CURRENT_UA,
+		FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
+		FUEL_GAUGE_REMAINING_CAPACITY_UAH,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+		FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
 		FUEL_GAUGE_SBS_MFR_ACCESS,
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		FUEL_GAUGE_TEMPERATURE,
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_TEMPERATURE_DK,
+		FUEL_GAUGE_VOLTAGE_UV,
 		FUEL_GAUGE_SBS_ATRATE,
-		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
-		FUEL_GAUGE_CHARGE_VOLTAGE,
-		FUEL_GAUGE_CHARGE_CURRENT,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
+		FUEL_GAUGE_CHARGE_VOLTAGE_UV,
+		FUEL_GAUGE_CHARGE_CURRENT_UA,
 		FUEL_GAUGE_STATUS,
 		FUEL_GAUGE_DESIGN_CAPACITY,
 		FUEL_GAUGE_STATE_OF_HEALTH,
@@ -127,44 +127,44 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	/* Check properties for valid ranges */
 #if CONFIG_EMUL
 	/* When emulating, check for the fixed values coming from the emulator */
-	zassert_equal(vals[0].avg_current, -2000);
+	zassert_equal(vals[0].avg_current_ua, -2000);
 	zassert_equal(vals[1].cycle_count, 100);
-	zassert_equal(vals[2].current, -2000);
-	zassert_equal(vals[3].full_charge_capacity, 1000);
-	zassert_equal(vals[4].remaining_capacity, 1000);
-	zassert_equal(vals[5].runtime_to_empty, 1);
-	zassert_equal(vals[6].runtime_to_full, 1);
+	zassert_equal(vals[2].current_ua, -2000);
+	zassert_equal(vals[3].full_charge_capacity_uah, 1000);
+	zassert_equal(vals[4].remaining_capacity_uah, 1000);
+	zassert_equal(vals[5].runtime_to_empty_mins, 1);
+	zassert_equal(vals[6].runtime_to_full_mins, 1);
 	zassert_equal(vals[7].sbs_mfr_access_word, 1);
-	zassert_equal(vals[8].relative_state_of_charge, 1);
-	zassert_equal(vals[9].temperature, 1);
-	zassert_equal(vals[10].voltage, 1000);
+	zassert_equal(vals[8].relative_state_of_charge_pct, 1);
+	zassert_equal(vals[9].temperature_dk, 1);
+	zassert_equal(vals[10].voltage_uv, 1000);
 	zassert_equal(vals[11].sbs_at_rate, -2);
-	zassert_equal(vals[12].sbs_at_rate_time_to_empty, 1);
-	zassert_equal(vals[13].chg_voltage, 1000);
-	zassert_equal(vals[14].chg_current, 1000);
+	zassert_equal(vals[12].sbs_at_rate_time_to_empty_mins, 1);
+	zassert_equal(vals[13].chg_voltage_uv, 1000);
+	zassert_equal(vals[14].chg_current_ua, 1000);
 	zassert_equal(vals[15].fg_status, 1);
 	zassert_equal(vals[16].design_cap, 1);
 	zassert_equal(vals[17].state_of_health, 1);
 #else
 	/* When having a real device, check for the valid ranges */
-	zassert_between_inclusive(props[0].avg_current, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(props[1].cycle_count, 0, 6553500);
-	zassert_between_inclusive(props[2].current, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(props[3].full_charge_capacity, 0, 32767 * 1000);
-	zassert_between_inclusive(props[4].remaining_capacity, 0, 32767 * 1000);
-	zassert_between_inclusive(props[5].runtime_to_empty, 0, 65535);
-	zassert_between_inclusive(props[6].runtime_to_full, 0, 65535);
+	zassert_between_inclusive(vals[0].avg_current_ua, -32768 * 1000, 32767 * 1000);
+	zassert_between_inclusive(vals[1].cycle_count, 0, 6553500);
+	zassert_between_inclusive(vals[2].current_ua, -32768 * 1000, 32767 * 1000);
+	zassert_between_inclusive(vals[3].full_charge_capacity_uah, 0, 32767 * 1000);
+	zassert_between_inclusive(vals[4].remaining_capacity_uah, 0, 32767 * 1000);
+	zassert_between_inclusive(vals[5].runtime_to_empty_mins, 0, 65535);
+	zassert_between_inclusive(vals[6].runtime_to_full_mins, 0, 65535);
 	/* Not testing props[7]. This is the manufacturer access and has only status bits */
-	zassert_between_inclusive(props[8].relative_state_of_charge, 0, 100);
-	zassert_between_inclusive(props[9].temperature, 0, 32767);
-	zassert_between_inclusive(props[10].voltage, 0, 32767 * 1000);
-	zassert_between_inclusive(props[11].sbs_at_rate, -32768, 32767);
-	zassert_between_inclusive(props[12].sbs_at_rate_time_to_empty, 0, 65535);
-	zassert_between_inclusive(props[13].chg_voltage, 0, 32767);
-	zassert_between_inclusive(props[14].chg_current, 0, 32767);
+	zassert_between_inclusive(vals[8].relative_state_of_charge_pct, 0, 100);
+	zassert_between_inclusive(vals[9].temperature_dk, 0, 32767);
+	zassert_between_inclusive(vals[10].voltage_uv, 0, 32767 * 1000);
+	zassert_between_inclusive(vals[11].sbs_at_rate, -32768, 32767);
+	zassert_between_inclusive(vals[12].sbs_at_rate_time_to_empty_mins, 0, 65535);
+	zassert_between_inclusive(vals[13].chg_voltage_uv, 0, 32767);
+	zassert_between_inclusive(vals[14].chg_current_ua, 0, 32767);
 	/* Not testing props[15]. This property is the status and only has only status bits */
-	zassert_between_inclusive(props[16].design_cap, 0, 32767);
-	zassert_between_inclusive(props[17].state_of_health, 0, 100);
+	zassert_between_inclusive(vals[16].design_cap, 0, 32767);
+	zassert_between_inclusive(vals[17].state_of_health, 0, 100);
 #endif
 }
 

--- a/tests/drivers/fuel_gauge/bq40z50/src/test_bq40z50.c
+++ b/tests/drivers/fuel_gauge/bq40z50/src/test_bq40z50.c
@@ -37,7 +37,7 @@ ZTEST_USER_F(bq40z50, test_get_some_props_failed_returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
@@ -99,30 +99,30 @@ ZTEST_USER_F(bq40z50, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t props[] = {
-		FUEL_GAUGE_AVG_CURRENT,
-		FUEL_GAUGE_CURRENT,
+		FUEL_GAUGE_AVG_CURRENT_UA,
+		FUEL_GAUGE_CURRENT_UA,
 		FUEL_GAUGE_CHARGE_CUTOFF,
 		FUEL_GAUGE_CYCLE_COUNT,
-		FUEL_GAUGE_FULL_CHARGE_CAPACITY,
-		FUEL_GAUGE_REMAINING_CAPACITY,
-		FUEL_GAUGE_RUNTIME_TO_EMPTY,
+		FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
+		FUEL_GAUGE_REMAINING_CAPACITY_UAH,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
 		FUEL_GAUGE_SBS_MFR_ACCESS,
-		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		FUEL_GAUGE_TEMPERATURE,
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_TEMPERATURE_DK,
+		FUEL_GAUGE_VOLTAGE_UV,
 		FUEL_GAUGE_SBS_MODE,
-		FUEL_GAUGE_CHARGE_CURRENT,
-		FUEL_GAUGE_CHARGE_VOLTAGE,
+		FUEL_GAUGE_CHARGE_CURRENT_UA,
+		FUEL_GAUGE_CHARGE_VOLTAGE_UV,
 		FUEL_GAUGE_STATUS,
 		FUEL_GAUGE_DESIGN_CAPACITY,
-		FUEL_GAUGE_DESIGN_VOLTAGE,
+		FUEL_GAUGE_DESIGN_VOLTAGE_MV,
 		FUEL_GAUGE_SBS_ATRATE,
-		FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
-		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
 		FUEL_GAUGE_SBS_ATRATE_OK,
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 		FUEL_GAUGE_STATE_OF_HEALTH,
 	};
 
@@ -131,57 +131,57 @@ ZTEST_USER_F(bq40z50, test_get_props__returns_ok)
 	zassert_ok(fuel_gauge_get_props(fixture->dev, props, vals, ARRAY_SIZE(props)));
 	/* Check properties for valid ranges */
 #if CONFIG_EMUL
-	zassert_equal(vals[0].avg_current, 1 * 1000);
-	zassert_equal(vals[1].current, 1 * 1000);
+	zassert_equal(vals[0].avg_current_ua, 1 * 1000);
+	zassert_equal(vals[1].current_ua, 1 * 1000);
 	/* Not testing props[2]. This is the charger cutoff and has a boolean.*/
 	zassert_equal(vals[3].cycle_count, 1);
-	zassert_equal(vals[4].full_charge_capacity, 1 * 1000);
-	zassert_equal(vals[5].remaining_capacity, 1 * 1000);
-	zassert_equal(vals[6].runtime_to_empty, 65535);
+	zassert_equal(vals[4].full_charge_capacity_uah, 1 * 1000);
+	zassert_equal(vals[5].remaining_capacity_uah, 1 * 1000);
+	zassert_equal(vals[6].runtime_to_empty_mins, 65535);
 	/* Not testing props[7]. This is the manufacturer access and has only status bits */
-	zassert_equal(vals[8].absolute_state_of_charge, 100);
-	zassert_equal(vals[9].relative_state_of_charge, 100);
-	zassert_equal(vals[10].temperature, 2980);
-	zassert_equal(vals[11].voltage, 1 * 1000);
+	zassert_equal(vals[8].absolute_state_of_charge_pct, 100);
+	zassert_equal(vals[9].relative_state_of_charge_pct, 100);
+	zassert_equal(vals[10].temperature_dk, 2980);
+	zassert_equal(vals[11].voltage_uv, 1 * 1000);
 	zassert_equal(vals[12].sbs_mode, 0);
-	zassert_equal(vals[13].chg_current, 1 * 1000);
-	zassert_equal(vals[14].chg_voltage, 1 * 1000);
+	zassert_equal(vals[13].chg_current_ua, 1 * 1000);
+	zassert_equal(vals[14].chg_voltage_uv, 1 * 1000);
 	/* Not testing props[15]. This property is the status and only has only status bits */
 	zassert_equal(vals[16].design_cap, 1);
-	zassert_equal(vals[17].design_volt, 14400);
+	zassert_equal(vals[17].design_volt_mv, 14400);
 	zassert_equal(vals[18].sbs_at_rate, 0);
-	zassert_equal(vals[19].sbs_at_rate_time_to_full, 65535);
-	zassert_equal(vals[20].sbs_at_rate_time_to_empty, 65535);
+	zassert_equal(vals[19].sbs_at_rate_time_to_full_mins, 65535);
+	zassert_equal(vals[20].sbs_at_rate_time_to_empty_mins, 65535);
 	zassert_equal(vals[21].sbs_at_rate_ok, 0);
 	zassert_equal(vals[22].sbs_remaining_capacity_alarm, 300);
-	zassert_equal(vals[23].sbs_remaining_time_alarm, 10);
+	zassert_equal(vals[23].sbs_remaining_time_alarm_mins, 10);
 	zassert_equal(vals[24].state_of_health, 100);
 #else
 	/* When having a real device, check for the valid ranges */
-	zassert_between_inclusive(vals[0].avg_current, -32767 * 1000, 32768 * 1000);
-	zassert_between_inclusive(vals[1].current, -32767 * 1000, 32768 * 1000);
+	zassert_between_inclusive(vals[0].avg_current_ua, -32767 * 1000, 32768 * 1000);
+	zassert_between_inclusive(vals[1].current_ua, -32767 * 1000, 32768 * 1000);
 	/* Not testing props[2]. This is the charger cutoff and has a boolean.*/
 	zassert_between_inclusive(vals[3].cycle_count, 0, 65535);
-	zassert_between_inclusive(vals[4].full_charge_capacity, 0, 65535 * 1000);
-	zassert_between_inclusive(vals[5].remaining_capacity, 0, 65535 * 1000);
-	zassert_between_inclusive(vals[6].runtime_to_empty, 0, 65535);
+	zassert_between_inclusive(vals[4].full_charge_capacity_uah, 0, 65535 * 1000);
+	zassert_between_inclusive(vals[5].remaining_capacity_uah, 0, 65535 * 1000);
+	zassert_between_inclusive(vals[6].runtime_to_empty_mins, 0, 65535);
 	/* Not testing props[7]. This is the manufacturer access and has only status bits */
-	zassert_between_inclusive(vals[8].absolute_state_of_charge, 0, 100);
-	zassert_between_inclusive(vals[9].relative_state_of_charge, 0, 100);
-	zassert_between_inclusive(vals[10].temperature, 0, 65535);
-	zassert_between_inclusive(vals[11].voltage, 0, 65535 * 1000);
+	zassert_between_inclusive(vals[8].absolute_state_of_charge_pct, 0, 100);
+	zassert_between_inclusive(vals[9].relative_state_of_charge_pct, 0, 100);
+	zassert_between_inclusive(vals[10].temperature_dk, 0, 65535);
+	zassert_between_inclusive(vals[11].voltage_uv, 0, 65535 * 1000);
 	zassert_between_inclusive(vals[12].sbs_mode, 0, 65535 * 1000);
-	zassert_between_inclusive(vals[13].chg_current, 0, 65535 * 1000);
-	zassert_between_inclusive(vals[14].chg_voltage, 0, 65535 * 1000);
+	zassert_between_inclusive(vals[13].chg_current_ua, 0, 65535 * 1000);
+	zassert_between_inclusive(vals[14].chg_voltage_uv, 0, 65535 * 1000);
 	/* Not testing props[15]. This property is the status and only has only status bits */
 	zassert_between_inclusive(vals[16].design_cap, 0, 65535);
-	zassert_between_inclusive(vals[17].design_volt, 0, 18000);
+	zassert_between_inclusive(vals[17].design_volt_mv, 0, 18000);
 	zassert_between_inclusive(vals[18].sbs_at_rate, -32768, 32767);
-	zassert_between_inclusive(vals[19].sbs_at_rate_time_to_full, 0, 65535);
-	zassert_between_inclusive(vals[20].sbs_at_rate_time_to_empty, 0, 65535);
+	zassert_between_inclusive(vals[19].sbs_at_rate_time_to_full_mins, 0, 65535);
+	zassert_between_inclusive(vals[20].sbs_at_rate_time_to_empty_mins, 0, 65535);
 	/* Not testing props[21]. This is the sbs_at_rate_ok property and has a boolean.*/
 	zassert_between_inclusive(vals[22].sbs_remaining_capacity_alarm, 0, 1000);
-	zassert_between_inclusive(vals[23].sbs_remaining_time_alarm, 0, 30);
+	zassert_between_inclusive(vals[23].sbs_remaining_time_alarm_mins, 0, 30);
 	zassert_between_inclusive(vals[24].state_of_health, 0, 100);
 #endif
 }

--- a/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
+++ b/tests/drivers/fuel_gauge/lc709203f/src/test_lc709203f.c
@@ -38,7 +38,7 @@ ZTEST_USER_F(lc709203f, test_get_some_props_failed__returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
@@ -68,7 +68,7 @@ ZTEST_USER_F(lc709203f, test_set_some_props_failed__returns_err)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
+		FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
 		/* Set Manufacturer's Access to arbitrary word */
 
 	};
@@ -80,7 +80,7 @@ ZTEST_USER_F(lc709203f, test_set_some_props_failed__returns_err)
 		{0},
 		/* Valid property */
 		/* Sets state of charge threshold to generate Alarm signal*/
-		{.state_of_charge_alarm = 10},
+		{.state_of_charge_alarm_pct = 10},
 	};
 
 	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
@@ -92,14 +92,14 @@ ZTEST_USER_F(lc709203f, test_set_prop_can_be_get)
 {
 	uint16_t sbs_mode = 0x0002;
 	uint16_t current_direction = 0x0001;
-	uint8_t state_of_charge_alarm = 20;
-	uint32_t low_voltage_alarm = 3000 * 1000;
+	uint8_t state_of_charge_alarm_pct = 20;
+	uint32_t low_voltage_alarm_uv = 3000 * 1000;
 
 	fuel_gauge_prop_t prop_types[] = {
 		FUEL_GAUGE_SBS_MODE,
 		FUEL_GAUGE_CURRENT_DIRECTION,
-		FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
-		FUEL_GAUGE_LOW_VOLTAGE_ALARM,
+		FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
+		FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
 	};
 
 	union fuel_gauge_prop_val set_props[] = {
@@ -110,10 +110,10 @@ ZTEST_USER_F(lc709203f, test_set_prop_can_be_get)
 			.current_direction = current_direction,
 		},
 		{
-			.state_of_charge_alarm = state_of_charge_alarm,
+			.state_of_charge_alarm_pct = state_of_charge_alarm_pct,
 		},
 		{
-			.low_voltage_alarm = low_voltage_alarm,
+			.low_voltage_alarm_uv = low_voltage_alarm_uv,
 		},
 	};
 
@@ -127,41 +127,41 @@ ZTEST_USER_F(lc709203f, test_set_prop_can_be_get)
 
 	zassert_equal(get_props[0].sbs_mode, sbs_mode);
 	zassert_equal(get_props[1].current_direction, current_direction);
-	zassert_equal(get_props[2].state_of_charge_alarm, state_of_charge_alarm);
-	zassert_equal(get_props[3].low_voltage_alarm, low_voltage_alarm);
+	zassert_equal(get_props[2].state_of_charge_alarm_pct, state_of_charge_alarm_pct);
+	zassert_equal(get_props[3].low_voltage_alarm_uv, low_voltage_alarm_uv);
 }
 
 ZTEST_USER_F(lc709203f, test_get_props__returns_ok)
 {
 	fuel_gauge_prop_t props[] = {
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		FUEL_GAUGE_TEMPERATURE,
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_TEMPERATURE_DK,
+		FUEL_GAUGE_VOLTAGE_UV,
 		FUEL_GAUGE_SBS_MODE,
 		FUEL_GAUGE_DESIGN_CAPACITY,
 		FUEL_GAUGE_CURRENT_DIRECTION,
-		FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
-		FUEL_GAUGE_LOW_VOLTAGE_ALARM,
+		FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
+		FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
 	int ret = fuel_gauge_get_props(fixture->dev, props, vals, ARRAY_SIZE(props));
 
 #if CONFIG_EMUL
-	zassert_equal(vals[0].relative_state_of_charge, 50);
-	zassert_equal(vals[1].temperature, 0x0BA6);
-	zassert_equal(vals[2].voltage, 3700 * 1000);
+	zassert_equal(vals[0].relative_state_of_charge_pct, 50);
+	zassert_equal(vals[1].temperature_dk, 0x0BA6);
+	zassert_equal(vals[2].voltage_uv, 3700 * 1000);
 	zassert_equal(vals[3].sbs_mode, 0x0001);
 	zassert_equal(vals[4].design_cap, 500);
 	zassert_true(((vals[5].current_direction == 0x0000) ||
 		      (vals[5].current_direction == 0x0001) ||
 		      (vals[5].current_direction == 0xFFFF)));
-	zassert_equal(vals[6].state_of_charge_alarm, 0x0008);
-	zassert_equal(vals[7].low_voltage_alarm, 0x0000);
+	zassert_equal(vals[6].state_of_charge_alarm_pct, 0x0008);
+	zassert_equal(vals[7].low_voltage_alarm_uv, 0x0000);
 #else
-	zassert_between_inclusive(vals[0].relative_state_of_charge, 0, 100);
-	zassert_between_inclusive(vals[1].temperature, 0x09E4, 0x0D04);
-	zassert_between_inclusive(vals[2].voltage, 0, 0xFFFF * 1000);
+	zassert_between_inclusive(vals[0].relative_state_of_charge_pct, 0, 100);
+	zassert_between_inclusive(vals[1].temperature_dk, 0x09E4, 0x0D04);
+	zassert_between_inclusive(vals[2].voltage_uv, 0, 0xFFFF * 1000);
 	zassert_between_inclusive(vals[3].sbs_mode, 0x0001, 0x0002);
 	zassert_true(((vals[4].design_cap == 100) || (vals[4].design_cap == 200) ||
 		      (vals[4].design_cap == 500) || (vals[4].design_cap == 1000) ||
@@ -169,8 +169,8 @@ ZTEST_USER_F(lc709203f, test_get_props__returns_ok)
 	zassert_true(((vals[5].current_direction == 0x0000) ||
 		      (vals[5].current_direction == 0x0001) ||
 		      (vals[5].current_direction == 0xFFFF)));
-	zassert_between_inclusive(vals[6].state_of_charge_alarm, 0, 100);
-	zassert_between_inclusive(vals[7].low_voltage_alarm, 0, 0xFFFF * 1000);
+	zassert_between_inclusive(vals[6].state_of_charge_alarm_pct, 0, 100);
+	zassert_between_inclusive(vals[7].low_voltage_alarm_uv, 0, 0xFFFF * 1000);
 #endif
 
 	zassert_equal(ret, 0, "Getting bad property has a good status.");
@@ -181,15 +181,15 @@ ZTEST_USER_F(lc709203f, test_set_get_single_prop)
 	uint8_t test_value = 5;
 
 	union fuel_gauge_prop_val state_of_charge_alarm_set = {
-		.state_of_charge_alarm = test_value,
+		.state_of_charge_alarm_pct = test_value,
 	};
 	union fuel_gauge_prop_val state_of_charge_alarm_get;
 
-	zassert_ok(fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
+	zassert_ok(fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
 				       state_of_charge_alarm_set));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
 				       &state_of_charge_alarm_get));
-	zassert_equal(state_of_charge_alarm_get.state_of_charge_alarm, test_value);
+	zassert_equal(state_of_charge_alarm_get.state_of_charge_alarm_pct, test_value);
 }
 
 ZTEST_SUITE(lc709203f, NULL, lc709203f_setup, NULL, NULL, NULL);

--- a/tests/drivers/fuel_gauge/ltc2959/src/test_ltc2959.c
+++ b/tests/drivers/fuel_gauge/ltc2959/src/test_ltc2959.c
@@ -43,9 +43,9 @@ ZTEST_F(ltc2959, test_get_props__returns_ok)
 {
 	fuel_gauge_prop_t props[] = {
 		FUEL_GAUGE_STATUS,
-		FUEL_GAUGE_VOLTAGE,
-		FUEL_GAUGE_CURRENT,
-		FUEL_GAUGE_TEMPERATURE,
+		FUEL_GAUGE_VOLTAGE_UV,
+		FUEL_GAUGE_CURRENT_UA,
+		FUEL_GAUGE_TEMPERATURE_DK,
 	};
 
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
@@ -53,12 +53,12 @@ ZTEST_F(ltc2959, test_get_props__returns_ok)
 
 #if CONFIG_EMUL
 	zassert_equal(vals[0].fg_status, 0x01);
-	zassert_equal(vals[1].voltage, 0x00);
-	zassert_equal(vals[2].current, 0x00);
-	zassert_equal(vals[3].temperature, 0x00);
+	zassert_equal(vals[1].voltage_uv, 0x00);
+	zassert_equal(vals[2].current_ua, 0x00);
+	zassert_equal(vals[3].temperature_dk, 0x00);
 #else
 	zassert_between_inclusive(vals[0].fg_status, 0, 0xFF);
-	zassert_between_inclusive(vals[1].voltage, 0, VOLTAGE_MAX_UV);
+	zassert_between_inclusive(vals[1].voltage_uv, 0, VOLTAGE_MAX_UV);
 #endif
 	zassert_equal(ret, 0, "Getting bad property has a good status.");
 }
@@ -66,26 +66,27 @@ ZTEST_F(ltc2959, test_get_props__returns_ok)
 ZTEST_F(ltc2959, test_set_get_single_prop)
 {
 	int ret;
-	union fuel_gauge_prop_val in = {.low_voltage_alarm = 1200000}; /* 1.2V */
+	union fuel_gauge_prop_val in = {.low_voltage_alarm_uv = 1200000}; /* 1.2V */
 
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_VOLTAGE_ALARM, in);
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV, in);
 	zassert_equal(ret, 0, "set low voltage threshold failed");
 
 	union fuel_gauge_prop_val out;
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_VOLTAGE_ALARM, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV, &out);
 	zassert_equal(ret, 0, "get low voltage threshold failed");
 
 	/* Allow for register quantization: one LSB ≈ 1.91 mV */
 	const int32_t lsb_uv = 62600000 / 32768; /* integer ≈ 1910 */
-	int32_t diff = (int32_t)out.low_voltage_alarm - (int32_t)in.low_voltage_alarm;
+	int32_t diff = (int32_t)out.low_voltage_alarm_uv - (int32_t)in.low_voltage_alarm_uv;
 
 	zassert_true(diff <= lsb_uv && diff >= -lsb_uv,
-		     "Set/get mismatch: in=%d, out=%d, diff=%d > LSB=%d", (int)in.low_voltage_alarm,
-		     (int)out.low_voltage_alarm, (int)(diff), (int)lsb_uv);
+		     "Set/get mismatch: in=%d, out=%d, diff=%d > LSB=%d",
+		     (int)in.low_voltage_alarm_uv, (int)out.low_voltage_alarm_uv, (int)(diff),
+		     (int)lsb_uv);
 
-	LOG_INF("in=%d, out=%d, diff=%d > LSB=%d", (int)in.low_voltage_alarm,
-		(int)out.low_voltage_alarm, (int)(diff), (int)lsb_uv);
+	LOG_INF("in=%d, out=%d, diff=%d > LSB=%d", (int)in.low_voltage_alarm_uv,
+		(int)out.low_voltage_alarm_uv, (int)(diff), (int)lsb_uv);
 }
 
 ZTEST_F(ltc2959, test_current_threshold_roundtrip)
@@ -94,37 +95,39 @@ ZTEST_F(ltc2959, test_current_threshold_roundtrip)
 	union fuel_gauge_prop_val in, out;
 	int32_t tol = CURRENT_LSB_UA ? (int32_t)CURRENT_LSB_UA : 100;
 
-	in.high_current_alarm = 123456; /* µA */
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_HIGH_CURRENT_ALARM, in);
+	in.high_current_alarm_ua = 123456; /* µA */
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_HIGH_CURRENT_ALARM_UA, in);
 	zassert_equal(ret, 0, "set current high threshold failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_HIGH_CURRENT_ALARM, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_HIGH_CURRENT_ALARM_UA, &out);
 	zassert_equal(ret, 0, "get current high threshold failed (%d)", ret);
 
-	int32_t diff = out.high_current_alarm - in.high_current_alarm;
+	int32_t diff = out.high_current_alarm_ua - in.high_current_alarm_ua;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= tol, "current high threshold mismatch: in=%d out=%d diff=%d tol=%d",
-		     (int)in.high_current_alarm, (int)out.high_current_alarm, (int)diff, (int)tol);
+		     (int)in.high_current_alarm_ua, (int)out.high_current_alarm_ua, (int)diff,
+		     (int)tol);
 
-	in.low_current_alarm = -78901; /* µA */
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_CURRENT_ALARM, in);
+	in.low_current_alarm_ua = -78901; /* µA */
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_CURRENT_ALARM_UA, in);
 	zassert_equal(ret, 0, "set current low threshold failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_CURRENT_ALARM, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_CURRENT_ALARM_UA, &out);
 	zassert_equal(ret, 0, "get current low threshold failed (%d)", ret);
 
-	diff = out.low_current_alarm - in.low_current_alarm;
+	diff = out.low_current_alarm_ua - in.low_current_alarm_ua;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= tol, "current low threshold mismatch: in=%d out=%d diff=%d tol=%d",
-		     (int)in.low_current_alarm, (int)out.low_current_alarm, (int)diff, (int)tol);
+		     (int)in.low_current_alarm_ua, (int)out.low_current_alarm_ua, (int)diff,
+		     (int)tol);
 }
 
 ZTEST_F(ltc2959, test_temperature_threshold_roundtrip)
@@ -133,35 +136,35 @@ ZTEST_F(ltc2959, test_temperature_threshold_roundtrip)
 	union fuel_gauge_prop_val in;
 	union fuel_gauge_prop_val out;
 
-	in.low_temperature_alarm = 3000;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_TEMPERATURE_ALARM, in);
+	in.low_temperature_alarm_dk = 3000;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK, in);
 	zassert_equal(ret, 0, "set temp low threshold failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_TEMPERATURE_ALARM, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_LOW_TEMPERATURE_ALARM_DK, &out);
 	zassert_equal(ret, 0, "get temp low threshold failed (%d)", ret);
-	int32_t diff = (int32_t)out.low_temperature_alarm - (int32_t)in.low_temperature_alarm;
+	int32_t diff = (int32_t)out.low_temperature_alarm_dk - (int32_t)in.low_temperature_alarm_dk;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= 1, "temp low threshold mismatch: in=%u out=%u diff=%d",
-		     in.low_temperature_alarm, out.low_temperature_alarm, (int)diff);
+		     in.low_temperature_alarm_dk, out.low_temperature_alarm_dk, (int)diff);
 
-	in.high_temperature_alarm = 3500;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_HIGH_TEMPERATURE_ALARM, in);
+	in.high_temperature_alarm_dk = 3500;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK, in);
 	zassert_equal(ret, 0, "set temp high threshold failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_HIGH_TEMPERATURE_ALARM, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_HIGH_TEMPERATURE_ALARM_DK, &out);
 	zassert_equal(ret, 0, "get temp high threshold failed (%d)", ret);
-	diff = (int32_t)out.high_temperature_alarm - (int32_t)in.high_temperature_alarm;
+	diff = (int32_t)out.high_temperature_alarm_dk - (int32_t)in.high_temperature_alarm_dk;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= 1, "temp high threshold mismatch: in=%u out=%u diff=%d",
-		     in.high_temperature_alarm, out.high_temperature_alarm, (int)diff);
+		     in.high_temperature_alarm_dk, out.high_temperature_alarm_dk, (int)diff);
 }
 
 ZTEST_F(ltc2959, test_adc_mode_roundtrip)
@@ -183,21 +186,21 @@ ZTEST_F(ltc2959, test_remaining_capacity_roundtrip)
 	int ret;
 	union fuel_gauge_prop_val in, out;
 
-	in.remaining_capacity = 1234567; /* µAh */
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY, in);
+	in.remaining_capacity_uah = 1234567; /* µAh */
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY_UAH, in);
 	zassert_equal(ret, 0, "set ACR failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY_UAH, &out);
 	zassert_equal(ret, 0, "get ACR failed (%d)", ret);
 
-	int32_t diff = (int32_t)out.remaining_capacity - (int32_t)in.remaining_capacity;
+	int32_t diff = (int32_t)out.remaining_capacity_uah - (int32_t)in.remaining_capacity_uah;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= 1, "ACR mismatch: in=%d out=%d diff=%d tol=1",
-		     (int)in.remaining_capacity, (int)out.remaining_capacity, (int)diff);
+		     (int)in.remaining_capacity_uah, (int)out.remaining_capacity_uah, (int)diff);
 }
 
 ZTEST_F(ltc2959, test_remaining_capacity_reserved_guard)
@@ -206,24 +209,24 @@ ZTEST_F(ltc2959, test_remaining_capacity_reserved_guard)
 	union fuel_gauge_prop_val in, out;
 
 	/* 0xFFFFFFFF counts ≈ 2,289,000,000 µAh (533 nAh/LSB) */
-	in.remaining_capacity = 2289000000U;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY, in);
+	in.remaining_capacity_uah = 2289000000U;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY_UAH, in);
 	zassert_equal(ret, 0, "set ACR near fullscale failed (%d)", ret);
 
-	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY, &out);
+	ret = fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_REMAINING_CAPACITY_UAH, &out);
 	zassert_equal(ret, 0, "get ACR near fullscale failed (%d)", ret);
 
 	/* We expect the driver to write 0xFFFFFFFE instead, so out <= in and close */
-	zassert_true(out.remaining_capacity <= in.remaining_capacity,
+	zassert_true(out.remaining_capacity_uah <= in.remaining_capacity_uah,
 		     "ACR guard failed: got larger than requested");
-	int32_t diff = (int32_t)in.remaining_capacity - (int32_t)out.remaining_capacity;
+	int32_t diff = (int32_t)in.remaining_capacity_uah - (int32_t)out.remaining_capacity_uah;
 
 	if (diff < 0) {
 		diff = -diff;
 	}
 
 	zassert_true(diff <= 1, "ACR guard too lossy: in=%d out=%d |diff|=%d",
-		     (int)in.remaining_capacity, (int)out.remaining_capacity, (int)diff);
+		     (int)in.remaining_capacity_uah, (int)out.remaining_capacity_uah, (int)diff);
 }
 
 ZTEST_F(ltc2959, test_cc_config_sanitized)
@@ -250,7 +253,7 @@ ZTEST_USER_F(ltc2959, test_get_some_props_failed__returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
@@ -267,7 +270,7 @@ ZTEST_F(ltc2959, test_set_some_props_failed__returns_err)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_LOW_VOLTAGE_ALARM,
+		FUEL_GAUGE_LOW_VOLTAGE_ALARM_UV,
 	};
 
 	union fuel_gauge_prop_val props[] = {
@@ -276,7 +279,7 @@ ZTEST_F(ltc2959, test_set_some_props_failed__returns_err)
 		/* Second invalid property */
 		{0},
 		/* Valid property */
-		{.voltage = 0},
+		{.voltage_uv = 0},
 	};
 
 	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -40,7 +40,7 @@ ZTEST_USER_F(max17048, test_get_some_props_failed_returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
@@ -54,10 +54,10 @@ ZTEST_USER_F(max17048, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t prop_types[] = {
-		FUEL_GAUGE_VOLTAGE,
-		FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		FUEL_GAUGE_RUNTIME_TO_FULL,
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+		FUEL_GAUGE_VOLTAGE_UV,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+		FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
 	};
 
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
@@ -70,8 +70,8 @@ ZTEST_USER_F(max17048, test_current_rate_zero)
 	/* Test when crate is 0, which is a special case */
 
 	fuel_gauge_prop_t prop_types[] = {
-		FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		FUEL_GAUGE_RUNTIME_TO_FULL,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+		FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
 	};
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
@@ -81,10 +81,10 @@ ZTEST_USER_F(max17048, test_current_rate_zero)
 	emul_max17048_set_crate_status(0);
 	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].runtime_to_empty, 0, "Runtime to empty is %d but it should be 0.",
-		      props[0].runtime_to_full);
-	zassert_equal(props[1].runtime_to_full, 0, "Runtime to full is %d but it should be 0.",
-		      props[1].runtime_to_full);
+	zassert_equal(props[0].runtime_to_empty_mins, 0,
+		      "Runtime to empty is %d but it should be 0.", props[0].runtime_to_empty_mins);
+	zassert_equal(props[1].runtime_to_full_mins, 0, "Runtime to full is %d but it should be 0.",
+		      props[1].runtime_to_full_mins);
 
 	zassert_ok(ret);
 	/* Return value to the original state */

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -40,7 +40,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
 
@@ -97,7 +97,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 	fuel_gauge_prop_t prop_types[] = {
 		FUEL_GAUGE_SBS_MFR_ACCESS,
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 		FUEL_GAUGE_SBS_MODE,
 		FUEL_GAUGE_SBS_ATRATE,
 	};
@@ -110,7 +110,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 			.sbs_remaining_capacity_alarm = word,
 		},
 		{
-			.sbs_remaining_time_alarm = word,
+			.sbs_remaining_time_alarm_mins = word,
 		},
 		{
 			.sbs_mode = word,
@@ -130,7 +130,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 
 	zassert_equal(get_props[0].sbs_mfr_access_word, word);
 	zassert_equal(get_props[1].sbs_remaining_capacity_alarm, word);
-	zassert_equal(get_props[2].sbs_remaining_time_alarm, word);
+	zassert_equal(get_props[2].sbs_remaining_time_alarm_mins, word);
 	zassert_equal(get_props[3].sbs_mode, word);
 	zassert_equal(get_props[4].sbs_at_rate, (int16_t)word);
 }
@@ -140,30 +140,30 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t prop_types[] = {
-		FUEL_GAUGE_VOLTAGE,
-		FUEL_GAUGE_CURRENT,
-		FUEL_GAUGE_AVG_CURRENT,
-		FUEL_GAUGE_TEMPERATURE,
-		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		FUEL_GAUGE_RUNTIME_TO_FULL,
-		FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		FUEL_GAUGE_REMAINING_CAPACITY,
-		FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+		FUEL_GAUGE_VOLTAGE_UV,
+		FUEL_GAUGE_CURRENT_UA,
+		FUEL_GAUGE_AVG_CURRENT_UA,
+		FUEL_GAUGE_TEMPERATURE_DK,
+		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
+		FUEL_GAUGE_RUNTIME_TO_FULL_MINS,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY_MINS,
+		FUEL_GAUGE_REMAINING_CAPACITY_UAH,
+		FUEL_GAUGE_FULL_CHARGE_CAPACITY_UAH,
 		FUEL_GAUGE_CYCLE_COUNT,
 		FUEL_GAUGE_SBS_MFR_ACCESS,
 		FUEL_GAUGE_SBS_MODE,
-		FUEL_GAUGE_CHARGE_CURRENT,
-		FUEL_GAUGE_CHARGE_VOLTAGE,
+		FUEL_GAUGE_CHARGE_CURRENT_UA,
+		FUEL_GAUGE_CHARGE_VOLTAGE_UV,
 		FUEL_GAUGE_STATUS,
 		FUEL_GAUGE_DESIGN_CAPACITY,
-		FUEL_GAUGE_DESIGN_VOLTAGE,
+		FUEL_GAUGE_DESIGN_VOLTAGE_MV,
 		FUEL_GAUGE_SBS_ATRATE,
-		FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
-		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL_MINS,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY_MINS,
 		FUEL_GAUGE_SBS_ATRATE_OK,
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 	};
 
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)] = {0};
@@ -177,7 +177,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 		FUEL_GAUGE_SBS_MFR_ACCESS,
 		FUEL_GAUGE_SBS_MODE,
 		FUEL_GAUGE_SBS_ATRATE,
-		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM_MINS,
 		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
 
 	};
@@ -213,13 +213,13 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 
 	zassume_ok(emul_fuel_gauge_set_battery_charging(fixture->sbs_fuel_gauge, expected_uV,
 							expected_uA));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE, &voltage));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT, &current));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE_UV, &voltage));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT_UA, &current));
 
-	zassert_equal(voltage.voltage, expected_uV, "Got %d instead of %d",
-			voltage.voltage, expected_uV);
-	zassert_equal(current.current, expected_uA, "Got %d instead of %d",
-			current.current, expected_uA);
+	zassert_equal(voltage.voltage_uv, expected_uV, "Got %d instead of %d", voltage.voltage_uv,
+		      expected_uV);
+	zassert_equal(current.current_ua, expected_uA, "Got %d instead of %d", current.current_ua,
+		      expected_uA);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_neg_1a)
@@ -232,13 +232,13 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_neg_1a)
 
 	zassume_ok(emul_fuel_gauge_set_battery_charging(fixture->sbs_fuel_gauge, expected_uV,
 							expected_uA));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE, &voltage));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT, &current));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE_UV, &voltage));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT_UA, &current));
 
-	zassert_equal(voltage.voltage, expected_uV, "Got %d instead of %d",
-			voltage.voltage, expected_uV);
-	zassert_equal(current.current, expected_uA, "Got %d instead of %d",
-			current.current, expected_uA);
+	zassert_equal(voltage.voltage_uv, expected_uV, "Got %d instead of %d", voltage.voltage_uv,
+		      expected_uV);
+	zassert_equal(current.current_ua, expected_uA, "Got %d instead of %d", current.current_ua,
+		      expected_uA);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_get_single_prop)

--- a/tests/drivers/fuel_gauge/sy24561/src/test_sy24561.c
+++ b/tests/drivers/fuel_gauge/sy24561/src/test_sy24561.c
@@ -40,7 +40,7 @@ ZTEST_USER_F(sy24561, test_get_some_props_failed_returns_bad_status)
 		/* Second invalid property */
 		FUEL_GAUGE_PROP_MAX,
 		/* Valid property */
-		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_VOLTAGE_UV,
 	};
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
@@ -54,8 +54,8 @@ ZTEST_USER_F(sy24561, test_get_props__returns_ok)
 	/* Validate what props are supported by the driver */
 
 	fuel_gauge_prop_t prop_types[] = {
-		FUEL_GAUGE_VOLTAGE,
-		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+		FUEL_GAUGE_VOLTAGE_UV,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE_PCT,
 		FUEL_GAUGE_STATUS,
 		FUEL_GAUGE_CURRENT_DIRECTION,
 	};
@@ -63,8 +63,8 @@ ZTEST_USER_F(sy24561, test_get_props__returns_ok)
 	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
 	zassert_ok(fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
-	zassert_equal(props[0].voltage, 3199000);
-	zassert_equal(props[1].relative_state_of_charge, 74);
+	zassert_equal(props[0].voltage_uv, 3199000);
+	zassert_equal(props[1].relative_state_of_charge_pct, 74);
 	zassert_equal(props[2].fg_status, 0);
 	zassert_equal(props[3].current_direction, 0);
 }
@@ -74,13 +74,13 @@ ZTEST_USER_F(sy24561, test_out_of_range_temperature_are_cropped)
 	union fuel_gauge_prop_val val;
 	int ret = 0;
 
-	val.temperature = 0;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_TEMPERATURE,
+	val.temperature_dk = 0;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_TEMPERATURE_DK,
 				  val); /* A warning is triggered but it should pass */
 	zassert_equal(ret, 0, "Setting too low temperature has good status");
 
-	val.temperature = 0xffff;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_TEMPERATURE,
+	val.temperature_dk = 0xffff;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_TEMPERATURE_DK,
 				  val); /* A warning is triggered but it should pass */
 	zassert_equal(ret, 0, "Setting too high temperature has good status");
 }
@@ -90,13 +90,13 @@ ZTEST_USER_F(sy24561, test_out_of_range_alarm_threshold_are_cropped)
 	union fuel_gauge_prop_val val;
 	int ret = 0;
 
-	val.state_of_charge_alarm = 0u;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
+	val.state_of_charge_alarm_pct = 0u;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
 				  val); /* A warning is triggered but it should pass */
 	zassert_equal(ret, 0, "Setting too low alarm threshold has good status");
 
-	val.state_of_charge_alarm = 0xffu;
-	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM,
+	val.state_of_charge_alarm_pct = 0xffu;
+	ret = fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_STATE_OF_CHARGE_ALARM_PCT,
 				  val); /* A warning is triggered but it should pass */
 	zassert_equal(ret, 0, "Setting too high alarm threshold has good status");
 }


### PR DESCRIPTION
This PR adds units to enum/struct fields for Fuel Gauge subsystem. It also marks the legacy struct fields as deprecated, and these fields will be removed in future. This PR also changed all the files in Zephyr tree, that used legacy fields without units.