### PR TITLE
drivers: counter: add missing functions in to counter_handlers.c

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -17,9 +17,10 @@
 		return z_impl_counter_ ## name((const struct device *)dev); \
 	}
 
-COUNTER_HANDLER(get_pending_int)
 COUNTER_HANDLER(stop)
 COUNTER_HANDLER(start)
+COUNTER_HANDLER(get_pending_int)
+COUNTER_HANDLER(reset)
 
 #include <zephyr/syscalls/counter_get_pending_int_mrsh.c>
 #include <zephyr/syscalls/counter_stop_mrsh.c>
@@ -46,6 +47,15 @@ static inline uint32_t z_vrfy_counter_get_frequency(const struct device *dev)
 }
 #include <zephyr/syscalls/counter_get_frequency_mrsh.c>
 
+#ifdef CONFIG_COUNTER_64BITS_FREQ
+static inline uint64_t z_vrfy_counter_get_frequency_64(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_get_frequency_64((const struct device *)dev);
+}
+#include <zephyr/syscalls/counter_get_frequency_64_mrsh.c>
+#endif /* CONFIG_COUNTER_64BITS_FREQ */
+
 static inline uint32_t z_vrfy_counter_us_to_ticks(const struct device *dev,
 					       uint64_t us)
 {
@@ -64,6 +74,62 @@ static inline uint64_t z_vrfy_counter_ticks_to_us(const struct device *dev,
 }
 #include <zephyr/syscalls/counter_ticks_to_us_mrsh.c>
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+static inline uint64_t z_vrfy_counter_us_to_ticks_64(const struct device *dev,
+					      uint64_t us)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_us_to_ticks_64((const struct device *)dev,
+					     (uint64_t)us);
+}
+#include <zephyr/syscalls/counter_us_to_ticks_64_mrsh.c>
+
+static inline uint64_t z_vrfy_counter_ticks_to_us_64(const struct device *dev,
+					      uint64_t ticks)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_ticks_to_us_64((const struct device *)dev,
+					     (uint64_t)ticks);
+}
+#include <zephyr/syscalls/counter_ticks_to_us_64_mrsh.c>
+
+static inline uint32_t z_vrfy_counter_ns_to_ticks(const struct device *dev,
+					  uint64_t ns)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_ns_to_ticks((const struct device *)dev,
+					  (uint64_t)ns);
+}
+#include <zephyr/syscalls/counter_ns_to_ticks_mrsh.c>
+
+static inline uint64_t z_vrfy_counter_ns_to_ticks_64(const struct device *dev,
+					     uint64_t ns)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_ns_to_ticks_64((const struct device *)dev,
+					     (uint64_t)ns);
+}
+#include <zephyr/syscalls/counter_ns_to_ticks_64_mrsh.c>
+
+static inline uint64_t z_vrfy_counter_ticks_to_ns(const struct device *dev,
+					  uint32_t ticks)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_ticks_to_ns((const struct device *)dev,
+					  (uint32_t)ticks);
+}
+#include <zephyr/syscalls/counter_ticks_to_ns_mrsh.c>
+
+static inline uint64_t z_vrfy_counter_ticks_to_ns_64(const struct device *dev,
+					     uint64_t ticks)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_ticks_to_ns_64((const struct device *)dev,
+					     (uint64_t)ticks);
+}
+#include <zephyr/syscalls/counter_ticks_to_ns_64_mrsh.c>
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
+
 static inline int z_vrfy_counter_get_value(const struct device *dev,
 					   uint32_t *ticks)
 {
@@ -72,6 +138,16 @@ static inline int z_vrfy_counter_get_value(const struct device *dev,
 	return z_impl_counter_get_value((const struct device *)dev, ticks);
 }
 #include <zephyr/syscalls/counter_get_value_mrsh.c>
+
+
+static inline int z_vrfy_counter_set_value(const struct device *dev,
+					   uint32_t ticks)
+{
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value));
+	return z_impl_counter_set_value((const struct device *)dev,
+					ticks);
+}
+#include <zephyr/syscalls/counter_set_value_mrsh.c>
 
 #ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline int z_vrfy_counter_get_value_64(const struct device *dev,
