### PR TITLE
soc: bflb: common: add shared BLE OS shims

### DIFF
--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CONFIG_SOC_FAMILY_BFLB)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES})
 
-  if(CONFIG_BFLB_FREERTOS_SHIM)
+  if(CONFIG_BFLB_FREERTOS_SHIM OR CONFIG_BFLB_BTBLE_PORT_OS_SHIM)
     add_subdirectory(shim)
   endif()
 endif() # SOC_FAMILY_BFLB

--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -6,4 +6,8 @@
 if(CONFIG_SOC_FAMILY_BFLB)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES})
+
+  if(CONFIG_BFLB_FREERTOS_SHIM)
+    add_subdirectory(shim)
+  endif()
 endif() # SOC_FAMILY_BFLB

--- a/modules/hal_bouffalolab/Kconfig
+++ b/modules/hal_bouffalolab/Kconfig
@@ -20,6 +20,13 @@ config BFLB_BTBLE_TASK_PRIO
 	  Priority level reported to the BLE controller blob via the
 	  FreeRTOS shim uxTaskPriorityGet() function.
 
+config BFLB_BTBLE_PORT_OS_SHIM
+	bool
+	help
+	  Zephyr RTOS port for the btblecontroller binary blob.
+	  Implements the btblecontroller_* OS abstraction for BL702L/BL616.
+	  Selected by SoC-specific BLE drivers that use the btblecontroller API.
+
 config BFLB_SHIM_HEAP_SIZE
 	int "BLE shim heap size"
 	default 8192

--- a/modules/hal_bouffalolab/Kconfig
+++ b/modules/hal_bouffalolab/Kconfig
@@ -5,3 +5,25 @@
 
 config ZEPHYR_HAL_BOUFFALOLAB_MODULE
 	bool
+
+config BFLB_FREERTOS_SHIM
+	bool
+	help
+	  FreeRTOS-to-Zephyr shim for Bouffalo Lab BLE controller blobs.
+	  Selected by SoC-specific BLE drivers that need it.
+
+config BFLB_BTBLE_TASK_PRIO
+	int "BLE controller task priority"
+	default 5
+	depends on BFLB_FREERTOS_SHIM
+	help
+	  Priority level reported to the BLE controller blob via the
+	  FreeRTOS shim uxTaskPriorityGet() function.
+
+config BFLB_SHIM_HEAP_SIZE
+	int "BLE shim heap size"
+	default 8192
+	depends on BFLB_FREERTOS_SHIM || BFLB_BTBLE_PORT_OS_SHIM
+	help
+	  Size in bytes of the dedicated memory pool used by the BLE
+	  controller shim layer for threads, stacks, and queues.

--- a/modules/hal_bouffalolab/shim/CMakeLists.txt
+++ b/modules/hal_bouffalolab/shim/CMakeLists.txt
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_BFLB_FREERTOS_SHIM freertos_shim.c)
+zephyr_sources_ifdef(CONFIG_BFLB_BTBLE_PORT_OS_SHIM btblecontroller_port_os.c)

--- a/modules/hal_bouffalolab/shim/CMakeLists.txt
+++ b/modules/hal_bouffalolab/shim/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources_ifdef(CONFIG_BFLB_FREERTOS_SHIM freertos_shim.c)

