### PR TITLE
arch: cortex_m: Kconfig: fix cache line size default setting

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -111,10 +111,10 @@ config CPU_CORTEX_M_HAS_SYSTICK
 	help
 	  This option is enabled when the CPU implements the SysTick timer.
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 32
 
-config ICACHE_LINE_SIZE
+configdefault ICACHE_LINE_SIZE
 	default 32
 
 config CPU_CORTEX_M_HAS_DWT

--- a/drivers/cache/cache_nrf.c
+++ b/drivers/cache/cache_nrf.c
@@ -90,6 +90,7 @@ static inline int _cache_all(NRF_CACHE_Type *cache, enum k_nrf_cache_op op)
 	return 0;
 }
 
+#if defined(ICACHE) || defined(DCACHE)
 #if NRF_CACHE_HAS_LINEADDR
 static inline void _cache_line(NRF_CACHE_Type *cache, enum k_nrf_cache_op op, uintptr_t line_addr)
 {
@@ -129,6 +130,13 @@ static inline int _cache_range(NRF_CACHE_Type *cache, enum k_nrf_cache_op op, vo
 {
 	uintptr_t line_addr = (uintptr_t)addr;
 	uintptr_t end_addr;
+	uint32_t cache_line_size = 0;
+
+	if (cache == NRF_DCACHE) {
+		cache_line_size = CONFIG_DCACHE_LINE_SIZE;
+	} else if (cache == NRF_ICACHE) {
+		cache_line_size = CONFIG_ICACHE_LINE_SIZE;
+	}
 
 	/* Some SOCs has a bug that requires to set 28th bit in the address on
 	 * Trustzone secure builds.
@@ -140,17 +148,21 @@ static inline int _cache_range(NRF_CACHE_Type *cache, enum k_nrf_cache_op op, vo
 
 	end_addr = line_addr + size;
 
-	/*
-	 * Align address to line size
-	 */
-	line_addr &= ~(CONFIG_DCACHE_LINE_SIZE - 1);
+	if (cache_line_size) {
+		__ASSERT_NO_MSG(cache_line_size % 2)
 
-	do {
-		_cache_line(cache, op, line_addr);
-		line_addr += CONFIG_DCACHE_LINE_SIZE;
-	} while (line_addr < end_addr);
+		/*
+		 * Align address to line size
+		 */
+		line_addr &= ~(cache_line_size - 1);
 
-	wait_for_cache(cache);
+		do {
+			_cache_line(cache, op, line_addr);
+			line_addr += cache_line_size;
+		} while (line_addr < end_addr);
+
+		wait_for_cache(cache);
+	}
 
 	return 0;
 }
@@ -184,8 +196,9 @@ static inline int _cache_all_checks(NRF_CACHE_Type *cache, enum k_nrf_cache_op o
 	return _cache_all(cache, op);
 }
 #endif /* NRF_CACHE_HAS_LINEADDR */
+#endif /* ICACHE || DCACHE */
 
-#if defined(NRF_DCACHE) && NRF_CACHE_HAS_TASKS
+#if defined(DCACHE) && defined(NRF_DCACHE) && NRF_CACHE_HAS_TASKS
 
 void cache_data_enable(void)
 {
@@ -291,7 +304,7 @@ int cache_data_flush_and_invd_range(void *addr, size_t size)
 
 #endif /* NRF_DCACHE */
 
-#if defined(NRF_ICACHE) && NRF_CACHE_HAS_TASKS
+#if defined(ICACHE) && defined(NRF_ICACHE) && NRF_CACHE_HAS_TASKS
 
 void cache_instr_enable(void)
 {

--- a/include/zephyr/drivers/usb/udc_buf.h
+++ b/include/zephyr/drivers/usb/udc_buf.h
@@ -15,7 +15,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 
-#if defined(CONFIG_DCACHE) && !defined(CONFIG_UDC_BUF_FORCE_NOCACHE)
+#if defined(CONFIG_DCACHE_LINE_SIZE) && CONFIG_DCACHE_LINE_SIZE > 0 \
+	&& !defined(CONFIG_UDC_BUF_FORCE_NOCACHE)
 /*
  * Here we try to get DMA-safe buffers, but we lack a consistent source of
  * information about data cache properties, such as line cache size, and a

--- a/tests/boards/nrf/dmm/src/main.c
+++ b/tests/boards/nrf/dmm/src/main.c
@@ -140,9 +140,11 @@ static void dmm_check_output_buffer(struct dmm_test_region *dtr, uint32_t *fill_
 	}
 
 	zassert_ok(retval);
-	if (IS_ENABLED(CONFIG_DCACHE) && is_cached) {
+#if defined(CONFIG_DCACHE_LINE_SIZE) && CONFIG_DCACHE_LINE_SIZE > 0
+	if (is_cached) {
 		zassert_true(IS_ALIGNED(buf, CONFIG_DCACHE_LINE_SIZE));
 	}
+#endif
 
 	if (IS_ENABLED(CONFIG_HAS_NORDIC_DMM)) {
 		if (was_prealloc) {
@@ -188,9 +190,11 @@ static void dmm_check_input_buffer(struct dmm_test_region *dtr, uint32_t *fill_v
 		TC_PRINT("%saligned buffer in prepare buf:%p size:%d took %d.%dus (%d cycles)\n",
 			aligned ? "" : "not ", buf, size, cyc_to_us(t), cyc_to_rem_ns(t), t);
 	}
-	if (IS_ENABLED(CONFIG_DCACHE) && is_cached) {
+#if defined(CONFIG_DCACHE_LINE_SIZE) && CONFIG_DCACHE_LINE_SIZE > 0
+	if (is_cached) {
 		zassert_true(IS_ALIGNED(buf, CONFIG_DCACHE_LINE_SIZE));
 	}
+#endif
 
 	if (IS_ENABLED(CONFIG_HAS_NORDIC_DMM)) {
 		if (was_prealloc) {


### PR DESCRIPTION
Setting symbol default value without 'configdefault', or without explicit 'if' checks of dependencies, results in dependency weakening. In this case, I/DCACHE_LINE_SIZE are redefined and set to the given default value even if the dependency D/ICACHE is not enabled.

Also fix some instances where DCACHE_LINE_SIZE is used without check if it's defined (DCache being enabled is not enough bcz of
https://github.com/zephyrproject-rtos/zephyr/blob/3f90fed7947d7a27ca99f9bd4058fbedb1bfcbd3/arch/Kconfig#L1131)