### PR TITLE
NXP: kinetis-sim: encode SIM clock specifiers

### DIFF
--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -189,7 +189,7 @@ i2c0: &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_tpm0>;
 	pinctrl-names = "default";
-	clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 24>;
+	clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 24)>;
 };
 
 zephyr_udc0: &usb {

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, 2025 NXP
+ * Copyright 2017, 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,54 +11,76 @@
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <fsl_clock.h>
 
-#define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(clock_control);
+static inline uint32_t mcux_sim_subsys_id(clock_control_subsys_t sub_system)
+{
+	return (uint32_t)(uintptr_t)sub_system;
+}
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_kinetis_ke1xf_sim))
+#define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_ke1xf_sim)
+#else
+#define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_sim)
+#endif
+
+static int mcux_sim_validate_gate_offset(uint32_t gate_offset)
+{
+	if (gate_offset == 0U) {
+		return 0;
+	}
+
+	if (((gate_offset & 0x3U) != 0U) ||
+	    (gate_offset >= DT_REG_SIZE(NXP_KINETIS_SIM_NODE))) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
 
 static int mcux_sim_on(const struct device *dev,
 		       clock_control_subsys_t sub_system)
 {
-	clock_ip_name_t clock_ip_name = (clock_ip_name_t) sub_system;
+	uint32_t clk = mcux_sim_subsys_id(sub_system);
+	uint32_t gate_offset = KINETIS_SIM_CLOCK_DECODE_GATE_OFFSET(clk);
+	uint32_t gate_bit = KINETIS_SIM_CLOCK_DECODE_GATE_BIT(clk);
 
-#ifdef CONFIG_ETH_NXP_ENET
-	if ((uint32_t)sub_system == KINETIS_SIM_ENET_CLK) {
-		clock_ip_name = kCLOCK_Enet0;
-	}
-#endif
-#ifdef CONFIG_COMPARATOR_NXP_CMP
-	if ((uint32_t)sub_system == KINETIS_SIM_CMP_CLK) {
-		clock_ip_name = kCLOCK_Cmp0;
-	}
-#endif
+	int ret;
 
-#ifdef CONFIG_REGULATOR_NXP_VREFV1
-	if ((uint32_t)sub_system == KINETIS_SIM_VREF_CLK) {
-		clock_ip_name = kCLOCK_Vref0;
-	}
-#endif
+	ARG_UNUSED(dev);
 
-#ifdef CONFIG_DMA_NXP_4CH_DMA
-	if ((uint32_t)sub_system == KINETIS_SIM_DMA_CLK) {
-		clock_ip_name = kCLOCK_Dma0;
+	ret = mcux_sim_validate_gate_offset(gate_offset);
+	if (ret) {
+		return ret;
 	}
 
-	if ((uint32_t)sub_system == KINETIS_SIM_DMAMUX_CLK) {
-		clock_ip_name = kCLOCK_Dmamux0;
+	if (gate_offset == 0U) {
+		return 0;
 	}
-#endif
 
-	CLOCK_EnableClock(clock_ip_name);
-
+	CLOCK_EnableClock((clock_ip_name_t)CLK_GATE_DEFINE(gate_offset, gate_bit));
 	return 0;
 }
 
 static int mcux_sim_off(const struct device *dev,
 			clock_control_subsys_t sub_system)
 {
-	clock_ip_name_t clock_ip_name = (clock_ip_name_t) sub_system;
+	uint32_t clk = mcux_sim_subsys_id(sub_system);
+	uint32_t gate_offset = KINETIS_SIM_CLOCK_DECODE_GATE_OFFSET(clk);
+	uint32_t gate_bit = KINETIS_SIM_CLOCK_DECODE_GATE_BIT(clk);
 
-	CLOCK_DisableClock(clock_ip_name);
+	int ret;
 
+	ARG_UNUSED(dev);
+
+	ret = mcux_sim_validate_gate_offset(gate_offset);
+	if (ret) {
+		return ret;
+	}
+
+	if (gate_offset == 0U) {
+		return 0;
+	}
+
+	CLOCK_DisableClock((clock_ip_name_t)CLK_GATE_DEFINE(gate_offset, gate_bit));
 	return 0;
 }
 
@@ -66,48 +88,28 @@ static int mcux_sim_get_subsys_rate(const struct device *dev,
 				    clock_control_subsys_t sub_system,
 				    uint32_t *rate)
 {
-	clock_name_t clock_name;
+	uint32_t clk = mcux_sim_subsys_id(sub_system);
+	uint32_t clock_name = KINETIS_SIM_CLOCK_DECODE_NAME(clk);
 
-	switch ((uint32_t) sub_system) {
-	case KINETIS_SIM_LPO_CLK:
-		clock_name = kCLOCK_LpoClk;
-		break;
-	case KINETIS_SIM_ENET_CLK:
-		clock_name = kCLOCK_CoreSysClk;
-		break;
-	case KINETIS_SIM_ENET_1588_CLK:
-		clock_name = kCLOCK_Osc0ErClk;
-		break;
-	default:
-		clock_name = (clock_name_t) sub_system;
-		break;
+	ARG_UNUSED(dev);
+
+	if (clock_name == KINETIS_SIM_LPO_CLK) {
+		*rate = CLOCK_GetFreq(kCLOCK_LpoClk);
+	} else {
+		*rate = CLOCK_GetFreq((clock_name_t)clock_name);
 	}
-
-	*rate = CLOCK_GetFreq(clock_name);
 
 	return 0;
 }
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_kinetis_ke1xf_sim))
-#define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_ke1xf_sim)
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_source)
+
+#if DT_NODE_HAS_PROP(NXP_KINETIS_SIM_NODE, clkout_source)
 	#define NXP_KINETIS_SIM_CLKOUT_SOURCE \
-			DT_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_source)
+		DT_PROP(NXP_KINETIS_SIM_NODE, clkout_source)
 #endif
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_divider)
+#if DT_NODE_HAS_PROP(NXP_KINETIS_SIM_NODE, clkout_divider)
 	#define NXP_KINETIS_SIM_CLKOUT_DIVIDER \
