### PR TITLE
boards: cy8ckit_041s_max: enable DMA driver

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
@@ -18,4 +18,5 @@ supported:
   - clock_control
   - pinctrl
   - i2c
+  - dma
 vendor: infineon

--- a/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100smax/psoc4100smax.dtsi
@@ -220,6 +220,15 @@
 			status = "disabled";
 		};
 
+		dma0: dma@40101000 {
+			#dma-cells = <1>;
+			compatible = "infineon,dmac";
+			reg = <0x40101000 0xa00>;
+			interrupts = <14 1>;
+			dma-channels = <16>;
+			status = "disabled";
+		};
+
 		tcpwm0: tcpwm0@40200000 {
 			reg = <0x40200000 0x300>;
 			#address-cells = <1>;

--- a/tests/drivers/dma/chan_blen_transfer/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/cyclic/boards/cy8ckit_041s_max.conf
+++ b/tests/drivers/dma/cyclic/boards/cy8ckit_041s_max.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_CYCLIC_XFER_SIZE=64

--- a/tests/drivers/dma/cyclic/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/dma/cyclic/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/loop_transfer/boards/cy8ckit_041s_max.conf
+++ b/tests/drivers/dma/loop_transfer/boards/cy8ckit_041s_max.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_LOOP_TRANSFER_SIZE=64

--- a/tests/drivers/dma/loop_transfer/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/scatter_gather/boards/cy8ckit_041s_max.conf
+++ b/tests/drivers/dma/scatter_gather/boards/cy8ckit_041s_max.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_SG_XFER_SIZE=64

--- a/tests/drivers/dma/scatter_gather/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/cy8ckit_041s_max.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
Add support for Infineon DMAC driver using cy8ckit_041s_max.

Closely relates to https://github.com/zephyrproject-rtos/zephyr/pull/101583, that PR should be merged first.

Also relates to https://github.com/zephyrproject-rtos/zephyr/pull/104545