### PR TITLE
dts: nrf5340: cpunet: add hfxo and lfxo nodes to soc

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -779,6 +779,17 @@ MEMC
   Hard-coded default values in drivers, of 320 (:dtcompatible:`st,stm32-xspi-psram`) and 129
   (:dtcompatible:`st,stm32-ospi-psram`), have been removed.
 
+Nordic
+======
+
+* :dtcompatible:`nordic,nrf53-hfxo` and :dtcompatible:`nordic,nrf53-lfxo` have been added to the
+  nRF5340 CPUNET target found in :zephyr_file:`dts/arm/nordic/nrf5340_cpunet.dtsi`. Previously
+  these clocks were only present in the devicetree for the CPUAPP target, thus the specified
+  startup time of the ``&hfxo`` was not used when building, for example, the Bluetooth
+  controller for the nRF5340 CPUNET target. The ``startup-time-us`` property of the ``&hfxo``
+  should be overwritten by any board using the nRF5340 SoC, otherwise it will default to 1400 us.
+  (:github:`105558`).
+
 NXP
 ===
 

--- a/dts/arm/nordic/nrf5340_clocks.dtsi
+++ b/dts/arm/nordic/nrf5340_clocks.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	clocks {
+		lfxo: lfxo {
+			compatible = "nordic,nrf53-lfxo";
+			#clock-cells = <0>;
+			clock-frequency = <32768>;
+		};
+
+		hfxo: hfxo {
+			compatible = "nordic,nrf53-hfxo";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(32)>;
+			startup-time-us = <1400>;
+		};
+	};
+};

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
 #include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuapp_ns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_ns.dtsi
