### PR TITLE
subsys/fs/fuse: Avoid using libC defined types in interface

### DIFF
--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -146,40 +146,40 @@ static int ffa_release_top(uint64_t fh)
 	return 0;
 }
 
-static int ffa_read_top(uint64_t fh, char *buf, size_t size, off_t off)
+static int ffa_read_top(uint64_t fh, char *buf, uint64_t size, int64_t off)
 {
 	int err;
 
-	err = fs_seek(&files[fh], off, FS_SEEK_SET);
+	err = fs_seek(&files[fh], (off_t)off, FS_SEEK_SET);
 
 	if (err == 0) {
-		err = fs_read(&files[fh], buf, size);
+		err = fs_read(&files[fh], buf, (size_t)size);
 	}
 
 	return nsi_errno_to_mid(-err);
 }
 
-static int ffa_write_top(uint64_t fh, const char *buf, size_t size, off_t off)
+static int ffa_write_top(uint64_t fh, const char *buf, uint64_t size, int64_t off)
 {
 	int err;
 
-	err = fs_seek(&files[fh], off, FS_SEEK_SET);
+	err = fs_seek(&files[fh], (off_t)off, FS_SEEK_SET);
 
 	if (err == 0) {
-		err = fs_write(&files[fh], buf, size);
+		err = fs_write(&files[fh], buf, (size_t)size);
 	}
 
 	return nsi_errno_to_mid(-err);
 }
 
-static int ffa_ftruncate_top(uint64_t fh, off_t size)
+static int ffa_ftruncate_top(uint64_t fh, int64_t size)
 {
-	int err = fs_truncate(&files[fh], size);
+	int err = fs_truncate(&files[fh], (off_t)size);
 
 	return nsi_errno_to_mid(-err);
 }
 
-static int ffa_truncate_top(const char *path, off_t size)
+static int ffa_truncate_top(const char *path, int64_t size)
 {
 	int err;
 	static struct fs_file_t file;
@@ -189,7 +189,7 @@ static int ffa_truncate_top(const char *path, off_t size)
 		return nsi_errno_to_mid(-err);
 	}
 
-	err = fs_truncate(&file, size);
+	err = fs_truncate(&file, (off_t)size);
 	if (err != 0) {
 		fs_close(&file);
 	} else {

--- a/subsys/fs/fuse_fs_access_bottom.c
+++ b/subsys/fs/fuse_fs_access_bottom.c
@@ -74,17 +74,17 @@ struct {
 
 struct op_args_truncate {
 	const char *path;
-	off_t size;
+	int64_t size;
 };
 struct op_args_ftruncate {
 	uint64_t fh;
-	off_t size;
+	int64_t size;
 };
 struct op_args_readwrite {
 	uint64_t fh;
 	char *buf;
-	off_t size;
-	off_t off;
+	uint64_t size;
+	int64_t off;
 };
 struct op_args_create {
 	const char *path;

--- a/subsys/fs/fuse_fs_access_bottom.h
+++ b/subsys/fs/fuse_fs_access_bottom.h
@@ -16,9 +16,9 @@ extern "C" {
 #define INVALID_FILE_HANDLE (INT32_MAX)
 
 struct ffa_dirent {
-	bool is_directory;
+	uint64_t size;
 	char *name;
-	size_t size;
+	bool is_directory;
 };
 
 struct ffa_op_callbacks {
@@ -30,10 +30,10 @@ struct ffa_op_callbacks {
 	int (*mkdir)(const char *path);
 	int (*create)(const char *path, uint64_t *fh);
 	int (*release)(uint64_t fh);
-	int (*read)(uint64_t fh, char *buf, size_t size, off_t off);
-	int (*write)(uint64_t fh, const char *buf, size_t size, off_t off);
-	int (*ftruncate)(uint64_t fh, off_t size);
-	int (*truncate)(const char *path, off_t size);
+	int (*read)(uint64_t fh, char *buf, uint64_t size, int64_t off);
+	int (*write)(uint64_t fh, const char *buf, uint64_t size, int64_t off);
+	int (*ftruncate)(uint64_t fh, int64_t size);
+	int (*truncate)(const char *path, int64_t size);
 	int (*unlink)(const char *path);
 	int (*rmdir)(const char *path);
 };


### PR DESCRIPTION
Let's avoid using off_t in the interface between the embedded and the host side of the FUSE driver.
off_t is a C library defined type and as such can have different sizes between the host C library and the embedded C library.

While at it, let's do also the same with size_t. Even though size_t is meant to be defined in stddef.h which is provided by the compiler, it is possible to override it in the embedded side.

We just replace them with a 64 bit type for each (signed and unsigned respectively matching the signedness of off_t and size_t).

There was a bug in the queue arg type for the read/write, which had the second parameter as off_t while it should have been size_t, which is now fixed to be uint64_t.

And a triviality: `ffa_dirent` is reordered so there should be less padding between members anymore.