### PR TITLE
drivers: ethernet: dwmac: Fix cbprintf warnings

### DIFF
--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -165,7 +165,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 		sys_cache_data_flush_range(pinned->data, pinned->len);
 		p->tx_frags[d_idx] = pinned;
 		LOG_DBG("d[%d]: frag %p pinned %p len %d", d_idx,
-			frag->data, pinned->data, pinned->len);
+			(void *)frag->data, (void *)pinned->data, pinned->len);
 
 		/* if no more fragments after this one: */
 		if (!frag->frags) {
@@ -236,7 +236,7 @@ static void dwmac_tx_release(struct dwmac_priv *p)
 
 		/* release corresponding fragments */
 		frag = p->tx_frags[d_idx];
-		LOG_DBG("unref frag %p", frag->data);
+		LOG_DBG("unref frag %p", (void *)frag->data);
 		net_pkt_frag_unref(frag);
 
 		/* last packet descriptor: */
@@ -366,12 +366,12 @@ static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
 				k_sem_give(&p->free_rx_descs);
 				break;
 			}
-			LOG_DBG("new frag[%d] at %p", d_idx, frag->data);
+			LOG_DBG("new frag[%d] at %p", d_idx, (void *)frag->data);
 			__ASSERT(frag->size == RX_FRAG_SIZE, "");
 			sys_cache_data_invd_range(frag->data, frag->size);
 			p->rx_frags[d_idx] = frag;
 		} else {
-			LOG_DBG("reusing frag[%d] at %p", d_idx, frag->data);
+			LOG_DBG("reusing frag[%d] at %p", d_idx, (void *)frag->data);
 		}
 
 		/* all is good: initialize the descriptor */


### PR DESCRIPTION
Fix warnings about using char * for %p argument in cbprintf. It's recommended to cast it to void * because it may cause misbehavior in certain configurations.