### PR TITLE
Bt addr cast void

### DIFF
--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -324,7 +324,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	} else if (bt_conn_get_info(conn, &info)) {
 		LOG_WRN("Could not parse connection info");
 	} else {
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 		error = otPlatBleGattMtuGet(ble_openthread_instance, &mtu);
 		if (error != OT_ERROR_NONE) {
@@ -368,7 +368,7 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t l
 	if (bt_conn_get_info(conn, &info)) {
 		LOG_INF("Could not parse connection info");
 	} else {
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 		error = otPlatBleGattMtuGet(ble_openthread_instance, &mtu);
 

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -541,7 +541,7 @@ bap_broadcast_assistant_recv_state_read_cb(struct bt_conn *conn, int err,
 	if (state != NULL) {
 		char le_addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
+		(void)bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
 		printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, encrypt_state "
 		       "%u, num_subgroups %u\n",
 		       state->src_id, le_addr, state->adv_sid, state->pa_sync_state,

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -653,7 +653,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0U) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -676,7 +676,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 
@@ -720,7 +720,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 	       le_addr, info->sid);

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -523,7 +523,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -544,7 +544,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/beacon/src/main.c
+++ b/samples/bluetooth/beacon/src/main.c
@@ -69,7 +69,7 @@ static void bt_ready(int err)
 	 */
 
 	bt_id_get(&addr, &count);
-	bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
+	(void)bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
 
 	printk("Beacon started, advertising as %s\n", addr_s);
 }

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -624,7 +624,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	LOG_INF("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 		le_addr, info->sid);

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -588,7 +588,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	LOG_INF("Attempt to connect to %s", addr_str);
 
 	err = bt_le_scan_stop();

--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -39,7 +39,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
@@ -77,7 +77,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -106,7 +106,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/central_gatt_write/src/central_gatt_write.c
+++ b/samples/bluetooth/central_gatt_write/src/central_gatt_write.c
@@ -26,7 +26,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	struct bt_conn *conn;
 	int err;
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 	       dev, type, ad->len, rssi);
 

--- a/samples/bluetooth/central_gatt_write/src/gatt_write_common.c
+++ b/samples/bluetooth/central_gatt_write/src/gatt_write_common.c
@@ -395,7 +395,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		printk("%s: Failed to connect to %s (0x%02x)\n", __func__, addr,
@@ -447,7 +447,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	err = bt_conn_get_info(conn, &conn_info);
 	if (err) {
@@ -497,7 +497,7 @@ static void le_phy_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE PHY Updated: %s Tx 0x%x, Rx 0x%x\n", addr, param->tx_phy,
 	       param->rx_phy);
@@ -510,7 +510,7 @@ static void le_data_len_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Data length updated: %s max tx %u (%u us) max rx %u (%u us)\n",
 	       addr, info->tx_max_len, info->tx_max_time, info->rx_max_len,

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -166,7 +166,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 	       dev, type, ad->len, rssi);
 
@@ -214,7 +214,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -250,7 +250,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -128,7 +128,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -211,7 +211,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 	       dev, type, ad->len, rssi);
 
@@ -241,7 +241,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -67,7 +67,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
@@ -144,7 +144,7 @@ static void connected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (reason) {
 		printk("Failed to connect to %s (%u)\n", addr, reason);
@@ -182,7 +182,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 
@@ -199,7 +199,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE conn param req: %s int (0x%04x, 0x%04x) lat %d to %d\n",
 	       addr, param->interval_min, param->interval_max, param->latency,
@@ -213,7 +213,7 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE conn param updated: %s int 0x%04x lat %d to %d\n",
 	       addr, interval, latency, timeout);
@@ -225,7 +225,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
@@ -242,7 +242,7 @@ static void le_phy_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE PHY Updated: %s Tx 0x%x, Rx 0x%x\n", addr, param->tx_phy,
 	       param->rx_phy);
@@ -255,7 +255,7 @@ static void le_data_len_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Data length updated: %s max tx %u (%u us) max rx %u (%u us)\n",
 	       addr, info->tx_max_len, info->tx_max_time, info->rx_max_len,
@@ -288,7 +288,7 @@ static void remote_info(struct bt_conn *conn, void *data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Get remote info %s...\n", addr);
 	err = bt_conn_get_remote_info(conn, &remote_info);
@@ -308,7 +308,7 @@ static void disconnect(struct bt_conn *conn, void *data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnecting %s...\n", addr);
 

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -271,7 +271,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 
 	/* We're only interested in connectable events and scan response
 	 * because service UUID is in sd of sample peripheral_ots.
@@ -497,7 +497,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 	first_selected = false;
 	if (err != 0) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -538,7 +538,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -71,7 +71,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i, name: %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
@@ -143,7 +143,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int bt_err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -179,7 +179,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 
@@ -205,7 +205,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -220,7 +220,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -233,7 +233,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char data_str[129];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
@@ -307,7 +307,7 @@ int main(void)
 		}
 		printk("Found periodic advertising.\n");
 
-		bt_addr_le_to_str(&per_addr, le_addr, sizeof(le_addr));
+		(void)bt_addr_le_to_str(&per_addr, le_addr, sizeof(le_addr));
 		printk("Creating Periodic Advertising Sync to %s...\n", le_addr);
 		bt_addr_le_copy(&sync_create_param.addr, &per_addr);
 		sync_create_param.options = 0;

--- a/samples/bluetooth/classic/a2dp_source/src/main.c
+++ b/samples/bluetooth/classic/a2dp_source/src/main.c
@@ -564,7 +564,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 
 	bt_conn_get_info(conn, &info);
 
-	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+	(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	printk("Security changed: %s level %u, err %s(%d)\n", addr, level,
 	       bt_security_err_to_str(err), err);
@@ -588,7 +588,7 @@ static void discovery_timeout_cb(const struct bt_br_discovery_result *results, s
 	size_t i;
 
 	for (i = 0; i < count; i++) {
-		bt_addr_to_str(&results[i].addr, addr, sizeof(addr));
+		(void)bt_addr_to_str(&results[i].addr, addr, sizeof(addr));
 		printk("Device[%d]: %s, rssi %d, cod 0x%02x%02x%02x", i, addr, results[i].rssi,
 		       results[i].cod[0], results[i].cod[1], results[i].cod[2]);
 

--- a/samples/bluetooth/classic/handsfree_ag/src/main.c
+++ b/samples/bluetooth/classic/handsfree_ag/src/main.c
@@ -309,7 +309,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 
 	bt_conn_get_info(conn, &info);
 
-	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+	(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	printk("Security changed: %s level %u, err %s(%d)\n", addr, level,
 	       bt_security_err_to_str(err), err);
@@ -338,7 +338,7 @@ static void discovery_timeout_cb(const struct bt_br_discovery_result *results, s
 	size_t i;
 
 	for (i = 0; i < count; i++) {
-		bt_addr_to_str(&results[i].addr, addr, sizeof(addr));
+		(void)bt_addr_to_str(&results[i].addr, addr, sizeof(addr));
 		printk("Device[%d]: %s, rssi %d, cod 0x%02x%02x%02x", i, addr, results[i].rssi,
 		       results[i].cod[0], results[i].cod[1], results[i].cod[2]);
 

--- a/samples/bluetooth/direct_adv/src/main.c
+++ b/samples/bluetooth/direct_adv/src/main.c
@@ -120,7 +120,7 @@ static void bt_ready(void)
 	 * This means there is no bond yet.
 	 */
 	if (bt_addr_le_cmp(&bond_addr, BT_ADDR_LE_NONE) != 0) {
-		bt_addr_le_to_str(&bond_addr, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(&bond_addr, addr, sizeof(addr));
 		printk("Direct advertising to %s\n", addr);
 
 		adv_param = *BT_LE_ADV_CONN_DIR_LOW_DUTY(&bond_addr);

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -128,7 +128,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n", dev, type, ad->len, rssi);
 
 	/* We're only interested in connectable events */
@@ -206,7 +206,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -229,7 +229,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 
@@ -247,7 +247,7 @@ static void cte_recv_cb(struct bt_conn *conn, struct bt_df_conn_iq_samples_repor
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (report->err == BT_DF_IQ_REPORT_ERR_SUCCESS) {
 		printk("CTE[%s]: samples type: %s, samples count %d, cte type %s, slot durations: "

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -160,7 +160,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -175,7 +175,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -195,7 +195,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 	static char data_str[ADV_DATA_HEX_STR_LEN_MAX];
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
@@ -239,7 +239,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s C:%u S:%u "
 	       "D:%u SR:%u E:%u Prim: %s, Secn: %s, Interval: 0x%04x (%u ms), "

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -154,7 +154,7 @@ int main(void)
 	}
 	printk("success\n");
 
-	bt_addr_le_to_str(&oob_local.addr, addr_s, sizeof(addr_s));
+	(void)bt_addr_le_to_str(&oob_local.addr, addr_s, sizeof(addr_s));
 
 	printk("Started extended advertising as %s\n", addr_s);
 	return 0;

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -445,7 +445,7 @@ static int eds_slot_restart(struct eds_slot *slot, uint8_t type)
 		return err;
 	}
 
-	bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
+	(void)bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
 	printk("Advertising as %s\n", addr_s);
 
 	slot->type = type;
@@ -642,7 +642,7 @@ static void bt_ready(int err)
 
 	/* Restore connectable if slot */
 	bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
-	bt_addr_le_to_str(&oob.addr, addr_s, sizeof(addr_s));
+	(void)bt_addr_le_to_str(&oob.addr, addr_s, sizeof(addr_s));
 	printk("Initial advertising as %s\n", addr_s);
 
 	k_work_schedule(&idle_work, EDS_IDLE_TIMEOUT);

--- a/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
@@ -106,7 +106,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	/* We are only interested in the previously connected device. */
 	if (!bt_addr_le_eq(addr, &peer_addr)) {
@@ -145,7 +145,7 @@ static void connect_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t 
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
 
@@ -306,7 +306,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		LOG_DBG("Failed to connect to %s (err %u)", addr, conn_err);
@@ -328,7 +328,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
 
@@ -344,7 +344,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr, level);
@@ -360,8 +360,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_identity[BT_ADDR_LE_STR_LEN];
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
 
@@ -373,7 +373,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	char passkey_str[7];
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, ARRAY_SIZE(passkey_str), "%06u", passkey);
 
@@ -387,7 +387,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 	char passkey_str[7];
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, ARRAY_SIZE(passkey_str), "%06u", passkey);
 
@@ -398,7 +398,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Pairing cancelled: %s", addr);
 }

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
@@ -185,7 +185,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		LOG_ERR("Failed to connect to %s %u %s", addr, err, bt_hci_err_to_str(err));
@@ -201,7 +201,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected from %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
 
@@ -212,7 +212,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr, level);
@@ -227,7 +227,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	char passkey_str[7];
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, ARRAY_SIZE(passkey_str), "%06u", passkey);
 
