### PR TITLE
drivers: misc: add stm32 system bootloader driver

### DIFF
--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory_ifdef(CONFIG_RENESAS_RA_EXTERNAL_INTERRUPT renesas_ra_external_
 add_subdirectory_ifdef(CONFIG_RENESAS_RX_DTC renesas_rx_dtc)
 add_subdirectory_ifdef(CONFIG_RENESAS_RX_EXTERNAL_INTERRUPT renesas_rx_external_interrupt)
 add_subdirectory_ifdef(CONFIG_STM32N6_AXISRAM stm32n6_axisram)
+add_subdirectory_ifdef(CONFIG_STM32_BOOTLOADER stm32_bootloader)
 add_subdirectory_ifdef(CONFIG_TIMEAWARE_GPIO timeaware_gpio)
 # zephyr-keep-sorted-stop
 

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -24,6 +24,7 @@ source "drivers/misc/renesas_drw/Kconfig"
 source "drivers/misc/renesas_ra_external_interrupt/Kconfig"
 source "drivers/misc/renesas_rx_dtc/Kconfig"
 source "drivers/misc/renesas_rx_external_interrupt/Kconfig"
+source "drivers/misc/stm32_bootloader/Kconfig"
 source "drivers/misc/stm32n6_axisram/Kconfig"
 source "drivers/misc/timeaware_gpio/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/misc/stm32_bootloader/CMakeLists.txt
+++ b/drivers/misc/stm32_bootloader/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+if(CONFIG_STM32_BOOTLOADER)
+
+  # Transport-agnostic sources.
+  zephyr_library_sources(stm32_bootloader_gpio.c)
+
+  # Transport-specific drivers.
+  add_subdirectory_ifdef(CONFIG_STM32_BOOTLOADER_UART usart)
+
+endif()

--- a/drivers/misc/stm32_bootloader/CMakeLists.txt
+++ b/drivers/misc/stm32_bootloader/CMakeLists.txt
@@ -10,4 +10,7 @@ if(CONFIG_STM32_BOOTLOADER)
   # Transport-specific drivers.
   add_subdirectory_ifdef(CONFIG_STM32_BOOTLOADER_UART usart)
 
+  # Optional flash_driver_api adapter.
+  zephyr_library_sources_ifdef(CONFIG_STM32_BOOTLOADER_FLASH stm32_bootloader_flash.c)
+
 endif()

--- a/drivers/misc/stm32_bootloader/Kconfig
+++ b/drivers/misc/stm32_bootloader/Kconfig
@@ -13,11 +13,48 @@ config STM32_BOOTLOADER
 	  MCU. The driver exposes the AN3155/ANxxxx command set through its
 	  own API (see <zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>).
 
+	  To program the target as if it were a local flash device, enable
+	  STM32_BOOTLOADER_FLASH and declare an st,stm32-bootloader-flash
+	  child node under the bootloader node.
+
 if STM32_BOOTLOADER
 
 module = STM32_BOOTLOADER
 module-str = stm32_bootloader
 source "subsys/logging/Kconfig.template.log_config"
+
+config STM32_BOOTLOADER_FLASH
+	bool "Flash-adapter view of the target"
+	default y
+	depends on DT_HAS_ST_STM32_BOOTLOADER_FLASH_ENABLED
+	depends on FLASH
+	select FLASH_PAGE_LAYOUT
+	help
+	  Enable the thin flash_driver_api adapter that exposes target memory
+	  regions declared as st,stm32-bootloader-flash child nodes. Lets
+	  callers use flash_read/write/erase, stream_flash, flash_img and
+	  mcumgr img_mgmt against the target.
+
+if STM32_BOOTLOADER_FLASH
+
+config STM32_BOOTLOADER_FLASH_INIT_PRIORITY
+	int "Flash adapter init priority"
+	default 91
+	help
+	  Must be initialised after the parent bootloader device (which uses
+	  CONFIG_STM32_BOOTLOADER_UART_INIT_PRIORITY for the UART transport).
+
+config STM32_BOOTLOADER_FLASH_MAX_PAGES_PER_ERASE
+	int "Max pages per flash_erase call"
+	default 256
+	range 1 4080
+	help
+	  Upper bound on the number of page indices the adapter may send to
+	  the parent in a single flash_erase call. The AN3155 Extended Erase
+	  command accepts up to 0xFFF0 pages; 256 covers realistic STM32
+	  flash layouts while keeping the on-stack buffer small.
+
+endif # STM32_BOOTLOADER_FLASH
 
 endif # STM32_BOOTLOADER
 

--- a/drivers/misc/stm32_bootloader/Kconfig
+++ b/drivers/misc/stm32_bootloader/Kconfig
@@ -1,0 +1,24 @@
+# STM32 system bootloader host driver
+#
+# Copyright (c) 2026 Alex Fabre
+# SPDX-License-Identifier: Apache-2.0
+
+config STM32_BOOTLOADER
+	bool "STM32 system bootloader host driver"
+	default y
+	depends on DT_HAS_ST_STM32_BOOTLOADER_ENABLED
+	select GPIO
+	help
+	  Drive a target STM32's built-in ROM bootloader (AN2606) from a host
+	  MCU. The driver exposes the AN3155/ANxxxx command set through its
+	  own API (see <zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>).
+
+if STM32_BOOTLOADER
+
+module = STM32_BOOTLOADER
+module-str = stm32_bootloader
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # STM32_BOOTLOADER
+
+rsource "usart/Kconfig"

--- a/drivers/misc/stm32_bootloader/stm32_bootloader_flash.c
+++ b/drivers/misc/stm32_bootloader/stm32_bootloader_flash.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Flash adapter for the STM32 system bootloader driver.
+ *
+ * Each @c st,stm32-bootloader-flash DT node (a child of an
+ * @c st,stm32-bootloader node) is instantiated as a Zephyr flash device.
+ * The adapter translates flash_driver_api offsets into absolute target
+ * addresses and delegates every call to the parent bootloader device:
+ *
+ *   flash_read  (offset, ...) -> stm32_bootloader_read_memory (base+off, ...)
+ *   flash_write (offset, ...) -> stm32_bootloader_write_memory(base+off, ...)
+ *   flash_erase (offset, size) -> stm32_bootloader_erase_pages(...)
+ *
+ * The adapter holds no session state: callers must call
+ * stm32_bootloader_enter() on the parent before any flash op, and exit
+ * when done. If the parent is not entered, the parent returns -ENOTCONN
+ * and the adapter propagates that.
+ *
+ * The adapter never issues a mass-erase on behalf of the caller: that
+ * would be wrong when the adapter's region is smaller than the target's
+ * total flash. Callers that want mass-erase invoke
+ * stm32_bootloader_mass_erase() directly on the parent.
+ */
+
+#define DT_DRV_COMPAT st_stm32_bootloader_flash
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>
+
+LOG_MODULE_REGISTER(stm32_sys_bl_flash, CONFIG_STM32_BOOTLOADER_LOG_LEVEL);
+
+struct stm32_bl_flash_config {
+	/** Parent bootloader device (transport-agnostic). */
+	const struct device *parent;
+	/** Absolute target address of region start. */
+	uint32_t base_address;
+	/** Region size in bytes. */
+	size_t size;
+	/** Uniform erase granularity. */
+	size_t erase_block_size;
+	/** Write alignment (AN3155 mandates 4). */
+	size_t write_block_size;
+	bool read_only;
+	/** flash_driver_api static parameters. */
+	struct flash_parameters params;
+	/** Uniform page layout. */
+	struct flash_pages_layout page_layout;
+};
+
+static int adapter_read(const struct device *dev, off_t offset, void *buf, size_t len)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	if (len == 0) {
+		return 0;
+	}
+	if (buf == NULL || offset < 0) {
+		return -EINVAL;
+	}
+	if ((size_t)offset + len > cfg->size) {
+		return -EINVAL;
+	}
+
+	return stm32_bootloader_read_memory(cfg->parent, cfg->base_address + (uint32_t)offset, buf,
+					    len);
+}
+
+static int adapter_write(const struct device *dev, off_t offset, const void *buf, size_t len)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	if (cfg->read_only) {
+		return -EACCES;
+	}
+	if (len == 0) {
+		return 0;
+	}
+	if (buf == NULL || offset < 0) {
+		return -EINVAL;
+	}
+	if ((size_t)offset + len > cfg->size) {
+		return -EINVAL;
+	}
+	if (((size_t)offset % cfg->write_block_size) != 0 || (len % cfg->write_block_size) != 0) {
+		LOG_ERR("Write not %zu-byte aligned", cfg->write_block_size);
+		return -EINVAL;
+	}
+
+	return stm32_bootloader_write_memory(cfg->parent, cfg->base_address + (uint32_t)offset, buf,
+					     len);
+}
+
+static int adapter_erase(const struct device *dev, off_t offset, size_t size)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	if (cfg->read_only) {
+		return -EACCES;
+	}
+	if (size == 0) {
+		return 0;
+	}
+	if (offset < 0) {
+		return -EINVAL;
+	}
+	if ((size_t)offset + size > cfg->size) {
+		return -EINVAL;
+	}
+	if (((size_t)offset % cfg->erase_block_size) != 0 || (size % cfg->erase_block_size) != 0) {
+		LOG_ERR("Erase not %zu-byte aligned", cfg->erase_block_size);
+		return -EINVAL;
+	}
+
+	/*
+	 * Convert the (offset, size) range into a list of AN3155 page indices
+	 * relative to the target's flash base. The parent bootloader driver
+	 * maps those indices to the right Standard or Extended Erase command.
+	 *
+	 * A small on-stack buffer keeps the translation allocation-free;
+	 * STM32 flash sizes in circulation need at most a few hundred pages,
+	 * well within the AN3155 per-command limit.
+	 */
+	size_t first = (size_t)offset / cfg->erase_block_size;
+	size_t count = size / cfg->erase_block_size;
+	uint16_t pages[CONFIG_STM32_BOOTLOADER_FLASH_MAX_PAGES_PER_ERASE];
+
+	if (count > ARRAY_SIZE(pages)) {
+		LOG_ERR("Erase covers %zu pages, max is %u", count,
+			(unsigned int)ARRAY_SIZE(pages));
+		return -ENOMEM;
+	}
+
+	/*
+	 * The AN3155 page index is a region-relative counter: page 0 is at
+	 * the region's declared reg base. The parent driver forwards it as
+	 * raw page number — the target's bootloader interprets it against
+	 * its own flash base (e.g. 0x08000000), which is what we want as
+	 * long as the region actually begins at the target's flash base.
+	 *
+	 * For non-main-flash regions (option bytes, system memory) AN3155
+	 * page erase is typically not applicable; such regions should be
+	 * declared read-only.
+	 */
+	for (size_t i = 0; i < count; i++) {
+		pages[i] = (uint16_t)(first + i);
+	}
+
+	return stm32_bootloader_erase_pages(cfg->parent, pages, count);
+}
+
+static const struct flash_parameters *adapter_get_parameters(const struct device *dev)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	return &cfg->params;
+}
+
+static int adapter_get_size(const struct device *dev, uint64_t *size)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	*size = (uint64_t)cfg->size;
+	return 0;
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void adapter_page_layout(const struct device *dev, const struct flash_pages_layout **layout,
+				size_t *layout_size)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	*layout = &cfg->page_layout;
+	*layout_size = 1;
+}
+#endif
+
+static DEVICE_API(flash, stm32_bl_flash_api) = {
+	.read = adapter_read,
+	.write = adapter_write,
+	.erase = adapter_erase,
+	.get_parameters = adapter_get_parameters,
+	.get_size = adapter_get_size,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = adapter_page_layout,
+#endif
+};
+
+static int stm32_bl_flash_init(const struct device *dev)
+{
+	const struct stm32_bl_flash_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->parent)) {
+		LOG_ERR("Parent bootloader device not ready");
+		return -ENODEV;
+	}
+	return 0;
+}
+
+#define STM32_BL_FLASH_DEFINE(inst)                                                                \
+	BUILD_ASSERT(DT_INST_REG_SIZE(inst) % DT_INST_PROP(inst, erase_block_size) == 0,           \
+		     "region size must be a multiple of erase-block-size");                        \
+                                                                                                   \
+	static const struct stm32_bl_flash_config stm32_bl_flash_cfg_##inst = {                    \
+		.parent = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                     \
+		.base_address = (uint32_t)DT_INST_REG_ADDR(inst),                                  \
+		.size = (size_t)DT_INST_REG_SIZE(inst),                                            \
+		.erase_block_size = DT_INST_PROP(inst, erase_block_size),                          \
+		.write_block_size = DT_INST_PROP(inst, write_block_size),                          \
+		.read_only = DT_INST_PROP(inst, read_only),                                        \
+		.params =                                                                          \
+			{                                                                          \
+				.write_block_size = DT_INST_PROP(inst, write_block_size),          \
+				.erase_value = 0xFF,                                               \
+			},                                                                         \
+		.page_layout =                                                                     \
+			{                                                                          \
+				.pages_count = DT_INST_REG_SIZE(inst) /                            \
+					       DT_INST_PROP(inst, erase_block_size),               \
+				.pages_size = DT_INST_PROP(inst, erase_block_size),                \
+			},                                                                         \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, stm32_bl_flash_init, NULL, NULL, &stm32_bl_flash_cfg_##inst,   \
+			      POST_KERNEL, CONFIG_STM32_BOOTLOADER_FLASH_INIT_PRIORITY,            \
+			      &stm32_bl_flash_api);
+
+DT_INST_FOREACH_STATUS_OKAY(STM32_BL_FLASH_DEFINE)

