### PR TITLE
tests: esp32: fix GPIO and RTC clock tests

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
@@ -7,21 +7,23 @@
 #include "device_subsys.h"
 #include <zephyr/drivers/clock_control/esp32_clock_control.h>
 
-/* Test common modules among espressif SOCs*/
+/* Test shared peripheral modules that use periph_module_enable/disable.
+ *
+ * Notes on module availability:
+ * - UART1: shared only on ESP32, ESP32-S3, ESP32-C3
+ * - UHCI0: has clock mask on all SoCs except ESP32-C2
+ * - TIMG0: available on all SoCs
+ *
+ */
 static const struct device_subsys_data subsys_data[] = {
-	{.subsys = (void *) ESP32_LEDC_MODULE},
-	{.subsys = (void *) ESP32_UART1_MODULE},
-	{.subsys = (void *) ESP32_I2C0_MODULE},
+#if defined(CONFIG_SOC_SERIES_ESP32) || defined(CONFIG_SOC_SERIES_ESP32S3) ||                      \
+	defined(CONFIG_SOC_SERIES_ESP32C3)
+	{.subsys = (void *)ESP32_UART1_MODULE},
+#endif
 #if !defined(CONFIG_SOC_SERIES_ESP32C2)
-	{.subsys = (void *) ESP32_UHCI0_MODULE},
+	{.subsys = (void *)ESP32_UHCI0_MODULE},
 #endif
-#if defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32S2) || \
-	defined(CONFIG_SOC_SERIES_ESP32S3)
-	{.subsys = (void *) ESP32_TIMG1_MODULE},
-#else
-	{.subsys = (void *) ESP32_TIMG0_MODULE},
-#endif
-	{.subsys = (void *) ESP32_RNG_MODULE},
+	{.subsys = (void *)ESP32_TIMG0_MODULE},
 };
 
 static const struct device_data devices[] = {

--- a/tests/drivers/gpio/gpio_basic_api/boards/esp32_devkitc_procpu.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/esp32_devkitc_procpu.overlay
@@ -7,17 +7,19 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&gpio0 16 0>;
-		in-gpios = <&gpio0 17 0>;
+		out-gpios = <&gpio0 18 0>;
+		in-gpios = <&gpio0 19 0>;
 	};
 };
 
 /*
- * Some notes about esp32 pins:
+ * Notes about esp32 pins:
  *    GPIO pins 34-39 are not suitable for this test because:
  *    1. input-only
  *    2. No internal pull-up/pull-down circuitry.
- *    The pin names are: SENSOR_VP(GPIO36),SENSOR_CAPP(GPIO37),
- *                       SENSOR_CAPN (GPIO38), SENSOR_VN (GPIO39),
- *                       VDET_1 (GPIO34), VDET_2 (GPIO35).
+ *
+ *    GPIO pins 16-17 are reserved for PSRAM on ESP32-WROVER modules.
+ *    GPIO pins 6-11 are reserved for SPI flash.
+ *
+ *    Using GPIO 18 and 19 which are available on WROVER modules.
  */

--- a/tests/drivers/gpio/gpio_basic_api/socs/esp32c6_hpcore.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/socs/esp32c6_hpcore.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 4 0>;
+		in-gpios = <&gpio0 5 0>;
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/socs/esp32h2.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/socs/esp32h2.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 4 0>;
+		in-gpios = <&gpio0 5 0>;
+	};
+};


### PR DESCRIPTION
1. Update ESP32 GPIO test overlay to avoid PSRAM-reserved pins and add overlays for ESP32-C6 and ESP32-H2
2. Restrict clock control test peripheral module list to entries available on each SoC
3. Fix RTC clock XTAL source test to skip non-exact divisions (e.g. 26 MHz / 4) and restore CPU to PLL after XTAL testing