### PR TITLE
Bluetooth: Remove bt_hci_cmd_create() 

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -83,7 +83,12 @@ API Changes
 Removed APIs and options
 ========================
 
-* ``CONFIG_BT_TBS_SUPPORTED_FEATURES``
+* Bluetooth
+
+   * ``CONFIG_BT_TBS_SUPPORTED_FEATURES``
+
+   * The deprecated ``bt_hci_cmd_create()`` functon was removed. It has been replaced by
+     :c:func:`bt_hci_cmd_alloc`.
 
 Deprecated APIs and options
 ===========================

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -49,22 +49,6 @@ static inline const char *bt_hci_err_to_str(uint8_t hci_err)
 }
 #endif
 
-/** Allocate a HCI command buffer.
-  *
-  * This function allocates a new buffer for a HCI command. It is given
-  * the OpCode (encoded e.g. using the BT_OP macro) and the total length
-  * of the parameters. Upon successful return the buffer is ready to have
-  * the parameters encoded into it.
-  *
-  * @deprecated Use bt_hci_cmd_alloc() instead.
-  *
-  * @param opcode     Command OpCode.
-  * @param param_len  Length of command parameters.
-  *
-  * @return Newly allocated buffer.
-  */
-__deprecated struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
-
 /** Allocate an HCI command buffer.
  *
  * This function allocates a new buffer for an HCI command. Upon successful

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -343,29 +343,6 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 }
 #endif /* defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL) */
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
-{
-	struct bt_hci_cmd_hdr *hdr;
-	struct net_buf *buf;
-
-	LOG_DBG("opcode 0x%04x param_len %u", opcode, param_len);
-
-	buf = bt_hci_cmd_alloc(K_FOREVER);
-	if (!buf) {
-		return NULL;
-	}
-
-	LOG_DBG("buf %p", buf);
-
-	hdr = net_buf_push(buf, sizeof(*hdr));
-	hdr->opcode = sys_cpu_to_le16(opcode);
-	hdr->param_len = param_len;
-
-	net_buf_push_u8(buf, BT_HCI_H4_CMD);
-
-	return buf;
-}
-
 struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout)
 {
 	struct net_buf *buf;
@@ -392,7 +369,15 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 {
 	struct bt_hci_cmd_hdr *hdr;
 
-	if (!buf) {
+	if (buf != NULL) {
+		/* Check for sufficient headeroom, which can only happen if the user passes a
+		 * buffer that was allocated incorrectly, i.e. through some other means than
+		 * bt_hci_cmd_alloc().
+		 */
+		if (net_buf_headroom(buf) < sizeof(uint8_t) + sizeof(*hdr)) {
+			return -EINVAL;
+		}
+	} else {
 		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
@@ -403,16 +388,11 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 
 	cmd(buf)->opcode = opcode;
 
-	/* TODO: Remove this condition when bt_hci_cmd_create() has been removed (after its
-	 * deprecation period)
-	 */
-	if (net_buf_headroom(buf) >= sizeof(uint8_t) + sizeof(*hdr)) {
-		hdr = net_buf_push(buf, sizeof(*hdr));
-		hdr->opcode = sys_cpu_to_le16(opcode);
-		hdr->param_len = buf->len - sizeof(*hdr);
+	hdr = net_buf_push(buf, sizeof(*hdr));
+	hdr->opcode = sys_cpu_to_le16(opcode);
+	hdr->param_len = buf->len - sizeof(*hdr);
 
-		net_buf_push_u8(buf, BT_HCI_H4_CMD);
-	}
+	net_buf_push_u8(buf, BT_HCI_H4_CMD);
 
 	/* Host Number of Completed Packets can ignore the ncmd value
 	 * and does not generate any cmd complete/status events.


### PR DESCRIPTION
The bt_hci_cmd_create() function was deprecated several releases ago (in Zephyr 4.2) and can therefore now be removed.