### PR TITLE
kernel/timeout: unify timer driver and kernel locking to fix SMP race

### DIFF
--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -230,6 +230,33 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+Timer Driver Locking
+--------------------
+
+The kernel exposes a unified timer lock via :c:func:`sys_clock_lock` and
+:c:func:`sys_clock_unlock`.  This lock protects both the kernel's internal
+tick accounting (``curr_tick``, the timeout queue) and any driver-private
+state that must be consistent with it (e.g. a hardware cycle counter
+baseline).
+
+Timer drivers that maintain internal state should acquire this lock at
+the start of their ISR, update their hardware state, then pass the lock
+key to :c:func:`sys_clock_announce_locked` which consumes it.  This
+ensures that the driver's cycle counter baseline and the kernel's
+``curr_tick`` are always updated under the same lock, eliminating race
+conditions that can arise on SMP systems (or, less commonly, on UP
+systems where higher-priority ISRs need consistent realtime references)
+when two separate locks are used.
+
+The driver-provided callbacks :c:func:`sys_clock_set_timeout` and
+:c:func:`sys_clock_elapsed` are always invoked by the kernel with this
+lock already held.
+
+For backward compatibility, :c:func:`sys_clock_announce` remains
+available and acquires the lock internally.  New and migrated drivers
+should prefer the :c:func:`sys_clock_lock` /
+:c:func:`sys_clock_announce_locked` pattern.
+
 Note that a natural implementation of this API results in a "tickless"
 kernel, which receives and processes timer interrupts only for
 registered events, relying on programmable hardware counters to

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -9,7 +9,6 @@
 #include <zephyr/arch/x86/cpuid.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <zephyr/irq.h>
 
@@ -87,7 +86,6 @@ struct apic_timer_lvt {
 	uint32_t unused2 : 13;
 };
 
-static struct k_spinlock lock;
 static uint64_t last_cycle;
 static uint64_t last_tick;
 static uint32_t last_elapsed;
@@ -129,7 +127,7 @@ static void isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 	uint64_t curr_cycle = rdtsc();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
 	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
@@ -144,8 +142,7 @@ static void isr(const void *arg)
 		set_trigger(next_cycle);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(delta_ticks);
+	sys_clock_announce_locked(delta_ticks, key);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -156,7 +153,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t next_cycle;
 
 	if (ticks == K_TICKS_FOREVER) {
@@ -180,8 +176,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		next_cycle = UINT64_MAX;
 	}
 	set_trigger(next_cycle);
-
-	k_spin_unlock(&lock, key);
 }
 
 uint32_t sys_clock_elapsed(void)
@@ -190,13 +184,11 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t curr_cycle = rdtsc();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
 	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
-	k_spin_unlock(&lock, key);
 	return delta_ticks;
 }
 

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/arch/cpu.h>
 
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
@@ -62,7 +61,6 @@ static uint64_t cycles_max;
 #define CYCLES_MAX CYCLES_MAX_5
 #endif
 
-static struct k_spinlock lock;
 static uint64_t last_cycle;
 static uint64_t last_tick;
 static uint32_t last_elapsed;
@@ -75,7 +73,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 #ifdef CONFIG_ARM_ARCH_TIMER_ERRATUM_740657
 	/*
@@ -90,7 +88,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 		 * DO NOT modify the compare register's value, DO NOT announce
 		 * elapsed ticks!
 		 */
-		k_spin_unlock(&lock, key);
+		sys_clock_unlock(key);
 		return;
 	}
 #endif /* CONFIG_ARM_ARCH_TIMER_ERRATUM_740657 */
@@ -133,9 +131,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	}
 #endif /* CONFIG_ARM_ARCH_TIMER_ERRATUM_740657 */
 
-	k_spin_unlock(&lock, key);
-
-	sys_clock_announce(delta_ticks);
+	sys_clock_announce_locked(delta_ticks, key);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -148,7 +144,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t next_cycle;
 
 	if (ticks == K_TICKS_FOREVER) {
@@ -162,7 +157,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	arm_arch_timer_set_compare(next_cycle);
 	arm_arch_timer_set_irq_mask(false);
-	k_spin_unlock(&lock, key);
 }
 
 uint32_t sys_clock_elapsed(void)
@@ -171,13 +165,11 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t curr_cycle = arm_arch_timer_count();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
 	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_elapsed = delta_ticks;
-	k_spin_unlock(&lock, key);
 	return delta_ticks;
 }
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -8,7 +8,6 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/sections.h>
 
