### PR TITLE
Bluetooth: Audio: Make "foreach" functions consistent

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1041,6 +1041,14 @@ Bluetooth Audio
 * ``CONFIG_BT_TBS_SUPPORTED_FEATURES`` has been removed. Applications should use the defined macros
   :c:macro:`BT_TBS_FEATURE_HOLD` and :c:macro:`BT_TBS_FEATURE_JOIN` to set their supported features.
   (:github:`102666`)
+* :c:func:`bt_bap_unicast_server_foreach_ep` and :c:func:`bt_has_preset_foreach` may now return an
+  error if the iteration stopped early, or if provided with invalid parameters. (:github:`105462`)
+* The callbacks for :c:func:`bt_bap_unicast_server_foreach_ep`,
+  :c:func:`bt_bap_unicast_group_foreach_stream`, :c:func:`bt_bap_broadcast_source_foreach_stream`,
+  :c:func:`bt_cap_unicast_group_foreach_stream`, :c:func:`bt_cap_initiator_broadcast_foreach_stream`
+  and :c:func:`bt_has_preset_foreach` now return ``true`` to continue the iteration,
+  and ``false`` to stop the iteration. Any callbacks for these functions need to be updated to
+  reflect the new return types and values. (:github:`105462`)
 
 Bluetooth Mesh
 ==============

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1575,8 +1575,11 @@ int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *c
  *
  * @param ep The structure object with endpoint info.
  * @param user_data Data to pass to the function.
+ *
+ * @retval true Continue iterating.
+ * @retval false Stop iterating.
  */
-typedef void (*bt_bap_ep_func_t)(struct bt_bap_ep *ep, void *user_data);
+typedef bool (*bt_bap_ep_func_t)(struct bt_bap_ep *ep, void *user_data);
 
 /**
  * @brief Iterate through all endpoints of the given connection.
@@ -1584,8 +1587,12 @@ typedef void (*bt_bap_ep_func_t)(struct bt_bap_ep *ep, void *user_data);
  * @param conn Connection object
  * @param func Function to call for each endpoint.
  * @param user_data Data to pass to the callback function.
+ *
+ * @retval 0 Success
+ * @retval -ECANCELED Iteration was stopped by the callback function before complete.
+ * @retval -EINVAL @p conn or @p func were NULL.
  */
-void bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);
+int bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);
 
 /**
  * @brief Initialize and configure a new ASE.
@@ -1755,8 +1762,8 @@ int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group);
  * @param stream     The audio stream
  * @param user_data  User data
  *
- * @retval true Stop iterating.
- * @retval false Continue iterating.
+ * @retval true Continue iterating.
+ * @retval false Stop iterating.
  */
 typedef bool (*bt_bap_unicast_group_foreach_stream_func_t)(struct bt_bap_stream *stream,
 							   void *user_data);
