### PR TITLE
net: iface: Add multicast address ref counting 

### DIFF
--- a/include/zephyr/net/igmp.h
+++ b/include/zephyr/net/igmp.h
@@ -43,7 +43,17 @@ struct igmp_param {
  * @param addr Multicast group to join
  * @param param Optional parameters
  *
- * @return Return 0 if joining was done, <0 otherwise.
+ * @retval 0 If multicast address was registered and joined successfully.
+ * @retval -EALREADY If multicast address was already registered and joined.
+ *                   This is non-fatal return code, the caller should still release
+ *                   the address with net_ipv4_igmp_leave() if no longer needed.
+ * @retval -ENETDOWN If multicast address was registered but not joined yet due to
+ *                   network interface being down. The address will be joined when
+ *                   interface is up again.
+ *                   This is non-fatal return code, the caller should still release
+ *                   the address with net_ipv4_igmp_leave() if no longer needed.
+ * @retval Other Any other error should be considered fatal, multicast address
+ *               was not registered for the interface.
  */
 #if defined(CONFIG_NET_IPV4_IGMP)
 int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,

--- a/include/zephyr/net/igmp.h
+++ b/include/zephyr/net/igmp.h
@@ -44,9 +44,6 @@ struct igmp_param {
  * @param param Optional parameters
  *
  * @retval 0 If multicast address was registered and joined successfully.
- * @retval -EALREADY If multicast address was already registered and joined.
- *                   This is non-fatal return code, the caller should still release
- *                   the address with net_ipv4_igmp_leave() if no longer needed.
  * @retval -ENETDOWN If multicast address was registered but not joined yet due to
  *                   network interface being down. The address will be joined when
  *                   interface is up again.

--- a/include/zephyr/net/mld.h
+++ b/include/zephyr/net/mld.h
@@ -38,9 +38,6 @@ extern "C" {
  * @param addr Multicast group to join
  *
  * @retval 0 If multicast address was registered and joined successfully.
- * @retval -EALREADY If multicast address was already registered and joined.
- *                   This is non-fatal return code, the caller should still release
- *                   the address with net_ipv6_mld_leave() if no longer needed.
  * @retval -ENETDOWN If multicast address was registered but not joined yet due to
  *                   network interface being down. The address will be joined when
  *                   interface is up again.

--- a/include/zephyr/net/mld.h
+++ b/include/zephyr/net/mld.h
@@ -37,7 +37,17 @@ extern "C" {
  * @param iface Network interface where join message is sent
  * @param addr Multicast group to join
  *
- * @return 0 if joining was done, <0 otherwise.
+ * @retval 0 If multicast address was registered and joined successfully.
+ * @retval -EALREADY If multicast address was already registered and joined.
+ *                   This is non-fatal return code, the caller should still release
+ *                   the address with net_ipv6_mld_leave() if no longer needed.
+ * @retval -ENETDOWN If multicast address was registered but not joined yet due to
+ *                   network interface being down. The address will be joined when
+ *                   interface is up again.
+ *                   This is non-fatal return code, the caller should still release
+ *                   the address with net_ipv6_mld_leave() if no longer needed.
+ * @retval Other Any other error should be considered fatal, multicast address
+ *               was not registered for the interface.
  */
 #if defined(CONFIG_NET_IPV6_MLD)
 int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr);

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -162,6 +162,11 @@ struct net_if_mcast_addr {
 	/** IP address */
 	struct net_addr address;
 
+	/** Reference counter. Used to track multicast group joining/leaving
+	 *  from various subsystems.
+	 */
+	atomic_t atomic_ref;
+
 	/** Rejoining multicast groups list node */
 	sys_snode_t rejoin_node;
 

--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -154,7 +154,7 @@ otError infra_if_init(otInstance *instance, struct net_if *ail_iface)
 	net_ipv6_addr_create_ll_allrouters_mcast(&mcast_addr);
 	ret = net_ipv6_mld_join(ail_iface, &mcast_addr);
 
-	VerifyOrExit((ret == 0 || ret == -EALREADY), error = OT_ERROR_FAILED);
+	VerifyOrExit((ret == 0), error = OT_ERROR_FAILED);
 exit:
 	return error;
 }

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -646,10 +646,10 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,
 	if (net_if_ipv4_maddr_is_joined(maddr)) {
 #if defined(CONFIG_NET_IPV4_IGMPV3)
 		if (param == NULL) {
-			return -EALREADY;
+			return 0;
 		}
 #else
-		return -EALREADY;
+		return 0;
 #endif
 	}
 

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -580,6 +580,40 @@ drop:
 }
 #endif
 
+int net_ipv4_igmp_rejoin(struct net_if *iface, const struct net_in_addr *addr)
+{
+	struct net_if_mcast_addr *maddr;
+	int ret = 0;
+
+	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
+	if (maddr == NULL) {
+		return -ENOENT;
+	}
+
+	if (net_if_is_offloaded(iface)) {
+		goto out;
+	}
+
+#if defined(CONFIG_NET_IPV4_IGMPV3)
+	ret = igmpv3_send_generic(iface, maddr);
+#else
+	ret = igmp_send_generic(iface, addr, true);
+#endif
+	if (ret < 0) {
+		return ret;
+	}
+
+out:
+	net_if_ipv4_maddr_join(iface, maddr);
+
+	net_if_mcast_monitor(iface, &maddr->address, true);
+
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_JOIN, iface, &maddr->address.in_addr,
+					sizeof(struct net_in_addr));
+
+	return ret;
+}
+
 int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,
 		       const struct igmp_param *param)
 {

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -587,6 +587,16 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,
 	int ret = 0;
 
 #if defined(CONFIG_NET_IPV4_IGMPV3)
+	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
+	if (maddr != NULL && maddr->sources_len > 0) {
+		/* For IGMPv3 specifically, if the address with non-empty
+		 * include/exclude list was registered, return an error as
+		 * registering lists from different sources is currently
+		 * not supported.
+		 */
+		return -EEXIST;
+	}
+
 	if (param != NULL) {
 		if (param->sources_len > CONFIG_NET_IF_MCAST_IPV4_SOURCE_COUNT) {
 			return -ENOMEM;
@@ -594,16 +604,19 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,
 	}
 #endif
 
-	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
-	if (maddr && net_if_ipv4_maddr_is_joined(maddr)) {
-		return -EALREADY;
+	maddr = net_if_ipv4_maddr_add(iface, addr);
+	if (maddr == NULL) {
+		return -ENOMEM;
 	}
 
-	if (!maddr) {
-		maddr = net_if_ipv4_maddr_add(iface, addr);
-		if (!maddr) {
-			return -ENOMEM;
+	if (net_if_ipv4_maddr_is_joined(maddr)) {
+#if defined(CONFIG_NET_IPV4_IGMPV3)
+		if (param == NULL) {
+			return -EALREADY;
 		}
+#else
+		return -EALREADY;
+#endif
 	}
 
 #if defined(CONFIG_NET_IPV4_IGMPV3)
@@ -633,6 +646,16 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct net_in_addr *addr,
 #endif
 	if (ret < 0) {
 		net_if_ipv4_maddr_leave(iface, maddr);
+
+		/* -ENETDOWN Indicate that network interface is down - this may
+		 * happen and should not be considered fatal, address group will
+		 * be joined when the interface goes up. Any other error should
+		 * be considered fatal though and address should be cleaned up.
+		 */
+		if (ret != -ENETDOWN) {
+			net_if_ipv4_maddr_rm(iface, addr);
+		}
+
 		return ret;
 	}
 
@@ -655,12 +678,19 @@ out:
 
 int net_ipv4_igmp_leave(struct net_if *iface, const struct net_in_addr *addr)
 {
+	struct net_if_mcast_addr removed_addr;
 	struct net_if_mcast_addr *maddr;
 	int ret = 0;
 
 	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
-	if (!maddr) {
+	if (maddr == NULL) {
 		return -ENOENT;
+	}
+
+	removed_addr = *maddr;
+	if (!net_if_ipv4_maddr_rm(iface, addr)) {
+		/* Address still in use */
+		return 0;
 	}
 
 	if (net_if_is_offloaded(iface)) {
@@ -668,10 +698,10 @@ int net_ipv4_igmp_leave(struct net_if *iface, const struct net_in_addr *addr)
 	}
 
 #if defined(CONFIG_NET_IPV4_IGMPV3)
-	maddr->record_type = IGMPV3_CHANGE_TO_INCLUDE_MODE;
-	maddr->sources_len = 0;
+	removed_addr.record_type = IGMPV3_CHANGE_TO_INCLUDE_MODE;
+	removed_addr.sources_len = 0;
 
-	ret = igmpv3_send_generic(iface, maddr);
+	ret = igmpv3_send_generic(iface, &removed_addr);
 #else
 	ret = igmp_send_generic(iface, addr, false);
 #endif
@@ -680,15 +710,10 @@ int net_ipv4_igmp_leave(struct net_if *iface, const struct net_in_addr *addr)
 	}
 
 out:
-	if (!net_if_ipv4_maddr_rm(iface, addr)) {
-		return -EINVAL;
-	}
+	net_if_mcast_monitor(iface, &removed_addr.address, false);
 
-	net_if_ipv4_maddr_leave(iface, maddr);
-
-	net_if_mcast_monitor(iface, &maddr->address, false);
-
-	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_LEAVE, iface, &maddr->address.in_addr,
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MCAST_LEAVE, iface,
+					&removed_addr.address.in_addr,
 					sizeof(struct net_in_addr));
 	return ret;
 }

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -256,7 +256,7 @@ int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)
 	}
 
 	if (net_if_ipv6_maddr_is_joined(maddr)) {
-		return -EALREADY;
+		return 0;
 	}
 
 	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -215,16 +215,13 @@ int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)
 	struct net_if_mcast_addr *maddr;
 	int ret = 0;
 
-	maddr = net_if_ipv6_maddr_lookup(addr, &iface);
-	if (maddr && net_if_ipv6_maddr_is_joined(maddr)) {
-		return -EALREADY;
+	maddr = net_if_ipv6_maddr_add(iface, addr);
+	if (maddr == NULL) {
+		return -ENOMEM;
 	}
 
-	if (!maddr) {
-		maddr = net_if_ipv6_maddr_add(iface, addr);
-		if (!maddr) {
-			return -ENOMEM;
-		}
+	if (net_if_ipv6_maddr_is_joined(maddr)) {
+		return -EALREADY;
 	}
 
 	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
@@ -241,6 +238,15 @@ int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)
 
 	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE);
 	if (ret < 0) {
+		/* -ENETDOWN Indicate that network interface is down - this may
+		 * happen and should not be considered fatal, address group will
+		 * be joined when the interface goes up. Any other error should
+		 * be considered fatal though and address should be cleaned up.
+		 */
+		if (ret != -ENETDOWN) {
+			net_if_ipv6_maddr_rm(iface, addr);
+		}
+
 		return ret;
 	}
 
@@ -259,15 +265,18 @@ out:
 int net_ipv6_mld_leave(struct net_if *iface, const struct net_in6_addr *addr)
 {
 	struct net_if_mcast_addr *maddr;
+	struct net_addr removed_addr;
 	int ret = 0;
 
 	maddr = net_if_ipv6_maddr_lookup(addr, &iface);
-	if (!maddr) {
+	if (maddr == NULL) {
 		return -ENOENT;
 	}
 
+	removed_addr = maddr->address;
 	if (!net_if_ipv6_maddr_rm(iface, addr)) {
-		return -EINVAL;
+		/* Address still in use */
+		return 0;
 	}
 
 	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
@@ -284,10 +293,10 @@ int net_ipv6_mld_leave(struct net_if *iface, const struct net_in6_addr *addr)
 	}
 
 out:
-	net_if_mcast_monitor(iface, &maddr->address, false);
+	net_if_mcast_monitor(iface, &removed_addr, false);
 
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_LEAVE, iface,
-					&maddr->address.in6_addr,
+					&removed_addr.in6_addr,
 					sizeof(struct net_in6_addr));
 
 	return ret;

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -228,10 +228,6 @@ int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)
 		return 0;
 	}
 
