### PR TITLE
pm: policy: event: enhance pm policy event implementation

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -212,10 +212,15 @@ bool pm_policy_state_any_active(void);
  * event, the policy manager will be able to decide whether certain power states
  * are worth entering or not.
  *
- * CPU is woken up before the time passed in cycle to minimize event handling
- * latency. Once woken up, the CPU will be kept awake until the event has been
- * handled, which is signaled by pm_policy_event_unregister() or moving event
- * into the future using pm_policy_event_update().
+ * Events are tracked in uptime ticks, and the policy uses the earliest (soonest)
+ * event time when calculating the time to the next wakeup.
+ *
+ * A given @p evt must be registered at most once at a time. Re-registering an
+ * already registered event behaves like pm_policy_event_update().
+ *
+ * Once woken up, the CPU is expected to remain awake until the event has been
+ * handled, which is signaled by pm_policy_event_unregister() or moving the
+ * event into the future using pm_policy_event_update().
  *
  * @param evt Event.
  * @param uptime_ticks When the event will occur, in uptime ticks.
@@ -230,6 +235,8 @@ void pm_policy_event_register(struct pm_policy_event *evt, int64_t uptime_ticks)
  * This shortcut allows for moving the time an event will occur without the
  * need for an unregister + register cycle.
  *
+ * If @p evt is not currently registered, this function has no effect.
+ *
  * @param evt Event.
  * @param uptime_ticks When the event will occur, in uptime ticks.
  *
@@ -239,6 +246,8 @@ void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks);
 
 /**
  * @brief Unregister an event.
+ *
+ * If @p evt is not currently registered, this function has no effect.
  *
  * @param evt Event.
  *
@@ -264,8 +273,14 @@ bool pm_policy_device_is_disabling_state(const struct device *dev,
 /**
  * @brief Returns the ticks until the next event
  *
- * If an event is registred, it will return the number of ticks until the next event, if the
- * "next"/"oldest" registered event is in the past, it will return 0. Otherwise it returns -1.
+ * Returns a relative timeout, in uptime ticks, until the earliest (soonest)
+ * registered event.
+ *
+ * The return value follows these rules:
+ * - If at least one event is registered and its scheduled time is in the future,
+ *   returns the number of ticks until that event.
+ * - If the earliest event is due now or already in the past, returns 0.
+ * - If no events are registered, returns -1.
  *
  * @retval >0 If next registered event is in the future
  * @retval 0 If next registered event is now or in the past

--- a/subsys/pm/policy/policy_events.c
+++ b/subsys/pm/policy/policy_events.c
@@ -12,6 +12,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/sys/time_units.h>
+#include <zephyr/sys/__assert.h>
 
 /** Lock to synchronize access to the events list. */
 static struct k_spinlock events_lock;
@@ -19,6 +20,19 @@ static struct k_spinlock events_lock;
 static sys_slist_t events_list;
 /** Pointer to Next Event. */
 static struct pm_policy_event *next_event;
