### PR TITLE
sys: util: Introduce ZTESTABLE_STATIC macro & use it instead of (re-)defining STATIC

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -1189,6 +1189,19 @@ static ALWAYS_INLINE uint64_t sys_lcm_s(int32_t a, int32_t b)
 	})
 
 /**
+ * @brief Define symbol as static unless we are building with ZTEST.
+ *
+ * Define the annotated symbol (function or variable) as static (private to the translation unit),
+ * unless we are building with ZTEST. This macro can be used to define private symbols which need
+ * to be accessible from tests.
+ */
+#ifdef CONFIG_ZTEST
+#define ZTESTABLE_STATIC
+#else
+#define ZTESTABLE_STATIC static
+#endif
+
+/**
  * @}
  */
 

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -27,11 +27,7 @@
 #include "common/bt_shell_private.h"
 
 #define GOEP_MOPL CONFIG_BT_GOEP_RFCOMM_MTU
-#ifdef CONFIG_ZTEST
-#define STATIC
-#else
-#define STATIC static
-#endif
+
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_MAX_CONN, BT_RFCOMM_BUF_SIZE(GOEP_MOPL),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
@@ -45,7 +41,7 @@ struct bt_goep_app {
 	struct net_buf *tx_buf;
 };
 
-STATIC struct bt_goep_app goep_app;
+ZTESTABLE_STATIC struct bt_goep_app goep_app;
 
 static struct bt_goep_transport_rfcomm_server rfcomm_server;
 static struct bt_goep_transport_l2cap_server l2cap_server;
@@ -53,9 +49,9 @@ static struct bt_goep_transport_l2cap_server l2cap_server;
 #define TLV_COUNT       3
 #define TLV_BUFFER_SIZE 64
 