@@ -82,6 +158,14 @@ static inline int z_vrfy_counter_get_value_64(const struct device *dev,
 	return z_impl_counter_get_value_64((const struct device *)dev, ticks);
 }
 #include <zephyr/syscalls/counter_get_value_64_mrsh.c>
+
+static inline int z_vrfy_counter_set_value_64(const struct device *dev,
+					      uint64_t ticks)
+{
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value_64));
+	return z_impl_counter_set_value_64((const struct device *)dev, ticks);
+}
+#include <zephyr/syscalls/counter_set_value_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
@@ -97,7 +181,6 @@ static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
 	return z_impl_counter_set_channel_alarm((const struct device *)dev,
 						(uint8_t)chan_id,
 						(const struct counter_alarm_cfg *)&cfg_copy);
-
 }
 #include <zephyr/syscalls/counter_set_channel_alarm_mrsh.c>
 
@@ -133,6 +216,52 @@ static inline uint32_t z_vrfy_counter_get_top_value(const struct device *dev)
 }
 #include <zephyr/syscalls/counter_get_top_value_mrsh.c>
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+static inline uint64_t z_vrfy_counter_get_max_top_value_64(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_get_max_top_value_64((const struct device *)dev);
+}
+#include <zephyr/syscalls/counter_get_max_top_value_64_mrsh.c>
+
+static inline int z_vrfy_counter_set_top_value_64(const struct device *dev,
+					  const struct counter_top_cfg_64 *cfg)
+{
+	struct counter_top_cfg_64 cfg_copy;
+
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_top_value_64));
+	K_OOPS(k_usermode_from_copy(&cfg_copy, cfg, sizeof(cfg_copy)));
+	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
+				    "callbacks may not be set from user mode"));
+	return z_impl_counter_set_top_value_64((const struct device *)dev,
+					       (const struct counter_top_cfg_64 *)&cfg_copy);
+}
+#include <zephyr/syscalls/counter_set_top_value_64_mrsh.c>
+
+static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev,
+					       uint8_t chan_id,
+					       const struct counter_alarm_cfg_64 *alarm_cfg)
+{
+	struct counter_alarm_cfg_64 cfg_copy;
+
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_alarm_64));
+	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
+	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
+				    "callbacks may not be set from user mode"));
+	return z_impl_counter_set_channel_alarm_64((const struct device *)dev,
+						   (uint8_t)chan_id,
+						   (const struct counter_alarm_cfg_64 *)&cfg_copy);
+}
+#include <zephyr/syscalls/counter_set_channel_alarm_64_mrsh.c>
+
+static inline uint64_t z_vrfy_counter_get_top_value_64(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_top_value_64));
+	return z_impl_counter_get_top_value_64((const struct device *)dev);
+}
+#include <zephyr/syscalls/counter_get_top_value_64_mrsh.c>
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
+
 static inline uint32_t z_vrfy_counter_get_max_top_value(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
@@ -158,3 +287,23 @@ static inline int z_vrfy_counter_set_guard_period(const struct device *dev,
 						flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_mrsh.c>
+
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+static inline uint64_t z_vrfy_counter_get_guard_period_64(const struct device *dev,
+						    uint32_t flags)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_get_guard_period_64((const struct device *)dev,
+						  flags);
+}
+#include <zephyr/syscalls/counter_get_guard_period_64_mrsh.c>
+
+static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev,
+					      uint64_t ticks, uint32_t flags)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_set_guard_period_64((const struct device *)dev,
+						  ticks, flags);
+}
+#include <zephyr/syscalls/counter_set_guard_period_64_mrsh.c>
+#endif /* CONFIG_COUNTER_64BITS_TICKS */

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -10,11 +10,11 @@
 /* For those APIs that just take one argument which is a counter driver
  * instance and return an integral value
  */
-#define COUNTER_HANDLER(name) \
-	static inline int z_vrfy_counter_##name(const struct device *dev) \
-	{ \
-		K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, name)); \
-		return z_impl_counter_ ## name((const struct device *)dev); \
+#define COUNTER_HANDLER(name)                                                                      \
+	static inline int z_vrfy_counter_##name(const struct device *dev)                          \
+	{                                                                                          \
+		K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, name));                                       \
+		return z_impl_counter_##name((const struct device *)dev);                          \
 	}
 
 COUNTER_HANDLER(stop)
