### PR TITLE
tests: drivers: pwm: gpio_loopback: Fix nrf5340dk configuration

### DIFF
--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,8 +11,8 @@
 
 / {
 	zephyr,user {
-		pwms = <&pwm0 0 160000 PWM_POLARITY_NORMAL>,
-		       <&pwm0 1 160000 PWM_POLARITY_NORMAL>;
+		pwms = <&pwm0 0 16000000 PWM_POLARITY_NORMAL>,
+		       <&pwm0 1 16000000 PWM_POLARITY_NORMAL>;
 
 		gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>,
 			<&gpio0 7 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
nrf5340dk k_cycle_get_32() returns value for 32kHz RTC clock. It means that can only be used to relatively slow signals. Increasing PWM period 100x to 16ms so that captured results return accepted deviation.