### PR TITLE
drivers: i2s: renesas: add RX secondary chained buffer mechanism

### DIFF
--- a/drivers/i2s/Kconfig.renesas_ra
+++ b/drivers/i2s/Kconfig.renesas_ra
@@ -14,6 +14,13 @@ config I2S_RENESAS_RA_SSIE
 
 if I2S_RENESAS_RA_SSIE
 
+config I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	bool "Secondary RX buffer"
+	default y if I2S_RENESAS_RA_SSIE_DTC
+	help
+	  Enable secondary buffer allocation for RX to use as a
+	  chained buffer and improve data reception continuity.
+
 config I2S_RENESAS_RA_SSIE_DTC
 	bool "DTC on Transmission and Reception"
 	default y

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -47,6 +47,7 @@ struct renesas_ra_ssie_data {
 	ssi_instance_ctrl_t fsp_ctrl;
 	i2s_cfg_t fsp_cfg;
 	ssi_extended_cfg_t fsp_ext_cfg;
+	struct k_spinlock lock;
 	volatile enum i2s_state state;
 	enum i2s_dir active_dir;
 	struct k_msgq rx_queue;
@@ -948,6 +949,7 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 	bool configured = false;
+	int ret;
 
 	if (dir == I2S_DIR_BOTH) {
 		if (dev_data->full_duplex == false) {
@@ -972,21 +974,30 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 		return -EINVAL;
 	}
 
-	switch (cmd) {
-	case I2S_TRIGGER_START:
-		return renesas_ra_ssie_start_transfer(dev, dir);
-	case I2S_TRIGGER_STOP:
-		return renesas_ra_ssie_stop(dev);
-	case I2S_TRIGGER_DRAIN:
-		return renesas_ra_trigger_drain(dev, dir);
-	case I2S_TRIGGER_DROP:
-		return renesas_ra_trigger_drop(dev, dir);
-	case I2S_TRIGGER_PREPARE:
-		return renesas_ra_trigger_prepare(dev, dir);
-	default:
-		LOG_ERR("Invalid trigger: %d", cmd);
-		return -EINVAL;
+	K_SPINLOCK(&dev_data->lock) {
+		switch (cmd) {
+		case I2S_TRIGGER_START:
+			ret = renesas_ra_ssie_start_transfer(dev, dir);
+			break;
+		case I2S_TRIGGER_STOP:
+			ret = renesas_ra_ssie_stop(dev);
+			break;
+		case I2S_TRIGGER_DRAIN:
+			ret = renesas_ra_trigger_drain(dev, dir);
+			break;
+		case I2S_TRIGGER_DROP:
+			ret = renesas_ra_trigger_drop(dev, dir);
+			break;
+		case I2S_TRIGGER_PREPARE:
+			ret = renesas_ra_trigger_prepare(dev, dir);
+			break;
+		default:
+			LOG_ERR("Invalid trigger: %d", cmd);
+			ret = -EINVAL;
+		}
 	}
+
+	return ret;
 }
 
 static int i2s_renesas_ra_ssie_init(const struct device *dev)

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -40,12 +40,6 @@ struct renesas_ra_ssie_config {
 };
 
 struct renesas_ra_ssie_stream {
-	struct i2s_config cfg;
-	void *mem_block;
-	size_t mem_block_len;
-};
-
-struct i2s_buf {
 	void *mem_block;
 	size_t mem_block_len;
 };
@@ -58,10 +52,12 @@ struct renesas_ra_ssie_data {
 	enum i2s_dir active_dir;
 	struct k_msgq rx_queue;
 	struct k_msgq tx_queue;
+	struct i2s_config tx_cfg;
+	struct i2s_config rx_cfg;
 	struct renesas_ra_ssie_stream tx_stream;
 	struct renesas_ra_ssie_stream rx_stream;
-	struct i2s_buf tx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_TX_BLOCK_COUNT];
-	struct i2s_buf rx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_RX_BLOCK_COUNT];
+	struct renesas_ra_ssie_stream tx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_TX_BLOCK_COUNT];
+	struct renesas_ra_ssie_stream rx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_RX_BLOCK_COUNT];
 	bool tx_configured;
 	bool rx_configured;
 	bool stop_with_draining;
@@ -219,10 +215,10 @@ static int renesas_ra_ssie_set_clock_divider(const struct device *dev,
 	fsp_ext_cfg->bit_clock_div = bit_clock_div;
 	return 0;
 }
-static void free_buffer_when_stop(struct renesas_ra_ssie_stream *stream)
+static void free_buffer_when_stop(struct i2s_config *cfg, struct renesas_ra_ssie_stream *stream)
 {
 	if (stream->mem_block != NULL) {
-		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
+		k_mem_slab_free(cfg->mem_slab, stream->mem_block);
 		stream->mem_block = NULL;
 		stream->mem_block_len = 0;
 	}
@@ -230,20 +226,20 @@ static void free_buffer_when_stop(struct renesas_ra_ssie_stream *stream)
 
 static void free_tx_buffer(struct renesas_ra_ssie_data *dev_data, const void *buffer)
 {
-	k_mem_slab_free(dev_data->tx_stream.cfg.mem_slab, (void *)buffer);
+	k_mem_slab_free(dev_data->tx_cfg.mem_slab, (void *)buffer);
 	LOG_DBG("Freed TX %p", buffer);
 }
 
 static void free_rx_buffer(struct renesas_ra_ssie_data *dev_data, void *buffer)
 {
-	k_mem_slab_free(dev_data->rx_stream.cfg.mem_slab, buffer);
+	k_mem_slab_free(dev_data->rx_cfg.mem_slab, buffer);
 	LOG_DBG("Freed RX %p", buffer);
 }
 
 static void drop_queue(const struct device *dev, enum i2s_dir dir)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct i2s_buf msg_item;
+	struct renesas_ra_ssie_stream msg_item;
 
 	if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
 		while (k_msgq_get(&dev_data->tx_queue, &msg_item, K_NO_WAIT) == 0) {
@@ -265,17 +261,17 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 	int ret;
 	fsp_err_t fsp_err;
 
-	ret = k_mem_slab_alloc(stream->cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
+	ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
 	if (ret < 0) {
 		return -ENOMEM;
 	}
-	stream->mem_block_len = stream->cfg.block_size;
+	stream->mem_block_len = dev_data->rx_cfg.block_size;
 
 	fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start read data");
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(&dev_data->rx_stream);
+		free_buffer_when_stop(&dev_data->rx_cfg, &dev_data->rx_stream);
 		return -EIO;
 	}
 
@@ -286,7 +282,7 @@ static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *stream = &dev_data->tx_stream;
-	struct i2s_buf msg_item;
+	struct renesas_ra_ssie_stream msg_item;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -303,7 +299,7 @@ static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start write data");
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(stream);
+		free_buffer_when_stop(&dev_data->tx_cfg, stream);
 		return -EIO;
 	}
 
@@ -315,7 +311,7 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *stream_tx = &dev_data->tx_stream;
 	struct renesas_ra_ssie_stream *stream_rx = &dev_data->rx_stream;
-	struct i2s_buf msg_item_tx;
+	struct renesas_ra_ssie_stream msg_item_tx;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -328,19 +324,19 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 	stream_tx->mem_block = msg_item_tx.mem_block;
 	stream_tx->mem_block_len = msg_item_tx.mem_block_len;
 
-	ret = k_mem_slab_alloc(stream_rx->cfg.mem_slab, &stream_rx->mem_block, K_NO_WAIT);
+	ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream_rx->mem_block, K_NO_WAIT);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		return -ENOMEM;
 	}
-	stream_rx->mem_block_len = stream_rx->cfg.block_size;
+	stream_rx->mem_block_len = dev_data->rx_cfg.block_size;
 
 	fsp_err = R_SSI_WriteRead(&dev_data->fsp_ctrl, stream_tx->mem_block, stream_rx->mem_block,
 				  stream_rx->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(stream_tx);
-		free_buffer_when_stop(stream_rx);
+		free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
+		free_buffer_when_stop(&dev_data->rx_cfg, stream_rx);
 		LOG_ERR("Failed to start write and read data");
 		return -EIO;
 	}
@@ -366,7 +362,7 @@ static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 		}
 	}
 
-	k_mem_slab_free(stream_tx->cfg.mem_slab, stream_tx->mem_block);
+	k_mem_slab_free(dev_data->tx_cfg.mem_slab, stream_tx->mem_block);
 	stream_tx->mem_block = NULL;
 	stream_tx->mem_block_len = 0;
 
@@ -378,15 +374,15 @@ static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 	return;
 
 dir_both_idle_end:
-	free_buffer_when_stop(stream_tx);
-	free_buffer_when_stop(stream_rx);
+	free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
+	free_buffer_when_stop(&dev_data->rx_cfg, stream_rx);
 }
 
 static void renesas_ra_ssie_rx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *stream = &dev_data->rx_stream;
-	struct i2s_buf msg_item_rx;
+	struct renesas_ra_ssie_stream msg_item_rx;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -395,7 +391,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	}
 
 	if (dev_data->trigger_drop) {
-		free_buffer_when_stop(stream);
+		free_buffer_when_stop(&dev_data->rx_cfg, stream);
 		return;
 	}
 
@@ -417,12 +413,13 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 			goto rx_disable;
 		}
 
-		ret = k_mem_slab_alloc(stream->cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
+		ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
 		if (ret < 0) {
 			dev_data->state = I2S_STATE_ERROR;
 			goto rx_disable;
 		}
-		stream->mem_block_len = stream->cfg.block_size;
+
+		stream->mem_block_len = dev_data->rx_cfg.block_size;
 
 		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
 		if (fsp_err != FSP_SUCCESS) {
@@ -435,7 +432,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	return;
 
 rx_disable:
-	free_buffer_when_stop(stream);
+	free_buffer_when_stop(&dev_data->rx_cfg, stream);
 	R_SSI_Stop(&dev_data->fsp_ctrl);
 }
 
@@ -443,7 +440,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *stream = &dev_data->tx_stream;
-	struct i2s_buf msg_item;
+	struct renesas_ra_ssie_stream msg_item;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -466,7 +463,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			goto tx_disable;
 		}
 
