### PR TITLE
drivers: sensor: qdec_bee: add Realtek Bee series support

### DIFF
--- a/drivers/sensor/realtek/CMakeLists.txt
+++ b/drivers/sensor/realtek/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2025, Realtek, SIBG-SD7
 # SPDX-License-Identifier: Apache-2.0
 
+add_subdirectory_ifdef(CONFIG_QDEC_BEE qdec_bee)
 add_subdirectory_ifdef(CONFIG_TACH_RTS5912 rts5912)

--- a/drivers/sensor/realtek/Kconfig
+++ b/drivers/sensor/realtek/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2025, Realtek, SIBG-SD7
 # SPDX-License-Identifier: Apache-2.0
 
+source "drivers/sensor/realtek/qdec_bee/Kconfig"
 source "drivers/sensor/realtek/rts5912/Kconfig"

--- a/drivers/sensor/realtek/qdec_bee/CMakeLists.txt
+++ b/drivers/sensor/realtek/qdec_bee/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(qdec_bee.c)

--- a/drivers/sensor/realtek/qdec_bee/Kconfig
+++ b/drivers/sensor/realtek/qdec_bee/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config QDEC_BEE
+	bool "Realtek Bee series QDEC driver"
+	default y
+	depends on DT_HAS_REALTEK_BEE_BASIC_QDEC_ENABLED || DT_HAS_REALTEK_BEE_AON_QDEC_ENABLED
+	select HAL_REALTEK_BEE_QDEC if DT_HAS_REALTEK_BEE_BASIC_QDEC_ENABLED
+	select HAL_REALTEK_BEE_AON_QDEC if DT_HAS_REALTEK_BEE_AON_QDEC_ENABLED
+	select PINCTRL
+	help
+	  This option enables the QDEC driver for Realtek Bee SoCs.

