### PR TITLE
samples, tests: watchdog: add yaml filter for alias name

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -16,8 +16,8 @@ common:
   depends_on: watchdog
 tests:
   sample.drivers.watchdog:
-    filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103) and
-      dt_nodelabel_enabled("watchdog0")
+    filter: dt_alias_exists("watchdog0") and
+      not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103)
     platform_exclude:
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -7,12 +7,11 @@ common:
 tests:
   drivers.watchdog:
     filter: >
-      not (CONFIG_WDT_SAM or CONFIG_WDT_SAM4L
+      dt_alias_exists("watchdog0") and not (CONFIG_WDT_SAM or CONFIG_WDT_SAM4L
        or dt_compat_enabled("st,stm32-window-watchdog")
        or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
        CONFIG_SOC_SERIES_IMXRT6XX or CONFIG_SOC_SERIES_IMXRT5XX or
        CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103 or CONFIG_SOC_MAX32655)
-       and dt_nodelabel_enabled("watchdog0")
     platform_exclude:
       - mec15xxevb_assy6853
       - s32z2xxdc2/s32z270/rtu0


### PR DESCRIPTION
Many boards in samples/drivers/watchdog/boards and tests/drivers/watchdog/wdt_basic_api use the 'watchdog0' alias instead of label.

Add a YAML filter to ensure these samples and tests are built with boards that provide the 'watchdog0' alias name.

```
$ grep -r watchdog0 -B1 samples/drivers/watchdog/boards/*.overlay
samples/drivers/watchdog/boards/adp_xc7k_ae350_clic.overlay-	aliases {
samples/drivers/watchdog/boards/adp_xc7k_ae350_clic.overlay:		watchdog0 = &wdt;
--
samples/drivers/watchdog/boards/adp_xc7k_ae350.overlay-	aliases {
samples/drivers/watchdog/boards/adp_xc7k_ae350.overlay:		watchdog0 = &wdt;
--
samples/drivers/watchdog/boards/ch32v003evt.overlay-	aliases {
samples/drivers/watchdog/boards/ch32v003evt.overlay:		watchdog0 = &iwdg;
--
samples/drivers/watchdog/boards/ch32v006evt.overlay-	aliases {
samples/drivers/watchdog/boards/ch32v006evt.overlay:		watchdog0 = &iwdg;
...
```
```
$ grep -r watchdog0 -B1 tests/drivers/watchdog/wdt_basic_api/boards/opentitan_earlgrey.overlay 
	aliases {
		watchdog0 = &aontimer;
```
