### PR TITLE
test: bluetooth: tester: add PAwR parameters to tester

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -444,6 +444,19 @@ struct btp_gap_decrypt_ead_adv_data_rp {
 	uint8_t decrypted_data[];
 } __packed;
 
+#define BTP_GAP_PAWR_CONFIGURE			0x34
+/* Uses same flags as BTP_GAP_PADV_CONFIGURE */
+struct btp_gap_pawr_configure_cmd {
+	uint8_t flags;
+	uint16_t interval_min;
+	uint16_t interval_max;
+	uint8_t num_subevents;
+	uint8_t subevent_interval;
+	uint8_t response_slot_delay;
+	uint8_t response_slot_spacing;
+	uint8_t num_response_slots;
+} __packed;
+
 /* events */
 #define BTP_GAP_EV_NEW_SETTINGS			0x80
 struct btp_gap_new_settings_ev {

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -2225,6 +2225,41 @@ static uint8_t padv_configure(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
+#if defined(CONFIG_BT_PER_ADV_RSP)
+static uint8_t pawr_configure(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+	uint32_t options = BT_LE_PER_ADV_OPT_NONE;
+	const struct btp_gap_pawr_configure_cmd *cp = cmd;
+	struct btp_gap_padv_configure_rp *rp = rsp;
+
+	if ((cp->flags & BTP_GAP_PADV_INCLUDE_TX_POWER) != 0) {
+		options |= BT_LE_PER_ADV_OPT_USE_TX_POWER;
+	}
+
+	struct bt_le_ext_adv *ext_adv = tester_gap_ext_adv_get(0);
+	struct bt_le_per_adv_param param = {
+		.interval_min = sys_le16_to_cpu(cp->interval_min),
+		.interval_max = sys_le16_to_cpu(cp->interval_max),
+		.options = options,
+		.num_subevents = cp->num_subevents,
+		.subevent_interval = cp->subevent_interval,
+		.response_slot_delay = cp->response_slot_delay,
+		.response_slot_spacing = cp->response_slot_spacing,
+		.num_response_slots = cp->num_response_slots,
+	};
+
+	if (tester_gap_padv_configure(ext_adv, &param) != 0) {
+		return BTP_STATUS_FAILED;
+	}
+
+	rp->current_settings = sys_cpu_to_le32(current_settings);
+
+	*rsp_len = sizeof(*rp);
+
+	return BTP_STATUS_SUCCESS;
+}
+#endif /* CONFIG_BT_PER_ADV_RSP */
+
 int tester_gap_padv_start(struct bt_le_ext_adv *ext_adv)
 {
 	int err;
@@ -3278,6 +3313,13 @@ static const struct btp_handler handlers[] = {
 		.func = padv_padv_sync_transfer_recv,
 	},
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER) */
+#if defined(CONFIG_BT_PER_ADV_RSP)
+	{
+		.opcode = BTP_GAP_PAWR_CONFIGURE,
+		.expect_len = sizeof(struct btp_gap_pawr_configure_cmd),
+		.func = pawr_configure,
+	},
+#endif /* defined(CONFIG_BT_PER_ADV_RSP) */
 #endif /* defined(CONFIG_BT_PER_ADV) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 #if defined(CONFIG_BT_RPA_TIMEOUT_DYNAMIC)


### PR DESCRIPTION
Extending PADV parameters for PAwR PTS test support. Also enabling CONFIG_BT_PER_ADV_RSP and CONFIG_BT_PER_ADV_SYNC_RSP for related test cases.

Required for following test cases:
GAP/PADV/PAM/BV-02-C
GAP/PADV/PASM/BV-02-C
GAP/PADV/PAST/BV-03-C
GAP/PADV/PAST/BV-04-C