### PR TITLE
samples: tflm_ethosu: add configurable Vela memory modes and test variants

### DIFF
--- a/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
+++ b/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: <text>Copyright 2021-2022, 2025 Arm Limited and/or its
+# SPDX-FileCopyrightText: <text>Copyright 2021-2022, 2025-2026 Arm Limited and/or its
 # affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 
@@ -53,4 +53,40 @@ if(CONFIG_SAMPLE_TFLM_ETHOSU_PMU)
       ETHOSU_PMU_EVENT_3=${ETHOSU_PMU_EVENT_3}
     )
   endif()
+endif()
+
+# -----------------------------------------------------------------------------
+# Vela memory mode -> region mapping used by this sample
+# -----------------------------------------------------------------------------
+set(_REGION_WEIGHTS      "NPU_REGIONCFG_0")
+set(_REGION_SCRATCH      "NPU_REGIONCFG_1")
+set(_REGION_FAST_SCRATCH "NPU_REGIONCFG_2")
+set(_REGION_CMD_STREAM   "NPU_QCONFIG")
+
+# NOTE:
+# We intentionally use zephyr_compile_definitions() here (instead of
+# target_compile_definitions(app ...)) because these overrides must be
+# visible when the HAL itself is compiled. The HAL sources key
+# off NPU_REGIONCFG_n / NPU_QCONFIG at build time (and on Arm Ethos-U85 NPU those
+# selections index into MEM_ATTR entries), so the macros need to propagate
+# globally through Zephyr's interface. This ensures the overrides are
+# consistently picked up regardless of how the sample is built.
+if(CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM)
+  zephyr_compile_definitions(
+    ${_REGION_WEIGHTS}=3
+    ${_REGION_SCRATCH}=0
+    ${_REGION_FAST_SCRATCH}=0
+    ${_REGION_CMD_STREAM}=3)
+elseif(CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_DEDICATED_SRAM)
+  zephyr_compile_definitions(
+    ${_REGION_WEIGHTS}=3
+    ${_REGION_SCRATCH}=3
+    ${_REGION_FAST_SCRATCH}=0
+    ${_REGION_CMD_STREAM}=3)
+elseif(CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY)
+  zephyr_compile_definitions(
+    ${_REGION_WEIGHTS}=0
+    ${_REGION_SCRATCH}=0
+    ${_REGION_FAST_SCRATCH}=0
+    ${_REGION_CMD_STREAM}=0)
 endif()

--- a/samples/modules/tflite-micro/tflm_ethosu/Kconfig
+++ b/samples/modules/tflite-micro/tflm_ethosu/Kconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: <text>Copyright 2022, 2025 Arm Limited and/or its
+# SPDX-FileCopyrightText: <text>Copyright 2022, 2025-2026 Arm Limited and/or its
 # affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,5 +19,62 @@ config SAMPLE_TFLM_ETHOSU_PMU
 	help
 	  Enable PMU counters for this sample. When enabled,
 	  the sample collects cycle and selected event counters per inference.
