### PR TITLE
llext: heap custom sections

### DIFF
--- a/arch/mips/core/CMakeLists.txt
+++ b/arch/mips/core/CMakeLists.txt
@@ -14,3 +14,5 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
+
+zephyr_linker_sources(NOINIT noinit.ld)

--- a/arch/mips/core/noinit.ld
+++ b/arch/mips/core/noinit.ld
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Intel Corporation
+ */
+#ifdef CONFIG_LLEXT
+*(.llext_heap)
+*(.llext_ext_heap)
+*(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */

--- a/arch/sparc/core/CMakeLists.txt
+++ b/arch/sparc/core/CMakeLists.txt
@@ -19,3 +19,5 @@ zephyr_library_sources_ifdef(CONFIG_SPARC_SVT trap_table_svt.S)
 zephyr_library_sources_ifndef(CONFIG_SPARC_SVT trap_table_mvt.S)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
+
+zephyr_linker_sources(NOINIT noinit.ld)

--- a/arch/sparc/core/noinit.ld
+++ b/arch/sparc/core/noinit.ld
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Intel Corporation
+ */
+#ifdef CONFIG_LLEXT
+*(.llext_heap)
+*(.llext_ext_heap)
+*(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */

--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -54,14 +54,67 @@ option.
    On Harvard architectures, applications must call
    :c:func:`llext_heap_init_harvard`.
 
+The backing data structure for the LLEXT heap is by default a
+:c:struct:`k_heap`, but it can be changed to :c:type:`sys_mem_blocks_t` for
+non-metadata (i.e., extension regions) by selecting
+:kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK` for
+:kconfig:option:`CONFIG_LLEXT_HEAP_MANAGEMENT`.
+
+:kconfig:option:`CONFIG_LLEXT_HEAP_MANAGEMENT`
+
+        Select the memory management API used to store extension regions in
+        LLEXT heap memory. This choice does not affect LLEXT metadata, which
+        is always managed with :c:struct:`k_heap`.
+
+:kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK`
+
+        Use :c:type:`sys_mem_blocks_t` API to manage LLEXT heap memory for
+        extension regions. A minimum of one block will be allocated per region.
+        Block size must be selected with care to ensure proper alignment for
+        extension regions.
+
+.. note::
+
+   :kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK` does not support
+   :kconfig:option:`CONFIG_LLEXT_HEAP_DYNAMIC`.
+
+The heap will be split into two, the size of each sub-heap controlled by the
+following options:
+
+:kconfig:option:`CONFIG_LLEXT_EXT_HEAP_SIZE`
+
+        Heap size in kilobytes available for LLEXT extension sections. Must be
+        a multiple of :kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE`.
+        Replaced by :kconfig:option:`CONFIG_LLEXT_INSTR_HEAP_SIZE` and
+        :kconfig:option:`CONFIG_LLEXT_DATA_HEAP_SIZE` if
+        :kconfig:option:`CONFIG_HARVARD` is selected.
+
+:kconfig:option:`CONFIG_LLEXT_METADATA_HEAP_SIZE`
+
+        Heap size in kilobytes available for LLEXT metadata.
+
+Another option controls block size.
+
+:kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE`
+
+        Block size in bytes for LLEXT :c:type:`sys_mem_blocks_t` heap(s).
+        Must be equal to or a multiple of ``LLEXT_PAGE_SIZE``. The block size
+        must also be equal to or a multiple of the largest alignment needed
+        for any extension region. If
+        :kconfig:option:`CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT` is
+        selected and regions are large, an unreasonably large block size may be
+        needed to satisfy alignment requirements.
+
 Heap placement
 --------------
 
-The LLEXT heap(s) have custom sections. The non-Harvard heap section
-(``.llext_heap``) is placed alongside ``.noinit`` sections by default.
-Harvard instruction and data heap sections (``.llext_instr_heap`` and
-``.llext_data_heap``) are placed in instruction and data memory respectively.
-These default placements can be overridden by providing a custom linker script.
+The LLEXT heap(s) have custom sections. Non-Harvard heap sections
+(``.llext_heap`` or ``.llext_metadata_heap`` and ``.llext_ext_heap`` if
+:kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK` is selected) are placed alongside
+``.noinit`` sections by default. Harvard instruction and data heap sections
+(``.llext_instr_heap`` and ``.llext_data_heap``) are placed in instruction and
+data memory respectively. These default placements can be overridden by
+providing a custom linker script.
 
 :kconfig:option:`CONFIG_CUSTOM_LINKER_SCRIPT`
 

--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -27,14 +27,6 @@ control these allocations.
 
         Size of the LLEXT heap in data memory in kilobytes.
 
-.. note::
-   The LLEXT instruction heap is grouped with Zephyr .rodata, which the linker
-   typically places after .text in instruction memory.
-
-.. warning::
-   LLEXT will be unable to link and execute extensions if instruction memory
-   (i.e., memory the processor can fetch instructions from) is not writable.
-
 Alternatively the application can configure a dynamic heap using the following
 option.
 
@@ -58,8 +50,36 @@ option.
    alignment required by the architecture.
 
 .. note::
+
    On Harvard architectures, applications must call
    :c:func:`llext_heap_init_harvard`.
+
+Heap placement
+--------------
+
+The LLEXT heap(s) have custom sections. The non-Harvard heap section
+(``.llext_heap``) is placed alongside ``.noinit`` sections by default.
+Harvard instruction and data heap sections (``.llext_instr_heap`` and
+``.llext_data_heap``) are placed in instruction and data memory respectively.
+These default placements can be overridden by providing a custom linker script.
+
+:kconfig:option:`CONFIG_CUSTOM_LINKER_SCRIPT`
+
+        Path to the linker script to be used instead of the one defined by the
+        board.
+
+        The linker script must be based on a version provided by Zephyr since
+        the kernel can expect a certain layout/certain regions.
+
+        This is useful when an application needs to add sections into the
+        linker script and avoid having to change the script provided by
+        Zephyr.
+
+.. warning::
+
+   LLEXT will be unable to load extensions if the instruction memory
+   ``.llext_instr_heap`` is placed in is not writable at the time the
+   extensions are loaded and linked.
 
 .. _llext_kconfig_type:
 

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -138,6 +138,9 @@ SECTIONS {
 		*(".rodata.*")
 		*(".rodata$*")
 		*(.gnu.linkonce.r.*)
+#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD)
+		*(.llext_instr_heap)
+#endif /* CONFIG_LLEXT && defined(CONFIG_HARVARD) */
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -197,6 +200,9 @@ SECTIONS {
 		*(".data.*")
 		*(".data$*")
 		*(".kernel.*")
+#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD)
+		*(.llext_data_heap)
+#endif /* CONFIG_LLEXT && defined(CONFIG_HARVARD) */
 
 /* This is an MWDT-specific section, created when -Hccm option is enabled */
 		*(".rodata_in_data")

--- a/include/zephyr/linker/common-noinit.ld
+++ b/include/zephyr/linker/common-noinit.ld
@@ -21,6 +21,11 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
 
         *(.noinit)
         *(".noinit.*")
+#ifdef CONFIG_LLEXT
+        *(.llext_heap)
+        *(.llext_ext_heap)
+        *(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */
 #ifdef CONFIG_USERSPACE
 	z_user_stacks_start = .;
 	*(.user_stacks*)

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -82,6 +82,14 @@ config LLEXT_HEAP_MEMBLK
 
 endchoice
 
+config LLEXT_HEAP_SIZE
+	int "llext heap memory size in kilobytes"
+	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD && !LLEXT_HEAP_MEMBLK
+	default 8
+	help
+	  Heap size in kilobytes available to llext for dynamic allocation. Replaced by
+	  LLEXT_INSTR_HEAP_SIZE and LLEXT_DATA_HEAP_SIZE if HARVARD is selected.
+
 if LLEXT_HEAP_MEMBLK
 
 config LLEXT_METADATA_HEAP_SIZE
@@ -95,7 +103,7 @@ config LLEXT_EXT_HEAP_SIZE
 	depends on !HARVARD
 	default 16
 	help
-	  Heap size in kilobytes available for LLEXT extension data. Must be a multiple of
+	  Heap size in kilobytes available for LLEXT extension sections. Must be a multiple of
 	  LLEXT_HEAP_MEMBLK_BLOCK_SIZE. Replaced by LLEXT_INSTR_HEAP_SIZE and
 	  LLEXT_DATA_HEAP_SIZE if HARVARD is selected.
 
@@ -110,13 +118,6 @@ config LLEXT_HEAP_MEMBLK_BLOCK_SIZE
 	  an unreasonably large block size may be needed to satisfy alignment requirements.
 
 endif
-
-config LLEXT_HEAP_SIZE
-	int "llext heap memory size in kilobytes"
-	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD && !LLEXT_HEAP_MEMBLK
-	default 8
-	help
-	  Heap size in kilobytes available to llext for dynamic allocation
 
 config LLEXT_INSTR_HEAP_SIZE
 	int "llext instruction heap memory size in kilobytes"

--- a/subsys/llext/llext_kheap.c
+++ b/subsys/llext/llext_kheap.c
@@ -16,10 +16,11 @@ struct k_heap llext_heap;
 #else /* !CONFIG_LLEXT_HEAP_DYNAMIC */
 #ifdef CONFIG_HARVARD
 Z_HEAP_DEFINE_IN_SECT(llext_instr_heap, (CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1)),
-		      __attribute__((section(".rodata.llext_instr_heap"))));
+		      __attribute__((section(".llext_instr_heap"))));
 Z_HEAP_DEFINE_IN_SECT(llext_data_heap, (CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1)),
-		      __attribute__((section(".data.llext_data_heap"))));
+		      __attribute__((section(".llext_data_heap"))));
 #else /* !CONFIG_HARVARD */
