### PR TITLE
west: zcmake.py: do not drop CMake outputs on failure, log them instead

### DIFF
--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -64,13 +64,16 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False, env=None):
     log.dbg('Running CMake:', quote_sh_list(cmd), level=log.VERBOSE_NORMAL)
     p = subprocess.Popen(cmd, env=env, **kwargs)
     out, _ = p.communicate()
+    out = out.decode(sys.getdefaultencoding()) if out else None
     if p.returncode == 0:
         if out:
-            return out.decode(sys.getdefaultencoding()).splitlines()
+            return out.splitlines()
         else:
             return None
     else:
         # A real error occurred, raise an exception
+        if out:
+            log.err(out)
         raise subprocess.CalledProcessError(p.returncode, p.args)
 
 


### PR DESCRIPTION
When everything goes well, run_cmake() returns the combined stdout+stderr from CMake. But when CMake fails, it was raising a Python exception with the barely useful exit status and discarding all messages. Use log.err() to print CMake outputs on failure.

This issue was reported on Discord: someone had a Python version lower than the minimum currently required by listsdk.cmake and there was zero useful message. Running listsdk.cmake directly showed the issue. Error handling: never tested much.

Fixes commit 31bdad529901 ("west: Implement CMake helpers in scripts/west_commands")

cc:
- https://github.com/zephyrproject-rtos/zephyr/pull/92555