### PR TITLE
soc: silabs: Use RAIL 3.0 APIs

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -9,8 +9,8 @@
 
 #include <sl_btctrl_linklayer.h>
 #include <sl_hci_common_transport.h>
-#include <pa_conversions_efr32.h>
-#include <rail.h>
+#include <sl_rail_util_compatible_pa.h>
+#include <sl_rail.h>
 #include <soc_radio.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
@@ -277,11 +277,19 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 	slz_set_tx_power(CONFIG_BT_CTLR_TX_PWR_ANTENNA);
 
 	if (IS_ENABLED(CONFIG_PM)) {
-		RAIL_ConfigSleep(sli_btctrl_get_radio_context_handle(),
-				 RAIL_SLEEP_CONFIG_TIMERSYNC_ENABLED);
-		RAIL_Status_t status = RAIL_InitPowerManager();
+		sl_rail_timer_sync_config_t timer_sync_config = SL_RAIL_TIMER_SYNC_DEFAULT;
+		sl_rail_status_t status;
 
-		if (status != RAIL_STATUS_NO_ERROR) {
+		status = sl_rail_config_sleep(sli_btctrl_get_radio_context_handle(),
+					      &timer_sync_config);
+		if (status != SL_RAIL_STATUS_NO_ERROR) {
+			LOG_ERR("RAIL: failed to configure sleep, status=%d", status);
+			ret = -EIO;
+			goto deinit;
+		}
+
+		status = sl_rail_init_power_manager();
+		if (status != SL_RAIL_STATUS_NO_ERROR) {
 			LOG_ERR("RAIL: failed to initialize power management, status=%d",
 					status);
 			ret = -EIO;

--- a/dts/arm/silabs/xg21/efr32xg21.dtsi
+++ b/dts/arm/silabs/xg21/efr32xg21.dtsi
@@ -19,6 +19,7 @@
 				     <38 1>, <39 1>, <40 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/arm/silabs/xg21/efr32xg21.dtsi
+++ b/dts/arm/silabs/xg21/efr32xg21.dtsi
@@ -17,7 +17,7 @@
 					  "rac_rsm", "rac_seq", "prortc", "synth";
 			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
 				     <38 1>, <39 1>, <40 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;

--- a/dts/arm/silabs/xg22/bgm22.dtsi
+++ b/dts/arm/silabs/xg22/bgm22.dtsi
@@ -7,6 +7,8 @@
 #include <silabs/xg22/efr32xg22.dtsi>
 
 &radio {
+	pa-2p4ghz = "highest";
+
 	bt_hci_silabs: bt_hci_silabs {
 		compatible = "silabs,bt-hci-efr32";
 		status = "disabled";

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -64,6 +64,7 @@
 	ble-coded-phy-supported;
 	ble-cte-rx-supported;
 	ble-cte-tx-supported;
+	pa-max-power-dbm = <8>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
@@ -48,6 +48,7 @@
 &radio {
 	ble-2mbps-supported;
 	ble-cte-tx-supported;
+	pa-max-power-dbm = <8>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg22/efr32xg22.dtsi
+++ b/dts/arm/silabs/xg22/efr32xg22.dtsi
@@ -16,7 +16,7 @@
 					  "synth";
 			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
 				     <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <6>;
 			pa-ramp-time-us = <2>;

--- a/dts/arm/silabs/xg22/efr32xg22.dtsi
+++ b/dts/arm/silabs/xg22/efr32xg22.dtsi
@@ -18,6 +18,7 @@
 				     <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <6>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/arm/silabs/xg23/efr32xg23.dtsi
+++ b/dts/arm/silabs/xg23/efr32xg23.dtsi
@@ -17,6 +17,7 @@
 			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
 				     <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;
 			pa-subghz = "highest";
 			pa-voltage-mv = <3300>;

--- a/dts/arm/silabs/xg24/bgm24.dtsi
+++ b/dts/arm/silabs/xg24/bgm24.dtsi
@@ -5,3 +5,7 @@
  */
 
 #include <silabs/xg24/efr32xg24.dtsi>
+
+&radio {
+	pa-2p4ghz = "highest";
+};

--- a/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
@@ -52,6 +52,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
@@ -35,6 +35,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
@@ -35,6 +35,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -23,6 +23,7 @@
 				     <37 1>, <38 1>, <39 1>, <70 1>, <71 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -21,7 +21,7 @@
 					  "rfeca1";
 			interrupts = <30 1>, <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
 				     <37 1>, <38 1>, <39 1>, <70 1>, <71 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;

--- a/dts/arm/silabs/xg24/mgm24.dtsi
+++ b/dts/arm/silabs/xg24/mgm24.dtsi
@@ -5,3 +5,7 @@
  */
 
 #include <silabs/xg24/efr32xg24.dtsi>
+
+&radio {
+	pa-2p4ghz = "highest";
+};

--- a/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
@@ -50,6 +50,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
@@ -51,6 +51,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg26/bgm26.dtsi
+++ b/dts/arm/silabs/xg26/bgm26.dtsi
@@ -7,6 +7,8 @@
 #include <silabs/xg26/efr32xg26.dtsi>
 
 &radio {
+	pa-2p4ghz = "highest";
+
 	bt_hci_silabs: bt_hci_silabs {
 		compatible = "silabs,bt-hci-efr32";
 		status = "disabled";

--- a/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
@@ -46,6 +46,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <16>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <6>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <11>;
 };
 
+&radio {
+	pa-max-power-dbm = <10>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/silabs/xg26/efr32xg26.dtsi
+++ b/dts/arm/silabs/xg26/efr32xg26.dtsi
@@ -20,7 +20,7 @@
 					  "rfeca1";
 			interrupts = <46 1>, <47 1>, <48 1>, <49 1>, <50 1>, <51 1>, <52 1>,
 				     <53 1>, <54 1>, <55 1>, <86 1>, <87 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;

--- a/dts/arm/silabs/xg26/efr32xg26.dtsi
+++ b/dts/arm/silabs/xg26/efr32xg26.dtsi
@@ -22,6 +22,7 @@
 				     <53 1>, <54 1>, <55 1>, <86 1>, <87 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/arm/silabs/xg26/mgm26.dtsi
+++ b/dts/arm/silabs/xg26/mgm26.dtsi
@@ -7,6 +7,8 @@
 #include <silabs/xg26/efr32xg26.dtsi>
 
 &radio {
+	pa-2p4ghz = "highest";
+
 	bt_hci_silabs: bt_hci_silabs {
 		compatible = "silabs,bt-hci-efr32";
 		status = "disabled";

--- a/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
@@ -46,6 +46,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
@@ -46,6 +46,7 @@
 };
 
 &radio {
+	pa-max-power-dbm = <10>;
 	pa-voltage-mv = <1800>;
 };
 

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <3>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <2>;
 };
 
+&radio {
+	pa-max-power-dbm = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
@@ -34,6 +34,10 @@
 	ngpios = <2>;
 };
 
+&radio {
+	pa-max-power-dbm = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <3>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg27/efr32xg27.dtsi
+++ b/dts/arm/silabs/xg27/efr32xg27.dtsi
@@ -19,7 +19,7 @@
 					  "prortc";
 			interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>,
 				     <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <8>;
 			pa-ramp-time-us = <2>;

--- a/dts/arm/silabs/xg27/efr32xg27.dtsi
+++ b/dts/arm/silabs/xg27/efr32xg27.dtsi
@@ -21,6 +21,7 @@
 				     <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <8>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/arm/silabs/xg28/efr32xg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32xg28.dtsi
@@ -18,6 +18,7 @@
 				     <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;
 			pa-subghz = "highest";
 			pa-voltage-mv = <3300>;

--- a/dts/arm/silabs/xg28/efr32xg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32xg28.dtsi
@@ -16,7 +16,7 @@
 					  "rfeca1";
 			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
 				     <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <20>;
 			pa-ramp-time-us = <10>;

--- a/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <2>;
 };
 
+&radio {
+	pa-max-power-dbm = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <2>;
 };
 
+&radio {
+	pa-max-power-dbm = <4>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(192)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
@@ -42,6 +42,10 @@
 	ngpios = <4>;
 };
 
+&radio {
+	pa-max-power-dbm = <6>;
+};
+
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32xg29.dtsi
+++ b/dts/arm/silabs/xg29/efr32xg29.dtsi
@@ -19,7 +19,7 @@
 					  "prortc";
 			interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>,
 				     <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
-			pa-2p4ghz = "highest";
+			pa-2p4ghz = "auto";
 			pa-initial-power-dbm = <10>;
 			pa-max-power-dbm = <8>;
 			pa-ramp-time-us = <2>;

--- a/dts/arm/silabs/xg29/efr32xg29.dtsi
+++ b/dts/arm/silabs/xg29/efr32xg29.dtsi
@@ -21,6 +21,7 @@
 				     <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
 			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
+			pa-max-power-dbm = <8>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;

--- a/dts/bindings/net/wireless/silabs,series2-radio.yaml
+++ b/dts/bindings/net/wireless/silabs,series2-radio.yaml
@@ -23,6 +23,12 @@ properties:
     description: |
       Initial Power Amplifier power in dBm.
 
+  pa-max-power-dbm:
+    type: int
+    required: true
+    description: |
+      Maximum Power Amplifier power in dBm.
+
   pa-ramp-time-us:
     type: int
     required: true
@@ -39,7 +45,9 @@ properties:
     type: string
     description: |
       Power Amplifier selection for 2.4 GHz. A value of 'highest' selects the highest
-      available PA on the given device. Other values explicitly select a specific PA.
+      available PA on the given device. A value of 'auto' dynamically selects the
+      optimal PA based on the output power configuration. Other values explicitly
+      select a specific PA.
       Not all PAs are available on all devices, check device specific documentation.
       If this property is not set, no 2.4 GHz PA is enabled.
     enum:
@@ -47,12 +55,17 @@ properties:
       - hp
       - mp
       - lp
+      - auto
 
   pa-subghz:
     type: string
     description: |
       Power Amplifier selection for sub-GHz. A value of 'highest' selects the highest
-      available PA on the given device. This is the only available option. If this
-      property is not set, no sub-GHz PA is enabled.
+      available PA on the given device. Other values explicitly select a specific PA. If
+      this property is not set, no sub-GHz PA is enabled.
     enum:
       - highest
+      - hp
+      - mp
+      - lp
+      - llp

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -56,9 +56,17 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
 
   zephyr_include_directories(
     ${RADIO_DIR}/rail_lib/common
-    ${RADIO_DIR}/rail_lib/plugin/pa-conversions
     ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_compatible_pa
     ${BLUETOOTH_DIR}/bgstack/ll/inc
+  )
+
+  zephyr_include_directories_ifdef(CONFIG_SILABS_DEVICE_IS_MODULE
+    ${RADIO_DIR}/rail_lib/plugin/pa-conversions
+  )
+  zephyr_include_directories_ifndef(CONFIG_SILABS_DEVICE_IS_MODULE
+    ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_pa_conversions
+    ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_pa_tables
+    ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_pa_tables/efr32xg${SILABS_DEVICE_FAMILY_NUMBER}
   )
 
   # sl_protocol_crypto
@@ -97,10 +105,13 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
   if(CONFIG_SOC_GECKO_USE_RAIL)
     # rail
     # PA curve for the modules comes from their config archive - omit the compilation of the SoC curves on modules
-    if(NOT CONFIG_SILABS_DEVICE_IS_MODULE)
-      zephyr_library_sources(${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_curves_efr32.c)
-    endif()
-    zephyr_library_sources(${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c)
+    zephyr_library_sources_ifdef(CONFIG_SILABS_DEVICE_IS_MODULE
+      ${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
+    )
+    zephyr_library_sources_ifndef(CONFIG_SILABS_DEVICE_IS_MODULE
+      ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_pa_conversions/sl_rail_util_pa_conversions.c
+      ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_pa_conversions/sl_rail_util_pa_tables.c
+    )
 
     if(CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL)
       zephyr_compile_definitions(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT=1)
@@ -370,6 +381,12 @@ zephyr_library_sources_ifdef(
   CONFIG_BUILD_ONLY_NO_BLOBS
   src/blob_stubs.c
 )
+if(CONFIG_SILABS_DEVICE_IS_MODULE)
+  zephyr_library_sources_ifdef(
+    CONFIG_BUILD_ONLY_NO_BLOBS
+    src/blob_stubs_module.c
+  )
+endif()
 
 zephyr_linker_sources(ROM_SECTIONS linker/code_classification_text.ld)
 zephyr_linker_sources(RAMFUNC_SECTION linker/code_classification_ramfunc.ld)

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_config.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * This configuration header is used by the HAL driver rail_util_pa from hal_silabs,
- * invoked through the init function of the hci_silabs_efr32 Bluetooth driver.
+ * invoked through drivers that use radio functionality, such as the hci_silabs_efr32 driver.
  * DeviceTree and Kconfig options are converted to config macros expected by the HAL driver.
  */
 
@@ -12,11 +12,14 @@
 #define SL_RAIL_UTIL_PA_CONFIG_H
 
 #include <zephyr/devicetree.h>
-#include "rail_types.h"
 
 #define SL_RAIL_UTIL_PA_POWER_DECI_DBM (DT_PROP(DT_NODELABEL(radio), pa_initial_power_dbm) * 10)
 #define SL_RAIL_UTIL_PA_RAMP_TIME_US   DT_PROP(DT_NODELABEL(radio), pa_ramp_time_us)
 #define SL_RAIL_UTIL_PA_VOLTAGE_MV     DT_PROP(DT_NODELABEL(radio), pa_voltage_mv)
+
+/* Modules still use legacy PA configuration */
+#ifdef CONFIG_SILABS_DEVICE_IS_MODULE
+#include "rail_types.h"
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(radio), pa_2p4ghz)
 #define SL_RAIL_UTIL_PA_SELECTION_2P4GHZ                                                           \
@@ -34,6 +37,8 @@
 
 #define SL_RAIL_UTIL_PA_CURVE_HEADER       CONFIG_SILABS_SISDK_RAIL_PA_CURVE_HEADER
 #define SL_RAIL_UTIL_PA_CURVE_TYPES        CONFIG_SILABS_SISDK_RAIL_PA_CURVE_TYPES_HEADER
+#endif /* CONFIG_SILABS_DEVICE_IS_MODULE */
+
 #define SL_RAIL_UTIL_PA_CALIBRATION_ENABLE CONFIG_SILABS_SISDK_RAIL_PA_ENABLE_CALIBRATION
 
 #endif /* SL_RAIL_UTIL_PA_CONFIG_H */

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_tables_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_tables_config.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This configuration header is used by the HAL driver sl_rail_util_pa_tables from hal_silabs,
+ * invoked through drivers that use radio functionality, such as the hci_silabs_efr32 driver.
+ * DeviceTree and Kconfig options are converted to config macros expected by the HAL driver.
+ */
+
+#ifndef SL_RAIL_UTIL_PA_TABLES_CONFIG_H
+#define SL_RAIL_UTIL_PA_TABLES_CONFIG_H
+
+#include <zephyr/devicetree.h>
+
+#ifdef CONFIG_SOC_SILABS_XG21
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#endif
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#endif
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG21 */
+
+#ifdef CONFIG_SOC_SILABS_XG22
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_6dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_6dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG22 */
+
+#ifdef CONFIG_SOC_SILABS_XG23
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, highest)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_HP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, mp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_MP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, lp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_LP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, llp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_LLP.h))
+#else
+#error "Unknown Sub-GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG23 */
+
+#ifdef CONFIG_SOC_SILABS_XG24
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#endif
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#endif
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG24 */
+
+#ifdef CONFIG_SOC_SILABS_XG26
+
+#ifdef CONFIG_SOC_EFR32MG26B510F3200IL136
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_10dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_automode_0_10dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#else /* CONFIG_SOC_EFR32MG26B510F3200IL136 */
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#endif
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#else
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#endif
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_EFR32MG26B510F3200IL136 */
+
+#endif /* CONFIG_SOC_SILABS_XG26 */
+
+#ifdef CONFIG_SOC_SILABS_XG27
+
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 4
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#else
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_4dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_4dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG27 */
+
+#ifdef CONFIG_SOC_SILABS_XG28
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, highest)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_915M_HP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, mp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_915M_MP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, lp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_915M_LP.h))
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_subghz, llp)
+#include STRINGIFY(CONCAT(CONCAT(sl_rail_util_pa_dbm_powersetting_mapping_table_,                  \
+				 DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm)), dbm_915M_LLP.h))
+#else
+#error "Unknown Sub-GHz PA configuration"
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG28 */
+
+#ifdef CONFIG_SOC_SILABS_XG29
+
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 4
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#else
+
+#if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
+	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_8dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h"
+#elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
+#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_8dbm.h"
+#else
+#error "Unknown 2.4 GHz PA configuration"
+#endif
+
+#endif
+
+#endif /* CONFIG_SOC_SILABS_XG29 */
+
+#endif /* SL_RAIL_UTIL_PA_TABLES_CONFIG_H */

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 
 #include <rail.h>
