### PR TITLE
drivers: adc: mchp_xec: add MEC175x support and DTS encoding

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -61,6 +61,13 @@ Haptics
 
 .. zephyr-keep-sorted-start re(^\w) ignorecase
 
+ADC
+===
+
+* The ``girqs`` and ``pcrs`` properties (array type) of :dtcompatible:`microchip,xec-adc` have been
+  replaced by encoded ``girqs`` (using ``MCHP_XEC_ECIA_GIRQ_ENC`` macros) and ``pcr-scr`` (int type)
+  for encoded PCR register index and bit position (:github:`105658`).
+
 Clock Control
 =============
 

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -7,20 +7,22 @@
 
 #define DT_DRV_COMPAT microchip_xec_adc
 
-#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(adc_mchp_xec);
-
+#include <errno.h>
+#include <soc.h>
 #include <zephyr/drivers/adc.h>
-#ifdef CONFIG_SOC_SERIES_MEC172X
-#include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
-#endif
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
+#include <zephyr/irq.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
-#include <soc.h>
-#include <errno.h>
-#include <zephyr/irq.h>
+
+#include <zephyr/logging/log.h>
+#define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
+LOG_MODULE_REGISTER(adc_mchp_xec);
+
+#ifndef SHLU32
+#define SHLU32(v, n) ((uint32_t)(v) << (n))
+#endif
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
@@ -71,8 +73,7 @@ struct adc_xec_config {
 	uint8_t girq_single_pos;
 	uint8_t girq_repeat;
 	uint8_t girq_repeat_pos;
-	uint8_t pcr_regidx;
-	uint8_t pcr_bitpos;
+	uint8_t enc_pcr;
 	const struct pinctrl_dev_config *pcfg;
 };
 
