### PR TITLE
Ch32v2x 3x/common components

### DIFF
--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -4,185 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <freq.h>
-#include <mem.h>
 #include <wch/qingke-v4b.dtsi>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <wch/common/ch32v20x_30x_common.dtsi>
 
-/ {
-	clocks {
-		clk_hse: clk-hse {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hse-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
+};
 
-		clk_hsi: clk-hsi {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hsi-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
+&pll {
+	mul = <15>;
+};
 
-		clk_lsi: clk-lsi {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
-			status = "disabled";
-		};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(10)>;
+};
 
-		pll: pll {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
-			mul = <15>;
-			status = "disabled";
-		};
-	};
-
-	soc {
-		sram0: memory@20000000 {
-			compatible = "mmio-sram";
-		};
-
-		flash: flash-controller@40022000 {
-			compatible = "wch,ch32v20x_30x-flash-controller";
-			reg = <0x40022000 0x400>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				reg = <0x08000000 DT_SIZE_K(224)>;
-			};
-		};
-
-		pwr: pwr@40007000 {
-			compatible = "wch,pwr";
-			reg = <0x40007000 16>;
-		};
-
-		pinctrl: pin-controller@40010000 {
-			compatible = "wch,20x_30x-afio";
-			reg = <0x40010000 16>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
-
-			gpioa: gpio@40010800 {
-				compatible = "wch,gpio";
-				reg = <0x40010800 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
-			};
-
-			gpiob: gpio@40010c00 {
-				compatible = "wch,gpio";
-				reg = <0x40010c00 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
-			};
-
-			gpioc: gpio@40011000 {
-				compatible = "wch,gpio";
-				reg = <0x40011000 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
-			};
-
-			gpiod: gpio@40011400 {
-				compatible = "wch,gpio";
-				reg = <0x40011400 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
-			};
-		};
-
-		usart1: uart@40013800 {
-			compatible = "wch,usart";
-			reg = <0x40013800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <53>;
-			status = "disabled";
-		};
-
-		usart2: uart@40004400 {
-			compatible = "wch,usart";
-			reg = <0x40004400 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
-			interrupt-parent = <&pfic>;
-			interrupts = <54>;
-			status = "disabled";
-		};
-
-		spi1: spi@40013000 {
-			compatible = "wch,spi";
-			reg = <0x40013000 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <51>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		spi2: spi@40003800 {
-			compatible = "wch,spi";
-			reg = <0x40003800 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
-			interrupt-parent = <&pfic>;
-			interrupts = <52>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		i2c1: i2c@40005400 {
-			compatible = "wch,i2c";
-			reg = <0x40005400 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <47>, <48>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		i2c2: i2c@40005800 {
-			compatible = "wch,i2c";
-			reg = <0x40005800 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
-			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
-			reg = <0x40021000 16>;
-			#clock-cells = <1>;
-		};
-
-		rng: rng@40023c00 {
-			compatible = "wch,rng";
-			reg = <0x40023c00 12>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_RNG>;
-			status = "disabled";
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(224)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(224)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(224)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c6t.dtsi
@@ -6,14 +6,23 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpioc {
 	gpio-reserved-ranges = <0 13>;
 };
 
 &gpiod {
 	gpio-reserved-ranges = <2 16>;
-};
-
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(10)>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203c8t.dtsi
@@ -6,20 +6,17 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
-&gpioc {
-	gpio-reserved-ranges = <0 13>;
-};
-
-&gpiod {
-	gpio-reserved-ranges = <2 16>;
-};
-
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(20)>;
-};
-
 / {
 	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+
 		usart3: uart@40004800 {
 			compatible = "wch,usart";
 			reg = <0x40004800 0x20>;
@@ -37,5 +34,39 @@
 			interrupts = <68>;
 			status = "disabled";
 		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
 	};
+};
+
+&gpioc {
+	gpio-reserved-ranges = <0 13>;
+};
+
+&gpiod {
+	gpio-reserved-ranges = <2 16>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(20)>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203f6p.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f6p.dtsi
@@ -21,7 +21,3 @@
 &gpiod {
 	gpio-reserved-ranges = <2 16>;
 };
-
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(10)>;
-};

--- a/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8p.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpioa {
 	gpio-reserved-ranges = <11 13>, <15 16>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203f8u.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpioa {
 	gpio-reserved-ranges = <11 13>, <15 16>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g6u.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpioa {
 	gpio-reserved-ranges = <8 9>;
 };
@@ -20,8 +33,4 @@
 
 &gpiod {
 	gpio-reserved-ranges = <2 16>;
-};
-
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(10)>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203g8r.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpioa {
 	gpio-reserved-ranges = <15 16>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k6t.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpiob {
 	gpio-reserved-ranges = <9 16>;
 };
@@ -16,8 +29,4 @@
 
 &gpiod {
 	gpio-reserved-ranges = <2 16>;
-};
-
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(10)>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203k8t.dtsi
@@ -6,6 +6,19 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+	};
+};
+
 &gpiob {
 	gpio-reserved-ranges = <9 16>;
 };

--- a/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
@@ -6,30 +6,63 @@
 
 #include <wch/ch32v203/ch32v203.dtsi>
 
+/ {
+	soc {
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpiod {
 	gpio-reserved-ranges = <3 16>;
 };
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
-};
-
-soc {
-	usart3: uart@40004800 {
-		compatible = "wch,usart";
-		reg = <0x40004800 0x20>;
-		clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
-		interrupt-parent = <&pfic>;
-		interrupts = <55>;
-		status = "disabled";
-	};
-
-	usart4: uart@40004c00 {
-		compatible = "wch,usart";
-		reg = <0x40004c00 0x20>;
-		clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
-		interrupt-parent = <&pfic>;
-		interrupts = <68>;
-		status = "disabled";
-	};
 };

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -4,141 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <freq.h>
-#include <mem.h>
 #include <wch/qingke-v4c.dtsi>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <wch/common/ch32v20x_30x_common.dtsi>
 
 / {
-	clocks {
-		clk_hse: clk-hse {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hse-clock";
-			clock-frequency = <DT_FREQ_M(32)>;
-			status = "disabled";
-		};
-
-		clk_hsi: clk-hsi {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hsi-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
-
-		clk_lsi: clk-lsi {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
-			status = "disabled";
-		};
-
-		pll: pll {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
-			mul = <15>;
-			status = "disabled";
-		};
-	};
-
 	soc {
-		sram0: memory@20000000 {
-			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(64)>;
-		};
-
-		flash: flash-controller@40022000 {
-			compatible = "wch,ch32v20x_30x-flash-controller";
-			reg = <0x40022000 0x400>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				reg = <0x08000000 DT_SIZE_K(480)>;
-			};
-		};
-
-		pwr: pwr@40007000 {
-			compatible = "wch,pwr";
-			reg = <0x40007000 16>;
-		};
-
-		iwdg: watchdog@40003000 {
-			compatible = "wch,iwdg";
-			reg = <0x40003000 0x10>;
-			status = "disabled";
-		};
-
-		exti: interrupt-controller@40010400 {
-			compatible = "wch,exti";
-			interrupt-controller;
-			#interrupt-cells = <1>;
-			reg = <0x40010400 16>;
-			interrupt-parent = <&pfic>;
-			num-lines = <16>;
-			line-ranges = <0 1>, <1 1>, <2 1>, <3 1>, <4 1>,
-				      <5 5>, <10 6>;
-			interrupts = <22 23 24 25 26 39 56>;
-			interrupt-names = "line0", "line1", "line2", "line3",
-					  "line4", "line5-9", "line10-15";
-			status = "disabled";
-		};
-
-		pinctrl: pin-controller@40010000 {
-			compatible = "wch,20x_30x-afio";
-			reg = <0x40010000 16>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
-
-			gpioa: gpio@40010800 {
-				compatible = "wch,gpio";
-				reg = <0x40010800 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
-			};
-
-			gpiob: gpio@40010c00 {
-				compatible = "wch,gpio";
-				reg = <0x40010c00 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
-			};
-
-			gpioc: gpio@40011000 {
-				compatible = "wch,gpio";
-				reg = <0x40011000 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
-			};
-
-			gpiod: gpio@40011400 {
-				compatible = "wch,gpio";
-				reg = <0x40011400 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
-			};
-		};
-
-		usart1: uart@40013800 {
-			compatible = "wch,usart";
-			reg = <0x40013800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <53>;
-			status = "disabled";
-		};
-
 		usart2: uart@40004400 {
 			compatible = "wch,usart";
 			reg = <0x40004400 0x20>;
@@ -147,82 +17,23 @@
 			interrupts = <54>;
 			status = "disabled";
 		};
-
-		usart3: uart@40004800 {
-			compatible = "wch,usart";
-			reg = <0x40004800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
-			interrupt-parent = <&pfic>;
-			interrupts = <55>;
-			status = "disabled";
-		};
-
-		usart4: uart@40004c00 {
-			compatible = "wch,usart";
-			reg = <0x40004c00 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
-			interrupt-parent = <&pfic>;
-			interrupts = <68>;
-			status = "disabled";
-		};
-
-		spi1: spi@40013000 {
-			compatible = "wch,spi";
-			reg = <0x40013000 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <51>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		spi2: spi@40003800 {
-			compatible = "wch,spi";
-			reg = <0x40003800 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
-			interrupt-parent = <&pfic>;
-			interrupts = <52>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		i2c1: i2c@40005400 {
-			compatible = "wch,i2c";
-			reg = <0x40005400 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <47>, <48>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		i2c2: i2c@40005800 {
-			compatible = "wch,i2c";
-			reg = <0x40005800 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
-			interrupt-parent = <&pfic>;
-			interrupts = <49>, <50>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
-			reg = <0x40021000 16>;
-			#clock-cells = <1>;
-		};
-
-		rng: rng@40023c00 {
-			compatible = "wch,rng";
-			reg = <0x40023c00 12>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_RNG>;
-			status = "disabled";
-		};
 	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(32)>;
+};
+
+&pll {
+	mul = <15>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(64)>;
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -34,6 +34,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(480)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208cbu.dtsi
@@ -6,6 +6,50 @@
 
 #include <wch/ch32v208/ch32v208.dtsi>
 
+/ {
+	soc {
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpioc {
 	gpio-reserved-ranges = <0 13>;
 };

--- a/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208rbt.dtsi
@@ -6,6 +6,50 @@
 
 #include <wch/ch32v208/ch32v208.dtsi>
 
+/ {
+	soc {
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpiod {
 	gpio-reserved-ranges = <0 2>, <3 12>;
 };

--- a/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208wbu.dtsi
@@ -6,6 +6,50 @@
 
 #include <wch/ch32v208/ch32v208.dtsi>
 
+/ {
+	soc {
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "wch,spi";
+			reg = <0x40003800 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <52>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "wch,i2c";
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <49>, <50>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpiod {
 	gpio-reserved-ranges = <0 2>, <7 8>;
 };

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -4,128 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <freq.h>
-#include <mem.h>
 #include <wch/qingke-v4f.dtsi>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <wch/common/ch32v20x_30x_common.dtsi>
 
 / {
-	clocks {
-		clk_hse: clk-hse {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hse-clock";
-			clock-frequency = <DT_FREQ_M(32)>;
-			status = "disabled";
-		};
-
-		clk_hsi: clk-hsi {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hsi-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
-
-		clk_lsi: clk-lsi {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
-			status = "disabled";
-		};
-
-		pll: pll {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
-			mul = <18>;
-			status = "disabled";
-		};
-	};
-
 	soc {
-		sram0: memory@20000000 {
-			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(32)>;
-		};
-
-		flash: flash-controller@40022000 {
-			compatible = "wch,ch32v20x_30x-flash-controller";
-			reg = <0x40022000 0x400>;
-
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				reg = <0x08000000 DT_SIZE_K(480)>;
-			};
-		};
-
-		pwr: pwr@40007000 {
-			compatible = "wch,pwr";
-			reg = <0x40007000 16>;
-		};
-
 		pinctrl: pin-controller@40010000 {
-			compatible = "wch,20x_30x-afio";
-			reg = <0x40010000 16>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
-
-			gpioa: gpio@40010800 {
-				compatible = "wch,gpio";
-				reg = <0x40010800 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
-			};
-
-			gpiob: gpio@40010c00 {
-				compatible = "wch,gpio";
-				reg = <0x40010c00 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
-			};
-
-			gpioc: gpio@40011000 {
-				compatible = "wch,gpio";
-				reg = <0x40011000 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
-			};
-
-			gpiod: gpio@40011400 {
-				compatible = "wch,gpio";
-				reg = <0x40011400 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <16>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
-			};
-
 			gpioe: gpio@40011800 {
 				compatible = "wch,gpio";
 				reg = <0x40011800 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <16>;
+				ngpios = <8>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPE>;
 			};
-		};
-
-		usart1: uart@40013800 {
-			compatible = "wch,usart";
-			reg = <0x40013800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <53>;
-			status = "disabled";
 		};
 
 		usart2: uart@40004400 {
@@ -146,79 +38,12 @@
 			status = "disabled";
 		};
 
-		usart4: uart@40004c00 {
-			compatible = "wch,usart";
-			reg = <0x40004c00 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
-			interrupt-parent = <&pfic>;
-			interrupts = <68>;
-			status = "disabled";
-		};
-
-		usart5: uart@40005000 {
-			compatible = "wch,usart";
-			reg = <0x40005000 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
-			interrupt-parent = <&pfic>;
-			interrupts = <69>;
-			status = "disabled";
-		};
-
-		usart6: uart@40001800 {
-			compatible = "wch,usart";
-			reg = <0x40001800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
-			interrupt-parent = <&pfic>;
-			interrupts = <87>;
-			status = "disabled";
-		};
-
-		usart7: uart@40001c00 {
-			compatible = "wch,usart";
-			reg = <0x40001c00 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
-			interrupt-parent = <&pfic>;
-			interrupts = <88>;
-			status = "disabled";
-		};
-
-		usart8: uart@40002000 {
-			compatible = "wch,usart";
-			reg = <0x40002000 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
-			interrupt-parent = <&pfic>;
-			interrupts = <89>;
-			status = "disabled";
-		};
-
-		spi1: spi@40013000 {
-			compatible = "wch,spi";
-			reg = <0x40013000 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <51>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
 		spi2: spi@40003800 {
 			compatible = "wch,spi";
 			reg = <0x40003800 0x24>;
 			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI2>;
 			interrupt-parent = <&pfic>;
 			interrupts = <52>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		i2c1: i2c@40005400 {
-			compatible = "wch,i2c";
-			reg = <0x40005400 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <47>, <48>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -234,42 +59,23 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
-
-		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
-			reg = <0x40021000 16>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
-		rng: rng@40023c00 {
-			compatible = "wch,rng";
-			reg = <0x40023c00 12>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_RNG>;
-			status = "disabled";
-		};
-
-		dma1: dma@40020000 {
-			compatible = "wch,wch-dma";
-			reg = <0x40020000 0x90>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
-			#dma-cells = <1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
-			dma-channels = <7>;
-		};
-
-		dma2: dma@40020400 {
-			compatible = "wch,wch-dma";
-			reg = <0x40020400 0x90>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
-			#dma-cells = <1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
-				     <101>, <102>, <103>;
-			dma-channels = <11>;
-		};
 	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(32)>;
+};
+
+&pll {
+	mul = <18>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -76,6 +76,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(480)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
@@ -17,3 +17,7 @@
 &gpioe {
 	gpio-reserved-ranges = <0 16>;
 };
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
+};

--- a/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
@@ -20,4 +20,5 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
@@ -13,3 +13,7 @@
 &gpioe {
 	gpio-reserved-ranges = <0 16>;
 };
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
+};

--- a/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
@@ -16,4 +16,5 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
@@ -6,6 +6,66 @@
 
 #include <wch/ch32v303/ch32v303.dtsi>
 
+/ {
+	soc {
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		usart5: uart@40005000 {
+			compatible = "wch,usart";
+			reg = <0x40005000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			interrupt-parent = <&pfic>;
+			interrupts = <69>;
+			status = "disabled";
+		};
+
+		usart6: uart@40001800 {
+			compatible = "wch,usart";
+			reg = <0x40001800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			interrupt-parent = <&pfic>;
+			interrupts = <87>;
+			status = "disabled";
+		};
+
+		usart7: uart@40001c00 {
+			compatible = "wch,usart";
+			reg = <0x40001c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			interrupt-parent = <&pfic>;
+			interrupts = <88>;
+			status = "disabled";
+		};
+
+		usart8: uart@40002000 {
+			compatible = "wch,usart";
+			reg = <0x40002000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			interrupt-parent = <&pfic>;
+			interrupts = <89>;
+			status = "disabled";
+		};
+
+		spi3: spi@4003c00 {
+			compatible = "wch,spi";
+			reg = <0x4003c00 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <67>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpiod {
 	gpio-reserved-ranges = <3 13>;
 };

--- a/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
@@ -6,6 +6,66 @@
 
 #include <wch/ch32v303/ch32v303.dtsi>
 
+/ {
+	soc {
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		usart5: uart@40005000 {
+			compatible = "wch,usart";
+			reg = <0x40005000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			interrupt-parent = <&pfic>;
+			interrupts = <69>;
+			status = "disabled";
+		};
+
+		usart6: uart@40001800 {
+			compatible = "wch,usart";
+			reg = <0x40001800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			interrupt-parent = <&pfic>;
+			interrupts = <87>;
+			status = "disabled";
+		};
+
+		usart7: uart@40001c00 {
+			compatible = "wch,usart";
+			reg = <0x40001c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			interrupt-parent = <&pfic>;
+			interrupts = <88>;
+			status = "disabled";
+		};
+
+		usart8: uart@40002000 {
+			compatible = "wch,usart";
+			reg = <0x40002000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			interrupt-parent = <&pfic>;
+			interrupts = <89>;
+			status = "disabled";
+		};
+
+		spi3: spi@4003c00 {
+			compatible = "wch,spi";
+			reg = <0x4003c00 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <67>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
 &gpioc {
 	gpio-reserved-ranges = <0 3>, <14 2>;
 };

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -4,115 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <freq.h>
-#include <mem.h>
 #include <wch/qingke-v4f.dtsi>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+#include <wch/common/ch32v20x_30x_common.dtsi>
 
 / {
-	chosen {
-		zephyr,entropy = &rng;
-	};
-
-	clocks {
-		clk_hse: clk-hse {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hse-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
-
-		clk_hsi: clk-hsi {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v00x-hsi-clock";
-			clock-frequency = <DT_FREQ_M(8)>;
-			status = "disabled";
-		};
-
-		clk_lsi: clk-lsi {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
-			status = "disabled";
-		};
-
-		pll: pll {
-			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
-			mul = <18>;
-			status = "disabled";
-		};
-	};
-
 	soc {
-		sram0: memory@20000000 {
-			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(32)>;
-		};
+		eth: ethernet@40028000 {
+			reg = <0x40028000 0x2000>;
+			compatible = "wch,ethernet-controller";
+			clocks = <&rcc CH32V20X_V30X_CLOCK_ETHMAC>,
+				 <&rcc CH32V20X_V30X_CLOCK_ETHMACTX>,
+				 <&rcc CH32V20X_V30X_CLOCK_ETHMACRX>;
+			clock-names = "mac", "tx", "rx";
 
-		flash: flash-controller@40022000 {
-			compatible = "wch,ch32v20x_30x-flash-controller";
-			reg = <0x40022000 0x400>;
-
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				reg = <0x08000000 DT_SIZE_K(480)>;
+			mac: ethernet {
+				compatible = "wch,ethernet";
+				interrupt-parent = <&pfic>;
+				interrupts = <77>, <78>;
+				internal-phy-pllmul = "15";
+				internal-phy-prediv = "2";
+				status = "disabled";
 			};
-		};
 
-		pwr: pwr@40007000 {
-			compatible = "wch,pwr";
-			reg = <0x40007000 16>;
+			mdio: mdio {
+				compatible = "wch,mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 
 		pinctrl: pin-controller@40010000 {
-			compatible = "wch,20x_30x-afio";
-			reg = <0x40010000 16>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
-
-			gpioa: gpio@40010800 {
-				compatible = "wch,gpio";
-				reg = <0x40010800 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <8>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
-			};
-
-			gpiob: gpio@40010c00 {
-				compatible = "wch,gpio";
-				reg = <0x40010c00 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <8>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
-			};
-
-			gpioc: gpio@40011000 {
-				compatible = "wch,gpio";
-				reg = <0x40011000 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <8>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
-			};
-
-			gpiod: gpio@40011400 {
-				compatible = "wch,gpio";
-				reg = <0x40011400 0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <8>;
-				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
-			};
-
 			gpioe: gpio@40011800 {
 				compatible = "wch,gpio";
 				reg = <0x40011800 0x20>;
@@ -121,15 +43,6 @@
 				ngpios = <8>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPE>;
 			};
-		};
-
-		usart1: uart@40013800 {
-			compatible = "wch,usart";
-			reg = <0x40013800 0x20>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <53>;
-			status = "disabled";
 		};
 
 		usart2: uart@40004400 {
@@ -195,17 +108,6 @@
 			status = "disabled";
 		};
 
-		spi1: spi@40013000 {
-			compatible = "wch,spi";
-			reg = <0x40013000 0x24>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <51>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
 		spi2: spi@40003800 {
 			compatible = "wch,spi";
 			reg = <0x40003800 0x24>;
@@ -228,17 +130,6 @@
 			#size-cells = <0>;
 		};
 
-		i2c1: i2c@40005400 {
-			compatible = "wch,i2c";
-			reg = <0x40005400 0x400>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <47>, <48>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
 		i2c2: i2c@40005800 {
 			compatible = "wch,i2c";
 			reg = <0x40005800 0x400>;
@@ -249,67 +140,23 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
-
-		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
-			reg = <0x40021000 16>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
-		rng: rng@40023c00 {
-			compatible = "wch,rng";
-			reg = <0x40023c00 12>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_RNG>;
-			status = "disabled";
-		};
-
-		dma1: dma@40020000 {
-			compatible = "wch,wch-dma";
-			reg = <0x40020000 0x90>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
-			#dma-cells = <1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
-			dma-channels = <7>;
-		};
-
-		dma2: dma@40020400 {
-			compatible = "wch,wch-dma";
-			reg = <0x40020400 0x90>;
-			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
-			#dma-cells = <1>;
-			interrupt-parent = <&pfic>;
-			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
-				     <101>, <102>, <103>;
-			dma-channels = <11>;
-		};
-
-		eth: ethernet@40028000 {
-			reg = <0x40028000 0x2000>;
-			compatible = "wch,ethernet-controller";
-			clocks = <&rcc CH32V20X_V30X_CLOCK_ETHMAC>,
-				 <&rcc CH32V20X_V30X_CLOCK_ETHMACTX>,
-				 <&rcc CH32V20X_V30X_CLOCK_ETHMACRX>;
-			clock-names = "mac", "tx", "rx";
-
-			mac: ethernet {
-				compatible = "wch,ethernet";
-				interrupt-parent = <&pfic>;
-				interrupts = <77>, <78>;
-				internal-phy-pllmul = "15";
-				internal-phy-prediv = "2";
-				status = "disabled";
-			};
-
-			mdio: mdio {
-				compatible = "wch,mdio";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				status = "disabled";
-			};
-		};
 	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&pll {
+	mul = <18>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -157,6 +157,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(480)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(480)>;
 };
 
 &cpu0 {

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025 James Bennion-Pedley
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+#include <mem.h>
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+
+	clocks {
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hse-clock";
+			clock-frequency = <DT_FREQ_M(8)>;
+			status = "disabled";
+		};
+
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hsi-clock";
+			clock-frequency = <DT_FREQ_M(8)>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(32)>;
+			status = "disabled";
+		};
+
+		pll: pll {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v20x_30x-pll-clock";
+			mul = <18>;
+			status = "disabled";
+		};
+	};
+
+	soc {
+		sram0: memory@20000000 {
+			compatible = "mmio-sram";
+		};
+
+		flash: flash-controller@40022000 {
+			compatible = "wch,ch32v20x_30x-flash-controller";
+			reg = <0x40022000 0x400>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+			};
+		};
+
+		pwr: pwr@40007000 {
+			compatible = "wch,pwr";
+			reg = <0x40007000 16>;
+		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "wch,iwdg";
+			reg = <0x40003000 0x10>;
+			status = "disabled";
+		};
+
+		exti: interrupt-controller@40010400 {
+			compatible = "wch,exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 16>;
+			interrupt-parent = <&pfic>;
+			num-lines = <16>;
+			line-ranges = <0 1>, <1 1>, <2 1>, <3 1>, <4 1>,
+				      <5 5>, <10 6>;
+			interrupts = <22 23 24 25 26 39 56>;
+			interrupt-names = "line0", "line1", "line2", "line3",
+					  "line4", "line5-9", "line10-15";
+			status = "disabled";
+		};
+
+		pinctrl: pin-controller@40010000 {
+			compatible = "wch,20x_30x-afio";
+			reg = <0x40010000 16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
+
+			gpioa: gpio@40010800 {
+				compatible = "wch,gpio";
+				reg = <0x40010800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
+			};
+
+			gpiob: gpio@40010c00 {
+				compatible = "wch,gpio";
+				reg = <0x40010c00 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
+			};
+
+			gpioc: gpio@40011000 {
+				compatible = "wch,gpio";
+				reg = <0x40011000 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
+			};
+
+			gpiod: gpio@40011400 {
+				compatible = "wch,gpio";
+				reg = <0x40011400 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
+			};
+		};
+
+		usart1: uart@40013800 {
+			compatible = "wch,usart";
+			reg = <0x40013800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <53>;
+			status = "disabled";
+		};
+
+		spi1: spi@40013000 {
+			compatible = "wch,spi";
+			reg = <0x40013000 0x24>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_SPI1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <51>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1: i2c@40005400 {
+			compatible = "wch,i2c";
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_I2C1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <47>, <48>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		rcc: rcc@40021000 {
+			compatible = "wch,rcc";
+			reg = <0x40021000 16>;
+			#clock-cells = <1>;
+			status = "okay";
+		};
+
+		rng: rng@40023c00 {
+			compatible = "wch,rng";
+			reg = <0x40023c00 12>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_RNG>;
+			status = "disabled";
+		};
+
+		dma1: dma@40020000 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020000 0xa8>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
+			dma-channels = <7>;
+		};
+
+		dma2: dma@40020400 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020400 0xd8>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
+				     <101>, <102>, <103>;
+			dma-channels = <11>;
+		};
+	};
+};

--- a/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
+++ b/dts/riscv/wch/common/ch32v20x_30x_common.dtsi
@@ -54,12 +54,17 @@
 		flash: flash-controller@40022000 {
 			compatible = "wch,ch32v20x_30x-flash-controller";
 			reg = <0x40022000 0x400>;
+			ranges;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				ranges = <0x0 0x08000000 DT_SIZE_K(480)>;
+
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 


### PR DESCRIPTION
This PR moves all common `CH32V20x/30x` peripheral DTS to a central DTSI file.

These peripherals have common definitions across the whole SOC family and are defined in the same reference manual provided by WCH [CH32FV2xV3xRM](https://www.wch-ic.com/downloads/CH32FV2x_V3xRM_PDF.html).
<img width="489" height="411" alt="image" src="https://github.com/user-attachments/assets/8099beed-3fc1-441d-9b75-c2fb135b7ba9" />

Currently all of the peripherals a maintained separately, so peripherals have been added inconsistently to different SOCs.
This PR moves them all centrally, with each board responsible for reserving GPIOs/deleting peripheral nodes that it does not use. As best as I can tell the compiled DTS is identical after this change, but please let me know if I've inadvertently deleted something.

WCH documents this nicely in the datasheet for each chip. The peripheral registers are consistent across the whole family, but each SOC / package will include slightly different numbers of each peripheral.
<img width="720" height="503" alt="image" src="https://github.com/user-attachments/assets/03719038-6be9-41e1-b13c-13137efee6eb" />

I have also cherry picked https://github.com/zephyrproject-rtos/zephyr/pull/98978 onto this PR with a note added to the migration guide about the rename.

With these changes in place it should be fairly trivial to add SOC support for the missing `CH32V305`/`CH32V317` socs.

This includes some of the DTS additions from https://github.com/zephyrproject-rtos/zephyr/pull/101390, so ideally that should get merged first and I'll rebase.