### PR TITLE
boards: nordic: nrf7120: Fix Wi-Fi GRTC channel allocation

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -81,7 +81,8 @@
 };
 
 &grtc {
-	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15>;
+	/* Channels 14-15 are reserved for Wi-Fi domain */
+	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11 12 13>;
 	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";


### PR DESCRIPTION
Wi-Fi users (14, 15) channels of GRTC, exclude them from the common allocation.