### PR TITLE
ethernet: dwmac: Configureable RX refill thread priority

### DIFF
--- a/drivers/ethernet/Kconfig.dwmac
+++ b/drivers/ethernet/Kconfig.dwmac
@@ -78,6 +78,13 @@ config DWMAC_NB_RX_DESCS
 	  memory. A smaller number increases the risk of an overflow and
 	  dropped packets.
 
+config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
+	int "Receive buffer refill thread priority"
+	default 0
+	help
+	  Priority level of the internal thread which is used to refill
+	  the receive buffer pool.
+
 endif # ETH_DWMAC
 
 endmenu

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -537,7 +537,7 @@ static void dwmac_iface_init(struct net_if *iface)
 	k_thread_create(&p->rx_refill_thread, p->rx_refill_thread_stack,
 			K_KERNEL_STACK_SIZEOF(p->rx_refill_thread_stack),
 			dwmac_rx_refill_thread, p, NULL, NULL,
-			0, K_PRIO_PREEMPT(0), K_NO_WAIT);
+			K_PRIO_PREEMPT(0), K_ESSENTIAL, K_NO_WAIT);
 	k_thread_name_set(&p->rx_refill_thread, "dwmac_rx_refill");
 
 	/* start up TX/RX */

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -537,7 +537,8 @@ static void dwmac_iface_init(struct net_if *iface)
 	k_thread_create(&p->rx_refill_thread, p->rx_refill_thread_stack,
 			K_KERNEL_STACK_SIZEOF(p->rx_refill_thread_stack),
 			dwmac_rx_refill_thread, p, NULL, NULL,
-			K_PRIO_PREEMPT(0), K_ESSENTIAL, K_NO_WAIT);
+			CONFIG_ETH_DWMAC_RX_REFILL_THREAD_PRIORITY,
+			K_ESSENTIAL, K_NO_WAIT);
 	k_thread_name_set(&p->rx_refill_thread, "dwmac_rx_refill");
 
 	/* start up TX/RX */


### PR DESCRIPTION
Add a Kconfig option to configure the RX refill thread priority.

The default is set to 0, which is the same as the previous hardcoded value. This allows users to set a different priority if needed.

Also fixes an error that the thread priority was passed to options argument of k_thread_create, instead of the prio argument.