### PR TITLE
lib: uuid: Promote UUID to unstable status

### DIFF
--- a/include/zephyr/sys/uuid.h
+++ b/include/zephyr/sys/uuid.h
@@ -23,8 +23,8 @@ extern "C" {
 
 /**
  * @defgroup uuid UUID
- * @since 4.0
- * @version 0.1.0
+ * @since 4.2
+ * @version 0.8.0
  * @ingroup utilities
  * @{
  */

--- a/lib/uuid/Kconfig
+++ b/lib/uuid/Kconfig
@@ -5,22 +5,19 @@
 menu "Universally Unique Identifier (UUID)"
 
 config UUID
-	bool "UUID support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "UUID support"
 	help
 	  Enable use of the UUID library.
 
 config UUID_V4
-	bool "UUID version 4 generation support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "UUID version 4 generation support"
 	depends on UUID
 	depends on ENTROPY_GENERATOR
 	help
 	  Enable generation of UUID v4.
 
 config UUID_V5
-	bool "UUID version 5 generation support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "UUID version 5 generation support"
 	depends on UUID
 	depends on MBEDTLS
 	depends on MBEDTLS_PSA_CRYPTO_C
@@ -34,8 +31,7 @@ config UUID_V5
 	  Enable generation of UUID v5.
 
 config UUID_BASE64
-	bool "UUID Base64 support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "UUID Base64 support"
 	depends on UUID
 	depends on BASE64
 	help


### PR DESCRIPTION
The UUID library has been present as an experimental library in the Zephyr code base since v4.2.
Since no need for major API changes has emerged in the last two Zephyr versions, the library can be safely promoted to unstable.

Furthermore, as long as the UUID remains experimental, its utility is limited as its adoption would roll back libraries to the experimental status. See, for example, #103817.