### PR TITLE
drivers: debug: Make ETR optional

### DIFF
--- a/drivers/debug/debug_coresight_nrf.c
+++ b/drivers/debug/debug_coresight_nrf.c
@@ -95,6 +95,7 @@ static void nrf_tpiu_init(void)
 	LOG_INF("CoreSight Host TPIU initialized");
 }
 
+#ifdef CONFIG_DEBUG_NRF_ETR
 static void nrf_etr_init(uintptr_t buf, size_t buf_word_len)
 {
 	mem_addr_t etr = DT_REG_ADDR(DT_NODELABEL(etr));
@@ -113,6 +114,7 @@ static void nrf_etr_init(uintptr_t buf, size_t buf_word_len)
 
 	LOG_INF("Coresight Host ETR initialized");
 }
+#endif
 
 static void nrf_stm_init(void)
 {
@@ -187,6 +189,7 @@ static void nrf_atbreplicator_init(mem_addr_t replicator_addr, uint32_t filter, 
 	coresight_lock(replicator_addr);
 }
 
+#if CONFIG_DEBUG_NRF_ETR
 static int coresight_nrf_init_stm_etr(uintptr_t buf, size_t buf_word_len)
 {
 	mem_addr_t atbfunnel211 = DT_REG_ADDR(DT_NODELABEL(atbfunnel211));
@@ -203,6 +206,7 @@ static int coresight_nrf_init_stm_etr(uintptr_t buf, size_t buf_word_len)
 
 	return 0;
 }
+#endif
 
 static int coresight_nrf_init_stm_tpiu(void)
 {
@@ -248,12 +252,14 @@ static int coresight_nrf_init(const struct device *dev)
 	case CORESIGHT_NRF_MODE_STM_TPIU: {
 		return coresight_nrf_init_stm_tpiu();
 	}
+#ifdef CONFIG_DEBUG_NRF_ETR
 	case CORESIGHT_NRF_MODE_STM_ETR: {
 		uintptr_t etr_buffer = DT_REG_ADDR(DT_NODELABEL(etr_buffer));
 		size_t buf_word_len = DT_REG_SIZE(DT_NODELABEL(etr_buffer)) / sizeof(uint32_t);
 
 		return coresight_nrf_init_stm_etr(etr_buffer, buf_word_len);
 	}
+#endif
 	default: {
 		LOG_ERR("Unsupported Coresight mode");
 		return -ENOTSUP;


### PR DESCRIPTION
Exclude ETR register writes when ETR mode is not used.