### PR TITLE
drivers: i2s: fix build on mimxrt1180_evk/mimxrt1189/cm33 by setting default DMA_TCD_QUEUE_SIZE to 4

### DIFF
--- a/drivers/i2s/Kconfig.mcux
+++ b/drivers/i2s/Kconfig.mcux
@@ -14,6 +14,9 @@ menuconfig I2S_MCUX_SAI
 
 if I2S_MCUX_SAI
 
+config DMA_TCD_QUEUE_SIZE
+	default 4 if I2S_MCUX_SAI
+
 config I2S_RX_BLOCK_COUNT
 	int "RX queue length"
 	default 4


### PR DESCRIPTION
CONFIG_DMA_TCD_QUEUE_SIZE defaults to 2 in MCUX eDMA, but i2s_mcux_sai.c requires it to be > 3 (NUM_DMA_BLOCKS_RX_PREP).

Add board-specific config to set CONFIG_DMA_TCD_QUEUE_SIZE=4 for mimxrt1180_evk/mimxrt1189/cm33 to satisfy the BUILD_ASSERT.

Fixes #103997