### PR TITLE
drivers: can: infineon: Adding CAN driver and support for Infineon devices

### DIFF
--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-pinctrl.dtsi
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk-pinctrl.dtsi
@@ -19,3 +19,12 @@
 &p6_0_scb3_uart_cts {
 	input-enable;
 };
+
+/* Configure pin drive mode for can pins */
+&p5_2_can1_rx {
+	input-enable;
+};
+
+&p5_3_can1_tx {
+	drive-push-pull;
+};

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
@@ -23,6 +23,7 @@
 		zephyr,flash = &slot0_partition;
 		zephyr,console = &uart3;
 		zephyr,shell-uart = &uart3;
+		zephyr,canbus = &can1;
 	};
 };
 
@@ -39,7 +40,23 @@ uart3: &scb3 {
 
 &peri0_group4_8bit_0 {
 	status = "okay";
-	clock-div = <109>;
+	clock-div = <86>;
+};
+
+&peri0_group4_16_5bit_0 {
+	status = "okay";
+	clock-div = <1>;
+};
+
+&canfd0 {
+	status = "okay";
+};
+
+&can1 {
+	status = "okay";
+	clocks = <&peri0_group4_16_5bit_0>;
+	pinctrl-0 = <&p5_2_can1_rx &p5_3_can1_tx>;
+	pinctrl-names = "default";
 };
 
 &watchdog0 {
@@ -120,8 +137,15 @@ uart3: &scb3 {
 	status = "okay";
 };
 
+/*
+ * CLK_HF2 feeds peri group 4 (UART, CAN, SPI, counter).
+ * Source from dpll_lp1 (CLKPATH2, 240 MHz) / 3 = 80 MHz
+ * for CiA 601-3 compliant CAN FD bit rates.
+ * The UART driver dynamically recalculates its peri divider.
+ */
 &clk_hf2 {
-	source-path = <IFX_CLK_HF_IN_CLKPATH0>;
+	source-path = <IFX_CLK_HF_IN_CLKPATH2>;
+	clock-div = <IFX_CLK_HF_DIVIDE_BY_3>;
 	status = "okay";
 };
 

--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
@@ -13,6 +13,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - can
   - gpio
   - spi
   - timer

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -15,6 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE can_handlers.c)
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CAN_ESP32_TWAI can_esp32_twai.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_FAKE can_fake.c)
+zephyr_library_sources_ifdef(CONFIG_CAN_INFINEON_MCAN can_infineon.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_KVASER_PCI can_kvaser_pci.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_LOOPBACK can_loopback.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_MAX32 can_max32.c)

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -123,6 +123,7 @@ source "drivers/can/transceiver/Kconfig"
 # zephyr-keep-sorted-start
 source "drivers/can/Kconfig.esp32"
 source "drivers/can/Kconfig.fake"
+source "drivers/can/Kconfig.infineon"
 source "drivers/can/Kconfig.kvaser"
 source "drivers/can/Kconfig.loopback"
 source "drivers/can/Kconfig.max32"

--- a/drivers/can/Kconfig.infineon
+++ b/drivers/can/Kconfig.infineon
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Linumiz
+# SPDX-License-Identifier: Apache-2.0
+
+config CAN_INFINEON_MCAN
+	bool "Infineon MCAN driver"
+	default y
+	depends on DT_HAS_INFINEON_CAN_ENABLED
+	depends on CLOCK_CONTROL
+	select CAN_MCAN
+	select PINCTRL
+	help
+	  Enable support for Infineon CAN driver.

