### PR TITLE
docs: extended docu to include tcp syslog server

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -194,7 +194,11 @@ formatted to *hh:mm:ss:mmm,uuu*. Otherwise is printed in raw format.
 
 Backend options:
 
-:kconfig:option:`CONFIG_LOG_BACKEND_UART`: Enabled built-in UART backend.
+:kconfig:option:`CONFIG_LOG_BACKEND_UART`: Enable built-in UART backend.
+
+:kconfig:option:`CONFIG_LOG_BACKEND_NET`: Enable built-in Networking backend to send syslog messages
+to a network server.
+
 
 .. _log_usage:
 

--- a/samples/net/syslog_net/README.rst
+++ b/samples/net/syslog_net/README.rst
@@ -30,7 +30,8 @@ variables in prj.conf file:
 	CONFIG_LOG_BACKEND_NET=y
 	CONFIG_LOG_BACKEND_NET_SERVER="[2001:db8::2]:514"
 
-Default port number is 514 if user does not specify a value.
+Default port number is 514 and the default protocol is UDP
+if user does not explicitly specify otherwise.
 The following syntax is supported for the server address
 and port:
 
@@ -41,6 +42,15 @@ and port:
 	[2001:db8::1]:514
 	[2001:db8::2]
 	2001:db::42
+
+To change the protocol to TCP, prefix the server address with ``tcp://``
+
+.. code-block:: console
+
+   tcp://192.0.2.1:514
+   tcp://192.0.2.42
+   tcp://[2001:db8::1]:514
+
 
 Build syslog_net sample application like this:
 


### PR DESCRIPTION
Added minor updates to documentation for the network logging backend.

Extended the sample documentation to include possible TCP backends.

Verified tcp setting on STM32U5 and Grafana Alloy