### PR TITLE
arch: arm64: mmu: page-align address and size in add_arm_mmu_region()

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -879,9 +879,15 @@ static inline void add_arm_mmu_region(struct arm_mmu_ptables *ptables,
 				      uint32_t extra_flags)
 {
 	if (region->size || region->attrs) {
+		uintptr_t pa = ROUND_DOWN(region->base_pa, CONFIG_MMU_PAGE_SIZE);
+		uintptr_t va = ROUND_DOWN(region->base_va, CONFIG_MMU_PAGE_SIZE);
+		size_t pa_offset = region->base_pa - pa;
+		size_t size = ROUND_UP(region->size + pa_offset,
+				       CONFIG_MMU_PAGE_SIZE);
+
 		/* MMU not yet active: must use unlocked version */
-		__add_map(ptables, region->name, region->base_pa, region->base_va,
-			  region->size, region->attrs | extra_flags);
+		__add_map(ptables, region->name, pa, va,
+			  size, region->attrs | extra_flags);
 	}
 }
 


### PR DESCRIPTION
Static MMU region entries populated via
MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY() pass raw DTS reg address and size values to __add_map(), which asserts page-alignment. DTS nodes may legitimately have non-page-aligned reg sizes reflecting actual hardware register footprints, causing an assert crash during early boot when CONFIG_ASSERT=y.

Align the base address down and size up to CONFIG_MMU_PAGE_SIZE in add_arm_mmu_region(), mirroring the k_mem_region_align() logic already used by the dynamic DEVICE_MMIO_MAP path in kernel/mmu.c. This ensures all static platform MMU region entries are mapped with page-granular parameters regardless of DTS reg values.