### PR TITLE
tests: drivers: pwm: Add support for other nrf platforms

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm20;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf54l15dk_nrf54l15_cpuapp.overlay"


### PR DESCRIPTION
Add overlays required to run the pwm_api test on
nrf52840dk, nrf54l15dk.