### PR TITLE
Bluetooth: BAP: QoS fixes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -83,6 +83,20 @@ Bluetooth Audio
   as :c:func:`bt_cap_commander_broadcast_reception_start` now ensures this when
   :c:member:`bt_cap_commander_cb.broadcast_reception_start` is called. This also applies for
   :c:func:`bt_cap_commander_broadcast_reception_stop` in a similar manner. (:github:`101070`)
+* :c:member:`bt_bap_stream.qos` is now ``const``, to better reflect that it is a read-only
+  value. Any non-read uses of it will need to be set with the appropriate operations such as
+  :c:func:`bt_bap_unicast_group_create`, :c:func:`bt_bap_unicast_group_reconfig`,
+  :c:func:`bt_bap_broadcast_source_create` or :c:func:`bt_bap_broadcast_source_reconfig`.
+  (:github:`104887`)
+* Almost all API uses of ``struct bt_bap_qos_cfg *`` is now const, which means that once the
+  ``qos`` has been stored in a parameter struct like
+  :c:struct:`bt_bap_broadcast_source_param` or
+  :c:struct:`bt_bap_unicast_group_stream_param`, then the parameter's pointer cannot be used
+  to modify the ``qos``, and the actual definition of the struct should be modified instead.
+  (:github:`104219`)
+* :c:member:`bt_bap_unicast_group_info.sink_pd` and :c:member:`bt_bap_unicast_group_info.source_pd`
+  now reflect the local values defined for the group, and not the values configured for any remote
+  ASEs. (:github:`104887`)
 
 Networking
 **********

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -933,8 +933,12 @@ struct bt_bap_stream {
 	 */
 	const struct bt_audio_codec_cfg *codec_cfg;
 
-	/** QoS Configuration */
-	struct bt_bap_qos_cfg *qos;
+	/** QoS Configuration
+	 *
+	 * Only valid if the endpoint for this stream is non-NULL and the state is
+	 * @ref BT_BAP_EP_STATE_QOS_CONFIGURED or higher.
+	 */
+	const struct bt_bap_qos_cfg *qos;
 
 	/** Audio stream operations */
 	struct bt_bap_stream_ops *ops;

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1631,7 +1631,7 @@ struct bt_bap_unicast_group_stream_param {
 	struct bt_bap_stream *stream;
 
 	/** The QoS settings for the stream object. */
-	struct bt_bap_qos_cfg *qos;
+	const struct bt_bap_qos_cfg *qos;
 };
 
 /**
@@ -2354,7 +2354,7 @@ struct bt_bap_broadcast_source_param {
 	struct bt_bap_broadcast_source_subgroup_param *params;
 
 	/** Quality of Service configuration. */
-	struct bt_bap_qos_cfg *qos;
+	const struct bt_bap_qos_cfg *qos;
 
 	/**
 	 * @brief Broadcast Source packing mode.

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1792,13 +1792,17 @@ int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_gro
 struct bt_bap_unicast_group_info {
 	/** Presentation delay for sink ASEs
 	 *
-	 * Will be @ref BT_BAP_PD_UNSET if no sink ASEs have been QoS configured
+	 * Will be @ref BT_BAP_PD_UNSET if no sink streams have been added to group.
+	 * The value does not reflect what has been configured on any remote ASEs, but only the
+	 * local value from when the group was created or reconfigured.
 	 */
 	uint32_t sink_pd;
 
 	/** Presentation delay for source ASEs
 	 *
-	 * Will be @ref BT_BAP_PD_UNSET if no source ASEs have been QoS configured
+	 * Will be @ref BT_BAP_PD_UNSET if no source streams have been added to group.
+	 * The value does not reflect what has been configured on any remote ASEs, but only the
+	 * local value from when the group was created or reconfigured.
 	 */
 	uint32_t source_pd;
 };

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -269,7 +269,7 @@ struct bt_cap_unicast_group_stream_param {
 	struct bt_cap_stream *stream;
 
 	/** The QoS settings for the stream object. */
-	struct bt_bap_qos_cfg *qos_cfg;
+	const struct bt_bap_qos_cfg *qos_cfg;
 };
 
 /**
@@ -666,7 +666,7 @@ struct bt_cap_initiator_broadcast_create_param {
 	struct bt_cap_initiator_broadcast_subgroup_param *subgroup_params;
 
 	/** Quality of Service configuration. */
