### PR TITLE
samples: drivers: watchdog: Fix Twister execution on Nordic targets

### DIFF
--- a/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l10_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l10_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuflpr.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15_dvk_nrf54l15_cpuflpr_xip.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuflpr.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/watchdog/boards/bl54l15u_dvk_nrf54l15_cpuflpr_xip.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt010 {
+watchdog0: &wdt010 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/nrf9280pdk_nrf9280_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf9280pdk_nrf9280_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt010 {
+watchdog0: &wdt010 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/ophelia4ev_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/ophelia4ev_nrf54l15_cpuflpr.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuflpr.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/watchdog/boards/raytac_an54lq_db_15_nrf54l15_cpuflpr_xip.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/xiao_nrf54l15_nrf54l15_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/boards/xiao_nrf54l15_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/xiao_nrf54l15_nrf54l15_cpuflpr.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&wdt31 {
+watchdog0: &wdt31 {
 	status = "okay";
 };


### PR DESCRIPTION
Fix execution of the watchdog sample under Twister.
sample.yaml contains filter `dt_nodelabel_enabled("watchdog0")`.
Add definition of label `watchdog0` to DTS overlays for Nordic targets.

Without this change, Twister skips this sample:
```
10:32:43  INFO    - 1/2 nrf54lm20dk/nrf54lm20b/cpuapp samples/drivers/watchdog/sample.drivers.watchdog FILTERED (runtime filter)
10:32:43  INFO    - 2/2 nrf54lm20dk/nrf54lm20a/cpuapp samples/drivers/watchdog/sample.drivers.watchdog FILTERED (runtime filter)
```