### PR TITLE
tests: Add timeout management system benchmark

### DIFF
--- a/tests/benchmarks/timeout_mgmt/CMakeLists.txt
+++ b/tests/benchmarks/timeout_mgmt/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(timeout_mgmt)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+  )

--- a/tests/benchmarks/timeout_mgmt/Kconfig
+++ b/tests/benchmarks/timeout_mgmt/Kconfig
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Timeout Management Benchmark"
+
+source "Kconfig.zephyr"
+
+config BENCHMARK_NUM_ITERATIONS
+	int "Number of iterations to gather data"
+	default 1000
+	help
+	  This option specifies the number of times each test will be executed
+	  before calculating the average times for reporting.
+
+config BENCHMARK_NUM_TIMEOUTS
+	int "Number of timeouts"
+	default 100
+	help
+	  This option specifies the maximum number of timeouts that the test
+	  will create. Increasing this value will place greater stress on
+	  the timeout management system.
+
+config BENCHMARK_TIMEOUT_BIAS
+	int "Timeout bias (ticks) to apply to the timeouts"
+	default 0
+	help
+	  This option specifies the number of ticks to add to each of the
+	  timeouts created by the test. This bias can be used to ensure that
+	  timeouts do not expire mid-test which could skew the results.
+
+
+config BENCHMARK_VERBOSE
+	bool "Display detailed results"
+	default n
+	help
+	  This option displays the average time of all the iterations done for
+	  each timeout in the tests. This generates large amounts of output. To
+	  analyze it, it is recommended to redirect the output to a file.

--- a/tests/benchmarks/timeout_mgmt/README.rst
+++ b/tests/benchmarks/timeout_mgmt/README.rst
@@ -1,0 +1,22 @@
+Timeout Management Measurements
+###############################
+
+Zephyr application developers may need to characterize the performance of the
+timeout management system for their platform. This benchmark provides a set of
+tests that measure the time taken to add and remove timeouts from the system.
+
+This benchmark measures:
+
+* Time to add timeouts with increasing timeout values
+* Time to add timeouts with decreasing timeout values
+* Time to remove timeouts from earliest expiration to latest
+* Time to remove timeouts from latest expiration to earliest
+
+By default, these tests show the minimum, maximum, and averages of the measured
+times. However, if the verbose option is enabled then the set of measured
+times will be displayed. The following will build this project with verbose
+support:
+
+.. code-block:: shell
+
+    EXTRA_CONF_FILE="prj.verbose.conf" west build -p -b <board> <path to project>

--- a/tests/benchmarks/timeout_mgmt/prj.conf
+++ b/tests/benchmarks/timeout_mgmt/prj.conf
@@ -1,0 +1,30 @@
+# Default base configuration file
+
+CONFIG_TEST=y
+
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1
+
+# We use irq_offload(), enable it
+CONFIG_IRQ_OFFLOAD=y
+
+# Reduce memory/code footprint
+CONFIG_BT=n
+CONFIG_FORCE_NO_ASSERT=y
+
+CONFIG_TEST_HW_STACK_PROTECTION=n
+# Disable HW Stack Protection (see #28664)
+CONFIG_HW_STACK_PROTECTION=n
+CONFIG_COVERAGE=n
+
+# Disable system power management
+CONFIG_PM=n
+
+CONFIG_TIMING_FUNCTIONS=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+CONFIG_APPLICATION_DEFINED_SYSCALL=y
+
+# Disable time slicing
+CONFIG_TIMESLICING=n
+
+CONFIG_SPEED_OPTIMIZATIONS=y

--- a/tests/benchmarks/timeout_mgmt/prj.verbose.conf
+++ b/tests/benchmarks/timeout_mgmt/prj.verbose.conf
@@ -1,0 +1,4 @@
+# Extra configuration file to enable verbose reporting
+# Use with EXTRA_CONF_FILE
+
+CONFIG_BENCHMARK_VERBOSE=y

