### PR TITLE
drivers: watchdog: nxp_fs26: fix watchdog checks

### DIFF
--- a/drivers/watchdog/wdt_nxp_fs26.c
+++ b/drivers/watchdog/wdt_nxp_fs26.c
@@ -98,9 +98,15 @@ static const uint32_t fs26_period_values[] = {
 	0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 64, 128, 256, 512, 1024
 };
 
-static const double fs26_dc_closed_values[] = {
-	0.3125, 0.375, 0.5, 0.625, 0.6875, 0.75, 0.8125
+/*
+ * Duty cycle numerators (denominator is 16).
+ * 5/16=31.25%, 6/16=37.50%, 8/16=50%, 10/16=62.50%,
+ * 11/16=68.75%, 12/16=75%, 13/16=81.25%
+ */
+static const uint8_t fs26_dc_closed_num[] = {
+	5, 6, 8, 10, 11, 12, 13
 };
+#define FS26_DC_DENOM 16
 
 /* CRC lookup table */
 static const uint8_t FS26_CRC_TABLE[FS26_CRC_TABLE_SIZE] = {
@@ -289,7 +295,7 @@ static int fs26_wd_refresh(const struct device *dev)
 	struct fs26_spi_rx_frame rx_frame;
 
 	if (config->wd_type == FS26_WD_SIMPLE) {
-		if (fs26_setreg(&config->spi, FS26_FS_WD_ANSWER, data->token) == 0) {
+		if (fs26_setreg(&config->spi, FS26_FS_WD_ANSWER, data->token)) {
 			LOG_ERR("Failed to write answer");
 			retval = -EIO;
 		}
@@ -503,22 +509,24 @@ static int wdt_nxp_fs26_install_timeout(const struct device *dev,
 	 * Find nearest duty cycle value based on new period, that results in a
 	 * window's minimum near the requested (rounded up)
 	 */
-	for (i = 0; i < ARRAY_SIZE(fs26_dc_closed_values); i++) {
-		window_min = (uint32_t)(fs26_dc_closed_values[i]
-					* fs26_period_values[data->window_period]);
+	for (i = 0; i < ARRAY_SIZE(fs26_dc_closed_num); i++) {
+		window_min = (fs26_dc_closed_num[i]
+				* fs26_period_values[data->window_period])
+				/ FS26_DC_DENOM;
 		if (window_min >= cfg->window.min) {
 			break;
 		}
 	}
-	if (i >= ARRAY_SIZE(fs26_dc_closed_values)) {
+	if (i >= ARRAY_SIZE(fs26_dc_closed_num)) {
 		LOG_ERR("Watchdog opened window too small");
 		return -EINVAL;
 	}
 	data->window_duty_cycle = i;
 
-	LOG_DBG("window.min requested %d ms, using %d ms (%.2f%%)",
+	LOG_DBG("window.min requested %d ms, using %d ms (%d.%02d%%)",
 		cfg->window.min, window_min,
-		fs26_dc_closed_values[data->window_duty_cycle] * 100);
+		fs26_dc_closed_num[data->window_duty_cycle] * 100 / FS26_DC_DENOM,
+		(fs26_dc_closed_num[data->window_duty_cycle] * 10000 / FS26_DC_DENOM) % 100);
 
 	/* Fail-safe reaction configuration */
 	switch (cfg->flags) {

--- a/drivers/watchdog/wdt_nxp_fs26.h
+++ b/drivers/watchdog/wdt_nxp_fs26.h
@@ -24,7 +24,7 @@
 /* Device status flags */
 #define FS26_DEV_STATUS_SHIFT                (24)
 #define FS26_DEV_STATUS_MASK                 (0xff << FS26_DEV_STATUS_SHIFT)
-#define FS26_GET_DEV_STATUS(n)               (((n) << FS26_DEV_STATUS_SHIFT) & FS26_DEV_STATUS_MASK)
+#define FS26_GET_DEV_STATUS(n)               (((n) & FS26_DEV_STATUS_MASK) >> FS26_DEV_STATUS_SHIFT)
 /* Main State machine availability (M_AVAL) */
 #define FS26_M_AVAL                          (0x1 << 31)
 /* Fail Safe State machine status (FS_EN) */
@@ -273,7 +273,8 @@
 #define WD_ERR_CNT_SHIFT                     (0)
 #define WD_ERR_CNT_MASK                      (0xf << WD_ERR_CNT_SHIFT)
 #define WD_ERR_CNT(n)                        \
-	(((n) & (0x7 << WD_RFR_CNT_SHIFT)) > 11) ? (11) : (((n) & (0x7 << WD_RFR_CNT_SHIFT)))
+	((((n) & WD_ERR_CNT_MASK) >> WD_ERR_CNT_SHIFT) > 11U) ? \
+		(11U) : ((((n) & WD_ERR_CNT_MASK) >> WD_ERR_CNT_SHIFT))
 
 /* FS26_FS_I_SAFE_INPUTS register */
 
@@ -338,8 +339,8 @@
 
 /* Reaction on RSTB or Fail Safe output in case of fault detection on ERRMON */
 #define ERRMON_FS_REACTION_SHIFT             (2)
-#define ERRMON_FS_REACTION_MASK              (0x1 << FCCU2_FS_REACTION_SHIFT)
-#define ERRMON_FS_REACTION                   (FCCU2_FS_REACTION_MASK)
+#define ERRMON_FS_REACTION_MASK              (0x1 << ERRMON_FS_REACTION_SHIFT)
+#define ERRMON_FS_REACTION                   (ERRMON_FS_REACTION_MASK)
 
 /* FCCU pin filtering time settings */
 #define FCCU12_FILT_SHIFT                    (0)
@@ -396,7 +397,8 @@
 #define FLT_ERR_CNT_SHIFT                    (0)
 #define FLT_ERR_CNT_MASK                     (0xf << FLT_ERR_CNT_SHIFT)
 #define FLT_ERR_CNT(n)                       \
-	((n & (0x7 << FLT_ERR_CNT_SHIFT)) > 12) ? (12) : ((n & (0x7 << FLT_ERR_CNT_SHIFT)))
+	((((n) & FLT_ERR_CNT_MASK) >> FLT_ERR_CNT_SHIFT) > 12U) ? \
+		(12U) : ((((n) & FLT_ERR_CNT_MASK) >> FLT_ERR_CNT_SHIFT))
 
 /* FS26_FS_WDW_DURATION register */
 
@@ -423,11 +425,11 @@
 /* Watchdog window duty cycle */
 #define WDW_DC_SHIFT                         (6)
 #define WDW_DC_MASK                          (0x7 << WDW_DC_SHIFT)
-#define WDW_DC_31_68                         (0x0 << WDW_PERIOD_SHIFT)
-#define WDW_DC_37_62                         (0x1 << WDW_PERIOD_SHIFT)
-#define WDW_DC_50_50                         (0x2 << WDW_PERIOD_SHIFT)
-#define WDW_DC_62_37                         (0x3 << WDW_PERIOD_SHIFT)
-#define WDW_DC_68_31                         (0x4 << WDW_PERIOD_SHIFT)
+#define WDW_DC_31_68                         (0x0 << WDW_DC_SHIFT)
+#define WDW_DC_37_62                         (0x1 << WDW_DC_SHIFT)
+#define WDW_DC_50_50                         (0x2 << WDW_DC_SHIFT)
+#define WDW_DC_62_37                         (0x3 << WDW_DC_SHIFT)
+#define WDW_DC_68_31                         (0x4 << WDW_DC_SHIFT)
 
 /* Watchdog window period */
 #define WDW_RECOVERY_SHIFT                   (0)


### PR DESCRIPTION
Fix broken FS26 watchdog field extraction and refresh checks.

Correct the device status macro, simple watchdog write error handling, related register field helper macros, and use integer duty-cycle values when selecting the watchdog window.