### PR TITLE
net: ethernet: lldp: improve it

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -647,9 +647,6 @@ struct ethernet_lldp {
 	/** Length of the optional Data Unit TLVs */
 	size_t optional_len;
 
-	/** Network interface that has LLDP supported. */
-	struct net_if *iface;
-
 	/** LLDP TX timer start time */
 	int64_t tx_timer_start;
 
@@ -689,14 +686,8 @@ struct ethernet_context {
 	struct net_if *iface;
 
 #if defined(CONFIG_NET_LLDP)
-#if NET_VLAN_MAX_COUNT > 0
-#define NET_LLDP_MAX_COUNT NET_VLAN_MAX_COUNT
-#else
-#define NET_LLDP_MAX_COUNT 1
-#endif /* NET_VLAN_MAX_COUNT > 0 */
-
 	/** LLDP specific parameters */
-	struct ethernet_lldp lldp[NET_LLDP_MAX_COUNT];
+	struct ethernet_lldp lldp;
 #endif
 
 	/**

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -21,6 +21,7 @@
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/lldp.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet_vlan.h>
@@ -647,11 +648,8 @@ struct ethernet_lldp {
 	/** Length of the optional Data Unit TLVs */
 	size_t optional_len;
 
-	/** LLDP TX timer start time */
-	int64_t tx_timer_start;
-
-	/** LLDP TX timeout */
-	uint32_t tx_timer_timeout;
+	/** LLDP TX timer timeout */
+	k_timepoint_t tx_timer_timeout;
 
 	/** LLDP RX callback function */
 	net_lldp_recv_cb_t cb;

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -30,36 +30,16 @@ static sys_slist_t lldp_ifaces;
 
 #define BUF_ALLOC_TIMEOUT K_MSEC(50)
 
-static void lldp_submit_work(uint32_t timeout)
+static void lldp_submit_work(k_timeout_t timeout)
 {
-	k_work_cancel_delayable(&lldp_tx_timer);
-	k_work_reschedule(&lldp_tx_timer, K_MSEC(timeout));
+	k_work_reschedule(&lldp_tx_timer, timeout);
 
 	NET_DBG("Next wakeup in %d ms",
 		k_ticks_to_ms_ceil32(
 			k_work_delayable_remaining_get(&lldp_tx_timer)));
 }
 
-static bool lldp_check_timeout(int64_t start, uint32_t time, int64_t timeout)
-{
-	start += time;
-	start = llabs(start);
-
-	if (start > timeout) {
-		return false;
-	}
-
-	return true;
-}
-
-static bool lldp_timedout(struct ethernet_lldp *lldp, int64_t timeout)
-{
-	return lldp_check_timeout(lldp->tx_timer_start,
-				  lldp->tx_timer_timeout,
-				  timeout);
-}
-
-static int lldp_send(struct ethernet_lldp *lldp)
+static void lldp_send(struct ethernet_lldp *lldp)
 {
 	static const struct net_eth_addr lldp_multicast_eth_addr = {
 		{ 0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e }
@@ -72,8 +52,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	if (!lldp->lldpdu) {
 		/* The ethernet driver has not set the lldpdu pointer */
 		NET_DBG("The LLDPDU is not set for lldp %p", lldp);
-		ret = -EINVAL;
-		goto out;
+		return;
 	}
 
 	if (lldp->optional_du && lldp->optional_len) {
@@ -89,8 +68,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	pkt = net_pkt_alloc_with_buffer(ctx->iface, len, NET_AF_UNSPEC, 0,
 					BUF_ALLOC_TIMEOUT);
 	if (!pkt) {
-		ret = -ENOMEM;
-		goto out;
+		return;
 	}
 
 	net_pkt_set_lldp(pkt, true);
@@ -100,7 +78,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 			    sizeof(struct net_lldpdu));
 	if (ret < 0) {
 		net_pkt_unref(pkt);
-		goto out;
+		return;
 	}
 
 	if (lldp->optional_du && lldp->optional_len) {
@@ -108,7 +86,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 				    lldp->optional_len);
 		if (ret < 0) {
 			net_pkt_unref(pkt);
-			goto out;
+			return;
 		}
 	}
 
@@ -118,7 +96,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 		ret = net_pkt_write(pkt, (uint8_t *)&tlv_end, sizeof(tlv_end));
 		if (ret < 0) {
 			net_pkt_unref(pkt);
-			goto out;
+			return;
 		}
 	}
 
@@ -134,66 +112,53 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	 */
 	if (net_if_try_send_data(ctx->iface, pkt, K_NO_WAIT) == NET_DROP) {
 		net_pkt_unref(pkt);
-		ret = -EIO;
+		return;
 	}
 
-out:
-	lldp->tx_timer_start = k_uptime_get();
+	NET_DBG("LLDP packet sent from iface %p", ctx->iface);
 
-	return ret;
+	return;
 }
 
-static uint32_t lldp_manage_timeouts(struct ethernet_lldp *lldp, int64_t timeout)
+static void lldp_tx_timeout(struct k_work *work __unused)
 {
-	int32_t next_timeout;
-
-	if (lldp_timedout(lldp, timeout)) {
-		lldp_send(lldp);
-	}
-
-	next_timeout = timeout - (lldp->tx_timer_start +
-				  lldp->tx_timer_timeout);
-
-	return abs(next_timeout);
-}
-
-static void lldp_tx_timeout(struct k_work *work)
-{
-	uint32_t timeout_update = UINT32_MAX - 1;
-	int64_t timeout = k_uptime_get();
+	k_timepoint_t timeout_update = sys_timepoint_calc(K_FOREVER);
+	k_timeout_t timeout;
 	struct ethernet_lldp *current, *next;
 
-	ARG_UNUSED(work);
-
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&lldp_ifaces, current, next, node) {
-		uint32_t next_timeout;
+		if (sys_timepoint_expired(current->tx_timer_timeout)) {
+			lldp_send(current);
 
-		next_timeout = lldp_manage_timeouts(current, timeout);
-		if (next_timeout < timeout_update) {
-			timeout_update = next_timeout;
+			current->tx_timer_timeout =
+				sys_timepoint_calc(K_SECONDS(CONFIG_NET_LLDP_TX_INTERVAL));
+		}
+
+		if (sys_timepoint_cmp(current->tx_timer_timeout, timeout_update) < 0) {
+			timeout_update = current->tx_timer_timeout;
 		}
 	}
 
-	if (timeout_update < (UINT32_MAX - 1)) {
-		NET_DBG("Waiting for %u ms", timeout_update);
-
-		k_work_reschedule(&lldp_tx_timer, K_MSEC(timeout_update));
+	timeout = sys_timepoint_timeout(timeout_update);
+	if (!K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		lldp_submit_work(timeout);
 	}
 }
 
 static void lldp_start_timer(struct ethernet_context *ctx)
 {
+	k_timeout_t timeout = K_NO_WAIT;
+
 	/* exit if started */
-	if (ctx->lldp.tx_timer_start != 0) {
+	if (sys_slist_find(&lldp_ifaces, &(ctx->lldp.node), NULL)) {
 		return;
 	}
 
+	ctx->lldp.tx_timer_timeout = sys_timepoint_calc(timeout);
+
 	sys_slist_append(&lldp_ifaces, &(ctx->lldp.node));
 
-	ctx->lldp.tx_timer_start = k_uptime_get();
-	ctx->lldp.tx_timer_timeout = CONFIG_NET_LLDP_TX_INTERVAL * MSEC_PER_SEC;
-
-	lldp_submit_work(ctx->lldp.tx_timer_timeout);
+	lldp_submit_work(timeout);
 }
 
 static int lldp_check_iface(struct net_if *iface)
@@ -220,10 +185,8 @@ static void lldp_start(struct net_if *iface, uint64_t mgmt_event)
 	ctx = net_if_l2_data(iface);
 
 	if (mgmt_event == NET_EVENT_IF_DOWN) {
-		if (sys_slist_find_and_remove(&lldp_ifaces,
-					      &(ctx->lldp.node))) {
-			ctx->lldp.tx_timer_start = 0;
-		}
+		NET_DBG("Stopping timer for iface %p", iface);
+		(void)sys_slist_find_and_remove(&lldp_ifaces, &(ctx->lldp.node));
 
 		if (sys_slist_is_empty(&lldp_ifaces)) {
 			k_work_cancel_delayable(&lldp_tx_timer);

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -30,28 +30,6 @@ static sys_slist_t lldp_ifaces;
 
 #define BUF_ALLOC_TIMEOUT K_MSEC(50)
 
-static int lldp_find(struct ethernet_context *ctx, struct net_if *iface)
-{
-	int i, found = -1;
-
-	for (i = 0; i < ARRAY_SIZE(ctx->lldp); i++) {
-		if (ctx->lldp[i].iface == iface) {
-			return i;
-		}
-
-		if (found < 0 && ctx->lldp[i].iface == NULL) {
-			found = i;
-		}
-	}
-
-	if (found >= 0) {
-		ctx->lldp[found].iface = iface;
-		return found;
-	}
-
-	return -ENOENT;
-}
-
 static void lldp_submit_work(uint32_t timeout)
 {
 	k_work_cancel_delayable(&lldp_tx_timer);
@@ -86,6 +64,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	static const struct net_eth_addr lldp_multicast_eth_addr = {
 		{ 0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e }
 	};
+	struct ethernet_context *ctx = CONTAINER_OF(lldp, struct ethernet_context, lldp);
 	int ret = 0;
 	struct net_pkt *pkt;
 	size_t len;
@@ -107,7 +86,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 		len += sizeof(uint16_t);
 	}
 
-	pkt = net_pkt_alloc_with_buffer(lldp->iface, len, NET_AF_UNSPEC, 0,
+	pkt = net_pkt_alloc_with_buffer(ctx->iface, len, NET_AF_UNSPEC, 0,
 					BUF_ALLOC_TIMEOUT);
 	if (!pkt) {
 		ret = -ENOMEM;
@@ -144,7 +123,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	}
 
 	(void)net_linkaddr_copy(net_pkt_lladdr_src(pkt),
-				net_if_get_link_addr(lldp->iface));
+				net_if_get_link_addr(ctx->iface));
 
 	(void)net_linkaddr_set(net_pkt_lladdr_dst(pkt),
 			       (uint8_t *)lldp_multicast_eth_addr.addr,
@@ -153,7 +132,7 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	/* send without timeout, so we do not risk being blocked by tx when
 	 * being flooded
 	 */
-	if (net_if_try_send_data(lldp->iface, pkt, K_NO_WAIT) == NET_DROP) {
+	if (net_if_try_send_data(ctx->iface, pkt, K_NO_WAIT) == NET_DROP) {
 		net_pkt_unref(pkt);
 		ret = -EIO;
 	}
@@ -202,24 +181,19 @@ static void lldp_tx_timeout(struct k_work *work)
 	}
 }
 
-static void lldp_start_timer(struct ethernet_context *ctx,
-			     struct net_if *iface,
-			     int slot)
+static void lldp_start_timer(struct ethernet_context *ctx)
 {
 	/* exit if started */
-	if (ctx->lldp[slot].tx_timer_start != 0) {
+	if (ctx->lldp.tx_timer_start != 0) {
 		return;
 	}
 
-	ctx->lldp[slot].iface = iface;
+	sys_slist_append(&lldp_ifaces, &(ctx->lldp.node));
 
-	sys_slist_append(&lldp_ifaces, &ctx->lldp[slot].node);
+	ctx->lldp.tx_timer_start = k_uptime_get();
+	ctx->lldp.tx_timer_timeout = CONFIG_NET_LLDP_TX_INTERVAL * MSEC_PER_SEC;
 
-	ctx->lldp[slot].tx_timer_start = k_uptime_get();
-	ctx->lldp[slot].tx_timer_timeout =
-				CONFIG_NET_LLDP_TX_INTERVAL * MSEC_PER_SEC;
-
-	lldp_submit_work(ctx->lldp[slot].tx_timer_timeout);
+	lldp_submit_work(ctx->lldp.tx_timer_timeout);
 }
 
 static int lldp_check_iface(struct net_if *iface)
@@ -235,29 +209,20 @@ static int lldp_check_iface(struct net_if *iface)
 	return 0;
 }
 
-static int lldp_start(struct net_if *iface, uint64_t mgmt_event)
+static void lldp_start(struct net_if *iface, uint64_t mgmt_event)
 {
 	struct ethernet_context *ctx;
-	int ret, slot;
 
-	ret = lldp_check_iface(iface);
-	if (ret < 0) {
-		return ret;
+	if (lldp_check_iface(iface) < 0) {
+		return;
 	}
 
 	ctx = net_if_l2_data(iface);
 
-	ret = lldp_find(ctx, iface);
-	if (ret < 0) {
-		return ret;
-	}
-
-	slot = ret;
-
 	if (mgmt_event == NET_EVENT_IF_DOWN) {
 		if (sys_slist_find_and_remove(&lldp_ifaces,
-					      &ctx->lldp[slot].node)) {
-			ctx->lldp[slot].tx_timer_start = 0;
+					      &(ctx->lldp.node))) {
+			ctx->lldp.tx_timer_start = 0;
 		}
 
 		if (sys_slist_is_empty(&lldp_ifaces)) {
@@ -265,10 +230,10 @@ static int lldp_start(struct net_if *iface, uint64_t mgmt_event)
 		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
 		NET_DBG("Starting timer for iface %p", iface);
-		lldp_start_timer(ctx, iface, slot);
+		lldp_start_timer(ctx);
 	}
 
-	return 0;
+	return;
 }
 
 static enum net_verdict net_lldp_recv(struct net_if *iface, uint16_t ptype, struct net_pkt *pkt)
@@ -291,12 +256,7 @@ static enum net_verdict net_lldp_recv(struct net_if *iface, uint16_t ptype, stru
 
 	ctx = net_if_l2_data(iface);
 
-	ret = lldp_find(ctx, iface);
-	if (ret < 0) {
-		return NET_DROP;
-	}
-
-	recv_cb = ctx->lldp[ret].cb;
+	recv_cb = ctx->lldp.cb;
 	if (recv_cb) {
 		return recv_cb(iface, pkt);
 	}
@@ -318,12 +278,7 @@ int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t recv_cb)
 
 	ctx = net_if_l2_data(iface);
 
-	ret = lldp_find(ctx, iface);
-	if (ret < 0) {
-		return ret;
-	}
-
-	ctx->lldp[ret].cb = recv_cb;
+	ctx->lldp.cb = recv_cb;
 
 	return 0;
 }
@@ -348,14 +303,8 @@ static void iface_cb(struct net_if *iface, void *user_data)
 int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	int i;
 
-	i = lldp_find(ctx, iface);
-	if (i < 0) {
-		return i;
-	}
-
-	ctx->lldp[i].lldpdu = lldpdu;
+	ctx->lldp.lldpdu = lldpdu;
 
 	return 0;
 }
@@ -363,15 +312,9 @@ int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu)
 int net_lldp_config_optional(struct net_if *iface, const uint8_t *tlv, size_t len)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	int i;
 
-	i = lldp_find(ctx, iface);
-	if (i < 0) {
-		return i;
-	}
-
-	ctx->lldp[i].optional_du = tlv;
-	ctx->lldp[i].optional_len = len;
+	ctx->lldp.optional_du = tlv;
+	ctx->lldp.optional_len = len;
 
 	return 0;
 }

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -340,7 +340,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	 * immediately. If the interface is not ethernet one, then
 	 * lldp_start() will return immediately.
 	 */
-	if (net_if_flag_is_set(iface, NET_IF_UP)) {
+	if (net_if_oper_state(iface) == NET_IF_OPER_UP) {
 		lldp_start(iface, NET_EVENT_IF_UP);
 	}
 }
@@ -409,9 +409,9 @@ void net_lldp_unset_lldpdu(struct net_if *iface)
 
 void net_lldp_init(void)
 {
-	net_if_foreach(iface_cb, NULL);
-
 	net_mgmt_init_event_callback(&cb, iface_event_handler,
 				     NET_EVENT_IF_UP | NET_EVENT_IF_DOWN);
 	net_mgmt_add_event_callback(&cb);
+
+	net_if_foreach(iface_cb, NULL);
 }

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -21,8 +21,9 @@ LOG_MODULE_REGISTER(net_lldp, CONFIG_NET_LLDP_LOG_LEVEL);
 
 static struct net_mgmt_event_callback cb;
 
+static void lldp_tx_timeout(struct k_work *work);
 /* Have only one timer in order to save memory */
-static struct k_work_delayable lldp_tx_timer;
+static K_WORK_DELAYABLE_DEFINE(lldp_tx_timer, lldp_tx_timeout);
 
 /* Track currently active timers */
 static sys_slist_t lldp_ifaces;
@@ -408,8 +409,6 @@ void net_lldp_unset_lldpdu(struct net_if *iface)
 
 void net_lldp_init(void)
 {
-	k_work_init_delayable(&lldp_tx_timer, lldp_tx_timeout);
-
 	net_if_foreach(iface_cb, NULL);
 
 	net_mgmt_init_event_callback(&cb, iface_event_handler,


### PR DESCRIPTION
1. With the vlan ifaces are now being virtual ifaces, there is now again a 1:1 relationship between `struct ethernet_ctx` and `struct net_if`, so we can simplify a lot.
2. we can use the `sys_timepoint_*` api
3. some other improvements 