### PR TITLE
bluetooth: host: monitor: fix build with 64b log timestamps

### DIFF
--- a/samples/bluetooth/central/sample.yaml
+++ b/samples/bluetooth/central/sample.yaml
@@ -25,3 +25,12 @@ tests:
       - xg27_dk2602a/efr32bg27c140f768im40
       - xg29_rb4412a/efr32mg29b140f1024im40
     build_only: true
+  sample.bluetooth.central.64b_ts:
+    extra_args:
+      - CONFIG_BT_DEBUG_MONITOR_UART=y
+      - CONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+      - CONFIG_LOG=y
+      - CONFIG_LOG_TIMESTAMP_64BIT=y
+    platform_allow:
+      - qemu_cortex_m3
+    build_only: true

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -194,7 +194,7 @@ static void encode_drops(struct bt_monitor_hdr *hdr, uint8_t type,
 	}
 }
 
-static uint32_t monitor_ts_get(void)
+static log_timestamp_t monitor_ts_get(void)
 {
 	uint64_t cycle;
 
@@ -207,7 +207,7 @@ static uint32_t monitor_ts_get(void)
 	return (cycle / (sys_clock_hw_cycles_per_sec() / MONITOR_TS_FREQ));
 }
 
-static inline void encode_hdr(struct bt_monitor_hdr *hdr, uint32_t timestamp,
+static inline void encode_hdr(struct bt_monitor_hdr *hdr, log_timestamp_t timestamp,
 			      uint16_t opcode, uint16_t len)
 {
 	struct bt_monitor_ts32 *ts;
@@ -217,7 +217,12 @@ static inline void encode_hdr(struct bt_monitor_hdr *hdr, uint32_t timestamp,
 
 	ts = (void *)hdr->ext;
 	ts->type = BT_MONITOR_TS32;
-	ts->ts32 = timestamp;
+	/* The btsnoop protocol only supports 32-bit timestamps (in 1/10th ms).
+	 * This overflows after 4.97 days, which is acceptable as it only affects
+	 * rendering in btmon/wireshark. Recordings are usually not that long
+	 * anyway, and packet ordering is still preserved.
+	 */
+	ts->ts32 = (uint32_t)timestamp;
 	hdr->hdr_len = sizeof(*ts);
 
 	encode_drops(hdr, BT_MONITOR_COMMAND_DROPS, &drops.cmd);
@@ -357,7 +362,7 @@ static void monitor_log_process(const struct log_backend *const backend,
 		return;
 	}
 
-	encode_hdr(&hdr, (uint32_t)log_msg_get_timestamp(&msg->log),
+	encode_hdr(&hdr, log_msg_get_timestamp(&msg->log),
 		   BT_MONITOR_USER_LOGGING,
 		   sizeof(user_log) + sizeof(id) + ctx.total_len + 1);
 


### PR DESCRIPTION
If CONFIG_LOG_TIMESTAMP_64BIT is enabled, then the call to log_set_timestamp_func in the Bluetooth monitor is type-invalid, which may fail to build with -Werror.

To avoid this type inconsistency let's use the type `log_timestamp_t`, which accounts for the correct size, depending on selected config.

Even though the monitoring protocol only seems to support 32b timestamps, the rest of the module is already based on 64b timestamps, so the truncation is only done later in the transmission, when calling encode_hdr() in bt_monitor_send().

In addition to the aforementioned fix, also add a build-only regression test in the Bluetooth central sample. **NB:** this is probably not a good place to put such a build test case, but on the other hand I believe that writing a dedicated test application for that very specific condition is probably overkill. Would anyone have a recommendation on where to put this ? In other words, is there any sample or test application that would be built in the CI that pulls the Bluetooth and logging subsystems to test combinations of kconfig options ?