### PR TITLE
drivers: clock_control: stm32_common: fix wrong register name for LSEDRV

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -1013,8 +1013,20 @@ static void set_up_fixed_clock_sources(void)
 		stm32_backup_domain_enable_access();
 
 #if STM32_LSE_DRIVING
+/*
+ * Most series have LSEDRV field in RCC_BDCR register,
+ * but a few series have it in a different one yet are
+ * handled by this driver. Pick proper register name:
+ */
+#define LSE_DRIVING_SHIFT					\
+	COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32C0X),	\
+		(RCC_CSR1_LSEDRV_Pos),				\
+	(COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32L0X),	\
+		(RCC_CSR_LSEDRV_Pos),				\
+		(RCC_BDCR_LSEDRV_Pos))))
+
 		/* Configure driving capability */
-		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
+		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << LSE_DRIVING_SHIFT);
 #endif
 
 		if (IS_ENABLED(STM32_LSE_BYPASS)) {


### PR DESCRIPTION
In a few series managed by the common driver, the `LSEDRV` field is not in `RCC_BDCR` but a different register.

Use proper register name when obtaining the shift to ensure a non-zero driving capability can be used on these series.

Fixes #104253 

Also present in older releases (resp. `v3.7-branch`, `v4.2-branch` and `v4.3-branch`):
https://github.com/zephyrproject-rtos/zephyr/blob/a65c7ffb985ade5f4040efd4249a03c785a635f4/drivers/clock_control/clock_stm32_ll_common.c#L675-L678
https://github.com/zephyrproject-rtos/zephyr/blob/31bb38917dc62824af3494eed2e393937443177f/drivers/clock_control/clock_stm32_ll_common.c#L719-L722
https://github.com/zephyrproject-rtos/zephyr/blob/bb9d2df75e34b909c22e77acde08763f5425606d/drivers/clock_control/clock_stm32_ll_common.c#L954-L957

