### PR TITLE
bluetooth: host: add IPT in the CS reflector subfeature

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -623,6 +623,8 @@ struct bt_conn_le_cs_capabilities {
 	bool chsel_alg_3c_supported;
 	/** Subfeature: Phase-based Ranging from RTT sounding sequence. */
 	bool pbr_from_rtt_sounding_seq_supported;
+	/** Subfeature: IPT in the CS reflector */
+	bool cs_ipt_reflector;
 	/** Optional T_IP1 time durations during CS steps.
 	 *
 	 *  - Bit 0: 10 us

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3927,6 +3927,8 @@ struct bt_hci_evt_le_read_all_remote_feat_complete {
 #define BT_HCI_LE_CS_SUBFEATURE_NO_TX_FAE_MASK BIT(1)
 #define BT_HCI_LE_CS_SUBFEATURE_CHSEL_ALG_3C_MASK BIT(2)
 #define BT_HCI_LE_CS_SUBFEATURE_PBR_FROM_RTT_SOUNDING_SEQ_MASK BIT(3)
+/** Subfeature: CS with IPT in the reflector. */
+#define BT_HCI_LE_CS_SUBFEATURE_CS_IPT_REFLECTOR_MASK BIT(4)
 
 #define BT_HCI_LE_CS_T_IP1_TIME_10US_MASK BIT(0)
 #define BT_HCI_LE_CS_T_IP1_TIME_20US_MASK BIT(1)

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -547,6 +547,10 @@ void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct net_buf 
 		sys_le16_to_cpu(evt->subfeatures_supported) &
 		BT_HCI_LE_CS_SUBFEATURE_PBR_FROM_RTT_SOUNDING_SEQ_MASK;
 
+	remote_cs_capabilities.cs_ipt_reflector =
+		sys_le16_to_cpu(evt->subfeatures_supported) &
+		BT_HCI_LE_CS_SUBFEATURE_CS_IPT_REFLECTOR_MASK;
+
 	remote_cs_capabilities.t_ip1_times_supported =
 		sys_le16_to_cpu(evt->t_ip1_times_supported);
 	remote_cs_capabilities.t_ip2_times_supported =
@@ -1347,6 +1351,10 @@ int bt_le_cs_read_local_supported_capabilities_v2(struct bt_conn_le_cs_capabilit
 		sys_le16_to_cpu(rp->subfeatures_supported) &
 		BT_HCI_LE_CS_SUBFEATURE_PBR_FROM_RTT_SOUNDING_SEQ_MASK;
 
+	ret->cs_ipt_reflector =
+		sys_le16_to_cpu(rp->subfeatures_supported) &
+		BT_HCI_LE_CS_SUBFEATURE_CS_IPT_REFLECTOR_MASK;
+
 	ret->t_ip1_times_supported = sys_le16_to_cpu(rp->t_ip1_times_supported);
 	ret->t_ip2_times_supported = sys_le16_to_cpu(rp->t_ip2_times_supported);
 	ret->t_fcs_times_supported = sys_le16_to_cpu(rp->t_fcs_times_supported);
@@ -1545,6 +1553,10 @@ int bt_le_cs_write_cached_remote_supported_capabilities_v2(struct bt_conn *conn,
 	if (params->pbr_from_rtt_sounding_seq_supported) {
 		cp->subfeatures_supported |=
 			sys_cpu_to_le16(BT_HCI_LE_CS_SUBFEATURE_PBR_FROM_RTT_SOUNDING_SEQ_MASK);
+	}
+	if (params->cs_ipt_reflector) {
+		cp->subfeatures_supported |=
+			sys_cpu_to_le16(BT_HCI_LE_CS_SUBFEATURE_CS_IPT_REFLECTOR_MASK);
 	}
 
 	cp->t_ip1_times_supported = sys_cpu_to_le16(params->t_ip1_times_supported);


### PR DESCRIPTION
Add support for the IPT in the CS reflector subfeature in the Bluetooth host stack.