### PR TITLE
Add bt hci driver for Realtek Bee family SoCs

### DIFF
--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
@@ -14,6 +14,7 @@
 		zephyr,itcm = &tcm1;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,bt-hci = &bee_bt_hci;
 	};
 
 	aliases {
@@ -63,4 +64,8 @@
 
 &cpu {
 	clock-frequency = <40000000>;
+};
+
+&bee_bt_hci {
+	status = "okay";
 };

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - uart
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - uart
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - uart
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - uart
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/drivers/bluetooth/hci/CMakeLists.txt
+++ b/drivers/bluetooth/hci/CMakeLists.txt
@@ -33,6 +33,7 @@ endif() # CONFIG_BUILD_ONLY_NO_BLOBS
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_BT_AMBIQ_HCI hci_ambiq.c apollox_blue.c)
+zephyr_library_sources_ifdef(CONFIG_BT_BEE hci_bee.c)
 zephyr_library_sources_ifdef(CONFIG_BT_CYW208XX hci_infineon_cyw208xx.c)
 zephyr_library_sources_ifdef(CONFIG_BT_DA1453X hci_da1453x.c)
 zephyr_library_sources_ifdef(CONFIG_BT_DA1469X hci_da1469x.c)

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -272,6 +272,7 @@ source "drivers/bluetooth/hci/Kconfig.infineon"
 source "drivers/bluetooth/hci/Kconfig.nxp"
 source "drivers/bluetooth/hci/Kconfig.stm32"
 source "drivers/bluetooth/hci/Kconfig.silabs"
+source "drivers/bluetooth/hci/Kconfig.bee"
 
 config BT_DRIVER_QUIRK_NO_AUTO_DLE
 	bool "Host auto-initiated Data Length Update quirk"

