### PR TITLE
tests: bluetooth: tester: add SPP (RFCOMM) service PTS support

### DIFF
--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 
 if(CONFIG_BT_RFCOMM)
     target_sources(app PRIVATE src/btp_rfcomm.c)
+    target_sources(app PRIVATE src/btp_spp.c)
 endif()
 
 zephyr_library_include_directories(src src/btp src/audio/btp)

--- a/tests/bluetooth/tester/src/btp/btp.h
+++ b/tests/bluetooth/tester/src/btp/btp.h
@@ -43,6 +43,7 @@
 #include "btp_pbp.h"
 #include "btp_sdp.h"
 #include "btp_rfcomm.h"
+#include "btp_spp.h"
 
 #define BTP_MTU 1024
 #define BTP_DATA_MAX_SIZE (BTP_MTU - sizeof(struct btp_hdr))
@@ -85,8 +86,9 @@
 #define BTP_SERVICE_ID_PBP      0x1e
 #define BTP_SERVICE_ID_SDP      0x1f
 #define BTP_SERVICE_ID_RFCOMM   0x20
+#define BTP_SERVICE_ID_SPP      0x21
 
-#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_RFCOMM
+#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_SPP
 
 /* Service ID starts from index 0.
  * BTP_SERVICE_ID_MAX is the last service ID.

--- a/tests/bluetooth/tester/src/btp/btp.h
+++ b/tests/bluetooth/tester/src/btp/btp.h
@@ -43,6 +43,7 @@
 #include "btp_pbp.h"
 #include "btp_sdp.h"
 #include "btp_rfcomm.h"
+#include "btp_spp.h"
 
 #define BTP_MTU 1024
 #define BTP_DATA_MAX_SIZE (BTP_MTU - sizeof(struct btp_hdr))
@@ -85,8 +86,9 @@
 #define BTP_SERVICE_ID_PBP      0x1e
 #define BTP_SERVICE_ID_SDP      0x1f
 #define BTP_SERVICE_ID_RFCOMM   0x20
+#define BTP_SERVICE_ID_SPP      0x21
 
-#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_RFCOMM
+#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_SPP
 
 #define BTP_STATUS_SUCCESS	0x00
 #define BTP_STATUS_FAILED	0x01

--- a/tests/bluetooth/tester/src/btp/btp_spp.h
+++ b/tests/bluetooth/tester/src/btp/btp_spp.h
@@ -1,0 +1,40 @@
+/* btp_spp.h - Bluetooth SPP tester headers */
+
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __BTP_SPP_H
+#define __BTP_SPP_H
+
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+
+/* SPP Commands */
+#define BTP_SPP_READ_SUPPORTED_COMMANDS    0x01
+struct btp_spp_read_supported_commands_rp {
+	uint8_t data[0];
+} __packed;
+
+#define BTP_SPP_CMD_DISCOVER               0x02
+struct btp_spp_discover_cmd {
+	uint8_t address_type;
+	bt_addr_t address;
+} __packed;
+
+#define BTP_SPP_CMD_REGISTER_SERVER         0x03
+struct btp_spp_register_server_cmd {
+	uint8_t channel;
+} __packed;
+
+/* SPP Events */
+#define BTP_SPP_EV_DISCOVERED              0x80
+struct btp_spp_discover_ev {
+	bt_addr_t address;
+	uint8_t channel;
+} __packed;
+
+#endif /* __BTP_SPP_H */

--- a/tests/bluetooth/tester/src/btp/bttester.h
+++ b/tests/bluetooth/tester/src/btp/bttester.h
@@ -151,3 +151,6 @@ uint8_t tester_unregister_sdp(void);
 
 uint8_t tester_init_rfcomm(void);
 uint8_t tester_unregister_rfcomm(void);
+
+uint8_t tester_init_spp(void);
+uint8_t tester_unregister_spp(void);