--- a/drivers/misc/stm32_bootloader/stm32_bootloader_gpio.c
+++ b/drivers/misc/stm32_bootloader/stm32_bootloader_gpio.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief STM32 bootloader GPIO control.
+ *
+ * Drives the BOOT0, BOOT1 and NRST pins used to enter and exit the
+ * STM32 system bootloader. Any pin whose @c port is NULL is treated as
+ * absent and silently skipped, so call sites do not need to branch on
+ * optional pins.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "stm32_bootloader_gpio.h"
+
+LOG_MODULE_REGISTER(stm32_sys_bl, CONFIG_STM32_BOOTLOADER_LOG_LEVEL);
+
+/**
+ * @brief Test whether a GPIO is declared in the configuration.
+ *
+ * @param gpio_dt_spec_ptr Pointer to a @c gpio_dt_spec.
+ * @return @c true if the pin has a non-NULL port, @c false otherwise.
+ */
+#define PIN_PRESENT(gpio_dt_spec_ptr) ((gpio_dt_spec_ptr)->port != NULL)
+
+/**
+ * @brief Configure a pin as output-inactive, skipping absent pins.
+ *
+ * Expands to a statement expression that yields an @c int errno value so
+ * it can be used as @c ret = PIN_CONFIGURE(...).
+ *
+ * @param p    Pointer to a @c gpio_dt_spec.
+ * @param name Human-readable pin name, used for log messages.
+ * @return 0 on success or if the pin is absent, negative errno otherwise.
+ */
+#define PIN_CONFIGURE(p, name)                                                                     \
+	({                                                                                         \
+		int _ret_ = 0;                                                                     \
+		if (PIN_PRESENT(p)) {                                                              \
+			if (!gpio_is_ready_dt(p)) {                                                \
+				LOG_ERR("%s GPIO not ready", name);                                \
+				_ret_ = -ENODEV;                                                   \
+			} else {                                                                   \
+				_ret_ = gpio_pin_configure_dt(p, GPIO_OUTPUT_INACTIVE);            \
+				if (_ret_ < 0) {                                                   \
+					LOG_ERR("Failed to configure %s GPIO: %d", name, _ret_);   \
+				}                                                                  \
+			}                                                                          \
+		}                                                                                  \
+		_ret_;                                                                             \
+	})
+
+/**
+ * @brief Drive a pin to @p value, skipping absent pins.
+ *
+ * Expands to a statement expression that yields an @c int errno value so
+ * it can be used as @c ret = PIN_SET(...).
+ *
+ * @param p     Pointer to a @c gpio_dt_spec.
+ * @param value Logical level to drive (int 0 or 1).
+ * @param name  Human-readable pin name, used for log messages.
+ * @return 0 on success or if the pin is absent, negative errno otherwise.
+ */
+#define PIN_SET(p, value, name)                                                                    \
+	({                                                                                         \
+		int _ret_ = 0;                                                                     \
+		if (PIN_PRESENT(p)) {                                                              \
+			_ret_ = gpio_pin_set_dt(p, value);                                         \
+			if (_ret_ < 0) {                                                           \
+				LOG_ERR("Failed to set %s GPIO: %d", name, _ret_);                 \
+			}                                                                          \
+		}                                                                                  \
+		_ret_;                                                                             \
+	})
+
+int stm32_bootloader_gpio_init(const struct stm32_bootloader_gpio_cfg *cfg)
+{
+	int ret;
+
+	ret = PIN_CONFIGURE(&cfg->boot0, "BOOT0");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = PIN_CONFIGURE(&cfg->boot1, "BOOT1");
+	if (ret < 0) {
+		return ret;
+	}
+	return PIN_CONFIGURE(&cfg->nrst, "NRST");
+}
+
+int stm32_bootloader_gpio_enter(const struct stm32_bootloader_gpio_cfg *cfg)
+{
+	int ret;
+
+	ret = PIN_SET(&cfg->boot0, 1, "BOOT0");
+	if (ret < 0) {
+		return ret;
+	}
+	ret = PIN_SET(&cfg->boot1, 1, "BOOT1");
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (PIN_PRESENT(&cfg->nrst)) {
+		ret = PIN_SET(&cfg->nrst, 1, "NRST");
+		if (ret < 0) {
+			return ret;
+		}
+		k_msleep(cfg->reset_pulse_ms);
+		ret = PIN_SET(&cfg->nrst, 0, "NRST");
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (cfg->boot_delay_ms) {
+		k_msleep(cfg->boot_delay_ms);
+	}
+	return 0;
+}
+
+int stm32_bootloader_gpio_exit(const struct stm32_bootloader_gpio_cfg *cfg, bool reset)
+{
+	int ret;
+
+	(void)PIN_SET(&cfg->boot0, 0, "BOOT0");
+	(void)PIN_SET(&cfg->boot1, 0, "BOOT1");
+
+	if (reset && PIN_PRESENT(&cfg->nrst)) {
+		ret = PIN_SET(&cfg->nrst, 1, "NRST");
+		if (ret < 0) {
+			return ret;
+		}
+		k_msleep(cfg->reset_pulse_ms);
+		ret = PIN_SET(&cfg->nrst, 0, "NRST");
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	return 0;
+}

--- a/drivers/misc/stm32_bootloader/stm32_bootloader_gpio.h
+++ b/drivers/misc/stm32_bootloader/stm32_bootloader_gpio.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_GPIO_H_
+#define ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_GPIO_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/drivers/gpio.h>
+
+/**
+ * @brief GPIO pins used to drive the target into / out of bootloader mode.
+ *
+ * Any pin with @c port == NULL is treated as absent and all operations on
+ * it are skipped. This lets a node declare only the pins it actually
+ * controls.
+ */
+struct stm32_bootloader_gpio_cfg {
+	struct gpio_dt_spec boot0;
+	struct gpio_dt_spec boot1;
+	struct gpio_dt_spec nrst;
+	uint16_t reset_pulse_ms;
+	uint16_t boot_delay_ms;
+};
+
+/** Configure declared pins as output-inactive. */
+int stm32_bootloader_gpio_init(const struct stm32_bootloader_gpio_cfg *cfg);
+
+/**
+ * @brief Drive the target into bootloader mode.
+ *
+ * BOOT pins are asserted (if declared), NRST is pulsed (if declared), then the caller
+ * sleeps for @c boot_delay_ms to give the bootloader time to start.
+ */
+int stm32_bootloader_gpio_enter(const struct stm32_bootloader_gpio_cfg *cfg);
+
+/**
+ * @brief Drive the target out of bootloader mode.
+ *
+ * BOOT pins are de-asserted (if declared).
+ * If @p reset is true and NRST is declared,
+ * NRST is pulsed to hard-reset the target.
+ */
+int stm32_bootloader_gpio_exit(const struct stm32_bootloader_gpio_cfg *cfg, bool reset);
+
+#endif /* ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_GPIO_H_ */

--- a/drivers/misc/stm32_bootloader/usart/CMakeLists.txt
+++ b/drivers/misc/stm32_bootloader/usart/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(stm32_bootloader_usart.c)

--- a/drivers/misc/stm32_bootloader/usart/Kconfig
+++ b/drivers/misc/stm32_bootloader/usart/Kconfig
@@ -1,0 +1,27 @@
+# STM32 system bootloader over USART (AN3155)
+#
+# Copyright (c) 2026 Alex Fabre
+# SPDX-License-Identifier: Apache-2.0
+
+config STM32_BOOTLOADER_UART
+	bool "USART transport (AN3155)"
+	default y
+	depends on STM32_BOOTLOADER
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_ST_STM32_BOOTLOADER),uart)
+	depends on SERIAL
+	help
+	  Program a target STM32 over UART using the AN3155 protocol.
+
+if STM32_BOOTLOADER_UART
+
+config STM32_BOOTLOADER_UART_INIT_PRIORITY
+	int "USART transport init priority"
+	default 90
+	help
+	  Must be after GPIO and UART.
+
+module = STM32_BOOTLOADER_UART
+module-str = stm32_bootloader_uart
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # STM32_BOOTLOADER_UART

