### PR TITLE
MAINTAINERS: add ZhiyuanTang17 as Realtek Bee maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4632,7 +4632,23 @@ Realtek Ameba Platforms:
     - dts/arm/realtek/ameba*/
     - dts/bindings/*/*ameba*
   labels:
-    - "platform: Ameba"
+    - "platform: Realtek Ameba"
+
+Realtek Bee Platforms:
+  status: maintained
+  maintainers:
+    - ZhiyuanTang17
+  files:
+    - boards/realtek/rtl87x2g*/
+    - boards/realtek/rtl8752h*/
+    - drivers/*/*bee*
+    - dts/arm/realtek/bee/
+    - dts/bindings/*/*bee*
+    - soc/realtek/bee/
+    - tests/boards/realtek/
+    - modules/hal_realtek/bee/
+  labels:
+    - "platform: Realtek Bee"
 
 Realtek EC Platforms:
   status: maintained


### PR DESCRIPTION
Add Realtek Bee Platforms section and assign ZhiyuanTang17 as the maintainer for related source files and documentation.

Nomination issue: https://github.com/zephyrproject-rtos/zephyr/issues/104811