### PR TITLE
dts: arm: ti: update J721E R5 compatible string to cortex-r5f

### DIFF
--- a/dts/arm/ti/am64x_r5.dtsi
+++ b/dts/arm/ti/am64x_r5.dtsi
@@ -21,7 +21,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-r5";
+			compatible = "arm,cortex-r5f";
 			reg = <0>;
 			clock-frequency = <DT_FREQ_M(800)>;
 		};

--- a/dts/arm/ti/j721e_main_r5.dtsi
+++ b/dts/arm/ti/j721e_main_r5.dtsi
@@ -21,7 +21,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-r5";
+			compatible = "arm,cortex-r5f";
 			reg = <0>;
 		};
 	};

--- a/dts/arm/ti/j722s_main_r5.dtsi
+++ b/dts/arm/ti/j722s_main_r5.dtsi
@@ -23,7 +23,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-r5";
+			compatible = "arm,cortex-r5f";
 			reg = <0>;
 		};
 	};

--- a/dts/arm/ti/j722s_mcu_r5.dtsi
+++ b/dts/arm/ti/j722s_mcu_r5.dtsi
@@ -23,7 +23,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-r5";
+			compatible = "arm,cortex-r5f";
 			reg = <0>;
 		};
 	};


### PR DESCRIPTION
This PR fixes an incorrect compatible string in the TI J721E R5 DTS file (`j721e_main_r5.dtsi`).

Currently, the core is defined as `arm,cortex-r5`. However, the core is a Cortex-R5F, and the FPU is already correctly enabled in the Kconfig:
`BOARD_BEAGLEBONE_AI64 -> SOC_J721E_MAIN_R5F0_0 -> SOC_SERIES_AM6X_R5 -> VFP_SP_D16`