### PR TITLE
net: ptp: Fix undefined bitwise shift in port management

### DIFF
--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -851,15 +851,18 @@ static int port_management_set(struct ptp_port *port,
 			       struct ptp_msg *req,
 			       struct ptp_tlv_mgmt *tlv)
 {
+	static const int8_t limit = sizeof(uint64_t) * CHAR_BIT - 1;
 	bool send_resp = false;
 
 	switch (tlv->id) {
 	case PTP_MGMT_LOG_ANNOUNCE_INTERVAL:
-		port->port_ds.log_announce_interval = *tlv->data;
+		/* Use limits to protect from undefined bitwise shift operations */
+		port->port_ds.log_announce_interval = CLAMP(*tlv->data, -limit, limit);
 		send_resp = true;
 		break;
 	case PTP_MGMT_LOG_SYNC_INTERVAL:
-		port->port_ds.log_sync_interval = *tlv->data;
+		/* Use limits to protect from undefined bitwise shift operations */
+		port->port_ds.log_sync_interval = CLAMP(*tlv->data, -limit, limit);
 		send_resp = true;
 		break;
 	case PTP_MGMT_UNICAST_NEGOTIATION_ENABLE:


### PR DESCRIPTION
Add bounds checking to PTP management interval parameters to prevent undefined behavior from bitwise shift operations.

The port_timer_set_timeout() and port_timer_set_timeout_random() functions perform left and right shift operations using the log_announce_interval and log_sync_interval values as shift counts. Without bounds validation, these int8_t parameters could be set to extreme values (e.g., via PTP management messages) that exceed the valid shift range, causing undefined behavior.

(C11, 6.5.7p3)
> If the value of the right operand is negative or is greater than
or equal to the width of the promoted left operand, the behavior is undefined

(C++11, 5.8p1)
> The behavior is undefined if the right operand is negative,
or greater than or equal to the length in bits of the promoted left operand.

Limit both log_announce_interval and log_sync_interval to the range [-63, 63] using MIN/MAX macros when accepting values from PTP management frames. This range is preventing shift operations outside the 64-bit width used in the timeout calculations.

Fixes: #109133