### PR TITLE
include: dt-bindings: clock: Correct typo in STM32H5 clock dt-bindings

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32h5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h5_clock.h
@@ -96,7 +96,7 @@
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 8, 6, CCIPR3_REG)
 #define SPI4_SEL(val)		STM32_DT_CLOCK_SELECT((val), 11, 9, CCIPR3_REG)
 #define SPI5_SEL(val)		STM32_DT_CLOCK_SELECT((val), 14, 12, CCIPR3_REG)
-#define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 15, CCIPR2_REG)
+#define SPI6_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 15, CCIPR3_REG)
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 26, 24, CCIPR3_REG)
 
 /** CCIPR4 devices */


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#104260

There was a typo in the STM32H5 clock device tree binding, causing SPI6 to behave unexpectedly.