### PR TITLE
Bluetooth: CAP: Check values and states 

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -156,6 +156,8 @@ New APIs and options
 
     * :c:func:`bt_ascs_register`
     * :c:func:`bt_ascs_unregister`
+    * :c:func:`bt_bap_unicast_client_qos_from_group`
+    * :c:func:`bt_bap_qos_cfg_eq`
 
   * Host
 
@@ -196,11 +198,13 @@ New APIs and options
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
 
-* :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
-
 * Network
 
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
+
+* Ring buffer
+
+  * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
 .. zephyr-keep-sorted-stop
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1840,6 +1840,34 @@ int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
  */
 int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir);
 
+/**
+ * @brief Get a copy of the QoS configured for the group of the stream
+ *
+ * This may be different from @p stream->qos if the stream has not been QoS configured or if group
+ * has been reconfigured with bt_bap_unicast_group_reconfig(). The QoS returned from this is what
+ * will be applied when bt_bap_stream_qos() is called for the group.
+ *
+ * @param[in] stream The stream to get the QoS configuration information from
+ * @param[out] qos The copy of the QoS configuration data
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p stream or @p qos are NULL, or @p stream is not part of a group.
+ */
+int bt_bap_unicast_client_qos_from_group(const struct bt_bap_stream *stream,
+					 struct bt_bap_qos_cfg *qos);
+
+/**
+ * @brief Compare two @ref bt_bap_qos_cfg and return whether they are equal
+ *
+ * @param a The first QoS config to compare with
+ * @param b The second QoS config to compare with
+ *
+ * @retval true @p a and @p b points to the same memory (including NULL),
+	   or all fields are identical.
+ * @retval false Either @p a or @p b is NULL or any of the fields are not identical.
+ */
+bool bt_bap_qos_cfg_eq(const struct bt_bap_qos_cfg *a, const struct bt_bap_qos_cfg *b);
+
 /** @} */ /* End of group bt_bap_unicast_client */
 /**
  * @brief BAP Broadcast APIs

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1697,7 +1697,6 @@ int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 	ep->qos_pref = *qos_pref;
 
 	bt_bap_stream_attach(conn, stream, ep);
-	stream->codec_cfg = &ep->codec_cfg;
 
 	err = ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1043,7 +1043,6 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 	bt_bap_iso_unref(iso);
 
 	bt_bap_stream_attach(NULL, stream, ep);
-	stream->codec_cfg = &ep->codec_cfg;
 	stream->qos = &ep->qos;
 	stream->group = sink;
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -389,7 +389,6 @@ broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 	bt_bap_iso_unref(iso);
 
 	bt_bap_stream_attach(NULL, stream, ep);
-	stream->codec_cfg = &ep->codec_cfg;
 	stream->qos = &ep->qos;
 	stream->group = source;
 	ep->broadcast_source = source;

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -175,6 +175,32 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 	return 0;
 }
 
+bool bt_bap_qos_cfg_eq(const struct bt_bap_qos_cfg *a, const struct bt_bap_qos_cfg *b)
+{
+	if (a == b) {
+		return true;
+	}
+
+	if (a == NULL || b == NULL) {
+		return false;
+	}
+
+	return a->pd == b->pd &&
+	       a->framing == b->framing &&
+	       a->phy == b->phy &&
+	       a->rtn == b->rtn &&
+	       a->sdu == b->sdu &&
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)
+	       a->latency == b->latency &&
+#endif /*  CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	       a->max_pdu == b->max_pdu &&
+	       a->burst_number == b->burst_number &&
+	       a->num_subevents == b->num_subevents &&
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+	       a->interval == b->interval;
+}
+
 struct bt_conn *bt_bap_ep_get_conn(const struct bt_bap_ep *ep)
 {
 	struct bt_conn *conn;

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -92,6 +92,7 @@ void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, st
 	}
 
 	stream->ep = ep;
+	stream->codec_cfg = &ep->codec_cfg;
 	ep->stream = stream;
 }
 
@@ -1370,11 +1371,9 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream, const struct bt_audio_c
 
 	if (err != 0) {
 		LOG_DBG("reconfiguring stream failed: %d", err);
-	} else {
-		stream->codec_cfg = codec_cfg;
 	}
 
-	return 0;
+	return err;
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -929,6 +929,9 @@ static bool unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 		return false;
 	}
 
+	__ASSERT(stream->codec_cfg == &ep->codec_cfg, "Stream %p not attached to ep %p", stream,
+		 ep);
+
 	cfg = net_buf_simple_pull_mem(buf, sizeof(*cfg));
 
 	if (buf->len < cfg->cc_len) {
@@ -969,7 +972,6 @@ static bool unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 
 	unicast_client_ep_set_codec_cfg(ep, cfg->codec.id, sys_le16_to_cpu(cfg->codec.cid),
 					sys_le16_to_cpu(cfg->codec.vid), cc, cfg->cc_len);
-	stream->codec_cfg = &ep->codec_cfg;
 
 	return true;
 }
@@ -3211,6 +3213,7 @@ int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_gro
 int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 				 const struct bt_audio_codec_cfg *codec_cfg)
 {
+	struct bt_audio_codec_cfg *ep_codec_cfg;
 	struct bt_bap_ep *ep = stream->ep;
 	struct bt_ascs_config_op *op;
 	struct net_buf_simple *buf;
@@ -3218,10 +3221,22 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 
 	LOG_DBG("stream %p", stream);
 
+	if (stream == NULL) {
+		LOG_DBG("Stream is NULL");
+
+		return -EINVAL;
+	}
+
 	if (stream->conn == NULL) {
 		LOG_DBG("Stream %p does not have a connection", stream);
 
 		return -ENOTCONN;
+	}
+
+	if (stream->ep == NULL || &stream->ep->codec_cfg != stream->codec_cfg) {
+		LOG_DBG("Invalid stream %p and stream->ep %p combination", stream, stream->ep);
+
+		return -EINVAL;
 	}
 
 	buf = bt_bap_unicast_client_ep_create_pdu(stream->conn, BT_ASCS_CONFIG_OP);
@@ -3242,6 +3257,15 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 	if (err != 0) {
 		return err;
 	}
+
+	/* Some values like path_id, ctlr_transcode, target_latency and target_phy are not updated
+	 * via the notification, so store them here immediately
+	 */
+	ep_codec_cfg = &stream->ep->codec_cfg;
+	ep_codec_cfg->path_id = codec_cfg->path_id;
+	ep_codec_cfg->ctlr_transcode = codec_cfg->ctlr_transcode;
+	ep_codec_cfg->target_latency = codec_cfg->target_latency;
+	ep_codec_cfg->target_phy = codec_cfg->target_phy;
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -2446,6 +2446,63 @@ static void unicast_group_del_iso(struct bt_bap_unicast_group *group, struct bt_
 	}
 }
 
