### PR TITLE
net: ocpp: Protect against static analysis issue generation

### DIFF
--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -64,8 +64,8 @@ static int frame_rpc_call_req(char *rpcbuf, int len, int pdu,
 
 	/* Encode OCPP Call Request msg: [2,"<UID>","<Action>",<Payload>] */
 	ret = snprintk(rpcbuf, len,
-		       "[2,\"%s\",\"%s\",%s]",
-		       uid, action, pdumsg);
+		       "[%c,\"%s\",\"%s\",%s]",
+		       OCPP_WAMP_RPC_REQ, uid, action, pdumsg);
 
 	if (ret < 0 || ret >= len) {
 		return -ENOMEM;
@@ -80,7 +80,9 @@ static int frame_rpc_call_res(char *rpcbuf, int len,
 	int ret;
 
 	/* Encode OCPP Call Result msg: [3,"<UID>",<Payload>] */
-	ret = snprintk(rpcbuf, len, "[3,\"%s\",%s]", uid, pdumsg);
+	ret = snprintk(rpcbuf, len,
+		       "[%c,\"%s\",%s]",
+		       OCPP_WAMP_RPC_RESP, uid, pdumsg);
 
 	if (ret < 0 || ret >= len) {
 		return -ENOMEM;

--- a/subsys/net/lib/ocpp/ocpp_wamp_rpc.c
+++ b/subsys/net/lib/ocpp/ocpp_wamp_rpc.c
@@ -18,6 +18,13 @@ int ocpp_send_to_server(struct ocpp_wamp_rpc_msg *snd, k_timeout_t timeout)
 
 	switch (snd->msg[OCPP_WAMP_RPC_TYPE_IDX]) {
 	case OCPP_WAMP_RPC_REQ:
+		/* To make sure static analysis won't generate false positive
+		 * test to ensure sndlock and rspsig has been initialized by the
+		 * calling functions.
+		 */
+		if (snd->sndlock == NULL || snd->rspsig == NULL) {
+			return -EINVAL;
+		}
 		/* ocpp spec - allow only one active call at a time
 		 * release lock on response received from CS or timeout
 		 */

--- a/tests/net/lib/ocpp/src/main.c
+++ b/tests/net/lib/ocpp/src/main.c
@@ -26,7 +26,7 @@ static void test_ocpp_charge_cycle(ocpp_session_handle_t hndl)
 			break;
 		}
 	}
-	zassert_equal(ret, 0, "CP authorize fail %d");
+	zassert_equal(ret, 0, "CP authorize fail %d", ret);
 	zassert_equal(status, OCPP_AUTH_ACCEPTED, "idtag not authorized");
 
 	ret = ocpp_start_transaction(hndl, sys_rand32_get(), 1, timeout_ms);


### PR DESCRIPTION
Static analysis has a difficult time tracing whether a call to
ocpp_send_to_server() needs to initialize sndlock and rspsig because
the message type is set very much earlier in the program logic flow.
Note that coverity is creating a single issue for sndlock and for rspsig
in each function that calls ocpp_send_to_server() without initializing
them.

Adding a NULL test will prevent future static analysis false positives.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100026
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100025
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100024
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100017
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100015
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100013
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100011
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100010
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100008
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100006

Signed-off-by: David J. Leach, Jr. <tasmar@gmail.com>