### PR TITLE
net: ip: icmp: Change net_icmp_handler_t return type to enum net_verdict

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -933,6 +933,9 @@ Networking
   code cannot use POSIX APIs, then the relevant network API prefix needs to be added to the
   code calling a network API.
 
+* The return type of :c:type:`net_icmp_handler_t` has changed from ``int`` to
+  :c:enum:`net_verdict`. (:github:`104815`)
+
 * The enum for HTTP server transaction status has been renamed from ``http_data_status``
   to ``http_transaction_status`` to better reflect its purpose. The enum values have also been
   renamed as follows:

--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -51,12 +51,19 @@ struct net_icmp_ping_params;
  * @param ip_hdr IP header of the packet.
  * @param icmp_hdr ICMP header of the packet.
  * @param user_data A valid pointer to user data or NULL
+ *
+ * @retval NET_OK The packet was handled successfully and no further
+ *         handlers will be called.
+ * @retval NET_CONTINUE The packet was not handled by this handler
+ *         and should be passed to the next one.
+ * @retval NET_DROP The packet should be dropped and no further handlers
+ *         will be called.
  */
-typedef int (*net_icmp_handler_t)(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *ip_hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data);
+typedef enum net_verdict (*net_icmp_handler_t)(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *ip_hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data);
 
 /**
  * @typedef net_icmp_offload_ping_handler_t

--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -239,9 +239,9 @@ static void handle_ra_from_ot(const uint8_t *buffer, uint16_t buffer_length)
 	}
 }
 
-static int handle_icmp6_input(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
-			      struct net_icmp_ip_hdr *hdr,
-			      struct net_icmp_hdr *icmp_hdr, void *user_data)
+static enum net_verdict handle_icmp6_input(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
+					   struct net_icmp_ip_hdr *hdr,
+					   struct net_icmp_hdr *icmp_hdr, void *user_data)
 {
 	uint16_t length = net_pkt_get_len(pkt);
 	struct otbr_msg_ctx *req = NULL;
@@ -264,10 +264,10 @@ static int handle_icmp6_input(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
 
 exit:
 	if (error == OT_ERROR_NONE) {
-		return 0;
+		return NET_CONTINUE;
 	}
 
-	return -1;
+	return NET_DROP;
 }
 
 static void infra_if_handle_backbone_icmp6(struct otbr_msg_ctx *msg_ctx_ptr)

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -507,12 +507,12 @@ int net_icmp_send_echo_request_no_wait(struct net_icmp_ctx *ctx,
 						  K_NO_WAIT);
 }
 
-static int icmp_call_handlers(struct net_pkt *pkt,
-			      struct net_icmp_ip_hdr *ip_hdr,
-			      struct net_icmp_hdr *icmp_hdr)
+static enum net_verdict icmp_call_handlers(struct net_pkt *pkt,
+					   struct net_icmp_ip_hdr *ip_hdr,
+					   struct net_icmp_hdr *icmp_hdr)
 {
 	struct net_icmp_ctx *ctx;
-	int ret = -ENOENT;
+	enum net_verdict ret = NET_DROP;
 
 	k_mutex_lock(&lock, K_FOREVER);
 
@@ -531,22 +531,27 @@ static int icmp_call_handlers(struct net_pkt *pkt,
 			}
 
 			ret = ctx->handler(ctx, pkt, ip_hdr, icmp_hdr, ctx->user_data);
-			if (ret < 0) {
-				goto out;
+			if (ret == NET_CONTINUE) {
+				continue;
 			}
+
+			/**
+			 * Any handler returning NET_OK or NET_DROP has processed and
+			 * possibly modified the pkt
+			 */
+			break;
 		}
 	}
 
-out:
 	k_mutex_unlock(&lock);
 
 	return ret;
 }
 
 
-int net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
-				struct net_ipv4_hdr *ipv4_hdr,
-				struct net_icmp_hdr *icmp_hdr)
+enum net_verdict net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
+					     struct net_ipv4_hdr *ipv4_hdr,
+					     struct net_icmp_hdr *icmp_hdr)
 {
 	struct net_icmp_ip_hdr ip_hdr;
 
@@ -556,9 +561,9 @@ int net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
 	return icmp_call_handlers(pkt, &ip_hdr, icmp_hdr);
 }
 
