### PR TITLE
soc: nxp: mcxw2xx: correct NUM_IRQS value

### DIFF
--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
@@ -15,7 +15,7 @@ config CORTEX_M_SYSTICK
 	default n if MCUX_OS_TIMER
 
 config NUM_IRQS
-	default 63
+	default 61
 
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
 


### PR DESCRIPTION
The NUM_IRQS value for MCXW2xx was incorrectly set to 63. According to the device reference manual, the correct number of interrupts is 61.

Fixes: #98279