### PR TITLE
samples: add missing README.rst for five samples

### DIFF
--- a/samples/boards/espressif/ethernet/README.rst
+++ b/samples/boards/espressif/ethernet/README.rst
@@ -1,0 +1,47 @@
+:orphan:
+
+.. _esp32_ethernet_sample:
+
+ESP32 Ethernet
+##############
+
+Overview
+********
+
+This sample demonstrates how to use the Ethernet interface on the ESP32
+Ethernet Kit. It initializes the Ethernet driver with DHCP for automatic
+IPv4 address assignment, enables the network shell for interactive
+debugging, and configures DNS resolution with Google's public DNS server
+(8.8.8.8).
+
+The sample enables the following features:
+
+* ESP32 Ethernet driver (``CONFIG_ETH_ESP32``)
+* IPv4 with DHCPv4 for automatic address configuration
+* DNS resolver for hostname lookups
+* Network shell for interactive network diagnostics (``ping``, ``dns``, etc.)
+
+Requirements
+************
+
+This sample requires the
+`ESP32 Ethernet Kit <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html>`_
+board with an integrated Ethernet PHY.
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/espressif/ethernet
+   :board: esp32_ethernet_kit/esp32/procpu
+   :goals: build flash
+   :compact:
+
+After flashing, the device will attempt to obtain an IPv4 address via DHCP.
+Use the network shell to verify connectivity:
+
+.. code-block:: console
+
+   uart:~$ net iface
+   uart:~$ net ping 8.8.8.8
+   uart:~$ net dns resolve google.com

--- a/samples/boards/microchip/mec172xevb_assy6906/qmspi_ldma/README.rst
+++ b/samples/boards/microchip/mec172xevb_assy6906/qmspi_ldma/README.rst
@@ -1,0 +1,50 @@
+:orphan:
+
+.. _mec172x_qmspi_ldma_sample:
+
+MEC172x QMSPI LDMA
+###################
+
+Overview
+********
+
+This sample demonstrates the Quad-SPI (QMSPI) interface with Local DMA (LDMA)
+on the Microchip MEC172x EVB (``mec172xevb_assy6906``). It exercises SPI flash
+operations using the Zephyr SPI API, including:
+
+* Reading the JEDEC ID (W25Q128, W25Q128JV, or SST26VF016B)
+* Reading and writing SPI flash status registers
+* Erasing sectors and programming pages
+* Reading data in multiple modes: slow (1-1-1-0), fast (1-1-1-8),
+  dual (1-1-2-8), and quad (1-1-4-8)
+* Asynchronous SPI read (when ``CONFIG_SPI_ASYNC`` is enabled)
+* Data integrity verification after erase, program, and read cycles
+
+Requirements
+************
+
+* Microchip MEC172x EVB (``mec172xevb_assy6906``)
+* SPI flash device connected to QSPI0 (W25Q128, W25Q128JV, or SST26VF016B)
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/microchip/mec172xevb_assy6906/qmspi_ldma
+   :board: mec172xevb_assy6906
+   :goals: build flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   JEDEC ID = 0x001840ef
+   W25Q128 16Mbyte SPI flash
+   SPI Flash Status1 = 0x00
+   SPI Flash Status2 = 0x02
+   Quad-Enable bit is set. WP# and HOLD# are IO[2] and IO[3]
+   ...
+   Data matches
+   Program End

--- a/samples/boards/microchip/mec172xevb_assy6906/rom_api/README.rst
+++ b/samples/boards/microchip/mec172xevb_assy6906/rom_api/README.rst
@@ -1,0 +1,48 @@
+:orphan:
+
+.. _mec172x_rom_api_sample:
+
+MEC172x ROM API
+###############
+
+Overview
+********
+
+This sample demonstrates the use of the MEC172x ROM API for hardware-
+accelerated cryptographic hash computations via the Zephyr crypto API.
+It verifies SHA-224, SHA-256, SHA-384, and SHA-512 hash operations using
+known test vectors with multiple message sizes (37, 185, and 238 bytes).
+
+The sample tests:
+
+* Multi-block hash computation with block-aligned updates plus remainder
+* Arbitrary chunk-size hash computation (0, 8, and 23 byte chunks)
+* Digest comparison against pre-computed expected values
+
+Requirements
+************
+
+* Microchip MEC172x EVB (``mec172xevb_assy6906``)
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/microchip/mec172xevb_assy6906/rom_api
+   :board: mec172xevb_assy6906
+   :goals: build flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   It lives! mec172xevb_assy6906
+   ROM API say GIVE MEMORY, MORE MEMORY!
+   ...
+   Test Zephyr crypto hash API for multiblock plus remainder
+   SHA-224
+   Hash computation PASS
+   ...
+   Application done

