### PR TITLE
net: ip: net_core: remove `conn_mgr_if_used` on RX

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -927,7 +927,6 @@ return_ret:
 static ssize_t nsos_recvfrom(void *obj, void *buf, size_t len, int flags,
 			     struct net_sockaddr *addr, net_socklen_t *addrlen)
 {
-	struct net_if *iface = NET_IF_GET(nsos_socket, 0);
 	struct nsos_socket *sock = obj;
 	struct nsos_mid_sockaddr_storage addr_storage_mid;
 	struct nsos_mid_sockaddr *addr_mid = (struct nsos_mid_sockaddr *)&addr_storage_mid;
@@ -961,7 +960,6 @@ return_ret:
 		return -1;
 	}
 
-	conn_mgr_if_used(iface);
 	return ret;
 }
 

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -491,7 +491,6 @@ static void net_rx(struct net_if *iface, struct net_pkt *pkt)
 	NET_DBG("Received pkt %p len %zu", pkt, pkt_len);
 
 	net_stats_update_bytes_recv(iface, pkt_len);
-	conn_mgr_if_used(iface);
 
 	if (IS_ENABLED(CONFIG_NET_LOOPBACK)) {
 #ifdef CONFIG_NET_L2_DUMMY


### PR DESCRIPTION
Remove the unconditional `conn_mgr_if_used` call on data reception. Receiving data ends up being a poor metric for "interface in use" in many situations. This is especially the case when connected to networks with broadcast packets that are not necessarily relevant for us, such as ARP discovery requests.

Introducing the change as I have recently found my home WiFi network randomly has multi-minute bursts of 1Hz broadcast ARP packets, which the embedded device cares nothing for but is being kept active regardless.

I can't think of any relevant protocol that requires receiving continuous data without any data transmission that this would impact, but happy to hear any counterpoints.