### PR TITLE
doc: kernel: fix incorrect Doxygen @retval/@return usage

### DIFF
--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -107,7 +107,8 @@ void k_mbox_init(struct k_mbox *mbox)
  * @param tx_msg Pointer to transmit message descriptor.
  * @param rx_msg Pointer to receive message descriptor.
  *
- * @return 0 if successfully matched, otherwise -1.
+ * @retval 0 Success.
+ * @retval -1 Not matched.
  */
 static int mbox_message_match(struct k_mbox_msg *tx_msg,
 			       struct k_mbox_msg *rx_msg)
@@ -205,7 +206,9 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
  *        Use K_NO_WAIT to return immediately, or K_FOREVER to wait as long
  *        as necessary.
  *
- * @return 0 if successful, -ENOMSG if failed immediately, -EAGAIN if timed out
+ * @retval 0 Success.
+ * @retval -ENOMSG Failed immediately.
+ * @retval -EAGAIN Timed out.
  */
 static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			     k_timeout_t timeout)
@@ -362,7 +365,7 @@ void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer)
  * @param rx_msg Pointer to receive message descriptor.
  * @param buffer Pointer to buffer to receive data.
  *
- * @return 0
+ * @retval 0 Always returns 0.
  */
 static int mbox_message_data_check(struct k_mbox_msg *rx_msg, void *buffer)
 {

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -140,7 +140,8 @@ static int create_free_list(struct k_mem_slab *slab)
  *
  * Perform any initialization that wasn't done at build time.
  *
- * @return 0 on success, fails otherwise.
+ * @retval 0 Success.
+ * @retval -EINVAL Slab contains invalid configuration and/or values.
  */
 static int init_mem_slab_obj_core_list(void)
 {

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -873,7 +873,7 @@ size_t k_mem_free_get(void)
  * @param[in] phys Physical address of region to be mapped, aligned to MMU_PAGE_SIZE
  * @param[in] size Size of region to be mapped, aligned to MMU_PAGE_SIZE
  *
- * @retval alignment to apply on the virtual address of this region
+ * @return alignment to apply on the virtual address of this region
  */
 static size_t virt_region_align(uintptr_t phys, size_t size)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -900,7 +900,7 @@ static inline void set_current(struct k_thread *new_thread)
  * copy before calling this function.
  *
  * @param interrupted Handle for the thread that was interrupted or NULL.
- * @retval Handle for the next thread to execute, or @p interrupted when
+ * @return Handle for the next thread to execute, or @p interrupted when
  *         no new thread is to be scheduled.
  */
 void *z_get_next_switch_handle(void *interrupted)


### PR DESCRIPTION
Fix several incorrect uses of the Doxygen `@retval` and @return command in kernel sources.

- Convert @return to structured @retval where functions return discrete values.
- Replace incorrect @retval usage with @return for non-discrete return types.

Partially addresses #65974.

Before proceeding with wider tree-wide fixes, I would appreciate confirmation that this direction matches the preferred documentation style for Zephyr.
Thank you!