### PR TITLE
drivers: pwm: stm32: Fix builds without mastermode support

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -225,7 +225,7 @@ static inline bool is_center_aligned(const uint32_t ll_countermode)
 
 static void ll_tim_set_trigger_output(TIM_TypeDef *timer, uint32_t mode)
 {
-#ifdef HAS_MASTERMODE_SUPPORT
+#if HAS_MASTERMODE_SUPPORT
 	LL_TIM_SetTriggerOutput(timer, mode);
 #else
 	ARG_UNUSED(timer);


### PR DESCRIPTION
Correct an #if which otherwise is always true, so we do not refer to a function which does not exist otherwise.

Fixes build failures in main which can be reproduced for example with:
```
mkdir build && cd build
cmake -GNinja -DBOARD=nucleo_wb09ke/stm32wb09 ../tests/drivers/pwm/pwm_api/ 
ninja
```
Introduced by
* https://github.com/zephyrproject-rtos/zephyr/commit/bb16624662f865a16bd877278e27ff40adca695a (the bug can be seen quite clearly in this diff)
* https://github.com/zephyrproject-rtos/zephyr/pull/97433