### PR TITLE
drivers: flash: stm32u3: various fixes

### DIFF
--- a/drivers/flash/flash_stm32u3x.c
+++ b/drivers/flash/flash_stm32u3x.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #include <soc.h>
 #include <stm32_ll_icache.h>
+#include <stm32_ll_pwr.h>
 #include <stm32_ll_system.h>
 #include <string.h>
 #include <zephyr/cache.h>
@@ -200,6 +201,17 @@ int flash_stm32_block_erase_loop(const struct device *dev,
 
 	sys_cache_instr_disable();
 
+	/* Prior to erase operation, the voltage range must be set to range 1. */
+	uint32_t voltage_scale = LL_PWR_GetRegulVoltageScaling();;
+
+	if (voltage_scale != LL_PWR_REGU_VOLTAGE_SCALE1) {
+		/* If not, then set the voltage scale 1 */
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+		while (LL_PWR_GetRegulCurrentVOS() != LL_PWR_REGU_VOLTAGE_SCALE1) {
+			/* and wait for the R1RDY flag */
+		}
+	}
+
 	for (address = offset; address <= offset + len - 1; address += FLASH_PAGE_SIZE) {
 		rc = erase_page(dev, address);
 		if (rc < 0) {
@@ -209,6 +221,15 @@ int flash_stm32_block_erase_loop(const struct device *dev,
 
 	if (cache_enabled) {
 		sys_cache_instr_enable();
+	}
+
+	/* Restore the voltage scale at its initial range : LL_PWR_REGU_VOLTAGE_SCALE2 */
+	if (voltage_scale != LL_PWR_REGU_VOLTAGE_SCALE1) {
+		/* If not, then restore the voltage scale */
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
+		while (LL_PWR_GetRegulCurrentVOS() != LL_PWR_REGU_VOLTAGE_SCALE2) {
+			/* and wait for the R2RDY flag */
+		}
 	}
 
 	return rc;
@@ -229,6 +250,17 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 
 	sys_cache_instr_disable();
 
+	/* Prior to write operation, the voltage range must be set to range 1. */
+	uint32_t voltage_scale = LL_PWR_GetRegulVoltageScaling();
+
+	if (voltage_scale != LL_PWR_REGU_VOLTAGE_SCALE1) {
+		/* If not, then set the voltage scale 1 */
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+		while (LL_PWR_GetRegulCurrentVOS() != LL_PWR_REGU_VOLTAGE_SCALE1) {
+			/* and wait for the R1RDY flag */
+		}
+	}
+
 	for (i = 0; i < len; i += FLASH_STM32_WRITE_BLOCK_SIZE) {
 		rc = write_nwords(dev, offset + i, ((const uint32_t *)data + (i >> 2)),
 				  FLASH_STM32_WRITE_BLOCK_SIZE / 4);
@@ -239,6 +271,15 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 
 	if (cache_enabled) {
 		sys_cache_instr_enable();
+	}
+
+	/* Restore the volatge scale at its initial range : LL_PWR_REGU_VOLTAGE_SCALE2 */
+	if (voltage_scale != LL_PWR_REGU_VOLTAGE_SCALE1) {
+		/* If not, then restore the voltage scale */
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
+		while (LL_PWR_GetRegulCurrentVOS() != LL_PWR_REGU_VOLTAGE_SCALE2) {
+			/* and wait for the R2RDY flag */
+		}
 	}
 
 	return rc;

--- a/drivers/flash/flash_stm32u3x.c
+++ b/drivers/flash/flash_stm32u3x.c
@@ -157,6 +157,10 @@ static int erase_page(const struct device *dev, unsigned int offset)
 			return -EINVAL;
 		}
 	} else {
+		/* On 512-Kbyte flash single-bank, set BKER = 0 to select bank 1. */
+		if (FLASH_SIZE ==  512 * 1024) {
+			regs->CR &= ~FLASH_STM32_NSBKER_MSK;
+		}
 		page = offset / FLASH_PAGE_SIZE_128_BITS;
 		LOG_DBG("Erase page %d", page);
 	}
@@ -202,7 +206,7 @@ int flash_stm32_block_erase_loop(const struct device *dev,
 	sys_cache_instr_disable();
 
 	/* Prior to erase operation, the voltage range must be set to range 1. */
-	uint32_t voltage_scale = LL_PWR_GetRegulVoltageScaling();;
+	uint32_t voltage_scale = LL_PWR_GetRegulVoltageScaling();
 
 	if (voltage_scale != LL_PWR_REGU_VOLTAGE_SCALE1) {
 		/* If not, then set the voltage scale 1 */

--- a/drivers/flash/flash_stm32u3x.c
+++ b/drivers/flash/flash_stm32u3x.c
@@ -251,11 +251,9 @@ void flash_stm32_page_layout(const struct device *dev,
 	static struct flash_pages_layout stm32_flash_layout[1];
 
 	if (stm32_flash_layout[0].pages_count == 0) {
-		if (stm32_flash_has_2_banks(dev)) {
-			stm32_flash_layout[0].pages_count = FLASH_PAGE_NB * 2;
-		} else {
-			stm32_flash_layout[0].pages_count = FLASH_PAGE_NB;
-		}
+		/* Considering one layout of full flash size, even with 2 banks */
+		stm32_flash_layout[0].pages_count = FLASH_SIZE / FLASH_PAGE_SIZE;
+		/* stm32U3 flash pages are always 4 kB in size */
 		stm32_flash_layout[0].pages_size = FLASH_PAGE_SIZE;
 	}
 


### PR DESCRIPTION
Fix stm32U3 flash driver for different  dual bank and flash size combinations

1) commit to give the total nb of 4KB-pages in the flash : it _does not_ depend on the dual/single bank configuration.
This is like the stm32U5 series.

The stm32_flash_layout  .pages_count is the **total number of pages** =  FLASH_SIZE / PAGE_SIZE
The stm32_flash_layout  .pages_size is  PAGE_SIZE  = 4KB
 
When the Dual Bank is set,  the nb of page _per bank_ is half the total nb of 4KB-pages, but the stm32_flash_layout always give the nb of page in the whole flash. 

Detailed page table is given by the refMan RM0487:
_"For STM32U375/385 devices with 512KB of flash, "when DUALBANK is set to 1 in the option bytes, for 512-Kbyte dual-bank STM32U375/385 devices, the base address of bank 2 is 0x0804 0000, and the total number of pages is divided by two."_

Dual Bank 1024KB    -> 128 pages of 4K (per Bank)
Single Bank 1024KB  -> 256 pages of 4K (per Bank)

Dual Bank 512KB    ->  64 pages of 4K (per Bank)
Single Bank 512KB  -> 128 pages of 4K (per Bank)

2) commit to erase and program in voltage scale1
See the refMan RM0487  "Flash main memory erase sequences" and "Flash memory programming sequences"
first item in the procedur e is to "Check that voltage range is set to range 1."

3) commit to Select bank 1 with BKER = 0  for 512KB flash single bank
See the refMan RM0487 "Table 33. Flash module 1-Mbyte dual-bank organization"
note "_2. When DUALBANK is set to 0 in the option bytes, for 512-Kbyte single-bank STM32U375/385 devices,  the flash is addressed as a single bank, and the page numbers are continuous from 0 to 127. Set BKER = 0 to select bank 1._"