-		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
+		k_mem_slab_free(dev_data->tx_cfg.mem_slab, stream->mem_block);
 
 		stream->mem_block = msg_item.mem_block;
 		stream->mem_block_len = msg_item.mem_block_len;
@@ -481,7 +478,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 	return;
 
 tx_disable:
-	free_buffer_when_stop(stream);
+	free_buffer_when_stop(&dev_data->tx_cfg, stream);
 }
 
 static void renesas_ra_ssie_idle_callback(const struct device *dev)
@@ -501,7 +498,7 @@ static void renesas_ra_ssie_idle_callback(const struct device *dev)
 	case I2S_DIR_TX:
 		if (dev_data->state == I2S_STATE_STOPPING) {
 			dev_data->state = I2S_STATE_READY;
-			free_buffer_when_stop(&dev_data->tx_stream);
+			free_buffer_when_stop(&dev_data->tx_cfg, &dev_data->tx_stream);
 		}
 
 		if (dev_data->state == I2S_STATE_RUNNING) {
@@ -575,33 +572,62 @@ static int renesas_ra_ssie_start_transfer(const struct device *dev)
 	return 0;
 }
 
+#define I2S_SUPPORTED_OPTIONS                                                                      \
+	(I2S_OPT_FRAME_CLK_CONTROLLER | I2S_OPT_FRAME_CLK_TARGET | I2S_OPT_BIT_CLK_CONTROLLER |    \
+	 I2S_OPT_BIT_CLK_TARGET | I2S_OPT_BIT_CLK_CONT)
+
+#define I2S_UNSUPPORTED_FORMATS (I2S_FMT_DATA_FORMAT_PCM_SHORT | I2S_FMT_DATA_FORMAT_PCM_LONG)
+
 static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir dir,
 					 const struct i2s_config *i2s_cfg)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 	i2s_cfg_t *fsp_cfg = &dev_data->fsp_cfg;
+	uint32_t frame_size_bytes;
+	i2s_pcm_width_t pcm_width;
+	i2s_word_length_t word_length;
+	i2s_mode_t operating_mode;
 	fsp_err_t fsp_err;
 	int ret;
-	uint32_t frame_size_bytes;
-	ssi_extended_cfg_t new_fsp_extend_cfg;
-	i2s_cfg_t new_fsp_cfg;
 
