### PR TITLE
net: dns_resolve: Send query to all servers

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2139,11 +2139,10 @@ try_resolve:
 			continue;
 		}
 
-		/* Do one concurrent query only for each name resolve.
-		 * TODO: Change the i (query index) to do multiple concurrent
-		 *       to each server.
+		/* Send query to all configured DNS servers. The first valid
+		 * response will be used, subsequent responses are ignored
+		 * as the query slot will already be released.
 		 */
-		break;
 	}
 
 	if (nfail > 0) {


### PR DESCRIPTION
It's possible we succesfully send a DNS query, but get no response. For this reason, we don't want to stop iterating through DNS servers, but just send a DNS query to all configured servers.

This is safe because the response handler (dispatcher_cb) matches responses by dns_id and query_hash via get_slot_by_id(), regardless of which server responds. Once the first valid response arrives, release_query() sets the query pointer to NULL, and invoke_query_callback() checks for this before invoking the callback, so duplicate responses from other servers are safely ignored.