### PR TITLE
TI K3 DRAM Springboard for R5F cores

### DIFF
--- a/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
+++ b/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
@@ -17,7 +17,7 @@
 	compatible = "beagle,beaglebone-ai64";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,ipc = &ipc0;

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
@@ -16,7 +16,7 @@
 	compatible = "beagle,beagley-ai";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,ipc = &ipc0;

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
@@ -16,7 +16,7 @@
 	compatible = "beagle,beagley-ai";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,ipc = &ipc0;

--- a/boards/ti/sk_am64/sk_am64_am6442_r5f0_0.dts
+++ b/boards/ti/sk_am64/sk_am64_am6442_r5f0_0.dts
@@ -14,7 +14,7 @@
 	compatible = "ti,am64x_sk_r5f0_0", "ti,am6442";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,ipc = &ipc0;
 		zephyr,ipc_shm = &ddr0;
 	};

--- a/boards/ti/sk_am64/sk_am64_am6442_r5f0_1.dts
+++ b/boards/ti/sk_am64/sk_am64_am6442_r5f0_1.dts
@@ -14,7 +14,7 @@
 	compatible = "ti,am64x_sk_r5f0_1", "ti,am6442";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,ipc = &ipc0;
 		zephyr,ipc_shm = &ddr0;
 	};

--- a/boards/ti/sk_am64/sk_am64_am6442_r5f1_0.dts
+++ b/boards/ti/sk_am64/sk_am64_am6442_r5f1_0.dts
@@ -14,7 +14,7 @@
 	compatible = "ti,am64x_sk_r5f1_0", "ti,am6442";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,ipc = &ipc0;
 		zephyr,ipc_shm = &ddr0;
 	};

--- a/boards/ti/sk_am64/sk_am64_am6442_r5f1_1.dts
+++ b/boards/ti/sk_am64/sk_am64_am6442_r5f1_1.dts
@@ -14,7 +14,7 @@
 	compatible = "ti,am64x_sk_r5f1_1", "ti,am6442";
 
 	chosen {
-		zephyr,sram = &atcm;
+		zephyr,sram = &ddr1;
 		zephyr,ipc = &ipc0;
 		zephyr,ipc_shm = &ddr0;
 	};

--- a/soc/ti/k3/Kconfig
+++ b/soc/ti/k3/Kconfig
@@ -16,4 +16,12 @@ config SOC_PART_NUMBER
 	default "AM6442" if SOC_AM6442_M4 || SOC_AM6442_R5F0_0 || SOC_AM6442_R5F0_1 || SOC_AM6442_R5F1_0 || SOC_AM6442_R5F1_1
 	default "J721e" if SOC_J721E_MAIN_R5F0_0
 
+config SOC_FAMILY_TI_K3_BOOT_SPRINGBOARD
+	def_bool ($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM)) >= 0x80000000)
+	depends on SOC_SERIES_AM64X_R5 || SOC_SERIES_J721E_R5 || SOC_SERIES_J722S_R5
+	help
+	  If Zephyr code area is in DRAM which is MPU protected from execution
+	  by default then this option enables a boot springboard in ATCM to set
+	  executable permissions before jumping to the code area in DRAM
+
 endif # SOC_FAMILY_TI_K3

--- a/soc/ti/k3/common/CMakeLists.txt
+++ b/soc/ti/k3/common/CMakeLists.txt
@@ -22,6 +22,7 @@ elseif(CONFIG_SOC_SERIES_AM62X_M4 OR CONFIG_SOC_SERIES_AM64X_M4)
 elseif(CONFIG_SOC_SERIES_AM64X_R5 OR CONFIG_SOC_SERIES_J721E_R5 OR CONFIG_SOC_SERIES_J722S_R5)
   zephyr_sources(cortex_r/soc.c)
   zephyr_sources_ifdef(CONFIG_ARM_MPU cortex_r/arm_mpu_regions.c)
