### PR TITLE
arch: riscv: use TLS-based stack canary guard

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -135,6 +135,8 @@ config RISCV
 	select ARCH_HAS_DIRECTED_IPIS
 	select BARRIER_OPERATIONS_BUILTIN if RISCV_ISA_BASE_FENCE
 	select ARCH_HAS_THREAD_PRIV_STACK_SPACE_GET if USERSPACE
+	select ARCH_HAS_STACK_CANARIES_TLS
+	select STACK_CANARIES_TLS_PREPEND if STACK_CANARIES_TLS
 	depends on DT_HAS_RISCV_ENABLED
 	help
 	  RISCV architecture
@@ -364,6 +366,7 @@ config KOBJECT_TEXT_AREA
 	default 1024 if UBSAN
 	default 512 if COVERAGE_GCOV
 	default 512 if NO_OPTIMIZATIONS
+	default 512 if STACK_CANARIES_ALL
 	default 512 if STACK_CANARIES && RISCV
 	default 256
 	depends on USERSPACE
@@ -835,6 +838,31 @@ config ARCH_HAS_SUSPEND_TO_RAM
 
 config ARCH_HAS_STACK_CANARIES_TLS
 	bool
+
+config STACK_CANARIES_TLS_PREPEND
+	bool
+	depends on STACK_CANARIES_TLS
+	help
+	  The stack canary (.stack_chk.guard) is placed as the first section
+	  in the TLS block at offset 0, before .tdata/.tbss. Required on
+	  architectures where the compiler accesses the canary via a fixed
+	  offset from the TLS base pointer (e.g. RISC-V).
+
+config STACK_CANARIES_TLS_GUARD_REG
+	string
+	default "tp" if RISCV
+	depends on STACK_CANARIES_TLS_PREPEND
+	help
+	  The register used as the TLS base pointer for stack canary access.
+	  Sets -mstack-protector-guard-reg=<reg>.
+
+config STACK_CANARIES_TLS_GUARD_OFFSET
+	int
+	default 0
+	depends on STACK_CANARIES_TLS_PREPEND
+	help
+	  The byte offset from the TLS base register to the stack canary.
+	  Sets -mstack-protector-guard-offset=<offset>.
 
 config ARCH_SUPPORTS_MEM_MAPPED_STACKS
 	bool

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -48,10 +48,13 @@ SECTION_FUNC(reset, __reset)
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 /*
  * Allocate a TLS area on the current stack, initialize it via
- * arch_riscv_early_tls_stack_update(), set tp to point to it, then
- * restore the original stack pointer.
+ * arch_riscv_early_tls_stack_update(), set tp to point to it.
  */
 .macro riscv_tls_init_early
+	/* Save s0/s1, else they get clobbered */
+	addi sp, sp, -16
+	sr s0, 0(sp)
+	sr s1, 8(sp)
 	mv s0, sp
 
 	call z_tls_data_size_asm
@@ -62,8 +65,13 @@ SECTION_FUNC(reset, __reset)
 	mv a0, s0	/* arg0: stack_top */
 	mv a1, s1	/* arg1: tls_size  */
 	call arch_riscv_early_tls_stack_update
-	mv sp, s0
 tls_skip\@:
+	/* Restore s0/s1. sp intentionally stays below the TLS area so the
+	 * runtime stack grows away from it. The 16-byte save frame above
+	 * sp is abandoned.
+	 */
+	lr s1, 8(s0)
+	lr s0, 0(s0)
 .endm
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
 
