### PR TITLE
Add SPI NOR flash and Cadence SPI fixes in slave mode

### DIFF
--- a/boards/amd/versalnet_rpu/versalnet_rpu.yaml
+++ b/boards/amd/versalnet_rpu/versalnet_rpu.yaml
@@ -11,3 +11,4 @@ vendor: amd
 supported:
   - sdhc
   - mbox
+  - flash

--- a/drivers/spi/spi_cdns.c
+++ b/drivers/spi/spi_cdns.c
@@ -261,16 +261,46 @@ static void spi_cdns_send(const struct device *dev)
 				break;
 			}
 		}
-		if ((spi_context_tx_buf_on(ctx) || spi_context_rx_buf_on(ctx))) {
-			if (data->tx_remain_entry > 0) {
-				data->tx_remain_entry--;
-				data->fifo_diff++;
-			}
+		if (data->tx_remain_entry > 0) {
+			data->tx_remain_entry--;
+			data->fifo_diff++;
 		}
 		spi_context_update_tx(&data->ctx, dfs, 1);
 	}
 
 	sys_write32(val, SPI_REG(dev, SPI_TX_DATA));
+}
+
+static inline void spi_cdns_rx_store(const struct spi_cdns_cfg *config,
+		struct spi_context *ctx,
+		uint32_t val, uint8_t dfs, int idx)
+{
+	switch (dfs) {
+	case 1:
+		if (config->fifo_width == 8) {
+			UNALIGNED_PUT(val & 0xFF, (uint8_t *)ctx->rx_buf);
+		} else if (config->fifo_width == 16) {
+			UNALIGNED_PUT((val >> 8 * (1 - idx)) & 0xFF,
+					(uint8_t *)ctx->rx_buf);
+		} else if (config->fifo_width == 32) {
+			UNALIGNED_PUT((val >> 8 * (3 - idx)) & 0xFF,
+					(uint8_t *)ctx->rx_buf);
+		}
+		break;
+	case 2:
+		if (config->fifo_width == 16) {
+			UNALIGNED_PUT(val & 0xFFFF, (uint16_t *)ctx->rx_buf);
+		} else if (config->fifo_width == 32) {
+			UNALIGNED_PUT((val >> 16 * (1 - idx)) & 0xFFFF,
+					(uint16_t *)ctx->rx_buf);
+		}
+		break;
+	case 4:
+		if (config->fifo_width == 32) {
+			UNALIGNED_PUT(val, (uint32_t *)ctx->rx_buf);
+		}
+		break;
+	}
 }
 
 /**
@@ -293,32 +323,15 @@ static void spi_cdns_recv(const struct device *dev)
 	loop = (config->fifo_width / 8) / dfs;
 	for (i = 0; i < loop; i++) {
 		if (spi_context_rx_buf_on(ctx)) {
-			switch (dfs) {
-			case 1:
-				if (config->fifo_width == 8) {
-					UNALIGNED_PUT(val & 0xFF, (uint8_t *)ctx->rx_buf);
-				} else if (config->fifo_width == 16) {
-					UNALIGNED_PUT((val >> 8 * (1 - i)) & 0xFF,
-						      (uint8_t *)ctx->rx_buf);
-				} else if (config->fifo_width == 32) {
-					UNALIGNED_PUT((val >> 8 * (3 - i)) & 0xFF,
-						      (uint8_t *)ctx->rx_buf);
-				}
-				break;
-			case 2:
-				if (config->fifo_width == 16) {
-					UNALIGNED_PUT(val & 0xFFFF, (uint16_t *)ctx->rx_buf);
-				} else if (config->fifo_width == 32) {
-					UNALIGNED_PUT((val >> 16 * (1 - i)) & 0xFFFF,
-						      (uint16_t *)ctx->rx_buf);
-				}
-				break;
-			case 4:
-				if (config->fifo_width == 32) {
-					UNALIGNED_PUT(val, (uint32_t *)ctx->rx_buf);
-				}
-				break;
+			spi_cdns_rx_store(config, ctx, val, dfs, i);
+
+			/* Slave: advance RX only when a buffer is present */
+			if (spi_context_is_slave(ctx)) {
+				spi_context_update_rx(ctx, dfs, 1);
 			}
+		}
+		/* Master: always advance RX per received frame */
+		if (!spi_context_is_slave(ctx)) {
 			spi_context_update_rx(ctx, dfs, 1);
 		}
 		if (data->fifo_diff > 0) {

--- a/dts/vendor/amd/versalnet.dtsi
+++ b/dts/vendor/amd/versalnet.dtsi
@@ -229,5 +229,30 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
+
+		spi0: spi@f1960000 {
+			compatible = "cdns,spi";
+			status = "disabled";
+			reg = <0xf1960000 0x1000>;
+			interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi1: spi@f1970000 {
+			compatible = "cdns,spi";
+			status = "disabled";
+			reg = <0xf1970000 0x1000>;
+			interrupts = <GIC_SPI 24 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+			clock-frequency = <120000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
 	};
 };

--- a/samples/drivers/spi_flash/boards/versalnet_rpu.overlay
+++ b/samples/drivers/spi_flash/boards/versalnet_rpu.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	status = "okay";
+
+	flash@2 {
+		compatible = "jedec,spi-nor";
+		reg = <2>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 25 36]; /* mx25u3235f */
+		size = <0x2000000>; /* 32MB */
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};

--- a/tests/drivers/flash/common/boards/versalnet_rpu.overlay
+++ b/tests/drivers/flash/common/boards/versalnet_rpu.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	status = "okay";
+
+	flash@2 {
+		compatible = "jedec,spi-nor";
+		reg = <2>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 25 36]; /* mx25u3235f */
+		size = <0x2000000>; /* 32MB */
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -271,3 +271,7 @@ tests:
       - SHIELD=mikroe_flash_5_click
       - DTC_OVERLAY_FILE="./boards/mikroe_flash_5_click.overlay"
       - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"
+  drivers.flash.common.versalnet:
+    build_only: true
+    platform_allow:
+      - versalnet_rpu/amd_versalnet_rpu


### PR DESCRIPTION
this pulls request adds:
-> Add board overlay for SPI flash sample (versalnet_rpu)
-> Add board overlay for flash common tests
-> Add Cadence SPI controller nodes to versalnet.dtsi
-> Fix RX FIFO overflow in Cadence SPI driver for slave mode