### PR TITLE
pm: policy: move pm_policy_device_is_disabling_state() declaration

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -247,21 +247,6 @@ void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks);
 void pm_policy_event_unregister(struct pm_policy_event *evt);
 
 /**
- * @brief Check if a state will disable a device
- *
- * This function allows client code to check if a state will disable a device.
- *
- * @param dev Device reference.
- * @param state The state to check on whether it disables the device.
- * @param substate_id The substate to check on whether it disables the device.
- *
- * @retval true if the state disables the device
- * @retval false if the state does not disable the device
- */
-bool pm_policy_device_is_disabling_state(const struct device *dev,
-					 enum pm_state state, uint8_t substate_id);
-
-/**
  * @brief Returns the ticks until the next event
  *
  * If an event is registred, it will return the number of ticks until the next event, if the
@@ -377,6 +362,21 @@ void pm_policy_device_power_lock_get(const struct device *dev);
  */
 void pm_policy_device_power_lock_put(const struct device *dev);
 
+/**
+ * @brief Check if a state will disable a device
+ *
+ * This function allows client code to check if a state will disable a device.
+ *
+ * @param dev Device reference.
+ * @param state The state to check on whether it disables the device.
+ * @param substate_id The substate to check on whether it disables the device.
+ *
+ * @retval true if the state disables the device
+ * @retval false if the state does not disable the device
+ */
+bool pm_policy_device_is_disabling_state(const struct device *dev,
+					 enum pm_state state, uint8_t substate_id);
+
 #else
 
 static inline void pm_policy_device_power_lock_get(const struct device *dev)
@@ -387,6 +387,17 @@ static inline void pm_policy_device_power_lock_get(const struct device *dev)
 static inline void pm_policy_device_power_lock_put(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+}
+
+static inline bool pm_policy_device_is_disabling_state(const struct device *dev,
+						       enum pm_state state,
+						       uint8_t substate_id)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	return false;
 }
 #endif /* CONFIG_PM_POLICY_DEVICE_CONSTRAINTS */
 


### PR DESCRIPTION
Currently, the declaration of the function `pm_policy_device_is_disabling_state` is located within the `CONFIG_PM` block in `policy.h`, so the function prototype is visible as long as `PM` is enabled. However, the implementation only exists in `policy_device_lock.c`, which is only compiled when `CONFIG_PM_POLICY_DEVICE_CONSTRAINTS=y`. This causes a situation where when `CONFIG_PM=y` and `CONFIG_PM_POLICY_DEVICE_CONSTRAINTS=n`, the function is **declared but not implemented** which will result in a linker failure if the function is called.

This PR moves `pm_policy_device_is_disabling_state` into the same `CONFIG_PM_POLICY_DEVICE_CONSTRAINTS` macro block as `pm_policy_device_power_lock_get/put`; and provides a static inline stub that returns false in the else branch (consistent with the existing `power_lock_get/put` style).