--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Linumiz
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/can.h>
+#include <zephyr/drivers/can/can_mcan.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
+
+#include <infineon_kconfig.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+
+#include <cy_canfd.h>
+
+LOG_MODULE_REGISTER(can_infineon, CONFIG_CAN_LOG_LEVEL);
+
+#define DT_DRV_COMPAT infineon_can
+
+struct can_infineon_data {
+	struct ifx_cat1_clock clock;
+};
+
+struct can_infineon_config {
+	mm_reg_t base;
+	mem_addr_t mrba;
+	mem_addr_t mram;
+	void (*config_irq)(void);
+	const struct pinctrl_dev_config *pcfg;
+	const struct device *ctrl_dev;
+	en_clk_dst_t clk_dst;
+};
+
+/*
+ * Wrapper config — defined here (before DT_DRV_COMPAT switch) so the
+ * channel driver can access the parent wrapper's config.
+ */
+struct canfd_ifx_ctrl_config {
+	CANFD_Type *base;
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	bool timestamp_counter;
+#endif /* CONFIG_CAN_RX_TIMESTAMP */
+	bool ecc_enabled;
+};
+
+static int can_infineon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+
+	return can_mcan_sys_read_reg(infineon_cfg->base, reg, val);
+}
+
+static int can_infineon_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+
+	return can_mcan_sys_write_reg(infineon_cfg->base, reg, val);
+}
+
+static int can_infineon_read_mram(const struct device *dev, uint16_t offset, void *dst, size_t len)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+
+	return can_mcan_sys_read_mram(infineon_cfg->mram, offset, dst, len);
+}
+
+static int can_infineon_write_mram(const struct device *dev, uint16_t offset, const void *src,
+				   size_t len)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+
+	return can_mcan_sys_write_mram(infineon_cfg->mram, offset, src, len);
+}
+
+static int can_infineon_clear_mram(const struct device *dev, uint16_t offset, size_t len)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+
+	return can_mcan_sys_clear_mram(infineon_cfg->mram, offset, len);
+}
+
+static int can_infineon_get_core_clock(const struct device *dev, uint32_t *rate)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_infineon_data *data = mcan_data->custom;
+
+	*rate = ifx_cat1_utils_peri_pclk_get_frequency(infineon_cfg->clk_dst, &data->clock);
+
+	return 0;
+}
+
+static int can_infineon_init(const struct device *dev)
+{
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_infineon_data *data = mcan_data->custom;
+	cy_rslt_t result;
+	int ret;
+
+	/* Ensure the parent controller (MRAM + channel clocks) is ready */
+	if (!device_is_ready(infineon_cfg->ctrl_dev)) {
+		LOG_ERR("CAN FD controller device not ready");
+		return -ENODEV;
+	}
+
+	/* Configure dt provided device signals when available */
+	ret = pinctrl_apply_state(infineon_cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret != 0) {
+		LOG_ERR("CAN pinctrl setup failed (%d)", ret);
+		return ret;
+	}
+
+	/* Connect this CAN instance to the peripheral clock divider */
+	result = ifx_cat1_utils_peri_pclk_assign_divider(infineon_cfg->clk_dst, &data->clock);
+	if (result != CY_RSLT_SUCCESS) {
+		LOG_ERR("CAN clock assign failed (%d)", (int)result);
+		return -EIO;
+	}
+
+	ret = can_mcan_configure_mram(dev, infineon_cfg->mrba, infineon_cfg->mram);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = can_mcan_init(dev);
+	if (ret != 0) {
+		LOG_ERR("can_mcan_init failed (%d)", ret);
+		return ret;
+	}
+
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	/*
+	 * If the parent controller has the shared timestamp counter enabled,
+	 * select the external timestamp source (TSS = 2) in the M_CAN core.
+	 * This must be done after can_mcan_init() which sets TSS = 1.
+	 */
+	const struct canfd_ifx_ctrl_config *ctrl_cfg = infineon_cfg->ctrl_dev->config;
+
+	if (ctrl_cfg->timestamp_counter) {
+		ret = can_mcan_write_reg(dev, CAN_MCAN_TSCC, FIELD_PREP(CAN_MCAN_TSCC_TSS, 2U));
+		if (ret != 0) {
+			return ret;
+		}
+	}
+#endif /* CONFIG_CAN_RX_TIMESTAMP */
+
+	if (infineon_cfg->config_irq != NULL) {
+		infineon_cfg->config_irq();
+	}
+
+	return 0;
+}
+
+static DEVICE_API(can, can_infineon_driver_api) = {
+	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
+	.set_mode = can_mcan_set_mode,
+	.set_timing = can_mcan_set_timing,
+	.send = can_mcan_send,
+	.add_rx_filter = can_mcan_add_rx_filter,
+	.remove_rx_filter = can_mcan_remove_rx_filter,
+	.get_state = can_mcan_get_state,
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
+	.recover = can_mcan_recover,
+#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE*/
+	.get_core_clock = can_infineon_get_core_clock,
+	.get_max_filters = can_mcan_get_max_filters,
+	.set_state_change_callback = can_mcan_set_state_change_callback,
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
+#ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
+#endif
+};
+
+static const struct can_mcan_ops can_infineon_ops = {
+	.read_reg = can_infineon_read_reg,
+	.write_reg = can_infineon_write_reg,
+	.read_mram = can_infineon_read_mram,
+	.write_mram = can_infineon_write_mram,
+	.clear_mram = can_infineon_clear_mram,
+};
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#define CAN_PERI_CLOCK_INIT(n)                                                                     \
+	.clock = {                                                                                 \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
+			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
+		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
+	},
+#else
+#define CAN_PERI_CLOCK_INIT(n)                                                                     \
+	.clock = {                                                                                 \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
+			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
+		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
+	},
+#endif
+
+#define CAN_INFINEON_MCAN_INIT(n)                                                                  \
+	CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(n);                                                 \
+	BUILD_ASSERT(CAN_MCAN_DT_INST_MRAM_ELEMENTS_SIZE(n) <= CAN_MCAN_DT_INST_MRAM_SIZE(n),      \
+		     "Insufficient Message RAM size to hold elements");                            \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	CAN_MCAN_DT_INST_CALLBACKS_DEFINE(n, can_infineon_cbs_##n);                                \
+                                                                                                   \
+	static void infineon_mcan_irq_config_##n(void)                                             \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int0, irq),                                     \
+			    DT_INST_IRQ_BY_NAME(n, int0, priority), can_mcan_line_0_isr,           \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int0, irq));                                     \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int1, irq),                                     \
+			    DT_INST_IRQ_BY_NAME(n, int1, priority), can_mcan_line_1_isr,           \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int1, irq));                                     \
+	}                                                                                          \
+                                                                                                   \
+	static struct can_infineon_data can_infineon_data_##n = {CAN_PERI_CLOCK_INIT(n)};          \
+                                                                                                   \
+	static const struct can_infineon_config can_infineon_cfg_##n = {                           \
+		.base = CAN_MCAN_DT_INST_MCAN_ADDR(n),                                             \
+		.mrba = CAN_MCAN_DT_INST_MRBA(n),                                                  \
+		.mram = CAN_MCAN_DT_INST_MRAM_ADDR(n),                                             \
+		.config_irq = infineon_mcan_irq_config_##n,                                        \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.ctrl_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                                      \
+		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
+	};                                                                                         \
+                                                                                                   \
+	static const struct can_mcan_config can_mcan_cfg_##n = CAN_MCAN_DT_CONFIG_INST_GET(        \
+		n, &can_infineon_cfg_##n, &can_infineon_ops, &can_infineon_cbs_##n);               \
+                                                                                                   \
+	static struct can_mcan_data can_mcan_data_##n =                                            \
+		CAN_MCAN_DATA_INITIALIZER(&can_infineon_data_##n);                                 \
+                                                                                                   \
+	CAN_DEVICE_DT_INST_DEFINE(n, can_infineon_init, NULL, &can_mcan_data_##n,                  \
+				  &can_mcan_cfg_##n, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,        \
+				  &can_infineon_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(CAN_INFINEON_MCAN_INIT);
+
+/*
+ * Infineon CAN FD controller wrapper.
+ *
+ * The Infineon CAN implementation wraps the individual BOSCH M_CAN channels in a higher
+ * level block.  The wrapper manages powering on the shared Message RAM and configures
+ * other optional features, such as timestamp-counter and ECC.
+ */
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT infineon_canfd_controller
+
+static int canfd_ifx_ctrl_init(const struct device *dev)
+{
+	const struct canfd_ifx_ctrl_config *cfg = dev->config;
+	uint32_t ctl;
+
+	/* Power on MRAM (clear CTL.MRAM_OFF) */
+	ctl = cfg->base->CTL;
+	ctl &= ~CANFD_CTL_MRAM_OFF_Msk;
+	cfg->base->CTL = ctl;
+
+	/*
+	 * Wait for MRAM power-up.  The PDL recommends 150 CPU cycles
+	 * (6 us at 25 MHz).  Using 10 us to be safe.
+	 */
+	k_busy_wait(10U);
+
+#ifdef CONFIG_CAN_RX_TIMESTAMP
+	/* Enable the shared timestamp counter if configured */
+	if (cfg->timestamp_counter) {
+		cfg->base->TS_CTL = CANFD_TS_CTL_ENABLED_Msk;
+	}
+#endif /* CONFIG_CAN_RX_TIMESTAMP */
+
+	/* Enable ECC if configured */
+	if (cfg->ecc_enabled) {
+		cfg->base->ECC_CTL = CANFD_ECC_CTL_ECC_EN_Msk;
+	}
+
+	return 0;
+}
+
+#define CANFD_IFX_CTRL_INIT(n)                                                                     \
+	static const struct canfd_ifx_ctrl_config canfd_ifx_ctrl_cfg_##n = {                       \
+		.base = (CANFD_Type *)DT_INST_REG_ADDR_BY_NAME(n, wrapper),                        \
+		.ecc_enabled = DT_INST_PROP(n, ecc_enabled),                                       \
+		IF_ENABLED(CONFIG_CAN_RX_TIMESTAMP,                                                \
+			   (.timestamp_counter = DT_INST_PROP(n, shared_timestamp_counter),)) };   \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, canfd_ifx_ctrl_init, NULL, NULL, &canfd_ifx_ctrl_cfg_##n,         \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(CANFD_IFX_CTRL_INIT)

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -210,64 +210,6 @@ static inline uint32_t ifx_uart_mem_width(uint32_t data_width)
 #endif
 }
 
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define IFX_CAT1_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
-#endif
-
-#if !defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-static uint8_t ifx_cat1_get_hfclk_for_peri_group(uint8_t peri_group)
-{
-#if defined(CONFIG_SOC_SERIES_PSE84)
-	switch (peri_group) {
-	case IFX_CAT1_INSTANCE_GROUP(0, 0):
-	case IFX_CAT1_INSTANCE_GROUP(1, 4):
-		return 0;
-	case IFX_CAT1_INSTANCE_GROUP(0, 7):
-	case IFX_CAT1_INSTANCE_GROUP(1, 0):
-		return 1;
-	case IFX_CAT1_INSTANCE_GROUP(0, 3):
-	case IFX_CAT1_INSTANCE_GROUP(1, 2):
-		return 5;
-	case IFX_CAT1_INSTANCE_GROUP(0, 4):
-	case IFX_CAT1_INSTANCE_GROUP(1, 3):
-		return 6;
-	case IFX_CAT1_INSTANCE_GROUP(1, 1):
-		return 7;
-	case IFX_CAT1_INSTANCE_GROUP(0, 2):
-		return 9;
-	case IFX_CAT1_INSTANCE_GROUP(0, 1):
-	case IFX_CAT1_INSTANCE_GROUP(0, 5):
-		return 10;
-	case IFX_CAT1_INSTANCE_GROUP(0, 8):
-		return 11;
-	case IFX_CAT1_INSTANCE_GROUP(0, 6):
-	case IFX_CAT1_INSTANCE_GROUP(0, 9):
-		return 13;
-	default:
-		break;
-	}
-#elif defined(CONFIG_SOC_SERIES_PSC3)
-	switch (peri_group) {
-	case 0:
-	case 2:
-		return 0;
-	case 1:
-	case 3:
-		return 1;
-	case 4:
-		return 2;
-	case 5:
-		return 3;
-	case 6:
-		return 4;
-	default:
-		break;
-	}
-#endif
-	return -EINVAL;
-}
-#endif
-
 cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 {
 	cy_rslt_t status;
@@ -290,7 +232,7 @@ cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 	peri_frequency = Cy_SysClk_ClkPeriGetFrequency();
 #elif defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) ||                                      \
 	defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-	uint8_t hfclk = ifx_cat1_get_hfclk_for_peri_group(data->clock_peri_group);
+	uint8_t hfclk = ifx_cat1_utils_peri_pclk_get_hfclk(data->clock_peri_group);
 
 	peri_frequency = Cy_SysClk_ClkHfGetFrequency(hfclk);
 #else

--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -941,64 +941,6 @@ void ifx_cat1_spi_register_callback(const struct device *dev,
 	data->irq_cause = 0;
 }
 
-#if !defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-#define IFX_CAT1_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
-#endif
-
-static uint8_t ifx_cat1_get_hfclk_for_peri_group(uint8_t peri_group)
-{
-#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-	switch (peri_group) {
-	case IFX_CAT1_INSTANCE_GROUP(0, 0):
-	case IFX_CAT1_INSTANCE_GROUP(1, 4):
-		return CLK_HF0;
-	case IFX_CAT1_INSTANCE_GROUP(0, 7):
-	case IFX_CAT1_INSTANCE_GROUP(1, 0):
-		return CLK_HF1;
-	case IFX_CAT1_INSTANCE_GROUP(0, 3):
-	case IFX_CAT1_INSTANCE_GROUP(1, 2):
-		return CLK_HF5;
-	case IFX_CAT1_INSTANCE_GROUP(0, 4):
-	case IFX_CAT1_INSTANCE_GROUP(1, 3):
-		return CLK_HF6;
-	case IFX_CAT1_INSTANCE_GROUP(1, 1):
-		return CLK_HF7;
-	case IFX_CAT1_INSTANCE_GROUP(0, 2):
-		return CLK_HF9;
-	case IFX_CAT1_INSTANCE_GROUP(0, 1):
-	case IFX_CAT1_INSTANCE_GROUP(0, 5):
-		return CLK_HF10;
-	case IFX_CAT1_INSTANCE_GROUP(0, 8):
-		return CLK_HF11;
-	case IFX_CAT1_INSTANCE_GROUP(0, 6):
-	case IFX_CAT1_INSTANCE_GROUP(0, 9):
-		return CLK_HF13;
-	default:
-		return -EINVAL;
-	}
-#elif defined(CONFIG_SOC_FAMILY_INFINEON_CAT1B)
-	switch (peri_group) {
-	case 0:
-	case 2:
-		return CLK_HF0;
-	case 1:
-	case 3:
-		return CLK_HF1;
-	case 4:
-		return CLK_HF2;
-	case 5:
-		return CLK_HF3;
-	case 6:
-		return CLK_HF4;
-	default:
-		return -EINVAL;
-	}
-#endif
-	return -EINVAL;
-}
-#endif
-
 static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t hz,
 					    uint8_t *over_sample_val)
 {
@@ -1020,7 +962,7 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 	uint32_t peri_freq = Cy_SysClk_ClkPeriGetFrequency();
 #elif defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) ||                                      \
 	defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-	uint8_t hfclk = ifx_cat1_get_hfclk_for_peri_group(data->clock_peri_group);
+	uint8_t hfclk = ifx_cat1_utils_peri_pclk_get_hfclk(data->clock_peri_group);
 
 	uint32_t peri_freq = Cy_SysClk_ClkHfGetFrequency(hfclk);
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.48-qfn.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.48-qfn.dtsi
@@ -288,6 +288,24 @@
 				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_6)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p3_2_can0_rx: p3_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_0_can0_rx: p5_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_12)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p3_3_can0_tx: p3_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_1_can0_tx: p5_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_12)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p0_1_pwm0_1: p0_1_pwm0_1 {
 				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_0)>;

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.56-qfn.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.56-qfn.dtsi
@@ -296,6 +296,24 @@
 				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_6)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p3_2_can0_rx: p3_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_0_can0_rx: p5_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_12)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p3_3_can0_tx: p3_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_1_can0_tx: p5_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_12)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p0_1_pwm0_1: p0_1_pwm0_1 {
 				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_0)>;

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.64-bga.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.64-bga.dtsi
@@ -296,6 +296,24 @@
 				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_6)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p3_2_can0_rx: p3_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_0_can0_rx: p5_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_12)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p3_3_can0_tx: p3_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_1_can0_tx: p5_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_12)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p0_1_pwm0_1: p0_1_pwm0_1 {
 				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_0)>;

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.77-bga.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.77-bga.dtsi
@@ -296,6 +296,24 @@
 				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_6)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p3_2_can0_rx: p3_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_0_can0_rx: p5_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_12)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p3_3_can0_tx: p3_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_12)>;
