### PR TITLE
soc: nxp: rw: Disable AVPLL and TDDR when doing clock initialization.

### DIFF
--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -126,13 +126,16 @@ __weak __ramfunc void clock_init(void)
 	CLOCK_SetClkDiv(kCLOCK_DivSystickClk, 1U);
 	CLOCK_AttachClk(kSYSTICK_DIV_to_SYSTICK_CLK);
 
-	SystemCoreClockUpdate();
-
 	/* Set PLL FRG clock to 20MHz. */
 	CLOCK_SetClkDiv(kCLOCK_DivPllFrgClk, 13U);
 
 	/* Call function set_flexspi_clock() to set flexspi clock source to aux0_pll_clk in XIP. */
 	set_flexspi_clock(FLEXSPI, 2U, 2U);
+
+	/* Deinitialization of the AVPLL. */
+	CLOCK_DeinitAvPll();
+	/* Deinitialize TDDR PLL. */
+	CLOCK_DeinitTddrRefClk();
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(os_timer), nxp_os_timer, okay)
 	CLOCK_AttachClk(kLPOSC_to_OSTIMER_CLK);


### PR DESCRIPTION
The RW612 will enter PM_STATE_RUNTIME_IDLE mode when idle but the average current is higher than expected. The expected current should be around 15mA but the actual current is nearly 18mA. By disabling AVPLL and TDDR clock in clock_init, the current of PM_STATE_RUNTIME_IDLE mode is ok, which is around 15.5mA