+#include <sl_rail.h>
 #include <sl_status.h>
 
 RAIL_Status_t RAIL_VerifyTxPowerCurves(const struct RAIL_TxPowerCurvesConfigAlt *config)
@@ -21,14 +22,15 @@ void RAIL_EnablePaCal(bool enable)
 {
 }
 
-RAIL_Status_t RAIL_ConfigSleep(RAIL_Handle_t handle, RAIL_SleepConfig_t config)
+sl_rail_status_t sl_rail_config_sleep(sl_rail_handle_t handle,
+				      const sl_rail_timer_sync_config_t *config)
 {
-	return RAIL_STATUS_NO_ERROR;
+	return SL_RAIL_STATUS_NO_ERROR;
 }
 
-RAIL_Status_t RAIL_InitPowerManager(void)
+sl_rail_status_t sl_rail_init_power_manager(void)
 {
-	return RAIL_STATUS_NO_ERROR;
+	return SL_RAIL_STATUS_NO_ERROR;
 }
 
 int16_t sl_btctrl_hci_receive(uint8_t *data, int16_t len, bool lastFragment)

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
@@ -9,16 +9,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <rail.h>
 #include <sl_rail.h>
 #include <sl_status.h>
 
-RAIL_Status_t RAIL_VerifyTxPowerCurves(const struct RAIL_TxPowerCurvesConfigAlt *config)
+sl_rail_status_t sl_rail_verify_tx_power_conversion(const struct sl_rail_tx_power_table_config *cfg)
 {
-	return RAIL_STATUS_NO_ERROR;
+	return SL_RAIL_STATUS_NO_ERROR;
 }
 
