### PR TITLE
Change priorities related to TISCI and other components

### DIFF
--- a/drivers/clock_control/Kconfig.tisci
+++ b/drivers/clock_control/Kconfig.tisci
@@ -7,3 +7,10 @@ config CLOCK_CONTROL_TISCI
 	depends on DT_HAS_TI_K2G_SCI_CLK_ENABLED
 	help
 	  Driver for TISCI based clock control.
+
+config CLOCK_CONTROL_TISCI_PRIORITY
+	int "TISCI Clock Controller Priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+		TISCI clock controller priority should always be equal or greater
+		than the TISCI priority.

--- a/drivers/clock_control/clock_control_tisci.c
+++ b/drivers/clock_control/clock_control_tisci.c
@@ -95,6 +95,6 @@ static DEVICE_API(clock_control, tisci_clock_driver_api) = {
 
 #define TI_K2G_SCI_CLK_INIT(_n)                                                                    \
 	DEVICE_DT_INST_DEFINE(_n, NULL, NULL, NULL, NULL, PRE_KERNEL_1,                            \
-			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &tisci_clock_driver_api);
+			      CONFIG_CLOCK_CONTROL_TISCI_PRIORITY, &tisci_clock_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TI_K2G_SCI_CLK_INIT)

--- a/drivers/firmware/tisci/Kconfig
+++ b/drivers/firmware/tisci/Kconfig
@@ -15,7 +15,7 @@ if TISCI
 
 config TISCI_INIT_PRIORITY
 	int "TISCI init priority"
-	default KERNEL_INIT_PRIORITY_OBJECTS
+	default KERNEL_INIT_PRIORITY_DEFAULT
 	help
 	  Init priority for the TISCI driver.
 

--- a/drivers/mbox/Kconfig.ti_secproxy
+++ b/drivers/mbox/Kconfig.ti_secproxy
@@ -7,9 +7,3 @@ config MBOX_TI_SECURE_PROXY
 	depends on DT_HAS_TI_SECURE_PROXY_ENABLED
 	help
 	  Driver for TI Secure Proxy Mailbox.
-
-config MBOX_TI_SECURE_PROXY_PRIORITY
-	int "MBOX_TI_SECURE_PROXY_PRIORITY"
-	default KERNEL_INIT_PRIORITY_OBJECTS
-	help
-	  Mbox secproxy initialization priority.

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -381,7 +381,7 @@ static DEVICE_API(mbox, secproxy_mailbox_driver_api) = {
 	}                                                                                          \
 	DEVICE_DT_INST_DEFINE(idx, secproxy_mailbox_##idx##_init, NULL,                            \
 			      &secproxy_mailbox_##idx##_data, &secproxy_mailbox_##idx##_config,    \
-			      PRE_KERNEL_1, CONFIG_MBOX_TI_SECURE_PROXY_PRIORITY,                  \
+			      PRE_KERNEL_1, CONFIG_MBOX_INIT_PRIORITY,                             \
 			      &secproxy_mailbox_driver_api)
 
 #define MAILBOX_INST(idx) MAILBOX_INSTANCE_DEFINE(idx);


### PR DESCRIPTION
Change priority from `KERNEL_INIT_PRIORITY_OBJECTS`  to  `KERNEL_INIT_PRIORITY_DEFAULT` for following components

1. Secure Proxy: To fulfil default priority dependency on ARM GICv3 (INTC priority)
2. TISCI: To fulfil the changed secure proxy priority dependency.
3. TISCI clock controller: To fulfil the changed TISCI priority dependency.