### PR TITLE
drivers: rtc: counter: Optional NVMEM storage for epoch offset

### DIFF
--- a/drivers/rtc/Kconfig.counter
+++ b/drivers/rtc/Kconfig.counter
@@ -10,3 +10,14 @@ config RTC_COUNTER
 	  RTC driver applied for RTC device without broken-down time registers.
 	  Wraps the counter API to provide RTC functionality.
 	  Uses unix timestamp to convert between broken-down time and counter ticks.
+
+config RTC_COUNTER_NVMEM
+	bool "Epoch offset in NVMEM"
+	default y
+	depends on RTC_COUNTER
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ZEPHYR_RTC_COUNTER),nvmem-cells)
+	select NVMEM
+	help
+	  Use an NVMEM cell to write the epoch offset when `rtc_set_time` is called,
+	  and read from the cell on init.
+	  Only compatible nodes with an NVMEM cell named "epoch-offset" will store data.

--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/nvmem.h>
 #include <zephyr/types.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/timeutil.h>
@@ -21,6 +22,9 @@ struct rtc_counter_config {
 	const struct device *counter_dev;
 	/* Number of alarm channels */
 	uint8_t alarms_count;
+#if defined(CONFIG_RTC_COUNTER_NVMEM)
+	struct nvmem_cell epoch_offset_cell;
+#endif
 };
 
 struct rtc_counter_data {
@@ -510,6 +514,16 @@ static int rtc_counter_set_time(const struct device *dev, const struct rtc_time 
 		return ret;
 	}
 
+#if defined(CONFIG_RTC_COUNTER_NVMEM)
+	if (nvmem_cell_is_ready(&config->epoch_offset_cell)) {
+		ret = nvmem_cell_write(&config->epoch_offset_cell, &data->epoch_offset, 0,
+				       sizeof(int64_t));
+		if (ret < 0) {
+			LOG_ERR("Failed to write epoch offset (%d)", ret);
+		}
+	}
+#endif
+
 	return 0;
 }
 
@@ -614,6 +628,18 @@ static int rtc_counter_init(const struct device *dev)
 	data->epoch_offset = 0;
 	data->epoch_valid = false;
 
+#if defined(CONFIG_RTC_COUNTER_NVMEM)
+	if (nvmem_cell_is_ready(&config->epoch_offset_cell)) {
+		int ret = nvmem_cell_read(&config->epoch_offset_cell, &data->epoch_offset, 0,
+					  sizeof(int64_t));
+		if (ret < 0) {
+			LOG_ERR("Failed to read epoch offset (%d)", ret);
+		} else {
+			data->epoch_valid = true;
+		}
+	}
+#endif
+
 #ifdef CONFIG_RTC_ALARM
 	data->rtc_dev = dev;
 	if (config->alarms_count == 0U) {
@@ -679,6 +705,9 @@ DT_INST_FOREACH_STATUS_OKAY(RTC_COUNTER_DECLARE_ALARM_STORAGE)
 	static const struct rtc_counter_config rtc_counter_config_##n = {           \
 		.counter_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                        \
 		.alarms_count = DT_PROP_OR(DT_DRV_INST(n), alarms_count, 0),            \
+		IF_ENABLED(CONFIG_RTC_COUNTER_NVMEM, (                             \
+			.epoch_offset_cell = NVMEM_CELL_INST_GET_BY_NAME_OR(n, epoch_offset, {0}), \
+		))                                                                  \
 	};                                                                          \
 	static struct rtc_counter_data rtc_counter_data_##n = {                     \
 		IF_ENABLED(CONFIG_RTC_ALARM, (                                          \

--- a/dts/bindings/rtc/zephyr,rtc-counter.yaml
+++ b/dts/bindings/rtc/zephyr,rtc-counter.yaml
@@ -1,8 +1,29 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Counter-based Virtual Real Time Clock (RTC)
+title: Counter-based Virtual Real Time Clock (RTC).
+
+description: |
+  Some counters continue running in lower power modes. The epoch offset
+  can be stored in NVMEM so it is preserved across resets, allowing the
+  RTC to maintain wall-clock time as long as the underlying counter keeps
+  running.
 
 compatible: "zephyr,rtc-counter"
 
-include: rtc-device.yaml
+include:
+- rtc-device.yaml
+- nvmem-consumer.yaml
+
+examples:
+- |
+  &rtc {
+          counter_rtc: counter-rtc {
+                  compatible = "zephyr,rtc-counter";
+                  status = "okay";
+                  alarms-count = <1>;
+
+                  nvmem-cells = <&epoch_offset>;
+                  nvmem-cell-names = "epoch-offset";
+          };
+  };


### PR DESCRIPTION
Some counters continue running in low power modes (for example i.MX SNVS LP RTC).
Optionally store and load the epoch offset from an NVMEM cell.