### PR TITLE
Bluetooth: CAP: Shell: Set correct stream_cnt for ac_14

### DIFF
--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1430,7 +1430,7 @@ static int cmd_cap_ac_14(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct bap_broadcast_ac_param param = {
 		.name = "AC_14",
-		.stream_cnt = 2U,
+		.stream_cnt = 1U,
 		.chan_cnt = 2U,
 	};
 


### PR DESCRIPTION
AC 14 is stereo on a single BIS, so that is 1 stream with 2 channels.