### PR TITLE
tests: boards: nrf70: ent_security: Fix missing test tag

### DIFF
--- a/tests/boards/nrf/nrf70/ent_security/testcase.yaml
+++ b/tests/boards/nrf/nrf70/ent_security/testcase.yaml
@@ -4,6 +4,7 @@ common:
     - drivers
     - wifi
     - net
+    - hostap
   platform_allow:
     - nrf7002dk/nrf5340/cpuapp
 tests:


### PR DESCRIPTION
This tag ensures that whenever hostap is changed then these tests are also run.