### PR TITLE
drivers: input: nunchuk: Added support for acceleration readings

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -240,6 +240,9 @@ Input
   * ``CONFIG_INPUT_CST8XX_PERIOD`` → :kconfig:option:`CONFIG_INPUT_CST8XX_PERIOD_MS`
   * ``CONFIG_INPUT_FT6146_PERIOD`` → :kconfig:option:`CONFIG_INPUT_FT6146_PERIOD_MS`
 
+  * Nunchuk driver wronlgy reported ``INPUT_KEY_Z``, respective ``INPUT_KEY_C`` in button events. This
+    has been fixed and ``INPUT_BTN_Z``, respective ``INPUT_BTN_C`` is used now.
+
 Interrupt Controllers
 =====================
 

--- a/drivers/input/Kconfig.nunchuk
+++ b/drivers/input/Kconfig.nunchuk
@@ -7,4 +7,10 @@ config INPUT_NUNCHUK
 	depends on DT_HAS_NINTENDO_NUNCHUK_ENABLED
 	select I2C
 	help
-	  This option enable the driver for the Nintendo Nunchuk joystick.
+	  This option enables the driver for the Nintendo Nunchuk joystick.
+
+config INPUT_NUNCHUK_ACCELERATION
+	bool "Nintendo Nunchuk joystick acceleration sensor data"
+	depends on INPUT_NUNCHUK
+	help
+	  This option enables the acceleration data reading for the Nintendo Nunchuk joystick.

--- a/drivers/input/input_nunchuk.c
+++ b/drivers/input/input_nunchuk.c
@@ -12,10 +12,11 @@
 #include <zephyr/input/input.h>
 #include <zephyr/kernel.h>
 #include <zephyr/timing/timing.h>
+#include <zephyr/input/input_nunchuk.h>
 
 LOG_MODULE_REGISTER(input_nunchuk, CONFIG_INPUT_LOG_LEVEL);
 
