### PR TITLE
Zephyr SDK 1.0.0-rc1 build fixes

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -507,7 +507,7 @@ static void irqstr_l1_irq_enable_disable(uint32_t irq,
 					 struct irqsteer_dispatcher *disp,
 					 bool enable)
 {
-	const struct irqsteer_config *cfg;
+	const struct irqsteer_config *cfg = NULL;
 
 	if (disp) {
 		cfg = disp->dev->config;

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -552,12 +552,12 @@ do {                                                                    \
  */
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
-	__asm__(".globl\t" #name "\n\t.equ\t" #name \
+	__asm__ __volatile__(".globl\t" #name "\n\t.equ\t" #name \
 		",%B0"                              \
 		"\n\t.type\t" #name ",%%object" :  : "n"(~(value)))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
+	__asm__ __volatile__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",%object")
 
@@ -566,12 +566,12 @@ do {                                                                    \
 	|| defined(CONFIG_X86)
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
-	__asm__(".globl\t" #name "\n\t.equ\t" #name \
+	__asm__ __volatile__(".globl\t" #name "\n\t.equ\t" #name \
 		",%c0"                              \
 		"\n\t.type\t" #name ",@object" :  : "n"(value))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
+	__asm__ __volatile__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",@object")
 
@@ -579,34 +579,34 @@ do {                                                                    \
 
 /* No special prefixes necessary for constants in this arch AFAICT */
 #define GEN_ABSOLUTE_SYM(name, value)		\
-	__asm__(".globl\t" #name "\n\t.equ\t" #name \
+	__asm__ __volatile__(".globl\t" #name "\n\t.equ\t" #name \
 		",%0"                              \
 		"\n\t.type\t" #name ",%%object" :  : "n"(value))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
+	__asm__ __volatile__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",%object")
 
 #elif defined(CONFIG_SPARC)
 #define GEN_ABSOLUTE_SYM(name, value)			\
-	__asm__(".global\t" #name "\n\t.equ\t" #name	\
+	__asm__ __volatile__(".global\t" #name "\n\t.equ\t" #name	\
 		",%0"					\
 		"\n\t.type\t" #name ",#object" : : "n"(value))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
+	__asm__ __volatile__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",#object")
 
 #elif defined(CONFIG_RX)
 #define GEN_ABSOLUTE_SYM(name, value)                \
-	__asm__(".global\t" #name "\n\t.equ\t" #name \
+	__asm__ __volatile__(".global\t" #name "\n\t.equ\t" #name \
 		",%c0"                               \
 		"\n\t.type\t" #name ",%%object" :  : "n"(value))
 
 #define GEN_ABSOLUTE_SYM_KCONFIG(name, value)        \
-	__asm__(".global\t" #name                    \
+	__asm__ __volatile__(".global\t" #name                    \
 		"\n\t.equ\t" #name "," #value        \
 		"\n\t.type\t" #name ",#object")
 

--- a/west.yml
+++ b/west.yml
@@ -381,7 +381,7 @@ manifest:
         - testing
         - tee
     - name: trusted-firmware-a
-      revision: 0a29cac8fe0f7bdb835b469d9ea11b8e17377a92
+      revision: 44bcc378b6ec4af8693d008f43983e488f1f5740
       path: modules/tee/tf-a/trusted-firmware-a
       groups:
         - tee


### PR DESCRIPTION
I'm cleaning up various build problems with SDK 1.0.0 that have crept into the tree. Here are three fixes:

 1. drivers/serial/uart_max32.c -- I don't think this is toolchain related, but it was pretty simple.
 2. Without `__volatile__`, the compiler occasionally elides asm statements that have unused output parameters. I don't think that's true for these, but it's safest to always use `__volatile__`.
 3. trusted-firmware-a needs a temporary fix when building with picolibc-enabled gcc. No need to upstream this one; there's already a different fix present there due to some LTO changes.