### PR TITLE
kernel: mem_domain: support memory domain de-initialization

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -168,6 +168,7 @@ config XTENSA_MMU
 	bool "Xtensa MMU Support"
 	select MMU
 	select ARCH_MEM_DOMAIN_SYNCHRONOUS_API if USERSPACE
+	select ARCH_MEM_DOMAIN_SUPPORTS_DEINIT if USERSPACE && XTENSA_MMU
 	select CURRENT_THREAD_USE_NO_TLS if USERSPACE
 	help
 	  Enable support for Xtensa Memory Management Unit.

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1331,6 +1331,64 @@ err:
 }
 
 /**
+ * @brief Find the L1 table tracking index from L1 table pointer.
+ *
+ * @param[in] l1_table Pointer to L1 table.
+ *
+ * @note This does not check if the incoming L1 table pointer is a valid
+ *       L1 table.
+ *
+ * @return Index to the L1 table counter array.
+ */
+static inline int l1_table_to_track_pos(uint32_t *l1_table)
+{
+	return (l1_table - (uint32_t *)l1_page_tables) / (L1_PAGE_TABLE_NUM_ENTRIES);
+}
+
+int arch_mem_domain_deinit(struct k_mem_domain *domain)
+{
+	k_spinlock_key_t key;
+	uint32_t *l1_table = domain->arch.ptables;
+	uint32_t *l2_table;
+
+	if (l1_table == NULL) {
+		return -EINVAL;
+	}
+
+	key = k_spin_lock(&xtensa_mmu_lock);
+
+	for (uint32_t l1_pos = 0; l1_pos < L1_PAGE_TABLE_NUM_ENTRIES; l1_pos++) {
+		if (!is_pte_illegal(l1_table[l1_pos])) {
+			/* Since the L1 PTE points to a valid L2 table,
+			 * we need to decrement the usage counter for
+			 * that L2 table.
+			 */
+			l2_table = (uint32_t *)PTE_PPN_GET(l1_table[l1_pos]);
+
+			l2_page_tables_counter_dec(l2_table);
+		}
+
+		l1_table[l1_pos] = PTE_L1_ILLEGAL;
+	}
+
+	if (IS_ENABLED(PAGE_TABLE_IS_CACHED)) {
+		sys_cache_data_flush_range((void *)l1_table, L1_PAGE_TABLE_SIZE);
+	}
+
+	atomic_clear_bit(l1_page_tables_track, l1_table_to_track_pos(l1_table));
+
+	domain->arch.ptables = NULL;
+
+	k_spin_unlock(&xtensa_mmu_lock, key);
+
+	K_SPINLOCK(&xtensa_counter_lock) {
+		calc_l2_page_tables_usage();
+	}
+
+	return 0;
+}
+
+/**
  * @brief Update the mappings of a memory region.
  *
  * @note This does not lock the necessary spin locks to prevent simultaneous updates

--- a/include/zephyr/app_memory/mem_domain.h
+++ b/include/zephyr/app_memory/mem_domain.h
@@ -137,6 +137,17 @@ int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 			     struct k_mem_partition *parts[]);
 
 /**
+ * @brief De-initialize a memory domain.
+ *
+ * @param domain The memory domain to be de-initialized.
+ *
+ * @retval 0 if successful
+ * @retval -EBUSY if there are still threads associated with this memory domain.
+ * @retval -EINVAL if invalid parameter supplied
+ */
+int k_mem_domain_deinit(struct k_mem_domain *domain);
+
+/**
  * @brief Add a memory partition into a memory domain.
  *
  * Add a memory partition into a memory domain. Partitions must conform to

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -721,6 +721,25 @@ int arch_mem_domain_max_partitions_get(void);
 int arch_mem_domain_init(struct k_mem_domain *domain);
 #endif /* CONFIG_ARCH_MEM_DOMAIN_DATA */
 
+/**
+ * @brief Architecture-specific hook for memory domain de-initialization
+ *
+ * Perform any tasks needed to de-initialize architecture-specific data within
+ * the memory domain, such as releasing memory for page tables.
+ *
+ * The associated function k_mem_domain_deinit() documents that making
+ * multiple de-init calls to the same memory domain is undefined behavior,
+ * but has no assertions in place to check this. If this matters, it may be
+ * desirable to add checks for this in the implementation of this function.
+ *
+ * This assumes the memory domain has been initialized properly and is valid.
+ *
+ * @param domain The memory domain to be de-initialized
+ * @retval 0 Success
+ * @retval -ENOMEM Insufficient memory
+ */
+int arch_mem_domain_deinit(struct k_mem_domain *domain);
+
 #ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 /**
  * @brief Add a thread to a memory domain (arch-specific)

--- a/kernel/Kconfig.mem_domain
+++ b/kernel/Kconfig.mem_domain
@@ -61,6 +61,13 @@ config ARCH_MEM_DOMAIN_SUPPORTS_ISOLATED_STACKS
 	  the architecture supports isolating thread stacks for threads
 	  within the same memory domain.
 
+config ARCH_MEM_DOMAIN_SUPPORTS_DEINIT
+	bool
+	select MEM_DOMAIN_HAS_THREAD_LIST
+	help
+	  This hidden option is selected by the target architecture if
+	  the architecture supports de-initializing a memory domain.
+
 config MEM_DOMAIN_ISOLATED_STACKS
 	bool
 	default y

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -88,6 +88,16 @@ void *test_mem_domain_setup(void)
 	return NULL;
 }
 
