### PR TITLE
net: ip: Add net_ipv6_addr_get_v4_mapped

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1736,6 +1736,20 @@ static inline bool net_ipv6_addr_is_v4_mapped(const struct net_in6_addr *addr)
 }
 
 /**
+ *  @brief Get the IPv4 address from an IPv4 mapped IPv6 address.
+ *         The v4 mapped addresses look like \::ffff:a.b.c.d
+ *
+ *  @param addr6 IPv6 address (must be a v4-mapped address, see
+ *               net_ipv6_addr_is_v4_mapped())
+ *  @param addr4 IPv4 address to be filled in
+ */
+static inline void net_ipv6_addr_get_v4_mapped(const struct net_in6_addr *addr6,
+					       struct net_in_addr *addr4)
+{
+	addr4->s_addr = UNALIGNED_GET(&addr6->s6_addr32[3]);
+}
+
+/**
  *  @brief Generate IPv6 address using a prefix and interface identifier.
  *         Interface identifier is either generated from EUI-64 (MAC) defined
  *         in RFC 4291 or from randomized value defined in RFC 7217.

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -967,6 +967,32 @@ ZTEST(ip_addr_fn, test_private_ipv4_addresses)
 
 }
 
+ZTEST(ip_addr_fn, test_ipv6_v4_mapped)
+{
+	struct net_in6_addr addr6;
+	struct net_in_addr addr4_in;
+	struct net_in_addr addr4_out;
+
+	/* A regular IPv6 address must not be reported as v4-mapped */
+	addr6 = (struct net_in6_addr){
+		{ { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1 } }
+	};
+
+	zassert_false(net_ipv6_addr_is_v4_mapped(&addr6),
+		      "Plain IPv6 address must not be v4-mapped");
+
+	addr4_in = (struct net_in_addr){ { { 192, 168, 0, 1 } } };
+	net_ipv6_addr_create_v4_mapped(&addr4_in, &addr6);
+
+	zassert_true(net_ipv6_addr_is_v4_mapped(&addr6),
+		     "Created v4-mapped address not detected as v4-mapped");
+
+	net_ipv6_addr_get_v4_mapped(&addr6, &addr4_out);
+
+	zassert_equal(addr4_out.s_addr, addr4_in.s_addr,
+		      "Extracted IPv4 address does not match original (192.168.0.1)");
+}
+
 void clear_addr4(struct net_if *iface, struct net_if_addr *addr, void *user_data)
 {
 	addr->is_used = false;


### PR DESCRIPTION
Add a helper function to extract an IPv4 address from a mapped IPv6 one.