### PR TITLE
MAINTAINERS: add carlocaione as LoRa/LoRaWAN collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3342,6 +3342,7 @@ LoRa and LoRaWAN:
   collaborators:
     - martinjaeger
     - mniestroj
+    - carlocaione
   files:
     - drivers/lora/
     - include/zephyr/drivers/lora.h


### PR DESCRIPTION
Adding myself as collaborator because there is some concurrent work being done on LoRa / LoRaWAN these days and I don't want to miss it.