### PR TITLE
modules: hal_silabs: Fix linking for Bluetooth Channel Sounding

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -319,8 +319,13 @@ if(CONFIG_SILABS_SISDK_I2C)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_LETIMER   ${PERIPHERAL_DIR}/src/sl_hal_letimer.c)
-zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_TIMER     ${PERIPHERAL_DIR}/src/sl_hal_timer.c)
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_VDAC      ${PERIPHERAL_DIR}/src/sl_hal_vdac.c)
+
+zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_TIMER
+  ${PERIPHERAL_DIR}/src/sl_hal_timer.c
+  # em_timer.c is still needed e.g. by RAIL for Bluetooth CS
+  ${EMLIB_DIR}/src/em_timer.c
+)
 
 zephyr_library_sources_ifdef(CONFIG_SILABS_SISDK_LDMA
   ${EMDRV_DIR}/dmadrv/src/dmadrv.c

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -14,6 +14,8 @@ config SOC_GECKO_HAS_RADIO
 config SOC_GECKO_USE_RAIL
 	bool "Use RAIL (Radio Abstraction Interface Layer)"
 	depends on SOC_GECKO_HAS_RADIO
+	select SILABS_SISDK_LDMA if BT_CHANNEL_SOUNDING
+	select SILABS_SISDK_TIMER if BT_CHANNEL_SOUNDING
 	help
 	  RAIL (Radio Abstraction Interface Layer) is a library needed to use the EFR radio
 	  hardware. This option enable the proper set of features to allow to properly compile


### PR DESCRIPTION
RAIL depends on the LDMA and TIMER peripherals when Bluetooth Channel Sounding support has been enabled, so be sure to include those in the build for such configurations.