### PR TITLE
drivers: nxp: fix SWT unlock wait on MCXE31x

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -239,6 +239,8 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 		CLOCK_EnableClock(kCLOCK_TempSensor);
 		break;
 #endif /* CONFIG_NXP_TEMPSENSE */
+	case MCUX_SIRC_CLK:
+		break;
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/watchdog/wdt_nxp_s32.c
+++ b/drivers/watchdog/wdt_nxp_s32.c
@@ -156,10 +156,10 @@ static int swt_unlock(const struct swt_nxp_s32_config *config)
 		REG_WRITE(SWT_SR, SWT_SR_WSC(SWT_SR_WSC_UNLOCK_KEY1));
 		REG_WRITE(SWT_SR, SWT_SR_WSC(SWT_SR_WSC_UNLOCK_KEY2));
 
-		if (!WAIT_FOR(FIELD_GET(SWT_CR_SLK_MASK, REG_READ(SWT_CR) != 0),
+		if (!WAIT_FOR(FIELD_GET(SWT_CR_SLK_MASK, REG_READ(SWT_CR)) == 0U,
 			      SWT_SOFT_LOCK_TIMEOUT_US, NULL)) {
 
-			LOG_ERR("Timedout while trying to unlock");
+			LOG_ERR("Timed out while trying to unlock");
 			err = -ETIMEDOUT;
 			/* make sure is locked again before we leave */
 			REG_WRITE(SWT_CR, REG_READ(SWT_CR) | SWT_CR_SLK(1U));


### PR DESCRIPTION
Fix two issues seen while validating the SWT watchdog on `frdm_mcxe31b`:

- handle `MCUX_SIRC_CLK` in the mc_cgm clock driver so the SWT device can initialize
- fix the SWT soft-lock unlock polling condition so `wdt_disable()` does not time out after `wdt_setup()`