### PR TITLE
net: wifi: shell: Add check for iface type when get iface

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -25,6 +25,9 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/wifi_utils.h>
+#ifdef CONFIG_WIFI_NM
+#include <zephyr/net/wifi_nm.h>
+#endif
 #include <zephyr/sys/slist.h>
 
 #include "net_shell_private.h"
@@ -136,6 +139,23 @@ static struct net_if *get_iface(enum iface_type type, int argc, char *argv[])
 			return NULL;
 		}
 	}
+
+#ifdef CONFIG_WIFI_NM
+	if (iface != NULL) {
+		/* If iface is valid nm wifi iface */
+		if (!wifi_nm_get_instance_iface(iface)) {
+			LOG_ERR("Interface %d is not a nm wifi iface", iface_index);
+			return NULL;
+		}
+
+		/* If iface nm wifi type match input type */
+		if ((type == IFACE_TYPE_STA && !wifi_nm_iface_is_sta(iface)) ||
+			(type == IFACE_TYPE_SAP && !wifi_nm_iface_is_sap(iface))) {
+			LOG_ERR("Interface %d type does not match %d", iface_index, type);
+			return NULL;
+		}
+	}
+#endif
 
 	return iface;
 }


### PR DESCRIPTION
When start uAP with specify interface "-i" like cmd: wifi ap enable … -i 1 (eg: 1 is STA iface, 2 is uAP iface)

Currently, get_iface() firstly choose iface by index specify by -i. If not find then get iface by input type(STA/UAP).

We don't hope use STA iface on hostapd or use uAP iface on supplicant. So for nm wifi, get_iface() need check the iface type: if iface get by index not nm wifi iface return NULL. if iface get by index not match with input type need return NULL.