### PR TITLE
doc: update `--skip-rebuild` to `--no-rebuild`

### DIFF
--- a/boards/ezurio/bl5340_dvk/doc/index.rst
+++ b/boards/ezurio/bl5340_dvk/doc/index.rst
@@ -293,7 +293,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfjprog --skip-rebuild
+      west flash -H -r nrfjprog --no-rebuild
 
 .. note::
 

--- a/boards/infineon/cyw920829m2evk_02/doc/index.rst
+++ b/boards/infineon/cyw920829m2evk_02/doc/index.rst
@@ -197,7 +197,7 @@ You can use ``west flash`` to flash MCUBootApp:
 .. code-block:: shell
 
    # Flash MCUBootApp.hex
-   west flash --skip-rebuild --hex-file /path/to/cypress/mcuboot/boot/cypress/MCUBootApp/out/CYW20829/Debug/MCUBootApp.hex
+   west flash --no-rebuild --hex-file /path/to/cypress/mcuboot/boot/cypress/MCUBootApp/out/CYW20829/Debug/MCUBootApp.hex
 
 .. note:: ``west flash`` requires an existing Zephyr build directory which can be created by first
     building any Zephyr application for the target board.

--- a/boards/nordic/nrf5340_audio_dk/doc/index.rst
+++ b/boards/nordic/nrf5340_audio_dk/doc/index.rst
@@ -81,7 +81,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfutil --skip-rebuild
+      west flash -H -r nrfutil --no-rebuild
 
 .. note::
 

--- a/boards/nordic/nrf5340dk/doc/index.rst
+++ b/boards/nordic/nrf5340dk/doc/index.rst
@@ -194,7 +194,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfutil --skip-rebuild
+      west flash -H -r nrfutil --no-rebuild
 
 .. note::
 

--- a/boards/nordic/nrf7002dk/doc/index.rst
+++ b/boards/nordic/nrf7002dk/doc/index.rst
@@ -192,7 +192,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      west flash -H -r nrfjprog --skip-rebuild
+      west flash -H -r nrfjprog --no-rebuild
 
 .. note::
 

--- a/boards/raytac/an7002q_db/doc/index.rst
+++ b/boards/raytac/an7002q_db/doc/index.rst
@@ -189,7 +189,7 @@ applications as usual (:ref:`build_an_application` and
 
    .. code-block:: console
 
-      $ west flash -H -r nrfjprog --skip-rebuild
+      $ west flash -H -r nrfjprog --no-rebuild
 
 .. note::
 

--- a/doc/connectivity/bluetooth/autopts/autopts-win10.rst
+++ b/doc/connectivity/bluetooth/autopts/autopts-win10.rst
@@ -129,7 +129,7 @@ and flash board with built earlier elf file:
 
 .. code-block::
 
-    west flash --skip-rebuild --board-dir /dev/ttyS2 --elf-file ~/zephyrproject/build/zephyr/zephyr.elf
+    west flash --no-rebuild --board-dir /dev/ttyS2 --elf-file ~/zephyrproject/build/zephyr/zephyr.elf
 
 Note that west does not accept COMs, so use /dev/ttyS2 as the COM3 equivalent,
 /dev/ttyS2 as the COM3 equivalent, etc.(/dev/ttyS + decremented COM number).

--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -416,19 +416,19 @@ for the FRDM-K64F as follows:
 
    .. code-block:: console
 
-      west flash --skip-rebuild
+      west flash --no-rebuild
 
 #. Confirm the newly flashed firmware image using west:
 
    .. code-block:: console
 
-      west flash --skip-rebuild --domain canopennode --runner canopen --confirm-only
+      west flash --no-rebuild --domain canopennode --runner canopen --confirm-only
 
 #. Finally, perform a program download via CANopen:
 
    .. code-block:: console
 
-      west flash --skip-rebuild --domain canopennode --runner canopen
+      west flash --no-rebuild --domain canopennode --runner canopen
 
 Modifying the Object Dictionary
 *******************************


### PR DESCRIPTION
`--skip-rebuild` was deprecated in #96115, replace with the new syntax.