### PR TITLE
net: lib: coap: Use struct net_sockaddr_storage

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -302,7 +302,7 @@ struct coap_observer {
 	/** Observer list node */
 	sys_snode_t list;
 	/** Observer connection end point information */
-	struct net_sockaddr addr;
+	struct net_sockaddr_storage addr;
 	/** Observer token */
 	uint8_t token[8];
 	/** Extended token length */

--- a/samples/net/sockets/coap_server/src/observer.c
+++ b/samples/net/sockets/coap_server/src/observer.c
@@ -116,8 +116,8 @@ static void obs_notify(struct coap_resource *resource,
 		       struct coap_observer *observer)
 {
 	send_notification_packet(resource,
-				 &observer->addr,
-				 sizeof(observer->addr),
+				 net_sad(&observer->addr),
+				 net_family2size(observer->addr.ss_family),
 				 resource->age, 0,
 				 observer->token, observer->tkl, false);
 }

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1676,7 +1676,7 @@ struct coap_observer *coap_observer_next_unused(
 	size_t i;
 
 	for (i = 0, o = observers; i < len; i++, o++) {
-		if (is_addr_unspecified(&o->addr)) {
+		if (is_addr_unspecified(net_sad(&o->addr))) {
 			return o;
 		}
 	}
@@ -1961,7 +1961,7 @@ void coap_observer_init(struct coap_observer *observer,
 {
 	observer->tkl = coap_header_get_token(request, observer->token);
 
-	memcpy(&observer->addr, addr, sizeof(*addr));
+	memcpy(&observer->addr, addr, net_family2size(addr->sa_family));
 }
 
 static inline void coap_observer_raise_event(struct coap_resource *resource,
@@ -2062,7 +2062,7 @@ struct coap_observer *coap_find_observer(
 
 		if (o->tkl == token_len &&
 		    memcmp(o->token, token, token_len) == 0 &&
-		    sockaddr_equal(&o->addr, addr)) {
+		    sockaddr_equal(net_sad(&o->addr), addr)) {
 			return o;
 		}
 	}
@@ -2079,7 +2079,7 @@ struct coap_observer *coap_find_observer_by_addr(
 	for (i = 0; i < len; i++) {
 		struct coap_observer *o = &observers[i];
 
-		if (sockaddr_equal(&o->addr, addr)) {
+		if (sockaddr_equal(net_sad(&o->addr), addr)) {
 			return o;
 		}
 	}

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -126,7 +126,7 @@ static int coap_server_process(int sock_fd)
 {
 	static uint8_t buf[CONFIG_COAP_SERVER_MESSAGE_SIZE];
 
-	struct net_sockaddr client_addr;
+	struct net_sockaddr_storage client_addr;
 	net_socklen_t client_addr_len = sizeof(client_addr);
 	struct coap_service *service = NULL;
 	struct coap_packet request;
@@ -142,7 +142,8 @@ static int coap_server_process(int sock_fd)
 		flags |= ZSOCK_MSG_TRUNC;
 	}
 
-	received = zsock_recvfrom(sock_fd, buf, sizeof(buf), flags, &client_addr, &client_addr_len);
+	received = zsock_recvfrom(sock_fd, buf, sizeof(buf), flags, net_sad(&client_addr),
+				  &client_addr_len);
 
 	if (received < 0) {
 		if (errno == EWOULDBLOCK) {
@@ -201,7 +202,8 @@ static int coap_server_process(int sock_fd)
 			goto unlock;
 		}
 
-		ret = coap_service_send(service, &response, &client_addr, client_addr_len, NULL);
+		ret = coap_service_send(service, &response, net_sad(&client_addr), client_addr_len,
+					NULL);
 		if (ret < 0) {
 			LOG_ERR("Failed to reply \"Request Entity Too Large\" (%d)", ret);
 			goto unlock;
@@ -218,7 +220,8 @@ static int coap_server_process(int sock_fd)
 		switch (type) {
 		case COAP_TYPE_RESET:
 			tkl = coap_header_get_token(&request, token);
-			coap_service_remove_observer(service, NULL, &client_addr, token, tkl);
+			coap_service_remove_observer(service, NULL, net_sad(&client_addr), token,
+						     tkl);
 			__fallthrough;
 		case COAP_TYPE_ACK:
 			coap_server_free(pending->data);
@@ -252,11 +255,12 @@ static int coap_server_process(int sock_fd)
 			goto unlock;
 		}
 
-		ret = coap_service_send(service, &response, &client_addr, client_addr_len, NULL);
+		ret = coap_service_send(service, &response, net_sad(&client_addr), client_addr_len,
+					NULL);
 	} else {
 		ret = coap_handle_request_len(&request, service->res_begin,
-					      COAP_SERVICE_RESOURCE_COUNT(service),
-					      options, opt_num, &client_addr, client_addr_len);
+					      COAP_SERVICE_RESOURCE_COUNT(service), options,
+					      opt_num, net_sad(&client_addr), client_addr_len);
 
 		/* Translate errors to response codes */
 		switch (ret) {
@@ -283,7 +287,8 @@ static int coap_server_process(int sock_fd)
 				goto unlock;
 			}
 
-			ret = coap_service_send(service, &ack, &client_addr, client_addr_len, NULL);
+			ret = coap_service_send(service, &ack, net_sad(&client_addr),
+						client_addr_len, NULL);
 		}
 	}
 

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -839,7 +839,7 @@ static void server_resource_1_callback(struct coap_resource *resource,
 {
 	bool r;
 
-	r = ipaddr_cmp(&observer->addr, (const struct net_sockaddr *)&dummy_addr);
+	r = ipaddr_cmp(net_sad(&observer->addr), (struct net_sockaddr *)&dummy_addr);
 	zassert_true(r, "The address of the observer doesn't match");
 
 	coap_remove_observer(resource, observer);
@@ -849,7 +849,7 @@ static void server_resource_2_callback(struct coap_resource *resource,
 {
 	bool r;
 
-	r = ipaddr_cmp(&observer->addr, (const struct net_sockaddr *)&dummy_addr);
+	r = ipaddr_cmp(net_sad(&observer->addr), (const struct net_sockaddr *)&dummy_addr);
 	zassert_true(r, "The address of the observer doesn't match");
 }
 


### PR DESCRIPTION
Replace `struct net_sockaddr` variable instances with `stuct net_sockaddr_storage`.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/104845