### PR TITLE
net: lib: coap_client: Store destination address in request

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -143,6 +143,9 @@ struct coap_client_request {
 
 /** @cond INTERNAL_HIDDEN */
 struct coap_client_internal_request {
+	struct net_sockaddr_storage addr;
+	net_socklen_t addrlen;
+
 	uint8_t request_token[COAP_TOKEN_MAX_LEN];
 	uint32_t offset;
 	uint16_t last_id;
@@ -161,18 +164,21 @@ struct coap_client_internal_request {
 	bool is_observe;
 	int last_response_id;
 };
+/** @endcond */
 
+/**
+ * @brief Representation of a CoAP client.
+ */
 struct coap_client {
+	/** @cond INTERNAL_HIDDEN */
 	int fd;
-	struct net_sockaddr address;
-	net_socklen_t socklen;
 	struct k_mutex lock;
 	uint8_t recv_buf[MAX_COAP_MSG_LEN];
 	struct coap_client_internal_request requests[CONFIG_COAP_CLIENT_MAX_REQUESTS];
 	struct coap_option echo_option;
 	bool send_echo;
+	/** @endcond */
 };
-/** @endcond */
 
 /**
  * @brief Initialize the CoAP client.

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -30,8 +30,10 @@ static K_SEM_DEFINE(coap_client_recv_sem, 0, 1);
 
 static bool timeout_expired(struct coap_client_internal_request *internal_req);
 static void cancel_requests_with(struct coap_client *client, int error);
-static int recv_response(struct coap_client *client, struct coap_packet *response, bool *truncated);
-static int handle_response(struct coap_client *client, const struct coap_packet *response,
+static int recv_response(struct coap_client *client, struct net_sockaddr *addr,
+			 net_socklen_t *addrlen, struct coap_packet *response, bool *truncated);
+static int handle_response(struct coap_client *client, const struct net_sockaddr *addr,
+			   net_socklen_t addrlen, const struct coap_packet *response,
 			   bool response_truncated);
 static struct coap_client_internal_request *get_request_with_mid(struct coap_client *client,
 								 uint16_t mid);
@@ -441,32 +443,23 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 		goto release;
 	}
 
-	/* Don't allow changing to a different address if there is already request ongoing. */
-	if (addr != NULL) {
-		if (memcmp(&client->address, addr, sizeof(*addr)) != 0) {
-			if (has_ongoing_request(client)) {
-				LOG_WRN("Can't change to a different socket, request ongoing.");
-				ret = -EALREADY;
-				goto release;
-			}
-
-			memcpy(&client->address, addr, sizeof(*addr));
-			client->socklen = sizeof(client->address);
-		}
-	} else {
-		if (client->socklen != 0) {
-			if (has_ongoing_request(client)) {
-				LOG_WRN("Can't change to a different socket, request ongoing.");
-				ret = -EALREADY;
-				goto release;
-			}
-
-			memset(&client->address, 0, sizeof(client->address));
-			client->socklen = 0;
-		}
-	}
-
 	reset_internal_request(internal_req);
+
+	if (addr != NULL) {
+		switch (addr->sa_family) {
+		case NET_AF_INET:
+			internal_req->addrlen = sizeof(struct net_sockaddr_in);
+			break;
+		case NET_AF_INET6:
+			internal_req->addrlen = sizeof(struct net_sockaddr_in6);
+			break;
+		default:
+			ret = -ENOTSUP;
+			goto release;
+		}
+
+		memcpy(&internal_req->addr, addr, internal_req->addrlen);
+	}
 
 	ret = coap_client_init_request(client, req, internal_req);
 	if (ret < 0) {
@@ -487,7 +480,7 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 	coap_client_schedule_poll(client, sock, req, internal_req);
 
 	ret = coap_pending_init(&internal_req->pending, &internal_req->request,
-				&client->address, params);
+				net_sad(&internal_req->addr), params);
 
 	if (ret < 0) {
 		LOG_ERR("Failed to initialize pending struct");
@@ -505,7 +498,7 @@ int coap_client_req(struct coap_client *client, int sock, const struct net_socka
 	LOG_DBG("Request is_observe %d", internal_req->is_observe);
 
 	ret = send_request(sock, internal_req->request.data, internal_req->request.offset, 0,
-			  &client->address, client->socklen);
+			   net_sad(&internal_req->addr), internal_req->addrlen);
 	if (ret < 0) {
 		ret = -errno;
 	}
@@ -564,9 +557,9 @@ static int resend_request(struct coap_client *client,
 	    coap_pending_cycle(&internal_req->pending)) {
 		LOG_ERR("Timeout, retrying send");
 
-		ret = send_request(client->fd, internal_req->request.data,
-					internal_req->request.offset, 0, &client->address,
-					client->socklen);
+		ret = send_request(
+			client->fd, internal_req->request.data, internal_req->request.offset, 0,
+			net_sad(&internal_req->addr), internal_req->addrlen);
 		if (ret > 0) {
 			ret = 0;
 		} else if (ret == -EAGAIN) {
@@ -654,6 +647,8 @@ static int handle_poll(void)
 
 	for (int i = 0; i < nfds; i++) {
 		struct coap_client *client = get_client(fds[i].fd);
+		struct net_sockaddr_storage addr = {0};
+		net_socklen_t addrlen = sizeof(addr);
 
 		if (!client) {
 			LOG_ERR("No client found for socket %d", fds[i].fd);
@@ -667,7 +662,8 @@ static int handle_poll(void)
 			struct coap_packet response;
 			bool response_truncated = false;
 
-			ret = recv_response(client, &response, &response_truncated);
+			ret = recv_response(client, net_sad(&addr), &addrlen, &response,
+					    &response_truncated);
 			if (ret < 0) {
 				if (ret == -EAGAIN) {
 					continue;
@@ -678,7 +674,8 @@ static int handle_poll(void)
 			}
 
 			k_mutex_lock(&client->lock, K_FOREVER);
-			ret = handle_response(client, &response, response_truncated);
+			ret = handle_response(client, net_sad(&addr), addrlen, &response,
+					      response_truncated);
 			if (ret < 0) {
 				LOG_ERR("Error handling response");
 			}
@@ -702,7 +699,8 @@ static int handle_poll(void)
 	return 0;
 }
 
-static int recv_response(struct coap_client *client, struct coap_packet *response, bool *truncated)
+static int recv_response(struct coap_client *client, struct net_sockaddr *addr,
+			 net_socklen_t *addrlen, struct coap_packet *response, bool *truncated)
 {
 	int total_len;
 	int available_len;
@@ -714,8 +712,8 @@ static int recv_response(struct coap_client *client, struct coap_packet *respons
 	}
 
 	memset(client->recv_buf, 0, sizeof(client->recv_buf));
-	total_len = receive(client->fd, client->recv_buf, sizeof(client->recv_buf), flags,
-			    &client->address, &client->socklen);
+	total_len = receive(client->fd, client->recv_buf, sizeof(client->recv_buf), flags, addr,
+			    addrlen);
 
 	if (total_len < 0) {
 		ret = -errno;
@@ -738,8 +736,8 @@ static int recv_response(struct coap_client *client, struct coap_packet *respons
 	return ret;
 }
 
-static int send_ack(struct coap_client *client, const struct coap_packet *req,
-		    uint8_t response_code)
+static int send_ack(int sock_fd, const struct net_sockaddr *addr, net_socklen_t addrlen,
+		    const struct coap_packet *req, uint8_t response_code)
 {
 	int ret;
 	struct coap_packet ack;
@@ -751,7 +749,7 @@ static int send_ack(struct coap_client *client, const struct coap_packet *req,
 		return ret;
 	}
 
-	ret = send_request(client->fd, ack.data, ack.offset, 0, &client->address, client->socklen);
+	ret = send_request(sock_fd, ack.data, ack.offset, 0, addr, addrlen);
 	if (ret < 0) {
 		LOG_ERR("Error sending a CoAP ACK-message");
 		return ret;
@@ -760,7 +758,8 @@ static int send_ack(struct coap_client *client, const struct coap_packet *req,
 	return 0;
 }
 
-static int send_rst(struct coap_client *client, const struct coap_packet *req)
+static int send_rst(int sock_fd, const struct net_sockaddr *addr, net_socklen_t addrlen,
+		    const struct coap_packet *req)
 {
 	int ret;
 	struct coap_packet rst;
@@ -772,7 +771,7 @@ static int send_rst(struct coap_client *client, const struct coap_packet *req)
 		return ret;
 	}
 
-	ret = send_request(client->fd, rst.data, rst.offset, 0, &client->address, client->socklen);
+	ret = send_request(sock_fd, rst.data, rst.offset, 0, addr, addrlen);
 	if (ret < 0) {
 		LOG_ERR("Error sending a CoAP RST-message");
 		return ret;
@@ -828,7 +827,8 @@ static bool find_echo_option(const struct coap_packet *response, struct coap_opt
 	return coap_find_options(response, COAP_OPTION_ECHO, option, 1);
 }
 
-static int handle_response(struct coap_client *client, const struct coap_packet *response,
+static int handle_response(struct coap_client *client, const struct net_sockaddr *addr,
+			   net_socklen_t addrlen, const struct coap_packet *response,
 			   bool response_truncated)
 {
 	int ret = 0;
@@ -882,7 +882,7 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 		LOG_WRN("No matching request for response");
 		if (response_type != COAP_TYPE_ACK) {
 			/* Ignore errors, unrelated to our queries */
-			(void)send_rst(client, response);
+			(void)send_rst(client->fd, addr, addrlen, response);
 		}
 		return 0;
 	}
@@ -911,8 +911,8 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 				struct coap_transmission_parameters params =
 					internal_req->pending.params;
 				ret = coap_pending_init(&internal_req->pending,
-							&internal_req->request, &client->address,
-							&params);
+							&internal_req->request,
+							net_sad(&internal_req->addr), &params);
 				if (ret < 0) {
 					LOG_ERR("Error creating pending");
 					goto fail;
@@ -922,8 +922,8 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 			}
 
 			ret = send_request(client->fd, internal_req->request.data,
-					   internal_req->request.offset, 0, &client->address,
-					   client->socklen);
+					   internal_req->request.offset, 0,
+					   net_sad(&internal_req->addr), internal_req->addrlen);
 			if (ret < 0) {
 				LOG_ERR("Error sending a CoAP request");
 				goto fail;
@@ -939,7 +939,7 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 	/* Send ack for CON */
 	if (response_type == COAP_TYPE_CON) {
 		/* CON response is always a separate response, respond with empty ACK. */
-		ret = send_ack(client, response, COAP_CODE_EMPTY);
+		ret = send_ack(client->fd, addr, addrlen, response, COAP_CODE_EMPTY);
 		if (ret < 0) {
 			goto fail;
 		}
@@ -955,7 +955,7 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 
 	if (!internal_req->request_ongoing) {
 		if (internal_req->is_observe) {
-			(void) send_rst(client, response);
+			(void)send_rst(client->fd, addr, addrlen, response);
 			return 0;
 		}
 		LOG_DBG("Drop request, already handled");
@@ -1056,7 +1056,7 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 
 		struct coap_transmission_parameters params = internal_req->pending.params;
 		ret = coap_pending_init(&internal_req->pending, &internal_req->request,
-					&client->address, &params);
+					net_sad(&internal_req->addr), &params);
 		if (ret < 0) {
 			LOG_ERR("Error creating pending");
 			goto fail;
@@ -1064,8 +1064,8 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 		coap_pending_cycle(&internal_req->pending);
 
 		ret = send_request(client->fd, internal_req->request.data,
-				   internal_req->request.offset, 0, &client->address,
-				   client->socklen);
+				   internal_req->request.offset, 0, net_sad(&internal_req->addr),
+				   internal_req->addrlen);
 		if (ret < 0) {
 			LOG_ERR("Error sending a CoAP request");
 			goto fail;

--- a/tests/net/lib/coap_client/CMakeLists.txt
+++ b/tests/net/lib/coap_client/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/)
 target_compile_definitions(app PRIVATE _POSIX_C_SOURCE=200809L)
 
 add_compile_definitions(CONFIG_ZVFS_POLL_MAX=3)
-add_compile_definitions(CONFIG_COAP_CLIENT=y)
+add_compile_definitions(CONFIG_COAP_CLIENT=1)
 add_compile_definitions(CONFIG_COAP_CLIENT_BLOCK_SIZE=256)
 add_compile_definitions(CONFIG_COAP_CLIENT_MESSAGE_SIZE=256)
 add_compile_definitions(CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE=48)

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -65,7 +65,9 @@ static struct coap_client_request long_request = {
 	.len = sizeof(long_payload) - 1,
 	.user_data = &sem2,
 };
-static struct net_sockaddr dst_address;
+static struct net_sockaddr_storage dst_address = {
+	.ss_family = NET_AF_INET,
+};
 
 
 
@@ -522,7 +524,7 @@ ZTEST_SUITE(coap_client, NULL, suite_setup, test_setup, test_after, NULL);
 
 ZTEST(coap_client, test_get_request)
 {
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -532,7 +534,8 @@ ZTEST(coap_client, test_request_block)
 {
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_block;
 
-	zassert_equal(coap_client_req(&client, 0, &dst_address, &short_request, NULL), -EAGAIN, "");
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL),
+		      -EAGAIN, "");
 }
 
 ZTEST(coap_client, test_resend_request)
@@ -547,7 +550,7 @@ ZTEST(coap_client, test_resend_request)
 	SET_CUSTOM_FAKE_SEQ(z_impl_zsock_sendto, sendto_fakes, ARRAY_SIZE(sendto_fakes));
 	set_socket_events(client.fd, ZSOCK_POLLOUT);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 	k_sleep(K_MSEC(MORE_THAN_ACK_TIMEOUT_MS));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
@@ -559,7 +562,7 @@ ZTEST(coap_client, test_echo_option)
 {
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_echo;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -571,7 +574,7 @@ ZTEST(coap_client, test_echo_option_next_req)
 
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_echo_next_req;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -583,7 +586,7 @@ ZTEST(coap_client, test_echo_option_next_req)
 	req.len = strlen(payload);
 
 	LOG_INF("Send next request");
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -594,12 +597,12 @@ ZTEST(coap_client, test_get_no_path)
 	struct coap_client_request req = short_request;
 
 	req.path[0] = '\0';
-	zassert_equal(coap_client_req(&client, 0, &dst_address, &req, NULL), -EINVAL, "");
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL), -EINVAL, "");
 }
 
 ZTEST(coap_client, test_send_large_data)
 {
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &long_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &long_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -616,7 +619,7 @@ ZTEST(coap_client, test_no_response)
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 	set_socket_events(client.fd, ZSOCK_POLLOUT);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, &params));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, &params));
 
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
@@ -626,7 +629,7 @@ ZTEST(coap_client, test_separate_response)
 {
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_empty_ack;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -641,7 +644,7 @@ ZTEST(coap_client, test_separate_response_lost)
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_only_ack;
 	set_socket_events(client.fd, ZSOCK_POLLOUT);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(COAP_SEPARATE_TIMEOUT)));
 	zassert_equal(last_response_code, -ETIMEDOUT, "");
@@ -662,7 +665,7 @@ ZTEST(coap_client, test_separate_response_ack_fail)
 	SET_CUSTOM_FAKE_SEQ(z_impl_zsock_sendto, sendto_fakes, ARRAY_SIZE(sendto_fakes));
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_empty_ack;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(COAP_SEPARATE_TIMEOUT)));
 	zassert_equal(last_response_code, -ENETDOWN, "");
@@ -678,8 +681,8 @@ ZTEST(coap_client, test_multiple_requests)
 
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req1, NULL));
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req2, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req1, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req2, NULL));
 
 	set_socket_events(client.fd, ZSOCK_POLLIN);
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
@@ -702,7 +705,7 @@ ZTEST(coap_client, test_unmatching_tokens)
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_unmatching;
 	set_socket_events(client.fd, ZSOCK_POLLIN | ZSOCK_POLLOUT);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, &params));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, &params));
 
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -ETIMEDOUT, "Unexpected response");
@@ -716,8 +719,8 @@ ZTEST(coap_client, test_multiple_clients)
 	req1.user_data = &sem1;
 	req2.user_data = &sem2;
 
