### PR TITLE
logging: Add CONFIG_LOG_CORE_ID_PREFIX for multicore systems

### DIFF
--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -271,7 +271,8 @@ static void log_message_process(struct log_frontend_stmesp_demux_log *packet)
 	uint16_t dlen = packet->hdr.total_len - (plen + sname_len);
 	uint8_t *data = dlen ? &packet->data[plen + sname_len] : NULL;
 
-	log_output_process(&log_output, ts, dname, sname, NULL, level, package, data, dlen, flags);
+	log_output_process(&log_output, ts, dname, sname, NULL,
+			   0, level, package, data, dlen, flags);
 }
 
 /** @brief Process a trace point message. */
@@ -299,7 +300,7 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 		const char *source =
 			log_frontend_stmesp_demux_sname_get(packet->major, packet->source_id);
 
-		log_output_process(&log_output, packet->timestamp, dname, source, NULL, level,
+		log_output_process(&log_output, packet->timestamp, dname, source, NULL, 0, level,
 				   (const uint8_t *)tp_log, NULL, 0, flags);
 		return;
 	} else if (packet->has_data) {
@@ -308,7 +309,7 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 			.desc = {.len = 4 /* hdr + fmt + id + data */}};
 		uint32_t tp_d32_p[] = {(uint32_t)desc.raw, (uint32_t)tp_d32, id, packet->data};
 
-		log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 1,
+		log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0, 1,
 				   (const uint8_t *)tp_d32_p, NULL, 0, flags);
 		return;
 	}
@@ -316,7 +317,7 @@ static void trace_point_process(struct log_frontend_stmesp_demux_trace_point *pa
 	static const union cbprintf_package_hdr desc = {.desc = {.len = 3 /* hdr + fmt + id */}};
 	uint32_t tp_p[] = {(uint32_t)desc.raw, (uint32_t)tp, packet->id};
 
-	log_output_process(&log_output, packet->timestamp, dname, sname, NULL,
+	log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0,
 			   1, (const uint8_t *)tp_p, NULL, 0, flags);
 }
 
@@ -331,7 +332,7 @@ static void hw_event_process(struct log_frontend_stmesp_demux_hw_event *packet)
 	static const union cbprintf_package_hdr desc = {.desc = {.len = 3 /* hdr + fmt + id */}};
 	uint32_t tp_p[] = {(uint32_t)desc.raw, (uint32_t)tp, (uint32_t)evt_name};
 
-	log_output_process(&log_output, packet->timestamp, dname, sname, NULL,
+	log_output_process(&log_output, packet->timestamp, dname, sname, NULL, 0,
 			   1, (const uint8_t *)tp_p, NULL, 0, flags);
 }
 

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -82,6 +82,9 @@ struct log_msg_hdr {
 #if defined(CONFIG_LOG_THREAD_ID_PREFIX)
 	void *tid;
 #endif
+#if defined(CONFIG_LOG_CORE_ID_PREFIX)
+	uint8_t core_id;
+#endif
 };
 /* Messages are aligned to alignment required by cbprintf package. */
 #define Z_LOG_MSG_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
@@ -813,6 +816,22 @@ static inline void *log_msg_get_tid(struct log_msg *msg)
 #else
 	ARG_UNUSED(msg);
 	return NULL;
+#endif
+}
+
+/** @brief Get Core ID.
+ *
+ * @param msg Log message.
+ *
+ * @return Core ID.
+ */
+static inline uint8_t log_msg_get_core_id(struct log_msg *msg)
+{
+#if defined(CONFIG_LOG_CORE_ID_PREFIX)
+	return msg->hdr.core_id;
+#else
+	ARG_UNUSED(msg);
+	return 0;
 #endif
 }
 

