### PR TITLE
boards: cirrus: Update partition sizes to support CS40L5x sample

### DIFF
--- a/boards/cirrus/crd40l50/crd40l50.dts
+++ b/boards/cirrus/crd40l50/crd40l50.dts
@@ -178,22 +178,17 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 DT_SIZE_K(64)>;
+			reg = <0x00020000 DT_SIZE_K(112)>;
 		};
 
-		slot1_partition: partition@30000 {
+		slot1_partition: partition@3c000 {
 			label = "image-1";
-			reg = <0x00030000 DT_SIZE_K(64)>;
+			reg = <0x0003c000 DT_SIZE_K(112)>;
 		};
 
-		scratch_partition: partition@40000 {
+		scratch_partition: partition@50000 {
 			label = "image-scratch";
-			reg = <0x00040000 DT_SIZE_K(64)>;
-		};
-
-		storage_partition: partition@50000 {
-			label = "storage";
-			reg = <0x00050000 DT_SIZE_K(64)>;
+			reg = <0x00058000 DT_SIZE_K(32)>;
 		};
 	};
 };


### PR DESCRIPTION
With logging and the shell enabled, the CS40L5x sample application is greater than 64 kB (the current size of image partitions for CRD40L50), which causes memory corruption. Remove the storage partition and increase the size of slots 0 and 1 to accomodate the CS40L5x sample application.