### PR TITLE
boards: nxp: mimxrt685_evk: Added acmp support

### DIFF
--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NXP
+# Copyright (c) 2020, 2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,6 +19,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - comparator
   - counter
   - dma
   - flash

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2024 NXP
+ * Copyright 2020, 2024, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -509,6 +509,14 @@
 		max-current-180 = <1020>;
 		max-bus-freq = <DT_FREQ_M(208)>;
 		min-bus-freq = <DT_FREQ_K(400)>;
+	};
+
+	acmp: cmp@139000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x139000 0x1000>;
+		interrupts = <24 0>;
+		clocks = <&clkctl1 MCUX_LPCMP0_CLK>;
+		status = "disabled";
 	};
 
 	lpadc0: adc@13a000 {

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 NXP
+ * Copyright 2020-2023, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -314,6 +314,16 @@ __weak void clock_init(void)
 			DT_PROP(DT_NODELABEL(i3c0), clk_divider_slow));
 	CLOCK_SetClkDiv(kCLOCK_DivI3cTcClk,
 			DT_PROP(DT_NODELABEL(i3c0), clk_divider_tc));
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(acmp), nxp_kinetis_acmp, okay)
+	CLOCK_AttachClk(kMAIN_CLK_to_ACMP_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivAcmpClk, 2);
+	POWER_DisablePD(kPDRUNCFG_PD_ACMP);
+	POWER_ApplyPD();
+	RESET_PeripheralReset(kACMP0_RST_SHIFT_RSTn);
+	/* Make sure ACMP voltage reference available*/
+	POWER_SetAnalogBuffer(true);
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpadc0), nxp_lpc_lpadc, okay)

--- a/tests/drivers/comparator/gpio_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_imx/rt/MIMXRT685SFVKB-pinctrl.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * PIO0_5(J30-1) looped back to CMP input PIO2_14(J1-9)
+ */
+
+/ {
+	aliases {
+		test-comp = &acmp;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&pinctrl {
+	acmp_default: acmp_default {
+		group0 {
+			pinmux = <CMP_IN1_PIO2_14>;
+			slew-rate = "normal";
+			drive-strength = "normal";
+			input-enable;
+			nxp,analog-mode;
+		};
+	};
+};
+
+&acmp {
+	pinctrl-0 = <&acmp_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	positive-mux-input = "IN1";
+	positive-port-input = "MUX";
+	negative-mux-input = "IN7";
+	negative-port-input = "DAC";
+
+	discrete-mode-enable-positive-channel;
+
+	dac-vref-source = "VIN2";
+	dac-value = <127>;
+	dac-enable;
+};

--- a/tests/drivers/comparator/gpio_loopback/src/test.c
+++ b/tests/drivers/comparator/gpio_loopback/src/test.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +32,7 @@ static void test_before(void *f)
 
 	k_sem_reset(&test_sem);
 	zassert_ok(gpio_pin_set_dt(&test_pin, 0));
+	k_msleep(1);
 	zassert_ok(comparator_set_trigger(test_dev, COMPARATOR_TRIGGER_NONE));
 	zassert_ok(comparator_set_trigger_callback(test_dev, NULL, NULL));
 	zassert_between_inclusive(comparator_trigger_is_pending(test_dev), 0, 1);


### PR DESCRIPTION
- Improved the tests/drivers/comparator/gpio_loopback testcase. 
- Enabled tests and samples for RT685 ACMP. 