### PR TITLE
dts: arm: silabs: Add clock configuration utility includes

### DIFF
--- a/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
+++ b/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg29/efr32bg29b220f1024cj45.dtsi>
+#include <silabs/xg29/clock-hfrcodpll.dtsi>
+#include <silabs/xg29/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -91,14 +93,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
 &hfxo {
@@ -111,32 +108,6 @@
 	ctune = <32>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
 };
 
 &usart1 {

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -7,6 +7,8 @@
 
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
+#include <silabs/xg21/clock-hfrcodpll.dtsi>
+#include <silabs/xg21/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
@@ -131,10 +133,6 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &hfxo {
 	ctune = <129>;
 	precision = <50>;
@@ -145,36 +143,6 @@
 	ctune = <79>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &adc0 {

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -8,6 +8,8 @@
 
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
+#include <silabs/xg21/clock-hfrcodpll.dtsi>
+#include <silabs/xg21/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
@@ -129,10 +131,6 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &hfxo {
 	ctune = <129>;
 	precision = <50>;
@@ -143,36 +141,6 @@
 	ctune = <79>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &adc0 {

--- a/boards/silabs/radio_boards/xg22/slwrb4182a.dts
+++ b/boards/silabs/radio_boards/xg22/slwrb4182a.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <silabs/xg22/efr32mg22c224f512im40.dtsi>
+#include <silabs/xg22/clock-lfxo.dtsi>
 #include "xg22_radio_board.dtsi"
 
 / {
@@ -81,26 +82,6 @@
 	ctune = <37>;
 	precision = <50>;
 	status = "okay";
-};
-
-&prortcclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
 };
 
 &radio {

--- a/boards/silabs/radio_boards/xg22/xg22_radio_board.dtsi
+++ b/boards/silabs/radio_boards/xg22/xg22_radio_board.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <silabs/xg22/clock-hfrcodpll.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -46,10 +47,6 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &dcdc {
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
@@ -59,17 +56,6 @@
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_K(76800)>;
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
 };
 
 &i2c0 {

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg23/efr32zg23b020f512im48.dtsi>
+#include <silabs/xg23/clock-hfrcodpll.dtsi>
+#include <silabs/xg23/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -118,14 +120,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <78000000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
 &hfxo {
@@ -138,36 +135,6 @@
 	ctune = <38>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_M(78)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&sysrtcclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &eusart0 {

--- a/boards/silabs/radio_boards/xg24/xg24_rb418xc.dtsi
+++ b/boards/silabs/radio_boards/xg24/xg24_rb418xc.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <silabs/xg24/clock-hfrcodpll.dtsi>
+#include <silabs/xg24/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -106,14 +108,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <78000000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
 &hfxo {
@@ -126,36 +123,6 @@
 	ctune = <44>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_M(78)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&sysrtcclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &usart0 {

--- a/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
+++ b/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <silabs/xg24/clock-hfrcodpll.dtsi>
+#include <silabs/xg24/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -101,50 +103,15 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <78000000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
 &lfxo {
 	ctune = <44>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_M(78)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&sysrtcclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &usart0 {

--- a/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
+++ b/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <silabs/xg26/clock-hfrcodpll.dtsi>
+#include <silabs/xg26/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -141,14 +143,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <DT_FREQ_M(78)>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
 &hfxo {
@@ -161,36 +158,6 @@
 	ctune = <63>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_M(78)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&sysrtcclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &usart0 {

--- a/boards/silabs/radio_boards/xg27/bg27_rb411xb.dtsi
+++ b/boards/silabs/radio_boards/xg27/bg27_rb411xb.dtsi
@@ -5,6 +5,8 @@
  */
 
 #include <silabs/xg27/efr32bg27c320f768gj39.dtsi>
+#include <silabs/xg27/clock-hfrcodpll.dtsi>
+#include <silabs/xg27/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -86,14 +88,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
 &hfxo {
@@ -106,32 +103,6 @@
 	ctune = <63>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
 };
 
 &usart1 {

--- a/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
+++ b/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg27/efr32mg27c140f768im40.dtsi>
+#include <silabs/xg27/clock-hfrcodpll.dtsi>
+#include <silabs/xg27/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -137,14 +139,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
 &hfxo {
@@ -157,32 +154,6 @@
 	ctune = <37>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
 };
 
 &usart1 {

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg28/efr32zg28b322f1024im68.dtsi>
+#include <silabs/xg28/clock-hfrcodpll.dtsi>
+#include <silabs/xg28/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -112,23 +114,11 @@
 	status = "okay";
 };
 
-&cpu0 {
-	clock-frequency = <78000000>;
-};
-
 &dcdc {
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
 	silabs,pfmx-peak-current-milliamp = <100>;
 	status = "okay";
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
 };
 
 &eusart1 {
@@ -209,16 +199,6 @@
 	status = "okay";
 };
 
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_M(78)>;
-	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-autorecover;
-};
-
 &hfxo {
 	ctune = <115>;
 	precision = <50>;
@@ -239,10 +219,6 @@
 	status = "okay";
 };
 
-&sysrtcclk {
-	clocks = <&lfxo>;
-};
-
 &timer0 {
 	status = "okay";
 
@@ -255,14 +231,6 @@
 
 &wdog0 {
 	status = "okay";
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
-};
-
-&wdog1clk {
-	clocks = <&lfxo>;
 };
 
 &flash0 {

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg29/efr32mg29b140f1024im40.dtsi>
+#include <silabs/xg29/clock-hfrcodpll.dtsi>
+#include <silabs/xg29/clock-lfxo.dtsi>
 #include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -137,14 +139,9 @@
 	};
 };
 
-&cpu0 {
-	clock-frequency = <76800000>;
-};
-
 &itm {
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
-	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
 &hfxo {
@@ -157,32 +154,6 @@
 	ctune = <63>;
 	precision = <50>;
 	status = "okay";
-};
-
-&hfrcodpll {
-	clock-frequency = <DT_FREQ_K(76800)>;
-	clocks = <&hfxo>;
-	dpll-autorecover;
-	dpll-edge = "fall";
-	dpll-lock = "phase";
-	dpll-m = <1919>;
-	dpll-n = <3839>;
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
-};
-
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
 };
 
 &usart1 {

--- a/dts/arm/silabs/xg21/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg21/clock-hfrcodpll.dtsi
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(76800)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_K(76800)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg21/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg21/clock-hfxo.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(38400)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(38400)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg21/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg21/clock-lfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&prortcclk {
+	clocks = <&lfxo>;
+};
+
+&rtccclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};
+
+&wdog1clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -6,20 +6,13 @@
 
 #include <mem.h>
 #include <silabs/xg22/bgm22.dtsi>
+#include <silabs/xg22/clock-lfxo.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,bgm220pc22hna", "silabs,bgm22", "silabs,xg22", "silabs,efr32",
 			     "simple-bus";
 	};
-};
-
-&em23grpaclk {
-	clocks = <&lfxo>;
-};
-
-&em4grpaclk {
-	clocks = <&lfxo>;
 };
 
 &flash0 {
@@ -55,10 +48,6 @@
 	status = "okay";
 };
 
-&prortcclk {
-	clocks = <&lfxo>;
-};
-
 &radio {
 	ble-2mbps-supported;
 	ble-coded-phy-supported;
@@ -67,14 +56,6 @@
 	pa-voltage-mv = <1800>;
 };
 
-&rtccclk {
-	clocks = <&lfxo>;
-};
-
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
-};
-
-&wdog0clk {
-	clocks = <&lfxo>;
 };

--- a/dts/arm/silabs/xg22/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg22/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(76800)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpbclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_K(76800)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg22/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg22/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(38400)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpbclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(38400)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg22/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg22/clock-lfxo.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&prortcclk {
+	clocks = <&lfxo>;
+};
+
+&rtccclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg23/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg23/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(78)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpcclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_M(78)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(78)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg23/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg23/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(39)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpcclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(39)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg23/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg23/clock-lfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lcdclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&sysrtcclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};
+
+&wdog1clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg24/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg24/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(78)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpcclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_M(78)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(78)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg24/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg24/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(39)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpcclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(39)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg24/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg24/clock-lfxo.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&sysrtcclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};
+
+&wdog1clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg26/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg26/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(78)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpcclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_M(78)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(78)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg26/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg26/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(39)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpcclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(39)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg26/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg26/clock-lfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lcdclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&sysrtcclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};
+
+&wdog1clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg27/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg27/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(76800)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpbclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_K(76800)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg27/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg27/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(38400)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpbclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(38400)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg27/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg27/clock-lfxo.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&prortcclk {
+	clocks = <&lfxo>;
+};
+
+&rtccclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg28/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg28/clock-hfrcodpll.dtsi
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(78)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpcclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_M(78)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(78)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg28/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg28/clock-hfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(39)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpcclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_M(39)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg28/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg28/clock-lfxo.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lcdclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&sysrtcclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};
+
+&wdog1clk {
+	clocks = <&lfxo>;
+};

--- a/dts/arm/silabs/xg29/clock-hfrcodpll.dtsi
+++ b/dts/arm/silabs/xg29/clock-hfrcodpll.dtsi
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(76800)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpbclk {
+	clocks = <&hfrcodpll>;
+};
+
+&em01grpcclk {
+	clocks = <&hfrcodpll>;
+};
+
+&hfrcodpll {
+	clock-frequency = <DT_FREQ_K(76800)>;
+	clocks = <&hfxo>;
+	dpll-autorecover;
+	dpll-edge = "fall";
+	dpll-lock = "phase";
+	dpll-m = <1919>;
+	dpll-n = <3839>;
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&sysclk {
+	clocks = <&hfrcodpll>;
+};

--- a/dts/arm/silabs/xg29/clock-hfxo.dtsi
+++ b/dts/arm/silabs/xg29/clock-hfxo.dtsi
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_K(38400)>;
+};
+
+&em01grpaclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpbclk {
+	clocks = <&hfxo>;
+};
+
+&em01grpcclk {
+	clocks = <&hfxo>;
+};
+
+&hfrcodpll {
+	status = "disabled";
+};
+
+&hfxo {
+	status = "okay";
+};
+
+&itm {
+	swo-ref-frequency = <DT_FREQ_K(38400)>;
+};
+
+&sysclk {
+	clocks = <&hfxo>;
+};

--- a/dts/arm/silabs/xg29/clock-lfxo.dtsi
+++ b/dts/arm/silabs/xg29/clock-lfxo.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&em23grpaclk {
+	clocks = <&lfxo>;
+};
+
+&em4grpaclk {
+	clocks = <&lfxo>;
+};
+
+&lfxo {
+	status = "okay";
+};
+
+&prortcclk {
+	clocks = <&lfxo>;
+};
+
+&rtccclk {
+	clocks = <&lfxo>;
+};
+
+&wdog0clk {
+	clocks = <&lfxo>;
+};


### PR DESCRIPTION
Add devicetree include files for each clock source to configure the devicetree to use that source. This simplifies clock configuration to including the correct header, rather than manually modifying every mux to select the given source.

Include clock config headers instead of manually configuring the clock muxes for every Series 2 radio board.