+int bt_bap_unicast_client_qos_from_group(const struct bt_bap_stream *stream,
+					 struct bt_bap_qos_cfg *qos)
+{
+	if (stream == NULL) {
+		LOG_DBG("stream is NULL");
+		return -EINVAL;
+	}
+
+	if (stream->group == NULL) {
+		LOG_DBG("stream not in a group");
+		return -EINVAL;
+	}
+
+	if (stream->iso == NULL) {
+		LOG_DBG("stream not bound with an ISO chan");
+		return -EINVAL;
+	}
+
+	if (qos == NULL) {
+		LOG_DBG("qos is NULL");
+		return -EINVAL;
+	}
+
+	/* stream->ep does not need to be set. We should be able to get dir based on bap_iso */
+	const struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+	const enum bt_audio_dir dir =
+		bap_iso->tx.stream == stream ? BT_AUDIO_DIR_SINK : BT_AUDIO_DIR_SOURCE;
+	const struct bt_bap_unicast_group *unicast_group = stream->group;
+	const struct bt_iso_chan_io_qos *iso_qos;
+
+	/* memset the struct since it contains padding so that it can be used with memcmp */
+	(void)memset(qos, 0, sizeof(*qos));
+	if (dir == BT_AUDIO_DIR_SINK) {
+		qos->pd = unicast_group->sink_pd;
+		qos->latency = unicast_group->cig_param.c_to_p_latency;
+		qos->interval = unicast_group->cig_param.c_to_p_interval;
+		iso_qos = &bap_iso->tx.qos;
+	} else {
+		qos->pd = unicast_group->source_pd;
+		qos->latency = unicast_group->cig_param.p_to_c_latency;
+		qos->interval = unicast_group->cig_param.p_to_c_interval;
+		iso_qos = &bap_iso->rx.qos;
+	}
+
+	qos->framing = unicast_group->cig_param.framing;
+	qos->phy = iso_qos->phy;
+	qos->rtn = iso_qos->rtn;
+	qos->sdu = iso_qos->sdu;
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	qos->max_pdu = iso_qos->max_pdu;
+	qos->burst_number = iso_qos->burst_number;
+	qos->num_subevents = bap_iso->qos.num_subevents;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+
+	return 0;
+}
+
 static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
 					      const struct bt_bap_qos_cfg *qos,
 					      enum bt_audio_dir dir)

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -36,6 +36,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_endpoint.h"
 #include "cap_internal.h"
