### PR TITLE
soc: nxp: rw: fix RTC wakeup status early clear

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -209,6 +209,8 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		save_mpu_state();
 #endif /* CONFIG_MPU */
 
+		/* Clear RTC wakeup status from previous wake before re-arming */
+		POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(rtc)));
 		POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(rtc)));
 
 		sys_clock_set_timeout(0, true);
@@ -249,8 +251,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			sys_clock_idle_exit();
 		}
 
-		/* Clear the RTC wakeup bits */
-		POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(rtc)));
 		POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(rtc)));
 
 		break;


### PR DESCRIPTION
POWER_ClearWakeupStatus for RTC was called on the PM3 exit path, clearing the status before the application could query the wakeup source via NXP_GET_WAKEUP_SIGNAL_STATUS().

Move the clear to the PM3 entry path, just before re-arming the wakeup source. This matches the existing GPIO wakeup status handling which already clears on entry.