@@ -241,7 +241,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 	char passkey_str[7];
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, ARRAY_SIZE(passkey_str), "%06u", passkey);
 
@@ -252,7 +252,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Pairing cancelled: %s", addr);
 }

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -364,7 +364,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -386,7 +386,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -157,7 +157,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 			printk("No connection handle (err %d)\n", ret);
 		} else {
 			/* Send first at the default selected power */
-			bt_addr_le_to_str(bt_conn_get_dst(conn),
+			(void)bt_addr_le_to_str(bt_conn_get_dst(conn),
 							  addr, sizeof(addr));
 			printk("Connected via connection (%d) at %s\n",
 			       default_conn_handle, addr);

--- a/samples/bluetooth/hci_vs_scan_req/src/main.c
+++ b/samples/bluetooth/hci_vs_scan_req/src/main.c
@@ -48,7 +48,7 @@ static const char *bt_addr_le_str(const bt_addr_le_t *addr)
 {
 	static char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	return str;
 }

--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -100,7 +100,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	LOG_INF("Found broadcaster with address %s (RSSI %i)",
 		le_addr, info->rssi);

--- a/samples/bluetooth/iso_central/src/main.c
+++ b/samples/bluetooth/iso_central/src/main.c
@@ -108,7 +108,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
@@ -197,7 +197,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	int iso_err;
 	struct bt_iso_connect_param connect_param;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -234,7 +234,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -500,7 +500,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	LOG_INF("Found peripheral with address %s (RSSI %i)",
 		le_addr, info->rssi);
@@ -519,7 +519,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0 && role == ROLE_CENTRAL) {
 		LOG_INF("Failed to connect to %s: %u %s", addr, err, bt_hci_err_to_str(err));
@@ -540,7 +540,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_INF("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/iso_peripheral/src/main.c
+++ b/samples/bluetooth/iso_peripheral/src/main.c
@@ -31,7 +31,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -45,7 +45,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected from %s, reason 0x%02x %s\n", addr,
 	       reason, bt_hci_err_to_str(reason));

--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -102,7 +102,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 	       "Interval: 0x%04x (%u us), SID: %u\n",
@@ -135,7 +135,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -150,7 +150,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -166,7 +166,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char data_str[129];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
@@ -180,7 +180,7 @@ static void biginfo_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
 
 	printk("BIG INFO[%u]: [DEVICE]: %s, sid 0x%02x, "
 	       "num_bis %u, nse %u, interval 0x%04x (%u ms), "

--- a/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
+++ b/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
@@ -127,7 +127,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
@@ -191,7 +191,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -231,7 +231,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/observer/src/observer.c
+++ b/samples/bluetooth/observer/src/observer.c
@@ -14,7 +14,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d), type %u, AD data len %u\n",
 	       addr_str, rssi, type, ad->len);
 }
@@ -65,7 +65,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS(info->adv_props);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i "
 	       "Data status: %u, AD data len: %u Name: %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Pri PHY: %s, Sec PHY: %s, "

--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -95,7 +95,7 @@ static void response_cb(struct bt_le_ext_adv *adv, struct bt_le_per_adv_response
 		return;
 	}
 
-	bt_addr_le_to_str(&peer, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&peer, addr_str, sizeof(addr_str));
 	printk("Connecting to %s in subevent %d\n", addr_str, info->subevent);
 
 	synced_param.peer = &peer;

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -85,7 +85,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 	       "Interval: 0x%04x (%u ms), SID: %u\n",
@@ -132,7 +132,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -147,7 +147,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -162,7 +162,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char data_str[129];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "

--- a/samples/bluetooth/periodic_sync_conn/src/main.c
+++ b/samples/bluetooth/periodic_sync_conn/src/main.c
@@ -29,7 +29,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync, struct bt_le_per_adv_sync_s
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("Synced to %s with %d subevents\n", le_addr, info->num_subevents);
 
 	params.properties = 0;
@@ -49,7 +49,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Sync terminated (reason %d)\n", info->reason);
 }
@@ -86,7 +86,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 			return;
 		}
 
-		bt_addr_le_to_str(&oob.addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&oob.addr, addr_str, sizeof(addr_str));
 		printk("Responding with own addr: %s\n", addr_str);
 
 		net_buf_simple_add_u8(&rsp_buf, sizeof(bt_addr_le_t));

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -32,7 +32,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync, struct bt_le_per_adv_sync_s
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("Synced to %s with %d subevents\n", le_addr, info->num_subevents);
 
 	default_sync = sync;
@@ -57,7 +57,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Sync terminated (reason %d)\n", info->reason);
 

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -270,7 +270,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Passkey for %s: %06u\n", addr, passkey);
 }
@@ -279,7 +279,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/peripheral_accept_list/src/main.c
+++ b/samples/bluetooth/peripheral_accept_list/src/main.c
@@ -103,7 +103,7 @@ static void add_bonded_addr_to_filter_list(const struct bt_bond_info *info, void
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
 	bt_le_filter_accept_list_add(&info->addr);
-	bt_addr_le_to_str(&info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&info->addr, addr_str, sizeof(addr_str));
 	printk("Added %s to advertising accept filter list\n", addr_str);
 	bond_count++;
 }

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -434,7 +434,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Passkey for %s: %06u\n", addr, passkey);
 }
@@ -443,7 +443,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/peripheral_gap_svc/src/main.c
+++ b/samples/bluetooth/peripheral_gap_svc/src/main.c
@@ -91,7 +91,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err != BT_HCI_ERR_SUCCESS) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -105,7 +105,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 }

--- a/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
+++ b/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
@@ -36,7 +36,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }
@@ -61,7 +61,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 }
 

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -39,7 +39,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s, err 0x%02x %s\n", addr,
@@ -58,7 +58,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected from %s, reason 0x%02x %s\n", addr,
 	       reason, bt_hci_err_to_str(reason));
@@ -69,7 +69,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
@@ -113,7 +113,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Passkey for %s: %06u\n", addr, passkey);
 }
@@ -122,7 +122,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -85,7 +85,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -75,7 +75,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -107,7 +107,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		k_work_submit(&work_adv_start);
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Connected (%u): %s\n", conn_count, addr);
 }
@@ -116,7 +116,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected %s, reason %s(0x%02x)\n", addr, bt_hci_err_to_str(reason), reason);
 
@@ -135,7 +135,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE conn  param req: %s int (0x%04x, 0x%04x) lat %d to %d\n",
 	       addr, param->interval_min, param->interval_max, param->latency,
@@ -149,7 +149,7 @@ static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE conn param updated: %s int 0x%04x lat %d to %d\n",
 	       addr, interval, latency, timeout);
@@ -161,7 +161,7 @@ static void le_phy_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("LE PHY Updated: %s Tx 0x%x, Rx 0x%x\n", addr, param->tx_phy,
 	       param->rx_phy);
@@ -174,7 +174,7 @@ static void le_data_len_updated(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Data length updated: %s max tx %u (%u us) max rx %u (%u us)\n",
 	       addr, info->tx_max_len, info->tx_max_time, info->rx_max_len,
@@ -188,7 +188,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
@@ -202,7 +202,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }
@@ -243,7 +243,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 }
 #endif /* CONFIG_BT_OBSERVER */
