### PR TITLE
net: lib: coap: client: Add multicast stream support

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -51,6 +51,19 @@ struct coap_client_response_data {
 	size_t payload_len;
 	/** Indicates the last block of the response. */
 	bool last_block;
+#if defined(CONFIG_COAP_CLIENT_MULTICAST) || defined(__DOXYGEN__)
+	/**
+	 * Source address of the response.
+	 * @kconfig_dep{CONFIG_COAP_CLIENT_MULTICAST}
+	 */
+	const struct net_sockaddr *source;
+
+	/**
+	 * Source address length of the response.
+	 * @kconfig_dep{CONFIG_COAP_CLIENT_MULTICAST}
+	 */
+	net_socklen_t source_len;
+#endif
 };
 
 /**
@@ -61,6 +74,11 @@ struct coap_client_response_data {
  * It is used to indicate errors, response codes from server or to deliver payload.
  * Blockwise transfers cause this callback to be called sequentially with increasing payload offset
  * and only partial content in buffer pointed by payload parameter.
+ *
+ * For multicast requests the callback is invoked once per responding server with
+ * @p source set to the unicast source address of that server. When the collection window
+ * expires, the callback is invoked one final time with @p source set to @c NULL to
+ * signal that no further responses will be delivered for this request.
  *
  * @param data The CoAP response data.
  * @param user_data User provided context.
@@ -139,6 +157,18 @@ struct coap_client_request {
 		options[MAX_EXTRA_OPTIONS];       /**< Extra options to be added to request */
 	uint8_t num_options;                      /**< Number of extra options */
 	void *user_data;                          /**< User provided context */
+#if defined(CONFIG_COAP_CLIENT_MULTICAST) || defined(__DOXYGEN__)
+	/**
+	 * Multicast response timeout in milliseconds. When > 0, indicates a multicast
+	 * request that accepts multiple responses within the timeout period. After the
+	 * timeout, a final callback with source=NULL signals completion, after which
+	 * no further callbacks will be issued. Multicast requests are always
+	 * non-confirmable (RFC 7252).
+	 *
+	 * @kconfig_dep{CONFIG_COAP_CLIENT_MULTICAST}
+	 */
+	uint32_t multicast_timeout_ms;
+#endif
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -163,6 +193,10 @@ struct coap_client_internal_request {
 	/* For GETs with observe option set */
 	bool is_observe;
 	int last_response_id;
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	bool is_mcast;
+	k_timepoint_t mcast_timeout;
+#endif
 };
 /** @endcond */
 

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -170,6 +170,15 @@ config COAP_CLIENT_TRUNCATE_MSGS
 	  receive network stack notifications about block truncation.
 	  Otherwise it happens silently.
 
