### PR TITLE
net: ipv6: check on-link prefix before falling back to default router

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -1012,20 +1012,26 @@ bool net_route_get_info(struct net_if *iface,
 
 		ret = true;
 		goto exit;
-	} else {
-		/* No specific route to this host, use the default
-		 * route instead.
-		 */
-		router = net_if_ipv6_router_find_default(NULL, dst);
-		if (!router) {
-			goto exit;
-		}
+	}
 
-		*nexthop = &router->address.in6_addr;
-
-		ret = true;
+	/* Check if destination is on-link on any interface before
+	 * falling back to the default router.
+	 */
+	if (net_if_ipv6_addr_onlink(NULL, dst)) {
 		goto exit;
 	}
+
+	/* No specific route to this host, use the default
+	 * route instead.
+	 */
+	router = net_if_ipv6_router_find_default(NULL, dst);
+	if (router == NULL) {
+		goto exit;
+	}
+
+	*nexthop = &router->address.in6_addr;
+	ret = true;
+	goto exit;
 
 exit:
 	net_ipv6_nbr_unlock();


### PR DESCRIPTION
When routing packets, check if the destination address matches an on-link prefix on any interface before using the default router. This ensures that the packets, destined for on-link prefixes, are not incorrectly sent to the default router.