### PR TITLE
drivers: ethernet: nxp_enet_qos: implement ptp feature

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -254,6 +254,11 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(enet))
 	CLOCK_AttachClk(kNONE_to_ENETRMII);
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	/* Attach PLL0 (150 MHz) to the ENET QoS PTP reference clock. */
+	CLOCK_AttachClk(kPLL0_to_ENETPTPREF);
+	CLOCK_SetClkDiv(kCLOCK_DivEnetptprefClk, 1u);
+#endif
 	CLOCK_EnableClock(kCLOCK_Enet);
 	SYSCON0->PRESETCTRL2 = SYSCON_PRESETCTRL2_ENET_RST_MASK;
 	SYSCON0->PRESETCTRL2 &= ~SYSCON_PRESETCTRL2_ENET_RST_MASK;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -358,6 +358,10 @@ arduino_serial: &flexcomm2_lpuart2 {};
 	};
 };
 
+&enet_ptp_clock {
+	status = "okay";
+};
+
 &flexpwm1_pwm0 {
 	pinctrl-0 = <&pinmux_flexpwm1_pwm0>;
 	pinctrl-names = "default";

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -23,6 +23,9 @@ LOG_MODULE_REGISTER(eth_nxp_enet_qos_mac, CONFIG_ETHERNET_LOG_LEVEL);
 #include <ethernet/eth_stats.h>
 #include "../eth.h"
 #include "nxp_enet_qos_priv.h"
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+#include <zephyr/drivers/ptp_clock.h>
+#endif
 
 /* Verify configuration */
 BUILD_ASSERT((ENET_QOS_RX_BUFFER_SIZE * NUM_RX_BUFDESC) >= ENET_QOS_MAX_NORMAL_FRAME_LEN,
@@ -187,6 +190,13 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	last_desc_ptr->read.control2 |= LAST_DESCRIPTOR_FLAG;
 	last_desc_ptr->read.control1 |= TX_INTERRUPT_ON_COMPLETE_FLAG;
 
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	if (net_pkt_is_tx_timestamping(pkt)) {
+		LOG_DBG("SET TX TIMESTAMP %p control %x", pkt, base->MAC_TIMESTAMP_CONTROL);
+		last_desc_ptr->read.control1 |= TX_TIMESTAMP_ENABLE_FLAG;
+	}
+#endif
+
 	LOG_DBG("Starting TX DMA on packet %p", pkt);
 	data->tx.num_descs = (frags_count + 1) / 2;
 
@@ -222,6 +232,22 @@ static void tx_dma_done(const struct device *dev)
 		LOG_DBG("TX DMA completed on packet %p", pkt);
 	}
 
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	volatile union nxp_enet_qos_tx_desc *last_desc =
+		&tx_data->descriptors[tx_data->num_descs - 1];
+
+	if (last_desc->write.status & LAST_DESCRIPTOR_FLAG) {
+		LOG_DBG("LAST DESCRIPTOR : status: %X", last_desc->write.status);
+	}
+	if (last_desc->write.status & TX_TIMESTAMP_STATUS_FLAG) {
+		pkt->timestamp.nanosecond = last_desc->write.timestamp_low;
+		pkt->timestamp.second = last_desc->write.timestamp_high;
+		LOG_DBG("TX HARD TIMESTAMP %llu.%09u", pkt->timestamp.second,
+			pkt->timestamp.nanosecond);
+		net_if_add_tx_timestamp(pkt);
+	}
+#endif
+
 	/* Returning the buffers and packet to the pool */
 	while (fragment != NULL) {
 		net_pkt_frag_unref(fragment);
@@ -245,7 +271,10 @@ static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct devi
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		ETHERNET_PROMISC_MODE |
 #endif
-		ENET_MAC_PACKET_FILTER_PM_MASK;
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	       ETHERNET_PTP |
+#endif
+	       ENET_MAC_PACKET_FILTER_PM_MASK;
 }
 
 static bool software_owns_descriptor(volatile union nxp_enet_qos_rx_desc *desc)
@@ -375,6 +404,37 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 		if ((desc->write.control3 & LAST_DESCRIPTOR_FLAG) == LAST_DESCRIPTOR_FLAG) {
 			/* Propagate completed packet to network stack */
 			LOG_DBG("Receiving RX packet");
+
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+			/*
+			 * When PTP timestamping is enabled the hardware appends a
+			 * context descriptor (RDES3 bit 30 = CTXT) immediately after
+			 * the last regular descriptor.  Peek at that slot; if it is
+			 * software-owned and carries the CTXT flag, extract the RX
+			 * timestamp (RDES0 = nanoseconds, RDES1 = seconds) and
+			 * recycle the slot as a regular RX descriptor.
+			 */
+			{
+				uint32_t ctx_idx = rx_data->next_desc_idx;
+				volatile union nxp_enet_qos_rx_desc *ctx_desc = &desc_arr[ctx_idx];
+
+				if (!(ctx_desc->write.control3 & OWN_FLAG) &&
+				    (ctx_desc->write.control3 & RECEIVE_CONTEXT_DESCRIPTOR_FLAG)) {
+					pkt->timestamp.nanosecond = ctx_desc->write.vlan_tag;
+					pkt->timestamp.second = ctx_desc->write.control1;
+
+					/* Recycle the context descriptor slot as a
+					 * regular RX descriptor — the reserved_buf at
+					 * this index was untouched by the context write.
+					 */
+					ctx_desc->read.buf1_addr =
+						(uint32_t)data->rx.reserved_bufs[ctx_idx]->data;
+					ctx_desc->read.control = rx_desc_refresh_flags;
+					rx_data->next_desc_idx = (ctx_idx + 1U) % NUM_RX_BUFDESC;
+				}
+			}
+#endif /* CONFIG_PTP_CLOCK_NXP_ENET_QOS */
+
 			if (net_recv_data(data->iface, pkt)) {
 				LOG_WRN("RECV failed on pkt %p", pkt);
 				/* Error during processing, we continue with new buffer */
@@ -773,6 +833,10 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 	/* Clearly, start the cogs to motion. */
 	enet_qos_start(base);
 
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	nxp_enet_qos_ptp_reset(config->enet_dev);
+#endif
+
 	/* The tx sem is taken during ethernet send function,
 	 * and given when DMA transmission is finished. Ie, send calls will be blocked
 	 * until the DMA is available again. This is therefore a simple but naive implementation.
@@ -799,7 +863,14 @@ static const struct device *eth_nxp_enet_qos_get_phy(const struct device *dev)
 	return config->phy_dev;
 }
 
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+static const struct device *eth_nxp_enet_qos_get_ptp_clock(const struct device *dev)
+{
+	const struct nxp_enet_qos_mac_config *config = dev->config;
 
+	return config->ptp_clock;
+}
+#endif
 
 static int eth_nxp_enet_qos_set_config(const struct device *dev,
 			       enum ethernet_config_type type,
@@ -853,7 +924,10 @@ static const struct ethernet_api api_funcs = {
 	.send = eth_nxp_enet_qos_tx,
 	.get_capabilities = eth_nxp_enet_qos_get_capabilities,
 	.get_phy = eth_nxp_enet_qos_get_phy,
-	.set_config	= eth_nxp_enet_qos_set_config,
+	.set_config = eth_nxp_enet_qos_set_config,
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	.get_ptp_clock = eth_nxp_enet_qos_get_ptp_clock,
+#endif
 };
 
 #define NXP_ENET_QOS_NODE_HAS_MAC_ADDR_CHECK(n)                                                    \
@@ -894,7 +968,8 @@ static const struct ethernet_api api_funcs = {
 			},                                                                         \
 		.irq_config_func = nxp_enet_qos_##n##_irq_config_func,                             \
 		.mac_addr_source = NXP_ENET_QOS_MAC_ADDR_SOURCE(n),                                \
-	};                                                                                         \
+		IF_ENABLED(CONFIG_PTP_CLOCK_NXP_ENET_QOS,                                          \
+			(.ptp_clock = DEVICE_DT_GET(DT_CHILD(DT_INST_PARENT(n), ptp_clock)),)) };  \
 	static struct nxp_enet_qos_mac_data enet_qos_##n##_mac_data = {                            \
 		.mac_addr.addr = DT_INST_PROP_OR(n, local_mac_address, {0}),                       \
 	};

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -124,7 +124,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	volatile union nxp_enet_qos_tx_desc *last_desc_ptr;
 
 	struct net_buf *fragment = pkt->frags;
-	int frags_count = 0, total_bytes = 0;
+	int frags_count = 0, total_bytes = 0, frags_idx = 0;
 	int ret;
 
 	/* Only allow send of the maximum normal packet size */
@@ -161,32 +161,46 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 
 	/* Setting up the descriptors  */
 	fragment = pkt->frags;
-	tx_desc_ptr->read.control2 |= FIRST_DESCRIPTOR_FLAG;
-	for (int i = 0; i < frags_count; i++) {
+	tx_desc_ptr->read.control2 = FIRST_DESCRIPTOR_FLAG;
+	while (frags_idx < frags_count) {
 		net_pkt_frag_ref(fragment);
 
 		tx_desc_ptr->read.buf1_addr = (uint32_t)fragment->data;
 		tx_desc_ptr->read.control1 = FIELD_PREP(0x3FFF, fragment->len);
 		tx_desc_ptr->read.control2 |= FIELD_PREP(0x7FFF, total_bytes);
 
+		/* if there are more fragments use buffer2 - ringbuffer mode */
+		if (frags_idx + 1 < frags_count) {
+			fragment = fragment->frags;
+			net_pkt_frag_ref(fragment);
+
+			tx_desc_ptr->read.buf2_addr = (uint32_t)fragment->data;
+			tx_desc_ptr->read.control1 |= FIELD_PREP(0x3FFF0000, fragment->len);
+			frags_idx++;
+		}
+
 		fragment = fragment->frags;
 		tx_desc_ptr++;
+		frags_idx++;
 	}
 	last_desc_ptr = tx_desc_ptr - 1;
 	last_desc_ptr->read.control2 |= LAST_DESCRIPTOR_FLAG;
 	last_desc_ptr->read.control1 |= TX_INTERRUPT_ON_COMPLETE_FLAG;
 
 	LOG_DBG("Starting TX DMA on packet %p", pkt);
+	data->tx.num_descs = (frags_count + 1) / 2;
 
 	/* Set the DMA ownership of all the used descriptors */
-	for (int i = 0; i < frags_count; i++) {
+	__DMB();
+	for (int i = 0; i < data->tx.num_descs; i++) {
 		data->tx.descriptors[i].read.control2 |= OWN_FLAG;
 	}
+	__DSB();
 
 	/* This implementation is clearly naive and basic, it just changes the
 	 * ring length for every TX send, there is room for optimization
 	 */
-	base->DMA_CH[0].DMA_CHX_TXDESC_RING_LENGTH = frags_count - 1;
+	base->DMA_CH[0].DMA_CHX_TXDESC_RING_LENGTH = data->tx.num_descs - 1;
 	base->DMA_CH[0].DMA_CHX_TXDESC_TAIL_PTR =
 		ENET_QOS_REG_PREP(DMA_CH_DMA_CHX_TXDESC_TAIL_PTR, TDTP,
 			ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t) tx_desc_ptr));

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -213,7 +213,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	base->DMA_CH[0].DMA_CHX_TXDESC_RING_LENGTH = data->tx.num_descs - 1;
 	base->DMA_CH[0].DMA_CHX_TXDESC_TAIL_PTR =
 		ENET_QOS_REG_PREP(DMA_CH_DMA_CHX_TXDESC_TAIL_PTR, TDTP,
-			ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t) tx_desc_ptr));
+				  ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t)tx_desc_ptr));
 
 	return 0;
 }
