### PR TITLE
tests: drivers: i2c: fix the clock-frequency limit issue for ek_ra2l1

### DIFF
--- a/tests/drivers/i2c/i2c_api/boards/ek_ra2l1.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/ek_ra2l1.overlay
@@ -10,25 +10,3 @@
 		gy271 = &iic0;
 	};
 };
-
-&pinctrl {
-	iic0_default: iic0_default {
-		group1 {
-			/* SCL0 SDA0 */
-			psels = <RA_PSEL(RA_PSEL_I2C, 4, 8)>,
-				<RA_PSEL(RA_PSEL_I2C, 4, 7)>;
-			drive-strength = "medium";
-		};
-	};
-};
-
-&iic0 {
-	pinctrl-0 = <&iic0_default>;
-	pinctrl-names = "default";
-	#address-cells = <1>;
-	#size-cells = <0>;
-	clock-frequency = <DT_FREQ_M(1)>;
-	interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
-	interrupt-names = "rxi", "txi", "tei", "eri";
-	status = "okay";
-};


### PR DESCRIPTION
- Remove I2C overlay config exceeding` max-bitrate-supported` constraint, causing build failure
- Remove redundant `pinctrl` and `iic0`, rely on board's base DTS