### PR TITLE
drivers: flash: rpi_pico: add optional untranslated read support

### DIFF
--- a/drivers/flash/Kconfig.rpi_pico
+++ b/drivers/flash/Kconfig.rpi_pico
@@ -12,3 +12,10 @@ config FLASH_RPI_PICO
 	select PICOSDK_USE_FLASH
 	help
 	  Enable Raspberry Pi Pico flash driver.
+
+config FLASH_RPI_PICO_READ_UNTRANSLATED
+	bool "Use untranslated window for flash reads"
+	depends on FLASH_RPI_PICO
+	depends on SOC_SERIES_RP2350
+	help
+	  Bypass XIP cache and address translation hardware when reading from flash.

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -25,6 +25,12 @@ LOG_MODULE_REGISTER(flash_rpi_pico, CONFIG_FLASH_LOG_LEVEL);
 #define ERASE_VALUE 0xff
 #define FLASH_SIZE  KB(CONFIG_FLASH_SIZE)
 
+#ifdef CONFIG_FLASH_RPI_PICO_READ_UNTRANSLATED
+#define PICO_FLASH_READ_BASE XIP_NOCACHE_NOALLOC_NOTRANSLATE_BASE
+#else
+#define PICO_FLASH_READ_BASE CONFIG_FLASH_BASE_ADDRESS
+#endif
+
 static const struct flash_parameters flash_rpi_parameters = {
 	.write_block_size = 1,
 	.erase_value = ERASE_VALUE,
@@ -50,7 +56,7 @@ static int flash_rpi_read(const struct device *dev, off_t offset, void *data, si
 		return -EINVAL;
 	}
 
-	memcpy(data, (uint8_t *)(CONFIG_FLASH_BASE_ADDRESS + offset), size);
+	memcpy(data, (uint8_t *)(PICO_FLASH_READ_BASE + offset), size);
 
 	return 0;
 }


### PR DESCRIPTION
Add an opt-in Kconfig option to use the RP2350 untranslated XIP alias for flash reads. This ensures the flash API can still access physical partitions when Address Translation has remapped the primary window. It otherwise introduces no changes for existing applications.