### PR TITLE
A couple of tiny fixes for upstream picolibc

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -79,7 +79,7 @@ typedef unsigned long blkcnt_t;
 typedef int pid_t;
 #endif
 
-#ifndef __useconds_t_defined
+#if !defined(_USECONDS_T_DECLARED) && !defined(__useconds_t_defined)
 typedef unsigned long useconds_t;
 #endif
 

--- a/tests/lib/c_lib/strerror/src/main.c
+++ b/tests/lib/c_lib/strerror/src/main.c
@@ -32,12 +32,14 @@ ZTEST(libc_strerror, test_strerror)
 	/* consistent behaviour w.r.t. errno with invalid input */
 	errno = 0;
 	expected = "";
+	/* After 1.8.11, picolibc changed this message */
+	const char *alternate = "Unknown error";
 	actual = strerror(-42);
-	zassert_equal(0, strcmp(expected, actual), "mismatch: exp: %s act: %s",
-		      expected, actual);
+	zassert_true((strcmp(expected, actual) == 0) || (strcmp(alternate, actual) == 0),
+		     "mismatch: exp: %s act: %s", expected, actual);
 	actual = strerror(4242);
-	zassert_equal(0, strcmp(expected, actual), "mismatch: exp: %s act: %s",
-		      expected, actual);
+	zassert_true((strcmp(expected, actual) == 0) || (strcmp(alternate, actual) == 0),
+		     "mismatch: exp: %s act: %s", expected, actual);
 	/* do not change errno on failure (for consistence) */
 	zassert_equal(0, errno, "");
 #endif


### PR DESCRIPTION
I'm preparing for some post-release work related to picolibc and found two trivial bugs. These aren't necessary for picolibc 1.8.10 but will be necessary for 1.8.11 and beyond.

 1. picolibc now defines `useconds_t` as required by POSIX.
 2. picolibc now uses a more useful error message when strerror is presented with a bogus value.

Both fixes are fully backwards compatible with picolibc 1.8.10, so they could be applied immediately if desired.