### PR TITLE
riscv: optimize floating-point exception decoding

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -695,6 +695,18 @@ config RISCV_M_MODE_STACK_SIZE
 	  runtime handler. Increase this if the handler is extended with
 	  functionality that requires more stack space.
 
+config RISCV_FPU_INSN_VALIDATE
+	bool
+	depends on FPU_SHARING
+	depends on ASSERT
+	default y
+	help
+	  Derived debug-only symbol. When enabled, the FPU trap handler will
+	  explicitly decode the trapping instruction to ensure it is a valid
+	  floating-point instruction. This catches edge cases where non-FPU
+	  instructions (like Vector instructions) might accidentally trigger
+	  an FP trap.
+
 rsource "Kconfig.isa"
 
 rsource "custom/Kconfig"

--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -186,6 +186,78 @@ void z_riscv_fpu_enter_exc(void)
 	z_riscv_fpu_disable();
 }
 
+#ifdef CONFIG_RISCV_FPU_INSN_VALIDATE
+/*
+ * Rigorous FP instruction validation used only during debug/assertion builds.
+ * It ensures the fast-path assembly hasn't accidentally trapped a non-FP
+ * instruction (like a Vector instruction) into the FPU context switch.
+ */
+static inline int debug_is_fp_insn(uint32_t instruction)
+{
+	/* 1. Check for Compressed (16-bit) Instructions */
+	if ((instruction & 0x3) != 0x3) {
+#ifdef CONFIG_RISCV_ISA_EXT_C
+		/* RVC Quadrants 00 and 10 are the only ones with FP loads/stores */
+		if ((instruction & 0x1) != 0) {
+			return 0;
+		}
+
+		uint32_t op = (instruction >> 13) & 0x7;
+#ifdef CONFIG_64BIT
+		/* valid FP instructions */
+		/* 00: C.FLD (001) C.FSD (101) */
+		/* 10: C.FLDSP (001) C.FSDSP (101) */
+		return (op & 3) == 0b01;
+#else
+		/* valid FP instructions */
+		/* 00: C.FLD (001) C.FSD (101)
+		 * C.FLW (011) C.FSW (111)
+		 */
+		/* 10: C.FLDSP (001) C.FSDSP (101)
+		 * C.FLWSP (011) C.FSWSP (111)
+		 */
+		return (op & 1) == 1;
+#endif
+#else
+		return 0;
+#endif
+	}
+
+	/* 2. Check Standard 32-bit Instructions */
+	uint32_t opcode = instruction & 0x7F;
+
+	switch (opcode) {
+	case 0b0000111: /* LOAD-FP */
+	case 0b0100111: /* STORE-FP */
+	{
+		/* Valid FP widths:
+		 * Half (1), Single (2), Double (3), Quad (4)
+		 */
+		uint32_t funct3 = (instruction >> 12) & 7;
+
+		return (funct3 >= 1 && funct3 <= 4);
+	}
+	case 0b1000011: /* FMADD */
+	case 0b1000111: /* FMSUB */
+	case 0b1001011: /* FNMSUB */
+	case 0b1001111: /* FNMADD */
+	case 0b1010011: /* FP-OP */
+		return 1;
+
+	case 0b1110011: /* SYSTEM (CSR accesses) */
+	{
+		/* Accessing fflags (1), frm (2), or fcsr (3) traps if FPU is off */
+		uint32_t funct3 = (instruction >> 12) & 0x7;
+		uint32_t csr = instruction >> 20;
+
+		return ((funct3 & 3) != 0) && (csr >= 1 && csr <= 3);
+	}
+	default:
+		return 0;
+	}
+}
+#endif
+
 /*
  * Process the FPU trap.
  *
@@ -208,6 +280,34 @@ void z_riscv_fpu_trap(struct arch_esf *esf)
 	__ASSERT((esf->mstatus & MSTATUS_FS) == 0 &&
 		 (z_riscv_status_read() & MSTATUS_FS) == 0,
 		 "called despite FPU being accessible");
+
+#ifdef CONFIG_RISCV_FPU_INSN_VALIDATE
+	/* Safely fetch instruction to avoid unaligned access faults */
+#ifdef CONFIG_RISCV_NO_MTVAL_ON_FP_TRAP
+	uint32_t instruction = *(uint16_t *)(esf->mepc);
+
+	if ((instruction & 3) == 3) {
+		/* It's a 32-bit instruction, fetch the upper 16 bits */
+		instruction |= ((uint32_t)*(uint16_t *)(esf->mepc + 2)) << 16;
+	}
+#else
+#ifdef CONFIG_RISCV_S_MODE
+	uint32_t instruction = csr_read(stval);
+#else
+	uint32_t instruction = csr_read(mtval);
+#endif
+#endif
+
+	/* Force a fatal error if the trap was triggered by a non-FPU instruction */
+	if (!debug_is_fp_insn(instruction)) {
+		__ASSERT(false,
+			 "Fatal Error: Non-FPU instruction (0x%08x) incorrectly routed to FPU trap "
+			 "handler.\n",
+			 instruction);
+
+		CODE_UNREACHABLE;
+	}
+#endif
 
 	/* save current owner's content  if any */
 	arch_flush_local_fpu();

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -286,25 +286,78 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	lw t2, 0(t0)		/* t0 = RV_EPC */
 1:
 #endif
