### PR TITLE
drivers: clock_control: bflb: Support for flash clock settings for BL60x and BL70x

### DIFF
--- a/drivers/clock_control/clock_control_bl60x.c
+++ b/drivers/clock_control/clock_control_bl60x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ * Copyright (c) 2025-2026 MASSDRIVER EI (massdriver.space)
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(clock_control_bl60x, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 #include <bouffalolab/bl60x/pds_reg.h>
 #include <bouffalolab/bl60x/l1c_reg.h>
 #include <bouffalolab/bl60x/extra_defines.h>
+#include <bouffalolab/bl60x/sf_ctrl_reg.h>
 #include <zephyr/drivers/clock_control/clock_control_bflb_common.h>
 
 #define CLK_SRC_IS(clk, src)                                                                       \
@@ -41,6 +42,8 @@ LOG_MODULE_REGISTER(clock_control_bl60x, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 #define CRYSTAL_ID_FREQ_26000000 4
 
 #define CRYSTAL_FREQ_TO_ID(freq) CONCAT(CRYSTAL_ID_FREQ_, freq)
+
+#define PLL_OVERCLOCK_MASK	0x10
 
 enum bl60x_clkid {
 	bl60x_clkid_clk_root = BL60X_CLKID_CLK_ROOT,
@@ -69,12 +72,21 @@ struct clock_control_bl60x_config {
 	uint32_t crystal_id;
 };
 
+struct clock_control_bl60x_flashclk_config {
+	enum bl60x_clkid	source;
+	uint8_t			divider;
+	uint8_t			read_delay;
+	bool			clock_invert;
+	bool			rx_clock_invert;
+};
+
 struct clock_control_bl60x_data {
 	bool crystal_enabled;
 	bool pll_enabled;
-	struct clock_control_bl60x_pll_config pll;
-	struct clock_control_bl60x_root_config root;
-	struct clock_control_bl60x_bclk_config bclk;
+	struct clock_control_bl60x_pll_config		pll;
+	struct clock_control_bl60x_root_config		root;
+	struct clock_control_bl60x_bclk_config		bclk;
+	struct clock_control_bl60x_flashclk_config	flashclk;
 };
 
 const static uint32_t clock_control_bl60x_crystal_SDMIN_table[5] = {
@@ -88,6 +100,19 @@ const static uint32_t clock_control_bl60x_crystal_SDMIN_table[5] = {
 	0x300000,
 	/* 26M */
 	0x49D39D,
+};
+
+const static uint32_t clock_control_bl60x_crystal_SDMIN_table_240M[5] = {
+	/* 32M */
+	0x4B0000,
+	/* 24M */
+	0x640000,
+	/* 38.4M */
+	0x3E8000,
+	/* 40M */
+	0x3C0000,
+	/* 26M */
+	0x5C4884,
 };
 
 static int clock_control_bl60x_deinit_crystal(void)
@@ -245,10 +270,13 @@ static void clock_control_bl60x_set_pll_source(uint32_t source)
 	sys_write32(tmp, PDS_BASE + PDS_CLKPLL_TOP_CTRL_OFFSET);
 }
 
-static void clock_control_bl60x_init_pll(enum bl60x_clkid source, uint32_t crystal_id)
+static void clock_control_bl60x_init_pll(enum bl60x_clkid source, uint32_t crystal_id,
+					 bool overclock)
 {
 	uint32_t tmp;
 	uint32_t old_rootclk;
+	const uint32_t *sdmin_table = overclock ? clock_control_bl60x_crystal_SDMIN_table_240M
+						: clock_control_bl60x_crystal_SDMIN_table;
 
 	old_rootclk = clock_bflb_get_root_clock();
 
@@ -304,11 +332,11 @@ static void clock_control_bl60x_init_pll(enum bl60x_clkid source, uint32_t cryst
 	tmp = sys_read32(PDS_BASE + PDS_CLKPLL_SDM_OFFSET);
 	if (source == BL60X_CLKID_CLK_CRYSTAL) {
 		tmp = (tmp & PDS_CLKPLL_SDMIN_UMSK) |
-		      (clock_control_bl60x_crystal_SDMIN_table[crystal_id]
+		      (sdmin_table[crystal_id]
 		       << PDS_CLKPLL_SDMIN_POS);
 	} else {
 		tmp = (tmp & PDS_CLKPLL_SDMIN_UMSK) |
-		      (clock_control_bl60x_crystal_SDMIN_table[CRYSTAL_ID_FREQ_32000000]
+		      (sdmin_table[CRYSTAL_ID_FREQ_32000000]
 		       << PDS_CLKPLL_SDMIN_POS);
 	}
 	sys_write32(tmp, PDS_BASE + PDS_CLKPLL_SDM_OFFSET);
@@ -430,6 +458,7 @@ static uint32_t clock_control_bl60x_get_xclk(const struct device *dev)
 
 static uint32_t clock_control_bl60x_get_clk(const struct device *dev)
 {
+	struct clock_control_bl60x_data *data = dev->data;
 	uint32_t tmp;
 	uint32_t hclk_div;
 
@@ -446,14 +475,28 @@ static uint32_t clock_control_bl60x_get_clk(const struct device *dev)
 	}
 	tmp = sys_read32(GLB_BASE + GLB_CLK_CFG0_OFFSET);
 	tmp = (tmp & GLB_REG_PLL_SEL_MSK) >> GLB_REG_PLL_SEL_POS;
-	if (tmp == 3) {
-		return MHZ(192) / (hclk_div + 1);
-	} else if (tmp == 2) {
-		return MHZ(160) / (hclk_div + 1);
-	} else if (tmp == 1) {
-		return MHZ(120) / (hclk_div + 1);
-	} else if (tmp == 0) {
-		return MHZ(48) / (hclk_div + 1);
+
+	if (data->pll.overclock) {
+		if (tmp == 3) {
+			return MHZ(240) / (hclk_div + 1);
+		} else if (tmp == 2) {
+			return MHZ(200) / (hclk_div + 1);
+		} else if (tmp == 1) {
+			return MHZ(150) / (hclk_div + 1);
+		} else if (tmp == 0) {
+			return MHZ(60) / (hclk_div + 1);
+		}
+
+	} else {
+		if (tmp == 3) {
+			return MHZ(192) / (hclk_div + 1);
+		} else if (tmp == 2) {
+			return MHZ(160) / (hclk_div + 1);
+		} else if (tmp == 1) {
+			return MHZ(120) / (hclk_div + 1);
+		} else if (tmp == 0) {
+			return MHZ(48) / (hclk_div + 1);
+		}
 	}
 	return 0;
 }
@@ -508,7 +551,7 @@ static void clock_control_bl60x_init_root_as_pll(const struct device *dev)
 	const struct clock_control_bl60x_config *config = dev->config;
 	uint32_t tmp;
 
-	clock_control_bl60x_init_pll(data->pll.source, config->crystal_id);
+	clock_control_bl60x_init_pll(data->pll.source, config->crystal_id, data->pll.overclock);
 
 	/* enable all 'PDS' clocks */
 	tmp = sys_read32(PDS_BASE + PDS_CLKPLL_OUTPUT_EN_OFFSET);
@@ -540,6 +583,56 @@ static void clock_control_bl60x_init_root_as_crystal(const struct device *dev)
 {
 	clock_bflb_set_root_clock(BFLB_MAIN_CLOCK_XTAL);
 	sys_write32(clock_control_bl60x_get_clk(dev), CORECLOCKREGISTER);
+}
+
+static __ramfunc void clock_control_bl60x_update_flash_clk(const struct device *dev)
+{
+	struct clock_control_bl60x_data *data = dev->data;
+	uint32_t tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp &= GLB_SF_CLK_DIV_UMSK;
+	tmp &= GLB_SF_CLK_EN_UMSK;
+	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(SF_CTRL_BASE + SF_CTRL_0_OFFSET);
+	tmp |= SF_CTRL_SF_IF_READ_DLY_EN_MSK;
+	tmp &= ~SF_CTRL_SF_IF_READ_DLY_N_MSK;
+	tmp |= (data->flashclk.read_delay << SF_CTRL_SF_IF_READ_DLY_N_POS);
+	if (data->flashclk.clock_invert) {
+		tmp &= ~SF_CTRL_SF_CLK_OUT_INV_SEL_MSK;
+	} else {
+		tmp |= SF_CTRL_SF_CLK_OUT_INV_SEL_MSK;
+	}
+	if (data->flashclk.rx_clock_invert) {
+		tmp |= SF_CTRL_SF_CLK_SF_RX_INV_SEL_MSK;
+	} else {
+		tmp &= ~SF_CTRL_SF_CLK_SF_RX_INV_SEL_MSK;
+	}
+	*(uint32_t *)(SF_CTRL_BASE + SF_CTRL_0_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp &= GLB_SF_CLK_SEL_UMSK;
+	tmp &= GLB_SF_CLK_SEL2_UMSK;
+	if (data->flashclk.source == bl60x_clkid_clk_pll) {
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+	} else if (data->flashclk.source == bl60x_clkid_clk_crystal) {
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
+	} else {
+		/* If using RC32M or BCLK, use BCLK */
+		tmp |= 2U << GLB_SF_CLK_SEL_POS;
+	}
+
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp |= GLB_SF_CLK_EN_MSK;
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	clock_bflb_settle();
 }
 
 static int clock_control_bl60x_update_root(const struct device *dev)
@@ -820,6 +913,8 @@ static int clock_control_bl60x_init(const struct device *dev)
 
 	clock_bflb_settle();
 
+	clock_control_bl60x_update_flash_clk(dev);
+
 	irq_unlock(key);
 
 	return 0;
@@ -843,27 +938,49 @@ static struct clock_control_bl60x_data clock_control_bl60x_data = {
 
 	.root = {
 #if CLK_SRC_IS(root, pll_192)
-			.source = bl60x_clkid_clk_pll,
-			.pll_select = DT_CLOCKS_CELL(DT_INST_CLOCKS_CTLR_BY_NAME(0, root), select),
+		.source = bl60x_clkid_clk_pll,
+		.pll_select = DT_CLOCKS_CELL(DT_INST_CLOCKS_CTLR_BY_NAME(0, root), select) & 0xF,
 #elif CLK_SRC_IS(root, crystal)
-			.source = bl60x_clkid_clk_crystal,
+		.source = bl60x_clkid_clk_crystal,
 #else
-			.source = bl60x_clkid_clk_rc32m,
+		.source = bl60x_clkid_clk_rc32m,
 #endif
-			.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, root), divider),
-		},
+		.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, root), divider),
+	},
 
 	.pll = {
 #if CLK_SRC_IS(pll_192, crystal)
-			.source = bl60x_clkid_clk_crystal,
+		.source = bl60x_clkid_clk_crystal,
 #else
-			.source = bl60x_clkid_clk_rc32m,
+		.source = bl60x_clkid_clk_rc32m,
 #endif
-		},
+#if CLK_SRC_IS(root, pll_192)
+		.overclock = DT_CLOCKS_CELL(DT_INST_CLOCKS_CTLR_BY_NAME(0, root), select)
+			     & PLL_OVERCLOCK_MASK ? true : false,
+#else
+		.overclock = false,
+#endif
+	},
 
 	.bclk = {
-			.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, bclk), divider),
-		},
+		.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, bclk), divider),
+	},
+
+	.flashclk = {
+#if CLK_SRC_IS(flash, crystal)
+		.source = bl60x_clkid_clk_crystal,
+#elif CLK_SRC_IS(flash, bclk)
+		.source = bl60x_clkid_clk_bclk,
+#elif CLK_SRC_IS(flash, pll_192)
+		.source = bl60x_clkid_clk_pll,
+#else
+		.source = bl60x_clkid_clk_rc32m,
+#endif
+		.read_delay = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), read_delay),
+		.clock_invert = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), clock_invert),
+		.rx_clock_invert = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), rx_clock_invert),
+		.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), divider),
+	},
 };
 
 BUILD_ASSERT(CLK_SRC_IS(pll_192, crystal) || CLK_SRC_IS(root, crystal)

--- a/drivers/clock_control/clock_control_bl70x.c
+++ b/drivers/clock_control/clock_control_bl70x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ * Copyright (c) 2025-2026 MASSDRIVER EI (massdriver.space)
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(clock_control_bl70x, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 #include <bouffalolab/bl70x/pds_reg.h>
 #include <bouffalolab/bl70x/l1c_reg.h>
 #include <bouffalolab/bl70x/extra_defines.h>
+#include <bouffalolab/bl60x/sf_ctrl_reg.h>
 #include <zephyr/drivers/clock_control/clock_control_bflb_common.h>
 
 #define CLK_SRC_IS(clk, src)                                                                       \
@@ -57,12 +58,21 @@ struct clock_control_bl70x_bclk_config {
 	uint8_t divider;
 };
 
+struct clock_control_bl70x_flashclk_config {
+	enum bl70x_clkid	source;
+	uint8_t			divider;
+	uint8_t			read_delay;
+	bool			clock_invert;
+	bool			rx_clock_invert;
+};
+
 struct clock_control_bl70x_data {
 	bool crystal_enabled;
 	bool dll_enabled;
-	struct clock_control_bl70x_dll_config dll;
-	struct clock_control_bl70x_root_config root;
-	struct clock_control_bl70x_bclk_config bclk;
+	struct clock_control_bl70x_dll_config		dll;
+	struct clock_control_bl70x_root_config		root;
+	struct clock_control_bl70x_bclk_config		bclk;
+	struct clock_control_bl70x_flashclk_config	flashclk;
 };
 
 static int clock_control_bl70x_deinit_crystal(void)
@@ -424,6 +434,56 @@ static void clock_control_bl70x_init_root_as_crystal(const struct device *dev)
 	sys_write32(clock_control_bl70x_get_clk(dev), CORECLOCKREGISTER);
 }
 
+static __ramfunc void clock_control_bl70x_update_flash_clk(const struct device *dev)
+{
+	struct clock_control_bl70x_data *data = dev->data;
+	uint32_t tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp &= GLB_SF_CLK_DIV_UMSK;
+	tmp &= GLB_SF_CLK_EN_UMSK;
+	tmp |= (data->flashclk.divider - 1) << GLB_SF_CLK_DIV_POS;
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(SF_CTRL_BASE + SF_CTRL_0_OFFSET);
+	tmp |= SF_CTRL_SF_IF_READ_DLY_EN_MSK;
+	tmp &= ~SF_CTRL_SF_IF_READ_DLY_N_MSK;
+	tmp |= (data->flashclk.read_delay << SF_CTRL_SF_IF_READ_DLY_N_POS);
+	if (data->flashclk.clock_invert) {
+		tmp &= ~SF_CTRL_SF_CLK_OUT_INV_SEL_MSK;
+	} else {
+		tmp |= SF_CTRL_SF_CLK_OUT_INV_SEL_MSK;
+	}
+	if (data->flashclk.rx_clock_invert) {
+		tmp |= SF_CTRL_SF_CLK_SF_RX_INV_SEL_MSK;
+	} else {
+		tmp &= ~SF_CTRL_SF_CLK_SF_RX_INV_SEL_MSK;
+	}
+	*(uint32_t *)(SF_CTRL_BASE + SF_CTRL_0_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp &= GLB_SF_CLK_SEL_UMSK;
+	tmp &= GLB_SF_CLK_SEL2_UMSK;
+	if (data->flashclk.source == bl70x_clkid_clk_dll) {
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+	} else if (data->flashclk.source == bl70x_clkid_clk_crystal) {
+		tmp |= 0U << GLB_SF_CLK_SEL_POS;
+		tmp |= 1U << GLB_SF_CLK_SEL2_POS;
+	} else {
+		/* If using RC32M or BCLK, use BCLK */
+		tmp |= 2U << GLB_SF_CLK_SEL_POS;
+	}
+
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	tmp = *(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET);
+	tmp |= GLB_SF_CLK_EN_MSK;
+	*(uint32_t *)(GLB_BASE + GLB_CLK_CFG2_OFFSET) = tmp;
+
+	clock_bflb_settle();
+}
+
 static int clock_control_bl70x_update_root(const struct device *dev)
 {
 	struct clock_control_bl70x_data *data = dev->data;
@@ -700,6 +760,8 @@ static int clock_control_bl70x_init(const struct device *dev)
 
 	clock_bflb_settle();
 
+	clock_control_bl70x_update_flash_clk(dev);
+
 	irq_unlock(key);
 
 	return 0;
@@ -739,6 +801,22 @@ static struct clock_control_bl70x_data clock_control_bl70x_data = {
 	.bclk = {
 			.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, bclk), divider),
 		},
+
+	.flashclk = {
+#if CLK_SRC_IS(flash, crystal)
+		.source = bl70x_clkid_clk_crystal,
+#elif CLK_SRC_IS(flash, bclk)
+		.source = bl70x_clkid_clk_bclk,
+#elif CLK_SRC_IS(flash, dll_144)
+		.source = bl70x_clkid_clk_dll,
+#else
+		.source = bl70x_clkid_clk_rc32m,
+#endif
+		.read_delay = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), read_delay),
+		.clock_invert = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), clock_invert),
+		.rx_clock_invert = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), rx_clock_invert),
+		.divider = DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(0, flash), divider),
+	},
 };
 
 BUILD_ASSERT(CLK_SRC_IS(dll_144, crystal) || CLK_SRC_IS(root, crystal)

--- a/dts/bindings/clock/bflb,flash-clk.yaml
+++ b/dts/bindings/clock/bflb,flash-clk.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  The BL61x Flash Clock
+  BFLB Flash Clock
   Source -> divider -> CLK
-  Only has settings for Bank 1 (boot flash) at the moment.
+  Only has settings for Bank 1 on BL61x (boot flash) at the moment.
 
-compatible: "bflb,bl61x-flash-clk"
+compatible: "bflb,flash-clk"
 
 include: [base.yaml, clock-controller.yaml]
 
@@ -15,7 +15,8 @@ properties:
     type: phandle-array
     required: true
     description: Source clocks.
-      Using WIFIPLL results in WIFIPLL x 0.375 (120M).
+      Using PLL as source results in using the 120M output on BL61x and BL60x,
+      and 144M output on BL70x
       When using RC32M main clock, use BCLK.
 
   divider:

--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -54,7 +54,15 @@
 		clk_bclk: clk-bclk {
 			#clock-cells = <0>;
 			compatible = "bflb,bclk";
-			divider = <4>;
+			divider = <2>;
+			status = "okay";
+		};
+
+		clk_flash: clk-flash {
+			#clock-cells = <0>;
+			compatible = "bflb,flash-clk";
+			clocks = <&clk_bclk>;
+			divider = <2>;
 			status = "okay";
 		};
 	};
