### PR TITLE
drivers: display: st7796s: Add tear scanline configuration support

### DIFF
--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -48,6 +48,7 @@ struct st7796s_config {
 	uint8_t madctl; /* Memory data access control */
 	uint8_t te_mode; /* Tearing enable mode */
 	uint32_t te_delay; /* Tearing enable delay */
+	uint16_t te_scanline; /* Tear scanline */
 	bool rgb_is_inverted;
 };
 
@@ -288,6 +289,21 @@ static int st7796s_lcd_config(const struct device *dev)
 		return ret;
 	}
 
+	/* Configure tear scanline if specified */
+	if (config->te_scanline > 0) {
+		uint8_t scanline_params[2];
+
+		/* STE command takes two parameters: N15-N8 and N7-N0 */
+		scanline_params[0] = (config->te_scanline >> 8) & 0xFF; /* N15-N8 */
+		scanline_params[1] = config->te_scanline & 0xFF;        /* N7-N0 */
+
+		ret = st7796s_send_cmd(dev, ST7796S_CMD_STE, scanline_params,
+				       sizeof(scanline_params));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	/* Attempt to enable TE signal */
 	ret = mipi_dbi_configure_te(config->mipi_dbi, config->te_mode,
 				    config->te_delay);
@@ -422,6 +438,7 @@ static DEVICE_API(display, st7796s_api) = {
 		.rgb_is_inverted = DT_INST_PROP(n, rgb_is_inverted),		\
 		.te_mode = MIPI_DBI_TE_MODE_DT_INST(n, te_mode),                \
 		.te_delay = DT_INST_PROP(n, te_delay),                          \
+		.te_scanline = DT_INST_PROP(n, tear_scanline),                  \
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n, st7796s_init,					\

--- a/drivers/display/display_st7796s.h
+++ b/drivers/display/display_st7796s.h
@@ -19,6 +19,7 @@
 #define ST7796S_CMD_TEON	0x35 /* Tearing effect on */
 #define ST7796S_CMD_MADCTL	0x36 /* Memory data access control */
 #define ST7796S_CMD_COLMOD	0x3A /* Interface pixel format */
+#define ST7796S_CMD_STE         0x44 /* Set tear scanline */
 #define ST7796S_CMD_FRMCTR1	0xB1 /* Frame rate control 1 (normal mode) */
 #define ST7796S_CMD_FRMCTR2	0xB2 /* Frame rate control 2 (idle mode) */
 #define ST7796S_CMD_FRMCTR3	0xB3 /* Frame rate control 3 (partial mode) */

--- a/dts/bindings/display/sitronix,st7796s.yaml
+++ b/dts/bindings/display/sitronix,st7796s.yaml
@@ -117,3 +117,12 @@ properties:
       as the inverted value of the RGB pixel-format specified in MADCTL.
       This option is convenient for supporting displays with bugs
       where the actual color is different from the pixel format of MADCTL.
+
+  tear-scanline:
+    type: int
+    default: 0
+    description: |
+      Set Tear ScanLine (STE) command value. This configures the scanline
+      where the Tearing Effect (TE) signal becomes active. The value ranges
+      from 0 to 0xFFFF, representing the scanline number N where TE output
+      is generated. Default is 0 (TE signal disabled).


### PR DESCRIPTION
Add support for configuring the Set Tear ScanLine (STE) command in the ST7796S LCD display driver.
This allows users to specify the exact scanline where the Tearing Effect (TE) signal becomes active, providing better control over display synchronization.

Changes:
- Add `ST7796S_CMD_STE` (`0x44`) command definition
- Add `tear-scanline` property to device tree binding
- Add `tear_scanline` field to driver configuration structure
- Implement STE command configuration in LCD initialization

The tear scanline can now be configured via device tree or an overlay file:
```
&st7796s {
    tear-scanline = <240>; /* TE signal becomes active at scanline 240 */
    /* other properties... */
};
```

<img width="1195" height="646" alt="Screenshot from 2026-03-03 17-06-38" src="https://github.com/user-attachments/assets/869efd94-146f-4fff-9014-54921f85bec7" />
