### PR TITLE
drivers: regulator: add VREFBUF support on STM32WB

### DIFF
--- a/drivers/regulator/regulator_stm32_vrefbuf.c
+++ b/drivers/regulator/regulator_stm32_vrefbuf.c
@@ -118,23 +118,26 @@ static int regulator_stm32_vrefbuf_get_voltage(const struct device *dev, int32_t
 static int regulator_stm32_vrefbuf_init(const struct device *dev)
 {
 	const struct regulator_stm32_vrefbuf_config *config = dev->config;
-	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	regulator_common_data_init(dev);
 
-	if (clock_control_on(clk, (clock_control_subsys_t)&config->pclken[0]) != 0) {
-		LOG_ERR("Could not enable clock");
-		return -EIO;
-	}
+	if (config->reset.dev != NULL) {
+		const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (!device_is_ready(config->reset.dev)) {
-		LOG_ERR("Reset controller not ready");
-		return -ENODEV;
-	}
+		if (clock_control_on(clk, (clock_control_subsys_t)&config->pclken[0]) != 0) {
+			LOG_ERR("Could not enable clock");
+			return -EIO;
+		}
 
-	if (reset_line_deassert_dt(&config->reset) != 0) {
-		LOG_ERR("Could not deassert reset line");
-		return -EIO;
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("Reset controller not ready");
+			return -ENODEV;
+		}
+
+		if (reset_line_deassert_dt(&config->reset) != 0) {
+			LOG_ERR("Could not deassert reset line");
+			return -EIO;
+		}
 	}
 
 	if (config->vrefp_output_enable) {
@@ -162,8 +165,8 @@ static DEVICE_API(regulator, api) = {
 	},
 
 #define REGULATOR_STM32_VREFBUF_DEFINE(inst)                                                       \
-	static struct regulator_stm32_vrefbuf_data data_##inst;                                    \
                                                                                                    \
+	static struct regulator_stm32_vrefbuf_data data_##inst;                                    \
 	static const struct regulator_stm32_vrefbuf_voltage ref_voltages_##inst[] = {              \
 		DT_FOREACH_PROP_ELEM(DT_DRV_INST(inst), ref_voltages, VREFBUF_VOLTAGE_ELEM)        \
 	};                                                                                         \
@@ -171,7 +174,7 @@ static DEVICE_API(regulator, api) = {
 	static const struct regulator_stm32_vrefbuf_config config_##inst = {                       \
 		.common = REGULATOR_DT_INST_COMMON_CONFIG_INIT(inst),                              \
 		.pclken = STM32_DT_INST_CLOCKS(inst),                                              \
-		.reset = RESET_DT_SPEC_GET(DT_DRV_INST(inst)),                                     \
+		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),                                     \
 		.vrefp_output_enable = DT_INST_PROP(inst, vrefp_output_enable),                    \
 		.ref_voltages = ref_voltages_##inst,                                               \
 		.ref_voltage_count = ARRAY_SIZE(ref_voltages_##inst),                              \

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -574,6 +574,13 @@
 			status = "disabled";
 		};
 
+		vrefbuf: vrefbuf@40010030 {
+			compatible = "st,stm32-vrefbuf";
+			reg = <0x40010030 0xd0>;
+			ref-voltages = <2048000>, <2500000>;
+			status = "disabled";
+		};
+
 		pwr: power@58000400 {
 			compatible = "st,stm32-pwr";
 			reg = <0x58000400 0x400>; /* PWR register bank */

--- a/dts/bindings/regulator/st,stm32-vrefbuf.yaml
+++ b/dts/bindings/regulator/st,stm32-vrefbuf.yaml
@@ -21,12 +21,6 @@ properties:
   reg:
     required: true
 
-  clocks:
-    required: true
-
-  resets:
-    required: true
-
   ref-voltages:
     type: array
     required: true
@@ -54,3 +48,11 @@ properties:
     description: |
       Enables the VREF+ output pin. VREF+ pin is in high-impedance state
       otherwise.
+
+  clocks:
+    type: phandle-array
+    description: Optional VREFBUF clock (present on some STM32 series).
+
+  resets:
+    type: phandle-array
+    description: Optional VREFBUF reset line (present on some STM32 series).


### PR DESCRIPTION
Extend the STM32 VREFBUF regulator driver to support STM32WB devices. Update the st,stm32-vrefbuf devicetree binding and add the VREFBUF node to the STM32WB SoC dtsi so that applications can enable the internal reference buffer on STM32WB.