### PR TITLE
Debug: coredump: Fix error checking

### DIFF
--- a/subsys/debug/coredump/coredump_shell.c
+++ b/subsys/debug/coredump/coredump_shell.c
@@ -287,7 +287,7 @@ static int print_raw_data(const struct shell *sh,
 		}
 
 		ret = coredump_cmd(COREDUMP_CMD_COPY_STORED_DUMP, copy);
-		if (ret != 0) {
+		if (ret < 0) {
 			return -EINVAL;
 		}
 
@@ -346,7 +346,7 @@ static int parse_and_print_coredump(const struct shell *sh,
 	}
 
 	ret = coredump_cmd(COREDUMP_CMD_COPY_STORED_DUMP, copy);
-	if (ret != 0) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -393,8 +393,8 @@ static int parse_and_print_coredump(const struct shell *sh,
 		}
 
 		ret = coredump_cmd(COREDUMP_CMD_COPY_STORED_DUMP, copy);
-		if (ret != 0) {
-			return -ENOMEM;
+		if (ret < 0) {
+			return ret;
 		}
 
 		hdr = (struct coredump_mem_hdr_t *)copy->buffer;


### PR DESCRIPTION
Fix error-checking bug in `coredump_shell.c` for `coredump_cmd(COREDUMP_CMD_COPY_STORED_DUMP, ...)`. The function returns the number of bytes copied (≥ 0) on success and a negative errno on failure, but the existing checks used `ret != 0` which incorrectly treated a successful non-zero byte count as an error.

This bug prevented the coredump printing shell commands from working.