### PR TITLE
gpio: mchp: Don't skip interrupt enable when IDET is unchanged

### DIFF
--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -292,10 +292,6 @@ static int gpio_xec_pin_interrupt_config(const struct device *dev, gpio_pin_t pi
 	idet_curr = MEC_GPIO_CR1_IDET_GET(cr1);
 	idet = gen_gpio_ctrl_icfg(mode, trig);
 
-	if (idet_curr == idet) {
-		return 0;
-	}
-
 	if ((idet == MEC_GPIO_CR1_IDET_LL) || (idet == MEC_GPIO_CR1_IDET_LH)) {
 		data->level_intr_bm |= BIT(pin);
 	} else {


### PR DESCRIPTION
`gpio_xec_pin_interrupt_config` returned early when the computed IDET configuration matched the current CR1 IDET field. On some reset paths the GPIO control register can retain the same IDET value while the interrupt aggregator state is reset/reconfigured. In that case, the early return prevents re-enabling the aggregator and interrupts remain disabled.

Remove the IDET equality early-return so the driver always updates the level/edge bookkeeping and programs the interrupt aggregator enable state.