+			};
+
+			/omit-if-no-ref/ p5_1_can0_tx: p5_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_12)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p0_1_pwm0_1: p0_1_pwm0_1 {
 				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_0)>;

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -126,6 +126,27 @@
 			status = "disabled";
 		};
 
+		canfd0: canfd@40440000 {
+			compatible = "infineon,canfd-controller";
+			reg = <0x40440000 0x1088>, <0x40450000 0x1000>;
+			reg-names = "wrapper", "mram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			can0: can@40440000 {
+				compatible = "infineon,can";
+				reg = <0x40440000 0x200>, <0x40450000 0x1000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x10e>;
+				status = "disabled";
+				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				interrupts = <64 4>, <65 4>;
+				interrupt-names = "int0", "int1";
+			};
+		};
+
 		watchdog0: watchdog@4020c000 {
 			compatible = "infineon,watchdog";
 			reg = <0x4020c000 0x10>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.dtsi
@@ -220,6 +220,38 @@
 			status = "disabled";
 		};
 
+		canfd0: canfd@42800000 {
+			compatible = "infineon,canfd-controller";
+			reg = <0x42800000 0x1088>, <0x42810000 0x1000>;
+			reg-names = "wrapper", "mram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			can0: can@42800000 {
+				compatible = "infineon,can";
+				reg = <0x42800000 0x200>, <0x42810000 0x800>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x405>;
+				status = "disabled";
+				bosch,mram-cfg = <0x0 15 15 8 8 0 8 8>;
+				interrupts = <99 4>, <100 4>;
+				interrupt-names = "int0", "int1";
+			};
+
+			can1: can@42800200 {
+				compatible = "infineon,can";
+				reg = <0x42800200 0x200>, <0x42810000 0x1000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x406>;
+				status = "disabled";
+				bosch,mram-cfg = <0x800 15 15 8 8 0 8 8>;
+				interrupts = <101 4>, <102 4>;
+				interrupt-names = "int0", "int1";
+			};
+		};
+
 		tcpwm0: tcpwm0@42a00000 {
 			reg = <0x42a00000 0x10000>;
 			#address-cells = <1>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-64.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-64.dtsi
@@ -491,6 +491,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-64_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-64_s.dtsi
@@ -491,6 +491,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-80.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-80.dtsi
@@ -583,6 +583,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-80_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.e-lqfp-80_s.dtsi
@@ -583,6 +583,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.vqfn-64.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.vqfn-64.dtsi
@@ -491,6 +491,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3.vqfn-64_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.vqfn-64_s.dtsi
@@ -491,6 +491,40 @@
 				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_DS_2)>;
 			};
 
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p5_2_can1_rx: p5_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_2_can1_rx: p6_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_2_can0_rx: p8_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_2_can0_rx: p9_2_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(9, 2, HSIOM_SEL_ACT_3)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p5_3_can1_tx: p5_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(5, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p6_3_can1_tx: p6_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p8_3_can0_tx: p8_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(8, 3, HSIOM_SEL_ACT_3)>;
+			};
+
+			/omit-if-no-ref/ p9_3_can0_tx: p9_3_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(9, 3, HSIOM_SEL_ACT_3)>;
+			};
+
 			/* PWM tcpwm_line*/
 			/omit-if-no-ref/ p4_0_pwm1_4: p4_0_pwm1_4 {
 				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_1)>;

