### PR TITLE
Enable pse84 ble  support

### DIFF
--- a/boards/infineon/kit_pse84_ai/Kconfig.defconfig
+++ b/boards/infineon/kit_pse84_ai/Kconfig.defconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_KIT_PSE84_AI_PSE846GPS2DBZC4A_M55
+
+if BT
+
+choice AIROC_PART
+	default CYW55500
+endchoice
+
+choice CYW55500_MODULE
+	default CYW55513_MURATA_2FY
+endchoice
+
+config MAIN_STACK_SIZE
+	default 2048 if BT_HCI
+
+endif # BT
+
+endif # BOARD_KIT_PSE84_AI_PSE846GPS2DBZC4A_M55

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common-pinctrl.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common-pinctrl.dtsi
@@ -13,3 +13,19 @@
 &p6_5_scb2_uart_rx {
 	input-enable;
 };
+
+&p10_1_scb4_uart_tx {
+	drive-push-pull;
+};
+
+&p10_0_scb4_uart_rx {
+	input-enable;
+};
+
+&p10_3_scb4_uart_rts {
+	drive-push-pull;
+};
+
+&p10_2_scb4_uart_cts {
+	input-enable;
+};

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -92,6 +92,10 @@ uart2: &scb2 {
 	status = "okay";
 };
 
+&gpio_prt11 {
+	status = "okay";
+};
+
 &gpio_prt13 {
 	status = "okay";
 };

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
@@ -32,5 +32,42 @@
 		zephyr,sram = &m55_data;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,bt-hci = &bt_hci_uart;
+	};
+};
+
+&peri0_group1_16_5bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_SCB>;
+	resource-instance = <4>;
+	clock-div = <1>;
+};
+
+uart4: &scb4 {
+	compatible = "infineon,uart";
+	status = "okay";
+
+	current-speed = <115200>;
+
+	clocks = <&peri0_group1_16_5bit_0>;
+
+	/* HCI-UART pins */
+	pinctrl-0 = <&p10_1_scb4_uart_tx &p10_0_scb4_uart_rx &p10_3_scb4_uart_rts
+		     &p10_2_scb4_uart_cts>;
+	pinctrl-names = "default";
+
+	/* HW Flow control must be enabled for HCI H4 */
+	hw-flow-control;
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+
+		cyw55513 {
+			status = "okay";
+			compatible = "infineon,bt-hci-uart";
+			bt-reg-on-gpios = <&gpio_prt11 0 GPIO_ACTIVE_HIGH>;
+			fw-download-speed = <115200>;
+			hci-operation-speed = <115200>;
+		};
 	};
 };

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -12,6 +12,7 @@ sysbuild: true
 toolchain:
   - zephyr
 supported:
+  - bluetooth
   - clock_control
   - gpio
   - pinctrl

--- a/boards/infineon/kit_pse84_eval/kconfig.defconfig
+++ b/boards/infineon/kit_pse84_eval/kconfig.defconfig
@@ -28,3 +28,23 @@ config HEAP_MEM_POOL_ADD_SIZE_BOARD
 endif # WIFI
 
 endif # BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M55
+
+if BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M33
+
+if BT
+
+# Select AIROC part and module
+choice AIROC_PART
+	default CYW55500
+endchoice
+
+choice CYW55500_MODULE
+	default CYW55513IUBG_SM
+endchoice
+
+config MAIN_STACK_SIZE
+	default 2048 if BT_HCI
+
+endif # BT
+
+endif # BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M33

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common-pinctrl.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common-pinctrl.dtsi
@@ -14,6 +14,22 @@
 	input-enable;
 };
 
+&p10_1_scb4_uart_tx {
+	drive-push-pull;
+};
+
+&p10_0_scb4_uart_rx {
+	input-enable;
+};
+
+&p10_3_scb4_uart_rts {
+	drive-push-pull;
+};
+
+&p10_2_scb4_uart_cts {
+	input-enable;
+};
+
 &p21_0_sdhc0_card_cmd {
 	drive-push-pull;
 	input-enable;

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -66,15 +66,15 @@ uart2: &scb2 {
 	status = "okay";
 };
 
-&gpio_prt16 {
-	status = "okay";
-};
-
 &gpio_prt2 {
 	status = "okay";
 };
 
 &gpio_prt8 {
+	status = "okay";
+};
+
+&gpio_prt10 {
 	status = "okay";
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
@@ -28,6 +28,7 @@
 		zephyr,sram = &m33s_data;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,bt-hci = &bt_hci_uart;
 	};
 };
 
