### PR TITLE
drivers: ethernet: ETH_IVSHMEM: add missing depends on DT_HAS_*

### DIFF
--- a/drivers/ethernet/Kconfig.ivshmem
+++ b/drivers/ethernet/Kconfig.ivshmem
@@ -10,6 +10,8 @@ menuconfig ETH_IVSHMEM
 	select IVSHMEM_V2
 	select IVSHMEM_DOORBELL
 	select OPENAMP
+	depends on DT_HAS_SIEMENS_IVSHMEM_ETH_ENABLED
+	default y
 	help
 	  Enable Inter-VM Shared Memory Ethernet driver.
 	  Used for Ethernet communication between "cells" in the Jailhouse hypervisor.


### PR DESCRIPTION
add missing depends on DT_HAS_* for the
ETH_IVSHMEM driver.