### PR TITLE
arch: arm64: add cache line size defaults for Cortex-A and Cortex-R

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -255,6 +255,12 @@ config ARMV9_A
 	  performance, and machine learning capabilities while maintaining
 	  backward compatibility with ARMv8-A software.
 
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
+
 rsource "xen/Kconfig"
 
 endif # CPU_CORTEX_A
@@ -275,6 +281,12 @@ config ARMV8_R
 	  virtualization at the highest security level while retaining the
 	  Protected Memory System Architecture (PMSA) based on a Memory Protection
 	  Unit (MPU). It supports the A32 and T32 instruction sets.
+
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
 
 rsource "cortex_r/Kconfig"
 


### PR DESCRIPTION
Add DCACHE_LINE_SIZE and ICACHE_LINE_SIZE defaults of 64 bytes for CPU_CORTEX_A and CPU_AARCH64_CORTEX_R configurations. This is analogous to commit 6868058c0351 ("arch: arm: cache: Add cache maintenance functions") which added similar defaults for aarch32 Cortex-A/R and Cortex-M cores.