### PR TITLE
drivers: sensor: adxl367: fix DATA_READY handling in trigger mode

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adi/adxl367/adxl367_trigger.c
@@ -22,8 +22,8 @@ static void adxl367_thread_cb(const struct device *dev)
 	uint8_t status;
 	int ret;
 
-	/* Clear the status */
-	ret = drv_data->hw_tf->read_reg(dev, ADXL367_STATUS, &status);
+	/* Check status_copy register to determine trigger source */
+	ret = drv_data->hw_tf->read_reg(dev, ADXL367_STATUS_COPY, &status);
 	if (ret != 0) {
 		return;
 	}


### PR DESCRIPTION
Clearing the `STATUS` register `0x0B` in `adxl367_thread_cb()` introduces a one-sample latency, since any trigger handler invoking `adxl367_get_accel_data()` has to wait until the next sample sets the `DATA_READY` bit again. See the I2C trace below, which shows status register returning `0x41` (`DATA_READY` bit set) after the first read in `adxl367_thread_cb()`, and subsequently returning `0x40` while being polled in `adxl367_get_accel_data()` until the next sample arrives.

<img width="1890" height="1212" alt="image" src="https://github.com/user-attachments/assets/7dcd90cf-34d6-4e2b-bdcb-78b616651d99" />

The fix is to instead read the `STATUS_COPY` register in `adxl367_thread_cb()` so that the `STATUS` register is preserved to be read and cleared in the handler, right before fetching the data. So, the fixed data path looks like:

**adxl367_thread_cb()** -- Read` STATUS_COPY (0x44)` instead of `STATUS (0x0B)`:

- This doesn't clear `DATA_READY` in the actual `STATUS` register
- Still accurately determines which trigger fired and invoke the respective handler

**trigger handler** -- if using the standard `sensor_sample_fetch()` API, polls `DATA_READY` on `STATUS` register (`0x0B`)

- Works correctly for trigger mode (`DATA_READY` still set from the interrupt)
- Works correctly for polling mode (wait for new data), i.e. maintains safety for direct calls to `sensor_sample_fetch()`
- Gets Sample N (the one that triggered), not Sample N+1

Here is the I2C trace with the fix in place. It shows data being read out right after the `STATUS` register indicates that the `DATA_READY` bit is set.

<img width="2217" height="1254" alt="image" src="https://github.com/user-attachments/assets/e9becf80-bfd5-49c4-9783-91177c5049b3" />