-	andi t0, t2, 0x7f	/* keep only the opcode bits */
-	/*
+	/* RISC-V base floating-point opcodes are 7 bits long. We map them
+	 * into a 32-bit O(1) lookup table by shifting the opcode right by 2.
+	 *
+	 * Opcodes and their resulting lookup bit indices:
 	 * Major FP opcodes:
-	 * 0000111 = LOAD-FP
-	 * 0100111 = STORE-FP
-	 * 1000011 = MADD
-	 * 1000111 = MSUB
-	 * 1001011 = NMSUB
-	 * 1001111 = NMADD
-	 * 1010011 = OP-FP
+	 * 0000111 = LOAD-FP  >> 2 -> 1
+	 * 0100111 = STORE-FP >> 2 -> 9
+	 * 1000011 = MADD     >> 2 -> 16
+	 * 1000111 = MSUB     >> 2 -> 17
+	 * 1001011 = NMSUB    >> 2 -> 18
+	 * 1001111 = NMADD    >> 2 -> 19
+	 * 1010011 = OP-FP    >> 2 -> 20
+	 *
+	 * Combined Bitmask: 0x001F0202
+	 *
+	 * When funct3 is not 1, 2, 3 or 4, 0*00111 is not floating point
+	 * Combined Bitmask in this case: 0x001F0202
 	 */
-	xori t1, t0, 0b1010011	/* OP-FP */
-	beqz t1, is_fp
-	ori  t1, t0, 0b0100000
-	xori t1, t1, 0b0100111	/* LOAD-FP / STORE-FP */
-	beqz t1, is_fp
-	ori  t1, t0, 0b0001100
-	xori t1, t1, 0b1001111	/* MADD / MSUB / NMSUB / NMADD */
-	beqz t1, is_fp
+	/* 1. Preparing the Bitmask (Done first for efficient register usage) */
+	/* Lower 12 bit masks should be 0 for vector instructions */
+	li t0, 0x3c3c
+	srli t1, t2, 12
+	andi t1, t1, 7
+	srl t0, t0, t1
+	andi t0, t0, 0x202 /* 0 for vector instructions with opcode 0b0*00111 */
+	li   t1, 0x001F0000 /* Load the pre-calculated O(1) upper 20 bits of FP opcode bitmask */
+	or t1, t1, t0       /* Final bitmask which accounts for vector instructions */
+
+	/* 2. Preparing t2 for lookup index and 32-bit instruction validation */
+	/*
+	 * Rotation shifting by 2 of t2 to move upper 5 bits of opcode to the lowest 5
+	 * significant bits for opcode indexing. Preserving 2 bits in t2 to avoid
+	 * using another register.
+	 */
+	slli t0, t2, 30 /* saving the lowest 2 bits in t0 */
+	/* Making space for lower two bits of instruction in upper two bits of t2 */
+#if defined(CONFIG_64BIT)
+	srliw t2, t2, 2
+#else
+	srli t2, t2, 2
+#endif
+	or t2, t2, t0 /* In 64-bit systems the whole instruction can be found in [61:30] of t2 */
+
+	/* 3. Validate the instruction is a standard 32-bit instruction (ends in 11) */
+	/* lower 2 bits are in the MSB now */
+#if defined(CONFIG_64BIT)
+	sraiw t0, t2, 30
+#else
+	srai t0, t2, 30
+#endif
+	/* t0 = -1 only if t2[31:30] = 0b11 */
+	sltiu t0, t0, -1 /* t0 = 0 only if t0 = -1 */
+	xori t0, t0, 1 /* Boolean flag: t0 = 1 if valid 32-bit, 0 if invalid */
+
+	/* 4. Perform the O(1) branchless lookup */
+	/* Shift validity flag by index: t0 = (1 << index).
+	* If invalid (t0=0), t0 becomes 0, neutralizing false positives. */
+#if defined(CONFIG_64BIT)
+	sllw  t0, t0, t2
+#else
+	sll   t0, t0, t2
+#endif
+	and  t1, t0, t1     /* Intersect the generated mask with our FP bitmask */
+	bnez t1, is_fp      /* If match, jump to floating-point exception handler */
+	/* 5. Restore t2 */
+#if defined(CONFIG_64BIT)
+	srai t2, t2, 30
+#else
+	srl t1, t2, 30
+	sll t2, t2, 2
+	or t2, t2, t1
+#endif
 	/*
 	 * The FRCSR, FSCSR, FRRM, FSRM, FSRMI, FRFLAGS, FSFLAGS and FSFLAGSI
 	 * are in fact CSR instructions targeting the fcsr, frm and fflags
@@ -314,8 +367,13 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	 * SYSTEM = 0b1110011, op = 0b.xx where xx is never 0
 	 * The csr# of interest are: 1=fflags, 2=frm, 3=fcsr
 	 */
