### PR TITLE
net: http: Allow user to turn off HTTP/1 or HTTP/2 in server

### DIFF
--- a/subsys/net/lib/http/CMakeLists.txt
+++ b/subsys/net/lib/http/CMakeLists.txt
@@ -11,9 +11,9 @@ zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 zephyr_library_sources_ifdef(CONFIG_HTTP_PARSER http_parser.c)
 zephyr_library_sources_ifdef(CONFIG_HTTP_PARSER_URL http_parser_url.c)
 zephyr_library_sources_ifdef(CONFIG_HTTP_CLIENT http_client.c)
-zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER
-  http_server_core.c
-  http_server_http1.c
+zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER http_server_core.c)
+zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER_VERSION_1 http_server_http1.c)
+zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER_VERSION_2
   http_server_http2.c
   http_hpack.c
   http_huffman.c

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -43,6 +43,27 @@ menuconfig HTTP_SERVER
 
 if HTTP_SERVER
 
+config HTTP_SERVER_VERSION_1
+	bool "HTTP/1.x support"
+	default y
+	help
+	  Support HTTP 1.x version.
+
+config HTTP_SERVER_VERSION_2
+	bool "HTTP/2 support"
+	default y
+	help
+	  Support HTTP/2 version.
+
+config HTTP_SERVER_VERSION
+	int
+	default 12 if HTTP_SERVER_VERSION_1 && HTTP_SERVER_VERSION_2
+	default 2 if !HTTP_SERVER_VERSION_1 && HTTP_SERVER_VERSION_2
+	default 1 if HTTP_SERVER_VERSION_1 && !HTTP_SERVER_VERSION_2
+	default 0
+	help
+	  What HTTP version is supported in HTTP server.
+
 config HTTP_SERVER_STACK_SIZE
 	int "HTTP server thread stack size"
 	default 4096 if FILE_SYSTEM

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -29,6 +29,9 @@ LOG_MODULE_REGISTER(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 #include "../../ip/net_private.h"
 #include "headers/server_internal.h"
 
+BUILD_ASSERT(CONFIG_HTTP_SERVER_VERSION > 0,
+	     "HTTP server requires at least HTTP/1.x or HTTP/2 support");
+
 #if defined(CONFIG_NET_TC_THREAD_COOPERATIVE)
 /* Lowest priority cooperative thread */
 #define THREAD_PRIORITY K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1)
@@ -461,11 +464,13 @@ static int handle_http_preface(struct http_client_ctx *client)
 		client->header_capture_ctx.status = HTTP_HEADER_STATUS_OK;
 	}
 
-	if (strncmp(client->cursor, HTTP2_PREFACE, sizeof(HTTP2_PREFACE) - 1) != 0) {
+	if (IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_1) &&
+	    strncmp(client->cursor, HTTP2_PREFACE, sizeof(HTTP2_PREFACE) - 1) != 0) {
 		return enter_http1_request(client);
 	}
 
-	return enter_http2_request(client);
+	return IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+		enter_http2_request(client) : -ENOTSUP;
 }
 
 static int handle_http_done(struct http_client_ctx *client)
@@ -495,40 +500,51 @@ static int handle_http_request(struct http_client_ctx *client)
 	do {
 		switch (client->server_state) {
 		case HTTP_SERVER_FRAME_DATA_STATE:
-			ret = handle_http_frame_data(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_data(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_PREFACE_STATE:
 			ret = handle_http_preface(client);
 			break;
 		case HTTP_SERVER_REQUEST_STATE:
-			ret = handle_http1_request(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_1) ?
+				handle_http1_request(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_HEADER_STATE:
-			ret = handle_http_frame_header(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_header(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_HEADERS_STATE:
-			ret = handle_http_frame_headers(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_headers(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_CONTINUATION_STATE:
-			ret = handle_http_frame_continuation(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_continuation(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_SETTINGS_STATE:
-			ret = handle_http_frame_settings(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_settings(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_WINDOW_UPDATE_STATE:
-			ret = handle_http_frame_window_update(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_window_update(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_RST_STREAM_STATE:
-			ret = handle_http_frame_rst_stream(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_rst_stream(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_GOAWAY_STATE:
-			ret = handle_http_frame_goaway(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_goaway(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_PRIORITY_STATE:
-			ret = handle_http_frame_priority(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_priority(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_FRAME_PADDING_STATE:
-			ret = handle_http_frame_padding(client);
+			ret = IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) ?
+				handle_http_frame_padding(client) : -ENOTSUP;
 			break;
 		case HTTP_SERVER_DONE_STATE:
 			ret = handle_http_done(client);

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -884,7 +884,8 @@ static int on_header_value(struct http_parser *parser,
 			}
 
 			if (ctx->has_upgrade_header) {
-				if (strcasecmp(ctx->header_buffer, "h2c") == 0) {
+				if (IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) &&
+				    strcasecmp(ctx->header_buffer, "h2c") == 0) {
 					ctx->http2_upgrade = true;
 				} else if (strcasecmp(ctx->header_buffer, "websocket") == 0) {
 					ctx->websocket_upgrade = true;
@@ -1081,7 +1082,7 @@ int handle_http1_request(struct http_client_ctx *client)
 			goto upgrade_not_found;
 		}
 
-		if (client->http2_upgrade) {
+		if (IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_2) && client->http2_upgrade) {
 			ret = handle_http1_to_http2_upgrade(client);
 			if (ret < 0) {
 				goto error;


### PR DESCRIPTION
If user does not need HTTP/1 or HTTP/2, then it is possible to turn off support for them.

While investigating HTTP/3 support, I noticed that we need a way to turn off other HTTP protocol versions.
