### PR TITLE
boards: infineon: kit_pse84_eval: fix SD card detect pin initialization

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
@@ -118,7 +118,7 @@
 	min-bus-freq = <400000>;
 	power-delay-ms = <1000>;
 	/* Card detect gpios */
-	cd-gpios = <&gpio_prt17 7 GPIO_PULL_UP>;
+	cd-gpios = <&gpio_prt17 7 GPIO_ACTIVE_HIGH>;
 
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";


### PR DESCRIPTION
Fix initialization of SD card CD pin to avoid conflicts with pull-down in EVK hardware.

Signed-off-by: Luis Reynoso <luis.reynoso@infineon.com>