### PR TITLE
[Backport v3.7-branch] drivers: clock_control: stm32_common: fix wrong register name for LSEDRV

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -673,8 +673,20 @@ static void set_up_fixed_clock_sources(void)
 #endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 #if STM32_LSE_DRIVING
+/*
+ * Most series have LSEDRV field in RCC_BDCR register,
+ * but a few series have it in a different one yet are
+ * handled by this driver. Pick proper register name:
+ */
+#define LSE_DRIVING_SHIFT					\
+	COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32C0X),	\
+		(RCC_CSR1_LSEDRV_Pos),				\
+	(COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32L0X),	\
+		(RCC_CSR_LSEDRV_Pos),				\
+		(RCC_BDCR_LSEDRV_Pos))))
+
 		/* Configure driving capability */
-		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
+		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << LSE_DRIVING_SHIFT);
 #endif
 
 		if (IS_ENABLED(STM32_LSE_BYPASS)) {


### PR DESCRIPTION
In a few series managed by the common driver, the LSEDRV field is not in RCC_BDCR but a different register.

Use proper register name when obtaining the shift to ensure a non-zero driving capability can be used on these series.


(cherry picked from commit 0f6b8c19ab8250b3c5d90e96ae58cd8f58cd0ef7)

Fixes #104253

Closes #104418