### PR TITLE
drivers: wifi: nxp: Reconfigure bandcfg when disabling AP

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -372,6 +372,7 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 #ifndef CONFIG_WIFI_NM_HOSTAPD_AP
 		wifi_mgmt_raise_ap_disable_result_event(g_uap.netif, WIFI_STATUS_AP_SUCCESS);
 #endif
+		wlan_uap_bandcfg_recfg();
 		break;
 #endif
 	case WLAN_REASON_PS_ENTER:


### PR DESCRIPTION
Reconfigure the bandcfg when disabling AP so that the band configurations are match between hostapd and wifi driver.