### PR TITLE
scripts: completion: bash: completion for `west rtt`

### DIFF
--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -908,6 +908,11 @@ __comp_west_attach()
 	__comp_west_runner_cmd
 }
 
+__comp_west_rtt()
+{
+	__comp_west_runner_cmd
+}
+
 __comp_west_spdx()
 {
 	local bool_opts="


### PR DESCRIPTION
Add completion handling for `west rtt`, which is the same as the other runner based commands.