### PR TITLE
west: blobs: support fallback URLs

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -1017,8 +1017,9 @@ maps, each of which has the following entries:
 - ``version``: A version string
 - ``license-path``: Path to the license file for this blob, relative to the root
   of the module repository
-- ``url``: URL that identifies the location the blob will be fetched from, as
-  well as the fetching scheme to use
+- ``url``: URL(s) that identify the location the blob will be fetched from, as
+  well as the fetching scheme to use. If it contains a list instead of a single string,
+  each URL will be considered as a fallback for fetching the same blob.
 - ``description``: Human-readable description of the binary blob
 - ``doc-url``: A URL pointing to the location of the official documentation for
   this blob

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -231,7 +231,7 @@ in ``--cache-dirs`` cli argument or ``blobs.cache-dirs`` config option.
 auto-cache) for a matching blob filename. Cached files may be stored either
 under their original filename or with a SHA-256 suffix (``<filename>.<sha>``).
 If found, the blob is copied from the cache to the blob path; otherwise
-it is downloaded from its url to the blob path.
+it is downloaded from its URL(s) to the blob path.
 
 .. _west-twister:
 

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 from west.commands import WestCommand
 
+from fetchers.core import ZephyrBlobException
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))
@@ -61,7 +62,7 @@ class Blobs(WestCommand):
             - license_path: path to the license file for the blob
             - license-abspath: absolute path to the license file for the blob
             - click-through: need license click-through or not
-            - url: URI to the remote location of the blob
+            - url: URI(s) to the remote location(s) of the blob
             - fetcher: method to use to fetch the blob
             - description: blob text description
             - doc-url: URL to the documentation for this blob
@@ -195,16 +196,39 @@ class Blobs(WestCommand):
 
     def download_blob(self, blob, path):
         '''Download a blob from its url to a given path.'''
-        url = blob['url']
-        scheme = blob.get('fetcher') or urlparse(url).scheme
-        self.dbg(f'Fetching blob from url {url} with {scheme} to path: {path}')
-        import fetchers
+        urls = blob['url']
+        if not isinstance(urls, list):
+            urls = (urls,)
 
