### PR TITLE
boards: add zephyr_i2c label and okay status for i2c0 on Silicon Labs Arduino boards

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -179,9 +179,10 @@
 	pinctrl-names = "default";
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &gpio {

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -143,9 +143,10 @@
 	pinctrl-names = "default";
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &gpio {


### PR DESCRIPTION
This increases out-of-the-box compatibility with various shields and drivers and also makes the configuration consistent with other Arduino boards.