### PR TITLE
boards: heltec: migrate ssd1306fb -> ssd1306

### DIFF
--- a/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_procpu.dts
@@ -129,7 +129,7 @@
 	pinctrl-names = "default";
 
 	ssd1306_128x64: display-controller@3c {
-		compatible = "solomon,ssd1306fb";
+		compatible = "solomon,ssd1306";
 		reg = <0x3c>;
 		width = <128>;
 		height = <64>;


### PR DESCRIPTION
Migated the ssd1306_128x64 node binding for the heltec_wifi_lora32_v3/esp32s3/procpu board from solomon,ssd1306fb to solomon,ssd1306.

From the migration guide:
https://docs.zephyrproject.org/latest/releases/migration-guide-4.4.html#display
"solomon,ssd1306fb and solomon,ssd1309fb devicetree compatibles has been renamed solomon,ssd1306 and solomon,ssd1309 respectively [...]"

Tested the following samples on hardware:
`samples/drivers/display`
`samples/subsys/display/lvgl`

