### PR TITLE
boards: infineon: cy8ckit_041s_max: add watchdog support

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
@@ -8,6 +8,12 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "cy8ckit_041s_max-pinctrl.dtsi"
 
+/ {
+	aliases {
+		watchdog0 = &watchdog0;
+	};
+};
+
 uart2: &scb2 {
 	compatible = "infineon,uart";
 	status = "okay";
@@ -68,5 +74,9 @@ spi1: &scb1 {
 };
 
 &gpio_prt7 {
+	status = "okay";
+};
+
+&watchdog0 {
 	status = "okay";
 };

--- a/drivers/watchdog/wdt_infineon.c
+++ b/drivers/watchdog/wdt_infineon.c
@@ -339,6 +339,13 @@ static int ifx_cat1_wdt_setup(const struct device *dev, uint8_t options)
 		k_yield();
 	}
 
+	/* Ensure compensated count fits in 16-bit WDT match register */
+	if (dev_data->ilo_compensated_counts > UINT16_MAX) {
+		LOG_WRN("ILO compensated count %u exceeds 16-bit match register, clamping to %u",
+			dev_data->ilo_compensated_counts, UINT16_MAX);
+		dev_data->ilo_compensated_counts = UINT16_MAX;
+	}
+
 	Cy_WDT_SetIgnoreBits(dev_data->wdt_ignore_bits);
 	Cy_WDT_SetMatch(dev_data->ilo_compensated_counts);
 #elif defined(CY_IP_MXS40SRSS) && (CY_IP_MXS40SRSS_VERSION >= 2)

--- a/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
@@ -214,6 +214,13 @@
 			status = "disabled";
 		};
 
+		watchdog0: watchdog@40030000 {
+			compatible = "infineon,watchdog";
+			reg = <0x40030000 0xf1c>;
+			interrupts = <6 0>;
+			status = "disabled";
+		};
+
 		tcpwm0: tcpwm0@40200000 {
 			reg = <0x40200000 0x300>;
 			#address-cells = <1>;


### PR DESCRIPTION
Add WDT (watchdog timer) support for the CY8CKIT-041S-MAX board.

- Add the watchdog peripheral node to the PSOC 4100S Max SoC devicetree
- Enable the watchdog and add the watchdog0 alias on the board
- Fix a driver bug where Cy_SysClk_IloCompensate could return a value
  exceeding the 16-bit WDT match register on S8SRSSLT devices, causing
  a HardFault via HAL assertion

Tested on hardware with both the watchdog sample and wdt_basic_api test.