### PR TITLE
Fix missing dependency for HTTP Websocket server

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -178,6 +178,7 @@ config HTTP_SERVER_CLIENT_INACTIVITY_TIMEOUT
 
 config HTTP_SERVER_WEBSOCKET
 	bool "Allow upgrading to Websocket connection"
+	select PSA_WANT_ALG_SHA_1
 	select WEBSOCKET_CLIENT
 	select WEBSOCKET
 	help

--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -45,6 +45,7 @@ int handle_http1_to_websocket_upgrade(struct http_client_ctx *client)
 	size_t key_len;
 	size_t olen;
 	int ret;
+	psa_status_t psa_status;
 
 	key_len = MIN(sizeof(key_accept) - 1, sizeof(client->ws_sec_key));
 	strncpy(key_accept, client->ws_sec_key, key_len);
@@ -53,8 +54,13 @@ int handle_http1_to_websocket_upgrade(struct http_client_ctx *client)
 	olen = MIN(sizeof(key_accept) - 1 - key_len, sizeof(WS_MAGIC) - 1);
 	memcpy(key_accept + key_len, WS_MAGIC, olen);
 
-	psa_hash_compute(PSA_ALG_SHA_1, key_accept, olen + key_len,
+	psa_status = psa_hash_compute(PSA_ALG_SHA_1, key_accept, olen + key_len,
 			 accept, sizeof(accept), &accept_len);
+	if (psa_status != PSA_SUCCESS) {
+		NET_DBG("Failed to compute hash for websocket key (%d)", psa_status);
+		ret = -EIO;
+		goto error;
+	}
 
 	ret = base64_encode(tmp, sizeof(tmp) - 1, &olen, accept, sizeof(accept));
 	if (ret) {


### PR DESCRIPTION
This PR adds the missing Kconfig symbol dependency for the PSA algorithm SHA1 which is needed for the computation of the `Sec-Websocket-Accept` response header.

This is how the `Sec-Websocket-Accept` response header is computed: 
 - concatenate the value of the request header `Sec-Websocket-Key` with GUID "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 - compute the SHA1
 - encode with base64

It also adds a check that the algorithm was successful and return an error if not. Otherwise it was failing silently and returned an incorrect response header.