### PR TITLE
drivers: rtc: rtc_counter: fix rtc_api alarm run failed in mcxe31b

### DIFF
--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,6 +26,8 @@ struct rtc_counter_config {
 struct rtc_counter_data {
 	/* Offset in counter ticks between raw counter and Unix epoch */
 	int64_t epoch_offset;
+	/* true once rtc_set_time() establishes epoch_offset */
+	bool epoch_valid;
 	/* protects epoch_offset */
 	struct k_spinlock lock;
 #ifdef CONFIG_RTC_ALARM
@@ -124,15 +126,26 @@ static void rtc_counter_alarm_callback(const struct device *counter_dev, uint8_t
 {
 	struct rtc_counter_data *data = (struct rtc_counter_data *)user_data;
 	const struct device *rtc_dev = data->rtc_dev;
+	rtc_alarm_callback cb = NULL;
+	void *cb_user_data = NULL;
 
-	if (chan_id < data->num_alarm_chans && data->alarm_callback[chan_id] != NULL) {
-		data->alarm_callback[chan_id](rtc_dev, chan_id, data->alarm_user_data[chan_id]);
-		data->alarm_pending[chan_id] = false;
-	} else if (chan_id < data->num_alarm_chans) {
-		data->alarm_pending[chan_id] = true;
-	} else {
+	ARG_UNUSED(counter_dev);
+	ARG_UNUSED(ticks);
+
+	if (chan_id >= data->num_alarm_chans) {
 		LOG_DBG("Spurious alarm callback on channel %u (max %u)", chan_id,
 			data->num_alarm_chans ? (data->num_alarm_chans - 1U) : 0U);
+		return;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		data->alarm_pending[chan_id] = true;
+		cb = data->alarm_callback[chan_id];
+		cb_user_data = data->alarm_user_data[chan_id];
+	}
+
+	if (cb != NULL) {
+		cb(rtc_dev, chan_id, cb_user_data);
 	}
 }
 
@@ -171,6 +184,7 @@ static int rtc_counter_alarm_set_time(const struct device *dev, uint16_t id, uin
 	uint32_t alarm_ticks;
 	uint32_t now_raw;
 	struct counter_alarm_cfg alarm_cfg;
+	bool epoch_valid;
 
 	if (!data->alarm_capable) {
 		return -ENOTSUP;
@@ -213,6 +227,16 @@ static int rtc_counter_alarm_set_time(const struct device *dev, uint16_t id, uin
 	/* Convert desired absolute Unix time to a raw tick value for the counter */
 	K_SPINLOCK(&data->lock) {
 		epoch = data->epoch_offset;
+		epoch_valid = data->epoch_valid;
+		/* Record configured mask and time for get_time; clear pending */
+		data->alarm_mask[id] = mask;
+		data->alarm_time[id] = *timeptr;
+		data->alarm_pending[id] = false;
+	}
+
+	/* Allow configuring alarms before rtc_set_time(). Arm them on set_time(). */
+	if (!epoch_valid) {
+		return 0;
 	}
 
 	raw_alarm_ticks_64 = (int64_t)desired_ticks - epoch;
@@ -245,14 +269,16 @@ static int rtc_counter_alarm_set_time(const struct device *dev, uint16_t id, uin
 	alarm_cfg.user_data = data;
 	alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE;
 
-	/* Record configured mask and time for get_time; clear pending */
-	K_SPINLOCK(&data->lock) {
-		data->alarm_mask[id] = mask;
-		data->alarm_time[id] = *timeptr;
-		data->alarm_pending[id] = false;
+	ret = counter_set_channel_alarm(config->counter_dev, (uint8_t)id, &alarm_cfg);
+	if (ret == -ETIME) {
+		/* Treat "late" as an immediate expiry when EXPIRE_WHEN_LATE was requested. */
+		K_SPINLOCK(&data->lock) {
+			data->alarm_pending[id] = true;
+		}
+		return 0;
 	}
 
-	return counter_set_channel_alarm(config->counter_dev, (uint8_t)id, &alarm_cfg);
+	return ret;
 }
 
 static int rtc_counter_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
@@ -420,8 +446,15 @@ static void rtc_counter_reschedule_alarms(const struct device *dev)
 		alarm_cfg.ticks = alarm_ticks;
 		alarm_cfg.user_data = data;
 		alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE;
+		int set_ret;
 
-		(void)counter_set_channel_alarm(config->counter_dev, (uint8_t)id, &alarm_cfg);
+		set_ret = counter_set_channel_alarm(config->counter_dev, (uint8_t)id,
+					   &alarm_cfg);
+		if (set_ret == -ETIME) {
+			K_SPINLOCK(&data->lock) {
+				data->alarm_pending[id] = true;
+			}
+		}
 	}
 }
 
@@ -464,6 +497,7 @@ static int rtc_counter_set_time(const struct device *dev, const struct rtc_time 
 	/* Update the software offset (in ticks): offset = desired_ticks - now_ticks */
 	K_SPINLOCK(&data->lock) {
 		data->epoch_offset = (int64_t)desired_ticks - (int64_t)now_ticks;
+		data->epoch_valid = true;
 	}
 
 #ifdef CONFIG_RTC_ALARM
@@ -578,6 +612,7 @@ static int rtc_counter_init(const struct device *dev)
 
 	/* Start with zero offset until rtc_set_time is called */
 	data->epoch_offset = 0;
+	data->epoch_valid = false;
 
 #ifdef CONFIG_RTC_ALARM
 	data->rtc_dev = dev;


### PR DESCRIPTION
This fixes rtc_api failures on FRDM-MCXE31B when using the zephyr,rtc-counter RTC wrapper.

The root cause:
- rtc_counter rejected rtc_alarm_set_time() calls made before rtc_set_time() established the epoch offset.
- Alarm “pending” status handling depended on whether a callback was installed, which can break tests expecting pending to latch when the alarm fires.

Solution:
- Track whether the epoch offset is valid (epoch_valid) and allow configuring alarms before rtc_set_time() by deferring counter alarm programming until the epoch is established.
- Set the alarm pending flag when an alarm fires regardless of whether a user callback is installed.
- When the underlying counter reports -ETIME for an absolute alarm with EXPIRE_WHEN_LATE, treat it as an immediate expiry by setting pending and returning success.

rtc_api run result in frdm_mcxe31b:
```
[20:34:55.187]*** Booting Zephyr OS build v4.3.
[20:34:55.219]0-7283-g413c115d357b ***
Running TESTSUITE rtc_api
===================================================================
START - test_alarm

[20:35:21.198] PASS - test_alarm in 26.001 seconds
===================================================================
START - test_alarm_callback

[20:35:47.212] PASS 
[20:35:47.240]- test_alarm_callback in 26.001 seconds
===================================================================
START - test_set_get_time
 PASS - test_set_get_time in 0.001 seconds
===================================================================
START - test_time_counting

[20:35:58.242] PASS - test_time_counting in
[20:35:58.289] 11.003 seconds
===================================================================
START - test_y2k

[20:36:00.254] PASS - test_y2k in 2.001 sec
[20:36:00.314]onds
===================================================================
TESTSUITE rtc_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [rtc_api]: pass = 5, fail = 0, skip = 0, total = 5 duration = 65.007 seconds
 - PASS - [rtc_api.test_alarm] duration = 26.001 seconds
 - PASS - [rtc_api.test_alarm_callback] duration = 26.001 seconds
 - PASS - [rtc_api.test_set_get_time] duration = 0.001 seconds
 - PASS - [rtc_api.test_time_counting] duration = 11.003 seconds
 - PASS - [rtc_api.test_y2k] duration = 2.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

This PR relates to https://github.com/zephyrproject-rtos/zephyr/pull/103552