### PR TITLE
tests: drivers: usb: uhc: add initial test

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.yaml
+++ b/boards/nxp/frdm_k22f/frdm_k22f.yaml
@@ -19,5 +19,7 @@ supported:
   - pwm
   - spi
   - usb_device
+  - usbd
+  - usbh
   - watchdog
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -24,6 +24,8 @@ supported:
   - i2c
   - spi
   - usb_device
+  - usbd
+  - usbh
   - watchdog
   - gint
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
@@ -27,6 +27,8 @@ supported:
   - spi
   - sdhc
   - usb_device
+  - usbd
+  - usbh
   - watchdog
   - rtc
   - gint

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -28,6 +28,7 @@ supported:
   - spi
   - usb_device
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -28,6 +28,7 @@ supported:
   - spi
   - usb_device
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -30,6 +30,7 @@ supported:
   - spi
   - usb_device
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -32,6 +32,7 @@ supported:
   - spi
   - usb_device
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
@@ -30,6 +30,7 @@ supported:
   - sdhc
   - spi
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -31,6 +31,7 @@ supported:
   - sdhc
   - spi
   - usbd
+  - usbh
   - watchdog
   - rtc
 vendor: nxp

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -28,7 +28,8 @@ supported:
   - pwm
   - spi
   - usb_device
-  - usb_host
+  - usbd
+  - usbh
   - watchdog
   - netif:eth
   - netif:openthread

--- a/tests/drivers/usb/uhc/CMakeLists.txt
+++ b/tests/drivers/usb/uhc/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_uhc)
+
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/usb/host)
+target_include_directories(app PRIVATE include)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/usb/uhc/prj.conf
+++ b/tests/drivers/usb/uhc/prj.conf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_ZTEST=y
+
+CONFIG_UHC_DRIVER=y
+CONFIG_USB_HOST_STACK=y

--- a/tests/drivers/usb/uhc/src/main.c
+++ b/tests/drivers/usb/uhc/src/main.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/usb/usbh.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/devicetree.h>
+
+#include "usbh_device.h"
+
+LOG_MODULE_REGISTER(udc_test, LOG_LEVEL_INF);
+
+USBH_CONTROLLER_DEFINE(uhs_ctx, DEVICE_DT_GET(DT_NODELABEL(zephyr_uhc0)));
+
+ZTEST(usbh_test, test_device)
+{
+	struct usb_device *udev;
+	int ret;
+
+	ret = usbh_init(&uhs_ctx);
+	zassert_ok(ret, "Failed to initialize USB host");
+
+	ret = usbh_enable(&uhs_ctx);
+	zassert_ok(ret, "Failed to enable USB host");
+
+	LOG_INF("Host controller enabled");
+
+	/* Give time for any USB Host stack operation to complete */
+	k_sleep(K_MSEC(500));
+
+	udev = usbh_device_get_any(&uhs_ctx);
+	zassert_not_null(udev, "Expecting a device to be connected and detected");
+	zassert_not_equal(udev->addr, 0, "Could not complete enumeration up to SET_ADDRESS");
+	zassert_not_null(udev->cfg_desc, "Could not read configuration descriptor header");
+	zassert_equal(udev->state, USB_STATE_CONFIGURED, "Could not complete configuration");
+
+	ret = usbh_disable(&uhs_ctx);
+	zassert_ok(ret, "Failed to disable USB host");
+
+	ret = usbh_shutdown(&uhs_ctx);
+	zassert_ok(ret, "Failed to shutdown host support");
+
+	LOG_INF("Host controller disabled");
+}
+
+ZTEST_SUITE(usbh_test, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/usb/uhc/testcase.yaml
+++ b/tests/drivers/usb/uhc/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  drivers.usb.uhc:
+    tags:
+      - drivers
+      - usbh
+    depends_on: usbh


### PR DESCRIPTION
Add a simple test that expects a device already connected when the controller initializes, then read its descriptors.

Used in the context of DWC2 PR, to cherry-pick on top of the commit to test, then:

For UHC already in-tree, nothing to change.

**nRF54LM20:**

```
west twister --scenario drivers.usb.uhc --device-testing --platform nrf54lm20dk/nrf54lm20a/cpuapp \
  --device-serial /dev/ttyUSB0 --flash-before
```

**ESP32S3:** (need to press the "reset" button when the logs pause)

```
west twister --scenario drivers.usb.uhc --device-testing --platform esp32s3_devkitc/esp32s3/procpu \
  --device-serial /dev/ttyUSB0 --flash-before
```

For now, it is not enabled for anything, as it has `depends_on: usbh`.