### PR TITLE
drivers: hwinfo: add Bouffalo Lab BL70x hardware info driver

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_HWINFO_AMBIQ hwinfo_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_ANDES hwinfo_andes.c)
+zephyr_library_sources_ifdef(CONFIG_HWINFO_BFLB hwinfo_bflb.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_CC13XX_CC26XX hwinfo_cc13xx_cc26xx.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_CC23X0 hwinfo_cc23x0.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_ESP32 hwinfo_esp32.c)

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -28,6 +28,7 @@ config HWINFO_SHELL
 # zephyr-keep-sorted-start
 rsource "Kconfig.ambiq"
 rsource "Kconfig.andes"
+rsource "Kconfig.bflb"
 rsource "Kconfig.cc13xx_cc26xx"
 rsource "Kconfig.cc23x0"
 rsource "Kconfig.esp32"

--- a/drivers/hwinfo/Kconfig.bflb
+++ b/drivers/hwinfo/Kconfig.bflb
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config HWINFO_BFLB
+	bool "Bouffalo Lab hwinfo driver"
+	default y
+	depends on SOC_FAMILY_BFLB
+	depends on SYSCON_BFLB_EFUSE
+	select HWINFO_HAS_DRIVER
+	help
+	  Enable Bouffalo Lab hwinfo driver.
+	  Uses the factory-programmed MAC address from efuse as a unique
+	  device ID.

--- a/drivers/hwinfo/hwinfo_bflb.c
+++ b/drivers/hwinfo/hwinfo_bflb.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/syscon.h>
+#include <zephyr/sys/byteorder.h>
+
+/*
+ * All BFLB SoCs (BL602, BL702, BL702L, BL616) store a factory-programmed
+ * MAC address in efuse at offset 0x14 (low 32 bits) and 0x18 (high 32 bits,
+ * only lower 16 bits used for MAC, bits 21:16 are parity). The MAC is stored
+ * in little-endian order and must be byte-swapped to network (big-endian)
+ * order so the OUI occupies the first three bytes.
+ */
+#define EFUSE_WIFI_MAC_LOW_OFFSET  0x14
+#define EFUSE_WIFI_MAC_HIGH_OFFSET 0x18
+#define DEVICE_ID_LENGTH           6
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	const struct device *efuse = DEVICE_DT_GET(DT_NODELABEL(efuse));
+	uint32_t mac_low, mac_high;
+	uint8_t id[DEVICE_ID_LENGTH];
+	int err;
+
+	if (!device_is_ready(efuse)) {
+		return -ENODEV;
+	}
+
+	err = syscon_read_reg(efuse, EFUSE_WIFI_MAC_LOW_OFFSET, &mac_low);
+	if (err != 0) {
+		return err;
+	}
+
+	err = syscon_read_reg(efuse, EFUSE_WIFI_MAC_HIGH_OFFSET, &mac_high);
+	if (err != 0) {
+		return err;
+	}
+
+	/* Convert from efuse little-endian to network byte order */
+	sys_put_be16((uint16_t)mac_high, &id[0]);
+	sys_put_be32(mac_low, &id[2]);
+
+	length = MIN(length, sizeof(id));
+	memcpy(buffer, id, length);
+
+	return length;
+}


### PR DESCRIPTION
Add a hardware info driver for the Bouffalo Lab BL70x SoC family that reads the unique device ID from the on-chip efuse.

Tested on Sipeed M0Sense (BL702).