### PR TITLE
drivers: interrupt: pint: Fix IRQ override when re-enabling

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -123,6 +123,8 @@ void nxp_pint_pin_disable(uint8_t pin)
 	if (slot == NO_PINT_ID) {
 		return;
 	}
+	/* This pin no longer have a slot assigned */
+	pin_pint_id[pin] = NO_PINT_ID;
 	/* Remove this pin from the PINT slot if one was in use */
 	pint_irq_cfg[slot].used = false;
 	PINT_PinInterruptConfig(pint_base, slot, kPINT_PinIntEnableNone, NULL);


### PR DESCRIPTION
Remove pin slot assignment if GPIO pin interrupt is disabled, otherwise a new interrupt configured while the interrupt is disabled will cause re-enabling of the original interrupt to override the slot assigned of the last interrupt configured.

Repo steps of original problem:
* Configure interrupt: gpio_pin_interrupt_configure_dt(&dtGpioSpec1, flags1);
* Disable interrupt: gpio_pin_interrupt_configure_dt(&dtGpioSpec1, GPIO_INT_DISABLE);
* Configure new interrupt: gpio_pin_interrupt_configure_dt(&dtGpioSpec2, flags2);
* Enable original interrupt: gpio_pin_interrupt_configure_dt(&dtGpioSpec1, flags1);
* Now new interrupt stopped working as the assigned IRQ slot has been overwritten