### PR TITLE
drivers: wifi: winc1500: fix out-of-bounds write in winc1500_get

### DIFF
--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -305,8 +305,8 @@ static int winc1500_get(net_sa_family_t family,
 	 * for now.
 	 */
 	sock = winc1500_socket(2, type, 0);
-	if (sock < 0) {
-		LOG_ERR("socket error!");
+	if (sock < 0 || sock >= CONFIG_WIFI_WINC1500_OFFLOAD_MAX_SOCKETS) {
+		LOG_ERR("socket error or out of bounds: %d", sock);
 		return -1;
 	}
 


### PR DESCRIPTION
The winc1500_socket function returns a socket index that was only being checked for negative error values. Coverity identified that the index was not being verified against the upper bound of the socket_data array, potentially leading to an out-of-bounds write.

Added an explicit check to ensure the socket index is within the valid range [0, CONFIG_WIFI_WINC1500_OFFLOAD_MAX_SOCKETS].

Fixes #84708