### PR TITLE
Add support for SPI DMA to display controller drivers st7789 & ili9xxx on STM32 platforms with dcache

### DIFF
--- a/drivers/display/display_ili9340.c
+++ b/drivers/display/display_ili9340.c
@@ -14,68 +14,69 @@ int ili9340_regs_init(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
 	const struct ili9340_regs *regs = config->regs;
-
+	uint8_t *buf_nocache = config->nocache_buf;
 	int r;
 
 	LOG_HEXDUMP_DBG(regs->gamset, ILI9340_GAMSET_LEN, "GAMSET");
-	r = ili9xxx_transmit(dev, ILI9340_GAMSET, regs->gamset,
+	memcpy(buf_nocache, regs->gamset, ILI9340_GAMSET_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_GAMSET, buf_nocache, ILI9340_GAMSET_LEN);
 			     ILI9340_GAMSET_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->frmctr1, ILI9340_FRMCTR1_LEN, "FRMCTR1");
-	r = ili9xxx_transmit(dev, ILI9340_FRMCTR1, regs->frmctr1,
-			     ILI9340_FRMCTR1_LEN);
+	memcpy(buf_nocache, regs->frmctr1, ILI9340_FRMCTR1_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_FRMCTR1, buf_nocache, ILI9340_FRMCTR1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->disctrl, ILI9340_DISCTRL_LEN, "DISCTRL");
-	r = ili9xxx_transmit(dev, ILI9340_DISCTRL, regs->disctrl,
-			     ILI9340_DISCTRL_LEN);
+	memcpy(buf_nocache, regs->disctrl, ILI9340_DISCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_DISCTRL, buf_nocache, ILI9340_DISCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl1, ILI9340_PWCTRL1_LEN, "PWCTRL1");
-	r = ili9xxx_transmit(dev, ILI9340_PWCTRL1, regs->pwctrl1,
-			     ILI9340_PWCTRL1_LEN);
+	memcpy(buf_nocache, regs->pwctrl1, ILI9340_PWCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_PWCTRL1, buf_nocache, ILI9340_PWCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl2, ILI9340_PWCTRL2_LEN, "PWCTRL2");
-	r = ili9xxx_transmit(dev, ILI9340_PWCTRL2, regs->pwctrl2,
-			     ILI9340_PWCTRL2_LEN);
+	memcpy(buf_nocache, regs->pwctrl2, ILI9340_PWCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_PWCTRL2, buf_nocache, ILI9340_PWCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl1, ILI9340_VMCTRL1_LEN, "VMCTRL1");
-	r = ili9xxx_transmit(dev, ILI9340_VMCTRL1, regs->vmctrl1,
-			     ILI9340_VMCTRL1_LEN);
+	memcpy(buf_nocache, regs->vmctrl1, ILI9340_VMCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_VMCTRL1, buf_nocache, ILI9340_VMCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl2, ILI9340_VMCTRL2_LEN, "VMCTRL2");
-	r = ili9xxx_transmit(dev, ILI9340_VMCTRL2, regs->vmctrl2,
-			     ILI9340_VMCTRL2_LEN);
+	memcpy(buf_nocache, regs->vmctrl2, ILI9340_VMCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_VMCTRL2, buf_nocache, ILI9340_VMCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pgamctrl, ILI9340_PGAMCTRL_LEN, "PGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9340_PGAMCTRL, regs->pgamctrl,
-			     ILI9340_PGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->pgamctrl, ILI9340_PGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_PGAMCTRL, buf_nocache, ILI9340_PGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ngamctrl, ILI9340_NGAMCTRL_LEN, "NGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9340_NGAMCTRL, regs->ngamctrl,
-			     ILI9340_NGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->ngamctrl, ILI9340_NGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9340_NGAMCTRL, buf_nocache, ILI9340_NGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}

--- a/drivers/display/display_ili9341.c
+++ b/drivers/display/display_ili9341.c
@@ -16,120 +16,138 @@ int ili9341_regs_init(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
 	const struct ili9341_regs *regs = config->regs;
-
+	uint8_t *buf_nocache = config->nocache_buf;
 	int r;
 
 	LOG_HEXDUMP_DBG(regs->pwseqctrl, ILI9341_PWSEQCTRL_LEN, "PWSEQCTRL");
-	r = ili9xxx_transmit(dev, ILI9341_PWSEQCTRL, regs->pwseqctrl, ILI9341_PWSEQCTRL_LEN);
+	memcpy(buf_nocache, regs->pwseqctrl, ILI9341_PWSEQCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PWSEQCTRL, buf_nocache, ILI9341_PWSEQCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->timctrla, ILI9341_TIMCTRLA_LEN, "TIMCTRLA");
-	r = ili9xxx_transmit(dev, ILI9341_TIMCTRLA, regs->timctrla, ILI9341_TIMCTRLA_LEN);
+	memcpy(buf_nocache, regs->timctrla, ILI9341_TIMCTRLA_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_TIMCTRLA, buf_nocache, ILI9341_TIMCTRLA_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->timctrlb, ILI9341_TIMCTRLB_LEN, "TIMCTRLB");
-	r = ili9xxx_transmit(dev, ILI9341_TIMCTRLB, regs->timctrlb, ILI9341_TIMCTRLB_LEN);
+	memcpy(buf_nocache, regs->timctrlb, ILI9341_TIMCTRLB_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_TIMCTRLB, buf_nocache, ILI9341_TIMCTRLB_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pumpratioctrl, ILI9341_PUMPRATIOCTRL_LEN, "PUMPRATIOCTRL");
-	r = ili9xxx_transmit(dev, ILI9341_PUMPRATIOCTRL, regs->pumpratioctrl,
-			     ILI9341_PUMPRATIOCTRL_LEN);
+	memcpy(buf_nocache, regs->pumpratioctrl, ILI9341_PUMPRATIOCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PUMPRATIOCTRL, buf_nocache, ILI9341_PUMPRATIOCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrla, ILI9341_PWCTRLA_LEN, "PWCTRLA");
-	r = ili9xxx_transmit(dev, ILI9341_PWCTRLA, regs->pwctrla, ILI9341_PWCTRLA_LEN);
+	memcpy(buf_nocache, regs->pwctrla, ILI9341_PWCTRLA_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PWCTRLA, buf_nocache, ILI9341_PWCTRLA_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrlb, ILI9341_PWCTRLB_LEN, "PWCTRLB");
-	r = ili9xxx_transmit(dev, ILI9341_PWCTRLB, regs->pwctrlb, ILI9341_PWCTRLB_LEN);
+	memcpy(buf_nocache, regs->pwctrlb, ILI9341_PWCTRLB_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PWCTRLB, buf_nocache, ILI9341_PWCTRLB_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->gamset, ILI9341_GAMSET_LEN, "GAMSET");
-	r = ili9xxx_transmit(dev, ILI9341_GAMSET, regs->gamset, ILI9341_GAMSET_LEN);
+	memcpy(buf_nocache, regs->gamset, ILI9341_GAMSET_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_GAMSET, buf_nocache, ILI9341_GAMSET_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->frmctr1, ILI9341_FRMCTR1_LEN, "FRMCTR1");
-	r = ili9xxx_transmit(dev, ILI9341_FRMCTR1, regs->frmctr1, ILI9341_FRMCTR1_LEN);
+	memcpy(buf_nocache, regs->frmctr1, ILI9341_FRMCTR1_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_FRMCTR1, buf_nocache, ILI9341_FRMCTR1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->disctrl, ILI9341_DISCTRL_LEN, "DISCTRL");
-	r = ili9xxx_transmit(dev, ILI9341_DISCTRL, regs->disctrl, ILI9341_DISCTRL_LEN);
+	memcpy(buf_nocache, regs->disctrl, ILI9341_DISCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_DISCTRL, buf_nocache, ILI9341_DISCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl1, ILI9341_PWCTRL1_LEN, "PWCTRL1");
-	r = ili9xxx_transmit(dev, ILI9341_PWCTRL1, regs->pwctrl1, ILI9341_PWCTRL1_LEN);
+	memcpy(buf_nocache, regs->pwctrl1, ILI9341_PWCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PWCTRL1, buf_nocache, ILI9341_PWCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl2, ILI9341_PWCTRL2_LEN, "PWCTRL2");
-	r = ili9xxx_transmit(dev, ILI9341_PWCTRL2, regs->pwctrl2, ILI9341_PWCTRL2_LEN);
+	memcpy(buf_nocache, regs->pwctrl2, ILI9341_PWCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PWCTRL2, buf_nocache, ILI9341_PWCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl1, ILI9341_VMCTRL1_LEN, "VMCTRL1");
-	r = ili9xxx_transmit(dev, ILI9341_VMCTRL1, regs->vmctrl1, ILI9341_VMCTRL1_LEN);
+	memcpy(buf_nocache, regs->vmctrl1, ILI9341_VMCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_VMCTRL1, buf_nocache, ILI9341_VMCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl2, ILI9341_VMCTRL2_LEN, "VMCTRL2");
-	r = ili9xxx_transmit(dev, ILI9341_VMCTRL2, regs->vmctrl2, ILI9341_VMCTRL2_LEN);
+	memcpy(buf_nocache, regs->vmctrl2, ILI9341_VMCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_VMCTRL2, buf_nocache, ILI9341_VMCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pgamctrl, ILI9341_PGAMCTRL_LEN, "PGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9341_PGAMCTRL, regs->pgamctrl, ILI9341_PGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->pgamctrl, ILI9341_PGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_PGAMCTRL, buf_nocache, ILI9341_PGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ngamctrl, ILI9341_NGAMCTRL_LEN, "NGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9341_NGAMCTRL, regs->ngamctrl, ILI9341_NGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->ngamctrl, ILI9341_NGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_NGAMCTRL, buf_nocache, ILI9341_NGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->enable3g, ILI9341_ENABLE3G_LEN, "ENABLE3G");
-	r = ili9xxx_transmit(dev, ILI9341_ENABLE3G, regs->enable3g, ILI9341_ENABLE3G_LEN);
+	memcpy(buf_nocache, regs->enable3g, ILI9341_ENABLE3G_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_ENABLE3G, buf_nocache, ILI9341_ENABLE3G_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ifmode, ILI9341_IFMODE_LEN, "IFMODE");
-	r = ili9xxx_transmit(dev, ILI9341_IFMODE, regs->ifmode, ILI9341_IFMODE_LEN);
+	memcpy(buf_nocache, regs->ifmode, ILI9341_IFMODE_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_IFMODE, buf_nocache, ILI9341_IFMODE_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ifctl, ILI9341_IFCTL_LEN, "IFCTL");
-	r = ili9xxx_transmit(dev, ILI9341_IFCTL, regs->ifctl, ILI9341_IFCTL_LEN);
+	memcpy(buf_nocache, regs->ifctl, ILI9341_IFCTL_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_IFCTL, buf_nocache, ILI9341_IFCTL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->etmod, ILI9341_ETMOD_LEN, "ETMOD");
-	r = ili9xxx_transmit(dev, ILI9341_ETMOD, regs->etmod, ILI9341_ETMOD_LEN);
+	memcpy(buf_nocache, regs->etmod, ILI9341_ETMOD_LEN);
+	r = ili9xxx_transmit(dev, ILI9341_ETMOD, buf_nocache, ILI9341_ETMOD_LEN);
 	if (r < 0) {
 		return r;
 	}

--- a/drivers/display/display_ili9342c.c
+++ b/drivers/display/display_ili9342c.c
@@ -17,103 +17,104 @@ int ili9342c_regs_init(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
 	const struct ili9342c_regs *regs = config->regs;
+	uint8_t *buf_nocache = config->nocache_buf;
 	int r;
 
 	/*  some commands require that SETEXTC be set first before it becomes enabled. */
 	LOG_HEXDUMP_DBG(regs->setextc, ILI9342C_SETEXTC_LEN, "SETEXTC");
-	r = ili9xxx_transmit(dev, ILI9342C_SETEXTC, regs->setextc,
-			     ILI9342C_SETEXTC_LEN);
+	memcpy(buf_nocache, regs->setextc, ILI9342C_SETEXTC_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_SETEXTC, buf_nocache, ILI9342C_SETEXTC_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->gamset, ILI9342C_GAMSET_LEN, "GAMSET");
-	r = ili9xxx_transmit(dev, ILI9342C_GAMSET, regs->gamset,
-			     ILI9342C_GAMSET_LEN);
+	memcpy(buf_nocache, regs->gamset, ILI9342C_GAMSET_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_GAMSET, buf_nocache, ILI9342C_GAMSET_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ifmode, ILI9342C_IFMODE_LEN, "IFMODE");
-	r = ili9xxx_transmit(dev, ILI9342C_IFMODE, regs->ifmode,
-			     ILI9342C_IFMODE_LEN);
+	memcpy(buf_nocache, regs->ifmode, ILI9342C_IFMODE_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_IFMODE, buf_nocache, ILI9342C_IFMODE_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->frmctr1, ILI9342C_FRMCTR1_LEN, "FRMCTR1");
-	r = ili9xxx_transmit(dev, ILI9342C_FRMCTR1, regs->frmctr1,
-			     ILI9342C_FRMCTR1_LEN);
+	memcpy(buf_nocache, regs->frmctr1, ILI9342C_FRMCTR1_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_FRMCTR1, buf_nocache, ILI9342C_FRMCTR1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->invtr, ILI9342C_INVTR_LEN, "INVTR");
-	r = ili9xxx_transmit(dev, ILI9342C_INVTR, regs->invtr,
-			     ILI9342C_INVTR_LEN);
+	memcpy(buf_nocache, regs->invtr, ILI9342C_INVTR_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_INVTR, buf_nocache, ILI9342C_INVTR_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->disctrl, ILI9342C_DISCTRL_LEN, "DISCTRL");
-	r = ili9xxx_transmit(dev, ILI9342C_DISCTRL, regs->disctrl,
-			     ILI9342C_DISCTRL_LEN);
+	memcpy(buf_nocache, regs->disctrl, ILI9342C_DISCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_DISCTRL, buf_nocache, ILI9342C_DISCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->etmod, ILI9342C_ETMOD_LEN, "ETMOD");
-	r = ili9xxx_transmit(dev, ILI9342C_ETMOD, regs->etmod,
-			     ILI9342C_ETMOD_LEN);
+	memcpy(buf_nocache, regs->etmod, ILI9342C_ETMOD_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_ETMOD, buf_nocache, ILI9342C_ETMOD_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl1, ILI9342C_PWCTRL1_LEN, "PWCTRL1");
-	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL1, regs->pwctrl1,
-			     ILI9342C_PWCTRL1_LEN);
+	memcpy(buf_nocache, regs->pwctrl1, ILI9342C_PWCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL1, buf_nocache, ILI9342C_PWCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl2, ILI9342C_PWCTRL2_LEN, "PWCTRL2");
-	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL2, regs->pwctrl2,
-			     ILI9342C_PWCTRL2_LEN);
+	memcpy(buf_nocache, regs->pwctrl2, ILI9342C_PWCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL2, buf_nocache, ILI9342C_PWCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl3, ILI9342C_PWCTRL3_LEN, "PWCTRL3");
-	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL3, regs->pwctrl3,
-			     ILI9342C_PWCTRL3_LEN);
+	memcpy(buf_nocache, regs->pwctrl3, ILI9342C_PWCTRL3_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_PWCTRL3, buf_nocache, ILI9342C_PWCTRL3_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl1, ILI9342C_VMCTRL1_LEN, "VMCTRL1");
-	r = ili9xxx_transmit(dev, ILI9342C_VMCTRL1, regs->vmctrl1,
-			     ILI9342C_VMCTRL1_LEN);
+	memcpy(buf_nocache, regs->vmctrl1, ILI9342C_VMCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_VMCTRL1, buf_nocache, ILI9342C_VMCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pgamctrl, ILI9342C_PGAMCTRL_LEN, "PGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9342C_PGAMCTRL, regs->pgamctrl,
-			     ILI9342C_PGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->pgamctrl, ILI9342C_PGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_PGAMCTRL, buf_nocache, ILI9342C_PGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ngamctrl, ILI9342C_NGAMCTRL_LEN, "NGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9342C_NGAMCTRL, regs->ngamctrl,
-			     ILI9342C_NGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->ngamctrl, ILI9342C_NGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_NGAMCTRL, buf_nocache, ILI9342C_NGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ifctl, ILI9342C_IFCTL_LEN, "IFCTL");
-	r = ili9xxx_transmit(dev, ILI9342C_IFCTL, regs->ifctl,
-			     ILI9342C_IFCTL_LEN);
+	memcpy(buf_nocache, regs->ifctl, ILI9342C_IFCTL_LEN);
+	r = ili9xxx_transmit(dev, ILI9342C_IFCTL, buf_nocache, ILI9342C_IFCTL_LEN);
 	if (r < 0) {
 		return r;
 	}