-int net_icmp_call_ipv6_handlers(struct net_pkt *pkt,
-				struct net_ipv6_hdr *ipv6_hdr,
-				struct net_icmp_hdr *icmp_hdr)
+enum net_verdict net_icmp_call_ipv6_handlers(struct net_pkt *pkt,
+					     struct net_ipv6_hdr *ipv6_hdr,
+					     struct net_icmp_hdr *icmp_hdr)
 {
 	struct net_icmp_ip_hdr ip_hdr;
 

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -412,17 +412,20 @@ static int icmpv4_handle_header_options(struct net_pkt *pkt,
 }
 #endif
 
-static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
-				      struct net_pkt *pkt,
-				      struct net_icmp_ip_hdr *hdr,
-				      struct net_icmp_hdr *icmp_hdr,
-				      void *user_data)
+static enum net_verdict icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
+						   struct net_pkt *pkt,
+						   struct net_icmp_ip_hdr *hdr,
+						   struct net_icmp_hdr *icmp_hdr,
+						   void *user_data)
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
 	struct net_in_addr req_src, req_dst;
 	const struct net_in_addr *src;
+	struct net_pkt_cursor backup;
 	int16_t payload_len;
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	net_ipv4_addr_copy_raw(req_src.s4_addr, ip_hdr->src);
 	net_ipv4_addr_copy_raw(req_dst.s4_addr, ip_hdr->dst);
@@ -501,7 +504,8 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 
 	net_stats_update_icmp_sent(net_pkt_iface(reply));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 drop:
 	if (reply) {
 		net_pkt_unref(reply);
@@ -509,7 +513,7 @@ drop:
 
 	net_stats_update_icmp_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 }
 
 int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
@@ -614,7 +618,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
-	int ret;
+	enum net_verdict verdict;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {
@@ -644,9 +648,10 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 
 	net_stats_update_icmp_recv(net_pkt_iface(pkt));
 
-	ret = net_icmp_call_ipv4_handlers(pkt, ip_hdr, icmp_hdr);
-	if (ret < 0 && ret != -ENOENT) {
-		NET_ERR("ICMPv4 handling failure (%d)", ret);
+	verdict = net_icmp_call_ipv4_handlers(pkt, ip_hdr, icmp_hdr);
+	if (verdict == NET_DROP) {
+		NET_DBG("ICMPv4 handling failure");
+		goto drop;
 	}
 
 	net_pkt_unref(pkt);
@@ -665,11 +670,11 @@ drop:
  */
 #define MIN_IPV4_MTU NET_IPV4_MTU
 
-static int icmpv4_handle_dst_unreach(struct net_icmp_ctx *ctx,
-				     struct net_pkt *pkt,
-				     struct net_icmp_ip_hdr *hdr,
-				     struct net_icmp_hdr *icmp_hdr,
-				     void *user_data)
+static enum net_verdict icmpv4_handle_dst_unreach(struct net_icmp_ctx *ctx,
+						  struct net_pkt *pkt,
+						  struct net_icmp_ip_hdr *hdr,
+						  struct net_icmp_hdr *icmp_hdr,
+						  void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(dst_unreach_access,
 					      struct net_icmpv4_dest_unreach);
@@ -680,10 +685,13 @@ static int icmpv4_handle_dst_unreach(struct net_icmp_ctx *ctx,
 	struct net_sockaddr_in sockaddr_src = {
 		.sin_family = NET_AF_INET,
 	};
+	struct net_pkt_cursor backup;
 	uint16_t mtu;
 	int ret;
 
 	ARG_UNUSED(user_data);
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	dest_unreach_hdr = (struct net_icmpv4_dest_unreach *)
 		net_pkt_get_data(pkt, &dst_unreach_access);
@@ -743,19 +751,21 @@ static int icmpv4_handle_dst_unreach(struct net_icmp_ctx *ctx,
 			net_sprint_ipv4_addr(&ip_hdr->src), ret, mtu);
 	}
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 drop:
 	net_stats_update_ipv4_pmtu_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 
 silent_drop:
 	/* If the event is not really an error then just ignore it and
-	 * return 0 so that icmpv4 module will not complain about it.
+	 * return NET_CONTINUE so that icmpv4 module will not complain about it.
 	 */
 	net_stats_update_ipv4_pmtu_drop(net_pkt_iface(pkt));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 }
 
 static struct net_icmp_ctx dst_unreach_ctx;

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -96,20 +96,23 @@ int net_icmpv6_create(struct net_pkt *pkt, uint8_t icmp_type, uint8_t icmp_code)
 	return net_pkt_set_data(pkt, &icmp_access);
 }
 
-static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
-				      struct net_pkt *pkt,
-				      struct net_icmp_ip_hdr *hdr,
-				      struct net_icmp_hdr *icmp_hdr,
-				      void *user_data)
+static enum net_verdict icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
+						   struct net_pkt *pkt,
+						   struct net_icmp_ip_hdr *hdr,
+						   struct net_icmp_hdr *icmp_hdr,
+						   void *user_data)
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
 	struct net_in6_addr req_src, req_dst;
 	const struct net_in6_addr *src;
