### PR TITLE
soc: nordic: common: tfm: kconfig: Add nRF53/nRF91 trustzone config

### DIFF
--- a/soc/nordic/common/Kconfig.tfm
+++ b/soc/nordic/common/Kconfig.tfm
@@ -1,9 +1,10 @@
-if BUILD_WITH_TFM && (SOC_SERIES_NRF54L || SOC_SERIES_NRF71)
+if BUILD_WITH_TFM && (SOC_SERIES_NRF54L || SOC_SERIES_NRF71 || SOC_SERIES_NRF53 || SOC_SERIES_NRF91)
 
 DT_NRF_MPC := $(dt_nodelabel_path,nrf_mpc)
 
 config NRF_TRUSTZONE_FLASH_REGION_SIZE
 	hex
+	default NRF_SPU_FLASH_REGION_SIZE if (SOC_SERIES_NRF53 || SOC_SERIES_NRF91)
 	default $(dt_node_int_prop_hex,$(DT_NRF_MPC),override-granularity)
 	help
 	  This defines the flash region size from the TrustZone perspective.
@@ -14,6 +15,7 @@ config NRF_TRUSTZONE_FLASH_REGION_SIZE
 
 config NRF_TRUSTZONE_RAM_REGION_SIZE
 	hex
+	default NRF_SPU_RAM_REGION_SIZE if (SOC_SERIES_NRF53 || SOC_SERIES_NRF91)
 	default $(dt_node_int_prop_hex,$(DT_NRF_MPC),override-granularity)
 	help
 	  This defines the RAM region size from the TrustZone perspective.
@@ -22,4 +24,4 @@ config NRF_TRUSTZONE_RAM_REGION_SIZE
 	  This abstraction allows us to configure TrustZone without depending
 	  on peripheral specific symbols.
 
-endif # BUILD_WITH_TFM
+endif # BUILD_WITH_TFM && (SOC_SERIES_NRF54L || SOC_SERIES_NRF71 || SOC_SERIES_NRF53 || SOC_SERIES_NRF91)


### PR DESCRIPTION
Adds default values for these SoC series