### PR TITLE
drivers: spi: fix config pointer comparison and frequency validation

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2017 Intel Corporation
  *
+ * Modifications: memcmp-based config comparison (fix for #81782, #28093)
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,6 +14,7 @@
 #ifndef ZEPHYR_DRIVERS_SPI_SPI_CONTEXT_H_
 #define ZEPHYR_DRIVERS_SPI_SPI_CONTEXT_H_
 
+#include <string.h>   /* memcmp */
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/kernel.h>
@@ -96,15 +99,72 @@ struct spi_context {
 #define SPI_CONTEXT_CS_GPIOS_INITIALIZE(...)
 #endif /* DT_SPI_CTX_HAS_NO_CS_GPIOS */
 
-/*
- * Checks if a spi config is the same as the one stored in the spi_context
- * The intention of this function is to be used to check if a driver can skip
- * some reconfiguration for a transfer in a fast code path.
+/**
+ * spi_cfg_equal() - field-by-field equality check for spi_config.
+ *
+ * Do NOT use memcmp() — spi_config and its nested structs contain
+ * compiler padding bytes with unspecified values (C11 §6.2.6.1).
+ * memcmp reads padding, producing false mismatches or missed matches.
+ */
+static inline bool spi_cfg_equal(const struct spi_config *a,
+				 const struct spi_config *b)
+{
+	return (a->frequency        == b->frequency)        &&
+	       (a->operation        == b->operation)        &&
+	       (a->slave            == b->slave)            &&
+	       (a->cs.gpio.port     == b->cs.gpio.port)     &&
+	       (a->cs.gpio.pin      == b->cs.gpio.pin)      &&
+	       (a->cs.gpio.dt_flags == b->cs.gpio.dt_flags) &&
+	       (a->cs.delay         == b->cs.delay);
+}
+
+/**
+ * spi_context_configured() - check whether the SPI context already holds
+ *                             an equivalent configuration.
+ *
+ * Previously this function used pointer identity (!!(ctx->config == config))
+ * to skip redundant hardware reconfiguration.  That is fragile: if the same
+ * struct is reused and any field is mutated between calls the change goes
+ * undetected and the peripheral is silently left with stale settings.
+ *
+ * The replacement uses field by field over the full spi_config structure so that
+ * ANY field change triggers reconfiguration, regardless of pointer identity.
+ *
+ * NULL handling:
+ *   - If either pointer is NULL the context is treated as unconfigured so
+ *     that the caller always proceeds to (re-)apply the configuration.
+ *
+ * Lock / ownership note:
+ *   The SPI_LOCK_ON ownership token is carried by the pointer identity of
+ *   the spi_config passed to spi_lock / spi_release and is checked separately
+ *   in those paths.  This function is concerned only with hardware config
+ *   equivalence and is therefore safe to compare by value.
+ *
+ * @param ctx    Pointer to the SPI context.
+ * @param config Pointer to the new SPI configuration to test.
+ *
+ * @return true  if ctx already holds a configuration identical in every
+ *               field to @p config (hardware update can be skipped).
+ * @return false if any field differs, or if either pointer is NULL.
  */
 static inline bool spi_context_configured(struct spi_context *ctx,
 					  const struct spi_config *config)
 {
-	return !!(ctx->config == config);
+	/*
+	 * Guard against NULL: a NULL cached config means the context has
+	 * never been configured (or was released), so always return false
+	 * to force a fresh configuration pass.
+	 */
+	if (!ctx->config || !config) {
+		return false;
+	}
+
+	/*
+	 * Compare all fields explicitly to avoid padding byte issues.
+	 * This detects any field mutation even when the caller reuses
+	 * the same pointer.
+	 */
+	return spi_cfg_equal(ctx->config, config);
 }
 
 /* Returns true if the spi configuration stored for this context
@@ -129,7 +189,7 @@ static inline void spi_context_lock(struct spi_context *ctx,
 #ifdef CONFIG_MULTITHREADING
 	bool already_locked = (spi_cfg->operation & SPI_LOCK_ON) &&
 			      (k_sem_count_get(&ctx->lock) == 0) &&
-			      (ctx->owner == spi_cfg);
+			      spi_cfg_equal(ctx->owner, spi_cfg);
 
 	if (!already_locked) {
 		k_sem_take(&ctx->lock, K_FOREVER);

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 Synopsys, Inc. All rights reserved.
  * Copyright (c) 2023 Meta Platforms
  *
+ * Modifications: NULL and zero-frequency guard (SPI-DW-002)
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -179,6 +181,54 @@ static void pull_data(const struct device *dev)
 	}
 }
 
+/**
+ * spi_dw_validate_config() - sanity-check an spi_config before touching HW.
+ *
+ * Centralises all input validation so that spi_dw_configure() and
+ * transceive() can call a single helper rather than duplicating
+ * guards.
+ *
+ * Checked conditions
+ * ------------------
+ *  1. config pointer must be non-NULL.
+ *  2. config->frequency must be > 0.
+ *  3. config->frequency must not exceed the controller's input clock
+ *     (a divider < 2 is illegal per the DW SSI databook, section 6.2.2).
+ *
+ * @param dev    SPI controller device.
+ * @param config Caller-supplied SPI configuration.
+ *
+ * @retval 0        Configuration is valid.
+ * @retval -EINVAL  config is NULL or frequency is zero / out of range.
+ */
+static int spi_dw_validate_config(const struct device *dev,
+				  const struct spi_config *config)
+{
+	const struct spi_dw_config *info = dev->config;
+
+	/* Guard 1: NULL pointer check */
+	if (!config) {
+		LOG_ERR("(%s): config pointer is NULL", dev->name);
+		return -EINVAL;
+	}
+
+	/* Guard 2: zero frequency would cause DIV/0 in clk divider calc */
+	if (config->frequency == 0U) {
+		LOG_ERR("(%s): SPI frequency must not be zero", dev->name);
+		return -EINVAL;
+	}
+
+	/* Guard 3: frequency must be achievable (divider >= 2) */
+	if (config->frequency > (info->clock_frequency / 2U)) {
+		LOG_ERR("(%s): SPI frequency %u exceeds max supported %u Hz",
+			dev->name, config->frequency,
+			info->clock_frequency / 2U);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int spi_dw_configure(const struct device *dev,
 			    struct spi_dw_data *spi,
 			    const struct spi_config *config)
@@ -188,8 +238,15 @@ static int spi_dw_configure(const struct device *dev,
 
 	LOG_DBG("%p (prev %p)", config, spi->ctx.config);
 
+	/* Always validate first, even if the context thinks it's configured */
+	int ret = spi_dw_validate_config(dev, config);
+
+	if (ret) {
+		return ret;
+	}
+
 	if (spi_context_configured(&spi->ctx, config)) {
-		/* Nothing to do */
+		/* Contents are identical — hardware update not required */
 		return 0;
 	}
 


### PR DESCRIPTION
spi_context_configured() compares config struct pointer addresses rather than field contents. When a caller reuses the same pointer but mutates frequency or operation fields, the driver silently skips reconfiguration and returns success with stale HW state.

Additionally, no NULL or zero-value guard exists on the frequency field, causing an integer division-by-zero when computing the baud rate divider in spi_dw.c.

Fix by:
- Replacing pointer comparison with field-level content check
- Adding NULL guard on config pointer
- Adding zero/range guard on config->frequency

Fixes: #81782
Fixes: #28093