### PR TITLE
soc: realtek: update interrupt init for rtl87x2g and rtl8752h

### DIFF
--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/logging/log.h>
+#include <soc.h>
 
 #include "clock_manager.h"
 #include "image_header.h"
@@ -79,6 +80,13 @@ void soc_early_reset_hook(void)
 	/* Initialize silicon flow data and apply FT parameters. */
 	si_flow_data_init();
 	ft_paras_apply();
+
+	/*
+	 * Connect the Level 1 interrupt ISR (Peripheral_Handler,
+	 * which is implemented in ROM) to the Zephyr interrupt subsystem.
+	 */
+	IRQ_CONNECT(Peripheral_IRQn, 0, Peripheral_Handler, NULL, 0);
+	irq_enable(Peripheral_IRQn);
 
 	/* Enable cache */
 	share_cache_ram();

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -32,6 +32,7 @@ extern char __extram_bss_start[];
 extern char __extram_bss_end[];
 
 extern void _isr_wrapper(void);
+extern void Peripheral_Handler(void);
 
 #define S_RAM_VECTOR_ADDR (0x14ec00)
 #define STACK_ROM_ADDRESS DT_REG_ADDR(DT_NODELABEL(bee_bt_controller))
@@ -135,6 +136,13 @@ void soc_early_init_hook(void)
 
 	SCB->VTOR = (uint32_t)S_RAM_VECTOR_ADDR;
 	(void)memcpy((void *)S_RAM_VECTOR_ADDR, _vector_start, vector_size);
+
+	/*
+	 * Connect the Level 1 interrupt ISR (Peripheral_Handler,
+	 * which is implemented in ROM) to the Zephyr interrupt subsystem.
+	 */
+	IRQ_CONNECT(Peripheral_IRQn, 0, Peripheral_Handler, NULL, 0);
+	irq_enable(Peripheral_IRQn);
 
 	rtl87x2g_extra_ram_init();
 

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: c8f99f7de0b8ea5817dd1873e0b31208be3fb63b
+      revision: 84a7fd556d95a411ee3cbf4ed29478eced58fb35
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
This pull request updates the interrupt initialization sequence for Realtek **rtl87x2g** and **rtl8752h** SoCs to ensure proper routing of peripheral interrupts.

### 🔹 Why is this needed?
* It acts as a necessary bridge between the hardware-specific Level 1 interrupt routing (handled by the ROM) and Zephyr's standard IRQ management system.
* Without this, the sub-interrupts routed under `Peripheral_IRQn` would not be properly enabled or handled. This update guarantees that all dependent peripheral interrupts are fully functional.

## Impact
* **Affected SoCs:** rtl87x2g, rtl8752h
* **Subsystems:** `soc/realtek`, interrupt controller

## Testing
✅ Successfully compiled and verified interrupt routing on the affected SoCs.