### PR TITLE
drivers: ethernet: only start thread in iface init

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -718,20 +718,10 @@ static void eth_enc28j60_rx_thread(void *p1, void *p2, void *p3)
 			eth_enc28j60_read_phy(dev, ENC28J60_PHY_PHSTAT2, &phstat2);
 			if (phstat2 & ENC28J60_BIT_PHSTAT2_LSTAT) {
 				LOG_INF("%s: Link up", dev->name);
-				/* We may have been interrupted before L2 init complete
-				 * If so flag that the carrier should be set on in init
-				 */
-				if (context->iface_initialized) {
-					net_eth_carrier_on(context->iface);
-				} else {
-					context->iface_carrier_on_init = true;
-				}
+				net_eth_carrier_on(context->iface);
 			} else {
 				LOG_INF("%s: Link down", dev->name);
-
-				if (context->iface_initialized) {
-					net_eth_carrier_off(context->iface);
-				}
+				net_eth_carrier_off(context->iface);
 			}
 		}
 
@@ -802,13 +792,15 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 
-	/* The device may have already interrupted us to flag link UP */
-	if (context->iface_carrier_on_init) {
-		net_if_carrier_on(iface);
-	} else {
-		net_if_carrier_off(iface);
-	}
-	context->iface_initialized = true;
+	net_if_carrier_off(iface);
+
+	/* Start interruption-poll thread */
+	k_thread_create(&context->thread, context->thread_stack,
+			CONFIG_ETH_ENC28J60_RX_THREAD_STACK_SIZE,
+			eth_enc28j60_rx_thread,
+			(void *)dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ETH_ENC28J60_RX_THREAD_PRIO),
+			0, K_NO_WAIT);
 }
 
 static const struct ethernet_api api_funcs = {
@@ -888,14 +880,6 @@ static int eth_enc28j60_init(const struct device *dev)
 	/* Enable Reception */
 	eth_enc28j60_set_eth_reg(dev, ENC28J60_REG_ECON1,
 				 ENC28J60_BIT_ECON1_RXEN);
-
-	/* Start interruption-poll thread */
-	k_thread_create(&context->thread, context->thread_stack,
-			CONFIG_ETH_ENC28J60_RX_THREAD_STACK_SIZE,
-			eth_enc28j60_rx_thread,
-			(void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_ETH_ENC28J60_RX_THREAD_PRIO),
-			0, K_NO_WAIT);
 
 	LOG_INF("%s: Initialized", dev->name);
 

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -236,8 +236,6 @@ struct eth_enc28j60_runtime {
 	struct gpio_callback gpio_cb;
 	struct k_sem tx_rx_sem;
 	struct k_sem int_sem;
-	bool iface_initialized : 1;
-	bool iface_carrier_on_init : 1;
 };
 
 #endif /*_ENC28J60_*/

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -479,10 +479,7 @@ static void enc424j600_rx_thread(void *p1, void *p2, void *p3)
 				net_eth_carrier_on(context->iface);
 			} else {
 				LOG_INF("Link down");
-
-				if (context->iface_initialized) {
-					net_eth_carrier_off(context->iface);
-				}
+				net_eth_carrier_off(context->iface);
 			}
 		} else {
 			LOG_ERR("Unknown Interrupt, EIR: 0x%04x", eir);
@@ -552,7 +549,14 @@ static void enc424j600_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 
 	net_if_carrier_off(iface);
-	context->iface_initialized = true;
+
+	/* Start interruption-poll thread */
+	k_thread_create(&context->thread, context->thread_stack,
+			CONFIG_ETH_ENC424J600_RX_THREAD_STACK_SIZE,
+			enc424j600_rx_thread,
+			context, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ETH_ENC424J600_RX_THREAD_PRIO),
+			0, K_NO_WAIT);
 }
 
 static int enc424j600_start_device(const struct device *dev)
@@ -751,14 +755,6 @@ static int enc424j600_init(const struct device *dev)
 		enc424j600_read_sfru(dev, ENC424J600_SFRX_ECON1L, &tmp);
 		LOG_DBG("ECON1: 0x%04x", tmp);
 	}
-
-	/* Start interruption-poll thread */
-	k_thread_create(&context->thread, context->thread_stack,
-			CONFIG_ETH_ENC424J600_RX_THREAD_STACK_SIZE,
-			enc424j600_rx_thread,
-			context, NULL, NULL,
-			K_PRIO_COOP(CONFIG_ETH_ENC424J600_RX_THREAD_PRIO),
-			0, K_NO_WAIT);
 
 	enc424j600_write_sbc(dev, ENC424J600_1BC_SETEIE);
 

--- a/drivers/ethernet/eth_enc424j600_priv.h
+++ b/drivers/ethernet/eth_enc424j600_priv.h
@@ -293,7 +293,6 @@ struct enc424j600_runtime {
 	struct k_sem int_sem;
 	uint16_t next_pkt_ptr;
 	bool suspended : 1;
-	bool iface_initialized : 1;
 };
 
 #endif /*_ENC424J600_*/

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -783,6 +783,11 @@ static void lan9250_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 
 	net_if_carrier_off(iface);
+
+	k_thread_create(&context->thread, context->thread_stack,
+			CONFIG_ETH_LAN9250_RX_THREAD_STACK_SIZE,
+			lan9250_thread, (void *)dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ETH_LAN9250_RX_THREAD_PRIO), 0, K_NO_WAIT);
 }
 
 static int lan9250_set_config(const struct device *dev, enum ethernet_config_type type,
@@ -937,11 +942,6 @@ static int lan9250_init(const struct device *dev)
 		LOG_ERR("Set mac address failed");
 		return ret;
 	}
-
-	k_thread_create(&context->thread, context->thread_stack,
-			CONFIG_ETH_LAN9250_RX_THREAD_STACK_SIZE,
-			lan9250_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_ETH_LAN9250_RX_THREAD_PRIO), 0, K_NO_WAIT);
 
 	LOG_INF("LAN9250 Initialized");
 

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -361,6 +361,17 @@ static void w6100_iface_init(struct net_if *iface)
 
 	/* Do not start the interface until PHY link is up */
 	net_if_carrier_off(iface);
+
+	/* Fetch initial link status */
+	w6100_update_link_status(dev);
+
+	k_thread_create(&ctx->thread, ctx->thread_stack,
+			CONFIG_ETH_W6100_RX_THREAD_STACK_SIZE,
+			w6100_thread,
+			(void *)dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ETH_W6100_RX_THREAD_PRIO),
+			0, K_NO_WAIT);
+	k_thread_name_set(&ctx->thread, "eth_w6100");
 }
 
 static enum ethernet_hw_caps w6100_get_capabilities(const struct device *dev)
@@ -628,14 +639,6 @@ static int w6100_init(const struct device *dev)
 			LOG_ERR("Unable to read RTR register");
 			return -ENODEV;
 		}
-
-	k_thread_create(&ctx->thread, ctx->thread_stack,
-			CONFIG_ETH_W6100_RX_THREAD_STACK_SIZE,
-			w6100_thread,
-			(void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_ETH_W6100_RX_THREAD_PRIO),
-			0, K_NO_WAIT);
-	k_thread_name_set(&ctx->thread, "eth_w6100");
 
 	LOG_INF("W6100 Initialized");
 


### PR DESCRIPTION
start rx and link status thread in iface init,
as only then the iface pointer in the data
struct is set.

Here only  for the quite simple spi ethernet controllers