### PR TITLE
net: ip: Allow to specify default router with net_if_ipv6_router_add()

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1960,12 +1960,14 @@ void net_if_ipv6_router_update_lifetime(struct net_if_router *router,
  *
  * @param iface Network interface
  * @param addr IPv6 address
- * @param router_lifetime Lifetime of the router
+ * @param is_default Is this router the default one
+ * @param router_lifetime Lifetime of the router. 0 if the router never expire.
  *
  * @return Pointer to router information, NULL if could not be added
  */
 struct net_if_router *net_if_ipv6_router_add(struct net_if *iface,
 					     const struct net_in6_addr *addr,
+					     bool is_default,
 					     uint16_t router_lifetime);
 
 /**
@@ -2614,7 +2616,7 @@ struct net_if_router *net_if_ipv4_router_find_default(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv4 address
  * @param is_default Is this router the default one
- * @param router_lifetime Lifetime of the router
+ * @param router_lifetime Lifetime of the router. 0 if the router never expire.
  *
  * @return Pointer to router information, NULL if could not be added
  */

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2818,7 +2818,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 		}
 	} else {
 		net_if_ipv6_router_add(net_pkt_iface(pkt), &ra_src,
-				       router_lifetime);
+				       router_lifetime != 0, router_lifetime);
 	}
 
 	net_ipv6_nbr_lock();

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -865,9 +865,9 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 		routers[i].is_used = true;
 		routers[i].iface = iface;
 		routers[i].address.family = family;
+		routers[i].is_default = is_default;
 
 		if (lifetime) {
-			routers[i].is_default = true;
 			routers[i].is_infinite = false;
 			routers[i].lifetime = lifetime;
 			routers[i].life_start = k_uptime_get_32();
@@ -877,7 +877,6 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 
 			iface_router_update_timer(routers[i].life_start);
 		} else {
-			routers[i].is_default = false;
 			routers[i].is_infinite = true;
 			routers[i].lifetime = 0;
 		}
@@ -897,8 +896,6 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
 			memcpy(net_if_router_ipv4(&routers[i]), addr,
 			       sizeof(struct net_in_addr));
-			routers[i].is_default = is_default;
-
 			net_mgmt_event_notify_with_info(
 					NET_EVENT_IPV4_ROUTER_ADD, iface,
 					&routers[i].address.in_addr,
@@ -3017,9 +3014,10 @@ void net_if_ipv6_router_update_lifetime(struct net_if_router *router,
 
 struct net_if_router *net_if_ipv6_router_add(struct net_if *iface,
 					     const struct net_in6_addr *addr,
+					     bool is_default,
 					     uint16_t lifetime)
 {
-	return iface_router_add(iface, NET_AF_INET6, addr, false, lifetime);
+	return iface_router_add(iface, NET_AF_INET6, addr, is_default, lifetime);
 }
 
 bool net_if_ipv6_router_rm(struct net_if_router *router)


### PR DESCRIPTION
Align the net_if_ipv6_router_add() behavior with its IPv4 counterpart, where it is possible to specify whether the router is a default one instead of making assumptions based on the lifetime value.

The current behavior was likely inspired by the Neighbor Discovery RFC, where the lifetime parameter of 0 received in the Router Advertisement message indicates that the router should not be treated as a default router, however this is an implementation detail of the Neighbor Discovery protocol and does not need to be enforced at the router API level, as this can be used outside of this protocol (for example when router is added manually from the application).

Therefore, allow to specify the "is_default" parameter separately just like in the IPv4 case.The Router Advertisement handling routine will just specify the "is_default" value based on the received lifetime value.

Also, clarify in the function documentation what does it mean to specify lifetime to 0 (which means the router never expires according to current implementation).

Fixes #104286