### PR TITLE
boards: microchip: pic32cxsg: Add counter nodes

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -217,6 +217,13 @@
 	status = "okay";
 };
 
+&tc0 {
+	compatible = "microchip,tc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <8>;
+	status = "okay";
+};
+
 &porta {
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -217,6 +217,13 @@
 	status = "okay";
 };
 
+&tc0 {
+	compatible = "microchip,tc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <8>;
+	status = "okay";
+};
+
 &porta {
 	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/pic32cx_sg41_cult.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &tc0;
+	};
+};
+
+&tc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/pic32cx_sg61_cult.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &tc0;
+	};
+};
+
+&tc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -84,6 +84,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define SAMPLE_TIMER DT_NODELABEL(rtc)
 #elif defined(CONFIG_COUNTER_RENESAS_RZA2M_OSTM)
 #define SAMPLE_TIMER DT_INST(0, renesas_rza2m_ostm_counter)
+#elif defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
+#define SAMPLE_TIMER DT_ALIAS(counter)
 #else
 #error Unable to find a counter device node in devicetree
 #endif

--- a/tests/drivers/counter/counter_basic_api/boards/microchip/pic32cx_sg41_cult_tc0.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/microchip/pic32cx_sg41_cult_tc0.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&tc0 {
+	status = "okay";
+	compatible = "microchip,tc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <1>;
+};
+
+&tcc1 {
+	status = "disabled";
+};

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -106,10 +106,13 @@ tests:
       - drivers
       - counter
     depends_on: counter
-    platform_allow: sam_e54_xpro
+    platform_allow:
+      - sam_e54_xpro
+      - pic32cx_sg41_cult
     timeout: 600
     extra_args:
-      DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc0.overlay"
+      - platform:sam_e54_xpro/atsame54p20a:"DTC_OVERLAY_FILE=boards/microchip/sam_e54_xpro_tc0.overlay"
+      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"DTC_OVERLAY_FILE=boards/microchip/pic32cx_sg41_cult_tc0.overlay"
   drivers.counter.basic_api.mchp_rtc:
     tags:
       - drivers


### PR DESCRIPTION
- Adds sample node in board files of pic32cx_sg61_cult and pic32cx_sg41_cult boards.
- Adds the test files to validate the counter with tcc on pic32cx_sg41_cult board