### PR TITLE
samples: drivers:: espi: npcx4: Add missing overlay

### DIFF
--- a/samples/drivers/espi/boards/npcx4m8f_evb.overlay
+++ b/samples/drivers/espi/boards/npcx4m8f_evb.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	board_power: resources {
+		compatible = "intel-rvp,board-power";
+		/* GPIO72 */
+		pwrg-gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+		/* GPIOA5 */
+		rsm-gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&espi0 {
+	status = "okay";
+	pinctrl-0 = <&espi_lpc_gp46_47_51_52_53_54_55_57>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
Adding missing NPCX4 board overlays that enables eSPI

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104433
Depends on https://github.com/zephyrproject-rtos/zephyr/pull/103963
