### PR TITLE
drivers: ethernet: nxp_enet: align initialization priority

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -1063,10 +1063,9 @@ static const struct nxp_enet_mod_config nxp_enet_mod_cfg_##n = {			\
 											\
 static struct nxp_enet_mod_data nxp_enet_mod_data_##n;					\
 											\
-/* Init the module before any of the MAC, MDIO, or PTP clock */				\
 DEVICE_DT_INST_DEFINE(n, nxp_enet_mod_init, NULL,					\
 		&nxp_enet_mod_data_##n, &nxp_enet_mod_cfg_##n,				\
-		POST_KERNEL, 0, NULL);
+		POST_KERNEL, CONFIG_ETH_INIT_PRIORITY, NULL);
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT nxp_enet
@@ -1084,10 +1083,9 @@ static const struct nxp_enet_mod_config nxp_enet1g_mod_cfg_##n = {			\
 											\
 static struct nxp_enet_mod_data nxp_enet1g_mod_data_##n;				\
 											\
-/* Init the module before any of the MAC, MDIO, or PTP clock */				\
 DEVICE_DT_INST_DEFINE(n, nxp_enet_mod_init, NULL,					\
 		&nxp_enet1g_mod_data_##n, &nxp_enet1g_mod_cfg_##n,			\
-		POST_KERNEL, 0, NULL);
+		POST_KERNEL, CONFIG_ETH_INIT_PRIORITY, NULL);
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT nxp_enet1g


### PR DESCRIPTION
drivers: ethernet: nxp_enet: align initialization priority.

eth_nxp_enet uses a separate module initialization, the priority of which was hardcoded to 0. A better approach is to follow the overall Kconfig CONFIG_ETH_INIT_PRIORITY, and it allows to initialize other modules before ethernet.