### PR TITLE
Bluetooth: CAP: Make CAP cancel thread safe

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(bt_cap_commander, CONFIG_BT_CAP_COMMANDER_LOG_LEVEL);
 
 #include "common/bt_str.h"
 
-static void cap_commander_proc_complete(void);
+static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc);
 
 static const struct bt_cap_commander_cb *cap_cb;
 
@@ -121,8 +121,9 @@ static void cap_commander_broadcast_assistant_add_src_cb(struct bt_conn *conn, i
 	LOG_DBG("conn %p", (void *)conn);
 
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
-
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -141,7 +142,9 @@ static void cap_commander_broadcast_assistant_add_src_cb(struct bt_conn *conn, i
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -161,10 +164,12 @@ static void cap_commander_broadcast_assistant_add_src_cb(struct bt_conn *conn, i
 			LOG_DBG("Failed to perform broadcast reception start for conn %p: %d",
 				(void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -302,19 +307,17 @@ static bool valid_broadcast_reception_start_param(
 }
 
 int cap_commander_broadcast_reception_start(
+	struct bt_cap_common_proc *active_proc,
 	const struct bt_cap_commander_broadcast_reception_start_param *param)
 {
 	struct bt_bap_broadcast_assistant_add_src_param add_src_param = {0};
 	struct bt_cap_commander_proc_param *proc_param;
-	struct bt_cap_common_proc *active_proc;
 	struct bt_conn *conn;
 	int err;
 
 	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START, param->count);
-
-	active_proc = bt_cap_common_get_active_proc();
 
 	for (size_t i = 0U; i < param->count; i++) {
 		const struct bt_cap_commander_broadcast_reception_start_member_param *member_param =
@@ -370,21 +373,28 @@ int cap_commander_broadcast_reception_start(
 int bt_cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param)
 {
+	struct bt_cap_common_proc *active_proc;
 	int err;
 
 	if (!valid_broadcast_reception_start_param(param)) {
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	err = cap_commander_broadcast_reception_start(param);
+	err = cap_commander_broadcast_reception_start(active_proc, param);
 	if (err != 0) {
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;
@@ -405,13 +415,15 @@ copy_broadcast_reception_stop_param(struct bt_bap_broadcast_assistant_mod_src_pa
 static void cap_commander_broadcast_assistant_recv_state_cb(
 	struct bt_conn *conn, int err, const struct bt_bap_scan_delegator_recv_state *state)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+	struct bt_cap_common_proc *active_proc;
 
 	if (state == NULL) {
 		/* Empty receive state, indicating that the source has been removed
 		 */
 		return;
 	}
+
+	active_proc = bt_cap_common_get_active_proc();
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
 		bt_cap_handover_receive_state_updated(conn, state);
@@ -429,6 +441,8 @@ static void cap_commander_broadcast_assistant_recv_state_cb(
 			 * and we need to wait for another notification
 			 */
 			if (subgroup->bis_sync != 0) {
+				bt_cap_common_unlock_proc();
+
 				return;
 			}
 		}
@@ -438,9 +452,13 @@ static void cap_commander_broadcast_assistant_recv_state_cb(
 		if (err != 0) {
 			LOG_DBG("Failed to rem_src for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+
+			return;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 static void cap_commander_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
@@ -450,6 +468,8 @@ static void cap_commander_broadcast_assistant_rem_src_cb(struct bt_conn *conn, i
 
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -468,7 +488,9 @@ static void cap_commander_broadcast_assistant_rem_src_cb(struct bt_conn *conn, i
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -486,10 +508,12 @@ static void cap_commander_broadcast_assistant_rem_src_cb(struct bt_conn *conn, i
 		if (err != 0) {
 			LOG_DBG("Failed to mod_src for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -499,6 +523,8 @@ static void cap_commander_broadcast_assistant_mod_src_cb(struct bt_conn *conn, i
 
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -515,9 +541,13 @@ static void cap_commander_broadcast_assistant_mod_src_cb(struct bt_conn *conn, i
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+
+			return;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 bool bt_cap_commander_valid_broadcast_reception_stop_param(
@@ -589,19 +619,17 @@ bool bt_cap_commander_valid_broadcast_reception_stop_param(
 }
 
 int cap_commander_broadcast_reception_stop(
+	struct bt_cap_common_proc *active_proc,
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
 	struct bt_bap_broadcast_assistant_mod_src_param mod_src_param = {0};
 	struct bt_cap_commander_proc_param *proc_param;
-	struct bt_cap_common_proc *active_proc;
 	struct bt_conn *conn;
 	int err;
 
 	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP, param->count);
-
-	active_proc = bt_cap_common_get_active_proc();
 
 	for (size_t i = 0U; i < param->count; i++) {
 		const struct bt_cap_commander_broadcast_reception_stop_member_param *member_param =
@@ -650,21 +678,28 @@ int cap_commander_broadcast_reception_stop(
 int bt_cap_commander_broadcast_reception_stop(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
+	struct bt_cap_common_proc *active_proc;
 	int err;
 
 	if (!bt_cap_commander_valid_broadcast_reception_stop_param(param)) {
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	err = cap_commander_broadcast_reception_stop(param);
+	err = cap_commander_broadcast_reception_stop(active_proc, param);
 	if (err != 0) {
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;
@@ -678,6 +713,8 @@ static void cap_commander_broadcast_assistant_set_broadcast_code_cb(struct bt_co
 
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -694,7 +731,9 @@ static void cap_commander_broadcast_assistant_set_broadcast_code_cb(struct bt_co
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -714,10 +753,12 @@ static void cap_commander_broadcast_assistant_set_broadcast_code_cb(struct bt_co
 			LOG_DBG("Failed to perform set broadcast code for conn %p: %d",
 				(void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -789,7 +830,11 @@ int bt_cap_commander_distribute_broadcast_code(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -798,8 +843,6 @@ int bt_cap_commander_distribute_broadcast_code(
 	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_DISTRIBUTE_BROADCAST_CODE, param->count);
-
-	active_proc = bt_cap_common_get_active_proc();
 
 	for (size_t i = 0U; i < param->count; i++) {
 		const struct bt_cap_commander_distribute_broadcast_code_member_param *member_param =
@@ -812,7 +855,7 @@ int bt_cap_commander_distribute_broadcast_code(
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->member[%zu]", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -836,15 +879,16 @@ int bt_cap_commander_distribute_broadcast_code(
 	err = bt_bap_broadcast_assistant_set_broadcast_code(
 		conn, proc_param->distribute_broadcast_code.src_id,
 		proc_param->distribute_broadcast_code.broadcast_code);
-
 	if (err != 0) {
+		bt_cap_common_clear_proc(active_proc);
+
 		LOG_DBG("Failed to start distribute broadcast code for conn %p: %d", (void *)conn,
 			err);
 
-		bt_cap_common_clear_active_proc();
-
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -871,9 +915,13 @@ void cap_commander_register_broadcast_assistant_callbacks(void)
 }
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 
-static void cap_commander_proc_complete(void)
+/**
+ * @brief Completes a CAP commander procedure.
+ *
+ * This will also unlock the provided @p active_proc
+ */
+static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	enum bt_cap_common_proc_type proc_type;
 	struct bt_conn *failed_conn;
 	int err;
@@ -889,10 +937,10 @@ static void cap_commander_proc_complete(void)
 			 * it's best to leave this up to the application layer
 			 */
 
-			bt_cap_handover_complete();
+			bt_cap_handover_complete(active_proc);
 		} else if (proc_type == BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP) {
 			if (err != 0) {
-				bt_cap_handover_complete();
+				bt_cap_handover_complete(active_proc);
 			} else {
 				/* We've successfully stopped broadcast reception on all the
 				 * acceptors. We can now stop and delete the broadcast source before
@@ -900,7 +948,7 @@ static void cap_commander_proc_complete(void)
 				 */
 
 				/* Clear commander parameters. Normally this is done just before the
-				 * application callbacks with bt_cap_common_clear_active_proc, but
+				 * application callbacks with bt_cap_common_clear_proc, but
 				 * since that is not happening here, we clear them manually. They
 				 * need to be cleared as the call to the CAP APIs does not clear old
 				 * data, and we need to reset everything before calling
@@ -909,19 +957,22 @@ static void cap_commander_proc_complete(void)
 				memset(active_proc->proc_param.commander, 0,
 				       sizeof(active_proc->proc_param.commander));
 
-				err = bt_cap_handover_broadcast_reception_stopped();
+				err = bt_cap_handover_broadcast_reception_stopped(active_proc);
 				if (err != 0) {
-					bt_cap_handover_complete();
+					bt_cap_handover_complete(active_proc);
+				} else {
+					bt_cap_common_unlock_proc();
 				}
 			}
 		} else {
+			bt_cap_common_unlock_proc();
 			__ASSERT(false, "invalid proc_type %d", proc_type);
 		}
 
 		return;
 	}
 
-	bt_cap_common_clear_active_proc();
+	bt_cap_common_clear_proc(active_proc);
 
 	if (cap_cb == NULL) {
 		return;
@@ -986,14 +1037,18 @@ static void cap_commander_proc_complete(void)
 
 int bt_cap_commander_cancel(void)
 {
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
 	if (!bt_cap_common_proc_is_active() && !bt_cap_common_proc_is_aborted()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("No CAP procedure is in progress");
 
 		return -EALREADY;
 	}
 
 	bt_cap_common_abort_proc(NULL, -ECANCELED);
-	cap_commander_proc_complete();
+	cap_commander_proc_complete(active_proc);
 
 	return 0;
 }
@@ -1086,6 +1141,7 @@ static void cap_commander_vcp_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int e
 
 	vcp_err = bt_vcp_vol_ctlr_conn_get(vol_ctlr, &conn);
 	if (vcp_err != 0) {
+		bt_cap_common_unlock_proc();
 		LOG_ERR("Failed to get conn by vol_ctrl: %d", vcp_err);
 		return;
 	}
@@ -1093,6 +1149,8 @@ static void cap_commander_vcp_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int e
 	LOG_DBG("conn %p", (void *)conn);
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1107,10 +1165,10 @@ static void cap_commander_vcp_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int e
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
-		LOG_DBG("Proc is aborted");
 		if (bt_cap_common_proc_all_handled()) {
-			LOG_DBG("All handled");
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1127,10 +1185,12 @@ static void cap_commander_vcp_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int e
 		if (err != 0) {
 			LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -1145,7 +1205,11 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -1159,8 +1223,6 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE, param->count);
 
-	active_proc = bt_cap_common_get_active_proc();
-
 	for (size_t i = 0U; i < param->count; i++) {
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &param->members[i]);
@@ -1169,7 +1231,7 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1189,10 +1251,12 @@ int bt_cap_commander_change_volume(const struct bt_cap_commander_change_volume_p
 	if (err != 0) {
 		LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -1266,6 +1330,8 @@ static void cap_commander_vcp_vol_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int 
 
 	vcp_err = bt_vcp_vol_ctlr_conn_get(vol_ctlr, &conn);
 	if (vcp_err != 0) {
+		bt_cap_common_unlock_proc();
+
 		LOG_ERR("Failed to get conn by vol_ctrl: %d", vcp_err);
 		return;
 	}
@@ -1273,6 +1339,8 @@ static void cap_commander_vcp_vol_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int 
 	LOG_DBG("conn %p", (void *)conn);
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1287,10 +1355,10 @@ static void cap_commander_vcp_vol_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int 
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
-		LOG_DBG("Proc is aborted");
 		if (bt_cap_common_proc_all_handled()) {
-			LOG_DBG("All handled");
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1311,10 +1379,12 @@ static void cap_commander_vcp_vol_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int 
 		if (err != 0) {
 			LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -1330,7 +1400,11 @@ int bt_cap_commander_change_volume_mute_state(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -1344,7 +1418,6 @@ int bt_cap_commander_change_volume_mute_state(
 	}
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE, param->count);
-	active_proc = bt_cap_common_get_active_proc();
 
 	for (size_t i = 0U; i < param->count; i++) {
 		struct bt_conn *member_conn =
@@ -1354,7 +1427,7 @@ int bt_cap_commander_change_volume_mute_state(
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1379,10 +1452,12 @@ int bt_cap_commander_change_volume_mute_state(
 	if (err != 0) {
 		LOG_DBG("Failed to set volume mute state for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -1476,6 +1551,8 @@ static void cap_commander_vcp_set_offset_cb(struct bt_vocs *inst, int err)
 
 	vocs_err = bt_vocs_client_conn_get(inst, &conn);
 	if (vocs_err != 0) {
+		bt_cap_common_unlock_proc();
+
 		LOG_ERR("Failed to get conn by inst: %d", vocs_err);
 		return;
 	}
@@ -1483,6 +1560,8 @@ static void cap_commander_vcp_set_offset_cb(struct bt_vocs *inst, int err)
 	LOG_DBG("conn %p", (void *)conn);
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1497,10 +1576,10 @@ static void cap_commander_vcp_set_offset_cb(struct bt_vocs *inst, int err)
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
-		LOG_DBG("Proc is aborted");
 		if (bt_cap_common_proc_all_handled()) {
-			LOG_DBG("All handled");
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1518,10 +1597,12 @@ static void cap_commander_vcp_set_offset_cb(struct bt_vocs *inst, int err)
 		if (err != 0) {
 			LOG_DBG("Failed to set offset for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -1538,7 +1619,11 @@ int bt_cap_commander_change_volume_offset(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -1552,8 +1637,6 @@ int bt_cap_commander_change_volume_offset(
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE, param->count);
 
-	active_proc = bt_cap_common_get_active_proc();
-
 	for (size_t i = 0U; i < param->count; i++) {
 		const struct bt_cap_commander_change_volume_offset_member_param *member_param =
 			&param->param[i];
@@ -1565,7 +1648,7 @@ int bt_cap_commander_change_volume_offset(
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1574,7 +1657,7 @@ int bt_cap_commander_change_volume_offset(
 		if (vol_ctlr == NULL) {
 			LOG_DBG("Invalid param->members[%zu] vol_ctlr", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1583,7 +1666,7 @@ int bt_cap_commander_change_volume_offset(
 		if (err != 0 || included.vocs_cnt == 0) {
 			LOG_DBG("Invalid param->members[%zu] vocs", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1607,10 +1690,12 @@ int bt_cap_commander_change_volume_offset(
 	if (err != 0) {
 		LOG_DBG("Failed to set volume for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -1706,6 +1791,7 @@ static void cap_commander_micp_mic_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, in
 
 	micp_err = bt_micp_mic_ctlr_conn_get(mic_ctlr, &conn);
 	if (micp_err != 0) {
+		bt_cap_common_unlock_proc();
 		LOG_ERR("Failed to get conn by mic_ctlr: %d", micp_err);
 		return;
 	}
@@ -1713,6 +1799,8 @@ static void cap_commander_micp_mic_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, in
 	LOG_DBG("conn %p", (void *)conn);
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1727,10 +1815,10 @@ static void cap_commander_micp_mic_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, in
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
-		LOG_DBG("Proc is aborted");
 		if (bt_cap_common_proc_all_handled()) {
-			LOG_DBG("All handled");
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1751,10 +1839,12 @@ static void cap_commander_micp_mic_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, in
 		if (err != 0) {
 			LOG_DBG("Failed to change mute for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -1770,7 +1860,11 @@ int bt_cap_commander_change_microphone_mute_state(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -1785,8 +1879,6 @@ int bt_cap_commander_change_microphone_mute_state(
 		__ASSERT(err == 0, "Failed to register MICP callbacks: %d", err);
 	}
 
-	active_proc = bt_cap_common_get_active_proc();
-
 	for (size_t i = 0U; i < param->count; i++) {
 		struct bt_conn *member_conn =
 			bt_cap_common_get_member_conn(param->type, &param->members[i]);
@@ -1795,7 +1887,7 @@ int bt_cap_commander_change_microphone_mute_state(
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -1820,10 +1912,12 @@ int bt_cap_commander_change_microphone_mute_state(
 	if (err != 0) {
 		LOG_DBG("Failed to set microphone mute state for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -1910,6 +2004,7 @@ static void cap_commander_micp_gain_set_cb(struct bt_aics *inst, int err)
 
 	micp_err = bt_aics_client_conn_get(inst, &conn);
 	if (micp_err != 0) {
+		bt_cap_common_unlock_proc();
 		LOG_ERR("Failed to get conn by aics: %d", micp_err);
 		return;
 	}
@@ -1917,6 +2012,8 @@ static void cap_commander_micp_gain_set_cb(struct bt_aics *inst, int err)
 	LOG_DBG("conn %p", (void *)conn);
 	if (!bt_cap_common_conn_in_active_proc(conn)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1931,10 +2028,10 @@ static void cap_commander_micp_gain_set_cb(struct bt_aics *inst, int err)
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
-		LOG_DBG("Proc is aborted");
 		if (bt_cap_common_proc_all_handled()) {
-			LOG_DBG("All handled");
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1950,10 +2047,12 @@ static void cap_commander_micp_gain_set_cb(struct bt_aics *inst, int err)
 		if (err != 0) {
 			LOG_DBG("Failed to set gain for conn %p: %d", (void *)conn, err);
 			bt_cap_common_abort_proc(conn, err);
-			cap_commander_proc_complete();
+			cap_commander_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_commander_proc_complete();
+		cap_commander_proc_complete(active_proc);
 	}
 }
 
@@ -1969,7 +2068,11 @@ int bt_cap_commander_change_microphone_gain_setting(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -1983,8 +2086,6 @@ int bt_cap_commander_change_microphone_gain_setting(
 		__ASSERT(err == 0, "Failed to register MICP callbacks: %d", err);
 	}
 
-	active_proc = bt_cap_common_get_active_proc();
-
 	for (size_t i = 0U; i < param->count; i++) {
 		const union bt_cap_set_member *member = &param->param[i].member;
 		struct bt_conn *member_conn = bt_cap_common_get_member_conn(param->type, member);
@@ -1995,7 +2096,7 @@ int bt_cap_commander_change_microphone_gain_setting(
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->param[%zu].member", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -2004,7 +2105,7 @@ int bt_cap_commander_change_microphone_gain_setting(
 		if (mic_ctlr == NULL) {
 			LOG_DBG("Invalid param->param[%zu].member mic_ctlr", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -2013,7 +2114,7 @@ int bt_cap_commander_change_microphone_gain_setting(
 		if (err != 0 || included.aics_cnt == 0) {
 			LOG_DBG("Invalid param->param[%zu].member aics", i);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -2037,10 +2138,12 @@ int bt_cap_commander_change_microphone_gain_setting(
 	if (err != 0) {
 		LOG_DBG("Failed to set gain for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -17,11 +17,15 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/syscalls/kernel.h>
+#include <zephyr/toolchain.h>
 
 #include "cap_internal.h"
 #include "csip_internal.h"
@@ -34,14 +38,36 @@ static struct bt_cap_common_client bt_cap_common_clients[CONFIG_BT_MAX_CONN];
 static const struct bt_uuid *cas_uuid = BT_UUID_CAS;
 static struct bt_cap_common_proc active_proc;
 
+static K_MUTEX_DEFINE(active_proc_mutex);
+#define CAP_ACTIVE_PROC_MUTEX_TIMEOUT K_MSEC(10000U)
+
 struct bt_cap_common_proc *bt_cap_common_get_active_proc(void)
 {
+	__maybe_unused int err;
+
+	err = k_mutex_lock(&active_proc_mutex, CAP_ACTIVE_PROC_MUTEX_TIMEOUT);
+	__ASSERT(err == 0, "Failed to lock mutex: %d", err);
+
+	LOG_DBG("Took active_proc_mutex (count: %u)", active_proc_mutex.lock_count);
+
 	return &active_proc;
 }
 
-void bt_cap_common_clear_active_proc(void)
+void bt_cap_common_unlock_proc(void)
 {
-	(void)memset(&active_proc, 0, sizeof(active_proc));
+	__maybe_unused int err;
+
+	err = k_mutex_unlock(&active_proc_mutex);
+	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
+
+	LOG_DBG("Released active_proc_mutex");
+}
+
+void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc)
+{
+	(void)memset(proc, 0, sizeof(*proc));
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt)

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -37,19 +37,21 @@ static const struct bt_cap_handover_cb *cap_cb;
 bool bt_cap_handover_is_handover_broadcast_source(
 	const struct bt_cap_broadcast_source *cap_broadcast_source)
 {
-
 	const struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	const struct bt_cap_handover_proc_param *proc_param = &active_proc->proc_param.handover;
+	bool ret;
 
 	if (!bt_cap_common_handover_is_active()) {
-		return false;
+		ret = false;
+	} else if (proc_param->is_unicast_to_broadcast) {
+		ret = cap_broadcast_source == proc_param->unicast_to_broadcast.broadcast_source;
+	} else {
+		ret = cap_broadcast_source == proc_param->broadcast_to_unicast.broadcast_source;
 	}
 
-	if (proc_param->is_unicast_to_broadcast) {
-		return cap_broadcast_source == proc_param->unicast_to_broadcast.broadcast_source;
-	}
+	bt_cap_common_unlock_proc();
 
-	return cap_broadcast_source == proc_param->broadcast_to_unicast.broadcast_source;
+	return ret;
 }
 
 struct cap_unicast_group_stream_lookup {
@@ -86,9 +88,8 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 	return false;
 }
 
-void bt_cap_handover_complete(void)
+void bt_cap_handover_complete(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	struct bt_cap_handover_proc_param *proc_param = &active_proc->proc_param.handover;
 	const bool is_unicast_to_broadcast = proc_param->is_unicast_to_broadcast;
 	struct bt_conn *failed_conn = active_proc->failed_conn;
@@ -104,7 +105,7 @@ void bt_cap_handover_complete(void)
 		unicast_group = proc_param->broadcast_to_unicast.unicast_group;
 	}
 
-	bt_cap_common_clear_active_proc();
+	bt_cap_common_clear_proc(active_proc);
 
 	if (cap_cb != NULL) {
 		if (is_unicast_to_broadcast) {
@@ -121,21 +122,32 @@ void bt_cap_handover_complete(void)
 	}
 }
 
-void bt_cap_handover_unicast_proc_complete(void)
+void bt_cap_handover_unicast_proc_complete(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	const enum bt_cap_common_proc_type proc_type = active_proc->proc_type;
 
 	if (proc_type == BT_CAP_COMMON_PROC_TYPE_STOP) {
 		if (active_proc->err != 0) {
-			bt_cap_handover_complete();
+			bt_cap_handover_complete(active_proc);
 		} else {
 			/* continue */
-			bt_cap_handover_unicast_to_broadcast_setup_broadcast();
+			const int err =
+				bt_cap_handover_unicast_to_broadcast_setup_broadcast(active_proc);
+
+			if (err != 0) {
+				active_proc->err = err;
+				active_proc->failed_conn = NULL;
+
+				bt_cap_handover_complete(active_proc);
+			} else {
+				bt_cap_common_unlock_proc();
+			}
 		}
 	} else if (proc_type == BT_CAP_COMMON_PROC_TYPE_START) {
-		bt_cap_handover_complete();
+		bt_cap_handover_complete(active_proc);
 	} else {
+		bt_cap_common_unlock_proc();
+
 		__ASSERT(false, "invalid proc_type %d", proc_type);
 	}
 }
@@ -155,18 +167,30 @@ void bt_cap_handover_broadcast_source_stopped(uint8_t reason)
 		proc_param->unicast_to_broadcast.broadcast_source = NULL;
 
 		active_proc->err = reason;
-		bt_cap_handover_complete();
+		bt_cap_handover_complete(active_proc);
 	} else {
 		if (reason == BT_HCI_ERR_LOCALHOST_TERM_CONN) {
 			/* Successfully stopped the broadcast source */
 			proc_param->broadcast_to_unicast.broadcast_stopped = true;
 			if (proc_param->broadcast_to_unicast.reception_stopped) {
-				bt_cap_handover_broadcast_audio_stopped();
+				const int err =
+					bt_cap_handover_broadcast_audio_stopped(active_proc);
+
+				if (err != 0) {
+					active_proc->err = err;
+					active_proc->failed_conn = NULL;
+
+					bt_cap_handover_complete(active_proc);
+
+					return;
+				}
 			}
+
+			bt_cap_common_unlock_proc();
 		} else {
 			proc_param->unicast_to_broadcast.broadcast_source = NULL;
 			active_proc->err = reason;
-			bt_cap_handover_complete();
+			bt_cap_handover_complete(active_proc);
 		}
 	}
 }
@@ -194,7 +218,8 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 		active_proc->err = err;
 		active_proc->failed_conn = NULL;
 
-		bt_cap_handover_complete();
+		bt_cap_handover_complete(active_proc);
+
 		return;
 	}
 
@@ -210,7 +235,7 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 			active_proc->err = err;
 			active_proc->failed_conn = NULL;
 
-			bt_cap_handover_complete();
+			bt_cap_handover_complete(active_proc);
 
 			return;
 		}
@@ -266,24 +291,24 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 		param.count++;
 	}
 
-	err = cap_commander_broadcast_reception_start(&param);
+	err = cap_commander_broadcast_reception_start(active_proc, &param);
 	if (err != 0) {
 		LOG_DBG("Failed to start reception start: %d", err);
 
-		bt_cap_handover_complete();
+		bt_cap_handover_complete(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 }
 
-void bt_cap_handover_unicast_to_broadcast_setup_broadcast(void)
+int bt_cap_handover_unicast_to_broadcast_setup_broadcast(struct bt_cap_common_proc *active_proc)
 {
 	struct bt_cap_initiator_broadcast_create_param *broadcast_create_param;
 	struct bt_cap_broadcast_source **broadcast_source;
 	struct bt_cap_handover_proc_param *proc_param;
-	struct bt_cap_common_proc *active_proc;
 	struct bt_le_ext_adv *ext_adv;
 	int err;
 
-	active_proc = bt_cap_common_get_active_proc();
 	proc_param = &active_proc->proc_param.handover;
 	broadcast_create_param = proc_param->unicast_to_broadcast.broadcast_create_param;
 
@@ -296,28 +321,24 @@ void bt_cap_handover_unicast_to_broadcast_setup_broadcast(void)
 	err = bt_cap_initiator_broadcast_audio_create(broadcast_create_param, broadcast_source);
 	if (err != 0) {
 		LOG_DBG("Failed to create broadcast source: %d", err);
-		active_proc->err = err;
-		active_proc->failed_conn = NULL;
 
-		bt_cap_handover_complete();
-
-		return;
+		return err;
 	}
 
 	ext_adv = active_proc->proc_param.handover.unicast_to_broadcast.ext_adv;
 	err = bt_cap_initiator_broadcast_audio_start(*broadcast_source, ext_adv);
 	if (err != 0) {
+		__maybe_unused int del_err;
+
 		LOG_DBG("Failed to start broadcast source: %d", err);
-		active_proc->err = err;
-		active_proc->failed_conn = NULL;
 
-		err = bt_cap_initiator_broadcast_audio_delete(*broadcast_source);
-		__ASSERT_NO_MSG(err == 0);
+		del_err = bt_cap_initiator_broadcast_audio_delete(*broadcast_source);
+		__ASSERT_NO_MSG(del_err == 0);
 
-		bt_cap_handover_complete();
-
-		return;
+		return err;
 	}
+
+	return 0;
 }
 
 static bool valid_unicast_to_broadcast_stream_metadata_param(
@@ -566,12 +587,6 @@ int bt_cap_handover_unicast_to_broadcast(
 		return -EINVAL;
 	}
 
-	if (bt_cap_common_test_and_set_proc_active()) {
-		LOG_DBG("A CAP procedure is already in progress");
-
-		return -EBUSY;
-	}
-
 	/* TBD: How do we prevent the unicast group from being modified or deleted while we are
 	 * doing this procedure?
 	 * TBD: How do we check for BASS?
@@ -580,12 +595,19 @@ int bt_cap_handover_unicast_to_broadcast(
 	if (lookup_data.cnt == 0U) {
 		LOG_DBG("param->unicast_group does not contain any streams");
 
-		bt_cap_common_clear_active_proc();
-
 		return -EINVAL;
 	}
 
 	active_proc = bt_cap_common_get_active_proc();
+
+	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
+		LOG_DBG("A CAP procedure is already in progress");
+
+		return -EBUSY;
+	}
+
 	proc_param = &active_proc->proc_param.handover;
 
 	/* Populate an array of unique connection pointers to determine which acceptors to add the
@@ -632,7 +654,7 @@ int bt_cap_handover_unicast_to_broadcast(
 				"Some streams contain an invalid conn pointer",
 				stream);
 
-			bt_cap_common_clear_active_proc();
+			bt_cap_common_clear_proc(active_proc);
 
 			return -EINVAL;
 		}
@@ -693,14 +715,16 @@ int bt_cap_handover_unicast_to_broadcast(
 
 	__ASSERT_NO_MSG(bt_cap_initiator_valid_unicast_audio_stop_param(&stop_param));
 
-	err = cap_initiator_unicast_audio_stop(&stop_param);
+	err = cap_initiator_unicast_audio_stop(active_proc, &stop_param);
 	if (err != 0) {
 		LOG_DBG("Failed to stop unicast audio: %d", err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
 
 		return -ENOEXEC;
 	}
+
+	bt_cap_common_unlock_proc();
 
 	return 0;
 }
@@ -880,13 +904,11 @@ valid_broadcast_to_unicast_param(const struct bt_cap_handover_broadcast_to_unica
 	return true;
 }
 
-int bt_cap_handover_broadcast_reception_stopped(void)
+int bt_cap_handover_broadcast_reception_stopped(struct bt_cap_common_proc *active_proc)
 {
 	struct bt_cap_handover_proc_param *proc_param;
-	struct bt_cap_common_proc *active_proc;
 	int err;
 
-	active_proc = bt_cap_common_get_active_proc();
 	proc_param = &active_proc->proc_param.handover;
 
 	err = bt_cap_initiator_broadcast_audio_stop(
@@ -899,9 +921,8 @@ int bt_cap_handover_broadcast_reception_stopped(void)
 	return err;
 }
 
-static bool bt_cap_handover_broadcast_to_unicast_all_stopped(void)
+static bool cap_handover_broadcast_to_unicast_all_stopped(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	bool all_stopped = true;
 
 	ARRAY_FOR_EACH(
@@ -947,19 +968,30 @@ void bt_cap_handover_receive_state_updated(const struct bt_conn *conn,
 			}
 		}
 
-		if (bt_cap_handover_broadcast_to_unicast_all_stopped()) {
+		if (cap_handover_broadcast_to_unicast_all_stopped(active_proc)) {
 			proc_param->broadcast_to_unicast.reception_stopped = true;
 			if (proc_param->broadcast_to_unicast.broadcast_stopped) {
 				/* Delete source and start unicast */
-				bt_cap_handover_broadcast_audio_stopped();
+				const int err =
+					bt_cap_handover_broadcast_audio_stopped(active_proc);
+
+				if (err != 0) {
+					active_proc->err = err;
+					active_proc->failed_conn = NULL;
+
+					bt_cap_handover_complete(active_proc);
+
+					return;
+				}
 			}
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
-void bt_cap_handover_broadcast_audio_stopped(void)
+int bt_cap_handover_broadcast_audio_stopped(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	struct bt_cap_handover_proc_param *proc_param = &active_proc->proc_param.handover;
 	int err;
 
@@ -971,11 +1003,8 @@ void bt_cap_handover_broadcast_audio_stopped(void)
 		proc_param->broadcast_to_unicast.broadcast_source);
 	if (err != 0) {
 		LOG_DBG("Failed to delete broadcast source: %d", err);
-		active_proc->err = err;
 
-		bt_cap_handover_complete();
-
-		return;
+		return err;
 	}
 	proc_param->broadcast_to_unicast.broadcast_source = NULL;
 
@@ -983,23 +1012,19 @@ void bt_cap_handover_broadcast_audio_stopped(void)
 					  &proc_param->broadcast_to_unicast.unicast_group);
 	if (err != 0) {
 		LOG_DBG("Failed to create unicast group: %d", err);
-		active_proc->err = err;
 
-		bt_cap_handover_complete();
-
-		return;
+		return err;
 	}
 
 	err = cap_initiator_unicast_audio_start(
-		proc_param->broadcast_to_unicast.unicast_start_param);
+		active_proc, proc_param->broadcast_to_unicast.unicast_start_param);
 	if (err != 0) {
 		LOG_DBG("Failed to start unicast audio: %d", err);
-		active_proc->err = err;
 
-		bt_cap_handover_complete();
-
-		return;
+		return err;
 	}
+
+	return 0;
 }
 
 int bt_cap_handover_broadcast_to_unicast(
@@ -1023,13 +1048,16 @@ int bt_cap_handover_broadcast_to_unicast(
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	active_proc = bt_cap_common_get_active_proc();
 	proc_param = &active_proc->proc_param.handover;
 	proc_param->broadcast_to_unicast.unicast_group_param = param->unicast_group_param;
 	proc_param->broadcast_to_unicast.unicast_start_param = param->unicast_start_param;
@@ -1045,7 +1073,7 @@ int bt_cap_handover_broadcast_to_unicast(
 		/* Register the broadcast assistant callbacks to receive the BASS receive states */
 		cap_commander_register_broadcast_assistant_callbacks();
 
-		err = bt_cap_handover_broadcast_reception_stopped();
+		err = bt_cap_handover_broadcast_reception_stopped(active_proc);
 	} else {
 		for (size_t i = 0U; i < param->reception_stop_param->count; i++) {
 			proc_param->broadcast_to_unicast.pending_recv_state_conns[i] =
@@ -1053,11 +1081,14 @@ int bt_cap_handover_broadcast_to_unicast(
 					param->reception_stop_param->type,
 					&param->reception_stop_param->param[i].member);
 		}
-		err = cap_commander_broadcast_reception_stop(param->reception_stop_param);
+		err = cap_commander_broadcast_reception_stop(active_proc,
+							     param->reception_stop_param);
 	}
 
 	if (err != 0) {
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -559,10 +559,9 @@ static bool iso_is_in_state(const struct bt_cap_stream *cap_stream, enum bt_iso_
 	return bap_stream_get_iso_state(bap_stream) == state;
 }
 
-static void set_cap_stream_in_progress(struct bt_cap_stream *cap_stream, bool value)
+static void set_cap_stream_in_progress(struct bt_cap_common_proc *active_proc,
+				       struct bt_cap_stream *cap_stream, bool value)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
-
 	for (size_t i = 0U; i < active_proc->proc_cnt; i++) {
 		if (cap_stream == active_proc->proc_param.initiator[i].stream) {
 			active_proc->proc_param.initiator[i].in_progress = value;
@@ -1239,9 +1238,8 @@ bool bt_cap_initiator_valid_unicast_audio_start_param(
 	return true;
 }
 
-static void cap_initiator_unicast_audio_proc_complete(void)
+static void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc *active_proc)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	enum bt_cap_common_proc_type proc_type;
 	struct bt_conn *failed_conn;
 	int err;
@@ -1252,7 +1250,7 @@ static void cap_initiator_unicast_audio_proc_complete(void)
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
 		/* Clear initiator parameters. Normally this is done just before the
-		 * application callbacks with bt_cap_common_clear_active_proc, but
+		 * application callbacks with bt_cap_common_clear_proc, but
 		 * since that is not happening here, we clear them manually. They
 		 * need to be cleared as the call to the CAP APIs does not clear old
 		 * data, and we need to reset everything before calling
@@ -1261,11 +1259,12 @@ static void cap_initiator_unicast_audio_proc_complete(void)
 		memset(active_proc->proc_param.initiator, 0,
 		       sizeof(active_proc->proc_param.initiator));
 
-		bt_cap_handover_unicast_proc_complete();
+		bt_cap_handover_unicast_proc_complete(active_proc);
+
 		return;
 	}
 
-	bt_cap_common_clear_active_proc();
+	bt_cap_common_clear_proc(active_proc);
 
 	if (cap_cb == NULL) {
 		return;
@@ -1296,18 +1295,20 @@ static void cap_initiator_unicast_audio_proc_complete(void)
 void bt_cap_initiator_cp_cb(struct bt_cap_stream *cap_stream, enum bt_bap_ascs_rsp_code rsp_code,
 			    enum bt_bap_ascs_reason reason)
 {
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
 	LOG_DBG("cap_stream %p", cap_stream);
 
-	set_cap_stream_in_progress(cap_stream, false);
+	set_cap_stream_in_progress(active_proc, cap_stream, false);
 
 	if (rsp_code != BT_BAP_ASCS_RSP_CODE_SUCCESS) {
-		struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
-
 		/* In the case that the control point write is rejected, we will not get a ASE state
 		 * change notification. This is considered an error that shall abort the current
 		 * procedure.
@@ -1322,18 +1323,22 @@ void bt_cap_initiator_cp_cb(struct bt_cap_stream *cap_stream, enum bt_bap_ascs_r
 
 		if (bt_cap_common_proc_is_aborted()) {
 			if (bt_cap_common_proc_all_handled()) {
-				cap_initiator_unicast_audio_proc_complete();
+				cap_initiator_unicast_audio_proc_complete(active_proc);
+			} else {
+				bt_cap_common_unlock_proc();
 			}
 
 			return;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 static int
-cap_initiator_unicast_audio_configure(const struct bt_cap_unicast_audio_start_param *param)
+cap_initiator_unicast_audio_configure(struct bt_cap_common_proc *active_proc,
+				      const struct bt_cap_unicast_audio_start_param *param)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	struct bt_cap_initiator_proc_param *proc_param;
 	struct bt_audio_codec_cfg *codec_cfg;
 	struct bt_bap_stream *bap_stream;
@@ -1400,7 +1405,8 @@ cap_initiator_unicast_audio_configure(const struct bt_cap_unicast_audio_start_pa
 	return err;
 }
 
-int cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param)
+int cap_initiator_unicast_audio_start(struct bt_cap_common_proc *active_proc,
+				      const struct bt_cap_unicast_audio_start_param *param)
 {
 	bool all_streaming = true;
 
@@ -1419,26 +1425,33 @@ int cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_pa
 		return -EALREADY;
 	}
 
-	return cap_initiator_unicast_audio_configure(param);
+	return cap_initiator_unicast_audio_configure(active_proc, param);
 }
 
 int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param)
 {
+	struct bt_cap_common_proc *active_proc;
 	int err;
 
 	if (!bt_cap_initiator_valid_unicast_audio_start_param(param)) {
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	err = cap_initiator_unicast_audio_start(param);
+	err = cap_initiator_unicast_audio_start(active_proc, param);
 	if (err != 0) {
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;
@@ -1454,6 +1467,8 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1464,6 +1479,8 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		 * the unicast server caches the configuration - We treat it as a release
 		 */
 		bt_cap_initiator_released(cap_stream);
+
+		bt_cap_common_unlock_proc();
 		return;
 	} else if (!bt_cap_common_subproc_is_type(BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG)) {
 		/* Unexpected callback - Abort */
@@ -1477,7 +1494,9 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1506,7 +1525,9 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to config stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1540,6 +1561,7 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 			*free_conn = stream_conn;
 		} else {
 			__ASSERT(false, "[%zu]: No free conns", i);
+			bt_cap_common_unlock_proc();
 			return;
 		}
 	}
@@ -1550,6 +1572,7 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 	bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_QOS_CONFIG);
 	proc_param = get_next_proc_param(active_proc);
 	if (proc_param == NULL) {
+		bt_cap_common_unlock_proc();
 		/* If proc_param is NULL then this step is a no-op and we can skip to the next step
 		 */
 		bt_cap_initiator_qos_configured(active_proc->proc_param.initiator[0].stream);
@@ -1589,12 +1612,16 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 			 */
 			bt_cap_common_abort_proc(conns[i], err);
 			if (i == 0U) {
-				cap_initiator_unicast_audio_proc_complete();
+				cap_initiator_unicast_audio_proc_complete(active_proc);
+
+				return;
 			}
 
-			return;
+			break;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
@@ -1603,6 +1630,8 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1622,7 +1651,9 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1636,12 +1667,16 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 
 		if (!bt_cap_common_proc_is_done()) {
 			/* Not yet finished, wait for all */
+			bt_cap_common_unlock_proc();
+
 			return;
 		}
 
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_ENABLE);
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param == NULL) {
+			bt_cap_common_unlock_proc();
+
 			/* If proc_param is NULL then this step is a no-op and we can skip to the
 			 * next step
 			 */
@@ -1661,7 +1696,9 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
 		}
 	} else if (bt_cap_common_subproc_is_type(BT_CAP_COMMON_SUBPROC_TYPE_RELEASE)) {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -1682,9 +1719,13 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to release stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
@@ -1696,6 +1737,8 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1713,7 +1756,9 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1737,7 +1782,9 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1746,6 +1793,8 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 	bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_CONNECT);
 	proc_param = get_next_proc_param(active_proc);
 	if (proc_param == NULL) {
+		bt_cap_common_unlock_proc();
+
 		/* If proc_param is NULL then this step is a no-op and we can skip to the next step
 		 */
 		bt_cap_initiator_connected(active_proc->proc_param.initiator[0].stream);
@@ -1764,6 +1813,8 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		 */
 		proc_param->in_progress = false;
 		bt_cap_initiator_connected(proc_param->stream);
+
+		bt_cap_common_unlock_proc();
 	} else if (err != 0) {
 		LOG_DBG("Failed to connect stream %p: %d", proc_param->stream, err);
 
@@ -1772,7 +1823,10 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		 * once all sent requests has completed
 		 */
 		bt_cap_common_abort_proc(bap_stream->conn, err);
-		cap_initiator_unicast_audio_proc_complete();
+		cap_initiator_unicast_audio_proc_complete(active_proc);
+	} else {
+
+		bt_cap_common_unlock_proc();
 	}
 }
 
@@ -1785,12 +1839,14 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
 	LOG_DBG("cap_stream %p", cap_stream);
 
-	set_cap_stream_in_progress(cap_stream, false);
+	set_cap_stream_in_progress(active_proc, cap_stream, false);
 
 	if (!bt_cap_common_subproc_is_type(BT_CAP_COMMON_SUBPROC_TYPE_CONNECT)) {
 		/* Unexpected callback - Abort */
@@ -1811,7 +1867,9 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1839,9 +1897,13 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 				LOG_DBG("Failed to connect stream %p: %d", next_cap_stream, err);
 
 				bt_cap_common_abort_proc(next_bap_stream->conn, err);
-				cap_initiator_unicast_audio_proc_complete();
+				cap_initiator_unicast_audio_proc_complete(active_proc);
+
+				return;
 			}
 		} /* else pending connection - wait for connected callback */
+
+		bt_cap_common_unlock_proc();
 
 		return;
 	}
@@ -1853,6 +1915,8 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 	bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_START);
 	proc_param = get_next_proc_param(active_proc);
 	if (proc_param == NULL) {
+		bt_cap_common_unlock_proc();
+
 		/* If proc_param is NULL then this step is a no-op and we can skip to the next step
 		 */
 		bt_cap_initiator_started(active_proc->proc_param.initiator[0].stream);
@@ -1869,11 +1933,13 @@ void bt_cap_initiator_connected(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to start stream %p: %d", proc_param->stream, err);
 
 			bt_cap_common_abort_proc(bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
 
 			return;
 		}
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
@@ -1884,6 +1950,8 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -1892,6 +1960,8 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 		/* If we are still connecting the streams, we terminate early as to not perform any
 		 * start operations until all streams are connected
 		 */
+		bt_cap_common_unlock_proc();
+
 		return;
 	} else if (!bt_cap_common_subproc_is_type(BT_CAP_COMMON_SUBPROC_TYPE_START)) {
 		/* Unexpected callback - Abort */
@@ -1905,7 +1975,9 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -1936,18 +2008,20 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 					 * once all sent requests has completed
 					 */
 					bt_cap_common_abort_proc(next_bap_stream->conn, err);
-					cap_initiator_unicast_audio_proc_complete();
+					cap_initiator_unicast_audio_proc_complete(active_proc);
 
 					return;
 				}
 			}
 		} /* else await notifications from server */
 
+		bt_cap_common_unlock_proc();
+
 		/* Return to await for response from server */
 		return;
 	}
 
-	cap_initiator_unicast_audio_proc_complete();
+	cap_initiator_unicast_audio_proc_complete(active_proc);
 }
 
 static bool can_update_metadata(const struct bt_bap_stream *bap_stream)
@@ -2048,8 +2122,8 @@ static bool valid_unicast_audio_update_param(const struct bt_cap_unicast_audio_u
 
 int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_update_param *param)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	struct bt_cap_initiator_proc_param *proc_param;
+	struct bt_cap_common_proc *active_proc;
 	struct bt_bap_stream *bap_stream;
 	const uint8_t *meta;
 	size_t meta_len;
@@ -2059,7 +2133,11 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
@@ -2095,7 +2173,9 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
 	if (err != 0) {
 		LOG_DBG("Failed to update metadata for stream %p: %d", proc_param->stream, err);
 
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;
@@ -2103,14 +2183,18 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
 
 int bt_cap_initiator_unicast_audio_cancel(void)
 {
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
 	if (!bt_cap_common_proc_is_active() && !bt_cap_common_proc_is_aborted()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("No CAP procedure is in progress");
 
 		return -EALREADY;
 	}
 
 	bt_cap_common_abort_proc(NULL, -ECANCELED);
-	cap_initiator_unicast_audio_proc_complete();
+	cap_initiator_unicast_audio_proc_complete(active_proc);
 
 	return 0;
 }
@@ -2121,6 +2205,8 @@ void bt_cap_initiator_metadata_updated(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -2136,7 +2222,9 @@ void bt_cap_initiator_metadata_updated(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -2165,13 +2253,13 @@ void bt_cap_initiator_metadata_updated(struct bt_cap_stream *cap_stream)
 				err);
 
 			bt_cap_common_abort_proc(bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
-
-		return;
+	} else {
+		cap_initiator_unicast_audio_proc_complete(active_proc);
 	}
-
-	cap_initiator_unicast_audio_proc_complete();
 }
 
 static bool can_release_stream(const struct bt_bap_stream *bap_stream)
@@ -2308,9 +2396,9 @@ bool bt_cap_initiator_valid_unicast_audio_stop_param(
 	return true;
 }
 
-int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param)
+int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
+				     const struct bt_cap_unicast_audio_stop_param *param)
 {
-	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	bool can_release = false;
 	bool can_disable = false;
 	bool can_stop = false;
@@ -2412,21 +2500,28 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 
 int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param)
 {
+	struct bt_cap_common_proc *active_proc;
 	int err;
 
 	if (!bt_cap_initiator_valid_unicast_audio_stop_param(param)) {
 		return -EINVAL;
 	}
 
+	active_proc = bt_cap_common_get_active_proc();
+
 	if (bt_cap_common_test_and_set_proc_active()) {
+		bt_cap_common_unlock_proc();
+
 		LOG_DBG("A CAP procedure is already in progress");
 
 		return -EBUSY;
 	}
 
-	err = cap_initiator_unicast_audio_stop(param);
+	err = cap_initiator_unicast_audio_stop(active_proc, param);
 	if (err != 0) {
-		bt_cap_common_clear_active_proc();
+		bt_cap_common_clear_proc(active_proc);
+	} else {
+		bt_cap_common_unlock_proc();
 	}
 
 	return err;
@@ -2438,6 +2533,8 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -2453,7 +2550,9 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -2477,7 +2576,9 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to disable stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -2489,6 +2590,8 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param == NULL) {
+			bt_cap_common_unlock_proc();
+
 			/* If proc_param is NULL then this step is a no-op and we can skip to the
 			 * next step
 			 */
@@ -2507,8 +2610,11 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
-		} /* else wait for server notification*/
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			/* else wait for server notification*/
+			bt_cap_common_unlock_proc();
+		}
 	}
 }
 
@@ -2518,6 +2624,8 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -2534,13 +2642,17 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 			/* We are still doing disable - Wait for those to be done, as stopped may
 			 * also be called when we are disabling sink ASEs
 			 */
+			bt_cap_common_unlock_proc();
+
 			return;
 		}
 	}
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -2565,7 +2677,9 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 				LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
 
 				bt_cap_common_abort_proc(next_bap_stream->conn, err);
-				cap_initiator_unicast_audio_proc_complete();
+				cap_initiator_unicast_audio_proc_complete(active_proc);
+
+				return;
 			}
 		} /* else await notification from server */
 	} else {
@@ -2579,6 +2693,8 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 
 		if (!bt_cap_common_proc_is_done()) {
 			/* We are still disabling or stopping some */
+			bt_cap_common_unlock_proc();
+
 			return;
 		}
 
@@ -2589,11 +2705,13 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 			/* If proc_param is NULL then this step is a no-op and we can finish the
 			 * procedure
 			 */
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
 
 			return;
 		} /* wait for bt_cap_initiator_qos_configured */
 	}
+
+	bt_cap_common_unlock_proc();
 }
 
 void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
@@ -2602,6 +2720,8 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_stream_in_active_proc(cap_stream)) {
 		/* State change happened outside of a procedure; ignore */
+		bt_cap_common_unlock_proc();
+
 		return;
 	}
 
@@ -2625,7 +2745,9 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_aborted()) {
 		if (bt_cap_common_proc_all_handled()) {
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 
 		return;
@@ -2649,10 +2771,12 @@ void bt_cap_initiator_released(struct bt_cap_stream *cap_stream)
 			LOG_DBG("Failed to release stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete();
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+		} else {
+			bt_cap_common_unlock_proc();
 		}
 	} else {
-		cap_initiator_unicast_audio_proc_complete();
+		cap_initiator_unicast_audio_proc_complete(active_proc);
 	}
 }
 

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -20,6 +20,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -294,8 +295,19 @@ struct bt_cap_common_client {
 	const struct bt_csip_set_coordinator_csis_inst *csis_inst;
 };
 
+/**
+ * Returns the current active proc with the mutex taken.
+ *
+ * The caller is responsible for unlocking the mutex.
+ */
 struct bt_cap_common_proc *bt_cap_common_get_active_proc(void);
-void bt_cap_common_clear_active_proc(void);
+void bt_cap_common_unlock_proc(void);
+/**
+ * @brief Clear and unlock @p proc
+ *
+ * @param proc The procedure to unlock and clear
+ */
+void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc);
 void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt);
 void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type);
 void bt_cap_common_set_handover_active(void);