--- a/drivers/misc/stm32_bootloader/usart/stm32_bootloader_usart.c
+++ b/drivers/misc/stm32_bootloader/usart/stm32_bootloader_usart.c
@@ -1,0 +1,711 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief STM32 system bootloader over USART (AN3155).
+ *
+ * Implements the standalone stm32_bootloader API over UART. All protocol
+ * logic lives here; the driver is independent of flash_driver_api. A
+ * companion flash adapter (see @c st,stm32-bootloader-flash) can expose
+ * target memory regions as Zephyr flash devices by delegating to the
+ * stm32_bootloader API.
+ *
+ * Layout of this file:
+ *   1. Per-instance config / data structs.
+ *   2. Low-level UART helpers (byte-level IO, framing helpers).
+ *   3. AN3155 command building blocks (send_cmd, send_addr, wait_ack).
+ *   4. Command-level helpers (fetch_info, read_mem, write_mem, erase_*).
+ *   5. Public API method implementations.
+ *   6. DEVICE_DT_INST_DEFINE boilerplate.
+ */
+
+#define DT_DRV_COMPAT st_stm32_bootloader
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>
+#include "../stm32_bootloader_gpio.h"
+#include "stm32_bootloader_usart.h"
+
+LOG_MODULE_REGISTER(stm32_sys_bl_uart, CONFIG_STM32_BOOTLOADER_UART_LOG_LEVEL);
+
+/* 1. ---- Per-instance structs ---- */
+
+struct stm32_bl_uart_config {
+	struct stm32_bootloader_gpio_cfg gpio;
+	const struct device *uart;
+	unsigned int baudrate;
+	unsigned int timeout_ms;
+	unsigned int erase_timeout_ms;
+	bool parity_none;
+};
+
+struct stm32_bl_uart_data {
+	struct k_mutex lock;
+	/** Backup of the host UART config, restored on exit. */
+	struct uart_config uart_cfg_bkp;
+	/** Target capabilities, fetched on enter. */
+	struct stm32_bootloader_info info;
+	bool uart_cfg_saved;
+	bool connected;
+};
+
+/* 2. ---- Low-level UART helpers ---- */
+
+static void tx(const struct device *uart, uint8_t byte)
+{
+	uart_poll_out(uart, byte);
+}
+
+static int rx(const struct device *uart, uint8_t *byte, unsigned int timeout_ms)
+{
+	int64_t deadline = k_uptime_get() + timeout_ms;
+
+	while (uart_poll_in(uart, byte) != 0) {
+		if (k_uptime_get() >= deadline) {
+			return -ETIMEDOUT;
+		}
+		k_busy_wait(10); /* ~1/9 of a character time at 115200 */
+	}
+	return 0;
+}
+
+static void drain_rx(const struct device *uart)
+{
+	uint8_t discard;
+
+	while (uart_poll_in(uart, &discard) == 0) {
+	}
+}
+
+static uint8_t xor_bytes(const uint8_t *buf, size_t len)
+{
+	uint8_t x = 0;
+
+	for (size_t i = 0; i < len; i++) {
+		x ^= buf[i];
+	}
+	return x;
+}
+
+/* 3. ---- AN3155 command building blocks ---- */
+
+static int wait_ack(const struct device *dev, unsigned int timeout_ms)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	uint8_t b;
+	int ret = rx(cfg->uart, &b, timeout_ms);
+
+	if (ret < 0) {
+		return ret;
+	}
+	if (b == STM32_BL_UART_ACK) {
+		return 0;
+	}
+	if (b == STM32_BL_UART_NACK) {
+		LOG_WRN("NACK received");
+		return -EPROTO;
+	}
+	LOG_WRN("Unexpected byte 0x%02x in place of ACK", b);
+	return -EPROTO;
+}
+
+/** Send cmd + ~cmd, wait for ACK. */
+static int send_cmd(const struct device *dev, uint8_t cmd)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+
+	drain_rx(cfg->uart);
+	tx(cfg->uart, cmd);
+	tx(cfg->uart, (uint8_t)~cmd);
+	return wait_ack(dev, cfg->timeout_ms);
+}
+
+/** Send a 32-bit address big-endian, with XOR checksum. Waits for ACK. */
+static int send_addr(const struct device *dev, uint32_t addr)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	uint8_t buf[4];
+
+	sys_put_be32(addr, buf);
+	for (int i = 0; i < 4; i++) {
+		tx(cfg->uart, buf[i]);
+	}
+	tx(cfg->uart, xor_bytes(buf, 4));
+	return wait_ack(dev, cfg->timeout_ms);
+}
+
+/* 4. ---- Command-level helpers ---- */
+
+static int fetch_info(const struct device *dev, struct stm32_bootloader_info *info)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	uint8_t b;
+	int ret;
+
+	memset(info, 0, sizeof(*info));
+
+	/* Get (0x00): N, version, N supported commands, ACK */
+	ret = send_cmd(dev, STM32_BL_UART_CMD_GET);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &info->num_cmds, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &info->bl_version, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	for (uint8_t i = 0; i < info->num_cmds; i++) {
+		/* Store the first ARRAY_SIZE(cmds) entries; sink any
+		 * overflow into a scratch byte so the RX stream stays
+		 * in sync with the protocol.
+		 */
+		uint8_t *dst = (i < ARRAY_SIZE(info->cmds)) ? &info->cmds[i] : &b;
+
+		ret = rx(cfg->uart, dst, cfg->timeout_ms);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	ret = wait_ack(dev, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	for (uint8_t i = 0; i < MIN(info->num_cmds, ARRAY_SIZE(info->cmds)); i++) {
+		if (info->cmds[i] == STM32_BL_UART_CMD_EE) {
+			info->has_extended_erase = true;
+			break;
+		}
+	}
+
+	/* Get Version (0x01): version, option1, option2, ACK */
+	ret = send_cmd(dev, STM32_BL_UART_CMD_GV);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &info->bl_version, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &info->option1, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &info->option2, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = wait_ack(dev, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Get ID (0x02): N (=1 for 2 bytes), PID hi, PID lo, ACK */
+	ret = send_cmd(dev, STM32_BL_UART_CMD_GID);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &b, cfg->timeout_ms); /* byte count minus one */
+	if (ret < 0) {
+		return ret;
+	}
+	uint8_t pid_hi, pid_lo;
+
+	ret = rx(cfg->uart, &pid_hi, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = rx(cfg->uart, &pid_lo, cfg->timeout_ms);
+	if (ret < 0) {
+		return ret;
+	}
+	info->pid = ((uint16_t)pid_hi << 8) | pid_lo;
+	return wait_ack(dev, cfg->timeout_ms);
+}
+
+static int read_chunked(const struct device *dev, uint32_t addr, uint8_t *buf, size_t len)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	size_t done = 0;
+
+	while (done < len) {
+		size_t chunk = MIN(len - done, STM32_BOOTLOADER_MAX_DATA_SIZE);
+		int ret = send_cmd(dev, STM32_BL_UART_CMD_RM);
+
+		if (ret < 0) {
+			return ret;
+		}
+		ret = send_addr(dev, addr + done);
+		if (ret < 0) {
+			return ret;
+		}
+
+		uint8_t n = (uint8_t)(chunk - 1);
+
+		tx(cfg->uart, n);
+		tx(cfg->uart, (uint8_t)~n);
+		ret = wait_ack(dev, cfg->timeout_ms);
+		if (ret < 0) {
+			return ret;
+		}
+
+		for (size_t i = 0; i < chunk; i++) {
+			ret = rx(cfg->uart, &buf[done + i], cfg->timeout_ms);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+		done += chunk;
+	}
+	return 0;
+}
+
+static int write_chunked(const struct device *dev, uint32_t addr, const uint8_t *buf, size_t len)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	size_t done = 0;
+
+	while (done < len) {
+		size_t chunk = MIN(len - done, STM32_BOOTLOADER_MAX_DATA_SIZE);
+		uint8_t n = (uint8_t)(chunk - 1);
+		uint8_t x = n;
+		int ret = send_cmd(dev, STM32_BL_UART_CMD_WM);
+
+		if (ret < 0) {
+			return ret;
+		}
+		ret = send_addr(dev, addr + done);
+		if (ret < 0) {
+			return ret;
+		}
+
+		tx(cfg->uart, n);
+		for (size_t i = 0; i < chunk; i++) {
+			tx(cfg->uart, buf[done + i]);
+			x ^= buf[done + i];
+		}
+		tx(cfg->uart, x);
+
+		ret = wait_ack(dev, cfg->timeout_ms);
+		if (ret < 0) {
+			return ret;
+		}
+		done += chunk;
+	}
+	return 0;
+}
+
+static int do_mass_erase(const struct device *dev)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	const struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (data->info.has_extended_erase) {
+		ret = send_cmd(dev, STM32_BL_UART_CMD_EE);
+		if (ret < 0) {
+			return ret;
+		}
+		tx(cfg->uart, 0xFF);
+		tx(cfg->uart, 0xFF);
+		tx(cfg->uart, 0x00); /* XOR(0xFF, 0xFF) */
+		return wait_ack(dev, cfg->erase_timeout_ms);
+	}
+
+	ret = send_cmd(dev, STM32_BL_UART_CMD_ER);
+	if (ret < 0) {
+		return ret;
+	}
+	tx(cfg->uart, STM32_BL_UART_STD_MASS_ERASE);
+	tx(cfg->uart, (uint8_t)~STM32_BL_UART_STD_MASS_ERASE);
+	return wait_ack(dev, cfg->erase_timeout_ms);
+}
+
+static int do_erase_pages(const struct device *dev, const uint16_t *pages, size_t count)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	const struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (count == 0) {
+		return 0;
+	}
+
+	if (data->info.has_extended_erase) {
+		/* Values 0xFFFx are reserved for special erases. */
+		if (count > 0xFFF0U) {
+			return -EINVAL;
+		}
+
+		ret = send_cmd(dev, STM32_BL_UART_CMD_EE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		uint16_t n_minus_1 = (uint16_t)(count - 1);
+		uint8_t x = 0;
+		uint8_t hi = (uint8_t)(n_minus_1 >> 8);
+		uint8_t lo = (uint8_t)(n_minus_1 & 0xFF);
+
+		tx(cfg->uart, hi);
+		tx(cfg->uart, lo);
+		x ^= hi ^ lo;
+
+		for (size_t i = 0; i < count; i++) {
+			hi = (uint8_t)(pages[i] >> 8);
+			lo = (uint8_t)(pages[i] & 0xFF);
+			tx(cfg->uart, hi);
+			tx(cfg->uart, lo);
+			x ^= hi ^ lo;
+		}
+		tx(cfg->uart, x);
+		return wait_ack(dev, cfg->erase_timeout_ms);
+	}
+
+	/* Standard Erase addresses pages 0..255 via single bytes. */
+	if (count > 255U) {
+		return -EINVAL;
+	}
+	for (size_t i = 0; i < count; i++) {
+		if (pages[i] > 0xFFU) {
+			return -EINVAL;
+		}
+	}
+
+	ret = send_cmd(dev, STM32_BL_UART_CMD_ER);
+	if (ret < 0) {
+		return ret;
+	}
+
+	uint8_t n_minus_1 = (uint8_t)(count - 1);
+	uint8_t x = n_minus_1;
+
+	tx(cfg->uart, n_minus_1);
+	for (size_t i = 0; i < count; i++) {
+		uint8_t page = (uint8_t)pages[i];
+
+		tx(cfg->uart, page);
+		x ^= page;
+	}
+	tx(cfg->uart, x);
+	return wait_ack(dev, cfg->erase_timeout_ms);
+}
+
+/* 5. ---- Public API methods ---- */
+
+static int api_enter(const struct device *dev)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (!data->uart_cfg_saved) {
+		ret = uart_config_get(cfg->uart, &data->uart_cfg_bkp);
+		if (ret < 0) {
+			LOG_ERR("uart_config_get failed: %d", ret);
+			goto out;
+		}
+		data->uart_cfg_saved = true;
+	}
+
+	struct uart_config bl_cfg = {
+		.baudrate = cfg->baudrate,
+		.parity = cfg->parity_none ? UART_CFG_PARITY_NONE : UART_CFG_PARITY_EVEN,
+		.stop_bits = UART_CFG_STOP_BITS_1,
+		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
+		.data_bits = UART_CFG_DATA_BITS_8,
+	};
+
+	ret = uart_configure(cfg->uart, &bl_cfg);
+	if (ret < 0) {
+		LOG_ERR("uart_configure failed: %d", ret);
+		goto out;
+	}
+
+	ret = stm32_bootloader_gpio_enter(&cfg->gpio);
+	if (ret < 0) {
+		goto out;
+	}
+
+	drain_rx(cfg->uart);
+	tx(cfg->uart, STM32_BL_UART_SYNC);
+	ret = wait_ack(dev, cfg->timeout_ms);
+	if (ret < 0) {
+		LOG_ERR("Bootloader sync failed: %d", ret);
+		goto out;
+	}
+
+	ret = fetch_info(dev, &data->info);
+	if (ret < 0) {
+		LOG_ERR("fetch_info failed: %d", ret);
+		goto out;
+	}
+
+	data->connected = true;
+	LOG_INF("Connected: BL v%d.%d, PID 0x%04x, %s erase", data->info.bl_version >> 4,
+		data->info.bl_version & 0x0F, data->info.pid,
+		data->info.has_extended_erase ? "extended" : "standard");
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_exit(const struct device *dev, bool reset_target)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret = 0;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (data->uart_cfg_saved) {
+		int r = uart_configure(cfg->uart, &data->uart_cfg_bkp);
+
+		if (r < 0) {
+			LOG_ERR("Failed to restore UART config: %d", r);
+			ret = r;
+		}
+	}
+	(void)stm32_bootloader_gpio_exit(&cfg->gpio, reset_target);
+
+	data->connected = false;
+	LOG_INF("Disconnected");
+
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_go(const struct device *dev, uint32_t addr)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	ret = send_cmd(dev, STM32_BL_UART_CMD_GO);
+	if (ret < 0) {
+		goto out;
+	}
+	ret = send_addr(dev, addr);
+	if (ret < 0) {
+		goto out;
+	}
+
+	(void)stm32_bootloader_gpio_exit(&cfg->gpio, false);
+	data->connected = false;
+	LOG_INF("Jumped to 0x%08x", addr);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_get_info(const struct device *dev, struct stm32_bootloader_info *info)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	/* Read-only path: bounded lock wait so a long-running operation
+	 * (e.g. mass_erase) cannot indefinitely block status callers.
+	 */
+	if (k_mutex_lock(&data->lock, K_MSEC(cfg->timeout_ms)) != 0) {
+		return -EBUSY;
+	}
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	memcpy(info, &data->info, sizeof(*info));
+	ret = 0;
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_read_memory(const struct device *dev, uint32_t addr, void *buf, size_t len)
+{
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (len == 0) {
+		return 0;
+	}
+	if (buf == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	ret = read_chunked(dev, addr, buf, len);
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_write_memory(const struct device *dev, uint32_t addr, const void *buf, size_t len)
+{
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (len == 0) {
+		return 0;
+	}
+	if (buf == NULL) {
+		return -EINVAL;
+	}
+	/* AN3155: address and length must be 4-byte aligned. */
+	if ((addr & 0x3U) != 0 || (len & 0x3U) != 0) {
+		LOG_ERR("write_memory addr/len not 4-byte aligned");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	ret = write_chunked(dev, addr, buf, len);
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_erase_pages(const struct device *dev, const uint16_t *pages, size_t num_pages)
+{
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (num_pages == 0) {
+		return 0;
+	}
+	if (pages == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	ret = do_erase_pages(dev, pages, num_pages);
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static int api_mass_erase(const struct device *dev)
+{
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	if (!data->connected) {
+		ret = -ENOTCONN;
+		goto out;
+	}
+	ret = do_mass_erase(dev);
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
+}
+
+static DEVICE_API(stm32_bootloader, stm32_bl_uart_api) = {
+	.enter = api_enter,
+	.exit = api_exit,
+	.go = api_go,
+	.get_info = api_get_info,
+	.read_memory = api_read_memory,
+	.write_memory = api_write_memory,
+	.erase_pages = api_erase_pages,
+	.mass_erase = api_mass_erase,
+};
+
+/* 6. ---- DT instantiation ---- */
+
+static int stm32_bl_uart_init(const struct device *dev)
+{
+	const struct stm32_bl_uart_config *cfg = dev->config;
+	struct stm32_bl_uart_data *data = dev->data;
+	int ret;
+
+	if (!device_is_ready(cfg->uart)) {
+		LOG_ERR("UART device not ready");
+		return -ENODEV;
+	}
+
+	ret = stm32_bootloader_gpio_init(&cfg->gpio);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_mutex_init(&data->lock);
+	data->connected = false;
+	data->uart_cfg_saved = false;
+
+	LOG_INF("STM32 bootloader/UART driver initialised");
+	return 0;
+}
+
+#define GPIO_OR_NULL(inst, name) GPIO_DT_SPEC_INST_GET_OR(inst, name, {0})
+
+#define STM32_BL_UART_DEFINE(inst)                                                                 \
+	static struct stm32_bl_uart_data stm32_bl_uart_data_##inst;                                \
+                                                                                                   \
+	static const struct stm32_bl_uart_config stm32_bl_uart_cfg_##inst = {                      \
+		.gpio =                                                                            \
+			{                                                                          \
+				.boot0 = GPIO_OR_NULL(inst, boot0_gpios),                          \
+				.boot1 = GPIO_OR_NULL(inst, boot1_gpios),                          \
+				.nrst = GPIO_OR_NULL(inst, nrst_gpios),                            \
+				.reset_pulse_ms = DT_INST_PROP(inst, reset_pulse_ms),              \
+				.boot_delay_ms = DT_INST_PROP(inst, boot_delay_ms),                \
+			},                                                                         \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.baudrate = DT_INST_PROP(inst, baudrate),                                          \
+		.timeout_ms = DT_INST_PROP(inst, timeout_ms),                                      \
+		.erase_timeout_ms = DT_INST_PROP(inst, erase_timeout_ms),                          \
+		.parity_none = DT_INST_PROP(inst, parity_none),                                    \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, stm32_bl_uart_init, NULL, &stm32_bl_uart_data_##inst,          \
+			      &stm32_bl_uart_cfg_##inst, POST_KERNEL,                              \
+			      CONFIG_STM32_BOOTLOADER_UART_INIT_PRIORITY, &stm32_bl_uart_api);
+
+/* Instantiate for UART-hosted nodes only. Future I2C/CAN transports live
+ * in their own source files and DT_INST_FOREACH_STATUS_OKAY invocations.
+ */
+#define STM32_BL_DEFINE(inst) COND_CODE_1(DT_INST_ON_BUS(inst, uart),  \
+									(STM32_BL_UART_DEFINE(inst)), ()	\
+								)
+
+DT_INST_FOREACH_STATUS_OKAY(STM32_BL_DEFINE)

--- a/drivers/misc/stm32_bootloader/usart/stm32_bootloader_usart.h
+++ b/drivers/misc/stm32_bootloader/usart/stm32_bootloader_usart.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_UART_H_
+#define ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_UART_H_
+
+/* AN3155 synchronisation and ACK bytes */
+#define STM32_BL_UART_SYNC 0x7F
+#define STM32_BL_UART_ACK  0x79
+#define STM32_BL_UART_NACK 0x1F
+
+/* AN3155 command bytes */
+#define STM32_BL_UART_CMD_GET 0x00
+#define STM32_BL_UART_CMD_GV  0x01
+#define STM32_BL_UART_CMD_GID 0x02
+#define STM32_BL_UART_CMD_RM  0x11
+#define STM32_BL_UART_CMD_GO  0x21
+#define STM32_BL_UART_CMD_WM  0x31
+#define STM32_BL_UART_CMD_ER  0x43
+#define STM32_BL_UART_CMD_EE  0x44
+
+/* Mass-erase payload for Standard Erase (0x43) */
+#define STM32_BL_UART_STD_MASS_ERASE 0xFF
+
+#endif /* ZEPHYR_DRIVERS_MISC_STM32_BOOTLOADER_UART_H_ */

--- a/dts/bindings/misc/st,stm32-bootloader-flash.yaml
+++ b/dts/bindings/misc/st,stm32-bootloader-flash.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Alex Fabre
+
+description: |
+  Flash adapter exposing a region of an STM32 target mcu as a Zephyr
+  flash device. 
+  Must be a child node of an 'st,stm32-bootloader' node, as the
+  adapter delegates every flash_read/write/erase call to the parent's
+  read_memory/write_memory/erase_pages. 
+  The reg addresses are absolute on the target's memory map
+  (e.g. 0x08000000 for main flash).
+
+  Multiple adapter children can coexist under a single bootloader node,
+  allowing flash areas per addressable regions (main flash, option bytes,
+  system memory, SRAM, ...).
+
+compatible: "st,stm32-bootloader-flash"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    description: |
+      <base-address size-in-bytes> of the target memory region exposed as
+      a flash device.
+
+  erase-block-size:
+    type: int
+    required: true
+    description: |
+      Page/sector size used for flash_erase operations. Non-uniform
+      layouts are not supported by this adapter — if you need them, expose
+      the adapter as read-only or split the region across multiple child
+      nodes.
+
+  write-block-size:
+    type: int
+    default: 4
+    description: Write alignment (AN3155 requires 4-byte aligned writes).
+
+  read-only:
+    type: boolean
+    description: |
+      When set, flash_write / flash_erase on this adapter return -EACCES.
+      Useful for exposing read-only regions (system memory, factory OTP).

--- a/dts/bindings/misc/st,stm32-bootloader-uart.yaml
+++ b/dts/bindings/misc/st,stm32-bootloader-uart.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Alex Fabre
+
+description: |
+  STM32 system bootloader over UART (AN3155).
+
+  Transport-specific bindings of a st,stm32-bootloader device.
+
+  The host sees its usart peripheral reconfigured to match the
+  AN3155-required framing (8-bit, even parity by default, 115200 baud,
+  no flow control). Configuration is restored the original dts settings
+  on exit.
+
+compatible: "st,stm32-bootloader"
+
+include: [uart-device.yaml, "st,stm32-bootloader.yaml"]
+
+properties:
+  timeout-ms:
+    type: int
+    default: 100
+    description: Per-command response timeout in milliseconds.
+
+  baudrate:
+    type: int
+    default: 115200
+    description: |
+      UART baudrate used during bootloader sessions. The STM32 bootloader
+      auto-detects between 1200 and 115200.
+
+  parity-none:
+    type: boolean
+    description: |
+      Set when the target requires no parity (STM32WB0 series, STM32WL3x
+      line). Most STM32 bootloaders require even parity (the default).

--- a/dts/bindings/misc/st,stm32-bootloader.yaml
+++ b/dts/bindings/misc/st,stm32-bootloader.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Alex Fabre
+
+description: |
+  Common properties for STM32 system bootloader host driver bindings.
+
+  Shared by all transport-specific bindings (USART for now; I2C, CAN, SPI
+  are possible future transports). The host optionally drives the target's
+  BOOT0, BOOT1 and NRST pins through GPIO; any pin absent from the device
+  tree is skipped, so this driver also works with targets that are already
+  in bootloader mode by other means.
+
+  To expose a region of the target's memory as a Zephyr flash device, add
+  an 'st,stm32-bootloader-flash' child node.
+
+properties:
+  boot0-gpios:
+    type: phandle-array
+    description: GPIO connected to the target STM32 BOOT0 (or BOOT) pin.
+
+  boot1-gpios:
+    type: phandle-array
+    description: GPIO connected to the target STM32 BOOT1 pin (if any).
+
+  nrst-gpios:
+    type: phandle-array
+    description: GPIO connected to the target STM32 NRST (reset) pin.
+
+  reset-pulse-ms:
+    type: int
+    default: 1
+    description: NRST pulse duration in milliseconds.
+
+  boot-delay-ms:
+    type: int
+    default: 10
+    description: |
+      Delay after reset before the bootloader is ready for commands
+      (refer to AN2606 for per-product values).
+
+  erase-timeout-ms:
+    type: int
+    default: 35000
+    description: |
+      Timeout for erase/mass-erase operations. Mass erase can take 30+ s.

--- a/include/zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h
+++ b/include/zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public API for the STM32 system bootloader host driver.
+ *
+ * The driver is standalone: it exposes the AN3155 command set through its
+ * own typed API, so callers interact with the target at the protocol's own
+ * level of abstraction (enter, get_info, read_memory, mass_erase, go, ...).
+ *
+ * A companion flash adapter driver (@c st,stm32-bootloader-flash) can
+ * optionally expose one or more target memory regions as Zephyr flash
+ * devices by delegating to the functions declared below. Users choose:
+ *
+ *  - Full bootloader control:  @c DEVICE_DT_GET(<bootloader-node>) and use
+ *                              the API in this header.
+ *  - Flash-style programming:  @c DEVICE_DT_GET(<flash-adapter-child>) and
+ *                              use @c flash_read / @c flash_write /
+ *                              @c flash_erase / @c stream_flash / etc.
+ *
+ * The adapter does not manage sessions — callers must @c enter the
+ * bootloader device before any @c flash_* call on a child adapter and
+ * @c exit when done.
+ *
+ * @defgroup stm32_bootloader STM32 system bootloader
+ * @ingroup misc_interfaces
+ * @{
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MISC_STM32_BOOTLOADER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MISC_STM32_BOOTLOADER_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum data bytes per single Read/Write Memory command (AN3155). */
+#define STM32_BOOTLOADER_MAX_DATA_SIZE 256
+
+/** Information returned by the target bootloader on the Get / Get Version /
+ *  Get ID commands.
+ */
+struct stm32_bootloader_info {
+	/** Bootloader version, BCD-packed (e.g. 0x31 = v3.1). */
+	uint8_t bl_version;
+	/** Number of supported commands reported by Get. */
+	uint8_t num_cmds;
+	/** Supported command bytes (truncated to 16 — enough for AN3155). */
+	uint8_t cmds[16];
+	/** Option byte 1 (from Get Version). */
+	uint8_t option1;
+	/** Option byte 2 (from Get Version). */
+	uint8_t option2;
+	/** Target Product ID (from Get ID). */
+	uint16_t pid;
+	/** True if Extended Erase (0x44) is supported, else Standard Erase (0x43). */
+	bool has_extended_erase;
+};
+
+/** @cond INTERNAL_HIDDEN */
+
+typedef int (*stm32_bootloader_enter_t)(const struct device *dev);
+typedef int (*stm32_bootloader_exit_t)(const struct device *dev, bool reset_target);
+typedef int (*stm32_bootloader_go_t)(const struct device *dev, uint32_t addr);
+typedef int (*stm32_bootloader_get_info_t)(const struct device *dev,
+					   struct stm32_bootloader_info *info);
+typedef int (*stm32_bootloader_read_memory_t)(const struct device *dev, uint32_t addr, void *buf,
+					      size_t len);
+typedef int (*stm32_bootloader_write_memory_t)(const struct device *dev, uint32_t addr,
+					       const void *buf, size_t len);
+typedef int (*stm32_bootloader_erase_pages_t)(const struct device *dev, const uint16_t *pages,
+					      size_t num_pages);
+typedef int (*stm32_bootloader_mass_erase_t)(const struct device *dev);
+
+struct stm32_bootloader_driver_api {
+	stm32_bootloader_enter_t enter;
+	stm32_bootloader_exit_t exit;
+	stm32_bootloader_go_t go;
+	stm32_bootloader_get_info_t get_info;
+	stm32_bootloader_read_memory_t read_memory;
+	stm32_bootloader_write_memory_t write_memory;
+	stm32_bootloader_erase_pages_t erase_pages;
+	stm32_bootloader_mass_erase_t mass_erase;
+};
+
+/** @endcond */
+
+/**
+ * @brief Enter the target STM32's system bootloader.
+ *
+ * Asserts BOOT pin(s) and pulses NRST if the device tree declares them,
+ * synchronises with the target over the transport bus, and caches the
+ * target's capabilities (so later @c erase_pages / @c mass_erase calls
+ * select the right erase command automatically).
+ *
+ * Must be called before any @c read_memory / @c write_memory /
+ * @c erase_pages / @c mass_erase / @c go on this device, and before any
+ * flash_* call on a companion @c st,stm32-bootloader-flash child node.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static inline int stm32_bootloader_enter(const struct device *dev)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->enter(dev);
+}
+
+/**
+ * @brief Exit the bootloader and restore the transport configuration.
+ *
+ * @param dev          Bootloader device.
+ * @param reset_target If true, pulse NRST to hard-reset the target.
+ *                     Requires an @c nrst-gpios in the device tree.
+ */
+static inline int stm32_bootloader_exit(const struct device *dev, bool reset_target)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->exit(dev, reset_target);
+}
+
+/**
+ * @brief Issue the Go command, starting execution at @p addr on the target.
+ *
+ * BOOT pin(s) are de-asserted so the target boots from flash on the next
+ * reset. @ref stm32_bootloader_exit() should still be called afterwards
+ * to restore the host's transport configuration.
+ */
+static inline int stm32_bootloader_go(const struct device *dev, uint32_t addr)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->go(dev, addr);
+}
+
+/**
+ * @brief Return the cached target bootloader information.
+ *
+ * The information is fetched during @ref stm32_bootloader_enter(); this
+ * call just copies it out. Returns @c -ENOTCONN if @c enter has not run.
+ */
+static inline int stm32_bootloader_get_info(const struct device *dev,
+					    struct stm32_bootloader_info *info)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->get_info(dev, info);
+}
+
+/**
+ * @brief Read from any addressable memory on the target.
+ *
+ * @p addr is an absolute address on the target's memory map (e.g.
+ * 0x08000000 for main flash, 0x1FFF7800 for option bytes on some parts,
+ * 0x20000000 for SRAM). The driver chunks the request into AN3155
+ * Read Memory commands as needed.
+ */
+static inline int stm32_bootloader_read_memory(const struct device *dev, uint32_t addr, void *buf,
+					       size_t len)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->read_memory(dev, addr, buf, len);
+}
+
+/**
+ * @brief Write to any addressable memory on the target.
+ *
+ * AN3155 requires 4-byte aligned addresses and lengths; the driver
+ * validates this at the boundary.
+ */
+static inline int stm32_bootloader_write_memory(const struct device *dev, uint32_t addr,
+						const void *buf, size_t len)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->write_memory(dev, addr, buf, len);
+}
+
+/**
+ * @brief Erase specific pages/sectors on the target.
+ *
+ * The driver auto-selects Standard Erase (0x43) or Extended Erase (0x44)
+ * based on the cached target capabilities.
+ */
+static inline int stm32_bootloader_erase_pages(const struct device *dev, const uint16_t *pages,
+					       size_t num_pages)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->erase_pages(dev, pages, num_pages);
+}
+
+/**
+ * @brief Erase the target's entire flash in a single command.
+ *
+ * Much faster on large targets than erasing every page individually.
+ * The driver auto-selects Standard or Extended Erase.
+ */
+static inline int stm32_bootloader_mass_erase(const struct device *dev)
+{
+	const struct stm32_bootloader_driver_api *api = DEVICE_API_GET(stm32_bootloader, dev);
+
+	return api->mass_erase(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MISC_STM32_BOOTLOADER_H_ */

--- a/samples/drivers/misc/stm32_bootloader/CMakeLists.txt
+++ b/samples/drivers/misc/stm32_bootloader/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stm32_bootloader)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/misc/stm32_bootloader/README.rst
+++ b/samples/drivers/misc/stm32_bootloader/README.rst
@@ -1,0 +1,90 @@
+.. zephyr:code-sample:: stm32-system-bootloader
+   :name: STM32 system bootloader
+   :relevant-api: stm32_bootloader flash_interface
+
+   Program a target STM32 from a host MCU via the target's built-in ROM
+   bootloader, using both the bootloader API and its flash-adapter view.
+
+Overview
+********
+
+Two device tree nodes cooperate:
+
+``stm32_target`` (``st,stm32-bootloader``)
+    The standalone bootloader driver. Exposes the AN3155 command set
+    through the typed API in
+    ``<zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>``:
+    ``enter`` / ``exit`` / ``go`` / ``get_info`` /
+    ``read_memory`` / ``write_memory`` /
+    ``erase_pages`` / ``mass_erase``.
+
+``main_flash`` (``st,stm32-bootloader-flash``, child of the bootloader)
+    A thin ``flash_driver_api`` adapter. Delegates ``flash_read`` /
+    ``flash_write`` / ``flash_erase`` to the parent's ``read_memory`` /
+    ``write_memory`` / ``erase_pages``. Makes the target usable with
+    Zephyr's existing DFU stack (``stream_flash``, ``flash_img``,
+    ``mcumgr img_mgmt``, UpdateHub) with no changes to those consumers.
+
+The sample uses both APIs side by side: the parent for lifecycle
+(``enter``, ``get_info``, ``mass_erase``, ``go``, ``exit``) and the
+child via ``stream_flash`` for the actual programming + readback verify.
+
+Session model
+*************
+
+The flash adapter holds no session state. Callers must call
+``stm32_bootloader_enter(parent)`` before any ``flash_*`` operation on a
+child and ``stm32_bootloader_exit(parent, ...)`` afterwards. If the
+parent is not entered, the adapter returns ``-ENOTCONN``.
+
+Hardware setup
+**************
+
+Host ``stm32h573i_dk`` connected to target ``nucleo_g0B1re``:
+
++---------------------+----------------------+
+| Host (H573)         | Target (G0B1)        |
++=====================+======================+
+| USART3 TX/RX        | USART1 RX/TX         |
++---------------------+----------------------+
+| PG8  → BOOT0        | BOOT0                |
++---------------------+----------------------+
+| PG5  → NRST         | NRST                 |
++---------------------+----------------------+
+| GND                 | GND                  |
++---------------------+----------------------+
+
+Building and running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/misc/stm32_bootloader
+   :board: stm32h573i_dk
+   :goals: build flash
+
+Expected log::
+
+   [00:00:00.xx] <inf> main: === STM32 bootloader sample ===
+   [00:00:00.xx] <inf> stm32_sys_bl_uart: Connected: BL v3.1, PID 0x0467, extended erase
+   [00:00:00.xx] <inf> main: Target: PID=0x0467, BL v3.1, extended erase
+   [00:00:00.xx] <inf> main: Mass-erasing target...
+   [00:00:xx.xx] <inf> main: Streaming 12 bytes of firmware...
+   [00:00:xx.xx] <inf> main: Verified 12 bytes @0x0
+   [00:00:xx.xx] <inf> main: Jumping to 0x08000000...
+   [00:00:xx.xx] <inf> stm32_sys_bl_uart: Disconnected
+   [00:00:xx.xx] <inf> main: === Done ===
+
+Using the bootloader API directly
+*********************************
+
+If your task doesn't fit flash semantics (reading option bytes, sending
+a ``Go`` to a custom address, querying the target, ...), use the
+bootloader API on the parent device. The flash adapter is entirely
+optional and does nothing when ``CONFIG_STM32_BOOTLOADER_FLASH=n``.
+
+Adding other memory regions
+***************************
+
+Add sibling ``st,stm32-bootloader-flash`` nodes under the bootloader
+node to expose additional regions as flash devices. For read-only
+regions (system memory, factory OTP) set the ``read-only`` DT property.

