### PR TITLE
boards: nxp: correct compatible name for dtcm

### DIFF
--- a/boards/nxp/frdm_imxrt1186/cm33_sram_dtcm.overlay
+++ b/boards/nxp/frdm_imxrt1186/cm33_sram_dtcm.overlay
@@ -14,7 +14,7 @@
 
 	soc {
 		dtcm: memory@30000000 {
-			compatible = "nmmio-sram";
+			compatible = "mmio-sram";
 			reg = <0x30000000 DT_SIZE_K(128)>;
 		};
 	};

--- a/boards/nxp/mimxrt1180_evk/cm33_sram_dtcm.overlay
+++ b/boards/nxp/mimxrt1180_evk/cm33_sram_dtcm.overlay
@@ -14,7 +14,7 @@
 
 	soc {
 		dtcm: memory@30000000 {
-			compatible = "nmmio-sram";
+			compatible = "mmio-sram";
 			reg = <0x30000000 DT_SIZE_K(128)>;
 		};
 	};


### PR DESCRIPTION
correct compatible name for dtcm