### PR TITLE
arch: riscv: thead: fence is insufficient to fence data cache

### DIFF
--- a/arch/riscv/custom/thead/cache_xtheadcmo.c
+++ b/arch/riscv/custom/thead/cache_xtheadcmo.c
@@ -12,9 +12,11 @@ int arch_dcache_invd_all(void)
 {
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 		/* th.dcache.iall */
 		".insn 0x20000B\n"
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;
@@ -38,6 +40,7 @@ int arch_dcache_invd_range(void *addr_in, size_t size)
 
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 	for (uintptr_t i = addr; i < ROUND_UP(addr + size, CONFIG_DCACHE_LINE_SIZE);
 	     i += CONFIG_DCACHE_LINE_SIZE) {
@@ -45,6 +48,7 @@ int arch_dcache_invd_range(void *addr_in, size_t size)
 	}
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;
@@ -100,9 +104,11 @@ int arch_dcache_flush_all(void)
 {
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 		/* th.dcache.call */
 		".insn 0x10000B\n"
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;
@@ -126,6 +132,7 @@ int arch_dcache_flush_range(void *addr_in, size_t size)
 
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 	for (uintptr_t i = addr; i < ROUND_UP(addr + size, CONFIG_DCACHE_LINE_SIZE);
 	     i += CONFIG_DCACHE_LINE_SIZE) {
@@ -133,6 +140,7 @@ int arch_dcache_flush_range(void *addr_in, size_t size)
 	}
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;
@@ -142,9 +150,11 @@ int arch_dcache_flush_and_invd_all(void)
 {
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 		/* th.dcache.ciall */
 		".insn 0x30000B\n"
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;
@@ -168,6 +178,7 @@ int arch_dcache_flush_and_invd_range(void *addr_in, size_t size)
 
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 	for (uintptr_t i = addr; i < ROUND_UP(addr + size, CONFIG_DCACHE_LINE_SIZE);
 	     i += CONFIG_DCACHE_LINE_SIZE) {
@@ -175,6 +186,7 @@ int arch_dcache_flush_and_invd_range(void *addr_in, size_t size)
 	}
 	__asm__ volatile (
 		"fence\n"
+		"fence.i\n"
 	);
 
 	return 0;


### PR DESCRIPTION
Using only the fence instruction to gate the management of data in cache is insufficient to prevent unordered access after flushing. Gate dcache instructions like icache instructions.

context: https://github.com/zephyrproject-rtos/zephyr/pull/104371