### PR TITLE
soc: nxp: imx943: fix pm_mcore link failure when SCMI CPU helpers absent

### DIFF
--- a/soc/nxp/imx/imx9/imx943/Kconfig
+++ b/soc/nxp/imx/imx9/imx943/Kconfig
@@ -58,5 +58,6 @@ config SOC_IMX943_PM_MCORE
 	default y
 	depends on PM
 	depends on SOC_MIMX94398_M33 || SOC_MIMX94398_M7_0 || SOC_MIMX94398_M7_1
+	depends on NXP_SCMI_CPU_DOMAIN_HELPERS
 	help
 	  Common PM flow for Cortex-M cores (M33/M7) on i.MX943


### PR DESCRIPTION
# soc: nxp: imx943: fix pm_mcore link failure when SCMI CPU helpers absent

Closes #103992

`SOC_IMX943_PM_MCORE` defaulted to `y` with `CONFIG_PM=y` but had no
dependency on `NXP_SCMI_CPU_DOMAIN_HELPERS`, causing `pm_mcore.c` to
link against `scmi_nxp_cpu_*` symbols that were never built.

## Fix

- Add `depends on NXP_SCMI_CPU_DOMAIN_HELPERS` to `SOC_IMX943_PM_MCORE`
  in Kconfig so `pm_mcore.c` is only compiled with the full SCMI stack.
- Add no-op inline fallbacks for `pm_state_set()` and
  `pm_state_exit_post_ops()` in `include/zephyr/pm/pm.h` instead of a
  per-SoC stub file, so the PM subsystem always has a valid backend to
  link against. This scales to other platforms without duplication.

## Testing

`samples/hello_world` on `imx943_evk/mimx94398/m33` with `CONFIG_PM=y`
and `CONFIG_ARM_SCMI_NXP_VENDOR_EXTENSIONS=n`, SDK 0.17.1. Build
succeeds where it previously failed with undefined references.