### PR TITLE
kernel: sched: fix z_tick_sleep unsigned comparison when !CONFIG_TIME…

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1175,14 +1175,18 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 		return 0;
 	}
 
-	/* We require a 32 bit unsigned subtraction to care a wraparound */
+	/* We require a 32 bit unsigned subtraction to handle a wraparound */
 	uint32_t left_ticks = expected_wakeup_ticks - sys_clock_tick_get_32();
 
-	/* To handle a negative value correctly, once type-cast it to signed 32 bit */
-	k_ticks_t ticks = (k_ticks_t)(int32_t)left_ticks;
+	/* Use signed comparison so past-due wakeups (negative remainder) return 0.
+	 * k_ticks_t may be uint32_t (!CONFIG_TIMEOUT_64BIT), so comparing ticks > 0
+	 * directly would be an unsigned comparison and would misinterpret a negative
+	 * remainder as a large positive value.
+	 */
+	int32_t signed_left = (int32_t)left_ticks;
 
-	if (ticks > 0) {
-		return ticks;
+	if (signed_left > 0) {
+		return (k_ticks_t)signed_left;
 	}
 
 	return 0;


### PR DESCRIPTION
…OUT_64BIT

When CONFIG_TIMEOUT_64BIT is not set, k_ticks_t is uint32_t. The previous code cast left_ticks through int32_t but then stored the result back in k_ticks_t (uint32_t), losing the sign. The subsequent ticks > 0 check was therefore an unsigned comparison, causing a past-due wakeup (where the subtraction wraps to a large uint32_t) to be misread as a large positive remainder and propagated up through k_sleep() as INT_MAX ms.

Fix by retaining the signed intermediate and comparing it directly as int32_t so negative remainders (past-due) correctly fall through to return 0.