### PR TITLE
arch posix: Correct stack bounds of posix threads

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -9,10 +9,24 @@ menu "Native (POSIX) Architecture Options"
 config ARCH
 	default "posix"
 
+config ARCH_POSIX_UPDATE_STACK_INFO
+	bool "Update thread stack info with real pthread stack bounds"
+	depends on THREAD_STACK_INFO
+	help
+	  When enabled, the POSIX architecture will update each thread's
+	  stack_info to reflect the actual pthread stack instead of the
+	  Zephyr-allocated stack. This is useful for applications that
+	  perform their own stack overflow checking against the real
+	  stack bounds.
+
 config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	int
+	default 60 if 64BIT && ARCH_POSIX_UPDATE_STACK_INFO && STACK_SENTINEL
+	default 56 if 64BIT && ARCH_POSIX_UPDATE_STACK_INFO
 	default 44 if 64BIT && STACK_SENTINEL
 	default 40 if 64BIT
+	default 36 if ARCH_POSIX_UPDATE_STACK_INFO && STACK_SENTINEL
+	default 32 if ARCH_POSIX_UPDATE_STACK_INFO
 	default 28 if STACK_SENTINEL
 	default 24
 	help

--- a/arch/posix/core/posix_core_nsi.c
+++ b/arch/posix/core/posix_core_nsi.c
@@ -62,3 +62,10 @@ int posix_arch_thread_name_set(int thread_idx, const char *str)
 {
 	return nct_thread_name_set(te_state, thread_idx, str);
 }
+
+#if defined(CONFIG_ARCH_POSIX_UPDATE_STACK_INFO)
+void posix_arch_get_thread_stack(int thread_idx, void **stack_addr, unsigned long *stack_size)
+{
+	nct_get_thread_stack(te_state, thread_idx, stack_addr, stack_size);
+}
+#endif

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -53,6 +53,34 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->callee_saved.thread_status = thread_status;
 
 	thread_status->thread_idx = posix_new_thread((void *)thread_status);
+
+#ifdef CONFIG_ARCH_POSIX_UPDATE_STACK_INFO
+	/*
+	 * Correct the stack_info to reflect the actual pthread stack.
+	 * The POSIX arch uses native pthread stacks instead of the
+	 * Zephyr-allocated stack, so stack_info needs to be updated.
+	 * Save the original values so they can be restored during abort
+	 * for consumers like CMSIS that derive thread identity from
+	 * the stack address.
+	 */
+	void *stack_addr;
+	unsigned long stack_size;
+
+	thread_status->zephyr_stack_start = thread->stack_info.start;
+	thread_status->zephyr_stack_size = thread->stack_info.size;
+
+	posix_arch_get_thread_stack(thread_status->thread_idx, &stack_addr, &stack_size);
+	thread->stack_info.start = (uintptr_t)stack_addr;
+	thread->stack_info.size = stack_size;
+	thread->stack_info.delta = 0;
+#if defined(CONFIG_STACK_SENTINEL)
+	/* Set the stack sentinel again, but now where the kernel will check after updating the
+	 * stack_info. This assumes the stack grows down, which is the case in most architectures
+	 * including x86 and arm/aarch64.
+	 */
+	*((uint32_t *)thread->stack_info.start) = STACK_SENTINEL;
+#endif /* CONFIG_STACK_SENTINEL */
+#endif /* CONFIG_ARCH_POSIX_UPDATE_STACK_INFO */
 }
 
 int arch_thread_name_set(struct k_thread *thread, const char *str)
@@ -149,6 +177,15 @@ void z_impl_k_thread_abort(k_tid_t thread)
 		}
 		posix_abort_thread(thread_idx);
 	}
+
+#ifdef CONFIG_ARCH_POSIX_UPDATE_STACK_INFO
+	/* Restore the original Zephyr stack info so that thread_abort_hook
+	 * consumers (e.g. CMSIS) that derive thread identity from the
+	 * stack address see the expected values.
+	 */
+	thread->stack_info.start = tstatus->zephyr_stack_start;
+	thread->stack_info.size = tstatus->zephyr_stack_size;
+#endif
 
 	z_thread_abort(thread);
 

