### PR TITLE
cmake: break offsets.h dependency cycle with heap_constants.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,6 +1050,7 @@ set_source_files_properties(${OFFSETS_C_PATH} ${ZEPHYR_BASE}/lib/heap/heap_const
   PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
 
 target_sources(${OFFSETS_LIB} PRIVATE ${ZEPHYR_BASE}/lib/heap/heap_constants.c)
+target_compile_definitions(${OFFSETS_LIB} PRIVATE _ZEPHYR_OFFSETS_LIB)
 
 target_link_libraries(${OFFSETS_LIB} zephyr_interface)
 add_dependencies(zephyr_interface

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6112,7 +6112,7 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
  * Heap sizing constants computed at build time from actual struct layouts
  * in lib/heap/heap_constants.c via the gen_offset mechanism.
  */
-#if __has_include(<zephyr/offsets.h>)
+#if __has_include(<zephyr/offsets.h>) && !defined(_ZEPHYR_OFFSETS_LIB)
 #include <zephyr/offsets.h>
 #endif
 


### PR DESCRIPTION
Commit 518d8420c9d90e39 ("lib: heap: compute Z_HEAP_MIN_SIZE from actual
struct layouts") added heap_constants.c to the offsets library.  This
file includes kernel.h, which conditionally includes offsets.h via
`__has_include()`.  On first build offsets.h does not yet exist, so the
`__has_include` evaluates to false and there is no cycle.  However, after
a successful build offsets.h is present on disk.  A subsequent CMake
re-run (e.g. from touching .config or running menuconfig) causes ninja
to re-evaluate dependencies; the compiler now sees the existing
offsets.h, adding it as a dependency of heap_constants.c.obj and
creating a cycle:

  offsets.h -> heap_constants.c.obj -> offsets.h

Fix this by defining `_ZEPHYR_OFFSETS_LIB` when compiling the offsets
library and guarding the offsets.h inclusion in kernel.h so it is
skipped for sources that are part of the offsets generation itself.

Fixes: #104757
