### PR TITLE
Revert "dts: nxp: mcx: delete "nxp,cmc-reset-cause" compatible"

### DIFF
--- a/drivers/hwinfo/Kconfig.mcux_mcx_cmc
+++ b/drivers/hwinfo/Kconfig.mcux_mcx_cmc
@@ -4,7 +4,7 @@
 config HWINFO_MCUX_MCX_CMC
 	bool "NXP MCX CMC reset cause"
 	default y
-	depends on DT_HAS_NXP_CMC_ENABLED
+	depends on DT_HAS_NXP_CMC_RESET_CAUSE_ENABLED
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP kinetis mcux CMC hwinfo driver.

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -452,7 +452,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc";
+			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -588,7 +588,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc";
+			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -61,6 +61,10 @@
 		status = "okay";
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	soc {
 		syscon: syscon@40091000 {
 			compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -31,6 +31,10 @@
 		};
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	/* Dummy pinctrl node, filled with pin mux options at board level */
 	pinctrl: pinctrl {
 		compatible = "nxp,port-pinctrl";

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -545,7 +545,7 @@
 		};
 
 		cmc: system-modules@4008b000 {
-			compatible = "nxp,cmc";
+			compatible = "nxp,cmc", "nxp,cmc-reset-cause";
 			reg = <0x4008b000 0x1000>;
 			interrupts = <1 0>;
 		};

--- a/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
+++ b/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
@@ -1,0 +1,6 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: CMC reset causes
+
+compatible: "nxp,cmc-reset-cause"


### PR DESCRIPTION
This reverts commit 2d17d0c6133f3f6e59b55aadede06f1c63f5191a as it introduced a failure in main which can be reproduced for example with
```
mkdir build && cd build
cmake -GNinja -DBOARD=frdm_mcxw71/mcxw716c \
  ../samples/net/sockets/echo_client/
ninja
```
Failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/22633956180/job/65591618868#step:12:6219

Revert of
* https://github.com/zephyrproject-rtos/zephyr/pull/104609