### PR TITLE
drivers: microchip: interrupt controller: Adds support for pic32cxsg boards

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -20,6 +20,7 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - interrupt_controller
   - pinctrl
   - pwm
   - reset

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -60,9 +60,15 @@
 		compatible = "gpio-keys";
 
 		button0: button_0 {
-			gpios = <&portb 19 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "SW1";
+			gpios = <&portd 00 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "SW 1";
 			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button1: button_1 {
+			gpios = <&portd 01 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "SW 2";
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 };
@@ -214,6 +220,10 @@
 };
 
 &portc {
+	status = "okay";
+};
+
+&portd {
 	status = "okay";
 };
 

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -20,6 +20,7 @@ supported:
   - gpio
   - hwinfo
   - i2c
+  - interrupt_controller
   - pinctrl
   - pwm
   - reset

--- a/drivers/interrupt_controller/intc_mchp_eic_g1.c
+++ b/drivers/interrupt_controller/intc_mchp_eic_g1.c
@@ -60,6 +60,8 @@ LOG_MODULE_REGISTER(intc_mchp_eic_g1, CONFIG_INTC_LOG_LEVEL);
 #define PORTD_SPECIAL_PINS_1_OFFSET DT_INST_PROP_BY_IDX(0, portd_special_pins_1, 1)
 #define PORTD_SPECIAL_PINS_2_OFFSET DT_INST_PROP_BY_IDX(0, portd_special_pins_2, 1)
 
+#define EIC_LINES_PER_PORT 16
+
 #define TIMEOUT_VALUE_US 1000
 #define DELAY_US         2
 
