### PR TITLE
wifi: siwx91x: Remove existing ipv6 addresses on wifi connection failure

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
@@ -94,6 +94,9 @@ unsigned int siwx91x_wifi_module_stats_event_handler(sl_wifi_event_t event, unsi
 		sidev->state = WIFI_STATE_COMPLETED;
 		break;
 	case STATE_UNASSOCIATED:
+		if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
+			net_if_dormant_on(sidev->iface);
+		}
 		wifi_mgmt_raise_disconnect_result_event(sidev->iface,
 							WIFI_REASON_DISCONN_SUCCESS);
 


### PR DESCRIPTION
Set the network interface to dormant state when STATE_UNASSOCIATED is detected in the WiFi module stats event handler. This ensures that IPv6 addresses are properly cleaned up during wifi connection failures.