### PR TITLE
dfu: Add optional custom section size option and optimise empty check

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -141,6 +141,11 @@ New Samples
 Libraries / Subsystems
 **********************
 
+* DFU
+
+  * Added :kconfig:option:`CONFIG_IMG_CUSTOM_SECTOR_SIZE` to allow MCUboot to use a different
+    sector size for reducing the swap-using-offset status area size.
+
 * LoRa / LoRaWAN
 
   * Added a native LoRaWAN backend

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -86,6 +86,18 @@ config IMG_ENABLE_IMAGE_CHECK
 	  Another use is to ensure that firmware upgrade routines from internet
 	  server to flash slot are performing properly.
 
+config IMG_CUSTOM_SECTOR_SIZE
+	int "Sector size for MCUboot images"
+	depends on MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET
+	default 0
+	range 0 $(UINT32_MAX)
+	help
+	  Use this to set a custom sector size for swap-using-offset images to be offset by, a
+	  value of 0 means to use the default sector size of the flash area by querying it.
+	  This should only be manually set by advanced users that are using a different erase
+	  sector size in the MCUboot image for optimisation reasons (e.g. to reduce the size of
+	  the swap status area).
+
 endif # MCUBOOT_IMG_MANAGER
 
 module = IMG_MANAGER

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -263,8 +263,6 @@ size_t boot_get_image_start_offset(uint8_t area_id)
 		 * slot image header
 		 */
 		const struct flash_area *fa;
-		uint32_t num_sectors = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
-		struct flash_sector sector_data;
 		int rc;
 
 		rc = flash_area_open(area_id, &fa);
@@ -274,6 +272,10 @@ size_t boot_get_image_start_offset(uint8_t area_id)
 		}
 
 		if (mcuboot_swap_type_multi(image) != BOOT_SWAP_TYPE_REVERT) {
+#if CONFIG_IMG_CUSTOM_SECTOR_SIZE == 0
+			uint32_t num_sectors = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
+			struct flash_sector sector_data;
+
 			/* For swap using offset mode, the image starts in the second sector of
 			 * the upgrade slot, so apply the offset when this is needed, do this by
 			 * getting information on first sector only, this is expected to return an
@@ -286,6 +288,9 @@ size_t boot_get_image_start_offset(uint8_t area_id)
 			} else {
 				off = sector_data.fs_size;
 			}
+#else
+			off = CONFIG_IMG_CUSTOM_SECTOR_SIZE;
+#endif
 		}
 
 		flash_area_close(fa);

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -198,7 +198,9 @@ int flash_img_init_id(struct flash_img_context *ctx, uint8_t area_id)
 	int rc;
 	const struct device *flash_dev;
 #if defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET)
+#if CONFIG_IMG_CUSTOM_SECTOR_SIZE == 0
 	uint32_t sector_count = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
+#endif
 	struct flash_sector sector_data;
 #endif
 
@@ -214,6 +216,7 @@ int flash_img_init_id(struct flash_img_context *ctx, uint8_t area_id)
 	/* Query size of first sector in flash for upgrade slot, so it can be erased, and begin
 	 * upload started at the second sector
 	 */
+#if CONFIG_IMG_CUSTOM_SECTOR_SIZE == 0
 	rc = flash_area_sectors((const struct flash_area *)ctx->flash_area, &sector_count,
 				&sector_data);
 
@@ -226,6 +229,9 @@ int flash_img_init_id(struct flash_img_context *ctx, uint8_t area_id)
 		ctx->flash_area = NULL;
 		return -ENOENT;
 	}
+#else
+	sector_data.fs_size = CONFIG_IMG_CUSTOM_SECTOR_SIZE;
+#endif
 
 	if (!flash_check_erased((const struct flash_area *)ctx->flash_area)) {
 		/* Flash is not empty, therefore flatten/erase the area to prevent issues when

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -148,29 +148,28 @@ size_t flash_img_bytes_written(struct flash_img_context *ctx)
  * Determines if the specified area of flash is completely unwritten.
  *
  * @param	fa	pointer to flash area to scan
+ * @param	len	length of area (starting from beginning) of flash area to scan (must be
+ *			divisible by 4)
  *
  * @return	0	when not empty, 1 when empty, negative errno code on error.
  */
-static int flash_check_erased(const struct flash_area *fa)
+static int flash_check_erased(const struct flash_area *fa, off_t len)
 {
 	uint32_t data[FLASH_CHECK_ERASED_BUFFER_SIZE];
-	off_t addr;
-	off_t end;
 	int bytes_to_read;
 	int rc;
 	int i;
 	uint8_t erased_val;
 	uint32_t erased_val_32;
 
-	assert(fa->fa_size % sizeof(erased_val_32) == 0);
+	assert(len % sizeof(erased_val_32) == 0);
 
 	erased_val = flash_area_erased_val(fa);
 	erased_val_32 = ERASED_VAL_32(erased_val);
 
-	end = fa->fa_size;
-	for (addr = 0; addr < end; addr += sizeof(data)) {
-		if (end - addr < sizeof(data)) {
-			bytes_to_read = end - addr;
+	for (off_t addr = 0; addr < len; addr += sizeof(data)) {
+		if (len - addr < sizeof(data)) {
+			bytes_to_read = len - addr;
 		} else {
 			bytes_to_read = sizeof(data);
 		}
@@ -233,7 +232,8 @@ int flash_img_init_id(struct flash_img_context *ctx, uint8_t area_id)
 	sector_data.fs_size = CONFIG_IMG_CUSTOM_SECTOR_SIZE;
 #endif
 
-	if (!flash_check_erased((const struct flash_area *)ctx->flash_area)) {
+	if (!flash_check_erased((const struct flash_area *)ctx->flash_area,
+				(off_t)sector_data.fs_size)) {
 		/* Flash is not empty, therefore flatten/erase the area to prevent issues when
 		 * the firmware update process begins
 		 */


### PR DESCRIPTION
    Adds a new Kconfig option, CONFIG_IMG_CUSTOM_SECTOR_SIZE, which can
    be used to force setting what the sector size is that MCUboot is
    using when configured in swap using offset mode, this allows for
    using different page sizes in the application vs MCUboot (in order
    to increase efficiency of MCUboot and reducing the swap status size)


    Optimises the erase check when using swap-using-offset to only erase
    the first sector if the first sector has data, rather than if any of
    the image has data