--- a/drivers/display/display_ili9488.c
+++ b/drivers/display/display_ili9488.c
@@ -14,54 +14,54 @@ int ili9488_regs_init(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
 	const struct ili9488_regs *regs = config->regs;
-
+	uint8_t *buf_nocache = config->nocache_buf;
 	int r;
 
 	LOG_HEXDUMP_DBG(regs->frmctr1, ILI9488_FRMCTR1_LEN, "FRMCTR1");
-	r = ili9xxx_transmit(dev, ILI9488_FRMCTR1, regs->frmctr1,
-			     ILI9488_FRMCTR1_LEN);
+	memcpy(buf_nocache, regs->frmctr1, ILI9488_FRMCTR1_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_FRMCTR1, buf_nocache, ILI9488_FRMCTR1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->disctrl, ILI9488_DISCTRL_LEN, "DISCTRL");
-	r = ili9xxx_transmit(dev, ILI9488_DISCTRL, regs->disctrl,
-			     ILI9488_DISCTRL_LEN);
+	memcpy(buf_nocache, regs->disctrl, ILI9488_DISCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_DISCTRL, buf_nocache, ILI9488_DISCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl1, ILI9488_PWCTRL1_LEN, "PWCTRL1");
-	r = ili9xxx_transmit(dev, ILI9488_PWCTRL1, regs->pwctrl1,
-			     ILI9488_PWCTRL1_LEN);
+	memcpy(buf_nocache, regs->pwctrl1, ILI9488_PWCTRL1_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_PWCTRL1, buf_nocache, ILI9488_PWCTRL1_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pwctrl2, ILI9488_PWCTRL2_LEN, "PWCTRL2");
-	r = ili9xxx_transmit(dev, ILI9488_PWCTRL2, regs->pwctrl2,
-			     ILI9488_PWCTRL2_LEN);
+	memcpy(buf_nocache, regs->pwctrl2, ILI9488_PWCTRL2_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_PWCTRL2, buf_nocache, ILI9488_PWCTRL2_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->vmctrl, ILI9488_VMCTRL_LEN, "VMCTRL");
-	r = ili9xxx_transmit(dev, ILI9488_VMCTRL, regs->vmctrl,
-			     ILI9488_VMCTRL_LEN);
+	memcpy(buf_nocache, regs->vmctrl, ILI9488_VMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_VMCTRL, buf_nocache, ILI9488_VMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->pgamctrl, ILI9488_PGAMCTRL_LEN, "PGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9488_PGAMCTRL, regs->pgamctrl,
-			     ILI9488_PGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->pgamctrl, ILI9488_PGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_PGAMCTRL, buf_nocache, ILI9488_PGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}
 
 	LOG_HEXDUMP_DBG(regs->ngamctrl, ILI9488_NGAMCTRL_LEN, "NGAMCTRL");
-	r = ili9xxx_transmit(dev, ILI9488_NGAMCTRL, regs->ngamctrl,
-			     ILI9488_NGAMCTRL_LEN);
+	memcpy(buf_nocache, regs->ngamctrl, ILI9488_NGAMCTRL_LEN);
+	r = ili9xxx_transmit(dev, ILI9488_NGAMCTRL, buf_nocache, ILI9488_NGAMCTRL_LEN);
 	if (r < 0) {
 		return r;
 	}

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -100,19 +100,20 @@ static int ili9xxx_set_mem_area(const struct device *dev, const uint16_t x,
 				const uint16_t y, const uint16_t w,
 				const uint16_t h)
 {
+	const struct ili9xxx_config *config = dev->config;
+	uint8_t *buf_nocache = config->nocache_buf;
 	int r;
-	uint16_t spi_data[2];
 
-	spi_data[0] = sys_cpu_to_be16(x);
-	spi_data[1] = sys_cpu_to_be16(x + w - 1U);
-	r = ili9xxx_transmit(dev, ILI9XXX_CASET, &spi_data[0], 4U);
+	((uint16_t*)buf_nocache)[0] = sys_cpu_to_be16(x);
+	((uint16_t*)buf_nocache)[1] = sys_cpu_to_be16(x + w - 1U);
+	r = ili9xxx_transmit(dev, ILI9XXX_CASET, buf_nocache, 4U);
 	if (r < 0) {
 		return r;
 	}
 
-	spi_data[0] = sys_cpu_to_be16(y);
-	spi_data[1] = sys_cpu_to_be16(y + h - 1U);
-	r = ili9xxx_transmit(dev, ILI9XXX_PASET, &spi_data[0], 4U);
+	((uint16_t*)buf_nocache)[0] = sys_cpu_to_be16(y);
+	((uint16_t*)buf_nocache)[1] = sys_cpu_to_be16(y + h - 1U);
+	r = ili9xxx_transmit(dev, ILI9XXX_PASET, buf_nocache, 4U);
 	if (r < 0) {
 		return r;
 	}
@@ -288,24 +289,25 @@ static int
 ili9xxx_set_pixel_format(const struct device *dev,
 			 const enum display_pixel_format pixel_format)
 {
+	const struct ili9xxx_config *config = dev->config;
 	struct ili9xxx_data *data = dev->data;
+	uint8_t *buf_nocache = config->nocache_buf;
 
 	int r;
-	uint8_t tx_data;
 	uint8_t bytes_per_pixel;
 
 	if (pixel_format == PIXEL_FORMAT_RGB_565  || pixel_format == PIXEL_FORMAT_RGB_565X) {
 		bytes_per_pixel = 2U;
-		tx_data = ILI9XXX_PIXSET_MCU_16_BIT | ILI9XXX_PIXSET_RGB_16_BIT;
+		buf_nocache[0] = ILI9XXX_PIXSET_MCU_16_BIT | ILI9XXX_PIXSET_RGB_16_BIT;
 	} else if (pixel_format == PIXEL_FORMAT_RGB_888) {
 		bytes_per_pixel = 3U;
-		tx_data = ILI9XXX_PIXSET_MCU_18_BIT | ILI9XXX_PIXSET_RGB_18_BIT;
+		buf_nocache[0] = ILI9XXX_PIXSET_MCU_18_BIT | ILI9XXX_PIXSET_RGB_18_BIT;
 	} else {
 		LOG_ERR("Unsupported pixel format");
 		return -ENOTSUP;
 	}
 
-	r = ili9xxx_transmit(dev, ILI9XXX_PIXSET, &tx_data, 1U);
+	r = ili9xxx_transmit(dev, ILI9XXX_PIXSET, buf_nocache, 1U);
 	if (r < 0) {
 		return r;
 	}
@@ -321,35 +323,36 @@ static int ili9xxx_set_orientation(const struct device *dev,
 {
 	const struct ili9xxx_config *config = dev->config;
 	struct ili9xxx_data *data = dev->data;
+	uint8_t *buf_nocache = config->nocache_buf;
 
 	int r;
-	uint8_t tx_data = data->pixel_format == PIXEL_FORMAT_RGB_565X
+	buf_nocache[0] = data->pixel_format == PIXEL_FORMAT_RGB_565X
 			? ILI9XXX_MADCTL_BGR : 0;
 	if (config->quirks->cmd_set == CMD_SET_1) {
 		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			tx_data |= ILI9XXX_MADCTL_MX;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MX;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9XXX_MADCTL_MV;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MV;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_ML;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_ML;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX |
-				   ILI9XXX_MADCTL_MY;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX |
+					   ILI9XXX_MADCTL_MY;
 		}
 	} else if (config->quirks->cmd_set == CMD_SET_2) {
 		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
 			/* Do nothing */
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_MX |
-				   ILI9XXX_MADCTL_ML;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_MX |
+					   ILI9XXX_MADCTL_ML;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
+			buf_nocache[0] |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
 		}
 	}
 
-	r = ili9xxx_transmit(dev, ILI9XXX_MADCTL, &tx_data, 1U);
+	r = ili9xxx_transmit(dev, ILI9XXX_MADCTL, buf_nocache, 1U);
 	if (r < 0) {
 		return r;
 	}
@@ -386,6 +389,7 @@ static void ili9xxx_get_capabilities(const struct device *dev,
 static int ili9xxx_configure(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
+	uint8_t *buf_nocache = config->nocache_buf;
 
 	int r;
 	enum display_pixel_format pixel_format;
@@ -436,9 +440,9 @@ static int ili9xxx_configure(const struct device *dev)
 		r = mipi_dbi_configure_te(config->mipi_dev, config->te_mode, 0);
 		if (r == 0) {
 			/* TE was enabled, send TEON, and enable vblank only */
-			const uint8_t tx_data = 0x0; /* Set M bit to 0 */
+			buf_nocache[0] = 0x0; /* Set M bit to 0 */
 
-			r = ili9xxx_transmit(dev, ILI9XXX_TEON, &tx_data, 1U);
+			r = ili9xxx_transmit(dev, ILI9XXX_TEON, buf_nocache, 1U);
 			if (r < 0) {
 				return r;
 			}
@@ -537,9 +541,12 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 #define ILI9XXX_INIT(n, t)                                                     \
 	ILI##t##_REGS_INIT(n);                                                 \
 									       \
+	static uint8_t ili9##t##_nocache_buf_##n[16] __aligned(4) __nocache;   \
+									       \
 	static const struct ili9xxx_config ili9##t##_config_##n = {            \
 		.quirks = &ili##t##_quirks,                                    \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(INST_DT_ILI9XXX(n, t))),   \
+		.nocache_buf = ili9##t##_nocache_buf_##n,                      \
 		.dbi_config = {                                                \
 			.mode = DT_STRING_UPPER_TOKEN_OR(                      \
 				INST_DT_ILI9XXX(n, t),                         \

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -70,6 +70,7 @@ struct ili9xxx_config {
 	const struct ili9xxx_quirks *quirks;
 	const struct device *mipi_dev;
 	struct mipi_dbi_config dbi_config;
+	uint8_t *nocache_buf;
 	uint8_t pixel_format;
 	uint16_t rotation;
 	uint16_t x_resolution;

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(display_st7789v);
 struct st7789v_config {
 	const struct device *mipi_dbi;
 	const struct mipi_dbi_config dbi_config;
+	uint8_t *nocache_buf;
 	uint8_t vcom;
 	uint8_t gctrl;
 	bool vdv_vrh_enable;
@@ -126,24 +127,24 @@ static int st7789v_blanking_off(const struct device *dev)
 static int st7789v_set_mem_area(const struct device *dev, const uint16_t x,
 				 const uint16_t y, const uint16_t w, const uint16_t h)
 {
+	const struct st7789v_config *config = dev->config;
 	struct st7789v_data *data = dev->data;
-	uint16_t spi_data[2];
 
 	uint16_t ram_x = x + data->x_offset;
 	uint16_t ram_y = y + data->y_offset;
-
+	uint8_t *buf_nocache = config->nocache_buf;
 	int ret;
 
-	spi_data[0] = sys_cpu_to_be16(ram_x);
-	spi_data[1] = sys_cpu_to_be16(ram_x + w - 1);
-	ret = st7789v_transmit(dev, ST7789V_CMD_CASET, (uint8_t *)&spi_data[0], 4);
+	((uint16_t*)buf_nocache)[0] = sys_cpu_to_be16(ram_x);
+	((uint16_t*)buf_nocache)[1] = sys_cpu_to_be16(ram_x + w - 1);
+	ret = st7789v_transmit(dev, ST7789V_CMD_CASET, (uint8_t *)buf_nocache, 4);
 	if (ret < 0) {
 		return ret;
 	}
 
-	spi_data[0] = sys_cpu_to_be16(ram_y);
-	spi_data[1] = sys_cpu_to_be16(ram_y + h - 1);
-	return st7789v_transmit(dev, ST7789V_CMD_RASET, (uint8_t *)&spi_data[0], 4);
+	((uint16_t*)buf_nocache)[0] = sys_cpu_to_be16(ram_y);
+	((uint16_t*)buf_nocache)[1] = sys_cpu_to_be16(ram_y + h - 1);
+	return st7789v_transmit(dev, ST7789V_CMD_RASET, (uint8_t *)buf_nocache, 4);
 }
 
 static int st7789v_write(const struct device *dev,
@@ -265,101 +266,97 @@ static int st7789v_lcd_init(const struct device *dev)
 {
 	struct st7789v_data *data = dev->data;
 	const struct st7789v_config *config = dev->config;
-	uint8_t tmp;
+	uint8_t *buf_nocache = config->nocache_buf;
 	int ret;
 
-	st7789v_set_lcd_margins(dev, data->x_offset,
-				data->y_offset);
+	st7789v_set_lcd_margins(dev, data->x_offset, data->y_offset);
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_CMD2EN,
-			       (uint8_t *)config->cmd2en_param,
-			       sizeof(config->cmd2en_param));
+	memcpy(buf_nocache, config->cmd2en_param, sizeof(config->cmd2en_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_CMD2EN, buf_nocache, sizeof(config->cmd2en_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PORCTRL,
-			       (uint8_t *)config->porch_param,
-			       sizeof(config->porch_param));
+	memcpy(buf_nocache, config->porch_param, sizeof(config->porch_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_PORCTRL, buf_nocache, sizeof(config->porch_param));
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Digital Gamma Enable, default disabled */
-	tmp = 0x00;
-	ret = st7789v_transmit(dev, ST7789V_CMD_DGMEN, &tmp, 1);
+	buf_nocache[0] = 0x00;
+	ret = st7789v_transmit(dev, ST7789V_CMD_DGMEN, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Frame Rate Control in Normal Mode, default value */
-	tmp = 0x0f;
-	ret = st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, &tmp, 1);
+	buf_nocache[0] = 0x0f;
+	ret = st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->gctrl;
-	ret = st7789v_transmit(dev, ST7789V_CMD_GCTRL, &tmp, 1);
+	buf_nocache[0] = config->gctrl;
+	ret = st7789v_transmit(dev, ST7789V_CMD_GCTRL, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->vcom;
-	ret = st7789v_transmit(dev, ST7789V_CMD_VCOMS, &tmp, 1);
+	buf_nocache[0] = config->vcom;
+	ret = st7789v_transmit(dev, ST7789V_CMD_VCOMS, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
 	if (config->vdv_vrh_enable) {
-		tmp = 0x01;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
+		buf_nocache[0] = 0x01;
+		ret = st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, buf_nocache, 1);
 		if (ret < 0) {
 			return ret;
 		}
 
-		tmp = config->vrh_value;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VRH, &tmp, 1);
+		buf_nocache[0] = config->vrh_value;
+		ret = st7789v_transmit(dev, ST7789V_CMD_VRH, buf_nocache, 1);
 		if (ret < 0) {
 			return ret;
 		}
 
-		tmp = config->vdv_value;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VDS, &tmp, 1);
+		buf_nocache[0] = config->vdv_value;
+		ret = st7789v_transmit(dev, ST7789V_CMD_VDS, buf_nocache, 1);
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PWCTRL1,
-			       (uint8_t *)config->pwctrl1_param,
-			       sizeof(config->pwctrl1_param));
+	memcpy(buf_nocache, config->pwctrl1_param, sizeof(config->pwctrl1_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_PWCTRL1, buf_nocache, sizeof(config->pwctrl1_param));
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Memory Data Access Control */
-	tmp = config->mdac;
-	ret = st7789v_transmit(dev, ST7789V_CMD_MADCTL, &tmp, 1);
+	buf_nocache[0] = config->mdac;
+	ret = st7789v_transmit(dev, ST7789V_CMD_MADCTL, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Interface Pixel Format */
-	tmp = config->colmod;
-	ret = st7789v_transmit(dev, ST7789V_CMD_COLMOD, &tmp, 1);
+	buf_nocache[0] = config->colmod;
+	ret = st7789v_transmit(dev, ST7789V_CMD_COLMOD, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->lcm;
-	ret = st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, &tmp, 1);
+	buf_nocache[0] = config->lcm;
+	ret = st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->gamma;
-	ret = st7789v_transmit(dev, ST7789V_CMD_GAMSET, &tmp, 1);
+	buf_nocache[0] = config->gamma;
+	ret = st7789v_transmit(dev, ST7789V_CMD_GAMSET, buf_nocache, 1);
 	if (ret < 0) {
 		return ret;
 	}
@@ -373,30 +370,28 @@ static int st7789v_lcd_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL,
-			       (uint8_t *)config->pvgam_param,
+	memcpy(buf_nocache, config->pvgam_param, sizeof(config->pvgam_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL, buf_nocache,
 			       sizeof(config->pvgam_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL,
-			       (uint8_t *)config->nvgam_param,
+	memcpy(buf_nocache, config->nvgam_param, sizeof(config->nvgam_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL, buf_nocache,
 			       sizeof(config->nvgam_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_RAMCTRL,
-			       (uint8_t *)config->ram_param,
-			       sizeof(config->ram_param));
+	memcpy(buf_nocache, config->ram_param, sizeof(config->ram_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_RAMCTRL, buf_nocache, sizeof(config->ram_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_RGBCTRL,
-			       (uint8_t *)config->rgb_param,
-			       sizeof(config->rgb_param));
+	memcpy(buf_nocache, config->rgb_param, sizeof(config->rgb_param));
+	ret = st7789v_transmit(dev, ST7789V_CMD_RGBCTRL, buf_nocache, sizeof(config->rgb_param));
 	return ret;
 }
 
@@ -474,11 +469,14 @@ static DEVICE_API(display, st7789v_api) = {
 	((DT_INST_STRING_UPPER_TOKEN(inst, mipi_mode) == MIPI_DBI_MODE_SPI_4WIRE) ?     \
 	SPI_WORD_SET(8) : SPI_WORD_SET(9))
 #define ST7789V_INIT(inst)								\
+	static uint8_t st7789v_nocache_buf_##inst[16] __aligned(4) __nocache;		\
+											\
 	static const struct st7789v_config st7789v_config_ ## inst = {			\
 		.mipi_dbi = DEVICE_DT_GET(DT_INST_PARENT(inst)),                        \
 		.dbi_config = MIPI_DBI_CONFIG_DT_INST(inst,                             \
 						      ST7789V_WORD_SIZE(inst) |         \
 						      SPI_OP_MODE_MASTER, 0),           \
+		.nocache_buf = st7789v_nocache_buf_##inst,				\
 		.vcom = DT_INST_PROP(inst, vcom),					\
 		.gctrl = DT_INST_PROP(inst, gctrl),					\
 		.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(inst, vrhs)			\

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -68,6 +68,10 @@ struct mipi_dbi_spi_config {
 	const struct gpio_dt_spec reset;
 	/* Minimum transfer bits */
 	const uint8_t xfr_min_bits;
+	/* Intermediate data buffer to be spi-dma compatible */
+	uint16_t * const spi_word_nocache;
+	/* Intermediate data buffer to be spi-dma compatible */
+	uint8_t * const spi_cmd_nocache;
 };
 
 struct mipi_dbi_spi_data {
@@ -78,8 +82,6 @@ struct mipi_dbi_spi_data {
 	atomic_t in_active_area;
 	struct gpio_callback te_cb_data;
 #endif
-	/* Used for 3 wire mode */
-	uint16_t spi_byte;
 };
 
 #if MIPI_DBI_SPI_TE_REQUIRED
@@ -111,7 +113,6 @@ mipi_dbi_spi_write_helper_3wire(const struct device *dev,
 				const uint8_t *data_buf, size_t len)
 {
 	const struct mipi_dbi_spi_config *config = dev->config;
-	struct mipi_dbi_spi_data *data = dev->data;
 	struct spi_buf buffer;
 	struct spi_buf_set buf_set = {
 		.buffers = &buffer,
@@ -128,12 +129,12 @@ mipi_dbi_spi_write_helper_3wire(const struct device *dev,
 	    != SPI_WORD_SET(9)) {
 		return -ENOTSUP;
 	}
-	buffer.buf = &data->spi_byte;
+	buffer.buf = config->spi_word_nocache;
 	buffer.len = 2;
 
 	/* Send command */
 	if (cmd_present) {
-		data->spi_byte = cmd;
+		*config->spi_word_nocache = cmd;
 		ret = spi_write(config->spi_dev, &dbi_config->config, &buf_set);
 		if (ret < 0) {
 			goto out;
@@ -141,7 +142,7 @@ mipi_dbi_spi_write_helper_3wire(const struct device *dev,
 	}
 	/* Write data, byte by byte */
 	for (size_t i = 0; i < len; i++) {
-		data->spi_byte = MIPI_DBI_DC_BIT | data_buf[i];
+		*config->spi_word_nocache = MIPI_DBI_DC_BIT | data_buf[i];
 		ret = spi_write(config->spi_dev, &dbi_config->config, &buf_set);
 		if (ret < 0) {
 			goto out;
@@ -173,10 +174,11 @@ mipi_dbi_spi_write_helper_4wire_8bit(const struct device *dev,
 	 * a command or data
 	 */
 
-	buffer.buf = &cmd;
-	buffer.len = sizeof(cmd);
-
 	if (cmd_present) {
+		*config->spi_cmd_nocache = cmd;
+		buffer.buf = config->spi_cmd_nocache;
+		buffer.len = 1;
+
 		/* Set CD pin low for command */
 		gpio_pin_set_dt(&config->cmd_data, 0);
 		ret = spi_write(config->spi_dev, &dbi_config->config, &buf_set);
@@ -216,7 +218,6 @@ mipi_dbi_spi_write_helper_4wire_16bit(const struct device *dev,
 		.buffers = &buffer,
 		.count = 1,
 	};
-	uint16_t data16;
 	int ret = 0;
 
 	/*
@@ -226,9 +227,9 @@ mipi_dbi_spi_write_helper_4wire_16bit(const struct device *dev,
 	 */
 
 	if (cmd_present) {
-		data16 = sys_cpu_to_be16(cmd);
-		buffer.buf = &data16;
-		buffer.len = sizeof(data16);
+		*config->spi_word_nocache = sys_cpu_to_be16(cmd);
+		buffer.buf = config->spi_word_nocache;
+		buffer.len = 2;
 
 		/* Set CD pin low for command */
 		gpio_pin_set_dt(&config->cmd_data, 0);
@@ -245,7 +246,7 @@ mipi_dbi_spi_write_helper_4wire_16bit(const struct device *dev,
 
 		/* iterate command data */
 		for (int i = 0; i < len; i++) {
-			data16 = sys_cpu_to_be16(data_buf[i]);
+			*config->spi_word_nocache = sys_cpu_to_be16(data_buf[i]);
 
 			ret = spi_write(config->spi_dev, &dbi_config->config,
 					&buf_set);
@@ -254,7 +255,7 @@ mipi_dbi_spi_write_helper_4wire_16bit(const struct device *dev,
 			}
 		}
 	} else {
-		int stuffing = len % sizeof(data16);
+		int stuffing = len % 2;
 
 		/* Set CD pin high for data, if there are any */
 		if (len > 0) {
@@ -275,9 +276,9 @@ mipi_dbi_spi_write_helper_4wire_16bit(const struct device *dev,
 
 		/* iterate remaining data with stuffing */
 		for (int i = len - stuffing; i < len; i++) {
-			data16 = sys_cpu_to_be16(data_buf[i]);
-			buffer.buf = &data16;
-			buffer.len = sizeof(data16);
+			*config->spi_word_nocache = sys_cpu_to_be16(data_buf[i]);
+			buffer.buf = config->spi_word_nocache;
+			buffer.len = 2;
 
 			ret = spi_write(config->spi_dev, &dbi_config->config,
 					&buf_set);
@@ -400,7 +401,6 @@ mipi_dbi_spi_read_helper_3wire(const struct device *dev,
 			       uint8_t *response, size_t len)
 {
 	const struct mipi_dbi_spi_config *config = dev->config;
-	struct mipi_dbi_spi_data *data = dev->data;
 	struct spi_config tmp_config;
 	struct spi_buf buffer;
 	struct spi_buf_set buf_set = {
@@ -424,12 +424,12 @@ mipi_dbi_spi_read_helper_3wire(const struct device *dev,
 	tmp_config.operation &= ~SPI_WORD_SIZE_MASK;
 	tmp_config.operation |= SPI_WORD_SET(9);
 
-	buffer.buf = &data->spi_byte;
+	buffer.buf = config->spi_word_nocache;
 	buffer.len = 1;
 
 	/* Send each command */
 	for (size_t i = 0; i < num_cmds; i++) {
-		data->spi_byte = cmds[i];
+		*config->spi_word_nocache = cmds[i];
 		ret = spi_write(config->spi_dev, &tmp_config, &buf_set);
 		if (ret < 0) {
 			goto out;
@@ -683,14 +683,17 @@ static DEVICE_API(mipi_dbi, mipi_dbi_spi_driver_api) = {
 };
 
 #define MIPI_DBI_SPI_INIT(n)							\
+	static uint16_t mipi_dbi_spi_nocache_buf_##n  __nocache;		\
 	static const struct mipi_dbi_spi_config					\
 	    mipi_dbi_spi_config_##n = {						\
 		    .spi_dev = DEVICE_DT_GET(					\
 				    DT_INST_PHANDLE(n, spi_dev)),		\
 		    .cmd_data = GPIO_DT_SPEC_INST_GET_OR(n, dc_gpios, {}),	\
-		    .tearing_effect = GPIO_DT_SPEC_INST_GET_OR(n, te_gpios, {}),  \
+		    .tearing_effect = GPIO_DT_SPEC_INST_GET_OR(n, te_gpios, {}),\
 		    .reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {}),	\
-		    .xfr_min_bits = DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits) \
+		    .xfr_min_bits = DT_INST_STRING_UPPER_TOKEN(n, xfr_min_bits),\
+		    .spi_word_nocache = &mipi_dbi_spi_nocache_buf_##n,		\
+		    .spi_cmd_nocache = (uint8_t *)&mipi_dbi_spi_nocache_buf_##n	\
 	};									\
 	static struct mipi_dbi_spi_data mipi_dbi_spi_data_##n;			\
 										\


### PR DESCRIPTION
Add support for using SPI DMA with the display drivers `sitronix,st7789v` and `ilitek,ili9341` (and variants `ili9340`, `ili9342c` & `ili9488`) when the SPI driver expects the buffers to be in uncached memory regions.

When using these display controllers connected via SPI to a STM32 platform it is currently not possible to activate `CONFIG_SPI_STM32_DMA` even if the (lvgl) framebuffer is moved to `.nocache` region. This is caused by the display drivers and the mipi_dbi_spi driver, which use local variables or even the device config data as buffers for init and display configuration transfers. The [STM32 SPI driver blocks](https://github.com/zephyrproject-rtos/zephyr/blob/ba5148006b29ca0deac19ea026dc6cadb7dfa70f/drivers/spi/spi_stm32.c#L872) these transfers when `CONFIG_DCACHE` is set.

This PR adds `__nocache` buffers to the display drivers `display_st7789v.c`, `display_ili9xxx.c` and the `mipi_dbi_spi.c` mipi-spi adapter driver and uses them for command and register writes/reads.

Tested on a custom board with both display controller types connected to a stm32h7rsx controller and the following selection of settings:
```
CONFIG_DMA=y
CONFIG_NOCACHE_MEMORY=y
CONFIG_SPI=y
CONFIG_SPI_STM32_DMA=y
CONFIG_DISPLAY=y
CONFIG_LVGL=y
CONFIG_LV_Z_VDB_ZEPHYR_REGION=y
CONFIG_LV_Z_VDB_ZEPHYR_REGION_NAME=".nocache"
```