### PR TITLE
soc: imx93: fix cpu pm dependency

### DIFF
--- a/soc/nxp/imx/imx9/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/CMakeLists.txt
@@ -11,6 +11,6 @@ elseif(CONFIG_SOC_MIMX9596)
   add_subdirectory(imx95)
 endif()
 
-if(CONFIG_CPU_CORTEX_A55)
-  zephyr_library_sources_ifdef(CONFIG_PM pm_acore.c)
+if(CONFIG_CPU_CORTEX_A55 AND CONFIG_PM)
+  zephyr_library_sources_ifdef(CONFIG_PM_CPU_OPS_PSCI pm_acore.c)
 endif()

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -28,4 +28,7 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 24000000
 
+config PM_CPU_OPS
+	default y if PM
+
 endif


### PR DESCRIPTION
SoC's PM API actually depends on PSCI driver, and enable PM_CPU_OPS for SoC when CONFIG_PM is enabled.

This PR is to fix twister issue for:
west build -p -b imx93_evk/mimx9352/a55 tests/lib/cpp/cxx -T cpp.main.newlib

```
/opt/toolchains/zephyr-sdk-0.17.4/aarch64-zephyr-elf/bin/../lib/gcc/aarch64-zephyr-elf/12.2.0/../../../../aarch64-zephyr-elf/bin/ld.bfd: zephyr/libzephyr.a(pm_acore.c.obj): in function `pm_state_set':
/__w/zephyr/zephyr/soc/nxp/imx/imx9/pm_acore.c:21: undefined reference to `psci_cpu_suspend'
/__w/zephyr/zephyr/soc/nxp/imx/imx9/pm_acore.c:21:(.text.pm_state_set+0x14): relocation truncated to fit: R_AARCH64_JUMP26 against undefined symbol `psci_cpu_suspend'

```