@@ -117,7 +125,14 @@ aa_loop:
 	add sp, sp, t0
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
-	/* Initialize tp early so TLS-based stack canaries work before z_prep_c */
+	/*
+	 * Initialize TLS before the first C function call. Compiler
+	 * inserts stack canary checks into C functions, and the canary
+	 * value is read from a TLS variable via tp. Without this early
+	 * init, tp is not set up and any C function called during early
+	 * boot (e.g. z_prep_c) would read the canary from an arbitrary
+	 * memory location.
+	 */
 	riscv_tls_init_early
 #endif
 

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -45,6 +45,28 @@ SECTION_FUNC(reset, __reset)
 
 /* use ABI name of registers for the sake of simplicity */
 
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+/*
+ * Allocate a TLS area on the current stack, initialize it via
+ * arch_riscv_early_tls_stack_update(), set tp to point to it, then
+ * restore the original stack pointer.
+ */
+.macro riscv_tls_init_early
+	mv s0, sp
+
+	call z_tls_data_size_asm
+	beqz a0, tls_skip\@
+	mv s1, a0
+	sub sp, sp, a0
+
+	mv a0, s0	/* arg0: stack_top */
+	mv a1, s1	/* arg1: tls_size  */
+	call arch_riscv_early_tls_stack_update
+	mv sp, s0
+tls_skip\@:
+.endm
+#endif /* CONFIG_THREAD_LOCAL_STORAGE */
+
 /*
  * Remainder of asm-land initialization code before we can jump into
  * the C domain
@@ -93,6 +115,11 @@ aa_loop:
 	la sp, z_interrupt_stacks
 	li t0, __z_interrupt_stack_SIZEOF
 	add sp, sp, t0
+
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	/* Initialize tp early so TLS-based stack canaries work before z_prep_c */
+	riscv_tls_init_early
+#endif
 
 #ifdef CONFIG_RISCV_SMRNMI_ENABLE_NMI_DELIVERY
 	csrs CSR_MNSTATUS, MNSTATUS_NMIE
@@ -173,6 +200,13 @@ wait_secondary_wake_flag:
 	/* Set up stack */
 	la t0, riscv_cpu_sp
 	lr sp, 0(t0)
+
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	/* Initialize tp early so TLS-based stack canaries work on secondary CPUs */
+	mv s2, a0		/* save hartid across TLS init calls */
+	riscv_tls_init_early
+	mv a0, s2		/* restore hartid */
+#endif
 
 	la t0, riscv_cpu_boot_flag
 	li t1, 1

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -126,12 +126,11 @@ aa_loop:
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	/*
-	 * Initialize TLS before the first C function call. Compiler
-	 * inserts stack canary checks into C functions, and the canary
-	 * value is read from a TLS variable via tp. Without this early
-	 * init, tp is not set up and any C function called during early
-	 * boot (e.g. z_prep_c) would read the canary from an arbitrary
-	 * memory location.
+	 * Initialize TLS before the first C function call. The compiler inserts
+	 * stack canary checks into C functions, and the canary value is read from
+	 * a TLS variable via tp. Without this early init, tp is not set up and
+	 * any C function called during early boot (e.g. z_prep_c) would read the
+	 * canary from an arbitrary memory location.
 	 */
 	riscv_tls_init_early
 #endif

