### PR TITLE
Add DAC driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -54,4 +54,11 @@
 				 <PC3B_ADC1_AIN5>;	/* J900 pin 8 - AN */
 		};
 	};
+
+	dac_default: dac_default {
+		group1 {
+			pinmux = <PA2B_DAC_VOUT0>,	/* J600 pin 1 */
+				 <PA5B_DAC_VOUT1>;	/* J600 pin 3 */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -186,6 +186,12 @@
 			gclkperiph-src = "gclk1";
 			gclkperiph-en = <0>;
 		};
+
+		dac {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
 	};
 
 	mclkperiph: mclkperiph {
@@ -278,4 +284,18 @@
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&dac {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+	refsel = "int_ref";
+	status = "okay";
+
+	dac0: channel@0 {
+		reg = <0>;
+		rate = <1000>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -14,6 +14,7 @@ supported:
   - clock_control
   - comparator
   - counter
+  - dac
   - dma
   - entropy
   - flash

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -54,4 +54,11 @@
 				 <PC3B_ADC1_AIN5>;	/* J900 pin 8 - AN */
 		};
 	};
+
+	dac_default: dac_default {
+		group1 {
+			pinmux = <PA2B_DAC_VOUT0>,	/* J600 pin 1 */
+				 <PA5B_DAC_VOUT1>;	/* J600 pin 3 */
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -180,6 +180,12 @@
 			gclkperiph-src = "gclk1";
 			gclkperiph-en = <0>;
 		};
+
+		dac {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			gclkperiph-src = "gclk1";
+			gclkperiph-en = <0>;
+		};
 	};
 
 	mclkperiph: mclkperiph {
@@ -272,4 +278,18 @@
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&dac {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+	refsel = "int_ref";
+	status = "okay";
+
+	dac0: channel@0 {
+		reg = <0>;
+		rate = <1000>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -14,6 +14,7 @@ supported:
   - clock_control
   - comparator
   - counter
+  - dac
   - dma
   - entropy
   - flash

--- a/drivers/dac/Kconfig.mchp
+++ b/drivers/dac/Kconfig.mchp
@@ -16,4 +16,22 @@ config DAC_MCHP_G1_DIFFERENTIAL
 	help
 	  Enable Differential Mode support for G1 DAC
 
+config DAC_MCHP_G1_REFRESH
+	bool "Refresh Period"
+	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	help
+	  Enable refresh period support for G1 DAC
+
+config DAC_MCHP_G1_EXTERNAL_FILTER
+	bool "External Filter"
+	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	help
+	  Enable External Filter support for G1 DAC
+
+config DAC_MCHP_G1_OVERSAMPLING_RATIO
+	bool "Oversampling Ratio"
+	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	help
+	  Enable Oversampling Ratio support for G1 DAC
+
 endif # DAC_MCHP_G1

--- a/drivers/dac/dac_mchp_g1.c
+++ b/drivers/dac/dac_mchp_g1.c
@@ -154,6 +154,7 @@ static void dac_conversion_speed(dac_registers_t *dac_reg, int rate, uint8_t cha
 		(dac_reg->DAC_DACCTRL[channel_id] & ~DAC_DACCTRL_CCTRL_Msk) | cctrl_val;
 }
 
+#if defined(CONFIG_DAC_MCHP_G1_EXTERNAL_FILTER)
 static inline void dac_external_filter(dac_registers_t *dac_reg, bool ext_filter,
 				       uint8_t channel_id)
 {
@@ -161,6 +162,7 @@ static inline void dac_external_filter(dac_registers_t *dac_reg, bool ext_filter
 		(dac_reg->DAC_DACCTRL[channel_id] & ~DAC_DACCTRL_FEXT_Msk) |
 		DAC_DACCTRL_FEXT(ext_filter);
 }
+#endif /* CONFIG_DAC_MCHP_G1_EXTERNAL_FILTER */
 
 static inline void dac_data_adj(dac_registers_t *dac_reg, uint8_t data_adj, uint8_t channel_id)
 {
@@ -176,6 +178,7 @@ static inline void dac_dither(dac_registers_t *dac_reg, uint8_t dither, uint8_t 
 		DAC_DACCTRL_DITHER(dither);
 }
 
+#if defined(CONFIG_DAC_MCHP_G1_REFRESH)
 static inline void dac_refresh(dac_registers_t *dac_reg, uint8_t refresh, uint8_t channel_id)
 {
 	if (refresh != 0) {
@@ -185,7 +188,9 @@ static inline void dac_refresh(dac_registers_t *dac_reg, uint8_t refresh, uint8_
 		(dac_reg->DAC_DACCTRL[channel_id] & ~DAC_DACCTRL_REFRESH_Msk) |
 		DAC_DACCTRL_REFRESH(refresh);
 }
+#endif /* CONFIG_DAC_MCHP_G1_REFRESH */
 
+#if defined(CONFIG_DAC_MCHP_G1_OVERSAMPLING_RATIO)
 static void dac_sampling_ratio(dac_registers_t *dac_reg, uint8_t sampling_ratio, uint8_t channel_id)
 {
 	uint8_t osr;
@@ -214,6 +219,7 @@ static void dac_sampling_ratio(dac_registers_t *dac_reg, uint8_t sampling_ratio,
 	dac_reg->DAC_DACCTRL[channel_id] =
 		(dac_reg->DAC_DACCTRL[channel_id] & ~DAC_DACCTRL_OSR_Msk) | DAC_DACCTRL_OSR(osr);
 }
+#endif /* CONFIG_DAC_MCHP_G1_OVERSAMPLING_RATIO */
 
 static void dac_write_channel(dac_registers_t *dac_reg, const struct dac_mchp_channel *ch_cfg,
 			      uint8_t channel_id, uint32_t value)
@@ -280,20 +286,30 @@ static int dac_configure(const struct device *dev, uint8_t channel_id)
 		/* Set the Dither */
 		dac_dither(dev_cfg->regs, dev_cfg->channels[i].dither, i);
 
+#if defined(CONFIG_DAC_MCHP_G1_REFRESH)
+
 		/* Set the refresh period */
 		if (dev_cfg->channels[i].sampling_ratio != 1) {
 			dac_refresh(dev_cfg->regs, 0, i);
 		} else {
 			dac_refresh(dev_cfg->regs, dev_cfg->channels[i].refresh, i);
 		}
+#endif /* CONFIG_DAC_MCHP_G1_REFRESH */
+
 		/* Set the conversion speed */
 		dac_conversion_speed(dev_cfg->regs, dev_cfg->channels[i].rate, i);
 
+#if defined(CONFIG_DAC_MCHP_G1_EXTERNAL_FILTER)
+
 		/* Set the External filter */
 		dac_external_filter(dev_cfg->regs, dev_cfg->channels[i].ext_filter, i);
+#endif /* CONFIG_DAC_MCHP_G1_EXTERNAL_FILTER */
+
+#if defined(CONFIG_DAC_MCHP_G1_OVERSAMPLING_RATIO)
 
 		/* Set the Oversampling Ratio */
 		dac_sampling_ratio(dev_cfg->regs, dev_cfg->channels[i].sampling_ratio, i);
+#endif /* CONFIG_DAC_MCHP_G1_OVERSAMPLING_RATIO */
 	}
 
 	return 0;

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -448,6 +448,22 @@
 			status = "disabled";
 		};
 
+		dac: dac@43002400 {
+			compatible = "microchip,dac-g1";
+			reg = <0x43002400 0x1e>;
+			interrupts = <123 0>, <124 0>, <125 0>, <126 0>, <127 0>;
+			interrupt-names = "overrun_underrun",
+					  "empty0",
+					  "empty1",
+					  "resrdy0",
+					  "resrdy1";
+			#io-channel-cells = <1>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_DAC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_DAC>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
 		tcc4: tcc@43001000 {
 			compatible = "microchip,tcc-g1";
 			reg = <0x43001000 0x2000>;

--- a/tests/drivers/dac/dac_api/boards/pic32cx_sg41_cult.conf
+++ b/tests/drivers/dac/dac_api/boards/pic32cx_sg41_cult.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -88,7 +88,8 @@
 	defined(CONFIG_BOARD_MIMXRT1180_EVK) || \
 	defined(CONFIG_BOARD_FRDM_MCXC444)   || \
 	defined(CONFIG_BOARD_PHYBOARD_ATLAS) || \
-	defined(CONFIG_BOARD_SAM_E54_XPRO)
+	defined(CONFIG_BOARD_SAM_E54_XPRO) || \
+	defined(CONFIG_BOARD_PIC32CX_SG41_CULT)
 /* clang-format on */
 
 #define DAC_DEVICE_NODE		DT_NODELABEL(dac)

--- a/tests/drivers/dac/dac_api/testcase.yaml
+++ b/tests/drivers/dac/dac_api/testcase.yaml
@@ -7,3 +7,5 @@ tests:
   drivers.dac.api:
     depends_on: dac
     min_ram: 16
+    platform_exclude:
+      - pic32cx_sg61_cult

--- a/tests/drivers/dac/dac_loopback/boards/pic32cx_sg41_cult.conf
+++ b/tests/drivers/dac/dac_loopback/boards/pic32cx_sg41_cult.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DAC_BUFFER_NOT_SUPPORT=y

--- a/tests/drivers/dac/dac_loopback/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* DAC0 internally connected to ADC channel 30*/
+
+&dac {
+	refsel = "vdd_ana";
+
+	dac0: channel@0 {
+		data-adj = "right";
+	};
+};
+
+&adc0 {
+	prescaler = <16>;
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -202,7 +202,10 @@
 #define ADC_CHANNEL_ID		0
 #define ADC_1ST_CHANNEL_INPUT	IADC_INPUT_DAC0
 
-#elif defined(CONFIG_BOARD_SAM_E54_XPRO)
+/* clang-format off */
+#elif defined(CONFIG_BOARD_SAM_E54_XPRO) || \
+	defined(CONFIG_BOARD_PIC32CX_SG41_CULT)
+/* clang-format on */
 
 /*  DAC0 internally connected to ADC channel 30 */
 #define DAC_DEVICE_NODE DT_NODELABEL(dac)
@@ -214,8 +217,8 @@
 #define ADC_GAIN             ADC_GAIN_1
 #define ADC_REFERENCE        ADC_REF_VDD_1
 #define ADC_ACQUISITION_TIME ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 4)
-#define ADC_CHANNEL_ID       1
-#define ADC_INPUT_POSITIVE   30
+#define ADC_CHANNEL_ID       0
+#define ADC_INPUT_POSITIVE   MCHP_ADC_DAC0
 
 #else
 #error "Unsupported board."

--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -34,5 +34,6 @@ tests:
       - xg24_ek2703a
       - xg24_rb4187c
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     integration_platforms:
       - nucleo_f207zg


### PR DESCRIPTION
- Add device tree nodes for PIC32CX_SG.
- Update DAC G1 driver implementation to support PIC32CX_SG
-  Update the board metadata to list DAC as a supported feature on the pic32cx_sg41_cult and sg61 board.
- Add board overlay file for pic32cx_sg41_cult to enable dac test cases to run on this boards.