### PR TITLE
dts: vendor: nordic: nrf5340: Add shared DFU memory areas

### DIFF
--- a/dts/vendor/nordic/nrf5340_shared_sram_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_shared_sram_partition.dtsi
@@ -24,6 +24,10 @@
 };
 
 &sram0 {
+	sram0_dfu_shared: shared-sram@0 {
+		reg = <0x0 0x2000>;
+	};
+
 	sram0_shared: sram@70000 {
 		/* Last 64 kB of sram0 */
 		reg = <0x70000 0x10000>;

--- a/dts/vendor/nordic/nrf5340_sram_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_sram_partition.dtsi
@@ -24,6 +24,13 @@
 			/* Secure image memory */
 			reg = <0x0 0x40000>;
 		};
+
+		sram0_offset_for_dfu: sram@2000 {
+			reg = <0x2000 DT_SIZE_K(440)>;
+			ranges = <0x0 0x2000 DT_SIZE_K(440)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
 	};
 
 	/*


### PR DESCRIPTION
Adds areas which are used for inter-core communication for DFU processing