--- a/arch/riscv/core/tls.c
+++ b/arch/riscv/core/tls.c
@@ -21,20 +21,19 @@ size_t FUNC_NO_STACK_PROTECTOR z_tls_data_size_asm(void)
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {
 	/*
-	 * TLS area for RISC-V is simple without any extra
-	 * data.
+	 * TLS area for RISC-V is simple without any extra data.
 	 */
 
 	/*
-	 * Since we are populating things backwards,
-	 * setup the TLS data/bss area first.
+	 * Since we are populating things backwards, setup the TLS data/bss
+	 * area first.
 	 */
 	stack_ptr -= z_tls_data_size();
 	z_tls_copy(stack_ptr);
 
 	/*
-	 * Set thread TLS pointer which is used in
-	 * context switch to point to TLS area.
+	 * Set thread TLS pointer which is used in context switch to point
+	 * to TLS area.
 	 */
 	new_thread->tls = POINTER_TO_UINT(stack_ptr);
 
@@ -44,22 +43,20 @@ size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 void FUNC_NO_STACK_PROTECTOR arch_riscv_early_tls_stack_update(char *stack_ptr, size_t tls_size)
 {
 	/*
-	 * TLS area for RISC-V is simple without any extra
-	 * data.
+	 * TLS area for RISC-V is simple without any extra data.
 	 */
 
 	/*
-	 * Since we are populating things backwards,
-	 * setup the TLS data/bss area first.
-	 * tls_size was already computed by the caller (z_tls_data_size_asm)
-	 * to avoid a redundant call.
+	 * Since we are populating things backwards, setup the TLS data/bss
+	 * area first. tls_size was already computed by the caller
+	 * (z_tls_data_size_asm) to avoid a redundant call.
 	 */
 	stack_ptr -= tls_size;
 	z_tls_copy(stack_ptr);
 
 	/*
-	 * Set tp directly to point to the TLS area,
-	 * since there are no threads spawned early in boot.
+	 * Set tp directly to point to the TLS area, since there are no
+	 * threads spawned early in boot.
 	 */
 	uintptr_t tls_addr = POINTER_TO_UINT(stack_ptr);
 

--- a/arch/riscv/core/tls.c
+++ b/arch/riscv/core/tls.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +11,12 @@
 #include <kernel_tls.h>
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/sys/util.h>
+
+/* Non-inline wrapper for z_tls_data_size(), required for calling from assembly. */
+size_t FUNC_NO_STACK_PROTECTOR z_tls_data_size_asm(void)
+{
+	return z_tls_data_size();
+}
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {
@@ -32,4 +39,29 @@ size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 	new_thread->tls = POINTER_TO_UINT(stack_ptr);
 
 	return z_tls_data_size();
+}
+
+void FUNC_NO_STACK_PROTECTOR arch_riscv_early_tls_stack_update(char *stack_ptr, size_t tls_size)
+{
+	/*
+	 * TLS area for RISC-V is simple without any extra
+	 * data.
+	 */
+
+	/*
+	 * Since we are populating things backwards,
+	 * setup the TLS data/bss area first.
+	 * tls_size was already computed by the caller (z_tls_data_size_asm)
+	 * to avoid a redundant call.
+	 */
+	stack_ptr -= tls_size;
+	z_tls_copy(stack_ptr);
+
+	/*
+	 * Set tp directly to point to the TLS area,
+	 * since there are no threads spawned early in boot.
+	 */
+	uintptr_t tls_addr = POINTER_TO_UINT(stack_ptr);
+
+	__asm__ volatile ("mv tp, %0" :: "r"(tls_addr));
 }

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -35,7 +35,7 @@ extern "C" {
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_STACK_CANARIES_TLS)
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
 	__asm__ volatile ("li tp, 0");
 #endif
 #if defined(CONFIG_SMP) || defined(CONFIG_USERSPACE)

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -35,7 +35,7 @@ extern "C" {
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_STACK_CANARIES_TLS)
 	__asm__ volatile ("li tp, 0");
 #endif
 #if defined(CONFIG_SMP) || defined(CONFIG_USERSPACE)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -185,10 +185,19 @@ set_compiler_property(PROPERTY security_canaries_explicit -fstack-protector-expl
 
 # Only a valid option with GCC 7.x and above, so let's do check and set.
 if(CONFIG_STACK_CANARIES_TLS)
-  check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=tls)
-  check_set_compiler_property(APPEND PROPERTY security_canaries_strong -mstack-protector-guard=tls)
-  check_set_compiler_property(APPEND PROPERTY security_canaries_all -mstack-protector-guard=tls)
-  check_set_compiler_property(APPEND PROPERTY security_canaries_explicit -mstack-protector-guard=tls)
+  if(CONFIG_STACK_CANARIES_TLS_PREPEND)
+    # The canary is at a fixed offset from the TLS base register (see
+    # STACK_CANARIES_TLS_GUARD_REG and STACK_CANARIES_TLS_GUARD_OFFSET).
+    check_set_compiler_property(APPEND PROPERTY security_canaries "SHELL:-mstack-protector-guard=tls -mstack-protector-guard-reg=${CONFIG_STACK_CANARIES_TLS_GUARD_REG} -mstack-protector-guard-offset=${CONFIG_STACK_CANARIES_TLS_GUARD_OFFSET}")
+    check_set_compiler_property(APPEND PROPERTY security_canaries_strong "SHELL:-mstack-protector-guard=tls -mstack-protector-guard-reg=${CONFIG_STACK_CANARIES_TLS_GUARD_REG} -mstack-protector-guard-offset=${CONFIG_STACK_CANARIES_TLS_GUARD_OFFSET}")
+    check_set_compiler_property(APPEND PROPERTY security_canaries_all "SHELL:-mstack-protector-guard=tls -mstack-protector-guard-reg=${CONFIG_STACK_CANARIES_TLS_GUARD_REG} -mstack-protector-guard-offset=${CONFIG_STACK_CANARIES_TLS_GUARD_OFFSET}")
+    check_set_compiler_property(APPEND PROPERTY security_canaries_explicit "SHELL:-mstack-protector-guard=tls -mstack-protector-guard-reg=${CONFIG_STACK_CANARIES_TLS_GUARD_REG} -mstack-protector-guard-offset=${CONFIG_STACK_CANARIES_TLS_GUARD_OFFSET}")
+  else()
+    check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=tls)
+    check_set_compiler_property(APPEND PROPERTY security_canaries_strong -mstack-protector-guard=tls)
+    check_set_compiler_property(APPEND PROPERTY security_canaries_all -mstack-protector-guard=tls)
+    check_set_compiler_property(APPEND PROPERTY security_canaries_explicit -mstack-protector-guard=tls)
+  endif()
 else()
   check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=global)
   check_set_compiler_property(APPEND PROPERTY security_canaries_global -mstack-protector-guard=global)