+	struct net_pkt_cursor backup;
 	int16_t payload_len;
 
 	ARG_UNUSED(user_data);
 	ARG_UNUSED(icmp_hdr);
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	net_ipv6_addr_copy_raw(req_src.s6_addr, ip_hdr->src);
 	net_ipv6_addr_copy_raw(req_dst.s6_addr, ip_hdr->dst);
@@ -179,7 +182,8 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 
 	net_stats_update_icmp_sent(net_pkt_iface(reply));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 
 drop:
 	if (reply) {
@@ -188,7 +192,7 @@ drop:
 
 	net_stats_update_icmp_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 }
 
 int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
@@ -349,7 +353,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
-	int ret;
+	enum net_verdict verdict;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {
@@ -374,9 +378,10 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 
 	net_stats_update_icmp_recv(net_pkt_iface(pkt));
 
-	ret = net_icmp_call_ipv6_handlers(pkt, ip_hdr, icmp_hdr);
-	if (ret < 0 && ret != -ENOENT) {
-		NET_ERR("ICMPv6 handling failure (%d)", ret);
+	verdict = net_icmp_call_ipv6_handlers(pkt, ip_hdr, icmp_hdr);
+	if (verdict == NET_DROP) {
+		NET_DBG("ICMPv6 handling failure");
+		goto drop;
 	}
 
 	net_pkt_unref(pkt);

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -406,19 +406,22 @@ drop:
 #define dbg_addr_recv(pkt_str, src, dst)	\
 	dbg_addr("Received", pkt_str, src, dst)
 
-static int handle_mld_query(struct net_icmp_ctx *ctx,
-			    struct net_pkt *pkt,
-			    struct net_icmp_ip_hdr *hdr,
-			    struct net_icmp_hdr *icmp_hdr,
-			    void *user_data)
+static enum net_verdict handle_mld_query(struct net_icmp_ctx *ctx,
+					 struct net_pkt *pkt,
+					 struct net_icmp_ip_hdr *hdr,
+					 struct net_icmp_hdr *icmp_hdr,
+					 void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(mld_access,
 					      struct net_icmpv6_mld_query);
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
 	uint16_t length = net_pkt_get_len(pkt);
 	struct net_icmpv6_mld_query *mld_query;
+	struct net_pkt_cursor backup;
 	uint16_t pkt_len;
 	int ret = -EIO;
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	if (net_pkt_remaining_data(pkt) < sizeof(struct net_icmpv6_mld_query)) {
 		/* MLDv1 query, drop. */
@@ -458,12 +461,20 @@ static int handle_mld_query(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	return send_mld_report(net_pkt_iface(pkt));
+	ret = send_mld_report(net_pkt_iface(pkt));
+	if (ret < 0) {
+		NET_DBG("DROP: failed to send MLD report (%d)", ret);
+		goto drop;
+	}
+
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 
 drop:
 	net_stats_update_ipv6_mld_drop(net_pkt_iface(pkt));
 
-	return ret;
+	net_pkt_cursor_restore(pkt, &backup);
+	return ret < 0 ? NET_DROP : NET_CONTINUE;
 }
 
 void net_ipv6_mld_init(void)

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1257,11 +1257,11 @@ static void ns_routing_info(struct net_pkt *pkt,
 	}
 }
 
-static int handle_ns_input(struct net_icmp_ctx *ctx,
-			   struct net_pkt *pkt,
-			   struct net_icmp_ip_hdr *hdr,
-			   struct net_icmp_hdr *icmp_hdr,
-			   void *user_data)
+static enum net_verdict handle_ns_input(struct net_icmp_ctx *ctx,
+					struct net_pkt *pkt,
+					struct net_icmp_ip_hdr *hdr,
+					struct net_icmp_hdr *icmp_hdr,
+					void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ns_access,
 					      struct net_icmpv6_ns_hdr);
@@ -1278,8 +1278,11 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 	struct net_in6_addr *tgt;
 	struct net_in6_addr ns_tgt, ns_src, ns_dst;
 	struct net_linkaddr src_lladdr;
+	struct net_pkt_cursor backup;
 
 	src_lladdr.len = 0;
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
 		goto drop;
@@ -1500,25 +1503,27 @@ send_na:
 
 	if (!net_ipv6_send_na(net_pkt_iface(pkt), na_src,
 			      na_dst, tgt, flags)) {
-		return 0;
+		net_pkt_cursor_restore(pkt, &backup);
+		return NET_CONTINUE;
 	}
 
 	NET_DBG("DROP: Cannot send NA");
 
-	return -EIO;
+	return NET_DROP;
 
 drop:
 	net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 
 silent_drop:
 	/* If the event is not really an error then just ignore it and
-	 * return 0 so that icmpv6 module will not complain about it.
+	 * return NET_CONTINUE so that icmpv6 module will not complain about it.
 	 */
 	net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 }
 #endif /* CONFIG_NET_IPV6_NBR_CACHE */
 
@@ -1880,11 +1885,11 @@ err:
 	return false;
 }
 
-static int handle_na_input(struct net_icmp_ctx *ctx,
-			   struct net_pkt *pkt,
-			   struct net_icmp_ip_hdr *hdr,
-			   struct net_icmp_hdr *icmp_hdr,
-			   void *user_data)
+static enum net_verdict handle_na_input(struct net_icmp_ctx *ctx,
+					struct net_pkt *pkt,
+					struct net_icmp_ip_hdr *hdr,
+					struct net_icmp_hdr *icmp_hdr,
+					void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(na_access,
 					      struct net_icmpv6_na_hdr);
@@ -1896,10 +1901,13 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 	struct net_icmpv6_na_hdr *na_hdr;
 	struct net_in6_addr na_tgt, na_dst;
 	struct net_if_addr *ifaddr;
+	struct net_pkt_cursor backup;
 
 	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
 		goto drop;
 	}
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	na_hdr = (struct net_icmpv6_na_hdr *)net_pkt_get_data(pkt, &na_access);
 	if (!na_hdr) {
@@ -1993,12 +2001,13 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 		net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 	}
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 
 drop:
 	net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 }
 
 int net_ipv6_send_ns(struct net_if *iface,
@@ -2613,11 +2622,11 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 }
 #endif
 
