### PR TITLE
boards: microchip: sama7g54_ek: fix the error "Filed to load MAC"

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/Kconfig.defconfig
+++ b/boards/microchip/sam/sama7g54_ek/Kconfig.defconfig
@@ -3,5 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+configdefault EEPROM
+	default y if NVMEM
+
 configdefault NET_L2_ETHERNET
 	default y if NETWORKING

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -150,6 +150,17 @@
 			size = <256>;
 			timeout = <5>;
 			status = "okay";
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom0_eui48: eui48@fa {
+					reg = <0xfa 6>;
+					#nvmem-cell-cells = <0>;
+				};
+			};
 		};
 
 		eeprom1: eeprom1@53 {
@@ -160,6 +171,17 @@
 			size = <256>;
 			timeout = <5>;
 			status = "okay";
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom1_eui48: eui48@fa {
+					reg = <0xfa 6>;
+					#nvmem-cell-cells = <0>;
+				};
+			};
 		};
 	};
 };
@@ -170,6 +192,9 @@
 	pinctrl-0 = <&pinctrl_gmac0_default>;
 	phy-connection-type = "gmii";
 	phy-handle = <&gmac0_phy>;
+
+	nvmem-cells = <&eeprom0_eui48>;
+	nvmem-cell-names = "mac_address";
 };
 
 &gmac0_mdio {
@@ -193,6 +218,9 @@
 	phy-connection-type = "mii";
 	phy-handle = <&gmac1_phy>;
 	ref-clk-source = "external";
+
+	nvmem-cells = <&eeprom1_eui48>;
+	nvmem-cell-names = "mac_address";
 };
 
 &gmac1_mdio {


### PR DESCRIPTION
The error "Filed to load MAC" is introduced by commit cf0d1b877e7 which does not update the MAC address support for sama7g54-ek. Fix it by updating the dts nodes of gmac0 and gmac1.

fixes: #96598