### PR TITLE
boards: shields: mcp2515: rearrange dts and use macros

### DIFF
--- a/boards/shields/mcp2515/adafruit_can_picowbell.overlay
+++ b/boards/shields/mcp2515/adafruit_can_picowbell.overlay
@@ -4,26 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+
+/ {
+	chosen {
+		zephyr,canbus = &mcp2515_adafruit_can_picowbell;
+	};
+};
+
 &pico_spi {
 	status = "okay";
 	cs-gpios = <&pico_header 20 GPIO_ACTIVE_LOW>;
 
 	mcp2515_adafruit_can_picowbell: can@0 {
 		compatible = "microchip,mcp2515";
-		spi-max-frequency = <1000000>;
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		osc-freq = <DT_FREQ_M(16)>;
 		int-gpios = <&pico_header 21 GPIO_ACTIVE_LOW>;
 		status = "okay";
-		reg = <0x0>;
-		osc-freq = <16000000>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;
 		};
-	};
-};
-
-/ {
-	chosen {
-		zephyr,canbus = &mcp2515_adafruit_can_picowbell;
 	};
 };

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -5,6 +5,14 @@
  */
 
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+
+/ {
+	chosen {
+		zephyr,canbus = &mcp2515_dfrobot_can_bus_v2_0;
+	};
+};
 
 &arduino_spi {
 	status = "okay";
@@ -12,21 +20,15 @@
 
 	mcp2515_dfrobot_can_bus_v2_0: can@0 {
 		compatible = "microchip,mcp2515";
-		spi-max-frequency = <1000000>;
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		osc-freq = <DT_FREQ_M(16)>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
 		status = "okay";
-		reg = <0x0>;
-		osc-freq = <16000000>;
 
 		can-transceiver {
 			min-bitrate = <60000>;
 			max-bitrate = <1000000>;
 		};
-	};
-};
-
-/ {
-	chosen {
-		zephyr,canbus = &mcp2515_dfrobot_can_bus_v2_0;
 	};
 };

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -5,6 +5,14 @@
  */
 
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+
+/ {
+	chosen {
+		zephyr,canbus = &mcp2515_keyestudio_can_bus_ks0411;
+	};
+};
 
 &arduino_spi {
 	status = "okay";
@@ -12,20 +20,14 @@
 
 	mcp2515_keyestudio_can_bus_ks0411: can@0 {
 		compatible = "microchip,mcp2515";
-		spi-max-frequency = <1000000>;
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		osc-freq = <DT_FREQ_M(16)>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		status = "okay";
-		reg = <0x0>;
-		osc-freq = <16000000>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;
 		};
-	};
-};
-
-/ {
-	chosen {
-		zephyr,canbus = &mcp2515_keyestudio_can_bus_ks0411;
 	};
 };

--- a/boards/shields/mcp2515/seeed_xiao_can.overlay
+++ b/boards/shields/mcp2515/seeed_xiao_can.overlay
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+
+/ {
+	chosen {
+		zephyr,canbus = &mcp2515_seeed_xiao_can;
+	};
+};
+
 /* Disable XIAO serial function, avoid conflict with CS & INT. */
 &xiao_serial {
 	status = "disabled";
@@ -15,20 +24,14 @@
 
 	mcp2515_seeed_xiao_can: can@0 {
 		compatible = "microchip,mcp2515";
-		spi-max-frequency = <1000000>;
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		osc-freq = <DT_FREQ_M(16)>;
 		int-gpios = <&xiao_d 6 GPIO_ACTIVE_LOW>;
 		status = "okay";
-		reg = <0x0>;
-		osc-freq = <16000000>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;
 		};
-	};
-};
-
-/ {
-	chosen {
-		zephyr,canbus = &mcp2515_seeed_xiao_can;
 	};
 };


### PR DESCRIPTION
Rearrange the devicetree overlays for the MCP2515 shields to better align with node and property order used in the rest of the tree.