-static int handle_ra_input(struct net_icmp_ctx *ctx,
-			   struct net_pkt *pkt,
-			   struct net_icmp_ip_hdr *hdr,
-			   struct net_icmp_hdr *icmp_hdr,
-			   void *user_data)
+static enum net_verdict handle_ra_input(struct net_icmp_ctx *ctx,
+					struct net_pkt *pkt,
+					struct net_icmp_ip_hdr *hdr,
+					struct net_icmp_hdr *icmp_hdr,
+					void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ra_access,
 					      struct net_icmpv6_ra_hdr);
@@ -2631,12 +2640,15 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 	uint32_t mtu, reachable_time, retrans_timer;
 	uint16_t router_lifetime;
 	struct net_in6_addr ra_src;
+	struct net_pkt_cursor backup;
 
 	ARG_UNUSED(user_data);
 
 	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
 		goto drop;
 	}
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	ra_hdr = (struct net_icmpv6_ra_hdr *)net_pkt_get_data(pkt, &ra_access);
 	if (!ra_hdr) {
@@ -2847,21 +2859,22 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 	/* Cancel the RS timer on iface */
 	net_if_stop_rs(net_pkt_iface(pkt));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 
 drop:
 	net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 }
 #endif /* CONFIG_NET_IPV6_ND */
 
 #if defined(CONFIG_NET_IPV6_PMTU)
 /* Packet format described in RFC 4443 ch 3.2. Packet Too Big Message */
-static int handle_ptb_input(struct net_icmp_ctx *ctx,
-			    struct net_pkt *pkt,
-			    struct net_icmp_ip_hdr *hdr,
-			    struct net_icmp_hdr *icmp_hdr,
+static enum net_verdict handle_ptb_input(struct net_icmp_ctx *ctx,
+					 struct net_pkt *pkt,
+					 struct net_icmp_ip_hdr *hdr,
+					 struct net_icmp_hdr *icmp_hdr,
 			    void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ptb_access, struct net_icmpv6_ptb);
@@ -2872,10 +2885,13 @@ static int handle_ptb_input(struct net_icmp_ctx *ctx,
 		.sin6_family = NET_AF_INET6,
 	};
 	struct net_pmtu_entry *entry;
+	struct net_pkt_cursor backup;
 	uint32_t mtu;
 	int ret;
 
 	ARG_UNUSED(user_data);
+
+	net_pkt_cursor_backup(pkt, &backup);
 
 	ptb_hdr = (struct net_icmpv6_ptb *)net_pkt_get_data(pkt, &ptb_access);
 	if (!ptb_hdr) {
@@ -2932,19 +2948,21 @@ static int handle_ptb_input(struct net_icmp_ctx *ctx,
 			net_sprint_ipv6_addr(&ip_hdr->src), ret, mtu);
 	}
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 drop:
 	net_stats_update_ipv6_pmtu_drop(net_pkt_iface(pkt));
 
-	return -EIO;
+	return NET_DROP;
 
 silent_drop:
 	/* If the event is not really an error then just ignore it and
-	 * return 0 so that icmpv6 module will not complain about it.
+	 * return NET_CONTINUE so that icmpv6 module will not complain about it.
 	 */
 	net_stats_update_ipv6_pmtu_drop(net_pkt_iface(pkt));
 
-	return 0;
+	net_pkt_cursor_restore(pkt, &backup);
+	return NET_CONTINUE;
 }
 #endif /* CONFIG_NET_IPV6_PMTU */
 

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -66,12 +66,12 @@ extern void net_process_tx_packet(struct net_pkt *pkt);
 
 extern struct net_if_addr *net_if_ipv4_addr_get_first_by_index(int ifindex);
 
