### PR TITLE
Remove 2 uses of fcntl.h

### DIFF
--- a/lib/os/zvfs/zvfs_eventfd.c
+++ b/lib/os/zvfs/zvfs_eventfd.c
@@ -8,7 +8,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/zvfs/eventfd.h>
 #include <zephyr/sys/bitarray.h>
 #include <zephyr/sys/fdtable.h>
@@ -229,11 +228,11 @@ static int zvfs_eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 	}
 
 	switch (request) {
-	case F_GETFL:
+	case ZVFS_F_GETFL:
 		ret = efd->flags & ZVFS_EFD_FLAGS_SET;
 		break;
 
-	case F_SETFL: {
+	case ZVFS_F_SETFL: {
 		int flags;
 
 		flags = va_arg(args, int);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1233,13 +1233,13 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 	flags = zsock_fcntl(client_ctx->sock_fd, ZVFS_F_GETFL, 0);
 	if (flags == -1) {
 		ret = -errno;
-		LOG_ERR("zsock_fcntl(F_GETFL) failed (%d)", ret);
+		LOG_ERR("zsock_fcntl(ZVFS_F_GETFL) failed (%d)", ret);
 		goto error;
 	}
 	ret = zsock_fcntl(client_ctx->sock_fd, ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 	if (ret == -1) {
 		ret = -errno;
-		LOG_ERR("zsock_fcntl(F_SETFL) failed (%d)", ret);
+		LOG_ERR("zsock_fcntl(ZVFS_F_SETFL) failed (%d)", ret);
 		goto error;
 	}
 


### PR DESCRIPTION
1) Use the zvfs macros in the code of the zvfs module itself, instead of using the versions from fcntl.h and remove that include as it is not needed anymore.

2) net: lwm2m: Remove use of fcntl.h macros from messages, Just for consistency with the actual code