### PR TITLE
net: ethernet: bridge: ensure valid MAC

### DIFF
--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -246,6 +246,9 @@ int eth_bridge_iface_remove(struct net_if *br, struct net_if *iface)
 static void random_linkaddr(uint8_t *linkaddr, size_t len)
 {
 	sys_rand_get(linkaddr, len);
+
+	linkaddr[0] |= 0x02;  /* force LAA bit */
+	linkaddr[0] &= ~0x01; /* clear multicast bit */
 }
 
 static void bridge_iface_init(struct net_if *iface)


### PR DESCRIPTION
The random_linkaddr() function may generate MAC addresses with the multicast bit set. Source MAC addresses must not be multicast, and randomly generated virtual interface addresses should have the locally administered (LAA) bit set.

Force the LAA bit and clear the multicast bit after generating the random address.
This matches the behavior used in other Zephyr virtual interfaces.


Fixes #104723