### PR TITLE
boards: shields: mikroe_can_fd_6_click: rearrange dts and use macros

### DIFF
--- a/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
+++ b/boards/shields/mikroe_can_fd_6_click/mikroe_can_fd_6_click.overlay
@@ -6,33 +6,33 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+
+/ {
+	chosen {
+		zephyr,canbus = &tcan4x5x_mikroe_can_fd_6_click;
+	};
+};
 
 &mikrobus_spi {
 	status = "okay";
 	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
 
-	tcan4x5x_mikroe_can_fd_6_click: tcan4x5x@0 {
+	tcan4x5x_mikroe_can_fd_6_click: can@0 {
 		compatible = "ti,tcan4x5x";
 		reg = <0>;
-		spi-max-frequency = <18000000>;
-		status = "okay";
-
-		clock-frequency = <40000000>;
+		spi-max-frequency = <DT_FREQ_M(18)>;
+		clock-frequency = <DT_FREQ_M(40)>;
 		device-state-gpios = <&mikrobus_header 0 GPIO_ACTIVE_HIGH>;
 		device-wake-gpios = <&mikrobus_header 6 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&mikrobus_header 1 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
 		ti,nwkrq-voltage-vio;
+		status = "okay";
 
 		can-transceiver {
 			max-bitrate = <8000000>;
 		};
-	};
-};
-
-/ {
-	chosen {
-		zephyr,canbus = &tcan4x5x_mikroe_can_fd_6_click;
 	};
 };


### PR DESCRIPTION
Rearrange the devicetree overlays for the MikroElektronika CAN FD 6 shield to better align with node and property order used in the rest of the tree.

Use "can" as devicetree node name as recommended in the Devicetree specification.