### PR TITLE
drivers: ethernet: set init priorities to the same value

### DIFF
--- a/boards/adi/apard32690/Kconfig.defconfig
+++ b/boards/adi/apard32690/Kconfig.defconfig
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 if BOARD_APARD32690
 
-configdefault MDIO_INIT_PRIORITY
-	default 81
-
-configdefault PHY_INIT_PRIORITY
-	default 82
-
 configdefault NET_L2_ETHERNET
 	default y
 

--- a/boards/adi/eval_adin1110ebz/Kconfig.defconfig
+++ b/boards/adi/eval_adin1110ebz/Kconfig.defconfig
@@ -8,12 +8,6 @@ if BOARD_ADI_EVAL_ADIN1110EBZ
 configdefault SPI_STM32_DMA
 	default y
 
-configdefault MDIO_INIT_PRIORITY
-	default 81
-
-configdefault PHY_INIT_PRIORITY
-	default 82
-
 config MEMC
 	default y
 

--- a/boards/adi/eval_adin2111d1z/Kconfig.defconfig
+++ b/boards/adi/eval_adin2111d1z/Kconfig.defconfig
@@ -5,14 +5,6 @@
 
 if BOARD_ADI_EVAL_ADIN2111D1Z
 
-config MDIO_INIT_PRIORITY
-	default 81
-	depends on MDIO
-
-config PHY_INIT_PRIORITY
-	default 82
-	depends on NET_L2_ETHERNET && ETH_DRIVER
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/adi/eval_adin2111ebz/Kconfig.defconfig
+++ b/boards/adi/eval_adin2111ebz/Kconfig.defconfig
@@ -5,12 +5,6 @@
 
 if BOARD_ADI_EVAL_ADIN2111EBZ
 
-configdefault MDIO_INIT_PRIORITY
-	default 81
-
-configdefault PHY_INIT_PRIORITY
-	default 82
-
 configdefault SPI_STM32_DMA
 	default y
 

--- a/boards/kws/pico2_spe/Kconfig.defconfig
+++ b/boards/kws/pico2_spe/Kconfig.defconfig
@@ -13,9 +13,6 @@ endif # I2C_DW
 config USB_SELF_POWERED
 	default n
 
-configdefault PHY_INIT_PRIORITY
-	default 82
-
 configdefault NET_L2_ETHERNET
 	default y
 

--- a/boards/kws/pico_spe/Kconfig.defconfig
+++ b/boards/kws/pico_spe/Kconfig.defconfig
@@ -13,9 +13,6 @@ endif # I2C_DW
 config USB_SELF_POWERED
 	default n
 
-configdefault PHY_INIT_PRIORITY
-	default 82
-
 configdefault NET_L2_ETHERNET
 	default y
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -499,6 +499,12 @@ Ethernet
   reworked to be used as active low, you may have to set the pin as
   ``GPIO_ACTIVE_LOW`` in devicetree (:github:`100751`).
 
+* :kconfig:option:`CONFIG_ETH_INIT_PRIORITY` is now set to 60 by default.
+  :kconfig:option:`CONFIG_PHY_INIT_PRIORITY` and :kconfig:option:`CONFIG_MDIO_INIT_PRIORITY` are now
+  defaulting to the value of :kconfig:option:`CONFIG_ETH_INIT_PRIORITY`. Same for
+  :kconfig:option:`CONFIG_PTP_CLOCK_INIT_PRIORITY`,  but only if :kconfig:option:`CONFIG_ETH_DRIVER`
+  is enabled. This way the priority is based on the dependencies in the devicetree.
+
 File System
 ===========
 

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -93,8 +93,8 @@ endif # "Ethernet Drivers"
 
 config ETH_INIT_PRIORITY
 	int "Ethernet driver init priority"
-	default 80
-	depends on NET_L2_ETHERNET || ETH_DRIVER
+	default 60
+	depends on NET_L2_ETHERNET || ETH_DRIVER || MDIO
 	help
 	  Ethernet device driver initialization priority.
 	  Do not mess with it unless you know what you are doing.

--- a/drivers/ethernet/mdio/Kconfig
+++ b/drivers/ethernet/mdio/Kconfig
@@ -48,7 +48,7 @@ rsource "Kconfig.xmc4xxx"
 
 config MDIO_INIT_PRIORITY
 	int "Init priority"
-	default 60
+	default ETH_INIT_PRIORITY
 	help
 	  MDIO device driver initialization priority.
 

--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -21,7 +21,7 @@ source "drivers/ethernet/phy/Kconfig.microchip_t1s"
 
 config PHY_INIT_PRIORITY
 	int "Ethernet PHY driver init priority"
-	default 70
+	default ETH_INIT_PRIORITY
 	help
 	  Ethernet PHY device driver initialization priority.
 	  Do not mess with it unless you know what you are doing.

--- a/drivers/ptp_clock/Kconfig
+++ b/drivers/ptp_clock/Kconfig
@@ -15,6 +15,7 @@ source "drivers/ptp_clock/Kconfig.nxp_netc"
 
 config PTP_CLOCK_INIT_PRIORITY
 	int "Init priority"
+	default ETH_INIT_PRIORITY if ETH_DRIVER
 	default 75
 	help
 	  PTP Clock device driver initialization priority


### PR DESCRIPTION
set init priorities to the same value, so the dependencies in the devicetree will decide over the order of the init.

The dependencies from the dt are btw already used to verify the init prios at the end of the build.