### PR TITLE
samples: entropy: Use random subsys to generate random values

### DIFF
--- a/samples/boards/st/power_mgmt/suspend_to_ram/src/main.c
+++ b/samples/boards/st/power_mgmt/suspend_to_ram/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/drivers/adc.h>
-#include <zephyr/drivers/entropy.h>
+#include <zephyr/random/random.h>
 #include <zephyr/drivers/spi.h>
 #include <string.h>
 #include <stdio.h>
@@ -39,8 +39,6 @@ static const struct adc_dt_spec adc_channels[] = {
 	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels,
 			     DT_SPEC_AND_COMMA)
 };
-
-const struct device *rng_dev;
 
 #define BUFFER_LENGTH	3
 
@@ -220,11 +218,6 @@ int main(void)
 {
 	__ASSERT_NO_MSG(gpio_is_ready_dt(&led));
 
-	rng_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
-	if (!device_is_ready(rng_dev)) {
-		printk("error: random device not ready");
-	}
-
 	spi_setup();
 
 	printk("Device ready\n");
@@ -240,7 +233,7 @@ int main(void)
 		printk("Exit Stop1\n");
 
 		(void)memset(entropy_buffer, 0x00, BUFFER_LENGTH);
-		entropy_get_entropy(rng_dev, (char *)entropy_buffer, BUFFER_LENGTH);
+		sys_rand_get(entropy_buffer, BUFFER_LENGTH);
 		printk("Sync entropy: ");
 		print_buf(entropy_buffer);
 

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/ztest.h>
-#include <zephyr/drivers/entropy.h>
+#include <zephyr/random/random.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <hal/nrf_clock.h>
@@ -22,7 +22,6 @@ LOG_MODULE_REGISTER(test);
 
 static bool test_end;
 
-static const struct device *const entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 static struct onoff_manager *hf_mgr;
 static struct onoff_client cli;
@@ -30,7 +29,6 @@ static uint32_t iteration;
 
 static void *setup(void)
 {
-	zassert_true(device_is_ready(entropy));
 	zassert_true(device_is_ready(clock_dev));
 
 	hf_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
@@ -116,8 +114,7 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 	do {
 		iteration++;
 
-		err = entropy_get_entropy(entropy, &rand, 1);
-		zassert_equal(err, 0);
+		sys_rand_get(&rand, 1);
 		backoff = 3 * rand;
 
 		sys_notify_init_spinwait(&cli.notify);
@@ -192,7 +189,6 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
 	uint64_t checkpoint = 1000;
-	int err;
 	uint8_t rand;
 	int backoff;
 
@@ -204,8 +200,7 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 	do {
 		iteration++;
 
-		err = entropy_get_entropy(entropy, &rand, 1);
-		zassert_equal(err, 0);
+		sys_rand_get(&rand, 1);
 		backoff = 3 * rand;
 
 		z_nrf_clock_bt_ctlr_hf_request();


### PR DESCRIPTION
Entropy devices should be used to feed the random generator and not as a random generator directly.

Change samples that were using entropy device instead of the random subsystem.