### PR TITLE
SX126x: Implement sleep mode (and a couple of fixes)

### DIFF
--- a/drivers/lora/native/sx126x/Kconfig
+++ b/drivers/lora/native/sx126x/Kconfig
@@ -15,6 +15,15 @@ config LORA_SX126X_NATIVE
 	  This is an experimental driver that does not depend on loramac-node
 	  or lora-basics-modem external modules.
 
+config LORA_SX126X_NATIVE_SLEEP
+	bool "Sleep mode power management"
+	default y
+	depends on LORA_SX126X_NATIVE
+	help
+	  Place the SX126x radio into sleep mode when idle to reduce
+	  power consumption (~600 nA vs ~1.6 mA in standby). Disable
+	  to keep the radio in standby for faster response times.
+
 config LORA_SX126X_NATIVE_STM32WL
 	bool
 	default y

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -406,14 +406,61 @@ static void sx126x_set_rf_path(const struct device *dev, bool enable, bool tx)
 	}
 }
 
+static int sx126x_set_sleep(const struct device *dev)
+{
+	struct sx126x_data *data = dev->data;
+	uint8_t cfg = SX126X_SLEEP_WARM_START;
+	int ret;
+
+	if (atomic_get(&data->state) == SX126X_STATE_SLEEP) {
+		return 0;
+	}
+
+	/* Disable DIO1 interrupt during sleep */
+	sx126x_hal_set_dio1_callback(dev, NULL);
+
+	sx126x_set_rf_path(dev, false, false);
+
+	ret = sx126x_hal_write_cmd(dev, SX126X_CMD_SET_SLEEP, &cfg, 1);
+	if (ret == 0) {
+		atomic_set(&data->state, SX126X_STATE_SLEEP);
+	}
+
+	return ret;
+}
+
+static int sx126x_ensure_ready(const struct device *dev)
+{
+	int ret;
+
+	/* Re-enable DIO1 interrupt */
+	ret = sx126x_hal_set_dio1_callback(dev, sx126x_dio1_callback);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/*
+	 * Wake the chip from sleep by sending GET_STATUS. The NSS edge
+	 * wakes the chip which then initializes into STDBY_RC (warm start
+	 * retains configuration). Cannot use sx126x_set_standby() here
+	 * because the HAL waits for BUSY LOW before sending the SPI command,
+	 * but BUSY stays HIGH until the chip is woken by an NSS edge.
+	 */
+	ret = sx126x_hal_wakeup(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
 static void sx126x_handle_irq_tx_done(const struct device *dev)
 {
 	struct sx126x_data *data = dev->data;
 	struct sx126x_tx_result result = { .status = 0 };
 
 	LOG_DBG("TX done");
-	atomic_set(&data->state, SX126X_STATE_IDLE);
-	sx126x_set_rf_path(dev, false, false);
+	sx126x_set_sleep(dev);
 
 	if (data->tx_async_signal != NULL) {
 		k_poll_signal_raise(data->tx_async_signal, 0);
@@ -475,8 +522,7 @@ static void sx126x_handle_irq_rx_done(const struct device *dev, uint16_t irq_sta
 		}
 	} else {
 		/* Sync mode */
-		atomic_set(&data->state, SX126X_STATE_IDLE);
-		sx126x_set_rf_path(dev, false, false);
+		sx126x_set_sleep(dev);
 		k_msgq_put(&data->rx_msgq, &result, K_NO_WAIT);
 	}
 }
@@ -486,8 +532,7 @@ static void sx126x_handle_irq_timeout(const struct device *dev)
 	struct sx126x_data *data = dev->data;
 
 	LOG_DBG("Timeout");
-	atomic_set(&data->state, SX126X_STATE_IDLE);
-	sx126x_set_rf_path(dev, false, false);
+	sx126x_set_sleep(dev);
 
 	if (data->tx_async_signal != NULL) {
 		struct sx126x_tx_result result = { .status = -ETIMEDOUT };
@@ -533,8 +578,10 @@ static void sx126x_irq_work_handler(struct k_work *work)
 		sx126x_handle_irq_timeout(dev);
 	}
 
-	/* Re-enable the DIO1 interrupt for the next event */
-	sx126x_hal_dio1_irq_enable(dev);
+	/* Re-enable the DIO1 interrupt for the next event (unless sleeping) */
+	if (atomic_get(&data->state) != SX126X_STATE_SLEEP) {
+		sx126x_hal_dio1_irq_enable(dev);
+	}
 }
 
 static int sx126x_lora_config(const struct device *dev,
@@ -545,7 +592,18 @@ static int sx126x_lora_config(const struct device *dev,
 	bool ldro;
 	int ret;
 
+	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_IDLE)) {
+		return -EBUSY;
+	}
+
 	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		return ret;
+	}
 
 	/* Store configuration */
 	memcpy(&data->config, config, sizeof(*config));
