### PR TITLE
drivers: dai: intel: uaol: fix linker error

### DIFF
--- a/drivers/dai/intel/uaol/Kconfig.uaol
+++ b/drivers/dai/intel/uaol/Kconfig.uaol
@@ -6,6 +6,7 @@
 config DAI_INTEL_UAOL
 	bool "Intel USB Audio Offload Link (UAOL) driver support for DAI interface"
 	default y
+	depends on UAOL
 	depends on DT_HAS_INTEL_UAOL_DAI_ENABLED
 	depends on PM_DEVICE_RUNTIME
 	help


### PR DESCRIPTION
This fixes a regression introduced with commit fc2b1b2f3e2.

This ensures that when the UAOL driver is disabled, the DAI UAOL driver is also disabled.