### PR TITLE
logging: Fix logging in PRE_KERNEL with thread id prefix

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -46,7 +46,7 @@ void z_log_msg_finalize(struct log_msg *msg, const void *source,
 	msg->hdr.desc = desc;
 	msg->hdr.source = source;
 #if CONFIG_LOG_THREAD_ID_PREFIX
-	msg->hdr.tid = k_is_in_isr() ? NULL : k_current_get();
+	msg->hdr.tid = (k_is_in_isr() || k_is_pre_kernel()) ? NULL : k_current_get();
 #endif
 	z_log_msg_commit(msg);
 }


### PR DESCRIPTION
Logging a message in PRE_KERNEL with CONFIG_LOG_THREAD_ID_PREFIX=y triggers a assert in k_current_get() because the current thread is not yet available.