### PR TITLE
drivers: fuel_gauge: add a driver for TI BQ27427

### DIFF
--- a/drivers/fuel_gauge/CMakeLists.txt
+++ b/drivers/fuel_gauge/CMakeLists.txt
@@ -12,6 +12,7 @@ if(CONFIG_EMUL AND CONFIG_USERSPACE)
 endif()
 
 # zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_BQ27427 bq27427)
 add_subdirectory_ifdef(CONFIG_BQ27Z746 bq27z746)
 add_subdirectory_ifdef(CONFIG_BQ40Z50 bq40z50)
 add_subdirectory_ifdef(CONFIG_FUEL_GAUGE_AXP2101 axp2101)

--- a/drivers/fuel_gauge/Kconfig
+++ b/drivers/fuel_gauge/Kconfig
@@ -21,6 +21,7 @@ config FUEL_GAUGE_INIT_PRIORITY
 
 # zephyr-keep-sorted-start
 source "drivers/fuel_gauge/axp2101/Kconfig"
+source "drivers/fuel_gauge/bq27427/Kconfig"
 source "drivers/fuel_gauge/bq27z746/Kconfig"
 source "drivers/fuel_gauge/bq40z50/Kconfig"
 source "drivers/fuel_gauge/composite/Kconfig"

--- a/drivers/fuel_gauge/bq27427/CMakeLists.txt
+++ b/drivers/fuel_gauge/bq27427/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_library()
+
+zephyr_library_sources(bq27427.c)

--- a/drivers/fuel_gauge/bq27427/Kconfig
+++ b/drivers/fuel_gauge/bq27427/Kconfig
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config BQ27427
+	bool "BQ27427 Fuel Gauge"
+	default y
+	depends on DT_HAS_TI_BQ27427_ENABLED
+	select I2C
+	help
+	  Enable I2C-based driver for BQ27427 Fuel Gauge.

