### PR TITLE
libc: minimal: annotate intentional overflow checks in strtoul/ll

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtoll.c
+++ b/lib/libc/minimal/source/stdlib/strtoll.c
@@ -108,6 +108,7 @@ long long strtoll(const char *nptr, char **endptr, register int base)
 			any = -1;
 		} else {
 			any = 1;
+			/* coverity[INTEGER_OVERFLOW] */
 			acc *= base;
 			acc += c;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -89,6 +89,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 			any = -1;
 		} else {
 			any = 1;
+			/* coverity[INTEGER_OVERFLOW] */
 			acc *= base;
 			acc += c;
 		}


### PR DESCRIPTION
Coverity issues #84798 and #84799 flag potential integer overflows during accumulator multiplication. However, both strtoul and strtoull already implement preventative cutoff/cutlim logic to ensure overflow is detected before it occurs.

Added Coverity annotations to silence these false positives as the math is protected by existing bounds checks.

Fixes #84799
Fixes #84798