@@ -224,8 +225,7 @@ static int adc_xec_start_read(const struct device *dev,
 
 	/* Setup ADC resolution */
 	sar_ctrl = regs->sar_control_reg;
-	sar_ctrl &= ~(MCHP_ADC_SAR_CTRL_RES_MASK |
-		      (1 << MCHP_ADC_SAR_CTRL_SHIFTD_POS));
+	sar_ctrl &= ~(MCHP_ADC_SAR_CTRL_RES_MASK | (1 << MCHP_ADC_SAR_CTRL_SHIFTD_POS));
 
 	if (sequence->resolution == 12) {
 		sar_ctrl |= MCHP_ADC_SAR_CTRL_RES_12_BITS;
@@ -306,38 +306,20 @@ static void xec_adc_get_sample(const struct device *dev)
 	regs->status_reg = ch_status;
 }
 
-#ifdef CONFIG_SOC_SERIES_MEC172X
 static inline void adc_xec_girq_clr(uint8_t girq_idx, uint8_t girq_posn)
 {
-	mchp_xec_ecia_girq_src_clr(girq_idx, girq_posn);
+	soc_ecia_girq_status_clear(girq_idx, girq_posn);
 }
 
 static inline void adc_xec_girq_en(uint8_t girq_idx, uint8_t girq_posn)
 {
-	mchp_xec_ecia_girq_src_en(girq_idx, girq_posn);
+	soc_ecia_girq_ctrl(girq_idx, girq_posn, 1u);
 }
 
 static inline void adc_xec_girq_dis(uint8_t girq_idx, uint8_t girq_posn)
 {
-	mchp_xec_ecia_girq_src_dis(girq_idx, girq_posn);
+	soc_ecia_girq_ctrl(girq_idx, girq_posn, 0u);
 }
-#else
-
-static inline void adc_xec_girq_clr(uint8_t girq_idx, uint8_t girq_posn)
-{
-	MCHP_GIRQ_SRC(girq_idx) = BIT(girq_posn);
-}
-
-static inline void adc_xec_girq_en(uint8_t girq_idx, uint8_t girq_posn)
-{
-	MCHP_GIRQ_ENSET(girq_idx) = BIT(girq_posn);
-}
-
-static inline void adc_xec_girq_dis(uint8_t girq_idx, uint8_t girq_posn)
-{
-	MCHP_GIRQ_ENCLR(girq_idx) = MCHP_KBC_IBF_GIRQ;
-}
-#endif
 
 static void adc_xec_single_isr(const struct device *dev)
 {
@@ -353,7 +335,7 @@ static void adc_xec_single_isr(const struct device *dev)
 	regs->control_reg = ctrl;
 
 	/* Also clear GIRQ source status bit */
-	adc_xec_girq_clr(cfg->girq_single, cfg->girq_single_pos);
+	soc_ecia_girq_status_clear(cfg->girq_single, cfg->girq_single_pos);
 
 	xec_adc_get_sample(dev);
 
@@ -420,6 +402,8 @@ static int adc_xec_init(const struct device *dev)
 	struct adc_xec_data * const data = dev->data;
 	int ret;
 
+	soc_xec_pcr_sleep_en_clear(cfg->enc_pcr);
+
 	data->adc_dev = dev;
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -429,6 +413,16 @@ static int adc_xec_init(const struct device *dev)
 	}
 
 	regs->config_reg = XEC_ADC_CFG_CLK_VAL(DT_INST_PROP(0, clktime));
+
+#if defined(CONFIG_SOC_SERIES_MEC175X)
+	/* For MEC175x SAR_CFG register (offset 0x8C), override  reset default values:
+	 * Write 0 for: PAR_DOUT=enabled, ADC_CLK_DIV=0 (DIV16, 3MHz SAR clock).
+	 */
+	{
+		volatile uint32_t *sar_cfg = (volatile uint32_t *)((uintptr_t)regs + 0x8Cu);
+		*sar_cfg = 0u;
+	}
+#endif
 
 	regs->control_reg =  XEC_ADC_CTRL_ACTIVATE
 		| XEC_ADC_CTRL_POWER_SAVER_DIS
@@ -453,14 +447,16 @@ static int adc_xec_init(const struct device *dev)
 
 PINCTRL_DT_INST_DEFINE(0);
 
+#define DEV_CFG_GIRQ(inst, idx)     MCHP_XEC_ECIA_GIRQ(DT_INST_PROP_BY_IDX(inst, girqs, idx))
+#define DEV_CFG_GIRQ_POS(inst, idx) MCHP_XEC_ECIA_GIRQ_POS(DT_INST_PROP_BY_IDX(inst, girqs, idx))
+
 static struct adc_xec_config adc_xec_dev_cfg_0 = {
 	.regs = (struct adc_xec_regs *)(DT_INST_REG_ADDR(0)),
-	.girq_single = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 0)),
-	.girq_single_pos = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 1)),
-	.girq_repeat = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 2)),
-	.girq_repeat_pos = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 3)),
-	.pcr_regidx = (uint8_t)(DT_INST_PROP_BY_IDX(0, pcrs, 0)),
-	.pcr_bitpos = (uint8_t)(DT_INST_PROP_BY_IDX(0, pcrs, 1)),
+	.girq_single = DEV_CFG_GIRQ(0, 0),
+	.girq_single_pos = DEV_CFG_GIRQ_POS(0, 0),
+	.girq_repeat = DEV_CFG_GIRQ(0, 1),
+	.girq_repeat_pos = DEV_CFG_GIRQ_POS(0, 1),
+	.enc_pcr = DT_INST_PROP(0, pcr_scr),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -467,8 +467,9 @@
 			compatible = "microchip,xec-adc";
 			reg = <0x40007c00 0x90>;
 			interrupts = <78 0>, <79 0>;