-	/* If the node do not only full duplex, return ERROR when configure I2S_DIR_BOTH */
-	if (dev_data->full_duplex == false) {
-		if (dir == I2S_DIR_BOTH) {
-			LOG_ERR("Cannot configure I2S_DIR_BOTH direction for half-duplex device");
-			return -ENOSYS;
-		}
+	/* Supports only the I2S format */
+	if ((i2s_cfg->format & I2S_UNSUPPORTED_FORMATS) != 0) {
+		LOG_ERR("Unsupported format: 0x%02x", i2s_cfg->format);
+		return -ENOTSUP;
+	}
+
+	/* I2S format using only MSB order */
+	if (i2s_cfg->format & I2S_FMT_DATA_ORDER_LSB) {
+		return -EINVAL;
+	}
+
+	if (i2s_cfg->format & I2S_FMT_DATA_FORMAT_LEFT_JUSTIFIED &&
+	    i2s_cfg->format & I2S_FMT_DATA_FORMAT_RIGHT_JUSTIFIED) {
+		return -EINVAL;
+	}
+
+	if ((i2s_cfg->options & ~I2S_SUPPORTED_OPTIONS)) {
+		LOG_ERR("Unsupported options: 0x%02x", i2s_cfg->options);
+		return -ENOTSUP;
 	}
 
 	/* If the state is not in ready or not ready state, return ERROR */
-	if (dev_data->state != I2S_STATE_READY && dev_data->state != I2S_STATE_NOT_READY) {
+	if (!(dev_data->state == I2S_STATE_READY || dev_data->state == I2S_STATE_NOT_READY)) {
 		LOG_ERR("Cannot configure in state: %d", dev_data->state);
 		return -EINVAL;
 	}
 
-	memcpy(&new_fsp_extend_cfg, &dev_data->fsp_ext_cfg, sizeof(ssi_extended_cfg_t));
-	memcpy(&new_fsp_cfg, &dev_data->fsp_cfg, sizeof(i2s_cfg_t));
+	/* If the node do not only full duplex, return ERROR when configure I2S_DIR_BOTH */
+	if (dev_data->full_duplex == false && dir == I2S_DIR_BOTH) {
+		LOG_ERR("Cannot configure I2S_DIR_BOTH direction for half-duplex device");
+		return -ENOSYS;
+	}
+
+	/* Module always generate bit clock although there is no data transferring */
+	if (i2s_cfg->options & I2S_OPT_BIT_CLK_GATED) {
+		LOG_ERR("Unsupported option: I2S_OPT_BIT_CLK_GATED");
+		return -ENOTSUP;
+	}
 
 	/* If frame_clk_freq = 0, set the state to not ready
 	 * Then drop all data in tx and rx queue
@@ -620,6 +646,11 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 		return 0;
 	}
 
+	if (i2s_cfg->channels != 2) {
+		LOG_ERR("Unsupported number of channels: %u", i2s_cfg->channels);
+		return -EINVAL;
+	}
+
 	if (i2s_cfg->mem_slab == NULL) {
 		LOG_ERR("No memory block to store data");
 		return -EINVAL;
@@ -630,30 +661,25 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 		return -EINVAL;
 	}
 
-	if (i2s_cfg->channels != 2) {
-		LOG_ERR("Unsupported number of channels: %u", i2s_cfg->channels);
-		return -EINVAL;
-	}
-
 	switch (i2s_cfg->word_size) {
 	case 8:
-		new_fsp_cfg.pcm_width = I2S_PCM_WIDTH_8_BITS;
-		new_fsp_cfg.word_length = I2S_WORD_LENGTH_8_BITS;
+		pcm_width = I2S_PCM_WIDTH_8_BITS;
+		word_length = I2S_WORD_LENGTH_8_BITS;
 		frame_size_bytes = 2;
 		break;
 	case 16:
-		new_fsp_cfg.pcm_width = I2S_PCM_WIDTH_16_BITS;
-		new_fsp_cfg.word_length = I2S_WORD_LENGTH_16_BITS;
+		pcm_width = I2S_PCM_WIDTH_16_BITS;
+		word_length = I2S_WORD_LENGTH_16_BITS;
 		frame_size_bytes = 4;
 		break;
 	case 24:
-		new_fsp_cfg.pcm_width = I2S_PCM_WIDTH_24_BITS;
-		new_fsp_cfg.word_length = I2S_WORD_LENGTH_24_BITS;
+		pcm_width = I2S_PCM_WIDTH_24_BITS;
+		word_length = I2S_WORD_LENGTH_24_BITS;
 		frame_size_bytes = 8;
 		break;
 	case 32:
-		new_fsp_cfg.pcm_width = I2S_PCM_WIDTH_32_BITS;
-		new_fsp_cfg.word_length = I2S_WORD_LENGTH_32_BITS;
+		pcm_width = I2S_PCM_WIDTH_32_BITS;
+		word_length = I2S_WORD_LENGTH_32_BITS;
 		frame_size_bytes = 8;
 		break;
 	default:
@@ -666,78 +692,22 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 		return -EINVAL;
 	}
 
-	switch (i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK) {
-	case I2S_FMT_DATA_FORMAT_I2S:
-		break;
-	case I2S_FMT_DATA_FORMAT_PCM_SHORT:
-		__fallthrough;
-	case I2S_FMT_DATA_FORMAT_LEFT_JUSTIFIED:
-		__fallthrough;
-	case I2S_FMT_DATA_FORMAT_RIGHT_JUSTIFIED:
-		__fallthrough;
-	default:
-		LOG_ERR("Unsupported data format: 0x%02x", i2s_cfg->format);
-		return -EINVAL;
-	}
-
-	if (i2s_cfg->format & I2S_FMT_DATA_ORDER_LSB) {
-		LOG_ERR("Unsupported stream format: 0x%02x", i2s_cfg->format);
-		return -EINVAL;
-	}
-
-	if (i2s_cfg->format & I2S_FMT_BIT_CLK_INV) {
-		LOG_ERR("Unsupported stream format: 0x%02x", i2s_cfg->format);
-		return -EINVAL;
-	}
-
-	if (i2s_cfg->format & I2S_FMT_FRAME_CLK_INV) {
-		LOG_ERR("Unsupported stream format: 0x%02x", i2s_cfg->format);
-		return -EINVAL;
-	}
-
-	/* Module always generate bit clock although there is no data transferring */
-	switch (i2s_cfg->options & BIT(0)) {
-	case I2S_OPT_BIT_CLK_CONT:
-		break;
-	case I2S_OPT_BIT_CLK_GATED:
-		__fallthrough;
-	default:
-		LOG_ERR("Unsupported operation mode");
-		return -EINVAL;
-	}
-
 	/*
 	 * For master mode, bit clock and frame clock is generated from internal
 	 * For slave mode, bit clock and frame clock is get from external
 	 */
-	switch (i2s_cfg->options & (I2S_OPT_BIT_CLK_FRAME_CLK_MASK)) {
-	case I2S_OPT_BIT_CLK_CONTROLLER | I2S_OPT_FRAME_CLK_CONTROLLER:
-		new_fsp_cfg.operating_mode = I2S_MODE_MASTER;
-		ret = renesas_ra_ssie_set_clock_divider(dev, i2s_cfg, &new_fsp_extend_cfg);
+	if (i2s_cfg->options & (I2S_OPT_BIT_CLK_TARGET | I2S_OPT_FRAME_CLK_TARGET)) {
+		operating_mode = I2S_MODE_SLAVE;
+	} else {
+		operating_mode = I2S_MODE_MASTER;
+		ret = renesas_ra_ssie_set_clock_divider(dev, i2s_cfg, &dev_data->fsp_ext_cfg);
 		if (ret < 0) {
 			return ret;
 		}
-		break;
-	case I2S_OPT_BIT_CLK_TARGET | I2S_OPT_FRAME_CLK_TARGET:
-		new_fsp_cfg.operating_mode = I2S_MODE_SLAVE;
-		break;
-	default:
-		LOG_ERR("Unsupported operation mode");
-		return -EINVAL;
 	}
-
-	if ((i2s_cfg->options & I2S_OPT_LOOPBACK) || (i2s_cfg->options & I2S_OPT_PINGPONG)) {
-		LOG_ERR("Unsupported options: 0x%02x", i2s_cfg->options);
-		return -EINVAL;
-	}
-
-#ifdef CONFIG_I2S_RENESAS_RA_SSIE_DTC
-	new_fsp_cfg.p_transfer_tx = NULL;
-	new_fsp_cfg.p_transfer_rx = NULL;
-#endif
 
 	if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
-		memcpy(&dev_data->tx_stream.cfg, i2s_cfg, sizeof(struct i2s_config));
+		dev_data->tx_cfg = *i2s_cfg;
 		dev_data->tx_configured = true;
 		if (dev_data->full_duplex == false) {
 			dev_data->rx_configured = false;
@@ -745,22 +715,12 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 	}
 
 	if (dir == I2S_DIR_RX || dir == I2S_DIR_BOTH) {
-		memcpy(&dev_data->rx_stream.cfg, i2s_cfg, sizeof(struct i2s_config));
+		dev_data->rx_cfg = *i2s_cfg;
 		dev_data->rx_configured = true;
 		if (dev_data->full_duplex == false) {
 			dev_data->tx_configured = false;
 		}
 	}
-
-#ifdef CONFIG_I2S_RENESAS_RA_SSIE_DTC
-	if (dev_data->tx_configured == true) {
-		new_fsp_cfg.p_transfer_tx = &dev_data->tx_transfer;
-	}
-
-	if (dev_data->rx_configured == true) {
-		new_fsp_cfg.p_transfer_rx = &dev_data->rx_transfer;
-	}
-#endif
 
 	fsp_err = R_SSI_Close(&dev_data->fsp_ctrl);
 	if (fsp_err != FSP_SUCCESS) {
@@ -768,8 +728,13 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 		return -EIO;
 	}
 
-	memcpy(&dev_data->fsp_ext_cfg, &new_fsp_extend_cfg, sizeof(ssi_extended_cfg_t));
-	memcpy(&dev_data->fsp_cfg, &new_fsp_cfg, sizeof(i2s_cfg_t));
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_DTC
+	fsp_cfg->p_transfer_tx = dev_data->tx_configured ? &dev_data->tx_transfer : NULL;
+	fsp_cfg->p_transfer_rx = dev_data->rx_configured ? &dev_data->rx_transfer : NULL;
+#endif
+	fsp_cfg->pcm_width = pcm_width;
+	fsp_cfg->word_length = word_length;
+	fsp_cfg->operating_mode = operating_mode;
 	fsp_cfg->p_extend = &dev_data->fsp_ext_cfg;
 
 	fsp_err = R_SSI_Open(&dev_data->fsp_ctrl, fsp_cfg);
@@ -789,10 +754,10 @@ static const struct i2s_config *i2s_renesas_ra_ssie_get_config(const struct devi
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 
 	if (dir == I2S_DIR_TX && dev_data->tx_configured) {
-		return &dev_data->tx_stream.cfg;
+		return &dev_data->tx_cfg;
 	}
 	if (dir == I2S_DIR_RX && dev_data->rx_configured) {
-		return &dev_data->rx_stream.cfg;
+		return &dev_data->rx_cfg;
 	}
 
 	return NULL;
@@ -801,7 +766,7 @@ static const struct i2s_config *i2s_renesas_ra_ssie_get_config(const struct devi
 static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, size_t size)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct i2s_buf msg_item = {.mem_block = mem_block, .mem_block_len = size};
+	struct renesas_ra_ssie_stream msg_item = {.mem_block = mem_block, .mem_block_len = size};
 	int ret;
 
 	if (!dev_data->tx_configured) {
@@ -814,13 +779,13 @@ static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, 
 		return -EIO;
 	}
 
-	if (size > dev_data->tx_stream.cfg.block_size) {
+	if (size > dev_data->tx_cfg.block_size) {
 		LOG_ERR("This device can only write blocks up to %u bytes",
-			dev_data->tx_stream.cfg.block_size);
+			dev_data->tx_cfg.block_size);
 		return -EIO;
 	}
 
-	ret = k_msgq_put(&dev_data->tx_queue, &msg_item, K_MSEC(dev_data->tx_stream.cfg.timeout));
+	ret = k_msgq_put(&dev_data->tx_queue, &msg_item, K_MSEC(dev_data->tx_cfg.timeout));
 	if (ret < 0) {
 		return ret;
 	}
@@ -831,7 +796,7 @@ static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, 
 static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, size_t *size)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct i2s_buf msg_item;
+	struct renesas_ra_ssie_stream msg_item;
 	int ret;
 
 	if (!dev_data->rx_configured) {
@@ -846,9 +811,8 @@ static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, 
 	}
 
 	ret = k_msgq_get(&dev_data->rx_queue, &msg_item,
-			 (dev_data->state == I2S_STATE_ERROR)
-				 ? K_NO_WAIT
-				 : K_MSEC(dev_data->rx_stream.cfg.timeout));
+			 (dev_data->state == I2S_STATE_ERROR) ? K_NO_WAIT
+							      : K_MSEC(dev_data->rx_cfg.timeout));
 	if (ret == -ENOMSG) {
 		return -EIO;
 	}
@@ -974,9 +938,11 @@ static int i2s_renesas_ra_ssie_init(const struct device *dev)
 		return ret;
 	}
 
-	k_msgq_init(&dev_data->tx_queue, (char *)dev_data->tx_msgs, sizeof(struct i2s_buf),
+	k_msgq_init(&dev_data->tx_queue, (char *)dev_data->tx_msgs,
+		    sizeof(struct renesas_ra_ssie_stream),
 		    CONFIG_I2S_RENESAS_RA_SSIE_TX_BLOCK_COUNT);
-	k_msgq_init(&dev_data->rx_queue, (char *)dev_data->rx_msgs, sizeof(struct i2s_buf),
+	k_msgq_init(&dev_data->rx_queue, (char *)dev_data->rx_msgs,
+		    sizeof(struct renesas_ra_ssie_stream),
 		    CONFIG_I2S_RENESAS_RA_SSIE_RX_BLOCK_COUNT);
 
 	fsp_err = R_SSI_Open(&dev_data->fsp_ctrl, &dev_data->fsp_cfg);

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -56,6 +56,9 @@ struct renesas_ra_ssie_data {
 	struct i2s_config rx_cfg;
 	struct renesas_ra_ssie_stream tx_stream;
 	struct renesas_ra_ssie_stream rx_stream;
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	struct renesas_ra_ssie_stream rx_stream_next;
+#endif
 	struct renesas_ra_ssie_stream tx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_TX_BLOCK_COUNT];
 	struct renesas_ra_ssie_stream rx_msgs[CONFIG_I2S_RENESAS_RA_SSIE_RX_BLOCK_COUNT];
 	bool tx_configured;
@@ -223,18 +226,36 @@ static int renesas_ra_ssie_set_clock_divider(const struct device *dev,
 	return 0;
 }
 
+static void i2s_renesas_ra_release_stream(struct renesas_ra_ssie_stream *stream)
+{
+	__ASSERT((stream != NULL), "Invalid parameter");
+
+	stream->mem_block = NULL;
+	stream->mem_block_len = 0;
+}
+
 static int i2s_renesas_ra_alloc_stream(struct i2s_config *cfg,
 				       struct renesas_ra_ssie_stream *stream)
 {
+	int ret = 0;
+
 	__ASSERT((cfg != NULL && stream != NULL), "Invalid parameter");
 
-	if (k_mem_slab_alloc(cfg->mem_slab, &stream->mem_block, K_NO_WAIT) < 0) {
-		return -ENOMEM;
+	if (k_mem_slab_num_free_get(cfg->mem_slab) > 0) {
+		ret = k_mem_slab_alloc(cfg->mem_slab, &stream->mem_block, K_NO_WAIT);
+		if (ret == 0) {
+			stream->mem_block_len = cfg->block_size;
+		}
+	} else {
+		ret = -ENOMEM;
 	}
 
-	stream->mem_block_len = cfg->block_size;
+	if (ret < 0) {
+		stream->mem_block = NULL;
+		stream->mem_block_len = 0;
+	}
 
-	return 0;
+	return ret;
 }
 
 static void i2s_renesas_ra_free_stream(struct i2s_config *cfg,
@@ -289,11 +310,21 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 		return ret;
 	}
 
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+	if (ret < 0) {
+		LOG_DBG("Failed to allocate secondary RX buffer");
+	}
+#endif
+
 	fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start read data");
 		dev_data->state = I2S_STATE_ERROR;
 		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+#endif
 		return -EIO;
 	}
 
@@ -342,14 +373,29 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 		return -ENOMEM;
 	}
 
-	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream_rx);
-	if (ret < 0) {
-		dev_data->state = I2S_STATE_ERROR;
-		return ret;
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	if (dev_data->state == I2S_STATE_RUNNING || dev_data->state == I2S_STATE_STOPPING) {
+		if (dev_data->rx_stream_next.mem_block == NULL) {
+			i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
+			dev_data->state = I2S_STATE_ERROR;
+			return -ENOMEM;
+		}
+
+		*stream_rx = dev_data->rx_stream_next;
+	} else {
+#endif
+		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream_rx);
+		if (ret < 0) {
+			i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
+			dev_data->state = I2S_STATE_ERROR;
+			return ret;
+		}
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
 	}
+#endif
 
 	fsp_err = R_SSI_WriteRead(&dev_data->fsp_ctrl, stream_tx->mem_block, stream_rx->mem_block,
-				  stream_rx->mem_block_len);
+				  MAX(stream_rx->mem_block_len, stream_tx->mem_block_len));
 	if (fsp_err != FSP_SUCCESS) {
 		dev_data->state = I2S_STATE_ERROR;
 		i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
@@ -357,6 +403,13 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 		LOG_ERR("Failed to start write and read data");
 		return -EIO;
 	}
