### PR TITLE
soc: timer: nrf: patch init order of grtc and nrf54l

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -631,6 +631,7 @@ int nrf_grtc_timer_clock_driver_init(void)
 	return sys_clock_driver_init();
 }
 #else
-SYS_INIT(sys_clock_driver_init, EARLY, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
+/* Init must follow soc init and precede LOG_CORE_INIT() */
+SYS_INIT(sys_clock_driver_init, EARLY, 1);
 SYS_INIT(grtc_post_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
 #endif

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -165,4 +165,5 @@ void arch_busy_wait(uint32_t time_us)
 	nrfx_coredep_delay_us(time_us);
 }
 
-SYS_INIT(nordicsemi_nrf54l_init, PRE_KERNEL_1, 0);
+/* Init must precede sys_clock_driver_init */
+SYS_INIT(nordicsemi_nrf54l_init, EARLY, 0);


### PR DESCRIPTION
The nrf54l soc init configures power and clock properties like applying trims, capacitance and setting up regulators. This must precede the grtc driver initializing the sys clock, as it depends on these clocks being initialized on the nrf54l series socs.

Update the nrf54l soc init to be EARLY 0, and set grtc sys clock driver init to EARLY 1. Additionally add comments explaining why these specific init levels where chosen.