### PR TITLE
llext: arm: add support for generating Thumb-2 veneer stub on the fly.

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -234,4 +234,7 @@ config ARM_VECTOR_TABLE_ITCM
 
 endchoice
 
+config ARCH_HAS_LLEXT_VENEERS
+	bool
+
 endmenu

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -34,6 +34,7 @@ config CPU_CORTEX_M
 	select ARCH_HAS_SUSPEND_TO_RAM
 	select ARCH_HAS_CODE_DATA_RELOCATION
 	select ARCH_SUPPORTS_ROM_START
+	select ARCH_HAS_LLEXT_VENEERS
 	imply XIP
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.

--- a/arch/arm/core/elf.c
+++ b/arch/arm/core/elf.c
@@ -8,6 +8,7 @@
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/llext.h>
 #include <zephyr/llext/llext_internal.h>
+#include <zephyr/llext/loader.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
@@ -101,6 +102,25 @@ LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
 #define SHIFT_THM_MOV_IMM3 4
 #define SHIFT_THM_MOV_IMM4 12
 
+#ifdef CONFIG_LLEXT_VENEERS
+/*
+ * Thumb-2 veneer stub (8 bytes, 4-byte aligned):
+ * LDR.W PC, [PC, #0]   ; loads PC from following word
+ * <target>             ; 32-bit absolute address
+ *
+ * See ARM Architecture Reference Manual ARMv7-A/R,
+ * Section A8.8.63 "LDR (immediate, Thumb)" - T3 encoding.
+ */
+#define THM_LDR_PC_PC_HI 0xF8DF  /* LDR.W PC, [PC, #imm12] */
+#define THM_LDR_PC_PC_LO 0xF000  /* imm12 = 0 */
+
+struct arm_veneer_entry {
+	uint16_t ldr_hi;
+	uint16_t ldr_lo;
+	uint32_t target;
+};
+#endif /* CONFIG_LLEXT_VENEERS */
+
 static inline int prel31_decode(elf_word reloc_type, uint32_t loc,
 				uint32_t sym_base_addr, const char *sym_name, int32_t *offset)
 {
@@ -111,7 +131,7 @@ static inline int prel31_decode(elf_word reloc_type, uint32_t loc,
 	*offset = sign_extend(*(int32_t *)loc, SHIFT_PREL31_SIGN);
 	*offset += sym_base_addr - loc;
 	if (*offset >= PREL31_UPPER_BOUNDARY || *offset < PREL31_LOWER_BOUNDARY) {
-		LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)\n",
+		LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)",
 			sym_name, loc, sym_base_addr);
 		ret = -ENOEXEC;
 	} else {
@@ -153,7 +173,7 @@ static inline int jumps_decode(elf_word reloc_type, uint32_t loc,
 	*offset = sign_extend(*offset, SHIFT_JUMPS_SIGN);
 	*offset += sym_base_addr - loc;
 	if (*offset >= JUMP_LOWER_BOUNDARY || *offset <= JUMP_UPPER_BOUNDARY) {
-		LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)\n",
+		LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)",
 			sym_name, loc, sym_base_addr);
 		ret = -ENOEXEC;
 	} else {
@@ -235,8 +255,6 @@ static inline int thm_jumps_decode(elf_word reloc_type, uint32_t loc,
 	*offset += sym_base_addr - loc;
 
 	if (*offset >= THM_JUMP_LOWER_BOUNDARY || *offset <= THM_JUMP_UPPER_BOUNDARY) {
-		LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)\n",
-			sym_name, loc, sym_base_addr);
 		ret = -ENOEXEC;
 	} else {
 		ret = 0;
@@ -263,15 +281,45 @@ static inline void thm_jumps_reloc(uint32_t loc, int32_t *offset,
 	*(uint16_t *)(loc + 2) = OPCODE2THM16MEM(*lower);
 }
 
-static int thm_jumps_handler(elf_word reloc_type, uint32_t loc,
-			uint32_t sym_base_addr, const char *sym_name)
+static int thm_jumps_handler(struct llext *ext, elf_word reloc_type,
+			uint32_t loc, uint32_t sym_base_addr, const char *sym_name)
 {
 	int ret;
 	int32_t offset;
 	uint32_t upper, lower;
 
 	ret = thm_jumps_decode(reloc_type, loc, sym_base_addr, sym_name, &offset, &upper, &lower);
-	if (!ret) {
+
+#ifdef CONFIG_LLEXT_VENEERS
+	if (ret == -ENOEXEC) {
+		struct arm_veneer_entry *entry = NULL;
+		struct arm_veneer_entry *stubs = ext->mem[LLEXT_MEM_VENEER];
+		size_t count = ext->mem_size[LLEXT_MEM_VENEER] / sizeof(struct arm_veneer_entry);
+
+		for (size_t k = 0; k < count; k++) {
+			if (stubs[k].target == sym_base_addr) {
+				entry = &stubs[k];
+				break;
+			}
+			if (stubs[k].target == 0) {
+				entry = &stubs[k];
+				entry->ldr_hi = THM_LDR_PC_PC_HI;
+				entry->ldr_lo = THM_LDR_PC_PC_LO;
+				entry->target = sym_base_addr;
+				break;
+			}
+		}
+
+		if (entry) {
+			ret = thm_jumps_decode(reloc_type, loc,
+				((uintptr_t)entry) | 1, sym_name, &offset, &upper, &lower);
+			LOG_DBG("sym '%s' %#x -> veneer %#x -> %#x",
+				sym_name, loc, (uint32_t)(uintptr_t)entry, sym_base_addr);
+		}
+	}
+#endif
+
+	if (ret == 0) {
 		thm_jumps_reloc(loc, &offset, &upper, &lower);
 	}
 
@@ -310,6 +358,68 @@ static void thm_movs_handler(elf_word reloc_type, uint32_t loc,
 	*(uint16_t *)loc = OPCODE2THM16MEM(upper);
 	*(uint16_t *)(loc + 2) = OPCODE2THM16MEM(lower);
 }
+
+#ifdef CONFIG_LLEXT_VENEERS
+/**
+ * @brief ARM Thumb-2 veneer table initialization
+ *
+ * Scans all REL sections for R_ARM_THM_CALL and R_ARM_THM_JUMP24 relocations
+ * targeting SHN_UNDEF symbols (external kernel/flash functions) and allocates
+ * a veneer table with one LDR.W PC stub per such relocation. External symbols
+ * are always beyond the ±16 MB Thumb-2 branch range when the extension is
+ * loaded into SRAM, so every such relocation will need a stub.
+ */
+int arch_elf_veneer_init(struct llext_loader *ldr, struct llext *ext)
+{
+	size_t n = 0;
+
+	for (int i = 0; i < ext->sect_cnt; i++) {
+		elf_shdr_t *shdr = &ext->sect_hdrs[i];
+
+		if (shdr->sh_type != SHT_REL) {
+			continue;
+		}
+		if (!(ext->sect_hdrs[shdr->sh_info].sh_flags & SHF_ALLOC)) {
+			continue;
+		}
+
+		for (int j = 0; j < (shdr->sh_size / shdr->sh_entsize); j++) {
+			elf_rel_t rel;
+			elf_sym_t sym;
+
+			if (llext_seek(ldr, shdr->sh_offset + j * shdr->sh_entsize) ||
+			    llext_read(ldr, &rel, sizeof(rel))) {
+				continue;
+			}
+
+			if (ELF32_R_TYPE(rel.r_info) != R_ARM_THM_CALL &&
+			    ELF32_R_TYPE(rel.r_info) != R_ARM_THM_JUMP24) {
+				continue;
+			}
+
+			if (llext_read_symbol(ldr, ext, (elf_rela_t *)&rel, &sym)) {
+				continue;
+			}
+
+			if (sym.st_shndx == SHN_UNDEF) {
+				n++;
+			}
+		}
+	}
+
+	if (n == 0) {
+		return 0;
+	}
+
+	ldr->sects[LLEXT_MEM_VENEER].sh_size = n * sizeof(struct arm_veneer_entry);
+	ldr->sects[LLEXT_MEM_VENEER].sh_addralign = 4;
+	ldr->sects[LLEXT_MEM_VENEER].sh_type = SHT_NOBITS;
+	ldr->sects[LLEXT_MEM_VENEER].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+
+	LOG_DBG("Veneer table: %zu slot(s)", n);
+	return 0;
+}
+#endif /* CONFIG_LLEXT_VENEERS */
 
 /**
  * @brief Architecture specific function for relocating partially linked (static) elf
@@ -394,7 +504,11 @@ int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *r
 
 	case R_ARM_THM_CALL:
 	case R_ARM_THM_JUMP24:
-		ret = thm_jumps_handler(reloc_type, loc, sym_base_addr, sym_name);
+		ret = thm_jumps_handler(ext, reloc_type, loc, sym_base_addr, sym_name);
+		if (ret != 0) {
+			LOG_ERR("sym '%s': relocation out of range (%#x -> %#x)",
+				sym_name, (uint32_t)loc, (uint32_t)sym_base_addr);
+		}
 		break;
 
 	case R_ARM_THM_MOVW_ABS_NC:

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -45,6 +45,9 @@ enum llext_mem {
 	LLEXT_MEM_TEXT,         /**< Executable code */
 	LLEXT_MEM_DATA,         /**< Initialized data */
 	LLEXT_MEM_RODATA,       /**< Read-only data */
+#ifdef CONFIG_LLEXT_VENEERS
+	LLEXT_MEM_VENEER,       /**< Architecture-specific veneer table */
+#endif
 	LLEXT_MEM_BSS,          /**< Uninitialized data */
 	LLEXT_MEM_EXPORT,       /**< Exported symbol table */
 	LLEXT_MEM_SYMTAB,       /**< Symbol table */
@@ -56,7 +59,6 @@ enum llext_mem {
 #ifdef CONFIG_LLEXT_RODATA_NO_RELOC
 	LLEXT_MEM_RODATA_NO_RELOC,  /**< Read-only data without relocations (kept in flash) */
 #endif
-
 	LLEXT_MEM_COUNT,        /**< Number of regions managed by LLEXT */
 };
 

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -77,6 +77,19 @@ int llext_read_symbol(struct llext_loader *ldr, struct llext *ext, const elf_rel
 /** @endcond */
 
 /**
+ * @brief Architecture specific function for initializing the veneer table
+ *
+ * Called once before regions are allocated to allow the architecture to
+ * populate ldr->sects[LLEXT_MEM_VENEER] with the required size for
+ * trampoline stubs needed to extend the reach of out-of-range branches.
+ *
+ * @param[in] ldr  Extension loader data and context
+ * @param[in] ext  Extension being linked
+ * @returns 0 on success or a negative error code
+ */
+int arch_elf_veneer_init(struct llext_loader *ldr, struct llext *ext);
+
+/**
  * @brief Architecture specific function for local binding relocations
  *
  * @param[in] loader Extension loader data and context

--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -20,7 +20,7 @@ CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y # supported by all targets
 # This test consumes large amounts of stack when loading the LLEXT.
 # Increase the available size to avoid overflowing (see issue #74536).
 
-CONFIG_MAIN_STACK_SIZE=2096
+CONFIG_MAIN_STACK_SIZE=4096
 
 # NOTE
 #

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -225,6 +225,18 @@ config LLEXT_IMPORT_ALL_GLOBALS
 	  used by the main application. This is useful to load basic extensions
 	  that have been compiled without the full Zephyr EDK.
 
+config LLEXT_VENEERS
+	bool "Veneer stubs for out-of-range relocations"
+	depends on ARCH_HAS_LLEXT_VENEERS
+	help
+	  When enabled, the architecture-specific LLEXT relocation handler
+	  generates veneer stubs for branch relocations whose target is outside
+	  the instruction's range. This allows linking extensions loaded into
+	  SRAM against kernel symbols in flash without -mlong-calls.
+
+	  Disable only if all external symbol calls are known to be in range
+	  or if -mlong-calls is used.
+
 config LLEXT_EXPERIMENTAL
 	bool "LLEXT experimental functionality"
 	help

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -562,7 +562,11 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 	for (i = 0; i < LLEXT_MEM_COUNT; ++i) {
 		if (ext->mem[i]) {
 			sys_cache_data_flush_range(ext->mem[i], ext->mem_size[i]);
-			if (i == LLEXT_MEM_TEXT && !ldr_parm->pre_located) {
+			if ((i == LLEXT_MEM_TEXT && !ldr_parm->pre_located)
+#ifdef CONFIG_LLEXT_VENEERS
+			    || i == LLEXT_MEM_VENEER
+#endif
+			    ) {
 				sys_cache_instr_invd_range(ext->mem[i], ext->mem_size[i]);
 			}
 		}

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -39,6 +39,11 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 
 static const char ELF_MAGIC[] = {0x7f, 'E', 'L', 'F'};
 
+__weak int arch_elf_veneer_init(struct llext_loader *ldr, struct llext *ext)
+{
+	return 0;
+}
+
 const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx)
 {
 	enum llext_mem mem_idx = ldr->sect_map[sh_ndx].mem_idx;
@@ -830,6 +835,13 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 	ret = llext_map_sections(ldr, ext, ldr_parm);
 	if (ret != 0) {
 		LOG_ERR("Failed to map ELF sections, ret %d", ret);
+		goto out;
+	}
+
+	LOG_DBG("Initializing veneer table...");
+	ret = arch_elf_veneer_init(ldr, ext);
+	if (ret != 0) {
+		LOG_ERR("Failed to initialize veneer table, ret %d", ret);
 		goto out;
 	}
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -36,6 +36,9 @@ static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx,
 
 		switch (mem_idx) {
 		case LLEXT_MEM_TEXT:
+#ifdef CONFIG_LLEXT_VENEERS
+		case LLEXT_MEM_VENEER:
+#endif
 			ext->mem_parts[mem_idx].attr = K_MEM_PARTITION_P_RX_U_RX;
 			break;
 		case LLEXT_MEM_DATA:
@@ -136,7 +139,11 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 						mem_idx, ext->mem[mem_idx], (size_t)region_align);
 				}
 			}
-		} else if (ldr_parm->pre_located) {
+		} else if (ldr_parm->pre_located
+#ifdef CONFIG_LLEXT_VENEERS
+		   && mem_idx != LLEXT_MEM_VENEER
+#endif
+		   ) {
 			/*
 			 * In pre-located files all regions, including BSS,
 			 * are placed by the user with a linker script. No
@@ -148,7 +155,11 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 		}
 	}
 
-	if (ldr_parm->pre_located) {
+	if (ldr_parm->pre_located
+#ifdef CONFIG_LLEXT_VENEERS
+	    && mem_idx != LLEXT_MEM_VENEER
+#endif
+	    ) {
 		/*
 		 * The ELF file is supposed to be pre-located, but some
 		 * regions are not accessible or not in the correct place.
@@ -285,6 +296,9 @@ void llext_adjust_mmu_permissions(struct llext *ext)
 		}
 		switch (mem_idx) {
 		case LLEXT_MEM_TEXT:
+#ifdef CONFIG_LLEXT_VENEERS
+		case LLEXT_MEM_VENEER:
+#endif
 			sys_cache_instr_invd_range(addr, size);
 			flags = K_MEM_PERM_EXEC;
 			break;
@@ -311,7 +325,11 @@ void llext_free_regions(struct llext *ext)
 	for (int i = 0; i < LLEXT_MEM_COUNT; i++) {
 #ifdef CONFIG_MMU
 		if (ext->mmu_permissions_set && ext->mem_size[i] != 0 &&
-		    (i == LLEXT_MEM_TEXT || i == LLEXT_MEM_RODATA)) {
+		    (i == LLEXT_MEM_TEXT || i == LLEXT_MEM_RODATA
+#ifdef CONFIG_LLEXT_VENEERS
+		     || i == LLEXT_MEM_VENEER
+#endif
+		     )) {
 			/* restore default RAM permissions of changed regions */
 			k_mem_update_flags(ext->mem[i],
 					   ROUND_UP(ext->mem_size[i], LLEXT_PAGE_SIZE),
@@ -321,7 +339,11 @@ void llext_free_regions(struct llext *ext)
 		if (ext->mem_on_heap[i]) {
 			LOG_DBG("freeing memory region %d", i);
 
-			if (i == LLEXT_MEM_TEXT) {
+			if (i == LLEXT_MEM_TEXT
+#ifdef CONFIG_LLEXT_VENEERS
+			    || i == LLEXT_MEM_VENEER
+#endif
+			    ) {
 				llext_free_instr(ext, ext->mem[i]);
 			} else {
 				llext_free_data(ext, ext->mem[i]);

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -63,6 +63,20 @@ foreach(ext_name ${ext_names})
   generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
 endforeach()
 
+if(CONFIG_LLEXT_VENEERS)
+  set(ext_bin ${PROJECT_BINARY_DIR}/llext/veneer.llext)
+  set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/veneer.inc)
+  add_llext_target(veneer_ext
+    OUTPUT  ${ext_bin}
+    SOURCES ${PROJECT_SOURCE_DIR}/src/veneer_ext.c
+  )
+  # -mno-long-calls overrides the global -mlong-calls so direct BL instructions
+  # are emitted, producing R_ARM_THM_CALL relocations that exercise the veneer.
+  get_target_property(veneer_lib veneer_ext lib_target)
+  target_compile_options(${veneer_lib} PRIVATE -mno-long-calls)
+  generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
+endif()
+
 if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
   add_llext_target(multi_file_ext
     OUTPUT  ${PROJECT_BINARY_DIR}/llext/multi_file.llext

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -444,6 +444,13 @@ LLEXT_LOAD_UNLOAD(riscv_edge_case_non_paired_hi20_lo12)
 
 #endif /* !CONFIG_LLEXT_TYPE_ELF_OBJECT */
 
+#ifdef CONFIG_LLEXT_VENEERS
+static LLEXT_CONST uint8_t veneer_ext[] ELF_ALIGN = {
+	#include "veneer.inc"
+};
+LLEXT_LOAD_UNLOAD(veneer)
+#endif /* CONFIG_LLEXT_VENEERS */
+
 #ifndef CONFIG_USERSPACE
 static LLEXT_CONST uint8_t export_dependent_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "export_dependent.inc"

--- a/tests/subsys/llext/src/veneer_ext.c
+++ b/tests/subsys/llext/src/veneer_ext.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This extension exercises the veneer stub feature (CONFIG_LLEXT_VENEERS):
+ * it calls standard library functions that may be out of direct branch range
+ * when the extension is loaded into SRAM, triggering veneer stub generation.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/ztest_assert.h>
+
+#define BUF_SIZE 32
+
+static uint8_t src_buf[BUF_SIZE];
+static uint8_t dst_buf[BUF_SIZE];
+static const char test_str[] = "veneer_test_string";
+
+void test_entry(void)
+{
+	size_t len;
+	int cmp;
+
+	printk("veneer test: start\n");
+
+	/* Initialize source buffer */
+	memset(src_buf, 0xAA, BUF_SIZE);
+
+	/* Test memcpy - copies src to dst */
+	memcpy(dst_buf, src_buf, BUF_SIZE);
+	zassert_equal(dst_buf[0], 0xAA, "memcpy failed");
+	zassert_equal(dst_buf[BUF_SIZE - 1], 0xAA, "memcpy failed");
+
+	/* Test memset - clear dst buffer */
+	memset(dst_buf, 0x55, BUF_SIZE);
+	zassert_equal(dst_buf[0], 0x55, "memset failed");
+
+	/* Test memmove - overlapping copy within src_buf.
+	 * Use 4-byte-aligned src/dst offsets to avoid unaligned memory access
+	 */
+	memset(src_buf, 0, BUF_SIZE);
+	src_buf[0] = 1;
+	src_buf[1] = 2;
+	src_buf[2] = 3;
+	src_buf[3] = 4;
+	memmove(&src_buf[4], &src_buf[0], 4);
+	zassert_equal(src_buf[4], 1, "memmove failed");
+	zassert_equal(src_buf[5], 2, "memmove failed");
+
+	/* Test strlen */
+	len = strlen(test_str);
+	zassert_equal(len, sizeof(test_str) - 1, "strlen failed: got %zu", len);
+
+	/* Test memcmp */
+	memset(src_buf, 0xBB, BUF_SIZE);
+	memset(dst_buf, 0xBB, BUF_SIZE);
+	cmp = memcmp(src_buf, dst_buf, BUF_SIZE);
+	zassert_equal(cmp, 0, "memcmp failed: buffers should be equal");
+
+	dst_buf[0] = 0xCC;
+	cmp = memcmp(src_buf, dst_buf, BUF_SIZE);
+	zassert_not_equal(cmp, 0, "memcmp failed: buffers should differ");
+
+	printk("veneer test: passed\n");
+}
+EXPORT_SYMBOL(test_entry);

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -43,6 +43,7 @@ tests:
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
+      - CONFIG_LLEXT_VENEERS=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_RODATA_NO_RELOC=y
   llext.readonly.memblk:
@@ -64,6 +65,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_LLEXT_VENEERS=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.readonly_mpu.memblk:
     arch_allow:


### PR DESCRIPTION
### Description

Fixes #63545

When an LLEXT is loaded in SRAM and calls kernel or libc symbols located in flash, the target may fall outside the ±16 MB range of Thumb-2 BL instructions, causing R_ARM_THM_CALL and R_ARM_THM_JUMP24 relocations to fail.

Add `CONFIG_LLEXT_ARM_VENEER` which, when enabled, generates an 8-byte LDR.W PC, [PC, #0] trampoline stubs for such out-of-range relocations.

Stubs are allocated from the LLEXT heap into a new `LLEXT_MEM_VENEER` region, instead of using new state variables to track the memory, to leverage the existing llext machinery used for TEXT, DATA etc.. which handle allocation, alignment, MMU/MPU sizing, and call `llext_init_mem_part`.

Furthermore, as a side effect, we no longer have to use `-mlong-calls`, which forced every function call to be indirect adding overhead to extensions with many internal calls (e.g., using big libraries). 

### Notes

* I've had to add some ugly cmake block for this test case, to use `-mno-long-calls` to force direct BL instructions and exercise the veneer path, otherwise the test case wouldn't be useful at all.

* Although the overhead is minimal, one slot is still allocated per undefined symbol, even if the symbols are duplicated. To store or generate unique veneers without reallocating memory, we would need to perform an $O(n^2)$ pass. I couldn't think of a better solution, so suggestions are welcome.

### Testing

Before:
```
uart:~$ *** Booting Zephyr OS build v4.2.0-41-gd4d4d3981605 ***
uart:~$ [00:00:01.154,000] <err> elf: sym 'abort': relocation out of range (0x30001356 -> 0x8058c19)
uart:~$ [00:00:01.174,000] <err> elf: sym 'abort': relocation out of range (0x3000135c -> 0x8058c19)
uart:~$ [00:00:01.195,000] <err> elf: sym 'abort': relocation out of range (0x30001362 -> 0x8058c19)
uart:~$ [00:00:01.215,000] <err> elf: sym 'memcpy': relocation out of range (0x30001368 -> 0x80b132b)
uart:~$ [00:00:01.236,000] <err> elf: sym 'memmove': relocation out of range (0x30001420 -> 0x80b1347)
uart:~$ [00:00:01.257,000] <err> elf: sym 'strlen': relocation out of range (0x300015a0 -> 0x8041205)
uart:~$ [00:00:01.278,000] <err> elf: sym 'strlen': relocation out of range (0x30001604 -> 0x8041205)
uart:~$ [00:00:01.299,000] <err> llext: Failed to link, ret -8
[00:00:01.299,000] <err> llext: Failed to link, ret -8
```

After:
```
uart:~$ *** Booting Zephyr OS build v4.2.0-41-g8258aafb769c ***
*** Booting Zephyr OS build v4.2.0-41-g8258aafb769c ***
uart:~$ [00:00:01.153,000] <inf> elf: Allocated 7 slot(s) for veneer table
uart:~$ [00:00:01.168,000] <inf> elf: sym 'abort' 0x30001366 -> stub 0x30001d34 -> 0x8058db1
uart:~$ [00:00:01.187,000] <inf> elf: sym 'abort' 0x3000136c -> stub 0x30001d3c -> 0x8058db1
uart:~$ [00:00:01.205,000] <inf> elf: sym 'abort' 0x30001372 -> stub 0x30001d44 -> 0x8058db1
uart:~$ [00:00:01.224,000] <inf> elf: sym 'memcpy' 0x30001378 -> stub 0x30001d4c -> 0x80b1509
uart:~$ [00:00:01.242,000] <inf> elf: sym 'memmove' 0x30001430 -> stub 0x30001d54 -> 0x80b1525
uart:~$ [00:00:01.261,000] <inf> elf: sym 'strlen' 0x300015b0 -> stub 0x30001d5c -> 0x8041205
uart:~$ [00:00:01.280,000] <inf> elf: sym 'strlen' 0x30001614 -> stub 0x30001d64 -> 0x8041205
uart:~$ [00:00:01.299,000] <inf> llext: Loaded extension sketch
```