### PR TITLE
arch: arm: cortex_a_r: make cache enable functions idempotent

### DIFF
--- a/arch/arm/core/cortex_a_r/cache.c
+++ b/arch/arm/core/cortex_a_r/cache.c
@@ -50,9 +50,18 @@ void arch_dcache_enable(void)
 {
 	uint32_t val;
 
+	val = __get_SCTLR();
+
+	/* Check if cache is already enabled */
+	if (val & SCTLR_C_Msk) {
+		/* Cache already enabled - clean and invalidate to ensure coherency */
+		L1C_CleanInvalidateDCacheAll();
+		return;
+	}
+
+	/* Cache not enabled - safe to invalidate (no dirty lines) */
 	arch_dcache_invd_all();
 
-	val = __get_SCTLR();
 	val |= SCTLR_C_Msk;
 	barrier_dsync_fence_full();
 	__set_SCTLR(val);
@@ -173,8 +182,20 @@ int arch_dcache_flush_and_invd_range(void *start_addr, size_t size)
 
 void arch_icache_enable(void)
 {
+	uint32_t val;
+
+	val = __get_SCTLR();
+
+	/* Check if cache is already enabled */
+	if (val & SCTLR_I_Msk) {
+		/* I-cache already enabled - invalidate to ensure coherency */
+		L1C_InvalidateICacheAll();
+		return;
+	}
+
+	/* Cache not enabled - invalidate before enabling */
 	arch_icache_invd_all();
-	__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
+	__set_SCTLR(val | SCTLR_I_Msk);
 	barrier_isync_fence_full();
 }
 


### PR DESCRIPTION
The arch_dcache_enable() and arch_icache_enable() functions could cause system crashes when called on caches that were already enabled. This occurs because arch_dcache_invd_all() invalidates the entire cache without first flushing dirty data, leading to memory corruption when the cache was previously enabled.

This scenario happens in cache tests where test setup calls sys_cache_data_enable(), but the SoC early init hook has already enabled caches during boot.

Fix by checking the SCTLR register before performing cache operations:
- If D-cache is already enabled, perform clean+invalidate instead of just invalidate to preserve dirty cache lines
- If I-cache is already enabled, perform invalidate only (no dirty lines in I-cache)
- If cache is not enabled, proceed with normal enable sequence

This makes the enable functions safe to call multiple times without risking data corruption or system crashes.