### PR TITLE
west: update hal_nxp to include wlcmgr logging fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 22a92524af8ff98fcfbbbdb345509b76729344b1
+      revision: pull/689/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This updates the hal_nxp manifest revision to test the wlcmgr logging 
fixes submitted in hal_nxp PR [#689](https://github.com/zephyrproject-rtos/hal_nxp/pull/689)

Depends on: zephyrproject-rtos/hal_nxp#689

Signed-off-by: Archit Anant <architanant5@gmail.com>