### PR TITLE
libc: :minimal: strtol: avoid assigning LONG_MIN to unsigned accumulator

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -115,7 +115,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	}
 
 	if (any < 0) {
-		acc = neg ? LONG_MIN : LONG_MAX;
+		acc = neg ? (unsigned long)LONG_MAX + 1UL : (unsigned long)LONG_MAX;
 		errno = ERANGE;
 	} else if (neg != 0) {
 		acc = -acc;


### PR DESCRIPTION
Use the unsigned magnitude for the negative overflow case instead of assigning LONG_MIN directly to the unsigned long accumulator. This avoids signed-to-unsigned overflow while preserving strtol() overflow behavior.

Fixes #84801