### PR TITLE
soc: nordic: nrf54l: fix I-cache init when built with TF-M

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -20,6 +20,9 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/cache.h>
+#ifndef __ZEPHYR__
+#include <hal/nrf_cache.h>
+#endif
 #include <lib/nrfx_coredep.h>
 #include <soc.h>
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
@@ -150,7 +153,11 @@ int nordicsemi_nrf54l_init(void)
 	 */
 	SystemCoreClock = NRF_PERIPH_GET_FREQUENCY(DT_NODELABEL(cpu));
 
+#ifdef __ZEPHYR__
 	sys_cache_instr_enable();
+#elif defined(NRF_ICACHE)
+	nrf_cache_enable(NRF_ICACHE);
+#endif
 
 #if (defined(NRF_APPLICATION) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)) || \
 	!defined(__ZEPHYR__)


### PR DESCRIPTION
sys_cache_instr_enable() calls into the Zephyr cache driver (cache_nrf.c), which is not compiled as part of the TF-M platform build. When CONFIG_CACHE_MANAGEMENT and CONFIG_ICACHE are both enabled, this produces an undefined reference at link time.

Use nrf_cache_enable() directly via the nrfx HAL for TF-M builds, which is already available in the TF-M platform. Zephyr builds are unaffected and continue to use the driver abstraction.