### PR TITLE
drivers: sensor: lis2dw12: remove unused variable

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -301,7 +301,6 @@ static int lis2dw12_attr_set_act_mode(const struct device *dev,
 					const struct sensor_value *val)
 {
 	const struct lis2dw12_device_config *cfg = dev->config;
-	struct lis2dw12_data *lis2dw12 = dev->data;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lis2dw12_sleep_on_t sleep_val = val->val1 & 0x03U;
 


### PR DESCRIPTION
The function lis2dw12_attr_set_act_mode of the lis2dw12 sensor driver has an unused variable and should be removed to prevent warnings.