### PR TITLE
bluetooth: avrcp: Move SDP registration to callback registration

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -2967,25 +2967,6 @@ void bt_avrcp_init(void)
 		return;
 	}
 
-	/* Register event handlers with AVCTP */
-	avctp_server.l2cap.psm = BT_L2CAP_PSM_AVRCP;
-	avctp_server.accept = avrcp_accept;
-	err = bt_avctp_server_register(&avctp_server);
-	if (err < 0) {
-		LOG_ERR("AVRCP registration failed (err %d)", err);
-		return;
-	}
-
-#if defined(CONFIG_BT_AVRCP_BROWSING)
-	avctp_browsing_server.l2cap.psm = BT_L2CAP_PSM_AVRCP_BROWSING;
-	avctp_browsing_server.accept = avrcp_browsing_accept;
-	err = bt_avctp_server_register(&avctp_browsing_server);
-	if (err < 0) {
-		LOG_ERR("AVRCP browsing registration failed (err %d)", err);
-		return;
-	}
-#endif /* CONFIG_BT_AVRCP_BROWSING */
-
 #if defined(CONFIG_BT_AVRCP_TG_COVER_ART)
 	err = bt_avrcp_tg_cover_art_init(&bt_avrcp_tg_cover_art_psm);
 	if (err < 0) {
@@ -2993,14 +2974,6 @@ void bt_avrcp_init(void)
 		return;
 	}
 #endif /* CONFIG_BT_AVRCP_TG_COVER_ART */
-
-#if defined(CONFIG_BT_AVRCP_TARGET)
-	bt_sdp_register_service(&avrcp_tg_rec);
-#endif /* CONFIG_BT_AVRCP_CONTROLLER */
-
-#if defined(CONFIG_BT_AVRCP_CONTROLLER)
-	bt_sdp_register_service(&avrcp_ct_rec);
-#endif /* CONFIG_BT_AVRCP_CONTROLLER */
 
 	LOG_DBG("AVRCP Initialized successfully.");
 
@@ -3805,8 +3778,42 @@ int bt_avrcp_ct_add_to_now_playing(struct bt_avrcp_ct *ct, uint8_t tid, struct n
 	return err;
 }
 
+static int avctp_server_register(void)
+{
+	int err;
+
+	/* Register event handlers with AVCTP */
+	avctp_server.l2cap.psm = BT_L2CAP_PSM_AVRCP;
+	avctp_server.l2cap.sec_level = BT_SECURITY_L2;
+	avctp_server.accept = avrcp_accept;
+	err = bt_avctp_server_register(&avctp_server);
+	if (err < 0 && err != -EEXIST) {
+		LOG_ERR("AVCTP server registration failed (err %d)", err);
+		goto failed;
+	}
+
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+	avctp_browsing_server.l2cap.psm = BT_L2CAP_PSM_AVRCP_BROWSING;
+	avctp_browsing_server.accept = avrcp_browsing_accept;
+	avctp_browsing_server.l2cap.sec_level = BT_SECURITY_L2;
+	err = bt_avctp_server_register(&avctp_browsing_server);
+	if (err < 0 && err != -EEXIST) {
+		LOG_ERR("AVCTP browsing server registration failed (err %d)", err);
+		goto failed;
+	}
+#endif /* CONFIG_BT_AVRCP_BROWSING */
+	LOG_DBG("AVCTP server registered");
+	return 0;
+
+failed:
+	/* TODO: Consider remove registered AVCTP servers here. */
+	return err;
+}
+
 int bt_avrcp_ct_register_cb(const struct bt_avrcp_ct_cb *cb)
 {
+	int err;
+
 	if (!cb) {
 		return -EINVAL;
 	}
@@ -3817,11 +3824,33 @@ int bt_avrcp_ct_register_cb(const struct bt_avrcp_ct_cb *cb)
 
 	avrcp_ct_cb = cb;
 
+#if defined(CONFIG_BT_AVRCP_CONTROLLER)
+	/* Register SDP record when CT callback is registered */
+	err = bt_sdp_register_service(&avrcp_ct_rec);
+	if (err < 0 && err != -EEXIST) {
+		LOG_ERR("AVRCP CT SDP registration failed (err %d)", err);
+		goto failed;
+	}
+	LOG_DBG("AVRCP CT SDP record registered");
+#endif /* CONFIG_BT_AVRCP_CONTROLLER */
+
+	/* Register AVCTP server on first role registration */
+	err = avctp_server_register();
+	if (err < 0) {
+		goto failed;
+	}
+
 	return 0;
+
+failed:
+	avrcp_ct_cb = NULL;
+	return err;
 }
 
 int bt_avrcp_tg_register_cb(const struct bt_avrcp_tg_cb *cb)
 {
+	int err;
+
 	if (!cb) {
 		return -EINVAL;
 	}
@@ -3832,7 +3861,27 @@ int bt_avrcp_tg_register_cb(const struct bt_avrcp_tg_cb *cb)
 
 	avrcp_tg_cb = cb;
 
+#if defined(CONFIG_BT_AVRCP_TARGET)
+	/* Register SDP record when TG callback is registered */
+	err = bt_sdp_register_service(&avrcp_tg_rec);
+	if (err < 0 && err != -EEXIST) {
+		LOG_ERR("AVRCP TG SDP registration failed (err %d)", err);
+		goto failed;
+	}
+	LOG_DBG("AVRCP TG SDP record registered");
+#endif /* CONFIG_BT_AVRCP_TARGET */
+
+	/* Register AVCTP server on first role registration */
+	err = avctp_server_register();
+	if (err < 0) {
+		goto failed;
+	}
+
 	return 0;
+
+failed:
+	avrcp_tg_cb = NULL;
+	return err;
 }
 
 int bt_avrcp_tg_send_unit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid,


### PR DESCRIPTION
Move AVRCP SDP record registration from bt_avrcp_init() to callback registration functions to align with other Bluetooth Classic profiles.