### PR TITLE
samples: drivers: rtc: allow compile-testing on sama7g54_ek and sama7d65_curiosity boards

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -22,6 +22,7 @@
 	aliases {
 		led0 = &led_green;
 		pwm-led0 = &pwm_led_green;
+		rtc = &rtc;
 		sw0 = &button_user;
 		sdhc0 = &sdmmc0;
 		sdhc1 = &sdmmc1;

--- a/samples/drivers/rtc/sample.yaml
+++ b/samples/drivers/rtc/sample.yaml
@@ -16,6 +16,8 @@ tests:
       - stm32f3_disco
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
       - mimxrt700_evk/mimxrt798s/cm33_cpu1
+      - sama7d65_curiosity
+      - sama7g54_ek
     integration_platforms:
       - stm32f3_disco
     depends_on:


### PR DESCRIPTION
This commit allows compile-testing `samples/drivers/rtc` on `sama7g54_ek` and `sama7d65_curiosity` boards.