### PR TITLE
drivers: crypto: bflb: add Bouffalo Lab SEC_ENG hardware crypto drivers

### DIFF
--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.dts
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.dts
@@ -106,6 +106,14 @@
 	pinctrl-names = "default";
 };
 
+&sec_eng_aes {
+	status = "okay";
+};
+
+&sec_eng_sha {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 

--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f_kit.yaml
@@ -25,4 +25,5 @@ supported:
   - pwm
   - adc
   - entropy
+  - crypto
 vendor: bflb

--- a/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.dts
+++ b/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.dts
@@ -86,6 +86,14 @@
 	pinctrl-names = "default";
 };
 
+&sec_eng_aes {
+	status = "okay";
+};
+
+&sec_eng_sha {
+	status = "okay";
+};
+
 &adc0 {
 	status = "okay";
 

--- a/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.yaml
+++ b/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f_kit.yaml
@@ -25,4 +25,5 @@ supported:
   - pwm
   - adc
   - entropy
+  - crypto
 vendor: bflb

--- a/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.dts
+++ b/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.dts
@@ -20,6 +20,14 @@
 	pinctrl-names = "default";
 };
 
+&sec_eng_aes {
+	status = "okay";
+};
+
+&sec_eng_sha {
+	status = "okay";
+};
+
 &spi0 {
 	status = "okay";
 

--- a/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.yaml
+++ b/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit.yaml
@@ -21,4 +21,5 @@ supported:
   - spi
   - flash
   - entropy
+  - crypto
 vendor: doiting

--- a/drivers/crypto/CMakeLists.txt
+++ b/drivers/crypto/CMakeLists.txt
@@ -5,6 +5,8 @@ zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ATAES132A crypto_ataes132a.c)
+zephyr_library_sources_ifdef(CONFIG_CRYPTO_BFLB_SEC_ENG_AES crypto_bflb_sec_eng_aes.c)
+zephyr_library_sources_ifdef(CONFIG_CRYPTO_BFLB_SEC_ENG_SHA crypto_bflb_sec_eng_sha.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_CC23X0 crypto_cc23x0.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ESP32_AES crypto_esp32_aes.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ESP32_SHA crypto_esp32_sha.c)

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -56,6 +56,7 @@ config CRYPTO_MBEDTLS_SHIM_MAX_SESSION
 
 # zephyr-keep-sorted-start
 source "drivers/crypto/Kconfig.ataes132a"
+source "drivers/crypto/Kconfig.bflb"
 source "drivers/crypto/Kconfig.cc23x0"
 source "drivers/crypto/Kconfig.esp32"
 source "drivers/crypto/Kconfig.intel"

--- a/drivers/crypto/Kconfig.bflb
+++ b/drivers/crypto/Kconfig.bflb
@@ -1,0 +1,32 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config CRYPTO_BFLB_SEC_ENG_AES
+	bool "Bouffalo Lab SEC Engine AES crypto driver"
+	default y
+	depends on DT_HAS_BFLB_SEC_ENG_AES_ENABLED
+	help
+	  Enable the Bouffalo Lab SEC Engine crypto driver providing
+	  hardware-accelerated AES (ECB/CBC/CTR).
+
+config CRYPTO_BFLB_SEC_ENG_AES_MAX_SESSION
+	int "Maximum concurrent AES cipher sessions"
+	default 4
+	depends on CRYPTO_BFLB_SEC_ENG_AES
+	help
+	  Maximum number of concurrent AES cipher sessions.
+
+config CRYPTO_BFLB_SEC_ENG_SHA
+	bool "Bouffalo Lab SEC Engine SHA hash driver"
+	default y
+	depends on DT_HAS_BFLB_SEC_ENG_SHA_ENABLED
+	help
+	  Enable the Bouffalo Lab SEC Engine SHA hash driver providing
+	  hardware-accelerated SHA-224 and SHA-256.
+
+config CRYPTO_BFLB_SEC_ENG_SHA_MAX_SESSION
+	int "Maximum concurrent SHA hash sessions"
+	default 4
+	depends on CRYPTO_BFLB_SEC_ENG_SHA
+	help
+	  Maximum number of concurrent SHA hash sessions.

