### PR TITLE
drivers: timer: nxp: select lptmr timer instance via DT role property

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -374,6 +374,10 @@ Counter
            resolution = <16>;
        };
 
+* A new ``role`` property has been added to :dtcompatible:`nxp,lptmr` to
+  distinguish the system timer role from the counter role. See the Timer section
+  for migration details. (:github:`104445`)
+
 * The NXP i.MX GPT counter driver (:dtcompatible:`nxp,imx-gpt`) now
   defaults to ``run-mode = "restart"`` instead of the previous hardcoded free-run behavior.
 
@@ -879,6 +883,21 @@ Timer
 * :dtcompatible:`renesas,rza2m-ostm` name has been replaced by :dtcompatible:`renesas,rza2m-ostm-timer`.
   The choice :kconfig:option:`DT_HAS_RENESAS_RZA2M_OSTM_ENABLED` has been replaced with
   :kconfig:option:`DT_HAS_RENESAS_RZA2M_OSTM_TIMER_ENABLED` (:github:`100934`)
+
+* :dtcompatible:`nxp,lptmr` nodes used as the system timer must now declare
+  ``role = "timer"`` in the board DTS overlay:
+
+  .. code-block:: devicetree
+
+     &lptmr0 {
+         role = "timer";
+     };
+
+  Boards based on i.MX95 and MCX-W SoCs already have this set in the SoC DTSI
+  and require no change. All other boards using
+  :kconfig:option:`CONFIG_MCUX_LPTMR_TIMER` must add the overlay above.
+  On Kinetis KE1xF, this overlay is also required when
+  :kconfig:option:`CONFIG_PM` is enabled.
 
 USB
 ===

--- a/drivers/counter/Kconfig.mcux_lptmr
+++ b/drivers/counter/Kconfig.mcux_lptmr
@@ -6,6 +6,7 @@
 config COUNTER_MCUX_LPTMR
 	bool "MCUX LPTMR driver"
 	default y
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPTMR),role,counter)
 	depends on DT_HAS_NXP_LPTMR_ENABLED
 	help
 	  Enable support for the MCUX Low Power Timer (LPTMR).

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -423,4 +423,12 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
 		&mcux_lptmr_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT)
+/*
+ * Skip instances with role = "timer"; those are managed exclusively by the
+ * MCUX_LPTMR_TIMER system timer driver.
+ */
+#define COUNTER_MCUX_LPTMR_DEVICE_INIT_WRAPPER(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, counter), \
+		    (COUNTER_MCUX_LPTMR_DEVICE_INIT(n)), ())
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT_WRAPPER)

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -6,11 +6,13 @@
 
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
-	default n
-	depends on DT_HAS_NXP_LPTMR_ENABLED
-	depends on !COUNTER_MCUX_LPTMR
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPTMR),role,timer)
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"
-	  interfaces.
+	  interfaces. The driver uses the devicetree `role` property to identify
+	  which `nxp,lptmr` node acts as the system timer. Exactly one enabled
+	  `nxp,lptmr` node must carry `role = "timer"` when this driver is enabled.
+	  Both MCUX_LPTMR_TIMER and COUNTER_MCUX_LPTMR can be enabled
+	  simultaneously when multiple LPTMR instances carry different roles.

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -15,30 +15,61 @@
 #include <fsl_lptmr.h>
 #include <zephyr/irq.h>
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
-	     "No LPTMR instance enabled in devicetree");
+/* Count enabled `nxp,lptmr` instances with `role = "timer"`. */
+#define LPTMR_TIMER_ROLE_COUNT(n) + DT_INST_ENUM_HAS_VALUE(n, role, timer)
+BUILD_ASSERT((0 DT_INST_FOREACH_STATUS_OKAY(LPTMR_TIMER_ROLE_COUNT)) == 1,
+	     "Exactly one enabled `nxp,lptmr` node must have `role = \"timer\"`");
 
-/* Prescaler clock mapping */
-#define TO_LPTMR_CLK_SEL(val) _DO_CONCAT(kLPTMR_PrescalerClock_, val)
-
-/* Devicetree properties */
-#define LPTMR_BASE ((LPTMR_Type *)(DT_INST_REG_ADDR(0)))
-#define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_INST_PROP_OR(0, clk_source, 0))
-#define LPTMR_PRESCALER DT_INST_PROP_OR(0, prescale_glitch_filter, 0)
 /*
- * Default must be false so prescale-glitch-filter can be used without requiring
- * an explicit bypass property.
+ * Collect devicetree properties from the timer-role instance.
+ *
+ * COND_CODE_1 expands to the property value for the `role = "timer"` instance
+ * and to nothing for all others. The BUILD_ASSERT above guarantees exactly one
+ * timer-role node, so DT_INST_FOREACH_STATUS_OKAY produces a single value.
  */
