### PR TITLE
kernel: Kconfig.device: fix CONFIG_DEVICE_DEINIT_SUPPORT help text

### DIFF
--- a/kernel/Kconfig.device
+++ b/kernel/Kconfig.device
@@ -39,8 +39,7 @@ config DEVICE_DEINIT_SUPPORT
 	  In very specific case, it might be necessary to de-initialize
 	  a device at runtime. This is possible by providing a function
 	  to do so. Note, that this will grow every struct device by a
-	  function pointer. All device drivers that use the relevant
-	  macros and provide such function should select this option.
+	  function pointer.
 
 endmenu
 


### PR DESCRIPTION
Drivers supporting device deinitialization should not select CONFIG_DEVICE_DEINIT_SUPPORT. Enabling deinit should be left up to the application configuration.