@@ -593,6 +594,39 @@ get_proc_param_by_cap_stream(struct bt_cap_common_proc *active_proc,
 	return NULL;
 }
 
+/**
+ * @brief Compare two @ref bt_audio_codec_cfg and return whether they are equal, excluding metadata
+ *
+ * Since metadata is set at a different point in time than the actual codec configuration, it cannot
+ * be checked at the same time.
+ *
+ * @param a The first codec config to compare with
+ * @param b The second codec config to compare with
+ *
+ * @retval true @p a and @p b points to the same memory or all fields are identical.
+ * @retval false Either @p a or @p b is NULL or any of the fields are not identical.
+ */
+static bool codec_cfg_and_data_eq(const struct bt_audio_codec_cfg *a,
+				  const struct bt_audio_codec_cfg *b)
+{
+	if (a == NULL || b == NULL) {
+		return false;
+	}
+
+	if (a == b) {
+		return true;
+	}
+
+	/* Values like path_id, ctlr_transcode, target_latency and target_phy are local only, but
+	 * the only way to update them in BAP is to perform a new codec configuration, so we need to
+	 * consider them here too.
+	 */
+	return a->path_id == b->path_id && a->ctlr_transcode == b->ctlr_transcode &&
+	       a->target_latency == b->target_latency && a->target_phy == b->target_phy &&
+	       a->id == b->id && a->cid == b->cid && a->vid == b->vid &&
+	       util_eq(a->data, a->data_len, b->data, b->data_len);
+}
+
 static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 {
 	const enum bt_cap_common_subproc_type subproc_type = active_proc->subproc_type;
@@ -618,13 +652,27 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 
 			switch (subproc_type) {
 			case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
-				if (state > BT_BAP_EP_STATE_IDLE) {
+				if (state > BT_BAP_EP_STATE_IDLE &&
+				    codec_cfg_and_data_eq(bap_stream->codec_cfg,
+							  proc_param->start.codec_cfg)) {
 					proc_done_cnt++;
 				}
 				break;
 			case BT_CAP_COMMON_SUBPROC_TYPE_QOS_CONFIG:
 				if (state > BT_BAP_EP_STATE_CODEC_CONFIGURED) {
-					proc_done_cnt++;
+					struct bt_bap_qos_cfg qos;
+					__maybe_unused int err;
+
+					err = bt_bap_unicast_client_qos_from_group(bap_stream,
+										   &qos);
+					/* May only happen if the stream is modified by another
+					 * thread, in which case everything else may be broken...
+					 */
+					__ASSERT(err == 0, "Failed to get QoS from stream %p: %d",
+						 bap_stream, err);
+					if (bt_bap_qos_cfg_eq(bap_stream->qos, &qos)) {
+						proc_done_cnt++;
+					}
 				} else if (state < BT_BAP_EP_STATE_CODEC_CONFIGURED) {
 					/* Unexpected state - Abort */
 					LOG_DBG("Unexpected state change");
@@ -633,7 +681,11 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 				}
 				break;
 			case BT_CAP_COMMON_SUBPROC_TYPE_ENABLE:
-				if (state > BT_BAP_EP_STATE_QOS_CONFIGURED) {
+				if (state > BT_BAP_EP_STATE_QOS_CONFIGURED &&
+				    util_eq(bap_stream->codec_cfg->meta,
+					    bap_stream->codec_cfg->meta_len,
+					    proc_param->start.codec_cfg->meta,
+					    proc_param->start.codec_cfg->meta_len)) {
 					proc_done_cnt++;
 				} else if (state < BT_BAP_EP_STATE_QOS_CONFIGURED) {
 					/* Unexpected state - Abort */
@@ -726,7 +778,12 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 		case BT_CAP_COMMON_SUBPROC_TYPE_META_UPDATE:
 			if (state == BT_BAP_EP_STATE_ENABLING ||
 			    state == BT_BAP_EP_STATE_STREAMING) {
-				proc_done_cnt = active_proc->proc_done_cnt + 1U;
+				if (util_eq(bap_stream->codec_cfg->meta,
+					    bap_stream->codec_cfg->meta_len,
+					    proc_param->meta_update.meta,
+					    proc_param->meta_update.meta_len)) {
+					proc_done_cnt = active_proc->proc_done_cnt + 1U;
+				}
 			} else {
 				/* Unexpected state - Abort */
 				LOG_DBG("Unexpected state change");
@@ -773,49 +830,99 @@ get_next_proc_param(struct bt_cap_common_proc *active_proc)
 
 		switch (subproc_type) {
 		case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_START);
+
 			if (state == BT_BAP_EP_STATE_IDLE) {
+				return proc_param;
+			}
+
+			if (state == BT_BAP_EP_STATE_CODEC_CONFIGURED &&
+			    bap_stream->codec_cfg != NULL &&
+			    !codec_cfg_and_data_eq(bap_stream->codec_cfg,
+						   proc_param->start.codec_cfg)) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_QOS_CONFIG:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_START);
+
 			if (state == BT_BAP_EP_STATE_CODEC_CONFIGURED) {
 				return proc_param;
 			}
+
+			if (state == BT_BAP_EP_STATE_QOS_CONFIGURED && bap_stream->qos != NULL) {
+				struct bt_bap_qos_cfg qos;
+				__maybe_unused int err;
+
+				err = bt_bap_unicast_client_qos_from_group(bap_stream, &qos);
+				/* May only happen if the stream is modified by another thread, in
+				 * which case everything else may be broken...
+				 */
+				__ASSERT(err == 0, "Failed to get QoS from stream %p: %d",
+					 bap_stream, err);
+				if (!bt_bap_qos_cfg_eq(bap_stream->qos, &qos)) {
+					return proc_param;
+				}
+			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_ENABLE:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_START);
+
 			if (state == BT_BAP_EP_STATE_QOS_CONFIGURED) {
+				return proc_param;
+			}
+
+			if (state == BT_BAP_EP_STATE_ENABLING && bap_stream->codec_cfg != NULL &&
+			    !util_eq(bap_stream->codec_cfg->meta, bap_stream->codec_cfg->meta_len,
+				     proc_param->start.codec_cfg->meta,
+				     proc_param->start.codec_cfg->meta_len)) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_CONNECT:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_START);
+
 			if (state == BT_BAP_EP_STATE_ENABLING && !proc_param->start.connected) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_START:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_START);
+
 			if (state == BT_BAP_EP_STATE_ENABLING) {
 				/* TODO: Add check for connected */
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_META_UPDATE:
-			if (state == BT_BAP_EP_STATE_ENABLING ||
-			    state == BT_BAP_EP_STATE_STREAMING) {
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_UPDATE);
+
+			if ((state == BT_BAP_EP_STATE_ENABLING ||
+			     state == BT_BAP_EP_STATE_STREAMING) &&
+			    !util_eq(bap_stream->codec_cfg->meta, bap_stream->codec_cfg->meta_len,
+				     proc_param->meta_update.meta,
+				     proc_param->meta_update.meta_len)) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_DISABLE:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_STOP);
+
 			if (state == BT_BAP_EP_STATE_ENABLING ||
 			    state == BT_BAP_EP_STATE_STREAMING) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_STOP:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_STOP);
+
 			if (state == BT_BAP_EP_STATE_DISABLING) {
 				return proc_param;
 			}
 			break;
 		case BT_CAP_COMMON_SUBPROC_TYPE_RELEASE:
+			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_STOP);
+
 			if (proc_param->stop.release && !proc_param->stop.completed) {
 				return proc_param;
 			}
@@ -1408,12 +1515,17 @@ cap_initiator_unicast_audio_configure(struct bt_cap_common_proc *active_proc,
 	active_proc->proc_initiated_cnt++;
 	proc_param->in_progress = true;
 
-	/* Since BAP operations may require a write long or a read long on the notification,
-	 * we cannot assume that we can do multiple streams at once, thus do it one at a time.
-	 * TODO: We should always be able to do one per ACL, so there is room for optimization.
-	 * This applies to all BAP calls in this file.
-	 */
-	err = bt_bap_stream_config(conn, bap_stream, ep, codec_cfg);
+	if (bap_stream->conn == NULL) {
+		/* Since BAP operations may require a write long or a read long on the notification,
+		 * we cannot assume that we can do multiple streams at once, thus do it one at a
+		 * time.
+		 * TODO: We should always be able to do one per ACL, so there is room for
+		 * optimization. This applies to all BAP calls in this file.
+		 */
+		err = bt_bap_stream_config(conn, bap_stream, ep, codec_cfg);
+	} else {
+		err = bt_bap_stream_reconfig(bap_stream, codec_cfg);
+	}
 	if (err != 0) {
 		LOG_DBG("Failed to config stream %p: %d", proc_param->stream, err);
 	}
@@ -1538,7 +1650,12 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
 
-		err = bt_bap_stream_config(conn, next_bap_stream, ep, codec_cfg);
+		if (next_bap_stream->conn == NULL) {
+			err = bt_bap_stream_config(conn, next_bap_stream, ep, codec_cfg);
+		} else {
+			err = bt_bap_stream_reconfig(next_bap_stream, codec_cfg);
+		}
+
 		if (err != 0) {
 			LOG_DBG("Failed to config stream %p: %d", next_cap_stream, err);
 

--- a/tests/bluetooth/audio/cap_initiator/include/test_common.h
+++ b/tests/bluetooth/audio/cap_initiator/include/test_common.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
@@ -21,7 +22,7 @@ void test_mocks_cleanup(void);
 void test_conn_init(struct bt_conn *conn, uint8_t index);
 
 void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *conn,
-			    struct bt_bap_ep *ep, struct bt_bap_lc3_preset *preset,
+			    struct bt_bap_ep *ep, const struct bt_audio_codec_cfg *codec_cfg,
 			    enum bt_bap_ep_state state);
 void mock_discover(
 	struct bt_conn conns[CONFIG_BT_MAX_CONN],

--- a/tests/bluetooth/audio/cap_initiator/src/test_common.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_common.c
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -17,6 +18,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/ztest_assert.h>
 
 #include "audio/bap_endpoint.h"
@@ -49,7 +51,7 @@ void test_conn_init(struct bt_conn *conn, uint8_t index)
 }
 
 void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *conn,
-			    struct bt_bap_ep *ep, struct bt_bap_lc3_preset *preset,
+			    struct bt_bap_ep *ep, const struct bt_audio_codec_cfg *codec_cfg,
 			    enum bt_bap_ep_state state)
 {
 	struct bt_bap_stream *bap_stream = &cap_stream->bap_stream;
@@ -64,15 +66,30 @@ void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *co
 	zassert_not_null(cap_stream);
 	zassert_not_null(conn);
 	zassert_not_null(ep);
-	zassert_not_null(preset);
+	zassert_not_null(codec_cfg);
 
-	err = bt_bap_stream_config(conn, &cap_stream->bap_stream, ep, &preset->codec_cfg);
+	err = bt_bap_stream_config(conn, &cap_stream->bap_stream, ep, codec_cfg);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	bap_stream->conn = conn;
-	bap_stream->ep = ep;
-	bap_stream->qos = &preset->qos;
-	bap_stream->codec_cfg = &preset->codec_cfg;
+	/* Verify that the codec config data was updated */
+	zassert_true(util_eq(codec_cfg->data, codec_cfg->data_len, bap_stream->codec_cfg->data,
+			     bap_stream->codec_cfg->data_len));
+
+	if (state > BT_BAP_EP_STATE_CODEC_CONFIGURED) {
+		err = bt_bap_unicast_client_qos_from_group(bap_stream, &bap_stream->ep->qos);
+		zassert_equal(err, 0, "Unexpected return value %d", err);
+		bap_stream->qos = &bap_stream->ep->qos;
+	}
+
+	if (state > BT_BAP_EP_STATE_ENABLING) {
+		zassert_true(codec_cfg->meta_len <= CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE,
+			     "codec_cfg metadata too large: %u > %d", codec_cfg->meta_len,
+			     CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE);
+
+		(void)memcpy(bap_stream->ep->codec_cfg.meta, codec_cfg->meta, codec_cfg->meta_len);
+		bap_stream->ep->codec_cfg.meta_len = codec_cfg->meta_len;
+	}
+
 	bap_stream->ep->state = state;
 }
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -46,13 +46,18 @@ BUILD_ASSERT(CONFIG_BT_MAX_CONN * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
 #define INDEX_TO_DIR(_idx) (((_idx) & 1U) + 1U)
 
 struct cap_initiator_test_unicast_start_fixture {
+	struct bt_cap_unicast_group_stream_pair_param
+		group_pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_cap_stream cap_streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
+	struct bt_cap_unicast_group_stream_param
+		group_stream_param[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_bap_ep *snk_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 	struct bt_bap_ep *src_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
 	struct bt_cap_unicast_audio_start_stream_param
 		audio_start_stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_cap_unicast_audio_start_param audio_start_param;
 	struct bt_cap_unicast_group *unicast_group;
+	struct bt_cap_unicast_group_param group_param;
 	struct bt_conn conns[CONFIG_BT_MAX_CONN];
 	struct bt_bap_lc3_preset preset;
 };
@@ -60,11 +65,6 @@ struct cap_initiator_test_unicast_start_fixture {
 static void cap_initiator_test_unicast_start_fixture_init(
 	struct cap_initiator_test_unicast_start_fixture *fixture)
 {
-	struct bt_cap_unicast_group_stream_pair_param
-		group_pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	struct bt_cap_unicast_group_stream_param
-		group_stream_param[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	struct bt_cap_unicast_group_param group_param = {0};
 	size_t stream_cnt = 0U;
 	size_t pair_idx = 0U;
 	int err;
@@ -76,29 +76,31 @@ static void cap_initiator_test_unicast_start_fixture_init(
 		test_conn_init(&fixture->conns[i], i);
 	}
 
-	while (stream_cnt < ARRAY_SIZE(group_stream_param)) {
+	while (stream_cnt < ARRAY_SIZE(fixture->group_stream_param)) {
 		const enum bt_audio_dir dir = INDEX_TO_DIR(stream_cnt);
 
 		pair_idx = stream_cnt / 2U;
 
-		group_stream_param[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
-		group_stream_param[stream_cnt].qos_cfg = &fixture->preset.qos;
+		fixture->group_stream_param[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
+		fixture->group_stream_param[stream_cnt].qos_cfg = &fixture->preset.qos;
 
 		/* Switch between sink and source depending on index*/
 		if (dir == BT_AUDIO_DIR_SINK) {
-			group_pair_params[pair_idx].tx_param = &group_stream_param[stream_cnt];
+			fixture->group_pair_params[pair_idx].tx_param =
+				&fixture->group_stream_param[stream_cnt];
 		} else {
-			group_pair_params[pair_idx].rx_param = &group_stream_param[stream_cnt];
+			fixture->group_pair_params[pair_idx].rx_param =
+				&fixture->group_stream_param[stream_cnt];
 		}
 
 		stream_cnt++;
 	}
 
-	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	group_param.params_count = pair_idx + 1U;
-	group_param.params = group_pair_params;
+	fixture->group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	fixture->group_param.params_count = pair_idx + 1U;
+	fixture->group_param.params = fixture->group_pair_params;
 
-	err = bt_cap_unicast_group_create(&group_param, &fixture->unicast_group);
+	err = bt_cap_unicast_group_create(&fixture->group_param, &fixture->unicast_group);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 }
 
@@ -398,13 +400,23 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_state_codec_configured)
 {
+	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
+	 * updated
+	 */
+	struct bt_bap_lc3_preset preset =
+		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
+			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 	int err;
 
 	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
 		test_unicast_set_state(stream_param->stream, stream_param->member.member,
-				       stream_param->ep, &fixture->preset,
+				       stream_param->ep, &preset.codec_cfg,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
+
+	/* Ensure that the 2 codec_cfgs are different */
+	zassert_false(util_eq(preset.codec_cfg.data, preset.codec_cfg.data_len,
+			      fixture->preset.codec_cfg.data, fixture->preset.codec_cfg.data_len));
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
@@ -418,21 +430,55 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+
+		/* Verify that the codec config data was updated */
+		zassert_true(util_eq(fixture->preset.codec_cfg.data,
+				     fixture->preset.codec_cfg.data_len, codec_cfg->data,
+				     codec_cfg->data_len));
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_qos_configured)
 {
+	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
+	 * updated
+	 */
+	struct bt_bap_lc3_preset preset =
+		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
+			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 	int err;
 
 	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
 		test_unicast_set_state(stream_param->stream, stream_param->member.member,
-				       stream_param->ep, &fixture->preset,
+				       stream_param->ep, &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
+	}
+
+	/* Ensure that the 2 QoS are different */
+	zassert_false(bt_bap_qos_cfg_eq(&preset.qos, &fixture->preset.qos));
+
+	/* Reconfigure the group with different QoS after the streams have been QoS configured */
+	ARRAY_FOR_EACH_PTR(fixture->group_stream_param, group_stream_param) {
+		if (group_stream_param->qos_cfg == NULL) {
+			break;
+		}
+
+		group_stream_param->qos_cfg = &preset.qos;
+	}
+	err = bt_cap_unicast_group_reconfig(fixture->unicast_group, &fixture->group_param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	/* Ensure that the stream and group QoS are different at this point*/
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+
+		/* Verify that the QoS config was updated */
+		zassert_false(bt_bap_qos_cfg_eq(&preset.qos, bap_stream->qos));
 	}
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
@@ -451,18 +497,31 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+
+		/* Verify that the QoS config was updated */
+		zassert_true(bt_bap_qos_cfg_eq(&fixture->preset.qos, bap_stream->qos));
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_enabling)
 {
+	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
+	 * updated
+	 */
+	struct bt_bap_lc3_preset preset =
+		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
+			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_RINGTONE);
 	int err;
 
 	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
 		test_unicast_set_state(stream_param->stream, stream_param->member.member,
-				       stream_param->ep, &fixture->preset,
+				       stream_param->ep, &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
+
+	/* Ensure that the 2 codec_cfgs' metadata are different */
+	zassert_false(util_eq(preset.codec_cfg.meta, preset.codec_cfg.meta_len,
+			      fixture->preset.codec_cfg.meta, fixture->preset.codec_cfg.meta_len));
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
@@ -476,22 +535,38 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+
+		/* Verify that the codec config data was updated */
+		zassert_true(util_eq(fixture->preset.codec_cfg.meta,
+				     fixture->preset.codec_cfg.meta_len, codec_cfg->meta,
+				     codec_cfg->meta_len));
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_streaming)
 {
+	/* Use a different preset than fixture->preset to also verify that the codec_cfg data is
+	 * updated
+	 */
+	struct bt_bap_lc3_preset preset =
+		(struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_48_2_1(
+			BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_RINGTONE);
 	int err;
 
 	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
 		test_unicast_set_state(stream_param->stream, stream_param->member.member,
-				       stream_param->ep, &fixture->preset,
+				       stream_param->ep, &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
+
+	/* Ensure that the 2 codec_cfgs' metadata are different */
+	zassert_false(util_eq(preset.codec_cfg.meta, preset.codec_cfg.meta_len,
+			      fixture->preset.codec_cfg.meta, fixture->preset.codec_cfg.meta_len));
 
 	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EALREADY, "Unexpected return value %d", err);
@@ -501,9 +576,15 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+
+		/* Verify that the codec config data was updated */
+		zassert_true(util_eq(fixture->preset.codec_cfg.meta,
+				     fixture->preset.codec_cfg.meta_len, codec_cfg->meta,
+				     codec_cfg->meta_len));
 	}
 }

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -223,7 +223,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
 
@@ -249,7 +249,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 
@@ -274,7 +274,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
 
@@ -299,7 +299,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 
@@ -325,7 +325,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
 
@@ -352,7 +352,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 
@@ -378,7 +378,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
 
@@ -404,7 +404,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 
@@ -456,7 +456,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inva
 
 	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
-				       get_ep_from_index(fixture, i), &fixture->preset,
+				       get_ep_from_index(fixture, i), &fixture->preset.codec_cfg,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -136,6 +136,7 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 				 const struct bt_audio_codec_cfg *codec_cfg)
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
+	struct bt_audio_codec_cfg *ep_codec_cfg;
 	int err;
 
 	if (stream == NULL || stream->ep == NULL || codec_cfg == NULL) {
@@ -156,7 +157,14 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 	if (err != 0) {
 		return err;
 	}
+
 	stream->codec_cfg = &stream->ep->codec_cfg;
+
+	ep_codec_cfg = &stream->ep->codec_cfg;
+	ep_codec_cfg->path_id = codec_cfg->path_id;
+	ep_codec_cfg->ctlr_transcode = codec_cfg->ctlr_transcode;
+	ep_codec_cfg->target_latency = codec_cfg->target_latency;
+	ep_codec_cfg->target_phy = codec_cfg->target_phy;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next, _node) {
 		if (listener->config != NULL) {

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -206,6 +206,12 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
+		__maybe_unused const int err =
+			bt_bap_unicast_client_qos_from_group(stream, &stream->ep->qos);
+
+		__ASSERT(err == 0, "%d", err);
+		stream->qos = &stream->ep->qos;
+
 		if (stream->conn == conn) {
 			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next,
 							  _node) {
@@ -606,6 +612,63 @@ static int unicast_group_add_iso(struct bt_bap_unicast_group *group, struct bt_b
 	return 0;
 }
 
+int bt_bap_unicast_client_qos_from_group(const struct bt_bap_stream *stream,
+					 struct bt_bap_qos_cfg *qos)
+{
+	if (stream == NULL) {
+		LOG_DBG("stream is NULL");
+		return -EINVAL;
+	}
+
+	if (stream->group == NULL) {
+		LOG_DBG("stream not in a group");
+		return -EINVAL;
+	}
+
+	if (stream->iso == NULL) {
+		LOG_DBG("stream not bound with an ISO chan");
+		return -EINVAL;
+	}
+
+	if (qos == NULL) {
+		LOG_DBG("qos is NULL");
+		return -EINVAL;
+	}
+
+	/* stream->ep does not need to be set. We should be able to get dir based on bap_iso */
+	const struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+	const enum bt_audio_dir dir =
+		bap_iso->tx.stream == stream ? BT_AUDIO_DIR_SINK : BT_AUDIO_DIR_SOURCE;
+	const struct bt_bap_unicast_group *unicast_group = stream->group;
+	const struct bt_iso_chan_io_qos *iso_qos;
+
+	/* memset the struct since it contains padding so that it can be used with memcmp */
+	(void)memset(qos, 0, sizeof(*qos));
+	if (dir == BT_AUDIO_DIR_SINK) {
+		qos->pd = unicast_group->sink_pd;
+		qos->latency = unicast_group->cig_param.c_to_p_latency;
+		qos->interval = unicast_group->cig_param.c_to_p_interval;
+		iso_qos = &bap_iso->tx.qos;
+	} else {
+		qos->pd = unicast_group->source_pd;
+		qos->latency = unicast_group->cig_param.p_to_c_latency;
+		qos->interval = unicast_group->cig_param.p_to_c_interval;
+		iso_qos = &bap_iso->rx.qos;
+	}
+
+	qos->framing = unicast_group->cig_param.framing;
+	qos->phy = iso_qos->phy;
+	qos->rtn = iso_qos->rtn;
+	qos->sdu = iso_qos->sdu;
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	qos->max_pdu = iso_qos->max_pdu;
+	qos->burst_number = iso_qos->burst_number;
+	qos->num_subevents = bap_iso->qos.num_subevents;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+
+	return 0;
+}
+
 static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
 					      const struct bt_bap_qos_cfg *qos,
 					      enum bt_audio_dir dir)
@@ -663,9 +726,11 @@ static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *grou
 	if (dir == BT_AUDIO_DIR_SOURCE) {
 		group->cig_param.p_to_c_interval = qos->interval;
 		group->cig_param.p_to_c_latency = qos->latency;
+		group->source_pd = qos->pd;
 	} else {
 		group->cig_param.c_to_p_interval = qos->interval;
 		group->cig_param.c_to_p_latency = qos->latency;
+		group->sink_pd = qos->pd;
 	}
 }
 
@@ -678,7 +743,6 @@ static void unicast_group_add_stream(struct bt_bap_unicast_group *group,
 
 	__ASSERT_NO_MSG(stream->ep == NULL || (stream->ep != NULL && stream->ep->iso == NULL));
 
-	stream->qos = qos;
 	stream->group = group;
 
 	/* iso initialized already */
@@ -742,6 +806,8 @@ int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
 		__maybe_unused int err;
 
 		stream_param = &param->params[i];
+
+		(*unicast_group)->cig_param.packing = param->packing;
 
 		err = unicast_group_add_stream_pair(*unicast_group, stream_param);
 		__ASSERT(err == 0, "%d", err);


### PR DESCRIPTION
Ensures that we check the values as well as the states when performing the CAP unicast start and unicast update CAP procedures. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/103427
depends on https://github.com/zephyrproject-rtos/zephyr/pull/104887