@@ -261,15 +261,14 @@ skip:
 	/* Allows another send */
 	k_sem_give(&data->tx.tx_sem);
 	LOG_DBG("Gave driver TX sem %p by thread %s", &data->tx.tx_sem,
-						      k_thread_name_get(k_current_get()));
+		k_thread_name_get(k_current_get()));
 }
 
 static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev)
 {
-	return ETHERNET_LINK_100BASE |
-		ETHERNET_LINK_10BASE |
+	return ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE |
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
-		ETHERNET_PROMISC_MODE |
+	       ETHERNET_PROMISC_MODE |
 #endif
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
 	       ETHERNET_PTP |
@@ -883,20 +882,15 @@ static int eth_nxp_enet_qos_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
-		memcpy(data->mac_addr.addr,
-		       cfg->mac_address.addr,
-		       sizeof(data->mac_addr.addr));
+		memcpy(data->mac_addr.addr, cfg->mac_address.addr, sizeof(data->mac_addr.addr));
 		/* Set MAC address */
 		base->MAC_ADDRESS0_HIGH =
 			ENET_QOS_REG_PREP(MAC_ADDRESS0_HIGH, ADDRHI,
-						data->mac_addr.addr[5] << 8 |
-						data->mac_addr.addr[4]);
-		base->MAC_ADDRESS0_LOW =
-			ENET_QOS_REG_PREP(MAC_ADDRESS0_LOW, ADDRLO,
-						data->mac_addr.addr[3] << 24 |
-						data->mac_addr.addr[2] << 16 |
-						data->mac_addr.addr[1] << 8  |
-						data->mac_addr.addr[0]);
+					  data->mac_addr.addr[5] << 8 | data->mac_addr.addr[4]);
+		base->MAC_ADDRESS0_LOW = ENET_QOS_REG_PREP(
+			MAC_ADDRESS0_LOW, ADDRLO,
+			data->mac_addr.addr[3] << 24 | data->mac_addr.addr[2] << 16 |
+				data->mac_addr.addr[1] << 8 | data->mac_addr.addr[0]);
 		LOG_INF("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
 			dev->name,
 			data->mac_addr.addr[0], data->mac_addr.addr[1],

--- a/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
+++ b/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
@@ -23,13 +23,18 @@
 #define NXP_OUI_BYTE_1 0x9A
 #define NXP_OUI_BYTE_2 0x22
 
-#define FIRST_DESCRIPTOR_FLAG BIT(29)
-#define LAST_DESCRIPTOR_FLAG BIT(28)
-#define OWN_FLAG BIT(31)
+/* receive descriptor 3 */
+#define LAST_DESCRIPTOR_FLAG            BIT(28)
+#define FIRST_DESCRIPTOR_FLAG           BIT(29)
+#define RECEIVE_CONTEXT_DESCRIPTOR_FLAG BIT(30)
+#define OWN_FLAG                        BIT(31)
+
 #define RX_INTERRUPT_ON_COMPLETE_FLAG BIT(30)
 #define TX_INTERRUPT_ON_COMPLETE_FLAG BIT(31)
-#define BUF1_ADDR_VALID_FLAG BIT(24)
-#define DESC_RX_PKT_LEN GENMASK(14, 0)
+#define TX_TIMESTAMP_ENABLE_FLAG      BIT(30)
+#define TX_TIMESTAMP_STATUS_FLAG      BIT(17)
+#define BUF1_ADDR_VALID_FLAG          BIT(24)
+#define DESC_RX_PKT_LEN               GENMASK(14, 0)
 
 #define ENET_QOS_RX_BUFFER_SIZE (CONFIG_NET_BUF_DATA_SIZE & 0xFFFFFFFC)
 #define ENET_QOS_MAX_NORMAL_FRAME_LEN 1518 /* Including FCS */
@@ -101,6 +106,9 @@ struct nxp_enet_qos_mac_config {
 	struct nxp_enet_qos_hw_info hw_info;
 	void (*irq_config_func)(void);
 	enum mac_address_source mac_addr_source;
+#if IS_ENABLED(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	const struct device *ptp_clock;
+#endif
 };
 
 struct nxp_enet_qos_tx_data {

--- a/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
+++ b/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
@@ -106,6 +106,7 @@ struct nxp_enet_qos_mac_config {
 struct nxp_enet_qos_tx_data {
 	struct k_sem tx_sem;
 	struct net_pkt *pkt;
+	int num_descs;
 	volatile union nxp_enet_qos_tx_desc descriptors[NUM_TX_BUFDESC];
 };
 

--- a/drivers/ptp_clock/CMakeLists.txt
+++ b/drivers/ptp_clock/CMakeLists.txt
@@ -9,5 +9,6 @@ zephyr_library_sources_ifdef(CONFIG_PTP_CLOCK_SHELL ptp_clock_shell.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_PTP_CLOCK_NXP_ENET ptp_clock_nxp_enet.c)
+zephyr_library_sources_ifdef(CONFIG_PTP_CLOCK_NXP_ENET_QOS ptp_clock_nxp_enet_qos.c)
 zephyr_library_sources_ifdef(CONFIG_PTP_CLOCK_NXP_NETC ptp_clock_nxp_netc.c)
 # zephyr-keep-sorted-stop

--- a/drivers/ptp_clock/Kconfig
+++ b/drivers/ptp_clock/Kconfig
@@ -10,6 +10,7 @@ if PTP_CLOCK
 
 # zephyr-keep-sorted-start
 source "drivers/ptp_clock/Kconfig.nxp_enet"
+source "drivers/ptp_clock/Kconfig.nxp_enet_qos"
 source "drivers/ptp_clock/Kconfig.nxp_netc"
 # zephyr-keep-sorted-stop
 

--- a/drivers/ptp_clock/Kconfig.nxp_enet_qos
+++ b/drivers/ptp_clock/Kconfig.nxp_enet_qos
@@ -1,0 +1,10 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config PTP_CLOCK_NXP_ENET_QOS
+	bool "NXP ENET QoS PTP Clock driver"
+	default y
+	depends on DT_HAS_NXP_ENET_QOS_PTP_CLOCK_ENABLED && NET_L2_PTP
+	depends on ETH_NXP_ENET_QOS
+	help
+	  Enable NXP ENET QoS PTP clock support

--- a/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet_qos.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * PTP clock driver for NXP ENET QoS.
+ *
+ * The ENET QoS PTP subsystem operates in fine-update mode.
+ * A 32-bit accumulator is incremented by ADDEND each reference-clock
+ * cycle; every time it overflows the system-time sub-second register
+ * is bumped by SNSINC nanoseconds.  Rate discipline is achieved by
+ * adjusting ADDEND via the TSADDREG mechanism.
+ *
+ * Register macros (ENET_MAC_*) come from the MCXN CMSIS device header
+ * (PERI_ENET.h) included transitively via eth_nxp_enet_qos.h.
+ * The fsl_enet_qos SDK HAL is intentionally NOT used here.
+ */
+
+#define DT_DRV_COMPAT nxp_enet_qos_ptp_clock
+
+#include <zephyr/drivers/ptp_clock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/ethernet/eth_nxp_enet_qos.h>
+#include <zephyr/logging/log.h>
+
+#include "fsl_clock.h"
+
+LOG_MODULE_REGISTER(ptp_clock_nxp_enet_qos);
+
+/*
+ * Desired PTP system-time clock frequency in Hz.
+ * Must be strictly less than the reference (bus) clock so that
+ * ADDEND = 2^32 * ptpClk / refClk fits in a 32-bit register.
+ * 50 MHz matches ENET_QOS_SYSTIME_REQUIRED_CLK_MHZ in the NXP HAL.
+ */
+#define PTP_CLOCK_NXP_ENET_QOS_PTPCLK_HZ 50000000U
+
+struct ptp_clock_nxp_enet_qos_config {
+	const struct device *module_dev;	/* device of the parent ENET QoSmodule */
+};
+
+struct ptp_clock_nxp_enet_qos_data {
+	enet_qos_t *base;	/* base address of the parent ENET QoS module */
+	struct k_mutex ptp_mutex;
+	uint32_t nominal_addend;
+	uint32_t ref_clk_hz;	/* the actual PTP clock frequency */
+};
+
+static int ptp_clock_nxp_enet_qos_set(const struct device *dev, struct net_ptp_time *tm)
+{
+	LOG_DBG("PTP set time: %u s, %u ns", (unsigned int)tm->second, tm->nanosecond);
+
+	struct ptp_clock_nxp_enet_qos_data *data = dev->data;
+
+	k_mutex_lock(&data->ptp_mutex, K_FOREVER);
+
+	data->base->MAC_SYSTEM_TIME_SECONDS_UPDATE = (uint32_t)tm->second;
+	/* ADDSUB = 0: absolute initialise */
+	data->base->MAC_SYSTEM_TIME_NANOSECONDS_UPDATE =
+		tm->nanosecond & ENET_MAC_SYSTEM_TIME_NANOSECONDS_UPDATE_TSSS_MASK;
+
+	/* Use TSINIT (absolute load), valid because the accumulator is already
+	 * running so it self-clears on the next accumulator overflow (~20 ns).
+	 */
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSINIT_MASK;
+	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSINIT_MASK) {
+	}
+
+	k_mutex_unlock(&data->ptp_mutex);
+	return 0;
+}
+
+static int ptp_clock_nxp_enet_qos_get(const struct device *dev, struct net_ptp_time *tm)
+{
+	struct ptp_clock_nxp_enet_qos_data *data = dev->data;
+	uint32_t ns1, ns2, sec;
+
+	/*
+	 * Guard against a seconds roll-over between the two nanosecond reads:
+	 * re-read if nanoseconds decreased (wrap occurred).
+	 */
+	do {
+		ns1 = data->base->MAC_SYSTEM_TIME_NANOSECONDS &
+		      ENET_MAC_SYSTEM_TIME_NANOSECONDS_TSSS_MASK;
+		sec = data->base->MAC_SYSTEM_TIME_SECONDS;
+		ns2 = data->base->MAC_SYSTEM_TIME_NANOSECONDS &
+		      ENET_MAC_SYSTEM_TIME_NANOSECONDS_TSSS_MASK;
+	} while (ns2 < ns1);
+
+	tm->second = sec;
+	tm->nanosecond = ns2;
+	return 0;
+}
+
+/**
+ * adjust PTP clock by increment nanoseconds, positive or negative.
+ */
+static int ptp_clock_nxp_enet_qos_adjust(const struct device *dev, int increment)
+{
+	LOG_DBG("PTP rate adjust increment: %d", increment);
+
+	struct ptp_clock_nxp_enet_qos_data *data = dev->data;
+	uint32_t ns_update;
+
+	if ((increment <= (-(int32_t)NSEC_PER_SEC)) || (increment >= (int32_t)NSEC_PER_SEC)) {
+		return -EINVAL;
+	}
+
+	if (increment >= 0) {
+		/* ADDSUB = 0: add */
+		ns_update = (uint32_t)increment & ENET_MAC_SYSTEM_TIME_NANOSECONDS_UPDATE_TSSS_MASK;
+	} else {
+		/* ADDSUB = 1: subtract */
+		ns_update = ((uint32_t)(-increment) &
+			     ENET_MAC_SYSTEM_TIME_NANOSECONDS_UPDATE_TSSS_MASK) |
+			    ENET_MAC_SYSTEM_TIME_NANOSECONDS_UPDATE_ADDSUB_MASK;
+	}
+
+	k_mutex_lock(&data->ptp_mutex, K_FOREVER);
+
+	data->base->MAC_SYSTEM_TIME_SECONDS_UPDATE = 0;
+	data->base->MAC_SYSTEM_TIME_NANOSECONDS_UPDATE = ns_update;
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSUPDT_MASK;
+	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSUPDT_MASK) {
+	}
+
+	k_mutex_unlock(&data->ptp_mutex);
+	return 0;
+}
+
+static int ptp_clock_nxp_enet_qos_rate_adjust(const struct device *dev, double ratio)
+{
+	LOG_DBG("PTP rate adjust ratio: %f", ratio);
+
+	struct ptp_clock_nxp_enet_qos_data *data = dev->data;
+	uint32_t new_addend;
+
+	/* No meaningful change */
+	if ((ratio > 1.0 && ratio - 1.0 < 1e-9) || (ratio < 1.0 && 1.0 - ratio < 1e-9)) {
+		return 0;
+	}
+
+	new_addend = (uint32_t)((double)data->nominal_addend * ratio);
+
+	k_mutex_lock(&data->ptp_mutex, K_FOREVER);
+
+	data->base->MAC_TIMESTAMP_ADDEND = new_addend;
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSADDREG_MASK;
+	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSADDREG_MASK) {
+	}
+
+	k_mutex_unlock(&data->ptp_mutex);
+	return 0;
+}
+
+/*
+ * ptp_hw_start - configure PTP hardware after DMA/MAC reset.
+ *
+ * Must be called after the parent ENET QoS DMA reset has completed
+ * (i.e. from the MAC driver's post-reset path), because:
+ *  - DMA SWR clears all MAC/PTP registers.
+ *  - TSINIT only self-clears once mac_ptp_ref_clk is ticking, which
+ *    requires the DMA to be out of reset.
+ *
+ * Called from nxp_enet_qos_ptp_reset() which is invoked by the MAC driver.
+ */
+static void ptp_hw_start(struct ptp_clock_nxp_enet_qos_data *data)
+{
+	LOG_INF("%s Starting NXP ENET QoS PTP hardware", __func__);
+
+	const uint32_t snsinc = NSEC_PER_SEC / PTP_CLOCK_NXP_ENET_QOS_PTPCLK_HZ;
+
+	/* Get the actual reference clock frequency. */
+	/* TODO: change to sysclock API when available */
+	data->ref_clk_hz = CLOCK_GetEnetPtpRefClkFreq();
+	LOG_INF("PTP reference clock %u Hz", data->ref_clk_hz);
+	__ASSERT(data->ref_clk_hz != 0, "Failed to get PTP clock");
+
+	data->nominal_addend =
+		(uint32_t)((double)(1ULL << 32) * (double)PTP_CLOCK_NXP_ENET_QOS_PTPCLK_HZ /
+			   (double)data->ref_clk_hz);
+	LOG_INF("PTP accumulator addend %u nsec", data->nominal_addend);
+
+	/*
+	 * Step 1: Enable timestamping in COARSE update mode (no TSCFUPDT yet).
+	 * In coarse mode TSINIT self-clears on the next mac_ptp_ref_clk edge,
+	 * not on an accumulator overflow, so it completes immediately.
+	 * nanosecond rollover in digital logic
+	 */
+	data->base->MAC_TIMESTAMP_CONTROL =
+		ENET_MAC_TIMESTAMP_CONTROL_TSENA_MASK | ENET_MAC_TIMESTAMP_CONTROL_TSIPV4ENA_MASK |
+		ENET_MAC_TIMESTAMP_CONTROL_TSIPV6ENA_MASK |
+		ENET_MAC_TIMESTAMP_CONTROL_TSENALL_MASK |
+		ENET_MAC_TIMESTAMP_CONTROL_TSEVNTENA_MASK |
+		ENET_MAC_TIMESTAMP_CONTROL_SNAPTYPSEL_MASK |
+		ENET_MAC_TIMESTAMP_CONTROL_TSCTRLSSR(1) |
+		ENET_MAC_TIMESTAMP_CONTROL_TSVER2ENA_MASK | ENET_MAC_TIMESTAMP_CONTROL_TSIPENA_MASK;
+
+	/* Step 2: initialize system time to zero (coarse mode — completes quickly) */
+	data->base->MAC_SYSTEM_TIME_NANOSECONDS_UPDATE = 0;
+	data->base->MAC_SYSTEM_TIME_SECONDS_UPDATE = 0;
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSINIT_MASK;
+	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSINIT_MASK) {
+	}
+
+	/* Step 3: switch to fine update mode */
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSCFUPDT_MASK;
+
+	/* Step 4: set sub-second increment for 50 MHz PTP clock → 20 ns/tick */
+	data->base->MAC_SUB_SECOND_INCREMENT = ENET_MAC_SUB_SECOND_INCREMENT_SNSINC(snsinc);
+
+	/*
+	 * Step 5: load the nominal addend into the fine accumulator.
+	 * TSENA has already propagated to mac_ptp_ref_clk domain (step 1),
+	 * so TSADDREG self-clears promptly.
+	 */
+	data->base->MAC_TIMESTAMP_ADDEND = data->nominal_addend;
+	data->base->MAC_TIMESTAMP_CONTROL |= ENET_MAC_TIMESTAMP_CONTROL_TSADDREG_MASK;
+	while (data->base->MAC_TIMESTAMP_CONTROL & ENET_MAC_TIMESTAMP_CONTROL_TSADDREG_MASK) {
+	}
+}
+
+
+/*
+ * driver initialisation
+ * called by the zephyr device model during system init
+ * setup base address and mutex only, but hardware init is done during the nxp_enet_qos_mac_init
+ */
+static int ptp_clock_nxp_enet_qos_init(const struct device *dev)
+{
+	LOG_INF("%s Initializing NXP ENET QoS PTP clock on device %s", __func__, dev->name);
+	const struct ptp_clock_nxp_enet_qos_config *config = dev->config;
+	struct ptp_clock_nxp_enet_qos_data *data = dev->data;
+	struct nxp_enet_qos_config *module_cfg = ENET_QOS_MODULE_CFG(config->module_dev);
+
+	data->base = module_cfg->base;
+	k_mutex_init(&data->ptp_mutex);
+
+	return 0;
+}
+
+static DEVICE_API(ptp_clock, ptp_clock_nxp_enet_qos_api) = {
+	.set = ptp_clock_nxp_enet_qos_set,
+	.get = ptp_clock_nxp_enet_qos_get,
+	.adjust = ptp_clock_nxp_enet_qos_adjust,
+	.rate_adjust = ptp_clock_nxp_enet_qos_rate_adjust,
+};
+
+#define PTP_CLOCK_NXP_ENET_QOS_INIT(n)                                                             \
+	static const struct ptp_clock_nxp_enet_qos_config ptp_clock_nxp_enet_qos_##n##_config = {  \
+		.module_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct ptp_clock_nxp_enet_qos_data ptp_clock_nxp_enet_qos_##n##_data;               \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ptp_clock_nxp_enet_qos_init, NULL,                               \
+			      &ptp_clock_nxp_enet_qos_##n##_data,                                  \
+			      &ptp_clock_nxp_enet_qos_##n##_config, POST_KERNEL,                   \
+			      CONFIG_PTP_CLOCK_INIT_PRIORITY, &ptp_clock_nxp_enet_qos_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PTP_CLOCK_NXP_ENET_QOS_INIT)
+
+/*
+ * nxp_enet_qos_ptp_reset - re-initialise PTP hardware during MAC init.
+ *
+ * Called by the ENET QoS MAC driver (eth_nxp_enet_qos_mac.c) after
+ * it completes the DMA software reset, at which point:
+ *  - All peripheral registers have been wiped.
+ *  - The PTP reference clock is running.
+ * Finds the PTP clock device(s) whose parent is module_dev and
+ * re-runs the hardware initialisation sequence.
+ */
+void nxp_enet_qos_ptp_reset(const struct device *module_dev)
+{
+	/* Set base directly from module_dev so this is safe even when
+	 * the PTP _init hasn't run yet (both drivers share INIT_PRIORITY).
+	 */
+	LOG_INF("%s Resetting NXP ENET QoS PTP hardware ", __func__);
+#define _PTP_RESET_IF_PARENT(n)                                                                    \
+	if (ptp_clock_nxp_enet_qos_##n##_config.module_dev == module_dev) {                        \
+		ptp_clock_nxp_enet_qos_##n##_data.base = ENET_QOS_MODULE_CFG(module_dev)->base;    \
+		ptp_hw_start(&ptp_clock_nxp_enet_qos_##n##_data);                                  \
+	}
+
+	DT_INST_FOREACH_STATUS_OKAY(_PTP_RESET_IF_PARENT)
+}

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -861,6 +861,11 @@
 			compatible = "nxp,enet-qos-mdio";
 			status = "disabled";
 		};
+
+		enet_ptp_clock: ptp_clock {
+			compatible = "nxp,enet-qos-ptp-clock";
+			status = "disabled";
+		};
 	};
 
 	wwdt0: watchdog@16000 {

--- a/dts/bindings/ethernet/nxp,enet-qos-ptp-clock.yaml
+++ b/dts/bindings/ethernet/nxp,enet-qos-ptp-clock.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP ENET QoS PTP (Precision Time Protocol) Clock
+
+compatible: "nxp,enet-qos-ptp-clock"
+
+include: ["base.yaml"]

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet_qos.h
@@ -51,4 +51,8 @@ struct nxp_enet_qos_config {
 };
 #define ENET_QOS_MODULE_CFG(module_dev) ((struct nxp_enet_qos_config *) module_dev->config)
 
+#if IS_ENABLED(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+extern void nxp_enet_qos_ptp_reset(const struct device *module_dev);
+#endif
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ETH_NXP_ENET_H__ */


### PR DESCRIPTION
activate the ptp timer and handle timestamps in rx and tx added ptp_clock_nxp_enet_qos
tested on my frdm_mcxn947 board

This adds PTP functionality for NXP MCXN MCU.
I copy paste from NXP enet_ptp_clock driver.

fixes #89448

Adib