### PR TITLE
drivers: sensor: icm4268x: annotate intentional unsigned comparison

### DIFF
--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -430,6 +430,7 @@ static int icm4268x_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			data->shift = 9;
 			data->readings[count].temperature =
 				icm4268x_read_temperature_from_packet(buffer);
+		/* coverity[unsigned_compare] */
 		} else if (IS_ACCEL(chan_spec.chan_type) && has_accel) {
 			/* Decode accel */
 			struct sensor_three_axis_data *data =


### PR DESCRIPTION
The IS_ACCEL macro checks if a channel is within the accelerometer range. Because SENSOR_CHAN_ACCEL_X currently evaluates to 0 and the channel type is unsigned, Coverity flags this as a redundant comparison.

Added a coverity[unsigned_compare] annotation to silence the warning. This preserves the macro's logic, ensuring the check remains valid even if the underlying enum order is modified in the future.

Fixes #100002