### PR TITLE
soc: infineon: edge: pse84: Remove dependency on edgeprotecttools

### DIFF
--- a/boards/infineon/kit_pse84_ai/doc/index.rst
+++ b/boards/infineon/kit_pse84_ai/doc/index.rst
@@ -67,8 +67,7 @@ The KIT-PSE84-AI includes an onboard programmer/debugger (`KitProg3`_) to provid
 flash programming, and serial communication over USB. Flash and debug commands use OpenOCD and
 require a custom Infineon OpenOCD version, that supports KitProg3, to be installed.
 
-Please refer to the `ModusToolbox™ software installation guide`_ to install the
-Infineon OpenOCD and Edge Protect Security Suite (edgeprotecttools).
+Please refer to the `ModusToolbox™ software installation guide`_ to install Infineon OpenOCD.
 
 Flashing
 ========

--- a/boards/infineon/kit_pse84_eval/doc/index.rst
+++ b/boards/infineon/kit_pse84_eval/doc/index.rst
@@ -69,8 +69,7 @@ The KIT-PSE84-EVAL includes an onboard programmer/debugger (`KitProg3`_) to prov
 flash programming, and serial communication over USB. Flash and debug commands use OpenOCD and
 require a custom Infineon OpenOCD version, that supports KitProg3, to be installed.
 
-Please refer to the `ModusToolbox™ software installation guide`_ to install the
-Infineon OpenOCD and Edge Protect Security Suite (edgeprotecttools).
+Please refer to the `ModusToolbox™ software installation guide`_ to install Infineon OpenOCD.
 
 Flashing
 ========

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+include(${ZEPHYR_BASE}/soc/infineon/edge/pse84/pse84_metadata.cmake)
+
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   zephyr_sources(soc_pse84_m33_s.c)
 
@@ -11,29 +13,10 @@ if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   zephyr_sources(security_config/pse84_s_system.c)
   zephyr_sources(security_config/pse84_s_sau.c)
 
-  find_program(EDGEPROTECTTOOLS edgeprotecttools OPTIONAL)
+  set(unsigned_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.hex)
+  set(signed_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex)
 
-  if(${EDGEPROTECTTOOLS} STREQUAL "EDGEPROTECTTOOLS-NOTFOUND")
-    message(WARNING "Could not find edgeprotecttools.
-      This will result in a nonfunctional secure cm33.
-      Please consult index.rst for kit_pse84_eval board.")
-  else()
-    message("-- Found edgeprotecttools: ${EDGEPROTECTTOOLS}")
-
-    set(unsigned_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.hex)
-    set(signed_hex ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex)
-    dt_nodelabel(m33s_header NODELABEL "m33s_header")
-    dt_reg_addr(header_addr PATH ${m33s_header})
-    dt_reg_size(header_size PATH ${m33s_header})
-
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND edgeprotecttools image-metadata --image ${unsigned_hex} --output ${signed_hex}
-        --erased-val 0xff --hex-addr ${header_addr} --header-size ${header_size}
-        --slot-size 0x130000
-    )
-
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${signed_hex})
-  endif()
+  pse84_add_metadata_secure_hex(${unsigned_hex} ${signed_hex})
 else()
   zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M55 soc_pse84_m55.c)
 endif()

--- a/soc/infineon/edge/pse84/pse84_metadata.cmake
+++ b/soc/infineon/edge/pse84/pse84_metadata.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Adds mcuboot metadata to the PSE84 CM33 secure image using imgtool
+# with parameters derived from the DT memory map (header address,
+# header size, and slot size). Uses default version 0.0.0+0 as imgtool
+# requires a version parameter.
+# Registers the add metadata command and output file via
+# extra_post_build properties.
+#
+# Usage: pse84_add_metadata_secure_hex(<input_hex> <output_hex>)
+function(pse84_add_metadata_secure_hex INPUT_FILE OUTPUT_FILE)
+  dt_nodelabel(m33s_header_node NODELABEL "m33s_header")
+  dt_nodelabel(m33s_xip_node NODELABEL "m33s_xip")
+  dt_reg_addr(header_addr PATH ${m33s_header_node})
+  dt_reg_size(header_size PATH ${m33s_header_node})
+  dt_reg_size(m33s_xip_size PATH ${m33s_xip_node})
+  math(EXPR slot_size "${m33s_xip_size} + ${header_size}" OUTPUT_FORMAT HEXADECIMAL)
+
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND ${PYTHON_EXECUTABLE} ${IMGTOOL} sign --version "0.0.0+0"
+      --header-size ${header_size} --erased-val 0xff --pad-header
+      --slot-size ${slot_size} --hex-addr ${header_addr}
+      ${INPUT_FILE} ${OUTPUT_FILE}
+  )
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${OUTPUT_FILE})
+endfunction()


### PR DESCRIPTION
For signing and verifying images on Infineon Edge devices use the mcuboot tool imgtool rather than depending on the Infineon specific edgeprotecttools. For the purposes required in the Zephyr environment this is more than enough.