### PR TITLE
driver: pwm: pwm_max32: Added support for PWM Events

### DIFF
--- a/drivers/pwm/pwm_max32.c
+++ b/drivers/pwm/pwm_max32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,16 @@
 
 #include <zephyr/logging/log.h>
 
+#ifdef CONFIG_PWM_EVENT
+#include <zephyr/drivers/pwm/pwm_utils.h>
+#include <zephyr/irq.h>
+#include <zephyr/spinlock.h>
+
+/** MAX32 MCUs do not have multiple channels */
+#define MAX32_PWM_CH 0
+
+#endif /* CONFIG_PWM_EVENT */
+
 LOG_MODULE_REGISTER(pwm_max32, CONFIG_PWM_LOG_LEVEL);
 
 /** PWM configuration. */
@@ -25,11 +35,18 @@ struct max32_pwm_config {
 	const struct device *clock;
 	struct max32_perclk perclk;
 	int prescaler;
+#ifdef CONFIG_PWM_EVENT
+	void (*irq_config_func)(const struct device *dev);
+#endif /* CONFIG_PWM_EVENT */
 };
 
 /** PWM data. */
 struct max32_pwm_data {
 	uint32_t period_cycles;
+#ifdef CONFIG_PWM_EVENT
+	sys_slist_t event_callbacks;
+	struct k_spinlock lock;
+#endif /* CONFIG_PWM_EVENT */
 };
 
 static int api_set_cycles(const struct device *dev, uint32_t channel, uint32_t period_cycles,
@@ -100,9 +117,68 @@ static int api_get_cycles_per_sec(const struct device *dev, uint32_t channel, ui
 	return ret;
 }
 
+#ifdef CONFIG_PWM_EVENT
+static void pwm_max32_isr(const struct device *dev)
+{
+	const struct max32_pwm_config *cfg = dev->config;
+	struct max32_pwm_data *data = dev->data;
+
+	MXC_TMR_ClearFlags(cfg->regs);
+	Wrap_MXC_TMR_ClearWakeupFlags(cfg->regs);
+
+	pwm_fire_event_callbacks(&data->event_callbacks, dev, MAX32_PWM_CH, PWM_EVENT_TYPE_PERIOD);
+}
+
+static void update_interrupts(const struct device *dev)
+{
+	const struct max32_pwm_config *cfg = dev->config;
+	struct max32_pwm_data *data = dev->data;
+	struct pwm_event_callback *cb, *tmp;
+	bool enable_int = false;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&data->event_callbacks, cb, tmp, node) {
+		if ((cb->event_mask & PWM_EVENT_TYPE_PERIOD) != 0) {
+			enable_int = true;
+			break;
+		}
+		if ((cb->event_mask & PWM_EVENT_TYPE_FAULT) != 0) {
+			/* MAX32 TMR doesn't support fault-based interrupts */
+			continue;
+		}
+	}
+
+	if (enable_int) {
+		Wrap_MXC_TMR_EnableInt(cfg->regs);
+	} else {
+		Wrap_MXC_TMR_DisableInt(cfg->regs);
+	}
+}
+
+static int api_manage_event_callback(const struct device *dev,
+					 struct pwm_event_callback *callback, bool set)
+{
+	struct max32_pwm_data *data = dev->data;
+	int ret;
+
+	ret = pwm_manage_event_callback(&data->event_callbacks, callback, set);
+	if (ret < 0) {
+		return ret;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		update_interrupts(dev);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PWM_EVENT */
+
 static DEVICE_API(pwm, pwm_max32_driver_api) = {
 	.set_cycles = api_set_cycles,
 	.get_cycles_per_sec = api_get_cycles_per_sec,
+#ifdef CONFIG_PWM_EVENT
+	.manage_event_callback = api_manage_event_callback,
+#endif /* CONFIG_PWM_EVENT */
 };
 
 static int pwm_max32_init(const struct device *dev)
@@ -115,10 +191,23 @@ static int pwm_max32_init(const struct device *dev)
 		LOG_ERR("PWM pinctrl initialization failed (%d)", ret);
 	}
 
+#ifdef CONFIG_PWM_EVENT
+	cfg->irq_config_func(dev);
+#endif /* CONFIG_PWM_EVENT */
+
 	return ret;
 }
 
 #define PWM_MAX32_DEFINE(_num)                                                                     \
