### PR TITLE
logging: fix getting runtime filter without backend provided

### DIFF
--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -162,6 +162,8 @@ int log_source_id_get(const char *name);
 /**
  * @brief Get source filter for the provided backend.
  *
+ * If NULL is provided as backend, the first available one is checked.
+ *
  * @param backend	Backend instance.
  * @param domain_id	ID of the domain.
  * @param source_id	Source (module or instance) ID.

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -586,7 +586,7 @@ void log_backend_disable(struct log_backend const *const backend)
 uint32_t log_filter_get(struct log_backend const *const backend,
 			uint32_t domain_id, int16_t source_id, bool runtime)
 {
-	int id = (backend == NULL) ? -1 : log_backend_id_get(backend);
+	uint8_t id = (backend == NULL) ? 0 : log_backend_id_get(backend);
 
 	return filter_get(id, domain_id, source_id, runtime);
 }


### PR DESCRIPTION
Previously, getting the runtime filter for NULL backend always returned 0. This was caused because -1 was provided as parameter which caused to shift the value by huge value and clearing it.
As there's no perfect solution to get the "default" value for multiple backends (we could check all and return minimal one), when user provides the NULL value as backend, we return now the first available backend's filter. This should work properly when used with sending the NULL parameter to the set filter function.