### PR TITLE
pm: device_system_managed: add warning log for resume failures

### DIFF
--- a/subsys/pm/device_system_managed.c
+++ b/subsys/pm/device_system_managed.c
@@ -68,8 +68,13 @@ bool pm_suspend_devices(void)
 void pm_resume_devices(void)
 {
 	for (int i = (num_susp - 1); i >= 0; i--) {
-		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
-				    PM_DEVICE_ACTION_RESUME);
+		const struct device *dev = TYPE_SECTION_START(pm_device_slots)[i];
+		int ret;
+
+		ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
+		if (ret < 0) {
+			LOG_WRN("Failed to resume device %s (%d)", dev->name, ret);
+		}
 	}
 
 	num_susp = 0;


### PR DESCRIPTION
Add error logging in pm_resume_devices() to report when a device fails to resume. This improves debuggability by making resume failures visible in the system log.