--- a/samples/drivers/misc/stm32_bootloader/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/misc/stm32_bootloader/boards/stm32h573i_dk.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Target: nucleo_g0B1re (STM32G0B1RE), 512 KiB flash, 2 KiB pages.
+ *
+ * The bootloader node describes how to reach the target. The
+ * main_flash child exposes its 512 KiB internal flash as a Zephyr
+ * flash device so the sample can stream firmware with stream_flash.
+ */
+
+&usart3 {
+	stm32_target: stm32_bootloader {
+		compatible = "st,stm32-bootloader";
+		boot0-gpios = <&gpiog 8 GPIO_ACTIVE_HIGH>;
+		nrst-gpios = <&gpiog 5 GPIO_ACTIVE_LOW>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		main_flash: main-flash@8000000 {
+			compatible = "st,stm32-bootloader-flash";
+			reg = <0x08000000 0x80000>;
+			erase-block-size = <0x800>;
+		};
+	};
+};

--- a/samples/drivers/misc/stm32_bootloader/prj.conf
+++ b/samples/drivers/misc/stm32_bootloader/prj.conf
@@ -1,0 +1,12 @@
+CONFIG_GPIO=y
+CONFIG_SERIAL=y
+CONFIG_LOG=y
+
+CONFIG_STM32_BOOTLOADER=y
+
+# The flash adapter + stream_flash stack (optional; disable if you only
+# need the bootloader API directly).
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_STREAM_FLASH=y
+CONFIG_STREAM_FLASH_POST_WRITE_CALLBACK=y

