### PR TITLE
drivers: usb: common: include headers from common's CMakeLists.txt

### DIFF
--- a/drivers/usb/common/CMakeLists.txt
+++ b/drivers/usb/common/CMakeLists.txt
@@ -3,3 +3,7 @@
 add_subdirectory(buf)
 add_subdirectory_ifdef(CONFIG_HAS_NRFX nrf_usbd_common)
 add_subdirectory_ifdef(CONFIG_SOC_FAMILY_STM32 stm32)
+
+if(CONFIG_UDC_DRIVER OR CONFIG_UHC_DRIVER)
+  zephyr_include_directories(.)
+endif()

--- a/drivers/usb/udc/CMakeLists.txt
+++ b/drivers/usb/udc/CMakeLists.txt
@@ -4,7 +4,6 @@
 zephyr_library()
 
 zephyr_library_sources(udc_common.c)
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/usb/common/)
 
 zephyr_library_sources_ifdef(CONFIG_UDC_DWC2 udc_dwc2.c)
 zephyr_library_sources_ifdef(CONFIG_UDC_NRF udc_nrf.c)


### PR DESCRIPTION
Before: `zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/usb/common/)`
After: `zephyr_include_directories(.)`

P.S.: trying smaller PRs, let me know if too small.