-	if (!net_if_is_up(iface)) {
-		return -ENETDOWN;
-	}
-
 	if (net_if_is_offloaded(iface)) {
 		goto out;
 	}

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -210,6 +210,41 @@ drop:
 	return ret;
 }
 
+int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr)
+{
+	struct net_if_mcast_addr *maddr;
+	int ret = 0;
+
+	maddr = net_if_ipv6_maddr_lookup(addr, &iface);
+	if (maddr == NULL) {
+		return -ENOENT;
+	}
+
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		return 0;
+	}
+
+	if (net_if_is_offloaded(iface)) {
+		goto out;
+	}
+
+	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE);
+	if (ret < 0) {
+		return ret;
+	}
+
+out:
+	net_if_ipv6_maddr_join(iface, maddr);
+
+	net_if_mcast_monitor(iface, &maddr->address, true);
+
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_MCAST_JOIN, iface,
+					&maddr->address.in6_addr,
+					sizeof(struct net_in6_addr));
+
+	return ret;
+}
+
 int net_ipv6_mld_join(struct net_if *iface, const struct net_in6_addr *addr)
 {
 	struct net_if_mcast_addr *maddr;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1176,7 +1176,7 @@ static void join_mcast_allnodes(struct net_if *iface)
 	}
 
 	ret = net_ipv6_mld_join(iface, &addr);