-	zassert_ok(coap_client_req(&client, client.fd, &dst_address, &req1, NULL));
-	zassert_ok(coap_client_req(&client2, client2.fd, &dst_address, &req2, NULL));
+	zassert_ok(coap_client_req(&client, client.fd, net_sad(&dst_address), &req1, NULL));
+	zassert_ok(coap_client_req(&client2, client2.fd, net_sad(&dst_address), &req2, NULL));
 
 	/* ensure we got both responses */
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
@@ -731,7 +734,7 @@ ZTEST(coap_client, test_poll_err)
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 	set_socket_events(client.fd, ZSOCK_POLLERR);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	k_sleep(K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS));
 	zassert_equal(last_response_code, -EIO, "Unexpected response");
@@ -742,7 +745,7 @@ ZTEST(coap_client, test_poll_err_after_response)
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 	set_socket_events(client.fd, ZSOCK_POLLIN);
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -762,8 +765,8 @@ ZTEST(coap_client, test_poll_err_on_another_sock)
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 	set_socket_events(client.fd, ZSOCK_POLLERR);
 
-	zassert_ok(coap_client_req(&client2, client2.fd, &dst_address, &req2, NULL));
-	zassert_ok(coap_client_req(&client, client.fd, &dst_address, &req1, NULL));
+	zassert_ok(coap_client_req(&client2, client2.fd, net_sad(&dst_address), &req2, NULL));
+	zassert_ok(coap_client_req(&client, client.fd, net_sad(&dst_address), &req1, NULL));
 
 	set_socket_events(client2.fd, ZSOCK_POLLIN);
 
