### PR TITLE
soc: stm32: common: Add xspi manager driver

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -272,6 +272,11 @@ zephyr_udc0: &usbotg_hs1 {
 	};
 };
 
+&xspim {
+	/* To be moved to sb/fsbl target once sysbuild added to the board */
+	status = "okay";
+};
+
 &xspi2 {
 	pinctrl-0 = <&xspim_p2_ncs1_pn1 &xspim_p2_dqs0_pn0 &xspim_p2_clk_pn6
 		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3 &xspim_p2_io2_pn4

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -283,9 +283,6 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
-		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	mx25um51245g: ospi-nor-flash@0 {

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_sb.dts
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_stm32n657xx_sb.dts
@@ -11,3 +11,8 @@
 	model = "STMicroelectronics STM32N657X0-Q-NUCLEO board";
 	compatible = "st,stm32n657x0-q-nucleo-sb";
 };
+
+&xspim {
+	io-port-2 = <&xspi2>;
+	status = "okay";
+};

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -375,9 +375,6 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p1_io12_pp12 &xspim_p1_io13_pp13 &xspim_p1_io14_pp14
 		     &xspim_p1_io15_pp15>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(AHB5, 5)>,
-		 <&rcc STM32_SRC_HCLK5 XSPI1_SEL(0)>,
-		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	memc: aps256xxn_obr: memory@0 {
@@ -402,9 +399,6 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
-		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	mx66uw1g45g: ospi-nor-flash@0 {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_stm32n657xx_fsbl.dts
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_stm32n657xx_fsbl.dts
@@ -11,3 +11,7 @@
 	model = "STMicroelectronics STM32N6570 Discovery Kit board";
 	compatible = "st,stm32n6570-dk-fsbl";
 };
+
+&xspim {
+	status = "okay";
+};

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_stm32n657xx_sb.dts
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_stm32n657xx_sb.dts
@@ -11,3 +11,7 @@
 	model = "STMicroelectronics STM32N6570 Discovery Kit board";
 	compatible = "st,stm32n6570-dk-serial-boot";
 };
+
+&xspim {
+	status = "okay";
+};

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2183,8 +2183,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 
 	LOG_DBG("XSPI Init'd");
 
-#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2) || \
-	defined(XSPIM) || defined(XSPIM1) || defined(XSPIM2)
+#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
 	/* XSPI I/O manager init Function */
 	XSPIM_CfgTypeDef xspi_mgr_cfg;
 
@@ -2202,7 +2201,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -EIO;
 	}
 
-#endif /* XSPIM */
+#endif /* HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2 */
 
 #if defined(XSPI_DCR1_DLYBYP)
 	/* XSPI delay block init Function */

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2183,7 +2183,8 @@ static int flash_stm32_xspi_init(const struct device *dev)
 
 	LOG_DBG("XSPI Init'd");
 
-#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
+#if (defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)) && \
+	!defined(CONFIG_STM32_XSPIM)
 	/* XSPI I/O manager init Function */
 	XSPIM_CfgTypeDef xspi_mgr_cfg;
 
@@ -2201,7 +2202,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -EIO;
 	}
 
-#endif /* HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2 */
+#endif /* (HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2) && !(xspim node) */
 
 #if defined(XSPI_DCR1_DLYBYP)
 	/* XSPI delay block init Function */

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -305,6 +305,7 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		return -EIO;
 	}
 
+#if !defined(CONFIG_STM32_XSPIM)
 	if (!IS_ENABLED(CONFIG_STM32_APP_IN_EXT_FLASH)) {
 		/*
 		 * Do not configure the XSPIManager if running on the ext flash
@@ -325,6 +326,7 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 			return -EIO;
 		}
 	}
+#endif /* !CONFIG_STM32_XSPIM */
 
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 	/* DELAYBlock Enable for the stm32H5 boards */

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1288,7 +1288,8 @@ static int mspi_stm32_xspi_config(const struct mspi_dt_spec *spec)
 		goto end;
 	}
 
-#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
+#if (defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)) && \
+	!defined(CONFIG_STM32_XSPIM)
 	/* XSPI I/O manager config */
 	XSPIM_CfgTypeDef mspi_mgr_cfg;
 
@@ -1306,7 +1307,7 @@ static int mspi_stm32_xspi_config(const struct mspi_dt_spec *spec)
 		ret = -EIO;
 		goto end;
 	}
-#endif
+#endif /* (HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2) && !CONFIG_STM32_XSPIM */
 
 #if defined(DLYB_XSPI1) || defined(DLYB_XSPI2) || defined(DLYB_OCTOSPI1) || defined(DLYB_OCTOSPI2)
 	HAL_XSPI_DLYB_CfgTypeDef mspi_delay_block_cfg = {0};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1343,6 +1343,19 @@
 			status = "disabled";
 		};
 
