### PR TITLE
soc: silabs: siwx91x: Allow to avoid literal pools

### DIFF
--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -4,9 +4,9 @@ zephyr_library()
 
 if(CONFIG_SLOW_FLASH_DATA)
   if(COMPILER STREQUAL gcc)
-    zephyr_compile_options(-mslow-flash-data)
+    zephyr_compile_options(-mslow-flash-data -fno-jump-tables)
   elseif(COMPILER STREQUAL iar)
-    zephyr_compile_options(--no_literal_pool)
+    zephyr_compile_options(--no_literal_pool --no_switch_tables)
   endif()
 endif()
 

--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -2,6 +2,14 @@
 
 zephyr_library()
 
+if(CONFIG_SLOW_FLASH_DATA)
+  if(COMPILER STREQUAL gcc)
+    zephyr_compile_options(-mslow-flash-data)
+  elseif(COMPILER STREQUAL iar)
+    zephyr_compile_options(--no_literal_pool)
+  endif()
+endif()
+
 zephyr_library_sources(
   fatal.c
   nmi.c

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -157,6 +157,22 @@ config STACK_ALIGN_DOUBLE_WORD
 	  Note that for ARMv6-M, ARMv8-M, and Cortex-M7 MCUs stack alignment
 	  on exception entry is enabled by default and it is not configurable.
 
+config SLOW_FLASH_DATA
+	bool
+	depends on !ARMV6_M_ARMV8_M_BASELINE
+	help
+	 On some SoC, accessing the rodata is slower than accessing the instructions (generally
+	 because data cache is missing). Therefore, all accesses to data stored in flash penalize
+	 performance. Use this option to use assembly instructions rather than literal pools (data
+	 interleaved with code).
+
+	 With current GCC versions (14.x), this option is incompatible with Thread Local Storage
+	 (TLS). User may either:
+	   - Use a patched version of gcc (preferred option), or
+	   - Rebuild libc (CONFIG_PICOLIBC_USE_MODULE=y) without TLS support
+	     (CONFIG_THREAD_LOCAL_STORAGE=n). In this case, access to "errno" will no longer be
+	     thread-safe.
+
 config RUNTIME_NMI
 	bool "Attach an NMI handler at runtime"
 	select REBOOT

--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -68,7 +68,12 @@ SECTION_FUNC(TEXT, z_arm_pendsv)
 #endif /* CONFIG_INSTRUMENT_THREAD_SWITCHING */
 
     /* load _kernel into r1 and current k_thread into r2 */
+#if defined(CONFIG_SLOW_FLASH_DATA)
+    movw r1, #:lower16:_kernel
+    movt r1, #:upper16:_kernel
+#else
     ldr r1, =_kernel
+#endif
     ldr r2, [r1, #_kernel_offset_to_current]
 
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)
@@ -136,7 +141,12 @@ SECTION_FUNC(TEXT, z_arm_pendsv)
      * to pend PendSV have been taken with the current kernel
      * state and this is what we're handling currently.
      */
+#if defined(CONFIG_SLOW_FLASH_DATA)
+    movw r7, #:lower16:_SCS_ICSR
+    movt r7, #:upper16:_SCS_ICSR
+#else
     ldr r7, =_SCS_ICSR
+#endif
     ldr r6, =_SCS_ICSR_UNPENDSV
 
     /* _kernel is still in r1 */

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -600,14 +600,25 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 			 "msr   PSP, %1\n" /* __set_PSP(stack_ptr) */
 
 			 "movs  r0,  #0\n" /* arch_irq_unlock(0) */
+#ifdef CONFIG_SLOW_FLASH_DATA
+			 "movw  r3, #:lower16:arch_irq_unlock_outlined\n"
+			 "movt  r3, #:upper16:arch_irq_unlock_outlined\n"
+#else
 			 "ldr   r3, =arch_irq_unlock_outlined\n"
+#endif
 			 "blx   r3\n"
 
 			 "mov   r0, r4\n" /* z_thread_entry(_main, NULL, NULL, NULL) */
 			 "movs  r1, #0\n"
 			 "movs  r2, #0\n"
 			 "movs  r3, #0\n"
+#ifdef CONFIG_SLOW_FLASH_DATA
+			 "movw  r4, #:lower16:z_thread_entry\n"
+			 "movt  r4, #:upper16:z_thread_entry\n"
+#else
 			 "ldr   r4, =z_thread_entry\n"
+#endif
+
 			 /* We don’t intend to return, so there is no need to link. */
 			 "bx    r4\n"
 			 /* Force a literal pool placement for the addresses referenced above */

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -15,6 +15,19 @@ if SOC_FAMILY_SILABS_SIWX91X
 
 rsource "*/Kconfig"
 
+config SILABS_SIWX91X_SLOW_FLASH_DATA
+	bool "Limit access to data in flash (EXPERIMENTAL)"
+	select SLOW_FLASH_DATA
+	help
+	  The main flash on siwx91x does not have a data cache. Use this option to request the
+	  compiler to limit access to data in flash.
+
+	  The benefit depends on the workload. Some kernel benchmarks (tests/benchmarks/app_kernel/)
+	  run up to 300% faster, while the typical improvement is around 10-50%.
+
+	  This option pulls the limitations described in CONFIG_SLOW_FLASH_DATA. The users have to
+	  make sure they are aware of them.
+
 config SILABS_SIWX91X_NWP
 	bool "Silabs Network Coprocessor"
 	depends on DT_HAS_SILABS_SIWX91X_NWP_ENABLED


### PR DESCRIPTION
On siwx91x, no data cache is associated with the main flash. Therefore,
all accesses to data stored in flash, especially [literal pools][1] penalizes
performances. Fortunately, GCC and IAR provide options (`-mslow-flash-data`
and `--no_literal_pool`) to prevent the generation of literal pools.

The benefit of this option depends of the workload. Some kernel benchmarks
(tests/benchmarks/app_kernel/) run up to 300% faster, while the typical
improvement is around 10-50%.

Unfortunately, current GCC versions (14.x) do not support -mslow-flash-data
when Thread Local Storage (TLS) variables are used. A patch is currently
[under][2] [review][3] to address this limitation. Without this gcc patch,
using -mslow-flash-data is not very user friendly. The user must rebuild
the libc (`CONFIG_PICOLIBC_USE_MODULE=y`) without TLS support
(`CONFIG_THREAD_LOCAL_STORAGE=n`), and must ensure that the application does
rely on thread-safe "errno".

In addition to -mslow-flash-data, we must also ensure that the assembler
does not generate literal pools. They are automatically generated by the
[LDR pseudo-instruction][4]:
  - If the constant can be constructed with a MOV or MVN instruction, the
    assembler emits the corresponding instruction.
  - Otherwise (when the value does not fit on 16bits), the assembler places
    the value in the next literal pool.

No options was found in GNU assembler to disable literal pool generation.
Therefore, this patch explicitly uses MOVT and MOVW when the assembler
would otherwise generate literal pool.

[1]: https://en.wikipedia.org/wiki/Literal_pool
[2]: https://gcc.gnu.org/pipermail/gcc-patches/2026-February/707887.html
[3]: https://github.com/zephyrproject-rtos/gcc/pull/65
[4]: https://developer.arm.com/documentation/dui0204/f/writing-arm-assembly-language/loading-constants-into-registers/loading-with-ldr-rd---const?lang=en