### PR TITLE
soc: renesas: rx: Init RX clocks in soc_early_init_hook

### DIFF
--- a/drivers/clock_control/clock_control_renesas_rx_root_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_rx_root_cgc.c
@@ -37,16 +37,6 @@ static int clock_control_renesas_rx_root_get_rate(const struct device *dev,
 	return 0;
 }
 
-static int clock_control_rx_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-#if CONFIG_HAS_RENESAS_RX_RDP
-	/* Call to HAL layer to initialize system clock and peripheral clock */
-	mcu_clock_setup();
-#endif
-	return 0;
-}
-
 static DEVICE_API(clock_control, clock_control_renesas_rx_root_api) = {
 	.on = clock_control_renesas_rx_root_on,
 	.off = clock_control_renesas_rx_root_off,
@@ -57,7 +47,7 @@ static DEVICE_API(clock_control, clock_control_renesas_rx_root_api) = {
 	static const struct clock_control_rx_root_cfg clock_control_rx_root_cfg##idx = {           \
 		.rate = DT_INST_PROP(idx, clock_frequency),                                        \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(idx, &clock_control_rx_init, NULL, NULL,                             \
+	DEVICE_DT_INST_DEFINE(idx, NULL, NULL, NULL,                             \
 			      &clock_control_rx_root_cfg##idx, PRE_KERNEL_1,                       \
 			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,                                  \
 			      &clock_control_renesas_rx_root_api);

--- a/soc/renesas/rx/rx130/soc.c
+++ b/soc/renesas/rx/rx130/soc.c
@@ -30,6 +30,7 @@ void soc_early_init_hook(void)
 	bsp_ram_initialize();
 	bsp_interrupt_open();
 	bsp_register_protect_open();
+	mcu_clock_setup();
 #if CONFIG_RENESAS_NONE_USED_PORT_INIT == 1
 	/*
 	 * This is the function that initializes the unused port.

--- a/soc/renesas/rx/rx140/soc.c
+++ b/soc/renesas/rx/rx140/soc.c
@@ -23,6 +23,7 @@ void soc_early_init_hook(void)
 	bsp_ram_initialize();
 	bsp_interrupt_open();
 	bsp_register_protect_open();
+	mcu_clock_setup();
 #if CONFIG_RENESAS_NONE_USED_PORT_INIT == 1
 	/*
 	 * This is the function that initializes the unused port.

--- a/soc/renesas/rx/rx261/soc.c
+++ b/soc/renesas/rx/rx261/soc.c
@@ -31,6 +31,7 @@ void soc_early_init_hook(void)
 	bsp_ram_initialize();
 	bsp_interrupt_open();
 	bsp_register_protect_open();
+	mcu_clock_setup();
 #ifdef CONFIG_RENESAS_NONE_USED_PORT_INIT
 	/*
 	 * This is the function that initializes the unused port.

--- a/soc/renesas/rx/rx26t/soc.c
+++ b/soc/renesas/rx/rx26t/soc.c
@@ -31,6 +31,7 @@ void soc_early_init_hook(void)
 	bsp_ram_initialize();
 	bsp_interrupt_open();
 	bsp_register_protect_open();
+	mcu_clock_setup();
 #if CONFIG_RENESAS_NONE_USED_PORT_INIT == 1
 	/*
 	 * This is the function that initializes the unused port.


### PR DESCRIPTION
The clock initialization for the RX series devices is not appropriate when placed under the root clock node. Without adding an external fixed clock on the board, the clock will not be initialized.
Therefore, the initialization must be handled inside soc_early_init_hook.