-	struct bt_bap_qos_cfg *qos;
+	const struct bt_bap_qos_cfg *qos;
 
 	/**
 	 * @brief Broadcast Source packing mode.

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1684,6 +1684,7 @@ static int ase_config(struct bt_ascs_ase *ase, const struct bt_ascs_config *cfg)
 	ascs_cp_rsp_success(ASE_ID(ase));
 
 	bt_bap_stream_attach(ase->conn, stream, &ase->ep);
+	stream->codec_cfg = &ase->ep.codec_cfg;
 
 	ascs_ep_set_state(&ase->ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 
@@ -1760,6 +1761,7 @@ int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 	ep->qos_pref = *qos_pref;
 
 	bt_bap_stream_attach(conn, stream, ep);
+	stream->codec_cfg = &ep->codec_cfg;
 
 	err = ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -695,18 +695,16 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 			if (ret < 0) {
 				LOG_DBG("Invalid BASE: %d", ret);
 				return false;
-			} else if (ret != sink->biginfo_num_bis) {
+			} else if (ret != sink->biginfo.num_bis) {
 				LOG_DBG("BASE contains different amount of BIS (%u) than reported "
 					"by BIGInfo (%u)",
-					ret, sink->biginfo_num_bis);
+					ret, sink->biginfo.num_bis);
 				return false;
 			}
 		}
 
 		/* Store newest BASE info until we are BIG synced */
 		if (sink->big == NULL) {
-			sink->qos_cfg.pd = bt_bap_base_get_pres_delay(base);
-
 			sink->subgroup_count = 0;
 			sink->valid_indexes_bitfield = 0;
 			bt_bap_base_foreach_subgroup(base, base_decode_subgroup_cb, sink);
@@ -834,10 +832,7 @@ static void biginfo_recv(struct bt_le_per_adv_sync *sync,
 		return;
 	}
 
-	atomic_set_bit(sink->flags,
-		       BT_BAP_BROADCAST_SINK_FLAG_BIGINFO_RECEIVED);
-	sink->iso_interval = biginfo->iso_interval;
-	sink->biginfo_num_bis = biginfo->num_bis;
+	atomic_set_bit(sink->flags, BT_BAP_BROADCAST_SINK_FLAG_BIGINFO_RECEIVED);
 	if (biginfo->encryption != atomic_test_bit(sink->flags,
 						   BT_BAP_BROADCAST_SINK_FLAG_BIG_ENCRYPTED)) {
 		atomic_set_bit_to(sink->flags,
@@ -850,10 +845,7 @@ static void biginfo_recv(struct bt_le_per_adv_sync *sync,
 		}
 	}
 
-	sink->qos_cfg.framing = biginfo->framing;
-	sink->qos_cfg.phy = biginfo->phy;
-	sink->qos_cfg.sdu = biginfo->max_sdu;
-	sink->qos_cfg.interval = biginfo->sdu_interval;
+	(void)memcpy(&sink->biginfo, biginfo, sizeof(sink->biginfo));
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&sink_cbs, listener, _node) {
 		if (listener->syncable != NULL) {
@@ -1014,13 +1006,26 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 	stream->iso = &iso->chan;
 	ep->id = id;
 
-	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->rx, &sink->qos_cfg);
+	(void)memset(&ep->qos, 0, sizeof(ep->qos));
+	ep->qos.pd = bt_bap_base_get_pres_delay((const struct bt_bap_base *)sink->base);
+	ep->qos.framing = sink->biginfo.framing;
+	ep->qos.phy = sink->biginfo.phy;
+	ep->qos.rtn = 0U; /* unknown for broadcast sinks */
+	ep->qos.sdu = sink->biginfo.max_sdu;
+	ep->qos.interval = sink->biginfo.sdu_interval;
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	ep->qos.max_pdu = sink->biginfo.max_pdu;
+	ep->qos.burst_number = sink->biginfo.burst_number;
+	ep->qos.num_subevents = sink->biginfo.sub_evt_count;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->rx, &ep->qos);
 	(void)memcpy(&ep->codec_cfg, codec_cfg, sizeof(*codec_cfg));
 
 	bt_bap_iso_unref(iso);
 
 	bt_bap_stream_attach(NULL, stream, ep);
-	stream->qos = &sink->qos_cfg;
+	stream->codec_cfg = &ep->codec_cfg;
+	stream->qos = &ep->qos;
 	stream->group = sink;
 
 	return 0;
@@ -1378,7 +1383,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	param.num_bis = sink->stream_count;
 	param.bis_bitfield = indexes_bitfield;
 	param.mse = 0; /* Let controller decide */
-	param.sync_timeout = interval_to_sync_timeout(sink->iso_interval);
+	param.sync_timeout = interval_to_sync_timeout(sink->biginfo.iso_interval);
 	param.encryption = atomic_test_bit(sink->flags,
 					   BT_BAP_BROADCAST_SINK_FLAG_BIG_ENCRYPTED);
 	if (param.encryption) {

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -370,7 +370,7 @@ broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 	stream->iso = &iso->chan;
 	ep->id = id;
 
-	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->tx, qos);
+	(void)memcpy(&ep->qos, qos, sizeof(*qos));
 	(void)memcpy(&ep->codec_cfg, subgroup_codec_cfg, sizeof(*subgroup_codec_cfg));
 
 	/* If there are any BIS specific codec configuration data, update the data to contain both
@@ -387,7 +387,8 @@ broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 	bt_bap_iso_unref(iso);
 
 	bt_bap_stream_attach(NULL, stream, ep);
-	stream->qos = qos;
+	stream->codec_cfg = &ep->codec_cfg;
+	stream->qos = &ep->qos;
 	stream->group = source;
 	ep->broadcast_source = source;
 
@@ -484,6 +485,7 @@ static bool encode_base(struct bt_bap_broadcast_source *source, struct net_buf_s
 	struct bt_bap_broadcast_subgroup *subgroup;
 	uint8_t streams_encoded;
 	uint8_t subgroup_count;
+	uint32_t pd;
 
 	/* 13 is the size of the fixed size values following this check */
 	if ((buf->size - buf->len) < MINIMUM_BASE_SIZE) {
@@ -492,12 +494,30 @@ static bool encode_base(struct bt_bap_broadcast_source *source, struct net_buf_s
 
 	subgroup_count = 0U;
 	SYS_SLIST_FOR_EACH_CONTAINER(&source->subgroups, subgroup, _node) {
+		/* All broadcast stream share the same PD, so just take the PD from the first stream
+		 * in the first subgroup
+		 */
+		if (subgroup_count == 0U) {
+			const struct bt_bap_stream *stream =
+				SYS_SLIST_PEEK_HEAD_CONTAINER(&subgroup->streams, stream, _node);
+
+			__ASSERT(stream != NULL && stream->ep != NULL,
+				 "stream or stream->ep was NULL");
+			pd = stream->ep->qos.pd;
+		}
+
 		subgroup_count++;
+	}
+
+	/* The minimum number of subgroups in a broadcast source is 1 */
+	if (subgroup_count == 0U) {
+		LOG_DBG("Invalid number of subgroups for broadcast source");
+		return false;
 	}
 
 	net_buf_simple_add_le16(buf, BT_UUID_BASIC_AUDIO_VAL);
 
-	net_buf_simple_add_le24(buf, source->qos->pd);
+	net_buf_simple_add_le24(buf, pd);
 	net_buf_simple_add_u8(buf, subgroup_count);
 
 	/* Since the `stream_data` is only stored in the broadcast source,
@@ -840,7 +860,6 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 
 	/* Finalize state changes and store information */
 	broadcast_source_set_state(source, BT_BAP_EP_STATE_QOS_CONFIGURED);
-	source->qos = qos;
 	source->packing = param->packing;
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	source->irc = param->irc;
@@ -1022,15 +1041,11 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 		struct bt_bap_stream *stream;
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, stream, _node) {
-			struct bt_iso_chan_io_qos *iso_qos;
+			struct bt_bap_ep *ep = stream->ep;
 
-			iso_qos = stream->ep->iso->chan.qos->tx;
-			bt_bap_qos_cfg_to_iso_qos(iso_qos, qos);
-			stream->qos = qos;
+			(void)memcpy(&ep->qos, qos, sizeof(*qos));
 		}
 	}
-
-	source->qos = qos;
 
 	return 0;
 }
@@ -1089,6 +1104,7 @@ int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source, struct
 	struct bt_bap_broadcast_subgroup *subgroup;
 	enum bt_bap_ep_state broadcast_state;
 	struct bt_bap_stream *stream;
+	struct bt_bap_qos_cfg *qos;
 	size_t bis_count;
 	int err;
 