@@ -56,82 +56,65 @@ static inline uint64_t z_vrfy_counter_get_frequency_64(const struct device *dev)
 #include <zephyr/syscalls/counter_get_frequency_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_FREQ */
 
-static inline uint32_t z_vrfy_counter_us_to_ticks(const struct device *dev,
-					       uint64_t us)
+static inline uint32_t z_vrfy_counter_us_to_ticks(const struct device *dev, uint64_t us)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_us_to_ticks((const struct device *)dev,
-					  (uint64_t)us);
+	return z_impl_counter_us_to_ticks((const struct device *)dev, (uint64_t)us);
 }
 #include <zephyr/syscalls/counter_us_to_ticks_mrsh.c>
 
-static inline uint64_t z_vrfy_counter_ticks_to_us(const struct device *dev,
-					       uint32_t ticks)
+static inline uint64_t z_vrfy_counter_ticks_to_us(const struct device *dev, uint32_t ticks)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ticks_to_us((const struct device *)dev,
-					  (uint32_t)ticks);
+	return z_impl_counter_ticks_to_us((const struct device *)dev, (uint32_t)ticks);
 }
 #include <zephyr/syscalls/counter_ticks_to_us_mrsh.c>
 
 #ifdef CONFIG_COUNTER_64BITS_TICKS
-static inline uint64_t z_vrfy_counter_us_to_ticks_64(const struct device *dev,
-					      uint64_t us)
+static inline uint64_t z_vrfy_counter_us_to_ticks_64(const struct device *dev, uint64_t us)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_us_to_ticks_64((const struct device *)dev,
-					     (uint64_t)us);
+	return z_impl_counter_us_to_ticks_64((const struct device *)dev, (uint64_t)us);
 }
 #include <zephyr/syscalls/counter_us_to_ticks_64_mrsh.c>
 
-static inline uint64_t z_vrfy_counter_ticks_to_us_64(const struct device *dev,
-					      uint64_t ticks)
+static inline uint64_t z_vrfy_counter_ticks_to_us_64(const struct device *dev, uint64_t ticks)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ticks_to_us_64((const struct device *)dev,
-					     (uint64_t)ticks);
+	return z_impl_counter_ticks_to_us_64((const struct device *)dev, (uint64_t)ticks);
 }
 #include <zephyr/syscalls/counter_ticks_to_us_64_mrsh.c>
 
-static inline uint32_t z_vrfy_counter_ns_to_ticks(const struct device *dev,
-					  uint64_t ns)
+static inline uint32_t z_vrfy_counter_ns_to_ticks(const struct device *dev, uint64_t ns)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ns_to_ticks((const struct device *)dev,
-					  (uint64_t)ns);
+	return z_impl_counter_ns_to_ticks((const struct device *)dev, (uint64_t)ns);
 }
 #include <zephyr/syscalls/counter_ns_to_ticks_mrsh.c>
 
-static inline uint64_t z_vrfy_counter_ns_to_ticks_64(const struct device *dev,
-					     uint64_t ns)
+static inline uint64_t z_vrfy_counter_ns_to_ticks_64(const struct device *dev, uint64_t ns)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ns_to_ticks_64((const struct device *)dev,
-					     (uint64_t)ns);
+	return z_impl_counter_ns_to_ticks_64((const struct device *)dev, (uint64_t)ns);
 }
 #include <zephyr/syscalls/counter_ns_to_ticks_64_mrsh.c>
 
-static inline uint64_t z_vrfy_counter_ticks_to_ns(const struct device *dev,
-					  uint32_t ticks)
+static inline uint64_t z_vrfy_counter_ticks_to_ns(const struct device *dev, uint32_t ticks)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ticks_to_ns((const struct device *)dev,
-					  (uint32_t)ticks);
+	return z_impl_counter_ticks_to_ns((const struct device *)dev, (uint32_t)ticks);
 }
 #include <zephyr/syscalls/counter_ticks_to_ns_mrsh.c>
 
