### PR TITLE
Add KSZ9131 RGMII DLL delay support

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -212,6 +212,7 @@
 		status = "okay";
 		reg = <7>;
 		int-gpios = <&pioa 31 GPIO_ACTIVE_LOW>;
+		microchip,rgmii-delay = "id";
 	};
 };
 

--- a/drivers/ethernet/phy/phy_microchip_ksz9131.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz9131.c
@@ -20,10 +20,29 @@ LOG_MODULE_REGISTER(phy_mchp_ksz9131, CONFIG_PHY_LOG_LEVEL);
 
 #include "phy_mii.h"
 
+/* KSZ9131 DLL control registers are accessed through Clause-22 indirect
+ * MMD access (device 2, registers 76 and 77). Bit 12 bypasses the DLL.
+ */
+#define KSZ9131_MMD_DEV_COMMON_CTRL 2
+#define KSZ9131_RXC_DLL_CTRL        76
+#define KSZ9131_TXC_DLL_CTRL        77
+#define KSZ9131_DLL_ENABLE_DELAY    0
+#define KSZ9131_DLL_DISABLE_DELAY   BIT(12)
+#define KSZ9131_DLL_DISABLE_MASK    BIT(12)
+
+enum ksz9131_rgmii_delay {
+	RGMII_NONE,
+	RGMII_ID,
+	RGMII_RX_ID,
+	RGMII_TX_ID,
+	RGMII_DELAY_UNSPEC
+};
+
 struct mchp_ksz9131_config {
 	uint8_t phy_addr;
 	const struct device *const mdio;
 	enum phy_link_speed default_speeds;
+	enum ksz9131_rgmii_delay rgmii_delay_type;
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
 	const struct gpio_dt_spec interrupt_gpio;
 #endif
@@ -539,6 +558,105 @@ done:
 }
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 
+static int ksz9131_mmd_select(const struct device *dev, uint8_t devad, uint16_t reg)
+{
+	const struct mchp_ksz9131_config *cfg = dev->config;
+	int ret;
+
+	ret = mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_ACR, devad);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, reg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_ACR, 0x4000U | devad);
+}
+
+static int ksz9131_mmd_read_c22(const struct device *dev, uint8_t devad, uint16_t reg,
+				uint16_t *val)
+{
+	const struct mchp_ksz9131_config *cfg = dev->config;
+	int ret;
+
+	ret = ksz9131_mmd_select(dev, devad, reg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return mdio_read(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+}
+
+static int ksz9131_mmd_write_c22(const struct device *dev, uint8_t devad, uint16_t reg,
+				 uint16_t val)
+{
+	const struct mchp_ksz9131_config *cfg = dev->config;
+	int ret;
+
+	ret = ksz9131_mmd_select(dev, devad, reg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+}
+
+static int ksz9131_mmd_modify_c22(const struct device *dev, uint8_t devad, uint16_t reg,
+				  uint16_t mask, uint16_t val)
+{
+	uint16_t tmp;
+	int ret;
+
+	ret = ksz9131_mmd_read_c22(dev, devad, reg, &tmp);
+	if (ret < 0) {
+		return ret;
+	}
+
+	tmp = (tmp & ~mask) | (val & mask);
+
+	return ksz9131_mmd_write_c22(dev, devad, reg, tmp);
+}
+
+static int ksz9131_enable_dll_delays(const struct device *dev)
+{
+	const struct mchp_ksz9131_config *const cfg = dev->config;
+	int ret = 0;
+	uint16_t rxcdll_val, txcdll_val;
+
+	switch (cfg->rgmii_delay_type) {
+	case RGMII_NONE:
+		rxcdll_val = KSZ9131_DLL_DISABLE_DELAY;
+		txcdll_val = KSZ9131_DLL_DISABLE_DELAY;
+		break;
+	case RGMII_ID:
+		rxcdll_val = KSZ9131_DLL_ENABLE_DELAY;
+		txcdll_val = KSZ9131_DLL_ENABLE_DELAY;
+		break;
+	case RGMII_RX_ID:
+		rxcdll_val = KSZ9131_DLL_ENABLE_DELAY;
+		txcdll_val = KSZ9131_DLL_DISABLE_DELAY;
+		break;
+	case RGMII_TX_ID:
+		rxcdll_val = KSZ9131_DLL_DISABLE_DELAY;
+		txcdll_val = KSZ9131_DLL_ENABLE_DELAY;
+		break;
+	default:
+		return 0;
+	}
+	ret = ksz9131_mmd_modify_c22(dev, KSZ9131_MMD_DEV_COMMON_CTRL, KSZ9131_RXC_DLL_CTRL,
+				     KSZ9131_DLL_DISABLE_MASK, rxcdll_val);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = ksz9131_mmd_modify_c22(dev, KSZ9131_MMD_DEV_COMMON_CTRL, KSZ9131_TXC_DLL_CTRL,
+				     KSZ9131_DLL_DISABLE_MASK, txcdll_val);
+
+	return ret;
+}
+
 static int phy_mchp_ksz9131_init(const struct device *dev)
 {
 	const struct mchp_ksz9131_config *const cfg = dev->config;
@@ -559,7 +677,11 @@ static int phy_mchp_ksz9131_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-
+	ret = ksz9131_enable_dll_delays(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable KSZ9131 DLL delays");
+		return ret;
+	}
 	ret = ksz9131_init_int_gpios(dev);
 	if (ret < 0) {
 		return ret;
@@ -591,6 +713,8 @@ static DEVICE_API(ethphy, mchp_ksz9131_phy_api) = {
 		.phy_addr = DT_INST_REG_ADDR(n),				\
 		.mdio = DEVICE_DT_GET(DT_INST_BUS(n)),				\
 		.default_speeds = PHY_INST_GENERATE_DEFAULT_SPEEDS(n),		\
+		.rgmii_delay_type =		\
+			DT_INST_ENUM_IDX_OR(n, microchip_rgmii_delay, RGMII_DELAY_UNSPEC), \
 		INTERRUPT_GPIO(n)						\
 	};									\
 										\

--- a/dts/bindings/ethernet/phy/microchip,ksz9131.yaml
+++ b/dts/bindings/ethernet/phy/microchip,ksz9131.yaml
@@ -17,3 +17,20 @@ properties:
   default-speeds:
     default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
               "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]
+  microchip,rgmii-delay:
+    type: string
+    description: |
+      Configure KSZ9131 internal RGMII clock delay mode.
+
+      This property is only applicable when the PHY is connected
+      using an RGMII interface.
+
+      - "none": no internal delay
+      - "id": enable RX and TX delay
+      - "rxid": enable RX delay only
+      - "txid": enable TX delay only
+    enum:
+      - "none"
+      - "id"
+      - "rxid"
+      - "txid"


### PR DESCRIPTION

Add support for configuring the internal RGMII DLL delays of the Microchip KSZ9131 PHY.
A new device tree property `microchip,rgmii-delay` is introduced to select the desired delay mode:
  - none
  - id
  - rxid
  - txid

This is required for reliable gigabit operation when the PHY is connected using an RGMII interface.

Tested on: SAMA7G54_EK