### PR TITLE
soc: st: stm32n6: initialize NPU at device priority

### DIFF
--- a/soc/st/stm32/stm32n6x/npu/Kconfig
+++ b/soc/st/stm32/stm32n6x/npu/Kconfig
@@ -9,10 +9,11 @@ config STM32N6_NPU
 	default y
 	depends on DT_HAS_ST_STM32_NPU_ENABLED
 
+if STM32N6_NPU
+
 config STM32N6_NPU_INIT_PRIORITY
 	int "STM32N6 NPU init priority"
-	default KERNEL_INIT_PRIORITY_DEFAULT
-	depends on STM32N6_NPU
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  STM32N6 NPU initialization priority.
 
@@ -22,9 +23,10 @@ config STM32N6_NPU_INIT_PRIORITY
 config STM32N6_NPU_CACHE_INIT_PRIORITY
 	int "STM32N6 NPU cache (aka CACHEAXI) init priority"
 	default APPLICATION_INIT_PRIORITY
-	depends on STM32N6_NPU
 	help
 	  STM32N6 NPU cache (aka CACHEAXI) initialization priority.
 
 	  Note: This value must have a lower priority (i.e., higher numerical value)
 	  than `STM32N6_NPU_INIT_PRIORITY`!
+
+endif # STM32N6_NPU


### PR DESCRIPTION
Use the more appropriate `KERNEL_DEVICE` priority as default for the NPU instead of `KERNEL_DEFAULT`. While at it, also clean up the NPU-specific Kconfig file by using an `if` block to gate symbols.