-static inline uint64_t z_vrfy_counter_ticks_to_ns_64(const struct device *dev,
-					     uint64_t ticks)
+static inline uint64_t z_vrfy_counter_ticks_to_ns_64(const struct device *dev, uint64_t ticks)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_ticks_to_ns_64((const struct device *)dev,
-					     (uint64_t)ticks);
+	return z_impl_counter_ticks_to_ns_64((const struct device *)dev, (uint64_t)ticks);
 }
 #include <zephyr/syscalls/counter_ticks_to_ns_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
 
-static inline int z_vrfy_counter_get_value(const struct device *dev,
-					   uint32_t *ticks)
+static inline int z_vrfy_counter_get_value(const struct device *dev, uint32_t *ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_value));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
@@ -139,19 +122,15 @@ static inline int z_vrfy_counter_get_value(const struct device *dev,
 }
 #include <zephyr/syscalls/counter_get_value_mrsh.c>
 
-
-static inline int z_vrfy_counter_set_value(const struct device *dev,
-					   uint32_t ticks)
+static inline int z_vrfy_counter_set_value(const struct device *dev, uint32_t ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value));
-	return z_impl_counter_set_value((const struct device *)dev,
-					ticks);
+	return z_impl_counter_set_value((const struct device *)dev, ticks);
 }
 #include <zephyr/syscalls/counter_set_value_mrsh.c>
 
 #ifdef CONFIG_COUNTER_64BITS_TICKS
-static inline int z_vrfy_counter_get_value_64(const struct device *dev,
-					   uint64_t *ticks)
+static inline int z_vrfy_counter_get_value_64(const struct device *dev, uint64_t *ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_value_64));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
@@ -159,8 +138,7 @@ static inline int z_vrfy_counter_get_value_64(const struct device *dev,
 }
 #include <zephyr/syscalls/counter_get_value_64_mrsh.c>
 
-static inline int z_vrfy_counter_set_value_64(const struct device *dev,
-					      uint64_t ticks)
+static inline int z_vrfy_counter_set_value_64(const struct device *dev, uint64_t ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value_64));
 	return z_impl_counter_set_value_64((const struct device *)dev, ticks);
