### PR TITLE
net: lib: http_server: remove legacy Mbed TLS header inclusion

### DIFF
--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -15,7 +15,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net/http/service.h>
 #include <zephyr/sys/base64.h>
-#include <mbedtls/sha1.h>
 #include <zephyr/net/websocket.h>
 #include <psa/crypto.h>
 


### PR DESCRIPTION
This was a leftover from the previous commit that removed usage of legacy crypto in favor of PSA API.