### PR TITLE
cmsis-dsp: restrict f16 support to targets with f16 arithmetic capability

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -311,7 +311,7 @@ config FP_SOFTABI
 endchoice
 
 config FP16
-	bool "Half-precision floating point support"
+	bool "Half-precision floating point storage support"
 	default y
 	help
 	  This option enables the half-precision (16-bit) floating point support
@@ -342,6 +342,17 @@ config FP16_ALT
 	  Please note that Clang doesn't support the ARM alternative format.
 
 endchoice
+
+config FP16_ARITHMETIC
+	bool "Half-precision floating point arithmetic support"
+	default y
+	depends on FP16
+	depends on ARMV8_1_M_MVEF || CPU_CORTEX_A
+	help
+	  This option indicates that the target supports half-precision
+	  (16-bit) floating-point arithmetic. This requires hardware with
+	  native f16 arithmetic capability, such as Cortex-M processors
+	  with MVE float or Cortex-A processors with NEON.
 
 rsource "cortex_m/Kconfig"
 rsource "cortex_a_r/Kconfig"

--- a/modules/cmsis-dsp/Kconfig
+++ b/modules/cmsis-dsp/Kconfig
@@ -308,7 +308,7 @@ config CMSIS_DSP_AUTOVECTORIZE
 config CMSIS_DSP_FLOAT16
 	bool "Half-Precision (16-bit Float) Support"
 	default y
-	depends on FP16
+	depends on FP16_ARITHMETIC
 	help
 	  This option enables the half-precision (16-bit) floating-point
 	  operations support.

--- a/tests/subsys/dsp/basicmath/CMakeLists.txt
+++ b/tests/subsys/dsp/basicmath/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(app PRIVATE
   src/f32.c
   )
 
-target_sources_ifdef(CONFIG_FP16 app PRIVATE src/f16.c)
+target_sources_ifdef(CONFIG_CMSIS_DSP_FLOAT16 app PRIVATE src/f16.c)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/tests/lib/cmsis_dsp)
 


### PR DESCRIPTION
Commit 6612580d9e4d correctly changed the `-mfpu` setting for Cortex-M55 variants without MVE from `auto` to `fpv5-sp-d16`.

However, this exposed a build failure when compiling CMSIS-DSP f16 sources for these targets:

```
Error: selected processor does not support `vld1.16 {d7[2]},[r2]!' in Thumb mode
```

The root cause is that `CONFIG_CMSIS_DSP_FLOAT16` depends only on `CONFIG_FP16`, which defaults to `y` on all ARM targets and only controls the `-mfp16-format=ieee` flag (i.e. the storage format for `__fp16`). This causes CMSIS-DSP f16 sources (which perform actual `_Float16` arithmetic operations) to be compiled for targets that lack the hardware to support it. On Cortex-M55 without MVE, GCC cannot emit valid code for `_Float16` load/store operations under `-mfpu=fpv5-sp-d16`.

This PR introduces a new Kconfig `CONFIG_FP16_ARITHMETIC` to distinguish between f16 storage format support (`CONFIG_FP16`) and actual f16 arithmetic capability. `CONFIG_FP16_ARITHMETIC` requires either MVE float (`ARMV8_1_M_MVEF`) or a Cortex-A core (`CPU_CORTEX_A`). `CONFIG_CMSIS_DSP_FLOAT16` now depends on `CONFIG_FP16_ARITHMETIC` instead of `CONFIG_FP16`.

Further information: [Getting started with Armv8.1-M based processors](https://developer.arm.com/community/arm-community-blogs/b/architectures-and-processors-blog/posts/armv8_2d00_m-based-processor-software-development-hints-and-tips)

Fixes #105117
