### PR TITLE
drivers: audio: tlv320: fix I2C error handling and I2S controller logic

### DIFF
--- a/drivers/audio/tlv320aic3110.c
+++ b/drivers/audio/tlv320aic3110.c
@@ -219,11 +219,13 @@ static int codec_configure_dai(const struct device *dev, audio_dai_cfg_t *cfg)
 
 	/* configure I2S interface */
 	val = IF_CTRL_IFTYPE(IF_CTRL_IFTYPE_I2S);
-	if (cfg->i2s.options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(cfg->i2s.options & I2S_OPT_BIT_CLK_TARGET)) {
 		val |= IF_CTRL_BCLK_OUT;
 	}
 
-	if (cfg->i2s.options & I2S_OPT_FRAME_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(cfg->i2s.options & I2S_OPT_FRAME_CLK_TARGET)) {
 		val |= IF_CTRL_WCLK_OUT;
 	}
 
@@ -309,7 +311,8 @@ static int codec_configure_clocks(const struct device *dev, struct audio_codec_c
 	LOG_DBG("MDAC: %u NDAC: %u DOSR: %u", mdac, ndac, dosr);
 	LOG_DBG("MADC: %u NADC: %u AOSR: %u", madc, nadc, aosr);
 
-	if (i2s->options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(i2s->options & I2S_OPT_BIT_CLK_TARGET)) {
 		bclk_div = dosr * mdac / (i2s->word_size * 2U); /* stereo */
 		if ((bclk_div * i2s->word_size * 2) != (dosr * mdac)) {
 			LOG_ERR("Unable to generate BCLK %u from MCLK %u",
@@ -335,7 +338,8 @@ static int codec_configure_clocks(const struct device *dev, struct audio_codec_c
 	codec_write_reg(dev, MADC_DIV_ADDR, (uint8_t)(MADC_DIV(madc) | MADC_POWER_UP_MASK));
 	codec_write_reg(dev, AOSR_ADDR, (uint8_t)aosr);
 
-	if (i2s->options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(i2s->options & I2S_OPT_BIT_CLK_TARGET)) {
 		codec_write_reg(dev, BCLK_DIV_ADDR, BCLK_DIV(bclk_div) | BCLK_DIV_POWER_UP);
 	}
 

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -246,11 +246,13 @@ static int codec_configure_dai(const struct device *dev, audio_dai_cfg_t *cfg)
 
 	/* configure I2S interface */
 	val = IF_CTRL_IFTYPE(IF_CTRL_IFTYPE_I2S);
-	if (cfg->i2s.options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(cfg->i2s.options & I2S_OPT_BIT_CLK_TARGET)) {
 		val |= IF_CTRL_BCLK_OUT;
 	}
 
-	if (cfg->i2s.options & I2S_OPT_FRAME_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(cfg->i2s.options & I2S_OPT_FRAME_CLK_TARGET)) {
 		val |= IF_CTRL_WCLK_OUT;
 	}
 
@@ -284,7 +286,7 @@ static int codec_configure_clocks(const struct device *dev,
 	struct i2s_config *i2s;
 	int osr, osr_min, osr_max;
 	enum osr_multiple osr_multiple;
-	int mdac, ndac, bclk_div, mclk_div;
+	int mdac, ndac, bclk_div = 0, mclk_div;
 
 	i2s = &cfg->dai_cfg.i2s;
 	LOG_DBG("MCLK %u Hz PCM Rate: %u Hz", cfg->mclk_freq,
@@ -340,7 +342,7 @@ static int codec_configure_clocks(const struct device *dev,
 			dac_clk, mod_clk);
 	LOG_DBG("NDAC: %u MDAC: %u OSR: %u", ndac, mdac, osr);
 
-	if (i2s->options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	if (!(i2s->options & I2S_OPT_BIT_CLK_TARGET)) {
 		bclk_div = osr * mdac / (i2s->word_size * 2U); /* stereo */
 		if ((bclk_div * i2s->word_size * 2) != (osr * mdac)) {
 			LOG_ERR("Unable to generate BCLK %u from MCLK %u",
@@ -361,7 +363,8 @@ static int codec_configure_clocks(const struct device *dev,
 	codec_write_reg(dev, OSR_MSB_ADDR, (uint8_t)((osr >> 8) & OSR_MSB_MASK));
 	codec_write_reg(dev, OSR_LSB_ADDR, (uint8_t)(osr & OSR_LSB_MASK));
 
-	if (i2s->options & I2S_OPT_BIT_CLK_CONTROLLER) {
+	/* Since CONTROLLER is 0, we check that the TARGET bit is NOT set */
+	if (!(i2s->options & I2S_OPT_BIT_CLK_TARGET)) {
 		codec_write_reg(dev, BCLK_DIV_ADDR,
 				BCLK_DIV(bclk_div) | BCLK_DIV_POWER_UP);
 	}

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -185,16 +185,26 @@ static void codec_write_reg(const struct device *dev, struct reg_addr reg,
 {
 	struct codec_driver_data *const dev_data = dev->data;
 	const struct codec_driver_config *const dev_cfg = dev->config;
+	int ret;
 
 	/* set page if different */
 	if (dev_data->reg_addr_cache.page != reg.page) {
-		i2c_reg_write_byte_dt(&dev_cfg->bus, 0, reg.page);
+		ret = i2c_reg_write_byte_dt(&dev_cfg->bus, 0, reg.page);
+		if (ret < 0) {
+			LOG_ERR("Failed to set page %u (err %d)", reg.page, ret);
+			return; /* Don't update cache or attempt read if page set failed */
+		}
 		dev_data->reg_addr_cache.page = reg.page;
 	}
 
-	i2c_reg_write_byte_dt(&dev_cfg->bus, reg.reg_addr, val);
-	LOG_DBG("WR PG:%u REG:%02u VAL:0x%02x",
-			reg.page, reg.reg_addr, val);
+	ret = i2c_reg_write_byte_dt(&dev_cfg->bus, reg.reg_addr, val);
+	if (ret < 0) {
+		LOG_ERR("I2C write failed: PG:%u REG:%u (err %d)",
+				reg.page, reg.reg_addr, ret);
+	} else {
+		LOG_DBG("WR PG:%u REG:%02u VAL:0x%02x",
+				reg.page, reg.reg_addr, val);
+	}
 }
 
 static void codec_read_reg(const struct device *dev, struct reg_addr reg,
@@ -202,16 +212,26 @@ static void codec_read_reg(const struct device *dev, struct reg_addr reg,
 {
 	struct codec_driver_data *const dev_data = dev->data;
 	const struct codec_driver_config *const dev_cfg = dev->config;
+	int ret;
 
 	/* set page if different */
 	if (dev_data->reg_addr_cache.page != reg.page) {
-		i2c_reg_write_byte_dt(&dev_cfg->bus, 0, reg.page);
+		ret = i2c_reg_write_byte_dt(&dev_cfg->bus, 0, reg.page);
+		if (ret < 0) {
+			LOG_ERR("Failed to set page %u (err %d)", reg.page, ret);
+			return; /* Don't update cache or attempt read if page set failed */
+		}
 		dev_data->reg_addr_cache.page = reg.page;
 	}
 
-	i2c_reg_read_byte_dt(&dev_cfg->bus, reg.reg_addr, val);
-	LOG_DBG("RD PG:%u REG:%02u VAL:0x%02x",
-			reg.page, reg.reg_addr, *val);
+	ret = i2c_reg_read_byte_dt(&dev_cfg->bus, reg.reg_addr, val);
+	if (ret < 0) {
+		LOG_ERR("I2C read failed: PG:%u REG:%u (err %d)",
+				reg.page, reg.reg_addr, ret);
+	} else {
+		LOG_DBG("RD PG:%u REG:%02u VAL:0x%02x",
+				reg.page, reg.reg_addr, *val);
+	}
 }
 
 static void codec_soft_reset(const struct device *dev)


### PR DESCRIPTION
This PR addresses several Coverity CIDs across the tlv320dac310x and tlv320aic3110 drivers related to unchecked I2C transactions and dead code in the I2S configuration logic.

Changes:

- I2S Logic (CID 444373): Fixed logically dead code in clock configuration. The I2S_OPT_BIT_CLK_CONTROLLER and I2S_OPT_FRAME_CLK_CONTROLLER macros are defined as 0, making bitwise AND tests always false. Updated these to check for the absence of the TARGET bits.

- I2C Error Handling (CID 444387): Updated internal register read/write/update helpers to evaluate return codes. Previously, I2C failures would result in silent errors and the processing of invalid data.

- Deceptive Logging: Updated LOG_DBG calls to only print register values if the I2C read was actually successful.
 
- Cache Integrity: Prevented the internal page cache from updating if the I2C page-switch command fails.
 

Fixes #84777
Fixes #84787
Fixes #84780