### PR TITLE
boards: nrf9151dk: add UART1 async API overlay

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf9151dk_nrf9151.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf9151dk_nrf9151.overlay
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart1_default_alt: uart1_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 29)>,
+				<NRF_PSEL(UART_RX, 0, 28)>;
+		};
+	};
+
+	uart1_sleep_alt: uart1_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 29)>,
+				<NRF_PSEL(UART_RX, 0, 28)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart1 {
+	current-speed = <115200>;
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	pinctrl-0 = <&uart1_default_alt>;
+	pinctrl-1 = <&uart1_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};


### PR DESCRIPTION
Add devicetree overlay for UART1 async API support on the nRF9151DK board, using GPIO pins P0.29 (TX) and P0.28 (RX) with low-power sleep state configuration.