### PR TITLE
Bluetooth: Document opaque types

### DIFF
--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -125,7 +125,10 @@ extern "C" {
 #define BT_AICS_ERR_GAIN_MODE_NOT_ALLOWED          0x84
 /** @} */
 
-/** @brief Opaque Audio Input Control Service instance. */
+/**
+ * @struct bt_aics
+ * @brief Opaque Audio Input Control Service instance.
+ */
 struct bt_aics;
 
 /** @brief Structure for initializing a Audio Input Control Service instance. */

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -628,16 +628,28 @@ struct bt_bap_ascs_rsp {
  */
 #define BT_BAP_ASCS_RSP(c, r) (struct bt_bap_ascs_rsp) { .code = c, .reason = r }
 
-/** @brief Abstract Audio Broadcast Source structure. */
+/**
+ * @struct bt_bap_broadcast_source
+ * @brief Abstract Audio Broadcast Source structure.
+ */
 struct bt_bap_broadcast_source;
 
-/** @brief Abstract Audio Broadcast Sink structure. */
+/**
+ * @struct bt_bap_broadcast_sink
+ * @brief Abstract Audio Broadcast Sink structure.
+ */
 struct bt_bap_broadcast_sink;
 
-/** @brief Abstract Audio Unicast Group structure. */
+/**
+ * @struct bt_bap_unicast_group
+ * @brief Abstract Audio Unicast Group structure.
+ */
 struct bt_bap_unicast_group;
 
-/** @brief Abstract Audio Endpoint structure. */
+/**
+ * @struct bt_bap_ep
+ * @brief Abstract Audio Endpoint structure.
+ */
 struct bt_bap_ep;
 
 /** Struct to hold subgroup specific information for the receive state */

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -47,10 +47,16 @@
 extern "C" {
 #endif
 
-/** @brief Abstract Audio Broadcast Source structure. */
+/**
+ * @struct bt_cap_broadcast_source
+ * @brief Abstract Audio Broadcast Source structure.
+ */
 struct bt_cap_broadcast_source;
 
-/** @brief Abstract CAP Unicast Group structure. */
+/**
+ * @struct bt_cap_unicast_group
+ * @brief Abstract CAP Unicast Group structure.
+ */
 struct bt_cap_unicast_group;
 
 /**

--- a/include/zephyr/bluetooth/audio/ccp.h
+++ b/include/zephyr/bluetooth/audio/ccp.h
@@ -47,7 +47,10 @@ extern "C" {
  * @ingroup bt_ccp
  * @{
  */
-/** @brief Abstract Call Control Server Telephone Bearer structure. */
+/**
+ * @struct bt_ccp_call_control_server_bearer
+ * @brief Abstract Call Control Server Telephone Bearer structure.
+ */
 struct bt_ccp_call_control_server_bearer;
 
 /**
@@ -144,10 +147,17 @@ int bt_ccp_call_control_server_get_bearer_uci(struct bt_ccp_call_control_server_
  * @ingroup bt_ccp
  * @{
  */
-/** Abstract Call Control Client structure. */
+
+/**
+ * @struct bt_ccp_call_control_client
+ * @brief Abstract Call Control Client structure.
+ */
 struct bt_ccp_call_control_client;
 
-/** Abstract Call Control Client bearer structure. */
+/**
+ * @struct bt_ccp_call_control_client_bearer
+ * @brief Abstract Call Control Client bearer structure.
+ */
 struct bt_ccp_call_control_client_bearer;
 
 /** Struct with information about bearers of a client */

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -93,7 +93,10 @@ extern "C" {
  */
 #define BT_CSIP_DATA_RSI(_rsi) BT_DATA(BT_DATA_CSIS_RSI, _rsi, BT_CSIP_RSI_SIZE)
 
-/** @brief Opaque Coordinated Set Identification Service instance. */
+/**
+ * @struct bt_csip_set_member_svc_inst
+ * @brief Opaque Coordinated Set Identification Service instance.
+ */
 struct bt_csip_set_member_svc_inst;
 
 /** Callback structure for the Coordinated Set Identification Service */

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -56,7 +56,10 @@ extern "C" {
 /** Preset name maximum length */
 #define BT_HAS_PRESET_NAME_MAX 40
 
-/** @brief Opaque Hearing Access Service object. */
+/**
+ * @struct bt_has
+ * @brief Opaque Hearing Access Service object.
+ */
 struct bt_has;
 
 /** Hearing Aid device type */

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -64,7 +64,10 @@ extern "C" {
 #define BT_MICP_MUTE_DISABLED                      0x02
 /** @} */
 
-/** @brief Opaque Microphone Controller instance. */
+/**
+ * @struct bt_micp_mic_ctlr
+ * @brief Opaque Microphone Controller instance.
+ */
 struct bt_micp_mic_ctlr;
 
 /** @brief Register parameters structure for Microphone Control Service */

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -208,7 +208,10 @@ extern "C" {
  */
 #define BT_TBS_MAX_UCI_SIZE 6
 
-/** @brief Opaque Telephone Bearer Service instance. */
+/**
+ * @struct bt_tbs_instance
+ * @brief Opaque Telephone Bearer Service instance.
+ */
 struct bt_tbs_instance;
 
 /**

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -81,7 +81,10 @@ extern "C" {
 #define BT_VCP_STATE_MUTED                     0x01
 /** @} */
 
-/** @brief Opaque Volume Control Service instance. */
+/**
+ * @struct bt_vcp_vol_ctlr
+ * @brief Opaque Volume Control Service instance.
+ */
 struct bt_vcp_vol_ctlr;
 
 /** Register structure for Volume Control Service */

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -66,7 +66,10 @@ extern "C" {
 #define BT_VOCS_MAX_OFFSET                         255
 /** @} */
 
-/** @brief Opaque Volume Offset Control Service instance. */
+/**
+ * @struct bt_vocs
+ * @brief Opaque Volume Offset Control Service instance.
+ */
 struct bt_vocs;
 
 /** @brief Structure for registering a Volume Offset Control Service instance. */

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -84,10 +84,16 @@ extern "C" {
 			* BT_HCI_LE_BYTES_PER_FEATURE_PAGE),        \
 		(0U)))
 
-/** Opaque type representing an advertiser. */
+/**
+ * @struct bt_le_ext_adv
+ * @brief Opaque type representing an advertiser.
+ */
 struct bt_le_ext_adv;
 
-/** Opaque type representing an periodic advertising sync. */
+/**
+ * @struct bt_le_per_adv_sync
+ * @brief Opaque type representing a periodic advertising sync.
+ */
 struct bt_le_per_adv_sync;
 
 /* Don't require everyone to include conn.h */

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -314,7 +314,10 @@ enum bt_a2dp_codec_type {
 	BT_A2DP_VENDOR = 0xff
 };
 
-/** @brief A2DP structure */
+/**
+ * @struct bt_a2dp
+ * @brief A2DP structure
+ */
 struct bt_a2dp;
 
 /* Internal to pass build */

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -287,9 +287,15 @@ typedef enum __packed {
 	BT_AVRCP_STATUS_SUCCESS = BT_AVRCP_STATUS_OPERATION_COMPLETED,
 } bt_avrcp_status_t;
 
-/** @brief AVRCP CT structure */
+/**
+ * @struct bt_avrcp_ct
+ * @brief AVRCP CT structure
+ */
 struct bt_avrcp_ct;
-/** @brief AVRCP TG structure */
+/**
+ * @struct bt_avrcp_tg
+ * @brief AVRCP TG structure
+ */
 struct bt_avrcp_tg;
 
 struct bt_avrcp_unit_info_rsp {

--- a/include/zephyr/bluetooth/classic/avrcp_cover_art.h
+++ b/include/zephyr/bluetooth/classic/avrcp_cover_art.h
@@ -29,9 +29,15 @@
 extern "C" {
 #endif
 
-/** @brief AVRCP CT structure */
+/**
+ * @struct bt_avrcp_ct
+ * @brief AVRCP CT structure
+ */
 struct bt_avrcp_ct;
-/** @brief AVRCP TG structure */
+/**
+ * @struct bt_avrcp_tg
+ * @brief AVRCP TG structure
+ */
 struct bt_avrcp_tg;
 
 /**

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -41,7 +41,16 @@ enum bt_hfp_ag_indicator {
 #define BT_HFP_AG_CODEC_MSBC    0x02
 #define BT_HFP_AG_CODEC_LC3_SWB 0x03
 
+/**
+ * @struct bt_hfp_ag
+ * @brief HFP AG structure
+ */
 struct bt_hfp_ag;
+
+/**
+ * @struct bt_hfp_ag_call
+ * @brief HFP AG call structure
+ */
 struct bt_hfp_ag_call;
 
 /** @typedef bt_hfp_ag_query_subscriber_func_t

--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -28,8 +28,16 @@ extern "C" {
 #define BT_HFP_HF_CODEC_MSBC    0x02
 #define BT_HFP_HF_CODEC_LC3_SWB 0x03
 
+/**
+ * @struct bt_hfp_hf
+ * @brief HFP HF structure
+ */
 struct bt_hfp_hf;
 
+/**
+ * @struct bt_hfp_hf_call
+ * @brief HFP HF call structure
+ */
 struct bt_hfp_hf_call;
 
 /** @brief The status of the call

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -36,7 +36,10 @@
 extern "C" {
 #endif
 
-/** Opaque type representing a connection to a remote device */
+/**
+ * @struct bt_conn
+ * @brief Opaque type representing a connection to a remote device
+ */
 struct bt_conn;
 
 /** Connection parameters for LE connections */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -376,8 +376,10 @@ struct bt_iso_tx_info {
 	uint16_t seq_num;
 };
 
-
-/** Opaque type representing an Connected Isochronous Group (CIG). */
+/**
+ * @struct bt_iso_cig
+ * @brief Opaque type representing a Connected Isochronous Group (CIG).
+ */
 struct bt_iso_cig;
 
 /** @brief Connected Isochronous Group (CIG) parameters */
@@ -488,7 +490,10 @@ struct bt_iso_connect_param {
 	struct bt_conn *acl;
 };
 
-/** Opaque type representing a Broadcast Isochronous Group (BIG). */
+/**
+ * @struct bt_iso_big
+ * @brief Opaque type representing a Broadcast Isochronous Group (BIG).
+ */
 struct bt_iso_big;
 
 /** @brief Broadcast Isochronous Group (BIG) creation parameters */

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -552,7 +552,10 @@ struct bt_ots_obj_metadata {
 	uint32_t                       props;
 };
 
-/** @brief Opaque OTS instance. */
+/**
+ * @struct bt_ots
+ * @brief Opaque OTS instance.
+ */
 struct bt_ots;
 
 /** @brief Descriptor for OTS object addition */


### PR DESCRIPTION
Bluetooth uses a variety of opaque types with varying levels of documentations. However doxygen won't pick up these struct unless they explicitly contain the `@struct` keyword.

This commit adds `@struct` for all opaque types, which allows them to show up in the documentation (as opaque types), but also allows us to `@ref` them from other places.