--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -57,6 +57,9 @@ extern "C" {
 /** @brief Flag forcing to skip logging the source. */
 #define LOG_OUTPUT_FLAG_SKIP_SOURCE		BIT(8)
 
+/** @brief Flag core/processor id prefix. */
+#define LOG_OUTPUT_FLAG_CORE			BIT(9)
+
 /**@} */
 
 /** @brief Supported backend logging format types for use
@@ -152,6 +155,7 @@ void log_output_msg_process(const struct log_output *log_output,
  * @param domain	Domain name string. Can be NULL.
  * @param source	Source name string. Can be NULL.
  * @param tid		Thread ID.
+ * @param core_id	Core ID.
  * @param level		Criticality level.
  * @param package	Cbprintf package with a logging message string.
  * @param data		Data passed to hexdump API. Can be NULL.
@@ -163,6 +167,7 @@ void log_output_process(const struct log_output *log_output,
 			const char *domain,
 			const char *source,
 			k_tid_t tid,
+			uint8_t core_id,
 			uint8_t level,
 			const uint8_t *package,
 			const uint8_t *data,

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -120,6 +120,14 @@ config LOG_THREAD_ID_PREFIX
 	  Enable support for prefixing log message with thread name or ID.
 	  Thread name is used if THREAD_NAME is enabled.
 
+config LOG_CORE_ID_PREFIX
+	bool "Core ID prefix"
+	depends on SMP || MP_MAX_NUM_CPUS > 1
+	help
+	  Enable support for prefixing log message with core/processor ID.
+	  This is useful for multicore systems to identify which CPU core
+	  generated each log message.
+
 config LOG_CUSTOM_FORMAT_SUPPORT
 	bool "Custom format support"
 	default n

--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -190,6 +190,10 @@ static uint32_t format_flags(void)
 		flags |= LOG_OUTPUT_FLAG_CORE;
 	}
 
+	if (IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX)) {
+		flags |= LOG_OUTPUT_FLAG_THREAD;
+	}
+
 	return flags;
 }
 

--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -186,6 +186,10 @@ static uint32_t format_flags(void)
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
+	if (IS_ENABLED(CONFIG_LOG_CORE_ID_PREFIX)) {
+		flags |= LOG_OUTPUT_FLAG_CORE;
+	}
+
 	return flags;
 }
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -48,6 +48,9 @@ void z_log_msg_finalize(struct log_msg *msg, const void *source,
 #if CONFIG_LOG_THREAD_ID_PREFIX
 	msg->hdr.tid = k_is_in_isr() ? NULL : k_current_get();
 #endif
+#if CONFIG_LOG_CORE_ID_PREFIX
+	msg->hdr.core_id = arch_proc_id();
+#endif
 	z_log_msg_commit(msg);
 }
 

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -298,9 +298,11 @@ static int ids_print(const struct log_output *output,
 		     bool level_on,
 		     bool func_on,
 		     bool thread_on,
+		     bool core_on,
 		     const char *domain,
 		     const char *source,
 		     k_tid_t tid,
+		     uint8_t core_id,
 		     uint32_t level)
 {
 	int total = 0;
@@ -323,6 +325,10 @@ static int ids_print(const struct log_output *output,
 					k_thread_priority_get(tid),
 					tid);
 		}
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_CORE_ID_PREFIX) && core_on) {
+		total += print_formatted(output, "[core %d] ", core_id);
 	}
 
 	if (domain) {
@@ -584,6 +590,7 @@ static uint32_t prefix_print(const struct log_output *output,
 			     const char *domain,
 			     const char *source,
 			     k_tid_t tid,
+			     uint8_t core_id,
 			     uint8_t level)
 {
 	__ASSERT_NO_MSG(level <= LOG_LEVEL_DBG);
@@ -594,6 +601,8 @@ static uint32_t prefix_print(const struct log_output *output,
 	bool level_on = flags & LOG_OUTPUT_FLAG_LEVEL;
 	bool thread_on = IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX) &&
 			 (flags & LOG_OUTPUT_FLAG_THREAD);
+	bool core_on = IS_ENABLED(CONFIG_LOG_CORE_ID_PREFIX) &&
+			 (flags & LOG_OUTPUT_FLAG_CORE);
 	bool source_off = flags & LOG_OUTPUT_FLAG_SKIP_SOURCE;
 	const char *tag = IS_ENABLED(CONFIG_LOG) ? z_log_get_tag() : NULL;
 
@@ -630,8 +639,8 @@ static uint32_t prefix_print(const struct log_output *output,
 		color_prefix(output, colors_on, level);
 	}
 
-	length += ids_print(output, level_on, func_on, thread_on, domain,
-			    source_off ? NULL : source, tid, level);
+	length += ids_print(output, level_on, func_on, thread_on, core_on, domain,
+			    source_off ? NULL : source, tid, core_id, level);
 
 	return length;
 }
@@ -649,6 +658,7 @@ void log_output_process(const struct log_output *output,
 			const char *domain,
 			const char *source,
 			k_tid_t tid,
+			uint8_t core_id,
 			uint8_t level,
 			const uint8_t *package,
 			const uint8_t *data,
@@ -661,7 +671,7 @@ void log_output_process(const struct log_output *output,
 
 	if (!raw_string) {
 		prefix_offset = prefix_print(output, flags, 0, timestamp,
-					     domain, source, tid, level);
+					     domain, source, tid, core_id, level);
 		cb = out_func;
 	} else {
 		prefix_offset = 0;
@@ -705,7 +715,8 @@ void log_output_msg_process(const struct log_output *output,
 	uint8_t *package = log_msg_get_package(msg, &plen);
 	uint8_t *data = log_msg_get_data(msg, &dlen);
 
-	log_output_process(output, timestamp, dname, sname, (k_tid_t)log_msg_get_tid(msg), level,
+	log_output_process(output, timestamp, dname, sname, (k_tid_t)log_msg_get_tid(msg),
+			   log_msg_get_core_id(msg), level,
 			   plen > 0 ? package : NULL, data, dlen, flags);
 }
 

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -54,7 +54,8 @@ ZTEST(test_log_output, test_no_flags)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, NULL, SNAME, NULL, LOG_LEVEL_INF, package, NULL, 0, 0);
+	log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, LOG_LEVEL_INF,
+			   package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
 	zassert_str_equal(exp_str, mock_buffer);
@@ -69,7 +70,7 @@ ZTEST(test_log_output, test_raw)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, NULL, SNAME, NULL, LOG_LEVEL_INTERNAL_RAW_STRING,
+	log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, LOG_LEVEL_INTERNAL_RAW_STRING,
 			   package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
@@ -85,7 +86,8 @@ ZTEST(test_log_output, test_no_flags_dname)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, DNAME, SNAME, NULL, LOG_LEVEL_INF, package, NULL, 0, 0);
+	log_output_process(&log_output, 0, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF,
+			   package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
 	zassert_str_equal(exp_str, mock_buffer);
@@ -101,7 +103,7 @@ ZTEST(test_log_output, test_level_flag)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, DNAME, SNAME, NULL, LOG_LEVEL_INF,
+	log_output_process(&log_output, 0, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
@@ -120,7 +122,7 @@ ZTEST(test_log_output, test_ts_flag)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, DNAME, SNAME, NULL, LOG_LEVEL_INF,
+	log_output_process(&log_output, 0, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
@@ -146,7 +148,7 @@ ZTEST(test_log_output, test_format_ts)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 1000000, DNAME, SNAME, NULL, LOG_LEVEL_INF,
+	log_output_process(&log_output, 1000000, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
@@ -184,7 +186,7 @@ ZTEST(test_log_output, test_levels)
 	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
 		reset_mock_buffer();
 
-		log_output_process(&log_output, 0, NULL, SNAME, NULL, levels[i],
+		log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, levels[i],
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
@@ -229,7 +231,7 @@ ZTEST(test_log_output, test_colors)
 	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
 		reset_mock_buffer();
 
-		log_output_process(&log_output, 0, NULL, SNAME, NULL, levels[i],
+		log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, levels[i],
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
@@ -262,7 +264,7 @@ ZTEST(test_log_output, test_thread_id)
 	err = cbprintf_package(package, sizeof(package), 0, "Test");
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 0, NULL, SNAME, k_current_get(), 1,
+	log_output_process(&log_output, 0, NULL, SNAME, k_current_get(), 0, 1,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
@@ -281,7 +283,7 @@ ZTEST(test_log_output, test_skip_src)
 	zassert_true(err > 0);
 
 	reset_mock_buffer();
-	log_output_process(&log_output, 0, NULL, SNAME, NULL, LOG_LEVEL_INF,
+	log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';

--- a/tests/subsys/logging/log_output_net/src/log_output_test.c
+++ b/tests/subsys/logging/log_output_net/src/log_output_test.c
@@ -62,8 +62,8 @@ ZTEST(test_log_output_net, test_format)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 1000000, DNAME, SNAME, NULL, LOG_LEVEL_INF, package, NULL,
-			   0, flags);
+	log_output_process(&log_output, 1000000, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF, package,
+			   NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
 	zassert_str_equal(exp_str, mock_buffer, "expected: %s, is: %s", exp_str, mock_buffer);

--- a/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
+++ b/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
@@ -71,7 +71,7 @@ ZTEST(test_timestamp, test_custom_timestamp)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 1, DNAME, SNAME, NULL, LOG_LEVEL_INF,
+	log_output_process(&log_output, 1, DNAME, SNAME, NULL, 0, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';


### PR DESCRIPTION
Add support for displaying CPU core ID as a prefix in log messages for multicore systems.

The implementation captures the core ID at message creation time using arch_proc_id() and stores it in the log message header.

A new runtime flag LOG_OUTPUT_FLAG_CORE allows backends to control core ID display independently of the compile-time configuration.

The configuration option CONFIG_LOG_CORE_ID_PREFIX is available only on multicore systems (depends on SMP || MP_MAX_NUM_CPUS > 1) to avoid memory overhead on single-core platforms.

Example output showing core ID prefix:

Before:

```txt
[   26.565030] <inf> pipe: pipeline_trigger: pipe:1 0x0 pipe trigger cmd 0
[   26.565040] <inf> copier: copier_comp_trigger: comp:1 0x30005 No dai copier found, start/end offset is not calculated
[   26.565160] <inf> ll_schedule: zephyr_ll_task_done: task complete 0xa00e2dc8 0xa00b65c4U
[   26.565160] <inf> ll_schedule: zephyr_ll_task_done: num_tasks 1 total_num_tasks 1
[   26.565160] <inf> ll_schedule: zephyr_domain_unregister: domain->type 1 domain->clk 0
[   26.568990] <inf> ipc: ipc_cmd: rx	: 0x46000005|0x1000
[   26.666990] <inf> ipc: ipc_cmd: rx	: 0x46001000|0x10005
```

After:

```txt
[   30.597910] <inf> [core 0] pipe: pipeline_trigger: pipe:1 0x0 pipe trigger cmd 0
[   30.597920] <inf> [core 0] copier: copier_comp_trigger: comp:1 0x30005 No dai copier found, start/end offset is not calculated
[   30.598030] <inf> [core 1] ll_schedule: zephyr_ll_task_done: task complete 0xa00e2dc8 0xa00b65c4U
[   30.598030] <inf> [core 1] ll_schedule: zephyr_ll_task_done: num_tasks 1 total_num_tasks 1
[   30.598030] <inf> [core 1] ll_schedule: zephyr_domain_unregister: domain->type 1 domain->clk 0
[   30.603870] <inf> [core 0] ipc: ipc_cmd: rx	: 0x46000005|0x1000
[   30.605880] <inf> [core 0] ipc: ipc_cmd: rx	: 0x46001000|0x10005
```

Tested on Intel ADSP ACE 1.5 (MTL)