### PR TITLE
samples: ipc: static_vrings: fix board match for mimxrt1180_evk

### DIFF
--- a/samples/subsys/ipc/ipc_service/static_vrings/Kconfig.sysbuild
+++ b/samples/subsys/ipc/ipc_service/static_vrings/Kconfig.sysbuild
@@ -16,7 +16,7 @@ string
 	default "mimxrt700_evk/mimxrt798s/cm33_cpu1" if $(BOARD) = "mimxrt700_evk"
 	default "frdm_mcxn947/mcxn947/cpu1" if $(BOARD) = "frdm_mcxn947"
 	default "mcx_n9xx_evk/mcxn947/cpu1" if $(BOARD) = "mcx_n9xx_evk"
-	default "mimxrt1180_evk/mimxrt1189/cm7" if $(BOARD) = "mimxrt1180_evk"
+	default "mimxrt1180_evk/mimxrt1189/cm7" if "$(BOARD)/$(BOARD_QUALIFIERS)" = "mimxrt1180_evk/mimxrt1189/cm33"
 	default "frdm_imxrt1186/mimxrt1186/cm7" if $(BOARD) = "frdm_imxrt1186"
 	default "ek_ra8p1/r7ka8p1kflcac/cm33" if $(BOARD) = "ek_ra8p1"
 	default "imx943_evk/mimx94398/m33" if "$(BOARD)/$(BOARD_QUALIFIERS)" = "imx943_evk/mimx94398/m7_1"


### PR DESCRIPTION
- The NET_CORE_BOARD entry for mimxrt1180_evk used a bare \$(BOARD) comparison, which evaluates to 'mimxrt1180_evk' for both the CM33 primary core and the CM7 remote core. This caused sysbuild to attempt adding a remote image when building the CM7 remote itself, creating a recursive configure dependency. As a result, the CM7 core never started and the IPC handshake between CM33 and CM7 hung indefinitely, causing a timeout in sample.ipc.static_vrings.

- Fix by using \$(BOARD)/\$(BOARD_QUALIFIERS) to pin the match to the CM33 primary core only, consistent with how imx943_evk multi-qualifier boards are already handled in the same file.

Fixes #92510