### PR TITLE
drivers: i2c: sam_twihs: Lock bus when transfering data

### DIFF
--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -65,6 +65,7 @@ struct twihs_msg {
 
 /* Device run time data */
 struct i2c_sam_twihs_dev_data {
+	struct k_sem lock;
 	struct k_sem sem;
 	struct twihs_msg msg;
 };
@@ -104,6 +105,7 @@ static int i2c_clk_set(Twihs *const twihs, uint32_t speed)
 static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 {
 	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
 	Twihs *const twihs = dev_cfg->regs;
 	uint32_t bitrate;
 	int ret;
@@ -132,10 +134,12 @@ static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 		return -EIO;
 	}
 
+	k_sem_take(&dev_data->lock, K_FOREVER);
+
 	/* Setup clock waveform */
 	ret = i2c_clk_set(twihs, bitrate);
 	if (ret < 0) {
-		return ret;
+		goto unlock;
 	}
 
 	/* Disable Slave Mode */
@@ -144,7 +148,11 @@ static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
 	/* Enable Master Mode */
 	twihs->TWIHS_CR = TWIHS_CR_MSEN;
 
-	return 0;
+	ret = 0;
+unlock:
+	k_sem_give(&dev_data->lock);
+
+	return ret;
 }
 
 static void write_msg_start(Twihs *const twihs, struct twihs_msg *msg,
@@ -185,11 +193,13 @@ static int i2c_sam_twihs_transfer(const struct device *dev,
 	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
 	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
 	Twihs *const twihs = dev_cfg->regs;
+	int ret;
 
 	__ASSERT_NO_MSG(msgs);
 	if (!num_msgs) {
 		return 0;
 	}
+	k_sem_take(&dev_data->lock, K_FOREVER);
 
 	/* Clear pending interrupts, such as NACK. */
 	(void)twihs->TWIHS_SR;
@@ -213,11 +223,15 @@ static int i2c_sam_twihs_transfer(const struct device *dev,
 
 		if (dev_data->msg.twihs_sr > 0) {
 			/* Something went wrong */
-			return -EIO;
+			ret = -EIO;
+			goto unlock;
 		}
 	}
 
-	return 0;
+	ret = 0;
+unlock:
+	k_sem_give(&dev_data->lock);
+	return ret;
 }
 
 static void i2c_sam_twihs_isr(const struct device *dev)
@@ -291,6 +305,7 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 	dev_cfg->irq_config();
 
 	/* Initialize semaphore */
+	k_sem_init(&dev_data->lock, 1, 1);
 	k_sem_init(&dev_data->sem, 0, 1);
 
 	/* Connect pins to the peripheral */


### PR DESCRIPTION
Added bus locking for sam_twihs in the same manner as #46111