### PR TITLE
samples: drivers: espi: Add special handling for NPCX4

### DIFF
--- a/samples/drivers/espi/boards/npcx4m8f_evb.conf
+++ b/samples/drivers/espi/boards/npcx4m8f_evb.conf
@@ -1,0 +1,12 @@
+CONFIG_LOG=y
+CONFIG_LOG_BUFFER_SIZE=4096
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=100
+
+# Enable correct VW behavior
+CONFIG_ESPI_VWIRE_VALID_BIT_CHECK=n
+
+# Enable eSPI VWire send check to ensure host receives the sent VWire signals.
+CONFIG_ESPI_NPCX_VWIRE_ENABLE_SEND_CHECK=y
+
+# Enable eSPI flash channel and test
+CONFIG_ESPI_FLASH_CHANNEL=y

--- a/samples/drivers/espi/boards/npcx4m8f_evb.overlay
+++ b/samples/drivers/espi/boards/npcx4m8f_evb.overlay
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/nuvoton-npcx-gpio.h>
+
 / {
 	board_power: resources {
 		compatible = "intel-rvp,board-power";
 		/* GPIO72 */
-		pwrg-gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+		pwrg-gpios = <&gpio7 2 (GPIO_ACTIVE_HIGH | NPCX_GPIO_VOLTAGE_1P8)>;
 		/* GPIOA5 */
 		rsm-gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 	};

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -205,6 +205,13 @@ int espi_init(void)
 #ifdef CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC
 	espi_add_callback(espi_dev, &oob_cb);
 #endif
+
+#if defined(CONFIG_SOC_SERIES_NPCX4) || defined(CONFIG_SOC_SERIES_NPCX9)
+	uint32_t enable = 1;
+
+	espi_write_lpc_request(espi_dev, ECUSTOM_HOST_SUBS_INTERRUPT_EN, &enable);
+#endif
+
 	LOG_INF("complete");
 
 	return ret;


### PR DESCRIPTION
NPCX4 requires eSPI interrupts to be explicitly enabled
NPCX4 requires additional KConfigs for correct eSPI VW handshake