### PR TITLE
kernel: fix LTO and code relocation

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -547,7 +547,6 @@ config LTO
 	bool "Link Time Optimization"
 	depends on !(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION
 	depends on !NATIVE_LIBRARY
-	depends on !CODE_DATA_RELOCATION
 	help
 	  This option enables Link Time Optimization.
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1477,9 +1477,11 @@ endmacro()
 # - NOKEEP: suppress the generation of KEEP() statements in the linker script,
 #   to allow any unused code in the given files/library to be discarded.
 # - PHDR [program_header]: add program header. Used on Xtensa platforms.
+# - TARGET: specify the target to which the relocation files belong. By default, the it's `zephyr`.
+#   Not needed when using the LIBRARY directive. Only needed for excluding relocated files from LTO.
 function(zephyr_code_relocate)
   set(options NOCOPY NOKEEP)
-  set(single_args LIBRARY LOCATION PHDR FILTER)
+  set(single_args LIBRARY LOCATION PHDR FILTER TARGET)
   set(multi_args FILES)
   cmake_parse_arguments(CODE_REL "${options}" "${single_args}"
     "${multi_args}" ${ARGN})
@@ -1519,6 +1521,8 @@ function(zephyr_code_relocate)
     set(nonempty_src_list "$<$<BOOL:${src_list_rel}>:${src_list}>")
     set(sep_list "$<$<AND:$<BOOL:${src_list_abs}>,$<BOOL:${src_list_rel}>>:$<SEMICOLON>>")
     set(file_list "${src_list_abs}${sep_list}${nonempty_src_list}")
+    # Exclude relocated files from LTO by applying the prohibit_lto compile option to the library target.
+    target_compile_options(${CODE_REL_LIBRARY} INTERFACE $<TARGET_PROPERTY:compiler,prohibit_lto>)
   else()
     # Check if CODE_REL_FILES is a generator expression, if so leave it
     # untouched.
@@ -1536,6 +1540,13 @@ function(zephyr_code_relocate)
       # Generator expression is present in file list. Leave the list untouched.
       set(file_list ${CODE_REL_FILES})
     endif()
+    if(NOT CODE_REL_TARGET)
+      set(CODE_REL_TARGET zephyr)
+    endif()
+    # Exclude relocated files from LTO by applying the prohibit_lto compile option.
+    set_source_files_properties(${file_list}
+                                TARGET_DIRECTORY ${CODE_REL_TARGET}
+                                PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
   endif()
   if(NOT CODE_REL_NOCOPY)
     set(flag_list COPY)

--- a/samples/application_development/code_relocation_nocopy/CMakeLists.txt
+++ b/samples/application_development/code_relocation_nocopy/CMakeLists.txt
@@ -9,10 +9,10 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 # Run ext_code from the external flash (XIP). No need to copy.
-zephyr_code_relocate(FILES src/ext_code.c LOCATION EXTFLASH_TEXT NOCOPY)
+zephyr_code_relocate(FILES src/ext_code.c LOCATION EXTFLASH_TEXT NOCOPY TARGET app)
 
 # But still relocate (copy) the data to RAM
-zephyr_code_relocate(FILES src/ext_code.c LOCATION RAM_DATA)
+zephyr_code_relocate(FILES src/ext_code.c LOCATION RAM_DATA TARGET app)
 
 # sram_code instead runs entirely from SRAM after being copied there.
-zephyr_code_relocate(FILES src/sram_code.c LOCATION RAM)
+zephyr_code_relocate(FILES src/sram_code.c LOCATION RAM TARGET app)

--- a/samples/boards/intel/adsp/code_relocation/CMakeLists.txt
+++ b/samples/boards/intel/adsp/code_relocation/CMakeLists.txt
@@ -7,8 +7,8 @@ project(adsp_cavs_code_relocation)
 
 target_sources(app PRIVATE src/main.c src/reloc.c)
 
-zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM2_LITERAL)
-zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM2_TEXT)
-zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM3_DATA)
-zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM3_RODATA)
-zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM4_BSS)
+zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM2_LITERAL TARGET app)
+zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM2_TEXT TARGET app)
+zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM3_DATA TARGET app)
+zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM3_RODATA TARGET app)
+zephyr_code_relocate(FILES src/reloc.c LOCATION SRAM4_BSS TARGET app)

--- a/tests/application_development/code_relocation/CMakeLists.txt
+++ b/tests/application_development/code_relocation/CMakeLists.txt
@@ -15,9 +15,9 @@ if(CONFIG_BOARD_QEMU_XTENSA)
 endif()
 
 # Code relocation feature
