### PR TITLE
samples: i2s: add i2s opt bclk config option

### DIFF
--- a/samples/drivers/i2s/output/Kconfig
+++ b/samples/drivers/i2s/output/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Mario Paja
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config SAMPLE_I2S_OPT_BIT_CLK_GATED
+	bool "Run I2S bit clock only while sending data"
+	help
+	  Enable I2S bit clock (BCLK) so that it runs
+	  only while audio data is actively being transmitted.

--- a/samples/drivers/i2s/output/src/main.c
+++ b/samples/drivers/i2s/output/src/main.c
@@ -76,8 +76,11 @@ int main(void)
 	i2s_cfg.block_size = BLOCK_SIZE;
 	i2s_cfg.timeout = 2000;
 	/* Configure the Transmit port as Controller */
-	i2s_cfg.options = I2S_OPT_FRAME_CLK_CONTROLLER
-			| I2S_OPT_BIT_CLK_CONTROLLER;
+	i2s_cfg.options = I2S_OPT_FRAME_CLK_CONTROLLER | I2S_OPT_BIT_CLK_CONTROLLER
+#ifdef CONFIG_SAMPLE_I2S_OPT_BIT_CLK_GATED
+			  | I2S_OPT_BIT_CLK_GATED
+#endif
+		;
 	i2s_cfg.mem_slab = &tx_0_mem_slab;
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
 	if (ret < 0) {


### PR DESCRIPTION
This change adds I2S_OPT_BIT_CLK_GATED config for mcus that support this i2s option