### PR TITLE
cmake: remove underscore prefix on local variables

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1956,8 +1956,8 @@ function(zephyr_constants_library)
 
   add_dependencies(zephyr_generated_headers ${target_name})
 
-  foreach(_dep IN LISTS ARG_DEPENDS)
-    add_dependencies(${lib_name} ${_dep}_h)
+  foreach(dep IN LISTS ARG_DEPENDS)
+    add_dependencies(${lib_name} ${dep}_h)
   endforeach()
 endfunction()
 


### PR DESCRIPTION
Remove `_` prefix on local CMake variables in `zephyr_constants_library()` per review feedback: underscore prefixing conflicts with the CMake convention used for function overloading.

Follow-up from #104861 which was closed after the heap series (#104999) was merged. This remaining fixup commit still needs to land.