### PR TITLE
scripts: gen_device_deps: Sort supported devices by DT dependency

### DIFF
--- a/scripts/build/gen_device_deps.py
+++ b/scripts/build/gen_device_deps.py
@@ -37,6 +37,17 @@ from elf_parser import ZephyrElf
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'dts', 'python-devicetree', 'src'))
 
 
+def get_device_dep_ord(dev):
+    if dev.edt_node:
+        if hasattr(dev.edt_node, 'dep_ordinal'):
+            return dev.edt_node.dep_ordinal
+        if hasattr(dev.edt_node, 'ordinal'):
+            return dev.edt_node.ordinal
+
+    # For devices without DT nodes, sort by handle after all DT devices
+    return 0x7FFFFFFF + dev.handle
+
+
 def parse_args():
     global args
 
@@ -172,7 +183,7 @@ def main():
             sorted_handles = {
                 "depends": sorted(dev.devs_depends_on, key=lambda d: d.handle),
                 "injected": sorted(dev.devs_depends_on_injected, key=lambda d: d.handle),
-                "supports": sorted(dev.devs_supports, key=lambda d: d.handle),
+                "supports": sorted(dev.devs_supports, key=get_device_dep_ord),
             }
             extra_sups = args.num_dynamic_devices if dev.pm and dev.pm.is_power_domain else 0
             lines = c_handle_comment(dev, sorted_handles)


### PR DESCRIPTION

When generating device dependency arrays, the supported devices list is currently sorted by device handle. This can cause child devices to be processed before their parent devices when a power domain resumes, leading to hardware access errors.
For example, with the NXP i.MX NETC hardware:
- netc-blk-ctrl (parent, dep_ord=297, handle=13)
- mdio (child, dep_ord=300, handle=10)
- ethernet (child, dep_ord=302, handle=12)

The current handle-based sorting produces the order [10, 12, 13],
causing MDIO and Ethernet to resume before the BLK controller has
configured the hardware. This results in bus faults when the child
devices attempt to access registers.

The devicetree dependency ordinal (dep_ord) represents the device's
position in the dependency tree, where parent nodes have smaller
ordinals than their children. Sorting by dep_ord ensures the correct
resume order: [13, 10, 12].

This fix changes the sorting key for supported devices from device handle to dependency ordinal, ensuring that parent devices are always processed before their children during power domain operations.

The sorting is performed at build time, so there is no runtime overhead.