@@ -1109,19 +1125,38 @@ int bt_bap_broadcast_source_start(struct bt_bap_broadcast_source *source, struct
 	}
 
 	bis_count = 0;
+	qos = NULL;
 	SYS_SLIST_FOR_EACH_CONTAINER(&source->subgroups, subgroup, _node) {
 		SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, stream, _node) {
+			struct bt_bap_ep *ep = stream->ep;
+			struct bt_iso_chan_io_qos *iso_qos = ep->iso->chan.qos->tx;
+
 			bis[bis_count++] = bt_bap_stream_iso_chan_get(stream);
+
+			bt_bap_qos_cfg_to_iso_qos(iso_qos, &ep->qos);
+
+			/* All BIS will share the same QOS values */
+			if (qos == NULL) {
+				qos = &ep->qos;
+			}
 		}
+	}
+
+	if (bis_count == 0U) {
+		/* TODO: This is just an extra check. Ideally this will never happen, but the above
+		 * is not (yet) thread safe so we need to handle this case.
+		 */
+		LOG_DBG("Can not start source with no streams");
+		return -ENOEXEC;
 	}
 
 	/* Create BIG */
 	param.num_bis = bis_count;
 	param.bis_channels = bis;
-	param.framing = source->qos->framing;
+	param.framing = qos->framing;
 	param.packing = source->packing;