--- a/arch/posix/include/posix_core.h
+++ b/arch/posix/include/posix_core.h
@@ -19,6 +19,14 @@ typedef struct {
 	void *arg2;
 	void *arg3;
 
+#if defined(CONFIG_ARCH_POSIX_UPDATE_STACK_INFO)
+	/* Original Zephyr-allocated stack info, saved before being
+	 * overwritten with the real pthread stack bounds.
+	 */
+	uintptr_t zephyr_stack_start;
+	size_t zephyr_stack_size;
+#endif
+
 	int thread_idx;
 
 #if defined(CONFIG_ARCH_HAS_THREAD_ABORT)
@@ -31,9 +39,13 @@ typedef struct {
 	 * Note: If more elements are added to this structure, remember to
 	 * update ARCH_POSIX_RECOMMENDED_STACK_SIZE in the configuration.
 	 *
-	 * Currently there are 4 pointers + 2 ints, on a 32-bit build this will result in 24 bytes
-	 * (4*4 + 2*4).
-	 * For a 64-bit build the recommended stack size will be 40 bytes ( 4*8 + 2*4 ).
+	 * Without CONFIG_ARCH_POSIX_UPDATE_STACK_INFO or CONFIG_ARCH_HAS_THREAD_ABORT:
+	 *   4 pointers + 1 int
+	 *   32-bit: 4*4 + 1*4 = 20 bytes
+	 *   64-bit: 4*8 + 1*4 = 36 bytes
+	 * With CONFIG_ARCH_HAS_THREAD_ABORT adds 1 int (4 bytes).
+	 * With CONFIG_ARCH_POSIX_UPDATE_STACK_INFO adds 1 pointer + 1 size_t
+	 *   (32-bit: 8 bytes, 64-bit: 16 bytes).
 	 */
 } posix_thread_status_t;
 
@@ -47,6 +59,7 @@ int posix_new_thread(void *payload);
 void posix_abort_thread(int thread_idx);
 int posix_arch_get_unique_thread_id(int thread_idx);
 int posix_arch_thread_name_set(int thread_idx, const char *str);
+void posix_arch_get_thread_stack(int thread_idx, void **stack_addr, unsigned long *stack_size);
 
 #ifndef POSIX_ARCH_DEBUG_PRINTS
 #define POSIX_ARCH_DEBUG_PRINTS 0

--- a/scripts/native_simulator/common/src/include/nct_if.h
+++ b/scripts/native_simulator/common/src/include/nct_if.h
@@ -26,6 +26,7 @@ int nct_new_thread(void *this, void *payload);
 void nct_abort_thread(void *this, int thread_idx);
 int nct_get_unique_thread_id(void *this, int thread_idx);
 int nct_thread_name_set(void *this, int thread_idx, const char *str);
+void nct_get_thread_stack(void *this, int thread_idx, void **stack_addr, unsigned long *stack_size);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/nct.c
+++ b/scripts/native_simulator/common/src/nct.c
@@ -423,6 +423,26 @@ int nct_new_thread(void *this_arg, void *payload)
 }
 
 /**
+ * Get the stack address and size for a thread.
+ */
+void nct_get_thread_stack(void *this_arg, int thread_idx, void **stack_addr,
+			 unsigned long *stack_size)
+{
+	struct nct_status_t *this = (struct nct_status_t *)this_arg;
+	struct threads_table_el *tt_el = ttable_get_element(this, thread_idx);
+	pthread_attr_t attr;
+	size_t stack_size_local;
+
+	NSI_SAFE_CALL(pthread_getattr_np(tt_el->thread, &attr));
+
+	NSI_SAFE_CALL(pthread_attr_getstack(&attr, stack_addr, &stack_size_local));
+
+	*stack_size = stack_size_local;
+
+	NSI_SAFE_CALL(pthread_attr_destroy(&attr));
+}
+
+/**
  * Initialize an instance of the threading emulator.
  *
  * Returns a pointer to the initialize threading emulator instance.


### PR DESCRIPTION
The native_sim uses the pthread stack instead of the Zephyr allocated ones. This updates the posix arch to make the real stack bounds available in thread info. (CircuitPython uses this to do it's own stack overflow checking and recovery.)