### PR TITLE
xtensa: call0 support

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -14,6 +14,11 @@ config SIMULATOR_XTENSA
 	help
 	  Enable if building to run on simulator.
 
+config XTENSA_CALL0_ABI
+	bool "Use non-windowed ABI"
+	help
+	  When selected, Call0 ABI is used instead of Windowed ABI.
+
 config XTENSA_RESET_VECTOR
 	bool "Build reset vector code"
 	default y

--- a/arch/xtensa/core/debug_helpers_asm.S
+++ b/arch/xtensa/core/debug_helpers_asm.S
@@ -17,11 +17,15 @@
 	.global     xtensa_backtrace_get_start
 	.type       xtensa_backtrace_get_start, @function
 xtensa_backtrace_get_start:
+#if __XTENSA_CALL0_ABI__
+	addi	a1, a1, -32
+#else
 	entry   a1, 32
 	/* Spill registers onto stack (excluding this function) */
 	call8   xthal_window_spill
 	/* a2, a3, a4 should be out arguments for i PC, i SP, i-1 PC respectively.
 	* Use a6 and a7 as scratch */
+#endif
 
 	/* Load address for interrupted stack */
 	l32i    a6, a5, 0
@@ -37,4 +41,9 @@ xtensa_backtrace_get_start:
 	addi    a6, a6, ___xtensa_irq_bsa_t_SIZEOF
 	/* Store i SP in a3 */
 	s32i    a6, a3, 0
+#if __XTENSA_CALL0_ABI__
+	addi	a1, a1, 32
+	ret
+#else
 	retw
