### PR TITLE
Bluetooth: Classic: add change connection packet type support

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2137,6 +2137,18 @@ struct bt_conn_br_cb {
 	 *  @param status HCI status of role change event.
 	 */
 	void (*role_changed)(struct bt_conn *conn, uint8_t status);
+
+	/** @brief The packet type of the BR/EDR connection has changed.
+	 *
+	 *  This callback notifies the application that the connection packet
+	 *  type change procedure has completed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param status HCI status of the event.
+	 *  @param packet_type New packet type bitmask.
+	 */
+	void (*packet_type_changed)(struct bt_conn *conn, uint8_t status,
+				    uint16_t packet_type);
 };
 
 /** @brief Connection callback structure.
@@ -3358,6 +3370,25 @@ int bt_conn_br_get_supervision_timeout(struct bt_conn *conn, uint16_t *timeout);
  *  @return  Zero for success, non-zero otherwise.
  */
 int bt_conn_br_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout);
+
+/** @brief Change BR/EDR connection packet type.
+ *
+ *  Change which packet types can be used for an established BR/EDR
+ *  ACL connection. This allows dynamically modifying the connection to
+ *  support different types of user data for throughput optimization.
+ *
+ *  @param conn         Connection object.
+ *  @param packet_type  Raw HCI BR/EDR ACL Packet_Type field composed of
+ *                      BT_HCI_ACL_PKT_TYPE_* values. For basic rate packet
+ *                      type bits, a set bit allows use of that packet type.
+ *                      For BT_HCI_ACL_PKT_TYPE_NO_* bits, a set bit means
+ *                      the corresponding EDR packet type shall not be used,
+ *                      as defined by the Bluetooth specification.
+ *
+ *  @retval 0 On success.
+ *  @retval -errno On failure.
+ */
+int bt_conn_br_change_packet_type(const struct bt_conn *conn, uint16_t packet_type);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2147,8 +2147,7 @@ struct bt_conn_br_cb {
 	 *  @param status HCI status of the event.
 	 *  @param packet_type New packet type bitmask.
 	 */
-	void (*packet_type_changed)(struct bt_conn *conn, uint8_t status,
-				    uint16_t packet_type);
+	void (*packet_type_changed)(struct bt_conn *conn, uint8_t status, uint16_t packet_type);
 };
 
 /** @brief Connection callback structure.

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -548,6 +548,53 @@ struct bt_hci_rp_pin_code_neg_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
+/** HCI Change Connection Packet Type opcode */
+#define BT_HCI_OP_CHANGE_CONN_PACKET_TYPE       BT_OP(BT_OGF_LINK_CTRL, 0x000f) /* 0x040f */
+/** HCI Change Connection Packet Type command parameters */
+struct bt_hci_cp_change_conn_packet_type {
+	/** Connection handle */
+	uint16_t handle;
+	/** Packet type bitmask */
+	uint16_t packet_type;
+} __packed;
+
+/* ACL packet type bits for HCI_Change_Connection_Packet_Type command.
+ * BR packet types (set bit = may be used):
+ *   See Core Spec v6.0, Vol 4, Part E, Section 7.1.14
+ * EDR packet types (set bit = shall NOT be used):
+ *   Note: EDR bits use reverse logic compared to BR bits.
+ */
+/** 2-DH1 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_2DH1            BIT(1)
+/** 3-DH1 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_3DH1            BIT(2)
+/** DM1 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DM1                BIT(3)
+/** DH1 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DH1                BIT(4)
+/** 2-DH3 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_2DH3            BIT(8)
+/** 3-DH3 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_3DH3            BIT(9)
+/** DM3 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DM3                BIT(10)
+/** DH3 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DH3                BIT(11)
+/** 2-DH5 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_2DH5            BIT(12)
+/** 3-DH5 shall not be used */
+#define BT_HCI_ACL_PKT_TYPE_NO_3DH5            BIT(13)
+/** DM5 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DM5                BIT(14)
+/** DH5 may be used */
+#define BT_HCI_ACL_PKT_TYPE_DH5                BIT(15)
+
+/** Bitmask of all BR basic rate ACL packet types */
+#define BT_HCI_ACL_PKT_TYPE_BR_MASK \
+	(BT_HCI_ACL_PKT_TYPE_DM1 | BT_HCI_ACL_PKT_TYPE_DH1 | \
+	 BT_HCI_ACL_PKT_TYPE_DM3 | BT_HCI_ACL_PKT_TYPE_DH3 | \
+	 BT_HCI_ACL_PKT_TYPE_DM5 | BT_HCI_ACL_PKT_TYPE_DH5)
+
 #define BT_HCI_OP_AUTH_REQUESTED                BT_OP(BT_OGF_LINK_CTRL, 0x0011) /* 0x0411 */
 struct bt_hci_cp_auth_requested {
 	uint16_t handle;
@@ -3281,6 +3328,18 @@ struct bt_hci_evt_data_buf_overflow {
 	uint8_t  link_type;
 } __packed;
 
+/** HCI Connection Packet Type Changed event. */
+#define BT_HCI_EVT_CONN_PKT_TYPE_CHANGED        0x1d
+/** HCI Connection Packet Type Changed event parameters. */
+struct bt_hci_evt_conn_pkt_type_changed {
+	/** HCI status. */
+	uint8_t  status;
+	/** Connection handle. */
+	uint16_t handle;
+	/** Packet type bitmask. */
+	uint16_t packet_type;
+} __packed;
+
 #define BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI     0x22
 struct bt_hci_evt_inquiry_result_with_rssi {
 	bt_addr_t addr;
@@ -4432,6 +4491,8 @@ struct bt_hci_evt_le_conn_rate_change {
 #define BT_EVT_MASK_LINK_KEY_REQ                 BT_EVT_BIT(22)
 #define BT_EVT_MASK_LINK_KEY_NOTIFY              BT_EVT_BIT(23)
 #define BT_EVT_MASK_DATA_BUFFER_OVERFLOW         BT_EVT_BIT(25)
+/** Event mask bit for Connection Packet Type Changed event. */
+#define BT_EVT_MASK_CONN_PKT_TYPE_CHANGED        BT_EVT_BIT(28)
 #define BT_EVT_MASK_INQUIRY_RESULT_WITH_RSSI     BT_EVT_BIT(33)
 #define BT_EVT_MASK_REMOTE_EXT_FEATURES          BT_EVT_BIT(34)
 #define BT_EVT_MASK_SYNC_CONN_COMPLETE           BT_EVT_BIT(43)

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -747,6 +747,26 @@ void bt_hci_role_change(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
+void bt_hci_conn_pkt_type_changed(struct net_buf *buf)
+{
+	struct bt_hci_evt_conn_pkt_type_changed *evt = (void *)buf->data;
+	uint16_t handle = sys_le16_to_cpu(evt->handle);
+	uint16_t packet_type = sys_le16_to_cpu(evt->packet_type);
+	struct bt_conn *conn;
+
+	LOG_DBG("status 0x%02x handle %u packet_type 0x%04x", evt->status, handle, packet_type);
+
+	conn = bt_conn_lookup_handle(handle, BT_CONN_TYPE_BR);
+	if (conn == NULL) {
+		LOG_ERR("Can't find conn for handle %u", handle);
+		return;
+	}
+
+	bt_conn_br_packet_type_changed(conn, evt->status, packet_type);
+
+	bt_conn_unref(conn);
+}
+
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 void bt_hci_link_mode_change(struct net_buf *buf)
 {

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -354,3 +354,35 @@ int bt_conn_br_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout)
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT, buf, NULL);
 }
+
+int bt_conn_br_change_packet_type(const struct bt_conn *conn, uint16_t packet_type)
+{
+	struct bt_hci_cp_change_conn_packet_type *cp;
+	struct net_buf *buf;
+
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+		return -EINVAL;
+	}
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_BR)) {
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		return -EINVAL;
+	}
+
+	if ((packet_type & BT_HCI_ACL_PKT_TYPE_BR_MASK) == 0) {
+		LOG_DBG("No BR packet type set in 0x%04x", packet_type);
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->packet_type = sys_cpu_to_le16(packet_type);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_CHANGE_CONN_PACKET_TYPE, buf, NULL);
+}

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -1751,6 +1751,71 @@ void br_role_changed(struct bt_conn *conn, uint8_t status)
 	bt_shell_print("Current role is: %s", get_conn_role_str(info.role));
 }
 
