### PR TITLE
dts: arm: nxp: mcxn94x: add ranges property to flash node

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -742,6 +742,9 @@
 			reg = <0 DT_SIZE_M(2)>;
 			erase-block-size = <DT_SIZE_K(8)>;
 			write-block-size = <16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 
 		uuid: uuid@1100000 {


### PR DESCRIPTION
Add the `ranges;` property to the flash@0 node to properly propagate address translations from the parent flash-controller to child partition nodes.

This PR should fix the: https://github.com/zephyrproject-rtos/zephyr/issues/103355

before this PR:
```
grep -E "CONFIG_FLASH_LOAD_OFFSET|CONFIG_FLASH_BASE_ADDRESS|CONFIG_FLASH_SIZE|CONFIG_XIP|CONFIG_FLASH_CODE_PARTITION_ADDRESS_INVALID" build/remote/zephyr/.config
CONFIG_FLASH_SIZE=2048
CONFIG_FLASH_BASE_ADDRESS=0x10000000
CONFIG_XIP=y
CONFIG_FLASH_LOAD_OFFSET=0x10a000
CONFIG_FLASH_CODE_PARTITION_ADDRESS_INVALID=y
```

After this fix:
```
grep -E "CONFIG_FLASH_LOAD_OFFSET|CONFIG_FLASH_BASE_ADDRESS|CONFIG_FLASH_SIZE|CONFIG_XIP|CONFIG_FLASH_CODE_PARTITION_ADDRESS_INVALID" build/remote/zephyr/.config
CONFIG_FLASH_SIZE=2048
CONFIG_FLASH_BASE_ADDRESS=0x10000000
CONFIG_XIP=y
CONFIG_FLASH_LOAD_OFFSET=0x10a000
```