### PR TITLE
doc: _scripts: boards: always prefer exact filename match for board image

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -122,6 +122,7 @@ def guess_image(board_or_shield):
         prefix_matches.append(f"**/{partial_name}.{{ext}}")
 
     patterns = (
+        "**/{name}.{ext}",
         *prefix_matches,
         "**/*{name}*.{ext}",
         "**/*.{ext}",


### PR DESCRIPTION
`guess_image()` used `**/*{name}*.{ext}`, which matched auxiliary images (e.g. `rtl87x2g_evb_a-jlink-wiring.webp`, `rtl87x2g_evb_a-download-mode.webp`) as well as the main board image.

Add an exact-match pattern `**/{name}.{ext}` first so the main board image is always preferred.

Fixes zephyrproject-rtos/zephyr#104821

cc @ZhiyuanTang17
