### PR TITLE
lib: json: Configurable float and double precision encoding

### DIFF
--- a/lib/utils/Kconfig
+++ b/lib/utils/Kconfig
@@ -20,6 +20,22 @@ config JSON_LIBRARY_FP_SUPPORT
 	  Requires a libc implementation with support for floating point
 	  functions: strtof(), strtod(), isnan() and isinf().
 
+config JSON_FLOAT_PRECISION
+	int "Maximum number of decimal places for an encoded float value"
+	depends on JSON_LIBRARY_FP_SUPPORT
+	default 9
+	help
+	  Sets the precision value in the printf style format string
+	  for a float.
+
+config JSON_DOUBLE_PRECISION
+	int "Maximum number of decimal places for an encoded double value"
+	depends on JSON_LIBRARY_FP_SUPPORT
+	default 16
+	help
+	  Sets the precision value in the printf style format string
+	  for a double.
+
 config RING_BUFFER
 	bool "Ring buffers"
 	help

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -1557,7 +1557,8 @@ static int float_encode(const float *num, json_append_bytes_t append_bytes, void
 	char buf[sizeof("-3.40282347e+38")];
 	int ret;
 
-	ret = print_double(buf, sizeof(buf), "%.9g", (double)*num);
+	ret = print_double(buf, sizeof(buf),
+			   "%." STRINGIFY(CONFIG_JSON_FLOAT_PRECISION) "g", (double)*num);
 
 	if (ret < 0) {
 		return ret;
@@ -1574,7 +1575,8 @@ static int double_encode(const double *num, json_append_bytes_t append_bytes, vo
 	char buf[sizeof("-1.797693134862316e+308")];
 	int ret;
 
-	ret = print_double(buf, sizeof(buf), "%.16g", *num);
+	ret = print_double(buf, sizeof(buf),
+			   "%." STRINGIFY(CONFIG_JSON_DOUBLE_PRECISION) "g", *num);
 
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
Created JSON lib Kconfig options to set the precision used for encoding float and double values

Fixes #105487
