### PR TITLE
lib: heap: Make canaries random and reduce their size

### DIFF
--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -115,7 +115,6 @@ config SYS_HEAP_HARDENING_MODERATE
 
 config SYS_HEAP_HARDENING_FULL
 	bool "Full"
-	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
 	select SYS_HEAP_CANARIES
 	help
 	  In addition to moderate checks, enable per-chunk trailer
@@ -127,7 +126,6 @@ config SYS_HEAP_HARDENING_FULL
 
 config SYS_HEAP_HARDENING_EXTREME
 	bool "Extreme"
-	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
 	select SYS_HEAP_CANARIES
 	select SYS_HEAP_VALIDATE
 	help
@@ -154,6 +152,17 @@ config SYS_HEAP_HARDENING_LEVEL
 
 config SYS_HEAP_CANARIES
 	bool
+
+config SYS_HEAP_CANARIES_RANDOM
+	bool "Use random base for heap canaries"
+	depends on SYS_HEAP_CANARIES
+	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
+	default y
+	help
+	  Use a random base value for heap canary computation,
+	  making canaries unpredictable across power cycles.
+	  Without this, canaries are still effective at detecting
+	  accidental corruption but are predictable.
 
 module = SYS_HEAP
 module-str = sys_heap

--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -115,6 +115,7 @@ config SYS_HEAP_HARDENING_MODERATE
 
 config SYS_HEAP_HARDENING_FULL
 	bool "Full"
+	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
 	select SYS_HEAP_CANARIES
 	help
 	  In addition to moderate checks, enable per-chunk trailer
@@ -126,6 +127,7 @@ config SYS_HEAP_HARDENING_FULL
 
 config SYS_HEAP_HARDENING_EXTREME
 	bool "Extreme"
+	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
 	select SYS_HEAP_CANARIES
 	select SYS_HEAP_VALIDATE
 	help

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(os_heap, CONFIG_SYS_HEAP_LOG_LEVEL);
 #include <sanitizer/msan_interface.h>
 #endif
 
-#ifdef CONFIG_SYS_HEAP_CANARIES
+#ifdef CONFIG_SYS_HEAP_CANARIES_RANDOM
 #include <zephyr/random/random.h>
 #endif
 
@@ -29,17 +29,20 @@ static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)
 #endif
 
 #ifdef CONFIG_SYS_HEAP_CANARIES
+#ifdef CONFIG_SYS_HEAP_CANARIES_RANDOM
+#define HEAP_CANARY_MAGIC(h) h->canary_base
+#else
+#define HEAP_CANARY_MAGIC(h) 0x5A6B7C8DU
+#endif
 #define HEAP_CANARY_POISON 0xDEADBEEFU
 
 /*
  * Compute a per-chunk canary from its address and size as well as the
- * base canary, which gets generated randomly at heap initialization.
- * Similar to stack canaries, this prevents attackers from forging
- * heap canaries without an information disclosure vulnerability.
+ * base canary to detect misplaced canaries.
  */
 static inline uint32_t compute_canary(struct z_heap *h, chunkid_t c)
 {
-	return ((c >> 16) | (c << 16)) ^ chunk_size(h, c) ^ h->canary_base;
+	return ((c >> 16) | (c << 16)) ^ chunk_size(h, c) ^ HEAP_CANARY_MAGIC(h);
 }
 
 static inline void set_chunk_canary(struct z_heap *h, chunkid_t c)
@@ -771,7 +774,7 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 		h->buckets[i].next = 0;
 	}
 
-#ifdef CONFIG_SYS_HEAP_CANARIES
+#ifdef CONFIG_SYS_HEAP_CANARIES_RANDOM
 	sys_rand_get(&h->canary_base, sizeof(h->canary_base));
 #endif
 

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -16,6 +16,9 @@ LOG_MODULE_REGISTER(os_heap, CONFIG_SYS_HEAP_LOG_LEVEL);
 #include <sanitizer/msan_interface.h>
 #endif
 
+#ifdef CONFIG_SYS_HEAP_CANARIES
+#include <zephyr/random/random.h>
+#endif
 
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)
@@ -26,22 +29,17 @@ static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)
 #endif
 
 #ifdef CONFIG_SYS_HEAP_CANARIES
