### PR TITLE
manifest: update hal_ambiq revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 5efc0228528a8adce5eae0d226fac85d2551eb3b
+      revision: 21565be7baa02f03d27a734bf9939c0dcb3cfec9
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
Update HAL for mainly the Apollo3 timer HAL changes. This should be included for Zephyr 4.4.0 release.