### PR TITLE
Bluetooth Host: Fix memory leak in ATT prep_pool

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2431,6 +2431,11 @@ static uint8_t att_exec_write_rsp(struct bt_att_chan *chan, uint8_t flags)
 					    &chan->att->prep_queue,
 					    &reassembled_data);
 		if (err != BT_ATT_ERR_SUCCESS) {
+			/* Discard queued buffers */
+			do {
+				net_buf_unref(buf);
+				buf = net_buf_slist_get(&chan->att->prep_queue);
+			} while (buf != NULL);
 			send_err_rsp(chan, BT_ATT_OP_EXEC_WRITE_REQ,
 				     handle, err);
 			return 0;


### PR DESCRIPTION
Before this we have a memory leak in the prep_pool when reassembly fails in :c:func:`att_exec_write_rsp`. Now on error the buffer is dequeued and freed, as are remaining queued prepare buffers.

Also added to release notes for 4.4.