### PR TITLE
drivers: sensor: st: Pass internal return values to fetch caller

### DIFF
--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -231,24 +231,31 @@ static int iis2iclx_sample_fetch(const struct device *dev,
 #if defined(CONFIG_IIS2ICLX_SENSORHUB)
 	struct iis2iclx_data *data = dev->data;
 #endif /* CONFIG_IIS2ICLX_SENSORHUB */
+	int ret = 0;
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		iis2iclx_sample_fetch_accel(dev);
+		ret = iis2iclx_sample_fetch_accel(dev);
 		break;
 #if defined(CONFIG_IIS2ICLX_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		iis2iclx_sample_fetch_temp(dev);
+		ret = iis2iclx_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		iis2iclx_sample_fetch_accel(dev);
+		ret = iis2iclx_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_IIS2ICLX_ENABLE_TEMP)
-		iis2iclx_sample_fetch_temp(dev);
+		ret = iis2iclx_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_IIS2ICLX_SENSORHUB)
 		if (data->shub_inited) {
-			iis2iclx_sample_fetch_shub(dev);
+			ret = iis2iclx_sample_fetch_shub(dev);
 		}
 #endif
 		break;
@@ -256,7 +263,7 @@ static int iis2iclx_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void iis2iclx_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc.c
@@ -213,25 +213,30 @@ static int iis2mdc_sample_fetch_temp(const struct device *dev)
 static int iis2mdc_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:
 	case SENSOR_CHAN_MAGN_XYZ:
-		iis2mdc_sample_fetch_mag(dev);
+		ret = iis2mdc_sample_fetch_mag(dev);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
-		iis2mdc_sample_fetch_temp(dev);
+		ret = iis2mdc_sample_fetch_temp(dev);
 		break;
 	case SENSOR_CHAN_ALL:
