### PR TITLE
net: config: fix race in check_interface() causing indefinite block

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -366,7 +366,15 @@ static void iface_up_handler(struct net_mgmt_event_callback *cb,
 
 static bool check_interface(struct net_if *iface)
 {
+	net_mgmt_init_event_callback(&mgmt_iface_cb, iface_up_handler,
+				     NET_EVENT_IF_UP);
+	net_mgmt_add_event_callback(&mgmt_iface_cb);
+
+	/* Check after registering the callback to avoid missing NET_EVENT_IF_UP
+	 * that could fire between the check and the callback registration.
+	 */
 	if (net_if_is_up(iface)) {
+		net_mgmt_del_event_callback(&mgmt_iface_cb);
 		k_sem_reset(&counter);
 		k_sem_give(&waiter);
 		return true;
@@ -374,10 +382,6 @@ static bool check_interface(struct net_if *iface)
 
 	NET_INFO("Waiting interface %d (%p) to be up...",
 		 net_if_get_by_iface(iface), iface);
-
-	net_mgmt_init_event_callback(&mgmt_iface_cb, iface_up_handler,
-				     NET_EVENT_IF_UP);
-	net_mgmt_add_event_callback(&mgmt_iface_cb);
 
 	return false;
 }


### PR DESCRIPTION
# net: config: fix race in check_interface() causing indefinite block

- NET_EVENT_IF_UP can fire between the net_if_is_up() check and
net_mgmt_add_event_callback() in check_interface(). When this
happens (e.g. with CONFIG_SHELL_BACKEND_TELNET=y which starts a
same-priority thread that brings the interface up concurrently),
the event is missed and net_config_init_by_iface() blocks forever.

- Fix by always registering the callback first, then checking
net_if_is_up() after registration. If the interface came up in
the race window, remove the callback and signal the semaphore
immediately. Move the NET_INFO print to only fire when we are
genuinely going to wait.

Fixes #102142

## Testing

Reproduced and verified on `native_sim`:
- Forced interface down, spawned a second thread to call `net_if_up()` after
  300ms, added a temporary `k_sleep()` between `net_mgmt_init_event_callback()`
  and `net_mgmt_add_event_callback()` to reliably open the race window.

**Before:**
```
Waiting interface 1 (0x80804ac) to be up...
Bringing interface up from second thread...
Timeout while waiting network interface
FAILED: ret=-100
```
**After:**
```
Waiting interface 1 (0x80804ac) to be up...
Bringing interface up from second thread...
SUCCESS: interface came up
```