### PR TITLE
doc: Update binding default documentation

### DIFF
--- a/doc/build/dts/bindings-upstream.rst
+++ b/doc/build/dts/bindings-upstream.rst
@@ -191,6 +191,10 @@ safely defaulted. Candidates for default values include:
 - defaults which match the vendor-specified power-on reset value
   (as long as they are independent from other properties)
 
+Default values for ``#address-cells`` and ``#size-cells`` cannot be defined in the
+bindings. The default behavior for these properties is already defined in the
+devicetree specification `§2.3.5 <https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#address-cells-and-size-cells>`_.
+
 Examples of how to write descriptions according to these rules:
 
 .. code-block:: yaml


### PR DESCRIPTION
Update the documentation for default values in bindings to clarify that default values for ``#address-cells`` and ``#size-cells`` cannot be defined in the bindings, as their default behavior is already defined in the devicetree specification section 2.3.5.

This to complement:
- https://github.com/zephyrproject-rtos/zephyr/issues/104478
- https://github.com/zephyrproject-rtos/zephyr/pull/104931