### PR TITLE
random: xoshiro128: remove unneeded SYS_INIT

### DIFF
--- a/subsys/random/random_xoshiro128.c
+++ b/subsys/random/random_xoshiro128.c
@@ -42,14 +42,6 @@ static inline uint32_t rotl(const uint32_t x, int k)
 	return (x << k) | (x >> (32 - k));
 }
 
-static int xoshiro128_initialize(void)
-{
-	if (!device_is_ready(entropy_driver)) {
-		return -ENODEV;
-	}
-	return 0;
-}
-
 static void xoshiro128_init_state(void)
 {
 	int rc;
@@ -112,9 +104,3 @@ void z_impl_sys_rand_get(void *dst, size_t outlen)
 		memcpy(unaligned, &ret, rem);
 	}
 }
-
-/* In-tree entropy drivers will initialize in PRE_KERNEL_1; ensure that they're
- * initialized properly before initializing ourselves.
- */
-SYS_INIT(xoshiro128_initialize, PRE_KERNEL_2,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Inside the init function, it was only checked if the entropy device is ready and if it is not ready a error code is returned. This is useless as the return codes of SYS_INIT() functions are not used or saved, in difference to device inits.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>