### PR TITLE
boards: mt8196: Add 'mt8196/mt8196/adsp' board yml

### DIFF
--- a/boards/mediatek/mt8196/mt8196_mt8196_adsp.yaml
+++ b/boards/mediatek/mt8196/mt8196_mt8196_adsp.yaml
@@ -1,0 +1,11 @@
+identifier: mt8196/mt8196/adsp
+name: Mediatek mt8196 Audio DSP
+type: mcu
+arch: xtensa
+toolchain:
+  - zephyr
+testing:
+  only_tags:
+    - kernel
+    - sof
+vendor: mediatek


### PR DESCRIPTION
The `mt8196/mt8196/adsp` board was missing the board yml file and hence not testable using Twister.