### PR TITLE
Adjust SF32LB52 boards CPU frequency

### DIFF
--- a/boards/coredevices/pt2/pt2.dts
+++ b/boards/coredevices/pt2/pt2.dts
@@ -64,7 +64,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <DT_FREQ_M(240)>;
+	clock-frequency = <DT_FREQ_M(144)>;
 };
 
 &dmac {
@@ -123,7 +123,7 @@
 
 	dll1 {
 		status = "okay";
-		clock-frequency = <DT_FREQ_M(240)>;
+		clock-frequency = <DT_FREQ_M(144)>;
 	};
 };
 

--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -65,7 +65,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <DT_FREQ_M(240)>;
+	clock-frequency = <DT_FREQ_M(144)>;
 };
 
 &hxt48 {
@@ -82,7 +82,7 @@
 
 	dll1 {
 		status = "okay";
-		clock-frequency = <DT_FREQ_M(240)>;
+		clock-frequency = <DT_FREQ_M(144)>;
 	};
 };
 


### PR DESCRIPTION
It's not entirely safe to run at 240 MHz without some extra PMUC
configuration or calibration values stored in eFuse.