-extern int net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
-				       struct net_ipv4_hdr *ipv4_hdr,
-				       struct net_icmp_hdr *icmp_hdr);
-extern int net_icmp_call_ipv6_handlers(struct net_pkt *pkt,
-				       struct net_ipv6_hdr *ipv6_hdr,
-				       struct net_icmp_hdr *icmp_hdr);
+extern enum net_verdict net_icmp_call_ipv4_handlers(struct net_pkt *pkt,
+						    struct net_ipv4_hdr *ipv4_hdr,
+						    struct net_icmp_hdr *icmp_hdr);
+extern enum net_verdict net_icmp_call_ipv6_handlers(struct net_pkt *pkt,
+						    struct net_ipv6_hdr *ipv6_hdr,
+						    struct net_icmp_hdr *icmp_hdr);
 
 extern struct net_if *net_ipip_get_virtual_interface(struct net_if *input_iface);
 

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -799,11 +799,11 @@ static int dhcpv4_probe_address(struct dhcpv4_server_ctx *ctx,
 	return ret;
 }
 
-static int echo_reply_handler(struct net_icmp_ctx *icmp_ctx,
-			      struct net_pkt *pkt,
-			      struct net_icmp_ip_hdr *ip_hdr,
-			      struct net_icmp_hdr *icmp_hdr,
-			      void *user_data)
+static enum net_verdict echo_reply_handler(struct net_icmp_ctx *icmp_ctx,
+					   struct net_pkt *pkt,
+					   struct net_icmp_ip_hdr *ip_hdr,
+					   struct net_icmp_hdr *icmp_hdr,
+					   void *user_data)
 {
 	struct dhcpv4_server_ctx *ctx = user_data;
 	struct dhcpv4_server_probe_ctx *probe_ctx;
@@ -879,7 +879,7 @@ static int echo_reply_handler(struct net_icmp_ctx *icmp_ctx,
 out:
 	k_mutex_unlock(&server_lock);
 
-	return 0;
+	return NET_CONTINUE;
 }
 
 static int dhcpv4_server_probing_init(struct dhcpv4_server_ctx *ctx)

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -45,11 +45,11 @@ static void ping_done(struct ping_context *ctx);
 
 #if defined(CONFIG_NET_NATIVE_IPV6)
 
-static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data)
+static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmpv6_echo_req);
@@ -61,14 +61,14 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	icmp_echo = (struct net_icmpv6_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
 	if (icmp_echo == NULL) {
-		return -EIO;
+		return NET_DROP;
 	}
 
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
 
 	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
 		if (net_pkt_read_be32(pkt, &cycles)) {
-			return -EIO;
+			return NET_DROP;
 		}
 
 		cycles = k_cycle_get_32() - cycles;
@@ -104,14 +104,14 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	return 0;
+	return NET_OK;
 }
 #else
-static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data)
+static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);
@@ -119,17 +119,17 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	ARG_UNUSED(icmp_hdr);
 	ARG_UNUSED(user_data);
 
-	return -ENOTSUP;
+	return NET_CONTINUE;
 }
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_NATIVE_IPV4)
 
-static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data)
+static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmp_access,
 					      struct net_icmpv4_echo_req);
@@ -141,14 +141,14 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	icmp_echo = (struct net_icmpv4_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
 	if (icmp_echo == NULL) {
-		return -EIO;
+		return NET_DROP;
 	}
 
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
 
 	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
 		if (net_pkt_read_be32(pkt, &cycles)) {
-			return -EIO;
+			return NET_DROP;
 		}
 
 		cycles = k_cycle_get_32() - cycles;
@@ -178,14 +178,14 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	return 0;
+	return NET_OK;
 }
 #else
-static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data)
+static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);
@@ -193,7 +193,7 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	ARG_UNUSED(icmp_hdr);
 	ARG_UNUSED(user_data);
 
