### PR TITLE
soc: st: n6: Set ADC as secure privileged in RIF

### DIFF
--- a/soc/st/stm32/stm32n6x/soc.c
+++ b/soc/st/stm32/stm32n6x/soc.c
@@ -52,6 +52,8 @@ static void soc_rif_config(void)
 	/* Enable the clock for the RIFSC (RIF Security Controller) */
 	__HAL_RCC_RIFSC_CLK_ENABLE();
 
+	/* ADC */
+	RIF_SLAVE_SEC_PRIV(ADC12);
 	/* DCMIPP */
 	RIF_MASTER_CID1_SEC_PRIV(DCMIPP);
 	RIF_SLAVE_SEC_PRIV(DCMIPP);


### PR DESCRIPTION
This is necessary for ADC to control GPIO analog multiplexes, when GPIOs are set as secure (by default).
Otherwise, the conversions inside ADC don't work properly on STM32N6. The conversion is done, but the data are not correct.