--- a/samples/drivers/misc/stm32_bootloader/sample.yaml
+++ b/samples/drivers/misc/stm32_bootloader/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: STM32 system bootloader host sample
+  description: |
+    Demonstrates the standalone bootloader driver and its companion flash
+    adapter by programming a small payload into a target STM32 via its
+    USART ROM bootloader.
+tests:
+  sample.drivers.misc.stm32_bootloader:
+    build_only: true
+    platform_allow:
+      - stm32h573i_dk
+    tags:
+      - drivers
+      - flash
+      - misc

--- a/samples/drivers/misc/stm32_bootloader/src/main.c
+++ b/samples/drivers/misc/stm32_bootloader/src/main.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief STM32 system bootloader sample: using both the bootloader and
+ *        flash-adapter APIs side by side.
+ *
+ * The bootloader node exposes the AN3155 command set through its own
+ * typed API (enter / get_info / go / exit / mass_erase / ...). Its child
+ * @c main_flash node exposes the target's internal flash as a Zephyr
+ * flash device, so programming flows through stream_flash exactly like
+ * on any other flash driver.
+ *
+ * Pick the API that matches your task:
+ *   - bl_dev (parent)        → lifecycle, go, mass_erase, raw memory R/W
+ *   - main_flash_dev (child) → flash_read / flash_write / flash_erase and
+ *                              anything that composes on top: stream_flash,
+ *                              flash_img, mcumgr img_mgmt, UpdateHub.
+ *
+ * The adapter does not manage sessions — call @c stm32_bootloader_enter
+ * on the parent before any @c flash_* call and @c stm32_bootloader_exit
+ * when you are done.
+ */
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/stream_flash.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/misc/stm32_bootloader/stm32_bootloader.h>
+
+LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
+
+static const struct device *const bl_dev = DEVICE_DT_GET(DT_NODELABEL(stm32_target));
+static const struct device *const main_flash_dev = DEVICE_DT_GET(DT_NODELABEL(main_flash));
+
+#define TARGET_FLASH_BASE DT_REG_ADDR(DT_NODELABEL(main_flash))
+#define TARGET_FLASH_SIZE DT_REG_SIZE(DT_NODELABEL(main_flash))
+
+static uint8_t stream_buf[256];
+static uint8_t verify_scratch[256];
+
+/*
+ * Minimal Cortex-M firmware: initial SP, reset vector pointing at the
+ * instruction two bytes in, and an endless Thumb loop ("b ."). Word-
+ * aligned so the AN3155 write-block-size constraint is satisfied.
+ */
+static const uint8_t test_firmware[] __aligned(4) = {
+	0x00, 0x00, 0x02, 0x20, /* Initial SP = 0x20020000 */
+	0x09, 0x00, 0x00, 0x08, /* Reset vector = 0x08000009 (Thumb) */
+	0xFE, 0xE7, 0xFE, 0xE7, /* b . ; b . */
+};
+
+static int verify_cb(uint8_t *buf, size_t len, size_t offset)
+{
+	int ret = flash_read(main_flash_dev, offset, verify_scratch, len);
+
+	if (ret < 0) {
+		LOG_ERR("Verify read @0x%zx: %d", offset, ret);
+		return ret;
+	}
+	if (memcmp(buf, verify_scratch, len) != 0) {
+		LOG_ERR("Verify mismatch @0x%zx", offset);
+		return -EIO;
+	}
+	LOG_INF("Verified %zu bytes @0x%zx", len, offset);
+	return 0;
+}
+
+int main(void)
+{
+	struct stm32_bootloader_info info;
+	struct stream_flash_ctx ctx;
+	int ret;
+
+	if (!device_is_ready(bl_dev) || !device_is_ready(main_flash_dev)) {
+		LOG_ERR("Devices not ready");
+		return -ENODEV;
+	}
+
+	LOG_INF("=== STM32 bootloader sample ===");
+
+	/* Parent API: lifecycle. */
+	ret = stm32_bootloader_enter(bl_dev);
+	if (ret < 0) {
+		LOG_ERR("enter: %d", ret);
+		return ret;
+	}
+
+	if (stm32_bootloader_get_info(bl_dev, &info) == 0) {
+		LOG_INF("Target: PID=0x%04x, BL v%d.%d, %s erase", info.pid, info.bl_version >> 4,
+			info.bl_version & 0x0F, info.has_extended_erase ? "extended" : "standard");
+	}
+
+	/*
+	 * Parent API: a single mass-erase command is much faster than
+	 * erasing every page individually via the flash adapter. The
+	 * flash adapter deliberately never issues mass-erase on its own.
+	 */
+	LOG_INF("Mass-erasing target...");
+	ret = stm32_bootloader_mass_erase(bl_dev);
+	if (ret < 0) {
+		LOG_ERR("mass_erase: %d", ret);
+		goto leave;
+	}
+
+	/*
+	 * Flash adapter: stream the firmware through stream_flash with a
+	 * post-write verify callback. No bootloader-specific code below
+	 * this point — this is the same code you would write for any
+	 * Zephyr flash device.
+	 */
+	ret = stream_flash_init(&ctx, main_flash_dev, stream_buf, sizeof(stream_buf), 0,
+				TARGET_FLASH_SIZE, verify_cb);
+	if (ret < 0) {
+		LOG_ERR("stream_flash_init: %d", ret);
+		goto leave;
+	}
+
+	LOG_INF("Streaming %zu bytes of firmware...", sizeof(test_firmware));
+	ret = stream_flash_buffered_write(&ctx, test_firmware, sizeof(test_firmware), true);
+	if (ret < 0) {
+		LOG_ERR("stream_flash_buffered_write: %d", ret);
+		goto leave;
+	}
+
+	/* Parent API: jump into the freshly written firmware. */
+	LOG_INF("Jumping to 0x%08x...", (unsigned int)TARGET_FLASH_BASE);
+	ret = stm32_bootloader_go(bl_dev, TARGET_FLASH_BASE);
+	if (ret < 0) {
+		LOG_ERR("go: %d", ret);
+	}
+
+leave:
+	(void)stm32_bootloader_exit(bl_dev, ret < 0);
+	LOG_INF("=== Done ===");
+	return ret;
+}


