### PR TITLE
hal_silabs: gecko: fix CMake RAIL lib parsing for efr32fg1p

### DIFF
--- a/modules/hal_silabs/gecko/CMakeLists.txt
+++ b/modules/hal_silabs/gecko/CMakeLists.txt
@@ -18,9 +18,12 @@ set(BLOBS_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/zephyr/blobs/gecko)
 string(TOUPPER ${CONFIG_SOC_SERIES} SILABS_GECKO_DEVICE)
 string(TOUPPER ${CONFIG_SOC} SILABS_GECKO_PART_NUMBER)
 
-# Get SoC series number, i.e. translate e.g. efr32bg22 -> 22
-string(SUBSTRING ${CONFIG_SOC_SERIES} 7 2 GECKO_SERIES_NUMBER)
-
+# Get SoC series number, i.e. translate e.g. efr32bg22 -> 22, efr32fg1p -> 1
+string(SUBSTRING "${CONFIG_SOC_SERIES}" 7 2 GECKO_SERIES_NUMBER)
+# Strip any non-numeric characters from the series number
+string(REGEX REPLACE "[^0-9]" "" GECKO_SERIES_NUMBER "${GECKO_SERIES_NUMBER}")
+# Get major series number for directory mapping
+string(REGEX MATCH "^[0-9]" GECKO_MAJOR_SERIES_NUMBER "${GECKO_SERIES_NUMBER}")
 
 function(add_prebuilt_library lib_name prebuilt_path)
   add_library(${lib_name} STATIC IMPORTED GLOBAL)
@@ -64,7 +67,7 @@ if(${CONFIG_SOC_GECKO_HAS_RADIO})
         ${RADIO_DIR}/rail_lib/plugin/rail_util_callbacks
         ${RADIO_DIR}/rail_lib/plugin/rail_util_callbacks/config
         ${RADIO_DIR}/rail_lib/plugin/rail_util_protocol
-        ${RADIO_DIR}/rail_lib/plugin/rail_util_protocol/config/efr32xg${GECKO_SERIES_NUMBER}/
+        ${RADIO_DIR}/rail_lib/plugin/rail_util_protocol/config/efr32xg${GECKO_MAJOR_SERIES_NUMBER}x/
         ${RADIO_DIR}/rail_lib/protocol/ble
         ${RADIO_DIR}/rail_lib/protocol/ieee802154
         ${RADIO_DIR}/rail_lib/protocol/zwave


### PR DESCRIPTION
Fixes incorrect CMake substring parsing that caused build failures on SoCs with non-numeric suffixes (e.g., efr32fg1p).

The previous logic extracted '1p', which broke the linking path for `librail_efr32xg1_gcc_release.a` and the protocol directory inclusion. This adds regex to strip non-numeric characters for the library path and appends 'x' for the major series wildcard directory.

Verified with a pristine build for `slwrb4250b` with RAIL enabled:
```
console
-- Zephyr version: 4.3.99 (/home/pavithra/Tarzan_ws/zephyr), build: v4.3.0-6567-g0c57145c9c33
[144/144] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       16308 B       256 KB      6.22%
             RAM:        4112 B        32 KB     12.55%
        IDT_LIST:          0 GB        32 KB      0.00%
```

Fixes #104300