### PR TITLE
drivers: clock_control: Infineon peripheral clock control cleanup

### DIFF
--- a/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
+++ b/boards/infineon/cy8ckit_041s_max/cy8ckit_041s_max_common.dtsi
@@ -35,33 +35,23 @@ spi1: &scb1 {
 
 &peri_clk_div0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <0>;
 };
 
 &peri_clk_div1 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <2>;
 };
 
 &peri_clk_div2 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <1>;
 };
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
 	clock-div = <11500>;
 };
 
 &peri_clk_div4 {
 	status = "okay";
-	resource-type = <IFX_RSC_ADC>;
-	resource-instance = <0>;
 	clock-div = <4>;
 };
 

--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp_common.dtsi
@@ -35,33 +35,23 @@ spi1: &scb1 {
 
 &peri_clk_div0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <0>;
 };
 
 &peri_clk_div1 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <1>;
 };
 
 &peri_clk_div2 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <1>;
 };
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
 	clock-div = <11500>;
 };
 
 &peri_clk_div4 {
 	status = "okay";
-	resource-type = <IFX_RSC_ADC>;
-	resource-instance = <0>;
 	clock-div = <4>;
 };
 

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
@@ -39,8 +39,6 @@ uart3: &scb3 {
 
 &peri0_group4_8bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <3>;
 	clock-div = <109>;
 };
 

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk_psc3m5fds2afq1_ns.dts
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk_psc3m5fds2afq1_ns.dts
@@ -39,8 +39,6 @@ uart3: &scb3 {
 
 &peri0_group4_8bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <3>;
 	clock-div = <109>;
 };
 

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -67,8 +67,6 @@ uart2: &scb2 {
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <2>;
 	clock-div = <1>;
 };
 

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
@@ -38,8 +38,6 @@
 
 &peri0_group1_16_5bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <4>;
 	clock-div = <1>;
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -57,8 +57,6 @@ uart2: &scb2 {
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <2>;
 	clock-div = <1>;
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
@@ -196,8 +196,6 @@
 
 &peri0_group1_16_5bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <4>;
 	clock-div = <1>;
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
@@ -64,15 +64,11 @@
 
 &peri1_group2_8bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SDHC>;
-	resource-instance = <0>;
 	clock-div = <2>;
 };
 
 &peri1_group3_8bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SDHC>;
-	resource-instance = <1>;
 	clock-div = <2>;
 };
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -212,6 +212,12 @@ Clock Control
   ``bflb,bl70x-root-clk`` and ``bflb,bl61x-flash-clk`` got respectively replaced with
   :dtcompatible:`bflb,flash-clk`, :dtcompatible:`bflb,pll` and :dtcompatible:`bflb,root-clk`.
 
+* The :dtcompatible:`infineon,peri-div` clock control binding has removed the ``resource-type``,
+  ``resource-instance``, and ``resource-channel`` properties. These properties are no longer used by
+  the driver and the corresponding fields have been removed from the driver's internal data structures.
+  Out-of-tree boards using this compatible must remove these properties from their devicetree nodes.
+  (:github:`105393`)
+
 Controller Area Network (CAN)
 =============================
 

--- a/drivers/clock_control/clock_control_infineon_peri_clock.c
+++ b/drivers/clock_control/clock_control_infineon_peri_clock.c
@@ -22,12 +22,10 @@
 #include <cy_systick.h>
 
 struct ifx_peri_clock_data {
-	struct ifx_cat1_resource_inst hw_resource;
 	struct ifx_cat1_clock clock;
 	uint16_t divider;
 	uint8_t frac_divider;
 	uint8_t div_type;
-	CySCB_Type *reg_addr;
 };
 
 static inline en_clk_dst_t peri_pclk_build_en_clk_dst(uint8_t output, uint8_t group,
@@ -122,9 +120,6 @@ static int ifx_cat1_peri_clock_init(const struct device *dev)
 		.div_type = DT_INST_PROP(n, div_type),                                             \
 		.divider = DT_INST_PROP(n, clock_div),                                             \
 		.frac_divider = DT_INST_PROP_OR(n, div_frac_value, 0),                             \
-		.hw_resource = {.type = DT_INST_PROP(n, resource_type),                            \
-				.block_num = DT_INST_PROP(n, resource_instance),                   \
-				.channel_num = DT_INST_PROP_OR(n, resource_channel, 0)},           \
 		PERI_CLOCK_INIT(n)};                                                               \
                                                                                                    \
 	static int ifx_cat1_peri_clock_init_##n(const struct device *dev)                          \

