### PR TITLE
Bluetooth: Controller: Fix dead code using CENTRAL_SPACING

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -813,7 +813,7 @@ config BT_CTLR_ASSERT_VENDOR
 
 config BT_CTLR_CENTRAL_SPACING
 	int "Central Connection Spacing"
-	depends on BT_CTLR_SCHED_ADVANCED
+	depends on BT_CTLR_SCHED_ADVANCED && BT_CENTRAL
 	default 0
 	range 0 $(UINT16_MAX)
 	help

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -731,11 +731,15 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 				*ticks_slot = conn->ull.ticks_slot;
 			}
 
-			if ((conn->lll.role == BT_HCI_ROLE_CENTRAL) &&
-			    (*ticks_slot <
-			     HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING))) {
-				*ticks_slot =
-					HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING);
+			if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
+			    (CONFIG_BT_CTLR_CENTRAL_SPACING != 0))
+			{
+				if ((conn->lll.role == BT_HCI_ROLE_CENTRAL) &&
+				    (*ticks_slot <
+				     HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING))) {
+					*ticks_slot =
+					  HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING);
+				}
 			}
 
 			return &conn->ull;


### PR DESCRIPTION
When CONFIG_BT_CTLR_CENTRAL_SPACING is configured to be 0, the comparison against *ticks_slot in ull_hdr_get_cb results in logically dead code because an unsigned ticker value cannot be less than zero.

This commit brackets the central spacing logic with a preprocessor check to ensure it is only compiled when a non-zero spacing is required, resolving the Coverity warning and slightly reducing the code footprint for default configurations.

Fixes #84715