--- a/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
@@ -150,6 +150,38 @@
 			#ipc-config-cells = <3>;
 		};
 
+		canfd0: canfd@52800000 {
+			compatible = "infineon,canfd-controller";
+			reg = <0x52800000 0x1088>, <0x52810000 0x1000>;
+			reg-names = "wrapper", "mram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			can0: can@52800000 {
+				compatible = "infineon,can";
+				reg = <0x52800000 0x200>, <0x52810000 0x800>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x405>;
+				status = "disabled";
+				bosch,mram-cfg = <0x0 15 15 8 8 0 8 8>;
+				interrupts = <99 4>, <100 4>;
+				interrupt-names = "int0", "int1";
+			};
+
+			can1: can@52800200 {
+				compatible = "infineon,can";
+				reg = <0x52800200 0x200>, <0x52810000 0x1000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x406>;
+				status = "disabled";
+				bosch,mram-cfg = <0x800 15 15 8 8 0 8 8>;
+				interrupts = <101 4>, <102 4>;
+				interrupt-names = "int0", "int1";
+			};
+		};
+
 		scb0: scb@52820000 {
 			compatible = "infineon,scb";
 			reg = <0x52820000 0xfd0>;

--- a/dts/arm/infineon/edge/pse84/pse84.bga-220.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.bga-220.dtsi
@@ -2037,6 +2037,40 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_4_can0_rx: p20_4_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_6_can1_rx: p20_6_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_5_can0_tx: p20_5_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.bga-220_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.bga-220_s.dtsi
@@ -2037,6 +2037,40 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_4_can0_rx: p20_4_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_6_can1_rx: p20_6_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_5_can0_tx: p20_5_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
@@ -208,6 +208,14 @@
 	interrupts = <34 4>;
 };
 
