### PR TITLE
drivers: flash: renesas: fix MPU fault on MRAM write for RA8X2

### DIFF
--- a/drivers/flash/Kconfig.renesas_ra
+++ b/drivers/flash/Kconfig.renesas_ra
@@ -71,6 +71,7 @@ config SOC_FLASH_RENESAS_RA_MRAM
 	select FLASH_PAGE_LAYOUT
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
+	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select USE_RA_FSP_MRAM
 	help
 	  Enable Flash MRAM driver for RA series


### PR DESCRIPTION
MRAM programs via direct memory-mapped writes, which the ARM MPU blocks unless `CONFIG_MPU_ALLOW_FLASH_WRITE` is enabled. This PR fixes a Data Access Violation on RA8X2 when running the flash common test suite.