### PR TITLE
kernel/sched: fix IPI race in z_get_next_switch_handle

### DIFF
--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -71,12 +71,15 @@ atomic_val_t ipi_mask_create(struct k_thread *thread)
 
 void signal_pending_ipi(void)
 {
-	/* Synchronization note: you might think we need to lock these
-	 * two steps, but an IPI is idempotent.  It's OK if we do it
-	 * twice.  All we require is that if a CPU sees the flag true,
-	 * it is guaranteed to send the IPI, and if a core sets
-	 * pending_ipi, the IPI will be sent the next time through
-	 * this code.
+	/* Note: with directed IPIs, arch_sched_directed_ipi() skips the
+	 * calling CPU, so if a CPU consumes its own pending bit the IPI
+	 * is silently dropped. When rescheduling, callers must ensure
+	 * that signal_pending_ipi() is invoked while the scheduler lock is
+	 * still held. Holding the lock ensures the scheduling decision and
+	 * IPI dispatch are atomic: either a concurrent flag_ipi() lands
+	 * before the lock is acquired (and the CPU sees the new thread),
+	 * or it lands after the lock is released (and the other CPU
+	 * dispatches the IPI).
 	 */
 
 #if defined(CONFIG_SCHED_IPI_SUPPORTED)

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -562,8 +562,8 @@ static void reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 	if (resched(key.key) && need_swap()) {
 		z_swap(lock, key);
 	} else {
-		k_spin_unlock(lock, key);
 		signal_pending_ipi();
+		k_spin_unlock(lock, key);
 	}
 }
 
@@ -806,8 +806,13 @@ void z_reschedule_irqlock(uint32_t key)
 	if (resched(key) && need_swap()) {
 		z_swap_irqlock(key);
 	} else {
-		irq_unlock(key);
+		/* TODO: We only hold the IRQ lock here, not _sched_spinlock,
+		 * violating the locking requirement documented in
+		 * signal_pending_ipi(). This can result in added delayed
+		 * rescheduling.
+		 */
 		signal_pending_ipi();
+		irq_unlock(key);
 	}
 }
 
@@ -963,8 +968,12 @@ void *z_get_next_switch_handle(void *interrupted)
 		ret = new_thread->switch_handle;
 		/* Active threads MUST have a null here */
 		new_thread->switch_handle = NULL;
+
+		/* Check for IPIs under the lock to avoid silently consuming a
+		 * rescheduling IPI flagged by another CPU for ourselves.
+		 */
+		signal_pending_ipi();
 	}
-	signal_pending_ipi();
 	return ret;
 #else
 	z_sched_usage_switch(_kernel.ready_q.cache);


### PR DESCRIPTION
Move signal_pending_ipi() inside the K_SPINLOCK block in z_get_next_switch_handle(). Calling it after the lock release creates a window where a CPU can consume its own pending IPI bit via atomic_clear in signal_pending_ipi(), then silently drop it in
arch_sched_directed_ipi() which skips the calling CPU (i == id).

In configurations where secondary CPUs have a single pinned thread and take no timer or external interrupts, this can lead to a permanent hang: the idle CPU can only be woken by IPIs, but no IPIs are pending and no timeslicing IPIs will be generated since the idle thread is not sliceable. This was reproduced when running under QEMU with the following sequence of events observed:
```
  CPU 0                                  CPU 1
  ─────                                  ─────

                                         Thread calls k_poll(K_MSEC(1))
                                           z_pend_curr():
                                             mark thread PENDING
                                             z_add_timeout(1ms)
                                             do_swap() to idle thread
                                         WFI

  Timer tick fires
  sys_clock_announce():
    slice_timeout(cpu1):
      flag_ipi(BIT(1))
    signal_pending_ipi():
      MSIP[cpu1] = 1

                                         CPU1 wakes from WFI
                                         z_get_next_switch_handle():
                                           acquire _sched_spinlock
                                           next_up() → idle
                                             (thread still PENDING,
                                              timeout hasn't fired yet)
                                           release _sched_spinlock

  Timer tick fires
  sys_clock_announce():
    z_thread_timeout(thread):
      z_unpend_thread(thread)
      z_ready_thread(thread):
        flag_ipi(BIT(1))

                                         signal_pending_ipi():
                                           atomic_clear(pending_ipi)
                                             returns BIT(1)
                                           arch_sched_directed_ipi(BIT(1))
                                             skips self, IPI silently lost
                                         return to idle thread
                                           WFI, thread stuck on ready queue.
```
Such an interleaving of events is, of course, likely only reproducible in practice in virtualized environments where (v)CPUs can be descheduled.

With signal_pending_ipi() inside the lock, next_up() and the IPI dispatch are atomic. Either the concurrent flag_ipi lands before the lock is acquired (and next_up sees the thread), or it lands after the lock is released (and the caller dispatches the IPI). There is no window where a CPU can consume its own bit for a thread it hasn't seen.