### PR TITLE
pm: device: refine device driver initialization

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -397,12 +397,14 @@ int pm_device_driver_init(const struct device *dev,
 
 	/* Startup into active mode */
 	rc = action_cb(dev, PM_DEVICE_ACTION_RESUME);
+	if (rc < 0) {
+		return rc;
+	}
 
 	/* Device is now in the ACTIVE state */
 	pm->state = PM_DEVICE_STATE_ACTIVE;
 
-	/* Return the PM_DEVICE_ACTION_RESUME result */
-	return rc;
+	return 0;
 }
 
 int pm_device_driver_deinit(const struct device *dev,


### PR DESCRIPTION
Only set state to ACTIVE after RESUME succeeds, if it fails, keep SUSPENDED STATE and attach an error code.