### PR TITLE
drivers: serial: renesas_ra: Fix tx_enable

### DIFF
--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -349,16 +349,13 @@ static int uart_ra_sci_fifo_read(const struct device *dev, uint8_t *rx_data, con
 
 static void uart_ra_sci_irq_tx_enable(const struct device *dev)
 {
-	struct uart_ra_sci_data *data = dev->data;
 	const struct uart_ra_sci_config *cfg = dev->config;
 #if CONFIG_UART_RA_SCI_UART_FIFO_ENABLE
+	struct uart_ra_sci_data *data = dev->data;
 	if (data->sci.fifo_depth != 0) {
 		cfg->regs->SSR_FIFO &= (uint8_t)~SCI_UART_SSR_FIFO_TDFE_TEND;
-	} else
-#endif
-	{
-		cfg->regs->SSR = (uint8_t)~SCI_UART_SSR_TDRE_TEND;
 	}
+#endif
 
 	cfg->regs->SCR |= (R_SCI0_SCR_TIE_Msk | R_SCI0_SCR_TEIE_Msk);
 }


### PR DESCRIPTION
In uart_ra_sci_irq_tx_enable() it clears the Transmit Data Empty and Transmit End flags.  Doing this results in the uart re-sending the last byte written to the TDR, and seems unnecessary.

Fixes #105162 