### PR TITLE
samples: drivers: stepper: add TMCM-3216 sample

### DIFF
--- a/samples/drivers/stepper/tmcm3216/CMakeLists.txt
+++ b/samples/drivers/stepper/tmcm3216/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Alexis Czezar C Torreno
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stepper_tmcm3216)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/stepper/tmcm3216/Kconfig
+++ b/samples/drivers/stepper/tmcm3216/Kconfig
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Alexis Czezar C Torreno
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "TMCM-3216 sample application"
+
+config STEPS_PER_REV
+	int "Steps per revolution"
+	default 200
+
+config PING_PONG_N_REV
+	int "Change direction every N revolutions"
+	default 1
+
+config MAX_VELOCITY
+	int "Maximum velocity in usteps/s"
+	default 50000
+
+config MAX_ACCELERATION
+	int "Maximum acceleration in usteps/s^2"
+	default 1000
+
+config MAX_DECELERATION
+	int "Maximum deceleration in usteps/s^2"
+	default 1000
+
+source "Kconfig.zephyr"

--- a/samples/drivers/stepper/tmcm3216/README.rst
+++ b/samples/drivers/stepper/tmcm3216/README.rst
@@ -1,0 +1,59 @@
+.. zephyr:code-sample:: tmcm3216
+   :name: TMCM-3216 stepper
+   :relevant-api: stepper_interface
+
+   Control a stepper motor using the ADI TMCM-3216 standalone stepper motor
+   controller and driver board over RS485.
+
+Description
+***********
+
+This sample demonstrates how to use the TMCM-3216 3-axis standalone stepper motor
+controller and driver board with Zephyr's stepper driver API. It configures the
+ramp parameters (velocity and acceleration) using the generic
+:c:func:`stepper_ctrl_configure_ramp` API, then performs a ping-pong movement
+depending on the :kconfig:option:`CONFIG_PING_PONG_N_REV` configuration, reversing
+direction each time the target position is reached.
+
+The sample also showcases TMCM-3216-specific extensions:
+
+- ``tmcm3216_get_max_velocity`` -- read back configured velocity
+- ``tmcm3216_get_actual_velocity`` -- read real-time motor velocity
+- ``tmcm3216_get_status`` -- read extended status (position, velocity, endstops,
+  position reached flag)
+
+Wiring
+******
+
+The TMCM-3216 communicates via RS485. Connect:
+
+- STM32 USART2 TX (PD5) to RS485 transceiver DI
+- STM32 USART2 RX (PD6) to RS485 transceiver RO
+- STM32 GPIO A0 (PA3) to RS485 transceiver DE/RE
+- RS485 transceiver A/B to TMCM-3216 RS485 A/B
+
+Building and Running
+********************
+
+This project controls the stepper and outputs status to the console. It requires
+an ADI TMCM-3216 module connected via an RS485 transceiver.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/stepper/tmcm3216
+   :board: nucleo_u575zi_q
+   :goals: build flash
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v4.3.0 ***
+   [00:00:00.059,000] <inf> stepper_tmcm3216: Starting TMCM-3216 stepper sample
+   [00:00:00.117,000] <inf> stepper_tmcm3216: Ramp configured: speed=50000 usteps/s accel=5000 decel=5000 usteps/s^2
+   [00:00:01.234,000] <inf> stepper_tmcm3216: Status: pos=3200 vel=0 moving=no pos_reached=yes left_end=no right_end=no
+   [00:00:01.234,000] <inf> stepper_tmcm3216: Moving by -3200 steps
+   [00:00:02.345,000] <inf> stepper_tmcm3216: Status: pos=0 vel=0 moving=no pos_reached=yes left_end=no right_end=no
+   [00:00:02.345,000] <inf> stepper_tmcm3216: Moving by 3200 steps
+
+   <repeats endlessly>

--- a/samples/drivers/stepper/tmcm3216/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/stepper/tmcm3216/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Alexis Czezar C Torreno
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Using USART2 on Arduino D0/D1 pins (PD9/PD8) for RS485 communication */
+&usart2 {
+	status = "okay";
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <9600>;
+
+	tmcm3216_bus: adi_tmcm3216 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		tmcm3216: tmcm3216@1 {
+			compatible = "adi,tmcm3216";
+			reg = <0x1>;
+			de-gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+
+			stepper_driver_0: stepper-driver {
+				compatible = "adi,tmcm3216-stepper-driver";
+				idx = <0>;
+				micro-step-res = <16>;
+			};
+
+			stepper_ctrl_0: stepper-ctrl {
+				compatible = "adi,tmcm3216-stepper-ctrl";
+				idx = <0>;
+			};
+		};
+	};
+};

--- a/samples/drivers/stepper/tmcm3216/prj.conf
+++ b/samples/drivers/stepper/tmcm3216/prj.conf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Alexis Czezar C Torreno
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_STEPPER=y
+CONFIG_LOG=y
+
+# Serial/UART for RS485
+CONFIG_SERIAL=y
+CONFIG_UART_USE_RUNTIME_CONFIGURE=y
+
+# GPIO for RS485 DE pin
+CONFIG_GPIO=y

