### PR TITLE
boards: teensy4: remove duplicate edma0 node

### DIFF
--- a/boards/pjrc/teensy4/teensy40.dts
+++ b/boards/pjrc/teensy4/teensy40.dts
@@ -72,10 +72,6 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-&edma0 {
-	status = "okay";
-};
-
 &flexcan1 {
 	pinctrl-0 = <&pinmux_flexcan1>;
 	pinctrl-names = "default";


### PR DESCRIPTION
The teensy40 DTS defined the edma0 node twice with identical status properties.