### PR TITLE
drivers: gpio: stm32: add missing port "W" to list

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -791,10 +791,10 @@ __maybe_unused static int gpio_stm32_init(const struct device *dev)
  * !!!Keep both lists in sync!!!
  */
 #define GPIO_PORTS_LWR \
-	a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, x, y, z
+	a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z
 
 #define GPIO_PORTS_UPR \
-	A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, X, Y, Z
+	A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z
 
 #define DEVICE_INIT_IF_OKAY(idx, __suffix) \
 	GPIO_DEVICE_INIT_STM32_IF_OKAY(__suffix, GET_ARG_N(UTIL_INC(idx), GPIO_PORTS_UPR))


### PR DESCRIPTION
This was not noticed because there is currently no STM32 with a GPIOW port, but adding it to the list is better for future-proofing.