### PR TITLE
net: Split private net logging helper macros in own header

### DIFF
--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -370,11 +370,11 @@ static void eth_iface_init(struct net_if *iface)
 				if (net_addr_pton(NET_AF_INET, ipv4_nm_cmd_opt, &netmask) == 0) {
 					net_if_ipv4_set_netmask_by_addr(iface, &addr, &netmask);
 				} else {
-					NET_ERR("Invalid netmask: %s", ipv4_nm_cmd_opt);
+					LOG_ERR("Invalid netmask: %s", ipv4_nm_cmd_opt);
 				}
 			}
 		} else {
-			NET_ERR("Invalid address: %s", ipv4_addr_cmd_opt);
+			LOG_ERR("Invalid address: %s", ipv4_addr_cmd_opt);
 		}
 	}
 
@@ -382,7 +382,7 @@ static void eth_iface_init(struct net_if *iface)
 		if (net_addr_pton(NET_AF_INET, ipv4_gw_cmd_opt, &addr) == 0) {
 			net_if_ipv4_set_gw(iface, &addr);
 		} else {
-			NET_ERR("Invalid gateway: %s", ipv4_gw_cmd_opt);
+			LOG_ERR("Invalid gateway: %s", ipv4_gw_cmd_opt);
 		}
 	}
 #endif

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -612,7 +612,7 @@ static int cc1200_tx(const struct device *dev,
 	bool status = false;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -338,7 +338,7 @@ static int ieee802154_cc13xx_cc26xx_tx(const struct device *dev,
 	int retry = CONFIG_IEEE802154_CC13XX_CC26XX_RADIO_TX_RETRIES;
 
 	if (mode != IEEE802154_TX_MODE_CSMA_CA) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -682,7 +682,7 @@ static int ieee802154_cc13xx_cc26xx_subg_tx(const struct device *dev,
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
 		/* For backwards compatibility we only log an error but do not bail. */
-		NET_ERR("TX mode %d not supported - sending directly instead.", mode);
+		LOG_ERR("TX mode %d not supported - sending directly instead.", mode);
 	}
 
 	if (k_sem_take(&drv_data->lock, K_FOREVER)) {

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -789,7 +789,7 @@ static int cc2520_tx(const struct device *dev,
 	bool status;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -622,7 +622,7 @@ static int kw41z_tx(const struct device *dev, enum ieee802154_tx_mode mode,
 	unsigned int key;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1114,7 +1114,7 @@ static int mcr20a_tx(const struct device *dev,
 	int retval;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -627,7 +627,7 @@ static int nrf5_tx(const struct device *dev,
 		break;
 #endif /* CONFIG_NET_PKT_TXTIME */
 	default:
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -675,7 +675,7 @@ static int rf2xx_tx(const struct device *dev,
 		case IEEE802154_TX_MODE_TXTIME:
 		case IEEE802154_TX_MODE_TXTIME_CCA:
 		default:
-			NET_ERR("TX mode %d not supported", mode);
+			LOG_ERR("TX mode %d not supported", mode);
 			return -ENOTSUP;
 		}
 

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -271,7 +271,7 @@ static int upipe_tx(const struct device *dev,
 	uint8_t i, data;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
-		NET_ERR("TX mode %d not supported", mode);
+		LOG_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -382,7 +382,7 @@ static void ppp_change_state(struct ppp_driver_context *ctx,
 	NET_ASSERT(new_state >= STATE_HDLC_FRAME_START &&
 		   new_state <= STATE_HDLC_FRAME_DATA);
 
-	NET_DBG("[%p] state %s (%d) => %s (%d)",
+	LOG_DBG("[%p] state %s (%d) => %s (%d)",
 		ctx, ppp_driver_state_str(ctx->state), ctx->state,
 		ppp_driver_state_str(new_state), new_state);
 

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -21,7 +21,6 @@
 
 #include <zephyr/net/net_timeout.h>
 #include <zephyr/net/net_linkaddr.h>
-#include <zephyr/net/net_log.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -16,12 +16,12 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/net/net_timeout.h>
 #include <zephyr/net/net_linkaddr.h>
+#include <zephyr/net/net_log.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,30 +47,6 @@ extern "C" {
  */
 
 /** @cond INTERNAL_HIDDEN */
-
-/* Network subsystem logging helpers */
-#ifdef CONFIG_THREAD_NAME
-#define NET_DBG(fmt, ...) LOG_DBG("(%s): " fmt,				\
-			k_thread_name_get(k_current_get()), \
-			##__VA_ARGS__)
-#else
-#define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),	\
-				  ##__VA_ARGS__)
-#endif /* CONFIG_THREAD_NAME */
-#define NET_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
-#define NET_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
-#define NET_INFO(fmt, ...) LOG_INF(fmt,  ##__VA_ARGS__)
-
-/* Rate-limited network logging macros */
-#define NET_ERR_RATELIMIT(fmt, ...)  LOG_ERR_RATELIMIT(fmt, ##__VA_ARGS__)
-#define NET_WARN_RATELIMIT(fmt, ...) LOG_WRN_RATELIMIT(fmt, ##__VA_ARGS__)
-#define NET_INFO_RATELIMIT(fmt, ...) LOG_INF_RATELIMIT(fmt, ##__VA_ARGS__)
-#define NET_DBG_RATELIMIT(fmt, ...)  LOG_DBG_RATELIMIT(fmt, ##__VA_ARGS__)
-
-#define NET_HEXDUMP_DBG(_data, _length, _str)  LOG_HEXDUMP_DBG(_data, _length, _str)
-#define NET_HEXDUMP_ERR(_data, _length, _str)  LOG_HEXDUMP_ERR(_data, _length, _str)
-#define NET_HEXDUMP_WARN(_data, _length, _str) LOG_HEXDUMP_WRN(_data, _length, _str)
-#define NET_HEXDUMP_INFO(_data, _length, _str) LOG_HEXDUMP_INF(_data, _length, _str)
 
 #define NET_ASSERT(cond, ...) __ASSERT(cond, "" __VA_ARGS__)
 

--- a/include/zephyr/net/net_log.h
+++ b/include/zephyr/net/net_log.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Network subsystem logging helpers.
+ *
+ * These macros are private to the network subsystem and should not be used
+ * by the application or other subsystems.
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_NET_LOG_H_
+#define ZEPHYR_INCLUDE_NET_NET_LOG_H_
+
+#include <zephyr/logging/log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+#ifdef CONFIG_THREAD_NAME
+#define NET_DBG(fmt, ...) LOG_DBG("(%s): " fmt,				\
+			k_thread_name_get(k_current_get()), \
+			##__VA_ARGS__)
+#else
+#define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),	\
+				  ##__VA_ARGS__)
+#endif /* CONFIG_THREAD_NAME */
+#define NET_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
+#define NET_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
+#define NET_INFO(fmt, ...) LOG_INF(fmt,  ##__VA_ARGS__)
+
+/* Rate-limited network logging macros */
+#define NET_ERR_RATELIMIT(fmt, ...)  LOG_ERR_RATELIMIT(fmt, ##__VA_ARGS__)
+#define NET_WARN_RATELIMIT(fmt, ...) LOG_WRN_RATELIMIT(fmt, ##__VA_ARGS__)
+#define NET_INFO_RATELIMIT(fmt, ...) LOG_INF_RATELIMIT(fmt, ##__VA_ARGS__)
+#define NET_DBG_RATELIMIT(fmt, ...)  LOG_DBG_RATELIMIT(fmt, ##__VA_ARGS__)
+
+#define NET_HEXDUMP_DBG(_data, _length, _str)  LOG_HEXDUMP_DBG(_data, _length, _str)
+#define NET_HEXDUMP_ERR(_data, _length, _str)  LOG_HEXDUMP_ERR(_data, _length, _str)
+#define NET_HEXDUMP_WARN(_data, _length, _str) LOG_HEXDUMP_WRN(_data, _length, _str)
+#define NET_HEXDUMP_INFO(_data, _length, _str) LOG_HEXDUMP_INF(_data, _length, _str)
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_NET_LOG_H_ */

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -32,6 +32,7 @@
 #include <zephyr/net/net_time.h>
 #include <zephyr/net/ethernet_vlan.h>
 #include <zephyr/net/ptp_time.h>
+#include <zephyr/logging/log.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1287,7 +1288,7 @@ static ALWAYS_INLINE void net_pkt_set_stats_tick(struct net_pkt *pkt,
 						 uint32_t tick)
 {
 	if (pkt->detail.count >= NET_PKT_DETAIL_STATS_COUNT) {
-		NET_ERR("Detail stats count overflow (%d >= %d)",
+		LOG_ERR("Detail stats count overflow (%d >= %d)",
 			pkt->detail.count, NET_PKT_DETAIL_STATS_COUNT);
 		return;
 	}

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -558,7 +558,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 	otMessageSettings settings;
 	bool is_ip6 = PKT_IS_IPv6(pkt);
 
-	NET_DBG("Sending %s packet to ot stack", is_ip6 ? "IPv6" : "IPv4");
+	LOG_DBG("Sending %s packet to ot stack", is_ip6 ? "IPv6" : "IPv4");
 
 	settings.mPriority = OT_MESSAGE_PRIORITY_NORMAL;
 	settings.mLinkSecurityEnabled = true;
@@ -566,7 +566,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 	message = is_ip6 ? otIp6NewMessage(instance, &settings)
 			 : openthread_ip4_new_msg(instance, &settings);
 	if (!message) {
-		NET_ERR("Cannot allocate new message buffer");
+		LOG_ERR("Cannot allocate new message buffer");
 		goto exit;
 	}
 
@@ -579,7 +579,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 
 	for (buf = pkt->buffer; buf; buf = buf->frags) {
 		if (otMessageAppend(message, buf->data, buf->len) != OT_ERROR_NONE) {
-			NET_ERR("Error while appending to otMessage");
+			LOG_ERR("Error while appending to otMessage");
 			otMessageFree(message);
 			goto exit;
 		}
@@ -588,7 +588,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 	error = is_ip6 ? otIp6Send(instance, message) : openthread_nat64_send(instance, message);
 
 	if (error != OT_ERROR_NONE) {
-		NET_ERR("Error while calling %s [error: %d]",
+		LOG_ERR("Error while calling %s [error: %d]",
 			is_ip6 ? "otIp6Send" : "openthread_nat64_send", error);
 	}
 

--- a/modules/openthread/platform/radio_spinel.cpp
+++ b/modules/openthread/platform/radio_spinel.cpp
@@ -102,7 +102,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 	otMessageSettings settings;
 	bool is_ip4 = PKT_IS_IPv4(pkt);
 
-	NET_DBG("Sending %s packet to ot stack", is_ip4 ? "IPv4" : "IPv6");
+	LOG_DBG("Sending %s packet to ot stack", is_ip4 ? "IPv4" : "IPv6");
 
 	settings.mPriority = OT_MESSAGE_PRIORITY_NORMAL;
 	settings.mLinkSecurityEnabled = true;
@@ -121,7 +121,7 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 
 	for (buf = pkt->buffer; buf; buf = buf->frags) {
 		if (otMessageAppend(message, buf->data, buf->len) != OT_ERROR_NONE) {
-			NET_ERR("Error while appending to otMessage");
+			LOG_ERR("Error while appending to otMessage");
 			otMessageFree(message);
 			goto exit;
 		}
@@ -129,14 +129,14 @@ static void openthread_handle_frame_to_send(otInstance *instance, struct net_pkt
 #if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)
 	if (is_ip4) {
 		if (otNat64Send(instance, message) != OT_ERROR_NONE) {
-			NET_ERR("Error while calling otNat64Send");
+			LOG_ERR("Error while calling otNat64Send");
 			goto exit;
 		}
 	} else {
 #endif /* CONFIG_OPENTHREAD_NAT64_TRANSLATOR*/
 
 		if (otIp6Send(instance, message) != OT_ERROR_NONE) {
-			NET_ERR("Error while calling otIp6Send");
+			LOG_ERR("Error while calling otIp6Send");
 			goto exit;
 		}
 #if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)

--- a/samples/net/ethernet/lldp/src/main.c
+++ b/samples/net/ethernet/lldp/src/main.c
@@ -24,8 +24,6 @@ static struct lldp_system_name_tlv {
 
 static void set_optional_tlv(struct net_if *iface)
 {
-	NET_DBG("");
-
 	tlv.type_length = net_htons((LLDP_TLV_SYSTEM_NAME << 9) |
 				    ((sizeof(tlv) - sizeof(uint16_t)) & 0x01ff));
 

--- a/samples/net/mdns_responder/src/service.c
+++ b/samples/net/mdns_responder/src/service.c
@@ -44,12 +44,12 @@ static int echo_service(const struct sockaddr *server_addr)
 	r = socket(server_addr->sa_family, SOCK_STREAM, 0);
 	if (r == -1) {
 		r = -errno;
-		NET_DBG("socket() failed (%d)", r);
+		LOG_DBG("socket() failed (%d)", r);
 		return r;
 	}
 
 	server_fd = r;
-	NET_DBG("server_fd is %d", server_fd);
+	LOG_DBG("server_fd is %d", server_fd);
 
 	r = setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof(int));
 	if (r == -1) {
@@ -62,7 +62,7 @@ static int echo_service(const struct sockaddr *server_addr)
 	r = bind(server_fd, server_addr, sizeof(*server_addr));
 	if (r == -1) {
 		r = -errno;
-		NET_DBG("bind() failed (%d)", r);
+		LOG_DBG("bind() failed (%d)", r);
 		close(server_fd);
 		return r;
 	}
@@ -76,12 +76,12 @@ static int echo_service(const struct sockaddr *server_addr)
 	}
 
 	inet_ntop(server_addr->sa_family, addrp, addrstr, sizeof(addrstr));
-	NET_DBG("bound to [%s]:%u", addrstr, ntohs(*portp));
+	LOG_DBG("bound to [%s]:%u", addrstr, ntohs(*portp));
 
 	r = listen(server_fd, 1);
 	if (r == -1) {
 		r = -errno;
-		NET_DBG("listen() failed (%d)", r);
+		LOG_DBG("listen() failed (%d)", r);
 		close(server_fd);
 		return r;
 	}
@@ -90,19 +90,19 @@ static int echo_service(const struct sockaddr *server_addr)
 		len = sizeof(client_addr);
 		r = accept(server_fd, (struct sockaddr *)&client_addr, &len);
 		if (r == -1) {
-			NET_DBG("accept() failed (%d)", errno);
+			LOG_DBG("accept() failed (%d)", errno);
 			break;
 		}
 
 		client_fd = r;
 
 		inet_ntop(server_addr->sa_family, addrp, addrstr, sizeof(addrstr));
-		NET_DBG("accepted connection from [%s]:%u", addrstr, ntohs(*portp));
+		LOG_DBG("accepted connection from [%s]:%u", addrstr, ntohs(*portp));
 
 		/* send a banner */
 		r = welcome(client_fd);
 		if (r == -1) {
-			NET_DBG("send() failed (%d)", errno);
+			LOG_DBG("send() failed (%d)", errno);
 			close(client_fd);
 			continue;
 		}
@@ -111,13 +111,13 @@ static int echo_service(const struct sockaddr *server_addr)
 			/* echo 1 line at a time */
 			r = recv(client_fd, line, sizeof(line), 0);
 			if (r == -1) {
-				NET_DBG("recv() failed (%d)", errno);
+				LOG_DBG("recv() failed (%d)", errno);
 				close(client_fd);
 				break;
 			}
 
 			if (r == 0) {
-				NET_DBG("connection closed by peer");
+				LOG_DBG("connection closed by peer");
 				close(client_fd);
 				break;
 			}
@@ -126,7 +126,7 @@ static int echo_service(const struct sockaddr *server_addr)
 
 			r = send(client_fd, line, len, 0);
 			if (r == -1) {
-				NET_DBG("send() failed (%d)", errno);
+				LOG_DBG("send() failed (%d)", errno);
 				close(client_fd);
 				break;
 			}
@@ -180,7 +180,7 @@ void service(void)
 	while (r == 0) {
 		r = echo_service((struct sockaddr *)&server_addr);
 		if (r < 0) {
-			NET_ERR("Fatal echo server error, %d", r);
+			LOG_ERR("Fatal echo server error, %d", r);
 		}
 	}
 }

--- a/samples/net/ocpp/src/main.c
+++ b/samples/net/ocpp/src/main.c
@@ -15,6 +15,7 @@
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/netdb.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_context.h>

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -49,7 +49,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 	data->udp.sock = socket(bind_addr->sa_family, SOCK_DGRAM, IPPROTO_UDP);
 #endif
 	if (data->udp.sock < 0) {
-		NET_ERR("Failed to create UDP socket (%s): %d", data->proto,
+		LOG_ERR("Failed to create UDP socket (%s): %d", data->proto,
 			errno);
 		return -errno;
 	}
@@ -66,7 +66,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 	ret = setsockopt(data->udp.sock, SOL_TLS, TLS_SEC_TAG_LIST,
 			 sec_tag_list, sizeof(sec_tag_list));
 	if (ret < 0) {
-		NET_ERR("Failed to set UDP secure option (%s): %d", data->proto,
+		LOG_ERR("Failed to set UDP secure option (%s): %d", data->proto,
 			errno);
 		ret = -errno;
 	}
@@ -75,7 +75,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 	ret = setsockopt(data->udp.sock, SOL_TLS, TLS_DTLS_ROLE,
 			 &role, sizeof(role));
 	if (ret < 0) {
-		NET_ERR("Failed to set DTLS role secure option (%s): %d",
+		LOG_ERR("Failed to set DTLS role secure option (%s): %d",
 			data->proto, errno);
 		ret = -errno;
 	}
@@ -99,7 +99,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 
 	ret = bind(data->udp.sock, bind_addr, bind_addrlen);
 	if (ret < 0) {
-		NET_ERR("Failed to bind UDP socket (%s): %d", data->proto,
+		LOG_ERR("Failed to bind UDP socket (%s): %d", data->proto,
 			errno);
 		ret = -errno;
 	}
@@ -114,7 +114,7 @@ static int process_udp(struct data *data)
 	struct sockaddr client_addr;
 	socklen_t client_addr_len;
 
-	NET_INFO("Waiting for UDP packets on port %d (%s)...",
+	LOG_INF("Waiting for UDP packets on port %d (%s)...",
 		 MY_PORT, data->proto);
 
 	do {
@@ -125,7 +125,7 @@ static int process_udp(struct data *data)
 
 		if (received < 0) {
 			/* Socket error */
-			NET_ERR("UDP (%s): Connection error %d", data->proto,
+			LOG_ERR("UDP (%s): Connection error %d", data->proto,
 				errno);
 			ret = -errno;
 			break;
@@ -136,18 +136,18 @@ static int process_udp(struct data *data)
 		ret = sendto(data->udp.sock, data->udp.recv_buffer, received, 0,
 			     &client_addr, client_addr_len);
 		if (ret < 0) {
-			NET_ERR("UDP (%s): Failed to send %d", data->proto,
+			LOG_ERR("UDP (%s): Failed to send %d", data->proto,
 				errno);
 			ret = -errno;
 			break;
 		}
 
 		if (++data->udp.counter % 1000 == 0U) {
-			NET_INFO("%s UDP: Sent %u packets", data->proto,
+			LOG_INF("%s UDP: Sent %u packets", data->proto,
 				 data->udp.counter);
 		}
 
-		NET_DBG("UDP (%s): Received and replied with %d bytes",
+		LOG_DBG("UDP (%s): Received and replied with %d bytes",
 			data->proto, received);
 	} while (true);
 

--- a/subsys/net/conn_mgr/conn_mgr_connectivity.c
+++ b/subsys/net/conn_mgr/conn_mgr_connectivity.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(conn_mgr_conn, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/conn_mgr_monitor.h>
 #include <zephyr/net/conn_mgr_connectivity.h>

--- a/subsys/net/conn_mgr/conn_mgr_monitor.c
+++ b/subsys/net/conn_mgr/conn_mgr_monitor.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(conn_mgr, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/conn_mgr_connectivity.h>

--- a/subsys/net/conn_mgr/events_handler.c
+++ b/subsys/net/conn_mgr/events_handler.c
@@ -9,6 +9,7 @@ LOG_MODULE_DECLARE(conn_mgr, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include "conn_mgr_private.h"
 

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_hostname, CONFIG_NET_HOSTNAME_LOG_LEVEL);
 
 #include <zephyr/net/hostname.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/logging/log_backend_net.h>
 

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_6lo, CONFIG_NET_6LO_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/udp.h>
 

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_conn, CONFIG_NET_CONN_LOG_LEVEL);
 #include <zephyr/sys/util.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/udp.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(net_icmp, ICMP_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/random/random.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/icmp.h>
 

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_icmpv4, CONFIG_NET_ICMPV4_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/icmp.h>

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_icmpv6, CONFIG_NET_ICMPV6_LOG_LEVEL);
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/icmp.h>

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv4_acd.c
+++ b/subsys/net/ip/ipv4_acd.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_ipv4_acd, CONFIG_NET_IPV4_ACD_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/random/random.h>

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ipv4_autoconf, CONFIG_NET_IPV4_AUTO_LOG_LEVEL);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/random/random.h>
 
 static struct net_mgmt_event_callback mgmt4_acd_cb;

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 #endif /* CONFIG_NET_IPV6_IID_STABLE */
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -14,6 +14,7 @@ LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ipv6_nd, CONFIG_NET_IPV6_ND_LOG_LEVEL);
 #include <errno.h>
 #include <stdlib.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_ipv6_pe, CONFIG_NET_IPV6_PE_LOG_LEVEL);
 #include <psa/crypto.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(net_nbr, CONFIG_NET_IPV6_NBR_CACHE_LOG_LEVEL);
 #include <errno.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 
 #include "net_private.h"
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(net_ctx, CONFIG_NET_CONTEXT_LOG_LEVEL);
 
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_offload.h>

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #include <zephyr/net/conn_mgr_connectivity.h>
 #include <zephyr/net/ipv4_autoconf.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <zephyr/net/ipv4_autoconf.h>
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_mgmt, CONFIG_NET_MGMT_EVENT_LOG_LEVEL);
 
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/debug/stack.h>
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_stats, NET_LOG_LEVEL);
 #include <stdlib.h>
 #include <errno.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/prometheus/collector.h>
 #include <zephyr/net/prometheus/counter.h>
 #include <zephyr/net/prometheus/gauge.h>

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_tc, CONFIG_NET_TC_LOG_LEVEL);
 #include <string.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_route, CONFIG_NET_ROUTE_LOG_LEVEL);
 
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_ip.h>

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
 #include <psa/crypto.h>
 #endif
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/udp.h>

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -11,6 +11,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_udp, CONFIG_NET_UDP_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include "net_private.h"
 #include "udp_internal.h"
 #include "net_stats.h"

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(net_utils, CONFIG_NET_UTILS_LOG_LEVEL);
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/socketcan.h>

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(net_l2_dummy, LOG_LEVEL_NONE);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_mgmt.h>
 

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/ethernet_bridge.h>

--- a/subsys/net/l2/ethernet/bridge/bridge_fdb.c
+++ b/subsys/net/l2/ethernet/bridge/bridge_fdb.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_eth_bridge_fdb, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/ethernet_bridge.h>
 #include <zephyr/net/ethernet_bridge_fdb.h>
 

--- a/subsys/net/l2/ethernet/bridge/bridge_input.c
+++ b/subsys/net/l2/ethernet/bridge/bridge_input.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(net_eth_bridge_input, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 
 #include <zephyr/net/ethernet_bridge.h>
+#include <zephyr/net/net_log.h>
 
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_FDB)
 #include <zephyr/net/ethernet_bridge_fdb.h>

--- a/subsys/net/l2/ethernet/dsa/dsa.c
+++ b/subsys/net/l2/ethernet/dsa/dsa.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_dsa, CONFIG_NET_DSA_LOG_LEVEL);
 #include <stdlib.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/dsa.h>

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/drivers/ptp_clock.h>
 #include <zephyr/net/ethernet_mgmt.h>

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include "gptp_messages.h"
 #include "gptp_md.h"
 #include "gptp_data_set.h"

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 
 #include "gptp_messages.h"
 #include "gptp_data_set.h"

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/drivers/ptp_clock.h>
 
 #include "gptp_messages.h"

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_lldp, CONFIG_NET_LLDP_LOG_LEVEL);
 #include <stdlib.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/lldp.h>

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(net_ethernet_vlan, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_ieee802154, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <zephyr/net/capture.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_linkaddr.h>

--- a/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_ieee802154_6lo_fragment, CONFIG_NET_L2_IEEE802154_LOG_LE
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/udp.h>

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ieee802154_frame, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 
 #include <ipv6.h>
 #include <nbr.h>

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ieee802154_mgmt, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <errno.h>
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/net/ieee802154_mgmt.h>
 #include <zephyr/net/ieee802154.h>

--- a/subsys/net/l2/ieee802154/ieee802154_security.c
+++ b/subsys/net/l2/ieee802154/ieee802154_security.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ieee802154_security, CONFIG_NET_L2_IEEE802154_LOG_LEVEL)
 
 #include <zephyr/crypto/crypto.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 
 extern const uint8_t level_2_authtag_len[4];
 

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -15,6 +15,7 @@
 #define __IEEE802154_UTILS_H__
 
 #include <zephyr/net/ieee802154_radio.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/sys/util_macro.h>
 
 /**

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/openthread.h>

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/openthread.h>
 

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -9,6 +9,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 #include <zephyr/net/ppp.h>

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 #include <zephyr/net/ppp.h>

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -9,6 +9,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>

--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/ppp.h>

--- a/subsys/net/l2/ppp/network.c
+++ b/subsys/net/l2/ppp/network.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/net/ppp.h>

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 #include <zephyr/net/ppp.h>

--- a/subsys/net/l2/ppp/pap.c
+++ b/subsys/net/l2/ppp/pap.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 #include "ppp_internal.h"

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_virtual_ipip, CONFIG_NET_L2_IPIP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/virtual.h>
 
 #include "ipv4.h"

--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(net_virtual, CONFIG_NET_L2_VIRTUAL_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/virtual.h>

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/toolchain.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/wifi_mgmt.h>
 #ifdef CONFIG_WIFI_NM
 #include <zephyr/net/wifi_nm.h>

--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_wifi_utils, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/wifi.h>
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/wifi_utils.h>

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_capture, CONFIG_NET_CAPTURE_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/virtual_mgmt.h>

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/coap.h>
 #include <zephyr/net/coap_mgmt.h>
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/dhcpv4.h>
 #include <zephyr/net/dhcpv6.h>
 #include <zephyr/net/net_mgmt.h>

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 #include <stdbool.h>
 #include <zephyr/random/random.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_mgmt.h>

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/dhcpv4.h>
 #include <zephyr/net/dhcpv4_server.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_dhcpv6, CONFIG_NET_DHCPV6_LOG_LEVEL);
 #include <zephyr/net/dhcpv6.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/random/random.h>
 #include <zephyr/sys/math_extras.h>
 

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(net_dns_dispatcher, CONFIG_DNS_SOCKET_DISPATCHER_LOG_LEVEL);
 #include <zephyr/sys/slist.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket_service.h>
 

--- a/subsys/net/lib/dns/dns_cache.c
+++ b/subsys/net/lib/dns/dns_cache.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include "dns_cache.h"
 
 LOG_MODULE_REGISTER(net_dns_cache, CONFIG_DNS_RESOLVER_LOG_LEVEL);

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/dns_sd.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(net_llmnr_responder, CONFIG_LLMNR_RESPONDER_LOG_LEVEL);
 
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket_service.h>

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket_service.h>

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 
 #include <zephyr/sys/crc.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/igmp.h>

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #include <stdlib.h>
 
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/http/status.h>

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -18,6 +18,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net/http/service.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/zvfs/eventfd.h>

--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/http/service.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/sys/base64.h>
 #include <zephyr/net/websocket.h>
 #include <psa/crypto.h>

--- a/subsys/net/lib/midi2/netmidi2.c
+++ b/subsys/net/lib/midi2/netmidi2.c
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <zephyr/net/socket_service.h>
+#include <zephyr/net/net_log.h>
 
 #if defined(CONFIG_MIDI2_UMP_STREAM_RESPONDER)
 #include <ump_stream_responder.h>

--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -13,6 +13,7 @@
 LOG_MODULE_REGISTER(net_mqtt, CONFIG_MQTT_LOG_LEVEL);
 
 #include <zephyr/net/mqtt.h>
+#include <zephyr/net/net_log.h>
 
 #include "mqtt_transport.h"
 #include "mqtt_internal.h"

--- a/subsys/net/lib/mqtt/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt/mqtt_decoder.c
@@ -13,6 +13,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_mqtt_dec, CONFIG_MQTT_LOG_LEVEL);
 
+#include <zephyr/net/net_log.h>
 #include "mqtt_internal.h"
 #include "mqtt_os.h"
 

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_mqtt_enc, CONFIG_MQTT_LOG_LEVEL);
 
 #include "mqtt_internal.h"
 #include "mqtt_os.h"
+#include <zephyr/net/net_log.h>
 
 static const struct mqtt_utf8 mqtt_3_1_0_proto_desc =
 	MQTT_UTF8_LITERAL("MQIsdp");

--- a/subsys/net/lib/mqtt/mqtt_rx.c
+++ b/subsys/net/lib/mqtt/mqtt_rx.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_mqtt_rx, CONFIG_MQTT_LOG_LEVEL);
 #include "mqtt_internal.h"
 #include "mqtt_transport.h"
 #include "mqtt_os.h"
+#include <zephyr/net/net_log.h>
 
 /** @file mqtt_rx.c
  *

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_mqtt_sock_tcp, CONFIG_MQTT_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
+#include <zephyr/net/net_log.h>
 
 #include "mqtt_os.h"
 

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_mqtt_sock_tls, CONFIG_MQTT_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
+#include <zephyr/net/net_log.h>
 
 #include "mqtt_os.h"
 

--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -12,6 +12,7 @@ LOG_MODULE_DECLARE(net_shell);
 #include <zephyr/shell/shell_uart.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_event.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/coap_mgmt.h>
 #include <zephyr/net/ethernet_mgmt.h>
 

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -10,6 +10,7 @@
 LOG_MODULE_REGISTER(net_sntp, CONFIG_SNTP_LOG_LEVEL);
 
 #include <zephyr/net/sntp.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/sys/clock.h>
 #include "sntp_pkt.h"
 #include <limits.h>

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_sock_addr, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_offload.h>
 #include <zephyr/internal/syscall_handler.h>

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <zephyr/tracing/tracing.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/internal/syscall_handler.h>
 

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_sock_can, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net/net_context.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/internal/syscall_handler.h>

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -15,6 +15,7 @@ LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_context.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/tracing/tracing.h>
 #include <zephyr/net/socket.h>

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(net_sock_packet, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net/net_context.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -9,6 +9,7 @@ LOG_MODULE_REGISTER(net_sock_svc, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/zvfs/eventfd.h>
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/random/random.h>
 #include <zephyr/internal/syscall_handler.h>

--- a/subsys/net/lib/trickle/trickle.c
+++ b/subsys/net/lib/trickle/trickle.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_trickle, CONFIG_NET_TRICKLE_LOG_LEVEL);
 #include <zephyr/random/random.h>
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/trickle.h>
 
 #define TICK_MAX ~0

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/websocket.h>

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/net_log.h>
 
 #include "zperf_internal.h"
 #include "zperf_session.h"

--- a/subsys/net/lib/zperf/zperf_raw_uploader.c
+++ b/subsys/net/lib/zperf/zperf_raw_uploader.c
@@ -10,6 +10,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/zperf.h>
 
 #include "zperf_internal.h"

--- a/subsys/net/lib/zperf/zperf_session.c
+++ b/subsys/net/lib/zperf/zperf_session.c
@@ -10,6 +10,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/udp.h>
 

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -16,6 +16,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #include <zephyr/shell/shell.h>
 
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/net_if.h>

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #include <zephyr/linker/sections.h>
 #include <zephyr/toolchain.h>
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/zperf.h>

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -11,6 +11,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 #include <errno.h>
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/zperf.h>
 

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #include <zephyr/kernel.h>
 
 #include <zephyr/net/mld.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/zperf.h>

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -9,6 +9,7 @@ LOG_MODULE_DECLARE(net_zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/zperf.h>
 

--- a/subsys/net/pkt_filter/base.c
+++ b/subsys/net/pkt_filter/base.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(npf_base, CONFIG_NET_PKT_FILTER_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt_filter.h>
 #include <zephyr/spinlock.h>
 

--- a/subsys/net/pkt_filter/ethernet.c
+++ b/subsys/net/pkt_filter/ethernet.c
@@ -8,6 +8,7 @@
 LOG_MODULE_REGISTER(npf_ethernet, CONFIG_NET_PKT_FILTER_LOG_LEVEL);
 
 #include <zephyr/net/ethernet.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt_filter.h>
 
 static bool addr_mask_compare(struct net_eth_addr *addr1,

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -417,14 +417,14 @@ static void telnet_accept(struct zsock_pollfd *pollfd)
 	sock = zsock_accept(pollfd->fd, &addr, &addrlen);
 	if (sock < 0) {
 		ret = -errno;
-		NET_ERR("Telnet accept error (%d)", ret);
+		LOG_ERR("Telnet accept error (%d)", ret);
 		return;
 	}
 
 	if (sh_telnet->fds[SOCK_ID_CLIENT].fd > 0) {
 		/* Too many connections. */
 		ret = 0;
-		NET_ERR("Telnet client already connected.");
+		LOG_ERR("Telnet client already connected.");
 		goto error;
 	}
 
@@ -508,7 +508,7 @@ static void telnet_server_cb(struct net_socket_service_event *evt)
 		return;
 	}
 
-	NET_ERR("Unexpected FD received for telnet, restarting service.");
+	LOG_ERR("Unexpected FD received for telnet, restarting service.");
 
 error:
 	telnet_restart_server();

--- a/tests/net/icmp/src/main.c
+++ b/tests/net/icmp/src/main.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(net_test, ICMP_LOG_LEVEL);
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/icmp.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_offload.h>

--- a/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_ieee802154_fake_driver, LOG_LEVEL_DBG);
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 /** FAKE ieee802.15.4 driver **/

--- a/tests/net/ieee802154/l2/src/ieee802154_shell_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_shell_test.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_ieee802154_mgmt_test, LOG_LEVEL_DBG);
 #include <zephyr/net/ieee802154_mgmt.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/shell/shell.h>
 

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_ieee802154_test, LOG_LEVEL_DBG);
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/socket.h>
 

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/ztest.h>
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_core.h>

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <zephyr/net_buf.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"

--- a/tests/net/lib/http_server/tls/src/main.c
+++ b/tests/net/lib/http_server/tls/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/net/http/service.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/sys/util.h>

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 
 #include <zephyr/net/mld.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_core.h>

--- a/tests/net/pmtu/src/main.c
+++ b/tests/net/pmtu/src/main.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_PMTU_LOG_LEVEL);
 #include <zephyr/ztest.h>
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_core.h>

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net_buf.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_log.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/net/socket.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 
 /* This test suite verifies that NET_AF_PACKET sockets behave according to well known behaviors.
  * Note, that this is not well standardized and relies on behaviors known from Linux or FreeBSD.

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/sys/sem.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net_buf.h>
 
 #include "../../socket_helpers.h"

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/ztest_assert.h>
 #include <zephyr/sys/sem.h>
 
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/dummy.h>
 

--- a/tests/net/socket/tls_ext/src/main.c
+++ b/tests/net/socket/tls_ext/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/sys/util.h>

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 
 #include <zephyr/misc/lorem_ipsum.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/websocket.h>
 #include <zephyr/sys/fdtable.h>


### PR DESCRIPTION
Split these private macros into their own header. That way
a) we are a bit clearer about them being private
b) we avoid including log/logging.h from a quite common header which causes some trouble

And remove all uses of these private networking subsystem macros from outside the networking subsystem and its tests.

Note net_pkt.h keeps using logging/log.h but that is due to its own conditional definitions.

(It is probably easier to review the PR per commit, the biggest commit is all the same)

The changes have been tested with a full twister run on native_sim and qemu_x86