### PR TITLE
drivers: audio: tlv320dac310x - Volume control via VOL/MICDET pin

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -409,6 +409,15 @@ static void codec_configure_output(const struct device *dev)
 	val |= HEADPHONE_DRV_CM(CM_VOLTAGE_1P65) | HEADPHONE_DRV_RESERVED;
 	codec_write_reg(dev, HEADPHONE_DRV_ADDR, val);
 
+#if DT_INST_PROP(0, use_volume_control_pin)
+	/*
+	 * set mic detect and volume control pin to volume control function.
+	 * See chapter "6.3.10.2 DAC Digital-Volume Control" and chapter
+	 * "6.3.10.3 Volume Control Pin" in the TLV320DAC3100 datasheet.
+	 */
+	codec_write_reg(dev, VOL_MICDET_ADC_CTRL_ADDR, VOL_MICDET_VOL_CTRL_PIN);
+#endif
+
 	/* enable pop removal on power down/up */
 	codec_read_reg(dev, HP_OUT_POP_RM_ADDR, &val);
 	codec_write_reg(dev, HP_OUT_POP_RM_ADDR, val | HP_OUT_POP_RM_ENABLE);

--- a/drivers/audio/tlv320dac310x.h
+++ b/drivers/audio/tlv320dac310x.h
@@ -86,6 +86,9 @@ extern "C" {
 #define BEEP_LEN_MIB_ADDR	(struct reg_addr){0, 74}
 #define BEEP_LEN_LSB_ADDR	(struct reg_addr){0, 75}
 
+#define VOL_MICDET_ADC_CTRL_ADDR (struct reg_addr){0, 116}
+#define VOL_MICDET_VOL_CTRL_PIN  (BIT(7))
+
 /* Page 1 registers */
 #define HEADPHONE_DRV_ADDR	(struct reg_addr){1, 31}
 #define HEADPHONE_DRV_POWERUP	(BIT(7) | BIT(6))

--- a/dts/bindings/audio/ti,tlv320dac.yaml
+++ b/dts/bindings/audio/ti,tlv320dac.yaml
@@ -11,3 +11,10 @@ properties:
   reset-gpios:
     type: phandle-array
     required: true
+
+  use-volume-control-pin:
+    type: boolean
+    description: |
+      Control the volume of the codec using the VOL/MICDET pin. This pin is
+      shared with the microphone detection function, so it will not work if
+      the microphone detection function is enabled.


### PR DESCRIPTION
This PR allows to use the VOL/MICDET pin to control the DAC volume. See chapter 6.3.10.3 Volume Control Pin of the datasheet.