### PR TITLE
Bluetooth: BAP: Unicast Client: Handle unexpected ASE IDs

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1658,6 +1658,8 @@ static uint8_t unicast_client_cp_notify(struct bt_conn *conn,
 		stream = audio_stream_by_ep_id(conn, ase_rsp->id);
 		if (stream == NULL) {
 			LOG_DBG("Could not find stream by id %u", ase_rsp->id);
+
+			continue;
 		} else {
 			client_ep = CONTAINER_OF(stream->ep, struct bt_bap_unicast_client_ep, ep);
 			client_ep->cp_ntf_pending = false;


### PR DESCRIPTION
If we receive a control point notification with an ASE ID that does not match any existing streams, i.e. audio_stream_by_ep_id returns NULL, we should not continue by calling the subsequent functions like unicast_client_notify_ep_config with a NULL stream.

A single notification may contain multiple ASE IDs; if any of them are unknown, we can either reject the entire notification, or we can ignore the specific ASE ID. For now, ignore the specific ASE ID to do a best effort to continue with any other changes.