### PR TITLE
logging: fix log overwrite issue

### DIFF
--- a/subsys/logging/backends/Kconfig.adsp_mtrace
+++ b/subsys/logging/backends/Kconfig.adsp_mtrace
@@ -16,3 +16,11 @@ backend-str = adsp_mtrace
 source "subsys/logging/Kconfig.template.log_format_config"
 
 endif # LOG_BACKEND_ADSP_MTRACE
+
+config MTRACE_LOG_CACHE_BUF_SIZE
+	int "Number of bytes dedicated for the mtrace log cache buffer"
+	depends on LOG_BACKEND_ADSP_MTRACE
+	default 0
+	range 0 32768
+	help
+	  Number of bytes dedicated for the mtrace log cache buffer.

--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -148,6 +148,12 @@ out:
 	return out;
 }
 
+#if CONFIG_MTRACE_LOG_CACHE_BUF_SIZE > ADSP_DW_SLOT_SIZE
+static uint8_t cache_buf[CONFIG_MTRACE_LOG_CACHE_BUF_SIZE];
+static size_t cache_buf_head;
+static size_t cache_buf_len;
+#endif
+
 static int char_out(uint8_t *data, size_t length, void *ctx)
 {
 	size_t space_left = 0;
@@ -157,7 +163,33 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	 * we handle the data even if mtrace notifier is not
 	 * active. this ensures we can capture early boot messages.
 	 */
+#if CONFIG_MTRACE_LOG_CACHE_BUF_SIZE > ADSP_DW_SLOT_SIZE
+	size_t bytes_copy = MIN(CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - cache_buf_len, length);
+	size_t bytes_write = 0;
+	size_t r_pos = cache_buf_head;
+	size_t w_pos = (cache_buf_head + cache_buf_len) % CONFIG_MTRACE_LOG_CACHE_BUF_SIZE;
+
+	memcpy(cache_buf + w_pos, data,
+	       MIN(bytes_copy, CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - w_pos));
+	if (bytes_copy > CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - w_pos) {
+		memcpy(cache_buf, data + (CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - w_pos),
+		       bytes_copy - (CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - w_pos));
+	}
+	cache_buf_len += bytes_copy;
+
+	bytes_write = MIN(cache_buf_len, CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - r_pos);
+	out = mtrace_out(cache_buf + r_pos, bytes_write, &space_left);
+	if (space_left > 0 && cache_buf_len > bytes_write) {
+		out += mtrace_out(cache_buf,
+				  MIN(space_left, cache_buf_len - bytes_write),
+				  &space_left);
+	}
+
+	cache_buf_head = (cache_buf_head + out) % CONFIG_MTRACE_LOG_CACHE_BUF_SIZE;
+	cache_buf_len -= out;
+#else
 	out = mtrace_out(data, length, &space_left);
+#endif
 
 	if (mtrace_active && mtrace_hook) {
 


### PR DESCRIPTION
Add an internal cache buffer in Intel's adsp mtrace backend to mitigate log overwrite issue when trace slot window is full.

See this truncated log:

```txt
[ 2435.784528][ 2804.204393] <inf> pipe: pipeline_new: pipeline new pipe_id 0 priority 0
```

One or more log entries are overwritten because  `ADSP_DW_SLOT_SIZE` is fixed and too small when a large number of log messages flood. Since `z_log_msg_claim` in `subsys/logging/log_core.c` is fire-and-forget, I fix the overwrite issue on adsp mtrace backend.

This solution isn't ideal; we'd appreciate your valuable feedback.