### PR TITLE
net: lib: sntp: Make sockaddr const for sntp_ctx

### DIFF
--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -74,7 +74,7 @@ struct sntp_ctx {
  *
  * @return 0 if ok, <0 if error.
  */
-int sntp_init(struct sntp_ctx *ctx, struct net_sockaddr *addr,
+int sntp_init(struct sntp_ctx *ctx, const struct net_sockaddr *addr,
 	      net_socklen_t addr_len);
 
 /**
@@ -120,7 +120,7 @@ void sntp_close(struct sntp_ctx *ctx);
  *
  * @return 0 if ok, <0 if error.
  */
-int sntp_init_async(struct sntp_ctx *ctx, struct net_sockaddr *addr, net_socklen_t addr_len,
+int sntp_init_async(struct sntp_ctx *ctx, const struct net_sockaddr *addr, net_socklen_t addr_len,
 		    const struct net_socket_service_desc *service);
 
 /**

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -170,7 +170,7 @@ static int32_t parse_response(uint8_t *data, uint16_t len, struct sntp_time *exp
 	return 0;
 }
 
-int sntp_init(struct sntp_ctx *ctx, struct net_sockaddr *addr, net_socklen_t addr_len)
+int sntp_init(struct sntp_ctx *ctx, const struct net_sockaddr *addr, net_socklen_t addr_len)
 {
 	int ret;
 
@@ -282,7 +282,7 @@ void sntp_close(struct sntp_ctx *ctx)
 
 #ifdef CONFIG_NET_SOCKETS_SERVICE
 
-int sntp_init_async(struct sntp_ctx *ctx, struct net_sockaddr *addr, net_socklen_t addr_len,
+int sntp_init_async(struct sntp_ctx *ctx, const struct net_sockaddr *addr, net_socklen_t addr_len,
 		    const struct net_socket_service_desc *service)
 {
 	int ret;

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -9,8 +9,8 @@
 #include <zephyr/net/sntp.h>
 #include <zephyr/net/socketutils.h>
 
-static int sntp_simple_helper(struct net_sockaddr *addr, net_socklen_t addr_len, uint32_t timeout,
-			      struct sntp_time *ts)
+static int sntp_simple_helper(const struct net_sockaddr *addr, net_socklen_t addr_len,
+			      uint32_t timeout, struct sntp_time *ts)
 {
 	int res;
 	struct sntp_ctx sntp_ctx;


### PR DESCRIPTION
Both sntp_init and sntp_init_async shouldn't modify the socket address passed.