+void br_packet_type_changed(struct bt_conn *conn, uint8_t status,
+			    uint16_t packet_type)
+{
+	bt_shell_print("Packet type changed (HCI status 0x%02x) packet_type 0x%04x",
+		       status, packet_type);
+}
+
+static int cmd_change_packet_type(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint16_t packet_type;
+	int err;
+
+	if (default_conn == NULL) {
+		shell_print(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	/* Start with all EDR types disabled (all NO_* bits set) */
+	packet_type = BT_HCI_ACL_PKT_TYPE_NO_2DH1 | BT_HCI_ACL_PKT_TYPE_NO_3DH1 |
+		      BT_HCI_ACL_PKT_TYPE_NO_2DH3 | BT_HCI_ACL_PKT_TYPE_NO_3DH3 |
+		      BT_HCI_ACL_PKT_TYPE_NO_2DH5 | BT_HCI_ACL_PKT_TYPE_NO_3DH5;
+
+	for (size_t i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "DM1")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DM1;
+		} else if (!strcmp(argv[i], "DH1")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DH1;
+		} else if (!strcmp(argv[i], "DM3")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DM3;
+		} else if (!strcmp(argv[i], "DH3")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DH3;
+		} else if (!strcmp(argv[i], "DM5")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DM5;
+		} else if (!strcmp(argv[i], "DH5")) {
+			packet_type |= BT_HCI_ACL_PKT_TYPE_DH5;
+		} else if (!strcmp(argv[i], "2-DH1")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_2DH1;
+		} else if (!strcmp(argv[i], "3-DH1")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_3DH1;
+		} else if (!strcmp(argv[i], "2-DH3")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_2DH3;
+		} else if (!strcmp(argv[i], "3-DH3")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_3DH3;
+		} else if (!strcmp(argv[i], "2-DH5")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_2DH5;
+		} else if (!strcmp(argv[i], "3-DH5")) {
+			packet_type &= ~BT_HCI_ACL_PKT_TYPE_NO_3DH5;
+		} else {
+			shell_error(sh, "Unknown packet type: %s", argv[i]);
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	shell_print(sh, "Changing packet type to 0x%04x", packet_type);
+
+	err = bt_conn_br_change_packet_type(default_conn, packet_type);
+	if (err != 0) {
+		shell_error(sh, "Failed to change packet type (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 static int cmd_switch_role(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
@@ -2073,6 +2138,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
 	SHELL_CMD_ARG(bonds, NULL, HELP_NONE, cmd_bonds, 1, 0),
+	SHELL_CMD_ARG(change-packet-type, NULL,
+		      "<[DM1] [DH1] [DM3] [DH3] [DM5] [DH5] "
+		      "[2-DH1] [3-DH1] [2-DH3] [3-DH3] [2-DH5] [3-DH5]>",
+		      cmd_change_packet_type, 2, 11),
 	SHELL_CMD_ARG(clear, NULL, "[all] ["HELP_ADDR"]", cmd_clear, 2, 0),
 	SHELL_CMD_ARG(select, NULL, HELP_ADDR, cmd_select, 2, 0),
 	SHELL_CMD_ARG(info, NULL, HELP_ADDR, cmd_info, 1, 1),

--- a/subsys/bluetooth/host/classic/shell/bredr.h
+++ b/subsys/bluetooth/host/classic/shell/bredr.h
@@ -16,5 +16,6 @@
 #include <stdint.h>
 
 void br_role_changed(struct bt_conn *conn, uint8_t status);
+void br_packet_type_changed(struct bt_conn *conn, uint8_t status, uint16_t packet_type);
 
 #endif /* __BREDR_H */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1883,6 +1883,22 @@ void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status)
 		}
 	}
 }
+
+void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status,
+				 uint16_t packet_type)
+{
+	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
+		if (callback->br.packet_type_changed) {
+			callback->br.packet_type_changed(conn, status, packet_type);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
+		if (cb->br.packet_type_changed) {
+			cb->br.packet_type_changed(conn, status, packet_type);
+		}
+	}
+}
 #endif
 
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1884,17 +1884,16 @@ void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status)
 	}
 }
 
