### PR TITLE
usb: device_next: allow to initialize multiple CDC ACM instances

### DIFF
--- a/doc/services/connectivity/usb/device_next/cdc_acm.rst
+++ b/doc/services/connectivity/usb/device_next/cdc_acm.rst
@@ -97,6 +97,15 @@ As the configuration would be identical for any board, there are common
 :zephyr_file:`Kconfig file <boards/common/usb/Kconfig.cdc_acm_serial.defconfig>`
 that must be included in the board's devicetree and Kconfig.defconfig files.
 
+Application can use :kconfig:option:`CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES`
+if different CDC ACM serial backends are required for common use cases such as
+logging, the shell, and specific protocols. This option also guarantees the
+order in which the instances will be registered and appear in the configuration
+descriptor. The option uses the chosen node properties to identify UART devices.
+The following are currently supported, in this order:
+"zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
+A supported property may be missing, and properties may reference the same device.
+
 Using CDC ACM UART in the application
 =====================================
 

--- a/doc/services/connectivity/usb/device_next/cdc_acm.rst
+++ b/doc/services/connectivity/usb/device_next/cdc_acm.rst
@@ -84,9 +84,12 @@ configure the shell to use the CDC ACM UART as the serial backend. See sample
 Since the use case as a serial backend is very common and no configuration is
 necessary at runtime for the CDC ACM UART, the stack offers a helper that
 performs the steps described in :ref:`usb_device_next_howto_configure`. The
-helper is enabled by the :kconfig:option:`CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT`
-and initializes the USB device stack with a single CDC ACM instance. Sample
-:zephyr:code-sample:`usb-cdc-acm-console` demonstrates how to use it.
+helper is enabled by the :kconfig:option:`CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT`.
+It initializes the USB device stack and registers CDC ACM instances. If only one
+instance is available, it registers this single CDC ACM instance. If more than
+one instance is available, the stack identifies and registers UART devices in a
+specific order using the chosen node properties.
+Sample :zephyr:code-sample:`usb-cdc-acm-console` demonstrates how to use it.
 
 :kconfig:option:`CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT` should also be used
 by the boards like :zephyr:board:`nrf52840dongle`, which do not have a debug
@@ -96,15 +99,6 @@ As the configuration would be identical for any board, there are common
 :zephyr_file:`devicetree file <boards/common/usb/cdc_acm_serial.dtsi>` and
 :zephyr_file:`Kconfig file <boards/common/usb/Kconfig.cdc_acm_serial.defconfig>`
 that must be included in the board's devicetree and Kconfig.defconfig files.
-
-Application can use :kconfig:option:`CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES`
-if different CDC ACM serial backends are required for common use cases such as
-logging, the shell, and specific protocols. This option also guarantees the
-order in which the instances will be registered and appear in the configuration
-descriptor. The option uses the chosen node properties to identify UART devices.
-The following are currently supported, in this order:
-"zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
-A supported property may be missing, and properties may reference the same device.
 
 Using CDC ACM UART in the application
 =====================================

--- a/doc/services/connectivity/usb/device_next/usb_device.rst
+++ b/doc/services/connectivity/usb/device_next/usb_device.rst
@@ -207,7 +207,7 @@ instance (``n``) and is used as an argument to the :c:func:`usbd_register_class`
 +===================================+=========================+=========================+
 | USB Audio 2 class                 | :ref:`uac2_device`      | :samp:`uac2_{n}`        |
 +-----------------------------------+-------------------------+-------------------------+
