### PR TITLE
kernel: drop deprecated options SCHED_DUMB and WAITQ_DUMB

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -423,6 +423,9 @@ DeviceTree
 Kernel
 ******
 
+* Dropped CONFIG_SCHED_DUMB and CONFIG_WAITQ_DUMB options which were deprecated
+  in Zephyr 4.2.0
+
 * :ref:`cleanup_api`
 
   * :c:macro:`SCOPE_VAR_DEFINE`

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -300,15 +300,8 @@ endchoice # DYNAMIC_THREAD_PREFER
 
 endif # DYNAMIC_THREADS
 
-config SCHED_DUMB
-	bool "Simple linked-list ready queue"
-	select DEPRECATED
-	help
-	  Deprecated in favour of SCHED_SIMPLE.
-
 choice SCHED_ALGORITHM
 	prompt "Scheduler priority queue algorithm"
-	default SCHED_SIMPLE if SCHED_DUMB
 	default SCHED_SIMPLE
 	help
 	  The kernel can be built with several choices for the
@@ -360,15 +353,8 @@ config SCHED_MULTIQ
 
 endchoice # SCHED_ALGORITHM
 
-config WAITQ_DUMB
-	bool "Simple linked-list wait_q"
-	select DEPRECATED
-	help
-	  Deprecated in favour of WAITQ_SIMPLE.
-
 choice WAITQ_ALGORITHM
 	prompt "Wait queue priority algorithm"
-	default WAITQ_SIMPLE if WAITQ_DUMB
 	default WAITQ_SIMPLE
 	help
 	  The wait_q abstraction used in IPC primitives to pend


### PR DESCRIPTION
Those kconfig options were deprecated in 4.2. Now they are removed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
