### PR TITLE
boards: renesas: Fix missing space in the board documentation

### DIFF
--- a/boards/renesas/fpb_ra8e1/doc/index.rst
+++ b/boards/renesas/fpb_ra8e1/doc/index.rst
@@ -54,6 +54,7 @@ programing tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) t
 Hardware
 ********
 Detailed Hardware features for the RA8E1 MCU group can be found at:
+
 - The RA8E1 MCU group: `RA8E1 Group User's Manual Hardware`_
 - The FPB-RA8E1 board: `FPB-RA8E1 - User's Manual`_
 


### PR DESCRIPTION
Fix missing space in the `fpb_ra8e1` board documentation.