### PR TITLE
dts: nxp: mcx: delete "nxp,cmc-reset-cause" compatible

### DIFF
--- a/drivers/hwinfo/Kconfig.mcux_mcx_cmc
+++ b/drivers/hwinfo/Kconfig.mcux_mcx_cmc
@@ -4,7 +4,7 @@
 config HWINFO_MCUX_MCX_CMC
 	bool "NXP MCX CMC reset cause"
 	default y
-	depends on DT_HAS_NXP_CMC_RESET_CAUSE_ENABLED
+	depends on DT_HAS_NXP_CMC_ENABLED
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP kinetis mcux CMC hwinfo driver.

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -452,7 +452,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
+			compatible = "nxp,cmc";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -588,7 +588,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
+			compatible = "nxp,cmc";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -61,10 +61,6 @@
 		status = "okay";
 	};
 
-	cmc {
-		compatible = "nxp,cmc-reset-cause";
-	};
-
 	soc {
 		syscon: syscon@40091000 {
 			compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -31,10 +31,6 @@
 		};
 	};
 
-	cmc {
-		compatible = "nxp,cmc-reset-cause";
-	};
-
 	/* Dummy pinctrl node, filled with pin mux options at board level */
 	pinctrl: pinctrl {
 		compatible = "nxp,port-pinctrl";

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -545,7 +545,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
+			compatible = "nxp,cmc";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
+++ b/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
@@ -1,6 +1,0 @@
-# Copyright 2025 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-description: CMC reset causes
-
-compatible: "nxp,cmc-reset-cause"


### PR DESCRIPTION
- Deletes virtual "nxp,cmc-reset-cause" compatible, as it is covered by existing "nxp,cmc".
- Fixes the issue discovered during discussion in https://github.com/zephyrproject-rtos/zephyr/issues/104464#issuecomment-3957779329