### PR TITLE
drivers: crypto: ataes132a: fix integer overflows in CRC and commands

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -52,11 +52,16 @@ static int ataes132a_send_command(const struct device *dev, uint8_t opcode,
 	uint8_t crc[2];
 	int i, i2c_return;
 
-	count = nparams + 5;
-	if (count > 64) {
+	/*
+	 * CID 487763: Validate nparams against both the 8-bit overflow
+	 * and the physical command buffer limit (64).
+	 */
+	if (nparams > (64 - 5)) {
 		LOG_ERR("command too large for command buffer");
 		return -EDOM;
 	}
+
+	count = nparams + 5;
 
 	/* If there is a command in progress, idle wait until it is available.
 	 * If there is concurrency protection around the driver, this should

--- a/drivers/crypto/crypto_ataes132a_priv.h
+++ b/drivers/crypto/crypto_ataes132a_priv.h
@@ -124,7 +124,11 @@ void ataes132a_atmel_crc(uint8_t *input, uint8_t length,
 			bit = !!(input[i] & BIT(j));
 			higher_crc_bit = crc >> 15;
 			double_carry = (crc & BIT(8)) << 1;
-			crc <<= 1;
+			/*
+			 * Explicitly mask to 16-bit to prevent
+			 * overflow/promotion warnings
+			 */
+			crc = (crc << 1) & 0xFFFF;
 			crc |= double_carry;
 
 			if ((bit ^ higher_crc_bit)) {


### PR DESCRIPTION
This commit addresses two integer handling issues in the ataes132a crypto driver identified by coverity scans.

1. In ataes132a_send_command, added a centralized validation check to ensure the 'nparams' value, when combined with the 5-byte packet overhead, does not exceed the 8-bit 'count' limit or the physical 64-byte command buffer. This prevents a potential wrap- around that would cause the chip to receive an invalid length byte.

2. In the Atmel CRC calculation, added an explicit cast to uint16_t during the bit-shift operation. This prevents unintended integer promotion and satisfies static analysis regarding potential overflows during the 16-bit CRC generation.

Fixes #84683
Fixes #84690