@@ -9,6 +9,7 @@
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
 #include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -15,19 +15,6 @@ dcnf: dcnf@0 {
 oscillators: clock-controller@4000 {
 	compatible = "nordic,nrf53-oscillators";
 	reg = <0x4000 0x1000>;
-
-	lfxo: lfxo {
-		compatible = "nordic,nrf53-lfxo";
-		#clock-cells = <0>;
-		clock-frequency = <32768>;
-	};
-
-	hfxo: hfxo {
-		compatible = "nordic,nrf53-hfxo";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(32)>;
-		startup-time-us = <1400>;
-	};
 };
 
 regulators: regulator@4000 {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	chosen {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -424,18 +424,19 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	lll = p->param;
 
 	/* Accumulate window widening */
-	lll->window_widening_prepare_us += lll->window_widening_periodic_us *
-					   (lll->lazy_prepare + 1U);
+	lll->window_widening_prepare_us += lll->window_widening_periodic_us * lll->lazy_prepare;
 	if (lll->window_widening_prepare_us > lll->window_widening_max_us) {
 		lll->window_widening_prepare_us = lll->window_widening_max_us;
 	}
 
 	/* Current window widening */
 	lll->window_widening_event_us += lll->window_widening_prepare_us;
-	lll->window_widening_prepare_us = 0;
 	if (lll->window_widening_event_us > lll->window_widening_max_us) {
 		lll->window_widening_event_us =	lll->window_widening_max_us;
 	}
+
+	/* Pre-increment window widening */
+	lll->window_widening_prepare_us = lll->window_widening_periodic_us;
 
 	/* Reset chain PDU being scheduled by lll_sync context */
 	lll->is_aux_sched = 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -200,18 +200,19 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	lll->latency_prepare = 0U;
 
 	/* Accumulate window widening */
-	lll->window_widening_prepare_us += lll->window_widening_periodic_us *
-					   (lll->lazy_prepare + 1U);
+	lll->window_widening_prepare_us += lll->window_widening_periodic_us * lll->lazy_prepare;
 	if (lll->window_widening_prepare_us > lll->window_widening_max_us) {
 		lll->window_widening_prepare_us = lll->window_widening_max_us;
 	}
 
 	/* Current window widening */
 	lll->window_widening_event_us += lll->window_widening_prepare_us;
-	lll->window_widening_prepare_us = 0U;
 	if (lll->window_widening_event_us > lll->window_widening_max_us) {
 		lll->window_widening_event_us =	lll->window_widening_max_us;
 	}
+
+	/* Pre-increment window widening */
+	lll->window_widening_prepare_us = lll->window_widening_periodic_us;
 
 	/* Initialize trx chain count */
 	trx_cnt = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -364,6 +364,21 @@ conn_is_valid:
 	slot_us = max_tx_time + max_rx_time;
 	slot_us += conn_lll->tifs_rx_us + (EVENT_CLOCK_JITTER_US << 1);
 	slot_us += ready_delay_us;
+
+#if !defined(CONFIG_BT_CTLR_CENTRAL_SPACING) || (CONFIG_BT_CTLR_CENTRAL_SPACING == 0U)
+	/* Let's be considerate of peripheral window widening and space multiple centrals
+	 * accordingly by including it in the time reservation.
+	 */
+	const uint8_t sca_acl_value_500_ppm = 0U; /* SCA value for 500 ppm, for ACL intervals */
+	uint32_t periph_window_widening_periodic_max_us =
+		DIV_ROUND_UP(((lll_clock_ppm_local_get() +
+			       lll_clock_ppm_get(sca_acl_value_500_ppm)) *
+			      ((uint32_t)interval * CONN_INT_UNIT_US)), USEC_PER_SEC);
+
+	slot_us += periph_window_widening_periodic_max_us << 1U;
+#endif /* !CONFIG_BT_CTLR_CENTRAL_SPACING || (CONFIG_BT_CTLR_CENTRAL_SPACING == 0U) */
+
+	/* Add event overheads */
 	slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 
 	conn->ull.ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(slot_us);

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -66,10 +66,17 @@
 #endif
 
 /* CIS Create Procedure uses 3 PDU transmissions, and one connection interval to process the LLCP
- * requested, hence minimum relative instant not be less than 4. I.e. the CIS_REQ PDU will be
- * transmitted in the next ACL interval.
- * The +1 also helps with the fact that currently we do not have Central implementation to handle
- * event latencies at the instant. Refer to `ull_conn_iso_start()` implementation.
+ * requested, hence ideally set the minimum relative instant not less than 4. I.e. the CIS_REQ PDU
+ * will be transmitted in the next ACL interval and the instant will be at the 4th ACL interval.
+ * This way both Central and Peripheral do not need to exercise any ACL interval latencies when
+ * establishing the CIG/CIS.
+ *
+ * BLUETOOTH CORE SPECIFICATION Version 6.3 | Vol 6, Part B, Section 2.4.2.29 LL_CIS_REQ
+ * "connEventCount should be set to a value greater than currEvent of the event in which the
+ * LL_CIS_REQ PDU is first transmitted."
+ *
+ * NOTE: The implementation can handle ACL latencies establishing the CIG/CIS with relative instant
+ *       of 0.
  */
 #define CIS_CREATE_INSTANT_DELTA_MIN 4U
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -81,6 +81,7 @@ static void mfy_cis_offset_get(void *param);
 static void ticker_op_cb(uint32_t status, void *param);
 #endif /* CONFIG_BT_CTLR_CENTRAL_SPACING  == 0 */
 
+static uint32_t cig_cis_offset_get(const struct ll_conn_iso_stream *cis, uint32_t ticks_offset);
 static uint32_t iso_interval_adjusted_bn_max_pdu_get(bool framed, uint32_t iso_interval,
 						     uint32_t iso_interval_cig,
 						     uint32_t sdu_interval,
@@ -925,11 +926,8 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	} else if (CONFIG_BT_CTLR_CENTRAL_SPACING > 0) {
 		uint32_t cis_offset;
 
-		cis_offset = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
-			     (EVENT_TICKER_RES_MARGIN_US << 1U);
-
-		cis_offset += cig->sync_delay - cis->sync_delay;
-
+		/* Calculate the offset for the select CIS in the CIG */
+		cis_offset = cig_cis_offset_get(cis, conn->ull.ticks_slot);
 		if (cis_offset < *cis_offset_min) {
 			cis_offset = *cis_offset_min;
 		}
@@ -1023,10 +1021,8 @@ int ull_central_iso_cis_offset_get(uint16_t cis_handle,
 	return -EBUSY;
 #else /* CONFIG_BT_CTLR_CENTRAL_SPACING != 0 */
 
-	*cis_offset_min = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
-			  (EVENT_TICKER_RES_MARGIN_US << 1U);
-
-	*cis_offset_min += cig->sync_delay - cis->sync_delay;
+	/* Calculate the offset for the select CIS in the CIG */
+	*cis_offset_min = cig_cis_offset_get(cis, conn->ull.ticks_slot);
 
 	return 0;
 #endif /* CONFIG_BT_CTLR_CENTRAL_SPACING != 0 */
@@ -1092,9 +1088,7 @@ static void mfy_cig_offset_get(void *param)
 	LL_ASSERT_DBG(!err);
 
 	/* Calculate the offset for the select CIS in the CIG */
-	offset_min_us = HAL_TICKER_TICKS_TO_US(ticks_to_expire) +
-			(EVENT_TICKER_RES_MARGIN_US << 2U);
-	offset_min_us += cig->sync_delay - cis->sync_delay;
+	offset_min_us = cig_cis_offset_get(cis, ticks_to_expire);
 
 	conn = ll_conn_get(cis->lll.acl_handle);
 	LL_ASSERT_DBG(conn != NULL);
@@ -1262,6 +1256,24 @@ static void ticker_op_cb(uint32_t status, void *param)
 	*((uint32_t volatile *)param) = status;
 }
 #endif /* CONFIG_BT_CTLR_CENTRAL_SPACING  == 0 */
+
+static uint32_t cig_cis_offset_get(const struct ll_conn_iso_stream *cis, uint32_t ticks_offset)
+{
+	const struct ll_conn_iso_group *cig;
+	uint32_t offset_us;
+
+	/* Get reference to associated CIG context for the CIS */
+	cig = cis->group;
+
+	/* Calculate the CIS offset from the CIG anchor point */
+	offset_us = HAL_TICKER_TICKS_TO_US(ticks_offset);
+	offset_us += cig->sync_delay - cis->sync_delay;
+
+	/* Add the event resolution margin jitter of both ACL and CIG */
+	offset_us += (EVENT_TICKER_RES_MARGIN_US << 2U);
+
+	return offset_us;
+}
 
 static uint32_t iso_interval_adjusted_bn_max_pdu_get(bool framed, uint32_t iso_interval,
 						     uint32_t iso_interval_cig,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1370,9 +1370,15 @@ void ull_conn_done(struct node_rx_event_done *done)
 		slot_us = tx_time + rx_time;
 		slot_us += lll->tifs_rx_us + (EVENT_CLOCK_JITTER_US << 1);
 		slot_us += ready_delay;
+#if defined(CONFIG_BT_PERIPHERAL)
+		if (lll->role == BT_HCI_ROLE_PERIPHERAL) {
+			slot_us += lll->periph.window_widening_periodic_us << 1U;
+			slot_us += EVENT_JITTER_US << 1U;
+		}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX) ||
-		    !conn->lll.role) {
+		    (lll->role == BT_HCI_ROLE_CENTRAL)) {
 			slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 		}
 
@@ -2403,6 +2409,12 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 		slot_us = max_tx_time + max_rx_time;
 		slot_us += lll->tifs_rx_us + (EVENT_CLOCK_JITTER_US << 1);
 		slot_us += ready_delay_us;
+#if defined(CONFIG_BT_PERIPHERAL)
+		if (lll->role == BT_HCI_ROLE_PERIPHERAL) {
+			slot_us += lll->periph.window_widening_periodic_us << 1U;
+			slot_us += EVENT_JITTER_US << 1U;
+		}
+#endif /* CONFIG_BT_PERIPHERAL */
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX) ||
 		    (lll->role == BT_HCI_ROLE_CENTRAL)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -900,14 +900,14 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 	}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-	/* Connection establishment timeout */
