### PR TITLE
Bluetooth: TBS: Make originate consistent between local and remote

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -2607,6 +2607,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri, uint8_t *call_index
 	struct tbs_inst *inst = inst_lookup_index(bearer_index);
 	uint8_t buf[CONFIG_BT_TBS_MAX_URI_LENGTH + sizeof(struct bt_tbs_call_cp_originate)];
 	struct bt_tbs_call_cp_originate *ccp = (struct bt_tbs_call_cp_originate *)buf;
+	struct tbs_inst *target_inst = NULL;
 	size_t uri_len;
 	int err;
 	int ret;
@@ -2614,30 +2615,50 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri, uint8_t *call_index
 	if (inst == NULL) {
 		LOG_DBG("Could not find TBS instance from index %u", bearer_index);
 		return -EINVAL;
-	} else if (!bt_tbs_valid_uri((uint8_t *)remote_uri, strlen(remote_uri))) {
+	}
+
+	if (remote_uri == NULL) {
+		LOG_DBG("remote_uri is NULL");
+		return -EINVAL;
+	}
+
+	if (call_index == NULL) {
+		LOG_DBG("call_index is NULL");
+		return -EINVAL;
+	}
+
+	uri_len = strlen(remote_uri);
+	if (!bt_tbs_valid_uri((uint8_t *)remote_uri, uri_len)) {
 		LOG_DBG("Invalid URI %s", remote_uri);
 		return -EINVAL;
 	}
 
-	err = k_mutex_lock(&inst->mutex, K_NO_WAIT);
+	if (inst_is_gtbs(inst)) {
+		target_inst = lookup_inst_by_uri_scheme((uint8_t *)remote_uri, uri_len);
+		if (target_inst == NULL) {
+			return -ENODEV;
+		}
+	} else {
+		target_inst = inst;
+	}
+
+	err = k_mutex_lock(&target_inst->mutex, K_NO_WAIT);
 	if (err != 0) {
 		LOG_DBG("Failed to lock mutex");
 		return -EBUSY;
 	}
 
-	uri_len = strlen(remote_uri);
-
 	ccp->opcode = BT_TBS_CALL_OPCODE_ORIGINATE;
 	(void)memcpy(ccp->uri, remote_uri, uri_len);
 
-	ret = originate_call(inst, ccp, uri_len, call_index);
+	ret = originate_call(target_inst, ccp, uri_len, call_index);
 
 	/* In the case that we are not connected to any TBS clients, we won't notify and we can
 	 * attempt to change state from dialing to alerting immediately
 	 */
-	(void)try_change_dialing_call_to_alerting(inst);
+	(void)try_change_dialing_call_to_alerting(target_inst);
 
-	err = k_mutex_unlock(&inst->mutex);
+	err = k_mutex_unlock(&target_inst->mutex);
 	__ASSERT(err == 0, "Failed to unlock mutex: %d", err);
 
 	return ret;

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -115,12 +115,12 @@ static struct bt_conn_cb conn_callbacks = {
 	.disconnected = disconnected,
 };
 
-static int test_provider_name(void)
+static int test_provider_name(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_set_bearer_provider_name(0, "BabblesimTBS");
+	err = bt_tbs_set_bearer_provider_name(bearer_index, "BabblesimTBS");
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer provider name: %d\n", err);
 		return err;
@@ -131,12 +131,12 @@ static int test_provider_name(void)
 	return err;
 }
 
-static int test_set_signal_strength(void)
+static int test_set_signal_strength(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_set_signal_strength(0, 6);
+	err = bt_tbs_set_signal_strength(bearer_index, 6);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer provider name: %d\n", err);
 		return err;
@@ -147,12 +147,12 @@ static int test_set_signal_strength(void)
 	return err;
 }
 
