### PR TITLE
bluetooth: l2cap: validate alloc_buf user data

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -675,6 +675,11 @@ struct bt_l2cap_chan_ops {
 	 *  If the application has not set a callback the L2CAP SDU MTU will be
 	 *  truncated to @ref BT_L2CAP_SDU_RX_MTU.
 	 *
+	 *  @note The stack stores the number of received segments in the first
+	 *        two bytes of the buffer user data. The buffer returned by this
+	 *        callback must have a user data size of at least
+	 *        @c sizeof(uint16_t).
+	 *
 	 *  @param chan The channel requesting a buffer.
 	 *
 	 *  @return Allocated buffer.

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2756,6 +2756,15 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 			bt_l2cap_chan_disconnect(&chan->chan);
 			return;
 		}
+
+		if (chan->_sdu->user_data_size < sizeof(uint16_t)) {
+			LOG_ERR("SDU buffer user_data_size %u is too small",
+				chan->_sdu->user_data_size);
+			net_buf_unref(chan->_sdu);
+			chan->_sdu = NULL;
+			bt_l2cap_chan_disconnect(&chan->chan);
+			return;
+		}
 		chan->_sdu_len = sdu_len;
 
 		/* Send sdu_len/mps worth of credits */


### PR DESCRIPTION
validate assumptions about buffers returned from bt_l2cap_chan_ops::alloc_buf in the le coc receive path.

if the returned buffer does not provide the minimum user data space needed for internal bookkeeping, disconnect and drop the buffer. also document the alloc_buf requirement.