### PR TITLE
Unify "device not ready" errors

### DIFF
--- a/drivers/input/input_adc_keys.c
+++ b/drivers/input/input_adc_keys.c
@@ -167,7 +167,7 @@ static int adc_keys_init(const struct device *dev)
 	int ret;
 
 	if (!adc_is_ready_dt(&cfg->channel)) {
-		LOG_ERR("ADC controller device %s not ready", cfg->channel.dev->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->channel.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_analog_axis.c
+++ b/drivers/input/input_analog_axis.c
@@ -231,7 +231,7 @@ static void analog_axis_thread(void *arg1, void *arg2, void *arg3)
 		const struct analog_axis_channel_config *axis_cfg = &cfg->channel_cfg[i];
 
 		if (!adc_is_ready_dt(&axis_cfg->adc)) {
-			LOG_ERR("ADC controller device not ready");
+			LOG_ERR_DEVICE_NOT_READY(axis_cfg->adc.dev);
 			return;
 		}
 

--- a/drivers/input/input_cap12xx.c
+++ b/drivers/input/input_cap12xx.c
@@ -198,7 +198,7 @@ static int cap12xx_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -249,8 +249,7 @@ static int cap12xx_init(const struct device *dev)
 	} else {
 		LOG_DBG("cap12xx driver in interrupt mode");
 		if (!gpio_is_ready_dt(config->int_gpio)) {
-			LOG_ERR("Interrupt GPIO controller device not ready (missing device tree "
-				"node?)");
+			LOG_ERR_DEVICE_NOT_READY(config->int_gpio->port);
 			return -ENODEV;
 		}
 

--- a/drivers/input/input_cf1133.c
+++ b/drivers/input/input_cf1133.c
@@ -268,7 +268,7 @@ static int cf1133_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -280,7 +280,7 @@ static int cf1133_init(const struct device *dev)
 	LOG_DBG("Int conf for TS gpio: %d", &config->int_gpio);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_ch9350l.c
+++ b/drivers/input/input_ch9350l.c
@@ -352,7 +352,7 @@ static int ch9350l_init(struct device const *dev)
 		    CONFIG_INPUT_CH9350L_FRAME_COUNT);
 
 	if (!device_is_ready(config->uart)) {
-		LOG_ERR("UART device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->uart);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_cst816s.c
+++ b/drivers/input/input_cst816s.c
@@ -240,7 +240,7 @@ static int cst816s_chip_init(const struct device *dev)
 	cst816s_chip_reset(dev);
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus %s not ready", cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 	ret = i2c_reg_read_byte_dt(&cfg->i2c, CST816S_REG_CHIP_ID, &chip_id);
@@ -293,7 +293,7 @@ static int cst816s_init(const struct device *dev)
 	const struct cst816s_config *config = dev->config;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO port %s not ready", config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_cy8cmbr3xxx.c
+++ b/drivers/input/input_cy8cmbr3xxx.c
@@ -360,7 +360,7 @@ static void cy8cmbr3xxx_reset(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->rst_gpio)) {
-		LOG_ERR("GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->rst_gpio.port);
 		return;
 	}
 
@@ -390,14 +390,14 @@ static int cy8cmbr3xxx_init(const struct device *dev)
 	k_work_init(&data->work, cy8cmbr3xxx_work_handler);
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
 	cy8cmbr3xxx_reset(dev);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -171,7 +171,7 @@ static int ft5336_init(const struct device *dev)
 	int r;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -201,7 +201,7 @@ static int ft5336_init(const struct device *dev)
 
 #ifdef CONFIG_INPUT_FT5336_INTERRUPT
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_ft6146.c
+++ b/drivers/input/input_ft6146.c
@@ -153,7 +153,7 @@ static int ft6146_reset(const struct device *dev)
 	}
 
 	if (!device_is_ready(config->reset_gpio.port)) {
-		LOG_ERR("Reset GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 		return -ENODEV;
 	}
 
@@ -184,7 +184,7 @@ static int ft6146_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -201,7 +201,7 @@ static int ft6146_init(const struct device *dev)
 
 #ifdef CONFIG_INPUT_FT6146_INTERRUPT
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -197,7 +197,7 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
 		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
+			LOG_ERR_DEVICE_NOT_READY(gpio->port);
 			return -ENODEV;
 		}
 
@@ -217,7 +217,7 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 		struct gpio_callback *gpio_cb;
 
 		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
+			LOG_ERR_DEVICE_NOT_READY(gpio->port);
 			return -ENODEV;
 		}
 

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -280,7 +280,7 @@ static int gt911_init(const struct device *dev)
 	struct gt911_data *data = dev->data;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -292,13 +292,13 @@ static int gt911_init(const struct device *dev)
 	int r;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 
 	if (config->rst_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->rst_gpio)) {
-			LOG_ERR("Reset GPIO controller device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->rst_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/input/input_ili2132a.c
+++ b/drivers/input/input_ili2132a.c
@@ -77,17 +77,17 @@ static int ili2132a_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&dev_cfg->i2c)) {
-		LOG_ERR("%s is not ready", dev_cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->i2c.bus);
 		return -ENODEV;
 	}
 
 	if (!gpio_is_ready_dt(&dev_cfg->rst)) {
-		LOG_ERR("Reset GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->rst.port);
 		return -ENODEV;
 	}
 
 	if (!gpio_is_ready_dt(&dev_cfg->irq)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev_cfg->irq.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_ite_it8801_kbd.c
+++ b/drivers/input/input_ite_it8801_kbd.c
@@ -148,7 +148,7 @@ static int kbd_it8801_init(const struct device *dev)
 
 	/* Verify multi-function parent is ready */
 	if (!device_is_ready(config->mfd)) {
-		LOG_ERR("(input)%s is not ready", config->mfd->name);
+		LOG_ERR_DEVICE_NOT_READY(config->mfd);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_mcux_kpp.c
+++ b/drivers/input/input_mcux_kpp.c
@@ -45,7 +45,7 @@ static void get_source_clk_rate(const struct device *dev, uint32_t *clk_rate)
 	clock_control_subsys_t clk_sub_sys = dev_cfg->clk_sub_sys;
 
 	if (!device_is_ready(ccm_dev)) {
-		LOG_ERR("CCM driver is not installed");
+		LOG_ERR_DEVICE_NOT_READY(ccm_dev);
 		*clk_rate = 0;
 		return;
 	}
@@ -142,7 +142,7 @@ static int input_kpp_init(const struct device *dev)
 	status_t stable = kStatus_Success;
 
 	if (!device_is_ready(config->ccm_dev)) {
-		LOG_ERR("CCM driver is not installed");
+		LOG_ERR_DEVICE_NOT_READY(config->ccm_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_modulino_buttons.c
+++ b/drivers/input/input_modulino_buttons.c
@@ -66,7 +66,7 @@ static int modulino_buttons_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -146,7 +146,7 @@ static int npcx_kbd_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {
-		LOG_ERR("%s device not ready", clk_dev->name);
+		LOG_ERR_DEVICE_NOT_READY(clk_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_nunchuk.c
+++ b/drivers/input/input_nunchuk.c
@@ -111,7 +111,7 @@ static int nunchuk_init(const struct device *dev)
 	data->interval_ms = K_MSEC(cfg->polling_interval_ms - 11);
 
 	if (!i2c_is_ready_dt(&cfg->i2c_bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c_bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -370,7 +370,7 @@ static int pinnacle_set_sensitivity(const struct device *dev)
 static bool pinnacle_is_ready_i2c(const struct pinnacle_bus *bus)
 {
 	if (!i2c_is_ready_dt(&bus->i2c)) {
-		LOG_ERR("I2C bus %s is not ready", bus->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(bus->i2c.bus);
 		return false;
 	}
 
@@ -417,7 +417,7 @@ static int pinnacle_seq_read_i2c(const struct pinnacle_bus *bus, uint8_t address
 static bool pinnacle_is_ready_spi(const struct pinnacle_bus *bus)
 {
 	if (!spi_is_ready_dt(&bus->spi)) {
-		LOG_ERR("SPI bus %s is not ready", bus->spi.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(bus->spi.bus);
 		return false;
 	}
 
@@ -711,7 +711,7 @@ int pinnacle_init_interrupt(const struct device *dev)
 	/* Configure GPIO pin for HW_DR signal */
 	rc = gpio_is_ready_dt(gpio);
 	if (!rc) {
-		LOG_ERR("GPIO device %s/%d is not ready", gpio->port->name, gpio->pin);
+		LOG_ERR_DEVICE_NOT_READY(gpio->port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_realtek_rts5912_kbd.c
+++ b/drivers/input/input_realtek_rts5912_kbd.c
@@ -114,7 +114,7 @@ static int rts5912_kbd_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(config->clk_dev)) {
-		LOG_ERR("clock kbd device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clk_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_renesas_ra_ctsu.c
+++ b/drivers/input/input_renesas_ra_ctsu.c
@@ -295,6 +295,7 @@ static int renesas_ra_ctsu_group_init(const struct device *dev)
 #endif /* CONFIG_INPUT_RENESAS_RA_QE_TOUCH_CFG */
 
 	if (!device_is_ready(cfg->ctsu_dev)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->ctsu_dev);
 		return -ENODEV;
 	}
 
@@ -559,6 +560,7 @@ static int renesas_ra_ctsu_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(ctsu_cfg->clock)) {
+		LOG_ERR_DEVICE_NOT_READY(ctsu_cfg->clock);
 		return -ENODEV;
 	}
 
@@ -653,7 +655,12 @@ static int ctsu_device_init(const struct device *dev)
 {
 	const struct ctsu_device_cfg *cfg = dev->config;
 
-	return device_is_ready(cfg->group_dev) ? 0 : -ENODEV;
+	if (!device_is_ready(cfg->group_dev)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->group_dev);
+		return -ENODEV;
+	}
+
+	return 0;
 }
 
 #undef DT_DRV_COMPAT

--- a/drivers/input/input_stmpe811.c
+++ b/drivers/input/input_stmpe811.c
@@ -462,7 +462,7 @@ static int stmpe811_init(const struct device *dev)
 	int err;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
-		LOG_ERR("I2C controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -486,7 +486,7 @@ static int stmpe811_init(const struct device *dev)
 
 	/* Initialize GPIO interrupt */
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_tsc_keys.c
+++ b/drivers/input/input_tsc_keys.c
@@ -177,7 +177,7 @@ static int stm32_tsc_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk)) {
-		LOG_ERR("%s: clock controller device not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(clk);
 		return -ENODEV;
 	}
 
@@ -397,7 +397,7 @@ static int input_tsc_keys_init(const struct device *dev)
 	struct input_tsc_keys_data *data = dev->data;
 
 	if (!device_is_ready(config->tsc_dev)) {
-		LOG_ERR("%s: TSC device not ready", config->tsc_dev->name);
+		LOG_ERR_DEVICE_NOT_READY(config->tsc_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_xpt2046.c
+++ b/drivers/input/input_xpt2046.c
@@ -196,7 +196,7 @@ static int xpt2046_init(const struct device *dev)
 	struct xpt2046_data *data = dev->data;
 
 	if (!spi_is_ready_dt(&config->bus)) {
-		LOG_ERR("SPI controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -205,7 +205,7 @@ static int xpt2046_init(const struct device *dev)
 	k_work_init_delayable(&data->dwork, xpt2046_release_handler);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -869,6 +869,28 @@ size_t z_device_get_all_static(const struct device **devices);
 __syscall bool device_is_ready(const struct device *dev);
 
 /**
+ * @brief Writes a "device not ready" warning message to the log.
+ *
+ * @details Writes a "device not ready" warning message to the log using the
+ * device name as reference, meant to be used in device_is_ready checks.
+ *
+ * @param dev pointer to a struct device.
+ */
+#define LOG_WRN_DEVICE_NOT_READY(dev) \
+	LOG_WRN("%s device not ready", (dev) ? (dev)->name : "(null)")
+
+/**
+ * @brief Writes a "device not ready" error message to the log.
+ *
+ * @details Writes a "device not ready" error message to the log using the
+ * device name as reference, meant to be used in device_is_ready checks.
+ *
+ * @param dev pointer to a struct device.
+ */
+#define LOG_ERR_DEVICE_NOT_READY(dev) \
+	LOG_ERR("%s device not ready", (dev) ? (dev)->name : "(null)")
+
+/**
  * @brief Initialize a device.
  *
  * A device whose initialization was deferred (by marking it as


### PR DESCRIPTION
Drivers and subsystems seems to all use different variations of "device not ready" messages, sometimes with no details about what device is not ready, sometimes with too many details on what device is not ready. This leads to a lot of unnecessary strings in the binary, which can add up to a decent amount of flash that could see better use on small devices.

Add a `LOG_ERR_DEVICE_NOT_READY` macro to have a single "device not ready" message that can be used around the os so that we have only one log string ending up in the binary.