-K_HEAP_DEFINE(llext_heap, CONFIG_LLEXT_HEAP_SIZE * KB(1));
-#endif
+Z_HEAP_DEFINE_IN_SECT(llext_heap, (CONFIG_LLEXT_HEAP_SIZE * KB(1)),
+		      __attribute__((section(".llext_heap"))));
+#endif /* CONFIG_HARVARD */
 #endif /* CONFIG_LLEXT_HEAP_DYNAMIC */

--- a/subsys/llext/llext_memblk.c
+++ b/subsys/llext/llext_memblk.c
@@ -13,6 +13,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 
+Z_HEAP_DEFINE_IN_SECT(llext_metadata_heap, (CONFIG_LLEXT_METADATA_HEAP_SIZE * KB(1)),
+		      __attribute__((section(".llext_metadata_heap"))));
 #ifdef CONFIG_HARVARD
 BUILD_ASSERT(CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1) % CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE == 0,
 	     "CONFIG_LLEXT_INSTR_HEAP_SIZE must be multiple of "
@@ -24,10 +26,9 @@ BUILD_ASSERT(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE % LLEXT_PAGE_SIZE == 0,
 	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE must be multiple of LLEXT_PAGE_SIZE");
 uint8_t llext_instr_heap_buf[CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1)]
 	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE)
