### PR TITLE
rtc:stm32: allow disabling of pending alarm

### DIFF
--- a/drivers/rtc/rtc_stm32.c
+++ b/drivers/rtc/rtc_stm32.c
@@ -859,12 +859,11 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 
 		stm32_backup_domain_enable_access();
 
-		if (rtc_stm32_is_active_alarm(RTC, id)) {
-			LL_RTC_DisableWriteProtection(RTC);
-			rtc_stm32_disable_alarm(RTC, id);
-			rtc_stm32_disable_interrupt_alarm(RTC, id);
-			LL_RTC_EnableWriteProtection(RTC);
-		}
+		LL_RTC_DisableWriteProtection(RTC);
+		rtc_stm32_disable_alarm(RTC, id);
+		rtc_stm32_disable_interrupt_alarm(RTC, id);
+		LL_RTC_EnableWriteProtection(RTC);
+
 		LOG_DBG("Alarm %d has been disabled", id);
 		goto disable_bkup_access;
 	}


### PR DESCRIPTION
Currently there's no way of disabling an RTC alarm if it's set; only if it's active. This commit disables the alarm, regardless of the status.

I don't know if this is the correct way to do it, but I don't really see the point of checking if the alarm has "gone off" before disabling it