### PR TITLE
soc: versalnet: add MMU regions for peripherals and increase xlat tables

### DIFF
--- a/boards/amd/versal2_apu/versal2_apu_defconfig
+++ b/boards/amd/versal2_apu/versal2_apu_defconfig
@@ -17,3 +17,8 @@ CONFIG_UART_PL011=y
 
 # This should be commented in order to test at EL1 S (EL1 Secure)
 CONFIG_ARMV8_A_NS=y
+
+# Default is 12 for ARM64_VA_BITS_40. With WDT and other peripheral MMU
+# entries we may need up to 28 tables. Keep it at 40 so that all possible
+# use cases like mem_protect and other tests will work.
+CONFIG_MAX_XLAT_TABLES=40

--- a/boards/amd/versalnet_apu/versalnet_apu_defconfig
+++ b/boards/amd/versalnet_apu/versalnet_apu_defconfig
@@ -26,3 +26,8 @@ CONFIG_ARMV8_A_NS=y
 # comment the lines below.
 CONFIG_FPU=n
 CONFIG_FPU_SHARING=n
+
+# Default is 12 for ARM64_VA_BITS_40. With WDT and other peripheral MMU
+# entries we may need up to 28 tables. Keep it at 40 so that all possible
+# use cases like mem_protect and other tests will work.
+CONFIG_MAX_XLAT_TABLES=40

--- a/soc/xlnx/versalnet/arm_mmu_regions.c
+++ b/soc/xlnx/versalnet/arm_mmu_regions.c
@@ -8,16 +8,40 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 
+#define DEVICE_ATTR (MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE)
+
 static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+			      DEVICE_ATTR),
 
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+			      DEVICE_ATTR),
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(cdns_i2c, DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_versal_8_9a, DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_zynqmp_dma_1_0,
+						DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_versal_wwdt, DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_versal_ospi_1_0,
+						DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(cdns_spi_r1p6, DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(snps_designware_i3c,
+						DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_canfd_2_0, DEVICE_ATTR)
+
+	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(xlnx_mbox_versal_ipi_mailbox,
+						DEVICE_ATTR)
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Add MMU region entries for I2C, UART, DMA, WWDT, OSPI, SPI, I3C, CANFD, and IPI mailbox peripherals using MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY. Introduce a DEVICE_ATTR macro to consolidate the common device memory attributes (MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE).

Increase CONFIG_MAX_XLAT_TABLES to 40 for versal2_apu and versalnet_apu boards. The new MMU entries require additional page table splits, needing up to 28 tables currently. The value is set to 40 to accommodate all possible use cases including mem_protect and other tests.