-void RAIL_EnablePaCal(bool enable)
+void sl_rail_enable_pa_cal(sl_rail_handle_t rail_handle, bool enable)
 {
 }
 

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs_module.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs_module.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Empty function stubs to enable building with CONFIG_BUILD_ONLY_NO_BLOBS on modules.
+ */
+
+#include <stdbool.h>
+
+#include <rail.h>
+#include "pa_curve_types_efr32.h"
+
+const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat;
+const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc;
+
+RAIL_Status_t RAIL_VerifyTxPowerCurves(const struct RAIL_TxPowerCurvesConfigAlt *config)
+{
+	return RAIL_STATUS_NO_ERROR;
+}
+
+void RAIL_EnablePaCal(bool enable)
+{
+}

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -14,7 +14,7 @@ config SOC_GECKO_HAS_RADIO
 config SOC_GECKO_USE_RAIL
 	bool "Use RAIL (Radio Abstraction Interface Layer)"
 	depends on SOC_GECKO_HAS_RADIO
-	select SILABS_SISDK_LDMA if BT_CHANNEL_SOUNDING
+	select SILABS_SISDK_LDMA
 	select SILABS_SISDK_TIMER if BT_CHANNEL_SOUNDING
 	help
 	  RAIL (Radio Abstraction Interface Layer) is a library needed to use the EFR radio

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: d375743bceb892a12b8ce6a22d23438353d500cb
+      revision: aad92b8a992dbb8eecc5560d2a648d70c884ede5
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Make use of RAIL 3.0 APIs (radio abstraction interface layer) for power management and power amplifier configuration.
Add a DTS property for the maximum supported output power for each SoC.
Select the appropriate PA configuration table based on SoC family, package type and supported output power.
Set the PA table that automatically selects the optimal PA for a given output power selection as the default.
