### PR TITLE
tests: boards: espressif: memory_layout: use platform_allow

### DIFF
--- a/tests/boards/espressif/memory_layout/testcase.yaml
+++ b/tests/boards/espressif/memory_layout/testcase.yaml
@@ -1,6 +1,13 @@
 common:
   tags: memory
-  filter: CONFIG_SOC_FAMILY_ESPRESSIF_ESP32
+  platform_allow:
+    - esp32_devkitc/esp32/procpu
+    - esp32s2_devkitc
+    - esp32s3_devkitc/esp32s3/procpu
+    - esp8684_devkitm
+    - esp32c3_devkitm
+    - esp32c6_devkitc/esp32c6/hpcore
+    - esp32h2_devkitm
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
Use platform_allow to explicitly list supported boards instead of
a config filter. This restricts the test to specific devkit boards
and avoids running on appcpu targets.

Fixes #104388