### PR TITLE
soc: infineon: enable DWT unit for PSOC6 devices with Cortex-M4 core

### DIFF
--- a/soc/infineon/cat1a/Kconfig
+++ b/soc/infineon/cat1a/Kconfig
@@ -9,6 +9,7 @@ config SOC_FAMILY_PSOC6
 	select ARM
 	select CPU_CORTEX_M4
 	select CPU_HAS_ARM_MPU
+	select CPU_CORTEX_M_HAS_DWT
 	select DYNAMIC_INTERRUPTS
 	select CPU_HAS_FPU
 	select SOC_FAMILY_INFINEON_CAT1


### PR DESCRIPTION
Add missing Kconfig selection to enable the Data Watch and Trace unit for the PSOC6 family of devices using a Cortex-M4 core.