### PR TITLE
doc: build: kconfig: Fix CONFIG_FILE description

### DIFF
--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -156,7 +156,7 @@ used.
 #. Otherwise, if board revisions are used and
    :file:`boards/<BOARD>_<revision>.conf` exists in the application
    configuration directory, the result of merging it with :file:`prj.conf` and
-   :file:`boards/<BOARD>.conf` is used.
+   :file:`boards/<BOARD>_<revision>.conf` is used.
 
 #. Otherwise, :file:`prj.conf` is used from the application configuration
    directory. If it does not exist then a fatal error will be emitted.


### PR DESCRIPTION
Correct the board revision file used in the description for variable CONFIG_FILE to accurately reflect the actual processing order.