### PR TITLE
boards: nordic: nrf7120dk: Use a single IPC channel

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -21,7 +21,7 @@
 		zephyr,wifi = &wlan0;
 	};
 
-	/* TODO: Fine tune the sizes */
+	/* Single IPC channel: 4KB shared memory for TX+RX */
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -29,26 +29,18 @@
 
 		ipc_shm_area_cpuapp_cpuuma: memory@200c0000 {
 			compatible = "mmio-sram";
-			reg = <0x200c0000 0x2000>;
-			ranges = <0x0 0x200c0000 0x2000>;
+			reg = <0x200c0000 0x1000>;
+			ranges = <0x0 0x200c0000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
 
 			ipc_shm_cpuapp_cpuuma_0: memory@0 {
-				reg = <0x0 DT_SIZE_K(2)>;
+				reg = <0x0 0x800>;
 			};
 
 			ipc_shm_cpuuma_cpuapp_0: memory@800 {
-				reg = <0x800 DT_SIZE_K(2)>;
-			};
-
-			ipc_shm_cpuapp_cpuuma_1: memory@1000 {
-				reg = <0x1000 DT_SIZE_K(2)>;
-			};
-
-			ipc_shm_cpuuma_cpuapp_1: memory@1800 {
-				reg = <0x1800 DT_SIZE_K(2)>;
+				reg = <0x800 0x800>;
 			};
 		};
 	};
@@ -60,16 +52,6 @@
 			rx-region = <&ipc_shm_cpuuma_cpuapp_0>;
 			mboxes = <&wifi_bellboard 2>,
 				 <&cpuapp_bellboard 0>;
-			mbox-names = "tx", "rx";
-			status = "okay";
-		};
-
-		ipc1: ipc1 {
-			compatible = "zephyr,ipc-icmsg";
-			tx-region = <&ipc_shm_cpuapp_cpuuma_1>;
-			rx-region = <&ipc_shm_cpuuma_cpuapp_1>;
-			mboxes = <&wifi_bellboard 3>,
-				 <&cpuapp_bellboard 1>;
 			mbox-names = "tx", "rx";
 			status = "okay";
 		};


### PR DESCRIPTION
The new IPC design between APP and Wi-Fi doesn't use ACKs, so, we only need a single IPC channel for (cmd, event) pairs, the ACKs are replaced with a direct-memory write based rings.