### PR TITLE
net: ipv4: Do packet length checks before starting fragment reassembly

### DIFF
--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -331,12 +331,6 @@ enum net_verdict net_ipv4_handle_fragment_hdr(struct net_pkt *pkt, struct net_ip
 	flag = net_ntohs(*((uint16_t *)&hdr->offset));
 	id = net_ntohs(*((uint16_t *)&hdr->id));
 
-	reass = reassembly_get(id, hdr->src, hdr->dst, hdr->proto);
-	if (!reass) {
-		LOG_ERR("Cannot get reassembly slot, dropping pkt %p", pkt);
-		goto drop;
-	}
-
 	more = (flag & NET_IPV4_MORE_FRAG_MASK) ? true : false;
 	net_pkt_set_ipv4_fragment_flags(pkt, flag);
 
@@ -346,6 +340,12 @@ enum net_verdict net_ipv4_handle_fragment_hdr(struct net_pkt *pkt, struct net_ip
 		 */
 		net_icmpv4_send_error(pkt, NET_ICMPV4_BAD_IP_HEADER,
 				      NET_ICMPV4_BAD_IP_HEADER_LENGTH);
+		goto drop;
+	}
+
+	reass = reassembly_get(id, hdr->src, hdr->dst, hdr->proto);
+	if (!reass) {
+		LOG_ERR("Cannot get reassembly slot, dropping pkt %p", pkt);
 		goto drop;
 	}
 


### PR DESCRIPTION
Make sure to check packet length check before starting the IPv4 fragmentation reassembly process. This way we can drop the malformed packet without consuming resources.

Fixes #104208