### PR TITLE
samples: net: wifi: shell: remove unused includes and blank line

### DIFF
--- a/samples/net/wifi/shell/src/wifi_test.c
+++ b/samples/net/wifi/shell/src/wifi_test.c
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <errno.h>
-
 int main(void)
 {
-
 	return 0;
 }


### PR DESCRIPTION
Remove unnecessary kernel.h and errno.h includes that are not used in the minimal main function, and remove extra blank line.