### PR TITLE
drivers: i2c: fix i2c_infineon_pdl error recovery

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -149,6 +149,7 @@ static void ifx_master_event_handler(void *callback_arg, uint32_t event)
 		/* In case of error abort transfer */
 		(void)_i2c_abort_async(dev);
 		data->error = true;
+		k_sem_give(&data->transfer_sem);
 	}
 
 	/* Release semaphore if operation complete


### PR DESCRIPTION
The Infineon i2c driver will lock the calling thread on an error event because the transfer semaphore is never released. This change allows the driver to recover and resume normal operation.