### PR TITLE
nxp/frdm_mcxa577: Fix MCUboot header size

### DIFF
--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -13,6 +13,10 @@ config NUM_IRQS
 	default 164 if SOC_SERIES_MCXAXX7
 	default 88
 
+# Default offset 0x200 is not enough with higher ISR count
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT && SOC_SERIES_MCXAXX7
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 1000000 if MCUX_OS_TIMER
 	default 16000 if MCUX_LPTMR_TIMER


### PR DESCRIPTION
The default value of ROM_START_OFFSET set to 0x200 wasn't compatible with IVT alignment (enforced in linker.cmd) which was set to 0x400 due to large number of ISR. The build process doesn't check these values so as a result MCUboot was hardfaulting when trying to boot an application after dereferencing zeroed data at offset 0x200 whereas the IVT was placed at 0x400.