### PR TITLE
dts: nordic: Add KMU push area to dts.

### DIFF
--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -22,6 +22,12 @@
 		/* Secure image memory */
 		reg = <0x0 DT_SIZE_K(96)>;
 		ranges = <0x0 0x0 DT_SIZE_K(96)>;
+
+		kmu_push_area: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 0x60>;
+			zephyr,memory-region = "kmu_push_area";
+		};
 	};
 
 	sram0_ns: image_ns@18000 {

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -21,6 +21,12 @@
 		/* Secure image memory */
 		reg = <0x0 DT_SIZE_K(128)>;
 		ranges = <0x0 0x0 DT_SIZE_K(128)>;
+
+		kmu_push_area: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 0x60>;
+			zephyr,memory-region = "kmu_push_area";
+		};
 	};
 
 	sram0_ns: image_ns@20000 {

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -797,3 +797,18 @@
 		};
 	};
 };
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		kmu_push_area: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 0x60>;
+		};
+	};
+};
+#endif

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -942,3 +942,18 @@
 		};
 	};
 };
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		kmu_push_area: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 0x60>;
+		};
+	};
+};
+#endif

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -23,6 +23,12 @@
 		/* Secure image memory */
 		reg = <0x0 DT_SIZE_K(256)>;
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
+
+		kmu_push_area: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 0x60>;
+			zephyr,memory-region = "kmu_push_area";
+		};
 	};
 
 	sram0_ns: image_ns@40000 {

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -23,6 +23,12 @@
 		/* Secure image memory */
 		reg = <0x0 DT_SIZE_K(256)>;
 		ranges = <0x0 0x0 DT_SIZE_K(256)>;
+
+		kmu_push_area: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 0x60>;
+			zephyr,memory-region = "kmu_push_area";
+		};
 	};
 
 	sram0_ns: image_ns@40000 {

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -143,13 +143,23 @@
 		};
 #endif
 
+#ifdef USE_NON_SECURE_ADDRESS_MAP
 		cpuapp_sram: memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(512)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20000000 0x80000>;
+			ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 		};
+#else
+		cpuapp_sram: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(512)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
+		};
+#endif
 
 		ram01_sram: memory@20080000 {
 			compatible = "mmio-sram";
@@ -1012,3 +1022,18 @@
 		};
 	};
 };
+
+#ifndef USE_NON_SECURE_ADDRESS_MAP
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		kmu_push_area: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 0x60>;
+		};
+	};
+};
+#endif


### PR DESCRIPTION
The KMU requires a 96-Byte push area in RAM.
This was previously handled in a linker script, but as a
hardware requirement this should be represented in dts.
Add a reserved-memory node kmu_push_area at 0x20000000 (96 bytes)
to all 54L devices with KMU support. Shift cpuapp_sram to
start at 0x20000060 in non-secure builds so the Zephyr RAM region
is disjoint from the KMU push area, preventing overlap.
The reserved-memory node is guarded by #ifndef USE_NON_SECURE_ADDRESS_MAP
since TF-M/NS builds manage the KMU push area through their own
partition layout starting at 0x2000000