### PR TITLE
soc: nordic: nrf71: Update MPC to allow unpriv access for all cores.

### DIFF
--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -43,31 +43,17 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #define LFXO_NODE DT_NODELABEL(lfxo)
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-/* Copied from TF-M native driver */
+
 struct mpc_region_override {
 	nrf_mpc_override_config_t config;
-	nrf_owner_t owner_id;
-	uintptr_t start_address;
+	uintptr_t startaddr;
 	uintptr_t endaddr;
 	uint32_t perm;
 	uint32_t permmask;
-	size_t index;
 };
 
-static void mpc_configure_override(NRF_MPC_Type *mpc, struct mpc_region_override *override)
-{
-	nrf_mpc_override_startaddr_set(mpc, override->index, override->start_address);
-	nrf_mpc_override_endaddr_set(mpc, override->index, override->endaddr);
-	nrf_mpc_override_perm_set(mpc, override->index, override->perm);
-	nrf_mpc_override_permmask_set(mpc, override->index, override->permmask);
-#if defined(NRF_MPC_HAS_OVERRIDE_OWNERID) && NRF_MPC_HAS_OVERRIDE_OWNERID
-	nrf_mpc_override_ownerid_set(mpc, override->index, override->owner_id);
-#endif
-	nrf_mpc_override_config_set(mpc, override->index, &override->config);
-}
-
 /*
- * Configure the override struct with reasonable defaults. This includes:
+ * Initialize the override struct with reasonable defaults. This includes:
  *
  * Use a slave number of 0 to avoid redirecting bus transactions from
  * one slave to another.
@@ -80,23 +66,72 @@ static void mpc_configure_override(NRF_MPC_Type *mpc, struct mpc_region_override
  * Indicate that secdom is not enabled as this driver is not used on
  * platforms with secdom.
  */
