### PR TITLE
drivers: systimer: xtensa: Add CCOUNT compensation

### DIFF
--- a/drivers/timer/Kconfig.xtensa
+++ b/drivers/timer/Kconfig.xtensa
@@ -1,6 +1,7 @@
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Cadence Design Systems, Inc.
 # Copyright (c) 2019 Intel Corp.
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 config XTENSA_TIMER
@@ -23,3 +24,29 @@ config XTENSA_TIMER_ID
 	  them can be unmaskable (and thus not usable by OS code that
 	  need synchronization, like the timer subsystem!).  In
 	  general timer zero is guaranteed to be present and usable.
+
+choice XTENSA_TIMER_LPM_TIMER
+	prompt "Xtensa CCOUNT low-power mode support"
+	depends on XTENSA_TIMER
+	default XTENSA_TIMER_LPM_TIMER_NONE
+	help
+	  CCOUNT stops when the CPU clock is gated during low-power modes.
+	  A companion timer that remains active can be used to compensate
+	  for the missed cycles.
+
+config XTENSA_TIMER_LPM_TIMER_NONE
+	bool "No compensation"
+	help
+	  Use no additional device as low-power mode timer.
+	  The SoC must never enter a low-power mode where CCOUNT stops
+	  when this option is selected.
+
+config XTENSA_TIMER_LPM_TIMER_HOOK
+	bool "Hook-based compensation"
+	depends on PM && TICKLESS_KERNEL
+	help
+	  The platform provides a hook returning the number of
+	  CPU cycles missed while CCOUNT was stopped during
+	  low-power mode.
+
+endchoice

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,8 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
+
+#include "xtensa_sys_timer.h"
 
 #define TIMER_IRQ UTIL_CAT(XCHAL_TIMER,		\
 			   UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT))
@@ -26,6 +29,20 @@ const int32_t z_sys_timer_irq_for_test = UTIL_CAT(XCHAL_TIMER,
 					 UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT));
 #endif
 
+static uint32_t ccount_compensation;
+static uint32_t ccount_pre_idle;
+static uint64_t lptim_pre_idle;
+static bool timeout_idle;
+
+static uint32_t ccount_comp(void)
+{
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+		return ccount_compensation;
+	}
+
+	return 0;
+}
+
 static void set_ccompare(uint32_t val)
 {
 	__asm__ volatile ("wsr.CCOMPARE" STRINGIFY(CONFIG_XTENSA_TIMER_ID) " %0"
@@ -37,7 +54,16 @@ static uint32_t ccount(void)
 	uint32_t val;
 
 	__asm__ volatile ("rsr.CCOUNT %0" : "=r"(val));
-	return val;
+	return val + ccount_comp();
+}
+
+static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
+{
+	uint32_t dticks = (curr - last_count) / CYC_PER_TICK;
+
+	last_count += dticks * CYC_PER_TICK;
+
+	return dticks;
 }
 
 static void ccompare_isr(const void *arg)
@@ -45,10 +71,9 @@ static void ccompare_isr(const void *arg)
 	ARG_UNUSED(arg);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t curr = ccount();
-	uint32_t dticks = (curr - last_count) / CYC_PER_TICK;
 
-	last_count += dticks * CYC_PER_TICK;
+	uint32_t curr = ccount();
+	uint32_t dticks = sys_clock_elapsed_ticks(curr);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t next = last_count + CYC_PER_TICK;
@@ -56,7 +81,7 @@ static void ccompare_isr(const void *arg)
 		if ((int32_t)(next - curr) < MIN_DELAY) {
 			next += CYC_PER_TICK;
 		}
-		set_ccompare(next);
+		set_ccompare(next - ccount_comp());
 	}
 
 	k_spin_unlock(&lock, key);
@@ -65,8 +90,6 @@ static void ccompare_isr(const void *arg)
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
-	ARG_UNUSED(idle);
-
 #if defined(CONFIG_TICKLESS_KERNEL)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
@@ -89,7 +112,23 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		cyc += CYC_PER_TICK;
 	}
 
-	set_ccompare(cyc);
+	set_ccompare(cyc - ccount_comp());
+
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+		if (idle && ticks != K_TICKS_FOREVER) {
+			uint64_t timeout_us =
+				((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+			lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
+			ccount_pre_idle = ccount();
+			timeout_idle = true;
+		} else {
+			timeout_idle = false;
+		}
+	} else {
+		ARG_UNUSED(idle);
+	}
+
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -120,9 +159,44 @@ void smp_timer_init(void)
 }
 #endif
 
