### PR TITLE
soc: realtek: select GEN_ISR_TABLES for rtl87x2g

### DIFF
--- a/soc/realtek/bee/rtl87x2g/Kconfig
+++ b/soc/realtek/bee/rtl87x2g/Kconfig
@@ -8,6 +8,7 @@ config SOC_SERIES_RTL87X2G
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select CLOCK_CONTROL
+	select GEN_ISR_TABLES
 	select DYNAMIC_INTERRUPTS
 	select ARMV8_M_DSP
 	select ARMV8_1_M_MVEI


### PR DESCRIPTION
The function `z_isr_install()` is used during the rtl87x2g SoC init, necessitating `GEN_ISR_TABLES`.

Enabling this config also correctly causes the `arch.arm.irq_vector_table` testcase to be filtered out (skipped). This is expected behavior as that test is intended for configurations without `GEN_ISR_TABLES`.