### PR TITLE
drivers: i2s: stm32 sai rework

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -307,6 +307,14 @@ STM32
   Applications must now explicitly configure interrupt priorities using Devicetree
   if they previously relied on the values found in SoC DTSI files. (:github:`106188`)
 
+* :dtcompatible:`st,stm32-sai` binding has been restructured to reflect the SAI hardware
+  topology. The parent node now represents the SAI Block controller, while a new
+  ``child-binding`` represents the SAI Sub-Block instances.
+  The following properties shall be moved from the parent SAI node to a child sub-block node:
+  ``dmas``, ``dma-names`` (now validated against ``enum: [tx, rx]``), ``pinctrl-0``,
+  ``pinctrl-names``, ``mclk-enable``, ``mclk-divider``, ``synchronous``, and
+  ``fifo-threshold``. (:github:`104423`)
+
 Syscon
 ======
 

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -27,7 +27,7 @@ config I2S_STM32_TX_BLOCK_COUNT
 endif # I2S_STM32
 
 menuconfig I2S_STM32_SAI
-	bool "STM32 MCU I2S controller driver"
+	bool "STM32 MCU SAI controller driver"
 	default y
 	depends on DT_HAS_ST_STM32_SAI_ENABLED
 	select CACHE_MANAGEMENT if CPU_HAS_DCACHE

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
- * Copyright (c) 2024-2025 Mario Paja
+ * Copyright (c) 2024-2026 Mario Paja
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -104,27 +104,30 @@ struct stream {
 	void (*queue_drop)(const struct device *dev);
 };
 
