### PR TITLE
net: wifi: pre-computed PBKDF2 key support

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -324,6 +324,8 @@ const char *wifi_bandwidth_txt(enum wifi_frequency_bandwidths bandwidth);
 #define WIFI_PSK_MAX_LEN 64
 /** Maximum WEP key length (WEP-104: 26 hex chars) */
 #define WIFI_WEP_KEY_MAX_LEN 26
+/** Length of the PBKDF2 key */
+#define WIFI_PSK_PBKDF2_KEY_LEN 32
 /** Max SAW password length */
 #define WIFI_SAE_PSWD_MAX_LEN 128
 /** MAC address length */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -684,6 +684,12 @@ struct wifi_connect_req_params {
 	const uint8_t *psk;
 	/** Pre-shared key length */
 	uint8_t psk_length; /* Min 8 - Max 64 */
+	/**
+	 * Pre-shared key is the pre-computed PBKDF2 output.
+	 * `psk_length` MUST be 32 bytes.
+	 * Only applicable for PSK based security types.
+	 */
+	bool psk_is_pbkdf2;
 	/** SAE password (same as PSK but with no length restrictions), optional */
 	const uint8_t *sae_password;
 	/** SAE password length */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -644,6 +644,60 @@ static void wpas_remove_certs(struct wpa_supplicant *wpa_s)
 }
 #endif
 
+static void pbkdf2_string_format(const uint8_t *psk, char output[WIFI_PSK_MAX_LEN + 1])
+{
+	uint8_t rem_len = WIFI_PSK_MAX_LEN + 1;
+
+	/* Chunk the formatting into 4 byte groups to reduce overhead */
+	for (int i = 0; i < WIFI_PSK_PBKDF2_KEY_LEN; i += 4) {
+		snprintf(output + (2 * i), rem_len, "%02x%02x%02x%02x", psk[i + 0], psk[i + 1],
+			 psk[i + 2], psk[i + 3]);
+		rem_len -= 8;
+	}
+}
+
+static int psk_validate(struct wifi_connect_req_params *params,
+			uint8_t output[WIFI_PSK_MAX_LEN + 1])
+{
+	if (params->psk == NULL ||
+	    params->security == WIFI_SECURITY_TYPE_WEP ||
+	    params->security == WIFI_SECURITY_TYPE_WEP_OPEN ||
+	    params->security == WIFI_SECURITY_TYPE_WEP_SHARED) {
+		/* No PSK or length validation not required */
+		return 0;
+	}
+
+	if (params->psk_is_pbkdf2) {
+		if ((params->security != WIFI_SECURITY_TYPE_PSK) &&
+		    (params->security != WIFI_SECURITY_TYPE_PSK_SHA256) &&
+		    (params->security != WIFI_SECURITY_TYPE_WPA_PSK) &&
+		    (params->security != WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL)) {
+			wpa_printf(MSG_ERROR,
+				   "PBKDF2 not supported for mode %d", params->security);
+			return -EINVAL;
+		}
+		if (params->psk_length != WIFI_PSK_PBKDF2_KEY_LEN) {
+			wpa_printf(MSG_ERROR,
+				   "PBKDF2 key must be %d bytes",
+				   WIFI_PSK_PBKDF2_KEY_LEN);
+			return -EINVAL;
+		}
+		/* Convert byte array to hex string */
+		pbkdf2_string_format(params->psk, output);
+	} else {
+		if ((params->psk_length < WIFI_PSK_MIN_LEN) ||
+			(params->psk_length > WIFI_PSK_MAX_LEN)) {
+			wpa_printf(MSG_ERROR,
+					"Passphrase should be in range (%d-%d) characters",
+					WIFI_PSK_MIN_LEN, WIFI_PSK_MAX_LEN);
+			return -EINVAL;
+		}
+		strncpy(output, params->psk, WIFI_PSK_MAX_LEN);
+		output[params->psk_length] = '\0';
+	}
+	return 0;
+}
+
 static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				       struct wifi_connect_req_params *params,
 				       bool mode_ap)
@@ -665,6 +719,9 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 
 	wpas_remove_certs(wpa_s);
 #endif