+		xspi3: spi@5802d000 {
+			compatible = "st,stm32-xspi";
+			reg = <0x5802d000 0x1000>, <0x80000000 DT_SIZE_M(256)>;
+			interrupts = <172 0>;
+			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clocks = <&rcc STM32_CLOCK(AHB5, 17)>,
+				 <&rcc STM32_SRC_HCLK5 XSPI3_SEL(0)>,
+				 <&rcc STM32_CLOCK(AHB5, 13)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
 		usbotg_hs1: otghs@58040000 {
 			compatible = "st,stm32n6-otghs", "st,stm32-otghs";
 			reg = <0x58040000 0x2000>;

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1317,14 +1317,22 @@
 			};
 		};
 
+		xspim: xspim@5802b400 {
+			compatible = "st,stm32-xspim";
+			reg = <0x5802b400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 13)>;
+			io-port-1 = <&xspi1>;
+			io-port-2 = <&xspi2>;
+			status = "disabled";
+		};
+
 		xspi1: xspi@58025000 {
 			compatible = "st,stm32-xspi";
 			reg = <0x58025000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <170 0>;
-			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB5, 5)>,
-				 <&rcc STM32_SRC_HCLK5 XSPI1_SEL(0)>,
-				 <&rcc STM32_CLOCK(AHB5, 13)>;
+				 <&rcc STM32_SRC_HCLK5 XSPI1_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -1334,10 +1342,9 @@
 			compatible = "st,stm32-xspi";
 			reg = <0x5802a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <171 0>;
-			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-				 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
-				 <&rcc STM32_CLOCK(AHB5, 13)>;
+				 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -1347,10 +1354,9 @@
 			compatible = "st,stm32-xspi";
 			reg = <0x5802d000 0x1000>, <0x80000000 DT_SIZE_M(256)>;
 			interrupts = <172 0>;
-			clock-names = "xspix", "xspi-ker", "xspi-mgr";
+			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB5, 17)>,
-				 <&rcc STM32_SRC_HCLK5 XSPI3_SEL(0)>,
-				 <&rcc STM32_CLOCK(AHB5, 13)>;
+				 <&rcc STM32_SRC_HCLK5 XSPI3_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/bindings/xspi/st,stm32-xspim.yaml
+++ b/dts/bindings/xspi/st,stm32-xspim.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STM32 XSPI Controller Manager
+
+    XSPIM configuration provides the XSPI manager state used when exiting first
+    stage application (typically a bootloader).
+    Its configuration only happens once across all target binaries.
+
+compatible: "st,stm32-xspim"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  io-port-1:
+    type: phandles
+    required: true
+    description: |
+      List of XSPI controllers mapped to XSPIM I/O port 1
+
+  io-port-2:
+    type: phandles
+    required: true
+    description: |
+      List of XSPI controllers mapped to XSPIM I/O port 2
+
+  ncs-override:
+    type: string
+    enum: ["disabled", "ncs1", "ncs2"]
+    default: "disabled"
+    description: |
+      Chip select signal override configuration:
+        - Overrride disabled
+        - XSPI Chip select signal sent to ncs1
+        - XSPI Chip select signal sent to ncs2
+
+  req2ack-time:
+    type: int
+    default: 1
+    description: |
+      In multiplexed mode, defines time between two transactions,
+      in XSPI clock cycles.

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -14,13 +14,9 @@ if(NOT CONFIG_DEBUG AND CONFIG_PM)
   zephyr_sources_ifdef(CONFIG_DT_HAS_SWJ_CONNECTOR_ENABLED pm_debug_swj.c)
 endif()
 
