### PR TITLE
arch: riscv: optimize mcause decoding on interrupt

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -265,13 +265,6 @@ config CLIC_SUPPORT_INTERRUPT_LEVEL
 	  levels. This option handles interrupt level in ISR to ensure proper
 	  nested ISR exits.
 
-config RISCV_SOC_EXCEPTION_FROM_IRQ
-	bool
-	help
-	  Option selected by SoCs that require a custom mechanism to check if
-	  an exception is the result of an interrupt or not. If selected,
-	  __soc_is_irq() needs to be implemented by the SoC.
-
 config RISCV_SOC_INTERRUPT_INIT
 	bool "SOC-based interrupt initialization"
 	help

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -75,9 +75,6 @@
 
 /* imports */
 GDATA(_sw_isr_table)
-#ifdef CONFIG_RISCV_SOC_EXCEPTION_FROM_IRQ
-GTEXT(__soc_is_irq)
-#endif
 GTEXT(__soc_handle_irq)
 GTEXT(z_riscv_fault)
 GTEXT(z_irq_spurious)
@@ -122,8 +119,6 @@ GTEXT(_isr_wrapper)
  * what standard behavior is defined). Hence, the arch level code expects
  * the following functions to be provided at the SOC level:
  *
- *     - __soc_is_irq (optional): decide if we're handling an interrupt or an
-         exception
  *     - __soc_handle_irq: handle SoC-specific details for a pending IRQ
  *       (e.g. clear a pending bit in a SoC-specific register)
  *
@@ -328,21 +323,11 @@ no_fp:	/* increment _current->arch.exception_depth */
 	 * Check if exception is the result of an interrupt or not.
 	 * (SOC dependent). Following the RISC-V architecture spec, the MSB
 	 * of the mcause register is used to indicate whether an exception
-	 * is the result of an interrupt or an exception/fault. But for some
-	 * SOCs (like pulpino or riscv-qemu), the MSB is never set to indicate
-	 * interrupt. Hence, check for interrupt/exception via the __soc_is_irq
-	 * function (that needs to be implemented by each SOC). The result is
-	 * returned via register a0 (1: interrupt, 0 exception)
+	 * is the result of an interrupt or an exception/fault.
 	 */
-
-#ifdef CONFIG_RISCV_SOC_EXCEPTION_FROM_IRQ
-	jal ra, __soc_is_irq
-	bnez a0, is_interrupt
-#else
 	csrr t0, mcause
 	srli t0, t0, RISCV_MCAUSE_IRQ_POS
 	bnez t0, is_interrupt
-#endif
 
 	/*
 	 * If the exception is the result of an ECALL, check whether to

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -326,19 +326,13 @@ no_fp:	/* increment _current->arch.exception_depth */
 	 * is the result of an interrupt or an exception/fault.
 	 */
 	csrr t0, mcause
-	srli t0, t0, RISCV_MCAUSE_IRQ_POS
-	bnez t0, is_interrupt
+	bltz t0, is_interrupt
 
 	/*
 	 * If the exception is the result of an ECALL, check whether to
 	 * perform a context-switch or an IRQ offload. Otherwise call z_riscv_fault
 	 * to report the exception.
-	 */
-	csrr t0, mcause
-	li t2, CONFIG_RISCV_MCAUSE_EXCEPTION_MASK
-	and t0, t0, t2
-
-	/*
+	 *
 	 * If mcause == RISCV_EXC_ECALLM, handle system call from
 	 * kernel thread.
 	 */


### PR DESCRIPTION
This removes support for the `RISCV_SOC_EXCEPTION_FROM_IRQ` config option because it is not used anywhere (commit 5df200275d71d0c6778c141b03d11bf08ee90f6e seems to have removed the only user), and micro-optimizes the RISC-V IRQ entry code to save between 1 and 4 instructions on every interrupt.

Removal of the `SOC_EXCEPTION_FROM_IRQ` option is not required for this optimization, but makes the change easier to follow.