@@ -232,7 +231,6 @@ __WARN("HPET_INT_LEVEL_TRIGGER has no effect, DTS setting is used instead")
 #endif
 #endif /* (DT_INST_IRQ_HAS_CELL(0, sense)) */
 
-static __pinned_bss struct k_spinlock lock;
 static __pinned_bss uint64_t last_count;
 static __pinned_bss uint64_t last_tick;
 static __pinned_bss uint32_t last_elapsed;
@@ -284,7 +282,7 @@ static void hpet_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t now = hpet_counter_get();
 
@@ -322,8 +320,7 @@ static void hpet_isr(const void *arg)
 		hpet_timer_comparator_set_safe(next);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 
 __pinned_func
@@ -373,11 +370,9 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ticks = ticks == K_TICKS_FOREVER ? HPET_MAX_TICKS : ticks;
 	ticks = CLAMP(ticks, 0, HPET_MAX_TICKS/2);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 
 	hpet_timer_comparator_set_safe(cyc);
-	k_spin_unlock(&lock, key);
 #endif
 }
 
@@ -388,12 +383,10 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = hpet_counter_get();
 	uint32_t ret = (uint32_t)((now - last_count) / cyc_per_tick);
 
 	last_elapsed = ret;
-	k_spin_unlock(&lock, key);
 	return ret;
 }
 

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -6,7 +6,6 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/dw_ace.h>
 
 #include <cavs-idc.h>
@@ -44,7 +43,6 @@ BUILD_ASSERT(COMPARATOR_IDX >= 0 && COMPARATOR_IDX <= 1);
 
 #define DSP_WCT_CS_TT(x)                     BIT(4 + x)
 
-static struct k_spinlock lock;
 static uint64_t last_count;
 
 /* Not using current syscon driver due to overhead due to MMU support */
@@ -106,7 +104,7 @@ static void compare_isr(const void *arg)
 	uint64_t curr;
 	uint64_t dticks;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	curr = count();
 	dticks = (curr - last_count) / CYC_PER_TICK;
@@ -126,9 +124,7 @@ static void compare_isr(const void *arg)
 	set_compare(next);
 #endif
 
-	k_spin_unlock(&lock, key);
-
-	sys_clock_announce((int32_t)dticks);
+	sys_clock_announce_locked((int32_t)dticks, key);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -139,7 +135,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t curr = count();
 	uint64_t next;
 	uint32_t adj, cyc = ticks * CYC_PER_TICK;
@@ -159,7 +154,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	set_compare(next);
-	k_spin_unlock(&lock, key);
 #endif
 }
 
@@ -168,10 +162,8 @@ uint32_t sys_clock_elapsed(void)
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t ret = (count() - last_count) / CYC_PER_TICK;
 
-	k_spin_unlock(&lock, key);
 	return (uint32_t)ret;
 }
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -11,7 +11,6 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT riscv_machine_timer
@@ -51,7 +50,6 @@
 #define CYCLES_MAX_4 (CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
 #define CYCLES_MAX   (CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
 
-static struct k_spinlock lock;
 static uint64_t last_count;
 static uint64_t last_ticks;
 static uint32_t last_elapsed;
@@ -106,7 +104,7 @@ static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t now = mtime();
 	uint64_t dcycles = now - last_count;
@@ -122,8 +120,7 @@ static void timer_isr(const void *arg)
 		set_mtimecmp(next);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -134,7 +131,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t cyc;
 
 	if (ticks == K_TICKS_FOREVER) {
@@ -146,8 +142,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		}
 	}
 	set_mtimecmp(cyc);
-
-	k_spin_unlock(&lock, key);
 }
 
 uint32_t sys_clock_elapsed(void)
@@ -156,13 +150,11 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = mtime();
 	uint64_t dcycles = now - last_count;
 	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
 
 	last_elapsed = dticks;
-	k_spin_unlock(&lock, key);
 	return dticks;
 }
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -7,7 +7,6 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 
 #include "xtensa_sys_timer.h"
@@ -21,7 +20,6 @@
 #define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000
 
-static struct k_spinlock lock;
 static unsigned int last_count;
 
 #if defined(CONFIG_TEST)
@@ -70,7 +68,7 @@ static void ccompare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint32_t curr = ccount();
 	uint32_t dticks = sys_clock_elapsed_ticks(curr);
