### PR TITLE
samples: bluetooth: peripheral_ets: Fix rw612 build fail.

### DIFF
--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -35,4 +35,5 @@ tests:
       - xg29_rb4412a/efr32mg29b140f1024im40
       - frdm_mcxw71
       - frdm_mcxw72
+      - frdm_rw612
     build_only: true

--- a/samples/bluetooth/peripheral_ets/sample.yaml
+++ b/samples/bluetooth/peripheral_ets/sample.yaml
@@ -7,7 +7,6 @@ tests:
     platform_allow:
       - qemu_cortex_m3
       - qemu_x86
-      - frdm_rw612
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
@@ -16,7 +15,6 @@ tests:
     platform_allow:
       - qemu_cortex_m3
       - qemu_x86
-      - frdm_rw612
     integration_platforms:
       - qemu_cortex_m3
     extra_args: EXTRA_CONF_FILE=overlay-local-time.conf


### PR DESCRIPTION
The frdm_rw612 board requires CONFIG_BUILD_ONLY_NO_BLOBS=y to build without binary blobs.

To fix the build error here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/22988076687/job/66743142962?pr=104868 in this PR: https://github.com/zephyrproject-rtos/zephyr/pull/104868
```
ERROR   - CMake build failure: /__w/zephyr/zephyr/samples/bluetooth/peripheral_ets for frdm_rw612/rw612
INFO    - 251/949 frdm_rw612/rw612          sample.bluetooth.peripheral_ets.local_time         ERROR CMake build failure (build <zephyr>)
INFO    - /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/build.log
ERROR   - Loading Zephyr default modules (Zephyr base).
-- Application: /__w/zephyr/zephyr/samples/bluetooth/peripheral_ets
-- CMake version: 3.28.3
-- Found Python3: /opt/python/venv/bin/python3 (found suitable version "3.12.3", minimum required is "3.12") found components: Interpreter 
-- Cache files will be written to: /root/.cache/zephyr
-- Zephyr version: 4.3.99 (/__w/zephyr/zephyr)
-- Found west (found suitable version "1.5.0", minimum required is "0.14.0")
-- Board: frdm_rw612, qualifiers: rw612
-- Found host-tools: zephyr 0.17.4 (/opt/toolchains/zephyr-sdk-0.17.4)
-- Found toolchain: zephyr 0.17.4 (/opt/toolchains/zephyr-sdk-0.17.4)
-- Found Dtc: /opt/toolchains/zephyr-sdk-0.17.4/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.7.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /__w/zephyr/zephyr/boards/nxp/frdm_rw612/frdm_rw612.dts
-- Generated zephyr.dts: /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/zephyr.dts
-- Generated pickled edt: /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/edt.pickle
-- Generated devicetree_generated.h: /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/include/generated/zephyr/devicetree_generated.h
Parsing /__w/zephyr/zephyr/Kconfig
Loaded configuration '/__w/zephyr/zephyr/boards/nxp/frdm_rw612/frdm_rw612_defconfig'
Merged configuration '/__w/zephyr/zephyr/samples/bluetooth/peripheral_ets/prj.conf'
Merged configuration '/__w/zephyr/zephyr/samples/bluetooth/peripheral_ets/overlay-local-time.conf'
Merged configuration '/__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/.config'
Kconfig header saved to '/__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /opt/toolchains/zephyr-sdk-0.17.4/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.38") 
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /opt/toolchains/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- connectivity_framework middleware is included.
-- Looking for device RW612 in /__w/zephyr/modules/hal/nxp/mcux/mcux-sdk-ng/devices/
-- Found device folder: /__w/zephyr/modules/hal/nxp/mcux/mcux-sdk-ng/devices/Wireless/RW/RW612
CMake Error at /__w/zephyr/modules/hal/nxp/zephyr/src/rw61x/CMakeLists.txt:39 (message):
  Couldn't find signed firmware !
  /__w/zephyr/modules/hal/nxp/zephyr/blobs/rw61x/rw61x_sb_ble_15d4_combo_a2.bin


-- Configuring incomplete, errors occurred!

INFO    - /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets.local_time/build.log
ERROR   - CMake build failure: /__w/zephyr/zephyr/samples/bluetooth/peripheral_ets for frdm_rw612/rw612
INFO    - 252/949 frdm_rw612/rw612          sample.bluetooth.peripheral_ets                    ERROR CMake build failure (build <zephyr>)
INFO    - /__w/zephyr/zephyr/twister-out/frdm_rw612_rw612/zephyr/samples/bluetooth/peripheral_ets/sample.bluetooth.peripheral_ets/build.log
ERROR   - Loading Zephyr default modules (Zephyr base).
```