### PR TITLE
samples: boards: espressif: ulp: add console harness to timer_wakeup

### DIFF
--- a/samples/boards/espressif/ulp/lp_core/timer_wakeup/sample.yaml
+++ b/samples/boards/espressif/ulp/lp_core/timer_wakeup/sample.yaml
@@ -7,3 +7,11 @@ tests:
     tags:
       - samples
     sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "First boot, LP core will wake us every"
+        - "HP core entering deep sleep"
+        - "Woke up from LP core! Wake count:"

--- a/samples/boards/espressif/ulp/lp_core/timer_wakeup/src/main.c
+++ b/samples/boards/espressif/ulp/lp_core/timer_wakeup/src/main.c
@@ -20,7 +20,7 @@ int main(void)
 
 	if (cause & RESET_LOW_POWER_WAKE) {
 		wake_count++;
-		printf("Woke up from LP core (LP timer)! Wake count: %d\n", wake_count);
+		printf("Woke up from LP core! Wake count: %d\n", wake_count);
 	} else {
 		wake_count = 0;
 		printf("First boot, LP core will wake us every %d ms\n",


### PR DESCRIPTION
Add console harness configuration to the LP core timer wakeup sample to enable automated test validation via expected serial output matching.