### PR TITLE
scripts: west_commands: tab completion for board revisions

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -42,6 +42,8 @@ Build System
   the application source dir per-default. Samples requiring application source dir to be added to
   ``SNIPPET_ROOT`` must instead add the application source dir using ``snippet_root = <dir>`` entry
   in :file:`zephyr/module.yml` or manually append the folder to the CMake variable ``SNIPPET_ROOT``.
+* Shell autocompletions (``west completion``) should be regenerated as board target auto-complete now
+  supports board revisions.
 
 Kernel
 ******

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -65,6 +65,10 @@ class Boards(WestCommand):
         parser.add_argument('-n', '--name', dest='name_re',
                             help='''a regular expression; only boards whose
                             names match NAME_RE will be listed''')
+        parser.add_argument('-a', '--all-targets', action='store_true',
+                            help='''Output all valid combinations of {name},
+                            {revisions}, and {qualifiers} that can be used as a board
+                            target''')
         list_boards.add_args(parser)
 
         return parser
@@ -91,24 +95,36 @@ class Boards(WestCommand):
         args.board_roots += module_settings['board_root']
         args.soc_roots += module_settings['soc_root']
 
+        all_targets: list[str] = []
         for board in list_boards.find_v2_boards(args).values():
             if name_re is not None and not name_re.search(board.name):
                 continue
 
-            if board.revisions:
-                revisions_list = ' '.join([rev.name for rev in board.revisions])
+            if args.all_targets:
+                all_targets += [f"{board.name}/{qualifier}"
+                                for qualifier in list_boards.board_v2_qualifiers(board)]
+                if board.revisions:
+                    all_targets += [f"{board.name}@{revision.name}/{qualifier}"
+                                    for qualifier in list_boards.board_v2_qualifiers(board)
+                                    for revision in board.revisions]
             else:
-                revisions_list = 'None'
+                if board.revisions:
+                    revisions_list = ','.join([rev.name for rev in board.revisions])
+                else:
+                    revisions_list = 'None'
 
-            self.inf(
-                args.format.format(
-                    name=board.name,
-                    full_name=board.full_name,
-                    revision_default=board.revision_default,
-                    revisions=revisions_list,
-                    dir=board.dir,
-                    hwm=board.hwm,
-                    vendor=board.vendor,
-                    qualifiers=list_boards.board_v2_qualifiers_csv(board),
+                self.inf(
+                    args.format.format(
+                        name=board.name,
+                        full_name=board.full_name,
+                        revision_default=board.revision_default,
+                        revisions=revisions_list,
+                        dir=board.dir,
+                        hwm=board.hwm,
+                        vendor=board.vendor,
+                        qualifiers=list_boards.board_v2_qualifiers_csv(board),
+                    )
                 )
-            )
+
+        if args.all_targets:
+            self.inf(os.linesep.join(all_targets))

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -663,6 +663,10 @@ __comp_west_completion()
 
 __comp_west_boards()
 {
+	local bool_opts="
+		--all-targets -a
+	"
+
 	local other_opts="
 		--format -f
 		--name -n
@@ -674,7 +678,7 @@ __comp_west_boards()
 		--soc-root
 	"
 
-	all_opts="$dir_opts $other_opts"
+	all_opts="$bool_opts $dir_opts $other_opts"
 
 	case "$prev" in
 		$(__west_to_extglob "$other_opts") )

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -392,13 +392,7 @@ __set_comp_west_projs()
 
 __set_comp_west_boards()
 {
-	boards=( $(__west_x boards --format='{name}|{qualifiers}' "$@") )
-	for i in ${!boards[@]}; do
-		name="${boards[$i]%%|*}"
-		transformed_board="${boards[$i]//|//}"
-		boards[$i]="${transformed_board//,/\ ${name}\/}"
-	done
-	__set_comp ${boards[@]}
+	__set_comp "$(__west_x boards --all-targets "$@")"
 }
 
 __set_comp_west_shields()

--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -317,27 +317,14 @@ function __zephyr_west_complete_board
     end
 
     if test $is_cache_valid -eq 0
-        set -l boards (west boards --format="{name}|{qualifiers}|{vendor}" 2> /dev/null)
+        set -l targets (west boards --all-targets 2> /dev/null)
 
         if test $status -eq 0
             echo $manifest_hash > $cache_file
         end
 
-        for board in $boards
-            set -l split_b (string split "|" $board)
-            set -l name $split_b[1]
-            set -l qualifiers $split_b[2]
-            set -l vendor $split_b[3]
-
-            if test $vendor != "None"
-                for qualifier in (string split "," $qualifiers)
-                    printf "%s\t%s\n" $name/$qualifier $vendor >> $cache_file
-                end
-            else
-                for qualifier in (string split "," $qualifiers)
-                    printf "%s\n" $name/$qualifier >> $cache_file
-                end
-            end
+        for target in $targets
+            printf "%s\n" $target >> $cache_file
         end
     end
 

--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -431,6 +431,7 @@ complete -c west -n "__zephyr_west_seen_subcommand_from completion; and __zephyr
 complete -c west -n "__zephyr_west_use_subcommand; and __zephyr_west_check_if_in_workspace" -ra boards -d "display information about supported boards"
 complete -c west -n "__zephyr_west_seen_subcommand_from boards" -o f -l format -d "format string"
 complete -c west -n "__zephyr_west_seen_subcommand_from boards" -o n -l name -d "name regex"
+complete -c west -n "__zephyr_west_seen_subcommand_from boards" -o a -l all-targets -d "output all board target combinations"
 complete -c west -n "__zephyr_west_seen_subcommand_from boards" -l arch-root -xa "(__zephyr_west_complete_directories)" -d "add an arch root"
 complete -c west -n "__zephyr_west_seen_subcommand_from boards" -l board-root -xa "(__zephyr_west_complete_directories)" -d "add a board root"
 complete -c west -n "__zephyr_west_seen_subcommand_from boards" -l soc-root -xa "(__zephyr_west_complete_directories)" -d "add a soc root"

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -299,6 +299,7 @@ _west_boards() {
   local -a opts=(
   {-f,--format}'[format string]:format string:'
   {-n,--name}'[name regex]:regex:'
+  '(-a --all-targets)'{-a,--all-targets}'[output all board target combinations]'
   '*--arch-root[Add an arch root]:arch root:_directories'
   '*--board-root[Add a board root]:board root:_directories'
   '*--soc-root[Add a soc root]:soc root:_directories'

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -115,16 +115,7 @@ _get_west_projs() {
 }
 
 _get_west_boards() {
-  local boards=( $(__west_x boards --format='{name}|{qualifiers}') )
-  local -a transformed_boards
-
-  for board_line in "${boards[@]}"; do
-    local name="${board_line%%|*}"
-    local transformed_board="${board_line//|//}"
-    transformed_boards+=("${transformed_board//,/ ${name}/}")
-  done
-
-  _describe 'boards' transformed_boards
+  _describe 'boards' $(__west_x boards --all-targets)
 }
 
 _get_west_shields() {


### PR DESCRIPTION
Add an option to `west boards` that automatically outputs all valid board targets as a newline separated list without requiring any post processing.

Update completion scripts to use `west boards --all-targets` to obtain the list of targets, instead of using shell black magic to perform string parsing and modification. As a result, all shells get board revision support.

Example completion after double tab in bash:
<img width="851" height="67" alt="image" src="https://github.com/user-attachments/assets/8ac85b98-9a3e-43db-ad60-abee61fadde5" />

Fixes #70597

> [!WARNING]
>  Only tested under bash, I'm not a user of the other shells, help needed