### PR TITLE
net: ip: Add net_family2size helper function

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -201,6 +201,12 @@ struct net_sockaddr_ll {
 	uint8_t         sll_addr[8];  /**< Physical-layer address, big endian */
 };
 
+/** struct net_sockaddr_can - The net_sockaddr structure for CAN sockets. */
+struct net_sockaddr_can {
+	net_sa_family_t can_family;   /**< Address family */
+	int             can_ifindex;  /**< SocketCAN network interface index */
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 /** Socket address struct for IPv6 where address is a pointer */

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -2226,6 +2226,33 @@ static inline uint8_t net_priority2vlan(enum net_priority priority)
 const char *net_family2str(net_sa_family_t family);
 
 /**
+ * @brief Return network address size for a given family.
+ *
+ * @param family Network address family code
+ *
+ * @return Network address size, or 0 if family is unknown.
+ */
+static inline size_t net_family2size(net_sa_family_t family)
+{
+	switch (family) {
+	case NET_AF_INET:
+		return sizeof(struct net_sockaddr_in);
+	case NET_AF_INET6:
+		return sizeof(struct net_sockaddr_in6);
+	case NET_AF_PACKET:
+		return sizeof(struct net_sockaddr_ll);
+	case NET_AF_UNIX:
+		return sizeof(struct net_sockaddr_un);
+	case NET_AF_CAN:
+		return sizeof(struct net_sockaddr_can);
+	case NET_AF_NET_MGMT:
+		return sizeof(struct net_sockaddr_nm);
+	default:
+		return 0;
+	}
+}
+
+/**
  * @brief Add IPv6 prefix as a privacy extension filter.
  *
  * @details Note that the filters can either allow or deny listing.

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -207,6 +207,40 @@ struct net_sockaddr_can {
 	int             can_ifindex;  /**< SocketCAN network interface index */
 };
 
+/**
+ * struct net_sockaddr_nm - The net_sockaddr structure for NET_MGMT sockets
+ *
+ * Similar concepts are used as in Linux AF_NETLINK. The NETLINK name is not
+ * used in order to avoid confusion between Zephyr and Linux as the
+ * implementations are different.
+ *
+ * The socket domain (address family) is AF_NET_MGMT, and the type of socket
+ * is either NET_SOCK_RAW or NET_SOCK_DGRAM, because this is a datagram-oriented
+ * service.
+ *
+ * The protocol (protocol type) selects for which feature the socket is used.
+ *
+ * When used with bind(), the nm_pid field of the net_sockaddr_nm can be
+ * filled with the calling thread' own id. The nm_pid serves here as the local
+ * address of this net_mgmt socket. The application is responsible for picking
+ * a unique integer value to fill in nm_pid.
+ */
+struct net_sockaddr_nm {
+	/** AF_NET_MGMT address family. */
+	net_sa_family_t nm_family;
+
+	/** Network interface related to this address */
+	int nm_ifindex;
+
+	/** Thread id or similar that is used to separate the different
+	 * sockets. Application can decide how the pid is constructed.
+	 */
+	uintptr_t nm_pid;
+
+	/** net_mgmt mask */
+	uint64_t nm_mask;
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 /** Socket address struct for IPv6 where address is a pointer */

--- a/include/zephyr/net/socket_net_mgmt.h
+++ b/include/zephyr/net/socket_net_mgmt.h
@@ -55,40 +55,6 @@ extern "C" {
 
 /** @} */ /* for @name */
 
-/**
- * struct net_sockaddr_nm - The net_sockaddr structure for NET_MGMT sockets
- *
- * Similar concepts are used as in Linux AF_NETLINK. The NETLINK name is not
- * used in order to avoid confusion between Zephyr and Linux as the
- * implementations are different.
- *
- * The socket domain (address family) is AF_NET_MGMT, and the type of socket
- * is either NET_SOCK_RAW or NET_SOCK_DGRAM, because this is a datagram-oriented
- * service.
- *
- * The protocol (protocol type) selects for which feature the socket is used.
- *
- * When used with bind(), the nm_pid field of the net_sockaddr_nm can be
- * filled with the calling thread' own id. The nm_pid serves here as the local
- * address of this net_mgmt socket. The application is responsible for picking
- * a unique integer value to fill in nm_pid.
- */
-struct net_sockaddr_nm {
-	/** AF_NET_MGMT address family. */
-	net_sa_family_t nm_family;
-
-	/** Network interface related to this address */
-	int nm_ifindex;
-
-	/** Thread id or similar that is used to separate the different
-	 * sockets. Application can decide how the pid is constructed.
-	 */
-	uintptr_t nm_pid;
-
-	/** net_mgmt mask */
-	uint64_t nm_mask;
-};
-
 
 /**
  * Each network management message is prefixed with this header.

--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -66,15 +66,6 @@ enum {
 #define CANFD_FDF 0x04 /**< Mark CAN FD for dual use of struct canfd_frame */
 
 /**
- * struct net_sockaddr_can - The net_sockaddr structure for CAN sockets
- *
- */
-struct net_sockaddr_can {
-	net_sa_family_t can_family;   /**< Address family */
-	int             can_ifindex;  /**< SocketCAN network interface index */
-};
-
-/**
  * @name Linux SocketCAN compatibility
  *
  * The following structures and functions provide compatibility with the CAN


### PR DESCRIPTION
Add a function to translate the socket address family to the size of the concrete socket address type.

Created as this was suggested here https://github.com/zephyrproject-rtos/zephyr/pull/104595#discussion_r2878719846