### PR TITLE
drivers: ethernet: phy: microchip_t1s: make PLCA node_count optional

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -647,7 +647,11 @@ static DEVICE_API(ethphy, mc_t1s_phy_api) = {
 	static struct mc_t1s_plca_config mc_t1s_plca_##n##_config = {                              \
 		.enable = DT_INST_PROP(n, plca_enable),                                            \
 		.node_id = DT_INST_PROP(n, plca_node_id),                                          \
-		.node_count = DT_INST_PROP(n, plca_node_count),                                    \
+		.node_count = COND_CODE_0(                                                     \
+			DT_INST_PROP(n, plca_node_id),                                           \
+			(DT_INST_PROP(n, plca_node_count)),                                        \
+			(DT_INST_PROP_OR(n, plca_node_count, 0))                                   \
+		),                                                                            \
 		.burst_count = DT_INST_PROP(n, plca_burst_count),                                  \
 		.burst_timer = DT_INST_PROP(n, plca_burst_timer),                                  \
 		.to_timer = DT_INST_PROP(n, plca_to_timer),                                        \


### PR DESCRIPTION
Plca nodes with (node_id != 0) do not manage transmit windows and therefore should not be required to provide plca_node_count. Make plca_node_count optional for (node_id != 0) and if omitted set the default value to 0. The behaviour for (node_id == 0) stays the same.