### PR TITLE
lora: optional configurable SYNC word

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -147,6 +147,7 @@ Libraries / Subsystems
     (:kconfig:option:`CONFIG_LORA_MODULE_BACKEND_NATIVE`) that implements
     LoRaWAN 1.0.x Class A directly on top of the LoRa radio driver, without
     the Semtech LoRaMac-node dependency.  Currently supports the EU868 region.
+  * :c:member:`lora_modem_config.sync_word`
 
 Other notable changes
 *********************

--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -93,8 +93,7 @@ int lbm_lora_config(const struct device *dev, const struct lora_modem_config *lo
 		},
 		.rf_freq_in_hz = lora_config->frequency,
 		.output_pwr_in_dbm = lora_config->tx_power,
-		.sync_word = lora_config->public_network ? LBM_LORA_SYNC_WORD_PUBLIC
-							 : LBM_LORA_SYNC_WORD_PRIVATE,
+		.sync_word = 0,
 	};
 	ral_status_t status;
 	int ret;
@@ -111,6 +110,13 @@ int lbm_lora_config(const struct device *dev, const struct lora_modem_config *lo
 	/* Ensure available, decremented after configuration */
 	if (!modem_acquire(dev)) {
 		return -EBUSY;
+	}
+
+	if (lora_config->sync_word) {
+		params.sync_word = lora_config->sync_word;
+	} else {
+		params.sync_word = lora_config->public_network ? LBM_LORA_SYNC_WORD_PUBLIC
+							       : LBM_LORA_SYNC_WORD_PRIVATE;
 	}
 
 	switch (lora_config->bandwidth) {

--- a/drivers/lora/loramac-node/sx12xx_common.c
+++ b/drivers/lora/loramac-node/sx12xx_common.c
@@ -411,6 +411,10 @@ int sx12xx_lora_config(const struct device *dev,
 				  crc, false, 0, config->iq_inverted, true);
 	}
 
+	if (config->sync_word) {
+		/* Radio_s API doesn't expose SYNC word functionality */
+		LOG_WRN_ONCE("loramac-node doesn't support custom SYNC words");
+	}
 	Radio.SetPublicNetwork(config->public_network);
 
 	modem_release(&dev_data);

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -318,12 +318,19 @@ static int sx126x_set_packet_params(const struct device *dev,
 	return sx126x_hal_write_regs(dev, SX126X_REG_IQ_POLARITY, &reg_val, 1);
 }
 
-static int sx126x_set_sync_word(const struct device *dev, bool public_network)
+static int sx126x_set_sync_word(const struct device *dev, const struct lora_modem_config *config)
 {
-	uint16_t sync_word = public_network ?
-			     SX126X_LORA_SYNC_WORD_PUBLIC :
-			     SX126X_LORA_SYNC_WORD_PRIVATE;
+	uint16_t sync_word;
 	uint8_t buf[2];
+
+	if (config->sync_word) {
+		/* Matching behaviour for other LoRa backends */
+		sync_word = 0x0404 | ((config->sync_word & 0xF0) << 8) |
+			    ((config->sync_word & 0x0F) << 4);
+	} else {
+		sync_word = config->public_network ? SX126X_LORA_SYNC_WORD_PUBLIC
+						   : SX126X_LORA_SYNC_WORD_PRIVATE;
+	}
 
 	sys_put_be16(sync_word, buf);
 	return sx126x_hal_write_regs(dev, SX126X_REG_LORA_SYNC_WORD_MSB, buf, 2);
@@ -909,7 +916,7 @@ static int sx126x_lora_config(const struct device *dev,
 	}
 
 	/* Set sync word */
-	ret = sx126x_set_sync_word(dev, config->public_network);
+	ret = sx126x_set_sync_word(dev, config);
 	if (ret < 0) {
 		goto out;
 	}

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -152,6 +152,13 @@ struct lora_modem_config {
 	/** TX-power in dBm to use for transmission */
 	int8_t tx_power;
 
+	/**
+	 * Override 'public_network' with an explicit sync word.
+	 * Not valid for the legacy loramac-node backend.
+	 * Must be a value other than 0x00.
+	 */
+	uint8_t sync_word;
+
 	/** Set to true for transmission, false for receiving */
 	bool tx;
 


### PR DESCRIPTION
When using the LoRa Basics Modem or Native backends, the SYNC word is user-configurable. Allow users to set it to a specific (non-zero) value.