+void sys_clock_idle_exit(void)
+{
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+
+		if (!timeout_idle) {
+			return;
+		}
+
+		k_spinlock_key_t key = k_spin_lock(&lock);
+
+		uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
+		uint64_t ccount_now = ccount();
+		uint64_t lptim_diff = lptim_now - lptim_pre_idle;
+		uint32_t ccount_diff = ccount_now - ccount_pre_idle;
+		uint64_t expected_cycles = (lptim_diff * sys_clock_hw_cycles_per_sec()) /
+					   z_xtensa_lptim_hook_get_freq();
+		uint32_t missed_cycles = 0;
+
+		if (expected_cycles > ccount_diff) {
+			missed_cycles = (uint32_t)(expected_cycles - ccount_diff);
+		}
+
+		ccount_compensation += missed_cycles;
+
+		ccount_now = ccount();
+		uint32_t dticks = sys_clock_elapsed_ticks(ccount_now);
+
+		timeout_idle = false;
+
+		k_spin_unlock(&lock, key);
+
+		/* Announce corrected ticks as CCOUNT remained stalled during LPM */
+		sys_clock_announce(dticks);
+	}
+}
+
 static int sys_clock_driver_init(void)
 {
-
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
 	set_ccompare(ccount() + CYC_PER_TICK);
 	irq_enable(TIMER_IRQ);

--- a/drivers/timer/xtensa_sys_timer.h
+++ b/drivers/timer/xtensa_sys_timer.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_TIMER_XTENSA_SYS_TIMER_H_
+#define ZEPHYR_DRIVERS_TIMER_XTENSA_SYS_TIMER_H_
+
+#include <zephyr/types.h>
+
+/**
+ * @brief Hook invoked before entering low-power mode
+ *
+ * Called by the Xtensa system timer driver when the kernel is about
+ * to enter low-power mode and a finite timeout is programmed.
+ *
+ * The SoC-specific implementation may:
+ *  - Configure an always-on low-power timer (LPTIM) that continues
+ *    running while the CPU CCOUNT register is halted.
+ *  - Program the LPTIM to wake the system after at most
+ *    @p max_lpm_time_us microseconds.
+ *  - Perform any additional platform-specific preparation required
+ *    prior to entering low-power mode.
+ *
+ * The function must return the current timestamp from the LPTIM,
+ * expressed in ticks (raw count). This value is used at LPM exit to
+ * determine how long CCOUNT remained stalled during low-power mode,
+ * allowing the driver to compensate for missed cycles.
+ *
+ * @param max_lpm_time_us Maximum allowed low-power residency in µs.
+ *
+ * @return Current LPTIM counter value in raw ticks.
+ */
+uint64_t z_xtensa_lptim_hook_on_lpm_entry(uint64_t max_lpm_time_us);
+
+/**
+ * @brief Hook invoked after exiting low-power mode
+ *
+ * Called by the Xtensa system timer driver immediately after the CPU
+ * resumes from low-power mode.
+ *
+ * The function must return the current timestamp from the LPTIM,
+ * expressed in ticks (raw count). The difference between this value
+ * and the one returned by z_xtensa_lptim_hook_on_lpm_entry() is used
+ * to compute how long the CPU CCOUNT was stalled, so the driver
+ * timer can apply the appropriate cycle compensation.
+ *
+ * @return Current LPTIM counter value in raw ticks.
+ */
+uint64_t z_xtensa_lptim_hook_on_lpm_exit(void);
+
+/**
+ * @brief Hook function for LPTIM clock frequency.
+ *
+ * @return LPTIM clock frequency in Hz.
+ */
+uint64_t z_xtensa_lptim_hook_get_freq(void);
+
+#endif /* ZEPHYR_DRIVERS_TIMER_XTENSA_SYS_TIMER_H_ */


### PR DESCRIPTION
Add CCOUNT compensation for time spent in LPM (CPU stalled).
Add sys_clock_idle_exit() for dticks announcement when leaving LPM.
Add hooks for SoC specific implementation of LP timer timestamp call.

Necessary for Power Management support (standby) for Espressif's Xtensa SoC's.