### PR TITLE
soc: st: Initialize backup SRAM early for use with retained mem

### DIFF
--- a/soc/st/stm32/common/stm32_backup_sram.c
+++ b/soc/st/stm32/common/stm32_backup_sram.c
@@ -70,4 +70,4 @@ static const struct stm32_backup_sram_config config = {
 };
 
 DEVICE_DT_INST_DEFINE(0, stm32_backup_sram_init, NULL, NULL, &config,
-		      POST_KERNEL, CONFIG_STM32_BACKUP_SRAM_INIT_PRIORITY, NULL);
+		      PRE_KERNEL_1, CONFIG_STM32_BACKUP_SRAM_INIT_PRIORITY, NULL);


### PR DESCRIPTION
Adjust the backup SRAM initialization to PRE_KERNEL_1 to ensure it's initialized before any retained_mem instances placed into that area.

I encountered this when the retained_mem tests failed in Twister for #104630 . See https://github.com/zephyrproject-rtos/zephyr/actions/runs/22869344485/job/66345265944?pr=104630#step:13:770

Manifests as this build failure for that test:

```
Generating files from /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out/nucleo_h723zg_stm32h723xx/zephyr/tests/drivers/retained_mem/api/drivers.retained_mem.api.ram/zephyr/zephyr.elf for board: nucleo_h723zg/stm32h723xx
ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.
ERROR: /soc/memory@38800000/retainedmem <NULL> is initialized before its dependency /soc/memory@38800000 <stm32_backup_sram_init> (PRE_KERNEL_1+8 < POST_KERNEL+1)
```

Changing the level, and running the test on my Nucleo H723zg board here it passes as expected:

```
% west twister --device-testing --device-serial /dev/tty.usbmodem1103 -p nucleo_h723zg --timeout-multiplier 2 -T tests/drivers/retained_mem --extra-args CONFIG_BOOT_DELAY=90   
Renaming previous output directory to /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out.98
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-7611-ga143581d8171
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out/testplan.json

Device testing on:

| Platform                  | ID   | Serial device         |
|---------------------------|------|-----------------------|
| nucleo_h723zg/stm32h723xx |      | /dev/tty.usbmodem1103 |

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    3, failed:    0, error:    0
INFO    - 4 test scenarios (4 configurations) selected, 3 configurations filtered (3 by static filter, 0 at runtime).
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 23.59 seconds.
INFO    - 3 of 3 executed test cases passed (100.00%) on 1 out of total 1410 platforms (0.07%).
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                     | ID   |   Counter |   Failures |
|---------------------------|------|-----------|------------|
| nucleo_h723zg/stm32h723xx |      |         1 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/petejohanson/source/lsmspg-zephyr-app/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

This appears to be a regression due to the changes in #104011 which moved retained_mem before the backup SRAM initialization. I think it's reasonable to move this earlier, given it only relies on the clock to be ready, but I'm not aware of any concerns across the entire STM32 product line, so hopefully someone from ST can chime in on that specific aspect.