### PR TITLE
video: buffer management improvement

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -427,6 +427,7 @@ New APIs and options
   * :c:macro:`VIDEO_FOREACH_YUV_SEMI_PLANAR`
   * :c:macro:`VIDEO_FOREACH_YUV_FULL_PLANAR`
   * :c:macro:`VIDEO_FOREACH_COMPRESSED`
+  * :c:func:`video_import_buffer`
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/drivers/video.h>
+#include <zephyr/video/video.h>
 #include <zephyr/drivers/video-controls.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -85,6 +85,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_tim
 		return NULL;
 	}
 
+	vbuf->memory = VIDEO_MEMORY_INTERNAL;
 	vbuf->size = size;
 	vbuf->bytesused = 0;
 
@@ -96,25 +97,59 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
 	return video_buffer_aligned_alloc(size, sizeof(void *), timeout);
 }
 
-void video_buffer_release(struct video_buffer *vbuf)
+int video_buffer_release(struct video_buffer *vbuf)
 {
-	if (vbuf == NULL || vbuf->buffer == NULL) {
-		return;
+	if (vbuf == NULL || vbuf->index >= ARRAY_SIZE(video_buf)) {
+		LOG_ERR("Invalid buffer index: %u", vbuf->index);
+		return -EINVAL;
 	}
 
-	for (uint16_t i = 0; i < ARRAY_SIZE(video_buf); i++) {
-		if (video_buf[i].buffer == vbuf->buffer) {
-			video_buf[i].buffer = NULL;
-			video_buf[i].size = 0;
-			video_buf[i].bytesused = 0;
+	if (video_buf[vbuf->index].buffer == NULL) {
+		LOG_ERR("Buffer %u is already released", vbuf->index);
+		return -EINVAL;
+	}
+
+	if (video_buf[vbuf->index].memory == VIDEO_MEMORY_INTERNAL) {
+		VIDEO_COMMON_FREE(video_buf[vbuf->index].buffer);
+	}
+
+	video_buf[vbuf->index].buffer = NULL;
+
+	return 0;
+}
+
+int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx)
+{
+	uint16_t ind;
+
+	if (mem == NULL || sz == 0) {
+		LOG_ERR("Invalid memory address or size");
+		return -EINVAL;
+	}
+
+	/* Find the 1st available slot in the video buffer pool */
+	for (ind = 0; ind < ARRAY_SIZE(video_buf); ind++) {
+		if (video_buf[ind].buffer == NULL) {
 			break;
 		}
 	}
 
-	if (vbuf->buffer != NULL) {
-		VIDEO_COMMON_FREE(vbuf->buffer);
-		vbuf->buffer = NULL;
+	if (ind == ARRAY_SIZE(video_buf)) {
+		return -ENOBUFS;
 	}
+
+	/* Populate the internal buffer */
+	video_buf[ind].index = ind;
+	video_buf[ind].size = sz;
+	video_buf[ind].memory = VIDEO_MEMORY_EXTERNAL;
+	video_buf[ind].buffer = mem;
+	video_buf[ind].bytesused = 0;
+	video_buf[ind].timestamp = 0;
+
+	/* Return the buffer index to the requester */
+	*idx = ind;
+
+	return 0;
 }
 
 int video_enqueue(const struct device *dev, struct video_buffer *buf)

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -70,6 +70,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_tim
 	for (uint16_t i = 0; i < ARRAY_SIZE(video_buf); i++) {
 		if (video_buf[i].buffer == NULL) {
 			vbuf = &video_buf[i];
+			vbuf->index = i;
 			break;
 		}
 	}
@@ -114,6 +115,25 @@ void video_buffer_release(struct video_buffer *vbuf)
 		VIDEO_COMMON_FREE(vbuf->buffer);
 		vbuf->buffer = NULL;
 	}
+}
+
+int video_enqueue(const struct device *dev, struct video_buffer *buf)
+{
+	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+
+	if (dev == NULL || buf == NULL || buf->index >= CONFIG_VIDEO_BUFFER_POOL_NUM_MAX ||
+	    (buf->type != VIDEO_BUF_TYPE_INPUT && buf->type != VIDEO_BUF_TYPE_OUTPUT)) {
+		return -EINVAL;
+	}
+
+	api = (const struct video_driver_api *)dev->api;
+	if (api->enqueue == NULL) {
+		return -ENOSYS;
+	}
+
+	video_buf[buf->index].type = buf->type;
+
+	return api->enqueue(dev, &video_buf[buf->index]);
 }
 
 int video_format_caps_index(const struct video_format_cap *fmts, const struct video_format *fmt,

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -52,6 +52,18 @@ enum video_buf_type {
 };
 
 /**
+ * @brief video_buf_memory enum
+ *
+ * Memory type of a buffer
+ */
+enum video_buf_memory {
+	/** buffer is allocated from the internal video heap */
+	VIDEO_MEMORY_INTERNAL = 1,
+	/** buffer is allocated from outside */
+	VIDEO_MEMORY_EXTERNAL = 2,
+};
+
+/**
  * @brief Video format structure
  *
  * Used to configure frame format.
@@ -137,6 +149,8 @@ struct video_buffer {
 	void *driver_data;
 	/** type of the buffer */
 	enum video_buf_type type;
+	/** type of the buffer memory, see @ref video_buf_memory */
+	uint8_t memory;
 	/** pointer to the start of the buffer. */
 	uint8_t *buffer;
 	/** index of the buffer in the video buffer pool */
@@ -962,8 +976,10 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout);
  * @brief Release a video buffer.
  *
  * @param buf Pointer to the video buffer to release.
+ *
+ * @retval 0 on success or a negative errno on failure
  */
-void video_buffer_release(struct video_buffer *buf);
+int video_buffer_release(struct video_buffer *buf);
 
 /**
  * @brief Search for a format that matches in a list of capabilities

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -570,21 +570,7 @@ static inline int video_enum_frmival(const struct device *dev, struct video_frmi
  * @retval -EINVAL If parameters are invalid.
  * @retval -EIO General input / output error.
  */
-static inline int video_enqueue(const struct device *dev, struct video_buffer *buf)
-{
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
-
-	if (dev == NULL || buf == NULL || buf->buffer == NULL) {
-		return -EINVAL;
-	}
-
-	api = (const struct video_driver_api *)dev->api;
-	if (api->enqueue == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->enqueue(dev, buf);
-}
+int video_enqueue(const struct device *dev, struct video_buffer *buf);
 
 /**
  * @brief Dequeue a video buffer.

--- a/include/zephyr/video/video.h
+++ b/include/zephyr/video/video.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public APIs for video
+ *
+ * This file contains public APIs for video area
+ */
+
+#ifndef ZEPHYR_INCLUDE_VIDEO_VIDEO_H_
+#define ZEPHYR_INCLUDE_VIDEO_VIDEO_H_
+
+/**
+ * @brief Video public APIs.
+ * @defgroup video_api Video APIs
+ * @since 4.4
+ * @version 0.1.0
+ * @ingroup video_interface
+ * @{
+ */
+
+/*
+ * TODO: Temporarily include this driver APIs header so that application just needs to
+ * import this file instead of both. It should be removed once video APIs are correctly
+ * re-organized into public and drivers APIs.
+ */
+#include <zephyr/drivers/video.h>
+
+/**
+ * @brief Import an external memory to the video buffer pool
+ *
+ * Import an externally allocated memory as a @ref video_buffer in the video buffer pool
+ *
+ * @param mem Pointer to the external memory
+ * @param sz Size of the external memory
+ * @param idx Returned index of the imported video buffer in the video buffer pool
+ *
+ * @retval 0 on success or a negative errno code on failure.
+ */
+int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx);
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_VIDEO_VIDEO_H_ */


### PR DESCRIPTION
This PR is split from the video buffer management rework PR https://github.com/zephyrproject-rtos/zephyr/pull/92370 (which sit there for quite a long time) but just include the **minimum** fixes for now.

It is also part of the video dependency branch for libZMP: https://github.com/zephyrproject-rtos/zephyr/pull/98513.

```
drivers: video: Enqueue and track internal buffers via index
drivers: video: Add support for user-provided buffers
```

- The current video framework maintains an internal `video_buf[]` array for all video buffers but this array is hidden from user. So, when we need to do **some wrapper** around the video_buf, it does not work as struct video_buf is local and destroyed when the function returns. For example

```
static bool mp_zvid_transform_chainfn(struct mp_pad *pad, struct mp_buffer *in_buf,
				      struct mp_buffer **out_buf)
{

	struct video_buffer in_vbuf = {.type = VIDEO_BUF_TYPE_INPUT, .buffer = in_buf->data};

	/* Enqueue input buffer */
	video_enqueue(zvid_transform->zvid_obj_in.vdev, &in_vbuf));

       // in_vbuf will be invalid once the function returned

	return true;
}
```

- Add `video_import_buffer()` to support external buffers allocated from outside, not on the video heap.