### PR TITLE
doc: dts: add guidance for modeling multi-API hardware

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -402,6 +402,8 @@ identifier for a chosen node.
 
 .. doxygengroup:: devicetree-generic-chosen
 
+.. _devicetree-zephyr-chosen-nodes:
+
 Zephyr-specific chosen nodes
 ****************************
 
@@ -496,9 +498,10 @@ device.
      - A node whose ``reg`` sets the base address and size of SRAM memory
        available to the Zephyr image, used during linking
    * - zephyr,system-timer
-     - Selects the hardware timer instance used as the Zephyr system timer.
-       Used when devicetree selects which timer instance provides that
-       singleton system function.
+     - Selects the hardware timer instance used as the Zephyr system timer,
+       which is a singleton system-wide function. Use this when devicetree
+       selects which timer instance provides the system timer, even if other
+       identical timer instances are used by other APIs.
    * - zephyr,system-timer-companion
      - Selects the device used to keep time while the primary system timer is
        inactive in low-power states

--- a/doc/build/dts/design.rst
+++ b/doc/build/dts/design.rst
@@ -85,3 +85,76 @@ Example remaining work
   set of bindings supported by Linux.
 
 - Devicetree source sharing between Zephyr and Linux is not done.
+
+.. _dt-multi-api-hardware:
+
+Modeling hardware exposed through multiple Zephyr APIs
+******************************************************
+
+When a hardware block can be used through different Zephyr APIs, devicetree
+should keep hardware identity separate from the way software drivers and
+subsystems use each hardware instance.
+
+Guidelines
+==========
+
+- Keep the ``compatible`` property focused on the device programming model.
+  Avoid changing it only to route software API selection. A different
+  ``compatible`` is appropriate when the hardware interfaces are
+  architecturally distinct, for example because they use separate register
+  blocks.
+
+- Use ``/chosen`` for singleton system-wide selection. If the system must
+  select exactly one instance for a global function, such as the system timer,
+  console, or entropy source, represent that choice with a platform-agnostic
+  chosen property, even if other identical hardware instances are used by
+  other APIs. See also :ref:`devicetree-zephyr-chosen-nodes`.
+
+- Place the selection at the right integration level. If it is a silicon-level
+  fixed attribute, describe it in the SoC ``.dtsi``. If it varies by board,
+  product, or application, describe it in the board ``.dts`` or an overlay.
+
+If different uses of the hardware device have different required
+properties, child nodes, or bus semantics, then they do not have to share one
+binding schema. In that case, use different ``compatible`` values or model the
+device as a multifunction one.
+
+Examples
+========
+
+**Singleton selection with** ``/chosen``
+
+The system timer is a singleton function. The ``zephyr,system-timer``
+chosen property selects which hardware timer instance provides it, while
+other identical instances remain available for other APIs.
+
+For example, two identical LPTMR timer instances can share the same
+``compatible`` in the hardware description:
+
+.. code-block:: devicetree
+
+   lptmr1: timer@44300000 {
+       compatible = "nxp,lptmr";
+       reg = <0x44300000 0x1000>;
+       /* ... */
+   };
+
+   lptmr2: timer@424d0000 {
+       compatible = "nxp,lptmr";
+       reg = <0x424d0000 0x1000>;
+       /* ... */
+   };
+
+An integration layer can then select which one provides the singleton system
+timer function:
+
+.. code-block:: devicetree
+
+   / {
+       chosen {
+           zephyr,system-timer = &lptmr1;
+       };
+   };
+
+The system-timer driver binds to the ``/chosen`` node. The counter
+driver skips that instance and uses the remaining one.


### PR DESCRIPTION
This PR documents the outcome of RFC #105249: guidance for modeling
hardware blocks that can be exposed through multiple Zephyr APIs.

## Changes

**`doc/build/dts/design.rst`**

- Add a new section "Modeling hardware exposed through multiple Zephyr APIs"
  with guidelines covering:
  - Keep `compatible` focused on hardware identity; a different `compatible`
    is only appropriate when hardware interfaces use separate register blocks
  - Use `/chosen` for singleton system-wide selection (e.g. system timer)
  - Use a per-node property (e.g. `zephyr,role`) for per-instance role
    assignment when no singleton selector applies
  - Place the assignment at the right integration level (`soc.dtsi` vs
    `board.dts` vs overlay)
- Add DTS code snippets for both approaches:
  - `/chosen` example using `zephyr,system-timer` with two LPTMR instances
  - Per-node property example using `zephyr,role` across three timer instances
- Note multi-interface hardware as remaining follow-up work

**`doc/build/dts/api/api.rst`**

- Improve `zephyr,system-timer` chosen node description
- Add `devicetree-zephyr-chosen-nodes` cross-reference label

Related: #105249
