### PR TITLE
dts: st: n6: enable i2s nodes

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -642,6 +642,58 @@
 			status = "disabled";
 		};
 
+		i2s1: i2s@52003000 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x52003000 0x400>;
+			interrupts = <153 0>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
+			dmas = <&gpdma1 0 80 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 1 79 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
+		i2s2: i2s@50003800 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x50003800 0x400>;
+			interrupts = <154 0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
+			dmas = <&gpdma1 0 82 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 1 81 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
+		i2s3: i2s@50003c00 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x50003c00 0x400>;
+			interrupts = <155 0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
+			dmas = <&gpdma1 0 84 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 1 83 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
+		i2s6: i2s@56001400 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x56001400 0x400>;
+			interrupts = <158 0>;
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>;
+			dmas = <&gpdma1 0 90 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 1 89 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
 		i3c1: i3c@50006000 {
 			compatible = "st,stm32-i3c";
 			reg = <0x50006000 0x400>;


### PR DESCRIPTION
These changes enable I2S1/2/3/6 nodes on STM32N6xx

I2S:
<img width="1393" height="470" alt="Screenshot 2026-03-15 at 09 08 35" src="https://github.com/user-attachments/assets/2cbcf344-81ae-4a34-b025-2722ac4896fa" />

Overlay:
```
/*
 * Copyright (c) 2026 Mario Paja
 *
 * SPDX-License-Identifier: Apache-2.0
 */

/ {
	aliases {
		i2s-tx = &i2s6;
	};
};

/* Half-Duplex Master Transmit */
&i2s6 {
	pinctrl-0 = <&i2s6_mck_pf6 &i2s6_ws_pb15
		     &i2s6_ck_pc12 &spi6_mosi_pg14>;
	pinctrl-names = "default";
    mck-enabled;
	status = "okay";
};

&gpdma1 {
	status = "okay";
};
```

