### PR TITLE
drivers: sensor: icm42x70: validate FIFO packet count

### DIFF
--- a/drivers/sensor/tdk/icm42x70/icm42x70.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70.c
@@ -600,6 +600,12 @@ static int icm42x70_fetch_from_fifo(const struct device *dev)
 			return status;
 		}
 
+		/* CID 520276: Constrain packet_count to the size of the driver buffer */
+		if (packet_count * packet_size > sizeof(data->driver.fifo_data)) {
+			LOG_WRN("FIFO count (%d) exceeds buffer size, capping.", packet_count);
+			packet_count = sizeof(data->driver.fifo_data) / packet_size;
+		}
+
 		/* Read FIFO data */
 		status |= inv_imu_read_reg(&data->driver, FIFO_DATA, packet_size * packet_count,
 					   (uint8_t *)&data->driver.fifo_data);


### PR DESCRIPTION
The driver was using a packet count value read directly from the hardware to control a loop bound and a register read size. If the hardware reported a value exceeding the internal buffer size, it could lead to a buffer overflow or an untrusted loop bound.

Add a check to cap the packet_count based on the actual size of the driver's FIFO data buffer.

Fixes #90512