### PR TITLE
enable watchdog for A55 on imx95_evk

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
@@ -13,6 +13,10 @@
 	model = "NXP i.MX95 A55";
 	compatible = "fsl,mimx95";
 
+	aliases {
+		watchdog0 = &wdog4;
+	};
+
 	chosen {
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
@@ -89,4 +93,8 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&lpuart1_default>;
 	pinctrl-names = "default";
+};
+
+&wdog4 {
+	status = "okay";
 };

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -17,6 +17,7 @@ supported:
   - i2c
   - uart
   - net
+  - watchdog
 testing:
   binaries:
     - flash.bin

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -143,6 +143,58 @@
 		status = "disabled";
 	};
 
+	ext_clk: ext24m {
+		/* WDOG ext clock: 24MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	lpo_clk: lpo32k {
+		/* WDOG LPO clock: 32KHz */
+		compatible = "fixed-clock";
+		clock-frequency = <32000>;
+		#clock-cells = <0>;
+	};
+
+	int_clk: int133m {
+		/* WDOG int clock: 133MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <133000000>;
+		#clock-cells = <0>;
+	};
+
+	ipg_clk: ipg133m {
+		/* WDOG ipg clock: 133MHz */
+		compatible = "fixed-clock";
+		clock-frequency = <133000000>;
+		#clock-cells = <0>;
+	};
+
+	wdog3: watchdog@42490000 {
+		compatible = "nxp,wdog32";
+		reg = <0x42490000 0x1000>;
+		interrupts = <GIC_SPI 77 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
+		status = "disabled";
+	};
+
+	wdog4: watchdog@424a0000 {
+		compatible = "nxp,wdog32";
+		reg = <0x424a0000 0x1000>;
+		interrupts = <GIC_SPI 78 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
+		status = "disabled";
+	};
+
 	lpi2c2: i2c@44350000 {
 		compatible = "nxp,lpi2c";
 		clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
dts: mimx95_a55: add watchdog device nodes
boards: imx95_evk: enable watchdog for A55