### PR TITLE
west.yml: update hal_stm32 revision for cube wba release 1.9.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 57803da28e985e1cbc32a7ea993578f7267d0935
+      revision: 46e113ade52b2ae8b17b5054e715ec80cec37d9a
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 revision to support stm32wba cube release 1.9.0