@@ -119,7 +121,7 @@ struct eic_mchp_dev_data {
  */
 uint8_t find_eic_line_from_pin(int port, int pin)
 {
-	uint8_t eic_line = pin % 16;
+	uint8_t eic_line = pin % EIC_LINES_PER_PORT;
 	uint32_t pin_mask = BIT(pin);
 
 	switch (port) {
@@ -303,21 +305,39 @@ int eic_mchp_config_interrupt(struct eic_config_params *eic_pin_config)
 		return -EBUSY;
 	}
 	eic_disable(eic_cfg->regs);
+	eic_sync_wait(eic_cfg->regs);
 
 	/* Configure the pin as input and connect it to eic peripheral */
 	eic_pin_config->port_addr->PORT_PINCFG[pin] |= PORT_PINCFG_PMUXEN(1) | PORT_PINCFG_INEN(1);
 	eic_pin_config->port_addr->PORT_PMUX[pmux_offset] &=
 		((pin & 1) == 0) ? (~PORT_PMUX_PMUXE_Msk) : (~PORT_PMUX_PMUXO_Msk);
 
-	/* - The bit position for respective eic line in the config
-	 * register is calculated and written into the respective config
-	 * register
-	 */
+/* The bit position for respective eic line in the config
+ * register is calculated and written into the respective config
+ * register
+ */
+#ifdef CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG
+	if (EIC_CONFIG_REG_IDX(eic_line) == 0) {
+		eic_cfg->regs->EIC_CONFIG0 &=
+			~(EIC_CONFIG_EIC_LINE_MSK << EIC_TRIG_TYPE_BIT_POS(eic_line));
+
+		eic_cfg->regs->EIC_CONFIG0 |=
+			((eic_pin_config->trig_type) << EIC_TRIG_TYPE_BIT_POS(eic_line));
+	} else {
+		eic_cfg->regs->EIC_CONFIG1 &=
+			~(EIC_CONFIG_EIC_LINE_MSK << EIC_TRIG_TYPE_BIT_POS(eic_line));
+
+		eic_cfg->regs->EIC_CONFIG1 |=
+			((eic_pin_config->trig_type) << EIC_TRIG_TYPE_BIT_POS(eic_line));
+	}
+#else
 	eic_cfg->regs->EIC_CONFIG[EIC_CONFIG_REG_IDX(eic_line)] &=
 		~(EIC_CONFIG_EIC_LINE_MSK << EIC_TRIG_TYPE_BIT_POS(eic_line));
 
 	eic_cfg->regs->EIC_CONFIG[EIC_CONFIG_REG_IDX(eic_line)] |=
 		((eic_pin_config->trig_type) << EIC_TRIG_TYPE_BIT_POS(eic_line));
+
+#endif /*CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG*/
 
 	/* Set the debouncing feature of the eic line if required */
 	if (eic_pin_config->debounce != 0) {
@@ -328,6 +348,7 @@ int eic_mchp_config_interrupt(struct eic_config_params *eic_pin_config)
 	enable_interrupt_line(eic_cfg->regs, eic_line);
 
 	eic_enable(eic_cfg->regs);
+	eic_sync_wait(eic_cfg->regs);
 
 	/*House keeping */
 	eic_data->line_busy |= BIT(eic_line);
@@ -362,7 +383,7 @@ static int eic_mchp_init(const struct device *dev)
 	if (eic_cfg->low_power_mode == true) {
 		eic_cfg->regs->EIC_CTRLA = EIC_CTRLA_CKSEL(EIC_CTRLA_CKSEL_CLK_ULP32K);
 	}
-	eic_cfg->regs->EIC_CTRLA |= EIC_CTRLA_ENABLE(EIC_CTRLA_ENABLE_Msk);
+	eic_enable(eic_cfg->regs);
 	eic_sync_wait(eic_cfg->regs);
 	LOG_DBG("EIC initialisation done 0x%p", eic_cfg->regs);
 

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -215,6 +215,7 @@
 			compatible = "microchip,port-g1-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			reg = <0x41008000 0x200>;
 			ranges = <0x41008000 0x41008000 0x200>;
 
 			porta: gpio@41008000 {

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -131,6 +131,35 @@
 			status = "disabled";
 		};
 
+		eic: interrupt-controller@40002800 {
+			compatible = "microchip,eic-g1-intc";
+			reg = <0x40002800 0x38>;
+			interrupts = <12 0>, <13 0>, <14 0>, <15 0>,
+				     <16 0>, <17 0>, <18 0>, <19 0>,
+				     <20 0>, <21 0>, <22 0>, <23 0>,
+				     <24 0>, <25 0>, <26 0>, <27 0>;
+			interrupt-names = "extint-0", "extint-1", "extint-2", "extint-3",
+					  "extint-4", "extint-5", "extint-6", "extint-7",
+					  "extint-8", "extint-9", "extint-10", "extint-11",
+					  "extint-12", "extint-13", "extint-14", "extint-15";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_EIC>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_EIC>;
+			clock-names = "mclk", "gclk";
+			low-power-mode;
+			/* Created this by listing down the mapping between eic lines and the port
+			 * and pin numbers available in the pic32cxsg family datasheet. The set
+			 * bits are commented beside the values
+			 */
+			porta-unsupported-pins = <0x34000300>; /*8|9|26|28|29*/
+			portc-unsupported-pins = <0x20004300>; /*8|9|14|29*/
+			portd-supported-pins = <0x301f03>; /*0|1|8|9|10|11|12|20|21*/
+
+			portb-special-pins-1 = <0x3c000000 0x2>; /*26|27|28|29*/
+			portc-special-pins-1 = <0x80 0x2>; /*7*/
+			portd-special-pins-1 = <0x1f00 0x5>; /*8|9|10|11|12*/
+			portd-special-pins-2 = <0x300000 0x6>; /*20|21*/
+		};
+
 		sercom0: sercom@40003000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x40003000 0x29>;

--- a/tests/drivers/gpio/gpio_basic_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*Connect PB08 and PB09*/
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&portb 8 0>;
+		in-gpios = <&portb 9 0>;
+	};
+};
+
+&portb {
+	status = "okay";
+};


### PR DESCRIPTION
- Adds reg of pinctrl node
- Add eic device tree node
- Updates the eic g1 driver to support pic32cx sg boards
- Updates the buttons pin and port of pic32cx_sg61_cult board
- Added pic32cx_sg overlay file for gpio_basic_api