### PR TITLE
boards: stm32h7b3i_dk: fix LEDs aliases in devicetree source

### DIFF
--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -95,8 +95,8 @@
 	};
 
 	aliases {
-		led0 = &blue_led;
-		led1 = &red_led;
+		led0 = &red_led;
+		led1 = &blue_led;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
Switch the 2 LED aliases, defined in the current devicetree source (dts) for STM32H7B3I discovery board. This way the naming will be the same as the corresponding nodes.

This way if you use the aliases in the application code, they will be identical with the labels.