### PR TITLE
scripts: west_commands: jlink: support erase-only mode with --erase flag

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -443,8 +443,13 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         if self.reset_type:
             lines.insert(0, f"RSetType {self.reset_type}")
 
+        # If erase-only mode, skip flashing and return early
         if self.erase:
             lines.append('erase') # Erase all flash sectors
+            lines.append('q') # Close the connection and quit
+            self.logger.debug('JLink commander script (erase only):\n' +
+                              '\n'.join(lines))
+            return None, lines
 
         # Get the build artifact to flash
         if self.file is not None:
@@ -570,6 +575,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         if flash_file:
             self.logger.info(f'Flashing file: {flash_file}')
+        else:
+            self.logger.info('Erasing flash only (no file will be flashed)')
         kwargs = {}
         if not self.logger.isEnabledFor(logging.DEBUG):
             kwargs['stdout'] = subprocess.DEVNULL


### PR DESCRIPTION
scripts: west_commands: jlink: support erase-only mode with --erase flag

Add support for erase-only mode when --erase flag is used. Previously,
--erase would always erase and then flash, which was not the intended
behavior for erase-only operations.

When --erase flag is enabled, only perform flash erase operation
without downloading the hex file. This allows users to erase flash
without flashing a new image.

Modified get_default_flash_commands() method to skip file download
when erase-only mode is enabled. Added appropriate log messages to
indicate erase-only mode.

Signed-off-by: John <john.liu@evenrealities.com>