+	IF_ENABLED(CONFIG_PWM_EVENT, (                                      \
+		static void max32_pwm_irq_init_##_num(const struct device *dev) \
+		{                                                               \
+			IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(_num)),                  \
+					DT_IRQ(DT_INST_PARENT(_num), priority),             \
+					pwm_max32_isr, DEVICE_DT_INST_GET(_num), 0);        \
+			irq_enable(DT_IRQN(DT_INST_PARENT(_num)));                  \
+		};                                                              \
+	)) /* CONFIG_PWM_EVENT */                                           \
 	static struct max32_pwm_data max32_pwm_data_##_num;                                        \
 	PINCTRL_DT_INST_DEFINE(_num);                                                              \
 	static const struct max32_pwm_config max32_pwm_config_##_num = {                           \
@@ -129,6 +218,7 @@ static int pwm_max32_init(const struct device *dev)
 		.perclk.bit = DT_CLOCKS_CELL(DT_INST_PARENT(_num), bit),                           \
 		.perclk.clk_src = DT_PROP(DT_INST_PARENT(_num), clock_source),                     \
 		.prescaler = DT_PROP(DT_INST_PARENT(_num), prescaler),                             \
+		IF_ENABLED(CONFIG_PWM_EVENT, (.irq_config_func = max32_pwm_irq_init_##_num,))      \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(_num, &pwm_max32_init, NULL, &max32_pwm_data_##_num,                 \
 			      &max32_pwm_config_##_num, POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,     \

--- a/samples/drivers/pwm/event/boards/max32672evkit.overlay
+++ b/samples/drivers/pwm/event/boards/max32672evkit.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer0 {
+	clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+	prescaler = <1>;
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&tmr0c_oa_p0_17>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};
+
+/ {
+	aliases {
+		pwm-0 = &timer0_pwm;
+	};
+};

--- a/samples/drivers/pwm/event/src/main.c
+++ b/samples/drivers/pwm/event/src/main.c
@@ -12,7 +12,14 @@
 
 #define PWM_CHANNEL   0
 #define PWM_PERIOD_NS (1 * NSEC_PER_MSEC)
-#define PWM_FLAGS     PWM_POLARITY_NORMAL
+
+#if defined(CONFIG_PWM_MAX32)
+#define PWM_FLAGS       PWM_POLARITY_INVERTED
+#define PWM_FULL_LOW_NS PWM_PERIOD_NS
+#else
+#define PWM_FLAGS       PWM_POLARITY_NORMAL
+#define PWM_FULL_LOW_NS 0
+#endif
 
 static struct pwm_event_callback callback;
 
@@ -30,7 +37,8 @@ static void pwm_callback_handler(const struct device *dev, struct pwm_event_call
 		pwm_idle = !pwm_idle;
 		counter = 0;
 
-		ret = pwm_set(dev, PWM_CHANNEL, PWM_PERIOD_NS, pwm_idle ? 0 : PWM_PERIOD_NS / 2,
+		ret = pwm_set(dev, PWM_CHANNEL, PWM_PERIOD_NS,
+				  pwm_idle ? PWM_FULL_LOW_NS : PWM_PERIOD_NS / 2,
 			      PWM_FLAGS);
 		if (ret < 0) {
 			printk("failed to set pwm (%d)\n", ret);


### PR DESCRIPTION
Closes #104213

Max32 PWM already has built-in support for interrupts at the end of Max32 PWM already has built-in support for interrupts at the end of each PWM period so added baseline support for the `PERIOD` event type in `CONFIG_PWM_EVENT`. Updated PWM Event sample to support Max32672EvKit.

I had to update the PWM event sample to allow for inverted polarity on Max32. This is to prevent a "small high" from occurring before the PWM duty cycle is updated in the ISR:
#### Sample output on Max32672Evkit with 22us "small high" from default polarity:
<img width="1021" height="179" alt="image" src="https://github.com/user-attachments/assets/380d167e-6092-45ee-a644-eb3b387fff93" />
<img width="1835" height="153" alt="image" src="https://github.com/user-attachments/assets/29999f52-34eb-4164-8c45-c6ead3112560" />

#### Sample output on Max32672EvKit with inverted polarity fix:
<img width="784" height="185" alt="image" src="https://github.com/user-attachments/assets/ca080883-81f5-40a7-a845-9db173e5573b" />
<img width="1085" height="179" alt="image" src="https://github.com/user-attachments/assets/ea6a65e3-25b0-4ff9-8397-7a404b4d1e89" />


I'm sure this issue will arise on other platforms so we should some mechanism to select polarity. I've copied the [counter example](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/drivers/counter/alarm/src/main.c#L67) by using `#if defined(CONFIG_PWM_MAX32)` to check if we need to invert the polarity though I'm happy to implement another approach if needed.