--- a/drivers/bluetooth/hci/Kconfig.bee
+++ b/drivers/bluetooth/hci/Kconfig.bee
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config BT_BEE
+	bool "Realtek Bee series BT HCI driver"
+	default y
+	depends on DT_HAS_REALTEK_BEE_BT_HCI_ENABLED
+	select HAL_REALTEK_BEE_BT
+	help
+	  This option enables the bt hci driver for Realtek Bee SoCs.
+
+if BT_BEE
+
+config BT_BEE_HCI_H2C_POOL_SIZE
+	int "HCI h2c pool size"
+	default 3072
+	help
+	  HCI H2C POOL is used by HCI command packets and
+	  HCI ACL data packets. Set this value according max
+	  LE ACL data packets num and max HCI command packets num.
+
+endif # BT_BEE

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/drivers/bluetooth.h>
+#include <zephyr/logging/log.h>
+
+#include "rtl_bt_hci.h"
+
+LOG_MODULE_REGISTER(bt_driver, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
+#define DT_DRV_COMPAT realtek_bee_bt_hci
+
+/* Min 20 required by BT controller. Set to 40 for margin. */
+#define BT_BEE_RX_BUF_COUNT 40
+
+struct k_thread rx_thread_data;
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
+
+struct rtl_bt_rx_buf {
+	intptr_t _unused;
+	uint8_t *buf;
+	uint32_t len;
+};
+
+K_MEM_SLAB_DEFINE(rx_slab, sizeof(struct rtl_bt_rx_buf), BT_BEE_RX_BUF_COUNT, 4);
+
+static struct {
+	struct k_fifo fifo;
+} rx = {
+	.fifo = Z_FIFO_INITIALIZER(rx.fifo),
+};
+
+struct bt_bee_data {
+	bt_hci_recv_t recv;
+};
+
+static bool bt_hci_bee_check_hci_event_discardable(const uint8_t *event_data)
+{
+	uint8_t event_type = event_data[0];
+
+	switch (event_type) {
+#if defined(CONFIG_BT_CLASSIC)
+	case BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI:
+	case BT_HCI_EVT_EXTENDED_INQUIRY_RESULT:
+		return true;
+#endif
+	case BT_HCI_EVT_LE_META_EVENT: {
+		uint8_t sub_event_type = event_data[sizeof(struct bt_hci_evt_hdr)];
+
+		switch (sub_event_type) {
+		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
+			return true;
+		default:
+			return false;
+		}
+	}
+	default:
+		return false;
+	}
+}
+
+static bool bt_hci_bee_recv_cb(T_RTL_BT_HCI_EVT evt, bool status, uint8_t *buf, uint32_t len)
+{
+	int ret = 0;
+
+	LOG_DBG("evt %u status %u, type %u, len %u", evt, status, buf[0], len);
+	switch (evt) {
+	case BT_HCI_EVT_OPENED: {
+		LOG_DBG("BT_HCI_EVT_OPENED");
+		if (status == false) {
+			ret = -EXDEV;
+		}
+	} break;
+
+	case BT_HCI_EVT_DATA_IND: {
+		struct rtl_bt_rx_buf *rx_buf;
+		int err;
+
+		err = k_mem_slab_alloc(&rx_slab, (void **)&rx_buf, K_NO_WAIT);
+		if (err == 0) {
+			rx_buf->buf = buf;
+			rx_buf->len = len;
+			k_fifo_put(&rx.fifo, rx_buf);
+			break;
+		}
+		LOG_ERR("Failed to alloc RX slab, err: %d", err);
+		rtl_bt_hci_ack(buf);
+	} break;
+
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	if (ret != 0) {
+		LOG_ERR("Error, evt %u status %u, type %u, len %u, ret %d", evt, status, buf[0],
+			len, ret);
+		return false;
+	}
+
+	return true;
+}
+
+void bt_hci_bee_handle_rx_data(const struct device *dev, struct rtl_bt_rx_buf *rx_buf)
+{
+	struct bt_bee_data *hci = dev->data;
+	struct net_buf *z_buf = NULL;
+	size_t buf_tailroom;
+
+	/* First byte is packet type */
+	switch (rx_buf->buf[0]) {
+	case H4_EVT: {
+		bool discardable = false;
+		struct bt_hci_evt_hdr hdr;
+
+		memcpy((void *)&hdr, &rx_buf->buf[1], sizeof(hdr));
+
+		discardable = bt_hci_bee_check_hci_event_discardable(&rx_buf->buf[1]);
+
+		z_buf = bt_buf_get_evt(hdr.evt, discardable, K_NO_WAIT);
+		if (z_buf != NULL) {
+			buf_tailroom = net_buf_tailroom(z_buf);
+
+			if (buf_tailroom >= (hdr.len + sizeof(hdr))) {
+				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
+				LOG_DBG("H4_EVT: event 0x%x", hdr.evt);
+				hci->recv(dev, z_buf);
+				break;
+			}
+			net_buf_unref(z_buf);
+		}
+		LOG_ERR("H4_EVT: event 0x%x, len %d, alloc failed", hdr.evt, hdr.len);
+	} break;
+
+	case H4_ACL: {
+		struct bt_hci_acl_hdr hdr;
+
+		memcpy((void *)&hdr, &rx_buf->buf[1], sizeof(hdr));
+
+		z_buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_NO_WAIT);
+		if (z_buf != NULL) {
+			buf_tailroom = net_buf_tailroom(z_buf);
+			if (buf_tailroom >= (hdr.len + sizeof(hdr))) {
+				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
+				LOG_DBG("H4_ACL: handle 0x%x, Calling bt_recv(%p)", hdr.handle,
+					z_buf);
+				hci->recv(dev, z_buf);
+				break;
+			}
+			net_buf_unref(z_buf);
+		}
+		LOG_ERR("H4_ACL: handle 0x%x, len %d, alloc failed", hdr.handle, hdr.len);
+	} break;
+
+	case H4_ISO: {
+		struct bt_hci_iso_hdr hdr;
+
+		memcpy((void *)&hdr, &rx_buf->buf[1], sizeof(hdr));
+
+		z_buf = bt_buf_get_rx(BT_BUF_ISO_IN, K_NO_WAIT);
+		if (z_buf != NULL) {
+			buf_tailroom = net_buf_tailroom(z_buf);
+			if (buf_tailroom >= (hdr.len + sizeof(hdr))) {
+				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
+				LOG_DBG("H4_ISO: handle 0x%x, Calling bt_recv(%p)", hdr.handle,
+					z_buf);
+				hci->recv(dev, z_buf);
+				break;
+			}
+			net_buf_unref(z_buf);
+		}
+		LOG_ERR("H4_ISO: handle 0x%x, len %d, alloc failed", hdr.handle, hdr.len);
+	} break;
+
+	default:
+		LOG_ERR("rtl_rx_thread: invalid type %d", rx_buf->buf[0]);
+		break;
+	}
+	rtl_bt_hci_ack(rx_buf->buf);
+	k_mem_slab_free(&rx_slab, rx_buf);
+}
+
+static void rtl_rx_thread(void *p1, void *p2, void *p3)
+{
+	struct rtl_bt_rx_buf *rx_buf;
+	const struct device *dev = (const struct device *)p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (1) {
+		rx_buf = k_fifo_get(&rx.fifo, K_FOREVER);
+		do {
+			bt_hci_bee_handle_rx_data(dev, rx_buf);
+
+			/* Give other threads a chance to run if the ISR
+			 * is receiving data so fast that rx.fifo never
+			 * or very rarely goes empty.
+			 */
+			k_yield();
+
+			rx_buf = k_fifo_get(&rx.fifo, K_NO_WAIT);
+		} while (rx_buf);
+	}
+}
+
+static int bt_hci_bee_send(const struct device *dev, struct net_buf *buf)
+{
+	int ret = 0;
+	T_RTL_BT_HCI_BUF hci_buf = {};
+	uint8_t packet_type = net_buf_pull_u8(buf);
+
+	switch (packet_type) {
+	case BT_HCI_H4_ACL:
+	case BT_HCI_H4_CMD:
+	case BT_HCI_H4_ISO:
+		break;
+
+	default:
+		LOG_ERR("Unknown packet type: 0x%02x", packet_type);
+		ret = -EINVAL;
+		goto done;
+	}
+
+	if (rtl_bt_hci_h2c_buf_alloc(&hci_buf, packet_type, buf->len) == false) {
+		ret = -EINVAL;
+		goto done;
+	}
+
+	if (rtl_bt_hci_h2c_buf_add(&hci_buf, buf->data, buf->len) == false) {
+		rtl_bt_hci_h2c_buf_rel(hci_buf);
+		ret = -EINVAL;
+		goto done;
+	}
+
+	if (rtl_bt_hci_send(hci_buf) == false) {
+		rtl_bt_hci_h2c_buf_rel(hci_buf);
+		ret = -EIO;
+	}
+
+done:
+	net_buf_unref(buf);
+	if (ret != 0) {
+		LOG_ERR("Error, type %d, len %u, ret %d", packet_type, buf->len, ret);
+	} else {
+		LOG_DBG("Sent, type %d, len %u", packet_type, buf->len);
+	}
+
+	return ret;
+}
+
+static int bt_hci_bee_open(const struct device *dev, bt_hci_recv_t recv)
+{
+	k_tid_t tid;
+
+	tid = k_thread_create(&rx_thread_data, rx_thread_stack,
+			      K_KERNEL_STACK_SIZEOF(rx_thread_stack), rtl_rx_thread, (void *)dev,
+			      NULL, NULL, 0, 0, K_NO_WAIT);
+	k_thread_name_set(tid, "rtl_rx_thread");
+
+	struct bt_bee_data *hci = dev->data;
+
+	if (rtl_bt_hci_h2c_pool_init(CONFIG_BT_BEE_HCI_H2C_POOL_SIZE)) {
+		if (rtl_bt_hci_open(bt_hci_bee_recv_cb)) {
+			hci->recv = recv;
+			LOG_DBG("Bee BT started");
+			return 0;
+		}
+	}
+	return -EINVAL;
+}
+
+static int bt_hci_bee_close(const struct device *dev)
+{
+	struct bt_bee_data *hci = dev->data;
+
+	hci->recv = NULL;
+
+	LOG_DBG("Bee BT stopped");
+
+	return 0;
+}
+
+static const struct bt_hci_driver_api drv = {
+	.open = bt_hci_bee_open,
+	.send = bt_hci_bee_send,
+	.close = bt_hci_bee_close,
+};
+
+#define BT_HCI_BEE_DEVICE_INIT(inst)                                                               \
+	static struct bt_bee_data bt_bee_data_##inst = {};                                         \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_bee_data_##inst, NULL, POST_KERNEL,            \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+
+/* Only one instance supported */
+BT_HCI_BEE_DEVICE_INIT(0)

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -100,6 +100,11 @@
 		};
 	};
 
