### PR TITLE
doc: releases: 4.4: Add kernel entry for Scope-based Cleanup Helpers

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -401,6 +401,19 @@ DeviceTree
 * :c:macro:`DT_CHILD_BY_UNIT_ADDR_INT`
 * :c:macro:`DT_INST_CHILD_BY_UNIT_ADDR_INT`
 
+Kernel
+******
+
+* :ref:`cleanup_api`
+
+  * :c:macro:`SCOPE_VAR_DEFINE`
+  * :c:macro:`SCOPE_GUARD_DEFINE`
+  * :c:macro:`SCOPE_DEFER_DEFINE`
+  * :c:macro:`scope_var`
+  * :c:macro:`scope_var_init`
+  * :c:macro:`scope_guard`
+  * :c:macro:`scope_defer`
+
 Libraries / Subsystems
 **********************
 


### PR DESCRIPTION
Add a Kernel section with an entry about the introduced cleanup helper macros.

Preview: https://builds.zephyrproject.io/zephyr/pr/104663/docs/releases/release-notes-4.4.html#kernel