-			DT_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_divider)
-#endif
-#else
-#define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_sim)
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_sim), clkout_source)
-	#define NXP_KINETIS_SIM_CLKOUT_SOURCE \
-		DT_PROP(DT_INST(0, nxp_kinetis_sim), clkout_source)
-#endif
-#if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_sim), clkout_divider)
-	#define NXP_KINETIS_SIM_CLKOUT_DIVIDER \
-		DT_PROP(DT_INST(0, nxp_kinetis_sim), clkout_divider)
-#endif
+		DT_PROP(NXP_KINETIS_SIM_NODE, clkout_divider)
 #endif
 
 static int mcux_sim_init(const struct device *dev)

--- a/drivers/pinctrl/pinctrl_nxp_port.c
+++ b/drivers/pinctrl/pinctrl_nxp_port.c
@@ -72,8 +72,7 @@ static int pinctrl_mcux_init(const struct device *dev)
 }
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_kinetis_sim))
-#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)                                                       \
-	CLK_GATE_DEFINE(DT_INST_CLOCKS_CELL(n, offset), DT_INST_CLOCKS_CELL(n, bits))
+#define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n) DT_INST_CLOCKS_CELL(n, name)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_scg_k4)
 #define PINCTRL_MCUX_DT_INST_CLOCK_SUBSYS(n)                                                       \
 	(DT_INST_CLOCKS_CELL(n, mrcc_offset) == 0                                                  \

--- a/dts/arm/nxp/kinetis/nxp_k22fx512.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k22fx512.dtsi
@@ -15,14 +15,14 @@
 			#size-cells = <0>;
 			reg = <0x400e6000 0x1000>;
 			interrupts = <74 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 6)>;
 			status = "disabled";
 		};
 
 		spi2: spi@400ac000 {
 			reg = <0x400ac000 0x88>;
 			interrupts = <65 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1030, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -33,7 +33,7 @@
 			reg = <0x400ea000 0x1000>;
 			interrupts = <66 0>, <67 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 10)>;
 
 			status = "disabled";
 		};
@@ -43,7 +43,7 @@
 			reg = <0x400eb000 0x1000>;
 			interrupts = <68 0>, <69 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 11)>;
 
 			status = "disabled";
 		};

--- a/dts/arm/nxp/kinetis/nxp_k2x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k2x.dtsi
@@ -145,7 +145,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <24 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -156,7 +156,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <25 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -165,7 +165,7 @@
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 10)>;
 
 			status = "disabled";
 		};
@@ -175,7 +175,7 @@
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 11)>;
 
 			status = "disabled";
 		};
@@ -185,7 +185,7 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 12)>;
 
 			status = "disabled";
 		};
@@ -195,7 +195,7 @@
 			reg = <0x4006d000 0x1000>;
 			interrupts = <37 0>, <38 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 13)>;
 
 			status = "disabled";
 		};
@@ -203,31 +203,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -284,7 +284,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -294,7 +294,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x88>;
 			interrupts = <27 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -304,7 +304,7 @@
 			compatible = "nxp,kinetis-wdog";
 			reg = <0x40052000 16>;
 			interrupts = <22 0>;
-			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_LPO_CLK, 0, 0)>;
 		};
 
 		ftm0: ftm@40038000 {
@@ -312,7 +312,7 @@
 			reg = <0x40038000 0x98>;
 			interrupts = <42 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x103c 24>;
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 24)>;
 			prescaler = <16>;
 			status = "disabled";
 		};
@@ -322,7 +322,7 @@
 			reg = <0x40039000 0x98>;
 			interrupts = <43 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x103c 25>;
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 25)>;
 			prescaler = <16>;
 			status = "disabled";
 		};
@@ -332,7 +332,7 @@
 			reg = <0x4003a000 0x98>;
 			interrupts = <44 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x103c 26>;
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 26)>;
 			prescaler = <16>;
 			status = "disabled";
 		};
@@ -342,7 +342,7 @@
 			reg = <0x400b9000 0x98>;
 			interrupts = <71 0>;
 			clocks = <&mcg KINETIS_MCG_FIXED_FREQ_CLK>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x103c 6>;
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 6)>;
 			prescaler = <16>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/kinetis/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k32l2b3.dtsi
@@ -115,31 +115,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -204,7 +204,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <8 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -215,7 +215,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <9 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -232,7 +232,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x1000>;
 			interrupts = <12 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 20>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x1038, 20)>;
 			status = "disabled";
 		};
 
