### PR TITLE
arm64: Enable CNTPS for EL1

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -105,7 +105,6 @@ void z_arm64_el3_init(void)
 #endif
 	reg |= (SCR_RES1 |		/* RES1 */
 		SCR_RW_BIT |		/* EL2 execution state is AArch64 */
-		SCR_ST_BIT |		/* Do not trap EL1 accesses to timer */
 		SCR_HCE_BIT |		/* Do not trap HVC */
 		SCR_SMD_BIT);		/* Do not trap SMC */
 #ifdef CONFIG_ARM_PAC
@@ -113,6 +112,12 @@ void z_arm64_el3_init(void)
 		SCR_API_BIT);		/* Do not trap pointer authentication instructions */
 #endif
 	write_scr_el3(reg);
+	/*
+	 * With SCR_ST_BIT == 0, a CNTPS interrupt is taken to Secure EL1 when
+	 * CNTPS_CTL_EL1.ENABLE = 1. Program CVAL to the maximum 64-bit value
+	 * first to prevent an immediate interrupt on enable.
+	 */
+	write_cntps_cval_el1(~(uint64_t)0);
 
 #if defined(CONFIG_GIC_V3)
 	reg = read_sysreg(ICC_SRE_EL3);
@@ -289,10 +294,6 @@ void z_arm64_el1_init(void)
 
 	write_cntv_cval_el0(~(uint64_t)0);
 	write_cntp_cval_el0(~(uint64_t)0);
-	/*
-	 * Enable secure cntps if/when we use the corresponding timer.
-	 * write_cntps_cval_el1(~(uint64_t)0);
-	 */
 
 	z_arm64_el1_plat_init();
 

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -65,6 +65,7 @@ MAKE_REG_HELPER(cnthps_ctl_el2);
 MAKE_REG_HELPER(cntv_ctl_el0)
 MAKE_REG_HELPER(cntv_cval_el0)
 MAKE_REG_HELPER(cntp_cval_el0)
+MAKE_REG_HELPER(cntps_cval_el1)
 MAKE_REG_HELPER(cntvct_el0);
 MAKE_REG_HELPER(cntvoff_el2);
 MAKE_REG_HELPER(currentel);


### PR DESCRIPTION
Setting SCR_ST_BIT actually traps CNTPS access to EL3, opposite to what the comment says.
 Remove to allow secure EL1 access. Also start CNTPS counter.