### PR TITLE
boards: doc: aithinker: per-SoC template

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/doc/index.rst
+++ b/boards/aithinker/ai_m61_32s_kit/doc/index.rst
@@ -1,93 +1,33 @@
 .. zephyr:board:: ai_m61_32s_kit
+.. |board| replace:: ``ai_m61_32s_kit``
+.. |soc| replace:: BL618
+.. |safe_overclock| replace:: ``ai_m61_32s_kit/bl618m05q2i/safe_overclock``
+.. |unsafe_overclock| replace:: ``ai_m61_32s_kit/bl618m05q2i/unsafe_overclock``
 
 Overview
 ********
 
 Ai-M61-32S is a Wi-Fi 6 + BLE5.3 module developed by Shenzhen Ai-Thinker Technology
-Co., Ltd. The module is equipped with BL618 chip as the core processor, supports Wi-Fi
-802.11b/g/n/ax protocol and BLE protocol, and supports Thread protocol. The BL618 system
-includes a low-power 32-bit RISC-V CPU with floating-point unit, DSP unit, cache and
-memory, with a maximum dominant frequency of 320M.
+Co., Ltd.
 
-Hardware
-********
+.. include:: ../../../aithinker/common/soc-bl61x.rst.inc
 
-For more information about the Bouffalo Lab BL-61x MCU:
-
-- `Bouffalo Lab BL61x MCU Datasheet`_
-- `Bouffalo Lab Development Zone`_
-- `ai_m61_32s_kit Schematics`_
-
-Supported Features
-==================
-
-.. zephyr:board-supported-hw::
-
-System Clock
-============
-
-The M61 (BL618) Development Board is configured to run at maximum speed (320MHz)
-and can be overclocked to 480 MHz.
-
-This board provides demonstration configurations for the overclocking of the BL618 SoC clocks:
-
-- ``ai_m61_32s_kit/bl618m05q2i/safe_overclock`` demonstrates 120MHz BCLK and 480MHz core clock on both variants. This nets a Coremark score up to 1600.
-- ``ai_m61_32s_kit/bl618m05q2i/unsafe_overclock`` demonstrates 120MHz or 106MHz BCLK and 640MHz core clock with higher core voltages. This nets a Coremark score up to 2100.
-
-If you are using the ALL variant, please use :``ai_m61_32s_kit@ALL``.
-
-When overclocking, DMA and DMA-using drivers will not work properly.
+If you are using the ALL variant, please use: ``ai_m61_32s_kit@ALL``.
 
 Serial Port
 ===========
 
-The ``ai_m61_32s_kit`` board uses UART0 as default serial port.  It is connected
+The |board| board uses UART0 as default serial port.  It is connected
 to USB Serial converter and port is used for both program and console.
 
+.. include:: ../../../aithinker/common/building-flashing.rst.inc
 
-Programming and Debugging
-*************************
+.. code-block:: console
 
-Samples
-=======
+   *** Booting Zephyr OS build v4.3.0 ***
+   Hello World! ai_m61_32s_kit/bl618m05q2i
 
