### PR TITLE
twister: move hardware reservation to runner context manager

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -24,6 +24,7 @@ from typing import Any
 import zephyr_module
 from twisterlib.constants import SUPPORTED_SIMS, ZEPHYR_BASE
 from twisterlib.coverage import supported_coverage_formats
+from twisterlib.hardwaremap import HardwareMap
 from twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')
@@ -1087,7 +1088,7 @@ class TwisterEnv:
                 self.arch_roots.append(project / Path(arch_root))
 
         self.modules = [m.meta for m in modules]
-        self.hwm = None
+        self.hwm: HardwareMap | None = None
 
         self.test_config = options.test_config
 

--- a/scripts/pylib/twister/twisterlib/error.py
+++ b/scripts/pylib/twister/twisterlib/error.py
@@ -13,20 +13,29 @@ class TwisterException(Exception):
         super().__init__(message)
         logger.error(''.join(["Twister call stack dump:\n"] + traceback.format_stack()[:-1]))
 
+
 class TwisterRuntimeError(TwisterException):
     pass
+
 
 class ConfigurationError(TwisterException):
     def __init__(self, cfile, message):
         TwisterException.__init__(self, str(cfile) + ": " + message)
 
+
 class BuildError(TwisterException):
     pass
+
 
 class ExecutionError(TwisterException):
     pass
 
+
 class StatusAttributeError(TwisterException):
-    def __init__(self, cls : type, value):
+    def __init__(self, cls: type, value):
         msg = f'{cls.__name__} assigned status {value}, which could not be cast to a TwisterStatus.'
         super().__init__(msg)
+
+
+class NoDeviceAvailableException(RuntimeError):
+    """Raised when no free device is available for reservation."""

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 import threading
 import time
-from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from queue import Empty, Queue
@@ -30,8 +29,7 @@ import psutil
 from serial.tools import list_ports
 from twisterlib.constants import ZEPHYR_BASE
 from twisterlib.environment import strip_ansi_sequences
-from twisterlib.error import TwisterException
-from twisterlib.hardwaremap import DUT
+from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
 
@@ -108,7 +106,6 @@ class Handler:
 
         self.args = []
         self.terminated = False
