### PR TITLE
Update rt1180 ele ping feature

### DIFF
--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -111,6 +111,19 @@ The i.MX RT1186 SoC is configured to use SysTick as the system clock source.
 The Cortex-M33 core can run up to 300 MHz, and the Cortex-M7 core can run up
 to 800 MHz.
 
+ELE Active Timer Requirement
+=============================
+
+The RT1180 platform requires periodic communication with the EdgeLock Enclave (ELE)
+to prevent system reset. According to the RT1180 System Reference Manual (SRM) section
+3.11 "ELE active timer", the ELE must be pinged at least once every 24 hours.
+
+Zephyr implements this requirement using a software timer that automatically pings the
+ELE every 23 hours (instead of 24 hours) to account for potential clock inaccuracies.
+This is transparent to the application and requires no user intervention.
+
+For more details, refer to the RT1180 SRM section 3.11.
+
 ITCM and DTCM
 =============
 

--- a/boards/nxp/mimxrt1180_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1180_evk/doc/index.rst
@@ -128,6 +128,19 @@ The MIMXRT1180 SoC is configured to use SysTick as the system clock source,
 running at 240MHz. When targeting the M7 core, SysTick will also be used,
 running at 792MHz
 
+ELE Active Timer Requirement
+=============================
+
+The RT1180 platform requires periodic communication with the EdgeLock Enclave (ELE)
+to prevent system reset. According to the RT1180 System Reference Manual (SRM) section
+3.11 "ELE active timer", the ELE must be pinged at least once every 24 hours.
+
+Zephyr implements this requirement using a software timer that automatically pings the
+ELE every 23 hours (instead of 24 hours) to account for potential clock inaccuracies.
+This is transparent to the application and requires no user intervention.
+
+For more details, refer to the RT1180 SRM section 3.11.
+
 ITCM and DTCM
 =============
 

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -26,6 +26,57 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
+/*
+ * RT118x ELE requires ping every 24 hours, which is mandatory,
+ * otherwise soc may reset.
+ *
+ * Note:
+ *   1. This is generic rule for all RT118x demos.
+ *   2. We ping ELE every 23 (but not 24) hours, in case of any clock inaccuracy.
+ *   3. This requirement comes from RT1180 SRM section 3.11 "ELE active timer".
+ *      Refer to the SRM for more details.
+ */
+#define ELE_PING_INTERVAL_HOURS 23U
+#define ELE_PING_INTERVAL_MS    (ELE_PING_INTERVAL_HOURS * 60UL * 60UL * 1000UL)
+
+/* Software timer for ELE ping */
+static struct k_timer ele_ping_timer;
+
+/* ELE ping timer callback function */
+static void ele_ping_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	status_t status;
+
+	/* Ping ELE to prevent SOC reset */
+	status = ELE_BaseAPI_Ping(MU_RT_S3MUA);
+
+	if (status == kStatus_Success) {
+		LOG_DBG("ELE ping successful");
+	} else {
+		LOG_ERR("ELE ping failed with status: %d", status);
+	}
+}
+
+/* Initialize ELE ping timer */
+static int ele_ping_timer_init(void)
+{
+	/* Initialize the timer */
+	k_timer_init(&ele_ping_timer, ele_ping_timer_handler, NULL);
+
+	/* Start the periodic timer with 23-hour interval */
+	k_timer_start(&ele_ping_timer, K_MSEC(ELE_PING_INTERVAL_MS),
+		      K_MSEC(ELE_PING_INTERVAL_MS));
+
+	LOG_DBG("ELE ping timer initialized, interval: %u hours", ELE_PING_INTERVAL_HOURS);
+
+	return 0;
+}
+
+/* Initialize ELE ping timer at POST_KERNEL level to ensure kernel services are available */
+SYS_INIT(ele_ping_timer_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_CPU_CORTEX_M33)
 #include <fsl_flexspi_nor_boot.h>
 


### PR DESCRIPTION
The RT1180 platform requires periodic communication with the EdgeLock Enclave (ELE) to prevent system reset. According to RT1180 SRM section 3.11 "ELE active timer", the ELE must be pinged at least once every 24 hours:

- Added ele_ping_timer using k_timer API
- Timer handler calls ELE_BaseAPI_Ping(MU_RT_S3MUA)
- Automatic initialization at POST_KERNEL level via SYS_INIT
- Added debug and error logging for monitoring ping status