### PR TITLE
Bluetooth: Classic: add extended inquiry response support

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -34,6 +34,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/crypto.h>
+#include <zephyr/bluetooth/data.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/classic/classic.h>
 #include <zephyr/net_buf.h>
@@ -524,94 +525,6 @@ int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk);
  * @return 0 in case of success, or a negative error code on failure.
  */
 int bt_id_delete(uint8_t id);
-
-/**
- * @brief Bluetooth data serialized size.
- *
- * Get the size of a serialized @ref bt_data given its data length.
- *
- * Size of 'AD Structure'->'Length' field, equal to 1.
- * Size of 'AD Structure'->'Data'->'AD Type' field, equal to 1.
- * Size of 'AD Structure'->'Data'->'AD Data' field, equal to data_len.
- *
- * See Core Specification Version 5.4 Vol. 3 Part C, 11, Figure 11.1.
- */
-#define BT_DATA_SERIALIZED_SIZE(data_len) ((data_len) + 2)
-
-/**
- * @brief Bluetooth data.
- *
- * @details Description of different AD Types that can be encoded into advertising data. Used to
- * form arrays that are passed to the @ref bt_le_adv_start function. The @ref BT_DATA define can
- * be used as a helpter to declare the elements of an @ref bt_data array.
- */
-struct bt_data {
-	/** Type of scan response data or advertisement data. */
-	uint8_t type;
-	/** Length of scan response data or advertisement data. */
-	uint8_t data_len;
-	/** Pointer to Scan response or advertisement data. */
-	const uint8_t *data;
-};
-
-/**
- * @brief Helper to declare elements of bt_data arrays
- *
- * This macro is mainly for creating an array of struct bt_data
- * elements which is then passed to e.g. @ref bt_le_adv_start function.
- *
- * @param _type Type of advertising data field
- * @param _data Pointer to the data field payload
- * @param _data_len Number of octets behind the _data pointer
- */
-#define BT_DATA(_type, _data, _data_len) \
-	{ \
-		.type = (_type), \
-		.data_len = (_data_len), \
-		.data = (const uint8_t *)(_data), \
-	}
-
-/**
- * @brief Helper to declare elements of bt_data arrays
- *
- * This macro is mainly for creating an array of struct bt_data
- * elements which is then passed to e.g. @ref bt_le_adv_start function.
- *
- * @param _type Type of advertising data field
- * @param _bytes Variable number of single-byte parameters
- */
-#define BT_DATA_BYTES(_type, _bytes...) \
-	BT_DATA(_type, ((uint8_t []) { _bytes }), \
-		sizeof((uint8_t []) { _bytes }))
-
-/**
- * @brief Get the total size (in octets) of a given set of @ref bt_data
- * structures.
- *
- * The total size includes the length (1 octet) and type (1 octet) fields for each element, plus
- * their respective data lengths.
- *
- * @param[in] data Array of @ref bt_data structures.
- * @param[in] data_count Number of @ref bt_data structures in @p data.
- *
- * @return Size of the concatenated data, built from the @ref bt_data structure set.
- */
-size_t bt_data_get_len(const struct bt_data data[], size_t data_count);
-
-/**
- * @brief Serialize a @ref bt_data struct into an advertising structure (a flat array).
- *
- * The data are formatted according to the Bluetooth Core Specification v. 5.4,
- * vol. 3, part C, 11.
- *
- * @param[in]  input Single @ref bt_data structure to read from.
- * @param[out] output Buffer large enough to store the advertising structure in
- *             @p input. The size of it must be at least the size of the
- *             `input->data_len + 2` (for the type and the length).
- *
- * @return Number of octets written in @p output.
- */
-size_t bt_data_serialize(const struct bt_data *input, uint8_t *output);
 
 /**
  * @brief Local Bluetooth LE controller features and capabilities.

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -24,6 +24,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/data.h>
 #include <zephyr/bluetooth/hci_types.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -635,6 +635,19 @@ struct bt_br_bond_info {
 void bt_br_foreach_bond(void (*func)(const struct bt_br_bond_info *info, void *user_data),
 			void *user_data);
 
+/** @brief Write Extended Inquiry Response data.
+ *
+ *  Write the extended inquiry response data to be sent during the
+ *  extended inquiry response procedure.
+ *
+ *  @param eir          Array of bt_data elements to include in the EIR.
+ *  @param eir_count    Number of elements in the @p eir array.
+ *  @param fec_required Whether FEC encoding is required (true/false).
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_br_write_eir(const struct bt_data *eir, size_t eir_count, bool fec_required);
+
 /**
  * @}
  */

