### PR TITLE
drivers: spi: nrfx_spis: Add missing pinctrl initial stage

### DIFF
--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -399,6 +399,11 @@ static int spi_nrfx_init(const struct device *dev)
 	struct spi_nrfx_data *dev_data = dev->data;
 	int err;
 
+	/* Apply sleep state by default.
+	 * If PM is disabled, the default state will be applied in pm_device_driver_init.
+	 */
+	(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
+
 	/* This sets only default values of mode and bit order. The ones to be
 	 * actually used are set in configure() when a transfer is prepared.
 	 */


### PR DESCRIPTION
Driver initialization is expected to keep the driver in the suspended stage before calling pm_device_driver_init. It means that initialization should set pinctrl SLEEP stage. Nordic SPIS driver was not doing that. If device runtime PM was enabled it resulted in pins being in the default state when it was expected that they are in the sleep state.