+
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+	if (ret < 0) {
+		LOG_DBG("Failed to allocate secondary RX buffer");
+	}
+#endif
 
 	/* In case I2S stream is draining, don't update the state */
 	if (dev_data->state != I2S_STATE_STOPPING) {
@@ -369,33 +422,26 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
-	struct renesas_ra_ssie_stream *stream_rx = &dev_data->rx_stream;
 	struct renesas_ra_ssie_stream *stream_tx = &dev_data->tx_stream;
-	int ret;
+	bool restart = true;
 
 	if (dev_data->state == I2S_STATE_STOPPING) {
-		/* If there is no msg in tx queue, set deivice the state to ready. */
-		if (k_msgq_num_used_get(&dev_data->tx_queue) == 0) {
+		/*
+		 * In case device is stopping, restart the transfer only if there is still data in
+		 * the TX queue and the trigger command is I2S_TRIGGER_DRAIN.
+		 */
+		if (k_msgq_num_used_get(&dev_data->tx_queue) == 0 ||
+		    dev_data->stop_with_draining == false) {
 			dev_data->state = I2S_STATE_READY;
-			goto dir_both_idle_end;
-		} else if (dev_data->stop_with_draining == false) {
-			dev_data->state = I2S_STATE_READY;
-			goto dir_both_idle_end;
+			restart = false;
 		}
 	}
 
 	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
 
-	ret = renesas_ra_ssie_tx_rx_start_transfer(dev);
-	if (ret < 0) {
-		goto dir_both_idle_end;
+	if (restart) {
+		renesas_ra_ssie_tx_rx_start_transfer(dev);
 	}
-
-	return;
-
-dir_both_idle_end:
-	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
-	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, stream_rx);
 }
 
 static void renesas_ra_ssie_idle_tx_handle(const struct device *dev)
@@ -423,55 +469,119 @@ static void renesas_ra_ssie_idle_rx_handle(const struct device *dev)
 
 static void renesas_ra_ssie_rx_callback(const struct device *dev)
 {
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
-	struct renesas_ra_ssie_stream *rx_stream = &dev_data->rx_stream;
+	bool free_stream = false;
+	bool free_next_stream = false;
 	fsp_err_t fsp_err;
 	int ret;
 
-	if (rx_stream->mem_block == NULL) {
+	if (dev_data->rx_stream.mem_block == NULL) {
+		return;
+	}
+
+	if (dev_data->rx_stream_next.mem_block != NULL) {
+		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, dev_data->rx_stream_next.mem_block,
+				     dev_data->rx_stream_next.mem_block_len);
+		if (fsp_err != FSP_SUCCESS) {
+			dev_data->state = I2S_STATE_ERROR;
+			LOG_ERR("Failed to restart RX transfer");
+			free_next_stream = true;
+		}
+	} else {
+		free_next_stream = true;
+	}
+
+	if (dev_data->trigger_drop) {
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
+		return;
+	}
+
+	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, &dev_data->rx_stream);
+	if (ret < 0) {
+		dev_data->state = I2S_STATE_ERROR;
+		free_stream = true;
+		free_next_stream = true;
+		goto free;
+	}
+
+	if (dev_data->active_dir == I2S_DIR_RX) {
+		if (dev_data->state == I2S_STATE_STOPPING) {
+			goto stop;
+		}
+
+		if (free_next_stream) {
+			dev_data->state = I2S_STATE_ERROR;
+			goto free;
+		}
+
+		dev_data->rx_stream = dev_data->rx_stream_next;
+		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+		if (ret < 0) {
+			LOG_DBG("Failed to allocate RX buffer");
+		}
+	}
+
+	return;
+free:
+	if (free_stream) {
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
+	}
+
+	if (free_next_stream) {
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+	}
+stop:
+	i2s_renesas_ra_release_stream(&dev_data->rx_stream);
+	R_SSI_Stop(&dev_data->fsp_ctrl);
+#else
+	struct renesas_ra_ssie_data *const dev_data = dev->data;
+	fsp_err_t fsp_err;
+	int ret;
+
+	if (dev_data->rx_stream.mem_block == NULL) {
 		return;
 	}
 
 	if (dev_data->trigger_drop) {
-		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, rx_stream);
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
 		return;
 	}
 
-	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, rx_stream);
+	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, &dev_data->rx_stream);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
-		goto rx_disable;
+		goto free;
 	}
 
-	rx_stream->mem_block = NULL;
-	rx_stream->mem_block_len = 0;
-
 	if (dev_data->active_dir == I2S_DIR_RX) {
-
 		if (dev_data->state == I2S_STATE_STOPPING) {
-			goto rx_disable;
+			goto stop;
 		}
 
-		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, rx_stream);
+		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
 		if (ret < 0) {
 			dev_data->state = I2S_STATE_ERROR;
-			goto rx_disable;
+			goto stop;
 		}
 
-		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, rx_stream->mem_block,
-				     rx_stream->mem_block_len);
+		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, dev_data->rx_stream.mem_block,
+				     dev_data->rx_stream.mem_block_len);
 		if (fsp_err != FSP_SUCCESS) {
 			dev_data->state = I2S_STATE_ERROR;
 			LOG_ERR("Failed to restart RX transfer");
-			goto rx_disable;
+			goto free;
 		}
 	}
 
 	return;
 
-rx_disable:
-	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, rx_stream);
+free:
+	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
+stop:
+	i2s_renesas_ra_release_stream(&dev_data->rx_stream);
 	R_SSI_Stop(&dev_data->fsp_ctrl);
+#endif
 }
 
 static void renesas_ra_ssie_tx_callback(const struct device *dev)
@@ -605,6 +715,10 @@ static int renesas_ra_ssie_stop(const struct device *dev)
 		return -EIO;
 	}
 
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+#endif
+
 	dev_data->stop_with_draining = false;
 	dev_data->trigger_drop = false;
 	dev_data->state = I2S_STATE_STOPPING;
@@ -650,6 +764,12 @@ static int renesas_ra_trigger_drop(const struct device *dev, enum i2s_dir dir)
 			return -EIO;
 		}
 	}
+
+#ifdef CONFIG_I2S_RENESAS_RA_SSIE_RX_SECONDARY_BUFFER
+	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream_next);
+	}
+#endif
 
 	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
 		drop_queue(dev, I2S_DIR_TX);
@@ -941,7 +1061,7 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 	bool configured = false;
-	int ret;
+	int ret = 0;
 
 	if (dir == I2S_DIR_BOTH) {
 		if (dev_data->full_duplex == false) {

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -221,6 +221,21 @@ static int renesas_ra_ssie_set_clock_divider(const struct device *dev,
 
 	return 0;
 }
+
+static int i2s_renesas_ra_alloc_stream(struct i2s_config *cfg,
+				       struct renesas_ra_ssie_stream *stream)
+{
+	__ASSERT((cfg != NULL && stream != NULL), "Invalid parameter");
+
+	if (k_mem_slab_alloc(cfg->mem_slab, &stream->mem_block, K_NO_WAIT) < 0) {
+		return -ENOMEM;
+	}
+
+	stream->mem_block_len = cfg->block_size;
+
+	return 0;
+}
+
 static void free_buffer_when_stop(struct i2s_config *cfg, struct renesas_ra_ssie_stream *stream)
 {
 	if (stream->mem_block != NULL) {
@@ -230,32 +245,32 @@ static void free_buffer_when_stop(struct i2s_config *cfg, struct renesas_ra_ssie
 	}
 }
 
-static void free_tx_buffer(struct renesas_ra_ssie_data *dev_data, const void *buffer)
+static int i2s_renesas_ra_put_stream(struct k_msgq *msgq, struct renesas_ra_ssie_stream *stream)
 {
-	k_mem_slab_free(dev_data->tx_cfg.mem_slab, (void *)buffer);
-	LOG_DBG("Freed TX %p", buffer);
+	__ASSERT((msgq != NULL && stream != NULL), "Invalid parameter");
+
+	return k_msgq_put(msgq, stream, K_NO_WAIT);
 }
 
-static void free_rx_buffer(struct renesas_ra_ssie_data *dev_data, void *buffer)
+static int i2s_renesas_ra_get_stream(struct k_msgq *msgq, struct renesas_ra_ssie_stream *stream,
+				     k_timeout_t timeout)
 {
-	k_mem_slab_free(dev_data->rx_cfg.mem_slab, buffer);
-	LOG_DBG("Freed RX %p", buffer);
+	__ASSERT((msgq != NULL && stream != NULL), "Invalid parameter");
+
+	return k_msgq_get(msgq, stream, timeout);
 }
 
 static void drop_queue(const struct device *dev, enum i2s_dir dir)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct renesas_ra_ssie_stream msg_item;
+	struct i2s_config *cfg = dir == I2S_DIR_TX ? &dev_data->tx_cfg : &dev_data->rx_cfg;
+	struct k_msgq *msgq = dir == I2S_DIR_TX ? &dev_data->tx_queue : &dev_data->rx_queue;
+	struct renesas_ra_ssie_stream stream;
+	int ret;
 
-	if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
-		while (k_msgq_get(&dev_data->tx_queue, &msg_item, K_NO_WAIT) == 0) {
-			free_tx_buffer(dev_data, msg_item.mem_block);
-		}
-	}
-
-	if (dir == I2S_DIR_RX || dir == I2S_DIR_BOTH) {
-		while (k_msgq_get(&dev_data->rx_queue, &msg_item, K_NO_WAIT) == 0) {
-			free_rx_buffer(dev_data, msg_item.mem_block);
+	while ((ret = k_msgq_get(msgq, &stream, K_NO_WAIT)) != -ENOMSG) {
+		if (ret == 0) {
+			k_mem_slab_free(cfg->mem_slab, stream.mem_block);
 		}
 	}
 }
@@ -267,11 +282,10 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 	int ret;
 	fsp_err_t fsp_err;
 
-	ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
+	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream);
 	if (ret < 0) {
-		return -ENOMEM;
+		return ret;
 	}
-	stream->mem_block_len = dev_data->rx_cfg.block_size;
 
 	fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
@@ -292,7 +306,7 @@ static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 	fsp_err_t fsp_err;
 	int ret;
 
-	ret = k_msgq_get(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
+	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		return -ENOMEM;
@@ -321,7 +335,7 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 	fsp_err_t fsp_err;
 	int ret;
 
-	ret = k_msgq_get(&dev_data->tx_queue, &msg_item_tx, K_NO_WAIT);
+	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item_tx, K_NO_WAIT);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		return -ENOMEM;
@@ -330,12 +344,11 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 	stream_tx->mem_block = msg_item_tx.mem_block;
 	stream_tx->mem_block_len = msg_item_tx.mem_block_len;
 
-	ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream_rx->mem_block, K_NO_WAIT);
+	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream_rx);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
-		return -ENOMEM;
+		return ret;
 	}
