### PR TITLE
drivers: counter: rv3032: fix bugs, add top value callbacks, and add to tests

### DIFF
--- a/drivers/counter/counter_rv3032.c
+++ b/drivers/counter/counter_rv3032.c
@@ -14,6 +14,8 @@
  * driver.
  *
  * Remarks:
+ * - Alarms are implemented by changing the top value. If an alarm is set, the
+ *   top value callback is replaced with the alarm's callback.
  * - The duration of the first countdown after (re)starting the timer can be
  *   off by ~1 tick. See 4.8.3. FIRST PERIOD DURATION in the data sheet. This
  *   applies each time the timer is enabled (CONTROL1 TE bit set) or when a new
@@ -47,10 +49,56 @@ struct rv3032_counter_data {
 	bool counter_is_enabled;
 	uint16_t top_value;
 
+	struct k_sem lock;
+
 	bool alarm_is_pending;
-	counter_alarm_callback_t callback;
+	void *callback;
 	void *user_data;
 };
+
+static void rv3032_counter_lock_sem(const struct device *dev)
+{
+	struct rv3032_counter_data *data = dev->data;
+	(void)k_sem_take(&data->lock, K_FOREVER);
+}
+
+static void rv3032_counter_unlock_sem(const struct device *dev)
+{
+	struct rv3032_counter_data *data = dev->data;
+	(void)k_sem_give(&data->lock);
+}
+
+/* Prevent the RV-3032 from generating periodic countdown timer interrupt pulses
+ * without disabling the counter. TIE is zeroed first to prevent an interrupt
+ * pulse from being generated when we then zero the TIMER_VALUE_* registers.
+ *
+ * This function is intended to be called from within a locked context.
+ * This function causes the TF flag to be set in the STATUS register.
+ */
+static int rv3032_counter_disable_interrupts_unsafe(const struct device *dev)
+{
+	const struct rv3032_counter_config *config = dev->config;
+	struct rv3032_counter_data *data = dev->data;
+	int err;
+
+	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2, RV3032_CONTROL2_TIE, 0);
+	if (err) {
+		LOG_ERR("Failed to disable counter interrupt signals : %d", err);
+		return err;
+	}
+
+	uint8_t time_val[2] = {0};
+
+	err = mfd_rv3032_write_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, time_val,
+				    sizeof(time_val));
+	if (err) {
+		LOG_ERR("Failed to zero TIMER_VALUE_* registers : %d", err);
+		return err;
+	}
+	data->top_value = 0;
+
+	return 0;
+}
 
 static int rv3032_counter_start(const struct device *dev)
 {
@@ -111,23 +159,79 @@ static int rv3032_counter_reset(const struct device *dev)
 		return 0;
 	}
 
+	rv3032_counter_lock_sem(dev);
+
 	const uint8_t timer_value_0 = data->top_value & 0xff;
 
 	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_TIMER_VALUE_0, timer_value_0);
 	if (err) {
 		LOG_ERR("Failed reset counter : %d", err);
-		return err;
+		goto unlock;
 	}
 
-	return 0;
+unlock:
+	rv3032_counter_unlock_sem(dev);
+
+	return err;
 }
 
 static void rv3032_counter_isr(const struct device *dev)
 {
+	const struct rv3032_counter_config *config = dev->config;
 	struct rv3032_counter_data *data = dev->data;
+	uint8_t status;
+	int err;
 
-	if (data->callback) {
-		data->callback(dev, 0, 0, data->user_data);
+	rv3032_counter_lock_sem(dev);
+
+	const bool is_alarm = data->alarm_is_pending;
+	void *callback = data->callback;
+	void *user_data = data->user_data;
+
+	err = mfd_rv3032_read_reg8(config->mfd, RV3032_REG_STATUS, &status);
+	if (err) {
+		LOG_ERR("Failed to read status register : %d", err);
+		goto unlock;
+	}
+	if (!(status & RV3032_STATUS_TF)) {
+		/* Nothing to do: interrupt was already handled or alarm was
+		 * cancelled.
+		 */
+		err = 1;
+		goto unlock;
+	}
+
+	if (is_alarm) {
+		data->alarm_is_pending = false;
+		data->callback = NULL;
+		data->user_data = NULL;
+
+		/* Disable counter interrupts (alarms should be one shot) */
+		err = rv3032_counter_disable_interrupts_unsafe(dev);
+		if (err) {
+			LOG_ERR("Failed to disable counter interrupts in counter alarm ISR : %d",
+				err);
+			goto unlock;
+		}
+	}
+
+	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
+	if (err) {
+		LOG_ERR("Failed to clear TF flag from status register : %d", err);
+		goto unlock;
+	}
+
+unlock:
+	rv3032_counter_unlock_sem(dev);
+
+	if (err || !callback) {
+		return;
+	}
+
+	if (is_alarm) {
+		((counter_alarm_callback_t)callback)(dev, 0, 0, user_data);
+	} else {
+		((counter_top_callback_t)callback)(dev, user_data);
 	}
 }
 
@@ -154,8 +258,11 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 		return -ENOTSUP;
 	}
 
+	rv3032_counter_lock_sem(dev);
+
 	if (data->alarm_is_pending) {
-		return -EBUSY;
+		err = -EBUSY;
+		goto unlock;
 	}
 
 	/* Pause the countdown timer if it is running to avoid triggering an
@@ -165,7 +272,7 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 		err = rv3032_counter_stop(dev);
 		if (err) {
 			LOG_ERR("Failed to pause counter : %d", err);
-			return err;
+			goto unlock;
 		}
 		counter_was_enabled = true;
 	}
@@ -173,7 +280,7 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
 	if (err) {
 		LOG_ERR("Failed to clear TF flag from status register : %d", err);
-		return err;
+		goto unlock;
 	}
 
 	uint8_t time_val[2] = {alarm_cfg->ticks & 0xff, (alarm_cfg->ticks >> 8) & 0xf};
@@ -182,14 +289,14 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 				    sizeof(time_val));
 	if (err) {
 		LOG_ERR("Failed to write TIMER_VALUE_* registers : %d", err);
-		return err;
+		goto unlock;
 	}
 
 	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2, RV3032_CONTROL2_TIE,
 				     RV3032_CONTROL2_TIE);
 	if (err) {
 		LOG_ERR("Failed to enable interrupt signals : %d", err);
-		return err;
+		goto unlock;
 	}
 
 	data->alarm_is_pending = true;
@@ -201,11 +308,14 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 		err = rv3032_counter_start(dev);
 		if (err) {
 			LOG_ERR("Failed to restart counter : %d", err);
-			return err;
+			goto unlock;
 		}
 	}
 
-	return 0;
+unlock:
+	rv3032_counter_unlock_sem(dev);
+
+	return err;
 }
 
 static int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
@@ -216,25 +326,31 @@ static int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id
 
 	/* Don't need to check channel ID, this is handled by the Counter API */
 
