### PR TITLE
boards: npck3m8k_evb: drop stale kscan-input reference

### DIFF
--- a/boards/nuvoton/npck3m8k_evb/npck3m8k_evb.dts
+++ b/boards/nuvoton/npck3m8k_evb/npck3m8k_evb.dts
@@ -17,7 +17,6 @@
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,flash = &flash0;
-		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	aliases {
@@ -38,9 +37,6 @@
 
 		/* For peci driver sample code */
 		peci-0 = &peci0;
-
-		/* For kscan test suites */
-		kscan0 = &kscan_input;
 	};
 
 	leds-pwm {
@@ -139,8 +135,4 @@
 	row-size = <8>;
 	col-size = <13>;
 	status = "okay";
-
-	kscan_input: kscan-input {
-		compatible = "zephyr,kscan-input";
-	};
 };

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -441,8 +441,6 @@ device.
      - Selects the CRC device used as an accelerator by the CRC subsystem
    * - zephyr,display
      - Sets the default display controller
-   * - zephyr,keyboard-scan
-     - Sets the default keyboard scan controller
    * - zephyr,dtcm
      - Data Tightly Coupled Memory node on some Arm SoCs
    * - zephyr,entropy


### PR DESCRIPTION
The kscan compatibility driver is long gone, this is stale.