### PR TITLE
samples: net: ptp: Fix ptp4l syntax

### DIFF
--- a/samples/net/ptp/README.rst
+++ b/samples/net/ptp/README.rst
@@ -53,7 +53,7 @@ Compile the ``ptp4l`` daemon and start it like this:
 
 .. code-block:: console
 
-    sudo ./ptp4l -4 -f -i zeth -m -q -l 6 -S
+    sudo ./ptp4l -4 -i zeth -m -q -l 6 -S
 
 Compile Zephyr application.
 


### PR DESCRIPTION
`ptp4l` take `-f` argument as a configuration file. This PR is removing such file for we are not using it.