@@ -240,7 +240,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40055000 0x1000>;
 			interrupts = <13 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 21>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x1038, 21)>;
 			status = "disabled";
 		};
 
@@ -249,7 +249,7 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <14 0>;
 			interrupt-names = "status";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 12)>;
 			status = "disabled";
 		};
 
@@ -257,7 +257,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x40038000 0x88>;
 			interrupts = <17 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 24>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 24)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -267,7 +267,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x40039000 0x88>;
 			interrupts = <18 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 25>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 25)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -277,7 +277,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x4003a000 0x88>;
 			interrupts = <19 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 26>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 26)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -307,7 +307,7 @@
 		pit0: pit@40037000 {
 			compatible = "nxp,pit";
 			reg = <0x40037000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 23)>;
 			interrupts = <22 0>;
 			max-load-value = <0xffffffff>;
 			status = "disabled";

--- a/dts/arm/nxp/kinetis/nxp_k66.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k66.dtsi
@@ -18,7 +18,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400c4000 0x14>;
 			interrupts = <86 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1038, 20)>;
 			dmas = <&edma0 1 58>, <&edma0 2 59>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -30,8 +30,8 @@
 			interrupts = <94 0>, <95 0>, <96 0>, <97 0>, <98 0>, <99 0>;
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning",
 					  "rx-warning", "wake-up";
-			clocks = <&sim KINETIS_SIM_OSCERCLK 0x1030 4>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x1030, 4)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1030, 4)>;
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;

--- a/dts/arm/nxp/kinetis/nxp_k6x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k6x.dtsi
@@ -176,7 +176,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <24 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -187,7 +187,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <25 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -198,7 +198,7 @@
 			#size-cells = <0>;
 			reg = <0x400e6000 0x1000>;
 			interrupts = <74 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 6)>;
 			status = "disabled";
 		};
 
@@ -207,7 +207,7 @@
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 10)>;
 
 			status = "disabled";
 		};
@@ -217,7 +217,7 @@
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 11)>;
 
 			status = "disabled";
 		};
@@ -227,7 +227,7 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 12)>;
 
 			status = "disabled";
 		};
@@ -237,7 +237,7 @@
 			reg = <0x4006d000 0x1000>;
 			interrupts = <37 0>, <38 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 13)>;
 
 			status = "disabled";
 		};
@@ -247,7 +247,7 @@
 			reg = <0x400ea000 0x1000>;
 			interrupts = <66 0>, <67 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 10)>;
 
 			status = "disabled";
 		};
@@ -257,7 +257,7 @@
 			reg = <0x400eb000 0x1000>;
 			interrupts = <68 0>, <69 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 11)>;
 
 			status = "disabled";
 		};
@@ -265,31 +265,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -350,7 +350,7 @@
 			dma-names = "rx", "tx";
 			rx-fifo-size = <4>;
 			tx-fifo-size = <4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -365,7 +365,7 @@
 			rx-fifo-size = <1>;
 			tx-fifo-size = <1>;
 			nxp,rx-tx-chn-share;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -380,7 +380,7 @@
 			rx-fifo-size = <1>;
 			tx-fifo-size = <1>;
 			nxp,rx-tx-chn-share;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1030, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -390,7 +390,7 @@
 			compatible = "nxp,kinetis-wdog";
 			reg = <0x40052000 16>;
 			interrupts = <22 0>;
-			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_LPO_CLK, 0, 0)>;
 		};
 
 		ftm0: ftm@40038000 {
@@ -432,8 +432,8 @@
 		adc0: adc@4003b000 {
 			compatible = "nxp,kinetis-adc16";
 			reg = <0x4003b000 0x70>;
-			clocks = <&sim KINETIS_SIM_SIM_SOPT7 0 0xf>,
-				 <&sim KINETIS_SIM_SIM_SOPT7 7 0x80>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 0, 0xf)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 7, 0x80)>;
 			dmas = <&edma0 0 40>;
 			dma-names = "adc0";
 			clk-source = <0>;
@@ -445,8 +445,8 @@
 		adc1: adc@400bb000 {
 			compatible = "nxp,kinetis-adc16";
 			reg = <0x400bb000 0x70>;
-			clocks = <&sim KINETIS_SIM_SIM_SOPT7 8 0xf00>,
-				 <&sim KINETIS_SIM_SIM_SOPT7 15 0x8000>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 8, 0xf00)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 15, 0x8000)>;
 			dmas = <&edma0 0 41>;
 			dma-names = "adc1";
 			clk-source = <0>;
@@ -485,7 +485,7 @@
 		enet: ethernet@400c0000 {
 			compatible = "nxp,enet";
 			reg = <0x400c0000 0x620>;
-			clocks = <&sim KINETIS_SIM_ENET_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x102C, 0)>;
 
 			enet_mac: ethernet {
 				compatible = "nxp,enet-mac";
@@ -508,7 +508,8 @@
 				compatible = "nxp,enet-ptp-clock";
 				interrupts = <82 0>;
 				interrupt-names = "IEEE1588_TMR";
-				clocks = <&sim KINETIS_SIM_ENET_1588_CLK 0 0>;
+				clocks = <&sim
+					  KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0, 0)>;
 				status = "disabled";
 			};
 		};
