### PR TITLE
soc: bflb: bl70x: relocate uart driver by file

### DIFF
--- a/soc/bflb/bl70x/CMakeLists.txt
+++ b/soc/bflb/bl70x/CMakeLists.txt
@@ -7,7 +7,8 @@ zephyr_sources(soc.c)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")
 
-zephyr_code_relocate_ifdef(CONFIG_UART_BFLB LIBRARY drivers__serial LOCATION ITCM NOKEEP)
+zephyr_code_relocate_ifdef(CONFIG_UART_BFLB FILES ${ZEPHYR_BASE}/drivers/serial/uart_bflb.c
+  LOCATION ITCM NOKEEP)
 zephyr_code_relocate_ifdef(CONFIG_RISCV_MACHINE_TIMER LIBRARY drivers__timer LOCATION ITCM NOKEEP)
 zephyr_code_relocate_ifdef(CONFIG_PINCTRL_BFLB LIBRARY drivers__pinctrl LOCATION ITCM NOKEEP)
 zephyr_code_relocate_ifdef(CONFIG_SYSCON_BFLB_EFUSE LIBRARY drivers__syscon LOCATION ITCM NOKEEP)


### PR DESCRIPTION
[variant 2/2]

Tests like log_backend_uart include an emulated UART driver which gets selected for ITCM code relocation, as part of drivers__serial. Filter by FILE instead of LIBRARY to avoid this.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104275