### PR TITLE
driver: crc: Add Silabs gpcrc driver

### DIFF
--- a/drivers/crc/CMakeLists.txt
+++ b/drivers/crc/CMakeLists.txt
@@ -11,4 +11,5 @@ zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_NXP crc_nxp.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_NXP_LPC crc_nxp_lpc.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_RENESAS_RA crc_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_SF32LB crc_sf32lb.c)
+zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_SILABS_GPCRC crc_silabs_gpcrc.c)
 # zephyr-keep-sorted-stop

--- a/drivers/crc/Kconfig
+++ b/drivers/crc/Kconfig
@@ -24,6 +24,7 @@ config CRC_DRIVER_INIT_PRIORITY
 source "drivers/crc/Kconfig.nxp"
 source "drivers/crc/Kconfig.renesas_ra"
 source "drivers/crc/Kconfig.sf32lb"
+source "drivers/crc/Kconfig.silabs"
 # zephyr-keep-sorted-stop
 
 config CRC_DRIVER_HAS_CRC4

--- a/drivers/crc/Kconfig.silabs
+++ b/drivers/crc/Kconfig.silabs
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Phuc Hoang
+# SPDX-License-Identifier: Apache-2.0
+
+config CRC_DRIVER_SILABS_GPCRC
+	bool "Silicon Labs GPCRC driver"
+	depends on DT_HAS_SILABS_GPCRC_ENABLED
+	default y
+	select SILABS_SISDK_GPCRC
+	select CRC_DRIVER_HAS_CRC16
+	select CRC_DRIVER_HAS_CRC16_ANSI
+	select CRC_DRIVER_HAS_CRC16_CCITT
+	select CRC_DRIVER_HAS_CRC16_ITU_T
+	select CRC_DRIVER_HAS_CRC16_REFLECT
+	select CRC_DRIVER_HAS_CRC32_IEEE
+	help
+	  Enable the General Purpose CRC (GPCRC) driver implementation
+	  for Silicon Labs Gecko (EFR32/EFM32) microcontrollers.

