### PR TITLE
scripts: west_commands: runners: jlink: support `--pre-script-cmd`

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -55,7 +55,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  gdb_host='',
                  gdb_port=DEFAULT_JLINK_GDB_PORT,
                  rtt_port=DEFAULT_JLINK_RTT_PORT,
-                 tui=False, tool_opt=None, dev_id_type=None, batch=False):
+                 tui=False, tool_opt=None, dev_id_type=None, batch=False,
+                 pre_script_cmds=None):
         super().__init__(cfg)
         self.file = cfg.file
         self.file_type = cfg.file_type
@@ -83,6 +84,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.rtt_port = rtt_port
         self.dev_id_type = dev_id_type
         self.is_batch = batch
+        self.pre_script_cmds = pre_script_cmds
 
         self.tool_opt = []
         if tool_opt is not None:
@@ -203,6 +205,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--dev-id-type', choices=['auto', 'serialno', 'tty', 'ip', 'tunnel'],
                             default='auto', help='Device type. "auto" (default) auto-detects '
                             'the type, or specify explicitly')
+        parser.add_argument('--pre-script-cmd', action='append', dest='pre_script_cmds',
+                            help='Custom JLink command to prepend to the runner.jlink. Can be '
+                            'given multiple times. ArgParse should preserve their order.')
 
         parser.set_defaults(reset=False)
 
@@ -225,7 +230,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  rtt_port=args.rtt_port,
                                  tui=args.tui, tool_opt=args.tool_opt,
                                  dev_id_type=args.dev_id_type,
-                                 batch=args.batch)
+                                 batch=args.batch,
+                                 pre_script_cmds=args.pre_script_cmds)
 
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:
@@ -434,7 +440,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 self.run_client(client_cmd)
 
     def get_default_flash_commands(self):
-        lines = [
+        lines = self.pre_script_cmds or [] # Prepend custom script commands
+
+        lines += [
             'ExitOnError 1',  # Treat any command-error as fatal
             'r',  # Reset and halt the target
             'BE' if self.build_conf.getboolean('CONFIG_BIG_ENDIAN') else 'LE'


### PR DESCRIPTION
Allow passing custom J-Link commands to the jlink runner via `--pre-script-cmd` argument.
The argument can be given multiple times.
The commands are prepended to `runner.jlink` in the order as they were given.

**Use Case**:
We have a custom board defined in `JLinkDevices.xml`.
As a result we need to execute the `JLinkDevicesXMLPath` JLink command, as there is no equivalent command line argument. Therefore we need to prepend custom lines to the `runner.jlink` script.
Ref: https://kb.segger.com/J-Link_Command_Strings#JLinkDevicesXMLPath

With the new feature we should be able to add in `board.cmake`:
```
board_runner_args(jlink --pre-script-cmd="exec JLinkDevicesXMLPath /some/custom/JLinkDevices.xml")
```