-	stream_rx->mem_block_len = dev_data->rx_cfg.block_size;
 
 	fsp_err = R_SSI_WriteRead(&dev_data->fsp_ctrl, stream_tx->mem_block, stream_rx->mem_block,
 				  stream_rx->mem_block_len);
@@ -404,7 +417,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	msg_item_rx.mem_block = stream->mem_block;
 	msg_item_rx.mem_block_len = stream->mem_block_len;
 
-	ret = k_msgq_put(&dev_data->rx_queue, &msg_item_rx, K_NO_WAIT);
+	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, &msg_item_rx);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		goto rx_disable;
@@ -419,7 +432,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 			goto rx_disable;
 		}
 
-		ret = k_mem_slab_alloc(dev_data->rx_cfg.mem_slab, &stream->mem_block, K_NO_WAIT);
+		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream);
 		if (ret < 0) {
 			dev_data->state = I2S_STATE_ERROR;
 			goto rx_disable;
@@ -464,7 +477,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			}
 		}
 
-		ret = k_msgq_get(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
+		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
 		if (ret < 0) {
 			goto tx_disable;
 		}
@@ -639,16 +652,22 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 	 * Then drop all data in tx and rx queue
 	 */
 	if (i2s_cfg->frame_clk_freq == 0) {
-		drop_queue(dev, dir);
 		if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
+			drop_queue(dev, I2S_DIR_TX);
+			dev_data->tx_stream.mem_block = NULL;
+			dev_data->tx_stream.mem_block_len = 0;
 			dev_data->tx_configured = false;
-			memset(&dev_data->tx_stream, 0, sizeof(struct renesas_ra_ssie_stream));
 		}
+
 		if (dir == I2S_DIR_RX || dir == I2S_DIR_BOTH) {
+			drop_queue(dev, I2S_DIR_RX);
+			dev_data->rx_stream.mem_block = NULL;
+			dev_data->rx_stream.mem_block_len = 0;
 			dev_data->rx_configured = false;
-			memset(&dev_data->rx_stream, 0, sizeof(struct renesas_ra_ssie_stream));
 		}
+
 		dev_data->state = I2S_STATE_NOT_READY;
+
 		return 0;
 	}
 
@@ -791,7 +810,7 @@ static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, 
 		return -EIO;
 	}
 
-	ret = k_msgq_put(&dev_data->tx_queue, &msg_item, K_MSEC(dev_data->tx_cfg.timeout));
+	ret = i2s_renesas_ra_put_stream(&dev_data->tx_queue, &msg_item);
 	if (ret < 0) {
 		return ret;
 	}
@@ -803,6 +822,8 @@ static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, 
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 	struct renesas_ra_ssie_stream msg_item;
+	k_timeout_t timeout =
+		(dev_data->state == I2S_STATE_ERROR) ? K_NO_WAIT : K_MSEC(dev_data->rx_cfg.timeout);
 	int ret;
 
 	if (!dev_data->rx_configured) {
@@ -816,9 +837,7 @@ static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, 
 		return -EIO;
 	}
 
-	ret = k_msgq_get(&dev_data->rx_queue, &msg_item,
-			 (dev_data->state == I2S_STATE_ERROR) ? K_NO_WAIT
-							      : K_MSEC(dev_data->rx_cfg.timeout));
+	ret = i2s_renesas_ra_get_stream(&dev_data->rx_queue, &msg_item, timeout);
 	if (ret == -ENOMSG) {
 		return -EIO;
 	}
@@ -902,15 +921,25 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 		if (dev_data->state != I2S_STATE_READY) {
 			R_SSI_Stop(&dev_data->fsp_ctrl);
 		}
+		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
+			drop_queue(dev, I2S_DIR_TX);
+		}
+		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
+			drop_queue(dev, I2S_DIR_RX);
+		}
 		dev_data->trigger_drop = true;
-		drop_queue(dev, dir);
 		return 0;
 
 	case I2S_TRIGGER_PREPARE:
 		if (dev_data->state != I2S_STATE_ERROR) {
 			return -EIO;
 		}
-		drop_queue(dev, dir);
+		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
+			drop_queue(dev, I2S_DIR_TX);
+		}
+		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
+			drop_queue(dev, I2S_DIR_RX);
+		}
 		dev_data->state = I2S_STATE_READY;
 		return 0;
 

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -236,7 +236,8 @@ static int i2s_renesas_ra_alloc_stream(struct i2s_config *cfg,
 	return 0;
 }
 
-static void free_buffer_when_stop(struct i2s_config *cfg, struct renesas_ra_ssie_stream *stream)
+static void i2s_renesas_ra_free_stream(struct i2s_config *cfg,
+				       struct renesas_ra_ssie_stream *stream)
 {
 	if (stream->mem_block != NULL) {
 		k_mem_slab_free(cfg->mem_slab, stream->mem_block);
@@ -291,7 +292,7 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start read data");
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(&dev_data->rx_cfg, &dev_data->rx_stream);
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
 		return -EIO;
 	}
 
@@ -317,7 +318,7 @@ static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start write data");
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
+		i2s_renesas_ra_free_stream(&dev_data->tx_cfg, tx_stream);
 		return -EIO;
 	}
 
@@ -350,8 +351,8 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 				  stream_rx->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
-		free_buffer_when_stop(&dev_data->rx_cfg, stream_rx);
+		i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, stream_rx);
 		LOG_ERR("Failed to start write and read data");
 		return -EIO;
 	}
@@ -382,7 +383,7 @@ static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 		}
 	}
 
-	free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
+	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
 
 	ret = renesas_ra_ssie_tx_rx_start_transfer(dev);
 	if (ret < 0) {
@@ -392,8 +393,8 @@ static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 	return;
 
 dir_both_idle_end:
-	free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
-	free_buffer_when_stop(&dev_data->rx_cfg, stream_rx);
+	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, stream_tx);
+	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, stream_rx);
 }
 
 static void renesas_ra_ssie_rx_callback(const struct device *dev)
@@ -408,7 +409,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	}
 
 	if (dev_data->trigger_drop) {
-		free_buffer_when_stop(&dev_data->rx_cfg, rx_stream);
+		i2s_renesas_ra_free_stream(&dev_data->rx_cfg, rx_stream);
 		return;
 	}
 
@@ -445,7 +446,7 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	return;
 
 rx_disable:
-	free_buffer_when_stop(&dev_data->rx_cfg, rx_stream);
+	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, rx_stream);
 	R_SSI_Stop(&dev_data->fsp_ctrl);
 }
 
@@ -470,7 +471,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			}
 		}
 
-		free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
+		i2s_renesas_ra_free_stream(&dev_data->tx_cfg, tx_stream);
 
 		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, tx_stream, K_NO_WAIT);
 		if (ret < 0) {
@@ -487,7 +488,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 	return;
 
 tx_disable:
-	free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
+	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, tx_stream);
 }
 
 static void renesas_ra_ssie_idle_callback(const struct device *dev)
@@ -507,7 +508,7 @@ static void renesas_ra_ssie_idle_callback(const struct device *dev)
 	case I2S_DIR_TX:
 		if (dev_data->state == I2S_STATE_STOPPING) {
 			dev_data->state = I2S_STATE_READY;
-			free_buffer_when_stop(&dev_data->tx_cfg, &dev_data->tx_stream);
+			i2s_renesas_ra_free_stream(&dev_data->tx_cfg, &dev_data->tx_stream);
 		}
 
 		if (dev_data->state == I2S_STATE_RUNNING) {

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -98,27 +98,25 @@ __maybe_unused static void ssi_rt_isr(void *p_args)
 	}
 }
 
-static int audio_clock_enable(const struct renesas_ra_ssie_config *config,
-			      ssi_extended_cfg_t *fsp_ext_cfg)
+static int audio_clock_enable(const struct device *dev)
 {
-	int ret;
-	uint32_t rate;
-
+	const struct renesas_ra_ssie_config *config = dev->config;
 	const struct device *audio_clk_dev = config->audio_clock_dev;
+	uint32_t rate;
+	int ret;
 
 	if (!device_is_ready(audio_clk_dev)) {
 		LOG_ERR("Invalid audio_clock device");
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(audio_clk_dev, (clock_control_subsys_t)0);
+	ret = clock_control_on(audio_clk_dev, NULL);
 	if (ret < 0) {
 		LOG_ERR("Failed to enable Audio clock, error %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(config->audio_clock_dev, (clock_control_subsys_t)0, &rate);
-
+	ret = clock_control_get_rate(config->audio_clock_dev, NULL, &rate);
 	if (ret < 0) {
 		LOG_ERR("Failed to get audio clock rate, error: (%d)", ret);
 		return ret;
@@ -952,7 +950,7 @@ static int i2s_renesas_ra_ssie_init(const struct device *dev)
 	}
 	config->irq_config_func(dev);
 
-	ret = audio_clock_enable(config, &dev_data->fsp_ext_cfg);
+	ret = audio_clock_enable(dev);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -373,9 +373,7 @@ static void renesas_ra_ssie_idle_dir_both_handle(const struct device *dev)
 		}
 	}
 
-	k_mem_slab_free(dev_data->tx_cfg.mem_slab, stream_tx->mem_block);
-	stream_tx->mem_block = NULL;
-	stream_tx->mem_block_len = 0;
+	free_buffer_when_stop(&dev_data->tx_cfg, stream_tx);
 
 	ret = renesas_ra_ssie_tx_rx_start_transfer(dev);
 	if (ret < 0) {
@@ -446,7 +444,6 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *tx_stream = &dev_data->tx_stream;
-	struct renesas_ra_ssie_stream tx_msg;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -464,17 +461,15 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			}
 		}
 
-		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &tx_msg, K_NO_WAIT);
+		free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
+
+		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, tx_stream, K_NO_WAIT);
 		if (ret < 0) {
 			goto tx_disable;
 		}
 