+config COAP_CLIENT_MULTICAST
+	bool "CoAP client multicast support"
+	help
+	  Enable multicast request support for the CoAP client. When enabled,
+	  requests can specify a multicast_timeout_ms to receive multiple
+	  responses from different servers within a timeout period.
+
+	  Per RFC 7252, multicast requests are always non-confirmable.
+
 endif # COAP_CLIENT
 
 config COAP_SERVER

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -449,9 +449,15 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 		switch (addr->sa_family) {
 		case NET_AF_INET:
 			internal_req->addrlen = sizeof(struct net_sockaddr_in);
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+			internal_req->is_mcast = net_ipv4_is_addr_mcast(&net_sin(addr)->sin_addr);
+#endif
 			break;
 		case NET_AF_INET6:
 			internal_req->addrlen = sizeof(struct net_sockaddr_in6);
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+			internal_req->is_mcast = net_ipv6_is_addr_mcast(&net_sin6(addr)->sin6_addr);
+#endif
 			break;
 		default:
 			ret = -ENOTSUP;
@@ -460,6 +466,24 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 
 		memcpy(&internal_req->addr, addr, internal_req->addrlen);
 	}
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast) {
+		if (req->confirmable) {
+			LOG_ERR("Multicast requests must be non-confirmable");
+			ret = -EINVAL;
+			goto release;
+		}
+
+		internal_req->mcast_timeout = sys_timepoint_calc(K_MSEC(req->multicast_timeout_ms));
+	} else {
+		if (req->multicast_timeout_ms > 0) {
+			LOG_ERR("Multicast timeout not supported for unicast");
+			ret = -EINVAL;
+			goto release;
+		}
+	}
+#endif
 
 	ret = coap_client_init_request(client, req, internal_req);
 	if (ret < 0) {
@@ -495,6 +519,15 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 	}
 	coap_pending_cycle(&internal_req->pending);
 	internal_req->is_observe = coap_request_is_observe(&internal_req->request);
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_observe && internal_req->is_mcast) {
+		LOG_ERR("Multicast requests can't observe");
+		ret = -EINVAL;
+		goto release;
+	}
+#endif
+
 	LOG_DBG("Request is_observe %d", internal_req->is_observe);
 
 	ret = send_request(sock, internal_req->request.data, internal_req->request.offset, 0,
@@ -534,8 +567,30 @@ static void report_callback_error(struct coap_client_internal_request *internal_
 	}
 }
 
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+static void report_multicast_complete(struct coap_client_internal_request *internal_req)
+{
+	if (internal_req->coap_request.cb != NULL &&
+	    !atomic_set(&internal_req->in_callback, 1)) {
+		const struct coap_client_response_data resp_data = {
+			.source = NULL,
+		};
+
+		internal_req->coap_request.cb(&resp_data, internal_req->coap_request.user_data);
+		atomic_clear(&internal_req->in_callback);
+	}
+}
+#endif
+
 static bool timeout_expired(const struct coap_client_internal_request *internal_req)
 {
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast && internal_req->request_ongoing &&
+	    sys_timepoint_expired(internal_req->mcast_timeout)) {
+		return true;
+	}
+#endif
+
 	if (internal_req->pending.timeout == 0) {
 		return false;
 	}
