### PR TITLE
drivers: ethernet: Remove NULL checks for iface initialization

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -273,12 +273,10 @@ static void e1000_iface_init(struct net_if *iface)
 	struct e1000_dev *dev = net_if_get_device(iface)->data;
 	const struct e1000_config *config = net_if_get_device(iface)->config;
 
-	if (dev->iface == NULL) {
-		dev->iface = iface;
+	dev->iface = iface;
 
-		/* Do the phy link up only once */
-		config->config_func(dev);
-	}
+	/* Do the phy link up only once */
+	config->config_func(dev);
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -798,9 +798,7 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 			     sizeof(context->mac_address),
 			     NET_LINK_ETHERNET);
 
-	if (context->iface == NULL) {
-		context->iface = iface;
-	}
+	context->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -358,9 +358,7 @@ static void eth_ivshmem_iface_init(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_ivshmem_dev_data *dev_data = dev->data;
 
-	if (dev_data->iface == NULL) {
-		dev_data->iface = iface;
-	}
+	dev_data->iface = iface;
 
 	net_if_set_link_addr(
 		iface, dev_data->mac_addr,

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -97,9 +97,7 @@ static void lan865x_iface_init(struct net_if *iface)
 
 	net_if_set_link_addr(iface, ctx->mac_address, sizeof(ctx->mac_address), NET_LINK_ETHERNET);
 
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -246,9 +246,7 @@ static void eth_iface_init(struct net_if *iface)
 	struct eth_litex_dev_data *context = port->data;
 
 	/* set interface */
-	if (context->iface == NULL) {
-		context->iface = iface;
-	}
+	context->iface = iface;
 
 	/* initialize ethernet L2 */
 	ethernet_init(iface);

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -515,9 +515,7 @@ static void eth_nxp_enet_iface_init(struct net_if *iface)
 			     sizeof(data->mac_addr),
 			     NET_LINK_ETHERNET);
 
-	if (data->iface == NULL) {
-		data->iface = iface;
-	}
+	data->iface = iface;
 
 #if defined(CONFIG_NET_DSA_DEPRECATED)
 	dsa_register_master_tx(iface, &eth_nxp_enet_tx);

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -92,9 +92,7 @@ static void eth_nxp_enet_qos_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, data->mac_addr.addr,
 			     sizeof(((struct net_eth_addr *)NULL)->addr), NET_LINK_ETHERNET);
 
-	if (data->iface == NULL) {
-		data->iface = iface;
-	}
+	data->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -294,9 +294,7 @@ static void eth_nxp_s32_iface_init(struct net_if *iface)
 	const struct eth_nxp_s32_config *cfg = dev->config;
 	struct eth_nxp_s32_data *ctx = dev->data;
 
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -164,14 +164,7 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	const struct nxp_s32_eth_config *cfg = dev->config;
 	const struct nxp_s32_eth_msix *msix;
 
-	/*
-	 * For VLAN, this value is only used to get the correct L2 driver.
-	 * The iface pointer in context should contain the main interface
-	 * if the VLANs are enabled.
-	 */
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	Netc_Eth_Ip_SetMacAddr(cfg->si_idx, (const uint8_t *)ctx->mac_addr);
 	net_if_set_link_addr(iface, ctx->mac_addr, sizeof(ctx->mac_addr), NET_LINK_ETHERNET);

--- a/drivers/ethernet/eth_nxp_s32_netc_vsi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_vsi.c
@@ -38,14 +38,7 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	const struct nxp_s32_eth_config *cfg = dev->config;
 	const struct nxp_s32_eth_msix *msix;
 
-	/*
-	 * For VLAN, this value is only used to get the correct L2 driver.
-	 * The iface pointer in context should contain the main interface
-	 * if the VLANs are enabled.
-	 */
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	Netc_Eth_Ip_SetMacAddr(cfg->si_idx, (const uint8_t *)ctx->mac_addr);
 	net_if_set_link_addr(iface, ctx->mac_addr, sizeof(ctx->mac_addr), NET_LINK_ETHERNET);

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -256,9 +256,7 @@ static void renesas_ra_eth_initialize(struct net_if *iface)
 
 	net_if_set_link_addr(iface, ctx->mac, sizeof(ctx->mac), NET_LINK_ETHERNET);
 
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1736,9 +1736,7 @@ static void eth_iface_init(struct net_if *iface)
 	int result;
 	int i;
 
-	if (dev_data->iface == NULL) {
-		dev_data->iface = iface;
-	}
+	dev_data->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -254,13 +254,10 @@ static void eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
-	bool is_first_init = false;
 
-	if (dev_data->iface == NULL) {
-		dev_data->iface = iface;
-		is_first_init = true;
-	}
+	dev_data->iface = iface;
 
 	/* Register Ethernet MAC Address with the upper layer */
 	net_if_set_link_addr(iface, dev_data->mac_addr,
@@ -285,23 +282,20 @@ static void eth_iface_init(struct net_if *iface)
 		LOG_ERR("PHY device not ready");
 	}
 
-	if (is_first_init) {
-		const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
-		/* Now that the iface is setup, we are safe to enable IRQs. */
-		__ASSERT_NO_MSG(cfg->config_func != NULL);
-		cfg->config_func();
+	/* Now that the iface is setup, we are safe to enable IRQs. */
+	__ASSERT_NO_MSG(cfg->config_func != NULL);
+	cfg->config_func();
 
-		/* Start interruption-poll thread */
-		k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,
-				K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack),
-				rx_thread, (void *) dev, NULL, NULL,
-				IS_ENABLED(CONFIG_ETH_STM32_HAL_RX_THREAD_PREEMPTIVE)
-					? K_PRIO_PREEMPT(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO)
-					: K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
-				0, K_NO_WAIT);
+	/* Start interruption-poll thread */
+	k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,
+			K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack),
+			rx_thread, (void *) dev, NULL, NULL,
+			IS_ENABLED(CONFIG_ETH_STM32_HAL_RX_THREAD_PREEMPTIVE)
+				? K_PRIO_PREEMPT(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO)
+				: K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
+			0, K_NO_WAIT);
 
-		k_thread_name_set(&dev_data->rx_thread, "stm_eth");
-	}
+	k_thread_name_set(&dev_data->rx_thread, "stm_eth");
 }
 
 static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -372,9 +372,7 @@ static void w5500_iface_init(struct net_if *iface)
 			     sizeof(ctx->mac_addr),
 			     NET_LINK_ETHERNET);
 
-	if (!ctx->iface) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -355,9 +355,7 @@ static void w6100_iface_init(struct net_if *iface)
 			     sizeof(ctx->mac_addr),
 			     NET_LINK_ETHERNET);
 
-	if (ctx->iface == NULL) {
-		ctx->iface = iface;
-	}
+	ctx->iface = iface;
 
 	ethernet_init(iface);
 

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -60,14 +60,7 @@ static void netc_eth_iface_init(struct net_if *iface)
 	const struct netc_eth_config *cfg = dev->config;
 	status_t result;
 
-	/*
-	 * For VLAN, this value is only used to get the correct L2 driver.
-	 * The iface pointer in context should contain the main interface
-	 * if the VLANs are enabled.
-	 */
-	if (data->iface == NULL) {
-		data->iface = iface;
-	}
+	data->iface = iface;
 
 	/* Set MAC address */
 	result = EP_SetPrimaryMacAddr(&data->handle, (uint8_t *)data->mac_addr);


### PR DESCRIPTION
WIth the rework of the vlan handeling, the iface init will only be executed once per instance, so we don't need that check anymore.