+#endif

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -53,6 +53,9 @@ static void *init_stack(struct k_thread *thread, int *stack_top,
 	 */
 	thread->arch.last_cpu = -1;
 
+#if __XTENSA_CALL0_ABI__
+	const int bsasz = sizeof(*frame);
+#else
 	/* We cheat and shave 16 bytes off, the top four words are the
 	 * A0-A3 spill area for the caller of the entry function,
 	 * which doesn't exist.  It will never be touched, so we
@@ -61,6 +64,7 @@ static void *init_stack(struct k_thread *thread, int *stack_top,
 	 * start will decrement the stack pointer by 16.
 	 */
 	const int bsasz = sizeof(*frame) - 16;
+#endif
 
 	frame = (void *)(((char *) stack_top) - bsasz);
 
@@ -90,6 +94,14 @@ static void *init_stack(struct k_thread *thread, int *stack_top,
 #endif
 #endif
 
+#if __XTENSA_CALL0_ABI__
+	frame->bsa.a2 = (uintptr_t)entry;
+	frame->bsa.a3 = (uintptr_t)arg1;
+	frame->a4 = (uintptr_t)arg2;
+	frame->a5 = (uintptr_t)arg3;
+	frame->a6 = 0;
+	frame->a7 = 0;
+#else
 	/* Arguments to z_thread_entry().  Remember these start at A6,
 	 * which will be rotated into A2 by the ENTRY instruction that
 	 * begins the C function.  And A4-A7 and A8-A11 are optional
@@ -104,6 +116,7 @@ static void *init_stack(struct k_thread *thread, int *stack_top,
 	frame->a10 = 0;                /* a10 */
 	frame->a9  = (uintptr_t)arg3;  /* a9 */
 	frame->a8  = (uintptr_t)arg2;  /* a8 */
+#endif
 
 	/* Finally push the BSA pointer and return the stack pointer
 	 * as the handle

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -38,6 +38,9 @@ xtensa_spill_reg_windows:
 .global xtensa_save_high_regs
 .align 4
 xtensa_save_high_regs:
+#if __XTENSA_CALL0_ABI__
+	movi a2, 0
+#else
 	/* Generate a rotated (modulo NREGS/4 bits!) WINDOWSTART in A2
 	 * by duplicating the bits twice and shifting down by WINDOWBASE
 	 * bits.  Now the LSB is the register quad at WINDOWBASE.
@@ -48,6 +51,7 @@ xtensa_save_high_regs:
 	rsr a3, WINDOWBASE
 	ssr a3
 	srl a2, a2
+#endif /* __XTENSA_CALL0_ABI__ */
 
 	mov a3, a1 /* Stash our original stack pointer */
 
@@ -212,10 +216,19 @@ _restore_ps_after:
 .global xtensa_arch_except_epc
 .align 4
 xtensa_arch_except:
+#if __XTENSA_CALL0_ABI__
+	addi a1, a1, -16
+#else
 	entry a1, 16
+#endif
 xtensa_arch_except_epc:
 	ill
+#if __XTENSA_CALL0_ABI__
+	addi a1, a1, 16
+	ret
+#else
 	retw
+#endif
 
 /*
  * void xtensa_arch_kernel_oops(int reason_p, void *ssf);
@@ -226,10 +239,19 @@ xtensa_arch_except_epc:
 .global xtensa_arch_kernel_oops_epc
 .align 4
 xtensa_arch_kernel_oops:
+#if __XTENSA_CALL0_ABI__
+	addi a1, a1, -16
+#else
 	entry a1, 16
+#endif
 xtensa_arch_kernel_oops_epc:
 	ill
+#if __XTENSA_CALL0_ABI__
+	addi a1, a1, 16
+	ret
+#else
 	retw
+#endif
 
 /*
  * void xtensa_switch(void *new, void **old_return);
@@ -241,32 +263,52 @@ xtensa_arch_kernel_oops_epc:
 .align 4
 xtensa_switch:
 #ifdef CONFIG_USERSPACE
+#if __XTENSA_CALL0_ABI__
+	addi	a1, a1, -32
+	s32i	a0, a1, 28
+#else
 	entry a1, 32
+#endif
+#else
+#if __XTENSA_CALL0_ABI__
+	addi	a1, a1, -16
+	s32i	a0, a1, 12
+#else
+	entry a1, 16
+#endif
+#endif
 
+#ifdef CONFIG_USERSPACE
 	s32i a4, a1, 0
 	s32i a5, a1, 4
 	s32i a6, a1, 8
 	s32i a7, a1, 12
+#if __XTENSA_CALL0_ABI__
+	s32i a2, a1, 16
+	s32i a3, a1, 20
+#endif
 
-	rsr a6, ZSR_CPU
-	l32i a6, a6, ___cpu_t_current_OFFSET
+	rsr ARG1, ZSR_CPU
+	l32i ARG1, ARG1, ___cpu_t_current_OFFSET
 #ifdef CONFIG_XTENSA_MMU
 #ifdef CONFIG_XTENSA_MMU_FLUSH_AUTOREFILL_DTLBS_ON_SWAP
-	call4 xtensa_swap_update_page_tables
+	CALL xtensa_swap_update_page_tables
 #else
-	SWAP_PAGE_TABLE a6, a4, a7
+	SWAP_PAGE_TABLE ARG1, a4, a7
 #endif
 #endif
 #ifdef CONFIG_XTENSA_MPU
-	call4 xtensa_mpu_map_write
+	CALL xtensa_mpu_map_write
 #endif
 
 	l32i a7, a1, 12
 	l32i a6, a1, 8
 	l32i a5, a1, 4
 	l32i a4, a1, 0
-#else
-	entry a1, 16
+#if __XTENSA_CALL0_ABI__
+	l32i a2, a1, 16
+	l32i a3, a1, 20
+#endif
 #endif
 
 	SPILL_ALL_WINDOWS
@@ -349,11 +391,22 @@ noflush:
 	 l32i a1, a2, ___xtensa_irq_bsa_t_a2_OFFSET
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
-	call4 z_thread_mark_switched_in
+	CALL z_thread_mark_switched_in
 #endif
 	j _restore_context
 _switch_restore_pc:
+#if __XTENSA_CALL0_ABI__
+#ifdef CONFIG_USERSPACE
+	l32i	a0, a1, 28
+	addi	a1, a1, 32
+#else
+	l32i	a0, a1, 12
+	addi	a1, a1, 16
+#endif
+	ret
+#else
 	retw
+#endif
 
 /* Define our entry handler to load the struct kernel_t from the
  * MISC0 special register, and to find the nest and irq_stack values
@@ -478,10 +531,12 @@ _continue:
 	beqz a0, _handle_tlb_miss_user
 	rsr.exccause a0
 #endif /* CONFIG_XTENSA_MMU */
+#if !__XTENSA_CALL0_ABI__
 	bnei a0, EXCCAUSE_ALLOCA, _not_alloca
 
 	j _xt_alloca_exc
 _not_alloca:
+#endif
 	rsr a0, ZSR_A0SAVE
 	j _Level1Vector
 #ifdef CONFIG_XTENSA_MMU

--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -578,14 +578,14 @@ _do_call_\@:
 	s32i a0, a3, \NEST_OFF
 
 	/* Last trick: the called function returned the "next" handle
-	 * to restore to in A6 (the call4'd function's A2).  If this
-	 * is not the same handle as we started with, we need to do a
-	 * register spill before restoring, for obvious reasons.
+	 * to restore to in A2. If this is not the same handle as we
+	 * started with, we need to do a register spill before restoring,
+	 * for obvious reasons.
 	 * Remember to restore the A1 stack pointer as it existed at
 	 * interrupt time so the caller of the interrupted function
 	 * spills to the right place.
 	 */
-	beq a6, a1, _restore_\@
+	beq a2, a1, _restore_\@
 
 #if !defined(CONFIG_KERNEL_COHERENCE) || \
     (defined(CONFIG_KERNEL_COHERENCE) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY))
@@ -609,9 +609,9 @@ _do_call_\@:
 	 * flush the cached data in stack.
 	 */
 
-	movi a2, 0
-	xsr.ZSR_FLUSH a2
-	beqz a2, _excint_noflush_\@
+	movi a4, 0
+	xsr.ZSR_FLUSH a4
+	beqz a4, _excint_noflush_\@
 
 	rsr.ZSR_CPU a3
 	l32i a3, a3, \NEST_OFF
@@ -622,13 +622,13 @@ _do_call_\@:
 _excint_flushloop_\@:
 	dhwb a3, 0
 	addi a3, a3, XCHAL_DCACHE_LINESIZE
-	blt a3, a2, _excint_flushloop_\@
+	blt a3, a4, _excint_flushloop_\@
 
 _excint_noflush_\@:
 #endif /* CONFIG_KERNEL_COHERENCE && CONFIG_USERSPACE && !CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 
 	/* Restore A1 stack pointer from "next" handle. */
-	mov a1, a6
+	mov a1, a2
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
 	call4 z_thread_mark_switched_in

--- a/arch/xtensa/include/xtensa_asm2.inc.S
+++ b/arch/xtensa/include/xtensa_asm2.inc.S
@@ -17,6 +17,27 @@
  * only by the assembler.
  */
 
+/* Macros to abstract away ABI differences */
+#if __XTENSA_CALL0_ABI__
+#define CALL	call0
+#define CALLX	callx0
+#define ARG1	a2	/* 1st outgoing call argument */
+#define ARG2	a3	/* 2nd outgoing call argument */
+#define ARG3	a4	/* 3rd outgoing call argument */
+#define ARG4	a5	/* 4th outgoing call argument */
+#define ARG5	a6	/* 5th outgoing call argument */
+#define ARG6	a7	/* 6th outgoing call argument */
+#else
+#define CALL	call4
+#define CALLX	callx4
+#define ARG1	a6	/* 1st outgoing call argument */
+#define ARG2	a7	/* 2nd outgoing call argument */
+#define ARG3	a8	/* 3rd outgoing call argument */
+#define ARG4	a9	/* 4th outgoing call argument */
+#define ARG5	a10	/* 5th outgoing call argument */
+#define ARG6	a11	/* 6th outgoing call argument */
+#endif
+
 #if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 .extern _xtensa_hifi_save
 #endif
@@ -73,6 +94,7 @@
  * anyway).
  */
 .macro SPILL_ALL_WINDOWS