@@ -327,28 +339,32 @@ bool bt_cap_initiator_stream_is_in_state(const struct bt_bap_stream *bap_stream,
 					 enum bt_bap_ep_state state);
 bool bt_cap_initiator_valid_unicast_audio_stop_param(
 	const struct bt_cap_unicast_audio_stop_param *param);
-int cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param);
-int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param);
+int cap_initiator_unicast_audio_start(struct bt_cap_common_proc *active_proc,
+				      const struct bt_cap_unicast_audio_start_param *param);
+int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
+				     const struct bt_cap_unicast_audio_stop_param *param);
 enum bt_bap_ep_state bt_cap_initiator_stream_get_state(const struct bt_bap_stream *bap_stream);
 
 int cap_commander_broadcast_reception_start(
-	const struct bt_cap_commander_broadcast_reception_start_param *param);
-int cap_commander_broadcast_reception_start(
+	struct bt_cap_common_proc *active_proc,
 	const struct bt_cap_commander_broadcast_reception_start_param *param);
 int cap_commander_broadcast_reception_stop(
+	struct bt_cap_common_proc *active_proc,
 	const struct bt_cap_commander_broadcast_reception_stop_param *param);
 bool bt_cap_commander_valid_broadcast_reception_stop_param(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param);
 void cap_commander_register_broadcast_assistant_callbacks(void);
 