-	cis->event_expire = CONN_ESTAB_COUNTDOWN;
-
 	/* Check if another CIS was already started and CIG ticker is
 	 * running. If so, we just return with updated offset and
 	 * validated handle.
 	 */
 	if (cig->state == CIG_STATE_ACTIVE) {
+		/* Connection establishment timeout */
+		cis->event_expire = CONN_ESTAB_COUNTDOWN;
+
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 		/* Initialize CIS event lazy at CIS create */
 		cis->lll.lazy_active = 0U;
@@ -960,6 +960,9 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 		}
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START */
 
+		/* Connection establishment timeout */
+		cis->event_expire = CONN_ESTAB_COUNTDOWN;
+
 		if (instant_latency > 0U) {
 			/* Try to start the CIG late by finding the CIG event relative to current
 			 * ACL event, taking latency into consideration. Adjust ticker periodicity
@@ -990,6 +993,7 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 				lost_cig_events = 1U;
 				cis_offset = cis->offset + iso_interval_us - acl_latency_us;
 			}
+
 			/* Correct the cis_offset to next CIG event, if the ACL and CIG overlaps.
 			 * ACL radio event at the instant was skipped and a relative CIS offset at
 			 * the current ACL event has been calculated. But the current ACL event
@@ -1003,6 +1007,7 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			}
 
 			cis->lll.event_count_prepare += lost_cig_events;
+			cis->event_expire += lost_cig_events;
 
 			if (lost_cig_events > (cis->lll.rx.ft - 1)) {
 				lost_payloads = (lost_cig_events - (cis->lll.rx.ft - 1)) *
@@ -1035,16 +1040,83 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 
 	} else if (IS_CENTRAL(cig)) {
+		uint32_t acl_interval_us;
 		uint32_t iso_interval_us;
 
+		acl_interval_us = conn->lll.interval * CONN_INT_UNIT_US;
 		iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
+
+		/* Connection establishment timeout */
+		cis->event_expire = (DIV_ROUND_UP((acl_interval_us - cis->offset),
+						  iso_interval_us) + 1U) * CONN_ESTAB_COUNTDOWN;
+
+		if (instant_latency > 0U) {
+			/* Try to start the CIG late by finding the CIG event relative to current
+			 * ACL event, taking latency into consideration.
+			 */
+			uint32_t lost_cig_events;
+			uint32_t acl_latency_us;
+			uint32_t lost_payloads;
+			uint32_t cis_offset;
+
+			acl_latency_us = instant_latency * acl_interval_us;
+			iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
+
+			if (acl_latency_us > iso_interval_us) {
+				/* Latency is greater than the ISO interval - find the offset from
+				 * this ACL event to the next active ISO event, and adjust the event
+				 * counter accordingly.
+				 */
+				lost_cig_events = DIV_ROUND_UP(acl_latency_us - cis->offset,
+							       iso_interval_us);
+				cis_offset = cis->offset + (lost_cig_events * iso_interval_us) -
+					     acl_latency_us;
+			} else {
+				/* Latency is less than- or equal to one ISO interval - start at
+				 * next ISO event.
+				 */
+				lost_cig_events = 1U;
+				cis_offset = cis->offset + iso_interval_us - acl_latency_us;
+			}
+
+			/* Correct the cis_offset to next CIG event, if the ACL and CIG overlaps.
+			 * ACL radio event at the instant was skipped and a relative CIS offset at
+			 * the current ACL event has been calculated. But the current ACL event
+			 * is partially overlapping with the other of CISes (not yet established) in
+			 * the CIG event. Hence, lets establish the CIS at the next ISO interval so
+			 * as to have a positive CIG event offset.
+			 */
+			if (cis_offset < (cig->sync_delay - cis->sync_delay)) {
+				cis_offset += iso_interval_us;
+				lost_cig_events++;
+			}
+
+			cis->lll.event_count_prepare += lost_cig_events;
+			cis->event_expire += lost_cig_events;
+
+			if (lost_cig_events > (cis->lll.rx.ft - 1)) {
+				lost_payloads = (lost_cig_events - (cis->lll.rx.ft - 1)) *
+						cis->lll.rx.bn;
+			} else {
+				lost_payloads = 0U;
+			}
+			cis->lll.rx.payload_count += lost_payloads;
+
+			if (lost_cig_events > (cis->lll.tx.ft - 1)) {
+				lost_payloads = (lost_cig_events - (cis->lll.tx.ft - 1)) *
+						cis->lll.tx.bn;
+			} else {
+				lost_payloads = 0U;
+			}
+			cis->lll.tx.payload_count += lost_payloads;
+
+			/* Calculate new offset */
+			cig_offset_us = cig_offset_calc(cig, cis, cis_offset, &ticks_at_expire,
+							remainder);
+		}
+
 		ticks_periodic  = HAL_TICKER_US_TO_TICKS(iso_interval_us);
 		ticks_remainder = HAL_TICKER_REMAINDER(iso_interval_us);
-
-		/* FIXME: Handle latency due to skipped ACL events around the
-		 * instant to start CIG
-		 */
-		LL_ASSERT_ERR(instant_latency == 0U);
 	} else {
 		LL_ASSERT_DBG(0);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -66,6 +66,12 @@
 
 
 static int init_reset(void);
+static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_iso_stream *cis,
+				uint32_t cis_offset, uint32_t *ticks_at_expire, uint32_t remainder);
+static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
+					 struct ll_conn_iso_stream *cis, uint32_t acl_latency_us,
+					 uint32_t iso_interval_us, uint32_t *ticks_at_expire,
+					 uint32_t remainder);
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 static void cis_lazy_fill(struct ll_conn_iso_stream *cis);
 static void mfy_cis_lazy_fill(void *param);