@@ -253,7 +253,7 @@ static void disconnect(struct bt_conn *conn, void *data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnecting %s...\n", addr);
 

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -26,9 +26,9 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
-	bt_addr_le_to_str(bt_conn_get_dst(info->conn), past_peer_addr,
+	(void)bt_addr_le_to_str(bt_conn_get_dst(info->conn), past_peer_addr,
 			  sizeof(past_peer_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, Interval 0x%04x (%u ms). PAST peer %s\n",
@@ -43,7 +43,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -58,7 +58,7 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char data_str[129];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, RSSI %i, CTE %u, data length %u, "
@@ -76,7 +76,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (default_conn == NULL) {
 		default_conn = bt_conn_ref(conn);
@@ -97,7 +97,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -44,7 +44,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -62,7 +62,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected from %s, reason 0x%02x %s\n", addr,
 	       reason, bt_hci_err_to_str(reason));
@@ -74,8 +74,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_identity[BT_ADDR_LE_STR_LEN];
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	printk("Identity resolved %s -> %s\n", addr_rpa, addr_identity);
 }
@@ -85,7 +85,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
@@ -107,7 +107,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Passkey for %s: %06u\n", addr, passkey);
 }
@@ -116,7 +116,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/samples/bluetooth/tmap_central/src/main.c
+++ b/samples/bluetooth/tmap_central/src/main.c
@@ -211,7 +211,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	/* Check for connectable, extended advertising */
 	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0) ||
 		((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) != 0) {
-		bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+		(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 		printk("[DEVICE]: %s, ", le_addr);
 		/* Check for TMAS support in advertising data */
 		bt_data_parse(buf, check_audio_support_and_connect, (void *)info->addr);

--- a/samples/bluetooth/tmap_peripheral/src/main.c
+++ b/samples/bluetooth/tmap_peripheral/src/main.c
@@ -103,7 +103,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		printk("Failed to connect to %s %u %s\n", addr, err, bt_hci_err_to_str(err));
@@ -125,7 +125,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/samples/boards/st/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/st/power_mgmt/stm32wb_ble/src/main.c
@@ -73,7 +73,7 @@ static void bt_ready(int err)
 	 */
 
 	bt_id_get(&addr, &count);
-	bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
+	(void)bt_addr_le_to_str(&addr, addr_s, sizeof(addr_s));
 
 	printk("Beacon started, advertising as %s\n", addr_s);
 

--- a/samples/subsys/logging/ble_backend/src/main.c
+++ b/samples/subsys/logging/ble_backend/src/main.c
@@ -59,7 +59,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_INF("Pairing cancelled: %s", addr);
 }

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -814,7 +814,7 @@ static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void
 				atomic_set_bit(svc_inst->clients[j].flags, FLAG_ACTIVE);
 				memcpy(&svc_inst->clients[j].addr, &info->addr,
 				       sizeof(bt_addr_le_t));
-				bt_addr_le_to_str(&svc_inst->clients[j].addr, addr_str,
+				(void)bt_addr_le_to_str(&svc_inst->clients[j].addr, addr_str,
 						  sizeof(addr_str));
 				LOG_DBG("Added %s to bonded list\n", addr_str);
 				return;

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1367,7 +1367,7 @@ static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void
 
 			atomic_set_bit(pacs.clients[i].flags, FLAG_ACTIVE);
 			memcpy(&pacs.clients[i].addr, &info->addr, sizeof(bt_addr_le_t));
-			bt_addr_le_to_str(&pacs.clients[i].addr, addr_str, sizeof(addr_str));
+			(void)bt_addr_le_to_str(&pacs.clients[i].addr, addr_str, sizeof(addr_str));
 			LOG_DBG("Added %s to bonded list\n", addr_str);
 			return;
 		}

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2437,7 +2437,7 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct 
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 
 	bt_shell_print("Found broadcaster with ID 0x%06X (%s) and addr %s and sid 0x%02X (scanning "
 		       "for 0x%06X (%s))",

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -121,7 +121,7 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bt_shell_print(
 		"[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
 		le_addr, broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval),
@@ -153,7 +153,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 		return;
 	}
 
-	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
 	bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 
 	is_bad_code = state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE;
@@ -615,7 +615,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 		char addr_str[BT_ADDR_LE_STR_LEN];
 		bool identified_broadcast = false;
 
-		bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 
 		if (sr_info.broadcast_id == auto_scan.broadcast_id) {
 			identified_broadcast = true;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -262,7 +262,7 @@ static int pa_sync_no_past(struct scan_delegator_sync_state *state, uint16_t pa_
 	} else {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&recv_state->addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&recv_state->addr, addr_str, sizeof(addr_str));
 		bt_shell_info("PA sync pending for addr %s", addr_str);
 		state->pa_syncing = true;
 		k_work_init_delayable(&state->pa_timer, pa_timer_handler);

--- a/subsys/bluetooth/audio/shell/cap_acceptor.c
+++ b/subsys/bluetooth/audio/shell/cap_acceptor.c
@@ -292,7 +292,7 @@ static int cmd_cap_acceptor_get_info(const struct shell *sh, size_t argc, char *
 	if (info.locked) {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&info.lock_client_addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&info.lock_client_addr, addr_str, sizeof(addr_str));
 		shell_print(sh, "\tLock owner: %s", addr_str);
 	}
 

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -56,7 +56,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	uint8_t conn_index;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		bt_shell_error("Failed to connect to %s (%u)", addr, err);
@@ -216,7 +216,7 @@ static bool csip_found(struct bt_data *data, void *user_data)
 		bt_addr_le_t *addr = user_data;
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 		bt_shell_print("Found CSIP advertiser with address %s", addr_str);
 
 		if (is_discovered(addr)) {
@@ -300,7 +300,7 @@ static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 
 	conn = conns[member_index];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	shell_print(sh, "Discovering for member[%u] (%s)",
 		    (uint8_t)member_index, addr);

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -282,7 +282,7 @@ static int cmd_csip_set_member_get_info(const struct shell *sh, size_t argc, cha
 	if (info.locked) {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&info.lock_client_addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&info.lock_client_addr, addr_str, sizeof(addr_str));
 		shell_print(sh, "\tLock owner: %s", addr_str);
 	}
 

--- a/subsys/bluetooth/common/bt_str.c
+++ b/subsys/bluetooth/common/bt_str.c
@@ -39,7 +39,7 @@ const char *bt_addr_str(const bt_addr_t *addr)
 {
 	static char str[BT_ADDR_STR_LEN];
 
-	bt_addr_to_str(addr, str, sizeof(str));
+	(void)bt_addr_to_str(addr, str, sizeof(str));
 
 	return str;
 }
@@ -48,7 +48,7 @@ const char *bt_addr_le_str(const bt_addr_le_t *addr)
 {
 	static char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	return str;
 }

--- a/subsys/bluetooth/controller/ll_sw/shell/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/shell/ll.c
@@ -45,7 +45,7 @@ int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	(void)ll_addr_read(addr_type, addr.val);
-	bt_addr_to_str(&addr, str_addr, sizeof(str_addr));
+	(void)bt_addr_to_str(&addr, str_addr, sizeof(str_addr));
 
 	shell_print(sh, "Current %s address: %s", str_type, str_addr);
 

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -145,7 +145,7 @@ static void br_device_found(const bt_addr_t *addr, int8_t rssi, const uint8_t co
 		eir += eir[0] + 1;
 	}
 
-	bt_addr_to_str(addr, br_addr, sizeof(br_addr));
+	(void)bt_addr_to_str(addr, br_addr, sizeof(br_addr));
 
 	bt_shell_print("[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
 }
@@ -984,7 +984,7 @@ static int cmd_oob(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	bt_addr_to_str(&oob.addr, addr, sizeof(addr));
+	(void)bt_addr_to_str(&oob.addr, addr, sizeof(addr));
 
 	shell_print(sh, "BR/EDR OOB data:");
 	shell_print(sh, "  addr %s", addr);
@@ -1615,7 +1615,7 @@ static void bond_info(const struct bt_br_bond_info *info, void *user_data)
 	char addr[BT_ADDR_STR_LEN];
 	int *bond_count = user_data;
 
-	bt_addr_to_str(&info->addr, addr, sizeof(addr));
+	(void)bt_addr_to_str(&info->addr, addr, sizeof(addr));
 	bt_shell_print("Remote Identity: %s", addr);
 	(*bond_count)++;
 }
@@ -1688,7 +1688,7 @@ static int cmd_select(const struct shell *sh, size_t argc, char *argv[])
 
 	default_conn = conn;
 
-	bt_addr_to_str(&addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_to_str(&addr, addr_str, sizeof(addr_str));
 	shell_print(sh, "Selected conn is now: %s", addr_str);
 
 	return 0;
@@ -1752,7 +1752,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 	if (info.type == BT_CONN_TYPE_BR) {
 		char addr_str[BT_ADDR_STR_LEN];
 
-		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
+		(void)bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
 		shell_print(sh, "Peer address %s", addr_str);
 	}
 

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -139,7 +139,7 @@ static void print_le_addr(const char *desc, const bt_addr_le_t *addr)
 				bt_addr_le_is_rpa(addr) ? "resolvable" :
 				"non-resolvable";
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	bt_shell_print("%s address: %s (%s)", desc, addr_str, addr_desc);
 }
@@ -527,7 +527,7 @@ bool passes_scan_filter(const struct bt_le_scan_recv_info *info, const struct ne
 	if (scan_filter.addr_set) {
 		char le_addr[BT_ADDR_LE_STR_LEN] = {0};
 
-		bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+		(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 		if (!is_substring(scan_filter.addr, le_addr)) {
 			return false;
@@ -568,7 +568,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 	(void)memset(name, 0, sizeof(name));
 
 	bt_data_parse(buf, data_cb, name);
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	bt_shell_print("%s%s, AD evt type %u, RSSI %i %s "
 		       "C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
@@ -642,7 +642,7 @@ static void adv_scanned(struct bt_le_ext_adv *adv,
 {
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(info->addr, str, sizeof(str));
 
 	bt_shell_print("Advertiser[%d] %p scanned by %s", bt_le_ext_adv_get_index(adv), adv, str);
 }
@@ -654,7 +654,7 @@ static void adv_connected(struct bt_le_ext_adv *adv,
 {
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(info->conn), str, sizeof(str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(info->conn), str, sizeof(str));
 
 	bt_shell_print("Advertiser[%d] %p connected by %s", bt_le_ext_adv_get_index(adv), adv, str);
 }
@@ -710,7 +710,7 @@ static const char *current_prompt(void)
 		return NULL;
 	}
 
-	bt_addr_le_to_str(info.le.dst, str, sizeof(str) - 2);
+	(void)bt_addr_le_to_str(info.le.dst, str, sizeof(str) - 2);
 	strcat(str, "> ");
 	return str;
 }
@@ -728,11 +728,11 @@ void conn_addr_str(struct bt_conn *conn, char *addr, size_t len)
 	switch (info.type) {
 #if defined(CONFIG_BT_CLASSIC)
 	case BT_CONN_TYPE_BR:
-		bt_addr_to_str(info.br.dst, addr, len);
+		(void)bt_addr_to_str(info.br.dst, addr, len);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
-		bt_addr_le_to_str(info.le.dst, addr, len);
+		(void)bt_addr_le_to_str(info.le.dst, addr, len);
 		break;
 	default:
 		break;
@@ -745,7 +745,7 @@ static void print_le_oob(const struct shell *sh, struct bt_le_oob *oob)
 	char c[KEY_STR_LEN];
 	char r[KEY_STR_LEN];
 
-	bt_addr_le_to_str(&oob->addr, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(&oob->addr, addr, sizeof(addr));
 
 	bin2hex(oob->le_sc_data.c, sizeof(oob->le_sc_data.c), c, sizeof(c));
 	bin2hex(oob->le_sc_data.r, sizeof(oob->le_sc_data.r), r, sizeof(r));
@@ -871,8 +871,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_identity[BT_ADDR_LE_STR_LEN];
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	bt_shell_print("Identity resolved %s -> %s", addr_rpa, addr_identity);
 }
@@ -1333,7 +1333,7 @@ static void per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char past_peer[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	if (is_past_peer) {
 		conn_addr_str(info->conn, past_peer, sizeof(past_peer));
@@ -1369,7 +1369,7 @@ static void per_adv_sync_terminated_cb(
 		}
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bt_shell_print("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
 		       bt_le_per_adv_sync_get_index(sync), le_addr);
 }
@@ -1381,7 +1381,7 @@ static void per_adv_sync_recv_cb(
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bt_shell_print("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
 		       "RSSI %i, CTE %u, data length %u",
 		       bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power,
@@ -1393,7 +1393,7 @@ static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
 	bt_shell_print("BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
 		       "nse 0x%02x, interval 0x%04x (%u us), bn 0x%02x, pto 0x%02x, irc 0x%02x, "
 		       "max_pdu 0x%04x, sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, "
@@ -1627,7 +1627,7 @@ static int cmd_id_create(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
 	shell_print(sh, "New identity (%d) created: %s", err, addr_str);
 
 	return 0;
@@ -1663,7 +1663,7 @@ static int cmd_id_reset(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
 	shell_print(sh, "Identity %u reset: %s", id, addr_str);
 
 	return 0;
@@ -1702,7 +1702,7 @@ static int cmd_id_show(const struct shell *sh, size_t argc, char *argv[])
 	for (i = 0; i < count; i++) {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&addrs[i], addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&addrs[i], addr_str, sizeof(addr_str));
 		shell_print(sh, "%s%zu: %s", i == selected_id ? "*" : " ", i, addr_str);
 	}
 
@@ -1724,7 +1724,7 @@ static int cmd_id_select(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	bt_addr_le_to_str(&addrs[id], addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&addrs[id], addr_str, sizeof(addr_str));
 	shell_print(sh, "Selected identity: %s", addr_str);
 	selected_id = id;
 
@@ -3783,7 +3783,7 @@ static int cmd_select(const struct shell *sh, size_t argc, char *argv[])
 
 	default_conn = conn;
 
-	bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&addr, addr_str, sizeof(addr_str));
 	shell_print(sh, "Selected conn is now: %s", addr_str);
 
 	return 0;
@@ -3888,7 +3888,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 	if (info.type == BT_CONN_TYPE_BR) {
 		char addr_str[BT_ADDR_STR_LEN];
 
-		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
+		(void)bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
 		shell_print(sh, "Peer address %s", addr_str);
 	}
 #endif /* defined(CONFIG_BT_CLASSIC) */
@@ -4244,7 +4244,7 @@ static void bond_info(const struct bt_bond_info *info, void *user_data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int *bond_count = user_data;
 
-	bt_addr_le_to_str(&info->addr, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(&info->addr, addr, sizeof(addr));
 	bt_shell_print("Remote Identity: %s", addr);
 	(*bond_count)++;
 }
@@ -4279,19 +4279,19 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 	switch (info.type) {
 #if defined(CONFIG_BT_CLASSIC)
 	case BT_CONN_TYPE_BR:
-		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+		(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 		bt_shell_print("%s#%u [BR][%s] %s", selected, info.id, role_str, addr);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
-		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		bt_shell_print("%s#%u [LE][%s] %s: Interval %u us, latency %u, timeout %u ms",
 			       selected, info.id, role_str, addr, info.le.interval_us,
 			       info.le.latency, info.le.timeout * 10);
 		break;
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
-		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		bt_shell_print(" #%u [ISO][%s] %s", info.id, role_str, addr);
 		break;
 #endif
@@ -4318,7 +4318,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 	char addr[BT_ADDR_LE_STR_LEN];
 	char passkey_str[7];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
@@ -4331,7 +4331,7 @@ static void auth_passkey_display_keypress(struct bt_conn *conn,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	bt_shell_print("Passkey keypress notification from %s: type %d", addr, type);
 }
@@ -4342,7 +4342,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	char addr[BT_ADDR_LE_STR_LEN];
 	char passkey_str[7];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
@@ -4353,7 +4353,7 @@ static void auth_passkey_entry(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	bt_shell_print("Enter passkey for %s", addr);
 }
@@ -4377,7 +4377,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	bt_shell_print("Confirm pairing for %s", addr);
 }
@@ -4424,7 +4424,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 
 		if (oobd_remote &&
 		    !bt_addr_le_eq(info.le.remote, &oob_remote.addr)) {
-			bt_addr_le_to_str(info.le.remote, addr, sizeof(addr));
+			(void)bt_addr_le_to_str(info.le.remote, addr, sizeof(addr));
 			bt_shell_print("No OOB data available for remote %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
@@ -4432,7 +4432,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 
 		if (oobd_local &&
 		    !bt_addr_le_eq(info.le.local, &oob_local.addr)) {
-			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
+			(void)bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
 			bt_shell_print("No OOB data available for local %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
@@ -4440,14 +4440,14 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 
 		bt_le_oob_set_sc_data(conn, oobd_local, oobd_remote);
 
-		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		bt_shell_print("Set %s OOB SC data for %s, ",
 			       oob_config_str(oob_info->lesc.oob_config), addr);
 		return;
 	}
 #endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
-	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 	bt_shell_print("Legacy OOB TK requested from remote %s", addr);
 }
 
@@ -4462,10 +4462,10 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 	switch (info.type) {
 	case BT_CONN_TYPE_LE:
-		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		break;
 	case BT_CONN_TYPE_BR:
-		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+		(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 		break;
 	default:
 		bt_shell_print("Unrecognized conn type: %d", info.type);
@@ -4486,10 +4486,10 @@ static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
 
 	switch (info.type) {
 	case BT_CONN_TYPE_LE:
-		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 		break;
 	case BT_CONN_TYPE_BR:
-		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+		(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 		break;
 	default:
 		bt_shell_print("Unrecognized conn type: %d", info.type);
@@ -4513,7 +4513,7 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 		return;
 	}
 
-	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
+	(void)bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	if (highsec) {
 		bt_shell_print("Enter 16 digits wide PIN code for %s", addr);
@@ -4554,7 +4554,7 @@ void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(peer, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(peer, addr, sizeof(addr));
 	bt_shell_print("Bond deleted for %s, id %u", addr, id);
 }
 
@@ -4563,7 +4563,7 @@ static void br_bond_deleted(const bt_addr_t *peer)
 {
 	char addr[BT_ADDR_STR_LEN];
 
-	bt_addr_to_str(peer, addr, sizeof(addr));
+	(void)bt_addr_to_str(peer, addr, sizeof(addr));
 	bt_shell_print("Classic bond deleted for %s", addr);
 }
 #endif /* CONFIG_BT_CLASSIC */

--- a/tests/bluetooth/classic/smp_general/src/smp_br_general.c
+++ b/tests/bluetooth/classic/smp_general/src/smp_br_general.c
@@ -517,7 +517,7 @@ static int cmd_get_security_info(const struct shell *sh, size_t argc, char *argv
 		return -ENOEXEC;
 	}
 
-	bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
+	(void)bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
 	shell_print(sh, "Peer address %s", addr_str);
 	shell_print(sh, "Encryption key size: %d", info.security.enc_key_size);
 	shell_print(sh, "Security level: %d", info.security.level);

--- a/tests/bluetooth/common/testlib/src/att.c
+++ b/tests/bluetooth/common/testlib/src/att.c
@@ -29,7 +29,7 @@ static void bt_testlib_att_exchange_mtu_cb(struct bt_conn *conn, uint8_t err,
 
 	k_mutex_lock(&exchange_mtu_lock, K_FOREVER);
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("MTU exchange %s (%s)", err == 0U ? "successful" : "failed", addr);
 

--- a/tests/bluetooth/host/conn/mocks/bt_str.c
+++ b/tests/bluetooth/host/conn/mocks/bt_str.c
@@ -13,7 +13,7 @@ const char *bt_addr_le_str(const bt_addr_le_t *addr)
 {
 	static char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	return str;
 }

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -808,7 +808,7 @@ static bool baa_check(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	LOG_DBG("Found BAA with ID 0x%06X, addr %s, sid 0x%02X, interval 0x%04X", broadcast_id,
 		le_addr, info->sid, info->interval);
@@ -1526,7 +1526,7 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	LOG_DBG("[DEVICE]: %s, broadcast_id 0x%06X, interval (ms) %u (0x%04x)), SID 0x%x, RSSI %i",
 		le_addr, broadcast_id, BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval),
 		info->interval, info->sid, info->rssi);

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -1922,7 +1922,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	struct btp_bap_unicast_connection *u_conn;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		LOG_DBG("Failed to connect to %s (%u)", addr, err);
@@ -1940,7 +1940,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
 }

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -428,7 +428,7 @@ static void oob_data_request(struct bt_conn *conn,
 
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
 
 	switch (oob_info->type) {
 	case BT_CONN_OOB_LE_SC:
@@ -461,7 +461,7 @@ static void oob_data_request(struct bt_conn *conn,
 
 		if (oobd_local &&
 		    !bt_addr_le_eq(info.le.local, &oob_sc_local.addr)) {
-			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
+			(void)bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
 			LOG_DBG("No OOB data available for local %s",
 				addr);
 			bt_conn_auth_cancel(conn);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -90,7 +90,7 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("Scan Recv: [DEVICE]: %s, broadcast_id 0x%06X, "
 	       "interval (ms) %u), SID 0x%x, RSSI %i\n",
 	       le_addr, broadcast_id, info->interval * 5 / 4,
@@ -133,7 +133,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 		return;
 	}
 
-	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
 	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 	printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, encrypt_state %u%s%s\n",
 	       state->src_id, le_addr, state->adv_sid, state->pa_sync_state, state->encrypt_state,
@@ -303,7 +303,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -318,7 +318,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -487,8 +487,8 @@ static void test_bass_add_source(void)
 		char addr[BT_ADDR_LE_STR_LEN];
 		char expected_addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&recv_state.addr, addr, sizeof(addr));
-		bt_addr_le_to_str(&add_src_param.addr, expected_addr, sizeof(expected_addr));
+		(void)bt_addr_le_to_str(&recv_state.addr, addr, sizeof(addr));
+		(void)bt_addr_le_to_str(&add_src_param.addr, expected_addr, sizeof(expected_addr));
 
 		FAIL("Unexpected addr %s != %s\n", addr, expected_addr);
 		return;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -325,7 +325,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 	       le_addr, info->sid);

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -190,7 +190,7 @@ static int pa_sync_no_past(struct sync_state *state,
 	} else {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(&recv_state->addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(&recv_state->addr, addr_str, sizeof(addr_str));
 		printk("PA sync pending for addr %s\n", addr_str);
 		state->pa_syncing = true;
 		k_work_init_delayable(&state->pa_timer, pa_timer_handler);
@@ -510,7 +510,7 @@ static bool broadcast_source_found(struct bt_data *data, void *user_data)
 	}
 
 	g_broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 
 	printk("Found BAP broadcast source with address %s and ID 0x%06X\n",
 	       addr_str, g_broadcast_id);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -461,7 +461,7 @@ static void broadcast_scan_recv(const struct bt_le_scan_recv_info *info, struct 
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, info->rssi);
 
 	bt_data_parse(ad, parse_ascs_ad_data, (void *)info);

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -219,7 +219,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 	       le_addr, info->sid);

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -352,7 +352,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 
 	broadcast_id = sys_get_le24(data->data + BT_UUID_SIZE_16);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 	       le_addr, info->sid);
@@ -498,7 +498,7 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
 	(void)bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 	printk("BASS recv state: src_id %u, addr %s, sid %u, sync_state %u, "
 	       "encrypt_state %u%s%s\n",
@@ -577,7 +577,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s\n", addr_str);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -304,7 +304,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	LOG_DBG("Device found: %s", addr_str);
 
 	bt_addr_le_copy(&remote_dev_addr, addr);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -427,7 +427,7 @@ static bool check_audio_support_and_connect_cb(struct bt_data *data, void *user_
 		return true; /* Continue parsing to next AD data type */
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s\n", addr_str);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
@@ -32,7 +32,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		FAIL("Failed to connect to %s (%u)\n", addr, err);

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -91,7 +91,7 @@ static void device_found(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, info->rssi);
 
 	/* connect only to devices in close proximity */
@@ -147,7 +147,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -281,7 +281,7 @@ void start_broadcast_adv(struct bt_le_ext_adv *adv)
 		}
 	}
 
-	bt_addr_le_to_str(info.addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info.addr, addr_str, sizeof(addr_str));
 	printk("Started advertising with addr %s\n", addr_str);
 }
 

--- a/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
@@ -201,7 +201,7 @@ static bool csip_found(struct bt_data *data, void *user_data)
 		const bt_addr_le_t *addr = user_data;
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 		printk("Found CSIP advertiser with address %s\n", addr_str);
 
 		if (is_discovered(addr)) {
@@ -338,7 +338,7 @@ static void connect_set(void)
 		return;
 	}
 
-	bt_addr_le_to_str(&addr_found[0], addr, sizeof(addr));
+	(void)bt_addr_le_to_str(&addr_found[0], addr, sizeof(addr));
 	err = bt_conn_le_create(&addr_found[0], BT_CONN_LE_CREATE_CONN, BT_BAP_CONN_PARAM_RELAXED,
 				&conns[0]);
 	if (err != 0) {
@@ -385,7 +385,7 @@ static void connect_set(void)
 	}
 
 	for (uint8_t i = 1; i < members_found; i++) {
-		bt_addr_le_to_str(&addr_found[i], addr, sizeof(addr));
+		(void)bt_addr_le_to_str(&addr_found[i], addr, sizeof(addr));
 
 		UNSET_FLAG(flag_connected);
 		printk("Connecting to member[%d] (%s)", i, addr);
@@ -412,7 +412,7 @@ static void disconnect_set(void)
 		char addr[BT_ADDR_LE_STR_LEN];
 		int err;
 
-		bt_addr_le_to_str(&addr_found[i], addr, sizeof(addr));
+		(void)bt_addr_le_to_str(&addr_found[i], addr, sizeof(addr));
 
 		printk("Disconnecting member[%u] (%s)", i, addr);
 		err = bt_conn_disconnect(conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -443,7 +443,7 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, info->rssi);
 
 	/* connect only to devices in close proximity */

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -2460,7 +2460,7 @@ void test_main(void)
 
 		char addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(bt_conn_get_dst(default_conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(default_conn), addr, sizeof(addr));
 		printk("Connected: %s\n", addr);
 
 		bt_conn_le_param_update(default_conn,

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1612,7 +1612,7 @@ void scan_and_connect(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	bt_addr_le_to_str(bt_conn_get_dst(default_conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(default_conn), addr, sizeof(addr));
 	printk("Connected: %s\n", addr);
 }
 

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -328,7 +328,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		bt_conn_unref(default_conn);

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -97,7 +97,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		FAIL("Failed to connect to %s (%u)\n", addr, err);

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -108,7 +108,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	/* Check for connectable, extended advertising */
 	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0) ||
 		((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE)) != 0) {
-		bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+		(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 		printk("[DEVICE]: %s, ", le_addr);
 		/* Check for TMAS support in advertising data */
 		bt_data_parse(buf, check_audio_support_and_connect, (void *)info->addr);

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/central.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/central.c
@@ -72,7 +72,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
 

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -108,7 +108,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != BT_HCI_ERR_SUCCESS) {
 		TEST_FAIL("Failed to connect to %s: %u", addr, err);
@@ -138,7 +138,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason %u)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -26,7 +26,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != BT_HCI_ERR_SUCCESS) {
 		TEST_FAIL("Failed to connect to %s: %u", addr, err);
@@ -53,7 +53,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason %u)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/adv/long_ad/src/scanner.c
+++ b/tests/bsim/bluetooth/host/adv/long_ad/src/scanner.c
@@ -33,7 +33,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
 

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -30,7 +30,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != BT_HCI_ERR_SUCCESS) {
 		TEST_FAIL("Failed to connect to %s: %u", addr, err);
@@ -46,7 +46,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason %u)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
@@ -36,7 +36,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != BT_HCI_ERR_SUCCESS) {
 		TEST_FAIL("Failed to connect to %s: %u", addr, err);
@@ -52,7 +52,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason %u)\n", addr, reason);
 
@@ -114,7 +114,7 @@ static void sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u us)\n",
@@ -129,7 +129,7 @@ static void term_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -148,7 +148,7 @@ static void recv_cb(struct bt_le_per_adv_sync *recv_sync,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s advertisement received\n",
 	       bt_le_per_adv_sync_get_index(recv_sync), le_addr);
 

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -23,7 +23,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		if (default_conn) {
@@ -47,7 +47,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
@@ -48,7 +48,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -67,7 +67,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -106,7 +106,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -32,7 +32,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -52,7 +52,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -40,7 +40,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -57,7 +57,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -108,7 +108,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 	LOG_DBG("Connecting to %s", str);
 
 	param = BT_LE_CONN_PARAM_DEFAULT;

--- a/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
@@ -41,7 +41,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -58,7 +58,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -109,7 +109,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 	LOG_DBG("Connecting to %s", str);
 
 	param = BT_LE_CONN_PARAM_DEFAULT;

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -38,7 +38,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -60,7 +60,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -90,7 +90,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -29,7 +29,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -49,7 +49,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
@@ -37,7 +37,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -58,7 +58,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -99,7 +99,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -31,7 +31,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -53,7 +53,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
@@ -115,7 +115,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	int err;
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
 
@@ -137,7 +137,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
 	addr = bt_conn_get_dst(conn);
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	if (err) {
 		TEST_FAIL("Failed to connect to %s (err %d)", addr_str, err);
@@ -154,7 +154,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr_str, reason);
 
@@ -172,7 +172,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr_str, level);

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
@@ -117,7 +117,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (err) {
 		TEST_FAIL("Failed to connect to %s (err %d)", addr_str, err);
@@ -135,7 +135,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr_str, reason);
 
@@ -150,7 +150,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr_str, level);

--- a/tests/bsim/bluetooth/host/gatt/device_name/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/device_name/src/client.c
@@ -37,7 +37,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	TEST_ASSERT(err == 0, "Security update failed: %s level %u err %d", addr_str, level, err);
 

--- a/tests/bsim/bluetooth/host/gatt/device_name/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/device_name/src/server.c
@@ -52,7 +52,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	TEST_ASSERT(err == 0, "Security update failed: %s level %u err %d", addr_str, level, err);
 

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -45,7 +45,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -67,7 +67,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -107,7 +107,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -30,7 +30,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -51,7 +51,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -34,7 +34,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -54,7 +54,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -95,7 +95,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -34,7 +34,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -55,7 +55,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -47,7 +47,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	static struct bt_gatt_exchange_params exchange_params;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -73,7 +73,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -114,7 +114,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -34,7 +34,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -55,7 +55,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
@@ -32,7 +32,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -52,7 +52,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -93,7 +93,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
@@ -33,7 +33,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -54,7 +54,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.c
@@ -90,7 +90,7 @@ static void stop_scan_and_connect(const bt_addr_le_t *addr,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d\n", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
@@ -90,7 +90,7 @@ static void scan_connect_to_first_result_device_found(const bt_addr_le_t *addr, 
 		TEST_FAIL("Unexpected advertisement type.");
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d\n",
 	       addr_str, rssi);
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/client.c
@@ -47,7 +47,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	TEST_ASSERT(err == 0, "Security update failed: %s level %u err %d", addr_str, level, err);
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/server.c
@@ -53,7 +53,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr_str, reason);
 
@@ -64,7 +64,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	TEST_ASSERT(err == 0, "Security update failed: %s level %u err %d", addr_str, level, err);
 

--- a/tests/bsim/bluetooth/host/iso/cis/src/common.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/common.c
@@ -50,7 +50,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -179,7 +179,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -195,7 +195,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -291,7 +291,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	LOG_DBG("Connecting to %s", str);
 

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -191,7 +191,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -207,7 +207,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -304,7 +304,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	LOG_DBG("Connecting to %s", str);
 

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -329,7 +329,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -348,7 +348,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%s (reason 0x%02x)", addr, reason);
 

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
@@ -206,7 +206,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	TEST_ASSERT(!conn_err, "Failed to connect to %s (%u)", addr, conn_err);
 
@@ -219,7 +219,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -298,7 +298,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	LOG_DBG("Connecting to %s", str);
 

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/central.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/central.c
@@ -82,7 +82,7 @@ static void acl_connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		LOG_ERR("Failed to connect to %s (0x%02x)", addr, err);
@@ -96,7 +96,7 @@ static void acl_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected from %s (reason 0x%02x)", addr, reason);
 }

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
@@ -45,7 +45,7 @@ static int send_data_over_l2cap(struct bt_l2cap_chan *chan, uint8_t *data, size_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
 
 	LOG_DBG("[%s] chan %p data %p len %d", addr, chan, data, len);
 
@@ -81,7 +81,7 @@ static void resume_sending_until_done(struct test_ctx *ctx)
 	} else {
 		char addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
 
 		LOG_DBG("[%s] Done sending", addr);
 	}
@@ -193,7 +193,7 @@ static void acl_connected(struct bt_conn *conn, uint8_t err)
 	struct test_ctx *ctx;
 	int ret;
 
-	bt_addr_le_to_str(central, addr, sizeof(addr));
+	(void)bt_addr_le_to_str(central, addr, sizeof(addr));
 
 	TEST_ASSERT(err == 0, "Failed to connect to %s (0x%02x)", addr, err);
 
@@ -219,7 +219,7 @@ static void acl_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected from %s (reason 0x%02x)", addr, reason);
 }

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
@@ -125,7 +125,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -141,7 +141,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -168,7 +168,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	LOG_DBG("Connecting to %s", str);
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -349,7 +349,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -365,7 +365,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -531,7 +531,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	char str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 
 	LOG_DBG("Connecting to %s", str);
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -187,7 +187,7 @@ static uint8_t notify_func(struct bt_conn *conn, struct bt_gatt_subscribe_params
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!data) {
 		LOG_INF("[UNSUBSCRIBED] addr %s", addr);
@@ -219,7 +219,7 @@ static void subscribe_func(struct bt_conn *conn, uint8_t err,
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 	__ASSERT(!err, "Subscribe failed for addr %s (err %d)", addr, err);
 
 	conn_info_ref = get_conn_info_ref(conn);
@@ -379,7 +379,7 @@ static bool parse_ad(struct bt_data *data, void *user_data)
 
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 		LOG_INF("Connecting to %s", addr_str);
 
 		struct bt_le_conn_param *param = BT_LE_CONN_PARAM_DEFAULT;
@@ -425,7 +425,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t conn_err)
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	__ASSERT(conn_err == BT_HCI_ERR_SUCCESS, "Failed to connect to %s (%u)", addr, conn_err);
 
@@ -461,7 +461,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_INF("Disconnected: %s (reason 0x%02x)", addr, reason);
 
@@ -485,7 +485,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	__ASSERT(!err, "Security for %s failed", addr);
 	LOG_INF("Security for %s changed: level %u", addr, level);
@@ -504,8 +504,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 	struct conn_info *conn_info_ref;
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	LOG_ERR("Identity resolved %s -> %s", addr_rpa, addr_identity);
 
@@ -536,7 +536,7 @@ static void mtu_exchange_cb(struct bt_conn *conn, uint8_t err,
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	conn_info_ref = get_conn_info_ref(conn);
 	__ASSERT_NO_MSG(conn_info_ref);
@@ -553,7 +553,7 @@ static void exchange_mtu(struct bt_conn *conn, void *data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	conn_info_ref = get_connected_conn_info_ref(conn);
 	if (conn_info_ref == NULL) {
@@ -583,7 +583,7 @@ static void subscribe_to_service(struct bt_conn *conn, void *data)
 	int *p_err = (int *)data;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	conn_info_ref = get_connected_conn_info_ref(conn);
 	if (conn_info_ref == NULL) {
@@ -653,7 +653,7 @@ static void notify_peers(struct bt_conn *conn, void *data)
 	struct conn_info *conn_info_ref;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	conn_info_ref = get_connected_conn_info_ref(conn);
 	if (conn_info_ref == NULL) {
@@ -718,7 +718,7 @@ void test_central_main(void)
 			start_scan();
 		} else {
 			if (atomic_test_bit(status_flags, DEVICE_IS_CONNECTING)) {
-				bt_addr_le_to_str(bt_conn_get_dst(conn_connecting),
+				(void)bt_addr_le_to_str(bt_conn_get_dst(conn_connecting),
 						  addr, sizeof(addr));
 				LOG_INF("already connecting to: %s", addr);
 			}

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -120,7 +120,7 @@ void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	if (tx == CONFIG_BT_L2CAP_TX_MTU && rx == CONFIG_BT_L2CAP_TX_MTU) {
 		char addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 		atomic_set_bit(conn_info.flags, CONN_INFO_MTU_EXCHANGED);
 		LOG_INF("Updating MTU succeeded %s", addr);
@@ -139,7 +139,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	rounds++;
 	conn_info.conn_ref = conn;
@@ -182,7 +182,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("LE conn param req: %s int (0x%04x (~%u ms), 0x%04x (~%u ms)) lat %d to %d",
 		addr, param->interval_min, (uint32_t)(param->interval_min * 1.25),
@@ -197,7 +197,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		LOG_ERR("Security for %p failed: %s level %u err %d", conn, addr, level, err);
@@ -234,7 +234,7 @@ static uint8_t rx_notification(struct bt_conn *conn, struct bt_gatt_subscribe_pa
 	/* TODO: enable */
 	/* __ASSERT_NO_MSG(atomic_test_bit(conn_info.flags, CONN_INFO_SUBSCRIBED)); */
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	received_counter = strtoul(data_ptr, NULL, 0);
 	LOG_INF("RX %d", received_counter);
@@ -315,7 +315,7 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 		char addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 		LOG_INF("[SUBSCRIBED] addr %s", addr);
 	}
 
@@ -338,7 +338,7 @@ static void subscribe_to_service(struct bt_conn *conn)
 		int err;
 		char addr[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 		memcpy(&uuid, CENTRAL_SERVICE_UUID, sizeof(uuid));
 		discover_params.uuid = &uuid.uuid;

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -38,7 +38,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -59,7 +59,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -89,7 +89,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
@@ -28,7 +28,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -44,7 +44,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
@@ -80,8 +80,8 @@ static void test_disable_set_default_id(void)
 			uint8_t addr_set_str[BT_ADDR_LE_STR_LEN];
 			uint8_t addr_stored_str[BT_ADDR_LE_STR_LEN];
 
-			bt_addr_le_to_str(&addr, addr_set_str, BT_ADDR_LE_STR_LEN);
-			bt_addr_le_to_str(&stored_id, addr_stored_str, BT_ADDR_LE_STR_LEN);
+			(void)bt_addr_le_to_str(&addr, addr_set_str, BT_ADDR_LE_STR_LEN);
+			(void)bt_addr_le_to_str(&stored_id, addr_stored_str, BT_ADDR_LE_STR_LEN);
 			TEST_FAIL("Expected stored ID to be equal to set ID: %s, %s", addr_set_str,
 				  addr_stored_str);
 		}

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
@@ -40,7 +40,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -57,7 +57,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_INF("%s: %p %s (reason 0x%02x)", __func__, conn, addr, reason);
 
@@ -108,7 +108,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 	LOG_DBG("Connecting to %s", str);
 
 	param = BT_LE_CONN_PARAM_DEFAULT;

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -44,7 +44,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, conn_err);
@@ -61,7 +61,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
 
@@ -94,7 +94,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, str, sizeof(str));
+	(void)bt_addr_le_to_str(addr, str, sizeof(str));
 	LOG_DBG("Connecting to %s", str);
 
 	param = BT_LE_CONN_PARAM_DEFAULT;

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/dut.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/dut.c
@@ -57,7 +57,7 @@ static int recv_cb(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	tester->sdu_count += 1;
 
-	bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(chan->conn), addr, sizeof(addr));
 
 	LOG_INF("Received SDU %d / %d from (%s)", tester->sdu_count, SDU_NUM, addr);
 
@@ -125,7 +125,7 @@ static struct bt_conn *connect_tester(void)
 	err = bt_testlib_connect(&tester, &conn);
 	TEST_ASSERT(!err, "Failed to initiate connection (err %d)", err);
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 	LOG_DBG("Connected to %s", addr);
 
 	return conn;

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -27,7 +27,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
 		TEST_FAIL("Failed to connect to %s (%u)", addr, err);
@@ -49,7 +49,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("conn_callback:Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -81,7 +81,7 @@ void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, struct ne
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	printk("Stopping scan\n");
@@ -114,7 +114,7 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 	switch (info.type) {
 	case BT_CONN_TYPE_LE:
 		(*conn_count)++;
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+		(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 		printk("%s: Connected to %s\n", __func__, addr);
 		break;
 	default:

--- a/tests/bsim/bluetooth/host/privacy/central/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/tester.c
@@ -43,7 +43,7 @@ void scanned_cb(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_scanned_info *in
 		int64_t new_time, diff, time_diff_ms, rpa_timeout_ms;
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 		printk("Scanned request from new address : %s\n", addr_str);
 
 		/* Ensure the RPA rotation occurs within +-10% of CONFIG_BT_RPA_TIMEOUT */

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
@@ -134,7 +134,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info->addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device found: %s (RSSI %d)", addr_str, info->rssi);
 
 	/* In the case of extended advertising and active scanning, this
@@ -202,7 +202,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Connected: %s", addr);
 }
@@ -215,7 +215,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
 
@@ -231,8 +231,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_identity[BT_ADDR_LE_STR_LEN];
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
 

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
@@ -283,7 +283,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		LOG_WRN("Failed to connect to %s (%u)", addr, err);
@@ -311,7 +311,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		return;
 	}
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
 
@@ -328,8 +328,8 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	char addr_identity[BT_ADDR_LE_STR_LEN];
 	char addr_rpa[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
-	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+	(void)bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	(void)bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
 	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
 }
@@ -338,7 +338,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr, level);

--- a/tests/bsim/bluetooth/host/scan/slow/src/dut.c
+++ b/tests/bsim/bluetooth/host/scan/slow/src/dut.c
@@ -24,7 +24,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	k_msleep(500); /* simulate a slow memcpy (or user processing the scan data) */
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	LOG_DBG("Device found: %s (RSSI %d), type %u, AD data len %u", addr_str, rssi, type,
 		ad->len);
 }

--- a/tests/bsim/bluetooth/host/scan/start_stop/src/main.c
+++ b/tests/bsim/bluetooth/host/scan/start_stop/src/main.c
@@ -40,7 +40,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 
 	memcpy(&adv_addr, addr, sizeof(adv_addr));
 
-	bt_addr_le_to_str(&adv_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&adv_addr, addr_str, sizeof(addr_str));
 	LOG_DBG("Device found: %s (RSSI %d), type %u, AD data len %u",
 	       addr_str, rssi, type, ad->len);
 	atomic_set(&flag_adv_report_received, true);

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.c
@@ -103,7 +103,7 @@ static void scan_connect_to_first_result__device_found(const bt_addr_le_t *addr,
 		TEST_FAIL("Unexpected advertisement type.");
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.c
@@ -103,7 +103,7 @@ static void scan_connect_to_first_result__device_found(const bt_addr_le_t *addr,
 		TEST_FAIL("Unexpected advertisement type.");
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
@@ -118,7 +118,7 @@ static void scan_connect_to_first_result__device_found(const bt_addr_le_t *addr,
 		TEST_FAIL("Unexpected advertisement type.");
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d\n", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
@@ -110,7 +110,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	int err;
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
 
@@ -132,7 +132,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
 	addr = bt_conn_get_dst(conn);
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	if (err) {
 		TEST_FAIL("Failed to connect to %s (err %d)", addr_str, err);
@@ -149,7 +149,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr_str, reason);
 
@@ -167,7 +167,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr_str, level);

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
@@ -110,7 +110,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (err) {
 		TEST_FAIL("Failed to connect to %s (err %d)", addr_str, err);
@@ -128,7 +128,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr_str, reason);
 
@@ -143,7 +143,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr_str, sizeof(addr_str));
 
 	if (!err) {
 		LOG_DBG("Security changed: %s level %u", addr_str, level);

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.c
@@ -54,7 +54,7 @@ static void print_conn_state_transition(const char *prefix, struct bt_conn *conn
 	err = bt_conn_get_info(conn, &info);
 	TEST_ASSERT(!err, "Unexpected conn info result.");
 
-	bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
 	printk("%s: %s\n", prefix, addr_str);
 }
 
@@ -136,7 +136,7 @@ static void scan_connect_to_first_result__device_found(const bt_addr_le_t *addr,
 		TEST_FAIL("Unexpected advertisement type.");
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d\n", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
@@ -53,7 +53,7 @@ static void print_conn_state_transition(const char *prefix, struct bt_conn *conn
 	err = bt_conn_get_info(conn, &info);
 	TEST_ASSERT(!err, "Unexpected conn info result.");
 
-	bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
 	printk("%s: %s\n", prefix, addr_str);
 }
 

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
@@ -126,7 +126,7 @@ static void stop_scan_and_connect(const bt_addr_le_t *addr,
 		return;
 	}
 
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 	printk("Got scan result, connecting.. dst %s, RSSI %d\n", addr_str, rssi);
 
 	err = bt_le_scan_stop();

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -1100,7 +1100,7 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(addr, le_addr, sizeof(le_addr));
 	printk("%s: type = 0x%x, addr = %s\n", __func__, adv_type, le_addr);
 
 	if (!is_reenable_addr &&
@@ -1132,7 +1132,7 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 	} else if (!is_scanned) {
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
-		bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+		(void)bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 		printk("Device found: %s, type: %u, AD len: %u, RSSI %d\n",
 			addr_str, adv_type, buf->len, rssi);
 
@@ -1188,7 +1188,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 	       "Interval: 0x%04x (%u ms), SID: %u\n",
@@ -1255,7 +1255,7 @@ per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -1271,7 +1271,7 @@ per_adv_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -1286,7 +1286,7 @@ per_adv_sync_recv_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
 	       "RSSI %i, CTE %u, data length %u\n",

--- a/tests/bsim/bluetooth/ll/bis/src/test_bis.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_bis.c
@@ -655,7 +655,7 @@ static void pa_sync_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 	       "Interval 0x%04x (%u ms), PHY %s\n",
@@ -670,7 +670,7 @@ static void pa_terminated_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -690,7 +690,7 @@ static void pa_recv_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
 	       "RSSI %i, CTE %u, data length %u\n",
@@ -716,7 +716,7 @@ static void pa_biginfo_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
 	printk("BIG INFO[%u]: [DEVICE]: %s, sid 0x%02x, "
 	       "num_bis %u, nse %u, interval 0x%04x (%u ms), "
 	       "bn %u, pto %u, irc %u, max_pdu %u, "
@@ -775,7 +775,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 	       "Interval: 0x%04x (%u ms), SID: %u\n",

--- a/tests/bsim/bluetooth/ll/bis/src/test_past.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_past.c
@@ -60,7 +60,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		FAIL("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -123,7 +123,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 			dev, type, ad->len, rssi);
 
@@ -138,7 +138,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -241,7 +241,7 @@ static void pa_sync_cb(struct bt_le_per_adv_sync *sync,
 
 	default_sync = sync;
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 		   "Interval 0x%04x (%u ms), PHY %s\n",
@@ -260,7 +260,7 @@ static void pa_terminated_cb(struct bt_le_per_adv_sync *sync,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 		   bt_le_per_adv_sync_get_index(sync), le_addr);
@@ -335,7 +335,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 		   "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 		   "Interval: 0x%04x (%u ms), SID: %u\n",

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -132,7 +132,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	(void)bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "
 	       "Interval: 0x%04x (%u ms), SID: %u\n",
@@ -157,7 +157,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err) {
 		struct bt_conn_info conn_info;
@@ -190,7 +190,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 
@@ -219,7 +219,7 @@ static void disconnect(struct bt_conn *conn, void *data)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnecting %s...\n", addr);
 	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
@@ -259,7 +259,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err) {
 		FAIL("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -380,7 +380,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 			dev, type, ad->len, rssi);
 
@@ -396,7 +396,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
@@ -85,7 +85,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Security changed: %s level %u\n", addr, level);
 }
@@ -258,7 +258,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Passkey for %s: %06u\n", addr, passkey);
 }
@@ -267,7 +267,7 @@ static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Pairing cancelled: %s\n", addr);
 }

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
@@ -38,7 +38,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 {
 	char dev[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	(void)bt_addr_le_to_str(addr, dev, sizeof(dev));
 	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n",
 	       dev, type, ad->len, rssi);
 
@@ -78,7 +78,7 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (conn_err != BT_HCI_ERR_SUCCESS) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
@@ -102,7 +102,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	printk("Disconnected: %s, reason 0x%02x %s\n", addr, reason, bt_hci_err_to_str(reason));
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
@@ -45,7 +45,7 @@ static void test_bap_broadcast_sink(void)
 
 	bsim_btp_bap_broadcast_scan_start();
 	bsim_btp_wait_for_bap_baa_found(&remote_addr, &broadcast_id, &adv_sid);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 	bsim_btp_bap_broadcast_scan_stop();
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_central.c
@@ -54,7 +54,7 @@ static void test_bap_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
@@ -37,7 +37,7 @@ static void test_bap_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
@@ -45,7 +45,7 @@ static void test_cap_broadcast_sink(void)
 
 	bsim_btp_bap_broadcast_scan_start();
 	bsim_btp_wait_for_bap_baa_found(&remote_addr, &broadcast_id, &adv_sid);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 	bsim_btp_bap_broadcast_scan_stop();
 

--- a/tests/bsim/bluetooth/tester/src/audio/cap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_central.c
@@ -58,7 +58,7 @@ static void test_cap_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
@@ -37,7 +37,7 @@ static void test_cap_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_central.c
@@ -36,7 +36,7 @@ static void test_ccp_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
@@ -40,7 +40,7 @@ static void test_ccp_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/csip_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/csip_central.c
@@ -34,7 +34,7 @@ static void test_csip_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/csip_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/csip_peripheral.c
@@ -36,7 +36,7 @@ static void test_csip_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/hap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_central.c
@@ -34,7 +34,7 @@ static void test_hap_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
@@ -36,7 +36,7 @@ static void test_hap_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/mcp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/mcp_central.c
@@ -37,7 +37,7 @@ static void test_mcp_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/mcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/mcp_peripheral.c
@@ -35,7 +35,7 @@ static void test_mcp_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/micp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/micp_central.c
@@ -36,7 +36,7 @@ static void test_micp_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/micp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/micp_peripheral.c
@@ -36,7 +36,7 @@ static void test_micp_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/tmap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/tmap_central.c
@@ -34,7 +34,7 @@ static void test_tmap_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/tmap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/tmap_peripheral.c
@@ -35,7 +35,7 @@ static void test_tmap_peripheral(void)
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
@@ -36,7 +36,7 @@ static void test_vcp_central(void)
 
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
@@ -38,7 +38,7 @@ static void test_vcp_peripheral(void)
 	bsim_btp_vcs_register(1U, 0U, 100U);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 	bsim_btp_wait_for_gap_device_disconnected(NULL);
 	LOG_INF("Device %s disconnected", addr_str);

--- a/tests/bsim/bluetooth/tester/src/host/gap_central.c
+++ b/tests/bsim/bluetooth/tester/src/host/gap_central.c
@@ -33,7 +33,7 @@ static void test_gap_central(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_stop_discovery();

--- a/tests/bsim/bluetooth/tester/src/host/gap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/host/gap_peripheral.c
@@ -35,7 +35,7 @@ static void test_gap_peripheral(void)
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s connected", addr_str);
 
 	bsim_btp_wait_for_gap_device_disconnected(&ev_addr);

--- a/tests/bsim/bluetooth/tester/src/host/iso_broadcaster.c
+++ b/tests/bsim/bluetooth/tester/src/host/iso_broadcaster.c
@@ -52,7 +52,7 @@ static void test_iso_broadcaster(void)
 	bsim_btp_gap_create_big(1, BIG_INTERVAL, 20, true, broadcast_code);
 
 	bsim_btp_wait_for_gap_bis_data_path_setup(&ev_addr, &bis_id);
-	bt_addr_le_to_str(&ev_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&ev_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Device %s: Data path of BIS %u is setup", addr_str, bis_id);
 	while (count > 0) {
 		net_buf_simple_reset(&data);

--- a/tests/bsim/bluetooth/tester/src/host/iso_sync_receiver.c
+++ b/tests/bsim/bluetooth/tester/src/host/iso_sync_receiver.c
@@ -47,18 +47,18 @@ static void test_iso_sync_receiver(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
 	bsim_btp_wait_for_gap_device_found(&remote_addr);
-	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	(void)bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
 	LOG_INF("Found remote device %s", addr_str);
 
 	bsim_btp_gap_padv_create_sync(&remote_addr, 0, 0, 0x200, 0);
 	bsim_btp_wait_for_gap_periodic_sync_established(&ev_addr, &sync_handle, &status);
-	bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
+	(void)bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
 	TEST_ASSERT(bt_addr_le_eq(&remote_addr, &ev_addr), "%s != %s", addr_str, ev_addr_str);
 	TEST_ASSERT(status == 0, "Sync failed with status %u", status);
 	LOG_INF("Device %s: periodic synced %u status %u", addr_str, sync_handle, status);
 
 	bsim_btp_wait_for_gap_periodic_biginfo(&ev_addr, &sid, &num_bis, &encryption);
-	bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
+	(void)bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
 	TEST_ASSERT(bt_addr_le_eq(&remote_addr, &ev_addr), "%s != %s", addr_str, ev_addr_str);
 	LOG_INF("Device %s: BIGinfo sid %u num_bis %u enc %u", addr_str, sid, num_bis, encryption);
 
@@ -66,7 +66,7 @@ static void test_iso_sync_receiver(void)
 				     broadcast_code);
 
 	bsim_btp_wait_for_gap_bis_data_path_setup(&ev_addr, &bis_id);
-	bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
+	(void)bt_addr_le_to_str(&ev_addr, ev_addr_str, sizeof(ev_addr_str));
 	TEST_ASSERT(bt_addr_le_eq(&remote_addr, &ev_addr), "%s != %s", addr_str, ev_addr_str);
 	LOG_INF("Device %s: Data path of BIS %u is setup", addr_str, bis_id);
 
@@ -76,7 +76,7 @@ static void test_iso_sync_receiver(void)
 		TEST_ASSERT(bis_stream_rx.len >= sizeof(*ev));
 
 		ev = net_buf_simple_pull_mem(&bis_stream_rx, sizeof(*ev));
-		bt_addr_le_to_str(&ev->address, ev_addr_str, sizeof(ev_addr_str));
+		(void)bt_addr_le_to_str(&ev->address, ev_addr_str, sizeof(ev_addr_str));
 		TEST_ASSERT(bt_addr_le_eq(&ev->address, &ev_addr));
 		TEST_ASSERT(ev->bis_id == bis_id, "Invalid BIS %u != %u", ev->bis_id, bis_id);
 		LOG_INF("Device %s: BIS Stream RX BIS %u len %u flags %u TS %u seq_num %u",


### PR DESCRIPTION
Search for the whole repository for every place where bt_addr_le_to_str and bt_addr_to_str are used without using the returned value (BTW - there is no place where the returned value is used in this repository) and make sure that every call is casted to (void).

Reference discussion: https://github.com/zephyrproject-rtos/zephyr/pull/94235#discussion_r2829450164

This is really not my work: Claude Sonnet 4.5 did the whole heavy lifting.

The generated summary:

## Summary

Analyzed all calls to `bt_addr_to_str` and `bt_addr_le_to_str` in the zephyr project folder.

### Statistics

| Metric | Count |
|--------|-------|
| **Total call sites found** | **500** |
| **Return value IS used** | **0** ❗ |
| **Already had (void) cast** | 28 |
| **Needed (void) cast (fixed)** | 472 |
| **Now have (void) cast** | **500** ✓ |

## Key Finding

**ZERO locations in the zephyr codebase use the return value of these functions!**

All 500 call sites use these functions solely for their side effect (converting a Bluetooth address to a string buffer). The functions return `int` (number of bytes formatted), but this value is never checked or used anywhere in the codebase.

## Places Where Return Value IS Used

**NONE** - Not a single file uses the return value.

Since there are NO places where the return value is used, I cannot provide "first 10 such places" as requested.

## Changes Applied

Added `(void)` casts to all 472 locations that were missing them:

### Modified Files by Category

1. **Tests (bsim)**: ~200 files
   - tests/bsim/bluetooth/ll/*
   - tests/bsim/bluetooth/host/*
   - tests/bsim/bluetooth/audio/*
   - tests/bsim/bluetooth/tester/*

2. **Subsystems**: ~10 files
   - subsys/bluetooth/host/shell/bt.c (41 lines)
   - subsys/bluetooth/host/classic/shell/bredr.c (5 lines)
   - subsys/bluetooth/audio/shell/* (multiple files)
   - subsys/bluetooth/audio/csip_set_member.c
   - subsys/bluetooth/audio/pacs.c
   - subsys/bluetooth/common/bt_str.c (2 lines)
   - subsys/bluetooth/controller/ll_sw/shell/ll.c

3. **Samples**: ~60 files
   - samples/bluetooth/peripheral_hr/
   - samples/bluetooth/central_hr/
   - samples/bluetooth/peripheral_*/ (multiple)
   - samples/bluetooth/central_*/ (multiple)
   - samples/bluetooth/iso_*/ (multiple)
   - samples/bluetooth/bap_*/ (multiple)
   - samples/bluetooth/cap_*/ (multiple)
   - samples/bluetooth/encrypted_advertising/*
   - And many more...

4. **Modules**: 1 file
   - modules/openthread/platform/ble.c (2 lines)

5. **Tests (non-bsim)**: ~5 files
   - tests/bluetooth/tester/src/btp_gap.c
   - tests/bluetooth/tester/src/audio/*
   - tests/bluetooth/classic/smp_general/src/smp_br_general.c
   - tests/bluetooth/host/conn/mocks/bt_str.c
   - tests/bluetooth/common/testlib/src/att.c

## Example Changes

### Before:
```c
bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
printk("Connected: %s\n", addr);
```

### After:
```c
(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
printk("Connected: %s\n", addr);
```

## Verification

Final verification commands confirm:
- ✅ 500 call sites now have `(void)` cast
- ✅ 0 call sites without `(void)` cast remain
- ✅ 0 call sites use the return value