### PR TITLE
watchdog: stm32n6: enable IWDG & WWDG on the STM32N6X series

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -139,10 +139,6 @@
 	status = "okay";
 };
 
-&wwdg {
-	status = "okay";
-};
-
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>; /* Arduino A0 */
 	pinctrl-names = "default";

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -54,6 +54,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 
 	csi_connector: connector_csi {
@@ -332,5 +333,9 @@ csi_interface: &dcmipp {
 };
 
 &rng {
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -204,10 +204,6 @@
 	status = "okay";
 };
 
-&wwdg {
-	status = "okay";
-};
-
 &rtc {
 	clocks = <&rcc STM32_CLOCK(APB1, 30)>,
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -206,10 +206,6 @@
 	status = "okay";
 };
 
-&wwdg {
-	status = "okay";
-};
-
 &adc1 {
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A3 */
 	pinctrl-names = "default";

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -31,6 +31,7 @@
 		led0 = &green_led_1;
 		led1 = &red_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 
 	psram: memory@90000000 {
@@ -570,5 +571,9 @@ zephyr_jpegenc: &jpeg {
 };
 
 &rng {
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -22,6 +22,7 @@ supported:
   - usb_device
   - usbd
   - video
+  - watchdog
 variants:
   stm32n6570_dk/stm32n657xx:
     twister: false

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -140,6 +140,8 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 		LL_DBGMCU_APB4_GRP1_FreezePeriph(LL_DBGMCU_APB4_GRP1_IWDG_STOP);
 #elif defined(CONFIG_SOC_SERIES_STM32MP2X)
 		LL_DBGMCU_APB3_GRP1_FreezePeriph(LL_DBGMCU_APB3_GRP1_IWDG4_STOP);
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+		LL_DBGMCU_APB4_FreezePeriph(LL_DBGMCU_APB4_GRP1_IWDG_STOP);
 #else
 		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_IWDG_STOP);
 #endif

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1442,6 +1442,21 @@
 			resets = <&rctl STM32_RESET(AHB5, 3)>;
 			status = "disabled";
 		};
+
+		iwdg: watchdog@56004800 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x56004800 0x400>;
+			interrupts = <18 0>;
+			status = "disabled";
+		};
+
+		wwdg: watchdog@50002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x50002c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <19 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/watchdog/wdt_basic_api/boards/stm32_iwdg.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/stm32_iwdg.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		watchdog0 = &iwdg;
+	};
+};
+
 &wwdg {
 	status = "disabled";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		watchdog0 = &wwdg;
+	};
+};
+
 &rcc {
 	/* Reduce APB1 speed to achieve test window timings */
 	apb1-prescaler = <16>;

--- a/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg_h7.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg_h7.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		watchdog0 = &wwdg;
+	};
+};
+
 /* stm32h7 has no apb1 prescaler */
 
 &wwdg {

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -68,6 +68,7 @@ tests:
       - nucleo_u575zi_q
       - nucleo_c031c6
       - nucleo_wba55cg
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.stm32wwdg_h7:
@@ -107,6 +108,7 @@ tests:
       - stm32h7s78_dk
       - nucleo_u385rg_q
       - nucleo_wba55cg
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.mec15xxevb_assy6853:


### PR DESCRIPTION
This PR enables the IWDG and WWDG for the STM32N6 series. It enables them for both Discovery and Nucleo N6 boards.

This has been successfully test using the samples/drivers/watchdog by with either IWDG or WWDG as watchdog0.