--- a/modules/hal_bouffalolab/shim/btblecontroller_port_os.c
+++ b/modules/hal_bouffalolab/shim/btblecontroller_port_os.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Zephyr RTOS port for the Bouffalo Lab BLE controller binary blob.
+ * Implements the btblecontroller_* OS abstraction used by BL702L/BL616
+ * precompiled libraries, mapping them to Zephyr kernel primitives.
+ */
+
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* Blob API return values */
+#define BTBLE_OK   1
+#define BTBLE_FAIL 0
+#define BTBLE_ERR  (-1)
+
+/* Stack size is specified in 4-byte words */
+#define STACK_WORD_SIZE 4U
+
+/* Infinite timeout sentinel used by the blob */
+#define BTBLE_WAIT_FOREVER 0xFFFFFFFFU
+
+static K_HEAP_DEFINE(shim_heap, CONFIG_BFLB_SHIM_HEAP_SIZE);
+
+/*
+ * Queue wrapper: Zephyr k_msgq requires a pre-allocated buffer and struct,
+ * while the blob API performs internal allocation.
+ */
+struct bflb_queue {
+	struct k_msgq msgq;
+	char buf[];
+};
+
+/*
+ * Thread wrapper: tracks k_thread, stack, and entry point together so
+ * btblecontroller_task_delete can free both.
+ */
+struct bflb_thread {
+	struct k_thread thread;
+	k_thread_stack_t *stack;
+	size_t stack_size;
+	void (*func)(void *arg);
+	void *arg;
+};
+
+static k_timeout_t ms_to_timeout(uint32_t ms)
+{
+	if (ms == 0U) {
+		return K_NO_WAIT;
+	} else if (ms == BTBLE_WAIT_FOREVER) {
+		return K_FOREVER;
+	}
+
+	return K_MSEC(ms);
+}
+
+/* Trampoline: adapts (void *) entry to Zephyr's (void *, void *, void *) */
+static void task_entry_wrapper(void *p1, void *p2, void *p3)
+{
+	struct bflb_thread *bt = (struct bflb_thread *)p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	bt->func(bt->arg);
+}
+
+/*
+ * btblecontroller_task_new - Create a new task.
+ *
+ * Returns 1 on success, -1 on allocation failure.
+ * stack_size is in 4-byte words.
+ * taskHandler receives the opaque handle for later deletion.
+ */
+int btblecontroller_task_new(void (*taskFunction)(void *), const char *name, int stack_size,
+			     void *arg, int prio, void *taskHandler)
+{
+	size_t stack_bytes = (size_t)stack_size * STACK_WORD_SIZE;
+	struct bflb_thread *bt;
+	int zprio;
+
+	bt = k_heap_alloc(&shim_heap, sizeof(*bt), K_NO_WAIT);
+	if (bt == NULL) {
+		return BTBLE_ERR;
+	}
+
+	bt->stack = k_heap_alloc(&shim_heap, stack_bytes, K_NO_WAIT);
+	if (bt->stack == NULL) {
+		k_heap_free(&shim_heap, bt);
+		return BTBLE_ERR;
+	}
+	bt->stack_size = stack_bytes;
+	bt->func = taskFunction;
+	bt->arg = arg;
+
+	/*
+	 * Blob priority: higher number = higher priority (0 = idle).
+	 * Zephyr preemptive: lower number = higher priority (0 = highest).
+	 */
+	zprio = CONFIG_NUM_PREEMPT_PRIORITIES - 1 - prio;
+	if (zprio < 0) {
+		zprio = 0;
+	}
+
+	k_thread_create(&bt->thread, bt->stack, stack_bytes, task_entry_wrapper, bt, NULL, NULL,
+			zprio, 0, K_FOREVER);
+	k_thread_name_set(&bt->thread, name);
+
+	if (taskHandler != NULL) {
+		*(void **)taskHandler = bt;
+	}
+
+	k_thread_start(&bt->thread);
+
+	return BTBLE_OK;
+}
+
+void btblecontroller_task_delete(uint32_t taskHandler)
+{
+	struct bflb_thread *bt = (struct bflb_thread *)(uintptr_t)taskHandler;
+
+	if (bt != NULL) {
+		k_thread_abort(&bt->thread);
+		k_heap_free(&shim_heap, bt->stack);
+		k_heap_free(&shim_heap, bt);
+	}
+}
+
+/*
+ * btblecontroller_queue_new - Create a message queue.
+ *
+ * size    = number of items
+ * max_msg = size of each item in bytes
+ *
+ * Returns 0 on success, -1 on failure.
+ */
+int btblecontroller_queue_new(uint32_t size, uint32_t max_msg, void *queue)
+{
+	size_t buf_bytes = (size_t)size * max_msg;
+	struct bflb_queue *q;
+
+	q = k_heap_alloc(&shim_heap, sizeof(*q) + buf_bytes, K_NO_WAIT);
+	if (q == NULL) {
+		return BTBLE_ERR;
+	}
+
+	k_msgq_init(&q->msgq, q->buf, max_msg, size);
+
+	*(void **)queue = q;
+	return 0;
+}
+
+void btblecontroller_queue_free(void *q_handle)
+{
+	struct bflb_queue *q = (struct bflb_queue *)q_handle;
+
+	if (q != NULL) {
+		k_msgq_purge(&q->msgq);
+		k_heap_free(&shim_heap, q);
+	}
+}
+
+/*
+ * btblecontroller_queue_send - Send to queue.
+ *
+ * Returns 1 on success, 0 on failure.
+ * timeout: milliseconds, BTBLE_WAIT_FOREVER for indefinite.
+ */
+int btblecontroller_queue_send(void *q_handle, void *msg, uint32_t size, uint32_t timeout)
+{
+	struct bflb_queue *q = (struct bflb_queue *)q_handle;
+
+	ARG_UNUSED(size);
+
+	return (k_msgq_put(&q->msgq, msg, ms_to_timeout(timeout)) == 0) ? BTBLE_OK : BTBLE_FAIL;
+}
+
+/*
+ * btblecontroller_queue_recv - Receive from queue.
+ *
+ * Returns 1 on success, 0 on failure.
+ */
+int btblecontroller_queue_recv(void *q_handle, void *msg, uint32_t timeout)
+{
+	struct bflb_queue *q = (struct bflb_queue *)q_handle;
+
+	return (k_msgq_get(&q->msgq, msg, ms_to_timeout(timeout)) == 0) ? BTBLE_OK : BTBLE_FAIL;
+}
+
+/*
+ * btblecontroller_queue_send_from_isr - Send from ISR context.
+ *
+ * Returns 1 on success, 0 on failure.
+ */
+int btblecontroller_queue_send_from_isr(void *q_handle, void *msg, uint32_t size)
+{
+	struct bflb_queue *q = (struct bflb_queue *)q_handle;
+
+	ARG_UNUSED(size);
+
+	return (k_msgq_put(&q->msgq, msg, K_NO_WAIT) == 0) ? BTBLE_OK : BTBLE_FAIL;
+}
+
+int btblecontroller_xport_is_inside_interrupt(void)
+{
+	return (int)k_is_in_isr();
+}
+
+void btblecontroller_task_delay(uint32_t ms)
+{
+	k_sleep(K_MSEC(ms));
+}
+
+void *btblecontroller_task_get_current_task_handle(void)
+{
+	return k_current_get();
+}
+
+void *btblecontroller_malloc(size_t xWantedSize)
+{
+	return k_heap_alloc(&shim_heap, xWantedSize, K_NO_WAIT);
+}
+
+void btblecontroller_free(void *buf)
+{
+	k_heap_free(&shim_heap, buf);
+}

