### PR TITLE
net: l2: ppp: Allow using zero asyncmap locally

### DIFF
--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -42,8 +42,8 @@ enum modem_ppp_receive_state {
 	/* Searching for start of frame and header */
 	MODEM_PPP_RECEIVE_STATE_HDR_SOF = 0,
 	MODEM_PPP_RECEIVE_STATE_HDR_FF,
-	MODEM_PPP_RECEIVE_STATE_HDR_7D,
-	MODEM_PPP_RECEIVE_STATE_HDR_23,
+	MODEM_PPP_RECEIVE_STATE_HDR_CTRL_UNESCAPE,
+	MODEM_PPP_RECEIVE_STATE_HDR_CTRL,
 	/* Writing bytes to network packet */
 	MODEM_PPP_RECEIVE_STATE_WRITING,
 	/* Unescaping next byte before writing to network packet */

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(modem_ppp, CONFIG_MODEM_MODULES_LOG_LEVEL);
 #define MODEM_PPP_CODE_DELIMITER	(0x7E)
 #define MODEM_PPP_CODE_ESCAPE		(0x7D)
 #define MODEM_PPP_VALUE_ESCAPE		(0x20)
+#define MODEM_PPP_CODE_CONTROL		(0x03)
 
 static uint16_t modem_ppp_fcs_init(uint8_t byte)
 {
@@ -215,22 +216,23 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 			break;
 		}
 		if (modem_ppp_is_byte_expected(byte, 0xFF)) {
-			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_7D;
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_CTRL;
 		} else {
 			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
 		}
 		break;
 
-	case MODEM_PPP_RECEIVE_STATE_HDR_7D:
-		if (modem_ppp_is_byte_expected(byte, MODEM_PPP_CODE_ESCAPE)) {
-			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_23;
-		} else {
-			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
-		}
-		break;
+	case MODEM_PPP_RECEIVE_STATE_HDR_CTRL_UNESCAPE:
+		byte ^= MODEM_PPP_VALUE_ESCAPE;
+		ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_CTRL;
+		__fallthrough;
 
-	case MODEM_PPP_RECEIVE_STATE_HDR_23:
-		if (modem_ppp_is_byte_expected(byte, 0x23)) {
+	case MODEM_PPP_RECEIVE_STATE_HDR_CTRL:
+		if (byte == MODEM_PPP_CODE_ESCAPE) {
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_CTRL_UNESCAPE;
+			break;
+		}
+		if (modem_ppp_is_byte_expected(byte, MODEM_PPP_CODE_CONTROL)) {
 			ppp->rx_pkt = net_pkt_rx_alloc_with_buffer(ppp->iface,
 				CONFIG_MODEM_PPP_NET_BUF_FRAG_SIZE, NET_AF_UNSPEC, 0, K_NO_WAIT);
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -374,7 +374,7 @@ static int lcp_ack_async_map(struct ppp_context *ctx, struct net_pkt *pkt,
 		return -EINVAL;
 	}
 
-	ret = net_pkt_read(pkt, &async_map, sizeof(async_map));
+	ret = net_pkt_read_be32(pkt, &async_map);
 	if (ret) {
 		return ret;
 	}
@@ -390,14 +390,14 @@ static int lcp_nak_async_map(struct ppp_context *ctx, struct net_pkt *pkt,
 			     uint8_t oplen)
 {
 	int ret;
-	uint16_t async_map;
+	uint32_t async_map;
 
 	/* Handle NAK: accept only equal to ours */
 	if (oplen != sizeof(async_map)) {
 		return -EINVAL;
 	}
 
-	ret = net_pkt_read(pkt, &async_map, sizeof(async_map));
+	ret = net_pkt_read_be32(pkt, &async_map);
 	if (ret) {
 		return ret;
 	}
@@ -459,7 +459,7 @@ static void lcp_init(struct ppp_context *ctx)
 	ppp_fsm_name_set(&ctx->lcp.fsm, ppp_proto2str(PPP_LCP));
 
 	ctx->lcp.my_options.mru = net_if_get_mtu(ctx->iface);
-	ctx->lcp.my_options.async_map = 0xffffffff;
+	ctx->lcp.my_options.async_map = 0;
 
 	ctx->lcp.fsm.my_options.info = lcp_my_options;
 	ctx->lcp.fsm.my_options.data = ctx->lcp.my_options_data;


### PR DESCRIPTION
The L2 PPP driver was not working for any other
Async-Control-Character-Map values than 0xffffffff.

This was caused by two issues:
* modem_ppp.c was expecting CONTROL field to be always escaped.
* lcp.c was decoding async_map values wrongly. Either as 16bit, or raw 32bit, instead of big-endian 32 bit.

Now it should be safe to default my_options.async_map to a zero.

This is related to https://github.com/zephyrproject-rtos/zephyr/pull/105292 where zero is allowed on remote option. This allows the same as my-option.