+
+choice SAMPLE_TFLM_ETHOSU_MEM_MODE
+	prompt "Vela memory mode (sample override)"
+	default SAMPLE_TFLM_ETHOSU_MEM_MODE_HAL_DEFAULT
+	depends on ETHOS_U
+	help
+	  Configure memory mode used by Vela.
+
+	  - On Arm Ethos-U55 NPU and Arm Ethos-U65 NPU:
+	    REGIONCFG values 0/1 route to AXI0 (governed by AXI_LIMIT0/1, typically on-chip SRAM),
+	    REGIONCFG values 2/3 route to AXI1 (governed by AXI_LIMIT2/3, typically external memory).
+	    (U55: AXI1 is read-only; U65: both ports are read/write.)
+	    This mapping is architectural (fixed).
+
+	  - On Arm Ethos-U85 NPU:
+	    REGIONCFG values 0/1 select MEM_ATTR[0/1] (typically the SRAM AXI port),
+	    REGIONCFG values 2/3 select MEM_ATTR[2/3] (typically the external AXI port).
+	    These defaults come from the HAL but can be changed by redefining
+	    NPU_MEM_ATTR_[0-3] if your system requires different attributes.
+
+	  The chosen mode must match the mode used when compiling the model with Vela.
+
+config SAMPLE_TFLM_ETHOSU_MEM_MODE_HAL_DEFAULT
+	bool "HAL default"
+	help
+	  Do not override the HAL defaults for region mapping.
+	  The HAL determines NPU_REGIONCFG_n and NPU_QCONFIG.
+
+config SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM
+	bool "Shared_Sram (weights=3, scratch=0, fast_scratch=0, cmd_stream=3)"
+	help
+	  Match Vela's Shared_Sram mode:
+	  - U55/U65: weights & command stream -> AXI1 / AXI_LIMIT3 (typically external),
+	             scratch & fast_scratch -> AXI0 / AXI_LIMIT0 (typically on-chip)
+	  - U85:     weights & command stream -> MEM_ATTR[3] (typically external),
+	             scratch & fast_scratch -> MEM_ATTR[0] (typically on-chip)
+
+config SAMPLE_TFLM_ETHOSU_MEM_MODE_DEDICATED_SRAM
+	bool "Dedicated_Sram (weights=3, scratch=3, fast_scratch=0, cmd_stream=3)"
+	depends on !(ETHOS_U55_64 || ETHOS_U55_128 || ETHOS_U55_256)
+	help
+	  Match Vela's Dedicated_Sram mode:
+	  - U55/U65: weights, scratch & command stream -> AXI1 / AXI_LIMIT3 (typically external),
+	             fast_scratch -> AXI0 / AXI_LIMIT0 (typically on-chip)
+	  - U85:     weights, scratch & command stream -> MEM_ATTR[3] (typically external),
+	             fast_scratch -> MEM_ATTR[0] (typically on-chip)
+	  Not supported on Arm Ethos-U55 NPU.
+
+config SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY
+	bool "Sram_Only (weights=1, scratch=0, fast_scratch=0, cmd_stream=1)"
+	help
+	  Match Vela's SRAM_Only mode (everything on the SRAM side):
+	  - U55/U65: weights & command stream -> AXI0 / AXI_LIMIT1,
+	             scratch & fast_scratch -> AXI0 / AXI_LIMIT0
+	  - U85:     weights & command stream -> MEM_ATTR[1] (SRAM port),
+	             scratch & fast_scratch -> MEM_ATTR[0] (SRAM port)
+endchoice
 
 source "Kconfig.zephyr"

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: tflite-ethosu
-   :name: TensorFlow Lite for Microcontrollers on Arm Ethos-U
+   :name: TensorFlow Lite for Microcontrollers on Arm(R) Ethos(TM)-U55, U65, and U85 NPUs
 
    Run an inference using an optimized TFLite model on Arm Ethos-U NPU.
 
@@ -12,10 +12,10 @@ framework and the Arm Ethos-U NPU.
 The sample application runs a model that has been downloaded from the
 `Arm model zoo <https://github.com/ARM-software/ML-zoo>`_. This model has then
 been optimized using the
-`Vela compiler <https://git.mlplatform.org/ml/ethos-u/ethos-u-vela.git>`_.
+`Vela compiler <https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela>`_.
 
 Vela takes a tflite file as input and produces another tflite file as output,
-where the operators supported by Ethos-U have been replaced by an Ethos-U custom
+where the operators supported by Arm Ethos-U NPU have been replaced by an Ethos-U custom
 operator. In an ideal case the complete network would be replaced by a single
 Ethos-U custom operator.
 
@@ -27,7 +27,7 @@ Use `keyword_spotting_cnn_small_int8`_ model in this sample:
 
 .. _keyword_spotting_cnn_small_int8: https://github.com/Arm-Examples/ML-zoo/tree/master/models/keyword_spotting/cnn_small/model_package_tf/model_archive/TFLite/tflite_int8
 
-.. note:: The default Vela-compiled model is to target Ethos-U55 and 128 MAC
+.. note:: The default Vela-compiled model is to target Arm Ethos-U55 NPU and 128 MAC
    on MPS3 target. Because one model can add up to hundreds of KB, don't
    attempt to add more models into code base for other targets.
 
@@ -37,9 +37,9 @@ Use `keyword_spotting_cnn_small_int8`_ model in this sample:
    - testing_input/input/0.npy
    - testing_output/identity/0.npy
 
-2. Optimizing the model for Ethos-U using Vela
+2. Optimizing the model for Arm Ethos-U NPU using Vela
 
-   Assuming target Ethos-U is U55 and 128 MAC:
+   Assuming target Arm Ethos-U55 NPU and 128 MAC:
 
    .. code-block:: console
 
@@ -90,56 +90,159 @@ Add the tflite-micro module to your West manifest and pull it:
     west config manifest.project-filter -- +tflite-micro
     west update
 
