### PR TITLE
drivers:spi_nand: ignore ECC errors on the parameter page

### DIFF
--- a/drivers/flash/spi_nand.c
+++ b/drivers/flash/spi_nand.c
@@ -619,9 +619,9 @@ static int onfi_parameters_load(const struct device *dev)
 		LOG_WRN("On-chip ECC not enabled");
 	}
 
-	/* Load parameter info into cache */
+	/* Load parameter info into cache (ignoring ECC errors) */
 	ret = spi_nand_page_read_to_cache(dev, 1);
-	if (ret != 0) {
+	if ((ret != 0) && (ret != -EBADMSG)) {
 		return ret;
 	}
 


### PR DESCRIPTION
The parameter page is not ECC protected, but can return ECC errors under some rare conditions. These errors should be ignored so drivers can initialize.