### PR TITLE
drivers: pwm: Adding PWM compare/capture event type, adds PWM_EVENT support to Infineon TCPWM driver

### DIFF
--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -24,6 +24,17 @@
 #include <cy_sysclk.h>
 
 #include <zephyr/logging/log.h>
+
+#ifdef CONFIG_PWM_EVENT
+#include <zephyr/drivers/pwm/pwm_utils.h>
+#include <zephyr/irq.h>
+#include <zephyr/spinlock.h>
+
+/* Infineon TCPWM PWM channels are single-channel */
+#define IFX_TCPWM_PWM_CH 0
+
+#endif /* CONFIG_PWM_EVENT */
+
 LOG_MODULE_REGISTER(pwm_ifx_tcpwm, CONFIG_PWM_LOG_LEVEL);
 
 struct ifx_tcpwm_pwm_config {
@@ -37,6 +48,10 @@ struct ifx_tcpwm_pwm_config {
 
 struct ifx_tcpwm_pwm_data {
 	struct ifx_cat1_clock clock;
+#ifdef CONFIG_PWM_EVENT
+	sys_slist_t event_callbacks;
+	struct k_spinlock lock;
+#endif /* CONFIG_PWM_EVENT */
 };
 
 static int ifx_tcpwm_pwm_init(const struct device *dev)
@@ -165,33 +180,138 @@ static int ifx_tcpwm_pwm_get_cycles_per_sec(const struct device *dev, uint32_t c
 	return 0;
 }
 
+#ifdef CONFIG_PWM_EVENT
+static void ifx_tcpwm_pwm_isr(const struct device *dev)
+{
+	const struct ifx_tcpwm_pwm_config *config = dev->config;
+	struct ifx_tcpwm_pwm_data *data = dev->data;
+	uint32_t pending;
+
+	pending = IFX_TCPWM_GetInterruptStatusMasked(config->reg_base);
+	IFX_TCPWM_ClearInterrupt(config->reg_base, pending);
+
+	if ((pending & CY_TCPWM_INT_ON_TC) != 0) {
+		pwm_fire_event_callbacks(&data->event_callbacks, dev, IFX_TCPWM_PWM_CH,
+					 PWM_EVENT_TYPE_PERIOD);
+	}
+
+	if ((pending & CY_TCPWM_INT_ON_CC0) != 0) {
+		pwm_fire_event_callbacks(&data->event_callbacks, dev, IFX_TCPWM_PWM_CH,
+					 PWM_EVENT_TYPE_COMPARE_CAPTURE);
+	}
+}
+
+static void ifx_tcpwm_pwm_update_interrupts(const struct device *dev)
+{
+	const struct ifx_tcpwm_pwm_config *config = dev->config;
+	struct ifx_tcpwm_pwm_data *data = dev->data;
+	struct pwm_event_callback *cb;
+	struct pwm_event_callback *tmp;
+	uint32_t mask = CY_TCPWM_INT_NONE;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&data->event_callbacks, cb, tmp, node) {
+		if ((cb->event_mask & PWM_EVENT_TYPE_PERIOD) != 0) {
+			mask |= CY_TCPWM_INT_ON_TC;
+		}
+		if ((cb->event_mask & PWM_EVENT_TYPE_COMPARE_CAPTURE) != 0) {
+			mask |= CY_TCPWM_INT_ON_CC0;
+		}
+	}
+
+	IFX_TCPWM_ClearInterrupt(config->reg_base, mask);
+	IFX_TCPWM_SetInterruptMask(config->reg_base, mask);
+}
+
+static int ifx_tcpwm_pwm_manage_event_callback(const struct device *dev,
+					       struct pwm_event_callback *callback, bool set)
+{
+	struct ifx_tcpwm_pwm_data *data = dev->data;
+	int ret;
+
+	ret = pwm_manage_event_callback(&data->event_callbacks, callback, set);
+	if (ret < 0) {
+		return ret;
+	}
+
+	K_SPINLOCK(&data->lock) {
+		ifx_tcpwm_pwm_update_interrupts(dev);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PWM_EVENT */
+
 static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	.set_cycles = ifx_tcpwm_pwm_set_cycles,
 	.get_cycles_per_sec = ifx_tcpwm_pwm_get_cycles_per_sec,
+#ifdef CONFIG_PWM_EVENT
+	.manage_event_callback = ifx_tcpwm_pwm_manage_event_callback,
+#endif /* CONFIG_PWM_EVENT */
 };
 
+/*
+ * Initialize the peripheral clock divider from devicetree.
+ *
+ * PSoC Edge SoCs require an extra peri_group index argument to
+ * IFX_CAT1_PERIPHERAL_GROUP_ADJUST, so the two variants are selected
+ * at compile time based on CONFIG_SOC_FAMILY_INFINEON_EDGE.
+ */
 #if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 #define PWM_PERI_CLOCK_INIT(n)                                                                     \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),         \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-		}
+	.clock = {                                                                                 \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),                 \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
+			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
+		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
+	}
 #else
 #define PWM_PERI_CLOCK_INIT(n)                                                                     \
-	.clock =                                                                                   \
-		{                                                                                  \
-			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
-				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
-				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
-			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
-		}
+	.clock = {                                                                                 \
+		.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                         \
+			DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),                 \
+			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
+		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
+	}
 #endif
 
