### PR TITLE
Bluetooth: Host: Make ACL/CIS disconnect order deterministic

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -169,6 +169,12 @@ New APIs and options
     * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
     * :c:func:`bt_le_per_adv_sync_cb_unregister`
 
+  * ISO
+
+    * :c:member:`bt_iso_chan_ops.disconnected` will now always be called before
+      :c:member:`bt_conn_cb.disconnected` for unicast (CIS) channels,
+      to provide a more deterministic order of callback events. (:github:`104695`).
+
   * Mesh
 
     * :c:func:`bt_mesh_input_numeric` to provide provisioning numeric input OOB value.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -729,6 +729,9 @@ struct bt_iso_chan_ops {
 	 *
 	 * For the above reason it is still possible to use bt_iso_chan_get_info() on the @p chan.
 	 *
+	 * If the @p chan is a unicast (CIS) channel, then this callback will always be called
+	 * before @ref bt_conn_cb.disconnected when the associated ACL connection also disconnects.
+	 *
 	 * @param chan   The channel that has been Disconnected
 	 * @param reason BT_HCI_ERR_* reason for the disconnection.
 	 */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2150,29 +2150,6 @@ static int send_conn_le_param_update(struct bt_conn *conn,
 	return bt_l2cap_update_conn_param(conn, param);
 }
 
-#if defined(CONFIG_BT_ISO_UNICAST)
-static struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(iso_conns); i++) {
-		struct bt_conn *iso = bt_conn_ref(&iso_conns[i]);
-
-		if (iso == NULL) {
-			continue;
-		}
-
-		if (iso->iso.acl == conn) {
-			return iso;
-		}
-
-		bt_conn_unref(iso);
-	}
-
-	return NULL;
-}
-#endif /* CONFIG_BT_ISO */
-
 #if defined(CONFIG_BT_CLASSIC)
 static struct bt_conn *conn_lookup_sco(struct bt_conn *conn)
 {
@@ -2206,7 +2183,7 @@ static void deferred_work(struct k_work *work)
 
 	if (conn->state == BT_CONN_DISCONNECTED) {
 #if defined(CONFIG_BT_ISO_UNICAST)
-		struct bt_conn *iso;
+		bool acl_coupled_with_cis;
 
 		if (bt_conn_is_iso(conn)) {
 			/* bt_iso_disconnected is responsible for unref'ing the
@@ -2217,23 +2194,36 @@ static void deferred_work(struct k_work *work)
 			return;
 		}
 
-		/* Mark all ISO channels associated
-		 * with ACL conn as not connected, and
-		 * remove ACL reference
+		/* Mark all CIS still associated with the ACL conn as disconnecting.
+		 * If any CIS are associated with the ACL, we postpone the disconnect work until
+		 * after the CIS has been disconnected from a HCI Disconnect event.
 		 */
-		iso = conn_lookup_iso(conn);
-		while (iso != NULL) {
-			struct bt_iso_chan *chan = iso->iso.chan;
+		acl_coupled_with_cis = false;
+		ARRAY_FOR_EACH_PTR(iso_conns, iso_conn) {
+			struct bt_conn *iso = bt_conn_ref(iso_conn);
 
-			if (chan != NULL) {
-				bt_iso_chan_set_state(chan,
-						      BT_ISO_STATE_DISCONNECTING);
+			if (iso == NULL) {
+				continue;
 			}
 
-			bt_iso_cleanup_acl(iso);
+			if (iso->iso.acl == conn) {
+				struct bt_iso_chan *chan = iso->iso.chan;
+
+				if (chan != NULL) {
+					bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTING);
+				}
+
+				acl_coupled_with_cis = true;
+			}
 
 			bt_conn_unref(iso);
-			iso = conn_lookup_iso(conn);
+		}
+
+		if (acl_coupled_with_cis) {
+			LOG_DBG("acl %p is pending on CIS disconnects, wait for CIS disconnects",
+				conn);
+
+			return;
 		}
 #endif
 #if defined(CONFIG_BT_CLASSIC)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1156,13 +1156,48 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 	return err;
 }
 
+static bool bt_iso_acl_has_cis(const struct bt_conn *acl)
+{
+	ARRAY_FOR_EACH_PTR(iso_conns, iso_conn) {
+		struct bt_conn *iso = bt_conn_ref(iso_conn);
+
+		if (iso == NULL) {
+			continue;
+		}
+
+		if (iso->iso.acl == acl) {
+			bt_conn_unref(iso);
+
+			return true;
+		}
+
+		bt_conn_unref(iso);
+	}
+
+	return false;
+}
+
 void bt_iso_cleanup_acl(struct bt_conn *iso)
 {
+	struct bt_conn *acl = iso->iso.acl;
 	LOG_DBG("%p", iso);
 
-	if (iso->iso.acl) {
-		bt_conn_unref(iso->iso.acl);
+	if (acl != NULL) {
 		iso->iso.acl = NULL;
+
+		/* If we have removed the last ACL reference, trigger the deferred work to finalize
+		 * the ACL disconnection
+		 */
+		if (acl->state == BT_CONN_DISCONNECTED && !bt_iso_acl_has_cis(acl)) {
+			LOG_DBG("Trigger disconnect work for ACL %p", acl);
+
+			__maybe_unused const int err =
+				k_work_schedule(&acl->deferred_work, K_NO_WAIT);
+
+			__ASSERT(err >= 0, "Failed to retrigger conn->deferred_work for %p", acl);
+		}
+
+		bt_conn_unref(acl);
 	}
 }
 


### PR DESCRIPTION
Currently the other of the ACL and CIS disconnect callbacks depend on the order of the HCI events received. Since this order is not specified by the core spec, it means that any users/applications of ISO will need to wait for all CIS disconnects callbacks and the ACL disconnect callback before attempting to reuse any of them.

From an API perspective this is not ideal, and the API will be much simpler if the order of ACL and ISO disconnect callbacks were deterministic, regardless of the controller.

This change postpones the finalization of the ACL disconnect until all the CIS associated with it has been disconnected. This will also make the API more similar to e.g. the L2CAP disconnect order.

No tests have been added since the Zephyr controller always sends the CIS disconnect events first, but other controllers, like the Nordic SDC, may not. See https://github.com/zephyrproject-rtos/zephyr/pull/34861 and https://github.com/zephyrproject-rtos/zephyr/pull/39514 for the Zephyr implementation. The PR has been manually tested with Nordic SDC to verify the correct behavior.

There will be a follow up PR for LE Audio, as the BAP unicast client has attempted to handle the 2 types of disconnect callbacks in any other, but it is tricky when an ACL `bt_conn` can actually be reused for a new connection, for another device, before the CIS have been properly free'd, since they share some of the same resources in LE Audio. 