### PR TITLE
dts: nxp: mcxc: move COP watchdog under sim node

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxc444.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc444.dtsi
@@ -1,13 +1,18 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <nxp/mcx/nxp_mcxc_common.dtsi>
 
-&sram0 {
-	reg = <0x1fffe000 DT_SIZE_K(32)>;
+/delete-node/ &sram0;
+
+/ {
+	sram0: memory@1fffe000 {
+		compatible = "mmio-sram";
+		reg = <0x1fffe000 DT_SIZE_K(32)>;
+	};
 };
 
 &flash0 {

--- a/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -102,6 +102,18 @@
 			reg = <0x40047000 0x1060>;
 			#clock-cells = <3>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x40047000 0x1060>;
+
+			cop: watchdog@0 {
+				compatible = "nxp,cop";
+				reg = <0x0 0x8>;
+				status = "disabled";
+				clk-source = <0>;
+				timeout-cycles = <1024>;
+			};
+
 			core_clk {
 				compatible = "fixed-factor-clock";
 				clocks = <&mcg KINETIS_MCG_OUT_CLK>;
@@ -115,14 +127,6 @@
 				clock-div = <2>;
 				#clock-cells = <0>;
 			};
-		};
-
-		cop: watchdog@40047000 {
-			compatible = "nxp,cop";
-			reg = <0x40047000 0x8>;
-			status = "disabled";
-			clk-source = <0>;
-			timeout-cycles = <1024>;
 		};
 
 		porta: pinmux@40049000 {


### PR DESCRIPTION
Move the COP watchdog device node to be a child of the SIM node, as COP is part of the SIM register space. This can fix the duplicate unit address warning.
Also fix the sram0 node definition in nxp_mcxc444.dtsi by deleting and redefining it to ensure proper memory layout.