-This application can be built and run on any Arm Ethos-U capable platform, for
-example Corstone(TM)-300. A reference implementation of Corstone-300 can be
-downloaded either as a FPGA bitfile for the
-`MPS3 FPGA prototyping board <https://developer.arm.com/tools-and-software/development-boards/fpga-prototyping-boards/mps3>`_,
-or as a
-`Fixed Virtual Platform <https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/arm-ecosystem-fvps>`_
-that can be emulated on a host machine.
+This application can be built and run on any Arm Ethos-U NPU capable platform, such
+as Corstone(TM)-300 or Corstone-320.
 
-Assuming that the Corstone-300 FVP has been downloaded, installed and added to
-the ``PATH`` variable, then building and testing can be done with following
-commands.
+Run target prerequisites
+------------------------
 
-Build the sample for the FVP:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
-   :board: mps3/corstone300/fvp
-   :goals: build
-
-Then run the image on the FVP:
+When using the CMake ``run`` target (``-t run``), set the FVP binary path for
+your platform and, for Arm Ethos-U85 NPU, pass the NPU configuration to the CLI:
 
 .. code-block:: bash
 
-    FVP_Corstone_SSE-300_Ethos-U55 build/zephyr/zephyr.elf
+    # Arm Ethos-U55/U65 NPU (Corstone-300 FVP)
+    export ARMFVP_BIN_PATH=/path/to/FVP_Corstone_SSE-300_<ver>/models/Linux64_GCC-<gcc>/
 
-Configuring PMU Events via CMake
-********************************
+    # Arm Ethos-U85 (Corstone-320 FVP)
+    export ARMFVP_BIN_PATH=/path/to/FVP_Corstone_SSE-320_<ver>/models/Linux64_GCC-<gcc>/
+    export ARMFVP_EXTRA_FLAGS='-C;mps4_board.subsystem.ethosu.num_macs=2048'  # match chosen ETHOS_U85_* Kconfig
 
-If ``CONFIG_SAMPLE_TFLM_ETHOSU_PMU`` is enabled, the sample reports
-per-inference PMU counters. You can override which PMU events are
-counted by setting CMake cache variables ``ETHOSU_PMU_EVENT_0`` ..
-``ETHOSU_PMU_EVENT_3`` (and ``_4`` .. ``_7`` when supported). Each value should
-be an event token from the PMU header (for example
-``ETHOSU_PMU_AXI0_RD_DATA_BEAT_RECEIVED``). Sensible defaults are provided by
-the sample CMake based on the target platform.
-
-For example, to enable the PMU instrumentation and override the first two
-events:
+Build and run on the FVP
+------------------------
 
 .. zephyr-app-commands::
    :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
    :board: mps3/corstone300/fvp
    :goals: run