+void test_mem_domain_teardown(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+#if defined(CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT)
+	zassert_equal(k_mem_domain_deinit(&test_domain), 0,
+		      "failed to de-initialize memory domain");
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT */
+}
+
 /* Helper function; run a function under a child user thread.
  * If domain is not NULL, add the child thread to that domain, instead of
  * whatever it would inherit.
@@ -230,6 +240,11 @@ static void mem_domain_init_entry(void *p1, void *p2, void *p3)
 	zassert_equal(
 		k_mem_domain_init(&no_access_domain, 0, NULL),
 		0, "failed to initialize memory domain");
+
+#if defined(CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT)
+	zassert_equal(k_mem_domain_deinit(&no_access_domain), 0,
+		      "failed to de-initialize memory domain");
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT */
 }
 
 static void mem_domain_add_partition_entry(void *p1, void *p2, void *p3)
@@ -500,6 +515,58 @@ ZTEST(mem_protect_domain, test_mem_domain_init_fail)
 		k_mem_domain_init(&test_domain_fail, ARRAY_SIZE(no_parts),
 				  no_parts),
 		0, "should fail to initialize memory domain");
+
+#if defined(CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT)
+	zassert_equal(k_mem_domain_deinit(&test_domain_fail), 0,
+		      "cannot de-initialize memory domain");
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT */
+}
+
+/**
+ * @brief Test error case of de-initializing memory domain fail
+ *
+ * @details Try to de-initialize a domain with various invalid
+ * conditions.
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+ZTEST(mem_protect_domain, test_mem_domain_deinit_fail)
+{
+#if defined(CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT)
+	set_fault_valid(false);
+
+	/* Should not be able to de-init the default domain. */
+	zassert_equal(k_mem_domain_deinit(&k_mem_domain_default), -EINVAL,
+		      "should fail de-initializing default domain");
+
+	/* Create a thread and attach it to the test_domain.
+	 * We should not be able to de-initialize the domain while
+	 * there is a thread attached to it.
+	 */
+	k_thread_create(&child_thread, child_stack, K_THREAD_STACK_SIZEOF(child_stack),
+			rw_part_access,	NULL, NULL, NULL, 0, K_USER, K_FOREVER);
+	k_thread_name_set(&child_thread, "child_thread");
+	k_mem_domain_add_thread(&test_domain, &child_thread);
+
+	zassert_equal(k_mem_domain_deinit(&test_domain), -EBUSY,
+		      "should fail de-initializing test domain with threads attached");
+
+	/* Let the thread run to the end so any memory domain related
+	 * cleanup will be done.
+	 */
+	k_thread_start(&child_thread);
+	k_thread_join(&child_thread, K_FOREVER);
+
+	/* Note that we cannot test the proper de-initialization of test_domain
+	 * here (... where this should succeed). It is because the test_domain
+	 * is still being used for other tests in this test suite.
+	 * Instead, it will be tested in test_mem_domain_teardown() when all
+	 * tests have run.
+	 */
+
+#else  /* CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT */
+	ztest_test_skip();
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SUPPORTS_DEINIT */
 }
 
 /**
@@ -603,4 +670,4 @@ ZTEST(mem_protect_domain, test_mem_part_remove_error_zerosize)
 }
 
 ZTEST_SUITE(mem_protect_domain, NULL, test_mem_domain_setup, NULL,
-		NULL, NULL);
+		NULL, test_mem_domain_teardown);

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -47,7 +47,7 @@ static void zzz_entry(void *p1, void *p2, void *p3)
 static K_THREAD_DEFINE(zzz_thread, 256 + CONFIG_TEST_EXTRA_STACK_SIZE,
 		       zzz_entry, NULL, NULL, NULL, 0, 0, 0);
 
-void test_mem_domain_setup(void)
+void *test_mem_domain_setup(void)
 {
 	int max_parts = arch_mem_domain_max_partitions_get();
 	struct k_mem_partition *parts[] = {
@@ -84,6 +84,8 @@ void test_mem_domain_setup(void)
 	for (unsigned int j = 0; j < MEM_REGION_ALLOC; j++) {
 		ro_buf[j] = (j % 256U);
 	}
+
+	return NULL;
 }
 
 /* Helper function; run a function under a child user thread.
@@ -600,13 +602,5 @@ ZTEST(mem_protect_domain, test_mem_part_remove_error_zerosize)
 		0, "should fail to remove memory partition");
 }
 
-/* setup function */
-void *mem_domain_setup(void)
-{
-	test_mem_domain_setup();
-
-	return NULL;
-}
-
-ZTEST_SUITE(mem_protect_domain, NULL, mem_domain_setup, NULL,
+ZTEST_SUITE(mem_protect_domain, NULL, test_mem_domain_setup, NULL,
 		NULL, NULL);

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -8,7 +8,7 @@
 #include <kernel_internal.h> /* For z_main_thread */
 #include <zephyr/sys/libc-hooks.h> /* for z_libc_partition */
 
-struct k_thread child_thread;
+static struct k_thread child_thread;
 K_THREAD_STACK_DEFINE(child_stack, KOBJECT_STACK_SIZE);
 
 /* Special memory domain for test case purposes */


### PR DESCRIPTION
This adds the ability to de-initialization a memory domain. This requires support in the architecture layer. One usage of this is to release the resources associated with the domain. For example, we can release allocated page tables so they can go back to the pool of page tables to be allocated later.

Xtensa is the first architecture to implement this as it allocates page tables on demand and can benefit from this.