-#define LPTMR_PRESCALER_BYPASS DT_INST_PROP_OR(0, prescale_glitch_filter_bypass, false)
-#define LPTMR_IRQN DT_INST_IRQN(0)
-#define LPTMR_IRQ_PRIORITY DT_INST_IRQ(0, priority)
+#define LPTMR_TIMER_REG(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_REG_ADDR(n)), ())
+#define LPTMR_BASE \
+	((LPTMR_Type *)(uintptr_t)(DT_INST_FOREACH_STATUS_OKAY(LPTMR_TIMER_REG)))
+
+#define LPTMR_CLK_SRC(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_PROP_OR(n, clk_source, 0)), ())
+#define LPTMR_CLK_SOURCE \
+	((lptmr_prescaler_clock_select_t) \
+	 (DT_INST_FOREACH_STATUS_OKAY(LPTMR_CLK_SRC)))
+
+#define LPTMR_PRESCALER_VAL(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_PROP_OR(n, prescale_glitch_filter, 0)), ())
+#define LPTMR_PRESCALER (DT_INST_FOREACH_STATUS_OKAY(LPTMR_PRESCALER_VAL))
+
+#define LPTMR_BYPASS_VAL(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_PROP_OR(n, prescale_glitch_filter_bypass, 0)), ())
+#define LPTMR_PRESCALER_BYPASS ((bool)(DT_INST_FOREACH_STATUS_OKAY(LPTMR_BYPASS_VAL)))
+
+#define LPTMR_TIMER_IRQN(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_IRQN(n)), ())
+#define LPTMR_IRQN (DT_INST_FOREACH_STATUS_OKAY(LPTMR_TIMER_IRQN))
+
+#define LPTMR_IRQ_PRI(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_IRQ(n, priority)), ())
+#define LPTMR_IRQ_PRIORITY (DT_INST_FOREACH_STATUS_OKAY(LPTMR_IRQ_PRI))
+
+#define LPTMR_RESOLUTION_VAL(n) \
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, role, timer), \
+			(DT_INST_PROP(n, resolution)), ())
+#define LPTMR_RESOLUTION (DT_INST_FOREACH_STATUS_OKAY(LPTMR_RESOLUTION_VAL))
 
 /* Timer cycles per tick */
 #define CYCLES_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() \
 			/ (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 
 /* Counter maximum value based on resolution */
-#define LPTMR_RESOLUTION DT_INST_PROP(0, resolution)
 #define COUNTER_MAX GENMASK(LPTMR_RESOLUTION - 1, 0)
 
 #define MAX_TICKS ((COUNTER_MAX / CYCLES_PER_TICK) - 1)

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -622,6 +622,7 @@
 			clk-source = <2>;
 			prescale-glitch-filter-bypass;
 			resolution = <32>;
+			role = "timer";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -346,6 +346,7 @@
 		clk-source = <2>;
 		prescale-glitch-filter-bypass;
 		resolution = <32>;
+		role = "timer";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/nxp_mcxw70.dtsi
@@ -447,6 +447,7 @@
 		clk-source = <2>;
 		prescale-glitch-filter-bypass;
 		resolution = <32>;
+		role = "timer";
 		status = "disabled";
 	};
 

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -96,3 +96,14 @@ properties:
       - restart
       - free-run
     default: restart
+
+  role:
+    type: string
+    default: "counter"
+    enum:
+      - "counter"
+      - "timer"
+    description: |
+      Selects the software role for this LPTMR instance.
+      "counter" (default): instance is managed by COUNTER_MCUX_LPTMR.
+      "timer": instance is managed by MCUX_LPTMR_TIMER as the system timer.

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -42,11 +42,11 @@ config 3RD_LEVEL_INTERRUPTS
 config NUM_IRQS
 	default 250 # 2ND_LVL_ISR_TBL_OFFSET + MAX_IRQ_PER_AGGREGATOR * NUM_2ND_LEVEL_AGGREGATORS
 
-# LPTMR cannot be shared with both the system timer and the counter simultaneously
-# as they now share the same compatible resource.
-# By default, when LPTMR is not used as a counter, it shows enabling LPTMR as the system clock.
-config MCUX_LPTMR_TIMER
-	default y if !COUNTER_MCUX_LPTMR
+# lptmr1 carries role = "timer"; lptmr2 is a counter (default role).
+# Both drivers can be active simultaneously on i.MX95 since they use separate
+# hardware instances. No mutual-exclusion guard is needed here.
+configdefault MCUX_LPTMR_TIMER
+	default y
 
 config CORTEX_M_SYSTICK
 	default n if MCUX_LPTMR_TIMER


### PR DESCRIPTION
Changes:
- Add `role` string property to the `nxp,lptmr` binding (default:
  `"counter"`, preserving existing behaviour)
- Timer driver selects the instance with `role = "timer"`; a
  BUILD_ASSERT enforces exactly one such instance
- Counter driver skips instances with `role = "timer"`
- Set `role = "timer"` on the timer-dedicated LPTMR instance in i.MX95
  and MCX-W SoCs DTSI
- Document required board overlay for out-of-tree boards in the 4.4
  migration guide

Out-of-tree boards using MCUX_LPTMR_TIMER must add a board overlay:

    &lptmr0 {
        role = "timer";
    };
