### PR TITLE
drivers: dma: stm32u5: remove unused function

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -170,18 +170,6 @@ bool stm32_dma_is_ht_irq_active(DMA_TypeDef *dma, uint32_t id)
 		LL_DMA_IsActiveFlag_HT(dma, dma_stm32_id_to_stream(id)));
 }
 
-static inline bool stm32_dma_is_te_irq_active(DMA_TypeDef *dma, uint32_t id)
-{
-	return (
-		(LL_DMA_IsEnabledIT_DTE(dma, dma_stm32_id_to_stream(id)) &&
-		LL_DMA_IsActiveFlag_DTE(dma, dma_stm32_id_to_stream(id))) ||
-		(LL_DMA_IsEnabledIT_ULE(dma, dma_stm32_id_to_stream(id)) &&
-		LL_DMA_IsActiveFlag_ULE(dma, dma_stm32_id_to_stream(id))) ||
-		(LL_DMA_IsEnabledIT_USE(dma, dma_stm32_id_to_stream(id)) &&
-		LL_DMA_IsActiveFlag_USE(dma, dma_stm32_id_to_stream(id)))
-		);
-}
-
 /* check if and irq of any type occurred on the channel */
 #define stm32_dma_is_irq_active LL_DMA_IsActiveFlag_MIS
 


### PR DESCRIPTION
Remove a unused function that causes a warning when building with clang from new zephyr sdk 1.0.0-rc1.

```
/home/user/west_workspace/zephyr/drivers/dma/dma_stm32u5.c:173:20: error: unused function 'stm32_dma_is_te_irq_active' [-Werror,-Wunused-function]
  173 | static inline bool stm32_dma_is_te_irq_active(DMA_TypeDef *dma, uint32_t id)
      |    
```