### PR TITLE
include: drivers: biometrics: document driver operations using new Doxygen aliases

### DIFF
--- a/include/zephyr/drivers/biometrics.h
+++ b/include/zephyr/drivers/biometrics.h
@@ -140,105 +140,91 @@ struct biometric_capture_result {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{Biometrics,biometrics_interface}
+ * @{
  */
 
 /**
- * @typedef biometric_api_get_capabilities
- * @brief Callback API to get sensor capabilities
+ * @brief Callback API to get sensor capabilities.
  * See biometric_get_capabilities() for argument description
  */
 typedef int (*biometric_api_get_capabilities)(const struct device *dev,
 					      struct biometric_capabilities *caps);
 
 /**
- * @typedef biometric_api_attr_set
- * @brief Callback API to set a sensor attribute
- * See biometric_attr_set() for argument description
+ * @brief Callback API to set a sensor attribute.
+ * See biometric_attr_set() for argument description.
  */
 typedef int (*biometric_api_attr_set)(const struct device *dev, enum biometric_attribute attr,
 				      int32_t val);
 
 /**
- * @typedef biometric_api_attr_get
- * @brief Callback API to get a sensor attribute
+ * @brief Callback API to get a sensor attribute.
  * See biometric_attr_get() for argument description
  */
 typedef int (*biometric_api_attr_get)(const struct device *dev, enum biometric_attribute attr,
 				      int32_t *val);
 
 /**
- * @typedef biometric_api_enroll_start
- * @brief Callback API to start enrollment
+ * @brief Callback API to start enrollment.
  * See biometric_enroll_start() for argument description
  */
 typedef int (*biometric_api_enroll_start)(const struct device *dev, uint16_t template_id);
 
 /**
- * @typedef biometric_api_enroll_capture
- * @brief Callback API to capture enrollment samples
+ * @brief Callback API to capture enrollment samples.
  * See biometric_enroll_capture() for argument description
  */
 typedef int (*biometric_api_enroll_capture)(const struct device *dev, k_timeout_t timeout,
 					    struct biometric_capture_result *result);
 
 /**
- * @typedef biometric_api_enroll_finalize
- * @brief Callback API to finalize enrollment
+ * @brief Callback API to finalize enrollment.
  * See biometric_enroll_finalize() for argument description
  */
 typedef int (*biometric_api_enroll_finalize)(const struct device *dev);
 
 /**
- * @typedef biometric_api_enroll_abort
- * @brief Callback API to abort enrollment
+ * @brief Callback API to abort enrollment.
  * See biometric_enroll_abort() for argument description
  */
 typedef int (*biometric_api_enroll_abort)(const struct device *dev);
 
 /**
- * @typedef biometric_api_template_store
- * @brief Callback API to store template
+ * @brief Callback API to store template.
  * See biometric_template_store() for argument description
  */
 typedef int (*biometric_api_template_store)(const struct device *dev, uint16_t id,
 					    const uint8_t *data, size_t size);
 
 /**
- * @typedef biometric_api_template_read
- * @brief Callback API to read template data
+ * @brief Callback API to read template data.
  * See biometric_template_read() for argument description
  */
 typedef int (*biometric_api_template_read)(const struct device *dev, uint16_t id, uint8_t *data,
 					   size_t size);
 
 /**
- * @typedef biometric_api_template_delete
- * @brief Callback API to delete template
+ * @brief Callback API to delete template.
  * See biometric_template_delete() for argument description
  */
 typedef int (*biometric_api_template_delete)(const struct device *dev, uint16_t id);
 
 /**
- * @typedef biometric_api_template_delete_all
- * @brief Callback API to delete all templates
+ * @brief Callback API to delete all templates.
  * See biometric_template_delete_all() for argument description
  */
 typedef int (*biometric_api_template_delete_all)(const struct device *dev);
 
 /**
- * @typedef biometric_api_template_list
- * @brief Callback API to list template IDs
+ * @brief Callback API to list template IDs.
  * See biometric_template_list() for argument description
  */
 typedef int (*biometric_api_template_list)(const struct device *dev, uint16_t *ids,
 					   size_t max_count, size_t *actual_count);
 
 /**
- * @typedef biometric_api_match
- * @brief Callback API to start matching operation
+ * @brief Callback API to start matching operation.
  * See biometric_match() for argument description
  */
 typedef int (*biometric_api_match)(const struct device *dev, enum biometric_match_mode mode,
@@ -246,34 +232,75 @@ typedef int (*biometric_api_match)(const struct device *dev, enum biometric_matc
 				   struct biometric_match_result *result);
 
 /**
- * @typedef biometric_api_led_control
- * @brief Callback API to control LED state
+ * @brief Callback API to control LED state.
  * See biometric_led_control() for argument description
  */
 typedef int (*biometric_api_led_control)(const struct device *dev, enum biometric_led_state state);
 
 /**
- * @brief Biometric driver API
+ * @driver_ops{Biometrics}
  */
 __subsystem struct biometric_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_get_capabilities
+	 */
 	biometric_api_get_capabilities get_capabilities;
+	/**
+	 * @driver_ops_optional @copybrief biometric_attr_set
+	 */
 	biometric_api_attr_set attr_set;
+	/**
+	 * @driver_ops_optional @copybrief biometric_attr_get
+	 */
 	biometric_api_attr_get attr_get;
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_enroll_start
+	 */
 	biometric_api_enroll_start enroll_start;
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_enroll_capture
+	 */
 	biometric_api_enroll_capture enroll_capture;
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_enroll_finalize
+	 */
 	biometric_api_enroll_finalize enroll_finalize;
+	/**
+	 * @driver_ops_optional @copybrief biometric_enroll_abort
+	 */
 	biometric_api_enroll_abort enroll_abort;
+	/**
+	 * @driver_ops_optional @copybrief biometric_template_store
+	 */
 	biometric_api_template_store template_store;
+	/**
+	 * @driver_ops_optional @copybrief biometric_template_read
+	 */
 	biometric_api_template_read template_read;
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_template_delete
+	 */
 	biometric_api_template_delete template_delete;
+	/**
+	 * @driver_ops_optional @copybrief biometric_template_delete_all
+	 */
 	biometric_api_template_delete_all template_delete_all;
+	/**
+	 * @driver_ops_optional @copybrief biometric_template_list
+	 */
 	biometric_api_template_list template_list;
+	/**
+	 * @driver_ops_mandatory @copybrief biometric_match
+	 */
 	biometric_api_match match;
+	/**
+	 * @driver_ops_optional @copybrief biometric_led_control
+	 */
 	biometric_api_led_control led_control;
 };
 
 /**
- * @endcond
+ * @}
  */
 
 /**
@@ -458,6 +485,7 @@ static inline int z_impl_biometric_enroll_finalize(const struct device *dev)
  *
  * @retval 0 on success
  * @retval -EALREADY No enrollment in progress
+ * @retval -ENOSYS Not supported by device
  * @retval -errno code on failure
  */
 __syscall int biometric_enroll_abort(const struct device *dev);
@@ -581,6 +609,7 @@ static inline int z_impl_biometric_template_delete(const struct device *dev, uin
  * @param dev Pointer to the biometric device
  *
  * @retval 0 Success
+ * @retval -ENOSYS Not supported by device
  * @retval -errno Negative errno code on failure
  */
 __syscall int biometric_template_delete_all(const struct device *dev);


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional biometrics driver operations

https://builds.zephyrproject.io/zephyr/pr/104791/docs/doxygen/html/group__biometrics__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/104791/docs/doxygen/html/structbiometric__driver__api.html