### PR TITLE
Drivers: sx126x add (G)FSK support

### DIFF
--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1092,6 +1092,7 @@ int sx126x_fsk_config(const struct device *dev,
 	}
 
 	uint8_t sync_word[] = {0x12, 0xAD};
+
 	ret = sx126x_set_fsk_sync_word(dev, sync_word, sizeof(sync_word));
 	if (ret < 0) {
 		LOG_ERR("Set FSK sync word failed: %d", ret);
@@ -1304,6 +1305,7 @@ int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_l
 
 	/* Ensure TX_DONE is routed to DIO1 even after async FSK RX remaps IRQs. */
 	uint16_t tx_irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_TX_TIMEOUT;
+
 	ret = sx126x_set_dio_irq_params(dev, tx_irq_mask, tx_irq_mask, 0, 0);
 	if (ret < 0) {
 		LOG_ERR("FSK TX: Failed IRQ map: %d", ret);

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1027,7 +1027,8 @@ static int sx126x_set_fsk_crc_params(const struct device *dev,
 
 int sx126x_fsk_config(const struct device *dev,
 		      uint32_t frequency, uint32_t bitrate,
-		      uint32_t fdev, uint8_t bandwidth, int8_t tx_power)
+		      uint32_t fdev, uint8_t shaping,
+		      uint8_t bandwidth, int8_t tx_power)
 {
 	struct sx126x_data *data = dev->data;
 	const struct sx126x_hal_config *config = dev->config;
@@ -1114,7 +1115,7 @@ int sx126x_fsk_config(const struct device *dev,
 	}
 
 	ret = sx126x_set_fsk_modulation_params(dev, bitrate, fdev,
-					       SX126X_FSK_MOD_SHAPING_OFF,
+					       shaping,
 					       bandwidth);
 	if (ret < 0) {
 		goto out;
@@ -1146,12 +1147,12 @@ int sx126x_fsk_config(const struct device *dev,
 	data->fsk_config.bitrate = bitrate;
 	data->fsk_config.fdev = fdev;
 	data->fsk_config.bandwidth = bandwidth;
-	data->fsk_config.shaping = SX126X_FSK_MOD_SHAPING_OFF;
+	data->fsk_config.shaping = shaping;
 	data->fsk_config.frequency = frequency;
 	data->fsk_config.tx_power = tx_power;
 
-	LOG_INF("FSK Config: freq=%u, bitrate=%u, fdev=%u, bw=0x%02x, power=%d",
-		frequency, bitrate, fdev, bandwidth, tx_power);
+	LOG_INF("FSK Config: freq=%u, bitrate=%u, fdev=%u, shaping=0x%02x, bw=0x%02x, power=%d",
+		frequency, bitrate, fdev, shaping, bandwidth, tx_power);
 
 out:
 	k_mutex_unlock(&data->lock);
@@ -1438,10 +1439,7 @@ int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
 		     ? 0 : k_ticks_to_ms_ceil32(timeout.ticks);
 	ret = sx126x_set_rx(dev, timeout_ms);
 	if (ret < 0) {
-		sx126x_set_rf_path(dev, false, false);
-		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_IDLE);
-		return ret;
+		goto out_error;
 	}
 
 	k_mutex_unlock(&data->lock);
@@ -1493,21 +1491,20 @@ int sx126x_fsk_recv_async(const struct device *dev, lora_recv_cb cb, void *user_
 		sx126x_set_standby(dev, SX126X_STANDBY_RC);
 		sx126x_set_rf_path(dev, false, false);
 		atomic_set(&data->state, SX126X_STATE_IDLE);
-
-		k_mutex_unlock(&data->lock);
-		return 0;
+		ret = 0;
+		goto out_unlock;
 	}
 
 	if (!data->config_valid || data->current_modulation != SX126X_MODULATION_FSK) {
 		LOG_ERR("FSK not configured");
-		k_mutex_unlock(&data->lock);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out_unlock;
 	}
 
 	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
 		LOG_ERR("FSK RX async: Busy");
-		k_mutex_unlock(&data->lock);
-		return -EBUSY;
+		ret = -EBUSY;
+		goto out_unlock;
 	}
 
 	data->rx_cb = cb;
@@ -1577,18 +1574,20 @@ int sx126x_fsk_recv_async(const struct device *dev, lora_recv_cb cb, void *user_
 	ret = sx126x_set_rx(dev, 0);
 	if (ret < 0) {
 		LOG_ERR("FSK RX async: Failed set RX: %d", ret);
-		sx126x_set_rf_path(dev, false, false);
 		goto out_error;
 	}
 
 	LOG_DBG("FSK RX async started");
-	k_mutex_unlock(&data->lock);
-	return 0;
+	ret = 0;
+	goto out_unlock;
 
 out_error:
 	data->rx_cb = NULL;
-	k_mutex_unlock(&data->lock);
+	data->rx_cb_user_data = NULL;
+	sx126x_set_rf_path(dev, false, false);
 	atomic_set(&data->state, SX126X_STATE_IDLE);
+out_unlock:
+	k_mutex_unlock(&data->lock);
 	return ret;
 }
 

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -288,15 +288,21 @@ static int sx126x_get_rx_buffer_status(const struct device *dev,
 static int sx126x_get_packet_status(const struct device *dev,
 				    int16_t *rssi, int8_t *snr)
 {
+	struct sx126x_data *data = dev->data;
 	uint8_t buf[3];
 	int ret;
 
-	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_PACKET_STATUS, buf, 2);
+	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_PACKET_STATUS, buf, 3);
 	if (ret == 0) {
-		/* RSSI is -value/2 dBm */
-		*rssi = -((int16_t)buf[0] >> 1);
-		/* SNR is value/4 dB (signed) */
-		*snr = ((int8_t)buf[1]) >> 2;
+		if (data->current_modulation == SX126X_MODULATION_FSK) {
+			/* GFSK packet status: [0]=status flags, [1]=RSSI_SYNC, [2]=RSSI_AVG */
+			*rssi = -((int16_t)buf[1] >> 1);
+			*snr = 0;
+		} else {
+			/* LoRa packet status: [0]=RSSI_PKT, [1]=SNR_PKT, [2]=SIGNAL_RSSI_PKT */
+			*rssi = -((int16_t)buf[0] >> 1);
+			*snr = ((int8_t)buf[1]) >> 2;
+		}
 	}
 
 	return ret;
@@ -460,12 +466,20 @@ static void sx126x_handle_irq_rx_done(const struct device *dev, uint16_t irq_sta
 
 	/* Handle async callback or signal sync receiver */
 	if (data->rx_cb != NULL) {
-		/* Async mode - call callback and restart RX */
-		data->rx_cb(dev, data->rx_buf, result.len,
-			    result.rssi, result.snr,
-			    data->rx_cb_user_data);
-		/* Restart RX for continuous reception */
-		sx126x_set_rx(dev, 0);
+		if (result.status > 0) {
+			data->rx_cb(dev, data->rx_buf, result.len,
+				    result.rssi, result.snr,
+				    data->rx_cb_user_data);
+		}
+		/*
+		 * Explicitly re-arm async RX after each RX_DONE for both LoRa and
+		 * FSK. Some GFSK flows behave as one-shot without this.
+		 */
+		if (sx126x_set_rx(dev, 0) < 0) {
+			LOG_ERR("Failed to re-arm async RX after RX_DONE");
+			atomic_set(&data->state, SX126X_STATE_IDLE);
+			sx126x_set_rf_path(dev, false, false);
+		}
 	} else {
 		/* Sync mode */
 		atomic_set(&data->state, SX126X_STATE_IDLE);
@@ -477,21 +491,57 @@ static void sx126x_handle_irq_rx_done(const struct device *dev, uint16_t irq_sta
 static void sx126x_handle_irq_timeout(const struct device *dev)
 {
 	struct sx126x_data *data = dev->data;
+	int state = atomic_get(&data->state);
 
 	LOG_DBG("Timeout");
-	atomic_set(&data->state, SX126X_STATE_IDLE);
-	sx126x_set_rf_path(dev, false, false);
 
-	if (data->tx_async_signal != NULL) {
+	/*
+	 * Always treat timeout in TX state as TX timeout, even if an RX callback
+	 * is registered from a previous async FSK receive session.
+	 */
+	if (state == SX126X_STATE_TX || data->tx_async_signal != NULL) {
 		struct sx126x_tx_result result = { .status = -ETIMEDOUT };
 
-		k_poll_signal_raise(data->tx_async_signal, -ETIMEDOUT);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_rf_path(dev, false, false);
+		if (data->tx_async_signal != NULL) {
+			k_poll_signal_raise(data->tx_async_signal, -ETIMEDOUT);
+		}
 		data->tx_async_signal = NULL;
 		k_msgq_put(&data->tx_msgq, &result, K_NO_WAIT);
+	} else if (state == SX126X_STATE_RX &&
+		   data->rx_cb != NULL &&
+		   data->current_modulation == SX126X_MODULATION_FSK) {
+		/*
+		 * Async RX should not timeout in continuous mode, but if it does,
+		 * recover by forcing continuous RX again instead of dropping to IDLE.
+		 */
+		int ret;
+
+		ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		if (ret < 0) {
+			LOG_ERR("Async RX timeout recovery standby failed: %d", ret);
+			atomic_set(&data->state, SX126X_STATE_IDLE);
+			sx126x_set_rf_path(dev, false, false);
+			return;
+		}
+
+		sx126x_set_rf_path(dev, true, false);
+		ret = sx126x_set_rx(dev, 0);
+		if (ret < 0) {
+			LOG_ERR("Async RX timeout recovery SetRx failed: %d", ret);
+			atomic_set(&data->state, SX126X_STATE_IDLE);
+			sx126x_set_rf_path(dev, false, false);
+			return;
+		}
+
+		atomic_set(&data->state, SX126X_STATE_RX);
 	} else if (data->rx_cb == NULL) {
 		/* Sync RX timeout */
 		struct sx126x_rx_result result = { .status = -EAGAIN };
 
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_rf_path(dev, false, false);
 		k_msgq_put(&data->rx_msgq, &result, K_NO_WAIT);
 	}
 }
@@ -522,7 +572,12 @@ static void sx126x_irq_work_handler(struct k_work *work)
 		sx126x_handle_irq_rx_done(dev, irq_status);
 	}
 
-	if (irq_status & SX126X_IRQ_RX_TX_TIMEOUT) {
+	/*
+	 * If RX_DONE and TIMEOUT are latched together, RX_DONE wins.
+	 * Handling timeout in the same cycle can incorrectly tear RX down.
+	 */
+	if ((irq_status & SX126X_IRQ_RX_TX_TIMEOUT) &&
+	    !(irq_status & SX126X_IRQ_RX_DONE)) {
 		sx126x_handle_irq_timeout(dev);
 	}
 
@@ -773,13 +828,21 @@ static int sx126x_lora_recv_async(const struct device *dev,
 	k_mutex_lock(&data->lock, K_FOREVER);
 
 	if (cb == NULL) {
+		/* Do not let LoRa stop commands tear down active FSK async RX. */
+		if (data->current_modulation != SX126X_MODULATION_LORA) {
+			k_mutex_unlock(&data->lock);
+			return 0;
+		}
+
 		/* Stop async reception */
 		data->rx_cb = NULL;
 		data->rx_cb_user_data = NULL;
-		if (atomic_cas(&data->state, SX126X_STATE_RX, SX126X_STATE_IDLE)) {
-			sx126x_set_standby(dev, SX126X_STANDBY_RC);
-			sx126x_set_rf_path(dev, false, false);
-		}
+
+		/* Force RX stop even if state tracking is out of sync. */
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_rf_path(dev, false, false);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+
 		k_mutex_unlock(&data->lock);
 		return 0;
 	}
@@ -1102,6 +1165,10 @@ int sx126x_fsk_set_packet_params(const struct device *dev,
 				 bool crc_on, bool whitening)
 {
 	struct sx126x_data *data = dev->data;
+	uint16_t preamble_bits;
+	uint8_t sync_bits;
+	uint8_t max_det_bits;
+	uint8_t preamble_det;
 	int ret;
 
 	k_mutex_lock(&data->lock, K_FOREVER);
@@ -1113,10 +1180,19 @@ int sx126x_fsk_set_packet_params(const struct device *dev,
 		}
 	}
 
+	preamble_bits = preamble_len * 8;
+	sync_bits = sync_word_len * 8;
+	max_det_bits = MIN(sync_bits, (uint8_t)MIN(preamble_bits, 255));
+	preamble_det = (max_det_bits >= 32) ? SX126X_FSK_PREAMBLE_DETECT_32_BITS :
+		       (max_det_bits >= 24) ? SX126X_FSK_PREAMBLE_DETECT_24_BITS :
+		       (max_det_bits >= 16) ? SX126X_FSK_PREAMBLE_DETECT_16_BITS :
+		       (max_det_bits > 0)   ? SX126X_FSK_PREAMBLE_DETECT_8_BITS :
+					      SX126X_FSK_PREAMBLE_DETECT_OFF;
+
 	ret = sx126x_set_fsk_packet_params(dev,
-					   preamble_len * 8,
-					   SX126X_FSK_PREAMBLE_DETECT_16_BITS,
-					   sync_word_len * 8,
+					   preamble_bits,
+					   preamble_det,
+					   sync_bits,
 					   SX126X_FSK_ADDR_FILT_OFF,
 					   fixed_len ? SX126X_FSK_PACKET_FIXED_LENGTH :
 						       SX126X_FSK_PACKET_VARIABLE_LENGTH,
@@ -1129,7 +1205,7 @@ int sx126x_fsk_set_packet_params(const struct device *dev,
 	}
 
 	data->fsk_config.preamble_len = preamble_len;
-	data->fsk_config.preamble_detect = SX126X_FSK_PREAMBLE_DETECT_16_BITS;
+	data->fsk_config.preamble_detect = preamble_det;
 	data->fsk_config.sync_word_len = sync_word_len;
 	data->fsk_config.addr_comp = SX126X_FSK_ADDR_FILT_OFF;
 	data->fsk_config.packet_type = fixed_len ? SX126X_FSK_PACKET_FIXED_LENGTH :
@@ -1225,6 +1301,14 @@ int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_l
 		goto out_error;
 	}
 
+	/* Ensure TX_DONE is routed to DIO1 even after async FSK RX remaps IRQs. */
+	uint16_t tx_irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_TX_TIMEOUT;
+	ret = sx126x_set_dio_irq_params(dev, tx_irq_mask, tx_irq_mask, 0, 0);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed IRQ map: %d", ret);
+		goto out_error;
+	}
+
 	ret = sx126x_set_fsk_packet_params(dev,
 		data->fsk_config.preamble_len * 8,
 		data->fsk_config.preamble_detect,
@@ -1290,6 +1374,64 @@ int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
 	data->rx_cb = NULL;
 	k_msgq_purge(&data->rx_msgq);
 
+	/* Ensure we're in FSK mode with correct settings */
+	ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set standby: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_GFSK);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set packet type: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_modulation_params(dev,
+		data->fsk_config.bitrate,
+		data->fsk_config.fdev,
+		data->fsk_config.shaping,
+		data->fsk_config.bandwidth);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set modulation params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_rf_frequency(dev, data->fsk_config.frequency);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set frequency: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_configure_pa_and_tx_params(dev,
+		data->fsk_config.tx_power,
+		data->fsk_config.frequency,
+		SX126X_RAMP_200_US);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set PA params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_packet_params(dev,
+		data->fsk_config.preamble_len * 8,
+		data->fsk_config.preamble_detect,
+		data->fsk_config.sync_word_len * 8,
+		data->fsk_config.addr_comp,
+		data->fsk_config.packet_type,
+		data->fsk_config.payload_len,
+		data->fsk_config.crc_type,
+		data->fsk_config.whitening);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to set packet params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_clear_irq_status(dev, SX126X_IRQ_ALL);
+	if (ret < 0) {
+		LOG_ERR("FSK RX: Failed to clear IRQs: %d", ret);
+		goto out_error;
+	}
+
 	sx126x_set_rf_path(dev, true, false);
 
 	timeout_ms = K_TIMEOUT_EQ(timeout, K_FOREVER)
@@ -1327,6 +1469,127 @@ int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
 	}
 
 	return result.status;
+
+out_error:
+	sx126x_set_rf_path(dev, false, false);
+	k_mutex_unlock(&data->lock);
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	return ret;
+}
+
+int sx126x_fsk_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (cb == NULL) {
+		/* Stop async reception */
+		data->rx_cb = NULL;
+		data->rx_cb_user_data = NULL;
+
+		/* Force RX stop even if state tracking is out of sync. */
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_rf_path(dev, false, false);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+
+		k_mutex_unlock(&data->lock);
+		return 0;
+	}
+
+	if (!data->config_valid || data->current_modulation != SX126X_MODULATION_FSK) {
+		LOG_ERR("FSK not configured");
+		k_mutex_unlock(&data->lock);
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+		LOG_ERR("FSK RX async: Busy");
+		k_mutex_unlock(&data->lock);
+		return -EBUSY;
+	}
+
+	data->rx_cb = cb;
+	data->rx_cb_user_data = user_data;
+
+	/* Ensure FSK mode */
+	ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed standby: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_GFSK);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed packet type: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_modulation_params(dev,
+		data->fsk_config.bitrate,
+		data->fsk_config.fdev,
+		data->fsk_config.shaping,
+		data->fsk_config.bandwidth);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed modulation: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_rf_frequency(dev, data->fsk_config.frequency);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed frequency: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_packet_params(dev,
+		data->fsk_config.preamble_len * 8,
+		data->fsk_config.preamble_detect,
+		data->fsk_config.sync_word_len * 8,
+		data->fsk_config.addr_comp,
+		data->fsk_config.packet_type,
+		SX126X_MAX_PAYLOAD_LEN,
+		data->fsk_config.crc_type,
+		data->fsk_config.whitening);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed packet params: %d", ret);
+		goto out_error;
+	}
+
+	/* RadioLib-style RX IRQ mapping for continuous async GFSK receive. */
+	uint16_t irq_mask = SX126X_IRQ_RX_DONE | SX126X_IRQ_CRC_ERR |
+			    SX126X_IRQ_SYNC_WORD_VALID;
+	ret = sx126x_set_dio_irq_params(dev, irq_mask, irq_mask, 0, 0);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed IRQ map: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_clear_irq_status(dev, SX126X_IRQ_ALL);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed clear IRQ: %d", ret);
+		goto out_error;
+	}
+
+	sx126x_set_rf_path(dev, true, false);
+
+	/* Start continuous RX */
+	ret = sx126x_set_rx(dev, 0);
+	if (ret < 0) {
+		LOG_ERR("FSK RX async: Failed set RX: %d", ret);
+		sx126x_set_rf_path(dev, false, false);
+		goto out_error;
+	}
+
+	LOG_DBG("FSK RX async started");
+	k_mutex_unlock(&data->lock);
+	return 0;
+
+out_error:
+	data->rx_cb = NULL;
+	k_mutex_unlock(&data->lock);
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	return ret;
 }
 
 int sx126x_set_lora_mode(const struct device *dev)

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -630,7 +630,16 @@ static int sx126x_lora_config(const struct device *dev,
 	}
 
 	/* Set sync word */
-	ret = sx126x_set_sync_word(dev, config->public_network);
+	if (data->lora_sync_word != 0) {
+		uint8_t buf[2] = {
+			(data->lora_sync_word & 0xF0U) | 0x04U,
+			((data->lora_sync_word & 0x0FU) << 4) | 0x04U,
+		};
+		ret = sx126x_hal_write_regs(dev, SX126X_REG_LORA_SYNC_WORD_MSB,
+					    buf, 2);
+	} else {
+		ret = sx126x_set_sync_word(dev, config->public_network);
+	}
 	if (ret < 0) {
 		goto out;
 	}
@@ -1233,12 +1242,12 @@ out:
 	return ret;
 }
 