-		k_mem_slab_free(dev_data->tx_cfg.mem_slab, tx_stream->mem_block);
-
-		*tx_stream = tx_msg;
-
-		fsp_err =
-			R_SSI_Write(&dev_data->fsp_ctrl, tx_stream->mem_block, tx_stream->mem_block_len);
+		fsp_err = R_SSI_Write(&dev_data->fsp_ctrl, tx_stream->mem_block,
+				      tx_stream->mem_block_len);
 		if (fsp_err != FSP_SUCCESS) {
 			LOG_ERR("Failed to restart write data");
 		}

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -301,25 +301,21 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
-	struct renesas_ra_ssie_stream *stream = &dev_data->tx_stream;
-	struct renesas_ra_ssie_stream msg_item;
+	struct renesas_ra_ssie_stream *tx_stream = &dev_data->tx_stream;
 	fsp_err_t fsp_err;
 	int ret;
 
-	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
+	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, tx_stream, K_NO_WAIT);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		return -ENOMEM;
 	}
 
-	stream->mem_block = msg_item.mem_block;
-	stream->mem_block_len = msg_item.mem_block_len;
-
-	fsp_err = R_SSI_Write(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
+	fsp_err = R_SSI_Write(&dev_data->fsp_ctrl, tx_stream->mem_block, tx_stream->mem_block_len);
 	if (fsp_err != FSP_SUCCESS) {
 		LOG_ERR("Failed to start write data");
 		dev_data->state = I2S_STATE_ERROR;
-		free_buffer_when_stop(&dev_data->tx_cfg, stream);
+		free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
 		return -EIO;
 	}
 
@@ -331,18 +327,14 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	struct renesas_ra_ssie_stream *stream_tx = &dev_data->tx_stream;
 	struct renesas_ra_ssie_stream *stream_rx = &dev_data->rx_stream;
-	struct renesas_ra_ssie_stream msg_item_tx;
 	fsp_err_t fsp_err;
 	int ret;
 
-	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item_tx, K_NO_WAIT);
+	ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, stream_tx, K_NO_WAIT);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		return -ENOMEM;
 	}
-
-	stream_tx->mem_block = msg_item_tx.mem_block;
-	stream_tx->mem_block_len = msg_item_tx.mem_block_len;
 
 	ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream_rx);
 	if (ret < 0) {
@@ -400,31 +392,27 @@ dir_both_idle_end:
 static void renesas_ra_ssie_rx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
-	struct renesas_ra_ssie_stream *stream = &dev_data->rx_stream;
-	struct renesas_ra_ssie_stream msg_item_rx;
+	struct renesas_ra_ssie_stream *rx_stream = &dev_data->rx_stream;
 	fsp_err_t fsp_err;
 	int ret;
 
-	if (stream->mem_block == NULL) {
+	if (rx_stream->mem_block == NULL) {
 		return;
 	}
 
 	if (dev_data->trigger_drop) {
-		free_buffer_when_stop(&dev_data->rx_cfg, stream);
+		free_buffer_when_stop(&dev_data->rx_cfg, rx_stream);
 		return;
 	}
 
-	msg_item_rx.mem_block = stream->mem_block;
-	msg_item_rx.mem_block_len = stream->mem_block_len;
-
-	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, &msg_item_rx);
+	ret = i2s_renesas_ra_put_stream(&dev_data->rx_queue, rx_stream);
 	if (ret < 0) {
 		dev_data->state = I2S_STATE_ERROR;
 		goto rx_disable;
 	}
 
-	stream->mem_block = NULL;
-	stream->mem_block_len = 0;
+	rx_stream->mem_block = NULL;
+	rx_stream->mem_block_len = 0;
 
 	if (dev_data->active_dir == I2S_DIR_RX) {
 
@@ -432,15 +420,14 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 			goto rx_disable;
 		}
 
-		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, stream);
+		ret = i2s_renesas_ra_alloc_stream(&dev_data->rx_cfg, rx_stream);
 		if (ret < 0) {
 			dev_data->state = I2S_STATE_ERROR;
 			goto rx_disable;
 		}
 
-		stream->mem_block_len = dev_data->rx_cfg.block_size;
-
-		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
+		fsp_err = R_SSI_Read(&dev_data->fsp_ctrl, rx_stream->mem_block,
+				     rx_stream->mem_block_len);
 		if (fsp_err != FSP_SUCCESS) {
 			dev_data->state = I2S_STATE_ERROR;
 			LOG_ERR("Failed to restart RX transfer");
@@ -451,15 +438,15 @@ static void renesas_ra_ssie_rx_callback(const struct device *dev)
 	return;
 
 rx_disable:
-	free_buffer_when_stop(&dev_data->rx_cfg, stream);
+	free_buffer_when_stop(&dev_data->rx_cfg, rx_stream);
 	R_SSI_Stop(&dev_data->fsp_ctrl);
 }
 
 static void renesas_ra_ssie_tx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
-	struct renesas_ra_ssie_stream *stream = &dev_data->tx_stream;
-	struct renesas_ra_ssie_stream msg_item;
+	struct renesas_ra_ssie_stream *tx_stream = &dev_data->tx_stream;
+	struct renesas_ra_ssie_stream tx_msg;
 	fsp_err_t fsp_err;
 	int ret;
 
@@ -477,18 +464,17 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			}
 		}
 
-		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &msg_item, K_NO_WAIT);
+		ret = i2s_renesas_ra_get_stream(&dev_data->tx_queue, &tx_msg, K_NO_WAIT);
 		if (ret < 0) {
 			goto tx_disable;
 		}
 
-		k_mem_slab_free(dev_data->tx_cfg.mem_slab, stream->mem_block);
+		k_mem_slab_free(dev_data->tx_cfg.mem_slab, tx_stream->mem_block);
 
-		stream->mem_block = msg_item.mem_block;
-		stream->mem_block_len = msg_item.mem_block_len;
+		*tx_stream = tx_msg;
 
 		fsp_err =
-			R_SSI_Write(&dev_data->fsp_ctrl, stream->mem_block, stream->mem_block_len);
+			R_SSI_Write(&dev_data->fsp_ctrl, tx_stream->mem_block, tx_stream->mem_block_len);
 		if (fsp_err != FSP_SUCCESS) {
 			LOG_ERR("Failed to restart write data");
 		}
@@ -497,7 +483,7 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 	return;
 
 tx_disable:
-	free_buffer_when_stop(&dev_data->tx_cfg, stream);
+	free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
 }
 
 static void renesas_ra_ssie_idle_callback(const struct device *dev)
@@ -791,7 +777,7 @@ static const struct i2s_config *i2s_renesas_ra_ssie_get_config(const struct devi
 static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, size_t size)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct renesas_ra_ssie_stream msg_item = {.mem_block = mem_block, .mem_block_len = size};
+	struct renesas_ra_ssie_stream tx_stream = {.mem_block = mem_block, .mem_block_len = size};
 	int ret;
 
 	if (!dev_data->tx_configured) {
@@ -810,7 +796,7 @@ static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, 
 		return -EIO;
 	}
 
-	ret = i2s_renesas_ra_put_stream(&dev_data->tx_queue, &msg_item);
+	ret = i2s_renesas_ra_put_stream(&dev_data->tx_queue, &tx_stream);
 	if (ret < 0) {
 		return ret;
 	}
@@ -821,7 +807,7 @@ static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, 
 static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, size_t *size)
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
-	struct renesas_ra_ssie_stream msg_item;
+	struct renesas_ra_ssie_stream rx_stream;
 	k_timeout_t timeout =
 		(dev_data->state == I2S_STATE_ERROR) ? K_NO_WAIT : K_MSEC(dev_data->rx_cfg.timeout);
 	int ret;
@@ -837,14 +823,14 @@ static int i2s_renesas_ra_ssie_read(const struct device *dev, void **mem_block, 
 		return -EIO;
 	}
 
-	ret = i2s_renesas_ra_get_stream(&dev_data->rx_queue, &msg_item, timeout);
+	ret = i2s_renesas_ra_get_stream(&dev_data->rx_queue, &rx_stream, timeout);
 	if (ret == -ENOMSG) {
 		return -EIO;
 	}
 
 	if (ret == 0) {
-		*mem_block = msg_item.mem_block;
-		*size = msg_item.mem_block_len;
+		*mem_block = rx_stream.mem_block;
+		*size = rx_stream.mem_block_len;
 	}
 
 	return ret;

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -26,7 +26,6 @@
 #include <soc.h>
 
 #define I2S_OPT_BIT_CLK_FRAME_CLK_MASK 0x6
-#define VALID_DIVISOR_COUNT            13
 #define SSI_CLOCK_DIV_INVALID          (-1)
 
 LOG_MODULE_REGISTER(renesas_ra_i2s_ssie, CONFIG_I2S_LOG_LEVEL);
