### PR TITLE
boards: renesas: Correct the flash-controller node reference

### DIFF
--- a/boards/renesas/ek_ra4c1/ek_ra4c1.dts
+++ b/boards/renesas/ek_ra4c1/ek_ra4c1.dts
@@ -17,7 +17,7 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,flash-controller = &flash;
+		zephyr,flash-controller = &flash1;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;


### PR DESCRIPTION
Correct the `flash-controller` node reference from `&flash`  to `&flash1`