### PR TITLE
dt-bindings/interrupt-controller: ite: Add RTC alarm interrupt numbers

### DIFF
--- a/include/zephyr/dt-bindings/interrupt-controller/ite-intc.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/ite-intc.h
@@ -56,6 +56,10 @@
 #define IT8XXX2_IRQ_WU66        54
 #define IT8XXX2_IRQ_WU67        55
 /* Group 7 */
+/** RTC alarm1 interrupt */
+#define IT8XXX2_IRQ_RTCT_ALARM1 56
+/** RTC alarm2 interrupt */
+#define IT8XXX2_IRQ_RTCT_ALARM2 57
 #define IT8XXX2_IRQ_TIMER2      58
 /* Group 8 */
 #define IT8XXX2_IRQ_PMC3_IBF    67


### PR DESCRIPTION
Add IRQ numbers for RTC1 and RTC2 alarm on the IT8xxx2 interrupt controller for RTC driver support.