### PR TITLE
drivers: pwm: mchp_xec: fix build error, PCR config, and init sequence

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -127,6 +127,13 @@ NXP
   ``zephyr,system-timer`` chosen property, so boards that added the overlay
   described in the Zephyr 4.4 migration guide can remove it.
 
+PWM
+===
+
+* The ``pcrs`` property (array type) of :dtcompatible:`microchip,xec-pwm` has been replaced
+  by ``pcr-scr`` (int type) to use encoded PCR register index and bit position macros
+  (:github:`104570`).
+
 SD Host Controller
 ==================
 

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Intel Corporation
- * Copyright (c) 2022 Microchip Technololgy Inc.
+ * Copyright (c) 2022 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,10 +13,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/pwm.h>
-#ifdef CONFIG_SOC_SERIES_MEC172X
-#include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
-#include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
-#endif
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
@@ -52,8 +48,7 @@ LOG_MODULE_REGISTER(pwm_mchp_xec, CONFIG_PWM_LOG_LEVEL);
 
 struct pwm_xec_config {
 	struct pwm_regs * const regs;
-	uint8_t pcr_idx;
-	uint8_t pcr_pos;
+	uint8_t enc_pcr;
 	const struct pinctrl_dev_config *pcfg;
 };
 
@@ -426,8 +421,11 @@ static DEVICE_API(pwm, pwm_xec_driver_api) = {
 static int pwm_xec_init(const struct device *dev)
 {
 	const struct pwm_xec_config * const cfg = dev->config;
-	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	int ret;
 
+	soc_xec_pcr_sleep_en_clear(cfg->enc_pcr);
+
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret != 0) {
 		LOG_ERR("XEC PWM pinctrl init failed (%d)", ret);
 		return ret;
@@ -439,8 +437,7 @@ static int pwm_xec_init(const struct device *dev)
 #define XEC_PWM_CONFIG(inst)							\
 	static struct pwm_xec_config pwm_xec_config_##inst = {			\
 		.regs = (struct pwm_regs * const)DT_INST_REG_ADDR(inst),	\
-		.pcr_idx = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 0),		\
-		.pcr_pos = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 1),		\
+		.enc_pcr = (uint8_t)DT_INST_PROP(inst, pcr_scr),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
 	};
 

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -391,7 +391,7 @@ static int pwm_xec_pm_action(const struct device *dev, enum pm_device_action act
 
 			data->config &= (~MCHP_PWM_CFG_ENABLE);
 		}
-	break;
+		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 		if ((regs->CONFIG & MCHP_PWM_CFG_ENABLE) == MCHP_PWM_CFG_ENABLE) {
 			/* Do copy first, then clear mode. */
@@ -405,7 +405,7 @@ static int pwm_xec_pm_action(const struct device *dev, enum pm_device_action act
 		if (ret == -ENOENT) {
 			ret = 0;
 		}
-	break;
+		break;
 	default:
 		ret = -ENOTSUP;
 	}

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -394,7 +394,7 @@
 		pwm0: pwm@40005800 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005800 0x20>;
-			pcrs = <1 4>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 4)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -402,7 +402,7 @@
 		pwm1: pwm@40005810 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005810 0x20>;
-			pcrs = <1 20>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 20)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -410,7 +410,7 @@
 		pwm2: pwm@40005820 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005820 0x20>;
-			pcrs = <1 21>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 21)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -418,7 +418,7 @@
 		pwm3: pwm@40005830 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005830 0x20>;
-			pcrs = <1 22>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 22)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -426,7 +426,7 @@
 		pwm4: pwm@40005840 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005840 0x20>;
-			pcrs = <1 23>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 23)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -434,7 +434,7 @@
 		pwm5: pwm@40005850 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005850 0x20>;
-			pcrs = <1 24>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 24)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -442,7 +442,7 @@
 		pwm6: pwm@40005860 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005860 0x20>;
-			pcrs = <1 25>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 25)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -450,7 +450,7 @@
 		pwm7: pwm@40005870 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005870 0x20>;
-			pcrs = <1 26>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 26)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -458,7 +458,7 @@
 		pwm8: pwm@40005880 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005880 0x20>;
