### PR TITLE
kernel: bugfix: fix incorrect uptime calculation in tickless SMP env

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -105,7 +105,10 @@ static uint64_t mtime(void)
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
-
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+	k_spinlock_key_t g_key = k_spin_lock(get_update_time_lock());
+	sys_dlist_t undo_job = SYS_DLIST_STATIC_INIT(&undo_job);
+#endif
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	uint64_t now = mtime();
@@ -123,7 +126,13 @@ static void timer_isr(const void *arg)
 	}
 
 	k_spin_unlock(&lock, key);
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+	sys_clock_announce(dticks, &undo_job);
+	k_spin_unlock(get_update_time_lock(), g_key);
+	sys_clock_announce_undojob_withoutlock(&undo_job);
+#else
 	sys_clock_announce(dticks);
+#endif
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <zephyr/types.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,7 +101,34 @@ void sys_clock_idle_exit(void);
  *
  * @param ticks Elapsed time, in ticks
  */
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+void sys_clock_announce(int32_t ticks, sys_dlist_t *undo_job);
+#else
 void sys_clock_announce(int32_t ticks);
+#endif
+
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+/**
+ * @brief Announce time progress to the kernel
+ *
+ * sys_clock_announce() will save timeouts job to undo_job,
+ * and call this API to announce the time progress to the kernel
+ * without lock.beaceuse the timeouts job list callback will call
+ * api which will get timeout_lock or timer driver lock,
+ * it will cause deadlock.
+ *
+ * @param undo_job List of timeouts to announce without lock
+ */
+void sys_clock_announce_undojob_withoutlock(sys_dlist_t *undo_job);
+
+/**
+ * @brief get update_time_lock lock
+ *
+ * update_time_lock is used to protect sys_clock_tick_get
+ *
+ */
+struct k_spinlock *get_update_time_lock(void);
+#endif
 
 /**
  * @brief Ticks elapsed since last sys_clock_announce() call

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -23,6 +23,10 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
  */
 static struct k_spinlock timeout_lock;
 
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+struct k_spinlock update_time_lock;
+#endif
+
 /* Ticks left to process in the currently-executing sys_clock_announce() */
 static int announce_remaining;
 
@@ -218,7 +222,11 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+void sys_clock_announce(int32_t ticks, sys_dlist_t *undo_job)
+#else
 void sys_clock_announce(int32_t ticks)
+#endif
 {
 	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
 
@@ -246,10 +254,15 @@ void sys_clock_announce(int32_t ticks)
 		curr_tick += dt;
 		t->dticks = 0;
 		remove_timeout(t);
-
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+		if (undo_job) {
+			sys_dlist_append(undo_job, &t->node);
+		}
+#else
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
 		key = k_spin_lock(&timeout_lock);
+#endif
 		announce_remaining -= dt;
 	}
 
@@ -269,13 +282,42 @@ void sys_clock_announce(int32_t ticks)
 #endif /* CONFIG_TIMESLICING */
 }
 
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+struct k_spinlock *get_update_time_lock(void)
+{
+	return &update_time_lock;
+}
+
+void sys_clock_announce_undojob_withoutlock(sys_dlist_t *undo_job)
+{
+	struct _timeout *t;
+	sys_dnode_t *m;
+
+	for (m = sys_dlist_peek_head(undo_job); m != NULL; m = sys_dlist_peek_head(undo_job)) {
+		t = CONTAINER_OF(m, struct _timeout, node);
+		sys_dlist_remove(m);
+		/* fn maybe call timer expire function and insert node
+		 * to timeoutlist, so we need to remove node
+		 * from undo_job before call fn.
+		 */
+		t->fn(t);
+	}
+}
+#endif
+
 int64_t sys_clock_tick_get(void)
 {
 	uint64_t t = 0U;
 
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+	k_spinlock_key_t g_key = k_spin_lock(&update_time_lock);
+#endif
 	K_SPINLOCK(&timeout_lock) {
 		t = curr_tick + elapsed();
 	}
+#if defined(CONFIG_SMP) && defined(CONFIG_TICKLESS_KERNEL)
+	k_spin_unlock(&update_time_lock, g_key);
+#endif
 	return t;
 }
 


### PR DESCRIPTION

```
In tickless + SMP scenarios, uptime calculation could return wrong values:
- One CPU core reads cur_tick and calculates elapsed time to get systick (systick = cur_tick + elapsed)
- Another CPU core runs timer ISR and updates cur_tick/elapsed concurrently
- cur_tick and elapsed were protected by separate spinlocks, leading to unsynchronized values between cur_tick and elapsed during concurrent access

Fix this issue by:
1. Introducing a single unified spinlock to protect both cur_tick and elapsed, ensuring their values are always consistent during uptime calculation
2. Moving undo timer job list processing to an unlocked context to avoid potential deadlocks caused by the new unified lock

```
Hi maintainers,
I just submitted this issue https://github.com/zephyrproject-rtos/zephyr/issues/105339

If this approach is approved, the same modification needs to be applied to other timer drivers in the codebase to ensure consistency.

Looking forward to your feedback!