### PR TITLE
drivers: flash: simulator: fix buggy per-instance erase capability

### DIFF
--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -532,6 +532,14 @@ const struct flash_simulator_params *z_vrfy_flash_simulator_get_params(const str
 #define FLASH_SIMULATOR_PAGE_COUNT(n)                                                              \
 	(FLASH_SIMULATOR_FLASH_SIZE(n) / FLASH_SIMULATOR_ERASE_UNIT(n))
 
+/* Resolve the no_explicit_erase capability per device instance.
+ * DT_INST_PROP for a boolean type is 0 when absent, 1 when set in DTS,
+ * so a logical OR with the Kconfig fallback covers all cases correctly.
+ */
+#define FLASH_SIMULATOR_NO_EXPLICIT_ERASE(n)                                                       \
+	(DT_INST_PROP(n, no_explicit_erase) ||                                                     \
+	 !IS_ENABLED(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE))
+
 #define MOCK_FLASH_SECTION(n)                                                                      \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, memory_region),                                       \
 	(Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_INST_PHANDLE(n, memory_region)))), ())
@@ -553,7 +561,7 @@ const struct flash_simulator_params *z_vrfy_flash_simulator_get_params(const str
 		.write_block_size = FLASH_SIMULATOR_PROG_UNIT(n),                                  \
 		.erase_value = FLASH_SIMULATOR_ERASE_VALUE(n),                                     \
 		.caps = {                                                                          \
-			.no_explicit_erase = !IS_ENABLED(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE),   \
+			.no_explicit_erase = FLASH_SIMULATOR_NO_EXPLICIT_ERASE(n),                 \
 		},                                                                                 \
 	};                                                                                         \
                                                                                                    \

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -16,3 +16,10 @@ properties:
     description: |
       Memory region used by the simulated flash memory. If this option is used
       the memory that is used by the simulated flash memory is not erased.
+  no-explicit-erase:
+    type: boolean
+    description: |
+      When set, this instance behaves as a RAM-like device that does not
+      require explicit erase before write. Overrides the global
+      CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE Kconfig option for this instance,
+      allowing different simulator instances to have different erase modes.

--- a/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
+++ b/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
@@ -452,6 +452,36 @@ ZTEST(flash_sim_api, test_get_erase_value)
 		      FLASH_SIMULATOR_ERASE_VALUE);
 }
 
+ZTEST(flash_sim_api, test_erase_capability)
+{
+	/* Verify that the runtime device capability matches the build configuration.
+	 * This is the test that was missing and resulted in issue #100352 not being caught:
+	 * the driver was incorrectly setting no_explicit_erase for all instances based
+	 * on a global Kconfig rather than per-instance properties.
+	 */
+	const struct flash_parameters *fp = flash_get_parameters(flash_dev);
+	int erase_cap;
+
+	zassert_not_null(fp, "flash_get_parameters() returned NULL");
+
+	erase_cap = flash_params_get_erase_cap(fp);
+
+#if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
+	/* Erase-type (classic Flash) device: must report explicit erase required */
+	zassert_false(fp->caps.no_explicit_erase,
+		      "Device is configured as explicit-erase but caps.no_explicit_erase=true");
+	zassert_equal(FLASH_ERASE_C_EXPLICIT, erase_cap,
+		      "Expected FLASH_ERASE_C_EXPLICIT (0x%x), got 0x%x",
+		      FLASH_ERASE_C_EXPLICIT, erase_cap);
+#else
+	/* RAM-like device: must report no explicit erase required */
+	zassert_true(fp->caps.no_explicit_erase,
+		     "Device is configured as RAM-like but caps.no_explicit_erase=false");
+	zassert_equal(0, erase_cap,
+		      "Expected erase capability 0 for RAM-like device, got 0x%x", erase_cap);
+#endif
+}
+
 ZTEST(flash_sim_api, test_flash_fill)
 {
 	off_t i;


### PR DESCRIPTION
### Description

The `no_explicit_erase` capability in the flash simulator was previously being incorrectly applied for all instances based on the global `CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE` Kconfig option. When boolean Devicetree properties were absent, they were overriding the Kconfig logic with `false`, causing the simulator to report requiring explicit erases even when configured as a RAM-like device.

This PR fixes the issue by:
1. Documenting the `no-explicit-erase` property in the `zephyr,sim-flash` Devicetree bindings, allowing it to act as a proper per-instance override.
2. Introducing a `FLASH_SIMULATOR_NO_EXPLICIT_ERASE` macro that performs a logical OR between the Devicetree property instance and the Kconfig fallback, ensuring correct runtime interpretation.
3. Adding a new `test_erase_capability` test to the flash simulator test suite to verify the runtime capability is correct and prevent future regressions.

### Fixes

- Fixes #100352
- Fixes #100400

### Testing

Built and tested via twister using QEMU x86:
```bash
west twister -p qemu_x86 -T tests/drivers/flash_simulator/flash_sim_impl -v
```
All 3 test configurations passed successfully, including the new `test_erase_capability` check.
