### PR TITLE
MAINTAINERS.yml: add maass-hamburg to networking ethernet area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4090,6 +4090,7 @@ Networking:
     - rlubos
     - jukkar
   collaborators:
+    - maass-hamburg
     - yangbolu1991
     - pdgendt
   files:


### PR DESCRIPTION
The ethenernet drivers area is deeply connected to the ethernet networking area, therefore add me here as a collaborator.