-#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-   application:
+Congratulations, you have |board| configured and running Zephyr.
 
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: ai_m61_32s_kit
-      :goals: build flash
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyUSB0`. For example:
-
-   .. code-block:: console
-
-      $ screen /dev/ttyUSB0 115200
-
-   Connection should be configured as follows:
-
-      - Speed: 115200
-      - Data: 8 bits
-      - Parity: None
-      - Stop bits: 1
-
-   Then, press and release RST button
-
-   .. code-block:: console
-
-      *** Booting Zephyr OS build v4.3.0 ***
-      Hello World! ai_m61_32s_kit/bl618m05q2i
-
-Congratulations, you have ``ai_m61_32s_kit`` configured and running Zephyr.
-
-
-.. _Bouffalo Lab BL61x MCU Datasheet:
-	https://github.com/bouffalolab/bl_docs/tree/main/BL616_DS/en
-
-.. _Bouffalo Lab Development Zone:
-	https://dev.bouffalolab.com/home?id=guest
-
-.. _ai_m61_32s_kit Schematics:
+.. _Schematics:
    https://docs.ai-thinker.com/en/ai_m61/

--- a/boards/aithinker/ai_m62_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_m62_12f_kit/doc/index.rst
@@ -1,84 +1,33 @@
 .. zephyr:board:: ai_m62_12f_kit
+.. |board| replace:: ``ai_m61_12f_kit``
+.. |soc| replace:: BL616
+.. |safe_overclock| replace:: ``ai_m61_12f_kit/bl616c50q2i/safe_overclock``
+.. |unsafe_overclock| replace:: ``ai_m61_12f_kit/bl616c50q2i/unsafe_overclock``
 
 Overview
 ********
 
 Ai-M62-12F is a Wi-Fi 6 + BLE5.3 module developed by Shenzhen Ai-Thinker Technology
-Co., Ltd. The module is equipped with BL616 chip as the core processor, supports Wi-Fi
-802.11b/g/n/ax protocol and BLE protocol, and supports Thread protocol. The BL616 system
-includes a low-power 32-bit RISC-V CPU with floating-point unit, DSP unit, cache and
-memory, with a maximum dominant frequency of 320M.
+Co., Ltd.
 
-Hardware
-********
+.. include:: ../../../aithinker/common/soc-bl61x.rst.inc
 
-For more information about the Bouffalo Lab BL-61x MCU:
-
-- `Bouffalo Lab BL61x MCU Datasheet`_
-- `Bouffalo Lab Development Zone`_
-- `ai_m62_12f_kit Schematics`_
-
-Supported Features
-==================
-
-.. zephyr:board-supported-hw::
-
-System Clock
-============
-
-The M62 (BL616) Development Board is configured to run at maximum speed (320MHz)
-and can be overclocked to 480 MHz.
+If you are using the ALL variant, please use: ``ai_m62_12f_kit@ALL``.
 
 Serial Port
 ===========
 
-The ``ai_m62_12f_kit`` board uses UART0 as default serial port.  It is connected
+The |board| board uses UART0 as default serial port.  It is connected
 to USB Serial converter and port is used for both program and console.
 
+.. include:: ../../../aithinker/common/building-flashing.rst.inc
 
-Programming and Debugging
-*************************
+.. code-block:: console
 
-Samples
-=======
+   *** Booting Zephyr OS build v4.3.0 ***
+   Hello World! ai_m62_12f_kit/bl616c50q2i
 
-#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-   application:
+Congratulations, you have |board| configured and running Zephyr.
 
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: ai_m62_12f_kit
-      :goals: build flash
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyUSB0`. For example:
-
-   .. code-block:: console
-
-      $ screen /dev/ttyUSB0 115200
-
-   Connection should be configured as follows:
-
-      - Speed: 115200
-      - Data: 8 bits
-      - Parity: None
-      - Stop bits: 1
-
-   Then, press and release RST button
-
-   .. code-block:: console
-
-      *** Booting Zephyr OS build v4.2.0 ***
-      Hello World! ai_m62_12f_kit/bl616c50q2i
-
-Congratulations, you have ``ai_m62_12f_kit`` configured and running Zephyr.
-
-
-.. _Bouffalo Lab BL61x MCU Datasheet:
-	https://github.com/bouffalolab/bl_docs/tree/main/BL616_DS/en
-
-.. _Bouffalo Lab Development Zone:
-	https://dev.bouffalolab.com/home?id=guest
-
-.. _ai_m62_12f_kit Schematics:
+.. _Schematics:
    https://docs.ai-thinker.com/en/ai_m62/

--- a/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
@@ -1,104 +1,28 @@
 .. zephyr:board:: ai_wb2_12f_kit
+.. |board| replace:: ``ai_wb2_12f_kit``
+.. |soc| replace:: BL602
 
 Overview
 ********
 
-BL602/BL604 is a Wi-Fi+BLE chipset introduced by Bouffalo Lab, which is used
-for low power consumption and high performance application development.  The
-wireless subsystem includes 2.4G radio, Wi-Fi 802.11b/g/n and BLE 5.0
-baseband/MAC design.  The microcontroller subsystem includes a 32-bit RISC CPU
-with low power consumption, cache and memory.  The power management unit
-controls the low power consumption mode.  In addition, it also supports
-various security features.  The external interfaces include SDIO, SPI, UART,
-I2C, IR remote, PWM, ADC, DAC, PIR and GPIO.
+This WB2 (BL602) 12F format Module Development Board features a BL602/BL604 SoC.
 
