### PR TITLE
modem: cmux: Fix trivial warning building with clang

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1446,6 +1446,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
 		__fallthrough;
 
 	case MODEM_CMUX_RECEIVE_STATE_FCS:
+	{
 		/* Compute FCS */
 		uint8_t *frame_start = &cmux->config.receive_buf[cmux->frame_start];
 
@@ -1467,7 +1468,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, int idx)
 
 		cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_EOF;
 		break;
-
+	}
 	case MODEM_CMUX_RECEIVE_STATE_EOF:
 		/* Validate byte is EOF */
 		if (byte != MODEM_CMUX_SOF) {


### PR DESCRIPTION
Fix `error: label followed by a declaration is a C23 extension` warning.

Issue introduced by
* 0d3883516f8ef4eb7d0ff031e8ed26f249ccdd19
* https://github.com/zephyrproject-rtos/zephyr/pull/105370

Failures in CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/23171994431/job/67325721701#step:12:600
https://github.com/zephyrproject-rtos/zephyr/actions/runs/23171994431/job/67325721699#step:12:729