### PR TITLE
Infineon board .yaml file updates

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max.yaml
@@ -13,9 +13,16 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - uart
-  - gpio
+  - adc
   - clock_control
-  - pinctrl
+  - counter
+  - flash
+  - gpio
   - i2c
+  - pinctrl
+  - pwm
+  - spi
+  - timer
+  - uart
+  - watchdog
 vendor: infineon

--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
@@ -13,7 +13,16 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - uart
+  - adc
   - clock_control
+  - counter
+  - flash
+  - gpio
+  - i2c
   - pinctrl
+  - pwm
+  - spi
+  - timer
+  - uart
+  - watchdog
 vendor: infineon

--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
@@ -14,17 +14,23 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
-  - bluetooth
-  - wifi
   - airoc
-  - cyw4343w
+  - bluetooth
+  - clock_control
   - counter
-  - gpio
-  - uart
-  - i2c
-  - thermistor
-  - uart
+  - cyw4343w
   - dma
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - rtc
+  - sdhc
+  - spi
+  - thermistor
   - timer
+  - uart
   - watchdog
+  - wifi
 vendor: infineon

--- a/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.yaml
+++ b/boards/infineon/cy8cproto_063_ble/cy8cproto_063_ble.yaml
@@ -14,10 +14,18 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - bluetooth
+  - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
-  - uart
   - i2c
-  - watchdog
+  - pinctrl
+  - pwm
+  - sdhc
   - spi
   - timer
+  - uart
+  - watchdog
 vendor: infineon

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml.yaml
@@ -14,16 +14,19 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - gpio
-  - uart
-  - clock_control
-  - bluetooth
   - adc
-  - watchdog
-  - spi
-  - i2c
-  - rtc
+  - bluetooth
+  - clock_control
+  - counter
   - dma
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
   - pwm
+  - rtc
+  - spi
+  - timer
+  - uart
   - watchdog
 vendor: infineon

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1010.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1010.yaml
@@ -14,16 +14,19 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - gpio
-  - uart
-  - clock_control
-  - bluetooth
   - adc
-  - watchdog
-  - spi
-  - i2c
-  - rtc
+  - bluetooth
+  - clock_control
+  - counter
   - dma
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
   - pwm
+  - rtc
+  - spi
+  - timer
+  - uart
   - watchdog
 vendor: infineon

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1340.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1340.yaml
@@ -14,16 +14,19 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - gpio
-  - uart
-  - clock_control
-  - bluetooth
   - adc
-  - watchdog
-  - spi
-  - i2c
-  - rtc
+  - bluetooth
+  - clock_control
+  - counter
   - dma
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
   - pwm
+  - rtc
+  - spi
+  - timer
+  - uart
   - watchdog
 vendor: infineon

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
@@ -13,9 +13,18 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
+  - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - rtc
   - spi
   - timer
   - uart
-  - dma
+  - watchdog
 vendor: infineon

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -12,7 +12,19 @@ sysbuild: true
 toolchain:
   - zephyr
 supported:
+  - adc
   - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
+  - i2c
+  - i2s
+  - i3c
   - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
   - uart
+  - watchdog

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -12,7 +12,19 @@ sysbuild: true
 toolchain:
   - zephyr
 supported:
+  - adc
   - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
+  - i2c
+  - i2s
+  - i3c
   - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
   - uart
+  - watchdog

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -12,9 +12,19 @@ ram: 5120
 toolchain:
   - zephyr
 supported:
+  - adc
   - clock_control
+  - counter
   - dma
+  - flash
   - gpio
+  - i2c
+  - i2s
+  - i3c
   - pinctrl
-  - uart
+  - pwm
+  - sdhc
   - spi
+  - timer
+  - uart
+  - watchdog

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -12,11 +12,20 @@ sysbuild: true
 toolchain:
   - zephyr
 supported:
+  - adc
   - clock_control
+  - counter
   - dma
+  - flash
   - gpio
-  - pinctrl
-  - uart
-  - spi
-  - sdhc
+  - i2c
   - i2s
+  - i3c
+  - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
+  - uart
+  - watchdog
+  - wifi

--- a/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m0p.yaml
+++ b/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m0p.yaml
@@ -12,4 +12,18 @@ flash: 8384
 toolchain:
   - zephyr
   - gnuarmemb
+supported:
+  - clock_control
+  - counter
+  - dma
+  - flash
+  - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
+  - uart
+  - watchdog
 vendor: infineon

--- a/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m7_0.yaml
+++ b/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m7_0.yaml
@@ -13,6 +13,18 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
+  - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
   - uart
+  - watchdog
 vendor: infineon

--- a/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m7_1.yaml
+++ b/boards/infineon/kit_xmc72_evk/kit_xmc72_evk_xmc7200d_e272k8384_m7_1.yaml
@@ -13,6 +13,18 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
+  - clock_control
+  - counter
+  - dma
+  - flash
   - gpio
+  - i2c
+  - pinctrl
+  - pwm
+  - sdhc
+  - spi
+  - timer
   - uart
+  - watchdog
 vendor: infineon


### PR DESCRIPTION
Add missing features to the supported list in the .yaml file for multiple boards:

    cy8ckit_041s_max:
    adc, counter, flash, pwm, spi, timer, watchdog

    cy8cproto_041tp:
    adc, counter, flash, gpio, i2c, pwm, spi, timer, uart, watchdog

    cy8cproto_062_4343w:
    clock_control, flash, pinctrl, pwm, rtc, spi

    cy8cproto_063_ble:
    bluetooth, clock_control, counter, dma, flash, pinctrl, pwm, sdhc

    cyw920829m2evk_02:
    counter, flash, pinctrl, timer

    kit_psc3m5_evk:
    adc, clock_control, dma, flash, i2c, pinctrl, pwm, rtc, spi, timer, uart, watchdog

    kit_pse84_ai:
    adc, counter, dma, flash, i2c, i2s, i3c, pwm, sdhc, spi, timer, watchdog

    kit_pse84_eval:
    adc, counter, flash, i2c, i2s, i3c, pwm, sdhc, timer, watchdog, wifi

    kit_xmc72_evk:
    adc, clock_control, counter, dma, flash, gpio, i2c, pinctrl, pwm, sdhc, spi, timer, uart, watchdog