### PR TITLE
Forbid user bindings from trying to set #address-cells or #size-cells defaults

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -409,6 +409,31 @@ Counter
      GPT now uses explicit devicetree properties rather than hardcoded values, allowing
      per-instance customization.
 
+.. _migration_4.4_devicetree:
+
+Devicetree
+==========
+
+* :ref:`dt-bindings` are no longer allowed to specify any default values for
+  the ``#address-cells`` and ``#size-cells`` properties. The semantics for
+  these properties are defined in Devicetree `Specification
+  <https://www.devicetree.org/specifications>`_ section 2.3.5 and users should
+  not try to override them with their own defaults.
+
+  The following bindings syntax now causes build errors:
+
+  .. code-block:: yaml
+
+     properties:
+       "#address-cells":
+         default: ...             <---- any default is a build error
+       "#size-cells":
+         default: ...             <---- any default is a build error
+
+  If you were relying on default values in your bindings, you now must
+  explicitly specify the values in your devicetree source to fix these build
+  errors.
+
 Display
 =======
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -406,6 +406,9 @@ New Samples
 DeviceTree
 **********
 
+* Migration guide: :ref:`migration_4.4_devicetree`
+* Bindings are no longer allowed to specify any default values for the
+  ``#address-cells`` and ``#size-cells`` properties.
 * :c:macro:`DT_CHILD_BY_UNIT_ADDR_INT`
 * :c:macro:`DT_INST_CHILD_BY_UNIT_ADDR_INT`
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -591,6 +591,7 @@ class PropertySpec:
         self.binding: Binding = binding
         self.name: str = name
         self._raw: dict[str, Any] = self.binding.raw["properties"][name]
+        self._check_special_properties()
 
     def __repr__(self) -> str:
         return f"<PropertySpec {self.name} type '{self.type}'>"
@@ -669,6 +670,20 @@ class PropertySpec:
     def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
+
+    def _check_special_properties(self):
+        # Add checks for properties which have special meaning
+        # according to the specification.
+        def invalid_cells_default(prop, default):
+            _err(f"invalid default value '{default}' specified for property '{prop}' "
+                 f"in binding {self.binding.path}; this property's default behavior is "
+                 "defined in DT Specification §2.3.5 and a default in a binding is invalid")
+
+        if self.name == "#address-cells" and self.default is not None:
+            invalid_cells_default("#address-cells", self.default)
+
+        if self.name == "#size-cells" and self.default is not None:
+            invalid_cells_default("#size-cells", self.default)
 
 PropertyValType = Union[int, str,
                         list[int], list[str],

--- a/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-address-cells-default.yaml
+++ b/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-address-cells-default.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: "Explicitly set #address-cells defaults should be forbidden"
+
+compatible: "wrong-address-cells-default"
+
+properties:
+  "#address-cells":
+    type: int
+    # Treat any default as an error, even if it's the value
+    # recommended by the spec. A spec-compliant program should
+    # be explicitly setting these properties.
+    default: 2

--- a/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-size-cells-default.yaml
+++ b/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-size-cells-default.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: "Explicitly set #size-cells defaults should be forbidden"
+
+compatible: "wrong-size-cells-default"
+
+properties:
+  "#size-cells":
+    type: int
+    # Treat any default as an error, even if it's the value
+    # recommended by the spec. A spec-compliant program should
+    # be explicitly setting these properties.
+    default: 1

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1017,6 +1017,24 @@ def test_wrong_props():
         assert value_str.startswith("'wrong-phandle-array-name' in 'properties:'")
         assert value_str.endswith("but no 'specifier-space' was provided.")
 
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding("test-wrong-bindings/wrong-address-cells-default.yaml", None)
+        value_str = str(e.value)
+        assert value_str.startswith("invalid default value '2' specified for property "
+                                    "'#address-cells' in binding ")
+        assert "test-wrong-bindings/wrong-address-cells-default.yaml" in value_str
+        assert value_str.endswith("; this property's default behavior is "
+                                  "defined in DT Specification §2.3.5 and a default in a binding is invalid")
+
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding("test-wrong-bindings/wrong-size-cells-default.yaml", None)
+        value_str = str(e.value)
+        assert value_str.startswith("invalid default value '1' specified for property "
+                                    "'#size-cells' in binding ")
+        assert "test-wrong-bindings/wrong-size-cells-default.yaml" in value_str
+        assert value_str.endswith("; this property's default behavior is "
+                                  "defined in DT Specification §2.3.5 and a default in a binding is invalid")
+
 
 def test_deepcopy():
     with from_here():


### PR DESCRIPTION
Make either of these illegal in bindings:

```yaml
properties:
  "#address-cells":
    default: ...             <---- any default here is forbidden by this PR
  "#size-cells":
    default: ...             <---- any default here is forbidden by this PR
```

The default behavior of these special properties is defined in the specification section 2.3.5. See individual commit logs for further details and quotes from the specification.

Hopefully this will clear up the situation described in #104478

Fixes: #104478
