### PR TITLE
boards: adi: Expose feather SPI/I2C bus nodes for MAX32655FTHR

### DIFF
--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -161,10 +161,19 @@
 	pinctrl-names = "default";
 };
 
-&i2c2 {
+&i2c2_scl_p0_30 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&i2c2_sda_p0_31 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+feather_i2c: &i2c2 {
 	status = "okay";
 	pinctrl-0 = <&i2c2_scl_p0_30 &i2c2_sda_p0_31>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &dma0 {
@@ -181,7 +190,23 @@
 	status = "okay";
 };
 
-&spi1 {
+&spi1_mosi_p0_21 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1_miso_p0_22 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1_sck_p0_23 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi1_ss0_p0_20 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+feather_spi: &spi1 {
 	status = "okay";
 	pinctrl-0 = <&spi1_mosi_p0_21 &spi1_miso_p0_22 &spi1_sck_p0_23 &spi1_ss0_p0_20>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Add feather_spi/feather_i2c node labels to the configured buses, and adjust the power source for those pins to ensure compatability with feather(wing) shields using SPI/I2C.