### PR TITLE
scripts: empty unused .help duplicates in west extensions

### DIFF
--- a/doc/develop/west/extensions.rst
+++ b/doc/develop/west/extensions.rst
@@ -96,9 +96,9 @@ details on the west APIs you can use, see :ref:`west-apis`.
        def __init__(self):
            super().__init__(
                'my-command-name',  # gets stored as self.name
-               'one-line help for what my-command-name does',  # self.help
+               '', # ignored self.help, will not be required by future west versions
                # self.description:
-               dedent('''
+               description=dedent('''
                A multi-line description of my-command.
 
                You can split this up into multiple paragraphs and they'll get
@@ -112,7 +112,6 @@ details on the west APIs you can use, see :ref:`west-apis`.
            # type of argparse handling you want. The "parser_adder" argument is
            # the return value of an argparse.ArgumentParser.add_subparsers() call.
            parser = parser_adder.add_parser(self.name,
-                                            help=self.help,
                                             description=self.description)
 
            # Add some example options using the standard argparse module API.

--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -44,7 +44,8 @@ WestCommand
 
    .. py:attribute:: help
 
-      As passed to the constructor.
+      As passed to the constructor. Required by built-in commands, ignored by
+      extensions, see https://github.com/zephyrproject-rtos/west/issues/927
 
    .. py:attribute:: description
 

--- a/scripts/west_commands/bindesc.py
+++ b/scripts/west_commands/bindesc.py
@@ -100,15 +100,14 @@ class Bindesc(WestCommand):
 
         super().__init__(
             'bindesc',
-            'work with Binary Descriptors',
-            dedent('''
+            '',
+            description=dedent('''
             Work with Binary Descriptors - constant data objects
             describing a binary image
             '''))
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(self.name,
-                                         help=self.help,
                                          description=self.description)
 
         subparsers = parser.add_subparsers(help='sub-command to run', required=True)

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -25,16 +25,14 @@ class Blobs(WestCommand):
     def __init__(self):
         super().__init__(
             'blobs',
-            # Keep this in sync with the string in west-commands.yml.
-            'work with binary blobs',
-            'Work with binary blobs',
+            '',
+            description='Work with binary blobs',
             accepts_unknown_args=False,
         )
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             epilog=textwrap.dedent(f'''\

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -23,16 +23,14 @@ class Boards(WestCommand):
     def __init__(self):
         super().__init__(
             'boards',
-            # Keep this in sync with the string in west-commands.yml.
-            'display information about supported boards',
-            'Display information about boards',
+            '',
+            description='Display information about boards',
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
         default_fmt = '{name}'
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             epilog=textwrap.dedent(f'''\

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -71,9 +71,8 @@ class Build(Forceable):
     def __init__(self):
         super().__init__(
             'build',
-            # Keep this in sync with the string in west-commands.yml.
-            'compile a Zephyr application',
-            BUILD_DESCRIPTION,
+            '',
+            description=BUILD_DESCRIPTION,
             accepts_unknown_args=True)
 
         self.source_dir = None
@@ -101,7 +100,6 @@ class Build(Forceable):
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             usage=BUILD_USAGE)

--- a/scripts/west_commands/completion.py
+++ b/scripts/west_commands/completion.py
@@ -62,15 +62,13 @@ class Completion(WestCommand):
     def __init__(self):
         super().__init__(
             'completion',
-            # Keep this in sync with the string in west-commands.yml.
-            'output shell completion scripts',
-            COMP_DESCRIPTION,
+            '',
+            description=COMP_DESCRIPTION,
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description)
 

--- a/scripts/west_commands/debug.py
+++ b/scripts/west_commands/debug.py
@@ -18,9 +18,8 @@ class Debug(WestCommand):
     def __init__(self):
         super().__init__(
             'debug',
-            # Keep this in sync with the string in west-commands.yml.
-            'flash and interactively debug a Zephyr application',
-            dedent('''
+            '',
+            description=dedent('''
             Connect to the board, flash the program, and start a
             debugging session. Use "west attach" instead to attach
             a debugger without reflashing.'''),
@@ -39,9 +38,8 @@ class DebugServer(WestCommand):
     def __init__(self):
         super().__init__(
             'debugserver',
-            # Keep this in sync with the string in west-commands.yml.
-            'connect to board and launch a debug server',
-            dedent('''
+            '',
+            description=dedent('''
             Connect to the board and launch a debug server which accepts
             incoming connections for debugging the connected board.
 
@@ -63,9 +61,8 @@ class Attach(WestCommand):
     def __init__(self):
         super().__init__(
             'attach',
-            # Keep this in sync with the string in west-commands.yml.
-            'interactively debug a board',
-            "Like \"west debug\", but doesn't reflash the program.",
+            '',
+            description="Like \"west debug\", but doesn't reflash the program.",
             accepts_unknown_args=True)
         self.runner_key = 'debug-runner'  # in runners.yaml
 
@@ -81,9 +78,8 @@ class Rtt(WestCommand):
     def __init__(self):
         super().__init__(
             'rtt',
-            # Keep this in sync with the string in west-commands.yml.
-            'open an rtt shell',
-            "",
+            '',
+            description='open an rtt shell',
             accepts_unknown_args=True)
         self.runner_key = 'debug-runner'  # in runners.yaml
 
@@ -99,9 +95,8 @@ class Reset(WestCommand):
     def __init__(self):
         super().__init__(
             'reset',
-            # Keep this in sync with the string in west-commands.yml.
-            'reset the board to reboot',
-            "",
+            '',
+            description='reset the board to reboot',
             accepts_unknown_args=True)
         self.runner_key = 'debug-runner'  # in runners.yaml
 

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -25,15 +25,13 @@ class ZephyrExport(WestCommand):
     def __init__(self):
         super().__init__(
             'zephyr-export',
-            # Keep this in sync with the string in west-commands.yml.
-            'export Zephyr installation as a CMake config package',
-            EXPORT_DESCRIPTION,
+            '',
+            description=EXPORT_DESCRIPTION,
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description)
         return parser

--- a/scripts/west_commands/gtags.py
+++ b/scripts/west_commands/gtags.py
@@ -19,8 +19,8 @@ class Gtags(WestCommand):
     def __init__(self):
         super().__init__(
             "gtags",
-            "create a GNU Global tags file for the current workspace",
-            """\
+            "",
+            description="""\
 Indexes source code files in the west workspace using GNU Global's
 "gtags" tool. For more information on Global and gtags, see:
 
@@ -40,7 +40,6 @@ projects etc., see the west documentation.""",
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             description=self.description,
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )

--- a/scripts/west_commands/packages.py
+++ b/scripts/west_commands/packages.py
@@ -28,15 +28,14 @@ class Packages(WestCommand):
     def __init__(self):
         super().__init__(
             "packages",
-            "manage packages for Zephyr",
-            "List and Install packages for Zephyr and modules",
+            "",
+            description="List and Install packages for Zephyr and modules",
             accepts_unknown_args=True,
         )
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             description=self.description,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=textwrap.dedent(

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -40,15 +40,14 @@ class Patch(WestCommand):
     def __init__(self):
         super().__init__(
             "patch",
-            "apply patches to the west workspace",
-            "Apply patches to the west workspace",
+            "",
+            description="Apply patches to the west workspace",
             accepts_unknown_args=False,
         )
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             epilog=textwrap.dedent("""\

--- a/scripts/west_commands/robot.py
+++ b/scripts/west_commands/robot.py
@@ -16,9 +16,8 @@ class Robot(WestCommand):
     def __init__(self):
         super().__init__(
             'robot',
-            # Keep this in sync with the string in west-commands.yml.
-            'run RobotFramework test suites',
-            EXPORT_DESCRIPTION,
+            '',
+            description=EXPORT_DESCRIPTION,
             accepts_unknown_args=True)
 
         self.runner_key = 'robot-runner'  # in runners.yaml

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -125,7 +125,6 @@ def add_parser_common(command, parser_adder=None, parser=None):
         parser = parser_adder.add_parser(
             command.name,
             formatter_class=argparse.RawDescriptionHelpFormatter,
-            help=command.help,
             description=command.description)
 
     # Remember to update west-completion.bash if you add or remove

--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -26,14 +26,13 @@ class Sdk(WestCommand):
     def __init__(self):
         super().__init__(
             "sdk",
-            "manage Zephyr SDK",
-            "List and Install Zephyr SDK",
+            "",
+            description="List and Install Zephyr SDK",
         )
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             description=self.description,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=textwrap.dedent(

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -24,16 +24,14 @@ class Shields(WestCommand):
     def __init__(self):
         super().__init__(
             'shields',
-            # Keep this in sync with the string in west-commands.yml.
-            'display list of supported shield',
-            'Display supported shields',
+            '',
+            description='Display list of supported shields',
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
         default_fmt = '{name}'
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             epilog=textwrap.dedent(f'''\

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -105,16 +105,14 @@ class Sign(Forceable):
     def __init__(self):
         super(Sign, self).__init__(
             'sign',
-            # Keep this in sync with the string in west-commands.yml.
-            'sign a Zephyr binary for bootloader chain-loading',
-            SIGN_DESCRIPTION,
+            '',
+            description=SIGN_DESCRIPTION,
             accepts_unknown_args=False)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
             epilog=SIGN_EPILOG,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description)
 

--- a/scripts/west_commands/simulate.py
+++ b/scripts/west_commands/simulate.py
@@ -16,9 +16,8 @@ class Simulate(WestCommand):
     def __init__(self):
         super().__init__(
             'simulate',
-            # Keep this in sync with the string in west-commands.yml.
-            'simulate board',
-            EXPORT_DESCRIPTION,
+            '',
+            description=EXPORT_DESCRIPTION,
             accepts_unknown_args=True)
 
         self.runner_key = 'sim-runner'  # in runners.yaml

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -24,12 +24,11 @@ class ZephyrSpdx(WestCommand):
     def __init__(self):
         super().__init__(
                 'spdx',
-                'create SPDX bill of materials',
-                SPDX_DESCRIPTION)
+                '',
+                description=SPDX_DESCRIPTION)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(self.name,
-                help=self.help,
                 description = self.description)
 
         # If you update these options, make sure to keep the docs in

--- a/scripts/west_commands/twister_cmd.py
+++ b/scripts/west_commands/twister_cmd.py
@@ -31,9 +31,8 @@ class Twister(WestCommand):
     def __init__(self):
         super(Twister, self).__init__(
             "twister",
-            # Keep this in sync with the string in west-commands.yml.
-            "west twister wrapper",
-            TWISTER_DESCRIPTION,
+            "",
+            description=TWISTER_DESCRIPTION,
             accepts_unknown_args=True,
         )
         python_version_guard()
@@ -41,7 +40,6 @@ class Twister(WestCommand):
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
-            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description,
             allow_abbrev=False


### PR DESCRIPTION
Stop requesting west extension authors to "keep in sync" an unused .help
duplicate. Empty such duplicates from existing extensions. They cannot
be `None` yet because current west versions unfortunately require them.

Since the beginning of west extensions (2019 commit d3bb3cf)
extension authors have been requested to provide not just a "help" field
in west-commands.yml, but also a duplicate in their WestCommmand
constructor than they should carefully "keep in sync".
While doing some unrelated extension work, I discovered by chance
that this duplicate has never been used. See detailed analysis in
zephyrproject-rtos/west#927, shorter analysis
in zephyrproject-rtos/west#933 and smoking gun
in the "TODO" comment added by west commit
zephyrproject-rtos/west@0d39b6b77a5ff059f6901

Signed-off-by: Marc Herbert <Marc.Herbert@gmail.com>