### PR TITLE
soc: st: l1: factorized poweroff sequence, l1/f1/wba: disable debug on poweroff

### DIFF
--- a/soc/st/stm32/stm32f1x/poweroff.c
+++ b/soc/st/stm32/stm32f1x/poweroff.c
@@ -16,6 +16,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+	LL_DBGMCU_DisableDBGStandbyMode();
 
 	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32l1x/poweroff.c
+++ b/soc/st/stm32/stm32l1x/poweroff.c
@@ -16,6 +16,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+	LL_DBGMCU_DisableDBGStandbyMode();
 
 	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32l1x/poweroff.c
+++ b/soc/st/stm32/stm32l1x/poweroff.c
@@ -15,11 +15,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_SB();
 	LL_PWR_ClearFlag_WU();
 
-	LL_LPM_DisableEventOnPend();
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32wbax/poweroff.c
+++ b/soc/st/stm32/stm32wbax/poweroff.c
@@ -25,5 +25,7 @@ void z_sys_poweroff(void)
 	LL_PWR_SetSRAM1SBRetention(LL_PWR_SRAM1_SB_NO_RETENTION);
 	LL_PWR_SetSRAM2SBRetention(LL_PWR_SRAM2_SB_NO_RETENTION);
 
+	LL_DBGMCU_DisableDBGStandbyMode();
+
 	stm32_enter_poweroff();
 }


### PR DESCRIPTION
Use `stm32_enter_poweroff()` helper function in stm32l1x power-off sequence.

Disable debug in poweroff sequence for SoCs where debug could leak current due to `CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP` being enabled.
