### PR TITLE
drivers: usb: udc: stm32: implement proper isochronous support for ST USB IP 

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -72,4 +72,55 @@ config UDC_STM32_OTG_RXFIFO_BASELINE_SIZE
 	  Refer to STM32 Reference Manuals for more details about the RxFIFO.
 endmenu
 
+menu "ST USB options"
+	depends on DT_HAS_ST_STM32_USB_ENABLED
+
+config UDC_STM32_STUSB_ISO_OUT_EP_NUM
+	int "Number of endpoints reserved for isochronous OUT"
+	default 0
+	range 0 $(UINT8_MAX)
+	help
+	  Number of endpoints reserved for OUT isochronous mode operation
+
+	  This option is used to reserve endpoints for configuration in
+	  isochronous mode, as it requires special handling which cannot
+	  be done easily with the current stack design. This option works
+	  toghether with the CONFIG_UDC_STM32_STUSB_ISO_IN_EP_NUM option.
+
+	  The first CONFIG_UDC_STM32_STUSB_ISO_OUT_EP_NUM endpoints are
+	  reserved and can only be configured as isochronous OUT. The
+	  next UDC_STM32_STUSB_ISO_IN_EP_NUM endpoints are reserved
+	  and can only be configured as isochronous IN. All remaining
+	  endpoints can be configured as bulk/interrupt in any direction
+	  (reservations start at EP1: EP0 is reserved as control endpoint).
+
+	  As an example, if CONFIG_UDC_STM32_STUSB_ISO_OUT_EP_NUM is set
+	  to 1 and CONFIG_UDC_STM32_STUSB_ISO_IN_EP_NUM is also set to 1:
+	    - (EP0 OUT/IN is reserved as control endpoint)
+
+	    - EP1 OUT is reserved for isochronous mode
+	    - EP1 IN is reserved and cannot be used
+
+	    - EP2 OUT is reserved and cannot be used
+	    - EP2 IN is reserved for isochronous mode
+
+	    - EP3~EPn OUT/IN can be used freely in bulk/interrupt mode
+
+	  When this option is set to zero, it is not possible to configure
+	  any endpoint as isochronous OUT.
+
+config UDC_STM32_STUSB_ISO_IN_EP_NUM
+	int "Number of endpoints reserved for isochronous IN"
+	default 0
+	range 0 $(UINT8_MAX)
+	help
+	  Number of endpoints reserved for IN isochronous mode operation
+
+	  When this option is set to zero, it is not possible to configure
+	  any endpoint in isochronous IN mode.
+
+	  Refer to CONFIG_UDC_STM32_STUSB_ISO_OUT_EP_NUM for more details.
+
+endmenu
+
 endif

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -37,11 +37,25 @@ config UDC_STM32_MAX_QMESSAGES
 	help
 	  Maximum number of messages for handling of STM32 USBD ISR events.
 
+config UDC_STM32_CLOCK_CHECK
+	bool "Runtime USB 48MHz clock check"
+	default n if SOC_SERIES_STM32F1X || \
+		     SOC_SERIES_STM32F3X || \
+		     SOC_SERIES_STM32U5X || \
+		     SOC_SERIES_STM32WBAX
+	default y
+	help
+	  Enable USB clock 48MHz configuration runtime check.
+	  In specific cases, this check might provide wrong verdict and should
+	  be disabled.
+
+menu "OTGHS/OTGFS options"
+	depends on DT_HAS_ST_STM32_OTGFS_ENABLED \
+		|| DT_HAS_ST_STM32_OTGHS_ENABLED
+
 config UDC_STM32_OTG_RXFIFO_BASELINE_SIZE
 	int "Baseline RxFIFO size (in bytes)"
 	default 600
-	depends on DT_HAS_ST_STM32_OTGFS_ENABLED \
-		|| DT_HAS_ST_STM32_OTGHS_ENABLED
 	help
 	  Baseline value for RXFIFO size computation
 
@@ -56,17 +70,6 @@ config UDC_STM32_OTG_RXFIFO_BASELINE_SIZE
 	  configuration (e.g., number of endpoints implemented).
 
 	  Refer to STM32 Reference Manuals for more details about the RxFIFO.
