### PR TITLE
Bluetooth: GATT: Fix bad error from bt_gatt_attr_read_included

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1788,7 +1788,7 @@ ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
 				   void *buf, uint16_t len, uint16_t offset)
 {
 	if ((attr == NULL) || (attr->user_data == NULL)) {
-		return -EINVAL;
+		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 	}
 
 	struct bt_gatt_attr *incl = attr->user_data;


### PR DESCRIPTION
If `attr` or `attr->user_data` is NULL, then the include characteristic is invalid. However the function,
bt_gatt_attr_read_included, should not return an errno value, but a GATT error. The reason why errno cannot be used, is that the return value is parsed through err_to_att which would make -EINVAL become 0x16 (depending on the libc implementation), which is an invalid ATT error code.

This was incorrectly introduced by commit
5a8189bf2afec221b925065854a714b1088ccddc.

Changed the return value from errno to a proper GATT/ATT error.