### PR TITLE
usb: device_next: usbd_cdc_ncm: correct net_if_carrier use

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -635,6 +635,7 @@ static void ncm_handle_notifications(const struct device *dev, const int err)
 	if (data->if_state == IF_STATE_CONNECTION_STATUS_SUBMITTED) {
 		data->if_state = IF_STATE_CONNECTION_STATUS_SENT;
 		LOG_INF("Connection status sent");
+		net_if_carrier_on(data->iface);
 	}
 }
 
@@ -840,6 +841,7 @@ static void usbd_cdc_ncm_update(struct usbd_class_data *const c_data,
 
 	if (data_iface == iface && alternate == 0) {
 		atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
+		net_if_carrier_off(data->iface);
 		data->tx_seq = 0;
 		data->rx_seq = 0;
 	}
@@ -867,6 +869,8 @@ static void usbd_cdc_ncm_disable(struct usbd_class_data *const c_data)
 
 	atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
 	atomic_clear_bit(&data->state, CDC_NCM_CLASS_SUSPENDED);
+
+	net_if_carrier_off(data->iface);
 
 	LOG_INF("Disabled %s", c_data->name);
 }
@@ -1126,7 +1130,6 @@ static int cdc_ncm_iface_start(const struct device *dev)
 	LOG_DBG("Start interface %d", net_if_get_by_iface(data->iface));
 
 	atomic_set_bit(&data->state, CDC_NCM_IFACE_UP);
-	net_if_carrier_on(data->iface);
 
 	if (atomic_test_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED)) {
 		(void)k_work_reschedule(&data->notif_work, K_MSEC(1));


### PR DESCRIPTION
net_if_carrier is to be used independently of the
administrative state (start and stop of the ethernet_api).

This way we are able to detect a "reconnect" of the USB cable, unfortunatly we can't detect a disconnection on it's own, but we can detect a reconnection and thus trigger the carrier state change. And therefore we can trigger the DHCP client to get a new IP address.

Split from https://github.com/zephyrproject-rtos/zephyr/pull/100809