-#define HEAP_CANARY_MAGIC 0x5A6B7C8D9EAFB0C1ULL
-#define HEAP_CANARY_POISON 0xDEADBEEFDEADBEEFULL
+#define HEAP_CANARY_POISON 0xDEADBEEFU
 
 /*
- * Compute a per-chunk canary from its address and size.  This is
- * sufficient to detect accidental corruption but is not cryptographically
- * secure — a determined attacker who knows the heap layout could forge
- * a valid canary.  A stronger scheme (e.g. SipHash with a random key)
- * could replace this if needed.
+ * Compute a per-chunk canary from its address and size as well as the
+ * base canary, which gets generated randomly at heap initialization.
+ * Similar to stack canaries, this prevents attackers from forging
+ * heap canaries without an information disclosure vulnerability.
  */
-static inline uint64_t compute_canary(struct z_heap *h, chunkid_t c)
+static inline uint32_t compute_canary(struct z_heap *h, chunkid_t c)
 {
-	uintptr_t addr = (uintptr_t)&chunk_buf(h)[c];
-	chunksz_t size = chunk_size(h, c);
-
-	return (addr ^ size) ^ HEAP_CANARY_MAGIC;
+	return ((c >> 16) | (c << 16)) ^ chunk_size(h, c) ^ h->canary_base;
 }
 
 static inline void set_chunk_canary(struct z_heap *h, chunkid_t c)
@@ -51,8 +49,8 @@ static inline void set_chunk_canary(struct z_heap *h, chunkid_t c)
 
 static inline void verify_chunk_canary(struct z_heap *h, chunkid_t c, void *mem)
 {
-	uint64_t expected = compute_canary(h, c);
-	uint64_t found = chunk_trailer(h, c)->canary;
+	uint32_t expected = compute_canary(h, c);
+	uint32_t found = chunk_trailer(h, c)->canary;
 
 	if (found != expected) {
 		if (found == HEAP_CANARY_POISON) {
@@ -772,6 +770,10 @@ void sys_heap_init(struct sys_heap *heap, void *mem, size_t bytes)
 	for (int i = 0; i < nb_buckets; i++) {
 		h->buckets[i].next = 0;
 	}
+
+#ifdef CONFIG_SYS_HEAP_CANARIES
+	sys_rand_get(&h->canary_base, sizeof(h->canary_base));
+#endif
 
 	/* chunk containing our struct z_heap */
 	set_chunk_size(h, 0, chunk0_size);

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -73,7 +73,7 @@ typedef uint32_t chunksz_t;
 #ifdef CONFIG_SYS_HEAP_CANARIES
 
 struct z_heap_chunk_trailer {
-	uint64_t canary;
+	uint32_t canary;
 } __aligned(CHUNK_UNIT);
 
 #define CHUNK_TRAILER_SIZE (sizeof(struct z_heap_chunk_trailer) / CHUNK_UNIT)
@@ -96,6 +96,9 @@ struct z_heap {
 	size_t free_bytes;
 	size_t allocated_bytes;
 	size_t max_allocated_bytes;
+#endif
+#ifdef CONFIG_SYS_HEAP_CANARIES
+	uint32_t canary_base;
 #endif
 	struct z_heap_bucket buckets[];
 };

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -97,7 +97,7 @@ struct z_heap {
 	size_t allocated_bytes;
 	size_t max_allocated_bytes;
 #endif
-#ifdef CONFIG_SYS_HEAP_CANARIES
+#ifdef CONFIG_SYS_HEAP_CANARIES_RANDOM
 	uint32_t canary_base;
 #endif
 	struct z_heap_bucket buckets[];

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -22,3 +22,4 @@ tests:
   libraries.heap.hardening_full:
     extra_configs:
       - CONFIG_SYS_HEAP_HARDENING_FULL=y
+      - CONFIG_TEST_RANDOM_GENERATOR=y

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -10,3 +10,4 @@ tests:
   libraries.heap_align.hardening_full:
     extra_configs:
       - CONFIG_SYS_HEAP_HARDENING_FULL=y
+      - CONFIG_TEST_RANDOM_GENERATOR=y

--- a/tests/lib/heap_min/testcase.yaml
+++ b/tests/lib/heap_min/testcase.yaml
@@ -11,3 +11,4 @@ tests:
   libraries.heap_min.hardening_full:
     extra_configs:
       - CONFIG_SYS_HEAP_HARDENING_FULL=y
+      - CONFIG_TEST_RANDOM_GENERATOR=y


### PR DESCRIPTION
Randomize the base canary value at heap creation in order to make it unpredictable to attackers and reduce their size to 4 bytes, which should still give enough entropy but reduce overhead especially on 32-bit targets.