### PR TITLE
drivers: disk: sdmmc_stm32: Provide erase when sdmmc is used in eMMC mode

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -709,9 +709,13 @@ static int stm32_sdmmc_access_erase(struct disk_info *disk, uint32_t sector, uin
 
 	k_sem_take(&priv->thread_lock, K_FOREVER);
 
+#ifdef CONFIG_SDMMC_STM32_EMMC
+	err = HAL_MMC_Erase(&priv->hsd, sector, sector + count);
+#else
 	err = HAL_SD_Erase(&priv->hsd, sector, sector + count);
+#endif
 	if (err != HAL_OK) {
-		LOG_ERR("sd erase block failed %d", err);
+		LOG_ERR("sdmmc erase block failed %d", err);
 		err = -EIO;
 		goto end;
 	}


### PR DESCRIPTION
If `CONFIG_SDMMC_STM32_EMMC=y`, the compiler complains about undefined reference to `HAL_SD_Erase()` because those files are not included in the build. Unfortunately, if eMMC is installed `CONFIG_SDMMC_STM32_EMMC=n` is not an option because the SD and eMMC protocols are different enough that eMMC will not work.