--- a/include/zephyr/bluetooth/data.h
+++ b/include/zephyr/bluetooth/data.h
@@ -1,0 +1,112 @@
+/**
+ * @file
+ * @brief Bluetooth data types and helpers.
+ */
+
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_DATA_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_DATA_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get the size of a serialized @ref bt_data given its data length.
+ *
+ * Size of 'AD Structure'->'Length' field, equal to 1.
+ * Size of 'AD Structure'->'Data'->'AD Type' field, equal to 1.
+ * Size of 'AD Structure'->'Data'->'AD Data' field, equal to data_len.
+ *
+ * See Core Specification Version 5.4 Vol. 3 Part C, 11, Figure 11.1.
+ */
+#define BT_DATA_SERIALIZED_SIZE(data_len) ((data_len) + 2)
+
+/**
+ * @brief Bluetooth data.
+ *
+ * @details Description of different AD Types that can be encoded into advertising data. Used to
+ * form arrays that are passed to the @ref bt_le_adv_start function. The @ref BT_DATA define can
+ * be used as a helpter to declare the elements of an @ref bt_data array.
+ */
+struct bt_data {
+	/** Type of scan response data or advertisement data. */
+	uint8_t type;
+	/** Length of scan response data or advertisement data. */
+	uint8_t data_len;
+	/** Pointer to Scan response or advertisement data. */
+	const uint8_t *data;
+};
+
+/**
+ * @brief Helper to declare elements of bt_data arrays
+ *
+ * This macro is mainly for creating an array of struct bt_data
+ * elements which is then passed to e.g. @ref bt_le_adv_start function.
+ *
+ * @param _type Type of advertising data field
+ * @param _data Pointer to the data field payload
+ * @param _data_len Number of octets behind the _data pointer
+ */
+#define BT_DATA(_type, _data, _data_len) \
+	{ \
+		.type = (_type), \
+		.data_len = (_data_len), \
+		.data = (const uint8_t *)(_data), \
+	}
+
+/**
+ * @brief Helper to declare elements of bt_data arrays
+ *
+ * This macro is mainly for creating an array of struct bt_data
+ * elements which is then passed to e.g. @ref bt_le_adv_start function.
+ *
+ * @param _type Type of advertising data field
+ * @param _bytes Variable number of single-byte parameters
+ */
+#define BT_DATA_BYTES(_type, _bytes...) \
+	BT_DATA(_type, ((uint8_t []) { _bytes }), \
+		sizeof((uint8_t []) { _bytes }))
+
+/**
+ * @brief Get the total size (in octets) of a given set of @ref bt_data
+ * structures.
+ *
+ * The total size includes the length (1 octet) and type (1 octet) fields for each element, plus
+ * their respective data lengths.
+ *
+ * @param[in] data Array of @ref bt_data structures.
+ * @param[in] data_count Number of @ref bt_data structures in @p data.
+ *
+ * @return Size of the concatenated data, built from the @ref bt_data structure set.
+ */
+size_t bt_data_get_len(const struct bt_data data[], size_t data_count);
+
+/**
+ * @brief Serialize a @ref bt_data struct into an advertising structure (a flat array).
+ *
+ * The data are formatted according to the Bluetooth Core Specification v. 5.4,
+ * vol. 3, part C, 11.
+ *
+ * @param[in]  input Single @ref bt_data structure to read from.
+ * @param[out] output Buffer large enough to store the advertising structure in
+ *             @p input. The size of it must be at least the size of the
+ *             `input->data_len + 2` (for the type and the length).
+ *
+ * @return Number of octets written in @p output.
+ */
+size_t bt_data_serialize(const struct bt_data *input, uint8_t *output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_DATA_H_ */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -894,6 +894,18 @@ struct bt_hci_cp_write_page_scan_type {
 	uint8_t type;
 } __packed;
 
+/** Maximum length of Extended Inquiry Response data. */
+#define BT_HCI_EIR_MAX_DATA_LEN                 240
+/** HCI opcode for Write Extended Inquiry Response. */
+#define BT_HCI_OP_WRITE_EXT_INQUIRY_RESPONSE    BT_OP(BT_OGF_BASEBAND, 0x0052) /* 0x0c52 */
+/** HCI command parameters for Write Extended Inquiry Response. */
+struct bt_hci_cp_write_ext_inquiry_response {
+	/** FEC encoding required. */
+	uint8_t fec_required;
+	/** Extended inquiry response data. */
+	uint8_t eir[BT_HCI_EIR_MAX_DATA_LEN];
+} __packed;
+
 #define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056) /* 0x0c56 */
 struct bt_hci_cp_write_ssp_mode {
 	uint8_t mode;

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1642,3 +1642,35 @@ int bt_br_write_local_name(const char *name)
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LOCAL_NAME, buf, NULL);
 }
