### PR TITLE
drivers: i2c: dw: fix target compound repeated START handling

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -583,6 +583,7 @@ static void i2c_dw_isr(const struct device *port)
 		if (intr_stat.bits.rx_full) {
 			if (dw->state != I2C_DW_CMD_SEND) {
 				dw->state = I2C_DW_CMD_SEND;
+				dw->read_in_progress = false;
 				if (slave_cb->write_requested) {
 					slave_cb->write_requested(dw->slave_cfg);
 				}


### PR DESCRIPTION
In target mode, read_in_progress is only cleared on STOP_DET. When a master issues a compound transaction with multiple repeated STARTs that transitions from read back to write and then read again, read_in_progress remains set from the first read phase. On the second read phase the ISR takes the read_processed path instead of read_requested, returning data from the wrong offset.

For example, an EEPROM-style compound transaction:
```
  S  addr+W  ptr  Sr  addr+R  [data1]  NAK
  Sr addr+W  ptr  Sr  addr+R  [data2]  NAK  P
```
Where S = START, Sr = repeated START, P = STOP, W = write, R = read, NAK = not-acknowledge (last byte of a read).

data1 reads correctly, but data2 returns stale EEPROM content because read_requested (which returns the byte at the current pointer) is skipped in favor of read_processed (which increments first, then returns the next byte).

Reset read_in_progress when entering a new write phase (RX_FULL with state != CMD_SEND). This ensures the subsequent read phase correctly calls read_requested to fetch data at the updated pointer.

The bug can be reproduced with the following C test program using the I2C_RDWR ioctl against any I2C EEPROM target:
```
  /* 4-message compound: set ptr + read + set ptr + read */
  struct i2c_msg msgs[4] = {
      { .addr = 0x54, .flags = 0,       .len = 1, .buf = &ptr },
      { .addr = 0x54, .flags = I2C_M_RD, .len = 1, .buf = &rd1 },
      { .addr = 0x54, .flags = 0,       .len = 1, .buf = &ptr },
      { .addr = 0x54, .flags = I2C_M_RD, .len = 1, .buf = &rd2 },
  };
  ioctl(fd, I2C_RDWR, &(struct i2c_rdwr_ioctl_data){msgs, 4});
  /* Before fix: rd1 correct, rd2 wrong (stale offset) */
  /* After fix:  rd1 == rd2 == expected value */
```
Tested with FT232H master and RP2040 EEPROM target at 400 kHz: 10000 compound w+r+w+r cycles with 0 failures. Also verified with libmpsse userspace I2C.