### PR TITLE
serial: uart_nrfx_uarte: option to request HFXO

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -47,6 +47,16 @@ config UART_NRFX_UARTE_ENHANCED_RX
 	  and hardware assisted required TIMER peripheral instance and PPI channel
 	  for accurate byte counting.
 
+config UART_NRFX_UARTE_HFXO_ON_ACTIVE
+	bool "Request the HFXO oscillator while peripheral is active"
+	depends on UART_NRFX_UARTE
+	depends on !SOC_NRF54H20
+	help
+	  Request the HFXO oscillator to be enabled while the UART peripheral is
+	  active. This improves the accuracy of the bitrate versus the HFINT oscillator,
+	  at the cost of startup latency (~700 us) when enabling the peripheral if the
+	  HFXO is not already active.
+
 config UART_ASYNC_TX_CACHE_SIZE
 	int "TX cache buffer size"
 	depends on UART_ASYNC_API

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -8,6 +8,7 @@
  * @brief Driver for Nordic Semiconductor nRF UARTE
  */
 
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device.h>
@@ -262,6 +263,10 @@ struct uarte_nrfx_data {
 #endif
 #ifdef UARTE_ANY_ASYNC
 	struct uarte_async_cb *async;
+#endif
+#ifdef CONFIG_UART_NRFX_UARTE_HFXO_ON_ACTIVE
+	struct onoff_client hfxo_client;
+	struct k_sem hfxo_ready;
 #endif
 	atomic_val_t poll_out_lock;
 	atomic_t flags;
@@ -2955,9 +2960,39 @@ static void wait_for_tx_stopped(const struct device *dev)
 	}
 }
 
+#ifdef CONFIG_UART_NRFX_UARTE_HFXO_ON_ACTIVE
+static void uarte_hfxo_active(struct onoff_manager *mgr,
+		    struct onoff_client *cli,
+		    uint32_t state,
+		    int res)
+{
+	struct uarte_nrfx_data *data = CONTAINER_OF(cli, struct uarte_nrfx_data, hfxo_client);
+
+	k_sem_give(&data->hfxo_ready);
+}
+#endif
+
 static void uarte_pm_resume(const struct device *dev)
 {
 	const struct uarte_nrfx_config *cfg = dev->config;
+
+#ifdef CONFIG_UART_NRFX_UARTE_HFXO_ON_ACTIVE
+	struct onoff_manager *mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	struct uarte_nrfx_data *data = dev->data;
+	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
+	int err;
+
+	k_sem_reset(&data->hfxo_ready);
+	sys_notify_init_callback(&data->hfxo_client.notify, uarte_hfxo_active);
+	err = onoff_request(mgr, &data->hfxo_client);
+	__ASSERT_NO_MSG(err >= 0);
+
+	/* Don't wait for the HFXO if in an ISR or pre-kernel context */
+	if (!isr_mode) {
+		err = k_sem_take(&data->hfxo_ready, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
+	}
+#endif
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || !LOW_POWER_ENABLED(cfg)) {
 		uarte_periph_enable(dev);
@@ -2969,6 +3004,7 @@ static int uarte_pm_suspend(const struct device *dev)
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	const struct uarte_nrfx_config *cfg = dev->config;
 	struct uarte_nrfx_data *data = dev->data;
+	int err;
 
 	(void)data;
 
@@ -3029,7 +3065,18 @@ static int uarte_pm_suspend(const struct device *dev)
 	}
 
 	nrf_uarte_disable(uarte);
-	return pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+
+#ifdef CONFIG_UART_NRFX_UARTE_HFXO_ON_ACTIVE
+	struct onoff_manager *mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	int onoff_err;
+
+	sys_notify_init_callback(&data->hfxo_client.notify, uarte_hfxo_active);
+	onoff_err = onoff_cancel_or_release(mgr, &data->hfxo_client);
+	__ASSERT_NO_MSG(onoff_err >= 0);
+#endif
+
+	return err;
 }
 
 static int uarte_nrfx_pm_action(const struct device *dev, enum pm_device_action action)
@@ -3099,8 +3146,9 @@ static int uarte_tx_path_init(const struct device *dev)
 static int uarte_instance_init(const struct device *dev,
 			       uint8_t interrupts_active)
 {
-	int err;
+	__maybe_unused struct uarte_nrfx_data *data = dev->data;
 	const struct uarte_nrfx_config *cfg = dev->config;
+	int err;
 
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 	/* For simulation the DT provided peripheral address needs to be corrected */
@@ -3130,9 +3178,11 @@ static int uarte_instance_init(const struct device *dev,
 	nrf_uarte_configure(uarte, &cfg->hw_config);
 #endif
 
-#ifdef UARTE_ANY_ASYNC
-	struct uarte_nrfx_data *data = dev->data;
+#ifdef CONFIG_UART_NRFX_UARTE_HFXO_ON_ACTIVE
+	k_sem_init(&data->hfxo_ready, 0, 1);
+#endif
 
+#ifdef UARTE_ANY_ASYNC
 	if (data->async) {
 		err = uarte_async_init(dev);
 		if (err < 0) {


### PR DESCRIPTION
Add the option to explicitly request the HFXO while the UARTE peripheral is active for nRF54L series devices. While the UARTE peripheral requests a high frequency clock from the clock controller, both the HFINT and HFXO oscillators satisfy this request. The problem is that the HFXO oscillator is required to reach the highest bitrate accuracies (and mitigate errata 30).

If we believe the datasheet that HFINT results in less accurate baudrates than HFXO.
<img width="1524" height="271" alt="image" src="https://github.com/user-attachments/assets/9d927d39-5107-42f2-be99-fc6682798d8d" />

Then the need for this option can be validated by running this function inside a `uart_poll_in` loop:
```
#include <zephyr/drivers/clock_control/nrf_clock_control.h>

static void print_hfclk_state(void)
{
	NRF_CLOCK_Type *C = NRF_CLOCK_S;
	nrf_clock_hfclk_t src = 0;
	bool running;

	running = nrf_clock_is_running(C, NRF_CLOCK_DOMAIN_HFCLK, &src);
	LOG_ERR("HFCLK: Running %d Source %d", running, src);
}
```
Which outputs data like this:
```
[00:00:02.136,256] <err> HFCLK: Running 0 Source 1
[00:00:02.136,608] <err> HFCLK: Running 0 Source 1
[00:00:02.136,864] <err> HFCLK: Running 0 Source 1
[00:00:02.137,184] <err> HFCLK: Running 0 Source 1
```
The "running" output on nRF54L's is directly from `XO.STAT`, so in the above case the HFXO is not running, despite UART RX being enabled.