### PR TITLE
drivers: counter: max32: Add counter reset and set_value support

### DIFF
--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -67,6 +67,26 @@ static int api_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
+static int api_set_value(const struct device *dev, uint32_t ticks)
+{
+	const struct max32_tmr_config *cfg = dev->config;
+
+	MXC_TMR_Stop(cfg->regs);
+	MXC_TMR_SetCount(cfg->regs, ticks);
+	MXC_TMR_Start(cfg->regs);
+	return 0;
+}
+
+static int api_reset(const struct device *dev)
+{
+	const struct max32_tmr_config *cfg = dev->config;
+
+	MXC_TMR_Stop(cfg->regs);
+	MXC_TMR_SetCount(cfg->regs, 0);
+	MXC_TMR_Start(cfg->regs);
+	return 0;
+}
+
 static int api_set_top_value(const struct device *dev, const struct counter_top_cfg *counter_cfg)
 {
 	const struct max32_tmr_config *cfg = dev->config;
@@ -289,6 +309,8 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 	.start = api_start,
 	.stop = api_stop,
 	.get_value = api_get_value,
+	.set_value = api_set_value,
+	.reset = api_reset,
 	.set_top_value = api_set_top_value,
 	.get_pending_int = api_get_pending_int,
 	.get_top_value = api_get_top_value,


### PR DESCRIPTION
Allow the ADI MAX32 platform use `counter_reset` and `counter_set_value`
- `reset` clears the counter
- `set_value` sets it to a given value

Fixes: #104212