-struct i2s_stm32_sai_data {
+struct stm32_sai_sub_data {
 	SAI_HandleTypeDef hsai;
 	DMA_HandleTypeDef hdma;
 	struct stream stream;
 };
 
-struct i2s_stm32_sai_cfg {
+struct stm32_sai_sub_cfg {
 	const struct pinctrl_dev_config *pincfg;
-	const struct stm32_pclken *pclken;
-	size_t pclk_len;
-	const struct pinctrl_dev_config *pcfg;
-
 	bool mclk_enable;
 	enum mclk_divider mclk_div;
 	bool synchronous;
+
+	const struct device *controller;
+};
+
+struct stm32_sai_cfg {
+	const struct stm32_pclken *pclken;
+	size_t pclk_len;
 };
 
 void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef *hsai)
 {
-	struct i2s_stm32_sai_data *dev_data = CONTAINER_OF(hsai, struct i2s_stm32_sai_data, hsai);
-	struct stream *stream = &dev_data->stream;
+	struct stm32_sai_sub_data *sub_data = CONTAINER_OF(hsai, struct stm32_sai_sub_data, hsai);
+	struct stream *stream = &sub_data->stream;
 	int ret;
 
 	/* Exit the callback, Stream is stopped */
@@ -179,8 +182,8 @@ exit:
 
 void HAL_SAI_TxCpltCallback(SAI_HandleTypeDef *hsai)
 {
-	struct i2s_stm32_sai_data *dev_data = CONTAINER_OF(hsai, struct i2s_stm32_sai_data, hsai);
-	struct stream *stream = &dev_data->stream;
+	struct stm32_sai_sub_data *sub_data = CONTAINER_OF(hsai, struct stm32_sai_sub_data, hsai);
+	struct stream *stream = &sub_data->stream;
 	void *mem_block_tmp = stream->mem_block;
 	struct queue_item item;
 	int ret;
@@ -274,42 +277,39 @@ void HAL_SAI_ErrorCallback(SAI_HandleTypeDef *hsai)
 	}
 }
 
-static int stm32_sai_enable_clock(const struct device *dev)
+static int stm32_sai_clock_en(const struct device *dev)
 {
-	const struct i2s_stm32_sai_cfg *cfg = dev->config;
+	const struct stm32_sai_cfg *sai_cfg = dev->config;
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	int err;
+	int ret;
 
 	/* Turn on SAI peripheral clock */
-	err = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
-	if (err != 0) {
-		LOG_ERR("I2S clock Enable: <FAILED>");
+	ret = clock_control_on(clk, (clock_control_subsys_t)&sai_cfg->pclken[0]);
+	if (ret != 0) {
 		return -EIO;
 	}
-	LOG_DBG("I2S clock Enable: <OK>");
 
-	if (cfg->pclk_len > 1) {
-		/* Enable I2S clock source */
-		err = clock_control_configure(clk, (clock_control_subsys_t)&cfg->pclken[1], NULL);
-		if (err < 0) {
-			LOG_ERR("I2S domain clock configuration: <FAILED>");
+	if (sai_cfg->pclk_len > 1) {
+		/* Enable SAI clock source */
+		ret = clock_control_configure(clk, (clock_control_subsys_t)&sai_cfg->pclken[1],
+					      NULL);
+		if (ret < 0) {
 			return -EIO;
 		}
 	}
-	LOG_DBG("I2S domain clock configuration: <OK>");
 
 	return 0;
 }
 
-static int i2s_stm32_sai_dma_init(const struct device *dev)
+static int sai_sub_dma_init(const struct device *dev)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
-	struct dma_config *dma_cfg = &dev_data->stream.dma_cfg;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
+	struct dma_config *dma_cfg = &sub_data->stream.dma_cfg;
 	int ret;
 
-	SAI_HandleTypeDef *hsai = &dev_data->hsai;
-	DMA_HandleTypeDef *hdma = &dev_data->hdma;
+	SAI_HandleTypeDef *hsai = &sub_data->hsai;
+	DMA_HandleTypeDef *hdma = &sub_data->hdma;
 
 	if (!device_is_ready(stream->dma_dev)) {
 		LOG_ERR("%s DMA device not ready", stream->dma_dev->name);
@@ -387,7 +387,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 		hdma->Init.DestInc = DMA_DINC_FIXED;
 #endif
 
-		__HAL_LINKDMA(hsai, hdmatx, dev_data->hdma);
+		__HAL_LINKDMA(hsai, hdmatx, sub_data->hdma);
 	} else {
 		hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
 
@@ -396,70 +396,67 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 		hdma->Init.DestInc = DMA_DINC_INCREMENTED;
 #endif
 
-		__HAL_LINKDMA(hsai, hdmarx, dev_data->hdma);
+		__HAL_LINKDMA(hsai, hdmarx, sub_data->hdma);
 	}
 
-	if (HAL_DMA_Init(&dev_data->hdma) != HAL_OK) {
+	if (HAL_DMA_Init(&sub_data->hdma) != HAL_OK) {
 		LOG_ERR("HAL_DMA_Init: <FAILED>");
 		return -EIO;
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32N6X)
-	if (HAL_DMA_ConfigChannelAttributes(&dev_data->hdma, DMA_CHANNEL_SEC | DMA_CHANNEL_PRIV |
+	if (HAL_DMA_ConfigChannelAttributes(&sub_data->hdma, DMA_CHANNEL_SEC | DMA_CHANNEL_PRIV |
 					    DMA_CHANNEL_SRC_SEC | DMA_CHANNEL_DEST_SEC) != HAL_OK) {
 		LOG_ERR("HAL_DMA_ConfigChannelAttributes: <Failed>");
 		return -EIO;
 	}
 #elif defined(CONFIG_DMA_STM32U5)
-	if (HAL_DMA_ConfigChannelAttributes(&dev_data->hdma, DMA_CHANNEL_NPRIV) != HAL_OK) {
+	if (HAL_DMA_ConfigChannelAttributes(&sub_data->hdma, DMA_CHANNEL_NPRIV) != HAL_OK) {
 		LOG_ERR("HAL_DMA_ConfigChannelAttributes: <Failed>");
 		return -EIO;
 	}
 #endif
 
+	LOG_DBG("dma@%08x Init: <OK>", (uint32_t)hdma->Instance);
+
 	return 0;
 }
 
-static int i2s_stm32_sai_initialize(const struct device *dev)
+static int sai_sub_init(const struct device *dev)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	const struct i2s_stm32_sai_cfg *cfg = dev->config;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	const struct stm32_sai_sub_cfg *sub_cfg = dev->config;
+	struct stream *stream = &sub_data->stream;
 	int ret = 0;
 
-	/* Enable SAI clock */
-	ret = stm32_sai_enable_clock(dev);
-	if (ret < 0) {
-		LOG_ERR("Clock enabling failed.");
-		return -EIO;
-	}
-
 	/* Configure DT provided pins */
-	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	ret = pinctrl_apply_state(sub_cfg->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
-		LOG_ERR("I2S pinctrl setup: <FAILED>");
+		LOG_ERR("SAI Sub-Block pinctrl setup: <FAILED>, ret: %d", ret);
 		return ret;
 	}
 
-	if (!device_is_ready(dev_data->stream.dma_dev)) {
-		LOG_ERR("%s device not ready", dev_data->stream.dma_dev->name);
+	if (!device_is_ready(sub_data->stream.dma_dev)) {
+		LOG_ERR("%s device not ready", sub_data->stream.dma_dev->name);
 		return -ENODEV;
 	}
 
-	ret = k_msgq_alloc_init(&dev_data->stream.queue, sizeof(struct queue_item),
+	ret = k_msgq_alloc_init(&sub_data->stream.queue, sizeof(struct queue_item),
 				CONFIG_I2S_STM32_SAI_BLOCK_COUNT);
 	if (ret < 0) {
-		LOG_ERR("k_msgq_alloc_init(): <FAILED>");
+		LOG_ERR("k_msgq_alloc_init(): <FAILED>, ret: %d", ret);
 		return ret;
 	}
 
 	/* Initialize DMA */
-	ret = i2s_stm32_sai_dma_init(dev);
+	ret = sai_sub_dma_init(dev);
 	if (ret < 0) {
-		LOG_ERR("i2s_stm32_sai_dma_init(): <FAILED>");
+		LOG_ERR("SAI Sub-Block DMA Init <FAILED>, ret: %d", ret);
 		return ret;
 	}
 
-	LOG_INF("%s inited", dev->name);
+	/* State set to not ready until successfully configured */
+	stream->state = I2S_STATE_NOT_READY;
 
 	return 0;
 }
@@ -477,15 +474,16 @@ static void dma_callback(const struct device *dma_dev, void *arg, uint32_t chann
 }
 
 #if defined(CONFIG_SOC_SERIES_STM32F4X)
-static int i2s_stm32_sai_f4_clock_source_configure(const struct device *dev)
+static int stm32_sai_sub_f4_clk_src_conf(const struct device *dev)
 {
-	const struct i2s_stm32_sai_cfg *const cfg = dev->config;
-	struct i2s_stm32_sai_data *const dev_data = dev->data;
-	SAI_HandleTypeDef *hsai = &dev_data->hsai;
+	const struct stm32_sai_sub_cfg *sub_cfg = dev->config;
+	const struct stm32_sai_cfg *sai_cfg = sub_cfg->controller->config;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	SAI_HandleTypeDef *hsai = &sub_data->hsai;
 	uint32_t clock_source = 0U;
 
-	if (cfg->pclk_len > 1) {
-		clock_source = cfg->pclken[1].bus;
+	if (sai_cfg->pclk_len > 1) {
+		clock_source = sai_cfg->pclken[1].bus;
 	}
 
 	switch (clock_source) {
@@ -523,13 +521,13 @@ static int i2s_stm32_sai_f4_clock_source_configure(const struct device *dev)
 }
 #endif /* CONFIG_SOC_SERIES_STM32F4X */
 
-static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
+static int stm32_sai_sub_conf(const struct device *dev, enum i2s_dir dir,
 				   const struct i2s_config *i2s_cfg)
 {
-	const struct i2s_stm32_sai_cfg *const cfg = dev->config;
-	struct i2s_stm32_sai_data *const dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
-	SAI_HandleTypeDef *hsai = &dev_data->hsai;
+	const struct stm32_sai_sub_cfg *const sub_cfg = dev->config;
+	struct stm32_sai_sub_data *const sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
+	SAI_HandleTypeDef *hsai = &sub_data->hsai;
 	uint8_t protocol;
 	uint8_t word_size;
 
@@ -547,7 +545,7 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 	/* ON F4x, the HAL modifies the RCC to set the source clock, so it is necessary to define
 	 * the ClockSource Init parameter.
 	 */
-	err = i2s_stm32_sai_f4_clock_source_configure(dev);
+	err = stm32_sai_sub_f4_clk_src_conf(dev);
 	if (err != 0) {
 		return err;
 	}
@@ -560,7 +558,7 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 
 		if (stream->master == false) {
 			hsai->Init.AudioMode = SAI_MODESLAVE_RX;
-			if (cfg->synchronous) {
+			if (sub_cfg->synchronous) {
 				hsai->Init.Synchro = SAI_SYNCHRONOUS;
 			}
 		}
@@ -570,7 +568,7 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 
 		if (stream->master == false) {
 			hsai->Init.AudioMode = SAI_MODESLAVE_TX;
-			if (cfg->synchronous) {
+			if (sub_cfg->synchronous) {
 				hsai->Init.Synchro = SAI_SYNCHRONOUS;
 			}
 		}
@@ -586,21 +584,21 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 
 	/* MckOutput is not supported by all MCU series */
 #if defined(SAI_MCK_OUTPUT_ENABLE)
-	if (cfg->mclk_enable && stream->master) {
+	if (sub_cfg->mclk_enable && stream->master) {
 		hsai->Init.MckOutput = SAI_MCK_OUTPUT_ENABLE;
 	} else {
 		hsai->Init.MckOutput = SAI_MCK_OUTPUT_DISABLE;
 	}
 #endif
 
-	if (cfg->mclk_div == (enum mclk_divider)MCLK_NO_DIV) {
+	if (sub_cfg->mclk_div == (enum mclk_divider)MCLK_NO_DIV) {
 		hsai->Init.NoDivider = SAI_MASTERDIVIDER_DISABLE;
 	} else {
 		hsai->Init.NoDivider = SAI_MASTERDIVIDER_ENABLE;
 
 		/* MckOverSampling is not supported by all MCU series */
 #if defined(SAI_MCK_OVERSAMPLING_DISABLE)
-		if (cfg->mclk_div == (enum mclk_divider)MCLK_DIV_256) {
+		if (sub_cfg->mclk_div == (enum mclk_divider)MCLK_DIV_256) {
 			hsai->Init.MckOverSampling = SAI_MCK_OVERSAMPLING_DISABLE;
 		} else {
 			hsai->Init.MckOverSampling = SAI_MCK_OVERSAMPLING_ENABLE;
@@ -724,19 +722,19 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 	return 0;
 }
 
-static int i2s_stm32_sai_write(const struct device *dev, void *mem_block, size_t size)
+static int stm32_sai_sub_write(const struct device *dev, void *mem_block, size_t size)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
 	int ret;
 
 	if (stream->state != I2S_STATE_RUNNING && stream->state != I2S_STATE_READY) {
-		LOG_ERR("TX Invalid state: %d", (int)stream->state);
+		LOG_ERR("TX Invalid state: %d", stream->state);
 		return -EIO;
 	}
 
 	if (size > stream->i2s_cfg.block_size) {
-		LOG_ERR("Max write size is: %u", (unsigned int)stream->i2s_cfg.block_size);
+		LOG_ERR("Max write size is: %zu", stream->i2s_cfg.block_size);
 		return -EINVAL;
 	}
 
@@ -745,26 +743,27 @@ static int i2s_stm32_sai_write(const struct device *dev, void *mem_block, size_t
 	ret = k_msgq_put(&stream->queue, &item, K_MSEC(stream->i2s_cfg.timeout));
 	if (ret < 0) {
 		LOG_ERR("TX queue full");
+		return ret;
 	}
 
 	return 0;
 }
 
-static int i2s_stm32_sai_read(const struct device *dev, void **mem_block, size_t *size)
+static int stm32_sai_sub_read(const struct device *dev, void **mem_block, size_t *size)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
+	struct stm32_sai_sub_data *sub_data = dev->data;
 	struct queue_item item;
 	int ret;
 
-	if (dev_data->stream.state == I2S_STATE_NOT_READY ||
-	    dev_data->stream.state == I2S_STATE_ERROR) {
-		LOG_ERR("RX invalid state: %d", (int)dev_data->stream.state);
+	if (sub_data->stream.state == I2S_STATE_NOT_READY ||
+	    sub_data->stream.state == I2S_STATE_ERROR) {
+		LOG_ERR("RX invalid state: %d", (int)sub_data->stream.state);
 		return -EIO;
 	}
 
-	ret = k_msgq_get(&dev_data->stream.queue, &item, K_MSEC(dev_data->stream.i2s_cfg.timeout));
+	ret = k_msgq_get(&sub_data->stream.queue, &item, K_MSEC(sub_data->stream.i2s_cfg.timeout));
 	if (ret < 0) {
-		LOG_ERR("RX queue: %d", k_msgq_num_used_get(&dev_data->stream.queue));
+		LOG_ERR("RX queue: %d", k_msgq_num_used_get(&sub_data->stream.queue));
 		return ret;
 	}
 
@@ -776,9 +775,9 @@ static int i2s_stm32_sai_read(const struct device *dev, void **mem_block, size_t
 
 static int stream_start(const struct device *dev, enum i2s_dir dir)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
-	SAI_HandleTypeDef *hsai = &dev_data->hsai;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
+	SAI_HandleTypeDef *hsai = &sub_data->hsai;
 	struct queue_item item;
 	int ret;
 
@@ -819,8 +818,8 @@ static int stream_start(const struct device *dev, enum i2s_dir dir)
 
 static void queue_drop(const struct device *dev)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
 	struct queue_item item;
 
 	if (stream->mem_block != NULL) {
@@ -834,11 +833,11 @@ static void queue_drop(const struct device *dev)
 	}
 }
 
-static int i2s_stm32_sai_trigger(const struct device *dev, enum i2s_dir dir,
+static int stm32_sai_sub_trigger(const struct device *dev, enum i2s_dir dir,
 				 enum i2s_trigger_cmd cmd)
 {
-	struct i2s_stm32_sai_data *dev_data = dev->data;
-	struct stream *stream = &dev_data->stream;
+	struct stm32_sai_sub_data *sub_data = dev->data;
+	struct stream *stream = &sub_data->stream;
 	unsigned int key;
 	int ret;
 
@@ -931,72 +930,98 @@ static int i2s_stm32_sai_trigger(const struct device *dev, enum i2s_dir dir,
 	return 0;
 }
 
-static DEVICE_API(i2s, i2s_stm32_driver_api) = {
-	.configure = i2s_stm32_sai_configure,
-	.trigger = i2s_stm32_sai_trigger,
-	.write = i2s_stm32_sai_write,
-	.read = i2s_stm32_sai_read,
+static int sai_init(const struct device *dev)
+{
+	int ret = 0;
+
+	/* Enable SAI clock */
+	ret = stm32_sai_clock_en(dev);
+	if (ret < 0) {
+		LOG_ERR("SAI clock enable <FAILED>, ret: %d.", ret);
+		return -EIO;
+	}
+
+	LOG_DBG("%s Init: <OK>", dev->name);
+
+	return 0;
+}
+
+static DEVICE_API(i2s, i2s_stm32_sai_api) = {
+	.configure = stm32_sai_sub_conf,
+	.trigger = stm32_sai_sub_trigger,
+	.write = stm32_sai_sub_write,
+	.read = stm32_sai_sub_read,
 };
 
-#define SAI_DMA_CHANNEL_INIT(index, dir, src, dest)                                                \
+#define SAI_FIFO_THRESHOLD(node) sai_fifo_threshold[DT_ENUM_IDX(node, fifo_threshold)]
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2bis)
+#define DMA_SLOT_BY_IDX(id, idx, slot) 0
+#else
+#define DMA_SLOT_BY_IDX(id, idx, slot) DT_DMAS_CELL_BY_IDX(id, idx, slot)
+#endif
+
+#define DMA_CHANNEL_CONFIG_BY_IDX(id, idx) DT_DMAS_CELL_BY_IDX(id, idx, channel_config)
+
+#define SAI_SUB_DMA_CHANNEL_INIT(node, src, dest)                                                  \
 	.stream = {                                                                                \
-		.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),                              \
-		.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                     \
-		.reg = (DMA_TypeDef *)DT_REG_ADDR(                                                 \
-			DT_PHANDLE_BY_NAME(DT_DRV_INST(index), dmas, dir)),                        \
+		.dma_dev = DEVICE_DT_GET(DT_DMAS_CTLR(node)),                                      \
+		.dma_channel = DT_DMAS_CELL_BY_IDX(node, 0, channel),                              \
+		.reg = (DMA_TypeDef *)DT_REG_ADDR(DT_PHANDLE_BY_IDX(node, dmas, 0)),               \
 		.dma_cfg = {                                                                       \
-			.dma_slot = STM32_DMA_SLOT(index, dir, slot),                              \
+			.dma_slot = DMA_SLOT_BY_IDX(node, 0, slot),                                \
 			.channel_direction = src##_TO_##dest,                                      \
 			.dma_callback = dma_callback,                                              \
 			.channel_priority = STM32_DMA_CONFIG_PRIORITY(                             \
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
+				DMA_CHANNEL_CONFIG_BY_IDX(node, 0)),                               \
 			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(                    \
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
+				DMA_CHANNEL_CONFIG_BY_IDX(node, 0)),                               \
 			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(                     \
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
+				DMA_CHANNEL_CONFIG_BY_IDX(node, 0)),                               \
 		},                                                                                 \
 		.stream_start = stream_start,                                                      \
 		.queue_drop = queue_drop,                                                          \
 	}
 
-#define SAI_FIFO_THRESHOLD(index) \
-	sai_fifo_threshold[DT_INST_ENUM_IDX_OR(index, fifo_threshold, 0)]
+#define SAI_SUB_REG_ADDR(node) (DT_REG_ADDR(DT_PARENT(node)) + DT_REG_ADDR(node))
 
-#define I2S_STM32_SAI_INIT(index)                                                                  \
+#define SAI_SUB_INIT(node)                                                                         \
+	PINCTRL_DT_DEFINE(node);                                                                   \
                                                                                                    \
-	PINCTRL_DT_INST_DEFINE(index);                                                             \
-                                                                                                   \
-	static const struct stm32_pclken clk_##index[] = STM32_DT_INST_CLOCKS(index);              \
-                                                                                                   \
-	struct i2s_stm32_sai_data sai_data_##index = {                                             \
+	static struct stm32_sai_sub_data sub_data_##node = {                                       \
 		.hsai = {                                                                          \
-			.Instance = (SAI_Block_TypeDef *)DT_INST_REG_ADDR(index),                  \
+			.Instance = (SAI_Block_TypeDef *)SAI_SUB_REG_ADDR(node),                   \
 			.Init.OutputDrive = SAI_OUTPUTDRIVE_DISABLE,                               \
-			.Init.FIFOThreshold = SAI_FIFO_THRESHOLD(index),                           \
+			.Init.FIFOThreshold = SAI_FIFO_THRESHOLD(node),                            \
 			.Init.SynchroExt = SAI_SYNCEXT_DISABLE,                                    \
 			.Init.CompandingMode = SAI_NOCOMPANDING,                                   \
 			.Init.TriState = SAI_OUTPUT_NOTRELEASED,                                   \
 		},                                                                                 \
-		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
-			    (SAI_DMA_CHANNEL_INIT(index, tx, MEMORY, PERIPHERAL)),                 \
-			    (SAI_DMA_CHANNEL_INIT(index, rx, PERIPHERAL, MEMORY))),                \
+		COND_CODE_1(DT_DMAS_HAS_NAME(node, tx),                                            \
+		    (SAI_SUB_DMA_CHANNEL_INIT(node, MEMORY, PERIPHERAL)),                          \
+		    (SAI_SUB_DMA_CHANNEL_INIT(node, PERIPHERAL, MEMORY))),                         \
 	};                                                                                         \
                                                                                                    \
-	struct i2s_stm32_sai_cfg sai_config_##index = {                                            \
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                   \
-		.pclken = clk_##index,                                                             \
-		.pclk_len = DT_INST_NUM_CLOCKS(index),                                             \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
-		.mclk_enable = DT_INST_PROP(index, mclk_enable),                                   \
-		.mclk_div = (enum mclk_divider)DT_ENUM_IDX(DT_DRV_INST(index), mclk_divider),      \
-		.synchronous = DT_INST_PROP(index, synchronous),                                   \
+	static const struct stm32_sai_sub_cfg sub_cfg_##node = {                                   \
+		.pincfg = PINCTRL_DT_DEV_CONFIG_GET(node),                                         \
+		.mclk_enable = DT_PROP(node, mclk_enable),                                         \
+		.mclk_div = DT_ENUM_IDX(node, mclk_divider),                                       \
+		.synchronous = DT_PROP(node, synchronous),                                         \
+		.controller = DEVICE_DT_GET(DT_PARENT(node)),                                      \
 	};                                                                                         \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(index, &i2s_stm32_sai_initialize, NULL, &sai_data_##index,           \
-			      &sai_config_##index, POST_KERNEL, CONFIG_I2S_INIT_PRIORITY,          \
-			      &i2s_stm32_driver_api);                                              \
-                                                                                                   \
-	K_MSGQ_DEFINE(queue_##index, sizeof(struct queue_item), CONFIG_I2S_STM32_SAI_BLOCK_COUNT,  \
-		      4);
+	DEVICE_DT_DEFINE(node, &sai_sub_init, NULL, &sub_data_##node, &sub_cfg_##node,             \
+			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_sai_api);               \
+	K_MSGQ_DEFINE(queue_##node, sizeof(struct queue_item), CONFIG_I2S_STM32_SAI_BLOCK_COUNT, 4);
 
-DT_INST_FOREACH_STATUS_OKAY(I2S_STM32_SAI_INIT)
+/* Controller Node */
+#define SAI_INIT(inst)                                                                             \
+	static const struct stm32_pclken clk_##inst[] = STM32_DT_INST_CLOCKS(inst);                \
+	static const struct stm32_sai_cfg sai_cfg_##inst = {                                       \
+		.pclken = clk_##inst,                                                              \
+		.pclk_len = DT_INST_NUM_CLOCKS(inst),                                              \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &sai_init, NULL, NULL, &sai_cfg_##inst, POST_KERNEL,           \
+			      CONFIG_I2S_INIT_PRIORITY, NULL);                                     \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, SAI_SUB_INIT)
+
+DT_INST_FOREACH_STATUS_OKAY(SAI_INIT)

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -115,6 +115,7 @@ struct stm32_sai_sub_cfg {
 	bool mclk_enable;
 	enum mclk_divider mclk_div;
 	bool synchronous;
+	enum i2s_dir dir;
 
 	const struct device *controller;
 };
@@ -554,6 +555,11 @@ static int stm32_sai_sub_conf(const struct device *dev, enum i2s_dir dir,
 	hsai->Init.Synchro = SAI_ASYNCHRONOUS;
 
 	if (dir == I2S_DIR_RX) {
+		if (sub_cfg->dir == I2S_DIR_TX) {
+			LOG_ERR("Invalid direction, SAI configured as TX");
+			return -EINVAL;
+		}
+
 		hsai->Init.AudioMode = SAI_MODEMASTER_RX;
 
 		if (stream->master == false) {
@@ -564,6 +570,11 @@ static int stm32_sai_sub_conf(const struct device *dev, enum i2s_dir dir,
 		}
 
 	} else if (dir == I2S_DIR_TX) {
+		if (sub_cfg->dir == I2S_DIR_RX) {
+			LOG_ERR("Invalid direction, SAI configured as RX");
+			return -EINVAL;
+		}
+
 		hsai->Init.AudioMode = SAI_MODEMASTER_TX;
 
 		if (stream->master == false) {
@@ -724,9 +735,15 @@ static int stm32_sai_sub_conf(const struct device *dev, enum i2s_dir dir,
 
 static int stm32_sai_sub_write(const struct device *dev, void *mem_block, size_t size)
 {
+	const struct stm32_sai_sub_cfg *const sub_cfg = dev->config;
 	struct stm32_sai_sub_data *sub_data = dev->data;
 	struct stream *stream = &sub_data->stream;
 	int ret;
+
+	if (sub_cfg->dir == I2S_DIR_RX) {
+		LOG_ERR("Invalid operation, SAI configured as RX");
+		return -EIO;
+	}
 
 	if (stream->state != I2S_STATE_RUNNING && stream->state != I2S_STATE_READY) {
 		LOG_ERR("TX Invalid state: %d", stream->state);
@@ -751,9 +768,15 @@ static int stm32_sai_sub_write(const struct device *dev, void *mem_block, size_t
 
 static int stm32_sai_sub_read(const struct device *dev, void **mem_block, size_t *size)
 {
+	const struct stm32_sai_sub_cfg *const sub_cfg = dev->config;
 	struct stm32_sai_sub_data *sub_data = dev->data;
 	struct queue_item item;
 	int ret;
+
+	if (sub_cfg->dir == I2S_DIR_TX) {
+		LOG_ERR("Invalid operation, SAI configured as TX");
+		return -EIO;
+	}
 
 	if (sub_data->stream.state == I2S_STATE_NOT_READY ||
 	    sub_data->stream.state == I2S_STATE_ERROR) {
@@ -1008,6 +1031,7 @@ static DEVICE_API(i2s, i2s_stm32_sai_api) = {
 		.mclk_div = DT_ENUM_IDX(node, mclk_divider),                                       \
 		.synchronous = DT_PROP(node, synchronous),                                         \
 		.controller = DEVICE_DT_GET(DT_PARENT(node)),                                      \
+		.dir = COND_CODE_1(DT_DMAS_HAS_NAME(node, tx), (I2S_DIR_TX), (I2S_DIR_RX)),        \
 	};                                                                                         \
 	DEVICE_DT_DEFINE(node, &sai_sub_init, NULL, &sub_data_##node, &sub_cfg_##node,             \
 			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_sai_api);               \

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -82,26 +82,25 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015804 {
+		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015804 0x20>;
+			reg = <0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 1 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 5 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -116,26 +116,25 @@
 			};
 		};
 
-		sai1_a: sai1@40015804 {
+		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015804 0x20>;
+			reg = <0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 1 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 5 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -172,26 +172,25 @@
 			};
 		};
 
-		sai1_a: sai1@40015804 {
+		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015804 0x20>;
+			reg = <0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 1 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-			dmas = <&dma2 5 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS) 0>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1071,26 +1071,25 @@
 		status = "disabled";
 	};
 
-	sai1_a: sai1@40015804 {
+	sai1: sai1@40015800 {
 		compatible = "st,stm32-sai";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		reg = <0x40015804 0x20>;
+		reg = <0x40015800 0x400>;
 		clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-		dmas = <&dma2 1 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-				   STM32_DMA_16BITS) 0>;
 		status = "disabled";
-	};
 
-	sai1_b: sai1@40015824 {
-		compatible = "st,stm32-sai";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x40015824 0x20>;
-		clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-		dmas = <&dma2 5 0 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-				   STM32_DMA_16BITS) 0>;
-		status = "disabled";
+		sai1_a: sai1a@4 {
+			reg = <0x4>;
+			dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+			status = "disabled";
+		};
+
+		sai1_b: sai1b@24 {
+			reg = <0x24>;
+			dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -776,26 +776,25 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			dmas = <&dma1 1 108 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					     STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			dmas = <&dma1 2 109 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					     STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma1 1 108 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma1 2 109 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		opamp1: opamp1@40010300 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -126,52 +126,50 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
 			status = "disabled";
+
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&gpdma1 1 53 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&gpdma1 0 54 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
-		sai1_b: sai1@40015424 {
+		sai2: sai2@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
+			reg = <0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
-		};
-
-		sai2_a: sai2@40015804 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015804 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
-			dmas = <&gpdma1 1 55 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai2_b: sai2@40015824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
-				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
-			dmas = <&gpdma1 0 56 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai2_a: sai2a@4 {
+				compatible = "st,stm32-sai-sub";
+				reg = <0x4>;
+				dmas = <&gpdma1 1 55 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai2_b: sai2b@24 {
+				compatible = "st,stm32-sai-sub";
+				reg = <0x24>;
+				dmas = <&gpdma1 0 56 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		uart4: serial@40004c00 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1290,28 +1290,26 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015804 {
+		sai1: sai1@40015800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015804 0x20>;
+			reg = <0x40015800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(1)>;
-			dmas = <&dma1 2 87 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					    STM32_DMA_16BITS) 0>;
+				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(1)>;
-			dmas = <&dma1 3 88 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					    STM32_DMA_16BITS) 0>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma1 2 87 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma1 3 88 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
+				status = "disabled";
+			};
 		};
 
 		comp1_ch1: comparator@5800380c {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1051,28 +1051,26 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@42005804 {
+		sai1: sai1@42005800 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x42005804 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
-				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
-			dmas = <&gpdma1 1 63 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
+				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(0)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@42005824 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x42005824 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
-				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
-			dmas = <&gpdma1 0 64 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&gpdma1 1 63 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&gpdma1 0 64 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		ltdc: ltdc@50001000 {

--- a/dts/arm/st/l4/stm32l4_sai.dtsi
+++ b/dts/arm/st/l4/stm32l4_sai.dtsi
@@ -6,28 +6,26 @@
 
 / {
 	soc {
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
-			dmas = <&dma2 1 1 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
-			dmas = <&dma2 2 1 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					   STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -841,28 +841,28 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
-			dmas = <&dma1 1 37 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					    STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
-			dmas = <&dma1 2 38 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					    STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				compatible = "st,stm32-sai-sub";
+				reg = <0x4>;
+				dmas = <&dma1 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				compatible = "st,stm32-sai-sub";
+				reg = <0x24>;
+				dmas = <&dma1 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		crc: crc@40023000 {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1471,52 +1471,50 @@
 				status = "disabled";
 			};
 
-			sai1_a: sai1@2005804 {
+			sai1: sai1@2005800 {
 				compatible = "st,stm32-sai";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x2005804 0x20>;
+				reg = <0x2005800 0x400>;
 				clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-				dmas = <&gpdma1 1 91 (STM32_DMA_MODE_NORMAL |
-						      STM32_DMA_PRIORITY_HIGH |
-						      STM32_DMA_16BITS)>;
 				status = "disabled";
+
+				sai1_a: sai1a@4 {
+					reg = <0x4>;
+					dmas = <&gpdma1 1 91
+						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					status = "disabled";
+				};
+
+				sai1_b: sai1b@24 {
+					reg = <0x24>;
+					dmas = <&gpdma1 0 92
+						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					status = "disabled";
+				};
 			};
 
-			sai1_b: sai1@2005824 {
+			sai2: sai2@2005c00 {
 				compatible = "st,stm32-sai";
 				#address-cells = <1>;
 				#size-cells = <0>;
-				reg = <0x2005824 0x20>;
-				clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-				dmas = <&gpdma1 0 92 (STM32_DMA_MODE_NORMAL |
-						      STM32_DMA_PRIORITY_HIGH |
-						      STM32_DMA_16BITS)>;
-				status = "disabled";
-			};
-
-			sai2_a: sai2@2005c04 {
-				compatible = "st,stm32-sai";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				reg = <0x2005c04 0x20>;
+				reg = <0x2005c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-				dmas = <&gpdma1 3 93 (STM32_DMA_MODE_NORMAL |
-						      STM32_DMA_PRIORITY_HIGH |
-						      STM32_DMA_16BITS)>;
 				status = "disabled";
-			};
 
-			sai2_b: sai2@2005c24 {
-				compatible = "st,stm32-sai";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				reg = <0x2005c24 0x20>;
-				clocks = <&rcc STM32_CLOCK(APB2, 22)>;
-				dmas = <&gpdma1 2 94 (STM32_DMA_MODE_NORMAL |
-						      STM32_DMA_PRIORITY_HIGH |
-						      STM32_DMA_16BITS)>;
-				status = "disabled";
+				sai2_a: sai2a@4 {
+					reg = <0x4>;
+					dmas = <&gpdma1 3 93
+						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					status = "disabled";
+				};
+
+				sai2_b: sai2b@24 {
+					reg = <0x24>;
+					dmas = <&gpdma1 2 94
+						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+					status = "disabled";
+				};
 			};
 
 			npu: npu@80e0000 {

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -484,26 +484,25 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			dmas = <&gpdma1 1 36 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			dmas = <&gpdma1 0 37 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		usb: usb@40016000 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -529,28 +529,26 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 36 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 37 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 
 		timers1: timers@40012c00 {

--- a/dts/arm/st/wba/stm32wba55.dtsi
+++ b/dts/arm/st/wba/stm32wba55.dtsi
@@ -10,28 +10,26 @@
 	soc {
 		compatible = "st,stm32wba55", "st,stm32wba", "simple-bus";
 
-		sai1_a: sai1@40015404 {
+		sai1: sai1@40015400 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
+			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 17 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
 			status = "disabled";
-		};
 
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 18 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-					      STM32_DMA_16BITS)>;
-			status = "disabled";
+			sai1_a: sai1a@4 {
+				reg = <0x4>;
+				dmas = <&gpdma1 1 17 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
+
+			sai1_b: sai1b@24 {
+				reg = <0x24>;
+				dmas = <&gpdma1 0 18 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -1,69 +1,82 @@
 # Copyright (c) 2024 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 SAI controller
+description: STM32 SAI Block controller
 
 compatible: "st,stm32-sai"
 
-include: [i2s-controller.yaml, pinctrl-device.yaml]
+include: i2s-controller.yaml
 
 properties:
   reg:
     required: true
 
-  dmas:
-    required: true
+child-binding:
+  description: SAI Sub-Block instances linked to SAI Block Controller
 
-  dma-names:
-    required: true
-    description: |
-      DMA channel name: "tx" or "rx", depending of expected device behavior.
+  properties:
+    reg:
+      type: int
+      required: true
 
-  pinctrl-0:
-    required: true
+    dmas:
+      type: phandle-array
+      required: true
 
-  pinctrl-names:
-    required: true
+    dma-names:
+      type: string-array
+      required: true
+      description: |
+        DMA channel name: "tx" or "rx", depending of expected device behavior.
+      enum: [tx, rx]
 
-  mclk-enable:
-    type: boolean
-    description: |
-      Master Clock Output function.
-      An mck pin must be listed within pinctrl-0 when enabling this property.
+    pinctrl-0:
+      type: phandles
+      required: true
 
-  mclk-divider:
-    type: string
-    default: "no-div"
-    description: |
-      Master Clock Divider Configuration.
+    pinctrl-names:
+      type: string-array
+      required: true
 
-      When no-div property is present:
-      - MCKDIV = SAI_CK_x / (FS * (FRL + 1))
-      Otherwise:
-      - MCKDIV = SAI_CK_x / (FS * (OSR + 1) * 256)
+    mclk-enable:
+      type: boolean
+      description: |
+        Master Clock Output function.
+        An mck pin must be listed within pinctrl-0 when enabling this property.
 
-      When div-256 is present OSR is set to 0.
-      When div-512 is present OSR is set to 1.
-    enum:
-      - "no-div"
-      - "div-256"
-      - "div-512"
+    mclk-divider:
+      type: string
+      default: "no-div"
+      description: |
+        Master Clock Divider Configuration.
 
-  synchronous:
-    type: boolean
-    description: |
-      Synchronous mode.
-      When present, the SAI controller is configured to work in synchronous mode.
+        When no-div property is present:
+        - MCKDIV = SAI_CK_x / (FS * (FRL + 1))
+        Otherwise:
+        - MCKDIV = SAI_CK_x / (FS * (OSR + 1) * 256)
 
-  fifo-threshold:
-    type: string
-    default: "full"
-    description: |
-      SAI Block Fifo Threshold defines the fill level at which the peripheral
-      triggers a DMA request or interrupt to transfer data
-    enum:
-      - "empty"
-      - "1/4"
-      - "1/2"
-      - "3/4"
-      - "full"
+        When div-256 is present OSR is set to 0.
+        When div-512 is present OSR is set to 1.
+      enum:
+        - "no-div"
+        - "div-256"
+        - "div-512"
+
+    synchronous:
+      type: boolean
+      description: |
+        Synchronous mode.
+        When present, the SAI controller is configured to work in synchronous mode.
+
+    fifo-threshold:
+      type: string
+      default: "full"
+      description: |
+        SAI Block Fifo Threshold defines the fill level at which the peripheral
+        triggers a DMA request or interrupt to transfer data
+      enum:
+        - "empty"
+        - "1/4"
+        - "1/2"
+        - "3/4"
+        - "full"

--- a/samples/drivers/i2s/output/boards/nucleo_f429zi.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_f429zi.overlay
@@ -20,6 +20,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_b {
 	pinctrl-0 = <&sai1_mclk_b_pf7 &sai1_sd_b_pe3 &sai1_fs_b_pf9 &sai1_sck_b_pf8>;
 	pinctrl-names = "default";

--- a/samples/drivers/i2s/output/boards/nucleo_f767zi.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_f767zi.overlay
@@ -20,6 +20,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_b {
 	pinctrl-0 = <&sai1_mclk_b_pf7 &sai1_sd_b_pe3 &sai1_fs_b_pf9 &sai1_sck_b_pf8>;
 	pinctrl-names = "default";

--- a/samples/drivers/i2s/output/boards/nucleo_g431kb.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_g431kb.overlay
@@ -15,6 +15,10 @@
 	div-q = <8>;
 };
 
+&sai1 {
+	status = "okay";
+};
+
 /* MCLK is not enabled */
 /* SAI1_A MCLK (PB8) is not available on the Arduino Nano header */
 &sai1_a {

--- a/samples/drivers/i2s/output/boards/nucleo_h563zi.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_h563zi.overlay
@@ -22,9 +22,13 @@
 	status = "okay";
 };
 
-&sai1_a {
+&sai1 {
+	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 		 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
+};
+
+&sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pe2 &sai1_sd_a_pe6
 		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;
 	pinctrl-names = "default";

--- a/samples/drivers/i2s/output/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
@@ -22,6 +22,12 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(APB2, 22)>,
+		 <&rcc STM32_SRC_PLL2_P SAI1_SEL(1)>;
+};
+
 &sai1_b {
 	pinctrl-0 = <&sai1_mclk_b_pf7 &sai1_sd_b_pe3
 		     &sai1_fs_b_pf9 &sai1_sck_b_pf8>;

--- a/samples/drivers/i2s/output/boards/nucleo_h7s3l8.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_h7s3l8.overlay
@@ -24,6 +24,12 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(APB2, 22)>,
+		 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pg7 &sai1_sd_a_pc1
 		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;

--- a/samples/drivers/i2s/output/boards/nucleo_l432kc.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_l432kc.overlay
@@ -25,6 +25,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pa3 &sai1_sd_a_pa10
 		     &sai1_fs_a_pa9 &sai1_sck_a_pa8>;

--- a/samples/drivers/i2s/output/boards/nucleo_l552ze_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_l552ze_q.overlay
@@ -21,6 +21,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pe2 &sai1_sd_a_pe6
 		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;

--- a/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_n657x0_q.overlay
@@ -30,9 +30,13 @@
 };
 
 /* 44.084KHz (-0.03% Error) */
-&sai2_b {
+&sai2 {
+	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 		 <&rcc STM32_SRC_IC7 SAI2_SEL(2)>;
+};
+
+&sai2_b {
 	pinctrl-0 = <&sai2_mclk_b_pe14 &sai2_sd_b_pe7
 		     &sai2_fs_b_pe13 &sai2_sck_b_pe12>;
 	pinctrl-names = "default";

--- a/samples/drivers/i2s/output/boards/nucleo_u385rg_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_u385rg_q.overlay
@@ -12,6 +12,10 @@
 };
 
 /* 46.875KHz (6.29% Error) */
+&sai1 {
+	status = "okay";
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pb8 &sai1_sd_a_pc3 &sai1_fs_a_pb9 &sai1_sck_a_pb10>;
 	pinctrl-names = "default";

--- a/samples/drivers/i2s/output/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_u575zi_q.overlay
@@ -22,6 +22,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_mclk_a_pe2 &sai1_sd_a_pe6
 		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;

--- a/samples/drivers/i2s/output/boards/nucleo_wba55cg.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_wba55cg.overlay
@@ -25,6 +25,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 /* SAI MCLK conflicts with SPI SCK */
 /* SAI FS conflicts with LPUART TX */
 &sai1_b {

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.overlay
@@ -22,6 +22,10 @@
 	status = "okay";
 };
 
+&sai1 {
+	status = "okay";
+};
+
 &sai1_a {
 	pinctrl-0 = <&sai1_sck_a_pe5 &sai1_fs_a_pe4 &sai1_sd_a_pe6>;
 	pinctrl-names = "default";

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -730,6 +730,11 @@ static void *test_i2s_speed_rxtx_configure(void)
 {
 	int ret;
 
+	if (!IS_ENABLED(CONFIG_I2S_TEST_USE_I2S_DIR_BOTH)) {
+		ztest_test_skip();
+		return 0;
+	}
+
 	/* Configure I2S Dir Both transfer. */
 	dev_i2s_rxtx = DEVICE_DT_GET_OR_NULL(I2S_DEV_NODE_RX);
 	zassert_not_null(dev_i2s_rxtx, "receive device not found");


### PR DESCRIPTION
The SAI source clock is currently initialized independently for each node (SAI-A & SAI-B), even though both nodes share the same source clock. The actual design allows users to configure different clock sources per node, which also introduces the possibility of clock mismatches, which can result in conflicts and operational failures on one of the nodes. (Reference: https://github.com/zephyrproject-rtos/zephyr/issues/104117)

**This PR introduces:**
- An updated binding
- A revised block clock
- A revised node configuration
- RX/TX direction guard for SAI configuration
- Initial SAI-SUB state to I2S_STATE_NOT_READY
---

### SAI RX–TX Loopback Test
**Hardware**: Nucleo H563ZI
**Configuration**: Both SAI1_A and SAI1_B enabled

**Log**:
```
<inf> i2s_stm32_sai: sai1@40015400 Init: <OK>
<inf> i2s_stm32_sai: dma@400200d0 Init: <OK>
<inf> i2s_stm32_sai: dma@40020050 Init: <OK>
*** Booting Zephyr OS build v4.3.0-7573-g799f8190bce2 ***
<inf> i2s_stm32_sai: sai1a@40015404 Init: <OK>
<inf> i2s_stm32_sai: sai1b@40015424 Init: <OK>
<dbg> i2s_stm32_sai: sai_sub_trigger: I2S_TRIGGER_START
<dbg> i2s_stm32_sai: sai_sub_trigger: I2S_TRIGGER_START
```
---

### SAI Streaming Test
**Hardware**: Nucleo H745ZI_Q (M7 core)
**Configuration**: SAI1_B enabled as TX target
**Log**:

```
<inf> i2s_stm32_sai: sai1@40015800 Init: <OK>
<inf> i2s_stm32_sai: dma@40020040 Init: <OK>
...
<inf> i2s_stm32_sai: sai1b@40015824 Init: <OK>
<dbg> i2s_stm32_sai: sai_sub_trigger: I2S_TRIGGER_START
<dbg> i2s_stm32_sai: HAL_SAI_TxCpltCallback: Exit TX callback, no more data in the queue
```