### PR TITLE
modules: hostap: Add support for external WPA3-SAE implementation

### DIFF
--- a/doc/connectivity/networking/api/wifi_crypto.rst
+++ b/doc/connectivity/networking/api/wifi_crypto.rst
@@ -18,7 +18,11 @@ Feature set (from hostap Kconfig)
 Features are gated by Kconfig. Relevant options include:
 
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP` — WEP (legacy)
-* :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3` — WPA3-SAE (default on)
+* :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON` — WPA3-SAE when Internal or
+  External is selected (``WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION``; default Internal).
+  :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3` is promptless and turns on the internal
+  bignum SAE path when Internal is chosen (set the implementation choice in ``prj.conf``, not
+  this symbol).
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP` — Wi-Fi Easy Connect (DPP)
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPS` — Wi-Fi Protected Setup
 * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P` — P2P / Wi-Fi Direct (implies WPS)

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1162,12 +1162,24 @@ Bluetooth HCI
 Networking
 **********
 
+Wi-Fi
+=====
+
 * :c:struct:`wifi_channel_info` gained a ``band`` field for set-channel. Behaviour
   is backwards compatible for 2.4 GHz (channels 1–14) and 5 GHz (36–165): omit or
   leave ``band`` as :c:macro:`WIFI_FREQ_BAND_UNKNOWN` and the driver infers the
   band. For 6 GHz, set ``band`` to :c:macro:`WIFI_FREQ_BAND_6_GHZ` (channel
   numbers overlap 1–14 with 2.4 GHz). Recompile so ``sizeof(struct
   wifi_channel_info)`` is correct when calling net_mgmt.
+
+* WPA3 is configured with the choice
+  ``WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION`` (Internal, External, or None).
+  Replace any ``CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=y`` line in ``prj.conf`` with
+  ``CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT=y`` (or ``_EXT`` /
+  ``_NONE`` as needed). :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3` is
+  now promptless and is selected only when Internal is chosen; do not assign it
+  directly. In C code, prefer :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON`
+  to detect either internal or external WPA3.
 
 * Networking APIs found in
 

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -308,10 +308,42 @@ config EAP_TLSV1_3
 	select MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 endif # WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 
-config WIFI_NM_WPA_SUPPLICANT_WPA3
-	bool "WPA3 support"
+choice WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION
+	prompt "WPA3 implementation"
+	default WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
-	default y
+	help
+	  Select how WPA3/SAE is provided. Internal uses the supplicant
+	  bignum-based implementation. External uses an out-of-tree
+	  implementation (e.g. PSA crypto). None disables WPA3.
+
+config WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_NONE
+	bool "None"
+	help
+	  WPA3 is disabled. Only WPA2 and earlier are available.
+
+config WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT
+	bool "Internal"
+	select WIFI_NM_WPA_SUPPLICANT_WPA3
+
+config WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_EXT
+	bool "External"
+
+endchoice
+
+config WIFI_NM_WPA_SUPPLICANT_WPA3
+	bool
+	help
+	  Internal WPA3/SAE implementation (bignum-based). Selected by
+	  WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT.
+
+config WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON
+	bool
+	default y if WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT || \
+		    WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_EXT
+	help
+	  WPA3/SAE is available (either internal or external implementation).
+	  Use this in code to gate WPA3 functionality regardless of backend.
 
 config WIFI_NM_WPA_SUPPLICANT_AP
 	bool "SoftAP mode support based on WPA supplicant"

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -419,7 +419,7 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 	case WPA_KEY_MGMT_PSK_SHA256:
 		return WIFI_SECURITY_TYPE_PSK_SHA256;
 	case WPA_KEY_MGMT_SAE:
-		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)) {
+		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)) {
 			if (pwe == 1) {
 				return WIFI_SECURITY_TYPE_SAE_H2E;
 			} else if (pwe == 2) {
@@ -438,7 +438,7 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 	case WPA_KEY_MGMT_FT_PSK:
 		return WIFI_SECURITY_TYPE_FT_PSK;
 	case WPA_KEY_MGMT_FT_SAE:
-		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)) {
+		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)) {
 			return WIFI_SECURITY_TYPE_FT_SAE;
 		}
 		return WIFI_SECURITY_TYPE_UNKNOWN;
@@ -449,7 +449,7 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 	case WPA_KEY_MGMT_FT_IEEE8021X_SHA384:
 		return WIFI_SECURITY_TYPE_FT_EAP_SHA384;
 	case WPA_KEY_MGMT_SAE_EXT_KEY:
-		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)) {
+		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)) {
 			return WIFI_SECURITY_TYPE_SAE_EXT_KEY;
 		}
 		return WIFI_SECURITY_TYPE_UNKNOWN;
@@ -747,7 +747,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 			}
 		}
 
-		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3) &&
+		if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON) &&
 		    (params->security == WIFI_SECURITY_TYPE_SAE_HNP ||
 		     params->security == WIFI_SECURITY_TYPE_SAE_H2E ||
 		     params->security == WIFI_SECURITY_TYPE_SAE_AUTO ||
@@ -853,7 +853,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
-			if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)) {
+			if (IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)) {
 				if (params->sae_password) {
 					if ((params->sae_password_length < WIFI_PSK_MIN_LEN) ||
 					    (params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -37,7 +37,7 @@ tests:
       - CONFIG_EAP_AKA=y
   wifi.build.wpa3:
     extra_configs:
-      - CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_IMPLEMENTATION_INT=y
       - CONFIG_MBEDTLS_SSL_PROTO_TLS1_2=y
   wifi.build.ap:
     extra_configs:


### PR DESCRIPTION
This is needed for any downstream vendors to replace wpa_supplicant internal implementation with their own module (e.g., WPA3-PSA for Nordic).

And the common symbol helps us maitain any implementations easily.