-This WB2 (BL602) 12F format Module Development Board features a SiFive E24 32 bit
-RISC-V CPU with FPU, it supports High Frequency clock up to 192Mhz, have 128k ROM, 276kB RAM,
-2.4 GHz WIFI 1T1R mode, support 20 MHz, data rate up to 72.2 Mbps, BLE 5.0
-with 2MB phy.  It is a secure MCU which supports Secure boot, ECC-256 signed
-image, QSPI/SPI Flash On-The-Fly AES Decryption and PKA (Public Key
-Accelerator).
-
-Hardware
-********
-
-For more information about the Bouffalo Lab BL-60x MCU:
-
-- `Bouffalo Lab BL60x MCU Website`_
-- `Bouffalo Lab BL60x MCU Datasheet`_
-- `Bouffalo Lab Development Zone`_
-- `ai_wb2_12f_kit Schematics`_
-- `The RISC-V BL602 Book`_
-
-Supported Features
-==================
-
-.. zephyr:board-supported-hw::
-
-System Clock
-============
-
-The WB2 (BL602) Development Board is configured to run at max speed (192MHz).
+.. include:: ../../../aithinker/common/soc-bl60x.rst.inc
 
 Serial Port
 ===========
 
-The ``ai_wb2_12f_kit`` board uses UART0 as default serial port.  It is connected
+The |board| board uses UART0 as default serial port.  It is connected
 to USB Serial converter and port is used for both program and console.
 
+.. include:: ../../../aithinker/common/building-flashing.rst.inc
 
-Programming and Debugging
-*************************
+.. code-block:: console
 
-Samples
-=======
+   *** Booting Zephyr OS build v4.1.0 ***
+   Hello World! ai_wb2_12f_kit/bl602c00q2i
 
