### PR TITLE
drivers: gpio: max149x6: Fix error propagation and diagnostic handling

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -28,6 +28,7 @@ static int max14906_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 {
 	struct max14906_data *data = dev->data;
 	int ret = 0;
+	int diag_ret;
 
 	if (rx_diag_buff[0]) {
 		LOG_ERR("[DIAG] MAX14906 in SPI diag - error detected\n");
@@ -65,7 +66,10 @@ static int max14906_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 			MAX149X6_GET_BIT(rx_diag_buff[1], 2), MAX149X6_GET_BIT(rx_diag_buff[1], 3));
 		if (rx_diag_buff[1] & 0x0f) {
 			LOG_ERR("[DIAG] gpio_max14906_diag_chan_get(%x)\n", rx_diag_buff[1] & 0x0f);
-			ret = gpio_max14906_diag_chan_get(dev);
+			diag_ret = gpio_max14906_diag_chan_get(dev);
+			if (diag_ret) {
+				ret = diag_ret;
+			}
 		}
 	}
 

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -400,14 +400,29 @@ static int gpio_max14906_config_diag(const struct device *dev)
 {
 	const struct max14906_data *data = dev->data;
 	const struct max14906_config *config = dev->config;
+	int ret;
 
 	/* Set Config1 and Config2 regs */
-	MAX14906_REG_WRITE(dev, MAX14906_CONFIG1_REG, config->config1.reg_raw);
-	MAX14906_REG_WRITE(dev, MAX14906_CONFIG2_REG, config->config2.reg_raw);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_CONFIG1_REG, config->config1.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14906_REG_WRITE(dev, MAX14906_CONFIG2_REG, config->config2.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* Configure per channel diagnostics */
-	MAX14906_REG_WRITE(dev, MAX14906_OPN_WR_EN_REG, data->chan_en.opn_wr_en.reg_raw);
-	MAX14906_REG_WRITE(dev, MAX14906_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en.reg_raw);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_OPN_WR_EN_REG, data->chan_en.opn_wr_en.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
 
 	return 0;
 }
@@ -498,10 +513,19 @@ static int gpio_max14906_init(const struct device *dev)
 	}
 
 	int ret = gpio_max14906_clean_on_power(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
-	MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, 0);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, 0);
+	if (ret < 0) {
+		return ret;
+	}
 
-	gpio_max14906_config_diag(dev);
+	ret = gpio_max14906_config_diag(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	LOG_DBG(" --- GPIO MAX14906 init OUT ---");
 

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -141,6 +141,13 @@ static int gpio_max14906_diag_chan_get(const struct device *dev)
 	}
 	data->glob.interrupt.reg_raw = ret;
 