@@ -191,4 +192,40 @@
 	source-path = <IFX_CLK_HF_IN_CLKPATH0>;
 	clock-div = <IFX_CLK_HF_DIVIDE_BY_4>;
 	status = "okay";
+};
+
+&peri0_group1_16_5bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_SCB>;
+	resource-instance = <4>;
+	clock-div = <1>;
+};
+
+uart4: &scb4 {
+	compatible = "infineon,uart";
+	status = "okay";
+
+	current-speed = <115200>;
+
+	clocks = <&peri0_group1_16_5bit_0>;
+
+	/* HCI-UART pins */
+	pinctrl-0 = <&p10_1_scb4_uart_tx &p10_0_scb4_uart_rx &p10_3_scb4_uart_rts
+		     &p10_2_scb4_uart_cts>;
+	pinctrl-names = "default";
+
+	/* HW Flow control must be enabled for HCI H4 */
+	hw-flow-control;
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+
+		cyw55513 {
+			status = "okay";
+			compatible = "infineon,bt-hci-uart";
+			bt-reg-on-gpios = <&gpio_prt11 0 GPIO_ACTIVE_HIGH>;
+			fw-download-speed = <115200>;
+			hci-operation-speed = <115200>;
+		};
+	};
 };

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -12,6 +12,7 @@ ram: 5120
 toolchain:
   - zephyr
 supported:
+  - bluetooth
   - clock_control
   - dma
   - gpio

--- a/drivers/bluetooth/hci/Kconfig.infineon
+++ b/drivers/bluetooth/hci/Kconfig.infineon
@@ -229,6 +229,37 @@ config CYW20829B1_BT_FW_TX10
 endchoice
 endif # CYW20829
 
+choice CYW55500_MODULE
+	prompt "CYW55500 module"
+	depends on CYW55500 && BT_H4
+
+config CYW55513IUBG_SM
+	bool "CYW55513 Module"
+	help
+	  AIROC™ CYW55513 Wi-Fi & Bluetooth® is a low-power, single chip device
+	  that support single-stream, tri-band,mWi-Fi 6/6E, IEEE 802.11ax compliant
+	  Wi-Fi MAC/baseband/radio, and Bluetooth®/Bluetooth® Low Energy 5.4.
+
+config CYW55513_MURATA_2FY
+	bool "CYW55513 Murata 2FY Module"
+	help
+	  Type 2FY is a small and high performance module based on Infineon CYW55513
+	  combo chipset which supports Wi-Fi® 802.11a/b/g/n/ac/ax + Bluetooth® 5.4
+	  BR/EDR/LE up to 143Mbps PHY data rate on Wi-Fi, 3Mbps PHY data rate on
+	  Bluetooth and 2Mbps PHY data rate on Bluetooth® LE.
+
+	  Detailed information about Murata Type 2FY module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2fy
+endchoice
+
+
+config BT_CYW555XX
+	bool "Bluetooth support for CYW555XX"
+	default y if CYW55513_MURATA_2FY || CYW55513IUBG_SM
+	help
+	  Common Bluetooth configuration for CYW555XX-based designs,
+	  including Murata 2FY modules and discrete chip implementations.
+
 config AIROC_CUSTOM_FIRMWARE_HCD_BLOB
 	string  "Path to user BT firmware HCD file"
 	help

