### PR TITLE
dts: arm: renesas: Remove system node for Renesas RA

### DIFF
--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -43,12 +43,6 @@
 			reg = <0x20000000 0x8000>;
 		};
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40041000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40041000 0x6c>;

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -26,12 +26,6 @@
 	};
 
 	soc {
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40041000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40041000 0x6c>;

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -35,12 +35,6 @@
 	soc {
 		interrupt-parent = <&nvic>;
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40082000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40082000 0x70>;

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -35,12 +35,6 @@
 	soc {
 		interrupt-parent = <&nvic>;
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40082000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40082000 0x70>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -34,12 +34,6 @@
 	soc {
 		interrupt-parent = <&nvic>;
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40082000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40082000 0x70>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -31,12 +31,6 @@
 	};
 
 	soc {
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40041000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40041000 0x70>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -34,12 +34,6 @@
 	soc {
 		interrupt-parent = <&nvic>;
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40082000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40082000 0x70>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -32,12 +32,6 @@
 	};
 
 	soc {
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			status = "okay";
-		};
-
 		elc: elc@40041000 {
 			compatible = "renesas,ra-elc";
 			reg = <0x40041000 0x70>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -55,32 +55,24 @@
 			reg = <0x22000000 DT_SIZE_K(896)>;
 		};
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			status = "okay";
-
-			battery_backup: battery-backup@3b0 {
-				compatible = "renesas,ra-battery-backup";
-				reg = <0x3b0 0x2>, <0x3d0 0x4>,
-				      <0xa84 0x1>, <0xa88 0x1>,
-				      <0xc40 0x1>, <0xc45 0x1>,
-				      <0xc46 0x1>, <0xc48 0x1>,
-				      <0xc49 0x1>, <0xc4a 0x1>,
-				      <0xc4c 0x1>, <0xc4d 0x1>,
-				      <0xc4e 0x1>, <0xd00 0x80>;
-				reg-names = "vbrsabar", "bbfsar",
-					    "vbattmnselr", "vbtbpcr1",
-					    "vbtber", "vbtbpcr2",
-					    "vbtbpsr", "vbtadsr",
-					    "vbtadcr1", "vbtadcr2",
-					    "vbtictlr", "vbtictlr2",
-					    "vbtimonr", "vbtbkrn";
-				manual-configure;
-				status = "disabled";
-			};
+		battery_backup: battery-backup@4001e3b0 {
+			compatible = "renesas,ra-battery-backup";
+			reg = <0x4001e3b0 0x2>, <0x4001e3d0 0x4>,
+			      <0x4001ea84 0x1>, <0x4001ea88 0x1>,
+			      <0x4001ec40 0x1>, <0x4001ec45 0x1>,
+			      <0x4001ec46 0x1>, <0x4001ec48 0x1>,
+			      <0x4001ec49 0x1>, <0x4001ec4a 0x1>,
+			      <0x4001ec4c 0x1>, <0x4001ec4d 0x1>,
+			      <0x4001ec4e 0x1>, <0x4001ed00 0x80>;
+			reg-names = "vbrsabar", "bbfsar",
+				    "vbattmnselr", "vbtbpcr1",
+				    "vbtber", "vbtbpcr2",
+				    "vbtbpsr", "vbtadsr",
+				    "vbtadcr1", "vbtadcr2",
+				    "vbtictlr", "vbtictlr2",
+				    "vbtimonr", "vbtbkrn";
+			manual-configure;
+			status = "disabled";
 		};
 
 		elc: elc@40201000 {

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -62,32 +62,24 @@
 	soc {
 		interrupt-parent = <&nvic>;
 
-		system: system@4001e000 {
-			compatible = "renesas,ra-system";
-			reg = <0x4001e000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			status = "okay";
-
-			battery_backup: battery-backup@3b0 {
-				compatible = "renesas,ra-battery-backup";
-				reg = <0x3b0 0x2>, <0x3d0 0x4>,
-				      <0xa84 0x1>, <0xa88 0x1>,
-				      <0xc40 0x1>, <0xc45 0x1>,
-				      <0xc46 0x1>, <0xc48 0x1>,
-				      <0xc49 0x1>, <0xc4a 0x1>,
-				      <0xc4c 0x1>, <0xc4d 0x1>,
-				      <0xc4e 0x1>, <0xd00 0x80>;
-				reg-names = "vbrsabar", "bbfsar",
-					    "vbattmnselr", "vbtbpcr1",
-					    "vbtber", "vbtbpcr2",
-					    "vbtbpsr", "vbtadsr",
-					    "vbtadcr1", "vbtadcr2",
-					    "vbtictlr", "vbtictlr2",
-					    "vbtimonr", "vbtbkrn";
-				manual-configure;
-				status = "disabled";
-			};
+		battery_backup: battery-backup@4001e3b0 {
+			compatible = "renesas,ra-battery-backup";
+			reg = <0x4001e3b0 0x2>, <0x4001e3d0 0x4>,
+			      <0x4001ea84 0x1>, <0x4001ea88 0x1>,
+			      <0x4001ec40 0x1>, <0x4001ec45 0x1>,
+			      <0x4001ec46 0x1>, <0x4001ec48 0x1>,
+			      <0x4001ec49 0x1>, <0x4001ec4a 0x1>,
+			      <0x4001ec4c 0x1>, <0x4001ec4d 0x1>,
+			      <0x4001ec4e 0x1>, <0x4001ed00 0x80>;
+			reg-names = "vbrsabar", "bbfsar",
+				    "vbattmnselr", "vbtbpcr1",
+				    "vbtber", "vbtbpcr2",
+				    "vbtbpsr", "vbtadsr",
+				    "vbtadcr1", "vbtadcr2",
+				    "vbtictlr", "vbtictlr2",
+				    "vbtimonr", "vbtbkrn";
+			manual-configure;
+			status = "disabled";
 		};
 
 		pinctrl: pin-controller@40400800 {


### PR DESCRIPTION
Since the system node has not been used for a long time, it should be removed to allow other peripheral nodes to define the register without being child nodes of the system node.