### PR TITLE
Unified Boot CPU Frequency Modeling and Publication

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -32,6 +32,7 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
+			clock-frequency = <DT_FREQ_M(96)>;
 			cpu-power-states = <&sleep &deep_sleep>;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/nxp/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/nxp_mcxw70.dtsi
@@ -32,6 +32,7 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
+			clock-frequency = <DT_FREQ_M(32)>;
 			cpu-power-states = <&sleep &deep_sleep>;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/include/zephyr/soc/cpu_clock.h
+++ b/include/zephyr/soc/cpu_clock.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Generic CPU clock frequency publication API.
+ *
+ * Provides a standard internal mechanism for SoC code to publish
+ * the current CPU core clock frequency after clock initialization
+ * or after a runtime frequency change.
+ *
+ * @note This is an internal SoC/platform API. Application code must not
+ *       call these functions directly.
+ */
+
+#ifndef ZEPHYR_INCLUDE_SOC_CPU_CLOCK_H_
+#define ZEPHYR_INCLUDE_SOC_CPU_CLOCK_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Publish the current CPU core clock frequency.
+ *
+ * Called by SoC code after clock initialization has completed (or after
+ * a runtime frequency change) to update @c SystemCoreClock.
+ *
+ * On platforms where the system timer clock is derived from the CPU clock
+ * and @kconfig{CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE} is
+ * enabled, this also updates the kernel runtime system timer frequency.
+ *
+ * @param hz The applied CPU core clock frequency in Hz. A value of 0 is
+ *           ignored.
+ */
+void z_soc_cpu_clock_hz_publish(uint32_t hz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SOC_CPU_CLOCK_H_ */

--- a/soc/common/CMakeLists.txt
+++ b/soc/common/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_sources_ifdef(CONFIG_SOC_CPU_CLOCK_PUBLISH cpu_clock.c)
+
 add_subdirectory_ifdef(CONFIG_RISCV_PRIVILEGED riscv-privileged)

--- a/soc/common/Kconfig
+++ b/soc/common/Kconfig
@@ -1,6 +1,24 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+config SOC_CPU_CLOCK_PUBLISH
+	bool "Use generic CPU clock frequency publication helper"
+	help
+	  Enable the z_soc_cpu_clock_hz_publish() helper that SoC code can
+	  call after clock initialization to update SystemCoreClock (and,
+	  when applicable, the kernel runtime system timer frequency) through
+	  a single common path.
+
+config SOC_CPU_CLOCK_PUBLISH_UPDATE_SYSTEM_TIMER
+	bool "Also update system timer frequency on CPU clock publish"
+	depends on SOC_CPU_CLOCK_PUBLISH
+	depends on SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
+	help
+	  When enabled, z_soc_cpu_clock_hz_publish() will also call
+	  z_sys_clock_hw_cycles_per_sec_update() with the published
+	  frequency. Only enable this on platforms where the system
+	  timer clock is derived from the CPU core clock.
+
 if RISCV_PRIVILEGED
 
 rsource "riscv-privileged/Kconfig"

--- a/soc/common/cpu_clock.c
+++ b/soc/common/cpu_clock.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/soc/cpu_clock.h>
+#include <zephyr/toolchain.h>
+
+extern uint32_t SystemCoreClock;
+
+#if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
+#include <zephyr/drivers/timer/system_timer.h>
+#endif
+
+void z_soc_cpu_clock_hz_publish(uint32_t hz)
+{
+	if (hz == 0U) {
+		return;
+	}
+
+	SystemCoreClock = hz;
+
+#if defined(CONFIG_SOC_CPU_CLOCK_PUBLISH_UPDATE_SYSTEM_TIMER)
+	z_sys_clock_hw_cycles_per_sec_update(hz);
+#endif
+}

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -4,6 +4,9 @@
 
 if SOC_SERIES_MCXW7XX
 
+config SOC_CPU_CLOCK_PUBLISH
+	default y
+
 config NUM_IRQS
 	default 112 if SOC_MCXW70AC
 	default 77 if SOC_MCXW727C
@@ -19,10 +22,11 @@ config MCUX_LPTMR_TIMER
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1024 if MCUX_LPTMR_TIMER
 
+DT_CPU0_PATH := /cpus/cpu@0
 DT_SYSCLK_PATH := $(dt_nodelabel_path,sysclk)
 DT_LPTMR_PATH := $(dt_nodelabel_path,lptmr0)
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,$(DT_SYSCLK_PATH),clock-frequency) if CORTEX_M_SYSTICK
+	default $(dt_node_int_prop_int,$(DT_CPU0_PATH),clock-frequency) if CORTEX_M_SYSTICK
 	default $(dt_node_int_prop_int,$(DT_LPTMR_PATH),clock-frequency) if MCUX_LPTMR_TIMER
 
 config MCUX_FLASH_K4_API

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -17,6 +17,10 @@
 #include <fsl_clock.h>
 #include <fsl_cmc.h>
 