@@ -599,6 +657,7 @@ static int sx126x_lora_config(const struct device *dev,
 		config->coding_rate, config->tx_power);
 
 out:
+	sx126x_set_sleep(dev);
 	k_mutex_unlock(&data->lock);
 	return ret;
 }
@@ -620,12 +679,20 @@ static int sx126x_lora_send_async(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_TX)) {
+	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_TX)) {
 		LOG_ERR("Busy");
 		return -EBUSY;
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		return ret;
+	}
+
 	data->tx_async_signal = async;
 	k_msgq_purge(&data->tx_msgq);
 
@@ -662,8 +729,8 @@ static int sx126x_lora_send_async(const struct device *dev,
 
 out_error:
 	data->tx_async_signal = NULL;
+	sx126x_set_sleep(dev);
 	k_mutex_unlock(&data->lock);
-	atomic_set(&data->state, SX126X_STATE_IDLE);
 	return ret;
 }
 
@@ -683,7 +750,9 @@ static int sx126x_lora_send(const struct device *dev,
 	ret = k_msgq_get(&data->tx_msgq, &result, K_SECONDS(15));
 	if (ret < 0) {
 		LOG_ERR("TX timeout");
-		atomic_set(&data->state, SX126X_STATE_IDLE);
+		/* Chip is still transmitting, abort first */
+		sx126x_set_standby(dev, SX126X_STANDBY_RC);
+		sx126x_set_sleep(dev);
 		return -ETIMEDOUT;
 	}
 
@@ -704,12 +773,20 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_RX)) {
 		LOG_ERR("Busy");
 		return -EBUSY;
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		return ret;
+	}
+
 	data->rx_cb = NULL;
 	k_msgq_purge(&data->rx_msgq);
 
@@ -723,8 +800,8 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 				       data->config.iq_inverted ?
 				       SX126X_LORA_IQ_INVERTED : SX126X_LORA_IQ_STANDARD);
 	if (ret < 0) {
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_IDLE);
 		return ret;
 	}
 
@@ -736,9 +813,8 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 		     ? 0 : k_ticks_to_ms_ceil32(timeout.ticks);
 	ret = sx126x_set_rx(dev, timeout_ms);
 	if (ret < 0) {
-		sx126x_set_rf_path(dev, false, false);
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_IDLE);
 		return ret;
 	}
 
@@ -748,9 +824,9 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 	ret = k_msgq_get(&data->rx_msgq, &result, timeout);
 	if (ret < 0) {
 		LOG_DBG("RX timeout");
-		atomic_set(&data->state, SX126X_STATE_IDLE);
+		/* Chip is still receiving, abort first */
 		sx126x_set_standby(dev, SX126X_STANDBY_RC);
-		sx126x_set_rf_path(dev, false, false);
+		sx126x_set_sleep(dev);
 		return -EAGAIN;
 	}
 
@@ -785,7 +861,7 @@ static int sx126x_lora_recv_async(const struct device *dev,
 		data->rx_cb_user_data = NULL;
 		if (atomic_cas(&data->state, SX126X_STATE_RX, SX126X_STATE_IDLE)) {
 			sx126x_set_standby(dev, SX126X_STANDBY_RC);
-			sx126x_set_rf_path(dev, false, false);
+			sx126x_set_sleep(dev);
 		}
 		k_mutex_unlock(&data->lock);
 		return 0;
@@ -797,10 +873,17 @@ static int sx126x_lora_recv_async(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_IDLE, SX126X_STATE_RX)) {
+	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_RX)) {
 		LOG_ERR("Busy");
 		k_mutex_unlock(&data->lock);
 		return -EBUSY;
+	}
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		return ret;
 	}
 
 	data->rx_cb = cb;
