### PR TITLE
boards: shields: mikroe_mcp251xfd_click: add missing CAN transceivers

### DIFF
--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2517fd_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2517fd_click.overlay
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Henrik Brix Andersen <henrik@brixandersen.dk>
  * SPDX-FileCopyrightText: Copyright (c) 2026 Navimatix GmbH
  * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
@@ -23,5 +24,9 @@
 		osc-freq = <DT_FREQ_M(40)>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
 		status = "okay";
+
+		can-transceiver {
+			max-bitrate = <5000000>;
+		};
 	};
 };

--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2517fd_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2517fd_click.overlay
@@ -4,22 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&mikrobus_spi {
-	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
-
-	mcp2517fd_mikroe_mcp2517fd_click: mcp2517fd@0 {
-		compatible = "microchip,mcp251xfd";
-		status = "okay";
-
-		spi-max-frequency = <18000000>;
-		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		reg = <0x0>;
-		osc-freq = <40000000>;
-	};
-};
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	chosen {
 		zephyr,canbus = &mcp2517fd_mikroe_mcp2517fd_click;
+	};
+};
+
+&mikrobus_spi {
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
+
+	mcp2517fd_mikroe_mcp2517fd_click: can@0 {
+		compatible = "microchip,mcp251xfd";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(18)>;
+		osc-freq = <DT_FREQ_M(40)>;
+		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		status = "okay";
 	};
 };

--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp251863_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp251863_click.overlay
@@ -4,22 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&mikrobus_spi {
-	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
-
-	mcp251863_mikroe_mcp251863_click: mcp251863@0 {
-		compatible = "microchip,mcp251xfd";
-		status = "okay";
-
-		spi-max-frequency = <18000000>;
-		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		reg = <0x0>;
-		osc-freq = <40000000>;
-	};
-};
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	chosen {
 		zephyr,canbus = &mcp251863_mikroe_mcp251863_click;
+	};
+};
+
+&mikrobus_spi {
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
+
+	mcp251863_mikroe_mcp251863_click: can@0 {
+		compatible = "microchip,mcp251xfd";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(18)>;
+		osc-freq = <DT_FREQ_M(40)>;
+		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		status = "okay";
 	};
 };

--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp251863_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp251863_click.overlay
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Henrik Brix Andersen <henrik@brixandersen.dk>
  * SPDX-FileCopyrightText: Copyright (c) 2026 Navimatix GmbH
  * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
@@ -11,6 +12,13 @@
 	chosen {
 		zephyr,canbus = &mcp251863_mikroe_mcp251863_click;
 	};
+
+	transceiver0: can-phy0 {
+		compatible = "microchip,ata6563", "can-transceiver-gpio";
+		standby-gpios = <&mikrobus_header 0 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
 };
 
 &mikrobus_spi {
@@ -22,6 +30,7 @@
 		spi-max-frequency = <DT_FREQ_M(18)>;
 		osc-freq = <DT_FREQ_M(40)>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		phys = <&transceiver0>;
 		status = "okay";
 	};
 };

--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2518fd_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2518fd_click.overlay
@@ -3,22 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&mikrobus_spi {
-	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
-
-	mcp2518fd_mikroe_mcp2518fd_click: mcp2518fd@0 {
-		compatible = "microchip,mcp251xfd";
-		status = "okay";
-
-		spi-max-frequency = <18000000>;
-		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		reg = <0x0>;
-		osc-freq = <40000000>;
-	};
-};
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	chosen {
 		zephyr,canbus = &mcp2518fd_mikroe_mcp2518fd_click;
+	};
+};
+
+&mikrobus_spi {
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
+
+	mcp2518fd_mikroe_mcp2518fd_click: can@0 {
+		compatible = "microchip,mcp251xfd";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(18)>;
+		osc-freq = <DT_FREQ_M(40)>;
+		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		status = "okay";
 	};
 };

--- a/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2518fd_click.overlay
+++ b/boards/shields/mikroe_mcp251xfd_click/mikroe_mcp2518fd_click.overlay
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Henrik Brix Andersen <henrik@brixandersen.dk>
  * SPDX-FileCopyrightText: Copyright (c) 2023 Andriy Gelman
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,5 +23,9 @@
 		osc-freq = <DT_FREQ_M(40)>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
 		status = "okay";
+
+		can-transceiver {
+			max-bitrate = <5000000>;
+		};
 	};
 };


### PR DESCRIPTION
Add missing CAN transceivers to the MikroElektronika MCP251xFD shield overlays.
    
Without the CAN transceiver added to the MCP251863 Click, the STBY pin will be pulled high from the internal pull-up resistor in the AT6563 CAN transceiver, causing the CAN transciever to stay in stand-by mode, preventing any CAN bus traffic from taking place.
    
On the two other shields, the default solder jumpers tie the STBY_I signal to GND, causing the CAN transceivers to always be enabled.
