### PR TITLE
pmci: mctp: test/samples: Remove unnecessary include

### DIFF
--- a/samples/subsys/pmci/mctp/i3c_bus_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/i3c_bus_endpoint/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>

--- a/samples/subsys/pmci/mctp/i3c_bus_owner/src/main.c
+++ b/samples/subsys/pmci/mctp/i3c_bus_owner/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>

--- a/tests/subsys/pmci/mctp/uart/src/main.c
+++ b/tests/subsys/pmci/mctp/uart/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>


### PR DESCRIPTION
These test & samples do not seem to need the unistd.h header, but including it limits us to C libraries which have it, which as it is a POSIX extension is not all.
So let's not include it so we do not limit ourselves unnecessarily.

Very related to:
* 312b1ef04f577d71e6169a47fb5a7ab66cf1cdae
* https://github.com/zephyrproject-rtos/zephyr/pull/100831

limitation can be repro'd by doing
```
cmake -GNinja -DBOARD=npcx4m8f_evb ../tests/subsys/pmci/mctp/uart/ -DCONFIG_MINIMAL_LIBC=y
ninja
```
