### PR TITLE
Fix multicore sysbuild flashing for nRF7120

### DIFF
--- a/boards/nordic/nrf7120dk/board.yml
+++ b/boards/nordic/nrf7120dk/board.yml
@@ -3,9 +3,44 @@ board:
   full_name: nRF7120 DK
   vendor: nordic
   socs:
-  - name: nrf7120
-    variants:
-    - name: xip
-      cpucluster: cpuflpr
-    - name: ns
-      cpucluster: cpuapp
+    - name: nrf7120
+      variants:
+        - name: xip
+          cpucluster: cpuflpr
+        - name: ns
+          cpucluster: cpuapp
+
+runners:
+  run_once:
+    '--recover':
+      - runners:
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - nrf7120dk/nrf7120/cpuapp
+              - nrf7120dk/nrf7120/cpuapp/ns
+              - nrf7120dk/nrf7120/cpuflpr
+              - nrf7120dk/nrf7120/cpuflpr/xip
+    '--erase':
+      - runners:
+          - jlink
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - nrf7120dk/nrf7120/cpuapp
+              - nrf7120dk/nrf7120/cpuapp/ns
+              - nrf7120dk/nrf7120/cpuflpr
+              - nrf7120dk/nrf7120/cpuflpr/xip
+    '--reset':
+      - runners:
+          - jlink
+          - nrfutil
+        run: last
+        groups:
+          - boards:
+              - nrf7120dk/nrf7120/cpuapp
+              - nrf7120dk/nrf7120/cpuapp/ns
+              - nrf7120dk/nrf7120/cpuflpr
+              - nrf7120dk/nrf7120/cpuflpr/xip

--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuflpr.dts
@@ -14,8 +14,8 @@
 	compatible = "nordic,nrf7120dk_nrf7120-cpuflpr";
 
 	chosen {
-		zephyr,console = &uart00;
-		zephyr,shell-uart = &uart00;
+		zephyr,console = &uart30;
+		zephyr,shell-uart = &uart30;
 		zephyr,code-partition = &cpuflpr_code_partition;
 		zephyr,flash = &cpuflpr_mram;
 		zephyr,sram = &ram03_sram;
@@ -48,7 +48,7 @@
 	status = "okay";
 };
 
-&uart00 {
+&uart30 {
 	status = "okay";
 };
 

--- a/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
@@ -19,8 +19,11 @@ clic: &cpuflpr_clic {};
 	cpuflpr_mram: mram@3de000 {
 		compatible = "soc-nv-flash";
 		reg = <0x3de000 DT_SIZE_K(116)>;
+		ranges = <0x0 0x3de000 DT_SIZE_K(116)>;
 		erase-block-size = <4096>;
 		write-block-size = <4>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 };
 

--- a/samples/sysbuild/hello_world/Kconfig.sysbuild
+++ b/samples/sysbuild/hello_world/Kconfig.sysbuild
@@ -34,7 +34,7 @@ config REMOTE_BOARD
 	default "$(BOARD)/nrf54h20/cpuppr/xip" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUPPR_XIP_CORE
 	default "$(BOARD)/nrf54h20/cpuflpr" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUFLPR_CORE
 	default "$(BOARD)/nrf54h20/cpuflpr/xip" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUFLPR_XIP_CORE
-	default "$(BOARD)/nrf7120/cpuflpr" if SOC_NRF7120_CPUAPP
+	default "$(BOARD)/nrf7120/cpuflpr" if SOC_NRF7120_ENGA_CPUAPP
 	default "$(BOARD)/max32655/rv32" if SOC_MAX32655_M4
 	default "$(BOARD)/max32690/rv32" if SOC_MAX32690_M4
 	default "$(BOARD)/max78002/rv32" if SOC_MAX78002_M4

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -370,7 +370,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 erase_arg = 'ERASE_ALL'
             elif self.erase_mode:
                 erase_arg = erase_mode
-            elif self.family == 'nrf54l':
+            elif self.family in ('nrf54l', 'nrf71'):
                 erase_arg = 'ERASE_NONE'
             else:
                 erase_arg = 'ERASE_RANGES_TOUCHED_BY_FIRMWARE'

--- a/snippets/nordic/nordic-flpr/soc/nrf7120_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf7120_cpuapp.overlay
@@ -23,7 +23,7 @@
 	};
 };
 
-&uart00 {
+&uart30 {
 	status = "reserved";
 };
 


### PR DESCRIPTION
- The REMOTE_BOARD Kconfig used a non-existent SOC_NRF7120_CPUAPP
  symbol; corrected to SOC_NRF7120_ENGA_CPUAPP.

- The cpuflpr_mram node was missing ranges, #address-cells and
  #size-cells, causing dtc warnings about mismatched address-cells
  when a fixed-partitions child node was present.

- The FLPR board DTS and the nordic-flpr snippet both referenced
  uart00 instead of uart30 for the FLPR console UART.

- The nrf_common runner was not applying ERASE_NONE for the nrf71
  family.

- The board.yml was missing a runners.run_once section, so --erase
  and --recover were applied to every domain instead of only the
  first, and --reset was not deferred to the last domain.