### PR TITLE
boards: others: canbardo: fix missing partition ranges

### DIFF
--- a/boards/others/canbardo/canbardo.dts
+++ b/boards/others/canbardo/canbardo.dts
@@ -131,10 +131,15 @@ zephyr_udc0: &usbhs {
 };
 
 &flash0 {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	ranges = <0x0 0x00400000 DT_SIZE_K(1024)>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* First half of sector 0 */
 		boot_partition: partition@0 {


### PR DESCRIPTION
Fix flash partitions being specified at the wrong addresses.