### PR TITLE
net: ipv4: avoid casting unaligned address to net_in_addr

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -364,8 +364,11 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 
 	if (net_ipv4_is_addr_mcast_raw(hdr->dst)) {
 		struct net_if *iface = net_pkt_iface(pkt);
-		struct net_if_mcast_addr *if_mcast_addr = net_if_ipv4_maddr_lookup(
-				(struct net_in_addr *)hdr->dst, &iface);
+		struct net_if_mcast_addr *if_mcast_addr;
+		struct net_in_addr dst;
+
+		net_ipv4_addr_copy_raw(dst.s4_addr, hdr->dst);
+		if_mcast_addr = net_if_ipv4_maddr_lookup(&dst, &iface);
 		if (!net_if_ipv4_maddr_is_joined(if_mcast_addr)) {
 			NET_DBG("DROP: mcast not for me");
 			goto drop;


### PR DESCRIPTION
This change addresses an alignment problem reported by UBSAN by using a copy of the address. This avoids the need for extensive rework to support net_if_ipv4_maddr_lookup_raw variant.

Fixes a regression introduced in https://github.com/zephyrproject-rtos/zephyr/pull/101400.