-int sx126x_set_lora_sync_word(const struct device *dev, uint16_t sync_word)
+int sx126x_set_lora_sync_word(const struct device *dev, uint8_t sync_word)
 {
-	uint8_t buf[2];
+	struct sx126x_data *data = dev->data;
 
-	sys_put_be16(sync_word, buf);
-	return sx126x_hal_write_regs(dev, SX126X_REG_LORA_SYNC_WORD_MSB, buf, 2);
+	data->lora_sync_word = sync_word;
+	return 0;
 }
 
 int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_len)

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1109,7 +1109,7 @@ int sx126x_fsk_config(const struct device *dev,
 		goto out;
 	}
 
-	ret = sx126x_configure_pa_and_tx_params(dev, tx_power, frequency,
+	ret = sx126x_hal_configure_tx_params(dev, tx_power, frequency,
 						SX126X_RAMP_40_US);
 	if (ret < 0) {
 		goto out;
@@ -1288,7 +1288,7 @@ int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_l
 		goto out_error;
 	}
 
-	ret = sx126x_configure_pa_and_tx_params(dev,
+	ret = sx126x_hal_configure_tx_params(dev,
 		data->fsk_config.tx_power,
 		data->fsk_config.frequency,
 		SX126X_RAMP_200_US);
@@ -1406,7 +1406,7 @@ int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
 		goto out_error;
 	}
 
-	ret = sx126x_configure_pa_and_tx_params(dev,
+	ret = sx126x_hal_configure_tx_params(dev,
 		data->fsk_config.tx_power,
 		data->fsk_config.frequency,
 		SX126X_RAMP_200_US);

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -875,6 +875,483 @@ static uint32_t sx126x_lora_airtime(const struct device *dev, uint32_t data_len)
 	return (t_preamble_us + t_payload_us + 500) / 1000;
 }
 
+/* ============================================ */
+/* FSK/GFSK Functions                           */
+/* ============================================ */
+
+static int sx126x_set_fsk_modulation_params(const struct device *dev,
+					    uint32_t bitrate, uint32_t fdev,
+					    uint8_t shaping, uint8_t bandwidth)
+{
+	uint8_t buf[8];
+	uint32_t br_reg = SX126X_FSK_BITRATE_TO_REG(bitrate);
+	uint32_t fdev_reg = SX126X_FSK_FDEV_TO_REG(fdev);
+
+	/* Bitrate: 3 bytes MSB first */
+	buf[0] = (br_reg >> 16) & 0xFF;
+	buf[1] = (br_reg >> 8) & 0xFF;
+	buf[2] = br_reg & 0xFF;
+	/* Pulse shaping */
+	buf[3] = shaping;
+	/* RX Bandwidth */
+	buf[4] = bandwidth;
+	/* Frequency deviation: 3 bytes MSB first */
+	buf[5] = (fdev_reg >> 16) & 0xFF;
+	buf[6] = (fdev_reg >> 8) & 0xFF;
+	buf[7] = fdev_reg & 0xFF;
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_MODULATION_PARAMS, buf, 8);
+}
+
+static int sx126x_set_fsk_packet_params(const struct device *dev,
+					uint16_t preamble_len,
+					uint8_t preamble_detect,
+					uint8_t sync_word_len,
+					uint8_t addr_comp,
+					uint8_t packet_type,
+					uint8_t payload_len,
+					uint8_t crc_type,
+					uint8_t whitening)
+{
+	uint8_t buf[9];
+
+	sys_put_be16(preamble_len, &buf[0]);
+	buf[2] = preamble_detect;
+	buf[3] = sync_word_len;
+	buf[4] = addr_comp;
+	buf[5] = packet_type;
+	buf[6] = payload_len;
+	buf[7] = crc_type;
+	buf[8] = whitening;
+
+	return sx126x_hal_write_cmd(dev, SX126X_CMD_SET_PACKET_PARAMS, buf, 9);
+}
+
+static int sx126x_set_fsk_sync_word(const struct device *dev,
+				    const uint8_t *sync_word, uint8_t len)
+{
+	if (len > 8) {
+		len = 8;
+	}
+	return sx126x_hal_write_regs(dev, SX126X_REG_FSK_SYNC_WORD_0, sync_word, len);
+}
+
+static int sx126x_set_fsk_whitening_seed(const struct device *dev, uint16_t seed)
+{
+	uint8_t buf[2];
+
+	buf[0] = (seed >> 8) & 0x01;
+	buf[1] = seed & 0xFF;
+
+	return sx126x_hal_write_regs(dev, SX126X_REG_FSK_WHITENING_MSB, buf, 2);
+}
+
+static int sx126x_set_fsk_crc_params(const struct device *dev,
+				     uint16_t crc_init, uint16_t crc_poly)
+{
+	uint8_t buf[2];
+	int ret;
+
+	sys_put_be16(crc_init, buf);
+	ret = sx126x_hal_write_regs(dev, SX126X_REG_FSK_CRC_INIT_MSB, buf, 2);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_put_be16(crc_poly, buf);
+	return sx126x_hal_write_regs(dev, SX126X_REG_FSK_CRC_POLY_MSB, buf, 2);
+}
+
+int sx126x_fsk_config(const struct device *dev,
+		      uint32_t frequency, uint32_t bitrate,
+		      uint32_t fdev, uint8_t bandwidth, int8_t tx_power)
+{
+	struct sx126x_data *data = dev->data;
+	const struct sx126x_hal_config *config = dev->config;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	if (ret < 0) {
+		LOG_ERR("Set FSK standby failed: %d", ret);
+		goto out;
+	}
+
+	if (config->dio3_tcxo_enable) {
+		ret = sx126x_set_dio3_as_tcxo_ctrl(dev, config->dio3_tcxo_voltage,
+						   config->tcxo_startup_delay_ms);
+		if (ret < 0) {
+			LOG_ERR("Set TCXO failed: %d", ret);
+			goto out;
+		}
+
+		ret = sx126x_calibrate(dev, SX126X_CALIBRATE_ALL);
+		if (ret < 0) {
+			LOG_ERR("Calibration failed: %d", ret);
+			goto out;
+		}
+	}
+
+	if (config->dio2_tx_enable) {
+		ret = sx126x_set_dio2_as_rf_switch(dev, true);
+		if (ret < 0) {
+			LOG_ERR("Set DIO2 RF switch failed: %d", ret);
+			goto out;
+		}
+	}
+
+	ret = sx126x_set_regulator_mode(dev, config->regulator_ldo ?
+					SX126X_REGULATOR_LDO : SX126X_REGULATOR_DCDC);
+	if (ret < 0) {
+		LOG_ERR("Set regulator failed: %d", ret);
+		goto out;
+	}
+
+	ret = sx126x_set_buffer_base_address(dev, 0x00, 0x00);
+	if (ret < 0) {
+		LOG_ERR("Set FSK buffer base failed: %d", ret);
+		goto out;
+	}
+
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_GFSK);
+	if (ret < 0) {
+		LOG_ERR("Set FSK packet type failed: %d", ret);
+		goto out;
+	}
+
+	ret = sx126x_hal_write_cmd(dev, SX126X_CMD_SET_RX_TX_FALLBACK_MODE,
+				   &(uint8_t){SX126X_RX_TX_FALLBACK_MODE_STDBY_RC}, 1);
+	if (ret < 0) {
+		LOG_ERR("Set RX/TX fallback mode failed: %d", ret);
+		goto out;
+	}
+
+	uint8_t sync_word[] = {0x12, 0xAD};
+	ret = sx126x_set_fsk_sync_word(dev, sync_word, sizeof(sync_word));
+	if (ret < 0) {
+		LOG_ERR("Set FSK sync word failed: %d", ret);
+		goto out;
+	}
+
+	ret = sx126x_calibrate_image(dev, frequency);
+	if (ret < 0) {
+		goto out;
+	}
+
+	ret = sx126x_set_rf_frequency(dev, frequency);
+	if (ret < 0) {
+		goto out;
+	}
+
+	ret = sx126x_configure_pa_and_tx_params(dev, tx_power, frequency,
+						SX126X_RAMP_40_US);
+	if (ret < 0) {
+		goto out;
+	}
+
+	ret = sx126x_set_fsk_modulation_params(dev, bitrate, fdev,
+					       SX126X_FSK_MOD_SHAPING_OFF,
+					       bandwidth);
+	if (ret < 0) {
+		goto out;
+	}
+
+	ret = sx126x_set_fsk_crc_params(dev, 0x1D0F, 0x1021);
+	if (ret < 0) {
+		LOG_ERR("Set FSK CRC params failed: %d", ret);
+		goto out;
+	}
+
+	uint16_t irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_DONE |
+			    SX126X_IRQ_RX_TX_TIMEOUT | SX126X_IRQ_CRC_ERR |
+			    SX126X_IRQ_SYNC_WORD_VALID;
+	ret = sx126x_set_dio_irq_params(dev, irq_mask, irq_mask, 0, 0);
+	if (ret < 0) {
+		goto out;
+	}
+
+	ret = sx126x_clear_irq_status(dev, SX126X_IRQ_ALL);
+	if (ret < 0) {
+		LOG_ERR("Clear IRQ failed: %d", ret);
+		goto out;
+	}
+
+	data->config_valid = true;
+	data->current_modulation = SX126X_MODULATION_FSK;
+
+	data->fsk_config.bitrate = bitrate;
+	data->fsk_config.fdev = fdev;
+	data->fsk_config.bandwidth = bandwidth;
+	data->fsk_config.shaping = SX126X_FSK_MOD_SHAPING_OFF;
+	data->fsk_config.frequency = frequency;
+	data->fsk_config.tx_power = tx_power;
+
+	LOG_INF("FSK Config: freq=%u, bitrate=%u, fdev=%u, bw=0x%02x, power=%d",
+		frequency, bitrate, fdev, bandwidth, tx_power);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+int sx126x_fsk_set_packet_params(const struct device *dev,
+				 uint16_t preamble_len,
+				 const uint8_t *sync_word, uint8_t sync_word_len,
+				 bool fixed_len, uint8_t payload_len,
+				 bool crc_on, bool whitening)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (sync_word != NULL && sync_word_len > 0) {
+		ret = sx126x_set_fsk_sync_word(dev, sync_word, sync_word_len);
+		if (ret < 0) {
+			goto out;
+		}
+	}
+
+	ret = sx126x_set_fsk_packet_params(dev,
+					   preamble_len * 8,
+					   SX126X_FSK_PREAMBLE_DETECT_16_BITS,
+					   sync_word_len * 8,
+					   SX126X_FSK_ADDR_FILT_OFF,
+					   fixed_len ? SX126X_FSK_PACKET_FIXED_LENGTH :
+						       SX126X_FSK_PACKET_VARIABLE_LENGTH,
+					   payload_len,
+					   crc_on ? SX126X_FSK_CRC_2_BYTE : SX126X_FSK_CRC_OFF,
+					   whitening ? SX126X_FSK_DC_FREE_WHITENING :
+						       SX126X_FSK_DC_FREE_OFF);
+	if (ret < 0) {
+		goto out;
+	}
+
+	data->fsk_config.preamble_len = preamble_len;
+	data->fsk_config.preamble_detect = SX126X_FSK_PREAMBLE_DETECT_16_BITS;
+	data->fsk_config.sync_word_len = sync_word_len;
+	data->fsk_config.addr_comp = SX126X_FSK_ADDR_FILT_OFF;
+	data->fsk_config.packet_type = fixed_len ? SX126X_FSK_PACKET_FIXED_LENGTH :
+						   SX126X_FSK_PACKET_VARIABLE_LENGTH;
+	data->fsk_config.payload_len = payload_len;
+	data->fsk_config.crc_type = crc_on ? SX126X_FSK_CRC_2_BYTE : SX126X_FSK_CRC_OFF;
+	data->fsk_config.whitening = whitening ? SX126X_FSK_DC_FREE_WHITENING :
+						 SX126X_FSK_DC_FREE_OFF;
+
+	if (whitening) {
+		ret = sx126x_set_fsk_whitening_seed(dev, 0x01FF);
+		if (ret < 0) {
+			goto out;
+		}
+	}
+
+	if (crc_on) {
+		ret = sx126x_set_fsk_crc_params(dev, 0xFFFF, 0x1021);
+	}
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+int sx126x_set_lora_sync_word(const struct device *dev, uint16_t sync_word)
+{
+	uint8_t buf[2];
+
+	sys_put_be16(sync_word, buf);
+	return sx126x_hal_write_regs(dev, SX126X_REG_LORA_SYNC_WORD_MSB, buf, 2);
+}
+
+int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_len)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_tx_result result;
+	int ret;
+
+	if (data_len > SX126X_MAX_PAYLOAD_LEN) {
+		LOG_ERR("FSK payload too long: %u", data_len);
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_TX)) {
+		LOG_ERR("FSK TX: Busy");
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	k_msgq_purge(&data->tx_msgq);
+
+	ret = sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to set standby: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_GFSK);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to set packet type: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_modulation_params(dev,
+		data->fsk_config.bitrate,
+		data->fsk_config.fdev,
+		data->fsk_config.shaping,
+		data->fsk_config.bandwidth);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to restore modulation params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_rf_frequency(dev, data->fsk_config.frequency);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to set frequency: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_configure_pa_and_tx_params(dev,
+		data->fsk_config.tx_power,
+		data->fsk_config.frequency,
+		SX126X_RAMP_200_US);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to restore PA/TX params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_clear_irq_status(dev, SX126X_IRQ_ALL);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to clear IRQs: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_set_fsk_packet_params(dev,
+		data->fsk_config.preamble_len * 8,
+		data->fsk_config.preamble_detect,
+		data->fsk_config.sync_word_len * 8,
+		data->fsk_config.addr_comp,
+		data->fsk_config.packet_type,
+		data_len,
+		data->fsk_config.crc_type,
+		data->fsk_config.whitening);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to set packet params: %d", ret);
+		goto out_error;
+	}
+
+	ret = sx126x_hal_write_buffer(dev, 0x00, data_buf, data_len);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: Failed to write buffer: %d", ret);
+		goto out_error;
+	}
+
+	sx126x_set_rf_path(dev, true, true);
+
+	LOG_DBG("FSK TX: Starting TX of %u bytes", data_len);
+
+	ret = sx126x_set_tx(dev, 5000);
+	if (ret < 0) {
+		LOG_ERR("FSK TX: SetTx failed: %d", ret);
+		goto out_error;
+	}
+
+	k_mutex_unlock(&data->lock);
+
+	ret = k_msgq_get(&data->tx_msgq, &result, K_MSEC(10000));
+	if (ret < 0) {
+		LOG_ERR("FSK TX timeout");
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_rf_path(dev, false, false);
+		return -ETIMEDOUT;
+	}
+
+	return result.status;
+
+out_error:
+	sx126x_set_rf_path(dev, false, false);
+	k_mutex_unlock(&data->lock);
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	return ret;
+}
+
+int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
+		    uint8_t size, k_timeout_t timeout, int16_t *rssi)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_rx_result result;
+	uint32_t timeout_ms;
+	int ret;
+
+	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	data->rx_cb = NULL;
+	k_msgq_purge(&data->rx_msgq);
+
+	sx126x_set_rf_path(dev, true, false);
+
+	timeout_ms = K_TIMEOUT_EQ(timeout, K_FOREVER)
+		     ? 0 : k_ticks_to_ms_ceil32(timeout.ticks);
+	ret = sx126x_set_rx(dev, timeout_ms);
+	if (ret < 0) {
+		sx126x_set_rf_path(dev, false, false);
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		return ret;
+	}
+
+	k_mutex_unlock(&data->lock);
+
+	ret = k_msgq_get(&data->rx_msgq, &result, timeout);
+	if (ret < 0) {
+		LOG_DBG("FSK RX: timeout");
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_rf_path(dev, false, false);
+		return -EAGAIN;
+	}
+
+	atomic_set(&data->state, SX126X_STATE_IDLE);
+	sx126x_set_rf_path(dev, false, false);
+
+	if (result.status > 0) {
+		int copy_len = MIN(result.status, size);
+
+		memcpy(data_buf, data->rx_buf, copy_len);
+		if (rssi != NULL) {
+			*rssi = result.rssi;
+		}
+		return copy_len;
+	}
+
+	return result.status;
+}
+
+int sx126x_set_lora_mode(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_set_packet_type(dev, SX126X_PACKET_TYPE_LORA);
+	if (ret < 0) {
+		LOG_ERR("Set LoRa packet type failed: %d", ret);
+	}
+
+	uint16_t irq_mask = SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_DONE |
+			    SX126X_IRQ_RX_TX_TIMEOUT | SX126X_IRQ_CRC_ERR;
+	sx126x_set_dio_irq_params(dev, irq_mask, irq_mask, 0, 0);
+
+	data->config_valid = false;
+	data->current_modulation = SX126X_MODULATION_LORA;
+
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
 static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 			       int8_t tx_power, uint16_t duration)
 {

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -84,6 +84,9 @@ struct sx126x_data {
 
 	/* Current modulation type */
 	uint8_t current_modulation;
+
+	/* LoRa sync word (1-byte spec value; 0 = use public_network from config) */
+	uint8_t lora_sync_word;
 };
 
 /* ============================================ */
@@ -177,6 +180,6 @@ int sx126x_set_lora_mode(const struct device *dev);
  * @param sync_word 16-bit Sync Word (e.g. 0x1424 for private, 0x3444 for public)
  * @return 0 on success, negative error code otherwise
  */
-int sx126x_set_lora_sync_word(const struct device *dev, uint16_t sync_word);
+int sx126x_set_lora_sync_word(const struct device *dev, uint8_t sync_word);
 
 #endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_INTERNAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -97,13 +97,15 @@ struct sx126x_data {
  * @param frequency RF frequency in Hz
  * @param bitrate Bit rate in bps (e.g., 50000 for 50 kbps)
  * @param fdev Frequency deviation in Hz (e.g., 25000 for 25 kHz)
+ * @param shaping Gaussian shaping (SX126X_FSK_MOD_SHAPING_*)
  * @param bandwidth RX bandwidth (use SX126X_FSK_BW_* constants)
  * @param tx_power TX power in dBm
  * @return 0 on success, negative error code otherwise
  */
 int sx126x_fsk_config(const struct device *dev,
 		      uint32_t frequency, uint32_t bitrate,
-		      uint32_t fdev, uint8_t bandwidth, int8_t tx_power);
+		      uint32_t fdev, uint8_t shaping,
+		      uint8_t bandwidth, int8_t tx_power);
 
 /**
  * @brief Set FSK packet parameters

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -148,6 +148,19 @@ int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
 		    uint8_t size, k_timeout_t timeout, int16_t *rssi);
 
 /**
+ * @brief Receive data asynchronously using FSK modulation
+ *
+ * Reception is cancelled by calling this function again with @p cb = NULL.
+ *
+ * @param dev Device instance
+ * @param cb Callback to run on receiving data. If NULL, any pending
+ *	     asynchronous receptions will be cancelled.
+ * @param user_data User data passed to callback
+ * @return 0 when reception successfully setup, negative on error
+ */
+int sx126x_fsk_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data);
+
+/**
  * @brief Switch back to LoRa modulation
  *
  * @param dev Device instance

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -17,6 +17,9 @@
 #define SX126X_STATE_TX   1
 #define SX126X_STATE_RX   2
 
+#define SX126X_MODULATION_LORA  0
+#define SX126X_MODULATION_FSK   1
+
 struct sx126x_tx_result {
 	int status;
 };
@@ -47,6 +50,24 @@ struct sx126x_data {
 	struct k_msgq rx_msgq;
 	struct sx126x_rx_result rx_result;
 
+	/* FSK/GFSK Configuration storage */
+	struct {
+		uint32_t bitrate;
+		uint32_t fdev;
+		uint32_t frequency;
+		uint8_t bandwidth;
+		uint8_t shaping;
+		uint16_t preamble_len;
+		uint8_t preamble_detect;
+		uint8_t sync_word_len;
+		uint8_t addr_comp;
+		uint8_t packet_type;
+		uint8_t payload_len;
+		uint8_t crc_type;
+		uint8_t whitening;
+		int8_t tx_power;
+	} fsk_config;
+
 	/* RX data buffer (shared between IRQ handler and recv) */
 	uint8_t rx_buf[SX126X_MAX_PAYLOAD_LEN];
 