-#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-   application:
+Congratulations, you have |board| configured and running Zephyr.
 
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: ai_wb2_12f_kit
-      :goals: build flash
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyUSB0`. For example:
-
-   .. code-block:: console
-
-      $ screen /dev/ttyUSB0 115200
-
-   Connection should be configured as follows:
-
-      - Speed: 115200
-      - Data: 8 bits
-      - Parity: None
-      - Stop bits: 1
-
-   Then, press and release RST button
-
-   .. code-block:: console
-
-      *** Booting Zephyr OS build v4.1.0 ***
-      Hello World! ai_wb2_12f_kit/bl602c00q2i
-
-Congratulations, you have ``ai_wb2_12f_kit`` configured and running Zephyr.
-
-
-.. _Bouffalo Lab BL60x MCU Website:
-	https://en.bouffalolab.com/product/?type=detail&id=6
-
-.. _Bouffalo Lab BL60x MCU Datasheet:
-	https://github.com/bouffalolab/bl_docs/tree/main/BL602_DS/en
-
-.. _Bouffalo Lab Development Zone:
-	https://dev.bouffalolab.com/home?id=guest
-
-.. _ai_wb2_12f_kit Schematics:
+.. _Schematics:
    https://docs.ai-thinker.com/en/wb2
-
-.. _The RISC-V BL602 Book:
-	https://lupyuen.github.io/articles/book
-
-.. _Flashing Firmware to BL602:
-	https://lupyuen.github.io/articles/book#flashing-firmware-to-bl602

--- a/boards/aithinker/common/building-flashing.rst.inc
+++ b/boards/aithinker/common/building-flashing.rst.inc
@@ -1,0 +1,31 @@
+.. SPDX-FileCopyrightText: Copyright MASSDRIVER EI (massdriver.space)
+.. SPDX-License-Identifier: Apache-2.0
+
+Programming and Debugging
+*************************
+
+Samples
+=======
+
+#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
+   application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :goals: build flash
+
+#. Run your favorite terminal program to listen for output. Under Linux the
+   terminal should be :code:`/dev/ttyUSB0`. For example:
+
+   .. code-block:: console
+
+      $ screen /dev/ttyUSB0 115200
+
+   Connection should be configured as follows:
+
+      - Speed: 115200
+      - Data: 8 bits
+      - Parity: None
+      - Stop bits: 1
+
+   Then, press and release RST button

--- a/boards/aithinker/common/soc-bl60x.rst.inc
+++ b/boards/aithinker/common/soc-bl60x.rst.inc
@@ -1,0 +1,55 @@
+.. SPDX-FileCopyrightText: Copyright MASSDRIVER EI (massdriver.space)
+.. SPDX-License-Identifier: Apache-2.0
+
+|soc| is a Wi-Fi+BLE chipset introduced by Bouffalo Lab, which is used
+for low power consumption and high performance application development.  The
+wireless subsystem includes 2.4G radio, Wi-Fi 802.11b/g/n and BLE 5.0
+baseband/MAC design.  The microcontroller subsystem includes a 32-bit RISC CPU
+with low power consumption, cache and memory.  The power management unit
+controls the low power consumption mode.  In addition, it also supports
+various security features.  The external interfaces include SDIO, SPI, UART,
+I2C, IR remote, PWM, ADC, DAC, PIR and GPIO.
+
+It features a SiFive E24 32 bit RISC-V CPU with FPU, it supports High Frequency
+clock up to 192Mhz, have 128k ROM, 276kB RAM,
+2.4 GHz WIFI 1T1R mode, support 20 MHz, data rate up to 72.2 Mbps, BLE 5.0
+with 2MB phy.  It is a secure MCU which supports Secure boot, ECC-256 signed
+image, QSPI/SPI Flash On-The-Fly AES Decryption and PKA (Public Key
+Accelerator).
+
+Hardware
+********
+
+For more information about the Bouffalo Lab |soc| MCU:
+
+- `Bouffalo Lab BL60x MCU Website`_
+- `Bouffalo Lab BL60x MCU Datasheet`_
+- `Bouffalo Lab Development Zone`_
+- `The RISC-V BL602 Book`_
+- `Flashing Firmware to BL602`_
+- |board| `Schematics`_
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+System Clock
+============
+
+This |soc| development board is configured to run at max speed (192MHz).
+
+.. _Bouffalo Lab BL60x MCU Website:
+	https://en.bouffalolab.com/product/?type=detail&id=6
+
+.. _Bouffalo Lab BL60x MCU Datasheet:
+	https://github.com/bouffalolab/bl_docs/tree/main/BL602_DS/en
+
+.. _Bouffalo Lab Development Zone:
+	https://dev.bouffalolab.com/home?id=guest
+
+.. _The RISC-V BL602 Book:
+	https://lupyuen.github.io/articles/book
+
+.. _Flashing Firmware to BL602:
+	https://lupyuen.github.io/articles/book#flashing-firmware-to-bl602

--- a/boards/aithinker/common/soc-bl61x.rst.inc
+++ b/boards/aithinker/common/soc-bl61x.rst.inc
@@ -1,0 +1,44 @@
+.. SPDX-FileCopyrightText: Copyright MASSDRIVER EI (massdriver.space)
+.. SPDX-License-Identifier: Apache-2.0
+
+It is equipped with |soc| chip as the core processor, supports Wi-Fi
+802.11b/g/n/ax protocol and BLE protocol, and supports Thread protocol. The |soc| system
+includes a low-power 32-bit RISC-V CPU with floating-point unit, DSP unit, cache and
+memory, with a maximum dominant frequency of 320M.
+
+Hardware
+********
+
+For more information about the Bouffalo Lab |soc| MCU:
+
+- `Bouffalo Lab BL61x MCU Datasheet`_
+- `Bouffalo Lab Development Zone`_
+- |board| `Schematics`_
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+
+System Clock
+============
+
+This |soc| development board is configured to run at maximum speed (320MHz)
+and can be overclocked to 480 MHz.
+
+This board provides demonstration configurations for the overclocking of the |soc| SoC clocks:
+
+- |safe_overclock| demonstrates 120MHz BCLK and 480MHz core clock on both variants.
+  This nets a Coremark score up to 1600.
+
+- |unsafe_overclock| demonstrates 120MHz or 106MHz BCLK and 640MHz core clock with higher core voltages.
+  This nets a Coremark score up to 2100.
+
+When overclocking, DMA and DMA-using drivers will not work properly.
+
+.. _Bouffalo Lab BL61x MCU Datasheet:
+	https://github.com/bouffalolab/bl_docs/tree/main/BL616_DS/en
+
+.. _Bouffalo Lab Development Zone:
+	https://dev.bouffalolab.com/home?id=guest

--- a/boards/aithinker/index.rst
+++ b/boards/aithinker/index.rst
@@ -7,4 +7,4 @@ Ai-Thinker Co.
    :maxdepth: 1
    :glob:
 
-   **/*
+   */**/index

--- a/boards/espressif/common/board-variants.rst
+++ b/boards/espressif/common/board-variants.rst
@@ -39,7 +39,6 @@ To apply a board variant, use the ``-S`` flag with west build:
 .. zephyr-app-commands::
    :tool: west
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: build
    :snippets: espressif-flash-32M,espressif-psram-4M
    :compact:

--- a/boards/espressif/common/building-flashing.rst
+++ b/boards/espressif/common/building-flashing.rst
@@ -43,7 +43,6 @@ To build the sample application using sysbuild use the command:
 .. zephyr-app-commands::
    :tool: west
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: build
    :west-args: --sysbuild
    :compact:
@@ -92,7 +91,6 @@ Build and flash applications as usual (see :ref:`build_an_application` and
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: build
 
 The usual ``flash`` target will work with the board configuration.
@@ -101,7 +99,6 @@ application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: flash
 
 Open the serial monitor using the following command:

--- a/boards/espressif/common/openocd-debugging.rst
+++ b/boards/espressif/common/openocd-debugging.rst
@@ -29,7 +29,6 @@ OpenOCD supports Zephyr RTOS thread awareness, allowing GDB to:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: debug
    :gen-args: -DCONFIG_DEBUG_THREAD_INFO=y -DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>
 
@@ -41,7 +40,6 @@ To use the Espressif OpenOCD, specify the path when building:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: <board>
    :goals: debug
    :gen-args: -DOPENOCD=/path/to/openocd -DOPENOCD_DEFAULT_PATH=/path/to/openocd/scripts
 

--- a/doc/_extensions/zephyr/application.py
+++ b/doc/_extensions/zephyr/application.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from sphinx.util.nodes import NodeMatcher
+
+from zephyr.domain import BoardNode
 
 ZEPHYR_BASE = Path(__file__).parents[3]
 
@@ -57,6 +60,11 @@ class ZephyrAppCommandsDirective(Directive):
     IN_TREE_STR = '# From the root of the zephyr repository'
 
     def run(self):
+        # Infer board name from the current document as a fallback
+        matcher = NodeMatcher(BoardNode)
+        board_nodes = list(self.state.document.traverse(matcher))
+        board_default = board_nodes[0]["id"] if board_nodes else None
+
         # Re-run on the current document if this directive's source changes.
         self.state.document.settings.env.note_dependency(__file__)
 
@@ -68,7 +76,7 @@ class ZephyrAppCommandsDirective(Directive):
         cd_into = 'cd-into' in self.options
         generator = self.options.get('generator', 'ninja').lower()
         host_os = self.options.get('host-os', 'all').lower()
-        board = self.options.get('board', None)
+        board = self.options.get('board', board_default)
         shield = self.options.get('shield', None)
         conf = self.options.get('conf', None)
         gen_args = self.options.get('gen-args', None)


### PR DESCRIPTION
This is an experiment to maintain all the SoC-specific documentation in one place.

Tempalte engine built out of this:

- `.. |board| replace:: ai_m61_12f_kit` (variable expansion)
- `.. include:: ../../../aithinker/common/soc-bl61x.rst`
- `.. zephyr-app-commands::` extended to use the current board by default

BouffaloLab pages simplified:

https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/aithinker/ai_m61_32s_kit/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/aithinker/ai_m62_12f_kit/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/aithinker/ai_wb2_12f_kit/doc/index.html

Espressif pages fixed:

https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32_ethernet_kit/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32c3_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32c3_devkitm/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32c3_rust/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32c5_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32c6_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32h2_devkitm/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32s2_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32s2_saola/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32s3_devkitc/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp32s3_eye/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp8684_devkitm/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp_threadbr/doc/index.html
https://builds.zephyrproject.io/zephyr/pr/104473/docs/boards/espressif/esp_wrover_kit/doc/index.html