### PR TITLE
samples: drivers: rtc: Remove CONFIG_RTC_ALARM from .conf files

### DIFF
--- a/samples/drivers/rtc/boards/frdm_mcxe31b.conf
+++ b/samples/drivers/rtc/boards/frdm_mcxe31b.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/frdm_mcxw71.conf
+++ b/samples/drivers/rtc/boards/frdm_mcxw71.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
+++ b/samples/drivers/rtc/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1010_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1010_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1015_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1015_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1020_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1020_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1024_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1024_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1040_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1040_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1050_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1050_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1060_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1060_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1062_fmurt6.conf
+++ b/samples/drivers/rtc/boards/mimxrt1062_fmurt6.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1064_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1064_evk.conf
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-CONFIG_RTC_ALARM=y
 CONFIG_RTC_INIT_PRIORITY=70


### PR DESCRIPTION
The board config files set CONFIG_RTC_ALARM but the sample program does not use alarm APIs. Hence, removing those. 