### PR TITLE
linker: fix xip data corruption with c++ exceptions

### DIFF
--- a/include/zephyr/linker/cplusplus-ram.ld
+++ b/include/zephyr/linker/cplusplus-ram.ld
@@ -11,7 +11,7 @@
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if defined (CONFIG_CPP_EXCEPTIONS)
-    SECTION_PROLOGUE(.tm_clone_table,,)
+    SECTION_DATA_PROLOGUE(.tm_clone_table,,)
 	{
 	KEEP (*(SORT_NONE(EXCLUDE_FILE (*crtend.o) .tm_clone_table)))
 	KEEP (*(SORT_NONE(.tm_clone_table)))


### PR DESCRIPTION
The .tm_clone_table section used SECTION_PROLOGUE instead of SECTION_DATA_PROLOGUE, causing VMA/LMA offset mismatch on XIP systems.

When the linker adds alignment padding to VMA but not LMA, arch_data_copy() places all subsequent data at wrong addresses, corrupting pointer-containing structures like usbd_context.

Fix by using SECTION_DATA_PROLOGUE which adds ALIGN_WITH_INPUT, ensuring padding is synchronized between VMA and LMA.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93779