@@ -84,8 +82,7 @@ static void ccompare_isr(const void *arg)
 		set_ccompare(next - ccount_comp());
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1);
+	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -94,7 +91,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t curr = ccount(), cyc, adj;
 
 	/* Round up to next tick boundary */
@@ -129,7 +125,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		ARG_UNUSED(idle);
 	}
 
-	k_spin_unlock(&lock, key);
 #endif
 }
 
@@ -139,11 +134,7 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = (ccount() - last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ret;
+	return (ccount() - last_count) / CYC_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -167,7 +158,7 @@ void sys_clock_idle_exit(void)
 			return;
 		}
 
-		k_spinlock_key_t key = k_spin_lock(&lock);
+		k_spinlock_key_t key = sys_clock_lock();
 
 		uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
 		uint64_t ccount_now = ccount();
@@ -188,10 +179,8 @@ void sys_clock_idle_exit(void)
 
 		timeout_idle = false;
 
-		k_spin_unlock(&lock, key);
-
 		/* Announce corrected ticks as CCOUNT remained stalled during LPM */
-		sys_clock_announce(dticks);
+		sys_clock_announce_locked(dticks, key);
 	}
 }
 

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -35,8 +35,6 @@
 #include <zephyr/arch/xtensa/thread_stack.h>
 #include <zephyr/sys/slist.h>
 
-#include <zephyr/drivers/timer/system_timer.h>
-
 #ifdef CONFIG_XTENSA_MMU
 #include <zephyr/arch/xtensa/xtensa_mmu.h>
 #endif
@@ -137,6 +135,11 @@ void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
 	{ \
 		Z_ISR_DECLARE(irq_p, flags_p, isr_p, isr_param_p); \
 	}
