### PR TITLE
Bluetooth: host: fix unaligned structure member access warnings

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3490,8 +3490,10 @@ struct bt_hci_evt_le_remote_feat_complete {
 #define BT_HCI_EVT_LE_LTK_REQUEST               0x05
 struct bt_hci_evt_le_ltk_request {
 	uint16_t handle;
-	uint64_t rand;
-	uint16_t ediv;
+	/** 64-bit random number used to identify the LTK. */
+	uint8_t  rand[8];
+	/** 16-bit encrypted diversifier used to identify the LTK. */
+	uint8_t  ediv[2];
 } __packed;
 
 #define BT_HCI_EVT_LE_CONN_PARAM_REQ            0x06

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -1358,8 +1358,10 @@ struct bt_hci_rp_le_rand {
 #define BT_HCI_OP_LE_START_ENCRYPTION           BT_OP(BT_OGF_LE, 0x0019) /* 0x2019 */
 struct bt_hci_cp_le_start_encryption {
 	uint16_t handle;
-	uint64_t rand;
-	uint16_t ediv;
+	/** 64-bit random number for LTK identification. */
+	uint8_t  rand[8];
+	/** 16-bit encrypted diversifier for LTK identification. */
+	uint8_t  ediv[2];
 	uint8_t  ltk[16];
 } __packed;
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2506,8 +2506,8 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],
 
 	cp = net_buf_add(buf, sizeof(*cp));
 	cp->handle = sys_cpu_to_le16(conn->handle);
-	memcpy(&cp->rand, rand, sizeof(cp->rand));
-	memcpy(&cp->ediv, ediv, sizeof(cp->ediv));
+	(void)memcpy(cp->rand, rand, sizeof(cp->rand));
+	(void)memcpy(cp->ediv, ediv, sizeof(cp->ediv));
 
 	memcpy(cp->ltk, ltk, len);
 	if (len < sizeof(cp->ltk)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2499,6 +2499,8 @@ static void le_ltk_request(struct net_buf *buf)
 	struct bt_conn *conn;
 	uint16_t handle;
 	uint8_t ltk[16];
+	uint64_t rand_value;
+	uint16_t ediv;
 
 	handle = sys_le16_to_cpu(evt->handle);
 
@@ -2510,7 +2512,10 @@ static void le_ltk_request(struct net_buf *buf)
 		return;
 	}
 
-	if (bt_smp_request_ltk(conn, evt->rand, evt->ediv, ltk)) {
+	(void)memcpy(&rand_value, evt->rand, sizeof(rand_value));
+	(void)memcpy(&ediv, evt->ediv, sizeof(ediv));
+
+	if (bt_smp_request_ltk(conn, rand_value, ediv, ltk)) {
 		le_ltk_reply(handle, ltk);
 	} else {
 		le_ltk_neg_reply(handle);


### PR DESCRIPTION
##### Bluetooth: host: fix unaligned structure member access warnings

The HCI LE Start Encryption command parameters for `rand` and `ediv` should be byte arrays, not integer types, to match the HCI specification and avoid unaligned structure member access warnings.

- Change `rand` from uint64_t to uint8_t[8]
- Change `ediv` from uint16_t to uint8_t[2]
- Update memcpy calls to remove unnecessary address-of operators

##### Bluetooth: host: fix unaligned access in LE LTK request event

The HCI LE LTK Request event parameters for `rand` and `ediv` should be byte arrays, not integer types, to match the HCI specification and avoid unaligned structure member access.

- Change `rand` from uint64_t to uint8_t[8]
- Change `ediv` from uint16_t to uint8_t[2]
- Add local variables in le_ltk_request() to convert byte arrays to integer types before passing to bt_smp_request_ltk()