--- a/samples/boards/nordic/nrf_sys_event/README.rst
+++ b/samples/boards/nordic/nrf_sys_event/README.rst
@@ -1,0 +1,58 @@
+:orphan:
+
+.. _nrf_sys_event_sample:
+
+nRF System Event
+################
+
+Overview
+********
+
+This sample demonstrates the nRF system event API (``nrf_sys_event``)
+for managing power modes on Nordic Semiconductor SoCs. It exercises:
+
+* Requesting and releasing global constant latency mode
+* Reference counting verification (multiple request/release cycles)
+* IRQ latency measurement with different RRAMC wake-up strategies
+  (when ``CONFIG_NRF_SYS_EVENT_IRQ_LATENCY`` is enabled):
+
+  * Default RRAMC mode (~15 µs wake-up time)
+  * PPI-triggered RRAMC wake-up before expected interrupt
+  * RRAMC standby mode (0 µs wake-up time)
+
+Requirements
+************
+
+This sample requires a Nordic Semiconductor development kit. Supported
+boards include nRF52, nRF5340, nRF54H20, nRF54L15, and nRF7120 series.
+See ``sample.yaml`` for the full list of allowed platforms.
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/nordic/nrf_sys_event
+   :board: nrf52840dk/nrf52840
+   :goals: build flash
+   :compact:
+
+To enable IRQ latency measurement with RRAMC wake-up testing:
+
+.. code-block:: console
+
+   west build -p always -b nrf54l15dk/nrf54l15/cpuapp -- \
+       -DCONFIG_NRF_SYS_EVENT_IRQ_LATENCY=y
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   request global constant latency mode
+   constant latency mode enabled
+   request global constant latency mode again
+   release global constant latency mode
+   constant latency mode will remain enabled
+   release global constant latency mode again
+   constant latency mode will be disabled
+   constant latency mode disabled

--- a/samples/drivers/ipm/ipm_mcux/remote/README.rst
+++ b/samples/drivers/ipm/ipm_mcux/remote/README.rst
@@ -1,0 +1,42 @@
+:orphan:
+
+.. _ipm_mcux_remote_sample:
+
+IPM MCUX Mailbox (Remote Core)
+##############################
+
+Overview
+********
+
+This is the remote core component of the IPM MCUX mailbox sample. It runs
+on the secondary processor (Cortex-M0+ or CPU1) and implements a simple
+ping-pong message echo using the NXP LPC mailbox inter-processor
+messaging (IPM) driver.
+
+When the remote core receives a message from the primary core via the
+mailbox interrupt, it echoes the same data back to the sender. This sample
+is intended to be used together with the primary core application located
+at ``samples/drivers/ipm/ipm_mcux``.
+
+Requirements
+************
+
+* NXP LPCXpresso54114 (``lpcxpresso54114/lpc54114/m0``) or
+  NXP LPCXpresso55S69 (``lpcxpresso55s69/lpc55s69/cpu1``)
+
+Building
+********
+
+Build the remote core image first, then build the primary core application
+which will automatically include the remote image.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/ipm/ipm_mcux/remote
+   :board: lpcxpresso54114/lpc54114/m0
+   :goals: build
+   :compact:
+
+See Also
+********
+
+* Primary core sample: ``samples/drivers/ipm/ipm_mcux``


### PR DESCRIPTION
Add README.rst documentation for the following samples that were
previously missing documentation:

- samples/boards/espressif/ethernet
- samples/boards/microchip/mec172xevb_assy6906/qmspi_ldma
- samples/boards/microchip/mec172xevb_assy6906/rom_api
- samples/boards/nordic/nrf_sys_event
- samples/drivers/ipm/ipm_mcux/remote

Each README follows the standard Zephyr sample documentation format
with Overview, Requirements, and Building and Running sections using
the `zephyr-app-commands` directive.

Relates to #27805