-		iis2mdc_sample_fetch_mag(dev);
-		iis2mdc_sample_fetch_temp(dev);
+		ret = iis2mdc_sample_fetch_mag(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = iis2mdc_sample_fetch_temp(dev);
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static DEVICE_API(sensor, iis2mdc_driver_api) = {

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc.c
@@ -25,15 +25,18 @@ static int iis3dhhc_sample_fetch(const struct device *dev,
 {
 	struct iis3dhhc_data *data = dev->data;
 	int16_t raw_accel[3];
+	int32_t ret = 0;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ACCEL_XYZ || chan == SENSOR_CHAN_ALL);
 
-	iis3dhhc_acceleration_raw_get(data->ctx, raw_accel);
-	data->acc[0] = raw_accel[0];
-	data->acc[1] = raw_accel[1];
-	data->acc[2] = raw_accel[2];
+	ret = iis3dhhc_acceleration_raw_get(data->ctx, raw_accel);
+	if (ret == 0) {
+		data->acc[0] = raw_accel[0];
+		data->acc[1] = raw_accel[1];
+		data->acc[2] = raw_accel[2];
+	}
 
-	return 0;
+	return ret;
 }
 
 static inline void iis3dhhc_convert(struct sensor_value *val,

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -350,36 +350,47 @@ static int ism330dhcx_sample_fetch_shub(const struct device *dev)
 static int ism330dhcx_sample_fetch(const struct device *dev,
 				   enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		ism330dhcx_sample_fetch_accel(dev);
+		ret = ism330dhcx_sample_fetch_accel(dev);
 #if defined(CONFIG_ISM330DHCX_SENSORHUB)
 		ism330dhcx_sample_fetch_shub(dev);
 #endif
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		ism330dhcx_sample_fetch_gyro(dev);
+		ret = ism330dhcx_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		ism330dhcx_sample_fetch_temp(dev);
+		ret = ism330dhcx_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		ism330dhcx_sample_fetch_accel(dev);
-		ism330dhcx_sample_fetch_gyro(dev);
+		ret = ism330dhcx_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = ism330dhcx_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
-		ism330dhcx_sample_fetch_temp(dev);
+		ret = ism330dhcx_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_ISM330DHCX_SENSORHUB)
-		ism330dhcx_sample_fetch_shub(dev);
+		ret = ism330dhcx_sample_fetch_shub(dev);
 #endif
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void ism330dhcx_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lis2de12/lis2de12.c
+++ b/drivers/sensor/st/lis2de12/lis2de12.c
@@ -192,26 +192,31 @@ static int lis2de12_sample_fetch_temp(const struct device *dev)
 static int lis2de12_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lis2de12_sample_fetch_accel(dev);
+		ret = lis2de12_sample_fetch_accel(dev);
 		break;
 #if defined(CONFIG_LIS2DE12_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lis2de12_sample_fetch_temp(dev);
+		ret = lis2de12_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lis2de12_sample_fetch_accel(dev);
+		ret = lis2de12_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LIS2DE12_ENABLE_TEMP)
-		lis2de12_sample_fetch_temp(dev);
+		ret = lis2de12_sample_fetch_temp(dev);
 #endif
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lis2de12_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/st/lis2ds12/lis2ds12.c
@@ -184,22 +184,27 @@ static int lis2ds12_sample_fetch_accel(const struct device *dev)
 static int lis2ds12_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lis2ds12_sample_fetch_accel(dev);
+		ret = lis2ds12_sample_fetch_accel(dev);
 		break;
 #if defined(CONFIG_LIS2DS12_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
 		/* ToDo:
-		lis2ds12_sample_fetch_temp(dev)
+		ret = lis2ds12_sample_fetch_temp(dev)
 		*/
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lis2ds12_sample_fetch_accel(dev);
+		ret = lis2ds12_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LIS2DS12_ENABLE_TEMP)
 		/* ToDo:
-		lis2ds12_sample_fetch_temp(dev)
+		ret = lis2ds12_sample_fetch_temp(dev)
 		*/
 #endif
 		break;
@@ -207,7 +212,7 @@ static int lis2ds12_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lis2ds12_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lis2du12/lis2du12.c
+++ b/drivers/sensor/st/lis2du12/lis2du12.c
@@ -227,18 +227,20 @@ static int lis2du12_sample_fetch_accel(const struct device *dev)
 static int lis2du12_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lis2du12_sample_fetch_accel(dev);
+		ret = lis2du12_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_ALL:
-		lis2du12_sample_fetch_accel(dev);
+		ret = lis2du12_sample_fetch_accel(dev);
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lis2du12_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -289,25 +289,30 @@ static int lis2mdl_sample_fetch_temp(const struct device *dev)
 static int lis2mdl_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:
 	case SENSOR_CHAN_MAGN_XYZ:
-		lis2mdl_sample_fetch_mag(dev);
+		ret = lis2mdl_sample_fetch_mag(dev);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
-		lis2mdl_sample_fetch_temp(dev);
+		ret = lis2mdl_sample_fetch_temp(dev);
 		break;
 	case SENSOR_CHAN_ALL:
-		lis2mdl_sample_fetch_mag(dev);
-		lis2mdl_sample_fetch_temp(dev);
+		ret = lis2mdl_sample_fetch_mag(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lis2mdl_sample_fetch_temp(dev);
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static DEVICE_API(sensor, lis2mdl_driver_api) = {

--- a/drivers/sensor/st/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/st/lsm6ds0/lsm6ds0.c
@@ -202,31 +202,38 @@ static int lsm6ds0_sample_fetch(const struct device *dev,
 			chan == SENSOR_CHAN_DIE_TEMP ||
 #endif
 			chan == SENSOR_CHAN_GYRO_XYZ);
+	int ret = 0;
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lsm6ds0_sample_fetch_accel(dev);
+		ret = lsm6ds0_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		lsm6ds0_sample_fetch_gyro(dev);
+		ret = lsm6ds0_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lsm6ds0_sample_fetch_temp(dev);
+		ret = lsm6ds0_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lsm6ds0_sample_fetch_accel(dev);
-		lsm6ds0_sample_fetch_gyro(dev);
+		ret = lsm6ds0_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lsm6ds0_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LSM6DS0_ENABLE_TEMP)
-		lsm6ds0_sample_fetch_temp(dev);
+		ret = lsm6ds0_sample_fetch_temp(dev);
 #endif
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lsm6ds0_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl.c
@@ -426,47 +426,61 @@ static int lsm6dsl_sample_fetch_press(const struct device *dev)
 static int lsm6dsl_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
+	int ret = 0;
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lsm6dsl_sample_fetch_accel(dev);
+		ret = lsm6dsl_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		lsm6dsl_sample_fetch_gyro(dev);
+		ret = lsm6dsl_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lsm6dsl_sample_fetch_temp(dev);
+		ret = lsm6dsl_sample_fetch_temp(dev);
 		break;
 #endif
 #if defined(CONFIG_LSM6DSL_EXT0_LIS2MDL) || defined(CONFIG_LSM6DSL_EXT0_LIS3MDL)
 	case SENSOR_CHAN_MAGN_XYZ:
-		lsm6dsl_sample_fetch_magn(dev);
+		ret = lsm6dsl_sample_fetch_magn(dev);
 		break;
 #endif
 #if defined(CONFIG_LSM6DSL_EXT0_LPS22HB)
 	case SENSOR_CHAN_AMBIENT_TEMP:
 	case SENSOR_CHAN_PRESS:
-		lsm6dsl_sample_fetch_press(dev);
+		ret = lsm6dsl_sample_fetch_press(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lsm6dsl_sample_fetch_accel(dev);
-		lsm6dsl_sample_fetch_gyro(dev);
+		ret = lsm6dsl_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lsm6dsl_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
-		lsm6dsl_sample_fetch_temp(dev);
+		ret = lsm6dsl_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_LSM6DSL_EXT0_LIS2MDL) || defined(CONFIG_LSM6DSL_EXT0_LIS3MDL)
-		lsm6dsl_sample_fetch_magn(dev);
+		ret = lsm6dsl_sample_fetch_magn(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_LSM6DSL_EXT0_LPS22HB)
-		lsm6dsl_sample_fetch_press(dev);
+		ret = lsm6dsl_sample_fetch_press(dev);
 #endif
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lsm6dsl_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -353,28 +353,38 @@ static int lsm6dso_sample_fetch(const struct device *dev,
 #if defined(CONFIG_LSM6DSO_SENSORHUB)
 	struct lsm6dso_data *data = dev->data;
 #endif /* CONFIG_LSM6DSO_SENSORHUB */
+	int ret = 0;
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lsm6dso_sample_fetch_accel(dev);
+		ret = lsm6dso_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		lsm6dso_sample_fetch_gyro(dev);
+		ret = lsm6dso_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lsm6dso_sample_fetch_temp(dev);
+		ret = lsm6dso_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lsm6dso_sample_fetch_accel(dev);
-		lsm6dso_sample_fetch_gyro(dev);
+		ret = lsm6dso_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lsm6dso_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
-		lsm6dso_sample_fetch_temp(dev);
+		ret = lsm6dso_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_LSM6DSO_SENSORHUB)
 		if (data->shub_inited) {
-			lsm6dso_sample_fetch_shub(dev);
+			ret = lsm6dso_sample_fetch_shub(dev);
 		}
 #endif
 		break;
@@ -382,7 +392,7 @@ static int lsm6dso_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lsm6dso_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -371,28 +371,38 @@ static int lsm6dso16is_sample_fetch(const struct device *dev,
 #if defined(CONFIG_LSM6DSO16IS_SENSORHUB)
 	struct lsm6dso16is_data *data = dev->data;
 #endif /* CONFIG_LSM6DSO16IS_SENSORHUB */
+	int ret = 0;
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lsm6dso16is_sample_fetch_accel(dev);
+		ret = lsm6dso16is_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		lsm6dso16is_sample_fetch_gyro(dev);
+		ret = lsm6dso16is_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DSO16IS_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lsm6dso16is_sample_fetch_temp(dev);
+		ret = lsm6dso16is_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lsm6dso16is_sample_fetch_accel(dev);
-		lsm6dso16is_sample_fetch_gyro(dev);
+		ret = lsm6dso16is_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lsm6dso16is_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LSM6DSO16IS_ENABLE_TEMP)
-		lsm6dso16is_sample_fetch_temp(dev);
+		ret = lsm6dso16is_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_LSM6DSO16IS_SENSORHUB)
 		if (data->shub_inited) {
-			lsm6dso16is_sample_fetch_shub(dev);
+			ret = lsm6dso16is_sample_fetch_shub(dev);
 		}
 #endif
 		break;
@@ -400,7 +410,7 @@ static int lsm6dso16is_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static inline void lsm6dso16is_accel_convert(struct sensor_value *val, int raw_val,

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -942,28 +942,38 @@ static int lsm6dsv16x_sample_fetch(const struct device *dev,
 #if defined(CONFIG_LSM6DSV16X_SENSORHUB)
 	struct lsm6dsv16x_data *data = dev->data;
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
+	int ret = 0;
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		lsm6dsv16x_sample_fetch_accel(dev);
+		ret = lsm6dsv16x_sample_fetch_accel(dev);
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		lsm6dsv16x_sample_fetch_gyro(dev);
+		ret = lsm6dsv16x_sample_fetch_gyro(dev);
 		break;
 #if defined(CONFIG_LSM6DSV16X_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
-		lsm6dsv16x_sample_fetch_temp(dev);
+		ret = lsm6dsv16x_sample_fetch_temp(dev);
 		break;
 #endif
 	case SENSOR_CHAN_ALL:
-		lsm6dsv16x_sample_fetch_accel(dev);
-		lsm6dsv16x_sample_fetch_gyro(dev);
+		ret = lsm6dsv16x_sample_fetch_accel(dev);
+		if (ret != 0) {
+			break;
+		}
+		ret = lsm6dsv16x_sample_fetch_gyro(dev);
+		if (ret != 0) {
+			break;
+		}
 #if defined(CONFIG_LSM6DSV16X_ENABLE_TEMP)
-		lsm6dsv16x_sample_fetch_temp(dev);
+		ret = lsm6dsv16x_sample_fetch_temp(dev);
+		if (ret != 0) {
+			break;
+		}
 #endif
 #if defined(CONFIG_LSM6DSV16X_SENSORHUB)
 		if (data->shub_inited) {
-			lsm6dsv16x_sample_fetch_shub(dev);
+			ret = lsm6dsv16x_sample_fetch_shub(dev);
 		}
 #endif
 		break;


### PR DESCRIPTION
A number of ST sensor drivers do not pass back a negative return code when the internal fetch calls fail. Because of this, the caller receives a good return code even when the sensor read actually failed, leading to the caller reading outdated/wrong data. Implements #105295.