--- a/tests/benchmarks/timeout_mgmt/src/main.c
+++ b/tests/benchmarks/timeout_mgmt/src/main.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @file
+ * This file contains the main testing module that invokes all the tests.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/timestamp.h>
+#include "utils.h"
+#include <zephyr/tc_util.h>
+#include <ksched.h>
+
+#define IS_ODD(x) (((x) & 0x1) != 0)
+
+uint32_t tm_off;
+
+static struct _timeout timeout[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+
+static uint64_t add_cycles[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+static uint64_t abort_cycles[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+static uint32_t ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+
+static void cycles_reset(unsigned int num_timeouts)
+{
+	unsigned int i;
+
+	for (i = 0; i < num_timeouts; i++) {
+		add_cycles[i] = 0ULL;
+		abort_cycles[i] = 0ULL;
+	}
+}
+
+/* Empty handler */
+static void handler(struct _timeout *t)
+{
+	ARG_UNUSED(t);
+}
+
+static void test_decreasing_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	for (i = 0; i < num_timeouts; i++) {
+		ticks[i] = num_timeouts - i + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/*
+	 * Abort timeouts in the reverse order of when they would expire. It is
+	 * possible that some timeouts may have expired by the time we stop
+	 * them, but that is deemed acceptable for the characterization curve.
+	 */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[i]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static void test_increasing_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	/* Add timeouts with increasing waits. */
+
+	for (i = 0; i < num_timeouts; i++) {
+		ticks[i] = i + 1 + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/*
+	 * Abort timeouts in the same order as they would expire. It is
+	 * possible that some timeouts may have expired by the time we stop
+	 * them, but that is deemed acceptable for the characterization curve.
+	 */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[i]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static void test_interleaved_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	/* Add timeouts with interleaving converging to the middle */
+
+	for (i = 0; i < num_timeouts; i++) {
+		if (IS_ODD(i)) {
+			ticks[i] = (num_timeouts - (i / 2)) + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+		} else {
+			ticks[i] = (i / 2) + 1 + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+		}
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/* Remove timeouts with interleaving diverging from the middle */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[num_timeouts - i - 1]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static uint64_t sqrt_u64(uint64_t square)
+{
+	if (square > 1) {
+		uint64_t lo = sqrt_u64(square >> 2) << 1;
+		uint64_t hi = lo + 1;
+
+		return ((hi * hi) > square) ? lo : hi;
+	}
+
+	return square;
+}
+
+static void compute_and_report_stats(unsigned int num_timeouts,
+				     unsigned int num_iterations,
+				     uint64_t *cycles, const char *str)
+{
+	uint64_t minimum = cycles[0];
+	uint64_t maximum = cycles[0];
+	uint64_t total = cycles[0];
+	uint64_t average;
+	uint64_t std_dev = 0;
+	uint64_t tmp;
+	uint64_t diff;
+	unsigned int i;
+
+	for (i = 1; i < num_timeouts; i++) {
+		if (cycles[i] > maximum) {
+			maximum = cycles[i];
+		}
+
+		if (cycles[i] < minimum) {
+			minimum = cycles[i];
+		}
+
+		total += cycles[i];
+	}
+
+	minimum /= (uint64_t)num_iterations;
+	maximum /= (uint64_t)num_iterations;
+	average = total / (num_timeouts * num_iterations);
+
+	for (i = 0; i < num_timeouts; i++) {
+		tmp = cycles[i] / num_iterations;
+		diff = (average > tmp) ? (average - tmp) : (tmp - average);
+
+		std_dev += (diff * diff);
+	}
+	std_dev /= num_timeouts;
+	std_dev = sqrt_u64(std_dev);
+
+	printk("------------------------------------\n");
+	printk("%s\n", str);
+
+	printk("    Minimum : %7llu cycles (%7u nsec)\n", minimum,
+	       (uint32_t)timing_cycles_to_ns(minimum));
+	printk("    Maximum : %7llu cycles (%7u nsec)\n", maximum,
+	       (uint32_t)timing_cycles_to_ns(maximum));
+	printk("    Average : %7llu cycles (%7u nsec)\n", average,
+	       (uint32_t)timing_cycles_to_ns(average));
+	printk("    Std Deviation: %7llu cycles (%7u nsec)\n", std_dev,
+	       (uint32_t)timing_cycles_to_ns(std_dev));
+}
+
+int main(void)
+{
+	unsigned int i;
+	unsigned int freq;
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	char description[120];
+	char tag[50];
+#endif
+
+	timing_init();
+
+	bench_test_init();
+
+	freq = timing_freq_get_mhz();
+
+	printk("Time Measurements for timeout system\n");
+	printk("Timing results: Clock frequency: %u MHz\n", freq);
+
+	timing_start();
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_increasing_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts with increasing waits");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.increasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout",
+			 tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts in order of expiration");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.abort.increasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout",
+			 tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_decreasing_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts with decreasing waits");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.decreasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts in reverse expiration order");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			"timeout.abort.decreasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_interleaved_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts converging to middle");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.converging.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts diverging from middle");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			"timeout.abort.diverging.%04u.ticks",
+			ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS - i - 1]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout",
+			 tag, ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS - i - 1]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	timing_stop();
+
+	TC_END_REPORT(0);
+
+	return 0;
+}

--- a/tests/benchmarks/timeout_mgmt/src/utils.h
+++ b/tests/benchmarks/timeout_mgmt/src/utils.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __BENCHMARK_TIMEOUT_MGMT_UTILS_H
+#define __BENCHMARK_TIMEOUT_MGMT_UTILS_H
+/*
+ * @brief This file contains macros used in the timeout management benchmarking.
+ */
+
+#include <zephyr/timing/timing.h>
+#include <zephyr/sys/printk.h>
+#include <stdio.h>
+
+#ifdef CSV_FORMAT_OUTPUT
+#define FORMAT_STR   "%-74s,%s,%s\n"
+#define CYCLE_FORMAT "%8u"
+#define NSEC_FORMAT  "%8u"
+#else
+#define FORMAT_STR   "%-74s:%s , %s\n"
+#define CYCLE_FORMAT "%8u cycles"
+#define NSEC_FORMAT  "%8u ns"
+#endif
+
+/**
+ * @brief Display a line of statistics
+ *
+ * This macro displays the following:
+ *  1. Test description summary
+ *  2. Number of cycles
+ *  3. Number of nanoseconds
+ */
+#define PRINT_F(summary, cycles, nsec)                            \
+	do {                                                      \
+		char cycle_str[32];                               \
+		char nsec_str[32];                                \
+								  \
+		snprintk(cycle_str, 30, CYCLE_FORMAT, cycles);    \
+		snprintk(nsec_str, 30, NSEC_FORMAT, nsec);        \
+		printk(FORMAT_STR, summary, cycle_str, nsec_str); \
+	} while (0)
+
+#define PRINT_STATS(summary, value)                   \
+	PRINT_F(summary, value,                       \
+		(uint32_t)timing_cycles_to_ns(value))
+
+#define PRINT_STATS_AVG(summary, value, counter)                    \
+	PRINT_F(summary, value / counter,                           \
+		(uint32_t)timing_cycles_to_ns_avg(value, counter))
+
+
+#endif

--- a/tests/benchmarks/timeout_mgmt/testcase.yaml
+++ b/tests/benchmarks/timeout_mgmt/testcase.yaml
@@ -1,0 +1,19 @@
+common:
+  platform_key:
+    - arch
+  min_ram: 32
+  timeout: 120
+  tags:
+    - kernel
+    - benchmark
+  integration_platforms:
+    - qemu_x86
+    - qemu_cortex_a53
+  harness: console
+
+tests:
+  benchmark.timeout_mgmt.simple:
+    harness_config:
+      type: one_line
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"


### PR DESCRIPTION
The timeout management benchmark can be used to show how the timeout management system performs under different loads.