### PR TITLE
tests: debug: gdbstub: Handle inlined k_thread_abort case

### DIFF
--- a/tests/subsys/debug/gdbstub/pytest/test_gdbstub.py
+++ b/tests/subsys/debug/gdbstub/pytest/test_gdbstub.py
@@ -57,7 +57,7 @@ def expected_gdb():
     re.compile(r'Breakpoint 1, test '),
     re.compile(r'Breakpoint 2, main '),
     re.compile(r'GDB:PASSED'),
-    re.compile(r'Breakpoint 3, k_thread_abort '),
+    re.compile(r'Breakpoint 3.*, k_thread_abort '),
     re.compile(r'2 .* breakpoint .* in main '),
     ]
 


### PR DESCRIPTION
The `k_thread_abort` syscall may be inlined, in which case setting a breakpoint on `k_thread_abort` can result in breakpoints at multiple locations being set (i.e. Breakpoint 3.1, 3.2, ...).

This commit updates the test regex to handle this case.

---

This issue is observed when building with GCC 14.3 from the Zephyr SDK 1.0.0. See the following excerpt for more information:

```
+b k_thread_abort
Breakpoint 3 at 0x103428: k_thread_abort. (2 locations)
...
++c
Breakpoint 3.1, k_thread_abort (thread=0x1250c0 <z_main_thread>) at /home/stephanos/Dev/zephyrproject/zephyr/twister-out/qemu_x86_atom/zephyr/gnu/tests/subsys/debug/gdbstub/debug.gdbstub_qemu.breakpoints/zephyr/include/generated/zephyr/syscalls/kernel.h:276
```