### PR TITLE
drivers: udc: mcux: make SOF notifications configurable via Kconfig

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
@@ -117,10 +117,9 @@ BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
 #endif
 #endif
 
-/* TODO: After Kconfig item that enable/disable sof is added,
- * use the Kconfig item to control this macro.
- */
+#ifdef CONFIG_UDC_ENABLE_SOF
 #define USB_DEVICE_CONFIG_SOF_NOTIFICATIONS (1U)
+#endif
 
 #endif
 


### PR DESCRIPTION
Replace the TODO comment with actual Kconfig-based control of the USB_DEVICE_CONFIG_SOF_NOTIFICATIONS macro. The macro is now only defined when CONFIG_UDC_ENABLE_SOF is enabled, allowing users to control SOF (Start of Frame) notifications through Kconfig instead of having it always enabled.