### PR TITLE
kernel: userspace: Add k_object_access_check syscall

### DIFF
--- a/include/zephyr/sys/kobject.h
+++ b/include/zephyr/sys/kobject.h
@@ -147,6 +147,18 @@ void k_object_access_all_grant(const void *object);
  */
 bool k_object_is_valid(const void *obj, enum k_objects otype);
 
+/**
+ * @brief Check if the current thread has access to an object
+ *
+ * Allows user threads to test if they have permission before attempting to
+ * perform an operation and fail gracefully if not.
+ *
+ * @param object The object to be checked
+ * @retval 0 The object is valid and current thread has access
+ * @retval -EBADF The object is not valid
+ * @retval -EPERM The object is valid but current thread has no access
+ */
+__syscall int k_object_access_check(const void *object);
 #else
 /* LCOV_EXCL_START */
 #define K_THREAD_ACCESS_GRANT(thread, ...)
@@ -190,6 +202,16 @@ static inline bool k_object_is_valid(const void *obj, enum k_objects otype)
 	ARG_UNUSED(otype);
 
 	return true;
+}
+
+/**
+ * @internal
+ */
+static inline int z_impl_k_object_access_check(const void *object)
+{
+	ARG_UNUSED(object);
+
+	return 0;
 }
 
 /* LCOV_EXCL_STOP */

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -784,6 +784,11 @@ int k_object_validate(struct k_object *ko, enum k_objects otype,
 	return 0;
 }
 
+int z_impl_k_object_access_check(const void *object)
+{
+	return k_object_validate(k_object_find(object), K_OBJ_ANY, _OBJ_INIT_ANY);
+}
+
 void k_object_init(const void *obj)
 {
 	struct k_object *ko;

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -66,6 +66,16 @@ static inline void z_vrfy_k_object_access_grant(const void *object,
 }
 #include <zephyr/syscalls/k_object_access_grant_mrsh.c>
 
+/*
+ * z_impl_k_object_access_check already checks if the object is valid.
+ * No additional verification is required.
+ */
+static inline int z_vrfy_k_object_access_check(const void *object)
+{
+	return z_impl_k_object_access_check(object);
+}
+#include <zephyr/syscalls/k_object_access_check_mrsh.c>
+
 static inline void z_vrfy_k_object_release(const void *object)
 {
 	struct k_object *ko;

--- a/tests/kernel/mem_protect/mem_protect/src/check_access.c
+++ b/tests/kernel/mem_protect/mem_protect/src/check_access.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+
+K_SEM_DEFINE(obj_access, 0, 1);
+K_SEM_DEFINE(obj_no_access, 0, 1);
+int no_obj;
+
+ZTEST_USER(userspace_access_check, test_access)
+{
+	zexpect_equal(k_object_access_check(&obj_access), 0, "should have access but doesn't");
+	zexpect_equal(k_object_access_check(&obj_no_access), -EPERM,
+		      "should not have access but does");
+	zexpect_equal(k_object_access_check(&no_obj), -EBADF, "should not be valid object but is");
+
+	/* User thread should always have access to itself */
+	zexpect_equal(k_object_access_check(k_current_get()), 0, "no access to itself");
+}
+
+static void *userspace_access_setup(void)
+{
+	k_object_access_grant(&obj_access, k_current_get());
+
+	return NULL;
+}
+
+ZTEST_SUITE(userspace_access_check, NULL, userspace_access_setup, NULL, NULL, NULL);


### PR DESCRIPTION
This allows user threads to test if they have permission to access an object before attempting to perform an operation on it and fail gracefully if not.