### PR TITLE
doc: releases: Add 4.1 to EOL releases

### DIFF
--- a/doc/releases/eol_releases.rst
+++ b/doc/releases/eol_releases.rst
@@ -20,7 +20,7 @@ Release Notes
    release-notes-1.*
    release-notes-2.[0-6]
    release-notes-3.[0-6]
-   release-notes-4.[0-0]
+   release-notes-4.[0-1]
 
 .. _eol_releases_migration_guides:
 
@@ -33,4 +33,4 @@ Migration Guides
    :reversed:
 
    migration-guide-3.[5-6]
-   migration-guide-4.[0-0]
+   migration-guide-4.[0-1]


### PR DESCRIPTION
When we added v4.3.0 (1d1dace9a268fec), we forgot to move 4.1.0 to EOL. Add 4.1.0 back to the EOL lists for release notes and migration guides.