### PR TITLE
boards: frdm_mcxa577: add arduino_gpio support

### DIFF
--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - gpio
+  - arduino_gpio
   - uart
   - counter
   - adc


### PR DESCRIPTION
## Description
Add `arduino_gpio` to the `supported` features list for the FRDM-MCXA577 board.

## Changes
- boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml: add `arduino_gpio` to `supported`

## Testing
- Not run (metadata-only change)
