### PR TITLE
cmake: break dependency cycle in zephyr_constants_library()

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1940,7 +1940,17 @@ function(zephyr_constants_library)
     ${ZEPHYR_BASE}/kernel/include
     ${ARG_INCLUDES}
   )
-  target_link_libraries(${lib_name} zephyr_interface)
+  # Use compile properties and ordering from zephyr_interface but not
+  # its link graph, to avoid cycles with zephyr_generated_headers.
+  target_include_directories(${lib_name} PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_include_directories(${lib_name} SYSTEM PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
+  target_compile_definitions(${lib_name} PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>)
+  target_compile_options(${lib_name} PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
+  add_dependencies(${lib_name} zephyr_interface)
 
   set_source_files_properties(${ARG_SOURCE} PROPERTIES
     COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)


### PR DESCRIPTION
Libraries that link into zephyr_interface via zephyr_link_libraries()
and also depend on zephyr_generated_headers create a dependency cycle
with constants libraries, because target_link_libraries() pulls in
the full link graph from zephyr_interface.

Reported by @jeremybettis with pw_log_zephyr:
https://github.com/zephyrproject-rtos/zephyr/pull/104999#issuecomment-4058305015

Replace target_link_libraries() with explicit property imports for
compile flags, include paths, and definitions using generator
expressions, plus add_dependencies() for build ordering.  This gives
constants libraries everything they need to compile without inheriting
the link graph that causes the cycle.