### PR TITLE
soc: st: stm32c5: Add initial support for C5 SoC series

### DIFF
--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -1,0 +1,750 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/stm32c5_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/reset/stm32c5_reset.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <freq.h>
+#include <mem.h>
+
+/ {
+	chosen {
+		zephyr,flash-controller = &flash;
+		zephyr,entropy = &rng;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m33";
+			reg = <0>;
+			cpu-power-states = <&stop0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
+		};
+
+		power-states {
+			stop0: state0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <20>;
+			};
+		};
+	};
+
+	clocks {
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "st,stm32-hse-clock";
+			status = "disabled";
+		};
+
+		clk_hsis: clk-hsis {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(144)>;
+			status = "disabled";
+		};
+
+		clk_hsidiv3: clk-hsidiv3 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "okay";
+		};
+
+		clk_psis: clk-psis {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(160)>;
+			status = "disabled";
+		};
+
+		clk_psidiv3: clk-psidiv3 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
+		clk_lse: clk-lse {
+			#clock-cells = <0>;
+			compatible = "st,stm32-lse-clock";
+			clock-frequency = <32768>;
+			driving-capability = <2>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(32)>;
+			status = "disabled";
+		};
+	};
+
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
+	soc {
+		flash: flash-controller@40022000 {
+			compatible = "st,stm32-flash-controller", "st,stm32l5-flash-controller";
+			reg = <0x40022000 0x400>;
+			interrupts = <5 0>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				write-block-size = <16>;
+				erase-block-size = <8192>;
+				max-erase-time = <10>;
+			};
+		};
+
+		/*
+		 * Reset and Clock Control
+		 * Base address: 0x44020C00 (APB3, RM0522 Table 3)
+		 *
+		 * compatible: "st,stm32c5-rcc" - requires a dedicated driver
+		 * because STM32C5 uses HSIS/PSIS instead of PLLs!
+		 */
+		rcc: rcc@44020c00 {
+			compatible = "st,stm32c5-rcc";
+			clocks-controller;
+			#clock-cells = <2>;
+			reg = <0x44020c00 0x400>;
+
+			rctl: reset-controller {
+				compatible = "st,stm32-rcc-rctl";
+				#reset-cells = <1>;
+			};
+		};
+
+		exti: interrupt-controller@44022000 {
+			compatible = "st,stm32g0-exti", "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			#address-cells = <0>;
+			reg = <0x44022000 0x400>;
+			num-lines = <40>;
+			interrupts = <7 0>, <8 0>, <9 0>, <10 0>,
+				     <11 0>, <12 0>, <13 0>, <14 0>,
+				     <15 0>, <16 0>, <17 0>, <18 0>,
+				     <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "line0", "line1", "line2", "line3",
+					  "line4", "line5", "line6", "line7",
+					  "line8", "line9", "line10", "line11",
+					  "line12", "line13", "line14", "line15";
+			line-ranges = <0 1>, <1 1>, <2 1>, <3 1>,
+				      <4 1>, <5 1>, <6 1>, <7 1>,
+				      <8 1>, <9 1>, <10 1>, <11 1>,
+				      <12 1>, <13 1>, <14 1>, <15 1>;
+		};
+
+		pinctrl: pin-controller@42020000 {
+			compatible = "st,stm32-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x42020000 0x2000>;
+
+			gpioa: gpio@42020000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42020000 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
+			};
+
+			gpiob: gpio@42020400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42020400 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
+			};
+
+			gpioc: gpio@42020800 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42020800 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
+			};
+
+			gpiod: gpio@42020c00 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42020c00 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
+			};
+
+			gpioe: gpio@42021000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42021000 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			};
+
+			gpioh: gpio@42021c00 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42021c00 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
+			};
+		};
+
+		rtc: rtc@44007800 {
+			compatible = "st,stm32-rtc";
+			reg = <0x44007800 0x400>;
+			interrupts = <2 0>;
+			clocks = <&rcc STM32_CLOCK(APB3, 21)>;
+			prescaler = <32768>;
+			alarms-count = <2>;
+			alrm-exti-line = <17>;
+			status = "disabled";
+		};
+
+		lptim1: timers@44004400 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK(APB3, 11)>;
+			resets = <&rctl STM32_RESET(APB3, 11)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44004400 0x400>;
+			interrupts = <57 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
+		lpuart1: serial@44002400 {
+			compatible = "st,stm32-lpuart", "st,stm32-uart";
+			reg = <0x44002400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
+			resets = <&rctl STM32_RESET(APB3, 6)>;
+			interrupts = <56 0>;
+			status = "disabled";
+		};
+
+		usart1: serial@40013800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40013800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
+			interrupts = <51 0>;
+			status = "disabled";
+		};
+
+		usart2: serial@40004400 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
+			interrupts = <52 0>;
+			status = "disabled";
+		};
+
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
+			interrupts = <53 0>;
+			status = "disabled";
+		};
+
+		uart4: serial@40004c00 {
+			compatible = "st,stm32-uart";
+			reg = <0x40004c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
+			interrupts = <54 0>;
+			status = "disabled";
+		};
+
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
+			interrupts = <55 0>;
+			status = "disabled";
+		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			interrupts = <31 0>;
+			status = "disabled";
+		};
+
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <0 7>;
+			status = "disabled";
+		};
+
+		timers1: timers@40012c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40012c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
+			interrupts = <36 0>, <37 0>, <38 0>, <39 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 0)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
+			interrupts = <40 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers5: timers@40000c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 3)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
+			interrupts = <41 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 4)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
+			interrupts = <42 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers7: timers@40001400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 5)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
+			interrupts = <43 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers8: timers@40013400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
+			interrupts = <72 0>, <73 0>, <74 0>, <75 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers12: timers@40001800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 6)>;
+			resets = <&rctl STM32_RESET(APB1L, 6)>;
+			interrupts = <58 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};	
+
+		timers15: timers@40014000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 16)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
+			interrupts = <59 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers16: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 17)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
+			interrupts = <60 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers17: timers@40014800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 18)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
+			interrupts = <61 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		i2c1: i2c@40005400 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
+			resets = <&rctl STM32_RESET(APB1L, 21)>;
+			interrupts = <44 0>, <45 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
+			resets = <&rctl STM32_RESET(APB1L, 22)>;
+			interrupts = <70 0>, <71 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
+		i3c1: i3c@40005c00 {
+			compatible = "st,stm32-i3c";
+			reg = <0x40005c00 0x400>;
+			interrupts = <46 0>, <47 0>;
+			interrupt-names = "event", "error";
+			#address-cells = <3>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			resets = <&rctl STM32_RESET(APB1L, 23)>;
+			status = "disabled";
+		};
+
+		spi1: spi@40013000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo",
+				     "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			interrupts = <48 5>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
+			resets = <&rctl STM32_RESET(APB2, 12)>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo",
+				     "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			interrupts = <49 5>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
+			resets = <&rctl STM32_RESET(APB1L, 14)>;
+			status = "disabled";
+		};
+
+		spi3: spi@40003c00 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo",
+				     "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			interrupts = <50 5>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
+			resets = <&rctl STM32_RESET(APB1L, 15)>;
+			status = "disabled";
+		};
+
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <34 0>, <35 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			resets = <&rctl STM32_RESET(APB1H, 9)>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
+		usb: usb@40016000 {
+			compatible = "st,stm32-usb";
+			reg = <0x40016000 0x400>;
+			interrupts = <62 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			maximum-speed = "full-speed";
+			phys = <&usb_fs_phy>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_HSIDIV3 CK48_SEL(2)>;
+			status = "disabled";
+		};
+
+		lpdma1: dma@40020000 {
+			compatible = "st,stm32u5-dma";
+			#dma-cells = <3>;
+			reg = <0x40020000 0x1000>;
+			interrupts = <23 0>, <24 0>, <25 0>, <26 0>,
+				     <27 0>, <28 0>, <29 0>, <30 0>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
+			dma-channels = <8>;
+			dma-requests = <96>;
+			dma-offset = <0>;
+			status = "disabled";
+		};
+
+		lpdma2: dma@40021000 {
+			compatible = "st,stm32u5-dma";
+			#dma-cells = <3>;
+			reg = <0x40021000 0x1000>;
+			interrupts = <78 0>, <79 0>, <80 0>, <81 0>,
+				     <82 0>, <83 0>, <84 0>, <85 0>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
+			dma-channels = <8>;
+			dma-requests = <96>;
+			dma-offset = <8>;
+			status = "disabled";
+		};
+
+		adc1: adc@42028000 {
+			compatible = "st,stm32-adc";
+			reg = <0x42028000 0x100>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
+			clock-names = "adcx";
+			interrupts = <32 0>;
+			vref-mv = <3300>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = "programmable";
+			status = "disabled";
+		};
+
+		dac1: dac@42028400 {
+			compatible = "st,stm32-dac";
+			reg = <0x42028400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 11)>;
+			interrupts = <77 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		rng: rng@420c0800 {
+			compatible = "st,stm32-rng";
+			reg = <0x420c0800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
+			interrupts = <64 0>;
+			nist-config = <0xf00d00>;
+			health-test-config = <0xaac7>;
+			status = "disabled";
+		};
+
+		aes: aes@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			interrupts = <68 0>;
+			status = "disabled";
+		};
+
+		hash: hash@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			interrupts = <69 0>;
+			status = "disabled";
+		};
+
+		crc: crc@40023000 {
+			compatible = "st,stm32-crc";
+			reg = <0x40023000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 12)>;
+			status = "disabled";
+		};
+
+		icache: icache@40030400 {
+			compatible = "st,stm32-icache";
+			reg = <0x40030400 0x400>;
+			interrupts = <66 0>;
+			status = "disabled";
+		};
+
+		ramcfg: ramcfg@40026000 {
+			compatible = "st,stm32-ramcfg";
+			reg = <0x40026000 0x1000>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 17)>;
+			interrupts = <4 0>;
+			status = "disabled";
+		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x08fff814>;
+		ts-cal2-addr = <0x08fff818>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3300>;
+		ts-cal-resolution = <12>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
+	};
+
+	vref: vref {
+		compatible = "st,stm32-vref";
+		vrefint-cal-addr = <0x08fff810>;
+		vrefint-cal-mv = <3300>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
+	};
+
+	vbat: vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 2>;
+		status = "disabled";
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <4>;
+};