-static void init_mpc_region_override(struct mpc_region_override *override)
+#define MPC_REGION_OVERRIDE_INIT(_startaddr, _endaddr, _secure, _privileged)			\
+	{											\
+		.config =  {									\
+			.slave_number = 0,							\
+			.lock = true,								\
+			.enable = true,								\
+			.secdom_enable = false,							\
+			.secure_mask = false,							\
+		},										\
+		.startaddr = _startaddr,							\
+		.endaddr = _endaddr,								\
+		.perm = (									\
+			(MPC_OVERRIDE_PERM_READ_Allowed << MPC_OVERRIDE_PERM_READ_Pos) |	\
+			(MPC_OVERRIDE_PERM_WRITE_Allowed << MPC_OVERRIDE_PERM_WRITE_Pos) |	\
+			(MPC_OVERRIDE_PERM_EXECUTE_Allowed << MPC_OVERRIDE_PERM_EXECUTE_Pos) |	\
+			(_secure << MPC_OVERRIDE_PERM_SECATTR_Pos) |				\
+			(_privileged << MPC_OVERRIDE_PERM_PRIVL_Pos)				\
+		),										\
+		.permmask = (									\
+			MPC_OVERRIDE_PERM_READ_Msk |						\
+			MPC_OVERRIDE_PERM_WRITE_Msk |						\
+			MPC_OVERRIDE_PERM_EXECUTE_Msk |						\
+			MPC_OVERRIDE_PERM_SECATTR_Msk |						\
+			MPC_OVERRIDE_PERM_PRIVL_Msk						\
+		),										\
+	}
+
+static const struct mpc_region_override mpc00_region_overrides[] = {
+	/* Make RAM_00/01/02 (AMBIX00 + AMBIX03) accessible to all domains */
+	MPC_REGION_OVERRIDE_INIT(0x20000000, 0x200E0000, 0, 0),
+	/* Make MRAM accessible to all domains */
+	MPC_REGION_OVERRIDE_INIT(0x00000000, 0x01000000, 0, 0),
+#if CONFIG_SOC_NRF71_WIFI_DAP
+	/* Allow access to Wi-Fi debug interface registers */
+	MPC_REGION_OVERRIDE_INIT(0x48000000, 0x48100000, 0, 0),
+#endif
+};
+
+static const struct mpc_region_override mpc03_region_overrides[] = {
+	/* Make RAM_02 (AMBIX03) accessible to the Wi-Fi domain for IPC */
+	MPC_REGION_OVERRIDE_INIT(0x200C0000, 0x200E0000, 0, 0),
+};
+
+static void set_mpc_region_override(NRF_MPC_Type *mpc,
+				    size_t index,
+				    const struct mpc_region_override *override)
 {
-	*override = (struct mpc_region_override){
-		.config =
-			(nrf_mpc_override_config_t){
-				.slave_number = 0,
-				.lock = true,
-				.enable = true,
-				.secdom_enable = false,
-				.secure_mask = false,
-			},
-		/* 0-NS R,W,X =1 */
-		.perm = 0x7,
-		.permmask = 0xF,
-		.owner_id = 0,
-	};
+	nrf_mpc_override_startaddr_set(mpc, index, override->startaddr);
+	nrf_mpc_override_endaddr_set(mpc, index, override->endaddr);
+	nrf_mpc_override_perm_set(mpc, index, override->perm);
+	nrf_mpc_override_permmask_set(mpc, index, override->permmask);
+	nrf_mpc_override_config_set(mpc, index, &override->config);
 }
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+static void mpc_configuration(void)
+{
+	ARRAY_FOR_EACH(mpc00_region_overrides, i) {
+		set_mpc_region_override(NRF_MPC00, i, &mpc00_region_overrides[i]);
+	}
+
+	ARRAY_FOR_EACH(mpc03_region_overrides, i) {
+		set_mpc_region_override(NRF_MPC03, i, &mpc03_region_overrides[i]);
+	}
+}
+#endif
 
 /**
  * Return the SPU instance that can be used to configure the
@@ -111,44 +146,6 @@ static inline NRF_SPU_Type *spu_instance_from_peripheral_addr(uint32_t periphera
 	return (NRF_SPU_Type *)(0x50000000 | apb_bus_number);
 }
 
-/* End of TF-M native driver */
-
-static void wifi_mpc_configuration(void)
-{
-	struct mpc_region_override override;
-	uint32_t index = 0;
-
-	/* Make RAM_00/01/02 (AMBIX00 + AMBIX03) accessible to the Wi-Fi domain*/
-	init_mpc_region_override(&override);
-	override.start_address = 0x20000000;
-	override.endaddr = 0x200E0000;
-	override.index = index++;
-	mpc_configure_override(NRF_MPC00, &override);
-
-	/* MRAM MPC overrides for wifi */
-	init_mpc_region_override(&override);
-	override.start_address = 0x00000000;
-	override.endaddr = 0x01000000;
-	override.index = index++;
-	mpc_configure_override(NRF_MPC00, &override);
-
-	/* Make RAM_02 (AMBIX03) accessible to the Wi-Fi domain for IPC */
-	init_mpc_region_override(&override);
-	override.start_address = 0x200C0000;
-	override.endaddr = 0x200E0000;
-	override.index = 0;
-	mpc_configure_override(NRF_MPC03, &override);
-
-	if (IS_ENABLED(CONFIG_SOC_NRF71_WIFI_DAP)) {
-		/* Allow access to Wi-Fi debug interface registers */
-		init_mpc_region_override(&override);
-		override.start_address = 0x48000000;
-		override.endaddr = 0x48100000;
-		override.index = index++;
-		mpc_configure_override(NRF_MPC00, &override);
-	}
-}
-
 static void grtc_configuration(void)
 {
 	/* Split security configuration to let Wi-Fi access GRTC */
@@ -160,18 +157,10 @@ static void grtc_configuration(void)
 }
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
+#if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
 static void wifi_setup(void)
 {
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-	/* Skip for tf-m, configuration exist in target_cfg_71.c */
-	wifi_mpc_configuration();
-
-	grtc_configuration();
-
-#endif
-
-#if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
 	/* Kickstart the LMAC processor */
 	NRF_WIFICORE_LRCCONF_LRC0->POWERON =
 		(LRCCONF_POWERON_MAIN_AlwaysOn << LRCCONF_POWERON_MAIN_Pos);
@@ -189,7 +178,16 @@ void soc_early_init_hook(void)
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
 	/* Currently not supported for non-secure */
 	SystemCoreClockUpdate();
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Skip for tf-m, configuration exist in target_cfg_71.c */
+	mpc_configuration();
+	grtc_configuration();
+#endif
+
+#if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
 	wifi_setup();
+#endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pwr_antswc)
 	*(volatile uint32_t *)PWR_ANTSWC_REG |= PWR_ANTSWC_ENABLE;


### PR DESCRIPTION
The MPC is currently set up to allow R,W,X,Priv access to all RAM and MRAM for all cores. This is not sufficient if CONFIG_USERSPACE is enabled, in which case the application core will be accessing memory unprivileged, using the MPU to manage memory access.

Update MPC configuration to allow R,W,X,Unpriv access to all RAM and MRAM for all cores. The R,W,X MPC configuration has to be applied regardless of CONFIG_USERSPACE, so no need to conditionally include the MPU configuration based in CONFIG_USERSPACE.