### PR TITLE
samples: net: openthread: shell: fix frdm_rw612 build command in README

### DIFF
--- a/samples/net/openthread/shell/README.rst
+++ b/samples/net/openthread/shell/README.rst
@@ -46,8 +46,8 @@ Example building for NXP's RW612 FRDM (RCP host).
 .. zephyr-app-commands::
    :zephyr-app: samples/net/openthread/shell
    :board: frdm_rw612
-   :conf: "prj-ot-host.conf"
    :goals: build
+   :gen-args: -DEXTRA_CONF_FILE=prj-ot-host.conf
    :compact:
 
 Example building for NXP's MCXW72 FRDM (host).


### PR DESCRIPTION
samples: net: openthread: shell: fix frdm_rw612 build command in README

Helps closing #103866

The README build example for frdm_rw612 used `:conf: "prj-ot-host.conf"`
which maps to `-DCONF_FILE` internally. This replaces the entire conf
selection, dropping `boards/frdm_rw612.conf` which sets
`CONFIG_HDLC_RCP_IF=y` required for RCP host mode. Without it the
build fails with:

```
error: '__device_dts_ord_DT_CHOSEN_zephyr_ieee802154_ORD'
undeclared here (not in a function)
```

Fix by replacing `:conf:` with `:gen-args: -DEXTRA_CONF_FILE=prj-ot-host.conf`
so the board conf is preserved.

Only `README.rst` was modified. Changes to `prj.conf` and
`prj-ot-host.conf` were discarded as they were not needed.

**Changes:**
- `samples/net/openthread/shell/README.rst`

**Testing:**
```
west build -b frdm_rw612 samples/net/openthread/shell --pristine -- \
  -DEXTRA_CONF_FILE=prj-ot-host.conf
```

Build completes successfully with `CONFIG_HDLC_RCP_IF=y` set.