### PR TITLE
soc: esp32c6: lp core gpio driver fixes and improvements

### DIFF
--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -6,13 +6,13 @@
 config GPIO_ESP32
 	bool "ESP32 GPIO"
 	default y
-	depends on DT_HAS_ESPRESSIF_ESP32_GPIO_ENABLED && !SOC_ESP32C6_LPCORE
+	depends on DT_HAS_ESPRESSIF_ESP32_GPIO_ENABLED
 	help
 	  Enables the ESP32 GPIO driver
 
 config LPGPIO_ESP32
 	bool "ESP32 Low Power GPIO"
 	default y
-	depends on DT_HAS_ESPRESSIF_ESP32_GPIO_ENABLED && SOC_ESP32C6_LPCORE
+	depends on DT_HAS_ESPRESSIF_ESP32_LPGPIO_ENABLED
 	help
 	  Enables the ESP32 GPIO driver

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -104,7 +104,7 @@
 		};
 
 		lp_gpio: gpio@600b2000 {
-			compatible = "espressif,esp32-gpio";
+			compatible = "espressif,esp32-lpgpio";
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x600b2000 DT_SIZE_K(4)>;

--- a/samples/boards/espressif/ulp/lp_core/gpio_wakeup/remote/boards/esp32c6_devkitc_lpcore.overlay
+++ b/samples/boards/espressif/ulp/lp_core/gpio_wakeup/remote/boards/esp32c6_devkitc_lpcore.overlay
@@ -17,3 +17,7 @@
 		};
 	};
 };
+
+&lp_gpio {
+	status = "okay";
+};

--- a/soc/espressif/common/Kconfig.console
+++ b/soc/espressif/common/Kconfig.console
@@ -56,6 +56,7 @@ config ESP_CONSOLE_USB_SERIAL_JTAG
 
 config ESP_CONSOLE_UART_NUM
 	int
+	default 0 if ESP32_ULP_HP_UART_CONSOLE_PRINT
 	default 0 if $(dt_nodelabel_enabled,uart0) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart0)
 	default 1 if $(dt_nodelabel_enabled,uart1) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart1)
 	default 2 if $(dt_nodelabel_enabled,uart2) && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CONSOLE)) = $(dt_nodelabel_reg_addr_hex,uart2)

--- a/soc/espressif/esp32c6/soc_lpcore.c
+++ b/soc/espressif/esp32c6/soc_lpcore.c
@@ -7,6 +7,7 @@
 #include <zephyr/toolchain.h>
 #include "soc/soc_caps.h"
 #include "ulp_lp_core_utils.h"
+#include "ulp_lp_core_interrupts.h"
 #include "ulp_lp_core_lp_timer_shared.h"
 #include "ulp_lp_core_memory_shared.h"
 #include <soc.h>
@@ -17,6 +18,12 @@ extern FUNC_NORETURN void z_cstart(void);
 void lp_core_startup(void)
 {
 	ulp_lp_core_update_wakeup_cause();
+
+	/* Enable LP core interrupts globally. The LP core has no interrupt
+	 * allocator, so this must be done once at startup for any peripheral
+	 * using the single interrupt vector.
+	 */
+	ulp_lp_core_intr_enable();
 
 	/* Start Zephyr kernel - runs device init (mbox, uart, etc.) then main() */
 	z_cstart();


### PR DESCRIPTION
- Fix lp_gpio Kconfig dependency to use proper DT_HAS_ESPRESSIF_ESP32_LPGPIO_ENABLED symbol instead of SOC_ESP32C6_LPCORE, and separate GPIO_ESP32 from LPGPIO_ESP32

- fix lp_gpio compatible string to espressif,esp32-lpgpio to match the corrected Kconfig dependency

- enable global LP core interrupts at startup via ulp_lp_core_intr_enable() in lp_core_startup(); the LP core has no interrupt allocator so this must be done once for any peripheral using the single interrupt vector

- enable lp_gpio in gpio_wakeup sample overlay

- fix ESP_CONSOLE_UART_NUM default for LP HP UART console