### PR TITLE
arch: arm64: init: fix erroneous instruction trap on SVE init

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -84,7 +84,9 @@ void z_arm64_el3_init(void)
 	if (is_sve_implemented()) {
 		reg |= CPTR_EZ_BIT;		/* Enable SVE access for lower ELs */
 		write_cptr_el3(reg);
-
+		
+		__asm("ISB");
+		
 		/* Initialize ZCR_EL3 for full SVE vector length */
 		/* ZCR_EL3.LEN = 0x1ff means full hardware vector length */
 		write_zcr_el3(0x1ff);
@@ -206,6 +208,8 @@ void z_arm64_el2_init(void)
 		reg |= (CPTR_EL2_ZEN_EL1_EN | CPTR_EL2_ZEN_EL0_EN);
 		write_cptr_el2(reg);
 
+		__asm("ISB");
+		
 		/* Initialize ZCR_EL2 for full SVE vector length */
 		/* ZCR_EL2.LEN = 0x1ff means full hardware vector length */
 		write_zcr_el2(0x1ff);
@@ -260,6 +264,8 @@ void z_arm64_el1_init(void)
 		reg |= CPACR_EL1_ZEN;	/* Do not trap SVE initially */
 		write_cpacr_el1(reg);
 
+		__asm("ISB");
+		
 		/* Initialize ZCR_EL1 SVE vector length */
 		write_zcr_el1(CONFIG_ARM64_SVE_VL_MAX/16 - 1);
 	} else {


### PR DESCRIPTION
The SVE initialization code for AArch64 is missing instruction synchronization barrier instructions (ISB) between special register writes, which leads to a trap (synchronous exception).

An ISB instruction is required for writes to CPTR_ELx to take effect before writing to ZCR_ELx. Since this was not present, the access to ZCR_ELx would result in a synchronous exception.

Fixed by adding the synchronization barriers using inline assembly.

Problematic behavior was observed and fix verified on a Cortex A320x2 FVP.