### PR TITLE
MAINTAINERS: Apply to become PM subsystem collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4472,6 +4472,7 @@ Power management:
     - tmleman
     - JordanYates
     - ZhaoxiangJin
+    - yongxu-wang15
   files:
     - include/zephyr/pm/
     - samples/subsys/pm/


### PR DESCRIPTION
My recent work has focused mainly on Power Management for NXP i.MX MPU platforms. I have been contributing in areas such as PM subsystem, SoC-level PM enablement,
driver PM support, and SCMI power related work.
I also have some practical experience with Power Management on multi-core SoCs, especially around system-level PM flows and SoC integration.

Through this work, I have gained a deeper understanding of Zephyr PM from subsystem level down to SoC and driver integration. I hope to contribute not only by submitting patches, but also by helping maintainer to reviews and support ongoing PM maintenance.

My work about PM link:

PM subsystem related PR:
[PM: add pm cpu shell interface by yongxu-wang15 · Pull Request #94498 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/94498)
[pm: device: clarify TURN_ON/TURN_OFF action semantics by yongxu-wang15 · Pull Request #105257 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/105257)
[pm: policy: fix duplicated space in policy by yongxu-wang15 · Pull Request #105019 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/105019)
[pm: device_system_managed: add warning log for resume failures by yongxu-wang15 · Pull Request #105259 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/105259)
[pm: device: replace magic number with named constant by yongxu-wang15 · Pull Request #105260 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/105260)

SOC level PR about PM:
[NXP imx95 add basic pm support by yongxu-wang15 · Pull Request #91410 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/91410)
[NXP support basic pm imx943 by yongxu-wang15 · Pull Request #96549 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/96549)
[soc: nxp: imx943: Fix potential out-of-bounds access in pm_mcore loop by yongxu-wang15 · Pull Request #97239 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/97239)
[NXP imx943 support s2ram pm level by yongxu-wang15 · Pull Request #98304 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/98304)

Driver level PR about PM:
[Add arm scmi power domain driver by yongxu-wang15 · Pull Request #102370 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/102370)
[NXP support pm device runtime for lpi2c on imx943 by yongxu-wang15 · Pull Request #101490 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/101490)
[NXP support netc driver suspend pm by yongxu-wang15 · Pull Request #102369 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/102369)
[NXP support lptmr tickless function by yongxu-wang15 · Pull Request #95143 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/95143)
[drivers: firmware: scmi: Introduce basic system power protocol by yongxu-wang15 · Pull Request #99037 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/99037)
[SCMI add power on off states in power protocol by yongxu-wang15 · Pull Request #95840 · zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/95840)