### PR TITLE
cmake: linker: ld: Always specify -znoexecstack for bare metal

### DIFF
--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -10,6 +10,7 @@ check_set_linker_property(TARGET linker PROPERTY base
 check_set_linker_property(TARGET linker PROPERTY baremetal
                           -nostdlib
                           -static
+                          -znoexecstack
                           ${LINKERFLAGPREFIX},-X
                           ${LINKERFLAGPREFIX},-N
 )

--- a/scripts/build/gen_image_info.py
+++ b/scripts/build/gen_image_info.py
@@ -58,8 +58,14 @@ def read_segments(filename):
     elffile = ELFFile(open(filename, 'rb'))  # noqa: SIM115
     segments = list()
     for segment_idx in range(elffile.num_segments()):
-        segments.insert(segment_idx, dict())
-        segments[segment_idx]['segment'] = elffile.get_segment(segment_idx)
+        segment = dict()
+        segment['segment'] = elffile.get_segment(segment_idx)
+
+        # PT_GNU_STACK segment has no loadable details (i.e. zero LMA/VMA and size), so skip it.
+        if segment['segment'].header.p_type == 'PT_GNU_STACK':
+            continue
+
+        segments.append(segment)
     return segments
 
 


### PR DESCRIPTION
Binutils 2.39 and above print out a warning when `.note.GNU-stack` section is missing from an object file.

```
  ld.bfd: warning: _thumb1_case_uqi.o: missing .note.GNU-stack section
  implies executable stack
  ld.bfd: NOTE: This behaviour is deprecated and will be removed in a future
  version of the linker
```

This commit adds `-znoexecstack` when linking bare metal executables to mark that stack is not executable when `.note.GNU-stack` section is missing, effectively suppressing the above warning.