### PR TITLE
llext: platform_exclude qemu_x86_tiny readonly_mmu

### DIFF
--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -93,6 +93,8 @@ tests:
       - arm
       - riscv
       - x86
+    platform_exclude:
+      - qemu_x86_tiny/atom       # See #105603
     filter: CONFIG_MMU or CONFIG_RISCV_PMP
     integration_platforms:
       - qemu_cortex_a53         # ARM Cortex-A53 (ARMv8-A ISA)


### PR DESCRIPTION
Adds qemu_x86_tiny/atom to platform_exclude for llext.readonly_mmu per bug #105603 to get it to stop failing in CI. Will be fixed later.