### PR TITLE
Bluetooth: BAP: Add callback and subscribe of supported ctxs

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -200,6 +200,7 @@ New APIs and options
     * :kconfig:option:`CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH`
     * :c:member:`bt_cap_handover_cb.unicast_to_broadcast_created`
     * :c:func:`bt_tbs_client_get_by_index`
+    * :c:member:`bt_bap_unicast_client_cb.supported_contexts`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1814,10 +1814,21 @@ struct bt_bap_unicast_client_cb {
 	 * @param conn  Connection to the remote unicast server.
 	 * @param dir   Direction of the location.
 	 * @param loc   The location bitfield value.
-	 *
-	 * @return 0 in case of success or negative value in case of error.
 	 */
 	void (*location)(struct bt_conn *conn, enum bt_audio_dir dir, enum bt_audio_location loc);
+
+	/**
+	 * @brief Remote Unicast Server Supported Contexts
+	 *
+	 * This callback is called whenever the supported contexts are read
+	 * from the server or otherwise notified to the client.
+	 *
+	 * @param conn     Connection to the remote unicast server.
+	 * @param snk_ctx  The sink context bitfield value.
+	 * @param src_ctx  The source context bitfield value.
+	 */
+	void (*supported_contexts)(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+				   enum bt_audio_context src_ctx);
 
 	/**
 	 * @brief Remote Unicast Server Available Contexts
@@ -1828,8 +1839,6 @@ struct bt_bap_unicast_client_cb {
 	 * @param conn     Connection to the remote unicast server.
 	 * @param snk_ctx  The sink context bitfield value.
 	 * @param src_ctx  The source context bitfield value.
-	 *
-	 * @return 0 in case of success or negative value in case of error.
 	 */
 	void (*available_contexts)(struct bt_conn *conn, enum bt_audio_context snk_ctx,
 				   enum bt_audio_context src_ctx);

--- a/samples/bluetooth/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/bap_unicast_client/src/main.c
@@ -489,11 +489,17 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	printk("dir %u loc %X\n", dir, loc);
 }
 
