### PR TITLE
shell: add missing dependency for KERNEL_THREAD_SHELL_UNWIND

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/Kconfig
+++ b/subsys/shell/modules/kernel_service/thread/Kconfig
@@ -50,6 +50,7 @@ config KERNEL_THREAD_SHELL_UNWIND
 	bool
 	default y
 	depends on ARCH_STACKWALK
+	depends on THREAD_MONITOR
 	select KERNEL_THREAD_SHELL
 	help
 	  Internal helper macro to compile the `unwind` subcommand


### PR DESCRIPTION
The option needs a dependency to THREAD_MONITOR, fix a build breakage with, for example:

west build -p -b nrf52dk/nrf52832 samples/subsys/shell/shell_module -- -DCONFIG_EXTRA_EXCEPTION_INFO=y -DCONFIG_THREAD_MONITOR=n