-#define NUNCHUK_DELAY_MS     10
+#define NUNCHUK_DELAY_MS  10
 #define NUNCHUK_READ_SIZE 6
 
 struct nunchuk_config {
@@ -24,13 +25,16 @@ struct nunchuk_config {
 };
 
 struct nunchuk_data {
+	struct k_work_delayable work;
+	k_timeout_t interval_ms;
 	const struct device *dev;
+#ifdef CONFIG_INPUT_NUNCHUK_ACCELERATION
+	uint16_t accel_x, accel_y, accel_z;
+#endif /* CONFIG_INPUT_NUNCHUK_ACCELERATION */
 	uint8_t joystick_x;
 	uint8_t joystick_y;
 	bool button_c;
 	bool button_z;
-	struct k_work_delayable work;
-	k_timeout_t interval_ms;
 };
 
 static int nunchuk_read_registers(const struct device *dev, uint8_t *buffer)
@@ -62,8 +66,6 @@ static void nunchuk_poll(struct k_work *work)
 	uint8_t joystick_x, joystick_y;
 	bool button_c, button_z;
 	bool y_changed;
-	bool sync_flag;
-	int ret;
 
 	nunchuk_read_registers(dev, buffer);
 
@@ -73,28 +75,67 @@ static void nunchuk_poll(struct k_work *work)
 
 	if (joystick_x != data->joystick_x) {
 		data->joystick_x = joystick_x;
-		sync_flag = !y_changed;
-		ret = input_report_abs(dev, INPUT_ABS_X, data->joystick_x, sync_flag, K_FOREVER);
+		input_report_abs(dev, INPUT_ABS_X, data->joystick_x, !y_changed, K_FOREVER);
 	}
 
 	if (y_changed) {
 		data->joystick_y = joystick_y;
-		ret = input_report_abs(dev, INPUT_ABS_Y, data->joystick_y, true, K_FOREVER);
+		input_report_abs(dev, INPUT_ABS_Y, data->joystick_y, true, K_FOREVER);
 	}
+
+#ifdef CONFIG_INPUT_NUNCHUK_ACCELERATION
+	uint16_t accel_x = (uint16_t)(buffer[2]) << 2 | ((buffer[5] >> 2) & 0x03);
+	uint16_t accel_y = (uint16_t)(buffer[3]) << 2 | ((buffer[5] >> 4) & 0x03);
+	uint16_t accel_z = (uint16_t)(buffer[4]) << 2 | ((buffer[5] >> 6) & 0x03);
+
+	bool x_accel_changed = accel_x != data->accel_x;
+	bool y_accel_changed = accel_y != data->accel_y;
+	bool z_accel_changed = accel_z != data->accel_z;
+
+	if (x_accel_changed) {
+		input_report(dev, INPUT_EV_DEVICE, INPUT_NUNCHUK_ACCEL_X, accel_x,
+			     !y_accel_changed && !z_accel_changed, K_FOREVER);
+	}
+	if (y_accel_changed) {
+		input_report(dev, INPUT_EV_DEVICE, INPUT_NUNCHUK_ACCEL_Y, accel_y, !z_accel_changed,
+			     K_FOREVER);
+	}
+	if (z_accel_changed) {
+		input_report(dev, INPUT_EV_DEVICE, INPUT_NUNCHUK_ACCEL_Z, accel_z, true, K_FOREVER);
+	}
+
+	data->accel_x = accel_x;
+	data->accel_y = accel_y;
+	data->accel_z = accel_z;
+#endif /* CONFIG_INPUT_NUNCHUK_ACCELERATION */
 
 	button_z = buffer[5] & BIT(0);
 	if (button_z != data->button_z) {
 		data->button_z = button_z;
-		ret = input_report_key(dev, INPUT_KEY_Z, !data->button_z, true, K_FOREVER);
+		input_report_key(dev, INPUT_BTN_Z, !data->button_z, true, K_FOREVER);
 	}
 
 	button_c = buffer[5] & BIT(1);
 	if (button_c != data->button_c) {
 		data->button_c = button_c;
-		ret = input_report_key(dev, INPUT_KEY_C, !data->button_c, true, K_FOREVER);
+		input_report_key(dev, INPUT_BTN_C, !data->button_c, true, K_FOREVER);
 	}
 
-	k_work_reschedule(dwork, data->interval_ms);
+	if (data->interval_ms.ticks != 0) {
+		k_work_reschedule(dwork, data->interval_ms);
+	}
+}
+
+int nunchuk_read(const struct device *dev)
+{
+	struct nunchuk_data *data = dev->data;
+
+	if (data->interval_ms.ticks != 0) {
+		return -EALREADY;
+	}
+
+	k_work_reschedule(&data->work, K_NO_WAIT);
+	return 0;
 }
 
 static int nunchuk_init(const struct device *dev)
@@ -108,7 +149,8 @@ static int nunchuk_init(const struct device *dev)
 	uint8_t buffer[NUNCHUK_READ_SIZE];
 
 	data->dev = dev;
-	data->interval_ms = K_MSEC(cfg->polling_interval_ms - 11);
+
+	data->interval_ms = K_MSEC(cfg->polling_interval_ms - (NUNCHUK_DELAY_MS + 1));
 
 	if (!i2c_is_ready_dt(&cfg->i2c_bus)) {
 		LOG_ERR_DEVICE_NOT_READY(cfg->i2c_bus.bus);
@@ -145,11 +187,18 @@ static int nunchuk_init(const struct device *dev)
 	data->joystick_y = buffer[1];
 	data->button_z = buffer[5] & BIT(0);
 	data->button_c = buffer[5] & BIT(1);
+#ifdef CONFIG_INPUT_NUNCHUK_ACCELERATION
+	data->accel_x = (uint16_t)(buffer[2]) << 2 | ((buffer[5] >> 2) & 0x03);
+	data->accel_y = (uint16_t)(buffer[3]) << 2 | ((buffer[5] >> 4) & 0x03);
+	data->accel_z = (uint16_t)(buffer[4]) << 2 | ((buffer[5] >> 6) & 0x03);
+#endif /* CONFIG_INPUT_NUNCHUK_ACCELERATION */
 
 	k_work_init_delayable(&data->work, nunchuk_poll);
-	ret = k_work_reschedule(&data->work, data->interval_ms);
+	if (data->interval_ms.ticks != 0) {
+		return k_work_reschedule(&data->work, data->interval_ms);
+	}
 
-	return ret;
+	return 0;
 }
 
 #define NUNCHUK_INIT(inst)                                                                         \
