### PR TITLE
Fix heap hardening CI regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1045,8 +1045,9 @@ target_include_directories(${OFFSETS_LIB} PRIVATE
   ${ARCH_DIR}/${ARCH}/include
   )
 
-# Make sure that LTO will never be enabled when compiling offsets.c
-set_source_files_properties(${OFFSETS_C_PATH} PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+# Make sure that LTO will never be enabled when compiling offsets sources
+set_source_files_properties(${OFFSETS_C_PATH} ${ZEPHYR_BASE}/lib/heap/heap_constants.c
+  PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
 
 target_sources(${OFFSETS_LIB} PRIVATE ${ZEPHYR_BASE}/lib/heap/heap_constants.c)
 

--- a/boards/qemu/leon3/board.cmake
+++ b/boards/qemu/leon3/board.cmake
@@ -8,6 +8,7 @@ set(QEMU_CPU_TYPE_${ARCH} leon3)
 set(QEMU_FLAGS_${ARCH}
   -nographic
   -machine leon3_generic
+  -m 1G
   -icount auto
   )
 board_set_debugger_ifnset(qemu)


### PR DESCRIPTION
Fix two CI regressions introduced by the heap hardening series (PR #103611):

- **cmake: prohibit LTO for heap_constants.c offsets source** — LTO strips
  `GEN_ABSOLUTE_SYM` absolute symbols from `heap_constants.c`, causing
  missing `___z_heap_*_SIZEOF` defines in `offsets.h`. Build failure on
  nRF5340 cpunet and similar LTO-enabled targets.

- **boards: qemu: leon3: pass -m 1G to match DTS SRAM size** — The DTS
  declares 1GB of SRAM but QEMU was invoked without `-m`, defaulting to
  128MB. The heap end marker was written beyond physical RAM, and the new
  MODERATE-level round-trip checks exposed the resulting inconsistency
  across 10 unrelated tests on qemu_leon3.