### PR TITLE
drivers: i2c: nrfx_twim: use timeout error code

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -178,7 +178,7 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 			 * bus from this error.
 			 */
 			(void)i2c_nrfx_twim_recover_bus(dev);
-			ret = -EIO;
+			ret = -ETIMEDOUT;
 			break;
 		}
 


### PR DESCRIPTION
Using different, more appropriate, error code in
case of timeout, to differentiate from regular EIO.