### PR TITLE
modules: hal_infineon: Get latest mtb-srf and minor changes

### DIFF
--- a/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
+++ b/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
@@ -7,6 +7,7 @@ if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
   set(zephyr_ifx_cycfg_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/zephyr-ifx-cycfg/kit_pse84_eval)
 
   zephyr_include_directories(${zephyr_ifx_cycfg_dir})
+  zephyr_include_directories(${zephyr_ifx_cycfg_dir}/device_headers)
   zephyr_library_sources(${zephyr_ifx_cycfg_dir}/cycfg_qspi_memslot.c)
   zephyr_library_sources(${zephyr_ifx_cycfg_dir}/ifx_cycfg_init.c)
   zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_AUTANALOG_SAR_ADC

--- a/west.yml
+++ b/west.yml
@@ -185,7 +185,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 470f874ce432763a2b82cd322d0ff6efc89240cd
+      revision: 839de193c8c555a75ce44c3d6085fae9227caa85
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Update the module dependency for hal-infineon to
include updates from [PR 43.](https://github.com/zephyrproject-rtos/hal_infineon/pull/43/)
The new folder structure requires an update in the CMakeList file for zephyr-ifx-cycfg.