### PR TITLE
shell: websocket: Fix crash on websocket disconnection

### DIFF
--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -41,6 +41,9 @@ struct shell_websocket {
 	/** Array for sockets used by the websocket service. */
 	struct zsock_pollfd fds[1];
 
+	/** Mutex protecting the socket access. */
+	struct k_mutex socket_lock;
+
 	/** Input buffer. */
 	uint8_t rx_buf[CONFIG_SHELL_CMD_BUFF_SIZE];
 

--- a/subsys/shell/backends/shell_websocket.c
+++ b/subsys/shell/backends/shell_websocket.c
@@ -315,6 +315,9 @@ static int sh_write(const struct shell_transport *transport,
 			k_mutex_unlock(&ws->socket_lock);
 			if (ret != 0) {
 				*cnt = length;
+				if (ret == -ENOTCONN || ret == -ECONNRESET || ret == -EPIPE) {
+					return 0;
+				}
 				return ret;
 			}
 		}

--- a/subsys/shell/backends/shell_websocket.c
+++ b/subsys/shell/backends/shell_websocket.c
@@ -35,6 +35,8 @@ static void ws_end_client_connection(struct shell_websocket *ws)
 
 	LOG_DBG("Closing connection to #%d", ws->fds[0].fd);
 
+	k_mutex_lock(&ws->socket_lock, K_FOREVER);
+
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_WS)) {
 		(void)log_backend_ws_unregister(ws->fds[0].fd);
 	}
@@ -51,6 +53,8 @@ static void ws_end_client_connection(struct shell_websocket *ws)
 	if (ret < 0) {
 		LOG_ERR("Failed to re-register socket service (%d)", ret);
 	}
+
+	k_mutex_unlock(&ws->socket_lock);
 }
 
 static int ws_send(struct shell_websocket *ws, bool block)
@@ -102,10 +106,13 @@ static void ws_send_prematurely(struct k_work *work)
 	struct shell_websocket *ws = CONTAINER_OF(dwork,
 						  struct shell_websocket,
 						  send_work);
-	int ret;
+	int ret = -EAGAIN;
 
 	/* Use non-blocking send to prevent system workqueue blocking. */
-	ret = ws_send(ws, false);
+	if (k_mutex_lock(&ws->socket_lock, K_NO_WAIT) == 0) {
+		ret = ws_send(ws, false);
+		k_mutex_unlock(&ws->socket_lock);
+	}
 	if (ret == -EAGAIN) {
 		/* Not all data was sent, reschedule the work. */
 		k_work_reschedule(&ws->send_work, K_MSEC(WEBSOCKET_TIMEOUT));
@@ -244,6 +251,7 @@ static int init(const struct shell_transport *transport,
 
 	k_work_init_delayable(&ws->send_work, ws_send_prematurely);
 	k_mutex_init(&ws->rx_lock);
+	k_mutex_init(&ws->socket_lock);
 
 	return 0;
 }
@@ -275,11 +283,6 @@ static int sh_write(const struct shell_transport *transport,
 
 	ws = (struct shell_websocket *)transport->ctx;
 
-	if (ws->fds[0].fd < 0 || ws->output_lock) {
-		*cnt = length;
-		return 0;
-	}
-
 	*cnt = 0;
 	lb = &ws->line_out;
 
@@ -302,7 +305,14 @@ static int sh_write(const struct shell_transport *transport,
 		 * is recognized.
 		 */
 		if (lb->buf[lb->len - 1] == '\n' || lb->len == WEBSOCKET_LINE_SIZE) {
+			k_mutex_lock(&ws->socket_lock, K_FOREVER);
+			if (ws->fds[0].fd < 0 || ws->output_lock) {
+				*cnt = length;
+				k_mutex_unlock(&ws->socket_lock);
+				return 0;
+			}
 			ret = ws_send(ws, true);
+			k_mutex_unlock(&ws->socket_lock);
 			if (ret != 0) {
 				*cnt = length;
 				return ret;


### PR DESCRIPTION
This PR fixes a crash caused by a failing `__ASSERT` in [subsys/shell/shell_ops.c](https://github.com/zephyrproject-rtos/zephyr/blob/fb3ae541cfb89fd31a229f0739886b3cac6b287b/subsys/shell/shell_ops.c#L462) when the shell is used over the websocket backend.

The assert is triggered when [shell_websocket.c](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/shell/backends/shell_websocket.c#L71) propagates an error from a `zsock_send()` attempt on a socket that is disconnected.

The current implementation relies solely on `zsock_poll*` events to detect disconnection, but because the disconnect handler runs in a different thread, a race can occur. To address this, I've introduced a mutex to synchronize access to the state and adds proper handling of `zsock_send()` return codes so a client disconnection does not crash the shell thread.