-	param.interval = source->qos->interval;
-	param.latency = source->qos->latency;
+	param.interval = qos->interval;
+	param.latency = qos->latency;
 	param.encryption = source->encryption;
 	if (param.encryption) {
 		(void)memcpy(param.bcode, source->broadcast_code, sizeof(param.bcode));

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -347,8 +347,8 @@ static int
 broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 			      const struct bt_audio_codec_cfg *subgroup_codec_cfg,
 			      const struct bt_bap_broadcast_source_stream_param *stream_param,
-			      struct bt_bap_qos_cfg *qos, struct bt_bap_broadcast_source *source,
-			      uint8_t id)
+			      const struct bt_bap_qos_cfg *qos,
+			      struct bt_bap_broadcast_source *source, uint8_t id)
 {
 	struct bt_bap_iso *iso;
 	struct bt_bap_ep *ep;
@@ -766,7 +766,7 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_param *param,
 				   struct bt_bap_broadcast_source **out_source)
 {
 	struct bt_bap_broadcast_source *source;
-	struct bt_bap_qos_cfg *qos;
+	const struct bt_bap_qos_cfg *qos;
 	size_t stream_count;
 	uint8_t index;
 	int err;
@@ -993,7 +993,7 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 {
 	struct bt_bap_broadcast_subgroup *subgroup = NULL;
 	enum bt_bap_ep_state broadcast_state;
-	struct bt_bap_qos_cfg *qos;
+	const struct bt_bap_qos_cfg *qos;
 
 	if (source == NULL) {
 		LOG_DBG("source is NULL");

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -116,7 +116,6 @@ struct bt_bap_broadcast_source {
 	bool encryption;
 
 	struct bt_iso_big *big;
-	struct bt_bap_qos_cfg *qos;
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	/* Stored advanced parameters */
 	uint8_t irc;
@@ -172,12 +171,10 @@ struct bt_bap_broadcast_sink {
 	uint8_t stream_count;
 	uint8_t bass_src_id;
 	uint8_t subgroup_count;
-	uint16_t iso_interval;
-	uint16_t biginfo_num_bis;
 	uint32_t broadcast_id; /* 24 bit */
 	uint32_t indexes_bitfield;
 	uint32_t valid_indexes_bitfield; /* based on codec support */
-	struct bt_bap_qos_cfg qos_cfg;
+	struct bt_iso_biginfo biginfo;
 	struct bt_le_per_adv_sync *pa_sync;
 	struct bt_iso_big *big;
 	uint8_t base_size;

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -87,7 +87,7 @@ void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, st
 			stream->conn = bt_conn_ref(conn);
 		}
 	}
-	stream->codec_cfg = &ep->codec_cfg;
+
 	stream->ep = ep;
 	ep->stream = stream;
 }

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -866,36 +866,6 @@ static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,
 	iso_io_qos->rtn = qos->rtn;
 }
 
-static void check_and_reset_group_pd(struct bt_bap_unicast_group *group, enum bt_audio_dir dir)
-{
-	bool dir_in_idle_or_config_state = true;
-	struct bt_bap_stream *stream;
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
-		if (stream->ep == NULL || stream->ep->dir != dir) {
-			continue;
-		}
-
-		if (stream->ep->state == BT_BAP_EP_STATE_IDLE ||
-		    stream->ep->state == BT_BAP_EP_STATE_CODEC_CONFIGURED) {
-			continue;
-		} else {
-			dir_in_idle_or_config_state = false;
-			break;
-		}
-	}
-
-	if (dir_in_idle_or_config_state) {
-		if (dir == BT_AUDIO_DIR_SINK) {
-			group->sink_pd = BT_BAP_PD_UNSET;
-		} else if (dir == BT_AUDIO_DIR_SOURCE) {
-			group->source_pd = BT_BAP_PD_UNSET;
-		} else {
-			__ASSERT(false, "Invalid dir %d", dir);
-		}
-	}
-}
-
 static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_simple *buf)
 {
 	struct bt_bap_unicast_client_ep *client_ep =
@@ -927,11 +897,6 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 
 	cfg = net_buf_simple_pull_mem(buf, sizeof(*cfg));
 
-	if (stream->codec_cfg == NULL) {
-		LOG_ERR("Stream %p does not have a codec configured", stream);
-		return;
-	}
-
 	if (buf->len < cfg->cc_len) {
 		LOG_ERR("Malformed ASE Config status: buf->len %u < %u cc_len", buf->len,
 			cfg->cc_len);
@@ -956,7 +921,7 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 		"latency %u pd_min %u pd_max %u pref_pd_min %u pref_pd_max %u codec 0x%02x ",
 		bt_audio_dir_str(ep->dir), pref->unframed_supported, pref->phy, pref->rtn,
 		pref->latency, pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max,
-		stream->codec_cfg->id);
+		cfg->codec.id);
 
 	if (!bt_bap_valid_qos_pref(pref)) {
 		LOG_DBG("Invalid QoS preferences");
@@ -970,14 +935,7 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 
 	unicast_client_ep_set_codec_cfg(ep, cfg->codec.id, sys_le16_to_cpu(cfg->codec.cid),
 					sys_le16_to_cpu(cfg->codec.vid), cc, cfg->cc_len);
-
-	/* Every time a stream enters the codec configured state, there is a chance that all streams
-	 * in that direction has exited the QoS configured state, and we need to update the stored
-	 * presentation delay
-	 */
-	if (stream->group != NULL) {
-		check_and_reset_group_pd((struct bt_bap_unicast_group *)stream->group, ep->dir);
-	}
+	stream->codec_cfg = &ep->codec_cfg;
 
 	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->configured != NULL) {
@@ -1048,40 +1006,40 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 
 	ep->cig_id = qos->cig_id;
 	ep->cis_id = qos->cis_id;
-	(void)memcpy(&stream->qos->interval, sys_le24_to_cpu(qos->interval), sizeof(qos->interval));
-	stream->qos->framing = qos->framing;
-	stream->qos->phy = qos->phy;
-	stream->qos->sdu = sys_le16_to_cpu(qos->sdu);
-	stream->qos->rtn = qos->rtn;
-	stream->qos->latency = sys_le16_to_cpu(qos->latency);
-	(void)memcpy(&stream->qos->pd, sys_le24_to_cpu(qos->pd), sizeof(qos->pd));
+	ep->qos.interval = sys_get_le24(qos->interval);
+	ep->qos.framing = qos->framing;
+	ep->qos.phy = qos->phy;
+	ep->qos.sdu = sys_le16_to_cpu(qos->sdu);
+	ep->qos.rtn = qos->rtn;
+	ep->qos.latency = sys_le16_to_cpu(qos->latency);
+	ep->qos.pd = sys_get_le24(qos->pd);
 
 	LOG_DBG("dir %s cig 0x%02x cis 0x%02x codec 0x%02x interval %u "
 		"framing 0x%02x phy 0x%02x rtn %u latency %u pd %u",
 		bt_audio_dir_str(dir), ep->cig_id, ep->cis_id, stream->codec_cfg->id,
-		stream->qos->interval, stream->qos->framing, stream->qos->phy, stream->qos->rtn,
-		stream->qos->latency, stream->qos->pd);
+		ep->qos.interval, ep->qos.framing, ep->qos.phy, ep->qos.rtn, ep->qos.latency,
+		ep->qos.pd);
 
 	__ASSERT_NO_MSG(stream->group != NULL);
 	group = (struct bt_bap_unicast_group *)stream->group;
 	if (dir == BT_AUDIO_DIR_SINK) {
 		if (group->sink_pd == BT_BAP_PD_UNSET) {
-			group->sink_pd = stream->qos->pd;
+			LOG_WRN("Group %p sink_pd is unset group", group);
 		} else {
-			if (group->sink_pd != stream->qos->pd) {
+			if (group->sink_pd != ep->qos.pd) {
 				LOG_WRN("Sink stream %p PD %u does not match the sink PD %u of the "
 					"group %p",
-					stream, stream->qos->pd, group->sink_pd, group);
+					stream, ep->qos.pd, group->sink_pd, group);
 			}
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		if (group->source_pd == BT_BAP_PD_UNSET) {
-			group->source_pd = stream->qos->pd;
+			LOG_WRN("Group %p source_pd is unset group", group);
 		} else {
-			if (group->source_pd != stream->qos->pd) {
+			if (group->source_pd != ep->qos.pd) {
 				LOG_WRN("Source stream %p PD %u does not match the source PD %u of "
 					"the group %p",
-					stream, stream->qos->pd, group->source_pd, group);
+					stream, ep->qos.pd, group->source_pd, group);
 			}
 		}
 	} else {
@@ -1098,6 +1056,7 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 	}
 
 	/* Notify upper layer */
+	stream->qos = &ep->qos;
 	if (stream->ops != NULL && stream->ops->qos_set != NULL) {
 		stream->ops->qos_set(stream);
 	} else {
@@ -2028,30 +1987,13 @@ static int unicast_client_ep_config(struct bt_bap_ep *ep, struct net_buf_simple 
 	return 0;
 }
 
-int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *buf,
-				 struct bt_bap_qos_cfg *qos)
+static int unicast_client_add_qos(struct bt_bap_ep *ep, struct net_buf_simple *buf,
+				  struct bt_bap_qos_cfg *qos)
 {
 	struct bt_ascs_qos *req;
 	struct bt_conn_iso *conn_iso;
 
-	LOG_DBG("ep %p buf %p qos %p", ep, buf, qos);
-
-	if (ep == NULL || ep->iso == NULL || ep->iso->chan.iso == NULL) {
-		LOG_DBG("Invalid endpoint %p (%p (%p))", ep, ep == NULL ? NULL : ep->iso,
-			(ep == NULL || ep->iso == NULL) ? NULL : ep->iso->chan.iso);
-		return -EINVAL;
-	}
-
-	switch (ep->state) {
-	/* Valid only if ASE_State field = 0x01 (Codec Configured) */
-	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
-		/* or 0x02 (QoS Configured) */
-	case BT_BAP_EP_STATE_QOS_CONFIGURED:
-		break;
-	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
-		return -EINVAL;
-	}
+	LOG_DBG("ep %p buf %p (%u / %u) qos %p", ep, buf, buf->len, buf->size, qos);
 
 	conn_iso = &ep->iso->chan.iso->iso;
 
@@ -2059,6 +2001,10 @@ int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *bu
 		"phy 0x%02x sdu %u rtn %u latency %u pd %u",
 		ep->id, conn_iso->info.unicast.cig_id, conn_iso->info.unicast.cis_id, qos->interval,
 		qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
+
+	if (buf->len + sizeof(*req) > buf->size) {
+		return -ENOMEM;
+	}
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->id;
@@ -2387,6 +2333,37 @@ static void bt_bap_qos_cfg_to_cig_param(struct bt_iso_cig_param *cig_param,
 	}
 }
 
+static void unicast_client_iso_param_to_qos_cfg(const struct bt_bap_stream *stream,
+						struct bt_bap_qos_cfg *qos)
+{
+	const struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+	const struct bt_bap_unicast_group *unicast_group = stream->group;
+	const struct bt_iso_chan_io_qos *iso_qos;
+	enum bt_audio_dir dir = stream->ep->dir;
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		qos->pd = unicast_group->sink_pd;
+		qos->latency = unicast_group->cig_param.c_to_p_latency;
+		qos->interval = unicast_group->cig_param.c_to_p_interval;
+		iso_qos = &bap_iso->tx.qos;
+	} else {
+		qos->pd = unicast_group->source_pd;
+		qos->latency = unicast_group->cig_param.p_to_c_latency;
+		qos->interval = unicast_group->cig_param.p_to_c_interval;
+		iso_qos = &bap_iso->rx.qos;
+	}
+
+	qos->framing = unicast_group->cig_param.framing;
+	qos->phy = iso_qos->phy;
+	qos->rtn = iso_qos->rtn;
+	qos->sdu = iso_qos->sdu;
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	qos->max_pdu = iso_qos->max_pdu;
+	qos->burst_number = iso_qos->burst_number;
+	qos->num_subevents = bap_iso->qos.num_subevents;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+}
+
 static uint8_t unicast_group_get_cis_count(const struct bt_bap_unicast_group *unicast_group)
 {
 	uint8_t cis_count = 0U;
@@ -2452,25 +2429,6 @@ static int bt_audio_cig_reconfigure(struct bt_bap_unicast_group *group)
 	}
 
 	return 0;
