### PR TITLE
arch: kconfig: ISR_TABLES_LOCAL_DECLARATION depend on IRQ vector table

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -482,6 +482,7 @@ config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
 config ISR_TABLES_LOCAL_DECLARATION
 	bool "ISR tables created locally and placed by linker"
 	depends on ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
+	depends on GEN_IRQ_VECTOR_TABLE
 	help
 	  Enable new scheme of interrupt tables generation.
 	  This is totally different generator that would create tables entries locally


### PR DESCRIPTION
`ISR_TABLES_LOCAL_DECLARATION` depends on `GEN_IRQ_VECTOR_TABLE` but this is not enforced in Kconfig.

Building without the `GEN_IRQ_VECTOR_TABLE` and with `ISR_TABLES_LOCAL_DECLARATION` will produce the following misleading static assertion error:

```
  "CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_{ADDRESS,CODE} not set"
```

As the `ISR_TABLES_LOCAL_DECLARATION` macros expect `GEN_IRQ_VECTOR_TABLE` to be enabled. `ISR_TABLES_LOCAL_DECLARATION` also depends on `GEN_ISR_TABLES` but that is a dependency of `GEN_IRQ_VECTOR_TABLE` already.

Note `GEN_SW_ISR_TABLE` is not required.