### PR TITLE
tests: drivers: can: reformat source files, switch to using zassert_ok() where possible

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -59,8 +59,7 @@ static void rx_std_callback_2(const struct device *dev, struct can_frame *frame,
 	k_sem_give(&rx_callback_sem);
 }
 
-static void rx_std_callback_fd_1(const struct device *dev, struct can_frame *frame,
-				 void *user_data)
+static void rx_std_callback_fd_1(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -71,8 +70,7 @@ static void rx_std_callback_fd_1(const struct device *dev, struct can_frame *fra
 	k_sem_give(&rx_callback_sem);
 }
 
-static void rx_std_callback_fd_2(const struct device *dev, struct can_frame *frame,
-				 void *user_data)
+static void rx_std_callback_fd_2(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -149,8 +147,7 @@ static inline int add_rx_msgq(const struct device *dev, const struct can_filter 
  *
  * @return CAN filter ID.
  */
-static inline int add_rx_filter(const struct device *dev,
-				const struct can_filter *filter,
+static inline int add_rx_filter(const struct device *dev, const struct can_filter *filter,
 				can_rx_callback_t callback)
 {
 	int filter_id;
@@ -172,10 +169,8 @@ static inline int add_rx_filter(const struct device *dev,
  * @param frame1  CAN frame 1
  * @param frame2  CAN frame 2
  */
-static void send_receive(const struct can_filter *filter1,
-			 const struct can_filter *filter2,
-			 const struct can_frame *frame1,
-			 const struct can_frame *frame2)
+static void send_receive(const struct can_filter *filter1, const struct can_filter *filter2,
+			 const struct can_frame *frame1, const struct can_frame *frame2)
 {
 	struct can_frame frame_buffer;
 	int filter_id_1;
@@ -280,8 +275,7 @@ ZTEST(canfd, test_send_fd_incorrect_esi)
  */
 ZTEST(canfd, test_send_receive_classic)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
-		     &test_std_frame_1, &test_std_frame_2);
+	send_receive(&test_std_filter_1, &test_std_filter_2, &test_std_frame_1, &test_std_frame_2);
 }
 
 /**
@@ -289,8 +283,8 @@ ZTEST(canfd, test_send_receive_classic)
  */
 ZTEST(canfd, test_send_receive_fd)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
-		     &test_std_fdf_frame_1, &test_std_fdf_frame_2);
+	send_receive(&test_std_filter_1, &test_std_filter_2, &test_std_fdf_frame_1,
+		     &test_std_fdf_frame_2);
 }
 
 /**
@@ -298,8 +292,8 @@ ZTEST(canfd, test_send_receive_fd)
  */
 ZTEST(canfd, test_send_receive_mixed)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
-		     &test_std_fdf_frame_1, &test_std_frame_2);
+	send_receive(&test_std_filter_1, &test_std_filter_2, &test_std_fdf_frame_1,
+		     &test_std_frame_2);
 }
 
 /**
@@ -524,7 +518,7 @@ ZTEST_USER(canfd, test_set_bitrate_data_while_started)
  */
 ZTEST_USER(canfd, test_set_timing_data_while_started)
 {
-	struct can_timing timing = { 0 };
+	struct can_timing timing = {0};
 	int err;
 
 	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE_3, TEST_SAMPLE_POINT_2);

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -98,7 +98,7 @@ static void send_test_frame(const struct device *dev, const struct can_frame *fr
 
 	err = can_send(dev, frame, TEST_SEND_TIMEOUT, NULL, NULL);
 	zassert_not_equal(err, -EBUSY, "arbitration lost in loopback mode");
-	zassert_equal(err, 0, "failed to send frame (err %d)", err);
+	zassert_ok(err, "failed to send frame (err %d)", err);
 }
 
 /**
@@ -118,7 +118,7 @@ static void send_test_frame_nowait(const struct device *dev, const struct can_fr
 
 	err = can_send(dev, frame, TEST_SEND_TIMEOUT, callback, (void *)frame);
 	zassert_not_equal(err, -EBUSY, "arbitration lost in loopback mode");
-	zassert_equal(err, 0, "failed to send frame (err %d)", err);
+	zassert_ok(err, "failed to send frame (err %d)", err);
 }
 
 /**
@@ -186,7 +186,7 @@ static void send_receive(const struct can_filter *filter1,
 	send_test_frame(can_dev, frame1);
 
 	err = k_msgq_get(&can_msgq, &frame_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	assert_frame_equal(&frame_buffer, frame1, 0);
 	can_remove_rx_filter(can_dev, filter_id_1);
@@ -209,16 +209,16 @@ static void send_receive(const struct can_filter *filter1,
 	send_test_frame_nowait(can_dev, frame2, tx_std_callback_2);
 
 	err = k_sem_take(&rx_callback_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	err = k_sem_take(&rx_callback_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(err, 0, "missing TX callback");
+	zassert_ok(err, "missing TX callback");
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(err, 0, "missing TX callback");
+	zassert_ok(err, "missing TX callback");
 
 	can_remove_rx_filter(can_dev, filter_id_1);
 	can_remove_rx_filter(can_dev, filter_id_2);
@@ -233,7 +233,7 @@ ZTEST(canfd, test_canfd_get_capabilities)
 	int err;
 
 	err = can_get_capabilities(can_dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN capabilities (err %d)", err);
 	zassert_not_equal(cap & (CAN_MODE_LOOPBACK | CAN_MODE_FD), 0,
 			  "CAN FD loopback mode not supported");
 }
@@ -315,18 +315,18 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 
 	/* Stop controller and set first mode */
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_mode(can_dev, first | CAN_MODE_LOOPBACK);
-	zassert_equal(err, 0, "failed to set first loopback mode (err %d)", err);
+	zassert_ok(err, "failed to set first loopback mode (err %d)", err);
 	zassert_equal(first | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	/* Add classic CAN and CAN FD filter */
 	filter_id_1 = add_rx_msgq(can_dev, &test_std_filter_1);
@@ -335,60 +335,60 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 	/* Verify classic filter in first mode */
 	send_test_frame(can_dev, &test_std_frame_1);
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	if ((first & CAN_MODE_FD) != 0) {
 		/* Verify CAN FD filter in first mode */
 		send_test_frame(can_dev, &test_std_fdf_frame_2);
 		err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(err, 0, "receive timeout");
+		zassert_ok(err, "receive timeout");
 		assert_frame_equal(&frame, &test_std_fdf_frame_2, 0);
 	}
 
 	/* Stop controller and set second mode */
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_mode(can_dev, second | CAN_MODE_LOOPBACK);
-	zassert_equal(err, 0, "failed to set second loopback mode (err %d)", err);
+	zassert_ok(err, "failed to set second loopback mode (err %d)", err);
 	zassert_equal(second | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	/* Verify classic filter in second mode */
 	send_test_frame(can_dev, &test_std_frame_1);
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	if ((second & CAN_MODE_FD) != 0) {
 		/* Verify CAN FD filter in second mode */
 		send_test_frame(can_dev, &test_std_fdf_frame_2);
 		err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(err, 0, "receive timeout");
+		zassert_ok(err, "receive timeout");
 		assert_frame_equal(&frame, &test_std_fdf_frame_2, 0);
 	}
 
 	/* Stop controller and restore CAN FD loopback mode */
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_mode(can_dev, CAN_MODE_FD | CAN_MODE_LOOPBACK);
-	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+	zassert_ok(err, "failed to set loopback-mode (err %d)", err);
 	zassert_equal(CAN_MODE_FD | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	can_remove_rx_filter(can_dev, filter_id_1);
 	can_remove_rx_filter(can_dev, filter_id_2);
@@ -420,16 +420,16 @@ ZTEST_USER(canfd, test_set_timing_data_min)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_timing_data(can_dev, can_get_timing_data_min(can_dev));
-	zassert_equal(err, 0, "failed to set minimum timing data parameters (err %d)", err);
+	zassert_ok(err, "failed to set minimum timing data parameters (err %d)", err);
 
 	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
-	zassert_equal(err, 0, "failed to restore default data bitrate");
+	zassert_ok(err, "failed to restore default data bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -445,16 +445,16 @@ ZTEST_USER(canfd, test_set_bitrate_data_too_low)
 	}
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate_data(can_dev, min - 1);
 	zassert_equal(err, -ENOTSUP, "too low data phase bitrate accepted");
 
 	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
-	zassert_equal(err, 0, "failed to restore default data bitrate");
+	zassert_ok(err, "failed to restore default data bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -466,13 +466,13 @@ ZTEST_USER(canfd, test_set_bitrate_too_high)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate_data(can_dev, max + 1);
 	zassert_equal(err, -ENOTSUP, "too high data phase bitrate accepted");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -495,16 +495,16 @@ ZTEST_USER(canfd, test_set_timing_data_max)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_timing_data(can_dev, can_get_timing_data_max(can_dev));
-	zassert_equal(err, 0, "failed to set maximum timing data parameters (err %d)", err);
+	zassert_ok(err, "failed to set maximum timing data parameters (err %d)", err);
 
 	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
-	zassert_equal(err, 0, "failed to restore default data bitrate");
+	zassert_ok(err, "failed to restore default data bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -549,7 +549,7 @@ static bool canfd_predicate(const void *state)
 	}
 
 	err = can_get_capabilities(can_dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN controller capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN controller capabilities (err %d)", err);
 
 	if ((cap & CAN_MODE_FD) == 0) {
 		return false;

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -228,7 +228,7 @@ static void send_test_frame(const struct device *dev, const struct can_frame *fr
 
 	err = can_send(dev, frame, TEST_SEND_TIMEOUT, NULL, NULL);
 	zassert_not_equal(err, -EBUSY, "arbitration lost in loopback mode");
-	zassert_equal(err, 0, "failed to send frame (err %d)", err);
+	zassert_ok(err, "failed to send frame (err %d)", err);
 }
 
 /**
@@ -248,7 +248,7 @@ static void send_test_frame_nowait(const struct device *dev, const struct can_fr
 
 	err = can_send(dev, frame, TEST_SEND_TIMEOUT, callback, (void *)frame);
 	zassert_not_equal(err, -EBUSY, "arbitration lost in loopback mode");
-	zassert_equal(err, 0, "failed to send frame (err %d)", err);
+	zassert_ok(err, "failed to send frame (err %d)", err);
 }
 
 /**
@@ -319,7 +319,7 @@ static void send_receive(const struct can_filter *filter1,
 	send_test_frame(can_dev, frame1);
 
 	err = k_msgq_get(&can_msgq, &frame_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	if ((filter1->flags & CAN_FILTER_IDE) != 0) {
 		if (filter1->mask != CAN_EXT_ID_MASK) {
@@ -369,16 +369,16 @@ static void send_receive(const struct can_filter *filter1,
 	zassert_true(filter_id_2 >= 0, "negative filter number");
 
 	err = k_sem_take(&rx_callback_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	err = k_sem_take(&rx_callback_sem, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(err, 0, "missing TX callback");
+	zassert_ok(err, "missing TX callback");
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(err, 0, "missing TX callback");
+	zassert_ok(err, "missing TX callback");
 
 	can_remove_rx_filter(can_dev, filter_id_1);
 	can_remove_rx_filter(can_dev, filter_id_2);
@@ -412,16 +412,16 @@ static void send_receive_rtr(const struct can_filter *filter,
 		can_remove_rx_filter(can_dev, filter_id);
 		ztest_test_skip();
 	}
-	zassert_equal(err, 0, "failed to send RTR frame (err %d)", err);
+	zassert_ok(err, "failed to send RTR frame (err %d)", err);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, rtr_frame, 0);
 
 	/* Verify that filter matches data frame */
 	send_test_frame(can_dev, data_frame);
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, data_frame, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
@@ -436,7 +436,7 @@ ZTEST_USER(can_classic, test_get_core_clock)
 	int err;
 
 	err = can_get_core_clock(can_dev, &rate);
-	zassert_equal(err, 0, "failed to get CAN core clock rate (err %d)", err);
+	zassert_ok(err, "failed to get CAN core clock rate (err %d)", err);
 	zassert_not_equal(rate, 0, "CAN core clock rate is 0");
 }
 
@@ -449,7 +449,7 @@ ZTEST_USER(can_classic, test_classic_get_capabilities)
 	int err;
 
 	err = can_get_capabilities(can_dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN capabilities (err %d)", err);
 	zassert_not_equal(cap & CAN_MODE_LOOPBACK, 0, "CAN loopback mode not supported");
 }
 
@@ -499,16 +499,16 @@ ZTEST_USER(can_classic, test_set_bitrate_too_low)
 	}
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate(can_dev, min - 1);
 	zassert_equal(err, -ENOTSUP, "too low bitrate accepted");
 
 	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
-	zassert_equal(err, 0, "failed to restore default bitrate");
+	zassert_ok(err, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -520,13 +520,13 @@ ZTEST_USER(can_classic, test_set_bitrate_too_high)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate(can_dev, max + 1);
 	zassert_equal(err, -ENOTSUP, "too high bitrate accepted");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -549,16 +549,16 @@ ZTEST_USER(can_classic, test_set_bitrate)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
-	zassert_equal(err, 0, "failed to set bitrate");
+	zassert_ok(err, "failed to set bitrate");
 
 	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
-	zassert_equal(err, 0, "failed to restore default bitrate");
+	zassert_ok(err, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -569,16 +569,16 @@ ZTEST_USER(can_classic, test_set_timing_min)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_timing(can_dev, can_get_timing_min(can_dev));
-	zassert_equal(err, 0, "failed to set minimum timing parameters (err %d)", err);
+	zassert_ok(err, "failed to set minimum timing parameters (err %d)", err);
 
 	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
-	zassert_equal(err, 0, "failed to restore default bitrate");
+	zassert_ok(err, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -589,16 +589,16 @@ ZTEST_USER(can_classic, test_set_timing_max)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_timing(can_dev, can_get_timing_max(can_dev));
-	zassert_equal(err, 0, "failed to set maximum timing parameters (err %d)", err);
+	zassert_ok(err, "failed to set maximum timing parameters (err %d)", err);
 
 	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
-	zassert_equal(err, 0, "failed to restore default bitrate");
+	zassert_ok(err, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -804,7 +804,7 @@ ZTEST(can_classic, test_send_callback)
 	send_test_frame_nowait(can_dev, &test_std_frame_1, tx_std_callback_1);
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
-	zassert_equal(err, 0, "missing TX callback");
+	zassert_ok(err, "missing TX callback");
 }
 
 /**
@@ -909,10 +909,10 @@ ZTEST(can_classic, test_send_receive_std_id_no_data)
 
 	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
 	err = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, NULL, NULL);
-	zassert_equal(err, 0, "failed to send frame without data (err %d)", err);
+	zassert_ok(err, "failed to send frame without data (err %d)", err);
 
 	err = k_msgq_get(&can_msgq, &frame_buffer, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 
 	assert_frame_equal(&frame, &frame_buffer, 0);
 
@@ -969,7 +969,7 @@ ZTEST_USER(can_classic, test_send_receive_msgq)
 
 	for (i = 0; i < nframes; i++) {
 		err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(err, 0, "receive timeout");
+		zassert_ok(err, "receive timeout");
 		assert_frame_equal(&frame, &test_std_frame_1, 0);
 	}
 
@@ -979,7 +979,7 @@ ZTEST_USER(can_classic, test_send_receive_msgq)
 
 	for (i = 0; i < nframes; i++) {
 		err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-		zassert_equal(err, 0, "receive timeout");
+		zassert_ok(err, "receive timeout");
 		assert_frame_equal(&frame, &test_std_frame_1, 0);
 	}
 
@@ -1025,7 +1025,7 @@ ZTEST_USER(can_classic, test_reject_std_id_rtr)
 		can_remove_rx_filter(can_dev, filter_id);
 		ztest_test_skip();
 	}
-	zassert_equal(err, 0, "failed to send RTR frame (err %d)", err);
+	zassert_ok(err, "failed to send RTR frame (err %d)", err);
 
 	err = k_msgq_get(&can_msgq, &frame_buffer, TEST_RECEIVE_TIMEOUT);
 	zassert_equal(err, -EAGAIN, "received a frame that should be rejected");
@@ -1052,7 +1052,7 @@ ZTEST_USER(can_classic, test_reject_ext_id_rtr)
 		can_remove_rx_filter(can_dev, filter_id);
 		ztest_test_skip();
 	}
-	zassert_equal(err, 0, "failed to send RTR frame (err %d)", err);
+	zassert_ok(err, "failed to send RTR frame (err %d)", err);
 
 	err = k_msgq_get(&can_msgq, &frame_buffer, TEST_RECEIVE_TIMEOUT);
 	zassert_equal(err, -EAGAIN, "received a frame that should be rejected");
@@ -1121,7 +1121,7 @@ ZTEST_USER(can_classic, test_recover)
 	int err;
 
 	err = can_get_capabilities(can_dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN capabilities (err %d)", err);
 
 	if ((cap & CAN_MODE_MANUAL_RECOVERY) != 0U) {
 		/* Check that manual recovery fails when not in manual recovery mode */
@@ -1129,32 +1129,32 @@ ZTEST_USER(can_classic, test_recover)
 		zassert_equal(err, -ENOTSUP, "wrong error return code (err %d)", err);
 
 		err = can_stop(can_dev);
-		zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+		zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 		/* Enter manual recovery mode */
 		err = can_set_mode(can_dev, CAN_MODE_NORMAL | CAN_MODE_MANUAL_RECOVERY);
-		zassert_equal(err, 0, "failed to set manual recovery mode (err %d)", err);
+		zassert_ok(err, "failed to set manual recovery mode (err %d)", err);
 		zassert_equal(CAN_MODE_NORMAL | CAN_MODE_MANUAL_RECOVERY, can_get_mode(can_dev));
 
 		err = can_start(can_dev);
-		zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+		zassert_ok(err, "failed to start CAN controller (err %d)", err);
 	}
 
 	err = can_recover(can_dev, TEST_RECOVER_TIMEOUT);
 
 	if ((cap & CAN_MODE_MANUAL_RECOVERY) != 0U) {
-		zassert_equal(err, 0, "failed to recover (err %d)", err);
+		zassert_ok(err, "failed to recover (err %d)", err);
 
 		err = can_stop(can_dev);
-		zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+		zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 		/* Restore loopback mode */
 		err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
-		zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+		zassert_ok(err, "failed to set loopback-mode (err %d)", err);
 		zassert_equal(CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 		err = can_start(can_dev);
-		zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+		zassert_ok(err, "failed to start CAN controller (err %d)", err);
 	} else {
 		/* Check that manual recovery fails when not supported */
 		zassert_equal(err, -ENOSYS, "wrong error return code (err %d)", err);
@@ -1171,16 +1171,16 @@ ZTEST_USER(can_classic, test_get_state)
 	int err;
 
 	err = can_get_state(can_dev, NULL, NULL);
-	zassert_equal(err, 0, "failed to get CAN state without destinations (err %d)", err);
+	zassert_ok(err, "failed to get CAN state without destinations (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 
 	err = can_get_state(can_dev, NULL, &err_cnt);
-	zassert_equal(err, 0, "failed to get CAN error counters (err %d)", err);
+	zassert_ok(err, "failed to get CAN error counters (err %d)", err);
 
 	err = can_get_state(can_dev, &state, &err_cnt);
-	zassert_equal(err, 0, "failed to get CAN state + error counters (err %d)", err);
+	zassert_ok(err, "failed to get CAN state + error counters (err %d)", err);
 }
 
 /**
@@ -1197,31 +1197,31 @@ ZTEST_USER(can_classic, test_filters_preserved_through_mode_change)
 	send_test_frame(can_dev, &test_std_frame_1);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_mode(can_dev, CAN_MODE_NORMAL);
-	zassert_equal(err, 0, "failed to set normal mode (err %d)", err);
+	zassert_ok(err, "failed to set normal mode (err %d)", err);
 	zassert_equal(CAN_MODE_NORMAL, can_get_mode(can_dev));
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
-	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+	zassert_ok(err, "failed to set loopback-mode (err %d)", err);
 	zassert_equal(CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
@@ -1241,32 +1241,32 @@ ZTEST_USER(can_classic, test_filters_preserved_through_bitrate_change)
 	send_test_frame(can_dev, &test_std_frame_1);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_get_state(can_dev, &state, NULL);
-	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_ok(err, "failed to get CAN state (err %d)", err);
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_2);
-	zassert_equal(err, 0, "failed to set bitrate 2");
+	zassert_ok(err, "failed to set bitrate 2");
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
-	zassert_equal(err, 0, "failed to set bitrate 1");
+	zassert_ok(err, "failed to set bitrate 1");
 
 	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
-	zassert_equal(err, 0, "failed to restore default bitrate");
+	zassert_ok(err, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
@@ -1282,17 +1282,17 @@ ZTEST_USER(can_classic, test_filters_added_while_stopped)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);
 
 	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
-	zassert_equal(err, 0, "receive timeout");
+	zassert_ok(err, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
@@ -1306,14 +1306,14 @@ ZTEST_USER(can_classic, test_stop_while_stopped)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_stop(can_dev);
 	zassert_not_equal(err, 0, "stopped CAN controller while stopped");
 	zassert_equal(err, -EALREADY, "wrong error return code (err %d)", err);
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -1337,21 +1337,21 @@ ZTEST_USER(can_classic, test_recover_while_stopped)
 	int err;
 
 	err = can_get_capabilities(can_dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN capabilities (err %d)", err);
 
 	if ((cap & CAN_MODE_MANUAL_RECOVERY) == 0U) {
 		ztest_test_skip();
 	}
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_recover(can_dev, K_NO_WAIT);
 	zassert_not_equal(err, 0, "recovered bus while stopped");
 	zassert_equal(err, -ENETDOWN, "wrong error return code (err %d)", err);
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -1362,14 +1362,14 @@ ZTEST_USER(can_classic, test_send_while_stopped)
 	int err;
 
 	err = can_stop(can_dev);
-	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+	zassert_ok(err, "failed to stop CAN controller (err %d)", err);
 
 	err = can_send(can_dev, &test_std_frame_1, TEST_SEND_TIMEOUT, NULL, NULL);
 	zassert_not_equal(err, 0, "sent a frame in stopped state");
 	zassert_equal(err, -ENETDOWN, "wrong error return code (err %d)", err);
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }
 
 /**

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -82,8 +82,7 @@ static void tx_ext_callback_2(const struct device *dev, int error, void *user_da
  *
  * See @a can_rx_callback_t() for argument description.
  */
-static void rx_std_callback_1(const struct device *dev, struct can_frame *frame,
-			      void *user_data)
+static void rx_std_callback_1(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -99,8 +98,7 @@ static void rx_std_callback_1(const struct device *dev, struct can_frame *frame,
  *
  * See @a can_rx_callback_t() for argument description.
  */
-static void rx_std_callback_2(const struct device *dev, struct can_frame *frame,
-			      void *user_data)
+static void rx_std_callback_2(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -150,8 +148,7 @@ static void rx_std_mask_callback_2(const struct device *dev, struct can_frame *f
  *
  * See @a can_rx_callback_t() for argument description.
  */
-static void rx_ext_callback_1(const struct device *dev, struct can_frame *frame,
-			      void *user_data)
+static void rx_ext_callback_1(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -167,8 +164,7 @@ static void rx_ext_callback_1(const struct device *dev, struct can_frame *frame,
  *
  * See @a can_rx_callback_t() for argument description.
  */
-static void rx_ext_callback_2(const struct device *dev, struct can_frame *frame,
-			      void *user_data)
+static void rx_ext_callback_2(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct can_filter *filter = user_data;
 
@@ -279,8 +275,7 @@ static inline int add_rx_msgq(const struct device *dev, const struct can_filter 
  *
  * @return CAN filter ID.
  */
-static inline int add_rx_filter(const struct device *dev,
-				const struct can_filter *filter,
+static inline int add_rx_filter(const struct device *dev, const struct can_filter *filter,
 				can_rx_callback_t callback)
 {
 	int filter_id;
@@ -302,10 +297,8 @@ static inline int add_rx_filter(const struct device *dev,
  * @param frame1  CAN frame 1
  * @param frame2  CAN frame 2
  */
-static void send_receive(const struct can_filter *filter1,
-			 const struct can_filter *filter2,
-			 const struct can_frame *frame1,
-			 const struct can_frame *frame2)
+static void send_receive(const struct can_filter *filter1, const struct can_filter *filter2,
+			 const struct can_frame *frame1, const struct can_frame *frame2)
 {
 	struct can_frame frame_buffer;
 	uint32_t mask = 0U;
@@ -393,8 +386,7 @@ static void send_receive(const struct can_filter *filter1,
  * @param data_frame  CAN data frame
  * @param rtr_frame   CAN RTR frame
  */
-static void send_receive_rtr(const struct can_filter *filter,
-			     const struct can_frame *data_frame,
+static void send_receive_rtr(const struct can_filter *filter, const struct can_frame *data_frame,
 			     const struct can_frame *rtr_frame)
 {
 	struct can_frame frame;
@@ -888,8 +880,7 @@ ZTEST(can_classic, test_send_ext_id_dlc_of_range)
  */
 ZTEST(can_classic, test_send_receive_std_id)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
-		     &test_std_frame_1, &test_std_frame_2);
+	send_receive(&test_std_filter_1, &test_std_filter_2, &test_std_frame_1, &test_std_frame_2);
 }
 
 /**
@@ -898,10 +889,10 @@ ZTEST(can_classic, test_send_receive_std_id)
 ZTEST(can_classic, test_send_receive_std_id_no_data)
 {
 	const struct can_frame frame = {
-		.flags   = 0,
-		.id      = TEST_CAN_STD_ID_1,
-		.dlc     = 0,
-		.data    = { 0 }
+		.flags = 0,
+		.id = TEST_CAN_STD_ID_1,
+		.dlc = 0,
+		.data = {0},
 	};
 	struct can_frame frame_buffer;
 	int filter_id;
@@ -924,8 +915,7 @@ ZTEST(can_classic, test_send_receive_std_id_no_data)
  */
 ZTEST(can_classic, test_send_receive_ext_id)
 {
-	send_receive(&test_ext_filter_1, &test_ext_filter_2,
-		     &test_ext_frame_1, &test_ext_frame_2);
+	send_receive(&test_ext_filter_1, &test_ext_filter_2, &test_ext_frame_1, &test_ext_frame_2);
 }
 
 /**
@@ -933,8 +923,8 @@ ZTEST(can_classic, test_send_receive_ext_id)
  */
 ZTEST(can_classic, test_send_receive_std_id_masked)
 {
-	send_receive(&test_std_masked_filter_1, &test_std_masked_filter_2,
-		     &test_std_frame_1, &test_std_frame_2);
+	send_receive(&test_std_masked_filter_1, &test_std_masked_filter_2, &test_std_frame_1,
+		     &test_std_frame_2);
 }
 
 /**
@@ -942,8 +932,8 @@ ZTEST(can_classic, test_send_receive_std_id_masked)
  */
 ZTEST(can_classic, test_send_receive_ext_id_masked)
 {
-	send_receive(&test_ext_masked_filter_1, &test_ext_masked_filter_2,
-		     &test_ext_frame_1, &test_ext_frame_2);
+	send_receive(&test_ext_masked_filter_1, &test_ext_masked_filter_2, &test_ext_frame_1,
+		     &test_ext_frame_2);
 }
 
 /**
@@ -1389,7 +1379,7 @@ ZTEST_USER(can_classic, test_set_bitrate_while_started)
  */
 ZTEST_USER(can_classic, test_set_timing_while_started)
 {
-	struct can_timing timing = { 0 };
+	struct can_timing timing = {0};
 	int err;
 
 	err = can_calc_timing(can_dev, &timing, TEST_BITRATE_1, TEST_SAMPLE_POINT);

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -26,60 +26,60 @@ CAN_MSGQ_DEFINE(can_msgq, 5);
  * @brief Standard (11-bit) CAN ID frame 1.
  */
 const struct can_frame test_std_frame_1 = {
-	.flags   = 0,
-	.id      = TEST_CAN_STD_ID_1,
-	.dlc     = 8,
-	.data    = {1, 2, 3, 4, 5, 6, 7, 8}
+	.flags = 0,
+	.id = TEST_CAN_STD_ID_1,
+	.dlc = 8,
+	.data = {1, 2, 3, 4, 5, 6, 7, 8},
 };
 
 /**
  * @brief Standard (11-bit) CAN ID frame 2.
  */
 const struct can_frame test_std_frame_2 = {
-	.flags   = 0,
-	.id      = TEST_CAN_STD_ID_2,
-	.dlc     = 8,
-	.data    = {1, 2, 3, 4, 5, 6, 7, 8}
+	.flags = 0,
+	.id = TEST_CAN_STD_ID_2,
+	.dlc = 8,
+	.data = {1, 2, 3, 4, 5, 6, 7, 8},
 };
 
 /**
  * @brief Extended (29-bit) CAN ID frame 1.
  */
 const struct can_frame test_ext_frame_1 = {
-	.flags   = CAN_FRAME_IDE,
-	.id      = TEST_CAN_EXT_ID_1,
-	.dlc     = 8,
-	.data    = {1, 2, 3, 4, 5, 6, 7, 8}
+	.flags = CAN_FRAME_IDE,
+	.id = TEST_CAN_EXT_ID_1,
+	.dlc = 8,
+	.data = {1, 2, 3, 4, 5, 6, 7, 8},
 };
 
 /**
  * @brief Extended (29-bit) CAN ID frame 1.
  */
 const struct can_frame test_ext_frame_2 = {
-	.flags   = CAN_FRAME_IDE,
-	.id      = TEST_CAN_EXT_ID_2,
-	.dlc     = 8,
-	.data    = {1, 2, 3, 4, 5, 6, 7, 8}
+	.flags = CAN_FRAME_IDE,
+	.id = TEST_CAN_EXT_ID_2,
+	.dlc = 8,
+	.data = {1, 2, 3, 4, 5, 6, 7, 8},
 };
 
 /**
  * @brief Standard (11-bit) CAN ID RTR frame 1.
  */
 const struct can_frame test_std_rtr_frame_1 = {
-	.flags   = CAN_FRAME_RTR,
-	.id      = TEST_CAN_STD_ID_1,
-	.dlc     = 0,
-	.data    = {0}
+	.flags = CAN_FRAME_RTR,
+	.id = TEST_CAN_STD_ID_1,
+	.dlc = 0,
+	.data = {0},
 };
 
 /**
  * @brief Extended (29-bit) CAN ID RTR frame 1.
  */
 const struct can_frame test_ext_rtr_frame_1 = {
-	.flags   = CAN_FRAME_IDE | CAN_FRAME_RTR,
-	.id      = TEST_CAN_EXT_ID_1,
-	.dlc     = 0,
-	.data    = {0}
+	.flags = CAN_FRAME_IDE | CAN_FRAME_RTR,
+	.id = TEST_CAN_EXT_ID_1,
+	.dlc = 0,
+	.data = {0},
 };
 
 #ifdef CONFIG_CAN_FD_MODE
@@ -87,28 +87,26 @@ const struct can_frame test_ext_rtr_frame_1 = {
  * @brief Standard (11-bit) CAN ID frame 1 with CAN FD payload.
  */
 const struct can_frame test_std_fdf_frame_1 = {
-	.flags   = CAN_FRAME_FDF | CAN_FRAME_BRS,
-	.id      = TEST_CAN_STD_ID_1,
-	.dlc     = 0xf,
-	.data    = { 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-		    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-		    31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-		    46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-		    61, 62, 63, 64 }
+	.flags = CAN_FRAME_FDF | CAN_FRAME_BRS,
+	.id = TEST_CAN_STD_ID_1,
+	.dlc = 0xf,
+	.data = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+		 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+		 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+		 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64},
 };
 
 /**
  * @brief Standard (11-bit) CAN ID frame 1 with CAN FD payload.
  */
 const struct can_frame test_std_fdf_frame_2 = {
-	.flags   = CAN_FRAME_FDF | CAN_FRAME_BRS,
-	.id      = TEST_CAN_STD_ID_2,
-	.dlc     = 0xf,
-	.data    = { 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-		    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-		    31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-		    46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-		    61, 62, 63, 64 }
+	.flags = CAN_FRAME_FDF | CAN_FRAME_BRS,
+	.id = TEST_CAN_STD_ID_2,
+	.dlc = 0xf,
+	.data = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+		 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+		 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+		 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64},
 };
 #endif /* CONFIG_CAN_FD_MODE */
 
@@ -119,7 +117,7 @@ const struct can_frame test_std_fdf_frame_2 = {
 const struct can_filter test_std_filter_1 = {
 	.flags = 0U,
 	.id = TEST_CAN_STD_ID_1,
-	.mask = CAN_STD_ID_MASK
+	.mask = CAN_STD_ID_MASK,
 };
 
 /**
@@ -129,7 +127,7 @@ const struct can_filter test_std_filter_1 = {
 const struct can_filter test_std_filter_2 = {
 	.flags = 0U,
 	.id = TEST_CAN_STD_ID_2,
-	.mask = CAN_STD_ID_MASK
+	.mask = CAN_STD_ID_MASK,
 };
 
 /**
@@ -139,7 +137,7 @@ const struct can_filter test_std_filter_2 = {
 const struct can_filter test_std_masked_filter_1 = {
 	.flags = 0U,
 	.id = TEST_CAN_STD_MASK_ID_1,
-	.mask = TEST_CAN_STD_MASK
+	.mask = TEST_CAN_STD_MASK,
 };
 
 /**
@@ -149,7 +147,7 @@ const struct can_filter test_std_masked_filter_1 = {
 const struct can_filter test_std_masked_filter_2 = {
 	.flags = 0U,
 	.id = TEST_CAN_STD_MASK_ID_2,
-	.mask = TEST_CAN_STD_MASK
+	.mask = TEST_CAN_STD_MASK,
 };
 
 /**
@@ -159,7 +157,7 @@ const struct can_filter test_std_masked_filter_2 = {
 const struct can_filter test_ext_filter_1 = {
 	.flags = CAN_FILTER_IDE,
 	.id = TEST_CAN_EXT_ID_1,
-	.mask = CAN_EXT_ID_MASK
+	.mask = CAN_EXT_ID_MASK,
 };
 
 /**
@@ -169,7 +167,7 @@ const struct can_filter test_ext_filter_1 = {
 const struct can_filter test_ext_filter_2 = {
 	.flags = CAN_FILTER_IDE,
 	.id = TEST_CAN_EXT_ID_2,
-	.mask = CAN_EXT_ID_MASK
+	.mask = CAN_EXT_ID_MASK,
 };
 
 /**
@@ -179,7 +177,7 @@ const struct can_filter test_ext_filter_2 = {
 const struct can_filter test_ext_masked_filter_1 = {
 	.flags = CAN_FILTER_IDE,
 	.id = TEST_CAN_EXT_MASK_ID_1,
-	.mask = TEST_CAN_EXT_MASK
+	.mask = TEST_CAN_EXT_MASK,
 };
 
 /**
@@ -189,7 +187,7 @@ const struct can_filter test_ext_masked_filter_1 = {
 const struct can_filter test_ext_masked_filter_2 = {
 	.flags = CAN_FILTER_IDE,
 	.id = TEST_CAN_EXT_MASK_ID_2,
-	.mask = TEST_CAN_EXT_MASK
+	.mask = TEST_CAN_EXT_MASK,
 };
 
 /**
@@ -199,7 +197,7 @@ const struct can_filter test_ext_masked_filter_2 = {
 const struct can_filter test_std_some_filter = {
 	.flags = 0U,
 	.id = TEST_CAN_SOME_STD_ID,
-	.mask = CAN_STD_ID_MASK
+	.mask = CAN_STD_ID_MASK,
 };
 
 /**
@@ -209,8 +207,7 @@ const struct can_filter test_std_some_filter = {
  * @param frame2  Second CAN frame.
  * @param id_mask CAN ID mask.
  */
-void assert_frame_equal(const struct can_frame *frame1,
-			const struct can_frame *frame2,
+void assert_frame_equal(const struct can_frame *frame1, const struct can_frame *frame2,
 			uint32_t id_mask)
 {
 	zassert_equal(frame1->flags, frame2->flags, "Flags do not match");

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -238,9 +238,9 @@ void can_common_test_setup(can_mode_t initial_mode)
 	(void)can_stop(can_dev);
 
 	err = can_set_mode(can_dev, initial_mode);
-	zassert_equal(err, 0, "failed to set initial mode (err %d)", err);
+	zassert_ok(err, "failed to set initial mode (err %d)", err);
 	zassert_equal(initial_mode, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	zassert_ok(err, "failed to start CAN controller (err %d)", err);
 }

--- a/tests/drivers/can/api/src/utilities.c
+++ b/tests/drivers/can/api/src/utilities.c
@@ -30,7 +30,7 @@ ZTEST(can_utilities, test_can_dlc_to_bytes)
 	}
 
 	/* CAN FD DLC, 12 to 64 data bytes in steps */
-	zassert_equal(can_dlc_to_bytes(9),  12, "wrong number of bytes for DLC 9");
+	zassert_equal(can_dlc_to_bytes(9), 12, "wrong number of bytes for DLC 9");
 	zassert_equal(can_dlc_to_bytes(10), 16, "wrong number of bytes for DLC 10");
 	zassert_equal(can_dlc_to_bytes(11), 20, "wrong number of bytes for DLC 11");
 	zassert_equal(can_dlc_to_bytes(12), 24, "wrong number of bytes for DLC 12");
@@ -52,7 +52,7 @@ ZTEST(can_utilities, test_can_bytes_to_dlc)
 	}
 
 	/* CAN FD DLC, 12 to 64 data bytes in steps */
-	zassert_equal(can_bytes_to_dlc(12), 9,  "wrong DLC for 12 bytes");
+	zassert_equal(can_bytes_to_dlc(12), 9, "wrong DLC for 12 bytes");
 	zassert_equal(can_bytes_to_dlc(16), 10, "wrong DLC for 16 bytes");
 	zassert_equal(can_bytes_to_dlc(20), 11, "wrong DLC for 20 bytes");
 	zassert_equal(can_bytes_to_dlc(24), 12, "wrong DLC for 24 bytes");
@@ -69,7 +69,7 @@ ZTEST(can_utilities, test_can_frame_matches_filter)
 	const struct can_filter test_ext_filter_std_id_1 = {
 		.flags = CAN_FILTER_IDE,
 		.id = TEST_CAN_STD_ID_1,
-		.mask = CAN_EXT_ID_MASK
+		.mask = CAN_EXT_ID_MASK,
 	};
 
 	/* Standard (11-bit) frames and filters */

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -76,7 +76,7 @@ static void assert_bitrate_correct(const struct device *dev, struct can_timing *
 	zassert_not_equal(timing->prescaler, 0, "prescaler is zero");
 
 	err = can_get_core_clock(dev, &core_clock);
-	zassert_equal(err, 0, "failed to get core CAN clock");
+	zassert_ok(err, "failed to get core CAN clock");
 
 	bitrate_calc = core_clock / timing->prescaler / ts;
 	zassert_equal(bitrate, bitrate_calc, "bitrate mismatch");
@@ -222,7 +222,7 @@ static bool test_timing_values(const struct device *dev, const struct can_timing
 		} else {
 			err = can_set_timing(dev, &timing);
 		}
-		zassert_equal(err, 0, "failed to set timing (err %d)", err);
+		zassert_ok(err, "failed to set timing (err %d)", err);
 
 		printk("OK, sample point error %d.%d%%\n", sp_err / 10, sp_err % 10);
 	}
@@ -260,7 +260,7 @@ ZTEST_USER(can_timing, test_timing_data)
 	int i;
 
 	err = can_get_capabilities(dev, &cap);
-	zassert_equal(err, 0, "failed to get CAN controller capabilities (err %d)", err);
+	zassert_ok(err, "failed to get CAN controller capabilities (err %d)", err);
 
 	if ((cap & CAN_MODE_FD) == 0) {
 		ztest_test_skip();
@@ -285,7 +285,7 @@ void *can_timing_setup(void)
 	k_object_access_grant(dev, k_current_get());
 
 	err = can_get_core_clock(dev, &core_clock);
-	zassert_equal(err, 0, "failed to get core CAN clock");
+	zassert_ok(err, "failed to get core CAN clock");
 
 	printk("testing on device %s @ %u Hz, sample point margin +/-%u permille\n", dev->name,
 		core_clock, CONFIG_CAN_SAMPLE_POINT_MARGIN);
@@ -294,7 +294,7 @@ void *can_timing_setup(void)
 		can_mode_t cap;
 
 		err = can_get_capabilities(dev, &cap);
-		zassert_equal(err, 0, "failed to get CAN controller capabilities (err %d)", err);
+		zassert_ok(err, "failed to get CAN controller capabilities (err %d)", err);
 
 		if ((cap & CAN_MODE_FD) != 0) {
 			switch (core_clock) {

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -31,6 +31,7 @@ struct can_timing_test {
 /**
  * @brief List of CAN timing values to test.
  */
+/* clang-format off */
 static const struct can_timing_test can_timing_tests[] = {
 	/* CiA 301 recommended bitrates */
 	{   10000, 875, false },
@@ -42,10 +43,12 @@ static const struct can_timing_test can_timing_tests[] = {
 	{  800000, 800, true },
 	{ 1000000, 750, true },
 };
+/* clang-format on */
 
 /**
  * @brief List of CAN FD data phase timing values to test.
  */
+/* clang-format off */
 static const struct can_timing_test can_timing_data_tests[] = {
 	/* CiA 601-2 recommended data phase bitrates */
 	{ 1000000, 750, true },
@@ -54,6 +57,7 @@ static const struct can_timing_test can_timing_data_tests[] = {
 	{ 5000000, 750, false },
 	{ 8000000, 750, false },
 };
+/* clang-format on */
 
 /**
  * @brief Assert that a CAN timing struct matches the specified bitrate
@@ -91,8 +95,7 @@ static void assert_bitrate_correct(const struct device *dev, struct can_timing *
  * @param dev pointer to the device structure for the driver instance
  * @param timing pointer to the CAN timing struct
  */
-static void assert_timing_within_bounds(struct can_timing *timing,
-					const struct can_timing *min,
+static void assert_timing_within_bounds(struct can_timing *timing, const struct can_timing *min,
 					const struct can_timing *max)
 {
 	zassert_true(timing->sjw <= max->sjw, "sjw exceeds max");
@@ -124,8 +127,8 @@ static void assert_sp_within_margin(struct can_timing *timing, uint16_t sp, uint
 	const uint16_t sp_calc = ((1 + timing->prop_seg + timing->phase_seg1) * 1000) / ts;
 
 	zassert_within(sp, sp_calc, sp_margin,
-		       "sample point %d not within calculated sample point %d +/- %d",
-		       sp, sp_calc, sp_margin);
+		       "sample point %d not within calculated sample point %d +/- %d", sp, sp_calc,
+		       sp_margin);
 }
 
 /**
@@ -175,12 +178,12 @@ static bool test_timing_values(const struct device *dev, const struct can_timing
 {
 	const struct can_timing *max = NULL;
 	const struct can_timing *min = NULL;
-	struct can_timing timing = { 0 };
+	struct can_timing timing = {0};
 	int sp_err = -EINVAL;
 	int err;
 
-	printk("testing bitrate %u, sample point %u.%u%%: ",
-	       test->bitrate, test->sp / 10, test->sp % 10);
+	printk("testing bitrate %u, sample point %u.%u%%: ", test->bitrate, test->sp / 10,
+	       test->sp % 10);
 
 	if (skip_timing_value_test(dev, test)) {
 		printk("skipped\n");
@@ -210,8 +213,8 @@ static bool test_timing_values(const struct device *dev, const struct can_timing
 			     "sample point error %d too large", sp_err);
 
 		printk("sjw = %u, prop_seg = %u, phase_seg1 = %u, phase_seg2 = %u, prescaler = %u ",
-			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
-			timing.prescaler);
+		       timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
+		       timing.prescaler);
 
 		assert_bitrate_correct(dev, &timing, test->bitrate);
 		assert_timing_within_bounds(&timing, min, max);
@@ -288,7 +291,7 @@ void *can_timing_setup(void)
 	zassert_ok(err, "failed to get core CAN clock");
 
 	printk("testing on device %s @ %u Hz, sample point margin +/-%u permille\n", dev->name,
-		core_clock, CONFIG_CAN_SAMPLE_POINT_MARGIN);
+	       core_clock, CONFIG_CAN_SAMPLE_POINT_MARGIN);
 
 	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
 		can_mode_t cap;
@@ -306,7 +309,7 @@ void *can_timing_setup(void)
 				break;
 			default:
 				TC_PRINT("Warning: CiA 601-3 recommends a CAN FD core clock of "
-					"20, 40, or 80 MHz for good node interoperability\n");
+					 "20, 40, or 80 MHz for good node interoperability\n");
 				break;
 			}
 		}
@@ -314,7 +317,8 @@ void *can_timing_setup(void)
 
 	if (IS_ENABLED(CONFIG_TEST_ALL_BITRATES) && core_clock != MHZ(80)) {
 		TC_PRINT("Warning: Testing all bitrates with CAN core clock of %u Hz "
-			 "(CONFIG_TEST_ALL_BITRATES=y)\n", core_clock);
+			 "(CONFIG_TEST_ALL_BITRATES=y)\n",
+			 core_clock);
 	}
 
 	return NULL;


### PR DESCRIPTION
- Replace `zassert_equal(err, 0, ...)` with `zassert_ok(err, ...)` to simplify code.
- Reformat the CAN test suite source files using clang-format.