### PR TITLE
bindings: tca9544a: drop child compatible

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
@@ -77,35 +77,30 @@
 		status = "disabled";
 
 		mux_i2c@0 {
-			compatible = "ti,tca9548a-channel";
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@1 {
-			compatible = "ti,tca9548a-channel";
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@2 {
-			compatible = "ti,tca9548a-channel";
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@3 {
-			compatible = "ti,tca9548a-channel";
 			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@4 {
-			compatible = "ti,tca9548a-channel";
 			reg = <4>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -121,21 +116,18 @@
 		};
 
 		mux_i2c@5 {
-			compatible = "ti,tca9548a-channel";
 			reg = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@6 {
-			compatible = "ti,tca9548a-channel";
 			reg = <6>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@7 {
-			compatible = "ti,tca9548a-channel";
 			reg = <7>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -156,28 +148,24 @@
 		status = "disabled";
 
 		mux_i2c@0 {
-			compatible = "ti,tca9544a-channel";
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@1 {
-			compatible = "ti,tca9544a-channel";
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@2 {
-			compatible = "ti,tca9544a-channel";
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		mux_i2c@3 {
-			compatible = "ti,tca9544a-channel";
 			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/i2c/ti,tca9544a.yaml
+++ b/dts/bindings/i2c/ti,tca9544a.yaml
@@ -5,6 +5,3 @@ description: Texas Instruments TCA9544A
 compatible: "ti,tca9544a"
 
 include: ti,tca954x-base.yaml
-
-child-binding:
-  compatible: "ti,tca9544a-channel"

--- a/dts/bindings/i2c/ti,tca9546a.yaml
+++ b/dts/bindings/i2c/ti,tca9546a.yaml
@@ -5,6 +5,3 @@ description: Texas Instruments TCA9546A
 compatible: "ti,tca9546a"
 
 include: ti,tca954x-base.yaml
-
-child-binding:
-  compatible: "ti,tca9546a-channel"

--- a/dts/bindings/i2c/ti,tca9548a.yaml
+++ b/dts/bindings/i2c/ti,tca9548a.yaml
@@ -5,6 +5,3 @@ description: Texas Instruments TCA9548A
 compatible: "ti,tca9548a"
 
 include: ti,tca954x-base.yaml
-
-child-binding:
-  compatible: "ti,tca9548a-channel"

--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -27,8 +27,19 @@ properties:
 
 child-binding:
   description: TCA954x I2C switch channel node
-  include: [i2c-controller.yaml]
+  bus: i2c
   on-bus: i2c
+  properties:
+    "#address-cells":
+      type: int
+      required: true
+    "#size-cells":
+      type: int
+      required: true
+    reg:
+      type: array
+      required: true
+
 
 examples:
   - |
@@ -42,7 +53,6 @@ examples:
         reset-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;
 
         mux_i2c@0 {
-            compatible = "ti,tca9546a-channel";
             reg = <0>;
             #address-cells = <1>;
             #size-cells = <0>;
@@ -54,7 +64,6 @@ examples:
         };
 
         mux_i2c@1 {
-            compatible = "ti,tca9546a-channel";
             reg = <1>;
             #address-cells = <1>;
             #size-cells = <0>;

--- a/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
@@ -15,14 +15,12 @@
 		#size-cells = <0>;
 
 		ch0: mux_i2c@0 {
-			compatible = "ti,tca9546a-channel";
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
 
 		ch1: mux_i2c@1 {
-			compatible = "ti,tca9546a-channel";
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
There's no need for compatible on child nodes, they just confuse the documentation, drop them.