### PR TITLE
drivers: udc_dwc2: Double fifo size for bulk endpoints

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1399,6 +1399,11 @@ static int dwc2_set_dedicated_fifo(const struct device *dev,
 		reqdep *= (1 + addnl);
 	}
 
+	/* Allocate double fifo size for bulk endpoints to improve throughput */
+	if ((cfg->attributes & USB_EP_TRANSFER_TYPE_MASK) == USB_EP_TYPE_BULK) {
+		reqdep *= 2;
+	}
+
 	if (priv->dynfifosizing) {
 		if (priv->txf_set & ~BIT_MASK(ep_idx)) {
 			dwc2_unset_unused_fifo(dev);

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1120,6 +1120,11 @@ static int dwc2_set_dedicated_fifo(const struct device *dev,
 		reqdep *= (1 + addnl);
 	}
 
+	/* Allocate double fifo size for bulk endpoints to improve throughput */
+	if ((cfg->attributes & USB_EP_TRANSFER_TYPE_MASK) == USB_EP_TYPE_BULK) {
+		reqdep *= 2;
+	}
+
 	if (priv->dynfifosizing) {
 		if (priv->txf_set & ~BIT_MASK(ep_idx)) {
 			dwc2_unset_unused_fifo(dev);


### PR DESCRIPTION
Double fifo size for bulk endpoints to allow packet to be transmitted while next one is being written to fifo. This offers significant throughput improvement when class supplies big enough buffers.

On nRF54H20 with SCSI buffer size 8192 with double buffering enabled and DWC2 operating in Buffer DMA mode, the maximum throughput increases more than double when used with disk driver that does nothing in read callback (i.e. this is the upper bound possible). Gnome Disks benchmark configured for 100 samples, 8 MiB sample size measures Average Read Rate equal 33.6 MB/s with this change compared to 15.3 MB/s without it.

---

I believe the proper solution is https://github.com/zephyrproject-rtos/zephyr/pull/99510. The throughput improvement is way too significant to not have it due to review disagreements, therefore I am submitting this as a standalone PR.