+&can0 {
+	interrupts = <84 4>, <85 4>;
+};
+
+&can1 {
+	interrupts = <86 4>, <87 4>;
+};
+
 &tcpwm0_0 {
 	interrupts = <88 4>;
 };

--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -420,6 +420,38 @@
 			status = "disabled";
 		};
 
+		canfd0: canfd@42840000 {
+			compatible = "infineon,canfd-controller";
+			reg = <0x42840000 0x1088>, <0x42850000 0x2000>;
+			reg-names = "wrapper", "mram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			can0: can@42840000 {
+				compatible = "infineon,can";
+				reg = <0x42840000 0x200>, <0x42850000 0x1000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x10b>;
+				status = "disabled";
+				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				interrupts = <106 4>, <107 4>;
+				interrupt-names = "int0", "int1";
+			};
+
+			can1: can@42840200 {
+				compatible = "infineon,can";
+				reg = <0x42840200 0x200>, <0x42850000 0x2000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x10c>;
+				status = "disabled";
+				bosch,mram-cfg = <0x1000 15 15 8 8 0 15 15>;
+				interrupts = <108 4>, <109 4>;
+				interrupt-names = "int0", "int1";
+			};
+		};
+
 		tcpwm0: tcpwm0@42860000 {
 			reg = <0x42860000 0x8000>;
 			#address-cells = <1>;

--- a/dts/arm/infineon/edge/pse84/pse84.ewlb-235.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.ewlb-235.dtsi
@@ -2037,6 +2037,40 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_4_can0_rx: p20_4_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_6_can1_rx: p20_6_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_5_can0_tx: p20_5_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.ewlb-235_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.ewlb-235_s.dtsi
@@ -2037,6 +2037,40 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_4_can0_rx: p20_4_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_6_can1_rx: p20_6_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_5_can0_tx: p20_5_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.wlb-154.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.wlb-154.dtsi
@@ -1398,6 +1398,24 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.wlb-154_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.wlb-154_s.dtsi
@@ -1398,6 +1398,24 @@
 			/omit-if-no-ref/ p21_1_tdm_i2s0_tx_sd: p21_1_tdm_i2s0_tx_sd {
 				pinmux = <DT_CAT1_PINMUX(21, 1, HSIOM_SEL_ACT_7)>;
 			};
+
+			/* canfd_ttcan_rx */
+			/omit-if-no-ref/ p16_0_can0_rx: p16_0_can0_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_2_can1_rx: p16_2_can1_rx {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_4)>;
+			};
+
+			/* canfd_ttcan_tx */
+			/omit-if-no-ref/ p16_1_can0_tx: p16_1_can0_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_4)>;
+			};
+
+			/omit-if-no-ref/ p16_3_can1_tx: p16_3_can1_tx {
+				pinmux = <DT_CAT1_PINMUX(16, 3, HSIOM_SEL_ACT_4)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -440,6 +440,38 @@
 			status = "disabled";
 		};
 
