### PR TITLE
drivers: nxp: add pinctrl sleep to PM suspend

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -422,8 +422,16 @@ static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_acti
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (error < 0 && error != -ENOENT) {
+			return error;
+		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (error < 0 && error != -ENOENT) {
+			return error;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -625,10 +625,21 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 
 static int i2c_mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_action action)
 {
+	const struct mcux_flexcomm_config *config = dev->config;
+	int error;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (error < 0 && error != -ENOENT) {
+			return error;
+		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (error < 0 && error != -ENOENT) {
+			return error;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		return 0;

--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -872,12 +872,22 @@ static void mipi_dbi_lcdic_isr(const struct device *dev)
 
 static int mipi_dbi_lcdic_pm_action(const struct device *dev, enum pm_device_action action)
 {
+	const struct mipi_dbi_lcdic_config *config = dev->config;
 	struct mipi_dbi_lcdic_data *data = dev->data;
+	int ret;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -762,8 +762,9 @@ static int mcux_sctimer_pwm_init_common(const struct device *dev)
 
 static int mcux_sctimer_pwm_pm_action(const struct device *dev, enum pm_device_action action)
 {
-#ifdef CONFIG_PM_DEVICE
 	const struct pwm_mcux_sctimer_config *config = dev->config;
+	int err;
+#ifdef CONFIG_PM_DEVICE
 	const struct pwm_mcux_sctimer_data *data = dev->data;
 	uint8_t channel;
 #endif /* CONFIG_PM_DEVICE */
@@ -773,6 +774,10 @@ static int mcux_sctimer_pwm_pm_action(const struct device *dev, enum pm_device_a
 #ifdef CONFIG_PM_DEVICE
 		SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
 #endif /* CONFIG_PM_DEVICE */
+		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0 && err != -ENOENT) {
+			return err;
+		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 #ifdef CONFIG_PM_DEVICE
@@ -789,6 +794,10 @@ static int mcux_sctimer_pwm_pm_action(const struct device *dev, enum pm_device_a
 			}
 		}
 #endif /* CONFIG_PM_DEVICE */
+		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (err < 0 && err != -ENOENT) {
+			return err;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -1214,8 +1214,16 @@ static int mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_acti
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0 && ret != -ENOENT) {
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		data->usart_intenset = USART_GetEnabledInterrupts(config->base);


### PR DESCRIPTION
Apply PINCTRL_STATE_SLEEP on PM suspend and PINCTRL_STATE_DEFAULT
on PM resume for NXP drivers that had empty SUSPEND/RESUME cases

If a sleep pinctrl state is defined in the board DTS, pins will
be reconfigured on suspend. If not defined, the call is a no-op.