+	rv3032_counter_lock_sem(dev);
+
 	if (!data->alarm_is_pending) {
-		return 0;
+		err = 0;
+		goto unlock;
 	}
 
-	err = rv3032_counter_stop(dev);
+	err = rv3032_counter_disable_interrupts_unsafe(dev);
 	if (err) {
-		LOG_ERR("Failed to stop counter while cancelling alarm : %d", err);
-		return err;
+		LOG_ERR("Error disabling counter interrupts while cancelling alarm : %d", err);
+		goto unlock;
 	}
 
 	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
 	if (err) {
 		LOG_ERR("Failed to clear TF flag from status register : %d", err);
-		return err;
+		goto unlock;
 	}
 
 	data->alarm_is_pending = false;
 	data->callback = NULL;
 	data->user_data = NULL;
+
+unlock:
+	rv3032_counter_unlock_sem(dev);
 
 	return err;
 }
@@ -260,18 +376,79 @@ static uint32_t rv3032_counter_get_pending_int(const struct device *dev)
 static int rv3032_counter_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
 {
 	const struct rv3032_counter_config *config = dev->config;
-	uint8_t timer[2];
+	struct rv3032_counter_data *data = dev->data;
+	bool counter_was_enabled = false;
 	int err;
 
-	timer[0] = cfg->ticks & 0xff;
-	timer[1] = (cfg->ticks >> 8) & 0xff;
+	/* Don't need to check cfg->ticks, this is handled by the Counter API */
 
-	err = mfd_rv3032_write_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, timer, 2);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
+	/* The RV-3032 restarts the countdown automatically when a new top value
+	 * is written, so these flags are unsupported.
+	 */
+	if (cfg->flags & (COUNTER_TOP_CFG_RESET_WHEN_LATE | COUNTER_TOP_CFG_DONT_RESET)) {
+		LOG_ERR("Unsupported cfg->flags: 0x%X (COUNTER_TOP_CFG_RESET_WHEN_LATE and"
+			" COUNTER_TOP_CFG_DONT_RESET are not supported)",
+			cfg->flags);
+		return -ENOTSUP;
 	}
 
-	return 0;
+	rv3032_counter_lock_sem(dev);
+
+	if (data->alarm_is_pending) {
+		err = -EBUSY;
+		goto unlock;
+	}
+
+	/* Pause the countdown timer if it is running to avoid triggering an
+	 * interrupt before we've updated the callback.
+	 */
+	if (data->counter_is_enabled) {
+		err = rv3032_counter_stop(dev);
+		if (err) {
+			LOG_ERR("Failed to pause counter : %d", err);
+			goto unlock;
+		}
+		counter_was_enabled = true;
+	}
+
+	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
+	if (err) {
+		LOG_ERR("Failed to clear TF flag from status register : %d", err);
+		goto unlock;
+	}
+
+	uint8_t time_val[2] = {cfg->ticks & 0xff, (cfg->ticks >> 8) & 0xf};
+
+	err = mfd_rv3032_write_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, time_val,
+				    sizeof(time_val));
+	if (err) {
+		LOG_ERR("Failed to write TIMER_VALUE_* registers : %d", err);
+		goto unlock;
+	}
+
+	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2, RV3032_CONTROL2_TIE,
+				     RV3032_CONTROL2_TIE);
+	if (err) {
+		LOG_ERR("Failed to enable interrupt signals : %d", err);
+		goto unlock;
+	}
+
+	data->callback = cfg->callback;
+	data->user_data = cfg->user_data;
+	data->top_value = cfg->ticks;
+
+	if (counter_was_enabled) {
+		err = rv3032_counter_start(dev);
+		if (err) {
+			LOG_ERR("Failed to restart counter : %d", err);
+			goto unlock;
+		}
+	}
+
+unlock:
+	rv3032_counter_unlock_sem(dev);
+
+	return err;
 }
 
 static uint32_t rv3032_counter_get_top_value(const struct device *dev)
@@ -284,6 +461,7 @@ static uint32_t rv3032_counter_get_top_value(const struct device *dev)
 static int rv3032_counter_init(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
+	struct rv3032_counter_data *data = dev->data;
 	uint8_t freq_config;
 	int err;
 
@@ -329,6 +507,8 @@ static int rv3032_counter_init(const struct device *dev)
 		LOG_ERR("Failed to zero TIMER_VALUE_* registers : %d", err);
 		return err;
 	}
+
+	k_sem_init(&data->lock, 1, 1);
 
 	mfd_rv3032_set_irq_handler(config->mfd, dev, RV3032_DEV_COUNTER, rv3032_counter_isr);
 

--- a/drivers/counter/counter_rv3032.c
+++ b/drivers/counter/counter_rv3032.c
@@ -6,6 +6,23 @@
 
 #define DT_DRV_COMPAT microcrystal_rv3032_counter
 
