### PR TITLE
drivers: dma: raise TCD queue default for MCUX SAI

### DIFF
--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -50,9 +50,13 @@ if DMA_MCUX_EDMA || DMA_MCUX_EDMA_V3 || DMA_MCUX_EDMA_V4
 
 config DMA_TCD_QUEUE_SIZE
 	int "number of TCD in a queue for SG mode"
+	default 4 if I2S_MCUX_SAI
 	default 2
 	help
-	  number of TCD in a queue for SG mode
+	  Number of TCDs in a queue for SG mode.
+	  The MCUX SAI I2S driver preloads 3 RX DMA blocks and also requires
+	  additional queue space for TX, so it needs this queue size to be
+	  greater than 3.
 
 config DMA_MCUX_TEST_SLOT_START
 	int "test slot start num"


### PR DESCRIPTION
Set `DMA_TCD_QUEUE_SIZE` default to 4 when `I2S_MCUX_SAI` is enabled.

The MCUX SAI I2S driver preloads 3 RX DMA blocks and enforces:

```c
BUILD_ASSERT(MAX_TX_DMA_BLOCKS > NUM_DMA_BLOCKS_RX_PREP,
	     "NUM_DMA_BLOCKS_RX_PREP must be < CONFIG_DMA_TCD_QUEUE_SIZE");
```

With the current MCUX eDMA default of 2, MCUX SAI I2S builds can fail at
compile time. Raising the default to 4 for `I2S_MCUX_SAI` aligns the eDMA
queue size with the driver's requirements and avoids board-specific
workarounds.

This is a focused fix for the build failure reported in #103997.

Fixes #103997