### PR TITLE
bluetooth: mesh: fix rpr null dereference

### DIFF
--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -880,6 +880,12 @@ static int handle_link_open(const struct bt_mesh_model *mod, struct bt_mesh_msg_
 			goto rsp;
 		}
 
+		if (srv.refresh.cb == NULL) {
+			LOG_WRN("RPR provisioning client bearer not available");
+			status = BT_MESH_RPR_ERR_LINK_CANNOT_OPEN;
+			goto rsp;
+		}
+
 		LOG_DBG("Node Refresh: %u", refresh);
 
 		atomic_set_bit(srv.flags, NODE_REFRESH);


### PR DESCRIPTION
Commit adds checking that the PB-ADV bearer has been closed before opening the PB-Remote link for NPPI
interface. NPPI interface callbacks are NULL if PB-ADV server bearer is still open.

The bug happens in Zephyr's qualification CI (reported by @sjanc)

The bug scenario:
Qualification tester starts start() in [btp_mesh.c:1460](https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/bluetooth/tester/src/btp_mesh.c#L1460) calls bt_mesh_prov_enable() twice — first with BT_MESH_PROV_ADV | BT_MESH_PROV_GATT, then with BT_MESH_PROV_REMOTE. The second call reaches [provisionee.c:737](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/provisionee.c#L737), which calls pb_remote_srv.link_accept() → node_refresh_link_accept(), storing the callback in srv.refresh.cb.

PB-ADV link opens. The function [provisionee.c:698](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/provisionee.c#L698) cancels other provisioning bearers to avoid multiple concurrent links. Since the active bearer is PB-ADV (not PB-Remote), it calls pb_remote_srv.link_cancel() → [rpr_srv.c:1361](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/rpr_srv.c#L1361), which sets srv.refresh.cb = NULL.

Provisioning completes. Inside provisionee.c, bt_mesh_provision() is called, which calls bt_mesh_start(), making the device fully operational on the mesh (scanning, beaconing, receiving mesh messages). The device is now accessible by RPR clients.

The PB-ADV link is NOT yet closed. The restoration of srv.refresh.cb depends on [provisionee.c:658](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/provisionee.c#L658) being called, which only happens when the PB-ADV Link Close bearer control PDU is received and processed.

RPR Link Open arrives. The RPR client (on another device) sends a node refresh Link Open. [rpr_srv.c:809](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/rpr_srv.c#L809) processes it: since the RPR link state is IDLE and it's a refresh procedure (buf->len == 1), it enters the node-refresh-from-idle code path at [rpr_srv.c:892](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/rpr_srv.c#L892) and dereferences srv.refresh.cb, which is NULL → SEGV.

The checking for non the node-refresh-from-idle code path is not required since pd-adv will return -EBUSY status [pb_adv:1031](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/pb_adv.c#L1031) and rpr handles this correctly here [rpr_srv.c:922](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/bluetooth/mesh/rpr_srv.c#L922)