### PR TITLE
stm32wbax s2ram memory config

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -236,7 +236,7 @@
 		};
 
 		pwr: power@46020800 {
-			compatible = "st,stm32-dualreg-pwr", "st,stm32-pwr";
+			compatible = "st,stm32wba-pwr", "st,stm32-pwr";
 			reg = <0x46020800 0x400>;
 			wkup-pins-nb = <8>;
 			wkup-pin-srcs = <2>;

--- a/dts/bindings/power/st,stm32wba-pwr.yaml
+++ b/dts/bindings/power/st,stm32wba-pwr.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32WBA power controller
+
+description: |
+  Power controller of STM32WBA series
+
+  Controls the memory retained in s2ram power state.
+
+compatible: "st,stm32wba-pwr"
+
+include: "st,stm32-dualreg-pwr.yaml"
+
+properties:
+  retain-sram2:
+    type: boolean
+    description: |
+      Enables retention of SRAM2 while in Standby low-power mode.
+      (Standby mode is a suspend-to-RAM power state)
+
+      If this property is present, the entire SRAM2 memory region
+      will be retained in Standby mode (all contents preserved).
+
+      If this property is not present, the SRAM2 memory region will
+      will not be retained in Standby mode (all contents are lost),
+      except if the Zephyr RAM region `/chosen/zephyr,sram` overlaps
+      with SRAM2 (in this case, retention is always enabled).
+
+examples:
+  - |
+    /*
+     * Not used RAM retained (and so powered) is simply a
+     * pointless waste of energy.
+     * `/chosen/zephyr,sram` (Zephyr system memory) is mapped on
+     * sram0 memory controller.
+     * According the required ram, sram0 memory controller will use
+     * SRAM1 (up to 448KB) and SRAM2 (up to 64KB) physical banks.
+     *
+     * Let's imagine a build report shows an application needs
+     * 120 KB of RAM and Standby low-power feature is required.
+     * In this case only the first 2 pages of SRAM1 will be retained.
+     * And SRAM2 is not retained by default.
+     * The overlay file can be modified like this:
+     */
+    sram0: memory@20000000 {
+            reg = <0x20000000 DT_SIZE_K(120)>;
+    };
+  - |
+    /*
+     * If for any specific reason application needs to retain SRAM2:
+     */
+    &pwr {
+            power-supply = "smps";
+            retain-sram2;
+            status = "okay";
+    };
+  - |
+    /*
+     * If full memory is required, SRAM1 and SRAM2 will be
+     * fully retained and the sram0 memory node will appear
+     * like this:
+     */
+    sram0: memory@20000000 {
+            reg = <0x20000000 DT_SIZE_K(512)>;
+    };

--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -35,6 +35,71 @@
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
+#if defined(CONFIG_PM_S2RAM)
+/* Retained region information (from DTS) */
+#define PWRC_NODE	DT_INST(0, st_stm32wba_pwr)
+#define RETAINED_SRAM12	DT_CHOSEN(zephyr_sram)
+#define RETAINED_SRAM12_START	(DT_REG_ADDR(RETAINED_SRAM12))
+#define RETAINED_SRAM12_END	(RETAINED_SRAM12_START + DT_REG_SIZE(RETAINED_SRAM12))
+
+/* Hardware information */
+#if defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define BASE(sramn) CONCAT(sramn, _BASE_S)
+#else
+#define BASE(sramn) CONCAT(sramn, _BASE_NS)
+#endif
+#define SRAM1_PAGE_SIZE (64 * 1024)
+
+/*
+ * @param i1s Start of interval 1 (inclusive)
+ * @param i1e End of interval 1 (exclusive)
+ * @param i2s Start of interval 2 (inclusive)
+ * @param i2e End of interval 2 (exclusive)
+ *
+ * Evaluates as true if there is an overlap between
+ * intervals [i1s, i1e) and [i2s, i2e).
+ */
+#define RANGES_OVERLAP(i1s, i1e, i2s, i2e)					\
+	(((i1e) > (i2s)) && ((i1s) < (i2e)))
+
+#if !defined(PWR_STOP2_SUPPORT) /* STM32WBA5x */
+/* No page granularity on STM32WBA5x */
+#define SRAM1_RETENTION_MASK LL_PWR_SRAM1_SB_FULL_RETENTION
+#else /* STM32WBA6x */
+/*
+ * @param pgn Page number as described in RefMan: 1~7
+ *
+ * Evaluates as true if page @p{pgn} is part of the retained
+ * region, false otherwise.
+ */
+#define SRAM1_PAGE_USED(pgn)							\
+	RANGES_OVERLAP(RETAINED_SRAM12_START, RETAINED_SRAM12_END,		\
+		BASE(SRAM1) + (((pgn) - 1) * SRAM1_PAGE_SIZE),			\
+		BASE(SRAM1) + ((pgn) * SRAM1_PAGE_SIZE))
+
+#define SRAM1_PAGE_RETAIN_MASK(pgn, msknum)					\
+	(SRAM1_PAGE_USED(pgn) ?	CONCAT(LL_PWR_SRAM1_SB_PAGE, msknum, _RETENTION) : 0)
+
+#define SRAM1_RETENTION_MASK							\
+	(SRAM1_PAGE_RETAIN_MASK(1, 1) |						\
+	 SRAM1_PAGE_RETAIN_MASK(2, 2) |						\
+	 SRAM1_PAGE_RETAIN_MASK(3, 3) |						\
+	 SRAM1_PAGE_RETAIN_MASK(4, 4) |						\
+	 SRAM1_PAGE_RETAIN_MASK(5, 567) |					\
+	 SRAM1_PAGE_RETAIN_MASK(6, 567) |					\
+	 SRAM1_PAGE_RETAIN_MASK(7, 567))
+
+BUILD_ASSERT(SRAM1_RETENTION_MASK != 0U,
+	"Retained SRAM1/2 region does not contain any SRAM1 page!");
+#endif /* !defined(PWR_STOP2_SUPPORT) */
+
+#define RETAINED_SRAM12_OVERLAPS_SRAM2                                 \
+		(RANGES_OVERLAP(RETAINED_SRAM12_START,                 \
+				RETAINED_SRAM12_END,                   \
+				BASE(SRAM2),                           \
+				BASE(SRAM2) + SRAM2_SIZE))
+#endif /* CONFIG_PM_S2RAM */
+
 
 #define HSE_ON (stm32_reg_read_bits(&RCC->CR, RCC_CR_HSEON) == RCC_CR_HSEON)
 
@@ -275,12 +340,26 @@ void stm32_power_init(void)
 	LL_DBGMCU_APB7_GRP1_FreezePeriph(LL_DBGMCU_APB7_GRP1_LPTIM1_STOP);
 #endif
 
-	/* Enable SRAM full retention */
-	LL_PWR_SetSRAM1SBRetention(LL_PWR_SRAM1_SB_FULL_RETENTION);
-	LL_PWR_SetSRAM2SBRetention(LL_PWR_SRAM2_SB_FULL_RETENTION);
+#ifdef CONFIG_PM_S2RAM
+	/*
+	 * According the defined RAM, only the required pages will be retained.
+	 * This memory size can be modified by the overlay mechanism matching
+	 * the RAM required by the application and highlighted in the building report.
+	 */
 
-	/* Enable Radio RAM full retention */
-	LL_PWR_SetRadioSBRetention(LL_PWR_RADIO_SB_FULL_RETENTION);
+	/* Retain only the required SRAM1 pages */
+	LL_PWR_SetSRAM1SBRetention(SRAM1_RETENTION_MASK);
+
+	if (DT_PROP(PWRC_NODE, retain_sram2) || RETAINED_SRAM12_OVERLAPS_SRAM2) {
+		/* Retain SRAM2 if explicitly requested or used by Zephyr as system RAM */
+		LL_PWR_SetSRAM2SBRetention(LL_PWR_SRAM2_SB_FULL_RETENTION);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_STM32WBA) || IS_ENABLED(CONFIG_IEEE802154_STM32WBA)) {
+		/* Retain radio RAM if a radio driver is enabled */
+		LL_PWR_SetRadioSBRetention(LL_PWR_RADIO_SB_FULL_RETENTION);
+	}
+#endif
 
 	/* Enabling  Ultra Low power mode */
 	LL_PWR_EnableUltraLowPowerMode();


### PR DESCRIPTION
Before this PR, all avaialble SRAM memory is retained in stdby power state even if not strictly required by the application.

With this PR, when  CONFIG_PM_S2RAM is enabled, system will be able to automatically retain only the SRAM pages according the real required memory.

This memory size can be overriden by the overlay mechanism matching the RAM required by the application and highlighted in the building report.

FYI: @vtardy-st, @Chastillon, @msmttchr, @FrancescoCiminoST   