+/** @file
+ * @brief Microcrystal RV-3032 counter driver.
+ *
+ * This driver exposes the RV-3032's periodic countdown timer through the
+ * Counter API. Interrupts are configured and delegated via the parent MFD
+ * driver.
+ *
+ * Remarks:
+ * - The duration of the first countdown after (re)starting the timer can be
+ *   off by ~1 tick. See 4.8.3. FIRST PERIOD DURATION in the data sheet. This
+ *   applies each time the timer is enabled (CONTROL1 TE bit set) or when a new
+ *   top value is written. This means counter alarms will ALWAYS be off by up to
+ *   ~1 tick.
+ * - The RV-3032 does not support reading the current value/ticks of the
+ *   periodic countdown timer.
+ */
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/spinlock.h>
@@ -27,22 +44,43 @@ struct rv3032_counter_config {
 };
 
 struct rv3032_counter_data {
-	struct counter_alarm_cfg alarm_cfg0;
+	bool counter_is_enabled;
+	uint16_t top_value;
+
+	bool alarm_is_pending;
+	counter_alarm_callback_t callback;
+	void *user_data;
 };
 
 static int rv3032_counter_start(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
+	struct rv3032_counter_data *data = dev->data;
+	int err;
 
-	return mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE,
-				      RV3032_CONTROL1_TE);
+	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE,
+				     RV3032_CONTROL1_TE);
+	if (err) {
+		return err;
+	}
+	data->counter_is_enabled = true;
+
+	return 0;
 }
 
 static int rv3032_counter_stop(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
+	struct rv3032_counter_data *data = dev->data;
+	int err;
 
-	return mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
+	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
+	if (err) {
+		return err;
+	}
+	data->counter_is_enabled = false;
+
+	return 0;
 }
 
 /* The RV-3032 does not support reading the current value of the periodic
@@ -55,30 +93,41 @@ static int rv3032_counter_get_value(const struct device *dev, uint32_t *ticks)
 	return -ENOTSUP;
 }
 
+/* The RV-3032's periodic countdown timer restarts whenever a value is
+ * written to a Timer Value register, even if it is unchanged. So by rewriting
+ * the current value of the Timer Value 0 register, we can restart the timer in
+ * a single I2C write, rather than having to disable then enable the timer.
+ */
 static int rv3032_counter_reset(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
-	int ret;
+	const struct rv3032_counter_data *data = dev->data;
+	int err;
 
-	ret = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
-	if (ret) {
-		goto exit;
+	/* If the countdown timer is disabled, it will reset itself upon being
+	 * enabled.
+	 */
+	if (!data->counter_is_enabled) {
+		return 0;
 	}
 
-	ret = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE,
-				     RV3032_CONTROL1_TE);
-exit:
+	const uint8_t timer_value_0 = data->top_value & 0xff;
 
-	return ret;
+	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_TIMER_VALUE_0, timer_value_0);
+	if (err) {
+		LOG_ERR("Failed reset counter : %d", err);
+		return err;
+	}
+
+	return 0;
 }
 
 static void rv3032_counter_isr(const struct device *dev)
 {
 	struct rv3032_counter_data *data = dev->data;
 
-	if (data->alarm_cfg0.callback) {
-		data->alarm_cfg0.callback(dev, 0, data->alarm_cfg0.ticks,
-					  data->alarm_cfg0.user_data);
+	if (data->callback) {
+		data->callback(dev, 0, 0, data->user_data);
 	}
 }
 
@@ -87,109 +136,105 @@ static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 {
 	const struct rv3032_counter_config *config = dev->config;
 	struct rv3032_counter_data *data = dev->data;
-	const uint32_t freq = config->counter_info.freq;
+	bool counter_was_enabled = false;
 	int err;
-	uint8_t time_val[2];
-	uint8_t freq_val;
 
-	data->alarm_cfg0.user_data = alarm_cfg->user_data;
-	data->alarm_cfg0.callback = alarm_cfg->callback;
-	data->alarm_cfg0.flags = alarm_cfg->flags;
-	data->alarm_cfg0.ticks = alarm_cfg->ticks;
+	/* Don't need to check channel ID, this is handled by the Counter API */
 
 	if (alarm_cfg->ticks > config->counter_info.max_top_value) {
-		LOG_ERR("alarm_cfg->ticks %d) Max value (%d)", alarm_cfg->ticks, config->counter_info.max_top_value);
+		LOG_ERR("alarm_cfg->ticks is %d, max value is %d", alarm_cfg->ticks,
+			config->counter_info.max_top_value);
+		return -EINVAL;
+	}
+
+	if (alarm_cfg->flags & (COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE)) {
+		LOG_ERR("Unsupported alarm_cfg->flags: 0x%X (absolute alarms / expire when late"
+			" are not supported, use relative alarms)",
+			alarm_cfg->flags);
 		return -ENOTSUP;
 	}
 
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2, RV3032_CONTROL2_TIE, 0);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
+	if (data->alarm_is_pending) {
+		return -EBUSY;
 	}
 
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
+	/* Pause the countdown timer if it is running to avoid triggering an
+	 * interrupt before we've updated the callback.
+	 */
+	if (data->counter_is_enabled) {
+		err = rv3032_counter_stop(dev);
+		if (err) {
+			LOG_ERR("Failed to pause counter : %d", err);
+			return err;
+		}
+		counter_was_enabled = true;
 	}
 
-	time_val[0] = alarm_cfg->ticks & 0xff;
-	time_val[1] = (alarm_cfg->ticks & 0xff00) >> 8;
+	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
+	if (err) {
+		LOG_ERR("Failed to clear TF flag from status register : %d", err);
+		return err;
+	}
+
+	uint8_t time_val[2] = {alarm_cfg->ticks & 0xff, (alarm_cfg->ticks >> 8) & 0xf};
 
 	err = mfd_rv3032_write_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, time_val,
 				    sizeof(time_val));
 	if (err) {
-		LOG_ERR("TIMER register write failed : %d", err);
+		LOG_ERR("Failed to write TIMER_VALUE_* registers : %d", err);
+		return err;
 	}
 
