### PR TITLE
manifest: optional: Update CHRE fixing C++17 deprecation warning

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -11,7 +11,7 @@ manifest:
       groups:
         - optional
     - name: chre
-      revision: 3b32c76efee705af146124fb4190f71be5a4e36e
+      revision: c4c2f49fdcaa2fed49eb1db027696a5734a010d2
       path: modules/lib/chre
       remote: upstream
       groups:


### PR DESCRIPTION
Integrate CHRE fix which avoids a warning with newer compilers due to including a deprecated header.

https://github.com/zephyrproject-rtos/chre/pull/10
