### PR TITLE
tests: watchdog: Fix filter condition - check alias state

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -17,7 +17,7 @@ common:
 tests:
   sample.drivers.watchdog:
     filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103) and
-      dt_nodelabel_enabled("watchdog0")
+      dt_alias_enabled("watchdog0")
     platform_exclude:
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -12,7 +12,7 @@ tests:
        or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
        CONFIG_SOC_SERIES_IMXRT6XX or CONFIG_SOC_SERIES_IMXRT5XX or
        CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103 or CONFIG_SOC_MAX32655)
-       and dt_nodelabel_enabled("watchdog0")
+       and dt_alias_enabled("watchdog0")
     platform_exclude:
       - mec15xxevb_assy6853
       - s32z2xxdc2/s32z270/rtu0


### PR DESCRIPTION
These commits extend sample.yaml/testcase.yaml filter with `dt_nodelabel_enabled("watchdog0")` condition.
https://github.com/zephyrproject-rtos/zephyr/commit/3d9711181cdf519957b76b4cbfae2d0b5e80f3ce https://github.com/zephyrproject-rtos/zephyr/commit/3a0cad96da55e9f8255fb444b71b28eef57a543d

However, "watchdog0" is defined as an aliast to watchdog device, not as a label.

Switch to use `dt_alias_enabled("watchdog0")` instead.