### PR TITLE
drivers: entropy: add BFLB SEC engine TRNG driver

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f.dtsi
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f.dtsi
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
@@ -24,4 +24,5 @@ supported:
   - input
   - pwm
   - adc
+  - entropy
 vendor: bflb

--- a/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f.dtsi
+++ b/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f.dtsi
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.yaml
+++ b/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.yaml
@@ -24,4 +24,5 @@ supported:
   - input
   - pwm
   - adc
+  - entropy
 vendor: bflb

--- a/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk.dts
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/boards/doiting/dt_bl10_devkit/dt_bl10_devkit.dts
+++ b/boards/doiting/dt_bl10_devkit/dt_bl10_devkit.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1.dtsi
+++ b/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1.dtsi
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 
@@ -58,4 +59,8 @@
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+&sec_eng_trng {
+	status = "okay";
 };

--- a/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.yaml
+++ b/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.yaml
@@ -20,4 +20,5 @@ supported:
   - i2c
   - spi
   - flash
+  - entropy
 vendor: doiting

--- a/boards/sipeed/maix_m0s_dock/maix_m0s.dtsi
+++ b/boards/sipeed/maix_m0s_dock/maix_m0s.dtsi
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,entropy = &sec_eng_trng;
 	};
 };
 

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -13,6 +13,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE entropy_handlers.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_AMBIQ_PUF_TRNG entropy_ambiq_puf_trng.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_BFLB_SEC_ENG entropy_bflb_sec_eng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BRCM_IPROC_RNG200 entropy_iproc_rng200.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BT_HCI entropy_bt_hci.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_CC13XX_CC26XX_RNG entropy_cc13xx_cc26xx.c)

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -23,6 +23,7 @@ config ENTROPY_INIT_PRIORITY
 # zephyr-keep-sorted-start
 source "drivers/entropy/Kconfig.ambiq"
 source "drivers/entropy/Kconfig.b91"
+source "drivers/entropy/Kconfig.bflb"
 source "drivers/entropy/Kconfig.bt_hci"
 source "drivers/entropy/Kconfig.cc13xx_cc26xx"
 source "drivers/entropy/Kconfig.esp32"

--- a/drivers/entropy/Kconfig.bflb
+++ b/drivers/entropy/Kconfig.bflb
@@ -1,0 +1,12 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config ENTROPY_BFLB_SEC_ENG
+	bool "Bouffalo Lab SEC Engine TRNG driver"
+	default y
+	depends on DT_HAS_BFLB_SEC_ENG_TRNG_ENABLED
+	select ENTROPY_HAS_DRIVER
+	help
+	  Enable the Bouffalo Lab SEC Engine TRNG entropy driver.
+	  Provides hardware true random number generation via the
+	  SEC_ENG TRNG peripheral.

