### PR TITLE
modules: openthread: platform: UART async fix

### DIFF
--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -124,6 +124,8 @@ static void uart_callback(const struct device *dev, void *user_data)
 	}
 }
 #else
+
+#define RX_TIMEOUT 100
 /* UART with async rx buffer */
 static uint8_t rx_buf[CONFIG_OPENTHREAD_COPROCESSOR_UART_RX_BUFFER_SIZE];
 
@@ -138,7 +140,7 @@ static void uart_async_cb(const struct device *dev,
 	switch (evt->type) {
 	case UART_RX_RDY: {
 		size_t len = ring_buf_put(ot_uart.rx_ringbuf,
-					  evt->data.rx.buf,
+					  evt->data.rx.buf + evt->data.rx.offset,
 					  evt->data.rx.len);
 
 		if (len > 0) {
@@ -153,7 +155,7 @@ static void uart_async_cb(const struct device *dev,
 	}
 	case UART_RX_DISABLED:
 		if (uart_enabled) {
-			uart_rx_enable(dev, rx_buf, sizeof(rx_buf), SYS_FOREVER_MS);
+			uart_rx_enable(dev, rx_buf, sizeof(rx_buf), RX_TIMEOUT);
 		}
 		break;
 
@@ -232,7 +234,7 @@ otError otPlatUartEnable(void)
 	uart_irq_rx_enable(ot_uart.dev);
 #else
 	uart_callback_set(ot_uart.dev, uart_async_cb, NULL);
-	uart_rx_enable(ot_uart.dev, rx_buf, sizeof(rx_buf), SYS_FOREVER_MS);
+	uart_rx_enable(ot_uart.dev, rx_buf, sizeof(rx_buf), RX_TIMEOUT);
 #endif
 
 	return OT_ERROR_NONE;

--- a/samples/net/openthread/coprocessor/README.rst
+++ b/samples/net/openthread/coprocessor/README.rst
@@ -46,10 +46,9 @@ Example building for the nrf52840dk/nrf52840 for RCP:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/openthread/coprocessor
-   :host-os: unix
    :board: nrf52840dk/nrf52840
-   :conf: "prj.conf overlay-rcp.conf"
-   :goals: run
+   :goals: build flash
+   :gen-args: -DEXTRA_CONF_FILE=overlay-rcp.conf
    :compact:
 
 There are configuration files for different boards and setups in the

--- a/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.conf
+++ b/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.conf
@@ -1,1 +1,14 @@
 CONFIG_UART_ASYNC_API=y
+CONFIG_OPENTHREAD_COPROCESSOR_UART_ASYNC=y
+CONFIG_OPENTHREAD_THREAD_VERSION_1_4=y
+CONFIG_OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE=1536
+# Disable the console subsystem
+CONFIG_CONSOLE=n
+
+# Disable UART-based console specifically
+CONFIG_UART_CONSOLE=n
+
+# Optional: Disable printk output to save more space
+CONFIG_PRINTK=n
+
+CONFIG_LOG=n

--- a/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.overlay
+++ b/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.overlay
@@ -6,12 +6,10 @@
 
 ot_uart: &usart1 {
 	dmas = <&gpdma1 0 12 STM32_DMA_PERIPH_TX>,
-	       <&gpdma1 1 11 STM32_DMA_PERIPH_RX>;
+	       <&gpdma1 1 11 (STM32_DMA_PERIPH_RX | STM32_DMA_MODE_CYCLIC)>;
 	dma-names = "tx", "rx";
-	fifo-enable;
 	status = "okay";
 	current-speed = <115200>;
-	hw-flow-control;
 };
 
 &gpdma1 {


### PR DESCRIPTION
Fix for asynchronous UART API in the OpenThread co-processor.

Add buffer offset, timeout in RX and enable DMA circular mode in NUCLEO-WBA65RI
