### PR TITLE
driver: crc: Fix crc macro in header file

### DIFF
--- a/include/zephyr/drivers/crc.h
+++ b/include/zephyr/drivers/crc.h
@@ -88,10 +88,13 @@ extern "C" {
 #define CRC24_PGP_INIT_VALUE 0x00B704CEU
 
 /** CRC32_C initial value */
+#define CRC32_C_INIT_VAL 0xFFFFFFFFU
+
+/** CRC32_IEEE initial value */
 #define CRC32_IEEE_INIT_VAL 0xFFFFFFFFU
 
 /** CRC32_K_4_2 initial value */
-#define CRC32_C_INIT_VAL 0xFFFFFFFFU
+#define CRC32_K_4_2_INIT_VAL 0xFFFFFFFFU
 
 /** @endcond */
 

--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -73,19 +73,19 @@ extern "C" {
 /** CRC8_REFLECT polynomial */
 #define CRC8_REFLECT_POLY 0xE0
 
-/** CRC8_ROHC polynomial */
+/** CRC16 polynomial */
 #define CRC16_POLY 0x8005
 
 /** CRC16_ANSI polynomial */
 #define CRC16_REFLECT_POLY 0xA001
 
-/** CRC16_CCITT polynomial */
+/** CRC16_CCITT/CRC16_ITU_T polynomial */
 #define CRC16_CCITT_POLY 0x1021
 
-/** CRC16_ITU_T polynomial */
+/**  CRC24_PGP polynomial */
 #define CRC24_PGP_POLY 0x01864CFBU
 
-/** CRC32_C polynomial */
+/** CRC32_IEEE polynomial */
 #define CRC32_IEEE_POLY 0x04C11DB7U
 
 /** CRC32C polynomial */


### PR DESCRIPTION
Fix crc macro in header file:
include/zephyr/drivers/crc.h
include/zephyr/sys/crc.h

I fix the crc macro as another commit regarding to PR 104471. 
Please review it.
Thanks.