@@ -526,8 +527,8 @@
 			interrupts = <75 0>, <76 0>, <77 0>, <78 0>, <79 0>, <80 0>;
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning",
 					  "wake-up";
-			clocks = <&sim KINETIS_SIM_OSCERCLK 0x103c 4>,
-				 <&sim KINETIS_SIM_BUS_CLK 0x103c 4>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x103c, 4)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 4)>;
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
@@ -548,15 +549,16 @@
 				     <8 0>, <9 0>, <10 0>, <11 0>,
 				     <12 0>, <13 0>, <14 0>, <15 0>,
 				     <16 0>;
-			clocks = <&sim KINETIS_SIM_DMA_CLK 0x1040 0x00000002>,
-				 <&sim KINETIS_SIM_DMAMUX_CLK 0x103c 0x00000002>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 0x00000002)>,
+				 <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 0x00000002)>;
 			status = "disabled";
 		};
 
 		pit0: pit@40037000 {
 			compatible = "nxp,pit";
 			reg = <0x40037000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 23)>;
 			status = "disabled";
 			max-load-value = <0xffffffff>;
 			#address-cells = <1>;

--- a/dts/arm/nxp/kinetis/nxp_k6x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k6x.dtsi
@@ -549,9 +549,9 @@
 				     <8 0>, <9 0>, <10 0>, <11 0>,
 				     <12 0>, <13 0>, <14 0>, <15 0>,
 				     <16 0>;
-			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 0x00000002)>,
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 1)>,
 				 <&sim
-				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 0x00000002)>;
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 1)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/kinetis/nxp_k8x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k8x.dtsi
@@ -443,9 +443,9 @@
 				     <8 0>, <9 0>, <10 0>, <11 0>,
 				     <12 0>, <13 0>, <14 0>, <15 0>,
 				     <16 0>;
-			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 0x00000002)>,
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 1)>,
 				 <&sim
-				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 0x00000002)>;
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 1)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_k8x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k8x.dtsi
@@ -110,8 +110,8 @@
 		adc0: adc@4003b000 {
 			compatible = "nxp,kinetis-adc16";
 			reg = <0x4003b000 0x1000>;
-			clocks = <&sim KINETIS_SIM_SIM_SOPT7 0 0xf>,
-				 <&sim KINETIS_SIM_SIM_SOPT7 7 0x80>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 0, 0xf)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_SIM_SOPT7, 7, 0x80)>;
 			interrupts = <39 0>;
 			dmas = <&edma0 0 40>;
 			dma-names = "adc0";
@@ -177,7 +177,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <24 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -188,7 +188,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <25 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -199,7 +199,7 @@
 			#size-cells = <0>;
 			reg = <0x400e6000 0x1000>;
 			interrupts = <74 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 6)>;
 			status = "disabled";
 		};
 
@@ -210,7 +210,7 @@
 			#size-cells = <0>;
 			reg = <0x400e7000 0x1000>;
 			interrupts = <91 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1028, 7)>;
 			status = "disabled";
 		};
 
@@ -218,7 +218,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400c4000 0x1000>;
 			interrupts = <30 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 4>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x102c, 4)>;
 			dmas = <&edma0 1 2>, <&edma0 2 3>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -228,7 +228,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400c5000 0x1000>;
 			interrupts = <31 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 5>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x102c, 5)>;
 			dmas = <&edma0 3 4>, <&edma0 4 5>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -238,7 +238,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400c6000 0x1000>;
 			interrupts = <32 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x102c, 6)>;
 			dmas = <&edma0 5 6>, <&edma0 6 7>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -248,7 +248,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400c7000 0x1000>;
 			interrupts = <33 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x102c, 7)>;
 			dmas = <&edma0 7 8>, <&edma0 8 9>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -258,7 +258,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x400d6000 0x1000>;
 			interrupts = <34 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x102c 22>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x102c, 22)>;
 			dmas = <&edma0 9 10>, <&edma0 10 11>;
 			dma-names = "rx", "tx";
 			status = "disabled";
@@ -267,31 +267,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		ftm0: ftm@40038000 {
@@ -343,7 +343,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -353,7 +353,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -363,7 +363,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x400ac000 0x1000>;
 			interrupts = <65 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1030, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -388,13 +388,13 @@
 			compatible = "nxp,kinetis-wdog";
 			reg = <0x40052000 0x1000>;
 			interrupts = <22 0>;
-			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_LPO_CLK, 0, 0)>;
 		};
 
 		pit0: pit@40037000 {
 			compatible = "nxp,pit";
 			reg = <0x40037000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 23)>;
 			status = "disabled";
 			max-load-value = <0xffffffff>;
 			#address-cells = <1>;
@@ -443,8 +443,9 @@
 				     <8 0>, <9 0>, <10 0>, <11 0>,
 				     <12 0>, <13 0>, <14 0>, <15 0>,
 				     <16 0>;
