### PR TITLE
doc: conf.py: exclude EOL release notes and migration guides from build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -109,6 +109,16 @@ templates_path = ["_templates"]
 
 exclude_patterns = ["_build"]
 
+# EOL release notes and migration guides are not built (to avoid dead links etc.)
+RELEASE_NOTES_GLOB_PATTERNS = [
+    "releases/release-notes-[12].*.rst",
+    "releases/release-notes-3.[0-6].rst",
+    "releases/release-notes-4.[01].rst",
+    "releases/migration-guide-3.[56].rst",
+    "releases/migration-guide-4.[01].rst",
+]
+exclude_patterns.extend(RELEASE_NOTES_GLOB_PATTERNS)
+
 if not west_found:
     exclude_patterns.append("**/*west-apis*")
 else:
@@ -280,7 +290,14 @@ doxybridge_projects = {"zephyr": doxyrunner_projects["zephyr"]["outdir"]}
 
 # -- Options for html_redirect plugin -------------------------------------
 
-html_redirect_pages = redirects.REDIRECTS
+html_redirect_pages = (
+    *redirects.REDIRECTS,
+    *(
+        (f"releases/{p.stem}", "releases/eol_releases")
+        for pattern in RELEASE_NOTES_GLOB_PATTERNS
+        for p in (ZEPHYR_BASE / "doc").glob(pattern)
+    ),
+)
 
 # -- Options for zephyr.link-roles ----------------------------------------
 

--- a/doc/releases/eol_releases.rst
+++ b/doc/releases/eol_releases.rst
@@ -6,31 +6,49 @@ End-of-life releases
 Release notes and migration guides for end-of-life releases of Zephyr RTOS are kept here for
 historical purposes.
 
-.. _eol_releases_relesase_notes:
+.. When adding new entries to this page, please ensure you update `RELEASE_NOTES_GLOB_PATTERNS`
+   accordingly in doc/conf.py so that the .rst file(s) actually stop being built by Sphinx and
+   that redirects to this page are added for them.
+
+.. _eol_releases_release_notes:
 
 Release Notes
 *************
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
-   :reversed:
-
-   release-notes-1.?
-   release-notes-1.*
-   release-notes-2.[0-6]
-   release-notes-3.[0-6]
-   release-notes-4.[0-1]
+* :zephyr_file:`Zephyr 4.1 Release Notes <doc/releases/release-notes-4.1.rst>`
+* :zephyr_file:`Zephyr 4.0 Release Notes <doc/releases/release-notes-4.0.rst>`
+* :zephyr_file:`Zephyr 3.6 Release Notes <doc/releases/release-notes-3.6.rst>`
+* :zephyr_file:`Zephyr 3.5 Release Notes <doc/releases/release-notes-3.5.rst>`
+* :zephyr_file:`Zephyr 3.4 Release Notes <doc/releases/release-notes-3.4.rst>`
+* :zephyr_file:`Zephyr 3.3 Release Notes <doc/releases/release-notes-3.3.rst>`
+* :zephyr_file:`Zephyr 3.2 Release Notes <doc/releases/release-notes-3.2.rst>`
+* :zephyr_file:`Zephyr 3.1 Release Notes <doc/releases/release-notes-3.1.rst>`
+* :zephyr_file:`Zephyr 3.0 Release Notes <doc/releases/release-notes-3.0.rst>`
+* :zephyr_file:`Zephyr 2.7 Release Notes <doc/releases/release-notes-2.7.rst>`
+* :zephyr_file:`Zephyr 2.6 Release Notes <doc/releases/release-notes-2.6.rst>`
+* :zephyr_file:`Zephyr 2.5 Release Notes <doc/releases/release-notes-2.5.rst>`
+* :zephyr_file:`Zephyr 2.4 Release Notes <doc/releases/release-notes-2.4.rst>`
+* :zephyr_file:`Zephyr 2.3 Release Notes <doc/releases/release-notes-2.3.rst>`
+* :zephyr_file:`Zephyr 2.2 Release Notes <doc/releases/release-notes-2.2.rst>`
+* :zephyr_file:`Zephyr 2.1 Release Notes <doc/releases/release-notes-2.1.rst>`
+* :zephyr_file:`Zephyr 2.0 Release Notes <doc/releases/release-notes-2.0.rst>`
+* :zephyr_file:`Zephyr 1.14 Release Notes <doc/releases/release-notes-1.14.rst>`
+* :zephyr_file:`Zephyr 1.13 Release Notes <doc/releases/release-notes-1.13.rst>`
+* :zephyr_file:`Zephyr 1.12 Release Notes <doc/releases/release-notes-1.12.rst>`
+* :zephyr_file:`Zephyr 1.11 Release Notes <doc/releases/release-notes-1.11.rst>`
+* :zephyr_file:`Zephyr 1.10 Release Notes <doc/releases/release-notes-1.10.rst>`
+* :zephyr_file:`Zephyr 1.9 Release Notes <doc/releases/release-notes-1.9.rst>`
+* :zephyr_file:`Zephyr 1.8 Release Notes <doc/releases/release-notes-1.8.rst>`
+* :zephyr_file:`Zephyr 1.7 Release Notes <doc/releases/release-notes-1.7.rst>`
+* :zephyr_file:`Zephyr 1.6 Release Notes <doc/releases/release-notes-1.6.rst>`
+* :zephyr_file:`Zephyr 1.5 Release Notes <doc/releases/release-notes-1.5.rst>`
 
 .. _eol_releases_migration_guides:
 
 Migration Guides
 ****************
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
-   :reversed:
-
-   migration-guide-3.[5-6]
-   migration-guide-4.[0-1]
+* :zephyr_file:`Zephyr 4.1 Migration Guide <doc/releases/migration-guide-4.1.rst>`
+* :zephyr_file:`Zephyr 4.0 Migration Guide <doc/releases/migration-guide-4.0.rst>`
+* :zephyr_file:`Zephyr 3.6 Migration Guide <doc/releases/migration-guide-3.6.rst>`
+* :zephyr_file:`Zephyr 3.5 Migration Guide <doc/releases/migration-guide-3.5.rst>`


### PR DESCRIPTION
This avoids having to touch release notes and migration guides for EOL releases when e.g. some references to boards or code samples need updating. Note that release notes and migration guides for actively maintained releases will still be built after this changes so they still can be impacted by the aforementioned types of updates.

https://builds.zephyrproject.io/zephyr/pr/104850/docs/releases/eol_releases.html#eol-releases