### PR TITLE
MAINTAINERS: Move myself to collaborators in Bluetooth Mesh

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -690,11 +690,11 @@ Bluetooth ISO:
 Bluetooth Mesh:
   status: maintained
   maintainers:
-    - PavelVPV
+    - alxelax
   collaborators:
     - jhedberg
+    - PavelVPV
     - LingaoM
-    - alxelax
     - akredalen
     - HaavardRei
     - omkar3141


### PR DESCRIPTION
Move myself (PavelVPV) from maintainers role to collaborator role in Bluetooth Mesh and assign alxelax as a new maintainer.