--- a/drivers/crypto/crypto_bflb_sec_eng_aes.c
+++ b/drivers/crypto/crypto_bflb_sec_eng_aes.c
@@ -1,0 +1,398 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bouffalo Lab SEC Engine AES cipher driver
+ */
+
+#define DT_DRV_COMPAT bflb_sec_eng_aes
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/crypto/crypto.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/cache.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+#include <bouffalolab/common/sec_eng_reg.h>
+
+LOG_MODULE_REGISTER(crypto_bflb_aes, CONFIG_CRYPTO_LOG_LEVEL);
+
+#define BFLB_AES_BLOCK_SIZE 16
+
+/* AES block cipher mode values (for BLOCK_MODE field) */
+#define BFLB_AES_MODE_ECB 0
+#define BFLB_AES_MODE_CTR 1
+#define BFLB_AES_MODE_CBC 2
+#define BFLB_AES_MODE_XTS 3
+
+/* AES key size values (for MODE field) */
+#define BFLB_AES_KEY_128 0
+#define BFLB_AES_KEY_192 1
+#define BFLB_AES_KEY_256 2
+
+/*
+ * HAL register offsets are relative to SEC_ENG_BASE. The DT node provides a
+ * named "sec_eng" register region with that base address.
+ */
+#define SEC_ENG_AES_BASE(inst) DT_INST_REG_ADDR_BY_NAME(inst, sec_eng)
+
+struct bflb_aes_session {
+	bool in_use;
+	uint8_t key[32];
+	uint16_t key_len;
+	enum cipher_algo algo;
+	enum cipher_mode mode;
+	enum cipher_op op;
+};
+
+struct crypto_bflb_aes_data {
+	struct k_mutex lock;
+	struct bflb_aes_session sessions[CONFIG_CRYPTO_BFLB_SEC_ENG_AES_MAX_SESSION];
+};
+
+struct crypto_bflb_aes_config {
+	uintptr_t base;
+};
+
+/* Helpers */
+
+static int bflb_aes_wait_not_busy(uintptr_t base)
+{
+	uint32_t timeout = 100000;
+
+	while (timeout--) {
+		if (!(sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET) & SEC_ENG_SE_AES_0_BUSY)) {
+			return 0;
+		}
+		k_busy_wait(1);
+	}
+
+	return -ETIMEDOUT;
+}
+
+/* AES implementation */
+
+static void bflb_aes_hw_init(uintptr_t base)
+{
+	uint32_t regval;
+
+	/* Set endianness to big-endian */
+	sys_write32(0x1f, base + SEC_ENG_SE_AES_0_ENDIAN_OFFSET);
+
+	/* Enable AES */
+	regval = sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+	regval |= SEC_ENG_SE_AES_0_EN;
+	sys_write32(regval, base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+}
+
+static int bflb_aes_do_op(uintptr_t base, const struct bflb_aes_session *sess, const uint8_t *in,
+			  uint8_t *out, uint32_t len, const uint8_t *iv, bool decrypt)
+{
+	uint32_t regval;
+	uint8_t block_mode;
+	uint8_t key_mode;
+	const uint8_t *key = sess->key;
+	int ret;
+
+	if (len % BFLB_AES_BLOCK_SIZE != 0) {
+		return -EINVAL;
+	}
+
+	switch (sess->mode) {
+	case CRYPTO_CIPHER_MODE_ECB:
+		block_mode = BFLB_AES_MODE_ECB;
+		break;
+	case CRYPTO_CIPHER_MODE_CBC:
+		block_mode = BFLB_AES_MODE_CBC;
+		break;
+	case CRYPTO_CIPHER_MODE_CTR:
+		block_mode = BFLB_AES_MODE_CTR;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	regval = sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+	regval &= ~SEC_ENG_SE_AES_0_BLOCK_MODE_MASK;
+	regval |= (block_mode << SEC_ENG_SE_AES_0_BLOCK_MODE_SHIFT);
+	if (sess->mode == CRYPTO_CIPHER_MODE_CTR) {
+		regval |= SEC_ENG_SE_AES_0_DEC_KEY_SEL;
+	} else {
+		regval &= ~SEC_ENG_SE_AES_0_DEC_KEY_SEL;
+	}
+	sys_write32(regval, base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+
+	/* Set key size */
+	regval = sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+	regval &= ~SEC_ENG_SE_AES_0_MODE_MASK;
+	regval &= ~SEC_ENG_SE_AES_0_HW_KEY_EN;
+	switch (sess->key_len) {
+	case 16:
+		key_mode = BFLB_AES_KEY_128;
+		break;
+	case 24:
+		key_mode = BFLB_AES_KEY_192;
+		break;
+	case 32:
+		key_mode = BFLB_AES_KEY_256;
+		break;
+	default:
+		return -EINVAL;
+	}
+	regval |= (key_mode << SEC_ENG_SE_AES_0_MODE_SHIFT);
+	sys_write32(regval, base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+
+	/* Write key registers */
+	sys_write32(sys_get_le32(key + 0), base + SEC_ENG_SE_AES_0_KEY_0_OFFSET);
+	sys_write32(sys_get_le32(key + 4), base + SEC_ENG_SE_AES_0_KEY_1_OFFSET);
+	sys_write32(sys_get_le32(key + 8), base + SEC_ENG_SE_AES_0_KEY_2_OFFSET);
+	sys_write32(sys_get_le32(key + 12), base + SEC_ENG_SE_AES_0_KEY_3_OFFSET);
+	if (sess->key_len >= 24) {
+		sys_write32(sys_get_le32(key + 16), base + SEC_ENG_SE_AES_0_KEY_4_OFFSET);
+		sys_write32(sys_get_le32(key + 20), base + SEC_ENG_SE_AES_0_KEY_5_OFFSET);
+	}
+	if (sess->key_len == 32) {
+		sys_write32(sys_get_le32(key + 24), base + SEC_ENG_SE_AES_0_KEY_6_OFFSET);
+		sys_write32(sys_get_le32(key + 28), base + SEC_ENG_SE_AES_0_KEY_7_OFFSET);
+	}
+
+	/* Configure operation */
+	regval = sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+	regval &= ~SEC_ENG_SE_AES_0_TRIG_1T;
+	if (iv) {
+		regval &= ~SEC_ENG_SE_AES_0_IV_SEL;
+	} else {
+		regval |= SEC_ENG_SE_AES_0_IV_SEL;
+	}
+	if (decrypt) {
+		regval |= SEC_ENG_SE_AES_0_DEC_EN;
+	} else {
+		regval &= ~SEC_ENG_SE_AES_0_DEC_EN;
+	}
+	regval &= ~SEC_ENG_SE_AES_0_MSG_LEN_MASK;
+	regval |= SEC_ENG_SE_AES_0_INT_CLR_1T;
+	regval |= ((len / BFLB_AES_BLOCK_SIZE) << SEC_ENG_SE_AES_0_MSG_LEN_SHIFT);
+	sys_write32(regval, base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+
+	/* Write IV */
+	if (iv) {
+		sys_write32(sys_get_le32(iv + 0), base + SEC_ENG_SE_AES_0_IV_0_OFFSET);
+		sys_write32(sys_get_le32(iv + 4), base + SEC_ENG_SE_AES_0_IV_1_OFFSET);
+		sys_write32(sys_get_le32(iv + 8), base + SEC_ENG_SE_AES_0_IV_2_OFFSET);
+		sys_write32(sys_get_le32(iv + 12), base + SEC_ENG_SE_AES_0_IV_3_OFFSET);
+	}
+
+	/* Set source and destination addresses */
+	sys_write32((uint32_t)(uintptr_t)in, base + SEC_ENG_SE_AES_0_MSA_OFFSET);
+	sys_write32((uint32_t)(uintptr_t)out, base + SEC_ENG_SE_AES_0_MDA_OFFSET);
+
+	/* The operation done here writes and reads autonomously to and from RAM, which is cached.
+	 * This is handled automatically on L1C SoCs (BL60x, BL70x/L)
+	 * But on XTHeadCMO SoCs (BL61x) this requires manual cache handling
+	 */
+	sys_cache_data_flush_range((void *)in, (size_t)len);
+
+	/* Trigger */
+	regval = sys_read32(base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+	regval |= SEC_ENG_SE_AES_0_TRIG_1T;
+	sys_write32(regval, base + SEC_ENG_SE_AES_0_CTRL_OFFSET);
+
+	ret = bflb_aes_wait_not_busy(base);
+
+	sys_cache_data_invd_range((void *)out, (size_t)len);
+
+	return ret;
+}
+
+static int bflb_aes_cipher_ecb_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt)
+{
+	const struct device *dev = ctx->device;
+	struct crypto_bflb_aes_data *data = dev->data;
+	const struct crypto_bflb_aes_config *cfg = dev->config;
+	struct bflb_aes_session *sess = ctx->drv_sessn_state;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	ret = bflb_aes_do_op(cfg->base, sess, pkt->in_buf, pkt->out_buf, pkt->in_len, NULL,
+			     sess->op == CRYPTO_CIPHER_OP_DECRYPT);
+	k_mutex_unlock(&data->lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int bflb_aes_cipher_cbc_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	const struct device *dev = ctx->device;
+	struct crypto_bflb_aes_data *data = dev->data;
+	const struct crypto_bflb_aes_config *cfg = dev->config;
+	struct bflb_aes_session *sess = ctx->drv_sessn_state;
+	bool decrypt = (sess->op == CRYPTO_CIPHER_OP_DECRYPT);
+	int in_offset = 0;
+	int out_offset = 0;
+	int ret;
+
+	if (!decrypt && (ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
+		memcpy(pkt->out_buf, iv, BFLB_AES_BLOCK_SIZE);
+		out_offset = BFLB_AES_BLOCK_SIZE;
+	}
+
+	if (decrypt && (ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
+		in_offset = BFLB_AES_BLOCK_SIZE;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	ret = bflb_aes_do_op(cfg->base, sess, pkt->in_buf + in_offset, pkt->out_buf + out_offset,
+			     pkt->in_len - in_offset, iv, decrypt);
+	k_mutex_unlock(&data->lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len - in_offset + out_offset;
+	}
+
+	return ret;
+}
+
+static int bflb_aes_cipher_ctr_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	const struct device *dev = ctx->device;
+	struct crypto_bflb_aes_data *data = dev->data;
+	const struct crypto_bflb_aes_config *cfg = dev->config;
+	struct bflb_aes_session *sess = ctx->drv_sessn_state;
+	uint8_t ctr[BFLB_AES_BLOCK_SIZE] = {0};
+	int ivlen = BFLB_AES_BLOCK_SIZE - (ctx->mode_params.ctr_info.ctr_len >> 3);
+	int ret;
+
+	memcpy(ctr, iv, ivlen);
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	ret = bflb_aes_do_op(cfg->base, sess, pkt->in_buf, pkt->out_buf, pkt->in_len, ctr,
+			     sess->op == CRYPTO_CIPHER_OP_DECRYPT);
+	k_mutex_unlock(&data->lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+/* Crypto API */
+
+static int crypto_bflb_aes_query_caps(const struct device *dev)
+{
+	return (CAP_RAW_KEY | CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS | CAP_NO_IV_PREFIX);
+}
+
+static int crypto_bflb_aes_begin_session(const struct device *dev, struct cipher_ctx *ctx,
+					 enum cipher_algo algo, enum cipher_mode mode,
+					 enum cipher_op op)
+{
+	struct crypto_bflb_aes_data *data = dev->data;
+	struct bflb_aes_session *sess = NULL;
+
+	if (algo != CRYPTO_CIPHER_ALGO_AES) {
+		return -ENOTSUP;
+	}
+
+	if (mode != CRYPTO_CIPHER_MODE_ECB && mode != CRYPTO_CIPHER_MODE_CBC &&
+	    mode != CRYPTO_CIPHER_MODE_CTR) {
+		return -ENOTSUP;
+	}
+
+	if (ctx->keylen != 16 && ctx->keylen != 24 && ctx->keylen != 32) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	for (int i = 0; i < CONFIG_CRYPTO_BFLB_SEC_ENG_AES_MAX_SESSION; i++) {
+		if (!data->sessions[i].in_use) {
+			sess = &data->sessions[i];
+			break;
+		}
+	}
+
+	if (!sess) {
+		k_mutex_unlock(&data->lock);
+		return -ENOSPC;
+	}
+
+	sess->in_use = true;
+
+	k_mutex_unlock(&data->lock);
+
+	sess->algo = algo;
+	sess->mode = mode;
+	sess->op = op;
+	sess->key_len = ctx->keylen;
+	memcpy(sess->key, ctx->key.bit_stream, ctx->keylen);
+
+	ctx->drv_sessn_state = sess;
+	ctx->device = dev;
+
+	switch (mode) {
+	case CRYPTO_CIPHER_MODE_ECB:
+		ctx->ops.block_crypt_hndlr = bflb_aes_cipher_ecb_op;
+		break;
+	case CRYPTO_CIPHER_MODE_CBC:
+		ctx->ops.cbc_crypt_hndlr = bflb_aes_cipher_cbc_op;
+		break;
+	case CRYPTO_CIPHER_MODE_CTR:
+		ctx->ops.ctr_crypt_hndlr = bflb_aes_cipher_ctr_op;
+		break;
+	default:
+		sess->in_use = false;
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int crypto_bflb_aes_free_session(const struct device *dev, struct cipher_ctx *ctx)
+{
+	struct crypto_bflb_aes_data *data = dev->data;
+	struct bflb_aes_session *sess = ctx->drv_sessn_state;
+
+	if (sess) {
+		k_mutex_lock(&data->lock, K_FOREVER);
+		sess->in_use = false;
+		k_mutex_unlock(&data->lock);
+	}
+
+	return 0;
+}
+
+static int crypto_bflb_aes_init(const struct device *dev)
+{
+	struct crypto_bflb_aes_data *data = dev->data;
+	const struct crypto_bflb_aes_config *cfg = dev->config;
+
+	k_mutex_init(&data->lock);
+	bflb_aes_hw_init(cfg->base);
+
+	return 0;
+}
+
+static DEVICE_API(crypto, crypto_bflb_aes_api) = {
+	.query_hw_caps = crypto_bflb_aes_query_caps,
+	.cipher_begin_session = crypto_bflb_aes_begin_session,
+	.cipher_free_session = crypto_bflb_aes_free_session,
+};
+
+#define BFLB_AES_INIT(inst)                                                                        \
+	static struct crypto_bflb_aes_data crypto_bflb_aes_data_##inst;                            \
+	static const struct crypto_bflb_aes_config crypto_bflb_aes_config_##inst = {               \
+		.base = SEC_ENG_AES_BASE(inst),                                                    \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, crypto_bflb_aes_init, NULL, &crypto_bflb_aes_data_##inst,      \
+			      &crypto_bflb_aes_config_##inst, POST_KERNEL,                         \
+			      CONFIG_CRYPTO_INIT_PRIORITY, &crypto_bflb_aes_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BFLB_AES_INIT)

--- a/drivers/crypto/crypto_bflb_sec_eng_sha.c
+++ b/drivers/crypto/crypto_bflb_sec_eng_sha.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Bouffalo Lab SEC Engine SHA hash driver
+ */
+
+#define DT_DRV_COMPAT bflb_sec_eng_sha
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/crypto/crypto.h>
+#include <zephyr/crypto/hash.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/cache.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+#include <bouffalolab/common/sec_eng_reg.h>
+
+LOG_MODULE_REGISTER(crypto_bflb_sha, CONFIG_CRYPTO_LOG_LEVEL);
+
+#define SHA_TIMEOUT_US          100000
+#define SHA256_BLOCK_SIZE       (512 / BITS_PER_BYTE)
+#define SHA512_BLOCK_SIZE       (1024 / BITS_PER_BYTE)
+#define SHA_FINAL_PAD_BUF_SIZE  (SHA512_BLOCK_SIZE * 2)
+#define BFLB_SHA_PAD_START_BYTE 0x80U
+
+/* SHA mode values (for MODE field) */
+#define SHA_MODE_SHA256 0
+#define SHA_MODE_SHA224 1
+#define SHA_MODE_SHA1   2
+#define SHA_MODE_SHA512 4
+#define SHA_MODE_SHA384 5
+
+/*
+ * HAL register offsets are relative to SEC_ENG_BASE. The DT node provides a
+ * named "sec_eng" register region with that base address.
+ */
+#define SEC_ENG_SHA_BASE(inst) DT_INST_REG_ADDR_BY_NAME(inst, sec_eng)
+
+struct bflb_sha_session {
+	bool in_use;
+	enum hash_algo algo;
+	uint8_t sha_buf[SHA512_BLOCK_SIZE]; /* partial block buffer */
+	uint32_t buf_pos;
+	uint64_t total_len;
+	bool started;
+};
+
+struct crypto_bflb_sha_data {
+	struct k_mutex lock;
+	struct bflb_sha_session sessions[CONFIG_CRYPTO_BFLB_SEC_ENG_SHA_MAX_SESSION];
+};
+
+struct crypto_bflb_sha_config {
+	uintptr_t base;
+};
+
+/* Helpers */
+
+static int bflb_sha_wait_not_busy(uintptr_t base)
+{
+	uint32_t timeout = SHA_TIMEOUT_US;
+
+	while (timeout--) {
+		if (!(sys_read32(base + SEC_ENG_SE_SHA_0_CTRL_OFFSET) & SEC_ENG_SE_SHA_0_BUSY)) {
+			return 0;
+		}
+		k_busy_wait(1);
+	}
+	return -ETIMEDOUT;
+}
+
+static int bflb_sha_block_size(enum hash_algo algo)
+{
+	switch (algo) {
+	case CRYPTO_HASH_ALGO_SHA384:
+	case CRYPTO_HASH_ALGO_SHA512:
+		return SHA512_BLOCK_SIZE;
+	default:
+		return SHA256_BLOCK_SIZE;
+	}
+}
+
+static int bflb_sha_digest_size(enum hash_algo algo)
+{
+	switch (algo) {
+	case CRYPTO_HASH_ALGO_SHA224:
+		return 28;
+	case CRYPTO_HASH_ALGO_SHA256:
+		return 32;
+	case CRYPTO_HASH_ALGO_SHA384:
+		return 48;
+	case CRYPTO_HASH_ALGO_SHA512:
+		return 64;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static uint8_t bflb_sha_hw_mode(enum hash_algo algo)
+{
+	switch (algo) {
+	case CRYPTO_HASH_ALGO_SHA256:
+		return SHA_MODE_SHA256;
+	case CRYPTO_HASH_ALGO_SHA224:
+		return SHA_MODE_SHA224;
+	case CRYPTO_HASH_ALGO_SHA384:
+		return SHA_MODE_SHA384;
+	case CRYPTO_HASH_ALGO_SHA512:
+		return SHA_MODE_SHA512;
+	default:
+		return 0;
+	}
+}
+
+static bool bflb_sha_algo_supported(enum hash_algo algo)
+{
+#if defined(CONFIG_SOC_SERIES_BL61X)
+	/* BL61x SEC_ENG supports SHA-224/256/384/512. */
+	return (algo == CRYPTO_HASH_ALGO_SHA224 || algo == CRYPTO_HASH_ALGO_SHA256 ||
+		algo == CRYPTO_HASH_ALGO_SHA384 || algo == CRYPTO_HASH_ALGO_SHA512);
+#else
+	/* BL60x/BL70x SEC_ENG supports SHA-224/256 only. */
+	return (algo == CRYPTO_HASH_ALGO_SHA224 || algo == CRYPTO_HASH_ALGO_SHA256);
+#endif
+}
+
+/* SHA implementation */
+
+static int bflb_sha_process_blocks(uintptr_t base, const uint8_t *data, uint32_t nblocks,
+				   size_t len, bool is_first, uint8_t hw_mode)
+{
+	uint32_t regval;
+
+	regval = sys_read32(base + SEC_ENG_SE_SHA_0_CTRL_OFFSET);
+
+	/* Set mode */
+	regval &= ~SEC_ENG_SE_SHA_0_MODE_MASK;
+	regval &= ~SEC_ENG_SE_SHA_0_MODE_EXT_MASK;
+	regval |= (hw_mode << SEC_ENG_SE_SHA_0_MODE_SHIFT);
+
+	/* Enable SHA */
+	regval |= SEC_ENG_SE_SHA_0_EN;
+
+	/* Set HASH_SEL for continuation (not first block) */
+	if (is_first) {
+		regval &= ~SEC_ENG_SE_SHA_0_HASH_SEL;
+	} else {
+		regval |= SEC_ENG_SE_SHA_0_HASH_SEL;
+	}
+
+	/* Set source address */
+	sys_write32((uint32_t)(uintptr_t)data, base + SEC_ENG_SE_SHA_0_MSA_OFFSET);
+
+	/* Set block count */
+	regval &= ~SEC_ENG_SE_SHA_0_MSG_LEN_MASK;
+	regval |= (nblocks << SEC_ENG_SE_SHA_0_MSG_LEN_SHIFT);
+	sys_write32(regval, base + SEC_ENG_SE_SHA_0_CTRL_OFFSET);
+
+	/* The SHA engine reads autonomously from RAM, which is cached.
+	 * This is handled automatically on L1C SoCs (BL60x, BL70x/L)
+	 * But on XTHeadCMO SoCs (BL61x) this requires manual cache handling
+	 */
+	sys_cache_data_flush_range((void *)data, len);
+
+	/* Trigger */
+	regval |= SEC_ENG_SE_SHA_0_TRIG_1T;
+	sys_write32(regval, base + SEC_ENG_SE_SHA_0_CTRL_OFFSET);
+
+	return bflb_sha_wait_not_busy(base);
+}
+
+static void bflb_sha_read_digest(uintptr_t base, uint8_t *output, enum hash_algo algo)
+{
+	int digest_len = bflb_sha_digest_size(algo);
+	bool is_sha512_family =
+		(algo == CRYPTO_HASH_ALGO_SHA384 || algo == CRYPTO_HASH_ALGO_SHA512);
+
+	if (is_sha512_family) {
+		int nwords = digest_len / sizeof(uint32_t);
+
+		for (int i = 0; i < nwords / 2; i++) {
+			sys_put_le32(sys_read32(base + SEC_ENG_SE_SHA_0_HASH_H_0_OFFSET +
+						(i * sizeof(uint32_t))),
+				     output);
+			output += sizeof(uint32_t);
+			sys_put_le32(sys_read32(base + SEC_ENG_SE_SHA_0_HASH_L_0_OFFSET +
+						(i * sizeof(uint32_t))),
+				     output);
+			output += sizeof(uint32_t);
+		}
+	} else {
+		int nwords = digest_len / sizeof(uint32_t);
+
+		for (int i = 0; i < nwords; i++) {
+			sys_put_le32(sys_read32(base + SEC_ENG_SE_SHA_0_HASH_L_0_OFFSET +
+						(i * sizeof(uint32_t))),
+				     output);
+			output += sizeof(uint32_t);
+		}
+	}
+}
+
+static int bflb_sha_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool finish)
+{
+	const struct device *dev = ctx->device;
+	struct crypto_bflb_sha_data *data = dev->data;
+	const struct crypto_bflb_sha_config *cfg = dev->config;
+	struct bflb_sha_session *sess = ctx->drv_sessn_state;
+	uintptr_t base = cfg->base;
+	int block_sz = bflb_sha_block_size(sess->algo);
+	const uint8_t *input = pkt->in_buf;
+	const uint32_t input_len = pkt->in_len;
+	uint32_t len = pkt->in_len;
+	int ret = 0;
+	uint8_t hw_mode = bflb_sha_hw_mode(sess->algo);
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	uint32_t fill = block_sz - sess->buf_pos;
+
+	/* If we have buffered data and new input fills a block */
+	if (sess->buf_pos > 0 && len >= fill) {
+		memcpy(sess->sha_buf + sess->buf_pos, input, fill);
+
+		ret = bflb_sha_process_blocks(base, sess->sha_buf, 1, block_sz, !sess->started,
+					      hw_mode);
+		if (ret) {
+			goto out;
+		}
+		sess->started = true;
+		input += fill;
+		len -= fill;
+		sess->buf_pos = 0;
+	}
+
+	/* Process full blocks from input */
+	uint32_t full_blocks = len / block_sz;
+
+	if (full_blocks > 0) {
+		ret = bflb_sha_process_blocks(base, input, full_blocks, full_blocks * block_sz,
+					      !sess->started, hw_mode);
+		if (ret) {
+			goto out;
+		}
+		sess->started = true;
+		input += full_blocks * block_sz;
+		len -= full_blocks * block_sz;
+	}
+
+	/* Buffer remaining bytes */
+	if (len > 0) {
+		memcpy(sess->sha_buf + sess->buf_pos, input, len);
+		sess->buf_pos += len;
+	}
+
+	/* Finalize if requested */
+	if (finish) {
+		uint8_t pad_buf[SHA_FINAL_PAD_BUF_SIZE];
+		uint32_t pad_len = sess->buf_pos;
+		uint64_t bit_len = (sess->total_len + input_len) * BITS_PER_BYTE;
+
+		memcpy(pad_buf, sess->sha_buf, sess->buf_pos);
+		pad_buf[pad_len++] = BFLB_SHA_PAD_START_BYTE;
+
+		if (block_sz == SHA256_BLOCK_SIZE) {
+			while (pad_len % SHA256_BLOCK_SIZE !=
+			       (SHA256_BLOCK_SIZE - sizeof(uint64_t))) {
+				pad_buf[pad_len++] = 0;
+			}
+			sys_put_be64(bit_len, pad_buf + pad_len);
+			pad_len += sizeof(uint64_t);
+		} else {
+			while (pad_len % SHA512_BLOCK_SIZE !=
+			       (SHA512_BLOCK_SIZE - (2 * sizeof(uint64_t)))) {
+				pad_buf[pad_len++] = 0;
+			}
+			/* 128-bit length (upper 64 bits = 0) */
+			memset(pad_buf + pad_len, 0, sizeof(uint64_t));
+			pad_len += sizeof(uint64_t);
+			sys_put_be64(bit_len, pad_buf + pad_len);
+			pad_len += sizeof(uint64_t);
+		}
+
+		ret = bflb_sha_process_blocks(base, pad_buf, pad_len / block_sz, pad_len,
+					      !sess->started, hw_mode);
+		if (ret) {
+			goto out;
+		}
+
+		bflb_sha_read_digest(base, pkt->out_buf, sess->algo);
+
+		/* Disable SHA */
+		uint32_t regval = sys_read32(base + SEC_ENG_SE_SHA_0_CTRL_OFFSET);
+
+		regval &= ~SEC_ENG_SE_SHA_0_HASH_SEL;
+		regval &= ~SEC_ENG_SE_SHA_0_EN;
+		sys_write32(regval, base + SEC_ENG_SE_SHA_0_CTRL_OFFSET);
+
+		/* Reset session for potential reuse */
+		sess->buf_pos = 0;
+		sess->total_len = 0;
+		sess->started = false;
+	} else {
+		/* Commit message length only when non-final update succeeds. */
+		sess->total_len += input_len;
+	}
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+/* Crypto API */
+
+static int crypto_bflb_sha_query_caps(const struct device *dev)
+{
+	return (CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS);
+}
+
+static int crypto_bflb_sha_begin_session(const struct device *dev, struct hash_ctx *ctx,
+					 enum hash_algo algo)
+{
+	struct crypto_bflb_sha_data *data = dev->data;
+	struct bflb_sha_session *sess = NULL;
+
+	if (!bflb_sha_algo_supported(algo)) {
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	for (int i = 0; i < CONFIG_CRYPTO_BFLB_SEC_ENG_SHA_MAX_SESSION; i++) {
+		if (!data->sessions[i].in_use) {
+			sess = &data->sessions[i];
+			break;
+		}
+	}
+
+	if (!sess) {
+		k_mutex_unlock(&data->lock);
+		return -ENOSPC;
+	}
+
+	memset(sess, 0, sizeof(*sess));
+	sess->in_use = true;
+
+	k_mutex_unlock(&data->lock);
+
+	sess->algo = algo;
+
+	ctx->drv_sessn_state = sess;
+	ctx->device = dev;
+	ctx->hash_hndlr = bflb_sha_hash_handler;
+	ctx->started = false;
+
+	return 0;
+}
+
+static int crypto_bflb_sha_free_session(const struct device *dev, struct hash_ctx *ctx)
+{
+	struct crypto_bflb_sha_data *data = dev->data;
+	struct bflb_sha_session *sess = ctx->drv_sessn_state;
+
+	if (sess) {
+		k_mutex_lock(&data->lock, K_FOREVER);
+		sess->in_use = false;
+		k_mutex_unlock(&data->lock);
+	}
+
+	return 0;
+}
+
+static int crypto_bflb_sha_init(const struct device *dev)
+{
+	struct crypto_bflb_sha_data *data = dev->data;
+
+	k_mutex_init(&data->lock);
+
+	return 0;
+}
+
+static DEVICE_API(crypto, crypto_bflb_sha_api) = {
+	.query_hw_caps = crypto_bflb_sha_query_caps,
+	.hash_begin_session = crypto_bflb_sha_begin_session,
+	.hash_free_session = crypto_bflb_sha_free_session,
+};
+
+#define BFLB_SHA_INIT(inst)                                                                        \
+	static struct crypto_bflb_sha_data crypto_bflb_sha_data_##inst;                            \
+	static const struct crypto_bflb_sha_config crypto_bflb_sha_config_##inst = {               \
+		.base = SEC_ENG_SHA_BASE(inst),                                                    \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, crypto_bflb_sha_init, NULL, &crypto_bflb_sha_data_##inst,      \
+			      &crypto_bflb_sha_config_##inst, POST_KERNEL,                         \
+			      CONFIG_CRYPTO_INIT_PRIORITY, &crypto_bflb_sha_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BFLB_SHA_INIT)

--- a/dts/bindings/crypto/bflb,sec-eng-aes.yaml
+++ b/dts/bindings/crypto/bflb,sec-eng-aes.yaml
@@ -1,0 +1,17 @@
+description: Bouffalo Lab SEC Engine AES hardware accelerator
+
+compatible: "bflb,sec-eng-aes"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    type: string-array
+    required: true
+    description: Register names must include "aes" and "sec_eng".
+
+  interrupts:
+    required: true

--- a/dts/bindings/crypto/bflb,sec-eng-sha.yaml
+++ b/dts/bindings/crypto/bflb,sec-eng-sha.yaml
@@ -1,0 +1,17 @@
+description: Bouffalo Lab SEC Engine SHA hardware accelerator
+
+compatible: "bflb,sec-eng-sha"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    type: string-array
+    required: true
+    description: Register names must include "sha" and "sec_eng".
+
+  interrupts:
+    required: true

--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -167,6 +167,24 @@
 			status = "disabled";
 		};
 
+		sec_eng_sha: sha@40004000 {
+			compatible = "bflb,sec-eng-sha";
+			reg = <0x40004000 0x100>, <0x40004000 0x600>;
+			reg-names = "sha", "sec_eng";
+			interrupts = <30 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
+		sec_eng_aes: aes@40004100 {
+			compatible = "bflb,sec-eng-aes";
+			reg = <0x40004100 0x100>, <0x40004000 0x600>;
+			reg-names = "aes", "sec_eng";
+			interrupts = <29 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		efuse: efuse@40007000 {
 			compatible = "bflb,efuse";
 			reg = <0x40007000 0x1000>;

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -186,6 +186,24 @@
 			status = "disabled";
 		};
 
+		sec_eng_sha: sha@20004000 {
+			compatible = "bflb,sec-eng-sha";
+			reg = <0x20004000 0x100>, <0x20004000 0x600>;
+			reg-names = "sha", "sec_eng";
+			interrupts = <26 1>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
+		sec_eng_aes: aes@20004100 {
+			compatible = "bflb,sec-eng-aes";
+			reg = <0x20004100 0x100>, <0x20004000 0x600>;
+			reg-names = "aes", "sec_eng";
+			interrupts = <26 1>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		uart0: uart@2000a000 {
 			compatible = "bflb,uart";
 			reg = <0x2000a000 0x100>;

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -172,6 +172,24 @@
 			status = "disabled";
 		};
 
+		sec_eng_sha: sha@40004000 {
+			compatible = "bflb,sec-eng-sha";
+			reg = <0x40004000 0x100>, <0x40004000 0x600>;
+			reg-names = "sha", "sec_eng";
+			interrupts = <30 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
+		sec_eng_aes: aes@40004100 {
+			compatible = "bflb,sec-eng-aes";
+			reg = <0x40004100 0x100>, <0x40004000 0x600>;
+			reg-names = "aes", "sec_eng";
+			interrupts = <29 0>;
+			interrupt-parent = <&clic>;
+			status = "disabled";
+		};
+
 		efuse: efuse@40007000 {
 			compatible = "bflb,efuse";
 			reg = <0x40007000 0x1000>;

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -41,6 +41,8 @@ LOG_MODULE_REGISTER(main);
 #define CRYPTO_DEV_COMPAT espressif_esp32_aes
 #elif DT_HAS_COMPAT_STATUS_OKAY(sifli_sf32lb_crypto)
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
+#elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_aes)
+#define CRYPTO_DEV_COMPAT bflb_sec_eng_aes
 #else
 #error "You need to enable one crypto device"
 #endif

--- a/tests/crypto/crypto_aes/src/main.c
+++ b/tests/crypto/crypto_aes/src/main.c
@@ -20,6 +20,8 @@
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
 #elif CONFIG_CRYPTO_STM32
 #define CRYPTO_DEV_COMPAT st_stm32_cryp
+#elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_aes)
+#define CRYPTO_DEV_COMPAT bflb_sec_eng_aes
 #else
 #error "You need to enable one crypto device"
 #endif

--- a/tests/crypto/crypto_hash/src/main.c
+++ b/tests/crypto/crypto_hash/src/main.c
@@ -25,6 +25,8 @@
 #define CRYPTO_DEV_COMPAT raspberrypi_pico_sha256
 #elif DT_HAS_COMPAT_STATUS_OKAY(sifli_sf32lb_crypto)
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
+#elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_sha)
+#define CRYPTO_DEV_COMPAT bflb_sec_eng_sha
 #else
 #error "You need to enable one crypto device"
 #endif


### PR DESCRIPTION
 ## Summary

Add hardware crypto drivers for the Bouffalo Lab SEC Engine (SEC_ENG), a peripheral present on BL602, BL616, BL702, and BL702L SoCs. The SEC_ENG block contains several independent accelerators sharing a common register space at `SEC_ENG_BASE`. Each sub-block is exposed as a separate Zephyr driver with its own DT compatible:

- **AES** (`bflb,sec-eng-aes`): ECB, CBC, and CTR modes with
  128/192/256-bit keys. Implements the Zephyr `crypto` cipher API.
- **SHA** (`bflb,sec-eng-sha`): SHA-224 and SHA-256 hardware hashing.
  Implements the Zephyr `crypto` hash API. (SHA-384/512 register fields exist but are not listed as supported and wont produce correct output anyway)

## Test plan

- [x] `samples/drivers/crypto`
- [x] `tests/crypto/crypto_aes`
- [x] `tests/crypto/crypto_hash`
- [x] `tests/crypto/mbedtls_psa`
- [x] `tests/crypto/secp256r1`