### PR TITLE
drivers: timer: xlnx_psttc: avoid conflict with ARM arch timer

### DIFF
--- a/drivers/timer/Kconfig.xlnx_psttc
+++ b/drivers/timer/Kconfig.xlnx_psttc
@@ -5,7 +5,7 @@
 
 config XLNX_PSTTC_TIMER
 	bool "Xilinx PS Triple-Timer Counter support"
-	default y
+	default y if !DT_HAS_ARM_ARMV8_TIMER_ENABLED
 	depends on DT_HAS_XLNX_TTCPS_ENABLED
 	select TICKLESS_CAPABLE
 	help


### PR DESCRIPTION
When both TTC (xlnx,ttcps) and ARM architected timer (arm,armv8-timer) are present in the devicetree, such as on Versal A72 APU boards, both timer drivers were being enabled causing a build failure due to conflicting system clock frequency assertions.

Change the TTC timer default to not enable when ARM arch timer is available in devicetree. This allows A72 platforms to use the global ARM timer as the system timer while still allowing TTC for R5 and other platforms without the ARM arch timer.