-void bt_cap_handover_complete(void);
-void bt_cap_handover_unicast_to_broadcast_setup_broadcast(void);
+/** Completes the handover procedure. This also unlocks the active_proc_mutex. */
+void bt_cap_handover_complete(struct bt_cap_common_proc *active_proc);
+int bt_cap_handover_unicast_to_broadcast_setup_broadcast(struct bt_cap_common_proc *active_proc);
 void bt_cap_handover_unicast_to_broadcast_reception_start(void);
-void bt_cap_handover_unicast_proc_complete(void);
+/** Completes the unicast procedure. This also unlocks the active_proc_mutex. */
+void bt_cap_handover_unicast_proc_complete(struct bt_cap_common_proc *active_proc);
 void bt_cap_handover_broadcast_source_stopped(uint8_t reason);
-void bt_cap_handover_broadcast_audio_stopped(void);
+int bt_cap_handover_broadcast_audio_stopped(struct bt_cap_common_proc *active_proc);
 void bt_cap_handover_receive_state_updated(const struct bt_conn *conn,
 					   const struct bt_bap_scan_delegator_recv_state *state);
 bool bt_cap_handover_is_handover_broadcast_source(
 	const struct bt_cap_broadcast_source *cap_broadcast_source);
-int bt_cap_handover_broadcast_reception_stopped(void);
+int bt_cap_handover_broadcast_reception_stopped(struct bt_cap_common_proc *active_proc);


### PR DESCRIPTION
The functions bt_cap_commander_cancel and
bt_cap_initiator_unicast_audio_cancel were not thread safe, and calling these while handling e.g. a notifications or a write response could cause fatal errors.

This commit modifies active_proc so that all access to it is guarded by a mutex.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104273