-	xori t1, t0, 0b1110011	/* SYSTEM opcode */
-	bnez t1, 2f		/* not a CSR insn */
+	/* * Due to the logic above, t0 currently holds the validated
+	 * bitmask of the instruction's opcode: (1 << (opcode >> 2)).
+	 * * For the SYSTEM opcode (0x73), the index is 28 (0x73 >> 2).
+	 * Therefore, we just check if t0 equals exactly (1 << 28).
+	 */
+	li t1, 0x10000000	/* Load (1 << 28) to check for SYSTEM opcode */
+	bne t1, t0, 2f		/* not a CSR insn */
 	srli t0, t2, 12
 	andi t0, t0, 0x3
 	beqz t0, 2f		/* not a CSR insn */

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -286,25 +286,45 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	lw t2, 0(t0)		/* t0 = RV_EPC */
 1:
 #endif
-	andi t0, t2, 0x7f	/* keep only the opcode bits */
-	/*
+	/* Move to RVC check if the instruction is not 32-bit encoded */
+	andi t0, t2, 3
+	xori t0, t0, 3
+	bnez t0, 2f		/* not a 32-bit encoding, RVC check below */
+
+	/* RISC-V base floating-point opcodes are 7 bits long. We map them
+	 * into a 32-bit O(1) lookup table by shifting the opcode right by 2.
+	 *
+	 * Opcodes and their resulting lookup bit indices:
 	 * Major FP opcodes:
-	 * 0000111 = LOAD-FP
-	 * 0100111 = STORE-FP
-	 * 1000011 = MADD
-	 * 1000111 = MSUB
-	 * 1001011 = NMSUB
-	 * 1001111 = NMADD
-	 * 1010011 = OP-FP
+	 * 0000111 = LOAD-FP  >> 2 -> 1
+	 * 0100111 = STORE-FP >> 2 -> 9
+	 * 1000011 = MADD     >> 2 -> 16
+	 * 1000111 = MSUB     >> 2 -> 17
+	 * 1001011 = NMSUB    >> 2 -> 18
+	 * 1001111 = NMADD    >> 2 -> 19
+	 * 1010011 = OP-FP    >> 2 -> 20
+	 *
+	 * Combined Bitmask: 0x001F0202
+	 *
+	 * When funct3 is not 1, 2, 3 or 4, 0*00111 is not floating point
+	 * Combined Bitmask in this case: 0x001F0000
 	 */
-	xori t1, t0, 0b1010011	/* OP-FP */
-	beqz t1, is_fp
-	ori  t1, t0, 0b0100000
-	xori t1, t1, 0b0100111	/* LOAD-FP / STORE-FP */
-	beqz t1, is_fp
-	ori  t1, t0, 0b0001100
-	xori t1, t1, 0b1001111	/* MADD / MSUB / NMSUB / NMADD */
-	beqz t1, is_fp
+	/* 1. Preparing the Bitmask (Done first for efficient register usage) */
+	/* Lower 12 bit masks should be 0 for vector instructions */
+	li t0, 0x3c3c
+	srli t1, t2, 12
+	andi t1, t1, 7
+	srl t0, t0, t1
+	andi t0, t0, 0x202 /* 0 for vector instructions with opcode 0b0*00111 */
+	li   t1, 0x001F0000 /* Load the pre-calculated O(1) upper 20 bits of FP opcode bitmask */
+	or t1, t1, t0       /* Final bitmask which accounts for vector instructions */
+
+	/* 2. Perform the O(1) branchless lookup */
+	srli t0, t2, 2
+	andi t0, t0, 0x1f
+	srl  t1, t1, t0		/* bit 0 set = FP major opcode */
+	andi t1, t1, 1
+	bnez t1, is_fp
 	/*
 	 * The FRCSR, FSCSR, FRRM, FSRM, FSRMI, FRFLAGS, FSFLAGS and FSFLAGSI
 	 * are in fact CSR instructions targeting the fcsr, frm and fflags
@@ -314,7 +334,8 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	 * SYSTEM = 0b1110011, op = 0b.xx where xx is never 0
 	 * The csr# of interest are: 1=fflags, 2=frm, 3=fcsr
 	 */
-	xori t1, t0, 0b1110011	/* SYSTEM opcode */
+	/* t0 holds t2[6:2]. Check for SYSTEM opcode (28) since its verified t2[1:0] == 0b11 */
+	xori t1, t0, 0b11100
 	bnez t1, 2f		/* not a CSR insn */
 	srli t0, t2, 12
 	andi t0, t0, 0x3


### PR DESCRIPTION
Replaces the branch-heavy floating-point decoder sequence in `arch/riscv/core/isr.S` with a deterministic O(1) bitmask lookup.

**Key Changes:**
* **O(1) Lookup:** Maps the 7 major base FP opcodes into a single 32-bit immediate bitmask (`0x001F0202`).
* **Flat Execution Time:** Regardless of the instruction, evaluation takes 10 instructions with only 1 branch in the critical path (existing implementation worst-case: 9 instructions with 3 branches).
* **Vector Filtering:** Filters vector instructions that share the same opcode with FP instructions.
* **Runtime Checker:** Adds a runtime checker to catch false triggers of FPU sharing.

Fixes #96551