@@ -817,8 +900,8 @@ static int sx126x_lora_recv_async(const struct device *dev,
 				       SX126X_LORA_IQ_INVERTED : SX126X_LORA_IQ_STANDARD);
 	if (ret < 0) {
 		data->rx_cb = NULL;
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_IDLE);
 		return ret;
 	}
 
@@ -829,9 +912,8 @@ static int sx126x_lora_recv_async(const struct device *dev,
 	ret = sx126x_set_rx(dev, 0);
 	if (ret < 0) {
 		data->rx_cb = NULL;
-		sx126x_set_rf_path(dev, false, false);
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_IDLE);
 		return ret;
 	}
 
@@ -888,15 +970,22 @@ static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 	struct sx126x_data *data = dev->data;
 	int ret;
 
-	if (atomic_get(&data->state) != SX126X_STATE_IDLE) {
+	if (atomic_get(&data->state) != SX126X_STATE_SLEEP) {
 		return -EBUSY;
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		return ret;
+	}
+
 	/* Set frequency */
 	ret = sx126x_set_rf_frequency(dev, frequency);
 	if (ret < 0) {
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
 		return ret;
 	}
@@ -905,6 +994,7 @@ static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 	ret = sx126x_hal_configure_tx_params(dev, tx_power, frequency,
 						SX126X_RAMP_200_US);
 	if (ret < 0) {
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
 		return ret;
 	}
@@ -915,7 +1005,7 @@ static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 	/* Start CW transmission */
 	ret = sx126x_hal_write_cmd(dev, SX126X_CMD_SET_TX_CONTINUOUS_WAVE, NULL, 0);
 	if (ret < 0) {
-		sx126x_set_rf_path(dev, false, false);
+		sx126x_set_sleep(dev);
 		k_mutex_unlock(&data->lock);
 		return ret;
 	}
@@ -928,7 +1018,7 @@ static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 	/* Stop CW */
 	k_mutex_lock(&data->lock, K_FOREVER);
 	sx126x_set_standby(dev, SX126X_STANDBY_RC);
-	sx126x_set_rf_path(dev, false, false);
+	sx126x_set_sleep(dev);
 	k_mutex_unlock(&data->lock);
 
 	return 0;
@@ -978,6 +1068,18 @@ static int sx126x_init(const struct device *dev)
 	ret = sx126x_chip_init(dev);
 	if (ret < 0) {
 		LOG_ERR("Chip init failed: %d", ret);
+		return ret;
+	}
+
+	/*
+	 * Place the radio into sleep mode upon boot.
+	 * The required lora_config call before transmission or reception
+	 * will wake the radio. It is automatically placed back into sleep
+	 * mode upon TX or RX completion.
+	 */
+	ret = sx126x_set_sleep(dev);
+	if (ret < 0) {
+		LOG_ERR("Initial sleep failed: %d", ret);
 		return ret;
 	}
 

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -460,12 +460,19 @@ static void sx126x_handle_irq_rx_done(const struct device *dev, uint16_t irq_sta
 
 	/* Handle async callback or signal sync receiver */
 	if (data->rx_cb != NULL) {
-		/* Async mode - call callback and restart RX */
-		data->rx_cb(dev, data->rx_buf, result.len,
-			    result.rssi, result.snr,
-			    data->rx_cb_user_data);
-		/* Restart RX for continuous reception */
-		sx126x_set_rx(dev, 0);
+		/*
+		 * Async mode: only report valid packets.
+		 * CRC/read failures are dropped and RX is restarted.
+		 */
+		if (result.status > 0) {
+			data->rx_cb(dev, data->rx_buf, result.len,
+				    result.rssi, result.snr,
+				    data->rx_cb_user_data);
+		}
+		/* Restart RX unless the callback stopped reception */
+		if (data->rx_cb != NULL) {
+			sx126x_set_rx(dev, 0);
+		}
 	} else {
 		/* Sync mode */
 		atomic_set(&data->state, SX126X_STATE_IDLE);

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -13,6 +13,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sx126x, CONFIG_LORA_LOG_LEVEL);
 
+#define SX126X_REST_STATE \
+	(IS_ENABLED(CONFIG_LORA_SX126X_NATIVE_SLEEP) \
+	 ? SX126X_STATE_SLEEP : SX126X_STATE_IDLE)
+
 static uint8_t bandwidth_to_reg(enum lora_signal_bandwidth bw)
 {
 	switch (bw) {
@@ -402,7 +406,7 @@ static void sx126x_set_rf_path(const struct device *dev, bool enable, bool tx)
 
 	sx126x_hal_set_antenna_enable(dev, enable);
 	if (!config->dio2_tx_enable) {
-		sx126x_hal_set_rf_switch(dev, enable && tx);
+		sx126x_hal_set_rf_switch(dev, enable, tx);
 	}
 }
 
@@ -411,6 +415,12 @@ static int sx126x_set_sleep(const struct device *dev)
 	struct sx126x_data *data = dev->data;
 	uint8_t cfg = SX126X_SLEEP_WARM_START;
 	int ret;
+
+	if (!IS_ENABLED(CONFIG_LORA_SX126X_NATIVE_SLEEP)) {
+		atomic_set(&data->state, SX126X_STATE_IDLE);
+		sx126x_set_rf_path(dev, false, false);
+		return 0;
+	}
 
 	if (atomic_get(&data->state) == SX126X_STATE_SLEEP) {
 		return 0;
@@ -432,6 +442,10 @@ static int sx126x_set_sleep(const struct device *dev)
 static int sx126x_ensure_ready(const struct device *dev)
 {
 	int ret;
+
+	if (!IS_ENABLED(CONFIG_LORA_SX126X_NATIVE_SLEEP)) {
+		return 0;
+	}
 
 	/* Re-enable DIO1 interrupt */
 	ret = sx126x_hal_set_dio1_callback(dev, sx126x_dio1_callback);
@@ -579,7 +593,7 @@ static void sx126x_irq_work_handler(struct k_work *work)
 	}
 
 	/* Re-enable the DIO1 interrupt for the next event (unless sleeping) */
-	if (atomic_get(&data->state) != SX126X_STATE_SLEEP) {
+	if (atomic_get(&data->state) != SX126X_REST_STATE) {
 		sx126x_hal_dio1_irq_enable(dev);
 	}
 }
@@ -592,7 +606,7 @@ static int sx126x_lora_config(const struct device *dev,
 	bool ldro;
 	int ret;
 
-	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_IDLE)) {
+	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_IDLE)) {
 		return -EBUSY;
 	}
 
@@ -601,7 +615,7 @@ static int sx126x_lora_config(const struct device *dev,
 	ret = sx126x_ensure_ready(dev);
 	if (ret < 0) {
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		atomic_set(&data->state, SX126X_REST_STATE);
 		return ret;
 	}
 
@@ -679,7 +693,7 @@ static int sx126x_lora_send_async(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_TX)) {
+	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_TX)) {
 		LOG_ERR("Busy");
 		return -EBUSY;
 	}
@@ -689,7 +703,7 @@ static int sx126x_lora_send_async(const struct device *dev,
 	ret = sx126x_ensure_ready(dev);
 	if (ret < 0) {
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		atomic_set(&data->state, SX126X_REST_STATE);
 		return ret;
 	}
 
@@ -773,7 +787,7 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_RX)) {
+	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_RX)) {
 		LOG_ERR("Busy");
 		return -EBUSY;
 	}
