### PR TITLE
net: l2: ppp: Async-Control-Character-Map updated too early

### DIFF
--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -597,8 +597,15 @@ struct net_if;
 
 /** @endcond */
 
+/** Default value for the PPP Asynchronous Control Character Map */
+#define NET_PPP_DEFAULT_ASYNC_MAP (0xffffffffU)
+
 /**
  * @brief Retrieve the PPP peers Asynchronous Control Character Map
+ *
+ * Before PPP LCP negotiation is complete, this function will return the default value of
+ * 0xffffffff. After LCP negotiation, this function will return the value that peer has
+ * provided.
  *
  * @param iface PPP network interface.
  *

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -354,6 +354,9 @@ uint32_t ppp_peer_async_control_character_map(struct net_if *iface)
 	__ASSERT(net_if_l2(iface) == &NET_L2_GET_NAME(PPP), "Not PPP L2");
 #endif /* !CONFIG_ZTEST */
 	ctx = net_if_l2_data(iface);
+	if (ctx->phase < PPP_NETWORK) {
+		return NET_PPP_DEFAULT_ASYNC_MAP;
+	}
 	return ctx->lcp.peer_options.async_map;
 }
 

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -107,7 +107,8 @@ static struct net_l2 test_net_l2 = {
 	.recv = test_net_l2_recv,
 };
 static struct ppp_context test_net_l2_data = {
-	.lcp.peer_options.async_map = 0xffffffff,
+	.phase = PPP_RUNNING,
+	.lcp.peer_options.async_map = NET_PPP_DEFAULT_ASYNC_MAP,
 };
 
 /* This emulates the network interface device which will receive unwrapped network packets */


### PR DESCRIPTION
When peer sends the Async-Control-Character-Map option on LCP phase, Zephyr correctly responsed with Configure-Ack. But the LCP negotiation phase have not been finnished yet, so the remote end may not expect us to immediately update the value.

This is seen when trying to use Zephyr's PPP stack against PPPD from Linux, where default asyncmap option is zero.

```
Serial connection established.
using channel 104
Using interface ppp0
Connect: ppp0 <--> /dev/ttyACM0
sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x42717a60> <pcomp> <accomp>]
rcvd [LCP ConfReq id=0x1 <mru 1464> <asyncmap 0xffffffff>]
sent [LCP ConfAck id=0x1 <mru 1464> <asyncmap 0xffffffff>]
sent [LCP ConfReq id=0x1 <asyncmap 0x0> <magic 0x42717a60> <pcomp> <accomp>]
rcvd [LCP ConfRej id=0x1 <magic 0x42717a60> <pcomp> <accomp>]
sent [LCP ConfReq id=0x2 <asyncmap 0x0>]
sent [LCP ConfReq id=0x2 <asyncmap 0x0>]
sent [LCP ConfReq id=0x2 <asyncmap 0x0>]
sent [LCP ConfReq id=0x2 <asyncmap 0x0>]
^CTerminating on signal 2
sent [LCP TermReq id=0x3 "User request"]
sent [LCP TermReq id=0x4 "User request"]
Connection terminated.
```

However, if we delay the update of the asyncmap to the network phase, it works just fine.

Fixes #105291