### PR TITLE
drivers: flash: spi_nor: remove redundant runtime check

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1449,10 +1449,9 @@ static int spi_nor_process_sfdp(const struct device *dev)
 	return rc;
 }
 
-#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+#if defined(CONFIG_FLASH_PAGE_LAYOUT) && defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
 static int setup_pages_layout(const struct device *dev)
 {
-#if defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
 	struct spi_nor_data *data = dev->data;
 	const size_t flash_size = dev_flash_size(dev);
 	const uint32_t layout_page_size = CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE;
@@ -1494,24 +1493,10 @@ static int setup_pages_layout(const struct device *dev)
 	data->layout.pages_size = layout_page_size;
 	data->layout.pages_count = flash_size / layout_page_size;
 	LOG_DBG("layout %zu x %zu By pages", data->layout.pages_count, data->layout.pages_size);
-#elif defined(CONFIG_SPI_NOR_SFDP_DEVICETREE)
-	const struct spi_nor_config *cfg = dev->config;
-	const struct flash_pages_layout *layout = &cfg->layout;
-	const size_t flash_size = dev_flash_size(dev);
-	size_t layout_size = layout->pages_size * layout->pages_count;
-
-	if (flash_size != layout_size) {
-		LOG_ERR("device size %u mismatch %zu * %zu By pages",
-			flash_size, layout->pages_count, layout->pages_size);
-		return -EINVAL;
-	}
-#else /* CONFIG_SPI_NOR_SFDP_RUNTIME */
-#error Unhandled SFDP choice
-#endif /* CONFIG_SPI_NOR_SFDP_RUNTIME */
 
 	return 0;
 }
-#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#endif /* CONFIG_FLASH_PAGE_LAYOUT && CONFIG_SPI_NOR_SFDP_RUNTIME */
 #endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 
 /**
@@ -1643,13 +1628,13 @@ static int spi_nor_configure(const struct device *dev)
 		return -ENODEV;
 	}
 
-#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+#if defined(CONFIG_FLASH_PAGE_LAYOUT) && defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
 	rc = setup_pages_layout(dev);
 	if (rc != 0) {
 		LOG_ERR("layout setup failed: %d", rc);
 		return -ENODEV;
 	}
-#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#endif /* CONFIG_FLASH_PAGE_LAYOUT && CONFIG_SPI_NOR_SFDP_RUNTIME */
 #endif /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 
 #if ANY_INST_HAS_MXICY_MX25R_POWER_MODE


### PR DESCRIPTION
The check for the layout size, when CONFIG_SPI_NOR_SFDP_DEVICETREE is enabled, is already done with build asserts during build (inside PAGE_LAYOUT_GEN). We don't need to check a second time.