### PR TITLE
sysbuild: cmake: Use supplied image for variant source image

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -489,8 +489,8 @@ function(ExternalZephyrVariantProject_Add)
     )
   endif()
 
-  get_target_property(ZBUILD_BOARD ${DEFAULT_IMAGE} BOARD)
-  get_target_property(ZBUILD_SOURCE_DIR ${DEFAULT_IMAGE} APP_SOURCE_DIR)
+  get_target_property(ZBUILD_BOARD ${ZBUILD_SOURCE_APP} BOARD)
+  get_target_property(ZBUILD_SOURCE_DIR ${ZBUILD_SOURCE_APP} APP_SOURCE_DIR)
   get_property(var_type CACHE ${ZBUILD_SOURCE_APP}_${shared_var} PROPERTY TYPE)
 
   set_property(


### PR DESCRIPTION
Fixes wrongly using the default image instead of the supplied user image in the variant image function
