### PR TITLE
drivers: ethernet: use iface as user_data for phy callback 

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -462,19 +462,16 @@ static int generate_mac_addr(uint8_t mac_addr[6])
 	return res;
 }
 
-static void phy_link_state_changed(const struct device *phy_dev,
+static void phy_link_state_changed(const struct device *phy_dev __unused,
 				   struct phy_link_state *state,
 				   void *user_data)
 {
-	const struct device *dev = (const struct device *)user_data;
-	struct eth_esp32_dev_data *const dev_data = dev->data;
-
-	ARG_UNUSED(phy_dev);
+	struct net_if *iface = (struct net_if *)user_data;
 
 	if (state->is_up) {
-		net_eth_carrier_on(dev_data->iface);
+		net_eth_carrier_on(iface);
 	} else {
-		net_eth_carrier_off(dev_data->iface);
+		net_eth_carrier_off(iface);
 	}
 }
 
@@ -613,7 +610,7 @@ static void eth_esp32_iface_init(struct net_if *iface)
 		net_if_carrier_off(iface);
 
 		phy_link_callback_set(eth_esp32_phy_dev, phy_link_state_changed,
-				      (void *)dev);
+				      (void *)iface);
 	} else {
 		LOG_ERR("PHY device not ready");
 	}

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -220,19 +220,16 @@ static const struct device *eth_get_phy(const struct device *dev)
 	return config->phy_dev;
 }
 
-static void phy_link_state_changed(const struct device *phy_dev,
+static void phy_link_state_changed(const struct device *phy_dev __unused,
 				   struct phy_link_state *state,
 				   void *user_data)
 {
-	const struct device *dev = (const struct device *)user_data;
-	struct eth_litex_dev_data *context = dev->data;
-
-	ARG_UNUSED(phy_dev);
+	struct net_if *iface = (struct net_if *)user_data;
 
 	if (state->is_up) {
-		net_eth_carrier_on(context->iface);
+		net_eth_carrier_on(iface);
 	} else {
-		net_eth_carrier_off(context->iface);
+		net_eth_carrier_off(iface);
 	}
 }
 
@@ -263,7 +260,7 @@ static void eth_iface_init(struct net_if *iface)
 	net_if_carrier_off(iface);
 
 	if (device_is_ready(config->phy_dev)) {
-		phy_link_callback_set(config->phy_dev, phy_link_state_changed, (void *)port);
+		phy_link_callback_set(config->phy_dev, phy_link_state_changed, (void *)iface);
 	} else {
 		LOG_ERR("PHY device not ready");
 	}

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -168,20 +168,18 @@ static enum ethernet_hw_caps axi_eth_lite_get_caps(const struct device *dev)
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
-static void axi_eth_lite_phy_link_state_changed(const struct device *phydev,
+static void axi_eth_lite_phy_link_state_changed(const struct device *phydev __unused,
 						struct phy_link_state *state, void *user_data)
 {
-	struct axi_eth_lite_data *data = user_data;
-
-	ARG_UNUSED(phydev);
+	struct net_if *iface = (struct net_if *)user_data;
 
 	LOG_INF("Link state changed to: %s (speed %x)", state->is_up ? "up" : "down", state->speed);
 
 	/* inform the L2 driver whether we can handle packets now */
 	if (state->is_up) {
-		net_eth_carrier_on(data->iface);
+		net_eth_carrier_on(iface);
 	} else {
-		net_eth_carrier_off(data->iface);
+		net_eth_carrier_off(iface);
 	}
 }
 
@@ -207,7 +205,8 @@ static void axi_eth_lite_iface_init(struct net_if *iface)
 		/* initially no carrier */
 		net_eth_carrier_off(iface);
 
-		err = phy_link_callback_set(config->phy, axi_eth_lite_phy_link_state_changed, data);
+		err = phy_link_callback_set(config->phy, axi_eth_lite_phy_link_state_changed,
+					    iface);
 
 		if (err < 0) {
 			LOG_ERR("Could not set PHY link state changed handler: %d", err);

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -447,20 +447,18 @@ static int xilinx_axienet_set_config(const struct device *dev, enum ethernet_con
 	}
 }
 
-static void phy_link_state_changed(const struct device *dev, struct phy_link_state *state,
+static void phy_link_state_changed(const struct device *dev __unused, struct phy_link_state *state,
 				   void *user_data)
 {
-	struct xilinx_axienet_data *data = user_data;
-
-	ARG_UNUSED(dev);
+	struct net_if *iface = (struct net_if *)user_data;
 
 	LOG_INF("Link state changed to: %s (speed %x)", state->is_up ? "up" : "down", state->speed);
 
 	/* inform the L2 driver about link event */
 	if (state->is_up) {
-		net_eth_carrier_on(data->interface);
+		net_eth_carrier_on(iface);
 	} else {
-		net_eth_carrier_off(data->interface);
+		net_eth_carrier_off(iface);
 	}
 }
 
@@ -479,7 +477,7 @@ static void xilinx_axienet_iface_init(struct net_if *iface)
 	/* carrier is initially off */
 	net_eth_carrier_off(iface);
 
-	err = phy_link_callback_set(config->phy, phy_link_state_changed, data);
+	err = phy_link_callback_set(config->phy, phy_link_state_changed, iface);
 
 	if (err) {
 		LOG_ERR("Could not set PHY link state changed handler : %d",

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -409,15 +409,15 @@ static void eth_intel_igc_set_mac_filter(const struct device *dev,
 	eth_intel_igc_set_mac_addr(data->base, index, mac_addr, config);
 }
 
-static void eth_intel_igc_phylink_cb(const struct device *phy, struct phy_link_state *state,
-				     void *user_data)
+static void eth_intel_igc_phylink_cb(const struct device *phy __unused,
+				     struct phy_link_state *state, void *user_data)
 {
-	struct eth_intel_igc_mac_data *data = (struct eth_intel_igc_mac_data *)user_data;
+	struct net_if *iface = (struct net_if *)user_data;
 
 	if (state->is_up) {
-		net_eth_carrier_on(data->iface);
+		net_eth_carrier_on(iface);
 	} else {
-		net_eth_carrier_off(data->iface);
+		net_eth_carrier_off(iface);
 	}
 }
 
@@ -463,7 +463,7 @@ static void eth_intel_igc_iface_init(struct net_if *iface)
 	eth_intel_igc_set_mac_filter(dev, DEST_ADDR, data->mac_addr, 0, 0);
 
 	if (device_is_ready(cfg->phy)) {
-		phy_link_callback_set(cfg->phy, eth_intel_igc_phylink_cb, (void *)data);
+		phy_link_callback_set(cfg->phy, eth_intel_igc_phylink_cb, (void *)iface);
 	} else {
 		LOG_ERR("PHY device is not ready");
 		return;

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -462,6 +462,8 @@ static void eth_intel_igc_iface_init(struct net_if *iface)
 
 	eth_intel_igc_set_mac_filter(dev, DEST_ADDR, data->mac_addr, 0, 0);
 
+	net_if_carrier_off(iface);
+
 	if (device_is_ready(cfg->phy)) {
 		phy_link_callback_set(cfg->phy, eth_intel_igc_phylink_cb, (void *)iface);
 	} else {


### PR DESCRIPTION
use iface as user_data for phy callback when we are only needing that in the phy callback.