### PR TITLE
drivers: gpio: bflb: fix GPIO output init pin mask and PSRAM GPIOs routing

### DIFF
--- a/drivers/gpio/gpio_bflb_bl60x_70x.c
+++ b/drivers/gpio/gpio_bflb_bl60x_70x.c
@@ -247,12 +247,12 @@ static int gpio_bflb_config(const struct device *dev, gpio_pin_t pin,
 		outputcfg |= BIT(pin);
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
 			tmp = sys_read32(cfg->base_reg + GLB_GPIO_CFGCTL32_OFFSET);
-			tmp = tmp | pin;
+			tmp |= BIT(pin);
 			sys_write32(tmp, cfg->base_reg + GLB_GPIO_CFGCTL32_OFFSET);
 		}
 		if (flags & GPIO_OUTPUT_INIT_LOW) {
 			tmp = sys_read32(cfg->base_reg + GLB_GPIO_CFGCTL32_OFFSET);
-			tmp = tmp & ~pin;
+			tmp &= ~BIT(pin);
 			sys_write32(tmp, cfg->base_reg + GLB_GPIO_CFGCTL32_OFFSET);
 		}
 	} else {

--- a/drivers/gpio/gpio_bflb_bl60x_70x.c
+++ b/drivers/gpio/gpio_bflb_bl60x_70x.c
@@ -309,6 +309,12 @@ int gpio_bflb_init(const struct device *dev)
 {
 	const struct gpio_bflb_config * const cfg = dev->config;
 
+#if defined(CONFIG_SOC_SERIES_BL70X) && !DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(psram))
+	/* Pins 23-28 are output-only (no high-Z). Route them through the PSRAM IO pads. */
+	sys_write32(GLB_CFG_GPIO_USE_PSRAM_IO_MSK,
+		    GLB_BASE + GLB_GPIO_USE_PSRAM__IO_OFFSET);
+#endif
+
 	cfg->irq_config_func(dev);
 
 	return 0;


### PR DESCRIPTION
Use `BIT(pin)` instead of the raw pin number when setting or clearing GPIO output values.

On BL70x, pins 23-28 are output-only and must be routed through the PSRAM IO pads. When PSRAM is not enabled, set `GLB_GPIO_USE_PSRAM_IO` so these pins are usable as regular GPIOs.