### PR TITLE
tests: net: http_server: core: Increase connect delay after restart

### DIFF
--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -2419,7 +2419,7 @@ ZTEST(server_function_tests_no_init, test_http_server_start_stop)
 	zassert_ok(http_server_start(), "Failed to start the server");
 
 	/* Let the server thread run. */
-	k_msleep(CONFIG_HTTP_SERVER_RESTART_DELAY + 10);
+	k_msleep(CONFIG_HTTP_SERVER_RESTART_DELAY + 50);
 
 	ret = zsock_socket(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TCP);
 	zassert_not_equal(ret, -1, "failed to create client socket (%d)", errno);


### PR DESCRIPTION
It's been observed that test_http_server_start_stop test case sometimes fail under heavy load with ECONNREFUSED error. It's hard to reproduce, however it could be an issue that the server thread has not enough time to setup the server before the connection attempt. After increasing the connect delay I was no longer able to reproduce the failure locally.