### PR TITLE
drivers: ethernet: dwmac: support MAC address config

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -498,6 +498,7 @@ Ethernet
   * :dtcompatible:`virtio,net` (:github:`100106`)
   * :dtcompatible:`vnd,ethernet` (:github:`96598`)
   * :dtcompatible:`wiznet,w5500` (:github:`100919`)
+  * :dtcompatible:`snps,designware-ethernet` (:github:`105090`)
 
 * The ``fixed-link`` property has been removed from :dtcompatible:`ethernet-phy`. Use
   the new :dtcompatible:`ethernet-phy-fixed-link` compatible instead, if that functionality

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -494,7 +494,7 @@ Ethernet
   * :dtcompatible:`nxp,enet-mac` (:github:`102775`)
   * :dtcompatible:`sensry,sy1xx-mac` (:github:`100619`)
   * :dtcompatible:`st,stm32n6-ethernet`, :dtcompatible:`st,stm32h7-ethernet`
-    and :dtcompatible:`st,stm32-ethernet` (:github:`102810`)
+    and :dtcompatible:`st,stm32-ethernet` (:github:`102810`, :github:`105090`)
   * :dtcompatible:`virtio,net` (:github:`100106`)
   * :dtcompatible:`vnd,ethernet` (:github:`96598`)
   * :dtcompatible:`wiznet,w5500` (:github:`100919`)

--- a/drivers/ethernet/Kconfig.dwmac
+++ b/drivers/ethernet/Kconfig.dwmac
@@ -32,6 +32,8 @@ config ETH_DWMAC_STM32H7X
 	select ETH_DWMAC
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select PINCTRL
+	select HWINFO
+	select CRC
 	default y
 	help
 	  This enables the Synopsys DesignWare MAC driver on STM32H7 series

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -596,7 +596,10 @@ int dwmac_probe(const struct device *dev)
 	LOG_DBG("hw_feature: 0x%08x 0x%08x 0x%08x 0x%08x",
 		p->feature0, p->feature1, p->feature2, p->feature3);
 
-	dwmac_platform_init(p);
+	ret = dwmac_platform_init(p);
+	if (ret != 0) {
+		return ret;
+	}
 
 	memset(p->tx_descs, 0, NB_TX_DESCS * sizeof(struct dwmac_dma_desc));
 	memset(p->rx_descs, 0, NB_RX_DESCS * sizeof(struct dwmac_dma_desc));

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -36,10 +36,11 @@ int dwmac_bus_init(struct dwmac_priv *p)
 static struct dwmac_dma_desc __aligned(CONFIG_DCACHE_LINE_SIZE)
 			dwmac_tx_rx_descriptors[NB_TX_DESCS + NB_RX_DESCS];
 