@@ -778,7 +781,7 @@ ZTEST(coap_client, test_duplicate_response)
 	z_impl_zsock_recvfrom_fake.custom_fake =
 		z_impl_zsock_recvfrom_custom_fake_duplicate_response;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT, "Unexpected response");
@@ -808,7 +811,7 @@ ZTEST(coap_client, test_observe)
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_observe;
 
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
@@ -825,7 +828,7 @@ ZTEST(coap_client, test_request_rst)
 {
 	z_impl_zsock_recvfrom_fake.custom_fake = z_impl_zsock_recvfrom_custom_fake_rst;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &short_request, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &short_request, NULL));
 
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, -ECONNRESET, "");
@@ -841,8 +844,8 @@ ZTEST(coap_client, test_cancel)
 
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req1, NULL));
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req2, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req1, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req2, NULL));
 
 	k_sleep(K_SECONDS(1));
 
@@ -869,8 +872,8 @@ ZTEST(coap_client, test_cancel_match)
 
 	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_no_reply;
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req1, NULL));
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req2, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req1, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req2, NULL));
 
 	k_sleep(K_SECONDS(1));
 
@@ -882,7 +885,7 @@ ZTEST(coap_client, test_cancel_match)
 	zassert_not_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, -ECANCELED, "");
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req1, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req1, NULL));
 
 	/* should not match */
 	coap_client_cancel_request(&client, &(struct coap_client_request) {
@@ -899,8 +902,8 @@ ZTEST(coap_client, test_cancel_match)
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_ok(k_sem_take(&sem2, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req1, NULL));
-	zassert_ok(coap_client_req(&client, 0, &dst_address, &req2, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req1, NULL));
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req2, NULL));
 
 	/* match both (wildcard)*/
 	coap_client_cancel_request(&client, &(struct coap_client_request) {0});
@@ -926,16 +929,16 @@ ZTEST(coap_client, test_non_confirmable)
 	set_socket_events(client.fd, ZSOCK_POLLOUT);
 
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
-		zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+		zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 	}
-	zassert_equal(coap_client_req(&client, 0, &dst_address, &req, NULL), -EAGAIN, "");
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL), -EAGAIN, "");
 
 	k_sleep(K_MSEC(MORE_THAN_LONG_EXCHANGE_LIFETIME_MS));
 
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
-		zassert_ok(coap_client_req(&client, 0, &dst_address, &req, NULL));
+		zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
 	}
-	zassert_equal(coap_client_req(&client, 0, &dst_address, &req, NULL), -EAGAIN, "");
+	zassert_equal(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL), -EAGAIN, "");
 
 	/* No callbacks from non-confirmable */
 	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));


### PR DESCRIPTION
A CoAP client should not be limited to a single destination address for all requests.
Store the destination address for each request or use the existing socket directly.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/104845