### PR TITLE
doc: develop: gsg: pin version for mac & windows, add tip in non-release

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -240,6 +240,10 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
                cd ~/zephyrproject
                west update
 
+            .. tip::
+
+               To check out a specific revision, use ``west init ~/zephyrproject --mr <revision>``
+
          .. only:: release
 
             .. We need to use a parsed-literal here because substitutions do not work in code
@@ -301,11 +305,25 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
       #. Get the Zephyr source code:
 
-         .. code-block:: bash
+         .. only:: not release
 
-            west init ~/zephyrproject
-            cd ~/zephyrproject
-            west update
+            .. code-block:: bash
+
+               west init ~/zephyrproject
+               cd ~/zephyrproject
+               west update
+
+            .. tip::
+
+               To check out a specific revision, use ``west init ~/zephyrproject --mr <revision>``
+
+         .. only:: release
+
+            .. parsed-literal::
+
+               west init ~/zephyrproject --mr v |zephyr-version-ltrim|
+               cd ~/zephyrproject
+               west update
 
       #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
          automatically load boilerplate code required for building Zephyr
@@ -381,11 +399,25 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
       #. Get the Zephyr source code:
 
-         .. code-block:: bat
+         .. only:: not release
 
-            west init zephyrproject
-            cd zephyrproject
-            west update
+            .. code-block:: bat
+
+               west init zephyrproject
+               cd zephyrproject
+               west update
+
+            .. tip::
+
+               To check out a specific revision, use ``west init zephyrproject --mr <revision>``
+
+         .. only:: release
+
+            .. parsed-literal::
+
+               west init zephyrproject --mr v |zephyr-version-ltrim|
+               cd zephyrproject
+               west update
 
       #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
          automatically load boilerplate code required for building Zephyr


### PR DESCRIPTION
## add pinned version for macos and windows

The introduced changes for releases in  #92564 were only added for the Ubuntu tab. This PR adds the same for macOS and Windows:

<img width="885" height="702" alt="Screenshot from 2026-02-27 13-54-49" src="https://github.com/user-attachments/assets/a5fb0726-e949-4159-81c9-1b0d39574a8a" />

## add tip in non release

new users often use the non-release, respectively "latest" doc version. In this version, step 4 checks out the latest development state when using `west init`. 
A new tip explains how to check out a specific revision:

<img width="843" height="253" alt="Screenshot from 2026-02-27 14-06-28" src="https://github.com/user-attachments/assets/a0c9f423-81b3-4365-a172-1fd894c6cde8" />




