### PR TITLE
xtensa: use __ASSERT_NO_MSG for assert with no message

### DIFF
--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -125,8 +125,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
 
 #ifdef CONFIG_KERNEL_COHERENCE
-	__ASSERT((((size_t)stack) % XCHAL_DCACHE_LINESIZE) == 0, "");
-	__ASSERT((((size_t)stack_ptr) % XCHAL_DCACHE_LINESIZE) == 0, "");
+	__ASSERT_NO_MSG((((size_t)stack) % XCHAL_DCACHE_LINESIZE) == 0);
+	__ASSERT_NO_MSG((((size_t)stack_ptr) % XCHAL_DCACHE_LINESIZE) == 0);
 	sys_cache_data_flush_and_invd_range(stack, (char *)stack_ptr - (char *)stack);
 #endif
 }


### PR DESCRIPTION
Instead of using __ASSERT() with an empty string as message, simply convert it to use __ASSERT_NO_MSG().