### PR TITLE
net: lib: http_server: Reject over length websocket key header

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -895,8 +895,12 @@ static int on_header_value(struct http_parser *parser,
 
 			if (ctx->websocket_sec_key_next) {
 #if defined(CONFIG_WEBSOCKET)
-				strncpy(ctx->ws_sec_key, ctx->header_buffer,
-					MIN(sizeof(ctx->ws_sec_key), offset));
+				if (offset >= sizeof(ctx->ws_sec_key)) {
+					LOG_ERR("Sec-WebSocket-Key too long");
+					return -EBADMSG;
+				}
+				memcpy(ctx->ws_sec_key, ctx->header_buffer, offset);
+				ctx->ws_sec_key[offset] = '\0';
 #endif
 				ctx->websocket_sec_key_next = false;
 			}


### PR DESCRIPTION
net: lib: http_server: Reject over length websocket key header

If CONFIG_HTTP_SERVER_MAX_HEADER_LEN is increased from the default of
32, a compiler warning pops in the HTTP websocket code:

    zephyr/subsys/net/lib/http/http_server_http1.c:
    In function 'on_header_value':
    zephyr/subsys/net/lib/http/http_server_http1.c:898:33:
    warning: 'strncpy' output may be truncated copying between 0 and 32
    bytes from a string of length 47 [-Wstringop-truncation]
      898 |          strncpy(ctx->ws_sec_key, ctx->header_buffer,
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      899 |                  MIN(sizeof(ctx->ws_sec_key), offset));
          |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This comes from:

                if (ctx->websocket_sec_key_next) {
    #if defined(CONFIG_WEBSOCKET)
                         strncpy(ctx->ws_sec_key, ctx->header_buffer,
                                 MIN(sizeof(ctx->ws_sec_key), offset));
    #endif

If eg. header_buffer is 48 bytes and holds a string >= 32 bytes then
ws_sec_key can end up non-nul terminated. That can then lead to buffer
overflow in handle_http1_to_websocket_upgrade().

Add a check to make sure the header value fits in ws_sec_key, if not
reject the request with a HTTP 500. The websocket key is not expected to
be > 31 bytes.

Once the check is in place, it's safe to use memcpy() for the copy, and
then add the terminating nul manually.

Signed-off-by: Michael Ellerman <mpe@oss.tenstorrent.com>