### PR TITLE
tests: arch: arm: arm_interrupt: Restore barriers for Cortex-M

### DIFF
--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -10,6 +10,7 @@
 #include <cmsis_core.h>
 #endif
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 
 /* Abstraction layer for interrupt controller operations */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
@@ -21,7 +22,6 @@
 #elif defined(CONFIG_ARMV7_R)
 /* Cortex-R: Use GIC Software Generated Interrupts (SGIs 0-15) */
 #include <zephyr/drivers/interrupt_controller/gic.h>
-#include <zephyr/sys/barrier.h>
 
 static volatile bool actually_trigger_sgi;
 
@@ -370,10 +370,8 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	irq_controller_clear_pending(i);
 	irq_enable(i);
 	irq_controller_set_pending(i);
-#if defined(CONFIG_ARMV7_R)
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
-#endif
 
 	/* Verify that the spurious ISR has led to the fault and the
 	 * expected reason variable is reset.
@@ -398,10 +396,8 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 		 * Instruction barriers to make sure the NVIC IRQ is
 		 * set to pending state before 'test_flag' is checked.
 		 */
-#if defined(CONFIG_ARMV7_R)
 		barrier_dsync_fence_full();
 		barrier_isync_fence_full();
-#endif
 
 #if defined(CONFIG_ARMV7_R)
 		/* On Cortex-R, SGI is sent immediately - allow time for processing */
@@ -449,10 +445,8 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 #endif
 
 	__enable_irq();
-#if defined(CONFIG_ARMV7_R)
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
-#endif
 
 	/* No stack variable access below this point.
 	 * The IRQ will handle the verification.


### PR DESCRIPTION
Commit 65c641dffee8 ("tests: arch: arm: Add Cortex-R5 support to arm_interrupt test") accidentally moved the barrier.h include inside the CONFIG_ARMV7_R guard and wrapped all DSB+ISB barrier calls in

Without barriers after NVIC_SetPendingIRQ(), the Cortex-M pipeline can execute past the pending write before the interrupt fires, causing the spurious IRQ assertion to fail on real hardware (nRF52, nRF54, nRF9160).

Restore barrier.h as an unconditional include and remove the CONFIG_ARMV7_R guards around all three barrier call sites so they apply to all ARM architectures as originally intended.

Fixes: #104940
(https://github.com/zephyrproject-rtos/zephyr/issues/104940)

While sending patches for commit 65c641dffee8  tested on QEMU but was not found this issue there the test case is passing 
