### PR TITLE
scripts: footprint: Optimize speed of generate_any_tree

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -23,7 +23,7 @@ from packaging import version
 
 from colorama import init, Fore, Style
 
-from anytree import RenderTree, NodeMixin, findall_by_attr
+from anytree import RenderTree, NodeMixin, PreOrderIter
 from anytree.exporter import DictExporter
 
 import elftools
@@ -693,6 +693,17 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
         else:
             node_workspace = node_others
 
+    # Node finding code using a local cache and optimized iteration to stop
+    # after finding the first match.
+    node_cache = {}
+    def _find_node(root, value):
+        node = node_cache.get(value)
+        if not node:
+            node = next(PreOrderIter(root, filter_=lambda n: n._identifier == value,
+                stop=None, maxlevel=None), None)
+            node_cache[value] = node
+        return node
+
     # A set of helper function for building a simple tree with a path-like
     # hierarchy.
     def _insert_one_elem(root, path, size, addr, section, loc):
@@ -705,9 +716,8 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
             else:
                 cur = str(Path(cur, part))
 
-            results = findall_by_attr(root, cur, name="_identifier")
-            if results:
-                item = results[0]
+            item = _find_node(root, cur)
+            if item:
                 if not hasattr(item, 'address'):
                     # Passing down through a non-terminal parent node.
                     parent = item


### PR DESCRIPTION
The generate_any_tree function finds all matching nodes when inserting into the tree, but only actually needs the first match. It also does this search multiple times for the same node as it traverses the tree. Optimize this in two ways: first, use an iterator that stops after the first match, and second, cache matching nodes to avoid repeat searches.

Tests on a large ELF file (8 MB, with ~5,000 non-zero size symbols) shows an improvement in generating the ROM report from 1m:40s to just 23s, almost 80% faster.