### PR TITLE
dts: stm32: can: Fixed missing master-can parameter

### DIFF
--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -48,6 +48,7 @@
 			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
+			master-can-reg = <0x40006400>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
dtsi for stm32f207 was missing a parameter as described in #104523, which caused CAN2 controller to incorrectly set RX filters.

Fixes #104523 