### PR TITLE
audio: dmic: gain configuration for streams

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -73,6 +73,10 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w)
 
+* Audio
+
+  * :c:member:`pcm_stream_cfg.gain_db`
+
 * :c:func:`lora_recv_duty_cycle_async`
 
 .. zephyr-keep-sorted-stop

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -215,6 +215,7 @@ static int dmic_nrfx_pdm_configure(const struct device *dev,
 	struct pcm_stream_cfg *stream = &config->streams[0];
 	uint32_t def_map, alt_map;
 	nrfx_pdm_config_t nrfx_cfg;
+	int8_t gain_limit;
 	int err;
 
 	if (drv_data->active) {
@@ -284,6 +285,13 @@ static int dmic_nrfx_pdm_configure(const struct device *dev,
 		nrfx_cfg.edge = NRF_PDM_EDGE_LEFTRISING;
 		channel->act_chan_map_lo = alt_map;
 	}
+
+	/* Limit requested gain to +- 20dB */
+	gain_limit = CLAMP(stream->gain_db, -20, 20);
+	/* Registers are 0.5dB steps */
+	nrfx_cfg.gain_l = NRF_PDM_GAIN_DEFAULT + (2 * gain_limit);
+	nrfx_cfg.gain_r = NRF_PDM_GAIN_DEFAULT + (2 * gain_limit);
+
 #if NRF_PDM_HAS_SELECTABLE_CLOCK
 	nrfx_cfg.mclksrc = drv_cfg->clk_src == ACLK
 			 ? NRF_PDM_MCLKSRC_ACLK

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -148,6 +148,8 @@ struct pcm_stream_cfg {
 	uint8_t pcm_width;
 	/** PCM sample block size per transfer */
 	uint16_t block_size;
+	/** Gain to apply to the channel (dB) */
+	int8_t gain_db;
 	/** SLAB for DMIC driver to allocate buffers for stream */
 	struct k_mem_slab *mem_slab;
 };


### PR DESCRIPTION
Add the option to configure the audio gain in the API.
Apply the requested stream gain to the two audio channels for the Nordic PDM IP.

Specifying the gain at the stream level seemed the best option, as I couldn't find a way to specify it per left/right channel.
Only implemented for Nordic hardware as that's all I have to test, but applying a gain to an audio channel is not a Nordic specific feature.