### PR TITLE
serial: cc13xx_cc26xx: Fix TX interrupt

### DIFF
--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -168,10 +168,8 @@ static int uart_cc13xx_cc26xx_configure(const struct device *dev,
 			    line_ctrl);
 
 	/* Clear all UART interrupts */
-	UARTIntClear(config->reg,
-		UART_INT_OE | UART_INT_BE | UART_INT_PE |
-		UART_INT_FE | UART_INT_RT | UART_INT_TX |
-		UART_INT_RX | UART_INT_CTS);
+	UARTIntClear(config->reg, UART_INT_OE | UART_INT_BE | UART_INT_PE | UART_INT_FE |
+					  UART_INT_RT | UART_INT_RX | UART_INT_CTS);
 
 	if (flow_ctrl) {
 		UARTHwFlowControlEnable(config->reg);


### PR DESCRIPTION
In cc13xx_cc26xx, the TX interrupt seems to be generated once initially on
enable and subsequently, when buffer goes from full to empty (since we are
operating in 1-byte buffer mode).

Due to this, if the TX interrupt is cleared in the configure function, a
new TX interrupt will not be generated untill we transition from a full to
empty buffer, even though the buffer itself is empty.

When using Zephyr Interrupt-driven UART API, one first needs to enable TX
interrupts `uart_irq_tx_enable()`, and then write data from the interrupt
callback, after checking `uart_irq_tx_ready()`. In case of cc13xx_cc26xx,
calling `uart_irq_tx_enable()` unmasks the TX interrupt, however, it will
not generate a new TX interrupt. Thus the callback will not be called
unless we first write something to the uart (using polling-API), causing a
transition in buffer state.

According to TI docs, writing 1 byte to the buffer will also clear the
TX interrupt, so it does not make sense to try clearing the interrupt
manulally in `configure` function.