### PR TITLE
boards: microchip: sam: document how to run Zephyr on MPU boards

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/doc/index.rst
+++ b/boards/microchip/sam/sama7d65_curiosity/doc/index.rst
@@ -96,6 +96,23 @@ Connections and IOs
 
 The `SAMA7D65-Curiosity Kit User Guide`_ has detailed information about board connections.
 
+Programming
+***********
+
+Prerequisite
+============
+
+Before Zephyr runs on SAMA7D65-Curiosity, `at91bootstrap`_ (the second stage
+bootloader for Microchip MPU) needs to run first. It will initialize the
+peripherals and memory controllers, download and jump to Zephyr entry point.
+
+Loading the firmware
+====================
+
+Using a bootloader compiled with sama7d65_curiositysd1_zephyr_defconfig
+configuration, the binary for Zephyr (zephyr.bin) copied to a SD card can be
+loaded and run on the SAMA7D65-Curiosity board.
+
 References
 **********
 
@@ -107,3 +124,6 @@ SAMA7D65 Curiosity Kit Page:
 
 .. _SAMA7D65-Curiosity Kit User Guide:
     https://ww1.microchip.com/downloads/aemDocuments/documents/MPU32/ProductDocuments/UserGuides/SAMA7D65-Curiosity-Kit-User-Guide-DS50003806.pdf
+
+.. _at91bootstrap:
+    https://developerhelp.microchip.com/xwiki/bin/view/products/mcu-mpu/32bit-mpu/at91bootstrap/

--- a/boards/microchip/sam/sama7g54_ek/doc/index.rst
+++ b/boards/microchip/sam/sama7g54_ek/doc/index.rst
@@ -51,6 +51,23 @@ Connections and IOs
 
 The `SAMA7G54-EK User Guide`_ has detailed information about board connections.
 
+Programming
+***********
+
+Prerequisite
+============
+
+Before Zephyr runs on SAMA7G54-EK, `at91bootstrap`_ (the second stage bootloader
+for Microchip MPU) needs to run first. It will initialize the peripherals and
+memory controllers, download and jump to Zephyr entry point.
+
+Loading the firmware
+====================
+
+Using a bootloader compiled with sama7g5eksd_zephyr_defconfig configuration, the
+binary for Zephyr (zephyr.bin) copied to a SD card can be loaded and run on the
+SAMA7G54-EK board.
+
 References
 **********
 
@@ -62,3 +79,6 @@ SAMA7G54 Evaluation Kit Page:
 
 .. _SAMA7G54-EK User Guide:
     https://ww1.microchip.com/downloads/aemDocuments/documents/MPU32/ProductDocuments/UserGuides/SAMA7G54-EK-User%27s-Guide-DS50003273.pdf
+
+.. _at91bootstrap:
+    https://developerhelp.microchip.com/xwiki/bin/view/products/mcu-mpu/32bit-mpu/at91bootstrap/


### PR DESCRIPTION
Document how to run Zephyr on MPU boards in 'doc/index.rst' files for sama7d65_curiosity and sama7g54_ek boards.