### PR TITLE
usb: device_next: allow to initialize multiple CDC ACM instances

### DIFF
--- a/doc/connectivity/usb/device_next/cdc_acm.rst
+++ b/doc/connectivity/usb/device_next/cdc_acm.rst
@@ -97,6 +97,13 @@ As the configuration would be identical for any board, there are common
 :zephyr_file:`Kconfig file <boards/common/usb/Kconfig.cdc_acm_serial.defconfig>`
 that must be included in the board's devicetree and Kconfig.defconfig files.
 
+The number of initialized CDC ACM instances is one by default.
+If the application requires multiple CDC ACM serial backends, the number of
+registered and initialized instances can be increased using
+:kconfig:option:`CONFIG_CDC_ACM_SERIAL_INSTANCES_NUMBER`.
+The order of the instances is not guaranteed. For identification purposes, a
+host application needs to use the label property of the CDC ACM UART node.
+
 Using CDC ACM UART in the application
 =====================================
 

--- a/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
+++ b/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
@@ -23,6 +23,16 @@ config CDC_ACM_SERIAL_ENABLE_AT_BOOT
 	  When disabled, the application is responsible for enabling/disabling
 	  the USB device.
 
+config CDC_ACM_SERIAL_INSTANCES_NUMBER
+	int "Maximum number of initiliazed CDC ACM instances"
+	range 1 7
+	default 1
+	help
+	  Register and initialize up to a selected number of CDC ACM instances.
+	  These instances will not be available for other configurations or USB
+	  device contexts. This number must not be higher than the number of
+	  available instances.
+
 config CDC_ACM_SERIAL_MANUFACTURER_STRING
 	string "USB device manufacturer string descriptor"
 	default "Zephyr Project"

--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -43,11 +43,15 @@ USBD_CONFIGURATION_DEFINE(cdc_acm_serial_hs_config,
 			  attributes,
 			  CONFIG_CDC_ACM_SERIAL_MAX_POWER, &hs_cfg_desc);
 
+BUILD_ASSERT(CONFIG_CDC_ACM_SERIAL_INSTANCES_NUMBER <= DT_NUM_INST_STATUS_OKAY(zephyr_cdc_acm_uart),
+	     "CONFIG_CDC_ACM_SERIAL_INSTANCES_NUMBER is higher than number of CDC ACM instances");
 
-static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
-			      const enum usbd_speed speed)
+static int register_cdc_acm(struct usbd_context *const uds_ctx,
+			    const enum usbd_speed speed)
 {
 	struct usbd_config_node *cfg_nd;
+	char name[] = "cdc_acm_0";
+	const int idx = 8; /* -^ */
 	int err;
 
 	if (speed == USBD_SPEED_HS) {
@@ -62,10 +66,13 @@ static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	err = usbd_register_class(&cdc_acm_serial, "cdc_acm_0", speed, 1);
-	if (err) {
-		LOG_ERR("Failed to register classes");
-		return err;
+	for (int n = 0; n < CONFIG_CDC_ACM_SERIAL_INSTANCES_NUMBER; n++) {
+		name[idx] = '0' + n;
+		err = usbd_register_class(&cdc_acm_serial, name, speed, 1);
+		if (err) {
+			LOG_ERR("Failed to register %s", name);
+			return err;
+		}
 	}
 
 	return usbd_device_set_code_triple(uds_ctx, speed,
@@ -105,13 +112,13 @@ static int cdc_acm_serial_init_device(void)
 
 	if (USBD_SUPPORTS_HIGH_SPEED &&
 	    usbd_caps_speed(&cdc_acm_serial) == USBD_SPEED_HS) {
-		err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_HS);
+		err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_HS);
 		if (err) {
 			return err;
 		}
 	}
 
-	err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_FS);
+	err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_FS);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
Allow to initialize multiple CDC ACM instances.