### PR TITLE
tests: bluetooth: tester: add RFCOMM service support

### DIFF
--- a/tests/bluetooth/tester/src/btp_core.c
+++ b/tests/bluetooth/tester/src/btp_core.c
@@ -51,6 +51,10 @@ static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
+#define SERVICES_BITMAP_BYTES DIV_ROUND_UP(BTP_SERVICE_ID_COUNT, BITS_PER_BYTE)
+#define SUPPORTED_SERVICES_RSP_LEN (sizeof(struct btp_core_read_supported_services_rp) + \
+		SERVICES_BITMAP_BYTES)
+
 static uint8_t supported_services(const void *cmd, uint16_t cmd_len,
 				  void *rsp, uint16_t *rsp_len)
 {
@@ -145,7 +149,12 @@ static uint8_t supported_services(const void *cmd, uint16_t cmd_len,
 	tester_set_bit(rp->data, BTP_SERVICE_ID_SDP);
 #endif /* CONFIG_BT_CLASSIC */
 
-	*rsp_len = sizeof(*rp) + 4U;
+	/* octet 4 */
+#if defined(CONFIG_BT_RFCOMM)
+	tester_set_bit(rp->data, BTP_SERVICE_ID_RFCOMM);
+#endif /* CONFIG_BT_RFCOMM */
+
+	*rsp_len = SUPPORTED_SERVICES_RSP_LEN;
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
- Add BTP_SERVICE_ID_RFCOMM to supported services when CONFIG_BT_RFCOMM is enabled
- Replace hardcoded response length (4U) with calculated SUPPORTED_SERVICES_RSP_LEN macro based on BTP_SERVICE_ID_COUNT

This ensures the supported services response properly scales with the number of services and correctly reports RFCOMM support.