### PR TITLE
net: lib: sockets: can: always verify length in `zcan_sendto_ctx()`

### DIFF
--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -256,7 +256,9 @@ ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 		dest_addr = (struct net_sockaddr *)&can_addr;
 	}
 
-	NET_ASSERT(len == sizeof(struct socketcan_frame));
+	if (len != sizeof(struct socketcan_frame)) {
+		return -EINVAL;
+	}
 
 	socketcan_to_can_frame((struct socketcan_frame *)buf, &zframe);
 


### PR DESCRIPTION
Always verify the length in `zcan_sendto_ctx()`.

Fixes: #104652