-   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_PMU=y -DETHOSU_PMU_EVENT_0=ETHOSU_PMU_AXI0_RD_DATA_BEAT_RECEIVED -DETHOSU_PMU_EVENT_1=ETHOSU_PMU_AXI1_RD_DATA_BEAT_RECEIVED
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM=y
+              -DCONFIG_ETHOS_U55_128=y
+
+Vela memory modes and overlays
+******************************
+
+Vela supports several Arm Ethos NPU memory placement modes. This sample reproduces
+those at build time using ``CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_*``:
+
+* ``CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM``
+* ``CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_DEDICATED_SRAM``
+* ``CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY``
+
+**Board overlays**
+
+Use overlays to place TensorFlow Lite buffers in matching memory regions:
+
+- ``boards/mps3_corstone300_fvp.sram_only.overlay``
+- ``boards/mps4_corstone320_fvp.sram_only.overlay``
+- ``boards/mps3_corstone300_fvp.dedicated_sram.overlay``
+- ``boards/mps4_corstone320_fvp.dedicated_sram.overlay``
+
+``Dedicated_Sram`` additionally requires an ``ETHOSU_FAST`` region declared in
+the overlay.
+
+**Example builds**
+
+Shared_Sram (default):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps3/corstone300/fvp
+   :goals: run
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM=y
+              -DCONFIG_ETHOS_U55_128=y
+
+Sram_Only (Arm Ethos-U65 NPU on Corstone-300):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps3/corstone300/fvp
+   :goals: run
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY=y
+              -DCONFIG_ETHOS_U65_256=y
+              -DDTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.sram_only.overlay
+
+Dedicated_Sram (Arm Ethos-U85 NPU on Corstone-320):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps4/corstone320/fvp
+   :goals: run
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_DEDICATED_SRAM=y
+              -DCONFIG_ETHOS_U85_2048=y
+              -DDTC_OVERLAY_FILE=boards/mps4_corstone320_fvp.dedicated_sram.overlay
+
+.. note::
+
+   - **Dedicated_Sram** is not supported on Arm Ethos-U55 NPU.
+   - Ensure the model's Vela mode matches the selected build mode.
+
+Memory regions
+**************
+
+The Arm Ethos-U NPU command streams address memory regions using **region indices** (0-3),
+which correspond to ``REGIONCFG`` values in the NPU configuration.
+Vela assigns these indices when compiling the model, and the HAL maps
+each index to a physical AXI interface or MEM_ATTR entry depending on the NPU.
+
+The **mapping used in this sample** is defined by the selected
+``CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_*`` option. The table below shows the
+region index assignments implemented by this sample's CMake and Kconfig logic:
+
+=================  =======  =======  ============  ============
+Mode               weights  scratch  fast_scratch  cmd_stream
+=================  =======  =======  ============  ============
+Shared_Sram        3        0        0             3
+Dedicated_Sram     3        3        0             3
+Sram_Only          0        0        0             0
+=================  =======  =======  ============  ============
+
+These index values are applied through ``zephyr_compile_definitions()`` as
+``NPU_REGIONCFG_n`` and ``NPU_QCONFIG`` macros during the build, ensuring the
+HAL and driver use a consistent region configuration:
+
+- ``NPU_REGIONCFG_0``: weights
+- ``NPU_REGIONCFG_1``: scratch
+- ``NPU_REGIONCFG_2``: fast scratch
+- ``NPU_QCONFIG``: command stream region
+
+These indices map to hardware interfaces as follows:
+
+**Architectural mapping**
+
+- **Arm Ethos-U55/U65 NPU:**
+  Regions 0-1 route to AXI0 (on-chip SRAM), 2-3 to AXI1 (external memory).
+  This mapping is fixed by the architecture.
+
+- **Arm Ethos-U85 NPU:**
+  Regions 0-3 select programmable ``MEM_ATTR[0-3]`` entries.
+  By default, the HAL configures MEM_ATTR[0-1] to map to SRAM and MEM_ATTR[2-3]
+  to external DDR. These defaults can be overridden if the system uses a custom
+  memory topology.
+
+When using **Dedicated_Sram**, ensure an ``ETHOSU_FAST`` node exists in the
+devicetree overlay to provide a valid region for the NPU's fast_scratch area.
+
+
+Configuring PMU Events via CMake
+********************************
+
+If ``CONFIG_SAMPLE_TFLM_ETHOSU_PMU`` is enabled, the sample reports
+per-inference PMU counters. You can override which events are counted by setting
+``ETHOSU_PMU_EVENT_0..3`` (and 4-7 if supported).
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps3/corstone300/fvp
+   :goals: run
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM=y
+              -DCONFIG_SAMPLE_TFLM_ETHOSU_PMU=y
+              -DETHOSU_PMU_EVENT_0=ETHOSU_PMU_AXI0_RD_DATA_BEAT_RECEIVED
+              -DETHOSU_PMU_EVENT_1=ETHOSU_PMU_AXI1_RD_DATA_BEAT_RECEIVED
 
 PMU report format
 *****************
 
-When enabled, the sample prints a short PMU report after each inference in a
-compact, machine-parseable style:
+When enabled, the sample prints a short PMU report after each inference:
 
 .. code-block:: text
 
@@ -155,22 +258,24 @@ compact, machine-parseable style:
 Timing Adapters (TA)
 ********************
 
-The timing adapters allows the platform to simulate user provided memory
-bandwidth and latency constraints on platforms that support it (FVP/FPGA).
-This sample does **not** auto-add overlays; apply a TA overlay explicitly with
-``-DDTC_OVERLAY_FILE=...``.
+The Timing Adapters allows simulation of memory bandwidth and latency limits on
+supported platforms (FVP or FPGA). Apply TA overlays explicitly with
+``-DDTC_OVERLAY_FILE=...``. TA overlays can be combined with any Vela memory
+mode to explore timing effects.
 
-For a full overview of TA behavior, controls, and usage guidance, see the
-`Evaluation Kit documentation: Timing Adapters <https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/docs/sections/timing_adapters.md>`_.
+For complete TA documentation, see the
+`Evaluation Kit docs <https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/docs/sections/timing_adapters.md>`_.
 