--- a/drivers/crc/crc_silabs_gpcrc.c
+++ b/drivers/crc/crc_silabs_gpcrc.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2025 Phuc Hoang
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/drivers/crc.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/clock_control_silabs.h>
+
+#include <sl_hal_gpcrc.h>
+
+
+LOG_MODULE_REGISTER(silabs_gpcrc, CONFIG_CRC_LOG_LEVEL);
+
+#define DT_DRV_COMPAT silabs_gpcrc
+
+struct crc_silabs_config {
+	const struct device *clock_dev;
+	const struct silabs_clock_control_cmu_config clock_cfg;
+	GPCRC_TypeDef *gpcrc;
+};
+
+struct crc_silabs_data {
+	bool is_crc32;
+	uint32_t xor_out;
+	struct k_sem lock;
+};
+
+/* Helper func */
+
+static inline void crc_silabs_lock(const struct device *dev)
+{
+	struct crc_silabs_data *data = dev->data;
+
+	k_sem_take(&data->lock, K_FOREVER);
+}
+
+static inline void crc_silabs_unlock(const struct device *dev)
+{
+	struct crc_silabs_data *data = dev->data;
+
+	k_sem_give(&data->lock);
+}
+
+static inline uint16_t reverse_16bit(uint16_t x)
+{
+	x = ((x & 0xAAAA) >> 1) | ((x & 0x5555) << 1);
+	x = ((x & 0xCCCC) >> 2) | ((x & 0x3333) << 2);
+	x = ((x & 0xF0F0) >> 4) | ((x & 0x0F0F) << 4);
+
+	return (x >> 8) | (x << 8);
+}
+
+static int set_crc_config(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_silabs_config *config = dev->config;
+	struct crc_silabs_data *data = dev->data;
+
+	/* Check the type, polynomial and init value */
+	switch (ctx->type) {
+	case CRC16: {
+		if (ctx->polynomial != CRC16_POLY) {
+			return -EINVAL;
+		}
+		ctx->seed &= 0xFFFFU;
+		data->xor_out = 0x0000U;
+		data->is_crc32 = false;
+		break;
+	}
+	case CRC16_ANSI: {
+		if (ctx->polynomial != CRC16_REFLECT_POLY) {
+			return -EINVAL;
+		}
+		ctx->seed &= 0xFFFFU;
+		data->xor_out = 0x0000U;
+		data->is_crc32 = false;
+		break;
+	}
+	case CRC16_ITU_T: {
+		__fallthrough;
+	}
+	case CRC16_CCITT: {
+		if (ctx->polynomial != CRC16_CCITT_POLY) {
+			return -EINVAL;
+		}
+		ctx->seed &= 0xFFFFU;
+		data->xor_out = 0x0000U;
+		data->is_crc32 = false;
+		break;
+	}
+	case CRC32_IEEE: {
+		if (ctx->polynomial != CRC32_IEEE_POLY) {
+			return -EINVAL;
+		}
+		data->xor_out = 0xFFFFFFFFU;
+		data->is_crc32 = true;
+		break;
+	}
+	default:
+		return -ENOTSUP;
+	}
+
+	/* Set config for gpcrc */
+	const sl_hal_gpcrc_init_t init = {
+		/* Depend on the data byte order, if the data byte order is big endian
+		 * and we write word/half word to input this flag must be true,
+		 * otherwise, it is not.
+		 */
+		.reverse_byte_order = false,
+		/* Flip the flag to get right result
+		 * Silabs EFR32 GPCRC needs to use the inverted RefIn and RefOut flags
+		 * to produce correct checksum results
+		 */
+		.reverse_bits = !(ctx->reversed & CRC_FLAG_REVERSE_INPUT), /* reverse input */
+		.enable_byte_mode = false,
+		.auto_init = false,
+		.crc_poly = ctx->polynomial,
+		/* 16 bit CRC Seed need to be reversed to get the right result
+		 * In the case where the CRC-16 algorithms have asymmetric seed value as follows:
+		 * CRC-16/DDS-110
+		 * CRC-16/ISO-IEC-14443-3-A
+		 * CRC-16/RIELLO
+		 * etc
+		 */
+		.init_value = (data->is_crc32) ? ctx->seed : reverse_16bit(ctx->seed),
+	};
+
+	sl_hal_gpcrc_reset(config->gpcrc);
+	sl_hal_gpcrc_init(config->gpcrc, &init);
+
+	return 0;
+}
+
+static inline void write_data_input(const struct device *dev, const void *buffer, size_t bufsize)
+{
+	size_t idx = 0;
+	const uint8_t *data_pt = (const uint8_t *)buffer;
+	const struct crc_silabs_config *config = dev->config;
+	struct crc_silabs_data *data = dev->data;
+
+	if (data->is_crc32) {
+		/* Word boundaries */
+		while ((idx < bufsize) && ((uintptr_t)&data_pt[idx] & 0x3)) {
+			sl_hal_gpcrc_write_input_8bit(config->gpcrc, data_pt[idx++]);
+		}
+
+		while ((bufsize - idx) >= sizeof(uint32_t)) {
+			uint32_t val = *((const uint32_t *)(data_pt + idx));
+
+			sl_hal_gpcrc_write_input_32bit(config->gpcrc, val);
+			idx += sizeof(uint32_t);
+		}
+	} else {
+		/* Half word boundaries */
+		while ((idx < bufsize) && ((uintptr_t)&data_pt[idx] & 0x1)) {
+			sl_hal_gpcrc_write_input_8bit(config->gpcrc, data_pt[idx++]);
+		}
+
+		while ((bufsize - idx) >= sizeof(uint16_t)) {
+			uint16_t val = *((const uint16_t *)(data_pt + idx));
+
+			sl_hal_gpcrc_write_input_16bit(config->gpcrc, val);
+			idx += sizeof(uint16_t);
+		}
+	}
+	/* Handle tail bytes */
+	while (idx < bufsize) {
+		sl_hal_gpcrc_write_input_8bit(config->gpcrc, data_pt[idx++]);
+	}
+}
+
+/* Driver APIs */
+
+static int crc_silabs_begin(const struct device *dev, struct crc_ctx *ctx)
+{
+	int ret;
+	const struct crc_silabs_config *config = dev->config;
+
+	if ((ctx == NULL) || (ctx->state != CRC_STATE_IDLE)) {
+		return -EINVAL;
+	}
+
+	crc_silabs_lock(dev);
+
+	ret = set_crc_config(dev, ctx);
+	if (ret != 0) {
+		crc_silabs_unlock(dev);
+		return ret;
+	}
+
+	sl_hal_gpcrc_enable(config->gpcrc);
+	sl_hal_gpcrc_start(config->gpcrc);
+
+	ctx->state = CRC_STATE_IN_PROGRESS;
+
+	return 0;
+}
+
+static int crc_silabs_update(const struct device *dev, struct crc_ctx *ctx, const void *buffer,
+							 size_t bufsize)
+{
+	uint32_t result = 0;
+	const struct crc_silabs_config *config = dev->config;
+	struct crc_silabs_data *data = dev->data;
+	/* Flip the flag to get right result
+	 * Silabs EFR32 GPCRC needs to use the inverted RefIn and RefOut flags
+	 * to produce correct checksum results
+	 */
+	bool reversed_out = !(ctx->reversed & CRC_FLAG_REVERSE_OUTPUT);
+
+	if (ctx->state == CRC_STATE_IDLE) {
+		return -EINVAL;
+	}
+	/* Write data to crc input */
+	write_data_input(dev, buffer, bufsize);
+
+	/* Get result */
+	if (!reversed_out) {
+		result = sl_hal_gpcrc_read_data(config->gpcrc);
+	} else {
+		result = sl_hal_gpcrc_read_data_bit_reversed(config->gpcrc);
+	}
+	/* Xor output */
+	result ^= data->xor_out;
+
+	if (ctx->type != CRC32_IEEE) {
+		ctx->result = (uint16_t)result;
+	} else {
+		ctx->result = result;
+	}
+
+	return 0;
+}
+
+static int crc_silabs_finish(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_silabs_config *config = dev->config;
+
+	if (ctx->state == CRC_STATE_IDLE) {
+		return -EINVAL;
+	}
+
+	ctx->state = CRC_STATE_IDLE;
+
+	crc_silabs_unlock(dev);
+	sl_hal_gpcrc_disable(config->gpcrc);
+
+	return 0;
+}
+
+static DEVICE_API(crc, crc_silabs_driver_api) = {
+	.begin = crc_silabs_begin,
+	.update = crc_silabs_update,
+	.finish = crc_silabs_finish,
+};
+
+static int crc_silabs_init(const struct device *dev)
+{
+	int ret;
+	const struct crc_silabs_config *config = dev->config;
+	struct crc_silabs_data *data = dev->data;
+
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(config->clock_dev,
+		(clock_control_subsys_t)(uintptr_t)&config->clock_cfg);
+
+	if ((ret != 0) && (ret != -EALREADY)) {
+		return ret;
+	}
+
+	k_sem_init(&data->lock, 1, 1);
+
+	return 0;
+}
+
+
+#define CRC_SILABS_GPCRC_INIT(idx)                                                                \
+	static struct crc_silabs_data silabs_gpcrc_data_##idx;                                    \
+	static const struct crc_silabs_config silabs_gpcrc_config_##idx = {                       \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                             \
+		.clock_cfg = SILABS_DT_CLOCK_CFG(DT_DRV_INST(idx)),                               \
+		.gpcrc = (GPCRC_TypeDef *)DT_INST_REG_ADDR(idx),                                  \
+	};                                                                                        \
+	                                                                                          \
+	DEVICE_DT_INST_DEFINE(idx,                                                                \
+		crc_silabs_init, NULL,                                                            \
+		&silabs_gpcrc_data_##idx,                                                         \
+		&silabs_gpcrc_config_##idx,                                                       \
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                                  \
+		&crc_silabs_driver_api)                                                           \
+
+DT_INST_FOREACH_STATUS_OKAY(CRC_SILABS_GPCRC_INIT)

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -17,6 +17,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &rtcc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -447,6 +448,13 @@
 			compatible = "silabs,buram";
 			reg = <0x50080000 0x80>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_HCLK>;