+#if defined(CONFIG_SOC_CPU_CLOCK_PUBLISH)
+#include <zephyr/soc/cpu_clock.h>
+#endif
+
 #define MCXW7_CMC_ADDR (CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 
 extern uint32_t SystemCoreClock;
@@ -159,7 +163,11 @@ __weak void clock_init(void)
 		CLOCK_GetCurSysClkConfig(&cur_config);
 	} while (cur_config.src != sys_clk_config.src);
 
+#if defined(CONFIG_SOC_CPU_CLOCK_PUBLISH)
+	z_soc_cpu_clock_hz_publish(DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency));
+#else
 	SystemCoreClock = 96000000U;
+#endif
 
 	/* OSC-RF / System Oscillator Configuration */
 	scg_sosc_config_t sosc_config = {


### PR DESCRIPTION
# Unified Boot CPU Frequency Modeling and Publication

## Summary

This proposal introduces a small, generic mechanism to unify how Zephyr models, applies, and publishes the boot CPU frequency.

The goal is to make the CPU frequency configured during early SoC initialization come from a consistent devicetree source when appropriate, and to expose the final applied frequency through a common publication path that updates:

1. `SystemCoreClock`, and
2. the runtime system timer frequency when required.

This targets a recurring class of SoC implementations where CPU frequency information is currently duplicated across devicetree, Kconfig defaults, board code, SoC init code, and HAL-specific constants.

## Problem Statement

Today, Zephyr has the pieces needed to describe CPU or system clock rates, but it does not provide a single, consistent contract for boot CPU frequency.

In practice, different SoCs use different patterns:

1. Some SoCs describe CPU frequency in devicetree and use it in Kconfig.
2. Some SoCs assign `SystemCoreClock` directly from devicetree.
3. Some SoCs hardcode the boot core frequency in C code or board code.
4. Some SoCs support runtime CPU frequency changes and update both `SystemCoreClock` and kernel timing state.
5. Some SoCs can only discover the effective frequency at runtime from hardware.

This fragmentation creates several problems:

- Frequency values are duplicated across multiple layers.
- `SystemCoreClock`, `SYS_CLOCK_HW_CYCLES_PER_SEC`, and devicetree frequency properties can drift apart.
- SoC code repeatedly reimplements the same "publish current CPU frequency" logic.
- Platforms with dynamic clocking need ad hoc glue between SoC clock code and kernel timing code.
- Reviewers and maintainers have no single rule for where boot CPU frequency should come from.

The MCXW7xx family is one concrete example of this gap. Its devicetree already contains a
96 MHz `sysclk` node (`dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi`), but early SoC initialization
still switches clocks manually and then hardcodes:

```c
SystemCoreClock = 96000000U;
```

This is functionally correct today, but it is another instance of duplicated clock truth.

## Evidence From Current Tree

### 1. Devicetree already models CPU or boot clock frequency on many platforms

A large number of SoCs already use `/cpus/cpu@0,clock-frequency` as the source of the system
timer or CPU-related configuration.

Examples (all using `SYS_CLOCK_HW_CYCLES_PER_SEC` defaulting to devicetree):

| Platform | File | Pattern |
|----------|------|---------|
| NXP MCXA | `soc/nxp/mcx/mcxa/Kconfig.defconfig` | `$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)` |
| NXP MCX E24x | `soc/nxp/mcx/mcxe/mcxe24x/Kconfig.defconfig` | same |
| NXP S32K | `soc/nxp/s32/s32k3/Kconfig.defconfig` | same |
| Silabs S2 | `soc/silabs/silabs_s2/Kconfig.defconfig` | same |
| TI CC23x0 | `soc/ti/simplelink/cc23x0/Kconfig.defconfig` | same |
| Renesas RZ/G2L | `soc/renesas/rz/rzg2l/Kconfig.defconfig` | same |
| Microchip SAM D5x/E5x | `soc/microchip/sam/sam_d5x_e5x/Kconfig.defconfig` | same |
| WCH CH32V | `soc/wch/ch32v/qingke_v4f/Kconfig.defconfig` | same |
| Rockchip RK3588 | `soc/rockchip/rk35/rk3588/Kconfig.defconfig.rk3588` | same |

This shows that Zephyr already accepts devicetree as a valid place to model CPU frequency.

### 2. Some SoCs already assign `SystemCoreClock` from devicetree

| Platform | File | Code |
|----------|------|------|
| NXP MCX C | `soc/nxp/mcx/mcxc/soc.c` | `SystemCoreClock = DT_PROP(DT_NODELABEL(cpu0), clock_frequency);` |
| NXP K32L | `soc/nxp/kinetis/k32lx/soc.c` | same |
| Nordic nRF54L | `soc/nordic/nrf54l/soc.c` | `SystemCoreClock = NRF_PERIPH_GET_FREQUENCY(DT_NODELABEL(cpu));` |

This indicates the idea is already viable in-tree, but not standardized.

### 3. Other SoCs still hardcode the boot core frequency in C

| Platform | File | Value |
|----------|------|-------|
| NXP MCXW7xx | `soc/nxp/mcx/mcxw/mcxw7xx/soc.c` | `96000000U` |
| NXP MCXW2xx | `soc/nxp/mcx/mcxw/mcxw2xx/soc.c` | `kFreq_32MHz` |
| NXP LPC55xxx | `soc/nxp/lpc/lpc55xxx/soc.c` | `96000000U` / `144000000U` |
| NXP FRDM-MCXN236 (board) | `boards/nxp/frdm_mcxn236/board.c` | `CLOCK_INIT_CORE_CLOCK = 150000000U` |
| NXP FRDM-MCXA156 (board) | `boards/nxp/frdm_mcxa156/board.c` | `CLOCK_INIT_CORE_CLOCK = 96000000U` |
| NXP imxrt5xx | `soc/nxp/imxrt/imxrt5xx/cm33/soc.c` | `CLOCK_INIT_CORE_CLOCK` |
| STM32 (various families) | `soc/st/stm32/stm32*/soc.c` | various hardcoded values |
| Renesas RZ (various) | `soc/renesas/rz/*/soc.c` | `uint32_t SystemCoreClock = ...;` |

This leads to repeated board/SoC-local solutions and duplicated frequency constants.

### 4. Zephyr already has runtime update infrastructure for system timer frequency

Zephyr already supports the case where the active system timer clock frequency changes at
runtime.

Relevant pieces:

- `CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE` (`drivers/timer/Kconfig`)
- `z_sys_clock_hw_cycles_per_sec_update()` (`kernel/sys_clock_hw_cycles.c`)
- `sys_clock_notify_freq_change()` (system timer driver callback)
- SysTick driver support (`drivers/timer/cortex_m_systick.c`)
- Documentation: `doc/kernel/services/timing/clocks.rst`

This means the kernel side already has a mechanism for "the timing-relevant frequency changed".
What is missing is a standard way for SoC clock initialization to publish the boot CPU frequency
through a common path.

### 5. Zephyr already has CPU frequency scaling support on some platforms

NXP MCXN already updates `SystemCoreClock` and the runtime system timer frequency when CPU
frequency changes dynamically:

```c
/* soc/nxp/mcx/mcxn/cpu_freq_scale.c */
static ALWAYS_INLINE void mcxn_update_system_timer_hz(uint32_t new_hz)
{
    SystemCoreClock = new_hz;
    z_sys_clock_hw_cycles_per_sec_update((uint32_t)SystemCoreClock);
}
```

This is further evidence that the missing abstraction is not "dynamic frequency support", but
"a unified publication path used by both boot-time and runtime frequency changes".

## Proposal

### Overview

Introduce a generic internal mechanism for SoC code to publish the current CPU frequency after
clock initialization has completed.

This proposal separates three concepts:

1. **Frequency description** in devicetree.
2. **SoC-specific clock application** logic (PLL/divider/source configuration).
3. **Publication** of the final applied frequency to the rest of the system.

The intent is not to force all SoCs to derive the boot CPU frequency exclusively from
devicetree. Instead, it standardizes how SoCs expose the result once the final boot frequency
is known.

### Proposed Model

#### 1. Standardize the preferred devicetree source for boot CPU frequency

Preferred source:

```dts
/ {
    cpus {
        cpu@0 {
            clock-frequency = <DT_FREQ_M(96)>;
        };
    };
};
```

Optional alternatives may remain for platforms where a dedicated clock node is more natural
(e.g. `sysclk`), but the preferred generic model should be the CPU node itself.

Rationale:

- Many SoCs already use `/cpus/cpu@0,clock-frequency`.
- This aligns better with the semantic meaning of "CPU frequency" than a platform-specific
  `sysclk` label.
- It reduces the need for SoC-local naming conventions.

#### 2. Add a generic internal helper for publishing CPU frequency

Example shape:

```c
/**
 * @brief Publish the current CPU clock frequency.
 *
 * Called by SoC code after clock initialization has completed (or after
 * a runtime frequency change) to update SystemCoreClock and, when
 * applicable, the kernel runtime system timer frequency.
 *
 * @param hz  The applied CPU core clock frequency in Hz.
 */
void z_soc_cpu_clock_hz_publish(uint32_t hz);
```

Responsibilities:

- Update `SystemCoreClock`.
- If the active system timer frequency is derived from CPU/core/system clock and runtime
  update support is enabled, update the kernel's runtime system timer frequency value.
- Provide one standard place for boot-time and runtime SoC frequency changes to converge.

Conceptual flow:

```text
SoC early clock init
  -> apply SoC-specific PLL/divider/source configuration
  -> determine final applied CPU frequency
  -> z_soc_cpu_clock_hz_publish(hz)
     -> SystemCoreClock = hz
     -> optionally z_sys_clock_hw_cycles_per_sec_update(...)
```

#### 3. Distinguish "desired frequency" from "applied frequency"

Devicetree should represent the expected boot target frequency.

However, the SoC code remains responsible for determining the final applied frequency in cases
where:

- Hardware straps or fuses affect the clock.
- Boot ROM or secure firmware set clocks before Zephyr runs.
- The exact resulting rate is discovered at runtime.
- The timer frequency is not identical to CPU frequency.

This avoids overclaiming that devicetree alone is always sufficient.

#### 4. Keep runtime CPUFreq compatible with the same publication path

For dynamic scaling platforms, runtime frequency changes should use the same helper after the
new rate is applied.

This would reduce duplicate update logic across CPUFreq-enabled SoCs.

## Non-Goals

This proposal does not attempt to:

- Force all SoCs to make CPU frequency fully devicetree-driven.
- Replace SoC-specific clock tree setup logic.
- Assume that system timer frequency is always identical to CPU frequency.
- Solve per-CPU independent frequency scaling.
- Redesign the full `clock_control` subsystem.

## Expected Benefits

### 1. Reduced duplication

A single CPU frequency value no longer needs to be manually duplicated across:

- devicetree,
- Kconfig defaults,
- SoC init code,
- board code,
- HAL constants.

### 2. Better consistency

`SystemCoreClock`, devicetree clock properties, and kernel timing-related frequency state are
less likely to diverge.

### 3. Easier maintenance across vendors

Vendors would have a clearer pattern:

1. Model the boot CPU frequency in devicetree when possible.
2. Perform SoC-specific clock setup.
3. Publish the final frequency through a common helper.

### 4. Better alignment with existing dynamic frequency support

Platforms that already support CPUFreq or timer-rate changes can reuse the same publication
contract at runtime.

## Compatibility and Risk

### 1. Static devicetree is not always the whole truth

Some SoCs cannot know the final boot CPU frequency from devicetree alone.

Examples include:

- Boot ROM configured clocks.
- Frequency derived from hardware configuration pins or fuses.
- Secure firmware-controlled clocks.

**Risk:** A too-rigid design could incorrectly assume that devicetree is authoritative.

**Mitigation:** Treat devicetree as the preferred boot target description, not necessarily the
final hardware truth. The SoC code remains responsible for publishing the applied result.

### 2. CPU frequency and system timer frequency are not always identical

On some platforms, `SystemCoreClock` and `SYS_CLOCK_HW_CYCLES_PER_SEC` are not the same
quantity.

The MCXW7xx family is one example where `SYS_CLOCK_HW_CYCLES_PER_SEC` may refer to `lptmr0`
frequency (32768 Hz) when PM is enabled, while `SystemCoreClock` refers to the CPU core clock
(96 MHz).

**Risk:** A generic helper that blindly equates the two would be wrong.

**Mitigation:** The helper API should update the timer runtime frequency only when that mapping
is known to be valid for the active timer/SoC configuration. Platforms where the system timer
is independent of CPU clock should only update `SystemCoreClock`.

### 3. Out-of-tree SoCs may already rely on local patterns

Some out-of-tree platforms may directly assign `SystemCoreClock` in board or SoC code.

**Risk:** A new preferred mechanism could create migration burden.

**Mitigation:** Make the new helper additive first. Existing direct assignments can continue to
work until platforms migrate.

### 4. Multi-core or per-CPU scaling cases are more complex

Zephyr's runtime timer frequency update mechanism is explicitly global and not compatible with
per-CPU independent timer frequencies (`doc/kernel/services/timing/clocks.rst`).

**Risk:** A proposal framed too generally could overpromise support for heterogeneous or
per-core clock domains.

**Mitigation:** Scope the initial mechanism to the common single-active-core /
single-global-timer case.

### 5. Interaction with `clock_control` and `assigned-clock-rates`

Some platforms already use clock assignment patterns in devicetree such as
`assigned-clock-rates`.

**Risk:** The proposal may overlap with existing platform-specific clock frameworks.

**Mitigation:** Keep this mechanism focused on CPU frequency publication, not on replacing
vendor clock tree configuration models.

## Initial Migration Candidates

Good first candidates are platforms that already have a devicetree CPU frequency model or an
obvious static boot frequency but still duplicate it in SoC code.

| Platform | DT Source | C Hardcode | Notes |
|----------|-----------|------------|-------|
| NXP MCXW7xx | `sysclk` 96 MHz in dtsi | `soc.c: 96000000U` | Straightforward |
| NXP LPC55xxx | — | `soc.c: 96000000U / 144000000U` | Needs DT model first |
| NXP FRDM-MCXN236 | — | `board.c: 150000000U` | Board-level init |
| NXP MCXW2xx | `sysclk` 32 MHz in dtsi | `soc.c: kFreq_32MHz` | Similar to MCXW7xx |

## Open Questions

1. Should the preferred source be `/cpus/cpu@0,clock-frequency`, or should a dedicated clock
   node such as `sysclk` remain acceptable as a first-class alternative?
2. Should the publication helper live under SoC internals, arch internals, or the timer
   subsystem?
3. Should the helper always update `SystemCoreClock`, with timer update remaining opt-in, or
   should both be configurable per platform?
4. How should platforms that discover effective frequency from hardware at runtime express the
   distinction between desired and applied boot frequency?
5. Should Zephyr recommend deprecating direct manual writes to `SystemCoreClock` outside the
   common publication helper over time?