--- a/drivers/entropy/entropy_bflb_sec_eng.c
+++ b/drivers/entropy/entropy_bflb_sec_eng.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bouffalo Lab SEC Engine TRNG entropy driver
+ */
+
+#define DT_DRV_COMPAT bflb_sec_eng_trng
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/entropy.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/logging/log.h>
+
+#include <bflb_soc.h>
+#include <bouffalolab/common/sec_eng_reg.h>
+
+LOG_MODULE_REGISTER(entropy_bflb, CONFIG_ENTROPY_LOG_LEVEL);
+
+/* TRNG produces 32 bytes (256 bits) per read */
+#define TRNG_OUTPUT_BYTES 32
+
+/* Timeout for TRNG busy-wait (matches vendor SDK: 100ms) */
+#define TRNG_TIMEOUT_US 100000
+
+struct entropy_bflb_data {
+	struct k_spinlock lock;
+};
+
+struct entropy_bflb_config {
+	uintptr_t base;
+};
+
+static inline void trng_nop_delay(void)
+{
+	/* 4 NOPs: busy will be set 1T after trigger */
+	__asm__ volatile("nop; nop; nop; nop");
+}
+
+static int trng_wait_not_busy(uint32_t base)
+{
+	uint32_t timeout = TRNG_TIMEOUT_US;
+
+	while (timeout--) {
+		if (!(sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET) &
+		      SEC_ENG_SE_TRNG_0_BUSY)) {
+			return 0;
+		}
+		k_busy_wait(1);
+	}
+
+	return -ETIMEDOUT;
+}
+
+static int trng_read_32bytes(uint32_t base, uint8_t out[TRNG_OUTPUT_BYTES])
+{
+	uint32_t regval;
+	uint32_t val;
+	int ret;
+
+	/* Enable TRNG */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_EN;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	/* Clear interrupt */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_INT_CLR_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	trng_nop_delay();
+
+	/* Wait for any prior operation */
+	ret = trng_wait_not_busy(base);
+	if (ret) {
+		goto out_disable;
+	}
+
+	/* Clear interrupt again */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_INT_CLR_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	/* Trigger TRNG generation */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_TRIG_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	trng_nop_delay();
+
+	/* Wait for generation to complete */
+	ret = trng_wait_not_busy(base);
+	if (ret) {
+		goto out_disable;
+	}
+
+	/* Read 8 x 32-bit output registers */
+	for (int i = 0; i < 8; i++) {
+		val = sys_read32(base + SEC_ENG_SE_TRNG_0_DOUT_0_OFFSET + (i * 4));
+		out[i * 4 + 0] = val & 0xff;
+		out[i * 4 + 1] = (val >> 8) & 0xff;
+		out[i * 4 + 2] = (val >> 16) & 0xff;
+		out[i * 4 + 3] = (val >> 24) & 0xff;
+	}
+
+	/* Clear trigger */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval &= ~SEC_ENG_SE_TRNG_0_TRIG_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	/* Clear output */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_DOUT_CLR_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval &= ~SEC_ENG_SE_TRNG_0_DOUT_CLR_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+out_disable:
+	/* Disable TRNG */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval &= ~SEC_ENG_SE_TRNG_0_EN;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	/* Final interrupt clear */
+	regval = sys_read32(base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_INT_CLR_1T;
+	sys_write32(regval, base + SEC_ENG_SE_TRNG_0_CTRL_0_OFFSET);
+
+	return ret;
+}
+
+static int entropy_bflb_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
+{
+	struct entropy_bflb_data *data = dev->data;
+	const struct entropy_bflb_config *cfg = dev->config;
+	uint8_t tmp[TRNG_OUTPUT_BYTES];
+	uint16_t remaining = length;
+	int ret;
+
+	while (remaining > 0) {
+		k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+		ret = trng_read_32bytes(cfg->base, tmp);
+
+		k_spin_unlock(&data->lock, key);
+
+		if (ret) {
+			return ret;
+		}
+
+		uint16_t copy_len = MIN(remaining, TRNG_OUTPUT_BYTES);
+
+		memcpy(buffer, tmp, copy_len);
+		buffer += copy_len;
+		remaining -= copy_len;
+	}
+
+	return 0;
+}
+
+static int entropy_bflb_get_entropy_isr(const struct device *dev, uint8_t *buffer, uint16_t length,
+					uint32_t flags)
+{
+	struct entropy_bflb_data *data = dev->data;
+	const struct entropy_bflb_config *cfg = dev->config;
+	uint8_t tmp[TRNG_OUTPUT_BYTES];
+	uint16_t remaining = length;
+	int ret;
+
+	if (!(flags & ENTROPY_BUSYWAIT)) {
+		return -ENOTSUP;
+	}
+
+	while (remaining > 0) {
+		k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+		ret = trng_read_32bytes(cfg->base, tmp);
+
+		k_spin_unlock(&data->lock, key);
+
+		if (ret) {
+			return ret;
+		}
+
+		uint16_t copy_len = MIN(remaining, TRNG_OUTPUT_BYTES);
+
+		memcpy(buffer, tmp, copy_len);
+		buffer += copy_len;
+		remaining -= copy_len;
+	}
+
+	return length;
+}
+
+static int entropy_bflb_init(const struct device *dev)
+{
+	const struct entropy_bflb_config *cfg = dev->config;
+	uint32_t regval;
+
+	/* Enable ring oscillator — the hardware entropy source for the TRNG's
+	 * internal DRBG. Without this, the DRBG reseeds from nothing when
+	 * re-enabled, producing repeated output.
+	 * (vendor SDK: SEC_Eng_Turn_On_Sec_Ring)
+	 */
+	regval = sys_read32(cfg->base + SEC_ENG_SE_TRNG_0_CTRL_3_OFFSET);
+	regval |= SEC_ENG_SE_TRNG_0_ROSC_EN;
+	sys_write32(regval, cfg->base + SEC_ENG_SE_TRNG_0_CTRL_3_OFFSET);
+
+	return 0;
+}
+
+static DEVICE_API(entropy, entropy_bflb_api) = {
+	.get_entropy = entropy_bflb_get_entropy,
+	.get_entropy_isr = entropy_bflb_get_entropy_isr,
+};
+
+#define ENTROPY_BFLB_INIT(inst)                                                                    \
+	static struct entropy_bflb_data entropy_bflb_data_##inst;                                  \
+	static const struct entropy_bflb_config entropy_bflb_config_##inst = {                     \
+		.base = DT_INST_REG_ADDR(inst),                                                  \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, entropy_bflb_init, NULL, &entropy_bflb_data_##inst,            \
+			      &entropy_bflb_config_##inst, PRE_KERNEL_1,                           \
+			      CONFIG_ENTROPY_INIT_PRIORITY, &entropy_bflb_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ENTROPY_BFLB_INIT)

--- a/dts/bindings/crypto/bflb,sec-eng-trng.yaml
+++ b/dts/bindings/crypto/bflb,sec-eng-trng.yaml
@@ -1,0 +1,12 @@
+description: Bouffalo Lab SEC Engine TRNG (True Random Number Generator)
+
+compatible: "bflb,sec-eng-trng"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -159,6 +159,14 @@
 			interrupt-parent = <&clic>;
 		};
 
+		sec_eng_trng: trng@40004000 {
+			compatible = "bflb,sec-eng-trng";
+			reg = <0x40004200 0x100>;
+			interrupts = <28 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		efuse: efuse@40007000 {
 			compatible = "bflb,efuse";
 			reg = <0x40007000 0x1000>;

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -178,6 +178,14 @@
 			interrupt-parent = <&clic>;
 		};
 
+		sec_eng_trng: trng@20004000 {
+			compatible = "bflb,sec-eng-trng";
+			reg = <0x20004200 0x100>;
+			interrupts = <28 1>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		uart0: uart@2000a000 {
 			compatible = "bflb,uart";
 			reg = <0x2000a000 0x100>;

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -164,6 +164,14 @@
 			interrupt-parent = <&clic>;
 		};
 
+		sec_eng_trng: trng@40004000 {
+			compatible = "bflb,sec-eng-trng";
+			reg = <0x40004200 0x100>;
+			interrupts = <28 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		efuse: efuse@40007000 {
 			compatible = "bflb,efuse";
 			reg = <0x40007000 0x1000>;


### PR DESCRIPTION
## Summary

This pull-request adds a Bouffalo Lab SEC Engine TRNG entropy driver, compatible with all known SoC series.

## Testing

```bash
west build -p -b dt_xt_zb1_devkit zephyr/tests/drivers/entropy/api
```