### PR TITLE
dts: bindings: pwm: add generic pwm-channels property

### DIFF
--- a/dts/bindings/pwm/atmel,sam0-tc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tc-pwm.yaml
@@ -32,9 +32,7 @@ properties:
     required: true
 
   channels:
-    type: int
     required: true
-    description: Number of channels this TC has
     enum:
       - 2
 

--- a/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
@@ -32,9 +32,7 @@ properties:
     required: true
 
   channels:
-    type: int
     required: true
-    description: Number of channels this TCC has
     enum:
       - 2
       - 3

--- a/dts/bindings/pwm/pwm-controller.yaml
+++ b/dts/bindings/pwm/pwm-controller.yaml
@@ -8,3 +8,7 @@ properties:
     type: int
     required: true
     description: Number of items to expect in a pwm specifier
+
+  channels:
+    type: int
+    description: Number of PWM channels supported by the controller.

--- a/dts/bindings/pwm/telink,b91-pwm.yaml
+++ b/dts/bindings/pwm/telink,b91-pwm.yaml
@@ -43,10 +43,8 @@ properties:
     description: Enable 32K Source Clock for PWM Channel 5
 
   channels:
-    type: int
     const: 6
     required: true
-    description: Number of channels this PWM has
 
   reg:
     required: true


### PR DESCRIPTION
Adds a generic `pwm-channels` property to the base PWM controller binding. This allows generic subsystems to dynamically query the number of supported channels at compile time via devicetree macros, removing the need for hardcoded channel limits.

Generic subsystems (such as Greybus) need to dynamically size arrays or allocate resources based on the hardware's capabilities. But currently, there is no generic way to query the channel count of a PWM controller at compile time without hardcoding limits.

By adding` pwm-channels `as an optional property to the base binding, subsystems can safely use `DT_PROP_OR(..., pwm_channels, 1)` to dynamically adapt to the underlying hardware without breaking existing boards.

Note: This addition was recommended by @Ayush1325 during the review of [beagleboard/greybus-zephyr#94.](https://github.com/beagleboard/greybus-zephyr/pull/94)