### PR TITLE
drivers: pinctrl: stm32: fix typo

### DIFF
--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -180,7 +180,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 {
 	const struct device *port;
 	uint32_t mux, func, line;
-	uint32_t pin_cgf = 0;
+	uint32_t pin_cfg = 0;
 	int ret = 0, cfg_ret;
 
 	ARG_UNUSED(reg);
@@ -199,30 +199,30 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		uint32_t pupd;
 
 		if (STM32_DT_PINMUX_FUNC(mux) == ALTERNATE) {
-			pin_cgf = pins[i].pincfg | STM32_MODE_OUTPUT | STM32_CNF_ALT_FUNC;
+			pin_cfg = pins[i].pincfg | STM32_MODE_OUTPUT | STM32_CNF_ALT_FUNC;
 		} else if (STM32_DT_PINMUX_FUNC(mux) == ANALOG) {
-			pin_cgf = pins[i].pincfg | STM32_MODE_INPUT | STM32_CNF_IN_ANALOG;
+			pin_cfg = pins[i].pincfg | STM32_MODE_INPUT | STM32_CNF_IN_ANALOG;
 		} else if (STM32_DT_PINMUX_FUNC(mux) == GPIO_IN) {
-			pin_cgf = pins[i].pincfg | STM32_MODE_INPUT;
-			pupd = pin_cgf & (STM32_PUPD_MASK << STM32_PUPD_SHIFT);
+			pin_cfg = pins[i].pincfg | STM32_MODE_INPUT;
+			pupd = pin_cfg & (STM32_PUPD_MASK << STM32_PUPD_SHIFT);
 			if (pupd == STM32_PUPD_NO_PULL) {
-				pin_cgf = pin_cgf | STM32_CNF_IN_FLOAT;
+				pin_cfg = pin_cfg | STM32_CNF_IN_FLOAT;
 			} else {
-				pin_cgf = pin_cgf | STM32_CNF_IN_PUPD;
+				pin_cfg = pin_cfg | STM32_CNF_IN_PUPD;
 			}
 		} else if (STM32_DT_PINMUX_FUNC(mux) == GPIO_OUT) {
-			pin_cgf = pins[i].pincfg | STM32_MODE_OUTPUT | STM32_CNF_GP_OUTPUT;
+			pin_cfg = pins[i].pincfg | STM32_MODE_OUTPUT | STM32_CNF_GP_OUTPUT;
 		} else {
 			/* Not supported */
 			__ASSERT_NO_MSG(STM32_DT_PINMUX_FUNC(mux));
 		}
 #else
 		if (STM32_DT_PINMUX_FUNC(mux) < STM32_ANALOG) {
-			pin_cgf = pins[i].pincfg | STM32_MODER_ALT_MODE;
+			pin_cfg = pins[i].pincfg | STM32_MODER_ALT_MODE;
 		} else if (STM32_DT_PINMUX_FUNC(mux) == STM32_ANALOG) {
-			pin_cgf = STM32_MODER_ANALOG_MODE;
+			pin_cfg = STM32_MODER_ANALOG_MODE;
 		} else if (STM32_DT_PINMUX_FUNC(mux) == STM32_GPIO) {
-			pin_cgf = pins[i].pincfg;
+			pin_cfg = pins[i].pincfg;
 		} else {
 			/* Not supported */
 			__ASSERT_NO_MSG(STM32_DT_PINMUX_FUNC(mux));
@@ -241,13 +241,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		line = STM32_DT_PINMUX_LINE(mux);
 		func = STM32_DT_PINMUX_FUNC(mux);
 
-		cfg_ret = stm32_gpioport_configure_pin(port, line, pin_cgf, func);
+		cfg_ret = stm32_gpioport_configure_pin(port, line, pin_cfg, func);
 
 		if (cfg_ret >= 0 && func == IS_GPIO_OUT) {
 			/* Apply output level configuration */
 			const struct gpio_stm32_config *cfg = port->config;
 			GPIO_TypeDef *gpio = cfg->base;
-			uint32_t gpio_out = pin_cgf & (STM32_ODR_MASK << STM32_ODR_SHIFT);
+			uint32_t gpio_out = pin_cfg & (STM32_ODR_MASK << STM32_ODR_SHIFT);
 
 			if (gpio_out == STM32_ODR_1) {
 				stm32_reg_write(&gpio->BSRR, BIT(line));


### PR DESCRIPTION
Fix a typo in `pinctrl_configure_pins` where the variable `pin_cgf` was used instead of `pin_cfg`.
Update all references accordingly.