--- a/drivers/sensor/realtek/qdec_bee/qdec_bee.c
+++ b/drivers/sensor/realtek/qdec_bee/qdec_bee.c
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/bee_clock_control.h>
+#include <zephyr/drivers/sensor/qdec_bee.h>
+#include <soc.h>
+#include <zephyr/irq.h>
+
+#include "bee_qdec_common.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(qdec_bee, CONFIG_SENSOR_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(realtek_bee_basic_qdec)
+#define DT_DRV_COMPAT   realtek_bee_basic_qdec
+#define QDEC_AXIS_COUNT BEE_QDEC_AXIS_MAX
+#define USE_BASIC_QDEC  1
+#elif DT_HAS_COMPAT_STATUS_OKAY(realtek_bee_aon_qdec)
+#define DT_DRV_COMPAT   realtek_bee_aon_qdec
+#define QDEC_AXIS_COUNT 1
+#else
+#error "No enabled QDEC node found in Device Tree"
+#endif
+
+struct qdec_bee_axis_data {
+	int32_t acc;
+	int32_t round;
+	sensor_trigger_handler_t data_ready_handler;
+	const struct sensor_trigger *data_ready_trigger;
+};
+
+struct qdec_bee_data {
+	struct qdec_bee_axis_data axes[QDEC_AXIS_COUNT];
+	const struct bee_qdec_ops *ops;
+};
+
+struct qdec_bee_config {
+	uint32_t reg;
+	const struct pinctrl_dev_config *pcfg;
+	void (*irq_connect)(void);
+	struct bee_qdec_axis_config axis_cfgs[BEE_QDEC_AXIS_MAX];
+#ifdef USE_BASIC_QDEC
+	uint16_t clkid;
+#endif
+};
+
+static int qdec_bee_get_axis_idx(const struct qdec_bee_config *config, enum sensor_channel chan)
+{
+	if (chan == SENSOR_CHAN_ROTATION) {
+		for (int i = 0; i < QDEC_AXIS_COUNT; i++) {
+			if (config->axis_cfgs[i].enable) {
+				return i;
+			}
+		}
+		return -ENODEV;
+	}
+
+	if (chan >= (enum sensor_channel)SENSOR_CHAN_QDEC_X_COUNT &&
+	    chan <= (enum sensor_channel)SENSOR_CHAN_QDEC_Z_COUNT) {
+		int axis_idx = chan - (enum sensor_channel)SENSOR_CHAN_QDEC_X_COUNT;
+
+		if (axis_idx >= 0 && axis_idx < QDEC_AXIS_COUNT &&
+		    config->axis_cfgs[axis_idx].enable) {
+			return axis_idx;
+		}
+	}
+
+	return -ENOTSUP;
+}
+
+static int qdec_bee_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct qdec_bee_config *config = dev->config;
+	struct qdec_bee_data *data = dev->data;
+	const struct bee_qdec_ops *ops = data->ops;
+	unsigned int key;
+	int i;
+
+	key = irq_lock();
+
+	if (chan == SENSOR_CHAN_ALL) {
+		for (i = 0; i < QDEC_AXIS_COUNT; i++) {
+			if (config->axis_cfgs[i].enable) {
+				data->axes[i].acc = (data->axes[i].round << 16) +
+						    ops->get_count(config->reg, i);
+			}
+		}
+	} else {
+		i = qdec_bee_get_axis_idx(config, chan);
+		if (i < 0) {
+			irq_unlock(key);
+			return i;
+		}
+		data->axes[i].acc = (data->axes[i].round << 16) + ops->get_count(config->reg, i);
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int qdec_bee_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	const struct qdec_bee_config *config = dev->config;
+	struct qdec_bee_data *data = dev->data;
+	int axis_idx = -1;
+
+	axis_idx = qdec_bee_get_axis_idx(config, chan);
+
+	if (axis_idx < 0) {
+		return -ENOTSUP;
+	}
+
+	val->val1 = data->axes[axis_idx].acc;
+	val->val2 = 0;
+
+	return 0;
+}
+
+static int qdec_bee_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+				sensor_trigger_handler_t handler)
+{
+	const struct qdec_bee_config *config = dev->config;
+	struct qdec_bee_data *data = dev->data;
+	const struct bee_qdec_ops *ops = data->ops;
+	unsigned int key;
+	int axis_idx;
+
+	if (trig->type != SENSOR_TRIG_DATA_READY) {
+		return -ENOTSUP;
+	}
+
+	axis_idx = qdec_bee_get_axis_idx(config, trig->chan);
+
+	if (axis_idx < 0) {
+		return -ENOTSUP;
+	}
+
+	key = irq_lock();
+
+	data->axes[axis_idx].data_ready_handler = handler;
+	data->axes[axis_idx].data_ready_trigger = trig;
+	if (handler) {
+		ops->int_enable(config->reg, axis_idx, BEE_QDEC_EVENT_NEW_DATA);
+		ops->int_enable(config->reg, axis_idx, BEE_QDEC_EVENT_ILLEGAL);
+	} else {
+		ops->int_disable(config->reg, axis_idx, BEE_QDEC_EVENT_NEW_DATA);
+		ops->int_disable(config->reg, axis_idx, BEE_QDEC_EVENT_ILLEGAL);
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static void qdec_bee_isr_handle_axis(const struct device *dev, int axis_idx)
+{
+	struct qdec_bee_data *data = dev->data;
+	const struct qdec_bee_config *config = dev->config;
+	const struct bee_qdec_ops *ops = data->ops;
+	uint32_t reg = config->reg;
+	sensor_trigger_handler_t handler;
+
+	if (!config->axis_cfgs[axis_idx].enable) {
+		return;
+	}
+
+	if (ops->get_status(reg, axis_idx, BEE_QDEC_EVENT_ILLEGAL)) {
+		ops->int_clear(reg, axis_idx, BEE_QDEC_EVENT_ILLEGAL);
+		const char *axis_name = (axis_idx == 0) ? "X" : (axis_idx == 1) ? "Y" : "Z";
+
+		LOG_ERR("%s axis qdec illegal status", axis_name);
+	}
+
+	if (ops->get_status(reg, axis_idx, BEE_QDEC_EVENT_NEW_DATA)) {
+		if (ops->get_status(reg, axis_idx, BEE_QDEC_EVENT_OVERFLOW)) {
+			data->axes[axis_idx].round += 1;
+			ops->int_clear(reg, axis_idx, BEE_QDEC_EVENT_OVERFLOW);
+		}
+		if (ops->get_status(reg, axis_idx, BEE_QDEC_EVENT_UNDERFLOW)) {
+			data->axes[axis_idx].round -= 1;
+			ops->int_clear(reg, axis_idx, BEE_QDEC_EVENT_UNDERFLOW);
+		}
+
+		ops->int_clear(reg, axis_idx, BEE_QDEC_EVENT_NEW_DATA);
+
+		handler = data->axes[axis_idx].data_ready_handler;
+
+		if (handler) {
+			handler(dev, data->axes[axis_idx].data_ready_trigger);
+		}
+	}
+}
+
+static void qdec_bee_isr(void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+
+	for (int i = 0; i < QDEC_AXIS_COUNT; i++) {
+		qdec_bee_isr_handle_axis(dev, i);
+	}
+}
+
+static int qdec_bee_init(const struct device *dev)
+{
+	struct qdec_bee_data *data = dev->data;
+	const struct qdec_bee_config *config = dev->config;
+	int ret;
+
+	data->ops = bee_qdec_get_ops();
+	if (!data->ops) {
+		LOG_ERR("Bee QDEC HAL not available");
+		return -ENOTSUP;
+	}
+
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef USE_BASIC_QDEC
+	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&config->clkid);
+#endif
+
+	ret = data->ops->init(config->reg, config->axis_cfgs);
+	if (ret < 0) {
+		return ret;
+	}
+
+	for (int i = 0; i < QDEC_AXIS_COUNT; i++) {
+		if (config->axis_cfgs[i].enable) {
+			data->ops->int_enable(config->reg, i, BEE_QDEC_EVENT_NEW_DATA);
+			data->ops->int_enable(config->reg, i, BEE_QDEC_EVENT_ILLEGAL);
+			data->ops->enable(config->reg, i);
+		}
+	}
+
+	config->irq_connect();
+
+	return 0;
+}
+
+static DEVICE_API(sensor, qdec_bee_driver_api) = {
+	.sample_fetch = qdec_bee_sample_fetch,
+	.channel_get = qdec_bee_channel_get,
+	.trigger_set = qdec_bee_trigger_set,
+};
+
+#define QDEC_BEE_AXIS_CFG(inst, axis_name)                                                         \
+	{.enable = DT_INST_PROP_OR(inst, axis_name##_enable, 0),                                   \
+	 .debounce_time_ms = DT_INST_PROP_OR(inst, axis_name##_debounce_time_ms, 0),               \
+	 .counts_per_revolution = DT_INST_PROP_OR(inst, axis_name##_counts_per_revolution, 4)}
+
+#ifdef USE_BASIC_QDEC
+#define QDEC_BEE_CLK_INIT(inst) .clkid = DT_INST_CLOCKS_CELL(inst, id),
+#define QDEC_BEE_IRQ_CONNECT_FUNC(inst)                                                            \
+	static void qdec_bee_isr_wrapper_##inst(void)                                              \
+	{                                                                                          \
+		const struct device *dev = DEVICE_DT_INST_GET(inst);                               \
+		qdec_bee_isr((void *)dev);                                                         \
+	}                                                                                          \
+	static void qdec_bee_irq_connect_##inst(void)                                              \
+	{                                                                                          \
+		RamVectorTableUpdate(Qdecode_VECTORn, qdec_bee_isr_wrapper_##inst);                \
+		NVIC_InitTypeDef NVIC_InitStruct;                                                  \
+		NVIC_InitStruct.NVIC_IRQChannel = Qdecode_IRQn;                                    \
+		NVIC_InitStruct.NVIC_IRQChannelPriority = 2;                                       \
+		NVIC_InitStruct.NVIC_IRQChannelCmd = ENABLE;                                       \
+		NVIC_Init(&NVIC_InitStruct);                                                       \
+	}
+#else
+#define QDEC_BEE_CLK_INIT(inst)
+#define QDEC_BEE_IRQ_CONNECT_FUNC(inst)                                                            \
+	static void qdec_bee_irq_connect_##inst(void)                                              \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), qdec_bee_isr,         \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}
+#endif
+
+#if (QDEC_AXIS_COUNT == 1)
+#define AON_QDEC_BEE_ASSERT(inst)                                                                  \
+	BUILD_ASSERT(DT_INST_PROP_OR(inst, x_enable, 0) == 1, "AON QDEC requires x_enable=1");     \
+	BUILD_ASSERT(DT_INST_PROP_OR(inst, y_enable, 0) == 0,                                      \
+		     "AON QDEC does not support y_enable");                                        \
+	BUILD_ASSERT(DT_INST_PROP_OR(inst, z_enable, 0) == 0, "AON QDEC does not support "         \
+							      "z_enable");
+#else
+#define AON_QDEC_BEE_ASSERT(inst)
+#endif
+
+#define QDEC_BEE_DEFINE(inst)                                                                      \
+	BUILD_ASSERT((DT_INST_PROP_OR(inst, x_enable, 0) | DT_INST_PROP_OR(inst, y_enable, 0) |    \
+		      DT_INST_PROP_OR(inst, z_enable, 0)) != 0,                                    \
+		     "Enable at least one qdec axis in device tree");                              \
+                                                                                                   \
+	AON_QDEC_BEE_ASSERT(inst)                                                                  \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+                                                                                                   \
+	QDEC_BEE_IRQ_CONNECT_FUNC(inst)                                                            \
+                                                                                                   \
+	static const struct qdec_bee_config qdec_bee_config_##inst = {                             \
+		.reg = DT_INST_REG_ADDR(inst),                                                     \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
+		.irq_connect = qdec_bee_irq_connect_##inst,                                        \
+		.axis_cfgs =                                                                       \
+			{                                                                          \
+				QDEC_BEE_AXIS_CFG(inst, x),                                        \
+				QDEC_BEE_AXIS_CFG(inst, y),                                        \
+				QDEC_BEE_AXIS_CFG(inst, z),                                        \
+			},                                                                         \
+		QDEC_BEE_CLK_INIT(inst)};                                                          \
+                                                                                                   \
+	static struct qdec_bee_data qdec_bee_data_##inst;                                          \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, qdec_bee_init, NULL, &qdec_bee_data_##inst,             \
+				     &qdec_bee_config_##inst, POST_KERNEL,                         \
+				     CONFIG_SENSOR_INIT_PRIORITY, &qdec_bee_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(QDEC_BEE_DEFINE)

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -315,6 +315,14 @@
 			channels = <4>;
 			status = "disabled";
 		};
+
+		qdec: qdec@40004000 {
+			compatible = "realtek,bee-basic-qdec";
+			reg = <0x40004000 0x30>;
+			clocks = <&cctl APB_CLK(QDEC)>;
+			interrupts = <19 0>;
+			status = "disabled";
+		};
 	};
 
 	clocks {

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -388,6 +388,13 @@
 			status = "disabled";
 		};
 
+		qdec: qdec@40001bd0 {
+			compatible = "realtek,bee-aon-qdec";
+			reg = <0x40001bd0 0x3>;
+			interrupts = <59 0>;
+			status = "disabled";
+		};
+
 		i2c0: i2c@40035800 {
 			compatible = "realtek,bee-i2c";
 			reg = <0x40035800 0xa0>;

--- a/dts/bindings/sensor/realtek,bee-aon-qdec.yaml
+++ b/dts/bindings/sensor/realtek,bee-aon-qdec.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Bee AON_QDEC.
+  This QDEC only supports the X-axis.
+
+compatible: "realtek,bee-aon-qdec"
+
+include: [sensor-device.yaml, pinctrl-device.yaml, "realtek,bee-qdec.yaml"]

--- a/dts/bindings/sensor/realtek,bee-basic-qdec.yaml
+++ b/dts/bindings/sensor/realtek,bee-basic-qdec.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Bee basic QDEC.
+  This QDEC supports the X, Y, Z axes.
+
+compatible: "realtek,bee-basic-qdec"
+
+include: [sensor-device.yaml, pinctrl-device.yaml, "realtek,bee-qdec.yaml"]
+
+properties:
+  y-enable:
+    type: boolean
+    description: Enable Y axis.
+
+  y-counts-per-revolution:
+    type: int
+    default: 4
+    description: |
+      Counts per revolution for the Y axis.
+      This specifies the hardware decoding mode, determining whether the
+      internal counter increments after 2 or 4 external waveform edge
+      transitions. The default represents the X4 decoding mode, which
+      provides the highest resolution. It could be changed to 2 if a
+      lower resolution is desired by the application.
+    enum:
+      - 2
+      - 4
+
+  y-debounce-time-ms:
+    type: int
+    description: |
+      Debounce time of the Y axis in milliseconds.
+
+  z-enable:
+    type: boolean
+    description: Enable Z axis.
+
+  z-counts-per-revolution:
+    type: int
+    default: 4
+    description: |
+      Counts per revolution for the Z axis.
+      This specifies the hardware decoding mode, determining whether the
+      internal counter increments after 2 or 4 external waveform edge
+      transitions. The default represents the X4 decoding mode, which
+      provides the highest resolution. It could be changed to 2 if a
+      lower resolution is desired by the application.
+    enum:
+      - 2
+      - 4
+
+  z-debounce-time-ms:
+    type: int
+    description: |
+      Debounce time of the Z axis in milliseconds.

--- a/dts/bindings/sensor/realtek,bee-qdec.yaml
+++ b/dts/bindings/sensor/realtek,bee-qdec.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Common properties for Realtek Bee QDEC.
+
+compatible: "realtek,bee-qdec"
+
+include: [sensor-device.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  x-enable:
+    type: boolean
+    description: Enable X axis.
+
+  x-counts-per-revolution:
+    type: int
+    default: 4
+    description: |
+      Counts per revolution for the X axis.
+      This specifies the hardware decoding mode, determining whether the
+      internal counter increments after 2 or 4 external waveform edge
+      transitions. The default represents the X4 decoding mode, which
+      provides the highest resolution. It could be changed to 2 if a
+      lower resolution is desired by the application.
+    enum:
+      - 2
+      - 4
+
+  x-debounce-time-ms:
+    type: int
+    description: |
+      Debounce time of the X axis in milliseconds.

--- a/include/zephyr/drivers/sensor/qdec_bee.h
+++ b/include/zephyr/drivers/sensor/qdec_bee.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for custom sensor channels of Realtek Bee QDEC
+ * @ingroup qdec_bee_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_BEE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_BEE_H_
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Realtek Bee QDEC
+ * @defgroup qdec_bee_interface Realtek Bee QDEC
+ * @ingroup sensor_interface_ext
+ *
+ * Realtek Bee QDEC provides custom sensor channels for raw X/Y/Z axis counts.
+ * @{
+ */
+
+/**
+ * @brief Custom sensor channels for Realtek Bee QDEC
+ */
+enum sensor_channel_qdec_bee {
+	/** X-axis raw count */
+	SENSOR_CHAN_QDEC_X_COUNT = SENSOR_CHAN_PRIV_START,
+	/** Y-axis raw count */
+	SENSOR_CHAN_QDEC_Y_COUNT,
+	/** Z-axis raw count */
+	SENSOR_CHAN_QDEC_Z_COUNT,
+};
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_BEE_H_ */

--- a/samples/sensor/qdec/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/samples/sensor/qdec/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+	pinctrl-0 = <&gpioa_default>;
+	pinctrl-names = "default";
+};
+
+&qdec {
+	y-enable;
+	y-counts-per-revolution = <4>;
+	y-debounce-time-ms = <5>;
+	pinctrl-0 = <&qdec_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	qdec_default: qdec_default {
+		group1 {
+			psels = <BEE_PSEL(QDEC_PHASE_A_Y, P3_2)>,
+				<BEE_PSEL(QDEC_PHASE_B_Y, P3_3)>;
+			output-disable;
+			bias-pull-up;
+		};
+	};
+
+	gpioa_default: gpioa_default {
+		group1 {
+			psels = <BEE_PSEL_GPIOA_11_P5_1>,
+				<BEE_PSEL_GPIOA_12_P5_2>;
+		};
+	};
+};

--- a/samples/sensor/qdec/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/samples/sensor/qdec/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+	pinctrl-0 = <&gpioa_default>;
+	pinctrl-names = "default";
+};
+
+&qdec {
+	x-enable;
+	x-counts-per-revolution = <4>;
+	x-debounce-time-ms = <5>;
+	pinctrl-0 = <&qdec_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	qdec_default: qdec_default {
+		group1 {
+			psels = <BEE_PSEL(QDPH0_IN_P1_3_P1_4, P1_3)>,
+				<BEE_PSEL(QDPH0_IN_P1_3_P1_4, P1_4)>;
+			output-disable;
+			bias-pull-up;
+		};
+	};
+
+	gpioa_default: gpioa_default {
+		group1 {
+			psels = <BEE_PSEL_GPIOA_4_P0_4>,
+				<BEE_PSEL_GPIOA_5_P0_5>;
+		};
+	};
+};

--- a/soc/realtek/bee/common/CMakeLists.txt
+++ b/soc/realtek/bee/common/CMakeLists.txt
@@ -6,3 +6,7 @@ zephyr_include_directories(.)
 if(CONFIG_HAL_REALTEK_BEE_TIM OR CONFIG_HAL_REALTEK_BEE_ENHTIM)
   zephyr_library_sources(bee_timer_common.c)
 endif()
+
+if(CONFIG_HAL_REALTEK_BEE_QDEC OR CONFIG_HAL_REALTEK_BEE_AON_QDEC)
+  zephyr_library_sources(bee_qdec_common.c)
+endif()

--- a/soc/realtek/bee/common/bee_qdec_common.c
+++ b/soc/realtek/bee/common/bee_qdec_common.c
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bee_qdec_common.h"
+
+/* Basic QDEC Implementations */
+
+#if defined(CONFIG_HAL_REALTEK_BEE_QDEC)
+
+static void basic_qdec_get_scale(uint8_t counts, uint32_t *scale)
+{
+	if (counts == 2) {
+		*scale = CounterScale_2_Phase;
+	} else {
+		*scale = CounterScale_1_Phase;
+	}
+}
+
+static int basic_qdec_init(uint32_t reg, const struct bee_qdec_axis_config *axis_cfgs)
+{
+	QDEC_InitTypeDef qdec_init_struct;
+	QDEC_TypeDef *qdec = (QDEC_TypeDef *)reg;
+	uint32_t scale_val = CounterScale_1_Phase;
+
+	QDEC_StructInit(&qdec_init_struct);
+	if (axis_cfgs[BEE_QDEC_AXIS_X].enable) {
+		basic_qdec_get_scale(axis_cfgs[BEE_QDEC_AXIS_X].counts_per_revolution, &scale_val);
+		qdec_init_struct.axisConfigX = ENABLE;
+		qdec_init_struct.debounceEnableX = ENABLE;
+		qdec_init_struct.debounceTimeX = 32 * axis_cfgs[BEE_QDEC_AXIS_X].debounce_time_ms;
+		qdec_init_struct.initPhaseX = phaseMode0;
+		qdec_init_struct.counterScaleX = scale_val;
+	}
+
+	if (axis_cfgs[BEE_QDEC_AXIS_Y].enable) {
+		basic_qdec_get_scale(axis_cfgs[BEE_QDEC_AXIS_Y].counts_per_revolution, &scale_val);
+		qdec_init_struct.axisConfigY = ENABLE;
+		qdec_init_struct.debounceEnableY = ENABLE;
+		qdec_init_struct.debounceTimeY = 32 * axis_cfgs[BEE_QDEC_AXIS_Y].debounce_time_ms;
+		qdec_init_struct.initPhaseY = phaseMode0;
+		qdec_init_struct.counterScaleY = scale_val;
+	}
+
+	if (axis_cfgs[BEE_QDEC_AXIS_Z].enable) {
+		basic_qdec_get_scale(axis_cfgs[BEE_QDEC_AXIS_Z].counts_per_revolution, &scale_val);
+		qdec_init_struct.axisConfigZ = ENABLE;
+		qdec_init_struct.debounceEnableZ = ENABLE;
+		qdec_init_struct.debounceTimeZ = 32 * axis_cfgs[BEE_QDEC_AXIS_Z].debounce_time_ms;
+		qdec_init_struct.initPhaseZ = phaseMode0;
+		qdec_init_struct.counterScaleZ = scale_val;
+	}
+
+	qdec_init_struct.manualLoadInitPhase = ENABLE;
+
+	QDEC_Init(qdec, &qdec_init_struct);
+
+	return 0;
+}
+
+static void basic_qdec_enable(uint32_t reg, enum bee_qdec_axis axis)
+{
+	uint32_t hal_axis;
+
+	if (axis == BEE_QDEC_AXIS_X) {
+		hal_axis = QDEC_AXIS_X;
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		hal_axis = QDEC_AXIS_Y;
+	} else {
+		hal_axis = QDEC_AXIS_Z;
+	}
+
+	QDEC_Cmd((QDEC_TypeDef *)reg, hal_axis, ENABLE);
+}
+
+static void basic_qdec_disable(uint32_t reg, enum bee_qdec_axis axis)
+{
+	uint32_t hal_axis;
+
+	if (axis == BEE_QDEC_AXIS_X) {
+		hal_axis = QDEC_AXIS_X;
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		hal_axis = QDEC_AXIS_Y;
+	} else {
+		hal_axis = QDEC_AXIS_Z;
+	}
+
+	QDEC_Cmd((QDEC_TypeDef *)reg, hal_axis, DISABLE);
+}
+
+static uint16_t basic_qdec_get_count(uint32_t reg, enum bee_qdec_axis axis)
+{
+	uint32_t hal_axis;
+
+	if (axis == BEE_QDEC_AXIS_X) {
+		hal_axis = QDEC_AXIS_X;
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		hal_axis = QDEC_AXIS_Y;
+	} else {
+		hal_axis = QDEC_AXIS_Z;
+	}
+
+	return QDEC_GetAxisCount((QDEC_TypeDef *)reg, hal_axis);
+}
+
+static void basic_get_int_params(enum bee_qdec_axis axis, enum bee_qdec_event_type type,
+				 uint32_t *mask, uint32_t *flag)
+{
+	if (axis == BEE_QDEC_AXIS_X) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			*mask = QDEC_X_CT_INT_MASK;
+			*flag = QDEC_X_INT_NEW_DATA;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			*mask = QDEC_X_ILLEGAL_INT_MASK;
+			*flag = QDEC_X_INT_ILLEGAL;
+		} else {
+			/* Do nothing */
+		}
+
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			*mask = QDEC_Y_CT_INT_MASK;
+			*flag = QDEC_Y_INT_NEW_DATA;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			*mask = QDEC_Y_ILLEGAL_INT_MASK;
+			*flag = QDEC_Y_INT_ILLEGAL;
+		} else {
+			/* Do nothing */
+		}
+	} else if (axis == BEE_QDEC_AXIS_Z) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			*mask = QDEC_Z_CT_INT_MASK;
+			*flag = QDEC_Z_INT_NEW_DATA;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			*mask = QDEC_Z_ILLEGAL_INT_MASK;
+			*flag = QDEC_Z_INT_ILLEGAL;
+		} else {
+			/* Do nothing */
+		}
+	} else {
+		/* Do nothing */
+	}
+}
+
+static void basic_qdec_int_enable(uint32_t reg, enum bee_qdec_axis axis,
+				  enum bee_qdec_event_type type)
+{
+	uint32_t mask_val = 0, config_val = 0;
+
+	basic_get_int_params(axis, type, &mask_val, &config_val);
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA || type == BEE_QDEC_EVENT_ILLEGAL) {
+		QDEC_INTMask((QDEC_TypeDef *)reg, mask_val, DISABLE);
+		QDEC_INTConfig((QDEC_TypeDef *)reg, config_val, ENABLE);
+	}
+}
+
+static void basic_qdec_int_disable(uint32_t reg, enum bee_qdec_axis axis,
+				   enum bee_qdec_event_type type)
+{
+	uint32_t mask_val = 0, config_val = 0;
+
+	basic_get_int_params(axis, type, &mask_val, &config_val);
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA || type == BEE_QDEC_EVENT_ILLEGAL) {
+		QDEC_INTMask((QDEC_TypeDef *)reg, mask_val, ENABLE);
+		QDEC_INTConfig((QDEC_TypeDef *)reg, config_val, DISABLE);
+	}
+}
+
+static void basic_qdec_int_clear(uint32_t reg, enum bee_qdec_axis axis,
+				 enum bee_qdec_event_type type)
+{
+	uint32_t val = 0;
+
+	if (axis == BEE_QDEC_AXIS_X) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			val = QDEC_CLR_NEW_CT_X;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			val = QDEC_CLR_ILLEGAL_INT_X;
+			QDEC_ClearINTPendingBit((QDEC_TypeDef *)reg, QDEC_CLR_ILLEGAL_CT_X);
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			val = QDEC_CLR_OVERFLOW_X;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			val = QDEC_CLR_UNDERFLOW_X;
+		} else {
+			/* Do nothing */
+		}
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			val = QDEC_CLR_NEW_CT_Y;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			val = QDEC_CLR_ILLEGAL_INT_Y;
+			QDEC_ClearINTPendingBit((QDEC_TypeDef *)reg, QDEC_CLR_ILLEGAL_CT_Y);
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			val = QDEC_CLR_OVERFLOW_Y;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			val = QDEC_CLR_UNDERFLOW_Y;
+		} else {
+			/* Do nothing */
+		}
+	} else if (axis == BEE_QDEC_AXIS_Z) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			val = QDEC_CLR_NEW_CT_Z;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			val = QDEC_CLR_ILLEGAL_INT_Z;
+			QDEC_ClearINTPendingBit((QDEC_TypeDef *)reg, QDEC_CLR_ILLEGAL_CT_Z);
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			val = QDEC_CLR_OVERFLOW_Z;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			val = QDEC_CLR_UNDERFLOW_Z;
+		} else {
+			/* Do nothing */
+		}
+	} else {
+		/* Do nothing */
+	}
+
+	if (val) {
+		QDEC_ClearINTPendingBit((QDEC_TypeDef *)reg, val);
+	}
+}
+
+static bool basic_qdec_get_status(uint32_t reg, enum bee_qdec_axis axis,
+				  enum bee_qdec_event_type type)
+{
+	uint32_t flag = 0;
+
+	if (axis == BEE_QDEC_AXIS_X) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			flag = QDEC_FLAG_NEW_CT_STATUS_X;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			flag = QDEC_FLAG_ILLEGAL_STATUS_X;
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			flag = QDEC_FLAG_OVERFLOW_X;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			flag = QDEC_FLAG_UNDERFLOW_X;
+		} else {
+			/* Do nothing */
+		}
+	} else if (axis == BEE_QDEC_AXIS_Y) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			flag = QDEC_FLAG_NEW_CT_STATUS_Y;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			flag = QDEC_FLAG_ILLEGAL_STATUS_Y;
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			flag = QDEC_FLAG_OVERFLOW_Y;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			flag = QDEC_FLAG_UNDERFLOW_Y;
+		} else {
+			/* Do nothing */
+		}
+	} else if (axis == BEE_QDEC_AXIS_Z) {
+		if (type == BEE_QDEC_EVENT_NEW_DATA) {
+			flag = QDEC_FLAG_NEW_CT_STATUS_Z;
+		} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+			flag = QDEC_FLAG_ILLEGAL_STATUS_Z;
+		} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+			flag = QDEC_FLAG_OVERFLOW_Z;
+		} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+			flag = QDEC_FLAG_UNDERFLOW_Z;
+		} else {
+			/* Do nothing */
+		}
+	} else {
+		/* Do nothing */
+	}
+
+	return QDEC_GetFlagState((QDEC_TypeDef *)reg, flag) ? true : false;
+}
+
+static const struct bee_qdec_ops bee_basic_qdec_ops = {
+	.init = basic_qdec_init,
+	.enable = basic_qdec_enable,
+	.disable = basic_qdec_disable,
+	.get_count = basic_qdec_get_count,
+	.int_enable = basic_qdec_int_enable,
+	.int_disable = basic_qdec_int_disable,
+	.int_clear = basic_qdec_int_clear,
+	.get_status = basic_qdec_get_status,
+};
+
+#endif /* CONFIG_HAL_REALTEK_BEE_QDEC */
+
+/* AON QDEC Implementations */
+
+#if defined(CONFIG_HAL_REALTEK_BEE_AON_QDEC)
+
+static int aon_qdec_init(uint32_t reg, const struct bee_qdec_axis_config *axis_cfgs)
+{
+	AON_QDEC_InitTypeDef qdec_init_struct;
+	AON_QDEC_TypeDef *qdec = (AON_QDEC_TypeDef *)reg;
+
+	if (axis_cfgs[BEE_QDEC_AXIS_Y].enable || axis_cfgs[BEE_QDEC_AXIS_Z].enable) {
+		return -ENOTSUP;
+	}
+
+	if (!axis_cfgs[BEE_QDEC_AXIS_X].enable) {
+		return 0;
+	}
+
+	AON_QDEC_StructInit(&qdec_init_struct);
+	qdec_init_struct.axisConfigX = ENABLE;
+	qdec_init_struct.debounceEnableX = ENABLE;
+	qdec_init_struct.debounceTimeX = 32 * axis_cfgs[BEE_QDEC_AXIS_X].debounce_time_ms;
+	qdec_init_struct.initPhaseX = phaseMode0;
+
+	if (axis_cfgs[BEE_QDEC_AXIS_X].counts_per_revolution == 2) {
+		qdec_init_struct.counterScaleX = CounterScale_2_Phase;
+	} else if (axis_cfgs[BEE_QDEC_AXIS_X].counts_per_revolution == 4) {
+		qdec_init_struct.counterScaleX = CounterScale_1_Phase;
+	} else {
+		return -ENOTSUP;
+	}
+
+	qdec_init_struct.manualLoadInitPhase = ENABLE;
+
+	AON_QDEC_DeInit();
+
+	AON_QDEC_Init(qdec, &qdec_init_struct);
+
+	return 0;
+}
+
+static void aon_qdec_enable(uint32_t reg, enum bee_qdec_axis axis)
+{
+	if (axis == BEE_QDEC_AXIS_X) {
+		AON_QDEC_Cmd((AON_QDEC_TypeDef *)reg, AON_QDEC_AXIS_X, ENABLE);
+	}
+}
+
+static void aon_qdec_disable(uint32_t reg, enum bee_qdec_axis axis)
+{
+	if (axis == BEE_QDEC_AXIS_X) {
+		AON_QDEC_Cmd((AON_QDEC_TypeDef *)reg, AON_QDEC_AXIS_X, DISABLE);
+	}
+}
+
+static uint16_t aon_qdec_get_count(uint32_t reg, enum bee_qdec_axis axis)
+{
+	if (axis == BEE_QDEC_AXIS_X) {
+		return AON_QDEC_GetAxisCount((AON_QDEC_TypeDef *)reg, AON_QDEC_AXIS_X);
+	}
+	return 0;
+}
+
+static void aon_qdec_int_enable(uint32_t reg, enum bee_qdec_axis axis,
+				enum bee_qdec_event_type type)
+{
+	AON_QDEC_TypeDef *qdec = (AON_QDEC_TypeDef *)reg;
+
+	if (axis != BEE_QDEC_AXIS_X) {
+		return;
+	}
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA) {
+		AON_QDEC_INTMask(qdec, AON_QDEC_X_CT_INT_MASK, DISABLE);
+		AON_QDEC_INTConfig(qdec, AON_QDEC_X_INT_NEW_DATA, ENABLE);
+	} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+		AON_QDEC_INTMask(qdec, AON_QDEC_X_ILLEAGE_INT_MASK, DISABLE);
+		AON_QDEC_INTConfig(qdec, AON_QDEC_X_INT_ILLEAGE, ENABLE);
+	} else {
+		/* Do nothing */
+	}
+}
+
+static void aon_qdec_int_disable(uint32_t reg, enum bee_qdec_axis axis,
+				 enum bee_qdec_event_type type)
+{
+	AON_QDEC_TypeDef *qdec = (AON_QDEC_TypeDef *)reg;
+
+	if (axis != BEE_QDEC_AXIS_X) {
+		return;
+	}
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA) {
+		AON_QDEC_INTMask(qdec, AON_QDEC_X_CT_INT_MASK, ENABLE);
+		AON_QDEC_INTConfig(qdec, AON_QDEC_X_INT_NEW_DATA, DISABLE);
+	} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+		AON_QDEC_INTMask(qdec, AON_QDEC_X_ILLEAGE_INT_MASK, ENABLE);
+		AON_QDEC_INTConfig(qdec, AON_QDEC_X_INT_ILLEAGE, DISABLE);
+	} else {
+		/* Do nothing */
+	}
+}
+
+static void aon_qdec_int_clear(uint32_t reg, enum bee_qdec_axis axis, enum bee_qdec_event_type type)
+{
+	if (axis != BEE_QDEC_AXIS_X) {
+		return;
+	}
+
+	AON_QDEC_TypeDef *qdec = (AON_QDEC_TypeDef *)reg;
+	uint32_t val = 0;
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA) {
+		val = AON_QDEC_CLR_NEW_CT_X;
+	} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+		val = AON_QDEC_CLR_ILLEGAL_INT_X;
+		AON_QDEC_ClearINTPendingBit(qdec, AON_QDEC_CLR_ILLEGAL_CT_X);
+	} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+		val = AON_QDEC_CLR_OVERFLOW_X;
+	} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+		val = AON_QDEC_CLR_UNDERFLOW_X;
+	} else {
+		/* Do nothing */
+	}
+
+	if (val) {
+		AON_QDEC_ClearINTPendingBit(qdec, val);
+	}
+}
+
+static bool aon_qdec_get_status(uint32_t reg, enum bee_qdec_axis axis,
+				enum bee_qdec_event_type type)
+{
+	if (axis != BEE_QDEC_AXIS_X) {
+		return false;
+	}
+
+	AON_QDEC_TypeDef *qdec = (AON_QDEC_TypeDef *)reg;
+	uint32_t flag = 0;
+
+	if (type == BEE_QDEC_EVENT_NEW_DATA) {
+		flag = AON_QDEC_FLAG_NEW_CT_STATUS_X;
+	} else if (type == BEE_QDEC_EVENT_ILLEGAL) {
+		flag = AON_QDEC_FLAG_ILLEGAL_STATUS_X;
+	} else if (type == BEE_QDEC_EVENT_OVERFLOW) {
+		flag = AON_QDEC_FLAG_OVERFLOW_X;
+	} else if (type == BEE_QDEC_EVENT_UNDERFLOW) {
+		flag = AON_QDEC_FLAG_UNDERFLOW_X;
+	} else {
+		/* Do nothing */
+	}
+
+	return AON_QDEC_GetFlagState(qdec, flag) ? true : false;
+}
+
+static const struct bee_qdec_ops bee_aon_qdec_ops = {
+	.init = aon_qdec_init,
+	.enable = aon_qdec_enable,
+	.disable = aon_qdec_disable,
+	.get_count = aon_qdec_get_count,
+	.int_enable = aon_qdec_int_enable,
+	.int_disable = aon_qdec_int_disable,
+	.int_clear = aon_qdec_int_clear,
+	.get_status = aon_qdec_get_status,
+};
+
+#endif /* CONFIG_HAL_REALTEK_BEE_AON_QDEC */
+
+const struct bee_qdec_ops *bee_qdec_get_ops(void)
+{
+#if defined(CONFIG_HAL_REALTEK_BEE_AON_QDEC)
+	return &bee_aon_qdec_ops;
+#elif defined(CONFIG_HAL_REALTEK_BEE_QDEC)
+	return &bee_basic_qdec_ops;
+#else
+	return NULL;
+#endif
+}