+  zephyr_sources_ifdef(CONFIG_SOC_FAMILY_TI_K3_BOOT_SPRINGBOARD cortex_r/boot.S)
 
   zephyr_include_directories(cortex_r)
 

--- a/soc/ti/k3/common/cortex_r/boot.S
+++ b/soc/ti/k3/common/cortex_r/boot.S
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024-2026 Texas Instruments Incorporated
+ *	Andrew Davis <afd@ti.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/cortex_a_r/mpu.h>
+
+#define FULL_ACCESS 0x3
+#define FULL_ACCESS_Msk ((FULL_ACCESS << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk)
+
+#define ARM_R5_MPU_REGION_SIZE_2GB (0x1eU)
+#define REGION_SIZE_2G ((ARM_R5_MPU_REGION_SIZE_2GB << MPU_RASR_SIZE_Pos) & MPU_RASR_SIZE_Msk)
+
+_ASM_FILE_PROLOGUE
+
+/**
+ * DRAM is XN by default. Setup a simple MPU region to allow enable
+ * execute before jumping to the real Zephyr start code in DRAM
+ */
+GTEXT(__boot_spring)
+SECTION_SUBSEC_FUNC(boot_section,_start,__boot_spring)
+
+    mov r0, #0 // MPU region 0
+    mcr p15, 0, r0, c6, c2, 0
+
+    mov r0, #0x80000000 // Base of DRAM
+    mcr p15, 0, r0, c6, c1, 0
+
+    mov r0, #MPU_RASR_TEX_Msk
+    orr r0, #FULL_ACCESS_Msk
+    mcr p15, 0, r0, c6, c1, 4
+
+    mov r0, #REGION_SIZE_2G // All of DRAM
+    orr r0, #MPU_RASR_ENABLE_Msk // Enable region
+    mcr p15, 0, r0, c6, c1, 2
+
+    mrc p15, 0, r0, c1, c0, 0 // Read SCTLR
+    orr r0, #(1 << 17) // Background MPU fallback enable
+    orr r0, #SCTLR_MPU_ENABLE // Enable MPU
+    dsb
+    mcr p15, 0, r0, c1, c0, 0 // Write SCTLR
+    isb
+
+    b __start

--- a/soc/ti/k3/common/cortex_r/linker.ld
+++ b/soc/ti/k3/common/cortex_r/linker.ld
@@ -6,6 +6,10 @@
 
 #include <zephyr/arch/arm/cortex_a_r/scripts/linker.ld>
 
+#ifdef CONFIG_SOC_FAMILY_TI_K3_BOOT_SPRINGBOARD
+ENTRY(__boot_spring)
+#endif
+
 SECTIONS
 {
 #ifdef CONFIG_OPENAMP_RSC_TABLE
@@ -13,5 +17,13 @@ SECTIONS
 	{
 		KEEP(*(.resource_table*))
 	} GROUP_LINK_IN(RSC_TABLE)
+#endif
+
+#ifdef CONFIG_SOC_FAMILY_TI_K3_BOOT_SPRINGBOARD
+	SECTION_PROLOGUE(boot_start,, SUBALIGN(4))
+	{
+		KEEP(*(.boot_section._start))
+		KEEP(*(.boot_section*))
+	} GROUP_LINK_IN(ATCM)
 #endif
 }


### PR DESCRIPTION
The R5 cores in K3 platform devices have only a small amount of local
memory. For larger projects much of the code is intended to be placed in
DRAM. But DRAM is XN by default. If Zephyr code area is in DRAM then we
need to setup a simple MPU region to enable execute permissions before
jumping to the real Zephyr start code in DRAM.

If placing Zephyr in DRAM, keep a small stub in ATCM which does this.
This is only active when setting Zephyr to run from DRAM, it can
still be run entirely from ATCM if the application is small enough
to allow for that.

Also update TI boards with R5F and DRAM to run from from this DRAM.

These R5F cores have little local SRAM but these boards have plenty of 
DRAM reserved for these cores. Only the smallest Zephyr applications
run entirely from this SRAM, so set the default as DRAM in DT.