### PR TITLE
drivers: uart: sam0: Fix interrupt handling in uart_sam0.c

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -25,11 +25,13 @@
 #endif
 
 /*
- * Interrupt error flag is only supported in devices with
- * SERCOM revision 0x500
+ * Interrupt error flag is not supported in devices with
+ * SERCOM revision 0x102
  */
-#if defined(SERCOM_U2201) && (REV_SERCOM == 0x500)
-#define SERCOM_REV500
+#if (REV_SERCOM == 0x102)
+#define SAM0_SERCOM_HAS_ERROR_FLAGS 0
+#else
+#define SAM0_SERCOM_HAS_ERROR_FLAGS 1
 #endif
 
 /* Device constant configuration parameters */
@@ -466,7 +468,7 @@ static int uart_sam0_configure(const struct device *dev,
 
 	dev_data->config_cache.data_bits = new_cfg->data_bits;
 
-#if defined(SERCOM_REV500)
+#if (SAM0_SERCOM_HAS_ERROR_FLAGS)
 	CTRLB_temp.bit.COLDEN = cfg->pads;
 #endif
 
@@ -677,7 +679,7 @@ static int uart_sam0_err_check(const struct device *dev)
 		err |= UART_ERROR_FRAMING;
 	}
 
-#if defined(SERCOM_REV500)
+#if (SAM0_SERCOM_HAS_ERROR_FLAGS)
 	if (regs->STATUS.reg & SERCOM_USART_STATUS_ISF) {
 		err |= UART_BREAK;
 	}
@@ -877,7 +879,7 @@ static int uart_sam0_irq_is_pending(const struct device *dev)
 	return (regs->INTENSET.reg & regs->INTFLAG.reg) != 0;
 }
 
-#if defined(SERCOM_REV500)
+#if (SAM0_SERCOM_HAS_ERROR_FLAGS)
 static void uart_sam0_irq_err_enable(const struct device *dev)
 {
 	const struct uart_sam0_dev_cfg *config = dev->config;
@@ -903,7 +905,6 @@ static int uart_sam0_irq_update(const struct device *dev)
 	const struct uart_sam0_dev_cfg *config = dev->config;
 	SercomUsart * const regs = config->regs;
 
-#if defined(SERCOM_REV500)
 	/*
 	 * Cache the TXC flag, and use this cached value to clear the interrupt
 	 * if we do not used the cached value, there is a chance TXC will set
@@ -912,6 +913,7 @@ static int uart_sam0_irq_update(const struct device *dev)
 	struct uart_sam0_dev_data *const dev_data = dev->data;
 
 	dev_data->txc_cache = regs->INTFLAG.bit.TXC;
+#if (SAM0_SERCOM_HAS_ERROR_FLAGS)
 	regs->INTFLAG.reg = SERCOM_USART_INTENCLR_ERROR
 			  | SERCOM_USART_INTENCLR_RXBRK
 			  | SERCOM_USART_INTENCLR_CTSIC
@@ -1194,7 +1196,7 @@ static DEVICE_API(uart, uart_sam0_driver_api) = {
 	.irq_rx_disable = uart_sam0_irq_rx_disable,
 	.irq_rx_ready = uart_sam0_irq_rx_ready,
 	.irq_is_pending = uart_sam0_irq_is_pending,
-#if defined(SERCOM_REV500)
+#if (SAM0_SERCOM_HAS_ERROR_FLAGS)
 	.irq_err_enable = uart_sam0_irq_err_enable,
 	.irq_err_disable = uart_sam0_irq_err_disable,
 #endif


### PR DESCRIPTION
allow txc_cache to be set for non-SERCOM_REV500 peripherals

fixes #87210