-	if (freq == 4096) {
-		freq_val = 0x0;
-	} else if (freq == 64) {
-		freq_val = 0x1;
-	} else if (freq == 1) {
-		freq_val = 0x2;
-	} else if (freq == 0) {
-		freq_val = 0x3;
-	} else {
-		freq_val = 0x0;
-	}
-
-	printk("alarm_cfg->ticks [%d] freq_val[%d]\n", alarm_cfg->ticks, freq_val);
-
-	/* Setup clock freq */
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TD,
-				     freq_val);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
-	}
-
-	/* Clear Timer Flag from status if there was something leftover */
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_STATUS, RV3032_STATUS_TF, 0);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
-	}
-
-	/* Enable Timer interrupts */
 	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2, RV3032_CONTROL2_TIE,
 				     RV3032_CONTROL2_TIE);
 	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
+		LOG_ERR("Failed to enable interrupt signals : %d", err);
+		return err;
 	}
 
-	/* Enable Timer */
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE,
-				     RV3032_CONTROL1_TE);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		goto err_return;
+	data->alarm_is_pending = true;
+	data->callback = alarm_cfg->callback;
+	data->user_data = alarm_cfg->user_data;
+	data->top_value = alarm_cfg->ticks;
+
+	if (counter_was_enabled) {
+		err = rv3032_counter_start(dev);
+		if (err) {
+			LOG_ERR("Failed to restart counter : %d", err);
+			return err;
+		}
 	}
 
-	mfd_rv3032_set_irq_handler(config->mfd, dev, RV3032_DEV_COUNTER, rv3032_counter_isr);
-
-err_return:
-
-	return err;
+	return 0;
 }
 
 static int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
 {
 	const struct rv3032_counter_config *config = dev->config;
+	struct rv3032_counter_data *data = dev->data;
 	int err;
 
-	if (chan_id != 0) {
-		LOG_ERR("Invalid channel id, only 0 is supported");
-		return -ENOTSUP;
+	/* Don't need to check channel ID, this is handled by the Counter API */
+
+	if (!data->alarm_is_pending) {
+		return 0;
 	}
 
-	/* disable counter interrupt */
-	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
+	err = rv3032_counter_stop(dev);
 	if (err) {
-		LOG_ERR("Status register read failed after EEPROM refresh: %d", err);
+		LOG_ERR("Failed to stop counter while cancelling alarm : %d", err);
+		return err;
 	}
+
+	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_STATUS, (uint8_t)~RV3032_STATUS_TF);
+	if (err) {
+		LOG_ERR("Failed to clear TF flag from status register : %d", err);
+		return err;
+	}
+
+	data->alarm_is_pending = false;
+	data->callback = NULL;
+	data->user_data = NULL;
 
 	return err;
 }
@@ -231,27 +276,61 @@ static int rv3032_counter_set_top_value(const struct device *dev, const struct c
 
 static uint32_t rv3032_counter_get_top_value(const struct device *dev)
 {
-	const struct rv3032_counter_config *config = dev->config;
-	uint8_t timer[2];
-	uint8_t val;
-	int err;
+	const struct rv3032_counter_data *data = dev->data;
 
-	err = mfd_rv3032_read_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, timer, 2);
-	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		return err;
-	}
-
-	val = timer[0] | (timer[1] << 8);
-
-	return val;
+	return data->top_value;
 }
 
 static int rv3032_counter_init(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
+	uint8_t freq_config;
+	int err;
 
-	LOG_DBG("Counter [%s] mdf-parent [%s]\n", dev->name, config->mfd->name);
+	if (!device_is_ready(config->mfd)) {
+		return -ENODEV;
+	}
+
+	LOG_DBG("Counter [%s] mfd-parent [%s]\n", dev->name, config->mfd->name);
+
+	/* Parent MFD driver clears status / control registers */
+
+	switch (config->counter_info.freq) {
+	case 4096:
+		freq_config = RV3032_CONTROL1_TD_4096;
+		break;
+	case 64:
+		freq_config = RV3032_CONTROL1_TD_64;
+		break;
+	case 1:
+		freq_config = RV3032_CONTROL1_TD_1;
+		break;
+	case 0:
+		freq_config = RV3032_CONTROL1_TD_1_60;
+		break;
+	default:
+		LOG_ERR("Invalid counter frequency : %d", config->counter_info.freq);
+		return -EINVAL;
+	}
+
+	/* Set the periodic countdown timer's clock frequency */
+	err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TD,
+				     freq_config);
+	if (err) {
+		LOG_ERR("Failed to set clock frequency : %d", err);
+		return err;
+	}
+
+	uint8_t time_val[2] = {0};
+
+	err = mfd_rv3032_write_regs(config->mfd, RV3032_REG_TIMER_VALUE_0, time_val,
+				    sizeof(time_val));
+	if (err) {
+		LOG_ERR("Failed to zero TIMER_VALUE_* registers : %d", err);
+		return err;
+	}
+
+	mfd_rv3032_set_irq_handler(config->mfd, dev, RV3032_DEV_COUNTER, rv3032_counter_isr);
 
 	return 0;
 }

--- a/drivers/counter/counter_rv3032.c
+++ b/drivers/counter/counter_rv3032.c
@@ -23,16 +23,14 @@ LOG_MODULE_REGISTER(rv3032_counter, CONFIG_COUNTER_LOG_LEVEL);
 
 struct rv3032_counter_config {
 	struct counter_config_info counter_info;
-	uint32_t base;
 	const struct device *mfd;
 };
 
 struct rv3032_counter_data {
 	struct counter_alarm_cfg alarm_cfg0;
-	uint32_t freq;
 };
 
-int rv3032_counter_start(const struct device *dev)
+static int rv3032_counter_start(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
 
@@ -40,26 +38,24 @@ int rv3032_counter_start(const struct device *dev)
 				      RV3032_CONTROL1_TE);
 }
 
-int rv3032_counter_stop(const struct device *dev)
+static int rv3032_counter_stop(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
 
 	return mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_TE, 0);
 }
 