-			girqs = <17 8>, <17 9>;
-			pcrs = <3 3>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 8)>,
+				<MCHP_XEC_ECIA_GIRQ_ENC(17, 9)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 3)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 			clktime = <32>;

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -708,8 +708,9 @@ adc0: adc@40007c00 {
 	compatible = "microchip,xec-adc";
 	reg = <0x40007c00 0x90>;
 	interrupts = <78 0>, <79 0>;
-	girqs = <17 8>, <17 9>;
-	pcrs = <3 3>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 8)>,
+		<MCHP_XEC_ECIA_GIRQ_ENC(17, 9)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 3)>;
 	status = "disabled";
 	#io-channel-cells = <1>;
 	clktime = <32>;

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -597,11 +597,14 @@
 		adc0: adc@40007c00 {
 			reg = <0x40007c00 0x90>;
 			interrupts = <78 3>, <79 3>;
-			girqs = <17 8>, <17 9>;
 			interrupt-names = "single", "repeat";
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(17, 8)>,
+				<MCHP_XEC_ECIA_GIRQ_ENC(17, 9)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(3, 3)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 			clktime = <32>;
+			channels = <16>;
 		};
 
 		peci0: peci@40006400 {

--- a/dts/bindings/adc/microchip,xec-adc.yaml
+++ b/dts/bindings/adc/microchip,xec-adc.yaml
@@ -6,7 +6,10 @@ description: Microchip XEC ADC
 
 compatible: "microchip,xec-adc"
 
-include: [adc-controller.yaml, pinctrl-device.yaml]
+include:
+  - name: adc-controller.yaml
+  - name: pinctrl-device.yaml
+  - name: microchip,dmec-ecia-girq.yaml
 
 properties:
   reg:
@@ -18,15 +21,11 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  girqs:
-    type: array
+  pcr-scr:
+    type: int
     required: true
-    description: Array of pairs of GIRQ number and bit position
-
-  pcrs:
-    type: array
-    required: true
-    description: ADC PCR register index and bit position
+    description: |
+      ADC Power Clock Reset(PCR) peripheral index and bit position
 
   clktime:
     type: int

--- a/samples/drivers/adc/adc_dt/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/samples/drivers/adc/adc_dt/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>, <&adc0 5>, <&adc0 6>, <&adc0 7>;
+	};
+};
+
+&adc0 {
+	compatible = "microchip,xec-adc";
+	status = "okay";
+	pinctrl-0 = <&adc04_gpio204 &adc05_gpio205
+		     &adc06_gpio206 &adc07_gpio207>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <0>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <0>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <0>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <0>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/soc/microchip/mec/common/reg/mec_adc.h
+++ b/soc/microchip/mec/common/reg/mec_adc.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#if defined(CONFIG_SOC_MEC172X_NLJ)
+#if defined(CONFIG_SOC_MEC172X_NLJ) || defined(CONFIG_SOC_SERIES_MEC175X)
 /* 16 ADC channels numbered 0 - 15 */
 #define MCHP_ADC_MAX_CHAN		16u
 #define MCHP_ADC_MAX_CHAN_MASK		0x0fu
@@ -48,7 +48,7 @@
 
 /* Single Conversion Select register */
 #define MCHP_ADC_SCS_REG_OFS		0x0cu
-#if defined(CONFIG_SOC_MEC172X_NLJ)
+#if defined(CONFIG_SOC_MEC172X_NLJ) || defined(CONFIG_SOC_SERIES_MEC175X)
 #define MCHP_ADC_SCS_REG_MASK		0xffffu
 #define MCHP_ADC_SCS_CH_0_15		0xffffu
 #define MCHP_ADC_SCS_CH(n)		BIT(((n) & 0x0fu))
@@ -60,7 +60,7 @@
 
 /* Repeat Conversion Select register */
 #define MCHP_ADC_RCS_REG_OFS		0x10u
-#if defined(CONFIG_SOC_MEC172X_NLJ)
+#if defined(CONFIG_SOC_MEC172X_NLJ) || defined(CONFIG_SOC_SERIES_MEC175X)
 #define MCHP_ADC_RCS_REG_MASK		0xffffu
 #define MCHP_ADC_RCS_CH_0_15		0xffffu
 #define MCHP_ADC_RCS_CH(n)		BIT(((n) & 0x0fu))
@@ -102,7 +102,7 @@
 /* Channel Vref Select register */
 #define MCHP_ADC_CH_VREF_SEL_REG_OFS	0x80u
 #define MCHP_ADC_CH_VREF_SEL_REG_MASK	0x00ffffffu
-#if defined(CONFIG_SOC_MEC172X_NLJ)
+#if defined(CONFIG_SOC_MEC172X_NLJ) || defined(CONFIG_SOC_SERIES_MEC175X)
 #define MCHP_ADC_CH_VREF_SEL_MASK(n)	SHLU32(0x03u, (((n) & 0x0f) * 2u))
 #define MCHP_ADC_CH_VREF_SEL_PAD(n)	0u
 #define MCHP_ADC_CH_VREF_SEL_GPIO(n)	SHLU32(0x01u, (((n) & 0x0f) * 2u))


### PR DESCRIPTION
Add MEC175x ADC support by initializing the SAR_CFG register (offset 0x8C) during driver init to enable parallel data output and configure the SAR clock divider.

Refine ADC devicetree nodes across all MEC SoC families:
- Encode girqs using MCHP_XEC_ECIA_GIRQ_ENC() macro
- Add pcr-scr using MCHP_XEC_SCR_ENCODE() for PCR init
- Add channels property (16) for MEC175x
- Remove duplicate interrupt-names in mec5.dtsi
- Fix tab indentation in mec1501hsz.dtsi and mec172x_common.dtsi

Extend mec_adc.h Kconfig guards with CONFIG_SOC_SERIES_MEC175X for 16-channel ADC register definitions.

Add board overlay for mec_assy6941_mec1753_qsz ADC sample.