-
-config UDC_STM32_CLOCK_CHECK
-	bool "Runtime USB 48MHz clock check"
-	default n if SOC_SERIES_STM32F1X || \
-		     SOC_SERIES_STM32F3X || \
-		     SOC_SERIES_STM32U5X || \
-		     SOC_SERIES_STM32WBAX
-	default y
-	help
-	  Enable USB clock 48MHz configuration runtime check.
-	  In specific cases, this check might provide wrong verdict and should
-	  be disabled.
+endmenu
 
 endif

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Linaro Limited
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Linaro Limited
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -657,9 +657,22 @@ static int udc_stm32_ep_mem_config(const struct device *dev,
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	const struct udc_stm32_config *cfg = dev->config;
+	const bool isochronous = ep_cfg->caps.iso;
 	uint32_t size;
 
-	size = MIN(udc_mps_ep_size(ep_cfg), cfg->ep_mps);
+	/*
+	 * Round up request size because the PMA must be accessed
+	 * using only word-aligned addresses.
+	 */
+	size = ROUND_UP(MIN(udc_mps_ep_size(ep_cfg), cfg->ep_mps), 4U);
+
+	if (isochronous) {
+		/*
+		 * Isochronous EP must be double-buffered.
+		 * Allocate two buffers of requested size.
+		 */
+		size *= 2;
+	}
 
 	if (!enable) {
 		priv->occupied_mem -= size;
@@ -672,8 +685,24 @@ static int udc_stm32_ep_mem_config(const struct device *dev,
 	}
 
 	/* Configure PMA offset for the endpoint */
-	if (HAL_PCDEx_PMAConfig(&priv->pcd, ep_cfg->addr, PCD_SNG_BUF,
-				priv->occupied_mem) != HAL_OK) {
+	uint32_t buftype, bufs;
+
+	if (isochronous) {
+		/*
+		 * HAL_PCDEx_PMAConfig() `pmaaddress` parameter takes two 16-bit
+		 * PMA addresses in the high/low 16 bits of fourth u32 parameter
+		 */
+		const uint16_t buf1_pma_addr = priv->occupied_mem;
+		const uint16_t buf2_pma_addr = priv->occupied_mem + (size / 2);
+
+		buftype = PCD_DBL_BUF;
+		bufs = ((uint32_t)buf2_pma_addr << 16) | buf1_pma_addr;
+	} else {
+		buftype = PCD_SNG_BUF;
+		bufs = priv->occupied_mem;
+	}
+
+	if (HAL_PCDEx_PMAConfig(&priv->pcd, ep_cfg->addr, buftype, bufs) != HAL_OK) {
 		return -EIO;
 	}
 
@@ -764,6 +793,53 @@ static int udc_stm32_ep_mem_config(const struct device *dev,
 	return 0;
 }
 #endif
+
+/* Initializes ep_cfg->addr and ep_cfg->caps (except caps.mps) */
+static void udc_stm32_init_ep_addr_caps(struct udc_ep_config *ep_cfg, uint8_t ep_addr)
+{
+	const uint8_t ep_idx = USB_EP_GET_IDX(ep_addr);
+	const uint8_t dir = USB_EP_GET_DIR(ep_addr);
+
+	ep_cfg->addr = ep_addr;
+
+	if (dir == USB_EP_DIR_OUT) {
+		ep_cfg->caps.out = 1;
+	} else {
+		ep_cfg->caps.in = 1;
+	}
+
+	if (ep_idx == 0u) {
+		ep_cfg->caps.control = 1;
+	} else {
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+		/* OTG IP: non-control endpoints can be used in any mode */
+		ep_cfg->caps.bulk = 1;
+		ep_cfg->caps.interrupt = 1;
+		ep_cfg->caps.iso = 1;
+#else /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb) */
+		/*
+		 * ST USB IP non-control endpoints allocation:
+		 *  - first ISO_OUT_EP_NUM accept isochronous OUT only
+		 *  - next ISO_IN_EP_NUM accept isochronous IN
+		 *  - all others accept bulk/interrupt in any direction
+		 */
+		const uint32_t num_iso_out = CONFIG_UDC_STM32_STUSB_ISO_OUT_EP_NUM;
+		const uint32_t num_iso_in = CONFIG_UDC_STM32_STUSB_ISO_IN_EP_NUM;
+
+		if (ep_idx <= num_iso_out) {
+			/* First M endpoints: ISO OUT only */
+			ep_cfg->caps.iso = (dir == USB_EP_DIR_OUT) ? 1 : 0;
+		} else if (ep_idx <= (num_iso_out + num_iso_in)) {
+			/* Next N endpoints: ISO IN only */
+			ep_cfg->caps.iso = (dir == USB_EP_DIR_IN) ? 1 : 0;
+		} else {
+			/* Remaining endpoints: bulk/interrupt mode */
+			ep_cfg->caps.bulk = 1;
+			ep_cfg->caps.interrupt = 1;
+		}
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb) */
+	}
+}
 
 static void udc_stm32_lock(const struct device *dev)
 {
@@ -1173,18 +1249,13 @@ static int udc_stm32_driver_preinit(const struct device *dev)
 	int err;
 
 	for (unsigned int i = 0; i < cfg->num_endpoints; i++) {
-		cfg->out_eps[i].caps.out = 1;
+		udc_stm32_init_ep_addr_caps(cfg->out_eps + i, USB_EP_DIR_OUT | i);
 		if (i == 0) {
-			cfg->out_eps[i].caps.control = 1;
 			cfg->out_eps[i].caps.mps = UDC_STM32_EP0_MAX_PACKET_SIZE;
 		} else {
-			cfg->out_eps[i].caps.bulk = 1;
-			cfg->out_eps[i].caps.interrupt = 1;
-			cfg->out_eps[i].caps.iso = 1;
 			cfg->out_eps[i].caps.mps = cfg->ep_mps;
 		}
 
-		cfg->out_eps[i].addr = USB_EP_DIR_OUT | i;
 		err = udc_register_ep(dev, cfg->out_eps + i);
 		if (err != 0) {
 			LOG_ERR("Failed to register endpoint");
@@ -1193,18 +1264,13 @@ static int udc_stm32_driver_preinit(const struct device *dev)
 	}
 
 	for (unsigned int i = 0; i < cfg->num_endpoints; i++) {
-		cfg->in_eps[i].caps.in = 1;
+		udc_stm32_init_ep_addr_caps(cfg->in_eps + i, USB_EP_DIR_IN | i);
 		if (i == 0) {
-			cfg->in_eps[i].caps.control = 1;
 			cfg->in_eps[i].caps.mps = UDC_STM32_EP0_MAX_PACKET_SIZE;
 		} else {
-			cfg->in_eps[i].caps.bulk = 1;
-			cfg->in_eps[i].caps.interrupt = 1;
-			cfg->in_eps[i].caps.iso = 1;
 			cfg->in_eps[i].caps.mps = cfg->ep_mps;
 		}
 
-		cfg->in_eps[i].addr = USB_EP_DIR_IN | i;
 		err = udc_register_ep(dev, cfg->in_eps + i);
 		if (err != 0) {
 			LOG_ERR("Failed to register endpoint");


### PR DESCRIPTION
The ST USB IP (compatible `st,stm32-usb`) supports two different modes of operation for each endpoint:
* single-buffered mode
  * Each direction (e.g., `EP0 IN` / `EP0 OUT`) uses a single USB SRAM buffer and a single `buffer descriptor` register to perform transfers
* double-buffered
  * A single direction (e.g., `EP1 OUT`) uses **two** USB SRAM buffers and two `buffer descriptor` registers to perform transfers
    * *(The two buffers are used similarly to front/back buffers in video apps)*
  * **The other direction (e.g., EP1 IN) cannot be used**

Unlike others, isochronous endpoints **must** be double-buffered which requires special handling that, up until now, was not implemented in the driver. As such, it was possible to incorrectly configure the IP which could result in e.g. wrong data being sent to the USB bus.

Update the UDC driver to properly support isochronous operation with this IP. To this end, and due to stack architecture, three new Kconfig options are introduced:
* `UDC_STM32_STUSB_ISOCHRONOUS_SUPPORT`: enables overall isochronous support
* `UDC_STM32_STUSB_ISO_OUT_EP_NUM` / `UDC_STM32_STUSB_ISO_IN_EP_NUM`: used to reserve a fixed number of endpoints for isochronous operation (in either direction)
  * This is done because the stack does not allow placing constraints on another EP when one is being configured
  * However, it would be sufficient to:
    * mark `EPn <OUT/IN>` as not supporting isochronous mode once `EPn <IN/OUT>` has been configured in bulk/interrupt mode
    * mark `EPn <OUT/IN>` as not being available (no mode supported) once `EPn <IN/OUT>` has been configured in isochronous mode
  * If the endpoint configuration mechanism of the stack is updated in the future, this could be revisited

Tested OK on STM32H573I-DK with `samples/subsys/usb/uac2_explicit_feedback` (requires additional patches not provided here)