-			pcrs = <1 27>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 27)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -575,7 +575,7 @@ ps2_0: ps2@40009000 {
 pwm0: pwm@40005800 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005800 0x20>;
-	pcrs = <1 4>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 4)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -583,7 +583,7 @@ pwm0: pwm@40005800 {
 pwm1: pwm@40005810 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005810 0x20>;
-	pcrs = <1 20>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 20)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -591,7 +591,7 @@ pwm1: pwm@40005810 {
 pwm2: pwm@40005820 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005820 0x20>;
-	pcrs = <1 21>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 21)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -599,7 +599,7 @@ pwm2: pwm@40005820 {
 pwm3: pwm@40005830 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005830 0x20>;
-	pcrs = <1 22>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 22)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -607,7 +607,7 @@ pwm3: pwm@40005830 {
 pwm4: pwm@40005840 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005840 0x20>;
-	pcrs = <1 23>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 23)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -615,7 +615,7 @@ pwm4: pwm@40005840 {
 pwm5: pwm@40005850 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005850 0x20>;
-	pcrs = <1 24>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 24)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -623,7 +623,7 @@ pwm5: pwm@40005850 {
 pwm6: pwm@40005860 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005860 0x20>;
-	pcrs = <1 25>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 25)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -631,7 +631,7 @@ pwm6: pwm@40005860 {
 pwm7: pwm@40005870 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005870 0x20>;
-	pcrs = <1 26>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 26)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };
@@ -639,7 +639,7 @@ pwm7: pwm@40005870 {
 pwm8: pwm@40005880 {
 	compatible = "microchip,xec-pwm";
 	reg = <0x40005880 0x20>;
-	pcrs = <1 27>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 27)>;
 	status = "disabled";
 	#pwm-cells = <3>;
 };

--- a/dts/arm/microchip/mec/mec172xnlj.dtsi
+++ b/dts/arm/microchip/mec/mec172xnlj.dtsi
@@ -70,7 +70,7 @@
 		pwm9: pwm@40005890 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005890 0x20>;
-			pcrs = <3 31>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 31)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -78,7 +78,7 @@
 		pwm10: pwm@400058a0 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x400058a0 0x20>;
-			pcrs = <4 0>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(4, 0)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -86,7 +86,7 @@
 		pwm11: pwm@400058b0 {
 			compatible = "microchip,xec-pwm";
 			reg = <0x400058b0 0x20>;
-			pcrs = <4 1>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(4, 1)>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -11,10 +11,11 @@ properties:
   reg:
     required: true
 
-  pcrs:
-    type: array
+  pcr-scr:
+    type: int
     required: true
-    description: PWM PCR register index and bit position
+    description: |
+      PWM Power Clock Reset(PCR) peripheral index and bit position
 
   "#pwm-cells":
     const: 3

--- a/soc/microchip/mec/common/soc_common.h
+++ b/soc/microchip/mec/common/soc_common.h
@@ -6,7 +6,10 @@
 #ifndef _ZEPHYR_SOC_MICROCHIP_MEC_COMMON_SOC_COMMON_H_
 #define _ZEPHYR_SOC_MICROCHIP_MEC_COMMON_SOC_COMMON_H_
 
-/* common peripheral register defines */
+#ifndef SHLU32
+#define SHLU32(v, n) ((uint32_t)(v) << (n))
+#endif
+
 #include <reg/mec_acpi_ec.h>
 #include <reg/mec_adc.h>
 #include <reg/mec_global_cfg.h>

--- a/tests/drivers/pwm/pwm_api/boards/microchip/mec_assy6941_mec1753_qsz.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};
+
+&pwm1 {
+	compatible = "microchip,xec-pwm";
+	status = "okay";
+	pinctrl-0 = <&pwm1_gpio054>;
+	pinctrl-names = "default";
+
+	/* Encode PCR index/bit */
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 20)>;
+};


### PR DESCRIPTION
This PR fixes build and initialization issues in the Microchip XEC PWM driver:

- Fix build error and refine PCR config in DTS: Update DTS PCR configuration for proper peripheral reset and clock control setup.   This prevents build failures on MEC175x platforms.