-	return -ENOTSUP;
+	return NET_CONTINUE;
 }
 #endif /* CONFIG_NET_IPV4 */
 

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -35,6 +35,7 @@ static struct ping_context {
 	/* Ping parameters */
 	uint32_t count;
 	uint32_t interval;
+	uint16_t identifier;
 	uint32_t sequence;
 	uint16_t payload_size;
 	uint8_t tos;
@@ -61,7 +62,12 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	icmp_echo = (struct net_icmpv6_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
 	if (icmp_echo == NULL) {
-		return NET_DROP;
+		return NET_CONTINUE;
+	}
+
+	if (net_ntohs(icmp_echo->identifier) != ping_ctx.identifier ||
+	    net_ntohs(icmp_echo->sequence) != ping_ctx.sequence) {
+		return NET_CONTINUE;
 	}
 
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
@@ -141,8 +147,14 @@ static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 	icmp_echo = (struct net_icmpv4_echo_req *)net_pkt_get_data(pkt,
 								&icmp_access);
 	if (icmp_echo == NULL) {
-		return NET_DROP;
+		return NET_CONTINUE;
 	}
+
+	if (net_ntohs(icmp_echo->identifier) != ping_ctx.identifier ||
+	    net_ntohs(icmp_echo->sequence) != ping_ctx.sequence) {
+		return NET_CONTINUE;
+	}
+
 
 	net_pkt_skip(pkt, sizeof(*icmp_echo));
 
@@ -251,6 +263,7 @@ static void ping_work(struct k_work *work)
 	struct net_icmp_ping_params params;
 	int ret;
 
+	ctx->identifier = sys_rand16_get();
 	ctx->sequence++;
 
 	if (ctx->sequence > ctx->count) {
@@ -265,7 +278,7 @@ static void ping_work(struct k_work *work)
 		k_work_reschedule(&ctx->work, K_SECONDS(2));
 	}
 
-	params.identifier = sys_rand32_get();
+	params.identifier = ctx->identifier;
 	params.sequence = ctx->sequence;
 	params.tc_tos = ctx->tos;
 	params.priority = ctx->priority;

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -761,11 +761,11 @@ static void tcp_upload_cb(enum zperf_status status,
 	}
 }
 
-static int ping_handler(struct net_icmp_ctx *ctx,
-			struct net_pkt *pkt,
-			struct net_icmp_ip_hdr *ip_hdr,
-			struct net_icmp_hdr *icmp_hdr,
-			void *user_data)
+static enum net_verdict ping_handler(struct net_icmp_ctx *ctx,
+				     struct net_pkt *pkt,
+				     struct net_icmp_ip_hdr *ip_hdr,
+				     struct net_icmp_hdr *icmp_hdr,
+				     void *user_data)
 {
 	struct k_sem *sem_wait = user_data;
 
@@ -776,7 +776,7 @@ static int ping_handler(struct net_icmp_ctx *ctx,
 
 	k_sem_give(sem_wait);
 
-	return 0;
+	return NET_CONTINUE;
 }
 
 static void send_ping(const struct shell *sh,

--- a/tests/boards/espressif/ethernet/src/main.c
+++ b/tests/boards/espressif/ethernet/src/main.c
@@ -56,8 +56,9 @@ static void ipv4_event(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
 	k_sem_give(&net_event);
 }
 
-static int icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt, struct net_icmp_ip_hdr *hdr,
-		      struct net_icmp_hdr *icmp_hdr, void *user_data)
+static enum net_verdict icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
+				   struct net_icmp_ip_hdr *hdr, struct net_icmp_hdr *icmp_hdr,
+				   void *user_data)
 {
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
 
@@ -65,7 +66,7 @@ static int icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt, struct net_
 
 	k_sem_give(&net_event);
 
-	return 0;
+	return NET_OK;
 }
 
 static void option_handler(struct net_dhcpv4_option_callback *cb, size_t length,

--- a/tests/boards/espressif/wifi/src/main.c
+++ b/tests/boards/espressif/wifi/src/main.c
@@ -116,8 +116,9 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint64_t
 	}
 }
 
-static int icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt, struct net_icmp_ip_hdr *hdr,
-		      struct net_icmp_hdr *icmp_hdr, void *user_data)
+static enum net_verdict icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt,
+				   struct net_icmp_ip_hdr *hdr, struct net_icmp_hdr *icmp_hdr,
+				   void *user_data)
 {
 	struct net_ipv4_hdr *ip_hdr = hdr->ipv4;
 	size_t hdr_offset = net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) +
@@ -144,7 +145,7 @@ static int icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt, struct net_
 sem_give:
 	k_sem_give(&wifi_event);
 
-	return 0;
+	return wifi_ctx.result == 0 ? NET_OK : NET_DROP;
 }
 
 static int wifi_scan(void)

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -810,11 +810,11 @@ ZTEST(net_chksum_offload, test_tx_chksum_offload_enabled_test_v4_udp_frag)
 	test_tx_chksum_udp_frag(NET_AF_INET, true);
 }
 
