### PR TITLE
doc: improve west completion setup for bash

### DIFF
--- a/doc/develop/west/install.rst
+++ b/doc/develop/west/install.rst
@@ -73,7 +73,7 @@ Using the completion scripts:
 
     .. code-block:: bash
 
-      west completion bash > ~/west-completion.bash; echo "source ~/west-completion.bash" >> ~/.bashrc
+      west completion bash > ~/west-completion.bash; printf '\n%s\n' "source ~/west-completion.bash" >> ~/.bashrc
 
   .. group-tab:: zsh
 


### PR DESCRIPTION
A pre-existing `~/.bashrc` file might not finish with a newline character.
In that case, a setting just appended to it would not register.
To avoid such a case, make the permenant west completion setup for bash not rely on it and explicitly add a preceding newline character.