--- a/drivers/i2s/i2s_infineon.c
+++ b/drivers/i2s/i2s_infineon.c
@@ -71,7 +71,6 @@ struct ifx_i2s_data {
 	struct queue_item rx_queue_buffer[RX_QUEUE_SIZE];
 	struct queue_item tx_queue_buffer[TX_QUEUE_SIZE];
 	struct ifx_cat1_clock clock;
-	struct ifx_cat1_resource_inst resource;
 	uint8_t clock_peri_group;
 	bool tx_waiting_to_start;
 };
@@ -969,11 +968,6 @@ static DEVICE_API(i2s, ifx_i2s_api) = {
 			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
 			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
 		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
-	},                                                                                         \
-	.resource = {                                                                              \
-		.type = DT_INST_PROP_BY_PHANDLE(n, clocks, resource_type),                         \
-		.block_num = DT_INST_PROP_BY_PHANDLE(n, clocks, resource_instance),                \
-		.channel_num = DT_INST_PROP_BY_PHANDLE(n, clocks, resource_channel),               \
 	},                                                                                         \
 	.clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 

--- a/dts/bindings/clock/infineon,peri-div.yaml
+++ b/dts/bindings/clock/infineon,peri-div.yaml
@@ -50,29 +50,3 @@ properties:
       The fraction part of the divider. The fractional divider can be 0-31, thus
       it divides the clock by 1/32 for each count. To divide the clock by 11/32nds
       set this value to 11.
-
-  resource-type:
-    type: int
-    required: true
-    description: |
-      Resource type that the peripheral clock is assigned to:
-      &scb3     : resource-type = IFX_RSC_SCB
-      &tcpwm0_0 : resource-type = IFX_RSC_TCPWM
-
-  resource-instance:
-    type: int
-    required: true
-    description: |
-      Resource instance that the peripheral clock is assigned to:
-      &scb0 : resource-instance = <0>
-      &scb3 : resource-instance = <3>
-      &scb5 : resource-instance = <5>
-      &tcpwm0_3: resource-instance = <0>
-
-  resource-channel:
-    type: int
-    description: |
-      Resource instance's channel that the peripheral clock is assigned to:
-      &tcpwm0_0 : resource-channel = <0>
-      &tcpwm0_4 : resource-channel = <4>
-      &tcpwm1_2 : resource-channel = <2>

--- a/samples/basic/blinky_pwm/boards/cy8ckit_041s_max.overlay
+++ b/samples/basic/blinky_pwm/boards/cy8ckit_041s_max.overlay
@@ -40,5 +40,4 @@
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-channel = <1>;
 };

--- a/samples/basic/blinky_pwm/boards/cy8cproto_041tp.overlay
+++ b/samples/basic/blinky_pwm/boards/cy8cproto_041tp.overlay
@@ -40,5 +40,4 @@
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-channel = <1>;
 };

--- a/samples/basic/blinky_pwm/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/basic/blinky_pwm/boards/cyw920829m2evk_02_common.overlay
@@ -36,9 +36,6 @@
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <9600>;
 };
 

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
@@ -38,9 +38,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <7>;
 	clock-div = <9600>;
 };
 

--- a/samples/basic/fade_led/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/basic/fade_led/boards/cyw920829m2evk_02_common.overlay
@@ -42,9 +42,6 @@
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <9600>;
 };
 
@@ -61,9 +58,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <1>;
-	resource-channel = <5>;
 	clock-div = <9600>;
 };
 

--- a/samples/basic/fade_led/boards/kit_psc3m5_evk.overlay
+++ b/samples/basic/fade_led/boards/kit_psc3m5_evk.overlay
@@ -53,9 +53,6 @@
 
 &peri0_group5_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <1>;
-	resource-channel = <4>;
 	clock-div = <9600>;
 };
 

--- a/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
@@ -38,9 +38,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <7>;
 	clock-div = <9600>;
 };
 

