### PR TITLE
manifest: update tflite-micro to fix C interface compilation

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -17,7 +17,7 @@ manifest:
       groups:
         - optional
     - name: tflite-micro
-      revision: 8d404de73acf7687831e16d88e86e4f73cfddf8e
+      revision: c3cded749ed601cd9c2868c61afcd871ee5b0844
       path: optional/modules/lib/tflite-micro
       repo-path: tflite-micro
       remote: upstream


### PR DESCRIPTION
The pinned tflite-micro revision (8d404de) uses C++-only fixed underlying type syntax (`typedef enum Foo : int`) in `tensorflow/lite/core/c/common.h`, breaking compilation from C files.

Bumps to c3cded74 which incorporates the fix from tensorflow/tflite-micro#3097, adding `#ifdef __cplusplus` guards around the affected enum declaration.

Fixes #105305