### PR TITLE
boards: shields: mikroe_mcp25625_click: add missing STBY on CAN transceiver

### DIFF
--- a/boards/shields/mikroe_mcp251x_click/mikroe_can_spi_click.overlay
+++ b/boards/shields/mikroe_mcp251x_click/mikroe_can_spi_click.overlay
@@ -4,26 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&mikrobus_spi {
-	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
-
-	mcp2515_mikroe_can_spi_click: mcp2515@0 {
-		compatible = "microchip,mcp2515";
-		status = "okay";
-
-		spi-max-frequency = <10000000>;
-		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		reg = <0x0>;
-		osc-freq = <10000000>;
-
-		can-transceiver {
-			max-bitrate = <1000000>;
-		};
-	};
-};
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	chosen {
 		zephyr,canbus = &mcp2515_mikroe_can_spi_click;
+	};
+};
+
+&mikrobus_spi {
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
+
+	mcp2515_mikroe_can_spi_click: can@0 {
+		compatible = "microchip,mcp2515";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(10)>;
+		osc-freq = <DT_FREQ_M(10)>;
+		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		status = "okay";
+
+		can-transceiver {
+			max-bitrate = <1000000>;
+		};
 	};
 };

--- a/boards/shields/mikroe_mcp251x_click/mikroe_mcp25625_click.overlay
+++ b/boards/shields/mikroe_mcp251x_click/mikroe_mcp25625_click.overlay
@@ -11,6 +11,13 @@
 	chosen {
 		zephyr,canbus = &mcp25625_mikroe_mcp25625_click;
 	};
+
+	transceiver0: can-phy0 {
+		compatible = "microchip,mcp2562", "can-transceiver-gpio";
+		standby-gpios = <&mikrobus_header 0 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <1000000>;
+		#phy-cells = <0>;
+	};
 };
 
 &mikrobus_spi {
@@ -22,10 +29,7 @@
 		spi-max-frequency = <DT_FREQ_M(10)>;
 		osc-freq = <DT_FREQ_M(20)>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		phys = <&transceiver0>;
 		status = "okay";
-
-		can-transceiver {
-			max-bitrate = <1000000>;
-		};
 	};
 };

--- a/boards/shields/mikroe_mcp251x_click/mikroe_mcp25625_click.overlay
+++ b/boards/shields/mikroe_mcp251x_click/mikroe_mcp25625_click.overlay
@@ -4,26 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&mikrobus_spi {
-	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
-
-	mcp25625_mikroe_mcp25625_click: mcp25625@0 {
-		compatible = "microchip,mcp2515";
-		status = "okay";
-
-		spi-max-frequency = <10000000>;
-		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		reg = <0x0>;
-		osc-freq = <20000000>;
-
-		can-transceiver {
-			max-bitrate = <1000000>;
-		};
-	};
-};
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
 
 / {
 	chosen {
 		zephyr,canbus = &mcp25625_mikroe_mcp25625_click;
+	};
+};
+
+&mikrobus_spi {
+	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
+
+	mcp25625_mikroe_mcp25625_click: can@0 {
+		compatible = "microchip,mcp2515";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(10)>;
+		osc-freq = <DT_FREQ_M(20)>;
+		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
+		status = "okay";
+
+		can-transceiver {
+			max-bitrate = <1000000>;
+		};
 	};
 };


### PR DESCRIPTION
Without the special CAN transceiver node to the MCP25625 Click, the STBY pin will be pulled high from the internal pull-up resistor in the MCP2562 CAN transceiver, causing the CAN transceiver to stay in stand-by mode, preventing any CAN bus traffic from taking place.

Tested on LPCXpresso55S28 development board and MCP25625 Click with Zephyr shell commands for CAN.