### PR TITLE
doc: add grouping by type to devicetree bindings index

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -32,7 +32,6 @@ Roles
 """
 
 import json
-import re
 import sys
 from collections.abc import Iterator
 from os import path
@@ -66,50 +65,31 @@ sys.path.insert(0, str(Path(__file__).parents[4] / "scripts/dts/python-devicetre
 sys.path.insert(0, str(Path(__file__).parents[4] / "scripts/west_commands"))
 sys.path.insert(0, str(Path(__file__).parents[3] / "_scripts"))
 
+import dts_binding_types
 from gen_boards_catalog import get_catalog
 
 ZEPHYR_BASE = Path(__file__).parents[4]
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 RESOURCES_DIR = Path(__file__).parent / "static"
 
+
 # Load and parse binding types from text file
-BINDINGS_TXT_PATH = ZEPHYR_BASE / "dts" / "bindings" / "binding-types.txt"
-ACRONYM_PATTERN = re.compile(r'([a-zA-Z0-9-]+)\s*\((.*?)\)')
-ACRONYM_PATTERN_UPPERCASE_ONLY = re.compile(r'(\b[A-Z0-9-]+)\s*\((.*?)\)')
-BINDING_TYPE_TO_DOCUTILS_NODE = {}
-
-
-def parse_text_with_acronyms(text, uppercase_only=False):
-    """Parse text that may contain acronyms into a list of nodes."""
+def _build_docutils_node_from_chunks(chunks) -> nodes.inline:
     result = nodes.inline()
-    last_end = 0
-
-    pattern = ACRONYM_PATTERN_UPPERCASE_ONLY if uppercase_only else ACRONYM_PATTERN
-    for match in pattern.finditer(text):
-        # Add any text before the acronym
-        if match.start() > last_end:
-            result += nodes.Text(text[last_end : match.start()])
-
-        # Add the acronym
-        abbr, explanation = match.groups()
-        result += nodes.abbreviation(abbr, abbr, explanation=explanation)
-        last_end = match.end()
-
-    # Add any remaining text
-    if last_end < len(text):
-        result += nodes.Text(text[last_end:])
-
+    for chunk in chunks:
+        if chunk["type"] == "text":
+            result += nodes.Text(chunk["content"])
+        elif chunk["type"] == "acronym":
+            result += nodes.abbreviation(
+                chunk["abbr"], chunk["abbr"], explanation=chunk["explanation"]
+            )
     return result
 
 
-with open(BINDINGS_TXT_PATH) as f:
-    for line in f:
-        line = line.strip()
-        if not line or line.startswith('#'):
-            continue
-
-        key, value = line.split('\t', 1)
-        BINDING_TYPE_TO_DOCUTILS_NODE[key] = parse_text_with_acronyms(value)
+BINDING_TYPE_TO_DOCUTILS_NODE = {
+    k: _build_docutils_node_from_chunks(v)
+    for k, v in dts_binding_types.load_binding_types().items()
+}
 
 logger = logging.getLogger(__name__)
 
@@ -975,7 +955,11 @@ class BoardSupportedHardwareDirective(SphinxDirective):
                     desc_entry = nodes.entry(classes=["description"])
                     desc_para = nodes.paragraph(classes=["status"])
                     if value["title"]:
-                        desc_para += parse_text_with_acronyms(value["title"], uppercase_only=True)
+                        desc_para += _build_docutils_node_from_chunks(
+                            dts_binding_types.parse_text_with_acronyms(
+                                value["title"], uppercase_only=True
+                            )
+                        )
                     else:
                         desc_para += nodes.Text(value["description"])
 

--- a/doc/_scripts/dts_binding_types.py
+++ b/doc/_scripts/dts_binding_types.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from pathlib import Path
+
+ZEPHYR_BASE = Path(__file__).parents[2]
+ZEPHYR_BINDINGS = ZEPHYR_BASE / "dts" / "bindings"
+BINDINGS_TXT_PATH = ZEPHYR_BINDINGS / "binding-types.txt"
+
+ACRONYM_PATTERN = re.compile(r'([a-zA-Z0-9-]+)\s*\((.*?)\)')
+ACRONYM_PATTERN_UPPERCASE_ONLY = re.compile(r'(\b[A-Z0-9-]+)\s*\((.*?)\)')
+
+
+def get_binding_type_from_path(binding_path: Path) -> str:
+    """
+    Get the binding type (e.g. 'gpio', 'sensor', etc.) from the binding file's path.
+    """
+    if binding_path.is_relative_to(ZEPHYR_BINDINGS):
+        return binding_path.relative_to(ZEPHYR_BINDINGS).parts[0]
+    return "misc"
+
+
+def parse_text_with_acronyms(text: str, uppercase_only: bool = False) -> list:
+    """
+    Parse text that may contain acronyms into a list of chunks.
+
+    Returns a list of dictionaries with structure:
+    - {"type": "text", "content": "..."}
+    - {"type": "acronym", "abbr": "...", "explanation": "..."}
+    """
+    result = []
+    last_end = 0
+
+    pattern = ACRONYM_PATTERN_UPPERCASE_ONLY if uppercase_only else ACRONYM_PATTERN
+    for match in pattern.finditer(text):
+        if match.start() > last_end:
+            result.append({"type": "text", "content": text[last_end : match.start()]})
+
+        abbr, explanation = match.groups()
+        result.append({"type": "acronym", "abbr": abbr, "explanation": explanation})
+        last_end = match.end()
+
+    if last_end < len(text):
+        result.append({"type": "text", "content": text[last_end:]})
+
+    return result
+
+
+def load_binding_types() -> dict:
+    """
+    Load the binding types from the registry text file.
+
+    Returns a dictionary mapping binding types (e.g. 'gpio')
+    to their parsed description (list of text/acronym chunks).
+    """
+    binding_types = {}
+    if not BINDINGS_TXT_PATH.exists():
+        return binding_types
+
+    with open(BINDINGS_TXT_PATH) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            # Split only on the first tab
+            parts = line.split('\t', 1)
+            if len(parts) == 2:
+                key, value = parts
+                binding_types[key] = parse_text_with_acronyms(value)
+
+    return binding_types

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -15,6 +15,7 @@ import list_hardware
 import list_shields
 import yaml
 import zephyr_module
+from dts_binding_types import get_binding_type_from_path
 from gen_devicetree_rest import VndLookup
 from get_maintainer import Maintainers
 from runners.core import ZephyrBinaryRunner
@@ -330,10 +331,8 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
 
                     binding_path = Path(node.binding_path)
                     is_custom_binding = False
-                    if binding_path.is_relative_to(ZEPHYR_BINDINGS):
-                        binding_type = binding_path.relative_to(ZEPHYR_BINDINGS).parts[0]
-                    else:
-                        binding_type = "misc"
+                    binding_type = get_binding_type_from_path(binding_path)
+                    if binding_type == "misc" and not binding_path.is_relative_to(ZEPHYR_BINDINGS):
                         is_custom_binding = True
 
                     if node.matching_compat is None:

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -18,6 +18,7 @@ import textwrap
 from collections import defaultdict
 from pathlib import Path
 
+import dts_binding_types
 import gen_helpers
 from devicetree import edtlib
 
@@ -173,6 +174,64 @@ class VndLookup:
 
         return vnd2ref_target
 
+
+class TypeLookup:
+    """
+    A convenience class for looking up information based on a
+    devicetree compatible's binding type.
+    """
+
+    def __init__(self, bindings):
+        self.type2name = {
+            "misc": [{"type": "text", "content": "Miscellaneous"}],
+            "generic": [{"type": "text", "content": "Generic"}],
+        }
+        self.type2name.update(dts_binding_types.load_binding_types())
+        self.type2bindings = self.init_type2bindings(bindings)
+        self.type2ref_target = self.init_type2ref_target()
+
+    def name(self, btype):
+        chunks = self.type2name.get(
+            btype,
+            [{"type": "text", "content": btype.capitalize()}]
+        )
+        parts = []
+        for chunk in chunks:
+            if chunk["type"] == "acronym":
+                parts.append(
+                    f":abbr:`{chunk['abbr']} ({chunk['explanation']})`"
+                )
+            else:
+                parts.append(chunk["content"])
+        return "".join(parts)
+
+    def target(self, btype):
+        return self.type2ref_target.get(btype, f"dt_type_{btype}")
+
+    def init_type2bindings(self, bindings):
+        unsorted = defaultdict(list)
+        for binding in bindings:
+            if binding.path:
+                btype = dts_binding_types.get_binding_type_from_path(Path(binding.path))
+            else:
+                btype = "misc"
+            unsorted[btype].append(binding)
+
+        def binding_key(binding):
+            return binding.compatible
+
+        type2bindings = {}
+        for btype in sorted(unsorted, key=lambda t: self.name(t).casefold()):
+            type2bindings[btype] = sorted(unsorted[btype], key=binding_key)
+
+        return type2bindings
+
+    def init_type2ref_target(self):
+        type2ref_target = {}
+        for btype in self.type2bindings:
+            type2ref_target[btype] = f'dt_type_{btype}'
+        return type2ref_target
+
 def main():
     args = parse_args()
     setup_logging(args.verbose)
@@ -180,7 +239,8 @@ def main():
     base_binding = load_base_binding()
     driver_sources = load_driver_sources()
     vnd_lookup = VndLookup(args.vendor_prefixes, bindings)
-    dump_content(bindings, base_binding, vnd_lookup, driver_sources, args.out_dir,
+    type_lookup = TypeLookup(bindings)
+    dump_content(bindings, base_binding, vnd_lookup, type_lookup, driver_sources, args.out_dir,
                  args.turbo_mode)
 
 def parse_args():
@@ -313,7 +373,8 @@ def load_driver_sources():
 
     return driver_sources
 
-def dump_content(bindings, base_binding, vnd_lookup, driver_sources, out_dir, turbo_mode):
+def dump_content(bindings, base_binding, vnd_lookup, type_lookup, driver_sources, out_dir,
+                 turbo_mode):
     # Dump the generated .rst files for a vnd2bindings dict.
     # Files are only written if they are changed. Existing .rst
     # files which would not be written by the 'vnd2bindings'
@@ -325,7 +386,7 @@ def dump_content(bindings, base_binding, vnd_lookup, driver_sources, out_dir, tu
     if turbo_mode:
         write_dummy_index(bindings, out_dir)
     else:
-        write_bindings_rst(vnd_lookup, out_dir)
+        write_bindings_rst(vnd_lookup, type_lookup, out_dir)
         write_orphans(bindings, base_binding, vnd_lookup, driver_sources, out_dir)
 
 def setup_bindings_dir(bindings, out_dir):
@@ -372,7 +433,7 @@ def write_dummy_index(bindings, out_dir):
     write_if_updated(out_dir / 'bindings.rst', content)
 
 
-def write_bindings_rst(vnd_lookup, out_dir):
+def write_bindings_rst(vnd_lookup, type_lookup, out_dir):
     # Write out_dir / bindings.rst, the top level index of bindings.
 
     string_io = io.StringIO()
@@ -386,6 +447,35 @@ def write_bindings_rst(vnd_lookup, out_dir):
     This page documents the available devicetree bindings.
     See {zref('dt-bindings')} for an introduction to the Zephyr bindings
     file format.
+
+    The bindings are grouped both by **type** and by **vendor**. Within each group,
+    bindings are listed by the "compatible" property they apply to, like this:
+
+    - <compatible-A>
+    - <compatible-B> (on <bus-name> bus)
+    - <compatible-C>
+    - ...
+
+    The text "(on <bus-name> bus)" appears when bindings may behave
+    differently depending on the bus the node appears on.
+    For example, this applies to some sensor device nodes, which may
+    appear as children of either I2C or SPI bus nodes.
+
+    Type index
+    **********
+
+    This section contains an index of bindings by type.
+    Click on a type's name to go to the list of bindings for that type.
+
+    .. rst-class:: rst-columns
+    ''', string_io)
+
+    for btype, bindings in type_lookup.type2bindings.items():
+        if len(bindings) == 0:
+            continue
+        print(f'- :ref:`{type_lookup.target(btype)}`', file=string_io)
+
+    print_block('''\
 
     Vendor index
     ************
@@ -404,26 +494,39 @@ def write_bindings_rst(vnd_lookup, out_dir):
 
     print_block('''\
 
+    Bindings by type
+    ****************
+
+    .. rst-class:: rst-columns
+    ''', string_io)
+
+    for btype, bindings in type_lookup.type2bindings.items():
+        if len(bindings) == 0:
+            continue
+
+        title = type_lookup.name(btype).strip()
+        underline = '=' * len(title)
+
+        print_block(f'''\
+        .. _{type_lookup.target(btype)}:
+
+        {title}
+        {underline}
+
+        .. rst-class:: rst-columns
+        ''', string_io)
+        for binding in bindings:
+            print(f'- :ref:`{binding_ref_target(binding)}`', file=string_io)
+        print(file=string_io)
+
+    print_block('''\
+
     Bindings by vendor
     ******************
-
-    This section contains available bindings, grouped by vendor.
-    Within each group, bindings are listed by the "compatible" property
-    they apply to, like this:
 
     **Vendor name (vendor prefix)**
 
     .. rst-class:: rst-columns
-
-    - <compatible-A>
-    - <compatible-B> (on <bus-name> bus)
-    - <compatible-C>
-    - ...
-
-    The text "(on <bus-name> bus)" appears when bindings may behave
-    differently depending on the bus the node appears on.
-    For example, this applies to some sensor device nodes, which may
-    appear as children of either I2C or SPI bus nodes.
     ''', string_io)
 
     for vnd, bindings in vnd_lookup.vnd2bindings.items():

--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -23,6 +23,7 @@ audio	Audio
 auxdisplay	Auxiliary Display
 base	Base
 battery	Battery
+biometrics	Biometrics
 bluetooth	Bluetooth
 cache	Cache
 can	CAN (Controller Area Network)
@@ -86,8 +87,12 @@ modem	Modem
 mspi	Multi-bit SPI (Serial Peripheral Interface)
 mtd	MTD (Memory Technology Device)
 net	Networking
+nvmem	NVMEM (Non-Volatile Memory)
+opamp	OPAMP (Operational Amplifier)
 options	Options
 ospi	OCTOSPI (Octal Serial Peripheral Interface)
+otp	OTP (One-Time Programmable) memory
+p_state Power state
 pcie	PCIe (Peripheral Component Interconnect Express)
 peci	PECI (Platform Environment Control Interface)
 phy	PHY
@@ -96,6 +101,7 @@ pm_cpu_ops	Power management CPU operations
 power	Power management
 power-domain	Power domain
 ppc	PPC architecture
+ppmcie	PMCI (Platform Management Components Interconnect)
 ps2	PS/2 (Personal System/2)
 psi5	PSI5 (Peripheral Sensor Interface, 5th generation)
 pwm	PWM (Pulse Width Modulation)
@@ -108,6 +114,7 @@ retention	Retention
 riscv	RISC-V architecture
 rng	RNG (Random Number Generator)
 rtc	RTC (Real Time Clock)
+rx	Renesas RX
 sd	SD (Secure Digital)
 sdhc	SDHC (Secure Digital High Capacity)
 sensor	Sensors


### PR DESCRIPTION
Group bindings by type in addition to vendor in the bindings index doc page.
Also updates some of the missing binding types descriptions in binding-types.txt

<img width="800" height="770" alt="image" src="https://github.com/user-attachments/assets/269f9a85-e2b5-4762-9572-ae074f623dd3" />

---

<img width="889" height="773" alt="image" src="https://github.com/user-attachments/assets/e694d1b4-61f3-491b-8225-f0a5f1862e03" />


Fixes #93150.