### PR TITLE
dts: bindings: vendor-prefixes: remove non-breaking spaces for sipeed

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -652,7 +652,7 @@ simtek	Cypress Semiconductor Corporation (Simtek Corporation)
 sinlinx	Sinlinx Electronics Technology Co., LTD
 sinovoip	SinoVoip Co., Ltd
 sinowealth	Sino Wealth Electronic Ltd
-sipeed	Shenzhen Sipeed Technology Co., Ltd.
+sipeed	Shenzhen Sipeed Technology Co., Ltd.
 sirf	SiRF Technology, Inc.
 sis	Silicon Integrated Systems Corp.
 sitronix	Sitronix Technology Corporation


### PR DESCRIPTION
sipeed vendor name had non-breaking spaces in it, which is probably not desirable in such a low-level, very much text-only, file. Replaced with normal whitespace characters.