### PR TITLE
boards: adi: Enable rtc counter on MAX78000 boards

### DIFF
--- a/boards/adi/max78000evkit/max78000evkit_max78000_m4.dts
+++ b/boards/adi/max78000evkit/max78000evkit_max78000_m4.dts
@@ -130,3 +130,7 @@
 	pinctrl-0 = <&owm_io_p0_18 &owm_pe_p0_19>;
 	pinctrl-names = "default";
 };
+
+&rtc_counter {
+	status = "okay";
+};

--- a/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
+++ b/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
@@ -14,6 +14,7 @@ supported:
   - gpio
   - i2c
   - pwm
+  - rtc_counter
   - serial
   - spi
   - trng

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
@@ -134,3 +134,7 @@ feather_i2c: &i2c1 {
 	pinctrl-0 = <&owm_io_p0_6 &owm_pe_p0_7>;
 	pinctrl-names = "default";
 };
+
+&rtc_counter {
+	status = "okay";
+};

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - i2c
   - pwm
+  - rtc_counter
   - serial
   - spi
   - trng


### PR DESCRIPTION
Enable rtc counter on MAX78000EVKIT and MAX78000FTHR boards.