### PR TITLE
drivers: i3c: ccc: fix RSTDAA R/W bit and setvendor target

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -693,6 +693,7 @@ int i3c_ccc_do_setvendor(const struct i3c_device_desc *target,
 			 size_t len)
 {
 	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
 
 	__ASSERT_NO_MSG(target != NULL);
 
@@ -701,10 +702,15 @@ int i3c_ccc_do_setvendor(const struct i3c_device_desc *target,
 		return -EINVAL;
 	}
 
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 0;
+	ccc_tgt_payload.data = payload;
+	ccc_tgt_payload.data_len = len;
+
 	memset(&ccc_payload, 0, sizeof(ccc_payload));
 	ccc_payload.ccc.id = I3C_CCC_VENDOR(false, id);
-	ccc_payload.ccc.data = payload;
-	ccc_payload.ccc.data_len = len;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
 
 	return i3c_do_ccc(target->bus, &ccc_payload);
 }

--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -146,7 +146,7 @@ int i3c_ccc_do_rstdaa(struct i3c_device_desc *target)
 	__ASSERT_NO_MSG(target->bus != NULL);
 
 	ccc_tgt_payload.addr = target->dynamic_addr;
-	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.rnw = 0;
 	ccc_tgt_payload.data_len = 0;
 
 	memset(&ccc_payload, 0, sizeof(ccc_payload));


### PR DESCRIPTION
- Fix directed RSTDAA using rnw=1 (read) instead of rnw=0 (write) per I3C spec
- Fix i3c_ccc_do_setvendor() sending a direct vendor CCC without the target address payload