### PR TITLE
boards: st: make MEMC enabling explicit to LTDC instead of DISPLAY

### DIFF
--- a/boards/st/stm32f429i_disc1/Kconfig.defconfig
+++ b/boards/st/stm32f429i_disc1/Kconfig.defconfig
@@ -6,6 +6,6 @@
 if BOARD_STM32F429I_DISC1
 
 config MEMC
-	default y if DISPLAY
+	default y if STM32_LTDC
 
 endif # BOARD_STM32F429I_DISC1

--- a/boards/st/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/st/stm32f746g_disco/Kconfig.defconfig
@@ -8,13 +8,9 @@ if BOARD_STM32F746G_DISCO
 configdefault NET_L2_ETHERNET
 	default y
 
-if DISPLAY
-
 # MEMC needs to be enabled in order to store
-# display buffer to external SDRAM connected to FMC
+# LTDC framebuffer to external SDRAM connected to FMC
 config MEMC
-	default y
-
-endif # DISPLAY
+	default y if STM32_LTDC
 
 endif # BOARD_STM32F746G_DISCO

--- a/boards/st/stm32f7508_dk/Kconfig.defconfig
+++ b/boards/st/stm32f7508_dk/Kconfig.defconfig
@@ -8,13 +8,9 @@ if BOARD_STM32F7508_DK
 configdefault NET_L2_ETHERNET
 	default y
 
-if DISPLAY
-
 # MEMC needs to be enabled in order to store
-# display buffer to external SDRAM connected to FMC
+# LTDC framebuffer to external SDRAM connected to FMC
 config MEMC
-	default y
-
-endif # DISPLAY
+	default y if STM32_LTDC
 
 endif # BOARD_STM32F7508_DK

--- a/boards/st/stm32h573i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h573i_dk/Kconfig.defconfig
@@ -23,7 +23,7 @@ endchoice
 config REGULATOR
 	default y
 
-config I2C_STM32_V2_TIMING
+configdefault I2C_STM32_V2_TIMING
 	default y if INPUT
 
 endif # DISPLAY

--- a/boards/st/stm32h745i_disco/Kconfig.defconfig
+++ b/boards/st/stm32h745i_disco/Kconfig.defconfig
@@ -10,7 +10,7 @@ configdefault NET_L2_ETHERNET
 	default y
 
 config MEMC
-	default y if DISPLAY
+	default y if STM32_LTDC
 
 
 endif # BOARD_STM32H745I_DISCO

--- a/boards/st/stm32h750b_dk/Kconfig.defconfig
+++ b/boards/st/stm32h750b_dk/Kconfig.defconfig
@@ -5,13 +5,9 @@
 
 if BOARD_STM32H750B_DK
 
-if DISPLAY
-
 # MEMC needs to be enabled in order to store
-# display buffer to external SDRAM connected to FMC
+# LTDC framebuffer to external SDRAM connected to FMC
 config MEMC
-	default y
-
-endif # DISPLAY
+	default y if STM32_LTDC
 
 endif # BOARD_STM32H750B_DK

--- a/boards/st/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7b3i_dk/Kconfig.defconfig
@@ -7,9 +7,9 @@
 if BOARD_STM32H7B3I_DK
 
 # MEMC needs to be enabled in order to store
-# display buffer to external SDRAM connected to FMC
+# LTDC framebuffer to external SDRAM connected to FMC
 config MEMC
-	default y if DISPLAY
+	default y if STM32_LTDC
 
 if LVGL
 

--- a/boards/st/stm32h7s78_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7s78_dk/Kconfig.defconfig
@@ -10,11 +10,10 @@ if BOARD_STM32H7S78_DK
 configdefault NET_L2_ETHERNET
 	default y
 
-if DISPLAY || VIDEO
 # MEMC needs to be enabled in order to store
-# display frame buffer and video buffer pool to external PSRAM
+# LTDC frame buffer and video buffer pool to external PSRAM
 config MEMC
-	default y
+	default y if STM32_LTDC || VIDEO
 
 if VIDEO
 # Place video buffer pool into the PSRAM
@@ -24,7 +23,6 @@ config VIDEO_BUFFER_POOL_ZEPHYR_REGION
 config VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME
 	default "PSRAM"
 endif # VIDEO
-endif # DISPLAY || VIDEO
 
 if INPUT
 

--- a/boards/st/stm32n6570_dk/Kconfig.defconfig
+++ b/boards/st/stm32n6570_dk/Kconfig.defconfig
@@ -11,12 +11,10 @@ configdefault NET_L2_ETHERNET
 configdefault OTP
 	default y if ETH_STM32_HAL && NVMEM
 
-if DISPLAY || VIDEO
 # MEMC needs to be enabled in order to store
-# display frame buffer and video buffer pool to external PSRAM
+# LTDC frame buffer and video buffer pool to external PSRAM
 config MEMC
-	default y
-endif # DISPLAY || VIDEO
+	default y if STM32_LTDC || VIDEO
 
 if DISPLAY
 config I2C_STM32_V2_TIMING

--- a/boards/st/stm32n6570_dk/Kconfig.defconfig
+++ b/boards/st/stm32n6570_dk/Kconfig.defconfig
@@ -17,7 +17,7 @@ config MEMC
 	default y if STM32_LTDC || VIDEO
 
 if DISPLAY
-config I2C_STM32_V2_TIMING
+configdefault I2C_STM32_V2_TIMING
 	default y if INPUT
 endif # DISPLAY
 


### PR DESCRIPTION
In several ST boards, MEMC is currently enabled depending on DISPLAY. While this is correct based on the default dts file, the real dependency is LTDC which defines within the dts file its framebuffer into a memory accessible via the MEMC hence make this dependency explicit by indicating STM32_LTDC instead of DISPLAY.