### PR TITLE
boards: heltec: Remove fb suffix from ssd1306 compatible

### DIFF
--- a/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
@@ -129,7 +129,7 @@
 	pinctrl-names = "default";
 
 	ssd1306_128x64: display-controller@3c {
-		compatible = "solomon,ssd1306fb";
+		compatible = "solomon,ssd1306";
 		reg = <0x3c>;
 		width = <128>;
 		height = <64>;


### PR DESCRIPTION
Update SSD1306 display controller compatible string from "solomon,ssd1306fb" to "solomon,ssd1306" to align with the Zephyr 4.4.0 display controller naming convention.


Fixes weekly CI issue:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/22269274740/job/64420887990#step:14:14575