### PR TITLE
samples: Fix nrf5340dk overlay in nrfx_prs sample

### DIFF
--- a/samples/boards/nordic/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/boards/nordic/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -22,12 +22,12 @@
 
 	spi2_default_alt: spi2_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 9)>,
+			psels = <NRF_PSEL(SPIM_SCK, 1, 6)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 1, 7)>;
+			psels = <NRF_PSEL(SPIM_MISO, 1, 9)>;
 			bias-pull-down;
 		};
 	};


### PR DESCRIPTION
Due to loopback update the existing overlay is no longer valid. P1.08 and P1.09 are now connected.