### PR TITLE
add tmcm3216 to build_all tests | replace `module-address` with `reg`

### DIFF
--- a/drivers/stepper/adi_tmc/tmcm3216/tmcm3216.c
+++ b/drivers/stepper/adi_tmc/tmcm3216/tmcm3216.c
@@ -141,7 +141,7 @@ static int tmcm3216_init(const struct device *dev)
 	};                                                                                         \
 	static const struct tmcm3216_config tmcm3216_config_##inst = {                             \
 		.rs485 = DEVICE_DT_GET(DT_INST_BUS(inst)),                                         \
-		.rs485_addr = DT_INST_PROP(inst, module_address),                                  \
+		.rs485_addr = DT_INST_REG_ADDR(inst),                                              \
 		.de_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, de_gpios, {0}),                          \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, tmcm3216_init, NULL, &tmcm3216_data_##inst,                    \

--- a/dts/bindings/stepper/adi/adi,tmcm3216.yaml
+++ b/dts/bindings/stepper/adi/adi,tmcm3216.yaml
@@ -10,10 +10,8 @@ compatible: "adi,tmcm3216"
 include: [base.yaml, uart-device.yaml]
 
 properties:
-  module-address:
-    type: int
+  reg:
     required: true
-    description: RS485 module address (1-255)
 
   de-gpios:
     type: phandle-array
@@ -26,23 +24,28 @@ examples:
     &usart2 {
         /* Bus options here, not shown */
 
-        tmcm3216: tmcm3216 {
-            compatible = "adi,tmcm3216";
-            status = "okay";
-            module-address = <1>;
-            de-gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+        adi_tmcm3216 {
+            #address-cells = <1>;
+            #size-cells = <0>;
 
-            stepper_driver_0: stepper-driver {
-                compatible = "adi,tmcm3216-stepper-driver";
+            tmcm3216: tmcm3216@1 {
+                compatible = "adi,tmcm3216";
                 status = "okay";
-                idx = <0>;
-                micro-step-res = <16>;
-            };
+                reg = <0x1>;
+                de-gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
 
-            stepper_ctrl_0: stepper-ctrl {
-                compatible = "adi,tmcm3216-stepper-ctrl";
-                status = "okay";
-                idx = <0>;
+                stepper_driver_0: stepper-driver {
+                    compatible = "adi,tmcm3216-stepper-driver";
+                    status = "okay";
+                    idx = <0>;
+                    micro-step-res = <16>;
+                };
+
+                stepper_ctrl_0: stepper-ctrl {
+                    compatible = "adi,tmcm3216-stepper-ctrl";
+                    status = "okay";
+                    idx = <0>;
+                };
             };
         };
     };

--- a/include/zephyr/drivers/stepper/stepper_tmcm3216.h
+++ b/include/zephyr/drivers/stepper/stepper_tmcm3216.h
@@ -12,7 +12,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_STEPPER_TMCM3216_H_
 
 #include <zephyr/device.h>
-#include <zephyr/drivers/stepper.h>
+#include <zephyr/drivers/stepper/stepper.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/drivers/build_all/stepper/uart.dtsi
+++ b/tests/drivers/build_all/stepper/uart.dtsi
@@ -7,6 +7,8 @@
  **************************************
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 adi_tmc51xx_uart: adi-tmc51xx {
 	compatible = "adi,tmc51xx";
 	status = "okay";
@@ -49,5 +51,30 @@ adi_tmc51xx_uart: adi-tmc51xx {
 		ihold = <1>;
 		irun = <2>;
 		iholddelay = <3>;
+	};
+};
+
+adi_tmcm3216 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	adi_tmcm3216_uart: adi-tmcm3216@1 {
+		compatible = "adi,tmcm3216";
+		status = "okay";
+		reg = <0x1>;
+		de-gpios = <&test_gpio 0x01 GPIO_ACTIVE_HIGH>;
+
+		stepper_driver_0: stepper-driver {
+			compatible = "adi,tmcm3216-stepper-driver";
+			status = "okay";
+			idx = <0>;
+			micro-step-res = <16>;
+		};
+
+		stepper_ctrl_0: stepper-ctrl {
+			compatible = "adi,tmcm3216-stepper-ctrl";
+			status = "okay";
+			idx = <0>;
+		};
 	};
 };


### PR DESCRIPTION
- added tmcm3216 to build_all tests
- minor bug_fix
- replacing `module-address` with `reg`

https://github.com/zephyrproject-rtos/zephyr/blob/ee7e0ba55bd871512bb16611a1c4b4442eb6cd61/dts/bindings/base/base.yaml#L46-L57

Ping @actorreno 
