### PR TITLE
i2c: dw: Add IC_CLK_FREQ_OPTIMIZATION support and refine SCL timing configuration

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -41,3 +41,16 @@ config I2C_DW_PM_POLICY_STATE_LOCK
 	help
 	  Enable this option to block power management policy state changes
 	  during I2C transfers.
+
+config I2C_DW_IC_CLK_FREQ_OPTIMIZATION
+	bool "Core Clock Frequency Optimization"
+	depends on I2C_DW
+	help
+	  Enable hardware optimization to reduce the required I2C core clock frequency.
+
+	  This features reduces the internal latency cycles required to generate the
+	  SCL high and low periods, allowing the controller to achieve target bus
+	  speeds with a lower system clock frequency (ic_clk).
+
+	  Enable this option only if your hardware IP supports this specific latency
+	  reduction feature.

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -963,6 +963,8 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	const struct i2c_dw_rom_config *const rom = dev->config;
+	uint32_t lcnt_val = 0U;
+	uint32_t hcnt_val = 0U;
 	uint32_t value = 0U;
 	uint32_t rc = 0U;
 	uint32_t reg_base = get_regs(dev);
@@ -973,71 +975,21 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 	/* and have setup the clock frequency and speed mode */
 	switch (I2C_SPEED_GET(dw->app_config)) {
 	case I2C_SPEED_STANDARD:
-		/* Following the directions on DW spec page 59, IC_SS_SCL_LCNT
-		 * must have register values larger than IC_FS_SPKLEN + 7
-		 */
-		value = I2C_STD_LCNT + rom->lcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
-		dw->lcnt = value;
-
-		/* Following the directions on DW spec page 59, IC_SS_SCL_HCNT
-		 * must have register values larger than IC_FS_SPKLEN + 5
-		 */
-		value = I2C_STD_HCNT + rom->hcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
-		dw->hcnt = value;
+		lcnt_val = I2C_STD_LCNT + rom->lcnt_offset;
+		hcnt_val = I2C_STD_HCNT + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_FAST:
-		/*
-		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT
-		 * must have register values larger than IC_FS_SPKLEN + 7
-		 */
-		value = I2C_FS_LCNT + rom->lcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
-		dw->lcnt = value;
-
-		/*
-		 * Following the directions on DW spec page 59, IC_FS_SCL_HCNT
-		 * must have register values larger than IC_FS_SPKLEN + 5
-		 */
-		value = I2C_FS_HCNT + rom->hcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
-		dw->hcnt = value;
+		lcnt_val = I2C_FS_LCNT + rom->lcnt_offset;
+		hcnt_val = I2C_FS_HCNT + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_FAST_PLUS:
-		/*
-		 * Following the directions on DW spec page 59, IC_FS_SCL_LCNT
-		 * must have register values larger than IC_FS_SPKLEN + 7
-		 */
-		value = I2C_FSP_LCNT + rom->lcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
-		dw->lcnt = value;
-
-		/*
-		 * Following the directions on DW spec page 59, IC_FS_SCL_HCNT
-		 * must have register values larger than IC_FS_SPKLEN + 5
-		 */
-		value = I2C_FSP_HCNT + rom->hcnt_offset;
-		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
-		dw->hcnt = value;
+		lcnt_val = I2C_FSP_LCNT + rom->lcnt_offset;
+		hcnt_val = I2C_FSP_HCNT + rom->hcnt_offset;
 		break;
 	case I2C_SPEED_HIGH:
 		if (dw->support_hs_mode) {
-			/*
-			 * Following the directions on DW spec page 59, IC_HS_SCL_LCNT
-			 * must have register values larger than IC_HS_SPKLEN + 7
-			 */
-			value = I2C_HS_LCNT + rom->lcnt_offset;
-			value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->hs_spk_len);
-			dw->lcnt = value;
-
-			/*
-			 * Following the directions on DW spec page 59, IC_HS_SCL_LCNT
-			 * must have register values larger than IC_HS_SPKLEN + 5
-			 */
-			value = I2C_HS_HCNT + rom->hcnt_offset;
-			value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->hs_spk_len);
-			dw->hcnt = value;
+			lcnt_val = I2C_HS_LCNT + rom->lcnt_offset;
+			hcnt_val = I2C_HS_HCNT + rom->hcnt_offset;
 		} else {
 			rc = -EINVAL;
 		}
@@ -1046,6 +998,20 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		/* TODO change */
 		rc = -EINVAL;
 	}