@@ -808,35 +814,6 @@ void ull_conn_iso_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	ull_conn_iso_transmit_test_cig_interval(cig->lll.handle, ticks_at_expire);
 }
 
-static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_iso_stream *cis,
-				uint32_t cis_offset, uint32_t *ticks_at_expire, uint32_t remainder)
-{
-	uint32_t acl_to_cig_ref_point;
-	uint32_t cis_offs_to_cig_ref;
-	uint32_t remainder_us;
-
-	remainder_us = remainder;
-	hal_ticker_remove_jitter(ticks_at_expire, &remainder_us);
-
-	cis_offs_to_cig_ref = cig->sync_delay - cis->sync_delay;
-
-	/* Establish the CIG reference point by adjusting ACL-to-CIS offset
-	 * (cis->offset) by the difference between CIG- and CIS sync delays.
-	 */
-	acl_to_cig_ref_point = cis_offset - cis_offs_to_cig_ref;
-
-	/* Calculate the CIG reference point of first CIG event. This
-	 * calculation is inaccurate. However it is the best estimate available
-	 * until the first anchor point for the leading CIS is available.
-	 */
-	cig->cig_ref_point = isoal_get_wrapped_time_us(HAL_TICKER_TICKS_TO_US(*ticks_at_expire),
-						       remainder_us +
-						       EVENT_OVERHEAD_START_US +
-						       acl_to_cig_ref_point);
-	/* Calculate initial ticker offset */
-	return remainder_us + acl_to_cig_ref_point;
-}
-
 void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			uint32_t ticks_at_expire, uint32_t remainder,
 			uint16_t instant_latency)
@@ -968,71 +945,19 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			 * ACL event, taking latency into consideration. Adjust ticker periodicity
 			 * with increased window widening.
 			 */
-			uint32_t lost_cig_events;
-			uint32_t iso_interval_us;
 			uint32_t acl_latency_us;
-			uint32_t lost_payloads;
-			uint32_t cis_offset;
+			uint32_t iso_interval_us;
 
 			acl_latency_us = instant_latency * conn->lll.interval * CONN_INT_UNIT_US;
 			iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
-
-			if (acl_latency_us > iso_interval_us) {
-				/* Latency is greater than the ISO interval - find the offset from
-				 * this ACL event to the next active ISO event, and adjust the event
-				 * counter accordingly.
-				 */
-				lost_cig_events = DIV_ROUND_UP(acl_latency_us - cis->offset,
-							       iso_interval_us);
-				cis_offset = cis->offset + (lost_cig_events * iso_interval_us) -
-					     acl_latency_us;
-			} else {
-				/* Latency is less than- or equal to one ISO interval - start at
-				 * next ISO event.
-				 */
-				lost_cig_events = 1U;
-				cis_offset = cis->offset + iso_interval_us - acl_latency_us;
-			}
-
-			/* Correct the cis_offset to next CIG event, if the ACL and CIG overlaps.
-			 * ACL radio event at the instant was skipped and a relative CIS offset at
-			 * the current ACL event has been calculated. But the current ACL event
-			 * is partially overlapping with the other of CISes (not yet established) in
-			 * the CIG event. Hence, lets establish the CIS at the next ISO interval so
-			 * as to have a positive CIG event offset.
-			 */
-			if (cis_offset < (cig->sync_delay - cis->sync_delay)) {
-				cis_offset += iso_interval_us;
-				lost_cig_events++;
-			}
-
-			cis->lll.event_count_prepare += lost_cig_events;
-			cis->event_expire += lost_cig_events;
-
-			if (lost_cig_events > (cis->lll.rx.ft - 1)) {
-				lost_payloads = (lost_cig_events - (cis->lll.rx.ft - 1)) *
-						cis->lll.rx.bn;
-			} else {
-				lost_payloads = 0U;
-			}
-			cis->lll.rx.payload_count += lost_payloads;
-
-			if (lost_cig_events > (cis->lll.tx.ft - 1)) {
-				lost_payloads = (lost_cig_events - (cis->lll.tx.ft - 1)) *
-						cis->lll.tx.bn;
-			} else {
-				lost_payloads = 0U;
-			}
-			cis->lll.tx.payload_count += lost_payloads;
+			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
+								 iso_interval_us, &ticks_at_expire,
+								 remainder);
 
 			/* Adjust for extra window widening */
