### PR TITLE
drivers: timer: stm32_lptim: fix incorrect configuration and harden against wrong usage

### DIFF
--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -41,7 +41,7 @@
 	};
 };
 
-&lptim1 {
+stm32_lp_tick_source: &lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -9,6 +9,7 @@ DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
 	default y
+	depends on $(dt_nodelabel_exists,stm32_lp_tick_source)
 	depends on DT_HAS_ST_STM32_LPTIM_ENABLED
 	depends on CLOCK_CONTROL && PM
 	select TICKLESS_CAPABLE


### PR DESCRIPTION
The driver requires nodelabel `stm32_lp_tick_source` to be attached on an LPTIM to work properly. If not done, a build failure occurs - see #105121 for details.

Add missing nodelabel to a board which lacked it and harden Kconfig to prevent compiling the driver when the nodelabel is missing, ensuring the build error cannot occur again.

Fixes #105121