-}
-
-static void audio_stream_qos_cleanup(const struct bt_conn *conn, struct bt_bap_unicast_group *group)
-{
-	struct bt_bap_stream *stream;
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
-		if (stream->conn != conn) {
-			/* Channel not part of this ACL, skip */
-			continue;
-		}
-
-		if (stream->ep == NULL) {
-			/* Stream did not have a endpoint configured yet */
-			continue;
-		}
-
-		bt_bap_iso_unbind_ep(stream->ep->iso, stream->ep);
-	}
 }
 
 static int unicast_client_cig_terminate(struct bt_bap_unicast_group *group)
@@ -2586,9 +2544,11 @@ static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *grou
 	if (dir == BT_AUDIO_DIR_SOURCE) {
 		group->cig_param.p_to_c_interval = qos->interval;
 		group->cig_param.p_to_c_latency = qos->latency;
+		group->source_pd = qos->pd;
 	} else {
 		group->cig_param.c_to_p_interval = qos->interval;
 		group->cig_param.c_to_p_latency = qos->latency;
+		group->sink_pd = qos->pd;
 	}
 }
 
@@ -2603,7 +2563,6 @@ static void unicast_group_add_stream(struct bt_bap_unicast_group *group,
 
 	__ASSERT_NO_MSG(stream->ep == NULL || (stream->ep != NULL && stream->ep->iso == NULL));
 
-	stream->qos = qos;
 	stream->group = group;
 
 	/* iso initialized already */
@@ -2742,6 +2701,9 @@ static void unicast_group_free(struct bt_bap_unicast_group *group)
 		sys_slist_remove(&group->streams, NULL, &stream->_node);
 	}
 
+	(void)memset(&group->cig_param, 0, sizeof(group->cig_param));
+	group->sink_pd = BT_BAP_PD_UNSET;
+	group->source_pd = BT_BAP_PD_UNSET;
 	group->allocated = false;
 }
 
