### PR TITLE
dts: bflb: Fix TRNG addresses

### DIFF
--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -161,7 +161,7 @@
 
 		sec_eng_trng: trng@40004000 {
 			compatible = "bflb,sec-eng-trng";
-			reg = <0x40004200 0x100>;
+			reg = <0x40004000 0x100>;
 			interrupts = <28 0>;
 			interrupt-parent = <&clic>;
 			status = "disabled";

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -195,7 +195,7 @@
 
 		sec_eng_trng: trng@20004000 {
 			compatible = "bflb,sec-eng-trng";
-			reg = <0x20004200 0x100>;
+			reg = <0x20004000 0x100>;
 			interrupts = <28 1>;
 			interrupt-parent = <&clic>;
 			status = "disabled";

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -166,7 +166,7 @@
 
 		sec_eng_trng: trng@40004000 {
 			compatible = "bflb,sec-eng-trng";
-			reg = <0x40004200 0x100>;
+			reg = <0x40004000 0x100>;
 			interrupts = <28 0>;
 			interrupt-parent = <&clic>;
 			status = "disabled";


### PR DESCRIPTION
Addresses were changed but only in the name and not the reg property, breaking the entries.