### PR TITLE
fs: fuse: Switch to use v3 of libfuse by default

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -682,23 +682,23 @@ crashes, you can cleanup the stale mount point by using the program
    $ fusermount -u flash
 
 You can chose to use the v2 FUSE host library or the v3 with
-:kconfig:option:`CONFIG_FUSE_LIBRARY_VERSION`.
+:kconfig:option:`CONFIG_FUSE_LIBRARY_VERSION`. By default v3 is selected.
 When using the v2, a minimal version of 2.6 is necessary. For v3, 3.0 should suffice.
 You will also need ``pkg-config`` setup to correctly pickup the FUSE install path and compiler flags.
 Note that using this feature with the 32-bit native_sim variant requires the 32-bit version of the
 corresponding FUSE library.
 
-For example, to use the v2 of the library, on a Ubuntu 24.04 host system, install the ``pkg-config``
-and ``libfuse-dev:i386`` for 32-bit builds, and ``libfuse-dev`` for 64-bit builds:
+For example, to use the v3 of the library, on a Ubuntu 24.04 host system, install the ``pkg-config``
+and ``libfuse3-dev:i386`` for 32-bit builds, and ``libfuse3-dev`` for 64-bit builds:
 
 .. code-block:: console
 
    $ sudo dpkg --add-architecture i386
    $ sudo apt update
-   $ sudo apt-get install pkg-config libfuse-dev:i386 libfuse-dev
+   $ sudo apt-get install pkg-config libfuse3-dev:i386 libfuse3-dev
    $ export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
 
-Similarly ``libfuse3-dev:i386`` and ``libfuse3-dev`` provide the 32 and 64-bit FUSE v3 library
+Similarly ``libfuse-dev:i386`` and ``libfuse-dev`` provide the 32 and 64-bit FUSE v2 library
 and headers.
 
 .. _native_sim_peripherals_c_compat:

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -68,6 +68,9 @@ Boards
   * The ``--file-type`` option can now be used without ``--file`` to select between build artifacts
     (hex, elf, bin).
 
+* native_sim: host FUSE access: Defaults to using libfusev3 now instead of v2. But can be chosen
+  with :kconfig:option:`CONFIG_FUSE_LIBRARY_VERSION` (:github:`104965`).
+
 * m5stack_fire: Removed unused pinctrl entries for UART2, and updated the UART1
   pin mapping from GPIO32/GPIO33 to GPIO16/GPIO17 to match the documented Grove
   PORT.C wiring.

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -114,12 +114,12 @@ config FUSE_FS_ACCESS
 choice FUSE_LIBRARY_VERSION
 	prompt "Host FUSE library version"
 	depends on FUSE_FS_ACCESS
-	default FUSE_LIBRARY_V2
+	default FUSE_LIBRARY_V3
 
 config FUSE_LIBRARY_V2
 	bool "Use libfuse(2)"
 	help
-	  Use v2 of the host FUSE library.
+	  Use v2 of the host FUSE library. This may not be available in newer distributions.
 
 config FUSE_LIBRARY_V3
 	bool "Use libfuse3"


### PR DESCRIPTION
Support for using v3 of the FUSE library instead of v2 was added in
b86e52b
As time has been passing more distros are removing v2 support, and at
this point probably all include the v3 in their package repos.

So, let's switch the default to v3.
And let's update the native_sim board docs to guide users to install that version by default.

Related
* https://github.com/zephyrproject-rtos/docker-image/pull/271 (docker image support added in 2025/10)
* https://github.com/zephyrproject-rtos/zephyr/pull/96208

Rendered docs: https://builds.zephyrproject.io/zephyr/pr/104965/docs/boards/native/native_sim/doc/index.html#host-fuse-filesystem-access