### PR TITLE
STM32MP13: add SPI support

### DIFF
--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -149,6 +149,13 @@
 	status = "okay";
 };
 
+&spi5 {
+	pinctrl-0 = <&spi5_nss_pf6 &spi5_sck_ph7
+		     &spi5_miso_pa8 &spi5_mosi_ph3>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c1_scl_pd12 &i2c1_sda_pe8>;

--- a/boards/st/stm32mp135f_dk/twister.yaml
+++ b/boards/st/stm32mp135f_dk/twister.yaml
@@ -8,6 +8,7 @@ toolchain:
 supported:
   - gpio
   - uart
+  - spi
 ram: 262144
 flash: 262144
 vendor: st

--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -129,6 +129,21 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 		case LL_APB1_GRP1_PERIPH_I2C2:
 			*rate = LL_RCC_GetI2CClockFreq(LL_RCC_I2C12_CLKSOURCE);
 			break;
+		case LL_APB1_GRP1_PERIPH_SPI2:
+			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI23_CLKSOURCE);
+			break;
+		case LL_APB1_GRP1_PERIPH_SPI3:
+			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI23_CLKSOURCE);
+			break;
+		default:
+			return -ENOTSUP;
+		}
+		break;
+	case STM32_CLOCK_BUS_APB2:
+		switch (pclken->enr) {
+		case LL_APB2_GRP1_PERIPH_SPI1:
+			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_SPI1_CLKSOURCE);
+			break;
 		default:
 			return -ENOTSUP;
 		}
@@ -143,6 +158,12 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 			break;
 		case LL_APB6_GRP1_PERIPH_I2C5:
 			*rate = LL_RCC_GetI2CClockFreq(LL_RCC_I2C5_CLKSOURCE);
+			break;
+		case LL_APB6_GRP1_PERIPH_SPI4:
+			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI4_CLKSOURCE);
+			break;
+		case LL_APB6_GRP1_PERIPH_SPI5:
+			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI5_CLKSOURCE);
 			break;
 		default:
 			return -ENOTSUP;

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -182,6 +182,71 @@
 				      <12 1>, <13 1>, <14 1>, <15 1>;
 		};
 
+		spi1: spi@44004000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			reg = <0x44004000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
+			interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			st,spi-data-width = "full-4-to-32-bit";
+			fifo-size = <16>;
+			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
+		spi2: spi@4000b000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			reg = <0x4000b000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			st,spi-data-width = "full-4-to-32-bit";
+			fifo-size = <16>;
+			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
+		spi3: spi@4000c000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			reg = <0x4000c000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
+			interrupts = <GIC_SPI 52 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			st,spi-data-width = "full-4-to-32-bit";
+			fifo-size = <16>;
+			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
+		spi4: spi@4c002000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			reg = <0x4c002000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB6, 2)>;
+			interrupts = <GIC_SPI 85 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			st,spi-data-width = "full-4-to-32-bit";
+			fifo-size = <16>;
+			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
+		spi5: spi@4c003000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			reg = <0x4c003000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB6, 3)>;
+			interrupts = <GIC_SPI 86 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			st,spi-data-width = "full-4-to-16-bit";
+			fifo-size = <8>;
+			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
 		i2c1: i2c@40012000 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/tests/drivers/spi/spi_loopback/boards/stm32mp135f_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32mp135f_dk.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Gregory Planchon <gregory.planchon@st.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi5 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};


### PR DESCRIPTION
Bring SPI to stm32mp135f_dk board.

Tested with spi_loopback with the following build command:
west build -b stm32mp135f_dk tests/drivers/spi/spi_loopback/ -p