--- a/drivers/fuel_gauge/bq27427/bq27427.c
+++ b/drivers/fuel_gauge/bq27427/bq27427.c
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_bq27427
+
+#include "bq27427.h"
+
+#include <errno.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/byteorder.h>
+
+struct bq27427_config {
+	struct i2c_dt_spec i2c;
+};
+
+static int bq27427_command_read(const struct device *dev, uint8_t command, uint16_t *value)
+{
+	uint8_t i2c_data[2];
+	const struct bq27427_config *cfg = (const struct bq27427_config *)dev->config;
+
+	const int status = i2c_burst_read_dt(&cfg->i2c, command, i2c_data, sizeof(i2c_data));
+
+	if (status < 0) {
+		return status;
+	}
+
+	*value = sys_get_le16(i2c_data);
+	return 0;
+}
+
+static int bq27427_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			    union fuel_gauge_prop_val *val)
+{
+	int rc = 0;
+	uint16_t tmp_val;
+
+	switch (prop) {
+	case FUEL_GAUGE_AVG_CURRENT:
+		rc = bq27427_command_read(dev, BQ27427_CMD_AVERAGE_CURRENT, &tmp_val);
+		val->avg_current = (int16_t)tmp_val * 1000;
+		break;
+	case FUEL_GAUGE_FLAGS:
+		rc = bq27427_command_read(dev, BQ27427_CMD_FLAGS, &tmp_val);
+		val->flags = tmp_val;
+		break;
+	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
+		rc = bq27427_command_read(dev, BQ27427_CMD_FULL_CHARGE_CAPACITY, &tmp_val);
+		val->full_charge_capacity = tmp_val * 1000;
+		break;
+	case FUEL_GAUGE_REMAINING_CAPACITY:
+		rc = bq27427_command_read(dev, BQ27427_CMD_REMAINING_CAPACITY, &tmp_val);
+		val->remaining_capacity = tmp_val * 1000;
+		break;
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+		rc = bq27427_command_read(dev, BQ27427_CMD_STATE_OF_CHARGE, &tmp_val);
+		val->relative_state_of_charge = tmp_val;
+		break;
+	case FUEL_GAUGE_TEMPERATURE:
+		rc = bq27427_command_read(dev, BQ27427_CMD_TEMPERATURE, &tmp_val);
+		val->temperature = tmp_val * 1000;
+		break;
+	case FUEL_GAUGE_VOLTAGE:
+		rc = bq27427_command_read(dev, BQ27427_CMD_VOLTAGE, &tmp_val);
+		val->voltage = tmp_val * 1000;
+		break;
+	default:
+		rc = -ENOTSUP;
+	}
+
+	return rc;
+}
+
+static int bq27427_init(const struct device *dev)
+{
+	const struct bq27427_config *cfg = (const struct bq27427_config *)dev->config;
+
+	if (!device_is_ready(cfg->i2c.bus)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(fuel_gauge, bq27427_driver_api) = {
+	.get_property = &bq27427_get_prop,
+};
+
+#define BQ27427_INIT(index)                                                                        \
+                                                                                                   \
+	static const struct bq27427_config bq27427_config_##index = {                              \
+		.i2c = I2C_DT_SPEC_INST_GET(index),                                                \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, &bq27427_init, NULL, NULL, &bq27427_config_##index,           \
+			      POST_KERNEL, CONFIG_FUEL_GAUGE_INIT_PRIORITY, &bq27427_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BQ27427_INIT)

--- a/drivers/fuel_gauge/bq27427/bq27427.c
+++ b/drivers/fuel_gauge/bq27427/bq27427.c
@@ -10,10 +10,13 @@
 
 #include <errno.h>
 
-#include <zephyr/kernel.h>
 #include <zephyr/drivers/fuel_gauge.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
+
+LOG_MODULE_REGISTER(bq27427);
 
 struct bq27427_config {
 	struct i2c_dt_spec i2c;
@@ -27,6 +30,7 @@ static int bq27427_command_read(const struct device *dev, uint8_t command, uint1
 	const int status = i2c_burst_read_dt(&cfg->i2c, command, i2c_data, sizeof(i2c_data));
 
 	if (status < 0) {
+		LOG_ERR("Failed to read register 0x%02X", command);
 		return status;
 	}
 
@@ -38,7 +42,7 @@ static int bq27427_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 			    union fuel_gauge_prop_val *val)
 {
 	int rc = 0;
-	uint16_t tmp_val;
+	uint16_t tmp_val = 0;
 
 	switch (prop) {
 	case FUEL_GAUGE_AVG_CURRENT:
@@ -63,7 +67,7 @@ static int bq27427_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 	case FUEL_GAUGE_TEMPERATURE:
 		rc = bq27427_command_read(dev, BQ27427_CMD_TEMPERATURE, &tmp_val);
-		val->temperature = tmp_val * 1000;
+		val->temperature = tmp_val;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
 		rc = bq27427_command_read(dev, BQ27427_CMD_VOLTAGE, &tmp_val);
@@ -81,6 +85,7 @@ static int bq27427_init(const struct device *dev)
 	const struct bq27427_config *cfg = (const struct bq27427_config *)dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("I2C bus not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/fuel_gauge/bq27427/bq27427.h
+++ b/drivers/fuel_gauge/bq27427/bq27427.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FUELGAUGE_BQ27427_BQ27427_H_
+#define ZEPHYR_DRIVERS_FUELGAUGE_BQ27427_BQ27427_H_
+
+/* Commands */
+enum bq27427_commands {
+	/* Standard commands */
+	BQ27427_CMD_CONTROL = 0x00u,                         /* Control() */
+	BQ27427_CMD_TEMPERATURE = 0x02u,                     /* Temperature() */
+	BQ27427_CMD_VOLTAGE = 0x04u,                         /* Voltage() */
+	BQ27427_CMD_FLAGS = 0x06u,                           /* Flags() */
+	BQ27427_CMD_NOMINAL_AVAILABLE_CAPACITY = 0x08u,      /* NominalAvailableCapacity() */
+	BQ27427_CMD_FULL_AVAILABLE_CAPACITY = 0x0Au,         /* FullAvailableCapacity() */
+	BQ27427_CMD_REMAINING_CAPACITY = 0x0Cu,              /* RemainingCapacity() */
+	BQ27427_CMD_FULL_CHARGE_CAPACITY = 0x0Eu,            /* FullChargeCapacity() */
+	BQ27427_CMD_AVERAGE_CURRENT = 0x10u,                 /* AverageCurrent() */
+	BQ27427_CMD_AVERAGE_POWER = 0x18u,                   /* AveragePower() */
+	BQ27427_CMD_STATE_OF_CHARGE = 0x1Cu,                 /* StateOfCharge() SOC */
+	BQ27427_CMD_INTERNAL_TEMPERATURE = 0x1Eu,            /* InternalTemperature() */
+	BQ27427_CMD_REMAINING_CAPACITY_UNFILTERED = 0x28u,   /* RemainingCapacityUnfiltered() */
+	BQ27427_CMD_REMAINING_CAPACITY_FILTERED = 0x2Au,     /* RemainingCapacityFiltered() */
+	BQ27427_CMD_FULL_CHARGE_CAPACITY_UNFILTERED = 0x2Cu, /* FullChargeCapacityUnfiltered() */
+	BQ27427_CMD_FULL_CHARGE_CAPACITY_FILTERED = 0x2Eu,   /* FullChargeCapacityFiltered() */
+	BQ27427_CMD_STATE_OF_CHARGE_UNFILTERED = 0x30u,      /* StateOfChargeUnfiltered() */
+
+	/* Extended commands */
+	BQ27427_EXT_CMD_DATA_CLASS = 0x3Eu,          /* DataClass() */
+	BQ27427_EXT_CMD_DATA_BLOCK = 0x3Fu,          /* DataBlock() */
+	BQ27427_EXT_CMD_BLOCK_DATA_START = 0x40u,    /* BlockData() start (0x40–0x5F) */
+	BQ27427_EXT_CMD_BLOCK_DATA_CHECKSUM = 0x60u, /* BlockDataCheckSum() */
+	BQ27427_EXT_CMD_BLOCK_DATA_CONTROL = 0x61u,  /* BlockDataControl() */
+};
+
+#endif

--- a/dts/bindings/fuel-gauge/ti,bq27427.yaml
+++ b/dts/bindings/fuel-gauge/ti,bq27427.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Texas Instruments BQ27427 fuel gauge. For more info visit
+  https://www.ti.com/product/BQ27427
+
+
+compatible: "ti,bq27427"
+
+include: [i2c-device.yaml, fuel-gauge.yaml]

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -23,6 +23,11 @@
  * @version 0.8.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup fuel_gauge_interface_ext Device-specific Fuel Gauge API extensions
+ *
+ * @{
+ * @}
  */
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/fuel_gauge/bq27427.h
+++ b/include/zephyr/drivers/fuel_gauge/bq27427.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for BQ27427 fuel gauge
+ * @ingroup fuel_gauge_bq27427_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_BQ27427_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_BQ27427_H_
+
+/**
+ * @defgroup fuel_gauge_bq27427_interface BQ27427
+ * @ingroup fuel_gauge_interface_ext
+ * @brief Texas Instruments BQ27427 single-cell battery fuel gauge.
+ *
+ * @see BQ27427 Technical Reference Manual:
+ * https://www.ti.com/lit/ug/sluucd5/sluucd5.pdf
+ *
+ * @{
+ */
+
+/**
+ * @name Custom flags for BQ27427
+ *
+ * Bit definitions for the flags reported by the BQ27427 fuel gauge.
+ * @{
+ */
+
+/** Over-temperature condition detected. */
+#define BQ27427_FLAG_OT          BIT(15)
+/** Under-temperature condition detected. */
+#define BQ27427_FLAG_UT          BIT(14)
+/** Full charge detected. */
+#define BQ27427_FLAG_FC          BIT(9)
+/** Fast charging allowed. */
+#define BQ27427_FLAG_CHG         BIT(8)
+/** Open-circuit voltage measurement taken. */
+#define BQ27427_FLAG_OCVTAKEN    BIT(7)
+/** Depth-of-discharge correction is currently applied. */
+#define BQ27427_FLAG_DOD_CORRECT BIT(6)
+/** Initialization or reset occurred. */
+#define BQ27427_FLAG_ITPOR       BIT(5)
+/** Fuel gauge is operating in configuration update mode. */
+#define BQ27427_FLAG_CFGUPMODE   BIT(4)
+/** Battery detected. Gauge predictions are invalid if this bit is clear. */
+#define BQ27427_FLAG_BAT_DET     BIT(3)
+/** State of charge is below the SOC1 threshold. */
+#define BQ27427_FLAG_SOC1        BIT(2)
+/** State of charge is below the SOCF threshold. */
+#define BQ27427_FLAG_SOCF        BIT(1)
+/** Discharging condition detected. */
+#define BQ27427_FLAG_DSG         BIT(0)
+
+/** @} */
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_BQ27427_H_ */

--- a/tests/drivers/build_all/fuel_gauge/i2c.dtsi
+++ b/tests/drivers/build_all/fuel_gauge/i2c.dtsi
@@ -58,3 +58,9 @@ hy4245@7 {
 	reg = <0x7>;
 	status = "okay";
 };
+
+bq27427@8 {
+	compatible = "ti,bq27427";
+	reg = <0x8>;
+	status = "okay";
+};


### PR DESCRIPTION
Add a driver for the Texas Instruments BQ27427 fuel gauge. The device provides battery fuel gauging for single-cell batteries and communicates over I2C. It enables reading fuel gauge properties such as voltage, current, temperature, state-of-charge, and capacity through the Zephyr fuel gauge subsystem.

BQ27427 Technical reference manual [here](https://www.ti.com/lit/pdf/sluucd5)