-void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status,
-				 uint16_t packet_type)
+void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status, uint16_t packet_type)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
-		if (callback->br.packet_type_changed) {
+		if (callback->br.packet_type_changed != NULL) {
 			callback->br.packet_type_changed(conn, status, packet_type);
 		}
 	}
 
 	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
-		if (cb->br.packet_type_changed) {
+		if (cb->br.packet_type_changed != NULL) {
 			cb->br.packet_type_changed(conn, status, packet_type);
 		}
 	}

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -518,8 +518,7 @@ void bt_conn_connected(struct bt_conn *conn);
 
 void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status);
 
-void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status,
-				 uint16_t packet_type);
+void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status, uint16_t packet_type);
 
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -518,6 +518,9 @@ void bt_conn_connected(struct bt_conn *conn);
 
 void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status);
 
+void bt_conn_br_packet_type_changed(struct bt_conn *conn, uint8_t status,
+				 uint16_t packet_type);
+
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3136,6 +3136,8 @@ static const struct event_handler normal_events[] = {
 		      sizeof(struct bt_hci_evt_remote_ext_features)),
 	EVENT_HANDLER(BT_HCI_EVT_ROLE_CHANGE, bt_hci_role_change,
 		      sizeof(struct bt_hci_evt_role_change)),
+	EVENT_HANDLER(BT_HCI_EVT_CONN_PKT_TYPE_CHANGED, bt_hci_conn_pkt_type_changed,
+		      sizeof(struct bt_hci_evt_conn_pkt_type_changed)),
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 	EVENT_HANDLER(BT_HCI_EVT_MODE_CHANGE, bt_hci_link_mode_change,
 		      sizeof(struct bt_hci_evt_mode_change)),