+
+static bool event_is_registered_locked(const struct pm_policy_event *evt)
+{
+	struct pm_policy_event *iter;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&events_list, iter, node) {
+		if (iter == evt) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 static void update_next_event(void)
 {
@@ -61,16 +75,32 @@ int64_t pm_policy_next_event_ticks(void)
 
 void pm_policy_event_register(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
+	__ASSERT_NO_MSG(evt != NULL);
+
 	K_SPINLOCK(&events_lock) {
+		bool registered = event_is_registered_locked(evt);
+
+		/*
+		 * Protect against list corruption on accidental double registration.
+		 * Re-registering an already registered event behaves like an update.
+		 */
 		evt->uptime_ticks = uptime_ticks;
-		sys_slist_append(&events_list, &evt->node);
+		if (!registered) {
+			sys_slist_append(&events_list, &evt->node);
+		}
 		update_next_event();
 	}
 }
 
 void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks)
 {
+	__ASSERT_NO_MSG(evt != NULL);
+
 	K_SPINLOCK(&events_lock) {
+		if (!event_is_registered_locked(evt)) {
+			K_SPINLOCK_BREAK;
+		}
+
 		evt->uptime_ticks = uptime_ticks;
 		update_next_event();
 	}
@@ -78,7 +108,13 @@ void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks)
 
 void pm_policy_event_unregister(struct pm_policy_event *evt)
 {
+	__ASSERT_NO_MSG(evt != NULL);
+
 	K_SPINLOCK(&events_lock) {
+		if (!event_is_registered_locked(evt)) {
+			K_SPINLOCK_BREAK;
+		}
+
 		(void)sys_slist_find_and_remove(&events_list, &evt->node);
 		update_next_event();
 	}

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -451,31 +451,58 @@ ZTEST(policy_api, test_pm_policy_events)
 	struct pm_policy_event evt1;
 	struct pm_policy_event evt2;
 	int64_t now_uptime_ticks;
-	int64_t evt1_1_uptime_ticks;
-	int64_t evt1_2_uptime_ticks;
+	int64_t evt1_short_uptime_ticks;
+	int64_t evt1_long_uptime_ticks;
 	int64_t evt2_uptime_ticks;
+	int64_t short_delta;
+	int64_t mid_delta;
+	int64_t long_delta;
+	int64_t tol;
 
 	now_uptime_ticks = k_uptime_ticks();
-	evt1_1_uptime_ticks = now_uptime_ticks + 100;
-	evt1_2_uptime_ticks = now_uptime_ticks + 200;
-	evt2_uptime_ticks = now_uptime_ticks + 2000;
+	short_delta = (int64_t)k_ms_to_ticks_ceil32(500);
+	mid_delta = (int64_t)k_ms_to_ticks_ceil32(1500);
+	long_delta = (int64_t)k_ms_to_ticks_ceil32(5000);
+	tol = (int64_t)k_ms_to_ticks_ceil32(250);
+
+	evt1_short_uptime_ticks = now_uptime_ticks + short_delta;
+	evt1_long_uptime_ticks = now_uptime_ticks + long_delta;
+	evt2_uptime_ticks = now_uptime_ticks + mid_delta;
 
 	zassert_equal(pm_policy_next_event_ticks(), -1);
-	pm_policy_event_register(&evt1, evt1_1_uptime_ticks);
-	pm_policy_event_register(&evt2, evt2_uptime_ticks);
-	zassert_within(pm_policy_next_event_ticks(), 100, 50);
+
+	/* update/unregister on an unregistered event are no-ops */
+	pm_policy_event_update(&evt1, evt1_short_uptime_ticks);
+	zassert_equal(pm_policy_next_event_ticks(), -1);
 	pm_policy_event_unregister(&evt1);
-	zassert_within(pm_policy_next_event_ticks(), 2000, 50);
+	zassert_equal(pm_policy_next_event_ticks(), -1);
+
+	/* Register one event far in the future */
+	pm_policy_event_register(&evt1, evt1_long_uptime_ticks);
+	zassert_within(pm_policy_next_event_ticks(), long_delta, tol);
+
+	/* Re-registering an already registered event behaves like an update */
+	pm_policy_event_register(&evt1, evt1_short_uptime_ticks);
+	zassert_within(pm_policy_next_event_ticks(), short_delta, tol);
+
+	/* Register another event and ensure the earliest one is selected */
+	pm_policy_event_register(&evt2, evt2_uptime_ticks);
+	zassert_within(pm_policy_next_event_ticks(), short_delta, tol);
+
+	/* Unregister evt1: evt2 becomes the earliest */
+	pm_policy_event_unregister(&evt1);
+	zassert_within(pm_policy_next_event_ticks(), mid_delta, tol);
+
+	/* Unregistering an already unregistered event is a no-op */
+	pm_policy_event_unregister(&evt1);
+	zassert_within(pm_policy_next_event_ticks(), mid_delta, tol);
+
+	/* Update evt2 still works */
+	pm_policy_event_update(&evt2, now_uptime_ticks + long_delta);
+	zassert_within(pm_policy_next_event_ticks(), long_delta, tol);
+
 	pm_policy_event_unregister(&evt2);
 	zassert_equal(pm_policy_next_event_ticks(), -1);
-	pm_policy_event_register(&evt2, evt2_uptime_ticks);
-	zassert_within(pm_policy_next_event_ticks(), 2000, 50);
-	pm_policy_event_register(&evt1, evt1_1_uptime_ticks);
-	zassert_within(pm_policy_next_event_ticks(), 100, 50);
-	pm_policy_event_update(&evt1, evt1_2_uptime_ticks);
-	zassert_within(pm_policy_next_event_ticks(), 200, 50);
-	pm_policy_event_unregister(&evt1);
-	pm_policy_event_unregister(&evt2);
 }
 
 ZTEST_SUITE(policy_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
1. Updated event-related API docs to fix wording and clarify semantics ("earliest/soonest event", ticks vs cycles).

2. Improve the event implementation to prevent list corruption on misuse:
- `pm_policy_event_register()` is now idempotent: re-registering
  the same evt updates its time instead of appending a duplicate node.
- `pm_policy_event_update()` / `pm_policy_event_unregister()` become clean
  `no-ops` if evt is not currently registered.
- Kept a basic `evt != NULL` assertion.

3. Expanded the existing policy API test to cover the new hardened behaviors (no-op update/unregister when unregistered, re-register == update).