-			iso_interval_us_frac = EVENT_US_TO_US_FRAC(cig->iso_interval *
-								   ISO_INT_UNIT_US);
+			iso_interval_us_frac = EVENT_US_TO_US_FRAC(iso_interval_us);
 			iso_interval_us_frac -= cig->lll.window_widening_periodic_us_frac *
 						instant_latency;
-			/* Calculate new offset */
-			cig_offset_us = cig_offset_calc(cig, cis, cis_offset, &ticks_at_expire,
-							remainder);
 		}
 
 		ticks_periodic  = EVENT_US_FRAC_TO_TICKS(iso_interval_us_frac);
@@ -1054,65 +979,12 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			/* Try to start the CIG late by finding the CIG event relative to current
 			 * ACL event, taking latency into consideration.
 			 */
-			uint32_t lost_cig_events;
 			uint32_t acl_latency_us;
-			uint32_t lost_payloads;
-			uint32_t cis_offset;
 
 			acl_latency_us = instant_latency * acl_interval_us;
-			iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
-
-			if (acl_latency_us > iso_interval_us) {
-				/* Latency is greater than the ISO interval - find the offset from
-				 * this ACL event to the next active ISO event, and adjust the event
-				 * counter accordingly.
-				 */
-				lost_cig_events = DIV_ROUND_UP(acl_latency_us - cis->offset,
-							       iso_interval_us);
-				cis_offset = cis->offset + (lost_cig_events * iso_interval_us) -
-					     acl_latency_us;
-			} else {
-				/* Latency is less than- or equal to one ISO interval - start at
-				 * next ISO event.
-				 */
-				lost_cig_events = 1U;
-				cis_offset = cis->offset + iso_interval_us - acl_latency_us;
-			}
-
-			/* Correct the cis_offset to next CIG event, if the ACL and CIG overlaps.
-			 * ACL radio event at the instant was skipped and a relative CIS offset at
-			 * the current ACL event has been calculated. But the current ACL event
-			 * is partially overlapping with the other of CISes (not yet established) in
-			 * the CIG event. Hence, lets establish the CIS at the next ISO interval so
-			 * as to have a positive CIG event offset.
-			 */
-			if (cis_offset < (cig->sync_delay - cis->sync_delay)) {
-				cis_offset += iso_interval_us;
-				lost_cig_events++;
-			}
-
-			cis->lll.event_count_prepare += lost_cig_events;
-			cis->event_expire += lost_cig_events;
-
-			if (lost_cig_events > (cis->lll.rx.ft - 1)) {
-				lost_payloads = (lost_cig_events - (cis->lll.rx.ft - 1)) *
-						cis->lll.rx.bn;
-			} else {
-				lost_payloads = 0U;
-			}
-			cis->lll.rx.payload_count += lost_payloads;
-
-			if (lost_cig_events > (cis->lll.tx.ft - 1)) {
-				lost_payloads = (lost_cig_events - (cis->lll.tx.ft - 1)) *
-						cis->lll.tx.bn;
-			} else {
-				lost_payloads = 0U;
-			}
-			cis->lll.tx.payload_count += lost_payloads;
-
-			/* Calculate new offset */
-			cig_offset_us = cig_offset_calc(cig, cis, cis_offset, &ticks_at_expire,
-							remainder);
+			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
+								 iso_interval_us, &ticks_at_expire,
+								 remainder);
 		}
 
 		ticks_periodic  = HAL_TICKER_US_TO_TICKS(iso_interval_us);
@@ -1218,6 +1090,94 @@ void ull_conn_iso_cis_terminate_done(struct node_rx_pdu *rx)
 		(void)mayfly_enqueue(TICKER_USER_ID_THREAD,
 				     TICKER_USER_ID_ULL_HIGH, 1, &mfys[cig->lll.handle]);
 	}
