### PR TITLE
drivers: modem: st87mxx: pass address of mdm_rssi to RSSI callback

### DIFF
--- a/drivers/modem/st87mxx.c
+++ b/drivers/modem/st87mxx.c
@@ -1873,7 +1873,7 @@ int st87mxx_getrssi(st87mxx_get_rssi_callback_t *get_rssi_callback_func)
 
 	/* #STENG URC received */
 	if (app_srv_data.rssi_data.get_rssi_callback_func != NULL) {
-		app_srv_data.rssi_data.get_rssi_callback_func((const char * const)mdata.mdm_rssi);
+		app_srv_data.rssi_data.get_rssi_callback_func((const char * const)&mdata.mdm_rssi);
 	}
 
 end:


### PR DESCRIPTION
Pass &mdata.mdm_rssi instead of casting the integer value directly
to a pointer, fixing a -Wint-to-pointer-cast compiler warning.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
