### PR TITLE
board: microchip: add SHA support for sama7d65-curiosity board

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - crypto
   - eeprom
   - i2c
   - pinctrl

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -83,6 +83,13 @@
 			reg = <0xe001d900 0x8>;
 		};
 
+		sha: sha@e1604000 {
+			compatible = "microchip,sha-g1-crypto";
+			reg = <0xe1604000 0x100>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 78>;
+			status = "disabled";
+		};
+
 		pit64b0: timer@e1800000 {
 			compatible = "microchip,sam-pit64b", "microchip,sam9x60-pit64b";
 			reg = <0xe1800000 0x4000>;

--- a/dts/bindings/crypto/microchip,sha-g1-crypto.yaml
+++ b/dts/bindings/crypto/microchip,sha-g1-crypto.yaml
@@ -1,9 +1,15 @@
-# Copyright (C) 2025 Microchip Technology Inc. and its subsidiaries
+# Copyright (C) 2025-2026 Microchip Technology Inc. and its subsidiaries
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Microchip SAM Secure Hash Algorithm (SHA).
+title: Microchip G1 SHA Controller Driver
+
+description: |
+  Microchip SAM Secure Hash Algorithm (SHA).
+
+  Group G1 SHA driver supports following hardware peripherals:
+    - module name="SHA" id="6156" version="700"
 
 compatible: "microchip,sha-g1-crypto"
 

--- a/soc/microchip/sam/sama7/sama7d6/soc.c
+++ b/soc/microchip/sam/sama7/sama7d6/soc.c
@@ -35,6 +35,10 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("sckc", SCKC_BASE_ADDRESS, 0x4,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(microchip_sha_g1_crypto),
+		   (MMU_REGION_FLAT_ENTRY("sha", SHA_BASE_ADDRESS, 0x100,
+					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/tests/crypto/crypto_hash/socs/sama7d65.overlay
+++ b/tests/crypto/crypto_hash/socs/sama7d65.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2026 Microchip Technology Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sha {
+	status = "okay";
+};

--- a/tests/crypto/crypto_hash/testcase.yaml
+++ b/tests/crypto/crypto_hash/testcase.yaml
@@ -17,6 +17,7 @@ tests:
       - esp32c3_devkitc
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
+      - sama7d65_curiosity
       - sama7g54_ek
       - nucleo_h753zi
       - sf32lb52_devkit_lcd


### PR DESCRIPTION
changes in this PR includes:
- update information for `microchip,sha-g1-crypto.yaml`
- add SHA nodes for sama7d6 SoCs
- configure MMU settings for SHA memory region
- allow testing `tests/crypto/crypto_hash` with sama7d65-curiosity board