### PR TITLE
soc: gd32vf103: add soc.h

### DIFF
--- a/soc/gd/gd32/gd32vf103/soc.h
+++ b/soc/gd/gd32/gd32vf103/soc.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Alexander Wachter
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC_ARM_GIGADEVICE_GD32VF103_SOC_H_
+#define _SOC_ARM_GIGADEVICE_GD32VF103_SOC_H_
+
+#ifndef _ASMLANGUAGE
+
+#include <gd32vf103.h>
+
+/* The GigaDevice HAL headers define this, but it conflicts with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* _SOC_ARM_GIGADEVICE_GD32VF103_SOC_H_ */


### PR DESCRIPTION
Add soc.h file that includes the hal soc headers.