### PR TITLE
bluetooth: host: add support for CS IPT procedures

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -675,6 +675,24 @@ struct bt_conn_le_cs_capabilities {
 	 *  - Bit 4: 30dB
 	 */
 	uint8_t tx_snr_capability;
+	/** Supported T_IP2_IPT time durations during CS steps.
+	 *
+	 *  - Bit 0: 10 us
+	 *  - Bit 1: 20 us
+	 *  - Bit 2: 30 us
+	 *  - Bit 3: 40 us
+	 *  - Bit 4: 50 us
+	 *  - Bit 5: 60 us
+	 *  - Bit 6: 80 us
+	 */
+	uint16_t t_ip2_ipt_times_supported;
+	/** Supported time in microseconds for the antenna switch period of the
+	 *  CS tones during IPT.
+	 *
+	 *  0x00, 0x01, 0x02, 0x04, or 0x0A - Time in microseconds for the
+	 *  antenna switch period of the CS tones
+	 */
+	uint8_t t_sw_ipt_time_supported;
 };
 
 /** Remote FAE Table for LE connections supporting CS */
@@ -825,6 +843,11 @@ struct bt_conn_le_cs_config {
 	enum bt_conn_le_cs_ch3c_shape ch3c_shape;
 	/** Number of channels skipped in each rising and falling sequence  */
 	uint8_t ch3c_jump;
+	/** CS enhancements 1
+	 *  Bit 0 - IPT is enabled in the CS reflector.
+	 *  All other bits are reserved and shall be set to 0.
+	 */
+	uint8_t cs_enhancements_1;
 	/** Interlude time in microseconds between the RTT packets */
 	uint8_t t_ip1_time_us;
 	/** Interlude time in microseconds between the CS tones */

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -498,6 +498,12 @@ struct bt_le_cs_create_config_params {
 	enum bt_conn_le_cs_rtt_type rtt_type;
 	/** CS Sync PHY */
 	enum bt_conn_le_cs_sync_phy cs_sync_phy;
+	/** Channel map used for CS procedure
+	 *  Channels n = 0, 1, 23, 24, 25, 77, and 78 are not allowed and shall be set to zero.
+	 *  Channel 79 is reserved for future use and shall be set to zero.
+	 *  At least 15 channels shall be enabled.
+	 */
+	 uint8_t channel_map[10];
 	/** The number of times the Channel_Map field will be cycled through for non-mode-0 steps
 	 * within a CS procedure
 	 */
@@ -508,12 +514,8 @@ struct bt_le_cs_create_config_params {
 	enum bt_conn_le_cs_ch3c_shape ch3c_shape;
 	/** Number of channels skipped in each rising and falling sequence  */
 	uint8_t ch3c_jump;
-	/** Channel map used for CS procedure
-	 *  Channels n = 0, 1, 23, 24, 25, 77, and 78 are not allowed and shall be set to zero.
-	 *  Channel 79 is reserved for future use and shall be set to zero.
-	 *  At least 15 channels shall be enabled.
-	 */
-	uint8_t channel_map[10];
+	/** CS enhancements 1 */
+	uint8_t cs_enhancements_1;
 };
 
 /** Callbacks for CS Test */
@@ -665,7 +667,7 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params);
 int bt_le_cs_create_config(struct bt_conn *conn, struct bt_le_cs_create_config_params *params,
 			   enum bt_le_cs_create_config_context context);
 
-/** @brief Create CS configuration
+/** @brief Remove CS configuration
  *
  * This command is used to remove a CS configuration from the local controller
  * identified by the config_id
@@ -852,6 +854,19 @@ int bt_le_cs_set_channel_classification(uint8_t channel_classification[10]);
  */
 int bt_le_cs_read_local_supported_capabilities(struct bt_conn_le_cs_capabilities *ret);
 
+/** @brief CS Read Local Supported Capabilities V2
+ *
+ *  This command is used to read the CS capabilities that are supported
+ *  by the local Controller.
+ *
+ * @note To use this API @kconfig{CONFIG_BT_CHANNEL_SOUNDING} must be set.
+ *
+ * @param ret Return values for the CS Procedure Enable command.
+ *
+ * @return Zero on success or (negative) error code on failure.
+ */
+int bt_le_cs_read_local_supported_capabilities_v2(struct bt_conn_le_cs_capabilities *ret);
+
 /** @brief CS Write Cached Remote Supported Capabilities
  *
  *  This command is used to write the cached copy of the CS capabilities
@@ -866,6 +881,22 @@ int bt_le_cs_read_local_supported_capabilities(struct bt_conn_le_cs_capabilities
  * @return Zero on success or (negative) error code on failure.
  */
 int bt_le_cs_write_cached_remote_supported_capabilities(
+	struct bt_conn *conn, const struct bt_conn_le_cs_capabilities *params);
+
+/** @brief CS Write Cached Remote Supported Capabilities V2
+ *
+ *  This command is used to write the cached copy of the CS capabilities
+ *  that are supported by the remote Controller for the connection
+ *  identified.
+ *
+ * @note To use this API @kconfig{CONFIG_BT_CHANNEL_SOUNDING} must be set.
+ *
+ * @param conn   Connection Object.
+ * @param params Parameters for the CS Write Cached Remote Supported Capabilities command.
+ *
+ * @return Zero on success or (negative) error code on failure.
+ */
+int bt_le_cs_write_cached_remote_supported_capabilities_v2(
 	struct bt_conn *conn, const struct bt_conn_le_cs_capabilities *params);
 
 /** @brief CS Write Cached Remote FAE Table

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -2602,6 +2602,62 @@ struct bt_hci_rp_le_read_local_supported_capabilities {
 	uint8_t  tx_snr_capability;
 } __packed;
 
+/** HCI opcode for LE Read Local Supported Capabilities (v2). */
+#define BT_HCI_OP_LE_CS_READ_LOCAL_SUPPORTED_CAPABILITIES_V2 BT_OP(BT_OGF_LE, 0x00A5) /* 0x20A5 */
+/** Test if LE Read Local Supported Capabilities v2 command is supported (octet 49, bit 2). */
+#define BT_LE_CS_READ_LOCAL_SUPPORTED_CAPABILITIES_V2_SUPPORTED(cmd) \
+	BT_CMD_TEST(cmd, 49, 2)
+
+/** HCI response parameters for LE Read Local Supported Capabilities command (v2). */
+struct bt_hci_rp_le_read_local_supported_capabilities_v2 {
+	/** Status. */
+	uint8_t  status;
+	/** Number of CS configurations supported. */
+	uint8_t  num_config_supported;
+	/** Maximum consecutive procedures supported. */
+	uint16_t max_consecutive_procedures_supported;
+	/** Number of antennas supported. */
+	uint8_t  num_antennas_supported;
+	/** Maximum antenna paths supported. */
+	uint8_t  max_antenna_paths_supported;
+	/** Roles supported. */
+	uint8_t  roles_supported;
+	/** Modes supported. */
+	uint8_t  modes_supported;
+	/** RTT capability. */
+	uint8_t  rtt_capability;
+	/** RTT AA-only N. */
+	uint8_t  rtt_aa_only_n;
+	/** RTT sounding N. */
+	uint8_t  rtt_sounding_n;
+	/** RTT random payload N. */
+	uint8_t  rtt_random_payload_n;
+	/** NADM sounding capability. */
+	uint16_t nadm_sounding_capability;
+	/** NADM random capability. */
+	uint16_t nadm_random_capability;
+	/** CS sync PHYs supported. */
+	uint8_t  cs_sync_phys_supported;
+	/** Subfeatures supported. */
+	uint16_t subfeatures_supported;
+	/** T_IP1 times supported. */
+	uint16_t t_ip1_times_supported;
+	/** T_IP2 times supported. */
+	uint16_t t_ip2_times_supported;
+	/** T_FCS times supported. */
+	uint16_t t_fcs_times_supported;
+	/** T_PM times supported. */
+	uint16_t t_pm_times_supported;
+	/** T_SW time supported. */
+	uint8_t  t_sw_time_supported;
+	/** TX SNR capability. */
+	uint8_t  tx_snr_capability;
+	/** T_IP2 IPT times supported. */
+	uint16_t  t_ip2_ipt_times_supported;
+	/** T_SW IPT time supported. */
+	uint8_t  t_sw_ipt_time_supported;
+} __packed;
+
 #define BT_HCI_OP_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES BT_OP(BT_OGF_LE, 0x008A) /* 0x208A */
 
 struct bt_hci_cp_le_read_remote_supported_capabilities {
@@ -2633,6 +2689,60 @@ struct bt_hci_cp_le_write_cached_remote_supported_capabilities {
 	uint16_t t_pm_times_supported;
 	uint8_t  t_sw_time_supported;
 	uint8_t  tx_snr_capability;
+} __packed;
+
+/** HCI opcode for LE CS Write Cached Remote Supported Capabilities (v2). */
+#define BT_HCI_OP_LE_CS_WRITE_CACHED_REMOTE_SUPPORTED_CAPABILITIES_V2 \
+	BT_OP(BT_OGF_LE, 0x00A6) /* 0x20A6 */
+
+/** HCI command parameters for LE CS Write Cached Remote Supported Capabilities (v2). */
+struct bt_hci_cp_le_write_cached_remote_supported_capabilities_v2 {
+	/** Connection handle. */
+	uint16_t handle;
+	/** Number of CS configurations supported. */
+	uint8_t  num_config_supported;
+	/** Maximum consecutive procedures supported. */
+	uint16_t max_consecutive_procedures_supported;
+	/** Number of antennas supported. */
+	uint8_t  num_antennas_supported;
+	/** Maximum antenna paths supported. */
+	uint8_t  max_antenna_paths_supported;
+	/** Roles supported. */
+	uint8_t  roles_supported;
+	/** Modes supported. */
+	uint8_t  modes_supported;
+	/** RTT capability. */
+	uint8_t  rtt_capability;
+	/** RTT AA-only N. */
+	uint8_t  rtt_aa_only_n;
+	/** RTT sounding N. */
+	uint8_t  rtt_sounding_n;
+	/** RTT random payload N. */
+	uint8_t  rtt_random_payload_n;
+	/** NADM sounding capability. */
+	uint16_t nadm_sounding_capability;
+	/** NADM random capability. */
+	uint16_t nadm_random_capability;
+	/** CS sync PHYs supported. */
+	uint8_t  cs_sync_phys_supported;
+	/** Subfeatures supported. */
+	uint16_t subfeatures_supported;
+	/** T_IP1 times supported. */
+	uint16_t t_ip1_times_supported;
+	/** T_IP2 times supported. */
+	uint16_t t_ip2_times_supported;
+	/** T_FCS times supported. */
+	uint16_t t_fcs_times_supported;
+	/** T_PM times supported. */
+	uint16_t t_pm_times_supported;
+	/** T_SW time supported. */
+	uint8_t  t_sw_time_supported;
+	/** TX SNR capability. */
+	uint8_t  tx_snr_capability;
+	/** T_IP2 IPT times supported. */
+	uint16_t  t_ip2_ipt_times_supported;
+	/** T_SW IPT time supported. */
+	uint8_t  t_sw_ipt_time_supported;
 } __packed;
 
 #define BT_HCI_OP_LE_CS_SECURITY_ENABLE BT_OP(BT_OGF_LE, 0x008C) /* 0x208C */
@@ -2841,7 +2951,8 @@ struct bt_hci_op_le_cs_test {
 	uint8_t  t_pm_time;
 	uint8_t  t_sw_time;
 	uint8_t  tone_antenna_config_selection;
-	uint8_t  reserved;
+	/** CS enhancements 1. */
+	uint8_t  cs_enhancements_1;
 	uint8_t  snr_control_initiator;
 	uint8_t  snr_control_reflector;
 	uint16_t drbg_nonce;
@@ -2871,7 +2982,8 @@ struct bt_hci_cp_le_cs_create_config {
 	uint8_t  channel_selection_type;
 	uint8_t  ch3c_shape;
 	uint8_t  ch3c_jump;
-	uint8_t  reserved;
+	/** CS enhancements 1. */
+	uint8_t  cs_enhancements_1;
 } __packed;
 
 #define BT_HCI_OP_LE_CS_REMOVE_CONFIG BT_OP(BT_OGF_LE, 0x0091) /* 0x2091 */
@@ -3847,6 +3959,7 @@ struct bt_hci_evt_le_read_all_remote_feat_complete {
 #define BT_HCI_LE_CS_TX_SNR_CAPABILITY_30DB_MASK BIT(4)
 
 #define BT_HCI_EVT_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE 0x2C
+
 struct bt_hci_evt_le_cs_read_remote_supported_capabilities_complete {
 	uint8_t  status;
 	uint16_t conn_handle;
@@ -3870,6 +3983,61 @@ struct bt_hci_evt_le_cs_read_remote_supported_capabilities_complete {
 	uint16_t t_pm_times_supported;
 	uint8_t  t_sw_time_supported;
 	uint8_t  tx_snr_capability;
+} __packed;
+
+/** HCI LE CS Read Remote Supported Capabilities Complete event (v2). */
+#define BT_HCI_EVT_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE_V2 0x38
+
+/** HCI event parameters for LE CS Read Remote Supported Capabilities Complete (v2). */
+struct bt_hci_evt_le_cs_read_remote_supported_capabilities_complete_v2 {
+	/** Status. */
+	uint8_t  status;
+	/** Connection handle. */
+	uint16_t conn_handle;
+	/** Number of CS configurations supported. */
+	uint8_t  num_config_supported;
+	/** Maximum consecutive procedures supported. */
+	uint16_t max_consecutive_procedures_supported;
+	/** Number of antennas supported. */
+	uint8_t  num_antennas_supported;
+	/** Maximum antenna paths supported. */
+	uint8_t  max_antenna_paths_supported;
+	/** Roles supported. */
+	uint8_t  roles_supported;
+	/** Modes supported. */
+	uint8_t  modes_supported;
+	/** RTT capability. */
+	uint8_t  rtt_capability;
+	/** RTT AA-only N. */
+	uint8_t  rtt_aa_only_n;
+	/** RTT sounding N. */
+	uint8_t  rtt_sounding_n;
+	/** RTT random payload N. */
+	uint8_t  rtt_random_payload_n;
+	/** NADM sounding capability. */
+	uint16_t nadm_sounding_capability;
+	/** NADM random capability. */
+	uint16_t nadm_random_capability;
+	/** CS sync PHYs supported. */
+	uint8_t  cs_sync_phys_supported;
+	/** Subfeatures supported. */
+	uint16_t subfeatures_supported;
+	/** T_IP1 times supported. */
+	uint16_t t_ip1_times_supported;
+	/** T_IP2 times supported. */
+	uint16_t t_ip2_times_supported;
+	/** T_FCS times supported. */
+	uint16_t t_fcs_times_supported;
+	/** T_PM times supported. */
+	uint16_t t_pm_times_supported;
+	/** T_SW time supported. */
+	uint8_t  t_sw_time_supported;
+	/** TX SNR capability. */
+	uint8_t  tx_snr_capability;
+	/** T_IP2 IPT times supported. */
+	uint16_t t_ip2_ipt_times_supported;
+	/** T_SW IPT time supported. */
+	uint8_t  t_sw_ipt_time_supported;
 } __packed;
 
 #define BT_HCI_EVT_LE_CS_READ_REMOTE_FAE_TABLE_COMPLETE 0x2D
@@ -3908,7 +4076,8 @@ struct bt_hci_evt_le_cs_config_complete {
 	uint8_t  channel_selection_type;
 	uint8_t  ch3c_shape;
 	uint8_t  ch3c_jump;
-	uint8_t  reserved;
+	/** CS enhancements 1. */
+	uint8_t  cs_enhancements_1;
 	uint8_t  t_ip1_time;
 	uint8_t  t_ip2_time;
 	uint8_t  t_fcs_time;
@@ -4299,6 +4468,9 @@ struct bt_hci_evt_le_conn_rate_change {
 
 #define BT_EVT_MASK_LE_FRAME_SPACE_UPDATE_COMPLETE BT_EVT_BIT(52)
 #define BT_EVT_MASK_LE_CONN_RATE_CHANGE            BT_EVT_BIT(54)
+
+/** Event mask for LE CS Read Remote Supported Capabilities Complete (v2). */
+#define BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE_V2 BT_EVT_BIT(55)
 
 /** HCI Error Codes, BT Core Spec v5.4 [Vol 1, Part F]. */
 #define BT_HCI_ERR_SUCCESS                      0x00

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3071,17 +3071,21 @@ static const struct event_handler meta_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE,
 		      bt_hci_le_cs_read_remote_supported_capabilities_complete,
 		      sizeof(struct bt_hci_evt_le_cs_read_remote_supported_capabilities_complete)),
+	EVENT_HANDLER(BT_HCI_EVT_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE_V2,
+		      bt_hci_le_cs_read_remote_supported_capabilities_complete_v2,
+		      sizeof(
+		      struct bt_hci_evt_le_cs_read_remote_supported_capabilities_complete_v2)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_READ_REMOTE_FAE_TABLE_COMPLETE,
 		      bt_hci_le_cs_read_remote_fae_table_complete,
 		      sizeof(struct bt_hci_evt_le_cs_read_remote_fae_table_complete)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_CONFIG_COMPLETE, bt_hci_le_cs_config_complete_event,
 		      sizeof(struct bt_hci_evt_le_cs_config_complete)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_SECURITY_ENABLE_COMPLETE,
-			  bt_hci_le_cs_security_enable_complete,
-			  sizeof(struct bt_hci_evt_le_cs_security_enable_complete)),
+		      bt_hci_le_cs_security_enable_complete,
+		      sizeof(struct bt_hci_evt_le_cs_security_enable_complete)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_PROCEDURE_ENABLE_COMPLETE,
-			  bt_hci_le_cs_procedure_enable_complete,
-			  sizeof(struct bt_hci_evt_le_cs_procedure_enable_complete)),
+		      bt_hci_le_cs_procedure_enable_complete,
+		      sizeof(struct bt_hci_evt_le_cs_procedure_enable_complete)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_SUBEVENT_RESULT,
 		      bt_hci_le_cs_subevent_result,
 		      sizeof(struct bt_hci_evt_le_cs_subevent_result)),
@@ -3724,6 +3728,13 @@ static int le_set_event_mask(void)
 	if (IS_ENABLED(CONFIG_BT_CHANNEL_SOUNDING) &&
 	    BT_FEAT_LE_CHANNEL_SOUNDING(bt_dev.le.features)) {
 		mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE;
+		/* Only set v2 event mask if controller supports it; v1-only CS controllers
+		 * may reject the Set Event Mask command if an unknown bit is set.
+		 */
+		if (BT_LE_CS_READ_LOCAL_SUPPORTED_CAPABILITIES_V2_SUPPORTED(
+				bt_dev.supported_commands)) {
+			mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE_V2;
+		}
 		mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_FAE_TABLE_COMPLETE;
 		mask |= BT_EVT_MASK_LE_CS_CONFIG_COMPLETE;
 		mask |= BT_EVT_MASK_LE_CS_SECURITY_ENABLE_COMPLETE;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -531,6 +531,7 @@ void bt_hci_le_past_received_v2(struct net_buf *buf);
 
 /* CS HCI event handlers */
 void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct net_buf *buf);
+void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct net_buf *buf);
 void bt_hci_le_cs_read_remote_fae_table_complete(struct net_buf *buf);
 void bt_hci_le_cs_config_complete_event(struct net_buf *buf);
 void bt_hci_le_cs_security_enable_complete(struct net_buf *buf);


### PR DESCRIPTION
Add support for CS IPT (Channel Sounding Inline PCT Transfer) in the Bluetooth host stack.

Changes include:
* definition of new CS IPT HCI opcodes;
* handling of CS IPT control procedures;
* integration with existing CS infrastructure;
* necessary updates to public headers.