### PR TITLE
kernel: Add userspace support for mailbox

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5455,7 +5455,7 @@ struct k_mbox {
  *
  * @param mbox Address of the mailbox.
  */
-void k_mbox_init(struct k_mbox *mbox);
+__syscall void k_mbox_init(struct k_mbox *mbox);
 
 /**
  * @brief Send a mailbox message in a synchronous manner.
@@ -5476,8 +5476,7 @@ void k_mbox_init(struct k_mbox *mbox);
  * @retval -ENOMSG Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
-		      k_timeout_t timeout);
+__syscall int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, k_timeout_t timeout);
 
 /**
  * @brief Send a mailbox message in an asynchronous manner.
@@ -5492,14 +5491,17 @@ int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
  * @param tx_msg Address of the transmit message descriptor.
  * @param sem Address of a semaphore, or NULL if none is needed.
  */
-void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
-			     struct k_sem *sem);
+__syscall void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, struct k_sem *sem);
 
 /**
  * @brief Receive a mailbox message.
  *
  * This routine receives a message from @a mbox, then optionally retrieves
  * its data and disposes of the message.
+ *
+ * When called from userspace, delayed retrieval with k_mbox_data_get is not
+ * supported. Therefore, either @a buffer must be non-NULL or the size in
+ * @a rx_msg must be zero, so that the message is disposed directly.
  *
  * @param mbox Address of the mailbox.
  * @param rx_msg Address of the receive message descriptor.
@@ -5511,9 +5513,10 @@ void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
  * @retval 0 Message received.
  * @retval -ENOMSG Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
+ * @retval -ENOTSUP Call from userspace with delayed retrieval.
  */
-int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg,
-		      void *buffer, k_timeout_t timeout);
+__syscall int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
+			 k_timeout_t timeout);
 
 /**
  * @brief Retrieve mailbox message data into a buffer.
@@ -5523,6 +5526,9 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg,
  *
  * Alternatively, this routine can be used to dispose of a received message
  * without retrieving its data.
+ *
+ * Since k_mbox_msg is not a kernel object, this method cannot be called from
+ * userspace.
  *
  * @param rx_msg Address of the receive message descriptor.
  * @param buffer Address of the buffer to receive data, or NULL to discard

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/init.h>
 /* private kernel APIs */
+#include <zephyr/internal/syscall_handler.h>
 #include <ksched.h>
 #include <kthread.h>
 #include <wait_q.h>
@@ -84,7 +85,7 @@ SYS_INIT(init_mbox_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 #endif /* CONFIG_NUM_MBOX_ASYNC_MSGS > 0 */
 
-void k_mbox_init(struct k_mbox *mbox)
+void z_impl_k_mbox_init(struct k_mbox *mbox)
 {
 	z_waitq_init(&mbox->tx_msg_queue);
 	z_waitq_init(&mbox->rx_msg_queue);
@@ -292,8 +293,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	return ret;
 }
 
-int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
-	       k_timeout_t timeout)
+int z_impl_k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, k_timeout_t timeout)
 {
 	/* configure things for a synchronous send, then send the message */
 	tx_msg->_syncing_thread = _current;
@@ -308,8 +308,7 @@ int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 }
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0)
-void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
-		      struct k_sem *sem)
+void z_impl_k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, struct k_sem *sem)
 {
 	struct k_mbox_async *async;
 
@@ -379,8 +378,8 @@ static int mbox_message_data_check(struct k_mbox_msg *rx_msg, void *buffer)
 	return 0;
 }
 
-int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
-	       k_timeout_t timeout)
+int z_impl_k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
+		      k_timeout_t timeout)
 {
 	struct k_thread *sending_thread;
 	struct k_mbox_msg *tx_msg;
@@ -437,6 +436,62 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 
 	return result;
 }
+
+#ifdef CONFIG_USERSPACE
+static inline void z_vrfy_k_mbox_init(struct k_mbox *mbox)
+{
+	K_OOPS(K_SYSCALL_OBJ_NEVER_INIT(mbox, K_OBJ_MBOX));
+
+	z_impl_k_mbox_init(mbox);
+}
+#include <zephyr/syscalls/k_mbox_init_mrsh.c>
+
+int z_vrfy_k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg, k_timeout_t timeout)
+{
+	K_OOPS(K_SYSCALL_OBJ(mbox, K_OBJ_MBOX));
+	K_OOPS(K_SYSCALL_MEMORY_READ(tx_msg, sizeof(*tx_msg)));
+	if (tx_msg->size != 0) {
+		K_OOPS(K_SYSCALL_MEMORY_READ(tx_msg->tx_data, tx_msg->size));
+	}
+
+	return z_impl_k_mbox_put(mbox, tx_msg, timeout);
+}
+#include <zephyr/syscalls/k_mbox_put_mrsh.c>
+
+static inline void z_vrfy_k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
+					   struct k_sem *sem)
+{
+	K_OOPS(K_SYSCALL_OBJ(mbox, K_OBJ_MBOX));
+	K_OOPS(K_SYSCALL_MEMORY_READ(tx_msg, sizeof(*tx_msg)));
+	if (tx_msg->size != 0) {
+		K_OOPS(K_SYSCALL_MEMORY_READ(tx_msg->tx_data, tx_msg->size));
+	}
+	if (sem != NULL) {
+		K_OOPS(K_SYSCALL_OBJ(sem, K_OBJ_SEM));
+	}
+
+	z_impl_k_mbox_async_put(mbox, tx_msg, sem);
+}
+#include <zephyr/syscalls/k_mbox_async_put_mrsh.c>
+
+static inline int z_vrfy_k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
+				    k_timeout_t timeout)
+{
+	K_OOPS(K_SYSCALL_OBJ(mbox, K_OBJ_MBOX));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(rx_msg, sizeof(*rx_msg)));
+	if (rx_msg->size != 0) {
+		if (buffer != NULL) {
+			K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, rx_msg->size));
+		} else {
+			/* Delayed retrieval not supported for userspace */
+			return -ENOTSUP;
+		}
+	}
+
+	return z_impl_k_mbox_get(mbox, rx_msg, buffer, timeout);
+}
+#include <zephyr/syscalls/k_mbox_get_mrsh.c>
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_MAILBOX
 

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -91,6 +91,7 @@ from collections import OrderedDict
 # https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
 kobjects = OrderedDict(
     [
+        ("k_mbox", (None, False, False)),
         ("k_mem_slab", (None, False, True)),
         ("k_msgq", (None, False, True)),
         ("k_mutex", (None, False, True)),


### PR DESCRIPTION
This allows user threads to communicate via mailbox objects.

Limitation: Since struct k_mbox_msg is not a kernel object, userspace cannot use k_mbox_data_get. Userspace must dispose messages with k_mbox_get immediately.