### PR TITLE
logging: swo: drain hardware pipeline in panic handler

### DIFF
--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -58,6 +58,17 @@ PINCTRL_DT_DEFINE(DT_NODELABEL(itm));
 
 #endif
 
+/*
+ * Estimate TPIU drain time from the configured SWO baud rate.
+ * ~200 bytes * 10 bits/byte with 50% margin, converted to microseconds.
+ * When frequency is 0 (default = max supported), fall back to 2 ms.
+ */
+#if CONFIG_LOG_BACKEND_SWO_FREQ_HZ > 0
+#define SWO_DRAIN_WAIT_US ((200UL * 10 * 1500000) / CONFIG_LOG_BACKEND_SWO_FREQ_HZ)
+#else
+#define SWO_DRAIN_WAIT_US 2000
+#endif
+
 static uint8_t buf[1];
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_SWO_OUTPUT_DEFAULT;
 
@@ -133,6 +144,22 @@ static void log_backend_swo_init(struct log_backend const *const backend)
 
 static void log_backend_swo_panic(struct log_backend const *const backend)
 {
+	ARG_UNUSED(backend);
+
+	/*
+	 * Poll ITM BUSY for up to SWO_DRAIN_WAIT_US. The formatter should
+	 * finish well before the TPIU output stage drains, so using the
+	 * same budget for both is conservative.
+	 */
+	for (uint32_t i = 0;
+	     i < SWO_DRAIN_WAIT_US && (ITM->TCR & ITM_TCR_BUSY_Msk); i++) {
+		k_busy_wait(1);
+	}
+
+	/* ITM BUSY only means the formatter is done — the TPIU output
+	 * buffer still needs time to clock bytes out at the SWO baud rate.
+	 */
+	k_busy_wait(SWO_DRAIN_WAIT_US);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)


### PR DESCRIPTION
The SWO log backend's `panic()` handler is a no-op. When `LOG_PANIC()`
is called (e.g., before a bootloader jumps to an app, or during a fatal
error), the logging subsystem flushes software buffers to the ITM FIFO,
but the TPIU hardware pipeline still has bytes in-flight on the SWO pin.
The debug probe loses these final messages.

This patch:
1. Spins on `ITM_TCR.BUSY` until the ITM formatter is idle
2. Busy-waits for the TPIU output stage to clock remaining bytes out
   at the configured SWO baud rate

The drain time is estimated from `CONFIG_LOG_BACKEND_SWO_FREQ_HZ`
(~200 bytes × 10 bits/byte with 50% margin). When the frequency is
left at 0 (default = max supported), a conservative 2 ms fallback
is used.

Discovered while working on MCUboot, where SWO logs were lost during
the transition from bootloader to app.

Tested on nRF5340 with J-Link SWO viewer.