### PR TITLE
drivers: i3c/i2c: rtio: fix NULL CQE dereference

### DIFF
--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -220,8 +220,12 @@ int i2c_rtio_configure(struct i2c_rtio *ctx, uint32_t i2c_config)
 	rtio_submit(r, 1);
 
 	cqe = rtio_cqe_consume(r);
-	res = cqe->result;
-	rtio_cqe_release(r, cqe);
+	if (unlikely(cqe != NULL)) {
+		res = cqe->result;
+		rtio_cqe_release(r, cqe);
+	} else {
+		res = -EIO;
+	}
 
 out:
 	k_sem_give(&ctx->lock);
@@ -252,8 +256,12 @@ int i2c_rtio_recover(struct i2c_rtio *ctx)
 	rtio_submit(r, 1);
 
 	cqe = rtio_cqe_consume(r);
-	res = cqe->result;
-	rtio_cqe_release(r, cqe);
+	if (unlikely(cqe != NULL)) {
+		res = cqe->result;
+		rtio_cqe_release(r, cqe);
+	} else {
+		res = -EIO;
+	}
 
 out:
 	k_sem_give(&ctx->lock);

--- a/drivers/i3c/i3c_rtio.c
+++ b/drivers/i3c/i3c_rtio.c
@@ -186,10 +186,10 @@ int i3c_rtio_configure(struct i3c_rtio *ctx, enum i3c_config_type type, void *co
 	cqe = rtio_cqe_consume(r);
 	if (unlikely(cqe != NULL)) {
 		res = cqe->result;
+		rtio_cqe_release(r, cqe);
 	} else {
 		res = -EIO;
 	}
-	rtio_cqe_release(r, cqe);
 
 out:
 	k_sem_give(&ctx->lock);
@@ -223,10 +223,10 @@ int i3c_rtio_ccc(struct i3c_rtio *ctx, struct i3c_ccc_payload *payload)
 	cqe = rtio_cqe_consume(r);
 	if (unlikely(cqe != NULL)) {
 		res = cqe->result;
+		rtio_cqe_release(r, cqe);
 	} else {
 		res = -EIO;
 	}
-	rtio_cqe_release(r, cqe);
 
 out:
 	k_sem_give(&ctx->lock);
@@ -259,10 +259,10 @@ int i3c_rtio_recover(struct i3c_rtio *ctx)
 	cqe = rtio_cqe_consume(r);
 	if (unlikely(cqe != NULL)) {
 		res = cqe->result;
+		rtio_cqe_release(r, cqe);
 	} else {
 		res = -EIO;
 	}
-	rtio_cqe_release(r, cqe);
 
 out:
 	k_sem_give(&ctx->lock);


### PR DESCRIPTION
- Fix I3C RTIO calling rtio_cqe_release() with NULL cqe when rtio_cqe_consume() fails
- Fix I2C RTIO dereferencing and releasing NULL cqe without any NULL check
- Both now guard with a NULL check, returning -EIO on failure