### PR TITLE
drivers: i3c: cdns: fix multiple bugs in Cadence I3C driver

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -29,7 +29,7 @@
 #define CONF_STATUS0_PROT_FAULTS_CHK      BIT(24)
 #define CONF_STATUS0_GPO_NUM(x)           (((x) & GENMASK(23, 16)) >> 16)
 #define CONF_STATUS0_GPI_NUM(x)           (((x) & GENMASK(15, 8)) >> 8)
-#define CONF_STATUS0_IBIR_DEPTH(x)        (4 << (((x) & GENMASK(7, 6)) >> 7))
+#define CONF_STATUS0_IBIR_DEPTH(x)        (4 << (((x) & GENMASK(7, 6)) >> 6))
 /* CONF_STATUS0_SUPPORTS_DDR moved to CONF_STATUS1 in rev >= 1p7 */
 #define CONF_STATUS0_SUPPORTS_DDR         BIT(5)
 #define CONF_STATUS0_SEC_MASTER           BIT(4)

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -55,7 +55,7 @@
 #define REV_ID_VID(id)       (((id) & GENMASK(31, 20)) >> 20)
 #define REV_ID_PID(id)       (((id) & GENMASK(19, 8)) >> 8)
 #define REV_ID_REV(id)       ((id) & GENMASK(7, 0))
-#define REV_ID_VERSION(m, n) ((m << 5) | (n))
+#define REV_ID_VERSION(m, n) (((m) << 5) | (n))
 #define REV_ID_REV_MAJOR(id) (((id) & GENMASK(7, 5)) >> 5)
 #define REV_ID_REV_MINOR(id) ((id) & GENMASK(4, 0))
 

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3046,7 +3046,7 @@ static void cdns_i3c_read_hw_cfg(const struct device *dev)
 	data->hw_cfg.ddr_rx_mem_depth = CONF_STATUS1_SLV_DDR_RX_DEPTH(cfg1) * 4;
 	data->hw_cfg.ddr_tx_mem_depth = CONF_STATUS1_SLV_DDR_TX_DEPTH(cfg1) * 4;
 	data->hw_cfg.ibir_mem_depth = CONF_STATUS0_IBIR_DEPTH(cfg0) * 4;
-	data->hw_cfg.ibi_mem_depth = CONF_STATUS1_IBI_DEPTH(cfg0) * 4;
+	data->hw_cfg.ibi_mem_depth = CONF_STATUS1_IBI_DEPTH(cfg1) * 4;
 
 	LOG_DBG("%s: FIFO info:\r\n"
 		"  cmd_mem_depth = %u\r\n"

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -289,9 +289,9 @@
 #define SLV_DDR_TX_FIFO             0x88
 #define SLV_DDR_RX_FIFO             0x8c
 #define DDR_PREAMBLE_MASK           GENMASK(19, 18)
-#define DDR_PREAMBLE_CMD_CRC        0x1 << 18
-#define DDR_PREAMBLE_DATA_ABORT     0x2 << 18
-#define DDR_PREAMBLE_DATA_ABORT_ALT 0x3 << 18
+#define DDR_PREAMBLE_CMD_CRC        (0x1 << 18)
+#define DDR_PREAMBLE_DATA_ABORT     (0x2 << 18)
+#define DDR_PREAMBLE_DATA_ABORT_ALT (0x3 << 18)
 #define DDR_DATA(x)                 (((x) & GENMASK(17, 2)) >> 2)
 #define DDR_EVEN_PARITY             BIT(0)
 #define DDR_ODD_PARITY              BIT(1)

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3588,9 +3588,9 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	k_sem_init(&data->ibi_hj_complete, 0, 1);
 #ifdef CONFIG_I3C_CONTROLLER
 	k_sem_init(&data->ibi_cr_complete, 0, 1);
-#endif /* CONFIG_I3C_TARGET */
 #endif /* CONFIG_I3C_CONTROLLER */
-#endif
+#endif /* CONFIG_I3C_TARGET */
+#endif /* CONFIG_I3C_USE_IBI */
 
 	cdns_i3c_interrupts_disable(config);
 	cdns_i3c_interrupts_clear(config);

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -267,7 +267,7 @@
 
 #define CMD1_FIFO            0x64
 #define CMD1_FIFO_CMDID(id)  ((id) << 24)
-#define CMD1_FIFO_DB(db)     (((db) & GENMASK(15, 8)) << 8)
+#define CMD1_FIFO_DB(db)     FIELD_PREP(GENMASK(15, 8), (db))
 #define CMD1_FIFO_CSRADDR(a) (a)
 #define CMD1_FIFO_CCC(id)    (id)
 


### PR DESCRIPTION
Had claude examine these files and found some valid issues

- Fix missing parentheses in `REV_ID_VERSION` macro parameter
- Fix swapped `#endif` comments for `CONFIG_I3C_CONTROLLER`/`CONFIG_I3C_TARGET`
- Fix `CMD1_FIFO_DB` macro always producing zero for byte-sized inputs (wrong mask/shift)
- Fix missing parentheses in DDR preamble macros causing operator precedence issues
- Fix `CONF_STATUS0_IBIR_DEPTH` wrong bit shift (`>>7` should be `>>6`)
- Fix `CONF_STATUS1_IBI_DEPTH` reading wrong register (`cfg0` instead of `cfg1`)
- Fix cancel transfer timeout never detected due to unsigned underflow