### PR TITLE
llext: don't emit discarded exports info when CONFIG_LLEXT=n

### DIFF
--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -123,6 +123,7 @@ struct z_llext_discarded_const_symbol {
 
 #define Z_LLEXT_DISCARD_STRTAB Z_GENERIC_SECTION(llext_discarded_exports_strtab)
 
+#ifdef CONFIG_LLEXT
 #define Z_MARKUP_NOT_EXPORTED_SYMBOL(grp, sym_ident, sym_name)		\
 	static const char Z_LLEXT_DISCARD_STRTAB __used				\
 		__llext_sym_name_ ## sym_name[] = STRINGIFY(sym_name);		\
@@ -134,6 +135,11 @@ struct z_llext_discarded_const_symbol {
 			.name = __llext_sym_name_ ## sym_name,			\
 			.group = __llext_sym_group_ ## sym_name,		\
 	};
+#else /* CONFIG_LLEXT */
+/* No extension support in this build */
+#define Z_MARKUP_NOT_EXPORTED_SYMBOL(grp, sym_ident, sym_name)
+#endif /* CONFIG_LLEXT */
+
 /** @endcond */
 
 /** @cond ignore */


### PR DESCRIPTION
In commit 7a671993eacf7542a450d62439c012503b7cda2e a change was introduced that placed variable in llext specific sections, but in the linker script these are guarded by `#ifdef CONFIG_LLEXT`, but not the corresponding C code, so these variables are being put in sections that are not specified in linker scripts. This causes issues with IAR linker, which warns about these orphan sections.