### PR TITLE
drivers: dma: add Realtek Ameba series support

### DIFF
--- a/drivers/dma/CMakeLists.txt
+++ b/drivers/dma/CMakeLists.txt
@@ -3,11 +3,13 @@
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/dma.h)
 
 zephyr_library()
+zephyr_library_include_directories(.)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_DMAMUX_STM32 dmamux_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_AMD_ACP_HOST dma_amd_acp_host.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_AMD_ACP_SDW dma_amd_acp_sdw.c)
+zephyr_library_sources_ifdef(CONFIG_DMA_AMEBA dma_ameba_gdma.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_ANDES_ATCDMACX00 dma_andes_atcdmacx00.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_BFLB dma_bflb.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_DW dma_dw.c dma_dw_common.c)

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -29,6 +29,7 @@ source "subsys/logging/Kconfig.template.log_config"
 # zephyr-keep-sorted-start
 source "drivers/dma/Kconfig.acp_host"
 source "drivers/dma/Kconfig.acp_sdw"
+source "drivers/dma/Kconfig.ameba"
 source "drivers/dma/Kconfig.andes_atcdmacx00"
 source "drivers/dma/Kconfig.bflb"
 source "drivers/dma/Kconfig.dma_pl330"

--- a/drivers/dma/Kconfig.ameba
+++ b/drivers/dma/Kconfig.ameba
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config DMA_AMEBA
+	bool "AMEBA General Purpose DMA driver"
+	depends on DT_HAS_REALTEK_AMEBA_GDMA_ENABLED
+	default y
+	help
+	  General Purpose DMA for AMEBA series.
+
+if DMA_AMEBA
+
+config DMA_AMEBA_SCATTER_GATHER
+	bool "Ameba DMA scatter/gather support"
+	depends on SOC_SERIES_AMEBAG2
+	default y
+	help
+	  Enable DMA scatter/gather support on Ameba SoC
+
+config DMA_AMEBA_LLI
+	bool "AMEBA Linked List Mode"
+	help
+	  This option supports data block in the form of linked lists.
+
+config DMA_AMEBA_LLI_MAX_DESC
+	int "Maximal number of available DMA descriptors"
+	default 16
+	help
+	  Reserves memory for a maximal number of descriptors
+
+endif # DMA_AMEBA

