### PR TITLE
drivers: clock control: stm32h7 set the voltage scale0 correctly

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -268,10 +268,11 @@ static int32_t prepare_regulator_voltage_scale(void)
 {
 	/* Make sure to put the CPU in highest Voltage scale during clock configuration */
 	/* Highest voltage is SCALE0 */
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
 #else
+	__HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
 	while (LL_PWR_IsActiveFlag_VOS() == 0) {
 #endif
 	}


### PR DESCRIPTION
This PR uses the correct macro that actually set VOS0
 (thanks to @pillo79 that got the bottom of the problem discovering
 that this is a bug in the STM zephyr driver).
A bug report that explains the problem can be found here:
 zephyrproject-rtos#104536 and the fix for the arduino-zephyr  https://github.com/arduino/zephyr/pull/12/changes Arduino 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104536