+
+	/* Enforce NULL terminated PSK in all code paths */
+	psk_null_terminated[0] = '\0';
 
 	if (wpa_s->ctrl_conn == NULL) {
 		wpa_printf(MSG_ERROR, "Control interface not ready");
@@ -741,19 +798,9 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 	}
 
 	if (params->security != WIFI_SECURITY_TYPE_NONE) {
-		if (params->psk &&
-		    params->security != WIFI_SECURITY_TYPE_WEP &&
-		    params->security != WIFI_SECURITY_TYPE_WEP_OPEN &&
-		    params->security != WIFI_SECURITY_TYPE_WEP_SHARED) {
-			if ((params->psk_length < WIFI_PSK_MIN_LEN) ||
-			    (params->psk_length > WIFI_PSK_MAX_LEN)) {
-				wpa_printf(MSG_ERROR,
-					   "Passphrase should be in range (%d-%d) characters",
-					   WIFI_PSK_MIN_LEN, WIFI_PSK_MAX_LEN);
-				goto out;
-			}
-			strncpy(psk_null_terminated, params->psk, WIFI_PSK_MAX_LEN);
-			psk_null_terminated[params->psk_length] = '\0';
+		/* PSK validation */
+		if (psk_validate(params, psk_null_terminated) < 0) {
+			goto out;
 		}
 
 		/* SAP - only open and WPA2-PSK are supported for now */
@@ -774,6 +821,11 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 		}
+
+		/* Pre-computed key has no quotes */
+		const char *psk_format = params->psk_is_pbkdf2 ?
+			"set_network %d psk %s" :
+			"set_network %d psk \"%s\"";
 
 		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON) &&
 		    (params->security == WIFI_SECURITY_TYPE_SAE_HNP ||
@@ -856,8 +908,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 		}
 #endif
 		else if (params->security == WIFI_SECURITY_TYPE_PSK_SHA256) {
-			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"",
-					   resp.network_id, psk_null_terminated)) {
+			if (!wpa_cli_cmd_v(psk_format, resp.network_id, psk_null_terminated)) {
 				goto out;
 			}
 
@@ -875,8 +926,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 			}
 		} else if (params->security == WIFI_SECURITY_TYPE_PSK ||
 			   params->security == WIFI_SECURITY_TYPE_WPA_PSK) {
-			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"",
-					   resp.network_id, psk_null_terminated)) {
+			if (!wpa_cli_cmd_v(psk_format, resp.network_id, psk_null_terminated)) {
 				goto out;
 			}
 
@@ -900,8 +950,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
-			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"", resp.network_id,
-					   psk_null_terminated)) {
+			if (!wpa_cli_cmd_v(psk_format, resp.network_id, psk_null_terminated)) {
 				goto out;
 			}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -39,6 +39,11 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #include <zephyr/net/wifi_certs.h>
 #endif
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
+#include "utils/common.h"
+#include "sha1.h"
+#endif
+
 #define WIFI_SHELL_MODULE "wifi"
 
 #define WIFI_SHELL_MGMT_EVENTS (            \
@@ -855,6 +860,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"ssid", sys_getopt_required_argument, 0, 's'},
 		{"passphrase", sys_getopt_required_argument, 0, 'p'},
 		{"key-mgmt", sys_getopt_required_argument, 0, 'k'},
+		{"pbkdf2", sys_getopt_no_argument, 0, 'D'},
 		{"ieee-80211w", sys_getopt_required_argument, 0, 'w'},
 		{"bssid", sys_getopt_required_argument, 0, 'm'},
 		{"band", sys_getopt_required_argument, 0, 'b'},
@@ -949,6 +955,9 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		case 'p':
 			params->psk = state->optarg;
 			params->psk_length = strlen(params->psk);
+			break;
+		case 'D':
+			params->psk_is_pbkdf2 = true;
 			break;
 		case 'c':
 			channel = strtol(state->optarg, &endptr, 10);
@@ -1237,6 +1246,35 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	if (params->ignore_broadcast_ssid > 2) {
 		PR_ERROR("Invalid ignore_broadcast_ssid value\n");
 		return -EINVAL;
+	}
+
+	if (params->psk_is_pbkdf2) {
+		/* params->security also required, but hard to enumerate exhaustively */
+		if (params->psk == NULL) {
+			PR_ERROR("--pbkdf2 requires a PSK\n");
+			return -EINVAL;
+		}
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
+		static uint8_t pbkdf2_precomputed[WIFI_PSK_PBKDF2_KEY_LEN];
+		uint32_t start_ms = k_uptime_get_32();
+
+		/* Precompute the PBKDF2 output */
+		PR("Starting computation of PBKDF2 output\n");
+		ret = pbkdf2_sha1(params->psk, params->ssid, params->ssid_length, 4096,
+					pbkdf2_precomputed, sizeof(pbkdf2_precomputed));
+		if (ret < 0) {
+			PR_ERROR("PBKDF2 computation failed (%d)\n", ret);
+			return ret;
+		}
+		PR("PBKDF2 computation complete in %u ms\n", k_uptime_get_32() - start_ms);
+
+		/* Overwrite PSK string with the precomputed PBKDF2 output */
+		params->psk = pbkdf2_precomputed;
+		params->psk_length = WIFI_PSK_PBKDF2_KEY_LEN;
+#else
+		PR_ERROR("PBKDF2 computation only supported with WPA Supplicant\n");
+		return -ENOSYS;
+#endif
 	}
 
 	return 0;
@@ -5292,6 +5330,7 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 			    "7:EAP-TLS, 8:WEP, 9:WPA-PSK, 10:WPA-Auto-Personal, 11:DPP, "
 			    "12:EAP-PEAP-MSCHAPv2, 13:EAP-PEAP-GTC, 14:EAP-TTLS-MSCHAPv2, "
 			    "15:EAP-PEAP-TLS, 20:SAE-EXT-KEY, 21:WEP-OPEN, 22:WEP-SHARED\n"
+			    "[--pbkdf2] Precompute PBKDF2 credentials (valid only for PSK types)\n"
 			    "[-w, --ieee-80211w]: MFP (optional: needs security type to be "
 			    "specified): 0:Disable, 1:Optional, 2:Required\n"
 			    "[-m, --bssid]: MAC address of the AP (BSSID)\n"
@@ -5320,7 +5359,7 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 			    "[-C, --ssid-protection]: Whether to use SSID protection in\n"
 			    "4-way handshake: 0:Disable, 1:Enable"),
 		 cmd_wifi_connect,
-		 2, 48);
+		 2, 49);
 
 SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
 		 SHELL_HELP("Disconnect from the Wi-Fi AP",


### PR DESCRIPTION
Add support to the API for signifying that the provided PSK is the pre-computed PBKDF2 output, instead of the ASCII passphrase. For drivers that support that option, it allows for significant execution time optimisations, as the computation has been measured as taking over 700ms on a 128MHz Cortex-M33 (nRF54L15). Computing the PBKDF2 value is left for the caller to implement.

Support for this option is added to the HostAP (wpa_supplicant) driver.

An example of a downstream project implementing the caching can be found here: https://github.com/Embeint/infuse-sdk/pull/839