-	if (ret < 0 && ret != -EALREADY && ret != -ENETDOWN) {
+	if (ret < 0 && ret != -ENETDOWN) {
 		NET_ERR("Cannot join all nodes address %s for %d (%d)",
 			net_sprint_ipv6_addr(&addr),
 			net_if_get_by_iface(iface), ret);
@@ -1205,7 +1205,7 @@ static void join_mcast_solicit_node(struct net_if *iface,
 
 	ret = net_ipv6_mld_join(iface, &addr);
 	if (ret < 0) {
-		if (ret != -EALREADY && ret != -ENETDOWN) {
+		if (ret != -ENETDOWN) {
 			NET_ERR("Cannot join solicit node address %s for %d (%d)",
 				net_sprint_ipv6_addr(&addr),
 				net_if_get_by_iface(iface), ret);

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1710,7 +1710,7 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 					  ifaddr, next, rejoin_node) {
 		int ret;
 
-		ret = net_ipv6_mld_join(iface, &ifaddr->address.in6_addr);
+		ret = net_ipv6_mld_rejoin(iface, &ifaddr->address.in6_addr);
 		if (ret < 0) {
 			NET_ERR("Cannot join mcast address %s for %d (%d)",
 				net_sprint_ipv6_addr(&ifaddr->address.in6_addr),
@@ -5216,7 +5216,7 @@ static void rejoin_ipv4_mcast_groups(struct net_if *iface)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&rejoin_needed, ifaddr, next, rejoin_node) {
 		int ret;
 
-		ret = net_ipv4_igmp_join(iface, &ifaddr->address.in_addr, NULL);
+		ret = net_ipv4_igmp_rejoin(iface, &ifaddr->address.in_addr);
 		if (ret < 0) {
 			NET_ERR("Cannot join mcast address %s for %d (%d)",
 				net_sprint_ipv4_addr(&ifaddr->address.in_addr),

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -713,6 +713,26 @@ static uint8_t get_ipaddr_diff(const uint8_t *src, const uint8_t *dst, int addr_
 
 	return len;
 }
+
+static void net_if_maddr_ref_init(struct net_if_mcast_addr *maddr)
+{
+	maddr->atomic_ref = ATOMIC_INIT(1);
+}
+
+static void net_if_maddr_ref(struct net_if_mcast_addr *maddr)
+{
+	atomic_inc(&maddr->atomic_ref);
+}
+
+static int net_if_maddr_unref(struct net_if_mcast_addr *maddr)
+{
+	if (atomic_get(&maddr->atomic_ref) <= 0) {
+		NET_ERR("Multicast address %p is freed already", maddr);
+		return -EINVAL;
+	}
+
+	return atomic_dec(&maddr->atomic_ref) - 1;
+}
 #endif /* CONFIG_NET_IP */
 
 #if defined(CONFIG_NET_NATIVE_IPV4) || defined(CONFIG_NET_NATIVE_IPV6)
@@ -2256,9 +2276,11 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		goto out;
 	}
 
-	if (net_if_ipv6_maddr_lookup(addr, &iface)) {
-		NET_WARN("Multicast address %s is already registered.",
-			net_sprint_ipv6_addr(addr));
+	ifmaddr = net_if_ipv6_maddr_lookup(addr, &iface);
+	if (ifmaddr != NULL) {
+		net_if_maddr_ref(ifmaddr);
+		NET_DBG("Multicast address %s is already registered (ref %ld).",
+			net_sprint_ipv6_addr(addr), atomic_get(&ifmaddr->atomic_ref));
 		goto out;
 	}
 
@@ -2269,6 +2291,8 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 
 		ipv6->mcast[i].is_used = true;
 		ipv6->mcast[i].address.family = NET_AF_INET6;
+		net_if_maddr_ref_init(&ipv6->mcast[i]);
+
 		memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
 
 		NET_DBG("[%zu] interface %d (%p) address %s added", i,
@@ -2294,6 +2318,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct net_in6_addr *addr)
 {
 	bool ret = false;
 	struct net_if_ipv6 *ipv6;
+	int refcount;
 
 	net_if_lock(iface);
 
@@ -2310,6 +2335,19 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct net_in6_addr *addr)
 		if (!net_ipv6_addr_cmp(&ipv6->mcast[i].address.in6_addr,
 				       addr)) {
 			continue;
+		}
+
+		refcount = net_if_maddr_unref(&ipv6->mcast[i]);
+		if (refcount > 0) {
+			NET_DBG("[%zu] interface %d (%p) address %s still in use (ref %ld)",
+				i, net_if_get_by_iface(iface), iface,
+				net_sprint_ipv6_addr(addr), atomic_get(&ipv6->mcast[i].atomic_ref));
+			goto out;
+		}
+		if (refcount < 0) {
+			/* Already released. */
+			ret = true;
+			goto out;
 		}
 
 		ipv6->mcast[i].is_used = false;
@@ -4836,11 +4874,20 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 		goto out;
 	}
 
+	maddr = net_if_ipv4_maddr_lookup(addr, &iface);
+	if (maddr != NULL) {
+		NET_DBG("Multicast address %s is already registered (ref %ld).",
+			net_sprint_ipv4_addr(addr), atomic_get(&maddr->atomic_ref));
+		net_if_maddr_ref(maddr);
+		goto out;
+	}
+
 	maddr = ipv4_maddr_find(iface, false, NULL);
 	if (maddr) {
 		maddr->is_used = true;
 		maddr->address.family = NET_AF_INET;
 		maddr->address.in_addr.s4_addr32[0] = addr->s4_addr32[0];
+		net_if_maddr_ref_init(maddr);
 
 		NET_DBG("interface %d (%p) address %s added",
 			net_if_get_by_iface(iface), iface,
@@ -4862,25 +4909,40 @@ bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct net_in_addr *addr)
 {
 	struct net_if_mcast_addr *maddr;
 	bool ret = false;
+	int refcount;
 
 	net_if_lock(iface);
 
 	maddr = ipv4_maddr_find(iface, true, addr);
-	if (maddr) {
-		maddr->is_used = false;
-
-		NET_DBG("interface %d (%p) address %s removed",
-			net_if_get_by_iface(iface), iface,
-			net_sprint_ipv4_addr(addr));
-
-		net_mgmt_event_notify_with_info(
-			NET_EVENT_IPV4_MADDR_DEL, iface,
-			&maddr->address.in_addr,
-			sizeof(struct net_in_addr));
-
-		ret = true;
+	if (maddr == NULL) {
+		goto out;
 	}
 
+	refcount = net_if_maddr_unref(maddr);
+	if (refcount > 0) {
+		NET_DBG("interface %d (%p) address %s still in use (ref %ld)",
+			net_if_get_by_iface(iface), iface, net_sprint_ipv4_addr(addr),
+			atomic_get(&maddr->atomic_ref));
+		goto out;
+	}
+	if (refcount < 0) {
+		/* Already released. */
+		ret = true;
+		goto out;
+	}
+
+	maddr->is_used = false;
+
+	NET_DBG("interface %d (%p) address %s removed",
+		net_if_get_by_iface(iface), iface, net_sprint_ipv4_addr(addr));
+
+	net_mgmt_event_notify_with_info(NET_EVENT_IPV4_MADDR_DEL, iface,
+					&maddr->address.in_addr,
+					sizeof(struct net_in_addr));
+
+	ret = true;
+
+out:
 	net_if_unlock(iface);
 
 	return ret;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2290,6 +2290,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		}
 
 		ipv6->mcast[i].is_used = true;
+		ipv6->mcast[i].is_joined = false;
 		ipv6->mcast[i].address.family = NET_AF_INET6;
 		net_if_maddr_ref_init(&ipv6->mcast[i]);
 
@@ -4885,6 +4886,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 	maddr = ipv4_maddr_find(iface, false, NULL);
 	if (maddr) {
 		maddr->is_used = true;
+		maddr->is_joined = false;
 		maddr->address.family = NET_AF_INET;
 		maddr->address.in_addr.s4_addr32[0] = addr->s4_addr32[0];
 #if defined(CONFIG_NET_IPV4_IGMPV3)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4887,6 +4887,9 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 		maddr->is_used = true;
 		maddr->address.family = NET_AF_INET;
 		maddr->address.in_addr.s4_addr32[0] = addr->s4_addr32[0];
+#if defined(CONFIG_NET_IPV4_IGMPV3)
+		maddr->sources_len = 0;
+#endif
 		net_if_maddr_ref_init(maddr);
 
 		NET_DBG("interface %d (%p) address %s added",

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1159,6 +1159,7 @@ out:
 #if defined(CONFIG_NET_IPV6_MLD)
 static void join_mcast_allnodes(struct net_if *iface)
 {
+	struct net_if_mcast_addr *maddr;
 	struct net_in6_addr addr;
 	int ret;
 
@@ -1167,6 +1168,12 @@ static void join_mcast_allnodes(struct net_if *iface)
 	}
 
 	net_ipv6_addr_create_ll_allnodes_mcast(&addr);
+
+	maddr = net_if_ipv6_maddr_lookup(&addr, &iface);
+	if (maddr != NULL) {
+		/* Address already present. */
+		return;
+	}
 
 	ret = net_ipv6_mld_join(iface, &addr);
 	if (ret < 0 && ret != -EALREADY && ret != -ENETDOWN) {
@@ -1179,6 +1186,7 @@ static void join_mcast_allnodes(struct net_if *iface)
 static void join_mcast_solicit_node(struct net_if *iface,
 				    struct net_in6_addr *my_addr)
 {
+	struct net_if_mcast_addr *maddr;
 	struct net_in6_addr addr;
 	int ret;
 
@@ -1188,6 +1196,12 @@ static void join_mcast_solicit_node(struct net_if *iface,
 
 	/* Join to needed multicast groups, RFC 4291 ch 2.8 */
 	net_ipv6_addr_create_solicited_node(my_addr, &addr);
+
+	maddr = net_if_ipv6_maddr_lookup(&addr, &iface);
+	if (maddr != NULL) {
+		/* Address already present. */
+		return;
+	}
 
 	ret = net_ipv6_mld_join(iface, &addr);
 	if (ret < 0) {

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -451,3 +451,10 @@ int net_ipv4_igmp_rejoin(struct net_if *iface, const struct net_in_addr *addr);
 #else
 #define net_ipv4_igmp_rejoin(...) -ENOSYS
 #endif
+
+/** Rejoin MLD mcast group w/o registering address, for internal use only. */
+#if defined(CONFIG_NET_IPV6_MLD)
+int net_ipv6_mld_rejoin(struct net_if *iface, const struct net_in6_addr *addr);
+#else
+#define net_ipv6_mld_rejoin(...) -ENOSYS
+#endif

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -444,3 +444,10 @@ static inline void net_pkt_print_buffer_info(struct net_pkt *pkt, const char *st
  * @param pkt The network packet to initialize.
  */
 void net_pkt_tx_init(struct net_pkt *pkt);
+
+/** Rejoin IGMP mcast group w/o registering address, for internal use only. */
+#if defined(CONFIG_NET_IPV4_IGMP)
+int net_ipv4_igmp_rejoin(struct net_if *iface, const struct net_in_addr *addr);
+#else
+#define net_ipv4_igmp_rejoin(...) -ENOSYS
+#endif

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -172,7 +172,7 @@ static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
 			int ret = net_ipv4_igmp_join(iface,
 				&net_sin(&v4_ctx[index].dispatcher.local_addr)->sin_addr,
 					NULL);
-			if (ret < 0 && ret != -EALREADY) {
+			if (ret < 0) {
 				NET_DBG("Cannot add IPv4 multicast address %s to iface %d (%d)",
 					net_sprint_ipv4_addr(&net_sin(
 						&v4_ctx[index].dispatcher.local_addr)->sin_addr),

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -157,7 +157,7 @@ static void join_ipv4_mcast_group(struct net_if *iface, void *user_data)
 	int ret;
 
 	ret = net_ipv4_igmp_join(iface, &net_sin(addr)->sin_addr, NULL);
-	if (ret < 0 && ret != -EALREADY) {
+	if (ret < 0) {
 		NET_DBG("Cannot join %s mDNS group (%d)", "IPv4", ret);
 	} else {
 		NET_DBG("Joined %s mDNS group %s", "IPv4",

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -171,7 +171,7 @@ static void join_ipv6_mcast_group(struct net_if *iface, void *user_data)
 	int ret;
 
 	ret = net_ipv6_mld_join(iface, &net_sin6(addr)->sin6_addr);
-	if (ret < 0 && ret != -EALREADY) {
+	if (ret < 0) {
 		NET_DBG("Cannot join %s mDNS group (%d)", "IPv6", ret);
 	} else {
 		NET_DBG("Joined %s mDNS group %s", "IPv6",

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -14,7 +14,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include "../ip/ipv4.h"
 
 #if defined(CONFIG_NET_IPV4)
-static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
+static void ip_address_info_cb(struct net_if *iface, void *user_data)
 {
 	struct net_shell_user_data *data = user_data;
 	const struct shell *sh = data->sh;
@@ -32,6 +32,7 @@ static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+	PR("Unicast:\n\n");
 	PR("Type      \tState    \tRef\tAddress\n");
 
 	ARRAY_FOR_EACH(ipv4->unicast, i) {
@@ -48,6 +49,21 @@ static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
 			   &ipv4->unicast[i].ipv4.address.in_addr),
 		   net_sprint_ipv4_addr(
 			   &ipv4->unicast[i].netmask));
+	}
+
+	PR("\nMulticast:\n\n");
+	PR("Joined\tRef\tAddress\n");
+
+	ARRAY_FOR_EACH(ipv4->mcast, i) {
+		if (!ipv4->mcast[i].is_used ||
+		    ipv4->mcast[i].address.family != NET_AF_INET) {
+			continue;
+		}
+
+		PR("%s\t%ld\t%s\n",
+		   ipv4->mcast[i].is_joined ? "yes" : "no",
+		   atomic_get(&ipv4->mcast[i].atomic_ref),
+		   net_sprint_ipv4_addr(&ipv4->mcast[i].address.in6_addr));
 	}
 }
 #endif /* CONFIG_NET_IPV4 */
@@ -89,7 +105,7 @@ static int cmd_net_ipv4(const struct shell *sh, size_t argc, char *argv[])
 	user_data.user_data = NULL;
 
 	/* Print information about address lifetime */
-	net_if_foreach(ip_address_lifetime_cb, &user_data);
+	net_if_foreach(ip_address_info_cb, &user_data);
 #endif /* CONFIG_NET_IPV4 */
 
 	return 0;

--- a/subsys/net/lib/shell/ipv6.c
+++ b/subsys/net/lib/shell/ipv6.c
@@ -79,7 +79,7 @@ static void ipv6_pe_filter_cb(struct net_in6_addr *prefix, bool is_denylist,
 #endif /* CONFIG_NET_IPV6_PE */
 
 #if defined(CONFIG_NET_IPV6)
-static void address_lifetime_cb(struct net_if *iface, void *user_data)
+static void address_info_cb(struct net_if *iface, void *user_data)
 {
 	struct net_shell_user_data *data = user_data;
 	const struct shell *sh = data->sh;
@@ -97,6 +97,7 @@ static void address_lifetime_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+	PR("Unicast:\n\n");
 	PR("Type      \tState    \tLifetime (sec)\tRef\tAddress\n");
 
 	ARRAY_FOR_EACH(ipv6->unicast, i) {
@@ -139,6 +140,21 @@ static void address_lifetime_cb(struct net_if *iface, void *user_data)
 		   net_sprint_ipv6_addr(&ipv6->unicast[i].address.in6_addr),
 		   prefix_len,
 		   ipv6->unicast[i].is_temporary ? " (temporary)" : "");
+	}
+
+	PR("\nMulticast:\n\n");
+	PR("Joined\tRef\tAddress\n");
+
+	ARRAY_FOR_EACH(ipv6->mcast, i) {
+		if (!ipv6->mcast[i].is_used ||
+		    ipv6->mcast[i].address.family != NET_AF_INET6) {
+			continue;
+		}
+
+		PR("%s\t%ld\t%s\n",
+		   ipv6->mcast[i].is_joined ? "yes" : "no",
+		   atomic_get(&ipv6->mcast[i].atomic_ref),
+		   net_sprint_ipv6_addr(&ipv6->mcast[i].address.in6_addr));
 	}
 }
 #endif /* CONFIG_NET_IPV6 */
@@ -221,7 +237,7 @@ static int cmd_net_ipv6(const struct shell *sh, size_t argc, char *argv[])
 	user_data.user_data = NULL;
 
 	/* Print information about address lifetime */
-	net_if_foreach(address_lifetime_cb, &user_data);
+	net_if_foreach(address_info_cb, &user_data);
 #endif /* CONFIG_NET_IPV6 */
 
 	return 0;

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -939,9 +939,13 @@ static void v6_addr_add(void)
 static void v6_addr_add_mcast_twice(void)
 {
 	struct net_if_mcast_addr *maddr;
+	struct net_if_mcast_addr *maddr2;
 
-	maddr = net_if_ipv6_maddr_add(iface1, &in6addr_mcast);
-	zassert_equal(maddr, NULL, "Address was added twice");
+	maddr = net_if_ipv6_maddr_lookup(&in6addr_mcast, &iface1);
+	zassert_not_null(maddr, "Address not found");
+
+	maddr2 = net_if_ipv6_maddr_add(iface1, &in6addr_mcast);
+	zassert_equal(maddr, maddr2, "Address was added twice");
 }
 
 static void v6_addr_lookup(void)
@@ -1001,12 +1005,12 @@ ZTEST(net_iface, test_v6_addr_add_rm_solicited)
 				      NET_ADDR_AUTOCONF, 0);
 	zassert_not_null(ifaddr, "Cannot add IPv6 global unicast address");
 
-	/* Add the corresponding solicited-node multicast address (should exist) */
+	/* Corresponding solicited-node multicast address should already exist */
 	net_ipv6_addr_create_solicited_node(&unicast_addr, &unicast_addr_mcast);
 	zassert_mem_equal(&unicast_addr_mcast, &iid_addr_mcast,
 			  sizeof(struct net_in6_addr));
-	maddr = net_if_ipv6_maddr_add(iface4, &unicast_addr_mcast);
-	zassert_is_null(maddr, "Solicited-node multicast address was added twice");
+	maddr = net_if_ipv6_maddr_lookup(&iid_addr_mcast, &iface4);
+	zassert_not_null(maddr, "Solicited-node multicast address was removed");
 
 	/* Remove the global unicast address */
 	ret = net_if_ipv6_addr_rm(iface4, &unicast_addr);

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -76,7 +76,6 @@ static bool is_query_received;
 static bool is_report_sent;
 static bool is_igmpv2_query_sent;
 static bool is_igmpv3_query_sent;
-static bool ignore_already;
 K_SEM_DEFINE(wait_data, 0, UINT_MAX);
 
 #define WAIT_TIME 500
@@ -331,13 +330,7 @@ static void join_group(void)
 	int ret;
 
 	ret = net_ipv4_igmp_join(net_iface, &mcast_addr, NULL);
-
-	if (ignore_already) {
-		zassert_true(ret == 0 || ret == -EALREADY,
-			     "Cannot join IPv4 multicast group");
-	} else {
-		zassert_ok(ret, "Cannot join IPv4 multicast group");
-	}
+	zassert_ok(ret, "Cannot join IPv4 multicast group");
 
 	/* Let the network stack to proceed */
 	k_msleep(THREAD_SLEEP);
@@ -362,8 +355,6 @@ static void leave_group(void)
 static void catch_join_group(void)
 {
 	is_group_joined = false;
-
-	ignore_already = false;
 
 	join_group();
 
@@ -390,8 +381,6 @@ static void catch_leave_group(void)
 static void verify_join_group(void)
 {
 	is_join_msg_ok = false;
-
-	ignore_already = false;
 
 	join_group();
 
@@ -471,15 +460,10 @@ static void socket_group_with_address(struct net_in_addr *local_addr, bool do_jo
 			       (void *)&mreqn, sizeof(mreqn));
 
 	if (do_join) {
-		if (ignore_already) {
-			zassert_true(ret == 0 || ret == -EALREADY,
-				     "Cannot join IPv4 multicast group (%d)", -errno);
-		} else {
-			zassert_ok(ret,
-				   "Cannot join IPv4 multicast group (%d) "
-				   "with local addr %s",
-				   -errno, net_sprint_ipv4_addr(local_addr));
-		}
+		zassert_ok(ret,
+			   "Cannot join IPv4 multicast group (%d) "
+			   "with local addr %s",
+			   -errno, net_sprint_ipv4_addr(local_addr));
 	} else {
 		zassert_ok(ret, "Cannot leave IPv4 multicast group (%d)", -errno);
 
@@ -519,12 +503,7 @@ static void socket_group_with_index(struct net_in_addr *local_addr, bool do_join
 			       (void *)&mreqn, sizeof(mreqn));
 
 	if (do_join) {
-		if (ignore_already) {
-			zassert_true(ret == 0 || ret == -EALREADY,
-				     "Cannot join IPv4 multicast group (%d)", -errno);
-		} else {
-			zassert_ok(ret, "Cannot join IPv4 multicast group (%d)", -errno);
-		}
+		zassert_ok(ret, "Cannot join IPv4 multicast group (%d)", -errno);
 	} else {
 		zassert_ok(ret, "Cannot leave IPv4 multicast group (%d)", -errno);
 
@@ -645,14 +624,11 @@ ZTEST_USER(net_igmp, test_group_rejoin)
 ZTEST(net_igmp, test_igmp_multi_join)
 {
 	is_join_msg_ok = false;
-	ignore_already = false;
 	join_group();
 	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting join event");
 	zassert_true(is_join_msg_ok, "Join msg invalid");
 
-	/* Second join would give -EALREADY, no report sent, still ref count will be increased */
 	is_join_msg_ok = false;
-	ignore_already = true;
 	join_group();
 	k_msleep(THREAD_SLEEP);
 	zassert_false(is_join_msg_ok, "Unexpected join msg");

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -642,4 +642,31 @@ ZTEST_USER(net_igmp, test_group_rejoin)
 	socket_leave_group_with_index(&my_addr);
 }
 
+ZTEST(net_igmp, test_igmp_multi_join)
+{
+	is_join_msg_ok = false;
+	ignore_already = false;
+	join_group();
+	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting join event");
+	zassert_true(is_join_msg_ok, "Join msg invalid");
+
+	/* Second join would give -EALREADY, no report sent, still ref count will be increased */
+	is_join_msg_ok = false;
+	ignore_already = true;
+	join_group();
+	k_msleep(THREAD_SLEEP);
+	zassert_false(is_join_msg_ok, "Unexpected join msg");
+
+	/* First leave should not send report due to two refs on the address */
+	is_leave_msg_ok = false;
+	leave_group();
+	k_msleep(THREAD_SLEEP);
+	zassert_false(is_leave_msg_ok, "Unexpected leave msg");
+
+	is_leave_msg_ok = false;
+	leave_group();
+	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting leave event");
+	zassert_true(is_leave_msg_ok, "Leave msg invalid");
+}
+
 ZTEST_SUITE(net_igmp, NULL, igmp_setup, NULL, NULL, igmp_teardown);

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -616,6 +616,7 @@ static void test_verify_send_report(void)
 	zassert_true(is_report_sent, "Report not sent");
 
 	leave_mldv2_capable_routers_group();
+	test_leave_group();
 }
 
 /* This value should be longer that the one in net_if.c when DAD timeouts */

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -1104,4 +1104,31 @@ ZTEST_USER(net_mld_test_suite, test_socket_catch_join_with_index)
 	socket_leave_group_with_index(&my_addr);
 }
 
+ZTEST(net_mld_test_suite, test_mld_multi_join)
+{
+	is_join_msg_ok = false;
+	ignore_already = false;
+	test_join_group();
+	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting join event");
+	zassert_true(is_join_msg_ok, "Join msg invalid");
+
+	/* Second join would give -EALREADY, no report sent, still ref count will be increased */
+	is_join_msg_ok = false;
+	ignore_already = true;
+	test_join_group();
+	k_msleep(THREAD_SLEEP);
+	zassert_false(is_join_msg_ok, "Unexpected join msg");
+
+	/* First leave should not send report due to two refs on the address */
+	is_leave_msg_ok = false;
+	test_leave_group();
+	k_msleep(THREAD_SLEEP);
+	zassert_false(is_leave_msg_ok, "Unexpected leave msg");
+
+	is_leave_msg_ok = false;
+	test_leave_group();
+	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting leave event");
+	zassert_true(is_leave_msg_ok, "Leave msg invalid");
+}
+
 ZTEST_SUITE(net_mld_test_suite, NULL, test_mld_setup, test_mld_before, NULL, NULL);

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -81,7 +81,6 @@ static bool is_join_msg_ok;
 static bool is_leave_msg_ok;
 static bool is_query_received;
 static bool is_report_sent;
-static bool ignore_already;
 
 static struct mld_report_handler *report_handler;
 
@@ -326,13 +325,7 @@ static void test_join_group(void)
 	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
 	ret = net_ipv6_mld_join(net_iface, &mcast_addr);
-
-	if (ignore_already) {
-		zassert_true(ret == 0 || ret == -EALREADY,
-			     "Cannot join IPv6 multicast group");
-	} else {
-		zassert_equal(ret, 0, "Cannot join IPv6 multicast group");
-	}
+	zassert_equal(ret, 0, "Cannot join IPv6 multicast group");
 
 	/* Let the network stack to proceed */
 	k_msleep(THREAD_SLEEP);
@@ -354,8 +347,6 @@ static void test_leave_group(void)
 static void test_catch_join_group(void)
 {
 	is_group_joined = false;
-
-	ignore_already = false;
 
 	test_join_group();
 
@@ -390,8 +381,6 @@ static void test_catch_leave_group(void)
 static void test_verify_join_group(void)
 {
 	is_join_msg_ok = false;
-
-	ignore_already = false;
 
 	test_join_group();
 
@@ -587,8 +576,6 @@ static void test_verify_send_report(void)
 
 	is_query_received = false;
 	is_report_sent = false;
-
-	ignore_already = true;
 
 	k_sem_reset(&wait_data);
 
@@ -1060,15 +1047,9 @@ static void socket_group_with_index(const struct net_in6_addr *local_addr, bool 
 			       (void *)&mreq, sizeof(mreq));
 
 	if (do_join) {
-		if (ignore_already) {
-			zassert_true(ret == 0 || ret == -EALREADY,
-				     "Cannot join IPv6 multicast group (%d)",
-				     -errno);
-		} else {
-			zassert_equal(ret, 0,
-				      "Cannot join IPv6 multicast group (%d)",
-				      -errno);
-		}
+		zassert_equal(ret, 0,
+			      "Cannot join IPv6 multicast group (%d)",
+			      -errno);
 	} else {
 		zassert_equal(ret, 0, "Cannot leave IPv6 multicast group (%d)",
 			      -errno);
@@ -1108,14 +1089,11 @@ ZTEST_USER(net_mld_test_suite, test_socket_catch_join_with_index)
 ZTEST(net_mld_test_suite, test_mld_multi_join)
 {
 	is_join_msg_ok = false;
-	ignore_already = false;
 	test_join_group();
 	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting join event");
 	zassert_true(is_join_msg_ok, "Join msg invalid");
 
-	/* Second join would give -EALREADY, no report sent, still ref count will be increased */
 	is_join_msg_ok = false;
-	ignore_already = true;
 	test_join_group();
 	k_msleep(THREAD_SLEEP);
 	zassert_false(is_join_msg_ok, "Unexpected join msg");


### PR DESCRIPTION
Add ref counting for multicast addresses, so that if a multicast address is registered from different subsystems, they won't interfere with each other. That way, if one subsystem decides to remove a multicast address, it won't affect other subsystems that may still need it.

Align IGMP/MLD code with the changes.

Resolves #104604