### PR TITLE
pm: policy: latency: enhance pm policy latency changed subscribe implementation

### DIFF
--- a/subsys/pm/policy/policy_latency.c
+++ b/subsys/pm/policy/policy_latency.c
@@ -40,7 +40,9 @@ static void update_max_latency(void)
 		int32_t new_max_latency_cyc = -1;
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&latency_subs, sreq, node) {
-			sreq->cb(new_max_latency_us);
+			if (sreq->cb != NULL) {
+				sreq->cb(new_max_latency_us);
+			}
 		}
 
 		if (new_max_latency_us != SYS_FOREVER_US) {
@@ -90,6 +92,13 @@ void pm_policy_latency_changed_subscribe(struct pm_policy_latency_subscription *
 					 pm_policy_latency_changed_cb_t cb)
 {
 	k_spinlock_key_t key = k_spin_lock(&latency_lock);
+
+	if (cb == NULL) {
+		req->cb = NULL;
+		(void)sys_slist_find_and_remove(&latency_subs, &req->node);
+		k_spin_unlock(&latency_lock, key);
+		return;
+	}
 
 	req->cb = cb;
 	sys_slist_append(&latency_subs, &req->node);

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -290,6 +290,26 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	zassert_equal(latency_cb_call_cnt, 1);
 }
 
+ZTEST(policy_api, test_pm_policy_latency_subscribe_null_disables)
+{
+	struct pm_policy_latency_request req;
+	struct pm_policy_latency_subscription sreq;
+
+	pm_policy_latency_changed_subscribe(&sreq, on_pm_policy_latency_changed);
+
+	latency_cb_call_cnt = 0;
+	expected_latency = 10000;
+	pm_policy_latency_request_add(&req, 10000);
+	zassert_equal(latency_cb_call_cnt, 1);
+
+	pm_policy_latency_changed_subscribe(&sreq, NULL);
+
+	latency_cb_call_cnt = 0;
+	expected_latency = SYS_FOREVER_US;
+	pm_policy_latency_request_remove(&req);
+	zassert_equal(latency_cb_call_cnt, 0);
+}
+
 /**
  * @brief Test pm_policy_state_constraints_get/put functions using devicetree
  * test-states property and PM_STATE_CONSTRAINTS macros.
@@ -407,6 +427,11 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 }
 
 ZTEST(policy_api, test_pm_policy_next_state_default_latency)
+{
+	ztest_test_skip();
+}
+
+ZTEST(policy_api, test_pm_policy_latency_subscribe_null_disables)
 {
 	ztest_test_skip();
 }


### PR DESCRIPTION
The comment for the API `pm_policy_latency_changed_subscribe` states: [NULL to disable](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/pm/policy.h#L426), but the function implementation directly saves and subscribes to this node, and subsequently calls it directly without null checking when changes occur. This actually poses a risk of **calling a null function pointer**. This PR fixes this issue to make the function implementation consistent with the API description.