### PR TITLE
soc: silabs: Add RF path switch

### DIFF
--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -211,6 +211,12 @@
 	status = "okay";
 };
 
+&radio {
+	rf-path-switch-combine;
+	rf-path-switch-control-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
+	rf-path-switch-radio-active-gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+};
+
 &se {
 	status = "okay";
 };

--- a/dts/bindings/net/wireless/silabs,series2-radio.yaml
+++ b/dts/bindings/net/wireless/silabs,series2-radio.yaml
@@ -69,3 +69,20 @@ properties:
       - mp
       - lp
       - llp
+
+  rf-path-switch-combine:
+    type: boolean
+    description: |
+      Logical AND the radio active signal with the RF path selection (control) signal.
+
+  rf-path-switch-control-gpios:
+    type: phandle-array
+    description: |
+      GPIO on which the RF path selection signal is emitted. Typically connected to the
+      control signal of an RF switch.
+
+  rf-path-switch-radio-active-gpios:
+    type: phandle-array
+    description: |
+      GPIO on which the radio active signal is emitted. Typically connected to the supply
+      of an RF switch to only enable it when the radio is in operation.

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -52,11 +52,13 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
 
   zephyr_compile_definitions(
     SL_RAIL_UTIL_PA_CONFIG_HEADER="sl_rail_util_pa_config.h"
+    SL_CATALOG_SL_RAIL_UTIL_RF_PATH_SWITCH_PRESENT=1
   )
 
   zephyr_include_directories(
     ${RADIO_DIR}/rail_lib/common
     ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_compatible_pa
+    ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_rf_path_switch
     ${BLUETOOTH_DIR}/bgstack/ll/inc
   )
 
@@ -104,6 +106,10 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
 
   if(CONFIG_SOC_GECKO_USE_RAIL)
     # rail
+    zephyr_library_sources(
+      ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_rf_path_switch/sl_rail_util_rf_path_switch.c
+    )
+
     # PA curve for the modules comes from their config archive - omit the compilation of the SoC curves on modules
     zephyr_library_sources_ifdef(CONFIG_SILABS_DEVICE_IS_MODULE
       ${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_rf_path_switch_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_rf_path_switch_config.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This configuration header is used by the HAL driver sl_rail_util_rf_path_switch
+ * from hal_silabs, invoked through SoC init when radio functionality is enabled.
+ * DeviceTree and Kconfig options are converted to config macros expected by the HAL driver.
+ */
+
+#ifndef SL_RAIL_UTIL_RF_PATH_SWITCH_CONFIG_H
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_CONFIG_H
+
+#include <zephyr/devicetree.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_RADIO_ACTIVE_DISABLE 0
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_RADIO_ACTIVE_COMBINE 1
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_RADIO_ACTIVE_MODE                                              \
+	DT_PROP(DT_NODELABEL(radio), rf_path_switch_combine)
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(radio), rf_path_switch_radio_active_gpios)
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_RADIO_ACTIVE_PORT                                              \
+	DT_NODE_CHILD_IDX(DT_GPIO_CTLR(DT_NODELABEL(radio), rf_path_switch_radio_active_gpios))
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_RADIO_ACTIVE_PIN                                               \
+	DT_GPIO_PIN(DT_NODELABEL(radio), rf_path_switch_radio_active_gpios)
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(radio), rf_path_switch_control_gpios)
+#if DT_GPIO_FLAGS(DT_NODELABEL(radio), rf_path_switch_control_gpios) & GPIO_ACTIVE_LOW
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_CONTROL_PORT                                                   \
+	DT_NODE_CHILD_IDX(DT_GPIO_CTLR(DT_NODELABEL(radio), rf_path_switch_control_gpios))
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_CONTROL_PIN                                                    \
+	DT_GPIO_PIN(DT_NODELABEL(radio), rf_path_switch_control_gpios)
+#else
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_INVERTED_CONTROL_PORT                                          \
+	DT_NODE_CHILD_IDX(DT_GPIO_CTLR(DT_NODELABEL(radio), rf_path_switch_control_gpios))
+#define SL_RAIL_UTIL_RF_PATH_SWITCH_INVERTED_CONTROL_PIN                                           \
+	DT_GPIO_PIN(DT_NODELABEL(radio), rf_path_switch_control_gpios)
+#endif
+#endif
+
+#endif /* SL_RAIL_UTIL_RF_PATH_SWITCH_CONFIG_H */

--- a/soc/silabs/silabs_s2/soc.c
+++ b/soc/silabs/silabs_s2/soc.c
@@ -61,7 +61,7 @@ void soc_early_init_hook(void)
 		sl_power_manager_init();
 	}
 	if (IS_ENABLED(CONFIG_SOC_GECKO_USE_RAIL)) {
-		rail_isr_installer();
+		soc_radio_init();
 	}
 }
 

--- a/soc/silabs/silabs_s2/soc_radio.c
+++ b/soc/silabs/silabs_s2/soc_radio.c
@@ -10,7 +10,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <rail.h>
+#include <sl_rail.h>
 
 #include <soc_radio.h>
 
@@ -42,4 +42,9 @@ void rail_isr_installer(void)
 			    RDMAILBOX_IRQHandler,
 			    NULL, 0);
 	}));
+}
+
+void soc_radio_init(void)
+{
+	rail_isr_installer();
 }

--- a/soc/silabs/silabs_s2/soc_radio.c
+++ b/soc/silabs/silabs_s2/soc_radio.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/kernel.h>
 #include <sl_rail.h>
+#include <sl_rail_util_rf_path_switch.h>
 
 #include <soc_radio.h>
 
@@ -47,4 +48,5 @@ void rail_isr_installer(void)
 void soc_radio_init(void)
 {
 	rail_isr_installer();
+	sl_rail_util_rf_path_switch_init();
 }

--- a/soc/silabs/silabs_s2/soc_radio.h
+++ b/soc/silabs/silabs_s2/soc_radio.h
@@ -11,3 +11,8 @@
  */
 
 void rail_isr_installer(void);
+
+/**
+ * @brief Initialize radio on Silicon Labs Series 2 SoCs
+ */
+void soc_radio_init(void);


### PR DESCRIPTION
Some Silicon Labs boards have an RF path switch on the 2.4 GHz RF path, shorting the antenna to ground when not in use, in order to avoid spurious harmonics for the sub-GHz radio. When not configured properly, this leads to Bluetooth RSSI being lowered by more than 20 dBm.

Add devicetree properties describing the RF path switch and configure the switch appropriately at boot using signals from the radio.