### PR TITLE
MAINTAINERS: Remove inactive networking collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3919,7 +3919,6 @@ Networking:
     - jukkar
   collaborators:
     - pdgendt
-    - ssharks
   files:
     - scripts/net/
     - drivers/net/


### PR DESCRIPTION
Remove @ssharks as collaborator due to inactivity.