-static int test_set_bearer_technology(void)
+static int test_set_bearer_technology(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_set_bearer_technology(0, BT_TBS_TECHNOLOGY_GSM);
+	err = bt_tbs_set_bearer_technology(bearer_index, BT_TBS_TECHNOLOGY_GSM);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set bearer technology: %d\n", err);
 		return err;
@@ -163,12 +163,12 @@ static int test_set_bearer_technology(void)
 	return err;
 }
 
-static int test_set_status_flags(void)
+static int test_set_status_flags(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_set_status_flags(0, 3);
+	err = bt_tbs_set_status_flags(bearer_index, 3);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not set status flags: %d\n", err);
 		return err;
@@ -179,13 +179,13 @@ static int test_set_status_flags(void)
 	return err;
 }
 
-static int test_answer_terminate(void)
+static int test_answer_terminate(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
 	printk("Placing call\n");
-	err = bt_tbs_originate(0, "tel:000000000001", &g_call_index);
+	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate call: %d\n", err);
 		return err;
@@ -210,12 +210,12 @@ static int test_answer_terminate(void)
 	return err;
 }
 
-static int test_hold_retrieve(void)
+static int test_hold_retrieve(uint8_t bearer_index)
 {
 	int err;
 
 	printk("%s\n", __func__);
-	err = bt_tbs_originate(0, "tel:000000000001", &g_call_index);
+	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate call: %d\n", err);
 		return err;
@@ -253,14 +253,14 @@ static int test_hold_retrieve(void)
 	return err;
 }
 
-static int test_join(void)
+static int test_join(uint8_t bearer_index)
 {
 	int err;
 	uint8_t call_indexes[2];
 
 	printk("%s\n", __func__);
 	printk("Placing first call\n");
-	err = bt_tbs_originate(0, "tel:000000000001", &g_call_index);
+	err = bt_tbs_originate(bearer_index, "tel:000000000001", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate first call: %d\n", err);
 		return err;
@@ -277,7 +277,7 @@ static int test_join(void)
 	call_indexes[0] = (uint8_t)g_call_index;
 
 	printk("Placing second call\n");
-	err = bt_tbs_originate(0, "tel:000000000002", &g_call_index);
+	err = bt_tbs_originate(bearer_index, "tel:000000000002", &g_call_index);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		FAIL("Could not originate second call: %d\n", err);
 		return err;
@@ -317,15 +317,15 @@ static int test_join(void)
 	return err;
 }
 
-static void test_tbs_server_only(void)
+static void test_tbs_server_only(uint8_t bearer_index)
 {
-	test_answer_terminate();
-	test_hold_retrieve();
-	test_join();
-	test_provider_name();
-	test_set_signal_strength();
-	test_set_bearer_technology();
-	test_set_status_flags();
+	test_answer_terminate(bearer_index);
+	test_hold_retrieve(bearer_index);
+	test_join(bearer_index);
+	test_provider_name(bearer_index);
+	test_set_signal_strength(bearer_index);
+	test_set_bearer_technology(bearer_index);
+	test_set_status_flags(bearer_index);
 }
 
 static void init(void)
@@ -448,7 +448,8 @@ static void tbs_test_server_only(void)
 {
 	init();
 
-	test_tbs_server_only();
+	test_tbs_server_only(0);
+	test_tbs_server_only(BT_TBS_GTBS_INDEX);
 
 	PASS("TBS server tests passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -333,7 +333,7 @@ static void init(void)
 	const struct bt_tbs_register_param gtbs_param = {
 		.provider_name = "Generic TBS",
 		.uci = "un000",
-		.uri_schemes_supported = "tel,skype",
+		.uri_schemes_supported = "skype",
 		.gtbs = true,
 		.authorization_required = false,
 		.technology = BT_TBS_TECHNOLOGY_3G,


### PR DESCRIPTION
If we get a remote request to originate a call via a control point write, we lookup a TBS instance based on the URI. However for the local API function bt_tbs_originate we did not, so the same operation, if the target bearer was GTBS, had different behavior depending on whether it was locally or remotely invoked.

This commit makes the two behave the same.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/104389