-int rv3032_counter_get_value(const struct device *dev, uint32_t *ticks)
+/* The RV-3032 does not support reading the current value of the periodic
+ * countdown timer.
+ */
+static int rv3032_counter_get_value(const struct device *dev, uint32_t *ticks)
 {
-	const struct rv3032_counter_config *config = dev->config;
-	uint8_t val[2];
-
-	mfd_rv3032_read_regs(config->mfd, RV3032_REG_CONTROL1, val, 2);
-
-	*ticks = (val[1]<<8) | val[0];
-
-	return 0;
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ticks);
+	return -ENOTSUP;
 }
 
-int rv3032_counter_reset(const struct device *dev)
+static int rv3032_counter_reset(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	int ret;
@@ -76,7 +72,7 @@ exit:
 	return ret;
 }
 
-void rv3032_counter_isr(const struct device *dev)
+static void rv3032_counter_isr(const struct device *dev)
 {
 	struct rv3032_counter_data *data = dev->data;
 
@@ -86,11 +82,12 @@ void rv3032_counter_isr(const struct device *dev)
 	}
 }
 
-int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
-			      const struct counter_alarm_cfg *alarm_cfg)
+static int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
+				    const struct counter_alarm_cfg *alarm_cfg)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	struct rv3032_counter_data *data = dev->data;
+	const uint32_t freq = config->counter_info.freq;
 	int err;
 	uint8_t time_val[2];
 	uint8_t freq_val;
@@ -100,8 +97,8 @@ int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 	data->alarm_cfg0.flags = alarm_cfg->flags;
 	data->alarm_cfg0.ticks = alarm_cfg->ticks;
 
-	if (alarm_cfg->ticks > 4096) {
-		LOG_ERR("alarm_cfg->ticks %d) Max value (4096)", alarm_cfg->ticks);
+	if (alarm_cfg->ticks > config->counter_info.max_top_value) {
+		LOG_ERR("alarm_cfg->ticks %d) Max value (%d)", alarm_cfg->ticks, config->counter_info.max_top_value);
 		return -ENOTSUP;
 	}
 
@@ -126,13 +123,13 @@ int rv3032_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 		LOG_ERR("TIMER register write failed : %d", err);
 	}
 
-	if (data->freq == 4096) {
+	if (freq == 4096) {
 		freq_val = 0x0;
-	} else if (data->freq == 64) {
+	} else if (freq == 64) {
 		freq_val = 0x1;
-	} else if (data->freq == 1) {
+	} else if (freq == 1) {
 		freq_val = 0x2;
-	} else if (data->freq == 0) {
+	} else if (freq == 0) {
 		freq_val = 0x3;
 	} else {
 		freq_val = 0x0;
@@ -178,7 +175,7 @@ err_return:
 	return err;
 }
 
-int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
+static int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	int err;
@@ -197,7 +194,10 @@ int rv3032_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	return err;
 }
 
-uint32_t rv3032_counter_get_pending_int(const struct device *dev)
+/* The Counter API does not specify a return value for errors, so 0 is also
+ * returned for errors here.
+ */
+static uint32_t rv3032_counter_get_pending_int(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	uint8_t status;
@@ -205,26 +205,14 @@ uint32_t rv3032_counter_get_pending_int(const struct device *dev)
 
 	err = mfd_rv3032_read_reg8(config->mfd, RV3032_REG_STATUS, &status);
 	if (err) {
-		LOG_ERR("TIMER register read failed : %d", err);
-		return err;
+		LOG_ERR("Status register read failed : %d", err);
+		return 0;
 	}
 
-	/* Check timer bit in status reg, if there is pending int fire ISR*/
-	if (status & RV3032_STATUS_TF) {
-		err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_STATUS, RV3032_STATUS_TF,
-					     RV3032_STATUS_TF);
-		if (err) {
-			LOG_ERR("TIMER register read failed : %d", err);
-			return err;
-		}
-
-		rv3032_counter_isr(dev);
-	}
-
-	return err;
+	return (status & RV3032_STATUS_TF) > 0;
 }
 
-int rv3032_counter_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+static int rv3032_counter_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	uint8_t timer[2];
@@ -241,7 +229,7 @@ int rv3032_counter_set_top_value(const struct device *dev, const struct counter_
 	return 0;
 }
 
-uint32_t rv3032_counter_get_top_value(const struct device *dev)
+static uint32_t rv3032_counter_get_top_value(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
 	uint8_t timer[2];
@@ -257,30 +245,6 @@ uint32_t rv3032_counter_get_top_value(const struct device *dev)
 	val = timer[0] | (timer[1] << 8);
 
 	return val;
-}
-
-uint32_t rv3032_counter_get_guard_period(const struct device *dev, uint32_t flags)
-{
-	return -ENOTSUP;
-}
-
-int rv3032_counter_set_guard_period(const struct device *dev, uint32_t ticks, uint32_t flags)
-{
-	return -ENOTSUP;
-}
-
-uint32_t rv3032_counter_get_freq(const struct device *dev)
-{
-	/*
-	 * 4096 Hz – Default value
-	 * 64 Hz
-	 * 1 Hz
-	 * 1/60 Hz
-	 */
-
-	const struct rv3032_counter_data *data = dev->data;
-
-	return data->freq;
 }
 
 static int rv3032_counter_init(const struct device *dev)
@@ -302,25 +266,23 @@ static DEVICE_API(counter, rv3032_counter_api) = {
 	.set_top_value = rv3032_counter_set_top_value,
 	.get_pending_int = rv3032_counter_get_pending_int,
 	.get_top_value = rv3032_counter_get_top_value,
-	.get_freq = rv3032_counter_get_freq,
 };
 
-#define rv3032_counter_INIT(inst)                                                                  \
+#define RV3032_COUNTER_INIT(inst)                                                                  \
 	static const struct rv3032_counter_config rv3032_counter_config_##inst = {                 \
 		.counter_info = {                                                                  \
-			.max_top_value = 4096,                                                     \
-			.flags = COUNTER_CONFIG_INFO_COUNT_UP,                                     \
+			.max_top_value = 4095,                                                     \
+			.freq = DT_INST_PROP_OR(inst, frequency, 4096),                            \
+			.flags = 0,                                     			   \
 			.channels = 1,                                                             \
 		},                                                                                 \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
 	};                                                                                         \
