### PR TITLE
flash: spi_nand: support bad block management

### DIFF
--- a/drivers/flash/spi_nand.c
+++ b/drivers/flash/spi_nand.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022-2025 Macronix International Co., Ltd.
  * Copyright (c) 2025 Embeint Pty Ltd
+ * Copyright (c) 2026 CodeWrights GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -84,6 +85,9 @@ struct spi_nand_data {
 /* Indicates that a dummy byte is to be sent following the address.
  */
 #define NAND_ACCESS_DUMMY_BYTE BIT(6)
+
+/* Offset of the bad block marker in the spare area */
+#define BAD_BLOCK_MARKER_OFFSET 0x00
 
 LOG_MODULE_REGISTER(spi_nand, CONFIG_FLASH_LOG_LEVEL);
 
@@ -584,18 +588,133 @@ static void spi_nand_pages_layout(const struct device *dev,
 
 #if defined(CONFIG_FLASH_EX_OP_ENABLED)
 
+static int spi_nand_is_bad_block(const struct device *dev, off_t addr,
+				 enum flash_block_status *status)
+{
+	const struct spi_nand_config *config = dev->config;
+	const uint32_t bad_block_marker_offset =
+		config->parameters->write_block_size + BAD_BLOCK_MARKER_OFFSET;
+	uint32_t page_address;
+	uint8_t bad_block_marker;
+	int ret;
+
+	/* Address must be in subregion of device */
+	if (!valid_region(dev, addr, 1)) {
+		return -EINVAL;
+	}
+
+	/* Address must be aligned to erase block */
+	if (addr % config->block_size) {
+		return -EINVAL;
+	}
+
+	page_address = addr >> config->addr_page_shift;
+
+	/* Copy data from main storage to cache (ignore ECC errors) */
+	ret = spi_nand_page_read_to_cache(dev, page_address);
+	if ((ret != 0) && (ret != -EBADMSG)) {
+		LOG_DBG("Copy from NAND to device cache failed (%d)", ret);
+		return ret;
+	}
+
+	/* Read bad block marker out of cache */
+	ret = spi_nand_read_from_cache(dev, bad_block_marker_offset, &bad_block_marker,
+				       sizeof(bad_block_marker));
+	if (ret != 0) {
+		LOG_DBG("Read from device cache failed (%d)", ret);
+		return ret;
+	}
+
+	/* Verify bad block marker */
+	if (bad_block_marker != 0xff) {
+		LOG_DBG("Block at address %06x is bad (marker %02x)", page_address,
+			bad_block_marker);
+		*status = FLASH_BLOCK_BAD;
+	} else {
+		LOG_DBG("Block at address %06x is good", page_address);
+		*status = FLASH_BLOCK_GOOD;
+	}
+
+	return 0;
+}
+
+static int spi_nand_mark_bad_block(const struct device *dev, off_t addr)
+{
+	const struct spi_nand_config *config = dev->config;
+	const uint32_t bad_block_marker_offset =
+		config->parameters->write_block_size + BAD_BLOCK_MARKER_OFFSET;
+	uint8_t bad_block_marker = 0x00;
+	uint32_t page_address;
+	uint8_t status;
+	int ret;
+
+	/* Address must be in subregion of device */
+	if (!valid_region(dev, addr, 1)) {
+		return -EINVAL;
+	}
+
+	/* Address must be aligned to erase block */
+	if (addr % config->block_size) {
+		return -EINVAL;
+	}
+
+	page_address = addr >> config->addr_page_shift;
+	LOG_DBG("Marking block starting at %06x as bad", page_address);
+
+	/* Enable write operation */
+	ret = spi_nand_cmd_write(dev, SPI_NAND_CMD_WRITE_ENABLE);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Copy bad block marker to cache (all other bytes stay reset at 0xff) */
+	ret = spi_nand_access(dev, SPI_NAND_CMD_PROGRAM_LOAD,
+			      NAND_ACCESS_WRITE | NAND_ACCESS_ADDRESSED | NAND_ACCESS_16BIT_ADDR,
+			      bad_block_marker_offset, &bad_block_marker, sizeof(bad_block_marker));
+	if (ret != 0) {
+		LOG_DBG("Copy to device cache failed (%d)", ret);
+		return ret;
+	}
+
+	/* Program the cache to the appropriate page */
+	ret = spi_nand_access(dev, SPI_NAND_CMD_PROGRAM_EXECUTE,
+			      NAND_ACCESS_WRITE | NAND_ACCESS_ADDRESSED | NAND_ACCESS_24BIT_ADDR,
+			      page_address, NULL, 0);
+	if (ret != 0) {
+		LOG_DBG("Program from cache to NAND failed (%d)", ret);
+		return ret;
+	}
+
+	/* Wait for the write to complete (poll every 0.1ms) */
+	ret = spi_nand_wait_until_ready(dev, "write", config->page_program_us, 100, &status);
+	if (ret != 0) {
+		return ret;
+	}
+	if (status & SPI_NAND_FEATURE_STATUS_PROGRAM_FAIL) {
+		LOG_ERR("Program operation failed");
+		ret = -EIO;
+		return ret;
+	}
+
+	return 0;
+}
+
 static int spi_nand_ex_op(const struct device *dev, uint16_t code, const uintptr_t in, void *out)
 {
 	int ret;
-
-	ARG_UNUSED(in);
-	ARG_UNUSED(out);
 
 	acquire_device(dev);
 
 	switch (code) {
 	case FLASH_EX_OP_RESET:
 		ret = spi_nand_reset(dev);
+		break;
+	case FLASH_EX_OP_IS_BAD_BLOCK:
+		ret = spi_nand_is_bad_block(dev, *(const off_t *)in,
+					    (enum flash_block_status *)out);
+		break;
+	case FLASH_EX_OP_MARK_BAD_BLOCK:
+		ret = spi_nand_mark_bad_block(dev, *(const off_t *)in);
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/tests/drivers/disk/disk_access/boards/mikroe_flash_5_click.overlay
+++ b/tests/drivers/disk/disk_access/boards/mikroe_flash_5_click.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 CodeWrights GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi_nand_mikroe_flash_5_click {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ftl_partition: partition@0 {
+			label = "ftl";
+			reg = <0x00000000 DT_SIZE_M(128)>;
+		};
+	};
+};
+
+/ {
+	ftl {
+		compatible = "zephyr,ftl-dhara";
+		partition = <&ftl_partition>;
+		disk-name = "NAND";
+		buffer-size = <2048>;
+	};
+};

--- a/tests/drivers/disk/disk_access/testcase.yaml
+++ b/tests/drivers/disk/disk_access/testcase.yaml
@@ -33,6 +33,17 @@ tests:
     platform_allow:
       - native_sim/native/64
       - native_sim
+  drivers.disk.ftl.spi_nand.mikroe_flash_5_click:
+    harness_config:
+      fixture: mikroe_flash_5_click
+    extra_configs:
+      - CONFIG_ZTEST_STACK_SIZE=4096
+      - CONFIG_DISK_DRIVER_SDMMC=n
+    extra_args:
+      - SHIELD=mikroe_flash_5_click
+      - DTC_OVERLAY_FILE="./boards/mikroe_flash_5_click.overlay"
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
   drivers.disk.loopback:
     extra_configs:
       - CONFIG_DISK_DRIVER_LOOPBACK=y

--- a/tests/drivers/disk/disk_performance/boards/mikroe_flash_5_click.overlay
+++ b/tests/drivers/disk/disk_performance/boards/mikroe_flash_5_click.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 CodeWrights GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi_nand_mikroe_flash_5_click {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ftl_partition: partition@0 {
+			label = "ftl";
+			reg = <0x00000000 DT_SIZE_M(128)>;
+		};
+	};
+};
+
+/ {
+	ftl {
+		compatible = "zephyr,ftl-dhara";
+		partition = <&ftl_partition>;
+		disk-name = "NAND";
+		buffer-size = <2048>;
+	};
+};

--- a/tests/drivers/disk/disk_performance/src/main.c
+++ b/tests/drivers/disk/disk_performance/src/main.c
@@ -18,6 +18,8 @@
 #define DISK_NAME "SD2"
 #elif defined(CONFIG_NVME)
 #define DISK_NAME "nvme0n0"
+#elif defined(CONFIG_DISK_DRIVER_FTL)
+#define DISK_NAME "NAND"
 #else
 #error "No disk device defined, is your board supported?"
 #endif

--- a/tests/drivers/disk/disk_performance/testcase.yaml
+++ b/tests/drivers/disk/disk_performance/testcase.yaml
@@ -18,3 +18,14 @@ tests:
     extra_configs:
       - CONFIG_NVME=y
     platform_allow: qemu_x86_64
+  drivers.disk.disk_performance.ftl.spi_nand.mikroe_flash_5_click:
+    harness_config:
+      fixture: mikroe_flash_5_click
+    extra_configs:
+      - CONFIG_ZTEST_STACK_SIZE=4096
+      - CONFIG_DISK_DRIVER_SDMMC=n
+    extra_args:
+      - SHIELD=mikroe_flash_5_click
+      - DTC_OVERLAY_FILE="./boards/mikroe_flash_5_click.overlay"
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0


### PR DESCRIPTION
This PR adds support for bad block management in SPI NAND flash devices. This includes functions to mark a block as bad and to check if a block is bad, either marked as bad in factory or by software. The bad block marker is stored in the first byte of the OOB area of the first page of each block.

Demo:
```
[00:00:00.009,000] <dbg> spi_nand: spi_nand_wait_until_ready: Ready after 200 us (Op reset, Status 00)
[00:00:00.011,000] <dbg> spi_nand: spi_nand_wait_until_ready: Ready after 200 us (Op read, Status 00)
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load: Valid CRC: 3D0F
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:      Manufacturer: WINBOND
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:             Model: W25N01GV
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:  Page Size (data): 2048
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load: Page Size (spare): 64
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:   Pages per Block: 64
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:   Blocks per Unit: 1024
[00:00:00.011,000] <dbg> spi_nand: onfi_parameters_load:             Units: 1
[00:00:00.012,000] <dbg> spi_nand: spi_nand_wait_until_ready: Ready after 200 us (Op read, Status 00)
[00:00:00.012,000] <dbg> spi_nand: spi_nand_is_bad_block: Block at address 000000 is good
[00:00:00.012,000] <dbg> spi_nand: spi_nand_mark_bad_block: Marking block starting at 000000 as bad
[00:00:00.013,000] <dbg> spi_nand: spi_nand_wait_until_ready: Ready after 600 us (Op write, Status 00)
[00:00:00.014,000] <dbg> spi_nand: spi_nand_wait_until_ready: Ready after 200 us (Op read, Status 00)
[00:00:00.014,000] <dbg> spi_nand: spi_nand_is_bad_block: Block at address 000000 is bad (marker 00)
```