### PR TITLE
west: rtt: jlink: Retry when socket connection fails with invalid argument

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -5,6 +5,7 @@
 '''Runner for debugging with J-Link.'''
 
 import argparse
+import errno
 import ipaddress
 import logging
 import os
@@ -377,17 +378,29 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             server_cmd += ['-nohalt']
             server_proc = self.popen_ignore_int(server_cmd)
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock = None
                 # wait for the port to be open
                 while server_proc.poll() is None:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     try:
                         sock.connect(('localhost', self.rtt_port))
                         break
-                    except ConnectionRefusedError:
-                        time.sleep(0.1)
+                    except OSError as e:
+                        sock.close()
+                        # On at least macOS sock.connect() can fail with the
+                        # exception OSError(22, 'Invalid argument'), which
+                        # corresponds to errno EINVAL, by leaving the socket in
+                        # a non-recoverable state, hence let's wait and try
+                        # again.
+                        if e.errno in (errno.ECONNREFUSED, errno.EINVAL):
+                            time.sleep(0.1)
+                        else:
+                            raise e
                 self.run_telnet_client('localhost', self.rtt_port, sock)
-            except Exception as e:
-                self.logger.error(e)
+            except OSError as e:
+                self.logger.error(
+                    f'Failed to connect to the localhost:{self.rtt_port} socket: {e}',
+                )
             finally:
                 server_proc.terminate()
                 server_proc.wait()


### PR DESCRIPTION
On macOS, calling `socket.connect()` may fail with `OSError(22, 'Invalid argument')` if it occurs at a certain point after `JLinkGDBServer` has started. This leaves the socket in an unrecoverable state, meaning all subsequent connection attempts using the same socket will fail with the same error. This race condition is relatively consistent on my development environment. Also, adding `time.sleep(1)` before creating a socket was addressing this issue. The proposed fix is to close the socket on known errors, create a new one and try connecting again.

macOS Sequoia 15.7.4
J-Link Software Pack V9.22 and V9.24

The problem was observed while running the following command (truncated):
```
$ west -vvv rtt --runner=jlink
...
runners.jlink: JLink executable: /Applications/SEGGER/JLink_V922/JLinkExe
runners.jlink: JLINKARM_GetDLLVersion()=92200
-- runners.jlink: JLink version: 9.22
-- runners.jlink: J-Link GDB server running on port 2331; no thread info available
-- runners.jlink: J-Link RTT server running on port 19021
runners.jlink: JLinkGDBServer -select usb -port 2331 -if swd -speed 4000 -device STM32U5G9ZJ -silent -endian little -singlerun -nogui -rtttelnetport 19021 -nohalt
SEGGER J-Link GDB Server V9.22 Command Line Version

JLinkARM.dll V9.22 (DLL compiled Feb 24 2026 12:17:49)

-----GDB Server start settings-----
GDBInit file:                  none
GDB Server Listening port:     2331
SWO raw output listening port: 2332
Terminal I/O port:             2333
Accept remote connection:      yes
Generate logfile:              off
Verify download:               off
Init regs on start:            off
Silent mode:                   on
Single run mode:               on
Target connection timeout:     0 ms
------J-Link related settings------
J-Link Host interface:         USB
J-Link script:                 none
J-Link settings file:          none
------Target related settings------
Target device:                 STM32U5G9ZJ
Target device parameters:      none
Target interface:              SWD
Target interface speed:        4000kHz
Target endian:                 little

ERROR: runners.jlink: [Errno 22] Invalid argument
```

After the fix:
```
$ west -vvv rtt --runner=jlink
...
runners.jlink: JLinkGDBServer -select usb -port 2331 -if swd -speed 4000 -device STM32U5G9ZJ -silent -endian little -singlerun -nogui -rtttelnetport 19021 -nohalt
SEGGER J-Link GDB Server V9.22 Command Line Version

JLinkARM.dll V9.22 (DLL compiled Feb 24 2026 12:17:49)

-----GDB Server start settings-----
GDBInit file:                  none
GDB Server Listening port:     2331
SWO raw output listening port: 2332
Terminal I/O port:             2333
Accept remote connection:      yes
Generate logfile:              off
Verify download:               off
Init regs on start:            off
Silent mode:                   on
Single run mode:               on
Target connection timeout:     0 ms
------J-Link related settings------
J-Link Host interface:         USB
J-Link script:                 none
J-Link settings file:          none
------Target related settings------
Target device:                 STM32U5G9ZJ
Target device parameters:      none
Target interface:              SWD
Target interface speed:        4000kHz
Target endian:                 little

SEGGER J-Link V9.22 - Real time terminal output
Process: JLinkGDBServerCLExe
[00:15:46.189,000] <inf> main: Tick 1892
[00:15:46.689,000] <inf> main: Tick 1893
[00:15:47.189,000] <inf> main: Tick 1894
[00:15:47.689,000] <inf> main: Tick 1895
[00:15:48.189,000] <inf> main: Tick 1896
[00:15:48.689,000] <inf> main: Tick 1897
```