### PR TITLE
usb: prevent yielding from usb_write when in isr

### DIFF
--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -60,6 +60,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <bos_desc.h>
+#include <kernel_arch_interface.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/init.h>
@@ -1393,7 +1394,9 @@ int usb_write(uint8_t ep, const uint8_t *data, uint32_t data_len, uint32_t *byte
 		ret = usb_dc_ep_write(ep, data, data_len, bytes_ret);
 		if (ret == -EAGAIN) {
 			LOG_WRN("Failed to write endpoint buffer 0x%02x", ep);
-			k_yield();
+			if (!arch_is_in_isr()) {
+				k_yield();
+			}
 		}
 
 	} while (ret == -EAGAIN && tries--);


### PR DESCRIPTION
There are cases where usb stack calls `usb_write` inside an interrupt handler. `usb_write` explicitly makes use of `k_yield` call inside itself. Calling `k_yield` from inside of an interrupt can lead to an infinite loop inside an interrupt. Therefore, only yield when not inside an interrupt.