### PR TITLE
boards: arduino: uno_r4: Fix iic1 frequency

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4.dts
+++ b/boards/arduino/uno_r4/arduino_uno_r4.dts
@@ -83,7 +83,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <DT_FREQ_K(400)>;
 	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -113,7 +113,7 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
+	clock-frequency = <DT_FREQ_K(400)>;
 	interrupts = <14 1>, <15 1>, <16 1>, <17 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";


### PR DESCRIPTION
Limit iic1 to the device's max-bitrate-supported value to avoid configuring an unsupported bus speed.