### PR TITLE
drivers: uaol: Do not warn on empty library

### DIFF
--- a/drivers/uaol/Kconfig
+++ b/drivers/uaol/Kconfig
@@ -8,7 +8,6 @@
 #
 menuconfig UAOL
 	bool "UAOL drivers"
-	default y
 	help
 	  Enable support for USB Audio Offload Link (UAOL) drivers.
 


### PR DESCRIPTION
Do not enable by default UAOL

Whoever needs it should select it instead.

Library added in:
* b50fcbd6eeebc1151a3aa7341136c3e5ae8b5e79
* https://github.com/zephyrproject-rtos/zephyr/pull/104137