### PR TITLE
arch: arm: cortex_a_r: Use arch_early_memcpy in relocate_vector_table

### DIFF
--- a/arch/arm/core/cortex_a_r/reboot.c
+++ b/arch/arm/core/cortex_a_r/reboot.c
@@ -14,6 +14,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/common/init.h>
 
 #if defined(CONFIG_AARCH32_ARMV8_R)
 
@@ -46,7 +47,7 @@ void __weak relocate_vector_table(void)
 	!defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0)
 	write_sctlr(read_sctlr() & ~HIVECS);
 	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
-	(void)memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
+	(void)arch_early_memcpy(VECTOR_ADDRESS, _vector_start, vector_size);
 #endif
 }
 


### PR DESCRIPTION
relocate_vector_table is called as part of z_arm_reset. This is considered early-boot code before XIP.

At this stage, Program might not have access to optimized compiler APIs that reside in FLASH.
Thus, its better for relocate_vector_table to use z_early_memcpy.