### PR TITLE
Bluetooth: CAP: Handover: Fix clearing wrong broadcast_source

### DIFF
--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -164,7 +164,7 @@ void bt_cap_handover_broadcast_source_stopped(uint8_t reason)
 				bt_cap_handover_broadcast_audio_stopped();
 			}
 		} else {
-			proc_param->unicast_to_broadcast.broadcast_source = NULL;
+			proc_param->broadcast_to_unicast.broadcast_source = NULL;
 			active_proc->err = reason;
 			bt_cap_handover_complete();
 		}


### PR DESCRIPTION
When proc_param->is_unicast_to_broadcast == false we should clear the broadcast_to_unicast.broadcast_source instead of the unicast_to_broadcast.broadcast_source.