@@ -585,16 +640,26 @@ static void coap_client_resend_handler(struct coap_client *client)
 	k_mutex_lock(&client->lock, K_FOREVER);
 
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
-		if (timeout_expired(&client->requests[i])) {
-			if (!client->requests[i].coap_request.confirmable) {
-				release_internal_request(&client->requests[i]);
+		struct coap_client_internal_request *internal_req = &client->requests[i];
+
+		if (timeout_expired(internal_req)) {
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+			if (internal_req->is_mcast) {
+				report_multicast_complete(internal_req);
+				release_internal_request(internal_req);
+				continue;
+			}
+#endif
+
+			if (!internal_req->coap_request.confirmable) {
+				release_internal_request(internal_req);
 				continue;
 			}
 
-			ret = resend_request(client, &client->requests[i]);
+			ret = resend_request(client, internal_req);
 			if (ret < 0) {
-				report_callback_error(&client->requests[i], ret);
-				release_internal_request(&client->requests[i]);
+				report_callback_error(internal_req, ret);
+				release_internal_request(internal_req);
 			}
 		}
 	}
@@ -867,8 +932,12 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	if (payload_len == 0 && response_type == COAP_TYPE_ACK &&
 	    response_code == COAP_CODE_EMPTY) {
 		internal_req = get_request_with_mid(client, response_id);
-		if (!internal_req) {
+		if (internal_req == NULL) {
 			LOG_WRN("No matching request for ACK");
+			return 0;
+		}
+		if (!internal_req->coap_request.confirmable) {
+			LOG_WRN("Unexpected ACK for non-confirmable request");
 			return 0;
 		}
 		internal_req->pending.t0 = k_uptime_get();
@@ -938,6 +1007,15 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 
 	/* Send ack for CON */
 	if (response_type == COAP_TYPE_CON) {
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+		if (internal_req->is_mcast) {
+			/* RFC 7252 Section 8.2: Responses to multicast requests MUST NOT be
+			 * Confirmable. Drop the invalid response.
+			 */
+			LOG_WRN("Dropping CON response to multicast request (RFC 7252 violation)");
+			return 0;
+		}
+#endif
 		/* CON response is always a separate response, respond with empty ACK. */
 		ret = send_ack(client->fd, addr, addrlen, response, COAP_CODE_EMPTY);
 		if (ret < 0) {
@@ -946,7 +1024,8 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	}
 
 	/* MID-based deduplication */
-	if (response_id == internal_req->last_response_id) {
+	if (response_id == internal_req->last_response_id &&
+	    COND_CODE_1(CONFIG_COAP_CLIENT_MULTICAST, (!internal_req->is_mcast), (true))) {
 		LOG_WRN("Duplicate MID, dropping");
 		return 0;
 	}
@@ -965,6 +1044,22 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 	if (internal_req->pending.timeout != 0) {
 		coap_pending_clear(&internal_req->pending);
 	}
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast) {
+		/* RFC 7959 Section 2.8: Block-wise transfers are not defined for use with IP
+		 * multicast. Drop any response that carries Block1/Block2 options or is
+		 * truncated (which would otherwise trigger blockwise receive logic).
+		 */
+		if (coap_get_option_int(response, COAP_OPTION_BLOCK2) > 0 ||
+		    coap_get_option_int(response, COAP_OPTION_BLOCK1) > 0 ||
+		    response_truncated) {
+			LOG_WRN("Dropping blockwise response in multicast mode (RFC 7959 "
+				"violation)");
+			return 0;
+		}
+	}
+#endif
 
 	/* Check if block2 exists */
 	block_option = coap_get_option_int(response, COAP_OPTION_BLOCK2);
@@ -1029,6 +1124,10 @@ static int handle_response(struct coap_client *client, const struct net_sockaddr
 				.payload = payload,
 				.payload_len = payload_len,
 				.last_block = last_block,
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+				.source = addr,
+				.source_len = addrlen,
+#endif
 			};
 
 			internal_req->coap_request.cb(&resp_data,
@@ -1077,17 +1176,29 @@ fail:
 	if (ret < 0) {
 		report_callback_error(internal_req, ret);
 	}
-	if (!internal_req->is_observe) {
-		if (response_type == COAP_TYPE_ACK) {
-			/* This is piggybacked ACK,
-			 * no need to wait for lifetime to expire, all data is already transferred
-			 * and acknowledged
-			 */
-			reset_internal_request(internal_req);
-		} else {
-			release_internal_request(internal_req);
-		}
+
+#if defined(CONFIG_COAP_CLIENT_MULTICAST)
+	if (internal_req->is_mcast) {
+		/* Multicast: keep request active until timeout */
+		return ret;
 	}
+#endif
+
+	if (internal_req->is_observe) {
+		/* Observer: keep request active until unobserve */
+		return ret;
+	}
+
+	if (response_type == COAP_TYPE_ACK) {
+		/* This is piggybacked ACK,
+		 * no need to wait for lifetime to expire, all data is already transferred
+		 * and acknowledged
+		 */
+		reset_internal_request(internal_req);
+	} else {
+		release_internal_request(internal_req);
+	}
+
 	return ret;
 }
 

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -28,7 +28,7 @@ static struct coap_client *clients[CONFIG_COAP_CLIENT_MAX_INSTANCES];
 static int num_clients;
 static K_SEM_DEFINE(coap_client_recv_sem, 0, 1);
 
-static bool timeout_expired(struct coap_client_internal_request *internal_req);
+static bool timeout_expired(const struct coap_client_internal_request *internal_req);
 static void cancel_requests_with(struct coap_client *client, int error);
 static int recv_response(struct coap_client *client, struct net_sockaddr *addr,
 			 net_socklen_t *addrlen, struct coap_packet *response, bool *truncated);
@@ -100,7 +100,7 @@ static void coap_client_schedule_poll(struct coap_client *client, int sock,
 	k_sem_give(&coap_client_recv_sem);
 }
 
-static bool exchange_lifetime_exceeded(struct coap_client_internal_request *internal_req)
+static bool exchange_lifetime_exceeded(const struct coap_client_internal_request *internal_req)
 {
 	int64_t time_since_t0, exchange_lifetime;
 
@@ -119,7 +119,7 @@ static bool exchange_lifetime_exceeded(struct coap_client_internal_request *inte
 	return time_since_t0 > exchange_lifetime;
 }
 
-static bool has_ongoing_request(struct coap_client *client)
+static bool has_ongoing_request(const struct coap_client *client)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing == true) {
@@ -130,7 +130,7 @@ static bool has_ongoing_request(struct coap_client *client)
 	return false;
 }
 
-static bool has_ongoing_exchange(struct coap_client *client)
+static bool has_ongoing_exchange(const struct coap_client *client)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing == true ||
@@ -142,7 +142,7 @@ static bool has_ongoing_exchange(struct coap_client *client)
 	return false;
 }
 
-static bool has_timeout_expired(struct coap_client *client)
+static bool has_timeout_expired(const struct coap_client *client)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (timeout_expired(&client->requests[i])) {
@@ -534,7 +534,7 @@ static void report_callback_error(struct coap_client_internal_request *internal_
 	}
 }
 
-static bool timeout_expired(struct coap_client_internal_request *internal_req)
+static bool timeout_expired(const struct coap_client_internal_request *internal_req)
 {
 	if (internal_req->pending.timeout == 0) {
 		return false;

--- a/tests/net/lib/coap_client/CMakeLists.txt
+++ b/tests/net/lib/coap_client/CMakeLists.txt
@@ -20,6 +20,7 @@ target_compile_definitions(app PRIVATE _POSIX_C_SOURCE=200809L)
 
 add_compile_definitions(CONFIG_ZVFS_POLL_MAX=3)
 add_compile_definitions(CONFIG_COAP_CLIENT=1)
+add_compile_definitions(CONFIG_COAP_CLIENT_MULTICAST=1)
 add_compile_definitions(CONFIG_COAP_CLIENT_BLOCK_SIZE=256)
 add_compile_definitions(CONFIG_COAP_CLIENT_MESSAGE_SIZE=256)
 add_compile_definitions(CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE=48)

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -65,11 +65,15 @@ static struct coap_client_request long_request = {
 	.len = sizeof(long_payload) - 1,
 	.user_data = &sem2,
 };
+
+/* Dummy destination addresses */
 static struct net_sockaddr_storage dst_address = {
 	.ss_family = NET_AF_INET,
 };
-
-
+static struct net_sockaddr_in mcast_address = {
+	.sin_family = NET_AF_INET,
+	.sin_addr = {{{224, 0, 1, 187}}},
+};
 
 static uint16_t get_next_pending_message_id(void)
 {
@@ -910,6 +914,241 @@ ZTEST(coap_client, test_cancel_match)
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 
+}
+
+#define MULTICAST_TIMEOUT_MS 1000
+/* 192.168.1.1, 192.168.1.2, ... */
+#define MULTICAST_SERVER_START_IP 0xC0A80101U
+#define MULTICAST_SERVER_PORT 5683
+
+static int multicast_response_count;
+static bool multicast_completed;
+static int multicast_recv_index;
+static uint16_t multicast_message_id;
+
+static void multicast_coap_callback(const struct coap_client_response_data *data, void *user_data)
+{
+	LOG_INF("Multicast callback, code=%d source=%p", data->result_code, data->source);
+
+	if (data->source == NULL) {
+		multicast_completed = true;
+	} else {
+		const struct net_sockaddr_in *addr4;
+
+		/* Verify each response carries a distinct source address matching the simulated
+		 * servers: 192.168.1.1 for the first response, 192.168.1.2 for the second, etc.
+		 */
+		zassert_not_null(data->source,
+				 "Expected non-NULL src_addr for multicast response %d",
+				 multicast_response_count);
+
+		zassert_equal(data->source->sa_family, NET_AF_INET,
+			      "Expected IPv4 source for response %d", multicast_response_count);
+		zassert_equal(data->source_len, sizeof(*addr4),
+			      "Expected IPv4 source length for response %d",
+			      multicast_response_count);
+
+		addr4 = net_sin(data->source);
+
+		zassert_equal(addr4->sin_port, net_htons(MULTICAST_SERVER_PORT),
+			      "Wrong source port for response %d", multicast_response_count);
+		zassert_equal(addr4->sin_addr.s_addr,
+			      net_htonl(MULTICAST_SERVER_START_IP + multicast_response_count),
+			      "Wrong source address for response %d", multicast_response_count);
+		multicast_response_count++;
+	}
+	k_sem_give((struct k_sem *)user_data);
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_multicast(int sock, void *buf, size_t len, int flags,
+							 const struct net_sockaddr *dest_addr,
+							 net_socklen_t addrlen)
+{
+	uint8_t *buf_u8 = buf;
+
+	multicast_message_id = sys_get_be16(buf_u8 + 2);
+	store_token(buf_u8);
+
+	LOG_INF("Multicast message ID: %d", multicast_message_id);
+	set_next_pending_message_id(multicast_message_id);
+
+	return 1;
+}
+
+static ssize_t zsock_recvfrom_custom_fake_multicast(int sock, void *buf, size_t max_len, int flags,
+						    struct net_sockaddr *src_addr,
+						    net_socklen_t *addrlen, bool confirmable)
+{
+	/* NON response: VV=01, TT=01(NON), TKL=8, Code=2.05 Content. */
+	uint8_t resp_data[] = {0x58, 0x45, 0x00, 0x00, 0x00, 0x00,
+			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	struct net_sockaddr_in *addr4;
+
+	if (confirmable) {
+		/* Turn the response into a confirmable one */
+		resp_data[0] = 0x48;
+	}
+
+	sys_put_be16(multicast_message_id, resp_data + 2);
+
+	restore_token(resp_data);
+	store_token(resp_data); /* Keep token available for subsequent calls */
+
+	zassert_not_null(src_addr, "Unexpected NULL source address");
+	zassert_not_null(addrlen, "Unexpected NULL source address length");
+
+	/* Simulate a different IPv4 source for each responding server */
+	addr4 = (struct net_sockaddr_in *)src_addr;
+
+	memset(addr4, 0, sizeof(*addr4));
+	addr4->sin_family = NET_AF_INET;
+	addr4->sin_port = net_htons(MULTICAST_SERVER_PORT);
+	addr4->sin_addr.s_addr =
+		net_htonl(MULTICAST_SERVER_START_IP + multicast_recv_index);
+	*addrlen = sizeof(*addr4);
+
+	multicast_recv_index++;
+	memcpy(buf, resp_data, sizeof(resp_data));
+
+	/* Keep triggering POLLIN until all simulated responses are delivered */
+	if (multicast_recv_index < 2) {
+		set_socket_events(sock, ZSOCK_POLLIN);
+	} else {
+		clear_socket_events(sock, ZSOCK_POLLIN);
+	}
+
+	return sizeof(resp_data);
+}
+
+static ssize_t z_impl_zsock_recvfrom_custom_fake_multicast(int sock, void *buf, size_t max_len,
+							   int flags,
+							   struct net_sockaddr *src_addr,
+							   net_socklen_t *addrlen)
+{
+	return zsock_recvfrom_custom_fake_multicast(sock, buf, max_len, flags, src_addr, addrlen,
+						    false);
+}
+
+static ssize_t z_impl_zsock_recvfrom_custom_fake_multicast_con(int sock, void *buf, size_t max_len,
+							       int flags,
+							       struct net_sockaddr *src_addr,
+							       net_socklen_t *addrlen)
+{
+	return zsock_recvfrom_custom_fake_multicast(sock, buf, max_len, flags, src_addr, addrlen,
+						    true);
+}
+
+ZTEST(coap_client, test_multicast_confirmable_rejected)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback,
+		.multicast_timeout_ms = MULTICAST_TIMEOUT_MS,
+		.user_data = &sem1,
+	};
+
+	zassert_equal(coap_client_req(&client, 0, (const struct net_sockaddr *)&mcast_address, &req,
+				      NULL),
+		      -EINVAL);
+}
+
+ZTEST(coap_client, test_multicast_get_timeout)
+{
+	multicast_response_count = 0;
+	multicast_completed = false;
+
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = false,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = multicast_coap_callback,
+		.multicast_timeout_ms = MULTICAST_TIMEOUT_MS,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_multicast;
+	/* POLLOUT in my_events enables the resend handler to fire once has_timeout_expired */
+	set_socket_events(client.fd, ZSOCK_POLLOUT);
+
+	zassert_ok(coap_client_req(&client, 0, (const struct net_sockaddr *)&mcast_address, &req,
+				   NULL));
+
+	/* Wait for the completion-only callback (no responses arrive before timeout) */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(multicast_response_count, 0, "No responses expected before timeout");
+	zassert_true(multicast_completed, "Expected completion callback after timeout");
+}
+
+ZTEST(coap_client, test_multicast_get_responses)
+{
+	multicast_response_count = 0;
+	multicast_completed = false;
+	multicast_recv_index = 0;
+
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = false,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = multicast_coap_callback,
+		.multicast_timeout_ms = MULTICAST_TIMEOUT_MS,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_multicast;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_multicast;
+	/* POLLIN delivers the simulated responses; POLLOUT enables timeout detection */
+	set_socket_events(client.fd, ZSOCK_POLLIN | ZSOCK_POLLOUT);
+
+	zassert_ok(coap_client_req(&client, 0, (const struct net_sockaddr *)&mcast_address, &req,
+				   NULL));
+
+	/* Collect two response callbacks */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	/* Then wait for the completion callback after multicast timeout */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+
+	zassert_equal(multicast_response_count, 2, "Expected 2 streamed responses");
+	zassert_true(multicast_completed, "Expected completion callback after timeout");
+}
+
+ZTEST(coap_client, test_multicast_con_response_rejected)
+{
+	multicast_response_count = 0;
+	multicast_completed = false;
+	multicast_recv_index = 0;
+
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = false,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = multicast_coap_callback,
+		.multicast_timeout_ms = MULTICAST_TIMEOUT_MS,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_multicast;
+	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_multicast_con;
+	/* POLLIN delivers CON responses; POLLOUT enables timeout detection */
+	set_socket_events(client.fd, ZSOCK_POLLIN | ZSOCK_POLLOUT);
+
+	zassert_ok(coap_client_req(&client, 0, (const struct net_sockaddr *)&mcast_address, &req,
+				   NULL));
+
+	/* Only the completion callback is expected; CON responses must be silently dropped
+	 * per RFC 7252 Section 8.2 (responses to multicast MUST NOT be Confirmable).
+	 */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+
+	zassert_equal(multicast_response_count, 0,
+		      "CON responses must be rejected in multicast mode");
+	zassert_true(multicast_completed, "Expected completion callback after timeout");
 }
 
 ZTEST(coap_client, test_non_confirmable)


### PR DESCRIPTION
Allow sending a CoAP GET request to a multicast address and stream the responses as per [RFC 7252 section 8](https://datatracker.ietf.org/doc/html/rfc7252#section-8).

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/104846