### PR TITLE
usb: uvc: use uvc_device_ in API and add _enable()/_shutdown()

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1010,6 +1010,13 @@ USB
 
 * :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
 
+* UVC device application API got modified:
+
+  * ``uvc_set_video_dev`` has been renamed to :c:func:`uvc_device_init`
+  * ``uvc_add_format`` has been renamed to :c:func:`uvc_device_add_format`
+  * :c:func:`uvc_device_enable` has been introduced
+  * :c:func:`uvc_device_shutdown` has been introduced
+
 USB-C
 =====
 

--- a/include/zephyr/usb/class/usbd_uvc.h
+++ b/include/zephyr/usb/class/usbd_uvc.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2025 tinyVision.ai Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) tinyVision.ai Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,26 +19,28 @@
  * @defgroup usbd_uvc USB Video Class (UVC) device API
  * @ingroup usb
  * @since 4.2
- * @version 0.1.0
+ * @version 0.1.1
  * @see uvc: "Universal Serial Bus Device Class Definition for Video Devices"
  *      Document Release 1.5 (August 9, 2012)
  * @{
  */
 
 /**
- * @brief Set the video device that a UVC instance will use for control requests.
+ * @brief Initialize a video device class.
+ *
+ * Set the video device that a UVC instance will use for control requests.
  *
  * It will query its supported video controls and frame intervals and use this information to
  * generate the USB descriptors presented to the host. In addition, for every supported UVC control
  * request from the host to this @p uvc_dev instance, it will issue a matching video API control
  * request to @p video_dev.
  *
- * @note This function must be called before @ref usbd_enable.
+ * @note This function must be called before @ref uvc_device_enable.
  *
  * @param uvc_dev Pointer to the UVC device to configure
  * @param video_dev Pointer to the video device to which controls requests are sent
  */
-void uvc_set_video_dev(const struct device *uvc_dev, const struct device *video_dev);
+void uvc_device_init(const struct device *uvc_dev, const struct device *video_dev);
 
 /**
  * @brief Add a video format that a UVC instance will present to the host.
@@ -47,7 +48,7 @@ void uvc_set_video_dev(const struct device *uvc_dev, const struct device *video_
  * This information will be used to generate USB descriptors.
  * The particular format selected by the host can be queried with @ref video_get_format.
  *
- * @note This function must be called before @ref usbd_enable.
+ * @note This function must be called before @ref uvc_device_enable.
  *
  * @note The @p fmt struct field @c size must be set prior to call this function,
  *       such as calling @ref video_set_format().
@@ -56,7 +57,29 @@ void uvc_set_video_dev(const struct device *uvc_dev, const struct device *video_
  * @param fmt The video format to add to this UVC instance
  * @return 0 on success, negative value on error
  */
-int uvc_add_format(const struct device *const uvc_dev, const struct video_format *const fmt);
+int uvc_device_add_format(const struct device *const uvc_dev, const struct video_format *const fmt);
+
+/**
+ * @brief Completes the configuration of an UVC device instance
+ *
+ * Prepare an UVC interface for being used.
+ *
+ * @note This function must be called before @ref usbd_init.
+ *
+ * @param uvc_dev Pointer to the UVC device to configure
+ * @return 0 on success, negative value on error
+ */
+int uvc_device_enable(const struct device *const uvc_dev);
+
+/**
+ * @brief Withdraw the configuration of an UVC device instance
+ *
+ * Reset the configuration of an USB device class, make it ready to be enabled again.
+ *
+ * @param uvc_dev Pointer to the UVC device to deconfigure
+ * @return 0 on success, negative value on error
+ */
+int uvc_device_shutdown(const struct device *const uvc_dev);
 
 /**
  * @}

--- a/samples/subsys/usb/uvc/src/main.c
+++ b/samples/subsys/usb/uvc/src/main.c
@@ -105,7 +105,7 @@ static int app_add_format(uint32_t pixfmt, uint32_t width, uint32_t height, bool
 		return 0;
 	}
 
-	ret = uvc_add_format(uvc_dev, &fmt);
+	ret = uvc_device_add_format(uvc_dev, &fmt);
 	if (ret == -ENOMEM) {
 		/* If there are too many formats, ignore the error, just list fewer formats */
 		return 0;
@@ -345,11 +345,17 @@ int main(void)
 		uvc_buf_count /= 2;
 	}
 
