### PR TITLE
Bluetooth: ISO: remove required_sec_level

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -887,6 +887,11 @@ Bluetooth Host
   with :kconfig:option:`CONFIG_BT_DEVICE_NAME_GATT_WRITABLE_AUTHEN`.
 * Replace any usage of :kconfig:option:`CONFIG_DEVICE_APPEARANCE_GATT_WRITABLE_AUTHEN`
   with :kconfig:option:`CONFIG_BT_DEVICE_APPEARANCE_GATT_WRITABLE_AUTHEN`.
+* The ``required_sec_level`` field has been removed from :c:struct:`bt_iso_chan`.
+  Applications that need to set security for CIS connections should call
+  :c:func:`bt_conn_set_security` on the ACL connection before calling
+  :c:func:`bt_iso_chan_connect`.
+* The ``sec_level`` field has been removed from :c:struct:`bt_iso_server`.
 
 Bluetooth Audio
 ===============

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -181,8 +181,6 @@ extern "C" {
 enum bt_iso_state {
 	/** Channel disconnected */
 	BT_ISO_STATE_DISCONNECTED,
-	/** Channel is pending ACL encryption before connecting */
-	BT_ISO_STATE_ENCRYPT_PENDING,
 	/** Channel in connecting state */
 	BT_ISO_STATE_CONNECTING,
 	/** Channel ready for upper layer traffic on it */
@@ -213,19 +211,6 @@ struct bt_iso_chan {
 	struct bt_iso_chan_qos		*qos;
 	/** Channel state */
 	enum bt_iso_state		state;
-#if (defined(CONFIG_BT_SMP) && defined(CONFIG_BT_ISO_UNICAST)) || defined(__DOXYGEN__)
-	/**
-	 * @brief The required security level of the channel
-	 *
-	 * This value can be set as the central before connecting a CIS
-	 * with bt_iso_chan_connect().
-	 * The value is overwritten to @ref bt_iso_server::sec_level for the
-	 * peripheral once a channel has been accepted.
-	 *
-	 * Only available when @kconfig{CONFIG_BT_SMP} is enabled.
-	 */
-	bt_security_t			required_sec_level;
-#endif /* CONFIG_BT_SMP && CONFIG_BT_ISO_UNICAST */
 	/** @internal Node used internally by the stack */
 	sys_snode_t node;
 };
@@ -794,15 +779,6 @@ struct bt_iso_accept_info {
 
 /** @brief ISO Server structure. */
 struct bt_iso_server {
-#if defined(CONFIG_BT_SMP) || defined(__DOXYGEN__)
-	/**
-	 * @brief Required minimum security level.
-	 *
-	 * Only available when @kconfig{CONFIG_BT_SMP} is enabled.
-	 */
-	bt_security_t		sec_level;
-#endif /* CONFIG_BT_SMP */
-
 	/**
 	 * @brief Server accept callback
 	 *

--- a/samples/bluetooth/iso_central/README.rst
+++ b/samples/bluetooth/iso_central/README.rst
@@ -12,8 +12,6 @@ The sample scans for a peripheral, establishes a connection, and sets up a conne
 Once the isochronous channel is connected, isochronous data is transferred to the peer device every 10 milliseconds.
 It is recommended to run this sample together with the :zephyr:code-sample:`ble_peripheral_iso` sample.
 
-To run the sample with an encrypted isochronous channel, enable :kconfig:option:`CONFIG_BT_SMP`.
-
 Requirements
 ************
 

--- a/samples/bluetooth/iso_central/src/main.c
+++ b/samples/bluetooth/iso_central/src/main.c
@@ -271,9 +271,6 @@ int main(void)
 
 	iso_chan.ops = &iso_ops;
 	iso_chan.qos = &iso_qos;
-#if defined(CONFIG_BT_SMP)
-	iso_chan.required_sec_level = BT_SECURITY_L2,
-#endif /* CONFIG_BT_SMP */
 
 	channels[0] = &iso_chan;
 	param.cis_channels = channels;

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -48,7 +48,6 @@ enum sdu_dir {
 #define DEFAULT_CIS_PACKING     0
 #define DEFAULT_CIS_FRAMING     0
 #define DEFAULT_CIS_COUNT       1U
-#define DEFAULT_CIS_SEC_LEVEL   BT_SECURITY_L1
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 #define DEFAULT_CIS_NSE          BT_ISO_NSE_MIN
@@ -428,9 +427,6 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 static struct bt_iso_server iso_server = {
-#if defined(CONFIG_BT_SMP)
-	.sec_level = DEFAULT_CIS_SEC_LEVEL,
-#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 

--- a/samples/bluetooth/iso_peripheral/src/main.c
+++ b/samples/bluetooth/iso_peripheral/src/main.c
@@ -160,9 +160,6 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 static struct bt_iso_server iso_server = {
-#if defined(CONFIG_BT_SMP)
-	.sec_level = BT_SECURITY_L1,
-#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -3183,7 +3183,6 @@ static int control_point_notify(struct bt_conn *conn, const void *data, uint16_t
 }
 
 static struct bt_iso_server iso_server = {
-	.sec_level = BT_SECURITY_L2,
 	.accept = ascs_iso_accept,
 };
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2574,9 +2574,6 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 {
 	reset_pairing(conn);
 	bt_l2cap_security_changed(conn, hci_err);
-	if (IS_ENABLED(CONFIG_BT_ISO_CENTRAL)) {
-		bt_iso_security_changed(conn, hci_err);
-	}
 
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->security_changed) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -557,8 +557,6 @@ const char *bt_iso_chan_state_str(uint8_t state)
 		return "disconnected";
 	case BT_ISO_STATE_CONNECTING:
 		return "connecting";
-	case BT_ISO_STATE_ENCRYPT_PENDING:
-		return "encryption pending";
 	case BT_ISO_STATE_CONNECTED:
 		return "connected";
 	case BT_ISO_STATE_DISCONNECTING:
@@ -579,8 +577,6 @@ void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, enum bt_iso_state sta
 	case BT_ISO_STATE_DISCONNECTED:
 		/* regardless of old state always allows this states */
 		break;
-	case BT_ISO_STATE_ENCRYPT_PENDING:
-		__fallthrough;
 	case BT_ISO_STATE_CONNECTING:
 		if (chan->state != BT_ISO_STATE_DISCONNECTED) {
 			LOG_WRN("%s()%d: invalid transition", func, line);
@@ -1123,17 +1119,6 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 		return -ENOTCONN;
 	}
 
-	if (chan->state == BT_ISO_STATE_ENCRYPT_PENDING) {
-		LOG_DBG("Channel already disconnected");
-		bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTED);
-
-		if (chan->ops->disconnected) {
-			chan->ops->disconnected(chan, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-		}
-
-		return 0;
-	}
-
 	if (chan->state == BT_ISO_STATE_DISCONNECTING) {
 		LOG_DBG("Already disconnecting");
 
@@ -1435,15 +1420,6 @@ int bt_iso_server_register(struct bt_iso_server *server)
 		return -EINVAL;
 	}
 
-#if defined(CONFIG_BT_SMP)
-	if (server->sec_level > BT_SECURITY_L3) {
-		return -EINVAL;
-	} else if (server->sec_level < BT_SECURITY_L1) {
-		/* Level 0 is only applicable for BR/EDR */
-		server->sec_level = BT_SECURITY_L1;
-	}
-#endif /* CONFIG_BT_SMP */
-
 	LOG_DBG("%p", server);
 
 	iso_server = server;
@@ -1489,10 +1465,6 @@ static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 		LOG_ERR("Server failed to accept: %d", err);
 		return err;
 	}
-
-#if defined(CONFIG_BT_SMP)
-	chan->required_sec_level = iso_server->sec_level;
-#endif /* CONFIG_BT_SMP */
 
 	bt_iso_chan_add(iso, chan);
 	bt_iso_chan_set_state(chan, BT_ISO_STATE_CONNECTING);
@@ -1545,30 +1517,12 @@ static int hci_le_accept_cis(uint16_t handle)
 	return 0;
 }
 
-static uint8_t iso_server_check_security(struct bt_conn *conn)
-{
-	if (IS_ENABLED(CONFIG_BT_CONN_DISABLE_SECURITY)) {
-		return BT_HCI_ERR_SUCCESS;
-	}
-
-#if defined(CONFIG_BT_SMP)
-	if (conn->sec_level >= iso_server->sec_level) {
-		return BT_HCI_ERR_SUCCESS;
-	}
-
-	return BT_HCI_ERR_INSUFFICIENT_SECURITY;
-#else
-	return BT_HCI_ERR_SUCCESS;
-#endif /* CONFIG_BT_SMP */
-}
-
 void hci_le_cis_req(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cis_req *evt = (void *)buf->data;
 	uint16_t acl_handle = sys_le16_to_cpu(evt->acl_handle);
 	uint16_t cis_handle = sys_le16_to_cpu(evt->cis_handle);
 	struct bt_conn *acl, *iso;
-	uint8_t sec_err;
 	int err;
 
 	LOG_DBG("acl_handle %u cis_handle %u cig_id %u cis %u", acl_handle, cis_handle, evt->cig_id,
@@ -1594,18 +1548,6 @@ void hci_le_cis_req(struct net_buf *buf)
 	if (!acl) {
 		LOG_ERR("Invalid ACL handle %u", acl_handle);
 		hci_le_reject_cis(cis_handle, BT_HCI_ERR_UNKNOWN_CONN_ID);
-		return;
-	}
-
-	sec_err = iso_server_check_security(acl);
-	if (sec_err != BT_HCI_ERR_SUCCESS) {
-		LOG_DBG("Insufficient security %u", sec_err);
-		err = hci_le_reject_cis(cis_handle, sec_err);
-		if (err != 0) {
-			LOG_ERR("Failed to reject CIS");
-		}
-
-		bt_conn_unref(acl);
 		return;
 	}
 
@@ -2363,96 +2305,6 @@ int bt_iso_cig_terminate(struct bt_iso_cig *cig)
 	return 0;
 }
 
-void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status)
-{
-	struct bt_iso_connect_param param[CONFIG_BT_ISO_MAX_CHAN];
-	size_t param_count;
-	int err;
-
-	/* The peripheral does not accept any ISO requests if security is
-	 * insufficient, so we only need to handle central here.
-	 * BT_ISO_STATE_ENCRYPT_PENDING is only set by the central.
-	 */
-	if (!IS_ENABLED(CONFIG_BT_CENTRAL) || acl->role != BT_CONN_ROLE_CENTRAL) {
-		return;
-	}
-
-	param_count = 0;
-	for (size_t i = 0; i < ARRAY_SIZE(iso_conns); i++) {
-		struct bt_conn *iso = &iso_conns[i];
-		struct bt_iso_chan *iso_chan;
-
-		if (iso == NULL || iso->iso.acl != acl) {
-			continue;
-		}
-
-		iso_chan = iso_chan(iso);
-		if (iso_chan->state != BT_ISO_STATE_ENCRYPT_PENDING) {
-			continue;
-		}
-
-		/* Set state to disconnected to indicate that we are no longer waiting for
-		 * encryption.
-		 * TODO: Remove the BT_ISO_STATE_ENCRYPT_PENDING state and replace with a flag to
-		 * avoid these unnecessary state changes
-		 */
-		bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_DISCONNECTED);
-
-		if (hci_status == BT_HCI_ERR_SUCCESS) {
-			param[param_count].acl = acl;
-			param[param_count].iso_chan = iso_chan;
-			param_count++;
-		} else {
-			LOG_DBG("Failed to encrypt ACL %p for ISO %p: %u %s", acl, iso, hci_status,
-				bt_hci_err_to_str(hci_status));
-
-			/* We utilize the disconnected callback to make the
-			 * upper layers aware of the error
-			 */
-			if (iso_chan->ops->disconnected) {
-				iso_chan->ops->disconnected(iso_chan, hci_status);
-			}
-		}
-	}
-
-	if (param_count == 0) {
-		/* Nothing to do for ISO. This happens if security is changed,
-		 * but no ISO channels were pending encryption.
-		 */
-		return;
-	}
-
-	err = hci_le_create_cis(param, param_count);
-	if (err != 0) {
-		LOG_ERR("Failed to connect CISes: %d", err);
-
-		for (size_t i = 0; i < param_count; i++) {
-			struct bt_iso_chan *iso_chan = param[i].iso_chan;
-
-			/* We utilize the disconnected callback to make the
-			 * upper layers aware of the error
-			 */
-			if (iso_chan->ops->disconnected) {
-				iso_chan->ops->disconnected(iso_chan, hci_status);
-			}
-		}
-
-		return;
-	}
-
-	/* Set connection states */
-	for (size_t i = 0; i < param_count; i++) {
-		struct bt_iso_chan *iso_chan = param[i].iso_chan;
-		struct bt_iso_cig *cig = get_cig(iso_chan);
-
-		__ASSERT(cig != NULL, "CIG was NULL");
-		cig->state = BT_ISO_CIG_STATE_ACTIVE;
-
-		bt_conn_set_state(iso_chan->iso, BT_CONN_INITIATING);
-		bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_CONNECTING);
-	}
-}
-
 static int hci_le_create_cis(const struct bt_iso_connect_param *param, size_t count)
 {
 	struct bt_hci_cis *cis;
@@ -2470,12 +2322,6 @@ static int hci_le_create_cis(const struct bt_iso_connect_param *param, size_t co
 
 	/* Program the cis parameters */
 	for (size_t i = 0; i < count; i++) {
-		struct bt_iso_chan *iso_chan = param[i].iso_chan;
-
-		if (iso_chan->state == BT_ISO_STATE_ENCRYPT_PENDING) {
-			continue;
-		}
-
 		cis = net_buf_add(buf, sizeof(*cis));
 
 		memset(cis, 0, sizeof(*cis));
@@ -2485,65 +2331,8 @@ static int hci_le_create_cis(const struct bt_iso_connect_param *param, size_t co
 		req->num_cis++;
 	}
 
-	/* If all CIS are pending for security, do nothing,
-	 * but return a recognizable return value
-	 */
-	if (req->num_cis == 0) {
-		net_buf_unref(buf);
-
-		return -ECANCELED;
-	}
-
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CIS, buf, NULL);
 }
-
-#if defined(CONFIG_BT_SMP)
-static int iso_chan_connect_security(const struct bt_iso_connect_param *param, size_t count)
-{
-	/* conn_idx_handled is an array of booleans for which conn indexes
-	 * already have been used to call bt_conn_set_security.
-	 * Using indexes avoids looping the array when checking if it has been
-	 * handled.
-	 */
-	bool conn_idx_handled[CONFIG_BT_MAX_CONN];
-
-	memset(conn_idx_handled, false, sizeof(conn_idx_handled));
-	for (size_t i = 0; i < count; i++) {
-		struct bt_iso_chan *iso_chan = param[i].iso_chan;
-		struct bt_conn *acl = param[i].acl;
-		uint8_t conn_idx = bt_conn_index(acl);
-
-		if (acl->sec_level < iso_chan->required_sec_level) {
-			if (!conn_idx_handled[conn_idx]) {
-				int err;
-
-				err = bt_conn_set_security(acl, iso_chan->required_sec_level);
-				if (err != 0) {
-					LOG_DBG("[%zu]: Failed to set security: %d", i, err);
-
-					/* Restore states */
-					for (size_t j = 0; j < i; j++) {
-						iso_chan = param[j].iso_chan;
-
-						bt_iso_cleanup_acl(iso_chan->iso);
-						bt_iso_chan_set_state(iso_chan,
-								      BT_ISO_STATE_DISCONNECTED);
-					}
-
-					return err;
-				}
-
-				conn_idx_handled[conn_idx] = true;
-			}
-
-			iso_chan->iso->iso.acl = bt_conn_ref(acl);
-			bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_ENCRYPT_PENDING);
-		}
-	}
-
-	return 0;
-}
-#endif /* CONFIG_BT_SMP */
 
 static bool iso_chans_connecting(void)
 {
@@ -2557,8 +2346,7 @@ static bool iso_chans_connecting(void)
 		}
 
 		iso_chan = iso_chan(iso);
-		if (iso_chan->state == BT_ISO_STATE_CONNECTING ||
-		    iso_chan->state == BT_ISO_STATE_ENCRYPT_PENDING) {
+		if (iso_chan->state == BT_ISO_STATE_CONNECTING) {
 			return true;
 		}
 	}
@@ -2619,23 +2407,8 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 		return -EBUSY;
 	}
 
-#if defined(CONFIG_BT_SMP)
-	/* Check for and initiate security for all channels that have
-	 * requested encryption if the ACL link is not already secured
-	 */
-	err = iso_chan_connect_security(param, count);
-	if (err != 0) {
-		LOG_DBG("Failed to initiate security for all CIS: %d", err);
-		return err;
-	}
-#endif /* CONFIG_BT_SMP */
-
 	err = hci_le_create_cis(param, count);
-	if (err == -ECANCELED) {
-		LOG_DBG("All channels are pending on security");
-
-		return 0;
-	} else if (err != 0) {
+	if (err != 0) {
 		LOG_DBG("Failed to connect CISes: %d", err);
 
 		return err;
@@ -2645,10 +2418,6 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 	for (size_t i = 0; i < count; i++) {
 		struct bt_iso_chan *iso_chan = param[i].iso_chan;
 		struct bt_iso_cig *cig;
-
-		if (iso_chan->state == BT_ISO_STATE_ENCRYPT_PENDING) {
-			continue;
-		}
 
 		iso_chan->iso->iso.acl = bt_conn_ref(param[i].acl);
 		bt_conn_set_state(iso_chan->iso, BT_CONN_INITIATING);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -116,9 +116,6 @@ void bt_iso_connected(struct bt_conn *iso);
 /* Notify ISO channels of a disconnect event */
 void bt_iso_disconnected(struct bt_conn *iso);
 
-/* Notify ISO connected channels of security changed */
-void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status);
-
 #if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
 void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan,
 				 enum bt_iso_state state,

--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -490,12 +490,6 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 
-#if defined(CONFIG_BT_SMP)
-	if (argc > 1) {
-		iso_chan.required_sec_level = *argv[1] - '0';
-	}
-#endif /* CONFIG_BT_SMP */
-
 	err = bt_iso_chan_connect(&connect_param, 1);
 	if (err) {
 		shell_error(sh, "Unable to connect (err %d)", err);
@@ -536,9 +530,6 @@ static int iso_accept(const struct bt_iso_accept_info *info, struct bt_iso_chan 
 }
 
 struct bt_iso_server iso_server = {
-#if defined(CONFIG_BT_SMP)
-	.sec_level = BT_SECURITY_L1,
-#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 
@@ -560,12 +551,6 @@ static int cmd_listen(const struct shell *sh, size_t argc, char *argv[])
 		shell_error(sh, "Invalid argument - use tx, rx or txrx");
 		return -ENOEXEC;
 	}
-
-#if defined(CONFIG_BT_SMP)
-	if (argc > 2) {
-		iso_server.sec_level = *argv[2] - '0';
-	}
-#endif /* CONFIG_BT_SMP */
 
 	err = bt_iso_server_register(&iso_server);
 	if (err) {
@@ -985,18 +970,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "[packing] [framing] [C to P latency] [P to C latency] [sdu] [phy] [rtn]",
 		      cmd_cig_create, 1, 10),
 	SHELL_CMD_ARG(cig_term, NULL, "Terminate the CIG", cmd_cig_term, 1, 0),
-#if defined(CONFIG_BT_SMP)
-	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel [security level]", cmd_connect, 1, 1),
-#else  /* !CONFIG_BT_SMP */
 	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel", cmd_connect, 1, 0),
-#endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BT_ISO_CENTRAL */
 #if defined(CONFIG_BT_ISO_PERIPHERAL)
-#if defined(CONFIG_BT_SMP)
-	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx> [security level]", cmd_listen, 2, 1),
-#else  /* !CONFIG_BT_SMP */
 	SHELL_CMD_ARG(listen, NULL, "<dir=tx,rx,txrx>", cmd_listen, 2, 0),
-#endif /* CONFIG_BT_SMP */
 #endif /* CONFIG_BT_ISO_PERIPHERAL */
 #if defined(CONFIG_BT_ISO_TX)
 	SHELL_CMD_ARG(send, NULL, "Send to ISO Channel [count]", cmd_send, 1, 1),

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -206,9 +206,6 @@ static void init(void)
 	for (size_t i = 0U; i < ARRAY_SIZE(iso_chans); i++) {
 		iso_chans[i].ops = &iso_ops;
 		iso_chans[i].qos = &iso_qos;
-#if defined(CONFIG_BT_SMP)
-		iso_chans[i].required_sec_level = BT_SECURITY_L2;
-#endif /* CONFIG_BT_SMP */
 	}
 }
 

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
@@ -137,9 +137,6 @@ static void init(void)
 		.sdu = CONFIG_BT_ISO_TX_MTU,
 	};
 	static struct bt_iso_server iso_server = {
-#if defined(CONFIG_BT_SMP)
-		.sec_level = BT_SECURITY_L2,
-#endif /* CONFIG_BT_SMP */
 		.accept = iso_accept,
 	};
 	static struct bt_iso_chan_ops iso_ops = {
@@ -162,9 +159,6 @@ static void init(void)
 
 	iso_chan.ops = &iso_ops;
 	iso_chan.qos = &iso_qos;
-#if defined(CONFIG_BT_SMP)
-	iso_chan.required_sec_level = BT_SECURITY_L2,
-#endif /* CONFIG_BT_SMP */
 
 	err = bt_iso_server_register(&iso_server);
 	if (err) {

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -437,9 +437,6 @@ static void test_cis_central(void)
 
 		iso_chan[i].ops = &iso_ops;
 		iso_chan[i].qos = &iso_qos[i];
-#if defined(CONFIG_BT_SMP)
-		iso_chan[i].required_sec_level = BT_SECURITY_L2,
-#endif /* CONFIG_BT_SMP */
 
 		channels[i] = &iso_chan[i];
 	}
@@ -684,9 +681,6 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 }
 
 static struct bt_iso_server iso_server = {
-#if defined(CONFIG_BT_SMP)
-	.sec_level = BT_SECURITY_L1,
-#endif /* CONFIG_BT_SMP */
 	.accept = iso_accept,
 };
 


### PR DESCRIPTION
Remove the required_sec_level for struct bt_iso_chan and all related automatic security machinery built around it (iso_chan_connect_security, bt_iso_security_changed, BT_ISO_STATE_ENCRYPT_PENDING and the CONFIG_BT_SMP checks in iso.c)

Applications can just call bt_conn_set_security() on the ACL connection before bt_iso_chan_connect() instead.

Fixes #104751