### PR TITLE
enable MMIO for mcux flexspi nor driver

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -304,7 +304,7 @@ static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %zu bytes to 0x%08zx", len, (ssize_t) offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
@@ -434,7 +434,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_InvalidateByRange((uint32_t) dst, size);
+	DCACHE_InvalidateByRange((uintptr_t)dst, size);
 #endif
 
 	return 0;
@@ -527,7 +527,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_InvalidateByRange((uint32_t) dst, size);
+	DCACHE_InvalidateByRange((uintptr_t)dst, size);
 #endif
 
 	return 0;

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -156,6 +156,7 @@
 		flexspi: spi@425e0000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <48 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1010.dtsi
@@ -103,7 +103,9 @@
 
 		flexspi: spi@400a0000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400a0000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400a0000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <26 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
@@ -41,6 +41,7 @@
 &flexspi {
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;
+	reg-names = "reg_base", "ahb";
 
 	/* 32 megabit internal flash present on chip */
 	w25q32jvwj0: w25q32jvwj@0 {

--- a/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
@@ -14,6 +14,7 @@
 &flexspi2 {
 	status = "okay";
 	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;
+	reg-names = "reg_base", "ahb";
 	rx-clock-source = <1>;
 
 	/* WINBOND */

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -131,7 +131,9 @@
 
 		flexspi: spi@402a8000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a8000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x402a8000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <108 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -143,7 +145,9 @@
 
 		flexspi2: spi@402a4000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x402a4000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x402a4000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <107 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm33.dtsi
@@ -46,10 +46,12 @@
 
 		flexspi: spi@525e0000 {
 			reg = <0x525e0000 0x4000>, <0x38000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@545e0000 {
 			reg = <0x545e0000 0x4000>, <0x14000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm33_ns.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm33_ns.dtsi
@@ -40,10 +40,12 @@
 
 		flexspi: spi@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x_cm7.dtsi
@@ -33,10 +33,12 @@
 
 		flexspi: spi@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "reg_base", "ahb";
 		};
 
 		flexspi2: spi@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -77,7 +77,9 @@
 
 		flexspi: spi@400cc000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400cc000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400cc000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <130 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -87,7 +89,9 @@
 
 		flexspi2: spi@400d0000 {
 			compatible = "nxp,imx-flexspi";
-			reg = <0x400d0000 0x4000>;
+			/* ahb address and size need to be updated by board */
+			reg = <0x400d0000 0x4000>, <0x0 DT_SIZE_M(1)>;
+			reg-names = "reg_base", "ahb";
 			interrupts = <131 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -120,10 +120,12 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	flexspi2: spi@13c000 {
 		reg = <0x13c000 0x1000>, <0x38000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -130,6 +130,7 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@50020000 {
 			reg = <0x50020000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_ns.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@40020000 {
 			reg = <0x40020000 0x1000>, <0x80000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn54x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn54x.dtsi
@@ -23,6 +23,7 @@
 
 		flexspi: spi@500c8000 {
 			reg = <0x500c8000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn94x.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x.dtsi
@@ -23,6 +23,7 @@
 
 		flexspi: spi@500c8000 {
 			reg = <0x500c8000 0x1000>, <0x90000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
@@ -19,6 +19,7 @@
 
 		flexspi: spi@400c8000 {
 			reg = <0x400c8000 0x1000>, <0x80000000 DT_SIZE_M(8)>;
+			reg-names = "reg_base", "ahb";
 		};
 	};
 };

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -148,6 +148,7 @@
 
 	flexspi: spi@134000 {
 		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+		reg-names = "reg_base", "ahb";
 	};
 
 	clkctl0: clkctl@1000 {

--- a/dts/arm/phytec/phycore_rt1170_common.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_common.dtsi
@@ -94,6 +94,7 @@
 	ahb-read-addr-opt;
 	rx-clock-source = <1>;
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(16)>;
+	reg-names = "reg_base", "ahb";
 
 	mx25u12832f: mx25u12832f@0 {
 		compatible = "nxp,imx-flexspi-nor";

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -11,6 +11,12 @@ properties:
   reg:
     required: true
 
+  reg-names:
+    required: true
+    description: |
+      Identifiers for register spaces with "reg_base" for control
+      and "ahb" for ahb space
+
   interrupts:
     required: true
 


### PR DESCRIPTION
drivers: flash_mcux_flexspi_nor: update for Cortex-A Core support
dts: imx-flexspi: add reg-names property and update dts accordingly
drivers: memc_mcux_flexspi: enable MMIO mapping
