### PR TITLE
cpuidle: optimize out weak stub function call for !TRACING

### DIFF
--- a/arch/mips/core/cpu_idle.c
+++ b/arch/mips/core/cpu_idle.c
@@ -10,7 +10,9 @@
 
 static ALWAYS_INLINE void mips_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	/* unlock interrupts */
 	irq_unlock(key);

--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -35,14 +35,18 @@ CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT must be selected"
 
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	posix_irq_full_unlock();
 	posix_halt_cpu();
 }
 
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	posix_atomic_halt_cpu(key);
 }
 

--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -10,9 +10,13 @@
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	__asm__ volatile("wfi");
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 	irq_unlock(MSTATUS_IEN);
 }
 #endif
@@ -20,9 +24,13 @@ void arch_cpu_idle(void)
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_ATOMIC_IDLE
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	__asm__ volatile("wfi");
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 	irq_unlock(key);
 }
 #endif

--- a/arch/rx/core/cpu_idle.c
+++ b/arch/rx/core/cpu_idle.c
@@ -9,7 +9,9 @@
 
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	/* The assembler instruction "wait" switches the processor to sleep mode,
 	 * which stops program execution until an interrupt is triggered.
@@ -27,7 +29,9 @@ void arch_cpu_idle(void)
 
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	/* The assembler instruction "wait" switches the processor to sleep mode,
 	 * which stops program execution until an interrupt is triggered.

--- a/arch/x86/core/cpuhalt.c
+++ b/arch/x86/core/cpuhalt.c
@@ -11,7 +11,9 @@
 __pinned_func
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	__asm__ volatile (
 	    "sti\n\t"
 	    "hlt\n\t");
@@ -22,7 +24,9 @@ void arch_cpu_idle(void)
 __pinned_func
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	__asm__ volatile (
 	    "sti\n\t"

--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -9,7 +9,9 @@
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	__asm__ volatile ("waiti 0");
 }
 #endif
@@ -17,7 +19,9 @@ void arch_cpu_idle(void)
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_ATOMIC_IDLE
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	__asm__ volatile ("waiti 0\n\t"
 			  "wsr.ps %0\n\t"
 			  "rsync" :: "a"(key));

--- a/soc/gaisler/leon3/idle.c
+++ b/soc/gaisler/leon3/idle.c
@@ -9,7 +9,9 @@
 
 static void leon_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	irq_unlock(key);
 
 	__asm__ volatile ("wr  %g0, %asr19");

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -443,7 +443,9 @@ void arch_cpu_idle(void)
 {
 	uint32_t cpu = arch_proc_id();
 
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	/*
 	 * unlock and invalidate icache if clock gating is allowed

--- a/soc/intel/intel_adsp/cavs/power.c
+++ b/soc/intel/intel_adsp/cavs/power.c
@@ -207,7 +207,9 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 __no_optimization
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 	/* Just spin forever with interrupts unmasked, for platforms
 	 * where WAITI can't be used or where its behavior is

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -57,7 +57,9 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	 * interrupt here to protect the below content.
 	 */
 	csr_clear(mie, MIP_MEIP);
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 
 #ifdef CONFIG_ESPI
 	/*
@@ -78,7 +80,9 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	/* CPU has been woken up, the interrupt is no longer needed */
 	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, false);
 #endif
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 	/*
 	 * Enable M-mode external interrupt
 	 * An interrupt can not be fired yet until we enable global interrupt

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -328,7 +328,9 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	 * interrupt here to protect the below content.
 	 */
 	csr_clear(mie, MIP_MEIP);
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 #ifdef CONFIG_ESPI
 	/*
 	 * H2RAM feature requires RAM clock to be active. Since the below doze
@@ -392,7 +394,9 @@ __no_idle:
 	/* CPU has been woken up, the interrupt is no longer needed */
 	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, false);
 #endif
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 	/*
 	 * Enable M-mode external interrupt
 	 * An interrupt can not be fired yet until we enable global interrupt

--- a/soc/nordic/common/vpr/soc_idle.c
+++ b/soc/nordic/common/vpr/soc_idle.c
@@ -13,7 +13,9 @@
  */
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	barrier_dsync_fence_full();
 	irq_unlock(MSTATUS_IEN);
 	__asm__ volatile("wfi");
@@ -21,7 +23,9 @@ void arch_cpu_idle(void)
 
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	barrier_dsync_fence_full();
 	irq_unlock(MSTATUS_IEN);
 	__asm__ volatile("wfi");

--- a/soc/snps/arc_iot/soc_idle.c
+++ b/soc/snps/arc_iot/soc_idle.c
@@ -19,12 +19,16 @@
 
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	irq_unlock(0);
 }
 
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	irq_unlock(key);
 }

--- a/soc/wch/ch32v/common/soc_idle.c
+++ b/soc/wch/ch32v/common/soc_idle.c
@@ -10,15 +10,23 @@
 /* note: default risc-v idle cannot be used as this will break ongoing DMA transactions */
 void arch_cpu_idle(void)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	irq_unlock(MSTATUS_IEN);
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 }
 
 /* note: default risc-v idle cannot be used as this will break ongoing DMA transactions */
 void arch_cpu_atomic_idle(unsigned int key)
 {
+#if defined(CONFIG_TRACING)
 	sys_trace_idle();
+#endif
 	irq_unlock(key);
+#if defined(CONFIG_TRACING)
 	sys_trace_idle_exit();
+#endif
 }


### PR DESCRIPTION
For !TRACING, most arch_cpu_idle and arch_cpu_atomic_idle implementation relies on the fact that there's weak stub implementations in subsys/tracing/tracing_none.c, this works, but the arch_cpu_idle sits in hot code path, so we'd better to make it as efficient as possible.

Take the riscv implementation for example,
Before the patch:

80000a66 <arch_cpu_idle>:
80000a66:	1141                	addi	sp,sp,-16
80000a68:	c606                	sw	ra,12(sp)
80000a6a:	37c5                	jal	80000a4a <sys_trace_idle>
80000a6c:	10500073          	wfi
80000a70:	3ff1                	jal	80000a4c <sys_trace_idle_exit>
80000a72:	47a1                	li	a5,8
80000a74:	3007a073          	csrs	mstatus,a5
80000a78:	40b2                	lw	ra,12(sp)
80000a7a:	0141                	addi	sp,sp,16
80000a7c:	8082                	ret

NOTE: the sys_trace_idle and sys_trace_idle_exit are just stubs when !TRACING

after the patch:
80000a62 <arch_cpu_idle>:
80000a62:	10500073          	wfi
80000a66:	47a1                	li	a5,8
80000a68:	3007a073          	csrs	mstatus,a5
80000a6c:	8082                	ret