-TA overlay only (Corstone-320)
-------------------------------
+TA overlay with Sram_Only (Corstone-320)
+----------------------------------------
 
 .. zephyr-app-commands::
    :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
    :board: mps4/corstone320/fvp
    :goals: run
-   :gen-args: -DDTC_OVERLAY_FILE=boards/mps4_corstone320_fvp.ta.overlay
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY=y
+              -DCONFIG_ETHOS_U85_2048=y
+              -DDTC_OVERLAY_FILE="boards/mps4_corstone320_fvp.ta.overlay;boards/mps4_corstone320_fvp.sram_only.overlay"
 
 TA overlay only (Corstone-300)
 ------------------------------
@@ -179,4 +284,15 @@ TA overlay only (Corstone-300)
    :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
    :board: mps3/corstone300/fvp
    :goals: run
-   :gen-args: -DDTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.ta.overlay
+   :gen-args: -DCONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SHARED_SRAM=y
+              -DCONFIG_ETHOS_U55_128=y
+              -DDTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.ta.overlay
+
+
+Trademarks
+***********
+
+Arm, Ethos, and Corstone are registered trademarks or trademarks of Arm Limited
+(or its subsidiaries or affiliates) in the US and/or elsewhere.
+
+TensorFlow, the TensorFlow logo and any related marks are trademarks of Google Inc.

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.dedicated_sram.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.dedicated_sram.overlay
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/* Define a dedicated secure DDR4 slice (256 MiB) at 0x7000_0000 */
+		ddr4_sec_700: memory@70000000 {
+			compatible = "zephyr,memory-region";
+			reg = <0x70000000 DT_SIZE_M(256)>;
+			zephyr,memory-region = "DDR4_SEC_700";
+		};
+
+		/* 256 KiB fast scratch for the NPU */
+		ethosu_fast_isram: sram@31000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x31000000 0x00040000>;
+			zephyr,memory-region = "ETHOSU_FAST";
+		};
+	};
+
+	chosen {
+		/* TFLM buffers live in external DDR4 */
+		zephyr,tflm-storage = &ddr4_sec_700; /* TFLM buffers in secure DDR4 @ 0x7000_0000 */
+	};
+};
+
+&ethosu0 {
+	fast-memory-region = <&ethosu_fast_isram>;
+};

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.sram_only.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.sram_only.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		/* Writable on-chip ISRAM for TFLM buffers */
+		zephyr,tflm-storage = &isram;
+	};
+};

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.dedicated_sram.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.dedicated_sram.overlay
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Keep a small ISRAM slice for .text to avoid colliding with fast scratch */
+	isram_text: sram@31000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x31000000 0x00100000>; /* 1 MiB for code/RO */
+		zephyr,memory-region = "ISRAM_TEXT";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/* Define a dedicated secure DDR4 slice (256 MiB) at 0x7000_0000 */
+		ddr4_sec_700: memory@70000000 {
+			compatible = "zephyr,memory-region";
+			reg = <0x70000000 DT_SIZE_M(256)>;
+			zephyr,memory-region = "DDR4_SEC_700";
+		};
+
+		/* 256 KiB fast scratch for the NPU */
+		ethosu_fast_isram: sram@31100000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x31100000 0x00040000>;
+			zephyr,memory-region = "ETHOSU_FAST";
+		};
+	};
+
+	chosen {
+		zephyr,flash = &isram_text;   /* code in ISRAM */
+		zephyr,tflm-storage = &ddr4_sec_700; /* TFLM buffers in secure DDR4 @ 0x7000_0000 */
+		/* zephyr,sram: use base DTS */
+	};
+};
+
+&ethosu0 {
+	fast-memory-region = <&ethosu_fast_isram>;
+};

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.sram_only.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.sram_only.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Split 4 MiB ISRAM:
+	 *  - 1 MiB for code/ro (RX)
+	 *  - 3 MiB for TFLM buffers (RW)
+	 */
+	isram_text: sram@31000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x31000000 0x00100000>; /* 1 MiB */
+		zephyr,memory-region = "ISRAM_TEXT";
+	};
+
+	isram_rw: sram@31100000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x31100000 0x00300000>; /* 3 MiB */
+		zephyr,memory-region = "ISRAM_RW";
+	};
+
+	chosen {
+		/* Code still executes from ISRAM (RX), data stays in SRAM (RW) */
+		zephyr,flash = &isram_text;
+		zephyr,sram = &sram;
+
+		/* TFLM buffers go to the writable ISRAM slice */
+		zephyr,tflm-storage = &isram_rw;
+	};
+};