--- a/drivers/bluetooth/hci/hci_uart_infineon.c
+++ b/drivers/bluetooth/hci/hci_uart_infineon.c
@@ -46,6 +46,9 @@ BUILD_ASSERT(DT_PROP(DT_INST_BUS(0), hw_flow_control) == 1,
 /* Length of UPDATE BAUD RATE command */
 #define HCI_VSC_UPDATE_BAUD_RATE_LENGTH   (6u)
 
+/* Length of Write_SCO_PCM_Int_Param command */
+#define HCI_VSC_WRITE_SCO_PCM_INT_PARAM_LENGTH   (5u)
+
 /* Default BAUDRATE */
 #define HCI_UART_DEFAULT_BAUDRATE         (115200)
 
@@ -53,13 +56,21 @@ BUILD_ASSERT(DT_PROP(DT_INST_BUS(0), hw_flow_control) == 1,
 extern const uint8_t brcm_patchram_buf[];
 extern const int brcm_patch_ram_length;
 
-enum {
-	BT_HCI_VND_OP_SET_MAC                   = 0xFC01,
-	BT_HCI_VND_OP_DOWNLOAD_MINIDRIVER       = 0xFC2E,
-	BT_HCI_VND_OP_WRITE_RAM                 = 0xFC4C,
-	BT_HCI_VND_OP_LAUNCH_RAM                = 0xFC4E,
-	BT_HCI_VND_OP_UPDATE_BAUDRATE           = 0xFC18,
-};
+#define BT_HCI_CMD_SET_MAC               0x0001
+#define BT_HCI_CMD_DOWNLOAD_MINIDRIVER   0x002E
+#define BT_HCI_CMD_WRITE_RAM             0x004C
+#define BT_HCI_CMD_LAUNCH_RAM            0x004E
+#define BT_HCI_CMD_UPDATE_BAUDRATE       0x0018
+#define BT_HCI_CMD_WRITE_PCM_INT_PARAM   0x001C
+
+/* Vendor specific commands */
+#define BT_HCI_VND_OP_SET_MAC                   BT_OP(BT_OGF_VS, BT_HCI_CMD_SET_MAC)
+#define BT_HCI_VND_OP_DOWNLOAD_MINIDRIVER       BT_OP(BT_OGF_VS, BT_HCI_CMD_DOWNLOAD_MINIDRIVER)
+#define BT_HCI_VND_OP_WRITE_RAM                 BT_OP(BT_OGF_VS, BT_HCI_CMD_WRITE_RAM)
+#define BT_HCI_VND_OP_LAUNCH_RAM                BT_OP(BT_OGF_VS, BT_HCI_CMD_LAUNCH_RAM)
+#define BT_HCI_VND_OP_UPDATE_BAUDRATE           BT_OP(BT_OGF_VS, BT_HCI_CMD_UPDATE_BAUDRATE)
+#define BT_HCI_VND_OP_WRITE_PCM_INT_PARAM       BT_OP(BT_OGF_VS, BT_HCI_CMD_WRITE_PCM_INT_PARAM)
+
 
 /*  bt_h4_vnd_setup function.
  * This function executes vendor-specific commands sequence to
@@ -224,6 +235,26 @@ static int bt_firmware_download(const uint8_t *firmware_image, uint32_t size)
 	return 0;
 }
 
+static int bt_update_sco_route(void)
+{
+	struct net_buf *buf;
+
+	/* Allocate buffer for write pcm internal params command*/
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		LOG_ERR("Unable to allocate command buffer");
+		return -ENOMEM;
+	}
+
+	/* Zero-initialize to use the default settings */
+	memset(net_buf_add(buf, HCI_VSC_WRITE_SCO_PCM_INT_PARAM_LENGTH), 0,
+		HCI_VSC_WRITE_SCO_PCM_INT_PARAM_LENGTH);
+
+	/* Send write pcm internal params command. */
+	return bt_hci_cmd_send_sync(BT_HCI_VND_OP_WRITE_PCM_INT_PARAM, buf, NULL);
+}
+
+
 int bt_h4_vnd_setup(const struct device *dev, const struct bt_hci_setup_params *params)
 {
 	int err;
@@ -336,5 +367,19 @@ int bt_h4_vnd_setup(const struct device *dev, const struct bt_hci_setup_params *
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CYW555XX)) {
+		/* Update SCO Route to PCM
+		 * Default route is set to Transport. While Sending Host Buffer Size,
+		 * BLE application only sets ACL data length and number of packet for ACL
+		 * but its not setting SCO packet count and size. As SCO Route is set to
+		 * Transport and Host is not setting SCO PKT Size and Count, Controller
+		 * sends invalid command response. So set the default route to PCM
+		 */
+		err = bt_update_sco_route();
+		if (err) {
+			LOG_ERR("Failed to update SCO route (err %d)", err);
+			return err;
+		}
+	}
 	return 0;
 }

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -57,6 +57,8 @@ LOG_MODULE_REGISTER(uart_ifx, CONFIG_UART_LOG_LEVEL);
 #define IFX_UART_RX_INT_MASK_NONE 0UL
 #define IFX_UART_TX_INT_MASK_NONE 0UL
 
+#define IFX_UART_RTS_RX_FIFO_LEVEL 63UL
+
 #ifdef CONFIG_UART_ASYNC_API
 #include <zephyr/drivers/dma.h>
 #include <cy_trigmux.h>
