### PR TITLE
dts: bindings: clock: nordic: Update load capacitance for LFXO

### DIFF
--- a/dts/bindings/clock/nordic,nrf54l-lfxo.yaml
+++ b/dts/bindings/clock/nordic,nrf54l-lfxo.yaml
@@ -23,39 +23,10 @@ properties:
 
   load-capacitance-femtofarad:
     type: int
-    enum:
-      - 4000
-      - 4500
-      - 5000
-      - 5500
-      - 6000
-      - 6500
-      - 7000
-      - 7500
-      - 8000
-      - 8500
-      - 9000
-      - 9500
-      - 10000
-      - 10500
-      - 11000
-      - 11500
-      - 12000
-      - 12500
-      - 13000
-      - 13500
-      - 14000
-      - 14500
-      - 15000
-      - 15500
-      - 16000
-      - 16500
-      - 17000
-      - 17500
-      - 18000
     description: |
-      Load capacitance in femtofarads. This property is only used when
-      load-capacitors is set to "internal".
+      Load capacitance in femtofarads, holding any value between 3000 and 18000. Configured
+      capacitance is within 650 fF tolerance from the desired setting.
+      This property is only used when load-capacitors is set to "internal".
 
   external-clock-source:
     type: boolean

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -38,6 +38,9 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #define LFXO_NODE DT_NODELABEL(lfxo)
 #define HFXO_NODE DT_NODELABEL(hfxo)
 
+#define LFXO_CAP_MIN_FF 3000UL  /* min load capacitance in femtofarads */
+#define LFXO_CAP_MAX_FF 18000UL /* max load capacitance in femtofarads */
+
 #if DT_PROP(LFXO_NODE, external_clock_source)
 BUILD_ASSERT(DT_ENUM_HAS_VALUE(LFXO_NODE, load_capacitors, internal) == 0,
 	     "Internal load capacitors must be disconnected when using "
@@ -54,6 +57,12 @@ static inline void power_and_clock_configuration(void)
  * that requires them to be configured with the same security property.
  */
 #if DT_ENUM_HAS_VALUE(LFXO_NODE, load_capacitors, internal)
+	BUILD_ASSERT(DT_PROP(LFXO_NODE, load_capacitance_femtofarad) >= LFXO_CAP_MIN_FF &&
+		     DT_PROP(LFXO_NODE, load_capacitance_femtofarad) <= LFXO_CAP_MAX_FF,
+		     "LFXO load capacitance must be between "
+		     STRINGIFY(LFXO_CAP_MIN_FF) " and " STRINGIFY(LFXO_CAP_MAX_FF)
+		     " femtofarads");
+
 	uint32_t xosc32ktrim = NRF_FICR->XOSC32KTRIM;
 	/* The SLOPE field is in the two's complement form, hence this special
 	 * handling. Ideally, it would result in just one SBFX instruction for


### PR DESCRIPTION
Type of load capacitance for LFXO changed from enum to int.