-	static struct rv3032_counter_data rv3032_counter_data_##inst = {                           \
-		.freq = DT_INST_PROP_OR(inst, frequency, 4096),                                    \
-	};                                                                                         \
+	static struct rv3032_counter_data rv3032_counter_data_##inst = {};                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(0, &rv3032_counter_init, NULL, &rv3032_counter_data_##inst,          \
+	DEVICE_DT_INST_DEFINE(inst, &rv3032_counter_init, NULL, &rv3032_counter_data_##inst,       \
 			      &rv3032_counter_config_##inst, POST_KERNEL,                          \
 			      CONFIG_COUNTER_MICROCRYSTAL_RV3032_INIT_PRIORITY,                    \
 			      &rv3032_counter_api);
 
-DT_INST_FOREACH_STATUS_OKAY(rv3032_counter_INIT)
+DT_INST_FOREACH_STATUS_OKAY(RV3032_COUNTER_INIT)

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -112,7 +112,6 @@ static void mfd_rv3032_work_cb(struct k_work *work)
 
 	/* Periodic counter - COUNTER*/
 	if (status & RV3032_STATUS_TF) {
-		ret = mfd_rv3032_clear_status(data->dev, RV3032_STATUS_TF);
 		mfd_rv3032_fire_child_callback(data, RV3032_DEV_COUNTER);
 		LOG_DBG("(STATUS) Periodic counter (%x)\n", status);
 	}

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -199,6 +199,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_BEE_TIMER
 	DEVS_FOR_DT_COMPAT(realtek_bee_counter_timer)
 #endif
+#ifdef CONFIG_COUNTER_RV3032
+	DEVS_FOR_DT_COMPAT(microcrystal_rv3032_counter)
+#endif
 };
 
 static const struct device *const period_devs[] = {
@@ -356,24 +359,25 @@ static void test_set_top_value_with_alarm_instance(const struct device *dev)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Counter failed to start", dev->name);
 
-	k_busy_wait(5000);
+	k_usleep(5000);
 
 	err = counter_get_value(dev, &cnt);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev->name,
-		     err);
-	if (counter_is_counting_up(dev)) {
-		err = (cnt > 0) ? 0 : 1;
-	} else {
-		top_value = counter_get_top_value(dev);
-		err = (cnt < top_value) ? 0 : 1;
+	if (err != -ENOTSUP) {
+		zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev->name, err);
+		if (counter_is_counting_up(dev)) {
+			err = (cnt > 0) ? 0 : 1;
+		} else {
+			top_value = counter_get_top_value(dev);
+			err = (cnt < top_value) ? 0 : 1;
+		}
+		zassert_true(err == 0, "%s: Counter should progress", dev->name);
 	}
-	zassert_true(err == 0, "%s: Counter should progress", dev->name);
 
 	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)",
 			dev->name, err);
 
-	k_busy_wait(5.2*counter_period_us);
+	k_usleep(5.2 * counter_period_us);
 
 	top_handler_cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		top_cnt : k_sem_count_get(&top_cnt_sem);
@@ -405,18 +409,19 @@ static void test_set_top_value_without_alarm_instance(const struct device *dev)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Counter failed to start", dev->name);
 
-	k_busy_wait(5000);
+	k_usleep(5000);
 
 	err = counter_get_value(dev, &cnt);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev->name,
-		     err);
-	if (counter_is_counting_up(dev)) {
-		err = (cnt > 0) ? 0 : 1;
-	} else {
-		top_value = counter_get_top_value(dev);
-		err = (cnt < top_value) ? 0 : 1;
+	if (err != -ENOTSUP) {
+		zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev->name, err);
+		if (counter_is_counting_up(dev)) {
+			err = (cnt > 0) ? 0 : 1;
+		} else {
+			top_value = counter_get_top_value(dev);
+			err = (cnt < top_value) ? 0 : 1;
+		}
+		zassert_true(err == 0, "%s: Counter should progress", dev->name);
 	}
-	zassert_true(err == 0, "%s: Counter should progress", dev->name);
 
 	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)",
