### PR TITLE
hal_nxp: integrate MCUX wireless connectivity 26.03.00-pvw2 release

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake
@@ -8,13 +8,19 @@ if(CONFIG_SOC_SERIES_RW6XX)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.coex ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.rw61x ON)
 
-        zephyr_compile_definitions(gPlatformDisableVendorSpecificInit=1U)
+        zephyr_compile_definitions(
+            gPlatformDisableVendorSpecificInit=1U
+            gPlatformUseTimerManager_d=0
+        )
 
         if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_NBU)
             zephyr_compile_definitions(
                 gPlatformMonolithicApp_d=1U
                 fw_cpu2_ble=fw_cpu2
                 fw_cpu2_combo=fw_cpu2
+                WIFI_LD_TARGET=LOAD_WIFI_FIRMWARE
+                BLE_LD_TARGET=LOAD_BLE_FIRMWARE
+                COMBO_LD_TARGET=LOAD_15D4_FIRMWARE
             )
 
             zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_NBU
@@ -40,15 +46,28 @@ if(CONFIG_SOC_SERIES_MCXW7XX)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.ot ON)
         set_variable_ifdef(CONFIG_SOC_MCXW727C CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.kw47_mcxw72)
         set_variable_ifdef(CONFIG_SOC_MCXW716C CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.kw45_k32w1_mcxw71)
+        zephyr_compile_definitions(
+            gPlatformIcsUseWorkqueueRxProcessing_d=0
+            gPlatformUseTimerManager_d=0
+            gPlatformUseHwParameter_d=0
+            gPlatformNbuDebugGpioDAccessEnabled_d=0
+            gPlatformSetSfcConfigAtInit_d=0
+            gPlatformSetWakeUpDelayAtInit_d=0
+            gPlatformSetBleMaxTxPowerAtInit_d=0
+        )
     endif()
 endif()
 
 if(CONFIG_SOC_SERIES_MCXW2XX)
     if(CONFIG_BT)
+        set(CONFIG_MCUX_COMPONENT_driver.ostimer ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.mcxw23 ON)
         set(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.ble ON)
+        zephyr_compile_definitions(
+            gPlatformUseTimerManager_d=0
+        )
     endif()
 endif()
 

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4489753aff624df8af71c96b2bdbd31327cafbb9
+      revision: 92cc3398bc562809ce3325a260751b5f855bd8ee
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Integrate the latest MCUX wireless connectivity release. Upgrading:
- connectivity framework
- multicore manager
- BLE SNPS controller
- mcxw71/mcxw72/mcxw23 blobs (ble only)