### PR TITLE
pm: policy: replace DT_PROP_LEN with ARRAY_SIZE

### DIFF
--- a/subsys/pm/policy/policy_device_lock.c
+++ b/subsys/pm/policy/policy_device_lock.c
@@ -63,7 +63,7 @@ DT_FOREACH_STATUS_OKAY_NODE(DEVICE_CONSTRAINTS_DEFINE)
 #define PM_STATE_DEVICE_CONSTRAINT_INIT(node_id)                                              \
 	{                                                                                     \
 		.dev = DEVICE_DT_NAME(node_id),                                                \
-		.pm_constraints_size = DT_PROP_LEN(node_id, zephyr_disabling_power_states),   \
+		.pm_constraints_size = ARRAY_SIZE(PM_CONSTRAINTS_NAME(node_id)),               \
 		.constraints = PM_CONSTRAINTS_NAME(node_id),                                  \
 	},
 


### PR DESCRIPTION
Use `ARRAY_SIZE` macro to determine the size of the `pm_constraints` array instead of `DT_PROP_LEN`. Because a practical issue is that `zephyr, disabling-power-states` may contain multiple power states, but one of the power states is in a **disabled** status. In this case, the size obtained by `DT_PROP_LEN` is larger than the actual size.