### PR TITLE
net: use net_if_* functions

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -261,7 +261,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 		CONTAINER_OF(work, struct nxp_enet_qos_rx_data, rx_work);
 	struct nxp_enet_qos_mac_data *data =
 		CONTAINER_OF(rx_data, struct nxp_enet_qos_mac_data, rx);
-	const struct device *dev = data->iface->if_dev->dev;
+	const struct device *dev = net_if_get_device(data->iface);
 	volatile union nxp_enet_qos_rx_desc *desc_arr = data->rx.descriptors;
 	uint32_t desc_idx = rx_data->next_desc_idx;
 	volatile union nxp_enet_qos_rx_desc *desc = &desc_arr[desc_idx];

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -1649,7 +1649,7 @@ static int nsos_socket_offload_init(const struct device *arg)
 
 static void nsos_iface_api_init(struct net_if *iface)
 {
-	iface->if_dev->socket_offload = nsos_socket_create;
+	net_if_socket_offload_set(iface, nsos_socket_create);
 
 	socket_offload_dns_register(&nsos_dns_ops);
 }

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1533,7 +1533,7 @@ static void nxp_wifi_auto_connect(void)
 	params.psk_length = psk_len;
 
 	LOG_DBG("AutoConnect SSID[%s]", ssid);
-	nxp_wifi_connect(g_mlan.netif->if_dev->dev, &params);
+	nxp_wifi_connect(net_if_get_device(g_mlan.netif), &params);
 }
 #endif
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -504,8 +504,8 @@ static int siwx91x_wifi_reg_domain(const struct device *dev, struct wifi_reg_dom
 
 static void siwx91x_iface_init(struct net_if *iface)
 {
-	const struct siwx91x_config *siwx91x_cfg = iface->if_dev->dev->config;
-	struct siwx91x_dev *sidev = iface->if_dev->dev->data;
+	const struct siwx91x_config *siwx91x_cfg = net_if_get_device(iface)->config;
+	struct siwx91x_dev *sidev = net_if_get_device(iface)->data;
 	sl_wifi_advanced_client_configuration_t client_config = {
 		.max_retry_attempts = 1,
 		.scan_interval = 0,

--- a/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
@@ -147,7 +147,7 @@ static void siwx91x_sock_on_recv(sl_si91x_fdset_t *read_fd, sl_si91x_fdset_t *wr
 				 sl_si91x_fdset_t *except_fd, int status)
 {
 	/* When CONFIG_NET_SOCKETS_OFFLOAD is set, only one interface exist */
-	struct siwx91x_dev *sidev = net_if_get_first_wifi()->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_if_get_first_wifi())->data;
 
 	ARRAY_FOR_EACH(sidev->fds_cb, i) {
 		if (SL_SI91X_FD_ISSET(i, read_fd)) {
@@ -169,7 +169,7 @@ static void siwx91x_sock_on_recv(sl_si91x_fdset_t *read_fd, sl_si91x_fdset_t *wr
 static int siwx91x_sock_get(net_sa_family_t family, enum net_sock_type type,
 			    enum net_ip_protocol ip_proto, struct net_context **context)
 {
-	struct siwx91x_dev *sidev = net_if_get_first_wifi()->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_if_get_first_wifi())->data;
 	int sockfd;
 
 	sockfd = sl_si91x_socket(family, type, ip_proto);
@@ -183,7 +183,7 @@ static int siwx91x_sock_get(net_sa_family_t family, enum net_sock_type type,
 
 static int siwx91x_sock_put(struct net_context *context)
 {
-	struct siwx91x_dev *sidev = net_context_get_iface(context)->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_context_get_iface(context))->data;
 	int sockfd = (int)context->offload_context;
 	int ret;
 
@@ -201,7 +201,7 @@ static int siwx91x_sock_put(struct net_context *context)
 static int siwx91x_sock_bind(struct net_context *context,
 			     const struct sockaddr *addr, socklen_t addrlen)
 {
-	struct siwx91x_dev *sidev = net_context_get_iface(context)->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_context_get_iface(context))->data;
 	int sockfd = (int)context->offload_context;
 	struct sockaddr addr_le;
 	int ret;
@@ -231,7 +231,7 @@ static int siwx91x_sock_connect(struct net_context *context,
 				const struct sockaddr *addr, socklen_t addrlen,
 				net_context_connect_cb_t cb, int32_t timeout, void *user_data)
 {
-	struct siwx91x_dev *sidev = net_context_get_iface(context)->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_context_get_iface(context))->data;
 	int sockfd = (int)context->offload_context;
 	struct sockaddr addr_le;
 	int ret;
@@ -268,7 +268,7 @@ static int siwx91x_sock_listen(struct net_context *context, int backlog)
 static int siwx91x_sock_accept(struct net_context *context,
 			       net_tcp_accept_cb_t cb, int32_t timeout, void *user_data)
 {
-	struct siwx91x_dev *sidev = net_context_get_iface(context)->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(net_context_get_iface(context))->data;
 	int sockfd = (int)context->offload_context;
 	struct net_context *newcontext;
 	struct sockaddr addr_le;
@@ -368,7 +368,7 @@ static int siwx91x_sock_recv(struct net_context *context,
 			     net_context_recv_cb_t cb, int32_t timeout, void *user_data)
 {
 	struct net_if *iface = net_context_get_iface(context);
-	struct siwx91x_dev *sidev = iface->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(iface)->data;
 	int sockfd = (int)context->offload_context;
 	int ret;
 
@@ -407,7 +407,7 @@ static struct net_offload siwx91x_offload = {
 
 void siwx91x_sock_init(struct net_if *iface)
 {
-	struct siwx91x_dev *sidev = iface->if_dev->dev->data;
+	struct siwx91x_dev *sidev = net_if_get_device(iface)->data;
 
 	iface->if_dev->offload = &siwx91x_offload;
 	k_event_init(&sidev->fds_recv_event);

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -385,9 +385,9 @@ static void *iface_setup(void)
 	net_if_dormant_on(iface1);
 
 	/* Operational state should be "oper down" */
-	zassert_equal(iface1->if_dev->oper_state, NET_IF_OPER_DOWN,
+	zassert_equal(net_if_oper_state(iface1), NET_IF_OPER_DOWN,
 		      "Invalid operational state (%d)",
-		      iface1->if_dev->oper_state);
+		      net_if_oper_state(iface1));
 
 	/* Mark the device ready and take the interface up */
 	dev->state->init_res = 0;
@@ -401,14 +401,14 @@ static void *iface_setup(void)
 	ret = net_if_up(iface1);
 	zassert_equal(ret, 0, "Interface 1 is not up (%d)", ret);
 
-	zassert_equal(iface1->if_dev->oper_state, NET_IF_OPER_DORMANT,
+	zassert_equal(net_if_oper_state(iface1), NET_IF_OPER_DORMANT,
 		      "Invalid operational state (%d)",
-		      iface1->if_dev->oper_state);
+		      net_if_oper_state(iface1));
 
 	net_if_dormant_off(iface1);
-	zassert_equal(iface1->if_dev->oper_state, NET_IF_OPER_UP,
+	zassert_equal(net_if_oper_state(iface1), NET_IF_OPER_UP,
 		      "Invalid operational state (%d)",
-		      iface1->if_dev->oper_state);
+		      net_if_oper_state(iface1));
 
 	ifaddr = net_if_ipv6_addr_add(iface1, &my_addr1,
 				      NET_ADDR_MANUAL, 0);

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -238,7 +238,7 @@ static void prepare_ra_message(struct net_pkt *pkt)
 
 	hdr.type = net_htons(NET_ETH_PTYPE_IPV6);
 	memset(&hdr.src, 0, sizeof(struct net_eth_addr));
-	memcpy(&hdr.dst, net_pkt_iface(pkt)->if_dev->link_addr.addr,
+	memcpy(&hdr.dst, net_if_get_link_addr(net_pkt_iface(pkt))->addr,
 	       sizeof(struct net_eth_addr));
 
 	net_pkt_set_overwrite(pkt, false);
@@ -266,7 +266,7 @@ static void inject_na_message(struct net_if *iface, struct net_in6_addr *src,
 
 	hdr.type = net_htons(NET_ETH_PTYPE_IPV6);
 	memset(&hdr.src, 0xaa, sizeof(struct net_eth_addr));
-	memcpy(&hdr.dst, net_pkt_iface(pkt)->if_dev->link_addr.addr,
+	memcpy(&hdr.dst, net_if_get_link_addr(net_pkt_iface(pkt))->addr,
 	       sizeof(struct net_eth_addr));
 
 	/* Reserve space for the L2 header. */

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -185,7 +185,7 @@ static struct dummy_api net_test_if_api = {
 
 static void init_null_iface(struct net_if *iface)
 {
-	struct net_test_mld *context = iface->if_dev->dev->data;
+	struct net_test_mld *context = net_if_get_device(iface)->data;
 
 	memset(&context->mac_addr, 0, sizeof(context->mac_addr));
 


### PR DESCRIPTION
use net_if_* functions, instead of directly accessing `struct net_if_dev` and `struct net_if`