### PR TITLE
subsys: usb: usb_c update ucpd_stm32 driver to allow building for stm32h5xx soc

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -51,6 +51,14 @@
 			label = "green led";
 		};
 	};
+
+	vbus1: vbus {
+		compatible = "zephyr,usb-c-vbus-adc";
+		io-channels = <&adc1 18>;
+		output-ohms = <49900>;
+		full-ohms = <(330000 + 49900)>;
+		status = "disabled";
+	};
 };
 
 &clk_hse {
@@ -167,11 +175,25 @@
 };
 
 &adc1 {
-	pinctrl-0 = <&adc1_inp3_pa6 &adc1_inp15_pa3>; /* Zio A0, Zio D35 */
+	/* Zio A0, Zio D35, VBUS_SENSE */
+	pinctrl-0 = <&adc1_inp3_pa6 &adc1_inp15_pa3 &adc1_inp18_pa4>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <6>;
 	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@12 {
+		reg = <18>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		/* Noisy board requires a bit of oversampling to have reliable VBUS_SENSE */
+		zephyr,oversampling = <8>;
+	};
 };
 
 &adc2 {
@@ -219,6 +241,38 @@
 			reg = <0x001f0000 DT_SIZE_K(64)>;
 		};
 	};
+};
+
+&ucpd1 {
+	status = "okay";
+
+	/*
+	 * UCPD is fed ucpd_ker_ck (HSI / 4) which is @ 16MHz. The ucpd_ker_ck goes to
+	 * a prescaler who's output feeds the 'half-bit' divider which is used
+	 * to generate clock for delay counters and BMC Rx/Tx blocks. The rx is
+	 * designed to work in freq ranges of 6 <--> 18 MHz, however recommended
+	 * range is 6 <--> 12 MHz (STM's HAL sets prescaler to /2 by default and
+	 * hbit to /14)
+	 *
+	 *          +-------+ @ 8 MHz  +-------+   @ ~600 kHz   +-----------+
+	 * HSI ---->| /psc  |--------->| /hbit |--------------->| trans_cnt |
+	 *          +-------+          +-------+   |            +-----------+
+	 *                                         |            +-----------+
+	 *                                         +----------->| ifrgap_cnt|
+	 *                                                      +-----------+
+	 * Requirements:
+	 *   1. hbit_clk ~= 600 kHz: 8 MHz / 600 kHz = 13.33
+	 *   2. tTransitionWindow - 12 to 20 uSec
+	 *   3. tInterframGap - >= 25 uSec
+	 *
+	 * hbit_clk = HSI / 4 / psc / hbit = 571.4 kHz = 1.751 uSec period
+	 * tTransitionWindow = 1.751uS * 8 = 14 uS
+	 * tInterFrameGap = 1.751 uS * 17 = 29.76 uS
+	 */
+	psc-ucpdclk = <2>;
+	hbitclkdiv = <14>;
+	pinctrl-0 = <&ucpd1_cc1_pb13 &ucpd1_cc2_pb14>;
+	pinctrl-names = "default";
 };
 
 zephyr_udc0: &usb {

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -25,4 +25,5 @@ supported:
   - rtc
   - i2c
   - i3c
+  - tcpc
 vendor: st

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -376,9 +376,9 @@ static void dead_battery(const struct device *dev, bool en)
 	update_stm32g0x_cc_line(config->ucpd_port);
 #else
 	if (en) {
-		stm32_reg_clear_bits(&PWR->CR3, PWR_CR3_UCPD_DBDIS);
+		LL_PWR_EnableUCPDDeadBattery();
 	} else {
-		stm32_reg_set_bits(&PWR->CR3, PWR_CR3_UCPD_DBDIS);
+		LL_PWR_DisableUCPDDeadBattery();
 	}
 #endif
 	data->dead_battery_active = en;
@@ -1413,7 +1413,8 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0, "No compatible STM32 TC
 	static const struct tcpc_config drv_config_##inst = {                                      \
 		.ucpd_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                 \
 		.ucpd_port = (UCPD_TypeDef *)DT_INST_REG_ADDR(inst),                               \
-		.ucpd_params.psc_ucpdclk = ilog2(DT_INST_PROP(inst, psc_ucpdclk)),                 \
+		.ucpd_params.psc_ucpdclk =                                                         \
+			(ilog2(DT_INST_PROP(inst, psc_ucpdclk)) << UCPD_CFG1_PSC_UCPDCLK_Pos),     \
 		.ucpd_params.transwin = DT_INST_PROP(inst, transwin) - 1,                          \
 		.ucpd_params.IfrGap = DT_INST_PROP(inst, ifrgap) - 1,                              \
 		.ucpd_params.HbitClockDiv = DT_INST_PROP(inst, hbitclkdiv) - 1,                    \

--- a/drivers/usb_c/tcpc/ucpd_stm32_priv.h
+++ b/drivers/usb_c/tcpc/ucpd_stm32_priv.h
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/usb_c/usbc_tcpc.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <stm32_ll_ucpd.h>
+#include <stm32_ll_pwr.h>
 
 /**
  * @brief The packet type(SOP*) consists of 2-bytes

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -693,6 +693,14 @@
 			status = "disabled";
 		};
 
+		ucpd1: ucpd@4000dc00 {
+			compatible = "st,stm32-ucpd";
+			reg = <0x4000dc00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			interrupts = <76 0>;
+			status = "disabled";
+		};
+
 		digi_die_temp: digi_dietemp@40008c00 {
 			compatible = "st,stm32-digi-temp";
 			reg = <0x40008c00 0x400>;

--- a/samples/subsys/usb_c/sink/boards/nucleo_h563zi.conf
+++ b/samples/subsys/usb_c/sink/boards/nucleo_h563zi.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 ARS Embedded Systems LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_GPIO_HOGS=y

--- a/samples/subsys/usb_c/sink/boards/nucleo_h563zi.overlay
+++ b/samples/subsys/usb_c/sink/boards/nucleo_h563zi.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 ARS Embedded Systems LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <dt-bindings/usb-c/pd.h>
+
+/ {
+	aliases {
+		usbc-port0 = &port1;
+	};
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port1: usbc-port@1 {
+			compatible = "usb-c-connector";
+			reg = <1>;
+			tcpc = <&ucpd1>;
+			vbus = <&vbus1>;
+			power-role = "sink";
+			sink-pdos = <PDO_FIXED(5000, 500, 0)>;
+		};
+	};
+};
+
+&vbus1 {
+	status = "okay";
+};
+
+&ucpd1 {
+	dead-battery;
+};
+
+&gpioa {
+	/* Activate /DB pin on TCPP01-M12 to enable CCx passthrough */
+	hog1 {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};


### PR DESCRIPTION
This PR implements https://github.com/zephyrproject-rtos/zephyr/issues/105533 and adds nucleo_h563zi as supported board for samples/subsys/usb_c/sink