-static const uint8_t dwmac_mac_addr[6] = DT_INST_PROP(0, local_mac_address);
+static struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 
 int dwmac_platform_init(struct dwmac_priv *p)
 {
+	int ret;
 	uint8_t *desc_uncached_addr;
 	uintptr_t desc_phys_addr;
 
@@ -83,7 +84,15 @@ int dwmac_platform_init(struct dwmac_priv *p)
 	irq_enable(DT_INST_IRQN(0));
 
 	/* retrieve MAC address */
-	memcpy(p->mac_addr, dwmac_mac_addr, sizeof(p->mac_addr));
+	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
+	if (ret == -ENODATA) {
+		LOG_DBG("No MAC address configured");
+		return 0;
+	}
+	if (ret < 0) {
+		LOG_ERR("Failed to load MAC address (%d)", ret);
+		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -38,7 +38,7 @@ static struct dwmac_dma_desc __aligned(CONFIG_DCACHE_LINE_SIZE)
 
 static const uint8_t dwmac_mac_addr[6] = DT_INST_PROP(0, local_mac_address);
 
-void dwmac_platform_init(struct dwmac_priv *p)
+int dwmac_platform_init(struct dwmac_priv *p)
 {
 	uint8_t *desc_uncached_addr;
 	uintptr_t desc_phys_addr;
@@ -84,6 +84,8 @@ void dwmac_platform_init(struct dwmac_priv *p)
 
 	/* retrieve MAC address */
 	memcpy(p->mac_addr, dwmac_mac_addr, sizeof(p->mac_addr));
+
+	return 0;
 }
 
 /* Our private device instance */

--- a/drivers/ethernet/eth_dwmac_priv.h
+++ b/drivers/ethernet/eth_dwmac_priv.h
@@ -82,7 +82,7 @@ struct dwmac_priv {
 
 int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(struct dwmac_priv *p);
-void dwmac_platform_init(struct dwmac_priv *p);
+int dwmac_platform_init(struct dwmac_priv *p);
 void dwmac_isr(const struct device *ddev);
 extern const struct ethernet_api dwmac_api;
 

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -23,10 +23,16 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ethernet/eth.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/crc.h>
 #include <zephyr/irq.h>
 
 #include "eth_dwmac_priv.h"
+
+#define ST_OUI_B0 0x00
+#define ST_OUI_B1 0x80
+#define ST_OUI_B2 0xE1
 
 PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
@@ -104,8 +110,26 @@ int dwmac_platform_init(struct dwmac_priv *p)
 	/* retrieve MAC address */
 	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
 	if (ret == -ENODATA) {
-		LOG_DBG("No MAC address configured");
-	} else if (ret < 0) {
+		uint8_t unique_device_ID_12_bytes[12];
+		uint32_t result_mac_32_bits;
+
+		/**
+		 * Set MAC address locally administered bit (LAA) as this is not assigned by the
+		 * manufacturer
+		 */
+		p->mac_addr[0] = ST_OUI_B0 | 0x02;
+		p->mac_addr[1] = ST_OUI_B1;
+		p->mac_addr[2] = ST_OUI_B2;
+
+		/* Nothing defined by the user, use device id */
+		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
+		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
+		memcpy(&p->mac_addr[3], &result_mac_32_bits, 3);
+
+		ret = 0;
+	}
+
+	if (ret < 0) {
 		LOG_ERR("Failed to load MAC address (%d)", ret);
 		return ret;
 	}

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -33,6 +33,7 @@ static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
 static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_INST_PARENT(0));
+static struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 
 int dwmac_bus_init(struct dwmac_priv *p)
 {
@@ -81,6 +82,8 @@ static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
 
 int dwmac_platform_init(struct dwmac_priv *p)
 {
+	int ret;
+
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
 
@@ -98,8 +101,14 @@ int dwmac_platform_init(struct dwmac_priv *p)
 		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
-	/* create MAC address */
-	gen_random_mac(p->mac_addr, 0x00, 0x80, 0xE1);
+	/* retrieve MAC address */
+	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
+	if (ret == -ENODATA) {
+		LOG_DBG("No MAC address configured");
+	} else if (ret < 0) {
+		LOG_ERR("Failed to load MAC address (%d)", ret);
+		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -79,7 +79,7 @@ int dwmac_bus_init(struct dwmac_priv *p)
 static struct dwmac_dma_desc dwmac_tx_descs[NB_TX_DESCS] __desc_mem;
 static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
 
-void dwmac_platform_init(struct dwmac_priv *p)
+int dwmac_platform_init(struct dwmac_priv *p)
 {
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
@@ -100,6 +100,8 @@ void dwmac_platform_init(struct dwmac_priv *p)
 
 	/* create MAC address */
 	gen_random_mac(p->mac_addr, 0x00, 0x80, 0xE1);
+
+	return 0;
 }
 
 /* Our private device instance */

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -141,7 +141,8 @@ static int eth_initialize(const struct device *dev)
 		return ret;
 	}
 
-	if (cfg->mac_cfg.type == NET_ETH_MAC_DEFAULT) {
+	ret = net_eth_mac_load(&cfg->mac_cfg, dev_data->mac_addr);
+	if (ret == -ENODATA) {
 		uint8_t unique_device_ID_12_bytes[12];
 		uint32_t result_mac_32_bits;
 
@@ -157,12 +158,13 @@ static int eth_initialize(const struct device *dev)
 		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
 		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
 		memcpy(&dev_data->mac_addr[3], &result_mac_32_bits, 3);
-	} else {
-		ret = net_eth_mac_load(&cfg->mac_cfg, dev_data->mac_addr);
-		if (ret < 0) {
-			LOG_ERR("Failed to load MAC (%d)", ret);
-			return ret;
-		}
+
+		ret = 0;
+	}
+
+	if (ret < 0) {
+		LOG_ERR("Failed to load MAC address (%d)", ret);
+		return ret;
 	}
 
 	heth->Init.MACAddr = dev_data->mac_addr;


### PR DESCRIPTION
Update the dwmac ethernet drivers to use a MAC address configuration struct and align the STM32 dwmac driver with the HAL-based driver, so that both use the same default MAC address.