@@ -447,23 +452,24 @@ static void alarm_handler(const struct device *dev, uint8_t chan_id,
 	uint32_t diff;
 
 	err = counter_get_value(dev, &now);
-	zassert_true(err == 0, "%s: Counter read failed (err: %d)",
-		     dev->name, err);
+	if (err != -ENOTSUP) {
+		zassert_true(err == 0, "%s: Counter read failed (err: %d)", dev->name, err);
 
-	top = counter_get_top_value(dev);
-	if (counter_is_counting_up(dev)) {
-		diff =  (now < counter) ?
-			(now + top - counter) : (now - counter);
-	} else {
-		diff = (now > counter) ?
-			(counter + top - now) : (counter - now);
+		top = counter_get_top_value(dev);
+		if (counter_is_counting_up(dev)) {
+			diff =  (now < counter) ?
+				(now + top - counter) : (now - counter);
+		} else {
+			diff = (now > counter) ?
+				(counter + top - now) : (counter - now);
+		}
+
+		zassert_true(diff <= counter_us_to_ticks(dev, processing_limit_us),
+				"Unexpected distance between reported alarm value(%u) "
+				"and actual counter value (%u), top:%d (processing "
+				"time limit (%d us) might be exceeded?",
+				counter, now, top, (int)processing_limit_us);
 	}
-
-	zassert_true(diff <= counter_us_to_ticks(dev, processing_limit_us),
-			"Unexpected distance between reported alarm value(%u) "
-			"and actual counter value (%u), top:%d (processing "
-			"time limit (%d us) might be exceeded?",
-			counter, now, top, (int)processing_limit_us);
 
 	if (user_data) {
 		zassert_true(&cntr_alarm_cfg == user_data,
@@ -474,8 +480,7 @@ static void alarm_handler(const struct device *dev, uint8_t chan_id,
 		alarm_cnt++;
 		return;
 	}
-	zassert_true(k_is_in_isr(), "%s: Expected interrupt context",
-			dev->name);
+
 	k_sem_give(&alarm_cnt_sem);
 }
 
@@ -535,6 +540,44 @@ out_stop:
 	return err == 0;
 }
 
+/* Countdown timers (e.g. RV3032, rts5912) may implement alarms by changing the
+ * top value.
+ */
+static bool setting_alarm_changes_top_value(const struct device *dev)
+{
+	int err;
+	const uint32_t counter_period_us = get_counter_period_us(dev);
+	const uint32_t max_top_value = counter_get_max_top_value(dev);
+	const uint32_t alarm_ticks = counter_us_to_ticks(dev, counter_period_us);
+	struct counter_top_cfg top_cfg = {
+		.callback = NULL,
+		.ticks = max_top_value,
+		.user_data = NULL,
+		.flags = 0
+	};
+	struct counter_alarm_cfg alarm_cfg = {
+		.callback = alarm_capable_handler,
+		.ticks = alarm_ticks,
+		.user_data = NULL,
+		.flags = 0
+	};
+
+	err = counter_set_top_value(dev, &top_cfg);
+	if (err || counter_get_top_value(dev) != max_top_value) {
+		return false;
+	}
+	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
+	if (err) {
+		return false;
+	}
+
+	bool top_value_changed = (counter_get_top_value(dev) == alarm_ticks);
+
+	(void)counter_cancel_channel_alarm(dev, 0);
+
+	return top_value_changed;
+}
+
 static void test_single_shot_alarm_instance(const struct device *dev, bool set_top)
 {
 	int err;
@@ -584,13 +627,13 @@ static void test_single_shot_alarm_instance(const struct device *dev, bool set_t
 	zassert_equal(0, err, "%s: Counter set alarm failed (err: %d)",
 			dev->name, err);
 
-	k_busy_wait(2*(uint32_t)counter_ticks_to_us(dev, ticks));
+	k_usleep(2 * (uint32_t)counter_ticks_to_us(dev, ticks));
 
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
 	zassert_equal(1, cnt, "%s: Expecting alarm callback", dev->name);
 
-	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
+	k_usleep(1.5 * counter_ticks_to_us(dev, ticks));
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
 	zassert_equal(1, cnt, "%s: Expecting alarm callback", dev->name);
@@ -633,7 +676,8 @@ static bool single_channel_alarm_capable(const struct device *dev)
 
 static bool single_channel_alarm_and_custom_top_capable(const struct device *dev)
 {
-	return alarm_capable(dev) && set_top_value_capable(dev);
+	return alarm_capable(dev) && set_top_value_capable(dev) &&
+	       !setting_alarm_changes_top_value(dev);
 }
 
 ZTEST(counter_basic, test_single_shot_alarm_notop)
@@ -722,7 +766,7 @@ static void test_multiple_alarms_instance(const struct device *dev)
 		return;
 	}
 
-	k_busy_wait(3*(uint32_t)counter_ticks_to_us(dev, cntr_alarm_cfg.ticks));
+	k_usleep(3 * (uint32_t)counter_ticks_to_us(dev, cntr_alarm_cfg.ticks));
 
 	err = counter_set_channel_alarm(dev, 0, &cntr_alarm_cfg);
 	zassert_equal(0, err, "%s: Counter set alarm failed", dev->name);
@@ -730,7 +774,7 @@ static void test_multiple_alarms_instance(const struct device *dev)
 	err = counter_set_channel_alarm(dev, 1, &cntr_alarm_cfg2);
 	zassert_equal(0, err, "%s: Counter set alarm failed", dev->name);
 
-	k_busy_wait(1.2 * counter_ticks_to_us(dev, ticks * 2U));
+	k_usleep(1.2 * counter_ticks_to_us(dev, ticks * 2U));
 
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
@@ -798,7 +842,7 @@ static void test_all_channels_instance(const struct device *dev)
 		}
 	}
 
-	k_busy_wait(1.5*counter_ticks_to_us(dev, ticks));
+	k_usleep(1.5 * counter_ticks_to_us(dev, ticks));
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
 	zassert_equal(nchan, cnt,
@@ -853,7 +897,7 @@ static void test_valid_function_without_alarm(const struct device *dev)
 		wait_for_us = (ticks_expected * 1000000) / freq;
 	} else {
 		/* Wait long enough for high frequency clocks to minimize
-		 * impact of latencies and k_busy_wait function accuracy.
+		 * impact of latencies and k_usleep function accuracy.
 		 */
 		wait_for_us = 1000;
 		ticks_expected = counter_us_to_ticks(dev, wait_for_us);
@@ -874,7 +918,7 @@ static void test_valid_function_without_alarm(const struct device *dev)
 		ticks_expected = tick_current - ticks_expected;
 	}
 
-	k_busy_wait(wait_for_us);
+	k_usleep(wait_for_us);
 
 	err = counter_get_value(dev, &ticks);
 
@@ -913,9 +957,16 @@ static bool ms_period_capable(const struct device *dev)
 	return false;
 }
 
+static bool valid_function_without_alarm_capable(const struct device *dev)
+{
+	uint32_t ticks;
+
+	return (counter_get_value(dev, &ticks) != -ENOTSUP) && ms_period_capable(dev);
+}
+
 ZTEST(counter_basic, test_valid_function_without_alarm)
 {
-	test_all_instances(test_valid_function_without_alarm, ms_period_capable);
+	test_all_instances(test_valid_function_without_alarm, valid_function_without_alarm_capable);
 }
 
 /**
@@ -945,14 +996,14 @@ static void test_late_alarm_instance(const struct device *dev)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Unexpected error", dev->name);
 
-	k_busy_wait(2*tick_us);
+	k_usleep(2 * tick_us);
 
 	alarm_cfg.ticks = counter_is_counting_up(dev) ? 0 : counter_get_top_value(dev);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 	zassert_equal(-ETIME, err, "%s: Unexpected error (%d)", dev->name, err);
 
 	/* wait couple of ticks */
