### PR TITLE
shell: backends: telnet: Use struct net_sockaddr_storage

### DIFF
--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -411,10 +411,10 @@ static void telnet_restart_server(void)
 static void telnet_accept(struct zsock_pollfd *pollfd)
 {
 	int sock, ret = 0;
-	struct net_sockaddr addr;
-	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+	struct net_sockaddr_storage addr;
+	net_socklen_t addrlen = sizeof(addr);
 
-	sock = zsock_accept(pollfd->fd, &addr, &addrlen);
+	sock = zsock_accept(pollfd->fd, net_sad(&addr), &addrlen);
 	if (sock < 0) {
 		ret = -errno;
 		NET_ERR("Telnet accept error (%d)", ret);
@@ -443,7 +443,7 @@ static void telnet_accept(struct zsock_pollfd *pollfd)
 	}
 
 	LOG_DBG("Telnet client connected (family NET_AF_INET%s)",
-		addr.sa_family == NET_AF_INET ? "" : "6");
+		addr.ss_family == NET_AF_INET ? "" : "6");
 
 	/* Disable echo - if command handling is enabled we reply that we
 	 * support echo.


### PR DESCRIPTION
A `struct net_sockaddr` should be considered an incomplete type, replace by using `net_sockaddr_storage`.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/104845