### PR TITLE
drivers: timer: nxp: select lptmr system timer instance via zephyr,system-timer chosen

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -488,6 +488,10 @@ device.
    * - zephyr,sram
      - A node whose ``reg`` sets the base address and size of SRAM memory
        available to the Zephyr image, used during linking
+   * - zephyr,system-timer
+     - Selects the hardware timer instance used as the Zephyr system timer.
+       Used when devicetree selects which timer instance provides that
+       singleton system function.
    * - zephyr,tracing-uart
      - Sets UART device used by tracing subsystem
    * - zephyr,uart-mcumgr

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -694,6 +694,23 @@ NXP
 
     git grep "#include <nxp/nxp_" -- '*.dtsi' '*.dts' '*.overlay'
 
+* :dtcompatible:`nxp,lptmr` nodes used as the system timer must now be
+  designated via the ``zephyr,system-timer`` chosen property. Boards based on
+  i.MX95 and MCX-W SoCs already have this set in the SoC DTSI and require no
+  change. All other boards using :kconfig:option:`CONFIG_MCUX_LPTMR_TIMER`
+  must add a board overlay:
+
+  .. code-block:: devicetree
+
+     / {
+         chosen {
+             zephyr,system-timer = &lptmr0;
+         };
+     };
+
+  On Kinetis KE1xF, this overlay is also required when
+  :kconfig:option:`CONFIG_PM` is enabled.
+
 QSPI
 ====
 

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -423,4 +423,18 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
 		&mcux_lptmr_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT)
+/*
+ * Skip the instance reserved as the system timer via zephyr,system-timer.
+ * When both drivers are enabled, they must operate on separate hardware.
+ */
+#define COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n)				\
+	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer),			\
+		(DT_SAME_NODE(DT_INST(n, nxp_lptmr),			\
+			      DT_CHOSEN(zephyr_system_timer))),		\
+		(0))
+
+#define COUNTER_MCUX_LPTMR_DEVICE_INIT_COND(n)				\
+	COND_CODE_0(COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n),		\
+		(COUNTER_MCUX_LPTMR_DEVICE_INIT(n)), ())
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT_COND)

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -4,13 +4,18 @@
 # Copyright (c) 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
+DT_COMPAT_NXP_LPTMR := nxp,lptmr
+
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
-	default n
-	depends on DT_HAS_NXP_LPTMR_ENABLED
-	depends on !COUNTER_MCUX_LPTMR
+	default $(dt_node_has_compat,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),$(DT_COMPAT_NXP_LPTMR))
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
+	depends on $(dt_node_has_compat,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),$(DT_COMPAT_NXP_LPTMR))
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"
-	  interfaces.
+	  interfaces. The instance to use is selected via the zephyr,system-timer
+	  chosen property.

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_lptmr
-
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/devicetree.h>
@@ -15,30 +13,35 @@
 #include <fsl_lptmr.h>
 #include <zephyr/irq.h>
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
-	     "No LPTMR instance enabled in devicetree");
+BUILD_ASSERT(DT_HAS_CHOSEN(zephyr_system_timer),
+	     "zephyr,system-timer must be set to an nxp,lptmr node");
+BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_system_timer), nxp_lptmr),
+	     "zephyr,system-timer must point to an nxp,lptmr compatible node");
 
 /* Prescaler clock mapping */
 #define TO_LPTMR_CLK_SEL(val) _DO_CONCAT(kLPTMR_PrescalerClock_, val)
 
+/* Devicetree node selected as system timer via zephyr,system-timer chosen */
+#define LPTMR_NODE DT_CHOSEN(zephyr_system_timer)
+
 /* Devicetree properties */
-#define LPTMR_BASE ((LPTMR_Type *)(DT_INST_REG_ADDR(0)))
-#define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_INST_PROP_OR(0, clk_source, 0))
-#define LPTMR_PRESCALER DT_INST_PROP_OR(0, prescale_glitch_filter, 0)
+#define LPTMR_BASE ((LPTMR_Type *)(DT_REG_ADDR(LPTMR_NODE)))
+#define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_PROP_OR(LPTMR_NODE, clk_source, 0))
+#define LPTMR_PRESCALER DT_PROP_OR(LPTMR_NODE, prescale_glitch_filter, 0)
 /*
  * Default must be false so prescale-glitch-filter can be used without requiring
  * an explicit bypass property.
  */
