### PR TITLE
tests: drivers: dma: cyclic: re-init guard after inter-cycle memset

### DIFF
--- a/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
+++ b/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
@@ -131,6 +131,7 @@ static int test_cyclic(void)
 
 	/* reset rx_data to validate that transfer cycles */
 	memset(rx_data, 0, sizeof(rx_data));
+	(void)memset(rx_data + CONFIG_DMA_CYCLIC_XFER_SIZE, 0xA5, GUARD_BUF_SIZE);
 
 	if (dma_resume(dma, chan_id) != 0) {
 		TC_PRINT("Failed to resume transfer\n");


### PR DESCRIPTION
Commit 7839d958ac81 ("tests: drivers: dma: cyclic: check rx buf overflow") added a 16-byte guard region at the end of rx_data, initialized to 0xA5 before the test starts, with overflow checks after each cycle.

Between cycle 1 and cycle 2, the test resets the receive buffer with memset(rx_data, 0, sizeof(rx_data)). Since rx_data was enlarged to CONFIG_DMA_CYCLIC_XFER_SIZE + GUARD_BUF_SIZE, this zeros the guard region along with the transfer area. The second cycle's guard check then finds 0x00 instead of 0xA5 and fails, even though the DMA never wrote past the buffer.

Fix by re-initializing the guard to 0xA5 immediately after the inter-cycle memset.