### PR TITLE
drivers: led: gpio: Use on/off

### DIFF
--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -24,9 +24,8 @@ struct led_gpio_config {
 	const struct gpio_dt_spec *led;
 };
 
-static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
+static int led_gpio_set(const struct device *dev, uint32_t led, bool val)
 {
-
 	const struct led_gpio_config *config = dev->config;
 	const struct gpio_dt_spec *led_gpio;
 
@@ -36,7 +35,17 @@ static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8
 
 	led_gpio = &config->led[led];
 
-	return gpio_pin_set_dt(led_gpio, value > 0);
+	return gpio_pin_set_dt(led_gpio, (val) ? 1 : 0);
+}
+
+static int led_gpio_on(const struct device *dev, uint32_t led)
+{
+	return led_gpio_set(dev, led, true);
+}
+
+static int led_gpio_off(const struct device *dev, uint32_t led)
+{
+	return led_gpio_set(dev, led, false);
 }
 
 static int led_gpio_init(const struct device *dev)
@@ -68,7 +77,8 @@ static int led_gpio_init(const struct device *dev)
 }
 
 static DEVICE_API(led, led_gpio_api) = {
-	.set_brightness	= led_gpio_set_brightness,
+	.on = led_gpio_on,
+	.off = led_gpio_off,
 };
 
 #define LED_GPIO_DEVICE(i)					\


### PR DESCRIPTION
According to the LED API docs, a driver is expected to either implement on/off or set_brightness. In Zephyr LED API, brightness is a percentage instead of raw value, with max brightness being 100.

For GPIO LED, which can only have 2 states, it makes more sense to implement on/off instead of brightness. This allows subsystems (like greybus) to differentiate between LEDs which only support on/off and LEDs, which actually can do multiple levels of brightness.

Since the higher level API takes care of directing led_set_brightness calls to use on/off, this change should not break anything.