### PR TITLE
boards: arduino: nano_33_ble: add board support for Rev2

### DIFF
--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev1.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev1.yaml
@@ -1,4 +1,4 @@
-identifier: arduino_nano_33_ble/nrf52840/sense
+identifier: arduino_nano_33_ble@rev1/nrf52840/sense
 name: Arduino Nano 33 BLE Sense
 type: mcu
 arch: arm

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.overlay
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Loic Domaigne
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &bmi270;
+	};
+};
+
+/delete-node/ &lsm9ds1;
+/delete-node/ &lsm9ds1_mag;
+/delete-node/ &hts221;
+
+&i2c1 {
+	bmi270: bmi270@68 {
+		compatible = "bosch,bmi270";
+		reg = <0x68>;
+	};
+
+	bmm150: bmm150@10 {
+		compatible = "bosch,bmm150";
+		reg = <0x10>;
+	};
+
+	hs3003: hts3003@44 {
+		compatible = "renesas,hs300x";
+		reg = <0x44>;
+	};
+};

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.yaml
@@ -1,0 +1,18 @@
+identifier: arduino_nano_33_ble@rev2/nrf52840/sense
+name: Arduino Nano 33 BLE Sense Rev2
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - ble
+  - i2c
+  - pwm
+  - serial
+  - spi
+  - uart
+  - usb_device
+  - watchdog
+vendor: arduino

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev1.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev1.yaml
@@ -1,0 +1,18 @@
+identifier: arduino_nano_33_ble@rev1
+name: Arduino Nano 33 BLE
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - ble
+  - i2c
+  - pwm
+  - serial
+  - spi
+  - uart
+  - usb_device
+  - watchdog
+vendor: arduino

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.overlay
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 Loic Domaigne
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &bmi270;
+	};
+};
+
+/delete-node/ &lsm9ds1;
+/delete-node/ &lsm9ds1_mag;
+
+&i2c1 {
+	bmi270: bmi270@68 {
+		compatible = "bosch,bmi270";
+		reg = <0x68>;
+	};
+
+	bmm150: bmm150@10 {
+		compatible = "bosch,bmm150";
+		reg = <0x10>;
+	};
+};

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.yaml
@@ -1,5 +1,5 @@
-identifier: arduino_nano_33_ble
-name: Arduino Nano 33 BLE
+identifier: arduino_nano_33_ble@rev2
+name: Arduino Nano 33 BLE Rev2
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arduino/nano_33_ble/board.yml
+++ b/boards/arduino/nano_33_ble/board.yml
@@ -2,6 +2,13 @@ board:
   name: arduino_nano_33_ble
   full_name: Arduino Nano 33 BLE (Sense)
   vendor: arduino
+  revision:
+    format: custom
+    default: "rev2"
+    exact: true
+    revisions:
+    - name: "rev1"
+    - name: "rev2"
   socs:
   - name: nrf52840
     variants:

--- a/boards/arduino/nano_33_ble/board.yml
+++ b/boards/arduino/nano_33_ble/board.yml
@@ -4,7 +4,7 @@ board:
   vendor: arduino
   revision:
     format: custom
-    default: "rev2"
+    default: "rev1"
     exact: true
     revisions:
     - name: "rev1"

--- a/boards/arduino/nano_33_ble/doc/index.rst
+++ b/boards/arduino/nano_33_ble/doc/index.rst
@@ -8,6 +8,9 @@ nRF52840 ARM Cortex-M4F CPU. Arduino sells 2 variants of the board, the
 plain `BLE`_ type and the `BLE Sense`_ type. The "Sense" variant is distinguished by
 the inclusion of more sensors, but otherwise both variants are the same.
 
+The current hardware revision of these boards is **Rev2**, which has updated the
+IMU and temperature/humidity sensors (among others).
+
 Hardware
 ********
 
@@ -19,8 +22,9 @@ Supported Features
 Connections and IOs
 ===================
 
-The `schematic`_ will tell you everything
-you need to know about the pins.
+The `schematic BLE`_ will tell you everything
+you need to know about the pins for the BLE variant. For the "Sense" variant, refer to
+`schematic BLE Sense`_.
 
 The I2C pull-ups are enabled by setting pin P1.00 high. This is automatically
 done at system init. The pin is specified in the ``zephyr,user`` Devicetree node
@@ -67,14 +71,31 @@ You will also need to specify the COM port using the --bossac-port argument:
 Flashing
 ========
 
-Attach the board to your computer using the USB cable, and then
+.. note::
 