+static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
-	printk("snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
@@ -513,6 +519,7 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 
 static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.location = unicast_client_location_cb,
+	.supported_contexts = supported_contexts_cb,
 	.available_contexts = available_contexts_cb,
 	.pac_record = pac_record_cb,
 	.endpoint = endpoint_cb,

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -82,7 +83,7 @@ struct bt_bap_unicast_client_ep {
 
 static const struct bt_uuid *snk_uuid = BT_UUID_PACS_SNK;
 static const struct bt_uuid *src_uuid = BT_UUID_PACS_SRC;
-static const struct bt_uuid *pacs_context_uuid = BT_UUID_PACS_SUPPORTED_CONTEXT;
+static const struct bt_uuid *pacs_supp_context_uuid = BT_UUID_PACS_SUPPORTED_CONTEXT;
 static const struct bt_uuid *pacs_snk_loc_uuid = BT_UUID_PACS_SNK_LOC;
 static const struct bt_uuid *pacs_src_loc_uuid = BT_UUID_PACS_SRC_LOC;
 static const struct bt_uuid *pacs_avail_ctx_uuid = BT_UUID_PACS_AVAILABLE_CONTEXT;
@@ -110,6 +111,7 @@ static struct unicast_client {
 	struct bt_gatt_subscribe_params snk_loc_subscribe;
 	struct bt_gatt_subscribe_params src_loc_subscribe;
 	struct bt_gatt_subscribe_params avail_ctx_subscribe;
+	struct bt_gatt_subscribe_params supp_ctx_subscribe;
 
 	/* TODO: We should be able to reduce the number of discover params for
 	 * CCCD discovery, but requires additional work if it is to support an
@@ -119,6 +121,7 @@ static struct unicast_client {
 	 */
 	struct bt_gatt_discover_params loc_cc_disc;
 	struct bt_gatt_discover_params avail_ctx_cc_disc;
+	struct bt_gatt_discover_params supp_ctx_cc_disc;
 
 	/* Discovery parameters */
 	enum bt_audio_dir dir;
@@ -1904,7 +1907,8 @@ static int unicast_client_ep_subscribe(struct bt_conn *conn, struct bt_bap_ep *e
 	atomic_set_bit(client_ep->subscribe.flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 	err = bt_gatt_subscribe(conn, &client_ep->subscribe);
-	if (err != 0 && err != -EALREADY) {
+	if (err != 0) {
+		(void)memset(&client_ep->subscribe, 0, sizeof(client_ep->subscribe));
 		return err;
 	}
 
@@ -1959,7 +1963,8 @@ static void unicast_client_ep_set_cp(struct bt_conn *conn, uint16_t handle)
 		atomic_set_bit(client->cp_subscribe.flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 		err = bt_gatt_subscribe(conn, &client->cp_subscribe);
-		if (err != 0 && err != -EALREADY) {
+		if (err != 0) {
+			(void)memset(&client->cp_subscribe, 0, sizeof(client->cp_subscribe));
 			LOG_DBG("Failed to subscribe: %d", err);
 
 			unicast_client_discover_complete(conn, err);
@@ -3976,7 +3981,7 @@ static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn, const struct
 
 	err = bt_gatt_read(conn, &client->read_params);
 	if (err != 0) {
-		LOG_DBG("Failed to read PAC records: %d", err);
+		LOG_DBG("Failed to read ASEs: %d", err);
 
 		unicast_client_discover_complete(conn, err);
 	}
@@ -4064,10 +4069,8 @@ static uint8_t unicast_client_pacs_avail_ctx_notify_cb(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	net_buf_simple_init_with_data(&buf, (void *)data, length);
-
-	if (buf.len != sizeof(context)) {
-		LOG_ERR("Avail_ctx notification incorrect size: %u", length);
+	if (length != sizeof(context)) {
+		LOG_ERR("Available context notification incorrect size: %u", length);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -4110,6 +4113,7 @@ static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 		/* If available_ctx is not found, we terminate the discovery as
 		 * the characteristic is mandatory
 		 */
+		LOG_ERR("Unable to find available PAC context");
 
 		unicast_client_discover_complete(conn, BT_ATT_ERR_ATTRIBUTE_NOT_FOUND);
 
@@ -4139,8 +4143,13 @@ static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 			err = bt_gatt_subscribe(conn, sub_params);
-			if (err != 0 && err != -EALREADY) {
-				LOG_ERR("Failed to subscribe to avail_ctx: %d", err);
+			if (err != 0) {
+				(void)memset(sub_params, 0, sizeof(*sub_params));
+				LOG_DBG("Failed to subscribe to avail_ctx: %d", err);
+
+				unicast_client_discover_complete(conn, err);
+
+				return BT_GATT_ITER_STOP;
 			}
 		} /* else already subscribed */
 	} else {
@@ -4240,9 +4249,7 @@ static uint8_t unicast_client_pacs_location_notify_cb(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	net_buf_simple_init_with_data(&buf, (void *)data, length);
-
-	if (buf.len != sizeof(location)) {
+	if (length != sizeof(location)) {
 		LOG_ERR("Location notification incorrect size: %u", length);
 		return BT_GATT_ITER_STOP;
 	}
@@ -4320,17 +4327,20 @@ static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 			sub_params = &uni_cli_insts[index].src_loc_subscribe;
 		}
 
-		sub_params->value_handle = value_handle;
-		sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
-		sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
-		sub_params->disc_params = &uni_cli_insts[index].loc_cc_disc;
-		sub_params->notify = unicast_client_pacs_location_notify_cb;
-		sub_params->value = BT_GATT_CCC_NOTIFY;
-		atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+		if (sub_params->value_handle == 0) {
+			sub_params->value_handle = value_handle;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
+			sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+			sub_params->disc_params = &uni_cli_insts[index].loc_cc_disc;
+			sub_params->notify = unicast_client_pacs_location_notify_cb;
+			sub_params->value = BT_GATT_CCC_NOTIFY;
+			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
-		err = bt_gatt_subscribe(conn, sub_params);
-		if (err != 0 && err != -EALREADY) {
-			LOG_ERR("Failed to subscribe to location: %d", err);
+			err = bt_gatt_subscribe(conn, sub_params);
+			if (err != 0) {
+				(void)memset(sub_params, 0, sizeof(*sub_params));
+				LOG_ERR("Failed to subscribe to location: %d", err);
+			}
 		}
 	}
 
@@ -4366,26 +4376,81 @@ static int unicast_client_pacs_location_discover(struct bt_conn *conn)
 	return bt_gatt_discover(conn, &client->disc_params);
 }
 
-static uint8_t unicast_client_pacs_context_read_func(struct bt_conn *conn, uint8_t err,
-						     struct bt_gatt_read_params *read,
-						     const void *data, uint16_t length)
+static void unicast_client_notify_supp_contexts(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+						enum bt_audio_context src_ctx)
 {
+	struct bt_bap_unicast_client_cb *listener, *next;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next, _node) {
+		if (listener->supported_contexts != NULL) {
+			listener->supported_contexts(conn, snk_ctx, src_ctx);
+		}
+	}
+}
+
+static uint8_t unicast_client_pacs_supp_ctx_notify_cb(struct bt_conn *conn,
+						      struct bt_gatt_subscribe_params *params,
+						      const void *data, uint16_t length)
+{
+	struct bt_pacs_context context;
 	struct net_buf_simple buf;
-	struct bt_pacs_context *context;
+
+	LOG_DBG("conn %p len %u", conn, length);
+
+	if (data == NULL) {
+		LOG_DBG("Unsubscribed");
+		params->value_handle = BAP_HANDLE_UNUSED;
+		return BT_GATT_ITER_STOP;
+	}
+
+	if (length != sizeof(context)) {
+		LOG_ERR("Supported context notification incorrect size: %u", length);
+		return BT_GATT_ITER_STOP;
+	}
+
+	net_buf_simple_init_with_data(&buf, (void *)data, length);
+	context.snk = net_buf_simple_pull_le16(&buf);
+	context.src = net_buf_simple_pull_le16(&buf);
+
+	LOG_DBG("sink context %u, source context %u", context.snk, context.src);
+
+	unicast_client_notify_supp_contexts(conn, context.snk, context.src);
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static uint8_t unicast_client_pacs_supp_context_read_func(struct bt_conn *conn, uint8_t err,
+							  struct bt_gatt_read_params *read,
+							  const void *data, uint16_t length)
+{
+	struct bt_pacs_context context;
+	struct net_buf_simple buf;
 	int cb_err;
 
 	memset(read, 0, sizeof(*read));
 
 	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
 
-	if (err || length < sizeof(uint16_t) * 2) {
-		goto discover_loc;
+	if (err || data == NULL || length != sizeof(context)) {
+		LOG_DBG("Could not read supported context: %d, %p, %u", err, data, length);
+
+		if (err == BT_ATT_ERR_SUCCESS) {
+			err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
+		}
+
+		unicast_client_discover_complete(conn, err);
+
+		return BT_GATT_ITER_STOP;
 	}
 
 	net_buf_simple_init_with_data(&buf, (void *)data, length);
-	context = net_buf_simple_pull_mem(&buf, sizeof(*context));
+	context.snk = net_buf_simple_pull_le16(&buf);
+	context.src = net_buf_simple_pull_le16(&buf);
 
-discover_loc:
+	LOG_DBG("sink context %u, source context %u", context.snk, context.src);
+
+	unicast_client_notify_supp_contexts(conn, context.snk, context.src);
+
 	/* Read ASE instances */
 	cb_err = unicast_client_pacs_location_discover(conn);
 	if (cb_err != 0) {
@@ -4397,17 +4462,31 @@ discover_loc:
 	return BT_GATT_ITER_STOP;
 }
 
-static uint8_t unicast_client_pacs_context_discover_cb(struct bt_conn *conn,
-						       const struct bt_gatt_attr *attr,
-						       struct bt_gatt_discover_params *discover)
+static int unicast_client_pacs_supp_ctx_read(struct bt_conn *conn, uint16_t handle)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
-	struct bt_gatt_chrc *chrc;
+
+	LOG_DBG("conn %p", conn);
+
+	client->read_params.func = unicast_client_pacs_supp_context_read_func;
+	client->read_params.handle_count = 1U;
+	client->read_params.single.handle = handle;
+	client->read_params.single.offset = 0U;
+
+	return bt_gatt_read(conn, &client->read_params);
+}
+
+static uint8_t
+unicast_client_pacs_supp_context_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+					     struct bt_gatt_discover_params *discover)
+{
+	const struct bt_gatt_chrc *chrc;
+	uint8_t chrc_properties;
 	uint16_t value_handle;
 	int err;
 
 	if (attr == NULL) {
-		LOG_ERR("Unable to find %s PAC context", bt_audio_dir_str(client->dir));
+		LOG_ERR("Unable to find supported PAC context");
 
 		unicast_client_discover_complete(conn, BT_ATT_ERR_ATTRIBUTE_NOT_FOUND);
 
@@ -4415,22 +4494,44 @@ static uint8_t unicast_client_pacs_context_discover_cb(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
+	chrc_properties = chrc->properties;
 	value_handle = chrc->value_handle;
 	memset(discover, 0, sizeof(*discover));
 
-	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
-		bt_audio_dir_str(client->dir));
+	LOG_DBG("conn %p attr %p handle 0x%04x", conn, attr, value_handle);
 
-	/* TODO: Subscribe to PAC context */
+	/* Supported contexts are optionally notifiable */
+	if ((chrc_properties & BT_GATT_CHRC_NOTIFY) != 0U) {
+		const uint8_t conn_index = bt_conn_index(conn);
+		struct bt_gatt_subscribe_params *sub_params;
 
-	client->read_params.func = unicast_client_pacs_context_read_func;
-	client->read_params.handle_count = 1U;
-	client->read_params.single.handle = value_handle;
-	client->read_params.single.offset = 0U;
+		sub_params = &uni_cli_insts[conn_index].supp_ctx_subscribe;
 
-	err = bt_gatt_read(conn, &client->read_params);
+		if (sub_params->value_handle == 0) {
+			LOG_DBG("Subscribing to handle %u", value_handle);
+			sub_params->value_handle = value_handle;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
+			sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+			sub_params->disc_params = &uni_cli_insts[conn_index].supp_ctx_cc_disc;
+			sub_params->notify = unicast_client_pacs_supp_ctx_notify_cb;
+			sub_params->value = BT_GATT_CCC_NOTIFY;
+			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+
+			err = bt_gatt_subscribe(conn, sub_params);
+			if (err != 0) {
+				(void)memset(sub_params, 0, sizeof(*sub_params));
+				LOG_DBG("Failed to subscribe to supp_ctx: %d", err);
+
+				unicast_client_discover_complete(conn, err);
+
+				return BT_GATT_ITER_STOP;
+			}
+		} /* else already subscribed */
+	}
+
+	err = unicast_client_pacs_supp_ctx_read(conn, value_handle);
 	if (err != 0) {
-		LOG_DBG("Failed to read PAC records: %d", err);
+		LOG_DBG("Failed to read supported contexts: %d", err);
 
 		unicast_client_discover_complete(conn, err);
 	}
@@ -4438,14 +4539,14 @@ static uint8_t unicast_client_pacs_context_discover_cb(struct bt_conn *conn,
 	return BT_GATT_ITER_STOP;
 }
 
-static int unicast_client_pacs_context_discover(struct bt_conn *conn)
+static int unicast_client_pacs_supp_context_discover(struct bt_conn *conn)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 
 	LOG_DBG("conn %p", conn);
 
-	client->disc_params.uuid = pacs_context_uuid;
-	client->disc_params.func = unicast_client_pacs_context_discover_cb;
+	client->disc_params.uuid = pacs_supp_context_uuid;
+	client->disc_params.func = unicast_client_pacs_supp_context_discover_cb;
 	client->disc_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 	client->disc_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	client->disc_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
@@ -4574,7 +4675,7 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 	}
 
 	/* Read PACS contexts */
-	cb_err = unicast_client_pacs_context_discover(conn);
+	cb_err = unicast_client_pacs_supp_context_discover(conn);
 	if (cb_err != 0) {
 		LOG_ERR("Unable to read PACS context: %d", cb_err);
 		goto fail;

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -954,11 +954,17 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	bt_shell_print("dir %u loc %X\n", dir, loc);
 }
 
+static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	bt_shell_print("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
-	bt_shell_print("snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	bt_shell_print("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
 static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
@@ -1023,6 +1029,7 @@ static void release_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code r
 
 static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.location = unicast_client_location_cb,
+	.supported_contexts = supported_contexts_cb,
 	.available_contexts = available_contexts_cb,
 	.config = config_cb,
 	.qos = qos_cb,

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -857,11 +857,18 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	LOG_DBG("dir %u loc %X", dir, loc);
 }
 
+static void unicast_client_supported_contexts_cb(struct bt_conn *conn,
+						 enum bt_audio_context snk_ctx,
+						 enum bt_audio_context src_ctx)
+{
+	LOG_DBG("Supported snk ctx %u src ctx %u", snk_ctx, src_ctx);
+}
+
 static void unicast_client_available_contexts_cb(struct bt_conn *conn,
 						 enum bt_audio_context snk_ctx,
 						 enum bt_audio_context src_ctx)
 {
-	LOG_DBG("snk ctx %u src ctx %u", snk_ctx, src_ctx);
+	LOG_DBG("Available snk ctx %u src ctx %u", snk_ctx, src_ctx);
 }
 
 static void unicast_client_config_cb(struct bt_bap_stream *stream,
@@ -1082,6 +1089,7 @@ static struct bt_bap_unicast_server_register_param param = {
 
 static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.location = unicast_client_location_cb,
+	.supported_contexts = unicast_client_supported_contexts_cb,
 	.available_contexts = unicast_client_available_contexts_cb,
 	.config = unicast_client_config_cb,
 	.qos = unicast_client_qos_cb,

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -196,13 +196,18 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	printk("dir %u loc %X\n", dir, loc);
 }
 
+static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
-	printk("snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
-
 
 static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		      enum bt_bap_ascs_reason reason)
@@ -362,6 +367,7 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 
 static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.location = unicast_client_location_cb,
+	.supported_contexts = supported_contexts_cb,
 	.available_contexts = available_contexts_cb,
 	.config = config_cb,
 	.qos = qos_cb,

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -42,6 +42,10 @@ extern enum bst_result_t bst_result;
 static struct audio_test_stream test_streams[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_ep *g_sinks[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_ep *g_sources[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
+static enum bt_audio_context cached_avail_snk_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
+static enum bt_audio_context cached_avail_src_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
+static enum bt_audio_context cached_supp_snk_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
+static enum bt_audio_context cached_supp_src_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
 
 static struct bt_bap_unicast_group_stream_pair_param pair_params[ARRAY_SIZE(test_streams)];
 static struct bt_bap_unicast_group_stream_param stream_params[ARRAY_SIZE(test_streams)];
@@ -66,6 +70,10 @@ CREATE_FLAG(flag_stream_disabled);
 CREATE_FLAG(flag_stream_stopped);
 CREATE_FLAG(flag_stream_released);
 CREATE_FLAG(flag_operation_success);
+CREATE_FLAG(flag_sink_avail_ctx_changed);
+CREATE_FLAG(flag_sink_supp_ctx_changed);
+CREATE_FLAG(flag_source_avail_ctx_changed);
+CREATE_FLAG(flag_source_supp_ctx_changed);
 
 static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
 {
@@ -200,6 +208,17 @@ static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context sn
 				  enum bt_audio_context src_ctx)
 {
 	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	printk("cached %d %d\n", cached_supp_snk_ctx, cached_supp_src_ctx);
+
+	if (snk_ctx != cached_supp_snk_ctx) {
+		cached_supp_snk_ctx = snk_ctx;
+		SET_FLAG(flag_sink_supp_ctx_changed);
+	}
+
+	if (src_ctx != cached_supp_src_ctx) {
+		cached_supp_src_ctx = src_ctx;
+		SET_FLAG(flag_source_supp_ctx_changed);
+	}
 }
 
 static void available_contexts_cb(struct bt_conn *conn,
@@ -207,6 +226,17 @@ static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context src_ctx)
 {
 	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+	printk("cached %d %d\n", cached_avail_snk_ctx, cached_avail_src_ctx);
+
+	if (snk_ctx != cached_avail_snk_ctx) {
+		cached_avail_snk_ctx = snk_ctx;
+		SET_FLAG(flag_sink_avail_ctx_changed);
+	}
+
+	if (src_ctx != cached_avail_src_ctx) {
+		cached_avail_src_ctx = src_ctx;
+		SET_FLAG(flag_source_avail_ctx_changed);
+	}
 }
 
 static void config_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
@@ -564,9 +594,15 @@ static void discover_sinks(void)
 
 	unicast_client_cbs.discover = discover_sinks_cb;
 
+	UNSET_FLAG(flag_sink_avail_ctx_changed);
+	UNSET_FLAG(flag_sink_supp_ctx_changed);
 	UNSET_FLAG(flag_codec_cap_found);
 	UNSET_FLAG(flag_sink_discovered);
 	UNSET_FLAG(flag_endpoint_found);
+
+	(void)memset(g_sinks, 0, sizeof(g_sinks));
+	cached_avail_snk_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
+	cached_supp_snk_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
 
 	err = bt_bap_unicast_client_discover(default_conn, BT_AUDIO_DIR_SINK);
 	if (err != 0) {
@@ -574,10 +610,11 @@ static void discover_sinks(void)
 		return;
 	}
 
-	memset(g_sinks, 0, sizeof(g_sinks));
-
 	WAIT_FOR_FLAG(flag_codec_cap_found);
 	WAIT_FOR_FLAG(flag_endpoint_found);
+
+	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
+	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_discovered);
 }
 
@@ -587,8 +624,14 @@ static void discover_sources(void)
 
 	unicast_client_cbs.discover = discover_sources_cb;
 
+	UNSET_FLAG(flag_source_avail_ctx_changed);
+	UNSET_FLAG(flag_source_supp_ctx_changed);
 	UNSET_FLAG(flag_codec_cap_found);
 	UNSET_FLAG(flag_source_discovered);
+
+	(void)memset(g_sources, 0, sizeof(g_sources));
+	cached_avail_src_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
+	cached_supp_src_ctx = BT_AUDIO_CONTEXT_TYPE_NONE;
 
 	err = bt_bap_unicast_client_discover(default_conn, BT_AUDIO_DIR_SOURCE);
 	if (err != 0) {
@@ -596,8 +639,8 @@ static void discover_sources(void)
 		return;
 	}
 
-	memset(g_sources, 0, sizeof(g_sources));
-
+	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
+	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_codec_cap_found);
 	WAIT_FOR_FLAG(flag_source_discovered);
 }
@@ -1074,6 +1117,18 @@ static void test_main(void)
 
 	discover_sources();
 	discover_sources(); /* test that we can discover twice */
+
+	/* Send signal to trigger a change to context types on the unicast server */
+	UNSET_FLAG(flag_sink_avail_ctx_changed);
+	UNSET_FLAG(flag_sink_supp_ctx_changed);
+	UNSET_FLAG(flag_source_avail_ctx_changed);
+	UNSET_FLAG(flag_source_supp_ctx_changed);
+	backchannel_sync_send_all();
+
+	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
+	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
+	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
+	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
 
 	/* Run the stream setup multiple time to ensure states are properly
 	 * set and reset

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/pacs.h>
@@ -384,41 +385,89 @@ static void set_location(void)
 	printk("Location successfully set\n");
 }
 
-static void set_available_contexts(void)
+static void set_contexts(void)
 {
 	int err;
 
-	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK,
-					     BT_AUDIO_CONTEXT_TYPE_MEDIA |
-						     BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL);
-	if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
-		FAIL("Failed to set sink supported contexts (err %d)\n", err);
-		return;
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
+		const enum bt_audio_context sink_ctx =
+			BT_AUDIO_CONTEXT_TYPE_MEDIA | BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL;
+
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, sink_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
+			FAIL("Failed to set sink supported contexts (err %d)\n", err);
+			return;
+		}
+
+		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, sink_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
+			FAIL("Failed to set sink available contexts (err %d)\n", err);
+			return;
+		}
 	}
 
-	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK,
-					     BT_AUDIO_CONTEXT_TYPE_MEDIA |
-						     BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL);
-	if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
-		FAIL("Failed to set sink available contexts (err %d)\n", err);
-		return;
+	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
+		const enum bt_audio_context source_ctx = BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS;
+
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, source_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SRC) && err != 0) {
+			FAIL("Failed to set source supported contexts (err %d)\n", err);
+			return;
+		}
+
+		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, source_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SRC) && err != 0) {
+			FAIL("Failed to set source available contexts (err %d)\n", err);
+			return;
+		}
 	}
 
-	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE,
-					     BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS);
-	if (IS_ENABLED(CONFIG_BT_PAC_SRC) && err != 0) {
-		FAIL("Failed to set source supported contexts (err %d)\n", err);
-		return;
+	printk("Contexts successfully set\n");
+}
+
+static void update_contexts(void)
+{
+	int err;
+
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
+		/* Shift contexts by one to ensure a new value */
+		const enum bt_audio_context sink_ctx =
+			(bt_pacs_get_available_contexts(BT_AUDIO_DIR_SINK) << 1U) &
+			BT_AUDIO_CONTEXT_TYPE_ANY;
+
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, sink_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
+			FAIL("Failed to set sink supported contexts (err %d)\n", err);
+			return;
+		}
+
+		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, sink_ctx);
+		if (IS_ENABLED(CONFIG_BT_PAC_SNK) && err != 0) {
+			FAIL("Failed to set sink available contexts (err %d)\n", err);
+			return;
+		}
 	}
 
-	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE,
-					     BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS);
-	if (IS_ENABLED(CONFIG_BT_PAC_SRC) && err != 0) {
-		FAIL("Failed to set source available contexts (err %d)\n", err);
-		return;
+	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
+		/* Shift contexts by one to ensure a new value */
+		const enum bt_audio_context source_ctx =
+			(bt_pacs_get_available_contexts(BT_AUDIO_DIR_SOURCE) << 1U) &
+			BT_AUDIO_CONTEXT_TYPE_ANY;
+
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, source_ctx);
+		if (err != 0) {
+			FAIL("Failed to set source supported contexts (err %d)\n", err);
+			return;
+		}
+
+		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, source_ctx);
+		if (err != 0) {
+			FAIL("Failed to set source available contexts (err %d)\n", err);
+			return;
+		}
 	}
 
-	printk("Available contexts successfully set\n");
+	printk("Contexts successfully updated\n");
 }
 
 static void init(void)
@@ -480,7 +529,7 @@ static void init(void)
 	}
 
 	set_location();
-	set_available_contexts();
+	set_contexts();
 
 	for (size_t i = 0; i < ARRAY_SIZE(test_streams); i++) {
 		bt_bap_stream_cb_register(bap_stream_from_audio_test_stream(&test_streams[i]),
@@ -517,11 +566,13 @@ static void test_main(void)
 {
 	init();
 
-	/* TODO: When babblesim supports ISO, wait for audio stream to pass */
-
 	WAIT_FOR_FLAG(flag_connected);
-	WAIT_FOR_FLAG(flag_stream_configured);
 
+	/* Wait for signal to trigger context type changes */
+	backchannel_sync_wait_any();
+	update_contexts();
+
+	WAIT_FOR_FLAG(flag_stream_configured);
 
 	WAIT_FOR_FLAG(flag_stream_started);
 	transceive_test_streams();


### PR DESCRIPTION
The supported contexts were read but never provided to the
upper layers. Additionally if the supported contexts are
notifible we also subscribe to it.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/94352