+	bee_bt_hci: bee_bt_hci {
+		compatible = "realtek,bee-bt-hci";
+		status = "disabled";
+	};
+
 	soc {
 		fmc: flash-controller@40022000 {
 			compatible = "realtek,rtl87x2g-flash-controller";

--- a/dts/bindings/bluetooth/realtek,bee-bt-hci.yaml
+++ b/dts/bindings/bluetooth/realtek,bee-bt-hci.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Bluetooth HCI for Realtek Bee SoCs
+
+compatible: "realtek,bee-bt-hci"
+
+include: bt-hci.yaml
+
+properties:
+  bt-hci-name:
+    default: "BT BEE"
+  bt-hci-bus:
+    default: "virtual"

--- a/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
@@ -35,6 +35,15 @@ if BT
 config NUM_METAIRQ_PRIORITIES
 	default 1
 
-endif
+config MAIN_STACK_SIZE
+	default 2048
+
+config BT_BUF_ACL_TX_COUNT
+	default 10
+
+config BT_BUF_EVT_RX_COUNT
+	default 16
+
+endif # BT
 
 endif # SOC_SERIES_RTL87X2G


### PR DESCRIPTION
### Overview

This PR adds the Bluetooth HCI driver implementation for Realtek Bee family SoCs and enables Bluetooth support for the realtek `rtl87x2g` SoC series.

**Changes:**

1.  **Driver Implementation (`drivers/bluetooth/hci/hci_bee.c`):**
    *   Implements the HCI H4 transport layer for the Realtek Bee Famliy.

2.  **SoC Integration:**
    *   Defines the HCI node in the `rtl87x2g` device tree.
    *   Adjusts stack sizes and buffer counts in Kconfig to support Bluetooth operations.

### Testing

Verified on **RTL87x2G Model A EVB** using the `samples/bluetooth/peripheral` sample.

*   **Board:** `rtl87x2g_evb_a/rtl8762gku`
*   **Sample:** `zephyr/samples/bluetooth/peripheral`

#### Build Logs

```
-- Configuring done
-- Generating done
-- Build files have been written to: C:/ACODE/upstream/zephyr/samples/bluetooth/peripheral/build

[1/175] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.3.99 (C:/ACODE/upstream/zephyr), build: v4.3.0-6888-g78c5416ff048
[18/18] Linking C executable zephyr\zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      135816 B       828 KB     16.02%
             RAM:       38269 B       100 KB     37.37%
            ITCM:        2292 B       104 KB      2.15%
          EXTRAM:          0 GB        16 KB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from C:/ACODE/upstream/zephyr/samples/bluetooth/peripheral/build/zephyr/zephyr.elf for board: rtl87x2g_evb_a/rtl8762gku
```

**Results:**
- [x] System Boot
- [x] HCI Transport Initialization (`BT BEE`)
- [x] Controller Version Check (`HCI: version 5.3`)
- [x] Advertising Start
- [x] Connection Establishment
- [x] Pairing/Bonding (Passkey entry successful)

#### SoC Logs

```text
*** Booting Zephyr OS build v4.3.0-6888-g78c5416ff048 ***
[00:00:00.171,906] <inf> bt_hci_core: No ID address. App must call settings_load()
Bluetooth initialized
[00:00:00.173,156] <wrn> bt_hci_core: Unable to store name
[00:00:00.177,093] <inf> bt_hci_core: HCI transport: BT BEE
[00:00:00.177,750] <inf> bt_hci_core: Identity: 25:63:87:4C:E0:00 (public)
[00:00:00.177,906] <inf> bt_hci_core: HCI: version 5.3 (0x0c) revision 0x0010, manufacturer 0x005d
[00:00:00.177,968] <inf> bt_hci_core: LMP: version 5.3 (0x0c) subver 0x8762
[00:00:00.178,218] <err> bt_settings: Failed to save ID (err -2)
Advertising successfully started
Indicate VND attr 0x4048b8c (UUID 12345678-1234-5678-1234-56789abcdef1)
Updated MTU: TX: 23 RX: 23 bytes
Connected
Passkey for 67:38:38:E6:3F:36 (random): 698583
[00:00:30.341,406] <err> bt_gatt: Failed to store CCCs (err -2)
[00:00:30.347,375] <err> bt_keys: Failed to save keys (err -2)
[00:00:30.347,718] <err> bt_gatt: Failed to store CCCs (err -2)
[00:00:30.347,937] <err> bt_gatt: Failed to store Client Features (err -2)
```

### Known Issues

Storage Errors: The logs show Failed to save ... (err -2) messages regarding settings and keys. This is expected as the Flash driver for this platform are not yet implemented (will be added in a future PR). The successful pairing process confirms that the HCI driver itself is functioning correctly despite the storage errors.