@@ -60,6 +81,87 @@ struct sx126x_data {
 	/* Deferred work for interrupt handling */
 	struct k_work irq_work;
 	const struct device *dev;
+
+	/* Current modulation type */
+	uint8_t current_modulation;
 };
+
+/* ============================================ */
+/* FSK/GFSK Public API                          */
+/* ============================================ */
+
+/**
+ * @brief Configure SX126x for FSK/GFSK modulation
+ *
+ * @param dev Device instance
+ * @param frequency RF frequency in Hz
+ * @param bitrate Bit rate in bps (e.g., 50000 for 50 kbps)
+ * @param fdev Frequency deviation in Hz (e.g., 25000 for 25 kHz)
+ * @param bandwidth RX bandwidth (use SX126X_FSK_BW_* constants)
+ * @param tx_power TX power in dBm
+ * @return 0 on success, negative error code otherwise
+ */
+int sx126x_fsk_config(const struct device *dev,
+		      uint32_t frequency, uint32_t bitrate,
+		      uint32_t fdev, uint8_t bandwidth, int8_t tx_power);
+
+/**
+ * @brief Set FSK packet parameters
+ *
+ * @param dev Device instance
+ * @param preamble_len Preamble length in bytes
+ * @param sync_word Sync word bytes (up to 8 bytes)
+ * @param sync_word_len Sync word length in bytes
+ * @param fixed_len True for fixed length packets, false for variable
+ * @param payload_len Payload length (for fixed) or max length (for variable)
+ * @param crc_on Enable CRC
+ * @param whitening Enable whitening (DC-free encoding)
+ * @return 0 on success, negative error code otherwise
+ */
+int sx126x_fsk_set_packet_params(const struct device *dev,
+				 uint16_t preamble_len,
+				 const uint8_t *sync_word, uint8_t sync_word_len,
+				 bool fixed_len, uint8_t payload_len,
+				 bool crc_on, bool whitening);
+
+/**
+ * @brief Send data using FSK modulation
+ *
+ * @param dev Device instance
+ * @param data_buf Data buffer to send
+ * @param data_len Data length in bytes
+ * @return 0 on success, negative error code otherwise
+ */
+int sx126x_fsk_send(const struct device *dev, uint8_t *data_buf, uint32_t data_len);
+
+/**
+ * @brief Receive data using FSK modulation
+ *
+ * @param dev Device instance
+ * @param data_buf Buffer for received data
+ * @param size Buffer size
+ * @param timeout Reception timeout
+ * @param rssi Pointer to store RSSI (can be NULL)
+ * @return Number of bytes received on success, negative error code otherwise
+ */
+int sx126x_fsk_recv(const struct device *dev, uint8_t *data_buf,
+		    uint8_t size, k_timeout_t timeout, int16_t *rssi);
+
+/**
+ * @brief Switch back to LoRa modulation
+ *
+ * @param dev Device instance
+ * @return 0 on success, negative error code otherwise
+ */
+int sx126x_set_lora_mode(const struct device *dev);
+
+/**
+ * @brief Set LoRa Sync Word
+ *
+ * @param dev Device instance
+ * @param sync_word 16-bit Sync Word (e.g. 0x1424 for private, 0x3444 for public)
+ * @return 0 on success, negative error code otherwise
+ */
+int sx126x_set_lora_sync_word(const struct device *dev, uint16_t sync_word);
 
 #endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_INTERNAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x_regs.h
