### PR TITLE
settings: make NVS and ZMS store interface instances const

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -34,7 +34,7 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
 static void *settings_nvs_storage_get(struct settings_store *cs);
 
-static struct settings_store_itf settings_nvs_itf = {
+static const struct settings_store_itf settings_nvs_itf = {
 	.csi_load = settings_nvs_load,
 	.csi_save = settings_nvs_save,
 	.csi_storage_get = settings_nvs_storage_get

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -38,11 +38,13 @@ static void *settings_zms_storage_get(struct settings_store *cs);
 static int settings_zms_get_last_hash_ids(struct settings_zms *cf);
 static ssize_t settings_zms_get_val_len(struct settings_store *cs, const char *name);
 
-static struct settings_store_itf settings_zms_itf = {.csi_load = settings_zms_load,
-						     .csi_load_one = settings_zms_load_one,
-						     .csi_save = settings_zms_save,
-						     .csi_storage_get = settings_zms_storage_get,
-						     .csi_get_val_len = settings_zms_get_val_len};
+static const struct settings_store_itf settings_zms_itf = {
+	.csi_load = settings_zms_load,
+	.csi_load_one = settings_zms_load_one,
+	.csi_save = settings_zms_save,
+	.csi_storage_get = settings_zms_storage_get,
+	.csi_get_val_len = settings_zms_get_val_len
+};
 
 static ssize_t settings_zms_read_fn(void *back_end, void *data, size_t len)
 {


### PR DESCRIPTION
Mark `settings_nvs_itf` and `settings_zms_itf` as `const` since they are statically defined interface tables that are never modified at runtime.

This lets the compiler place them in read-only storage and trims RAM usage.