--- a/modules/hal_bouffalolab/shim/freertos_shim.c
+++ b/modules/hal_bouffalolab/shim/freertos_shim.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * FreeRTOS API shim for Bouffalo Lab BLE controller binary blobs.
+ *
+ * The BLE blobs call FreeRTOS functions (xTaskCreate, xQueueGenericSend,
+ * pvPortMalloc, etc.). This shim maps them to Zephyr kernel primitives.
+ */
+
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* FreeRTOS compatibility constants */
+#define pdPASS                                1
+#define pdFAIL                                0
+#define pdFALSE                               0
+#define errQUEUE_FULL                         0
+#define errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY (-1)
+#define STACK_WORD_SIZE                       4U
+#define portMAX_DELAY                         0xFFFFFFFFU
+
+static K_HEAP_DEFINE(shim_heap, CONFIG_BFLB_SHIM_HEAP_SIZE);
+
+typedef void *TaskHandle_t;
+typedef void *QueueHandle_t;
+typedef void (*TaskFunction_t)(void *);
+
+struct bflb_thread {
+	struct k_thread thread;
+	k_thread_stack_t *stack;
+	size_t stack_size;
+	TaskFunction_t func;
+	void *arg;
+};
+
+struct bflb_queue {
+	bool is_sem;
+	union {
+		struct k_sem sem;
+		struct k_msgq msgq;
+	};
+	char buf[];
+};
+
+static k_timeout_t ticks_to_timeout(uint32_t xTicksToWait)
+{
+	if (xTicksToWait == 0U) {
+		return K_NO_WAIT;
+	} else if (xTicksToWait == portMAX_DELAY) {
+		return K_FOREVER;
+	}
+
+	return K_MSEC(xTicksToWait);
+}
+
+static void task_entry_wrapper(void *p1, void *p2, void *p3)
+{
+	struct bflb_thread *bt = (struct bflb_thread *)p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	bt->func(bt->arg);
+}
+
+int32_t xTaskCreate(TaskFunction_t pxTaskCode, const char *pcName, uint16_t usStackDepth,
+		    void *pvParameters, uint32_t uxPriority, TaskHandle_t *pxCreatedTask)
+{
+	size_t stack_bytes = (size_t)usStackDepth * STACK_WORD_SIZE;
+	struct bflb_thread *bt;
+	int zprio;
+
+	bt = k_heap_alloc(&shim_heap, sizeof(*bt), K_NO_WAIT);
+	if (bt == NULL) {
+		return errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
+	}
+
+	bt->stack = k_heap_alloc(&shim_heap, stack_bytes, K_NO_WAIT);
+	if (bt->stack == NULL) {
+		k_heap_free(&shim_heap, bt);
+		return errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
+	}
+	bt->stack_size = stack_bytes;
+	bt->func = pxTaskCode;
+	bt->arg = pvParameters;
+
+	/* FreeRTOS: higher number = higher priority
+	 * Zephyr: lower number = higher priority
+	 */
+	zprio = CONFIG_NUM_PREEMPT_PRIORITIES - 1 - (int)uxPriority;
+	if (zprio < 0) {
+		zprio = 0;
+	}
+
+	k_thread_create(&bt->thread, bt->stack, stack_bytes, task_entry_wrapper, bt, NULL, NULL,
+			zprio, 0, K_FOREVER);
+	k_thread_name_set(&bt->thread, pcName);
+
+	if (pxCreatedTask != NULL) {
+		*pxCreatedTask = bt;
+	}
+
+	k_thread_start(&bt->thread);
+
+	return pdPASS;
+}
+
+void vTaskDelete(TaskHandle_t xTaskToDelete)
+{
+	struct bflb_thread *bt = (struct bflb_thread *)xTaskToDelete;
+
+	if (bt != NULL) {
+		k_thread_abort(&bt->thread);
+		k_heap_free(&shim_heap, bt->stack);
+		k_heap_free(&shim_heap, bt);
+	}
+}
+
+void vTaskDelay(uint32_t xTicksToDelay)
+{
+	k_sleep(K_MSEC(xTicksToDelay));
+}
+
+void vTaskSwitchContext(void)
+{
+	k_yield();
+}
+
+uint32_t uxTaskPriorityGet(TaskHandle_t xTask)
+{
+	ARG_UNUSED(xTask);
+	return CONFIG_BFLB_BTBLE_TASK_PRIO;
+}
+
+QueueHandle_t xQueueGenericCreate(uint32_t uxQueueLength, uint32_t uxItemSize, uint8_t ucQueueType)
+{
+	struct bflb_queue *q;
+
+	ARG_UNUSED(ucQueueType);
+
+	if (uxItemSize == 0U) {
+		/*
+		 * FreeRTOS uses zero-sized items for semaphores and mutexes:
+		 * xQueueGenericCreate(1, 0, queueQUEUE_TYPE_BINARY_SEMAPHORE).
+		 * Map to k_sem — no buffer allocation needed.
+		 */
+		q = k_heap_alloc(&shim_heap, sizeof(*q), K_NO_WAIT);
+		if (q == NULL) {
+			return NULL;
+		}
+		q->is_sem = true;
+		k_sem_init(&q->sem, 0, uxQueueLength);
+	} else {
+		size_t buf_bytes = (size_t)uxQueueLength * uxItemSize;
+
+		q = k_heap_alloc(&shim_heap, sizeof(*q) + buf_bytes, K_NO_WAIT);
+		if (q == NULL) {
+			return NULL;
+		}
+		q->is_sem = false;
+		k_msgq_init(&q->msgq, q->buf, uxItemSize, uxQueueLength);
+	}
+
+	return q;
+}
+
+int32_t xQueueGenericSend(QueueHandle_t xQueue, const void *pvItemToQueue, uint32_t xTicksToWait,
+			  int32_t xCopyPosition)
+{
+	struct bflb_queue *q = (struct bflb_queue *)xQueue;
+
+	ARG_UNUSED(xCopyPosition);
+
+	if (q->is_sem) {
+		k_sem_give(&q->sem);
+		return pdPASS;
+	}
+
+	return (k_msgq_put(&q->msgq, pvItemToQueue, ticks_to_timeout(xTicksToWait)) == 0)
+		       ? pdPASS
+		       : errQUEUE_FULL;
+}
+
+int32_t xQueueGenericSendFromISR(QueueHandle_t xQueue, const void *pvItemToQueue,
+				 int32_t *pxHigherPriorityTaskWoken, int32_t xCopyPosition)
+{
+	struct bflb_queue *q = (struct bflb_queue *)xQueue;
+
+	ARG_UNUSED(xCopyPosition);
+
+	if (pxHigherPriorityTaskWoken != NULL) {
+		*pxHigherPriorityTaskWoken = pdFALSE;
+	}
+
+	if (q->is_sem) {
+		k_sem_give(&q->sem);
+		return pdPASS;
+	}
+
+	return (k_msgq_put(&q->msgq, pvItemToQueue, K_NO_WAIT) == 0) ? pdPASS : errQUEUE_FULL;
+}
+
+int32_t xQueueReceive(QueueHandle_t xQueue, void *pvBuffer, uint32_t xTicksToWait)
+{
+	struct bflb_queue *q = (struct bflb_queue *)xQueue;
+	k_timeout_t timeout = ticks_to_timeout(xTicksToWait);
+
+	if (q->is_sem) {
+		return (k_sem_take(&q->sem, timeout) == 0) ? pdPASS : pdFAIL;
+	}
+
+	return (k_msgq_get(&q->msgq, pvBuffer, timeout) == 0) ? pdPASS : pdFAIL;
+}
+
+void vQueueDelete(QueueHandle_t xQueue)
+{
+	struct bflb_queue *q = (struct bflb_queue *)xQueue;
+
+	if (q != NULL) {
+		if (q->is_sem) {
+			k_sem_reset(&q->sem);
+		} else {
+			k_msgq_purge(&q->msgq);
+		}
+		k_heap_free(&shim_heap, q);
+	}
+}
+
+void *pvPortMalloc(size_t xWantedSize)
+{
+	return k_heap_alloc(&shim_heap, xWantedSize, K_NO_WAIT);
+}
+
+void vPortFree(void *pv)
+{
+	k_heap_free(&shim_heap, pv);
+}


### PR DESCRIPTION
- Add FreeRTOS-to-Zephyr shim (`freertos_shim.c`) for BLE controller blobs that call raw FreeRTOS APIs (BL60x, BL70x)
- Add btblecontroller OS port (`btblecontroller_port_os.c`) for blobs using the btblecontroller_* wrapper API (BL70xL, BL61x)
- Gate each behind a Kconfig bool (`BT_BFLB_FREERTOS_SHIM`, `BT_BFLB_BTBLE_PORT_OS`) selected by SoC-specific BLE drivers

Both shims map the blob's OS abstractions (tasks, queues, malloc) to Zephyr kernel primitives. Placing them in `soc/bflb/common/shim/` avoids duplicating identical code across ongoing/upcoming SoC BLE ports.
