### PR TITLE
MAINTAINERS: Apply to become power management collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4477,6 +4477,7 @@ Power management:
     - teburd
     - tmleman
     - JordanYates
+    - ZhaoxiangJin
   files:
     - include/zephyr/pm/
     - samples/subsys/pm/


### PR DESCRIPTION
I have a strong interest in this field, and my daily work involves MCU power management. I am already quite familiar with Zephyr's PM subsystem and have made several contributions to it. I am applying to become a collaborator for this domain to assist the maintainer with domain maintenance work, and to contribute insights from my experience with MCU power architectures/features to help improve and optimize Zephyr's PM.

Contribution history: https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+author%3AZhaoxiangJin+label%3A%22area%3A+Power+Management%22+is%3Aclosed