+
+int bt_br_write_eir(const struct bt_data *eir, size_t eir_count, bool fec_required)
+{
+	struct bt_hci_cp_write_ext_inquiry_response *cp;
+	struct net_buf *buf;
+	size_t offset = 0;
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(*cp)) {
+		net_buf_unref(buf);
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->fec_required = fec_required ? 0x01 : 0x00;
+	(void)memset(cp->eir, 0, sizeof(cp->eir));
+
+	for (size_t i = 0; i < eir_count; i++) {
+		if (offset + BT_DATA_SERIALIZED_SIZE(eir[i].data_len) > BT_HCI_EIR_MAX_DATA_LEN) {
+			net_buf_unref(buf);
+			return -EINVAL;
+		}
+
+		offset += bt_data_serialize(&eir[i], &cp->eir[offset]);
+	}
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_EXT_INQUIRY_RESPONSE, buf, NULL);
+}

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -26,6 +26,7 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/classic/classic.h>
 #include <zephyr/bluetooth/classic/l2cap_br.h>
 
 #include <zephyr/shell/shell.h>
@@ -2007,6 +2008,25 @@ static int cmd_l2cap_connless_send(const struct shell *sh, size_t argc, char *ar
 }
 #endif /* CONFIG_BT_L2CAP_CONNLESS */
 
+static int cmd_write_eir_name(const struct shell *sh, size_t argc, char *argv[])
+{
+	const char *name = bt_get_name();
+	size_t len = strlen(name);
+	struct bt_data eir[] = {
+		BT_DATA(BT_DATA_NAME_COMPLETE, name, len),
+	};
+	int err;
+
+	err = bt_br_write_eir(eir, ARRAY_SIZE(eir), true);
+	if (err != 0) {
+		shell_error(sh, "Failed to write EIR (err %d)", err);
+		return err;
+	}
+
+	shell_print(sh, "EIR written with device name: %s", name);
+	return 0;
+}
+
 static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc == 1) {
@@ -2108,6 +2128,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 #endif
 	SHELL_CMD_ARG(cod-get, NULL, HELP_NONE, cmd_get_class_of_device, 1, 0),
 	SHELL_CMD_ARG(cod-set, NULL, "<cod>", cmd_set_class_of_device, 2, 0),
+	SHELL_CMD_ARG(write-eir-name, NULL, HELP_NONE, cmd_write_eir_name, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Title: Bluetooth: Classic: add extended inquiry response support

Description:

Add bt_br_write_eir() API to set the extended inquiry response (EIR) data for BR/EDR device discovery. EIR allows remote devices to obtain more information during the inquiry process without needing to establish a connection.

The API follows the same design pattern as BLE advertising (bt_le_adv_start()), accepting an array of struct bt_data elements which are serialized into the 240-byte EIR payload using bt_data_serialize().

Changes:

- **Commit 1:** Add bt_br_write_eir() API
  - Define BT_HCI_OP_WRITE_EXT_INQUIRY_RESPONSE HCI command and related structures in hci_types.h
  - Add bt_br_write_eir(const struct bt_data *eir, size_t eir_count, bool fec_required) declaration in classic.h
  - Implement the API in br.c, serializing bt_data array into EIR format
  - Update tests/bluetooth/shell/prj_br.conf with required Kconfig options

- **Commit 2:** Add write-eir shell command for testing
  - Add br write-eir <name> shell command to write a device name as EIR data