### PR TITLE
twister: increase ESP32 reset pulse duration

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -873,7 +873,7 @@ class DeviceHandler(Handler):
                     # Reset pulse: IO0=LOW (DTR=False), EN=LOW (RTS=True)
                     ser.dtr = False
                     ser.rts = True
-                    time.sleep(0.01)
+                    time.sleep(0.1)
 
                     # Return to normal boot
                     ser.rts = False


### PR DESCRIPTION
Increase the reset pulse from 10ms to 100ms to ensure reliable boot across all Espressif SoCs. Shorter pulses may cause the UART to miss early bootloader output, leading to false-positive test failures.