### PR TITLE
soc: imxrt118x: harden CM7 kick-off sequence and raise VDD_SOC

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -238,8 +238,8 @@ __weak void clock_init(void)
 #endif
 
 #if CONFIG_CPU_CORTEX_M7
-	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_CORE0, kDCDC_1P0Target1P1V);
-	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_CORE1, kDCDC_1P0Target1P1V);
+	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_CORE0, kDCDC_1P0Target1P125V);
+	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_CORE1, kDCDC_1P0Target1P125V);
 	/* FBB need to be enabled in OverDrive(OD) mode */
 	PMU_EnableFBB(ANADIG_PMU, true);
 #endif

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -984,10 +984,16 @@ static int second_core_boot(void)
 	result1 = MU_RT_S3MUA->RR[0];
 	result2 = MU_RT_S3MUA->RR[1];
 
+	/* Disable M7 clock before clearing CPU_WAIT bit */
+	CLOCK_DisableClock(kCLOCK_M7);
+
 	/* Deassert Wait */
 	BLK_CTRL_S_AONMIX->M7_CFG =
 		(BLK_CTRL_S_AONMIX->M7_CFG & (~BLK_CTRL_S_AONMIX_M7_CFG_WAIT_MASK)) |
 		BLK_CTRL_S_AONMIX_M7_CFG_WAIT(0);
+
+	/* Re-enable M7 clock again */
+	CLOCK_EnableClock(kCLOCK_M7);
 
 	return 0;
 }


### PR DESCRIPTION
- Gate off M7 clock before clearing M7_CFG[WAIT] (CPUWAIT) and gate it back on after the deassert. (This is the process requirement in the newest RT118X RM)
- Increase default DCDC/core voltage to 1.125 V for improved margin.