-			clocks = <&sim KINETIS_SIM_DMA_CLK 0x1040 0x00000002>,
-				 <&sim KINETIS_SIM_DMAMUX_CLK 0x103c 0x00000002>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_DMA_CLK, 0x1040, 0x00000002)>,
+				 <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_DMAMUX_CLK, 0x103c, 0x00000002)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kl25z.dtsi
@@ -71,7 +71,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <8 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -82,7 +82,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <9 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -115,7 +115,7 @@
 			compatible = "nxp,kinetis-lpsci";
 			reg = <0x4006a000 0xc>;
 			interrupts = <12 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 10)>;
 
 			status = "disabled";
 		};
@@ -131,31 +131,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {

--- a/dts/arm/nxp/kinetis/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kv5x.dtsi
@@ -166,7 +166,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <24 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -177,38 +177,38 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <25 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		ftm0: ftm@40038000 {
@@ -248,7 +248,8 @@
 			reg = <0x4002c000 0x1000>;
 			interrupts = <26 3>;
 			status = "disabled";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x103c 12>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x103c, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -258,7 +259,8 @@
 			reg = <0x4002d000 0x1000>;
 			interrupts = <27 3>;
 			status = "disabled";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x103c 13>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x103c, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -268,7 +270,8 @@
 			reg = <0x400ac000 0x1000>;
 			interrupts = <65 3>;
 			status = "disabled";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1030 12>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1030, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -278,7 +281,8 @@
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1034 10>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1034, 10)>;
 			status = "disabled";
 		};
 
@@ -287,7 +291,8 @@
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1034 11>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1034, 11)>;
 			status = "disabled";
 		};
 
@@ -296,7 +301,8 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1034 12>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1034, 12)>;
 			status = "disabled";
 		};
 
@@ -305,7 +311,8 @@
 			reg = <0x4006d000 0x1000>;
 			interrupts = <44 0>, <45 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1034 13>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1034, 13)>;
 			status = "disabled";
 		};
 
@@ -314,7 +321,8 @@
 			reg = <0x400ea000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1028 10>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1028, 10)>;
 			status = "disabled";
 		};
 
@@ -323,7 +331,8 @@
 			reg = <0x400eb000 0x1000>;
 			interrupts = <28 0>, <29 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_FAST_PERIPHERAL_CLK 0x1028 11>;
+			clocks = <&sim
+				  KINETIS_SIM_CLOCK(KINETIS_SIM_FAST_PERIPHERAL_CLK, 0x1028, 11)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kw2xd.dtsi
@@ -140,7 +140,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <24 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -151,7 +151,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <25 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -160,7 +160,7 @@
 			reg = <0x4006a000 0x1000>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 10)>;
 
 			status = "disabled";
 		};
@@ -170,7 +170,7 @@
 			reg = <0x4006b000 0x1000>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 11)>;
 
 			status = "disabled";
 		};
@@ -180,7 +180,7 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "status", "error";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 12)>;
 
 			status = "disabled";
 		};
@@ -188,31 +188,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -269,7 +269,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x88>;
 			interrupts = <26 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -279,7 +279,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x88>;
 			interrupts = <27 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -301,7 +301,7 @@
 			compatible = "nxp,kinetis-wdog";
 			reg = <0x40052000 16>;
 			interrupts = <22 0>;
-			clocks = <&sim KINETIS_SIM_LPO_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_LPO_CLK, 0, 0)>;
 		};
 
 		ftm0: ftm@40038000 {

--- a/dts/arm/nxp/kinetis/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kw40z.dtsi
@@ -109,7 +109,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <8 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -120,7 +120,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <9 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -128,7 +128,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x18>;
 			interrupts = <12 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1038, 20)>;
 
 			status = "disabled";
 		};
@@ -136,19 +136,19 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -184,7 +184,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x9c>;
 			interrupts = <10 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			status = "disabled";
 
 			#address-cells = <1>;
@@ -195,7 +195,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x9c>;
 			interrupts = <29 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/kinetis/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_kw41z.dtsi
@@ -112,7 +112,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <8 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -123,7 +123,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <9 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -131,7 +131,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x18>;
 			interrupts = <12 0>;
-			clocks = <&sim KINETIS_SIM_CORESYS_CLK 0x1038 20>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_CORESYS_CLK, 0x1038, 20)>;
 
 			status = "disabled";
 		};
@@ -139,19 +139,19 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xa4>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -187,7 +187,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002c000 0x9c>;
 			interrupts = <10 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 12)>;
 			status = "disabled";
 
 			#address-cells = <1>;
@@ -198,7 +198,7 @@
 			compatible = "nxp,dspi";
 			reg = <0x4002d000 0x9c>;
 			interrupts = <29 3>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 13)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -209,7 +209,7 @@
 			reg = <0x40038000 0x88>;
 			interrupts = <0x84 0>;
 			/* channel information needed - fixme */
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 24>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 24)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -220,7 +220,7 @@
 			reg = <0x40039000 0x88>;
 			interrupts = <0x88 0>;
 			/* channel information needed - fixme */
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 25>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 25)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -231,7 +231,7 @@
 			reg = <0x4003a000 0x88>;
 			interrupts = <0x8c 0>;
 			/* channel information needed - fixme */
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 26>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 26)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;

