### PR TITLE
tests: bluetooth: tester: fix registered_services bitmap size

### DIFF
--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -53,7 +53,7 @@ static struct btp_buf *delayed_cmd;
 static struct {
 	const struct btp_handler *handlers;
 	size_t num;
-} service_handler[BTP_SERVICE_ID_MAX + 1];
+} service_handler[BTP_SERVICE_ID_COUNT];
 
 static struct net_buf_simple *rsp_buf = NET_BUF_SIMPLE(BTP_MTU);
 static K_MUTEX_DEFINE(rsp_buf_mutex);

--- a/tests/bluetooth/tester/src/btp/btp.h
+++ b/tests/bluetooth/tester/src/btp/btp.h
@@ -88,6 +88,12 @@
 
 #define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_RFCOMM
 
+/* Service ID starts from index 0.
+ * BTP_SERVICE_ID_MAX is the last service ID.
+ * The Service ID count should be BTP_SERVICE_ID_MAX + 1.
+ */
+#define BTP_SERVICE_ID_COUNT (BTP_SERVICE_ID_MAX + 1)
+
 #define BTP_STATUS_SUCCESS	0x00
 #define BTP_STATUS_FAILED	0x01
 #define BTP_STATUS_UNKNOWN_CMD	0x02

--- a/tests/bluetooth/tester/src/btp_core.c
+++ b/tests/bluetooth/tester/src/btp_core.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #define CAP_SUPPORTED 1
 #endif
 
-static ATOMIC_DEFINE(registered_services, BTP_SERVICE_ID_MAX);
+static ATOMIC_DEFINE(registered_services, BTP_SERVICE_ID_COUNT);
 
 static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 				  void *rsp, uint16_t *rsp_len)


### PR DESCRIPTION
The registered_services bitmap was incorrectly sized using BTP_SERVICE_ID_MAX, which is the last valid service ID (starting from 0). This caused the bitmap to be one element too small.

Fix by defining BTP_SERVICE_ID_COUNT as (BTP_SERVICE_ID_MAX + 1) and using it for the ATOMIC_DEFINE size to properly accommodate all service IDs from 0 to BTP_SERVICE_ID_MAX inclusive.

Add comment explaining the service ID indexing and count calculation.