### PR TITLE
Add buffer address alignment for MCUX boards that use ELCDIF

### DIFF
--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -92,6 +92,7 @@ config LV_Z_FULL_REFRESH
 config LV_Z_VDB_ALIGN
 	int "Rending buffer alignment"
 	default 4
+	default 8 if DISPLAY_MCUX_ELCDIF
 	depends on LV_Z_BUFFER_ALLOC_STATIC
 	help
 	  Rendering buffer alignment. Depending on chosen color depth,

--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -10,6 +10,7 @@ source "Kconfig.zephyr"
 config SAMPLE_BUFFER_ADDR_ALIGN
 	int "The display buffer address alignment"
 	default 8 if 64BIT
+	default 8 if DISPLAY_MCUX_ELCDIF
 	default 4
 
 config SAMPLE_PITCH_ALIGN


### PR DESCRIPTION
 Set buffer address alignment to 8 byte for MCUX boards that use ELCDIF, to meet MCUX ELCDIF hardware requirement. This is to fix the issue https://github.com/zephyrproject-rtos/zephyr/issues/103818