@@ -160,23 +159,21 @@ static ssi_clock_div_t get_ssi_clock_div_enum(uint32_t divisor)
 }
 
 static int renesas_ra_ssie_set_clock_divider(const struct device *dev,
-					     const struct i2s_config *i2s_cfg,
-					     ssi_extended_cfg_t *fsp_ext_cfg)
+					     const struct i2s_config *i2s_cfg)
 {
-	static const uint32_t valid_divisors[] = {1, 2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128};
+	const uint32_t valid_divisors[] = {1, 2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128};
 	const struct renesas_ra_ssie_config *config = dev->config;
-	int ret;
-	double err;
-	uint32_t rate;
-	uint32_t divider;
-	uint32_t target_bclk;
-	uint32_t actual_bclk = 0;
+	struct renesas_ra_ssie_data *dev_data = dev->data;
+	ssi_extended_cfg_t *fsp_ext_cfg = &dev_data->fsp_ext_cfg;
+	const uint64_t target_bclk =
+		i2s_cfg->word_size * i2s_cfg->channels * i2s_cfg->frame_clk_freq;
 	uint32_t selected_div = 0;
-	double error_percent = DBL_MAX;
+	int error_min = INT_MAX;
 	ssi_clock_div_t bit_clock_div = SSI_CLOCK_DIV_INVALID;
+	uint32_t rate;
+	int ret;
 
-	ret = clock_control_get_rate(config->audio_clock_dev, (clock_control_subsys_t)0, &rate);
-
+	ret = clock_control_get_rate(config->audio_clock_dev, NULL, &rate);
 	if (ret < 0) {
 		LOG_ERR("Failed to get audio clock rate, error: (%d)", ret);
 		return ret;
@@ -186,31 +183,42 @@ static int renesas_ra_ssie_set_clock_divider(const struct device *dev,
 		return -EIO;
 	}
 
-	target_bclk = i2s_cfg->word_size * i2s_cfg->channels * i2s_cfg->frame_clk_freq;
-
-	for (size_t i = 0; i < VALID_DIVISOR_COUNT; ++i) {
-		divider = valid_divisors[i];
-		actual_bclk = rate / divider;
+	for (size_t i = 0; i < ARRAY_SIZE(valid_divisors); i++) {
+		const uint64_t actual_bclk = DIV_ROUND_CLOSEST(rate, valid_divisors[i]);
+		int err = INT_MAX;
 
 		if (actual_bclk >= target_bclk) {
-			err = 100.0 * ((double)actual_bclk - target_bclk) / target_bclk;
-			if (selected_div == 0 || err < error_percent) {
-				selected_div = divider;
-				error_percent = err;
+			err = DIV_ROUND_UP(1000 * (actual_bclk - target_bclk), target_bclk);
+		} else {
+			err = DIV_ROUND_UP(1000 * (target_bclk - actual_bclk), target_bclk);
+		}
+
+		if (selected_div == 0 || err < error_min) {
+			selected_div = valid_divisors[i];
+			error_min = err;
+
+			if (error_min == 0) {
+				break;
 			}
 		}
 	}
 
-	if (selected_div == 0 || error_percent > 10.0) {
+	if (selected_div == 0 || error_min > 100) {
+		LOG_ERR("Cannot find suitable clock config for target bit clock: %llu Hz",
+			target_bclk);
 		return -EIO;
 	}
 
 	bit_clock_div = get_ssi_clock_div_enum(selected_div);
 	if (bit_clock_div == SSI_CLOCK_DIV_INVALID) {
+		LOG_ERR("Invalid clock divisor selected");
 		return -EINVAL;
 	}
 
+	LOG_DBG("SPS error: %d 1/1000", error_min);
+
 	fsp_ext_cfg->bit_clock_div = bit_clock_div;
+
 	return 0;
 }
 static void free_buffer_when_stop(struct i2s_config *cfg, struct renesas_ra_ssie_stream *stream)
@@ -698,7 +706,7 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 		operating_mode = I2S_MODE_SLAVE;
 	} else {
 		operating_mode = I2S_MODE_MASTER;
-		ret = renesas_ra_ssie_set_clock_divider(dev, i2s_cfg, &dev_data->fsp_ext_cfg);
+		ret = renesas_ra_ssie_set_clock_divider(dev, i2s_cfg);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -295,6 +295,8 @@ static int renesas_ra_ssie_rx_start_transfer(const struct device *dev)
 		return -EIO;
 	}
 
+	dev_data->state = I2S_STATE_RUNNING;
+
 	return 0;
 }
 
@@ -318,6 +320,8 @@ static int renesas_ra_ssie_tx_start_transfer(const struct device *dev)
 		free_buffer_when_stop(&dev_data->tx_cfg, tx_stream);
 		return -EIO;
 	}
+
+	dev_data->state = I2S_STATE_RUNNING;
 
 	return 0;
 }
@@ -350,6 +354,11 @@ static int renesas_ra_ssie_tx_rx_start_transfer(const struct device *dev)
 		free_buffer_when_stop(&dev_data->rx_cfg, stream_rx);
 		LOG_ERR("Failed to start write and read data");
 		return -EIO;
+	}
+
+	/* In case I2S stream is draining, don't update the state */
+	if (dev_data->state != I2S_STATE_STOPPING) {
+		dev_data->state = I2S_STATE_RUNNING;
 	}
 
 	return 0;
@@ -540,34 +549,126 @@ static void renesas_ra_ssie_callback(i2s_callback_args_t *p_args)
 	}
 }
 
-static int renesas_ra_ssie_start_transfer(const struct device *dev)
+static int renesas_ra_ssie_start_transfer(const struct device *dev, enum i2s_dir dir)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
 	int ret;
 
-	/* Start transfer following the current state */
-	switch (dev_data->active_dir) {
-	case I2S_DIR_BOTH:
-		dev_data->state = I2S_STATE_RUNNING;
-		ret = renesas_ra_ssie_tx_rx_start_transfer(dev);
-		break;
-	case I2S_DIR_TX:
-		dev_data->state = I2S_STATE_RUNNING;
-		ret = renesas_ra_ssie_tx_start_transfer(dev);
-		break;
-	case I2S_DIR_RX:
-		dev_data->state = I2S_STATE_RUNNING;
-		ret = renesas_ra_ssie_rx_start_transfer(dev);
-		break;
-	default:
-		LOG_ERR("Invalid direction: %d", dev_data->active_dir);
+	if (dev_data->state != I2S_STATE_READY) {
 		return -EIO;
 	}
 
+	/* Start transfer following the current state */
+	switch (dir) {
+	case I2S_DIR_BOTH:
+		ret = renesas_ra_ssie_tx_rx_start_transfer(dev);
+		break;
+	case I2S_DIR_TX:
+		ret = renesas_ra_ssie_tx_start_transfer(dev);
+		break;
+	case I2S_DIR_RX:
+		ret = renesas_ra_ssie_rx_start_transfer(dev);
+		break;
+	default:
+		LOG_ERR("Invalid direction: %d", dir);
+		ret = -EIO;
+	}
+
 	if (ret < 0) {
-		LOG_ERR("START - Starting transfer failed");
 		return ret;
 	}
+
+	dev_data->active_dir = dir;
+	dev_data->stop_with_draining = false;
+	dev_data->trigger_drop = false;
+
+	return 0;
+}
+
+static int renesas_ra_ssie_stop(const struct device *dev)
+{
+	struct renesas_ra_ssie_data *dev_data = dev->data;
+
+	if (dev_data->state != I2S_STATE_RUNNING) {
+		return -EIO;
+	}
+
+	dev_data->stop_with_draining = false;
+	dev_data->trigger_drop = false;
+	dev_data->state = I2S_STATE_STOPPING;
+
+	return 0;
+}
+
+static int renesas_ra_trigger_drain(const struct device *dev, enum i2s_dir dir)
+{
+	struct renesas_ra_ssie_data *dev_data = dev->data;
+
+	if (dev_data->state != I2S_STATE_RUNNING) {
+		return -EIO;
+	}
+
+	if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
+		dev_data->stop_with_draining =
+			k_msgq_num_used_get(&dev_data->tx_queue) > 0 ? true : false;
+	} else {
+		/* I2S_DIR_RX */
+		dev_data->stop_with_draining = false;
+	}
+
+	dev_data->state = I2S_STATE_STOPPING;
+	dev_data->trigger_drop = false;
+
+	return 0;
+}
+
+static int renesas_ra_trigger_drop(const struct device *dev, enum i2s_dir dir)
+{
+	struct renesas_ra_ssie_data *dev_data = dev->data;
+	fsp_err_t fsp_err;
+
+	if (dev_data->state == I2S_STATE_NOT_READY) {
+		return -EIO;
+	}
+
+	if (dev_data->state != I2S_STATE_READY) {
+		fsp_err = R_SSI_Stop(&dev_data->fsp_ctrl);
+		if (fsp_err != FSP_SUCCESS) {
+			LOG_ERR("Failed to stop SSI, error: (%d)", fsp_err);
+			return -EIO;
+		}
+	}
+
+	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
+		drop_queue(dev, I2S_DIR_TX);
+	}
+
+	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
+		drop_queue(dev, I2S_DIR_RX);
+	}
+
+	dev_data->trigger_drop = true;
+
+	return 0;
+}
+
+static int renesas_ra_trigger_prepare(const struct device *dev, enum i2s_dir dir)
+{
+	struct renesas_ra_ssie_data *dev_data = dev->data;
+
+	if (dev_data->state != I2S_STATE_ERROR) {
+		return -EIO;
+	}
+
+	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
+		drop_queue(dev, I2S_DIR_TX);
+	}
+
+	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
+		drop_queue(dev, I2S_DIR_RX);
+	}
+
+	dev_data->state = I2S_STATE_READY;
 
 	return 0;
 }
