### PR TITLE
include: zephyr: Add K_xxx_THREAD_DEFINE entry field documentation link

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -988,7 +988,7 @@ struct _static_thread_data {
  *
  * @param name Name of the thread.
  * @param stack_size Stack size in bytes.
- * @param entry Thread entry function.
+ * @param entry Thread entry function, see @ref k_thread_entry_t.
  * @param p1 1st entry point parameter.
  * @param p2 2nd entry point parameter.
  * @param p3 3rd entry point parameter.
@@ -1033,7 +1033,7 @@ struct _static_thread_data {
  *
  * @param name Name of the thread.
  * @param stack_size Stack size in bytes.
- * @param entry Thread entry function.
+ * @param entry Thread entry function, see @ref k_thread_entry_t.
  * @param p1 1st entry point parameter.
  * @param p2 2nd entry point parameter.
  * @param p3 3rd entry point parameter.


### PR DESCRIPTION
Save some seconds by immediately linking to the thread entry point function type documentation.