### PR TITLE
driver: ram_console: add RAM console header

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -127,6 +127,15 @@ config RAM_CONSOLE_BUFFER_SIZE
 	  one byte less. Messages will wrap around if the actual length
 	  is exceeded.
 
+config RAM_CONSOLE_HEADER
+	bool "Add RAM console header at the first 64B memory of console buffer"
+	depends on RAM_CONSOLE
+	help
+	  Add RAM console header at the first 64B memory of console buffer, the
+	  header includes the information of flag string, buffer address and size,
+	  cursor's absolute position, the header is defined in the header file:
+	  include/zephyr/drivers/console/ram_console.h
+
 config RTT_CONSOLE
 	bool "Use RTT console"
 	depends on USE_SEGGER_RTT

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -8,6 +8,7 @@
  */
 
 
+#include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
@@ -15,6 +16,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/devicetree_regions.h>
+#include <zephyr/drivers/console/ram_console.h>
 
 #ifdef CONFIG_RAM_CONSOLE_BUFFER_SECTION
 #if !DT_HAS_CHOSEN(zephyr_ram_console)
@@ -36,13 +38,27 @@
 
 char ram_console_buf[CONFIG_RAM_CONSOLE_BUFFER_SIZE] RAM_CONSOLE_BUF_ATTR;
 char *ram_console;
+#ifdef CONFIG_RAM_CONSOLE_HEADER
+static struct ram_console_header *header;
+#else
 static int pos;
+#endif
 
 static int ram_console_out(int character)
 {
+#ifdef CONFIG_RAM_CONSOLE_HEADER
+	header->buf_addr[header->pos % header->buf_size] = (char)character;
+	header->pos++;
+	/* in case of overflow as it is absolute position */
+	if (header->pos == 0) {
+		header->pos = (0xFFFFFFFF % header->buf_size) + 1;
+	}
+#else
 	ram_console[pos] = (char)character;
 	/* Leave one byte to ensure we're always NULL-terminated */
 	pos = (pos + 1) % (CONFIG_RAM_CONSOLE_BUFFER_SIZE - 1);
+#endif
+
 	return character;
 }
 
@@ -57,6 +73,17 @@ static int ram_console_init(void)
 #else
 	ram_console = ram_console_buf;
 #endif
+#ifdef CONFIG_RAM_CONSOLE_HEADER
+	unsigned int size = CONFIG_RAM_CONSOLE_BUFFER_SIZE - 1;
+
+	memset(ram_console, 0, size + 1);
+	header = (struct ram_console_header *)ram_console;
+	strcpy(header->flag_string, RAM_CONSOLE_HEAD_STR);
+	header->buf_addr = (char *)(ram_console + RAM_CONSOLE_HEAD_SIZE);
+	header->buf_size = size - RAM_CONSOLE_HEAD_SIZE;
+	header->pos = 0;
+#endif
+
 	__printk_hook_install(ram_console_out);
 	__stdout_hook_install(ram_console_out);
 

--- a/include/zephyr/drivers/console/ram_console.h
+++ b/include/zephyr/drivers/console/ram_console.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief RAM Console definitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CONSOLE_RAM_CONSOLE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_RAM_CONSOLE_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief RAM Console Header FLAG String
+ */
+#define RAM_CONSOLE_HEAD_STR	"RAM_CONSOLE"
+/**
+ * @brief RAM Console Header size in bytes
+ */
+#define RAM_CONSOLE_HEAD_SIZE	64
+
+/**
+ * @brief RAM Console Header struct definition
+ */
+struct ram_console_header {
+	/**
+	 * RAM Console header flag string which is RAM_CONSOLE_HEAD_STR by
+	 * default.
+	 */
+	char flag_string[12];
+	/**
+	 * The start address of RAM Console buffer which is used to save
+	 * console strings.
+	 */
+	char *buf_addr;
+	/**
+	 * The size of RAM Console buffer which is used to save console
+	 * strings.
+	 */
+	size_t buf_size;
+	/**
+	 * The absolute position of console cursor, which is start from zero
+	 * and always increasing, and back to zero when it is overflow.
+	 */
+	uint32_t pos;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CONSOLE_RAM_CONSOLE_H_ */


### PR DESCRIPTION
Add some header information at the first 64 bytes of ram console memory, so could use dumping tool to dump the buffer dynamically.