-        self.duts: list[DUT] = []
 
     def get_test_timeout(self):
         return math.ceil(self.instance.testsuite.timeout *
@@ -501,61 +498,6 @@ class DeviceHandler(Handler):
                     break
 
     @staticmethod
-    @contextmanager
-    def acquire_dut_locks(duts):
-        try:
-            for d in duts:
-                d.lock.acquire()
-            yield
-        finally:
-            for d in duts:
-                d.lock.release()
-
-    def device_is_available(self, instance) -> DUT | None:
-        device = instance.platform.name
-        fixture = instance.testsuite.harness_config.get("fixture")
-        duts_found: list[DUT] = []
-
-        for d in self.duts:
-            if fixture and fixture not in map(lambda f: f.split(sep=':')[0], d.fixtures):
-                continue
-            if d.platform != device or (d.serial is None and d.serial_pty is None):
-                continue
-            duts_found.append(d)
-
-        if not duts_found:
-            raise TwisterException(f"No device to serve as {device} platform.")
-
-        # Select an available DUT with less failures
-        for d in sorted(duts_found, key=lambda _dut: _dut.failures):
-            # get all DUTs with the same id
-            duts_shared_hw = [_d for _d in self.duts if _d.id == d.id]
-            with self.acquire_dut_locks(duts_shared_hw):
-                avail = False
-                if d.available:
-                    for _d in duts_shared_hw:
-                        _d.available = 0
-                    d.counter_increment()
-                    avail = True
-                    logger.debug(f"Retain DUT:{d.platform}, Id:{d.id}, "
-                                f"counter:{d.counter}, failures:{d.failures}")
-            if avail:
-                return d
-
-        return None
-
-    def make_dut_available(self, dut: DUT) -> None:
-        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
-            dut.failures_increment()
-        logger.debug(f"Release DUT:{dut.platform}, Id:{dut.id}, "
-                     f"counter:{dut.counter}, failures:{dut.failures}")
-        # get all DUTs with the same id
-        duts_shared_hw = [_d for _d in self.duts if _d.id == dut.id]
-        with self.acquire_dut_locks(duts_shared_hw):
-            for _d in duts_shared_hw:
-                _d.available = 1
-
-    @staticmethod
     def run_custom_script(script, timeout):
         with subprocess.Popen(script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
             try:
@@ -667,7 +609,7 @@ class DeviceHandler(Handler):
             logger.debug(f"Terminated serial-pty:'{ser_pty}'")
     #
 
-    def _create_serial_connection(self, dut, serial_device, hardware_baud,
+    def _create_serial_connection(self, serial_device, hardware_baud,
                                   flash_timeout, serial_pty, ser_pty_process):
         try:
             ser = serial.Serial(
@@ -680,12 +622,12 @@ class DeviceHandler(Handler):
                 timeout=max(flash_timeout, self.get_test_timeout())
             )
         except serial.SerialException as e:
-            self._handle_serial_exception(e, dut, serial_pty, ser_pty_process)
+            self._handle_serial_exception(e, serial_pty, ser_pty_process)
             raise
 
         return ser
 
-    def _handle_serial_exception(self, exception, dut, serial_pty, ser_pty_process):
+    def _handle_serial_exception(self, exception, serial_pty, ser_pty_process):
         self.instance.status = TwisterStatus.FAIL
         self.instance.reason = "Serial Device Error"
         logger.error(f"Serial device error: {exception!s}")
@@ -693,38 +635,6 @@ class DeviceHandler(Handler):
         self.instance.add_missing_case_status(TwisterStatus.BLOCK, "Serial Device Error")
         if serial_pty and ser_pty_process:
             self._terminate_pty(serial_pty, ser_pty_process)
-
-        self.make_dut_available(dut)
-
-    def get_other_duts_with_same_id(self, hardware: DUT) -> list[DUT]:
-        """Get all DUTs that share the same hardware ID as the provided DUT,
-        excluding the provided DUT itself."""
-        duts: list[DUT] = []
-        # get all DUTs with the same id
-        duts_shared_hw = [_d for _d in self.duts if _d.id == hardware.id]
-        serials = {hardware.serial}
-        for d in duts_shared_hw:
-            if d.serial and d.serial not in serials:
-                duts.append(d)
-                serials.add(d.serial)
-        return duts
-
-    def get_hardware(self) -> DUT | None:
-        hardware = None
-        try:
-            hardware = self.device_is_available(self.instance)
-            in_waiting = 0
-            while not hardware:
-                time.sleep(1)
-                in_waiting += 1
-                if in_waiting % 60 == 0:
-                    logger.debug(f"Waiting for a DUT to run {self.instance.name}")
-                hardware = self.device_is_available(self.instance)
-        except TwisterException as error:
-            self.instance.status = TwisterStatus.FAIL
-            self.instance.reason = str(error)
-            logger.error(self.instance.reason)
-        return hardware
 
     def _start_serial_pty(self, serial_pty, serial_pty_master):
         ser_pty_process = None
@@ -748,12 +658,7 @@ class DeviceHandler(Handler):
         return ser_pty_process
 
     def handle(self, harness):
-        runner = None
-        hardware = self.get_hardware()
-        if hardware:
-            self.instance.dut = hardware.id
-        else:
-            return
+        hardware: CompoundHardwareData = self.instance.reserved_duts[0]
 
         # Run pre-script BEFORE starting serial PTY to avoid conflicts
         pre_script = hardware.pre_script
@@ -794,7 +699,6 @@ class DeviceHandler(Handler):
 
         try:
             ser = self._create_serial_connection(
-                hardware,
                 serial_port,
                 hardware.serial_baud,
                 flash_timeout,
@@ -891,7 +795,7 @@ class DeviceHandler(Handler):
                     ser.open()
 
             except serial.SerialException as e:
-                self._handle_serial_exception(e, hardware, serial_pty, ser_pty_process)
+                self._handle_serial_exception(e, serial_pty, ser_pty_process)
                 return
 
         if failure_type != Handler.FailureType.FLASH:
@@ -927,8 +831,6 @@ class DeviceHandler(Handler):
             if script_param:
                 timeout = script_param.get("post_script_timeout", timeout)
             self.run_custom_script(post_script, timeout)
-
-        self.make_dut_available(hardware)
 
 
 class QEMUHandler(Handler):

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -10,6 +10,8 @@ import logging
 import os
 import platform
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from multiprocessing import Lock, Value
 from pathlib import Path
@@ -18,7 +20,8 @@ import scl
 import yaml
 from natsort import natsorted
 from twisterlib.constants import ZEPHYR_BASE
-from twisterlib.hardwaredata import HardwareData
+from twisterlib.error import NoDeviceAvailableException, TwisterException
+from twisterlib.hardwaredata import CompoundHardwareData, HardwareData
 
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.
@@ -470,3 +473,77 @@ class HardwareMap:
                 table.append([platform, p.id, p.serial])
 
         print(tabulate(table, headers=header, tablefmt="github"))
+
+    @staticmethod
+    @contextmanager
+    def acquire_dut_locks(duts: list[DUT]) -> Iterator[None]:
+        try:
+            for d in duts:
+                d.lock.acquire()
+            yield
+        finally:
+            for d in duts:
+                d.lock.release()
+
+    def reserve_dut(self, device: str, fixture: str | None) -> DUT:
+        """Reserve a DUT matching the specified device and fixture."""
+        duts_found: list[DUT] = []
+
+        for d in self.duts:
+            if fixture and fixture not in (f.split(sep=':')[0] for f in d.fixtures):
+                continue
+            if d.platform != device or (d.serial is None and d.serial_pty is None):
+                continue
+            duts_found.append(d)
+
+        if not duts_found:
+            raise TwisterException(f"No device to serve as {device} platform.")
+
+        # Select an available DUT with less failures
+        for d in sorted(duts_found, key=lambda _dut: _dut.failures):
+            # get all DUTs with the same id
+            duts_shared_hw = [_d for _d in self.duts if _d.id == d.id]
+            with self.acquire_dut_locks(duts_shared_hw):
+                avail = False
+                if d.available:
+                    for _d in duts_shared_hw:
+                        _d.available = 0
+                    d.counter_increment()
+                    avail = True
+                    logger.debug(f"Retain DUT:{d.platform}, Id:{d.id}, "
+                                 f"counter:{d.counter}, failures:{d.failures}")
+            if avail:
+                return d
+
+        raise NoDeviceAvailableException(f"No free {device} devices available")
+
+    def release_dut(self, dut: DUT) -> None:
+        """Release a previously reserved DUT, making it available for future reservations."""
+        logger.debug(f"Release DUT:{dut.platform}, Id:{dut.id}, "
+                     f"counter:{dut.counter}, failures:{dut.failures}")
+        # get all DUTs with the same id
+        duts_shared_hw = [_d for _d in self.duts if _d.id == dut.id]
+        with self.acquire_dut_locks(duts_shared_hw):
+            for _d in duts_shared_hw:
+                _d.available = 1
+
+    def _get_other_duts_with_same_id(self, hardware: DUT) -> list[DUT]:
+        """Get all DUTs that share the same hardware ID as the provided DUT,
+        excluding the provided DUT itself."""
+        duts: list[DUT] = []
+        # get all DUTs with the same id
+        duts_shared_hw = [_d for _d in self.duts if _d.id == hardware.id]
+        serials = {hardware.serial}
+        for d in duts_shared_hw:
+            if d.serial and d.serial not in serials:
+                duts.append(d)
+                serials.add(d.serial)
+        return duts
+
+    def create_compound_hardware_data(self, hardware: DUT) -> CompoundHardwareData:
+        """Create a CompoundHardwareData object for the provided DUT,
+        including any auxiliary connections that share the same hardware ID."""
+        compound_hardware = CompoundHardwareData.from_dict(hardware.to_dict())
+        for dut in self._get_other_duts_with_same_id(hardware):
+            compound_hardware.entries.append(HardwareData(**dut.to_dict()))
+        return compound_hardware

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -25,7 +25,6 @@ from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
-from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
@@ -378,7 +377,6 @@ class Pytest(Harness):
         self.source_dir = instance.testsuite.source_dir
         self.report_file = os.path.join(self.running_dir, 'report.xml')
         self.pytest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
-        self.reserved_dut = None
         self._output = []
         self.pytest_config_file = os.path.join(self.running_dir, TWISTER_PYTEST_CONFIG_FILE)
         self.pytest_params = HarnessPytestConfig(platform=instance.platform.name)
@@ -394,8 +392,6 @@ class Pytest(Harness):
         finally:
             self.instance.record(self.recording)
             self._update_test_status()
-            if self.reserved_dut:
-                self.instance.handler.make_dut_available(self.reserved_dut)
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config
@@ -424,6 +420,7 @@ class Pytest(Harness):
 
         if handler.type_str == 'device':
             self._generate_parameters_for_hardware(handler)
+            self.pytest_params.duts = self.instance.reserved_duts
         else:
             for fixture in handler.options.fixture:
                 self.pytest_params.twister_fixtures.append(fixture)
@@ -458,14 +455,6 @@ class Pytest(Harness):
             )
 
     def _generate_parameters_for_hardware(self, handler: DeviceHandler):
-        hardware = handler.get_hardware()
-        if not hardware:
-            raise PytestHarnessException('Hardware is not available')
-        # update the instance with the device id to have it in the summary report
-        self.instance.dut = hardware.id
-
-        self.reserved_dut = hardware
-
         options = handler.options
         if options.west_runner:
             self.pytest_params.runner = options.west_runner
@@ -481,12 +470,6 @@ class Pytest(Harness):
 
         # Platform flash_before is intended for boards with USB reset issues during flashing
         self.pytest_params.flash_before = self.instance.platform.flash_before
-
-        # Prepare DUT configuration for pytest
-        compound_hardware = CompoundHardwareData.from_dict(hardware.to_dict())
-        compound_hardware.entries = handler.get_other_duts_with_same_id(hardware)
-
-        self.pytest_params.duts.append(compound_hardware)
 
     def run_command(self, cmd, timeout):
         cmd, env = self._update_command_with_env_dependencies(cmd)

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -364,8 +364,8 @@ class Reporting:
             if instance.toolchain:
                 suite['toolchain'] = instance.toolchain
 
-            if instance.dut:
-                suite["dut"] = instance.dut
+            if instance.hardware_id:
+                suite["dut"] = instance.hardware_id
             if available_ram:
                 suite["available_ram"] = available_ram
             if available_rom:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -17,6 +17,7 @@ import sys
 import time
 import traceback
 from collections import deque
+from collections.abc import Iterator
 from math import log10
 from multiprocessing import Lock, Process, Value
 from multiprocessing.managers import BaseManager
@@ -29,7 +30,13 @@ from elftools.elf.sections import SymbolTableSection
 from packaging import version
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.constants import canonical_zephyr_base
-from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
+from twisterlib.error import (
+    BuildError,
+    ConfigurationError,
+    NoDeviceAvailableException,
+    StatusAttributeError,
+    TwisterException,
+)
 from twisterlib.log_helper import setup_logging
 from twisterlib.statuses import TwisterStatus
 
@@ -1111,14 +1118,16 @@ class ProjectBuilder(FilterBuilder):
 
         # Run the generated binary using one of the supported handlers
         elif op == "run":
+            processing_queue_updated = False
             try:
-                logger.debug(f"run test: {self.instance.name}")
-                self.run()
-                logger.debug(f"run status: {self.instance.name} {self.instance.status}")
+                with self.reserve_hardware() as ready_to_run:
+                    if ready_to_run:
+                        logger.debug(f"run test: {self.instance.name}")
+                        self.run()
+                        logger.debug(f"run status: {self.instance.name} {self.instance.status}")
 
                 # to make it work with pickle
                 self.instance.handler.thread = None
-                self.instance.handler.duts = None
 
                 next_op = "coverage" if self.options.coverage else "report"
                 additionals = {
@@ -1133,8 +1142,16 @@ class ProjectBuilder(FilterBuilder):
                 self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
                 next_op = 'report'
                 additionals = {}
+            except NoDeviceAvailableException:
+                # no device available to run the test,
+                # add the task back to the pipeline to process it later
+                processing_queue.appendleft(message)
+                processing_queue_updated = True
+                # to avoid busy waiting
+                time.sleep(1)
             finally:
-                self._add_to_processing_queue(processing_queue, next_op, additionals)
+                if not processing_queue_updated:
+                    self._add_to_processing_queue(processing_queue, next_op, additionals)
 
         # Run per-instance code coverage
         elif op == "coverage":
@@ -1585,8 +1602,8 @@ class ProjectBuilder(FilterBuilder):
                 if instance.handler.ready and instance.run:
                     more_info = instance.handler.type_str
                     htime = instance.execution_time
-                    if instance.dut:
-                        more_info += f": {instance.dut},"
+                    if instance.hardware_id:
+                        more_info += f": {instance.hardware_id},"
                     if htime:
                         more_info += f" {htime:.3f}s"
                 else:
@@ -1753,9 +1770,6 @@ class ProjectBuilder(FilterBuilder):
             logger.debug(f"Reset instance status from '{instance.status}' to None before run.")
             instance.status = TwisterStatus.NONE
 
-            if instance.handler.type_str == "device":
-                instance.handler.duts = self.env.hwm.duts
-
             if(self.options.seed is not None and instance.platform.name.startswith("native_")):
                 self.parse_generated()
                 if('CONFIG_FAKE_ENTROPY_NATIVE_SIM' in self.defconfig and
@@ -1815,6 +1829,40 @@ class ProjectBuilder(FilterBuilder):
                 instance.metrics["available_rom"] = 0
                 instance.metrics["available_ram"] = 0
             instance.metrics["handler_time"] = instance.execution_time
+
+    @contextlib.contextmanager
+    def reserve_hardware(self) -> Iterator[bool]:
+        """Context manager for reserving hardware for a test instance.
+
+        Yields True if the hardware was successfully reserved, False otherwise.
+        The hardware is automatically released when the context is exited.
+        """
+        if self.instance.handler.type_str == "device":
+            hwm = self.env.hwm
+            hardware = None
+            try:
+                device = self.instance.platform.name
+                fixture = self.instance.testsuite.harness_config.get("fixture")
+                hardware = hwm.reserve_dut(device, fixture)
+                compound_hardware = hwm.create_compound_hardware_data(hardware)
+                self.instance.reserved_duts.append(compound_hardware)
+                self.instance.hardware_id = hardware.id
+                yield True
+            except TwisterException as error:
+                self.instance.status = TwisterStatus.FAIL
+                self.instance.reason = str(error)
+                logger.error(self.instance.reason)
+                yield False
+            finally:
+                if hardware:
+                    if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+                        hardware.failures_increment()
+                    hwm.release_dut(hardware)
+                    self.instance.reserved_duts = []
+        else:
+            # No hardware reservation needed for non-device handlers
+            yield True
+
 
 class TwisterRunner:
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -30,6 +30,7 @@ from twisterlib.handlers import (
     QEMUWinHandler,
     SimulationHandler,
 )
+from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
 from twisterlib.size_calc import SizeCalculator
 from twisterlib.statuses import TwisterStatus
@@ -67,7 +68,7 @@ class TestInstance:
         self.retries = 0
         self.toolchain = toolchain
         self.name = os.path.join(platform.name, toolchain, testsuite.name)
-        self.dut = None
+        self.hardware_id: str | None = None
         self.suite_repeat = None
         self.test_repeat = None
         self.test_shuffle = None
@@ -99,6 +100,7 @@ class TestInstance:
         self.filter_type = None
         self.required_applications = []
         self.required_build_dirs = []
+        self.reserved_duts: list[CompoundHardwareData] = []
 
     def setup_run_id(self):
         self.run_id = self._get_run_id()

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import pytest
 import yaml
-from twisterlib.hardwaredata import HardwareData
 from twisterlib.harness import Pytest
 from twisterlib.platform import Platform
 from twisterlib.testinstance import TestInstance
@@ -38,8 +37,6 @@ def testinstance(tmp_path: Path) -> TestInstance:
     )
     testinstance.handler.options.fixture = ['fixture1:option1', 'fixture2']
     testinstance.handler.type_str = 'native'
-    testinstance.handler.get_hardware = mock.Mock(return_value=HardwareData())
-    testinstance.handler.get_other_duts_with_same_id = mock.Mock(return_value=[])
     testinstance.build_dir = tmp_path
     return testinstance
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -21,7 +21,6 @@ from unittest import mock
 import pytest
 import twisterlib.harness
 from serial import SerialException
-from twisterlib.error import TwisterException
 from twisterlib.handlers import (
     BinaryHandler,
     DeviceHandler,
@@ -29,7 +28,6 @@ from twisterlib.handlers import (
     QEMUHandler,
     SimulationHandler,
 )
-from twisterlib.hardwaremap import DUT
 from twisterlib.statuses import TwisterStatus
 
 # pylint: disable=no-name-in-module
@@ -733,220 +731,6 @@ def test_devicehandler_monitor_serial_splitlines(mocked_instance):
     assert harness.handle.call_count == 2
 
 
-TESTDATA_10 = [
-    (
-        'dummy_platform',
-        'dummy fixture',
-        [
-            mock.Mock(
-                fixtures=[],
-                platform='dummy_platform',
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='another_platform',
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=None,
-                serial=None,
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            )
-        ],
-        3
-    ),
-    (
-        'dummy_platform',
-        'dummy fixture',
-        [
-            mock.Mock(
-                fixtures=[],
-                platform='dummy_platform',
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='another_platform',
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=None,
-                serial=None,
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                available=1,
-                failures=1,
-                counter_increment=mock.Mock(),
-                counter=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                available=1,
-                failures=0,
-                counter_increment=mock.Mock(),
-                counter=0
-            )
-        ],
-        4
-    ),
-    (
-        'dummy_platform',
-        'dummy fixture',
-        [],
-        TwisterException
-    ),
-    (
-        'dummy_platform',
-        'dummy fixture',
-        [
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                counter_increment=mock.Mock(),
-                failures=0,
-                available=0
-            ),
-            mock.Mock(
-                fixtures=['another fixture'],
-                platform='dummy_platform',
-                serial_pty=mock.Mock(),
-                counter_increment=mock.Mock(),
-                failures=0,
-                available=0
-            ),
-            mock.Mock(
-                fixtures=['dummy fixture'],
-                platform='dummy_platform',
-                serial=mock.Mock(),
-                counter_increment=mock.Mock(),
-                failures=0,
-                available=0
-            ),
-            mock.Mock(
-                fixtures=['another fixture'],
-                platform='dummy_platform',
-                serial=mock.Mock(),
-                counter_increment=mock.Mock(),
-                failures=0,
-                available=0
-            )
-        ],
-        None
-    )
-]
-
-@pytest.mark.parametrize(
-    'platform_name, fixture, duts, expected',
-    TESTDATA_10,
-    ids=['two good duts, select the first one',
-         'two duts, the first was failed once, select the second not failed',
-         'exception - no duts', 'no available duts']
-)
-def test_devicehandler_device_is_available(
-    mocked_instance,
-    platform_name,
-    fixture,
-    duts,
-    expected
-):
-    mocked_instance.platform.name = platform_name
-    mocked_instance.testsuite.harness_config = {'fixture': fixture}
-
-    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
-    handler.duts = duts
-
-    if isinstance(expected, int):
-        device = handler.device_is_available(mocked_instance)
-
-        assert device == duts[expected]
-        assert device.available == 0
-        device.counter_increment.assert_called_once()
-    elif expected is None:
-        device = handler.device_is_available(mocked_instance)
-
-        assert device is None
-    elif isinstance(expected, type):
-        with pytest.raises(expected):
-            device = handler.device_is_available(mocked_instance)
-    else:
-        assert False
-
-
-def test_devicehandler_make_dut_available(mocked_instance):
-    serial = mock.Mock(name='dummy_serial')
-    duts = [
-        mock.Mock(available=0, serial=serial, serial_pty=None),
-        mock.Mock(available=0, serial=None, serial_pty=serial),
-        mock.Mock(
-            available=0,
-            serial=mock.Mock('another_serial'),
-            serial_pty=None
-        )
-    ]
-
-    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
-    handler.duts = duts
-
-    handler.make_dut_available(duts[1])
-
-    assert len([None for d in handler.duts if d.available == 1]) == 1
-    assert handler.duts[0].available == 0
-    assert handler.duts[2].available == 0
-
-    handler.make_dut_available(duts[0])
-
-    assert len([None for d in handler.duts if d.available == 1]) == 2
-    assert handler.duts[2].available == 0
-
-
 TESTDATA_11 = [
     (mock.Mock(pid=0, returncode=0), False),
     (mock.Mock(pid=0, returncode=1), False),
@@ -995,51 +779,6 @@ def test_devicehandler_run_custom_script(caplog, mock_process, raise_timeout):
     else:
         assert 'timed out' not in caplog.text.lower()
         assert 'custom script failure' in caplog.text.lower()
-
-
-TESTDATA_12 = [
-    (0, False),
-    (4, False),
-    (0, True)
-]
-
-@pytest.mark.parametrize(
-    'num_of_failures, raise_exception',
-    TESTDATA_12,
-    ids=['no failures', 'with failures', 'exception']
-)
-def test_devicehandler_get_hardware(
-    mocked_instance,
-    caplog,
-    num_of_failures,
-    raise_exception
-):
-    expected_hardware = mock.Mock()
-
-    def mock_availability(handler, instance, no=num_of_failures):
-        if raise_exception:
-            raise TwisterException(f'dummy message')
-        if handler.no:
-            handler.no -= 1
-            return None
-        return expected_hardware
-
-    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
-    handler.no = num_of_failures
-
-    with mock.patch.object(
-        DeviceHandler,
-        'device_is_available',
-        mock_availability
-    ):
-        hardware = handler.get_hardware()
-
-    if raise_exception:
-        assert 'dummy message' in caplog.text.lower()
-        assert mocked_instance.status == TwisterStatus.FAIL
-        assert mocked_instance.reason == 'dummy message'
-    else:
-        assert hardware == expected_hardware
 
 
 TESTDATA_13 = [
@@ -1243,15 +982,14 @@ def test_devicehandler_update_instance_info(
 
 
 TESTDATA_15 = [
-    ('dummy device', 'dummy pty', None, None, True, False, False),
+    ('dummy device', 'dummy pty', None, None, True, False),
     (
         'dummy device',
         'dummy pty',
         mock.Mock(communicate=mock.Mock(return_value=('', ''))),
         SerialException,
         False,
-        True,
-        'dummy pty'
+        True
     ),
     (
         'dummy device',
@@ -1259,14 +997,13 @@ TESTDATA_15 = [
         None,
         SerialException,
         False,
-        False,
-        'dummy device'
+        False
     )
 ]
 
 @pytest.mark.parametrize(
     'serial_device, serial_pty, ser_pty_process, expected_exception,' \
-    ' expected_result, terminate_ser_pty_process, make_available',
+    ' expected_result, terminate_ser_pty_process',
     TESTDATA_15,
     ids=['valid', 'serial pty process', 'no serial pty']
 )
@@ -1277,8 +1014,7 @@ def test_devicehandler_create_serial_connection(
     ser_pty_process,
     expected_exception,
     expected_result,
-    terminate_ser_pty_process,
-    make_available
+    terminate_ser_pty_process
 ):
     def mock_serial(*args, **kwargs):
         if expected_exception:
@@ -1290,11 +1026,6 @@ def test_devicehandler_create_serial_connection(
     handler.instance.add_missing_case_status = missing_mock
     twisterlib.handlers.terminate_process = mock.Mock()
 
-    dut = DUT()
-    dut.available = 0
-    dut.failures = 0
-    handler.duts = [dut]
-
     hardware_baud = 14400
     flash_timeout = 60
     serial_mock = mock.Mock(side_effect=mock_serial)
@@ -1302,19 +1033,16 @@ def test_devicehandler_create_serial_connection(
     with mock.patch('serial.Serial', serial_mock), \
          pytest.raises(expected_exception) if expected_exception else \
          nullcontext():
-        result = handler._create_serial_connection(dut, serial_device, hardware_baud,
+        result = handler._create_serial_connection(serial_device, hardware_baud,
                                                    flash_timeout, serial_pty,
                                                    ser_pty_process)
 
     if expected_result:
         assert result is not None
-        assert dut.failures == 0
 
     if expected_exception:
         assert handler.instance.status == TwisterStatus.FAIL
         assert handler.instance.reason == 'Serial Device Error'
-        assert dut.available == 1
-        assert dut.failures == 1
         missing_mock.assert_called_once_with('blocked', 'Serial Device Error')
 
     if terminate_ser_pty_process:
@@ -1356,35 +1084,32 @@ def test_devicehandler_start_serial_pty(
         assert result is not None
 
 TESTDATA_17 = [
-    (False, False, False, False, None, False, False,
+    (True, False, False, None, False, False,
      TwisterStatus.NONE, None, []),
-    (True, True, False, False, None, False, False,
-     TwisterStatus.NONE, None, []),
-    (True, False, True, False, None, False, False,
+    (False, True, False, None, False, False,
      TwisterStatus.ERROR, 'Device issue (Flash error)', []),
-    (True, False, False, True, None, False, False,
+    (False, False, True, None, False, False,
      TwisterStatus.ERROR, 'Device issue (Timeout)', ['Flash operation timed out.']),
-    (True, False, False, False, 1, False, False,
+    (False, False, False, 1, False, False,
      TwisterStatus.ERROR, 'Device issue (Flash error?)', []),
-    (True, False, False, False, 0, True, False,
+    (False, False, False, 0, True, False,
      TwisterStatus.NONE, None, ['Timed out while monitoring serial output on IPName']),
-    (True, False, False, False, 0, False, True,
+    (False, False, False, 0, False, True,
      TwisterStatus.NONE, None, ["Terminating serial-pty:'Serial PTY'",
                                 "Terminated serial-pty:'Serial PTY', stdout:'', stderr:''"]),
 ]
 
 @pytest.mark.parametrize(
-    'has_hardware, raise_create_serial, raise_popen, raise_timeout,' \
+    'raise_create_serial, raise_popen, raise_timeout,' \
     ' returncode, do_timeout_thread, use_pty,' \
     ' expected_status, expected_reason, expected_logs',
     TESTDATA_17,
-    ids=['no hardware', 'create serial failure', 'popen called process error',
+    ids=['create serial failure', 'popen called process error',
          'communicate timeout', 'nonzero returncode', 'valid pty', 'valid dev']
 )
 def test_devicehandler_handle(
     mocked_instance,
     caplog,
-    has_hardware,
     raise_create_serial,
     raise_popen,
     raise_timeout,
@@ -1436,7 +1161,7 @@ def test_devicehandler_handle(
             __exit__=mock.Mock(return_value=None)
         )
 
-    hardware = None if not has_hardware else mock.Mock(
+    hardware = mock.Mock(
         baud=14400,
         runner='dummy runner',
         serial_pty='Serial PTY' if use_pty else None,
@@ -1449,7 +1174,7 @@ def test_devicehandler_handle(
     )
 
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
-    handler.get_hardware = mock.Mock(return_value=hardware)
+    handler.instance.reserved_duts = [hardware]
     handler.options = mock.Mock(
         timeout_multiplier=1,
         west_flash=None,
@@ -1466,7 +1191,6 @@ def test_devicehandler_handle(
     handler.terminate = mock.Mock(side_effect=mock_terminate)
     handler._update_instance_info = mock.Mock()
     handler._final_handle_actions = mock.Mock()
-    handler.make_dut_available = mock.Mock()
     twisterlib.handlers.terminate_process = mock.Mock()
     handler.instance.platform.name = 'IPName'
 
@@ -1491,13 +1215,8 @@ def test_devicehandler_handle(
          mock.patch('os.ttyname', ttyname_mock):
         handler.handle(harness)
 
-    handler.get_hardware.assert_called_once()
-
     messages = [record.msg for record in caplog.records]
     assert all([msg in messages for msg in expected_logs])
-
-    if not has_hardware:
-        return
 
     handler.run_custom_script.assert_has_calls([
         mock.call('dummy pre script', mock.ANY)
@@ -1516,8 +1235,6 @@ def test_devicehandler_handle(
         assert handler.instance.reason == expected_reason
     if expected_status:
         assert handler.instance.status == expected_status
-
-    handler.make_dut_available.assert_called_once_with(hardware)
 
 
 TESTDATA_18 = [

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from twisterlib.error import NoDeviceAvailableException, TwisterException
 from twisterlib.hardwaremap import DUT, HardwareMap
 
 
@@ -791,3 +792,209 @@ def test_hardwaremap_save_existing_map_disconnect_omits_serial(mocked_hm):
 
     # And ensure nobody writes serial=None
     assert all(d.get('serial') is not None for d in dumped if 'serial' in d)
+
+
+TESTDATA_10 = [
+    (
+        'dummy_platform',
+        'dummy fixture',
+        [
+            mock.Mock(
+                fixtures=[],
+                platform='dummy_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='another_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=None,
+                serial=None,
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            )
+        ],
+        3
+    ),
+    (
+        'dummy_platform',
+        'dummy fixture',
+        [
+            mock.Mock(
+                fixtures=[],
+                platform='dummy_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='another_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=None,
+                serial=None,
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=1,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            )
+        ],
+        4
+    ),
+    (
+        'dummy_platform',
+        'dummy fixture',
+        [],
+        TwisterException
+    ),
+    (
+        'dummy_platform',
+        'dummy fixture',
+        [
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                counter_increment=mock.Mock(),
+                failures=0,
+                available=0
+            ),
+            mock.Mock(
+                fixtures=['another fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                counter_increment=mock.Mock(),
+                failures=0,
+                available=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial=mock.Mock(),
+                counter_increment=mock.Mock(),
+                failures=0,
+                available=0
+            ),
+            mock.Mock(
+                fixtures=['another fixture'],
+                platform='dummy_platform',
+                serial=mock.Mock(),
+                counter_increment=mock.Mock(),
+                failures=0,
+                available=0
+            )
+        ],
+        NoDeviceAvailableException
+    )
+]
+
+@pytest.mark.parametrize(
+    'platform_name, fixture, duts, expected',
+    TESTDATA_10,
+    ids=['two good duts, select the first one',
+         'two duts, the first was failed once, select the second not failed',
+         'exception - no duts', 'no available duts']
+)
+def test_hardwaremap_reserve_dut(
+    platform_name,
+    fixture,
+    duts,
+    expected
+):
+    hm = HardwareMap(env=mock.Mock())
+    hm.duts = duts
+
+    if isinstance(expected, int):
+        device = hm.reserve_dut(platform_name, fixture)
+
+        assert device == duts[expected]
+        assert device.available == 0
+        device.counter_increment.assert_called_once()
+    elif isinstance(expected, type):
+        with pytest.raises(expected):
+            hm.reserve_dut(platform_name, fixture)
+    else:
+        pytest.fail(f"Unexpected expected value: {expected}")
+
+
+def test_hardwaremap_release_dut():
+    serial = mock.Mock(name='dummy_serial')
+    duts = [
+        mock.Mock(available=0, serial=serial, serial_pty=None),
+        mock.Mock(available=0, serial=None, serial_pty=serial),
+        mock.Mock(
+            available=0,
+            serial=mock.Mock('another_serial'),
+            serial_pty=None
+        )
+    ]
+
+    hm = HardwareMap(env=mock.Mock())
+    hm.duts = duts
+
+    hm.release_dut(duts[1])
+
+    assert len([None for d in hm.duts if d.available == 1]) == 1
+    assert hm.duts[0].available == 0
+    assert hm.duts[2].available == 0
+
+    hm.release_dut(duts[0])
+
+    assert len([None for d in hm.duts if d.available == 1]) == 2
+    assert hm.duts[2].available == 0

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -13,7 +13,6 @@ import textwrap
 from unittest import mock
 
 import pytest
-from twisterlib.hardwaredata import HardwareData
 from twisterlib.harness import (
     Bsim,
     Console,
@@ -21,7 +20,6 @@ from twisterlib.harness import (
     Harness,
     HarnessImporter,
     Pytest,
-    PytestHarnessException,
     Robot,
     Test,
 )
@@ -522,15 +520,7 @@ def test_console_handle(
     assert console.capture_coverage == exp_capture
 
 
-TEST_DATA_5 = [("serial_pty", 0), (None, 0), (None, 1)]
-
-
-@pytest.mark.parametrize(
-    "pty_value, hardware_value",
-    TEST_DATA_5,
-    ids=["hardware pty", "hardware", "non hardware"],
-)
-def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_value):
+def test_pytest__generate_parameters_for_hardware(tmp_path):
     # Arrange
     mock_platform = mock.Mock()
     mock_platform.name = "mock_platform"
@@ -549,58 +539,19 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
 
     handler = mock.Mock()
     handler.instance = instance
-
-    hardware = HardwareData()
-    hardware.serial_pty = pty_value
-    hardware.serial = "serial"
-    hardware.serial_baud = 115200
-    hardware.runner = "runner"
-    hardware.runner_params = ["--runner-param1", "runner-param2"]
-    hardware.fixtures = ["fixture1:option1", "fixture2"]
-
     options = handler.options
     options.west_flash = "args"
     options.flash_command = "flash_command"
-
-    hardware.probe_id = "123"
-    hardware.product = "product"
-    hardware.pre_script = "pre_script"
-    hardware.post_flash_script = "post_flash_script"
-    hardware.post_script = "post_script"
 
     pytest_test = Pytest()
     pytest_test.configure(instance)
 
     # Act
-    if hardware_value == 0:
-        handler.get_hardware.return_value = hardware
-        handler.get_other_duts_with_same_id = mock.Mock(return_value=[])
-        pytest_test._generate_parameters_for_hardware(handler)
-    else:
-        handler.get_hardware.return_value = None
+    pytest_test._generate_parameters_for_hardware(handler)
 
     # Assert
-    if hardware_value == 1:
-        with pytest.raises(PytestHarnessException) as exinfo:
-            pytest_test._generate_parameters_for_hardware(handler)
-        assert str(exinfo.value) == "Hardware is not available"
-    else:
-        assert pytest_test.pytest_params.duts
-        if pty_value == "serial_pty":
-            assert pytest_test.pytest_params.duts[0].serial_pty == "serial_pty"
-        else:
-            assert pytest_test.pytest_params.duts[0].serial == "serial"
-            assert pytest_test.pytest_params.duts[0].serial_baud == 115200
-        assert pytest_test.pytest_params.duts[0].runner == "runner"
-        assert pytest_test.pytest_params.duts[0].runner_params == ["--runner-param1", "runner-param2"]
-        assert pytest_test.pytest_params.west_flash_extra_args == "args"
-        assert pytest_test.pytest_params.flash_command == "flash_command"
-        assert pytest_test.pytest_params.duts[0].probe_id == "123"
-        assert pytest_test.pytest_params.duts[0].product == "product"
-        assert pytest_test.pytest_params.duts[0].pre_script == "pre_script"
-        assert pytest_test.pytest_params.duts[0].post_flash_script == "post_flash_script"
-        assert pytest_test.pytest_params.duts[0].post_script == "post_script"
-        assert pytest_test.pytest_params.duts[0].fixtures == ["fixture1:option1", "fixture2"]
+    assert pytest_test.pytest_params.west_flash_extra_args == "args"
+    assert pytest_test.pytest_params.flash_command == "flash_command"
 
 
 def test_pytest__update_command_with_env_dependencies():

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2067,7 +2067,7 @@ def test_projectbuilder_report_out(
     instance_mock.handler.seed = 123
     instance_mock.handler.ready = ready_run
     instance_mock.run = ready_run
-    instance_mock.dut = 'dummy dut'
+    instance_mock.hardware_id = 'dummy dut'
     instance_mock.execution_time = 60
     instance_mock.platform.name = 'dummy platform'
     instance_mock.status = status


### PR DESCRIPTION
* twister: move hardware reservation to runner context manager

  Hardware reservation logic moved from Handler class to ProjectBuilder
  runner using context manager approach. When NoDeviceAvailableException
  is raised due to no free devices, the **task is re-queued for later
  processing instead of blocking the execution pipeline**.
  
  The reserve_hardware() context manager handles device reservation,
  yields execution control only when hardware is available, and ensures
  proper cleanup in the finally block.
  
  All DUT management logic is now consolidated in HardwareMap class,
  removing DUT references from Handler classes. This improves code
  maintainability by centralizing responsibilities and eliminating
  shared ownership of hardware resources between modules.

* tests: twister: Align tests with hardware reservation changes

  Update unit tests after moving hardware reservation logic from
  Handler class to HardwareMap. Relocate and rename tests to match
  the new module structure and API changes.