+#if !__XTENSA_CALL0_ABI__
 #if XCHAL_NUM_AREGS == 64
 	and a12, a12, a12
 	rotw 3
@@ -94,6 +116,7 @@
 #else
 #error Unrecognized XCHAL_NUM_AREGS
 #endif
+#endif /* __XTENSA_CALL0_ABI__ */
 .endm
 
 #if XCHAL_HAVE_FP && defined(CONFIG_CPU_HAS_FPU) && defined(CONFIG_FPU_SHARING)
@@ -332,6 +355,16 @@ _swap_page_table_\@:
  * the context save handle in A1 as it's first argument.
  */
 .macro CROSS_STACK_CALL
+#if __XTENSA_CALL0_ABI__
+	mov a7, a2
+	mov a2, a3
+	mov a3, a1
+	mov a6, a3
+	/* Recover the interrupted SP from the BSA */
+	l32i a1, a1, 0
+	l32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	addi a1, a1, ___xtensa_irq_bsa_t_SIZEOF
+#else
 	/* Since accessing A4-A11 may trigger window overflows so
 	 * we need to setup A0 and A1 correctly before putting
 	 * the function arguments for the next two callx4 into
@@ -351,31 +384,60 @@ _swap_page_table_\@:
 	rsr.ZSR_EPC a3		/* restore saved "context handle" in A3 */
 	mov a10, a3             /* pass "context handle" in 2nd frame's A2 */
 	mov a11, a2		/* handler in 2nd frame's A3, next frame's A7 */
+#endif
+	CALL _xstack_call0_\@
 
-	call4 _xstack_call0_\@
 	mov a1, a3		/* restore original SP */
+#if !__XTENSA_CALL0_ABI__
 	mov a2, a6		/* copy return value */
