### PR TITLE
dts: arm: nxp: lpc55S1x: fix size of reserved flash region

### DIFF
--- a/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
@@ -37,6 +37,12 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	/* lpc55_1x Memory configurations:
+	 *
+	 * LPC55x12: RAMX: 16K, SRAM0: 32K
+	 * LPC55x14: RAMX: 16K, SRAM0: 32K, SRAM1: 16K, USBRAM: 16k
+	 * LPC55x16: RAMX: 16K, SRAM0: 32K, SRAM1: 16K, SRAM2: 16K, USBRAM: 16k
+	 */
 	sramx: memory@4000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x4000000 DT_SIZE_K(16)>;
@@ -85,6 +91,12 @@
 		};
 	};
 
+	/* lpc55_1x Flash memory configurations:
+	 *
+	 * LPC55x12: CODE:  64K, PFR: 12K, BOOT: 128K
+	 * LPC55x14: CODE: 128K, PFR: 12K, BOOT: 128K
+	 * LPC55x16: CODE: 224K, PFR: 12K, BOOT: 128K
+	 */
 	iap: flash-controller@34000 {
 		compatible = "nxp,iap-fmc55";
 		reg = <0x34000 0x18>;
@@ -94,14 +106,14 @@
 
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";
-			reg = <0x0 DT_SIZE_K(246)>;
+			reg = <0x0 DT_SIZE_K(244)>;
 			erase-block-size = <512>;
 			write-block-size = <512>;
 		};
 
-		flash_reserved: flash@3d800 {
+		flash_reserved: flash@3d000 {
 			compatible = "soc-nv-flash";
-			reg = <0x0003d800 DT_SIZE_K(10)>;
+			reg = <0x0003d000 DT_SIZE_K(12)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
According to NXP [AN12949 (2.1.2)](https://www.nxp.com/docs/en/application-note/AN12949.pdf) and [UM11295 (2.1.5/10.1)](https://www.nxp.com/doc/UM11295), the size of the Protected Flash Region (PFR) is 12 KB, located at `0x3d000` to `0x3ffff`, and included in all LPC55S1x/LPC551x devices. The common DTS include file for all LPC55S1x/LPC551x devices is intended to provide the maximum flash memory configuration for 256 KB devices and can **therefore only allocate 244 KB for customer-usable flash memory**. The **PFR must be 12 KB** in size and **bound to address `0x3d000`**.

Please review carefully or preferably cross-referenced with the NXP documents mentioned. This change definitely affects all LPC55S16-based (Zephyr in-tree) boards and, more importantly, potentially hidden products (customer's downstream boards) that may already be on the market.

<details>
<summary>Additional references and summaries</summary>

### lpc55_1x Flash memory configurations:

  LPC55x12: CODE:  64K, PFR: 12K, BOOT: 128K
  LPC55x14: CODE: 128K, PFR: 12K, BOOT: 128K
  LPC55x16: CODE: 224K, PFR: 12K, BOOT: 128K

### NXP AN12949 (2.1.2):

The PFR size of LPC55S1x is 12 KB, located in 0x0003_D000 – 0x0003_FFFF.

- For LPC55S1x 64/128 KB part, the total flash size can be used by customer is 64/128 KB
- For LPC55S1x 256 KB part, the total flash size can be used by customer is 244 KB.

### NXP UM11295 (2.1.5):

Flash memory, on CM33 code bus. The last 17 pages (12 KB) are reserved on the 256 KB flash devices resulting in 244 KB internal flash memory.

> [!NOTE]
>
> 17 pages and 12 KB contradict each other.
>
> In UM11295 section 6.5, only 16 pages are documented. The last page starting at `0x3fe00` can be interpreted as part of this, making a total of 17 pages, even though its contents are not documented. However, there is no documentation about the content or use of the 7 pages before that, starting at `0x3d000`, nor is there any indication that this area is reserved. But 17+7=24 pages (* 512 bytes) only add up to 12 KB, which is also defined in AN1949.

### NXP UM11295 (6.2):

An 128 kB on-chip boot ROM with bootloader is included on all LPC55S1x/LPC551x devices.

### NXP UM11295 (6.5):

The PFR region is used as the persistent storage for the secure boot and the SoC specific parameters. It starts at FIXED address 0x3DE00. (See also chapter 7 about the Secure Boot ROM)

```
  start    –    end     pages
-------------------------------------------------------------------
0x00000000 – 0x0003cfff  488    244KB CODE
-------------------------------------------------------------------
0x0003d000 – 0x0003d7ff  4      2.0KB ???
0x0003d800 – 0x0003ddff  3      1.5KB ???
-------------------------------------------------------------------
0x0003de00 – 0x0003dfff  1      0.5KB PFR:CFPA:Scratch
0x0003e000 – 0x0003e1ff  1      0.5KB PFR:CFPA:Ping
0x0003e200 – 0x0003e3ff  1      0.5KB PFR:CFPA:Pong
0x0003e400 – 0x0003e5ff  1      0.5KB PFR:CMPA:Config
0x0003e600 – 0x0003ebff  3      1.5KB PFR:CMPA:PUF (Key Store)
0x0003ec00 – 0x0003fdff  9      4.5KB PFR:NMPA (w/UUID @ 0x0003fc70)
0x0003fe00 – 0x0003ffff  1      0.5KB ???
```

### NXP UM11295 (10.1):

The Protected Flash Region (PFR) is included on all LPC55S1x/LPC551x devices.

</details>