-	__attribute__((section(".rodata.llext_instr_heap_buf")));
+	__attribute__((section(".llext_instr_heap")));
 uint8_t llext_data_heap_buf[CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1)]
-	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE)
-	__attribute__((section(".data.llext_data_heap_buf")));
+	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE) __attribute__((section(".llext_data_heap")));
 SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(llext_instr_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
 				   CONFIG_LLEXT_INSTR_HEAP_SIZE * KB(1) /
 					   CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
@@ -36,17 +37,18 @@ SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(llext_data_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLO
 				   CONFIG_LLEXT_DATA_HEAP_SIZE * KB(1) /
 					   CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
 				   llext_data_heap_buf);
-K_HEAP_DEFINE(llext_metadata_heap, CONFIG_LLEXT_METADATA_HEAP_SIZE * KB(1));
 #else  /* !CONFIG_HARVARD */
 BUILD_ASSERT(CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1) % CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE == 0,
 	     "CONFIG_LLEXT_EXT_HEAP_SIZE must be multiple of "
 	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE");
 BUILD_ASSERT(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE % LLEXT_PAGE_SIZE == 0,
 	     "CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE must be multiple of LLEXT_PAGE_SIZE");
-SYS_MEM_BLOCKS_DEFINE(llext_ext_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
-		      CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1) / CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
-		      CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE);
-K_HEAP_DEFINE(llext_metadata_heap, CONFIG_LLEXT_METADATA_HEAP_SIZE * KB(1));
+uint8_t llext_ext_heap_buf[CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1)]
+	__aligned(CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE) __attribute__((section(".llext_ext_heap")));
+SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(llext_ext_heap, CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   CONFIG_LLEXT_EXT_HEAP_SIZE * KB(1) /
+					   CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE,
+				   llext_ext_heap_buf);
 #endif /* CONFIG_HARVARD */
 
 static inline struct llext_alloc *get_llext_alloc(struct llext_alloc_map *map, void *alloc_ptr)


### PR DESCRIPTION
Put heap(s) in custom sections with names, providing default placement in our linker scripts but enabling users to place them elsewhere using custom linker scripts. The non-Harvard heaps are in .noinit by default because that's where they go without a custom section.

I was requested this by folks using a Harvard architecture board, but I thought I should also provide it for the non-Harvard LLEXT heaps.

EDIT: Follow up PR for doc changes https://github.com/zephyrproject-rtos/zephyr/pull/105876