### PR TITLE
tests: drivers: comparator: Enable gpio_loopback test on nrf54lm20b

### DIFF
--- a/tests/drivers/comparator/gpio_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * P1.30 looped back to P1.31 (AIN1)
+ */
+
+/ {
+	aliases {
+		test-comp = &comp;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio1 30 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/socs/nrf54lm20b_cpuapp_nrf_comp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/socs/nrf54lm20b_cpuapp_nrf_comp.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
+&comp {
+	main-mode = "SE";
+	psel = <NRF_COMP_AIN1>; /* P1.31 */
+	refsel = "INT_1V2";
+	sp-mode = "HIGH";
+	th-up = <63>;
+	th-down = <59>;
+	isource = "DISABLED";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/socs/nrf54lm20b_cpuapp_nrf_lpcomp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/socs/nrf54lm20b_cpuapp_nrf_lpcomp.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
+&comp {
+	compatible = "nordic,nrf-lpcomp";
+	psel = <NRF_COMP_AIN1>; /* P1.31 */
+	refsel = "VDD_4_8";
+	status = "okay";
+};

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -30,6 +30,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.comparator.gpio_loopback.nrf_lpcomp:
@@ -41,6 +42,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.comparator.gpio_loopback.stm32_comp:


### PR DESCRIPTION
Add overlays required to run gpio_loopback test on nrf54lm20dk/nrf54lm20b/cpuapp.