### PR TITLE
doc: security: standards: fix ETSI link in CRA doc page

### DIFF
--- a/doc/security/standards/cyber-resilience-act.rst
+++ b/doc/security/standards/cyber-resilience-act.rst
@@ -392,7 +392,7 @@ include product-specific requirements for:
 * Firewalls (prEN 304 636)
 
 For the complete list of draft standards and participation in public consultations, see the
-`ETSI Cyber Resilience Act Portal <https://www.etsi.org/committee/1430-tc-cyber>`_.
+`ETSI Cyber Resilience Act Portal <https://docbox.etsi.org/cyber/CYBER/Open>`_.
 
 Educational resources
 =====================


### PR DESCRIPTION
Looks like ETSI may have set up a weird/wrong redirect on a URL that used to point to CRA-related ETSI standards. The broken link was reported by someone from ETSI and this commit replaces it with the suggestion made by that person.