--- a/drivers/dma/dma_ameba_gdma.c
+++ b/drivers/dma/dma_ameba_gdma.c
@@ -1,0 +1,753 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT realtek_ameba_gdma
+
+/* Include <soc.h> before <ameba_soc.h> to avoid redefining unlikely() macro */
+#include <soc.h>
+#include <ameba_soc.h>
+
+#include "dma_ameba_gdma.h"
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(dma_ameba_gdma, CONFIG_DMA_LOG_LEVEL);
+
+enum dma_reload_type {
+	GDMA_single = 0,
+	GDMA_reload_dst,
+	GDMA_reload_src,
+	GDMA_reload_src_dst,
+};
+
+struct dma_ameba_channel {
+	uint32_t block_size;
+	uint32_t block_num;
+	uint32_t block_id;
+	uint32_t src_trans_width;
+	uint32_t dst_trans_width;
+	uint32_t src_addr;
+	uint32_t dst_addr;
+	uint32_t chnl_priority;
+	GDMA_InitTypeDef gdma_struct;
+	struct dma_block_config *cur_dma_blk_cfg;
+	dma_callback_t callback;
+	void *user_data;
+	struct GDMA_CH_LLI *link_node;
+	uint8_t reload_type;
+	uint8_t chnl_direction;
+	bool busy;
+};
+
+struct dma_ameba_data {
+	struct dma_context dma_ctx;
+	/* define Bitmap variable for channel request */
+	ATOMIC_DEFINE(channels_atomic, DT_INST_PROP(0, dma_channels));
+	struct dma_ameba_channel *channel_status;
+#ifdef CONFIG_DMA_AMEBA_LLI
+	struct GDMA_CH_LLI *lli_pool;
+#endif
+};
+
+struct dma_ameba_config {
+	uint32_t base;
+	uint8_t channel_num;
+	uint8_t instance_id;
+	void (*config_irq)(const struct device *dev);
+	struct device *src_dev;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+};
+
+static inline int dma_ameba_data_size_convert(uint32_t data_size)
+{
+	switch (data_size) {
+	case 1:
+		return TrWidthOneByte;
+	case 2:
+		return TrWidthTwoBytes;
+	case 4:
+		return TrWidthFourBytes;
+	default:
+		LOG_ERR("data_size must be 1, 2, or 4 (size = %d)", data_size);
+		return -EINVAL;
+	}
+}
+
+static inline int dma_ameba_burst_size_convert(uint32_t burst_size)
+{
+	switch (burst_size) {
+	case 1:
+		return MsizeOne;
+	case 4:
+		return MsizeFour;
+	case 8:
+		return MsizeEight;
+	case 16:
+		return MsizeSixteen;
+	default:
+		LOG_ERR("burst size must be 1, 4, 8, 16 (size = %d)", burst_size);
+		return -EINVAL;
+	}
+}
+
+static inline int dma_ameba_reload_type_get(struct dma_config *config_dma)
+{
+	enum dma_reload_type type;
+
+	if (config_dma->head_block->source_reload_en && config_dma->head_block->dest_reload_en) {
+		type = GDMA_reload_src_dst;
+	} else if (config_dma->head_block->source_reload_en) {
+		type = GDMA_reload_src;
+	} else if (config_dma->head_block->dest_reload_en) {
+		type = GDMA_reload_dst;
+	} else {
+		type = GDMA_single;
+	}
+	return type;
+}
+
+static int dma_ameba_blockcfg_update(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	/* 1. config channel width/burst length/addr change mode/block size */
+	data->channel_status[channel].gdma_struct.GDMA_SrcAddr =
+		data->channel_status[channel].cur_dma_blk_cfg->source_address;
+	data->channel_status[channel].gdma_struct.GDMA_DstAddr =
+		data->channel_status[channel].cur_dma_blk_cfg->dest_address;
+	if (data->channel_status[channel].cur_dma_blk_cfg->source_addr_adj ==
+		    DMA_ADDR_ADJ_DECREMENT ||
+	    data->channel_status[channel].cur_dma_blk_cfg->dest_addr_adj ==
+		    DMA_ADDR_ADJ_DECREMENT) {
+		LOG_ERR("dma does not support addr decrement mode");
+		return -ENOTSUP;
+	}
+	data->channel_status[channel].gdma_struct.GDMA_SrcInc =
+		data->channel_status[channel].cur_dma_blk_cfg->source_addr_adj;
+	data->channel_status[channel].gdma_struct.GDMA_DstInc =
+		data->channel_status[channel].cur_dma_blk_cfg->dest_addr_adj;
+
+	/* set single block size = data block size / src_data_width */
+	data->channel_status[channel].gdma_struct.GDMA_BlockSize =
+		data->channel_status[channel].cur_dma_blk_cfg->block_size >>
+		data->channel_status[channel].gdma_struct.GDMA_SrcDataWidth;
+
+	/* 2. Continuous block(Adjacent address spaces) mode*/
+	if (data->channel_status[channel].cur_dma_blk_cfg->dest_reload_en ||
+	    data->channel_status[channel].cur_dma_blk_cfg->source_reload_en) {
+		data->channel_status[channel].gdma_struct.GDMA_ReloadSrc =
+			data->channel_status[channel].cur_dma_blk_cfg->source_reload_en;
+		data->channel_status[channel].gdma_struct.GDMA_ReloadDst =
+			data->channel_status[channel].cur_dma_blk_cfg->dest_reload_en;
+	}
+
+#ifdef CONFIG_DMA_AMEBA_SCATTER_GATHER
+	/* 3. scatter and gather */
+	if (data->channel_status[channel].cur_dma_blk_cfg->source_gather_en &&
+	    data->channel_status[channel].cur_dma_blk_cfg->dest_scatter_en) {
+		LOG_ERR("The same channel cannot enable source gather and dest scatter at the same "
+			"time");
+		return -EPERM;
+	} else if (data->channel_status[channel].cur_dma_blk_cfg->source_gather_en) {
+		GDMA_SourceGather(
+			config->instance_id, channel,
+			data->channel_status[channel].cur_dma_blk_cfg->source_gather_count,
+			data->channel_status[channel].cur_dma_blk_cfg->source_gather_interval);
+	} else if (data->channel_status[channel].cur_dma_blk_cfg->dest_scatter_en) {
+		GDMA_DestinationScatter(
+			config->instance_id, channel,
+			data->channel_status[channel].cur_dma_blk_cfg->dest_scatter_count,
+			data->channel_status[channel].cur_dma_blk_cfg->dest_scatter_interval);
+	}
+	/* else: normal DMA mode without scatter/gather - do nothing */
+#endif
+	/* 3. Initialization. */
+	GDMA_SetChnlPriority(config->instance_id, channel,
+			     data->channel_status[channel].chnl_priority);
+	GDMA_Init(config->instance_id, channel, &data->channel_status[channel].gdma_struct);
+
+	data->channel_status[channel].block_size =
+		data->channel_status[channel].gdma_struct.GDMA_BlockSize;
+	data->channel_status[channel].dst_addr =
+		data->channel_status[channel].gdma_struct.GDMA_DstAddr;
+	data->channel_status[channel].src_addr =
+		data->channel_status[channel].gdma_struct.GDMA_SrcAddr;
+
+	return 0;
+}
+
+static void dma_ameba_isr_handler(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+	int err = 0;
+	uint32_t isr_type;
+
+	/* If multiple blocks perform reload transmission, the reload bit needs to be cleared
+	 * when transmitting to the second block in reverse order.
+	 */
+	if (data->channel_status[channel].block_num == data->channel_status[channel].block_id + 2) {
+		GDMA_ChCleanAutoReload(config->instance_id, channel, CLEAN_RELOAD_SRC_DST);
+	}
+	/* 1. DMA interrupt type.*/
+	isr_type = GDMA_ClearINT(config->instance_id, channel);
+
+	if (isr_type & BlockType) {
+		LOG_DBG("dma block %d transfer complete.", data->channel_status[channel].block_id);
+		data->channel_status[channel].block_id++;
+	}
+	/* transfer complete*/
+	if (isr_type == TransferType) {
+		data->channel_status[channel].busy = false;
+	}
+	/* transfer error(protocol error)*/
+	if (isr_type == ErrType) {
+		err = -EIO;
+	}
+	/* 2. Configure dma transfer if there are multiple DMA configuration blocks */
+	if (data->channel_status[channel].cur_dma_blk_cfg == NULL) {
+		LOG_ERR("cur_dma_blk_cfg is NULL");
+		return;
+	}
+	if (data->channel_status[channel].cur_dma_blk_cfg->next_block != NULL) {
+		/*update dma configuration and re-init dma*/
+		data->channel_status[channel].cur_dma_blk_cfg =
+			data->channel_status[channel].cur_dma_blk_cfg->next_block;
+		GDMA_Cmd(config->instance_id, channel, DISABLE);
+		dma_ameba_blockcfg_update(dev, channel);
+		GDMA_Cmd(config->instance_id, channel, ENABLE);
+	} else {
+		/* 3. Execute user call back function.*/
+		if (data->channel_status[channel].callback) {
+			data->channel_status[channel].callback(
+				dev, data->channel_status[channel].user_data, channel, err);
+		}
+	}
+}
+
+/* 1. Extract parameter validation */
+static int dma_ameba_validate_config(const struct dma_ameba_config *config, uint32_t channel,
+				     struct dma_config *config_dma)
+{
+	if (!config_dma) {
+		LOG_ERR("invalid dma config parameters");
+		return -EINVAL;
+	}
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+
+	if (config_dma->channel_direction > PERIPHERAL_TO_MEMORY) {
+		LOG_ERR("channel_direction (%d) is not supported", config_dma->channel_direction);
+		return -ENOTSUP;
+	}
+
+	if (config_dma->head_block->fifo_mode_control) {
+		LOG_ERR("fifo_mode_control settings is not supported");
+		return -ENOTSUP;
+	}
+
+	if (config_dma->channel_priority >= config->channel_num) {
+		LOG_ERR("channel_priority must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+
+	if (config_dma->head_block->source_addr_adj == DMA_ADDR_ADJ_DECREMENT ||
+	    config_dma->head_block->dest_addr_adj == DMA_ADDR_ADJ_DECREMENT) {
+		LOG_ERR("dma does not support addr decrement mode");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+/* 2. Extract basic channel configurations (direction, width, burst) */
+static int dma_ameba_config_basic(struct dma_ameba_data *data, uint32_t channel,
+				  struct dma_config *config_dma)
+{
+	int ret;
+
+	/* Configure direction and handshake interface */
+	if (config_dma->channel_direction == MEMORY_TO_PERIPHERAL) {
+		if (config_dma->head_block->flow_control_mode) {
+			data->channel_status[channel].gdma_struct.GDMA_DIR = TTFCMemToPeri_PerCtrl;
+		}
+		if (!config_dma->dest_handshake) {
+			data->channel_status[channel].gdma_struct.GDMA_DstHandshakeInterface =
+				config_dma->dma_slot;
+		} else {
+			LOG_ERR("dma does not support software handshake");
+			return -ENOTSUP;
+		}
+	} else if (config_dma->channel_direction == PERIPHERAL_TO_MEMORY) {
+		if (config_dma->head_block->flow_control_mode) {
+			data->channel_status[channel].gdma_struct.GDMA_DIR = TTFCPeriToMem_PerCtrl;
+		}
+		if (!config_dma->source_handshake) {
+			data->channel_status[channel].gdma_struct.GDMA_SrcHandshakeInterface =
+				config_dma->dma_slot;
+		} else {
+			LOG_ERR("dma does not support software handshake");
+			return -ENOTSUP;
+		}
+	} else {
+		/* Do nothing */
+	}
+
+	/* Configure width and burst size */
+	ret = dma_ameba_data_size_convert(config_dma->source_data_size);
+	if (ret != -EINVAL) {
+		data->channel_status[channel].gdma_struct.GDMA_SrcDataWidth = ret;
+	} else {
+		return ret;
+	}
+
+	ret = dma_ameba_data_size_convert(config_dma->dest_data_size);
+	if (ret != -EINVAL) {
+		data->channel_status[channel].gdma_struct.GDMA_DstDataWidth = ret;
+	} else {
+		return ret;
+	}
+
+	ret = dma_ameba_burst_size_convert(config_dma->source_burst_length);
+	if (ret != -EINVAL) {
+		data->channel_status[channel].gdma_struct.GDMA_SrcMsize = ret;
+	} else {
+		return ret;
+	}
+
+	ret = dma_ameba_burst_size_convert(config_dma->dest_burst_length);
+	if (ret != -EINVAL) {
+		data->channel_status[channel].gdma_struct.GDMA_DstMsize = ret;
+	} else {
+		return ret;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_DMA_AMEBA_LLI
+/* 3. Configure multi-block (LLI) transfer */
+static int dma_ameba_config_lli(struct dma_ameba_data *data, uint32_t channel,
+				struct dma_config *config_dma, struct GDMA_CH_LLI *lli_pool)
+{
+	struct dma_block_config *cur_block = config_dma->head_block;
+	struct dma_ameba_channel *ch = &data->channel_status[channel];
+
+	if (config_dma->head_block->next_block && (config_dma->block_count <= 1)) {
+		LOG_ERR("The block_count does not match the dma_block_cfg configuration.");
+		return -EINVAL;
+	}
+
+	if (config_dma->block_count > CONFIG_DMA_AMEBA_LLI_MAX_DESC) {
+		LOG_ERR("block_count %d exceeds max descriptor %d",
+			config_dma->block_count, CONFIG_DMA_AMEBA_LLI_MAX_DESC);
+		return -EINVAL;
+	}
+
+	ch->gdma_struct.GDMA_LlpSrcEn =
+		(config_dma->head_block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT);
+	ch->gdma_struct.GDMA_LlpDstEn =
+		(config_dma->head_block->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT);
+
+	ch->link_node = lli_pool;
+
+	for (int i = 0; i < config_dma->block_count && cur_block; i++) {
+		if (ch->gdma_struct.GDMA_LlpSrcEn) {
+			ch->link_node[i].LliEle.Sarx = cur_block->source_address;
+		}
+
+		if (ch->gdma_struct.GDMA_LlpDstEn) {
+			ch->link_node[i].LliEle.Darx = cur_block->dest_address;
+		}
+
+		/* Link list concatenation */
+		if ((i == config_dma->block_count - 1) && (config_dma->cyclic == 1)) {
+			ch->link_node[i].pNextLli = &ch->link_node[0];
+		} else if ((i == config_dma->block_count - 1) && (config_dma->cyclic == 0)) {
+			ch->link_node[i].pNextLli = NULL;
+		} else {
+			ch->link_node[i].pNextLli = &ch->link_node[i + 1];
+		}
+
+		ch->link_node[i].BlockSize =
+			cur_block->block_size >> ch->gdma_struct.GDMA_SrcDataWidth;
+
+		cur_block = cur_block->next_block;
+	}
+
+	return 0;
+}
+#endif
+
+static int dma_ameba_configure(const struct device *dev, uint32_t channel,
+			       struct dma_config *config_dma)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+	int ret;
+
+	/* 1. Check parameters */
+	ret = dma_ameba_validate_config(config, channel, config_dma);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* 2. Init GDMA struct and generic properties */
+	GDMA_StructInit(&data->channel_status[channel].gdma_struct);
+	data->channel_status[channel].gdma_struct.GDMA_Index = config->instance_id;
+	data->channel_status[channel].gdma_struct.GDMA_ChNum = channel;
+	data->channel_status[channel].gdma_struct.GDMA_DIR = config_dma->channel_direction;
+	data->channel_status[channel].gdma_struct.GDMA_SrcAddr =
+		config_dma->head_block->source_address;
+	data->channel_status[channel].gdma_struct.GDMA_DstAddr =
+		config_dma->head_block->dest_address;
+	data->channel_status[channel].gdma_struct.GDMA_SrcInc =
+		config_dma->head_block->source_addr_adj;
+	data->channel_status[channel].gdma_struct.GDMA_DstInc =
+		config_dma->head_block->dest_addr_adj;
+
+	/* 3. Configure channel basic settings */
+	ret = dma_ameba_config_basic(data, channel, config_dma);
+	if (ret != 0) {
+		return ret;
+	}
+
+	data->channel_status[channel].gdma_struct.GDMA_BlockSize =
+		config_dma->head_block->block_size >>
+		data->channel_status[channel].gdma_struct.GDMA_SrcDataWidth;
+	if (config_dma->head_block->dest_reload_en || config_dma->head_block->source_reload_en) {
+		data->channel_status[channel].gdma_struct.GDMA_ReloadSrc =
+			config_dma->head_block->source_reload_en;
+		data->channel_status[channel].gdma_struct.GDMA_ReloadDst =
+			config_dma->head_block->dest_reload_en;
+	}
+
+	/* 4. Multi-block (LLI) transfer mode */
+#ifdef CONFIG_DMA_AMEBA_LLI
+	if (config_dma->block_count > 1) {
+		ret = dma_ameba_config_lli(data, channel, config_dma, data->lli_pool);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+#endif
+
+	/* 5. Scatter and gather mode */
+#ifdef CONFIG_DMA_AMEBA_SCATTER_GATHER
+	if (config_dma->head_block->source_gather_en && config_dma->head_block->dest_scatter_en) {
+		LOG_ERR("Cannot enable source gather and dest scatter at the same time");
+		return -EPERM;
+	} else if (config_dma->head_block->source_gather_en) {
+		GDMA_SourceGather(config->instance_id, channel,
+				  config_dma->head_block->source_gather_count,
+				  config_dma->head_block->source_gather_interval);
+	} else if (config_dma->head_block->dest_scatter_en) {
+		GDMA_DestinationScatter(config->instance_id, channel,
+					config_dma->head_block->dest_scatter_count,
+					config_dma->head_block->dest_scatter_interval);
+	}
+	/* else: normal DMA mode without scatter/gather - do nothing */
+#endif
+
+	/* 6. Initialization and channel status recording */
+	data->channel_status[channel].gdma_struct.GDMA_IsrType =
+		(TransferType | BlockType | ErrType);
+	GDMA_Init(config->instance_id, channel, &data->channel_status[channel].gdma_struct);
+	GDMA_SetChnlPriority(config->instance_id, channel, config_dma->channel_priority);
+	if (data->channel_status[channel].link_node != NULL) {
+		GDMA_SetLLP(config->instance_id, channel, config_dma->block_count,
+			    data->channel_status[channel].link_node, config_dma->cyclic);
+	}
+
+	data->channel_status[channel].block_num = config_dma->block_count;
+	data->channel_status[channel].block_size = config_dma->head_block->block_size;
+	data->channel_status[channel].chnl_direction = config_dma->channel_direction;
+	data->channel_status[channel].chnl_priority = config_dma->channel_priority;
+	data->channel_status[channel].src_trans_width =
+		data->channel_status[channel].gdma_struct.GDMA_SrcDataWidth;
+	data->channel_status[channel].dst_trans_width =
+		data->channel_status[channel].gdma_struct.GDMA_DstDataWidth;
+	data->channel_status[channel].dst_addr = config_dma->head_block->dest_address;
+	data->channel_status[channel].src_addr = config_dma->head_block->source_address;
+	data->channel_status[channel].callback = config_dma->dma_callback;
+	data->channel_status[channel].user_data = config_dma->user_data;
+	data->channel_status[channel].reload_type = dma_ameba_reload_type_get(config_dma);
+	data->channel_status[channel].cur_dma_blk_cfg = config_dma->head_block;
+
+	return 0;
+}
+
+static int dma_ameba_start(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+	/* channel enable */
+	GDMA_Cmd(config->instance_id, channel, ENABLE);
+
+	data->channel_status[channel].busy = true;
+
+	return 0;
+}
+
+static int dma_ameba_stop(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+	/* channel disable */
+	GDMA_Cmd(config->instance_id, channel, DISABLE);
+
+	data->channel_status[channel].busy = false;
+
+#ifdef CONFIG_DMA_AMEBA_LLI
+	/* Reset link_node to indicate no active LLI transfer */
+	data->channel_status[channel].link_node = NULL;
+#endif
+
+	return 0;
+}
+
+static int dma_ameba_get_status(const struct device *dev, uint32_t channel,
+				struct dma_status *status)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+
+	if (!status) {
+		LOG_ERR("status is NULL");
+		return -EINVAL;
+	}
+
+	status->busy = data->channel_status[channel].busy;
+	/* In the actual test, only the total amount of data can be read
+	 * if it is greater than 2048 Bytes.
+	 */
+	status->pending_length = data->channel_status[channel].block_size -
+				 GDMA_GetBlkSize(config->instance_id, channel);
+	status->dir = data->channel_status[channel].chnl_direction;
+
+	return 0;
+}
+
+static int dma_ameba_reload(const struct device *dev, uint32_t channel, uint32_t src, uint32_t dst,
+			    size_t size)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+	/* update current channel's parameters. */
+	data->channel_status[channel].src_addr = src;
+	data->channel_status[channel].dst_addr = dst;
+	data->channel_status[channel].block_size = size;
+
+	GDMA_Cmd(config->instance_id, channel, DISABLE);
+	GDMA_SetSrcAddr(config->instance_id, channel, src);
+	GDMA_SetDstAddr(config->instance_id, channel, dst);
+	/* The size required by the gdma hardware must be aligned
+	 * with the source transmission width.
+	 */
+	size = size >> data->channel_status[channel].src_trans_width;
+	GDMA_SetBlkSize(config->instance_id, channel, (uint32_t)size);
+
+	return 0;
+}
+
+static int dma_ameba_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+
+	if (data->channel_status[channel].busy == false) {
+		LOG_ERR("suspend channel not busy");
+		return -EINVAL;
+	}
+
+	GDMA_Suspend(config->instance_id, channel);
+
+	data->channel_status[channel].busy = false;
+
+	return 0;
+}
+
+static int dma_ameba_resume(const struct device *dev, uint32_t channel)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+
+	if (channel >= config->channel_num) {
+		LOG_ERR("channel id must be < (%d)", config->channel_num);
+		return -EINVAL;
+	}
+
+	if (data->channel_status[channel].busy == true) {
+		LOG_ERR("resume channel is busy");
+		return -EINVAL;
+	}
+
+	GDMA_Resume(config->instance_id, channel);
+
+	data->channel_status[channel].busy = true;
+
+	return 0;
+}
+
+static bool dma_ameba_chan_filter(const struct device *dev, int channel, void *filter_param)
+{
+	uint32_t requested_channel;
+
+	if (!filter_param) {
+		return true;
+	}
+
+	requested_channel = *(uint32_t *)filter_param;
+
+	if (channel == requested_channel) {
+		return true;
+	}
+
+	return false;
+}
+
+static int dma_ameba_init(const struct device *dev)
+{
+	const struct dma_ameba_config *config = (const struct dma_ameba_config *)dev->config;
+	struct dma_ameba_data *data = (struct dma_ameba_data *)dev->data;
+	int ret;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (ret < 0) {
+		LOG_ERR("Could not initialize clock (%d)", ret);
+		return ret;
+	}
+
+	for (uint32_t i = 0; i < config->channel_num; i++) {
+		data->channel_status[i].reload_type = GDMA_single;
+	}
+
+	data->dma_ctx.dma_channels = config->channel_num;
+	data->dma_ctx.magic = DMA_MAGIC;
+	data->dma_ctx.atomic = data->channels_atomic;
+	config->config_irq(dev);
+
+	return 0;
+}
+
+static DEVICE_API(dma, dma_ameba_api) = {
+	.config = dma_ameba_configure,
+	.start = dma_ameba_start,
+	.stop = dma_ameba_stop,
+	.suspend = dma_ameba_suspend,
+	.resume = dma_ameba_resume,
+	.get_status = dma_ameba_get_status,
+	.reload = dma_ameba_reload,
+	.chan_filter = dma_ameba_chan_filter,
+};
+
+/*
+ * Macro to CONNECT and enable each irq (order is given by the 'listify')
+ * chan: channel of the DMA instance (assuming one irq per channel)
+ * dma : dma instance (one GDMA instance on ameba)
+ */
+#define DMA_AMEBA_IRQ_CONNECT_CHANNEL(chan, dma)                                                   \
+	do {                                                                                       \
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(dma, chan, irq),                                    \
+			    DT_INST_IRQ_BY_IDX(dma, chan, priority), dma_ameba_irq_##dma##_##chan, \
+			    DEVICE_DT_INST_GET(dma), 0);                                           \
+		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));                                    \
+	} while (0)
+
+/*
+ * Macro to configure the irq for each dma instance (n)
+ * Loop to CONNECT and enable each irq for each channel
+ * Expecting as many irq as property <dma_channels>
+ */
+#define DMA_AMEBA_IRQ_CONNECT(n)                                                                   \
+	static void dma_ameba_config_irq_##n(const struct device *dev)                             \
+	{                                                                                          \
+		ARG_UNUSED(dev);                                                                   \
+		LISTIFY(DT_INST_PROP(n, dma_channels),                                             \
+				DMA_AMEBA_IRQ_CONNECT_CHANNEL,                                     \
+				(;),                                                               \
+				n);                                                                \
+	}
+
+/*
+ * Macro to instantiate the irq handler (order is given by the 'listify')
+ * chan: channel of the DMA instance (assuming one irq per channel)
+ * dma : dma instance (one GDMA instance on ameba)
+ */
+#define DMA_AMEBA_DEFINE_IRQ_HANDLER(chan, dma)                                                    \
+	static void dma_ameba_irq_##dma##_##chan(const struct device *dev)                         \
+	{                                                                                          \
+		dma_ameba_isr_handler(dev, chan);                                                  \
+	}
+
+#define DMA_AMEBA_INIT(n)                                                                          \
+	BUILD_ASSERT(DT_INST_PROP(n, dma_channels) == DT_NUM_IRQS(DT_DRV_INST(n)),                 \
+		     "Nb of Channels and IRQ mismatch");                                           \
+                                                                                                   \
+	LISTIFY(DT_INST_PROP(n, dma_channels),                                                     \
+			DMA_AMEBA_DEFINE_IRQ_HANDLER,                                              \
+			(;),                                                                       \
+			n);                                                                        \
+                                                                                                   \
+	DMA_AMEBA_IRQ_CONNECT(n);                                                                  \
+                                                                                                   \
+	static const struct dma_ameba_config dma_config_##n = {                                    \
+		.instance_id = n,                                                                  \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.channel_num = DT_INST_PROP(n, dma_channels),                                      \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (void *)DT_INST_CLOCKS_CELL(n, idx),                               \
+		.config_irq = dma_ameba_config_irq_##n,                                            \
+	};                                                                                         \
+	static struct dma_ameba_channel dma_ameba_##n##_channels[DT_INST_PROP(n, dma_channels)];   \
+	IF_ENABLED(CONFIG_DMA_AMEBA_LLI,                                                           \
+		(static struct GDMA_CH_LLI lli_pool_##n[DT_INST_PROP(n, dma_channels) *            \
+						CONFIG_DMA_AMEBA_LLI_MAX_DESC];))                  \
+	static struct dma_ameba_data dma_data_##n = {                                              \
+		.channel_status = dma_ameba_##n##_channels,                                        \
+		IF_ENABLED(CONFIG_DMA_AMEBA_LLI, (.lli_pool = lli_pool_##n,))                      \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &dma_ameba_init, NULL, &dma_data_##n, &dma_config_##n,            \
+			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &dma_ameba_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DMA_AMEBA_INIT);

--- a/drivers/dma/dma_ameba_gdma.h
+++ b/drivers/dma/dma_ameba_gdma.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_AMEBA_GDMA_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_AMEBA_GDMA_H_
+
+/**
+ * @file
+ * @brief Ameba GDMA helper macros for devicetree-based configuration
+ *
+ * This file provides Ameba-specific helper macros built on top of the
+ * generic devicetree DMA API in <zephyr/devicetree/dma.h>, mainly to
+ * decode the SoC-specific packed "config" cell into struct dma_config
+ * fields.
+ */
+
+#include <zephyr/devicetree/dma.h>
+
+/* Ameba-specific helpers for decoding the packed DMA "config" cell */
+
+/**
+ * @brief Direction defined on bits 0-1.
+ *
+ * @param value Packed configuration value:
+ *              0 -> MEM_TO_MEM,
+ *              1 -> MEM_TO_PERIPH,
+ *              2 -> PERIPH_TO_MEM,
+ *              3 -> PERIPH_TO_PERIPH.
+ */
+#define AMEBA_DMA_CH_DIR_GET(value) ((value >> 0) & 0x3)
+
+/**
+ * @brief Source address increment mode defined on bits 2-3.
+ *
+ * @param value Packed configuration value:
+ *              0 -> increment,
+ *              1 -> decrement (not supported),
+ *              2 -> no change.
+ */
+#define AMEBA_DMA_SRC_ADDR_ADJ_GET(value) ((value >> 2) & 0x3)
+
+/**
+ * @brief Destination address increment mode defined on bits 4-5.
+ *
+ * @param value Packed configuration value:
+ *              0 -> increment,
+ *              1 -> decrement (not supported),
+ *              2 -> no change.
+ */
+#define AMEBA_DMA_DST_ADDR_ADJ_GET(value) ((value >> 4) & 0x3)
+
+/**
+ * @brief Source data size defined on bits 6-8.
+ *
+ * @param value Packed configuration value (width can be 1/2/4 bytes).
+ */
+#define AMEBA_DMA_SRC_DATA_SIZE_GET(value) ((value >> 6) & 0x7)
+
+/**
+ * @brief Destination data size defined on bits 9-11.
+ *
+ * @param value Packed configuration value (width can be 1/2/4 bytes).
+ */
+#define AMEBA_DMA_DST_DATA_SIZE_GET(value) ((value >> 9) & 0x7)
+
+/**
+ * @brief Source burst size (msize) defined on bits 12-16.
+ *
+ * @param value Packed configuration value (burst size can be 1, 4, 8, 16).
+ */
+#define AMEBA_DMA_SRC_BST_SIZE_GET(value) ((value >> 12) & 0x1F)
+
+/**
+ * @brief Destination burst size (msize) defined on bits 17-21.
+ *
+ * @param value Packed configuration value (burst size can be 1, 4, 8, 16).
+ */
+#define AMEBA_DMA_DST_BST_SIZE_GET(value) ((value >> 17) & 0x1F)
+
+/**
+ * @brief Channel priority defined on bits 22-24 as 0-7.
+ *
+ * @param value Packed configuration value (priority 0-7, 0 is highest).
+ */
+#define AMEBA_DMA_CH_PRIORITY_GET(value) ((value >> 22) & 0x7)
+
+/**
+ * @brief Build a DMA configuration initializer from devicetree.
+ *
+ * This macro uses the generic DT_INST_DMAS_*() helpers from
+ * <zephyr/devicetree/dma.h> and decodes the Ameba-specific "config"
+ * bitfield into struct dma_config fields.
+ *
+ * @param inst        Devicetree instance index.
+ * @param dir         Name of the DMA spec (e.g. "tx", "rx").
+ * @param block_number Number of DMA blocks.
+ * @param cb          DMA callback function.
+ */
+#define AMEBA_DMA_CONFIG(inst, dir, block_number, cb)                                              \
+	{                                                                                          \
+		.dma_slot = DT_INST_DMAS_CELL_BY_NAME(inst, dir, slot),                            \
+		.channel_direction =                                                               \
+			AMEBA_DMA_CH_DIR_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)),        \
+		.channel_priority =                                                                \
+			AMEBA_DMA_CH_PRIORITY_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)),   \
+		.source_data_size =                                                                \
+			AMEBA_DMA_SRC_DATA_SIZE_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)), \
+		.dest_data_size =                                                                  \
+			AMEBA_DMA_DST_DATA_SIZE_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)), \
+		.source_burst_length =                                                             \
+			AMEBA_DMA_SRC_BST_SIZE_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)),  \
+		.dest_burst_length =                                                               \
+			AMEBA_DMA_DST_BST_SIZE_GET(DT_INST_DMAS_CELL_BY_NAME(inst, dir, config)),  \
+		.block_count = block_number,                                                       \
+		.dma_callback = cb,                                                                \
+	}
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_AMEBA_GDMA_H_ */

