### PR TITLE
Bluetooth: Host: Fix stale dynamic CID reuse

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1272,6 +1272,8 @@ static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 {
 	LOG_DBG("chan %p", chan);
 
+	chan->rx.cid = 0U;
+
 	/* Redirect to experimental API. */
 	IF_ENABLED(CONFIG_BT_L2CAP_SEG_RECV, ({
 		if (chan->chan.ops->seg_recv) {
@@ -1447,19 +1449,20 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 
 	le_chan->required_sec_level = server->sec_level;
 
-	if (!l2cap_chan_add(conn, *chan, l2cap_chan_destroy)) {
-		return BT_L2CAP_LE_ERR_NO_RESOURCES;
-	}
-
 	/* Init TX parameters */
 	l2cap_chan_tx_init(le_chan);
 	le_chan->tx.cid = scid;
 	le_chan->tx.mps = mps;
 	le_chan->tx.mtu = mtu;
-	l2cap_chan_tx_give_credits(le_chan, credits);
 
 	/* Init RX parameters */
 	l2cap_chan_rx_init(le_chan);
+
+	if (!l2cap_chan_add(conn, *chan, l2cap_chan_destroy)) {
+		return BT_L2CAP_LE_ERR_NO_RESOURCES;
+	}
+
+	l2cap_chan_tx_give_credits(le_chan, credits);
 
 	/* Set channel PSM */
 	le_chan->psm = server->psm;


### PR DESCRIPTION
Currently, the CID for dynamic channels are not cleared on reuse.
l2cap_chan_alloc_cid() sees the non-zero CID and skips allocation.
If another dynamic channel (e.g. EATT) has claimed that CID in the
meantime, the reused CID collides and the remote rejects with
BT_L2CAP_LE_ERR_SCID_IN_USE.

This commit adds clearing of bt_l2cap_le_chan.rx.cid to
`l2cap_chan_rx_init()`, to match the pattern for how state is cleared
for bt_l2cap_le_chan.tx in `l2cap_chan_tx_init()`. As a consequence of
this, the function calling the CID-allocating function on the server
side (`l2cap_chan_add()`) is moved after the init functions.