--- a/cmake/linker_script/common/thread-local-storage.cmake
+++ b/cmake/linker_script/common/thread-local-storage.cmake
@@ -2,6 +2,14 @@
 # Please keep in sync
 
 if(CONFIG_THREAD_LOCAL_STORAGE)
+  if(CONFIG_STACK_CANARIES_TLS_PREPEND)
+    # Stack canary section placed before tdata so the canary is at a
+    # fixed offset (0) from the TLS base pointer.
+    zephyr_linker_section(NAME .stack_chk LMA FLASH NOINPUT)
+    zephyr_linker_section_configure(SECTION .stack_chk INPUT ".stack_chk.guard" KEEP)
+    # GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+  endif()
+
   zephyr_linker_section(NAME .tdata LMA FLASH NOINPUT)
   zephyr_linker_section_configure(SECTION .tdata INPUT ".tdata")
   zephyr_linker_section_configure(SECTION .tdata INPUT ".tdata.*")

--- a/cmake/linker_script/common/thread-local-storage.cmake
+++ b/cmake/linker_script/common/thread-local-storage.cmake
@@ -7,7 +7,6 @@ if(CONFIG_THREAD_LOCAL_STORAGE)
     # fixed offset (0) from the TLS base pointer.
     zephyr_linker_section(NAME .stack_chk LMA FLASH NOINPUT)
     zephyr_linker_section_configure(SECTION .stack_chk INPUT ".stack_chk.guard" KEEP)
-    # GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
   endif()
 
   zephyr_linker_section(NAME .tdata LMA FLASH NOINPUT)

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -279,6 +279,14 @@ extern char z_user_stacks_end[];
 extern char z_kobject_data_begin[];
 #endif /* CONFIG_USERSPACE */
 
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+/* Stack canary is prepended to the TLS block; these symbols define its extent. */
+extern char __stack_chk_start[];
+extern char __stack_chk_end[];
+extern char __stack_chk_size[];
+extern char __stack_chk_align[];
+#endif /* CONFIG_STACK_CANARIES_TLS_PREPEND */
+
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 extern char __tdata_start[];
 extern char __tdata_end[];

