### PR TITLE
ethernet: dwmac_stm32h7x: add support for H5/H7RS series and phy-connection-type

### DIFF
--- a/drivers/ethernet/Kconfig.dwmac
+++ b/drivers/ethernet/Kconfig.dwmac
@@ -27,7 +27,8 @@ config ETH_DWMAC
 config ETH_DWMAC_STM32H7X
 	bool "Synopsys DesignWare MAC driver for STM32 series"
 	depends on !ETH_STM32_HAL
-	depends on SOC_SERIES_STM32H7X \
+	depends on SOC_SERIES_STM32H5X \
+		   || SOC_SERIES_STM32H7X \
 		   || SOC_SERIES_STM32H7RSX
 	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
 	select ETH_DWMAC
@@ -37,7 +38,7 @@ config ETH_DWMAC_STM32H7X
 	select CRC
 	default y
 	help
-	  This enables the Synopsys DesignWare MAC driver on STM32 H7/H7RS
+	  This enables the Synopsys DesignWare MAC driver on STM32 H5/H7/H7RS
 	  series SoCs.
 
 config ETH_DWMAC_MMU

--- a/drivers/ethernet/Kconfig.dwmac
+++ b/drivers/ethernet/Kconfig.dwmac
@@ -25,9 +25,10 @@ config ETH_DWMAC
 	  - various hardware offloads (when available)
 
 config ETH_DWMAC_STM32H7X
-	bool "Synopsys DesignWare MAC driver for STM32H7 series"
+	bool "Synopsys DesignWare MAC driver for STM32 series"
 	depends on !ETH_STM32_HAL
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X \
+		   || SOC_SERIES_STM32H7RSX
 	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
 	select ETH_DWMAC
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
@@ -36,8 +37,8 @@ config ETH_DWMAC_STM32H7X
 	select CRC
 	default y
 	help
-	  This enables the Synopsys DesignWare MAC driver on STM32H7 series
-	  SoCs.
+	  This enables the Synopsys DesignWare MAC driver on STM32 H7/H7RS
+	  series SoCs.
 
 config ETH_DWMAC_MMU
 	bool "Synopsys DesignWare MAC driver for MMU based platforms"

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -27,12 +27,25 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/irq.h>
+#include <stm32_ll_system.h>
 
 #include "eth_dwmac_priv.h"
 
 #define ST_OUI_B0 0x00
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
+
+#if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
+#define PHY_MODE LL_SYSCFG_ETH_MII
+#elif DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
+#define PHY_MODE LL_SYSCFG_ETH_RMII
+#else
+#error "Unsupported PHY connection type"
+#endif
+#define STM32_CONFIGURE_ETH_PHY_MODE() do {                                                        \
+	__HAL_RCC_SYSCFG_CLK_ENABLE();                                                             \
+	LL_SYSCFG_SetPHYInterface(PHY_MODE);                                                       \
+} while (0)
 
 PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
@@ -43,7 +56,6 @@ static struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 
 int dwmac_bus_init(struct dwmac_priv *p)
 {
-	uint32_t reg_addr, reg_val;
 	int ret;
 
 	p->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
@@ -62,15 +74,7 @@ int dwmac_bus_init(struct dwmac_priv *p)
 		return ret;
 	}
 
-	/* set SYSCFGEN in RCC_APB4ENR */
-	reg_addr = DT_REG_ADDR(DT_INST(0, st_stm32h7_rcc)) + 0xf4;
-	reg_val = sys_read32(reg_addr);
-	sys_write32(reg_val | BIT(1), reg_addr);
-
-	/* set RMII mode in SYSCFG_PMCR */
-	reg_addr = 0x58000404;  /* no DT node? */
-	reg_val = sys_read32(reg_addr);
-	sys_write32(reg_val | 0x03800000, reg_addr);
+	STM32_CONFIGURE_ETH_PHY_MODE();
 
 	p->base_addr = DT_REG_ADDR(DT_INST_PARENT(0));
 	return 0;

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -35,7 +35,21 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+
+#if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
+#define PHY_MODE LL_SBS_ETH_MII
+#elif DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
+#define PHY_MODE LL_SBS_ETH_RMII
+#else
+#error "Unsupported PHY connection type"
+#endif
+#define STM32_CONFIGURE_ETH_PHY_MODE() do {                                                        \
+	__HAL_RCC_SBS_CLK_ENABLE();                                                                \
+	LL_SBS_SetPHYInterface(PHY_MODE);                                                          \
+} while (0)
+
+#elif defined(CONFIG_SOC_SERIES_STM32H7X)
 
 #if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
 #define PHY_MODE LL_SYSCFG_ETH_MII
@@ -101,7 +115,7 @@ int dwmac_bus_init(struct dwmac_priv *p)
 #if defined(CONFIG_NOCACHE_MEMORY)
 #define __desc_mem __nocache __aligned(4)
 #else
-#error "missing memory attribute for descriptors"
+#define __desc_mem __aligned(4)
 #endif
 
 /* Descriptor rings in uncached memory */

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -35,6 +35,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+
 #if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
 #define PHY_MODE LL_SYSCFG_ETH_MII
 #elif DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
@@ -46,6 +48,22 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 	__HAL_RCC_SYSCFG_CLK_ENABLE();                                                             \
 	LL_SYSCFG_SetPHYInterface(PHY_MODE);                                                       \
 } while (0)
+
+#elif defined(CONFIG_SOC_SERIES_STM32H7RSX)
+
+#if DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
+#define PHY_MODE LL_SBS_ETH_PHYSEL_GMII_MII
+#elif DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
+#define PHY_MODE LL_SBS_ETH_PHYSEL_RMII
+#else
+#error "Unsupported PHY connection type"
+#endif
+#define STM32_CONFIGURE_ETH_PHY_MODE() do {                                                        \
+	__HAL_RCC_SBS_CLK_ENABLE();                                                                \
+	LL_SBS_SetEthernetPhy(PHY_MODE);                                                           \
+} while (0)
+
+#endif
 
 PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -33,3 +33,4 @@ tests:
     platform_allow:
       - stm32h735g_disco
       - nucleo_h753zi
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -34,3 +34,4 @@ tests:
       - stm32h735g_disco
       - nucleo_h753zi
       - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
+      - stm32h573i_dk

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -32,3 +32,4 @@ tests:
       - CONFIG_ETH_PHY_DRIVER=n
     platform_allow:
       - stm32h735g_disco
+      - nucleo_h753zi


### PR DESCRIPTION
This PR adds support to configure the phy connection type to the value specified in device tree. Instead of open coding values, this now utilizes the STM32 Low-Level APIs.

Also add support for STM32H7RS and STM32H5 series which have a similar Ethernet MAC to the H7 series, but with some differences with respect to configuration of phy connection type. 