--- a/soc/realtek/bee/common/bee_qdec_common.h
+++ b/soc/realtek/bee/common/bee_qdec_common.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file bee_qdec_common.h
+ * @brief Realtek Bee Series Common QDEC Abstraction Layer.
+ */
+
+#ifndef ZEPHYR_DRIVERS_COMMON_BEE_QDEC_H_
+#define ZEPHYR_DRIVERS_COMMON_BEE_QDEC_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+#include <rtl_aon_qdec.h>
+#include <rtl_rcc.h>
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#include <rtl876x_qdec.h>
+#include <rtl876x_rcc.h>
+#include <rtl876x_nvic.h>
+#include <vector_table.h>
+#else
+#error "Unsupported Realtek Bee SoC series"
+#endif
+
+/**
+ * @defgroup bee_qdec_abstraction QDEC Abstraction Interface
+ * @{
+ */
+
+enum bee_qdec_axis {
+	BEE_QDEC_AXIS_X = 0,
+	BEE_QDEC_AXIS_Y,
+	BEE_QDEC_AXIS_Z,
+	BEE_QDEC_AXIS_MAX
+};
+
+enum bee_qdec_event_type {
+	BEE_QDEC_EVENT_NEW_DATA,
+	BEE_QDEC_EVENT_ILLEGAL,
+	BEE_QDEC_EVENT_OVERFLOW,
+	BEE_QDEC_EVENT_UNDERFLOW,
+};
+
+/**
+ * @brief Configuration for a single axis
+ */
+struct bee_qdec_axis_config {
+	bool enable;
+	uint8_t counts_per_revolution; /* 2 or 4 */
+	uint32_t debounce_time_ms;
+};
+
+/**
+ * @brief Unified QDEC Operations Structure.
+ */
+struct bee_qdec_ops {
+	/**
+	 * @brief Initialize the QDEC hardware.
+	 * @param reg Base address of the QDEC register.
+	 * @param axis_cfg Array of configuration for X, Y, Z axes.
+	 * @return 0 on success, negative errno on failure.
+	 */
+	int (*init)(uint32_t reg, const struct bee_qdec_axis_config *axis_cfgs);
+
+	/**
+	 * @brief Enable the QDEC axis.
+	 */
+	void (*enable)(uint32_t reg, enum bee_qdec_axis axis);
+
+	/**
+	 * @brief Disable the QDEC axis.
+	 */
+	void (*disable)(uint32_t reg, enum bee_qdec_axis axis);
+
+	/**
+	 * @brief Get the current raw accumulation count.
+	 */
+	uint16_t (*get_count)(uint32_t reg, enum bee_qdec_axis axis);
+
+	/**
+	 * @brief Enable interrupt for specific event.
+	 */
+	void (*int_enable)(uint32_t reg, enum bee_qdec_axis axis, enum bee_qdec_event_type type);
+
+	/**
+	 * @brief Disable interrupt for specific event.
+	 */
+	void (*int_disable)(uint32_t reg, enum bee_qdec_axis axis, enum bee_qdec_event_type type);
+
+	/**
+	 * @brief Clear interrupt pending status / flag.
+	 */
+	void (*int_clear)(uint32_t reg, enum bee_qdec_axis axis, enum bee_qdec_event_type type);
+
+	/**
+	 * @brief Check interrupt status / flag state.
+	 * @return true if set, false otherwise.
+	 */
+	bool (*get_status)(uint32_t reg, enum bee_qdec_axis axis, enum bee_qdec_event_type type);
+};
+
+/**
+ * @brief Retrieve the QDEC Operations structure.
+ * @return const struct bee_qdec_ops* Pointer to the operations structure.
+ */
+const struct bee_qdec_ops *bee_qdec_get_ops(void);
+
+/** @} */
+
+#endif /* ZEPHYR_DRIVERS_COMMON_BEE_QDEC_H_ */


### PR DESCRIPTION
**Description**

This PR adds the QDEC (Quadrature Decoder) driver support for Realtek Bee series SoCs. The driver is implemented based on the standard Zephyr Sensor API and supports the following series:
- **RTL87x2G** (AON QDEC)
- **RTL8752H** (Basic QDEC)

**Key features implemented:**
- Hardware rotation counting (X, Y, and Z axis)
- Data ready interrupt trigger support

**Testing**

I have verified the driver functionality using the standard Zephyr QDEC sample (`samples/sensor/qdec`) on the following hardware platforms:

1.  **Board:** `rtl87x2g_evb_a_rtl8762gku`
    - SoC: RTL87X2G
    - Test: `samples/sensor/qdec`

2.  **Board:** `rtl8752h_evb_rtl8752hjl`
    - SoC: RTL8752H
    - Test: `samples/sensor/qdec`

**Logs**

```console
Quadrature decoder sensor test
Quadrature encoder emulator enabled with 100 ms period
Position = 20 degrees
Position = 40 degrees
Position = 60 degrees
Position = 80 degrees
Position = 100 degrees
Position = 120 degrees
Position = 140 degrees
Position = 160 degrees
Position = 180 degrees
Position = 200 degrees
```