+/*
+ * Per-instance wrapper init for PWM event support.
+ *
+ * IRQ_CONNECT requires compile-time constant arguments derived from the
+ * devicetree instance index (n).  This macro generates a wrapper that
+ * calls the main init function first, configures the interrupt.  This avoids
+ * duplicating the bulk ofg the init logic for every pwm instance.
+ */
+#define INFINEON_TCPWM_PWM_IRQ_INIT(n)                                                             \
+	static int ifx_tcpwm_pwm_init_##n(const struct device *dev)                                \
+	{                                                                                          \
+		int ret;                                                                           \
+                                                                                                   \
+		ret = ifx_tcpwm_pwm_init(dev);                                                     \
+		if (ret < 0) {                                                                     \
+			return ret;                                                                \
+		}                                                                                  \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),       \
+			    ifx_tcpwm_pwm_isr, DEVICE_DT_INST_GET(n), 0);                          \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                            \
+		return 0;                                                                          \
+	}
+
+/* clang-format off */
+/*
+ * Per-instance device instantiation macro.
+ *
+ * Defines pinctrl state, mutable driver data, immutable config, and
+ * registers the device.  When CONFIG_PWM_EVENT is enabled, the IRQ
+ * wrapper init function is also emitted via INFINEON_TCPWM_PWM_IRQ_INIT.
+ *
+ * In the DEVICE_DT_INST_DEFINE below, the COND_CODE_1 macro is used to
+ * use the wrapper init function when CONFIG_PWM_EVENT is enabled and use
+ * the main init function otherwise.
+ */
 #define INFINEON_TCPWM_PWM_INIT(n)                                                                 \
+	IF_ENABLED(CONFIG_PWM_EVENT, (INFINEON_TCPWM_PWM_IRQ_INIT(n)))                             \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
                                                                                                    \
 	static struct ifx_tcpwm_pwm_data ifx_tcpwm_pwm##n##_data = {PWM_PERI_CLOCK_INIT(n)};       \
@@ -210,8 +330,10 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 		.clk_dst = DT_PROP(DT_INST_PARENT(n), clk_dst),                                    \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_pwm_init, NULL, &ifx_tcpwm_pwm##n##_data,               \
-			      &pwm_tcpwm_config_##n, POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,        \
-			      &ifx_tcpwm_pwm_api);
+	DEVICE_DT_INST_DEFINE(                                                                     \
+		n, COND_CODE_1(CONFIG_PWM_EVENT, (ifx_tcpwm_pwm_init_##n), (ifx_tcpwm_pwm_init)),  \
+		NULL, &ifx_tcpwm_pwm##n##_data, &pwm_tcpwm_config_##n, POST_KERNEL,                \
+		CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
+/* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_PWM_INIT)

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -97,6 +97,12 @@ extern "C" {
  */
 #define PWM_EVENT_TYPE_FAULT		(2U << PWM_EVENT_TYPE_SHIFT)
 
+/** Configure the event to trigger at a compare/capture match. This fires
+ * when the counter reaches the compare value (output compare mode) or
+ * when an external edge is captured (input capture mode).
+ */
+#define PWM_EVENT_TYPE_COMPARE_CAPTURE	(4U << PWM_EVENT_TYPE_SHIFT)
+
 /** @} */
 
 /**

--- a/samples/drivers/pwm/event/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/drivers/pwm/event/boards/cyw920829m2evk_02_common.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-0 = &pwm0_1;
+	};
+};
+
+&tcpwm0_1 {
+	status = "okay";
+
+	pwm0_1: pwm0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_0>;
+		pinctrl-0 = <&p3_6_pwm0_1>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+	clock-div = <100>;
+};
+
+&pinctrl {
+	p3_6_pwm0_1: p3_6_pwm0_1 {
+		drive-push-pull;
+	};
+};

--- a/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b0lkml.overlay
+++ b/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b0lkml.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b1010.overlay
+++ b/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b1010.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b1340.overlay
+++ b/samples/drivers/pwm/event/boards/cyw920829m2evk_02_cyw20829b1340.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cyw920829m2evk_02_common.overlay"

--- a/samples/drivers/pwm/event/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/pwm/event/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-0 = &pwm1_4;
+	};
+};
+
+&tcpwm1_4 {
+	status = "okay";
+
+	pwm1_4: pwm1_4 {
+		status = "okay";
+		clocks = <&peri0_group5_16bit_0>;
+		pinctrl-0 = <&p4_0_pwm1_4>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group5_16bit_0 {
+	status = "okay";
+	clock-div = <100>;
+};
+
+&pinctrl {
+	p4_0_pwm1_4: p4_0_pwm1_4 {
+		drive-push-pull;
+	};
+};
+
+&gpio_prt4 {
+	status = "okay";
+};

--- a/samples/drivers/pwm/event/boards/kit_pse84_eval_common.overlay
+++ b/samples/drivers/pwm/event/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-0 = &pwm0_1;
+	};
+};
+
+&tcpwm0_1 {
+	status = "okay";
+
+	pwm0_1: pwm0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_1_pwm0_1>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	clock-div = <100>;
+};
+
+&pinctrl {
+	p16_1_pwm0_1: p16_1_pwm0_1 {
+		drive-push-pull;
+	};
+};

--- a/samples/drivers/pwm/event/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/drivers/pwm/event/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/drivers/pwm/event/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/pwm/event/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
- Adds new PWM_EVENT_TYPE_COMPARE_CAPTURE event type to the PWM API.
- Adds implementation of the PWM_EVENT API option.  The Infineon TCPWM Module supports the PWM_EVENT_TYPE_COMPARE_CAPTURE and PWM_EVENT_TYPE_PERIOD events.
- Adds overlays for Infineon kit_psc3m5_evk, kit_pse84_eval, and cyw920829m2evk_02 boards.