### PR TITLE
sys: util: rewrite WRITE_BIT macro to support 64-bit bitfields

### DIFF
--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -49,17 +49,23 @@ extern "C" {
 #define BIT64(_n) (1ULL << (_n))
 
 /**
- * @brief Set or clear a bit depending on a boolean value
+ * @brief Set or clear a bit depending on a boolean value in an unsigned integer
  *
- * The argument @p var is a variable whose value is written to as a
- * side effect.
+ * The argument @p var is a variable whose value is written to as a side effect.
  *
  * @param var Variable to be altered
  * @param bit Bit number
  * @param set if 0, clears @p bit in @p var; any other value sets @p bit
  */
-#define WRITE_BIT(var, bit, set) \
-	((var) = (set) ? ((var) | BIT(bit)) : ((var) & ~BIT(bit)))
+#define WRITE_BIT(var, bit, set)                                                                   \
+	do {                                                                                       \
+		__typeof__(var) __mask = ((__typeof__(var))1U << (bit));                           \
+		if (set) {                                                                         \
+			(var) |= __mask;                                                           \
+		} else {                                                                           \
+			(var) &= ~__mask;                                                          \
+		}                                                                                  \
+	} while (0)
 
 /**
  * @brief Bit mask with bits 0 through <tt>n-1</tt> (inclusive) set,

--- a/tests/lib/sys_util/src/main.c
+++ b/tests/lib/sys_util/src/main.c
@@ -70,6 +70,23 @@ ZTEST(sys_util, test_NUM_VA_ARGS_LESS_1)
 	/* support up to 64 args */
 	zassert_equal(63, NUM_VA_ARGS_LESS_1(LISTIFY(64, ~, (,))));
 }
+
+/**
+ * @brief Test WRITE_BIT works as expected with typical use cases
+ *
+ * @see WRITE_BIT()
+ */
+ZTEST(sys_util, test_WRITE_BIT)
+{
+	uint64_t bit_field = 0;
+
+	for (size_t i = 0; i < 64; i++) {
+		WRITE_BIT(bit_field, i, true);
+		zassert_true(IS_BIT_SET(bit_field, i), "Bit %zu not set, but it shall.", i);
+		WRITE_BIT(bit_field, i, false);
+		zassert_false(IS_BIT_SET(bit_field, i), "Bit %zu set, but it shall not.", i);
+	}
+}
 /**
  * @}
  */


### PR DESCRIPTION
solves https://github.com/zephyrproject-rtos/zephyr/issues/104200