@@ -423,7 +425,8 @@ static int ifx_cat1_uart_configure(const struct device *dev, const struct uart_c
 	data->scb_config.dataWidth = convert_uart_data_bits_z_to_cy(cfg->data_bits);
 	data->scb_config.stopBits = convert_uart_stop_bits_z_to_cy(cfg->stop_bits);
 	data->scb_config.parity = convert_uart_parity_z_to_cy(cfg->parity);
-	data->scb_config.enableCts = data->cts_enabled;
+	data->scb_config.enableCts = cfg->flow_ctrl;
+	data->scb_config.rtsRxFifoLevel = cfg->flow_ctrl ? IFX_UART_RTS_RX_FIFO_LEVEL : 0UL;
 
 	Cy_SCB_UART_Init(config->reg_addr, &(data->scb_config), NULL);
 	Cy_SCB_UART_Enable(config->reg_addr);

--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -120,7 +120,7 @@ config CYW43439
 
 config CYW55500
 	bool "CYW55500"
-	select AIROC_WIFI6
+	select AIROC_WIFI6 if WIFI
 	help
 	  Enable Infineon AIROC CYW55500 Wi-Fi connectivity,
 	  More information about CYW55500 device you can find on

--- a/modules/hal_infineon/btstack-integration/CMakeLists.txt
+++ b/modules/hal_infineon/btstack-integration/CMakeLists.txt
@@ -98,6 +98,16 @@ if(CONFIG_CYW20829B1_BT_FW_TX10)
   set(blob_hcd_file ${hal_blobs_dir}/COMPONENT_CYW20829B1/COMPONENT_BTFW-TX10/bt_firmware.hcd)
 endif()
 
+# CYW55513 Discrete Module
+if(CONFIG_CYW55513IUBG_SM)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_CYW55513/COMPONENT_BTFW/bt_firmware.hcd)
+endif()
+
+# CYW55513 Murata 2FY Module
+if(CONFIG_CYW55513_MURATA_2FY)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_CYW55513/COMPONENT_BTFW_MURATA-2FY/bt_firmware.hcd)
+endif()
+
 # use user provided FIRMWARE HCD file (path must be defined in CONFIG_AIROC_CUSTOM_FIRMWARE_HCD_BLOB)
 if(CONFIG_AIROC_CUSTOM_FIRMWARE_HCD_BLOB)
   # Allowed to pass absolute path to HCD blob file, or relative path from Application folder.


### PR DESCRIPTION
This is to enable the ble support on infineon pse84 boards,  kit_pse84_eval and kit_pse84_ai.  Both the kits use hci uart transport to communicate to the connectivity chip based on CYW55513.

This PR includes the below changes

1.  drivers: serial: infineon: updated hardware flow control support

    Update the Infineon PDL UART driver to support Zephyr's standard
    UART hardware flow control configuration.

    Flow control is now derived from uart_config.flow_control allowing
    applications to enable RTS/CTS using the generic UART API and
    devicetree settings

    configure the RTS rx fifo trigger level when flow control is enabled

2.  drivers: bluetooth: update Infineon HCI UART transport for CYW55513

    Introduces common Kconfig configurations for the CYW55513 connectivity
    module, supporting both Murata 2FY and discrete implementations.

    Additionally, updates the HCI driver to include a new vendor-specific
    command required for updating the SCO route to PCM

3.  hal_infineon: btstack-integration: add CYW55513 firmware integration

    Updates the build system within the BT stack integration layer to
    identify and include the Bluetooth controller firmware images for the
    CYW55513 connectivity module.

4.  boards: infineon: kit_pse84_eval: enable ble support

    This update configures the board to support the CYW55513 connectivity
    module by enabling the required Kconfig symbols and defining the
    HCI UART interface in the Devicetree

    Changes:
    - dts: Enable the Infineon HCI UART node with hardware flow control.
    - pinctrl:  Configured UART pins (TX, RX) and hardware flow control
      pins (RTS, CTS) specifically for the Bluetooth HCI interface
    - defconfig: Adjusted CONFIG_MAIN_STACK_SIZE to provide sufficient
      headroom for the Bluetooth HCI driver and event processing.
    - kconfig: make AIROC_WIFI6 selection conditional on WIFI to fix
      dependency warnings in BLE-only builds.

5.   boards: infineon: kit_pse84_ai: enable ble support

      This update configures the board to support the CYW55513
      Murata 2FY connectivity module by enabling the required
      Kconfig symbols and defining the HCI UART interface in
      the Devicetree
  
      Changes:
      - dts: Enable the Infineon HCI UART node with hardware flow control.
      - pinctrl:  Configured UART pins (TX, RX) and hardware flow control
        pins (RTS, CTS) specifically for the Bluetooth HCI interface
      - defconfig: Adjusted CONFIG_MAIN_STACK_SIZE to provide sufficient
        headroom for the Bluetooth HCI driver and event processing.