-   .. zephyr-app-commands::
-      :zephyr-app: samples/basic/blinky
-      :board: arduino_nano_33_ble
-      :goals: build
-      :compact:
+   Rev2 can be easily identified by looking at the board, which has the
+   name/revision printed on it: NANO 33 BLE REV2 (or NANO 33 BLE SENSE REV2 for
+   the "Sense" variant).
+   To build for Rev2, the tag ``@rev2`` **must be used**. Zephyr has always supported Rev1,
+   the build command remains unchanged. The tag ``@rev1`` is the default and can be omitted.
 
+To build :zephyr:code-sample:`blinky` for the board revision **Rev2**:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: arduino_nano_33_ble@rev2
+   :goals: build
+   :compact:
+
+To build for the board revision **Rev1**:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: arduino_nano_33_ble
+   :goals: build
+   :compact:
+
+Attach the board to your computer using the USB cable.
 Double-tap the RESET button on your board. Your board should disconnect, reconnect,
 and there should be a pulsing orange LED near the USB port.
 
@@ -163,22 +184,22 @@ References
 .. target-notes::
 
 .. _BLE:
-    https://store.arduino.cc/products/arduino-nano-33-ble
+    https://store.arduino.cc/products/nano-33-ble-rev2
 
 .. _BLE SENSE:
-    https://store.arduino.cc/products/arduino-nano-33-ble-sense
+    https://store.arduino.cc/products/nano-33-ble-sense-rev2
 
-.. _pinouts:
-    https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts
+.. _schematic BLE:
+    https://docs.arduino.cc/resources/schematics/ABX00071-schematics.pdf
 
-.. _schematic:
-    https://content.arduino.cc/assets/NANO33BLE_V2.0_sch.pdf
+.. _schematic BLE Sense:
+    https://docs.arduino.cc/resources/schematics/ABX00069-schematics.pdf
 
 .. _GDB Debug version TRACE32 for Arduino Nano 33 BLE:
     https://www.lauterbach.com/frames.html?register_arduino.php
 
 .. _Lauterbach TRACE32 GDB Front-End Debugger for Nano 33 BLE:
-    https://docs.arduino.cc/tutorials/nano-33-ble-sense/trace-32
+    https://docs.arduino.cc/tutorials/nano-33-ble-sense-rev2/lauterbach-debugger/
 
 .. _TRACE32 as GDB Front-End:
     https://www2.lauterbach.com/pdf/frontend_gdb.pdf

--- a/boards/arduino/nano_33_ble/revision.cmake
+++ b/boards/arduino/nano_33_ble/revision.cmake
@@ -1,0 +1,8 @@
+set(BOARD_REVISIONS "rev1" "rev2")
+if(NOT DEFINED BOARD_REVISION)
+  set(BOARD_REVISION "rev2")
+else()
+  if(NOT BOARD_REVISION IN_LIST BOARD_REVISIONS)
+    message(FATAL_ERROR "${BOARD_REVISION} is not a valid revision for arduino_nano_33_ble. Accepted revisions: ${BOARD_REVISIONS}")
+  endif()
+endif()

--- a/boards/arduino/nano_33_ble/revision.cmake
+++ b/boards/arduino/nano_33_ble/revision.cmake
@@ -1,6 +1,6 @@
 set(BOARD_REVISIONS "rev1" "rev2")
 if(NOT DEFINED BOARD_REVISION)
-  set(BOARD_REVISION "rev2")
+  set(BOARD_REVISION "rev1")
 else()
   if(NOT BOARD_REVISION IN_LIST BOARD_REVISIONS)
     message(FATAL_ERROR "${BOARD_REVISION} is not a valid revision for arduino_nano_33_ble. Accepted revisions: ${BOARD_REVISIONS}")


### PR DESCRIPTION
This PR adds support for the arduino nano 33 BLE (Sense) Rev2. 

It updates the nano_33_ble board folder to support the latest revision Rev2 of the nano 33 BLE(Sense) board. The devicetree and boards files have been refactored to support the different board variants (BLE/Sense) and revisions (rev1 / rev2).
Default build revision is set to rev2, as rev1 product line has reached end of life.

### Main differences between Rev1 and Rev2

| Board variant    | Rev1        | Rev 2                         | 
|------------------------|--------------|-----------------------------|
|  BLE   + Sense    | lms9ds1 | bmi270 + bmm150 | 
|  Sense                 | hts221    | hs3003                      |

### Supporting documents: 

Datasheet and schematics for the boards/revision can be found here:
- [Nano 33 BLE Rev1](https://docs.arduino.cc/hardware/nano-33-ble/)
- [Nano 33 BLE SENSE Rev1](https://docs.arduino.cc/hardware/nano-33-ble-sense/)
- [Nano 33 BLE Rev2](https://docs.arduino.cc/hardware/nano-33-ble-rev2/)
- [Nano 33 BLE SENSE Rev2](https://docs.arduino.cc/hardware/nano-33-ble-sense-rev2/)