### PR TITLE
west: rtt: jlink: Add ability to select RTT channel

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -998,14 +998,21 @@ class ZephyrBinaryRunner(abc.ABC):
         # RuntimeError avoids a stack trace saved in run_common.
         raise RuntimeError(err)
 
-    def run_telnet_client(self, host: str, port: int, active_sock=None) -> None:
+    def run_telnet_client(
+        self, host: str, port: int, active_sock=None,
+        send_on_connect: str | None = None,
+    ) -> None:
         '''
         Run a telnet client for user interaction.
+
+        :param send_on_connect: Send the given string right after connecting to
+                                the given socket. If provided, it will result in
+                                avoiding using `nc` as the client.
         '''
         # If the caller passed in an active socket, use that
         if active_sock is not None:
             sock = active_sock
-        elif shutil.which('nc') is not None:
+        elif send_on_connect is None and shutil.which('nc') is not None:
             # If a `nc` command is available, run it, as it will provide the
             # best support for CONFIG_SHELL_VT100_COMMANDS etc.
             client_cmd = ['nc', host, str(port)]
@@ -1016,6 +1023,10 @@ class ZephyrBinaryRunner(abc.ABC):
             # Start a new socket connection
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect((host, port))
+
+        if send_on_connect is not None:
+            # Send the given string before entering the interactive mode
+            sock.sendall(send_on_connect.encode('ascii'))
 
         # Otherwise, use a pure python implementation. This will work well for logging,
         # but input is line based only.

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -56,6 +56,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  gdb_host='',
                  gdb_port=DEFAULT_JLINK_GDB_PORT,
                  rtt_port=DEFAULT_JLINK_RTT_PORT,
+                 rtt_channel=None,
                  tui=False, tool_opt=None, dev_id_type=None, batch=False,
                  pre_script_cmds=None):
         super().__init__(cfg)
@@ -83,6 +84,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.tui_arg = ['-tui'] if tui else []
         self.loader = loader
         self.rtt_port = rtt_port
+        self.rtt_channel = rtt_channel
         self.dev_id_type = dev_id_type
         self.is_batch = batch
         self.pre_script_cmds = pre_script_cmds
@@ -200,6 +202,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='RTT client, default is JLinkRTTClient')
         parser.add_argument('--rtt-port', default=DEFAULT_JLINK_RTT_PORT,
                             help=f'jlink rtt port, defaults to {DEFAULT_JLINK_RTT_PORT}')
+        parser.add_argument('--rtt-channel', type=int, default=None,
+                            help='jlink rtt channel, not send by default')
         parser.add_argument('--flash-sram', default=False, action='store_true',
                             help='if given, flashing the image to SRAM and '
                             'modify PC register to be SRAM base address')
@@ -229,6 +233,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  gdb_host=args.gdb_host,
                                  gdb_port=args.gdb_port,
                                  rtt_port=args.rtt_port,
+                                 rtt_channel=args.rtt_channel,
                                  tui=args.tui, tool_opt=args.tool_opt,
                                  dev_id_type=args.dev_id_type,
                                  batch=args.batch,
@@ -399,10 +404,20 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                         # a non-recoverable state, hence let's wait and try
                         # again.
                         if e.errno in (errno.ECONNREFUSED, errno.EINVAL):
-                            time.sleep(0.1)
+                            time.sleep(0.05)
                         else:
                             raise e
-                self.run_telnet_client('localhost', self.rtt_port, sock)
+
+                if self.rtt_channel is not None:
+                    # The config string has to be sent within 100 ms after
+                    # establishing the connection, otherwise it would be ignored
+                    # and no channel selection would be applied.
+                    rtt_config = f'$$SEGGER_TELNET_ConfigStr=RTTCh;{self.rtt_channel}$$'
+                else:
+                    rtt_config = None
+
+                self.run_telnet_client('localhost', self.rtt_port, sock,
+                                       send_on_connect=rtt_config)
             except OSError as e:
                 self.logger.error(
                     f'Failed to connect to the localhost:{self.rtt_port} socket: {e}',


### PR DESCRIPTION
When the `west rtt --runner=jlink` command is executed, the client is attached to the channel number 0 by default. However, if several subsystems are configured to use different RTT channels, e.g. shell to the channel 0 and logging to the channel 1, it's currently impossible to attach to any channel other than 0.

The `west rtt` command for the `jlink` runner is extended by a new argument called `--rtt-channel=<channel>` where `<channel>` is an integer, e.g. 0, 1, etc. Usage example:

    west rtt --runner=jlink --rtt-channel=1

When the channel is specified, once the client is connected, it sends the following configuration sequence:

    $$SEGGER_TELNET_ConfigStr=RTTCh;<channel>$$

See the official documentation for more information on the format of the configuration string: https://kb.segger.com/J-Link_RTT_TELNET_Channel

This configuration sequence instructs the server to send data associated only to the given channel. This string must be send within 100 ms after establishing a connection, otherwise it would be ignored.

The following is an example of a configuration where shell uses channel 0 and logging - channel 1:

    CONFIG_SHELL=y
    CONFIG_SHELL_BACKEND_RTT=y
    CONFIG_SHELL_BACKEND_RTT_BUFFER=0
    CONFIG_SHELL_BACKEND_SERIAL=n
    CONFIG_SHELL_LOG_BACKEND=n

    CONFIG_LOG=y
    CONFIG_LOG_BACKEND_RTT=y
    CONFIG_LOG_BACKEND_RTT_BUFFER=1
    CONFIG_LOG_BACKEND_UART=n

The following is a usage example of attaching to the channel with shell:

```
$ west rtt --no-rebuild --runner=jlink --rtt-channel=0
-- west rtt: using runner jlink
...
SEGGER J-Link V9.24 - Real time terminal output
Process: JLinkGDBServerCLExe

rtt:~$ kernel uptime
kernel uptime
Uptime: 61850 ms
rtt:~$
```

And the following with the logging channel:

```
$ west rtt --no-rebuild --runner=jlink --rtt-channel=1
-- west rtt: using runner jlink
...
SEGGER J-Link V9.24 - Real time terminal output
Process: JLinkGDBServerCLExe
[00:04:02.462,000] <inf> main: Tick 10700
[00:04:04.724,000] <inf> main: Tick 10800
^C
```