-#define LPTMR_PRESCALER_BYPASS DT_INST_PROP_OR(0, prescale_glitch_filter_bypass, false)
-#define LPTMR_IRQN DT_INST_IRQN(0)
-#define LPTMR_IRQ_PRIORITY DT_INST_IRQ(0, priority)
+#define LPTMR_PRESCALER_BYPASS DT_PROP_OR(LPTMR_NODE, prescale_glitch_filter_bypass, false)
+#define LPTMR_IRQN DT_IRQN(LPTMR_NODE)
+#define LPTMR_IRQ_PRIORITY DT_IRQ(LPTMR_NODE, priority)
 
 /* Timer cycles per tick */
 #define CYCLES_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() \
 			/ (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 
 /* Counter maximum value based on resolution */
-#define LPTMR_RESOLUTION DT_INST_PROP(0, resolution)
+#define LPTMR_RESOLUTION DT_PROP(LPTMR_NODE, resolution)
 #define COUNTER_MAX GENMASK(LPTMR_RESOLUTION - 1, 0)
 
 #define MAX_TICKS ((COUNTER_MAX / CYCLES_PER_TICK) - 1)

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -12,6 +12,10 @@
 #include <freq.h>
 
 / {
+	chosen {
+		zephyr,system-timer = &lptmr1;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -23,6 +23,7 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,entropy = &trng;
 		zephyr,nbu = &nbu;
+		zephyr,system-timer = &lptmr0;
 	};
 
 	cpus {

--- a/dts/arm/nxp/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/nxp_mcxw70.dtsi
@@ -23,6 +23,7 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,entropy = &trng_0;
 		zephyr,nbu = &nbu;
+		zephyr,system-timer = &lptmr_0;
 	};
 
 	cpus {

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -42,18 +42,15 @@ config 3RD_LEVEL_INTERRUPTS
 config NUM_IRQS
 	default 250 # 2ND_LVL_ISR_TBL_OFFSET + MAX_IRQ_PER_AGGREGATOR * NUM_2ND_LEVEL_AGGREGATORS
 
-# LPTMR cannot be shared with both the system timer and the counter simultaneously
-# as they now share the same compatible resource.
-# By default, when LPTMR is not used as a counter, it shows enabling LPTMR as the system clock.
-config MCUX_LPTMR_TIMER
-	default y if !COUNTER_MCUX_LPTMR
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 
 config CORTEX_M_SYSTICK
 	default n if MCUX_LPTMR_TIMER
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
-	default $(dt_node_int_prop_int,/soc/timer@44300000,clock-frequency) if MCUX_LPTMR_TIMER
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),clock-frequency) if MCUX_LPTMR_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1024 if MCUX_LPTMR_TIMER

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -9,21 +9,18 @@ config NUM_IRQS
 	default 77 if SOC_MCXW727C
 	default 75
 
-config MCUX_LPTMR_TIMER
-	default y if PM
-
-
 # LPTMR runs from a 32.768 kHz clock when PM is enabled. Using 1024 ticks/sec gives an exact
 # 32-cycle tick period (32768 / 1024), reducing jitter and keeping the timer
 # efficient in low‑power.
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1024 if MCUX_LPTMR_TIMER
 
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
-DT_LPTMR_PATH := $(dt_nodelabel_path,lptmr0)
+DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,$(DT_SYSCLK_PATH),clock-frequency) if CORTEX_M_SYSTICK
-	default $(dt_node_int_prop_int,$(DT_LPTMR_PATH),clock-frequency) if MCUX_LPTMR_TIMER
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),clock-frequency) if MCUX_LPTMR_TIMER
 
 config MCUX_FLASH_K4_API
 	default y


### PR DESCRIPTION
The MCUX LPTMR timer driver previously assumed a single enabled nxp,lptmr
instance, preventing the system timer and counter drivers from coexisting
on SoCs that have multiple LPTMR instances (e.g. i.MX95, MCX-W).

This series uses the zephyr,system-timer chosen property to designate
which nxp,lptmr instance the system timer driver should use, following
the established Zephyr convention for system-level device selection.

Changes:
- Timer driver reads its hardware instance from
  DT_CHOSEN(zephyr_system_timer) instead of assuming a single instance
- Counter driver skips the instance designated as the system timer,
  allowing both drivers to coexist on SoCs with multiple LPTMR instances
- Set zephyr,system-timer = &lptmr1 in the i.MX95 DTSI
- Set zephyr,system-timer = &lptmr0 / &lptmr_0 in the MCX-W7x and
  MCX-W70 DTSIs
- Document required board overlay for out-of-tree boards in the 4.4
  migration guide

Out-of-tree boards using CONFIG_MCUX_LPTMR_TIMER must add a board
overlay:

    / {
        chosen {
            zephyr,system-timer = &lptmr0;
        };
    };

Related RFC: #105249