-if(CONFIG_STM32_WKUP_PINS)
-  zephyr_sources(stm32_wkup_pins.c)
-endif()
-
-if(CONFIG_STM32_IOCELL)
-  zephyr_sources(stm32_iocell.c)
-endif()
+zephyr_sources_ifdef(CONFIG_STM32_WKUP_PINS stm32_wkup_pins.c)
+zephyr_sources_ifdef(CONFIG_STM32_IOCELL stm32_iocell.c)
+zephyr_sources_ifdef(CONFIG_STM32_XSPIM stm32_xspim.c)
 
 if(CONFIG_PM AND CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
   message(WARNING "\

--- a/soc/st/stm32/common/Kconfig
+++ b/soc/st/stm32/common/Kconfig
@@ -74,3 +74,18 @@ config STM32_IOCELL_CHECK_ENABLE
 	  Enables logging of I/O cell driver. This can be useful for reporting
 	  discrepancy between device-tree configuration and value stored in
 	  device OTP/option bytes
+
+config STM32_XSPIM
+	bool "STM32 XSPI Manager"
+	select USE_STM32_HAL_XSPI
+	default y if DT_HAS_ST_STM32_XSPIM_ENABLED
+	help
+	  Enables support for XSPI Manager.
+
+if STM32_XSPIM
+
+module = STM32_XSPIM
+module-str = stm32_xpsim
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # STM32_XSPIM

--- a/soc/st/stm32/common/stm32_xspim.c
+++ b/soc/st/stm32/common/stm32_xspim.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT st_stm32_xspim
+
+#include <errno.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <soc.h>
+
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+LOG_MODULE_REGISTER(stm32_xpsim, CONFIG_STM32_XSPIM_LOG_LEVEL);
+
+/* Read-only driver configuration */
+struct xspim_stm32_cfg {
+	/* XSPIM instance */
+	XSPIM_TypeDef *base;
+	/* XSPIM Clock configuration */
+	struct stm32_pclken pclken;
+};
+
+struct io_ports_dev_cfg {
+	/* XSPI controller IOMEM base address */
+	XSPI_TypeDef *base;
+	/* XSPI port identifier */
+	int io_port;
+};
+
+#define XSPIM_IO_PORT_ENTRY(node_id, prop, idx, const_port)				\
+	IF_ENABLED(									\
+		DT_NODE_HAS_STATUS_OKAY(DT_PHANDLE_BY_IDX(node_id, prop, idx)),		\
+		({									\
+			.base = (XSPI_TypeDef *)DT_REG_ADDR(				\
+				DT_PHANDLE_BY_IDX(node_id, prop, idx)),			\
+			.io_port = (const_port),					\
+		},)									\
+	)
+
+#define XSPIM_IO_PORT_DEV(port, value)					\
+	DT_INST_FOREACH_PROP_ELEM_VARGS(0, port, XSPIM_IO_PORT_ENTRY, value)
+
+static const struct io_ports_dev_cfg controllers_io_map[] = {
+	XSPIM_IO_PORT_DEV(io_port_1, HAL_XSPIM_IOPORT_1)
+	XSPIM_IO_PORT_DEV(io_port_2, HAL_XSPIM_IOPORT_2)
+};
+
+static const uint32_t ncs_override[] = {
+	HAL_XSPI_CSSEL_OVR_DISABLED,
+	HAL_XSPI_CSSEL_OVR_NCS1,
+	HAL_XSPI_CSSEL_OVR_NCS2
+};
+
+static int xspim_stm32_init(const struct device *dev)
+{
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct xspim_stm32_cfg *cfg = dev->config;
+	XSPIM_CfgTypeDef xspi_mgr_cfg;
+
+	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
+		return -EIO;
+	}
+
+	xspi_mgr_cfg.nCSOverride = ncs_override[DT_INST_ENUM_IDX(0, ncs_override)];
+	xspi_mgr_cfg.Req2AckTime = DT_INST_PROP(0, req2ack_time);
+
+	/*
+	 * XSPIM configuration requires to unclock all XSPI instance
+	 * Hence it can only be done at bootloader stage to avoid unclocking
+	 * XSPI instance controlling the NOR the application it is run from.
+	 *
+	 * As we're running on bootloader build, don't trust the list of enabled
+	 * controllers: it can be changed in application description.
+	 * Instead use the list of controllers available in io-port-n properties
+	 */
+	for (int i = 0; i < ARRAY_SIZE(controllers_io_map) ; ++i) {
+		XSPI_HandleTypeDef hxspi = {0};
+
+		hxspi.Instance = controllers_io_map[i].base;
+
+		xspi_mgr_cfg.IOPort = controllers_io_map[i].io_port;
+
+		if (HAL_XSPIM_Config(&hxspi, &xspi_mgr_cfg,
+				     HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+			LOG_ERR("XSPIM config failed for dev %p", controllers_io_map[i].base);
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static const struct xspim_stm32_cfg xspim_stm32_cfg = {
+	.base = (XSPIM_TypeDef *)DT_INST_REG_ADDR(0),
+	.pclken = STM32_DT_INST_CLOCK_INFO(0),
+};
+
+DEVICE_DT_INST_DEFINE(0, &xspim_stm32_init, NULL,
+		      NULL, &xspim_stm32_cfg,
+		      PRE_KERNEL_2, 0, NULL);


### PR DESCRIPTION
Add XSPI Manager support. Limited to STM32N6 for now, support should be extended STM32H7RS and STM32U5 afterwards.

By default allows to configure XSPIM for usual XSPI usage, but required for XSPI muxing.
Allows to get rid of a temporary hack on HAL.

Extracted from: https://github.com/zephyrproject-rtos/zephyr/pull/103009