### PR TITLE
bluetooth: mesh: fix quick(within block sending) dfu suspend resume procedure

### DIFF
--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1248,6 +1248,16 @@ static int handle_xfer_status(const struct bt_mesh_model *mod, struct bt_mesh_ms
 
 	if (cli->state == BT_MESH_BLOB_CLI_STATE_START) {
 		expected_phase = BT_MESH_BLOB_XFER_PHASE_WAITING_FOR_BLOCK;
+		/* If a transfer is resumed quickly (before the server's rx_timeout
+		 * fires), the server is still in WAITING_FOR_CHUNK. The server's
+		 * idempotency logic replies Success without changing its phase.
+		 * Accept WAITING_FOR_CHUNK here so the client can proceed to
+		 * BLOCK_START, which will reset the server's timeout timer.
+		 */
+		if (info.status == BT_MESH_BLOB_SUCCESS &&
+		    info.phase == BT_MESH_BLOB_XFER_PHASE_WAITING_FOR_CHUNK) {
+			expected_phase = info.phase;
+		}
 	} else if (cli->state == BT_MESH_BLOB_CLI_STATE_XFER_CHECK) {
 		expected_phase = BT_MESH_BLOB_XFER_PHASE_COMPLETE;
 	} else if (cli->state != BT_MESH_BLOB_CLI_STATE_XFER_PROGRESS_GET) {

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1611,7 +1611,14 @@ int bt_mesh_blob_cli_resume(struct bt_mesh_blob_cli *cli)
 		return -ENODEV;
 	}
 
-	block_set(cli, 0);
+	/* Resume from the current block, not block 0. If the server hasn't
+	 * timed out yet (still in WAITING_FOR_CHUNK), it will reject a
+	 * BLOCK_START for a different block number with WRONG_PHASE
+	 * (MshMBTv1.0 5.2.2.3). Starting from the same block the client
+	 * was on when it suspended avoids this mismatch. Earlier blocks
+	 * are already completed by all active targets.
+	 */
+	block_set(cli, cli->block.number);
 	return xfer_start(cli);
 }
 


### PR DESCRIPTION
PR fixes customer use case when user sends dfu suspend command over dfd server and immediately (within 2-3 seconds) resumes dfu procedure.
Suspending and resuming happens within block sending on blob server side that faced with indempotency of block start procedure. So blob server replies Success status but continues chunk sending without resetting the block timer (according to specification).
Blob client expects status `Waiting for Block` but gets `Waiting for Chunk` and fails the whole dfu procedure.

PR adds `Waiting for Chunk` as expected status if blob server has been started and really waits for chunk.

Additionally, PR fixes resuming procedure that always resumed with sending the first block.
If blob server was suspended (or quick-suspended-resumed) withing sending other than the first block then client and server have different ongoing block number and blob client drops server with failing whole dfu procedure again.

These two fixes are mandatory to make suspend-resume procedure robust and independent on frequency of command sending by user as well as on the which block is proceeded during it.