@@ -783,7 +797,7 @@ static int sx126x_lora_recv(const struct device *dev, uint8_t *data_buf,
 	ret = sx126x_ensure_ready(dev);
 	if (ret < 0) {
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		atomic_set(&data->state, SX126X_REST_STATE);
 		return ret;
 	}
 
@@ -873,7 +887,7 @@ static int sx126x_lora_recv_async(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (!atomic_cas(&data->state, SX126X_STATE_SLEEP, SX126X_STATE_RX)) {
+	if (!atomic_cas(&data->state, SX126X_REST_STATE, SX126X_STATE_RX)) {
 		LOG_ERR("Busy");
 		k_mutex_unlock(&data->lock);
 		return -EBUSY;
@@ -882,7 +896,7 @@ static int sx126x_lora_recv_async(const struct device *dev,
 	ret = sx126x_ensure_ready(dev);
 	if (ret < 0) {
 		k_mutex_unlock(&data->lock);
-		atomic_set(&data->state, SX126X_STATE_SLEEP);
+		atomic_set(&data->state, SX126X_REST_STATE);
 		return ret;
 	}
 
@@ -970,7 +984,7 @@ static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 	struct sx126x_data *data = dev->data;
 	int ret;
 
-	if (atomic_get(&data->state) != SX126X_STATE_SLEEP) {
+	if (atomic_get(&data->state) != SX126X_REST_STATE) {
 		return -EBUSY;
 	}
 
@@ -1077,10 +1091,12 @@ static int sx126x_init(const struct device *dev)
 	 * will wake the radio. It is automatically placed back into sleep
 	 * mode upon TX or RX completion.
 	 */
-	ret = sx126x_set_sleep(dev);
-	if (ret < 0) {
-		LOG_ERR("Initial sleep failed: %d", ret);
-		return ret;
+	if (IS_ENABLED(CONFIG_LORA_SX126X_NATIVE_SLEEP)) {
+		ret = sx126x_set_sleep(dev);
+		if (ret < 0) {
+			LOG_ERR("Initial sleep failed: %d", ret);
+			return ret;
+		}
 	}
 
 	return 0;

--- a/drivers/lora/native/sx126x/sx126x.h
+++ b/drivers/lora/native/sx126x/sx126x.h
@@ -13,9 +13,12 @@
 #include "sx126x_hal.h"
 #include "sx126x_regs.h"
 
-#define SX126X_STATE_IDLE 0
-#define SX126X_STATE_TX   1
-#define SX126X_STATE_RX   2
+enum sx126x_state {
+	SX126X_STATE_SLEEP = 0,
+	SX126X_STATE_IDLE,
+	SX126X_STATE_TX,
+	SX126X_STATE_RX,
+};
 
 struct sx126x_tx_result {
 	int status;

--- a/drivers/lora/native/sx126x/sx126x_hal.h
+++ b/drivers/lora/native/sx126x/sx126x_hal.h
@@ -77,7 +77,7 @@ void sx126x_hal_dio1_irq_enable(const struct device *dev);
 
 void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable);
 
-void sx126x_hal_set_rf_switch(const struct device *dev, bool tx);
+void sx126x_hal_set_rf_switch(const struct device *dev, bool enable, bool tx);
 
 int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
 			      gpio_flags_t flags, const char *name);

--- a/drivers/lora/native/sx126x/sx126x_hal.h
+++ b/drivers/lora/native/sx126x/sx126x_hal.h
@@ -85,4 +85,6 @@ int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
 int sx126x_hal_configure_tx_params(const struct device *dev, int8_t power,
 				   uint32_t frequency, uint8_t ramp_time);
 
+int sx126x_hal_wakeup(const struct device *dev);
+
 #endif /* ZEPHYR_DRIVERS_LORA_SX126X_SX126X_HAL_H_ */

--- a/drivers/lora/native/sx126x/sx126x_hal_common.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_common.c
@@ -60,16 +60,16 @@ void sx126x_hal_set_antenna_enable(const struct device *dev, bool enable)
 	}
 }
 
-void sx126x_hal_set_rf_switch(const struct device *dev, bool tx)
+void sx126x_hal_set_rf_switch(const struct device *dev, bool enable, bool tx)
 {
 	const struct sx126x_hal_config *config = dev->config;
 
 	if (config->tx_enable.port != NULL) {
-		gpio_pin_set_dt(&config->tx_enable, tx);
+		gpio_pin_set_dt(&config->tx_enable, enable && tx);
 	}
 
 	if (config->rx_enable.port != NULL) {
-		gpio_pin_set_dt(&config->rx_enable, !tx);
+		gpio_pin_set_dt(&config->rx_enable, enable && !tx);
 	}
 }
 

--- a/drivers/lora/native/sx126x/sx126x_hal_common.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_common.c
@@ -26,22 +26,17 @@ static int spi_transfer(const struct spi_dt_spec *spi,
 
 	struct spi_buf tx_bufs[] = {
 		{ .buf = (uint8_t *)hdr, .len = hdr_len },
-		{ .buf = data, .len = data_len },
+		{ .buf = read ? NULL : data, .len = data_len },
 	};
 	struct spi_buf rx_bufs[] = {
 		{ .buf = rx_hdr, .len = hdr_len },
 		{ .buf = data, .len = data_len },
 	};
-	struct spi_buf_set tx_set = {
-		.buffers = tx_bufs,
-		.count = (read || (data_len == 0)) ? 1 : 2,
-	};
-	struct spi_buf_set rx_set = {
-		.buffers = rx_bufs,
-		.count = read ? 2 : 1,
-	};
+	int count = (data_len == 0) ? 1 : 2;
+	struct spi_buf_set tx_set = { .buffers = tx_bufs, .count = count };
+	struct spi_buf_set rx_set = { .buffers = rx_bufs, .count = count };
 
-	return spi_transceive_dt(spi, &tx_set, &rx_set);
+	return spi_transceive_dt(spi, &tx_set, read ? &rx_set : NULL);
 }
 
 int sx126x_hal_wait_busy(const struct device *dev, uint32_t timeout_ms)

--- a/drivers/lora/native/sx126x/sx126x_hal_common.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_common.c
@@ -96,6 +96,35 @@ int sx126x_hal_configure_gpio(const struct gpio_dt_spec *gpio,
 	return 0;
 }
 
+int sx126x_hal_wakeup(const struct device *dev)
+{
+	const struct sx126x_hal_config *config = dev->config;
+	uint8_t buf[2] = { SX126X_CMD_GET_STATUS, 0x00 };
+	struct spi_buf tx_buf = {
+		.buf = buf,
+		.len = sizeof(buf),
+	};
+	struct spi_buf_set tx_set = {
+		.buffers = &tx_buf,
+		.count = 1,
+	};
+	int ret;
+
+	/*
+	 * Send a write-only GET_STATUS command. The NSS falling edge wakes
+	 * the chip from sleep. Use spi_write_dt() (TX-only) rather than
+	 * spi_transceive_dt() because the chip's MISO line is undefined
+	 * during sleep mode.
+	 */
+	ret = spi_write_dt(&config->spi, &tx_set);
+	if (ret < 0) {
+		LOG_ERR("Wakeup SPI failed: %d", ret);
+		return ret;
+	}
+
+	return sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+}
+
 int sx126x_hal_write_cmd(const struct device *dev, uint8_t opcode,
 			 const uint8_t *data, size_t len)
 {
@@ -116,6 +145,12 @@ int sx126x_hal_write_cmd(const struct device *dev, uint8_t opcode,
 
 	if (opcode != SX126X_CMD_SET_SLEEP) {
 		ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
+	} else {
+		/*
+		 * The chip needs time to fully enter sleep mode before the
+		 * next NSS falling edge can wake it up reliably.
+		 */
+		k_busy_wait(500);
 	}
 
 	return ret;

--- a/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
@@ -34,23 +34,6 @@ static inline struct sx126x_hal_data *get_hal_data(const struct device *dev)
 	return &data->hal;
 }
 
-static int sx126x_hal_wakeup(const struct device *dev)
-{
-	const struct sx126x_hal_config *config = dev->config;
-	uint8_t tx_buf[2] = { SX126X_CMD_GET_STATUS, 0x00 };
-
-	struct spi_buf tx_spi_buf = {
-		.buf = tx_buf,
-		.len = sizeof(tx_buf),
-	};
-	struct spi_buf_set tx_set = {
-		.buffers = &tx_spi_buf,
-		.count = 1,
-	};
-
-	return spi_write_dt(&config->spi, &tx_set);
-}
-
 int sx126x_hal_reset(const struct device *dev)
 {
 	int ret;
@@ -64,17 +47,11 @@ int sx126x_hal_reset(const struct device *dev)
 
 	/*
 	 * After RCC reset, the radio is in sleep mode. Send a wakeup command
-	 * to allow the busy flag to be properly checked.
+	 * to transition into STDBY_RC so that BUSY can be properly checked.
 	 */
 	ret = sx126x_hal_wakeup(dev);
 	if (ret < 0) {
 		LOG_ERR("Wakeup failed: %d", ret);
-		return ret;
-	}
-
-	/* Wait for chip to be ready */
-	ret = sx126x_hal_wait_busy(dev, SX126X_BUSY_DEFAULT_TIMEOUT);
-	if (ret < 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
Place the `SX126x` radio into sleep mode whenever it is not actively transmitting or receiving saving a lot of power (but also slightly increasing response time), add a Kconfig option for that and fix a couple of issues.