### PR TITLE
Bluetooth: SPP: Add rfcomm server unregister interface

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -20,6 +20,7 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,7 +150,9 @@ struct bt_rfcomm_server {
 	int (*accept)(struct bt_conn *conn, struct bt_rfcomm_server *server,
 		      struct bt_rfcomm_dlc **dlc);
 
-	struct bt_rfcomm_server	*_next;
+	/** @cond INTERNAL_HIDDEN */
+	sys_snode_t node;
+	/** @endcond */
 };
 
 /** @brief RFCOMM RPN baud rate values */

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -233,6 +233,16 @@ struct bt_rfcomm_rpn {
  */
 int bt_rfcomm_server_register(struct bt_rfcomm_server *server);
 
+/** @brief Unregister RFCOMM server
+ *
+ *  Unregister RFCOMM server for a channel.
+ *
+ *  @param server Server structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_rfcomm_server_unregister(struct bt_rfcomm_server *server);
+
 /** @brief Connect RFCOMM channel
  *
  *  Connect RFCOMM dlc by channel, once the connection is completed dlc

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -50,7 +50,7 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 #define SESSION_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				     struct bt_rfcomm_session, rtx_work)
 
-static struct bt_rfcomm_server *servers;
+static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 
 #define RFCOMM_SESSION(_ch) CONTAINER_OF(_ch, \
 					 struct bt_rfcomm_session, br_chan.chan)
@@ -169,8 +169,9 @@ static struct bt_rfcomm_dlc *rfcomm_dlcs_remove_dlci(struct bt_rfcomm_dlc *dlcs,
 static struct bt_rfcomm_server *rfcomm_server_lookup_channel(uint8_t channel)
 {
 	struct bt_rfcomm_server *server;
+	struct bt_rfcomm_server *next;
 
-	for (server = servers; server; server = server->_next) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&servers, server, next, node) {
 		if (server->channel == channel) {
 			return server;
 		}
@@ -227,8 +228,7 @@ int bt_rfcomm_server_register(struct bt_rfcomm_server *server)
 
 	LOG_DBG("Channel 0x%02x", server->channel);
 
-	server->_next = servers;
-	servers = server;
+	sys_slist_prepend(&servers, &server->node);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -233,6 +233,15 @@ int bt_rfcomm_server_register(struct bt_rfcomm_server *server)
 	return 0;
 }
 
+int bt_rfcomm_server_unregister(struct bt_rfcomm_server *server)
+{
+	if (!sys_slist_find_and_remove(&servers, &server->node)) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
 static void rfcomm_dlc_tx_trigger(struct bt_rfcomm_dlc *dlc)
 {
 	int err;


### PR DESCRIPTION
Title: Bluetooth: SPP: Add rfcomm server unregister interface

Description:

This PR adds an RFCOMM server unregister interface (bt_rfcomm_server_unregister()) to support dynamic unregistration of RFCOMM channels.

As a prerequisite, the first commit refactors the RFCOMM server list from a manually managed linked list (_next pointer) to use the generic sys_slist_t API, which is consistent with other Zephyr subsystems and enables clean removal via sys_slist_find_and_remove().

Changes:

- **Commit 1:** Replace the custom _next pointer linked list in bt_rfcomm_server with sys_snode_t and sys_slist_t, using standard slist APIs for iteration and insertion.
- **Commit 2:** Add bt_rfcomm_server_unregister() API that removes a previously registered RFCOMM server from the server list.