-        fetcher = fetchers.get_fetcher_cls(scheme)
-        self.dbg(f'Found fetcher: {fetcher}')
-        inst = fetcher()
-        self.ensure_folder(path)
-        inst.fetch(self, blob, path)
+        valid_url = None
+        has_error = False
+        for url in urls:
+            scheme = blob.get('fetcher') or urlparse(url).scheme
+            self.dbg(f'Fetching blob from url {url} with {scheme} to path: {path}')
+            import fetchers
+
+            fetcher_class = fetchers.get_fetcher_cls(scheme)
+            self.dbg(f'Found fetcher: {fetcher_class}')
+            fetcher = fetcher_class()
+            self.ensure_folder(path)
+
+            # Select an URL the fetcher will use
+            single_url_blob = blob.copy()
+            single_url_blob['url'] = url
+
+            try:
+                fetcher.fetch(self, single_url_blob, path)
+            except ZephyrBlobException as e:
+                self.wrn(e)
+                has_error = True
+            else:
+                valid_url = url
+                break
+
+        if valid_url is None:
+            raise ZephyrBlobException('No URL worked for this blob')
+        if has_error:
+            self.inf(f'Fallback URL worked: {valid_url}')
 
     def fetch_blob(self, args, blob):
         """
@@ -275,6 +299,7 @@ class Blobs(WestCommand):
 
     def fetch(self, args):
         bad_checksum_count = 0
+        failed_fetch_count = 0
         blobs = self.get_blobs(args)
         for blob in blobs:
             if blob['status'] == zephyr_module.BLOB_PRESENT:
@@ -320,13 +345,21 @@ class Blobs(WestCommand):
                     self.wrn('Skip fetching this blob.')
                     continue
 
-            self.fetch_blob(args, blob)
-            if not self.verify_blob(blob):
-                bad_checksum_count += 1
+            try:
+                self.fetch_blob(args, blob)
+            except ZephyrBlobException as e:
+                self.err(f"Failed to fetch blob: {e}")
+                failed_fetch_count += 1
+            else:
+                if not self.verify_blob(blob):
+                    bad_checksum_count += 1
 
         if bad_checksum_count:
             self.err(f"{bad_checksum_count} blobs have bad checksums")
             sys.exit(os.EX_DATAERR)
+
+        if failed_fetch_count:
+            self.die(f"{failed_fetch_count} blobs failed to be fetched")
 
     def clean(self, args):
         blobs = self.get_blobs(args)

--- a/scripts/west_commands/fetchers/core.py
+++ b/scripts/west_commands/fetchers/core.py
@@ -8,6 +8,9 @@ from typing import List, Type
 
 from west.commands import WestCommand
 
+class ZephyrBlobException(Exception):
+    pass
+
 class ZephyrBlobFetcher(ABC):
 
     @staticmethod

--- a/scripts/west_commands/fetchers/git_lfs.py
+++ b/scripts/west_commands/fetchers/git_lfs.py
@@ -1,12 +1,9 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import sys
-
 import requests
 
-from fetchers.core import ZephyrBlobFetcher
+from fetchers.core import ZephyrBlobException, ZephyrBlobFetcher
 
 
 class GitLFSFetcher(ZephyrBlobFetcher):
@@ -30,8 +27,7 @@ class GitLFSFetcher(ZephyrBlobFetcher):
         if "size" in blob:
             size = blob["size"]
         else:
-            west_command.err(f"'size' field missing for blob {path}, unable to fetch")
-            sys.exit(os.EX_USAGE)
+            raise ZephyrBlobException(f"'size' field missing for blob {path}, unable to fetch")
 
         west_command.dbg(f'GitLFSFetcher fetching {oid} from {url}')
 
@@ -57,39 +53,34 @@ class GitLFSFetcher(ZephyrBlobFetcher):
             resp = requests.post(url + "/objects/batch", json=request, headers=headers)
             resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
         except requests.exceptions.HTTPError as e:
-            west_command.err(f'HTTP error occurred: {e}')
-            sys.exit(os.EX_DATAERR)
+            raise ZephyrBlobException(f'HTTP error occurred: {e}') from e
         except requests.exceptions.RequestException as e:
-            west_command.err(f'An error occurred: {e}')
-            sys.exit(os.EX_DATAERR)
+            raise ZephyrBlobException(f'An error occurred: {e}') from e
 
         # Download the LFS object
         # see https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md#successful-responses
         for obj in resp.json().get("objects", []):
             if obj["oid"] == oid:
                 if "error" in obj:
-                    west_command.err(f'Failed to download LFS object {oid}: {obj["error"]}')
-                    sys.exit(os.EX_DATAERR)
+                    raise ZephyrBlobException(
+                        f'Failed to download LFS object {oid}: {obj["error"]}'
+                    )
 
                 try:
                     download = obj["actions"]["download"]
-                except KeyError:
-                    west_command.err(f'Unexpected response from LFS server: {obj}')
-                    sys.exit(os.EX_DATAERR)
+                except KeyError as e:
+                    raise ZephyrBlobException(f'Unexpected response from LFS server: {obj}') from e
 
                 west_command.dbg(f'GitLFSFetcher fetching {download["href"]} to {path}')
                 try:
                     resp = requests.get(download["href"], headers=download.get("header", {}))
                     resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
                 except requests.exceptions.HTTPError as e:
-                    west_command.err(f'HTTP error occurred: {e}')
-                    sys.exit(os.EX_DATAERR)
+                    raise ZephyrBlobException(f'HTTP error occurred: {e}') from e
                 except requests.exceptions.RequestException as e:
-                    west_command.err(f'An error occurred: {e}')
-                    sys.exit(os.EX_DATAERR)
+                    raise ZephyrBlobException(f'An error occurred: {e}') from e
                 with open(path, "wb") as f:
                     f.write(resp.content)
                 break
         else:
-            west_command.err(f'Failed to download LFS object {oid}')
-            sys.exit(os.EX_DATAERR)
+            raise ZephyrBlobException(f'Failed to download LFS object {oid}')

--- a/scripts/west_commands/fetchers/http.py
+++ b/scripts/west_commands/fetchers/http.py
@@ -2,11 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import requests
-import sys
 
-from fetchers.core import ZephyrBlobFetcher
+from fetchers.core import ZephyrBlobException, ZephyrBlobFetcher
 
 class HTTPFetcher(ZephyrBlobFetcher):
 
@@ -21,10 +19,8 @@ class HTTPFetcher(ZephyrBlobFetcher):
             resp = requests.get(url)
             resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
         except requests.exceptions.HTTPError as e:
-            west_command.err(f'HTTP error occurred: {e}')
-            sys.exit(os.EX_NOHOST)
+            raise ZephyrBlobException(f'HTTP error occurred: {e}') from e
         except requests.exceptions.RequestException as e:
-            west_command.err(f'An error occurred: {e}')
-            sys.exit(os.EX_DATAERR)
+            raise ZephyrBlobException(f'An error occurred: {e}') from e
         with open(path, "wb") as f:
             f.write(resp.content)

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     from yaml import SafeLoader
 
+# NOTE: keep in sync with doc/develop/modules.rst
 METADATA_SCHEMA = '''
 ## A JSON Schema (Draft 2020-12) for basic validation of the structure of a
 ## metadata YAML file.
@@ -116,7 +117,11 @@ properties:
         click-through:
           type: boolean
         url:
-          type: string
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                type: string
         description:
           type: string
         doc-url:


### PR DESCRIPTION
Allow fallback URLs in case a server is temporarily down.
Integrity is still ensured by SHA256.

**Edit: continue download and fail after all were tried**

Before: only one supported:
```
  url: https://...
```
After: either of these:
```
  url: https://...

  url:
    - https://...
    - https://...
```

Example:

```
$ west blobs fetch
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m0s0sp.a
ERROR: HTTP error occurred: 404 Client Error: Not Found for url: https://github.com/boufffffalolab/bl_iot_sdk-components/raw/73ffff3849ea621dacafdb66835505d6404d7dd8/network/ble/blecontroller_bl702_m0s0sp/lib/libblecontroller_bl702_m0s0sp.a
ERROR: HTTP error occurred: 404 Client Error: Not Found for url: https://github.com/boufffffalolab/bl_iot_sdk-components/raw/73ffff3849ea621dacafdb66835505d6404d7dd8/network/ble/blecontroller_bl702_m0s0sp/lib/libblecontroller_bl702_m0s0sp.a
Fallback URL worked: https://github.com/bouffalolab/bl_iot_sdk-components/raw/73ffff3849ea621dacafdb66835505d6404d7dd8/network/ble/blecontroller_bl702_m0s0sp/lib/libblecontroller_bl702_m0s0sp.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m0s1.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m0s1p.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m0s1s.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m0s1t10.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m1s1.a
Fetching blob hal_bouffalolab: /home/josuah/z/bflb/modules/hal/bouffalolab/zephyr/blobs/lib/bl70x/libblecontroller_bl702_m16s1.a
```