### PR TITLE
sysbuild: Set variant image DTC overlay file to empty file

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -577,8 +577,12 @@ function(ExternalZephyrVariantProject_Add)
     set_target_properties(${ZBUILD_APPLICATION} PROPERTIES MAIN_APP True)
   endif()
 
+  set(${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE ${ZEPHYR_BASE}/share/sysbuild/images/empty.overlay
+      CACHE INTERNAL "Application default DTC file" FORCE
+  )
+
   set(${ZBUILD_APPLICATION}_DTS_SOURCE ${CMAKE_BINARY_DIR}/${ZBUILD_SOURCE_APP}/zephyr/zephyr.dts
-      CACHE INTERNAL "Application DTC file" FORCE
+      CACHE INTERNAL "Application pre-configured DTC file" FORCE
   )
 
   set(${ZBUILD_APPLICATION}_DTS_DEPS ${CMAKE_BINARY_DIR}/${ZBUILD_SOURCE_APP}/zephyr/zephyr.dts.d

--- a/share/sysbuild/images/empty.overlay
+++ b/share/sysbuild/images/empty.overlay
@@ -1,0 +1,1 @@
+/* Intentionally empty file */


### PR DESCRIPTION
Fixes an issue in applications that have an app.overlay file to prevent a double inclusion of that file