### PR TITLE
tests: drivers: adc: adc_accuracy_test: update accuracy for nrf52840

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
@@ -8,7 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference-mv = <3000>;
-		expected-accuracy = <32>;
+		expected-accuracy = <60>;
 	};
 };
 


### PR DESCRIPTION
3V buck voltage has 2% accuracy, thus align expectations.