### PR TITLE
flash: spi_nand: support reset operation

### DIFF
--- a/drivers/flash/Kconfig.nand
+++ b/drivers/flash/Kconfig.nand
@@ -9,6 +9,7 @@ menuconfig SPI_NAND
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_EX_OP
 	select SPI
 	select CRC
 


### PR DESCRIPTION
Add support for reset extended operation to clear all volatile register settings.

Notably, ECC enable and block protection registers are not reset by a soft reset.