### PR TITLE
soc: st: stm32u3: Add STM32U3C5 SoC entry

### DIFF
--- a/dts/arm/st/u3/stm32u3c5.dtsi
+++ b/dts/arm/st/u3/stm32u3c5.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u3/stm32u3.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32u3c5", "st,stm32u3", "simple-bus";
+
+		pinctrl: pin-controller@42020000 {
+			gpiof: gpio@42021400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42021400 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u3/stm32u3c5Xi.dtsi
+++ b/dts/arm/st/u3/stm32u3c5Xi.dtsi
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Filip Stojanovic <filipembedded@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u3/stm32u3c5.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x20000000 DT_SIZE_K(640)>;
+		zephyr,memory-region = "SRAM0";
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(2048)>;
+				ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -219,6 +219,7 @@ family:
     socs:
     - name: stm32u375xx
     - name: stm32u385xx
+    - name: stm32u3c5xx
   - name: stm32u5x
     socs:
     - name: stm32u5a5xx

--- a/soc/st/stm32/stm32u3x/Kconfig.soc
+++ b/soc/st/stm32/stm32u3x/Kconfig.soc
@@ -18,6 +18,11 @@ config SOC_STM32U385XX
 	bool
 	select SOC_SERIES_STM32U3X
 
+config SOC_STM32U3C5XX
+	bool
+	select SOC_SERIES_STM32U3X
+
 config SOC
 	default "stm32u375xx" if SOC_STM32U375XX
 	default "stm32u385xx" if SOC_STM32U385XX
+	default "stm32u3c5xx" if SOC_STM32U3C5XX

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 46e113ade52b2ae8b17b5054e715ec80cec37d9a
+      revision: pull/350/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR adds STM32U3C5 SoC entry to STM32U3 series.

This PR is blocked by: [This PR](https://github.com/zephyrproject-rtos/hal_stm32/pull/350)