### PR TITLE
cmake: Introduce ZEPHYR_SDK_INSTALL_DIR_FORCE environment variable

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -48,7 +48,12 @@ if(HostTools_FOUND)
   return()
 endif()
 
-find_package(Zephyr-sdk 0.16)
+if(DEFINED ENV{ZEPHYR_SDK_INSTALL_DIR_FORCE})
+  message(STATUS "ZEPHYR_SDK_INSTALL_DIR_FORCE is set, disabling SDK version compatibility check")
+  find_package(Zephyr-sdk)
+else()
+  find_package(Zephyr-sdk 0.16)
+endif()
 
 # gperf is an optional dependency
 find_program(GPERF gperf)

--- a/doc/develop/env_vars.rst
+++ b/doc/develop/env_vars.rst
@@ -213,6 +213,12 @@ the :ref:`toolchain <gs_toolchain>` used to build Zephyr applications.
 
    Path where Zephyr SDK is installed.
 
+.. envvar:: ZEPHYR_SDK_INSTALL_DIR_FORCE
+
+   Disables the SDK version compatibility check when defined. When :envvar:`ZEPHYR_SDK_INSTALL_DIR`
+   is set, this forces the SDK installation under the specified directory to be used regardless of
+   compatibility.
+
 .. envvar:: ZEPHYR_TOOLCHAIN_VARIANT
 
    The name of the toolchain to use.

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -58,6 +58,14 @@ example, you can set ``ZEPHYR_SDK_INSTALL_DIR`` to ``/company/tools``, where the
 This allows the Zephyr build system to choose the correct version of the SDK,
 while allowing multiple Zephyr SDKs to be grouped together at a specific path.
 
+By default, Zephyr build system chooses the latest compatible SDK version found in the CMake package
+registry or the directory specified by the :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variable
+when defined.
+
+This behaviour can be overridden by defining the :envvar:`ZEPHYR_SDK_INSTALL_DIR_FORCE` environment
+variable, which disables the SDK version compatibility check and allows the SDK installation pointed
+by :envvar:`ZEPHYR_SDK_INSTALL_DIR` to be used regardless of compatibility.
+
 .. _toolchain_zephyr_sdk_compatibility:
 
 Zephyr SDK version compatibility


### PR DESCRIPTION
This commit introduces a new environment variable, ZEPHYR_SDK_INSTALL_DIR_FORCE, that allows the Zephyr SDK installation pointed by ZEPHYR_SDK_INSTALL_DIR to be used regardless of compatibility.

The purpose of this is to aid A/B comparison between different SDK versions for debugging purposes.

Note that, when ZEPHYR_SDK_INSTALL_DIR is not defined or points to a directory containing multiple SDK installations, this has a side effect of allowing the latest SDK version discovered within the scope to be used regardless of compatibility; however, this behaviour is intentionally not documented since it was never the intended use of
ZEPHYR_SDK_INSTALL_DIR_FORCE.