--- a/tests/bluetooth/tester/src/btp_core.c
+++ b/tests/bluetooth/tester/src/btp_core.c
@@ -144,6 +144,10 @@ static uint8_t supported_services(const void *cmd, uint16_t cmd_len,
 #if defined(CONFIG_BT_CLASSIC)
 	tester_set_bit(rp->data, BTP_SERVICE_ID_SDP);
 #endif /* CONFIG_BT_CLASSIC */
+#if defined(CONFIG_BT_RFCOMM)
+	tester_set_bit(rp->data, BTP_SERVICE_ID_RFCOMM);
+	tester_set_bit(rp->data, BTP_SERVICE_ID_SPP);
+#endif /* CONFIG_BT_RFCOMM */
 
 	*rsp_len = sizeof(*rp) + 4U;
 
@@ -303,6 +307,9 @@ static uint8_t register_service(const void *cmd, uint16_t cmd_len,
 #if defined(CONFIG_BT_RFCOMM)
 	case BTP_SERVICE_ID_RFCOMM:
 		status = tester_init_rfcomm();
+		break;
+	case BTP_SERVICE_ID_SPP:
+		status = tester_init_spp();
 		break;
 #endif /* CONFIG_BT_RFCOMM */
 	default:
@@ -468,6 +475,9 @@ static uint8_t unregister_service(const void *cmd, uint16_t cmd_len,
 #if defined(CONFIG_BT_RFCOMM)
 	case BTP_SERVICE_ID_RFCOMM:
 		status = tester_unregister_rfcomm();
+		break;
+	case BTP_SERVICE_ID_SPP:
+		status = tester_unregister_spp();
 		break;
 #endif /* CONFIG_BT_RFCOMM */
 	default:

--- a/tests/bluetooth/tester/src/btp_core.c
+++ b/tests/bluetooth/tester/src/btp_core.c
@@ -148,6 +148,10 @@ static uint8_t supported_services(const void *cmd, uint16_t cmd_len,
 #if defined(CONFIG_BT_CLASSIC)
 	tester_set_bit(rp->data, BTP_SERVICE_ID_SDP);
 #endif /* CONFIG_BT_CLASSIC */
+#if defined(CONFIG_BT_RFCOMM)
+	tester_set_bit(rp->data, BTP_SERVICE_ID_RFCOMM);
+	tester_set_bit(rp->data, BTP_SERVICE_ID_SPP);
+#endif /* CONFIG_BT_RFCOMM */
 
 	/* octet 4 */
 #if defined(CONFIG_BT_RFCOMM)
@@ -313,6 +317,9 @@ static uint8_t register_service(const void *cmd, uint16_t cmd_len,
 	case BTP_SERVICE_ID_RFCOMM:
 		status = tester_init_rfcomm();
 		break;
+	case BTP_SERVICE_ID_SPP:
+		status = tester_init_spp();
+		break;
 #endif /* CONFIG_BT_RFCOMM */
 	default:
 		LOG_WRN("unknown id: 0x%02x", cp->id);
@@ -477,6 +484,9 @@ static uint8_t unregister_service(const void *cmd, uint16_t cmd_len,
 #if defined(CONFIG_BT_RFCOMM)
 	case BTP_SERVICE_ID_RFCOMM:
 		status = tester_unregister_rfcomm();
+		break;
+	case BTP_SERVICE_ID_SPP:
+		status = tester_unregister_spp();
 		break;
 #endif /* CONFIG_BT_RFCOMM */
 	default:

--- a/tests/bluetooth/tester/src/btp_spp.c
+++ b/tests/bluetooth/tester/src/btp_spp.c
@@ -1,0 +1,258 @@
+/* btp_spp.c - Bluetooth SPP (Serial Port Profile) Tester */
+
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/classic/rfcomm.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/uuid.h>
+
+#include <zephyr/logging/log.h>
+#define LOG_MODULE_NAME btp_spp
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
+
+#include "btp/btp.h"
+#define SDP_CLIENT_BUF_LEN 512
+#define SPP_RFCOMM_CHANNEL_MIN 1
+#define SPP_RFCOMM_CHANNEL_MAX 31
+NET_BUF_POOL_FIXED_DEFINE(sdp_pool, CONFIG_BT_MAX_CONN, SDP_CLIENT_BUF_LEN, 8, NULL);
+
+static uint8_t spp_channel;
+static struct bt_sdp_attribute spp_attrs_channel[] = {
+	BT_SDP_NEW_SERVICE,
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SVCLASS_ID_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+			BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 12),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+			},
+			)
+		},
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 5),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_RFCOMM)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+				&spp_channel
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROFILE_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(0x0102)
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_SERVICE_NAME("Serial Port"),
+};
+
+static struct bt_sdp_record spp_rec_channel = BT_SDP_RECORD(spp_attrs_channel);
+/*
+ * Register SPP server SDP record only.
+ * The actual RFCOMM server registration (bt_rfcomm_server_register()) is
+ * triggered separately by AutoPTS after the SDP registration callback fires.
+ */
+static int spp_server_register(uint8_t channel)
+{
+	int err;
+
+	spp_channel = channel;
+	err = bt_sdp_register_service(&spp_rec_channel);
+	if (err < 0) {
+		return err;
+	}
+
+	LOG_DBG("SPP: server registered (channel=%u)", spp_channel);
+	return 0;
+}
+
+/* ---- BTP command handlers --------------------------------------------- */
+static uint8_t spp_supported(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+	struct btp_spp_read_supported_commands_rp *rp = rsp;
+
+	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_SPP, rp->data);
+	*rsp_len += sizeof(*rp);
+
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t spp_discover_cb(struct bt_conn *conn, struct bt_sdp_client_result *result,
+			       const struct bt_sdp_discover_params *params)
+{
+	struct btp_spp_discover_ev ev;
+	const bt_addr_t *peer;
+	uint16_t channel;
+	int err;
+
+	if (result == NULL) {
+		LOG_DBG("SDP discovery completed");
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
+
+	if (result->resp_buf == NULL) {
+		LOG_ERR("SDP response buffer is NULL");
+		return BT_SDP_DISCOVER_UUID_CONTINUE;
+	}
+
+	/* Parse the SDP response to find RFCOMM channel */
+	err = bt_sdp_get_proto_param(result->resp_buf, BT_SDP_PROTO_RFCOMM, &channel);
+	if (err < 0) {
+		LOG_ERR("Failed to get RFCOMM channel (err %d)", err);
+		return BT_SDP_DISCOVER_UUID_CONTINUE;
+	}
+
+	LOG_DBG("SPP service found on RFCOMM channel %u", channel);
+
+	/* Send discovery event to tester */
+	memset(&ev, 0, sizeof(ev));
+
+	peer = bt_conn_get_dst_br(conn);
+	if (peer != NULL) {
+		bt_addr_copy(&ev.address, peer);
+	}
+	ev.channel = (uint8_t)channel;
+
+	tester_event(BTP_SERVICE_ID_SPP, BTP_SPP_EV_DISCOVERED, &ev, sizeof(ev));
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+}
+
+static struct bt_sdp_discover_params sdp_discover = {
+	.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
+	.func = spp_discover_cb,
+	.pool = &sdp_pool,
+	.uuid = BT_UUID_DECLARE_16(BT_SDP_SERIAL_PORT_SVCLASS),
+};
+
+static uint8_t spp_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+	const struct btp_spp_discover_cmd *cp = cmd;
+	struct bt_conn *conn;
+	int err;
+	bt_addr_t addr;
+
+	/* Check if this is BR/EDR address type */
+	if (cp->address_type != BTP_BR_ADDRESS_TYPE) {
+		LOG_ERR("Invalid address type: 0x%02x", cp->address_type);
+		return BTP_STATUS_FAILED;
+	}
+
+	/* Copy address */
+	bt_addr_copy(&addr, &cp->address);
+
+	/* Get BR/EDR connection */
+	conn = bt_conn_lookup_addr_br(&addr);
+	if (conn == NULL) {
+		LOG_ERR("BR/EDR connection not found");
+		return BTP_STATUS_FAILED;
+	}
+
+	/* Start SDP discovery */
+	err = bt_sdp_discover(conn, &sdp_discover);
+	if (err < 0) {
+		LOG_ERR("SDP discovery failed (err %d)", err);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	LOG_DBG("SPP discovery started");
+	bt_conn_unref(conn);
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t spp_register_server_cmd(const void *cmd, uint16_t cmd_len, void *rsp,
+				       uint16_t *rsp_len)
+{
+	const struct btp_spp_register_server_cmd *cp = cmd;
+	int err;
+
+	/* Validate channel number (RFCOMM channels are 1-31) */
+	if (cp->channel < SPP_RFCOMM_CHANNEL_MIN || cp->channel > SPP_RFCOMM_CHANNEL_MAX) {
+		LOG_ERR("Invalid RFCOMM channel: %u", cp->channel);
+		return BTP_STATUS_FAILED;
+	}
+
+	/* Register SPP server with specified channel */
+	err = spp_server_register(cp->channel);
+	if (err < 0) {
+		LOG_ERR("SPP server registration failed (err %d)", err);
+		return BTP_STATUS_FAILED;
+	}
+
+	LOG_DBG("SPP server registered on channel %u", cp->channel);
+	return BTP_STATUS_SUCCESS;
+}
+
+/* ---- registration ------------------------------------------------------ */
+static const struct btp_handler spp_handlers[] = {
+	{
+		.opcode     = BTP_SPP_READ_SUPPORTED_COMMANDS,
+		.index      = BTP_INDEX_NONE,
+		.expect_len = 0,
+		.func       = spp_supported,
+	},
+	{
+		.opcode     = BTP_SPP_CMD_DISCOVER,
+		.expect_len = sizeof(struct btp_spp_discover_cmd),
+		.func       = spp_discover,
+	},
+	{
+		.opcode     = BTP_SPP_CMD_REGISTER_SERVER,
+		.expect_len = sizeof(struct btp_spp_register_server_cmd),
+		.func       = spp_register_server_cmd,
+	},
+};
+
+uint8_t tester_init_spp(void)
+{
+	tester_register_command_handlers(BTP_SERVICE_ID_SPP, spp_handlers,
+					 ARRAY_SIZE(spp_handlers));
+
+	return BTP_STATUS_SUCCESS;
+}
+
+uint8_t tester_unregister_spp(void)
+{
+	return BTP_STATUS_SUCCESS;
+}


### PR DESCRIPTION
Add a Serial Port Profile (SPP) service to the Bluetooth tester over RFCOMM, enabling SDP-based discovery and simple server registration.