### PR TITLE
ci: pr_metadata_check: drop cancel-in-progress concurrency

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -12,10 +12,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   do-not-merge:
     name: Prevent Merging


### PR DESCRIPTION
The concurrency key with cancel-in-progress was added in
commit db1a4f6e5475 ("ci: pr_metadata_check: add a concurrency key")
and it causes cancelled runs to show up as failing checks on PRs when
commits are pushed in quick succession. GitHub aggregates check
conclusions across all runs for a given workflow, so a cancelled run
appears as a check failure even when the latest run succeeds. For
example:

  $ gh pr status
  Created by you
    #654321  some: pr: title [user:branch]
    × 1/45 checks failing - Review required

This workflow runs a lightweight Python script that completes in
seconds, so there is no meaningful resource saving from cancelling
in-progress runs. Remove the concurrency block to avoid the spurious
failure reports.

