### PR TITLE
drivers: crypto: mbedtls_shim: remove legacy code

### DIFF
--- a/drivers/crypto/crypto_mbedtls_shim.c
+++ b/drivers/crypto/crypto_mbedtls_shim.c
@@ -15,12 +15,6 @@
 #include <errno.h>
 #include <zephyr/crypto/crypto.h>
 
-#if !defined(CONFIG_MBEDTLS_CFG_FILE)
-#include "mbedtls/config.h"
-#else
-#include CONFIG_MBEDTLS_CFG_FILE
-#endif /* CONFIG_MBEDTLS_CFG_FILE */
-
 #include <psa/crypto.h>
 
 #define MBEDTLS_SUPPORT (CAP_RAW_KEY | CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS | \
@@ -28,7 +22,7 @@
 
 #define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mbedtls);
+LOG_MODULE_REGISTER(mbedtls_shim);
 
 struct mbedtls_shim_session {
 	union {
@@ -45,12 +39,6 @@ struct mbedtls_shim_session {
 struct mbedtls_shim_session mbedtls_sessions[CRYPTO_MAX_SESSION];
 
 static K_MUTEX_DEFINE(mbedtls_sessions_lock);
-
-#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-#include "mbedtls/memory_buffer_alloc.h"
-#else
-#error "You need to define MBEDTLS_MEMORY_BUFFER_ALLOC_C"
-#endif /* MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
 static struct mbedtls_shim_session *mbedtls_get_unused_session(void)
 {


### PR DESCRIPTION
Remove inclusions that date back to the original addition of this driver and that are no more required when PSA API is used.