### PR TITLE
enable cache related defines by default

### DIFF
--- a/soc/xlnx/versal/Kconfig.defconfig
+++ b/soc/xlnx/versal/Kconfig.defconfig
@@ -20,6 +20,12 @@ endif # SOC_VERSAL_RPU
 
 if SOC_VERSAL_APU
 
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
+
 config CACHE_MANAGEMENT
 	default y
 

--- a/soc/xlnx/versal2/Kconfig.defconfig
+++ b/soc/xlnx/versal2/Kconfig.defconfig
@@ -6,6 +6,9 @@
 
 if SOC_AMD_VERSAL2
 
+configdefault CACHE_MANAGEMENT
+	default y
+
 if SOC_AMD_VERSAL2_RPU
 
 config NUM_IRQS

--- a/soc/xlnx/versal2/Kconfig.defconfig
+++ b/soc/xlnx/versal2/Kconfig.defconfig
@@ -23,6 +23,12 @@ endif # SOC_AMD_VERSAL2_RPU
 
 if SOC_AMD_VERSAL2_APU
 
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
+
 config NUM_IRQS
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts

--- a/soc/xlnx/versalnet/Kconfig.defconfig
+++ b/soc/xlnx/versalnet/Kconfig.defconfig
@@ -6,11 +6,10 @@
 
 if SOC_AMD_VERSALNET
 
-if SOC_AMD_VERSALNET_RPU
+configdefault CACHE_MANAGEMENT
+	default y
 
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_ARM_ARCH_TIMER=y
-CONFIG_CACHE_MANAGEMENT=y
+if SOC_AMD_VERSALNET_RPU
 
 config NUM_IRQS
 	# must be >= the highest interrupt number used
@@ -23,10 +22,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 endif # SOC_AMD_VERSALNET_RPU
 
 if SOC_AMD_VERSALNET_APU
-
-CONFIG_CACHE_MANAGEMENT=y
-CONFIG_ARM_ARCH_TIMER=y
-CONFIG_CACHE_MANAGEMENT=y
 
 config NUM_IRQS
 	# must be >= the highest interrupt number used

--- a/soc/xlnx/versalnet/Kconfig.defconfig
+++ b/soc/xlnx/versalnet/Kconfig.defconfig
@@ -23,6 +23,12 @@ endif # SOC_AMD_VERSALNET_RPU
 
 if SOC_AMD_VERSALNET_APU
 
+configdefault DCACHE_LINE_SIZE
+	default 64
+
+configdefault ICACHE_LINE_SIZE
+	default 64
+
 config NUM_IRQS
 	# must be >= the highest interrupt number used
 	# - include the UART interrupts


### PR DESCRIPTION
Enable CONFIG_CACHE_MANAGMENT by default for versal2 and versalnet soc for both APU and RPU cores