### PR TITLE
watchdog: wdt_xilinx_wwdt: Add explicit state validation in feed

### DIFF
--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -159,7 +159,7 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	if (channel_id != 0 || !data->timeout_active) {
+	if (channel_id != 0 || !data->timeout_active || !data->wdt_started) {
 		ret = -EINVAL;
 		goto out;
 	}


### PR DESCRIPTION
Add software state check (!data->wdt_started) to wdt_feed() validation to ensure feed operations are only allowed after wdt_setup() has been called.