### PR TITLE
boards: arc: nsim_em7d_v22: increase MPU regions from 8 to 16

### DIFF
--- a/boards/snps/nsim/arc_classic/support/mdb_em7d_v22.args
+++ b/boards/snps/nsim/arc_classic/support/mdb_em7d_v22.args
@@ -28,7 +28,7 @@
 	-dmp_peripheral
 	-smart_stack_entries=8
 	-mpu
-	-mpu_regions=8
+	-mpu_regions=16
 	-interrupts=20
 	-interrupt_priorities=4
 	-ext_interrupts=16

--- a/boards/snps/nsim/arc_classic/support/nsim_em7d_v22.props
+++ b/boards/snps/nsim/arc_classic/support/nsim_em7d_v22.props
@@ -32,7 +32,7 @@
 	nsim_isa_stack_checking=1
 	nsim_isa_has_dmp_peripheral=1
 	nsim_isa_smart_stack_entries=8
-	mpu_regions=8
+	mpu_regions=16
 	mpu_version=2
 	nsim_isa_number_of_interrupts=20
 	nsim_isa_number_of_levels=4


### PR DESCRIPTION
Increase the number of MPU regions for `nsim/nsim_em7d_v22` from 8 to 16 to enable userspace memory domain tests.

The issue:
The `nsim_em7d_v22` board has ARC MPU v2 with limited hardware regions. After allocating regions for static memory (ICCM, DCCM, PERIPHERAL) and thread stacks, only 3 MPU regions remain for memory domain partitions.

Two tests fail because they need more than 3 partition regions:
- [shared_mem]- needs 4 partitions for enc_domain
- [userspace]- dynamically adds partitions

Solution:
Increase `mpu_regions` from 8 to 16 in the nSIM configuration files, matching other ARC EM boards (`nsim_em`, `nsim_em11d`). This provides sufficient MPU regions for userspace tests and improves test coverage on this board.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/104362