--- a/include/zephyr/dt-bindings/clock/stm32c5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c5_clock.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_
+
+#include "stm32_common_clocks.h"
+
+/** Domain clocks */
+
+/* RM0522, Table 64 Kernel clock distribution summary */
+
+/** System clock */
+/* defined in stm32_common_clocks.h */
+
+/** Fixed clocks  */
+/* Low speed clocks defined in stm32_common_clocks.h */
+#define STM32_SRC_HSE		(STM32_SRC_LSI + 1)  /* HSE: 4-50 MHz external */
+#define STM32_SRC_HSIS		(STM32_SRC_HSE + 1)  /* HSIS: 144 MHz internal */
+#define STM32_SRC_HSIDIV3	(STM32_SRC_HSIS + 1) /* HSIDIV3: 48 MHz (HSIS/3) */
+#define STM32_SRC_HSIK		(STM32_SRC_HSIDIV3 + 1) /* HSIK: 144 MHz / div */
+#define STM32_SRC_PSIS		(STM32_SRC_HSIK + 1) /* PSIS: 100/144/160 MHz PSI */
+#define STM32_SRC_PSIDIV3	(STM32_SRC_PSIS + 1) /* PSIDIV3: PSIS/3 */
+#define STM32_SRC_PSIK		(STM32_SRC_PSIDIV3 + 1) /* PSIK: PSIS / div */
+
+/** Bus clocks */
+#define STM32_SRC_HCLK		(STM32_SRC_PSIK + 1)
+#define STM32_SRC_PCLK1		(STM32_SRC_HCLK + 1)
+#define STM32_SRC_PCLK2		(STM32_SRC_PCLK1 + 1)
+#define STM32_SRC_PCLK3		(STM32_SRC_PCLK2 + 1)
+
+/** Bus clock enable registers */
+#define STM32_CLOCK_BUS_AHB1    0x088
+#define STM32_CLOCK_BUS_AHB2    0x08C
+#define STM32_CLOCK_BUS_AHB4    0x094
+#define STM32_CLOCK_BUS_APB1    0x09C
+#define STM32_CLOCK_BUS_APB1_2  0x0A0
+#define STM32_CLOCK_BUS_APB2    0x0A4
+#define STM32_CLOCK_BUS_APB3    0x0A8
+
+#define STM32_PERIPH_BUS_MIN    STM32_CLOCK_BUS_AHB1
+#define STM32_PERIPH_BUS_MAX    STM32_CLOCK_BUS_APB3
+
+/** @brief RCC_CCIPRx register offset (RM0522) */
+#define CCIPR1_REG              0xD8
+#define CCIPR2_REG              0xDC
+#define CCIPR3_REG              0xE0
+
+/** @brief RCC_RTCCR register offset (RTC domain control, equivalent to BDCR on other STM32) */
+#define BDCR_REG                0xF0
+
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x1C
+#define CFGR2_REG               0x20
+
+/** CCIPR1 devices */
+#define USART1_SEL(val)         STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR1_REG)
+#define USART2_SEL(val)         STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR1_REG)
+#define USART3_SEL(val)         STM32_DT_CLOCK_SELECT((val), 5, 4, CCIPR1_REG)
+#define UART4_SEL(val)          STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR1_REG)
+#define UART5_SEL(val)          STM32_DT_CLOCK_SELECT((val), 9, 8, CCIPR1_REG)
+#define USART6_SEL(val)         STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR1_REG)
+#define UART7_SEL(val)          STM32_DT_CLOCK_SELECT((val), 13, 12, CCIPR1_REG)
+#define LPUART1_SEL(val)        STM32_DT_CLOCK_SELECT((val), 15, 14, CCIPR1_REG)
+#define SPI1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR1_REG)
+#define SPI2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 19, 18, CCIPR1_REG)
+#define SPI3_SEL(val)           STM32_DT_CLOCK_SELECT((val), 21, 20, CCIPR1_REG)
+#define FDCAN_SEL(val)          STM32_DT_CLOCK_SELECT((val), 27, 26, CCIPR1_REG)
+
+/** CCIPR2 devices */
+#define I2C1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR2_REG)
+#define I2C2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR2_REG)
+#define I3C1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 7, 6, CCIPR2_REG)
+#define LPTIM1_SEL(val)         STM32_DT_CLOCK_SELECT((val), 17, 16, CCIPR2_REG)
+#define CK48_SEL(val)           STM32_DT_CLOCK_SELECT((val), 25, 24, CCIPR2_REG)
+#define SYSTICK_SEL(val)        STM32_DT_CLOCK_SELECT((val), 31, 30, CCIPR2_REG)
+#define ADCDAC_SEL(val)         STM32_DT_CLOCK_SELECT((val), 11, 10, CCIPR2_REG)
+
+/** CCIPR3 devices */
+#define XSPI1_SEL(val)          STM32_DT_CLOCK_SELECT((val), 1, 0, CCIPR3_REG)
+
+/** BDCR devices */
+#define RTC_SEL(val)            STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
+
+/** CFGR1 devices */
+#define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 21, 18, CFGR1_REG)
+#define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 24, 22, CFGR1_REG)
+#define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR1_REG)
+#define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR1_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/reset/stm32c5_reset.h
+++ b/include/zephyr/dt-bindings/reset/stm32c5_reset.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C5_RESET_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C5_RESET_H_
+
+#include "stm32-common.h"
+
+/* RCC bus reset register offset */
+#define STM32_RESET_BUS_AHB1    0x060
+#define STM32_RESET_BUS_AHB2    0x064
+#define STM32_RESET_BUS_AHB4    0x06C
+#define STM32_RESET_BUS_APB1L   0x074
+#define STM32_RESET_BUS_APB1H   0x078
+#define STM32_RESET_BUS_APB2    0x07C
+#define STM32_RESET_BUS_APB3    0x080
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_STM32C5_RESET_H_ */


### PR DESCRIPTION
This PR adds initial support for the new STM32C5 SoC series.

The initial support adds the following files:
- **dts/arm/st/c5/stm32c5.dtsi**: peripheral nodes common to all
  STM32C5 variants (C53x/542, C55x/562, C59x/C5A3), including
  clocks, EXTI (40 lines), GPIO (A-E, H), serial (USART1-3,
  UART4-5, LPUART1), timers (TIM1/2/5-8/12/15-17, LPTIM1),
  I2C1-2, I3C1, SPI1-3, FDCAN1, USB FS, LPDMA1-2, ADC1,
  DAC1, RNG, AES, HASH, CRC, ICACHE, RAMCFG, RTC, IWDG, WWDG.

- **include/zephyr/dt-bindings/clock/stm32c5_clock.h**: clock
  source IDs, bus enable register offsets, and kernel clock
  mux helpers (CCIPR1/2/3, BDCR, CFGR1).

- **include/zephyr/dt-bindings/reset/stm32c5_reset.h**: reset
  register offsets for all RCC buses.

All addresses, IRQ numbers and RCC bit positions are verified against RM0522 Rev 1 (February 2026).