### PR TITLE
tests: boards: espressif: use ztest harness for memory_layout

### DIFF
--- a/tests/boards/espressif/memory_layout/testcase.yaml
+++ b/tests/boards/espressif/memory_layout/testcase.yaml
@@ -8,13 +8,7 @@ common:
     - esp32c3_devkitm
     - esp32c6_devkitc/esp32c6/hpcore
     - esp32h2_devkitm
-  harness: console
-  harness_config:
-    type: multi_line
-    regex:
-      - "total SRAM region: (.*) bytes"
-      - "heap boundary: (.*) KB verified"
-      - "PASS"
+  harness: ztest
 tests:
   boards.espressif.memory_layout.simple_boot: {}
   boards.espressif.memory_layout.mcuboot:


### PR DESCRIPTION
The memory_layout test uses the ztest framework with zassert macros, so the harness should be ztest instead of console with custom regex patterns.