### PR TITLE
Add frdm-imrt1186 flexspi function support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186-pinctrl.dtsi
@@ -58,14 +58,15 @@
 	/* QSPI Flash on FlexSPI2 - GPIO_AON_22/23/24/25/26/27 */
 	pinmux_flexspi2: pinmux_flexspi2 {
 		group0 {
-			pinmux = <&iomuxc_aon_gpio_aon_22_flexspi2_a_ss0_b>,
+			pinmux = <&iomuxc_aon_gpio_aon_21_flexspi2_a_dqs>,
+				 <&iomuxc_aon_gpio_aon_22_flexspi2_a_ss0_b>,
 				 <&iomuxc_aon_gpio_aon_23_flexspi2_a_sclk>,
 				 <&iomuxc_aon_gpio_aon_24_flexspi2_a_data0>,
 				 <&iomuxc_aon_gpio_aon_25_flexspi2_a_data1>,
 				 <&iomuxc_aon_gpio_aon_26_flexspi2_a_data2>,
 				 <&iomuxc_aon_gpio_aon_27_flexspi2_a_data3>;
-			drive-strength = "high";
-			slew-rate = "fast";
+			bias-pull-down;
+			input-enable;
 		};
 	};
 

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -109,6 +109,8 @@
 	 * corresponding MPU settings.
 	 */
 	status = "disabled";
+	pinctrl-0 = <&pinmux_flexspi2>;
+	pinctrl-names = "default";
 	ahb-prefetch;
 	ahb-read-addr-opt;
 	rx-clock-source = <1>;
@@ -119,7 +121,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
-		jedec-id = [ef 60 18];
+		jedec-id = [ef 40 18];
 		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -16,6 +16,7 @@ ram: 8192
 flash: 16384
 supported:
   - adc
+  - flash
   - gpio
   - can
   - uart

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.dts
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.dts
@@ -48,6 +48,10 @@
 	current-speed = <115200>;
 };
 
+&flexspi2 {
+	status = "okay";
+};
+
 &lpadc1 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -13,6 +13,7 @@ ram: 256
 flash: 256
 supported:
   - adc
+  - flash
   - gpio
   - can
   - uart

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -621,6 +621,14 @@ __weak void clock_init(void)
 	rootCfg.mux = kCLOCK_FLEXSPI1_ClockRoot_MuxSysPll3Pfd0;
 	rootCfg.div = 3;
 	CLOCK_SetRootClock(kCLOCK_Root_Flexspi1, &rootCfg);
+#endif
+
+#if !(DT_NODE_HAS_COMPAT(DT_PARENT(DT_CHOSEN(zephyr_flash)), nxp_imx_flexspi_nor)) &&  \
+	defined(CONFIG_MEMC_MCUX_FLEXSPI) && DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi2), okay)
+	/* Configure FLEXSPI2 using SYS_PLL3_PFD2_CLK */
+	rootCfg.mux = kCLOCK_FLEXSPI2_ClockRoot_MuxSysPll3Pfd2;
+	rootCfg.div = 2;
+	CLOCK_SetRootClock(kCLOCK_Root_Flexspi2, &rootCfg);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(tpm2), okay)

--- a/tests/drivers/flash/erase_blocks/testcase.yaml
+++ b/tests/drivers/flash/erase_blocks/testcase.yaml
@@ -16,5 +16,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
       - frdm_mcxc444
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
     integration_platforms:
       - nrf9160dk/nrf9160

--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -37,6 +37,13 @@
 /* We need to go up two levels: storage_partition -> partitions -> flash0 */
 #define TEST_FLASH_START (DT_REG_ADDR(DT_PARENT(DT_PARENT(DT_NODELABEL(TEST_AREA)))))
 #define TEST_FLASH_SIZE  (DT_REG_SIZE(DT_PARENT(DT_PARENT(DT_NODELABEL(TEST_AREA)))))
+#elif defined(CONFIG_SOC_SERIES_IMXRT118X)
+/* For i.MX RT118x, storage_partition -> partitions -> external FlexSPI NOR.
+ * Prefer /chosen zephyr,flash-controller for flash geometry.
+ * Flash operations use offsets from 0, not physical addresses.
+ */
+#define TEST_FLASH_START 0
+#define TEST_FLASH_SIZE  DT_PROP(DT_CHOSEN(zephyr_flash_controller), size)
 #else
 #error "Missing definition of TEST_FLASH_START and TEST_FLASH_SIZE for this target"
 #endif


### PR DESCRIPTION
1. Enable flash_shell case on cm33/cm7 cores.
2. Enable common/erase_blocks/interface_test/negative_tests cases
  on frdm-imxrt1186.