### PR TITLE
driver: display: ltdc: fix deadlock on full write

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -237,7 +237,11 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 		sys_cache_data_flush_range((void *)buf, config->height * config->width *
 					   data->current_pixel_size);
 
-		stm32_ltdc_sync_frame(data, buf);
+		/* Avoid waiting for a frame sync when the active buffer is unchanged. */
+		if (buf != data->front_buf) {
+			stm32_ltdc_sync_frame(data, buf);
+		}
+
 		return 0;
 	}
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -193,9 +193,15 @@ static void stm32_ltdc_partial_write(const struct device *dev,
  * LINE interrupt so that the irq handler can swap the buffer.
  * Wait for the end of the swap by waiting for the semaphore given by
  * the irq handler upon LTDC register update
+ *
+ * NOTE: MUST only be called when switching between two different buffers,
+ * front_buf and pend_buf, where front_buf != pend_buf. Otherwise, it
+ * will lead to a deadlock.
  */
 static void stm32_ltdc_sync_frame(struct display_stm32_ltdc_data *data, const uint8_t *pend_buf)
 {
+	__ASSERT(data->front_buf != pend_buf, "Buffers must be different");
+
 	k_sem_reset(&data->sem);
 
 	data->pend_buf = pend_buf;


### PR DESCRIPTION
When writing a full-screen with a single buffer, `stm32_ltdc_write()` calls `stm32_ltdc_sync_frame()` which resets the semaphore, sets the given buffer to `pend_buf`, enables the LTDC line interrupt and waits for the semaphore to be given. However, the semaphore is never given by `stm32_ltdc_global_isr()` because it gives it only when `front_buf != pend_buf` which is not the case because `front_buf == pend_buf` because there is just a single buffer.

The solution is to alway give the semaphore in `stm32_ltdc_global_isr()`.

The following log demonstrates that the second call of `stm32_ltdc_write()` hangs forever because after the first call `front_buf == pend_buf` (see `<err>` messages which were added in the driver):

```
*** Booting Zephyr OS build v4.3.0-8149-g11dc0bde676f ***
[00:00:00.196,000] <inf> main: Starting the main loop
[00:00:00.210,000] <err> display_stm32_ltdc: stm32_ltdc_write x=0 y=0 w=240 h=320 pitch=240
[00:00:00.210,000] <err> display_stm32_ltdc: full-screen stm32_ltdc_write -> stm32_ltdc_sync_frame
[00:00:00.210,000] <err> display_stm32_ltdc: stm32_ltdc_sync_frame: pend=0x2002af54 front=0x200008c0 fb=0x200008c0
[00:00:00.210,000] <err> display_stm32_ltdc: stm32_ltdc_sync_frame: waiting for sem
[00:00:00.210,000] <inf> main: Tick 0 (sleep_ms=18)
[00:00:00.212,000] <err> display_stm32_ltdc: stm32_ltdc_sync_frame: sem acquired
[00:00:00.228,000] <inf> main: Tick 1 (sleep_ms=4)
[00:00:00.238,000] <err> display_stm32_ltdc: stm32_ltdc_write x=0 y=0 w=240 h=320 pitch=240
[00:00:00.238,000] <err> display_stm32_ltdc: full-screen stm32_ltdc_write -> stm32_ltdc_sync_frame
[00:00:00.238,000] <err> display_stm32_ltdc: stm32_ltdc_sync_frame: pend=0x2002af54 front=0x2002af54 fb=0x200008c0
[00:00:00.238,000] <err> display_stm32_ltdc: stm32_ltdc_sync_frame: waiting for sem
[00:00:00.238,000] <inf> main: Tick 2 (sleep_ms=23)
[00:00:00.262,000] <inf> main: Tick 3 (sleep_ms=3)
[00:00:00.265,000] <inf> main: Tick 4 (sleep_ms=30)
[00:00:00.295,000] <inf> main: Tick 5 (sleep_ms=3)
[00:00:00.298,000] <inf> main: Tick 6 (sleep_ms=30)
[00:00:00.328,000] <inf> main: Tick 7 (sleep_ms=3)
[00:00:00.331,000] <inf> main: Tick 8 (sleep_ms=30)
[00:00:00.361,000] <inf> main: Tick 9 (sleep_ms=3)
[00:00:00.364,000] <inf> main: Tick 10 (sleep_ms=30)
[00:00:00.394,000] <inf> main: Tick 11 (sleep_ms=3)
[00:00:00.397,000] <inf> main: Tick 12 (sleep_ms=30)
[00:00:00.428,000] <inf> main: Tick 13 (sleep_ms=2)
[00:00:00.430,000] <inf> main: Tick 14 (sleep_ms=31)
[00:00:00.461,000] <inf> main: Tick 15 (sleep_ms=2)
[00:00:00.463,000] <inf> main: Tick 16 (sleep_ms=31)
[00:00:00.494,000] <inf> main: Tick 17 (sleep_ms=1)
[00:00:00.495,000] <inf> main: Tick 18 (sleep_ms=1)
^C
```

The relevant configuration:
```
# LVGL
CONFIG_LVGL=y
CONFIG_LV_COLOR_DEPTH_16=y
CONFIG_LV_Z_BITS_PER_PIXEL=16
CONFIG_LV_Z_FULL_REFRESH=y
CONFIG_LV_Z_MEM_POOL_SIZE=153600

# LTDC
CONFIG_STM32_LTDC_FB_NUM=0
```