### PR TITLE
tests: subsys: logging: log-backend_uart: exclude dt_xt_zb1_devkit

### DIFF
--- a/tests/subsys/logging/log_backend_uart/testcase.yaml
+++ b/tests/subsys/logging/log_backend_uart/testcase.yaml
@@ -9,6 +9,8 @@ common:
   filter: CONFIG_UART_CONSOLE
   integration_platforms:
     - qemu_x86
+  platform_exclude:
+    - dt_xt_zb1_devkit
 tests:
   logging.backend.uart.single:
     extra_args: DTC_OVERLAY_FILE="./single.overlay"


### PR DESCRIPTION
Variant [1/2]

Do not run this test for dt_xt_zb1_devkit as it puts the drivers__serial library in the ITCM region to have early init boot logs working, so has fewer resources than what the "ram:" filter reports, and fewer than what #64917 originally planned for it.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104275