--- a/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
@@ -132,31 +132,31 @@
 		porta: pinmux@40049000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x40049000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 9)>;
 		};
 
 		portb: pinmux@4004a000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004a000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 10)>;
 		};
 
 		portc: pinmux@4004b000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004b000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 11)>;
 		};
 
 		portd: pinmux@4004c000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004c000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 12)>;
 		};
 
 		porte: pinmux@4004d000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x4004d000 0xd0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1038, 13)>;
 		};
 
 		gpioa: gpio@400ff000 {
@@ -222,7 +222,7 @@
 			#size-cells = <0>;
 			reg = <0x40066000 0x1000>;
 			interrupts = <8 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 6)>;
 			status = "disabled";
 		};
 
@@ -233,7 +233,7 @@
 			#size-cells = <0>;
 			reg = <0x40067000 0x1000>;
 			interrupts = <9 0>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 7)>;
 			status = "disabled";
 		};
 
@@ -250,7 +250,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40054000 0x1000>;
 			interrupts = <12 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 20>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x1038, 20)>;
 			status = "disabled";
 		};
 
@@ -258,7 +258,7 @@
 			compatible = "nxp,lpuart";
 			reg = <0x40055000 0x1000>;
 			interrupts = <13 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 21>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x1038, 21)>;
 			status = "disabled";
 		};
 
@@ -267,7 +267,7 @@
 			reg = <0x4006c000 0x1000>;
 			interrupts = <14 0>;
 			interrupt-names = "status";
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 12)>;
 			status = "disabled";
 		};
 
@@ -275,7 +275,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x40038000 0x88>;
 			interrupts = <17 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 24>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 24)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -285,7 +285,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x40039000 0x88>;
 			interrupts = <18 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 25>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 25)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -295,7 +295,7 @@
 			compatible = "nxp,kinetis-tpm";
 			reg = <0x4003a000 0x88>;
 			interrupts = <19 0>;
-			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103c 26>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_MCGPCLK, 0x103c, 26)>;
 			prescaler = <16>;
 			status = "disabled";
 			#pwm-cells = <3>;
@@ -325,7 +325,7 @@
 		pit0: pit@40037000 {
 			compatible = "nxp,pit";
 			reg = <0x40037000 0x1000>;
-			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 23)>;
 			interrupts = <22 0>;
 			max-load-value = <0xffffffff>;
 			status = "disabled";
@@ -350,14 +350,14 @@
 			reg = <0x40073000 0x1000>;
 			interrupts = <16 0>;
 			status = "disabled";
-			clocks = <&sim KINETIS_SIM_CMP_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 19)>;
 		};
 
 		vref: vref@40074000 {
 			compatible = "nxp,vrefv1";
 			reg = <0x40074000 0x100>;
 			status = "disabled";
-			clocks = <&sim KINETIS_SIM_VREF_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1034, 20)>;
 			chop-oscillator-en;
 			current-compensation-en;
 			internal-voltage-regulator-en;
@@ -379,8 +379,8 @@
 			dma-requests = <64>;
 			reg = <0x40008000 0x1000>,
 			      <0x40021000 0x1000>;
-			clocks = <&sim KINETIS_SIM_DMA_CLK 0 0>,
-				 <&sim KINETIS_SIM_DMAMUX_CLK 0 0>;
+			clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x1040, 8)>,
+				 <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_BUS_CLK, 0x103c, 1)>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>;
 			status = "disabled";
 		};

--- a/dts/bindings/clock/nxp,kinetis-sim.yaml
+++ b/dts/bindings/clock/nxp,kinetis-sim.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, NXP
+# Copyright (c) 2017, 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: Kinetis System Integration Module (SIM) IP node
@@ -34,6 +34,10 @@ properties:
     const: 3
 
 clock-cells:
+  # 32-bit encoded id: gate_offset[31:19] | gate_bit[18:14] | clock_name[13:9] |
+  #   mux_val[8:6] | mux_shift[5:1] | has_mux[0]
+  # Use KINETIS_SIM_CLOCK() or KINETIS_SIM_CLOCK_MUX() macros from
+  # include/zephyr/dt-bindings/clock/kinetis_sim.h to build this value.
   - name
-  - offset
-  - bits
+  - offset  # gate register offset (explicit, e.g. 0x1034); kept for ADC16 compatibility
+  - bits    # gate bit index (explicit); kept for ADC16 compatibility

--- a/include/zephyr/dt-bindings/clock/kinetis_sim.h
+++ b/include/zephyr/dt-bindings/clock/kinetis_sim.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2017, 2025 NXP
- * Copyright (c) 2017, 2025 NXP
+ * Copyright (c) 2017, 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,5 +32,80 @@
 
 #define KINETIS_SIM_CMP_CLK		4323
 #define KINETIS_SIM_VREF_CLK		4324
