### PR TITLE
boards: xmc47_relax_kit: fix I2C initialization by adding clock-frequency

### DIFF
--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -10,6 +10,7 @@
 #include <infineon/cat3/xmc/xmc4700_F144x2048.dtsi>
 #include <infineon/cat3/xmc/xmc4700_F144x2048-intc.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "xmc47_relax_kit-pinctrl.dtsi"
 #include "arduino_r3_connector.dtsi"
 
@@ -138,6 +139,7 @@
 
 &usic1ch1 {
 	compatible = "infineon,xmc4xxx-i2c";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 
 	pinctrl-0 = <&i2c_scl_p0_13_u1c1 &i2c_sda_p3_15_u1c1>;


### PR DESCRIPTION
Fix I2C initialization failure on XMC47 Relax Kit by adding the missing 
clock-frequency property to the I2C node.

Without this property, the I2C driver fails to initialize with 
'Invalid I2C bit rate value' error. This change sets the I2C speed to 
I2C_BITRATE_STANDARD (100kHz) as the default.

Fixes #[issue-number] (if there's a related issue)