### PR TITLE
arch: riscv: fix PMP failure with RISCV_ALWAYS_SWITCH_THROUGH_ECALL

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -669,7 +669,7 @@ void z_riscv_pmp_init(void)
 	attr_cnt = set_pmp_mem_attr(&index, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
 #endif /* CONFIG_MEM_ATTR */
 
-#if defined(CONFIG_MEM_ATTR) || defined(CONFIG_PMP_NO_LOCK_GLOBAL)
+#ifdef CONFIG_PMP_KERNEL_MODE_DYNAMIC
 	/*
 	 * This early, we want to protect unlock PMP entries as soon as
 	 * possible. But we need a temporary default "catch all" PMP entry for

--- a/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/testcase.yaml
+++ b/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/testcase.yaml
@@ -3,7 +3,7 @@ common:
     - qemu_riscv32
     - qemu_riscv32e
     - qemu_riscv64
-  filter: CONFIG_RISCV_PMP
+  filter: CONFIG_RISCV_PMP and not CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL
   ignore_faults: true
 
 tests:


### PR DESCRIPTION
This PR fixes 2 PMP stack guard issues when `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` is enabled.

Issue 1: Failure on the first switch to the main thread
---------------------------
Reproduce step:
```
./scripts/twister -c -v -p qemu_riscv32 -x CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=y -s kernel.memory_protection.stackprot
```

When `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=y`, `is_kernel_syscall` enables the PMP stack guard (mstatus.MPRV, MPP) before switching to the thread's PMP context.

However, there is no proper PMP catch all entry configured in `z_riscv_pmp_init` during early kernel initialization when `CONFIG_PMP_STACK_GUARD` is enabled.
https://github.com/zephyrproject-rtos/zephyr/blob/b84319c460bfdf368ae26382928ec53c913752e6/arch/riscv/core/pmp.c#L672-L680
As a result, when the first time switch to main thread, an unexpected PMP violation is occur in `is_kernel_syscall` (line 434) after PMP stack guard enabled.
https://github.com/zephyrproject-rtos/zephyr/blob/b84319c460bfdf368ae26382928ec53c913752e6/arch/riscv/core/isr.S#L411-L434

This fix uses `CONFIG_PMP_KERNEL_MODE_DYNAMIC` to ensure PMP catch entry is configured.
(`PMP_KERNEL_MODE_DYNAMIC` is selected by [`MEM_ATTR`](https://github.com/zephyrproject-rtos/zephyr/blob/b84319c460bfdf368ae26382928ec53c913752e6/arch/riscv/Kconfig#L367), [`PMP_NO_LOCK_GLOBAL`](https://github.com/zephyrproject-rtos/zephyr/blob/b84319c460bfdf368ae26382928ec53c913752e6/arch/riscv/Kconfig#L418) and [`PMP_STACK_GUARD`](https://github.com/zephyrproject-rtos/zephyr/blob/b84319c460bfdf368ae26382928ec53c913752e6/arch/riscv/Kconfig#L439).)
```
-#if defined(CONFIG_MEM_ATTR) || defined(CONFIG_PMP_NO_LOCK_GLOBAL)
+#ifdef CONFIG_PMP_KERNEL_MODE_DYNAMIC
```

The most accurate condition would be:
```
#if (defined(CONFIG_MEM_ATTR) || defined(CONFIG_PMP_NO_LOCK_GLOBAL)) ||
(defined(CONFIG_PMP_STACK_GUARD) && defined(CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL))
```

But I think using `CONFIG_PMP_KERNEL_MODE_DYNAMIC` is simpler and has no side effect when `CONFIG_PMP_STACK_GUARD=y` and `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=n`.

Issue 2: tests/arch/riscv/pmp/clear-pmp-unlocked-entries fails with `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL`
---------------------------
Reproduce step after patch the issue 1 fix:
```
./scripts/twister -c -v -p qemu_riscv32 -x CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=y -s arch.riscv.pmp.clear.unlocked.entries
```

This test case attempts to clear all non-locked PMP entries, including the PMP catch all entry.
However, when the test finishes and attempts to switch out, `is_kernel_syscall()` tries to enable the PMP stack guard, but the required PMP catch all entry has already been cleared.

I think the main issue is that this test's specific scenario (clearing all non-locked PMP entries) is not compatible with `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL`.
Therefore, this PR simply adds a filter to skip this condition in the test.