### PR TITLE
dts: QEMU: Add i/d-cache-line-size properties

### DIFF
--- a/boards/qemu/cortex_a9/qemu_cortex_a9.dts
+++ b/boards/qemu/cortex_a9/qemu_cortex_a9.dts
@@ -20,6 +20,8 @@
 		cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a9";
+			i-cache-line-size = <32>;
+			d-cache-line-size = <32>;
 			reg = <0>;
 		};
 	};

--- a/dts/arm64/qemu/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu/qemu-virt-a53.dtsi
@@ -30,12 +30,16 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-a53";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu@1 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a53";
 			reg = <1>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 	};
 


### PR DESCRIPTION
Add i/d-cache-line-size dts properties for qemu virt-a53 and cortex-a9 targets.