### PR TITLE
boards: pcbcupid: glyph_c6: Adds I2C node

### DIFF
--- a/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
+++ b/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
@@ -21,4 +21,14 @@
 			bias-pull-up;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO4>,
+				 <I2C0_SCL_GPIO5>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
 };

--- a/boards/pcbcupid/glyph_c6/glyph_c6_hpcore.dts
+++ b/boards/pcbcupid/glyph_c6/glyph_c6_hpcore.dts
@@ -56,3 +56,10 @@
 &gpio0 {
 	status = "okay";
 };
+
+&i2c0 {
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/pcbcupid/glyph_c6/glyph_c6_hpcore.yaml
+++ b/boards/pcbcupid/glyph_c6/glyph_c6_hpcore.yaml
@@ -7,4 +7,5 @@ toolchain:
   - zephyr
 supported:
   - gpio
+  - i2c
   - uart


### PR DESCRIPTION
- Adds the i2c0 node in hpcore dts
- Adds the pinmux of the same
- Adds the i2c tag in board yaml for including the board for ci tests