### PR TITLE
doc: drop outdated note about device specific api naming

### DIFF
--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -253,12 +253,6 @@ implementation of both the subsystem API and the specific APIs:
 Applications use the device through both the subsystem and specific
 APIs.
 
-.. note::
-   Public API for device-specific extensions should be prefixed with the
-   compatible for the device to which it applies.  For example, if
-   adding special functions to support the Maxim DS3231 the identifier
-   fragment ``specific`` in the examples above would be ``maxim_ds3231``.
-
 Single Driver, Multiple Instances
 *********************************
 


### PR DESCRIPTION
Drop a note about prefixing device specific api naming with the full normalized compatible for the device. Nothing in tree adopted this and it would be unnecessarily verbose, the standard "keep the coding style coherent" works just fine for this.