@@ -157,6 +206,8 @@ static int nunchuk_init(const struct device *dev)
 		.i2c_bus = I2C_DT_SPEC_INST_GET(inst),                                             \
 		.polling_interval_ms = DT_INST_PROP(inst, polling_interval_ms),                    \
 	};                                                                                         \
+	BUILD_ASSERT(DT_INST_PROP(inst, polling_interval_ms) > 20 ||                               \
+		     DT_INST_PROP(inst, polling_interval_ms) == 0);                                \
                                                                                                    \
 	static struct nunchuk_data nunchuk_data_##inst;                                            \
                                                                                                    \

--- a/dts/bindings/input/nintendo,nunchuk.yaml
+++ b/dts/bindings/input/nintendo,nunchuk.yaml
@@ -12,5 +12,6 @@ properties:
     type: int
     default: 50
     description: |
-      Interval between two reads, in ms. The interval must be greater than 21 ms. Default to 50 ms.
-    min: 21
+      Interval between two reads, in ms. The interval must be greater than 20 ms or equal to 0 ms
+      to disable the periodical polling and use the nunchuk_read() function to trigger a readout.
+      Defaults to 50 ms.

--- a/include/zephyr/input/input_nunchuk.h
+++ b/include/zephyr/input/input_nunchuk.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for Nunchuk input driver synchronous reading.
+ * @ingroup nunchuk_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/device.h>
+
+/**
+ * @defgroup nunchuk_interface Nunchuk
+ * @ingroup input_interface_ext
+ * @brief Nintendo Nunchuk joystick
+ * @{
+ */
+
+/**
+ * @brief Acceleration on the X axis reported by the Nunchuk.
+ *
+ * @kconfig_dep{CONFIG_INPUT_NUNCHUK_ACCELERATION}
+ */
+#define INPUT_NUNCHUK_ACCEL_X 0
+
+/**
+ * @brief Acceleration on the Y axis reported by the Nunchuk.
+ *
+ * @kconfig_dep{CONFIG_INPUT_NUNCHUK_ACCELERATION}
+ */
+#define INPUT_NUNCHUK_ACCEL_Y 1
+
+/**
+ * @brief Acceleration on the Z axis reported by the Nunchuk.
+ *
+ * @kconfig_dep{CONFIG_INPUT_NUNCHUK_ACCELERATION}
+ */
+#define INPUT_NUNCHUK_ACCEL_Z 2
+
+/**
+ * @brief Starts the reading process of the current button states, joystick position and optionally
+ * the acceleration (if @c CONFIG_INPUT_NUNCHUK_ACCELERATION is enabled) from the Nunchuk.
+ *
+ * This function does only function if the property 'polling-interval-ms' is set to 0 in the DTS
+ * definition for the Nunchuk input driver, so that background polling is disabled.
+ *
+ * Note that the function exits immediately and the data is read from the Nunchuk in the background
+ * and reported via the standard input event interface.
+ *
+ * @param dev	Pointer to the Nunchuk device
+ * @retval	SUCCESS if the data read process could be started.
+ * @retval	-errno In case of any error.
+ */
+int nunchuk_read(const struct device *dev);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_ */


### PR DESCRIPTION
If CONFIG_ INPUT_NUNCHUK_ROTATION is selected, the nunchuk input driver reports periodically the accelerometer values using the INPUT_ABS_RX, INPUT_ABS_RY and INPUT_ABS_RZ input event codes. INPUT_NUNCHUK_ROTATION_10BIT can be selected to get the effective 10 bit values. If CONFIG_NUNCHUK_SYNC_READ is selected (y), the nunchuk is not polled periodically anymore and inputs are not indicated by input events, the nunchuk actual data can be read using the nunchuk_read() function.