### PR TITLE
drivers: sensor: clock: fix overflow when converting cycles to ns

### DIFF
--- a/drivers/sensor/sensor_clock_external.c
+++ b/drivers/sensor/sensor_clock_external.c
@@ -58,9 +58,23 @@ int sensor_clock_get_cycles(uint64_t *cycles)
 	return rc;
 }
 
+/*
+ * Convert external clock cycles to nanoseconds.
+ *
+ * Unlike for sys clocks, which have k_cyc_to_ns_near64(), there isn't a similar conversion macro
+ * for external clocks. In practice this will always choose the slower conversion path since clock
+ * frequency (f) is not known at compile time. The conversion is done in a way that doesn't overflow
+ * the value.
+ *
+ * @param t Time in cycles
+ * @param f Clock frequency
+ * @return Time in nanoseconds rounded to nearest
+ */
+#define sensor_clk_ext_cyc_to_ns_near64(t, f) z_tmcvt_64(t, f, Z_HZ_ns, false, false, true)
+
 uint64_t sensor_clock_cycles_to_ns(uint64_t cycles)
 {
-	return (cycles * NSEC_PER_SEC) / freq;
+	return sensor_clk_ext_cyc_to_ns_near64(cycles, freq);
 }
 
 SYS_INIT(external_sensor_clock_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/drivers/sensor/sensor_clock_sys.c
+++ b/drivers/sensor/sensor_clock_sys.c
@@ -25,5 +25,5 @@ int sensor_clock_get_cycles(uint64_t *cycles)
 
 uint64_t sensor_clock_cycles_to_ns(uint64_t cycles)
 {
-	return (cycles * NSEC_PER_SEC) / sys_clock_hw_cycles_per_sec();
+	return k_cyc_to_ns_near64(cycles);
 }


### PR DESCRIPTION
The straightforward way to convert cycles to nanoseconds with
```
  cycles * NSEC_PER_SEC / cycles_per_sec
```
will easily overflow the multiplication in the numerator. Rewriting the operation as
```
  NSEC_PER_SEC * (cycles / cycles_per_sec + (cycles % cycles_per_sec) / cycles_per_sec)
```
or `NSEC_PER_SEC * (quot + (rem / cycles_per_sec))` improves the situation and allows useful sensor timestamps for a bit longer before overflows are a concern.

The API in sys/time_units.h handles exactly this type of numerical manipulation for time units which might overflow. The predefined macros only handle conversions between the various `Z_HZ_*` macros so a wrapper for `z_tmcvt_64` is required for the external clock case.

The time conversion macros do hide a gotcha in that they determine the conversion style (slow & safe / unsafe & fast) based on `CONFIG_SYS_CLOCK_MAX_TIMEOUT_DAYS`. I think in practice, with the default value of 365 any reasonable device will not experience unexpected overflows as `cyc -> ns` would overflow after 365 days with a clock frequency of ~500Hz. So it should always choose the safe implementation.

I tested this with a `nucleo_u5a5zj_q` using a simple loop to read / decode the internal die temperature sensor. With the default clock frequencies the sensor timestamp overflows after 115.2 seconds. Switching to `time_unit.h` macros fixed the issue. For the external clock, I used the 32bit counter to verify that the timestamps still work as expected, but obviously I haven't been able to test the overflow case. 
