### PR TITLE
Bluetooth: TBS: replace GTBS/TBS instance locks with global lock

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -97,8 +97,9 @@ struct tbs_inst {
 
 	bool authorization_required;
 
-	struct k_mutex mutex;
-	/* Flags for each client. Access and modification of these shall be guarded by the mutex */
+	/* Flags for each client. Access and modification of these shall be guarded
+	 * by the global tbs_mutex
+	 */
 	struct tbs_flags flags[CONFIG_BT_MAX_CONN];
 
 	/* Control point notifications are handled separately from other notifications - We will not
@@ -116,6 +117,8 @@ struct tbs_inst {
 
 static struct tbs_inst svc_insts[CONFIG_BT_TBS_BEARER_COUNT];
 static struct tbs_inst gtbs_inst;
+static K_MUTEX_DEFINE(tbs_mutex);
+
 static bool try_change_dialing_call_to_alerting(struct tbs_inst *inst);
 
 #define READ_BUF_SIZE                                                                             \
@@ -362,33 +365,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	const uint8_t conn_index = bt_conn_index(conn);
 	int err;
 
-	/* Clear pending TBS notifications */
-	for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
-		err = k_mutex_lock(&svc_insts[i].mutex, MUTEX_TIMEOUT);
-		if (err != 0) {
-			LOG_WRN("Failed to take mutex: %d", err);
-			/* In this case we still need to clear the data, so continue and hope for
-			 * the best
-			 */
-		}
-
-		if (svc_insts[i].cp_ntf.pending && conn_index == svc_insts[i].cp_ntf.conn_index) {
-			(void)memset(&svc_insts[i].cp_ntf, 0, sizeof(svc_insts[i].cp_ntf));
-		}
-
-		(void)memset(&svc_insts[i].flags[conn_index], 0,
-			     sizeof(svc_insts[i].flags[conn_index]));
-
-		if (err == 0) { /* if mutex was locked */
-			/* Try to promote after clearing flags */
-			(void)try_change_dialing_call_to_alerting(&svc_insts[i]);
-			err = k_mutex_unlock(&svc_insts[i].mutex);
-			__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
-		}
-	}
-
-	/* Clear pending GTBS notifications */
-	err = k_mutex_lock(&gtbs_inst.mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_WRN("Failed to take mutex: %d", err);
 		/* In this case we still need to clear the data, so continue and hope for
@@ -396,6 +373,22 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		 */
 	}
 
+	/* Clear pending notifications */
+	for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
+		if (svc_insts[i].cp_ntf.pending && conn_index == svc_insts[i].cp_ntf.conn_index) {
+			(void)memset(&svc_insts[i].cp_ntf, 0, sizeof(svc_insts[i].cp_ntf));
+		}
+
+		(void)memset(&svc_insts[i].flags[conn_index], 0,
+			     sizeof(svc_insts[i].flags[conn_index]));
+
+		/* Try to promote after clearing flags */
+		if (err == 0) { /* if mutex was locked */
+			(void)try_change_dialing_call_to_alerting(&svc_insts[i]);
+		}
+	}
+
+	/* Clear pending GTBS notifications */
 	if (gtbs_inst.cp_ntf.pending && conn_index == gtbs_inst.cp_ntf.conn_index) {
 		(void)memset(&gtbs_inst.cp_ntf, 0, sizeof(gtbs_inst.cp_ntf));
 	}
@@ -404,7 +397,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	if (err == 0) { /* if mutex was locked */
 		(void)try_change_dialing_call_to_alerting(&gtbs_inst);
-		err = k_mutex_unlock(&gtbs_inst.mutex);
+		err = k_mutex_unlock(&tbs_mutex);
 		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 	}
 }
@@ -956,7 +949,7 @@ static bool promote_dialing_call_to_alerting(struct tbs_inst *inst)
  * @retval false No promotion occurred.
  */
 
- /* Caller must lock inst->mutex before calling this function */
+ /* Caller must lock tbs_mutex before calling this function */
 static bool try_change_dialing_call_to_alerting(struct tbs_inst *inst)
 {
 	bool promoted = false;
@@ -1004,6 +997,7 @@ static void notify_handler_cb(struct bt_conn *conn, void *data)
 	struct tbs_flags *flags = &inst->flags[bt_conn_index(conn)];
 	struct bt_conn_info info;
 	int err;
+	bool locked = false;
 
 	err = bt_conn_get_info(conn, &info);
 	__ASSERT(err == 0, "Failed to get conn info: %d", err);
@@ -1017,11 +1011,13 @@ static void notify_handler_cb(struct bt_conn *conn, void *data)
 		notify_handler_cb(conn, &gtbs_inst);
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to take mutex: %d", err);
 		goto reschedule;
 	}
+
+	locked = true;
 
 	if (flags->bearer_provider_name_changed) {
 		LOG_DBG("Notifying Bearer Provider Name: %s", inst->provider_name);
@@ -1202,8 +1198,10 @@ reschedule:
 		__ASSERT(err >= 0, "Failed to reschedule work: %d", err);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
-	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
+	if (locked) {
+		err = k_mutex_unlock(&tbs_mutex);
+		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
+	}
 }
 
 static void notify_work_handler(struct k_work *work)
