### PR TITLE
dts: cva6: cva6.dtsi contains wrong reg for gpio and eth

### DIFF
--- a/dts/riscv/openhwgroup/cva6.dtsi
+++ b/dts/riscv/openhwgroup/cva6.dtsi
@@ -133,7 +133,7 @@
 			device_type = "network";
 			interrupt-parent = <&plic>;
 			interrupts = <3 0>;
-			reg = <0x0 0x30000000 0x0 0x8000>;
+			reg = <0x30000000 0x8000>;
 			status = "disabled";
 		};
 
@@ -142,7 +142,7 @@
 			#gpio-cells = <2>;
 			compatible = "xlnx,xps-gpio-1.00.a";
 			gpio-controller;
-			reg = <0x0 0x40000000 0x0 0x10000>;
+			reg = <0x40000000 0x10000>;
 			xlnx,all-inputs = <0x0>;
 			xlnx,all-inputs-2 = <0x0>;
 			xlnx,dout-default = <0x0>;


### PR DESCRIPTION
The cva6.dtsi contains bad reg values for eth and gpio peripherals. The form reg=<0x0 base 0x0 size> has been replaced with expected reg=<base size>.