+++ b/drivers/lora/native/sx126x/sx126x_regs.h
@@ -102,6 +102,110 @@
 #define SX126X_CALIBRATE_IMAGE              BIT(6)
 #define SX126X_CALIBRATE_ALL                0x7F
 
+/* ============================================ */
+/* FSK/GFSK Modulation Parameters               */
+/* ============================================ */
+
+/* FSK Modulation Shaping (for SET_MODULATION_PARAMS) */
+#define SX126X_FSK_MOD_SHAPING_OFF          0x00
+#define SX126X_FSK_MOD_SHAPING_G_BT_03      0x08  /* Gaussian BT=0.3 */
+#define SX126X_FSK_MOD_SHAPING_G_BT_05      0x09  /* Gaussian BT=0.5 */
+#define SX126X_FSK_MOD_SHAPING_G_BT_07      0x0A  /* Gaussian BT=0.7 */
+#define SX126X_FSK_MOD_SHAPING_G_BT_1       0x0B  /* Gaussian BT=1.0 */
+
+/* FSK RX Bandwidth (for SET_MODULATION_PARAMS) */
+#define SX126X_FSK_BW_4800                  0x1F
+#define SX126X_FSK_BW_5800                  0x17
+#define SX126X_FSK_BW_7300                  0x0F
+#define SX126X_FSK_BW_9700                  0x1E
+#define SX126X_FSK_BW_11700                 0x16
+#define SX126X_FSK_BW_14600                 0x0E
+#define SX126X_FSK_BW_19500                 0x1D
+#define SX126X_FSK_BW_23400                 0x15
+#define SX126X_FSK_BW_29300                 0x0D
+#define SX126X_FSK_BW_39000                 0x1C
+#define SX126X_FSK_BW_46900                 0x14
+#define SX126X_FSK_BW_58600                 0x0C
+#define SX126X_FSK_BW_78200                 0x1B
+#define SX126X_FSK_BW_93800                 0x13
+#define SX126X_FSK_BW_117300                0x0B
+#define SX126X_FSK_BW_156200                0x1A
+#define SX126X_FSK_BW_187200                0x12
+#define SX126X_FSK_BW_234300                0x0A
+#define SX126X_FSK_BW_312000                0x19
+#define SX126X_FSK_BW_373600                0x11
+#define SX126X_FSK_BW_467000                0x09
+
+/* FSK Preamble Detector Length (for SET_PACKET_PARAMS) */
+#define SX126X_FSK_PREAMBLE_DETECT_OFF      0x00
+#define SX126X_FSK_PREAMBLE_DETECT_8_BITS   0x04
+#define SX126X_FSK_PREAMBLE_DETECT_16_BITS  0x05
+#define SX126X_FSK_PREAMBLE_DETECT_24_BITS  0x06
+#define SX126X_FSK_PREAMBLE_DETECT_32_BITS  0x07
+
+/* FSK Address Filtering (for SET_PACKET_PARAMS) */
+#define SX126X_FSK_ADDR_FILT_OFF            0x00
+#define SX126X_FSK_ADDR_FILT_NODE           0x01
+#define SX126X_FSK_ADDR_FILT_NODE_BROADCAST 0x02
+
+/* FSK Packet Length Mode (for SET_PACKET_PARAMS) */
+#define SX126X_FSK_PACKET_FIXED_LENGTH      0x00
+#define SX126X_FSK_PACKET_VARIABLE_LENGTH   0x01
+
+/* FSK CRC Types (for SET_PACKET_PARAMS) */
+#define SX126X_FSK_CRC_OFF                  0x01
+#define SX126X_FSK_CRC_1_BYTE               0x00
+#define SX126X_FSK_CRC_2_BYTE               0x02
+#define SX126X_FSK_CRC_1_BYTE_INV           0x04
+#define SX126X_FSK_CRC_2_BYTE_INV           0x06
+#define SX126X_FSK_CRC_2_BYTE_IBM           0x0A
+#define SX126X_FSK_CRC_2_BYTE_CCIT          0x0C
+
+/* FSK Whitening (DC-Free) Mode (for SET_PACKET_PARAMS) */
+#define SX126X_FSK_DC_FREE_OFF              0x00
+#define SX126X_FSK_DC_FREE_WHITENING        0x01
+
+/* FSK Sync Word Registers (up to 8 bytes) */
+#define SX126X_REG_FSK_SYNC_WORD_0          0x06C0
+#define SX126X_REG_FSK_SYNC_WORD_1          0x06C1
+#define SX126X_REG_FSK_SYNC_WORD_2          0x06C2
+#define SX126X_REG_FSK_SYNC_WORD_3          0x06C3
+#define SX126X_REG_FSK_SYNC_WORD_4          0x06C4
+#define SX126X_REG_FSK_SYNC_WORD_5          0x06C5
+#define SX126X_REG_FSK_SYNC_WORD_6          0x06C6
+#define SX126X_REG_FSK_SYNC_WORD_7          0x06C7
+
+/* FSK Node and Broadcast Address Registers */
+#define SX126X_REG_FSK_NODE_ADDRESS         0x06CD
+#define SX126X_REG_FSK_BROADCAST_ADDRESS    0x06CE
+
+/* FSK CRC Registers */
+#define SX126X_REG_FSK_CRC_INIT_MSB         0x06BC
+#define SX126X_REG_FSK_CRC_INIT_LSB         0x06BD
+#define SX126X_REG_FSK_CRC_POLY_MSB         0x06BE
+#define SX126X_REG_FSK_CRC_POLY_LSB         0x06BF
+
+/* FSK Whitening Seed Registers */
+#define SX126X_REG_FSK_WHITENING_MSB        0x06B8
+#define SX126X_REG_FSK_WHITENING_LSB        0x06B9
+
+/* Bitrate calculation: bitrate_reg = (32 * XTAL_FREQ) / bitrate */
+#define SX126X_FSK_BITRATE_TO_REG(br) \
+	((uint32_t)(((uint64_t)32 * SX126X_XTAL_FREQ) / (br)))
+
+/* Frequency deviation calculation: fdev_reg = (fdev * 2^25) / XTAL_FREQ */
+#define SX126X_FSK_FDEV_TO_REG(fdev) \
+	((uint32_t)(((uint64_t)(fdev) << 25) / SX126X_XTAL_FREQ))
+
+/* RX/TX Fallback Mode values */
+#define SX126X_RX_TX_FALLBACK_MODE_FS       0x40
+#define SX126X_RX_TX_FALLBACK_MODE_STDBY_XOSC 0x30
+#define SX126X_RX_TX_FALLBACK_MODE_STDBY_RC 0x20
+
+/* ============================================ */
+/* LoRa Modulation Parameters                   */
+/* ============================================ */
+
 /* LoRa Bandwidth values (for SET_MODULATION_PARAMS) */
 #define SX126X_LORA_BW_7_8                  0x00
 #define SX126X_LORA_BW_10_4                 0x08


### PR DESCRIPTION
Since PR #103291 we have a native control over the radio SX126x i wanted to use this radio on its FSK side, 

Add FSK/GFSK modulation support to the native SX126x driver. This extends the existing LoRa-only driver to support FSK modulation for applications that require it like legacy protocols, non-LoRaWAN applications, custom protocols, with that in mind adding a different sync word is important for LoRa in order to be compatible with meshtastic.

  ## FSK Features

  - Configurable bitrate, frequency deviation, and RX bandwidth
  - Gaussian pulse shaping (BT=0.3, 0.5, 0.7, 1.0)
  - Configurable preamble detection (8, 16, 24, 32 bits)
  - CRC support (1-byte, 2-byte, IBM, CCITT)
  - Data whitening support
  - Sync word configuration (up to 8 bytes)

  ## LoRa Enhancements

  - Added `sx126x_set_lora_sync_word()` to set custom sync word (previously only public/private LoRaWAN values were supported via `public_network` config)

  ## Build Tested

  - `nrf52840dk/nrf52840` with `CONFIG_LORA_MODULE_BACKEND_NATIVE=y` (Just building)
  - `RP2040` with `CONFIG_LORA_MODULE_BACKEND_NATIVE=y` (Hardware verification) 