### PR TITLE
lib: os: cbprintf: fix -wsign-compare warning

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1656,7 +1656,12 @@ int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
 			break;
 		case 'c':
 			bps = buf;
-			buf[0] = CHAR_IS_SIGNED ? value->sint : value->uint;
+			/* Use if-else to avoid -Wsign-compare warning */
+			if (CHAR_IS_SIGNED) {
+				buf[0] = value->sint;
+			} else {
+				buf[0] = value->uint;
+			}
 			bpe = buf + 1;
 			break;
 		case 'd':


### PR DESCRIPTION
Replace ternary operator with if-else to avoid mixing signed and unsigned types in the conditional expression. This eliminates the compiler warning while preserving the original logic.

Fixes #104581