@@ -168,8 +146,7 @@ static inline int z_vrfy_counter_set_value_64(const struct device *dev,
 #include <zephyr/syscalls/counter_set_value_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
 
-static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
-						   uint8_t chan_id,
+static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev, uint8_t chan_id,
 						   const struct counter_alarm_cfg *alarm_cfg)
 {
 	struct counter_alarm_cfg cfg_copy;
@@ -178,24 +155,20 @@ static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_channel_alarm((const struct device *)dev,
-						(uint8_t)chan_id,
+	return z_impl_counter_set_channel_alarm((const struct device *)dev, (uint8_t)chan_id,
 						(const struct counter_alarm_cfg *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_channel_alarm_mrsh.c>
 
-static inline int z_vrfy_counter_cancel_channel_alarm(const struct device *dev,
-						      uint8_t chan_id)
+static inline int z_vrfy_counter_cancel_channel_alarm(const struct device *dev, uint8_t chan_id)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, cancel_alarm));
-	return z_impl_counter_cancel_channel_alarm((const struct device *)dev,
-						   (uint8_t)chan_id);
+	return z_impl_counter_cancel_channel_alarm((const struct device *)dev, (uint8_t)chan_id);
 }
 #include <zephyr/syscalls/counter_cancel_channel_alarm_mrsh.c>
 
 static inline int z_vrfy_counter_set_top_value(const struct device *dev,
-					       const struct counter_top_cfg
-					       *cfg)
+					       const struct counter_top_cfg *cfg)
 {
 	struct counter_top_cfg cfg_copy;
 
@@ -204,8 +177,7 @@ static inline int z_vrfy_counter_set_top_value(const struct device *dev,
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
 	return z_impl_counter_set_top_value((const struct device *)dev,
-					    (const struct counter_top_cfg *)
-					    &cfg_copy);
+					    (const struct counter_top_cfg *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_top_value_mrsh.c>
 
@@ -225,7 +197,7 @@ static inline uint64_t z_vrfy_counter_get_max_top_value_64(const struct device *
 #include <zephyr/syscalls/counter_get_max_top_value_64_mrsh.c>
 
 static inline int z_vrfy_counter_set_top_value_64(const struct device *dev,
-					  const struct counter_top_cfg_64 *cfg)
+						  const struct counter_top_cfg_64 *cfg)
 {
 	struct counter_top_cfg_64 cfg_copy;
 
@@ -238,9 +210,8 @@ static inline int z_vrfy_counter_set_top_value_64(const struct device *dev,
 }
 #include <zephyr/syscalls/counter_set_top_value_64_mrsh.c>
 
-static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev,
-					       uint8_t chan_id,
-					       const struct counter_alarm_cfg_64 *alarm_cfg)
+static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev, uint8_t chan_id,
+						      const struct counter_alarm_cfg_64 *alarm_cfg)
 {
 	struct counter_alarm_cfg_64 cfg_copy;
 
@@ -248,8 +219,7 @@ static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_channel_alarm_64((const struct device *)dev,
-						   (uint8_t)chan_id,
+	return z_impl_counter_set_channel_alarm_64((const struct device *)dev, (uint8_t)chan_id,
 						   (const struct counter_alarm_cfg_64 *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_channel_alarm_64_mrsh.c>
@@ -269,41 +239,34 @@ static inline uint32_t z_vrfy_counter_get_max_top_value(const struct device *dev
 }
 #include <zephyr/syscalls/counter_get_max_top_value_mrsh.c>
 
-static inline uint32_t z_vrfy_counter_get_guard_period(const struct device *dev,
-							uint32_t flags)
+static inline uint32_t z_vrfy_counter_get_guard_period(const struct device *dev, uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_get_guard_period((const struct device *)dev,
-					       flags);
+	return z_impl_counter_get_guard_period((const struct device *)dev, flags);
 }
 #include <zephyr/syscalls/counter_get_guard_period_mrsh.c>
 
-static inline int z_vrfy_counter_set_guard_period(const struct device *dev,
-						   uint32_t ticks, uint32_t flags)
+static inline int z_vrfy_counter_set_guard_period(const struct device *dev, uint32_t ticks,
+						  uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_set_guard_period((const struct device *)dev,
-						ticks,
-						flags);
+	return z_impl_counter_set_guard_period((const struct device *)dev, ticks, flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_mrsh.c>
 
 #ifdef CONFIG_COUNTER_64BITS_TICKS
-static inline uint64_t z_vrfy_counter_get_guard_period_64(const struct device *dev,
-						    uint32_t flags)
+static inline uint64_t z_vrfy_counter_get_guard_period_64(const struct device *dev, uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_get_guard_period_64((const struct device *)dev,
-						  flags);
+	return z_impl_counter_get_guard_period_64((const struct device *)dev, flags);
 }
 #include <zephyr/syscalls/counter_get_guard_period_64_mrsh.c>
 
-static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev,
-					      uint64_t ticks, uint32_t flags)
+static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev, uint64_t ticks,
+						     uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_set_guard_period_64((const struct device *)dev,
-						  ticks, flags);
+	return z_impl_counter_set_guard_period_64((const struct device *)dev, ticks, flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */


### PR DESCRIPTION
counter_handlers.c was missing verifier/marshaling coverage for multiple counter APIs, especially 64-bit helpers. This change adds the missing z_vrfy handlers and corresponding mrsh includes so the syscall layer matches the public counter API surface.

Missing functions now covered in drivers/counter/counter_handlers.c:

z_vrfy_counter_get_frequency_64
z_vrfy_counter_us_to_ticks_64
z_vrfy_counter_ticks_to_us_64
z_vrfy_counter_ns_to_ticks
z_vrfy_counter_ns_to_ticks_64
z_vrfy_counter_ticks_to_ns
z_vrfy_counter_ticks_to_ns_64
z_vrfy_counter_reset
z_vrfy_counter_set_value
z_vrfy_counter_set_value_64
z_vrfy_counter_get_max_top_value_64
z_vrfy_counter_set_top_value_64
z_vrfy_counter_set_channel_alarm_64
z_vrfy_counter_get_top_value_64
z_vrfy_counter_get_guard_period_64
z_vrfy_counter_set_guard_period_64

Also run clang formater on the file