@@ -2498,8 +2505,8 @@ int bt_bap_broadcast_source_get_base(struct bt_bap_broadcast_source *source,
  * @param stream     The audio stream
  * @param user_data  User data
  *
- * @retval true  Stop iterating.
- * @retval false Continue iterating.
+ * @retval true  Continue iterating.
+ * @retval false Stop iterating.
  */
 typedef bool (*bt_bap_broadcast_source_foreach_stream_func_t)(struct bt_bap_stream *stream,
 							      void *user_data);
@@ -2512,7 +2519,7 @@ typedef bool (*bt_bap_broadcast_source_foreach_stream_func_t)(struct bt_bap_stre
  * @param user_data      User specified data that is sent to the callback function
  *
  * @retval 0          Success (even if no streams exists in the broadcast source).
- * @retval -ECANCELED The @p func returned true.
+ * @retval -ECANCELED The @p func returned false and stopped the iteration.
  * @retval -EINVAL    @p source or @p func were NULL.
  */
 int bt_bap_broadcast_source_foreach_stream(struct bt_bap_broadcast_source *source,

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -404,13 +404,13 @@ int bt_cap_unicast_group_add_streams(struct bt_cap_unicast_group *unicast_group,
  */
 int bt_cap_unicast_group_delete(struct bt_cap_unicast_group *unicast_group);
 
-/** Callback function for bt_bap_unicast_group_foreach_stream()
+/** Callback function for bt_cap_unicast_group_foreach_stream()
  *
  * @param stream     The audio stream
  * @param user_data  User data
  *
- * @retval true Stop iterating.
- * @retval false Continue iterating.
+ * @retval true Continue iterating.
+ * @retval false Stop iterating.
  */
 typedef bool (*bt_cap_unicast_group_foreach_stream_func_t)(struct bt_cap_stream *stream,
 							   void *user_data);
@@ -423,7 +423,7 @@ typedef bool (*bt_cap_unicast_group_foreach_stream_func_t)(struct bt_cap_stream 
  * @param user_data      User specified data that is sent to the callback function
  *
  * @retval 0 Success (even if no streams exists in the group).
- * @retval -ECANCELED The @p func returned true.
+ * @retval -ECANCELED The @p func returned false and stopped the iteration.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
 int bt_cap_unicast_group_foreach_stream(struct bt_cap_unicast_group *unicast_group,
@@ -841,8 +841,8 @@ int bt_cap_initiator_broadcast_get_base(struct bt_cap_broadcast_source *broadcas
  * @param stream     The audio stream
  * @param user_data  User data
  *
- * @retval true Stop iterating.
- * @retval false Continue iterating.
+ * @retval true Continue iterating.
+ * @retval false Stop iterating.
  */
 typedef bool (*bt_cap_initiator_broadcast_foreach_stream_func_t)(struct bt_cap_stream *stream,
 								 void *user_data);
@@ -855,7 +855,7 @@ typedef bool (*bt_cap_initiator_broadcast_foreach_stream_func_t)(struct bt_cap_s
  * @param user_data         User specified data that is sent to the callback function.
  *
  * @retval 0          Success (even if no streams exists in the group).
- * @retval -ECANCELED The @p func returned true.
+ * @retval -ECANCELED The @p func returned false and stopped the iteration.
  * @retval -EINVAL    @p broadcast_source or @p func were NULL.
  */
 int bt_cap_initiator_broadcast_foreach_stream(struct bt_cap_broadcast_source *broadcast_source,

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -426,14 +426,6 @@ int bt_has_preset_available(uint8_t index);
  */
 int bt_has_preset_unavailable(uint8_t index);
 
-/** Enum for return values for @ref bt_has_preset_func_t functions */
-enum {
-	/** Stop iterating */
-	BT_HAS_PRESET_ITER_STOP = 0,
-	/** Continue iterating */
-	BT_HAS_PRESET_ITER_CONTINUE,
-};
-
 /**
  * @typedef bt_has_preset_func_t
  * @brief Preset iterator callback.
@@ -443,11 +435,11 @@ enum {
  * @param name Preset name.
  * @param user_data Data given.
  *
- * @return BT_HAS_PRESET_ITER_CONTINUE if should continue to the next preset.
- * @return BT_HAS_PRESET_ITER_STOP to stop.
+ * @retval true Continue iterating.
+ * @retval false Stop iterating.
  */
-typedef uint8_t (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties properties,
-					const char *name, void *user_data);
+typedef bool (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties properties,
+				     const char *name, void *user_data);
 
 /**
  * @brief Preset iterator.
@@ -457,8 +449,12 @@ typedef uint8_t (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties pr
  * @param index Preset index, passing @ref BT_HAS_PRESET_INDEX_NONE skips index matching.
  * @param func Callback function.
  * @param user_data Data to pass to the callback.
+ *
+ * @retval 0 Success
+ * @retval -ECANCELED Iteration was stopped by the callback function before complete.
+ * @retval -EINVAL @p func was NULL.
  */
-void bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_data);
+int bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_data);
 
 /**
  * @brief Set active preset.

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1902,15 +1902,29 @@ static ssize_t ascs_config(struct bt_conn *conn, struct net_buf_simple *buf)
 	return buf->size;
 }
 
-void bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data)
+int bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data)
 {
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+		return -EINVAL;
+	}
+
+	if (func == NULL) {
+		LOG_DBG("func is NULL");
+		return -EINVAL;
+	}
+
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ascs.ase_pool[i];
 
 		if (ase->conn == conn) {
-			func(&ase->ep, user_data);
+			if (!func(&ase->ep, user_data)) {
+				return -ECANCELED;
+			}
 		}
 	}
+
+	return 0;
 }
 
 static void ase_qos(struct bt_ascs_ase *ase, uint8_t cig_id, uint8_t cis_id,

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -360,7 +360,7 @@ int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 int bt_ascs_disable_ase(struct bt_bap_ep *ep);
 int bt_ascs_release_ase(struct bt_bap_ep *ep);
 
-void bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);
+int bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);
 
 int bt_ascs_register(uint8_t snk_cnt, uint8_t src_cnt);
 int bt_ascs_unregister(void);

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -1364,9 +1364,7 @@ int bt_bap_broadcast_source_foreach_stream(struct bt_bap_broadcast_source *sourc
 		struct bt_bap_stream *stream, *next_stream;
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&subgroup->streams, stream, next_stream, _node) {
-			const bool stop = func(stream, user_data);
-
-			if (stop) {
+			if (!func(stream, user_data)) {
 				return -ECANCELED;
 			}
 		}

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3237,9 +3237,7 @@ int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_gro
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_group->streams, stream, next, _node) {
-		const bool stop = func(stream, user_data);
-
-		if (stop) {
+		if (!func(stream, user_data)) {
 			return -ECANCELED;
 		}
 	}

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -217,9 +217,9 @@ int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream 
 	return bt_ascs_config_ase(conn, stream, codec_cfg, qos_pref);
 }
 
-void bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data)
+int bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data)
 {
-	bt_ascs_foreach_ep(conn, func, user_data);
+	return bt_ascs_foreach_ep(conn, func, user_data);
 }
 
 bool bt_bap_unicast_server_has_ep(const struct bt_bap_ep *ep)

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -85,7 +85,7 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 
 	data->streams[data->cnt++] = cap_stream;
 
-	return false;
+	return true;
 }
 
 void bt_cap_handover_complete(struct bt_cap_common_proc *active_proc)
@@ -751,12 +751,12 @@ static bool broadcast_source_foreach_stream_cb(struct bt_cap_stream *cap_stream,
 	if (!bt_cap_initiator_stream_is_in_state(bap_stream, BT_BAP_EP_STATE_STREAMING)) {
 		LOG_DBG("Stream %p is in invalid state %s", cap_stream,
 			bt_bap_ep_state_str(bt_cap_initiator_stream_get_state(bap_stream)));
-		return true;
+		return false;
 	}
 
 	data->streams[data->cnt++] = cap_stream;
 
-	return false;
+	return true;
 }
 
 static bool valid_valid_broadcast_to_unicast_unicast_start_param(

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -565,12 +565,17 @@ static struct has_preset {
 static sys_slist_t preset_list = SYS_SLIST_STATIC_INIT(&preset_list);
 static sys_slist_t preset_free_list = SYS_SLIST_STATIC_INIT(&preset_free_list);
 
-typedef uint8_t (*preset_func_t)(const struct has_preset *preset, void *user_data);
+typedef bool (*preset_func_t)(const struct has_preset *preset, void *user_data);
 
-static void preset_foreach(uint8_t start_index, uint8_t end_index, preset_func_t func,
-			   void *user_data)
+static int preset_foreach(uint8_t start_index, uint8_t end_index, preset_func_t func,
+			  void *user_data)
 {
 	struct has_preset *preset, *tmp;
+
+	if (func == NULL) {
+		LOG_DBG("func is NULL");
+		return -EINVAL;
+	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&preset_list, preset, tmp, node) {
 		if (preset->index < start_index) {
@@ -578,22 +583,24 @@ static void preset_foreach(uint8_t start_index, uint8_t end_index, preset_func_t
 		}
 
 		if (preset->index > end_index) {
-			return;
+			break;
 		}
 
-		if (func(preset, user_data) == BT_HAS_PRESET_ITER_STOP) {
-			return;
+		if (!func(preset, user_data)) {
+			return -ECANCELED;
 		}
 	}
+
+	return 0;
 }
 
-static uint8_t preset_found(const struct has_preset *preset, void *user_data)
+static bool preset_found(const struct has_preset *preset, void *user_data)
 {
 	const struct has_preset **found = user_data;
 
 	*found = preset;
 
-	return BT_HAS_PRESET_ITER_STOP;
+	return false;
 }
 
 static void preset_insert(struct has_preset *preset)
@@ -986,8 +993,9 @@ static int read_preset_response(struct has_client *client)
 
 	__ASSERT_NO_MSG(client != NULL);
 
-	preset_foreach(client->read_presets_req.start_index, BT_HAS_PRESET_INDEX_LAST,
-		       preset_found, &preset);
+	err = preset_foreach(client->read_presets_req.start_index, BT_HAS_PRESET_INDEX_LAST,
+			     preset_found, &preset);
+	__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 	if (unlikely(preset == NULL)) {
 		return bt_has_cp_read_preset_rsp(client, NULL, BT_HAS_IS_LAST);
@@ -996,7 +1004,9 @@ static int read_preset_response(struct has_client *client)
 	if (client->read_presets_req.num_presets > 1) {
 		const struct has_preset *next = NULL;
 
-		preset_foreach(preset->index + 1, BT_HAS_PRESET_INDEX_LAST, preset_found, &next);
+		err = preset_foreach(preset->index + 1, BT_HAS_PRESET_INDEX_LAST, preset_found,
+				     &next);
+		__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 		is_last = next == NULL;
 	}
@@ -1105,14 +1115,16 @@ static int preset_list_changed(struct has_client *client)
 		return 0;
 	}
 
-	preset_foreach(client->preset_changed_index_next, BT_HAS_PRESET_INDEX_LAST,
-		       preset_found, &preset);
+	err = preset_foreach(client->preset_changed_index_next, BT_HAS_PRESET_INDEX_LAST,
+			     preset_found, &preset);
+	__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 	if (preset == NULL) {
 		return 0;
 	}
 
-	preset_foreach(preset->index + 1, BT_HAS_PRESET_INDEX_LAST, preset_found, &next);
+	err = preset_foreach(preset->index + 1, BT_HAS_PRESET_INDEX_LAST, preset_found, &next);
+	__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 	/* It is last Preset Changed notification if there are no presets left to notify and the
 	 * currently notified preset have the highest index known to the client.
@@ -1162,6 +1174,7 @@ static uint8_t handle_read_preset_req(struct bt_conn *conn, struct net_buf_simpl
 	const struct bt_has_cp_read_presets_req *req;
 	const struct has_preset *preset = NULL;
 	struct has_client *client;
+	__maybe_unused int err;
 
 	if (buf->len < sizeof(*req)) {
 		return BT_HAS_ERR_INVALID_PARAM_LEN;
@@ -1185,7 +1198,8 @@ static uint8_t handle_read_preset_req(struct bt_conn *conn, struct net_buf_simpl
 	LOG_DBG("start_index %d num_presets %d", req->start_index, req->num_presets);
 
 	/* Abort if there is no preset in requested index range */
-	preset_foreach(req->start_index, BT_HAS_PRESET_INDEX_LAST, preset_found, &preset);
+	err = preset_foreach(req->start_index, BT_HAS_PRESET_INDEX_LAST, preset_found, &preset);
+	__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 	if (preset == NULL) {
 		return BT_ATT_ERR_OUT_OF_RANGE;
@@ -1208,6 +1222,7 @@ static uint8_t handle_read_preset_req(struct bt_conn *conn, struct net_buf_simpl
 static int set_preset_name(uint8_t index, const char *name, size_t len)
 {
 	struct has_preset *preset = NULL;
+	__maybe_unused int err;
 
 	LOG_DBG("index %d name_len %zu", index, len);
 
@@ -1216,7 +1231,8 @@ static int set_preset_name(uint8_t index, const char *name, size_t len)
 	}
 
 	/* Abort if there is no preset in requested index range */
-	preset_foreach(index, BT_HAS_PRESET_INDEX_LAST, preset_found, &preset);
+	err = preset_foreach(index, BT_HAS_PRESET_INDEX_LAST, preset_found, &preset);
+	__ASSERT(err != -EINVAL, "preset_foreach returned %d", err);
 
 	if (preset == NULL) {
 		return -ENOENT;
@@ -1623,20 +1639,25 @@ struct bt_has_preset_foreach_data {
 	void *user_data;
 };
 
-static uint8_t bt_has_preset_foreach_func(const struct has_preset *preset, void *user_data)
+static bool bt_has_preset_foreach_func(const struct has_preset *preset, void *user_data)
 {
 	const struct bt_has_preset_foreach_data *data = user_data;
 
 	return data->func(preset->index, preset->properties, preset->name, data->user_data);
 }
 
-void bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_data)
+int bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_data)
 {
 	uint8_t start_index, end_index;
 	struct bt_has_preset_foreach_data data = {
 		.func = func,
 		.user_data = user_data,
 	};
+
+	if (func == NULL) {
+		LOG_DBG("func is NULL");
+		return -EINVAL;
+	}
 
 	if (index == BT_HAS_PRESET_INDEX_NONE) {
 		start_index = BT_HAS_PRESET_INDEX_FIRST;
@@ -1645,7 +1666,7 @@ void bt_has_preset_foreach(uint8_t index, bt_has_preset_func_t func, void *user_
 		start_index = end_index = index;
 	}
 
-	preset_foreach(start_index, end_index, bt_has_preset_foreach_func, &data);
+	return preset_foreach(start_index, end_index, bt_has_preset_foreach_func, &data);
 }
 
 int bt_has_preset_active_set(uint8_t index)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -50,6 +50,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"
 #include "host/shell/bt.h"
@@ -4155,7 +4156,7 @@ static int cmd_bap_stats(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)
-static void print_ase_info(struct bt_bap_ep *ep, void *user_data)
+static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 {
 	struct bt_bap_ep_info info;
 	int err;
@@ -4164,16 +4165,21 @@ static void print_ase_info(struct bt_bap_ep *ep, void *user_data)
 	if (err == 0) {
 		printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
 	}
+
+	return true;
 }
 
 static int cmd_print_ase_info(const struct shell *sh, size_t argc, char *argv[])
 {
+	__maybe_unused int err;
+
 	if (!default_conn) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	bt_bap_unicast_server_foreach_ep(default_conn, print_ase_info, NULL);
+	err = bt_bap_unicast_server_foreach_ep(default_conn, print_ase_info, NULL);
+	__ASSERT(err == 0, "bt_bap_unicast_server_foreach_ep returned %d", err);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/shell/has.c
+++ b/subsys/bluetooth/audio/shell/has.c
@@ -19,6 +19,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"
 
@@ -159,15 +161,15 @@ struct print_list_entry_data {
 	const struct shell *sh;
 };
 
-static uint8_t print_list_entry(uint8_t index, enum bt_has_properties properties,
-				const char *name, void *user_data)
+static bool print_list_entry(uint8_t index, enum bt_has_properties properties, const char *name,
+			     void *user_data)
 {
 	struct print_list_entry_data *data = user_data;
 
 	shell_print(data->sh, "%d: index 0x%02x prop 0x%02x name %s", ++data->num, index,
 		    properties, name);
 
-	return BT_HAS_PRESET_ITER_CONTINUE;
+	return true;
 }
 
 static int cmd_preset_list(const struct shell *sh, size_t argc, char **argv)
@@ -175,8 +177,10 @@ static int cmd_preset_list(const struct shell *sh, size_t argc, char **argv)
 	struct print_list_entry_data data = {
 		.sh = sh,
 	};
+	__maybe_unused int err;
 
-	bt_has_preset_foreach(0, print_list_entry, &data);
+	err = bt_has_preset_foreach(0, print_list_entry, &data);
+	__ASSERT(err == 0, "bt_has_preset_foreach returned %d", err);
 
 	if (data.num == 0) {
 		shell_print(sh, "No presets registered");

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -1411,7 +1411,7 @@ static bool bap_broadcast_source_foreach_stream_cb(struct bt_bap_stream *stream,
 
 	(*cnt)++;
 
-	return false;
+	return true;
 }
 
 static ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_foreach_stream)
@@ -1436,7 +1436,7 @@ static bool bap_broadcast_source_foreach_stream_return_early_cb(struct bt_bap_st
 
 	(*cnt)++;
 
-	return true;
+	return false;
 }
 
 static ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_foreach_stream_return_early)

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -337,7 +337,7 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 
 	(*cnt)++;
 
-	return false;
+	return true;
 }
 
 static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_foreach_stream)
@@ -373,7 +373,7 @@ static bool unicast_group_foreach_stream_return_early_cb(struct bt_cap_stream *s
 
 	(*cnt)++;
 
-	return true;
+	return false;
 }
 
 static ZTEST_F(cap_initiator_test_unicast_group,

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -744,9 +744,7 @@ int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_gro
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_group->streams, stream, next, _node) {
-		const bool stop = func(stream, user_data);
-
-		if (stop) {
+		if (!func(stream, user_data)) {
 			return -ECANCELED;
 		}
 	}

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -74,12 +74,14 @@ static struct bt_le_ext_adv *ext_adv;
 
 CREATE_FLAG(flag_stream_configured);
 CREATE_FLAG(flag_stream_started);
-static void print_ase_info(struct bt_bap_ep *ep, void *user_data)
+static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 {
 	struct bt_bap_ep_info info;
 
 	bt_bap_ep_get_info(ep, &info);
 	printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
+
+	return true;
 }
 
 static struct bt_bap_stream *stream_alloc(void)
@@ -99,6 +101,8 @@ static int lc3_config(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_
 		      const struct bt_audio_codec_cfg *codec_cfg, struct bt_bap_stream **stream,
 		      struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	int err;
+
 	printk("ASE Codec Config: conn %p ep %p dir %u\n", conn, ep, dir);
 
 	print_codec_cfg(codec_cfg);
@@ -112,7 +116,10 @@ static int lc3_config(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_
 
 	printk("ASE Codec Config stream %p\n", *stream);
 
-	bt_bap_unicast_server_foreach_ep(conn, print_ase_info, NULL);
+	err = bt_bap_unicast_server_foreach_ep(conn, print_ase_info, NULL);
+	if (err != 0) {
+		FAIL("bt_bap_unicast_server_foreach_ep returned %d", err);
+	}
 
 	*pref = qos_pref;
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -657,36 +657,36 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 	err = bt_bap_ep_get_info(cap_stream->bap_stream.ep, &ep_info);
 	if (err != 0) {
 		FAIL("Failed to get EP info: %d\n", err);
-		return true;
+		return false;
 	}
 
 	err = bt_cap_unicast_group_get_info(unicast_group, &cap_info);
 	if (err != 0) {
 		FAIL("Failed to get CAP unicast group info: %d\n", err);
-		return true;
+		return false;
 	}
 
 	err = bt_bap_unicast_group_get_info(cap_info.unicast_group, &bap_info);
 	if (err != 0) {
 		FAIL("Failed to get BAP unicast group info: %d\n", err);
-		return true;
+		return false;
 	}
 
 	if (ep_info.dir == BT_AUDIO_DIR_SINK) {
 		if (bap_info.sink_pd != expected_pd) {
 			FAIL("Unexpected sink PD %u (expected %u)\n", bap_info.sink_pd,
 			     expected_pd);
-			return true;
+			return false;
 		}
 	} else {
 		if (bap_info.source_pd != expected_pd) {
 			FAIL("Unexpected source PD %u (expected %u)\n", bap_info.source_pd,
 			     expected_pd);
-			return true;
+			return false;
 		}
 	}
 
-	return false;
+	return true;
 }
 
 static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool wait)


### PR DESCRIPTION
Modify foreach functions in LE Audio to follow the same pattern: Return true to continue iterating.
Return false to stop iterating.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/96839