+
+	if (I2C_SPEED_GET(dw->app_config) == I2C_SPEED_HIGH) {
+		/* Ensure minimum HCNT and LCNT register values for High Speed */
+		lcnt_val = I2C_ENSURE_MIN_SCL_LCNT(lcnt_val, rom->hs_spk_len);
+		hcnt_val = I2C_ENSURE_MIN_SCL_HCNT(hcnt_val, rom->hs_spk_len);
+	} else {
+		/* Ensure minimum HCNT and LCNT register values for:
+		 * Standard, Fast and Fast Plus Speed modes
+		 */
+		lcnt_val = I2C_ENSURE_MIN_SCL_LCNT(lcnt_val, rom->fs_spk_len);
+		hcnt_val = I2C_ENSURE_MIN_SCL_HCNT(hcnt_val, rom->fs_spk_len);
+	}
+	dw->lcnt = lcnt_val;
+	dw->hcnt = hcnt_val;
 
 	/*
 	 * Clear any interrupts currently waiting in the controller

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -635,7 +635,6 @@ done:
 
 static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 {
-	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 	uint32_t value;
 	union ic_con_register ic_con;
@@ -692,7 +691,6 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		LOG_DBG("I2C: speed set to STANDARD");
 		write_ss_scl_lcnt(dw->lcnt, reg_base);
 		write_ss_scl_hcnt(dw->hcnt, reg_base);
-		write_fs_spklen(rom->fs_spk_len, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_STANDARD;
 
 		break;
@@ -702,7 +700,6 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		LOG_DBG("I2C: speed set to FAST or FAST_PLUS");
 		write_fs_scl_lcnt(dw->lcnt, reg_base);
 		write_fs_scl_hcnt(dw->hcnt, reg_base);
-		write_fs_spklen(rom->fs_spk_len, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_FAST;
 
 		break;
@@ -714,7 +711,6 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 		LOG_DBG("I2C: speed set to HIGH");
 		write_hs_scl_lcnt(dw->lcnt, reg_base);
 		write_hs_scl_hcnt(dw->hcnt, reg_base);
-		write_hs_spklen(rom->hs_spk_len, reg_base);
 		ic_con.bits.speed = I2C_DW_SPEED_HIGH;
 
 		break;
@@ -1360,6 +1356,10 @@ static int i2c_dw_initialize(const struct device *dev)
 	}
 
 	rom->config_func(dev);
+
+	/* Set spike length */
+	write_fs_spklen(rom->fs_spk_len, reg_base);
+	write_hs_spklen(rom->hs_spk_len, reg_base);
 
 	dw->app_config = I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(rom->bitrate);
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -977,20 +977,14 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * must have register values larger than IC_FS_SPKLEN + 7
 		 */
 		value = I2C_STD_LCNT + rom->lcnt_offset;
