### PR TITLE
west: Sync picolibc with Zephyr SDK 1.0.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -362,7 +362,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: ca8b6ebba5226a75545e57a140443168a26ba664
+      revision: 01254932e8e81085817ed61fd858648584ffe37c
     - name: psa-arch-tests
       revision: 6e8219237435112df33bbcf37b7f5657fcfb9cff
       path: modules/tee/tf-m/psa-arch-tests


### PR DESCRIPTION
THis commit updates the picolibc module to match the version of picolibc included in the Zephyr SDK 1.0.0 release.

---

To be merged after https://github.com/zephyrproject-rtos/zephyr/pull/105514