### PR TITLE
enable watchdog on A53 for imx8mp/m/n evk board

### DIFF
--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
@@ -15,6 +15,10 @@
 	model = "NXP i.MX8MM A53";
 	compatible = "fsl,mimx8mm";
 
+	aliases {
+		watchdog0 = &wdog1;
+	};
+
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
@@ -92,4 +96,8 @@
 		int-gpios = <&gpio1 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";
 	};
+};
+
+&wdog1 {
+	status = "okay";
 };

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
@@ -17,6 +17,7 @@ supported:
   - net
   - gpio
   - i2c
+  - watchdog
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
@@ -15,6 +15,10 @@
 	model = "NXP i.MX8MN A53";
 	compatible = "fsl,mimx8mn";
 
+	aliases {
+		watchdog0 = &wdog1;
+	};
+
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
@@ -92,4 +96,8 @@
 		int-gpios = <&gpio1 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";
 	};
+};
+
+&wdog1 {
+	status = "okay";
 };

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
@@ -17,6 +17,7 @@ supported:
   - net
   - gpio
   - i2c
+  - watchdog
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
@@ -15,6 +15,10 @@
 	model = "NXP i.MX8MP A53";
 	compatible = "fsl,mimx8mp";
 
+	aliases {
+		watchdog0 = &wdog1;
+	};
+
 	chosen {
 		zephyr,canbus = &flexcan1;
 		zephyr,console = &uart4;
@@ -129,5 +133,9 @@
 };
 
 &gpio5 {
+	status = "okay";
+};
+
+&wdog1 {
 	status = "okay";
 };

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - net
   - uart
+  - watchdog
 testing:
   ignore_tags:
     - bluetooth

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys_clock.h>
 #include <fsl_wdog.h>
 
@@ -18,23 +19,31 @@ LOG_MODULE_REGISTER(wdt_mcux_wdog);
 
 #define WDOG_TMOUT_SEC(x)  (((x * 2) / MSEC_PER_SEC) - 1)
 
+#define DEV_CFG(_dev)  ((const struct mcux_wdog_config *)(_dev)->config)
+#define DEV_DATA(_dev) ((struct mcux_wdog_data *)(_dev)->data)
+
 struct mcux_wdog_config {
-	WDOG_Type *base;
+	DEVICE_MMIO_NAMED_ROM(reg);
 	void (*irq_config_func)(const struct device *dev);
 	const struct pinctrl_dev_config *pcfg;
 };
 
 struct mcux_wdog_data {
+	DEVICE_MMIO_NAMED_RAM(reg);
 	wdt_callback_t callback;
 	wdog_config_t wdog_config;
 	bool timeout_valid;
 };
 
+static inline WDOG_Type *get_base_address(const struct device *dev)
+{
+	return (WDOG_Type *)DEVICE_MMIO_NAMED_GET(dev, reg);
+}
+
 static int mcux_wdog_setup(const struct device *dev, uint8_t options)
 {
-	const struct mcux_wdog_config *config = dev->config;
 	struct mcux_wdog_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	if (!data->timeout_valid) {
 		LOG_ERR("No valid timeouts installed");
@@ -68,9 +77,8 @@ static int mcux_wdog_setup(const struct device *dev, uint8_t options)
 
 static int mcux_wdog_disable(const struct device *dev)
 {
-	const struct mcux_wdog_config *config = dev->config;
 	struct mcux_wdog_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	WDOG_Deinit(base);
 	data->timeout_valid = false;
@@ -118,8 +126,7 @@ static int mcux_wdog_install_timeout(const struct device *dev,
 
 static int mcux_wdog_feed(const struct device *dev, int channel_id)
 {
-	const struct mcux_wdog_config *config = dev->config;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	if (channel_id != 0) {
 		LOG_ERR("Invalid channel id");
@@ -134,9 +141,8 @@ static int mcux_wdog_feed(const struct device *dev, int channel_id)
 
 static void mcux_wdog_isr(const struct device *dev)
 {
-	const struct mcux_wdog_config *config = dev->config;
 	struct mcux_wdog_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 	uint32_t flags;
 
 	flags = WDOG_GetStatusFlags(base);
@@ -151,6 +157,9 @@ static int mcux_wdog_init(const struct device *dev)
 {
 	const struct mcux_wdog_config *config = dev->config;
 	int ret;
+
+	/* Map the named MMIO region */
+	DEVICE_MMIO_NAMED_MAP(dev, reg, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
 	config->irq_config_func(dev);
 
@@ -174,7 +183,7 @@ static void mcux_wdog_config_func(const struct device *dev);
 PINCTRL_DT_INST_DEFINE(0);
 
 static const struct mcux_wdog_config mcux_wdog_config = {
-	.base = (WDOG_Type *) DT_INST_REG_ADDR(0),
+	DEVICE_MMIO_NAMED_ROM_INIT(reg, DT_DRV_INST(0)),
 	.irq_config_func = mcux_wdog_config_func,
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -141,6 +141,14 @@
 		status = "disabled";
 	};
 
+	wdog1: wdog@30280000 {
+		compatible = "nxp,imx-wdog";
+		reg = <0x30280000 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 79 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		status = "disabled";
+	};
+
 	gpt1: gpt@302d0000 {
 		compatible = "nxp,imx-gpt";
 		reg = <0x302d0000 DT_SIZE_K(64)>;

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -142,6 +142,14 @@
 		status = "disabled";
 	};
 
+	wdog1: wdog@30280000 {
+		compatible = "nxp,imx-wdog";
+		reg = <0x30280000 0x1000>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 79 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		status = "disabled";
+	};
+
 	gpt1: gpt@302d0000 {
 		compatible = "nxp,imx-gpt";
 		reg = <0x302d0000 DT_SIZE_K(64)>;

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -143,6 +143,14 @@
 			status = "disabled";
 		};
 
+		wdog1: wdog@30280000 {
+			compatible = "nxp,imx-wdog";
+			reg = <0x30280000 0x1000>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 79 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
 		gpt1: gpt@302d0000 {
 			compatible = "nxp,imx-gpt";
 			reg = <0x302d0000 DT_SIZE_K(64)>;


### PR DESCRIPTION
drivers: watchdog: imx_wdog: add MMIO mapping support
dts: arm64: mimx8mp: add watchdog device node
boards: imx8mp_evk: enable watchdog by default
dts: arm64: mimx8mm: add watchdog device node
boards: imx8mm_evk: enable watchdog by default
dts: arm64: mimx8mn: add watchdog device node
boards: imx8mn_evk: enable watchdog by default