+	/* clear stale cached faults */
+	data->chan.ovr_ld.reg_raw = 0;
+	data->chan.opn_wir.reg_raw = 0;
+	data->chan.sht_vdd.reg_raw = 0;
+	data->chan.doi_level.reg_raw = 0;
+	data->glob.glob_err.reg_raw = 0;
+
 	if (data->glob.interrupt.reg_raw) {
 		if (data->glob.interrupt.reg_bits.OVER_LD_FAULT ||
 		    data->glob.interrupt.reg_bits.CURR_LIM) {

--- a/drivers/gpio/gpio_max14906.h
+++ b/drivers/gpio/gpio_max14906.h
@@ -291,8 +291,8 @@ struct max149x6_config {
 	union max14906_config1 config1;
 	union max14906_config2 config2;
 	union max14906_config_curr_lim curr_lim;
-	union max14906_config_di config_do;
-	union max14906_config_do config_di;
+	union max14906_config_do config_do;
+	union max14906_config_di config_di;
 	enum max149x6_spi_addr spi_addr;
 	uint8_t pkt_size;
 };

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -26,6 +26,7 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 {
 	struct max14916_data *data = dev->data;
 	int ret = 0;
+	int diag_ret;
 
 	if (rx_diag_buff[0]) {
 		LOG_ERR("[DIAG] MAX14916 in SPI diag - error detected");
@@ -68,7 +69,10 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 
 		if (rx_diag_buff[1]) {
 			LOG_ERR("[DIAG] gpio_max14916_diag_chan_get(%x)\n", rx_diag_buff[1] & 0x0f);
-			ret = gpio_max14916_diag_chan_get(dev);
+			diag_ret = gpio_max14916_diag_chan_get(dev);
+			if (diag_ret) {
+				ret = diag_ret;
+			}
 		}
 	}
 

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -120,6 +120,14 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 	}
 	data->glob.interrupt.reg_raw = ret;
 
+	/* clear stale cached faults */
+	data->chan.ovr_ld = 0;
+	data->chan.curr_lim = 0;
+	data->chan.ow_off = 0;
+	data->chan.ow_on = 0;
+	data->chan.sht_vdd = 0;
+	data->glob.glob_err.reg_raw = 0;
+
 	if (data->glob.interrupt.reg_raw) {
 		if (data->glob.interrupt.reg_bits.OVER_LD_FLT) {
 			ret = max149x6_reg_transceive(dev, MAX14916_OVR_LD_REG, 0, NULL,

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -102,41 +102,70 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 {
 	const struct max14916_config *config = dev->config;
 	struct max14916_data *data = dev->data;
-	int ret = 0;
+	int ret;
+	int diag_ret = 0;
 
 	if (!gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR("FLT flag is rised");
-		ret = -EIO;
+		diag_ret = -EIO;
 	}
 
-	data->glob.interrupt.reg_raw =
-		max149x6_reg_transceive(dev, MAX14916_INT_REG, 0, NULL, MAX149x6_READ);
+	ret = max149x6_reg_transceive(dev, MAX14916_INT_REG, 0, NULL, MAX149x6_READ);
+	if (ret < 0) {
+		return ret;
+	}
+	data->glob.interrupt.reg_raw = ret;
 
 	if (data->glob.interrupt.reg_raw) {
 		if (data->glob.interrupt.reg_bits.OVER_LD_FLT) {
-			data->chan.ovr_ld = max149x6_reg_transceive(dev, MAX14916_OVR_LD_REG, 0,
-								    NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_OVR_LD_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->chan.ovr_ld = ret;
 		}
 		if (data->glob.interrupt.reg_bits.CURR_LIM) {
-			data->chan.curr_lim = max149x6_reg_transceive(dev, MAX14916_CURR_LIM_REG, 0,
-								      NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_CURR_LIM_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->chan.curr_lim = ret;
 		}
 		if (data->glob.interrupt.reg_bits.OW_OFF_FLT) {
-			data->chan.ow_off = max149x6_reg_transceive(dev, MAX14916_OW_OFF_FLT_REG, 0,
-								    NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_OW_OFF_FLT_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->chan.ow_off = ret;
 		}
 		if (data->glob.interrupt.reg_bits.OW_ON_FLT) {
-			data->chan.ow_on = max149x6_reg_transceive(dev, MAX14916_OW_ON_FLT_REG, 0,
-								   NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_OW_ON_FLT_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->chan.ow_on = ret;
 		}
 		if (data->glob.interrupt.reg_bits.SHT_VDD_FLT) {
-			data->chan.sht_vdd = max149x6_reg_transceive(dev, MAX14916_SHT_VDD_FLT_REG,
-								     0, NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_SHT_VDD_FLT_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->chan.sht_vdd = ret;
 		}
 
 		if (data->glob.interrupt.reg_bits.SUPPLY_ERR) {
-			data->glob.glob_err.reg_raw = max149x6_reg_transceive(
-				dev, MAX14916_GLOB_ERR_REG, 0, NULL, MAX149x6_READ);
+			ret = max149x6_reg_transceive(dev, MAX14916_GLOB_ERR_REG, 0, NULL,
+						      MAX149x6_READ);
+			if (ret < 0) {
+				return ret;
+			}
+			data->glob.glob_err.reg_raw = ret;
+
 			PRINT_ERR(data->glob.glob_err.reg_bits.VINT_UV);
 			PRINT_ERR(data->glob.glob_err.reg_bits.VA_UVLO);
 			PRINT_ERR(data->glob.glob_err.reg_bits.VDD_BAD);
@@ -150,10 +179,10 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 		if (data->glob.interrupt.reg_bits.COM_ERR) {
 			LOG_ERR("MAX14916 Communication Error");
 		}
-		ret = -EIO;
+		diag_ret = -EIO;
 	}
 
-	return ret;
+	return diag_ret;
 }
 
 static int gpio_max14916_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
@@ -162,6 +191,9 @@ static int gpio_max14916_port_set_bits_raw(const struct device *dev, gpio_port_p
 	uint32_t reg_val = 0;
 
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	if (ret < 0) {
+		return ret;
+	}
 	reg_val = ret | pins;
 
 	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
@@ -173,6 +205,9 @@ static int gpio_max14916_port_clear_bits_raw(const struct device *dev, gpio_port
 	uint32_t reg_val = 0;
 
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	if (ret < 0) {
+		return ret;
+	}
 	reg_val = ret & ~pins;
 
 	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
@@ -186,6 +221,9 @@ static int gpio_max14916_port_set_masked_raw(const struct device *dev,
 	uint32_t reg_val;
 
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	if (ret < 0) {
+		return ret;
+	}
 	reg_val = (ret & ~mask) | (value & mask);
 
 	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
@@ -230,7 +268,14 @@ static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_f
 
 static int gpio_max14916_port_get_raw(const struct device *dev, gpio_port_value_t *value)
 {
-	*value = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	int ret;
+
+	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*value = ret;
 
 	return 0;
 }
@@ -241,6 +286,9 @@ static int gpio_max14916_port_toggle_bits(const struct device *dev, gpio_port_pi
 	uint32_t reg_val = 0;
 
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
+	if (ret < 0) {
+		return ret;
+	}
 
 	reg_val = ret;
 	reg_val ^= pins;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -362,17 +362,17 @@ static int gpio_max14916_config_diag(const struct device *dev)
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en.reg_raw);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en.reg_raw);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en.reg_raw);
 	if (ret < 0) {
 		return ret;
 	}
@@ -501,7 +501,41 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 		.spi_addr = DT_INST_PROP(id, spi_addr),                                            \
 	};                                                                                         \
                                                                                                    \
-	static struct max14916_data max##model##_##id##_data;                                      \
+	static struct max14916_data max##model##_##id##_data = {                                   \
+		.chan_en.ow_on_en.reg_bits =                                                       \
+			{                                                                          \
+				.OW_ON_EN1 = DT_INST_PROP_BY_IDX(id, ow_on_en, 0),                 \
+				.OW_ON_EN2 = DT_INST_PROP_BY_IDX(id, ow_on_en, 1),                 \
+				.OW_ON_EN3 = DT_INST_PROP_BY_IDX(id, ow_on_en, 2),                 \
+				.OW_ON_EN4 = DT_INST_PROP_BY_IDX(id, ow_on_en, 3),                 \
+				.OW_ON_EN5 = DT_INST_PROP_BY_IDX(id, ow_on_en, 4),                 \
+				.OW_ON_EN6 = DT_INST_PROP_BY_IDX(id, ow_on_en, 5),                 \
+				.OW_ON_EN7 = DT_INST_PROP_BY_IDX(id, ow_on_en, 6),                 \
+				.OW_ON_EN8 = DT_INST_PROP_BY_IDX(id, ow_on_en, 7),                 \
+			},                                                                         \
+		.chan_en.ow_off_en.reg_bits =                                                      \
+			{                                                                          \
+				.OW_OFF_EN1 = DT_INST_PROP_BY_IDX(id, ow_off_en, 0),               \
+				.OW_OFF_EN2 = DT_INST_PROP_BY_IDX(id, ow_off_en, 1),               \
+				.OW_OFF_EN3 = DT_INST_PROP_BY_IDX(id, ow_off_en, 2),               \
+				.OW_OFF_EN4 = DT_INST_PROP_BY_IDX(id, ow_off_en, 3),               \
+				.OW_OFF_EN5 = DT_INST_PROP_BY_IDX(id, ow_off_en, 4),               \
+				.OW_OFF_EN6 = DT_INST_PROP_BY_IDX(id, ow_off_en, 5),               \
+				.OW_OFF_EN7 = DT_INST_PROP_BY_IDX(id, ow_off_en, 6),               \
+				.OW_OFF_EN8 = DT_INST_PROP_BY_IDX(id, ow_off_en, 7),               \
+			},                                                                         \
+		.chan_en.sht_vdd_en.reg_bits =                                                     \
+			{                                                                          \
+				.SH_VDD_EN1 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 0),               \
+				.SH_VDD_EN2 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 1),               \
+				.SH_VDD_EN3 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 2),               \
+				.SH_VDD_EN4 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 3),               \
+				.SH_VDD_EN5 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 4),               \
+				.SH_VDD_EN6 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 5),               \
+				.SH_VDD_EN7 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 6),               \
+				.SH_VDD_EN8 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 7),               \
+			},                                                                         \
+	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(id, &gpio_max14916_init, NULL, &max##model##_##id##_data,            \
 			      &max##model##_##id##_cfg, POST_KERNEL,                               \

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -293,9 +293,7 @@ static int gpio_max14916_port_toggle_bits(const struct device *dev, gpio_port_pi
 	reg_val = ret;
 	reg_val ^= pins;
 
-	MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
-
-	return 0;
+	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
 }
 
 static int gpio_max14916_clean_on_power(const struct device *dev)
@@ -335,12 +333,33 @@ static int gpio_max14916_config_diag(const struct device *dev)
 {
 	const struct max14916_config *config = dev->config;
 	struct max14916_data *data = dev->data;
+	int ret;
 
-	MAX14916_REG_WRITE(dev, MAX14916_CONFIG1_REG, config->config1.reg_raw);
-	MAX14916_REG_WRITE(dev, MAX14916_CONFIG2_REG, config->config2.reg_raw);
-	MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_on_en);
-	MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en);
-	MAX14916_REG_WRITE(dev, MAX14916_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_CONFIG1_REG, config->config1.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14916_REG_WRITE(dev, MAX14916_CONFIG2_REG, config->config2.reg_raw);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_on_en);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -413,10 +432,19 @@ static int gpio_max14916_init(const struct device *dev)
 	LOG_ERR("[GPIO] EN    - %d\n", gpio_pin_get_dt(&config->en_gpio));
 
 	int ret = gpio_max14916_clean_on_power(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
-	MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, 0);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, 0);
+	if (ret < 0) {
+		return ret;
+	}
 
-	gpio_max14916_config_diag(dev);
+	ret = gpio_max14916_config_diag(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	LOG_DBG(" --- GPIO MAX14916 init OUT ---");
 

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -50,7 +50,7 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 		PRINT_ERR(data->glob.interrupt.reg_bits.OVER_LD_FLT);
 	}
 
-	if (rw == MAX149x6_WRITE && (rx_diag_buff[1] & 0x0f)) {
+	if (rw == MAX149x6_WRITE && rx_diag_buff[1]) {
 		/* +-----------------------------------------------------------------------+
 		 * | LSB                             BYTE 2                            MSB |
 		 * +--------+--------+--------+--------+--------+--------+--------+--------+
@@ -67,7 +67,7 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 			MAX149X6_GET_BIT(rx_diag_buff[1], 4), MAX149X6_GET_BIT(rx_diag_buff[1], 5),
 			MAX149X6_GET_BIT(rx_diag_buff[1], 6), MAX149X6_GET_BIT(rx_diag_buff[1], 7));
 
-		LOG_ERR("[DIAG] gpio_max14916_diag_chan_get(%x)\n", rx_diag_buff[1] & 0x0f);
+		LOG_ERR("[DIAG] gpio_max14916_diag_chan_get(%x)\n", rx_diag_buff[1]);
 		diag_ret = gpio_max14916_diag_chan_get(dev);
 		if (diag_ret < 0) {
 			ret = diag_ret;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -362,7 +362,7 @@ static int gpio_max14916_config_diag(const struct device *dev)
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_on_en);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -252,9 +252,9 @@ static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_f
 	switch (flags & GPIO_DIR_MASK) {
 	case GPIO_OUTPUT:
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
-			gpio_max14916_port_set_bits_raw(dev, BIT(pin));
+			err = gpio_max14916_port_set_bits_raw(dev, BIT(pin));
 		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
-			gpio_max14916_port_clear_bits_raw(dev, BIT(pin));
+			err = gpio_max14916_port_clear_bits_raw(dev, BIT(pin));
 		}
 		break;
 	case GPIO_INPUT:

--- a/drivers/gpio/gpio_max14916.h
+++ b/drivers/gpio/gpio_max14916.h
@@ -161,6 +161,48 @@ union max14916_global_err {
 	} reg_bits;
 };
 
+union max14916_ow_off_en {
+	uint8_t reg_raw;
+	struct {
+		uint8_t OW_OFF_EN1: 1; /* BIT0 */
+		uint8_t OW_OFF_EN2: 1;
+		uint8_t OW_OFF_EN3: 1;
+		uint8_t OW_OFF_EN4: 1;
+		uint8_t OW_OFF_EN5: 1;
+		uint8_t OW_OFF_EN6: 1;
+		uint8_t OW_OFF_EN7: 1;
+		uint8_t OW_OFF_EN8: 1; /* BIT7 */
+	} reg_bits;
+};
+
+union max14916_ow_on_en {
+	uint8_t reg_raw;
+	struct {
+		uint8_t OW_ON_EN1: 1; /* BIT0 */
+		uint8_t OW_ON_EN2: 1;
+		uint8_t OW_ON_EN3: 1;
+		uint8_t OW_ON_EN4: 1;
+		uint8_t OW_ON_EN5: 1;
+		uint8_t OW_ON_EN6: 1;
+		uint8_t OW_ON_EN7: 1;
+		uint8_t OW_ON_EN8: 1; /* BIT7 */
+	} reg_bits;
+};
+
+union max14916_sht_vdd_en {
+	uint8_t reg_raw;
+	struct {
+		uint8_t SH_VDD_EN1: 1; /* BIT0 */
+		uint8_t SH_VDD_EN2: 1;
+		uint8_t SH_VDD_EN3: 1;
+		uint8_t SH_VDD_EN4: 1;
+		uint8_t SH_VDD_EN5: 1;
+		uint8_t SH_VDD_EN6: 1;
+		uint8_t SH_VDD_EN7: 1;
+		uint8_t SH_VDD_EN8: 1; /* BIT7 */
+	} reg_bits;
+};
+
 struct max149x6_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec fault_gpio;
@@ -186,9 +228,9 @@ struct max14916_data {
 		uint8_t sht_vdd;
 	} chan;
 	struct {
-		uint8_t ow_off_en;
-		uint8_t ow_on_en;
-		uint8_t sht_vdd_en;
+		union max14916_ow_off_en ow_off_en;
+		union max14916_ow_on_en ow_on_en;
+		union max14916_sht_vdd_en sht_vdd_en;
 	} chan_en;
 	struct {
 		union max14916_interrupt interrupt;

--- a/drivers/gpio/gpio_max149x6.h
+++ b/drivers/gpio/gpio_max149x6.h
@@ -82,6 +82,8 @@ static uint8_t max149x6_crc(uint8_t *data, bool encode, uint8_t check_byte)
  * @param dev - MAX149x6 device config.
  * @param addr - Register value to which data is written.
  * @param val - Value which is to be written to requested register.
+ * @param rx_diag_buff - Optional buffer for received diagnostic bytes.
+ * @param rw - Transaction direction (MAX149x6_READ or MAX149x6_WRITE).
  * @return 0 in case of success, negative error code otherwise.
  */
 static int max149x6_reg_transceive(const struct device *dev, uint8_t addr, uint8_t val,
@@ -134,17 +136,22 @@ static int max149x6_reg_transceive(const struct device *dev, uint8_t addr, uint8
 		}
 	}
 
+	/* byte0 is first diagnostic byte */
 	if (rx_diag_buff != NULL) {
 		rx_diag_buff[0] = local_rx_buff[0];
 	}
 
-	/* In case of write we are getting 2 diagnostic bytes - byte0 & byte1
-	 * and pass them to diag buffer to be parsed in next stage
-	 */
-	if ((MAX149x6_WRITE == rw) && (rx_diag_buff != NULL)) {
-		rx_diag_buff[1] = local_rx_buff[1];
-	} else {
-		ret = local_rx_buff[1];
+	/* byte1 for WRITE: second diagnostic byte */
+	if (MAX149x6_WRITE == rw) {
+		if (rx_diag_buff != NULL) {
+			rx_diag_buff[1] = local_rx_buff[1];
+		}
+		return ret;
+	}
+
+	/* byte1 for READ: register value returned to caller */
+	if (MAX149x6_READ == rw) {
+		return local_rx_buff[1];
 	}
 
 	return ret;

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -599,9 +599,9 @@
 				ngpios = <8>;
 				crc-en;
 				spi-addr = <0>;
-				ow-on-en = <0 0 0 0>;
-				ow-off-en = <0 0 0 0>;
-				sh-vdd-en = <0 0 0 0>;
+				ow-on-en = <0 0 0 0 0 0 0 0>;
+				ow-off-en = <0 0 0 0 0 0 0 0>;
+				sh-vdd-en = <0 0 0 0 0 0 0 0>;
 				drdy-gpios = <&test_gpio 0 0>;
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;


### PR DESCRIPTION
Whilst testing the MAX14906/MAX14916 drivers on a custom board I encountered multiple correctness issues in the upstream implementation. This is a follow up for #104033. See commit headers and bodies for exact details.

The MAX149xx driver family has a sizeable number of correctness issues that prevent reliable use. The correctness fixes in this PR serve only to make the current drivers work correctly, before a more significant refactor can take place.

Headlines of the commits:
drivers: gpio: max149x6: fix spurious error return on write
drivers: gpio: max149x6: propagate SPI read errors
drivers: gpio: max149x6: propagate SPI write errors
drivers: gpio: max149x6: propagate config path errors
drivers: gpio: max149x6: preserve parser fault status
drivers: gpio: max149x6: clear stale diagnostic channel caches
drivers: gpio: max149x6: harmonize diagnostic helper error handling
drivers: gpio: max14916: fix ow_on_en written to wrong register
drivers: gpio: max14916: wire channel-enable DT properties
drivers: gpio: max14916: parse write faults on all channels
drivers: gpio: max14906: fix swapped config_do/config_di types

The overall theme of this PR:
- SPI error propagation
- consistent diagnostic helper behavior and stale-cache cleanup
- MAX14916 DT/register mapping correctness
- MAX14916 fault byte parsing for all 8 channels
- a latent MAX14906 header type swap fix

Larger refactor work is intentionally out of scope for this PR:
- driver locking
- register caching (see #104034)
- public diagnostics API exposure
- general style and idiomacy with respect to other gpio expanders / general zephyr drivers

## Test setup
Custom board with 4x MAX14906. OR connected SPI lines + EN + FAULT + SYNCH (READY pulled low, per datasheet – if not used) to a STM32G0B1CET6 MCU.

Note: changes made to MAX14916 drivers are only things obviously wrong. I have not tested those, but as you can see in the commits, these are mostly errors from copying over MAX14906 code into the MAX14916 specific driver. It made sense to me, given how broken these drivers are, to try to bring these drivers up to speed in tandem.