### PR TITLE
drivers: ieee802154: stm32wba: handle rx failure notification

### DIFF
--- a/drivers/ieee802154/ieee802154_stm32wba.c
+++ b/drivers/ieee802154/ieee802154_stm32wba.c
@@ -169,10 +169,19 @@ static void stm32wba_802154_receive_failed(stm32wba_802154_ral_rx_error_t error)
 	const struct device *dev = stm32wba_802154_get_device();
 	enum ieee802154_rx_fail_reason reason;
 
-	if (error == STM32WBA_802154_RAL_RX_ERROR_NO_BUFFERS) {
+	switch (error) {
+	case STM32WBA_802154_RAL_RX_ERROR_FCS:
+		reason = IEEE802154_RX_FAIL_INVALID_FCS;
+		break;
+	case STM32WBA_802154_RAL_RX_ERROR_NO_FRAME_RECEIVED:
 		reason = IEEE802154_RX_FAIL_NOT_RECEIVED;
-	} else {
+		break;
+	case STM32WBA_802154_RAL_RX_ERROR_DEST_ADDRESS_FILTERED:
+		reason = IEEE802154_RX_FAIL_ADDR_FILTERED;
+		break;
+	default:
 		reason = IEEE802154_RX_FAIL_OTHER;
+		break;
 	}
 
 	if (IS_ENABLED(CONFIG_IEEE802154_STM32WBA_LOG_RX_FAILURES)) {
@@ -982,7 +991,7 @@ static int stm32wba_802154_attr_get(const struct device *dev,
 static void stm32wba_802154_receive_done(uint8_t *p_buffer,
 					 stm32wba_802154_ral_receive_done_metadata_t *p_metadata)
 {
-	if (p_buffer == NULL) {
+	if ((p_buffer == NULL) || (p_metadata->error != STM32WBA_802154_RAL_RX_ERROR_NONE)) {
 		stm32wba_802154_receive_failed(p_metadata->error);
 		return;
 	}


### PR DESCRIPTION
This PR includes a fix in the ieee802.15.4 driver to skip Rx packet notified from low layer with an error code and the RX failure is notified to upper layer through the IEEE802154_EVENT_RX_FAILED event.

FYI : @asm5878