@@ -862,68 +963,15 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 
 	switch (cmd) {
 	case I2S_TRIGGER_START:
-		if (dev_data->state != I2S_STATE_READY) {
-			return -EIO;
-		}
-		dev_data->active_dir = dir;
-		dev_data->stop_with_draining = false;
-		dev_data->trigger_drop = false;
-		return renesas_ra_ssie_start_transfer(dev);
-
+		return renesas_ra_ssie_start_transfer(dev, dir);
 	case I2S_TRIGGER_STOP:
-		if (dev_data->state != I2S_STATE_RUNNING) {
-			return -EIO;
-		}
-		dev_data->stop_with_draining = false;
-		dev_data->trigger_drop = false;
-		dev_data->state = I2S_STATE_STOPPING;
-		return 0;
-
+		return renesas_ra_ssie_stop(dev);
 	case I2S_TRIGGER_DRAIN:
-		if (dev_data->state != I2S_STATE_RUNNING) {
-			return -EIO;
-		}
-		dev_data->trigger_drop = false;
-		if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
-			if (k_msgq_num_used_get(&dev_data->tx_queue) > 0) {
-				dev_data->stop_with_draining = true;
-			}
-			dev_data->state = I2S_STATE_STOPPING;
-		} else if (dir == I2S_DIR_RX) {
-			dev_data->stop_with_draining = false;
-			dev_data->state = I2S_STATE_STOPPING;
-		}
-		return 0;
-
+		return renesas_ra_trigger_drain(dev, dir);
 	case I2S_TRIGGER_DROP:
-		if (dev_data->state == I2S_STATE_NOT_READY) {
-			return -EIO;
-		}
-		if (dev_data->state != I2S_STATE_READY) {
-			R_SSI_Stop(&dev_data->fsp_ctrl);
-		}
-		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
-			drop_queue(dev, I2S_DIR_TX);
-		}
-		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
-			drop_queue(dev, I2S_DIR_RX);
-		}
-		dev_data->trigger_drop = true;
-		return 0;
-
+		return renesas_ra_trigger_drop(dev, dir);
 	case I2S_TRIGGER_PREPARE:
-		if (dev_data->state != I2S_STATE_ERROR) {
-			return -EIO;
-		}
-		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
-			drop_queue(dev, I2S_DIR_TX);
-		}
-		if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
-			drop_queue(dev, I2S_DIR_RX);
-		}
-		dev_data->state = I2S_STATE_READY;
-		return 0;
-
+		return renesas_ra_trigger_prepare(dev, dir);
 	default:
 		LOG_ERR("Invalid trigger: %d", cmd);
 		return -EINVAL;

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -12,16 +12,12 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2s.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/drivers/pwm.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 
-#include "r_ssi.h"
-#include "rp_ssi.h"
-#ifdef CONFIG_I2S_RENESAS_RA_SSIE_DTC
-#include "r_dtc.h"
-#endif
+#include <r_ssi.h>
+#include <r_dtc.h>
 
 #include <soc.h>
 
@@ -261,11 +257,14 @@ static int i2s_renesas_ra_alloc_stream(struct i2s_config *cfg,
 static void i2s_renesas_ra_free_stream(struct i2s_config *cfg,
 				       struct renesas_ra_ssie_stream *stream)
 {
+	__ASSERT((cfg != NULL && stream != NULL), "Invalid parameter");
+
 	if (stream->mem_block != NULL) {
 		k_mem_slab_free(cfg->mem_slab, stream->mem_block);
-		stream->mem_block = NULL;
-		stream->mem_block_len = 0;
 	}
+
+	stream->mem_block = NULL;
+	stream->mem_block_len = 0;
 }
 
 static int i2s_renesas_ra_put_stream(struct k_msgq *msgq, struct renesas_ra_ssie_stream *stream)
@@ -575,7 +574,6 @@ stop:
 	}
 
 	return;
-
 free:
 	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, &dev_data->rx_stream);
 stop:
@@ -600,7 +598,9 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 			/* If there is no msg in tx queue, set decive state to ready*/
 			if (k_msgq_num_used_get(&dev_data->tx_queue) == 0) {
 				goto tx_disable;
-			} else if (dev_data->stop_with_draining == false) {
+			}
+
+			if (dev_data->stop_with_draining == false) {
 				goto tx_disable;
 			}
 		}
@@ -620,7 +620,6 @@ static void renesas_ra_ssie_tx_callback(const struct device *dev)
 	}
 
 	return;
-
 tx_disable:
 	i2s_renesas_ra_free_stream(&dev_data->tx_cfg, tx_stream);
 }
@@ -860,15 +859,13 @@ static int i2s_renesas_ra_ssie_configure(const struct device *dev, enum i2s_dir 
 	if (i2s_cfg->frame_clk_freq == 0) {
 		if (dir == I2S_DIR_TX || dir == I2S_DIR_BOTH) {
 			drop_queue(dev, I2S_DIR_TX);
-			dev_data->tx_stream.mem_block = NULL;
-			dev_data->tx_stream.mem_block_len = 0;
+			i2s_renesas_ra_release_stream(&dev_data->tx_stream);
 			dev_data->tx_configured = false;
 		}
 
 		if (dir == I2S_DIR_RX || dir == I2S_DIR_BOTH) {
 			drop_queue(dev, I2S_DIR_RX);
-			dev_data->rx_stream.mem_block = NULL;
-			dev_data->rx_stream.mem_block_len = 0;
+			i2s_renesas_ra_release_stream(&dev_data->rx_stream);
 			dev_data->rx_configured = false;
 		}
 
@@ -984,14 +981,17 @@ static const struct i2s_config *i2s_renesas_ra_ssie_get_config(const struct devi
 {
 	struct renesas_ra_ssie_data *dev_data = dev->data;
 
-	if (dir == I2S_DIR_TX && dev_data->tx_configured) {
-		return &dev_data->tx_cfg;
-	}
-	if (dir == I2S_DIR_RX && dev_data->rx_configured) {
-		return &dev_data->rx_cfg;
+	if (dir == I2S_DIR_TX) {
+		return dev_data->tx_configured ? &dev_data->tx_cfg : NULL;
 	}
 
-	return NULL;
+	if (dir == I2S_DIR_RX) {
+		return dev_data->rx_configured ? &dev_data->rx_cfg : NULL;
+	}
+
+	/* dir == I2S_DIR_BOTH */
+	return dev_data->rx_configured ? &dev_data->rx_cfg
+				       : (dev_data->tx_configured ? &dev_data->tx_cfg : NULL);
 }
 
 static int i2s_renesas_ra_ssie_write(const struct device *dev, void *mem_block, size_t size)
@@ -1068,6 +1068,7 @@ static int i2s_renesas_ra_ssie_trigger(const struct device *dev, enum i2s_dir di
 			LOG_ERR("I2S_DIR_BOTH is not supported for half-duplex device");
 			return -ENOSYS;
 		}
+
 		configured = dev_data->tx_configured && dev_data->rx_configured;
 	} else if (dir == I2S_DIR_TX) {
 		configured = dev_data->tx_configured;
@@ -1130,7 +1131,6 @@ static int i2s_renesas_ra_ssie_init(const struct device *dev)
 	}
 
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-
 	if (ret < 0) {
 		LOG_ERR("%s: pinctrl config failed.", __func__);
 		return ret;
@@ -1148,6 +1148,7 @@ static int i2s_renesas_ra_ssie_init(const struct device *dev)
 		LOG_ERR("Failed to initialize the device");
 		return -EIO;
 	}
+
 	config->irq_config_func(dev);
 
 	ret = audio_clock_enable(dev);

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -397,6 +397,29 @@ dir_both_idle_end:
 	i2s_renesas_ra_free_stream(&dev_data->rx_cfg, stream_rx);
 }
 
+static void renesas_ra_ssie_idle_tx_handle(const struct device *dev)
+{
+	struct renesas_ra_ssie_data *const dev_data = dev->data;
+
+	if (dev_data->state == I2S_STATE_STOPPING) {
+		i2s_renesas_ra_free_stream(&dev_data->tx_cfg, &dev_data->tx_stream);
+		dev_data->state = I2S_STATE_READY;
+	}
+
+	if (dev_data->state == I2S_STATE_RUNNING) {
+		renesas_ra_ssie_tx_start_transfer(dev);
+	}
+}
+
+static void renesas_ra_ssie_idle_rx_handle(const struct device *dev)
+{
+	struct renesas_ra_ssie_data *const dev_data = dev->data;
+
+	if (dev_data->state == I2S_STATE_STOPPING) {
+		dev_data->state = I2S_STATE_READY;
+	}
+}
+
 static void renesas_ra_ssie_rx_callback(const struct device *dev)
 {
 	struct renesas_ra_ssie_data *const dev_data = dev->data;
@@ -504,27 +527,14 @@ static void renesas_ra_ssie_idle_callback(const struct device *dev)
 	case I2S_DIR_BOTH:
 		renesas_ra_ssie_idle_dir_both_handle(dev);
 		break;
-
 	case I2S_DIR_TX:
-		if (dev_data->state == I2S_STATE_STOPPING) {
-			dev_data->state = I2S_STATE_READY;
-			i2s_renesas_ra_free_stream(&dev_data->tx_cfg, &dev_data->tx_stream);
-		}
-
-		if (dev_data->state == I2S_STATE_RUNNING) {
-			renesas_ra_ssie_tx_start_transfer(dev);
-		}
+		renesas_ra_ssie_idle_tx_handle(dev);
 		break;
-
 	case I2S_DIR_RX:
-		if (dev_data->state == I2S_STATE_STOPPING) {
-			dev_data->state = I2S_STATE_READY;
-		}
+		renesas_ra_ssie_idle_rx_handle(dev);
 		break;
-
 	default:
 		LOG_ERR("Invalid direction: %d", dev_data->active_dir);
-		return;
 	}
 }
 

--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -672,14 +672,6 @@ static int renesas_ra_trigger_prepare(const struct device *dev, enum i2s_dir dir
 		return -EIO;
 	}
 
-	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_TX) {
-		drop_queue(dev, I2S_DIR_TX);
-	}
-
-	if (dir == I2S_DIR_BOTH || dir == I2S_DIR_RX) {
-		drop_queue(dev, I2S_DIR_RX);
-	}
-
 	dev_data->state = I2S_STATE_READY;
 
 	return 0;


### PR DESCRIPTION
- Add the optional configuration to enable the secondary buffer to be used as a chained buffer in the RX direction for the Renesas RA SSIE driver. This would enhance the ability to operate at higher sample rates.
- Clean up and update the code formatting to improve readability and maintain a consistent style throughout the file.