### PR TITLE
Bluetooth: ctlr: nordic: check for integer underflow in scan ops

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -126,6 +126,8 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	uint32_t window_widening_us;
 	struct node_rx_ftr *ftr;
 	uint16_t window_size_us;
+	uint32_t end_timer_us;
+	uint32_t end_delays_us;
 	uint32_t aux_offset_us;
 	uint32_t overhead_us;
 	uint8_t *pri_dptr;
@@ -233,14 +235,15 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	node_rx = ull_pdu_rx_alloc_peek(1);
 	LL_ASSERT_DBG(node_rx);
 
+	end_timer_us = radio_tmr_end_get();
+	end_delays_us = radio_rx_chain_delay_get(pdu_phy, pdu_phy_flags_rx) + pdu_us;
+	LL_ASSERT_MSG(end_timer_us >= end_delays_us, "Timer expired before starting");
+
 	/* Store the lll context, aux_ptr and start of PDU in footer */
 	ftr = &(node_rx->rx_ftr);
 	ftr->param = param;
 	ftr->aux_ptr = aux_ptr;
-	ftr->radio_end_us = radio_tmr_end_get() -
-			    radio_rx_chain_delay_get(pdu_phy,
-						     pdu_phy_flags_rx) -
-			    pdu_us;
+	ftr->radio_end_us = end_timer_us - end_delays_us;
 
 	radio_isr_set(setup_cb, node_rx);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -652,6 +652,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	aux_offset_us -= window_widening_us;
 
 	ticks_aux_offset = HAL_TICKER_US_TO_TICKS(aux_offset_us);
+	printk("Offset from scan window: %u (radio end %u)\n", aux_offset_us, ftr->radio_end_us);
 
 	/* Check if too late to ULL schedule an auxiliary PDU reception */
 	if (!ftr->aux_lll_sched) {

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -25,6 +25,7 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -181,6 +181,56 @@ static void main_ext_adv_advertiser(void)
 	TEST_PASS("Extended advertiser passed");
 }
 
