### PR TITLE
drivers: nrf_wifi: Fix Current PHY rate which displayed as zero

### DIFF
--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -90,6 +90,7 @@ struct nrf_wifi_vif_ctx_zep {
 #endif /* CONFIG_NRF70_DATA_TX */
 	unsigned long rssi_record_timestamp_us;
 	signed short rssi;
+	unsigned long tx_bitrate;
 #endif /* CONFIG_NRF70_STA_MODE */
 #ifdef CONFIG_NRF70_AP_MODE
 	int inactive_time_sec;

--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -1237,6 +1237,7 @@ int nrf_wifi_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si, uns
 		}
 	} else {
 		si->data.signal = (int)vif_ctx_zep->rssi;
+		si->data.current_tx_rate = vif_ctx_zep->tx_bitrate;
 	}
 
 	ret = nrf_wifi_sys_fmac_get_interface(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx);
@@ -1309,6 +1310,7 @@ void nrf_wifi_wpa_supp_event_proc_get_sta(void *if_priv,
 	if (info->sta_info.valid_fields & NRF_WIFI_STA_INFO_TX_BITRATE_VALID) {
 		if (info->sta_info.tx_bitrate.valid_fields & NRF_WIFI_RATE_INFO_BITRATE_VALID) {
 			signal_info->data.current_tx_rate = info->sta_info.tx_bitrate.bitrate * 100;
+			vif_ctx_zep->tx_bitrate = signal_info->data.current_tx_rate;
 		}
 	}
 out:


### PR DESCRIPTION
Current PHY rate is sometimes displayed as zero.
Add caching logic for Current PHY rate.