### PR TITLE
samples: mgmt: mcumgr: smp_svr: Reduce RAM in nrf52840 RAM load

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf52840dk_nrf52840_ram_load.overlay
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf52840dk_nrf52840_ram_load.overlay
@@ -47,9 +47,9 @@
 	};
 
 	soc {
-		sram0: memory@20006000 {
+		sram0: memory@20008000 {
 			compatible = "mmio-sram";
-			reg = <0x20006000 DT_SIZE_K(200)>;
+			reg = <0x20008000 DT_SIZE_K(192)>;
 		};
 	};
 };

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -206,14 +206,6 @@ tests:
       - mimxrt1050_evk/mimxrt1052/hyperflash
     integration_platforms:
       - mimxrt1050_evk/mimxrt1052/hyperflash
-  sample.mcumgr.smp_svr.ram_load.serial.fs.shell:
-    extra_args:
-      - FILE_SUFFIX="ram_load"
-      - EXTRA_CONF_FILE="serial.conf;fs.conf;shell.conf"
-    platform_allow:
-      - nrf52840dk/nrf52840
-    integration_platforms:
-      - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.raw-serial.fs:
     extra_args: EXTRA_CONF_FILE="raw-serial.conf;fs.conf"
     platform_allow:


### PR DESCRIPTION
    Reduces the amount of RAM available here, as MCUboot is set to use
    30KiB of RAM which conflicts


And removes an invalid build