### PR TITLE
Bluetooth: CAP: Add additional verification of active_proc_mutex

### DIFF
--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -65,6 +65,9 @@ void bt_cap_common_unlock_proc(void)
 
 void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc)
 {
+	__ASSERT(active_proc_mutex.lock_count == 1U, "Unexpected active_proc_mutex.lock_count: %u",
+		 active_proc_mutex.lock_count);
+
 	(void)memset(proc, 0, sizeof(*proc));
 
 	bt_cap_common_unlock_proc();


### PR DESCRIPTION
Add assert for verifying that the active_proc_mutex is always
free'd when bt_cap_common_clear_proc is called.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/104627