### PR TITLE
Bugfix/uart interrupt fixes mspm0

### DIFF
--- a/drivers/serial/uart_mspm0.c
+++ b/drivers/serial/uart_mspm0.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Texas Instruments
+ * Copyright (c) 2025-2026 Texas Instruments
  * Copyright (c) 2025 Linumiz
  * Copyright (c) 2025 Bang & Olufsen A/S, Denmark
  *
@@ -325,8 +325,8 @@ static int uart_mspm0_irq_tx_ready(const struct device *dev)
 	const struct uart_mspm0_config *config = dev->config;
 	struct uart_mspm0_data *data = dev->data;
 
-	return (data->pending_interrupt &
-		(DL_UART_MAIN_IIDX_TX | DL_UART_MAIN_IIDX_EOT_DONE))
+	return ((data->pending_interrupt == DL_UART_MAIN_IIDX_TX) ||
+			(data->pending_interrupt == DL_UART_MAIN_IIDX_EOT_DONE))
 		&& !DL_UART_Main_isTXFIFOFull(config->regs) ? 1 : 0;
 }
 
@@ -356,7 +356,7 @@ static int uart_mspm0_irq_rx_ready(const struct device *dev)
 	const struct uart_mspm0_config *config = dev->config;
 	struct uart_mspm0_data *data = dev->data;
 
-	return (data->pending_interrupt & DL_UART_MAIN_IIDX_RX) &&
+	return (data->pending_interrupt == DL_UART_MAIN_IIDX_RX) &&
 		!DL_UART_Main_isRXFIFOEmpty(config->regs) ? 1 : 0;
 }
 
@@ -409,21 +409,12 @@ static void uart_mspm0_irq_error_disable(const struct device *dev)
 
 static void uart_mspm0_isr(const struct device *dev)
 {
-	const struct uart_mspm0_config *config = dev->config;
 	struct uart_mspm0_data *const dev_data = dev->data;
-	uint32_t int_status;
 
 	/* Perform callback if defined */
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);
 	}
-
-	/* Unilaterally clearing the interrupt status */
-	int_status = DL_UART_Main_getEnabledInterruptStatus(config->regs,
-				UART_MSPM0_TX_INTERRUPTS | UART_MSPM0_RX_INTERRUPTS);
-	DL_UART_Main_clearInterruptStatus(config->regs, int_status);
-
-	dev_data->pending_interrupt = DL_UART_MAIN_IIDX_NO_INTERRUPT;
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_mspm0.c
+++ b/drivers/serial/uart_mspm0.c
@@ -285,9 +285,10 @@ static int uart_mspm0_err_check(const struct device *dev)
 	}
 }
 
-#define UART_MSPM0_TX_INTERRUPTS (DL_UART_MAIN_INTERRUPT_TX |		\
-				  DL_UART_MAIN_INTERRUPT_EOT_DONE)
-#define UART_MSPM0_RX_INTERRUPTS (DL_UART_MAIN_INTERRUPT_RX)
+#define UART_MSPM0_TX_INTERRUPTS (DL_UART_MAIN_INTERRUPT_TX | DL_UART_MAIN_INTERRUPT_EOT_DONE)
+
+#define UART_MSPM0_RX_INTERRUPTS                                                                   \
+	(DL_UART_MAIN_INTERRUPT_RX | DL_UART_MAIN_INTERRUPT_RX_TIMEOUT_ERROR)
 
 static int uart_mspm0_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data, int size)
@@ -356,7 +357,8 @@ static int uart_mspm0_irq_rx_ready(const struct device *dev)
 	const struct uart_mspm0_config *config = dev->config;
 	struct uart_mspm0_data *data = dev->data;
 
-	return (data->pending_interrupt == DL_UART_MAIN_IIDX_RX) &&
+	return ((data->pending_interrupt == DL_UART_MAIN_IIDX_RX) ||
+		(data->pending_interrupt == DL_UART_MAIN_IIDX_RX_TIMEOUT_ERROR)) &&
 		!DL_UART_Main_isRXFIFOEmpty(config->regs) ? 1 : 0;
 }
 
@@ -440,6 +442,10 @@ static int uart_mspm0_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	DL_UART_Main_enableFIFOs(config->regs);
+	DL_UART_Main_setRXFIFOThreshold(config->regs, DL_UART_RX_FIFO_LEVEL_1_2_FULL);
+	DL_UART_Main_setTXFIFOThreshold(config->regs, DL_UART_TX_FIFO_LEVEL_EMPTY);
+	DL_UART_Main_setRXInterruptTimeout(config->regs, 15U);
 	config->irq_config_func(dev);
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 


### PR DESCRIPTION
Two fixes are contained within this PR

1. the removal of explicit interrupt clears. Interrupts should be cleared during irq_update. As getPendingInterrupt will clear the interrupt that is pending. It is possible for an additional ISR to fire in between irq_update and the end of the callback, leading to a missed event. This is seen at higher baudrates with multiple bytes (1 MHz+ using the shell, for example)

2. the improvement of the CPU handling, such that the RX Fifo will fire at less frequent intervals (a higher threshold) 