### PR TITLE
doc: stepper: fix doxygen grouping

### DIFF
--- a/doc/hardware/peripherals/stepper/index.rst
+++ b/doc/hardware/peripherals/stepper/index.rst
@@ -102,13 +102,13 @@ API Reference
 
 A common set of functions which should be implemented by all stepper drivers.
 
-.. doxygengroup:: stepper_hw_driver_interface
+.. doxygengroup:: stepper_hw_driver
 
 .. _stepper-ctrl-api-reference:
 
 A common set of functions which should be implemented by all stepper motion controllers.
 
-.. doxygengroup:: stepper_ctrl_interface
+.. doxygengroup:: stepper_ctrl
 
 Stepper motion controller specific APIs
 ***************************************

--- a/doc/hardware/peripherals/stepper/integrated_controller_driver.rst
+++ b/doc/hardware/peripherals/stepper/integrated_controller_driver.rst
@@ -4,8 +4,8 @@ Integrated Stepper Motion Control and Driver
 ############################################
 
 A device composed of both motion controller and stepper driver blocks in a single IC is modeled as a
-multi-functional device in devicetree, and has two software drivers implementing :c:group:`stepper_ctrl_interface`
-and :c:group:`stepper_hw_driver_interface` APIs respectively. An example of such device is :dtcompatible:`adi,tmc50xx`.
+multi-functional device in devicetree, and has two software drivers implementing :c:group:`stepper_ctrl`
+and :c:group:`stepper_hw_driver` APIs respectively. An example of such device is :dtcompatible:`adi,tmc50xx`.
 
 .. code-block:: dts
 

--- a/include/zephyr/drivers/stepper/stepper.h
+++ b/include/zephyr/drivers/stepper/stepper.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @ingroup stepper_interface
+ * @ingroup stepper_hw_driver
  * @brief Main header file for stepper hardware driver API.
  */
 
@@ -26,7 +26,7 @@ extern "C" {
  * @defgroup stepper_interface Stepper
  * @ingroup io_interfaces
  *
- * @defgroup stepper_hw_driver_interface Stepper Hardware Driver Interface
+ * @defgroup stepper_hw_driver Stepper Hardware Driver
  * @brief Interfaces for stepper hardware drivers
  * @ingroup stepper_interface
  * @since 4.0

--- a/include/zephyr/drivers/stepper/stepper_ctrl.h
+++ b/include/zephyr/drivers/stepper/stepper_ctrl.h
@@ -5,7 +5,7 @@
 
 /**
  * @file
- * @ingroup stepper_ctrl_interface
+ * @ingroup stepper_ctrl
  * @brief Main header file for stepper motion controller driver API.
  */
 
@@ -14,7 +14,7 @@
 
 /**
  * @brief Interfaces for stepper motion controllers.
- * @defgroup stepper_ctrl_interface Stepper Motion Controller Interface
+ * @defgroup stepper_ctrl Stepper Motion Controller
  * @since 4.0
  * @version 0.9.0
  * @ingroup stepper_interface


### PR DESCRIPTION
Fix doxygen grouping under stepper area

Changes:
- Remove redundant "interface" from group names
- Rename:
  `stepper_hw_driver_interface` to `stepper_hw_driver`
  `stepper_ctrl_interface` to `stepper_ctrl`
- Fix `@ingroup` references causing `stepper.h` to show outside the stepper group

Fixes #104974 