@@ -2800,7 +2762,7 @@ static int stream_pair_param_check(const struct bt_bap_unicast_group_stream_pair
 static bool valid_unicast_group_stream_param(const struct bt_bap_unicast_group *unicast_group,
 					     const struct bt_bap_unicast_group_stream_param *param,
 					     struct bt_bap_unicast_group_cig_param *cig_param,
-					     enum bt_audio_dir dir)
+					     uint32_t *pd, enum bt_audio_dir dir)
 {
 	const struct bt_bap_qos_cfg *qos;
 
@@ -2852,6 +2814,12 @@ static bool valid_unicast_group_stream_param(const struct bt_bap_unicast_group *
 		} else if (cig_param->c_to_p_latency != qos->latency) {
 			return false;
 		}
+
+		if (*pd == BT_BAP_PD_UNSET) {
+			*pd = qos->pd;
+		} else if (*pd != qos->pd) {
+			return false;
+		}
 	} else {
 		if (cig_param->p_to_c_interval == 0) {
 			cig_param->p_to_c_interval = qos->interval;
@@ -2862,6 +2830,12 @@ static bool valid_unicast_group_stream_param(const struct bt_bap_unicast_group *
 		if (cig_param->p_to_c_latency == 0) {
 			cig_param->p_to_c_latency = qos->latency;
 		} else if (cig_param->p_to_c_latency != qos->latency) {
+			return false;
+		}
+
+		if (*pd == BT_BAP_PD_UNSET) {
+			*pd = qos->pd;
+		} else if (*pd != qos->pd) {
 			return false;
 		}
 	}
@@ -2884,9 +2858,10 @@ static bool valid_unicast_group_stream_param(const struct bt_bap_unicast_group *
 
 static bool
 valid_group_stream_pair_param(const struct bt_bap_unicast_group *unicast_group,
-			      const struct bt_bap_unicast_group_stream_pair_param *pair_param)
+			      const struct bt_bap_unicast_group_stream_pair_param *pair_param,
+			      struct bt_bap_unicast_group_cig_param *cig_param, uint32_t *sink_pd,
+			      uint32_t *source_pd)
 {
-	struct bt_bap_unicast_group_cig_param cig_param = {0};
 
 	if (pair_param == NULL) {
 		LOG_DBG("pair_param is NULL");
@@ -2895,14 +2870,14 @@ valid_group_stream_pair_param(const struct bt_bap_unicast_group *unicast_group,
 
 	if (pair_param->rx_param != NULL) {
 		if (!valid_unicast_group_stream_param(unicast_group, pair_param->rx_param,
-						      &cig_param, BT_AUDIO_DIR_SOURCE)) {
+						      cig_param, source_pd, BT_AUDIO_DIR_SOURCE)) {
 			return false;
 		}
 	}
 
 	if (pair_param->tx_param != NULL) {
 		if (!valid_unicast_group_stream_param(unicast_group, pair_param->tx_param,
-						      &cig_param, BT_AUDIO_DIR_SINK)) {
+						      cig_param, sink_pd, BT_AUDIO_DIR_SINK)) {
 			return false;
 		}
 	}
@@ -2913,6 +2888,10 @@ valid_group_stream_pair_param(const struct bt_bap_unicast_group *unicast_group,
 static bool valid_unicast_group_param(struct bt_bap_unicast_group *unicast_group,
 				      const struct bt_bap_unicast_group_param *param)
 {
+	struct bt_bap_unicast_group_cig_param cig_param = {0};
+	uint32_t source_pd = BT_BAP_PD_UNSET;
+	uint32_t sink_pd = BT_BAP_PD_UNSET;
+
 	if (param == NULL) {
 		LOG_DBG("streams is NULL");
 		return false;
@@ -2936,7 +2915,8 @@ static bool valid_unicast_group_param(struct bt_bap_unicast_group *unicast_group
 	}
 
 	for (size_t i = 0U; i < param->params_count; i++) {
-		if (!valid_group_stream_pair_param(unicast_group, &param->params[i])) {
+		if (!valid_group_stream_pair_param(unicast_group, &param->params[i], &cig_param,
+						   &sink_pd, &source_pd)) {
 			return false;
 		}
 	}
@@ -3102,6 +3082,9 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 				     struct bt_bap_unicast_group_stream_pair_param params[],
 				     size_t num_param)
 {
+	struct bt_bap_unicast_group_cig_param cig_param = {0};
+	uint32_t source_pd = BT_BAP_PD_UNSET;
+	uint32_t sink_pd = BT_BAP_PD_UNSET;
 	struct bt_bap_stream *tmp_stream;
 	size_t total_stream_cnt;
 	struct bt_iso_cig *cig;
@@ -3140,7 +3123,8 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 	}
 
 	for (size_t i = 0U; i < num_param; i++) {
-		if (!valid_group_stream_pair_param(unicast_group, &params[i])) {
+		if (!valid_group_stream_pair_param(unicast_group, &params[i], &cig_param, &sink_pd,
+						   &source_pd)) {
 			return -EINVAL;
 		}
 	}
@@ -3313,8 +3297,6 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 	struct net_buf_simple *buf;
 	struct bt_bap_ep *ep;
 	bool conn_stream_found;
-	uint32_t source_pd;
-	uint32_t sink_pd;
 	int err;
 
 	if (conn == NULL) {
@@ -3369,11 +3351,12 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 		return -EINVAL;
 	}
 
-	source_pd = group->source_pd;
-	sink_pd = group->sink_pd;
-
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		const struct bt_bap_ep *paired_ep;
+		struct bt_bap_qos_cfg qos;
+
+		__ASSERT_NO_MSG(stream->group == group);
+		__ASSERT_NO_MSG(stream->iso != NULL);
 
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
@@ -3386,14 +3369,13 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			return -EINVAL;
 		}
 
-		paired_ep = bt_bap_iso_get_paired_ep(ep);
-		if (paired_ep != NULL && paired_ep->stream != NULL &&
-		    paired_ep->stream->conn != NULL && paired_ep->stream->conn != stream->conn) {
-			LOG_DBG("Misconfigured group %p: Stream %p has endpoint %p for conn %p "
-				"paired with endpoint %p for conn %p",
-				group, stream, ep, stream->conn, paired_ep,
-				paired_ep->stream->conn);
+		if (ep->iso == NULL) {
+			LOG_DBG("stream->ep->iso is NULL");
+			return -EINVAL;
+		}
 
+		if (ep->iso->chan.iso == NULL) {
+			LOG_DBG("stream->ep->iso->chan.iso == NULL is NULL");
 			return -EINVAL;
 		}
 
@@ -3409,50 +3391,19 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			return -EINVAL;
 		}
 
-		if (bt_bap_stream_verify_qos(stream, stream->qos) != BT_BAP_ASCS_REASON_NONE) {
+		paired_ep = bt_bap_iso_get_paired_ep(ep);
+		if (paired_ep != NULL && paired_ep->stream != NULL &&
+		    paired_ep->stream->conn != NULL && paired_ep->stream->conn != stream->conn) {
+			LOG_DBG("Misconfigured group %p: Stream %p has endpoint %p for conn %p "
+				"paired with endpoint %p for conn %p",
+				group, stream, ep, stream->conn, paired_ep,
+				paired_ep->stream->conn);
+
 			return -EINVAL;
 		}
 
-		/* Verify ep->dir and presentation delay. If the group already has a configured
-		 * presentation delay in a direction, we compare the stream's presentation delay
-		 * with the group's presentation delay, and if they differ we reject the request.
-		 * As per the BAP spec section 7.1, all streams in a direction shall have the same
-		 * presentation delay. The group presentation delay is set once any endpoint in a
-		 * direction has changed state to "QoS configured" or "above", and cleared again if
-		 * all endpoints for that direction enters the codec configured or idle state.
-		 * The check for presentation delay is also conditional on whether other devices are
-		 * involved - If there is only a single connection that has ASEs in a QoS Configured
-		 * state or "above", then we can freely modify the presentation delay.
-		 */
-		switch (ep->dir) {
-		case BT_AUDIO_DIR_SINK:
-			if (sink_pd == BT_BAP_PD_UNSET) {
-				sink_pd = stream->qos->pd;
-			} else {
-				if (sink_qos_configured_on_other_conn &&
-				    sink_pd != stream->qos->pd) {
-					LOG_DBG("Sink stream %p did not have the same PD %u as "
-						"other sink streams %u",
-						stream, stream->qos->pd, sink_pd);
-					return -EINVAL;
-				}
-			}
-			break;
-		case BT_AUDIO_DIR_SOURCE:
-			if (source_pd == BT_BAP_PD_UNSET) {
-				source_pd = stream->qos->pd;
-			} else {
-				if (source_qos_configured_on_other_conn &&
-				    source_pd != stream->qos->pd) {
-					LOG_DBG("Source stream %p did not have the same PD %u as "
-						"other source streams %u",
-						stream, stream->qos->pd, source_pd);
-					return -EINVAL;
-				}
-			}
-			break;
-		default:
-			__ASSERT(false, "invalid endpoint dir: %u", ep->dir);
+		unicast_client_iso_param_to_qos_cfg(stream, &qos);
+		if (bt_bap_stream_verify_qos(stream, &qos) != BT_BAP_ASCS_REASON_NONE) {
 			return -EINVAL;
 		}
 
@@ -3477,6 +3428,8 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 	(void)memset(op, 0, sizeof(*op));
 	ep = NULL; /* Needed to find the control point handle */
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
+		struct bt_bap_qos_cfg qos;
+
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
 			continue;
@@ -3484,9 +3437,11 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 
 		op->num_ases++;
 
-		err = bt_bap_unicast_client_ep_qos(stream->ep, buf, stream->qos);
+		unicast_client_iso_param_to_qos_cfg(stream, &qos);
+		err = unicast_client_add_qos(stream->ep, buf, &qos);
 		if (err != 0) {
-			audio_stream_qos_cleanup(conn, group);
+			LOG_DBG("[%zu] Failed to add QoS parameters for stream %p: %d",
+				op->num_ases, stream, err);
 
 			return err;
 		}
@@ -3499,7 +3454,6 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 	err = bt_bap_unicast_client_ep_send(conn, ep, buf);
 	if (err != 0) {
 		LOG_DBG("Could not send config QoS: %d", err);
-		audio_stream_qos_cleanup(conn, group);
 
 		return err;
 	}

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -2531,7 +2531,8 @@ static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
 }
 
 static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *group,
-					       struct bt_bap_iso *iso, struct bt_bap_qos_cfg *qos,
+					       struct bt_bap_iso *iso,
+					       const struct bt_bap_qos_cfg *qos,
 					       enum bt_audio_dir dir)
 {
 	/* Store the stream Codec QoS in the bap_iso */
@@ -2557,7 +2558,7 @@ static void unicast_group_add_stream(struct bt_bap_unicast_group *group,
 				     struct bt_bap_iso *iso, enum bt_audio_dir dir)
 {
 	struct bt_bap_stream *stream = param->stream;
-	struct bt_bap_qos_cfg *qos = param->qos;
+	const struct bt_bap_qos_cfg *qos = param->qos;
 
 	LOG_DBG("group %p stream %p qos %p iso %p dir %u", group, stream, qos, iso, dir);
 

--- a/subsys/bluetooth/audio/bap_unicast_client_internal.h
+++ b/subsys/bluetooth/audio/bap_unicast_client_internal.h
@@ -37,9 +37,6 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream);
 
 struct net_buf_simple *bt_bap_unicast_client_ep_create_pdu(struct bt_conn *conn, uint8_t op);
 
-int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *buf,
-				 struct bt_bap_qos_cfg *qos);
-
 int bt_bap_unicast_client_ep_send(struct bt_conn *conn, struct bt_bap_ep *ep,
 				  struct net_buf_simple *buf);
 

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1259,129 +1259,6 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
-static int cmd_stream_qos(const struct shell *sh, size_t argc, char *argv[])
-{
-	struct bt_bap_qos_cfg *qos;
-	unsigned long interval;
-	int err = 0;
-
-	if (default_stream == NULL) {
-		shell_print(sh, "No stream selected");
-		return -ENOEXEC;
-	}
-
-	qos = default_stream->qos;
-
-	if (qos == NULL) {
-		shell_print(sh, "Stream not configured");
-		return -ENOEXEC;
-	}
-
-	interval = shell_strtoul(argv[1], 0, &err);
-	if (err != 0) {
-		return -ENOEXEC;
-	}
-
-	if (!IN_RANGE(interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
-		return -ENOEXEC;
-	}
-
-	qos->interval = interval;
-
-	if (argc > 2) {
-		unsigned long framing;
-
-		framing = shell_strtoul(argv[2], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (framing != BT_ISO_FRAMING_UNFRAMED && framing != BT_ISO_FRAMING_FRAMED) {
-			return -ENOEXEC;
-		}
-
-		qos->framing = framing;
-	}
-
-	if (argc > 3) {
-		unsigned long latency;
-
-		latency = shell_strtoul(argv[3], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (!IN_RANGE(latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
-			return -ENOEXEC;
-		}
-
-		qos->latency = latency;
-	}
-
-	if (argc > 4) {
-		unsigned long pd;
-
-		pd = shell_strtoul(argv[4], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (pd > BT_AUDIO_PD_MAX) {
-			return -ENOEXEC;
-		}
-
-		qos->pd = pd;
-	}
-
-	if (argc > 5) {
-		unsigned long sdu;
-
-		sdu = shell_strtoul(argv[5], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (sdu > BT_ISO_MAX_SDU) {
-			return -ENOEXEC;
-		}
-
-		qos->sdu = sdu;
-	}
-
-	if (argc > 6) {
-		unsigned long phy;
-
-		phy = shell_strtoul(argv[6], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (phy != BT_GAP_LE_PHY_1M && phy != BT_GAP_LE_PHY_2M &&
-		    phy != BT_GAP_LE_PHY_CODED) {
-			return -ENOEXEC;
-		}
-
-		qos->phy = phy;
-	}
-
-	if (argc > 7) {
-		unsigned long rtn;
-
-		rtn = shell_strtoul(argv[7], 0, &err);
-		if (err != 0) {
-			return -ENOEXEC;
-		}
-
-		if (rtn > BT_ISO_CONNECTED_RTN_MAX) {
-			return -ENOEXEC;
-		}
-
-		qos->rtn = rtn;
-	}
-
-	return 0;
-}
-
 static int set_group_param(
 	const struct shell *sh, struct bt_bap_unicast_group_param *group_param,
 	struct bt_bap_unicast_group_stream_pair_param pair_param[ARRAY_SIZE(unicast_streams)],
@@ -4244,8 +4121,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)
 	SHELL_CMD_ARG(create_broadcast_sink, NULL, "0x<broadcast_id>", cmd_create_broadcast_sink, 2,
 		      0),
-	SHELL_CMD_ARG(create_sink_by_name, NULL, "<broadcast_name>",
-		      cmd_create_sink_by_name, 2, 0),
+	SHELL_CMD_ARG(create_sink_by_name, NULL, "<broadcast_name>", cmd_create_sink_by_name, 2, 0),
 	SHELL_CMD_ARG(sync_broadcast, NULL,
 		      "0x<bis_index> [[[0x<bis_index>] 0x<bis_index>] ...] "
 		      "[bcode <broadcast code> || bcode_str <broadcast code as string>]",
@@ -4260,8 +4136,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(config, NULL,
 		      "<direction: sink, source> <index> [loc <loc_bits>] [preset <preset_name>]",
 		      cmd_config, 3, 4),
-	SHELL_CMD_ARG(stream_qos, NULL, "interval [framing] [latency] [pd] [sdu] [phy] [rtn]",
-		      cmd_stream_qos, 2, 6),
 	SHELL_CMD_ARG(connect, NULL, "Connect the CIS of the stream", cmd_connect, 1, 0),
 	SHELL_CMD_ARG(qos, NULL, "Send QoS configure for Unicast Group", cmd_qos, 1, 0),
 	SHELL_CMD_ARG(enable, NULL, "[context]", cmd_enable, 1, 1),

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -50,6 +50,7 @@ ZTEST_RULE(mock_rule, mock_init_rule_before, mock_destroy_rule_after);
 struct bap_broadcast_source_test_suite_fixture {
 	struct bt_bap_broadcast_source_param *param;
 	struct bt_audio_codec_cfg *codec_cfg;
+	struct bt_bap_qos_cfg *qos_cfg;
 	uint8_t *bis_data;
 	size_t stream_cnt;
 	struct bt_bap_broadcast_source *source;
@@ -69,7 +70,6 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	const enum bt_audio_location loc = BT_AUDIO_LOCATION_FRONT_LEFT;
 	struct bt_bap_broadcast_source_subgroup_param *subgroup_param;
 	struct bt_bap_broadcast_source_stream_param *stream_params;
-	struct bt_bap_qos_cfg *qos_cfg;
 	struct bt_bap_stream *streams;
 	const uint16_t latency = 10U; /* ms*/
 	const uint32_t pd = 40000U;   /* us */
@@ -89,8 +89,8 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	zassert_not_null(stream_params);
 	fixture->codec_cfg = malloc(sizeof(struct bt_audio_codec_cfg));
 	zassert_not_null(fixture->codec_cfg);
-	qos_cfg = malloc(sizeof(struct bt_bap_qos_cfg));
-	zassert_not_null(qos_cfg);
+	fixture->qos_cfg = malloc(sizeof(struct bt_bap_qos_cfg));
+	zassert_not_null(fixture->qos_cfg);
 	streams = malloc(sizeof(struct bt_bap_stream) * CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
 	zassert_not_null(streams);
 	fixture->bis_data = malloc(CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
@@ -105,14 +105,14 @@ static void bap_broadcast_source_test_suite_fixture_init(
 	       sizeof(struct bt_bap_broadcast_source_stream_param) *
 		       CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
 	memset(fixture->codec_cfg, 0, sizeof(struct bt_audio_codec_cfg));
-	memset(qos_cfg, 0, sizeof(struct bt_bap_qos_cfg));
+	memset(fixture->qos_cfg, 0, sizeof(struct bt_bap_qos_cfg));
 	memset(streams, 0, sizeof(struct bt_bap_stream) * CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT);
 	memset(fixture->bis_data, 0, CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE);
 
 	/* Initialize default values*/
 	*fixture->codec_cfg = BT_AUDIO_CODEC_LC3_CONFIG(
 		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10, loc, 40U, 1, ctx);
-	*qos_cfg = BT_BAP_QOS_CFG_UNFRAMED(10000u, sdu, rtn, latency, pd);
+	*fixture->qos_cfg = BT_BAP_QOS_CFG_UNFRAMED(10000u, sdu, rtn, latency, pd);
 	memcpy(fixture->bis_data, bis_cfg_data, sizeof(bis_cfg_data));
 
 	for (size_t i = 0U; i < CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT; i++) {
@@ -130,7 +130,7 @@ static void bap_broadcast_source_test_suite_fixture_init(
 
 	fixture->param->params_count = CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT;
 	fixture->param->params = subgroup_param;
-	fixture->param->qos = qos_cfg;
+	fixture->param->qos = fixture->qos_cfg;
 	fixture->param->encryption = false;
 	memset(fixture->param->broadcast_code, 0, sizeof(fixture->param->broadcast_code));
 	fixture->param->packing = BT_ISO_PACKING_SEQUENTIAL;
@@ -180,8 +180,8 @@ static void bap_broadcast_source_test_suite_after(void *f)
 	free(param->params[0].params);
 	free(fixture->codec_cfg);
 	free(fixture->bis_data);
+	free(fixture->qos_cfg);
 	free(param->params);
-	free(param->qos);
 	free(param);
 
 	bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
@@ -345,7 +345,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_inval_subg
 ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_inval_qos_null)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
-	struct bt_bap_qos_cfg *qos = create_param->qos;
+	const struct bt_bap_qos_cfg *qos = create_param->qos;
 	int err;
 
 	create_param->qos = NULL;
@@ -596,9 +596,9 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_reconfigure_singl
 	}
 
 	reconf_param->params_count = 1U;
-	reconf_param->qos->sdu = 100U;
-	reconf_param->qos->rtn = 3U;
-	reconf_param->qos->phy = 1U;
+	fixture->qos_cfg->sdu = 100U;
+	fixture->qos_cfg->rtn = 3U;
+	fixture->qos_cfg->phy = 1U;
 
 	err = bt_bap_broadcast_source_reconfig(fixture->source, reconf_param);
 	zassert_equal(0, err, "Unable to reconfigure broadcast source: err %d", err);
@@ -647,9 +647,9 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_reconfigure_all)
 		}
 	}
 
-	reconf_param->qos->sdu = 100U;
-	reconf_param->qos->rtn = 3U;
-	reconf_param->qos->phy = 1U;
+	fixture->qos_cfg->sdu = 100U;
+	fixture->qos_cfg->rtn = 3U;
+	fixture->qos_cfg->phy = 1U;
 
 	err = bt_bap_broadcast_source_reconfig(fixture->source, reconf_param);
 	zassert_equal(0, err, "Unable to reconfigure broadcast source: err %d", err);
@@ -780,7 +780,6 @@ ZTEST_F(bap_broadcast_source_test_suite,
 ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_reconfigure_inval_qos_null)
 {
 	struct bt_bap_broadcast_source_param *param = fixture->param;
-	struct bt_bap_qos_cfg *qos = param->qos;
 	int err;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",
@@ -791,8 +790,6 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_reconfigure_inval
 
 	param->qos = NULL;
 	err = bt_bap_broadcast_source_reconfig(fixture->source, param);
-	/* Restore the params for the cleanup after function */
-	param->qos = qos;
 	zassert_not_equal(0, err, "Did not fail with NULL qos");
 
 	err = bt_bap_broadcast_source_delete(fixture->source);

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -554,7 +554,8 @@ static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
 }
 
 static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *group,
-					       struct bt_bap_iso *iso, struct bt_bap_qos_cfg *qos,
+					       struct bt_bap_iso *iso,
+					       const struct bt_bap_qos_cfg *qos,
 					       enum bt_audio_dir dir)
 {
 	/* Store the stream Codec QoS in the bap_iso */
@@ -578,7 +579,7 @@ static void unicast_group_add_stream(struct bt_bap_unicast_group *group,
 				     struct bt_bap_iso *iso, enum bt_audio_dir dir)
 {
 	struct bt_bap_stream *stream = param->stream;
-	struct bt_bap_qos_cfg *qos = param->qos;
+	const struct bt_bap_qos_cfg *qos = param->qos;
 
 	__ASSERT_NO_MSG(stream->ep == NULL || (stream->ep != NULL && stream->ep->iso == NULL));
 


### PR DESCRIPTION
Makes the use of QoS more consistent, reduce memory requirements and make it const/read-only where applicable.

Fixes: #110775