+
+/** @cond INTERNAL_HIDDEN */
+extern uint32_t sys_clock_cycle_get_32(void);
+extern uint64_t sys_clock_cycle_get_64(void);
+/** @endcond */
 
 /** Implementation of @ref arch_k_cycle_get_32. */
 static inline uint32_t arch_k_cycle_get_32(void)

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <zephyr/types.h>
+#include <zephyr/spinlock.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +31,83 @@ extern "C" {
  * @defgroup clock_apis System Clock APIs
  * @{
  */
+
+/**
+ * @brief Lock the system clock.
+ *
+ * Acquires the kernel timer lock that protects tick accounting and
+ * the timeout queue.  Timer drivers should call this at the start of
+ * their ISR and pass the returned key to sys_clock_announce_locked()
+ * which consumes it.  The lock is released when
+ * sys_clock_announce_locked() returns.
+ *
+ * The driver-provided functions sys_clock_set_timeout() and
+ * sys_clock_elapsed() are always called by the kernel with this lock
+ * already held.
+ *
+ * Example usage from a timer ISR:
+ *
+ * @code{.c}
+ * static void timer_isr(const void *arg)
+ * {
+ *     k_spinlock_key_t key = sys_clock_lock();
+ *
+ *     // Update driver-private state (e.g. cycle counter baseline)
+ *     uint64_t now = read_hw_counter();
+ *     uint32_t dticks = (now - last_cycle) / CYC_PER_TICK;
+ *     last_cycle += (uint64_t)dticks * CYC_PER_TICK;
+ *
+ *     // Reprogram comparator if needed ...
+ *
+ *     // Announce ticks — key ownership transfers to announce.
+ *     sys_clock_announce_locked(dticks, key);
+ * }
+ * @endcode
+ *
+ * @return Lock key to be passed to sys_clock_announce_locked()
+ *         or sys_clock_unlock().
+ */
+#if defined(CONFIG_SMP) || defined(CONFIG_SPIN_VALIDATE)
+k_spinlock_key_t sys_clock_lock(void);
+#else
+/*
+ * When actual spinlocks are not needed (UP without CONFIG_SPIN_VALIDATE),
+ * k_spin_lock() reduces to arch_irq_lock() and the lock argument is
+ * ignored.  Inline this to avoid the overhead of an extra function
+ * call for legacy drivers using sys_clock_announce().
+ */
+static inline k_spinlock_key_t sys_clock_lock(void)
+{
+	k_spinlock_key_t key;
+
+	/* If this fires, a new config grew real spinlock content and
+	 * the #if guard above needs updating.
+	 */
+	BUILD_ASSERT(sizeof(struct k_spinlock) <= 1);
+
+	key.key = arch_irq_lock();
+	return key;
+}
+#endif
+
+/**
+ * @brief Unlock the system clock.
+ *
+ * Releases the kernel timer lock previously acquired with
+ * sys_clock_lock().  Provided for drivers with special needs;
+ * most drivers should use sys_clock_announce_locked() which
+ * handles unlocking automatically.
+ *
+ * @param key Lock key returned by sys_clock_lock().
+ */
+#if defined(CONFIG_SMP) || defined(CONFIG_SPIN_VALIDATE)
+void sys_clock_unlock(k_spinlock_key_t key);
+#else
+static inline void sys_clock_unlock(k_spinlock_key_t key)
+{
+	arch_irq_unlock(key.key);
+}
+#endif
 
 /**
  * @brief Set system clock timeout
@@ -69,6 +147,9 @@ extern "C" {
  * really) attempt to serialize things by "assigning" timeouts to
  * specific CPUs.
  *
+ * @note This function is called by the kernel with the system clock
+ * lock held.
+ *
  * @param ticks Timeout in tick units
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
@@ -94,13 +175,37 @@ void sys_clock_idle_exit(void);
  *
  * Informs the kernel that the specified number of ticks have elapsed
  * since the last call to sys_clock_announce() (or system startup for
- * the first call).  The timer driver is expected to delivery these
+ * the first call).  The timer driver is expected to deliver these
  * announcements as close as practical (subject to hardware and
  * latency limitations) to tick boundaries.
  *
+ * The caller must already hold the system clock lock obtained via
+ * sys_clock_lock().  The key is consumed: the lock is released when
+ * this function returns.
+ *
+ * This is the preferred interface for timer ISRs that need to update
+ * driver-internal state (e.g. cycle counter baseline) atomically with
+ * the kernel tick accounting.  See sys_clock_lock() for example usage.
+ *
+ * @param ticks Elapsed time, in ticks
+ * @param key Lock key obtained from sys_clock_lock().
+ */
+void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
+
+/**
+ * @brief Announce time progress to the kernel (legacy wrapper)
+ *
+ * Convenience wrapper around @ref sys_clock_announce_locked that
+ * acquires the system clock lock internally.  New drivers should
+ * prefer sys_clock_lock() + sys_clock_announce_locked() to protect
+ * driver state and tick accounting under a single lock.
+ *
  * @param ticks Elapsed time, in ticks
  */
-void sys_clock_announce(int32_t ticks);
+static inline void sys_clock_announce(int32_t ticks)
+{
+	sys_clock_announce_locked(ticks, sys_clock_lock());
+}
 
 /**
  * @brief Ticks elapsed since last sys_clock_announce() call
@@ -109,6 +214,9 @@ void sys_clock_announce(int32_t ticks);
  * last call to sys_clock_announce() was made.  The kernel will call
  * this with appropriate locking, the driver needs only provide an
  * instantaneous answer.
+ *
+ * @note This function is called by the kernel with the system clock
+ * lock held.
  */
 uint32_t sys_clock_elapsed(void);
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -218,10 +218,8 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void sys_clock_announce(int32_t ticks)
+void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 {
-	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
-
 	/* We release the lock around the callbacks below, so on SMP
 	 * systems someone might be already running the loop.  Don't
 	 * race (which will cause parallel execution of "sequential"
@@ -268,6 +266,18 @@ void sys_clock_announce(int32_t ticks)
 	z_time_slice();
 #endif /* CONFIG_TIMESLICING */
 }
+
+#if defined(CONFIG_SMP) || defined(CONFIG_SPIN_VALIDATE)
+k_spinlock_key_t sys_clock_lock(void)
+{
+	return k_spin_lock(&timeout_lock);
+}
+
+void sys_clock_unlock(k_spinlock_key_t key)
+{
+	k_spin_unlock(&timeout_lock, key);
+}
+#endif
 
 int64_t sys_clock_tick_get(void)
 {

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -211,7 +211,12 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 		POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(rtc)));
 
-		sys_clock_set_timeout(0, true);
+		{
+			k_spinlock_key_t key = sys_clock_lock();
+
+			sys_clock_set_timeout(0, true);
+			sys_clock_unlock(key);
+		}
 
 		if (POWER_EnterPowerMode(POWER_MODE3, &slp_cfg)) {
 			/* Go back to PM Mode 3 if RTC wakeup is to be ignored.*/
@@ -227,7 +232,12 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 #endif
 				NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(rtc)));
 				sys_clock_idle_exit();