+		canfd0: canfd@52840000 {
+			compatible = "infineon,canfd-controller";
+			reg = <0x52840000 0x1088>, <0x52850000 0x2000>;
+			reg-names = "wrapper", "mram";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			can0: can@52840000 {
+				compatible = "infineon,can";
+				reg = <0x52840000 0x200>, <0x52850000 0x1000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x10b>;
+				status = "disabled";
+				bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+				interrupts = <106 4>, <107 4>;
+				interrupt-names = "int0", "int1";
+			};
+
+			can1: can@52840200 {
+				compatible = "infineon,can";
+				reg = <0x52840200 0x200>, <0x52850000 0x2000>;
+				reg-names = "m_can", "message_ram";
+				clk-dst = <0x10c>;
+				status = "disabled";
+				bosch,mram-cfg = <0x1000 15 15 8 8 0 15 15>;
+				interrupts = <108 4>, <109 4>;
+				interrupt-names = "int0", "int1";
+			};
+		};
+
 		tcpwm0: tcpwm0@52860000 {
 			reg = <0x52860000 0x8000>;
 			#address-cells = <1>;

--- a/dts/bindings/can/infineon,can.yaml
+++ b/dts/bindings/can/infineon,can.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Linumiz
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Infineon MCAN Driver
+
+compatible: "infineon,can"
+
+include: ["bosch,m_can-base.yaml", "pinctrl-device.yaml"]
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  clk-dst:
+    type: int
+    required: true
+    description: |
+      Peripheral clock destination ID for this CAN instance.
+      Maps to an en_clk_dst_t value used by the Infineon PDL to
+      connect a peripheral clock divider to this CAN block.

--- a/dts/bindings/can/infineon,canfd-controller.yaml
+++ b/dts/bindings/can/infineon,canfd-controller.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: |
+  Infineon CAN FD controller wrapper.
+
+description: |
+  This node represents the top-level Infineon CANFD IP block that contains
+  shared resources (global control register, Message RAM, ECC) common to all
+  CAN FD channels.  Individual CAN channels are child nodes of this controller.
+
+  The controller driver powers on the Message RAM and configures optional
+  wrapper-level features (timestamp counter, ECC) before any channel can
+  operate.
+
+compatible: "infineon,canfd-controller"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    description: |
+      Two register regions:
+        - wrapper: Base address and size of the CANFD controller wrapper
+          registers (CTL, STATUS, TS_CTL, ECC_CTL).
+        - mram: Base address and size of the shared Message RAM.
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 1
+
+  shared-timestamp-counter:
+    type: boolean
+    description: |
+      Enable the shared timestamp counter in the CAN FD wrapper.
+      When set, the driver enables the wrapper's TS_CTL counter and
+      configures each child M_CAN channel to use it as an external
+      timestamp source.
+
+  ecc-enabled:
+    type: boolean
+    description: |
+      Enable ECC on the shared Message RAM.  When set, the driver
+      activates single-bit error correction and double-bit error
+      detection for all Message RAM accesses.

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -475,3 +475,104 @@ static inline cy_rslt_t ifx_cat1_utils_peri_pclk_assign_divider(en_clk_dst_t clk
 		_clock->channel);
 #endif
 }
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+/**
+ * @brief Pack a PERI instance and group number into a single switch key.
+ *
+ * PSE84 has multiple PERI instances (PERI0, PERI1), each with its own set of
+ * peri clock groups.  This macro combines the two into a unique value for use
+ * in switch statements that map (instance, group) → HF clock index.
+ */
+#define IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(instance, group) (((instance) << 4) | (group))
+
+/**
+ * @brief Map a peripheral group index to the HF clock that sources it.
+ *
+ * The mapping is SoC-specific and fixed in hardware.
+ *
+ * @param peri_group Peripheral group index (or instance|group composite
+ *                   on EDGE family SoCs).
+ * @return HF clock index suitable for Cy_SysClk_ClkHfGetFrequency().
+ */
+static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
+{
+	switch (peri_group) {
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 0):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 4):
+		return CLK_HF0;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 7):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 0):
+		return CLK_HF1;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 3):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 2):
+		return CLK_HF5;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 4):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 3):
+		return CLK_HF6;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(1, 1):
+		return CLK_HF7;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 2):
+		return CLK_HF9;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 1):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 5):
+		return CLK_HF10;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 8):
+		return CLK_HF11;
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 6):
+	case IFX_CAT1_PERIPHERAL_INSTANCE_GROUP(0, 9):
+		return CLK_HF13;
+	default:
+		break;
+	}
+	return -EINVAL;
+}
+
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_CAT1B)
+/**
+ * @brief Map a peripheral group index to the HF clock that sources it.
+ *
+ * The mapping is SoC-specific and fixed in hardware.
+ *
+ * @param peri_group Peripheral group index (or instance|group composite
+ *                   on EDGE family SoCs).
+ * @return HF clock index suitable for Cy_SysClk_ClkHfGetFrequency().
+ */
+static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
+{
+	switch (peri_group) {
+	case 0:
+	case 2:
+		return CLK_HF0;
+	case 1:
+	case 3:
+		return CLK_HF1;
+	case 4:
+		return CLK_HF2;
+	case 5:
+		return CLK_HF3;
+	case 6:
+		return CLK_HF4;
+	default:
+		break;
+	}
+	return -EINVAL;
+}
+
+#else /* !CONFIG_SOC_FAMILY_INFINEON_EDGE && !CONFIG_SOC_FAMILY_INFINEON_CAT1B */
+/**
+ * @brief Map a peripheral group index to the HF clock that sources it.
+ *
+ * Fallback for SoC families that do not yet implement this mapping.
+ * Always returns -EINVAL.
+ *
+ * @param peri_group Peripheral group index (unused).
+ * @return -EINVAL always.
+ */
+static inline uint8_t ifx_cat1_utils_peri_pclk_get_hfclk(uint8_t peri_group)
+{
+	ARG_UNUSED(peri_group);
+
+	return -EINVAL;
+}
+#endif