--- a/samples/modules/tflite-micro/tflm_ethosu/linker.ld
+++ b/samples/modules/tflite-micro/tflm_ethosu/linker.ld
@@ -1,17 +1,27 @@
 /*
- * Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
- *
+ * SPDX-FileCopyrightText: <text>Copyright 2022, 2026 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(ddr4), okay)
-GROUP_START(DDR4)
-
-	SECTION_DATA_PROLOGUE(_DDR4_SECTION_NAME,,SUBALIGN(16))
-	{
-		. = ALIGN(16);
-		*(tflm_model tflm_arena tflm_input tflm_output)
-	} GROUP_LINK_IN(DDR4)
-
-GROUP_END(DDR4)
+/*
+ * If a chosen handle is provided, use it.
+ * Otherwise default to DDR4.
+ */
+#if DT_NODE_EXISTS(DT_CHOSEN(zephyr_tflm_storage))
+  #define SAMPLE_TFLM_REGION DT_STRING_UPPER_TOKEN(DT_CHOSEN(zephyr_tflm_storage), zephyr_memory_region)
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(ddr4), okay)
+  #define SAMPLE_TFLM_REGION DDR4
+#else
+  #error "No TFLM storage region: set chosen zephyr,tflm-storage in an overlay or add a ddr4 node."
 #endif
+
+GROUP_START(SAMPLE_TFLM_REGION)
+SECTION_DATA_PROLOGUE(_TFLM_STORAGE_REGION_SECTION_NAME,,SUBALIGN(16))
+{
+  . = ALIGN(16);
+  *(tflm_model tflm_arena tflm_input tflm_output)
+} GROUP_LINK_IN(SAMPLE_TFLM_REGION)
+GROUP_END(SAMPLE_TFLM_REGION)
+
+#undef SAMPLE_TFLM_REGION

--- a/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
+++ b/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
@@ -9,6 +9,57 @@ tests:
       - tflite-micro
     filter: dt_compat_enabled("arm,ethos-u")
     build_only: true
+    platform_allow:
+      - mps3/corstone300/fvp
+      - kit_pse84_ai/pse846gps2dbzc4a/m55
     integration_platforms:
       - mps3/corstone300/fvp
       - kit_pse84_ai/pse846gps2dbzc4a/m55
+  sample.drivers.tflm_ethosu_sram_only:
+    tags:
+      - NPU
+    modules:
+      - tflite-micro
+    filter: dt_compat_enabled("arm,ethos-u")
+    build_only: true
+    platform_allow:
+      - mps3/corstone300/fvp
+    integration_platforms:
+      - mps3/corstone300/fvp
+    extra_configs:
+      - CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY=y
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.sram_only.overlay
+  sample.drivers.tflm_ethosu_dedicated_sram:
+    tags:
+      - NPU
+    modules:
+      - tflite-micro
+    filter: dt_compat_enabled("arm,ethos-u")
+    build_only: true
+    platform_allow:
+      - mps3/corstone300/fvp
+    integration_platforms:
+      - mps3/corstone300/fvp
+    extra_configs:
+      - CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_DEDICATED_SRAM=y
+    extra_args:
+      - CONFIG_ETHOS_U65_256=y
+      - DTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.dedicated_sram.overlay
+  sample.drivers.tflm_ethosu_mps4_u85_pmu:
+    tags:
+      - NPU
+    modules:
+      - tflite-micro
+    filter: dt_compat_enabled("arm,ethos-u")
+    build_only: true
+    platform_allow:
+      - mps4/corstone320/fvp
+    integration_platforms:
+      - mps4/corstone320/fvp
+    extra_configs:
+      - CONFIG_SAMPLE_TFLM_ETHOSU_MEM_MODE_SRAM_ONLY=y
+    extra_args:
+      - CONFIG_ETHOS_U85_2048=y
+      - CONFIG_SAMPLE_TFLM_ETHOSU_PMU=y
+      - DTC_OVERLAY_FILE="boards/mps4_corstone320_fvp.ta.overlay;boards/mps4_corstone320_fvp.sram_only.overlay"


### PR DESCRIPTION
This series updates the `tflm_ethosu` sample to support additional Vela memory
  modes and corresponding platform configurations.

  Highlights:
  - add selectable build-time Vela memory mode mapping
  - add SRAM-only and dedicated-SRAM overlays for FVP targets
  - document overlay and TA usage in the README
  - add build-only test variants for SRAM-only, dedicated-SRAM, and U85/PMU setups