+}
+
+static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_iso_stream *cis,
+				uint32_t cis_offset, uint32_t *ticks_at_expire, uint32_t remainder)
+{
+	uint32_t acl_to_cig_ref_point;
+	uint32_t cis_offs_to_cig_ref;
+	uint32_t remainder_us;
+
+	remainder_us = remainder;
+	hal_ticker_remove_jitter(ticks_at_expire, &remainder_us);
+
+	cis_offs_to_cig_ref = cig->sync_delay - cis->sync_delay;
+
+	/* Establish the CIG reference point by adjusting ACL-to-CIS offset
+	 * (cis->offset) by the difference between CIG- and CIS sync delays.
+	 */
+	acl_to_cig_ref_point = cis_offset - cis_offs_to_cig_ref;
+
+	/* Calculate the CIG reference point of first CIG event. This
+	 * calculation is inaccurate. However it is the best estimate available
+	 * until the first anchor point for the leading CIS is available.
+	 */
+	cig->cig_ref_point = isoal_get_wrapped_time_us(HAL_TICKER_TICKS_TO_US(*ticks_at_expire),
+						       remainder_us + EVENT_OVERHEAD_START_US +
+						       acl_to_cig_ref_point);
+	/* Calculate initial ticker offset */
+	return remainder_us + acl_to_cig_ref_point;
+}
+
+static uint32_t cis_payload_count_lost(uint32_t lost_cig_events, uint8_t ft, uint8_t bn)
+{
+	uint32_t lost_payloads;
+
+	if (lost_cig_events > (ft - 1U)) {
+		lost_payloads = (lost_cig_events - (ft - 1U)) * bn;
+	} else {
+		lost_payloads = 0U;
+	}
+
+	return lost_payloads;
+}
+
+static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
+					 struct ll_conn_iso_stream *cis, uint32_t acl_latency_us,
+					 uint32_t iso_interval_us, uint32_t *ticks_at_expire,
+					 uint32_t remainder)
+{
+	uint32_t lost_cig_events;
+	uint32_t cis_offset_us;
+	uint32_t cig_offset_us;
+
+	if (acl_latency_us > iso_interval_us) {
+		/* Latency is greater than the ISO interval - find the offset from
+		 * this ACL event to the next active ISO event, and adjust the event
+		 * counter accordingly.
+		 */
+		lost_cig_events = DIV_ROUND_UP(acl_latency_us - cis->offset, iso_interval_us);
+		cis_offset_us = cis->offset + (lost_cig_events * iso_interval_us) - acl_latency_us;
+	} else {
+		/* Latency is less than- or equal to one ISO interval - start at
+		 * next ISO event.
+		 */
+		lost_cig_events = 1U;
+		cis_offset_us = cis->offset + iso_interval_us - acl_latency_us;
+	}
+
+	/* Correct the cis_offset to next CIG event, if the ACL and CIG overlaps. ACL radio event at
+	 * the instant was skipped and a relative CIS offset at the current ACL event has been
+	 * calculated. But the current ACL event is partially overlapping with the other of CISes
+	 * (not yet established) in the CIG event. Hence, let's establish the CIS at the next ISO
+	 * interval so as to have a positive CIG event offset.
+	 */
+	if (cis_offset_us < (cig->sync_delay - cis->sync_delay)) {
+		cis_offset_us += iso_interval_us;
+		lost_cig_events++;
+	}
+
+	cis->lll.event_count_prepare += lost_cig_events;
+	cis->event_expire += lost_cig_events;
+	cis->lll.rx.payload_count += cis_payload_count_lost(lost_cig_events, cis->lll.rx.ft,
+							    cis->lll.rx.bn);
+	cis->lll.tx.payload_count += cis_payload_count_lost(lost_cig_events, cis->lll.tx.ft,
+							    cis->lll.tx.bn);
+
+	cig_offset_us = cig_offset_calc(cig, cis, cis_offset_us, ticks_at_expire, remainder);
+
+	return cig_offset_us;
 }
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -67,11 +67,12 @@
 
 static int init_reset(void);
 static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_iso_stream *cis,
-				uint32_t cis_offset, uint32_t *ticks_at_expire, uint32_t remainder);
+				uint32_t cis_offset, uint32_t ticks_at_expire,
+				uint32_t remainder_us);
 static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
 					 struct ll_conn_iso_stream *cis, uint32_t acl_latency_us,
-					 uint32_t iso_interval_us, uint32_t *ticks_at_expire,
-					 uint32_t remainder);
+					 uint32_t iso_interval_us, uint32_t ticks_at_expire,
+					 uint32_t remainder_us);
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 static void cis_lazy_fill(struct ll_conn_iso_stream *cis);
 static void mfy_cis_lazy_fill(void *param);
@@ -900,9 +901,13 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 		return;
 	}
 
-	ticker_id = TICKER_ID_CONN_ISO_BASE + ll_conn_iso_group_handle_get(cig);
+	uint32_t remainder_us = remainder;
 
-	cig_offset_us = cig_offset_calc(cig, cis, cis->offset, &ticks_at_expire, remainder);
+	hal_ticker_remove_jitter(&ticks_at_expire, &remainder_us);
+
+	cig_offset_us = cig_offset_calc(cig, cis, cis->offset, ticks_at_expire, remainder_us);
+
+	ticker_id = TICKER_ID_CONN_ISO_BASE + ll_conn_iso_group_handle_get(cig);
 
 	if (false) {
 
@@ -958,8 +963,8 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 
 			iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
 			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
-								 iso_interval_us, &ticks_at_expire,
-								 remainder);
+								 iso_interval_us, ticks_at_expire,
+								 remainder_us);
 
 			/* Adjust for extra window widening */
 			iso_interval_us_frac = EVENT_US_TO_US_FRAC(iso_interval_us);
@@ -996,8 +1001,8 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			acl_latency_us &= 0xFFFFFFFFULL;
 
 			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
-								 iso_interval_us, &ticks_at_expire,
-								 remainder);
+								 iso_interval_us, ticks_at_expire,
+								 remainder_us);
 		}
 
 		ticks_periodic  = HAL_TICKER_US_TO_TICKS(iso_interval_us);
@@ -1106,14 +1111,11 @@ void ull_conn_iso_cis_terminate_done(struct node_rx_pdu *rx)
 }
 
 static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_iso_stream *cis,