### PR DESCRIPTION
# Overview

STM32 devices have an internal bootloader stored in the internal boot ROM, that aims to let users download an application program into the internal flash memory through one of the available serial peripherals (such as USART, CAN, USB, I2C, I3C, SPI, FDCAN).

This driver aims to provide a convenient way for any host mcu to interact with a STM32 system bootloader (USART only in this first version).

# Test requirements

- Host: Any board with a serial line and some GPIO.
- Target: Any STM32 eval board, or STM32 board with a serial line(*) the BOOT(s) pin(s) and NRST pin exposed.

(*) The system bootloader initializes some peripherals with specific pin mapping. User must refer to AN2606 to check for the expected pin mapping for a given peripheral. 

[AN2606](https://www.st.com/resource/en/application_note/an2606-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf) describes the overall process and the requirements for each STM32 ref.
[AN3155](https://www.st.com/resource/en/application_note/an3155-how-to-use-usart-protocol-in-bootloader-on-stm32-mcus-stmicroelectronics.pdf) describes the UART protocol variant.

# Sample app

The driver comes with a sample app that uses a `stm32h573i_dk` as the host, and a `nucleo_g0b1re` for the target. 

The following features of the driver are tested:

- Booting the target board in bootloader mode
- Connecting through USART interface
- Reading target info
- Erasing target flash
- Writing 10 bytes and verifying
- Running the target code (Go command)
- Leaving the bootloader mode.

When running the sample app will display the following logs:

```log
*** Booting Zephyr OS build v4.3.0-6922-g92b1de96f3b2 ***
[00:00:00.000,000] <inf> main: === STM32 USART Bootloader Sample ===
[00:00:00.000,000] <inf> main: Entering bootloader...
[00:00:00.011,000] <inf> stm32_bootloader_uart: Connected to bootloader
[00:00:00.011,000] <inf> main: Reading target info...
[00:00:00.014,000] <inf> stm32_bootloader_uart: BL v3.1, PID 0x0467, extended_erase=1
[00:00:00.014,000] <inf> main: Target: PID=0x0467, BL v3.1, extended_erase=1
[00:00:00.014,000] <inf> main: Erasing target flash...
[00:00:00.037,000] <inf> stm32_bootloader_uart: Mass erase complete
[00:00:00.037,000] <inf> main: Writing test data (10 bytes)...
[00:00:00.039,000] <inf> main: Progress: 10/10 bytes (100%)
[00:00:00.039,000] <inf> main: Verifying...
[00:00:00.041,000] <inf> main: Jumping to 0x08000000...
[00:00:00.042,000] <inf> stm32_bootloader_uart: Started execution from 0x08000000
[00:00:00.042,000] <inf> main: Reset target
[00:00:00.043,000] <inf> stm32_bootloader_uart: Disconnected from bootloader
[00:00:00.043,000] <inf> main: === Done! Target should be running. ===
```