### PR TITLE
input: kbd matrix: switch polling properties to microseconds

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -631,6 +631,25 @@ Infineon
   * ``CONFIG_BT_CYW43XX`` → :kconfig:option:` CONFIG_BT_HCI_UART_INFINEON`
   * ``dtcompatible: "infineon,cyw43xxx-bt-hci"`` → ``dtcompatible: "infineon,bt-hci-uart"``
 
+Keyboard matrix
+===============
+
+* The common keyboard matrix Devicetree bindings have been updated to use
+  microseconds instead of milliseconds for polling period properties.
+
+  The following properties have been renamed and their units changed:
+
+  * ``poll-period-ms`` -> ``poll-period-us``
+  * ``stable-poll-period-ms`` -> ``stable-poll-period-us``
+
+  Applications using these properties must:
+
+  * Replace the old property names with the new ones, and
+  * Convert the values from milliseconds to microseconds. For example, a value
+    of ``10`` previously representing 10 ms must now be written as ``10000`` to
+    represent 10,000 µs.
+
+
 MDIO
 ====
 

--- a/dts/bindings/input/kbd-matrix-common.yaml
+++ b/dts/bindings/input/kbd-matrix-common.yaml
@@ -16,18 +16,18 @@ properties:
     description: |
       The number of column in the keyboard matrix.
 
-  poll-period-ms:
+  poll-period-us:
     type: int
-    default: 5
+    default: 5000
     description: |
-      Defines the poll period in msecs between between matrix scans, set to 0
-      to never exit poll mode. Defaults to 5ms if unspecified.
+      Defines the poll period in usecs between between matrix scans, set to 0
+      to never exit poll mode. Defaults to 5,000us if unspecified.
 
-  stable-poll-period-ms:
+  stable-poll-period-us:
     type: int
     description: |
-      Defines the poll period in msecs between matrix scans when the matrix is
-      stable, defaults to poll-period-ms value if unspecified.
+      Defines the poll period in usecs between matrix scans when the matrix is
+      stable, defaults to poll-period-us value if unspecified.
 
   poll-timeout-ms:
     type: int

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -197,10 +197,9 @@ struct input_kbd_matrix_common_config {
 		.api = _api, \
 		.row_size = _row_size, \
 		.col_size = _col_size, \
-		.poll_period_us = DT_PROP(node_id, poll_period_ms) * USEC_PER_MSEC, \
-		.stable_poll_period_us = DT_PROP_OR(node_id, stable_poll_period_ms, \
-						    DT_PROP(node_id, poll_period_ms)) * \
-							USEC_PER_MSEC, \
+		.poll_period_us = DT_PROP(node_id, poll_period_us), \
+		.stable_poll_period_us = DT_PROP_OR(node_id, stable_poll_period_us, \
+						    DT_PROP(node_id, poll_period_us)), \
 		.poll_timeout_ms = DT_PROP(node_id, poll_timeout_ms), \
 		.debounce_down_us = DT_PROP(node_id, debounce_down_ms) * USEC_PER_MSEC, \
 		.debounce_up_us = DT_PROP(node_id, debounce_up_ms) * USEC_PER_MSEC, \

--- a/tests/drivers/input/kbd_matrix/boards/native_sim.overlay
+++ b/tests/drivers/input/kbd_matrix/boards/native_sim.overlay
@@ -9,7 +9,7 @@
 		compatible = "test-kbd-scan";
 		row-size = <3>;
 		col-size = <3>;
-		poll-period-ms = <5>;
+		poll-period-us = <5000>;
 		debounce-down-ms = <40>;
 		debounce-up-ms = <80>;
 		poll-timeout-ms = <500>;


### PR DESCRIPTION
As discussed with @fabiobaltieri in #105110, this PR switches the common keyboard matrix polling configuration from milliseconds to microseconds, and updates the Devicetree bindings, common headers, and documentation accordingly.

## Background

While developing a keyboard driver that reuses the common keyboard matrix logic (ghost-key detection, per-key debouncing, etc.), I include and use:

- `struct input_kbd_matrix_common_config`
- `struct input_kbd_matrix_common_data`
- `INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT_ROW_COL(...)`

For some applications, I need to configure the scan interval in microseconds. To support this, I initially added `poll-period-ms` to the blocklist in my Devicetree and introduced a new `poll-period-us` property in my own binding.

During this integration, I ran into a build issue: the common config initializer reads the `poll-period-ms` property directly from Devicetree via `DT_PROP()`, which effectively requires the binding to provide `poll-period-ms`. At the same time:

- `poll-period-ms`
- `stable-poll-period-ms`

are expressed in milliseconds, whereas my use case needs microsecond resolution. Internally, the common code already converts these values to microseconds before use, so the `*_ms` properties in Devicetree do not clearly reflect the effective runtime units and make it harder to align my binding with the common binding.

To make this setup more consistent and easier to reuse (for my driver and similar use cases), this PR updates the Devicetree properties and the common structs to use microseconds directly.

## Changes

This PR updates the units and names to use microseconds in Devicetree binding/Common header/Documentation:
  - `poll-period-ms`        → `poll-period-us`
  - `stable-poll-period-ms` → `stable-poll-period-us`