### PR TITLE
samples: fs: fs_sample: add Nucleo L4R5ZI SDMMC board support

### DIFF
--- a/samples/subsys/fs/fs_sample/boards/nucleo_l4r5zi.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Waqar Ahmed
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sdmmc1 {
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9 &sdmmc1_d2_pc10
+		     &sdmmc1_d3_pc11 &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	pinctrl-names = "default";
+	bus-width = <4>;
+	disk-name = "SD";
+	status = "okay";
+};


### PR DESCRIPTION
Add overlay and Kconfig fragment for the STM32 Nucleo L4R5ZI board to enable the filesystem sample using native 4-bit SDIO mode via the on-chip SDMMC1 peripheral.