### PR TITLE
drivers: counter: fix get_pending_int return type mismatch

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -19,10 +19,8 @@
 
 COUNTER_HANDLER(stop)
 COUNTER_HANDLER(start)
-COUNTER_HANDLER(get_pending_int)
 COUNTER_HANDLER(reset)
 
-#include <zephyr/syscalls/counter_get_pending_int_mrsh.c>
 #include <zephyr/syscalls/counter_stop_mrsh.c>
 #include <zephyr/syscalls/counter_start_mrsh.c>
 
@@ -238,6 +236,14 @@ static inline uint32_t z_vrfy_counter_get_max_top_value(const struct device *dev
 	return z_impl_counter_get_max_top_value((const struct device *)dev);
 }
 #include <zephyr/syscalls/counter_get_max_top_value_mrsh.c>
+
+static inline uint32_t z_vrfy_counter_get_pending_int(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_pending_int));
+	return z_impl_counter_get_pending_int((const struct device *)dev);
+}
+
+#include <zephyr/syscalls/counter_get_pending_int_mrsh.c>
 
 static inline uint32_t z_vrfy_counter_get_guard_period(const struct device *dev, uint32_t flags)
 {

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -813,9 +813,9 @@ static inline int z_impl_counter_set_top_value(const struct device *dev,
  * @retval 1 if any counter interrupt is pending.
  * @retval 0 if no counter interrupt is pending.
  */
-__syscall int counter_get_pending_int(const struct device *dev);
+__syscall uint32_t counter_get_pending_int(const struct device *dev);
 
-static inline int z_impl_counter_get_pending_int(const struct device *dev)
+static inline uint32_t z_impl_counter_get_pending_int(const struct device *dev)
 {
 	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 


### PR DESCRIPTION
The `counter_api_get_pending_int` typedef returns `uint32_t`, but the public
`counter_get_pending_int` API, its inline implementation, and its syscall
handler all return `int`. 

Change the public API, inline impl, and syscall handler to return `uint32_t`
to match the driver API typedef.