@@ -141,10 +149,16 @@
 			status = "okay";
 			clocks = <&clk_rc32m>, <&clk_crystal>, <&clk_root>, <&clk_bclk>,
 				 <&clk_pll BL60X_PLL_192MHz>, <&clk_pll BL60X_PLL_160MHz>,
-				 <&clk_pll BL60X_PLL_120MHz>, <&clk_pll BL60X_PLL_48MHz>;
+				 <&clk_pll BL60X_PLL_120MHz>, <&clk_pll BL60X_PLL_48MHz>,
+				 <&clk_pll BL60X_PLL_OC_240MHz>, <&clk_pll BL60X_PLL_OC_200MHz>,
+				 <&clk_pll BL60X_PLL_OC_150MHz>, <&clk_pll BL60X_PLL_OC_60MHz>,
+				 <&clk_flash>;
 			clock-names = "rc32m", "crystal", "root", "bclk",
 				      "pll_192", "pll_160",
-				      "pll_120", "pll_48";
+				      "pll_120", "pll_48",
+				      "pll_oc_240", "pll_oc_200",
+				      "pll_oc_150", "pll_oc_60",
+				      "flash";
 		};
 
 		adc0: adc@40002000 {

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -66,7 +66,7 @@
 
 		clk_flash: clk-flash {
 			#clock-cells = <0>;
-			compatible = "bflb,bl61x-flash-clk";
+			compatible = "bflb,flash-clk";
 			clocks = <&clk_bclk>;
 			divider = <2>;
 			status = "okay";

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -56,6 +56,14 @@
 			divider = <2>;
 			status = "okay";
 		};
+
+		clk_flash: clk-flash {
+			#clock-cells = <0>;
+			compatible = "bflb,flash-clk";
+			clocks = <&clk_bclk>;
+			divider = <2>;
+			status = "okay";
+		};
 	};
 
 	chosen {
@@ -146,10 +154,12 @@
 			status = "okay";
 			clocks = <&clk_rc32m>, <&clk_crystal>, <&clk_root>, <&clk_bclk>,
 				 <&clk_pll BL70X_DLL_144MHz>, <&clk_pll BL70X_DLL_96MHz>,
-				 <&clk_pll BL70X_DLL_120MHz>, <&clk_pll BL70X_DLL_57MHz>;
+				 <&clk_pll BL70X_DLL_120MHz>, <&clk_pll BL70X_DLL_57MHz>,
+				 <&clk_flash>;
 			clock-names = "rc32m", "crystal", "root", "bclk",
 				      "dll_144", "dll_96",
-				      "dll_120", "dll_57";
+				      "dll_120", "dll_57",
+				      "flash";
 		};
 
 		adc0: adc@40002000 {

--- a/include/zephyr/dt-bindings/clock/bflb_bl60x_clock.h
+++ b/include/zephyr/dt-bindings/clock/bflb_bl60x_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ * Copyright (c) 2025-2026 MASSDRIVER EI (massdriver.space)
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,9 +15,28 @@
 #define BL60X_CLKID_CLK_BCLK    BFLB_CLKID_CLK_BCLK
 #define BL60X_CLKID_CLK_PLL     4
 
+/** The root frequency of the PLL is 480MHz */
+
+/** ID 0, 48MHz = 480 / 10 */
 #define BL60X_PLL_48MHz		0
+/** ID 1, 120MHz = 480 / 4 */
 #define BL60X_PLL_120MHz	1
+/** ID 2, 160MHz = 480 / 3 */
 #define BL60X_PLL_160MHz	2
+/** ID 3, 192MHz = 480 / 2.5 */
 #define BL60X_PLL_192MHz	3
+
+/** Overclocked x 1.25
+ * BCLK divider is the most important scaler for BL60x, so remember to tune the dividers
+ */
+
+/** ID 0, 60MHz = 480 / 10 * 1.25 */
+#define BL60X_PLL_OC_60MHz	(0 | 0x10)
+/** ID 1, 150MHz = 480 / 4 * 1.25 */
+#define BL60X_PLL_OC_150MHz	(1 | 0x10)
+/** ID 2, 200MHz = 480 / 3 * 1.25 */
+#define BL60X_PLL_OC_200MHz	(2 | 0x10)
+/** ID 3, 240MHz = 480 / 2.5 * 1.25 */
+#define BL60X_PLL_OC_240MHz	(3 | 0x10)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_BFLB_BL60X_CLOCK_H_ */


### PR DESCRIPTION
Allow configuration of flash clock for BL60xand BL70x,

Add Overclock entry for BL60x