### PR TITLE
samples: tfm_integration: Set Python3_EXECUTABLE for external project 

### DIFF
--- a/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
@@ -84,6 +84,7 @@ ExternalProject_Add(tfm_psa_arch_test_app
                 -G ${CMAKE_GENERATOR}
                 -S ${TFM_TEST_REPO_PATH}/tests_psa_arch
                 -B ${PROJECT_BINARY_DIR}/tfm_ns
+                -DPython3_EXECUTABLE=${PYTHON_EXECUTABLE}
                 -DCROSS_COMPILE=${TFM_TOOLCHAIN_PATH}/${TFM_TOOLCHAIN_PREFIX}
                 -DPSA_TOOLCHAIN_FILE=${TFM_BINARY_DIR}/api_ns/cmake/${TFM_TOOLCHAIN_NS_FILE}
                 -DCONFIG_SPE_PATH=${TFM_BINARY_DIR}/api_ns

--- a/samples/tfm_integration/tfm_regression_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_regression_test/CMakeLists.txt
@@ -46,6 +46,7 @@ ExternalProject_Add(tfm_regression_test_app
                 -G ${CMAKE_GENERATOR}
                 -S ${TFM_TEST_REPO_PATH}/tests_reg
                 -B ${PROJECT_BINARY_DIR}/tfm_ns
+                -DPython3_EXECUTABLE=${PYTHON_EXECUTABLE}
                 -DCONFIG_SPE_PATH=${TFM_BINARY_DIR}/api_ns
                 -DTFM_TOOLCHAIN_FILE=cmake/${TFM_TOOLCHAIN_NS_FILE}
                 -DCROSS_COMPILE=${TFM_TOOLCHAIN_PATH}/${TFM_TOOLCHAIN_PREFIX}


### PR DESCRIPTION
Set `Python3_EXECUTABLE` to the Zephyr-wide Python executable when invoking
the TF-M `tests_psa_arch` test build to ensure that the same Python
installation used by the Zephyr build system is used by the TF-M test build
process.

Without this, when running Zephyr build inside a virtual environment, [the TF-M test build process may pick up the system Python installation](https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/22748940698/job/65979144024#step:16:10037), which may lead to various errors related to missing Python dependencies (notoriously, [`ModuleNotFoundError: No module named 'click'`](https://github.com/zephyrproject-rtos/sdk-ng/actions/runs/22748940698/job/65979144024#step:16:15662)).