### PR TITLE
drivers: input: gt911: Added support for gt912, gt927, gt9271, gt928, gt967

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -33,7 +33,12 @@ LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 #define GT911_REG_CONFIG_VERSION          GT911_REG_CONFIG
 #define GT911_REG_CONFIG_TOUCH_NUM_OFFSET 0x5
 #define GT911_REG_CONFIG_SIZE             186U
-#define GT911_PRODUCT_ID            0x00313139U
+#define GT911_PRODUCT_ID                  0x00313139U
+#define GT9271_PRODUCT_ID                 0x31373239U
+#define GT912_PRODUCT_ID                  0x00323139U
+#define GT927_PRODUCT_ID                  0x00373239U
+#define GT928_PRODUCT_ID                  0x00383239U
+#define GT967_PRODUCT_ID                  0x00373639U
 
 /* Points registers */
 #define GT911_REG_POINT_0       0x814F
@@ -385,8 +390,16 @@ static int gt911_init(const struct device *dev)
 		LOG_ERR("Device did not respond to I2C request");
 		return r;
 	}
-	if (reg_id != GT911_PRODUCT_ID) {
-		LOG_ERR("The Device ID is not correct");
+	switch (reg_id) {
+	case GT911_PRODUCT_ID:
+	case GT912_PRODUCT_ID:
+	case GT927_PRODUCT_ID:
+	case GT928_PRODUCT_ID:
+	case GT967_PRODUCT_ID:
+	case GT9271_PRODUCT_ID:
+		break;
+	default:
+		LOG_ERR("Unexpected device id: %08x ", reg_id);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Hi community, 

this is the fix for following issue:
[https://github.com/zephyrproject-rtos/zephyr/issues/104442](url)

The Goodix GT9271 touch controller is currently not handled correctly by the Zephyr GT911 driver.

The GT9217 chip reports a different Product ID than the one expected and checked in the Zephyr driver implementation. Because of this, the driver does not properly recognize or initialize the controller.

According to Kconfig.gt911, the driver is intended to support the following Goodix controllers:
"This driver should support gt9110, gt912, gt927, gt9271, gt928"

#However, at the moment only the GT911 appears to be supported in the driver code. Other listed controllers (including GT9271) are not properly detected due to strict Product ID checking.


