### PR TITLE
Add DMA driver support for PIC32CM PL devices

### DIFF
--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
@@ -118,3 +118,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&dmac {
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.yaml
@@ -11,6 +11,7 @@ flash: 64
 ram: 8
 supported:
   - clock_control
+  - dma
   - gpio
   - pinctrl
   - uart

--- a/dts/arm/microchip/pic32c/pic32cm_pl/common/pic32cm_pl.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_pl/common/pic32cm_pl.dtsi
@@ -95,6 +95,17 @@
 			};
 		};
 
+		dmac: dmac@41006000 {
+			compatible = "microchip,dmac-g2-dma";
+			reg = <0x41006000 0x50>;
+			interrupts = <5 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_AHB_DMAC>;
+			clock-names = "mclk";
+			dma-channels = <0x2>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sercom0: sercom@42000400 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x42000400 0x31>;

--- a/soc/microchip/pic32c/pic32cm_pl/common/mchp_dt_helper.h
+++ b/soc/microchip/pic32c/pic32cm_pl/common/mchp_dt_helper.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file mchp_dt_helper.h
+ * @brief device tree helper macros.
+ *
+ * This file contains the device tree helper macros.
+ */
+
+#ifndef SOC_MICROCHIP_PIC32CM_PL_COMMON_MCHP_DT_HELPER_H_
+
+/* clang-format off */
+/* Helper macros for use with DMAC controller
+ * return 0xff as default value if there is no 'dmas' property
+ */
+#define MCHP_DT_INST_DMA_CELL(n, name, cell)						\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CELL_BY_NAME(n, name, cell)),			\
+			(0xff))
+#define MCHP_DT_INST_DMA_TRIGSRC(n, name) MCHP_DT_INST_DMA_CELL(n, name, trigsrc)
+#define MCHP_DT_INST_DMA_CHANNEL(n, name) MCHP_DT_INST_DMA_CELL(n, name, channel)
+#define MCHP_DT_INST_DMA_CTLR(n, name)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CTLR_BY_NAME(n, name)),				\
+			(DT_INVALID_NODE))
+/* clang-format on */
+
+#endif /* SOC_MICROCHIP_PIC32CM_PL_COMMON_MCHP_DT_HELPER_H_ */

--- a/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_pl10_cnano.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/pic32cm_pl10_cnano.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -20,3 +20,4 @@ tests:
       - nucleo_c031c6
       - sam_e54_xpro
       - pic32cm_jh01_cpro
+      - pic32cm_pl10_cnano

--- a/tests/drivers/dma/loop_transfer/boards/pic32cm_pl10_cnano.conf
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cm_pl10_cnano.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_LOOP_TRANSFER_SIZE=512

--- a/tests/drivers/dma/loop_transfer/boards/pic32cm_pl10_cnano.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cm_pl10_cnano.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds
* DMA controller node for the PIC32CM PL family
* Updates the corresponding pic32cm_pl10_cnano board device tree to enable DMA support.
* Adds Twister test files to validate the DMA functionality.