### PR TITLE
soc: nxp: imxrt118x: fix boot container image entry fields

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -99,9 +99,10 @@ const __imx_boot_container_section container boot_header = {
 	},
 	.array = {
 		{
-			(uint32_t)(-1 * CONFIG_IMAGE_CONTAINER_OFFSET),
-			(uint32_t)_flash_used,
-			(uint32_t)__rom_region_start,
+			(uint32_t)CONFIG_CONTAINER_USER_IMAGE_OFFSET,
+			(uint32_t)(_flash_used - CONFIG_CONTAINER_USER_IMAGE_OFFSET -
+				CONFIG_IMAGE_CONTAINER_OFFSET),
+			(uint32_t)_vector_start,
 			0x00000000,
 			(uint32_t)__start,
 			0x00000000,


### PR DESCRIPTION
The image array entry in the boot container had incorrect values for offset, size, and load_addr fields, preventing use with NXP Secure Provisioning Tool (SPT).

The offset was calculated as -1 * CONFIG_IMAGE_CONTAINER_OFFSET (0xFFFFF000) instead of CONFIG_CONTAINER_USER_IMAGE_OFFSET (0xA000). The size and load_addr fields did not account for the header region.

These fields now correctly reflect the flash layout with container at 0x1000 and application code at 0xB000.