-				sys_clock_set_timeout(0, true);
+				{
+					k_spinlock_key_t key = sys_clock_lock();
+
+					sys_clock_set_timeout(0, true);
+					sys_clock_unlock(key);
+				}
 				/* GDET got enabled when exiting PM3, disable it
 				 * again before re-entering PM3.
 				 */

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -220,7 +220,10 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 * is not passed as the next timeout.
 		 *
 		 */
+		k_spinlock_key_t key = sys_clock_lock();
+
 		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_unlock(key);
 	}
 
 	/*

--- a/subsys/shell/modules/kernel_service/thread/list.c
+++ b/subsys/shell/modules/kernel_service/thread/list.c
@@ -112,7 +112,11 @@ static int cmd_kernel_thread_list(const struct shell *sh, size_t argc, char **ar
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(sh, "Scheduler: %u since last call", sys_clock_elapsed());
+	k_spinlock_key_t key = sys_clock_lock();
+	uint32_t elapsed = sys_clock_elapsed();
+
+	sys_clock_unlock(key);
+	shell_print(sh, "Scheduler: %u since last call", elapsed);
 	shell_print(sh, "Threads:");
 
 	/*


### PR DESCRIPTION
# PR: kernel/timeout: unify timer driver and kernel locking to fix SMP race

## The problem

On SMP systems with tickless kernels, there is a race condition between
the timer driver ISR and the kernel's tick accounting that affects every
code path using the internal `elapsed()` helper in `kernel/timeout.c`.

The kernel computes elapsed time as:

    curr_tick + elapsed()

where `curr_tick` is maintained by the kernel in `kernel/timeout.c`
under `timeout_lock`, and `elapsed()` calls the driver-provided
`sys_clock_elapsed()` which computes time since the last ISR using
driver-internal state (e.g. `last_cycle`) protected by a separate,
driver-private spinlock.

### The two-lock race: step by step

Two locks are involved:
- **timeout_lock** (kernel) — protects `curr_tick`, `announce_remaining`,
  and the timeout list
- **driver lock** (timer driver) — protects `last_cycle` and comparator
  programming

The lock ordering is:
- `sys_clock_tick_get()`: **timeout_lock → driver lock** (holds
  timeout_lock, then calls `sys_clock_elapsed()` which takes driver lock)
- Timer ISR: **driver lock → (release) → timeout_lock** (holds driver
  lock, releases it, then `sys_clock_announce()` takes timeout_lock)

No ABBA deadlock because they are never nested in reverse. But the gap
in the ISR path — between releasing the driver lock and acquiring
timeout_lock — is where the race lives.

Consider the ARM arch timer and RISC-V machine timer drivers as
representative examples of drivers affected by this pattern:

**Initial state:** `curr_tick = 100`, `last_cycle` corresponds to tick 100,
hardware counter is at tick ~150.

| Step | CPU A (sys_clock_tick_get) | CPU B (timer ISR) |
|------|---------------------------|-------------------|
| 1 | | Lock **driver lock** |
| 2 | Lock **timeout_lock** | Read counter, compute `dticks = 50` |
| 3 | Read `curr_tick` = 100 | Advance `last_cycle` += 50 ticks |
| 4 | Call `elapsed()` → `sys_clock_elapsed()` | `last_elapsed = 0` |
| 5 | Try to lock **driver lock** → **spins** | Unlock **driver lock** |
| 6 | Get **driver lock** | Call `sys_clock_announce(50)` |
| 7 | Compute `(counter - new_last_cycle) / CYC = 2` | Try **timeout_lock** → **spins** |
| 8 | Unlock **driver lock**, return `elapsed = 2` | (still spinning) |
| 9 | **Return 100 + 2 = 102** | (still spinning) |
| 10 | Unlock **timeout_lock** | Get timeout_lock, `curr_tick += 50` → 150 |

Just before the ISR fired, `sys_clock_tick_get()` would have returned
`100 + 50 = 150` (old `curr_tick` + large elapsed). After the race, it
returns **102**. **Time went backwards by 48 ticks.**

The root cause: the ISR advances the driver's baseline (`last_cycle`)
before `sys_clock_announce()` advances the kernel's baseline (`curr_tick`).
In the gap between these two operations, `sys_clock_elapsed()` reports
elapsed time relative to the **new** driver baseline while `curr_tick`
still reflects the **old** kernel baseline. The announced ticks are
"lost" — neither reflected in `curr_tick` nor in `elapsed()`.

### Why the two-lock design exists

The driver lock and timeout_lock cannot simply be nested because
`sys_clock_set_timeout()` (called from within `sys_clock_announce()` via
`z_add_timeout()` and `z_abort_timeout()`) acquires the driver lock while
timeout_lock is held. If the ISR held the driver lock across announce,
this would create an ABBA deadlock:

- ISR: **driver lock → timeout_lock** (in announce)
- Kernel: **timeout_lock → driver lock** (in sys_clock_set_timeout)

This is why drivers release their private lock before calling
`sys_clock_announce()`, creating the race window.

## The fix: a single unified lock

The key observation: every time the driver lock is taken, timeout_lock
is either already held or is about to be taken immediately after.
The two locks always appear together — they protect state that must be
consistent with each other. Having two locks is the root cause of the
race, and merging them eliminates it entirely.

### Design

1. **Expose the kernel's timeout_lock to timer drivers** via new
   `sys_clock_lock()` / `sys_clock_unlock()` accessors.

2. **Introduce `sys_clock_announce_locked()`** which performs the
   announce with the lock already held, and takes ownership of the
   lock key (it handles unlock/relock around timeout callbacks and
   the final unlock). The existing `sys_clock_announce()` becomes a
   trivial wrapper for backward compatibility:

   ```c
   void sys_clock_announce(int32_t ticks)
   {
       sys_clock_announce_locked(ticks, sys_clock_lock());
   }
   ```

   This avoids a flag day: all existing drivers continue to work
   unmodified. Drivers can be migrated one at a time.

3. **Timer drivers use `sys_clock_lock()` instead of a private lock.**
   The ISR sequence becomes:

   ```c
   static void timer_isr(const void *arg)
   {
       k_spinlock_key_t key = sys_clock_lock();

       /* Update driver state — last_cycle, comparator, etc.
        * Both last_cycle and curr_tick are now under the SAME lock.
        */
       uint64_t now = arm_arch_timer_count();
       uint32_t dticks = (cycle_diff_t)(now - last_cycle) / CYC_PER_TICK;
       last_cycle += (cycle_diff_t)dticks * CYC_PER_TICK;
       ...

       /* No gap — announce runs under the same lock.
        * curr_tick is updated while last_cycle is still consistent.
        */
       sys_clock_announce_locked(dticks, key);
       /* key consumed — announce handled the final unlock */
   }
   ```

4. **`sys_clock_elapsed()` and `sys_clock_set_timeout()` need no
   locking** — they are always called from contexts that already hold
   timeout_lock (via `elapsed()`, `z_add_timeout()`, `z_abort_timeout()`,
   or `sys_clock_announce()` itself). Removing the private lock from
   these functions simplifies the driver.

### Why this doesn't increase lock contention

Every timer ISR today does:

    k_spin_lock(&driver_lock);
    ... update driver state ...
    k_spin_unlock(&driver_lock);
    /* immediately followed by: */
    sys_clock_announce(dticks);
        → k_spin_lock(&timeout_lock);
        ...

The two lock acquisitions are back-to-back. Replacing them with a
single `sys_clock_lock()` is strictly more efficient — one lock
operation instead of two per ISR, and no gap between them.

Similarly, `sys_clock_tick_get()` today does:

    K_SPINLOCK(&timeout_lock) {
        t = curr_tick + elapsed();
            → sys_clock_elapsed()
                → k_spin_lock(&driver_lock);
                ...
    }

Two nested lock acquisitions become one. The lock hold time is
unchanged (the same code runs), but there is less overhead.

## This series

This PR introduces the API and converts all SMP-capable timer drivers
that use a private spinlock: `arm_arch_timer`, `riscv_machine_timer`,
`xtensa_sys_timer`, `hpet`, `apic_tsc`, and `intel_adsp_timer`.

The `arcv2_timer0` driver also has an SMP path but uses non-standard
locking patterns (mixing `arch_irq_lock()` with spinlocks, separate
SMP/non-SMP ISR code paths). It is left unconverted and needs
attention from someone familiar with that driver.

Remaining non-SMP drivers continue to work via the backward-compatible
`sys_clock_announce()` wrapper and can be migrated incrementally.

## Related

- Issue: https://github.com/zephyrproject-rtos/zephyr/issues/105339
- PR #105340 identified the race but proposed an invasive kernel
  change (new global lock, modified `sys_clock_announce()` signature
  with undo-job lists). This series achieves the same correctness
  goal with a simpler approach: eliminating the two-lock design
  rather than adding a third lock.

Fixes #106315
