### PR TITLE
drivers: usb: buf: Do not add empty library

### DIFF
--- a/drivers/usb/common/buf/CMakeLists.txt
+++ b/drivers/usb/common/buf/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Copyright Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_UDC_DRIVER usb_buf.c)
+if(CONFIG_UDC_DRIVER OR CONFIG_UHC_DRIVER)
+  zephyr_library()
+  zephyr_library_sources(usb_buf.c)
+endif()


### PR DESCRIPTION
Change CMakeLists.txt to register Zephyr library only if respective source code is compiled.

Fixes CMake Warning:
  No SOURCES given to Zephyr library: drivers__usb__common__buf