### PR TITLE
stm32wbax: ble controller and link layer threads initialization change

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -18,6 +18,7 @@
 #include <zephyr/pm/pm.h>
 #include "linklayer_plat.h"
 #include <linklayer_plat_local.h>
+#include <hci_if.h>
 
 #include <zephyr/sys/byteorder.h>
 
@@ -411,6 +412,11 @@ static int bt_hci_stm32wba_open(const struct device *dev, bt_hci_recv_t recv)
 {
 	struct hci_data *data = dev->data;
 	int ret = 0;
+	/* Initialization of the thread dedicated to BLE Host Controller IP */
+	stm32wba_ble_ctlr_thread_init();
+
+	/* Initialization of the thread dedicated to Link Layer Controller IP */
+	stm32wba_ll_ctlr_thread_init();
 
 	if (bt_hci_state == BT_HCI_STATE_CLOSED) {
 #if !defined(CONFIG_IEEE802154_STM32WBA)

--- a/drivers/ieee802154/ieee802154_stm32wba.c
+++ b/drivers/ieee802154/ieee802154_stm32wba.c
@@ -35,6 +35,7 @@
 #endif
 
 #include <linklayer_plat_local.h>
+#include <hci_if.h>
 #include "ieee802154_stm32wba.h"
 #include <stm32wba_802154_intf.h>
 
@@ -684,6 +685,9 @@ static int stm32wba_802154_stop(const struct device *dev)
 static int stm32wba_802154_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	/* Initialization of the thread dedicated to Link Layer Controller IP */
+	stm32wba_ll_ctlr_thread_init();
 
 	k_fifo_init(&stm32wba_802154_data.rx_fifo);
 	k_sem_init(&stm32wba_802154_data.tx_wait, 0, 1);

--- a/soc/st/stm32/stm32wbax/Kconfig
+++ b/soc/st/stm32/stm32wbax/Kconfig
@@ -22,3 +22,39 @@ config SOC_SERIES_STM32WBAX
 	select PM_DEVICE if PM
 	select PM_DEVICE_RUNTIME if PM
 	select PM_DEVICE_SYSTEM_MANAGED if PM
+
+if SOC_SERIES_STM32WBAX
+
+config STM32WBA_LL_THREAD_STACK_SIZE
+	int "Stack size of the Link Layer thread"
+	default 1536
+	depends on BT_STM32WBA || IEEE802154_STM32WBA
+	help
+	  Link Layer thread stack size in bytes.
+
+config STM32WBA_LL_THREAD_PRIO
+	int "Link Layer thread priority"
+	default 4
+	depends on BT_STM32WBA || IEEE802154_STM32WBA
+	help
+	  This option sets the cooperative priority of the Link Layer thread.
+	  The LL thread shall have a higher priority than the BLE CTLR thread and the upper layer
+	  Zephyr stack threads associated to the BLE and IEEE 802.15.4 protocols such as the
+	  BT Rx thread (BT_RX_PRIO), the BT long workqueue (BT_LONG_WQ_PRIO), the net mgmt thread,
+	  the connection manager monitor thread, the udp thread...
+
+config STM32WBA_BLE_CTLR_THREAD_STACK_SIZE
+	int "Stack size of the BLE Controller thread"
+	default 512
+	depends on BT_STM32WBA
+	help
+	  BLE Controller thread stack size in bytes.
+
+config STM32WBA_BLE_CTLR_THREAD_PRIO
+	int "BLE Controller thread priority"
+	depends on BT_STM32WBA
+	default 14
+	help
+	  This option sets the cooperative priority of the BLE Controller thread.
+
+endif # SOC_SERIES_STM32WBAX

--- a/soc/st/stm32/stm32wbax/hci_if/hci_if.h
+++ b/soc/st/stm32/stm32wbax/hci_if/hci_if.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _STM32WBA_HCI_IF_H_
+#define _STM32WBA_HCI_IF_H_
+
+int stm32wba_ll_ctlr_thread_init(void);
+int stm32wba_ble_ctlr_thread_init(void);
+
+#endif /* _STM32WBA_HCI_IF_H_ */

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -14,12 +14,17 @@
 #endif /* CONFIG_BT_STM32WBA */
 #include "ll_intf.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(host_if);
+
 K_MUTEX_DEFINE(ble_ctrl_stack_mutex);
 #if defined(CONFIG_BT_STM32WBA)
-struct k_work_q ble_ctrl_work_q;
-struct k_work ble_ctrl_stack_work, bpka_work;
+static struct k_work_q ble_ctlr_work_q;
+static struct k_work ble_ctlr_stack_work, bpka_work;
+static bool ble_ctlr_work_q_initialized;
 #endif /* CONFIG_BT_STM32WBA */
 struct k_work_q ll_work_q;
+static bool ll_work_q_initialized;
 uint8_t ll_state_busy;
 
 /* TODO: More tests to be done to optimize thread stacks' sizes */
@@ -33,7 +38,7 @@ uint8_t ll_state_busy;
 #define LL_THREAD_PRIO (4)
 
 #if defined(CONFIG_BT_STM32WBA)
-K_THREAD_STACK_DEFINE(ble_ctrl_work_area, BLE_CTRL_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(ble_ctlr_work_area, BLE_CTRL_THREAD_STACK_SIZE);
 #endif /* CONFIG_BT_STM32WBA */
 K_THREAD_STACK_DEFINE(ll_work_area, LL_THREAD_STACK_SIZE);
 
@@ -42,7 +47,7 @@ void HostStack_Process(void);
 #endif /* CONFIG_BT_STM32WBA */
 
 #if defined(CONFIG_BT_STM32WBA)
-static void ble_ctrl_stack_handler(struct k_work *work)
+static void ble_ctlr_stack_handler(struct k_work *work)
 {
 	uint8_t running = 0x00;
 	change_state_options_t options;
@@ -68,40 +73,47 @@ static void bpka_work_handler(struct k_work *work)
 }
 #endif /* CONFIG_BT_STM32WBA */
 
-static int stm32wba_ctrl_init(void)
+int stm32wba_ll_ctlr_thread_init(void)
 {
-	struct k_work_queue_config ll_cfg = {.name = "LL thread"};
+	if (!ll_work_q_initialized) {
+		struct k_work_queue_config ll_cfg = {.name = "LL thread"};
 
+		ll_work_q_initialized = true;
+		k_work_queue_init(&ll_work_q);
+		k_work_queue_start(&ll_work_q, ll_work_area,
+				K_THREAD_STACK_SIZEOF(ll_work_area),
+				LL_THREAD_PRIO, &ll_cfg);
+	}
+	return 0;
+}
+
+int stm32wba_ble_ctlr_thread_init(void)
+{
 #if defined(CONFIG_BT_STM32WBA)
-	struct k_work_queue_config ble_ctrl_cfg = {.name = "ble ctrl thread"};
+	if (!ble_ctlr_work_q_initialized) {
+		struct k_work_queue_config ble_ctlr_cfg = {.name = "ble ctlr thread"};
 
-	k_work_queue_init(&ble_ctrl_work_q);
-	k_work_queue_start(&ble_ctrl_work_q, ble_ctrl_work_area,
-			   K_THREAD_STACK_SIZEOF(ble_ctrl_work_area),
-			   BLE_CTRL_THREAD_PRIO, &ble_ctrl_cfg);
+		ble_ctlr_work_q_initialized = true;
+		k_work_queue_init(&ble_ctlr_work_q);
+		k_work_queue_start(&ble_ctlr_work_q, ble_ctlr_work_area,
+				K_THREAD_STACK_SIZEOF(ble_ctlr_work_area),
+				BLE_CTRL_THREAD_PRIO, &ble_ctlr_cfg);
 
-	k_work_init(&ble_ctrl_stack_work, &ble_ctrl_stack_handler);
-	k_work_init(&bpka_work, &bpka_work_handler);
+		k_work_init(&ble_ctlr_stack_work, &ble_ctlr_stack_handler);
+		k_work_init(&bpka_work, &bpka_work_handler);
+	}
 #endif /* CONFIG_BT_STM32WBA */
-
-	k_work_queue_init(&ll_work_q);
-	k_work_queue_start(&ll_work_q, ll_work_area,
-			   K_THREAD_STACK_SIZEOF(ll_work_area),
-			   LL_THREAD_PRIO, &ll_cfg);
-
 	return 0;
 }
 
 #if defined(CONFIG_BT_STM32WBA)
 void HostStack_Process(void)
 {
-	k_work_submit_to_queue(&ble_ctrl_work_q, &ble_ctrl_stack_work);
+	k_work_submit_to_queue(&ble_ctlr_work_q, &ble_ctlr_stack_work);
 }
 
 void BPKACB_Process(void)
 {
-	k_work_submit_to_queue(&ble_ctrl_work_q, &bpka_work);
+	k_work_submit_to_queue(&ble_ctlr_work_q, &bpka_work);
 }
 #endif /* CONFIG_BT_STM32WBA */
-
-SYS_INIT(stm32wba_ctrl_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -27,20 +27,13 @@ struct k_work_q ll_work_q;
 static bool ll_work_q_initialized;
 uint8_t ll_state_busy;
 
-/* TODO: More tests to be done to optimize thread stacks' sizes */
 #if defined(CONFIG_BT_STM32WBA)
-#define BLE_CTRL_THREAD_STACK_SIZE (256 * 7)
-#define BLE_CTRL_THREAD_PRIO (14)
-#endif /* CONFIG_BT_STM32WBA */
-#define LL_THREAD_STACK_SIZE (256 * 7)
+BUILD_ASSERT(CONFIG_STM32WBA_LL_THREAD_PRIO < CONFIG_STM32WBA_BLE_CTLR_THREAD_PRIO,
+	"priority of the Link Layer thread must be higher than the priority of BLE Ctlr thread");
 
-/* The LL thread has higher priority than the BLE CTRL thread and the Zephyr BLE stack threads */
-#define LL_THREAD_PRIO (4)
-
-#if defined(CONFIG_BT_STM32WBA)
-K_THREAD_STACK_DEFINE(ble_ctlr_work_area, BLE_CTRL_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(ble_ctlr_work_area, CONFIG_STM32WBA_BLE_CTLR_THREAD_STACK_SIZE);
 #endif /* CONFIG_BT_STM32WBA */
-K_THREAD_STACK_DEFINE(ll_work_area, LL_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(ll_work_area, CONFIG_STM32WBA_LL_THREAD_STACK_SIZE);
 
 #if defined(CONFIG_BT_STM32WBA)
 void HostStack_Process(void);
@@ -81,8 +74,9 @@ int stm32wba_ll_ctlr_thread_init(void)
 		ll_work_q_initialized = true;
 		k_work_queue_init(&ll_work_q);
 		k_work_queue_start(&ll_work_q, ll_work_area,
-				K_THREAD_STACK_SIZEOF(ll_work_area),
-				LL_THREAD_PRIO, &ll_cfg);
+				   K_THREAD_STACK_SIZEOF(ll_work_area),
+				   K_PRIO_COOP(CONFIG_STM32WBA_LL_THREAD_PRIO),
+				   &ll_cfg);
 	}
 	return 0;
 }
@@ -96,8 +90,9 @@ int stm32wba_ble_ctlr_thread_init(void)
 		ble_ctlr_work_q_initialized = true;
 		k_work_queue_init(&ble_ctlr_work_q);
 		k_work_queue_start(&ble_ctlr_work_q, ble_ctlr_work_area,
-				K_THREAD_STACK_SIZEOF(ble_ctlr_work_area),
-				BLE_CTRL_THREAD_PRIO, &ble_ctlr_cfg);
+				   K_THREAD_STACK_SIZEOF(ble_ctlr_work_area),
+				   K_PRIO_COOP(CONFIG_STM32WBA_BLE_CTLR_THREAD_PRIO),
+				   &ble_ctlr_cfg);
 
 		k_work_init(&ble_ctlr_stack_work, &ble_ctlr_stack_handler);
 		k_work_init(&bpka_work, &bpka_work_handler);


### PR DESCRIPTION
This PR includes change concerning the initialization of the threads dedicated to the ble controller and the link layer.
Moreover new KConfigs are created to configure the size and the priorities of the ble controller and the link layer threads.

FYI: @asm5878