@@ -1222,7 +1220,7 @@ static ssize_t read_provider_name(struct bt_conn *conn, const struct bt_gatt_att
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -1240,7 +1238,7 @@ static ssize_t read_provider_name(struct bt_conn *conn, const struct bt_gatt_att
 					strlen(inst->provider_name));
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -1251,13 +1249,13 @@ static void cfg_changed_clear_pending(struct tbs_inst *inst, uint16_t value,
 				      const struct bt_uuid *uuid)
 {
 	if (value == 0U) {
-		int err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+		int err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex");
 		} else {
 			set_value_changed(inst, value_cb, uuid);
-			err = k_mutex_unlock(&inst->mutex);
+			err = k_mutex_unlock(&tbs_mutex);
 			__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 		}
 	}
@@ -1316,7 +1314,7 @@ static ssize_t read_uri_scheme_list(struct bt_conn *conn, const struct bt_gatt_a
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -1332,7 +1330,7 @@ static ssize_t read_uri_scheme_list(struct bt_conn *conn, const struct bt_gatt_a
 		ret = bt_gatt_attr_read(conn, attr, buf, len, offset, read_buf.data, read_buf.len);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -1426,7 +1424,7 @@ static void current_calls_cfg_changed(const struct bt_gatt_attr *attr, uint16_t 
 	LOG_DBG("Index %u: value 0x%04x", inst_index(inst), value);
 
 	if (value == 0U) {
-		int err = k_mutex_lock(&inst->mutex, K_FOREVER);
+		int err = k_mutex_lock(&tbs_mutex, K_FOREVER);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex: %d", err);
@@ -1439,7 +1437,7 @@ static void current_calls_cfg_changed(const struct bt_gatt_attr *attr, uint16_t 
 		set_value_changed(inst, set_list_current_calls_changed_cb,
 				  BT_UUID_TBS_LIST_CURRENT_CALLS);
 
-		err = k_mutex_unlock(&inst->mutex);
+		err = k_mutex_unlock(&tbs_mutex);
 		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 	}
 }
@@ -1452,7 +1450,7 @@ static ssize_t read_current_calls(struct bt_conn *conn, const struct bt_gatt_att
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -1475,7 +1473,7 @@ static ssize_t read_current_calls(struct bt_conn *conn, const struct bt_gatt_att
 		ret = bt_gatt_attr_read(conn, attr, buf, len, offset, read_buf.data, read_buf.len);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -1523,7 +1521,7 @@ static ssize_t read_incoming_uri(struct bt_conn *conn, const struct bt_gatt_attr
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -1554,7 +1552,7 @@ static ssize_t read_incoming_uri(struct bt_conn *conn, const struct bt_gatt_attr
 		}
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -1581,7 +1579,7 @@ static ssize_t read_call_state(struct bt_conn *conn, const struct bt_gatt_attr *
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -1604,7 +1602,7 @@ static ssize_t read_call_state(struct bt_conn *conn, const struct bt_gatt_attr *
 		ret = bt_gatt_attr_read(conn, attr, buf, len, offset, read_buf.data, read_buf.len);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -1621,7 +1619,7 @@ static void call_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t val
 	LOG_DBG("Index %u: value 0x%04x", inst_index(inst), value);
 
 	if (value == 0U) {
-		int err = k_mutex_lock(&inst->mutex, K_FOREVER);
+		int err = k_mutex_lock(&tbs_mutex, K_FOREVER);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex: %d", err);
@@ -1633,7 +1631,7 @@ static void call_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t val
 		/* Clear any pending notifications for any connections that unsubscribe */
 		set_value_changed(inst, set_call_state_changed_cb, BT_UUID_TBS_CALL_STATE);
 
-		err = k_mutex_unlock(&inst->mutex);
+		err = k_mutex_unlock(&tbs_mutex);
 		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 	}
 }
@@ -1984,14 +1982,14 @@ static ssize_t write_call_cp(struct bt_conn *conn, const struct bt_gatt_attr *at
 	LOG_DBG("Index %u: Processing the %s opcode", inst_index(inst),
 		bt_tbs_opcode_str(ccp->opcode));
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
 	}
 
 	if (inst->cp_ntf.pending) {
-		err = k_mutex_unlock(&inst->mutex);
+		err = k_mutex_unlock(&tbs_mutex);
 		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 		return BT_GATT_ERR(BT_TBS_RESULT_CODE_OPERATION_NOT_POSSIBLE);
@@ -2140,7 +2138,7 @@ static ssize_t write_call_cp(struct bt_conn *conn, const struct bt_gatt_attr *at
 		__ASSERT(err >= 0, "Failed to schedule work: %d", err);
 	} /* else local operation; don't notify */
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	if (calls_changed) {
@@ -2188,7 +2186,7 @@ static void call_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 
 	/* Clear the pending notification only when its owning connection unsubscribes */
 	if (value == 0U) {
-		int err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+		int err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex");
@@ -2197,7 +2195,7 @@ static void call_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 				inst->cp_ntf.pending = false;
 			}
 
-			err = k_mutex_unlock(&inst->mutex);
+			err = k_mutex_unlock(&tbs_mutex);
 			__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 		}
 	}
@@ -2237,7 +2235,7 @@ static ssize_t read_friendly_name(struct bt_conn *conn, const struct bt_gatt_att
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2266,7 +2264,7 @@ static ssize_t read_friendly_name(struct bt_conn *conn, const struct bt_gatt_att
 		}
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2292,7 +2290,7 @@ static ssize_t read_incoming_call(struct bt_conn *conn, const struct bt_gatt_att
 	ssize_t ret;
 	int err;
 
-	err = k_mutex_lock(&inst->mutex, MUTEX_TIMEOUT);
+	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2321,7 +2319,7 @@ static ssize_t read_incoming_call(struct bt_conn *conn, const struct bt_gatt_att
 		}
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2488,9 +2486,6 @@ static int tbs_inst_init_and_register(struct tbs_inst *inst, struct bt_gatt_serv
 
 	k_work_init_delayable(&inst->reporting_interval_work, signal_interval_timeout);
 	k_work_init_delayable(&inst->notify_work, notify_work_handler);
-
-	ret = k_mutex_init(&inst->mutex);
-	__ASSERT(ret == 0, "Failed to initialize mutex");
 
 	ret = bt_gatt_service_register(svc);
 	if (ret != 0) {
@@ -2701,7 +2696,7 @@ int bt_tbs_accept(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2712,7 +2707,7 @@ int bt_tbs_accept(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2733,7 +2728,7 @@ int bt_tbs_hold(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2744,7 +2739,7 @@ int bt_tbs_hold(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2765,7 +2760,7 @@ int bt_tbs_retrieve(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2776,7 +2771,7 @@ int bt_tbs_retrieve(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2797,7 +2792,7 @@ int bt_tbs_terminate(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2808,7 +2803,7 @@ int bt_tbs_terminate(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2854,7 +2849,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri, uint8_t *call_index
 		target_inst = inst;
 	}
 
-	err = k_mutex_lock(&target_inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2870,7 +2865,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri, uint8_t *call_index
 	 */
 	(void)try_change_dialing_call_to_alerting(target_inst);
 
-	err = k_mutex_unlock(&target_inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2901,7 +2896,7 @@ int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2915,7 +2910,7 @@ int bt_tbs_join(uint8_t call_index_cnt, uint8_t *call_indexes)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2933,7 +2928,7 @@ int bt_tbs_remote_answer(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2952,7 +2947,7 @@ int bt_tbs_remote_answer(uint8_t call_index)
 		ret = BT_TBS_RESULT_CODE_STATE_MISMATCH;
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -2974,7 +2969,7 @@ int bt_tbs_remote_hold(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -2994,7 +2989,7 @@ int bt_tbs_remote_hold(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -3016,7 +3011,7 @@ int bt_tbs_remote_retrieve(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3035,7 +3030,7 @@ int bt_tbs_remote_retrieve(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -3056,7 +3051,7 @@ int bt_tbs_remote_terminate(uint8_t call_index)
 		return BT_TBS_RESULT_CODE_INVALID_CALL_INDEX;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3067,7 +3062,7 @@ int bt_tbs_remote_terminate(uint8_t call_index)
 		notify_calls(inst);
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;
@@ -3122,7 +3117,7 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to, const char *fro
 		return -ENOMEM;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3141,7 +3136,7 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to, const char *fro
 
 	notify_calls(inst);
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	LOG_DBG("New call with call index %u", call->index);
@@ -3165,7 +3160,7 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name)
 		return 0;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3175,7 +3170,7 @@ int bt_tbs_set_bearer_provider_name(uint8_t bearer_index, const char *name)
 
 	set_value_changed(inst, set_bearer_provider_name_changed_cb, BT_UUID_TBS_PROVIDER_NAME);
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return 0;
@@ -3196,7 +3191,7 @@ int bt_tbs_set_bearer_technology(uint8_t bearer_index, uint8_t new_technology)
 		return 0;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3206,7 +3201,7 @@ int bt_tbs_set_bearer_technology(uint8_t bearer_index, uint8_t new_technology)
 
 	set_value_changed(inst, set_bearer_technology_changed_cb, BT_UUID_TBS_TECHNOLOGY);
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return 0;
@@ -3256,7 +3251,7 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags)
 		return 0;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3266,7 +3261,7 @@ int bt_tbs_set_status_flags(uint8_t bearer_index, uint16_t status_flags)
 
 	set_value_changed(inst, set_status_flags_changed_cb, BT_UUID_TBS_STATUS_FLAGS);
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return 0;
@@ -3297,7 +3292,7 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char *uri_scheme_list
 		return -ENOMEM;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	err = k_mutex_lock(&tbs_mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
@@ -3329,7 +3324,7 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char *uri_scheme_list
 		}
 	}
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&tbs_mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return 0;


### PR DESCRIPTION
Remove separate instance locks and replace all locking and unlocking with a single global lock.

Fixes #104571
Fixes #104655