### PR TITLE
manifest: mcuboot: prepare MCUboot for TF-PSA-Crypto transition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -326,7 +326,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: d9c2ba153128efd7c16db9f36dea4ee69f63c7f5
+      revision: 6fc2d6b3b8bf86961fa066b828ff0b05c07a0c15
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update the MCUboot project in order to include some fixes which are required for the transition from Mbed TLS 3.6.5 to TF-PSA-Crypto 1.x.
This is required for https://github.com/zephyrproject-rtos/zephyr/pull/104031