### PR TITLE
drivers: regulator: shell: fix uninitialized variables

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -164,7 +164,7 @@ static int cmd_vlist(const struct shell *sh, size_t argc, char **argv)
 	volt_cnt = regulator_count_voltages(dev);
 
 	for (unsigned int i = 0U; i < volt_cnt; i++) {
-		int32_t volt_uv;
+		int32_t volt_uv = 0;
 
 		(void)regulator_list_voltage(dev, i, &volt_uv);
 
@@ -245,7 +245,7 @@ static int cmd_clist(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	unsigned int current_cnt;
-	int32_t last_current_ua;
+	int32_t last_current_ua = 0;
 
 	ARG_UNUSED(argc);
 
@@ -258,7 +258,7 @@ static int cmd_clist(const struct shell *sh, size_t argc, char **argv)
 	current_cnt = regulator_count_current_limits(dev);
 
 	for (unsigned int i = 0U; i < current_cnt; i++) {
-		int32_t current_ua;
+		int32_t current_ua = 0;
 
 		(void)regulator_list_current_limit(dev, i, &current_ua);
 


### PR DESCRIPTION
This PR fixes warnings due to uninitialized variables in the clist and vlist commands.

These have been found using the zephyr 1.0.0-rc1 sdk.

```
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c: In function 'cmd_clist':
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c:266:51: error: 'current_ua' may be used uninitialized [-Werror=maybe-uninitialized]
  266 |                 if ((i == 0U) || (last_current_ua != current_ua)) {
      |                                  ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c:261:25: note: 'current_ua' declared here
  261 |                 int32_t current_ua;
      |                         ^~~~~~~~~~
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c: In function 'cmd_vlist':
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c:172:48: error: 'volt_uv' may be used uninitialized [-Werror=maybe-uninitialized]
  172 |                 if ((i == 0U) || (last_volt_uv != volt_uv)) {
      |                                  ~~~~~~~~~~~~~~^~~~~~~~~~~
/home/user/west_workspace/zephyr/drivers/regulator/regulator_shell.c:167:25: note: 'volt_uv' declared here
  167 |                 int32_t volt_uv;
      |                         ^~~~~~~

```