### PR TITLE
arch: riscv: correct signature of __soc_handle_irq

### DIFF
--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -109,7 +109,7 @@ static inline void arch_isr_direct_header(void)
 	++(arch_curr_cpu()->nested);
 }
 
-extern void __soc_handle_irq(unsigned long mcause);
+extern unsigned long __soc_handle_irq(unsigned long mcause);
 
 static inline void arch_isr_direct_footer(int swap)
 {

--- a/soc/openisa/rv32m1/soc_irq.S
+++ b/soc/openisa/rv32m1/soc_irq.S
@@ -24,14 +24,6 @@ GTEXT(__soc_restore_context)
  * With a0 == irq_num, this is equivalent to:
  *
  * EVENT_UNIT->INTPTPENDCLEAR = (1U << irq_num);
- *
- * We could write this routine in C, but the assembly
- * that's calling us requires that a0 still contain irq_num
- * on return, and assuming nobody would ever change a
- * C implementation in a way that silently clobbers it
- * is playing with fire. Instead, we play tricks in
- * soc_context.h so that offsets.h contains a pointer to
- * INTPTPENDCLEAR.
  */
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	la t0, __EVENT_INTPTPENDCLEAR


### PR DESCRIPTION
When __soc_handle_irq is called inside _isr_wrapper, it actually expects the function to return an IRQ number but the declaration of __soc_handle_irq in the header has it returning `void` instead. Fix the declaration to reflect that it actually returns an XLEN-length integer.

All existing implementations of __soc_handle_irq already follow this behavior by either not modifying the a0 register or setting it to the correct IRQ number, and follow the calling convention in all other respects:

 * soc/ite/ec/common/soc_irq.S: trampoline to `uint8_t get_irq(void* unused)`
 * soc/adi/max32/soc_irq_rv32.S: internally calls `uint32_t max32_rv32_intc_get_next_source(void)` and doesn't modify a0 afterwards
 * soc/openisa/rv32m1/soc_irq.S: does not modify a0, and obliquely refers to this issue in a comment explaining why the function isn't implemented in C
 * soc/common/riscv-privileged/soc_irq.S: does not modify a0
 * all others: stub (just `ret`), which is a valid implementation of the integer identity function