### PR TITLE
drivers: counter: max32: Add pinctrl support

### DIFF
--- a/drivers/counter/Kconfig.max32_timer
+++ b/drivers/counter/Kconfig.max32_timer
@@ -1,9 +1,10 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 config COUNTER_TIMER_MAX32
 	bool "MAX32xxx counter driver"
 	default y
 	depends on DT_HAS_ADI_MAX32_COUNTER_ENABLED
+	select PINCTRL
 	help
 	  Enable the counter driver for MAX32 MCUs.

--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +31,7 @@ struct max32_tmr_config {
 	struct counter_config_info info;
 	struct max32_tmr_ch_data *ch_data;
 	mxc_tmr_regs_t *regs;
+	const struct pinctrl_dev_config *pctrl;
 	const struct device *clock;
 	struct max32_perclk perclk;
 	int clock_source;
@@ -285,6 +286,11 @@ static int max32_counter_init(const struct device *dev)
 		return ret;
 	}
 
+	ret = pinctrl_apply_state(cfg->pctrl, PINCTRL_STATE_DEFAULT);
+	if (ret < 0 && ret != -ENOENT) {
+		return ret;
+	}
+
 	ret = Wrap_MXC_TMR_Init(regs, &tmr_cfg);
 	if (ret != E_NO_ERROR) {
 		return ret;
@@ -326,6 +332,7 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 
 #define COUNTER_MAX32_DEFINE(_num)                                                                 \
 	static struct max32_tmr_ch_data counter##_num##_ch_data[MAX32_TIMER_CH];                   \
+	PINCTRL_DT_INST_DEFINE(_num);                                                              \
 	static void max32_tmr_irq_init_##_num(const struct device *dev)                            \
 	{                                                                                          \
 		IRQ_CONNECT(DT_IRQN(TIMER(_num)), DT_IRQ(TIMER(_num), priority),                   \
@@ -345,6 +352,7 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 				.channels = MAX32_TIMER_CH,                                        \
 			},                                                                         \
 		.regs = (mxc_tmr_regs_t *)DT_REG_ADDR(TIMER(_num)),                                \
+		.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(_num),                                     \
 		.clock = DEVICE_DT_GET(DT_CLOCKS_CTLR(TIMER(_num))),                               \
 		.perclk.bus = DT_CLOCKS_CELL(TIMER(_num), offset),                                 \
 		.perclk.bit = DT_CLOCKS_CELL(TIMER(_num), bit),                                    \

--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -330,7 +330,23 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 #define TIMER(_num)    DT_INST_PARENT(_num)
 #define MAX32_TIM(idx) ((mxc_tmr_regs_t *)DT_REG_ADDR(TIMER(idx)))
 
+#define COUNTER_MAX32_CLOCK_SOURCE(_num)                                                           \
+	DT_PROP(TIMER(_num), clock_source)
+
+#define COUNTER_MAX32_EXT_CLK_FREQ(_num)                                                           \
+	DT_PROP(DT_CLOCKS_CTLR_BY_IDX(TIMER(_num), 1), clock_frequency)
+
+#define COUNTER_MAX32_CLK_IS_EXT_CLK(_num)                                                         \
+	IS_EQ(COUNTER_MAX32_CLOCK_SOURCE(_num), ADI_MAX32_PRPH_CLK_SRC_EXTCLK)
+
+#define COUNTER_MAX32_CLOCK_FREQ(_num)                                                             \
+	COND_CODE_1(COUNTER_MAX32_CLK_IS_EXT_CLK(_num),                                            \
+		    (COUNTER_MAX32_EXT_CLK_FREQ(_num)),                                            \
+		    (ADI_MAX32_GET_PRPH_CLK_FREQ(DT_PROP(TIMER(_num), clock_source))))
+
 #define COUNTER_MAX32_DEFINE(_num)                                                                 \
+	BUILD_ASSERT(COUNTER_MAX32_CLOCK_FREQ(_num) > 0,                                           \
+		     "Counter clock frequency must be greater than 0");                            \
 	static struct max32_tmr_ch_data counter##_num##_ch_data[MAX32_TIMER_CH];                   \
 	PINCTRL_DT_INST_DEFINE(_num);                                                              \
 	static void max32_tmr_irq_init_##_num(const struct device *dev)                            \
@@ -345,8 +361,7 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 				.max_top_value = WRAP_MXC_IS_32B_TIMER(MAX32_TIM(_num))            \
 							 ? UINT32_MAX                              \
 							 : UINT16_MAX,                             \
-				.freq = ADI_MAX32_GET_PRPH_CLK_FREQ(                               \
-						DT_PROP(TIMER(_num), clock_source)) /              \
+				.freq = COUNTER_MAX32_CLOCK_FREQ(_num) /                           \
 					DT_PROP(TIMER(_num), prescaler),                           \
 				.flags = COUNTER_CONFIG_INFO_COUNT_UP,                             \
 				.channels = MAX32_TIMER_CH,                                        \

--- a/dts/arm/adi/max32/max32662.dtsi
+++ b/dts/arm/adi/max32/max32662.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,18 @@
 /delete-node/ &i2c2;
 
 /delete-node/ &rtc_counter;
+
+/* MAX32662 external clocks. */
+/ {
+	clocks {
+		clk_lp_ext: clk_lp_ext {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 &adc {
 	compatible = "adi,max32-adc-sar", "adi,max32-adc";
@@ -113,7 +125,7 @@
 			reg = <0x40113000 0x2000>;
 			interrupts = <8 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>, <&clk_lp_ext>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 

--- a/dts/arm/adi/max32/max32670.dtsi
+++ b/dts/arm/adi/max32/max32670.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,18 @@
 };
 
 /delete-node/ &rtc_counter;
+
+/* MAX32670 external clocks. */
+/ {
+	clocks {
+		clk_extclk2: clk_extclk2 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 /* MAX32670 extra peripherals. */
 / {
@@ -128,7 +140,7 @@
 			reg = <0x40114000 0x1000>;
 			interrupts = <9 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>, <&clk_extclk2>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 
@@ -143,7 +155,7 @@
 			reg = <0x40115000 0x1000>;
 			interrupts = <10 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 1>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 1>, <&clk_extclk2>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 

--- a/dts/arm/adi/max32/max32672.dtsi
+++ b/dts/arm/adi/max32/max32672.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,18 @@
 /delete-node/ &clk_iso;
 
 /delete-node/ &rtc_counter;
+
+/* MAX32672 external clocks. */
+/ {
+	clocks {
+		clk_extclk2: clk_extclk2 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 &adc {
 	compatible = "adi,max32-adc-sar", "adi,max32-adc";
@@ -154,7 +166,7 @@
 			reg = <0x40114000 0x1000>;
 			interrupts = <9 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 0>, <&clk_extclk2>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 
@@ -169,7 +181,7 @@
 			reg = <0x40115000 0x1000>;
 			interrupts = <10 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 1>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 1>, <&clk_extclk2>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 

--- a/dts/bindings/counter/adi,max32-counter.yaml
+++ b/dts/bindings/counter/adi,max32-counter.yaml
@@ -16,3 +16,15 @@ examples:
                     status = "okay";
             };
     };
+
+    &clk_lptmr0 {
+            clock-frequency = <32768>;
+            status = "okay";
+    };
+
+    &lptimer0 {
+            clock-source = <ADI_MAX32_PRPH_CLK_SRC_EXTCLK>;
+            counter1: counter {
+                    status = "okay";
+            };
+    };

--- a/dts/bindings/counter/adi,max32-counter.yaml
+++ b/dts/bindings/counter/adi,max32-counter.yaml
@@ -1,8 +1,18 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 description: ADI MAX32 counter
 
 compatible: "adi,max32-counter"
 
-include: [base.yaml]
+include: [base.yaml, pinctrl-device.yaml]
+
+examples:
+  - |
+    &timer0 {
+            counter0: counter {
+                    pinctrl-0 = <&tmr0c_ioa_p0_4>;
+                    pinctrl-names = "default";
+                    status = "okay";
+            };
+    };

--- a/dts/vendor/adi/max32/max32655.dtsi
+++ b/dts/vendor/adi/max32/max32655.dtsi
@@ -1,11 +1,30 @@
 /*
- * Copyright (c) 2023-2025 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <adi/max32/max32xxx.dtsi>
 #include <zephyr/dt-bindings/dma/max32655_dma.h>
+
+/* MAX32655 external clocks. */
+/ {
+	clocks {
+		clk_lptmr0: clk_lptmr0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+
+		clk_lptmr1: clk_lptmr1 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 &pinctrl {
 	reg = <0x40008000 0x2400>;
@@ -96,7 +115,7 @@
 			reg = <0x40080c00 0x400>;
 			interrupts = <9 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>, <&clk_lptmr0>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 
@@ -111,7 +130,7 @@
 			reg = <0x40081000 0x400>;
 			interrupts = <10 0>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>, <&clk_lptmr1>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 			prescaler = <1>;
 

--- a/dts/vendor/adi/max32/max32680.dtsi
+++ b/dts/vendor/adi/max32/max32680.dtsi
@@ -1,11 +1,30 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <adi/max32/max32xxx.dtsi>
 #include <zephyr/dt-bindings/dma/max32680_dma.h>
+
+/* MAX32680 external clocks. */
+/ {
+	clocks {
+		clk_lptmr0: clk_lptmr0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+
+		clk_lptmr1: clk_lptmr1 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 &pinctrl {
 	reg = <0x40008000 0x2400>;
@@ -73,7 +92,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40080c00 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>, <&clk_lptmr0>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 
@@ -87,7 +106,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40081000 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>, <&clk_lptmr1>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 

--- a/dts/vendor/adi/max32/max32690.dtsi
+++ b/dts/vendor/adi/max32/max32690.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,25 @@
 
 &clk_ipo {
 	clock-frequency = <DT_FREQ_M(120)>;
+};
+
+/* MAX32690 external clocks. */
+/ {
+	clocks {
+		clk_lptmr0: clk_lptmr0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+
+		clk_lptmr1: clk_lptmr1 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
 };
 
 &flash0 {
@@ -146,7 +165,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40080c00 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>, <&clk_lptmr0>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 
@@ -160,7 +179,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40081000 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>, <&clk_lptmr1>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 

--- a/dts/vendor/adi/max32/max78000.dtsi
+++ b/dts/vendor/adi/max32/max78000.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,25 @@
 };
 
 /delete-node/ &clk_erfo;
+
+/* MAX78000 external clocks. */
+/ {
+	clocks {
+		clk_lptmr0: clk_lptmr0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+
+		clk_lptmr1: clk_lptmr1 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+	};
+};
 
 &pinctrl {
 	reg = <0x40008000 0x2200>;
@@ -94,7 +113,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40080c00 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>, <&clk_lptmr0>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 
@@ -116,7 +135,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40081000 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>, <&clk_lptmr1>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 

--- a/dts/vendor/adi/max32/max78002.dtsi
+++ b/dts/vendor/adi/max32/max78002.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +31,20 @@
 			compatible = "fixed-clock";
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(25)>;
+			status = "disabled";
+		};
+
+		clk_lptmr0: clk_lptmr0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			status = "disabled";
+		};
+
+		clk_lptmr1: clk_lptmr1 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
 			status = "disabled";
 		};
 	};
@@ -135,7 +149,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40080c00 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 2>, <&clk_lptmr0>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 
@@ -155,7 +169,7 @@
 			compatible = "adi,max32-timer";
 			reg = <0x40081000 0x400>;
 			status = "disabled";
-			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS2 3>, <&clk_lptmr1>;
 			clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
 			prescaler = <1>;
 

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 87df40a91ab1bed470f211d55da56b7ef9966ea2
+      revision: f24186100783b7633594e7114b4b1d98e55a080d
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Add pinctrl support for MAX32 counter driver so that external clock input and timer I/O signals can be utilized.

- Add pinctrl support to the counter driver to allow configuration of timer I/O pins via device tree.
- Update device tree files to include fixed-clock nodes representing external clock sources for low-power timers.
- Add proper handling of external clock frequency for timer instances using external clock inputs.