+
+/*
+ * SIM clock specifier encoding.
+ *
+ * Each SIM clock reference is a 3-cell specifier \<id offset bits\>:
+ *
+ *   id     - 32-bit encoded value containing gate and rate information
+ *   offset - gate register offset (explicit, for readability and
+ *             consumers such as ADC16 that read it directly)
+ *   bits   - gate bit index or mask (explicit, same reason)
+ *
+ * Layout of the `id` cell (32-bit):
+ *   [31:19] gate_offset (13 bits) - SCGC register offset; 0 = no gate
+ *   [18:14] gate_bit    (5 bits)  - bit position within SCGC register
+ *   [13:9]  clock_name  (5 bits)  - KINETIS_SIM_*_CLK for get_rate
+ *   [8:6]   mux_val     (3 bits)  - mux source value for configure
+ *   [5:1]   mux_shift   (5 bits)  - mux bit shift in mux register
+ *   [0]     has_mux     (1 bit)   - 1 = configure mux on .configure call
+ *
+ * All known clock name values (0-19) and gate offsets (up to 0x1040)
+ * fit within their respective fields.
+ */
+
+/** @cond INTERNAL_HIDDEN */
+#define KINETIS_SIM_CLOCK_ID(name, gate_offset, gate_bit) \
+	((((gate_offset) & 0x1FFFU) << 19) | \
+	 (((gate_bit)    & 0x1FU)   << 14) | \
+	 (((name)        & 0x1FU)   <<  9))
+
+#define KINETIS_SIM_CLOCK_ID_MUX(name, gate_offset, gate_bit, mux_shift, mux_val) \
+	(KINETIS_SIM_CLOCK_ID(name, gate_offset, gate_bit) | \
+	 (((mux_val)   & 0x7U) << 6) | \
+	 (((mux_shift) & 0x1FU) << 1) | 0x1U)
+/** @endcond */
+
+/** @cond INTERNAL_HIDDEN */
+/* Decoders used by the driver and soc.c */
+#define KINETIS_SIM_CLOCK_DECODE_GATE_OFFSET(val)  (((val) >> 19) & 0x1FFFU)
+#define KINETIS_SIM_CLOCK_DECODE_GATE_BIT(val)     (((val) >> 14) & 0x1FU)
+#define KINETIS_SIM_CLOCK_DECODE_NAME(val)         (((val) >>  9) & 0x1FU)
+#define KINETIS_SIM_CLOCK_DECODE_MUX_VAL(val)      (((val) >>  6) & 0x7U)
+#define KINETIS_SIM_CLOCK_DECODE_MUX_SHIFT(val)    (((val) >>  1) & 0x1FU)
+#define KINETIS_SIM_CLOCK_HAS_MUX(val)             ((val) & 0x1U)
+/** @endcond */
+
+/**
+ * @def KINETIS_SIM_CLOCK
+ * @brief Build a 3-cell SIM clock specifier.
+ *
+ * Expands to \<id offset bits\> where `id` encodes gate and rate information,
+ * and `offset`/`bits` are kept explicit for readability and for consumers
+ * (e.g. ADC16) that read them as separate cells.
+ *
+ * @param name   Clock name selector (KINETIS_SIM_*_CLK)
+ * @param offset Gate register offset (e.g. 0x1034)
+ * @param bits   Gate bit index (0..31)
+ */
+#define KINETIS_SIM_CLOCK(name, offset, bits) \
+	KINETIS_SIM_CLOCK_ID(name, offset, bits) offset bits
+
+/**
+ * @def KINETIS_SIM_CLOCK_MUX
+ * @brief Build a 3-cell SIM clock specifier with mux configuration.
+ *
+ * Like KINETIS_SIM_CLOCK but also encodes the mux register field and value
+ * needed for clock_control_configure() support.
+ *
+ * @param name      Clock name selector (KINETIS_SIM_*_CLK)
+ * @param offset    Gate register offset
+ * @param bits      Gate bit index (0..31)
+ * @param mux_shift Bit shift of the mux field in the mux register (e.g. SOPT2)
+ * @param mux_val   Value to write into the mux field
+ */
+#define KINETIS_SIM_CLOCK_MUX(name, offset, bits, mux_shift, mux_val) \
+	KINETIS_SIM_CLOCK_ID_MUX(name, offset, bits, mux_shift, mux_val) offset bits
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_KINETIS_SIM_H_ */

--- a/samples/basic/blinky_pwm/boards/frdm_mcxc242.overlay
+++ b/samples/basic/blinky_pwm/boards/frdm_mcxc242.overlay
@@ -5,9 +5,9 @@
  */
 
 &tpm1 {
-	clocks = <&sim KINETIS_SIM_OSCERCLK 0x103c 25>;
+	clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x103c, 25)>;
 };
 
 &tpm2 {
-	clocks = <&sim KINETIS_SIM_OSCERCLK 0x103c 26>;
+	clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x103c, 26)>;
 };

--- a/samples/drivers/led/pwm/boards/frdm_mcxc242.overlay
+++ b/samples/drivers/led/pwm/boards/frdm_mcxc242.overlay
@@ -15,9 +15,9 @@
 };
 
 &tpm1 {
-	clocks = <&sim KINETIS_SIM_OSCERCLK 0x103c 25>;
+	clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x103c, 25)>;
 };
 
 &tpm2 {
-	clocks = <&sim KINETIS_SIM_OSCERCLK 0x103c 26>;
+	clocks = <&sim KINETIS_SIM_CLOCK(KINETIS_SIM_OSCERCLK, 0x103c, 26)>;
 };

