### PR TITLE
tests: drivers: flash: common: lm20 require fixture

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -193,6 +193,16 @@ tests:
       and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     platform_exclude:
       - beagleconnect_freedom/cc1352p7
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    extra_args:
+      - CONFIG_TEST_FORCE_STORAGE_PARTITION=y
+  drivers.flash.common.test_storage_partition.nrf54lm20:
+    platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    harness_config:
+      fixture: external_flash
     extra_args:
       - CONFIG_TEST_FORCE_STORAGE_PARTITION=y
   drivers.flash.common.ra_ospi_b_nor:


### PR DESCRIPTION
For drivers.flash.common.test_storage_partition
lm20 require fixture which selects board with ext flash enabled.