### PR TITLE
mgmt: mcumgr: img_mgmt: typo fix

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -640,7 +640,7 @@ static int img_mgmt_set_next_boot_slot_common(int slot, int active_slot, bool co
 	rc = boot_set_next(fa, slot == active_slot, confirm);
 	if (rc != 0) {
 		/* Failed to set next slot for boot as desired */
-		LOG_ERR("Faled boot_set_next with code %d, for slot %d,"
+		LOG_ERR("Failed boot_set_next with code %d, for slot %d,"
 			" with active slot %d and confirm %d",
 			 rc, slot, active_slot, confirm);
 


### PR DESCRIPTION
Fix `Faled` -> `Failed`.