@@ -4007,6 +4009,7 @@ static int set_event_mask(void)
 		mask |= BT_EVT_MASK_REMOTE_NAME_REQ_COMPLETE;
 		mask |= BT_EVT_MASK_REMOTE_FEATURES;
 		mask |= BT_EVT_MASK_ROLE_CHANGE;
+		mask |= BT_EVT_MASK_CONN_PKT_TYPE_CHANGED;
 #ifdef CONFIG_BT_POWER_MODE_CONTROL
 		mask |= BT_EVT_MASK_MODE_CHANGE;
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -557,6 +557,7 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf);
 void bt_hci_read_remote_features_complete(struct net_buf *buf);
 void bt_hci_read_remote_ext_features_complete(struct net_buf *buf);
 void bt_hci_role_change(struct net_buf *buf);
+void bt_hci_conn_pkt_type_changed(struct net_buf *buf);
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 void bt_hci_link_mode_change(struct net_buf *buf);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1247,6 +1247,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 #endif
 #if defined(CONFIG_BT_CLASSIC)
 	.br.role_changed = br_role_changed,
+	.br.packet_type_changed = br_packet_type_changed,
 #endif
 };
 #endif /* CONFIG_BT_CONN */


### PR DESCRIPTION
Bluetooth: Classic: add change connection packet type support

This PR adds support for dynamically changing the allowed ACL packet types on an established BR/EDR connection via the HCI Change Connection Packet Type command.

### Changes

- Add bt_conn_br_change_packet_type() public API in conn.h, allowing applications to change packet types on a BR/EDR connection for throughput optimization.
- Define BT_HCI_OP_CHANGE_CONN_PACKET_TYPE opcode, bt_hci_cp_change_conn_packet_type command struct, and BT_HCI_ACL_PKT_TYPE_* bitmask defines in hci_types.h (per Core Spec v6.0, Vol 4, Part E, Section 7.1.14).
- Implement the API in conn_br.c with input validation and HCI command construction.
- Update tests/bluetooth/shell/prj_br.conf with related config options.

### Usage

Applications can select specific BR/EDR packet types (DM1/DH1/DM3/DH3/DM5/DH5) and disable EDR packet types (2-DH1/3-DH1/2-DH3/3-DH3/2-DH5/3-DH5) to optimize throughput based on their requirements.

c
/* Example: allow only DM1 and DH1 packets */
bt_conn_br_change_packet_type(conn,
    BT_HCI_ACL_PKT_TYPE_DM1 | BT_HCI_ACL_PKT_TYPE_DH1);
