### PR TITLE
drivers: input: chsc6x: add CHSC6540 support

### DIFF
--- a/drivers/input/Kconfig.chsc6x
+++ b/drivers/input/Kconfig.chsc6x
@@ -4,7 +4,7 @@
 config INPUT_CHSC6X
 	bool "Use CHSC6X capacitive touch panel driver"
 	default y
-	depends on DT_HAS_CHIPSEMI_CHSC6X_ENABLED
+	depends on DT_HAS_CHIPSEMI_CHSC6X_ENABLED || DT_HAS_CHIPSEMI_CHSC6540_ENABLED
 	select GPIO
 	select I2C
 	help

--- a/drivers/input/input_chsc6x.c
+++ b/drivers/input/input_chsc6x.c
@@ -1,10 +1,9 @@
 /*
  * Copyright (c) 2024 Nicolas Goualard <nicolas.goualard@sfr.fr>
+ * Copyright (c) 2026 Muhammad Waleed Badar
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define DT_DRV_COMPAT chipsemi_chsc6x
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/input/input.h>
@@ -12,9 +11,15 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 
+LOG_MODULE_REGISTER(chsc6x, CONFIG_INPUT_LOG_LEVEL);
+
+typedef int (*chsc6x_read_data_fn)(const struct i2c_dt_spec *i2c, uint8_t *is_pressed,
+				   uint16_t *x_axis, uint16_t *y_axis);
+
 struct chsc6x_config {
 	struct i2c_dt_spec i2c;
 	const struct gpio_dt_spec int_gpio;
+	chsc6x_read_data_fn read_data;
 };
 
 struct chsc6x_data {
@@ -23,36 +28,73 @@ struct chsc6x_data {
 	struct gpio_callback int_gpio_cb;
 };
 
-#define CHSC6X_READ_ADDR             0
-#define CHSC6X_READ_LENGTH           5
-#define CHSC6X_OUTPUT_POINTS_PRESSED 0
-#define CHSC6X_OUTPUT_COL            2
-#define CHSC6X_OUTPUT_ROW            4
+#define CHSC6X_READ_ADDR 0
+#define CHSC6X_READ_LEN  5
+#define CHSC6X_PRESS_POS 0
+#define CHSC6X_X_POS     2
+#define CHSC6X_Y_POS     4
 
-LOG_MODULE_REGISTER(chsc6x, CONFIG_INPUT_LOG_LEVEL);
+static int __maybe_unused chsc6x_read_data(const struct i2c_dt_spec *i2c, uint8_t *is_pressed,
+					   uint16_t *x_axis, uint16_t *y_axis)
+{
+	uint8_t output[CHSC6X_READ_LEN];
+	int ret;
+
+	ret = i2c_burst_read_dt(i2c, CHSC6X_READ_ADDR, output, CHSC6X_READ_LEN);
+	if (ret < 0) {
+		return -ENODATA;
+	}
+
+	*is_pressed = output[CHSC6X_PRESS_POS];
+	*x_axis = output[CHSC6X_X_POS];
+	*y_axis = output[CHSC6X_Y_POS];
+
+	return 0;
+}
+
+#define CHSC6540_READ_ADDR 0
+#define CHSC6540_READ_LEN  7
+#define CHSC6540_PRESS_POS 2
+#define CHSC6540_X_POS     3
+#define CHSC6540_Y_POS     5
+
+static int __maybe_unused chsc6540_read_data(const struct i2c_dt_spec *i2c, uint8_t *is_pressed,
+					     uint16_t *x_axis, uint16_t *y_axis)
+{
+	uint8_t output[CHSC6540_READ_LEN];
+	int ret;
+
+	ret = i2c_burst_read_dt(i2c, CHSC6540_READ_ADDR, output, CHSC6540_READ_LEN);
+	if (ret < 0) {
+		return -ENODATA;
+	}
+
+	*is_pressed = output[CHSC6540_PRESS_POS];
+	*x_axis = sys_get_be16(&output[CHSC6540_X_POS]) & 0x0FFF;
+	*y_axis = sys_get_be16(&output[CHSC6540_Y_POS]) & 0x0FFF;
+
+	return 0;
+}
 
 static int chsc6x_process(const struct device *dev)
 {
-	uint8_t output[CHSC6X_READ_LENGTH];
-	uint8_t row, col;
-	bool is_pressed;
+	uint16_t y_axis, x_axis;
+	uint8_t is_pressed;
 	int ret;
 
 	const struct chsc6x_config *cfg = dev->config;
 
-	ret = i2c_burst_read_dt(&cfg->i2c, CHSC6X_READ_ADDR, output, CHSC6X_READ_LENGTH);
+	ret = cfg->read_data(&cfg->i2c, &is_pressed, &x_axis, &y_axis);
 	if (ret < 0) {
-		LOG_ERR("Could not read data: %i", ret);
-		return -ENODATA;
+		LOG_ERR("Could not read data: %d", ret);
+		return ret;
 	}
 
-	is_pressed = output[CHSC6X_OUTPUT_POINTS_PRESSED];
-	col = output[CHSC6X_OUTPUT_COL];
-	row = output[CHSC6X_OUTPUT_ROW];
+	LOG_DBG("is_pressed=%u, x_axis=%u, y_axis=%u", is_pressed, x_axis, y_axis);
 
 	if (is_pressed) {
-		input_report_abs(dev, INPUT_ABS_X, col, false, K_FOREVER);
-		input_report_abs(dev, INPUT_ABS_Y, row, false, K_FOREVER);
+		input_report_abs(dev, INPUT_ABS_X, x_axis, false, K_FOREVER);
+		input_report_abs(dev, INPUT_ABS_Y, y_axis, false, K_FOREVER);
 		input_report_key(dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 	} else {
 		input_report_key(dev, INPUT_BTN_TOUCH, 0, true, K_FOREVER);
@@ -126,14 +168,21 @@ static int chsc6x_init(const struct device *dev)
 	return chsc6x_chip_init(dev);
 };
 
-#define CHSC6X_DEFINE(index)                                                                       \
-	static const struct chsc6x_config chsc6x_config_##index = {                                \
-		.i2c = I2C_DT_SPEC_INST_GET(index),                                                \
-		.int_gpio = GPIO_DT_SPEC_INST_GET(index, irq_gpios),                               \
+#define CHSC6_DEFINE(node_id, _read_data)                                                          \
+	static const struct chsc6x_config chsc6x_config_##node_id = {                              \
+		.i2c = I2C_DT_SPEC_GET(node_id),                                                   \
+		.int_gpio = GPIO_DT_SPEC_GET(node_id, irq_gpios),                                  \
+		.read_data = _read_data,                                                           \
 	};                                                                                         \
-	static struct chsc6x_data chsc6x_data_##index;                                             \
-	DEVICE_DT_INST_DEFINE(index, chsc6x_init, NULL, &chsc6x_data_##index,                      \
-			      &chsc6x_config_##index, POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY,     \
-			      NULL);
+	static struct chsc6x_data chsc6x_data_##node_id;                                           \
+	DEVICE_DT_DEFINE(node_id, chsc6x_init, NULL, &chsc6x_data_##node_id,                       \
+			 &chsc6x_config_##node_id, POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
 
-DT_INST_FOREACH_STATUS_OKAY(CHSC6X_DEFINE)
+#define CHSC6X_DEFINE(node_id) \
+	CHSC6_DEFINE(node_id, chsc6x_read_data)
+
+#define CHSC6540_DEFINE(node_id) \
+	CHSC6_DEFINE(node_id, chsc6540_read_data)
+
+DT_FOREACH_STATUS_OKAY(chipsemi_chsc6x, CHSC6X_DEFINE)
+DT_FOREACH_STATUS_OKAY(chipsemi_chsc6540, CHSC6540_DEFINE)

--- a/dts/bindings/input/chipsemi,chsc6540.yaml
+++ b/dts/bindings/input/chipsemi,chsc6540.yaml
@@ -1,0 +1,5 @@
+description: CHSC6540 touch controller
+
+compatible: "chipsemi,chsc6540"
+
+include: chipsemi,chsc6x-common.yaml

--- a/dts/bindings/input/chipsemi,chsc6x-common.yaml
+++ b/dts/bindings/input/chipsemi,chsc6x-common.yaml
@@ -1,0 +1,11 @@
+description: CHSC6X touchscreen sensor
+
+include: i2c-device.yaml
+
+properties:
+  irq-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      Interrupt GPIO. Used by the controller to signal touch data is
+      available. Active low.

--- a/dts/bindings/input/chipsemi,chsc6x.yaml
+++ b/dts/bindings/input/chipsemi,chsc6x.yaml
@@ -2,12 +2,4 @@ description: CHSC6X touchscreen sensor
 
 compatible: "chipsemi,chsc6x"
 
-include: i2c-device.yaml
-
-properties:
-  irq-gpios:
-    type: phandle-array
-    required: true
-    description: |
-      Interrupt GPIO. Used by the controller to signal touch data is
-      available. Active low.
+include: chipsemi,chsc6x-common.yaml


### PR DESCRIPTION
- Introduce a function pointer (read_data) in driver config to abstract controller-specific data parsing.
- Implement chsc6x_read_data() and chsc6540_read_data() with variant-specific register layouts.
- Switch to DT_FOREACH_STATUS_OKAY() for per-compatible device instantiation.
- Replace instance-based macros with node-based DEVICE_DT_DEFINE().

This change allows the driver to support both chipsemi,chsc6x and chipsemi,chsc6540 via devicetree without duplicating core logic.