+static void main_ext_adv_advertiser_5x(void)
+{
+	static const struct bt_le_ext_adv_start_param adv_start_param = {
+		.timeout = 0,
+		.num_events = 1,
+	};
+	struct bt_le_ext_adv *ext_adv;
+	struct bt_data ad;
+	int err;
+
+	common_init();
+	create_ext_adv_set(&ext_adv, false);
+
+	/* Broadcast the device name */
+	ad.type = BT_DATA_NAME_COMPLETE;
+	ad.data_len = strlen(CONFIG_BT_DEVICE_NAME);
+	ad.data = (const uint8_t *)CONFIG_BT_DEVICE_NAME;
+	err = bt_le_ext_adv_set_data(ext_adv, &ad, 1, NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data: %d\n", err);
+		return;
+	}
+
+	/* Small delay to allow scanner to setup */
+	k_sleep(K_MSEC(10));
+
+	/* Send exactly 5 extended advertising reports */
+	for (int i = 0; i < 5; i++) {
+		printk("Starting advertising set %d\n", i);
+		err = bt_le_ext_adv_start(ext_adv, &adv_start_param);
+		if (err) {
+			printk("Failed to start advertising set %d: %d\n", i, err);
+			return;
+		}
+		/* Wait 1 second between reports */
+		k_sleep(K_MSEC(1000));
+	}
+
+	/* Delete the advertising set */
+	err = bt_le_ext_adv_delete(ext_adv);
+	if (err) {
+		printk("Failed to delete advertising data: %d\n", err);
+		return;
+	}
+
+	ext_adv = NULL;
+
+	TEST_PASS("Extended advertiser passed");
+}
+
 static void adv_connect_and_disconnect_cycle(void)
 {
 	struct bt_le_ext_adv *ext_adv;
@@ -257,6 +307,12 @@ static const struct bst_test_instance ext_adv_advertiser[] = {
 		.test_descr = "Basic extended advertising test. "
 			      "Will just start extended advertising.",
 		.test_main_f = main_ext_adv_advertiser
+	},
+	{
+		.test_id = "ext_adv_advertiser_5x",
+		.test_descr = "Basic extended advertising test. "
+			      "Will advertise 5x times with a 1 second gap",
+		.test_main_f = main_ext_adv_advertiser_5x
 	},
 	{
 		.test_id = "ext_adv_conn_advertiser",

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -129,12 +129,12 @@ static void common_init(void)
 	printk("Bluetooth initialized\n");
 }
 
-static void start_scan(void)
+static void start_scan(const struct bt_le_scan_param *param)
 {
 	int err;
 
 	printk("Start scanning...");
-	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
+	err = bt_le_scan_start(param ? param : BT_LE_SCAN_PASSIVE, NULL);
 	if (err) {
 		TEST_FAIL("Failed to start scan: %d", err);
 		return;
@@ -145,7 +145,7 @@ static void start_scan(void)
 static void main_ext_adv_scanner(void)
 {
 	common_init();
-	start_scan();
+	start_scan(NULL);
 
 	printk("Waiting for extended advertisements...\n");
 
@@ -154,9 +154,35 @@ static void main_ext_adv_scanner(void)
 	TEST_PASS("Extended adv scanner passed");
 }
 
+static void main_ext_adv_scanner_5x(void)
+{
+	/* 100% duty cycle scanning, no filtering */
+	static const struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL_MIN,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+	};
+
+	common_init();
+
+	start_scan(&scan_param);
+
+	printk("Waiting for 5x extended advertisements...\n");
+
+	for(int i = 0; i < 5; i++) {
+		WAIT_FOR_FLAG(flag_ext_adv_seen);
+		atomic_clear(&flag_ext_adv_seen);
+		printk("Observed advertising set %d\n", i);
+	}
+
+	TEST_PASS("Extended adv scanner 5x passed");
+}
+
+
 static void scan_connect_and_disconnect_cycle(void)
 {
-	start_scan();
+	start_scan(NULL);
 
 	printk("Waiting for extended advertisements...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
@@ -182,7 +208,7 @@ static void main_ext_adv_conn_scanner(void)
 
 	scan_connect_and_disconnect_cycle();
 
-	start_scan();
+	start_scan(NULL);
 	printk("Waiting to extended advertisements (again)...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
 
@@ -198,7 +224,7 @@ static void main_ext_adv_conn_scanner_x5(void)
 		scan_connect_and_disconnect_cycle();
 	}
 
-	start_scan();
+	start_scan(NULL);
 	printk("Waiting to extended advertisements (again)...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
 
@@ -211,6 +237,12 @@ static const struct bst_test_instance ext_adv_scanner[] = {
 		.test_descr = "Basic extended advertising scanning test. "
 			      "Will just scan an extended advertiser.",
 		.test_main_f = main_ext_adv_scanner
+	},
+	{
+		.test_id = "ext_adv_scanner_5x",
+		.test_descr = "Basic extended advertising scanning test. "
+			      "Expects to receive 5x extended advertising reports",
+		.test_main_f = main_ext_adv_scanner_5x
 	},
 	{
 		.test_id = "ext_adv_conn_scanner",

--- a/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
@@ -5,6 +5,7 @@ common:
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 
 tests:

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Embeint Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reliable extended advertising test:
+#
+# - Broadcasting Only: a Bluetooth LE broadcaster advertises 5x with extended
+#   advertising, and a scanner scans every extended advertisement packet.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="ext_adv_5x"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_extended_prj_advertiser_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
+  -testid=ext_adv_advertiser_5x -rs=23
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=0 \
+  -testid=ext_adv_scanner_5x -rs=6
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=10e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -12,3 +12,5 @@ tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
 tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/audio/
+tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
+tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh


### PR DESCRIPTION
Validate that the unsigned integers used to construct `radio_end_us` do not underflow.
This should not fail, but does with the new testcase added for nRF54L15.
```
d_01: @00:00:00.012717  ASSERTION FAIL [end_timer_us >= end_delays_us] @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c:240
d_01: @00:00:00.012717          Timer expired before starting
d_01: @00:00:00.012717  @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c:240
```
This is not a babblesim failure, as the root cause `radio_tmr_end_get` returning 0 has been observed on real hardware.

This is the failure mode discussed [here](https://discord.com/channels/720317445772017664/1072528982278414448/1480009457688772649) in the babblesim discord channel