--- a/samples/drivers/audio/dmic/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/audio/dmic/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -35,9 +35,6 @@ dmic_dev: &dmic0 {
 
 &peri1_group1_16_5bit_2 {
 	status = "okay";
-	resource-type = <IFX_RSC_PDM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <2>;
 	div-frac-value = <7>;
 };

--- a/samples/drivers/counter/alarm/boards/cy8ckit_041s_max.overlay
+++ b/samples/drivers/counter/alarm/boards/cy8ckit_041s_max.overlay
@@ -16,7 +16,6 @@
 };
 
 &peri_clk_div3 {
-	resource-channel = <1>;
 	clock-div = <11519>;
 	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/cy8cproto_041tp.overlay
+++ b/samples/drivers/counter/alarm/boards/cy8cproto_041tp.overlay
@@ -16,6 +16,5 @@
 };
 
 &peri_clk_div3 {
-	resource-channel = <1>;
 	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/drivers/counter/alarm/boards/cyw920829m2evk_02_common.overlay
@@ -18,8 +18,5 @@
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <1>;
 	clock-div = <9599>;
 };

--- a/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
@@ -18,8 +18,5 @@
 
 &peri0_group5_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <1>;
 	clock-div = <2400>;
 };

--- a/samples/drivers/counter/alarm/boards/kit_pse84_eval_common.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_pse84_eval_common.overlay
@@ -18,8 +18,5 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <1>;
 	clock-div = <9600>;
 };

--- a/tests/drivers/audio/dmic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/audio/dmic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -41,9 +41,6 @@
 
 &peri1_group1_16_5bit_2 {
 	status = "okay";
-	resource-type = <IFX_RSC_PDM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <2>;
 	div-frac-value = <1>;
 };

--- a/tests/drivers/i2s/i2s_api/boards/kit_pse84_common.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/kit_pse84_common.overlay
@@ -33,9 +33,6 @@
 
 &peri1_group1_16_5bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TDM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <4>;
 	div-frac-value = <28>;
 };

--- a/tests/drivers/i2s/i2s_speed/boards/kit_pse84_common.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/kit_pse84_common.overlay
@@ -33,9 +33,6 @@
 
 &peri1_group1_16_5bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TDM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <4>;
 	div-frac-value = <28>;
 };

--- a/tests/drivers/pwm/pwm_api/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/cyw920829m2evk_02_common.overlay
@@ -27,9 +27,6 @@
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <9600>;
 };
 

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
@@ -27,9 +27,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <7>;
 	clock-div = <9600>;
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8ckit_041s_max.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8ckit_041s_max.overlay
@@ -31,9 +31,6 @@
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <4>;
 	clock-div = <24>;
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8cproto_041tp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/cy8cproto_041tp.overlay
@@ -31,9 +31,6 @@
 
 &peri_clk_div3 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <0>;
 	clock-div = <24>;
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/cyw920829m2evk_02_common.overlay
@@ -30,9 +30,6 @@
 
 &peri0_group1_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <1>;
 	clock-div = <9600>;
 };
 
@@ -49,9 +46,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <1>;
-	resource-channel = <0>;
 	clock-div = <9600>;
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_psc3m5_evk.overlay
@@ -30,9 +30,6 @@
 
 &peri0_group5_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <1>;
-	resource-channel = <4>;
 	clock-div = <25>;
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
@@ -30,9 +30,6 @@
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <0>;
-	resource-channel = <1>;
 	clock-div = <9600>;
 };
 
@@ -49,9 +46,6 @@
 
 &peri0_group1_16bit_2 {
 	status = "okay";
-	resource-type = <IFX_RSC_TCPWM>;
-	resource-instance = <1>;
-	resource-channel = <19>;
 	clock-div = <9600>;
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_psc3m5_evk.overlay
@@ -51,6 +51,4 @@ spi1: &scb4 {
 
 &peri0_group4_16bit_0 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <4>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_common.overlay
@@ -35,8 +35,6 @@ spi1: &scb10 {
 
 &peri0_group1_16bit_2 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <10>;
 };
 
 &p16_1_scb10_spi_m_mosi {

--- a/tests/drivers/uart/uart_async_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_psc3m5_evk.overlay
@@ -33,7 +33,5 @@ dut: &scb4 {
 
 &peri0_group4_8bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <4>;
 	clock-div = <109>;
 };

--- a/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -33,7 +33,5 @@ dut: &scb5 {
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <5>;
 	clock-div = <109>;
 };

--- a/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -33,7 +33,5 @@ dut: &scb5 {
 
 &peri0_group1_16bit_1 {
 	status = "okay";
-	resource-type = <IFX_RSC_SCB>;
-	resource-instance = <5>;
 	clock-div = <109>;
 };


### PR DESCRIPTION
Cleanup the Infineon peripheral clock driver by removing several bindings that are no longer used.  