-				uint32_t cis_offset, uint32_t *ticks_at_expire, uint32_t remainder)
+				uint32_t cis_offset, uint32_t ticks_at_expire,
+				uint32_t remainder_us)
 {
 	uint32_t acl_to_cig_ref_point;
 	uint32_t cis_offs_to_cig_ref;
-	uint32_t remainder_us;
-
-	remainder_us = remainder;
-	hal_ticker_remove_jitter(ticks_at_expire, &remainder_us);
 
 	cis_offs_to_cig_ref = cig->sync_delay - cis->sync_delay;
 
@@ -1126,7 +1128,7 @@ static uint32_t cig_offset_calc(struct ll_conn_iso_group *cig, struct ll_conn_is
 	 * calculation is inaccurate. However it is the best estimate available
 	 * until the first anchor point for the leading CIS is available.
 	 */
-	cig->cig_ref_point = isoal_get_wrapped_time_us(HAL_TICKER_TICKS_TO_US(*ticks_at_expire),
+	cig->cig_ref_point = isoal_get_wrapped_time_us(HAL_TICKER_TICKS_TO_US(ticks_at_expire),
 						       remainder_us + EVENT_OVERHEAD_START_US +
 						       acl_to_cig_ref_point);
 	/* Calculate initial ticker offset */
@@ -1148,8 +1150,8 @@ static uint32_t cis_payload_count_lost(uint32_t lost_cig_events, uint8_t ft, uin
 
 static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
 					 struct ll_conn_iso_stream *cis, uint32_t acl_latency_us,
-					 uint32_t iso_interval_us, uint32_t *ticks_at_expire,
-					 uint32_t remainder)
+					 uint32_t iso_interval_us, uint32_t ticks_at_expire,
+					 uint32_t remainder_us)
 {
 	uint32_t lost_cig_events;
 	uint32_t cis_offset_us;
@@ -1206,7 +1208,7 @@ static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
 	cis->lll.tx.payload_count += cis_payload_count_lost(lost_cig_events, cis->lll.tx.ft,
 							    cis->lll.tx.bn);
 
-	cig_offset_us = cig_offset_calc(cig, cis, cis_offset_us, ticks_at_expire, remainder);
+	cig_offset_us = cig_offset_calc(cig, cis, cis_offset_us, ticks_at_expire, remainder_us);
 
 	return cig_offset_us;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -945,10 +945,17 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			 * ACL event, taking latency into consideration. Adjust ticker periodicity
 			 * with increased window widening.
 			 */
-			uint32_t acl_latency_us;
+			uint64_t acl_latency_us;
 			uint32_t iso_interval_us;
 
-			acl_latency_us = instant_latency * conn->lll.interval * CONN_INT_UNIT_US;
+			acl_latency_us = (uint64_t)instant_latency * conn->lll.interval *
+					 CONN_INT_UNIT_US;
+			LL_ASSERT_ERR(acl_latency_us <= UINT32_MAX);
+
+			/* Avoid the requirement of explicit cast when assigning to 32-bit parameter
+			 */
+			acl_latency_us &= 0xFFFFFFFFULL;
+
 			iso_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
 			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
 								 iso_interval_us, &ticks_at_expire,
@@ -979,9 +986,15 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 			/* Try to start the CIG late by finding the CIG event relative to current
 			 * ACL event, taking latency into consideration.
 			 */
-			uint32_t acl_latency_us;
+			uint64_t acl_latency_us;
 
-			acl_latency_us = instant_latency * acl_interval_us;
+			acl_latency_us = (uint64_t)instant_latency * acl_interval_us;
+			LL_ASSERT_ERR(acl_latency_us <= UINT32_MAX);
+
+			/* Avoid the requirement of explicit cast when assigning to 32-bit parameter
+			 */
+			acl_latency_us &= 0xFFFFFFFFULL;
+
 			cig_offset_us = cig_instant_latency_calc(cig, cis, acl_latency_us,
 								 iso_interval_us, &ticks_at_expire,
 								 remainder);
@@ -1143,11 +1156,29 @@ static uint32_t cig_instant_latency_calc(struct ll_conn_iso_group *cig,
 	uint32_t cig_offset_us;
 
 	if (acl_latency_us > iso_interval_us) {
+		LL_ASSERT_DBG(acl_latency_us >= cis->offset);
+
 		/* Latency is greater than the ISO interval - find the offset from
 		 * this ACL event to the next active ISO event, and adjust the event
 		 * counter accordingly.
 		 */
 		lost_cig_events = DIV_ROUND_UP(acl_latency_us - cis->offset, iso_interval_us);
+
+		/* Clamp lost_cig_events to an 8-bit value to keep the 16-bit cis->event_expire
+		 * bounded, regardless of its initial value (it may be CONN_ESTAB_COUNTDOWN or a
+		 * computed multiple of the ISO interval). This limits how far the establishment
+		 * can be deferred and caps the amount of event/loss accounting performed. If a
+		 * very large number of CIG events are effectively lost, let the anchor point sync
+		 * fail and eventually lead to connection failed to be established; this is an
+		 * acceptable compromise. Keep a debug assertion to catch such extreme conditions
+		 * during development.
+		 */
+		LL_ASSERT_DBG(lost_cig_events < UINT8_MAX);
+		if (lost_cig_events >= UINT8_MAX) {
+			/* Consider possible lost_cig_events++ done below in case of ACL overlap */
+			lost_cig_events = UINT8_MAX - 1U;
+		}
+
 		cis_offset_us = cis->offset + (lost_cig_events * iso_interval_us) - acl_latency_us;
 	} else {
 		/* Latency is less than- or equal to one ISO interval - start at

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -490,6 +490,11 @@ static void rp_cc_state_wait_rx_cis_ind(struct ll_conn *conn, struct proc_ctx *c
 			/* Check if this connection event is where we need to start the CIS */
 			rp_cc_check_instant_rx_cis_ind(conn, ctx, evt, param);
 			break;
+		} else {
+			/* FIXME: Add checks for CIG sync_delay >= CIS sync_delay and gracefully
+			 *        handle invalid values by completing the LLCP as failure to
+			 *        establish connection.
+			 */
 		}
 		/* If we get to here the CIG_ID referred in req/acquire has become void/invalid */
 		/* This cannot happen unless the universe has started to deflate */

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -395,6 +395,8 @@ void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 	slot_us = max_rx_time + max_tx_time;
 	slot_us += lll->tifs_rx_us + (EVENT_CLOCK_JITTER_US << 1);
 	slot_us += ready_delay_us;
+	slot_us += lll->periph.window_widening_periodic_us << 1U;
+	slot_us += EVENT_JITTER_US << 1U;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX)) {
 		slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -379,7 +379,8 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 		sync_offset_us -= drift_us;
 	}
 
-	interval_us -= lll->window_widening_periodic_us;
+	lll->window_widening_prepare_us = lll->window_widening_periodic_us;
+	interval_us -= lll->window_widening_prepare_us;
 
 	/* Calculate event time reservation */
 	slot_us = PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, lll->phy);
@@ -1117,7 +1118,8 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 		lll->event_counter++;
 	}
 
