### PR TITLE
intel_adsp: ace4: adsp_power.h: Declare intel_adsp_clock_soft_off_exit()

### DIFF
--- a/soc/intel/intel_adsp/ace/include/ace40/adsp_power.h
+++ b/soc/intel/intel_adsp/ace/include/ace40/adsp_power.h
@@ -99,6 +99,13 @@ static ALWAYS_INLINE bool soc_cpu_is_powered(int cpu_num)
 }
 
 /**
+ * @brief Restore timer after leaving soft-off.
+ *
+ */
+void intel_adsp_clock_soft_off_exit(void);
+
+
+/**
  * @brief Retrieve node identifier for Intel ADSP HOST power domain.
  */
 #define INTEL_ADSP_HST_DOMAIN_DTNODE DT_NODELABEL(hst_domain)


### PR DESCRIPTION
Compiling for NVL/NVL-S reports:
[139/525] Building C object zephyr/CMakeFiles/zephyr.dir/soc/intel/intel_adsp/ace/power.c.obj /.../zephyr/soc/intel/intel_adsp/ace/power.c:401:4: warning: implicit declaration of function 'intel_adsp_clock_soft_off_exit' is invalid in C99 [-Wimplicit-function-declaration]
                        intel_adsp_clock_soft_off_exit();
                        ^
1 warning generated.

Because the ace4 version of adsp_power.h is missing the declaration of intel_adsp_clock_soft_off_exit().