+			status = "okay";
 		};
 
 		rtcc0: rtcc@58000000 {

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &rtcc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &msc;
 	};
@@ -480,6 +481,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &sysrtc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -482,6 +483,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &sysrtc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -474,6 +475,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/arm/silabs/xg26/xg26.dtsi
+++ b/dts/arm/silabs/xg26/xg26.dtsi
@@ -15,6 +15,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &sysrtc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -543,6 +544,13 @@
 			reg = <0x50084000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		eusart1: eusart@5008c000 {

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &rtcc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &msc;
 	};
@@ -480,6 +481,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_PCLK>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -16,6 +16,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &sysrtc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -482,6 +483,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_INVALID>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -15,6 +15,7 @@
 / {
 	chosen {
 		silabs,sleeptimer = &rtcc0;
+		zephyr,crc = &gpcrc;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -485,6 +486,13 @@
 			reg = <0x50080000 0x80>;
 			clocks = <&cmu CLOCK_BURAM CLOCK_BRANCH_PCLK>;
 			status = "disabled";
+		};
+
+		gpcrc: gpcrc@50088000 {
+			compatible = "silabs,gpcrc";
+			reg = <0x50088000 0x4000>;
+			clocks = <&cmu CLOCK_GPCRC0 CLOCK_BRANCH_PCLK>;
+			status = "okay";
 		};
 
 		dcdc: dcdc@50094000 {

--- a/dts/bindings/crc/silabs,gpcrc.yaml
+++ b/dts/bindings/crc/silabs,gpcrc.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Phuc Hoang
+# SPDX-License-Identifier: Apache-2.0
+
+title: Silabs General Purpose CRC (Cyclic Redundancy Check)
+
+description: |
+  Silabs General Purpose CRC (Cyclic Redundancy Check) driver
+
+  The GPCRC module is a peripheral that implements a Cyclic Redundancy Check (CRC) function.
+  It supports a fixed 32-bit polynomial and a user configurable 16-bit polynomial.
+  The fixed 32-bit polynomial is the commonly used IEEE 802.3 polynomial 0x04C11DB7.
+
+compatible: "silabs,gpcrc"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -318,6 +318,8 @@ if(CONFIG_SILABS_SISDK_I2C)
   )
 endif()
 
+# GPCRC
+zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_GPCRC     ${PERIPHERAL_DIR}/src/sl_hal_gpcrc.c)
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_LETIMER   ${PERIPHERAL_DIR}/src/sl_hal_letimer.c)
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_TIMER     ${PERIPHERAL_DIR}/src/sl_hal_timer.c)
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_VDAC      ${PERIPHERAL_DIR}/src/sl_hal_vdac.c)

--- a/modules/hal_silabs/simplicity_sdk/Kconfig
+++ b/modules/hal_silabs/simplicity_sdk/Kconfig
@@ -21,6 +21,9 @@ config SILABS_SISDK_EMU
 config SILABS_SISDK_EUSART
 	bool "Peripheral HAL for EUSART"
 
+config SILABS_SISDK_GPCRC
+	bool "Peripheral HAL for GPCRC"
+
 config SILABS_SISDK_GPIO
 	bool "Peripheral HAL for GPIO"
 


### PR DESCRIPTION
Add Silabs General gpcrc driver for Series 2 boards Enable crc sample for Silabs series 2

I added a CRC driver to the Silabs Series 2 with a general-purpose CRC. I found that hardware CRC use cases are few and seemingly unnecessary, but since the Silabs platform already has this peripheral, I wrote it. Anyway, I think it's better to have it and not use it than to need it and not have it.

I tested it on a real circuit with an SLWRB4180B.