+#endif
 	j _xstack_returned_\@
 .align 4
 _xstack_call0_\@:
+#if __XTENSA_CALL0_ABI__
+	mov a4, a1
+	mov a1, a2
+	addi a1, a1, -16
+	s32i a4, a1, 0
+	s32i a0, a1, 12
+	s32i a3, a1, 8
+#ifdef CONFIG_USERSPACE
+	s32i a12, a1, 4
+#endif
+#else
 	/* We want an ENTRY to set a bit in windowstart and do the
 	 * rotation, but we want our own SP.  After that, we are
 	 * running in a valid frame, so re-enable interrupts.
 	 */
 	entry a1, 16
 	mov a1, a2
+#endif
 	rsr.ZSR_EPS a2
 	wsr.ps a2
 
 #ifdef CONFIG_USERSPACE
+#if __XTENSA_CALL0_ABI__
+	mov a12, a6
+#else
 	/* Save "context handle" in A3 as we need it to determine
 	 * if we need to swap page table later.
 	 */
 	mov a3, a6
 #endif
+#endif
 
-	callx4 a7		/* call handler */
+#if __XTENSA_CALL0_ABI__
+	mov a2, a6
+#endif
+	CALLX a7		/* call handler */
+#if !__XTENSA_CALL0_ABI__
 	mov a2, a6		/* copy return value */
+#endif
+#ifdef CONFIG_USERSPACE
+#if __XTENSA_CALL0_ABI__
+	mov a3, a12
+#endif
+#endif
 
 #ifdef CONFIG_USERSPACE
 	rsil a6, XCHAL_NUM_INTLEVELS
@@ -387,29 +449,46 @@ _xstack_call0_\@:
 	 */
 	beq a2, a3, _xstack_skip_table_swap_\@
 
+#if __XTENSA_CALL0_ABI__
+	mov a12, a2	/* Preserve handler return value */
+#endif
+
 	/* Need to switch page tables because the "next" handle
 	 * returned above is not the same handle as we started
 	 * with. This means we are being restored to another
 	 * thread.
 	 */
-	rsr a6, ZSR_CPU
-	l32i a6, a6, ___cpu_t_current_OFFSET
+	rsr ARG1, ZSR_CPU
+	l32i ARG1, ARG1, ___cpu_t_current_OFFSET
 
 #ifdef CONFIG_XTENSA_MMU
 #ifdef CONFIG_XTENSA_MMU_FLUSH_AUTOREFILL_DTLBS_ON_SWAP
-	call4 xtensa_swap_update_page_tables
+	CALL xtensa_swap_update_page_tables
 #else
-	SWAP_PAGE_TABLE a6, a3, a7
+	SWAP_PAGE_TABLE ARG1, a3, a7
 #endif
 #endif
 #ifdef CONFIG_XTENSA_MPU
-	call4 xtensa_mpu_map_write
+	CALL xtensa_mpu_map_write
+#endif
+#if __XTENSA_CALL0_ABI__
+	mov a2, a12	/* Restore handler return value */
 #endif
 
 _xstack_skip_table_swap_\@:
 #endif /* CONFIG_USERSPACE */
 
+#if __XTENSA_CALL0_ABI__
+#ifdef CONFIG_USERSPACE
+	l32i a12, a1, 4
+#endif
+	l32i a3, a1, 8
+	l32i a0, a1, 12
+	l32i a1, a1, 0
+	ret
+#else
 	retw
+#endif
 _xstack_returned_\@:
 .endm
 
@@ -631,7 +710,7 @@ _excint_noflush_\@:
 	mov a1, a2
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
-	call4 z_thread_mark_switched_in
+	CALL z_thread_mark_switched_in
 #endif
 
 _restore_\@:

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -82,6 +82,10 @@ elseif("${ARCH}" STREQUAL "rx")
   include(${CMAKE_CURRENT_LIST_DIR}/target_rx.cmake)
 endif()
 
+if(CONFIG_XTENSA_CALL0_ABI)
+  list(APPEND TOOLCHAIN_C_FLAGS -mabi=call0)
+endif()
+
 if(SYSROOT_DIR)
   # The toolchain has specified a sysroot dir, pass it to the compiler
   list(APPEND TOOLCHAIN_C_FLAGS


### PR DESCRIPTION
These changes extend Zephyr support to Xtensa cores without windowed registers option.

This pull-request includes 2 commits:
- The fist commit is a prerequisite that reworks CROSS_STACK_CALL such that it does not assume Windowed ABI.
- The second commit is the actual changes to support call0 ABI.

Remaining todo:
- Support CONFIG_USERSPACE
