### PR TITLE
west.yml: hal_realtek: add ameba scripts requirements.txt

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: 5d482b1086d551f07ae331caae7f2b05029068fe
+      revision: 22d60ef726d1da464959aee0f57b04b820c69764
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
This PR updates the `hal_realtek` module revision and integrates Python
dependencies for Ameba scripts into Zephyr's package management.

Changes in the `hal_realtek` module:
- Add `ameba/scripts/requirements.txt` with Python dependencies required by
  Ameba image / signing tools.
- Extend `zephyr/module.yml` with a `package-managers.pip.requirement-files`
  entry pointing to `ameba/scripts/requirements.txt`.

With this change, Ameba-related Python dependencies can be installed via:

```bash
west packages -m hal_realtek pip --install
west packages pip --install