--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -1,8 +1,18 @@
+/* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Please keep in sync with cmake/linker_script/common/thread-local-storage.cmake */
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+    /* Stack canary section placed before tdata so the canary is at a
+     * fixed offset (0) from the TLS base pointer.
+     */
+    SECTION_DATA_PROLOGUE(stack_chk,,)
+    {
+        KEEP(*(.stack_chk.guard));
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif /* CONFIG_STACK_CANARIES_TLS_PREPEND */
 	SECTION_DATA_PROLOGUE(tdata,,)
 	{
 		*(.tdata .tdata.* .gnu.linkonce.td.*);
@@ -12,6 +22,17 @@
 	{
 		*(.tbss .tbss.* .gnu.linkonce.tb.* .tcommon);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+#ifdef CONFIG_XIP
+        PROVIDE(__stack_chk_start = LOADADDR(stack_chk));
+#else
+        PROVIDE(__stack_chk_start = ADDR(stack_chk));
+#endif
+	PROVIDE(__stack_chk_align = ALIGNOF(stack_chk));
+	PROVIDE(__stack_chk_size = (SIZEOF(stack_chk) + __stack_chk_align - 1) & ~(__stack_chk_align - 1));
+	PROVIDE(__stack_chk_end = __stack_chk_start + __stack_chk_size);
+#endif /* CONFIG_STACK_CANARIES_TLS_PREPEND */
 
 	/*
 	 * These needs to be outside of the tdata/tbss
@@ -34,8 +55,14 @@
 	PROVIDE(__tbss_size = (SIZEOF(tbss) + __tbss_align - 1) & ~(__tbss_align - 1));
 	PROVIDE(__tbss_end = __tbss_start + __tbss_size);
 
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+	PROVIDE(__tls_start = __stack_chk_start);
+	PROVIDE(__tls_end = __tbss_end);
+	PROVIDE(__tls_size = __tbss_end - __stack_chk_start);
+#else
 	PROVIDE(__tls_start = __tdata_start);
 	PROVIDE(__tls_end = __tbss_end);
 	PROVIDE(__tls_size = __tbss_end - __tdata_start);
+#endif /* CONFIG_STACK_CANARIES_TLS_PREPEND */
 
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */

--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -57,12 +57,11 @@
 
 #if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
 	PROVIDE(__tls_start = __stack_chk_start);
-	PROVIDE(__tls_end = __tbss_end);
 	PROVIDE(__tls_size = __tbss_end - __stack_chk_start);
 #else
 	PROVIDE(__tls_start = __tdata_start);
-	PROVIDE(__tls_end = __tbss_end);
 	PROVIDE(__tls_size = __tbss_end - __tdata_start);
 #endif /* CONFIG_STACK_CANARIES_TLS_PREPEND */
+	PROVIDE(__tls_end = __tbss_end);
 
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -48,7 +48,11 @@ void _StackCheckHandler(void)
  * The canary value gets initialized in z_cstart().
  */
 #ifdef CONFIG_STACK_CANARIES_TLS
+#ifdef CONFIG_STACK_CANARIES_TLS_PREPEND
+__attribute__((section(".stack_chk.guard"))) Z_THREAD_LOCAL volatile uintptr_t __stack_chk_guard;
+#else
 Z_THREAD_LOCAL volatile uintptr_t __stack_chk_guard;
+#endif
 #elif CONFIG_USERSPACE
 K_APP_DMEM(z_libc_partition) volatile uintptr_t __stack_chk_guard;
 #else

--- a/kernel/include/kernel_tls.h
+++ b/kernel/include/kernel_tls.h
@@ -47,12 +47,14 @@ static inline FUNC_NO_STACK_PROTECTOR size_t z_tls_data_size(void)
 static inline FUNC_NO_STACK_PROTECTOR void z_tls_copy(char *dest)
 {
 #if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
-	/* .stack_chk.guard precedes .tdata in the TLS block (see
-	 * thread-local-storage.ld), so both are copied in one memcpy.
+	/* Copy .stack_chk.guard and .tdata separately since linker may
+	 * pad between sections
 	 */
-	memcpy(dest, __stack_chk_start,
-	       (size_t)(uintptr_t)__stack_chk_size + (size_t)(uintptr_t)__tdata_size);
-	dest += (size_t)(uintptr_t)__stack_chk_size + (size_t)(uintptr_t)__tdata_size;
+	memcpy(dest, __stack_chk_start, (size_t)(uintptr_t)__stack_chk_size);
+	dest += (size_t)(uintptr_t)__stack_chk_size;
+
+	memcpy(dest, __tdata_start, (size_t)(uintptr_t)__tdata_size);
+	dest += (size_t)(uintptr_t)__tdata_size;
 #else
 	/* Copy initialized data (tdata) */
 	memcpy(dest, __tdata_start, (size_t)(uintptr_t)__tdata_size);

--- a/kernel/include/kernel_tls.h
+++ b/kernel/include/kernel_tls.h
@@ -47,8 +47,8 @@ static inline FUNC_NO_STACK_PROTECTOR size_t z_tls_data_size(void)
 static inline FUNC_NO_STACK_PROTECTOR void z_tls_copy(char *dest)
 {
 #if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
-	/* Copy .stack_chk.guard and .tdata separately since linker may
-	 * pad between sections
+	/* Copy .stack_chk.guard and .tdata separately since the linker may insert
+	 * padding between sections.
 	 */
 	memcpy(dest, __stack_chk_start, (size_t)(uintptr_t)__stack_chk_size);
 	dest += (size_t)(uintptr_t)__stack_chk_size;

--- a/kernel/include/kernel_tls.h
+++ b/kernel/include/kernel_tls.h
@@ -26,10 +26,14 @@
  *
  * @return Total size of TLS data/bss areas
  */
-static inline size_t z_tls_data_size(void)
+static inline FUNC_NO_STACK_PROTECTOR size_t z_tls_data_size(void)
 {
-	return (size_t)(uintptr_t)__tdata_size +
-	       (size_t)(uintptr_t)__tbss_size;
+	size_t size = (size_t)(uintptr_t)__tdata_size + (size_t)(uintptr_t)__tbss_size;
+
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+	size += (size_t)(uintptr_t)__stack_chk_size;
+#endif
+	return size;
 }
 
 /**
@@ -40,13 +44,21 @@ static inline size_t z_tls_data_size(void)
  *
  * @param dest Pointer to destination
  */
-static inline void z_tls_copy(char *dest)
+static inline FUNC_NO_STACK_PROTECTOR void z_tls_copy(char *dest)
 {
+#if defined(CONFIG_STACK_CANARIES_TLS_PREPEND)
+	/* .stack_chk.guard precedes .tdata in the TLS block (see
+	 * thread-local-storage.ld), so both are copied in one memcpy.
+	 */
+	memcpy(dest, __stack_chk_start,
+	       (size_t)(uintptr_t)__stack_chk_size + (size_t)(uintptr_t)__tdata_size);
+	dest += (size_t)(uintptr_t)__stack_chk_size + (size_t)(uintptr_t)__tdata_size;
+#else
 	/* Copy initialized data (tdata) */
 	memcpy(dest, __tdata_start, (size_t)(uintptr_t)__tdata_size);
-
-	/* Clear BSS data (tbss) */
 	dest += (size_t)(uintptr_t)__tdata_size;
+#endif
+	/* Clear BSS data (tbss) */
 	memset(dest, 0, (size_t)(uintptr_t)__tbss_size);
 }
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -487,6 +487,7 @@ static FUNC_NORETURN void switch_to_main_thread(char *stack_ptr)
 #endif /* CONFIG_MULTITHREADING */
 
 __boot_func
+FUNC_NO_STACK_PROTECTOR
 void __weak z_early_rand_get(uint8_t *buf, size_t length)
 {
 	static uint64_t state = (uint64_t)CONFIG_TIMER_RANDOM_INITIAL_STATE;

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -191,7 +191,7 @@ extern char __{mem}_{kind}_reloc_size[];
 
 
 DATA_COPY_FUNCTION = """
-void data_copy_xip_relocation(void)
+FUNC_NO_STACK_PROTECTOR void data_copy_xip_relocation(void)
 {{
 {0}
 }}


### PR DESCRIPTION
This change enables per thread stack canary for RISC-V.

RISC-V GCC accesses the stack canary via a fixed offset from the thread pointer (tp) when -mstack-protector-guard=tls is used. The compiler emits code equivalent to:

  lw t0, 0(tp)   # load canary from tp+0

Additionally, tp is zeroed in arch_kernel_init() when TLS is enabled, which means any C function called before thread setup completes (such as z_early_rand_get or data_copy_xip_relocation) would fault trying to access the canary.

Introduce STACK_CANARIES_TLS_PREPEND, which places the .stack_chk.guard section at offset 0 of the TLS block, before .tdata and .tbss. The compiler flags -mstack-protector-guard-reg=tp and -mstack-protector-guard-offset=0 are passed so GCC generates the correct canary access.

With STACK_CANARIES_TLS_PREPEND the per-thread TLS block layout is:

         +------------------+  <--- tp (offset 0)
         | .stack_chk.guard |  (__stack_chk_guard)
         +------------------+
         | .tdata           |  (initialized TLS data)
         +------------------+
         | .tbss            |  (zero-initialized TLS data)
         +------------------+

The RISC-V reset path is extended to initialize tp before any C code runs by allocating a TLS area on the boot stack and calling arch_riscv_early_tls_stack_update(). Early boot functions that run before tp is set up (z_early_rand_get, data_copy_xip_relocation) are marked FUNC_NO_STACK_PROTECTOR to avoid canary access before tp is valid.