### PR TITLE
drivers: spi: dw: add frequency validation in configuration path

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -225,6 +225,20 @@ static int spi_dw_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	/* zero frequency would cause DIV/0 in clk divider calc */
+	if (!config->frequency) {
+		LOG_ERR("(%s): Frequency must not be zero", dev->name);
+		return -EINVAL;
+	}
+
+	/* return error if the expected bus frequency is
+	 * greater than half of the input core clock frequency
+	 */
+	if (config->frequency > (info->clock_frequency / DW_SPI_MIN_SCKDIV)) {
+		LOG_ERR("(%s): Invalid bus frequency", dev->name);
+		return -EINVAL;
+	}
+
 	/* Word size */
 	if (!IS_ENABLED(CONFIG_SPI_DW_HSSI) && (info->max_xfer_size == 32)) {
 		ctrlr0 |= DW_SPI_CTRLR0_DFS_32(SPI_WORD_SIZE_GET(config->operation));

--- a/drivers/spi/spi_dw_regs.h
+++ b/drivers/spi/spi_dw_regs.h
@@ -41,6 +41,8 @@ extern "C" {
 #define DW_SPI_REG_DR			(0x60)
 #define DW_SPI_REG_RX_SAMPLE_DLY	(0xf0)
 
+#define DW_SPI_MIN_SCKDIV		(0x2)
+
 /* Register helpers */
 DEFINE_MM_REG_WRITE(ctrlr0, DW_SPI_REG_CTRLR0, 32)
 DEFINE_MM_REG_READ(ctrlr0, DW_SPI_REG_CTRLR0, 32)


### PR DESCRIPTION
Validate the SPI bus frequency supplied via spi_config before it is used to compute the baud-rate clock divider to prevent the following faults:

- A zero frequency causes an integer division-by-zero when computing the clock divider, resulting in a hardware fault or an undefined value being written to the SPI_BAUDR register.

- A frequency exceeding half of the input core clock produces a divider value less than the minimum of 2 required by the DesignWare SSI databook (section 6.2.2), overclocking the peripheral and causing undefined bus behaviour.

Return -EINVAL for a zero frequency and -EINVAL for a frequency greater than clk_hz / 2, surfacing the error to the caller rather than silently misconfiguring the hardware.

Assisted-by: Claude:claude-opus-4.6

Fixes: #111119