### PR TITLE
video: HM01B0 data-bits -> bus-width

### DIFF
--- a/drivers/video/hm01b0.c
+++ b/drivers/video/hm01b0.c
@@ -20,6 +20,7 @@
 #include "video_device.h"
 
 LOG_MODULE_REGISTER(hm01b0, CONFIG_VIDEO_LOG_LEVEL);
+
 #define MAX_FRAME_RATE 10
 #define MIN_FRAME_RATE 1
 #define HM01B0_ID      0x01B0
@@ -73,10 +74,10 @@ LOG_MODULE_REGISTER(hm01b0, CONFIG_VIDEO_LOG_LEVEL);
 #define HM01B0_ORIENTATION_VMIRROR BIT(1)
 #define HM01B0_CCI_OSC_CLOCK_DIV_VT_REG_DIV_1 0x08 /* vt_reg_div[3:2]=10 */
 
-#define HM01B0_CTRL_VAL(data_bits) \
-	((data_bits) == 8 ? 0x02 : \
-	(data_bits) == 4 ? 0x42 : \
-	(data_bits) == 1 ? 0x22 : 0x00)
+#define HM01B0_BIT_CONTROL_VAL(bus_width) \
+	((bus_width) == 8 ? 0x02 : \
+	 (bus_width) == 4 ? 0x42 : \
+	 (bus_width) == 1 ? 0x22 : 0x00)
 
 /* Note: Bayer versions do not support 160x120 type settings */
 enum hm01b0_resolution {
@@ -233,8 +234,8 @@ struct hm01b0_data {
 };
 
 struct hm01b0_config {
-	const struct i2c_dt_spec i2c;
-	const uint8_t ctrl_val;
+	struct i2c_dt_spec i2c;
+	int8_t bus_width;
 };
 
 #define HM01B0_VIDEO_FORMAT_CAP(width, height, format)                                             \
@@ -266,6 +267,7 @@ static const struct video_format_cap hm01b0_fmts[] = {
 static int hm01b0_apply_configuration(const struct device *dev, enum hm01b0_resolution resolution)
 {
 	const struct hm01b0_config *config = dev->config;
+	const uint32_t bit_control = HM01B0_BIT_CONTROL_VAL(config->bus_width);
 	int ret;
 
 	/* Number of registers is the same for all configuration */
@@ -277,7 +279,7 @@ static int hm01b0_apply_configuration(const struct device *dev, enum hm01b0_reso
 	}
 
 	/* REG_BIT_CONTROL */
-	ret = video_write_cci_reg(&config->i2c, HM01B0_CCI_BIT_CONTROL, config->ctrl_val);
+	ret = video_write_cci_reg(&config->i2c, HM01B0_CCI_BIT_CONTROL, bit_control);
 	if (ret < 0) {
 		LOG_ERR("Failed to write BIT_CONTROL reg (%d)", ret);
 		return ret;
@@ -603,16 +605,17 @@ static int hm01b0_init(const struct device *dev)
 	return hm01b0_init_controls(dev);
 }
 
+#define HM01B0_LINK_PROP(inst, prop) DT_PROP(DT_INST_ENDPOINT_BY_ID(inst, 0, 0), prop)
 
-#define HM01B0_INIT(inst)                                                                       \
-	const struct hm01b0_config hm01b0_config_##inst = {                                     \
-		.i2c = I2C_DT_SPEC_INST_GET(inst),                                              \
-		.ctrl_val = HM01B0_CTRL_VAL(DT_INST_PROP(inst, data_bits))                      \
-	};                                                                                      \
-	struct hm01b0_data hm01b0_data_##inst;                                                  \
-	DEVICE_DT_INST_DEFINE(inst, &hm01b0_init, NULL, &hm01b0_data_##inst,                    \
-			      &hm01b0_config_##inst, POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,   \
-			      &hm01b0_driver_api);                                              \
+#define HM01B0_INIT(inst)                                                                          \
+	const struct hm01b0_config hm01b0_config_##inst = {                                        \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.bus_width = HM01B0_LINK_PROP(inst, bus_width),                                    \
+	};                                                                                         \
+	struct hm01b0_data hm01b0_data_##inst;                                                     \
+	DEVICE_DT_INST_DEFINE(inst, &hm01b0_init, NULL, &hm01b0_data_##inst,                       \
+			      &hm01b0_config_##inst, POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,      \
+			      &hm01b0_driver_api);                                                 \
 	VIDEO_DEVICE_DEFINE(hm01b0_##inst, DEVICE_DT_INST_GET(inst), NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(HM01B0_INIT)

--- a/dts/bindings/video/himax,hm01b0.yaml
+++ b/dts/bindings/video/himax,hm01b0.yaml
@@ -8,20 +8,38 @@ description: |
     Himax HM01B0 video sensor.
 
 compatible: "himax,hm01b0"
-properties:
-  data-bits:
-    type: int
-    default: 1
-    description: |
-      Camera output data width. 1/4/8 bits.
-      The default output data width value is 1, pixel value is serialised.
-    enum: [1, 4, 8]
 
 include: i2c-device.yaml
 
 child-binding:
   child-binding:
     include: video-interfaces.yaml
+    properties:
+
+      bus-width:
+        type: int
+        default: 8
+        description: |
+          Maximum number of parallel pins, 1, 4 or 8.
+
+          Depending on the bus width, different modes can be selected by choosing a pixel format:
+
+          When 8-bit (default) mode is used:
+
+          - 8-bit mode gives 1 byte per pixel, no padding
+          - 4-bit mode gives 2 bytes per pixel, 4-bit data, 4-bit zero,
+          - 1-bit mode gives 8 bytes per pixel, 1-bit data, 7-bit zero,
+
+          When 4-bit mode is used (with compatible receiver):
+
+          - 4-bit mode gives 1 byte per pixel, no padding
+          - 1-bit mode gives 4 bytes per pixel, 1-bit data, 3-bit zero, 1-bit data, 3-bit zero,
+
+          When 1-bit mode is used (with compatible receiver):
+
+          - 1-bit mode gives 1 byte per pixel, no padding
+
+        enum: [1, 4, 8]
 
 examples:
   - |
@@ -31,10 +49,10 @@ examples:
         compatible = "himax,hm01b0";
         reg = <0x24>;
         status = "okay";
-        data-bits = <0x4>;
         port {
           hm01b0_ep_out: endpoint {
             remote-endpoint-label = "video_pio_dma_ep_in";
+            bus-width = <4>;
           };
         };
       };

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1507,7 +1507,6 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
  * | Aaaaaaaa Rrrrrrrr Gggggggg Bbbbbbbb | ...
  * @endcode
  */
-
 #define VIDEO_PIX_FMT_ARGB32 VIDEO_FOURCC('B', 'A', '2', '4')
 
 /**
@@ -1515,7 +1514,6 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
  * | Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa | ...
  * @endcode
  */
-
 #define VIDEO_PIX_FMT_ABGR32 VIDEO_FOURCC('A', 'R', '2', '4')
 
 /**
@@ -1523,7 +1521,6 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
  * | Rrrrrrrr Gggggggg Bbbbbbbb Aaaaaaaa | ...
  * @endcode
  */
-
 #define VIDEO_PIX_FMT_RGBA32 VIDEO_FOURCC('A', 'B', '2', '4')
 
 /**
@@ -1531,7 +1528,6 @@ int video_transfer_buffer(const struct device *src, const struct device *sink,
  * | Aaaaaaaa Bbbbbbbb Gggggggg Rrrrrrrr | ...
  * @endcode
  */
-
 #define VIDEO_PIX_FMT_BGRA32 VIDEO_FOURCC('R', 'A', '2', '4')
 
 /**

--- a/tests/drivers/build_all/video/app.overlay
+++ b/tests/drivers/build_all/video/app.overlay
@@ -143,10 +143,10 @@
 				compatible = "himax,hm01b0";
 				reg = <0x24>;
 				status = "okay";
-				data-bits = <0x4>;
 
 				port {
 					hm01b0_ep_out: endpoint {
+						bus-width = <4>;
 						remote-endpoint-label = "";
 					};
 				};


### PR DESCRIPTION
Rename the `data-bits` property into a `bus-width` and move it to the endpoint.

Add a note about its expected effect.

As seen on https://github.com/zephyrproject-rtos/zephyr/pull/98154