-	/* Must be called before usb_enable() */
-	uvc_set_video_dev(uvc_dev, uvc_src_dev);
+	/* Initialize control descriptors from the video device */
+	uvc_device_init(uvc_dev, uvc_src_dev);
 
-	/* Must be called before usb_enable() */
+	/* Fill the table of formats */
 	ret = app_add_filtered_formats();
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Prepare the UVC device for being run */
+	ret = uvc_device_enable(uvc_dev);
 	if (ret != 0) {
 		return ret;
 	}

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -35,6 +35,12 @@ LOG_MODULE_REGISTER(usbd_uvc, CONFIG_USBD_VIDEO_LOG_LEVEL);
 #define UVC_IDX_VC_UNIT 3
 #define UVC_MAX_HEADER_LENGTH 0xff
 
+/* Offset at which full-speed descriptors will start to be added */
+#define UVC_FS_DESC_IDX 10
+
+/* Offset at which full-speed descriptors will start to be added */
+#define UVC_HS_DESC_IDX 10
+
 enum uvc_op {
 	UVC_OP_GET_ERRNO,
 	UVC_OP_VC_CTRL,
@@ -1113,7 +1119,7 @@ static void *uvc_get_desc(struct usbd_class_data *const c_data, const enum usbd_
 	return cfg->fs_desc;
 }
 
-static int uvc_assign_desc(const struct device *dev, void *const desc,
+static int uvc_assign_desc(const struct device *const dev, void *const desc,
 			   const bool add_to_fs, const bool add_to_hs)
 {
 	const struct uvc_config *cfg = dev->config;
@@ -1143,6 +1149,25 @@ err:
 	LOG_WRN("Out of descriptors, raise CONFIG_USBD_VIDEO_MAX_FORMATS above %u",
 		CONFIG_USBD_VIDEO_MAX_FORMATS);
 	return -ENOMEM;
+}
+
+static int uvc_deassign_all_descs(const struct device *const dev)
+{
+	const struct uvc_config *cfg = dev->config;
+	struct uvc_data *data = dev->data;
+	size_t n;
+
+	/* Clear Full Speed descriptor pointers */
+	n = data->fs_desc_idx - UVC_FS_DESC_IDX;
+	memset(&cfg->fs_desc[UVC_FS_DESC_IDX], 0x00, sizeof(*cfg->fs_desc) * n);
+	data->fs_desc_idx = UVC_FS_DESC_IDX;
+
+	/* Clear High Speed descriptor pointers */
+	n = data->hs_desc_idx - UVC_HS_DESC_IDX;
+	memset(&cfg->hs_desc[UVC_HS_DESC_IDX], 0x00, sizeof(*cfg->hs_desc) * n);
+	data->hs_desc_idx = UVC_HS_DESC_IDX;
+
+	return 0;
 }
 
 static union uvc_fmt_desc *uvc_new_fmt_desc(const struct device *dev)
@@ -1477,18 +1502,15 @@ static uint32_t uvc_get_mask(const struct device *video_dev,
 	return mask;
 }
 
-static int uvc_init(struct usbd_class_data *const c_data)
+int uvc_device_enable(const struct device *const dev)
 {
-	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_config *cfg = dev->config;
 	struct uvc_data *data = dev->data;
 	int ret;
 
-	__ASSERT_NO_MSG(data->video_dev != NULL);
-
-	if (atomic_test_bit(&data->state, UVC_STATE_INITIALIZED)) {
-		LOG_DBG("UVC instance '%s' is already initialized", dev->name);
-		return 0;
+	if (!atomic_test_bit(&data->state, UVC_STATE_INITIALIZED)) {
+		LOG_ERR("UVC instance '%s' is not initialized ", dev->name);
+		return -EIO;
 	}
 
 	cfg->desc->if1_hdr.wTotalLength += cfg->desc->if1_color.bLength;
@@ -1511,27 +1533,45 @@ static int uvc_init(struct usbd_class_data *const c_data)
 	cfg->desc->if1_hdr.wTotalLength = sys_cpu_to_le16(cfg->desc->if1_hdr.wTotalLength);
 
 	/* Generating the default probe message now that descriptors are complete */
-
 	ret = uvc_get_vs_probe_struct(dev, &data->default_probe, UVC_GET_CUR);
 	if (ret != 0) {
 		LOG_ERR("init: failed to query the default probe");
 		return ret;
 	}
 
-	atomic_set_bit(&data->state, UVC_STATE_INITIALIZED);
+	return 0;
+}
 
+int uvc_device_shutdown(const struct device *const dev)
+{
+	struct uvc_data *data = dev->data;
+
+	uvc_deassign_all_descs(dev);
+
+	atomic_clear_bit(&data->state, UVC_STATE_INITIALIZED);
+
+	return 0;
+}
+
+static int uvc_init(struct usbd_class_data *const c_data)
+{
 	return 0;
 }
 
 /* UVC public API */
 
-void uvc_set_video_dev(const struct device *const dev, const struct device *const video_dev)
+void uvc_device_init(const struct device *const dev, const struct device *const video_dev)
 {
 	struct uvc_data *data = dev->data;
 	const struct uvc_config *cfg = dev->config;
 	const struct uvc_control_map *map = NULL;
 	uint32_t mask = 0;
 	size_t map_sz = 0;
+
+	if (atomic_test_and_set_bit(&data->state, UVC_STATE_INITIALIZED)) {
+		LOG_WRN("UVC instance '%s' is already initialized ", dev->name);
+		return;
+	}
 
 	data->video_dev = video_dev;
 
@@ -1559,11 +1599,16 @@ void uvc_set_video_dev(const struct device *const dev, const struct device *cons
 	cfg->desc->if0_xu.bmControls[3] = mask >> 24;
 }
 
-int uvc_add_format(const struct device *const dev, const struct video_format *const fmt)
+int uvc_device_add_format(const struct device *const dev, const struct video_format *const fmt)
 {
 	struct uvc_data *data = dev->data;
 	const struct uvc_config *cfg = dev->config;
 	int ret;
+
+	if (!atomic_test_bit(&data->state, UVC_STATE_INITIALIZED)) {
+		LOG_ERR("UVC instance '%s' is not initialized ", dev->name);
+		return -EIO;
+	}
 
 	if (data->video_dev == NULL) {
 		LOG_ERR("Video device not yet configured into UVC");
@@ -2241,8 +2286,8 @@ struct usb_desc_header *uvc_hs_desc_##n[UVC_MAX_HS_DESC] = {			\
 	};									\
 										\
 	struct uvc_data uvc_data_##n = {					\
-		.fs_desc_idx = 10,						\
-		.hs_desc_idx = 10,						\
+		.fs_desc_idx = UVC_FS_DESC_IDX,					\
+		.hs_desc_idx = UVC_HS_DESC_IDX,					\
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n, uvc_preinit, NULL, &uvc_data_##n, &uvc_cfg_##n,\

--- a/tests/subsys/usb/uvc/src/main.c
+++ b/tests/subsys/usb/uvc/src/main.c
@@ -45,7 +45,7 @@ void *uvc_test_enable(void)
 {
 	int ret;
 
-	uvc_set_video_dev(uvc_dev, video_dev);
+	uvc_device_init(uvc_dev, video_dev);
 
 	for (size_t i = 0; i < ARRAY_SIZE(test_formats); i++) {
 		struct video_format fmt = test_formats[i];
@@ -53,11 +53,12 @@ void *uvc_test_enable(void)
 		ret = video_estimate_fmt_size(&fmt);
 		zassert_ok(ret);
 
-		ret = uvc_add_format(uvc_dev, &fmt);
+		ret = uvc_device_add_format(uvc_dev, &fmt);
 		zassert_ok(ret);
 	}
 
-	k_sleep(K_MSEC(500));
+	ret = uvc_device_enable(uvc_dev);
+	zassert_ok(ret, "Failed to initialize UVC device class");
 
 	ret = usbh_init(uhs_ctx);
 	zassert_ok(ret, "Failed to initialize USB host");
@@ -102,6 +103,9 @@ void uvc_test_shutdown(void *f)
 
 	ret = usbd_shutdown(test_usbd);
 	zassert_ok(ret, "Failed to shutdown device support");
+
+	ret = uvc_device_shutdown(uvc_dev);
+	zassert_ok(ret, "Failed to shutodwn UVC device class");
 
 	LOG_INF("Device support disabled");
 


### PR DESCRIPTION
Use a different API call to complete the function rather than relying on USB `.init()` to terminate the configuration.

This allows to setup the endpoint descriptors before `usbd_init()` is called.

Tested with `west build -b nrf52840dk/nrf52840 -S video-sw-generator samples/subsys/usb/uvc/`

Not yet tested with both CDC ACM and UVC.

Fixes: #104855 (UVC part)