### PR TITLE
drivers: eeprom: microchip: mec: common eeprom driver

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -446,6 +446,8 @@ EEPROM
 * Added :c:func:`eeprom_target_read_data()` and :c:func:`eeprom_target_write_data()` which takes an
   offset and length and deprecated :c:func:`eeprom_target_program()` for the I2C EEPROM target driver.
 
+* Updated :dtcompatible:`microchip,xec-eeprom` for PCR and GIRQ properties to use new macros (:github:`104591`).
+
 ESP32-S3
 ========
 

--- a/dts/arm/microchip/mec/mec172xnlj.dtsi
+++ b/dts/arm/microchip/mec/mec172xnlj.dtsi
@@ -62,8 +62,8 @@
 			reg = <0x40002c00 0x400>;
 			interrupts = <155 2>;
 			size = <8192>;
-			girqs = <18 13>;
-			pcrs = <4 14>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(18, 13)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(4, 14)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/microchip/mec/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec/mec172xnsz.dtsi
@@ -62,8 +62,8 @@
 			reg = <0x40002c00 0x400>;
 			interrupts = <155 2>;
 			size = <2048>;
-			girqs = <18 13>;
-			pcrs = <4 14>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(18, 13)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(4, 14)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
@@ -1226,12 +1226,20 @@
 		pinmux = <MCHP_XEC_PINMUX(0251, MCHP_AF1)>;
 	};
 
+	/omit-if-no-ref/ pspi_sdo_gpio251: pspi_sdo_gpio251 {
+		pinmux = <MCHP_XEC_PINMUX(0251, MCHP_AF2)>;
+	};
+
 	/omit-if-no-ref/ spi0_int_sdo_gpio251: spi0_int_sdo_gpio251 {
 		pinmux = <MCHP_XEC_PINMUX(0251, MCHP_AF3)>;
 	};
 
-	/omit-if-no-ref/ spi0_int_io1_gpio252: spi0_int_io1_gpio252 {
+	/omit-if-no-ref/ int_spi_io1_gpio252: int_spi_io1_gpio252 {
 		pinmux = <MCHP_XEC_PINMUX(0252, MCHP_AF1)>;
+	};
+
+	/omit-if-no-ref/ pspi_sdi_gpio252: pspi_sdi_gpio252 {
+		pinmux = <MCHP_XEC_PINMUX(0252, MCHP_AF2)>;
 	};
 
 	/omit-if-no-ref/ spi0_int_sdi_gpio252: spi0_int_sdi_gpio252 {
@@ -1250,12 +1258,20 @@
 		pinmux = <MCHP_XEC_PINMUX(0256, MCHP_AF1)>;
 	};
 
+	/omit-if-no-ref/ pspi_cs_n_gpio256: pspi_cs_n_gpio256 {
+		pinmux = <MCHP_XEC_PINMUX(0256, MCHP_AF2)>;
+	};
+
 	/omit-if-no-ref/ spi0_int_cs_n_gpio256: spi0_int_cs_n_gpio256 {
 		pinmux = <MCHP_XEC_PINMUX(0256, MCHP_AF3)>;
 	};
 
 	/omit-if-no-ref/ int_spi_clk_gpio257: int_spi_clk_gpio257 {
 		pinmux = <MCHP_XEC_PINMUX(0257, MCHP_AF1)>;
+	};
+
+	/omit-if-no-ref/ pspi_clk_gpio257: pspi_clk_gpio257 {
+		pinmux = <MCHP_XEC_PINMUX(0257, MCHP_AF2)>;
 	};
 
 	/omit-if-no-ref/ spi0_int_clk_gpio257: spi0_int_clk_gpio257 {

--- a/dts/arm/microchip/mec/mec5/mec5_eeprom_8kb.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5_eeprom_8kb.dtsi
@@ -6,8 +6,11 @@
 
 /* MEC5 EEPROM controller with internal 8 kilobyte EEPROM */
 eeprom: eeprom@40002c00 {
+	compatible = "microchip,xec-eeprom";
 	reg = <0x40002c00 0x400>;
 	interrupts = <155 2>;
 	size = <8192>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(18, 13)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(4, 14)>;
 	status = "disabled";
 };

--- a/dts/bindings/mtd/microchip,xec-eeprom.yaml
+++ b/dts/bindings/mtd/microchip,xec-eeprom.yaml
@@ -5,20 +5,16 @@ description: Microchip on-chip EEPROM
 
 compatible: "microchip,xec-eeprom"
 
-include: [eeprom-base.yaml, pinctrl-device.yaml]
+include:
+  - name: eeprom-base.yaml
+  - name: pinctrl-device.yaml
+  - name: microchip,dmec-ecia-girq.yaml
 
 properties:
   reg:
     required: true
 
-  girqs:
-    type: array
+  pcr-scr:
+    type: int
     required: true
-    description: |
-      Array of GIRQ and bit position pairs for each interrupt
-      signal the block generates.
-
-  pcrs:
-    type: array
-    required: true
-    description: PS2 PCR register index and bit position
+    description: EEPROM PCR register index and bit position

--- a/samples/drivers/eeprom/boards/mec_assy6941_mec1653b_nsz.overlay
+++ b/samples/drivers/eeprom/boards/mec_assy6941_mec1653b_nsz.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* mec_assy6941 EVB with MEC1653B-NSZ daughter card
+ * MEC1653B has internal 8KB EEPROM and controller.
+ * Internal pins are disabled to reduce leakage.
+ */
+
+/ {
+	aliases {
+		eeprom-0 = &eeprom;
+	};
+};
+
+&eeprom {
+	status = "okay";
+	pinctrl-0 = <&pspi_cs_n_gpio256
+		     &pspi_clk_gpio257
+		     &pspi_sdi_gpio252
+		     &pspi_sdo_gpio251>;
+	pinctrl-names = "default";
+};

--- a/samples/drivers/eeprom/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/samples/drivers/eeprom/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* mec_assy6941 EVB with MEC1753Q-SZ daughter card
+ * MEC1753 has internal 8KB EEPROM and controller.
+ * Internal pins are disabled to reduce leakage.
+ */
+
+/ {
+	aliases {
+		eeprom-0 = &eeprom;
+	};
+};
+
+&eeprom {
+	status = "okay";
+	pinctrl-0 = <&pspi_cs_n_gpio256
+		     &pspi_clk_gpio257
+		     &pspi_sdi_gpio252
+		     &pspi_sdo_gpio251>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
Updated EEPROM dts for PCR and GIRQ property.
Updated pinctrl to access internal EEPROM for MEC5 part.