### PR TITLE
drivers: i2c: i2c_nrfx_twim: take into account clock inaccuaracies

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -17,7 +17,25 @@ extern "C" {
 #endif
 
 #define I2C_NRFX_TWIM_INVALID_FREQUENCY ((nrf_twim_frequency_t)-1)
-#define I2C_NRFX_TWIM_FREQUENCY(bitrate)                                                           \
+
+/* Formula for getting the frequency settings is following:
+ * 2^12 * (2^20 / (f_PCLK / desired_frequency)) where f_PCLK is a frequency that
+ * drives the TWIM.
+ *
+ * @param f_pclk Frequency of the clock that drives the peripheral.
+ * @param baudrate Desired baudrate.
+ *
+ * @return Frequency setting to be written to the FREQUENCY register
+ */
+#define I2C_NRFX_TWIM_FREQUENCY_CALCULATE(bitrate, f_pclk) \
+	((nrf_twim_frequency_t)((BIT(20) / DIV_ROUND_CLOSEST(f_pclk, bitrate)) << 12))
+
+#define I2C_NRFX_TWIM_FREQUENCY_CALCULATE_CORRECTED(bitrate, f_pclk, tolerance_percent)		\
+	I2C_NRFX_TWIM_FREQUENCY_CALCULATE(bitrate,						\
+					  DIV_ROUND_CLOSEST(f_pclk * (100 + tolerance_percent), \
+					  100))
+
+#define I2C_NRFX_TWIM_FREQUENCY_ENUM_GET(bitrate, f_pclk)                                          \
 	(bitrate == I2C_BITRATE_STANDARD ? NRF_TWIM_FREQ_100K                                      \
 	 : bitrate == 250000             ? NRF_TWIM_FREQ_250K                                      \
 	 : bitrate == I2C_BITRATE_FAST                                                             \
@@ -26,8 +44,16 @@ extern "C" {
 			      (bitrate == I2C_BITRATE_FAST_PLUS ? NRF_TWIM_FREQ_1000K :))          \
 			   I2C_NRFX_TWIM_INVALID_FREQUENCY)
 
-#define I2C_FREQUENCY(inst) \
-	I2C_NRFX_TWIM_FREQUENCY(DT_INST_PROP_OR(inst, clock_frequency, I2C_BITRATE_STANDARD))
+#define INTENDED_CLOCK_FREQUENCY(inst) DT_INST_PROP_OR(inst, clock_frequency, I2C_BITRATE_STANDARD)
+#define CLOCK_TOLERANCE(inst) DT_INST_PROP(inst, clock_tolerance_percent)
+
+#define I2C_FREQUENCY(inst)									 \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clock_tolerance_percent),			 \
+		    (I2C_NRFX_TWIM_FREQUENCY_CALCULATE_CORRECTED(INTENDED_CLOCK_FREQUENCY(inst), \
+								 NRF_PERIPH_GET_FREQUENCY(inst), \
+								 CLOCK_TOLERANCE(inst))),	 \
+		    (I2C_NRFX_TWIM_FREQUENCY_ENUM_GET(INTENDED_CLOCK_FREQUENCY(inst),		 \
+						      NRF_PERIPH_GET_FREQUENCY(inst))))
 
 /* Macro determines PM actions interrupt safety level.
  *

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -25,3 +25,9 @@ properties:
     description: |
       Maximum number of bits available in the EasyDMA MAXCNT register. This
       property must be set at SoC level DTS files.
+
+  clock-tolerance-percent:
+    type: int
+    description: |
+      This property is used to correct for clock inaccuracy to ensure that SCL
+      frequency does not exceed the value specified in "clock-frequency".

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -308,6 +308,7 @@
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -347,6 +348,7 @@
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -386,6 +388,7 @@
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -612,6 +615,7 @@
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -353,6 +353,7 @@
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -392,6 +393,7 @@
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -431,6 +433,7 @@
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -652,6 +655,7 @@
 				reg = <0xed000 0x1000>;
 				interrupts = <237 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -691,6 +695,7 @@
 				reg = <0xee000 0x1000>;
 				interrupts = <238 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};
@@ -745,6 +750,7 @@
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
+				clock-tolerance-percent = <6>;
 				status = "disabled";
 				zephyr,pm-device-runtime-auto;
 			};


### PR DESCRIPTION
Take into account clock inaccuracies when calculating FREQUENCY register value in TWIM.