-STATIC struct bt_obex_tlv tlvs[TLV_COUNT];
-STATIC uint8_t tlv_buffers[TLV_COUNT][TLV_BUFFER_SIZE];
-STATIC uint8_t tlv_count;
+ZTESTABLE_STATIC struct bt_obex_tlv tlvs[TLV_COUNT];
+ZTESTABLE_STATIC uint8_t tlv_buffers[TLV_COUNT][TLV_BUFFER_SIZE];
+ZTESTABLE_STATIC uint8_t tlv_count;
 
 static struct bt_goep_app *goep_alloc(struct bt_conn *conn)
 {
@@ -184,7 +180,7 @@ static void goep_server_action(struct bt_obex_server *server, bool final, struct
 	goep_parse_headers(buf);
 }
 
-STATIC struct bt_obex_server_ops goep_server_ops = {
+ZTESTABLE_STATIC struct bt_obex_server_ops goep_server_ops = {
 	.connect = goep_server_connect,
 	.disconnect = goep_server_disconnect,
 	.put = goep_server_put,
@@ -248,7 +244,7 @@ static void goep_client_action(struct bt_obex_client *client, uint8_t rsp_code,
 	goep_parse_headers(buf);
 }
 
-STATIC struct bt_obex_client_ops goep_client_ops = {
+ZTESTABLE_STATIC struct bt_obex_client_ops goep_client_ops = {
 	.connect = goep_client_connect,
 	.disconnect = goep_client_disconnect,
 	.put = goep_client_put,

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -27,11 +27,7 @@
 #include "common/bt_shell_private.h"
 
 #define HELP_NONE "[none]"
-#ifdef CONFIG_ZTEST
-#define STATIC
-#else
-#define STATIC static
-#endif
+
 extern struct bt_conn *default_conn;
 
 #if defined(CONFIG_BT_HFP_HF)
@@ -316,7 +312,7 @@ void hf_query_call(struct bt_hfp_hf *hf, struct bt_hfp_hf_current_call *call)
 }
 #endif /* CONFIG_BT_HFP_HF_ECS */
 
-STATIC struct bt_hfp_hf_cb hf_cb = {
+ZTESTABLE_STATIC struct bt_hfp_hf_cb hf_cb = {
 	.connected = hf_connected,
 	.disconnected = hf_disconnected,
 	.sco_connected = hf_sco_connected,
@@ -1403,7 +1399,7 @@ void ag_hf_indicator_value(struct bt_hfp_ag *ag, enum hfp_ag_hf_indicators indic
 	bt_shell_print("indicator %d value %d", indicator, value);
 }
 
-STATIC struct bt_hfp_ag_cb ag_cb = {
+ZTESTABLE_STATIC struct bt_hfp_ag_cb ag_cb = {
 	.connected = ag_connected,
 	.disconnected = ag_disconnected,
 	.sco_connected = ag_sco_connected,

--- a/subsys/kvss/nvs/nvs.c
+++ b/subsys/kvss/nvs/nvs.c
@@ -17,12 +17,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
-#ifdef CONFIG_ZTEST
-#define STATIC
-#else
-#define STATIC static
-#endif
-
 static int nvs_prev_ate(struct nvs_fs *fs, uint32_t *addr, struct nvs_ate *ate);
 static int nvs_ate_valid(struct nvs_fs *fs, uint16_t entry_addr,
 			 const struct nvs_ate *entry);
@@ -112,8 +106,8 @@ static inline size_t nvs_al_size(struct nvs_fs *fs, size_t len)
  * may include a header, primary data, and a tail. All buffers are
  * written as a single contiguous stream.
  */
-STATIC int nvs_flash_al_wrt_streams(struct nvs_fs *fs, uint32_t addr,
-				    const struct nvs_flash_wrt_stream *strm)
+ZTESTABLE_STATIC int nvs_flash_al_wrt_streams(struct nvs_fs *fs, uint32_t addr,
+					      const struct nvs_flash_wrt_stream *strm)
 {
 	const struct flash_parameters *fp = fs->flash_parameters;
 	size_t wbs = fp->write_block_size;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -73,12 +73,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define OUTPUT_CONTEXT_IN_USE_MARK (enum coap_block_size)(-1)
 
-#ifdef CONFIG_ZTEST
-#define STATIC
-#else
-#define STATIC static
-#endif
-
 /* Resources */
 
 /* Shared set of in-flight LwM2M messages */
@@ -103,8 +97,8 @@ sys_slist_t *lwm2m_engine_obj_inst_list(void);
 
 static int handle_request(struct coap_packet *request, struct lwm2m_message *msg);
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
-STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num,
-				    enum coap_block_size block_size);
+ZTESTABLE_STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num,
+					      enum coap_block_size block_size);
 struct coap_block_context *lwm2m_output_block_context(void);
 #endif
 
@@ -213,7 +207,7 @@ static void free_block_ctx(struct lwm2m_block_context *ctx)
 }
 
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
-STATIC int request_output_block_ctx(struct coap_block_context **ctx)
+ZTESTABLE_STATIC int request_output_block_ctx(struct coap_block_context **ctx)
 {
 	int ret = -ENOMEM;
 	int i;
@@ -234,7 +228,7 @@ STATIC int request_output_block_ctx(struct coap_block_context **ctx)
 	return ret;
 }
 
-STATIC void release_output_block_ctx(struct coap_block_context **ctx)
+ZTESTABLE_STATIC void release_output_block_ctx(struct coap_block_context **ctx)
 {
 	int i;
 
@@ -280,8 +274,8 @@ static inline void release_body_encode_buffer(uint8_t **buffer)
 	}
 }
 
-STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num,
-				    enum coap_block_size block_size)
+ZTESTABLE_STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num,
+					      enum coap_block_size block_size)
 {
 	int ret;
 	uint16_t payload_size;
@@ -390,7 +384,7 @@ STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_nu
 	return 0;
 }
 
-STATIC int prepare_msg_for_send(struct lwm2m_message *msg)
+ZTESTABLE_STATIC int prepare_msg_for_send(struct lwm2m_message *msg)
 {
 	int ret;
 	/* save the big buffer for later use (splitting blocks) */


### PR DESCRIPTION
Introduce the macro ZTESTABLE_STATIC, which can be used to define private (static) symbols which otherwise need to be accessible from ztests.

And use this new macro in the 3 modules which were otherwise each (re)defining STATIC.

STATIC is a too common macro name, which is very likely to conflict with definitions in headers which may be included indirectly, as it has happened with the silabs hal, causing [15 failures in weekly](https://github.com/zephyrproject-rtos/zephyr/actions/runs/22269274740)

The macro is added in sys/util.h so it is available in general. Note that the ztest headers are only available when enabling CONFIG_ZTEST.

The failure in main can be repro'd for example with
```
mkdir build && cd build
cmake -GNinja -DBOARD=siwx917_rb4342a/siwg917m111mgtba ../tests/subsys/settings/nvs/ && ninja
```