--- a/samples/drivers/stepper/tmcm3216/sample.yaml
+++ b/samples/drivers/stepper/tmcm3216/sample.yaml
@@ -1,0 +1,8 @@
+sample:
+  name: TMCM-3216 Stepper Sample
+tests:
+  sample.drivers.stepper.tmcm3216:
+    harness: stepper
+    tags: stepper
+    platform_allow: nucleo_u575zi_q
+    depends_on: serial gpio

--- a/samples/drivers/stepper/tmcm3216/src/main.c
+++ b/samples/drivers/stepper/tmcm3216/src/main.c
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Alexis Czezar C Torreno
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/stepper/stepper.h>
+#include <zephyr/drivers/stepper/stepper_ctrl.h>
+#include <zephyr/drivers/stepper/stepper_tmcm3216.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(stepper_tmcm3216, CONFIG_STEPPER_LOG_LEVEL);
+
+static const struct device *stepper_drv = DEVICE_DT_GET(DT_NODELABEL(stepper_driver_0));
+static const struct device *stepper_ctl = DEVICE_DT_GET(DT_NODELABEL(stepper_ctrl_0));
+
+static K_SEM_DEFINE(steps_completed_sem, 0, 1);
+
+static int32_t ping_pong_target = CONFIG_STEPS_PER_REV * CONFIG_PING_PONG_N_REV *
+				  DT_PROP(DT_NODELABEL(stepper_driver_0), micro_step_res);
+
+static void stepper_callback(const struct device *dev, const enum stepper_ctrl_event event,
+			     void *user_data)
+{
+	ARG_UNUSED(user_data);
+	switch (event) {
+	case STEPPER_CTRL_EVENT_STEPS_COMPLETED:
+		k_sem_give(&steps_completed_sem);
+		break;
+	default:
+		break;
+	}
+}
+
+static void print_tmcm3216_status(const struct device *dev)
+{
+	struct tmcm3216_status status;
+
+	if (tmcm3216_get_status(dev, &status) == 0) {
+		LOG_INF("Status: pos=%d vel=%d moving=%s pos_reached=%s left_end=%s right_end=%s",
+			status.actual_position, status.actual_velocity,
+			status.is_moving ? "yes" : "no",
+			status.position_reached ? "yes" : "no",
+			status.left_endstop ? "yes" : "no",
+			status.right_endstop ? "yes" : "no");
+	}
+}
+
+int main(void)
+{
+	LOG_INF("Starting TMCM-3216 stepper sample");
+
+	if (!device_is_ready(stepper_ctl)) {
+		LOG_ERR("Stepper ctrl device %s not ready", stepper_ctl->name);
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(stepper_drv)) {
+		LOG_ERR("Stepper driver device %s not ready", stepper_drv->name);
+		return -ENODEV;
+	}
+
+	stepper_ctrl_set_event_cb(stepper_ctl, stepper_callback, NULL);
+	stepper_enable(stepper_drv);
+
+	/* Configure ramp parameters (velocity and acceleration) */
+	const struct stepper_ctrl_ramp ramp = {
+		.acceleration_max = CONFIG_MAX_ACCELERATION,
+		.speed_max = CONFIG_MAX_VELOCITY,
+		.deceleration_max = CONFIG_MAX_DECELERATION,
+	};
+
+	stepper_ctrl_configure_ramp(stepper_ctl, &ramp);
+	LOG_INF("Ramp configured: speed=%u usteps/s accel=%u decel=%u usteps/s^2",
+		ramp.speed_max, ramp.acceleration_max, ramp.deceleration_max);
+
+	/* TMCM-3216 specific: verify velocity readback */
+	uint32_t max_velocity;
+
+	tmcm3216_get_max_velocity(stepper_ctl, &max_velocity);
+	LOG_DBG("Max velocity readback: %u usteps/s", max_velocity);
+
+	stepper_ctrl_set_reference_position(stepper_ctl, 0);
+	stepper_ctrl_move_by(stepper_ctl, ping_pong_target);
+	k_sleep(K_MSEC(500));  /* Give module time to process */
+
+	for (;;) {
+		if (k_sem_take(&steps_completed_sem, K_SECONDS(30)) == 0) {
+			/* TMCM-3216 specific: read extended status */
+			print_tmcm3216_status(stepper_ctl);
+
+			/* TMCM-3216 specific: read actual velocity */
+			int32_t actual_vel;
+
+			if (tmcm3216_get_actual_velocity(stepper_ctl, &actual_vel) == 0) {
+				LOG_DBG("Actual velocity at stop: %d usteps/s", actual_vel);
+			}
+
+			ping_pong_target *= -1;
+			stepper_ctrl_move_by(stepper_ctl, ping_pong_target);
+			LOG_INF("Moving by %d steps", ping_pong_target);
+		} else {
+			LOG_WRN("Timeout waiting for movement, retrying...");
+			ping_pong_target *= -1;
+			stepper_ctrl_move_by(stepper_ctl, ping_pong_target);
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add sample application demonstrating TMCM-3216 stepper control. 
This tests all the functions in both stepper driver and controller.

Linking previous PR of the driver itself for reference.
https://github.com/zephyrproject-rtos/zephyr/pull/104508