-| USB CDC ACM class                 | :ref:`uart_api`         | :samp:`cdc_acm_{n}`     |
+| USB CDC ACM class                 | :ref:`uart_api`         | UART device name        |
 +-----------------------------------+-------------------------+-------------------------+
 | USB CDC ECM class                 | Ethernet device         | :samp:`cdc_ecm_{n}`     |
 +-----------------------------------+-------------------------+-------------------------+

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -853,6 +853,8 @@ int usbd_add_configuration(struct usbd_context *uds_ctx,
  * @param[in] cfg     Configuration value (bConfigurationValue)
  *
  * @return 0 on success, other values on fail.
+ * @retval -EALREADY If class instance is already registered.
+ * @retval -EBUSY If USB device support is already initialized.
  */
 int usbd_register_class(struct usbd_context *uds_ctx,
 			const char *name,

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -746,28 +746,51 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  * Macro defines class (function) data, as well as corresponding node
  * structures used internally by the stack.
  *
+ * The @param class_name can be used to provide a string literal that can be
+ * used as a reference. For example, to have a reference between device name
+ * that a class instance is implementing and class name, which is used to
+ * register a class. The device name can be passed using the DEVICE_DT_NAME()
+ * macro.
+ *
+ * @param class_id     Class identifier
  * @param class_name   Class name
  * @param class_api    Pointer to struct usbd_class_api
  * @param class_priv   Class private data
  * @param class_v_reqs Pointer to struct usbd_cctx_vendor_req
  */
-#define USBD_DEFINE_CLASS(class_name, class_api, class_priv, class_v_reqs)	\
-	static struct usbd_class_data class_name = {				\
-		.name = STRINGIFY(class_name),					\
+#define USBD_DEFINE_CLASS_WITH_NAME(class_id, class_name,			\
+				    class_api, class_priv, class_v_reqs)	\
+	static struct usbd_class_data class_id = {				\
+		.name = class_name,						\
 		.api = class_api,						\
 		.v_reqs = class_v_reqs,						\
 		.priv = class_priv,						\
 	};									\
 	static STRUCT_SECTION_ITERABLE_ALTERNATE(				\
-		usbd_class_fs, usbd_class_node, class_name##_fs) = {		\
-		.c_data = &class_name,						\
+		usbd_class_fs, usbd_class_node, class_id##_fs) = {		\
+		.c_data = &class_id,						\
 	};									\
 	IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (					\
 	static STRUCT_SECTION_ITERABLE_ALTERNATE(				\
-		usbd_class_hs, usbd_class_node, class_name##_hs) = {		\
-		.c_data = &class_name,						\
+		usbd_class_hs, usbd_class_node, class_id##_hs) = {		\
+		.c_data = &class_id,						\
 	}									\
 	))
+
+/**
+ * @brief Define USB device support class data
+ *
+ * This macro is similar to USBD_DEFINE_CLASS_WITH_NAME(), except it does not
+ * provide an argument for the class name.
+ *
+ * @param class_id     Class identifier
+ * @param class_api    Pointer to struct usbd_class_api
+ * @param class_priv   Class private data
+ * @param class_v_reqs Pointer to struct usbd_cctx_vendor_req
+ */
+#define USBD_DEFINE_CLASS(class_id, class_api, class_priv, class_v_reqs)	\
+	USBD_DEFINE_CLASS_WITH_NAME(class_id, STRINGIFY(class_id),		\
+				    class_api, class_priv, class_v_reqs)
 
 /** @brief Helper to declare request table of usbd_cctx_vendor_req
  *

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -16,6 +16,3 @@ common:
     - mimxrt1060_evk/mimxrt1062/qspi
 tests:
   sample.usbd.console: {}
-  sample.usbd.console.multiple-instances:
-    extra_configs:
-      - CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES=y

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -16,3 +16,6 @@ common:
     - mimxrt1060_evk/mimxrt1062/qspi
 tests:
   sample.usbd.console: {}
+  sample.usbd.console.multiple-instances:
+    extra_configs:
+      - CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES=y

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -1,17 +1,18 @@
 sample:
   name: Console over CDC ACM serial
+common:
+  depends_on:
+    - usbd
+  tags: usb
+  harness: console
+  harness_config:
+    fixture: fixture_usb_cdc
+  integration_platforms:
+    - nrf52840dk/nrf52840
+    - frdm_k64f
+    - stm32f723e_disco
+    - nucleo_f413zh
+    - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt1060_evk/mimxrt1062/qspi
 tests:
-  sample.usbd.console:
-    depends_on:
-      - usbd
-    tags: usb
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - frdm_k64f
-      - stm32f723e_disco
-      - nucleo_f413zh
-      - mimxrt685_evk/mimxrt685s/cm33
-      - mimxrt1060_evk/mimxrt1062/qspi
-    harness: console
-    harness_config:
-      fixture: fixture_usb_cdc
+  sample.usbd.console: {}

--- a/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
+++ b/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
@@ -23,19 +23,6 @@ config CDC_ACM_SERIAL_ENABLE_AT_BOOT
 	  When disabled, the application is responsible for enabling/disabling
 	  the USB device.
 
-config CDC_ACM_SERIAL_MULTIPLE_INSTANCES
-	bool "Register and initialize multiple CDC ACM instances"
-	help
-	  Register multiple CDC ACM instances whose UARTs are referenced by
-	  appropriate Zephyr-specific chosen node properties. The order in which
-	  the instances will be registered and appear in the configuration
-	  descriptor is guaranteed. The following are currently supported, in
-	  this order: "zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
-	  A supported property may be missing, and properties may reference the
-	  same device.
-	  Each instance occupies two IN endpoints and one OUT endpoint. USB device
-	  controller must have enough resources to support multiple instances.
-
 config CDC_ACM_SERIAL_MANUFACTURER_STRING
 	string "USB device manufacturer string descriptor"
 	default "Zephyr Project"

--- a/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
+++ b/subsys/usb/device_next/app/Kconfig.cdc_acm_serial
@@ -23,6 +23,19 @@ config CDC_ACM_SERIAL_ENABLE_AT_BOOT
 	  When disabled, the application is responsible for enabling/disabling
 	  the USB device.
 
+config CDC_ACM_SERIAL_MULTIPLE_INSTANCES
+	bool "Register and initialize multiple CDC ACM instances"
+	help
+	  Register multiple CDC ACM instances whose UARTs are referenced by
+	  appropriate Zephyr-specific chosen node properties. The order in which
+	  the instances will be registered and appear in the configuration
+	  descriptor is guaranteed. The following are currently supported, in
+	  this order: "zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr".
+	  A supported property may be missing, and properties may reference the
+	  same device.
+	  Each instance occupies two IN endpoints and one OUT endpoint. USB device
+	  controller must have enough resources to support multiple instances.
+
 config CDC_ACM_SERIAL_MANUFACTURER_STRING
 	string "USB device manufacturer string descriptor"
 	default "Zephyr Project"

--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -43,9 +43,31 @@ USBD_CONFIGURATION_DEFINE(cdc_acm_serial_hs_config,
 			  attributes,
 			  CONFIG_CDC_ACM_SERIAL_MAX_POWER, &hs_cfg_desc);
 
+#define GET_CHOSEN_OR_NULL(chosen)						\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_CHOSEN(chosen), zephyr_cdc_acm_uart),	\
+		    (DEVICE_DT_GET_OR_NULL(DT_CHOSEN(chosen))),			\
+		    (NULL))
 
-static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
-			      const enum usbd_speed speed)
+/*
+ * The CDC ACM instances are registered in the same order that they appear in
+ * this array. Therefore, they are always presented in the same order on the
+ * host side. Add new entries at the end.
+ */
+const static struct device *uart_devs[] = {
+#if CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES
+	GET_CHOSEN_OR_NULL(zephyr_console),
+	GET_CHOSEN_OR_NULL(zephyr_shell_uart),
+	GET_CHOSEN_OR_NULL(zephyr_uart_mcumgr),
+	GET_CHOSEN_OR_NULL(zephyr_bt_c2h_uart),
+	GET_CHOSEN_OR_NULL(zephyr_ot_uart),
+	GET_CHOSEN_OR_NULL(zephyr_bt_mon_uart),
+#else
+	DEVICE_DT_GET_ANY(zephyr_cdc_acm_uart),
+#endif
+};
+
+static int register_cdc_acm(struct usbd_context *const uds_ctx,
+			    const enum usbd_speed speed)
 {
 	struct usbd_config_node *cfg_nd;
 	int err;
@@ -62,10 +84,16 @@ static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	err = usbd_register_class(&cdc_acm_serial, "cdc_acm_0", speed, 1);
-	if (err) {
-		LOG_ERR("Failed to register classes");
-		return err;
+	for (int n = 0; n < ARRAY_SIZE(uart_devs); n++) {
+		if (uart_devs[n] == NULL) {
+			continue;
+		}
+
+		err = usbd_register_class(&cdc_acm_serial, uart_devs[n]->name, speed, 1);
+		if (err != 0 && err != -EALREADY) {
+			LOG_ERR("Failed to register %s", uart_devs[n]->name);
+			return err;
+		}
 	}
 
 	return usbd_device_set_code_triple(uds_ctx, speed,
@@ -105,13 +133,13 @@ static int cdc_acm_serial_init_device(void)
 
 	if (USBD_SUPPORTS_HIGH_SPEED &&
 	    usbd_caps_speed(&cdc_acm_serial) == USBD_SPEED_HS) {
-		err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_HS);
+		err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_HS);
 		if (err) {
 			return err;
 		}
 	}
 
-	err = register_cdc_acm_0(&cdc_acm_serial, USBD_SPEED_FS);
+	err = register_cdc_acm(&cdc_acm_serial, USBD_SPEED_FS);
 	if (err) {
 		return err;
 	}

--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -54,17 +54,18 @@ USBD_CONFIGURATION_DEFINE(cdc_acm_serial_hs_config,
  * host side. Add new entries at the end.
  */
 const static struct device *uart_devs[] = {
-#if CONFIG_CDC_ACM_SERIAL_MULTIPLE_INSTANCES
 	GET_CHOSEN_OR_NULL(zephyr_console),
 	GET_CHOSEN_OR_NULL(zephyr_shell_uart),
 	GET_CHOSEN_OR_NULL(zephyr_uart_mcumgr),
 	GET_CHOSEN_OR_NULL(zephyr_bt_c2h_uart),
 	GET_CHOSEN_OR_NULL(zephyr_ot_uart),
 	GET_CHOSEN_OR_NULL(zephyr_bt_mon_uart),
-#else
-	DEVICE_DT_GET_ANY(zephyr_cdc_acm_uart),
-#endif
 };
+
+/* This allows to keep old behavior when there is only one compatible node,
+ * regardless of chosen property.
+ */
+const struct device *uart_dev = DEVICE_DT_GET_ANY(zephyr_cdc_acm_uart);
 
 static int register_cdc_acm(struct usbd_context *const uds_ctx,
 			    const enum usbd_speed speed)
@@ -84,17 +85,27 @@ static int register_cdc_acm(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	for (int n = 0; n < ARRAY_SIZE(uart_devs); n++) {
-		if (uart_devs[n] == NULL) {
-			continue;
-		}
+	if (DT_NUM_INST_STATUS_OKAY(zephyr_cdc_acm_uart) > 1) {
+		for (int n = 0; n < ARRAY_SIZE(uart_devs); n++) {
+			if (uart_devs[n] == NULL) {
+				continue;
+			}
 
-		err = usbd_register_class(&cdc_acm_serial, uart_devs[n]->name, speed, 1);
-		if (err != 0 && err != -EALREADY) {
-			LOG_ERR("Failed to register %s", uart_devs[n]->name);
+			err = usbd_register_class(&cdc_acm_serial,
+						  uart_devs[n]->name, speed, 1);
+			if (err != 0 && err != -EALREADY) {
+				LOG_ERR("Failed to register %s", uart_devs[n]->name);
+				return err;
+			}
+		}
+	} else {
+		err = usbd_register_class(&cdc_acm_serial,
+					  uart_dev->name, speed, 1);
+		if (err != 0) {
 			return err;
 		}
 	}
+
 
 	return usbd_device_set_code_triple(uds_ctx, speed,
 					   USB_BCC_MISCELLANEOUS, 0x02, 0x01);

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -1345,9 +1345,11 @@ const static struct usb_desc_header *cdc_acm_hs_desc_##n[] = {			\
 		    (CDC_ACM_DEFINE_HS_DESC_HEADER(n)),				\
 		    ())								\
 										\
-	USBD_DEFINE_CLASS(cdc_acm_##n,						\
-			  &usbd_cdc_acm_api,					\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);		\
+	USBD_DEFINE_CLASS_WITH_NAME(cdc_acm_##n,				\
+				    DEVICE_DT_NAME(DT_DRV_INST(n)),		\
+				    &usbd_cdc_acm_api,				\
+				    (void *)DEVICE_DT_GET(DT_DRV_INST(n)),	\
+				    NULL);					\
 										\
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, label), (				\
 	USBD_DESC_STRING_DEFINE(cdc_acm_if_desc_data_##n,			\

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -319,13 +319,13 @@ int usbd_register_class(struct usbd_context *const uds_ctx,
 	/* TODO: does it still need to be atomic ? */
 	if (atomic_test_bit(&c_nd->state, USBD_CCTX_REGISTERED)) {
 		LOG_WRN("Class instance already registered");
-		ret = -EBUSY;
+		ret = -EALREADY;
 		goto register_class_error;
 	}
 
 	if ((c_data->uds_ctx != NULL) && (c_data->uds_ctx != uds_ctx)) {
 		LOG_ERR("Class registered to other context at different speed");
-		ret = -EBUSY;
+		ret = -EALREADY;
 		goto register_class_error;
 	}
 


### PR DESCRIPTION
Application can use new option CDC_ACM_SERIAL_MULTIPLE_INSTANCES if different CDC ACM serial backends are required for common use cases such as logging, the shell, and specific protocols. This option also guarantees the order in which the instances will be registered and appear in the configuration descriptor. The option uses the chosen node properties to identify UART devices.

The following are currently supported, in this order: "zephyr,console", "zephyr,shell-uart", "zephyr,uart-mcumgr". A supported property may be missing, and properties may reference the same device.