### PR TITLE
drivers: clock_control_nxp_mc_cgm.c: Unreachable adc,lpcmp,tempsens

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -203,12 +203,8 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 		CLOCK_EnableClock(kCLOCK_Pit2Clk);
 		break;
 #endif
-	default:
-		return -ENOTSUP;
-	}
 
 #if defined(CONFIG_COMPARATOR_NXP_LPCMP)
-	switch ((uint32_t)sub_system) {
 	case MCUX_CMP0_CLK:
 		CLOCK_EnableClock(kCLOCK_Lpcmp0);
 		break;
@@ -222,13 +218,9 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 		CLOCK_EnableClock(kCLOCK_Lpcmp2);
 		break;
 #endif /* FSL_FEATURE_SOC_LPCMP_COUNT > 2U */
-	default:
-		break;
-	}
 #endif /* CONFIG_COMPARATOR_NXP_HSCMP */
 
 #if defined(CONFIG_ADC_NXP_SAR_ADC)
-	switch ((uint32_t)sub_system) {
 	case MCUX_ADC0_CLK:
 		CLOCK_EnableClock(kCLOCK_Adc0);
 		break;
@@ -240,16 +232,16 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 		CLOCK_EnableClock(kCLOCK_Adc2);
 		break;
 #endif /* FSL_FEATURE_SOC_ADC_COUNT > 2U */
-	default:
-		break;
-	}
 #endif /* CONFIG_ADC_NXP_SAR_ADC */
 
 #if defined(CONFIG_NXP_TEMPSENSE)
-	if ((uint32_t)sub_system == MCUX_TEMPSENSE_CLK) {
+	case MCUX_TEMPSENSE_CLK:
 		CLOCK_EnableClock(kCLOCK_TempSensor);
-	}
+		break;
 #endif /* CONFIG_NXP_TEMPSENSE */
+	default:
+		return -ENOTSUP;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
In the function `mc_cgm_clock_control_on`, in first switch-case
was added a `default`-case which returns `-ENOTSUP`.
The first switch-case is followed by two switch-cases (for adc, lpcmp),
and one if-condition (for tempsens).
If none of the cases in the first switch is fulfilled,
(e.g. trying to enable clock for adc) function early returns `-ENOTSUP`,
and the rest of the code becomes **UNREACHABLE**.

This bugfix groups all the switches and the if-condition (for tempsens),
in one main switch and keeps the return `-ENOTSUP` as the default case,
considering that this return was added for a reason.