--- a/dts/arm/realtek/amebad/amebad.dtsi
+++ b/dts/arm/realtek/amebad/amebad.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/amebad_clock.h>
+#include <zephyr/dt-bindings/dma/ameba_dma.h>
 
 / {
 	cpus {
@@ -51,6 +52,19 @@
 		sram0: memory@10003020 {
 			compatible = "mmio-sram";
 			reg = <0x10003020 0x00074000>;
+		};
+
+		dma: dma@4002a000 {
+			compatible = "realtek,ameba-gdma";
+			reg = <0x4002a000 0x3c0>;
+			clocks = <&rcc AMEBA_GDMA0_CLK>;
+			interrupts = <41 0>, <42 0>, <43 0>, <44 0>, <45 0>, <46 0>;
+			interrupt-names = "CH0", "CH1", "CH2", "CH3", "CH4", "CH5";
+			#dma-cells = <3>;
+			dma-channels = <6>;
+			dma-buf-addr-alignment = <32>;
+			dma-buf-size-alignment = <32>;
+			status = "disabled";
 		};
 
 		pinctrl: pinctrl@48000400 {

--- a/dts/arm/realtek/amebadplus/amebadplus.dtsi
+++ b/dts/arm/realtek/amebadplus/amebadplus.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8.1-m.dtsi>
 #include <zephyr/dt-bindings/clock/amebadplus_clock.h>
+#include <zephyr/dt-bindings/dma/ameba_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
@@ -52,6 +53,19 @@
 		sram0: memory@20010020 {
 			compatible = "mmio-sram";
 			reg = <0x20010020 0x00030000>;
+		};
+
+		dma: dma@40110000 {
+			compatible = "realtek,ameba-gdma";
+			reg = <0x40110000 0x3c0>;
+			clocks = <&rcc AMEBA_DMAC_CLK>;
+			interrupts = <33 0>, <34 0>, <35 0>, <36 0>, <37 0>, <38 0>, <39 0>, <40 0>;
+			interrupt-names = "CH0", "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7";
+			#dma-cells = <3>;
+			dma-channels = <8>;
+			dma-buf-addr-alignment = <32>;
+			dma-buf-size-alignment = <32>;
+			status = "disabled";
 		};
 
 		spic: flash-controller@40128000 {

--- a/dts/arm/realtek/amebag2/amebag2.dtsi
+++ b/dts/arm/realtek/amebag2/amebag2.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8.1-m.dtsi>
 #include <zephyr/dt-bindings/clock/amebag2_clock.h>
+#include <zephyr/dt-bindings/dma/ameba_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
@@ -69,6 +70,19 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 			};
+		};
+
+		dma: dma@40120000 {
+			compatible = "realtek,ameba-gdma";
+			reg = <0x40120000 0x3c0>;
+			clocks = <&rcc AMEBA_DMAC_CLK>;
+			interrupts = <30 0>, <31 0>, <32 0>, <33 0>, <34 0>, <35 0>, <36 0>, <37 0>;
+			interrupt-names = "CH0", "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7";
+			#dma-cells = <3>;
+			dma-channels = <8>;
+			dma-buf-addr-alignment = <32>;
+			dma-buf-size-alignment = <32>;
+			status = "disabled";
 		};
 
 		pinctrl: pinctrl@4080a800 {

--- a/dts/bindings/dma/realtek,ameba-gdma.yaml
+++ b/dts/bindings/dma/realtek,ameba-gdma.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Realtek's GDMA (General Direct Memory Access) peripheral
+
+  General Direct Memory Access (GDMA) device allows
+  peripheral-to-memory, memory-to-peripheral, and memory-to-memory
+  data transfer.
+
+  The GDMA controller in ameba has eight independent channels,
+  each channel can be connected to different peripherals.
+
+  channel: Select channel for data transmitting
+  slot: Handshake interface index, ref to ameba_gdma.h
+  config: A 32bit mask specifying the DMA channel configuration
+    - bit 0-1:     Direction  (see dma.h)
+                 - 0x0: MEMORY to MEMORY
+                 - 0x1: MEMORY to PERIPH
+                 - 0x2: PERIPH to MEMORY
+                 - 0x3: PERIPH to PERIPH(reserved)
+    - bit 2-3:     Source address increase
+                 - 0x0: increment address between transfers
+                 - 0x1: decrement address between transfers
+                 - 0x2: no address increment between transfers
+                 - 0x3: reserved
+    - bit 4-5:     Destination address increase
+                 - 0x0: increment address between transfers
+                 - 0x1: decrement address between transfers(Not support)
+                 - 0x2: no address increment between transfers
+                 - 0x3: reserved
+    - bit 6-8:     Source data width
+                 - 0x1: 1 byte
+                 - 0x2: 2 byte
+                 - 0x4: 4 byte
+    - bit 9-11:    Destination data width
+                 - 0x1: 1 byte
+                 - 0x2: 2 byte
+                 - 0x4: 4 byte
+    - bit 12-16:   Source data msize
+                 - 0x1: msize 1
+                 - 0x4: msize 4
+                 - 0x8: msize 8
+                 - 0x10: msize 16
+    - bit 17-21:   Destination data width
+                 - 0x1: msize 1
+                 - 0x4: msize 4
+                 - 0x8: msize 8
+                 - 0x10: msize 16
+    - bit 22-24:   Priority
+                 - 0 ~ 7 can be configured
+  Example of devicetree configuration
+  &uart2 {
+        dmas = <&dma 2 5 0xa>, <&dma 3 4 0x10021>;
+        dma-names = "rx", "tx";
+  };
+  "uart2" uses dma0 for transmitting and receiving in the example.
+  Each is named "rx" and "tx".
+  The channel cell assigns channel 2 to receive and channel 3 to transmit.
+  The slot cell configs specified handshake for different peripherals.
+  The config cell can take various configs.
+  But the setting used depends on each driver implementation.
+  Set the priority for the transmitting channel as HIGH, LOW(the default) for receive channel.
+
+compatible: "realtek,ameba-gdma"
+
+include: dma-controller.yaml
+
+properties:
+  "#dma-cells":
+    const: 3
+
+dma-cells:
+  - channel
+  - slot
+  - config

--- a/include/zephyr/dt-bindings/dma/ameba_dma.h
+++ b/include/zephyr/dt-bindings/dma/ameba_dma.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_AMEBA_DMA_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_AMEBA_DMA_H_
+
+/**
+ * @file
+ * @brief Ameba SoC DMA devicetree binding flags
+ *
+ * This file defines bitfield flags used to configure DMA channels
+ * in devicetree for Ameba SoCs.
+ */
+
+/**
+ * @name DMA channel configuration flags
+ * @{
+ */
+
+/**
+ * @brief Set DMA transfer direction bits [1:0].
+ *
+ * @param val Direction value encoded in bits [1:0].
+ */
+#define AMEBA_DMA_CH_DIR_SET(val) ((val & 0x3) << 0)
+
+/**
+ * @brief DMA transfer direction: memory to memory.
+ */
+#define AMEBA_DMA_MEMORY_TO_MEMORY AMEBA_DMA_CH_DIR_SET(0)
+
+/**
+ * @brief DMA transfer direction: memory to peripheral.
+ */
+#define AMEBA_DMA_MEMORY_TO_PERIPH AMEBA_DMA_CH_DIR_SET(1)
+
+/**
+ * @brief DMA transfer direction: peripheral to memory.
+ */
+#define AMEBA_DMA_PERIPH_TO_MEMORY AMEBA_DMA_CH_DIR_SET(2)
+
+/**
+ * @brief DMA transfer direction: peripheral to peripheral.
+ */
+#define AMEBA_DMA_PERIPH_TO_PERIPH AMEBA_DMA_CH_DIR_SET(3)
+
+/**
+ * @brief Set source address adjustment bits [3:2].
+ *
+ * @param val Address adjustment value encoded in bits [3:2].
+ */
+#define AMEBA_DMA_SRC_ADDR_ADJ_SET(val) ((val & 0x3) << 2)
+
+/**
+ * @brief Source address increment after each transfer.
+ */
+#define AMEBA_DMA_SRC_ADDR_ADJ_INC AMEBA_DMA_SRC_ADDR_ADJ_SET(0)
+
+/**
+ * @brief Source address does not change.
+ */
+#define AMEBA_DMA_SRC_ADDR_ADJ_NO_CHANGE AMEBA_DMA_SRC_ADDR_ADJ_SET(2)
+
+/**
+ * @brief Set destination address adjustment bits [5:4].
+ *
+ * @param val Address adjustment value encoded in bits [5:4].
+ */
+#define AMEBA_DMA_DST_ADDR_ADJ_SET(val) ((val & 0x3) << 4)
+
+/**
+ * @brief Destination address increment after each transfer.
+ */
+#define AMEBA_DMA_DST_ADDR_ADJ_INC AMEBA_DMA_DST_ADDR_ADJ_SET(0)
+
+/**
+ * @brief Destination address does not change.
+ */
+#define AMEBA_DMA_DST_ADDR_ADJ_NO_CHANGE AMEBA_DMA_DST_ADDR_ADJ_SET(2)
+
+/**
+ * @brief Set source data width bits [8:6].
+ *
+ * @param val Data width value encoded in bits [8:6].
+ */
+#define AMEBA_DMA_SRC_DATA_SIZE_SET(val) ((val & 0x7) << 6)
+
+/**
+ * @brief Source data width: 8 bits.
+ */
+#define AMEBA_DMA_SRC_WIDTH_8BITS AMEBA_DMA_SRC_DATA_SIZE_SET(0)
+
+/**
+ * @brief Source data width: 16 bits.
+ */
+#define AMEBA_DMA_SRC_WIDTH_16BITS AMEBA_DMA_SRC_DATA_SIZE_SET(1)
+
+/**
+ * @brief Source data width: 32 bits.
+ */
+#define AMEBA_DMA_SRC_WIDTH_32BITS AMEBA_DMA_SRC_DATA_SIZE_SET(2)
+
+/**
+ * @brief Set destination data width bits [11:9].
+ *
+ * @param val Data width value encoded in bits [11:9].
+ */
+#define AMEBA_DMA_DST_DATA_SIZE_SET(val) ((val & 0x7) << 9)
+
+/**
+ * @brief Destination data width: 8 bits.
+ */
+#define AMEBA_DMA_DST_WIDTH_8BITS AMEBA_DMA_DST_DATA_SIZE_SET(0)
+
+/**
+ * @brief Destination data width: 16 bits.
+ */
+#define AMEBA_DMA_DST_WIDTH_16BITS AMEBA_DMA_DST_DATA_SIZE_SET(1)
+
+/**
+ * @brief Destination data width: 32 bits.
+ */
+#define AMEBA_DMA_DST_WIDTH_32BITS AMEBA_DMA_DST_DATA_SIZE_SET(2)
+
+/**
+ * @brief Set source burst length bits [16:12].
+ *
+ * @param val Burst length value encoded in bits [16:12].
+ */
+#define AMEBA_DMA_SRC_BURST_SET(val) ((val & 0x1F) << 12)
+
+/**
+ * @brief Source burst length: 1 transfer.
+ */
+#define AMEBA_DMA_SRC_BURST_ONE AMEBA_DMA_SRC_BURST_SET(0)
+
+/**
+ * @brief Source burst length: 4 transfers.
+ */
+#define AMEBA_DMA_SRC_BURST_FOUR AMEBA_DMA_SRC_BURST_SET(1)
+
+/**
+ * @brief Source burst length: 8 transfers.
+ */
+#define AMEBA_DMA_SRC_BURST_EIGHT AMEBA_DMA_SRC_BURST_SET(2)
+
+/**
+ * @brief Source burst length: 16 transfers.
+ */
+#define AMEBA_DMA_SRC_BURST_SIXTEEN AMEBA_DMA_SRC_BURST_SET(3)
+
+/**
+ * @brief Set destination burst length bits [21:17].
+ *
+ * @param val Burst length value encoded in bits [21:17].
+ */
+#define AMEBA_DMA_DST_BURST_SET(val) ((val & 0x1F) << 17)
+
+/**
+ * @brief Destination burst length: 1 transfer.
+ */
+#define AMEBA_DMA_DST_BURST_ONE AMEBA_DMA_DST_BURST_SET(0)
+
+/**
+ * @brief Destination burst length: 4 transfers.
+ */
+#define AMEBA_DMA_DST_BURST_FOUR AMEBA_DMA_DST_BURST_SET(1)
+
+/**
+ * @brief Destination burst length: 8 transfers.
+ */
+#define AMEBA_DMA_DST_BURST_EIGHT AMEBA_DMA_DST_BURST_SET(2)
+
+/**
+ * @brief Destination burst length: 16 transfers.
+ */
+#define AMEBA_DMA_DST_BURST_SIXTEEN AMEBA_DMA_DST_BURST_SET(3)
+
+/**
+ * @brief Set channel priority bits [24:22].
+ *
+ * @param val Channel priority value in range 0–7.
+ */
+#define AMEBA_DMA_CH_PRIORITY_SET(val) ((val & 0x7) << 22)
+
+/**
+ * @brief Typical peripheral TX configuration.
+ *
+ * Memory to peripheral, source address increment, destination address fixed.
+ */
+#define AMEBA_DMA_PERIPH_TX                                                                        \
+	(AMEBA_DMA_MEMORY_TO_PERIPH | AMEBA_DMA_SRC_ADDR_ADJ_INC | AMEBA_DMA_DST_ADDR_ADJ_NO_CHANGE)
+
+/**
+ * @brief Typical peripheral RX configuration.
+ *
+ * Peripheral to memory, source address fixed, destination address increment.
+ */
+#define AMEBA_DMA_PERIPH_RX                                                                        \
+	(AMEBA_DMA_PERIPH_TO_MEMORY | AMEBA_DMA_SRC_ADDR_ADJ_NO_CHANGE | AMEBA_DMA_DST_ADDR_ADJ_INC)
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_AMEBA_DMA_H_ */


### PR DESCRIPTION
**Description**

This PR adds the DMA driver support for Realtek Ameba series SoCs. The driver is implemented based on the standard Zephyr DMA API and supports the following series:

- amebad
- amebadplus
- amebag2

**Key features implemented:**

- Memory to Memory transfer
- Peripheral to Memory transfer
- Memory to Peripheral transfer