### PR TITLE
drivers: mspi_dw: Update Kconfig for MSPI_DW to imply DMA and XIP based on SOC series

### DIFF
--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -8,6 +8,8 @@ config MSPI_DW
 	depends on DT_HAS_SNPS_DESIGNWARE_SSI_ENABLED
 	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_SSI),pinctrl-0)
 	imply MSPI_TIMING
+	imply MSPI_XIP if !SOC_SERIES_NRF71
+	imply MSPI_DMA if SOC_SERIES_NRF71
 
 if MSPI_DW
 


### PR DESCRIPTION
Added conditions to imply MSPI_DMA for SOC_SERIES_NRF71 and MSPI_XIP for all other series in the MSPI_DW configuration.

Currently, the only device upstream that supports DMA for the designware MSPI driver is the nrf7120 which also currently doesn't support XiP.