### PR TITLE
boards: nordic: Fix nRF54L05/L10 DEVELOP_IN targets

### DIFF
--- a/boards/nordic/nrf54l15dk/Kconfig
+++ b/boards/nordic/nrf54l15dk/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NRF54L15DK
+	select SOC_NRF54L10_DEVELOP_IN_NRF54L15 if SOC_NRF54L10
+	select SOC_NRF54L05_DEVELOP_IN_NRF54L15 if SOC_NRF54L05

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -57,14 +57,14 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
                                                                 NRF_PPR)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
                                                                 NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA
-                                                                DEVELOP_IN_NRF54L15)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUAPP     NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA
-                                                                DEVELOP_IN_NRF54L15)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_DEVELOP_IN_NRF54L15 DEVELOP_IN_NRF54L15)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUAPP     NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUFLPR    NRF_FLPR)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_DEVELOP_IN_NRF54L15 DEVELOP_IN_NRF54L15)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15 NRF54L15_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF54L15_CPUAPP NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_CPUFLPR    NRF_FLPR)

--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -114,4 +114,18 @@ config SOC_NRF54LM20A_DEVELOP_IN_NRF54LM20B
 	  onto the nRF54LM20B DK. This symbol needs to be considered by certain system
 	  initialization functionality residing in SoC erratas.
 
+config SOC_NRF54L10_DEVELOP_IN_NRF54L15
+	bool
+	help
+	  The nrf54l15dk board can be used to develop the nRF54L10 SoC onto the nRF54L15 DK.
+	  This symbol needs to be considered by certain system initialization functionality
+	  residing in system_nrf54l.c and SoC erratas.
+
+config SOC_NRF54L05_DEVELOP_IN_NRF54L15
+	bool
+	help
+	  The nrf54l15dk board can be used to develop the nRF54L05 SoC onto the nRF54L15 DK.
+	  This symbol needs to be considered by certain system initialization functionality
+	  residing in system_nrf54l.c and SoC erratas.
+
 endif # SOC_SERIES_NRF54L


### PR DESCRIPTION
Fix nRF54L05/L10 DEVELOP_IN targets on nRF54L15 DK.