### PR TITLE
manifest: uoscore-edhoc: include fix for crypto

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -391,7 +391,7 @@ manifest:
       groups:
         - tee
     - name: uoscore-uedhoc
-      revision: ac80c3bf2b88deec86d129654fbde09761582342
+      revision: e47f6465a96d12a54b875e5f6e5b2a203fb0d61d
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
       revision: 9164bd18dcd88ff9d9ef98279501fc1093571017


### PR DESCRIPTION
The fix replaces PSA_KEY_HANDLE_INIT with PSA_KEY_ID_NULL since the former has been removed from TF-PSA-Crypto 1.0.