### PR TITLE
boards: nsim: rmx100: enable U-mode extension for PMP stack guards

### DIFF
--- a/boards/snps/nsim/arc_v/support/rmx100.props
+++ b/boards/snps/nsim/arc_v/support/rmx100.props
@@ -1,5 +1,5 @@
 	nsim_isa_family=rv32
-	nsim_isa_ext=-all.i.zicsr.zifencei.zihintpause.a.m.zba.zbb.zbs.zca.zcb.zcmp.zcmt.zicbom
+	nsim_isa_ext=-all.i.zicsr.zifencei.zihintpause.a.m.u.zba.zbb.zbs.zca.zcb.zcmp.zcmt.zicbom
 	nsim_isa_big_endian=0
 	nsim_mmio_base=2560
 	nsim_mem-dev=uart0,kind=16550,base=0x10000000,irq=24


### PR DESCRIPTION
Enable U-mode extension on rmx100 platform to fix kernel.common.stack_protection test.

Per RISC-V spec, section [3.1.6.4. Memory Privilege in mstatus Register](https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#_memory_privilege_in_mstatus_register), `MPRV is read-only 0 if U-mode is not supported.`, preventing unlocked PMP entries from being enforced in M-mode.

Fixes: #105087