### PR TITLE
soc: nxp: mcxw70: fix build issue due to wrong selection of HAS_PM

### DIFF
--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig
@@ -13,10 +13,10 @@ config SOC_MCXW716C
 
 config SOC_MCXW727C
 	select NXP_MULTICORE if NXP_NBU
+	select HAS_PM
 
 config SOC_MCXW70AC
 	select NXP_MULTICORE if NXP_NBU
-	select HAS_PM
 
 config SOC_MCXW70AC
 	bool


### PR DESCRIPTION
PR #103203 introduced a regression for mcxw70 builds by incorrectly moving `HAS_PM` from MCXW72 to MCXW70.
This fix restores the correct configuration.

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/105126