### PR TITLE
[Backport v4.3-branch] net: lib: sockets: tls: Validate addrlen before memcpy

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -678,6 +678,10 @@ static void tls_session_store(struct tls_context *context,
 		return;
 	}
 
+	if (addrlen > sizeof(peer_addr)) {
+		return;
+	}
+
 	memcpy(&peer_addr, addr, addrlen);
 	mbedtls_ssl_session_init(&session);
 
@@ -705,6 +709,10 @@ static void tls_session_restore(struct tls_context *context,
 	int ret;
 
 	if (!context->options.cache_enabled) {
+		return;
+	}
+
+	if (addrlen > sizeof(peer_addr)) {
 		return;
 	}
 


### PR DESCRIPTION
Prevent writing data that is larger than the destination struct's size.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/105038
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104948
(cherry picked from commit bcc4c0bb1e34708515994e4a0227efb2b0804499)