-	interval_us -= lll->window_widening_periodic_us;
+	lll->window_widening_prepare_us = lll->window_widening_periodic_us;
+	interval_us -= lll->window_widening_prepare_us;
 
 	/* Calculate event time reservation */
 	slot_us = PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, lll->phy);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -386,6 +386,8 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 	slot_us = PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, lll->phy);
 	ready_delay_us = lll_radio_rx_ready_delay_get(lll->phy, PHY_FLAGS_S8);
 	slot_us += ready_delay_us;
+	slot_us += lll->window_widening_periodic_us << 1U;
+	slot_us += EVENT_JITTER_US << 1U;
 
 	/* Add implementation defined radio event overheads */
 	if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX)) {
@@ -1124,6 +1126,8 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 	/* Calculate event time reservation */
 	slot_us = PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE, lll->phy);
 	slot_us += ready_delay_us;
+	slot_us += lll->window_widening_periodic_us << 1U;
+	slot_us += EVENT_JITTER_US << 1U;
 
 	/* Add implementation defined radio event overheads */
 	if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -603,7 +603,8 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	sync_iso_offset_us -= EVENT_JITTER_US;
 	sync_iso_offset_us -= ready_delay_us;
 
-	interval_us -= lll->window_widening_periodic_us;
+	lll->window_widening_prepare_us = lll->window_widening_periodic_us;
+	interval_us -= lll->window_widening_prepare_us;
 
 	/* Calculate ISO Receiver BIG event timings */
 
@@ -685,7 +686,7 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	if (ticks_diff & BIT(HAL_TICKER_CNTR_MSBIT)) {
 		sync_iso_offset_us += interval_us -
 			lll->window_widening_periodic_us;
-		lll->window_widening_event_us +=
+		lll->window_widening_prepare_us +=
 			lll->window_widening_periodic_us;
 		lll->payload_count += lll->bn;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -658,7 +658,6 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	slot_us += ready_delay_us;
 	slot_us += lll->window_widening_periodic_us << 1U;
 	slot_us += EVENT_JITTER_US << 1U;
-	slot_us += EVENT_TICKER_RES_MARGIN_US << 2U;
 
 	/* Add implementation defined radio event overheads */
 	if (IS_ENABLED(CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX)) {

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -8,6 +8,7 @@ tests:
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpunet
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp


### PR DESCRIPTION
The hfxo and lfxo clocks are used by both cpuapp and cpunet cores, but the hfxo and lfxo nodes are only present in devicetree for the cpuapp core. This prevents the cpunet build from knowing if there is an hfxo and/or lfxo present. Therefore add the lfxo and hfxo clocks to nrf5340_cpunet.dtsi

All boards in tree have both the hfxo and lfxo present, and the calibration these is only possible from cpuapp, so the only information that needs to be made available to cpunet is the hfxo and presence and startup time, and lfxo presence.

20260330:
Bluetooth Controller issues exposed by change in hfxo startup time when changed from 1500 to 1400 us, that are fixed as follows:
* Fixing event resolution margin in cis_offset_min calculation
that caused ACL to overlap CIG when the event jitters due to
the coarse units of the sleep clock used by ticker.
* Fix window widening for Periodic Advertising Sync and ISO
Synchronized Receiver to correctly consider ULL skipped
and LLL prepare skipped events.
Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/2b49185452007a6cc5ff7ff2ab01cac6cc4897d1 ("Bluetooth: Controller: Fix
window widening on connection update").
* Fix missing window widening and permitted sleep clock jitter
in the ACL connection, Periodic Advertising Sync and ISO
Sync Receiver time reservations.
* Fix missing implementation to handle instant_latency for
Central ISO setup.
Fixes `ASSERTION FAIL [instant_latency == 0U] @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c:1010` mentioned in #82399