-static int dummy_icmp_handler(struct net_icmp_ctx *ctx,
-			      struct net_pkt *pkt,
-			      struct net_icmp_ip_hdr *hdr,
-			      struct net_icmp_hdr *icmp_hdr,
-			      void *user_data)
+static enum net_verdict dummy_icmp_handler(struct net_icmp_ctx *ctx,
+					   struct net_pkt *pkt,
+					   struct net_icmp_ip_hdr *hdr,
+					   struct net_icmp_hdr *icmp_hdr,
+					   void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);
@@ -822,7 +822,7 @@ static int dummy_icmp_handler(struct net_icmp_ctx *ctx,
 	ARG_UNUSED(icmp_hdr);
 	ARG_UNUSED(user_data);
 
-	return 0;
+	return NET_OK;
 }
 
 static void test_icmp_init(net_sa_family_t family, bool offloaded,
@@ -1162,11 +1162,11 @@ ZTEST(net_chksum_offload, test_tx_chksum_offload_enabled_test_v4_udp_frag_bad)
 	test_rx_chksum_udp_frag_bad(NET_AF_INET, true);
 }
 
-static int icmp_handler(struct net_icmp_ctx *ctx,
-			struct net_pkt *pkt,
-			struct net_icmp_ip_hdr *hdr,
-			struct net_icmp_hdr *icmp_hdr,
-			void *user_data)
+static enum net_verdict icmp_handler(struct net_icmp_ctx *ctx,
+				     struct net_pkt *pkt,
+				     struct net_icmp_ip_hdr *hdr,
+				     struct net_icmp_hdr *icmp_hdr,
+				     void *user_data)
 {
 	struct k_sem *wait_data = user_data;
 
@@ -1196,7 +1196,7 @@ static int icmp_handler(struct net_icmp_ctx *ctx,
 
 	k_sem_give(wait_data);
 
-	return 0;
+	return NET_OK;
 }
 
 static void test_rx_chksum_icmp_frag(net_sa_family_t family, bool offloaded)

--- a/tests/net/icmp/src/main.c
+++ b/tests/net/icmp/src/main.c
@@ -334,6 +334,7 @@ static int offload_ping_handler(struct net_icmp_ctx *ctx,
 	struct net_ipv4_hdr *ipv4_hdr;
 	struct net_ipv6_hdr *ipv6_hdr;
 	net_icmp_handler_t resp_handler;
+	enum net_verdict verdict;
 	int ret;
 
 	ret = net_icmp_get_offload_rsp_handler(icmp_offload_ctx, &resp_handler);
@@ -373,12 +374,13 @@ static int offload_ping_handler(struct net_icmp_ctx *ctx,
 		ip_hdr.ipv6 = ipv6_hdr;
 	}
 
-	ret = resp_handler(ctx, reply, &ip_hdr, icmp_hdr, user_data);
-	if (ret < 0) {
+	verdict = resp_handler(ctx, reply, &ip_hdr, icmp_hdr, user_data);
+	if (verdict != NET_OK) {
 		LOG_ERR("Cannot send response (%d)", ret);
+		return -EIO;
 	}
 
-	return ret;
+	return 0;
 }
 
 static void offload_iface_init(struct net_if *iface)
@@ -423,11 +425,11 @@ NET_DEVICE_OFFLOAD_INIT(test_offload, "test_offload", NULL, NULL, &offload_ctx, 
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &offload_api, 1500);
 #endif /* CONFIG_NET_OFFLOADING_SUPPORT */
 
-static int icmp_handler(struct net_icmp_ctx *ctx,
-			struct net_pkt *pkt,
-			struct net_icmp_ip_hdr *hdr,
-			struct net_icmp_hdr *icmp_hdr,
-			void *user_data)
+static enum net_verdict icmp_handler(struct net_icmp_ctx *ctx,
+				     struct net_pkt *pkt,
+				     struct net_icmp_ip_hdr *hdr,
+				     struct net_icmp_hdr *icmp_hdr,
+				     void *user_data)
 {
 	struct test_icmp_context *test = user_data;
 
@@ -445,13 +447,13 @@ static int icmp_handler(struct net_icmp_ctx *ctx,
 			net_sprint_ipv6_addr(&ip_hdr->src),
 			net_sprint_ipv6_addr(&ip_hdr->dst));
 	} else {
-		return -ENOENT;
+		return NET_CONTINUE;
 	}
 
 	test->req_received = true;
 	k_sem_give(&test->tx_sem);
 
-	return 0;
+	return NET_OK;
 }
 
 ZTEST(icmp_tests, test_icmpv6_echo_request)
@@ -624,15 +626,15 @@ ZTEST(icmp_tests, test_offload_icmpv6_echo_request)
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV6)
 static K_SEM_DEFINE(test_req_sem, 0, 1);
 