--- a/soc/nxp/kinetis/k32lx/soc.c
+++ b/soc/nxp/kinetis/k32lx/soc.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/arch/cpu.h>
 
 /*******************************************************************************
@@ -29,19 +30,23 @@
 
 #define CLOCK_DIVIDER(clk) DT_PROP_OR(CLOCK_NODEID(clk), clock_div, 1) - 1
 
+/* Decode the clock name selector from the encoded `name` cell */
+#define DT_CLOCK_NAME(node_id) \
+	KINETIS_SIM_CLOCK_DECODE_NAME(DT_PHA(node_id, clocks, name))
+
 #define LPUART_CLOCK_SEL(label) \
-	(DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgIrc48MClk \
+	(DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_McgIrc48MClk \
 		 ? SIM_MODULE_CLK_SEL_IRC48M_CLK                                                   \
-	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_Osc0ErClk \
+	 : DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_Osc0ErClk \
 		 ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK                                                 \
-	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgInternalRefClk \
+	 : DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_McgInternalRefClk \
 		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
 		 : SIM_MODULE_CLK_SEL_DISABLED)
 
 #define TPM_CLOCK_SEL(node_id)                                                                     \
-	(DT_PHA(node_id, clocks, name) == kCLOCK_McgIrc48MClk ? SIM_MODULE_CLK_SEL_IRC48M_CLK      \
-	 : DT_PHA(node_id, clocks, name) == kCLOCK_Osc0ErClk  ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK    \
-	 : DT_PHA(node_id, clocks, name) == kCLOCK_McgInternalRefClk                               \
+	(DT_CLOCK_NAME(node_id) == kCLOCK_McgIrc48MClk ? SIM_MODULE_CLK_SEL_IRC48M_CLK      \
+	 : DT_CLOCK_NAME(node_id) == kCLOCK_Osc0ErClk  ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK    \
+	 : DT_CLOCK_NAME(node_id) == kCLOCK_McgInternalRefClk                               \
 		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
 		 : SIM_MODULE_CLK_SEL_DISABLED)
 

--- a/soc/nxp/mcx/mcxc/soc.c
+++ b/soc/nxp/mcx/mcxc/soc.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/arch/cpu.h>
 
 /*******************************************************************************
@@ -29,19 +30,23 @@
 
 #define CLOCK_DIVIDER(clk) DT_PROP_OR(CLOCK_NODEID(clk), clock_div, 1) - 1
 
+/* Decode the clock name selector from the encoded `name` cell */
+#define DT_CLOCK_NAME(node_id) \
+	KINETIS_SIM_CLOCK_DECODE_NAME(DT_PHA(node_id, clocks, name))
+
 #define LPUART_CLOCK_SEL(label) \
-	(DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgIrc48MClk \
+	(DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_McgIrc48MClk \
 		 ? SIM_MODULE_CLK_SEL_IRC48M_CLK                                                   \
-	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_Osc0ErClk \
+	 : DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_Osc0ErClk \
 		 ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK                                                 \
-	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgInternalRefClk \
+	 : DT_CLOCK_NAME(DT_NODELABEL(label)) == kCLOCK_McgInternalRefClk \
 		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
 		 : SIM_MODULE_CLK_SEL_DISABLED)
 
 #define TPM_CLOCK_SEL(node_id)                                                                     \
-	(DT_PHA(node_id, clocks, name) == kCLOCK_McgIrc48MClk ? SIM_MODULE_CLK_SEL_IRC48M_CLK      \
-	 : DT_PHA(node_id, clocks, name) == kCLOCK_Osc0ErClk  ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK    \
-	 : DT_PHA(node_id, clocks, name) == kCLOCK_McgInternalRefClk                               \
+	(DT_CLOCK_NAME(node_id) == kCLOCK_McgIrc48MClk ? SIM_MODULE_CLK_SEL_IRC48M_CLK      \
+	 : DT_CLOCK_NAME(node_id) == kCLOCK_Osc0ErClk  ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK    \
+	 : DT_CLOCK_NAME(node_id) == kCLOCK_McgInternalRefClk                               \
 		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
 		 : SIM_MODULE_CLK_SEL_DISABLED)
 


### PR DESCRIPTION
Historically, Kinetis SIM clock consumers passed only the `name` cell even
though the binding declares `#clock-cells = <3>` (name, offset, bits). The
gate offset and bit were left as DT-explicit cells but often ignored or
incorrect.

This series encodes the gate register offset and bit index into the 32-bit
`id` cell so that the driver can perform clock gating purely from `id`.
The explicit `offset` and `bits` cells are preserved for backward
compatibility with drivers (e.g. ADC16) that read them directly from DT.

Changes:
- dt-bindings: add `KINETIS_SIM_CLOCK()` and `KINETIS_SIM_CLOCK_MUX()`
  macros encoding gate and mux info into the `id` cell.
- drivers: decode `id` via `KINETIS_SIM_CLOCK_DECODE_*()` macros; add
  gate offset validation against the SIM DT region size.
- soc: extract clock name from encoded `id` before comparing against
  `kCLOCK_*` enums.
- dts: convert all Kinetis and MCX devicetrees to the new macros; fix
  ENET gate register and PTP clock source in nxp_k6x.dtsi; fix DMA/DMAMUX
  gate bit index (bitmask→bit-shift) in nxp_k6x.dtsi and nxp_k8x.dtsi.
- dts/bindings: document the encoded `id` cell layout.

The `has_mux/mux_shift/mux_val` fields in `id` are reserved for a future
`clock_control_configure()` implementation for SOPT mux selection.