### PR TITLE
soc: mcxw: Fix SWD debug/flash issue on MCXW72 target

### DIFF
--- a/boards/nxp/frdm_mcxw71/doc/index.rst
+++ b/boards/nxp/frdm_mcxw71/doc/index.rst
@@ -149,6 +149,26 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v3.7.0-xxx-xxxx ***
    Hello World! frdm_mcxw71/mcxw716c
 
+Entering ISP Mode
+=================
+
+To boot the MCU in ISP mode, follow these steps:
+
+   * Disconnect the ``FRDM-MCXW71`` board from all power sources.
+   * Keep the ``SW3`` button on the board pressed, while connecting
+     the board to the host computer USB port.
+   * Release the ``SW3`` button. The MCXW72 MCU boots in ISP mode.
+   * Reconnect any external power supply, if needed.
+
+Flashing with Low Power Mode
+============================
+
+When running an application with low power mode enabled (``CONFIG_PM=y``), flashing
+via the standard debug probe (MCU-Link or J-Link) may fail. This is because the
+MCU enters low power states where the SWD debug interface becomes unresponsive.
+
+To flash a board running a low power image, enter ISP mode (see ``Entering ISP Mode``).
+
 NBU Flashing
 ============
 
@@ -162,11 +182,7 @@ Two images must be written to the board: one for the host (CM33) and one for the
 - To flash the ``NBU Flashing``, follow the instructions below:
 
    * Install ``blhost`` from NXP's website. This is the tool that will allow you to flash the NBU.
-   * Enter ISP mode. To boot the MCU in ISP mode, follow these steps:
-      - Disconnect the ``FRDM-MCXW71`` board from all power sources.
-      - Keep the ``SW3`` (ISP) button on the board pressed, while connecting the board to the host computer USB port.
-      - Release the ``SW3`` (ISP) button. The MCXW71 MCU boots in ISP mode.
-      - Reconnect any external power supply, if needed.
+   * Enter ISP mode (see ``Entering ISP Mode``).
    * Use the following command to flash NBU file:
 
 .. tabs::

--- a/boards/nxp/frdm_mcxw72/doc/index.rst
+++ b/boards/nxp/frdm_mcxw72/doc/index.rst
@@ -143,6 +143,26 @@ should see the following message in the terminal:
    *** Booting Zephyr OS build v3.7.0-xxx-xxxx ***
    Hello World! frdm_mcxw72
 
+Entering ISP Mode
+=================
+
+To boot the MCU in ISP mode, follow these steps:
+
+   * Disconnect the ``FRDM-MCXW72`` board from all power sources.
+   * Keep the ``SW3`` button on the board pressed, while connecting
+     the board to the host computer USB port.
+   * Release the ``SW3`` button. The MCXW72 MCU boots in ISP mode.
+   * Reconnect any external power supply, if needed.
+
+Flashing with Low Power Mode
+============================
+
+When running an application with low power mode enabled (``CONFIG_PM=y``), flashing
+via the standard debug probe (MCU-Link or J-Link) may fail. This is because the
+MCU enters low power states where the SWD debug interface becomes unresponsive.
+
+To flash a board running a low power image, enter ISP mode (see ``Entering ISP Mode``).
+
 NBU Flashing
 ============
 
@@ -156,11 +176,7 @@ Two images must be written to the board: one for the host (CM33) and one for the
 - To flash the ``NBU Flashing``, follow the instructions below:
 
    * Install ``blhost`` from NXP's website. This is the tool that will allow you to flash the NBU.
-   * Enter ISP mode. To boot the MCU in ISP mode, follow these steps:
-      - Disconnect the ``FRDM-MCXW72`` board from all power sources.
-      - Keep the ``SW4`` and ``SW1`` buttons on the board pressed, while connecting the board to the host computer USB port.
-      - Release the ``SW4`` and ``SW1`` buttons. The MCXW72 MCU boots in ISP mode.
-      - Reconnect any external power supply, if needed.
+   * Enter ISP mode (see ``Entering ISP Mode``).
    * Use the following command to flash NBU file:
 
 .. tabs::

--- a/soc/nxp/mcx/mcxw/mcxw7xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/power.c
@@ -48,7 +48,6 @@ static void set_cmc_configuration(void)
 {
 	CMC_SetPowerModeProtection(MCXW7_CMC_ADDR, kCMC_AllowAllLowPowerModes);
 	CMC_LockPowerModeProtectionSetting(MCXW7_CMC_ADDR);
-	CMC_EnableDebugOperation(MCXW7_CMC_ADDR, IS_ENABLED(CONFIG_DEBUG));
 	CMC_ConfigFlashMode(MCXW7_CMC_ADDR, false, false, false);
 }
 

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -15,6 +15,9 @@
 #include <fsl_ccm32k.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
+#include <fsl_cmc.h>
+
+#define MCXW7_CMC_ADDR (CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 
 extern uint32_t SystemCoreClock;
 extern void nxp_nbu_init(void);
@@ -324,7 +327,7 @@ static int soc_nbu_init(void)
 {
 #if defined(CONFIG_NXP_NBU)
 	nxp_nbu_init();
-#else
+#elif defined(CONFIG_PM)
 	/* Shutdown NBU as not used */
 
 	/* Reset all RFMC registers and put the NBU CM3 in reset */
@@ -346,6 +349,11 @@ static int soc_nbu_init(void)
 	/* Force low power entry request to the radio domain */
 	RF_CMC1->RADIO_LP |= RF_CMC1_RADIO_LP_CK(0x2);
 	RFMC->RF2P4GHZ_CTRL |= RFMC_RF2P4GHZ_CTRL_LP_ENTER(0x1U);
+#endif
+#if !defined(CONFIG_SOC_MCXW716C)
+	/* Allow wakeup from the debugger */
+	RFMC->RF2P4GHZ_CFG |= RFMC_RF2P4GHZ_CFG_FORCE_DBG_PWRUP_ACK_MASK;
+	CMC_EnableDebugOperation(MCXW7_CMC_ADDR, true);
 #endif
 	return 0;
 }


### PR DESCRIPTION
Resolved an issue where repeated flash/debug cycles would fail, requiring the board to be placed in ISP mode before it could be programmed again.

https://github.com/zephyrproject-rtos/zephyr/issues/104780