-zephyr_code_relocate(FILES src/test_file1.c ${SRAM2_PHDR} LOCATION SRAM2)
+zephyr_code_relocate(FILES src/test_file1.c ${SRAM2_PHDR} LOCATION SRAM2 TARGET app)
 
-zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/test_file2.c ${RAM_PHDR} LOCATION RAM FILTER ".*sram")
+zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/test_file2.c ${RAM_PHDR} LOCATION RAM FILTER ".*sram" TARGET app)
 
 # Add custom library that we can relocate code for
 add_subdirectory(test_lib)
@@ -30,12 +30,12 @@ zephyr_code_relocate(LIBRARY test_lib LOCATION SRAM2)
 set(reloc_files src/test_file4.c src/test_file5.c)
 set(genex_expr
   ${CMAKE_CURRENT_LIST_DIR}/$<JOIN:${reloc_files},$<SEMICOLON>${CMAKE_CURRENT_LIST_DIR}/>)
-zephyr_code_relocate(FILES ${genex_expr} LOCATION SRAM2)
+zephyr_code_relocate(FILES ${genex_expr} LOCATION SRAM2 TARGET app)
 
-zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_LITERAL)
-zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_TEXT)
-zephyr_code_relocate(FILES src/test_file3.c LOCATION RAM_DATA)
-zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_BSS)
+zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_LITERAL TARGET app)
+zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_TEXT TARGET app)
+zephyr_code_relocate(FILES src/test_file3.c LOCATION RAM_DATA TARGET app)
+zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_BSS TARGET app)
 
 # Test NOKEEP support. Placing both KEEP and NOKEEP symbols in the same location
 # (this and test_file2.c in RAM) should work fine.

--- a/tests/application_development/ram_context_for_isr/CMakeLists.txt
+++ b/tests/application_development/ram_context_for_isr/CMakeLists.txt
@@ -17,8 +17,8 @@ if(CONFIG_CPU_CORTEX_M_HAS_VTOR)
   zephyr_code_relocate(FILES ${ZEPHYR_BASE}/arch/arm/core/cortex_m/exc_exit.c LOCATION RAM)
 endif()
 
-zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c FILTER ".test_irq_callback" LOCATION RAM)
-zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/fake_driver.c FILTER ".fake_driver_isr" LOCATION RAM)
+zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c FILTER ".test_irq_callback" LOCATION RAM TARGET app)
+zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/fake_driver.c FILTER ".fake_driver_isr" LOCATION RAM TARGET app)
 
 # Only needed because the fake driver is defined in tests folder
 zephyr_linker_sources(SECTIONS sections-rom.ld)

--- a/tests/arch/common/interrupt/testcase.yaml
+++ b/tests/arch/common/interrupt/testcase.yaml
@@ -65,10 +65,8 @@ tests:
       - CONFIG_TEST_USERSPACE=n
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
       - CONFIG_LTO=y
-    # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
     filter: >
       not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
-      and not CONFIG_CODE_DATA_RELOCATION
   arch.shared_interrupt.lto.speed:
     <<: *shared-interrupt-lto
     extra_configs:

--- a/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
@@ -8,5 +8,5 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 if(CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION)
-  zephyr_code_relocate(FILES src/test_buffers.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION})
+  zephyr_code_relocate(FILES src/test_buffers.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION} TARGET app)
 endif()

--- a/tests/drivers/dma/loop_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/loop_transfer/CMakeLists.txt
@@ -7,4 +7,4 @@ project(loop_transfer)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
-zephyr_code_relocate(FILES src/test_dma_loop.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION}_RODATA_BSS)
+zephyr_code_relocate(FILES src/test_dma_loop.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION}_RODATA_BSS TARGET app)

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -79,8 +79,7 @@ tests:
   kernel.common.lto:
     platform_key:
       - arch
-    # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
-    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED and not CONFIG_CODE_DATA_RELOCATION
+    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
     tags: lto
     extra_configs:
       - CONFIG_TEST_USERSPACE=n
@@ -92,8 +91,7 @@ tests:
   kernel.common.lto.singlethreaded:
     platform_key:
       - arch
-    # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
-    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED and not CONFIG_CODE_DATA_RELOCATION
+    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
     tags: lto
     extra_configs:
       - CONFIG_TEST_USERSPACE=n


### PR DESCRIPTION
When using LTO and code relocation together,
the files, that are relocacted have to be excluded from LTO.

Unfortnatly we need to know the target, when using `set_source_files_properties()` to add compile options, so that had to be added as a optional argument to
`zephyr_code_relocate()`.