-		if (value <= (rom->fs_spk_len + 7)) {
-			value = rom->fs_spk_len + 8;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
 		dw->lcnt = value;
 
 		/* Following the directions on DW spec page 59, IC_SS_SCL_HCNT
 		 * must have register values larger than IC_FS_SPKLEN + 5
 		 */
 		value = I2C_STD_HCNT + rom->hcnt_offset;
-		if (value <= (rom->fs_spk_len + 5)) {
-			value = rom->fs_spk_len + 6;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
 		dw->hcnt = value;
 		break;
 	case I2C_SPEED_FAST:
@@ -999,10 +993,7 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * must have register values larger than IC_FS_SPKLEN + 7
 		 */
 		value = I2C_FS_LCNT + rom->lcnt_offset;
-		if (value <= (rom->fs_spk_len + 7)) {
-			value = rom->fs_spk_len + 8;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
 		dw->lcnt = value;
 
 		/*
@@ -1010,10 +1001,7 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * must have register values larger than IC_FS_SPKLEN + 5
 		 */
 		value = I2C_FS_HCNT + rom->hcnt_offset;
-		if (value <= (rom->fs_spk_len + 5)) {
-			value = rom->fs_spk_len + 6;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
 		dw->hcnt = value;
 		break;
 	case I2C_SPEED_FAST_PLUS:
@@ -1022,10 +1010,7 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * must have register values larger than IC_FS_SPKLEN + 7
 		 */
 		value = I2C_FSP_LCNT + rom->lcnt_offset;
-		if (value <= (rom->fs_spk_len + 7)) {
-			value = rom->fs_spk_len + 8;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->fs_spk_len);
 		dw->lcnt = value;
 
 		/*
@@ -1033,26 +1018,25 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 		 * must have register values larger than IC_FS_SPKLEN + 5
 		 */
 		value = I2C_FSP_HCNT + rom->hcnt_offset;
-		if (value <= (rom->fs_spk_len + 5)) {
-			value = rom->fs_spk_len + 6;
-		}
-
+		value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->fs_spk_len);
 		dw->hcnt = value;
 		break;
 	case I2C_SPEED_HIGH:
 		if (dw->support_hs_mode) {
+			/*
+			 * Following the directions on DW spec page 59, IC_HS_SCL_LCNT
+			 * must have register values larger than IC_HS_SPKLEN + 7
+			 */
 			value = I2C_HS_LCNT + rom->lcnt_offset;
-			if (value <= (rom->hs_spk_len + 7)) {
-				value = rom->hs_spk_len + 8;
-			}
-
+			value = I2C_ENSURE_MIN_SCL_LCNT(value, rom->hs_spk_len);
 			dw->lcnt = value;
 
+			/*
+			 * Following the directions on DW spec page 59, IC_HS_SCL_LCNT
+			 * must have register values larger than IC_HS_SPKLEN + 5
+			 */
 			value = I2C_HS_HCNT + rom->hcnt_offset;
-			if (value <= (rom->hs_spk_len + 5)) {
-				value = rom->hs_spk_len + 6;
-			}
-
+			value = I2C_ENSURE_MIN_SCL_HCNT(value, rom->hs_spk_len);
 			dw->hcnt = value;
 		} else {
 			rc = -EINVAL;

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -78,8 +78,30 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 #define I2C_HS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
 #define I2C_HS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
 
+#ifdef CONFIG_I2C_DW_IC_CLK_FREQ_OPTIMIZATION
+
 /* The below SCL macros calculations are valid
- * if CONFIG_IC_CLK_FREQ_OPTIMIZATION is off
+ * if IC_CLK_FREQ_OPTIMIZATION is on
+ * Refer section 2.14.2 of DW spec
+ */
+
+#define I2C_MIN_SCL_LCNT         6
+#define I2C_MIN_SCL_HCNT         5
+#define I2C_SCL_HCNT_OFFSET      3
+
+/* Min SCL High Time is 5 cycles. High Time = HCNT + spike_len + 3 */
+#define I2C_ENSURE_MIN_SCL_HCNT(x, spk_len)    \
+	((((x) + (spk_len) + I2C_SCL_HCNT_OFFSET) < I2C_MIN_SCL_HCNT) ? \
+	(I2C_MIN_SCL_HCNT - ((spk_len) + I2C_SCL_HCNT_OFFSET)) : (x))
+
+/* Min SCL Low Time is 6 cycles */
+#define I2C_ENSURE_MIN_SCL_LCNT(x, spk_len)    \
+	(((x) < I2C_MIN_SCL_LCNT) ? I2C_MIN_SCL_LCNT : (x))
+
+#else /* CONFIG_I2C_DW_IC_CLK_FREQ_OPTIMIZATION */
+
+/* The below SCL macros calculations are valid
+ * if IC_CLK_FREQ_OPTIMIZATION is off
  * Refer section 2.14.1 of DW spec
  */
 #define I2C_MIN_SCL_LCNT(spk)  ((spk) + 8)
@@ -94,6 +116,8 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 #define I2C_ENSURE_MIN_SCL_LCNT(x, spk_len)	\
 	(((x) < I2C_MIN_SCL_LCNT(spk_len)) ?	\
 	I2C_MIN_SCL_LCNT(spk_len) : (x))
+
+#endif /* CONFIG_I2C_DW_IC_CLK_FREQ_OPTIMIZATION */
 
 /*
  * DesignWare speed values don't directly translate from the Zephyr speed

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -78,6 +78,23 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 #define I2C_HS_HCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 6) / 8)
 #define I2C_HS_LCNT  ((CONFIG_I2C_DW_CLOCK_SPEED * 7) / 8)
 
+/* The below SCL macros calculations are valid
+ * if CONFIG_IC_CLK_FREQ_OPTIMIZATION is off
+ * Refer section 2.14.1 of DW spec
+ */
+#define I2C_MIN_SCL_LCNT(spk)  ((spk) + 8)
+#define I2C_MIN_SCL_HCNT(spk)  ((spk) + 6)
+
+/* Min SCL High Time is spike_len + 6 cycles */
+#define I2C_ENSURE_MIN_SCL_HCNT(x, spk_len)	\
+	(((x) < I2C_MIN_SCL_HCNT(spk_len)) ?	\
+	I2C_MIN_SCL_HCNT(spk_len) : (x))
+
+/* Min SCL Low Time is spike_len + 8 cycles */
+#define I2C_ENSURE_MIN_SCL_LCNT(x, spk_len)	\
+	(((x) < I2C_MIN_SCL_LCNT(spk_len)) ?	\
+	I2C_MIN_SCL_LCNT(spk_len) : (x))
+
 /*
  * DesignWare speed values don't directly translate from the Zephyr speed
  * selections in include/i2c.h so here we do a little translation


### PR DESCRIPTION
The PR mainly contains:
1. I2C's SCL updates:
    - Introduce support for the DesignWare I2C specific core clock frequency 
      optimization feature (IC_CLK_FREQ_OPTIMIZATION).
    - This feature reduces the internal latency cycles required to generate
       the SCL high and low periods, allowing the controller to achieve target
       bus speeds with a lower input clock (ic_clk) frequency.
    - Replace hardcoded magic numbers for SCL High and Low Count register
       minimum values with descriptive macros.

2. Spike length filter code:
    - Move the spike length setting to the common initialization function
       to ensure it is applied for both master and slave modes.