-	k_busy_wait(5*tick_us);
+	k_usleep(5 * tick_us);
 
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
@@ -969,7 +1020,7 @@ static void test_late_alarm_instance(const struct device *dev)
 			dev->name, err);
 
 	/* wait to ensure that tick+1 timeout will expire. */
-	k_busy_wait(3*tick_us);
+	k_usleep(3 * tick_us);
 
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
@@ -999,7 +1050,7 @@ static void test_late_alarm_error_instance(const struct device *dev)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Unexpected error", dev->name);
 
-	k_busy_wait(2*tick_us);
+	k_usleep(2 * tick_us);
 
 	alarm_cfg.ticks = counter_is_counting_up(dev) ? 0 : counter_get_top_value(dev);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
@@ -1064,7 +1115,7 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 	zassert_equal(0, err, "%s: Unexpected error", dev->name);
 
 	if (IS_ENABLED(CONFIG_COUNTER_NRF_RTC)) {
-		k_busy_wait(1000);
+		k_usleep(1000);
 	}
 
 	alarm_cfg.ticks = 1;
@@ -1076,7 +1127,7 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 				dev->name, err);
 
 		/* wait to ensure that tick+1 timeout will expire. */
-		k_busy_wait(3*tick_us);
+		k_usleep(3 * tick_us);
 
 		cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 			alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
@@ -1120,7 +1171,7 @@ static bool short_relative_capable(const struct device *dev)
 		goto end;
 	}
 
-	k_busy_wait(counter_ticks_to_us(dev, 10));
+	k_usleep(counter_ticks_to_us(dev, 10));
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 			alarm_cnt : k_sem_count_get(&alarm_cnt_sem);
 	if (cnt == 1) {
@@ -1134,7 +1185,7 @@ end:
 	k_sem_reset(&alarm_cnt_sem);
 	alarm_cnt = 0;
 	counter_stop(dev);
-	k_busy_wait(1000);
+	k_usleep(1000);
 
 	return ret;
 }
@@ -1183,7 +1234,7 @@ static void test_cancelled_alarm_does_not_expire_instance(const struct device *d
 		zassert_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
 				dev->name, err);
 
-		k_busy_wait(us/2 + i);
+		k_usleep(us / 2 + i);
 
 		alarm_cfg.ticks = alarm_cfg.ticks + 2*ticks;
 		alarm_cfg.ticks = alarm_cfg.ticks % top;
@@ -1192,7 +1243,7 @@ static void test_cancelled_alarm_does_not_expire_instance(const struct device *d
 				dev->name, err);
 
 		/* wait to ensure that tick+1 timeout will expire. */
-		k_busy_wait(us);
+		k_usleep(us);
 
 		err = counter_cancel_channel_alarm(dev, 0);
 		zassert_equal(0, err, "%s: Failed to cancel an alarm (err: %d)",
@@ -1285,7 +1336,7 @@ static void *counter_setup(void)
 	 * need such delay for the Xtal LF clock source to start and for this
 	 * test to use the correct timing.
 	 */
-	k_busy_wait(USEC_PER_MSEC * 300);
+	k_usleep(USEC_PER_MSEC * 300);
 
 	k_sem_init(&top_cnt_sem, 0, UINT_MAX);
 	k_object_access_grant(&top_cnt_sem, k_current_get());


### PR DESCRIPTION
This fixes several bugs in the RV-3032 counter driver and better aligns its behaviour with the counter API as it is documented. 

Major changes include:
-  `rv3032_counter_get_value` now returns `-ENOTSUP`: the RV-3032 does not support reading the value of its periodic countdown timer
- Added checks in `rv3032_counter_set_alarm` and other functions for invalid arguments, flags, etc.
- `rv3032_counter_set_top_value` can be used to configure a recurring interrupt / callback rather than just setting the top value. Setting an alarm will erase/overwrite a top value callback (only one can be active at a time).
- Added locks for internal thread safety / consistency since top value / alarm callbacks are offloaded to the system work queue. This driver is NOT fully threadsafe though: it is still not safe for a user to call functions from this driver in multiple threads without adding their own thread safety.

### Testing
After refactoring the `counter_basic_api` suite, this driver passes 4 of the tests and skips the other 6. I've tested it at 3 of its clock speeds, making the following local change to the period returned by `get_counter_period_us` (line 229) for each:
```
- 4096 Hz: return 20000; (no change)
- 64 Hz:   return 200000;
- 1 Hz:    return 2000000; (takes ~5 minutes to run)
```
Results for 64 Hz:
```
SUITE PASS - 100.00% [counter_basic]: pass = 4, fail = 0, skip = 6, total = 10 duration = 26.460 seconds
 - PASS - [counter_basic.test_all_channels] duration = 3.108 seconds
 - SKIP - [counter_basic.test_cancelled_alarm_does_not_expire] duration = 0.102 seconds
 - SKIP - [counter_basic.test_late_alarm] duration = 0.102 seconds
 - SKIP - [counter_basic.test_late_alarm_error] duration = 0.102 seconds
 - SKIP - [counter_basic.test_multiple_alarms] duration = 0.105 seconds
 - PASS - [counter_basic.test_set_top_value_with_alarm] duration = 10.511 seconds
 - PASS - [counter_basic.test_short_relative_alarm] duration = 5.112 seconds
 - PASS - [counter_basic.test_single_shot_alarm_notop] duration = 7.109 seconds
 - SKIP - [counter_basic.test_single_shot_alarm_top] duration = 0.107 seconds
 - SKIP - [counter_basic.test_valid_function_without_alarm] duration = 0.102 seconds
```

I have not run the test suite on any other counters after my changes, so I'm open to moving that commit to a different PR if it would be preferable. 

Major test suite changes
- Replace `k_busy_wait` with `k_usleep` since the RV-3032's callbacks are offloaded to a work queue, and don't get a chance to run when using `k_busy_wait`. I'm not sure if there are consequences of this change that could mess with drivers that don't use this approach...
- Added checks to skip some sections if `counter_get_top_value` returns -ENOTSUP