--- a/tests/drivers/can/api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/can/api/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Increase the secure flash partition to 192KB for the CAN API test,
+ * which overflows the default 128KB slot0_partition.
+ */
+
+&slot0_partition {
+	reg = <0x12000000 DT_SIZE_K(192)>;
+};
+
+&slot0_ns_partition {
+	reg = <0x02030000 DT_SIZE_K(64)>;
+};


### PR DESCRIPTION
- Adds CAN driver for Infineon devices using the Bosch M_CAN IP core.
- Adds DTS bindings (infineon,canfd-controller, infineon,can) and CAN node definitions to soc and dtsi files.
- Adds clock control support for CAN peripheral clocks; refactors ifx_cat1_utils_peri_pclk_get_hfclk() into a shared inline in the clock control header, eliminating duplication in the SPI and UART drivers.
- Enables CAN on the kit_psc3m5_evk board with pinctrl (P5.2 RX, P5.3 TX) and a 16.5-bit peripheral clock divider.
- Adds CAN API and CAN Timing test overlays.

This PR is based on the work done in an existing PR https://github.com/zephyrproject-rtos/zephyr/pull/101930.  This PR includes those changes, but changes clock control to use the existing peripheral clock driver and the adds the infineon,canfd-controller which is responsible for MRAM initialization and allows enabling MRAM ECC. 