-static int icmp_request_handler(struct net_icmp_ctx *ctx,
-				struct net_pkt *pkt,
-				struct net_icmp_ip_hdr *hdr,
-				struct net_icmp_hdr *icmp_hdr,
-				void *user_data)
+static enum net_verdict icmp_request_handler(struct net_icmp_ctx *ctx,
+					     struct net_pkt *pkt,
+					     struct net_icmp_ip_hdr *hdr,
+					     struct net_icmp_hdr *icmp_hdr,
+					     void *user_data)
 {
 	k_sem_give(&test_req_sem);
 
-	return 0;
+	return NET_OK;
 }
 
 ZTEST(icmp_tests, test_malformed_icmpv6_echo_request_on_ipv4)

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -116,11 +116,11 @@ static uint8_t current = TEST_ICMPV4_UNKNOWN;
 static struct net_in_addr my_addr  = { { { 192, 0, 2, 1 } } };
 static struct net_if *net_iface;
 
-static int handle_reply_msg(struct net_icmp_ctx *ctx,
-			    struct net_pkt *pkt,
-			    struct net_icmp_ip_hdr *hdr,
-			    struct net_icmp_hdr *icmp_hdr,
-			    void *user_data)
+static enum net_verdict handle_reply_msg(struct net_icmp_ctx *ctx,
+					 struct net_pkt *pkt,
+					 struct net_icmp_ip_hdr *hdr,
+					 struct net_icmp_hdr *icmp_hdr,
+					 void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(hdr);
@@ -128,10 +128,10 @@ static int handle_reply_msg(struct net_icmp_ctx *ctx,
 	ARG_UNUSED(user_data);
 
 	if (net_pkt_get_len(pkt) != sizeof(icmpv4_echo_rep)) {
-		return -ENOMSG;
+		return NET_DROP;
 	}
 
-	return 0;
+	return NET_OK;
 }
 
 struct net_icmpv4_context {

--- a/tests/net/icmpv6/src/main.c
+++ b/tests/net/icmpv6/src/main.c
@@ -120,11 +120,11 @@ NET_DEVICE_INIT(net_icmpv6_test, "net_icmpv6_test",
 		&net_icmpv6_if_api, DUMMY_L2,
 		NET_L2_GET_CTX_TYPE(DUMMY_L2), 127);
 
-static int handle_test_msg(struct net_icmp_ctx *ctx,
-			   struct net_pkt *pkt,
-			   struct net_icmp_ip_hdr *hdr,
-			   struct net_icmp_hdr *icmp_hdr,
-			   void *user_data)
+static enum net_verdict handle_test_msg(struct net_icmp_ctx *ctx,
+					struct net_pkt *pkt,
+					struct net_icmp_ip_hdr *hdr,
+					struct net_icmp_hdr *icmp_hdr,
+					void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(hdr);
@@ -132,19 +132,17 @@ static int handle_test_msg(struct net_icmp_ctx *ctx,
 	ARG_UNUSED(user_data);
 
 	struct net_buf *last = net_buf_frag_last(pkt->buffer);
-	int ret;
 
 	if (last->len != ICMPV6_MSG_SIZE) {
 		handler_status = -EINVAL;
-		ret = -EINVAL;
-	} else {
-		handler_status = 0;
-		ret = 0;
+		handler_called++;
+		return NET_DROP;
 	}
 
+	handler_status = 0;
 	handler_called++;
 
-	return ret;
+	return NET_OK;
 }
 
 static struct net_pkt *create_pkt(uint8_t *data, int len,

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -2217,11 +2217,11 @@ static uint8_t ipv6_reass_frag2[] = {
 
 static uint16_t test_recv_payload_len = 1300U;
 
-static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
-				  struct net_pkt *pkt,
-				  struct net_icmp_ip_hdr *ip_hdr,
-				  struct net_icmp_hdr *icmp_hdr,
-				  void *user_data)
+static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
+					       struct net_pkt *pkt,
+					       struct net_icmp_ip_hdr *ip_hdr,
+					       struct net_icmp_hdr *icmp_hdr,
+					       void *user_data)
 {
 	const struct net_ipv6_hdr *hdr = NET_IPV6_HDR(pkt);
 	uint8_t verify_buf[NET_IPV6H_LEN];

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -529,11 +529,11 @@ static void leave_mldv2_capable_routers_group(void)
 }
 
 /* We are not really interested to parse the query at this point */
-static int handle_mld_query(struct net_icmp_ctx *ctx,
-			    struct net_pkt *pkt,
-			    struct net_icmp_ip_hdr *hdr,
-			    struct net_icmp_hdr *icmp_hdr,
-			    void *user_data)
+static enum net_verdict handle_mld_query(struct net_icmp_ctx *ctx,
+					 struct net_pkt *pkt,
+					 struct net_icmp_ip_hdr *hdr,
+					 struct net_icmp_hdr *icmp_hdr,
+					 void *user_data)
 {
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(pkt);


### PR DESCRIPTION
Update the return type of the ICMP callback handler to enum net_verdict.
This fixes an issue where currently all ICMP handler are passed the same
pkt. Handlers could have modified the passed packet resulting in undefined
behavior.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104781