### PR TITLE
Fix native posix newline and buf size

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -266,6 +266,15 @@ config POSIX_ARCH_CONSOLE_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 
+config POSIX_ARCH_CONSOLE_STDOUT_BUF_SIZE
+	int "Standard output buffer size"
+	default 256
+	depends on POSIX_ARCH_CONSOLE
+	help
+	  Size of the buffer used to buffer printk messages before flushing
+	  to the host terminal. Messages are flushed on newline or when the
+	  buffer is full.
+
 config SEMIHOST_CONSOLE
 	bool "Use semihosting for console"
 	select CONSOLE_HAS_DRIVER

--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -17,24 +17,21 @@ static int n_pend; /* Number of pending characters in buffer */
 #if defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE)
 static int print_char(int c)
 {
-	int printnow = 0;
-
-	if ((c != '\n') && (c != '\r')) {
-		stdout_buff[n_pend++] = c;
-		stdout_buff[n_pend] = 0;
-	} else {
-		printnow = 1;
+	if (c == '\r') {
+		/* Discard carriage return */
+		return c;
 	}
 
-	if (n_pend >= _STDOUT_BUF_SIZE - 1) {
-		printnow = 1;
-	}
+	stdout_buff[n_pend++] = c;
+	stdout_buff[n_pend] = 0;
 
-	if (printnow) {
-		posix_print_trace("%s\n", stdout_buff);
+	/* Flush if buffer is full or on newline */
+	if (n_pend >= sizeof(stdout_buff) - 1 || c == '\n') {
+		posix_print_trace("%s", stdout_buff);
 		n_pend = 0;
 		stdout_buff[0] = 0;
 	}
+
 	return c;
 }
 #endif /* defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE) */

--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -10,7 +10,7 @@
 #include <zephyr/sys/printk-hooks.h>
 #include <zephyr/sys/libc-hooks.h>
 
-#define _STDOUT_BUF_SIZE 256
+#define _STDOUT_BUF_SIZE CONFIG_POSIX_ARCH_CONSOLE_STDOUT_BUF_SIZE
 static char stdout_buff[_STDOUT_BUF_SIZE];
 static int n_pend; /* Number of pending characters in buffer */
 

--- a/subsys/logging/backends/Kconfig.native_posix
+++ b/subsys/logging/backends/Kconfig.native_posix
@@ -11,6 +11,14 @@ config LOG_BACKEND_NATIVE_POSIX
 
 if LOG_BACKEND_NATIVE_POSIX
 
+config LOG_BACKEND_NATIVE_POSIX_STDOUT_BUF_SIZE
+	int "Standard output buffer size"
+	default 256
+	help
+	  Size of the buffer used to buffer log messages before flushing
+	  to the host terminal. Messages are flushed on newline or when the
+	  buffer is full.
+
 backend = NATIVE_POSIX
 backend-str = native_posix
 source "subsys/logging/Kconfig.template.log_format_config"

--- a/subsys/logging/backends/log_backend_native_posix.c
+++ b/subsys/logging/backends/log_backend_native_posix.c
@@ -21,25 +21,17 @@ static uint32_t log_format_current = CONFIG_LOG_BACKEND_NATIVE_POSIX_OUTPUT_DEFA
 
 static void preprint_char(int c)
 {
-	int printnow = 0;
-
 	if (c == '\r') {
-		/* Discard carriage returns */
+		/* Discard carriage return */
 		return;
 	}
-	if (c != '\n') {
-		stdout_buff[n_pend++] = c;
-		stdout_buff[n_pend] = 0;
-	} else {
-		printnow = 1;
-	}
 
-	if (n_pend >= _STDOUT_BUF_SIZE - 1) {
-		printnow = 1;
-	}
+	stdout_buff[n_pend++] = c;
+	stdout_buff[n_pend] = 0;
 
-	if (printnow) {
-		posix_print_trace("%s\n", stdout_buff);
+	/* Flush if buffer is full or on newline */
+	if (n_pend >= sizeof(stdout_buff) - 1 || c == '\n') {
+		posix_print_trace("%s", stdout_buff);
 		n_pend = 0;
 		stdout_buff[0] = 0;
 	}

--- a/subsys/logging/backends/log_backend_native_posix.c
+++ b/subsys/logging/backends/log_backend_native_posix.c
@@ -14,7 +14,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/arch/posix/posix_trace.h>
 
-#define _STDOUT_BUF_SIZE 256
+#define _STDOUT_BUF_SIZE CONFIG_LOG_BACKEND_NATIVE_POSIX_STDOUT_BUF_SIZE
 static char stdout_buff[_STDOUT_BUF_SIZE];
 static int n_pend; /* Number of pending characters in buffer */
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_NATIVE_POSIX_OUTPUT_DEFAULT;


### PR DESCRIPTION
Add native posix buffer configuration to avoid buffer flushing in the middle of writing ANSI escape sequences.
This causes printing issues of the sequence.

Fixes: #104906