### PR TITLE
MSPM0 RTC Bugfix for LP_MSPM0Lx22x and MSPM0Gx51x variants

### DIFF
--- a/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <ti/mspm0/g/mspm0g.dtsi>
 
@@ -61,4 +65,8 @@
 			};
 		};
 	};
+};
+
+&rtc {
+	ti,rtc-x;
 };

--- a/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Texas Instruments
+ * Copyright (c) 2025-2026 Texas Instruments
  * Copyright (c) 2025 Linumiz GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -14,4 +14,8 @@
 			reg = <0x20000000 DT_SIZE_K(32)>;
 		};
 	};
+};
+
+&rtc {
+	ti,rtc-x;
 };

--- a/samples/drivers/rtc/boards/lp_mspm0g3507.overlay
+++ b/samples/drivers/rtc/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};

--- a/samples/drivers/rtc/boards/lp_mspm0g3519.overlay
+++ b/samples/drivers/rtc/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};

--- a/samples/drivers/rtc/boards/lp_mspm0l2228.overlay
+++ b/samples/drivers/rtc/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc;
+	};
+};
+
+&rtc {
+	status = "okay";
+};


### PR DESCRIPTION
There are different rtc variants present on the MSPM0 families, with some RTC flavors such as RTC_A and RTC_B, which are present on the devices MSPM0L2228 and MSPM0G3519 do not have general purpose power registers (GPRCM). This was accounted for in the original implementation with the ti,rtc-x devicetree binding which skips these checks, but the binding was not added to the affected devices (or was removed somewhere along the way). 

This PR adds the bindings back explicitly and also allows the user to run samples/drivers/rtc on MSPM0 devices. 

All 3 boards (LP_MSPM0G3507, LP_MSPM0L2228, and LP_MSPM0G3519) were observed to exhibit correct behavior on the RTC examples