### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -344,7 +344,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: cf40f6dc7fc441ee6848ea2e177c4522588c1b8c
+      revision: 2b09581c7654f4dfd38681270350c9ae6b0438a2
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: cebea8e27ceb91a7d4580d17db65f93669befe72


### PR DESCRIPTION
Update the HW models module to:
2b09581c7654f4dfd38681270350c9ae6b0438a2

Including the following:
2b09581 Refactor target specific code and definitions
da1f4e3 hal: nrfx_common replacement: Minor refactor
c2ca4ec RADIO: Refactor getting frequency and Tx power

Just to get Zephyr pointing at the tip of main before the 4.4 release.