### PR TITLE
bluetooth: host: avrcp: fix return value handling in command handlers

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -2025,7 +2025,8 @@ static void avrcp_unit_info_cmd_handler(struct bt_avrcp *avrcp, uint8_t tid, str
 		goto err_rsp;
 	}
 
-	return avrcp_tg_cb->unit_info_req(get_avrcp_tg(avrcp), tid);
+	avrcp_tg_cb->unit_info_req(get_avrcp_tg(avrcp), tid);
+	return;
 
 err_rsp:
 	err = bt_avrcp_send_unit_info_err_rsp(avrcp, tid);
@@ -2442,7 +2443,8 @@ static void avrcp_subunit_info_cmd_handler(struct bt_avrcp *avrcp, uint8_t tid,
 		goto err_rsp;
 	}
 
-	return avrcp_tg_cb->subunit_info_req(get_avrcp_tg(avrcp), tid);
+	avrcp_tg_cb->subunit_info_req(get_avrcp_tg(avrcp), tid);
+	return;
 
 err_rsp:
 	err = bt_avrcp_send_subunit_info(avrcp, tid, BT_AVRCP_RSP_REJECTED);
@@ -2478,7 +2480,8 @@ static void avrcp_pass_through_cmd_handler(struct bt_avrcp *avrcp, uint8_t tid,
 		goto err_rsp;
 	}
 
-	return avrcp_tg_cb->passthrough_req(get_avrcp_tg(avrcp), tid, buf);
+	avrcp_tg_cb->passthrough_req(get_avrcp_tg(avrcp), tid, buf);
+	return;
 
 err_rsp:
 	rsp_buf = bt_avrcp_create_pdu(NULL);


### PR DESCRIPTION
Fix three command handlers that were incorrectly returning the result of callback functions with void return type:
- avrcp_unit_info_cmd_handler
- avrcp_subunit_info_cmd_handler
- avrcp_pass_through_cmd_handler

Split the callback invocation and return statement to properly handle the void return type, avoiding potential compiler warnings or errors.